### PR TITLE
feat: Add ISO 8601 date format option

### DIFF
--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -362,7 +362,10 @@ Description: Offline OpenStreetMap tiles via TileServer GL
 
 ### Date Format
 
-**Options**: MM/DD/YYYY (e.g., 12/31/2024) or DD/MM/YYYY (e.g., 31/12/2024)
+**Options**:
+- MM/DD/YYYY (e.g., 12/31/2024)
+- DD/MM/YYYY (e.g., 31/12/2024)
+- YYYY-MM-DD (e.g., 2024-12-31) - ISO 8601 standard
 
 **Default**: MM/DD/YYYY
 

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -16,7 +16,7 @@ import { type Theme, useSettings } from '../contexts/SettingsContext';
 
 type DistanceUnit = 'km' | 'mi';
 type TimeFormat = '12' | '24';
-type DateFormat = 'MM/DD/YYYY' | 'DD/MM/YYYY';
+type DateFormat = 'MM/DD/YYYY' | 'DD/MM/YYYY' | 'YYYY-MM-DD';
 type MapPinStyle = 'meshmonitor' | 'official';
 
 interface SettingsTabProps {
@@ -665,6 +665,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
             >
               <option value="MM/DD/YYYY">MM/DD/YYYY (e.g., 12/31/2024)</option>
               <option value="DD/MM/YYYY">DD/MM/YYYY (e.g., 31/12/2024)</option>
+              <option value="YYYY-MM-DD">YYYY-MM-DD (e.g., 2024-12-31) - ISO 8601</option>
             </select>
           </div>
           <div className="setting-item">

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -7,7 +7,7 @@ import { DEFAULT_TILESET_ID, type TilesetId, type CustomTileset } from '../confi
 
 export type DistanceUnit = 'km' | 'mi';
 export type TimeFormat = '12' | '24';
-export type DateFormat = 'MM/DD/YYYY' | 'DD/MM/YYYY';
+export type DateFormat = 'MM/DD/YYYY' | 'DD/MM/YYYY' | 'YYYY-MM-DD';
 export type MapPinStyle = 'meshmonitor' | 'official';
 
 // Built-in theme types
@@ -141,7 +141,10 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
 
   const [dateFormat, setDateFormatState] = useState<DateFormat>(() => {
     const saved = localStorage.getItem('dateFormat');
-    return (saved === 'DD/MM/YYYY' ? 'DD/MM/YYYY' : 'MM/DD/YYYY') as DateFormat;
+    if (saved === 'DD/MM/YYYY' || saved === 'YYYY-MM-DD') {
+      return saved as DateFormat;
+    }
+    return 'MM/DD/YYYY';
   });
 
   const [mapTileset, setMapTilesetState] = useState<TilesetId>(() => {

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -25,7 +25,7 @@ export function formatTime(date: Date, format: TimeFormat = '24'): string {
 /**
  * Formats a date according to the user's preferred date format
  * @param date - Date object to format
- * @param format - 'MM/DD/YYYY' or 'DD/MM/YYYY'
+ * @param format - 'MM/DD/YYYY', 'DD/MM/YYYY', or 'YYYY-MM-DD' (ISO 8601)
  * @returns Formatted date string
  */
 export function formatDate(date: Date, format: DateFormat = 'MM/DD/YYYY'): string {
@@ -35,6 +35,8 @@ export function formatDate(date: Date, format: DateFormat = 'MM/DD/YYYY'): strin
 
   if (format === 'DD/MM/YYYY') {
     return `${day}/${month}/${year}`;
+  } else if (format === 'YYYY-MM-DD') {
+    return `${year}-${month}-${day}`;
   } else {
     return `${month}/${day}/${year}`;
   }
@@ -44,7 +46,7 @@ export function formatDate(date: Date, format: DateFormat = 'MM/DD/YYYY'): strin
  * Formats a complete date and time according to user preferences
  * @param date - Date object to format
  * @param timeFormat - '12' for 12-hour format, '24' for 24-hour format
- * @param dateFormat - 'MM/DD/YYYY' or 'DD/MM/YYYY'
+ * @param dateFormat - 'MM/DD/YYYY', 'DD/MM/YYYY', or 'YYYY-MM-DD' (ISO 8601)
  * @returns Formatted date and time string
  */
 export function formatDateTime(
@@ -59,7 +61,7 @@ export function formatDateTime(
  * Formats a timestamp (milliseconds since epoch) according to user preferences
  * @param timestamp - Timestamp in milliseconds
  * @param timeFormat - '12' for 12-hour format, '24' for 24-hour format
- * @param dateFormat - 'MM/DD/YYYY' or 'DD/MM/YYYY'
+ * @param dateFormat - 'MM/DD/YYYY', 'DD/MM/YYYY', or 'YYYY-MM-DD' (ISO 8601)
  * @returns Formatted date and time string
  */
 function formatTimestamp(
@@ -75,7 +77,7 @@ function formatTimestamp(
  * Formats a relative time (e.g., "5 minutes ago") with optional absolute time
  * @param timestamp - Timestamp in milliseconds
  * @param timeFormat - '12' for 12-hour format, '24' for 24-hour format
- * @param dateFormat - 'MM/DD/YYYY' or 'DD/MM/YYYY'
+ * @param dateFormat - 'MM/DD/YYYY', 'DD/MM/YYYY', or 'YYYY-MM-DD' (ISO 8601)
  * @param showAbsolute - Whether to include absolute time in parentheses
  * @returns Formatted relative time string
  */
@@ -124,7 +126,7 @@ export function formatRelativeTime(
  *
  * @param date - Date object to format
  * @param timeFormat - '12' for 12-hour format, '24' for 24-hour format
- * @param dateFormat - 'MM/DD/YYYY' or 'DD/MM/YYYY' (used for older dates)
+ * @param dateFormat - 'MM/DD/YYYY', 'DD/MM/YYYY', or 'YYYY-MM-DD' (ISO 8601) (used for older dates)
  * @returns Smart formatted datetime string
  */
 export function formatMessageTime(
@@ -179,7 +181,7 @@ export function formatMessageTime(
 /**
  * Get the date string for a message (for date separators)
  * @param date - Date object
- * @param _dateFormat - 'MM/DD/YYYY' or 'DD/MM/YYYY' (reserved for future use)
+ * @param _dateFormat - 'MM/DD/YYYY', 'DD/MM/YYYY', or 'YYYY-MM-DD' (ISO 8601) (reserved for future use)
  * @returns Formatted date string for separator
  */
 export function getMessageDateSeparator(


### PR DESCRIPTION
## Summary

Adds support for ISO 8601 (YYYY-MM-DD) date format as requested in #759. Users can now select from three date format options in Settings.

## Changes

- **Type Definitions**: Added `'YYYY-MM-DD'` to the `DateFormat` type union
- **Date Formatting**: Updated `formatDate()` function to support ISO 8601 format
- **Settings UI**: Added new option "YYYY-MM-DD (e.g., 2024-12-31) - ISO 8601" to the date format selector
- **Documentation**: Updated settings documentation to reflect the new format option
- **JSDoc Updates**: Updated all function documentation to mention ISO 8601 support

## Format Options

Users can now choose from:
- `MM/DD/YYYY` (e.g., 12/31/2024) - US format
- `DD/MM/YYYY` (e.g., 31/12/2024) - European format
- `YYYY-MM-DD` (e.g., 2024-12-31) - ISO 8601 standard ✨ NEW

## Testing

- ✅ Built and deployed to Docker dev container
- ✅ Verified code is in bundled JavaScript
- ✅ Tested date formatting logic with sample dates
- ✅ Maintained backward compatibility with existing formats

## Files Changed

- `src/contexts/SettingsContext.tsx` - Added ISO 8601 to type and validation
- `src/utils/datetime.ts` - Added formatting logic for ISO 8601
- `src/components/SettingsTab.tsx` - Added UI option for ISO 8601
- `docs/features/settings.md` - Updated documentation

## Notes

This implementation:
- Follows the existing code patterns
- Maintains backward compatibility
- Applies the format consistently across all date displays in the application
- Addresses the request in issue #759 for proper international standard date formatting

Fixes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)