### PR TITLE
fix: Preserve release notes when LXC workflow adds assets

### DIFF
--- a/.github/workflows/lxc-template-build.yml
+++ b/.github/workflows/lxc-template-build.yml
@@ -78,6 +78,17 @@ jobs:
             lxc/build/*.sha256
           retention-days: 90
 
+      - name: Get existing release body
+        if: startsWith(github.ref, 'refs/tags/')
+        id: get_release
+        run: |
+          RELEASE_BODY=$(gh release view "${GITHUB_REF#refs/tags/}" --json body --jq '.body')
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "$RELEASE_BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
@@ -86,6 +97,10 @@ jobs:
             lxc/build/*.tar.gz
             lxc/build/*.sha256
           body: |
+            ${{ steps.get_release.outputs.body }}
+
+            ---
+
             ## Proxmox LXC Template
 
             This release includes a Proxmox-compatible LXC container template for MeshMonitor.


### PR DESCRIPTION
## Summary
Fixes the LXC template build workflow to preserve existing release notes instead of overwriting them.

## Problem
The LXC template build workflow was replacing the entire release body with just the Proxmox installation instructions, losing all the carefully crafted release notes about features, bug fixes, and related PRs/issues.

## Solution
- Added a step to fetch the existing release body before uploading LXC assets
- Modified the workflow to append the LXC template section to existing notes
- Added a separator (`---`) between the original content and LXC instructions

## Impact
Future releases will maintain their full changelog and context while still including the LXC deployment instructions at the bottom.

## Test plan
- [x] Workflow change reviewed
- [ ] Will be tested on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)