### PR TITLE
fix: Respect user date format preference in auto-acknowledge {DATE} token

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3,7 +3,7 @@ import meshtasticProtobufService from './meshtasticProtobufService.js';
 import protobufService from './protobufService.js';
 import { TcpTransport } from './tcpTransport.js';
 import { calculateDistance } from '../utils/distance.js';
-import { formatTime } from '../utils/datetime.js';
+import { formatTime, formatDate } from '../utils/datetime.js';
 import { logger } from '../utils/logger.js';
 import { getEnvironmentConfig } from './config/environment.js';
 import { notificationService } from './services/notificationService.js';
@@ -4148,13 +4148,15 @@ class MeshtasticManager {
           ? message.hopStart - message.hopLimit
           : 0;
 
-      // Format timestamp in local timezone (from TZ environment variable)
-      const env = getEnvironmentConfig();
+      // Format timestamp according to user preferences
       const timestamp = new Date(message.timestamp);
-      const receivedDate = timestamp.toLocaleDateString('en-US', { timeZone: env.timezone });
 
-      // Get time format preference from settings and use formatTime utility
+      // Get date and time format preferences from settings
+      const dateFormat = databaseService.getSetting('dateFormat') || 'MM/DD/YYYY';
       const timeFormat = databaseService.getSetting('timeFormat') || '24';
+
+      // Use formatDate and formatTime utilities to respect user preferences
+      const receivedDate = formatDate(timestamp, dateFormat as 'MM/DD/YYYY' | 'DD/MM/YYYY');
       const receivedTime = formatTime(timestamp, timeFormat as '12' | '24');
 
       // Replace tokens in the message template

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -28,7 +28,7 @@ export function formatTime(date: Date, format: TimeFormat = '24'): string {
  * @param format - 'MM/DD/YYYY' or 'DD/MM/YYYY'
  * @returns Formatted date string
  */
-function formatDate(date: Date, format: DateFormat = 'MM/DD/YYYY'): string {
+export function formatDate(date: Date, format: DateFormat = 'MM/DD/YYYY'): string {
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
   const year = date.getFullYear();


### PR DESCRIPTION
## Summary
Extend the fix from PR #702 to make the `{DATE}` token in auto-acknowledge messages respect the user's Display Preferences date format setting (MM/DD/YYYY vs DD/MM/YYYY).

## Problem
The `{DATE}` token was using `toLocaleDateString()` which defaults to MM/DD/YYYY format, completely ignoring the user's configured date format preference in Display Preferences.

## Solution
- Export `formatDate` function from `datetime.ts`
- Import and use the `formatDate()` utility in `meshtasticManager.ts`
- Retrieve the `dateFormat` setting from the database
- Apply the user's date format preference when formatting dates in auto-acknowledge messages
- Follows the same pattern as PR #702 which fixed the `{TIME}` token

## Changes
- Added `formatDate` export in `datetime.ts`
- Updated `checkAutoAcknowledge()` to retrieve and apply date format setting
- Replaced `toLocaleDateString()` with `formatDate(timestamp, dateFormat)`

## Testing
- All 48 existing auto-acknowledge template tests pass
- TypeScript type checking passes
- Date format now properly respects user preference

## Related
Extends fix from #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)