### PR TITLE
fix: Add channel filter to DM unread count and mark-as-read queries

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -3471,6 +3471,7 @@ class DatabaseService {
       SELECT id, ?, ? FROM messages
       WHERE ((fromNodeId = ? AND toNodeId = ?) OR (fromNodeId = ? AND toNodeId = ?))
         AND portnum = 1
+        AND channel = -1
     `;
     const params: any[] = [userId, Date.now(), localNodeId, remoteNodeId, remoteNodeId, localNodeId];
 
@@ -3549,6 +3550,7 @@ class DatabaseService {
       LEFT JOIN read_messages rm ON m.id = rm.message_id AND rm.user_id ${userId === null ? 'IS NULL' : '= ?'}
       WHERE rm.message_id IS NULL
         AND m.portnum = 1
+        AND m.channel = -1
         AND ((m.fromNodeId = ? AND m.toNodeId = ?) OR (m.fromNodeId = ? AND m.toNodeId = ?))
     `);
 


### PR DESCRIPTION
## Summary

- Fixed stuck DM unread indicator by adding `channel = -1` filter to database queries
- The `getUnreadDMCount` and `markDMMessagesAsRead` queries were missing the channel filter, causing channel messages addressed to specific nodes to be incorrectly counted as DMs
- Frontend correctly filters by `channel === -1`, but backend queries did not, causing the mismatch

## Root Cause

Direct Messages use `channel = -1` to distinguish them from regular channel messages (channels 0-7). The backend database queries were filtering by `portnum = 1` (text messages) but not by channel, so:
1. Channel messages sent to a specific node (not broadcast) were counted as unread DMs
2. When viewing the DM tab, frontend filtered them out (they have `channel >= 0`)
3. When marking as read, the wrong messages were marked, so the indicator persisted

## Changes

- `src/services/database.ts:3553` - Added `AND m.channel = -1` to `getUnreadDMCount`
- `src/services/database.ts:3474` - Added `AND channel = -1` to `markDMMessagesAsRead`

## Test Plan

- [x] TypeScript compilation passes
- [x] Server build succeeds
- [x] System tests pass
- [ ] Manual verification: DM unread indicator clears properly when viewing DMs

Fixes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)