### PR TITLE
fix: handle non-JSON audit log details without crashing

### DIFF
--- a/src/components/AuditLogTab.tsx
+++ b/src/components/AuditLogTab.tsx
@@ -413,7 +413,13 @@ const AuditLogTab: React.FC = () => {
                             <div className="detail-section">
                               <strong>{t('audit.details')}:</strong>
                               <pre className="detail-pre">
-                                {log.details ? JSON.stringify(JSON.parse(log.details), null, 2) : t('audit.na')}
+                                {log.details ? (() => {
+                                  try {
+                                    return JSON.stringify(JSON.parse(log.details), null, 2);
+                                  } catch {
+                                    return log.details;
+                                  }
+                                })() : t('audit.na')}
                               </pre>
                             </div>
                             {(log.valueBefore || log.valueAfter) && (
@@ -422,7 +428,13 @@ const AuditLogTab: React.FC = () => {
                                   <div className="detail-section before">
                                     <strong>{t('audit.value_before')}</strong>
                                     <pre className="detail-pre">
-                                      {JSON.stringify(JSON.parse(log.valueBefore), null, 2)}
+                                      {(() => {
+                                        try {
+                                          return JSON.stringify(JSON.parse(log.valueBefore), null, 2);
+                                        } catch {
+                                          return log.valueBefore;
+                                        }
+                                      })()}
                                     </pre>
                                   </div>
                                 )}
@@ -430,7 +442,13 @@ const AuditLogTab: React.FC = () => {
                                   <div className="detail-section after">
                                     <strong>{t('audit.value_after')}</strong>
                                     <pre className="detail-pre">
-                                      {JSON.stringify(JSON.parse(log.valueAfter), null, 2)}
+                                      {(() => {
+                                        try {
+                                          return JSON.stringify(JSON.parse(log.valueAfter), null, 2);
+                                        } catch {
+                                          return log.valueAfter;
+                                        }
+                                      })()}
                                     </pre>
                                   </div>
                                 )}


### PR DESCRIPTION
## Summary
- Wrap JSON.parse calls in try-catch blocks when displaying expanded audit log details
- Fixes crash when clicking on `auto_upgrade_triggered` events (and other events with plain text details)
- If parsing fails, displays the raw string instead of crashing

## Problem
Clicking on the `auto_upgrade` event in the audit log caused a console error:
```
Uncaught SyntaxError: Unexpected token 'A', "Auto-upgra"... is not valid JSON
```

The `auto_upgrade_triggered` event stores its details as a plain string (`"Auto-upgrade initiated: X → Y"`) rather than a JSON object, but the AuditLogTab component was blindly calling `JSON.parse()` on all details strings.

## Test plan
- [ ] Navigate to Audit Log tab
- [ ] Click on an `auto_upgrade_triggered` event to expand details
- [ ] Verify no console error and details display correctly
- [ ] Click on other audit events with JSON details and verify they still pretty-print correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)