### PR TITLE
feat: improve Packet Monitor details and encrypted channel display

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1298,13 +1298,15 @@ class MeshtasticManager {
         const portnum = meshPacket.decoded?.portnum ?? 0;
         const portnumName = meshtasticProtobufService.getPortNumName(portnum);
 
-        // Generate payload preview
+        // Generate payload preview and store decoded payload
         let payloadPreview = null;
+        let decodedPayload: any = null;
         if (isEncrypted) {
           payloadPreview = '🔒 <ENCRYPTED>';
         } else if (meshPacket.decoded?.payload) {
           try {
-            const processedPayload = meshtasticProtobufService.processPayload(portnum, meshPacket.decoded.payload);
+            decodedPayload = meshtasticProtobufService.processPayload(portnum, meshPacket.decoded.payload);
+            const processedPayload = decodedPayload;
             if (portnum === 1 && typeof processedPayload === 'string') {
               // TEXT_MESSAGE - show first 100 chars
               payloadPreview = processedPayload.substring(0, 100);
@@ -1381,6 +1383,11 @@ class MeshtasticManager {
         if (isEncrypted && meshPacket.encrypted) {
           // Convert Uint8Array to hex string for storage
           metadata.encrypted_payload = Buffer.from(meshPacket.encrypted).toString('hex');
+        }
+
+        // Include decoded payload for non-encrypted packets
+        if (decodedPayload !== null) {
+          metadata.decoded_payload = decodedPayload;
         }
 
         packetLogService.logPacket({


### PR DESCRIPTION
## Summary
- Store decoded payload in packet metadata for detailed viewing
- Show all telemetry fields expanded in packet detail popup (instead of just summary like "[Telemetry: Device]")
- Display "??" for encrypted packet channels (instead of misleading channel hash values like 147)
- Add tooltip showing actual channel hash when hovering on "??"

## Background
When viewing Packet Monitor, the detail popup was only showing a summary string like "[Telemetry: Device]" instead of the actual decoded telemetry data. Additionally, encrypted packets from nodes we can't decrypt were showing a "channel hash" (0-255) in the Channel column, which was misleading since valid channels are only 0-7.

## Changes
- **Backend** (`src/server/meshtasticManager.ts`): Store the full decoded protobuf payload in `metadata.decoded_payload`
- **Frontend** (`src/components/PacketMonitorPanel.tsx`):
  - Parse and expand decoded_payload in the detail modal
  - Show "??" for encrypted packets with channel > 7, with tooltip showing the raw hash value

## Test plan
- [x] TypeScript compiles without errors
- [x] Database tests pass
- [x] Server tests pass
- [x] Manual testing - verified decoded payloads display correctly
- [x] Manual testing - verified encrypted packets show "??" with tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)