### PR TITLE
fix: Display unknown nodes in traceroutes and fix UI z-index issues (v2.6.1)

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.6.0
-appVersion: "2.6.0"
+version: 2.6.1
+appVersion: "2.6.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bufbuild/protobuf": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/App.css
+++ b/src/App.css
@@ -26,6 +26,11 @@
   --ctp-pink: #f5c2e7;
   --ctp-flamingo: #f2cdcd;
   --ctp-rosewater: #f5e0dc;
+
+  /* Layout dimensions */
+  --header-height: 60px;
+  --sidebar-width: 60px;
+  --banner-height: 36px;
 }
 
 * {
@@ -110,6 +115,33 @@ body {
 
 .device-name {
   color: var(--ctp-green);
+}
+
+/* Warning and Update Banners */
+.warning-banner,
+.update-banner {
+  position: fixed;
+  left: var(--sidebar-width);
+  right: 0;
+  padding: 8px 16px;
+  text-align: center;
+  font-size: 14px;
+  font-weight: 500;
+  z-index: 9999;
+  box-sizing: border-box;
+}
+
+.warning-banner {
+  top: var(--header-height);
+  background-color: #dc2626;
+  color: white;
+  border-bottom: 2px solid #991b1b;
+}
+
+.update-banner {
+  background-color: #3b82f6;
+  color: white;
+  border-bottom: 2px solid #1d4ed8;
 }
 
 .connection-status {
@@ -940,6 +972,12 @@ body {
 }
 
 @media (max-width: 768px) {
+  /* Update layout dimensions for mobile */
+  :root {
+    --header-height: 48px;
+    --sidebar-width: 48px;
+  }
+
   /* Reduce font size globally on mobile */
   body {
     font-size: 0.875rem; /* 14px - reduced from 16px */
@@ -949,6 +987,13 @@ body {
     padding: 0.5rem;
     height: 48px; /* Smaller header on mobile */
     left: 48px; /* Account for collapsed sidebar */
+  }
+
+  /* Adjust banners for mobile */
+  .warning-banner,
+  .update-banner {
+    font-size: 13px;
+    padding: 6px 12px;
   }
 
   /* Hide logo, node name, and connection text on mobile */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1192,9 +1192,11 @@ function App() {
       }
 
       // Format each hop with SNR and distance
+      const BROADCAST_ADDR = 4294967295;
       nodeNums.forEach((nodeNum, idx) => {
         const node = nodes.find(n => n.nodeNum === nodeNum);
-        const nodeName = node?.user?.longName || node?.user?.shortName || `!${nodeNum.toString(16)}`;
+        const nodeName = nodeNum === BROADCAST_ADDR ? '(unknown)' :
+                        (node?.user?.longName || node?.user?.shortName || `!${nodeNum.toString(16)}`);
 
         // Get SNR for this hop
         const snrIdx = idx === 0 ? -1 : idx - 1; // First node has no SNR, subsequent nodes use previous indices
@@ -3555,10 +3557,13 @@ function App() {
       const weight = Math.min(2 + usage, 8);
 
       // Get node names for popup
+      const BROADCAST_ADDR = 4294967295;
       const node1 = nodes.find(n => n.nodeNum === segment.nodeNums[0]);
       const node2 = nodes.find(n => n.nodeNum === segment.nodeNums[1]);
-      const node1Name = node1?.user?.longName || node1?.user?.shortName || `!${segment.nodeNums[0].toString(16)}`;
-      const node2Name = node2?.user?.longName || node2?.user?.shortName || `!${segment.nodeNums[1].toString(16)}`;
+      const node1Name = segment.nodeNums[0] === BROADCAST_ADDR ? '(unknown)' :
+                        (node1?.user?.longName || node1?.user?.shortName || `!${segment.nodeNums[0].toString(16)}`);
+      const node2Name = segment.nodeNums[1] === BROADCAST_ADDR ? '(unknown)' :
+                        (node2?.user?.longName || node2?.user?.shortName || `!${segment.nodeNums[1].toString(16)}`);
 
       // Calculate distance if both nodes have position data
       let segmentDistanceKm = 0;
@@ -3814,28 +3819,14 @@ function App() {
 
       {/* Default Password Warning Banner */}
       {isDefaultPassword && (
-        <div style={{
-          backgroundColor: '#dc2626',
-          color: 'white',
-          padding: '8px 16px',
-          textAlign: 'center',
-          fontSize: '14px',
-          fontWeight: '500',
-          borderBottom: '2px solid #991b1b'
-        }}>
+        <div className="warning-banner">
           ⚠️ Security Warning: The admin account is using the default password. Please change it immediately in the Users tab.
         </div>
       )}
 
       {updateAvailable && (
-        <div style={{
-          backgroundColor: '#3b82f6',
-          color: 'white',
-          padding: '8px 16px',
-          textAlign: 'center',
-          fontSize: '14px',
-          fontWeight: '500',
-          borderBottom: '2px solid #1d4ed8'
+        <div className="update-banner" style={{
+          top: isDefaultPassword ? 'calc(var(--header-height) + var(--banner-height))' : 'var(--header-height)'
         }}>
           🔔 Update Available: Version {latestVersion} is now available.{' '}
           <a

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -36,7 +36,7 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           position: 'fixed',
           top: '20px',
           right: '20px',
-          zIndex: 9999,
+          zIndex: 10001,
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'flex-end'

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1188,7 +1188,7 @@ class MeshtasticManager {
       const toNum = Number(meshPacket.to);
       const toNodeId = `!${toNum.toString(16).padStart(8, '0')}`;
 
-      logger.debug(`🗺️ Traceroute response from ${fromNodeId}:`, routeDiscovery);
+      logger.info(`🗺️ Traceroute response from ${fromNodeId}:`, JSON.stringify(routeDiscovery, null, 2));
 
       // Ensure from node exists in database (don't overwrite existing names)
       const existingFromNode = databaseService.getNode(fromNum);
@@ -1229,6 +1229,7 @@ class MeshtasticManager {
       }
 
       // Build the route string
+      const BROADCAST_ADDR = 4294967295;
       const route = routeDiscovery.route || [];
       const routeBack = routeDiscovery.routeBack || [];
       const snrTowards = routeDiscovery.snrTowards || [];
@@ -1287,7 +1288,7 @@ class MeshtasticManager {
         route.forEach((nodeNum: number, index: number) => {
           const nodeId = `!${nodeNum.toString(16).padStart(8, '0')}`;
           const node = databaseService.getNode(nodeNum);
-          const nodeName = node?.longName || nodeId;
+          const nodeName = nodeNum === BROADCAST_ADDR ? '(unknown)' : (node?.longName || nodeId);
           const snr = snrTowards[index] !== undefined ? `${(snrTowards[index] / 4).toFixed(1)}dB` : 'N/A';
           const dist = calcDistance(fullPath[index], nodeNum);
           if (dist) {
@@ -1361,7 +1362,7 @@ class MeshtasticManager {
         routeBack.forEach((nodeNum: number, index: number) => {
           const nodeId = `!${nodeNum.toString(16).padStart(8, '0')}`;
           const node = databaseService.getNode(nodeNum);
-          const nodeName = node?.longName || nodeId;
+          const nodeName = nodeNum === BROADCAST_ADDR ? '(unknown)' : (node?.longName || nodeId);
           const snr = snrBack[index] !== undefined ? `${(snrBack[index] / 4).toFixed(1)}dB` : 'N/A';
           const dist = calcDistanceReturn(fullReturnPath[index], nodeNum);
           if (dist) {
@@ -1435,7 +1436,7 @@ class MeshtasticManager {
       databaseService.insertMessage(message);
       logger.debug(`💾 Saved traceroute result from ${fromNodeId} (channel: ${channelIndex})`);
 
-      // Save to traceroutes table
+      // Save to traceroutes table (save raw data including broadcast addresses)
       const tracerouteRecord = {
         fromNodeNum: fromNum,
         toNodeNum: toNum,


### PR DESCRIPTION
## Summary
- Fixed password warning banner visibility after Mobile UI Refresh
- Fixed toast notifications appearing behind header
- Replaced "Broadcast" with "(unknown)" for placeholder hops in traceroutes

## Changes

### Password Warning Banner Fix
The red password warning banner was hidden behind the fixed header after the Mobile UI Refresh (v2.6.0). 
- Added CSS variables for consistent layout dimensions (`--header-height`, `--sidebar-width`, `--banner-height`)
- Positioned warning and update banners as fixed elements below the header with proper z-index
- Added responsive mobile support (48px header/sidebar on mobile vs 60px on desktop)

### Toast Notification z-index Fix
Toast notifications were appearing behind the header bar.
- Increased toast container z-index from 9999 to 10001
- Header has z-index 10000, so toasts now properly appear on top

### Traceroute Unknown Nodes
Meshtastic firmware reports `0xffffffff` (broadcast address) as a placeholder for unknown intermediate hops in traceroutes, with invalid SNR values of -128.
- Changed display from "Broadcast" to "(unknown)" for better clarity
- Applied to:
  - Map segment tooltips
  - Traceroute text messages
  - Traceroute list display in Messages tab
- Raw data (including 0xffffffff values) is still preserved in the database for debugging

## Testing
- Verified password warning banner appears correctly on desktop and mobile
- Verified toast notifications appear above all UI elements
- Verified traceroutes display "(unknown)" instead of "Broadcast" for placeholder hops
- Tested on both map and Messages tab displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)