### PR TITLE
fix: Sync favorites from device on each connection

### DIFF
--- a/src/server/meshtasticManager.test.ts
+++ b/src/server/meshtasticManager.test.ts
@@ -372,9 +372,9 @@ describe('MeshtasticManager - Configuration Polling', () => {
       expect(adminPacket.length).toBeGreaterThan(0);
     });
 
-    it('should NOT include isFavorite in nodeData from NodeInfo updates', () => {
-      // This is the critical fix: NodeInfo processing should not include isFavorite
-      // because the device doesn't broadcast favorite status
+    it('should sync isFavorite from NodeInfo updates to fix reconnect issue (#213)', () => {
+      // Fix for issue #213: favorites should be synced from device on each connection
+      // to reflect changes made while offline (e.g., via mobile app)
       const mockNodeInfo = {
         num: 1129874776,
         user: {
@@ -386,6 +386,7 @@ describe('MeshtasticManager - Configuration Polling', () => {
         lastHeard: Date.now() / 1000,
         snr: 5.25,
         hopsAway: 0,
+        isFavorite: true,  // Device now sends favorite status
         position: {
           latitudeI: 285605888,
           longitudeI: -811991040,
@@ -401,11 +402,12 @@ describe('MeshtasticManager - Configuration Polling', () => {
         snr: mockNodeInfo.snr,
         rssi: 0,
         hopsAway: mockNodeInfo.hopsAway,
-        // Note: isFavorite is NOT included here - it's a local-only setting
+        isFavorite: mockNodeInfo.isFavorite,  // Now synced from device
       };
 
-      // Verify isFavorite is not in nodeData
-      expect(nodeData).not.toHaveProperty('isFavorite');
+      // Verify isFavorite IS included in nodeData when provided by device
+      expect(nodeData).toHaveProperty('isFavorite');
+      expect(nodeData.isFavorite).toBe(true);
       expect(nodeData.nodeNum).toBe(1129874776);
       expect(nodeData.hopsAway).toBe(0);
     });

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1677,10 +1677,13 @@ class MeshtasticManager {
         hopsAway: nodeInfo.hopsAway !== undefined ? nodeInfo.hopsAway : undefined
       };
 
-      // Only set isFavorite from device for NEW nodes (not updates)
-      // This preserves user's local favorite settings while honoring device favorites on fresh install
-      if (!existingNode && nodeInfo.isFavorite !== undefined) {
+      // Always sync isFavorite from device to keep in sync with changes made while offline
+      // This ensures favorites are updated when reconnecting (fixes #213)
+      if (nodeInfo.isFavorite !== undefined) {
         nodeData.isFavorite = nodeInfo.isFavorite;
+        if (existingNode && existingNode.isFavorite !== nodeInfo.isFavorite) {
+          logger.debug(`⭐ Updating favorite status for node ${nodeId} from ${existingNode.isFavorite} to ${nodeInfo.isFavorite}`);
+        }
       }
 
       // Add user information if available


### PR DESCRIPTION
## Summary
Fixes #213 - Favorites are now properly synced from the device on each connection, ensuring that changes made via other clients (e.g., mobile app) while disconnected are reflected after reconnecting to MeshMonitor.

## Changes
- Modified `processNodeInfoProtobuf()` in `meshtasticManager.ts` to always sync `isFavorite` from device for both new and existing nodes
- Added debug logging when favorite status is updated for existing nodes
- Updated test to verify favorites are properly synced on reconnect

## Behavior
Previously, favorite status was only synced for new nodes during initial connection. Now:
- ⭐ Favorites are synced from the device on every connection
- 🔄 Changes made via other clients while offline are reflected on reconnect
- 📝 Debug logs show when favorite status is updated

## Testing
- All 615 tests pass ✅
- Updated test validates correct behavior for issue #213

## Test plan
- [x] Run full test suite (`npm run test:run`)
- [x] Verify test specifically for favorites sync passes
- [ ] Manual testing: disconnect, change favorites on mobile, reconnect and verify sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)