### PR TITLE
fix: Ensure locally connected node always shows as secure

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2274,6 +2274,24 @@ class MeshtasticManager {
         nodeData.shortName = nodeInfo.user.shortName;
         nodeData.hwModel = nodeInfo.user.hwModel;
         nodeData.role = nodeInfo.user.role;
+
+        // Capture public key if present (important for local node)
+        if (nodeInfo.user.publicKey && nodeInfo.user.publicKey.length > 0) {
+          // Convert Uint8Array to base64 for storage
+          nodeData.publicKey = Buffer.from(nodeInfo.user.publicKey).toString('base64');
+          nodeData.hasPKC = true;
+          logger.debug(`🔐 Captured public key for ${nodeId}: ${nodeData.publicKey.substring(0, 16)}...`);
+
+          // Check for key security issues
+          const { checkLowEntropyKey } = await import('../services/lowEntropyKeyService.js');
+          const isLowEntropy = checkLowEntropyKey(nodeData.publicKey, 'base64');
+
+          if (isLowEntropy) {
+            nodeData.keyIsLowEntropy = true;
+            nodeData.keySecurityIssueDetails = 'Known low-entropy key detected - this key is compromised and should be regenerated';
+            logger.warn(`⚠️ Low-entropy key detected for node ${nodeId}!`);
+          }
+        }
       }
 
       // viaMqtt is at the top level of NodeInfo, not inside user

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2051,8 +2051,19 @@ apiRouter.get('/telemetry/available/nodes', requirePermission('info', 'read'), (
 
     // Check for PKC-enabled nodes
     const nodesWithPKC: string[] = [];
+
+    // Get the local node ID to ensure it's always marked as secure
+    const localNodeNumStr = databaseService.getSetting('localNodeNum');
+    let localNodeId: string | null = null;
+    if (localNodeNumStr) {
+      const localNodeNum = parseInt(localNodeNumStr, 10);
+      localNodeId = `!${localNodeNum.toString(16).padStart(8, '0')}`;
+    }
+
     nodes.forEach(node => {
-      if (node.hasPKC || node.publicKey) {
+      // Local node is always secure (direct TCP/serial connection, no mesh encryption needed)
+      // OR node has PKC enabled
+      if (node.nodeId === localNodeId || node.hasPKC || node.publicKey) {
         nodesWithPKC.push(node.nodeId);
       }
     });


### PR DESCRIPTION
## Summary
- Fix locally connected node showing as insecure despite being impossible to be insecure
- Add publicKey capture to NodeInfo processing for local node
- Ensure `/api/telemetry/available/nodes` always marks local node as secure

## Problem
After PR #616 fixed PKC status for Virtual Nodes, the locally connected node was still showing as insecure. This is technically impossible because the local node communicates directly via TCP/serial connection, not over the mesh network where encryption would be needed.

## Root Cause
1. `processNodeInfoProtobuf()` wasn't capturing the publicKey from NodeInfo messages during initial configuration (only `processNodeInfoMessageProtobuf()` did this for remote nodes)
2. The `/api/telemetry/available/nodes` endpoint didn't account for the fact that local connections are inherently secure regardless of PKC status on the mesh

## Changes
**src/server/meshtasticManager.ts** (lines 2278-2294):
- Added publicKey capture logic to `processNodeInfoProtobuf()` 
- Mirrors the existing logic from `processNodeInfoMessageProtobuf()` for consistency
- Includes low-entropy key detection for security
- Ensures local node PKC status is captured during initial configuration

**src/server/server.ts** (lines 2055-2069):
- Modified `/api/telemetry/available/nodes` endpoint to identify the local node
- Always includes local node in the PKC list since local connections are inherently secure
- Local node communicates via direct TCP/serial connection (no mesh encryption layer)

## Why Local Node Is Always Secure
The locally connected node communicates directly with MeshMonitor via TCP or serial connection. There is no mesh network hop involved, so there's no opportunity for mesh-level packet interception. The PKC indicator for mesh communication doesn't apply to the direct local connection.

## Test Plan
- [x] Build and deploy fix to Docker container
- [x] Verify code deployment in container
- [ ] Test with actual hardware to confirm local node shows secure indicator

## Files Modified
- `src/server/meshtasticManager.ts` - Added publicKey capture to NodeInfo processing
- `src/server/server.ts` - Always mark local node as secure in API endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)