### PR TITLE
fix: Resolve auto-upgrade container name conflict with Docker Compose

### DIFF
--- a/scripts/upgrade-watchdog.sh
+++ b/scripts/upgrade-watchdog.sh
@@ -107,9 +107,14 @@ recreate_container() {
       log_success "Image pulled: ${IMAGE_NAME}:latest"
     fi
 
-    # Recreate using docker compose (this properly handles all configuration)
+    # Stop and remove existing container first to avoid name conflicts
+    log "Stopping existing container..."
     cd "$COMPOSE_PROJECT_DIR" || return 1
-    if docker compose $compose_files up -d --force-recreate --no-deps meshmonitor; then
+    docker compose $compose_files stop meshmonitor 2>/dev/null || true
+    docker compose $compose_files rm -f meshmonitor 2>/dev/null || true
+
+    # Recreate using docker compose (this properly handles all configuration)
+    if docker compose $compose_files up -d --no-deps meshmonitor; then
       log_success "Container recreated successfully via Docker Compose"
       return 0
     else


### PR DESCRIPTION
## Summary

Fixes auto-upgrade failures caused by container name conflicts when using Docker Compose.

## Problem

When attempting to auto-upgrade, users were encountering this error:

```
Error response from daemon: Conflict. The container name "/meshmonitor" 
is already in use by container "dca39ff2bb0a7db88d40398b8853fde16026f7a98e55125a9a59fc4403cde971". 
You have to remove (or rename) that container to be able to reuse that name.
```

The issue occurred because the `--force-recreate` flag in `docker compose up` wasn't properly handling the existing container removal, leading to name conflicts.

## Solution

Modified the `scripts/upgrade-watchdog.sh` to:

1. **Explicitly stop the existing container** using `docker compose stop`
2. **Remove the stopped container** using `docker compose rm -f`
3. **Create the new container** using `docker compose up -d` (without `--force-recreate`)

This ensures a clean sequence: stop → remove → create, avoiding any name conflicts.

## Changes

- Updated `recreate_container()` function in `scripts/upgrade-watchdog.sh`
- Added explicit `docker compose stop meshmonitor` before recreation
- Added explicit `docker compose rm -f meshmonitor` to remove old container
- Removed `--force-recreate` flag (no longer needed)
- Added error suppression (`|| true`) to handle edge cases gracefully

## Testing

The fix ensures:
- ✅ Clean container shutdown
- ✅ Complete container removal
- ✅ Successful recreation without name conflicts
- ✅ All configuration preserved from `docker-compose.yml` files
- ✅ Works with both `docker-compose.yml` and `docker-compose.upgrade.yml` overlays

## Impact

- Fixes auto-upgrade for Docker Compose deployments
- No breaking changes - maintains backward compatibility
- Improves reliability of upgrade process

🤖 Generated with [Claude Code](https://claude.com/claude-code)