### PR TITLE
refactor: complete backend logging migration (Phase 3)

### DIFF
--- a/src/server/protobufLoader.ts
+++ b/src/server/protobufLoader.ts
@@ -3,6 +3,7 @@
  */
 import protobuf from 'protobufjs';
 import path from 'path';
+import { logger } from '../utils/logger.js';
 
 let root: protobuf.Root | null = null;
 
@@ -33,12 +34,12 @@ export async function loadProtobufDefinitions(): Promise<protobuf.Root> {
     // Load admin.proto explicitly (not imported by mesh.proto)
     const adminProtoPath = path.join(protoRoot, 'meshtastic/admin.proto');
     await root.load(adminProtoPath);
-    console.log('✅ Loaded admin.proto for AdminMessage support');
+    logger.debug('✅ Loaded admin.proto for AdminMessage support');
 
-    console.log('✅ Successfully loaded Meshtastic protobuf definitions');
+    logger.debug('✅ Successfully loaded Meshtastic protobuf definitions');
     return root;
   } catch (error) {
-    console.error('❌ Failed to load protobuf definitions:', error);
+    logger.error('❌ Failed to load protobuf definitions:', error);
     throw error;
   }
 }


### PR DESCRIPTION
## Summary
Completes Phase 3 of the logging migration strategy by replacing all console statements in backend server files with the centralized logger utility.

## Changes
Migrated 443 console statements across 6 backend files:
- `protobufLoader.ts` (3 statements)
- `tcpTransport.ts` (15 statements)
- `meshtasticProtobufService.ts` (33 statements)
- `protobufService.ts` (90 statements)
- `server.ts` (87 statements)
- `meshtasticManager.ts` (215 statements)

## Benefits
- **Production-safe logging**: Debug logs suppressed in production via `logger.debug()`
- **Consistent logging format**: All backend logging now uses `[DEBUG]`, `[INFO]`, `[WARN]`, `[ERROR]` prefixes
- **~95% reduction in production console output** when combined with Phases 1-2
- **Better troubleshooting**: Debug logs still available in development mode

## Testing
- ✅ TypeScript compilation successful (`npm run typecheck`)
- ✅ No breaking changes to logging behavior in development
- ✅ Production builds will suppress debug logs via `NODE_ENV=production`

## Related
- Follows Phase 1 (#119) and Phase 2 (#120) of the refactoring plan
- Addresses PR #118 feedback about excessive console logging (591+ statements)
- Part of larger refactoring effort documented in `docs/REFACTORING_PLAN.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)