### PR TITLE
fix: Increase map pan offset for better popup visibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -796,10 +796,21 @@ function App() {
   // Open popup for selected node
   useEffect(() => {
     if (selectedNodeId) {
-      const marker = markerRefs.current.get(selectedNodeId);
-      if (marker) {
-        marker.openPopup();
-      }
+      // Delay opening popup to ensure MapCenterController completes first
+      // This prevents competing pan operations
+      const timer = setTimeout(() => {
+        const marker = markerRefs.current.get(selectedNodeId);
+        if (marker) {
+          // Open popup without autopanning - let MapCenterController handle positioning
+          const popup = marker.getPopup();
+          if (popup) {
+            popup.options.autoPan = false;
+          }
+          marker.openPopup();
+        }
+      }, 100); // Small delay to let MapCenterController start
+
+      return () => clearTimeout(timer);
     }
   }, [selectedNodeId]);
 

--- a/src/components/MapCenterController.tsx
+++ b/src/components/MapCenterController.tsx
@@ -21,19 +21,29 @@ export const MapCenterController: React.FC<MapCenterControllerProps> = ({
 
   useEffect(() => {
     if (centerTarget) {
-      // Listen for moveend event after setView completes, then pan to show popup
-      map.once('moveend', () => {
-        // Pan the map down by 220 pixels to account for popup height
-        // This ensures both the marker and the popup above it are fully visible
-        map.panBy([0, -220], { animate: true, duration: 0.3 });
+      // Get the map container height to calculate the center offset
+      const mapContainer = map.getContainer();
+      const mapHeight = mapContainer.clientHeight;
 
-        // Wait for the pan animation to complete before resetting
-        setTimeout(() => {
-          onCenterComplete(); // Reset target after all animations complete
-        }, 350); // Slightly longer than the 0.3s pan duration
-      });
+      // We want the popup (which appears above the marker) centered in viewport
+      // To do this, the marker needs to be below center
+      // In Leaflet's pixel coordinate system, Y increases downward
+      // So to move the target point UP in screen space, we SUBTRACT from Y
+      const panOffset = Math.floor(mapHeight / 4);
 
-      map.setView(centerTarget, 15); // Zoom level 15 for close view
+      // Calculate the pixel point to pan to
+      const targetPoint = map.project(centerTarget, 15);
+      const offsetPoint = targetPoint.subtract([0, panOffset]);
+      const offsetLatLng = map.unproject(offsetPoint, 15);
+
+      // Use setView with the offset position in a single operation
+      // This avoids multiple move events and competing animations
+      map.setView(offsetLatLng, 15, { animate: true, duration: 0.5 });
+
+      // Reset target after animation completes
+      setTimeout(() => {
+        onCenterComplete();
+      }, 550); // Slightly longer than animation duration
     }
   }, [centerTarget, onCenterComplete, map]);
 


### PR DESCRIPTION
Fixes #383

## Problem

When clicking on node markers on the map, the node detail popup was being cut off at the top of the screen. Users had to manually pan the map to see the full popup content.

## Root Cause

The original implementation had multiple issues causing inconsistent popup positioning:

1. **Competing animations**: The MapCenterController used `setView()` followed by `panBy()`, creating two separate move operations that could interfere with each other
2. **Immediate popup opening**: `openPopup()` was called immediately, potentially triggering Leaflet's built-in autopan before the MapCenterController finished
3. **Fixed offset**: A static 150-220px offset didn't adapt to different screen sizes

## Solution

Implemented a single-operation centering approach with dynamic viewport-relative offset:

1. **Single setView() operation**: Calculate the offset position in pixel space, then use a single `setView()` call to eliminate competing animations
2. **Dynamic offset**: Use 1/4 of the map viewport height instead of fixed pixels, adapting to different screen sizes
3. **Delayed popup opening**: Add 100ms delay before opening popup to prevent interference with map centering
4. **Correct coordinate math**: Use `subtract()` in Leaflet's pixel coordinate system where Y increases downward

## Changes

**src/components/MapCenterController.tsx**:
- Changed from two-step animation (`setView()` + `panBy()`) to single `setView()` operation
- Calculate offset as `Math.floor(mapHeight / 4)` for dynamic sizing
- Use `targetPoint.subtract([0, panOffset])` to move the target point UP in screen space
- Correctly account for Leaflet's coordinate system where Y increases downward

**src/App.tsx**:
- Add 100ms delay before calling `openPopup()` to prevent competing pan operations
- Explicitly set `popup.options.autoPan = false` to ensure no interference

## Testing

- ✅ Built and deployed successfully
- ✅ Popup now consistently centers in viewport
- ✅ Works across different screen sizes due to dynamic offset
- ✅ No more "fighting" animations or inconsistent behavior
- ✅ Smooth single animation to centered position

## Technical Details

The centering logic works by:
1. Converting target lat/lng to pixel coordinates
2. Calculating offset point by subtracting 1/4 map height from Y (moving point UP in pixel space)
3. Converting offset pixel point back to lat/lng
4. Using single `setView()` to smoothly animate to offset position
5. This positions the marker below viewport center, centering the popup above it

🤖 Generated with [Claude Code](https://claude.com/claude-code)