### PR TITLE
fix: Prevent false CORS warnings and overlapping poll requests on slow networks

### DIFF
--- a/public/cors-detection.js
+++ b/public/cors-detection.js
@@ -62,11 +62,14 @@ window.fetch = function(...args) {
 };
 
 // Mark as loaded if React mounts anything - this prevents any redirect
-const observer = new MutationObserver(() => {
-  if (document.getElementById('root').children.length > 0) {
-    appLoaded = true;
-    console.log('[CORS Detection] React app mounted - CORS detection disabled');
-    observer.disconnect();
-  }
-});
-observer.observe(document.getElementById('root'), { childList: true });
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const observer = new MutationObserver(() => {
+    if (rootElement.children.length > 0) {
+      appLoaded = true;
+      console.log('[CORS Detection] React app mounted - CORS detection disabled');
+      observer.disconnect();
+    }
+  });
+  observer.observe(rootElement, { childList: true });
+}

--- a/src/hooks/useCsrfFetch.ts
+++ b/src/hooks/useCsrfFetch.ts
@@ -11,7 +11,11 @@ import { useCsrf } from '../contexts/CsrfContext';
 export const useCsrfFetch = () => {
   const { getToken: getCsrfToken } = useCsrf();
 
-  const csrfFetch = useCallback(async (url: string, options?: RequestInit): Promise<Response> => {
+  const csrfFetch = useCallback(async (
+    url: string,
+    options?: RequestInit,
+    signal?: AbortSignal
+  ): Promise<Response> => {
     const headers = new Headers(options?.headers);
 
     // Add CSRF token for mutation requests
@@ -27,10 +31,12 @@ export const useCsrfFetch = () => {
     }
 
     // Always include credentials for session cookies
+    // Use provided signal for request cancellation (e.g., from TanStack Query)
     return fetch(url, {
       ...options,
       headers,
       credentials: 'include',
+      signal: signal || options?.signal,
     });
   }, [getCsrfToken]);
 

--- a/src/hooks/usePoll.test.ts
+++ b/src/hooks/usePoll.test.ts
@@ -126,7 +126,8 @@ describe('usePoll', () => {
       });
 
       await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith('/api/poll');
+        // authFetch is called with (url, options, signal) for abort support
+        expect(mockFetch).toHaveBeenCalledWith('/api/poll', undefined, expect.any(AbortSignal));
       });
     });
 
@@ -139,7 +140,8 @@ describe('usePoll', () => {
       });
 
       await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith('http://custom.url/api/poll');
+        // authFetch is called with (url, options, signal) for abort support
+        expect(mockFetch).toHaveBeenCalledWith('http://custom.url/api/poll', undefined, expect.any(AbortSignal));
       });
     });
   });


### PR DESCRIPTION
## Summary
Two fixes for slow network issues:

### 1. False CORS Warnings (Issue #856)
- Removed timeout-based detection entirely - no more time-based triggering
- Only redirect to CORS error page when actual CORS errors are detected (2+ required)
- Once React mounts, CORS detection is disabled

### 2. Overlapping Poll Requests
- Added `refetchInterval` function that skips intervals when a request is in progress
- Pass TanStack Query's AbortSignal to fetch for proper request cancellation
- Updated `useCsrfFetch` to accept and forward AbortSignal

## Why This Works
**CORS fix**: Slow networks no longer trigger false warnings because there's no timeout - only explicit CORS errors trigger redirect.

**Poll fix**: On slow networks where responses take longer than the poll interval:
1. The interval check sees `fetchStatus === 'fetching'` and returns `false` (skip)
2. If a new request somehow starts, the AbortSignal cancels the previous one

## Test plan
- [x] Test with Chrome DevTools network throttling "Slow 3G" - no false CORS warning
- [x] Test with slow network - only one poll request at a time
- [ ] Test with actual CORS misconfiguration - should still show error page

Fixes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)