### PR TITLE
fix: Use CONTAINER_NAME variable in upgrade-watchdog compose commands

### DIFF
--- a/scripts/upgrade-watchdog.sh
+++ b/scripts/upgrade-watchdog.sh
@@ -218,11 +218,11 @@ recreate_container() {
       log "Using project name: $COMPOSE_PROJECT_NAME"
     fi
 
-    docker compose $project_flag $compose_files stop meshmonitor 2>/dev/null || true
-    docker compose $project_flag $compose_files rm -f meshmonitor 2>/dev/null || true
+    docker compose $project_flag $compose_files stop "$CONTAINER_NAME" 2>/dev/null || true
+    docker compose $project_flag $compose_files rm -f "$CONTAINER_NAME" 2>/dev/null || true
 
     # Recreate using docker compose (this properly handles all configuration)
-    if docker compose $project_flag $compose_files up -d --no-deps meshmonitor; then
+    if docker compose $project_flag $compose_files up -d --no-deps "$CONTAINER_NAME"; then
       log_success "Container recreated successfully via Docker Compose"
       return 0
     else


### PR DESCRIPTION
## Summary
- Fixed hardcoded service name in upgrade-watchdog.sh Docker Compose commands
- Replaced hardcoded `meshmonitor` with `$CONTAINER_NAME` variable in stop, rm, and up commands
- Allows upgrade watchdog to work with any service name in docker-compose.yml

## Problem
The upgrade-watchdog.sh script was failing for users with custom service names in their docker-compose.yml files. The script hardcoded `meshmonitor` as the service name in Docker Compose commands, but users may name their services differently (e.g., `wski-hat`).

## Changes
Updated three Docker Compose command invocations in `scripts/upgrade-watchdog.sh`:
- Line 221: `docker compose stop` - now uses `$CONTAINER_NAME`
- Line 222: `docker compose rm` - now uses `$CONTAINER_NAME`  
- Line 225: `docker compose up` - now uses `$CONTAINER_NAME`

## Test plan
- [x] All system tests passed (Configuration Import, Quick Start, Reverse Proxy, OIDC, Virtual Node CLI, Backup & Restore)
- [x] Verified the `CONTAINER_NAME` environment variable is already supported and documented in the upgrade watchdog
- [x] Confirmed fix addresses the exact error reported in issue #753

## Related Issues
Fixes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)