### PR TITLE
fix: Remove redundant MapLibre GL CSS CDN link causing CSP violation

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="apple-mobile-web-app-title" content="MeshMonitor" />
     <meta name="description" content="Monitor and manage your Meshtastic mesh network" />
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" />
     <title>MeshMonitor - Meshtastic Node Monitoring</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Removes redundant CDN link for MapLibre GL CSS from index.html
- Fixes CSP violation error reported in #692

## Root Cause
The MapLibre GL CSS was being loaded **twice**:
1. ✅ Correctly imported in `VectorTileLayer.tsx:4` (bundled by Vite)
2. ❌ Redundantly loaded from CDN in `index.html:15` (violates CSP)

The CDN link was unnecessary since the CSS is already bundled through the component import.

## Changes
- Removed `<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" />` from index.html
- CSS continues to load correctly via the component import in VectorTileLayer.tsx

## Testing
- [ ] Verify no CSP errors in browser console
- [ ] Verify vector tile maps render correctly
- [ ] Verify MapLibre GL styles are applied

## Security Impact
This change improves security by:
- Eliminating external CDN dependency for stylesheets
- Maintaining strict CSP policy (`style-src 'self'`)
- Preventing potential third-party tracking via CSS

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)