### PR TITLE
chore: Bump version to 2.17.7

### DIFF
--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -147,6 +147,20 @@ When enabled, MeshMonitor monitors for nodes that appear for the first time in t
 - **All Channels**: Monitor all channels for new nodes
 - Choose the channel where you expect new users to appear
 
+**Maximum Hops Filter**: Limit welcome messages to nodes within a specific hop range
+
+- **Range**: 0-7 hops
+- **Default**: 7 (all nodes)
+- **Purpose**: Prevents welcoming distant nodes that may not be regular network participants
+- **Use Cases**:
+  - Set to 0-1 for welcoming only direct neighbors
+  - Set to 2-3 for local network participants
+  - Set to 7 to welcome all nodes regardless of distance
+- **Benefits**:
+  - Reduces unnecessary mesh traffic for distant nodes
+  - Focuses welcomes on local/active participants
+  - Helps manage network congestion in large meshes
+
 **Custom Welcome Message**: Craft your welcome message using dynamic tokens:
 
 - **`{SENDER}`**: Long name of the new node joining (e.g., "Alice's Node")

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.17.6
-appVersion: "2.17.6"
+version: 2.17.7
+appVersion: "2.17.7"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.17.6",
+  "version": "2.17.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.17.6",
+      "version": "2.17.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.17.6",
+  "version": "2.17.7",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump version to 2.17.7 in package.json, package-lock.json, and Helm chart
- Update automation documentation to include the new Maximum Hops filter for Auto-Welcome feature

## Changes Since 2.17.6
This release includes the following merged PRs:
- #593: Add maximum hops filter to Auto-Welcome feature
- #592/#587: Implement three-state connection indicator
- #591: Center map on locally connected node for first-time visitors
- #588: Add position exchange button to DM conversations

## Documentation Updates
- Added documentation for Maximum Hops Filter in Auto-Welcome (docs/features/automation.md)
  - Range: 0-7 hops
  - Allows users to limit welcome messages to nearby nodes
  - Reduces network congestion for large meshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)