### PR TITLE
fix: Disable hover tooltips on map pins for touch devices

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -141,6 +141,21 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
   const { hasPermission } = useAuth();
 
+  // Detect touch device to disable hover tooltips on mobile
+  const [isTouchDevice, setIsTouchDevice] = useState(false);
+
+  useEffect(() => {
+    // Check if the device supports touch
+    const checkTouch = () => {
+      return (
+        'ontouchstart' in window ||
+        navigator.maxTouchPoints > 0 ||
+        (navigator as any).msMaxTouchPoints > 0
+      );
+    };
+    setIsTouchDevice(checkTouch());
+  }, []);
+
   // Ref for spiderfier controller to manage overlapping markers
   const spiderfierRef = useRef<SpiderfierControllerRef>(null);
 
@@ -828,18 +843,20 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 zIndexOffset={shouldAnimate ? 10000 : 0}
                 ref={(ref) => handleMarkerRef(ref, node.user?.id)}
               >
-                <Tooltip direction="top" offset={[0, -20]} opacity={0.9} interactive>
-                  <div style={{ textAlign: 'center' }}>
-                    <div style={{ fontWeight: 'bold' }}>
-                      {node.user?.longName || node.user?.shortName || `!${node.nodeNum.toString(16)}`}
-                    </div>
-                    {node.hopsAway !== undefined && (
-                      <div style={{ fontSize: '0.85em', opacity: 0.8 }}>
-                        {node.hopsAway} hop{node.hopsAway !== 1 ? 's' : ''}
+                {!isTouchDevice && (
+                  <Tooltip direction="top" offset={[0, -20]} opacity={0.9} interactive>
+                    <div style={{ textAlign: 'center' }}>
+                      <div style={{ fontWeight: 'bold' }}>
+                        {node.user?.longName || node.user?.shortName || `!${node.nodeNum.toString(16)}`}
                       </div>
-                    )}
-                  </div>
-                </Tooltip>
+                      {node.hopsAway !== undefined && (
+                        <div style={{ fontSize: '0.85em', opacity: 0.8 }}>
+                          {node.hopsAway} hop{node.hopsAway !== 1 ? 's' : ''}
+                        </div>
+                      )}
+                    </div>
+                  </Tooltip>
+                )}
                 <Popup autoPan={false}>
                   <div className="node-popup">
                     <div className="node-popup-header">


### PR DESCRIPTION
## Summary
Resolves #582 where hover tooltips were interfering with tap behavior on mobile devices (iPhone 16 Pro, iPad, etc.). Map pins now correctly detect touch devices and only show tooltips on desktop browsers with hover capability.

## Changes
- Added touch device detection using `ontouchstart`, `maxTouchPoints`, and `msMaxTouchPoints` APIs
- Conditionally render `<Tooltip>` component only on non-touch devices
- Touch detection runs once on component mount and sets state
- Desktop users: hover to see node name and hop count tooltip
- Mobile/tablet users: tap pins directly to open full popup without interference

## Technical Details
Added to `src/components/NodesTab.tsx`:
- Touch detection state (`isTouchDevice`) initialized on component mount
- Tooltip wrapped in conditional rendering: `{!isTouchDevice && (<Tooltip>...)}`
- Detection checks multiple browser APIs for broad compatibility

## Testing
- ✅ Built and deployed to Docker container successfully
- ✅ Touch detection code verified in minified bundle
- ✅ System tests running - Configuration Import test PASSED
- ✅ Quick Start test in progress
- Tested on desktop: tooltips appear on hover as expected
- Ready for mobile testing by reporter

## User Impact
- **Before**: Mobile users experienced inconsistent tap behavior - sometimes showing hover info, sometimes full popup, sometimes nothing
- **After**: Mobile users can reliably tap pins to open the full node popup
- Desktop experience unchanged - hover tooltips still work perfectly

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)