### PR TITLE
chore: Mark version 2.13.4 release tasks as complete

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -8,8 +8,8 @@
 - [x] Update version in Helm chart to 2.13.4
 - [x] Regenerate package-lock.json
 - [x] Run system tests
-- [ ] Create pull request
-- [ ] Merge and create release
+- [x] Create pull request (#460)
+- [x] Merge and create release (v2.13.4)
 
 ## Completed Tasks
 


### PR DESCRIPTION
## Summary

Updates TODOS.md to reflect the successful completion of the v2.13.4 release.

## Changes
- Marked PR #460 as created and merged
- Marked GitHub release v2.13.4 as published
- All version 2.13.4 release tasks now complete

This is a documentation-only change to keep the TODOS.md file in sync with the actual release state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)