### PR TITLE
feat: telemetry parsing, direct messages, danger zone, and UX improvements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2250,3 +2250,76 @@ body {
 .setting-input:hover {
   border-color: var(--ctp-overlay0);
 }
+
+/* Danger Zone Styles */
+.danger-zone {
+  border: 2px solid var(--ctp-red);
+  border-radius: 8px;
+  padding: 1.5rem;
+  background: rgba(243, 139, 168, 0.05);
+  margin-top: 2rem;
+}
+
+.danger-zone h3 {
+  color: var(--ctp-red);
+  border-bottom-color: var(--ctp-red);
+}
+
+.danger-zone-description {
+  color: var(--ctp-subtext0);
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+  font-style: italic;
+}
+
+.danger-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  background: var(--ctp-surface0);
+  border-radius: 8px;
+  border: 1px solid var(--ctp-surface2);
+}
+
+.danger-action:last-child {
+  margin-bottom: 0;
+}
+
+.danger-action-info h4 {
+  color: var(--ctp-text);
+  font-size: 1rem;
+  margin: 0 0 0.5rem 0;
+  font-weight: 600;
+}
+
+.danger-action-info p {
+  color: var(--ctp-subtext0);
+  font-size: 0.875rem;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.danger-button {
+  background: var(--ctp-red);
+  color: var(--ctp-base);
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s, transform 0.1s;
+  white-space: nowrap;
+  min-width: 150px;
+}
+
+.danger-button:hover {
+  background: var(--ctp-maroon);
+  transform: translateY(-1px);
+}
+
+.danger-button:active {
+  transform: translateY(0);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -805,13 +805,17 @@ function App() {
       channelSet.add(msg.channel);
     });
 
-    return Array.from(channelSet).sort((a, b) => a - b);
+    // Filter out channel -1 (used for direct messages) and sort
+    return Array.from(channelSet)
+      .filter(ch => ch !== -1)
+      .sort((a, b) => a - b);
   };
 
   const getDMMessages = (nodeId: string): MeshMessage[] => {
     return messages.filter(msg =>
       (msg.from === nodeId || msg.to === nodeId) &&
-      msg.to !== '!ffffffff' // Exclude broadcasts
+      msg.to !== '!ffffffff' && // Exclude broadcasts
+      msg.channel === -1 // Only direct messages
     );
   };
 
@@ -1789,6 +1793,97 @@ function App() {
     }
   };
 
+  const handlePurgeNodes = async () => {
+    const confirmed = window.confirm(
+      'Are you sure you want to erase all nodes and traceroute history?\n\n' +
+      'Impact:\n' +
+      '• All node information will be deleted\n' +
+      '• All traceroute history will be deleted\n' +
+      '• A node refresh will be triggered to repopulate the list\n\n' +
+      'This action cannot be undone!'
+    );
+
+    if (!confirmed) return;
+
+    try {
+      const response = await fetch('/api/purge/nodes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      if (response.ok) {
+        alert('Node list and traceroutes have been purged. Refreshing...');
+        window.location.reload();
+      } else {
+        alert('Failed to purge nodes. Please try again.');
+      }
+    } catch (error) {
+      console.error('Error purging nodes:', error);
+      alert('Error purging nodes. Please try again.');
+    }
+  };
+
+  const handlePurgeTelemetry = async () => {
+    const confirmed = window.confirm(
+      'Are you sure you want to purge all telemetry data?\n\n' +
+      'Impact:\n' +
+      '• All historical telemetry records will be deleted\n' +
+      '• Telemetry graphs will show no historical data\n' +
+      '• Current node states (battery, voltage) will be preserved\n' +
+      '• New telemetry will continue to be collected\n\n' +
+      'This action cannot be undone!'
+    );
+
+    if (!confirmed) return;
+
+    try {
+      const response = await fetch('/api/purge/telemetry', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      if (response.ok) {
+        alert('Telemetry data has been purged.');
+      } else {
+        alert('Failed to purge telemetry. Please try again.');
+      }
+    } catch (error) {
+      console.error('Error purging telemetry:', error);
+      alert('Error purging telemetry. Please try again.');
+    }
+  };
+
+  const handlePurgeMessages = async () => {
+    const confirmed = window.confirm(
+      'Are you sure you want to purge all messages?\n\n' +
+      'Impact:\n' +
+      '• All channel messages will be deleted\n' +
+      '• All direct messages will be deleted\n' +
+      '• Message history will be permanently lost\n' +
+      '• New messages will continue to be received\n\n' +
+      'This action cannot be undone!'
+    );
+
+    if (!confirmed) return;
+
+    try {
+      const response = await fetch('/api/purge/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      if (response.ok) {
+        alert('Messages have been purged. Refreshing...');
+        window.location.reload();
+      } else {
+        alert('Failed to purge messages. Please try again.');
+      }
+    } catch (error) {
+      console.error('Error purging messages:', error);
+      alert('Error purging messages. Please try again.');
+    }
+  };
+
   const renderSettingsTab = () => (
     <div className="tab-content">
       <div className="settings-header-card">
@@ -1834,6 +1929,50 @@ function App() {
               onChange={(e) => handleTracerouteIntervalChange(parseInt(e.target.value))}
               className="setting-input"
             />
+          </div>
+        </div>
+
+        <div className="settings-section danger-zone">
+          <h3>⚠️ Danger Zone</h3>
+          <p className="danger-zone-description">These actions cannot be undone. Use with caution.</p>
+
+          <div className="danger-action">
+            <div className="danger-action-info">
+              <h4>Erase Node List</h4>
+              <p>Removes all nodes and traceroute history from the database. A node refresh will be triggered to repopulate the list.</p>
+            </div>
+            <button
+              className="danger-button"
+              onClick={handlePurgeNodes}
+            >
+              Erase Nodes
+            </button>
+          </div>
+
+          <div className="danger-action">
+            <div className="danger-action-info">
+              <h4>Purge Telemetry</h4>
+              <p>Removes all historical telemetry data (battery, voltage, temperature, etc.). Current node states will be preserved.</p>
+            </div>
+            <button
+              className="danger-button"
+              onClick={handlePurgeTelemetry}
+            >
+              Purge Telemetry
+            </button>
+          </div>
+
+          <div className="danger-action">
+            <div className="danger-action-info">
+              <h4>Purge Messages</h4>
+              <p>Removes all messages from channels and direct message conversations. This action is permanent.</p>
+            </div>
+            <button
+              className="danger-button"
+              onClick={handlePurgeMessages}
+            >
+              Purge Messages
+            </button>
           </div>
         </div>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -963,8 +963,6 @@ function App() {
       node.position.longitude != null
     );
 
-    console.log('🗺️ Map render:', { currentNodeId, selectedNodeId, tracerouteCount: traceroutes.length });
-
     // Calculate center point of all nodes for initial map view
     const getMapCenter = (): [number, number] => {
       if (nodesWithPosition.length === 0) {
@@ -1102,9 +1100,6 @@ function App() {
                       )}
                       {node.user?.id && (() => {
                         const hopCount = getTracerouteHopCount(node.user.id);
-                        if (hopCount < 999) {
-                          console.log(`Node ${node.user.longName} (${node.user.id}): ${hopCount} hops`);
-                        }
                         return hopCount < 999;
                       })() && (
                         <div className="node-hops" title="Traceroute Hops">
@@ -2009,15 +2004,25 @@ function App() {
           onClick={() => setActiveTab('channels')}
         >
           Channels
-          {Object.values(unreadCounts).some(count => count > 0) && (
+          {Object.entries(unreadCounts).some(([channel, count]) => parseInt(channel) !== -1 && count > 0) && (
             <span className="tab-notification-dot"></span>
           )}
         </button>
         <button
           className={`tab-btn ${activeTab === 'messages' ? 'active' : ''}`}
-          onClick={() => setActiveTab('messages')}
+          onClick={() => {
+            setActiveTab('messages');
+            // Clear unread count for direct messages (channel -1)
+            setUnreadCounts(prev => ({ ...prev, [-1]: 0 }));
+            // Set selected channel to -1 so new DMs don't create unread notifications
+            setSelectedChannel(-1);
+            selectedChannelRef.current = -1;
+          }}
         >
           Messages
+          {unreadCounts[-1] > 0 && (
+            <span className="tab-notification-dot"></span>
+          )}
         </button>
         <button
           className={`tab-btn ${activeTab === 'info' ? 'active' : ''}`}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -581,6 +581,39 @@ app.post('/api/settings/traceroute-interval', (req, res) => {
   }
 });
 
+// Danger zone endpoints
+app.post('/api/purge/nodes', async (_req, res) => {
+  try {
+    databaseService.purgeAllNodes();
+    // Trigger a node refresh after purging
+    await meshtasticManager.refreshNodeDatabase();
+    res.json({ success: true, message: 'All nodes and traceroutes purged, refresh triggered' });
+  } catch (error) {
+    console.error('Error purging nodes:', error);
+    res.status(500).json({ error: 'Failed to purge nodes' });
+  }
+});
+
+app.post('/api/purge/telemetry', (_req, res) => {
+  try {
+    databaseService.purgeAllTelemetry();
+    res.json({ success: true, message: 'All telemetry data purged' });
+  } catch (error) {
+    console.error('Error purging telemetry:', error);
+    res.status(500).json({ error: 'Failed to purge telemetry' });
+  }
+});
+
+app.post('/api/purge/messages', (_req, res) => {
+  try {
+    databaseService.purgeAllMessages();
+    res.json({ success: true, message: 'All messages purged' });
+  } catch (error) {
+    console.error('Error purging messages:', error);
+    res.status(500).json({ error: 'Failed to purge messages' });
+  }
+});
+
 // Health check endpoint
 app.get('/api/health', (_req, res) => {
   res.json({

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -890,6 +890,23 @@ class DatabaseService {
     const telemetry = stmt.all(nodeId) as DbTelemetry[];
     return telemetry.map(t => this.normalizeBigInts(t));
   }
+
+  // Danger zone operations
+  purgeAllNodes(): void {
+    console.log('⚠️ PURGING all nodes and traceroutes from database');
+    this.db.exec('DELETE FROM traceroutes');
+    this.db.exec('DELETE FROM nodes');
+  }
+
+  purgeAllTelemetry(): void {
+    console.log('⚠️ PURGING all telemetry from database');
+    this.db.exec('DELETE FROM telemetry');
+  }
+
+  purgeAllMessages(): void {
+    console.log('⚠️ PURGING all messages from database');
+    this.db.exec('DELETE FROM messages');
+  }
 }
 
 export default new DatabaseService();


### PR DESCRIPTION
## Summary
- Fix environment telemetry parsing to properly capture temperature, humidity, and pressure data
- Prevent telemetry data pollution from NodeInfo packets during refresh
- Isolate direct messages from channels with proper channel=-1 handling
- Preserve node names across non-NODEINFO packet updates
- Add Settings danger zone for data purge operations
- Improve UI notifications and reduce console spam

## Key Changes

### Telemetry Fixes
- **Fix environment telemetry parsing**: Access `deviceMetrics`, `environmentMetrics`, `powerMetrics` fields directly instead of using incorrect `variant.case` structure
- **Stop telemetry pollution from NodeInfo**: Only save telemetry from TELEMETRY_APP packets, not from node refresh packets
- **Preserve current node states**: Battery/voltage displayed in UI while historical data is properly tracked

### Direct Message Isolation
- **Channel -1 for DMs**: Direct messages (non-broadcast) now use channel=-1 to separate them from channel messages
- **Filter channel list**: Channel -1 no longer appears in the Channels tab
- **Proper DM retrieval**: `getDMMessages` now explicitly filters for channel=-1
- **Better logging**: Distinguish between direct and channel messages in logs

### Node Name Preservation
- **Prevent name overwrites**: Only update technical fields (SNR/RSSI/lastHeard) from MeshPackets
- **Names from NODEINFO only**: Node names like "Yeraze Mobile" only updated from NODEINFO packets
- **Traceroute handling**: Check if node exists before updating to avoid overwriting names

### Danger Zone (Settings)
- **Erase Node List**: Purges all nodes + traceroutes, triggers refresh
- **Purge Telemetry**: Removes all historical telemetry data
- **Purge Messages**: Deletes all channel and DM messages
- Each action requires confirmation with impact explanation
- Styled with red borders and warning indicators

### UX Improvements
- **Remove console spam**: Eliminated constant "Map render" and "Node X hops" logs
- **DM notifications**: Messages tab now shows unread badge for direct messages (channel -1)
- **Channels tab badge fix**: Excludes DM unread count from Channels tab badge
- **Auto-clear DM badge**: Switching to Messages tab clears the DM unread count

## Test Plan
- ✅ Verify environment telemetry appears in graphs for nodes like "KE4JQ G2 Base"
- ✅ Confirm direct messages only appear in DM conversations, not Primary channel
- ✅ Check node names persist correctly (e.g., "Yeraze Mobile" doesn't revert to ID)
- ✅ Test danger zone buttons with confirmation dialogs
- ✅ Verify console is clean without constant logging
- ✅ Confirm DM notification badge works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)