### PR TITLE
feat: Add periodic SNR/RSSI telemetry tracking and graphing

### DIFF
--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -366,7 +366,7 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(({ nodeId, te
   };
 
   const getTelemetryLabel = (type: string): string => {
-    const labels: { [key: string]: string } = {
+    const labels: { [key: string]: string} = {
       batteryLevel: 'Battery Level',
       voltage: 'Voltage',
       channelUtilization: 'Channel Utilization',
@@ -374,6 +374,8 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(({ nodeId, te
       temperature: 'Temperature',
       humidity: 'Humidity',
       pressure: 'Barometric Pressure',
+      snr: 'Signal-to-Noise Ratio (SNR)',
+      rssi: 'Signal Strength (RSSI)',
       ch1Voltage: 'Channel 1 Voltage',
       ch1Current: 'Channel 1 Current',
       ch2Voltage: 'Channel 2 Voltage',
@@ -404,6 +406,8 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(({ nodeId, te
       temperature: '#ff8042',
       humidity: '#00c4cc',
       pressure: '#a28dff',
+      snr: '#94e2d5',       // Catppuccin teal - for signal quality
+      rssi: '#f9e2af',      // Catppuccin yellow - for signal strength
       ch1Voltage: '#d084d8',
       ch1Current: '#ff6b9d',
       ch2Voltage: '#c084ff',


### PR DESCRIPTION
## Summary

Implements SNR/RSSI telemetry graphing as requested in #527. This enhancement allows users to monitor signal quality and link performance over time.

## Changes

### Backend (src/server/meshtasticManager.ts)
- Modified SNR/RSSI telemetry capture to save periodic snapshots every **10 minutes** even when values remain stable
- Still saves immediately when values change for quick detection of signal degradation
- Enhanced logging to indicate whether telemetry was saved due to change or periodic snapshot

### Frontend (src/components/TelemetryGraphs.tsx)
- Added proper graph labels: "Signal-to-Noise Ratio (SNR)" and "Signal Strength (RSSI)"
- Added Catppuccin-themed colors: teal (#94e2d5) for SNR, yellow (#f9e2af) for RSSI
- Graphs now display automatically when SNR/RSSI telemetry data exists for a node

## Why This Change?

Previously, SNR/RSSI telemetry was only saved when values changed. For nodes with stable signal quality (common for static nodes with good links), there would be very few data points, making it impossible to see trends over time.

This implementation ensures users have sufficient historical data to:
- Monitor link quality to direct nodes over time
- Compare antenna performance over longer timeframes  
- Verify that stable links remain consistent
- Detect gradual signal degradation

## Test Plan

- [x] TypeScript compilation passes (`npm run typecheck`)
- [x] Build completes successfully (`npm run build`)
- [ ] Manual testing: Verify SNR/RSSI graphs appear in node telemetry view after data accumulates
- [ ] Manual testing: Confirm periodic snapshots are saved every 10 minutes
- [ ] Manual testing: Verify immediate saves when values change

## Notes

- **MQTT-only nodes**: Nodes connected only via MQTT won't have SNR/RSSI data (MQTT packets don't include RF metrics)
- **Historical data**: Users will need to wait for new data points to accumulate after this change is deployed
- **SNR/RSSI source**: These metrics are captured from received packets, showing signal quality from other nodes

Fixes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)