### PR TITLE
fix: Resolve favorites star icon not updating immediately

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import { flushSync } from 'react-dom'
 import { Popup, Polyline } from 'react-leaflet'
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
 import L from 'leaflet'
@@ -48,6 +49,10 @@ import { useCsrf } from './contexts/CsrfContext'
 import LoginModal from './components/LoginModal'
 import LoginPage from './components/LoginPage'
 import UserMenu from './components/UserMenu'
+
+// Track pending favorite requests outside component to persist across remounts
+// Maps nodeNum -> expected isFavorite state
+const pendingFavoriteRequests = new Map<number, boolean>()
 import TracerouteHistoryModal from './components/TracerouteHistoryModal'
 import RouteSegmentTraceroutesModal from './components/RouteSegmentTraceroutesModal'
 import { NodeFilterPopup } from './components/NodeFilterPopup'
@@ -1727,28 +1732,34 @@ function App() {
       if (pollData.nodes) {
         // Merge server data with local optimistic updates for nodes with pending favorite changes
         // This prevents polling from overwriting optimistic UI updates
-        setNodes(prevNodes => {
-          const pendingNodeNums = pendingFavoriteRequests.current;
+        const pendingRequests = pendingFavoriteRequests;
 
-          if (pendingNodeNums.size === 0) {
-            // No pending updates, safe to use server data as-is
-            return pollData.nodes;
-          }
+        console.log('[POLL] Received nodes:', pollData.nodes.length, 'Pending requests:', pendingRequests.size);
 
+        if (pendingRequests.size === 0) {
+          // No pending updates, safe to use server data as-is
+          setNodes(pollData.nodes);
+        } else {
+          console.log('[POLL] Merging with pending favorites:', Array.from(pendingRequests.entries()));
           // Merge: keep optimistic isFavorite for nodes with pending requests
-          return pollData.nodes.map((serverNode: DeviceInfo) => {
-            if (pendingNodeNums.has(serverNode.nodeNum)) {
-              // Find the current local state for this node
-              const localNode = prevNodes.find(n => n.nodeNum === serverNode.nodeNum);
-              if (localNode) {
-                // Preserve the local optimistic isFavorite value
-                return { ...serverNode, isFavorite: localNode.isFavorite };
+          setNodes(pollData.nodes.map((serverNode: DeviceInfo) => {
+            const pendingState = pendingRequests.get(serverNode.nodeNum);
+            if (pendingState !== undefined) {
+              // Check if server data now matches our pending update
+              if (serverNode.isFavorite === pendingState) {
+                // Server has caught up, remove from pending
+                console.log('[POLL] Server caught up for node:', serverNode.nodeNum);
+                pendingRequests.delete(serverNode.nodeNum);
+                return serverNode;
               }
+              // Server hasn't caught up yet, preserve the local optimistic value
+              console.log('[POLL] Preserving optimistic value for node:', serverNode.nodeNum, 'pending:', pendingState, 'server:', serverNode.isFavorite);
+              return { ...serverNode, isFavorite: pendingState };
             }
             // Use server data for nodes without pending updates
             return serverNode;
-          });
-        });
+          }));
+        }
       }
 
       // Process messages data
@@ -2825,12 +2836,13 @@ function App() {
     }
   }, []);
 
-  // Track pending favorite requests to prevent multiple rapid clicks
-  const pendingFavoriteRequests = useRef<Set<number>>(new Set());
+  // pendingFavoriteRequests is defined as a module-level variable to persist across remounts
 
   // Function to toggle node favorite status
   const toggleFavorite = async (node: DeviceInfo, event: React.MouseEvent) => {
     event.stopPropagation(); // Prevent node selection when clicking star
+
+    console.log('[FAVORITE] Toggle called for node:', node.nodeNum, 'current:', node.isFavorite);
 
     if (!node.user?.id) {
       logger.error('Cannot toggle favorite: node has no user ID');
@@ -2838,7 +2850,8 @@ function App() {
     }
 
     // Prevent multiple rapid clicks on the same node
-    if (pendingFavoriteRequests.current.has(node.nodeNum)) {
+    if (pendingFavoriteRequests.has(node.nodeNum)) {
+      console.log('[FAVORITE] Already pending for node:', node.nodeNum);
       return;
     }
 
@@ -2846,18 +2859,28 @@ function App() {
     const originalFavoriteStatus = node.isFavorite;
     const newFavoriteStatus = !originalFavoriteStatus;
 
-    try {
-      // Mark this request as pending
-      pendingFavoriteRequests.current.add(node.nodeNum);
+    console.log('[FAVORITE] Will update to:', newFavoriteStatus);
 
-      // Optimistically update the UI
-      setNodes(prevNodes =>
-        prevNodes.map(n =>
-          n.nodeNum === node.nodeNum
-            ? { ...n, isFavorite: newFavoriteStatus }
-            : n
-        )
-      );
+    try {
+      // Mark this request as pending with the expected new state
+      pendingFavoriteRequests.set(node.nodeNum, newFavoriteStatus);
+      console.log('[FAVORITE] Set pending for node:', node.nodeNum, 'Map size:', pendingFavoriteRequests.size, 'Map contents:', Array.from(pendingFavoriteRequests.entries()));
+
+      console.log('[FAVORITE] About to call setNodes...');
+      // Optimistically update the UI - use flushSync to force immediate render
+      // This prevents the polling from overwriting the optimistic update before it renders
+      flushSync(() => {
+        setNodes(prevNodes => {
+          console.log('[FAVORITE] setNodes callback executing, prevNodes length:', prevNodes.length);
+          const updated = prevNodes.map(n =>
+            n.nodeNum === node.nodeNum
+              ? { ...n, isFavorite: newFavoriteStatus }
+              : n
+          );
+          console.log('[FAVORITE] setNodes callback complete');
+          return updated;
+        });
+      });
 
       // Send update to backend (with device sync enabled by default)
       const response = await authFetch(`${baseUrl}/api/nodes/${node.user.id}/favorite`, {
@@ -2911,11 +2934,12 @@ function App() {
             : n
         )
       );
+      // Remove from pending on error since we reverted
+      pendingFavoriteRequests.delete(node.nodeNum);
       showToast('Failed to update favorite status. Please try again.', 'error');
-    } finally {
-      // Always remove the pending request marker
-      pendingFavoriteRequests.current.delete(node.nodeNum);
     }
+    // Note: On success, the polling logic will remove from pendingFavoriteRequests
+    // when it detects the server has caught up
   };
 
   // Function to handle sender icon clicks

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1134,6 +1134,25 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 // Memoize NodesTab to prevent re-rendering when App.tsx updates for message status
 // Only re-render when actual node data or map-related props change
 const NodesTab = React.memo(NodesTabComponent, (prevProps, nextProps) => {
+  // Check if favorite status changed for any node
+  // Build sets of favorite node numbers for comparison
+  const prevFavorites = new Set(
+    prevProps.processedNodes.filter(n => n.isFavorite).map(n => n.nodeNum)
+  );
+  const nextFavorites = new Set(
+    nextProps.processedNodes.filter(n => n.isFavorite).map(n => n.nodeNum)
+  );
+
+  // If the sets differ in size or content, favorites changed - must re-render
+  if (prevFavorites.size !== nextFavorites.size) {
+    return false; // Allow re-render
+  }
+  for (const nodeNum of prevFavorites) {
+    if (!nextFavorites.has(nodeNum)) {
+      return false; // Allow re-render
+    }
+  }
+
   // Check if any node's position changed
   // If spiderfier is active (keepSpiderfied), avoid re-rendering to preserve fanout
   // Users can manually refresh the map if a mobile node moves while markers are fanned


### PR DESCRIPTION
## Summary
Fixed an issue where clicking the star to favorite/unfavorite a node wouldn't update the icon immediately when viewing the full node list (worked correctly with filtered lists).

## Root Cause
The React.memo comparison in NodesTab was comparing nodes by array index, but when favorites change, the entire array gets reordered (favorites are sorted to the top). This caused the comparison to look at different nodes and fail to detect the favorite status change.

## Changes Made
- Updated NodesTab.tsx memo comparison to compare sets of favorited node IDs instead of comparing by index position
- Modified App.tsx to use flushSync() to force immediate synchronous rendering of optimistic updates
- Moved pendingFavoriteRequests from component state to module-level to persist across React.StrictMode remounts  
- Improved polling merge logic to properly detect when server has caught up with local changes

## Technical Details
The processedNodes array separates favorites from non-favorites and sorts favorites to the top (App.tsx:2802-2811). When a node's isFavorite changes, its position in the array shifts. The old memo comparison used array indices which compared completely different nodes after reordering. The new comparison builds Sets of favorite node IDs and compares those, correctly detecting any favorite changes regardless of array ordering.

## Test Plan
- [x] Tested with 227 nodes in the mesh
- [x] Star updates immediately when clicked on full node list
- [x] Star updates immediately when clicked on filtered node list  
- [x] Multiple rapid clicks are properly prevented
- [x] Polling continues to merge server updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)