### PR TITLE
fix: Update notification banner dismiss button overflow (fixes #269)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,4 @@
+# TODOs
+
+## Completed
+- Fix update notification banner dismiss button overflow (issue #269)

--- a/src/App.css
+++ b/src/App.css
@@ -153,13 +153,10 @@ body {
   border-bottom: 2px solid #1d4ed8;
   display: flex;
   align-items: center;
-  justify-content: center;
-  position: relative;
+  gap: 8px;
 }
 
 .banner-dismiss {
-  position: absolute;
-  right: 16px;
   background: none;
   border: none;
   color: white;
@@ -169,6 +166,8 @@ body {
   padding: 4px 8px;
   opacity: 0.8;
   transition: opacity 0.2s ease;
+  flex-shrink: 0;
+  margin-right: 8px;
 }
 
 .banner-dismiss:hover {
@@ -1034,7 +1033,9 @@ body {
   .warning-banner,
   .update-banner {
     font-size: 13px;
-    padding: 6px 12px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    padding-left: 12px;
   }
 
   /* Hide logo, node name, and connection text on mobile */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3641,19 +3641,21 @@ function App() {
         <div className="update-banner" style={{
           top: isDefaultPassword ? 'calc(var(--header-height) + var(--banner-height))' : 'var(--header-height)'
         }}>
-          🔔 Update Available: Version {latestVersion} is now available.{' '}
-          <a
-            href={releaseUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{
-              color: 'white',
-              textDecoration: 'underline',
-              fontWeight: '600'
-            }}
-          >
-            View Release Notes →
-          </a>
+          <div style={{ flex: 1, textAlign: 'center' }}>
+            🔔 Update Available: Version {latestVersion} is now available.{' '}
+            <a
+              href={releaseUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: 'white',
+                textDecoration: 'underline',
+                fontWeight: '600'
+              }}
+            >
+              View Release Notes →
+            </a>
+          </div>
           <button
             className="banner-dismiss"
             onClick={() => setUpdateAvailable(false)}


### PR DESCRIPTION
## Summary
Fixed the update notification banner dismiss button (✕) that was positioned off the right edge of the screen, requiring horizontal scrolling to access it on both mobile and desktop browsers.

## Changes Made
- **Replaced absolute positioning with flexbox layout**: The banner now uses proper flex properties instead of absolute positioning for the dismiss button
- **Content wrapper**: Added a flex container (`flex: 1`) with centered text alignment for the banner message
- **Button positioning**: Made the button a regular flex child with `flex-shrink: 0` to ensure it never shrinks
- **Mobile responsiveness**: Simplified mobile padding rules to work with the new flexbox layout

### Technical Details
**Before:** The banner used `justify-content: center` with an absolutely positioned button at `right: 16px`, causing the centered content to overflow and push the button off-screen.

**After:** The content div takes up all available space (`flex: 1`) with text centered within it, while the button sits naturally on the right as a flex child that never shrinks.

## Testing
- ✅ Tested on desktop viewport (full width)
- ✅ Tested on mobile viewport (narrow width using browser dev tools)
- ✅ Dismiss button is fully visible without horizontal scrolling
- ✅ Text remains centered appropriately
- ✅ Button remains clickable and functional

## Test Results
System tests showed pre-existing failures unrelated to this UI-only change:
- Quick Start test: Meshtastic node connection timeout (infrastructure)
- Reverse Proxy tests: 502 Bad Gateway errors (infrastructure)

These failures are environmental/network issues and not caused by the CSS changes.

## Screenshots
User confirmed fix works correctly after testing at http://localhost:8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)