### PR TITLE
chore: Bump version to 2.8.4

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.8.3
-appVersion: "2.8.3"
+version: 2.8.4
+appVersion: "2.8.4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.8.3",
+      "version": "2.8.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bufbuild/protobuf": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Version bump to 2.8.4 for the next release.

## Changes
- **package.json**: Updated version from 2.8.3 to 2.8.4
- **package-lock.json**: Regenerated with new version
- **helm/meshmonitor/Chart.yaml**: Updated version and appVersion to 2.8.4

## Included in 2.8.4
- ✅ Text truncation fix for long node names on mobile (#251, #253)
  - Long node names now display with ellipsis (`...`) instead of being cut off
  - Fixes display issues on iOS Safari (iPhone 13 Pro and smaller screens)
  - Applied to node list, dashboard cards, and header device name

## Release Notes Preview
This will be a patch release focusing on mobile UX improvements, specifically addressing text overflow issues on smaller screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)