### PR TITLE
fix: Clarify ALLOWED_ORIGINS requirement for localhost access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,13 +42,29 @@ MESHTASTIC_TCP_PORT=4403
 
 # CORS Configuration
 # ALLOWED_ORIGINS: Comma-separated list of allowed origins for CORS
-# REQUIRED when using HTTPS or reverse proxy with a different hostname than backend
-# Examples:
-#   Single domain:  ALLOWED_ORIGINS=https://meshmonitor.example.com
-#   Multiple:       ALLOWED_ORIGINS=https://meshmonitor.example.com,https://mesh.example.com
-#   Wildcard:       ALLOWED_ORIGINS=*  (NOT recommended for production)
-# If blank in development, defaults to http://localhost:3000,http://localhost:5173,http://localhost:8080
-# ALLOWED_ORIGINS=https://meshmonitor.example.com
+# REQUIRED: Must be set to match how you access MeshMonitor, even for localhost
+#
+# For localhost access (most common for Docker deployments):
+#   ALLOWED_ORIGINS=http://localhost:8080
+#
+# For access via server IP address:
+#   ALLOWED_ORIGINS=http://192.168.1.50:8080
+#
+# For multiple access methods (localhost AND server IP):
+#   ALLOWED_ORIGINS=http://localhost:8080,http://192.168.1.50:8080
+#
+# For production with HTTPS:
+#   ALLOWED_ORIGINS=https://meshmonitor.example.com
+#
+# Multiple HTTPS domains:
+#   ALLOWED_ORIGINS=https://meshmonitor.example.com,https://mesh.example.com
+#
+# Wildcard (NOT recommended for production, testing only):
+#   ALLOWED_ORIGINS=*
+#
+# If blank in development mode, defaults to http://localhost:3000,http://localhost:5173,http://localhost:8080
+# However, it's best practice to explicitly set this value to avoid CORS issues
+ALLOWED_ORIGINS=http://localhost:8080
 
 # Web Push Notification Configuration (VAPID keys)
 # Generate keys by running: node generate-vapid-keys.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       # Minimal configuration for http://localhost:8080
       - NODE_ENV=development  # Use development mode for simple HTTP deployments
       - TZ=America/New_York
+      - ALLOWED_ORIGINS=http://localhost:8080  # Required for CORS
 
       # OPTIONAL: Uncomment and configure for production deployments
       # See docs/configuration/production.md for full production setup guide

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,6 +31,7 @@ services:
       - meshmonitor-data:/data
     environment:
       - MESHTASTIC_NODE_IP=192.168.1.100  # Change to your node's IP
+      - ALLOWED_ORIGINS=http://localhost:8080  # Required for CORS
 
 volumes:
   meshmonitor-data:
@@ -103,31 +104,35 @@ environment:
   - TZ=Europe/London  # See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 ```
 
-### Remote Access Over Local Network
+### Accessing from Different Devices/IPs
 
-**Important:** If you want to access MeshMonitor from other devices on your local network (e.g., `http://192.168.1.50:8080`), you **must** set `ALLOWED_ORIGINS`:
+**Important:** MeshMonitor uses CORS protection to prevent unauthorized access. You **must** set `ALLOWED_ORIGINS` to match how you're accessing the application.
 
+**For localhost access** (as shown in the basic example):
+```yaml
+- ALLOWED_ORIGINS=http://localhost:8080
+```
+
+**For access via server IP** (e.g., `http://192.168.1.50:8080`):
 ```yaml
 environment:
   - MESHTASTIC_NODE_IP=192.168.1.100
   - ALLOWED_ORIGINS=http://192.168.1.50:8080  # Replace with your server's IP
 ```
 
-**Why?** MeshMonitor uses CORS protection to prevent unauthorized access. By default, only `http://localhost:8080` is allowed. When accessing from another device, you need to explicitly allow your server's IP address.
-
-**Examples:**
+**For multiple access methods** (localhost AND server IP):
 ```yaml
-# Single origin
-- ALLOWED_ORIGINS=http://192.168.1.50:8080
+- ALLOWED_ORIGINS=http://localhost:8080,http://192.168.1.50:8080
+```
 
-# Multiple origins (comma-separated)
+**Additional examples:**
+```yaml
+# Multiple origins with hostname
 - ALLOWED_ORIGINS=http://192.168.1.50:8080,http://meshmonitor.local:8080
 
 # Allow all origins (not recommended, use for testing only)
 - ALLOWED_ORIGINS=*
 ```
-
-**Note:** `ALLOWED_ORIGINS` is not required for `http://localhost` access - that works by default.
 
 ## Production Deployment
 


### PR DESCRIPTION
## Summary

Fixes #346

This PR updates documentation and example configurations to explicitly require `ALLOWED_ORIGINS=http://localhost:8080` for localhost access, resolving CORS errors that users were experiencing when following the Quick Start guide.

## Problem

Users following the Quick Start guide were encountering:
- CORS errors when accessing `http://localhost:8080`
- Login failures with default credentials
- The documentation incorrectly stated that `ALLOWED_ORIGINS` was not required for localhost access

## Changes

### 1. Documentation (docs/getting-started.md)
- ✅ Added `ALLOWED_ORIGINS=http://localhost:8080` to the basic docker-compose.yml example
- ✅ Removed misleading note claiming localhost doesn't need ALLOWED_ORIGINS
- ✅ Reorganized CORS configuration section with clearer examples
- ✅ Added examples for different access scenarios (localhost, server IP, multiple origins)

### 2. Example Configuration (docker-compose.yml)
- ✅ Added `ALLOWED_ORIGINS=http://localhost:8080` to default environment variables

### 3. Environment Template (.env.example)
- ✅ Expanded documentation with clear examples for different scenarios
- ✅ Added uncommented default value: `ALLOWED_ORIGINS=http://localhost:8080`
- ✅ Clarified that ALLOWED_ORIGINS is required even for localhost access

## Test Results

All system tests pass successfully:

```
Configuration Import:     ✓ PASSED
Quick Start Test:         ✓ PASSED
Reverse Proxy Test:       ✓ PASSED
Reverse Proxy + OIDC:     ✓ PASSED

✓ ALL SYSTEM TESTS PASSED
```

Full test output available in the test run.

## Impact

- **Users**: No more CORS errors when following Quick Start guide
- **Existing Deployments**: No breaking changes - configurations without ALLOWED_ORIGINS will continue to work with development mode defaults
- **Documentation**: Clearer guidance on CORS configuration requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)