### PR TITLE
chore: Release v2.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [2.4.6] - 2025-01-13
+
+### Fixed
+- **OIDC Callback Parameter Preservation**: Fixed OIDC authentication failure with RFC 9207-compliant providers (PocketID, etc.) that include the `iss` (issuer) parameter in authorization callbacks
+  - Modified callback handler to preserve all query parameters from authorization callback instead of reconstructing URL with only code/state
+  - Now passes complete callback URL to openid-client's authorizationCodeGrant function
+  - Maintains full backward compatibility with existing OIDC providers (Authentik, Keycloak, Auth0, Okta, Azure AD)
+  - Resolves "response parameter iss (issuer) missing" error
+  - Fixes #197
+
 ## [2.1.0] - 2025-10-10
 
 ### Added

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.4.5
-appVersion: "2.4.5"
+version: 2.4.6
+appVersion: "2.4.6"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bufbuild/protobuf": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Version 2.4.6 Release

This PR bumps the version to 2.4.6 and includes the CHANGELOG entry for the OIDC callback parameter preservation fix.

### Changes

- Updated `package.json` to version 2.4.6
- Updated Helm chart (`Chart.yaml`) to version 2.4.6  
- Regenerated `package-lock.json` with updated version
- Added CHANGELOG entry documenting the v2.4.6 release

### What's in v2.4.6

#### Fixed
- **OIDC Callback Parameter Preservation**: Fixed OIDC authentication failure with RFC 9207-compliant providers (PocketID, etc.) that include the `iss` (issuer) parameter in authorization callbacks
  - Modified callback handler to preserve all query parameters from authorization callback instead of reconstructing URL with only code/state
  - Now passes complete callback URL to openid-client's authorizationCodeGrant function
  - Maintains full backward compatibility with existing OIDC providers (Authentik, Keycloak, Auth0, Okta, Azure AD)
  - Resolves "response parameter iss (issuer) missing" error
  - Fixes #197

### Related PRs

- #203 - The actual OIDC fix (already merged)

### Testing

- ✅ All 615 unit tests passing
- ✅ All system tests passing
- ✅ Backward compatible with existing OIDC providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)