### PR TITLE
feat: Add security notification buttons to Security tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4725,7 +4725,7 @@ function App() {
         {activeTab === 'notifications' && <NotificationsTab isAdmin={authStatus?.user?.isAdmin || false} />}
         {activeTab === 'users' && <UsersTab />}
         {activeTab === 'audit' && <AuditLogTab />}
-        {activeTab === 'security' && <SecurityTab onTabChange={setActiveTab} onSelectDMNode={setSelectedDMNode} />}
+        {activeTab === 'security' && <SecurityTab onTabChange={setActiveTab} onSelectDMNode={setSelectedDMNode} setNewMessage={setNewMessage} />}
       </main>
 
       {/* Node Popup */}

--- a/src/styles/SecurityTab.css
+++ b/src/styles/SecurityTab.css
@@ -277,6 +277,29 @@
   margin-left: 10px;
 }
 
+.send-notification-btn {
+  background: #007bff;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  font-weight: bold;
+  transition: background 0.2s, transform 0.1s;
+  margin-left: 8px;
+  min-width: 36px;
+}
+
+.send-notification-btn:hover {
+  background: #0056b3;
+  transform: scale(1.05);
+}
+
+.send-notification-btn:active {
+  transform: scale(0.95);
+}
+
 .issue-details {
   padding: 20px;
   border-top: 1px solid #dee2e6;
@@ -413,6 +436,12 @@
   font-size: 12px;
   color: #999;
   font-family: monospace;
+}
+
+.duplicate-node-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .group-recommendations {


### PR DESCRIPTION
## Summary
- Add send buttons next to each node on the Security page
- Navigate to Direct Messages with pre-populated security notifications  
- Buttons display send icon (→) next to each affected node

## Changes
- Added send notification button to low-entropy keys section
- Added send notification button to duplicate keys section
- Pre-populate message based on security issue type:
  * **Low entropy:** "MeshMonitor Security Notification: Your node has a low entropy key. Read more: https://bit.ly/4oL5m0P"
  * **Duplicate key:** "MeshMonitor Security Notification: Your node has a key shared with N other nearby nodes. Read more: https://bit.ly/4okVACV"
- Navigate to messages tab and select the target node's conversation
- Style buttons with blue color, hover effects, and proper spacing

## Test plan
- [x] TypeScript type checking passes
- [x] Build succeeds
- [x] All system tests pass:
  - Configuration Import test
  - Quick Start test  
  - Security Test
  - Reverse Proxy test
  - Reverse Proxy + OIDC test
- [ ] Manual verification: Click send button on Security page
- [ ] Verify navigation to Direct Messages tab
- [ ] Verify message is pre-populated with correct notification
- [ ] Verify correct node conversation is selected

## Screenshots
N/A - UI feature enhancement

🤖 Generated with [Claude Code](https://claude.com/claude-code)