### PR TITLE
ui: Improve route popup distance formatting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1519,8 +1519,8 @@ function App() {
                               Used in <strong>{usage}</strong> traceroute{usage !== 1 ? 's' : ''}
                             </div>
                             {segmentDistanceKm > 0 && (
-                              <div className="route-distance">
-                                Distance: {formatDistance(segmentDistanceKm, distanceUnit)}
+                              <div className="route-usage">
+                                Distance: <strong>{formatDistance(segmentDistanceKm, distanceUnit)}</strong>
                               </div>
                             )}
                             {snrStats && (
@@ -1696,8 +1696,8 @@ function App() {
                                   }).join(' → ')}
                                 </div>
                                 {forwardTotalDistanceKm > 0 && (
-                                  <div className="route-distance">
-                                    Distance: {formatDistance(forwardTotalDistanceKm, distanceUnit)}
+                                  <div className="route-usage">
+                                    Distance: <strong>{formatDistance(forwardTotalDistanceKm, distanceUnit)}</strong>
                                   </div>
                                 )}
                               </div>
@@ -1766,8 +1766,8 @@ function App() {
                                   }).join(' → ')}
                                 </div>
                                 {backTotalDistanceKm > 0 && (
-                                  <div className="route-distance">
-                                    Distance: {formatDistance(backTotalDistanceKm, distanceUnit)}
+                                  <div className="route-usage">
+                                    Distance: <strong>{formatDistance(backTotalDistanceKm, distanceUnit)}</strong>
                                   </div>
                                 )}
                               </div>


### PR DESCRIPTION
## Summary
Improves the visual formatting of distance information in route popups for better readability and consistency.

## Changes

### Before
Distance was displayed with `route-distance` class, causing inconsistent styling and poor visibility.

### After
- Uses `route-usage` class for consistent styling
- Distance values wrapped in `<strong>` tags for accent color highlighting
- Centered text with consistent visual hierarchy

### Affected Popups
1. **Purple route segments** - intermediate hop popups
2. **Red forward traceroute paths** - forward path popups
3. **Red return traceroute paths** - return path popups

## Visual Improvements
- Distance values now centered and highlighted like "Used in N traceroutes"
- Consistent accent color (catppuccin mauve) applied to numeric values
- Better readability and visual hierarchy

## Test plan
- [x] Build succeeds
- [ ] Click on purple route segment - distance is highlighted and centered
- [ ] Click on red forward traceroute path - distance is highlighted and centered
- [ ] Click on red return traceroute path - distance is highlighted and centered
- [ ] Verify distance format matches "Used in N traceroutes" styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)