### PR TITLE
chore: Bump version to 2.17.5

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.17.4
-appVersion: "2.17.4"
+version: 2.17.5
+appVersion: "2.17.5"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.17.4",
+      "version": "2.17.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Version bump to 2.17.5 in preparation for fix release.

## Changes
- Updated `package.json` version to 2.17.5
- Updated Helm chart version and appVersion to 2.17.5  
- Regenerated `package-lock.json`

## Included Fixes
This release will include:
- #577 - Display full hardware model names with version numbers (#575)

🤖 Generated with [Claude Code](https://claude.com/claude-code)