### PR TITLE
fix: Show Virtual Node traceroutes in Traceroute History modal

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -2551,13 +2551,16 @@ class DatabaseService {
   }
 
   getTraceroutesByNodes(fromNodeNum: number, toNodeNum: number, limit: number = 10): DbTraceroute[] {
+    // Search bidirectionally to capture traceroutes initiated from either direction
+    // This is especially important for 3rd party traceroutes (e.g., via Virtual Node)
+    // where the stored direction might be reversed from what's being queried
     const stmt = this.db.prepare(`
       SELECT * FROM traceroutes
-      WHERE fromNodeNum = ? AND toNodeNum = ?
+      WHERE (fromNodeNum = ? AND toNodeNum = ?) OR (fromNodeNum = ? AND toNodeNum = ?)
       ORDER BY timestamp DESC
       LIMIT ?
     `);
-    const traceroutes = stmt.all(fromNodeNum, toNodeNum, limit) as DbTraceroute[];
+    const traceroutes = stmt.all(fromNodeNum, toNodeNum, toNodeNum, fromNodeNum, limit) as DbTraceroute[];
     return traceroutes.map(t => this.normalizeBigInts(t));
   }
 


### PR DESCRIPTION
## Summary
Fixes an issue where traceroutes initiated by 3rd party Virtual Node clients do not appear in the UI's Traceroute History modal.

## Problem
When a 3rd party Virtual Node client initiates a traceroute:
- Request: Node A → Node B
- Response stored in DB: `fromNum=B` (responder), `toNum=A` (requester)
- UI query: Looks for `fromNum=A`, `toNum=B`
- **Result**: No match found because the query was directional

## Solution
Modified `getTraceroutesByNodes()` in `src/services/database.ts:2553-2565` to search **bidirectionally**:

```sql
WHERE (fromNodeNum = ? AND toNodeNum = ?) OR (fromNodeNum = ? AND toNodeNum = ?)
```

This ensures traceroutes are found regardless of the stored direction, which is essential for 3rd party traceroutes where the initiator might not be the local node.

## Testing
- ✅ Built Docker image with changes
- ✅ Configuration Import test: **PASSED**
- ⏳ Quick Start test: In progress
- ⏳ Backup/Restore test: In progress

## Test plan
- [ ] Initiate a traceroute from a Virtual Node client (e.g., using Meshtastic Python CLI)
- [ ] Verify the traceroute appears in the "recent traceroute" box on Messages page
- [ ] Verify the traceroute appears in the Traceroute History modal
- [ ] Verify bidirectional traceroutes (A→B and B→A) both appear when viewing history for either pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)