### PR TITLE
feat: Add per-user map preferences with server-side persistence

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -134,9 +134,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   const {
     timeFormat,
     dateFormat,
-    temporaryTileset,
-    setTemporaryTileset,
     mapTileset,
+    setMapTileset,
     mapPinStyle,
     customTilesets,
   } = useSettings();
@@ -376,8 +375,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     prevNodesRef.current = currentNodes;
   }, [processedNodes, showAnimations, triggerNodeAnimation]);
 
-  // Calculate active tileset
-  const activeTileset = temporaryTileset || mapTileset;
+  // Use the map tileset from settings
+  const activeTileset = mapTileset;
 
   // Handle center complete
   const handleCenterComplete = () => {
@@ -1100,7 +1099,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
           </MapContainer>
           <TilesetSelector
             selectedTilesetId={activeTileset}
-            onTilesetChange={setTemporaryTileset}
+            onTilesetChange={setMapTileset}
           />
           {nodesWithPosition.length === 0 && (
             <div className="map-overlay">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -99,7 +99,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
             'Check browser console and server logs for details.');
         }
 
-        logger.debug('Login successful');
+        logger.debug('Login successful - reloading page to apply user preferences');
+
+        // Reload the page to apply user-specific preferences
+        window.location.reload();
       }
     } catch (error) {
       logger.error('Login failed:', error);
@@ -129,7 +132,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       // Refresh auth status to get anonymous user permissions
       await refreshAuth();
 
-      logger.debug('Logout successful');
+      logger.debug('Logout successful - reloading page to clear user preferences');
+
+      // Reload the page to clear user-specific preferences
+      window.location.reload();
     } catch (error) {
       logger.error('Logout failed:', error);
       throw error;

--- a/src/server/migrations/030_add_user_map_preferences.ts
+++ b/src/server/migrations/030_add_user_map_preferences.ts
@@ -1,0 +1,72 @@
+/**
+ * Migration 030: Add user_map_preferences table
+ *
+ * Adds a table to store per-user map preferences including:
+ * - Map tileset selection
+ * - Map filter settings (showPaths, showNeighborInfo, showRoute, etc.)
+ *
+ * These preferences persist across logins and allow each user to have
+ * their own map view configuration.
+ */
+
+import Database from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+export const migration = {
+  up: (db: Database.Database): void => {
+  logger.info('Running migration 030: Add user_map_preferences table');
+
+  try {
+    // Create user_map_preferences table
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS user_map_preferences (
+        user_id INTEGER PRIMARY KEY,
+        map_tileset TEXT,
+        show_paths INTEGER DEFAULT 0,
+        show_neighbor_info INTEGER DEFAULT 0,
+        show_route INTEGER DEFAULT 1,
+        show_motion INTEGER DEFAULT 1,
+        show_mqtt_nodes INTEGER DEFAULT 1,
+        show_animations INTEGER DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+        CHECK (show_paths IN (0, 1)),
+        CHECK (show_neighbor_info IN (0, 1)),
+        CHECK (show_route IN (0, 1)),
+        CHECK (show_motion IN (0, 1)),
+        CHECK (show_mqtt_nodes IN (0, 1)),
+        CHECK (show_animations IN (0, 1))
+      )
+    `);
+
+    // Create index for faster lookups
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_user_map_preferences_user_id
+      ON user_map_preferences(user_id)
+    `);
+
+    logger.info('✅ Migration 030 completed: user_map_preferences table created');
+  } catch (error) {
+    logger.error('❌ Migration 030 failed:', error);
+    throw error;
+  }
+  },
+
+  down: (db: Database.Database): void => {
+  logger.info('Reverting migration 030: Remove user_map_preferences table');
+
+  try {
+    // Drop index
+    db.exec(`DROP INDEX IF EXISTS idx_user_map_preferences_user_id`);
+
+    // Drop table
+    db.exec(`DROP TABLE IF EXISTS user_map_preferences`);
+
+    logger.info('✅ Migration 030 reverted: user_map_preferences table removed');
+  } catch (error) {
+    logger.error('❌ Migration 030 revert failed:', error);
+    throw error;
+  }
+  }
+};

--- a/src/server/migrations/031_add_sorting_to_user_preferences.ts
+++ b/src/server/migrations/031_add_sorting_to_user_preferences.ts
@@ -1,0 +1,51 @@
+/**
+ * Migration 031: Add sorting preferences to user_map_preferences table
+ *
+ * Adds columns for preferred sort field and direction to allow
+ * per-user node list sorting preferences.
+ */
+
+import Database from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+export const migration = {
+  up: (db: Database.Database): void => {
+    logger.info('Running migration 031: Add sorting preferences to user_map_preferences');
+
+    try {
+      // Add preferred_sort_field and preferred_sort_direction columns
+      db.exec(`
+        ALTER TABLE user_map_preferences
+        ADD COLUMN preferred_sort_field TEXT DEFAULT 'longName'
+      `);
+
+      db.exec(`
+        ALTER TABLE user_map_preferences
+        ADD COLUMN preferred_sort_direction TEXT DEFAULT 'asc'
+      `);
+
+      // Add CHECK constraints for the new columns
+      // Note: SQLite doesn't support adding CHECK constraints via ALTER TABLE,
+      // so we'll validate in application code instead
+
+      logger.info('✅ Migration 031 completed: sorting preferences added to user_map_preferences');
+    } catch (error) {
+      logger.error('❌ Migration 031 failed:', error);
+      throw error;
+    }
+  },
+
+  down: (_db: Database.Database): void => {
+    logger.info('Reverting migration 031: Remove sorting preferences from user_map_preferences');
+
+    try {
+      // SQLite doesn't support DROP COLUMN directly, would need to recreate table
+      // For now, leaving columns in place on rollback
+      logger.warn('⚠️ Migration 031 rollback: SQLite does not support DROP COLUMN, columns will remain');
+      logger.info('✅ Migration 031 reverted (columns remain but will be ignored)');
+    } catch (error) {
+      logger.error('❌ Migration 031 revert failed:', error);
+      throw error;
+    }
+  }
+};

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -33,6 +33,7 @@ import { migration as passwordLockedMigration } from '../server/migrations/023_a
 import { migration as perChannelPermissionsMigration } from '../server/migrations/024_add_per_channel_permissions.js';
 import { migration as apiTokensMigration } from '../server/migrations/025_add_api_tokens.js';
 import { migration as cascadeForeignKeysMigration } from '../server/migrations/028_add_cascade_to_foreign_keys.js';
+import { migration as userMapPreferencesMigration } from '../server/migrations/030_add_user_map_preferences.js';
 import { validateThemeDefinition as validateTheme } from '../utils/themeValidation.js';
 
 // Configuration constants for traceroute history
@@ -397,6 +398,7 @@ class DatabaseService {
     this.runAPITokensMigration();
     this.runCascadeForeignKeysMigration();
     this.runAutoWelcomeMigration();
+    this.runUserMapPreferencesMigration();
     this.ensureAutomationDefaults();
     this.isInitialized = true;
   }
@@ -1011,6 +1013,26 @@ class DatabaseService {
       logger.debug('✅ Auto-welcome existing nodes migration completed successfully');
     } catch (error) {
       logger.error('❌ Failed to run auto-welcome existing nodes migration:', error);
+      throw error;
+    }
+  }
+
+  private runUserMapPreferencesMigration(): void {
+    const migrationKey = 'migration_030_user_map_preferences';
+
+    try {
+      const currentStatus = this.getSetting(migrationKey);
+      if (currentStatus === 'completed') {
+        logger.debug('✅ User map preferences migration already completed');
+        return;
+      }
+
+      logger.debug('Running migration 030: Add user_map_preferences table...');
+      userMapPreferencesMigration.up(this.db);
+      this.setSetting(migrationKey, 'completed');
+      logger.debug('✅ User map preferences migration completed successfully');
+    } catch (error) {
+      logger.error('❌ Failed to run user map preferences migration:', error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
Implements user-specific map preferences that persist across logins (#786), with proper isolation between users and graceful defaults for anonymous users.

## Changes

### Database Schema
- ✅ Migration 030: `user_map_preferences` table
  - Stores per-user map tileset and filter settings
  - Foreign key to users table with ON DELETE CASCADE
  - CHECK constraints for boolean values
  - Indexed on user_id for performance
- ✅ Migration 031: Sorting preferences columns (prepared for future use)

### Backend Implementation
- ✅ User model methods: `getMapPreferences()` and `saveMapPreferences()`
- ✅ API endpoints with CSRF protection:
  - `GET /api/user/map-preferences` - Load user preferences
  - `POST /api/user/map-preferences` - Save user preferences
- ✅ Anonymous user handling: Returns null preferences, blocks saving
- ✅ Validation for all preference fields

### Frontend Implementation
- ✅ MapContext: Save/load all filter toggles from server
- ✅ SettingsContext: Save/load map tileset preference
- ✅ CSRF token support using `useCsrf` hook
- ✅ **Removed localStorage** to prevent cross-user contamination
- ✅ Fixed TilesetSelector to use persistent `setMapTileset`
- ✅ Page reload on login/logout to apply preferences correctly

## Features
- 🎯 Each authenticated user gets isolated map preferences
- 🎭 Anonymous users always use system defaults (cannot save)
- 🗺️ Preferences stored:
  - Map tileset selection
  - Show Paths
  - Show Neighbor Info
  - Show Route
  - Show Motion
  - Show MQTT Nodes
  - Show Animations
- 💾 Server database is single source of truth
- 🔄 Automatic page reload on login/logout ensures preferences apply

## Technical Details

### Why Remove localStorage?
Previously, preferences were saved to both localStorage and the database. This caused **cross-contamination** where User A's settings would persist in the browser and show for User B after login, because localStorage is shared across all users on the same browser.

**Solution:** Server database is now the only source of truth. Preferences load fresh from the server on each login/page load, ensuring proper user isolation.

### Anonymous User Behavior
- GET endpoint returns `{preferences: null}` for anonymous users
- POST endpoint returns 403 Forbidden for anonymous users
- Frontend uses hardcoded defaults when preferences are null
- No localStorage means settings don't persist across sessions

## Testing
- ✅ Manual testing: Login/logout preference persistence
- ✅ Verified anonymous user cannot save preferences  
- ✅ Confirmed no cross-contamination between users
- ✅ Page reload correctly applies user preferences
- ✅ All system tests passing

## Migration Safety
- Migrations use `IF NOT EXISTS` for idempotency
- Foreign key constraint ensures data integrity
- Default values match current behavior
- Rollback support included in migrations

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)