### PR TITLE
feat: Add animated node icons on map with persistent toggle

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.10.5
-appVersion: "2.10.5"
+version: 2.10.6
+appVersion: "2.10.6"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.10.5",
+      "version": "2.10.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bufbuild/protobuf": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/App.css
+++ b/src/App.css
@@ -3530,6 +3530,26 @@ body {
   min-width: 40px;
 }
 
+/* Node Pulse Animation */
+@keyframes node-pulse {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.5);
+    opacity: 0.9;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.node-icon-pulse {
+  animation: node-pulse 1s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 /* Footer Styles */
 .app-footer {
   background: var(--ctp-crust);

--- a/src/utils/mapIcons.ts
+++ b/src/utils/mapIcons.ts
@@ -43,8 +43,9 @@ export function createNodeIcon(options: {
   isRouter: boolean;
   shortName?: string;
   showLabel: boolean;
+  animate?: boolean;
 }): L.DivIcon {
-  const { hops, isSelected, isRouter, shortName, showLabel } = options;
+  const { hops, isSelected, isRouter, shortName, showLabel, animate = false } = options;
   const color = getHopColor(hops);
   const size = isSelected ? 60 : 48;
   const strokeWidth = isSelected ? 3 : 2;
@@ -97,7 +98,7 @@ export function createNodeIcon(options: {
   ` : '';
 
   const html = `
-    <div style="position: relative; width: ${size}px; height: ${size}px;">
+    <div class="${animate ? 'node-icon-pulse' : ''}" style="position: relative; width: ${size}px; height: ${size}px;">
       ${markerSvg}
       ${label}
     </div>


### PR DESCRIPTION
## Summary
Adds a new "Show Animations" feature to the map view that provides visual feedback when nodes send updates or packets. Node icons pulse with a smooth 1-second animation to help users quickly identify network activity.

## Changes
- Added "Show Animations" toggle checkbox to map controls (disabled by default)
- Node icons pulse with 1s animation when receiving updates/packets
- Icons scale to 1.5x with smooth cubic-bezier easing
- Animated nodes elevated above neighbors using z-index offset
- Shortname labels displayed during animation regardless of zoom level
- Animation setting persists to localStorage across page reloads
- Node updates detected via lastHeard timestamp comparison
- Removed debug console.log statements
- Version bump to 2.10.6

## Implementation Details
- **MapContext**: Added showAnimations state with localStorage persistence
- **NodesTab**: Added UI toggle, useEffect for node update detection, and animation logic
- **App.css**: Added CSS keyframe animation with smooth easing
- **mapIcons.ts**: Added animate parameter to createNodeIcon function
- **Z-index management**: Uses Leaflet's zIndexOffset prop to raise animated icons

## Test Plan
- [x] Enable "Show Animations" toggle
- [x] Verify icons pulse when nodes send updates
- [x] Verify shortname labels show during animation
- [x] Verify animated icons appear above neighbors
- [x] Reload page and verify setting persists
- [x] TypeScript compilation passes
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)