### PR TITLE
feat: display hop count next to message timestamps (v1.12.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2189,6 +2189,11 @@ function App() {
                                       hour: '2-digit',
                                       minute: '2-digit'
                                     })}
+                                    {msg.hopStart !== undefined && msg.hopLimit !== undefined && (
+                                      <span style={{ fontSize: '0.75em', marginLeft: '4px', opacity: 0.7 }}>
+                                        ({msg.hopStart - msg.hopLimit} hop{msg.hopStart - msg.hopLimit !== 1 ? 's' : ''})
+                                      </span>
+                                    )}
                                   </span>
                                 </div>
                               </div>
@@ -2465,7 +2470,14 @@ function App() {
                       <div key={msg.id} className={`message-item ${isTraceroute ? 'traceroute' : msg.from === selectedDMNode ? 'received' : 'sent'}`}>
                         <div className="message-header">
                           <span className="message-from">{getNodeName(msg.from)}</span>
-                          <span className="message-time">{msg.timestamp.toLocaleTimeString()}</span>
+                          <span className="message-time">
+                            {msg.timestamp.toLocaleTimeString()}
+                            {msg.hopStart !== undefined && msg.hopLimit !== undefined && (
+                              <span style={{ fontSize: '0.75em', marginLeft: '4px', opacity: 0.7 }}>
+                                ({msg.hopStart - msg.hopLimit} hop{msg.hopStart - msg.hopLimit !== 1 ? 's' : ''})
+                              </span>
+                            )}
+                          </span>
                           {isTraceroute && <span className="traceroute-badge">TRACEROUTE</span>}
                         </div>
                         <div className="message-text" style={isTraceroute ? {whiteSpace: 'pre-line', fontFamily: 'monospace'} : {}}>{msg.text}</div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import TelemetryGraphs from './components/TelemetryGraphs'
 import InfoTab from './components/InfoTab'
 import SettingsTab from './components/SettingsTab'
 import Dashboard from './components/Dashboard'
+import HopCountDisplay from './components/HopCountDisplay'
 import { version } from '../package.json'
 import { type TemperatureUnit } from './utils/temperature'
 import { calculateDistance, formatDistance } from './utils/distance'
@@ -2189,11 +2190,7 @@ function App() {
                                       hour: '2-digit',
                                       minute: '2-digit'
                                     })}
-                                    {msg.hopStart !== undefined && msg.hopLimit !== undefined && (
-                                      <span style={{ fontSize: '0.75em', marginLeft: '4px', opacity: 0.7 }}>
-                                        ({msg.hopStart - msg.hopLimit} hop{msg.hopStart - msg.hopLimit !== 1 ? 's' : ''})
-                                      </span>
-                                    )}
+                                    <HopCountDisplay hopStart={msg.hopStart} hopLimit={msg.hopLimit} />
                                   </span>
                                 </div>
                               </div>
@@ -2472,11 +2469,7 @@ function App() {
                           <span className="message-from">{getNodeName(msg.from)}</span>
                           <span className="message-time">
                             {msg.timestamp.toLocaleTimeString()}
-                            {msg.hopStart !== undefined && msg.hopLimit !== undefined && (
-                              <span style={{ fontSize: '0.75em', marginLeft: '4px', opacity: 0.7 }}>
-                                ({msg.hopStart - msg.hopLimit} hop{msg.hopStart - msg.hopLimit !== 1 ? 's' : ''})
-                              </span>
-                            )}
+                            <HopCountDisplay hopStart={msg.hopStart} hopLimit={msg.hopLimit} />
                           </span>
                           {isTraceroute && <span className="traceroute-badge">TRACEROUTE</span>}
                         </div>

--- a/src/components/HopCountDisplay.tsx
+++ b/src/components/HopCountDisplay.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface HopCountDisplayProps {
+  hopStart?: number;
+  hopLimit?: number;
+}
+
+/**
+ * Display hop count for mesh messages
+ * Shows hop count calculated as (hopStart - hopLimit)
+ * Only renders when both values are available and result is valid
+ */
+const HopCountDisplay: React.FC<HopCountDisplayProps> = ({ hopStart, hopLimit }) => {
+  // Return null if either value is missing
+  if (hopStart === undefined || hopLimit === undefined) {
+    return null;
+  }
+
+  const hopCount = hopStart - hopLimit;
+
+  // Guard against malformed data (negative hop counts)
+  if (hopCount < 0) {
+    return null;
+  }
+
+  return (
+    <span style={{ fontSize: '0.75em', marginLeft: '4px', opacity: 0.7 }}>
+      ({hopCount} hop{hopCount !== 1 ? 's' : ''})
+    </span>
+  );
+};
+
+export default HopCountDisplay;


### PR DESCRIPTION
## Summary
- Display hop count (hopStart - hopLimit) in small print next to message timestamps
- Applies to both channel messages and direct messages for better mesh network visibility
- Version bumped to 1.11.1

## Test plan
- [ ] Verify hop count displays correctly next to timestamps in channel messages
- [ ] Verify hop count displays correctly next to timestamps in direct messages
- [ ] Confirm hop count only shows when both hopStart and hopLimit are available
- [ ] Check formatting (small print, slightly dimmed, proper spacing)
- [ ] Verify plural handling ("1 hop" vs "2 hops")
- [ ] Test with messages that don't have hop data (should not display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)