### PR TITLE
feat: add paxcounter telemetry graph support on Messages page

### DIFF
--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -357,6 +357,10 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
         co2: 'CO₂',
         co2Temperature: 'CO₂ Sensor Temperature',
         co2Humidity: 'CO₂ Sensor Humidity',
+        // Paxcounter metrics
+        paxcounterWifi: 'Paxcounter WiFi',
+        paxcounterBle: 'Paxcounter BLE',
+        paxcounterUptime: 'Paxcounter Uptime',
       };
       return labels[type] || type;
     };
@@ -407,6 +411,10 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
         co2: '#ed8796', // Red for CO2 (important air quality indicator)
         co2Temperature: '#f5a97f', // Peach
         co2Humidity: '#91d7e3', // Sky blue
+        // Paxcounter metrics
+        paxcounterWifi: '#ff9500', // Orange
+        paxcounterBle: '#17c0fa', // Cyan
+        paxcounterUptime: '#9c88ff', // Purple
       };
       return colors[type] || '#8884d8';
     };


### PR DESCRIPTION
## Summary
- Add labels and colors for Paxcounter telemetry types (WiFi, BLE, Uptime) to TelemetryGraphs component
- The backend and TelemetryChart (Dashboard) already supported paxcounter, but TelemetryGraphs (Messages page) was missing the display configuration
- Fixes issue where paxcounter data was being collected but not displayed on the node's Messages page

Closes #967

## Test plan
- [x] Verify Paxcounter WiFi, BLE, and Uptime graphs display on the Messages page when telemetry data exists
- [x] Confirm proper labels (Paxcounter WiFi, Paxcounter BLE, Paxcounter Uptime) are shown
- [x] Confirm proper colors (Orange, Cyan, Purple) are applied

## System Test Results
```
Configuration Import:     ✓ PASSED
Quick Start Test:         ✓ PASSED
Security Test:            ✓ PASSED
Reverse Proxy Test:       ✓ PASSED
Reverse Proxy + OIDC:     ✓ PASSED
Virtual Node CLI Test:    ✓ PASSED
Backup & Restore Test:    ✓ PASSED
V1 Public API Test:       ✓ PASSED

✓ ALL SYSTEM TESTS PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)