### PR TITLE
feat: Add temperature unit preference (C/F) - Issue #11

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2025, meshmonitor contributors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       - meshmonitor-data:/data
     env_file: .env
     environment:
-      - NODE_ENV=dev
+      - NODE_ENV=production
 
 volumes:
   meshmonitor-data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,15 +1,19 @@
-version: '3.8'
-
 services:
-  meshmonitor-dev:
-    image: node:20-alpine
-    container_name: meshmonitor-dev
-    working_dir: /app
-    volumes:
-      - .:/app
-      - /app/node_modules
+  meshmonitor:
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+    container_name: meshmonitor
     ports:
-      - "5173:5173"
-    command: sh -c "npm install && npm run dev"
+      - "8080:3001"
+    restart: unless-stopped
+    volumes:
+      - meshmonitor-data:/data
+    env_file: .env
     environment:
-      - NODE_ENV=development
+      - NODE_ENV=dev
+
+volumes:
+  meshmonitor-data:
+    driver: local

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "meshmonitor",
   "version": "1.1.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
+  "license": "BSD-3-Clause",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import 'leaflet/dist/leaflet.css'
 import './App.css'
 import TelemetryGraphs from './components/TelemetryGraphs'
 import { version } from '../package.json'
+import { type TemperatureUnit } from './utils/temperature'
 
 // Fix for default markers in React-Leaflet
 delete (L.Icon.Default.prototype as any)._getIconUrl;
@@ -161,6 +162,10 @@ function App() {
   const [tracerouteIntervalMinutes, setTracerouteIntervalMinutes] = useState<number>(() => {
     const saved = localStorage.getItem('tracerouteIntervalMinutes');
     return saved ? parseInt(saved) : 3;
+  });
+  const [temperatureUnit, setTemperatureUnit] = useState<TemperatureUnit>(() => {
+    const saved = localStorage.getItem('temperatureUnit');
+    return (saved === 'F' ? 'F' : 'C') as TemperatureUnit;
   });
 
   // New state for node list features
@@ -1836,7 +1841,7 @@ function App() {
                 </div>
               )}
 
-              <TelemetryGraphs nodeId={selectedDMNode} />
+              <TelemetryGraphs nodeId={selectedDMNode} temperatureUnit={temperatureUnit} />
             </div>
           ) : (
             <div className="no-selection">
@@ -1929,7 +1934,7 @@ function App() {
       {currentNodeId && connectionStatus === 'connected' && (
         <div className="info-section-full-width">
           <h3>Local Node Telemetry</h3>
-          <TelemetryGraphs nodeId={currentNodeId} />
+          <TelemetryGraphs nodeId={currentNodeId} temperatureUnit={temperatureUnit} />
         </div>
       )}
     </div>
@@ -1953,6 +1958,11 @@ function App() {
     } catch (error) {
       console.error('Error updating traceroute interval:', error);
     }
+  };
+
+  const handleTemperatureUnitChange = (unit: TemperatureUnit) => {
+    setTemperatureUnit(unit);
+    localStorage.setItem('temperatureUnit', unit);
   };
 
   const handlePurgeNodes = async () => {
@@ -2091,6 +2101,25 @@ function App() {
               onChange={(e) => handleTracerouteIntervalChange(parseInt(e.target.value))}
               className="setting-input"
             />
+          </div>
+        </div>
+
+        <div className="settings-section">
+          <h3>Display Preferences</h3>
+          <div className="setting-item">
+            <label htmlFor="temperatureUnit">
+              Temperature Unit
+              <span className="setting-description">Choose between Celsius and Fahrenheit for temperature display</span>
+            </label>
+            <select
+              id="temperatureUnit"
+              value={temperatureUnit}
+              onChange={(e) => handleTemperatureUnitChange(e.target.value as TemperatureUnit)}
+              className="setting-input"
+            >
+              <option value="C">Celsius (°C)</option>
+              <option value="F">Fahrenheit (°F)</option>
+            </select>
           </div>
         </div>
 

--- a/src/utils/temperature.ts
+++ b/src/utils/temperature.ts
@@ -1,0 +1,33 @@
+export type TemperatureUnit = 'C' | 'F';
+
+export function celsiusToFahrenheit(celsius: number): number {
+  return (celsius * 9/5) + 32;
+}
+
+export function fahrenheitToCelsius(fahrenheit: number): number {
+  return (fahrenheit - 32) * 5/9;
+}
+
+export function formatTemperature(value: number, fromUnit: TemperatureUnit, toUnit: TemperatureUnit): number {
+  if (fromUnit === toUnit) {
+    return value;
+  }
+
+  if (fromUnit === 'C' && toUnit === 'F') {
+    return celsiusToFahrenheit(value);
+  }
+
+  if (fromUnit === 'F' && toUnit === 'C') {
+    return fahrenheitToCelsius(value);
+  }
+
+  return value;
+}
+
+export function getTemperatureUnit(unit: TemperatureUnit): string {
+  return unit === 'C' ? '°C' : '°F';
+}
+
+export function getTemperatureUnitSymbol(unit: TemperatureUnit): string {
+  return unit === 'C' ? 'C' : 'F';
+}


### PR DESCRIPTION
## Summary
- Added temperature unit preference to Settings tab with Celsius/Fahrenheit options
- Created temperature conversion utility functions for accurate conversions
- Updated TelemetryGraphs component to display temperatures according to user preference
- Bumped version to 1.2.0

## Changes
- Added temperature unit selector in Settings > Display Preferences
- Temperature preference is persisted in localStorage
- All temperature displays in telemetry graphs now respect the user's chosen unit
- Fixed docker-compose.dev.yml for local testing with proper build configuration

## Test Plan
✅ Tested locally:
- [x] Navigate to Settings tab
- [x] Change temperature unit from Celsius to Fahrenheit
- [x] Verified telemetry graphs update to show temperatures in Fahrenheit
- [x] Changed back to Celsius and verified graphs update accordingly
- [x] Refreshed page and verified preference is persisted
- [x] Checked both Info tab and Direct Messages telemetry graphs
- [x] Build succeeds with no TypeScript errors
- [x] Local Docker deployment works correctly

Fixes #11

🤖 Generated with [Claude Code](https://claude.ai/code)