### PR TITLE
fix: Correct Docker tag format in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,6 +212,7 @@ jobs:
         id: notes
         run: |
           VERSION="${{ needs.validate-release.outputs.version }}"
+          VERSION_NO_V="${VERSION#v}"  # Remove 'v' prefix for Docker tag
           echo "## 🚀 MeshMonitor ${VERSION}" > release-notes.md
           echo "" >> release-notes.md
           echo "### 📦 Installation" >> release-notes.md
@@ -222,7 +223,7 @@ jobs:
           echo "  --name meshmonitor \\" >> release-notes.md
           echo "  -p 8080:3001 \\" >> release-notes.md
           echo "  -v meshmonitor-data:/data \\" >> release-notes.md
-          echo "  ghcr.io/${{ github.repository }}:${VERSION}" >> release-notes.md
+          echo "  ghcr.io/${{ github.repository }}:${VERSION_NO_V}" >> release-notes.md
           echo '```' >> release-notes.md
           echo "" >> release-notes.md
           echo "### 🧪 Testing" >> release-notes.md


### PR DESCRIPTION
## Summary
Fixes Docker tag format in release notes to match the actual published tags.

## Problem
The Docker metadata action strips the 'v' prefix from version tags when building images (e.g., v2.17.8 becomes 2.17.8), but the release notes were showing installation commands with the 'v' prefix, causing `docker pull` to fail.

## Changes
- Add `VERSION_NO_V` variable that strips 'v' prefix using `${VERSION#v}`
- Use `VERSION_NO_V` for the Docker tag in installation instructions
- Keep `VERSION` with 'v' prefix for release title display

## Testing
- Manually updated releases v2.17.0 through v2.17.8 with correct Docker tags
- Verified correct tag format: `ghcr.io/yeraze/meshmonitor:2.17.8` (without 'v')

## Impact
Future releases will automatically have correct Docker tags in their installation instructions, making it easier for users to pull and run the images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)