### PR TITLE
feat: Add PSK generation button to channel editor

### DIFF
--- a/src/components/configuration/ChannelsConfigSection.tsx
+++ b/src/components/configuration/ChannelsConfigSection.tsx
@@ -152,6 +152,20 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
     }
   };
 
+  const handleGeneratePSK = () => {
+    // Generate 32 random bytes (256 bits for AES256)
+    const randomBytes = new Uint8Array(32);
+    crypto.getRandomValues(randomBytes);
+
+    // Convert to base64
+    const base64Key = btoa(String.fromCharCode(...randomBytes));
+
+    if (editingChannel) {
+      setEditingChannel({ ...editingChannel, psk: base64Key });
+      showToast('Generated new AES256 key', 'success');
+    }
+  };
+
   return (
     <>
       <div className="settings-section">
@@ -319,14 +333,33 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                   Leave empty for no encryption, or enter base64-encoded key (16 or 32 bytes)
                 </span>
               </label>
-              <input
-                id="edit-channel-psk"
-                type="text"
-                value={editingChannel.psk}
-                onChange={(e) => setEditingChannel({ ...editingChannel, psk: e.target.value })}
-                className="setting-input"
-                placeholder="Optional: base64 PSK"
-              />
+              <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <input
+                  id="edit-channel-psk"
+                  type="text"
+                  value={editingChannel.psk}
+                  onChange={(e) => setEditingChannel({ ...editingChannel, psk: e.target.value })}
+                  className="setting-input"
+                  placeholder="Optional: base64 PSK"
+                  style={{ flex: 1 }}
+                />
+                <button
+                  onClick={handleGeneratePSK}
+                  type="button"
+                  style={{
+                    padding: '0.5rem 1rem',
+                    backgroundColor: 'var(--ctp-green)',
+                    color: 'var(--ctp-base)',
+                    border: 'none',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    whiteSpace: 'nowrap'
+                  }}
+                  title="Generate random AES256 key"
+                >
+                  Generate
+                </button>
+              </div>
             </div>
 
             <div className="setting-item">


### PR DESCRIPTION
## Summary
- Added "Generate" button to PSK field in channel editing modal
- Securely generates AES256 keys using crypto.getRandomValues()
- Auto-populates base64-encoded PSK in the input field

## Changes
- Added `handleGeneratePSK()` function that generates 32 random bytes (256 bits)
- Converts bytes to base64 format (Meshtastic standard)
- Updates PSK field and shows success toast notification
- Button styled with green color and positioned next to PSK input field
- Added helpful tooltip explaining the button function

## Why
This improves UX by allowing users to easily generate cryptographically secure PSKs without needing external tools or manually encoding keys. Previously, users had to use external tools to generate secure keys and convert them to base64.

## Test plan
- [x] Build succeeds
- [x] System tests pass (Quick Start test verified)
- [x] Deployed to Docker and verified code is present
- [ ] Manual test: Open channel editor modal
- [ ] Manual test: Click "Generate" button
- [ ] Manual test: Verify PSK field is populated with base64 string
- [ ] Manual test: Verify success toast appears
- [ ] Manual test: Save channel and verify encryption works

🤖 Generated with [Claude Code](https://claude.com/claude-code)