### PR TITLE
feat: Add telemetry data purge menu to individual graphs

### DIFF
--- a/src/components/TelemetryGraphs.css
+++ b/src/components/TelemetryGraphs.css
@@ -48,7 +48,15 @@
   font-weight: 500;
 }
 
-.favorite-btn {
+.graph-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  position: relative;
+}
+
+.favorite-btn,
+.graph-menu-btn {
   background: none;
   border: none;
   font-size: 1.2rem;
@@ -63,12 +71,47 @@
   transition: color 0.2s ease;
 }
 
-.favorite-btn:hover {
+.favorite-btn:hover,
+.graph-menu-btn:hover {
   color: var(--ctp-yellow);
 }
 
 .favorite-btn.favorited {
   color: var(--ctp-yellow);
+}
+
+.graph-menu-btn {
+  font-size: 1.4rem;
+  font-weight: bold;
+  line-height: 1;
+}
+
+.telemetry-context-menu {
+  background-color: var(--ctp-base);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+  min-width: 150px;
+  padding: 4px 0;
+}
+
+.context-menu-item {
+  display: block;
+  width: 100%;
+  padding: 8px 16px;
+  background: none;
+  border: none;
+  color: var(--ctp-text);
+  text-align: left;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s ease;
+}
+
+.context-menu-item:hover {
+  background-color: var(--ctp-surface0);
+  color: var(--ctp-red);
 }
 
 @media (max-width: 768px) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1935,6 +1935,27 @@ apiRouter.get('/telemetry/:nodeId', optionalAuth(), (req, res) => {
   }
 });
 
+// Delete telemetry data for a specific node and type
+apiRouter.delete('/telemetry/:nodeId/:telemetryType', requireAuth(), requirePermission('info', 'write'), (req, res) => {
+  try {
+    const { nodeId, telemetryType } = req.params;
+
+    logger.info(`Purging telemetry data for node ${nodeId}, type ${telemetryType}`);
+
+    const deleted = databaseService.deleteTelemetryByNodeAndType(nodeId, telemetryType);
+
+    if (deleted) {
+      logger.info(`Successfully purged ${telemetryType} telemetry for node ${nodeId}`);
+      res.json({ success: true, message: `Telemetry data purged successfully` });
+    } else {
+      res.status(404).json({ error: 'No telemetry data found to delete' });
+    }
+  } catch (error) {
+    logger.error('Error purging telemetry data:', error);
+    res.status(500).json({ error: 'Failed to purge telemetry data' });
+  }
+});
+
 // Check which nodes have telemetry data
 apiRouter.get('/telemetry/available/nodes', requirePermission('info', 'read'), (_req, res) => {
   try {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1913,6 +1913,13 @@ class DatabaseService {
     return Number(result.changes);
   }
 
+  deleteTelemetryByNodeAndType(nodeId: string, telemetryType: string): boolean {
+    // Delete telemetry data for a specific node and type
+    const stmt = this.db.prepare('DELETE FROM telemetry WHERE nodeId = ? AND telemetryType = ?');
+    const result = stmt.run(nodeId, telemetryType);
+    return Number(result.changes) > 0;
+  }
+
   // Database maintenance
   vacuum(): void {
     this.db.exec('VACUUM');


### PR DESCRIPTION
## Summary
Adds a three-dot menu (⋯) next to the favorite star on telemetry graphs that allows users to purge individual telemetry types for specific nodes with confirmation and feedback.

## Changes

### Frontend
- Added context menu button to telemetry graph headers (TelemetryGraphs.tsx:56-342)
- Implemented click-outside detection for menu closing
- Added confirmation dialog before purging data
- Added success/error toast notifications
- Auto-refreshes telemetry data after successful purge
- New context menu styling with Catppuccin theme

### Backend
- Added DELETE `/api/telemetry/:nodeId/:telemetryType` endpoint (server.ts:1939-1957)
- Requires 'info' write permission for access
- Added database method `deleteTelemetryByNodeAndType()` (database.ts:1916-1921)
- Fixed CSRF middleware to handle token length mismatches gracefully (csrf.ts:73-90)

### Database
- New method deletes telemetry records by nodeId and telemetryType
- Returns boolean indicating success (true if rows deleted)

## Testing
- Tested menu open/close functionality
- Verified confirmation dialog appears
- Confirmed data is deleted from database
- Verified permission requirements (info:write)
- Tested CSRF protection
- Verified auto-refresh after successful purge
- Confirmed toast notifications display correctly

## Screenshots
The three-dot menu appears next to the favorite star on each telemetry graph. Clicking it displays a "Purge Data" option that prompts for confirmation before deleting all data of that specific telemetry type for that specific node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)