### PR TITLE
feat: move map legend and tileset selector to right side

### DIFF
--- a/src/components/MapLegend.css
+++ b/src/components/MapLegend.css
@@ -1,17 +1,17 @@
 .map-legend {
   position: absolute;
   top: 10px;
-  left: 50%;
-  transform: translateX(-50%);
+  right: 10px;
   z-index: 1000;
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(10px);
-  padding: 8px 16px;
+  padding: 8px 12px;
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   display: flex;
-  align-items: center;
-  gap: 12px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
   font-family: system-ui, -apple-system, sans-serif;
   font-size: 12px;
 }
@@ -19,7 +19,8 @@
 .legend-title {
   font-weight: 600;
   color: #333;
-  margin-right: 4px;
+  margin-bottom: 2px;
+  font-size: 11px;
 }
 
 .legend-item {

--- a/src/components/TilesetSelector.css
+++ b/src/components/TilesetSelector.css
@@ -1,8 +1,7 @@
 .tileset-selector {
   position: absolute;
   bottom: 20px;
-  left: 50%;
-  transform: translateX(-20%);
+  right: 10px;
   background: rgba(255, 255, 255, 0.95);
   border-radius: 8px;
   padding: 12px 16px;
@@ -116,6 +115,7 @@
 .tileset-selector.collapsed {
   padding: 8px 12px;
   bottom: 10px;
+  right: 10px;
 }
 
 /* Hide on mobile devices */


### PR DESCRIPTION
## Summary
- Moves the map legend (hops indicator) from top-center to top-right
- Moves the tileset selector (map style buttons) from bottom-center to bottom-right
- Changes map legend to vertical layout for more compact display on the right side

## Before/After
The map controls were previously positioned in the center (top and bottom) covering the map content. Now they are positioned on the right side, keeping the map view clear.

## Changes
- `src/components/MapLegend.css` - Changed positioning from `left: 50%` to `right: 10px`, changed layout to vertical
- `src/components/TilesetSelector.css` - Changed positioning from `left: 50%` to `right: 10px`

## Test plan
- [ ] Navigate to the Nodes tab with the map view
- [ ] Verify the hop count legend appears in the top-right corner
- [ ] Verify the map style selector appears in the bottom-right corner
- [ ] Verify both controls are out of the way of the main map content
- [ ] Test collapsing/expanding the tileset selector works correctly

Closes #927

🤖 Generated with [Claude Code](https://claude.com/claude-code)