### PR TITLE
fix: Use explicit null check for welcomedAt to prevent re-welcomes

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -4709,7 +4709,8 @@ class MeshtasticManager {
       }
 
       // Skip if node has already been welcomed (nodes should only be welcomed once)
-      if (node.welcomedAt) {
+      // Use explicit null/undefined check to handle edge case where welcomedAt might be 0
+      if (node.welcomedAt !== null && node.welcomedAt !== undefined) {
         logger.debug(`⏭️  Skipping auto-welcome for ${nodeId} - already welcomed previously`);
         return;
       }


### PR DESCRIPTION
## Summary

Fixed a potential edge case in auto-welcome logic where a node with `welcomedAt=0` could be re-welcomed repeatedly due to JavaScript's truthy evaluation treating `0` as falsy.

## Changes

**Before:**
```typescript
if (node.welcomedAt) {
  logger.debug(`⏭️  Skipping auto-welcome for ${nodeId} - already welcomed previously`);
  return;
}
```

**After:**
```typescript
if (node.welcomedAt !== null && node.welcomedAt !== undefined) {
  logger.debug(`⏭️  Skipping auto-welcome for ${nodeId} - already welcomed previously`);
  return;
}
```

## Impact

This defensive programming approach ensures that any non-null, non-undefined value (including `0`) will prevent re-welcomes.

While no production code path currently sets `welcomedAt` to `0`, this fix makes the code more robust against edge cases such as:
- Legacy data from old databases
- Database corruption or failed updates  
- Restored backups with unusual timestamp values

## Testing

- All 16 existing auto-welcome tests pass
- No behavioral changes for normal cases (where `welcomedAt` is either `null` or a proper timestamp)

## Related Issues

Fixes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)