### PR TITLE
fix: Use appBasename as default in usePoll hook

### DIFF
--- a/src/hooks/usePoll.test.ts
+++ b/src/hooks/usePoll.test.ts
@@ -11,6 +11,11 @@ import { createElement } from 'react';
 import { usePoll, POLL_QUERY_KEY } from './usePoll';
 import type { PollData } from './usePoll';
 
+// Mock init.ts to provide empty appBasename for tests
+vi.mock('../init', () => ({
+  appBasename: '',
+}));
+
 // Mock useCsrfFetch
 const mockFetch = vi.fn();
 vi.mock('./useCsrfFetch', () => ({

--- a/src/hooks/usePoll.ts
+++ b/src/hooks/usePoll.ts
@@ -27,6 +27,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useCsrfFetch } from './useCsrfFetch';
 import type { DeviceInfo, Channel } from '../types/device';
+import { appBasename } from '../init';
 
 /**
  * Connection status from the server
@@ -142,7 +143,7 @@ export interface PollData {
  * Options for usePoll hook
  */
 interface UsePollOptions {
-  /** Base URL for API requests (default: '') */
+  /** Base URL for API requests (default: appBasename from init.ts) */
   baseUrl?: string;
   /** Poll interval in milliseconds (default: 5000) */
   pollInterval?: number;
@@ -176,7 +177,6 @@ export const POLL_QUERY_KEY = ['poll'] as const;
  * @example
  * ```tsx
  * const { data, isLoading, error } = usePoll({
- *   baseUrl: '',
  *   pollInterval: 5000,
  *   enabled: connectionStatus === 'connected'
  * });
@@ -192,7 +192,7 @@ export const POLL_QUERY_KEY = ['poll'] as const;
  * }
  * ```
  */
-export function usePoll({ baseUrl = '', pollInterval = 5000, enabled = true }: UsePollOptions = {}) {
+export function usePoll({ baseUrl = appBasename, pollInterval = 5000, enabled = true }: UsePollOptions = {}) {
   const authFetch = useCsrfFetch();
 
   return useQuery({


### PR DESCRIPTION
## Summary
- Fixed usePoll hook defaulting baseUrl to empty string instead of appBasename
- This caused 404 errors when BASE_URL is configured (e.g., /meshmonitor)
- Convenience hooks in useServerData.ts (useNodes, useChannels, etc.) now correctly use the configured base URL

## Test plan
- [x] Manually verified in browser - no more 404 errors for /api/poll
- [x] Requests now go to /meshmonitor/api/poll as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)