### PR TITLE
refactor: Move channel purge button from Danger Zone to Info popup

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1947,6 +1947,17 @@ body {
   color: var(--ctp-sky);
 }
 
+.channel-button.selected .channel-info-link {
+  color: var(--ctp-base);
+  background: rgba(17, 17, 27, 0.3);
+  font-weight: 600;
+}
+
+.channel-button.selected .channel-info-link:hover {
+  background: rgba(17, 17, 27, 0.5);
+  color: var(--ctp-text);
+}
+
 .channel-button-status {
   display: flex;
   gap: 0.25rem;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3532,48 +3532,6 @@ function App() {
                           </button>
                         </div>
                       )}
-
-                      {/* Danger Zone */}
-                      {hasPermission(`channel_${selectedChannel}` as ResourceType, 'write') && selectedChannel !== -1 && (
-                        <div className="danger-zone" style={{
-                          marginTop: '2rem',
-                          padding: '1rem',
-                          border: '2px solid #dc3545',
-                          borderRadius: '8px',
-                          backgroundColor: 'rgba(220, 53, 69, 0.1)'
-                        }}>
-                          <h3 style={{
-                            color: '#dc3545',
-                            marginTop: 0,
-                            marginBottom: '0.5rem',
-                            fontSize: '1.1rem'
-                          }}>
-                            Danger Zone
-                          </h3>
-                          <p style={{
-                            marginBottom: '1rem',
-                            fontSize: '0.9rem',
-                            opacity: 0.8
-                          }}>
-                            Purge all messages from this channel. This action cannot be undone.
-                          </p>
-                          <button
-                            onClick={() => handlePurgeChannelMessages(selectedChannel)}
-                            className="danger-btn"
-                            style={{
-                              backgroundColor: '#dc3545',
-                              color: 'white',
-                              border: 'none',
-                              padding: '0.5rem 1rem',
-                              borderRadius: '4px',
-                              cursor: 'pointer',
-                              fontWeight: 'bold'
-                            }}
-                          >
-                            Purge All Messages
-                          </button>
-                        </div>
-                      )}
                     </div>
                   )}
                 </div>
@@ -3684,6 +3642,42 @@ function App() {
                     </div>
                   )}
                 </div>
+                {hasPermission(`channel_${channelInfoModal}` as ResourceType, 'write') && channelInfoModal !== -1 && (
+                  <div style={{
+                    marginTop: '1.5rem',
+                    paddingTop: '1rem',
+                    borderTop: '1px solid var(--ctp-surface2)'
+                  }}>
+                    <button
+                      onClick={() => {
+                        handleCloseModal();
+                        handlePurgeChannelMessages(channelInfoModal);
+                      }}
+                      style={{
+                        width: '100%',
+                        padding: '0.75rem',
+                        backgroundColor: '#dc3545',
+                        color: 'white',
+                        border: 'none',
+                        borderRadius: '4px',
+                        cursor: 'pointer',
+                        fontWeight: 'bold',
+                        fontSize: '0.95rem'
+                      }}
+                      title="Purge all messages from this channel"
+                    >
+                      Purge All Messages
+                    </button>
+                    <p style={{
+                      marginTop: '0.5rem',
+                      fontSize: '0.85rem',
+                      color: 'var(--ctp-subtext0)',
+                      textAlign: 'center'
+                    }}>
+                      This action cannot be undone
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Improved UX by relocating the channel message purge functionality to a more discoverable location.

## Changes
- ✨ Moved "Purge All Messages" button from dedicated Danger Zone section to channel Info popup
- 🗑️ Removed Danger Zone section from Channels page for cleaner UI
- 🎨 Enhanced visibility of "info" link on selected channels with improved contrast
  - White text color on selected channels (instead of blue on blue)
  - Darker semi-transparent background
  - Bold font weight (600)
  - Better hover state styling

## Benefits
- **Cleaner UI**: Removes visual clutter from the main channels view
- **Better discoverability**: Purge action is now accessible via the info popup alongside other channel information
- **Improved accessibility**: Info link is now clearly visible even when channel is selected

## Testing
Tested locally - confirmed that:
- Danger Zone section is removed from Channels page
- Purge button appears in channel Info popup with proper styling
- Info link is visible on both selected and unselected channels
- Purge functionality works as expected with confirmation dialog