### PR TITLE
fix: prevent Firefox sort dropdown from triggering panel drag

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -316,6 +316,10 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     }
   }, []); // Empty deps - function never changes
 
+  // Utility to prevent mousedown from triggering drag on form elements
+  // Firefox handles select/input mousedown differently, which can trigger panel drag
+  const stopPropagation = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
+
   // Stable callback factories for node item interactions
   const handleNodeClick = useCallback((node: DeviceInfo) => {
     return () => {
@@ -831,6 +835,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               placeholder={t('nodes.filter_placeholder')}
               value={nodesNodeFilter}
               onChange={(e) => setNodesNodeFilter(e.target.value)}
+              onMouseDown={stopPropagation}
               className="filter-input-small"
             />
             <div className="sort-controls">
@@ -852,6 +857,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               <select
                 value={sortField}
                 onChange={(e) => setSortField(e.target.value as any)}
+                onMouseDown={stopPropagation}
                 className="sort-dropdown"
                 title={t('nodes.sort_by')}
               >


### PR DESCRIPTION
## Summary
- Add explicit `onMouseDown` stopPropagation handlers to sort dropdown and filter input
- Fixes Firefox-specific bug where changing sort order causes node list panel to drag

## Problem
In Firefox (and forks like Floorp), clicking on the sort dropdown to change the sorting order would cause the node list panel to attach to the mouse cursor for dragging.

## Root Cause
Firefox handles `mousedown`/`mouseup` events differently than Chrome/Safari for native `<select>` elements. When selecting an option from the dropdown:
1. The `mousedown` event would bubble up to the parent drag handler
2. `isDragging` state would be set to `true`
3. After the dropdown closes, `mouseup` might not fire properly
4. This leaves the panel in a stuck "dragging" state

## Solution
Add explicit `onMouseDown={(e) => e.stopPropagation()}` to both:
- The sort dropdown `<select>` element
- The filter `<input>` element (for consistency)

This prevents the mouse events from bubbling up to the drag handler.

## Test plan
- [ ] Test in Firefox/Floorp: Change sort order, verify panel doesn't drag
- [ ] Test in Chrome/Safari: Verify normal functionality preserved

Fixes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)