### PR TITLE
chore: Bump version to 2.13.3 and update documentation

### DIFF
--- a/RELEASE_NOTES_v2.13.3.md
+++ b/RELEASE_NOTES_v2.13.3.md
@@ -1,0 +1,82 @@
+# v2.13.3 - Map Customization & Security Scanner Improvements
+
+This release introduces customizable map pin styles, fixes security scanner counting issues, and includes dependency updates.
+
+## 🚀 Features
+
+### Map Pin Style Customization
+**[#451](https://github.com/Yeraze/meshmonitor/pull/451) - Add Map Pin Style setting and fix map label display**
+
+New map visualization options with two pin styles:
+
+- **New Map Pin Style setting** in Settings > Display Preferences
+- **MeshMonitor style** (default): Pin/tower markers with zoom-based labels (labels appear at zoom level ≥ 13)
+- **Official Meshtastic style**: Circle markers with always-visible short names in center
+- **Fixed map label display** by restoring accidentally deleted `ZoomHandler.tsx` component
+- Setting persists across browser sessions with database storage
+- Improved icon anchoring for both styles
+
+## 🐛 Bug Fixes
+
+### Security Scanner Improvements
+**[#450](https://github.com/Yeraze/meshmonitor/pull/450) - fix: Clear orphaned duplicate key flags in security scanner**
+
+Fixed counting mismatch on Security page:
+
+- **Resolved discrepancy** where backend reported more duplicate nodes than displayed in UI
+- **Clears orphaned duplicate flags** when a node's duplicate partner disappears from network
+- **Accurate counts** that match what's displayed in the UI
+- Updated `duplicateKeySchedulerService.ts` to maintain flag consistency
+
+## 🔧 Dependencies
+
+- **[#441](https://github.com/Yeraze/meshmonitor/pull/441)** - chore(deps): Bump express-rate-limit from 8.1.0 to 8.2.1
+- **[#438](https://github.com/Yeraze/meshmonitor/pull/438)** - chore(deps-dev): Bump the production-dependencies group with 3 updates
+- **[#437](https://github.com/Yeraze/meshmonitor/pull/437)** - chore(deps-dev): Bump the development-dependencies group with 4 updates
+
+## 💡 What's Changed
+
+Full Changelog: [v2.13.2...v2.13.3](https://github.com/Yeraze/meshmonitor/compare/v2.13.2...v2.13.3)
+
+## 🚀 MeshMonitor v2.13.3
+
+### 📦 Installation
+
+**Docker (recommended):**
+```bash
+docker run -d \
+  --name meshmonitor \
+  -p 8080:3001 \
+  -v meshmonitor-data:/data \
+  ghcr.io/yeraze/meshmonitor:v2.13.3
+```
+
+**Docker Compose:**
+```yaml
+services:
+  meshmonitor:
+    image: ghcr.io/yeraze/meshmonitor:v2.13.3
+    container_name: meshmonitor
+    ports:
+      - "8080:3001"
+    volumes:
+      - meshmonitor-data:/data
+    environment:
+      - MESHTASTIC_NODE_IP=192.168.1.100  # Change to your node's IP
+    restart: unless-stopped
+
+volumes:
+  meshmonitor-data:
+```
+
+### 🧪 Testing
+All system tests passed:
+- Configuration Import: ✓ PASSED
+- Quick Start Test: ✓ PASSED
+- Security Test: ✓ PASSED
+- Reverse Proxy Test: ✓ PASSED
+- Reverse Proxy + OIDC: ✓ PASSED
+- Virtual Node CLI Test: ✓ PASSED
+
+✅ TypeScript checks passed
+✅ Docker images built for linux/amd64, linux/arm64, linux/arm/v7

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,12 +1,21 @@
 # TODO List
 
-## Mobile UI Improvements
+## Version 2.13.3 Release Tasks
+
+- [x] Update version in package.json to 2.13.3
+- [x] Update version in Helm chart to 2.13.3
+- [x] Regenerate package-lock.json
+- [x] Update documentation with recent changes
+
+## Completed Tasks
+
+### Mobile UI Improvements
 
 - [x] Add unread message indicator to dropdown on Messages page
 - [x] Reflow Security page rows to 2 lines for mobile display
 - [x] Break Device Backup modal onto 2 lines for mobile compatibility
 
-## Virtual Node Enhancements
+### Virtual Node Enhancements
 
 - [x] Add Virtual Node status block to Info page showing connection status and number of connected clients
 - [x] Display IP addresses of connected Virtual Node clients when authenticated

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.13.2
-appVersion: "2.13.2"
+version: 2.13.3
+appVersion: "2.13.3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.13.2",
+      "version": "2.13.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Bump version to 2.13.3 and create comprehensive release documentation summarizing recent features and bug fixes.

## Changes

- **Version Updates**: Updated version to 2.13.3 in package.json, Helm Chart.yaml, and package-lock.json
- **Release Notes**: Created RELEASE_NOTES_v2.13.3.md documenting all changes since v2.13.2
- **Documentation**: Updated TODOS.md to track version release completion

## Release Highlights (v2.13.3)

### Features
- **Map Pin Style Customization** (#451) - Users can now choose between MeshMonitor style (pin/tower markers with zoom-based labels) and Official Meshtastic style (circle markers with always-visible names)

### Bug Fixes
- **Security Scanner Improvements** (#450) - Fixed counting discrepancy where orphaned duplicate key flags weren't being cleared when nodes disappeared from the network

### Dependencies
- **express-rate-limit** updated from 8.1.0 to 8.2.1 (#441)
- **Development dependencies** updated (#437, #438)

## Test Results

All system tests passed:
- ✓ Configuration Import test
- ✓ Quick Start test  
- ✓ Security test
- ✓ Reverse Proxy test
- ✓ Reverse Proxy + OIDC test
- ✓ Virtual Node CLI test

🤖 Generated with [Claude Code](https://claude.com/claude-code)