### PR TITLE
chore: Bump version to 2.17.6

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.17.5
-appVersion: "2.17.5"
+version: 2.17.6
+appVersion: "2.17.6"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.17.5",
+      "version": "2.17.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Version bump to 2.17.6 in preparation for the next release.

## Changes
- Updated version in `package.json` (2.17.5 → 2.17.6)
- Regenerated `package-lock.json`
- Updated version in Helm chart `Chart.yaml` (version and appVersion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)