### PR TITLE
docs: document VERSION_CHECK_DISABLED environment variable

### DIFF
--- a/docs/configuration/auto-upgrade.md
+++ b/docs/configuration/auto-upgrade.md
@@ -87,6 +87,22 @@ services:
       - COMPOSE_PROJECT_DIR=/compose  # Path to docker-compose files
 ```
 
+### Disabling Version Check
+
+If you want to completely disable the version check (and hide the "Update Available" banner), set the `VERSION_CHECK_DISABLED` environment variable:
+
+```yaml
+services:
+  meshmonitor:
+    environment:
+      - VERSION_CHECK_DISABLED=true  # Disable version check and update banner
+```
+
+This is useful for:
+- Air-gapped deployments without internet access
+- Environments where you manage updates through other means (CI/CD, Kubernetes operators, etc.)
+- Development or testing environments where you don't want update notifications
+
 ## Using the Upgrade Feature
 
 ### Step 1: Check for Updates

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -166,6 +166,7 @@ See the [Push Notifications guide](/features/notifications) for setup instructio
 | `SYSTEM_BACKUP_DIR` | Directory for full system backups | `/data/system-backups` |
 | `RESTORE_FROM_BACKUP` | Path to backup file to restore on startup | None |
 | `AUTO_UPGRADE_ENABLED` | Enable automatic upgrades in Kubernetes | `false` |
+| `VERSION_CHECK_DISABLED` | Disable version check and hide update banner | `false` |
 | `APPRISE_CONFIG_DIR` | Directory for Apprise notification configuration | None |
 | `DUPLICATE_KEY_SCAN_INTERVAL_HOURS` | Hours between duplicate encryption key scans | `24` |
 


### PR DESCRIPTION
## Summary

- Documents the `VERSION_CHECK_DISABLED` environment variable that disables the version check and hides the update banner

## Changes

- **docs/configuration/auto-upgrade.md**: Added "Disabling Version Check" section explaining the variable and use cases
- **docs/configuration/index.md**: Added `VERSION_CHECK_DISABLED` to the System Management Variables table

## Use Cases

- Air-gapped deployments without internet access
- Environments where updates are managed through CI/CD, Kubernetes operators, etc.
- Development or testing environments where update notifications are not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)