### PR TITLE
feat: add Russian language support

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -21,6 +21,7 @@ export const AVAILABLE_LANGUAGES = [
   { code: 'es', name: 'Spanish', nativeName: 'Español' },
   { code: 'de', name: 'German', nativeName: 'Deutsch' },
   { code: 'fr', name: 'French', nativeName: 'Français' },
+  { code: 'ru', name: 'Russian', nativeName: 'Русский' },
 ];
 
 i18n


### PR DESCRIPTION
## Summary
- Add Russian language to the available languages list in i18n configuration

Closes #953

## Changes
- Added `{ code: 'ru', name: 'Russian', nativeName: 'Русский' }` to AVAILABLE_LANGUAGES in `src/config/i18n.ts`
- Russian translation file (`ru.json`) already exists from Weblate contributions

## Test plan
- [x] Verify Russian appears in language selector
- [x] Verify ru.json locale file exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)