### PR TITLE
fix: Forward hop count info in Virtual Node Server

### DIFF
--- a/src/server/meshtasticProtobufService.ts
+++ b/src/server/meshtasticProtobufService.ts
@@ -776,6 +776,7 @@ export class MeshtasticProtobufService {
     };
     snr?: number;
     lastHeard?: number;
+    hopsAway?: number;
   }): Promise<Uint8Array | null> {
     const root = getProtobufRoot();
     if (!root) {
@@ -844,6 +845,7 @@ export class MeshtasticProtobufService {
         deviceMetrics: deviceMetrics,
         snr: info.snr,
         lastHeard: info.lastHeard,
+        hopsAway: info.hopsAway,
       });
 
       const fromRadio = FromRadio.create({

--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -572,6 +572,7 @@ export class VirtualNodeServer extends EventEmitter {
           } : undefined,
           snr: node.snr,
           lastHeard: node.lastHeard,
+          hopsAway: node.hopsAway,
         });
 
         if (nodeInfoMessage) {


### PR DESCRIPTION
## Summary
Fixes #676 - Hop counts now display correctly in Meshtastic mobile apps when connected via Virtual Node Server.

## Problem
When users connected to MeshMonitor's Virtual Node Server through the Meshtastic Android/iOS app, all nodes showed "Hops Away: ?" instead of the actual hop count. The hop count was correctly displayed in MeshMonitor's web UI and when connecting directly to the physical node.

## Root Cause
The Virtual Node Server was not forwarding hop count (`hopsAway`) data to connected clients during initial configuration replay. The data exists in the database and is correctly captured from the physical node, but was being dropped when reconstructing NodeInfo packets for clients.

## Changes Made
1. **meshtasticProtobufService.ts:779** - Added `hopsAway?: number` parameter to `createNodeInfo()` method signature
2. **meshtasticProtobufService.ts:848** - Set `hopsAway: info.hopsAway` when creating NodeInfo protobuf object
3. **virtualNodeServer.ts:575** - Pass `hopsAway: node.hopsAway` from Virtual Node Server when calling `createNodeInfo()`

## Testing
- ✅ All system tests pass (Configuration Import, Quick Start, Security, Reverse Proxy, OIDC, Virtual Node CLI, Backup & Restore)
- ✅ Code builds successfully in Docker
- ✅ Changes verified in deployed container

## Backward Compatibility
The `hops_away` field is `optional` in the Meshtastic protobuf definition, so this change is backward compatible with older clients that don't expect this field.

## Impact
- Mobile apps will now display proper hop counts instead of "?"
- Users can see which nodes are direct neighbors (0 hops) vs. relayed through other nodes
- No breaking changes to API or database

🤖 Generated with [Claude Code](https://claude.com/claude-code)