### PR TITLE
hotfix: Release 2.17.4 - CSRF and rate limiting fixes

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.17.3
-appVersion: "2.17.3"
+version: 2.17.4
+appVersion: "2.17.4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.17.3",
+      "version": "2.17.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
This hotfix release bumps the version to 2.17.4 and addresses critical CSRF token access and rate limiting issues for reverse proxy deployments.

## Changes
- Bump version to 2.17.4 in package.json
- Bump version to 2.17.4 in Helm chart (Chart.yaml)
- Update package-lock.json

## Related Issues
- Fixes issues identified in #568

## Test Plan
- System tests passed (Config Import, Quick Start, Reverse Proxy, OIDC, and Backup/Restore tests)
- All deployment scenarios verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)