### PR TITLE
feat: improve auto-welcome race condition protection

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1819,6 +1819,22 @@ class DatabaseService {
   }
 
   /**
+   * Atomically mark a specific node as welcomed if not already welcomed.
+   * This prevents race conditions where multiple processes try to welcome the same node.
+   * Returns true if the node was marked, false if already welcomed.
+   */
+  markNodeAsWelcomedIfNotAlready(nodeNum: number, nodeId: string): boolean {
+    const now = Date.now();
+    const stmt = this.db.prepare(`
+      UPDATE nodes
+      SET welcomedAt = ?, updatedAt = ?
+      WHERE nodeNum = ? AND nodeId = ? AND welcomedAt IS NULL
+    `);
+    const result = stmt.run(now, now, nodeNum, nodeId);
+    return result.changes > 0;
+  }
+
+  /**
    * Get nodes with key security issues (low-entropy or duplicate keys)
    */
   getNodesWithKeySecurityIssues(): DbNode[] {


### PR DESCRIPTION
## Summary
- Add robust safeguards to prevent nodes from receiving multiple welcome messages
- Implements in-memory tracking Set and atomic database operations to eliminate race conditions

This is a rebased version of PR #935 by @temalo, adapted to work with the current main branch.

## Changes
- Added `welcomingNodes: Set<number>` to track nodes currently being welcomed
- Added `markNodeAsWelcomedIfNotAlready()` atomic database method
- Updated `checkAutoWelcome()` with try-finally pattern and delayed cleanup
- Added comprehensive tests for race condition protection

## Test plan
- [x] TypeScript type check passes
- [x] All 37 auto-welcome tests pass
- [ ] CI tests pass

Closes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)