### PR TITLE
fix: remove network_mode host from BLE bridge configuration

### DIFF
--- a/docker-compose.ble.yml
+++ b/docker-compose.ble.yml
@@ -16,7 +16,6 @@ services:
     #   dockerfile: Dockerfile
     container_name: meshmonitor-ble-bridge
     privileged: true  # Required for BLE hardware access
-    network_mode: host  # Allows localhost TCP communication with meshmonitor
     restart: unless-stopped
     volumes:
       - /var/run/dbus:/var/run/dbus  # Required for D-Bus/Bluetooth access
@@ -36,8 +35,8 @@ services:
   # Override meshmonitor service to connect to BLE bridge
   meshmonitor:
     environment:
-      # Configure MeshMonitor to connect to the BLE bridge
-      - MESHTASTIC_NODE_IP=localhost
+      # Configure MeshMonitor to connect to the BLE bridge via Docker service name
+      - MESHTASTIC_NODE_IP=meshmonitor-ble-bridge
       - MESHTASTIC_NODE_PORT=4403
     depends_on:
       ble-bridge:

--- a/docs/.vitepress/theme/DockerComposeConfigurator.vue
+++ b/docs/.vitepress/theme/DockerComposeConfigurator.vue
@@ -411,7 +411,6 @@ const dockerComposeYaml = computed(() => {
     lines.push('    image: ghcr.io/yeraze/meshtastic-ble-bridge:latest')
     lines.push('    container_name: meshmonitor-ble-bridge')
     lines.push('    privileged: true')
-    lines.push('    network_mode: host')
     lines.push('    restart: unless-stopped')
     lines.push('    volumes:')
     lines.push('      - /var/run/dbus:/var/run/dbus')

--- a/docs/configuration/ble-bridge.md
+++ b/docs/configuration/ble-bridge.md
@@ -111,7 +111,6 @@ services:
     image: ghcr.io/yeraze/meshtastic-ble-bridge:latest
     container_name: meshmonitor-ble-bridge
     privileged: true  # Required for BLE hardware access
-    network_mode: host  # Allows localhost TCP communication
     restart: unless-stopped
     volumes:
       - /var/run/dbus:/var/run/dbus  # Required for D-Bus/Bluetooth
@@ -129,11 +128,9 @@ The BLE bridge requires `privileged: true` to access Bluetooth hardware. This gr
 
 **Security Note:** Privileged mode should only be used on trusted systems. For production, consider using device-specific capabilities instead.
 
-#### Host Networking
+#### Docker Networking
 
-Using `network_mode: host` allows the BLE bridge to listen on `localhost:4403`, making it accessible to MeshMonitor without complex container networking.
-
-**Alternative:** For isolated networking, see [Advanced Networking](#advanced-networking) below.
+The BLE bridge and MeshMonitor communicate using Docker's internal networking. MeshMonitor connects to the BLE bridge using its container name (`meshmonitor-ble-bridge`) as the hostname.
 
 #### Volume Mounts
 
@@ -148,11 +145,11 @@ When using the overlay, MeshMonitor automatically configures itself:
 
 ```yaml
 environment:
-  - MESHTASTIC_NODE_IP=localhost
+  - MESHTASTIC_NODE_IP=meshmonitor-ble-bridge
   - MESHTASTIC_NODE_PORT=4403
 ```
 
-The BLE bridge acts as a transparent TCP proxy on port 4403.
+The BLE bridge acts as a transparent TCP proxy on port 4403. MeshMonitor connects to it using Docker's internal DNS, which resolves the container name to the correct IP.
 
 ## Pairing Your Device
 


### PR DESCRIPTION
## Summary

- Removed `network_mode: host` from BLE bridge configuration
- Using host networking breaks Docker's internal DNS, causing containers to not find each other by name

## Problem

When using `network_mode: host`, the BLE bridge container joins the host's network namespace. This means:
- Docker's internal DNS no longer resolves container names
- `MESHTASTIC_NODE_IP=meshmonitor-ble-bridge` results in `ENOTFOUND`
- Users had to use `localhost` which only works with host networking

## Solution

Remove `network_mode: host` and use Docker's default bridge networking:
- Containers can communicate using service names
- `meshmonitor-ble-bridge` resolves correctly via Docker DNS
- Better isolation and security

## Changes

### `docker-compose.ble.yml`
- Removed `network_mode: host`
- Changed `MESHTASTIC_NODE_IP` from `localhost` to `meshmonitor-ble-bridge`

### `docs/.vitepress/theme/DockerComposeConfigurator.vue`
- Removed line that generates `network_mode: host` for BLE bridge

### `docs/configuration/ble-bridge.md`
- Updated example configuration
- Updated documentation to explain Docker networking

## Test plan

- [ ] Deploy with BLE bridge and verify MeshMonitor can connect to `meshmonitor-ble-bridge:4403`
- [ ] Verify Docker Compose Configurator generates correct config for BLE option

Fixes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)