### PR TITLE
fix: position map Features panel in upper-right by default

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -252,17 +252,24 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   }, [sidebarSize]);
 
   // Map controls position state with localStorage persistence
+  // Default position is upper-right (x calculated from viewport width - panel width - margin)
+  const getDefaultMapControlsPosition = () => ({
+    x: window.innerWidth - 200 - 10, // right-align: viewport - estimated panel width (~200px) - 10px margin
+    y: 10
+  });
+
   const [mapControlsPosition, setMapControlsPosition] = useState(() => {
     const saved = localStorage.getItem('mapControlsPosition');
     if (saved) {
       try {
         const parsed = JSON.parse(saved);
-        return { x: parsed.x ?? 10, y: parsed.y ?? 10 };
+        const defaultPos = getDefaultMapControlsPosition();
+        return { x: parsed.x ?? defaultPos.x, y: parsed.y ?? defaultPos.y };
       } catch {
-        return { x: 10, y: 10 };
+        return getDefaultMapControlsPosition();
       }
     }
-    return { x: 10, y: 10 };
+    return getDefaultMapControlsPosition();
   });
 
   // Map controls drag state


### PR DESCRIPTION
## Summary
- Changes the default position for the map Features panel from upper-left (10, 10) to upper-right
- Uses viewport width calculation: `window.innerWidth - 200px - 10px margin`
- Prevents overlap with the Node List panel which also starts in the upper-left

## Test plan
- [x] Clear localStorage `mapControlsPosition` key (or test in incognito)
- [x] Open the Nodes tab with map view
- [x] Verify Features panel appears in upper-right corner
- [x] Verify Node List panel appears in upper-left corner (unchanged)
- [x] System tests pass

## System Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| Reverse Proxy Test | ✅ PASSED |
| Reverse Proxy + OIDC | ✅ PASSED |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)