### PR TITLE
fix(i18n): update language loading strategy to use currentOnly

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -31,7 +31,7 @@ i18n
   .use(initReactI18next)
   .init({
     fallbackLng: 'en',
-    load: 'languageOnly', // Use 'en' instead of 'en-US'
+    load: 'currentOnly', 
     debug: process.env.NODE_ENV === 'development',
 
     interpolation: {


### PR DESCRIPTION
This PR updates the i18n configuration by changing the load option from languageOnly to currentOnly.

Previously, when using languageOnly, locale variants such as zh_Hans were normalized to zh. This caused unintended fallback behavior when a dedicated zh_Hans translation was available, but the system incorrectly resolved it as zh and loaded the fallback resources instead.

By switching to currentOnly, the full locale identifier is preserved during the loading process. This ensures that locale-specific resources (e.g. zh_Hans) are correctly resolved and prevents unexpected fallback to more generic languages.