### PR TITLE
fix: Preserve all OIDC callback parameters including issuer (#197)

### DIFF
--- a/src/server/auth/oidcAuth.ts
+++ b/src/server/auth/oidcAuth.ts
@@ -104,27 +104,29 @@ export async function generateAuthorizationUrl(
  * Handle OIDC callback and create/update user
  */
 export async function handleOIDCCallback(
-  code: string,
-  state: string,
+  callbackUrl: URL,
   expectedState: string,
   codeVerifier: string,
-  expectedNonce: string,
-  redirectUri: string
+  expectedNonce: string
 ): Promise<User> {
   if (!oidcConfig) {
     throw new Error('OIDC not initialized');
   }
 
   try {
+    // Extract state from callback URL for validation
+    const state = callbackUrl.searchParams.get('state');
+
     // Validate state
     if (state !== expectedState) {
       throw new Error('Invalid state parameter');
     }
 
     // Exchange code for tokens
+    // Pass the full callback URL with all parameters (including iss if present)
     const tokenResponse = await client.authorizationCodeGrant(
       oidcConfig,
-      new URL(redirectUri + `?code=${code}&state=${state}`),
+      callbackUrl,
       {
         pkceCodeVerifier: codeVerifier,
         expectedState,


### PR DESCRIPTION
## Problem

OIDC authentication was failing with PocketID and other providers that include the `iss` (issuer) parameter in authorization callbacks, as required by RFC 9207 (OAuth 2.0 Authorization Server Issuer Identification).

**Error from issue #197:**
```
response parameter "iss" (issuer) missing
```

The callback handler was manually reconstructing the callback URL with only `code` and `state` parameters, discarding any additional parameters sent by the authorization server.

## Root Cause

**In authRoutes.ts**, the callback handler extracted only code/state:
```typescript
const { code, state } = req.query;
```

**Then in oidcAuth.ts**, `handleOIDCCallback` reconstructed the URL:
```typescript
new URL(redirectUri + `?code=${code}&state=${state}`)
```

This lost the `iss` parameter and any other parameters the provider sent, causing validation failures in `openid-client` which expects RFC 9207 compliance.

## Solution

Modified the OIDC callback flow to preserve all query parameters:

### 1. authRoutes.ts - Construct full callback URL
```typescript
// Construct the full callback URL with all query parameters
// This preserves additional parameters like 'iss' (issuer) that some OIDC providers send
const protocol = req.protocol;
const host = req.get('host');
const path = req.path;
const queryString = req.url.split('?')[1] || '';
const fullCallbackUrl = new URL(`${protocol}://${host}${path}?${queryString}`);
```

### 2. oidcAuth.ts - Accept full URL instead of reconstructing
```typescript
export async function handleOIDCCallback(
  callbackUrl: URL,  // Changed from individual params
  expectedState: string,
  codeVerifier: string,
  expectedNonce: string
): Promise<User>
```

Pass complete URL to `openid-client`'s `authorizationCodeGrant`:
```typescript
const tokenResponse = await client.authorizationCodeGrant(
  oidcConfig,
  callbackUrl,  // Full URL with all parameters
  {
    pkceCodeVerifier: codeVerifier,
    expectedState,
    expectedNonce
  }
);
```

## Benefits

✅ Supports RFC 9207 compliant OIDC providers (PocketID, etc.)  
✅ Maintains backward compatibility with existing providers  
✅ More robust - preserves any future callback parameters  
✅ Follows openid-client best practices  
✅ No breaking changes

## Testing

- ✅ All 615 unit tests passing
- ✅ TypeScript compilation successful  
- ✅ No modifications to test suite required (change is transparent)

## Compatibility

This fix is backward compatible. Existing OIDC providers (Authentik, Keycloak, Auth0, etc.) will continue to work normally. The change simply ensures we pass **all** parameters from the callback to the openid-client library, rather than filtering them.

## Files Changed

- `src/server/auth/oidcAuth.ts` - Modified signature and implementation
- `src/server/routes/authRoutes.ts` - Construct full callback URL

## Closes

Fixes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)