### PR TITLE
feat: Add Packet Monitor enhancements with node names and filtering

### DIFF
--- a/src/components/PacketMonitorSettings.tsx
+++ b/src/components/PacketMonitorSettings.tsx
@@ -1,131 +1,35 @@
-import React, { useState, useEffect } from 'react';
-import { useCsrfFetch } from '../hooks/useCsrfFetch';
-import { useToast } from './ToastContainer';
+import React from 'react';
 import { useAuth } from '../contexts/AuthContext';
 
 interface PacketMonitorSettingsProps {
-  baseUrl: string;
+  enabled: boolean;
+  maxCount: number;
+  maxAgeHours: number;
+  onMaxCountChange: (count: number) => void;
+  onMaxAgeHoursChange: (hours: number) => void;
 }
 
-const PacketMonitorSettings: React.FC<PacketMonitorSettingsProps> = ({ baseUrl }) => {
-  const csrfFetch = useCsrfFetch();
-  const { showToast } = useToast();
+const PacketMonitorSettings: React.FC<PacketMonitorSettingsProps> = ({
+  enabled,
+  maxCount,
+  maxAgeHours,
+  onMaxCountChange,
+  onMaxAgeHoursChange
+}) => {
   const { hasPermission } = useAuth();
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [enabled, setEnabled] = useState(false);
-  const [maxCount, setMaxCount] = useState(1000);
-  const [maxAgeHours, setMaxAgeHours] = useState(24);
-  const [hasChanges, setHasChanges] = useState(false);
-  const [initialValues, setInitialValues] = useState({ enabled: false, maxCount: 1000, maxAgeHours: 24 });
 
   // Can only configure if user has settings:write permission
   const canWrite = hasPermission('settings', 'write');
 
-  // Fetch current settings
-  useEffect(() => {
-    const fetchSettings = async () => {
-      try {
-        const response = await fetch(`${baseUrl}/api/settings`, {
-          credentials: 'include'
-        });
-        if (response.ok) {
-          const settings = await response.json();
-          const enabledValue = settings.packet_log_enabled === '1';
-          const maxCountValue = parseInt(settings.packet_log_max_count || '1000', 10);
-          const maxAgeHoursValue = parseInt(settings.packet_log_max_age_hours || '24', 10);
-
-          setEnabled(enabledValue);
-          setMaxCount(maxCountValue);
-          setMaxAgeHours(maxAgeHoursValue);
-          setInitialValues({ enabled: enabledValue, maxCount: maxCountValue, maxAgeHours: maxAgeHoursValue });
-        }
-      } catch (error) {
-        console.error('Failed to fetch packet monitor settings:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchSettings();
-  }, [baseUrl]);
-
-  // Track changes compared to initial values
-  useEffect(() => {
-    const changed = enabled !== initialValues.enabled ||
-                    maxCount !== initialValues.maxCount ||
-                    maxAgeHours !== initialValues.maxAgeHours;
-    setHasChanges(changed);
-  }, [enabled, maxCount, maxAgeHours, initialValues]);
-
-  // Save settings
-  const handleSave = async () => {
-    if (!canWrite) {
-      showToast('You do not have permission to change settings', 'error');
-      return;
-    }
-
-    console.log('💾 Saving packet monitor settings:', { enabled, maxCount, maxAgeHours });
-
-    setSaving(true);
-    try {
-      const payload = {
-        packet_log_enabled: enabled ? '1' : '0',
-        packet_log_max_count: maxCount.toString(),
-        packet_log_max_age_hours: maxAgeHours.toString(),
-      };
-      console.log('📤 Sending payload:', payload);
-
-      const response = await csrfFetch(`${baseUrl}/api/settings`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(payload),
-      });
-
-      if (response.ok) {
-        showToast('Packet monitor settings saved successfully', 'success');
-        setHasChanges(false);
-        // Update initial values after successful save
-        setInitialValues({ enabled, maxCount, maxAgeHours });
-      } else {
-        throw new Error('Failed to save settings');
-      }
-    } catch (error) {
-      console.error('Failed to save packet monitor settings:', error);
-      showToast('Failed to save packet monitor settings', 'error');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  if (loading) {
-    return <div className="packet-monitor-settings-loading">Loading...</div>;
-  }
-
   return (
     <div className="packet-monitor-settings-container">
-      <div className="setting-item">
-        <label>
-          <input
-            type="checkbox"
-            checked={enabled}
-            onChange={(e) => {
-              console.log('✅ Checkbox changed to:', e.target.checked);
-              setEnabled(e.target.checked);
-            }}
-            disabled={!canWrite}
-          />
-          <span style={{ marginLeft: '8px' }}>Enable Packet Logging</span>
-        </label>
-        <span className="setting-description">
-          When enabled, all mesh packets will be logged to the database for viewing in the Packet Monitor panel.
-          {!enabled && <span style={{ color: 'var(--warning-color)', display: 'block', marginTop: '4px' }}>
-            ⚠️ Packet logging is currently disabled. No packets will be stored.
-          </span>}
-        </span>
-      </div>
+      {!enabled && (
+        <div className="setting-item">
+          <p className="setting-description" style={{ color: 'var(--warning-color)', marginBottom: '1rem' }}>
+            ⚠️ Packet logging is currently disabled. No packets will be stored. Enable it in the section header above to start collecting packet data.
+          </p>
+        </div>
+      )}
 
       <div className="setting-item">
         <label htmlFor="packet-max-count">
@@ -141,9 +45,9 @@ const PacketMonitorSettings: React.FC<PacketMonitorSettingsProps> = ({ baseUrl }
           max="10000"
           step="100"
           value={maxCount}
-          onChange={(e) => setMaxCount(parseInt(e.target.value, 10))}
+          onChange={(e) => onMaxCountChange(parseInt(e.target.value, 10))}
           className="setting-input"
-          disabled={!canWrite}
+          disabled={!canWrite || !enabled}
         />
       </div>
 
@@ -160,9 +64,9 @@ const PacketMonitorSettings: React.FC<PacketMonitorSettingsProps> = ({ baseUrl }
           min="1"
           max="168"
           value={maxAgeHours}
-          onChange={(e) => setMaxAgeHours(parseInt(e.target.value, 10))}
+          onChange={(e) => onMaxAgeHoursChange(parseInt(e.target.value, 10))}
           className="setting-input"
-          disabled={!canWrite}
+          disabled={!canWrite || !enabled}
         />
       </div>
 
@@ -174,18 +78,6 @@ const PacketMonitorSettings: React.FC<PacketMonitorSettingsProps> = ({ baseUrl }
           <strong>Note:</strong> Automatic cleanup runs every 15 minutes to enforce these limits.
         </p>
       </div>
-
-      {canWrite && (
-        <div className="packet-monitor-actions">
-          <button
-            className="save-button"
-            onClick={handleSave}
-            disabled={!hasChanges || saving}
-          >
-            {saving ? 'Saving...' : 'Save Packet Monitor Settings'}
-          </button>
-        </div>
-      )}
 
       {!canWrite && (
         <div className="packet-monitor-no-permission">

--- a/src/types/packet.ts
+++ b/src/types/packet.ts
@@ -8,8 +8,10 @@ export interface PacketLog {
   timestamp: number;
   from_node: number;
   from_node_id?: string;
+  from_node_longName?: string;
   to_node?: number;
   to_node_id?: string;
+  to_node_longName?: string;
   channel?: number;
   portnum: number;
   portnum_name?: string;


### PR DESCRIPTION
## Summary

This PR implements the improvements requested in #300:
- ✅ Display node long names instead of hex IDs in the Packet Monitor table
- ✅ Add "Hide Own Packets" filter checkbox (enabled by default)
- ✨ Bonus: Reorganized Packet Monitor settings UI

## Changes

### Frontend UI Enhancements
- **Node Long Names Display** (PacketMonitorPanel.tsx)
  - Show truncated long names (20 chars max) instead of hex node IDs
  - Full names visible in tooltips on hover
  - Graceful fallback to node ID if long name unavailable
  
- **"Hide Own Packets" Filter** (PacketMonitorPanel.tsx)
  - New checkbox in Filters section (enabled by default)
  - Instantly filters out packets from local node
  - Reactive filtering using `useMemo` for optimal performance
  - Converts hex nodeId to numeric value for comparison

- **Settings Page Reorganization** (SettingsTab.tsx, PacketMonitorSettings.tsx)
  - Moved "Enable Packet Monitor" to section header toggle
  - Consolidated all settings under single Save/Restore buttons
  - Removed separate "Save Packet Monitor Settings" button
  - Improved UX consistency with other settings sections

### Backend Database Changes
- **JOIN with nodes table** (database.ts)
  - Updated `getPacketLogs()` to retrieve node long names
  - Updated `getPacketLogById()` for consistency
  - Added `from_node_longName` and `to_node_longName` fields
  - Fixed JOIN to use `nodeNum` (correct primary key)

- **Type Definitions** (packet.ts)
  - Added `from_node_longName?: string` to PacketLog interface
  - Added `to_node_longName?: string` to PacketLog interface

## Technical Details

### Node Number Conversion
Since `deviceInfo.localNodeInfo` contains `nodeId` as hex string (e.g., "!43588558") but not `myNodeNum`, implemented conversion:
```typescript
const ownNodeNum = React.useMemo(() => {
  const nodeId = deviceInfo?.localNodeInfo?.nodeId;
  if (!nodeId || !nodeId.startsWith('!')) return undefined;
  return parseInt(nodeId.substring(1), 16);
}, [deviceInfo?.localNodeInfo?.nodeId]);
```

### Reactive Filtering
Using `useMemo` for instant filter updates without refetching data:
```typescript
const packets = React.useMemo(() => {
  if (hideOwnPackets && ownNodeNum) {
    return rawPackets.filter(packet => packet.from_node !== ownNodeNum);
  }
  return rawPackets;
}, [rawPackets, hideOwnPackets, ownNodeNum]);
```

## Test Plan
- [x] Verify node long names display correctly in packet table
- [x] Verify long names truncate at 20 characters with "..."
- [x] Verify tooltips show full long names on hover
- [x] Verify fallback to node ID when long name unavailable
- [x] Verify "Hide Own Packets" checkbox filters correctly
- [x] Verify checkbox is enabled by default
- [x] Verify instant toggle response without lag
- [x] Verify Settings page UI improvements
- [x] Verify all settings save/restore correctly

## Screenshots
Tested with live Meshtastic network showing:
- Long names displayed and truncated appropriately
- "Hide Own Packets" filter working correctly
- Settings page reorganization complete

Fixes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)