### PR TITLE
docs: Fix dead links and add docs build check to PR workflow

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -9,6 +9,8 @@ on:
       - '**.js'
       - '**.jsx'
       - '**.json'
+      - '**.md'
+      - 'docs/**'
       - '.github/workflows/pr-tests.yml'
 
 # Cancel in-progress runs for the same PR
@@ -77,6 +79,7 @@ jobs:
       backend: ${{ steps.changes.outputs.backend }}
       frontend: ${{ steps.changes.outputs.frontend }}
       docker: ${{ steps.changes.outputs.docker }}
+      docs: ${{ steps.changes.outputs.docs }}
 
     steps:
       - name: Checkout code
@@ -101,6 +104,9 @@ jobs:
             docker:
               - 'Dockerfile'
               - '.dockerignore'
+            docs:
+              - 'docs/**'
+              - '**.md'
 
   focused-tests:
     name: Focused Tests
@@ -143,6 +149,30 @@ jobs:
             echo "Building frontend..."
             npm run build
           fi
+
+  docs-build:
+    name: Documentation Build
+    runs-on: ubuntu-latest
+    needs: changed-files
+    if: needs.changed-files.outputs.docs == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit
+
+      - name: Build documentation
+        run: |
+          echo "Building VitePress documentation..."
+          npm run docs:build
 
   # The PR Status Check job has been removed as GitHub Actions
   # automatically provides its own status checks for each job.

--- a/docs/configuration/fail2ban.md
+++ b/docs/configuration/fail2ban.md
@@ -501,8 +501,8 @@ Remove the logs bind mount from docker-compose.yml and restart.
 
 - [fail2ban Documentation](https://fail2ban.readthedocs.io/)
 - [AbuseIPDB Documentation](https://docs.abuseipdb.com/)
-- [MeshMonitor Security Guide](/docs/configuration/production)
-- [Reverse Proxy Configuration](/docs/configuration/reverse-proxy)
+- [MeshMonitor Security Guide](/configuration/production)
+- [Reverse Proxy Configuration](/configuration/reverse-proxy)
 
 ## Support
 


### PR DESCRIPTION
## Summary
Fixes the VitePress documentation build failure and adds a docs build check to the PR workflow to prevent this from happening again.

## Problem 1: Dead Links in Documentation
The Deploy Documentation workflow was failing with dead link errors:
```
(!) Found dead link /docs/configuration/production in file configuration/fail2ban.md
(!) Found dead link /docs/configuration/reverse-proxy in file configuration/fail2ban.md
```

**Root Cause**: Links in `fail2ban.md` included the `/docs/` prefix, which is incorrect for VitePress internal links. VitePress links should be relative to the docs root without the `/docs/` prefix.

## Problem 2: No PR Validation for Docs
Documentation changes were not being validated in PRs, allowing broken links to be merged and only discovered when deploying to GitHub Pages.

## Solution

### 1. Fix Dead Links (`docs/configuration/fail2ban.md`)
Removed `/docs/` prefix from internal links:
- `/docs/configuration/production` → `/configuration/production`
- `/docs/configuration/reverse-proxy` → `/configuration/reverse-proxy`

### 2. Add Docs Build Check (`.github/workflows/pr-tests.yml`)

**Added Documentation Build Job**:
```yaml
docs-build:
  name: Documentation Build
  runs-on: ubuntu-latest
  needs: changed-files
  if: needs.changed-files.outputs.docs == 'true'

  steps:
    - name: Build documentation
      run: npm run docs:build
```

**Updated Path Filters**:
- Added `'**.md'` and `'docs/**'` to workflow triggers
- Added `docs` filter to `changed-files` job
- Detects changes to any markdown file or files in `docs/` directory

## Changes

**Modified Files**:
- `docs/configuration/fail2ban.md` - Fixed 2 dead links
- `.github/workflows/pr-tests.yml` - Added docs build validation

## Benefits

✅ **Prevents broken documentation** from being merged  
✅ **Catches dead links early** in the PR review process  
✅ **Only runs when docs change** (efficient CI usage)  
✅ **Same validation as production** deploy  

## Testing

The docs build check will run on this PR and validate:
- All internal links resolve correctly
- VitePress can build the documentation successfully
- No dead links exist in the documentation

## Future PRs

Any PR that modifies:
- Files in `docs/` directory
- Any `.md` file in the repository

Will automatically trigger the Documentation Build job to validate the changes before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)