### PR TITLE
feat: disable all automation features by default on fresh install

### DIFF
--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -43,7 +43,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
 
   const [tracerouteIntervalMinutes, setTracerouteIntervalMinutesState] = useState<number>(() => {
     const saved = localStorage.getItem('tracerouteIntervalMinutes');
-    return saved ? parseInt(saved) : 3;
+    return saved ? parseInt(saved) : 0;
   });
 
   const [temperatureUnit, setTemperatureUnitState] = useState<TemperatureUnit>(() => {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -56,7 +56,7 @@ class MeshtasticManager {
   private transport: TcpTransport | null = null;
   private isConnected = false;
   private tracerouteInterval: NodeJS.Timeout | null = null;
-  private tracerouteIntervalMinutes: number = 3;
+  private tracerouteIntervalMinutes: number = 0;
   private announceInterval: NodeJS.Timeout | null = null;
   private serverStartTime: number = Date.now();
   private localNodeInfo: {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1138,8 +1138,8 @@ apiRouter.post('/settings', requirePermission('settings', 'write'), (req, res) =
 apiRouter.delete('/settings', requirePermission('settings', 'write'), (_req, res) => {
   try {
     databaseService.deleteAllSettings();
-    // Reset traceroute interval to default
-    meshtasticManager.setTracerouteInterval(3);
+    // Reset traceroute interval to default (disabled)
+    meshtasticManager.setTracerouteInterval(0);
     res.json({ success: true, message: 'Settings reset to defaults' });
   } catch (error) {
     logger.error('Error resetting settings:', error);

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -174,7 +174,8 @@ class DatabaseService {
         autoAnnounceIntervalHours: '6',
         autoAnnounceMessage: 'MeshMonitor {VERSION} online for {DURATION} {FEATURES}',
         autoAnnounceChannelIndex: '0',
-        autoAnnounceOnStart: 'false'
+        autoAnnounceOnStart: 'false',
+        tracerouteIntervalMinutes: '0'
       };
 
       Object.entries(automationSettings).forEach(([key, defaultValue]) => {


### PR DESCRIPTION
## Summary
Fixes #150

Changed default behavior for all automation features to be **disabled** on first-time installation. This provides a safer out-of-box experience and requires users to explicitly enable automation features they want to use.

## Changes
- **Auto-traceroute**: Changed default interval from 3 minutes to **0 (disabled)**
- **Auto-acknowledge**: Already disabled by default (confirmed)
- **Auto-announce**: Already disabled by default (confirmed)

## Modified Files
- `src/server/meshtasticManager.ts`: Set `tracerouteIntervalMinutes` default to 0
- `src/services/database.ts`: Added `tracerouteIntervalMinutes: '0'` to `ensureAutomationDefaults()`
- `src/contexts/SettingsContext.tsx`: Changed frontend default from 3 to 0
- `src/server/server.ts`: Updated settings reset default to 0

## Test Plan
- ✅ All 513 tests pass
- ✅ Fresh install verified with clean database
- ✅ Database logs confirm all automation defaults set to disabled:
  - `autoAckEnabled: false`
  - `autoAnnounceEnabled: false`
  - `tracerouteIntervalMinutes: 0`
- ✅ Traceroute scheduler confirms: "Traceroute interval set to 0 (disabled)"

## Verification
Started fresh dev environment with wiped database and verified logs show:
```
[DEBUG] ✅ Set default for autoAckEnabled: false
[DEBUG] ✅ Set default for autoAnnounceEnabled: false
[DEBUG] ✅ Set default for tracerouteIntervalMinutes: 0
[DEBUG] 🗺️ Traceroute interval set to 0 (disabled)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)