### PR TITLE
feat: add resizable packet monitor panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5947,20 +5947,65 @@ body {
   left: 0;
   right: 0;
   width: 100%;
-  height: 35%;
+  /* height is now set dynamically via inline style */
   z-index: 2;
   background: var(--bg-primary);
   border-top: 2px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
 }
 
-/* Adjust map container when packet monitor is visible */
+/* Resize handle at top of packet monitor */
+.packet-monitor-resize-handle {
+  position: absolute;
+  top: -4px;
+  left: 0;
+  right: 0;
+  height: 8px;
+  cursor: ns-resize;
+  background: transparent;
+  z-index: 10;
+  transition: background 0.2s ease;
+}
+
+.packet-monitor-resize-handle:hover,
+.packet-monitor-container.resizing .packet-monitor-resize-handle {
+  background: var(--primary-color, #4a9eff);
+}
+
+.packet-monitor-resize-handle::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 40px;
+  height: 4px;
+  background: var(--border-color);
+  border-radius: 2px;
+  transition: background 0.2s ease;
+}
+
+.packet-monitor-resize-handle:hover::before,
+.packet-monitor-container.resizing .packet-monitor-resize-handle::before {
+  background: var(--primary-color, #4a9eff);
+}
+
+/* During resize, prevent pointer events on content */
+.packet-monitor-container.resizing .packet-monitor-panel {
+  pointer-events: none;
+}
+
+/* Adjust map container when packet monitor is visible - height now set dynamically */
 .map-container.with-packet-monitor {
-  height: 65%;
+  /* height is now set dynamically via inline style */
+  transition: height 0.05s ease-out;
 }
 
 /* Adjust node list sidebar when packet monitor is visible */
 .nodes-split-view:has(.packet-monitor-container) .nodes-sidebar {
-  max-height: calc(65% - 32px);
+  /* Use a reasonable max-height that works with dynamic sizing */
+  max-height: calc(100% - 200px);
 }
 
 /* Hide packet monitor toggle on mobile */

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -15,6 +15,7 @@ import { useTelemetryNodes, useDeviceConfig } from '../hooks/useServerData';
 import { useUI } from '../contexts/UIContext';
 import { useSettings } from '../contexts/SettingsContext';
 import { useAuth } from '../contexts/AuthContext';
+import { useResizable } from '../hooks/useResizable';
 import MapLegend from './MapLegend';
 import ZoomHandler from './ZoomHandler';
 import MapResizeHandler from './MapResizeHandler';
@@ -169,6 +170,19 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     // Load from localStorage
     const saved = localStorage.getItem('showPacketMonitor');
     return saved === 'true';
+  });
+
+  // Packet Monitor resizable height (default 35% of viewport, min 150px, max 70%)
+  const {
+    size: packetMonitorHeight,
+    isResizing: isPacketMonitorResizing,
+    handleMouseDown: handlePacketMonitorResizeStart,
+    handleTouchStart: handlePacketMonitorTouchStart
+  } = useResizable({
+    id: 'packet-monitor-height',
+    defaultHeight: Math.round(window.innerHeight * 0.35),
+    minHeight: 150,
+    maxHeight: Math.round(window.innerHeight * 0.7)
   });
 
   // Track if packet logging is enabled on the server
@@ -740,7 +754,10 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
       </div>
 
       {/* Right Side - Map and Optional Packet Monitor */}
-      <div className={`map-container ${showPacketMonitor && canViewPacketMonitor ? 'with-packet-monitor' : ''}`}>
+      <div
+        className={`map-container ${showPacketMonitor && canViewPacketMonitor ? 'with-packet-monitor' : ''}`}
+        style={showPacketMonitor && canViewPacketMonitor ? { height: `calc(100% - ${packetMonitorHeight}px)` } : undefined}
+      >
         {shouldShowData() ? (
           <>
             <div className={`map-controls ${isMapControlsCollapsed ? 'collapsed' : ''}`}>
@@ -1138,7 +1155,16 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
       {/* Packet Monitor Panel (Desktop Only) */}
       {showPacketMonitor && canViewPacketMonitor && (
-        <div className="packet-monitor-container">
+        <div
+          className={`packet-monitor-container ${isPacketMonitorResizing ? 'resizing' : ''}`}
+          style={{ height: `${packetMonitorHeight}px` }}
+        >
+          <div
+            className="packet-monitor-resize-handle"
+            onMouseDown={handlePacketMonitorResizeStart}
+            onTouchStart={handlePacketMonitorTouchStart}
+            title="Drag to resize"
+          />
           <PacketMonitorPanel
             onClose={() => setShowPacketMonitor(false)}
             onNodeClick={handlePacketNodeClick}

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -1,0 +1,185 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+export interface UseResizableOptions {
+  /** Unique ID for localStorage persistence */
+  id: string;
+  /** Default height in pixels */
+  defaultHeight: number;
+  /** Minimum height in pixels */
+  minHeight?: number;
+  /** Maximum height in pixels or percentage of viewport */
+  maxHeight?: number;
+  /** Direction of resize: 'vertical' resizes height, 'horizontal' resizes width */
+  direction?: 'vertical' | 'horizontal';
+}
+
+export interface UseResizableReturn {
+  size: number;
+  isResizing: boolean;
+  handleMouseDown: (e: React.MouseEvent) => void;
+  handleTouchStart: (e: React.TouchEvent) => void;
+  resetSize: () => void;
+}
+
+const STORAGE_PREFIX = 'resizable_size_';
+
+function getStorageKey(id: string): string {
+  return `${STORAGE_PREFIX}${id}`;
+}
+
+function loadSize(id: string, defaultSize: number): number {
+  try {
+    const saved = localStorage.getItem(getStorageKey(id));
+    if (saved) {
+      const parsed = parseFloat(saved);
+      if (!isNaN(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return defaultSize;
+}
+
+function saveSize(id: string, size: number): void {
+  try {
+    localStorage.setItem(getStorageKey(id), String(size));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export function useResizable(options: UseResizableOptions): UseResizableReturn {
+  const {
+    id,
+    defaultHeight,
+    minHeight = 100,
+    maxHeight = window.innerHeight * 0.8,
+    direction = 'vertical'
+  } = options;
+
+  const [size, setSize] = useState<number>(() => loadSize(id, defaultHeight));
+  const [isResizing, setIsResizing] = useState(false);
+  const resizeStartRef = useRef<{ startPos: number; startSize: number } | null>(null);
+
+  // Constrain size to bounds
+  const constrainSize = useCallback((newSize: number): number => {
+    const effectiveMaxHeight = typeof maxHeight === 'number'
+      ? Math.min(maxHeight, window.innerHeight * 0.8)
+      : window.innerHeight * 0.8;
+    return Math.max(minHeight, Math.min(newSize, effectiveMaxHeight));
+  }, [minHeight, maxHeight]);
+
+  // Handle mouse move during resize
+  const handleMouseMove = useCallback((e: MouseEvent) => {
+    if (!resizeStartRef.current) return;
+
+    // For vertical resize from top edge (panel at bottom), moving up increases size
+    const delta = direction === 'vertical'
+      ? resizeStartRef.current.startPos - e.clientY
+      : e.clientX - resizeStartRef.current.startPos;
+
+    const newSize = constrainSize(resizeStartRef.current.startSize + delta);
+    setSize(newSize);
+  }, [constrainSize, direction]);
+
+  // Handle touch move during resize
+  const handleTouchMove = useCallback((e: TouchEvent) => {
+    if (!resizeStartRef.current || !e.touches[0]) return;
+
+    const delta = direction === 'vertical'
+      ? resizeStartRef.current.startPos - e.touches[0].clientY
+      : e.touches[0].clientX - resizeStartRef.current.startPos;
+
+    const newSize = constrainSize(resizeStartRef.current.startSize + delta);
+    setSize(newSize);
+  }, [constrainSize, direction]);
+
+  // Handle resize end
+  const handleResizeEnd = useCallback(() => {
+    if (resizeStartRef.current) {
+      resizeStartRef.current = null;
+      setIsResizing(false);
+      // Save size when resize ends
+      setSize(currentSize => {
+        saveSize(id, currentSize);
+        return currentSize;
+      });
+    }
+  }, [id]);
+
+  // Set up global event listeners when resizing
+  useEffect(() => {
+    if (isResizing) {
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleResizeEnd);
+      window.addEventListener('touchmove', handleTouchMove, { passive: false });
+      window.addEventListener('touchend', handleResizeEnd);
+
+      // Prevent text selection during resize
+      document.body.style.userSelect = 'none';
+      document.body.style.cursor = direction === 'vertical' ? 'ns-resize' : 'ew-resize';
+
+      return () => {
+        window.removeEventListener('mousemove', handleMouseMove);
+        window.removeEventListener('mouseup', handleResizeEnd);
+        window.removeEventListener('touchmove', handleTouchMove);
+        window.removeEventListener('touchend', handleResizeEnd);
+        document.body.style.userSelect = '';
+        document.body.style.cursor = '';
+      };
+    }
+  }, [isResizing, handleMouseMove, handleTouchMove, handleResizeEnd, direction]);
+
+  // Handle mouse down on resize handle
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    resizeStartRef.current = {
+      startPos: direction === 'vertical' ? e.clientY : e.clientX,
+      startSize: size
+    };
+
+    setIsResizing(true);
+  }, [size, direction]);
+
+  // Handle touch start on resize handle
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (!e.touches[0]) return;
+
+    e.stopPropagation();
+
+    resizeStartRef.current = {
+      startPos: direction === 'vertical' ? e.touches[0].clientY : e.touches[0].clientX,
+      startSize: size
+    };
+
+    setIsResizing(true);
+  }, [size, direction]);
+
+  // Reset to default size
+  const resetSize = useCallback(() => {
+    setSize(defaultHeight);
+    saveSize(id, defaultHeight);
+  }, [id, defaultHeight]);
+
+  // Ensure size is valid on window resize
+  useEffect(() => {
+    const handleResize = () => {
+      setSize(currentSize => constrainSize(currentSize));
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [constrainSize]);
+
+  return {
+    size,
+    isResizing,
+    handleMouseDown,
+    handleTouchStart,
+    resetSize
+  };
+}


### PR DESCRIPTION
## Summary
- Add drag-to-resize functionality for the packet monitor panel height
- Create reusable `useResizable` hook for vertical resize with mouse and touch support
- Add resize handle at top border of packet monitor panel (subtle grip indicator)
- Height persists to localStorage and restores on page load
- Constraints: minimum 150px, maximum 70% of viewport
- Visual feedback on hover and during resize (blue highlight bar)
- Map container height adjusts dynamically during resize

Closes #926

## Test plan
- [x] Verify resize handle appears at top of packet monitor
- [x] Verify dragging up increases panel height
- [x] Verify dragging down decreases panel height
- [x] Verify height persists after page refresh
- [x] Verify minimum/maximum constraints work
- [x] Verify map resizes correctly during drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)