### PR TITLE
feat: Add Transmit Power configuration to LoRa settings

### DIFF
--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -45,6 +45,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
   const [overrideFrequency, setOverrideFrequency] = useState<number>(0);
   const [region, setRegion] = useState<number>(0);
   const [hopLimit, setHopLimit] = useState<number>(3);
+  const [txPower, setTxPower] = useState<number>(0);
   const [channelNum, setChannelNum] = useState<number>(0);
   const [sx126xRxBoostedGain, setSx126xRxBoostedGain] = useState<boolean>(false);
 
@@ -143,6 +144,9 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
           if (config.deviceConfig.lora.hopLimit !== undefined) {
             console.log(`[ConfigurationTab] Setting hopLimit to: ${config.deviceConfig.lora.hopLimit}`);
             setHopLimit(config.deviceConfig.lora.hopLimit);
+          }
+          if (config.deviceConfig.lora.txPower !== undefined) {
+            setTxPower(config.deviceConfig.lora.txPower);
           }
           if (config.deviceConfig.lora.channelNum !== undefined) {
             setChannelNum(config.deviceConfig.lora.channelNum);
@@ -298,6 +302,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
         overrideFrequency,
         region,
         hopLimit: validHopLimit,
+        txPower,
         channelNum,
         sx126xRxBoostedGain
       });
@@ -643,6 +648,8 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
           setRegion={setRegion}
           hopLimit={hopLimit}
           setHopLimit={setHopLimit}
+          txPower={txPower}
+          setTxPower={setTxPower}
           channelNum={channelNum}
           setChannelNum={setChannelNum}
           sx126xRxBoostedGain={sx126xRxBoostedGain}

--- a/src/components/configuration/LoRaConfigSection.tsx
+++ b/src/components/configuration/LoRaConfigSection.tsx
@@ -11,6 +11,7 @@ interface LoRaConfigSectionProps {
   overrideFrequency: number;
   region: number;
   hopLimit: number;
+  txPower: number;
   channelNum: number;
   sx126xRxBoostedGain: boolean;
   setUsePreset: (value: boolean) => void;
@@ -22,6 +23,7 @@ interface LoRaConfigSectionProps {
   setOverrideFrequency: (value: number) => void;
   setRegion: (value: number) => void;
   setHopLimit: (value: number) => void;
+  setTxPower: (value: number) => void;
   setChannelNum: (value: number) => void;
   setSx126xRxBoostedGain: (value: boolean) => void;
   isSaving: boolean;
@@ -38,6 +40,7 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
   overrideFrequency,
   region,
   hopLimit,
+  txPower,
   channelNum,
   sx126xRxBoostedGain,
   setUsePreset,
@@ -49,6 +52,7 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
   setOverrideFrequency,
   setRegion,
   setHopLimit,
+  setTxPower,
   setChannelNum,
   setSx126xRxBoostedGain,
   isSaving,
@@ -287,6 +291,19 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
           max="7"
           value={hopLimit}
           onChange={(e) => setHopLimit(parseInt(e.target.value))}
+          className="setting-input"
+        />
+      </div>
+      <div className="setting-item">
+        <label htmlFor="txPower">
+          Transmit Power (dBm)
+          <span className="setting-description">LoRa transmit power in dBm. Value of 0 uses the default maximum safe power for your hardware. Units are in dBm.</span>
+        </label>
+        <input
+          id="txPower"
+          type="number"
+          value={txPower}
+          onChange={(e) => setTxPower(parseInt(e.target.value))}
           className="setting-input"
         />
       </div>


### PR DESCRIPTION
## Summary
- Add missing Transmit Power (dBm) field to the LoRa Radio Configuration section
- Allows users to configure LoRa radio transmit power directly from the Device Configuration page
- Backend already supported this field; this PR adds the missing UI component

## Changes
- Add `txPower` state management to ConfigurationTab
- Add `txPower` input field to LoRaConfigSection component  
- Include `txPower` in configuration loading and saving logic
- Add help text explaining that 0 uses default maximum safe power for the hardware

## Technical Details
The `tx_power` field is defined in the Meshtastic protobuf at `config.proto:1048` as part of LoRaConfig. The backend services (protobufService.ts and meshtasticManager.ts) already had full support for this field - only the frontend UI component was missing.

The field is positioned in the UI between "Hop Limit" and "Channel Number" in the LoRa Radio Configuration section.

## Test Plan
- [x] Build Docker image with changes
- [ ] Verify Transmit Power field appears in LoRa Radio Configuration
- [ ] Test loading current txPower value from connected device
- [ ] Test saving new txPower value to device
- [ ] Verify value of 0 uses default safe power
- [ ] Run system tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)