### PR TITLE
chore: Bump version to 2.18.9

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.18.8
-appVersion: "2.18.8"
+version: 2.18.9
+appVersion: "2.18.9"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.18.8",
+  "version": "2.18.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.18.8",
+      "version": "2.18.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.18.8",
+  "version": "2.18.9",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Bump version to 2.18.9 across all configuration files.

## Changes

- ✅ package.json: 2.18.8 → 2.18.9
- ✅ package-lock.json: 2.18.8 → 2.18.9  
- ✅ helm/meshmonitor/Chart.yaml: 2.18.8 → 2.18.9

## What's Included in 2.18.9

This release includes the comprehensive Packet Monitor improvements from #661:

### Filter Persistence
- All filter settings now persist in localStorage
- Settings restore on page load and tab switches
- No more filter resets when navigating away

### Enhanced Visibility
- Increased packet limit from 100 to 10,000
- All available packets displayed without restrictions

### Full JSON Inspection
- Complete packet data in popup modal
- Encrypted payload bytes included as hex string
- Perfect for debugging and analysis

### JSONL Export
- Export button (📥) in header
- One JSON object per line format
- Respects active filters
- Smart filename generation

### Safety Improvements
- Safe JSON parsing prevents crashes
- Error handling for corrupted localStorage
- Extracted magic numbers to constants
- Improved type safety

## Testing

✅ Version updated in all files  
✅ package-lock.json regenerated  
✅ Ready for release

🤖 Generated with [Claude Code](https://claude.com/claude-code)