### PR TITLE
fix: Update Claude Code Review workflow to v1 API

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,45 +46,45 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           # Try OAuth token first, fall back to API key
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Optional: Specify model using claude_args (defaults to Claude Sonnet 4)
+          # claude_args: "--model claude-opus-4-1-20250805"
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          # Prompt for automated review (replaces direct_prompt in v1.0)
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
             - Security concerns
             - Test coverage
-            
+
             Be constructive and helpful in your feedback.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true
           
           # Optional: Customize review based on file types
-          # direct_prompt: |
+          # prompt: |
           #   Review this PR focusing on:
           #   - For TypeScript files: Type safety and proper interface usage
           #   - For API endpoints: Security, input validation, and error handling
           #   - For React components: Performance, accessibility, and best practices
           #   - For tests: Coverage, edge cases, and test quality
-          
+
           # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
+          # prompt: |
+          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
+
+          # Optional: Add specific tools for running tests or linting (v1.0 syntax)
+          # claude_args: "--allowedTools 'Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)'"
           
           # Optional: Skip review for certain conditions
           # if: |


### PR DESCRIPTION
## Summary
Fixes the failing claude-code-review workflow by migrating from deprecated @beta to stable @v1 API.

## Problem
The Claude Code Review workflow was failing with "fetch failed" errors because:
- The `@beta` tag is outdated/unstable
- The `direct_prompt` parameter was deprecated in v1.0

## Changes Made
1. **Update action version** (.github/workflows/claude-code-review.yml:49)
   - Changed from `anthropics/claude-code-action@beta` to `@v1`
   - Using `@v1` provides automatic patch updates while protecting from breaking changes

2. **Migrate to v1.0 API parameters** (.github/workflows/claude-code-review.yml:59)
   - `direct_prompt` → `prompt` (v1.0 unified parameter)
   - `model` → `claude_args: "--model"` syntax
   - `allowed_tools` → `claude_args: "--allowedTools"` syntax

3. **Update example configurations** (.github/workflows/claude-code-review.yml:73-87)
   - Updated all commented examples to use v1.0 syntax

## Testing
- ✅ Configuration follows official v1.0 migration guide
- ✅ Authentication secrets remain unchanged (CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY)
- ✅ Backward compatible with existing setup

## References
- [Claude Code Action v1.0 Migration Guide](https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md)
- Related issues with @beta tag: [#40](https://github.com/anthropics/claude-code/issues/40), [#5585](https://github.com/anthropics/claude-code/issues/5585)

🤖 Generated with [Claude Code](https://claude.com/claude-code)