### PR TITLE
fix: correct MQTT hop detection in traceroute visualization

### DIFF
--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -122,7 +122,8 @@ export function useTraceroutePaths({
     // Calculate segment usage counts and collect SNR values with timestamps
     const segmentUsage = new Map<string, number>();
     const segmentSNRs = new Map<string, Array<{ snr: number; timestamp: number }>>();
-    // Track segments that have MQTT hops (0.0 dB SNR indicates MQTT traversal)
+    // Track segments that have MQTT/unknown hops (-128 raw SNR = -32 scaled indicates MQTT/unknown)
+    // Note: -128 (INT8_MIN) is the Meshtastic sentinel value for unknown SNR (MQTT gateways, older firmware)
     const segmentHasMqtt = new Map<string, boolean>();
     const segmentsList: Array<{
       key: string;
@@ -209,8 +210,9 @@ export function useTraceroutePaths({
               segmentSNRs.set(segmentKey, []);
             }
             segmentSNRs.get(segmentKey)!.push({ snr: snrValue, timestamp });
-            // Mark segment as MQTT if SNR is 0.0 dB (indicates MQTT traversal)
-            if (snrValue === 0) {
+            // Mark segment as MQTT/unknown if SNR is -32 dB (raw -128 / 4 = -32)
+            // -128 (INT8_MIN) is Meshtastic's sentinel value for unknown SNR (MQTT gateways, older firmware)
+            if (snrValue === -32) {
               segmentHasMqtt.set(segmentKey, true);
             }
           }
@@ -254,8 +256,9 @@ export function useTraceroutePaths({
               segmentSNRs.set(segmentKey, []);
             }
             segmentSNRs.get(segmentKey)!.push({ snr: snrValue, timestamp });
-            // Mark segment as MQTT if SNR is 0.0 dB (indicates MQTT traversal)
-            if (snrValue === 0) {
+            // Mark segment as MQTT/unknown if SNR is -32 dB (raw -128 / 4 = -32)
+            // -128 (INT8_MIN) is Meshtastic's sentinel value for unknown SNR (MQTT gateways, older firmware)
+            if (snrValue === -32) {
               segmentHasMqtt.set(segmentKey, true);
             }
           }


### PR DESCRIPTION
## Summary
Fix incorrect MQTT hop detection in traceroute path visualization.

## Problem
The code was checking for `SNR === 0.0 dB` to detect MQTT hops, but 0.0 dB is actually a valid (though weak) radio signal.

## Solution
Use the correct Meshtastic sentinel value:
- Raw value: **-128** (INT8_MIN)
- Scaled value: **-32 dB** (after dividing by 4)

This value is used by Meshtastic firmware to indicate "unknown SNR" which occurs when:
- Packets traverse MQTT gateways (no radio signal to measure)
- Packets pass through nodes with older firmware that don't record SNR

## References
- [Meshtastic Traceroute Documentation](https://meshtastic.org/docs/configuration/module/traceroute/)
- [Python Meshtastic mesh_interface](https://python.meshtastic.org/mesh_interface.html) - defines `UNK_SNR = -128`
- [GitHub Issue #892](https://github.com/meshtastic/Meshtastic-Android/issues/892) - Traceroute MQTT indication

## Test plan
- [x] TypeScript compiles without errors
- [ ] Visual verification with traceroutes that include MQTT hops

🤖 Generated with [Claude Code](https://claude.com/claude-code)