### PR TITLE
feat: Add HostMetrics telemetry support for Linux-based devices

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2020,6 +2020,36 @@ class MeshtasticManager {
             });
           }
         }
+      } else if (telemetry.hostMetrics) {
+        const hostMetrics = telemetry.hostMetrics;
+        logger.debug(`🖥️ HostMetrics telemetry: uptime=${hostMetrics.uptimeSeconds}s, freemem=${hostMetrics.freememBytes}B`);
+
+        // Save all HostMetrics metrics to telemetry table
+        const metricsToSave = [
+          { type: 'hostUptimeSeconds', value: hostMetrics.uptimeSeconds, unit: 's' },
+          { type: 'hostFreememBytes', value: hostMetrics.freememBytes, unit: 'bytes' },
+          { type: 'hostDiskfree1Bytes', value: hostMetrics.diskfree1Bytes, unit: 'bytes' },
+          { type: 'hostDiskfree2Bytes', value: hostMetrics.diskfree2Bytes, unit: 'bytes' },
+          { type: 'hostDiskfree3Bytes', value: hostMetrics.diskfree3Bytes, unit: 'bytes' },
+          { type: 'hostLoad1', value: hostMetrics.load1, unit: 'load' },
+          { type: 'hostLoad5', value: hostMetrics.load5, unit: 'load' },
+          { type: 'hostLoad15', value: hostMetrics.load15, unit: 'load' }
+        ];
+
+        for (const metric of metricsToSave) {
+          if (metric.value !== undefined && metric.value !== null && !isNaN(Number(metric.value))) {
+            databaseService.insertTelemetry({
+              nodeId,
+              nodeNum: fromNum,
+              telemetryType: metric.type,
+              timestamp,
+              value: Number(metric.value),
+              unit: metric.unit,
+              createdAt: now,
+              packetTimestamp
+            });
+          }
+        }
       }
 
       databaseService.upsertNode(nodeData);


### PR DESCRIPTION
## Summary

Adds support for HostMetrics telemetry to display statistics from Linux-based Meshtastic devices (like Pi LoRa HAT) that don't send LocalStats.

## Problem

Linux-based devices (Pi LoRa HAT, native Linux) send HostMetrics instead of LocalStats, which meant network packet statistics weren't displaying for these devices. Users only saw:

```
Network Statistics
Total Nodes: 258
Total Channels: 1
Total Messages: 100
Active Message Channels: 1
```

But not the packet statistics (Packets TX, Packets RX, etc.).

## Solution

1. **Backend**: Added HostMetrics telemetry processing in `meshtasticManager.ts`
   - Saves uptime, free memory, disk space, and load average metrics to telemetry database
   - Processes HostMetrics alongside existing LocalStats support

2. **Frontend**: Updated `InfoTab.tsx` to display both telemetry types
   - Fetches both LocalStats and HostMetrics data
   - Shows uptime from either source (prefers HostMetrics for Linux devices)
   - Adds new "Host System Metrics" section for Linux devices showing:
     - Host uptime
     - Free memory (MB)
     - Disk space free (GB)
     - Load average (1/5/15 minute)
   - Displays helpful message when LocalStats unavailable but HostMetrics present

## Screenshots

**For Linux devices (Pi LoRa HAT):**
- Network Statistics section now shows: "Packet statistics not available. This device is sending HostMetrics (Linux-based device) instead of LocalStats."
- New Host System Metrics section displays system health information

**For embedded devices (Heltec, etc.):**
- Continues to show packet statistics as before
- No changes to existing behavior

## Testing

- ✅ All system tests passed
- ✅ Build successful (frontend + backend)
- ✅ Manual testing shows HostMetrics correctly processed and displayed

## Notes

- This doesn't add packet statistics to Linux devices (those metrics aren't available from HostMetrics)
- Instead, it provides visibility into what telemetry IS available (system health) and explains why packet stats aren't shown
- Improves UX by clarifying device differences rather than silently hiding data

Fixes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)