### PR TITLE
fix: Properly distinguish between local and remote SNR telemetry

### DIFF
--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -376,6 +376,8 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(({ nodeId, te
       humidity: 'Humidity',
       pressure: 'Barometric Pressure',
       snr: 'Signal-to-Noise Ratio (SNR)',
+      snr_local: 'SNR - Local (Our Measurements)',
+      snr_remote: 'SNR - Remote (Node Reports)',
       rssi: 'Signal Strength (RSSI)',
       ch1Voltage: 'Channel 1 Voltage',
       ch1Current: 'Channel 1 Current',
@@ -407,7 +409,9 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(({ nodeId, te
       temperature: '#ff8042',
       humidity: '#00c4cc',
       pressure: '#a28dff',
-      snr: '#94e2d5',       // Catppuccin teal - for signal quality
+      snr: '#94e2d5',       // Catppuccin teal - for signal quality (legacy)
+      snr_local: '#89dceb', // Catppuccin sky - for local SNR measurements
+      snr_remote: '#a6e3a1', // Catppuccin green - for remote SNR reports
       rssi: '#f9e2af',      // Catppuccin yellow - for signal strength
       ch1Voltage: '#d084d8',
       ch1Current: '#ff6b9d',

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1409,7 +1409,7 @@ class MeshtasticManager {
 
         // Save SNR as telemetry if it has changed OR if 10+ minutes have passed
         // This ensures we have historical data for stable links
-        const latestSnrTelemetry = databaseService.getLatestTelemetryForType(nodeId, 'snr');
+        const latestSnrTelemetry = databaseService.getLatestTelemetryForType(nodeId, 'snr_local');
         const tenMinutesMs = 10 * 60 * 1000;
         const shouldSaveSnr = !latestSnrTelemetry ||
                               latestSnrTelemetry.value !== meshPacket.rxSnr ||
@@ -1419,7 +1419,7 @@ class MeshtasticManager {
           databaseService.insertTelemetry({
             nodeId,
             nodeNum: fromNum,
-            telemetryType: 'snr',
+            telemetryType: 'snr_local',
             timestamp,
             value: meshPacket.rxSnr,
             unit: 'dB',
@@ -1427,7 +1427,7 @@ class MeshtasticManager {
           });
           const reason = !latestSnrTelemetry ? 'initial' :
                         latestSnrTelemetry.value !== meshPacket.rxSnr ? 'changed' : 'periodic';
-          logger.debug(`📊 Saved SNR telemetry: ${meshPacket.rxSnr} dB (${reason}, previous: ${latestSnrTelemetry?.value || 'N/A'})`);
+          logger.debug(`📊 Saved local SNR telemetry: ${meshPacket.rxSnr} dB (${reason}, previous: ${latestSnrTelemetry?.value || 'N/A'})`);
         }
       }
       if (meshPacket.rxRssi && meshPacket.rxRssi !== 0) {
@@ -2357,7 +2357,7 @@ class MeshtasticManager {
 
         // Save SNR telemetry with same logic as packet processing:
         // Save if it has changed OR if 10+ minutes have passed since last save
-        const latestSnrTelemetry = databaseService.getLatestTelemetryForType(nodeId, 'snr');
+        const latestSnrTelemetry = databaseService.getLatestTelemetryForType(nodeId, 'snr_remote');
         const tenMinutesMs = 10 * 60 * 1000;
         const shouldSaveSnr = !latestSnrTelemetry ||
                               latestSnrTelemetry.value !== nodeInfo.snr ||
@@ -2367,7 +2367,7 @@ class MeshtasticManager {
           databaseService.insertTelemetry({
             nodeId,
             nodeNum: Number(nodeInfo.num),
-            telemetryType: 'snr',
+            telemetryType: 'snr_remote',
             timestamp,
             value: nodeInfo.snr,
             unit: 'dB',
@@ -2375,7 +2375,7 @@ class MeshtasticManager {
           });
           const reason = !latestSnrTelemetry ? 'initial' :
                         latestSnrTelemetry.value !== nodeInfo.snr ? 'changed' : 'periodic';
-          logger.debug(`📊 Saved SNR telemetry from NodeInfo: ${nodeInfo.snr} dB (${reason}, previous: ${latestSnrTelemetry?.value || 'N/A'})`);
+          logger.debug(`📊 Saved remote SNR telemetry from NodeInfo: ${nodeInfo.snr} dB (${reason}, previous: ${latestSnrTelemetry?.value || 'N/A'})`);
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

This PR fixes the SNR telemetry collection to properly distinguish between local and remote measurements:

- **Local SNR (`snr_local`)**: SNR values we measure when directly receiving packets from nodes (from `meshPacket.rxSnr`)
- **Remote SNR (`snr_remote`)**: SNR values that remote nodes report about their own reception quality (from `nodeInfo.snr`)

Previously, all SNR data was being saved as generic `'snr'` telemetry type, making it impossible to distinguish between our measurements and what remote nodes were reporting.

## Changes

### Backend (`src/server/meshtasticManager.ts`)
- Line 1422: Changed direct packet SNR to save as `'snr_local'` instead of `'snr'`
- Line 2370: Changed NodeInfo SNR to save as `'snr_remote'` instead of `'snr'`
- Updated log messages to indicate "local" vs "remote" SNR

### Frontend (`src/components/TelemetryGraphs.tsx`)
- Added labels: "SNR - Local (Our Measurements)" and "SNR - Remote (Node Reports)"
- Added distinct colors: sky blue for local, green for remote
- Kept legacy `'snr'` type for backward compatibility with existing data

## Test Results

All system tests passed successfully:
- ✓ Configuration Import test
- ✓ Quick Start test (includes security test)
- ✓ Reverse Proxy test
- ✓ Reverse Proxy + OIDC test
- ✓ Virtual Node CLI test
- ✓ System Backup & Restore test

## Visual Impact

Node Details pages will now show up to 3 SNR graphs:
1. Legacy "Signal-to-Noise Ratio (SNR)" - historical data only
2. "SNR - Local (Our Measurements)" - actively updating with our measurements
3. "SNR - Remote (Node Reports)" - actively updating with node-reported values

This provides much better insight into signal quality by distinguishing between what we measure vs. what remote nodes experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)