### PR TITLE
feat: add Paxcounter telemetry support

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -841,6 +841,9 @@
   "telemetry.uptime_seconds": "Uptime",
   "telemetry.ch1_voltage": "Channel 1 Voltage",
   "telemetry.ch1_current": "Channel 1 Current",
+  "telemetry.paxcounter_wifi": "Paxcounter WiFi",
+  "telemetry.paxcounter_ble": "Paxcounter BLE",
+  "telemetry.paxcounter_uptime": "Paxcounter Uptime",
 
   "map.satellite": "Satellite",
   "map.terrain": "Terrain",

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -72,6 +72,9 @@ const TELEMETRY_LABEL_KEYS: Record<string, string> = {
   pressure: 'telemetry.barometric_pressure',
   ch1Voltage: 'telemetry.ch1_voltage',
   ch1Current: 'telemetry.ch1_current',
+  paxcounterWifi: 'telemetry.paxcounter_wifi',
+  paxcounterBle: 'telemetry.paxcounter_ble',
+  paxcounterUptime: 'telemetry.paxcounter_uptime',
 };
 
 // Fallback labels (used when translation is not available or for sorting/filtering)
@@ -85,6 +88,9 @@ const TELEMETRY_LABELS: Record<string, string> = {
   pressure: 'Barometric Pressure',
   ch1Voltage: 'Channel 1 Voltage',
   ch1Current: 'Channel 1 Current',
+  paxcounterWifi: 'Paxcounter WiFi',
+  paxcounterBle: 'Paxcounter BLE',
+  paxcounterUptime: 'Paxcounter Uptime',
 };
 
 // Export for external use (returns English labels for sorting/filtering compatibility)
@@ -100,6 +106,9 @@ const TELEMETRY_COLORS: Record<string, string> = {
   pressure: '#a28dff',
   ch1Voltage: '#d084d8',
   ch1Current: '#ff6b9d',
+  paxcounterWifi: '#ff9500',
+  paxcounterBle: '#17c0fa',
+  paxcounterUptime: '#9c88ff',
 };
 
 const getColor = (type: string): string => TELEMETRY_COLORS[type] || '#8884d8';

--- a/src/server/meshtasticProtobufService.ts
+++ b/src/server/meshtasticProtobufService.ts
@@ -585,6 +585,11 @@ export class MeshtasticProtobufService {
           const routing = Routing.decode(payload);
           return routing;
 
+        case 34: // PAXCOUNTER_APP
+          const Paxcount = root.lookupType('meshtastic.Paxcount');
+          const paxcount = Paxcount.decode(payload);
+          return paxcount;
+
         case 67: // TELEMETRY_APP
           const Telemetry = root.lookupType('meshtastic.Telemetry');
           const telemetry = Telemetry.decode(payload);


### PR DESCRIPTION
## Summary

- Add support for receiving and storing Paxcounter telemetry data from Meshtastic nodes
- Paxcounter counts nearby WiFi and BLE devices, useful for estimating foot traffic or population density

## Changes

- Add PAXCOUNTER_APP (portnum 34) protobuf decoding in protobuf service
- Add `processPaxcounterMessageProtobuf` handler to save three telemetry metrics:
  - `paxcounterWifi`: WiFi device count
  - `paxcounterBle`: BLE device count  
  - `paxcounterUptime`: Paxcounter module uptime
- Add telemetry labels and chart colors in TelemetryChart.tsx
- Add translation keys for paxcounter telemetry types
- Add payload preview for Paxcounter packets in packet logging

## Test plan

- [x] Build passes
- [x] System tests pass
- [ ] Deploy and verify paxcounter data appears in telemetry charts when a node sends PAXCOUNTER_APP packets

Closes #967

🤖 Generated with [Claude Code](https://claude.com/claude-code)