### PR TITLE
feat: Add collapsible Node Details section on Messages page

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.15.0
-appVersion: "2.15.0"
+version: 2.15.1
+appVersion: "2.15.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.15.0",
+      "version": "2.15.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/components/NodeDetailsBlock.css
+++ b/src/components/NodeDetailsBlock.css
@@ -7,11 +7,39 @@
   border-radius: 8px;
 }
 
+.node-details-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
 .node-details-title {
   color: #cdd6f4; /* var(--ctp-text) */
-  margin: 0 0 20px 0;
+  margin: 0;
   font-size: 1.2rem;
   font-weight: 600;
+}
+
+.node-details-toggle {
+  background: none;
+  border: none;
+  color: #cdd6f4; /* var(--ctp-text) */
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 5px 10px;
+  border-radius: 4px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.node-details-toggle:hover {
+  background-color: #313244; /* var(--ctp-surface0) */
+  color: #89b4fa; /* var(--ctp-blue) */
+}
+
+.node-details-toggle:focus {
+  outline: 2px solid #89b4fa; /* var(--ctp-blue) */
+  outline-offset: 2px;
 }
 
 .node-details-grid {

--- a/src/components/NodeDetailsBlock.tsx
+++ b/src/components/NodeDetailsBlock.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { DeviceInfo } from '../types/device';
 import { getHardwareModelShortName } from '../utils/hardwareModel';
 import { getDeviceRoleName } from '../utils/deviceRole';
@@ -16,6 +16,14 @@ interface NodeDetailsBlockProps {
 
 const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = '24', dateFormat = 'MM/DD/YYYY' }) => {
   const { channels } = useData();
+  const [isCollapsed, setIsCollapsed] = useState<boolean>(() => {
+    const stored = localStorage.getItem('nodeDetailsCollapsed');
+    return stored === 'true';
+  });
+
+  useEffect(() => {
+    localStorage.setItem('nodeDetailsCollapsed', isCollapsed.toString());
+  }, [isCollapsed]);
 
   if (!node) {
     return null;
@@ -122,77 +130,87 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
 
   return (
     <div className="node-details-block">
-      <h3 className="node-details-title">Node Details</h3>
-      <div className="node-details-grid">
-        {/* Battery Status */}
-        {(deviceMetrics?.batteryLevel !== undefined || deviceMetrics?.voltage !== undefined) && (
-          <div className="node-detail-card">
-            <div className="node-detail-label">Battery</div>
-            <div className={`node-detail-value ${getBatteryClass(deviceMetrics?.batteryLevel)}`}>
-              {formatBatteryLevel(deviceMetrics?.batteryLevel)}
-              {deviceMetrics?.voltage !== undefined && (
-                <span className="node-detail-secondary"> ({formatVoltage(deviceMetrics.voltage)})</span>
-              )}
+      <div className="node-details-header">
+        <h3 className="node-details-title">Node Details</h3>
+        <button
+          className="node-details-toggle"
+          onClick={() => setIsCollapsed(!isCollapsed)}
+          aria-label={isCollapsed ? 'Expand node details' : 'Collapse node details'}
+        >
+          {isCollapsed ? '▼' : '▲'}
+        </button>
+      </div>
+      {!isCollapsed && (
+        <div className="node-details-grid">
+          {/* Hardware Model - Now First */}
+          {hwModel !== undefined && (
+            <div className="node-detail-card node-detail-card-hardware">
+              <div className="node-detail-label">Hardware</div>
+              <div className="node-detail-value node-detail-hardware-content">
+                {hardwareImageUrl && (
+                  <img
+                    src={hardwareImageUrl}
+                    alt={getHardwareModelShortName(hwModel)}
+                    className="hardware-image"
+                  />
+                )}
+                <span className="hardware-name">{getHardwareModelShortName(hwModel)}</span>
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Signal Quality - SNR */}
-        {snr !== undefined && (
-          <div className="node-detail-card">
-            <div className="node-detail-label">Signal (SNR)</div>
-            <div className={`node-detail-value ${getSignalClass(snr)}`}>
-              {formatSNR(snr)}
+          {/* Battery Status */}
+          {(deviceMetrics?.batteryLevel !== undefined || deviceMetrics?.voltage !== undefined) && (
+            <div className="node-detail-card">
+              <div className="node-detail-label">Battery</div>
+              <div className={`node-detail-value ${getBatteryClass(deviceMetrics?.batteryLevel)}`}>
+                {formatBatteryLevel(deviceMetrics?.batteryLevel)}
+                {deviceMetrics?.voltage !== undefined && (
+                  <span className="node-detail-secondary"> ({formatVoltage(deviceMetrics.voltage)})</span>
+                )}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Signal Quality - RSSI */}
-        {rssi !== undefined && (
-          <div className="node-detail-card">
-            <div className="node-detail-label">Signal (RSSI)</div>
-            <div className="node-detail-value">
-              {formatRSSI(rssi)}
+          {/* Signal Quality - SNR */}
+          {snr !== undefined && (
+            <div className="node-detail-card">
+              <div className="node-detail-label">Signal (SNR)</div>
+              <div className={`node-detail-value ${getSignalClass(snr)}`}>
+                {formatSNR(snr)}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Channel Utilization */}
-        {deviceMetrics?.channelUtilization !== undefined && (
-          <div className="node-detail-card">
-            <div className="node-detail-label">Channel Utilization</div>
-            <div className={`node-detail-value ${getUtilizationClass(deviceMetrics.channelUtilization)}`}>
-              {formatUtilization(deviceMetrics.channelUtilization)}
+          {/* Signal Quality - RSSI */}
+          {rssi !== undefined && (
+            <div className="node-detail-card">
+              <div className="node-detail-label">Signal (RSSI)</div>
+              <div className="node-detail-value">
+                {formatRSSI(rssi)}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Air Utilization TX */}
-        {deviceMetrics?.airUtilTx !== undefined && (
-          <div className="node-detail-card">
-            <div className="node-detail-label">Air Utilization TX</div>
-            <div className={`node-detail-value ${getUtilizationClass(deviceMetrics.airUtilTx)}`}>
-              {formatUtilization(deviceMetrics.airUtilTx)}
+          {/* Channel Utilization */}
+          {deviceMetrics?.channelUtilization !== undefined && (
+            <div className="node-detail-card">
+              <div className="node-detail-label">Channel Utilization</div>
+              <div className={`node-detail-value ${getUtilizationClass(deviceMetrics.channelUtilization)}`}>
+                {formatUtilization(deviceMetrics.channelUtilization)}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Hardware Model */}
-        {hwModel !== undefined && (
-          <div className="node-detail-card node-detail-card-hardware">
-            <div className="node-detail-label">Hardware</div>
-            <div className="node-detail-value node-detail-hardware-content">
-              {hardwareImageUrl && (
-                <img
-                  src={hardwareImageUrl}
-                  alt={getHardwareModelShortName(hwModel)}
-                  className="hardware-image"
-                />
-              )}
-              <span className="hardware-name">{getHardwareModelShortName(hwModel)}</span>
+          {/* Air Utilization TX */}
+          {deviceMetrics?.airUtilTx !== undefined && (
+            <div className="node-detail-card">
+              <div className="node-detail-label">Air Utilization TX</div>
+              <div className={`node-detail-value ${getUtilizationClass(deviceMetrics.airUtilTx)}`}>
+                {formatUtilization(deviceMetrics.airUtilTx)}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
         {/* Node ID */}
         {node.nodeNum !== undefined && (
@@ -260,16 +278,17 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
           </div>
         )}
 
-        {/* Last Heard */}
-        {lastHeard !== undefined && (
-          <div className="node-detail-card">
-            <div className="node-detail-label">Last Heard</div>
-            <div className="node-detail-value">
-              {formatLastHeard(lastHeard)}
+          {/* Last Heard */}
+          {lastHeard !== undefined && (
+            <div className="node-detail-card">
+              <div className="node-detail-label">Last Heard</div>
+              <div className="node-detail-value">
+                {formatLastHeard(lastHeard)}
+              </div>
             </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Move Hardware box to first position in Node Detail area for better visibility
- Add collapsible functionality to Node Details section with toggle button
- Persist collapsed state in localStorage for user preference
- Bump version to 2.15.1

## Changes
- **NodeDetailsBlock.tsx**: 
  - Added React state management for collapse/expand functionality
  - Moved Hardware card to first position in grid
  - Added collapsible wrapper with conditional rendering
  - Implemented localStorage persistence for collapsed state
  
- **NodeDetailsBlock.css**:
  - Added header flexbox layout for title and toggle button
  - Styled toggle button with hover and focus states
  - Accessibility improvements with proper focus indicators

- **Version Updates**:
  - package.json: 2.15.0 → 2.15.1
  - helm/meshmonitor/Chart.yaml: 2.15.0 → 2.15.1
  - package-lock.json: Regenerated

## Test Plan
- [x] Build succeeds in Docker
- [x] Container starts and runs correctly
- [x] All system tests pass (Configuration Import, Quick Start, Security, Reverse Proxy, OIDC, Virtual Node CLI)
- [x] Hardware box appears first in Node Details grid
- [x] Toggle button expands/collapses section
- [x] State persists across page reloads
- [x] Accessibility: Toggle button has proper aria-labels and focus states

## Screenshots
The Node Details section now features:
- Hardware information prominently displayed first
- Collapsible header with ▲/▼ toggle button
- State persistence using localStorage key `nodeDetailsCollapsed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)