### PR TITLE
feat(api): add POST /api/v1/messages endpoint for sending messages

### DIFF
--- a/docs/public/openapi.yaml
+++ b/docs/public/openapi.yaml
@@ -387,7 +387,7 @@ components:
         toNodeId:
           type: string
           description: Node ID for direct message (e.g., "!a1b2c3d4"). Required if channel is not specified.
-          pattern: '^![0-9a-fA-F]{8}$'
+          pattern: '^![0-9a-fA-F]{1,8}$'
           example: "!a1b2c3d4"
         replyId:
           type: integer

--- a/src/server/routes/v1/messages.ts
+++ b/src/server/routes/v1/messages.ts
@@ -9,6 +9,7 @@ import databaseService from '../../../services/database.js';
 import meshtasticManager from '../../meshtasticManager.js';
 import { hasPermission } from '../../auth/authMiddleware.js';
 import { ResourceType } from '../../../types/permission.js';
+import { messageLimiter } from '../../middleware/rateLimiters.js';
 import { logger } from '../../../utils/logger.js';
 
 const router = express.Router();
@@ -118,7 +119,7 @@ router.get('/:messageId', (req: Request, res: Response) => {
  * - requestId: number - Request ID for matching delivery acknowledgments
  * - deliveryState: string - Initial delivery state ("pending")
  */
-router.post('/', async (req: Request, res: Response) => {
+router.post('/', messageLimiter, async (req: Request, res: Response) => {
   try {
     const { text, channel, toNodeId, replyId } = req.body;
 

--- a/src/server/routes/v1/openapi.yaml
+++ b/src/server/routes/v1/openapi.yaml
@@ -387,7 +387,7 @@ components:
         toNodeId:
           type: string
           description: Node ID for direct message (e.g., "!a1b2c3d4"). Required if channel is not specified.
-          pattern: '^![0-9a-fA-F]{8}$'
+          pattern: '^![0-9a-fA-F]{1,8}$'
           example: "!a1b2c3d4"
         replyId:
           type: integer


### PR DESCRIPTION
## Summary

- Adds a new `POST /api/v1/messages` endpoint to the v1 REST API for sending messages via API tokens
- Supports sending to channels (0-7) or direct messages to specific nodes
- Respects API token permissions (`channel_X:write` for channels, `messages:write` for DMs)
- Returns message ID for tracking delivery status
- Supports optional `replyId` for message replies

## API Usage

### Send to Channel
```bash
curl -X POST https://your-server/api/v1/messages \
  -H "Authorization: Bearer mm_v1_..." \
  -H "Content-Type: application/json" \
  -d '{"text": "Hello from API!", "channel": 0}'
```

### Send Direct Message
```bash
curl -X POST https://your-server/api/v1/messages \
  -H "Authorization: Bearer mm_v1_..." \
  -H "Content-Type: application/json" \
  -d '{"text": "Private message", "toNodeId": "!a1b2c3d4"}'
```

### Response
```json
{
  "success": true,
  "data": {
    "messageId": "2715451348_123456789",
    "requestId": 123456789,
    "deliveryState": "pending",
    "text": "Hello from API!",
    "channel": 0,
    "toNodeId": "broadcast"
  }
}
```

## Test plan

- [x] Typecheck passes
- [x] All 889 server tests pass (includes 10 new tests for POST endpoint)
- [x] Build succeeds
- [ ] CI checks pass
- [ ] Test sending channel message via API
- [ ] Test sending direct message via API
- [ ] Test permission denial with insufficient permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)