### PR TITLE
feat: hops_away visualization with blue-to-red gradient (v1.12.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -4,8 +4,11 @@ import { getHopColor } from '../utils/mapIcons';
 const MapLegend: React.FC = () => {
   const legendItems = [
     { hops: '0', color: getHopColor(0), label: 'Local Node' },
-    { hops: '1-3', color: getHopColor(1), label: '1-3 Hops' },
-    { hops: '4-5', color: getHopColor(4), label: '4-5 Hops' },
+    { hops: '1', color: getHopColor(1), label: '1 Hop' },
+    { hops: '2', color: getHopColor(2), label: '2 Hops' },
+    { hops: '3', color: getHopColor(3), label: '3 Hops' },
+    { hops: '4', color: getHopColor(4), label: '4 Hops' },
+    { hops: '5', color: getHopColor(5), label: '5 Hops' },
     { hops: '6+', color: getHopColor(6), label: '6+ Hops' }
   ];
 

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -6,8 +6,7 @@ const MapLegend: React.FC = () => {
     { hops: '0', color: getHopColor(0), label: 'Local Node' },
     { hops: '1-3', color: getHopColor(1), label: '1-3 Hops' },
     { hops: '4-5', color: getHopColor(4), label: '4-5 Hops' },
-    { hops: '6+', color: getHopColor(6), label: '6+ Hops' },
-    { hops: 'No Data', color: getHopColor(999), label: 'No Traceroute' }
+    { hops: '6+', color: getHopColor(6), label: '6+ Hops' }
   ];
 
   return (

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1308,7 +1308,8 @@ class MeshtasticManager {
         nodeId: nodeId,
         lastHeard: nodeInfo.lastHeard ? Number(nodeInfo.lastHeard) : Date.now() / 1000,
         snr: nodeInfo.snr,
-        rssi: 0 // Will be updated from mesh packet if available
+        rssi: 0, // Will be updated from mesh packet if available
+        hopsAway: nodeInfo.hopsAway !== undefined ? nodeInfo.hopsAway : undefined
       };
 
       // Add user information if available

--- a/src/utils/mapIcons.ts
+++ b/src/utils/mapIcons.ts
@@ -2,26 +2,35 @@ import L from 'leaflet';
 
 /**
  * Get color based on hop count
- * 0 hops: Green (#22c55e) - Direct connection
- * 1-3 hops: Blue (#3b82f6 -> #1d4ed8)
- * 4-5 hops: Orange (#f59e0b -> #ea580c)
- * 6+ hops: Red (#ef4444)
- * 999 hops: Grey (#9ca3af) - No traceroute data
+ * Uses a blue-to-red gradient (through purple/magenta)
+ * 0 hops: Green (#22c55e) - Direct connection (local node)
+ * 1 hop: Blue (#0000FF)
+ * 2 hops: Blue-Purple (#3300CC)
+ * 3 hops: Purple (#660099)
+ * 4 hops: Red-Purple (#990066)
+ * 5 hops: Red-Magenta (#CC0033)
+ * 6+ hops: Red (#FF0000)
+ * 999 hops: Grey (#9ca3af) - No hop data
  */
 export function getHopColor(hops: number): string {
   if (hops === 0) {
-    return '#22c55e'; // Green for direct connection
+    return '#22c55e'; // Green for local node (direct connection)
   } else if (hops === 999) {
-    return '#9ca3af'; // Grey for no traceroute data
-  } else if (hops <= 3) {
-    // Blue gradient for 1-3 hops
-    if (hops === 1) return '#3b82f6';
-    if (hops === 2) return '#2563eb';
-    return '#1d4ed8'; // hops === 3
-  } else if (hops <= 5) {
-    return hops === 4 ? '#f59e0b' : '#ea580c'; // Orange gradient
+    return '#9ca3af'; // Grey for no hop data
+  } else if (hops >= 6) {
+    return '#FF0000'; // Red for 6+ hops
   } else {
-    return '#ef4444'; // Red for 6+ hops
+    // Linear gradient from blue to red (1-6 hops)
+    // Using RGB interpolation: Blue(0,0,255) → Red(255,0,0)
+    const colors = [
+      '#0000FF', // 1 hop: Blue
+      '#3300CC', // 2 hops: Blue-Purple
+      '#660099', // 3 hops: Purple
+      '#990066', // 4 hops: Red-Purple
+      '#CC0033', // 5 hops: Red-Magenta
+      '#FF0000'  // 6 hops: Red
+    ];
+    return colors[hops - 1] || colors[colors.length - 1];
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace traceroute-based hop counting with protobuf `hops_away` field
- Implement blue-to-red color gradient for hop count visualization
- Add altitude and hop count to map node popup
- Version bump to 1.12.1

## Changes

### Hop Count Data Source
- **Use `hops_away` from protobuf**: More reliable than traceroute-derived hop counts
- **Extract from NodeInfo messages**: Properly parse and save `hopsAway` field in meshtasticManager
- **Update all displays**: Node list, map pins, and sorting now use `hops_away`

### Color Gradient Visualization
Map pins now use a smooth blue-to-red gradient:
- **0 hops**: 🟢 Green `#22c55e` - Local Node
- **1 hop**: 🔵 Blue `#0000FF`
- **2 hops**: 🔵🟣 Blue-Purple `#3300CC`
- **3 hops**: 🟣 Purple `#660099`
- **4 hops**: 🟣🔴 Red-Purple `#990066`
- **5 hops**: 🔴🟣 Red-Magenta `#CC0033`
- **6+ hops**: 🔴 Red `#FF0000`

### UI Enhancements
- **Map Legend**: Expanded to show all 7 distinct hop levels (previously grouped)
- **Node Popup**: Added "Hops Away" and "Altitude" fields
- **Node List**: Hop count displayed in stats section (🔗 icon)
- **Sorting**: Fixed to use `hopsAway` instead of traceroute data

### Code Quality
- Removed unused `getTracerouteHopCount()` function
- Removed "No Traceroute" entry from map legend (no longer applicable)
- Updated comments to reflect protobuf data source
- Net code reduction: -7 lines

## Technical Details

The `hops_away` field is directly reported by mesh nodes via the protobuf `NodeInfo` message and provides accurate hop distance information. This is more reliable than deriving hop counts from traceroute data, which may be incomplete or unavailable.

Color gradient uses linear RGB interpolation from blue (0,0,255) to red (255,0,0), creating visually distinct colors for each hop level that are easy to distinguish on the map.

## Test plan
- [x] Build succeeds
- [x] Map displays nodes with color gradient based on hop count
- [x] Legend shows all 7 hop levels with correct colors
- [x] Node popup shows hop count and altitude (when available)
- [x] Node list displays hop count in stats
- [x] Sorting by hops works correctly
- [x] Verified `hopsAway` data is being captured from protobuf messages
- [x] Confirmed color gradient is visually distinct and easy to read

🤖 Generated with [Claude Code](https://claude.com/claude-code)