### PR TITLE
docs: Integrate LXC deployment guide and reorganize Getting Started page

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -67,6 +67,13 @@ export default defineConfig({
             { text: '🔄 Automatic Self-Upgrade', link: '/configuration/auto-upgrade' },
             { text: 'Push Notifications', link: '/features/notifications' }
           ]
+        },
+        {
+          text: 'Deployment',
+          items: [
+            { text: 'Deployment Guide', link: '/deployment/DEPLOYMENT_GUIDE' },
+            { text: '📦 Proxmox LXC', link: '/deployment/PROXMOX_LXC_GUIDE' }
+          ]
         }
       ],
       '/development/': [
@@ -122,5 +129,5 @@ export default defineConfig({
   ],
 
   // Exclude old documentation directories from VitePress processing
-  srcExclude: ['**/deployment/**', '**/architecture/**', '**/database/**', '**/api/**']
+  srcExclude: ['**/architecture/**', '**/database/**', '**/api/**']
 })

--- a/docs/deployment/PROXMOX_LXC_GUIDE.md
+++ b/docs/deployment/PROXMOX_LXC_GUIDE.md
@@ -47,7 +47,7 @@ MeshMonitor can be deployed in Proxmox VE using LXC (Linux Containers) as an alt
 
 ```bash
 # 1. Download template on your computer
-wget https://github.com/jeremiah-k/meshmonitor/releases/latest/download/meshmonitor-latest-amd64.tar.gz
+wget https://github.com/yeraze/meshmonitor/releases/latest/download/meshmonitor-latest-amd64.tar.gz
 
 # 2. Upload to Proxmox server
 scp meshmonitor-latest-amd64.tar.gz root@YOUR-PROXMOX-IP:/var/lib/vz/template/cache/
@@ -74,7 +74,7 @@ systemctl start meshmonitor-apprise
 
 ### Step 1: Download the LXC Template
 
-1. Go to the [MeshMonitor Releases](https://github.com/jeremiah-k/meshmonitor/releases) page
+1. Go to the [MeshMonitor Releases](https://github.com/yeraze/meshmonitor/releases) page
 2. Download the latest `meshmonitor-*-amd64.tar.gz` file
 3. Optionally download the `.sha256` file to verify integrity
 
@@ -529,7 +529,7 @@ LXC deployments do not support auto-upgrade. To update:
 
 2. **Download new template**:
    ```bash
-   wget https://github.com/jeremiah-k/meshmonitor/releases/download/v2.19.5/meshmonitor-2.19.5-amd64.tar.gz
+   wget https://github.com/yeraze/meshmonitor/releases/download/v2.19.5/meshmonitor-2.19.5-amd64.tar.gz
    ```
 
 3. **Upload to Proxmox**:
@@ -588,21 +588,21 @@ LXC deployments do not support auto-upgrade. To update:
 
 ## Additional Resources
 
-- **Main Documentation**: [Getting Started Guide](../getting-started.md)
-- **Configuration Guide**: [Production Deployment](../configuration/production.md)
-- **Docker Deployment**: [Deployment Guide](./DEPLOYMENT_GUIDE.md)
-- **GitHub**: [MeshMonitor Repository](https://github.com/jeremiah-k/meshmonitor)
-- **Issues**: [Report Problems](https://github.com/jeremiah-k/meshmonitor/issues)
+- **Main Documentation**: [Getting Started Guide](/getting-started)
+- **Configuration Guide**: [Production Deployment](/configuration/production)
+- **Docker Deployment**: [Deployment Guide](/deployment/DEPLOYMENT_GUIDE)
+- **GitHub**: [MeshMonitor Repository](https://github.com/yeraze/meshmonitor)
+- **Issues**: [Report Problems](https://github.com/yeraze/meshmonitor/issues)
 
 ## Getting Help
 
 If you encounter issues:
 
 1. Check this troubleshooting guide
-2. Review the [main documentation](../getting-started.md)
-3. Search [existing issues](https://github.com/jeremiah-k/meshmonitor/issues)
-4. Ask in [Discussions](https://github.com/jeremiah-k/meshmonitor/discussions)
-5. Create a [new issue](https://github.com/jeremiah-k/meshmonitor/issues/new) with:
+2. Review the [main documentation](/getting-started)
+3. Search [existing issues](https://github.com/yeraze/meshmonitor/issues)
+4. Ask in [Discussions](https://github.com/yeraze/meshmonitor/discussions)
+5. Create a [new issue](https://github.com/yeraze/meshmonitor/issues/new) with:
    - LXC container configuration
    - Service logs (`journalctl -u meshmonitor`)
    - Environment configuration (redact sensitive data)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,20 +2,59 @@
 
 This guide will help you get MeshMonitor up and running quickly.
 
-::: tip Interactive Configurator
+::: tip Interactive Docker Compose Configurator
 Want a custom configuration generated for you? Try our **[Docker Compose Configurator](/configurator)** - it generates a ready-to-use `docker-compose.yml` and `.env` file based on your specific setup (TCP, BLE, Serial, with or without reverse proxy, etc.).
 :::
+
+## Deployment Methods
+
+MeshMonitor supports multiple deployment options to fit your infrastructure:
+
+### Officially Supported
+
+- **🐳 Docker Compose** (recommended) - Works on any platform with Docker
+  - Easiest setup with auto-upgrade support
+  - Full feature support
+  - See [Quick Start](#quick-start-with-docker-compose) below
+
+- **☸️ Kubernetes/Helm** - Production-grade orchestration
+  - Available in our [GitHub repository](https://github.com/yeraze/meshmonitor)
+  - See [Deployment Guide](/deployment/DEPLOYMENT_GUIDE) for details
+
+### Community Supported
+
+The following deployment methods are contributed and supported by the community:
+
+- **📦 Proxmox LXC** - Lightweight containers for Proxmox VE users
+  - Pre-built templates available
+  - See [Proxmox LXC Deployment Guide](/deployment/PROXMOX_LXC_GUIDE)
+
+- **❄️ NixOS Flake** - Declarative deployment for NixOS
+  - Community contribution by [@benjajaja](https://github.com/benjajaja)
+  - See [NixOS flake example](https://github.com/benjajaja/nixos-rk3588/blob/main/meshmonitor/flake.nix)
+  - Discussed in [Issue #781](https://github.com/yeraze/meshmonitor/issues/781)
+
+- **🔧 Bare Metal** - Direct installation with Node.js
+  - For development or custom setups
+  - See [Deployment Guide](/deployment/DEPLOYMENT_GUIDE)
 
 ## Prerequisites
 
 Before you begin, ensure you have:
 
+### Meshtastic Device
 - A Meshtastic device connected to your network via IP (WiFi or Ethernet)
 - **OR** A Serial/USB device with the [Serial Bridge](/configuration/serial-bridge)
 - **OR** A Bluetooth device with the [BLE Bridge](/configuration/ble-bridge)
 - **OR** `meshtasticd` running as a virtual node
-- Docker and Docker Compose installed (for Docker deployment)
-- **OR** Node.js 20+ and npm (for bare metal deployment)
+
+### Deployment Platform
+Choose one based on your deployment method:
+- **Docker Compose**: Docker and Docker Compose installed
+- **Proxmox LXC**: Proxmox VE 7.0+
+- **Kubernetes**: Kubernetes cluster with Helm 3+
+- **NixOS**: NixOS system
+- **Bare Metal**: Node.js 20+ and npm
 
 ## Quick Start with Docker Compose
 

--- a/lxc/README.md
+++ b/lxc/README.md
@@ -74,7 +74,7 @@ See the [Proxmox LXC Deployment Guide](../docs/deployment/PROXMOX_LXC_GUIDE.md) 
 
 ### Quick Start
 
-1. Download template from [GitHub Releases](https://github.com/jeremiah-k/meshmonitor/releases)
+1. Download template from [GitHub Releases](https://github.com/yeraze/meshmonitor/releases)
 2. Upload to Proxmox: `scp meshmonitor-*.tar.gz root@proxmox:/var/lib/vz/template/cache/`
 3. Create LXC container from template via Proxmox web UI
 4. Configure `/etc/meshmonitor/meshmonitor.env` with your node IP
@@ -140,5 +140,5 @@ To modify the build process:
 ## Support
 
 - **Documentation**: [Proxmox LXC Guide](../docs/deployment/PROXMOX_LXC_GUIDE.md)
-- **Issues**: [GitHub Issues](https://github.com/jeremiah-k/meshmonitor/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/jeremiah-k/meshmonitor/discussions)
+- **Issues**: [GitHub Issues](https://github.com/yeraze/meshmonitor/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/yeraze/meshmonitor/discussions)


### PR DESCRIPTION
## Summary

Integrates the Proxmox LXC deployment guide into the published documentation and reorganizes the Getting Started page for better user experience.

## Changes

### Documentation Integration
- ✅ Enabled `deployment/` directory in VitePress (removed from `srcExclude`)
- ✅ Added "Deployment" section to sidebar navigation
- ✅ Made LXC deployment guide accessible at meshmonitor.org
- ✅ Added general deployment guide to sidebar

### Getting Started Page Reorganization
- ✅ Kept Docker Compose Configurator at the top as primary call-to-action
- ✅ Added clear "Deployment Methods" section with:
  - **Officially Supported**: Docker Compose (recommended), Kubernetes/Helm
  - **Community Supported**: Proxmox LXC, NixOS Flake, Bare Metal
- ✅ Added NixOS Flake deployment option (community contribution from #781)
- ✅ Improved Prerequisites section with separate device and platform subsections
- ✅ Better information hierarchy and flow

### Link and Reference Fixes
- ✅ Updated all internal doc links from `.md` to VitePress format (`/path`)
- ✅ Fixed all GitHub repository references from `jeremiah-k` to `yeraze`
- ✅ Ensured all cross-references work correctly

## Issue Resolution

The LXC deployment guide (`docs/deployment/PROXMOX_LXC_GUIDE.md`) already existed but was excluded from the published documentation. The `lxc/README.md` referenced it as the "Proxmox LXC Deployment Guide" but users couldn't access it on meshmonitor.org.

## Testing

- ✅ Verified all links work in local VitePress dev server
- ✅ Confirmed sidebar navigation displays correctly
- ✅ Checked Getting Started page renders properly
- ✅ Validated LXC guide is accessible

## Related Issues

- Closes discussion about missing LXC documentation
- References #781 (NixOS Flake community contribution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)