### PR TITLE
docs: add Discord community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ Quick start:
 
 This project is licensed under the BSD-3-Clause License - see the [LICENSE](LICENSE) file for details.
 
+## Community & Support
+
+- **Discord**: [Join our Discord](https://discord.gg/aeeQbKN5) - Chat with the community and get help
+- **GitHub Issues**: Report bugs and request features
+- **Documentation**: [meshmonitor.org](https://meshmonitor.org/)
+
 ## Acknowledgments
 
 - [Meshtastic](https://meshtastic.org/) - Open source mesh networking

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,7 @@ Manage users, permissions, and authentication with a comprehensive admin interfa
 
 ## Community & Support
 
+- **Discord**: [Join our Discord](https://discord.gg/aeeQbKN5) - Chat with the community and get help
 - **GitHub**: [github.com/yeraze/meshmonitor](https://github.com/yeraze/meshmonitor)
 - **Issues**: Report bugs and request features on GitHub Issues
 - **License**: BSD-3-Clause


### PR DESCRIPTION
## Summary
- Added Discord invite link to README.md
- Added Discord invite link to meshmonitor.org website (docs/index.md)

Discord: https://discord.gg/aeeQbKN5

🤖 Generated with [Claude Code](https://claude.com/claude-code)