### PR TITLE
fix: Prevent unauthorized Messages tab access from Security tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3952,6 +3952,15 @@ function App() {
   };
 
   const renderMessagesTab = () => {
+    // Check if user has permission to view messages
+    if (!hasPermission('messages', 'read')) {
+      return (
+        <div className="no-permission-message">
+          <p>You need <strong>messages:read</strong> permission to view direct messages.</p>
+        </div>
+      );
+    }
+
     // Use processedNodes which already has sorting applied from the Map page logic
     const nodesWithMessages = processedNodes
       .filter(node => node.user?.id !== currentNodeId) // Exclude local node

--- a/src/components/SecurityTab.tsx
+++ b/src/components/SecurityTab.tsx
@@ -126,15 +126,27 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ onTabChange, onSelectD
   };
 
   const handleNodeClick = useCallback((nodeNum: number) => {
+    // Check if user has permission to view messages before navigating
+    if (!hasPermission('messages', 'read')) {
+      setError('You need messages:read permission to view direct messages');
+      return;
+    }
+
     if (onTabChange && onSelectDMNode) {
       // Convert nodeNum to hex string with leading ! for DM node ID
       const nodeId = `!${nodeNum.toString(16).padStart(8, '0')}`;
       onSelectDMNode(nodeId);
       onTabChange('messages');
     }
-  }, [onTabChange, onSelectDMNode]);
+  }, [onTabChange, onSelectDMNode, hasPermission]);
 
   const handleSendNotification = useCallback((node: SecurityNode, duplicateCount?: number) => {
+    // Check if user has permission to send messages before navigating
+    if (!hasPermission('messages', 'read')) {
+      setError('You need messages:read permission to send notifications');
+      return;
+    }
+
     if (onTabChange && onSelectDMNode && setNewMessage) {
       // Convert nodeNum to hex string with leading ! for DM node ID
       const nodeId = `!${node.nodeNum.toString(16).padStart(8, '0')}`;
@@ -152,7 +164,7 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ onTabChange, onSelectD
       setNewMessage(message);
       onTabChange('messages');
     }
-  }, [onTabChange, onSelectDMNode, setNewMessage]);
+  }, [onTabChange, onSelectDMNode, setNewMessage, hasPermission]);
 
   const handleExport = useCallback(async (format: 'csv' | 'json') => {
     try {


### PR DESCRIPTION
## Summary
- Fixed security access control vulnerability where users with only `security:read` permission could navigate to Messages tab
- Added permission checks to prevent viewing Messages tab without `messages:read` permission
- Added permission checks to SecurityTab button handlers before navigation

## Problem
An anonymous user configured with only `security:read` permission could:
1. View the Security tab (correct behavior)
2. Click the "Send notification" button on a node with security issues
3. Get redirected to the Messages tab with a pre-filled message
4. **View all nodes and their telemetry** without having `messages:read` permission

## Changes Made

### src/components/SecurityTab.tsx
- Added permission check to `handleNodeClick()` to verify `messages:read` before navigating to Messages tab
- Added permission check to `handleSendNotification()` to verify `messages:read` before navigating to Messages tab
- Display error messages when permission is denied: "You need messages:read permission to view direct messages" / "...to send notifications"
- Updated dependency arrays to include `hasPermission`

### src/App.tsx
- Added permission check at the beginning of `renderMessagesTab()` 
- Returns permission denied message if user lacks `messages:read` permission
- Message: "You need **messages:read** permission to view direct messages."

## Test Plan
- [x] Build succeeds
- [ ] With anonymous user having only `security:read` permission:
  - [ ] Can view Security tab
  - [ ] Clicking notification button shows error instead of navigating
  - [ ] Cannot view Messages tab (shows permission denied)
  - [ ] Cannot view node telemetry through Messages tab
- [ ] With user having `messages:read` permission:
  - [ ] Can navigate from Security tab to Messages tab
  - [ ] Can send notifications
  - [ ] Can view Messages tab normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)