### PR TITLE
feat: Add telemetry favorites and dashboard

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2378,6 +2378,69 @@ body {
   transform: translateY(0);
 }
 
+/* Settings Management Buttons */
+.settings-buttons {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.save-button {
+  background: var(--ctp-green);
+  color: var(--ctp-base);
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s, transform 0.1s, opacity 0.2s;
+  white-space: nowrap;
+  min-width: 120px;
+}
+
+.save-button:hover:not(:disabled) {
+  background: var(--ctp-teal);
+  transform: translateY(-1px);
+}
+
+.save-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.save-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.reset-button {
+  background: var(--ctp-yellow);
+  color: var(--ctp-base);
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s, transform 0.1s, opacity 0.2s;
+  white-space: nowrap;
+  min-width: 120px;
+}
+
+.reset-button:hover:not(:disabled) {
+  background: var(--ctp-peach);
+  transform: translateY(-1px);
+}
+
+.reset-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.reset-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* System Status Modal */
 .modal-overlay {
   position: fixed;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -189,6 +189,36 @@ function App() {
           setNodeAddress('192.168.1.100');
         }
 
+        // Load settings from server
+        const settingsResponse = await fetch('/api/settings');
+        if (settingsResponse.ok) {
+          const settings = await settingsResponse.json();
+
+          // Apply server settings if they exist, otherwise use localStorage/defaults
+          if (settings.maxNodeAgeHours) {
+            const value = parseInt(settings.maxNodeAgeHours);
+            setMaxNodeAgeHours(value);
+            localStorage.setItem('maxNodeAgeHours', value.toString());
+          }
+
+          if (settings.tracerouteIntervalMinutes) {
+            const value = parseInt(settings.tracerouteIntervalMinutes);
+            setTracerouteIntervalMinutes(value);
+            localStorage.setItem('tracerouteIntervalMinutes', value.toString());
+          }
+
+          if (settings.temperatureUnit) {
+            setTemperatureUnit(settings.temperatureUnit as TemperatureUnit);
+            localStorage.setItem('temperatureUnit', settings.temperatureUnit);
+          }
+
+          if (settings.telemetryVisualizationHours) {
+            const value = parseInt(settings.telemetryVisualizationHours);
+            setTelemetryVisualizationHours(value);
+            localStorage.setItem('telemetryVisualizationHours', value.toString());
+          }
+        }
+
         // Check connection status
         await checkConnectionStatus();
       } catch (error) {
@@ -1977,6 +2007,7 @@ function App() {
             messages={messages}
             currentNodeId={currentNodeId}
             temperatureUnit={temperatureUnit}
+            telemetryHours={telemetryVisualizationHours}
             getAvailableChannels={getAvailableChannels}
           />
         )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import './App.css'
 import TelemetryGraphs from './components/TelemetryGraphs'
 import InfoTab from './components/InfoTab'
 import SettingsTab from './components/SettingsTab'
+import Dashboard from './components/Dashboard'
 import { version } from '../package.json'
 import { type TemperatureUnit } from './utils/temperature'
 import { DeviceInfo, Channel } from './types/device'
@@ -1964,6 +1965,12 @@ function App() {
           )}
         </button>
         <button
+          className={`tab-btn ${activeTab === 'dashboard' ? 'active' : ''}`}
+          onClick={() => setActiveTab('dashboard')}
+        >
+          Dashboard
+        </button>
+        <button
           className={`tab-btn ${activeTab === 'info' ? 'active' : ''}`}
           onClick={() => setActiveTab('info')}
         >
@@ -2009,6 +2016,12 @@ function App() {
             temperatureUnit={temperatureUnit}
             telemetryHours={telemetryVisualizationHours}
             getAvailableChannels={getAvailableChannels}
+          />
+        )}
+        {activeTab === 'dashboard' && (
+          <Dashboard
+            temperatureUnit={temperatureUnit}
+            telemetryHours={telemetryVisualizationHours}
           />
         )}
         {activeTab === 'settings' && (

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -1,0 +1,127 @@
+.dashboard {
+  padding: 20px;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+.dashboard-title {
+  color: #cdd6f4;
+  margin: 0 0 10px 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.dashboard-subtitle {
+  color: #a6adc8;
+  margin: 0 0 20px 0;
+  font-size: 0.9rem;
+}
+
+.dashboard-loading,
+.dashboard-error,
+.dashboard-empty {
+  color: #a6adc8;
+  text-align: center;
+  padding: 40px 20px;
+  background-color: #181825;
+  border-radius: 8px;
+  margin: 20px;
+}
+
+.dashboard-empty h2 {
+  color: #cdd6f4;
+  margin-bottom: 10px;
+}
+
+.dashboard-empty p {
+  color: #a6adc8;
+}
+
+.dashboard-error {
+  color: #f38ba8;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
+  gap: 20px;
+  width: 100%;
+}
+
+.dashboard-chart-container {
+  background-color: #1e1e2e;
+  border: 1px solid #45475a;
+  border-radius: 8px;
+  padding: 15px;
+}
+
+.dashboard-chart-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.dashboard-chart-title {
+  color: #cdd6f4;
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 500;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-right: 10px;
+}
+
+.dashboard-remove-btn {
+  background: none;
+  border: none;
+  color: #585b70;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.dashboard-remove-btn:hover {
+  color: #f38ba8;
+}
+
+.dashboard-no-data {
+  color: #a6adc8;
+  text-align: center;
+  padding: 40px 20px;
+  font-style: italic;
+}
+
+@media (max-width: 1024px) {
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .dashboard {
+    padding: 10px;
+  }
+
+  .dashboard-grid {
+    gap: 15px;
+  }
+
+  .dashboard-chart-container {
+    padding: 10px;
+  }
+
+  .dashboard-chart-title {
+    font-size: 0.9rem;
+  }
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,0 +1,338 @@
+import React, { useState, useEffect } from 'react';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import './Dashboard.css';
+import { type TemperatureUnit, formatTemperature, getTemperatureUnit } from '../utils/temperature';
+
+interface TelemetryData {
+  id?: number;
+  nodeId: string;
+  nodeNum: number;
+  telemetryType: string;
+  timestamp: number;
+  value: number;
+  unit?: string;
+  createdAt: number;
+}
+
+interface FavoriteChart {
+  nodeId: string;
+  telemetryType: string;
+}
+
+interface NodeInfo {
+  nodeNum: number;
+  user?: {
+    id: string;
+    longName?: string;
+    shortName?: string;
+    hwModel?: number;
+  };
+  deviceMetrics?: {
+    batteryLevel?: number | null;
+    voltage?: number | null;
+    channelUtilization?: number | null;
+    airUtilTx?: number | null;
+  };
+  lastHeard?: number;
+  snr?: number;
+  rssi?: number;
+}
+
+interface ChartData {
+  timestamp: number;
+  value: number;
+  time: string;
+}
+
+interface DashboardProps {
+  temperatureUnit?: TemperatureUnit;
+  telemetryHours?: number;
+}
+
+const Dashboard: React.FC<DashboardProps> = ({ temperatureUnit = 'C', telemetryHours = 24 }) => {
+  const [favorites, setFavorites] = useState<FavoriteChart[]>([]);
+  const [telemetryData, setTelemetryData] = useState<Map<string, TelemetryData[]>>(new Map());
+  const [nodes, setNodes] = useState<Map<string, NodeInfo>>(new Map());
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch favorites and node information
+  useEffect(() => {
+    const fetchFavoritesAndNodes = async () => {
+      try {
+        setLoading(true);
+
+        // Fetch favorites from settings
+        const settingsResponse = await fetch('/api/settings');
+        if (!settingsResponse.ok) {
+          throw new Error('Failed to fetch settings');
+        }
+
+        const settings = await settingsResponse.json();
+        const favoritesArray: FavoriteChart[] = settings.telemetryFavorites
+          ? JSON.parse(settings.telemetryFavorites)
+          : [];
+
+        setFavorites(favoritesArray);
+
+        // Fetch node information
+        const nodesResponse = await fetch('/api/nodes');
+        if (!nodesResponse.ok) {
+          throw new Error('Failed to fetch nodes');
+        }
+
+        const nodesData = await nodesResponse.json();
+        const nodesMap = new Map<string, NodeInfo>();
+        nodesData.forEach((node: NodeInfo) => {
+          if (node.user?.id) {
+            nodesMap.set(node.user.id, node);
+          }
+        });
+        setNodes(nodesMap);
+
+        // Fetch telemetry data for each favorite
+        const telemetryMap = new Map<string, TelemetryData[]>();
+
+        await Promise.all(
+          favoritesArray.map(async (favorite) => {
+            try {
+              const response = await fetch(`/api/telemetry/${favorite.nodeId}?hours=${telemetryHours}`);
+              if (response.ok) {
+                const data: TelemetryData[] = await response.json();
+                // Filter to only get the specific telemetry type
+                const filteredData = data.filter(d => d.telemetryType === favorite.telemetryType);
+                const key = `${favorite.nodeId}-${favorite.telemetryType}`;
+                telemetryMap.set(key, filteredData);
+              }
+            } catch (err) {
+              console.error(`Error fetching telemetry for ${favorite.nodeId}:`, err);
+            }
+          })
+        );
+
+        setTelemetryData(telemetryMap);
+        setError(null);
+      } catch (err) {
+        console.error('Error in Dashboard:', err);
+        setError(err instanceof Error ? err.message : 'Failed to load dashboard data');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchFavoritesAndNodes();
+    const interval = setInterval(fetchFavoritesAndNodes, 30000); // Refresh every 30 seconds
+
+    return () => clearInterval(interval);
+  }, [telemetryHours]);
+
+  const prepareChartData = (data: TelemetryData[], isTemperature: boolean = false): ChartData[] => {
+    return data
+      .sort((a, b) => a.timestamp - b.timestamp)
+      .map(item => ({
+        timestamp: item.timestamp,
+        value: isTemperature ? formatTemperature(item.value, 'C', temperatureUnit) : item.value,
+        time: new Date(item.timestamp).toLocaleTimeString([], {
+          hour: '2-digit',
+          minute: '2-digit'
+        })
+      }));
+  };
+
+  const getTelemetryLabel = (type: string): string => {
+    const labels: { [key: string]: string } = {
+      batteryLevel: 'Battery Level',
+      voltage: 'Voltage',
+      channelUtilization: 'Channel Utilization',
+      airUtilTx: 'Air Utilization (TX)',
+      temperature: 'Temperature',
+      humidity: 'Humidity',
+      pressure: 'Barometric Pressure',
+      ch1Voltage: 'Channel 1 Voltage',
+      ch1Current: 'Channel 1 Current'
+    };
+    return labels[type] || type;
+  };
+
+  const getColor = (type: string): string => {
+    const colors: { [key: string]: string } = {
+      batteryLevel: '#82ca9d',
+      voltage: '#8884d8',
+      channelUtilization: '#ffc658',
+      airUtilTx: '#ff7c7c',
+      temperature: '#ff8042',
+      humidity: '#00c4cc',
+      pressure: '#a28dff',
+      ch1Voltage: '#d084d8',
+      ch1Current: '#ff6b9d'
+    };
+    return colors[type] || '#8884d8';
+  };
+
+  const removeFavorite = async (nodeId: string, telemetryType: string) => {
+    try {
+      const newFavorites = favorites.filter(
+        f => !(f.nodeId === nodeId && f.telemetryType === telemetryType)
+      );
+
+      // Update local state
+      setFavorites(newFavorites);
+
+      // Remove from telemetry data
+      const key = `${nodeId}-${telemetryType}`;
+      const newTelemetryData = new Map(telemetryData);
+      newTelemetryData.delete(key);
+      setTelemetryData(newTelemetryData);
+
+      // Save to server
+      await fetch('/api/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ telemetryFavorites: JSON.stringify(newFavorites) })
+      });
+    } catch (error) {
+      console.error('Error removing favorite:', error);
+      // Revert on error
+      window.location.reload();
+    }
+  };
+
+  if (loading) {
+    return <div className="dashboard-loading">Loading dashboard...</div>;
+  }
+
+  if (error) {
+    return <div className="dashboard-error">Error: {error}</div>;
+  }
+
+  if (favorites.length === 0) {
+    return (
+      <div className="dashboard-empty">
+        <h2>No Favorites Yet</h2>
+        <p>Star telemetry charts in the Nodes tab to see them here</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="dashboard">
+      <h2 className="dashboard-title">Telemetry Dashboard</h2>
+      <p className="dashboard-subtitle">Showing last {telemetryHours} hours of favorited telemetry</p>
+
+      <div className="dashboard-grid">
+        {favorites.map((favorite) => {
+          const key = `${favorite.nodeId}-${favorite.telemetryType}`;
+          const data = telemetryData.get(key) || [];
+          const node = nodes.get(favorite.nodeId);
+
+          // Format node name with both longName and shortName
+          let nodeName = '';
+          if (node?.user) {
+            if (node.user.longName && node.user.shortName) {
+              nodeName = `${node.user.longName} (${node.user.shortName})`;
+            } else if (node.user.longName) {
+              nodeName = node.user.longName;
+            } else if (node.user.shortName) {
+              nodeName = node.user.shortName;
+            } else {
+              nodeName = favorite.nodeId;
+            }
+          } else {
+            nodeName = favorite.nodeId;
+          }
+
+          if (data.length === 0) {
+            return (
+              <div key={key} className="dashboard-chart-container">
+                <div className="dashboard-chart-header">
+                  <h3 className="dashboard-chart-title">
+                    {nodeName} - {getTelemetryLabel(favorite.telemetryType)}
+                  </h3>
+                  <button
+                    className="dashboard-remove-btn"
+                    onClick={() => removeFavorite(favorite.nodeId, favorite.telemetryType)}
+                    aria-label="Remove from dashboard"
+                  >
+                    ✕
+                  </button>
+                </div>
+                <div className="dashboard-no-data">No data available</div>
+              </div>
+            );
+          }
+
+          const isTemperature = favorite.telemetryType === 'temperature';
+          const chartData = prepareChartData(data, isTemperature);
+          const unit = isTemperature ? getTemperatureUnit(temperatureUnit) : (data[0]?.unit || '');
+          const color = getColor(favorite.telemetryType);
+
+          return (
+            <div key={key} className="dashboard-chart-container">
+              <div className="dashboard-chart-header">
+                <h3 className="dashboard-chart-title">
+                  {nodeName} - {getTelemetryLabel(favorite.telemetryType)} {unit && `(${unit})`}
+                </h3>
+                <button
+                  className="dashboard-remove-btn"
+                  onClick={() => removeFavorite(favorite.nodeId, favorite.telemetryType)}
+                  aria-label="Remove from dashboard"
+                >
+                  ✕
+                </button>
+              </div>
+
+              <ResponsiveContainer width="100%" height={200}>
+                <LineChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#ccc" />
+                  <XAxis
+                    dataKey="timestamp"
+                    type="number"
+                    domain={['dataMin', 'dataMax']}
+                    tick={{ fontSize: 12 }}
+                    tickFormatter={(timestamp) => new Date(timestamp).toLocaleTimeString([], {
+                      hour: '2-digit',
+                      minute: '2-digit'
+                    })}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 12 }}
+                    domain={['auto', 'auto']}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: '#1e1e2e',
+                      border: '1px solid #45475a',
+                      borderRadius: '4px',
+                      color: '#cdd6f4'
+                    }}
+                    labelStyle={{ color: '#cdd6f4' }}
+                    labelFormatter={(value) => {
+                      const date = new Date(value);
+                      return date.toLocaleString([], {
+                        month: 'short',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        second: '2-digit'
+                      });
+                    }}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="value"
+                    stroke={color}
+                    strokeWidth={2}
+                    dot={{ fill: color, r: 3 }}
+                    activeDot={{ r: 5 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/components/InfoTab.tsx
+++ b/src/components/InfoTab.tsx
@@ -16,6 +16,7 @@ interface InfoTabProps {
   messages: MeshMessage[];
   currentNodeId: string;
   temperatureUnit: TemperatureUnit;
+  telemetryHours: number;
   getAvailableChannels: () => number[];
 }
 
@@ -29,6 +30,7 @@ const InfoTab: React.FC<InfoTabProps> = ({
   messages,
   currentNodeId,
   temperatureUnit,
+  telemetryHours,
   getAvailableChannels
 }) => {
   return (
@@ -111,7 +113,7 @@ const InfoTab: React.FC<InfoTabProps> = ({
       {currentNodeId && connectionStatus === 'connected' && (
         <div className="info-section-full-width">
           <h3>Local Node Telemetry</h3>
-          <TelemetryGraphs nodeId={currentNodeId} temperatureUnit={temperatureUnit} />
+          <TelemetryGraphs nodeId={currentNodeId} temperatureUnit={temperatureUnit} telemetryHours={telemetryHours} />
         </div>
       )}
     </div>

--- a/src/components/TelemetryGraphs.css
+++ b/src/components/TelemetryGraphs.css
@@ -34,11 +34,41 @@
   padding: 15px;
 }
 
+.graph-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
 .graph-title {
   color: #cdd6f4;
-  margin: 0 0 10px 0;
+  margin: 0;
   font-size: 1rem;
   font-weight: 500;
+}
+
+.favorite-btn {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #585b70;
+  transition: color 0.2s ease;
+}
+
+.favorite-btn:hover {
+  color: #f9e2af;
+}
+
+.favorite-btn.favorited {
+  color: #f9e2af;
 }
 
 @media (max-width: 768px) {

--- a/src/components/TelemetryGraphs.test.tsx
+++ b/src/components/TelemetryGraphs.test.tsx
@@ -65,16 +65,38 @@ describe('TelemetryGraphs Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (global.fetch as Mock).mockResolvedValue({
-      ok: true,
-      json: async () => mockTelemetryData
+    // Mock both settings fetch (for favorites) and telemetry fetch
+    (global.fetch as Mock).mockImplementation((url: string) => {
+      if (url.includes('/api/settings')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({})  // No favorites by default
+        });
+      }
+      // Default to telemetry data
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockTelemetryData
+      });
     });
   });
 
   it('should render loading state initially', async () => {
     // Mock fetch to be slow
-    (global.fetch as Mock).mockImplementation(() =>
-      new Promise(resolve => setTimeout(resolve, 100))
+    (global.fetch as Mock).mockImplementation((url: string) =>
+      new Promise(resolve => setTimeout(() => {
+        if (url.includes('/api/settings')) {
+          resolve({
+            ok: true,
+            json: async () => ({})
+          });
+        } else {
+          resolve({
+            ok: true,
+            json: async () => mockTelemetryData
+          });
+        }
+      }, 100))
     );
 
     await act(async () => {
@@ -101,7 +123,16 @@ describe('TelemetryGraphs Component', () => {
   });
 
   it('should display error state when fetch fails', async () => {
-    (global.fetch as Mock).mockRejectedValueOnce(new Error('Network error'));
+    (global.fetch as Mock).mockImplementation((url: string) => {
+      if (url.includes('/api/settings')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({})  // No favorites
+        });
+      }
+      // Telemetry fetch fails
+      return Promise.reject(new Error('Network error'));
+    });
 
     render(<TelemetryGraphs nodeId={mockNodeId} />);
 
@@ -111,9 +142,18 @@ describe('TelemetryGraphs Component', () => {
   });
 
   it('should display no data message when telemetry is empty', async () => {
-    (global.fetch as Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => []
+    (global.fetch as Mock).mockImplementation((url: string) => {
+      if (url.includes('/api/settings')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({})  // No favorites
+        });
+      }
+      // Return empty telemetry
+      return Promise.resolve({
+        ok: true,
+        json: async () => []
+      });
     });
 
     render(<TelemetryGraphs nodeId={mockNodeId} />);
@@ -173,10 +213,19 @@ describe('TelemetryGraphs Component', () => {
   });
 
   it('should handle API returning non-ok status', async () => {
-    (global.fetch as Mock).mockResolvedValueOnce({
-      ok: false,
-      status: 404,
-      statusText: 'Not Found'
+    (global.fetch as Mock).mockImplementation((url: string) => {
+      if (url.includes('/api/settings')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({})
+        });
+      }
+      // Telemetry fetch returns non-ok
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found'
+      });
     });
 
     render(<TelemetryGraphs nodeId={mockNodeId} />);
@@ -194,9 +243,17 @@ describe('TelemetryGraphs Component', () => {
       { nodeId: mockNodeId, telemetryType: 'batteryLevel', value: 75, timestamp: Date.now() }
     ];
 
-    (global.fetch as Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockData
+    (global.fetch as Mock).mockImplementation((url: string) => {
+      if (url.includes('/api/settings')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({})
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockData
+      });
     });
 
     render(<TelemetryGraphs nodeId={mockNodeId} />);
@@ -263,9 +320,17 @@ describe('TelemetryGraphs Component', () => {
       { nodeId: mockNodeId, telemetryType: 'voltage', value: 3.7, timestamp: Date.now(), unit: 'V' }
     ];
 
-    (global.fetch as Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockDataWithUnits
+    (global.fetch as Mock).mockImplementation((url: string) => {
+      if (url.includes('/api/settings')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({})
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockDataWithUnits
+      });
     });
 
     render(<TelemetryGraphs nodeId={mockNodeId} />);
@@ -303,9 +368,17 @@ describe('TelemetryGraphs Component', () => {
         }
       ];
 
-      (global.fetch as Mock).mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockData
+      (global.fetch as Mock).mockImplementation((url: string) => {
+        if (url.includes('/api/settings')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({})
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => mockData
+        });
       });
 
       render(<TelemetryGraphs nodeId={mockNodeId} />);
@@ -328,9 +401,17 @@ describe('TelemetryGraphs Component', () => {
         }
       ];
 
-      (global.fetch as Mock).mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockData
+      (global.fetch as Mock).mockImplementation((url: string) => {
+        if (url.includes('/api/settings')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({})
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => mockData
+        });
       });
 
       render(<TelemetryGraphs nodeId={mockNodeId} temperatureUnit="F" />);
@@ -371,9 +452,17 @@ describe('TelemetryGraphs Component', () => {
         }
       ];
 
-      (global.fetch as Mock).mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockData
+      (global.fetch as Mock).mockImplementation((url: string) => {
+        if (url.includes('/api/settings')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({})
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => mockData
+        });
       });
 
       render(<TelemetryGraphs nodeId={mockNodeId} temperatureUnit="F" />);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -610,6 +610,63 @@ app.post('/api/settings/traceroute-interval', (req, res) => {
   }
 });
 
+// Get all settings
+app.get('/api/settings', (_req, res) => {
+  try {
+    const settings = databaseService.getAllSettings();
+    res.json(settings);
+  } catch (error) {
+    console.error('Error fetching settings:', error);
+    res.status(500).json({ error: 'Failed to fetch settings' });
+  }
+});
+
+// Save settings
+app.post('/api/settings', (req, res) => {
+  try {
+    const settings = req.body;
+
+    // Validate settings
+    const validKeys = ['maxNodeAgeHours', 'tracerouteIntervalMinutes', 'temperatureUnit', 'telemetryVisualizationHours'];
+    const filteredSettings: Record<string, string> = {};
+
+    for (const key of validKeys) {
+      if (key in settings) {
+        filteredSettings[key] = String(settings[key]);
+      }
+    }
+
+    // Save to database
+    databaseService.setSettings(filteredSettings);
+
+    // Apply traceroute interval if changed
+    if ('tracerouteIntervalMinutes' in filteredSettings) {
+      const interval = parseInt(filteredSettings.tracerouteIntervalMinutes);
+      if (!isNaN(interval) && interval >= 1 && interval <= 60) {
+        meshtasticManager.setTracerouteInterval(interval);
+      }
+    }
+
+    res.json({ success: true, settings: filteredSettings });
+  } catch (error) {
+    console.error('Error saving settings:', error);
+    res.status(500).json({ error: 'Failed to save settings' });
+  }
+});
+
+// Reset settings to defaults
+app.delete('/api/settings', (_req, res) => {
+  try {
+    databaseService.deleteAllSettings();
+    // Reset traceroute interval to default
+    meshtasticManager.setTracerouteInterval(3);
+    res.json({ success: true, message: 'Settings reset to defaults' });
+  } catch (error) {
+    console.error('Error resetting settings:', error);
+    res.status(500).json({ error: 'Failed to reset settings' });
+  }
+});
+
 // Danger zone endpoints
 app.post('/api/purge/nodes', async (_req, res) => {
   try {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -627,7 +627,7 @@ app.post('/api/settings', (req, res) => {
     const settings = req.body;
 
     // Validate settings
-    const validKeys = ['maxNodeAgeHours', 'tracerouteIntervalMinutes', 'temperatureUnit', 'telemetryVisualizationHours'];
+    const validKeys = ['maxNodeAgeHours', 'tracerouteIntervalMinutes', 'temperatureUnit', 'telemetryVisualizationHours', 'telemetryFavorites'];
     const filteredSettings: Record<string, string> = {};
 
     for (const key of validKeys) {

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,4 +1,4 @@
-export type TabType = 'nodes' | 'channels' | 'messages' | 'info' | 'settings';
+export type TabType = 'nodes' | 'channels' | 'messages' | 'info' | 'settings' | 'dashboard';
 
 export type SortField = 'longName' | 'shortName' | 'id' | 'lastHeard' | 'snr' | 'battery' | 'hwModel' | 'location' | 'hops';
 


### PR DESCRIPTION
## Summary
- Added telemetry chart favoriting functionality with persistent storage
- Created a new Dashboard tab that displays all favorited telemetry graphs
- Improved node identification by showing longName and shortName instead of IDs

## Features Added

### 1. Telemetry Chart Favorites
- Added star icon (☆/★) in the upper right corner of each telemetry chart
- Click to toggle favorite status for individual charts
- Favorites are persisted server-side in the settings database
- Visual feedback with yellow color when favorited

### 2. Dashboard Tab
- New "Dashboard" tab in main navigation between Messages and Info
- Shows all favorited telemetry graphs across all nodes in a grid layout
- Each graph clearly labeled with node name and telemetry type
- Displays node names in format: `LongName (ShortName)` for better readability
- Remove button (✕) on each graph to unfavorite directly from dashboard
- Auto-refreshes data every 30 seconds
- Empty state message guides users when no favorites are selected

### 3. Server-side Persistence
- Extended settings API to support `telemetryFavorites` storage
- Favorites persist across browser sessions and reloads
- Node-specific favorites allow different selections per node

## Technical Details
- Updated `TabType` to include 'dashboard' option
- Created new `Dashboard` component with responsive grid layout
- Modified `TelemetryGraphs` component to support favorite toggling
- Added CSS styling consistent with existing Catppuccin theme

## Testing
- Tested favorite persistence across reloads ✓
- Verified dashboard displays correct node names ✓
- Confirmed auto-refresh functionality ✓
- Tested responsive layout on different screen sizes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)