### PR TITLE
fix: Auto-upgrade environment variable handling and add test upgrade feature

### DIFF
--- a/src/components/configuration/AutoUpgradeTestSection.tsx
+++ b/src/components/configuration/AutoUpgradeTestSection.tsx
@@ -20,12 +20,30 @@ interface TestResponse {
   overallMessage: string;
 }
 
+interface TriggerUpgradeResponse {
+  success: boolean;
+  upgradeId: string;
+  message: string;
+}
+
+interface UpgradeStatus {
+  upgradeId: string;
+  status: 'pending' | 'backing_up' | 'downloading' | 'restarting' | 'health_check' | 'complete' | 'failed' | 'rolling_back';
+  targetVersion: string;
+  startTime: string;
+  endTime?: string;
+  message?: string;
+}
+
 const AutoUpgradeTestSection: React.FC<AutoUpgradeTestSectionProps> = ({ baseUrl }) => {
   const csrfFetch = useCsrfFetch();
   const { showToast } = useToast();
   const [isTesting, setIsTesting] = useState(false);
   const [testResults, setTestResults] = useState<TestResponse | null>(null);
   const [showDetails, setShowDetails] = useState(false);
+  const [isTestUpgrading, setIsTestUpgrading] = useState(false);
+  const [upgradeStatus, setUpgradeStatus] = useState<UpgradeStatus | null>(null);
+  const [statusPollInterval, setStatusPollInterval] = useState<NodeJS.Timeout | null>(null);
 
   const handleTestConfiguration = async () => {
     setIsTesting(true);
@@ -65,6 +83,90 @@ const AutoUpgradeTestSection: React.FC<AutoUpgradeTestSectionProps> = ({ baseUrl
     }
   };
 
+  const pollUpgradeStatus = async (upgradeId: string) => {
+    try {
+      const response = await csrfFetch(`${baseUrl}/api/upgrade/status/${upgradeId}`);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      const status: UpgradeStatus = await response.json();
+      setUpgradeStatus(status);
+
+      // Stop polling if upgrade is complete or failed
+      if (status.status === 'complete' || status.status === 'failed') {
+        if (statusPollInterval) {
+          clearInterval(statusPollInterval);
+          setStatusPollInterval(null);
+        }
+        setIsTestUpgrading(false);
+
+        if (status.status === 'complete') {
+          showToast('Test upgrade completed successfully!', 'success');
+        } else {
+          showToast('Test upgrade failed', 'error');
+        }
+      }
+    } catch (error) {
+      logger.error('Failed to poll upgrade status:', error);
+    }
+  };
+
+  const handleTestUpgrade = async () => {
+    // Clear any previous status
+    setUpgradeStatus(null);
+    setIsTestUpgrading(true);
+
+    try {
+      // Trigger upgrade with current version (latest)
+      const response = await csrfFetch(`${baseUrl}/api/upgrade/trigger`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          targetVersion: 'latest',
+          force: true,  // Force re-pull even if same version
+          backup: true   // Always create backup during test
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const data: TriggerUpgradeResponse = await response.json();
+
+      if (data.success) {
+        showToast('Test upgrade started! Monitoring progress...', 'info');
+
+        // Start polling for status
+        const interval = setInterval(() => {
+          pollUpgradeStatus(data.upgradeId);
+        }, 2000); // Poll every 2 seconds
+
+        setStatusPollInterval(interval);
+
+        // Do initial poll immediately
+        pollUpgradeStatus(data.upgradeId);
+      } else {
+        throw new Error(data.message || 'Failed to start test upgrade');
+      }
+    } catch (error) {
+      logger.error('Failed to trigger test upgrade:', error);
+      showToast('Failed to start test upgrade', 'error');
+      setIsTestUpgrading(false);
+    }
+  };
+
+  // Cleanup polling on unmount
+  React.useEffect(() => {
+    return () => {
+      if (statusPollInterval) {
+        clearInterval(statusPollInterval);
+      }
+    };
+  }, [statusPollInterval]);
+
   const getStatusIcon = (passed: boolean) => {
     return passed ? '✅' : '❌';
   };
@@ -73,24 +175,98 @@ const AutoUpgradeTestSection: React.FC<AutoUpgradeTestSectionProps> = ({ baseUrl
     return passed ? '#10b981' : '#ef4444';
   };
 
+  const getUpgradeStatusDisplay = (status: string) => {
+    const statusMap: Record<string, { label: string; icon: string; color: string }> = {
+      pending: { label: 'Pending', icon: '⏳', color: '#6b7280' },
+      backing_up: { label: 'Creating Backup', icon: '💾', color: '#3b82f6' },
+      downloading: { label: 'Pulling Image', icon: '⬇️', color: '#3b82f6' },
+      restarting: { label: 'Recreating Container', icon: '🔄', color: '#f59e0b' },
+      health_check: { label: 'Health Check', icon: '🏥', color: '#f59e0b' },
+      complete: { label: 'Complete', icon: '✅', color: '#10b981' },
+      failed: { label: 'Failed', icon: '❌', color: '#ef4444' },
+      rolling_back: { label: 'Rolling Back', icon: '↩️', color: '#f59e0b' }
+    };
+    return statusMap[status] || { label: status, icon: '❓', color: '#6b7280' };
+  };
+
   return (
     <div className="settings-section">
       <h3>Auto-Upgrade Testing</h3>
       <p className="setting-description">
         Test your auto-upgrade configuration to ensure all components are properly set up.
-        This checks environment variables, file permissions, the upgrader sidecar, and more.
+        The <strong>Configuration Test</strong> checks environment variables, file permissions, the upgrader sidecar, and more.
+        The <strong>Upgrade Process Test</strong> performs an actual upgrade with the current version, testing backup creation,
+        container recreation, and health checks without changing your version.
       </p>
 
-      <div className="setting-item" style={{ marginTop: '1rem' }}>
+      <div className="setting-item" style={{ marginTop: '1rem', display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
         <button
           onClick={handleTestConfiguration}
-          disabled={isTesting}
+          disabled={isTesting || isTestUpgrading}
           className="save-button"
           style={{ width: 'auto', padding: '0.5rem 1rem' }}
         >
           {isTesting ? 'Testing Configuration...' : 'Test Auto-Upgrade Configuration'}
         </button>
+        <button
+          onClick={handleTestUpgrade}
+          disabled={isTestUpgrading || isTesting}
+          className="save-button"
+          style={{ width: 'auto', padding: '0.5rem 1rem', backgroundColor: '#f59e0b' }}
+        >
+          {isTestUpgrading ? 'Running Test Upgrade...' : 'Test Upgrade Process'}
+        </button>
       </div>
+
+      {upgradeStatus && (
+        <div style={{ marginTop: '1.5rem' }}>
+          <div style={{
+            padding: '1rem',
+            borderRadius: '4px',
+            backgroundColor: upgradeStatus.status === 'complete' ? '#f0fdf4' : upgradeStatus.status === 'failed' ? '#fef2f2' : '#f0f9ff',
+            border: `1px solid ${upgradeStatus.status === 'complete' ? '#10b981' : upgradeStatus.status === 'failed' ? '#ef4444' : '#3b82f6'}`,
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem' }}>
+              <span style={{ fontSize: '1.5rem' }}>
+                {getUpgradeStatusDisplay(upgradeStatus.status).icon}
+              </span>
+              <span style={{
+                fontWeight: 'bold',
+                color: getUpgradeStatusDisplay(upgradeStatus.status).color
+              }}>
+                {getUpgradeStatusDisplay(upgradeStatus.status).label}
+              </span>
+            </div>
+            <div style={{ fontSize: '0.9rem', opacity: 0.9 }}>
+              <div>Target Version: {upgradeStatus.targetVersion}</div>
+              <div>Started: {new Date(upgradeStatus.startTime).toLocaleString()}</div>
+              {upgradeStatus.endTime && (
+                <div>Completed: {new Date(upgradeStatus.endTime).toLocaleString()}</div>
+              )}
+              {upgradeStatus.message && (
+                <div style={{ marginTop: '0.5rem', fontStyle: 'italic' }}>
+                  {upgradeStatus.message}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {(upgradeStatus.status === 'complete' || upgradeStatus.status === 'failed') && (
+            <div style={{
+              marginTop: '1rem',
+              padding: '0.75rem',
+              backgroundColor: 'var(--background-secondary, #2a2a2a)',
+              borderRadius: '4px',
+              fontSize: '0.85rem'
+            }}>
+              <strong>Note:</strong> {upgradeStatus.status === 'complete'
+                ? 'Test upgrade completed successfully! The container was recreated with the same version. Check the system logs to verify everything is working correctly.'
+                : 'Test upgrade failed. Check the error message above and the system logs for details.'
+              }
+            </div>
+          )}
+        </div>
+      )}
 
       {testResults && (
         <div style={{ marginTop: '1.5rem' }}>


### PR DESCRIPTION
## Summary
- Fixes critical bug where environment variables with spaces caused Docker to fail during auto-upgrade
- Adds comprehensive "Test Upgrade Process" feature to settings panel for validating upgrade functionality

## Bug Fix: Environment Variables with Spaces

**Problem**: The upgrade watchdog script was building environment variables as inline `-e KEY=VALUE` arguments, causing shell word-splitting for values containing spaces. This caused Docker to interpret parts of the value as separate arguments.

For example, `OIDC_SCOPES=openid profile email` was being passed as:
```bash
-e OIDC_SCOPES=openid profile email
```

This caused Docker to interpret "profile" as an image name, resulting in:
```
Unable to find image 'profile:latest' locally
docker: Error response from daemon: pull access denied for profile
```

**Solution** (`scripts/upgrade-watchdog.sh`):
- Write environment variables to a temporary file instead of inline arguments
- Use Docker's `--env-file` parameter which properly handles values with spaces
- Clean up temporary file after container creation
- This ensures environment variables with spaces (like OIDC_SCOPES) are preserved correctly during container recreation

**Additional Fix**: Added support for bind mounts in addition to volume mounts during container recreation, ensuring all mount types are properly preserved.

## New Feature: Test Upgrade Process

**Feature** (`src/components/configuration/AutoUpgradeTestSection.tsx`):
- Added "Test Upgrade Process" button to settings panel
- Triggers a real upgrade using the current version (force re-pull)
- Tests the complete upgrade flow without version changes:
  - Backup creation
  - Image pulling
  - Container recreation
  - Health checks
- Real-time status monitoring with visual indicators:
  - ⏳ Pending
  - 💾 Creating Backup
  - ⬇️ Pulling Image
  - 🔄 Recreating Container
  - 🏥 Health Check
  - ✅ Complete / ❌ Failed
- Polls upgrade status every 2 seconds
- Automatically cleans up polling on completion or unmount

## Testing

### Manual Testing Results:
- Backup created successfully (upgrade-backup-20251110_150917.tar.gz, 2.2MB)
- Container recreated without errors
- Health checks passing
- Environment variables preserved correctly (including OIDC_SCOPES with spaces)
- Total upgrade time: ~27 seconds
- Test upgrade feature working as expected with real-time status updates

### System Test Status:
```
Quick Start Test: PASSING (14+ tests)
Configuration Import Test: FAILED (pre-existing issue, unrelated to these changes)
```

The configuration import test failure is a pre-existing issue with the configuration import functionality and is unrelated to the upgrade changes in this PR.

## Files Changed
- `scripts/upgrade-watchdog.sh` - Fixed environment variable handling and bind mount support
- `src/components/configuration/AutoUpgradeTestSection.tsx` - Added test upgrade feature with real-time monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)