### PR TITLE
feat: Add Purge Node Database button to Configuration page

### DIFF
--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -430,6 +430,34 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
     }
   };
 
+  const handlePurgeNodeDb = async () => {
+    const confirmed = window.confirm(
+      'Are you sure you want to purge the node database?\n\n' +
+      'This will PERMANENTLY DELETE all stored node information from the device.\n' +
+      'This action CANNOT be undone!\n\n' +
+      'The device will automatically rebuild the database as it hears from nodes on the mesh.'
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    setIsSaving(true);
+    setStatusMessage('');
+    try {
+      await apiService.purgeNodeDb(0);
+      setStatusMessage('Node database purged successfully!');
+      showToast('Node database purged successfully!', 'success');
+    } catch (error) {
+      logger.error('Error purging node database:', error);
+      const errorMsg = error instanceof Error ? error.message : 'Failed to purge node database';
+      setStatusMessage(`Error: ${errorMsg}`);
+      showToast(`Failed to purge node database: ${errorMsg}`, 'error');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="tab-content">
@@ -452,7 +480,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
           Incorrect settings may cause communication issues, network problems, or require a factory reset.
           Only modify these settings if you understand what you are doing.
         </p>
-        <div style={{ marginTop: '1.5rem' }}>
+        <div style={{ marginTop: '1.5rem', display: 'flex', gap: '1rem' }}>
           <button
             onClick={handleRebootDevice}
             disabled={isSaving}
@@ -469,6 +497,23 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
             }}
           >
             🔄 Reboot Device
+          </button>
+          <button
+            onClick={handlePurgeNodeDb}
+            disabled={isSaving}
+            style={{
+              backgroundColor: '#d32f2f',
+              color: '#fff',
+              padding: '0.75rem 1.5rem',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: isSaving ? 'not-allowed' : 'pointer',
+              fontSize: '1rem',
+              fontWeight: 'bold',
+              opacity: isSaving ? 0.6 : 1
+            }}
+          >
+            🗑️ Purge Node Database
           </button>
         </div>
       </div>

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5312,6 +5312,30 @@ class MeshtasticManager {
   }
 
   /**
+   * Purge the node database on the connected Meshtastic device
+   * @param seconds Number of seconds to wait before purging (typically 0 for immediate)
+   */
+  async purgeNodeDb(seconds: number = 0): Promise<void> {
+    if (!this.isConnected || !this.transport) {
+      throw new Error('Not connected to Meshtastic node');
+    }
+
+    try {
+      logger.debug(`⚙️ Sending purge node database command: will purge in ${seconds} seconds`);
+      // NOTE: Session passkeys are only required for REMOTE admin operations (admin messages sent to other nodes via mesh).
+      // For local TCP connections to the device itself, no session passkey is needed.
+      const purgeMsg = protobufService.createPurgeNodeDbMessage(seconds);
+      const adminPacket = protobufService.createAdminPacket(purgeMsg, this.localNodeInfo?.nodeNum || 0, this.localNodeInfo?.nodeNum);
+
+      await this.transport.send(adminPacket);
+      logger.debug('⚙️ Sent purge node database admin message (local operation, no session passkey required)');
+    } catch (error) {
+      logger.error('❌ Error sending purge node database command:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Set device configuration (role, broadcast intervals, etc.)
    */
   async setDeviceConfig(config: any): Promise<void> {

--- a/src/server/protobufService.ts
+++ b/src/server/protobufService.ts
@@ -1122,6 +1122,39 @@ class ProtobufService {
   }
 
   /**
+   * Create an AdminMessage to purge the node database
+   * @param seconds Number of seconds to wait before purging (typically 0 for immediate)
+   * @param sessionPasskey Optional session passkey for authentication
+   */
+  createPurgeNodeDbMessage(seconds: number = 0, sessionPasskey?: Uint8Array): Uint8Array {
+    try {
+      const root = getProtobufRoot();
+      const AdminMessage = root?.lookupType('meshtastic.AdminMessage');
+      if (!AdminMessage) {
+        throw new Error('AdminMessage type not found in loaded proto files');
+      }
+
+      const adminMsgData: any = {
+        nodedbReset: seconds
+      };
+
+      // Only include sessionPasskey if provided
+      if (sessionPasskey && sessionPasskey.length > 0) {
+        adminMsgData.sessionPasskey = sessionPasskey;
+      }
+
+      const adminMsg = AdminMessage.create(adminMsgData);
+
+      const encoded = AdminMessage.encode(adminMsg).finish();
+      logger.debug(`⚙️ Created NodeDB Reset admin message (nodedbReset=${seconds})`);
+      return encoded;
+    } catch (error) {
+      logger.error('Failed to create NodeDB Reset message:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Create an AdminMessage to begin settings edit transaction
    * @param sessionPasskey Optional session passkey for authentication
    */

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3573,6 +3573,25 @@ apiRouter.post('/device/reboot', requirePermission('configuration', 'write'), as
   }
 });
 
+apiRouter.post('/device/purge-nodedb', requirePermission('configuration', 'write'), async (req, res) => {
+  try {
+    const seconds = req.body?.seconds || 0;
+
+    // Purge the device's node database
+    await meshtasticManager.purgeNodeDb(seconds);
+
+    // Also purge the local database
+    logger.info('🗑️ Purging local node database');
+    databaseService.purgeAllNodes();
+    logger.info('✅ Local node database purged successfully');
+
+    res.json({ success: true, message: `Node database purged (both device and local)${seconds > 0 ? ` in ${seconds} seconds` : ''}` });
+  } catch (error) {
+    logger.error('Error purging node database:', error);
+    res.status(500).json({ error: 'Failed to purge node database' });
+  }
+});
+
 // Helper to detect if running in Docker
 function isRunningInDocker(): boolean {
   try {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -892,6 +892,23 @@ class ApiService {
     return response.json();
   }
 
+  async purgeNodeDb(seconds: number = 0) {
+    await this.ensureBaseUrl();
+    const response = await fetch(`${this.baseUrl}/api/device/purge-nodedb`, {
+      method: 'POST',
+      headers: this.getHeadersWithCsrf(),
+      credentials: 'include',
+      body: JSON.stringify({ seconds }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.error || 'Failed to purge node database');
+    }
+
+    return response.json();
+  }
+
   async restartContainer() {
     await this.ensureBaseUrl();
     const response = await fetch(`${this.baseUrl}/api/system/restart`, {


### PR DESCRIPTION
## Summary
Adds a "Purge Node Database" button next to the "Reboot Device" button on the Configuration page. This allows users to clear both the device's NodeDB and the local MeshMonitor database.

## Changes

### Backend
- **protobufService.ts**: Added `createPurgeNodeDbMessage()` method to create AdminMessage with `nodedb_reset` command
- **meshtasticManager.ts**: Added `purgeNodeDb()` method to send the purge command to the device
- **server.ts**: Added `/api/device/purge-nodedb` endpoint with proper permission checks (`configuration:write`)
- Endpoint purges both device NodeDB and local database (nodes, messages, telemetry, traceroutes, route segments, neighbor info)

### Frontend
- **api.ts**: Added `purgeNodeDb()` method to call the backend API
- **ConfigurationTab.tsx**: 
  - Added `handlePurgeNodeDb()` handler with confirmation dialog
  - Added "Purge Node Database" button (🗑️) with darker red color (#d32f2f) to indicate destructive action
  - Button placed next to "Reboot Device" button in the warning section

## Features
- Confirmation dialog warns users about permanent deletion
- Uses Meshtastic `nodedb_reset` AdminMessage command (admin.proto:473)
- Requires `configuration:write` permission
- Provides toast notifications for success/error states
- Both databases will automatically repopulate as new packets are received from the mesh

## Testing
- Built and deployed successfully in Docker
- Button appears on Configuration page next to Reboot Device button
- Proper warning and confirmation flow

## Screenshots
The button appears at the top of the Configuration page in the warning section:
- 🔄 **Reboot Device** (red #ff6b6b)
- 🗑️ **Purge Node Database** (darker red #d32f2f)

Fixes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)