### PR TITLE
fix(notifications): use persisted node name for startup notification prefix

### DIFF
--- a/src/server/services/pushNotificationService.ts
+++ b/src/server/services/pushNotificationService.ts
@@ -473,8 +473,23 @@ class PushNotificationService {
     logger.info(`📢 Broadcasting ${preferenceKey} notification to ${subscriptions.length} subscriptions${targetUserId ? ` (target user: ${targetUserId})` : ''}`);
 
     // Get local node name for prefix
+    // First try the live connection, then fall back to database (for startup before connection)
+    let localNodeName: string | null = null;
     const localNodeInfo = meshtasticManager.getLocalNodeInfo();
-    const localNodeName = localNodeInfo?.longName || null;
+    if (localNodeInfo?.longName) {
+      localNodeName = localNodeInfo.longName;
+    } else {
+      // Fall back to database - get localNodeNum from settings and look up the node
+      const localNodeNumStr = databaseService.getSetting('localNodeNum');
+      if (localNodeNumStr) {
+        const localNodeNum = parseInt(localNodeNumStr, 10);
+        const localNode = databaseService.getNode(localNodeNum);
+        if (localNode?.longName) {
+          localNodeName = localNode.longName;
+          logger.debug(`📢 Using node name from database for prefix: ${localNodeName}`);
+        }
+      }
+    }
 
     for (const subscription of subscriptions) {
       const userId = subscription.userId;


### PR DESCRIPTION
## Summary
- Fixes the "Prefix Notifications with Node Name" setting not working for container startup notifications
- When meshtasticManager.getLocalNodeInfo() returns null at startup (before connection), now falls back to looking up the node name from the database using the persisted localNodeNum setting

## Root Cause
The startup notification is sent before the Meshtastic connection is established, so `meshtasticManager.getLocalNodeInfo()` returns null. The code was using this null value directly instead of falling back to the persisted node info in the database.

## Test plan
- [x] TypeScript type checking passes
- [x] Unit tests pass (107 tests)
- [x] System tests pass (7 test suites)

### System Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | PASSED |
| Quick Start Test | PASSED |
| Security Test | PASSED |
| Reverse Proxy Test | PASSED |
| Reverse Proxy + OIDC | PASSED |
| Virtual Node CLI Test | PASSED |
| Backup & Restore Test | PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)