### PR TITLE
chore: Bump version to 2.19.12

### DIFF
--- a/docs/user-scripts.md
+++ b/docs/user-scripts.md
@@ -94,9 +94,14 @@ All scripts receive these environment variables:
 
 - `MESSAGE`: Full message text received
 - `FROM_NODE`: Sender's node number
+- `FROM_LAT`: Sender's latitude (if known)
+- `FROM_LON`: Sender's longitude (if known)
+- `MM_LAT`: MeshMonitor node's latitude (if known)
+- `MM_LON`: MeshMonitor node's longitude (if known)
 - `PACKET_ID`: Message packet ID
 - `TRIGGER`: The trigger pattern that matched
 - `PARAM_*`: Extracted parameters from trigger pattern (e.g., `PARAM_name`, `PARAM_location`)
+- `TZ`: Server timezone (IANA timezone name)
 
 ## Source Code Location
 

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.19.11
-appVersion: "2.19.11"
+version: 2.19.12
+appVersion: "2.19.12"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.19.11",
+  "version": "2.19.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.19.11",
+      "version": "2.19.12",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.19.11",
+  "version": "2.19.12",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump version to 2.19.12 in package.json and Helm chart
- Update user-scripts.md documentation with new location environment variables (`FROM_LAT`, `FROM_LON`, `MM_LAT`, `MM_LON`, `TZ`)

## Changes since v2.19.11
- fix: Use appBasename as default in usePoll hook (#839)
- feat: Add usePoll and useServerData hooks for data fetching (#835)
- feat: Extract authentication and utility hooks from App.tsx (#838)
- fix: Add channel filter to DM unread count and mark-as-read queries (#836)
- feat: Add location environment variables for auto-responder scripts (#837)
- fix: Prevent infinite loop in packet monitor when filtering packets (#831)
- fix: Preserve release notes when LXC workflow adds assets (#830)

🤖 Generated with [Claude Code](https://claude.com/claude-code)