### PR TITLE
Release v2.9.1 - Add Support MeshMonitor button

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -3,6 +3,12 @@
 ## In Progress
 
 ## Completed
+- Version 2.9.1 - Add Support MeshMonitor button to Settings page
+  - [x] Add prominent "Support MeshMonitor" button with Ko-fi link to Settings header
+  - [x] Style button as blue square with heart emoji and text
+  - [x] Add hover effect for better UX
+- Version 2.9.0 - Mesh Traffic Monitor & UI Improvements
+- Created GitHub release v2.9.0
 - Implement mesh packet monitor feature (issue #285)
   - [x] Add packet_log database table and configuration settings
   - [x] Create PacketLogService for logging and cleanup

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.9.0
-appVersion: "2.9.0"
+version: 2.9.1
+appVersion: "2.9.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bufbuild/protobuf": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -340,6 +340,32 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         >
           ❓
         </a>
+        <a
+          href="https://ko-fi.com/yeraze"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            marginLeft: '0.5rem',
+            padding: '0.5rem 1rem',
+            fontSize: '1rem',
+            color: '#ffffff',
+            backgroundColor: '#89b4fa',
+            textDecoration: 'none',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            borderRadius: '6px',
+            fontWeight: '500',
+            transition: 'background-color 0.2s',
+            border: 'none',
+            cursor: 'pointer'
+          }}
+          title="Support MeshMonitor"
+          onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#74a0e0'}
+          onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#89b4fa'}
+        >
+          ❤️ Support MeshMonitor
+        </a>
       </div>
       <div className="settings-content">
         <div className="settings-section">


### PR DESCRIPTION
## Summary
- Add prominent "Support MeshMonitor" button to Settings page header linking to Ko-fi
- Button features blue background, white text, heart emoji, and hover effect for better visibility
- Version bumped to 2.9.1

## Changes
- Added Ko-fi support button next to Help button in Settings header
- Styled as blue square button with hover effect (#89b4fa → #74a0e0)
- Updated version to 2.9.1 in package.json, package-lock.json, and Helm Chart.yaml
- Updated TODOS.md with completed feature

## Screenshots
The button appears in the top-right corner of the Settings page:
- Blue button with "❤️ Support MeshMonitor" text
- Positioned next to the ❓ Help icon
- Hover effect darkens the button

## Test plan
- [x] Build and deploy with Docker dev environment
- [x] Verify button appears in Settings header
- [x] Verify Ko-fi link opens correctly in new tab
- [x] Verify hover effect works
- [x] Verify button is responsive and visible on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)