### PR TITLE
feat: add Simplified Chinese to language selector

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -22,6 +22,7 @@ export const AVAILABLE_LANGUAGES = [
   { code: 'de', name: 'German', nativeName: 'Deutsch' },
   { code: 'fr', name: 'French', nativeName: 'Français' },
   { code: 'ru', name: 'Russian', nativeName: 'Русский' },
+  { code: 'zh_Hans', name: 'Chinese (Simplified)', nativeName: '简体中文' },
 ];
 
 i18n


### PR DESCRIPTION
## Summary
- Add Simplified Chinese (简体中文) option to the language selector dropdown
- The `zh_Hans.json` translation file was already added via Weblate sync (#966) - this enables users to select it in the UI

## Test plan
- [ ] Verify Chinese (Simplified) appears in the language dropdown in Settings
- [ ] Verify selecting it changes the UI language correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)