### PR TITLE
docs: Reference meshtastic-serial-bridge for Serial/USB devices

### DIFF
--- a/docs/architecture/SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/SYSTEM_ARCHITECTURE.md
@@ -331,19 +331,25 @@ MeshMonitor → TCP:4403 → BLE Bridge → BLE → Meshtastic Node
 ```
 [MeshMonitor BLE Bridge](https://github.com/Yeraze/meshtastic-ble-bridge) provides TCP-to-BLE translation for Bluetooth Low Energy Meshtastic devices.
 
-**3. meshtasticd Proxy (Serial Nodes)**
+**3. Serial Bridge (USB/Serial Nodes)**
 ```
-MeshMonitor → TCP:4403 → meshtasticd → Serial → Meshtastic Node
+MeshMonitor → TCP:4403 → Serial Bridge → Serial/USB → Meshtastic Node
 ```
-[meshtasticd](https://github.com/meshtastic/python) provides TCP proxy for Serial/USB-connected Meshtastic devices.
+[Meshtastic Serial Bridge](https://github.com/Yeraze/meshtastic-serial-bridge) provides TCP-to-Serial translation for USB and Serial-connected Meshtastic devices.
 
-**4. HomeAssistant Integration**
+**4. meshtasticd Proxy (Virtual Nodes)**
+```
+MeshMonitor → TCP:4403 → meshtasticd (Virtual Node)
+```
+[meshtasticd](https://github.com/meshtastic/python) provides virtual Meshtastic node simulation for testing without physical hardware.
+
+**5. HomeAssistant Integration**
 ```
 MeshMonitor → TCP:4403 → HomeAssistant Meshtastic Integration → Node
 ```
 Connect through HomeAssistant's native Meshtastic support.
 
-**4. Custom TCP Proxies**
+**6. Custom TCP Proxies**
 ```
 MeshMonitor → TCP:4403 → Custom Proxy → Meshtastic Network
 ```

--- a/docs/configuration/ble-bridge.md
+++ b/docs/configuration/ble-bridge.md
@@ -24,7 +24,7 @@ Use the BLE Bridge when:
 **Do NOT use the BLE Bridge if:**
 
 - ❌ Your device has WiFi/Ethernet - connect directly via TCP instead
-- ❌ Your device is USB/Serial connected - use [meshtasticd](/configuration/meshtasticd) instead
+- ❌ Your device is USB/Serial connected - use the [Meshtastic Serial Bridge](https://github.com/Yeraze/meshtastic-serial-bridge) instead
 - ❌ Your system doesn't have Bluetooth hardware
 
 ## Prerequisites
@@ -409,6 +409,7 @@ The BLE bridge handles translation between these protocols automatically.
 If the BLE bridge doesn't meet your needs:
 
 - **WiFi/Ethernet devices:** Connect directly via TCP (no bridge needed)
-- **Serial/USB devices:** Use [meshtasticd](/configuration/meshtasticd) instead
+- **Serial/USB devices:** Use the [Meshtastic Serial Bridge](https://github.com/Yeraze/meshtastic-serial-bridge) instead
+- **Virtual nodes:** Use [meshtasticd](/configuration/meshtasticd) for testing without hardware
 - **HomeAssistant users:** Connect through HomeAssistant's Meshtastic integration
 - **Long-range BLE:** Consider using a BLE-to-WiFi bridge device

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -4,11 +4,14 @@ MeshMonitor is designed to be flexible and adaptable to various deployment scena
 
 ## Configuration Topics
 
+### [Serial Bridge for USB/Serial Devices](https://github.com/Yeraze/meshtastic-serial-bridge)
+Connect MeshMonitor to Serial or USB-connected Meshtastic devices using the Serial Bridge. Simple Docker-based TCP-to-Serial gateway with zero configuration.
+
 ### [BLE Bridge for Bluetooth Devices](/configuration/ble-bridge)
 Connect MeshMonitor to Bluetooth Low Energy (BLE) Meshtastic devices using the BLE Bridge. Perfect for portable devices and systems with Bluetooth support.
 
 ### [Using meshtasticd](/configuration/meshtasticd)
-Learn how to configure MeshMonitor to work with `meshtasticd`, the virtual Meshtastic node daemon, perfect for testing and development without physical hardware, or for Serial/USB-connected devices.
+Learn how to configure MeshMonitor to work with `meshtasticd`, the virtual Meshtastic node daemon, perfect for testing and development without physical hardware.
 
 ### [SSO Setup](/configuration/sso)
 Configure Single Sign-On (SSO) authentication using OpenID Connect (OIDC) for enterprise deployments and centralized identity management.
@@ -187,6 +190,7 @@ MeshMonitor logs to stdout/stderr by default. Configure log aggregation in your 
 
 ## Next Steps
 
+- [Connect Serial/USB devices](https://github.com/Yeraze/meshtastic-serial-bridge)
 - [Connect to Bluetooth devices](/configuration/ble-bridge)
 - [Configure meshtasticd](/configuration/meshtasticd)
 - [Set up SSO](/configuration/sso)

--- a/docs/configuration/meshtasticd.md
+++ b/docs/configuration/meshtasticd.md
@@ -1,23 +1,26 @@
-# Using meshtasticd
+# Using meshtasticd for Virtual Nodes
 
-`meshtasticd` is a virtual Meshtastic node daemon and TCP proxy that runs on your computer. It's perfect for development, testing, and connecting Serial/USB Meshtastic devices to MeshMonitor.
+`meshtasticd` is a virtual Meshtastic node daemon that simulates a Meshtastic device in software. It's perfect for development, testing, and running virtual mesh networks without physical hardware.
 
 ## What is meshtasticd?
 
-`meshtasticd` provides two main capabilities:
-
-1. **Virtual Node Simulation:** Run a software Meshtastic node without physical hardware
-2. **Serial/USB Proxy:** Bridge Serial/USB-connected devices to TCP for MeshMonitor
+`meshtasticd` provides **virtual node simulation** - running a software Meshtastic node without physical hardware.
 
 Use cases include:
 
 - Testing MeshMonitor without physical hardware
-- Connecting Serial/USB Meshtastic devices (not Bluetooth)
 - Running a virtual Meshtastic node on a server or Raspberry Pi
 - Developing and testing mesh applications
-- Creating virtual mesh networks
+- Creating virtual mesh networks for simulation and testing
 
-**Note:** For **Bluetooth (BLE)** devices, use the [MeshMonitor BLE Bridge](/configuration/ble-bridge) instead. `meshtasticd` does not support Bluetooth connections.
+## Physical Device Connections
+
+**For physical Meshtastic devices, use the appropriate bridge:**
+
+- **Serial/USB devices:** Use the [Meshtastic Serial Bridge](https://github.com/Yeraze/meshtastic-serial-bridge) instead
+- **Bluetooth (BLE) devices:** Use the [MeshMonitor BLE Bridge](/configuration/ble-bridge) instead
+
+`meshtasticd` is designed for virtual node simulation, not for connecting physical hardware.
 
 ## Installing meshtasticd
 
@@ -274,6 +277,7 @@ docker run -d \
 
 ## Next Steps
 
+- [Connect Serial/USB devices](https://github.com/Yeraze/meshtastic-serial-bridge) with the Serial Bridge
 - [Connect Bluetooth devices](/configuration/ble-bridge) with the BLE Bridge
 - [Configure SSO](/configuration/sso) for authentication
 - [Set up a reverse proxy](/configuration/reverse-proxy) for external access

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -155,19 +155,18 @@ npm run build:server
 npm start
 ```
 
-## Using with meshtasticd
+## Using with Physical or Virtual Devices
 
-If you're developing with a Bluetooth or Serial Meshtastic device, use `meshtasticd` as a TCP proxy:
+### Virtual Nodes with meshtasticd
+
+If you're developing without physical hardware, use `meshtasticd` for virtual node simulation:
 
 ```bash
 # Install meshtasticd
 pip install meshtasticd
 
-# For Bluetooth devices
-meshtasticd --ble-device "Meshtastic_1234"
-
-# For Serial devices
-meshtasticd --serial-port /dev/ttyUSB0
+# Run a virtual node
+meshtasticd --hwmodel RAK4631
 
 # Point MeshMonitor to localhost
 export MESHTASTIC_NODE_IP=localhost
@@ -175,6 +174,33 @@ npm run dev:full
 ```
 
 See the [meshtasticd configuration guide](/configuration/meshtasticd) for more details.
+
+### Serial/USB Devices
+
+For Serial or USB-connected Meshtastic devices, use the [Meshtastic Serial Bridge](https://github.com/Yeraze/meshtastic-serial-bridge):
+
+```bash
+# Run the serial bridge
+docker run -d --device /dev/ttyUSB0:/dev/ttyUSB0 -p 4403:4403 \
+  ghcr.io/yeraze/meshtastic-serial-bridge:latest
+
+# Point MeshMonitor to localhost
+export MESHTASTIC_NODE_IP=localhost
+npm run dev:full
+```
+
+### Bluetooth Devices
+
+For Bluetooth Low Energy (BLE) Meshtastic devices, use the [MeshMonitor BLE Bridge](/configuration/ble-bridge):
+
+```bash
+# Run the BLE bridge (see BLE Bridge documentation for setup)
+docker compose -f docker-compose.ble.yml up -d
+
+# Point MeshMonitor to localhost
+export MESHTASTIC_NODE_IP=localhost
+npm run dev:full
+```
 
 ## Development Environment Details
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -377,23 +377,35 @@ See the [BLE Bridge repository](https://github.com/Yeraze/meshtastic-ble-bridge)
 
 #### For Serial/USB Devices
 
-Use [meshtasticd](https://github.com/meshtastic/python/tree/master/meshtasticd) as a TCP proxy:
+Use the [Meshtastic Serial Bridge](https://github.com/Yeraze/meshtastic-serial-bridge) to create a TCP-to-Serial gateway:
 
 ```bash
-# Install meshtasticd
-pip install meshtasticd
+# Create docker-compose.yml with serial-bridge
+cat > docker-compose.yml << 'EOF'
+services:
+  serial-bridge:
+    image: ghcr.io/yeraze/meshtastic-serial-bridge:latest
+    container_name: meshtastic-serial-bridge
+    devices:
+      - /dev/ttyUSB0:/dev/ttyUSB0  # Change to your device
+    ports:
+      - "4403:4403"
+    restart: unless-stopped
 
-# For Serial devices:
-meshtasticd --serial-port /dev/ttyUSB0
+  meshmonitor:
+    image: ghcr.io/yeraze/meshmonitor:latest
+    environment:
+      - MESHTASTIC_NODE_IP=serial-bridge
+    depends_on:
+      - serial-bridge
+EOF
+
+docker compose up -d
 ```
 
-Then configure MeshMonitor to connect to meshtasticd:
+The serial bridge connects to your USB/Serial Meshtastic device and exposes it on TCP port 4403 for MeshMonitor.
 
-```yaml
-environment:
-  - MESHTASTIC_NODE_IP=localhost  # meshtasticd runs on localhost
-  - MESHTASTIC_TCP_PORT=4403      # Default meshtasticd port
-```
+See the [Serial Bridge repository](https://github.com/Yeraze/meshtastic-serial-bridge) for detailed setup instructions.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,6 +7,8 @@ This guide will help you get MeshMonitor up and running quickly.
 Before you begin, ensure you have:
 
 - A Meshtastic device connected to your network via IP (WiFi or Ethernet)
+- **OR** A Serial/USB device with the [Serial Bridge](https://github.com/Yeraze/meshtastic-serial-bridge)
+- **OR** A Bluetooth device with the [BLE Bridge](/configuration/ble-bridge)
 - **OR** `meshtasticd` running as a virtual node
 - Docker and Docker Compose installed (for Docker deployment)
 - **OR** Node.js 20+ and npm (for bare metal deployment)
@@ -164,9 +166,11 @@ ALLOWED_ORIGINS=https://meshmonitor.example.com # REQUIRED!
 - **`ALLOWED_ORIGINS`**: **CRITICAL** - Must match your HTTPS domain, or frontend won't load
 - **Rate limiting**: Stricter (1000 requests/15min vs 10,000)
 
-## Using with meshtasticd
+## Using with Virtual or Physical Devices
 
-If you're using `meshtasticd` (the virtual Meshtastic node daemon), make sure it's running and accessible before starting MeshMonitor:
+### Virtual Nodes with meshtasticd
+
+If you're using `meshtasticd` (the virtual Meshtastic node daemon) for testing without physical hardware:
 
 ```bash
 # Start meshtasticd (example)
@@ -178,6 +182,14 @@ docker compose up -d
 ```
 
 See the [meshtasticd configuration guide](/configuration/meshtasticd) for more details.
+
+### Serial/USB Devices
+
+For Serial or USB-connected Meshtastic devices, use the [Meshtastic Serial Bridge](https://github.com/Yeraze/meshtastic-serial-bridge) to expose your device on TCP port 4403.
+
+### Bluetooth Devices
+
+For Bluetooth Low Energy (BLE) Meshtastic devices, use the [MeshMonitor BLE Bridge](/configuration/ble-bridge) to create a TCP-to-BLE gateway.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Updated all documentation and FAQs to reference the new [meshtastic-serial-bridge](https://github.com/Yeraze/meshtastic-serial-bridge) project for Serial/USB-connected Meshtastic nodes. This follows the same pattern established for the BLE bridge documentation.

### Key Changes

- **Serial/USB devices** → Now reference meshtastic-serial-bridge with Docker Compose examples
- **meshtasticd** → Refocused as a virtual node simulator for testing without hardware
- **All docs updated** → FAQ, getting started, configuration guides, architecture, development setup, and README

### Files Modified

- `README.md` - Updated quick start and integration options
- `docs/faq.md` - Updated with Serial Bridge setup instructions
- `docs/configuration/meshtasticd.md` - Refocused on virtual nodes only
- `docs/configuration/index.md` - Added Serial Bridge as configuration option
- `docs/configuration/ble-bridge.md` - Updated references to Serial Bridge
- `docs/getting-started.md` - Added all device connection options
- `docs/architecture/SYSTEM_ARCHITECTURE.md` - Distinguished between bridges and virtual nodes
- `docs/development/setup.md` - Separated sections for each device type

## Test plan

- [x] Review all documentation changes for accuracy
- [x] Verify all links to meshtastic-serial-bridge repository are correct
- [x] Ensure Docker Compose examples are valid
- [x] Confirm meshtasticd documentation now focuses on virtual nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)