### PR TITLE
chore: Release version 2.13.4

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -2,26 +2,38 @@
 
 ## Current Sprint
 
-### Configuration Improvements
+## Version 2.13.4 Release Tasks
+
+- [x] Update version in package.json to 2.13.4
+- [x] Update version in Helm chart to 2.13.4
+- [x] Regenerate package-lock.json
+- [x] Run system tests
+- [ ] Create pull request
+- [ ] Merge and create release
+
+## Completed Tasks
+
+### Version 2.13.4 (Current Release)
+
+#### Configuration Improvements
 - [x] Add localhost to default ALLOWED_ORIGINS configuration (#458)
   - Changed default from empty array to `['http://localhost:8080', 'http://localhost:3001']`
   - Improves out-of-box experience for local development and testing
   - Still requires explicit configuration for production deployments
   - Files: src/server/config/environment.ts:282-288, .env.example, docs/configuration/index.md:81
 
-### Bug Fixes
-- [x] Fix traceroute visualization not updating when clicking different nodes
+#### Documentation Enhancements
+- [x] Add interactive Docker Compose configurator to documentation (#454)
+
+#### Bug Fixes
+- [x] Fix traceroute visualization not updating when clicking different nodes (#457)
   - Issue: NodesTab memo comparison only checked null vs non-null for traceroutes
   - Fixed by adding reference comparison to detect when traceroute content changes (src/components/NodesTab.tsx:1110-1114)
 
-## Version 2.13.3 Release Tasks
+#### Chores
+- [x] Update TODOS.md with ALLOWED_ORIGINS configuration improvement (#459)
 
-- [x] Update version in package.json to 2.13.3
-- [x] Update version in Helm chart to 2.13.3
-- [x] Regenerate package-lock.json
-- [x] Update documentation with recent changes
-
-## Completed Tasks
+### Version 2.13.3
 
 ### Mobile UI Improvements
 

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.13.3
-appVersion: "2.13.3"
+version: 2.13.4
+appVersion: "2.13.4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.13.3",
+      "version": "2.13.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

This release includes configuration improvements, documentation enhancements, and bug fixes since version 2.13.3.

### Configuration Improvements
- Add localhost to default ALLOWED_ORIGINS configuration (#458)
  - Changed default from empty array to `['http://localhost:8080', 'http://localhost:3001']`
  - Improves out-of-box experience for local development and testing

### Documentation Enhancements  
- Add interactive Docker Compose configurator to documentation (#454)

### Bug Fixes
- Fix traceroute visualization not updating when selecting different nodes (#457)
  - Fixed memo comparison to detect when traceroute content changes

### Chores
- Update TODOS.md with ALLOWED_ORIGINS configuration improvement (#459)

## Test Results

All system tests passed:
- ✅ Configuration Import
- ✅ Quick Start Test (includes security test)
- ✅ Reverse Proxy Test
- ✅ Reverse Proxy + OIDC
- ✅ Virtual Node CLI Test

## Version Changes
- package.json: 2.13.3 → 2.13.4
- helm/meshmonitor/Chart.yaml: 2.13.3 → 2.13.4
- Updated TODOS.md with release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)