### PR TITLE
chore: bump version to 2.20.5

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.20.4
-appVersion: "2.20.4"
+version: 2.20.5
+appVersion: "2.20.5"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.20.4",
+  "version": "2.20.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.20.4",
+      "version": "2.20.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.20.4",
+  "version": "2.20.5",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Release 2.20.5

### Features
- [#937](https://github.com/Yeraze/meshmonitor/pull/937) - feat: add Docker image cleanup after auto-upgrade (Closes #923)
- [#934](https://github.com/Yeraze/meshmonitor/pull/934) - feat: add resizable packet monitor panel (Closes #926)
- [#933](https://github.com/Yeraze/meshmonitor/pull/933) - feat: make map legend and tileset selector draggable
- [#931](https://github.com/Yeraze/meshmonitor/pull/931) - feat: move map legend and tileset selector to right side
- [#930](https://github.com/Yeraze/meshmonitor/pull/930) - feat: add immediate auto-upgrade option
- [#929](https://github.com/Yeraze/meshmonitor/pull/929) - feat: add hop count tapback auto-ack option

### Bug Fixes
- [#938](https://github.com/Yeraze/meshmonitor/pull/938) - fix: remove network_mode host from BLE bridge configuration (Fixes #936)

### Closed Issues
- #923 - Auto-upgrade cleanup (disk space from accumulated images)
- #926 - Make packet monitor height adjustable
- #936 - Can't connect to BLE bridge with container name

🤖 Generated with [Claude Code](https://claude.com/claude-code)