### PR TITLE
feat(ui): add Map Features position constraints and Reset Positions button

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -386,6 +386,10 @@
   "settings.miles": "Miles",
   "settings.12_hour": "12 Hour",
   "settings.24_hour": "24 Hour",
+  "settings.reset_ui_positions": "Reset UI Positions",
+  "settings.reset_ui_positions_description": "Reset the positions of draggable UI elements (Node List, Map Features, Hop Legend, Tile Selector) to their default locations.",
+  "settings.reset_ui_positions_button": "Reset Positions",
+  "settings.reset_ui_positions_success": "UI positions have been reset. Refresh the page to see the changes.",
 
   "configuration.title": "Device Configuration",
   "configuration.node_identity": "Node Identity",

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -932,6 +932,26 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         </div>
 
         <div className="settings-section">
+          <h3>{t('settings.reset_ui_positions')}</h3>
+          <p className="setting-description">{t('settings.reset_ui_positions_description')}</p>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={() => {
+              // Clear all draggable UI element positions from localStorage
+              localStorage.removeItem('nodesSidebarPosition');
+              localStorage.removeItem('nodesSidebarSize');
+              localStorage.removeItem('mapControlsPosition');
+              localStorage.removeItem('draggable_position_map-legend');
+              localStorage.removeItem('draggable_position_tileset-selector');
+              showToast(t('settings.reset_ui_positions_success'), 'success');
+            }}
+          >
+            {t('settings.reset_ui_positions_button')}
+          </button>
+        </div>
+
+        <div className="settings-section">
           <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
             <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: 0, cursor: 'pointer' }}>
               <input


### PR DESCRIPTION
## Summary

- Fix Map Features panel going offscreen by constraining position to map container bounds
- Add sanity check to clear invalid saved positions on load (migration from old viewport-based positions)
- Add position constraint on mount and window resize to keep panel visible
- Use sentinel value (-1) for default position to fall back to CSS right-based positioning
- Add "Reset UI Positions" button in Settings to reset all draggable elements:
  - Node List position and size
  - Map Features panel
  - Hop Legend
  - Tile Selector

## Test plan

- [ ] Verify Map Features panel stays visible when window is resized
- [ ] Test that old saved positions that are offscreen are automatically reset
- [ ] Click "Reset Positions" button in Settings and verify toast appears
- [ ] Refresh page and verify all UI elements return to default positions
- [ ] Drag elements to custom positions, reload, verify positions persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)