### PR TITLE
fix: Divide traceroute SNR values by 4 to match protobuf spec

### DIFF
--- a/src/utils/traceroute.tsx
+++ b/src/utils/traceroute.tsx
@@ -91,8 +91,9 @@ export function formatTracerouteRoute(
       const nodeName = formatNodeName(nodeNum, nodes);
 
       // Get SNR for this hop (SNR array corresponds to hops between nodes)
+      // Note: Traceroute SNR values are scaled by 4 in the protobuf, so divide by 4
       const snrValue = snrArray[idx] !== undefined ? snrArray[idx] : null;
-      const snrDisplay = snrValue !== null ? ` (${snrValue} dB)` : '';
+      const snrDisplay = snrValue !== null ? ` (${(snrValue / 4).toFixed(1)} dB)` : '';
 
       // Check if this segment should be highlighted
       const isSegmentStart = options?.highlightSegment &&
@@ -111,7 +112,8 @@ export function formatTracerouteRoute(
       if (isSegmentStart) {
         const nextNodeName = formatNodeName(fullPath[idx + 1], nodes);
         const nextSnrValue = snrArray[idx + 1] !== undefined ? snrArray[idx + 1] : null;
-        const nextSnrDisplay = nextSnrValue !== null ? ` (${nextSnrValue} dB)` : '';
+        // Note: Traceroute SNR values are scaled by 4 in the protobuf, so divide by 4
+        const nextSnrDisplay = nextSnrValue !== null ? ` (${(nextSnrValue / 4).toFixed(1)} dB)` : '';
 
         pathElements.push(
           <span


### PR DESCRIPTION
## Summary
Fixes incorrect SNR display in traceroutes where values were showing 4x too high. This was caused by not accounting for the protobuf scaling factor.

## Root Cause
According to the Meshtastic protobuf specification (`protobufs/meshtastic/mesh.proto`):
- Line 902-904: `snr_towards` - "The list of SNRs (in dB, **scaled by 4**)"
- Line 912-914: `snr_back` - "The list of SNRs (in dB, **scaled by 4**)"

The `formatTracerouteRoute` utility function was displaying these scaled values directly without dividing by 4, resulting in SNR values that were 4x too high.

## Changes
- Updated `formatTracerouteRoute` in `src/utils/traceroute.tsx` to divide traceroute SNR values by 4
- Added explanatory comments about the protobuf scaling requirement
- Formatted SNR to 1 decimal place for consistency
- Applied fix to both regular path display and highlighted segment display

## Verification
- Existing SNR handling in `meshtasticManager.ts` (lines 1445, 1472, 1486, 1519, 1546, 1560) already divides by 4 correctly
- Map segment SNR display in `App.tsx` (lines 3576, 3619) already divides by 4 correctly
- This fix brings the `formatTracerouteRoute` utility in line with the rest of the codebase

## Important Note
Other SNR fields in the protobuf (`rx_snr`, `NeighborInfo.snr`) are regular floats and not scaled, so they remain unchanged.

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)