### PR TITLE
feat: Align telemetry time bounds on Messages page

### DIFF
--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -228,6 +228,31 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(({ nodeId, te
 
   const groupedData = groupByType(telemetryData);
 
+  // Calculate global time range across all telemetry data
+  // Min time: earliest datapoint, Max time: current time
+  const getGlobalTimeRange = (): [number, number] | null => {
+    if (telemetryData.length === 0) {
+      return null;
+    }
+
+    let minTime = Infinity;
+
+    telemetryData.forEach((item) => {
+      if (item.timestamp < minTime) minTime = item.timestamp;
+    });
+
+    if (minTime === Infinity) {
+      return null;
+    }
+
+    // Use current time as the maximum time
+    const maxTime = Date.now();
+
+    return [minTime, maxTime];
+  };
+
+  const globalTimeRange = getGlobalTimeRange();
+
   // Filter out position telemetry (latitude, longitude)
   // Filter out altitude if it hasn't changed
   const filteredData = Array.from(groupedData.entries()).filter(([type, data]) => {
@@ -276,7 +301,7 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(({ nodeId, te
                   <XAxis
                     dataKey="timestamp"
                     type="number"
-                    domain={['dataMin', 'dataMax']}
+                    domain={globalTimeRange || ['dataMin', 'dataMax']}
                     tick={{ fontSize: 12 }}
                     tickFormatter={(timestamp) => new Date(timestamp).toLocaleTimeString([], {
                       hour: '2-digit',


### PR DESCRIPTION
## Summary
Synchronizes the time axis across all telemetry charts on the Messages page detailed view to use unified time bounds, making temporal comparisons easier and matching the Dashboard page behavior.

## Changes
- Added `getGlobalTimeRange()` function to calculate unified time bounds across all telemetry types for a node
- **Minimum time**: Earliest datapoint across all telemetry types
- **Maximum time**: Current time (`Date.now()`)
- Applied global time range to all chart XAxis domains via `domain` prop
- Maintains fallback to independent scaling (`['dataMin', 'dataMax']`) if no data available

## Technical Details
**File Modified**: `src/components/TelemetryGraphs.tsx`

Previously, each telemetry chart (battery, voltage, temperature, etc.) independently scaled its time axis based on its own datapoints. Now all charts for a node share the same time window.

**Time Bounds Logic** (lines 231-252):
```typescript
const getGlobalTimeRange = (): [number, number] | null => {
  // Find earliest timestamp across all telemetry
  let minTime = Infinity;
  telemetryData.forEach((item) => {
    if (item.timestamp < minTime) minTime = item.timestamp;
  });
  
  // Use current time as maximum
  const maxTime = Date.now();
  return [minTime, maxTime];
};
```

**Applied to Charts** (line 304):
```typescript
<XAxis
  domain={globalTimeRange || ['dataMin', 'dataMax']}
  // ...
/>
```

## Benefits
- **Visual Alignment**: All charts share the same time window from earliest data to now
- **Identify Data Gaps**: Easy to see when metrics stop updating (line ends before right edge)
- **Temporal Comparisons**: Compare events across different telemetry types on aligned timeline
- **Real-time Feel**: Charts always extend to current moment, showing freshness of data
- **Consistency**: Matches Dashboard page time alignment behavior

## Example
If a node has:
- Battery data: 2 hours ago → 10 minutes ago
- Temperature data: 1 hour ago → 5 minutes ago
- Voltage data: 3 hours ago → now

All three charts will show:
- **Left edge**: 3 hours ago (earliest datapoint)
- **Right edge**: Current time (now)

This makes it immediately obvious that battery and temperature data are stale while voltage is current.

## Test plan
- [x] Build successful
- [x] All system tests passed (Quick Start, Reverse Proxy, OIDC)
- [x] Development environment tested on port 8080
- [ ] Manual UI verification: View Messages page with detailed telemetry for a node
- [ ] Verify all charts align to same time bounds
- [ ] Verify charts extend to current time on right edge
- [ ] Verify data gaps are visually apparent

🤖 Generated with [Claude Code](https://claude.com/claude-code)