### PR TITLE
fix: Display full hardware model names with version numbers

### DIFF
--- a/src/components/NodeDetailsBlock.tsx
+++ b/src/components/NodeDetailsBlock.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { DeviceInfo } from '../types/device';
-import { getHardwareModelShortName } from '../utils/hardwareModel';
+import { getHardwareModelName } from '../utils/nodeHelpers';
 import { getDeviceRoleName } from '../utils/deviceRole';
 import { getHardwareImageUrl } from '../utils/hardwareImages';
 import { formatRelativeTime } from '../utils/datetime';
@@ -150,11 +150,11 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
                 {hardwareImageUrl && (
                   <img
                     src={hardwareImageUrl}
-                    alt={getHardwareModelShortName(hwModel)}
+                    alt={getHardwareModelName(hwModel) || 'Unknown'}
                     className="hardware-image"
                   />
                 )}
-                <span className="hardware-name">{getHardwareModelShortName(hwModel)}</span>
+                <span className="hardware-name">{getHardwareModelName(hwModel)}</span>
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
Fixes #575 - Hardware section in node details now displays full device names with version numbers instead of abbreviated versions.

## Changes
- Modified `NodeDetailsBlock.tsx` to use `getHardwareModelName()` from `nodeHelpers.ts` instead of `getHardwareModelShortName()` from `hardwareModel.ts`
- The `getHardwareModelShortName()` function was stripping version suffixes using regex, causing devices like "HELTEC_V3" and "HELTEC_V4" to both display as just "HELTEC"

## Examples
**Before:**
- HELTEC_V3 → "HELTEC"
- HELTEC_V4 → "HELTEC"

**After:**
- HELTEC_V3 → "Heltec V3"
- HELTEC_V4 → "Heltec V4"

## Test Plan
- [x] Built and deployed to dev environment
- [x] Verified hardware names now include version information
- [x] Maintains proper formatting with capitalization and spacing
- [x] Consistent with hardware name display in other parts of the app (NodesTab, SecurityTab)

## Related Files
- `src/components/NodeDetailsBlock.tsx:3,153,157`
- `src/utils/nodeHelpers.ts:143-148`

🤖 Generated with [Claude Code](https://claude.com/claude-code)