### PR TITLE
chore: Release 2.17.8

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.17.7
-appVersion: "2.17.7"
+version: 2.17.8
+appVersion: "2.17.8"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.17.7",
+  "version": "2.17.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.17.7",
+      "version": "2.17.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.17.7",
+  "version": "2.17.8",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Release 2.17.8

This release includes a bug fix for the Virtual Node Server.

### What's Changed

**Bug Fixes:**
- Improve Virtual Node firmware version synchronization (#598, fixes #597)
  - Updated default firmware version from 2.0.0 to 2.6.0  
  - Added three-tier firmware version resolution (in-memory → database → fallback)
  - Eliminates intermittent "Firmware update required" errors for Android clients

### Pull Requests Merged Since 2.17.7
- #598: fix: Improve Virtual Node firmware version synchronization

### Issues Resolved Since 2.17.7
- #597: [BUG] Firmware update required

**Full Changelog**: https://github.com/Yeraze/meshmonitor/compare/v2.17.7...v2.17.8