### PR TITLE
chore: Release v2.8.8 - Fix TRUST_PROXY to support all Express values

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -5,3 +5,5 @@
 - Implement reply button auto-focus feature (issue #280)
   - Added auto-focus to message input when clicking reply button
   - Added reply state clearing when switching channels or DM nodes
+- Version 2.8.8
+- Fix TRUST_PROXY environment variable to support all Express values (true/false/number/IP)

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.8.7
-appVersion: "2.8.7"
+version: 2.8.8
+appVersion: "2.8.8"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.8.7",
+      "version": "2.8.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bufbuild/protobuf": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
This PR releases version 2.8.8, which fixes the TRUST_PROXY environment variable handling to support all valid Express proxy trust values.

### Problem
Previously, TRUST_PROXY only accepted boolean strings ('true' or 'false'). When users set TRUST_PROXY=1 (which is valid and recommended for single proxy setups), they would get a warning:
```
[WARN] ⚠️ Invalid TRUST_PROXY value: "1". Expected 'true' or 'false'. Using default: false
```

This was inconsistent with Express documentation and the README which mentioned numeric values like 1, 2, etc.

### Solution
- Created new `parseTrustProxy()` function that properly handles all Express proxy trust values:
  - Boolean values: `'true'`, `'false'`
  - Numeric values: `1`, `2`, etc. (number of proxy hops to trust)
  - String values: IP addresses or CIDR notation (e.g., `'192.168.1.0/24'`)
- Updated `EnvironmentConfig` interface to support `boolean | number | string` for trustProxy
- Updated version to 2.8.8

### Changes
- `package.json`: Version bump to 2.8.8
- `package-lock.json`: Regenerated with new version
- `helm/meshmonitor/Chart.yaml`: Version bump to 2.8.8
- `src/server/config/environment.ts`: 
  - Added `parseTrustProxy()` function
  - Updated trustProxy type to `boolean | number | string`
  - Replaced `parseBoolean()` call with `parseTrustProxy()`

### Testing
- ✅ TypeScript compilation passes
- ✅ Docker build succeeds
- ✅ Server starts without TRUST_PROXY warnings when set to `1`
- ✅ Tested with docker-compose.dev.yml (TRUST_PROXY=1)

### Documentation
The README already documented the various TRUST_PROXY values correctly. This PR makes the code match the documentation.

## Test plan
- [ ] Verify TRUST_PROXY=true works without warnings
- [ ] Verify TRUST_PROXY=false works without warnings
- [ ] Verify TRUST_PROXY=1 works without warnings
- [ ] Verify TRUST_PROXY=2 works without warnings
- [ ] Verify TRUST_PROXY with IP/CIDR works without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)