### PR TITLE
docs: update documentation for reply threading and emoji tapback features

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,12 @@ This allows MeshMonitor to connect to **any** Meshtastic device (BLE, Serial, or
 - Node role display (Client, Router, Repeater, etc.)
 - Hops Away tracking for network distance
 
-### 💬 **iPhone Messages-Style UI**
+### 💬 **iPhone Messages-Style UI with Reactions**
 - Beautiful message bubbles with proper alignment
+- **Interactive reply button** - Reply to any message with proper threading
+- **Instant emoji reactions** - Quick tapback with 👍 👎 ❓ ❗ 😂 😢 💩
+- Hover-based action menu on each message
+- Clickable existing reactions to send the same emoji
 - Sender identification dots with tooltips
 - Real-time message delivery status
 - Send and receive text messages
@@ -453,7 +457,7 @@ Any proxy implementing the Meshtastic TCP protocol can bridge to MeshMonitor.
 
 ### Messages
 - `GET /api/messages` - Get messages with pagination
-- `POST /api/messages/send` - Send message to channel
+- `POST /api/messages/send` - Send message to channel (supports `text`, `channel`, `destination`, `replyId`, `emoji`)
 - `GET /api/messages/channel/:channel` - Channel-specific messages
 - `GET /api/messages/direct/:nodeId1/:nodeId2` - Direct messages
 
@@ -513,12 +517,19 @@ interface MeshMessage {
   id: string;
   from: string;
   to: string;
+  fromNodeId: string;
+  toNodeId: string;
   text: string;
   timestamp: Date;
   channel: number;
   portnum?: number;
   acknowledged?: boolean;
+  ackFailed?: boolean;
   isLocalMessage?: boolean;
+  hopStart?: number;
+  hopLimit?: number;
+  replyId?: number;        // Message ID being replied to
+  emoji?: number;          // 0=normal message, 1=tapback reaction
 }
 ```
 

--- a/docs/architecture/SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/SYSTEM_ARCHITECTURE.md
@@ -54,7 +54,11 @@ src/
 **Responsibilities:**
 - User interface rendering and interaction
 - Real-time connection status display
-- Message composition and display
+- Message composition and display with threaded replies and emoji reactions
+  - Interactive hover-based reply button on each message
+  - Instant emoji tapback reactions (👍 👎 ❓ ❗ 😂 😢 💩)
+  - Reply context display in send box
+  - Clickable reactions to send the same emoji
 - Node information visualization with map integration
 - Telemetry data visualization with graphs
 - Traceroute visualization and management
@@ -290,7 +294,11 @@ TCP Stream → Buffer Accumulator → Frame Detector (0x94 0xc3)
 - **NodeInfo packets**: Device information, user details, and role configuration
 - **Position packets**: GPS coordinates, altitude, and location timestamps
 - **Telemetry packets**: Battery level, voltage, channel utilization, air utilization
-- **Text Message packets**: User communications with replyId and emoji support
+- **Text Message packets**: User communications with threading and reactions
+  - `replyId` field enables threaded conversations and tapbacks
+  - `emoji` flag (0=normal message, 1=tapback) differentiates replies from reactions
+  - Supports instant emoji reactions: 👍 👎 ❓ ❗ 😂 😢 💩
+  - Protobuf fields 7 (replyId) and 8 (emoji) as per Meshtastic spec
 - **Traceroute packets**: Network path analysis and SNR measurements
 - **Admin packets**: Channel configuration and node management
 


### PR DESCRIPTION
## Summary
- Comprehensive documentation updates for the reply threading and emoji tapback features added in PR #81
- Updates all architecture and database documentation to reflect the new messaging capabilities

## Documentation Updated
- **README.md**: Updated messaging features, MeshMessage interface, and API endpoints
- **ARCHITECTURE.md**: Enhanced component descriptions, UI/UX features, and message types
- **docs/database/SCHEMA.md**: Added field descriptions, business rules, and SQL queries for replies/tapbacks
- **docs/architecture/DATA_STRUCTURES.md**: Updated interfaces with complete examples (regular messages, replies, tapbacks)
- **docs/architecture/SYSTEM_ARCHITECTURE.md**: Enhanced frontend responsibilities and packet processing details

## Key Documentation Additions
- Detailed explanation of replyId and emoji protobuf fields (fields 7 and 8)
- Differentiation between threaded replies and emoji tapback reactions
- SQL queries for finding replies and reactions
- Complete MeshMessage interface examples
- Updated API endpoint documentation

## Related
- Follows up on PR #81 (reply and tapback support implementation)
- Ensures all documentation reflects current system capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>