### PR TITLE
feat: Add location environment variables for auto-responder scripts

### DIFF
--- a/examples/auto-responder-scripts/README.md
+++ b/examples/auto-responder-scripts/README.md
@@ -75,9 +75,16 @@ All scripts receive these environment variables:
 
 - `MESSAGE`: Full message text received
 - `FROM_NODE`: Sender's node number
+- `FROM_LAT`: Sender's latitude (if known)
+- `FROM_LON`: Sender's longitude (if known)
+- `MM_LAT`: MeshMonitor node's latitude (if known)
+- `MM_LON`: MeshMonitor node's longitude (if known)
 - `PACKET_ID`: Message packet ID
 - `TRIGGER`: The trigger pattern that matched
 - `PARAM_*`: Extracted parameters from trigger pattern (e.g., `PARAM_name`, `PARAM_location`)
+- `TZ`: Server timezone (IANA timezone name)
+
+**Note:** Location variables (`FROM_LAT`, `FROM_LON`, `MM_LAT`, `MM_LON`) are only set when position data is available in the database.
 
 ## Output Format
 
@@ -164,6 +171,42 @@ Multi-message example scripts that demonstrate returning multiple responses.
 **Trigger:** `lorem`
 **Example message:** `lorem`
 **Responses:** Three sequential messages containing Lorem Ipsum text, sent 30 seconds apart with retry logic.
+
+### distance.py (Python)
+Distance calculator that uses the new location environment variables to calculate the distance between the sender and the MeshMonitor node.
+
+**Trigger:** `distance, dist`
+**Example message:** `distance`
+**Response:** `Distance: 15.2km / 9.4mi (NE)`
+
+**Features:**
+- Uses `FROM_LAT`/`FROM_LON` for sender location
+- Uses `MM_LAT`/`MM_LON` for MeshMonitor location
+- Shows distance in both kilometers and miles
+- Includes compass direction from sender to MeshMonitor
+
+### api-query.py (Python)
+Demonstrates using MeshMonitor's v1 API from scripts. Shows how to query node information using API token authentication.
+
+**Requirements:**
+- `MM_API_TOKEN` environment variable (generate from Settings > API Tokens)
+- `MM_API_URL` environment variable (optional, defaults to `http://localhost:3001/meshmonitor`)
+
+**Trigger:** `nodeinfo, nodeinfo {nodeid}`
+**Example messages:**
+- `nodeinfo` - Shows info about the sender node
+- `nodeinfo !abc12345` - Shows info about a specific node
+
+**Response:** `NodeName (!abc12345) | HW: TBEAM | Loc: 25.7617,-80.1918 | Batt: 85% | Seen: 5m ago`
+
+**Setup:**
+1. Generate an API token: Settings > API Tokens > Generate Token
+2. Add to docker-compose.yaml:
+   ```yaml
+   environment:
+     - MM_API_TOKEN=your_token_here
+   ```
+3. Configure trigger with pattern `nodeinfo, nodeinfo {nodeid}`
 
 ## Regex Pattern Examples
 

--- a/examples/auto-responder-scripts/api-query.py
+++ b/examples/auto-responder-scripts/api-query.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+API Query Script - Demonstrates using MeshMonitor's v1 API from scripts.
+
+This script shows how to use an API token to query the MeshMonitor v1 API
+for complex data operations like looking up nodes, messages, and telemetry.
+
+Requirements:
+- Python 3.6+
+- MM_API_TOKEN environment variable (generate from Settings > API Tokens)
+- MM_API_URL environment variable (defaults to http://localhost:3001/meshmonitor)
+
+Setup:
+1. Generate an API token in MeshMonitor: Settings > API Tokens > Generate Token
+2. Add to docker-compose.yaml environment variables:
+   - MM_API_TOKEN=your_api_token_here
+   - MM_API_URL=http://localhost:3001/meshmonitor  # Optional, defaults to localhost
+3. Copy this script to your scripts directory
+4. Configure trigger in MeshMonitor UI:
+   - Trigger Pattern: nodeinfo, nodeinfo {nodeid}
+   - Response Type: Script
+   - Response: /data/scripts/api-query.py
+
+Usage:
+- nodeinfo - Shows info about the sender node
+- nodeinfo !abc12345 - Shows info about a specific node
+
+Environment Variables Available:
+- FROM_NODE: Sender's node number
+- FROM_LAT, FROM_LON: Sender's location (if known)
+- MM_LAT, MM_LON: MeshMonitor node location (if known)
+- MM_API_TOKEN: API token for authentication
+- MM_API_URL: Base URL for API (e.g., http://localhost:3001/meshmonitor)
+"""
+
+import os
+import sys
+import json
+import urllib.request
+import urllib.error
+from typing import Optional, Dict, Any
+
+# Configuration
+API_TOKEN = os.environ.get("MM_API_TOKEN", "")
+API_URL = os.environ.get("MM_API_URL", "http://localhost:3001/meshmonitor")
+
+
+def api_request(endpoint: str, timeout: int = 5) -> Optional[Dict[str, Any]]:
+    """
+    Make an authenticated request to the MeshMonitor v1 API.
+
+    Args:
+        endpoint: API endpoint (e.g., '/api/v1/nodes')
+        timeout: Request timeout in seconds
+
+    Returns:
+        Parsed JSON response or None on error
+    """
+    if not API_TOKEN:
+        return None
+
+    url = f"{API_URL.rstrip('/')}{endpoint}"
+    headers = {
+        "Authorization": f"Bearer {API_TOKEN}",
+        "Accept": "application/json",
+        "User-Agent": "MeshMonitor-Script/1.0"
+    }
+
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        print(f"API HTTP error: {e.code}", file=sys.stderr)
+        return None
+    except urllib.error.URLError as e:
+        print(f"API URL error: {e.reason}", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"API error: {e}", file=sys.stderr)
+        return None
+
+
+def get_node_info(node_id: str) -> Optional[Dict[str, Any]]:
+    """
+    Get information about a specific node.
+
+    Args:
+        node_id: Node ID (e.g., '!abc12345')
+
+    Returns:
+        Node data or None if not found
+    """
+    result = api_request(f"/api/v1/nodes/{node_id}")
+    if result and result.get("success"):
+        return result.get("data")
+    return None
+
+
+def get_all_nodes() -> list:
+    """Get all nodes from the mesh network."""
+    result = api_request("/api/v1/nodes")
+    if result and result.get("success"):
+        return result.get("data", [])
+    return []
+
+
+def format_node_info(node: Dict[str, Any]) -> str:
+    """Format node information for display."""
+    parts = []
+
+    # Basic info
+    name = node.get("longName") or node.get("shortName") or "Unknown"
+    node_id = node.get("nodeId", "?")
+    parts.append(f"{name} ({node_id})")
+
+    # Hardware
+    hw_model = node.get("hwModel")
+    if hw_model:
+        parts.append(f"HW: {hw_model}")
+
+    # Location
+    lat = node.get("latitude")
+    lon = node.get("longitude")
+    if lat and lon:
+        parts.append(f"Loc: {lat:.4f},{lon:.4f}")
+
+    # Battery
+    battery = node.get("batteryLevel")
+    if battery and battery > 0:
+        parts.append(f"Batt: {battery}%")
+
+    # Last seen
+    last_heard = node.get("lastHeard")
+    if last_heard:
+        # Convert to relative time
+        import time
+        try:
+            elapsed = int(time.time()) - int(last_heard)
+            if elapsed < 60:
+                parts.append(f"Seen: {elapsed}s ago")
+            elif elapsed < 3600:
+                parts.append(f"Seen: {elapsed // 60}m ago")
+            elif elapsed < 86400:
+                parts.append(f"Seen: {elapsed // 3600}h ago")
+            else:
+                parts.append(f"Seen: {elapsed // 86400}d ago")
+        except (ValueError, TypeError):
+            pass
+
+    return " | ".join(parts)
+
+
+def main():
+    """Main function to handle node info requests."""
+    try:
+        # Get parameters
+        from_node = os.environ.get("FROM_NODE", "0")
+        param_nodeid = os.environ.get("PARAM_nodeid", "").strip()
+
+        # Check if API token is configured
+        if not API_TOKEN:
+            output = {
+                "response": "API token not configured. Set MM_API_TOKEN in environment."
+            }
+            print(json.dumps(output))
+            return
+
+        # Determine which node to look up
+        if param_nodeid:
+            # User specified a node ID
+            target_node_id = param_nodeid
+            if not target_node_id.startswith("!"):
+                # Try to interpret as hex node number
+                try:
+                    node_num = int(target_node_id, 16)
+                    target_node_id = f"!{target_node_id.lower()}"
+                except ValueError:
+                    target_node_id = f"!{target_node_id}"
+        else:
+            # Look up the sender's node
+            try:
+                from_num = int(from_node)
+                target_node_id = f"!{from_num:08x}"
+            except ValueError:
+                output = {"response": "Invalid sender node number"}
+                print(json.dumps(output))
+                return
+
+        # Query the API
+        node = get_node_info(target_node_id)
+
+        if node:
+            info = format_node_info(node)
+            output = {"response": info[:200]}  # Truncate to Meshtastic limit
+        else:
+            # Try to find by searching all nodes
+            all_nodes = get_all_nodes()
+            matching = [n for n in all_nodes if target_node_id.lower() in (n.get("nodeId", "").lower())]
+
+            if matching:
+                info = format_node_info(matching[0])
+                output = {"response": info[:200]}
+            else:
+                output = {"response": f"Node {target_node_id} not found"}
+
+        print(json.dumps(output))
+
+    except Exception as e:
+        error_msg = f"Error: {str(e)}"
+        if len(error_msg) > 195:
+            error_msg = error_msg[:192] + "..."
+        output = {"response": error_msg}
+        print(json.dumps(output))
+        print(f"Script error: {e}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/auto-responder-scripts/distance.py
+++ b/examples/auto-responder-scripts/distance.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Distance Calculator Script - Uses location environment variables.
+
+This script demonstrates how to use the FROM_LAT/FROM_LON and MM_LAT/MM_LON
+environment variables to calculate the distance between the sender and the
+MeshMonitor node.
+
+Requirements:
+- Python 3.6+
+- No external dependencies
+
+Setup:
+1. Copy this script to your scripts directory
+2. Configure trigger in MeshMonitor UI:
+   - Trigger Pattern: distance, dist
+   - Response Type: Script
+   - Response: /data/scripts/distance.py
+
+Usage:
+- distance - Calculates distance from sender to MeshMonitor node
+- dist - Alias for distance
+
+Environment Variables Used:
+- FROM_LAT, FROM_LON: Sender's location
+- MM_LAT, MM_LON: MeshMonitor node location
+- FROM_NODE: Sender's node number (for display)
+"""
+
+import os
+import json
+import math
+from typing import Optional, Tuple
+
+
+def haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """
+    Calculate the great-circle distance between two points on Earth.
+
+    Args:
+        lat1, lon1: First point (latitude, longitude in degrees)
+        lat2, lon2: Second point (latitude, longitude in degrees)
+
+    Returns:
+        Distance in kilometers
+    """
+    R = 6371  # Earth's radius in km
+
+    # Convert to radians
+    lat1_rad = math.radians(lat1)
+    lat2_rad = math.radians(lat2)
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+
+    # Haversine formula
+    a = math.sin(dlat / 2) ** 2 + \
+        math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(dlon / 2) ** 2
+    c = 2 * math.asin(math.sqrt(a))
+
+    return R * c
+
+
+def km_to_miles(km: float) -> float:
+    """Convert kilometers to miles."""
+    return km * 0.621371
+
+
+def get_bearing(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """
+    Calculate the bearing from point 1 to point 2.
+
+    Args:
+        lat1, lon1: Starting point (latitude, longitude in degrees)
+        lat2, lon2: Ending point (latitude, longitude in degrees)
+
+    Returns:
+        Bearing in degrees (0-360)
+    """
+    lat1_rad = math.radians(lat1)
+    lat2_rad = math.radians(lat2)
+    dlon = math.radians(lon2 - lon1)
+
+    x = math.sin(dlon) * math.cos(lat2_rad)
+    y = math.cos(lat1_rad) * math.sin(lat2_rad) - \
+        math.sin(lat1_rad) * math.cos(lat2_rad) * math.cos(dlon)
+
+    bearing = math.degrees(math.atan2(x, y))
+    return (bearing + 360) % 360
+
+
+def bearing_to_direction(bearing: float) -> str:
+    """Convert bearing to compass direction."""
+    directions = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]
+    index = round(bearing / 45) % 8
+    return directions[index]
+
+
+def get_location(lat_var: str, lon_var: str) -> Optional[Tuple[float, float]]:
+    """Get location from environment variables."""
+    lat = os.environ.get(lat_var)
+    lon = os.environ.get(lon_var)
+
+    if lat and lon:
+        try:
+            return (float(lat), float(lon))
+        except ValueError:
+            return None
+    return None
+
+
+def main():
+    """Main function to calculate and report distance."""
+    try:
+        # Get locations from environment
+        from_loc = get_location("FROM_LAT", "FROM_LON")
+        mm_loc = get_location("MM_LAT", "MM_LON")
+        from_node = os.environ.get("FROM_NODE", "?")
+
+        # Check if both locations are available
+        if not from_loc:
+            output = {
+                "response": "Your location is not available. "
+                           "Send a position update first."
+            }
+            print(json.dumps(output))
+            return
+
+        if not mm_loc:
+            output = {
+                "response": "MeshMonitor location not set. "
+                           "The node needs a GPS fix or manual position."
+            }
+            print(json.dumps(output))
+            return
+
+        # Calculate distance
+        dist_km = haversine(from_loc[0], from_loc[1], mm_loc[0], mm_loc[1])
+        dist_mi = km_to_miles(dist_km)
+
+        # Calculate bearing (from sender to MM)
+        bearing = get_bearing(from_loc[0], from_loc[1], mm_loc[0], mm_loc[1])
+        direction = bearing_to_direction(bearing)
+
+        # Format response based on distance
+        if dist_km < 1:
+            # Less than 1 km - show in meters
+            dist_m = dist_km * 1000
+            response = f"Distance: {dist_m:.0f}m ({direction})"
+        elif dist_km < 10:
+            # Less than 10 km - show one decimal
+            response = f"Distance: {dist_km:.1f}km / {dist_mi:.1f}mi ({direction})"
+        else:
+            # Larger distances - show whole numbers
+            response = f"Distance: {dist_km:.0f}km / {dist_mi:.0f}mi ({direction})"
+
+        output = {"response": response}
+        print(json.dumps(output))
+
+    except Exception as e:
+        error_msg = f"Error calculating distance: {str(e)}"
+        if len(error_msg) > 195:
+            error_msg = error_msg[:192] + "..."
+        output = {"response": error_msg}
+        print(json.dumps(output))
+        print(f"Script error: {e}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -4997,6 +4997,23 @@ class MeshtasticManager {
                 MATCHED_PATTERN: matchedPattern || '',
               };
 
+              // Add location environment variables for the sender node (FROM_LAT, FROM_LON)
+              const fromNode = databaseService.getNode(fromNum);
+              if (fromNode?.latitude != null && fromNode?.longitude != null) {
+                scriptEnv.FROM_LAT = String(fromNode.latitude);
+                scriptEnv.FROM_LON = String(fromNode.longitude);
+              }
+
+              // Add location environment variables for the MeshMonitor node (MM_LAT, MM_LON)
+              const localNodeInfo = this.getLocalNodeInfo();
+              if (localNodeInfo) {
+                const mmNode = databaseService.getNode(localNodeInfo.nodeNum);
+                if (mmNode?.latitude != null && mmNode?.longitude != null) {
+                  scriptEnv.MM_LAT = String(mmNode.latitude);
+                  scriptEnv.MM_LON = String(mmNode.longitude);
+                }
+              }
+
               // Add extracted parameters as PARAM_* environment variables
               Object.entries(extractedParams).forEach(([key, value]) => {
                 scriptEnv[`PARAM_${key}`] = value;


### PR DESCRIPTION
## Summary
- Adds `FROM_LAT`/`FROM_LON` environment variables for the sender node's location
- Adds `MM_LAT`/`MM_LON` environment variables for the MeshMonitor node's location
- Creates `distance.py` example script that calculates distance and bearing between nodes
- Creates `api-query.py` example script demonstrating v1 API usage with token authentication

## Environment Variables

| Variable | Description |
|----------|-------------|
| `FROM_LAT` | Sender node's latitude (if known) |
| `FROM_LON` | Sender node's longitude (if known) |
| `MM_LAT` | MeshMonitor node's latitude (if known) |
| `MM_LON` | MeshMonitor node's longitude (if known) |

Location variables are only set when position data is available in the database.

## New Example Scripts

### distance.py
Calculates distance and bearing between the sender and MeshMonitor node using the Haversine formula.
- Shows distance in km/mi with compass direction
- Handles missing location data gracefully
- Trigger: `distance, dist`

### api-query.py
Demonstrates using the v1 API with token authentication for complex data queries.
- Queries node information using Bearer token auth
- Shows hardware model, location, battery, last seen
- Trigger: `nodeinfo, nodeinfo {nodeid}`

## Test Plan
- [x] TypeScript typecheck passes
- [x] Core unit tests pass (meshtasticManager.test.ts, database tests)
- [x] Verified example scripts have correct shebang and output format

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)