### PR TITLE
fix: Apply activity filtering to Virtual Node initial config

### DIFF
--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -533,8 +533,11 @@ export class VirtualNodeServer extends EventEmitter {
       }
 
       // === STEP 2: Rebuild and send all NodeInfo entries from database ===
-      const allNodes = databaseService.getAllNodes();
-      logger.debug(`Virtual node: Rebuilding ${allNodes.length} NodeInfo entries from database`);
+      // Apply activity filtering based on maxNodeAgeHours setting
+      const maxNodeAgeHours = parseInt(databaseService.getSetting('maxNodeAgeHours') || '24');
+      const maxNodeAgeDays = maxNodeAgeHours / 24;
+      const allNodes = databaseService.getActiveNodes(maxNodeAgeDays);
+      logger.debug(`Virtual node: Rebuilding ${allNodes.length} active NodeInfo entries from database (maxNodeAgeHours: ${maxNodeAgeHours})`);
 
       for (const node of allNodes) {
         // Check if client is still connected


### PR DESCRIPTION
## Summary
The Virtual Node was sending all nodes (including inactive/stale ones) to connected clients regardless of their activity status. This change applies the `maxNodeAgeHours` setting to filter out inactive nodes during the initial config replay.

## Problem
In `virtualNodeServer.ts:536`, the code was using `getAllNodes()` which retrieves every node from the database regardless of when it was last heard from. This meant mobile clients connecting to the Virtual Node would receive information about nodes that may not have been active in weeks or months, ignoring the user's configured `maxNodeAgeHours` setting.

## Solution
- Read `maxNodeAgeHours` setting (default: 24 hours) from database settings
- Use `getActiveNodes(maxNodeAgeDays)` instead of `getAllNodes()` in `sendInitialConfig()`
- Only send nodes heard within the configured time window to connected clients
- Add debug logging showing active node count and filter threshold

## Changes
- Modified `src/server/virtualNodeServer.ts` lines 536-540
- Changed from `getAllNodes()` to `getActiveNodes(maxNodeAgeDays)`
- Added configuration reading for `maxNodeAgeHours`
- Enhanced logging to show filter threshold

## Benefits
- Consistent with other parts of the application that already use `maxNodeAgeHours` filtering
- Prevents mobile clients from seeing stale/inactive nodes
- Reduces the number of NodeInfo messages sent during initial connection
- Improves data quality for connected clients
- Respects user configuration preferences

## Testing
Tested with Docker container deployment. The Virtual Node now correctly filters nodes based on the configured activity threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)