### PR TITLE
fix: Update Security Scanner last scan timestamp

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.12.3
-appVersion: "2.12.3"
+version: 2.12.4
+appVersion: "2.12.4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.12.3",
+  "version": "2.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.12.3",
+      "version": "2.12.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bufbuild/protobuf": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.12.3",
+  "version": "2.12.4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/server/routes/securityRoutes.ts
+++ b/src/server/routes/securityRoutes.ts
@@ -51,24 +51,7 @@ router.get('/scanner/status', (_req: Request, res: Response) => {
   try {
     const status = duplicateKeySchedulerService.getStatus();
 
-    // Get last scan information from the most recently updated node
-    const nodesWithIssues = databaseService.getNodesWithKeySecurityIssues();
-    let lastScanTime: number | null = null;
-
-    if (nodesWithIssues.length > 0) {
-      // Find the most recently checked node
-      const allNodes = databaseService.getAllNodes();
-      const nodesWithKeys = allNodes.filter(n => n.publicKey);
-      if (nodesWithKeys.length > 0) {
-        // Use lastHeard as proxy for last scan (not perfect but works)
-        lastScanTime = Math.max(...nodesWithKeys.map(n => n.lastHeard || 0));
-      }
-    }
-
-    return res.json({
-      ...status,
-      lastScanTime
-    });
+    return res.json(status);
   } catch (error) {
     logger.error('Error getting scanner status:', error);
     return res.status(500).json({ error: 'Failed to get scanner status' });

--- a/src/server/services/duplicateKeySchedulerService.ts
+++ b/src/server/services/duplicateKeySchedulerService.ts
@@ -10,6 +10,7 @@ class DuplicateKeySchedulerService {
   private intervalId: NodeJS.Timeout | null = null;
   private scanInterval: number;
   private isScanning: boolean = false;
+  private lastScanTime: number | null = null;
 
   /**
    * @param intervalHours - How often to scan for duplicates (in hours). Default: 24 hours
@@ -93,6 +94,9 @@ class DuplicateKeySchedulerService {
           }
         }
 
+        // Update last scan time (Unix timestamp in seconds)
+        this.lastScanTime = Math.floor(Date.now() / 1000);
+
         this.isScanning = false;
         return;
       }
@@ -119,6 +123,9 @@ class DuplicateKeySchedulerService {
 
       logger.info(`✅ Duplicate key scan complete: ${updateCount} nodes flagged across ${duplicates.size} duplicate groups`);
 
+      // Update last scan time (Unix timestamp in seconds)
+      this.lastScanTime = Math.floor(Date.now() / 1000);
+
     } catch (error) {
       logger.error('Error during duplicate key scan:', error);
     } finally {
@@ -129,11 +136,12 @@ class DuplicateKeySchedulerService {
   /**
    * Get scanner status
    */
-  getStatus(): { running: boolean; scanningNow: boolean; intervalHours: number } {
+  getStatus(): { running: boolean; scanningNow: boolean; intervalHours: number; lastScanTime: number | null } {
     return {
       running: this.intervalId !== null,
       scanningNow: this.isScanning,
-      intervalHours: this.scanInterval / (60 * 60 * 1000)
+      intervalHours: this.scanInterval / (60 * 60 * 1000),
+      lastScanTime: this.lastScanTime
     };
   }
 }


### PR DESCRIPTION
## Summary
Fixes #418 - Security Scanner "Last Scan" field now properly updates when running manual scans.

## Changes
- Added `lastScanTime` property to `DuplicateKeySchedulerService` to track scan completion
- Updated `runScan()` to set timestamp when scans complete (both success and no-issues cases)
- Updated `getStatus()` to return `lastScanTime` in status response
- Removed broken workaround from `securityRoutes.ts` that incorrectly used `lastHeard` timestamps
- Bumped version to 2.12.4

## Technical Details
The previous implementation tried to infer scan time from node `lastHeard` timestamps, which represent when mesh messages were received, not when security scans ran. This resulted in the "Last Scan" field showing "Never" even after successful scans.

The fix properly tracks scan completion timestamps at the service level, ensuring accurate reporting in the Security tab UI.

## Test Plan
- [x] Built and tested with Docker dev environment
- [x] Verified code compiles without errors
- [ ] Manually verify "Last Scan" updates after clicking "Run Scan Now"

🤖 Generated with [Claude Code](https://claude.com/claude-code)