### PR TITLE
Fix connection indicator three-state status (#587)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -704,6 +704,11 @@ body {
   animation: pulse 1s infinite;
 }
 
+.status-indicator.node-offline {
+  background: var(--ctp-yellow);
+  animation: pulse 1.5s infinite;
+}
+
 @keyframes pulse {
   0% {
     box-shadow: 0 0 0 0 rgba(166, 227, 161, 0.7);
@@ -1045,6 +1050,10 @@ body {
 
 .status-text.rebooting {
   color: var(--ctp-peach);
+}
+
+.status-text.node-offline {
+  color: var(--ctp-yellow);
 }
 
 .channel-config {

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -4,7 +4,7 @@ export type SortField = 'longName' | 'shortName' | 'id' | 'lastHeard' | 'snr' | 
 
 export type SortDirection = 'asc' | 'desc';
 
-export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'configuring' | 'rebooting' | 'user-disconnected';
+export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'configuring' | 'rebooting' | 'user-disconnected' | 'node-offline';
 
 export interface MapCenterControllerProps {
   centerTarget: [number, number] | null;


### PR DESCRIPTION
## Summary

Implements a three-state connection indicator to properly distinguish between:
- 🟢 **Green "connected"**: Server connected AND node responsive
- 🟡 **Yellow "Node Offline"**: Server connected but node not responding (device powered off/unplugged)
- 🟡 **Yellow "initializing"**: Node downloading initial configuration
- 🔴 **Red "Offline"**: Server is offline

## Changes

### Backend (meshtasticManager.ts)
- Track node responsiveness using `localNodeInfo` presence as indicator
- Clear `localNodeInfo` on both connect and disconnect events
- Add `nodeResponsive` and `configuring` flags to `getConnectionStatus()` response
- `nodeResponsive` is true when we have received MyNodeInfo from the device
- `configuring` is true when connected but initial config capture is not complete

### Frontend (App.tsx)
- Add 'node-offline' to ConnectionStatus type
- Detect and display yellow "Node Offline" state when server connected but node unresponsive
- Detect and display yellow "initializing" state during config download
- Fix server offline detection by adding error handling to `updateDataFromBackend()`
- Previously, when status was 'connected', failures to fetch data were silently ignored
- Now properly sets status to 'disconnected' when server becomes unreachable

### Styling (App.css)
- Add CSS styling for node-offline indicator with yellow color and pulse animation

## Testing

Tested scenarios:
- ✅ Container shutdown: Shows red "Offline" within 5 seconds
- ✅ Node power off: Shows yellow "Node Offline" when device is unplugged
- ✅ Normal operation: Shows green "connected" when both server and node are operational
- ✅ Config download: Shows yellow "initializing" during initial configuration (if caught by 5-second polling)

### System Tests
All system tests pass:
```
Configuration Import:     ✓ PASSED
Quick Start Test:         ✓ PASSED
Security Test:            ✓ PASSED
Reverse Proxy Test:       ✓ PASSED
Reverse Proxy + OIDC:     ✓ PASSED
Virtual Node CLI Test:    ✓ PASSED
Backup & Restore Test:    ✓ PASSED

✓ ALL SYSTEM TESTS PASSED
```

## Limitations

The yellow states (Node Offline and initializing) may not always be visible during node reboots because:
1. Frontend polls connection status every 5 seconds
2. Node reboots typically complete in 1-2 seconds
3. Brief status windows may be missed between polling intervals

For immediate status changes (like unplugging the device or shutting down the server), the indicator updates correctly within one polling cycle.

## Fixes

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)