### PR TITLE
fix: centralize traceroute data for consistent display across views

### DIFF
--- a/src/hooks/usePoll.ts
+++ b/src/hooks/usePoll.ts
@@ -100,6 +100,24 @@ export interface DeviceConfig {
 }
 
 /**
+ * Traceroute data from the poll endpoint
+ */
+export interface PollTraceroute {
+  id?: number;
+  fromNodeNum: number;
+  toNodeNum: number;
+  fromNodeId: string;
+  toNodeId: string;
+  route: string;
+  routeBack: string;
+  snrTowards: string;
+  snrBack: string;
+  timestamp: number;
+  createdAt: number;
+  hopCount: number;
+}
+
+/**
  * Raw message from the server (before timestamp conversion)
  */
 export interface RawMessage {
@@ -137,6 +155,7 @@ export interface PollData {
   telemetryNodes?: TelemetryNodes;
   config?: PollConfig;
   deviceConfig?: DeviceConfig;
+  traceroutes?: PollTraceroute[];
 }
 
 /**

--- a/src/hooks/useTraceroutes.ts
+++ b/src/hooks/useTraceroutes.ts
@@ -1,0 +1,139 @@
+/**
+ * Centralized hook for traceroute data access
+ *
+ * Provides a single source of truth for traceroute data across all views:
+ * - Dashboard TracerouteWidget
+ * - Node View (getRecentTraceroute)
+ * - Traceroute History Modal
+ *
+ * Data is synchronized via the poll mechanism, ensuring consistent
+ * display across all components. Traceroutes are sorted by timestamp DESC
+ * (newest first) to match the database ordering.
+ */
+
+import { usePoll, PollTraceroute } from './usePoll';
+import { useQueryClient } from '@tanstack/react-query';
+import { POLL_QUERY_KEY, PollData } from './usePoll';
+
+/**
+ * Hook to access traceroute data from the poll cache
+ *
+ * @returns Object with traceroutes and utility functions
+ *
+ * @example
+ * ```tsx
+ * const { traceroutes, getRecentTraceroute, getTraceroutesByNode } = useTraceroutes();
+ *
+ * // Get all recent traceroutes for dashboard widget
+ * const allRecent = traceroutes;
+ *
+ * // Get most recent traceroute for a specific node (for Node View)
+ * const recent = getRecentTraceroute(nodeId);
+ *
+ * // Get traceroutes between two nodes
+ * const history = getTraceroutesByNodePair(fromNodeNum, toNodeNum);
+ * ```
+ */
+export function useTraceroutes() {
+  const { data, isLoading, error } = usePoll();
+
+  // Traceroutes from poll, already sorted by timestamp DESC from server
+  const traceroutes = (data?.traceroutes ?? []) as PollTraceroute[];
+
+  /**
+   * Get the most recent traceroute involving a specific node
+   * Used by Node View to show the latest traceroute
+   *
+   * @param nodeId - The node ID to find traceroutes for
+   * @param withinMs - Only consider traceroutes within this time window (default: 24 hours)
+   * @returns The most recent traceroute or null
+   */
+  const getRecentTraceroute = (nodeId: string, withinMs: number = 24 * 60 * 60 * 1000): PollTraceroute | null => {
+    const cutoffTime = Date.now() - withinMs;
+
+    // Traceroutes are already sorted by timestamp DESC, so first match is most recent
+    const recent = traceroutes.find(
+      tr => (tr.fromNodeId === nodeId || tr.toNodeId === nodeId) && tr.timestamp >= cutoffTime
+    );
+
+    return recent ?? null;
+  };
+
+  /**
+   * Get all traceroutes involving a specific node
+   * Useful for filtering traceroutes by node
+   *
+   * @param nodeId - The node ID to filter by
+   * @returns Array of traceroutes involving the node (sorted by timestamp DESC)
+   */
+  const getTraceroutesByNode = (nodeId: string): PollTraceroute[] => {
+    return traceroutes.filter(tr => tr.fromNodeId === nodeId || tr.toNodeId === nodeId);
+  };
+
+  /**
+   * Get traceroutes between two specific nodes
+   * Used by Traceroute History Modal for recent entries preview
+   *
+   * @param fromNodeNum - Source node number
+   * @param toNodeNum - Destination node number
+   * @param limit - Maximum number of results (default: 10)
+   * @returns Array of traceroutes between the nodes (sorted by timestamp DESC)
+   */
+  const getTraceroutesByNodePair = (
+    fromNodeNum: number,
+    toNodeNum: number,
+    limit: number = 10
+  ): PollTraceroute[] => {
+    return traceroutes
+      .filter(tr =>
+        (tr.fromNodeNum === fromNodeNum && tr.toNodeNum === toNodeNum) ||
+        (tr.fromNodeNum === toNodeNum && tr.toNodeNum === fromNodeNum)
+      )
+      .slice(0, limit);
+  };
+
+  /**
+   * Get the best (lowest hop count) traceroute between two nodes
+   * Used by Dashboard Widget to show optimal route
+   *
+   * @param fromNodeNum - Source node number
+   * @param toNodeNum - Destination node number
+   * @returns The traceroute with lowest hop count, or null
+   */
+  const getBestTraceroute = (fromNodeNum: number, toNodeNum: number): PollTraceroute | null => {
+    const relevantTraceroutes = traceroutes.filter(tr =>
+      (tr.fromNodeNum === fromNodeNum && tr.toNodeNum === toNodeNum) ||
+      (tr.fromNodeNum === toNodeNum && tr.toNodeNum === fromNodeNum)
+    );
+
+    if (relevantTraceroutes.length === 0) return null;
+
+    return relevantTraceroutes.reduce((best, current) =>
+      current.hopCount < best.hopCount ? current : best
+    );
+  };
+
+  return {
+    traceroutes,
+    isLoading,
+    error,
+    getRecentTraceroute,
+    getTraceroutesByNode,
+    getTraceroutesByNodePair,
+    getBestTraceroute,
+  };
+}
+
+/**
+ * Get traceroutes from cache without subscribing to updates
+ * Useful for callbacks and handlers outside React components
+ *
+ * @param queryClient - The query client instance
+ * @returns Array of traceroutes from cache
+ */
+export function getTraceroutesFromCache(
+  queryClient: ReturnType<typeof useQueryClient>
+): PollTraceroute[] {
+  const data = queryClient.getQueryData<PollData>(POLL_QUERY_KEY);
+  return (data?.traceroutes ?? []) as PollTraceroute[];
+}


### PR DESCRIPTION
## Summary

Fixes #915 - Traceroute data was displayed inconsistently across three views:
- **Traceroute History Modal** - showed correct/fresh data
- **Node View** - showed stale data
- **Dashboard Widget** - showed stale data

### Root Cause
Each component fetched traceroutes independently with different caching strategies:
- TracerouteWidget: TanStack Query with 30s stale time, 60s refresh
- Node View: Separate `fetchTraceroutes()` with 60s interval
- History Modal: Direct API call

### Solution
- Add traceroutes to `/api/poll` endpoint for real-time sync (5s poll interval)
- Create centralized `useTraceroutes` hook for consistent data access
- All views now share the same data source
- Traceroutes sorted by `timestamp DESC` (newest first) matching database ordering

## Changes

| File | Description |
|------|-------------|
| `src/server/server.ts` | Add traceroutes to poll endpoint (section 9) |
| `src/hooks/usePoll.ts` | Add `PollTraceroute` type and `traceroutes` to `PollData` |
| `src/hooks/useTraceroutes.ts` | **New** - Centralized hook with utility functions |
| `src/App.tsx` | Process poll traceroutes, remove separate fetch |
| `src/components/TracerouteWidget.tsx` | Use centralized hook instead of TanStack Query |

## Test plan

- [ ] Perform traceroute, verify all 3 views update within poll interval (5s)
- [ ] Purge traceroutes, verify all 3 views clear
- [ ] Disconnect/reconnect, verify data consistency
- [ ] Verify ordering remains `timestamp DESC` across all views
- [ ] TypeScript passes: `npm run typecheck`
- [ ] Build succeeds: `npm run build`
- [ ] Server tests pass (838 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)