### PR TITLE
chore: bump version to 2.20.6

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.20.5
-appVersion: "2.20.5"
+version: 2.20.6
+appVersion: "2.20.6"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.20.5",
+  "version": "2.20.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.20.5",
+      "version": "2.20.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.20.5",
+  "version": "2.20.6",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump version to 2.20.6

## Changes since 2.20.5
- #946 feat: improve Packet Monitor details and encrypted channel display
- #942 fix: propagate viaMqtt field to VNS clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)