### PR TITLE
refactor: Extract MessageStatusIndicator into shared component

### DIFF
--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -7,7 +7,7 @@
 
 import React, { useRef } from 'react';
 import { Channel } from '../types/device';
-import { MeshMessage, MessageDeliveryState } from '../types/message';
+import { MeshMessage } from '../types/message';
 import { ResourceType } from '../types/permission';
 import { TimeFormat, DateFormat } from '../contexts/SettingsContext';
 import { formatMessageTime, getMessageDateSeparator, shouldShowDateSeparator } from '../utils/datetime';
@@ -16,55 +16,10 @@ import { renderMessageWithLinks } from '../utils/linkRenderer';
 import HopCountDisplay from './HopCountDisplay';
 import LinkPreview from './LinkPreview';
 import { logger } from '../utils/logger';
+import { MessageStatusIndicator } from './MessageStatusIndicator';
 
 // Default PSK value for unencrypted channels
 const DEFAULT_UNENCRYPTED_PSK = 'AQ==';
-
-/**
- * Render message delivery status indicator
- */
-function renderMessageStatus(msg: MeshMessage): React.ReactElement {
-  const messageAge = Date.now() - msg.timestamp.getTime();
-  const TIMEOUT_MS = 30000;
-
-  if (msg.ackFailed || msg.routingErrorReceived || msg.deliveryState === MessageDeliveryState.FAILED) {
-    return (
-      <span className="status-failed" title="Failed to send - routing error or max retries exceeded">
-        ❌
-      </span>
-    );
-  }
-
-  if (msg.deliveryState === MessageDeliveryState.CONFIRMED) {
-    return (
-      <span className="status-confirmed" title="Received by target node">
-        🔒
-      </span>
-    );
-  }
-
-  if (msg.deliveryState === MessageDeliveryState.DELIVERED) {
-    return (
-      <span className="status-delivered" title="Transmitted to mesh">
-        ✅
-      </span>
-    );
-  }
-
-  if (messageAge < TIMEOUT_MS) {
-    return (
-      <span className="status-pending" title="Sending...">
-        ⏳
-      </span>
-    );
-  }
-
-  return (
-    <span className="status-timeout" title="No acknowledgment received (timeout)">
-      ⏱️
-    </span>
-  );
-}
 
 export interface ChannelsTabProps {
   // Data
@@ -532,7 +487,7 @@ export default function ChannelsTab({
                                     </div>
                                   </div>
                                 </div>
-                                {isMine && <div className="message-status">{renderMessageStatus(msg)}</div>}
+                                {isMine && <div className="message-status"><MessageStatusIndicator message={msg} /></div>}
                               </div>
                             </React.Fragment>
                           );

--- a/src/components/MessageStatusIndicator.tsx
+++ b/src/components/MessageStatusIndicator.tsx
@@ -1,0 +1,68 @@
+/**
+ * MessageStatusIndicator - Shared component for message delivery status
+ *
+ * Displays an icon indicating the current delivery state of a message.
+ * Used by both MessagesTab and ChannelsTab.
+ */
+
+import React from 'react';
+import { MeshMessage, MessageDeliveryState } from '../types/message';
+
+/** Timeout for pending messages before showing timeout indicator */
+const TIMEOUT_MS = 30000;
+
+interface MessageStatusIndicatorProps {
+  message: MeshMessage;
+}
+
+/**
+ * Render message delivery status indicator
+ */
+export function MessageStatusIndicator({ message }: MessageStatusIndicatorProps): React.ReactElement {
+  const messageAge = Date.now() - message.timestamp.getTime();
+
+  // Check for explicit failures first
+  if (message.ackFailed || message.routingErrorReceived || message.deliveryState === MessageDeliveryState.FAILED) {
+    return (
+      <span className="status-failed" title="Failed to send - routing error or max retries exceeded">
+        ❌
+      </span>
+    );
+  }
+
+  // Confirmed - received by target node (DMs only)
+  if (message.deliveryState === MessageDeliveryState.CONFIRMED) {
+    return (
+      <span className="status-confirmed" title="Received by target node">
+        🔒
+      </span>
+    );
+  }
+
+  // Delivered - transmitted to mesh
+  if (message.deliveryState === MessageDeliveryState.DELIVERED) {
+    return (
+      <span className="status-delivered" title="Transmitted to mesh">
+        ✅
+      </span>
+    );
+  }
+
+  // Pending - still waiting for acknowledgment
+  if (messageAge < TIMEOUT_MS) {
+    return (
+      <span className="status-pending" title="Sending...">
+        ⏳
+      </span>
+    );
+  }
+
+  // Timeout - no acknowledgment received
+  return (
+    <span className="status-timeout" title="No acknowledgment received (timeout)">
+      ⏱️
+    </span>
+  );
+}
+
+export default MessageStatusIndicator;

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -7,7 +7,7 @@
 
 import React, { useRef, useCallback } from 'react';
 import { DeviceInfo } from '../types/device';
-import { MeshMessage, MessageDeliveryState } from '../types/message';
+import { MeshMessage } from '../types/message';
 import { ResourceType } from '../types/permission';
 import { TimeFormat, DateFormat } from '../contexts/SettingsContext';
 import {
@@ -26,6 +26,7 @@ import LinkPreview from './LinkPreview';
 import NodeDetailsBlock from './NodeDetailsBlock';
 import TelemetryGraphs from './TelemetryGraphs';
 import { NodeFilterPopup } from './NodeFilterPopup';
+import { MessageStatusIndicator } from './MessageStatusIndicator';
 
 // Types for node with message metadata
 interface NodeWithMessages extends DeviceInfo {
@@ -126,52 +127,6 @@ export interface MessagesTabProps {
 
   // Helper function
   shouldShowData: () => boolean;
-}
-
-/**
- * Render message delivery status indicator
- */
-function renderMessageStatus(msg: MeshMessage): React.ReactElement {
-  const messageAge = Date.now() - msg.timestamp.getTime();
-  const TIMEOUT_MS = 30000;
-
-  if (msg.ackFailed || msg.routingErrorReceived || msg.deliveryState === MessageDeliveryState.FAILED) {
-    return (
-      <span className="status-failed" title="Failed to send - routing error or max retries exceeded">
-        ❌
-      </span>
-    );
-  }
-
-  if (msg.deliveryState === MessageDeliveryState.CONFIRMED) {
-    return (
-      <span className="status-confirmed" title="Received by target node">
-        🔒
-      </span>
-    );
-  }
-
-  if (msg.deliveryState === MessageDeliveryState.DELIVERED) {
-    return (
-      <span className="status-delivered" title="Transmitted to mesh">
-        ✅
-      </span>
-    );
-  }
-
-  if (messageAge < TIMEOUT_MS) {
-    return (
-      <span className="status-pending" title="Sending...">
-        ⏳
-      </span>
-    );
-  }
-
-  return (
-    <span className="status-timeout" title="No acknowledgment received (timeout)">
-      ⏱️
-    </span>
-  );
 }
 
 const MessagesTab: React.FC<MessagesTabProps> = ({
@@ -777,7 +732,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             </div>
                           </div>
                         </div>
-                        {isMine && <div className="message-status">{renderMessageStatus(msg)}</div>}
+                        {isMine && <div className="message-status"><MessageStatusIndicator message={msg} /></div>}
                       </div>
                     </React.Fragment>
                   );


### PR DESCRIPTION
## Summary

Follow-up to PR #860 - extracts the duplicated `renderMessageStatus` function from MessagesTab and ChannelsTab into a shared `MessageStatusIndicator` component.

- Creates new `MessageStatusIndicator` component in `src/components/`
- Updates `MessagesTab.tsx` to use the shared component
- Updates `ChannelsTab.tsx` to use the shared component
- Removes ~45 lines of duplicate code

## Changes

| File | Change |
|------|--------|
| `src/components/MessageStatusIndicator.tsx` | +68 (new file) |
| `src/components/MessagesTab.tsx` | -45 lines (removed local function) |
| `src/components/ChannelsTab.tsx` | -45 lines (removed local function) |

## Test plan

- [ ] Verify message status icons still display correctly in Messages tab
- [ ] Verify message status icons still display correctly in Channels tab
- [ ] Build passes
- [ ] TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)