### PR TITLE
fix: Add iPhone PWA safe area support and fix mobile layout (v2.6.3)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="theme-color" content="#1a1a1a" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="apple-mobile-web-app-title" content="MeshMonitor" />
     <meta name="description" content="Monitor and manage your Meshtastic mesh network" />
     <title>MeshMonitor - Meshtastic Node Monitoring</title>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bufbuild/protobuf": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/App.css
+++ b/src/App.css
@@ -47,10 +47,14 @@ body {
   -moz-osx-font-smoothing: grayscale;
   background: var(--ctp-base);
   color: var(--ctp-text);
+  margin: 0;
+  padding: 0;
+  padding-bottom: env(safe-area-inset-bottom); /* Account for iPhone home indicator */
 }
 
 .app {
   min-height: 100vh;
+  min-height: 100dvh; /* Use dynamic viewport height for mobile browsers */
   background: var(--ctp-base);
   display: flex;
   flex-direction: column;
@@ -60,6 +64,7 @@ body {
   background: var(--ctp-mantle);
   border-bottom: 1px solid var(--ctp-surface0);
   padding: 1.5rem 2rem;
+  padding-top: max(1.5rem, env(safe-area-inset-top)); /* Account for iPhone notch/status bar */
   position: fixed;
   top: 0;
   left: 60px;
@@ -245,6 +250,7 @@ body {
 .app-main {
   padding: 2rem;
   padding-top: calc(var(--header-height) + 2rem); /* Account for fixed header + desired padding */
+  padding-bottom: max(2rem, env(safe-area-inset-bottom)); /* Account for iPhone home indicator */
   width: calc(100% - 60px); /* Full width minus sidebar */
   margin: 0;
   margin-left: 60px; /* Space for narrow sidebar */
@@ -1018,6 +1024,7 @@ body {
   .app-main {
     padding: 0.5rem;
     padding-top: calc(var(--header-height) + 0.5rem); /* Account for fixed header + desired padding */
+    padding-bottom: max(0.5rem, env(safe-area-inset-bottom)); /* Account for iPhone home indicator */
     padding-left: 56px; /* 48px sidebar + 8px gap */
     margin-left: 0 !important;
     width: 100% !important;
@@ -1145,6 +1152,20 @@ body {
 
   .login-divider {
     margin: 1rem 0 !important;
+  }
+
+  /* Add extra bottom spacing on mobile for safe scrolling */
+  .app-main::after {
+    content: '';
+    display: block;
+    height: 8rem; /* Extra space at bottom */
+    height: calc(8rem + env(safe-area-inset-bottom));
+  }
+
+  /* Ensure body/html allow scrolling on mobile */
+  body {
+    overflow-y: auto !important;
+    -webkit-overflow-scrolling: touch;
   }
 }
 

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -2,6 +2,7 @@
   position: fixed;
   left: 0;
   top: 0; /* Full page height from top of viewport */
+  bottom: 0;
   height: 100vh;
   width: 60px; /* Default to narrow/icon-only on desktop */
   background: var(--color-bg-primary, #1a1a1a);
@@ -10,6 +11,10 @@
   z-index: 10001; /* Above header (10000) so it overlays cleanly */
   display: flex;
   flex-direction: column;
+  padding-top: env(safe-area-inset-top); /* Account for iPhone notch/status bar */
+  padding-bottom: max(1rem, env(safe-area-inset-bottom)); /* Account for iPhone home indicator */
+  padding-left: env(safe-area-inset-left); /* Account for iPhone landscape notch */
+  box-sizing: border-box; /* Include padding in height calculation */
 }
 
 .sidebar.collapsed {
@@ -229,6 +234,8 @@
   .sidebar {
     /* Collapsed by default - show as hamburger icon only */
     width: 48px;
+    padding-bottom: 6rem; /* Extra padding on mobile for home indicator */
+    padding-bottom: max(6rem, calc(env(safe-area-inset-bottom) + 4rem));
   }
 
   .sidebar:not(.collapsed) {


### PR DESCRIPTION
## Summary
Fixes display issues when running MeshMonitor as a PWA on iPhone, where content was hidden behind the status bar and home indicator.

## Changes

### iPhone Status Bar
- Changed Apple status bar style from `black-translucent` to `black` to prevent overlay
- Status bar now sits above content instead of overlaying it

### Safe Area Support
- Added `env(safe-area-inset-top)` padding to app header for iPhone notch/status bar
- Added `env(safe-area-inset-bottom)` padding to body for home indicator
- Added safe area padding to sidebar (top, bottom, left)

### Mobile Sidebar Fix
- Added 6rem bottom padding to sidebar on mobile devices
- Prevents GitHub logo and version number from being cut off by home indicator
- Added `box-sizing: border-box` for proper height calculation

### Mobile Content Spacing
- Added 8rem bottom spacer to main content area on mobile for proper scrolling
- Used `100dvh` (dynamic viewport height) for proper mobile viewport handling
- Added overflow and scroll behavior settings

### Version
- Bumped version to 2.6.3

## Testing
- [x] Tested on iPhone in mobile Safari
- [x] Tested as installed PWA on iPhone
- [x] Verified sidebar bottom content (GitHub logo, version) is visible
- [x] Verified content doesn't hide behind status bar or home indicator
- [x] Verified proper scrolling on all pages

## Screenshots
The PWA now properly displays on iPhone with:
- Status bar above content (not overlaying)
- Sidebar fully visible including bottom elements
- Proper spacing around home indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)