### PR TITLE
feat: Improve emoji picker with modal UI and prevent accidental sends

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1664,7 +1664,7 @@ body {
   opacity: 1;
 }
 
-.reply-button, .emoji-button {
+.reply-button, .emoji-button, .emoji-picker-button {
   background: var(--ctp-surface2);
   color: var(--ctp-text);
   border: 1px solid var(--ctp-overlay0);
@@ -1676,7 +1676,7 @@ body {
   white-space: nowrap;
 }
 
-.emoji-button {
+.emoji-button, .emoji-picker-button {
   padding: 0.25rem 0.4rem;
   font-size: 0.9rem;
   line-height: 1;
@@ -1687,14 +1687,114 @@ body {
   justify-content: center;
 }
 
-.reply-button:hover, .emoji-button:hover {
+.reply-button:hover, .emoji-button:hover, .emoji-picker-button:hover {
   background: var(--ctp-surface1);
   border-color: var(--ctp-overlay1);
   transform: scale(1.1);
 }
 
-.emoji-button:active {
+.emoji-button:active, .emoji-picker-button:active {
   transform: scale(0.95);
+}
+
+/* Emoji Picker Modal */
+.emoji-picker-modal {
+  background: var(--ctp-base);
+  border: 1px solid var(--ctp-surface2);
+  border-radius: 16px;
+  padding: 1.5rem;
+  max-width: 440px;
+  width: 90%;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+}
+
+.emoji-picker-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.emoji-picker-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--ctp-text);
+}
+
+.emoji-picker-close {
+  background: transparent;
+  border: none;
+  color: var(--ctp-text);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: background 0.2s ease;
+}
+
+.emoji-picker-close:hover {
+  background: var(--ctp-surface1);
+}
+
+.emoji-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(50px, 1fr));
+  gap: 0.5rem;
+}
+
+.emoji-picker-item {
+  background: var(--ctp-surface0);
+  border: 1px solid var(--ctp-surface2);
+  border-radius: 12px;
+  padding: 0.75rem;
+  font-size: 1.5rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 50px;
+}
+
+.emoji-picker-item:hover {
+  background: var(--ctp-surface1);
+  border-color: var(--ctp-overlay0);
+  transform: scale(1.1);
+}
+
+.emoji-picker-item:active {
+  transform: scale(0.95);
+}
+
+/* Mobile responsiveness for emoji picker */
+@media (max-width: 768px) {
+  .emoji-picker-modal {
+    max-width: 95%;
+    padding: 1rem;
+  }
+
+  .emoji-picker-grid {
+    grid-template-columns: repeat(auto-fill, minmax(45px, 1fr));
+    gap: 0.4rem;
+  }
+
+  .emoji-picker-item {
+    padding: 0.6rem;
+    font-size: 1.3rem;
+    min-height: 45px;
+  }
+
+  /* Prevent accidental activation on mobile with larger touch targets */
+  .emoji-picker-item:active {
+    background: var(--ctp-surface2);
+  }
 }
 
 /* Reply indicator in send box */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -141,6 +141,7 @@ function App() {
   const [configRefreshTrigger, setConfigRefreshTrigger] = useState(0);
   const [showTracerouteHistoryModal, setShowTracerouteHistoryModal] = useState(false);
   const [selectedRouteSegment, setSelectedRouteSegment] = useState<{nodeNum1: number; nodeNum2: number} | null>(null);
+  const [emojiPickerMessage, setEmojiPickerMessage] = useState<MeshMessage | null>(null);
 
   // Check if mobile viewport and default to collapsed on mobile
   const isMobileViewport = () => window.innerWidth <= 768;
@@ -217,13 +218,35 @@ function App() {
   // Constants for emoji tapbacks
   const EMOJI_FLAG = 1; // Protobuf flag indicating this is a tapback/reaction
   const TAPBACK_EMOJIS = [
+    // Common reactions (compatible with Meshtastic OLED displays)
     { emoji: '👍', title: 'Thumbs up' },
     { emoji: '👎', title: 'Thumbs down' },
-    { emoji: '❓', title: 'Question' },
-    { emoji: '❗', title: 'Exclamation' },
+    { emoji: '❤️', title: 'Heart' },
     { emoji: '😂', title: 'Laugh' },
     { emoji: '😢', title: 'Cry' },
-    { emoji: '💩', title: 'Poop' }
+    { emoji: '😮', title: 'Wow' },
+    { emoji: '😡', title: 'Angry' },
+    { emoji: '🎉', title: 'Celebrate' },
+    // Questions and alerts
+    { emoji: '❓', title: 'Question' },
+    { emoji: '❗', title: 'Exclamation' },
+    { emoji: '‼️', title: 'Double exclamation' },
+    // Fun emojis (OLED compatible)
+    { emoji: '💩', title: 'Poop' },
+    { emoji: '👋', title: 'Wave' },
+    { emoji: '🤠', title: 'Cowboy' },
+    { emoji: '🐭', title: 'Mouse' },
+    { emoji: '😈', title: 'Devil' },
+    // Weather (OLED compatible)
+    { emoji: '☀️', title: 'Sunny' },
+    { emoji: '☔', title: 'Rain' },
+    { emoji: '☁️', title: 'Cloudy' },
+    { emoji: '🌫️', title: 'Foggy' },
+    // Additional useful reactions
+    { emoji: '✅', title: 'Check' },
+    { emoji: '❌', title: 'X' },
+    { emoji: '🔥', title: 'Fire' },
+    { emoji: '💯', title: '100' }
   ] as const;
 
   // Meshtastic default PSK (base64 encoded single null byte = unencrypted)
@@ -3194,16 +3217,13 @@ function App() {
                                     >
                                       ↩
                                     </button>
-                                    {TAPBACK_EMOJIS.map(({ emoji, title }) => (
-                                      <button
-                                        key={emoji}
-                                        className="emoji-button"
-                                        onClick={() => handleSendTapback(emoji, msg)}
-                                        title={title}
-                                      >
-                                        {emoji}
-                                      </button>
-                                    ))}
+                                    <button
+                                      className="emoji-picker-button"
+                                      onClick={() => setEmojiPickerMessage(msg)}
+                                      title="React with emoji"
+                                    >
+                                      😄
+                                    </button>
                                   </div>
                                 )}
                                 <div className="message-text" style={{whiteSpace: 'pre-line'}}>
@@ -3913,16 +3933,13 @@ function App() {
                                   >
                                     ↩
                                   </button>
-                                  {TAPBACK_EMOJIS.map(({ emoji, title }) => (
-                                    <button
-                                      key={emoji}
-                                      className="emoji-button"
-                                      onClick={() => handleSendTapback(emoji, msg)}
-                                      title={title}
-                                    >
-                                      {emoji}
-                                    </button>
-                                  ))}
+                                  <button
+                                    className="emoji-picker-button"
+                                    onClick={() => setEmojiPickerMessage(msg)}
+                                    title="React with emoji"
+                                  >
+                                    😄
+                                  </button>
                                 </div>
                               )}
                               <div className="message-text" style={{whiteSpace: 'pre-line'}}>
@@ -4920,6 +4937,40 @@ function App() {
 
       <LoginModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
       <RebootModal isOpen={showRebootModal} onClose={handleRebootModalClose} />
+
+      {/* Emoji Picker Modal */}
+      {emojiPickerMessage && (
+        <div className="modal-overlay" onClick={() => setEmojiPickerMessage(null)}>
+          <div className="emoji-picker-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="emoji-picker-header">
+              <h3>React with an emoji</h3>
+              <button
+                className="emoji-picker-close"
+                onClick={() => setEmojiPickerMessage(null)}
+                title="Close"
+              >
+                ×
+              </button>
+            </div>
+            <div className="emoji-picker-grid">
+              {TAPBACK_EMOJIS.map(({ emoji, title }) => (
+                <button
+                  key={emoji}
+                  className="emoji-picker-item"
+                  onClick={() => {
+                    handleSendTapback(emoji, emojiPickerMessage);
+                    setEmojiPickerMessage(null);
+                  }}
+                  title={title}
+                >
+                  {emoji}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
       {showTracerouteHistoryModal && selectedDMNode && (
         <TracerouteHistoryModal
           fromNodeNum={parseNodeId(currentNodeId)}


### PR DESCRIPTION
## Summary

Implements the improved emoji response picker feature requested in #500. This update addresses the issues with the current bulky inline emoji picker and prevents accidental emoji sends on mobile devices.

**Key Changes:**
- **Two-step emoji selection** - Replaced 7 inline emoji buttons with a single 😄 button that opens a modal picker
- **Expanded emoji set** - Increased from 7 to 24 emojis with Meshtastic OLED display compatibility
- **Mobile-optimized** - Responsive design with larger touch targets and proper spacing to prevent accidental taps
- **Better UX** - Modal interface with grid layout, hover tooltips, and easy dismissal

**Emoji Selection (24 total):**
- Common reactions: 👍 👎 ❤️ 😂 😢 😮 😡 🎉
- Questions/alerts: ❓ ❗ ‼️
- Fun emojis: 💩 👋 🤠 🐭 😈
- Weather: ☀️ ☔ ☁️ 🌫️
- Additional: ✅ ❌ 🔥 💯

All emojis are compatible with Meshtastic OLED displays where supported.

## Changes Made

**Frontend (src/App.tsx):**
- Added `emojiPickerMessage` state to track which message to react to (line 144)
- Expanded `TAPBACK_EMOJIS` array from 7 to 24 emojis with categories (lines 219-249)
- Replaced inline emoji buttons with single emoji picker button in channel messages (lines 3220-3226)
- Replaced inline emoji buttons with single emoji picker button in DM messages (lines 3936-3942)
- Added emoji picker modal component with grid layout (lines 4941-4972)

**Styling (src/App.css):**
- Updated button styles to include `.emoji-picker-button` class (lines 1667-1698)
- Added `.emoji-picker-modal` styles with responsive design (lines 1700-1798)
- Mobile optimizations with `@media` query for screens ≤768px
- Larger touch targets on mobile (45px minimum)
- Proper visual feedback for hover and active states

## How It Works

1. Hover over any message to see action buttons (↩ reply and 😄 emoji)
2. Click the 😄 emoji button to open the emoji picker modal
3. Select an emoji from the grid
4. The emoji is sent as a reaction and the modal closes automatically
5. Click outside the modal or press the × button to close without sending

## Mobile Safety Features

- **Two-step process** prevents immediate sends when accidentally touching a message
- **Larger touch targets** (minimum 45px) reduce fat-finger errors
- **Visual feedback** on touch with proper active states
- **Easy dismissal** with overlay click or close button

## Test Plan

- [x] Build completed successfully
- [x] Container running on port 8080
- [x] Emoji picker opens on button click
- [x] All 24 emojis display correctly in grid
- [x] Emoji reactions send properly
- [x] Modal closes after selection
- [x] Modal closes on overlay click
- [x] Responsive design works on mobile viewport
- [ ] Manual testing on actual mobile device recommended

## Related Issues

Fixes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)