### PR TITLE
add VERSION_CHECK_DISABLED

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -935,7 +935,7 @@ function App() {
 
   // Check for version updates
   useEffect(() => {
-    const checkForUpdates = async () => {
+    const checkForUpdates = async (interval: number) => {
       try {
         const response = await fetch(`${baseUrl}/api/version/check`);
         if (response.ok) {
@@ -953,16 +953,18 @@ function App() {
           } else {
             setUpdateAvailable(false);
           }
+        } else if (response.status == 404) {
+          clearInterval(interval);
         }
       } catch (error) {
         logger.error('Error checking for updates:', error);
       }
     };
 
-    checkForUpdates();
-
     // Check for updates every 4 hours
     const interval = setInterval(checkForUpdates, 4 * 60 * 60 * 1000);
+
+    checkForUpdates(interval);
 
     return () => clearInterval(interval);
   }, [baseUrl]);

--- a/src/server/config/environment.ts
+++ b/src/server/config/environment.ts
@@ -137,6 +137,7 @@ export interface EnvironmentConfig {
   allowedOriginsProvided: boolean;
   trustProxy: boolean | number | string;
   trustProxyProvided: boolean;
+  versionCheckDisabled: boolean;
 
   // Session/Security
   sessionSecret: string;
@@ -363,6 +364,8 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
     wasProvided: process.env.DATABASE_PATH !== undefined
   };
 
+  const versionCheckDisabled = process.env.VERSION_CHECK_DISABLED == "true";
+
   // Meshtastic
   const meshtasticNodeIp = {
     value: process.env.MESHTASTIC_NODE_IP || '192.168.1.100',
@@ -508,6 +511,7 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
     allowedOriginsProvided: allowedOrigins.wasProvided,
     trustProxy: trustProxy.value,
     trustProxyProvided: trustProxy.wasProvided,
+    versionCheckDisabled: versionCheckDisabled,
 
     // Session/Security
     sessionSecret,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4080,6 +4080,9 @@ let versionCheckCache: { data: any; timestamp: number } | null = null;
 const VERSION_CHECK_CACHE_MS = 5 * 60 * 1000; // 5 minute cache (reduced to detect image availability sooner)
 
 apiRouter.get('/version/check', optionalAuth(), async (_req, res) => {
+  if (env.versionCheckDisabled) {
+    return res.status(404).send();
+  }
   try {
     // Check cache first
     if (versionCheckCache && (Date.now() - versionCheckCache.timestamp) < VERSION_CHECK_CACHE_MS) {


### PR DESCRIPTION
It's impossible and undesired for me to auto-update on my system (SBC with NixOS). I have to click-away the banner every time I open meshmonitor.

`VERSION_CHECK_DISABLED=true` env var suppresses the version check banner, and interval.