### PR TITLE
fix: Resolve sidebar overlap and popup z-index issues

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2915,7 +2915,7 @@ body {
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
   max-width: 280px;
   font-size: 14px;
-  z-index: 1000;
+  z-index: 10002; /* Above sidebar (10001) to prevent overlap */
 }
 
 .node-popup .popup-header {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2197,10 +2197,27 @@ function App() {
   // Function to handle sender icon clicks
   const handleSenderClick = useCallback((nodeId: string, event: React.MouseEvent) => {
     const rect = event.currentTarget.getBoundingClientRect();
+
+    // Get sidebar width from CSS variable to avoid overlap
+    const sidebarWidth = parseInt(
+      getComputedStyle(document.documentElement).getPropertyValue('--sidebar-width') || '60px'
+    );
+
+    // Popup max-width is 280px, and it's centered with translateX(-50%)
+    // So the left edge will be at x - 140px
+    const popupHalfWidth = 140;
+    let x = rect.left + rect.width / 2;
+
+    // Ensure popup doesn't go under the sidebar (with 10px padding for safety)
+    const minX = sidebarWidth + popupHalfWidth + 10;
+    if (x < minX) {
+      x = minX;
+    }
+
     setNodePopup({
       nodeId,
       position: {
-        x: rect.left + rect.width / 2,
+        x,
         y: rect.top
       }
     });

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -52,17 +52,32 @@ const Sidebar: React.FC<SidebarProps> = ({
     icon: string;
     onClick?: () => void;
     showNotification?: boolean;
-  }> = ({ id, label, icon, onClick, showNotification }) => (
-    <button
-      className={`sidebar-nav-item ${activeTab === id ? 'active' : ''}`}
-      onClick={onClick || (() => setActiveTab(id))}
-      title={isCollapsed ? label : ''}
-    >
-      <span className="nav-icon">{icon}</span>
-      {!isCollapsed && <span className="nav-label">{label}</span>}
-      {showNotification && <span className="nav-notification-dot"></span>}
-    </button>
-  );
+  }> = ({ id, label, icon, onClick, showNotification }) => {
+    const handleClick = () => {
+      // Auto-collapse sidebar when navigation item is clicked (if expanded)
+      if (!isCollapsed) {
+        setIsCollapsed(true);
+      }
+      // Execute the custom onClick or default setActiveTab
+      if (onClick) {
+        onClick();
+      } else {
+        setActiveTab(id);
+      }
+    };
+
+    return (
+      <button
+        className={`sidebar-nav-item ${activeTab === id ? 'active' : ''}`}
+        onClick={handleClick}
+        title={isCollapsed ? label : ''}
+      >
+        <span className="nav-icon">{icon}</span>
+        {!isCollapsed && <span className="nav-label">{label}</span>}
+        {showNotification && <span className="nav-notification-dot"></span>}
+      </button>
+    );
+  };
 
   const SectionHeader: React.FC<{ title: string }> = ({ title }) => (
     !isCollapsed ? <div className="sidebar-section-header">{title}</div> : null


### PR DESCRIPTION
## Summary

Fixes #342 - Resolves UI issues where the sidebar menu overlapped with content and interfered with popovers.

## Changes

This PR implements three key fixes:

1. **Auto-collapse sidebar on navigation** - The sidebar now automatically collapses when any navigation item is clicked, preventing it from overwhelming the main content area.

2. **Fixed popup z-index** - Increased node popup z-index from 1000 to 10002 (above sidebar's 10001) ensuring popovers always appear on top of the sidebar.

3. **Smart popup positioning** - Enhanced popup positioning logic to account for sidebar width and prevent overlap. The popup now dynamically adjusts its position to stay clear of the sidebar with a 10px safety margin.

## Files Changed

- `src/components/Sidebar.tsx` - Auto-collapse on navigation item click
- `src/App.css` - Node popup z-index increased to 10002
- `src/App.tsx` - Smart popup positioning to avoid sidebar overlap

## Test Plan

- [x] Built and tested in dev environment
- [ ] Manual testing: Click navigation items and verify sidebar collapses
- [ ] Manual testing: Click node shortname bubbles on Channels page
- [ ] Manual testing: Verify popovers appear above sidebar
- [ ] Manual testing: Verify popovers don't overlap with sidebar when near left edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)