### PR TITLE
fix: exclude MQTT-sourced nodes from VNS client sync

### DIFF
--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -534,10 +534,12 @@ export class VirtualNodeServer extends EventEmitter {
 
       // === STEP 2: Rebuild and send all NodeInfo entries from database ===
       // Apply activity filtering based on maxNodeAgeHours setting
+      // IMPORTANT: Exclude MQTT-sourced nodes to prevent "node bloat" (Issue #919)
+      // Only send nodes that the physical device actually heard directly
       const maxNodeAgeHours = parseInt(databaseService.getSetting('maxNodeAgeHours') || '24');
       const maxNodeAgeDays = maxNodeAgeHours / 24;
-      const allNodes = databaseService.getActiveNodes(maxNodeAgeDays);
-      logger.debug(`Virtual node: Rebuilding ${allNodes.length} active NodeInfo entries from database (maxNodeAgeHours: ${maxNodeAgeHours})`);
+      const allNodes = databaseService.getActiveNodesExcludingMqtt(maxNodeAgeDays);
+      logger.debug(`Virtual node: Rebuilding ${allNodes.length} active NodeInfo entries from database (maxNodeAgeHours: ${maxNodeAgeHours}, excluding MQTT nodes)`);
 
       for (const node of allNodes) {
         // Check if client is still connected


### PR DESCRIPTION
## Summary
- Add `getActiveNodesExcludingMqtt()` database method
- VNS now only sends nodes the physical device directly heard
- Nodes with `viaMqtt=true` are filtered out during initial config sync

## Problem
After a few hours of using VNS with an Android client, the VNS becomes unusable because it presents thousands of nodes during sync. This is caused by MQTT-sourced nodes being included - nodes that the physical Meshtastic device never directly heard, but were aggregated via MQTT from the broader network.

The screenshot in the issue shows 1700+ nodes being synced to the Android client.

## Solution
Filter out MQTT-sourced nodes when VNS sends the initial node list to clients. Only nodes that were heard directly by the physical node (via radio) are sent.

## Test Plan
- [ ] Connect Android client to VNS
- [ ] Verify node count is reasonable (only directly-heard nodes)
- [ ] Let it run for several hours
- [ ] Verify reconnection works without bloat

Fixes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)