### PR TITLE
feat: Add Mark All Read button for direct messages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2795,8 +2795,9 @@ body {
 
 .sidebar-header-content {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
   margin-bottom: 0.75rem;
 }
 
@@ -2804,6 +2805,21 @@ body {
   margin: 0;
   color: var(--ctp-text);
   font-size: 1.1rem;
+}
+
+.mark-all-read-btn {
+  background: var(--ctp-surface1);
+  border: 1px solid var(--ctp-surface2);
+  color: var(--ctp-text);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.mark-all-read-btn:hover {
+  background: var(--ctp-surface2);
 }
 
 .filter-popup-btn {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4074,6 +4074,16 @@ function App() {
             {!isMessagesNodeListCollapsed && (
               <div className="sidebar-header-content">
                 <h3>Nodes</h3>
+                <button
+                  className="mark-all-read-btn"
+                  onClick={() => {
+                    // Mark all DM messages as read (server-side handles all nodes)
+                    markMessagesAsRead(undefined, undefined, undefined, true);
+                  }}
+                  title="Mark all direct messages as read"
+                >
+                  Mark All Read
+                </button>
               </div>
             )}
             {!isMessagesNodeListCollapsed && (

--- a/src/contexts/MessagingContext.tsx
+++ b/src/contexts/MessagingContext.tsx
@@ -26,7 +26,7 @@ interface MessagingContextType {
   isDMScrolledToBottom: boolean;
   setIsDMScrolledToBottom: React.Dispatch<React.SetStateAction<boolean>>;
   // New read tracking functions
-  markMessagesAsRead: (messageIds?: string[], channelId?: number, nodeId?: string) => Promise<void>;
+  markMessagesAsRead: (messageIds?: string[], channelId?: number, nodeId?: string, allDMs?: boolean) => Promise<void>;
   fetchUnreadCounts: () => Promise<UnreadCounts | null>;
   unreadCountsData: UnreadCounts | null;
 }
@@ -73,9 +73,9 @@ export const MessagingProvider: React.FC<MessagingProviderProps> = ({ children, 
 
   // Mark messages as read using the mutation hook
   const markMessagesAsRead = useCallback(
-    async (messageIds?: string[], channelId?: number, nodeId?: string): Promise<void> => {
+    async (messageIds?: string[], channelId?: number, nodeId?: string, allDMs?: boolean): Promise<void> => {
       try {
-        await markAsReadMutation({ messageIds, channelId, nodeId });
+        await markAsReadMutation({ messageIds, channelId, nodeId, allDMs });
         // The mutation automatically invalidates and refetches unread counts
       } catch (error) {
         console.error('Error marking messages as read:', error);

--- a/src/hooks/useUnreadCounts.ts
+++ b/src/hooks/useUnreadCounts.ts
@@ -94,6 +94,8 @@ interface MarkAsReadOptions {
   channelId?: number;
   /** Mark all DMs with a node as read */
   nodeId?: string;
+  /** Mark ALL DMs as read (across all nodes) */
+  allDMs?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds a "Mark All Read" button in the Messages tab sidebar below the "Nodes" heading
- Clicking the button marks all DM messages as read with a single server-side operation
- Handles all messages including those from nodes not currently visible in the UI

## Changes
- Added `markAllDMMessagesAsRead` method to database service for efficient bulk operation
- Added `allDMs` parameter to `/api/messages/mark-read` endpoint
- Added button UI with styling in Messages sidebar
- Updated `MessagingContext` and `useUnreadCounts` hook to support the new parameter

## Test plan
- [x] Manually tested on local dev environment
- [x] Manually tested on remote test system via `:dev` image
- [x] Typecheck passes
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)