### PR TITLE
feat: Add paho-mqtt<2.0 for Apprise MQTT support (fixes #276)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apk add --no-cache \
     supervisor \
     su-exec \
     && python3 -m venv /opt/apprise-venv \
-    && /opt/apprise-venv/bin/pip install --no-cache-dir apprise
+    && /opt/apprise-venv/bin/pip install --no-cache-dir apprise "paho-mqtt<2.0"
 
 # Copy package files
 COPY package*.json ./


### PR DESCRIPTION
## Summary
- Adds `paho-mqtt<2.0` dependency to the Apprise installation in the Docker image
- Enables MQTT notification support in Apprise
- Resolves the "Apprise not available or no URLs configured" error when using MQTT URLs

## Changes Made
Modified `Dockerfile` line 42 to include `"paho-mqtt<2.0"` in the pip install command alongside `apprise`.

## Testing
- Successfully built Docker image with the updated dependency
- Verified `paho-mqtt-1.6.1` was installed (compatible with Apprise MQTT requirements)
- System tests show same pre-existing failures as main branch (unrelated to this change)

## Related Issue
Fixes #276

## References
- [Apprise MQTT Documentation](https://github.com/caronc/apprise/wiki/Notify_mqtt) - requires paho-mqtt version < 2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)