### PR TITLE
fix(i18n): add translations to refactored Dashboard components

### DIFF
--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { arrayMove } from '@dnd-kit/sortable';
 import { DragEndEvent } from '@dnd-kit/core';
 import '../Dashboard.css';
@@ -19,6 +20,7 @@ const Dashboard: React.FC<DashboardProps> = React.memo(({
   currentNodeId = null,
   canEdit = true,
 }) => {
+  const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   
   // Modal state
@@ -182,11 +184,11 @@ const Dashboard: React.FC<DashboardProps> = React.memo(({
   }, [favorites, setFavorites, baseUrl, csrfFetch]);
 
   if (loading) {
-    return <div className="dashboard-loading">Loading dashboard...</div>;
+    return <div className="dashboard-loading">{t('dashboard.loading')}</div>;
   }
 
   if (error) {
-    return <div className="dashboard-error">Error: {error}</div>;
+    return <div className="dashboard-error">{t('dashboard.error', { error })}</div>;
   }
 
   const hours = daysToView * 24;
@@ -256,8 +258,8 @@ const Dashboard: React.FC<DashboardProps> = React.memo(({
 
       {!hasContent && (
         <div className="dashboard-empty">
-          <h2>No Widgets or Favorites Yet</h2>
-          <p>Click &quot;+ Add Widget&quot; above or star telemetry charts in the Nodes tab</p>
+          <h2>{t('dashboard.empty_title')}</h2>
+          <p>{t('dashboard.empty_description')}</p>
         </div>
       )}
     </div>

--- a/src/components/Dashboard/components/DashboardFilters.tsx
+++ b/src/components/Dashboard/components/DashboardFilters.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { getTelemetryLabel } from '../../TelemetryChart';
 import { type SortOption } from '../types';
 
@@ -56,6 +57,7 @@ const DashboardFilters: React.FC<DashboardFiltersProps> = ({
   sortOption,
   onSortChange,
 }) => {
+  const { t } = useTranslation();
   const roleDropdownRef = useRef<HTMLDivElement>(null);
 
   // Close dropdown when clicking outside
@@ -79,7 +81,7 @@ const DashboardFilters: React.FC<DashboardFiltersProps> = ({
       <div className="dashboard-filters">
         <div className="dashboard-filter-group">
           <label htmlFor="daysToView" style={{ marginRight: '0.5rem', fontWeight: '500' }}>
-            Days to View:
+            {t('dashboard.days_to_view')}
           </label>
           <input
             type="number"
@@ -103,7 +105,7 @@ const DashboardFilters: React.FC<DashboardFiltersProps> = ({
         <input
           type="text"
           className="dashboard-search"
-          placeholder="Search nodes or telemetry types..."
+          placeholder={t('dashboard.search_placeholder')}
           value={searchQuery}
           onChange={e => onSearchChange(e.target.value)}
         />
@@ -113,7 +115,7 @@ const DashboardFilters: React.FC<DashboardFiltersProps> = ({
           value={selectedNode}
           onChange={e => onNodeChange(e.target.value)}
         >
-          <option value="all">All Nodes</option>
+          <option value="all">{t('dashboard.all_nodes')}</option>
           {uniqueNodes.map(([nodeId, nodeName]) => (
             <option key={nodeId} value={nodeId}>
               {nodeName}
@@ -126,7 +128,7 @@ const DashboardFilters: React.FC<DashboardFiltersProps> = ({
           value={selectedType}
           onChange={e => onTypeChange(e.target.value)}
         >
-          <option value="all">All Types</option>
+          <option value="all">{t('dashboard.all_types')}</option>
           {uniqueTypes.map(type => (
             <option key={type} value={type}>
               {getTelemetryLabel(type)}
@@ -137,7 +139,9 @@ const DashboardFilters: React.FC<DashboardFiltersProps> = ({
         <div className="dashboard-role-filter-dropdown" ref={roleDropdownRef}>
           <div className="dashboard-role-filter-button" onClick={onToggleRoleDropdown}>
             <span>
-              {selectedRoles.size === 0 ? 'Device Roles: All' : `Device Roles: ${selectedRoles.size} selected`}
+              {selectedRoles.size === 0
+                ? t('dashboard.device_roles_all')
+                : t('dashboard.device_roles_selected', { count: selectedRoles.size })}
             </span>
             <span className="dashboard-dropdown-arrow">{roleDropdownOpen ? '▲' : '▼'}</span>
           </div>
@@ -147,7 +151,7 @@ const DashboardFilters: React.FC<DashboardFiltersProps> = ({
                 <>
                   <label className="dashboard-role-checkbox-label">
                     <input type="checkbox" checked={selectedRoles.size === 0} onChange={onClearRoleFilter} />
-                    <span>All Roles</span>
+                    <span>{t('dashboard.all_roles')}</span>
                   </label>
                   <div className="dashboard-role-divider" />
                   {uniqueRoles.map(role => (
@@ -162,7 +166,7 @@ const DashboardFilters: React.FC<DashboardFiltersProps> = ({
                   ))}
                 </>
               ) : (
-                <span className="dashboard-no-roles">No roles available</span>
+                <span className="dashboard-no-roles">{t('dashboard.no_roles')}</span>
               )}
             </div>
           )}
@@ -170,18 +174,18 @@ const DashboardFilters: React.FC<DashboardFiltersProps> = ({
       </div>
 
       <div className="dashboard-sort">
-        <label htmlFor="sort-select">Sort by:</label>
+        <label htmlFor="sort-select">{t('dashboard.sort_by')}</label>
         <select
           id="sort-select"
           className="dashboard-sort-select"
           value={sortOption}
           onChange={e => onSortChange(e.target.value as SortOption)}
         >
-          <option value="custom">Custom Order (Drag & Drop)</option>
-          <option value="node-asc">Node Name (A-Z)</option>
-          <option value="node-desc">Node Name (Z-A)</option>
-          <option value="type-asc">Telemetry Type (A-Z)</option>
-          <option value="type-desc">Telemetry Type (Z-A)</option>
+          <option value="custom">{t('dashboard.sort_custom')}</option>
+          <option value="node-asc">{t('dashboard.sort_node_asc')}</option>
+          <option value="node-desc">{t('dashboard.sort_node_desc')}</option>
+          <option value="type-asc">{t('dashboard.sort_type_asc')}</option>
+          <option value="type-desc">{t('dashboard.sort_type_desc')}</option>
         </select>
       </div>
     </div>

--- a/src/components/Dashboard/components/DashboardGrid.tsx
+++ b/src/components/Dashboard/components/DashboardGrid.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   DndContext,
   closestCenter,
@@ -74,6 +75,8 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
   filteredCount,
   canEdit = true,
 }) => {
+  const { t } = useTranslation();
+
   // Drag and drop sensors
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -85,9 +88,9 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
   return (
     <>
       <div className="dashboard-results-info">
-        {widgetsCount > 0 && `${widgetsCount} widget${widgetsCount !== 1 ? 's' : ''}`}
+        {widgetsCount > 0 && t(widgetsCount !== 1 ? 'dashboard.widget_count_plural' : 'dashboard.widget_count', { count: widgetsCount })}
         {widgetsCount > 0 && favoritesCount > 0 && ', '}
-        {favoritesCount > 0 && `${filteredCount} of ${favoritesCount} chart${favoritesCount !== 1 ? 's' : ''}`}
+        {favoritesCount > 0 && t(favoritesCount !== 1 ? 'dashboard.chart_count_plural' : 'dashboard.chart_count', { shown: filteredCount, total: favoritesCount })}
       </div>
 
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>

--- a/src/components/Dashboard/components/DashboardHeader.tsx
+++ b/src/components/Dashboard/components/DashboardHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface DashboardHeaderProps {
   favoritesCount: number;
@@ -11,22 +12,24 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   daysToView,
   onAddWidgetClick,
 }) => {
+  const { t } = useTranslation();
+
   return (
     <div className="dashboard-header-section">
       <div>
-        <h2 className="dashboard-title">Telemetry Dashboard</h2>
+        <h2 className="dashboard-title">{t('dashboard.title')}</h2>
         <p className="dashboard-subtitle">
           {favoritesCount > 0
-            ? `Showing last ${daysToView} days of favorited telemetry`
-            : 'Add widgets or star telemetry in the Nodes tab'}
+            ? t('dashboard.subtitle_with_data', { days: daysToView })
+            : t('dashboard.subtitle_empty')}
         </p>
       </div>
       <button
         className="dashboard-add-widget-btn"
         onClick={onAddWidgetClick}
-        title="Add widget"
+        title={t('dashboard.add_widget_title')}
       >
-        + Add Widget
+        {t('dashboard.add_widget_button')}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary

- Add `useTranslation` hook and i18n translation keys to Dashboard components introduced in PR #870
- All hardcoded English strings replaced with translation function calls

## Changes

- **DashboardHeader.tsx**: Title, subtitle, add widget button
- **DashboardFilters.tsx**: Filter labels, dropdowns, sort options
- **DashboardGrid.tsx**: Widget/chart count display
- **Dashboard.tsx**: Loading, error, and empty states

## Context

PR #870 refactored the Dashboard into a modular structure but used hardcoded English strings. This follow-up PR restores i18n support using the existing translation keys from en.json.

## Test plan

- [ ] Verify Dashboard displays correctly in English
- [ ] Verify Dashboard translates when switching to other languages (es/de/fr)
- [ ] Build and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)