### PR TITLE
fix: Add proper top padding to account for fixed header on all pages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -244,6 +244,7 @@ body {
 
 .app-main {
   padding: 2rem;
+  padding-top: calc(var(--header-height) + 2rem); /* Account for fixed header + desired padding */
   width: calc(100% - 60px); /* Full width minus sidebar */
   margin: 0;
   margin-left: 60px; /* Space for narrow sidebar */
@@ -1016,6 +1017,7 @@ body {
 
   .app-main {
     padding: 0.5rem;
+    padding-top: calc(var(--header-height) + 0.5rem); /* Account for fixed header + desired padding */
     padding-left: 56px; /* 48px sidebar + 8px gap */
     margin-left: 0 !important;
     width: 100% !important;
@@ -1026,6 +1028,7 @@ body {
     margin-left: -0.25rem;
     margin-right: -0.25rem;
   }
+
 
   /* Hide channel grid buttons on mobile, show dropdown instead */
   .channels-grid {


### PR DESCRIPTION
## Summary
- Fixes issue where page content (headers, titles) appeared behind the fixed top header on both desktop and mobile viewports
- Adds proper top padding to `.app-main` container to account for the fixed header height

## Changes
- Desktop: Added `padding-top: calc(var(--header-height) + 2rem)` to `.app-main` (60px + 2rem)
- Mobile: Added `padding-top: calc(var(--header-height) + 0.5rem)` to `.app-main` (48px + 0.5rem)

## Impact
- All tabs now display correctly with proper spacing below the header:
  - Channels
  - Messages  
  - Nodes/Map
  - Dashboard (Telemetry)
  - Device Information
  - Automation
  - Configuration
  - Users
  - Audit Log

## Test plan
- [x] Tested on mobile viewport (<768px width)
- [x] Tested on desktop viewport (>768px width)
- [x] Verified all tabs display correctly with no content hidden behind header
- [x] Verified proper spacing on both mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)