### PR TITLE
fix: Respect maxNodeAgeHours setting for traceroute display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2615,7 +2615,7 @@ function App() {
       (msg.from === nodeId || msg.to === nodeId) &&
       msg.to !== '!ffffffff' && // Exclude broadcasts
       msg.channel === -1 && // Only direct messages
-      msg.portnum === 1 // Only text messages, exclude traceroutes (portnum 70)
+      msg.portnum === 1 // Only text messages
     );
   };
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1764,10 +1764,12 @@ apiRouter.post('/position/request', requirePermission('messages', 'write'), asyn
   }
 });
 
-// Get recent traceroutes (last 24 hours)
+// Get recent traceroutes (respects maxNodeAgeHours setting)
 apiRouter.get('/traceroutes/recent', (req, res) => {
   try {
-    const hoursParam = req.query.hours ? parseInt(req.query.hours as string) : 24;
+    // Use maxNodeAgeHours setting from database, fallback to 24 if not set
+    const maxNodeAgeHours = parseInt(databaseService.getSetting('maxNodeAgeHours') || '24');
+    const hoursParam = req.query.hours ? parseInt(req.query.hours as string) : maxNodeAgeHours;
     const limit = req.query.limit ? parseInt(req.query.limit as string) : 100;
 
     const allTraceroutes = databaseService.getAllTraceroutes(limit);


### PR DESCRIPTION
## Summary
Fixed inconsistency where the traceroute display box on the Messages page would sometimes be empty even when the Traceroute History modal showed valid recent traceroutes.

## Root Cause
- Backend `/api/traceroutes/recent` endpoint was hard-coded to filter traceroutes to the last 24 hours
- Frontend `getRecentTraceroute()` function used the user's `maxNodeAgeHours` setting for filtering
- This mismatch caused traceroutes to not appear in the display box when the user's `maxNodeAgeHours` setting differed from 24

## Changes
- Updated `/api/traceroutes/recent` endpoint (src/server/server.ts:1771) to read `maxNodeAgeHours` from database settings instead of using hard-coded 24 hours
- Now both backend and frontend use the same time filter, ensuring consistency
- Traceroute display box now correctly shows traceroutes within the configured time window

## Testing
- Verified traceroute display box shows traceroutes consistent with Traceroute History modal
- Tested with nodes that previously showed empty display despite having recent traceroutes
- Confirmed fix works with different `maxNodeAgeHours` settings

## Impact
- Fixes issue where users would see traceroutes in History but not in the display box
- Ensures consistent behavior across all traceroute UI elements
- Respects user's `maxNodeAgeHours` configuration setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)