### PR TITLE
Release v2.20.2

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.20.1
-appVersion: "2.20.1"
+version: 2.20.2
+appVersion: "2.20.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.20.1",
+  "version": "2.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.20.1",
+      "version": "2.20.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.20.1",
+  "version": "2.20.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Release v2.20.2

### New Features

- **MQTT Traceroute Visualization** - [#895](https://github.com/Yeraze/meshmonitor/pull/895) (Closes [#893](https://github.com/Yeraze/meshmonitor/issues/893))
  - Segments with 0.0 dB SNR (indicating MQTT traversal) now display as dotted lines in muted gray
  - "via MQTT" badge shown in route segment popup

- **Inactive Node Notifications** - [#883](https://github.com/Yeraze/meshmonitor/pull/883) (Closes [#864](https://github.com/Yeraze/meshmonitor/issues/864))
  - Configurable notifications when nodes go inactive
  - By @seanmoro

### Documentation

- **Translations Contribution Guide** - [#894](https://github.com/Yeraze/meshmonitor/pull/894)

### Translations

- [#882](https://github.com/Yeraze/meshmonitor/pull/882), [#884](https://github.com/Yeraze/meshmonitor/pull/884) - Translation updates from Weblate (Russian added)

### Dependencies

- [#885](https://github.com/Yeraze/meshmonitor/pull/885) - Development dependencies update
- [#886](https://github.com/Yeraze/meshmonitor/pull/886) - Production dependencies update
- [#887](https://github.com/Yeraze/meshmonitor/pull/887) - maplibre-gl 5.14.0
- [#888](https://github.com/Yeraze/meshmonitor/pull/888) - @typescript-eslint/eslint-plugin 8.48.1
- [#889](https://github.com/Yeraze/meshmonitor/pull/889) - @typescript-eslint/parser 8.48.1
- [#890](https://github.com/Yeraze/meshmonitor/pull/890) - puppeteer 24.32.0
- [#891](https://github.com/Yeraze/meshmonitor/pull/891) - Multi-dependency update
- [#892](https://github.com/Yeraze/meshmonitor/pull/892) - react-router-dom 7.10.1

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)