### PR TITLE
feat: Persist map position and zoom in LocalStorage

### DIFF
--- a/src/components/MapPositionHandler.tsx
+++ b/src/components/MapPositionHandler.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useMap } from 'react-leaflet';
+import { useMapContext } from '../contexts/MapContext';
+
+/**
+ * Component that tracks map center changes and updates context
+ */
+const MapPositionHandler = () => {
+  const map = useMap();
+  const { setMapCenter } = useMapContext();
+
+  useEffect(() => {
+    const handleMoveEnd = () => {
+      const center = map.getCenter();
+      setMapCenter([center.lat, center.lng]);
+    };
+
+    // Set initial center
+    handleMoveEnd();
+
+    // Listen for map move events
+    map.on('moveend', handleMoveEnd);
+
+    return () => {
+      map.off('moveend', handleMoveEnd);
+    };
+  }, [map, setMapCenter]);
+
+  return null;
+};
+
+export default MapPositionHandler;

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -16,6 +16,7 @@ import { useAuth } from '../contexts/AuthContext';
 import MapLegend from './MapLegend';
 import ZoomHandler from './ZoomHandler';
 import MapResizeHandler from './MapResizeHandler';
+import MapPositionHandler from './MapPositionHandler';
 import { SpiderfierController, SpiderfierControllerRef } from './SpiderfierController';
 import { TilesetSelector } from './TilesetSelector';
 import { MapCenterController } from './MapCenterController';
@@ -96,6 +97,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     triggerNodeAnimation,
     mapCenterTarget,
     setMapCenterTarget,
+    mapCenter,
     mapZoom,
     setMapZoom,
     selectedNodeId,
@@ -439,7 +441,11 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   }, [nodesWithPosition.map(n => `${n.nodeNum}-${n.position!.latitude}-${n.position!.longitude}`).join(',')]);
 
   // Calculate center point of all nodes for initial map view
+  // Use saved map center from localStorage if available, otherwise calculate from nodes
   const getMapCenter = (): [number, number] => {
+    if (mapCenter) {
+      return mapCenter;
+    }
     if (nodesWithPosition.length === 0) {
       return [25.7617, -80.1918]; // Default to Miami area
     }
@@ -758,7 +764,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
             </div>
             <MapContainer
               center={getMapCenter()}
-              zoom={nodesWithPosition.length > 0 ? 10 : 8}
+              zoom={mapZoom}
               style={{ height: '100%', width: '100%' }}
             >
               <MapCenterController
@@ -771,6 +777,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 maxZoom={getTilesetById(activeTileset).maxZoom}
               />
               <ZoomHandler onZoomChange={setMapZoom} />
+              <MapPositionHandler />
               <MapResizeHandler trigger={showPacketMonitor} />
               <SpiderfierController ref={spiderfierRef} zoomLevel={mapZoom} />
               <MapLegend />

--- a/src/contexts/MapContext.tsx
+++ b/src/contexts/MapContext.tsx
@@ -35,6 +35,8 @@ interface MapContextType {
   triggerNodeAnimation: (nodeId: string) => void;
   mapCenterTarget: [number, number] | null;
   setMapCenterTarget: (target: [number, number] | null) => void;
+  mapCenter: [number, number] | null;
+  setMapCenter: (center: [number, number] | null) => void;
   mapZoom: number;
   setMapZoom: (zoom: number) => void;
   traceroutes: DbTraceroute[];
@@ -65,7 +67,27 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
   });
   const [animatedNodes, setAnimatedNodes] = useState<Set<string>>(new Set());
   const [mapCenterTarget, setMapCenterTarget] = useState<[number, number] | null>(null);
-  const [mapZoom, setMapZoom] = useState<number>(10);
+  const [mapCenter, setMapCenter] = useState<[number, number] | null>(() => {
+    const saved = localStorage.getItem('mapCenter');
+    if (saved) {
+      try {
+        return JSON.parse(saved);
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  });
+  const [mapZoom, setMapZoom] = useState<number>(() => {
+    const saved = localStorage.getItem('mapZoom');
+    if (saved) {
+      const zoom = parseFloat(saved);
+      if (!isNaN(zoom)) {
+        return zoom;
+      }
+    }
+    return 10;
+  });
   const [traceroutes, setTraceroutes] = useState<DbTraceroute[]>([]);
   const [neighborInfo, setNeighborInfo] = useState<EnrichedNeighborInfo[]>([]);
   const [positionHistory, setPositionHistory] = useState<PositionHistoryItem[]>([]);
@@ -75,6 +97,18 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
   useEffect(() => {
     localStorage.setItem('showAnimations', showAnimations.toString());
   }, [showAnimations]);
+
+  // Persist map center to localStorage
+  useEffect(() => {
+    if (mapCenter) {
+      localStorage.setItem('mapCenter', JSON.stringify(mapCenter));
+    }
+  }, [mapCenter]);
+
+  // Persist map zoom to localStorage
+  useEffect(() => {
+    localStorage.setItem('mapZoom', mapZoom.toString());
+  }, [mapZoom]);
 
   // Trigger animation for a node (lasts 1 second)
   const triggerNodeAnimation = React.useCallback((nodeId: string) => {
@@ -111,6 +145,8 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
         triggerNodeAnimation,
         mapCenterTarget,
         setMapCenterTarget,
+        mapCenter,
+        setMapCenter,
         mapZoom,
         setMapZoom,
         traceroutes,


### PR DESCRIPTION
## Summary

Implements LocalStorage persistence for map position and zoom level to maintain user's view across page reloads and tab switches.

## Changes

- **MapContext**: Added `mapCenter` state with LocalStorage persistence for both position and zoom
- **MapPositionHandler**: New component that listens to Leaflet's `moveend` event to track map panning
- **NodesTab**: Updated to use saved map state on initialization instead of recalculating

## Implementation Details

### How It Works

1. **On First Load**: Map uses calculated center (average of node positions) and default zoom (10)
2. **User Interaction**: 
   - When user pans the map, `MapPositionHandler` saves center to LocalStorage
   - When user zooms, `ZoomHandler` saves zoom level to LocalStorage
3. **On Reload/Tab Switch**: Map restores last saved position and zoom from LocalStorage

### Per-User Storage

Uses browser LocalStorage, making settings unique to each user (not global), as requested in the issue.

## Testing

- ✅ Build successful
- ⏳ System tests running (will update when complete)
- ✅ Dev environment verified working on port 8080

## Resolves

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)