### PR TITLE
fix: ensure protobufs git submodule is initialized during Docker builds (v1.11.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,13 @@ RUN rm -f package-lock.json && \
 # Copy source files
 COPY . .
 
+# Verify protobufs are present (fail fast if git submodule wasn't initialized)
+RUN if [ ! -f "protobufs/meshtastic/mesh.proto" ]; then \
+      echo "ERROR: Protobuf files not found! Git submodule may not be initialized."; \
+      echo "Run: git submodule update --init --recursive"; \
+      exit 1; \
+    fi
+
 # Build the React application (always for root, will be rewritten at runtime)
 RUN npm run build
 

--- a/README.md
+++ b/README.md
@@ -235,14 +235,15 @@ For complete Kubernetes documentation, configuration options, and examples, see 
 
 ### Development Setup
 
-1. **Clone the repository**
+1. **Clone the repository with submodules**
    ```bash
-   git clone <repository-url>
+   git clone --recurse-submodules https://github.com/Yeraze/meshmonitor.git
    cd meshmonitor
+   ```
 
-   # Initialize and update git submodules (required for protobufs)
-   git submodule init
-   git submodule update
+   **Important:** If you already cloned without `--recurse-submodules`:
+   ```bash
+   git submodule update --init --recursive
    ```
 
 2. **Install dependencies**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes #86 - Docker builds failing with `ENOENT: no such file or directory, open '/app/protobufs/meshtastic/mesh.proto'`

## 🔍 Root Cause

The protobufs are stored as a **git submodule**, but GitHub Actions workflows were not checking out submodules when building Docker images. This caused the protobufs directory to be empty in published images, leading to runtime failures when the app tried to load protobuf definitions.

## ✅ Changes

### GitHub Actions Workflows
- **docker-publish.yml**: Added `submodules: recursive` to checkout step
- **release.yml**: Added `submodules: recursive` to checkout step
- **ci.yml**: Added `submodules: recursive` to Docker build checkout step

### Dockerfile
- Added verification check to fail fast if protobufs are missing
- Provides clear error message with instructions to initialize submodules

### Documentation
- Updated README.md with proper git clone instructions using `--recurse-submodules`
- Added fallback instructions for existing clones

### Version
- Bumped to v1.11.2

## 🧪 Testing

- ✅ Local Docker build passes with verification check
- ✅ Type checking passes
- ✅ All workflows updated consistently

## 📝 Impact

- **Users affected**: Those building from source tarballs or without submodules initialized
- **Workaround**: Use published Docker images from ghcr.io or clone with `--recurse-submodules`
- **Fix**: This PR ensures all future Docker builds from GitHub Actions include protobufs

🤖 Generated with [Claude Code](https://claude.com/claude-code)