### PR TITLE
fix: Revert mobile node popup dimension changes (v2.8.9)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -7,3 +7,5 @@
   - Added reply state clearing when switching channels or DM nodes
 - Version 2.8.8
 - Fix TRUST_PROXY environment variable to support all Express values (true/false/number/IP)
+- Created GitHub release v2.8.8
+- Reverted mobile node popup dimension changes from PR #279

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.8.8
-appVersion: "2.8.8"
+version: 2.8.9
+appVersion: "2.8.9"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.8.8",
+  "version": "2.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.8.8",
+      "version": "2.8.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bufbuild/protobuf": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.8.8",
+  "version": "2.8.9",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/App.css
+++ b/src/App.css
@@ -2976,9 +2976,7 @@ body {
 /* Responsive Node Popup */
 @media (max-width: 768px) {
   .node-popup {
-    min-width: 0;
-    max-width: calc(100vw - 40px);
-    width: min-content;
+    max-width: 240px;
     padding: 10px;
     font-size: 13px;
   }
@@ -2989,31 +2987,6 @@ body {
 
   .node-popup .popup-details > div {
     font-size: 12px;
-  }
-
-  /* Route popup (sidebar node popup) responsive sizing */
-  .route-popup {
-    min-width: 0;
-    max-width: calc(100vw - 60px);
-  }
-}
-
-/* Extra small devices (iPhone SE, etc.) */
-@media (max-width: 400px) {
-  .node-popup {
-    min-width: 0;
-    max-width: calc(100vw - 30px);
-    width: max-content;
-  }
-
-  .node-popup-grid {
-    grid-template-columns: 1fr;
-  }
-
-  /* Route popup - even narrower on very small screens */
-  .route-popup {
-    min-width: 0;
-    max-width: calc(100vw - 40px);
   }
 }
 


### PR DESCRIPTION
## Summary
This PR reverts the mobile node popup dimension changes from PR #279 that inadvertently modified the popup size on mobile devices and releases version 2.8.9.

### Problem
PR #279 introduced responsive sizing for node popups on mobile devices, changing from a fixed 240px width to dynamic calculations like `calc(100vw - 40px)`. While this was intended to improve mobile node list responsiveness, it had unintended side effects on the node popup dimensions.

### Solution
Reverted the mobile node popup styles back to the original implementation:
- Restored fixed `max-width: 240px` for node popups on mobile (max-width: 768px)
- Removed the dynamic width calculations (`min-width: 0`, `max-width: calc(100vw - 40px)`, `width: min-content`)
- Removed the route-popup responsive sizing section
- Removed the entire extra small devices (max-width: 400px) media query section

### Changes
**src/App.css:**
- Mobile (max-width: 768px) `.node-popup`: Restored `max-width: 240px` (removed dynamic sizing)
- Removed route-popup responsive sizing
- Removed extra small devices media query (max-width: 400px)

**Version bump:**
- Updated to v2.8.9 in package.json, package-lock.json, and Chart.yaml

### Testing
- ✅ Built and tested with Docker
- ✅ Application starts successfully
- ✅ Node popup dimensions restored to original fixed size on mobile

### Impact
This restores the original mobile node popup behavior while maintaining the other improvements from PR #279 for the node list itself.

## Test plan
- [ ] Test node popup on mobile devices (verify fixed 240px width)
- [ ] Verify node list remains responsive on mobile
- [ ] Check that popups display correctly on both small and large mobile screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)