### PR TITLE
fix: Use language code only for i18n to avoid 404 on region locales

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -30,6 +30,7 @@ i18n
   .use(initReactI18next)
   .init({
     fallbackLng: 'en',
+    load: 'languageOnly', // Use 'en' instead of 'en-US'
     debug: process.env.NODE_ENV === 'development',
 
     interpolation: {


### PR DESCRIPTION
## Summary
- Add `load: 'languageOnly'` to i18next config to strip region codes from browser locales

## Problem
Browsers report locales with region codes (e.g., `en-US`, `en-GB`) but we only have base language translation files (e.g., `en.json`). This caused 404 errors when loading translation files.

## Solution
Configure i18next to use `load: 'languageOnly'` which strips the region code, so `en-US` becomes `en` and correctly loads `en.json`.

## Test plan
- [ ] Load site with browser set to `en-US` locale - should load `en.json` without 404
- [ ] Load site with browser set to other regional locales - should fallback correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)