### PR TITLE
feat: Add Unmessageable tag support in Node Identity configuration

### DIFF
--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -31,6 +31,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
   // Device Config State
   const [longName, setLongName] = useState('');
   const [shortName, setShortName] = useState('');
+  const [isUnmessagable, setIsUnmessagable] = useState(false);
   const [role, setRole] = useState<number>(0);
   const [nodeInfoBroadcastSecs, setNodeInfoBroadcastSecs] = useState(3600);
 
@@ -91,6 +92,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
         if (config.localNodeInfo) {
           setLongName(config.localNodeInfo.longName || '');
           setShortName(config.localNodeInfo.shortName || '');
+          setIsUnmessagable(config.localNodeInfo.isUnmessagable || false);
         }
 
         // Populate device config
@@ -259,7 +261,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
     setIsSaving(true);
     setStatusMessage('');
     try {
-      await apiService.setNodeOwner(longName, shortName);
+      await apiService.setNodeOwner(longName, shortName, isUnmessagable);
       setStatusMessage('Node names saved successfully! Device will reboot...');
       showToast('Node names saved! Device will reboot...', 'success');
       onConfigChangeTriggeringReboot?.();
@@ -605,8 +607,10 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
         <NodeIdentitySection
           longName={longName}
           shortName={shortName}
+          isUnmessagable={isUnmessagable}
           setLongName={setLongName}
           setShortName={setShortName}
+          setIsUnmessagable={setIsUnmessagable}
           isSaving={isSaving}
           onSave={handleSaveNodeOwner}
         />

--- a/src/components/configuration/NodeIdentitySection.tsx
+++ b/src/components/configuration/NodeIdentitySection.tsx
@@ -3,8 +3,10 @@ import React from 'react';
 interface NodeIdentitySectionProps {
   longName: string;
   shortName: string;
+  isUnmessagable: boolean;
   setLongName: (value: string) => void;
   setShortName: (value: string) => void;
+  setIsUnmessagable: (value: boolean) => void;
   isSaving: boolean;
   onSave: () => Promise<void>;
 }
@@ -12,8 +14,10 @@ interface NodeIdentitySectionProps {
 const NodeIdentitySection: React.FC<NodeIdentitySectionProps> = ({
   longName,
   shortName,
+  isUnmessagable,
   setLongName,
   setShortName,
+  setIsUnmessagable,
   isSaving,
   onSave
 }) => {
@@ -64,6 +68,21 @@ const NodeIdentitySection: React.FC<NodeIdentitySectionProps> = ({
           className="setting-input"
           placeholder="MESH"
         />
+      </div>
+      <div className="setting-item">
+        <label htmlFor="isUnmessagable" style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+          <input
+            id="isUnmessagable"
+            type="checkbox"
+            checked={isUnmessagable}
+            onChange={(e) => setIsUnmessagable(e.target.checked)}
+            style={{ marginTop: '0.2rem', flexShrink: 0 }}
+          />
+          <div style={{ flex: 1 }}>
+            <div>Unmessageable</div>
+            <span className="setting-description">Prevent others from sending direct messages to this node</span>
+          </div>
+        </label>
       </div>
       <button
         className="save-button"

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5704,14 +5704,14 @@ class MeshtasticManager {
   /**
    * Set node owner (long name and short name)
    */
-  async setNodeOwner(longName: string, shortName: string): Promise<void> {
+  async setNodeOwner(longName: string, shortName: string, isUnmessagable?: boolean): Promise<void> {
     if (!this.isConnected || !this.transport) {
       throw new Error('Not connected to Meshtastic node');
     }
 
     try {
-      logger.debug(`⚙️ Setting node owner: "${longName}" (${shortName})`);
-      const setOwnerMsg = protobufService.createSetOwnerMessage(longName, shortName, new Uint8Array());
+      logger.debug(`⚙️ Setting node owner: "${longName}" (${shortName}), isUnmessagable: ${isUnmessagable}`);
+      const setOwnerMsg = protobufService.createSetOwnerMessage(longName, shortName, isUnmessagable, new Uint8Array());
       const adminPacket = protobufService.createAdminPacket(setOwnerMsg, this.localNodeInfo?.nodeNum || 0, this.localNodeInfo?.nodeNum);
 
       await this.transport.send(adminPacket);

--- a/src/server/protobufService.ts
+++ b/src/server/protobufService.ts
@@ -1052,9 +1052,10 @@ class ProtobufService {
    * Create an AdminMessage to set node owner (long name and short name)
    * @param longName Node long name
    * @param shortName Node short name
+   * @param isUnmessagable Optional flag to prevent others from sending direct messages
    * @param sessionPasskey Optional session passkey for authentication
    */
-  createSetOwnerMessage(longName: string, shortName: string, sessionPasskey?: Uint8Array): Uint8Array {
+  createSetOwnerMessage(longName: string, shortName: string, isUnmessagable?: boolean, sessionPasskey?: Uint8Array): Uint8Array {
     try {
       const root = getProtobufRoot();
       const AdminMessage = root?.lookupType('meshtastic.AdminMessage');
@@ -1065,7 +1066,8 @@ class ProtobufService {
 
       const userMsg = User.create({
         longName: longName,
-        shortName: shortName
+        shortName: shortName,
+        isUnmessagable: isUnmessagable
       });
 
       const adminMsgData: any = {
@@ -1080,7 +1082,7 @@ class ProtobufService {
       const adminMsg = AdminMessage.create(adminMsgData);
 
       const encoded = AdminMessage.encode(adminMsg).finish();
-      logger.debug(`⚙️ Created SetOwner admin message: "${longName}" (${shortName})`);
+      logger.debug(`⚙️ Created SetOwner admin message: "${longName}" (${shortName}), isUnmessagable: ${isUnmessagable}`);
       return encoded;
     } catch (error) {
       logger.error('Failed to create SetOwner message:', error);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3604,12 +3604,12 @@ apiRouter.post('/config/neighborinfo', requirePermission('configuration', 'write
 
 apiRouter.post('/config/owner', requirePermission('configuration', 'write'), async (req, res) => {
   try {
-    const { longName, shortName } = req.body;
+    const { longName, shortName, isUnmessagable } = req.body;
     if (!longName || !shortName) {
       res.status(400).json({ error: 'longName and shortName are required' });
       return;
     }
-    await meshtasticManager.setNodeOwner(longName, shortName);
+    await meshtasticManager.setNodeOwner(longName, shortName, isUnmessagable);
     res.json({ success: true, message: 'Node owner updated' });
   } catch (error) {
     logger.error('Error setting node owner:', error);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -824,13 +824,13 @@ class ApiService {
     return response.json();
   }
 
-  async setNodeOwner(longName: string, shortName: string) {
+  async setNodeOwner(longName: string, shortName: string, isUnmessagable?: boolean) {
     await this.ensureBaseUrl();
     const response = await fetch(`${this.baseUrl}/api/config/owner`, {
       method: 'POST',
       headers: this.getHeadersWithCsrf(),
       credentials: 'include',
-      body: JSON.stringify({ longName, shortName }),
+      body: JSON.stringify({ longName, shortName, isUnmessagable }),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
Implements support for the `is_unmessagable` field from the Meshtastic User packet, allowing users to configure the "Unmessageable" tag through the MeshMonitor configuration interface.

## Changes
- **Frontend:**
  - Added checkbox UI in NodeIdentitySection for Unmessageable setting
  - Added state management in ConfigurationTab  
  - Updated API service to pass isUnmessagable parameter

- **Backend:**
  - Updated `/api/config/owner` endpoint to handle isUnmessagable field
  - Updated meshtasticManager to include isUnmessagable in SetOwner message
  - Updated protobufService to include isUnmessagable in User message (field 9)

## Test plan
- [x] Built Docker image successfully
- [ ] System tests are currently running
- [ ] Manual testing: Verify checkbox appears in Configuration > Node Identity section  
- [ ] Manual testing: Toggle checkbox and save, verify device receives is_unmessagable field
- [ ] Manual testing: Verify setting persists across page reloads

## Related Issue
Closes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)