### PR TITLE
fix: Make 'Hide Own Packets' filter work in pop-out window (#719)

### DIFF
--- a/src/pages/PacketMonitorPage.tsx
+++ b/src/pages/PacketMonitorPage.tsx
@@ -2,9 +2,47 @@ import React from 'react';
 import PacketMonitorPanel from '../components/PacketMonitorPanel';
 import { AuthProvider } from '../contexts/AuthContext';
 import { SettingsProvider } from '../contexts/SettingsContext';
-import { DataProvider } from '../contexts/DataContext';
+import { DataProvider, useData } from '../contexts/DataContext';
 import { CsrfProvider } from '../contexts/CsrfContext';
+import api from '../services/api';
 import '../App.css';
+
+const PacketMonitorContent: React.FC = () => {
+  const { setDeviceInfo } = useData();
+
+  React.useEffect(() => {
+    const fetchDeviceInfo = async () => {
+      try {
+        const config = await api.getCurrentConfig();
+        setDeviceInfo(config);
+      } catch (error) {
+        console.error('Failed to fetch device info:', error);
+      }
+    };
+
+    fetchDeviceInfo();
+  }, [setDeviceInfo]);
+
+  return (
+    <div style={{
+      width: '100vw',
+      height: '100vh',
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+      background: 'var(--bg-primary)'
+    }}>
+      <PacketMonitorPanel
+        onClose={() => window.close()}
+        onNodeClick={(nodeId) => {
+          // In pop-out mode, we can't navigate to node details
+          // So we'll just log it or ignore it
+          console.log('Node clicked in pop-out:', nodeId);
+        }}
+      />
+    </div>
+  );
+};
 
 const PacketMonitorPage: React.FC = () => {
   return (
@@ -12,23 +50,7 @@ const PacketMonitorPage: React.FC = () => {
       <AuthProvider>
         <SettingsProvider>
           <DataProvider>
-            <div style={{
-              width: '100vw',
-              height: '100vh',
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              background: 'var(--bg-primary)'
-            }}>
-              <PacketMonitorPanel
-                onClose={() => window.close()}
-                onNodeClick={(nodeId) => {
-                  // In pop-out mode, we can't navigate to node details
-                  // So we'll just log it or ignore it
-                  console.log('Node clicked in pop-out:', nodeId);
-                }}
-              />
-            </div>
+            <PacketMonitorContent />
           </DataProvider>
         </SettingsProvider>
       </AuthProvider>


### PR DESCRIPTION
## Summary
Fixes the 'Hide Own Packets' filter not working in the pop-out packet monitor window.

## Problem
The filter was being ignored in the pop-out window because:
- Pop-out window creates a fresh `DataProvider` with no device info
- Without device info, `ownNodeNum` was undefined
- Filter logic requires `ownNodeNum` to identify and hide own packets

## Solution
- Added `useEffect` hook to fetch device info when pop-out window loads
- Used `api.getCurrentConfig()` to ensure proper BASE_URL support
- Restructured component to wrap content in `PacketMonitorContent` that has access to `useData()` hook

## Technical Details
The fix creates a nested component structure:
1. `PacketMonitorPage` sets up all context providers (CSRF, Auth, Settings, Data)
2. `PacketMonitorContent` (new) fetches device info using `api.getCurrentConfig()`
3. Device info is stored in `DataContext` via `setDeviceInfo()`
4. `PacketMonitorPanel` can now access `ownNodeNum` and filter correctly

This approach ensures the pop-out window has the same device context as the main application window.

## Testing
- [x] Manually tested in development environment with BASE_URL=/meshmonitor
- [x] Verified filter now works correctly in pop-out window
- [x] Confirmed BASE_URL is properly respected for API calls

## Related Issues
Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)