### PR TITLE
feat: Add smart datetime formatting and date separators for messages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1559,6 +1559,31 @@ body {
   justify-content: flex-start;
 }
 
+/* Date separator for message grouping */
+.date-separator {
+  display: flex;
+  align-items: center;
+  text-align: center;
+  margin: 1.5rem 0 1rem 0;
+  position: relative;
+}
+
+.date-separator::before,
+.date-separator::after {
+  content: '';
+  flex: 1;
+  border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+}
+
+.date-separator-text {
+  padding: 0 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ctp-subtext0);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
 .sender-dot {
   width: 32px;
   height: 32px;


### PR DESCRIPTION
## Summary
Implements smart datetime display for messages and date separators between days (Discord/Teams-like UI pattern).

Resolves #499

## Smart Datetime Formatting
Messages now display context-aware timestamps:
- **Today**: just time (12:34 PM)
- **Yesterday**: "Yesterday 12:34 PM"
- **This week**: "Mon 12:34 PM"
- **This year**: "Nov 8 12:34 PM"
- **Older**: full date (11/08/2024 12:34 PM)

## Date Separators
Visual dividers between days with centered labels:
- Shows "Today", "Yesterday", or full date
- Applied to both Channels and Messages/DM tabs
- Discord/Teams-like horizontal line with centered text

## Implementation Details
### New Utility Functions (`src/utils/datetime.ts`)
- `formatMessageTime()` - Context-aware datetime formatting based on message age
- `getMessageDateSeparator()` - Generates separator labels
- `shouldShowDateSeparator()` - Determines when to show separators between messages

### UI Updates (`src/App.tsx`)
- Updated Channels tab message rendering with separators and smart datetime
- Updated Messages/DM tab message rendering with separators and smart datetime
- Applied to both regular messages and traceroute messages

### Styling (`src/App.css`)
- Added `.date-separator` styles with horizontal lines and centered text
- Uppercase labels with subtle opacity

## Test plan
- [x] Build passes with no TypeScript errors
- [x] Docker container rebuilt and running
- [x] CSS styles properly included in build
- [x] Date separator styles confirmed in deployed assets
- [ ] Visual testing: Open Channels tab and verify smart datetime formatting
- [ ] Visual testing: Verify date separators appear between different days
- [ ] Visual testing: Open Messages/DM tab and verify same behavior
- [ ] Test with messages from today, yesterday, this week, and older

🤖 Generated with [Claude Code](https://claude.com/claude-code)