### PR TITLE
feat: add immediate auto-upgrade option

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2274,5 +2274,9 @@
   "auto_upgrade_test.toast_start_failed": "Failed to start test upgrade",
   "auto_upgrade_test.check_connection_error": "Connection Error",
   "auto_upgrade_test.message_server_communication_failed": "Failed to communicate with server",
-  "auto_upgrade_test.message_connect_failed": "Could not connect to server"
+  "auto_upgrade_test.message_connect_failed": "Could not connect to server",
+  "auto_upgrade_test.immediate_upgrade": "Upgrade Immediately When Available",
+  "auto_upgrade_test.immediate_upgrade_description": "When a new version is detected and auto-upgrade is enabled, automatically begin the upgrade without waiting for manual confirmation. Use with caution - upgrades will happen automatically as soon as a new release is available.",
+  "auto_upgrade_test.setting_saved": "Auto-upgrade setting saved",
+  "auto_upgrade_test.setting_save_failed": "Failed to save auto-upgrade setting"
 }

--- a/src/components/configuration/AutoUpgradeTestSection.tsx
+++ b/src/components/configuration/AutoUpgradeTestSection.tsx
@@ -46,6 +46,47 @@ const AutoUpgradeTestSection: React.FC<AutoUpgradeTestSectionProps> = ({ baseUrl
   const [isTestUpgrading, setIsTestUpgrading] = useState(false);
   const [upgradeStatus, setUpgradeStatus] = useState<UpgradeStatus | null>(null);
   const [statusPollInterval, setStatusPollInterval] = useState<NodeJS.Timeout | null>(null);
+  const [autoUpgradeImmediate, setAutoUpgradeImmediate] = useState(false);
+  const [isLoadingSettings, setIsLoadingSettings] = useState(true);
+
+  // Load the autoUpgradeImmediate setting on mount
+  React.useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const response = await csrfFetch(`${baseUrl}/api/settings`);
+        if (response.ok) {
+          const settings = await response.json();
+          setAutoUpgradeImmediate(settings.autoUpgradeImmediate === 'true');
+        }
+      } catch (error) {
+        logger.error('Failed to load autoUpgradeImmediate setting:', error);
+      } finally {
+        setIsLoadingSettings(false);
+      }
+    };
+    loadSettings();
+  }, [baseUrl, csrfFetch]);
+
+  const handleAutoUpgradeImmediateChange = async (enabled: boolean) => {
+    setAutoUpgradeImmediate(enabled);
+    try {
+      const response = await csrfFetch(`${baseUrl}/api/settings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ autoUpgradeImmediate: enabled ? 'true' : 'false' }),
+      });
+      if (response.ok) {
+        showToast(t('auto_upgrade_test.setting_saved'), 'success');
+      } else {
+        showToast(t('auto_upgrade_test.setting_save_failed'), 'error');
+        setAutoUpgradeImmediate(!enabled); // Revert on failure
+      }
+    } catch (error) {
+      logger.error('Failed to save autoUpgradeImmediate setting:', error);
+      showToast(t('auto_upgrade_test.setting_save_failed'), 'error');
+      setAutoUpgradeImmediate(!enabled); // Revert on failure
+    }
+  };
 
   const handleTestConfiguration = async () => {
     setIsTesting(true);
@@ -199,6 +240,24 @@ const AutoUpgradeTestSection: React.FC<AutoUpgradeTestSectionProps> = ({ baseUrl
         {' '}<strong>{t('auto_upgrade_test.config_test_name')}</strong> {t('auto_upgrade_test.config_test_description')}
         {' '}<strong>{t('auto_upgrade_test.upgrade_test_name')}</strong> {t('auto_upgrade_test.upgrade_test_description')}
       </p>
+
+      <div className="setting-item" style={{ marginTop: '1rem' }}>
+        <label className="checkbox-label" style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem' }}>
+          <input
+            type="checkbox"
+            checked={autoUpgradeImmediate}
+            onChange={(e) => handleAutoUpgradeImmediateChange(e.target.checked)}
+            disabled={isLoadingSettings}
+            style={{ marginTop: '0.25rem' }}
+          />
+          <div>
+            <strong>{t('auto_upgrade_test.immediate_upgrade')}</strong>
+            <p className="setting-description" style={{ margin: '0.25rem 0 0 0' }}>
+              {t('auto_upgrade_test.immediate_upgrade_description')}
+            </p>
+          </div>
+        </label>
+      </div>
 
       <div className="setting-item" style={{ marginTop: '1rem', display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
         <button

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -422,7 +422,8 @@ class DatabaseService {
         autoAnnounceOnStart: 'false',
         autoAnnounceUseSchedule: 'false',
         autoAnnounceSchedule: '0 */6 * * *',
-        tracerouteIntervalMinutes: '0'
+        tracerouteIntervalMinutes: '0',
+        autoUpgradeImmediate: 'false'
       };
 
       Object.entries(automationSettings).forEach(([key, defaultValue]) => {


### PR DESCRIPTION
## Summary
- Adds a "Upgrade Immediately When Available" checkbox to the Auto-Upgrade Testing settings
- When enabled, detected upgrades begin automatically without waiting for user confirmation
- The server-side version check triggers the upgrade when a new version is available

## Details
This implements issue #925 by adding an option for fully automated upgrades.

### How it works
1. When `autoUpgradeImmediate` is enabled, the server-side `/api/version/check` endpoint automatically triggers an upgrade
2. The upgrade uses the existing `upgradeService.triggerUpgrade()` infrastructure
3. An audit log entry is created when auto-upgrade is triggered
4. No manual confirmation or frontend interaction required

### New Setting
- `autoUpgradeImmediate` - When enabled and auto-upgrade is configured, upgrades happen automatically as soon as a new version is detected

### Files Changed
- `src/services/database.ts` - Added default setting
- `src/server/server.ts` - Added setting validation and auto-upgrade trigger logic
- `src/components/configuration/AutoUpgradeTestSection.tsx` - Added checkbox UI
- `public/locales/en.json` - Added translation keys

## Test plan
- [ ] Enable auto-upgrade via docker-compose.upgrade.yml
- [ ] Navigate to Settings > Auto-Upgrade Testing
- [ ] Verify "Upgrade Immediately When Available" checkbox appears
- [ ] Enable the checkbox and verify it saves
- [ ] When a new version is available, verify upgrade triggers automatically

Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)