### PR TITLE
fix: add submodules checkout to release workflow test-suite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- Fixed release workflow test-suite job failing due to missing protobufs submodule
- Added `submodules: recursive` to checkout step to match docker-release job

## Problem
The v2.20.6 release pipeline failed because the test-suite job didn't checkout the protobufs submodule, causing `createNodeInfo` tests to fail with "expected null not to be null".

## Solution
Added `submodules: recursive` to the test-suite checkout step, matching the existing configuration in the docker-release job.

## Test plan
- [ ] Merge this PR
- [ ] Re-run the release pipeline for v2.20.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)