### PR TITLE
feat: Add hover tooltips to map pins

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { MapContainer, TileLayer, Marker, Popup, Polyline, Circle } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Popup, Tooltip, Polyline, Circle } from 'react-leaflet';
 import type { Marker as LeafletMarker } from 'leaflet';
 import { DeviceInfo } from '../types/device';
 import { TabType } from '../types/ui';
@@ -828,6 +828,18 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 zIndexOffset={shouldAnimate ? 10000 : 0}
                 ref={(ref) => handleMarkerRef(ref, node.user?.id)}
               >
+                <Tooltip direction="top" offset={[0, -20]} opacity={0.9} interactive>
+                  <div style={{ textAlign: 'center' }}>
+                    <div style={{ fontWeight: 'bold' }}>
+                      {node.user?.longName || node.user?.shortName || `!${node.nodeNum.toString(16)}`}
+                    </div>
+                    {node.hopsAway !== undefined && (
+                      <div style={{ fontSize: '0.85em', opacity: 0.8 }}>
+                        {node.hopsAway} hop{node.hopsAway !== 1 ? 's' : ''}
+                      </div>
+                    )}
+                  </div>
+                </Tooltip>
                 <Popup autoPan={false}>
                   <div className="node-popup">
                     <div className="node-popup-header">


### PR DESCRIPTION
## Summary
- Adds interactive tooltips that appear on hover over map pins
- Displays node name and hop count for quick identification
- Preserves existing click-to-open popup functionality

## Changes
- Added `Tooltip` component from react-leaflet to map markers
- Tooltip shows node name (long name, short name, or hex ID) in bold
- Shows hop count below name when available (e.g., "2 hops")
- Tooltip is interactive and clickable (same behavior as clicking the pin)
- Positioned above pin with slight transparency for modern look

## User Experience
- **Hover** to see quick info (name + hops)
- **Click** for full details popup (unchanged)
- Non-intrusive and doesn't block map interaction

## Testing
- Built and tested locally in Docker dev environment
- Verified tooltip appears correctly on hover
- Confirmed clicking tooltip works like clicking pin
- Existing popup functionality remains intact

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)