### PR TITLE
chore: bump version to 2.20.9

### DIFF
--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.20.8
-appVersion: "2.20.8"
+version: 2.20.9
+appVersion: "2.20.9"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.20.8",
+  "version": "2.20.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.20.8",
+      "version": "2.20.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.20.8",
+  "version": "2.20.9",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Version bump to 2.20.9

## Changes since v2.20.8

### New Features
- **Individual Filter Checkboxes for Auto Traceroute** - Users can now enable/disable each filter type independently without losing their configuration. Fixes the issue where setting regex to empty would reset to '.*'. [#990](https://github.com/Yeraze/meshmonitor/pull/990)
- **POST /api/v1/messages Endpoint** - New API endpoint for sending messages programmatically [#988](https://github.com/Yeraze/meshmonitor/pull/988)
- **Paxcounter Telemetry Graph on Messages Page** - Added paxcounter telemetry visualization [#982](https://github.com/Yeraze/meshmonitor/pull/982)
- **Notification Node Name Prefix** - Option to prefix notifications with node name for better identification [#981](https://github.com/Yeraze/meshmonitor/pull/981)
- **Server Event Notifications** - Added server event notifications for monitoring [#979](https://github.com/Yeraze/meshmonitor/pull/979)

### Bug Fixes
- **MQTT Message Filtering** - Capture viaMqtt field for proper MQTT message filtering [#986](https://github.com/Yeraze/meshmonitor/pull/986)
- **Map Features Panel Position** - Fixed Features panel position to upper-right by default [#984](https://github.com/Yeraze/meshmonitor/pull/984)

### Documentation
- **VERSION_CHECK_DISABLED** - Documented the VERSION_CHECK_DISABLED environment variable [#987](https://github.com/Yeraze/meshmonitor/pull/987)

### Translations
- **Chinese (Simplified)** - Translation updates from Weblate [#980](https://github.com/Yeraze/meshmonitor/pull/980)

🤖 Generated with [Claude Code](https://claude.com/claude-code)