### PR TITLE
fix: Improve upgrade timing and reduce API polling

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.15.1
-appVersion: "2.15.1"
+version: 2.15.2
+appVersion: "2.15.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.15.1",
+      "version": "2.15.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Fixes two issues with the automatic upgrade functionality:

1. **Premature upgrade prompts before container images are ready**
2. **Excessive API polling (2x per second) when update banner visible**

## Changes

### Issue 1: Premature Upgrade Prompts

**Root Cause:** The Docker image availability check incorrectly treated HTTP 401 (Unauthorized) as "image exists". However, GHCR returns 401 for **all** unauthenticated requests, even for non-existent images, making it impossible to differentiate.

**Fix:**
- Updated `checkDockerImageExists()` in `src/server/server.ts:3033-3092`
- Only trust HTTP 200 as definitive "image exists" signal
- For HTTP 401 responses, use time-based heuristic: wait 15 minutes after release publication
- GitHub Actions typically needs 10-15 minutes to build and push container images
- Reduced version check cache from 1 hour to 5 minutes for faster image availability detection

### Issue 2: Excessive API Polling

**Root Cause:** The `authFetch` function was recreated on every component render (not memoized), causing the upgrade status check useEffect to run on every render instead of just once.

**Fix:**
- Wrapped `authFetch` in `useCallback` in `src/App.tsx:568-627`
- Also increased base polling interval from 5s to 10s during active upgrades
- Increased max polling interval from 15s to 30s

## Test Results

✅ All system tests passed:
- Configuration Import Test
- Quick Start Test  
- Security Test
- Reverse Proxy Test
- Reverse Proxy + OIDC Test
- Virtual Node CLI Test

## Files Changed

- `src/server/server.ts` - Docker image availability check logic
- `src/App.tsx` - Memoized authFetch and adjusted polling intervals
- `package.json` - Version bump to 2.15.2
- `helm/meshmonitor/Chart.yaml` - Version bump to 2.15.2
- `package-lock.json` - Updated lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)