### PR TITLE
fix: restore map nodes list text entry, sorting, and mobile usability

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3907,11 +3907,11 @@ body {
     height: 100%;
   }
 
-  /* Adjust map controls on mobile to not overlap with floating sidebar */
+  /* Adjust map controls on mobile - keep in upper right, no dragging */
   .map-controls {
     top: 16px;
     right: 8px;
-    left: 56px;
+    left: auto;
     max-width: calc(100vw - 64px);
     padding: 0.5rem;
   }

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -374,14 +374,19 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
   // Drag handlers for sidebar
   const handleDragStart = useCallback((e: React.MouseEvent) => {
-    if (isNodeListCollapsed) return;
+    if (isNodeListCollapsed || isTouchDevice) return; // Disable drag on mobile
+    // Don't start drag if clicking on interactive elements
+    const target = e.target as HTMLElement;
+    if (target.tagName === 'INPUT' || target.tagName === 'SELECT' || target.tagName === 'BUTTON') {
+      return;
+    }
     e.preventDefault();
     setIsDragging(true);
     setDragStart({
       x: e.clientX - sidebarPosition.x,
       y: e.clientY - sidebarPosition.y,
     });
-  }, [isNodeListCollapsed, sidebarPosition]);
+  }, [isNodeListCollapsed, sidebarPosition, isTouchDevice]);
 
   const handleDragMove = useCallback((e: MouseEvent) => {
     if (!isDragging) return;
@@ -406,7 +411,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
   // Resize handlers for sidebar
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
-    if (isNodeListCollapsed) return;
+    if (isNodeListCollapsed || isTouchDevice) return; // Disable resize on mobile
     e.preventDefault();
     e.stopPropagation();
     setIsResizing(true);
@@ -418,7 +423,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
       width: sidebarSize.width || 350,
       height: sidebarSize.height || currentHeight,
     });
-  }, [isNodeListCollapsed, sidebarSize]);
+  }, [isNodeListCollapsed, sidebarSize, isTouchDevice]);
 
   const handleResizeMove = useCallback((e: MouseEvent) => {
     if (!isResizing) return;
@@ -481,7 +486,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
   // Map controls drag handlers
   const handleMapControlsDragStart = useCallback((e: React.MouseEvent) => {
-    if (isMapControlsCollapsed) return;
+    if (isMapControlsCollapsed || isTouchDevice) return; // Disable drag on mobile
     e.preventDefault();
     e.stopPropagation();
     setIsDraggingMapControls(true);
@@ -489,7 +494,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
       x: e.clientX - mapControlsPosition.x,
       y: e.clientY - mapControlsPosition.y,
     });
-  }, [isMapControlsCollapsed, mapControlsPosition]);
+  }, [isMapControlsCollapsed, mapControlsPosition, isTouchDevice]);
 
   const handleMapControlsDragMove = useCallback((e: MouseEvent) => {
     if (!isDraggingMapControls) return;
@@ -761,10 +766,10 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
           maxHeight: isNodeListCollapsed ? undefined : (sidebarSize.height ? `${sidebarSize.height}px` : 'calc(100% - 32px)'),
         }}
       >
-        <div 
+        <div
           className="sidebar-header"
           onMouseDown={handleDragStart}
-          style={{ cursor: isNodeListCollapsed ? 'default' : 'grab' }}
+          style={{ cursor: (isNodeListCollapsed || isTouchDevice) ? 'default' : 'grab' }}
         >
           <button
             className="collapse-nodes-btn"
@@ -1041,7 +1046,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
             <div
               ref={mapControlsRef}
               className={`map-controls ${isMapControlsCollapsed ? 'collapsed' : ''}`}
-              style={{
+              style={isTouchDevice ? undefined : {
                 left: isMapControlsCollapsed ? undefined : `${mapControlsPosition.x}px`,
                 top: isMapControlsCollapsed ? undefined : `${mapControlsPosition.y}px`,
                 right: isMapControlsCollapsed ? undefined : 'auto',
@@ -1058,7 +1063,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               <div
                 className="map-controls-header"
                 style={{
-                  cursor: isMapControlsCollapsed ? 'default' : (isDraggingMapControls ? 'grabbing' : 'grab'),
+                  cursor: (isMapControlsCollapsed || isTouchDevice) ? 'default' : (isDraggingMapControls ? 'grabbing' : 'grab'),
                 }}
                 onMouseDown={handleMapControlsDragStart}
               >


### PR DESCRIPTION
## Summary
- Fixes text entry in node filter input (was broken by drag handler's preventDefault)
- Fixes sort dropdown interaction (clicks were being intercepted by drag handler)
- Disables drag/resize behavior on mobile/touch devices
- Positions map features panel in upper right on mobile (static, not draggable)

## Problem
PR #941 introduced draggable UI components for the node list sidebar and map features panel. The drag handler attached to the sidebar header was calling `preventDefault()` on all mousedown events, which prevented text inputs and select dropdowns from receiving focus and responding to user input.

## Changes
- **NodesTab.tsx**: Skip drag initiation when clicking on INPUT, SELECT, or BUTTON elements
- **NodesTab.tsx**: Disable drag, resize, and custom positioning on touch devices
- **NodesTab.tsx**: Update cursor styles to not show grab cursor on mobile
- **App.css**: Keep map features panel in upper right on mobile (`right: 8px`, `left: auto`)

## Test plan
- [ ] Verify text entry works in node filter input
- [ ] Verify sort dropdown responds to clicks and changes sort order
- [ ] Verify drag still works on desktop when clicking outside interactive elements
- [ ] Verify mobile shows map features in upper right corner (not draggable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)