### PR TITLE
fix: Use PAT for Claude triage workflow to support external contributors

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -87,7 +87,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.CLAUDE_GITHUB_TOKEN }}
           model: "claude-sonnet-4-20250514"
 
           direct_prompt: |
@@ -261,7 +261,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.CLAUDE_GITHUB_TOKEN }}
           model: "claude-sonnet-4-20250514"
 
           direct_prompt: |


### PR DESCRIPTION
## Summary
- Switch from `GITHUB_TOKEN` to `CLAUDE_GITHUB_TOKEN` (PAT) for Claude Code action
- Remove permission checks (no longer needed with PAT)
- Enable Claude to triage issues from external contributors

## Problem
The workflow was failing when external contributors opened issues because the default `GITHUB_TOKEN` has limited permissions. Claude Code needs write access to:
- Comment on issues
- Add labels
- Close duplicate issues

Error message:
```
Actor has insufficient permissions: read
Actor does not have write permissions to the repository
```

## Solution
Use a Personal Access Token (PAT) stored as `CLAUDE_GITHUB_TOKEN` which has write permissions regardless of who triggers the workflow.

## Setup Required
Before merging, you need to:
1. Create a fine-grained PAT at https://github.com/settings/personal-access-tokens/new
2. Grant permissions: Issues (Read and write), Pull requests (Read and write)
3. Add it as a repository secret named `CLAUDE_GITHUB_TOKEN`

## Test Plan
- [x] System tests pass locally
- [ ] After adding PAT secret, test with an issue from external contributor

🤖 Generated with [Claude Code](https://claude.com/claude-code)