### PR TITLE
fix: Restrict Claude Code Review to trusted contributors only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,16 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    # Only run for trusted contributors to prevent secret access issues with forks
+    # - OWNER: Repository owner
+    # - MEMBER: Organization member
+    # - COLLABORATOR: Repository collaborator
+    # For external contributors, maintainers can manually re-run the workflow after review
+    if: |
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR'
+
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Restrict Claude Code Review workflow to only run for trusted contributors (OWNER, MEMBER, COLLABORATOR)
- Prevents OIDC token access errors for PRs from external forks

## Problem
The Claude Code Review workflow was failing for external contributors like @Codename-11 with the error:
```
Failed to setup GitHub token: Error: Could not fetch an OIDC token. 
Did you remember to add `id-token: write` to your workflow permissions?
```

This happens because GitHub Actions restricts access to secrets and OIDC tokens for PRs from forks as a security measure to prevent malicious PRs from accessing repository secrets.

## Solution
Added an `if` condition to the workflow to only run for trusted contributors:
- **OWNER**: Repository owner
- **MEMBER**: Organization member
- **COLLABORATOR**: Repository collaborator

For external contributors, the workflow will be skipped. Maintainers can manually re-run the workflow after reviewing the PR if they want Claude's feedback.

## Testing
After merging this PR, the workflow should:
- ✅ Skip for PRs from external contributors (preventing the OIDC error)
- ✅ Run successfully for PRs from trusted contributors
- ✅ Allow manual re-runs by maintainers for any PR

Fixes the issue reported for PR #674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)