### PR TITLE
fix: Persist all map feature toggle selections to localStorage

### DIFF
--- a/src/contexts/MapContext.tsx
+++ b/src/contexts/MapContext.tsx
@@ -56,11 +56,26 @@ interface MapProviderProps {
 }
 
 export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
-  const [showPaths, setShowPaths] = useState<boolean>(false);
-  const [showNeighborInfo, setShowNeighborInfo] = useState<boolean>(false);
-  const [showRoute, setShowRoute] = useState<boolean>(true);
-  const [showMotion, setShowMotion] = useState<boolean>(true);
-  const [showMqttNodes, setShowMqttNodes] = useState<boolean>(true);
+  const [showPaths, setShowPaths] = useState<boolean>(() => {
+    const saved = localStorage.getItem('showPaths');
+    return saved === 'true';
+  });
+  const [showNeighborInfo, setShowNeighborInfo] = useState<boolean>(() => {
+    const saved = localStorage.getItem('showNeighborInfo');
+    return saved === 'true';
+  });
+  const [showRoute, setShowRoute] = useState<boolean>(() => {
+    const saved = localStorage.getItem('showRoute');
+    return saved !== null ? saved === 'true' : true; // default: true
+  });
+  const [showMotion, setShowMotion] = useState<boolean>(() => {
+    const saved = localStorage.getItem('showMotion');
+    return saved !== null ? saved === 'true' : true; // default: true
+  });
+  const [showMqttNodes, setShowMqttNodes] = useState<boolean>(() => {
+    const saved = localStorage.getItem('showMqttNodes');
+    return saved !== null ? saved === 'true' : true; // default: true
+  });
   const [showAnimations, setShowAnimations] = useState<boolean>(() => {
     const saved = localStorage.getItem('showAnimations');
     return saved === 'true';
@@ -93,7 +108,27 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
   const [positionHistory, setPositionHistory] = useState<PositionHistoryItem[]>([]);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
-  // Persist showAnimations to localStorage
+  // Persist feature toggles to localStorage
+  useEffect(() => {
+    localStorage.setItem('showPaths', showPaths.toString());
+  }, [showPaths]);
+
+  useEffect(() => {
+    localStorage.setItem('showNeighborInfo', showNeighborInfo.toString());
+  }, [showNeighborInfo]);
+
+  useEffect(() => {
+    localStorage.setItem('showRoute', showRoute.toString());
+  }, [showRoute]);
+
+  useEffect(() => {
+    localStorage.setItem('showMotion', showMotion.toString());
+  }, [showMotion]);
+
+  useEffect(() => {
+    localStorage.setItem('showMqttNodes', showMqttNodes.toString());
+  }, [showMqttNodes]);
+
   useEffect(() => {
     localStorage.setItem('showAnimations', showAnimations.toString());
   }, [showAnimations]);


### PR DESCRIPTION
## Summary
Fixes #697 by persisting all map feature toggle selections to localStorage, not just "Show Animations" and "Show Packet Monitor".

## Changes
- Updated all map feature state initializers in `MapContext.tsx` to load from localStorage
- Added useEffect hooks to persist all feature toggles when changed:
  - Show Route Segments
  - Show Neighbor Info
  - Show Traceroute
  - Show MQTT
  - Show Position History
- Preserved original default values:
  - `Show Traceroute`, `Show Position History`, `Show MQTT` default to **true**
  - `Show Route Segments`, `Show Neighbor Info` default to **false**

## Behavior
All map feature selections are now consistently saved and restored across:
- Page refreshes
- Browser restarts
- Container/server restarts

## Test Plan
- [x] TypeScript compilation passes
- [x] Docker build succeeds
- [x] Container runs successfully with changes deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)