### PR TITLE
fix: Implement dynamic bucketing for telemetry data to prevent premature cutoff

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1873,9 +1873,11 @@ apiRouter.get('/telemetry/:nodeId', optionalAuth(), (req, res) => {
     const cutoffTime = Date.now() - (hoursParam * 60 * 60 * 1000);
 
     // Use averaged query for graph data to reduce data points
-    // This ensures max 20 points per hour (60 minutes / 3 minute intervals = 20)
-    // Pass hours to apply LIMIT for performance
-    const recentTelemetry = databaseService.getTelemetryByNodeAveraged(nodeId, cutoffTime, 3, hoursParam);
+    // Dynamic bucketing automatically adjusts interval based on time range:
+    // - 0-24h: 3-minute intervals (high detail)
+    // - 1-7d: 30-minute intervals (medium detail)
+    // - 7d+: 2-hour intervals (low detail, full coverage)
+    const recentTelemetry = databaseService.getTelemetryByNodeAveraged(nodeId, cutoffTime, undefined, hoursParam);
     res.json(recentTelemetry);
   } catch (error) {
     logger.error('Error fetching telemetry:', error);


### PR DESCRIPTION
## Summary
Implements dynamic time interval bucketing for telemetry data to fix issue #548 where data was cut off prematurely when viewing long time periods or with chatty nodes.

## Changes
- Modified `getTelemetryByNodeAveraged()` in `database.ts` to automatically select optimal time intervals based on the requested time range:
  - **0-24 hours**: 3-minute intervals (high detail)
  - **1-7 days**: 30-minute intervals (medium detail)
  - **7+ days**: 2-hour intervals (full coverage)
- Updated data point LIMIT calculation to be dynamic based on the actual interval used
- Added 2x padding factor to account for multiple telemetry types per node
- Updated `/api/telemetry/:nodeId` endpoint in `server.ts` to use automatic interval selection

## Problem
Previously, the system always used fixed 3-minute intervals regardless of time range. For a 5-day period with multiple telemetry types:
- 5 days × 20 points/hour × 10 telemetry types = ~24,000 rows needed
- But the limit was only ~2,420 rows
- Result: Data was cut off after covering only ~10% of the time range

## Solution
With dynamic bucketing:
- 5 days now uses 30-minute intervals = 240 points per type
- 10 types × 240 points = 2,400 rows (well within the new dynamic limit)
- Result: Full coverage of the entire 5-day period

## Testing
- All 7 system test suites pass:
  - Configuration Import ✓
  - Quick Start Test ✓
  - Security Test ✓
  - Reverse Proxy Test ✓
  - Reverse Proxy + OIDC ✓
  - Virtual Node CLI Test ✓
  - Backup & Restore Test ✓

## Impact
- Users can now view telemetry data for long time periods without data gaps
- Particularly benefits users with chatty nodes or multiple telemetry types
- No breaking changes - backward compatible

Fixes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)