### PR TITLE
fix: Add GitHub token to Claude Code action for issue operations

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -87,6 +87,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           model: "claude-sonnet-4-20250514"
 
           direct_prompt: |
@@ -260,6 +261,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           model: "claude-sonnet-4-20250514"
 
           direct_prompt: |


### PR DESCRIPTION
## Summary

Fixes the Claude Issue Triage workflow that was failing with permission errors. The Claude Code action requires both `claude_code_oauth_token` (for AI) and `github_token` (for GitHub operations) to function properly.

## Changes

- Added `github_token: ${{ secrets.GITHUB_TOKEN }}` parameter to both Claude Code action steps in the issue-triage workflow
- Enables the action to comment on issues, add/remove labels, and close duplicate issues

## Issue Fixed

Resolves the failure in https://github.com/Yeraze/meshmonitor/actions/runs/18888992700

The workflow was failing with:
```
User does not have write access on this repository
```

## Testing

- All system tests pass (Configuration Import, Quick Start, Security, Reverse Proxy, OIDC)
- The workflow now has proper permissions defined and the required token parameter

## How It Works

The `GITHUB_TOKEN` is automatically provided by GitHub Actions and inherits the permissions already defined in the workflow file:
```yaml
permissions:
  contents: read
  issues: write
  pull-requests: read
  id-token: write
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)