### PR TITLE
chore: Bump version to 2.19.4

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.19.3
-appVersion: "2.19.3"
+version: 2.19.4
+appVersion: "2.19.4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.19.3",
+  "version": "2.19.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.19.3",
+      "version": "2.19.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.19.3",
+  "version": "2.19.4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Updates version to 2.19.4 in package.json, package-lock.json, and Helm chart.

## Test plan
- [x] All system tests passing (Configuration Import, Quick Start, Security, Reverse Proxy, Reverse Proxy + OIDC, Virtual Node CLI, Backup & Restore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)