### PR TITLE
fix: Truncate long telemetry chart titles on mobile to prevent layout overflow

### DIFF
--- a/src/components/TelemetryGraphs.css
+++ b/src/components/TelemetryGraphs.css
@@ -46,6 +46,10 @@
   margin: 0;
   font-size: 1rem;
   font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: calc(100% - 60px); /* Reserve space for favorite and menu buttons */
 }
 
 .graph-actions {

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -575,7 +575,7 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(({ nodeId, te
           return (
             <div key={type} className="graph-container">
               <div className="graph-header">
-                <h4 className="graph-title">{label} {unit && `(${unit})`}</h4>
+                <h4 className="graph-title" title={`${label} ${unit ? `(${unit})` : ''}`}>{label} {unit && `(${unit})`}</h4>
                 <div className="graph-actions">
                   <button
                     className={`favorite-btn ${favorites.has(type) ? 'favorited' : ''}`}


### PR DESCRIPTION
## Summary
- Fixes mobile layout issues where long telemetry chart titles caused overflow and broke the dashboard layout
- Adds text truncation with ellipsis for chart titles on mobile devices
- Implements tooltip to show full chart name on hover/tap

## Changes
- Added CSS text truncation (`overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`) to `.graph-title` class
- Set `max-width: calc(100% - 60px)` to reserve space for favorite and menu buttons
- Added `title` attribute to chart title `h4` element for full-text tooltip accessibility

## Testing
- Tested on mobile viewport with long chart names like "Signal-to-Noise Ratio (SNR)" and "SNR - Local (Our Measurements)"
- Verified text truncates properly with ellipsis
- Confirmed favorite and menu buttons remain visible and functional
- Verified tooltip shows full chart name on hover

## Screenshots
Long chart names now truncate gracefully on mobile devices while maintaining button functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)