### PR TITLE
feat: Add channel-based Auto Responder support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5700,6 +5700,7 @@ function App() {
               <AutoResponderSection
                 enabled={autoResponderEnabled}
                 triggers={autoResponderTriggers}
+                channels={channels}
                 baseUrl={baseUrl}
                 onEnabledChange={setAutoResponderEnabled}
                 onTriggersChange={setAutoResponderTriggers}


### PR DESCRIPTION
## Summary

Adds the ability to configure Auto Responder triggers to work on specific channels or direct messages. When a trigger is configured for a channel, responses are sent to that channel instead of via DM.

## Changes

### Frontend
- ✅ Add channel selection dropdown to Auto Responder trigger configuration
- ✅ Display channel badge showing "DM" or "CH N: Name" for each trigger
- ✅ Automatically disable "Verify Response" checkbox for channel-based triggers (channels don't support ACKs)
- ✅ Pass channels prop from App.tsx to AutoResponderSection

### Backend
- ✅ Add `channel` field to AutoResponderTrigger interface (type: `number | 'dm'`)
- ✅ Update `checkAutoResponder()` to filter triggers by channel/DM
- ✅ Channel messages: `maxAttempts = 1` (no retries, no ACK support)
- ✅ DM messages: `maxAttempts = 3` (with retry logic when verifyResponse enabled)

### Message Queue
- ✅ Add `channel` parameter to QueuedMessage interface
- ✅ Update `enqueue()` to accept channel parameter
- ✅ Update sendCallback to route messages appropriately:
  - **Channels:** `destination=0`, `channel=channelIndex`
  - **DMs:** `destination=nodeNumber`, `channel=undefined`

### Data Migration
- ✅ Automatic migration on server startup sets undefined channel fields to 'dm'
- ✅ Ensures backward compatibility with existing triggers

## Fixes
- Fixed display showing "Channel unknown" for legacy triggers (now shows "DM")
- Prevented duplicate responses on channels (single attempt only)
- Improved logging to clearly show channel vs DM targets

## Testing
- ✅ Tested with channel 1 (meshmonitor)
- ✅ Verified responses sent to channel (not DM)
- ✅ Verified single attempt (no retries)
- ✅ Verified DM triggers still work with retry logic
- ✅ Verified migration works for existing triggers

## Screenshots

### Channel Selection UI
Triggers can now be configured for specific channels:
- Direct Messages (default, supports retry logic)
- Channel 0-7 (single attempt, no retries)

### Channel Badge Display
Each trigger displays a badge showing where it will respond:
- **DM** (blue) - Direct message trigger
- **CH N: Name** (purple) - Channel trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)