### PR TITLE
docs: Fix iOS Virtual Node connection instructions (#493)

### DIFF
--- a/docs/configuration/virtual-node.md
+++ b/docs/configuration/virtual-node.md
@@ -112,12 +112,12 @@ service:
 ### iOS (Official Meshtastic App)
 
 1. Open the Meshtastic iOS app
-2. Go to **Settings** > **Radio Configuration**
-3. Select **Network** as your connection type
+2. From the Connection screen, tap **Manual**
+3. Select **TCP** as the connection type
 4. Enter your MeshMonitor server details:
-   - **Host**: Your MeshMonitor server IP or hostname
+   - **Address**: Your MeshMonitor server IP or hostname
    - **Port**: `4404` (or your custom VIRTUAL_NODE_PORT)
-5. Save and connect
+5. Tap **Connect**
 
 The app will connect to MeshMonitor's Virtual Node Server instead of directly to your physical node.
 


### PR DESCRIPTION
## Summary

Fixes #493 - Corrects the iOS app connection instructions for the Virtual Node Server.

### Issue

The documentation provided incorrect steps for connecting the iOS Meshtastic app to MeshMonitor's Virtual Node Server.

### Changes

**Before (Incorrect):**
1. Open the Meshtastic iOS app
2. Go to Settings > Radio Configuration
3. Select Network as your connection type
4. Enter Host and Port
5. Save and connect

**After (Correct):**
1. Open the Meshtastic iOS app
2. From the Connection screen, tap **Manual**
3. Select **TCP** as the connection type
4. Enter Address and Port
5. Tap **Connect**

### Files Modified

- `docs/configuration/virtual-node.md` - Updated iOS connection instructions (lines 112-122)

### Testing

Documentation-only change. No code or functional changes required.

### Resolves

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)