### PR TITLE
fix: correct font styling for route segment SNR statistics

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2444,15 +2444,18 @@ body {
   font-size: 1rem;
 }
 
-.snr-stat-row .stat-label {
+.route-popup .snr-stat-row .stat-label {
   color: var(--ctp-subtext1);
   font-weight: 500;
+  font-size: 0.875rem;
+  font-family: inherit;
 }
 
-.snr-stat-row .stat-value {
+.route-popup .snr-stat-row .stat-value {
   color: var(--ctp-text);
   font-weight: 600;
-  font-family: 'Courier New', monospace;
+  font-size: 0.875rem;
+  font-family: inherit;
 }
 
 .snr-timeline-chart {


### PR DESCRIPTION
## Problem
When clicking on route segments with many datapoints, the SNR statistics (Min/Max/Average/Sample Count) were displaying with:
- ❌ Overly large font size (1.875rem)
- ❌ Wrong font family (Courier New monospace)
- ❌ Heavy font weight (700)

## Root Cause
CSS specificity conflict between two style rules:
1. **Route popup styles** () - intended for route popups
2. **Global stats styles** () - used elsewhere in the app (audit logs, etc.)

The global styles were overriding the route popup styles because they had the same specificity but were defined later in the CSS file.

## Solution
- Made route popup styles more specific by prefixing with `.route-popup`
- Set appropriate font size (`0.875rem`) for compact display in popups
- Use inherited font family instead of monospace
- Maintain proper visual hierarchy

## Changes
```css
/* Before: Low specificity, could be overridden */
.snr-stat-row .stat-value { ... }

/* After: Higher specificity, won't be overridden */
.route-popup .snr-stat-row .stat-value { ... }
```

## Testing
✅ Route popup stats now display correctly with proper font size and family
✅ Global stats elsewhere remain unchanged