### PR TITLE
fix: load paxcount.proto for PAXCOUNTER_APP support

### DIFF
--- a/src/server/protobufLoader.ts
+++ b/src/server/protobufLoader.ts
@@ -41,6 +41,11 @@ export async function loadProtobufDefinitions(): Promise<protobuf.Root> {
     await root.load(apponlyProtoPath);
     logger.debug('✅ Loaded apponly.proto for ChannelSet support');
 
+    // Load paxcount.proto for PAXCOUNTER_APP support
+    const paxcountProtoPath = path.join(protoRoot, 'meshtastic/paxcount.proto');
+    await root.load(paxcountProtoPath);
+    logger.debug('✅ Loaded paxcount.proto for Paxcount support');
+
     logger.debug('✅ Successfully loaded Meshtastic protobuf definitions');
     return root;
   } catch (error) {


### PR DESCRIPTION
## Summary
- Fix PAXCOUNTER_APP (portnum 34) messages failing to decode
- Add explicit loading of `paxcount.proto` in protobufLoader.ts
- The proto file was not being imported by `mesh.proto`, causing "no such type: meshtastic.Paxcount" errors

## Test plan
- [x] Verified paxcounter telemetry data is now being captured and stored
- [x] Confirmed WiFi/BLE/Uptime values are properly decoded from the Paxcount message
- [x] Database shows paxcounter entries from "Yeraze BLE Sandbox" node

🤖 Generated with [Claude Code](https://claude.com/claude-code)