### PR TITLE
fix: Resolve Auto Welcome race condition on container startup

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -321,10 +321,8 @@ setTimeout(async () => {
       }
     }
 
-    await meshtasticManager.connect();
-    logger.debug('Meshtastic manager connected successfully');
-
-    // Mark all existing nodes as welcomed to prevent thundering herd on startup
+    // Mark all existing nodes as welcomed BEFORE connecting to prevent thundering herd
+    // This must run before connect() so nodes in the DB are marked before new packets arrive
     const autoWelcomeEnabled = databaseService.getSetting('autoWelcomeEnabled');
     if (autoWelcomeEnabled === 'true') {
       const markedCount = databaseService.markAllNodesAsWelcomed();
@@ -332,6 +330,9 @@ setTimeout(async () => {
         logger.info(`👋 Marked ${markedCount} existing node(s) as welcomed to prevent spam on startup`);
       }
     }
+
+    await meshtasticManager.connect();
+    logger.debug('Meshtastic manager connected successfully');
 
     // Initialize backup scheduler
     backupSchedulerService.initialize(meshtasticManager);

--- a/src/services/database.autowelcome-migration.test.ts
+++ b/src/services/database.autowelcome-migration.test.ts
@@ -251,4 +251,97 @@ describe('DatabaseService - Auto Welcome Migration', () => {
       expect(node.welcomedAt).toBe(now);
     });
   });
+
+  describe('markAllNodesAsWelcomed', () => {
+    it('should mark all nodes without welcomedAt', () => {
+      // Insert some test nodes without welcomedAt
+      const insertStmt = dbService.db.prepare(`
+        INSERT INTO nodes (nodeNum, nodeId, longName, shortName, hwModel, createdAt, updatedAt)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `);
+
+      const now = Date.now();
+      insertStmt.run(111111, '!0001b207', 'Node One', 'ONE', 0, now, now);
+      insertStmt.run(222222, '!000363de', 'Node Two', 'TWO', 0, now, now);
+      insertStmt.run(333333, '!000516f5', 'Node Three', 'THR', 0, now, now);
+
+      // Verify nodes don't have welcomedAt (excluding broadcast node)
+      const beforeStmt = dbService.db.prepare('SELECT COUNT(*) as count FROM nodes WHERE welcomedAt IS NULL AND nodeNum IN (111111, 222222, 333333)');
+      const before = beforeStmt.get() as { count: number };
+      expect(before.count).toBe(3);
+
+      // Mark all nodes as welcomed
+      const markedCount = dbService.markAllNodesAsWelcomed();
+      // Should mark our 3 test nodes (broadcast node may or may not have welcomedAt already)
+      expect(markedCount).toBeGreaterThanOrEqual(3);
+
+      // Verify all our test nodes now have welcomedAt
+      const afterStmt = dbService.db.prepare('SELECT COUNT(*) as count FROM nodes WHERE welcomedAt IS NOT NULL AND nodeNum IN (111111, 222222, 333333)');
+      const after = afterStmt.get() as { count: number };
+      expect(after.count).toBe(3);
+    });
+
+    it('should not modify nodes that already have welcomedAt', () => {
+      const originalWelcomedAt = Date.now() - (10 * 24 * 60 * 60 * 1000); // 10 days ago
+
+      // Insert a node with welcomedAt already set
+      dbService.db.exec(`
+        INSERT INTO nodes (nodeNum, nodeId, longName, shortName, hwModel, welcomedAt, createdAt, updatedAt)
+        VALUES (444444, '!0006c9c0', 'Node Four', 'FOR', 0, ${originalWelcomedAt}, ${Date.now()}, ${Date.now()})
+      `);
+
+      // Mark all nodes
+      dbService.markAllNodesAsWelcomed();
+
+      // Verify the original welcomedAt wasn't changed
+      const stmt = dbService.db.prepare('SELECT welcomedAt FROM nodes WHERE nodeNum = ?');
+      const node = stmt.get(444444) as { welcomedAt: number };
+      expect(node.welcomedAt).toBe(originalWelcomedAt);
+    });
+
+    it('should return 0 when no nodes need to be marked', () => {
+      // Mark all existing nodes first
+      dbService.markAllNodesAsWelcomed();
+
+      // Now calling again should return 0
+      const markedCount = dbService.markAllNodesAsWelcomed();
+      expect(markedCount).toBe(0);
+    });
+
+    it('should handle mixed scenarios correctly', () => {
+      const now = Date.now();
+      const oldWelcomedAt = now - (5 * 24 * 60 * 60 * 1000); // 5 days ago
+
+      // Insert mix of nodes - some with welcomedAt, some without
+      dbService.db.exec(`
+        INSERT INTO nodes (nodeNum, nodeId, longName, shortName, hwModel, welcomedAt, createdAt, updatedAt)
+        VALUES (555555, '!00087a63', 'Node Five', 'FIV', 0, ${oldWelcomedAt}, ${now}, ${now})
+      `);
+
+      dbService.db.exec(`
+        INSERT INTO nodes (nodeNum, nodeId, longName, shortName, hwModel, createdAt, updatedAt)
+        VALUES (666666, '!000a2d26', 'Node Six', 'SIX', 0, ${now}, ${now})
+      `);
+
+      dbService.db.exec(`
+        INSERT INTO nodes (nodeNum, nodeId, longName, shortName, hwModel, createdAt, updatedAt)
+        VALUES (777777, '!000bdc89', 'Node Seven', 'SEV', 0, ${now}, ${now})
+      `);
+
+      // Should only mark the 2 nodes without welcomedAt (666666 and 777777)
+      const markedCount = dbService.markAllNodesAsWelcomed();
+      expect(markedCount).toBeGreaterThanOrEqual(2);
+
+      // Verify node 555555 kept its original timestamp
+      const stmt1 = dbService.db.prepare('SELECT welcomedAt FROM nodes WHERE nodeNum = ?');
+      const node1 = stmt1.get(555555) as { welcomedAt: number };
+      expect(node1.welcomedAt).toBe(oldWelcomedAt);
+
+      // Verify nodes 666666 and 777777 now have welcomedAt
+      const node2 = stmt1.get(666666) as { welcomedAt: number };
+      const node3 = stmt1.get(777777) as { welcomedAt: number };
+      expect(node2.welcomedAt).toBeDefined();
+      expect(node3.welcomedAt).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Fixed a race condition in the Auto Welcome feature where nodes could be welcomed multiple times during container startup, causing a "thundering herd" of welcome messages.

## Problem
When the container starts and Auto Welcome is enabled, there was a timing issue:

1. `meshtasticManager.connect()` establishes TCP connection
2. Node database packets start arriving asynchronously via event handlers
3. Nodes are immediately added to the database and processed
4. `markAllNodesAsWelcomed()` runs **after** connection completes
5. Nodes received **during connection** weren't marked, so they triggered Auto Welcome

This caused users to see dozens of welcome messages when restarting the container with Auto Welcome enabled.

## Solution
Move `markAllNodesAsWelcomed()` to run **before** `meshtasticManager.connect()`:

- Ensures all existing database nodes are marked as welcomed before any new packets arrive
- Prevents the race condition between packet processing and the welcome marking
- No functional changes, just reordered the initialization sequence

## Changes
- **src/server/server.ts**: Move Auto Welcome initialization before connection
- **src/services/database.autowelcome-migration.test.ts**: Add comprehensive tests for `markAllNodesAsWelcomed()`

## Testing
- ✅ All existing tests pass
- ✅ Added 4 new tests for `markAllNodesAsWelcomed()` function
- ✅ System tests running (will update when complete)

## Fixes
Fixes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)