### PR TITLE
feat: Add collapsible map controls with Features title

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3483,6 +3483,53 @@ body {
   font-weight: 500;
 }
 
+/* Map controls title */
+.map-controls-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ctp-mauve);
+  margin-bottom: 0.5rem;
+  padding-right: 28px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Map controls collapse button */
+.map-controls-collapse-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: var(--ctp-surface1);
+  border: none;
+  border-radius: 4px;
+  color: var(--ctp-text);
+  cursor: pointer;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  transition: all 0.2s ease;
+  padding: 0;
+  line-height: 1;
+}
+
+.map-controls-collapse-btn:hover {
+  background: var(--ctp-surface2);
+  transform: scale(1.1);
+}
+
+.map-controls-collapse-btn:active {
+  transform: scale(0.95);
+}
+
+/* Collapsed state for map controls */
+.map-controls.collapsed {
+  padding: 0.5rem;
+  min-width: 40px;
+}
+
 /* Footer Styles */
 .app-footer {
   background: var(--ctp-crust);

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -113,10 +113,22 @@ const NodesTab: React.FC<NodesTabProps> = ({
   // Track if packet logging is enabled on the server
   const [packetLogEnabled, setPacketLogEnabled] = useState<boolean>(false);
 
+  // Track if map controls are collapsed
+  const [isMapControlsCollapsed, setIsMapControlsCollapsed] = useState(() => {
+    // Load from localStorage
+    const saved = localStorage.getItem('isMapControlsCollapsed');
+    return saved === 'true';
+  });
+
   // Save packet monitor preference to localStorage
   useEffect(() => {
     localStorage.setItem('showPacketMonitor', showPacketMonitor.toString());
   }, [showPacketMonitor]);
+
+  // Save map controls collapse state to localStorage
+  useEffect(() => {
+    localStorage.setItem('isMapControlsCollapsed', isMapControlsCollapsed.toString());
+  }, [isMapControlsCollapsed]);
 
   // Check if user has permission to view packet monitor
   const canViewPacketMonitor = hasPermission('channels', 'read') && hasPermission('messages', 'read');
@@ -373,56 +385,68 @@ const NodesTab: React.FC<NodesTabProps> = ({
       <div className={`map-container ${showPacketMonitor && canViewPacketMonitor ? 'with-packet-monitor' : ''}`}>
         {shouldShowData() ? (
           <>
-            <div className="map-controls">
-              <label className="map-control-item">
-                <input
-                  type="checkbox"
-                  checked={showPaths}
-                  onChange={(e) => setShowPaths(e.target.checked)}
-                />
-                <span>Show Route Segments</span>
-              </label>
-              <label className="map-control-item">
-                <input
-                  type="checkbox"
-                  checked={showNeighborInfo}
-                  onChange={(e) => setShowNeighborInfo(e.target.checked)}
-                />
-                <span>Show Neighbor Info</span>
-              </label>
-              <label className="map-control-item">
-                <input
-                  type="checkbox"
-                  checked={showRoute}
-                  onChange={(e) => setShowRoute(e.target.checked)}
-                />
-                <span>Show Traceroute</span>
-              </label>
-              <label className="map-control-item">
-                <input
-                  type="checkbox"
-                  checked={showMqttNodes}
-                  onChange={(e) => setShowMqttNodes(e.target.checked)}
-                />
-                <span>Show MQTT</span>
-              </label>
-              <label className="map-control-item">
-                <input
-                  type="checkbox"
-                  checked={showMotion}
-                  onChange={(e) => setShowMotion(e.target.checked)}
-                />
-                <span>Show Position History</span>
-              </label>
-              {canViewPacketMonitor && packetLogEnabled && (
-                <label className="map-control-item packet-monitor-toggle">
-                  <input
-                    type="checkbox"
-                    checked={showPacketMonitor}
-                    onChange={(e) => setShowPacketMonitor(e.target.checked)}
-                  />
-                  <span>Show Packet Monitor</span>
-                </label>
+            <div className={`map-controls ${isMapControlsCollapsed ? 'collapsed' : ''}`}>
+              <button
+                className="map-controls-collapse-btn"
+                onClick={() => setIsMapControlsCollapsed(!isMapControlsCollapsed)}
+                title={isMapControlsCollapsed ? 'Expand controls' : 'Collapse controls'}
+              >
+                {isMapControlsCollapsed ? '▼' : '▲'}
+              </button>
+              {!isMapControlsCollapsed && (
+                <>
+                  <div className="map-controls-title">Features</div>
+                  <label className="map-control-item">
+                    <input
+                      type="checkbox"
+                      checked={showPaths}
+                      onChange={(e) => setShowPaths(e.target.checked)}
+                    />
+                    <span>Show Route Segments</span>
+                  </label>
+                  <label className="map-control-item">
+                    <input
+                      type="checkbox"
+                      checked={showNeighborInfo}
+                      onChange={(e) => setShowNeighborInfo(e.target.checked)}
+                    />
+                    <span>Show Neighbor Info</span>
+                  </label>
+                  <label className="map-control-item">
+                    <input
+                      type="checkbox"
+                      checked={showRoute}
+                      onChange={(e) => setShowRoute(e.target.checked)}
+                    />
+                    <span>Show Traceroute</span>
+                  </label>
+                  <label className="map-control-item">
+                    <input
+                      type="checkbox"
+                      checked={showMqttNodes}
+                      onChange={(e) => setShowMqttNodes(e.target.checked)}
+                    />
+                    <span>Show MQTT</span>
+                  </label>
+                  <label className="map-control-item">
+                    <input
+                      type="checkbox"
+                      checked={showMotion}
+                      onChange={(e) => setShowMotion(e.target.checked)}
+                    />
+                    <span>Show Position History</span>
+                  </label>
+                  {canViewPacketMonitor && packetLogEnabled && (
+                    <label className="map-control-item packet-monitor-toggle">
+                      <input
+                        type="checkbox"
+                        checked={showPacketMonitor}
+                        onChange={(e) => setShowPacketMonitor(e.target.checked)}
+                      />
+                      <span>Show Packet Monitor</span>
+                    </label>
+                  )}
+                </>
               )}
             </div>
             <MapContainer


### PR DESCRIPTION
## Summary

- Added a collapsible map controls panel with a "Features" title
- Users can now hide/show the feature checkboxes using a collapse button in the top-right corner
- The collapse state persists to localStorage for better user experience
- Styled with Catppuccin theme colors for consistency

## Changes

### UI Improvements
- **Collapse Button**: Added an arrow button (▲/▼) in the top-right corner of the map controls panel
- **Features Title**: Added a prominent "FEATURES" title at the top of the controls panel in purple
- **Collapsible State**: Checkboxes can be hidden/shown by clicking the collapse button
- **State Persistence**: The collapsed/expanded state is saved to localStorage

### Technical Details
- Modified `src/components/NodesTab.tsx`:
  - Added `isMapControlsCollapsed` state with localStorage persistence
  - Added collapse button with click handler
  - Made checkboxes conditionally render based on collapse state
  - Added "Features" title element

- Modified `src/App.css`:
  - Added `.map-controls-title` styling for the Features title
  - Added `.map-controls-collapse-btn` styling for the collapse button
  - Added hover and active states with smooth transitions
  - Added `.map-controls.collapsed` class for the collapsed state

## Test plan

- [ ] Navigate to the Map page
- [ ] Verify the "FEATURES" title is visible at the top of the controls panel
- [ ] Click the collapse arrow button in the top-right corner
- [ ] Verify the checkboxes hide and the arrow changes from ▲ to ▼
- [ ] Click the button again to expand
- [ ] Verify the checkboxes show and the arrow changes from ▼ to ▲
- [ ] Refresh the page and verify the state persists
- [ ] Test on mobile and desktop viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)