### PR TITLE
docs: Add DISABLE_ANONYMOUS environment variable to configuration

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -56,6 +56,7 @@ MeshMonitor can be configured using environment variables. Here are the most imp
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `DISABLE_ANONYMOUS` | Disable anonymous access - require login for all features | `false` |
 | `DISABLE_LOCAL_AUTH` | Disable local username/password authentication (OIDC only) | `false` |
 | `ADMIN_USERNAME` | Override default admin username on first run | `admin` |
 


### PR DESCRIPTION
## Summary
- Documents the `DISABLE_ANONYMOUS` environment variable that was added in v2.7.3 (PR #237)
- Adds it to the Authentication Variables section in the configuration documentation

## Details
The `DISABLE_ANONYMOUS` variable was introduced in v2.7.3 but wasn't added to the website documentation. This PR adds it to the environment variables table at `docs/configuration/index.md`.

**Variable Description:**
- `DISABLE_ANONYMOUS`: Disable anonymous access - require login for all features
- Default: `false`

## Test plan
- [x] Documentation accurately describes the variable
- [x] Follows existing documentation format and style
- [x] Placed in the correct section (Authentication Variables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)