### PR TITLE
chore: Bump version to 2.16.8

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.16.7
-appVersion: "2.16.7"
+version: 2.16.8
+appVersion: "2.16.8"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "meshmonitor",
-  "version": "2.16.7",
+  "version": "2.16.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.16.7",
+      "version": "2.16.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@rollup/rollup-linux-arm64-musl": "^4.53.2",
         "@types/bcrypt": "^6.0.0",
         "@types/express-session": "^1.18.2",
         "@types/qrcode": "^1.5.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.16.7",
+  "version": "2.16.8",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Version bump to 2.16.8

## Changes
- Updated package.json version to 2.16.8
- Updated package-lock.json
- Updated Helm chart version and appVersion to 2.16.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)