### PR TITLE
fix: Use node's actual lastHeard timestamp instead of server time

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -20,6 +20,14 @@ None
     - Location: tests/ directory (create new test file)
 
 ## Completed
+- Node lastHeard timestamp fix
+  - [x] Identified issue: processNodeInfoProtobuf and processNodeInfo were using server time instead of node's lastHeard from protobuf
+  - [x] Root cause: All nodes got same timestamp when nodelist was downloaded, not reflecting when each node was actually last heard
+  - [x] Fixed processNodeInfoProtobuf (line 1863) to use nodeInfo.lastHeard from protobuf with fallback to server time
+  - [x] Fixed legacy processNodeInfo function (line 3111) to use nodeInfo.lastHeard with fallback to server time
+  - [x] Added Math.min() cap to prevent future timestamps from being stored (handles nodes with incorrect time)
+  - [x] Built and deployed fix to Docker container
+  - Impact: Each node now shows its actual last heard time, not the time of the last nodelist download, with protection against future timestamps
 - Traceroute utility refactoring
   - [x] Fixed array mutation bug in traceroute.tsx using immutable Set-based tracking instead of splice()
   - [x] Fixed SNR index calculation to use correct indices from unmutated arrays

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1860,7 +1860,7 @@ class MeshtasticManager {
       const nodeData: any = {
         nodeNum: Number(nodeInfo.num),
         nodeId: nodeId,
-        lastHeard: Date.now() / 1000, // Use server time when we received this node info
+        lastHeard: Math.min(nodeInfo.lastHeard || (Date.now() / 1000), Date.now() / 1000), // Cap at current time to prevent future timestamps
         snr: nodeInfo.snr,
         rssi: 0, // Will be updated from mesh packet if available
         hopsAway: nodeInfo.hopsAway !== undefined ? nodeInfo.hopsAway : undefined
@@ -3108,7 +3108,7 @@ class MeshtasticManager {
       altitude: nodeInfo.position?.altitude,
       // Note: Telemetry data (batteryLevel, voltage, etc.) is NOT saved from NodeInfo packets
       // It is only saved from actual TELEMETRY_APP packets in processTelemetryMessageProtobuf()
-      lastHeard: Math.floor(Date.now() / 1000), // Use server time, not node-reported time
+      lastHeard: Math.min(nodeInfo.lastHeard || Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)), // Cap at current time to prevent future timestamps
       snr: nodeInfo.snr,
       rssi: nodeInfo.rssi
     };


### PR DESCRIPTION
## Summary
Fixes the issue where all nodes showed the same "Last Seen" timestamp (the time when the nodelist was downloaded), making it impossible to distinguish recently active nodes from long-inactive ones.

## Problem
Previously, when the node list was downloaded from the device, all nodes would get assigned the current server timestamp. This meant every node's "Last Seen" time was identical - reflecting when the list was fetched, not when each individual node was actually last heard from.

## Root Cause
In `meshtasticManager.ts`, two functions were incorrectly using `Date.now()` (current server time) instead of reading the `lastHeard` field from the NodeInfo protobuf:
- `processNodeInfoProtobuf` (line 1863)
- `processNodeInfo` legacy function (line 3111)

The Meshtastic protobuf definition includes a `last_heard` field that contains the actual timestamp when each node was last heard by the device.

## Solution
1. **Use actual node timestamp**: Changed both functions to use `nodeInfo.lastHeard` from the protobuf
2. **Add fallback**: Keep server time as a fallback if `lastHeard` is not provided
3. **Cap future timestamps**: Added `Math.min()` to prevent storing timestamps in the future (handles nodes with incorrect clock settings)

## Changes
- Modified `src/server/meshtasticManager.ts`:
  - Updated `processNodeInfoProtobuf` to use `nodeInfo.lastHeard` with timestamp capping
  - Updated legacy `processNodeInfo` to use `nodeInfo.lastHeard` with timestamp capping
- Updated `TODOS.md` to document the completed fix

## Impact
- Each node now displays its actual last heard time, not the nodelist download time
- Easy to identify which nodes are recently active vs. long inactive
- Protection against future timestamps from nodes with incorrect time settings

## Testing
- Built and tested in Docker dev environment
- Verified nodes show different last seen times based on their actual activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)