### PR TITLE
feat: improve map visualization and traceroute scheduling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1379,7 +1379,7 @@ function App() {
                     checked={showPaths}
                     onChange={(e) => setShowPaths(e.target.checked)}
                   />
-                  <span>Show Paths</span>
+                  <span>Show Route Segments</span>
                 </label>
                 <label className="map-control-item">
                   <input
@@ -1387,7 +1387,7 @@ function App() {
                     checked={showRoute}
                     onChange={(e) => setShowRoute(e.target.checked)}
                   />
-                  <span>Show Route</span>
+                  <span>Show Traceroute</span>
                 </label>
                 <label className="map-control-item">
                   <input
@@ -1395,7 +1395,7 @@ function App() {
                     checked={showMotion}
                     onChange={(e) => setShowMotion(e.target.checked)}
                   />
-                  <span>Show Motion</span>
+                  <span>Show Position History</span>
                 </label>
               </div>
               <MapContainer
@@ -1421,11 +1421,13 @@ function App() {
                   const isSelected = selectedNodeId === node.user?.id;
 
                   // Get hop count for this node
-                  const hops = node.user?.id ? getTracerouteHopCount(node.user.id) : 999;
+                  // Local node always gets 0 hops (green), otherwise use traceroute data
+                  const isLocalNode = node.user?.id === currentNodeId;
+                  const hops = isLocalNode ? 0 : (node.user?.id ? getTracerouteHopCount(node.user.id) : 999);
                   const showLabel = mapZoom >= 13; // Show labels when zoomed in
 
                   const markerIcon = createNodeIcon({
-                    hops: hops, // 999 (no traceroute) will show as red
+                    hops: hops, // 0 (local) = green, 999 (no traceroute) = grey
                     isSelected,
                     isRouter,
                     shortName: node.user?.shortName,
@@ -2181,7 +2183,7 @@ function App() {
                                     </button>
                                   ))}
                                 </div>
-                                <div className="message-text">
+                                <div className="message-text" style={{whiteSpace: 'pre-line'}}>
                                   {msg.text}
                                 </div>
                                 {reactions.length > 0 && (
@@ -2487,7 +2489,7 @@ function App() {
                           </span>
                           {isTraceroute && <span className="traceroute-badge">TRACEROUTE</span>}
                         </div>
-                        <div className="message-text" style={isTraceroute ? {whiteSpace: 'pre-line', fontFamily: 'monospace'} : {}}>{msg.text}</div>
+                        <div className="message-text" style={isTraceroute ? {whiteSpace: 'pre-line', fontFamily: 'monospace'} : {whiteSpace: 'pre-line'}}>{msg.text}</div>
                       </div>
                     );
                   })

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -3,10 +3,11 @@ import { getHopColor } from '../utils/mapIcons';
 
 const MapLegend: React.FC = () => {
   const legendItems = [
-    { hops: '0', color: getHopColor(0), label: 'Direct (0 hops)' },
+    { hops: '0', color: getHopColor(0), label: 'Local Node' },
     { hops: '1-3', color: getHopColor(1), label: '1-3 Hops' },
     { hops: '4-5', color: getHopColor(4), label: '4-5 Hops' },
-    { hops: '6+', color: getHopColor(6), label: '6+ / Unknown' }
+    { hops: '6+', color: getHopColor(6), label: '6+ Hops' },
+    { hops: 'No Data', color: getHopColor(999), label: 'No Traceroute' }
   ];
 
   return (

--- a/src/utils/mapIcons.ts
+++ b/src/utils/mapIcons.ts
@@ -6,10 +6,13 @@ import L from 'leaflet';
  * 1-3 hops: Blue (#3b82f6 -> #1d4ed8)
  * 4-5 hops: Orange (#f59e0b -> #ea580c)
  * 6+ hops: Red (#ef4444)
+ * 999 hops: Grey (#9ca3af) - No traceroute data
  */
 export function getHopColor(hops: number): string {
   if (hops === 0) {
     return '#22c55e'; // Green for direct connection
+  } else if (hops === 999) {
+    return '#9ca3af'; // Grey for no traceroute data
   } else if (hops <= 3) {
     // Blue gradient for 1-3 hops
     if (hops === 1) return '#3b82f6';
@@ -18,7 +21,7 @@ export function getHopColor(hops: number): string {
   } else if (hops <= 5) {
     return hops === 4 ? '#f59e0b' : '#ea580c'; // Orange gradient
   } else {
-    return '#ef4444'; // Red for 6+ hops or unknown
+    return '#ef4444'; // Red for 6+ hops
   }
 }
 


### PR DESCRIPTION
## Summary
- **Map Visualization**: Display nodes without traceroute in grey (instead of red), always show local node in green, and clarify map control labels
- **Traceroute Scheduler**: Implement smart retry intervals (3h for untraced nodes, 24h for traced nodes) with random selection to prevent targeting same nodes repeatedly  
- **Message Display**: Preserve linebreaks in messages for better readability of multi-line content (e.g., weather forecasts)

## Changes

### Map Visualization Improvements
- Nodes with no traceroute data now display in **grey** (#9ca3af) instead of red
- Local/connected node always displays in **green** (0 hops)
- Updated map legend to show "Local Node" and "No Traceroute" entries
- Renamed map controls for clarity:
  - "Show Paths" → "Show Route Segments"
  - "Show Route" → "Show Traceroute"  
  - "Show Motion" → "Show Position History"

### Traceroute Scheduler Enhancements
- **Smart retry intervals**:
  - Nodes without successful traceroute: retry every **3 hours**
  - Nodes with successful traceroute: retry every **24 hours**
- **Random node selection** from all eligible nodes (prevents continuously retrying same node)
- Updated `getNodeNeedingTraceroute()` to query based on traceroute existence and age
- Added comprehensive tests for new time-based retry logic

### Message Display Fix
- Added `whiteSpace: 'pre-line'` to all message displays (channel and DM messages)
- Preserves linebreaks (`\n`) while collapsing other whitespace
- Significantly improves readability of multi-line messages from weather bots and other sources

## Test Plan
- [x] Verify grey color appears for nodes without traceroute data
- [x] Verify local node displays in green
- [x] Verify map legend shows all color categories correctly
- [x] Verify traceroute scheduler selects different nodes randomly
- [x] Verify 3h/24h retry intervals work correctly
- [x] Verify multi-line messages display with proper linebreaks
- [x] All unit tests pass (29/29 in database.extended.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)