### PR TITLE
fix: Prevent infinite loop in Packet Monitor with empty filter results

### DIFF
--- a/src/components/PacketMonitorPanel.tsx
+++ b/src/components/PacketMonitorPanel.tsx
@@ -97,6 +97,12 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
 
     if (!lastItem) return;
 
+    // Prevent infinite loop when filters result in empty packet list
+    // If we have raw packets but no filtered packets, don't keep trying to load more
+    if (packets.length === 0 && rawPackets.length > 0) {
+      return;
+    }
+
     if (
       lastItem.index >= packets.length - 1 &&
       hasMore &&
@@ -105,7 +111,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
     ) {
       loadMore();
     }
-  }, [rowVirtualizer.getVirtualItems(), hasMore, loadingMore, packets.length, canView]);
+  }, [rowVirtualizer.getVirtualItems(), hasMore, loadingMore, packets.length, rawPackets.length, canView]);
 
   // Load more packets function
   const loadMore = async () => {
@@ -197,7 +203,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
       console.error('Failed to fetch packets:', error);
       setLoading(false);
     }
-  }, [canView, filters, autoScroll, rawPackets]);
+  }, [canView, filters, autoScroll]);
 
   // Initial fetch and polling
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fixed infinite request loop in Packet Monitor when filters result in no matching packets
- Removed problematic dependency that caused fetchPackets to recreate on every state change
- Added guard to prevent infinite loading when filters exclude all packets

## Problem
The Packet Monitor was entering an infinite request loop when applying filters that resulted in no matching packets (e.g., "Encrypted only" filter when no encrypted packets exist). This caused:
- Continuous flood of GET /packets requests (304 Not Modified)
- Browser unresponsiveness
- Backend/proxy rate limiting issues

## Root Causes
1. **Primary Issue**: The `fetchPackets` callback had `rawPackets` in its dependency array (line 206)
   - Every time packets were fetched, `rawPackets` state changed
   - This caused `fetchPackets` to be recreated
   - Which triggered the polling useEffect (lines 209-222) to restart
   - Creating an infinite loop of fetches

2. **Secondary Issue**: Virtual scroller tried to load more when filtered results were empty
   - Used filtered `packets` array length to detect scroll position
   - But used unfiltered `rawPackets` length as fetch offset
   - When filters excluded everything, kept trying to load more

## Solution
1. **Removed `rawPackets` from fetchPackets dependency array**
   - Now only recreates when `canView`, `filters`, or `autoScroll` change
   - These are the actual conditions that should trigger a refetch
   - Prevents the infinite recreation loop

2. **Added guard in virtual scrolling effect**
   - Detects when `packets.length === 0` but `rawPackets.length > 0`
   - Indicates filtering is excluding all packets
   - Stops trying to load more in this scenario

## Testing
Verified the fix:
1. Go to Packet Monitor
2. Click "Erase all data"
3. Enable filters and select "Encrypted Only"
4. Observe only ONE initial request, then normal 5-second polling interval
5. No more infinite request flood

Fixes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)