### PR TITLE
docs: Add Tampa Bay Area Mesh to Site Gallery

### DIFF
--- a/docs/site-gallery.md
+++ b/docs/site-gallery.md
@@ -15,6 +15,13 @@ Running a public MeshMonitor instance? We'd love to feature it! **[File an issue
 
 ---
 
+### Tampa Bay Area Mesh
+- **URL**: [mesh.axiom-labs.dev](https://mesh.axiom-labs.dev)
+- **Network**: [Are You Meshing With Us?](https://areyoumeshingwith.us/)
+- **Description**: Monitoring the Tampa Bay Area and surrounding Meshtastic Network with real-time updates and comprehensive coverage.
+
+---
+
 ### Central Oregon Mesh
 - **URL**: [192.81.132.42:8080](http://192.81.132.42:8080/)
 - **Location**: Central Oregon, US


### PR DESCRIPTION
## Summary
- Added Tampa Bay Area Mesh MeshMonitor instance to the Site Gallery
- Instance URL: https://mesh.axiom-labs.dev
- Monitoring the Tampa Bay Area and surrounding Meshtastic Network
- Associated with the "Are You Meshing With Us?" mesh network

## Test plan
- [x] Verified the site gallery markdown formatting
- [x] Confirmed all URLs are properly formatted
- [x] Ensured entry follows existing gallery format
- [x] Documentation-only change, no testing required

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)