### PR TITLE
chore: Bump version to 2.16.7

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.16.6
-appVersion: "2.16.6"
+version: 2.16.7
+appVersion: "2.16.7"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "meshmonitor",
-  "version": "2.16.6",
+  "version": "2.16.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.16.6",
+      "version": "2.16.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "^4.53.1",
         "@types/bcrypt": "^6.0.0",
         "@types/express-session": "^1.18.2",
         "@types/qrcode": "^1.5.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.16.6",
+  "version": "2.16.7",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Version bump to 2.16.7, which includes the following changes since v2.16.6:

## Changes Included

- fix: Save SNR telemetry from NodeInfo packets (#535)
- fix: Apply global time range constraints to solar data on Dashboard (#534)
- feat: Add CSV/JSON export to Security Scanner (#533)
- chore(deps-dev): Bump @types/archiver from 6.0.4 to 7.0.0 (#517)
- chore(deps): Bump @rollup/rollup-linux-arm-gnueabihf (#516)

## Files Modified

- `package.json` - Updated version to 2.16.7
- `package-lock.json` - Regenerated with new version
- `helm/meshmonitor/Chart.yaml` - Updated chart and app version to 2.16.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)