### PR TITLE
Fix packet monitor overlapping node list

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4848,6 +4848,11 @@ body {
   height: 65%;
 }
 
+/* Adjust node list sidebar when packet monitor is visible */
+.nodes-split-view:has(.packet-monitor-container) .nodes-sidebar {
+  max-height: calc(65% - 32px);
+}
+
 /* Hide packet monitor toggle on mobile */
 @media (max-width: 768px) {
   .packet-monitor-toggle {


### PR DESCRIPTION
## Summary
Fixes an issue where the node list sidebar overlaps the packet monitor panel when both are visible.

## Changes
- Added CSS rule to reduce node list `max-height` from `calc(100% - 32px)` to `calc(65% - 32px)` when packet monitor is visible
- Uses CSS `:has()` pseudo-class to detect when packet monitor container is present
- Node list now properly stays within the top 65% of the viewport, matching the map container height

## Testing
- [ ] Verify node list no longer overlaps packet monitor when both are visible
- [ ] Verify node list returns to full height when packet monitor is closed
- [ ] Verify layout works correctly on desktop (packet monitor hidden on mobile)

## Related
Improves UX for packet monitor feature introduced in v2.9.0 (#289)