### PR TITLE
feat: add solar production estimates to v1 REST API

### DIFF
--- a/src/server/routes/v1/index.ts
+++ b/src/server/routes/v1/index.ts
@@ -13,6 +13,7 @@ import traceroutesRouter from './traceroutes.js';
 import messagesRouter from './messages.js';
 import networkRouter from './network.js';
 import packetsRouter from './packets.js';
+import solarRouter from './solar.js';
 import docsRouter from './docs.js';
 
 const router = express.Router();
@@ -35,7 +36,8 @@ router.get('/', (_req, res) => {
       traceroutes: '/api/v1/traceroutes',
       messages: '/api/v1/messages',
       network: '/api/v1/network',
-      packets: '/api/v1/packets'
+      packets: '/api/v1/packets',
+      solar: '/api/v1/solar'
     }
   });
 });
@@ -47,5 +49,6 @@ router.use('/traceroutes', traceroutesRouter);
 router.use('/messages', messagesRouter);
 router.use('/network', networkRouter);
 router.use('/packets', packetsRouter);
+router.use('/solar', solarRouter);
 
 export default router;

--- a/src/server/routes/v1/openapi.yaml
+++ b/src/server/routes/v1/openapi.yaml
@@ -49,6 +49,8 @@ tags:
     description: Network-wide statistics and topology
   - name: Packets
     description: Raw packet log data from the mesh network
+  - name: Solar
+    description: Solar production estimates from forecast.solar
 
 security:
   - BearerAuth: []
@@ -666,6 +668,75 @@ components:
           example: true
         data:
           $ref: '#/components/schemas/Packet'
+
+    SolarEstimate:
+      type: object
+      properties:
+        timestamp:
+          type: integer
+          description: Unix timestamp (seconds) for the estimate period
+          example: 1699560000
+        datetime:
+          type: string
+          format: date-time
+          description: ISO 8601 datetime string
+          example: "2024-11-09T14:00:00.000Z"
+        wattHours:
+          type: number
+          description: Estimated watt-hours of solar production for this period
+          example: 450.5
+        fetchedAt:
+          type: integer
+          description: Unix timestamp when this estimate was fetched from forecast.solar
+          example: 1699557600
+
+    SolarListResponse:
+      type: object
+      required:
+        - success
+        - count
+        - data
+      properties:
+        success:
+          type: boolean
+          example: true
+        count:
+          type: integer
+          description: Number of estimates returned
+          example: 24
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/SolarEstimate'
+
+    SolarRangeResponse:
+      type: object
+      required:
+        - success
+        - count
+        - start
+        - end
+        - data
+      properties:
+        success:
+          type: boolean
+          example: true
+        count:
+          type: integer
+          description: Number of estimates returned
+          example: 24
+        start:
+          type: integer
+          description: Start timestamp of the requested range
+          example: 1699520400
+        end:
+          type: integer
+          description: End timestamp of the requested range
+          example: 1699606800
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/SolarEstimate'
 
 paths:
   /:
@@ -1304,6 +1375,89 @@ paths:
                 $ref: '#/components/schemas/Error'
         '404':
           description: Packet not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /solar:
+    get:
+      tags:
+        - Solar
+      summary: Get solar production estimates
+      description: |
+        Retrieve recent solar production estimates from forecast.solar.
+        Solar monitoring must be enabled and configured in MeshMonitor settings.
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of estimates to return
+          required: false
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 1000
+      responses:
+        '200':
+          description: Solar estimates retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SolarListResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /solar/range:
+    get:
+      tags:
+        - Solar
+      summary: Get solar estimates for a time range
+      description: Retrieve solar production estimates for a specific time period
+      parameters:
+        - name: start
+          in: query
+          description: Start timestamp (Unix seconds)
+          required: true
+          schema:
+            type: integer
+        - name: end
+          in: query
+          description: End timestamp (Unix seconds)
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Solar estimates retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SolarRangeResponse'
+        '400':
+          description: Bad request (invalid timestamps)
           content:
             application/json:
               schema:

--- a/src/server/routes/v1/solar.test.ts
+++ b/src/server/routes/v1/solar.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Solar API Endpoint Unit Tests
+ *
+ * Tests the solar production estimates v1 API endpoints
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+// Mock the solarMonitoringService before importing the router
+vi.mock('../../services/solarMonitoringService.js', () => ({
+  solarMonitoringService: {
+    getRecentEstimates: vi.fn(),
+    getEstimatesInRange: vi.fn()
+  }
+}));
+
+// Import after mocking
+import solarRouter from './solar.js';
+import { solarMonitoringService } from '../../services/solarMonitoringService.js';
+
+describe('Solar API Routes', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/solar', solarRouter);
+  });
+
+  describe('GET /api/v1/solar', () => {
+    it('should return solar estimates with correct format', async () => {
+      const mockEstimates = [
+        { timestamp: 1699560000, watt_hours: 450.5, fetched_at: 1699557600 },
+        { timestamp: 1699563600, watt_hours: 520.3, fetched_at: 1699557600 },
+        { timestamp: 1699567200, watt_hours: 380.2, fetched_at: 1699557600 }
+      ];
+
+      vi.mocked(solarMonitoringService.getRecentEstimates).mockReturnValue(mockEstimates);
+
+      const response = await request(app)
+        .get('/api/v1/solar')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.count).toBe(3);
+      expect(response.body.data).toHaveLength(3);
+      expect(response.body.data[0]).toHaveProperty('timestamp');
+      expect(response.body.data[0]).toHaveProperty('datetime');
+      expect(response.body.data[0]).toHaveProperty('wattHours');
+      expect(response.body.data[0]).toHaveProperty('fetchedAt');
+    });
+
+    it('should use default limit of 100', async () => {
+      vi.mocked(solarMonitoringService.getRecentEstimates).mockReturnValue([]);
+
+      await request(app)
+        .get('/api/v1/solar')
+        .expect(200);
+
+      expect(solarMonitoringService.getRecentEstimates).toHaveBeenCalledWith(100);
+    });
+
+    it('should respect custom limit parameter', async () => {
+      vi.mocked(solarMonitoringService.getRecentEstimates).mockReturnValue([]);
+
+      await request(app)
+        .get('/api/v1/solar?limit=50')
+        .expect(200);
+
+      expect(solarMonitoringService.getRecentEstimates).toHaveBeenCalledWith(50);
+    });
+
+    it('should cap limit at 1000', async () => {
+      vi.mocked(solarMonitoringService.getRecentEstimates).mockReturnValue([]);
+
+      await request(app)
+        .get('/api/v1/solar?limit=5000')
+        .expect(200);
+
+      expect(solarMonitoringService.getRecentEstimates).toHaveBeenCalledWith(1000);
+    });
+
+    it('should return empty array when no data', async () => {
+      vi.mocked(solarMonitoringService.getRecentEstimates).mockReturnValue([]);
+
+      const response = await request(app)
+        .get('/api/v1/solar')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.count).toBe(0);
+      expect(response.body.data).toEqual([]);
+    });
+  });
+
+  describe('GET /api/v1/solar/range', () => {
+    it('should return solar estimates within time range', async () => {
+      const mockEstimates = [
+        { timestamp: 1699560000, watt_hours: 450.5, fetched_at: 1699557600 },
+        { timestamp: 1699563600, watt_hours: 520.3, fetched_at: 1699557600 }
+      ];
+
+      vi.mocked(solarMonitoringService.getEstimatesInRange).mockReturnValue(mockEstimates);
+
+      const response = await request(app)
+        .get('/api/v1/solar/range?start=1699520400&end=1699606800')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.count).toBe(2);
+      expect(response.body.start).toBe(1699520400);
+      expect(response.body.end).toBe(1699606800);
+      expect(response.body.data).toHaveLength(2);
+    });
+
+    it('should return 400 for missing start parameter', async () => {
+      const response = await request(app)
+        .get('/api/v1/solar/range?end=1699606800')
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toBe('Bad Request');
+      expect(response.body.message).toContain('Invalid');
+    });
+
+    it('should return 400 for missing end parameter', async () => {
+      const response = await request(app)
+        .get('/api/v1/solar/range?start=1699520400')
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toBe('Bad Request');
+      expect(response.body.message).toContain('Invalid');
+    });
+
+    it('should return 400 when start is after end', async () => {
+      const response = await request(app)
+        .get('/api/v1/solar/range?start=1699606800&end=1699520400')
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toBe('Bad Request');
+      expect(response.body.message).toContain('before');
+    });
+
+    it('should return empty array for range with no data', async () => {
+      vi.mocked(solarMonitoringService.getEstimatesInRange).mockReturnValue([]);
+
+      const response = await request(app)
+        .get('/api/v1/solar/range?start=1699520400&end=1699606800')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.count).toBe(0);
+      expect(response.body.data).toEqual([]);
+    });
+  });
+});

--- a/src/server/routes/v1/solar.ts
+++ b/src/server/routes/v1/solar.ts
@@ -1,0 +1,98 @@
+/**
+ * v1 API - Solar Estimates Endpoint
+ *
+ * Provides read-only access to solar production estimates from forecast.solar
+ */
+
+import express, { Request, Response } from 'express';
+import { solarMonitoringService } from '../../services/solarMonitoringService.js';
+import { logger } from '../../../utils/logger.js';
+
+const router = express.Router();
+
+/**
+ * GET /api/v1/solar
+ * Get recent solar production estimates
+ *
+ * Query parameters:
+ * - limit: number - Max number of records to return (default: 100, max: 1000)
+ */
+router.get('/', (req: Request, res: Response) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit as string) || 100, 1000);
+    const estimates = solarMonitoringService.getRecentEstimates(limit);
+
+    res.json({
+      success: true,
+      count: estimates.length,
+      data: estimates.map(est => ({
+        timestamp: est.timestamp,
+        datetime: new Date(est.timestamp * 1000).toISOString(),
+        wattHours: est.watt_hours,
+        fetchedAt: est.fetched_at
+      }))
+    });
+  } catch (error) {
+    logger.error('Error getting solar estimates:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Internal Server Error',
+      message: 'Failed to retrieve solar estimates'
+    });
+  }
+});
+
+/**
+ * GET /api/v1/solar/range
+ * Get solar production estimates for a specific time range
+ *
+ * Query parameters:
+ * - start: number - Start timestamp (unix seconds)
+ * - end: number - End timestamp (unix seconds)
+ */
+router.get('/range', (req: Request, res: Response) => {
+  try {
+    const start = parseInt(req.query.start as string);
+    const end = parseInt(req.query.end as string);
+
+    if (isNaN(start) || isNaN(end)) {
+      return res.status(400).json({
+        success: false,
+        error: 'Bad Request',
+        message: 'Invalid start or end timestamp'
+      });
+    }
+
+    if (start > end) {
+      return res.status(400).json({
+        success: false,
+        error: 'Bad Request',
+        message: 'Start timestamp must be before end timestamp'
+      });
+    }
+
+    const estimates = solarMonitoringService.getEstimatesInRange(start, end);
+
+    res.json({
+      success: true,
+      count: estimates.length,
+      start,
+      end,
+      data: estimates.map(est => ({
+        timestamp: est.timestamp,
+        datetime: new Date(est.timestamp * 1000).toISOString(),
+        wattHours: est.watt_hours,
+        fetchedAt: est.fetched_at
+      }))
+    });
+  } catch (error) {
+    logger.error('Error getting solar estimates in range:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Internal Server Error',
+      message: 'Failed to retrieve solar estimates'
+    });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- Exposes Forecast.Solar production estimates via the v1 REST API
- Adds `GET /api/v1/solar` endpoint for recent estimates with configurable limit
- Adds `GET /api/v1/solar/range` endpoint for estimates within a time range
- Includes full OpenAPI documentation for new endpoints
- Comprehensive unit test coverage (10 tests)

## Endpoints

### GET /api/v1/solar
Returns recent solar production estimates.
- **Query params**: `limit` (default: 100, max: 1000)
- **Response**: Array of estimates with timestamp, datetime, wattHours, fetchedAt

### GET /api/v1/solar/range
Returns solar estimates within a time range.
- **Query params**: `start` (unix timestamp), `end` (unix timestamp)
- **Response**: Array of estimates plus start/end range info

## Test plan
- [x] Unit tests pass (10 tests in solar.test.ts)
- [ ] Manual test with running instance
- [ ] Verify OpenAPI docs render correctly at /api/v1/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)