### PR TITLE
fix: Add id-token permission for Claude Code Action

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: read
+  id-token: write  # Required for Claude Code Action OIDC authentication
 
 concurrency:
   group: issue-triage-${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary
- Adds `id-token: write` permission to the issue-triage workflow to enable OIDC authentication for the Claude Code Action

## Problem
The automated issue triage workflow was failing with:
```
Failed to setup GitHub token: Error: Could not fetch an OIDC token.
Did you remember to add `id-token: write` to your workflow permissions?
```

Failed run: https://github.com/Yeraze/meshmonitor/actions/runs/18876794584

## Solution
Added `id-token: write` to the workflow permissions block. This allows the Claude Code Action to authenticate using GitHub's OIDC token provider.

## Test plan
- The workflow will run successfully on the next issue that's opened
- Can verify by checking the Actions tab after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)