### PR TITLE
fix: Improve collapsed map controls display on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3469,6 +3469,13 @@ body {
     padding: 0.5rem;
   }
 
+  /* When collapsed on mobile, reset to compact button */
+  .map-controls.collapsed {
+    left: auto;
+    max-width: none;
+    width: auto;
+  }
+
   .map-control-item span {
     font-size: 0.8rem;
   }
@@ -4160,6 +4167,16 @@ body {
 .map-controls.collapsed {
   padding: 0.5rem;
   min-width: 40px;
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Center the collapse button when collapsed */
+.map-controls.collapsed .map-controls-collapse-btn {
+  position: static;
+  margin: 0;
 }
 
 /* Node Pulse Animation */


### PR DESCRIPTION
## Summary
- Fixes mobile UI issue where collapsed map controls displayed as a long horizontal bar instead of a compact square button on iOS PWA
- Adds mobile-specific CSS overrides to properly size and center the collapsed map controls
- Centers the collapse button arrow within the collapsed container

## Changes Made
1. **Mobile width override** (`src/App.css:3472-3477`):
   - Resets `left`, `max-width`, and `width` properties when collapsed on mobile
   - Prevents horizontal stretching across the screen

2. **Square button sizing** (`src/App.css:4170`):
   - Added `min-height: 40px` to match `min-width: 40px`
   - Creates proper 40px × 40px compact square button

3. **Centered arrow** (`src/App.css:4171-4180`):
   - Uses flexbox to center content (`display: flex`, `align-items: center`, `justify-content: center`)
   - Resets button position to `static` when collapsed for proper centering

## Testing
- Tested locally with Docker dev environment
- Verified collapsed controls display as compact square button
- Confirmed arrow is centered within the button

## Screenshots
Before: Long horizontal bar (as shown in #541)
After: Compact 40px × 40px square button with centered arrow

Fixes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)