### PR TITLE
feat: Add localhost to default ALLOWED_ORIGINS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,7 @@ MESHTASTIC_TCP_PORT=4403
 
 # CORS Configuration
 # ALLOWED_ORIGINS: Comma-separated list of allowed origins for CORS
-# REQUIRED: Must be set to match how you access MeshMonitor, even for localhost
+# Default: http://localhost:8080,http://localhost:3001 (if not specified)
 #
 # For localhost access (most common for Docker deployments):
 #   ALLOWED_ORIGINS=http://localhost:8080
@@ -78,8 +78,7 @@ MESHTASTIC_TCP_PORT=4403
 # Wildcard (NOT recommended for production, testing only):
 #   ALLOWED_ORIGINS=*
 #
-# If blank in development mode, defaults to http://localhost:3000,http://localhost:5173,http://localhost:8080
-# However, it's best practice to explicitly set this value to avoid CORS issues
+# For production deployments, it's best practice to explicitly set this value
 ALLOWED_ORIGINS=http://localhost:8080
 
 # Web Push Notification Configuration (VAPID keys)

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -78,7 +78,7 @@ See the [Virtual Node Server guide](/configuration/virtual-node) for detailed co
 | `COOKIE_SAMESITE` | Cookie SameSite policy (`strict`, `lax`, or `none`) | `strict` in production |
 | `SESSION_MAX_AGE` | Session cookie lifetime in milliseconds | `86400000` (24 hours) |
 | `SESSION_ROLLING` | Reset session expiry on each request (keeps active users logged in) | `true` |
-| `ALLOWED_ORIGINS` | **REQUIRED for HTTPS/reverse proxy**: Comma-separated list of allowed CORS origins | localhost URLs in development |
+| `ALLOWED_ORIGINS` | **REQUIRED for HTTPS/reverse proxy**: Comma-separated list of allowed CORS origins | `http://localhost:8080, http://localhost:3001` |
 
 ### Authentication Variables
 

--- a/src/server/config/environment.ts
+++ b/src/server/config/environment.ts
@@ -281,7 +281,9 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
 
   const allowedOriginsRaw = process.env.ALLOWED_ORIGINS;
   const allowedOrigins = {
-    value: allowedOriginsRaw ? allowedOriginsRaw.split(',').map(o => o.trim()).filter(o => o.length > 0) : [],
+    value: allowedOriginsRaw
+      ? allowedOriginsRaw.split(',').map(o => o.trim()).filter(o => o.length > 0)
+      : ['http://localhost:8080', 'http://localhost:3001'],
     wasProvided: allowedOriginsRaw !== undefined
   };
   const trustProxy = parseTrustProxy('TRUST_PROXY', process.env.TRUST_PROXY, false);


### PR DESCRIPTION
## Summary
- Improved default CORS configuration for better out-of-box experience
- ALLOWED_ORIGINS now defaults to localhost URLs when not specified
- Explicit configuration still required for production deployments

## Changes
When `ALLOWED_ORIGINS` is not specified in the environment, it now defaults to:
- `http://localhost:8080` (typical frontend port)
- `http://localhost:3001` (backend port)

This eliminates common CORS errors during local development and testing while maintaining security by requiring explicit configuration for production deployments with different domains or HTTPS.

### Files Modified
- `src/server/config/environment.ts`: Updated default from empty array to localhost URLs
- `.env.example`: Updated documentation to reflect new default behavior
- `docs/configuration/index.md`: Updated configuration table with explicit default values

## Test plan
- [x] System tests run (CORS test passed, unrelated failures are pre-existing)
- [x] Build successful
- [x] No breaking changes to existing configurations

## Notes
- Test failures in system-tests.sh are unrelated to this change (hardware connectivity issues)
- CORS configuration test passed: "✓ PASS: CORS configured for allowed origin"
- Users with existing ALLOWED_ORIGINS configurations are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)