### PR TITLE
fix: handle Channel 0 correctly in autoresponder trigger editor

### DIFF
--- a/src/components/auto-responder/TriggerItem.tsx
+++ b/src/components/auto-responder/TriggerItem.tsx
@@ -30,7 +30,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
   const [editResponse, setEditResponse] = useState(trigger.response);
   const [editMultiline, setEditMultiline] = useState(trigger.multiline || false);
   const [editVerifyResponse, setEditVerifyResponse] = useState(trigger.verifyResponse || false);
-  const [editChannel, setEditChannel] = useState<number | 'dm'>(trigger.channel || 'dm');
+  const [editChannel, setEditChannel] = useState<number | 'dm'>(trigger.channel !== undefined ? trigger.channel : 'dm');
   const [triggerValidation, setTriggerValidation] = useState<{ valid: boolean; error?: string }>({ valid: true });
 
   // Validate trigger in realtime
@@ -82,7 +82,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
       setEditResponse(trigger.response);
       setEditMultiline(trigger.multiline || false);
       setEditVerifyResponse(trigger.verifyResponse || false);
-      setEditChannel(trigger.channel || 'dm');
+      setEditChannel(trigger.channel !== undefined ? trigger.channel : 'dm');
       setTriggerValidation({ valid: true });
     }
   }, [isEditing, trigger.trigger, trigger.responseType, trigger.response, trigger.multiline, trigger.verifyResponse, trigger.channel]);
@@ -608,12 +608,12 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                 <span style={{
                   fontSize: '0.7rem',
                   padding: '0.15rem 0.4rem',
-                  background: (trigger.channel === 'dm' || !trigger.channel) ? 'var(--ctp-sky)' : 'var(--ctp-lavender)',
+                  background: (trigger.channel === 'dm' || trigger.channel === undefined) ? 'var(--ctp-sky)' : 'var(--ctp-lavender)',
                   color: 'var(--ctp-base)',
                   borderRadius: '3px',
                   fontWeight: 'bold'
                 }}>
-                  {(trigger.channel === 'dm' || !trigger.channel)
+                  {(trigger.channel === 'dm' || trigger.channel === undefined)
                     ? 'DM'
                     : `CH ${trigger.channel}: ${channels.find(c => c.id === trigger.channel)?.name || 'Unknown'}`}
                 </span>


### PR DESCRIPTION
## Summary

- Fixes #897 - Channel 0 selection in autoresponder trigger editor was saving as "DM"
- JavaScript's falsy evaluation treated `0` as falsy, so `trigger.channel || 'dm'` returned `'dm'` when channel was `0`
- Changed from logical OR (`||`) to explicit undefined checks to properly handle Channel 0 as a valid channel index

## Changes

**`src/components/auto-responder/TriggerItem.tsx`**:
- Line 33: State initialization now uses `trigger.channel !== undefined ? trigger.channel : 'dm'`
- Line 85: useEffect reset uses same pattern
- Lines 611, 616: Display logic uses `trigger.channel === undefined` instead of `!trigger.channel`

## Test plan

- [x] TypeScript type check passes
- [x] ESLint passes on changed file
- [x] Docker build succeeds
- [x] Verified fix is present in built code
- [x] All system tests pass:
  - Configuration Import: ✓ PASSED
  - Quick Start Test: ✓ PASSED
  - Security Test: ✓ PASSED
  - Reverse Proxy Test: ✓ PASSED
  - Reverse Proxy + OIDC: ✓ PASSED
  - Virtual Node CLI Test: ✓ PASSED
  - Backup & Restore Test: ✓ PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)