### PR TITLE
chore: Bump version to 2.17.0

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -48,10 +48,11 @@
 
 **Remaining:**
 - [ ] Update Device Configurator with system backup settings (optional)
-- [ ] Update package.json to 2.16.0
-- [ ] Update Helm chart to 2.16.0
-- [ ] Regenerate package-lock.json
-- [ ] Create release
+- [x] Update package.json to 2.17.0
+- [x] Update Helm chart to 2.17.0
+- [x] Regenerate package-lock.json
+- [ ] Run system tests
+- [ ] Create release (v2.17.0)
 
 #### DM Conversation Enhancements (#490)
 

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.16.8
-appVersion: "2.16.8"
+version: 2.17.0
+appVersion: "2.17.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.16.8",
+  "version": "2.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.16.8",
+      "version": "2.17.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.16.8",
+  "version": "2.17.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Update version in package.json from 2.16.8 to 2.17.0
- Update version in Helm chart (Chart.yaml) from 2.16.8 to 2.17.0
- Regenerate package-lock.json to reflect new version
- Update TODOS.md to track version bump completion

## Test plan
- [x] Version updated in package.json
- [x] Version updated in Helm chart
- [x] package-lock.json regenerated successfully
- [x] TODOS.md updated
- [ ] System tests passing (recently run, skipping for this version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)