### PR TITLE
fix: add missing actions:read permission to Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,6 +23,7 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
+      actions: read
       id-token: write
     
     steps:


### PR DESCRIPTION
## Summary
- Adds missing `actions:read` permission to the Claude Code Review workflow

## Problem
The Claude Code Review action was failing on PRs with the error:
```
Failed to setup GitHub token: Error: Could not fetch an OIDC token. 
Did you remember to add `id-token: write` to your workflow permissions?
```

While `id-token: write` was present, the workflow was missing the `actions:read` permission which is also required for GitHub's OIDC authentication to work properly.

## Solution
Added `actions:read` to the permissions block alongside the existing permissions.

## Test plan
- [x] Verify workflow file syntax is correct
- [ ] Confirm the Claude Code Review action runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)