### PR TITLE
feat: add Docker image cleanup after auto-upgrade

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2250,6 +2250,7 @@
   "auto_upgrade_test.status_downloading": "Pulling Image",
   "auto_upgrade_test.status_restarting": "Recreating Container",
   "auto_upgrade_test.status_health_check": "Health Check",
+  "auto_upgrade_test.status_cleanup": "Cleaning Up Old Images",
   "auto_upgrade_test.status_complete": "Complete",
   "auto_upgrade_test.status_failed": "Failed",
   "auto_upgrade_test.status_rolling_back": "Rolling Back",

--- a/scripts/upgrade-watchdog.sh
+++ b/scripts/upgrade-watchdog.sh
@@ -387,6 +387,70 @@ wait_for_health() {
   return 1
 }
 
+# Clean up old Docker images to free disk space
+cleanup_old_images() {
+  log "Cleaning up old MeshMonitor images..."
+
+  # Get the current image ID being used by the container
+  local current_image_id=$(docker inspect --format='{{.Image}}' "$CONTAINER_NAME" 2>/dev/null | cut -d':' -f2 | cut -c1-12)
+
+  if [ -z "$current_image_id" ]; then
+    log_warn "Could not determine current image ID, skipping cleanup"
+    return 0
+  fi
+
+  log "Current image ID: $current_image_id"
+
+  # Find all MeshMonitor images (excluding the current one)
+  local old_images=$(docker images "${IMAGE_NAME}" --format '{{.ID}} {{.Tag}}' 2>/dev/null | while read id tag; do
+    # Get short ID for comparison
+    local short_id=$(echo "$id" | cut -c1-12)
+    if [ "$short_id" != "$current_image_id" ]; then
+      echo "$id"
+    fi
+  done)
+
+  if [ -z "$old_images" ]; then
+    log "No old images to clean up"
+    return 0
+  fi
+
+  # Count images to be removed
+  local image_count=$(echo "$old_images" | wc -l)
+  log "Found $image_count old image(s) to remove"
+
+  # Remove each old image
+  local removed=0
+  local failed=0
+  for image_id in $old_images; do
+    if docker rmi "$image_id" 2>/dev/null; then
+      removed=$((removed + 1))
+      log "Removed image: $image_id"
+    else
+      failed=$((failed + 1))
+      log_warn "Could not remove image: $image_id (may be in use)"
+    fi
+  done
+
+  if [ $removed -gt 0 ]; then
+    log_success "Cleaned up $removed old image(s)"
+  fi
+
+  if [ $failed -gt 0 ]; then
+    log_warn "$failed image(s) could not be removed"
+  fi
+
+  # Also clean up dangling images (untagged images from the build process)
+  local dangling=$(docker images -f "dangling=true" -q 2>/dev/null)
+  if [ -n "$dangling" ]; then
+    log "Removing dangling images..."
+    echo "$dangling" | xargs docker rmi 2>/dev/null || true
+    log_success "Dangling images cleaned up"
+  fi
+
+  return 0
+}
+
 # Perform upgrade
 perform_upgrade() {
   local trigger_data
@@ -466,6 +530,10 @@ perform_upgrade() {
     log_error "Health check failed - upgrade may have issues"
     return 1
   fi
+
+  # Step 5: Clean up old images to free disk space
+  write_status "cleanup"
+  cleanup_old_images
 
   # Success!
   write_status "complete"

--- a/src/components/configuration/AutoUpgradeTestSection.tsx
+++ b/src/components/configuration/AutoUpgradeTestSection.tsx
@@ -29,7 +29,7 @@ interface TriggerUpgradeResponse {
 
 interface UpgradeStatus {
   upgradeId: string;
-  status: 'pending' | 'backing_up' | 'downloading' | 'restarting' | 'health_check' | 'complete' | 'failed' | 'rolling_back';
+  status: 'pending' | 'backing_up' | 'downloading' | 'restarting' | 'health_check' | 'cleanup' | 'complete' | 'failed' | 'rolling_back';
   targetVersion: string;
   startTime: string;
   endTime?: string;
@@ -225,6 +225,7 @@ const AutoUpgradeTestSection: React.FC<AutoUpgradeTestSectionProps> = ({ baseUrl
       downloading: { label: t('auto_upgrade_test.status_downloading'), icon: '⬇️', color: '#3b82f6' },
       restarting: { label: t('auto_upgrade_test.status_restarting'), icon: '🔄', color: '#f59e0b' },
       health_check: { label: t('auto_upgrade_test.status_health_check'), icon: '🏥', color: '#f59e0b' },
+      cleanup: { label: t('auto_upgrade_test.status_cleanup'), icon: '🧹', color: '#f59e0b' },
       complete: { label: t('auto_upgrade_test.status_complete'), icon: '✅', color: '#10b981' },
       failed: { label: t('auto_upgrade_test.status_failed'), icon: '❌', color: '#ef4444' },
       rolling_back: { label: t('auto_upgrade_test.status_rolling_back'), icon: '↩️', color: '#f59e0b' }


### PR DESCRIPTION
## Summary

- Added automatic cleanup of old MeshMonitor Docker images after successful auto-upgrade
- Addresses disk space issues from accumulated images during frequent upgrades (10GB+)
- Added "cleanup" status step to the upgrade UI

## Changes

### `scripts/upgrade-watchdog.sh`
- Added `cleanup_old_images()` function that runs after health check passes
- Removes old MeshMonitor images while preserving the currently running one
- Also cleans up dangling images from the build process
- Safe operation: failures don't block upgrade completion

### `src/components/configuration/AutoUpgradeTestSection.tsx`
- Added `cleanup` to the UpgradeStatus type
- Added UI display for "Cleaning Up Old Images" status with 🧹 icon

### `public/locales/en.json`
- Added translation for cleanup status

## Test plan

- [ ] Trigger a test upgrade and verify the cleanup step appears in the status
- [ ] After upgrade completes, verify old images are removed (`docker images | grep meshmonitor`)
- [ ] Verify the current running image is preserved
- [ ] Verify upgrade still succeeds if cleanup fails (e.g., image in use by another container)

Closes #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)