### PR TITLE
fix: Hide widget edit controls for users without dashboard write permission

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4200,6 +4200,7 @@ function App() {
             favoriteTelemetryStorageDays={favoriteTelemetryStorageDays}
             baseUrl={baseUrl}
             currentNodeId={currentNodeId}
+            canEdit={hasPermission('dashboard', 'write')}
           />
         )}
         {activeTab === 'settings' && (

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -33,6 +33,7 @@ interface DashboardProps {
   favoriteTelemetryStorageDays?: number;
   baseUrl: string;
   currentNodeId?: string | null;
+  canEdit?: boolean;
 }
 
 // Custom widget types for node status and traceroute
@@ -58,6 +59,7 @@ const Dashboard: React.FC<DashboardProps> = React.memo(({
   favoriteTelemetryStorageDays = 7,
   baseUrl,
   currentNodeId = null,
+  canEdit = true,
 }) => {
   const csrfFetch = useCsrfFetch();
   const [favorites, setFavorites] = useState<FavoriteChart[]>([]);
@@ -741,6 +743,7 @@ const Dashboard: React.FC<DashboardProps> = React.memo(({
                           onRemove={() => handleRemoveWidget(widget.id)}
                           onAddNode={(nodeId) => handleAddNodeToWidget(widget.id, nodeId)}
                           onRemoveNode={(nodeId) => handleRemoveNodeFromWidget(widget.id, nodeId)}
+                          canEdit={canEdit}
                         />
                       );
                     } else if (widget.type === 'traceroute') {
@@ -753,6 +756,7 @@ const Dashboard: React.FC<DashboardProps> = React.memo(({
                           nodes={nodes}
                           onRemove={() => handleRemoveWidget(widget.id)}
                           onSelectNode={(nodeId) => handleSelectTracerouteNode(widget.id, nodeId)}
+                          canEdit={canEdit}
                         />
                       );
                     }

--- a/src/components/NodeStatusWidget.tsx
+++ b/src/components/NodeStatusWidget.tsx
@@ -22,6 +22,7 @@ interface NodeStatusWidgetProps {
   onRemove: () => void;
   onAddNode: (nodeId: string) => void;
   onRemoveNode: (nodeId: string) => void;
+  canEdit?: boolean;
 }
 
 interface NodeStatusRow {
@@ -38,6 +39,7 @@ const NodeStatusWidget: React.FC<NodeStatusWidgetProps> = ({
   onRemove,
   onAddNode,
   onRemoveNode,
+  canEdit = true,
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [showSearch, setShowSearch] = useState(false);
@@ -142,29 +144,31 @@ const NodeStatusWidget: React.FC<NodeStatusWidgetProps> = ({
       </div>
 
       <div className="node-status-content">
-        {/* Add node search */}
-        <div className="node-status-add-section" ref={searchRef}>
-          <div className="node-status-search-container">
-            <input
-              type="text"
-              className="node-status-search"
-              placeholder="Search nodes to add..."
-              value={searchQuery}
-              onChange={e => setSearchQuery(e.target.value)}
-              onFocus={() => setShowSearch(true)}
-            />
-            {showSearch && availableNodes.length > 0 && (
-              <div className="node-status-search-dropdown">
-                {availableNodes.map(node => (
-                  <div key={node.nodeId} className="node-status-search-item" onClick={() => handleAddNode(node.nodeId)}>
-                    {node.name}
-                    <span className="node-status-search-id">{node.nodeId}</span>
-                  </div>
-                ))}
-              </div>
-            )}
+        {/* Add node search - only show if user can edit */}
+        {canEdit && (
+          <div className="node-status-add-section" ref={searchRef}>
+            <div className="node-status-search-container">
+              <input
+                type="text"
+                className="node-status-search"
+                placeholder="Search nodes to add..."
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+                onFocus={() => setShowSearch(true)}
+              />
+              {showSearch && availableNodes.length > 0 && (
+                <div className="node-status-search-dropdown">
+                  {availableNodes.map(node => (
+                    <div key={node.nodeId} className="node-status-search-item" onClick={() => handleAddNode(node.nodeId)}>
+                      {node.name}
+                      <span className="node-status-search-id">{node.nodeId}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        )}
 
         {/* Node status table */}
         {nodeRows.length > 0 ? (
@@ -174,7 +178,7 @@ const NodeStatusWidget: React.FC<NodeStatusWidgetProps> = ({
                 <th>Node</th>
                 <th>Last Heard</th>
                 <th>Hops</th>
-                <th></th>
+                {canEdit && <th></th>}
               </tr>
             </thead>
             <tbody>
@@ -183,21 +187,25 @@ const NodeStatusWidget: React.FC<NodeStatusWidgetProps> = ({
                   <td className="node-status-name">{row.name}</td>
                   <td className="node-status-time">{formatLastHeard(row.lastHeard)}</td>
                   <td className="node-status-hops">{row.hopsAway !== null ? row.hopsAway : '-'}</td>
-                  <td className="node-status-actions">
-                    <button
-                      className="node-status-remove-node"
-                      onClick={() => onRemoveNode(row.nodeId)}
-                      title="Remove node"
-                    >
-                      ×
-                    </button>
-                  </td>
+                  {canEdit && (
+                    <td className="node-status-actions">
+                      <button
+                        className="node-status-remove-node"
+                        onClick={() => onRemoveNode(row.nodeId)}
+                        title="Remove node"
+                      >
+                        ×
+                      </button>
+                    </td>
+                  )}
                 </tr>
               ))}
             </tbody>
           </table>
         ) : (
-          <div className="node-status-empty">No nodes added. Use the search above to add nodes.</div>
+          <div className="node-status-empty">
+            {canEdit ? 'No nodes added. Use the search above to add nodes.' : 'No nodes configured.'}
+          </div>
         )}
       </div>
     </div>

--- a/src/components/TracerouteWidget.tsx
+++ b/src/components/TracerouteWidget.tsx
@@ -31,6 +31,7 @@ interface TracerouteWidgetProps {
   nodes: Map<string, NodeInfo>;
   onRemove: () => void;
   onSelectNode: (nodeId: string) => void;
+  canEdit?: boolean;
 }
 
 const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
@@ -40,6 +41,7 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
   nodes,
   onRemove,
   onSelectNode,
+  canEdit = true,
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [showSearch, setShowSearch] = useState(false);
@@ -208,37 +210,41 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
       </div>
 
       <div className="traceroute-content">
-        {/* Node selection */}
-        <div className="traceroute-select-section" ref={searchRef}>
-          <div className="traceroute-search-container">
-            <input
-              type="text"
-              className="traceroute-search"
-              placeholder={targetNodeId ? 'Change node...' : 'Select a node...'}
-              value={searchQuery}
-              onChange={e => setSearchQuery(e.target.value)}
-              onFocus={() => setShowSearch(true)}
-            />
-            {showSearch && availableNodes.length > 0 && (
-              <div className="traceroute-search-dropdown">
-                {availableNodes.map(node => (
-                  <div
-                    key={node.nodeId}
-                    className="traceroute-search-item"
-                    onClick={() => handleSelectNode(node.nodeId)}
-                  >
-                    {node.name}
-                    <span className="traceroute-search-id">{node.nodeId}</span>
-                  </div>
-                ))}
-              </div>
-            )}
+        {/* Node selection - only show if user can edit */}
+        {canEdit && (
+          <div className="traceroute-select-section" ref={searchRef}>
+            <div className="traceroute-search-container">
+              <input
+                type="text"
+                className="traceroute-search"
+                placeholder={targetNodeId ? 'Change node...' : 'Select a node...'}
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+                onFocus={() => setShowSearch(true)}
+              />
+              {showSearch && availableNodes.length > 0 && (
+                <div className="traceroute-search-dropdown">
+                  {availableNodes.map(node => (
+                    <div
+                      key={node.nodeId}
+                      className="traceroute-search-item"
+                      onClick={() => handleSelectNode(node.nodeId)}
+                    >
+                      {node.name}
+                      <span className="traceroute-search-id">{node.nodeId}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        )}
 
         {/* Traceroute display */}
         {!targetNodeId ? (
-          <div className="traceroute-empty">Select a node above to view traceroute information.</div>
+          <div className="traceroute-empty">
+            {canEdit ? 'Select a node above to view traceroute information.' : 'No node configured.'}
+          </div>
         ) : isLoading ? (
           <div className="traceroute-loading">Loading traceroute data...</div>
         ) : !traceroute ? (


### PR DESCRIPTION
## Summary
- Hide node search inputs and remove buttons in Node Status and Traceroute widgets for users without dashboard write permission
- Add `canEdit` prop to Dashboard component based on `hasPermission('dashboard', 'write')`
- Update empty state messages to reflect read-only mode

## Test plan
- [x] Build successfully
- [x] All system tests pass
- [ ] Log in as admin - verify search inputs visible in Node Status and Traceroute widgets
- [ ] Log in as user without dashboard write permission - verify search inputs hidden and remove buttons hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)