### PR TITLE
fix: Prevent backup type indicator from wrapping across lines

### DIFF
--- a/src/components/configuration/BackupManagementSection.tsx
+++ b/src/components/configuration/BackupManagementSection.tsx
@@ -437,7 +437,8 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
                             borderRadius: '4px',
                             fontSize: '0.8rem',
                             backgroundColor: backup.type === 'automatic' ? 'var(--ctp-blue)' : 'var(--ctp-mauve)',
-                            color: '#fff'
+                            color: '#fff',
+                            whiteSpace: 'nowrap'
                           }}>
                             {backup.type === 'automatic' ? '🤖 Auto' : '👤 Manual'}
                           </span>


### PR DESCRIPTION
## Summary

Fixes #400 - The backup type indicator (e.g., "👤 Manual" or "🤖 Auto") in the device configuration backup list modal was wrapping the emoji and text across two lines instead of keeping them together on a single line.

**Changes:**
- Added `whiteSpace: 'nowrap'` CSS property to the backup type indicator badge span in `BackupManagementSection.tsx:441`
- This matches the styling pattern already used for action buttons in the same table

**Visual Impact:**
- Before: Icon on one line, text ("Manual") on the next line
- After: Icon and text stay together on one line

## Test plan

- [x] Built Docker container with updated code
- [x] Verified the fix is present in the built JavaScript bundle
- [x] Ran full system test suite: **ALL TESTS PASSED** ✓
  - Configuration Import: ✓ PASSED
  - Quick Start Test: ✓ PASSED  
  - Security Test: ✓ PASSED
  - Reverse Proxy Test: ✓ PASSED
  - Reverse Proxy + OIDC: ✓ PASSED

**Manual verification:**
1. Navigate to Device Configuration section
2. Click "📋 Show Saved Backups"
3. Verify the Type column shows "👤 Manual" or "🤖 Auto" as single-line badges without wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)