### PR TITLE
docs: Add Southern China Greater Bay Area to Site Gallery

### DIFF
--- a/docs/site-gallery.md
+++ b/docs/site-gallery.md
@@ -36,6 +36,14 @@ Running a public MeshMonitor instance? We'd love to feature it! **[File an issue
 
 ---
 
+### Southern China Greater Bay Area
+- **URL**: [meshmonitor.meshcn.net](https://meshmonitor.meshcn.net/)
+- **Network**: [MeshCN](https://meshcn.net/)
+- **Location**: Greater Bay Area (Guangzhou and Shenzhen), China
+- **Description**: Public MeshMonitor instance operated by the MeshCN community, visualising Meshtastic/LoRa mesh nodes and traffic across the Greater Bay Area.
+
+---
+
 ## About the Site Gallery
 
 The Site Gallery showcases MeshMonitor instances that are publicly accessible. These sites demonstrate:


### PR DESCRIPTION
## Summary

Adding MeshCN community's public MeshMonitor instance to the Site Gallery as requested in issue #745.

## Site Details

- **URL**: https://meshmonitor.meshcn.net/
- **Name**: Southern China Greater Bay Area MeshMonitor
- **Network**: [MeshCN community](https://meshcn.net/)
- **Location**: Greater Bay Area (Guangzhou and Shenzhen), China
- **Description**: Public MeshMonitor instance operated by the MeshCN community, visualising Meshtastic/LoRa mesh nodes and traffic across the Greater Bay Area

## Changes

- Added new entry to `docs/site-gallery.md` in the Featured Sites section
- Positioned after Kansas City Mesh and before the "About the Site Gallery" section
- Includes all relevant information: URL, network link, location, and description

## Screenshot

The submitter provided a screenshot showing their active MeshMonitor instance:

![Southern China Greater Bay Area MeshMonitor](https://github.com/user-attachments/assets/68241156-d86e-4c80-9371-352a2abf6f41)

## Checklist

- [x] Site URL is publicly accessible
- [x] Site information is complete and accurate
- [x] Follows the format of existing gallery entries
- [x] Added location information for international visibility

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)