### PR TITLE
fix: Scroll Messages and Channels tabs to bottom on load

### DIFF
--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -85,6 +85,9 @@ export interface ChannelsTabProps {
 
   // Emoji picker
   setEmojiPickerMessage: (message: MeshMessage | null) => void;
+
+  // Refs from parent for scroll handling
+  channelMessagesContainerRef: React.RefObject<HTMLDivElement | null>;
 }
 
 export default function ChannelsTab({
@@ -122,11 +125,11 @@ export default function ChannelsTab({
   getNodeShortName,
   isMqttBridgeMessage,
   setEmojiPickerMessage,
+  channelMessagesContainerRef,
 }: ChannelsTabProps) {
   const { t } = useTranslation();
 
   // Refs
-  const channelMessagesContainerRef = useRef<HTMLDivElement>(null);
   const channelMessageInputRef = useRef<HTMLInputElement>(null);
 
   // Helper: get channel name

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -128,6 +128,9 @@ export interface MessagesTabProps {
 
   // Helper function
   shouldShowData: () => boolean;
+
+  // Refs from parent for scroll handling
+  dmMessagesContainerRef: React.RefObject<HTMLDivElement | null>;
 }
 
 const MessagesTab: React.FC<MessagesTabProps> = ({
@@ -178,11 +181,11 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   setShowPurgeDataModal,
   setEmojiPickerMessage,
   shouldShowData,
+  dmMessagesContainerRef,
 }) => {
   const { t } = useTranslation();
 
   // Refs
-  const dmMessagesContainerRef = useRef<HTMLDivElement>(null);
   const dmMessageInputRef = useRef<HTMLInputElement>(null);
 
   // Helper functions


### PR DESCRIPTION
## Summary
- Connect message container refs from App.tsx to child components so scroll-to-bottom works correctly
- Simplify scroll logic to always scroll on tab/channel switch, removing race conditions
- Remove unused tracking refs that caused unreliable scroll behavior

## Problem
Messages and Channels tabs were loading at the top of the message list instead of scrolling to the newest messages at the bottom. This was caused by:
1. Child components creating local refs that weren't connected to App.tsx's scroll handlers
2. Race conditions between scroll effects and flag reset effects

## Solution
- Pass `channelMessagesContainerRef` and `dmMessagesContainerRef` from App.tsx to child components
- Remove local ref creation and useEffect scroll handlers from ChannelsTab and MessagesTab
- Simplify scroll logic to always scroll to bottom when switching tabs or channels

## Test plan
- [ ] Open Channels tab - should scroll to bottom showing newest messages
- [ ] Switch between channels - should scroll to bottom on each switch
- [ ] Switch away from Channels tab and back - should scroll to bottom
- [ ] Open Messages tab and select a conversation - should scroll to bottom
- [ ] Switch between conversations - should scroll to bottom
- [ ] Verify infinite scroll still works (scroll up to load older messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)