### PR TITLE
fix: ensure broadcast node exists to prevent FK constraint failures (#70)

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -113,6 +113,8 @@ class DatabaseService {
     this.initialize();
     // Always ensure Primary channel exists, even if database already initialized
     this.ensurePrimaryChannel();
+    // Always ensure broadcast node exists for channel messages
+    this.ensureBroadcastNode();
   }
 
   private initialize(): void {
@@ -143,6 +145,35 @@ class DatabaseService {
       }
     } catch (error) {
       console.error('❌ Error in ensurePrimaryChannel:', error);
+    }
+  }
+
+  private ensureBroadcastNode(): void {
+    console.log('🔍 ensureBroadcastNode() called');
+    try {
+      const broadcastNodeNum = 4294967295; // 0xFFFFFFFF
+      const broadcastNodeId = '!ffffffff';
+
+      const existingNode = this.getNode(broadcastNodeNum);
+      console.log('🔍 getNode(4294967295) returned:', existingNode);
+
+      if (!existingNode) {
+        console.log('🔍 No broadcast node found, creating it');
+        this.upsertNode({
+          nodeNum: broadcastNodeNum,
+          nodeId: broadcastNodeId,
+          longName: 'Broadcast',
+          shortName: 'BCAST'
+        });
+
+        // Verify it was created
+        const verify = this.getNode(broadcastNodeNum);
+        console.log('🔍 After upsert, getNode(4294967295) returns:', verify);
+      } else {
+        console.log(`✅ Broadcast node already exists`);
+      }
+    } catch (error) {
+      console.error('❌ Error in ensureBroadcastNode:', error);
     }
   }
 


### PR DESCRIPTION
## Problem
When users send messages to channels (not direct messages), the system was failing with a Foreign Key constraint error:

```
FOREIGN KEY constraint failed
```

This occurred because channel messages use a broadcast destination (`toNodeNum = 4294967295` / `0xFFFFFFFF`), but no corresponding node entry existed in the database.

## Root Cause
The `messages` table has foreign key constraints on both `fromNodeNum` and `toNodeNum`:
```sql
FOREIGN KEY (fromNodeNum) REFERENCES nodes(nodeNum),
FOREIGN KEY (toNodeNum) REFERENCES nodes(nodeNum)
```

When sending to a channel, the code correctly ensured the local node existed, but the broadcast destination node (4294967295) was never created, causing the FK constraint to fail.

## Solution
Added `ensureBroadcastNode()` method that:
- Creates a broadcast node entry with `nodeNum = 4294967295` and `nodeId = !ffffffff`
- Sets friendly names: `longName = "Broadcast"`, `shortName = "BCAST"`
- Follows the same pattern as `ensurePrimaryChannel()`
- Called automatically during database initialization

## Testing
- ✅ TypeScript compilation passes
- ✅ Tests pass (234/235 - 1 unrelated WIP test)
- Ready for manual testing by reporter

## Related
Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)