### PR TITLE
chore: upgrade to Node.js 22 and deprecate Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - name: Checkout code
@@ -49,11 +49,11 @@ jobs:
         run: npm run test:run -- --exclude="**/server.test.ts"
 
       - name: Generate coverage report
-        if: matrix.node-version == '20.x'  # Only generate coverage on one version
+        if: matrix.node-version == '22.x'  # Only generate coverage on one version
         run: npm run test:coverage -- --exclude="**/server.test.ts"
 
       - name: Upload coverage to Codecov
-        if: matrix.node-version == '20.x'
+        if: matrix.node-version == '22.x'
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage/coverage-final.json
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install dependencies
@@ -115,7 +115,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - name: Checkout code
@@ -74,11 +74,11 @@ jobs:
         run: npm run test:run
 
       - name: Generate coverage report
-        if: matrix.node-version == '20.x'
+        if: matrix.node-version == '22.x'
         run: npm run test:coverage
 
       - name: Check coverage thresholds
-        if: matrix.node-version == '20.x'
+        if: matrix.node-version == '22.x'
         run: |
           echo "Checking coverage thresholds..."
           # Add coverage threshold checks here when configured
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
@@ -19,7 +19,7 @@ RUN npm run build
 RUN npm run build:server
 
 # Production stage
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ A comprehensive web application for monitoring Meshtastic mesh networks over IP.
 
 ### Prerequisites
 
-- Node.js 20+ or Docker
+- Node.js 20+ or 22+ (Node.js 18 is deprecated and will lose support April 2025)
+- Docker (recommended) or local Node.js environment
 - A Meshtastic device with WiFi/Ethernet connectivity
 - Network access to your Meshtastic node
 


### PR DESCRIPTION
## Summary
- Upgraded Docker images from Node 20 to Node 22 Alpine
- Updated CI workflows to test with Node 20 and 22 (dropped Node 18)
- Added Node 18 deprecation notice to README

## Context
Node.js 18 reaches end-of-life on April 30, 2025 (4 months away). This PR upgrades to Node.js 22, which is currently Active LTS and recommended for production use through October 2025.

## Changes
- ✅ Dockerfile: Upgraded both build and production stages to `node:22-alpine`
- ✅ CI Workflows: Updated test matrix to use Node 20.x and 22.x
- ✅ README: Added deprecation notice for Node 18 users
- ✅ Tests pass with Node 22 (excluding existing server test issues)

## Dependencies
This PR depends on the recently merged better-sqlite3 v12.4.1 upgrade (PR #23), which adds Node 22 compatibility.

## Test Plan
- [x] Docker build succeeds with Node 22
- [x] Unit tests pass (excluding pre-existing server test failures)
- [x] Verified better-sqlite3 v12 supports Node 22
- [ ] CI checks should pass with updated matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)