### PR TITLE
feat: move language selector to top of Settings page

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -258,6 +258,7 @@
   "settings.title": "Einstellungen",
   "settings.language": "Sprache",
   "settings.languageDescription": "Wähle deine bevorzugte Sprache",
+  "settings.language_contribute": "Deine Sprache fehlt? Hilf bei der Übersetzung von MeshMonitor auf",
   "settings.temperature_unit": "Temperatureinheit",
   "settings.distance_unit": "Entfernungseinheit",
   "settings.time_format": "Zeitformat",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -348,6 +348,7 @@
   "settings.title": "Settings",
   "settings.language": "Language",
   "settings.languageDescription": "Choose your preferred language",
+  "settings.language_contribute": "Don't see your language? Help translate MeshMonitor on",
   "settings.temperature_unit": "Temperature Unit",
   "settings.distance_unit": "Distance Unit",
   "settings.time_format": "Time Format",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -269,6 +269,7 @@
   "settings.title": "Ajustes",
   "settings.language": "Idioma",
   "settings.languageDescription": "Elige tu idioma preferido",
+  "settings.language_contribute": "¿No ves tu idioma? Ayuda a traducir MeshMonitor en",
   "settings.temperature_unit": "Unidad de temperatura",
   "settings.distance_unit": "Unidad de distancia",
   "settings.time_format": "Formato de hora",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -258,6 +258,7 @@
   "settings.title": "Paramètres",
   "settings.language": "Langue",
   "settings.languageDescription": "Choisissez votre langue préférée",
+  "settings.language_contribute": "Votre langue n'est pas disponible ? Aidez à traduire MeshMonitor sur",
   "settings.temperature_unit": "Unité de température",
   "settings.distance_unit": "Unité de distance",
   "settings.time_format": "Format de l'heure",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -264,5 +264,8 @@
     "messages.last_traced": "Последний раз трассировалась {{time}}",
     "messages.security_issue_title": "Проблема безопасности",
     "messages.issue_details": "Детали проблемы",
-    "messages.low_entropy_warning": "Этот узел использует известный криптографический ключ с низкой энтропией. "
+    "messages.low_entropy_warning": "Этот узел использует известный криптографический ключ с низкой энтропией. ",
+    "settings.language": "Язык",
+    "settings.languageDescription": "Выберите предпочитаемый язык",
+    "settings.language_contribute": "Не видите свой язык? Помогите перевести MeshMonitor на"
 }

--- a/public/locales/zh_Hans.json
+++ b/public/locales/zh_Hans.json
@@ -10,5 +10,8 @@
     "nav.users": "用户",
     "nav.admin_commands": "管理员指令",
     "nav.audit": "检查日志",
-    "nav.security": "安全"
+    "nav.security": "安全",
+    "settings.language": "语言",
+    "settings.languageDescription": "选择您的首选语言",
+    "settings.language_contribute": "没有看到您的语言？帮助在以下平台翻译 MeshMonitor："
 }

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -629,6 +629,30 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       </div>
       <div className="settings-content">
         <div className="settings-section">
+          <h3>{t('settings.language')}</h3>
+          <div className="setting-item">
+            <label htmlFor="language">
+              {t('settings.languageDescription')}
+            </label>
+            <LanguageSelector
+              value={language}
+              onChange={onLanguageChange}
+            />
+          </div>
+          <p className="setting-description" style={{ marginTop: '0.5rem' }}>
+            {t('settings.language_contribute')}{' '}
+            <a
+              href="https://hosted.weblate.org/projects/meshmonitor/meshmonitor/"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'var(--accent-color)' }}
+            >
+              Weblate
+            </a>
+          </p>
+        </div>
+
+        <div className="settings-section">
           <h3>{t('settings.node_display')}</h3>
           <div className="setting-item">
             <label htmlFor="maxNodeAge">
@@ -900,16 +924,6 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
                 </optgroup>
               )}
             </select>
-          </div>
-          <div className="setting-item">
-            <label htmlFor="language">
-              {t('settings.language')}
-              <span className="setting-description">{t('settings.languageDescription')}</span>
-            </label>
-            <LanguageSelector
-              value={language}
-              onChange={onLanguageChange}
-            />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Move the Language section to the top of the Settings page for better visibility
- Non-English speakers can now easily find the language selector without scrolling
- Add a translated "Help translate on Weblate" link to encourage contributions

## Test plan
- [ ] Verify Language section appears at the top of Settings (right after the header)
- [ ] Verify the Weblate link works
- [ ] Verify language selection still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)