### PR TITLE
docs: Add X-Forwarded headers to Apache reverse proxy config

### DIFF
--- a/docs/configuration/reverse-proxy.md
+++ b/docs/configuration/reverse-proxy.md
@@ -194,6 +194,8 @@ Create `/etc/apache2/sites-available/meshmonitor.conf`:
 
     # Proxy Configuration
     ProxyPreserveHost On
+    RequestHeader set X-Forwarded-Proto "https"
+    RequestHeader set X-Forwarded-Port "443"
     ProxyPass / http://localhost:8080/
     ProxyPassReverse / http://localhost:8080/
 


### PR DESCRIPTION
## Summary

Fixes #760

The Apache reverse proxy documentation was missing critical headers needed for proper HTTPS detection when `TRUST_PROXY=true`.

Without `X-Forwarded-Proto`, MeshMonitor cannot detect that the original connection was HTTPS (even though Apache terminated SSL), causing false "COOKIE_SECURE warning" errors when `COOKIE_SECURE=true` is set.

## Changes

- Add `RequestHeader set X-Forwarded-Proto "https"` to Apache VirtualHost config
- Add `RequestHeader set X-Forwarded-Port "443"` to Apache VirtualHost config

## Impact

These headers allow Express to correctly detect HTTPS when trust proxy is enabled, preventing spurious security warnings for users with the recommended Apache reverse proxy setup.

## Test plan

- [x] Documentation change only, no code changes
- [x] Verified NGINX config already includes equivalent headers (`proxy_set_header X-Forwarded-Proto $scheme`)
- [x] Posted solution to issue #760 for user verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)