### PR TITLE
fix: restore message saving for auto-ack responses

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 1.18.1
-appVersion: "1.18.1"
+version: 1.18.2
+appVersion: "1.18.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bufbuild/protobuf": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Fixed critical bug where auto-ack responses were not being saved to the database, making them invisible in the UI despite being sent to the mesh network.

## Root Cause
In v1.18.1 (#136), we removed message saving from `meshtasticManager.sendTextMessage()` because it was using the wrong channel for direct messages (0 instead of -1). This created an unintended consequence: **auto-ack responses were no longer being saved to the database**.

The auto-ack feature calls `sendTextMessage()` directly (not through the server.ts API endpoint), so when we removed the saving logic, auto-acks stopped appearing in the UI even though they were successfully being transmitted to the mesh network.

## Solution

### Restored Message Saving with Correct Channel Logic
Re-added message saving to `meshtasticManager.sendTextMessage()` with the **correct channel assignment**:
```typescript
// Use channel -1 for direct messages, otherwise use the actual channel
channel: destination ? -1 : channel
```

### Removed Duplicate Saving
Removed the duplicate message saving from `server.ts` API endpoint since `sendTextMessage()` now handles it properly for all callers (both API and internal like auto-ack).

## Changes
- ✅ Auto-ack responses now visible in UI
- ✅ Direct messages correctly use channel -1
- ✅ Channel messages correctly use actual channel number
- ✅ No duplicate message saves
- ✅ Version bumped to 1.18.2

## Testing
- ✅ All 409 tests passing
- ✅ Verified auto-ack messages trigger and are sent to mesh
- ✅ Messages saved with correct channel assignment
- ✅ No duplicate saves in database

## Before/After
**Before:** Auto-ack responses were sent to mesh but not saved to database (invisible in UI)  
**After:** Auto-ack responses are both sent to mesh AND saved to database (visible in UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)