### PR TITLE
feat: Add Site Gallery page to showcase public MeshMonitor instances

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,6 +20,7 @@ export default defineConfig({
       { text: 'Home', link: '/' },
       { text: 'Getting Started', link: '/getting-started' },
       { text: 'FAQ', link: '/faq' },
+      { text: '🌐 Site Gallery', link: '/site-gallery' },
       {
         text: 'Docs',
         items: [
@@ -40,7 +41,8 @@ export default defineConfig({
             { text: 'Automation', link: '/features/automation' },
             { text: 'Device Configuration', link: '/features/device' },
             { text: 'Push Notifications', link: '/features/notifications' },
-            { text: '🎨 Theme Gallery', link: '/THEME_GALLERY' }
+            { text: '🎨 Theme Gallery', link: '/THEME_GALLERY' },
+            { text: '🌐 Site Gallery', link: '/site-gallery' }
           ]
         }
       ],

--- a/docs/site-gallery.md
+++ b/docs/site-gallery.md
@@ -1,0 +1,61 @@
+# MeshMonitor Site Gallery
+
+Discover public MeshMonitor instances from the community! These sites showcase MeshMonitor in action, monitoring real-world Meshtastic networks.
+
+::: tip Want your site listed here?
+Running a public MeshMonitor instance? We'd love to feature it! **[File an issue on GitHub](https://github.com/yeraze/meshmonitor/issues/new?title=Site%20Gallery%20Submission&body=Please%20add%20my%20MeshMonitor%20instance%20to%20the%20Site%20Gallery%3A%0A%0A**Site%20URL**%3A%20%0A**Name%2FDescription**%3A%20%0A**Associated%20Mesh%20Network%2FWebsite**%20(optional)%3A%20)** to request your site be added to the gallery.
+:::
+
+## Featured Sites
+
+### South Florida Mesh
+- **URL**: [meshmonitor.yeraze.com](https://meshmonitor.yeraze.com/)
+- **Network**: [Are You Meshing With Us?](https://areyoumeshingwith.us/)
+- **Description**: Monitoring the South Florida Meshtastic network with real-time updates and comprehensive coverage.
+
+---
+
+### Central Oregon Mesh
+- **URL**: [192.81.132.42:8080](http://192.81.132.42:8080/)
+- **Location**: Central Oregon, US
+- **Description**: Community-maintained MeshMonitor instance monitoring the Central Oregon Meshtastic network.
+
+---
+
+## About the Site Gallery
+
+The Site Gallery showcases MeshMonitor instances that are publicly accessible. These sites demonstrate:
+
+- Real-world deployments of MeshMonitor
+- Various network configurations and scales
+- Different use cases and community implementations
+- The capabilities and features of MeshMonitor in production
+
+## Guidelines for Submission
+
+When requesting your site be added to the gallery, please provide:
+
+1. **Public URL**: Your MeshMonitor instance must be publicly accessible
+2. **Site Name/Description**: A brief description of your instance
+3. **Network Information**: (Optional) Information about the mesh network you're monitoring
+4. **Contact**: A way to reach you if there are issues with your listing
+
+## Privacy & Security
+
+Remember that publicly accessible MeshMonitor instances will be visible to anyone on the internet. Ensure that:
+
+- You've properly configured authentication (change default credentials!)
+- Sensitive information is protected
+- You're following security best practices from the [Production Deployment Guide](/configuration/production)
+- You comply with your local laws and regulations regarding data sharing
+
+## Join the Community
+
+Running a public MeshMonitor instance? You're helping to grow the Meshtastic ecosystem! Connect with other operators:
+
+- **GitHub**: [github.com/yeraze/meshmonitor](https://github.com/yeraze/meshmonitor)
+- **Issues & Discussions**: Share your experiences and learn from others
+
+---
+
+*Note: Sites listed here are community-maintained. The MeshMonitor project does not endorse or guarantee the availability or security of listed sites.*


### PR DESCRIPTION
## Summary

Add a new Site Gallery page to the documentation website to showcase public MeshMonitor instances from the community.

- Created new documentation page at `/site-gallery` featuring public instances
- Added prominent callout box encouraging community submissions via GitHub issues
- Featured two initial sites: South Florida Mesh and Central Oregon Mesh
- Included submission guidelines, privacy considerations, and security best practices
- Added navigation links in main navbar and Features sidebar
- Follows same structure and styling as Theme Gallery page

## Changes

**New Files:**
- `docs/site-gallery.md` - Site Gallery page with featured instances and guidelines

**Modified Files:**
- `docs/.vitepress/config.mts` - Added Site Gallery to navigation bar and Features sidebar

## Test plan

- [x] Verified site renders correctly at http://localhost:5173/site-gallery
- [x] Confirmed navigation links work in main navbar and Features sidebar
- [x] Tested GitHub issue submission link works correctly
- [x] Verified all site links are functional
- [x] Checked responsive layout and styling consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)