### PR TITLE
fix: Include incomplete nodes filter in header count

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -510,15 +510,21 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
           <div className="sidebar-header-content">
             <h3>Nodes ({(() => {
               const filteredCount = processedNodes.filter(node => {
+                // Security filter
                 if (securityFilter === 'flaggedOnly') {
-                  return node.keyIsLowEntropy || node.duplicateKeyDetected;
+                  if (!node.keyIsLowEntropy && !node.duplicateKeyDetected) return false;
                 }
                 if (securityFilter === 'hideFlagged') {
-                  return !node.keyIsLowEntropy && !node.duplicateKeyDetected;
+                  if (node.keyIsLowEntropy || node.duplicateKeyDetected) return false;
+                }
+                // Incomplete nodes filter
+                if (!showIncompleteNodes && !isNodeComplete(node)) {
+                  return false;
                 }
                 return true;
               }).length;
-              return securityFilter !== 'all' ? `${filteredCount}/${processedNodes.length}` : processedNodes.length;
+              const isFiltered = securityFilter !== 'all' || !showIncompleteNodes;
+              return isFiltered ? `${filteredCount}/${processedNodes.length}` : processedNodes.length;
             })()})</h3>
           </div>
           )}


### PR DESCRIPTION
## Summary
- The node count in the header now reflects the "Hide Incomplete Nodes" filter
- When incomplete nodes are hidden, the count displays as "visible/total" (e.g., "85/101")
- Previously, the count always showed the total regardless of the incomplete nodes setting

## Test plan
- [ ] Enable "Hide Incomplete Nodes" in settings
- [ ] Verify the Nodes header shows "X/Y" format where X is visible count and Y is total
- [ ] Disable "Hide Incomplete Nodes" and verify count shows just the total

Fixes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)