### PR TITLE
fix: Allow hop filter min/max of 0 and improve Packet Monitor fonts (#497)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2835,7 +2835,10 @@ function App() {
                     min="0"
                     max="10"
                     value={nodeFilters.maxHops}
-                    onChange={(e) => setNodeFilters({...nodeFilters, maxHops: parseInt(e.target.value) || 10})}
+                    onChange={(e) => {
+                      const val = parseInt(e.target.value);
+                      setNodeFilters({...nodeFilters, maxHops: isNaN(val) ? 10 : val});
+                    }}
                   />
                 </div>
               </div>

--- a/src/components/PacketMonitorPanel.css
+++ b/src/components/PacketMonitorPanel.css
@@ -199,15 +199,13 @@
 }
 
 .packet-table .timestamp {
-  font-family: 'Courier New', monospace;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--text-secondary);
 }
 
 .packet-table .from-node,
 .packet-table .to-node {
-  font-family: 'Courier New', monospace;
-  font-size: 11px;
+  font-size: 12px;
 }
 
 .node-id-link {


### PR DESCRIPTION
## Summary

Two minor UI improvements to enhance usability:

1. **Hop Filter Fix**: Allow hop filter max value to be set to 0 (was incorrectly defaulting to 10)
   - Fixed bug in `src/App.tsx:2838` where `parseInt(e.target.value) || 10` prevented setting max hops to 0
   - Now users can filter nodes by 0-0 hops to show only direct connections

2. **Packet Monitor Font Improvements**: Make Time, From, and To fields more readable
   - Removed monospace font from Time, From, and To columns
   - Increased font size from 11px to 12px
   - Fields now use consistent, readable system font like the Content field

## Test Plan

✅ All system tests passed successfully:

- ✅ Configuration Import Test
- ✅ Quick Start Test  
- ✅ Security Test
- ✅ Reverse Proxy Test
- ✅ Reverse Proxy + OIDC Test
- ✅ Virtual Node CLI Test

See test results in build output.

## Changes

- `src/App.tsx`: Fixed maxHops filter logic to properly handle 0 value
- `src/components/PacketMonitorPanel.css`: Removed monospace font and increased size for better readability

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)