### PR TITLE
fix: Add /api/status endpoint and remove Prometheus references

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1593,6 +1593,34 @@ apiRouter.get('/health', optionalAuth(), (_req, res) => {
   });
 });
 
+// Detailed status endpoint - provides system statistics and connection status
+apiRouter.get('/status', optionalAuth(), (_req, res) => {
+  const connectionStatus = meshtasticManager.getConnectionStatus();
+  const localNode = meshtasticManager.getLocalNodeInfo();
+
+  res.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    version: packageJson.version,
+    nodeEnv: env.nodeEnv,
+    connection: {
+      connected: connectionStatus.connected,
+      localNode: localNode ? {
+        nodeNum: localNode.nodeNum,
+        nodeId: localNode.nodeId,
+        longName: localNode.longName,
+        shortName: localNode.shortName
+      } : null
+    },
+    statistics: {
+      nodes: databaseService.getNodeCount(),
+      messages: databaseService.getMessageCount(),
+      channels: databaseService.getChannelCount()
+    },
+    uptime: process.uptime()
+  });
+});
+
 // Version check endpoint - compares current version with latest GitHub release
 let versionCheckCache: { data: any; timestamp: number } | null = null;
 const VERSION_CHECK_CACHE_MS = 60 * 60 * 1000; // 1 hour cache


### PR DESCRIPTION
## Summary
Fixes #215 - Implements the missing `/api/status` endpoint that was documented but not implemented, and removes references to the non-existent Prometheus `/metrics` endpoint.

## Problem
Users reported two issues:
1. The `/api/status` endpoint returned "Cannot GET /api/status" despite being documented
2. The `/metrics` endpoint for Prometheus was documented but doesn't actually exist

## Changes

### Added `/api/status` Endpoint
Implements a detailed status endpoint that provides:
- ✅ Version information
- 🔌 Connection status to Meshtastic node  
- 📡 Local node information (if connected)
- 📊 Database statistics (nodes, messages, channels)
- ⏱️ Server uptime

Example response:
```json
{
  "status": "ok",
  "timestamp": "2025-10-15T12:00:00.000Z",
  "version": "2.6.0",
  "nodeEnv": "production",
  "connection": {
    "connected": true,
    "localNode": {
      "nodeNum": 123456789,
      "nodeId": "!075bcd15",
      "longName": "My Node",
      "shortName": "NODE"
    }
  },
  "statistics": {
    "nodes": 42,
    "messages": 1337,
    "channels": 3
  },
  "uptime": 86400
}
```

### Documentation Updates
- ❌ Removed Prometheus `/metrics` endpoint references
- ❌ Removed ServiceMonitor, Grafana, and Prometheus from Helm examples
- ✅ Updated monitoring section with practical shell script examples
- ✅ Added example JSON responses for both `/health` and `/status` endpoints
- ✅ Provided bash-based alerting examples that work with the endpoints

## Testing
- All 615 tests pass ✅
- TypeScript compilation successful ✅
- Endpoint properly uses `optionalAuth()` middleware
- Manually tested and verified working ✅

## Use Cases
The `/api/status` endpoint enables:
- Monitoring dashboards
- Uptime checkers (UptimeRobot, StatusCake, etc.)
- Custom alerting scripts
- Health checks in load balancers
- System status pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)