### PR TITLE
feat: Add Node ID display in hex and decimal formats

### DIFF
--- a/src/components/NodeDetailsBlock.tsx
+++ b/src/components/NodeDetailsBlock.tsx
@@ -96,6 +96,22 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
     return formatRelativeTime(lastHeard * 1000, timeFormat, dateFormat, false);
   };
 
+  /**
+   * Format node ID in hex format
+   */
+  const formatNodeIdHex = (nodeNum: number | undefined): string => {
+    if (nodeNum === undefined || nodeNum === null) return 'N/A';
+    return `0x${nodeNum.toString(16).toUpperCase().padStart(8, '0')}`;
+  };
+
+  /**
+   * Format node ID in decimal format
+   */
+  const formatNodeIdDecimal = (nodeNum: number | undefined): string => {
+    if (nodeNum === undefined || nodeNum === null) return 'N/A';
+    return nodeNum.toString();
+  };
+
   const { deviceMetrics, snr, rssi, lastHeard, hopsAway, viaMqtt, user, firmwareVersion } = node;
   const hwModel = user?.hwModel;
   const role = user?.role;
@@ -171,6 +187,17 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
                 />
               )}
               <span className="hardware-name">{getHardwareModelShortName(hwModel)}</span>
+            </div>
+          </div>
+        )}
+
+        {/* Node ID */}
+        {node.nodeNum !== undefined && (
+          <div className="node-detail-card">
+            <div className="node-detail-label">Node ID</div>
+            <div className="node-detail-value">
+              <div>{formatNodeIdHex(node.nodeNum)}</div>
+              <div className="node-detail-secondary">{formatNodeIdDecimal(node.nodeNum)}</div>
             </div>
           </div>
         )}


### PR DESCRIPTION
Addresses #382

Extends the Node Details area on the messages page to display Node ID in both hex and decimal formats.

## Changes Made

- **Node ID Display**: Added hex format (e.g., `0x43588558`) as primary display
- **Decimal Format**: Added decimal format (e.g., `1129874776`) as secondary display
- **Formatting Functions**: 
  - `formatNodeIdHex()` - Converts node number to uppercase hex with 0x prefix, padded to 8 characters
  - `formatNodeIdDecimal()` - Displays raw decimal value
- **Positioning**: Node ID section placed between Hardware and Role sections for logical grouping
- **Styling**: Uses existing `.node-detail-secondary` CSS class for clean secondary text display

## Firmware Version

Firmware version was already implemented and displaying correctly in the Node Details block, so no additional changes were needed for that part of the feature request.

## Testing

- ✅ Node ID displays correctly in hex format
- ✅ Node ID displays correctly in decimal format
- ✅ Proper null checking prevents errors when node data unavailable
- ✅ Styling consistent with other node detail cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)