### PR TITLE
fix: Extend traceroute display window to 7 days in Messages tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1994,8 +1994,10 @@ function App() {
     const currentNodeNumStr = currentNodeId.replace('!', '');
     const currentNodeNum = parseInt(currentNodeNumStr, 16);
 
-    // Find most recent traceroute between current node and selected node using maxNodeAgeHours setting
-    const cutoff = Date.now() - (maxNodeAgeHours * 60 * 60 * 1000);
+    // Find most recent traceroute between current node and selected node
+    // Use 7 days for traceroute visibility (traceroutes are less frequent than node updates)
+    const TRACEROUTE_DISPLAY_HOURS = 7 * 24; // 7 days
+    const cutoff = Date.now() - (TRACEROUTE_DISPLAY_HOURS * 60 * 60 * 1000);
     const recentTraceroutes = traceroutes
       .filter(tr => {
         const isRelevant = (


### PR DESCRIPTION
## Summary
- Fixed issue where traceroutes weren't showing in the Messages tab pink box despite being visible in "Show History"
- Extended traceroute display window from 24 hours (maxNodeAgeHours) to 7 days
- Decoupled traceroute visibility timing from node age filtering

## Problem
The `getRecentTraceroute` function was filtering traceroutes using `maxNodeAgeHours` (default: 24 hours), which is designed for filtering stale nodes from the map. This caused:

- ✅ Traceroutes older than 24 hours remained in the database
- ✅ They showed in "Show History" modal (no age filter)
- ❌ They didn't show in the pink traceroute box (filtered out by 24-hour check)

## Solution
Changed traceroute display logic to use a dedicated 7-day time window instead of `maxNodeAgeHours`. This makes sense because:

1. Traceroutes are less frequent than node updates
2. They provide valuable routing information that should remain visible longer
3. 7-day window aligns with common traceroute retention periods

## Changes
- **File**: src/App.tsx:1997-2000
- Replaced `maxNodeAgeHours` with constant `TRACEROUTE_DISPLAY_HOURS = 7 * 24`
- Updated comments to clarify the rationale

## Test plan
- [x] TypeScript compilation passes with no errors
- [x] Logic verified with test cases for 1-day, 3-day, 6-day, and 8-day old traceroutes
- [ ] Manual test: View Messages tab for a node with traceroutes between 24-168 hours old
- [ ] Manual test: Verify traceroutes older than 7 days don't show in pink box
- [ ] Manual test: Confirm "Show History" still displays all traceroutes

## Impact
Users will now see traceroutes in the Messages tab pink box for up to 7 days instead of only 24 hours, improving visibility of recent routing information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)