### PR TITLE
fix: Add tooltip support for truncated dashboard chart titles

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -147,7 +147,7 @@ const SortableChartItem: React.FC<SortableChartItemProps> = React.memo(({
           <div className="dashboard-drag-handle" {...attributes} {...listeners}>
             ⋮⋮
           </div>
-          <h3 className="dashboard-chart-title">
+          <h3 className="dashboard-chart-title" title={`${nodeName} - ${getTelemetryLabel(favorite.telemetryType)}`}>
             {nodeName} - {getTelemetryLabel(favorite.telemetryType)}
           </h3>
           <button
@@ -174,7 +174,7 @@ const SortableChartItem: React.FC<SortableChartItemProps> = React.memo(({
         <div className="dashboard-drag-handle" {...attributes} {...listeners}>
           ⋮⋮
         </div>
-        <h3 className="dashboard-chart-title">
+        <h3 className="dashboard-chart-title" title={`${nodeName} - ${getTelemetryLabel(favorite.telemetryType)} ${unit ? `(${unit})` : ''}`}>
           {nodeName} - {getTelemetryLabel(favorite.telemetryType)} {unit && `(${unit})`}
         </h3>
         <button


### PR DESCRIPTION
## Summary
- Applies the same fix from PR #618 to the telemetry dashboard
- Adds tooltip support for chart titles that are truncated on mobile devices
- Improves mobile UX by allowing users to see full chart names on hover/tap

## Changes
- Added `title` attributes to dashboard chart title `h3` elements for full-text tooltip accessibility
- Covers both the "no data" state and the normal state with chart data
- Dashboard.css already has proper text truncation (`overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`) implemented using flexbox layout

## Testing
- Verified tooltip functionality shows complete chart names when truncated
- Tested on mobile viewport with long chart names
- Confirmed existing text truncation behavior works correctly

## Related
- Follows the pattern established in PR #618 for TelemetryGraphs component
- Maintains consistency across both telemetry displays (per-node graphs and dashboard favorites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)