### PR TITLE
fix: Add auto-welcome settings to validKeys whitelist

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.10.6
-appVersion: "2.10.6"
+version: 2.10.7
+appVersion: "2.10.7"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.10.6",
+  "version": "2.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.10.6",
+      "version": "2.10.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bufbuild/protobuf": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.10.6",
+  "version": "2.10.7",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2063,7 +2063,7 @@ apiRouter.post('/settings', requirePermission('settings', 'write'), (req, res) =
     const currentSettings = databaseService.getAllSettings();
 
     // Validate settings
-    const validKeys = ['maxNodeAgeHours', 'tracerouteIntervalMinutes', 'temperatureUnit', 'distanceUnit', 'telemetryVisualizationHours', 'telemetryFavorites', 'autoAckEnabled', 'autoAckRegex', 'autoAckMessage', 'autoAckChannels', 'autoAckDirectMessages', 'autoAnnounceEnabled', 'autoAnnounceIntervalHours', 'autoAnnounceMessage', 'autoAnnounceChannelIndex', 'autoAnnounceOnStart', 'preferredSortField', 'preferredSortDirection', 'timeFormat', 'dateFormat', 'mapTileset', 'packet_log_enabled', 'packet_log_max_count', 'packet_log_max_age_hours'];
+    const validKeys = ['maxNodeAgeHours', 'tracerouteIntervalMinutes', 'temperatureUnit', 'distanceUnit', 'telemetryVisualizationHours', 'telemetryFavorites', 'autoAckEnabled', 'autoAckRegex', 'autoAckMessage', 'autoAckChannels', 'autoAckDirectMessages', 'autoAnnounceEnabled', 'autoAnnounceIntervalHours', 'autoAnnounceMessage', 'autoAnnounceChannelIndex', 'autoAnnounceOnStart', 'autoWelcomeEnabled', 'autoWelcomeMessage', 'autoWelcomeTarget', 'autoWelcomeWaitForName', 'preferredSortField', 'preferredSortDirection', 'timeFormat', 'dateFormat', 'mapTileset', 'packet_log_enabled', 'packet_log_max_count', 'packet_log_max_age_hours'];
     const filteredSettings: Record<string, string> = {};
 
     for (const key of validKeys) {


### PR DESCRIPTION
## Summary
Fixed auto-welcome settings not persisting by adding missing keys to the validKeys whitelist in the /api/settings POST endpoint.

## Changes
- Added four missing auto-welcome keys to validKeys array in src/server/server.ts:
  - `autoWelcomeEnabled`
  - `autoWelcomeMessage`
  - `autoWelcomeTarget`
  - `autoWelcomeWaitForName`
- Bumped version to 2.10.7 in package.json, package-lock.json, and Helm chart

## Root Cause
The backend was silently discarding auto-welcome settings when the frontend tried to save them because these keys were not included in the validKeys whitelist. This meant settings appeared to save in the UI but were never persisted to the database.

## Test Plan
- [x] Start the application
- [x] Navigate to Settings
- [x] Configure auto-welcome settings (enable, set message, select target)
- [x] Click Save
- [x] Reload the page
- [x] Verify settings persist correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)