### PR TITLE
fix: Change Docker publishing to trigger only on GitHub Releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,8 @@
 name: Docker Build and Publish
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*'
+  release:
+    types: [published]
   pull_request:
     branches:
       - main
@@ -42,12 +39,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
Update the Docker publish workflow to only build and publish images when a GitHub Release is published, rather than on every push to main.

## Problem
The current workflow triggers Docker builds on:
- Every push to main branch
- Every tag push (v*)

This creates intermediate Docker images that aren't tied to official releases, cluttering the container registry.

## Solution
Change the workflow trigger to:
- `release: types: [published]` - Only publish images for official GitHub Releases
- Keep PR builds for validation (without publishing)

## Changes
✅ **Workflow Trigger Update**
- Removed: `push` to main branch
- Removed: `push` to tags (v*)
- Added: `release` with type `published`
- Kept: `pull_request` for validation builds

✅ **Tag Generation Update**
- Removed: `type=ref,event=branch` (no longer needed)
- Updated: `latest` tag now only applies when `event_name == 'release'`
- Kept: All semver patterns ({{version}}, {{major}}.{{minor}}, {{major}})
- Kept: PR reference tags for validation builds

## Behavior After Merge

### What Will Trigger Builds:
✅ Creating a GitHub Release (e.g., v1.2.0)
- Builds and publishes with tags: `1.2.0`, `1.2`, `1`, `latest`

✅ Opening/updating a PR
- Builds for validation only (does not publish)

### What Will NOT Trigger Builds:
❌ Pushing commits to main
❌ Pushing tags manually with `git push --tags`

## Benefits
- **Controlled Release Process** - Images only for official releases
- **Cleaner Registry** - No intermediate or test images
- **Clear Versioning** - Each image corresponds to a GitHub Release
- **Maintains PR Validation** - Still tests builds on PRs

## Test Plan
- [x] Workflow syntax validated
- [ ] Merge to main
- [ ] Verify no build triggered by merge commit
- [ ] Create next release (e.g., v1.1.1)
- [ ] Verify Docker images are published automatically
- [ ] Confirm images appear at ghcr.io/yeraze/meshmonitor

## Notes
This aligns with best practices where Docker images are only published for official releases, not on every commit to main. The workflow will automatically trigger when you create releases through the GitHub UI or `gh release create`.

🤖 Generated with [Claude Code](https://claude.ai/code)