### PR TITLE
feat: show date on chart X-axis when data spans more than 24 hours

### DIFF
--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -20,6 +20,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useTelemetry, type TelemetryData } from '../hooks/useTelemetry';
 import { type TemperatureUnit, formatTemperature, getTemperatureUnit } from '../utils/temperature';
+import { formatChartAxisTimestamp } from '../utils/datetime';
 
 interface FavoriteChart {
   nodeId: string;
@@ -344,12 +345,7 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
               type="number"
               domain={globalTimeRange || ['dataMin', 'dataMax']}
               tick={{ fontSize: 12 }}
-              tickFormatter={timestamp =>
-                new Date(timestamp).toLocaleTimeString([], {
-                  hour: '2-digit',
-                  minute: '2-digit',
-                })
-              }
+              tickFormatter={timestamp => formatChartAxisTimestamp(timestamp, globalTimeRange)}
             />
             <YAxis yAxisId="left" tick={{ fontSize: 12 }} domain={['auto', 'auto']} />
             <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 12 }} domain={['auto', 'auto']} hide={true} />

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -8,6 +8,7 @@ import { useToast } from './ToastContainer';
 import { useCsrfFetch } from '../hooks/useCsrfFetch';
 import { useTelemetry, useSolarEstimates, type TelemetryData } from '../hooks/useTelemetry';
 import { useFavorites, useToggleFavorite } from '../hooks/useFavorites';
+import { formatChartAxisTimestamp } from '../utils/datetime';
 
 interface TelemetryGraphsProps {
   nodeId: string;
@@ -533,12 +534,7 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
                       type="number"
                       domain={globalTimeRange || ['dataMin', 'dataMax']}
                       tick={{ fontSize: 12 }}
-                      tickFormatter={timestamp =>
-                        new Date(timestamp).toLocaleTimeString([], {
-                          hour: '2-digit',
-                          minute: '2-digit',
-                        })
-                      }
+                      tickFormatter={timestamp => formatChartAxisTimestamp(timestamp, globalTimeRange)}
                     />
                     <YAxis yAxisId="left" tick={{ fontSize: 12 }} domain={['auto', 'auto']} />
                     <YAxis

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -237,3 +237,43 @@ export function shouldShowDateSeparator(
          prevDate.getMonth() !== currentDate.getMonth() ||
          prevDate.getDate() !== currentDate.getDate();
 }
+
+/**
+ * Formats a timestamp for chart X-axis display.
+ * Shows date + time if the time range spans more than 24 hours,
+ * otherwise just shows time.
+ *
+ * @param timestamp - Timestamp in milliseconds
+ * @param timeRange - Tuple of [minTimestamp, maxTimestamp] in milliseconds, or null
+ * @returns Formatted string like "Dec 9 14:32" (multi-day) or "14:32" (single day)
+ */
+export function formatChartAxisTimestamp(
+  timestamp: number,
+  timeRange: [number, number] | null
+): string {
+  const date = new Date(timestamp);
+  const timeStr = date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  // If no time range provided, default to time-only format
+  if (!timeRange) {
+    return timeStr;
+  }
+
+  const [minTime, maxTime] = timeRange;
+  const rangeMs = maxTime - minTime;
+  const twentyFourHours = 24 * 60 * 60 * 1000;
+
+  // If range is more than 24 hours, include the date
+  if (rangeMs > twentyFourHours) {
+    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const monthName = monthNames[date.getMonth()];
+    const day = date.getDate();
+    return `${monthName} ${day} ${timeStr}`;
+  }
+
+  return timeStr;
+}


### PR DESCRIPTION
## Summary
- Added smart date/time formatting for chart X-axis labels
- Shows "Dec 9 14:32" format when data spans > 24 hours
- Shows "14:32" format for single-day data (existing behavior)

Closes #902

## Test plan
- [ ] Build and deploy container
- [ ] View dashboard with telemetry data spanning multiple days
- [ ] Verify X-axis shows date + time format (e.g., "Dec 9 14:32")
- [ ] View dashboard with < 24 hours of data
- [ ] Verify X-axis shows time-only format (e.g., "14:32")

🤖 Generated with [Claude Code](https://claude.com/claude-code)