### PR TITLE
fix: show upgrade progress when auto-upgrade is underway

### DIFF
--- a/src/server/routes/upgradeRoutes.ts
+++ b/src/server/routes/upgradeRoutes.ts
@@ -21,14 +21,17 @@ router.use(requireAuth());
 
 /**
  * GET /api/upgrade/status
- * Check if upgrade functionality is enabled
+ * Check if upgrade functionality is enabled and if an upgrade is in progress
  */
-router.get('/status', (_req: Request, res: Response) => {
+router.get('/status', async (_req: Request, res: Response) => {
   try {
+    const activeUpgrade = await upgradeService.getActiveUpgrade();
+
     return res.json({
       enabled: upgradeService.isEnabled(),
       deploymentMethod: upgradeService.getDeploymentMethod(),
-      currentVersion: packageJson.version
+      currentVersion: packageJson.version,
+      activeUpgrade: activeUpgrade || null
     });
   } catch (error) {
     logger.error('Error checking upgrade status:', error);

--- a/src/server/services/upgradeService.ts
+++ b/src/server/services/upgradeService.ts
@@ -373,6 +373,51 @@ class UpgradeService {
   }
 
   /**
+   * Get the currently active upgrade, if any
+   * @returns The active upgrade details or null if no upgrade is in progress
+   */
+  async getActiveUpgrade(): Promise<{
+    upgradeId: string;
+    status: string;
+    progress: number;
+    currentStep: string;
+    fromVersion: string;
+    toVersion: string;
+    startedAt: number;
+  } | null> {
+    try {
+      const STALE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+      const staleThreshold = Date.now() - STALE_TIMEOUT_MS;
+
+      const row = databaseService.db.prepare(
+        `SELECT id, status, progress, currentStep, fromVersion, toVersion, startedAt
+         FROM upgrade_history
+         WHERE status IN ('pending', 'backing_up', 'downloading', 'restarting', 'health_check')
+         AND startedAt >= ?
+         ORDER BY startedAt DESC
+         LIMIT 1`
+      ).get(staleThreshold) as any;
+
+      if (!row) {
+        return null;
+      }
+
+      return {
+        upgradeId: row.id,
+        status: row.status,
+        progress: row.progress || 0,
+        currentStep: row.currentStep || 'Starting...',
+        fromVersion: row.fromVersion,
+        toVersion: row.toVersion,
+        startedAt: row.startedAt,
+      };
+    } catch (error) {
+      logger.error('❌ Failed to get active upgrade:', error);
+      return null;
+    }
+  }
+
+  /**
    * Pre-flight checks before upgrade
    */
   private async preFlightChecks(_targetVersion: string): Promise<{ safe: boolean; issues: string[] }> {


### PR DESCRIPTION
## Summary
- When "Automatically begin upgrade" is enabled in settings, the frontend now detects if an upgrade is already in progress
- Shows the progress bar instead of the "Upgrade Now" button when auto-upgrade has been triggered
- Frontend resumes upgrade progress tracking after page refresh

## Changes
- Add `getActiveUpgrade()` method to upgradeService to find in-progress upgrades
- Modify `GET /api/upgrade/status` to return `activeUpgrade` info
- Frontend checks for active upgrades on load and resumes tracking
- Frontend handles `autoUpgradeTriggered` flag from version check endpoint

## Test plan
- [ ] Enable "Automatically begin upgrade" in settings
- [ ] Trigger an upgrade (either auto or manually)
- [ ] Verify progress bar shows instead of "Upgrade Now" button
- [ ] Refresh page during upgrade and verify progress resumes

## System Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| Reverse Proxy Test | ✅ PASSED |
| Reverse Proxy + OIDC | ✅ PASSED |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)