### PR TITLE
fix: apply "Hide Incomplete Nodes" filter to map markers

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -843,7 +843,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               <SpiderfierController ref={spiderfierRef} zoomLevel={mapZoom} />
               <MapLegend />
               {nodesWithPosition
-                .filter(node => showMqttNodes || !node.viaMqtt)
+                .filter(node => (showMqttNodes || !node.viaMqtt) && (showIncompleteNodes || isNodeComplete(node)))
                 .map(node => {
                 const roleNum = typeof node.user?.role === 'string'
                   ? parseInt(node.user.role, 10)


### PR DESCRIPTION
## Summary
- Map markers now respect the "Hide Incomplete Nodes" setting
- Previously the filter was only applied to the node list, not the map

Closes #901

## Test plan
- [ ] Enable "Hide Incomplete Nodes" in settings
- [ ] Verify incomplete nodes are hidden from the node list (existing behavior)
- [ ] Verify incomplete nodes are also hidden from the map markers (fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)