### PR TITLE
chore: Bump version to 2.19.7

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.19.6
-appVersion: "2.19.6"
+version: 2.19.7
+appVersion: "2.19.7"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.19.6",
+  "version": "2.19.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.19.6",
+      "version": "2.19.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.19.6",
+  "version": "2.19.7",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Version Bump

Bumps version to 2.19.7 across all relevant files.

## Changes Included Since 2.19.6

### Features
- **#775**: Add separate auto-ack templates for direct vs multi-hop connections (#766)
  - Added `{HOPS}` token as alias to `{NUMBER_HOPS}`
  - Separate message templates for direct connections (0 hops) vs multi-hop
  - Direct connections can show SNR/RSSI metrics
  - Multi-hop messages show hop count

## Files Updated
- `package.json`: Version 2.19.6 → 2.19.7
- `package-lock.json`: Regenerated with new version
- `helm/meshmonitor/Chart.yaml`: Version and appVersion updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>