### PR TITLE
fix: resolve Express 5 wildcard route compatibility issue

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -740,7 +740,7 @@ app.get('/api/health', (_req, res) => {
 });
 
 // Catch all handler: send back React's index.html file for client-side routing
-app.get('*', (_req, res) => {
+app.use((_req: express.Request, res: express.Response) => {
   res.sendFile(path.join(buildPath, 'index.html'));
 });
 


### PR DESCRIPTION
## Summary
- Fixed server startup crash caused by Express 5's updated path-to-regexp module
- Replaced `app.get('*')` with `app.use()` for the catch-all route handler
- Ensures proper serving of React's index.html for client-side routing

## Problem
After the recent dependency updates, the server was failing to start with the error:
```
PathError [TypeError]: Missing parameter name at index 1: *
```

This was due to Express 5's path-to-regexp module no longer supporting the bare `*` wildcard syntax for route matching.

## Solution
Changed the catch-all route from using `app.get('*', ...)` to `app.use(...)` which properly handles all unmatched routes in Express 5.

## Test plan
- [x] Server starts successfully without errors
- [x] Web interface loads at http://localhost:8080
- [x] Client-side routing works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)