### PR TITLE
fix: Center map on locally connected node for first-time visitors

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -467,12 +467,25 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   // Calculate center point of all nodes for initial map view
   // Use saved map center from localStorage if available, otherwise calculate from nodes
   const getMapCenter = (): [number, number] => {
+    // Use saved map center from previous session if available
     if (mapCenter) {
       return mapCenter;
     }
+
+    // If no nodes with positions, use default location
     if (nodesWithPosition.length === 0) {
       return [25.7617, -80.1918]; // Default to Miami area
     }
+
+    // Prioritize the locally connected node's position for first-time visitors
+    if (currentNodeId) {
+      const localNode = nodesWithPosition.find(node => node.user?.id === currentNodeId);
+      if (localNode && localNode.position) {
+        return [localNode.position.latitude, localNode.position.longitude];
+      }
+    }
+
+    // Fall back to average position of all nodes
     const avgLat = nodesWithPosition.reduce((sum, node) => sum + node.position!.latitude, 0) / nodesWithPosition.length;
     const avgLng = nodesWithPosition.reduce((sum, node) => sum + node.position!.longitude, 0) / nodesWithPosition.length;
     return [avgLat, avgLng];

--- a/src/contexts/MapContext.tsx
+++ b/src/contexts/MapContext.tsx
@@ -86,7 +86,7 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
         return zoom;
       }
     }
-    return 10;
+    return 13; // Default zoom level for initial view (city/neighborhood level)
   });
   const [traceroutes, setTraceroutes] = useState<DbTraceroute[]>([]);
   const [neighborInfo, setNeighborInfo] = useState<EnrichedNeighborInfo[]>([]);


### PR DESCRIPTION
## Summary
Fixes #590 - Map now centers on locally connected node position for first-time visitors

## Changes
- Modified `getMapCenter()` to prioritize locally connected node position
- Increased default zoom level from 10 to 13 for better initial detail
- Maintained fallback hierarchy: saved center → local node → average of all nodes → Miami default

## Why
First-time visitors were seeing the map centered on an average position of all mesh nodes, which could be far from their own location. This change provides a more intuitive initial experience by centering on the user's locally connected node.

## Test Plan
1. Clear localStorage to simulate first-time visitor
2. Load the Node Map tab
3. Verify map centers on locally connected node position
4. Verify zoom level is 13 (city/neighborhood detail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)