### PR TITLE
chore: bump version to 1.17.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "1.16.0",
+  "version": "1.17.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Updates package.json version number to 1.17.2 to reflect the current release.

This was missed during the v1.17.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)