### PR TITLE
chore: Bump version to 2.19.10

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.19.9
-appVersion: "2.19.9"
+version: 2.19.10
+appVersion: "2.19.10"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.19.9",
+  "version": "2.19.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.19.9",
+      "version": "2.19.10",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.19.9",
+  "version": "2.19.10",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bumped version from 2.19.9 to 2.19.10 in package.json
- Updated Helm chart version to 2.19.10
- Regenerated package-lock.json

## Test Plan
- [x] System tests running (configuration import test passed)
- [x] Version updated in all required files
- [x] package-lock.json regenerated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)