### PR TITLE
chore: Bump version to 2.19.13

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.19.12
-appVersion: "2.19.12"
+version: 2.19.13
+appVersion: "2.19.13"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.19.12",
+  "version": "2.19.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.19.12",
+      "version": "2.19.13",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.19.12",
+  "version": "2.19.13",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump version to 2.19.13

## Changes since 2.19.12
- #849: Fix traceroute API limit with dynamic calculation based on settings

## Test plan
- [ ] Version displays correctly in UI
- [ ] Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)