### PR TITLE
docs: add TZ environment variable to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ For complete Kubernetes documentation, configuration options, and examples, see 
 | `NODE_ENV` | `development` | Environment mode |
 | `PORT` | `3001` | Server port (production) |
 | `BASE_URL` | (empty) | Runtime base URL path for subfolder deployment (e.g., `/meshmonitor`) |
+| `TZ` | `America/New_York` | Timezone for auto-acknowledge message timestamps (see [TZ database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)) |
 
 ### Meshtastic Node Requirements
 


### PR DESCRIPTION
## Summary
- Add documentation for the `TZ` environment variable in the README's Environment Variables table

## Details
The `TZ` environment variable is used by the `checkAutoAcknowledge()` function in `src/server/meshtasticManager.ts:3143` to format message timestamps in auto-acknowledge responses. Without this documentation, users may not be aware they can customize the timezone for these automated messages.

This change adds:
- Documentation in the Environment Variables table
- Default value: `America/New_York` (matching the code default)
- Link to TZ database timezone list for easy reference

## Test plan
- [x] Documentation accurately reflects code behavior
- [x] Link to TZ database is valid
- [x] Format matches existing environment variable documentation

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)