### PR TITLE
fix(map): only show uncertainty circle for nodes currently using estimated position

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2523,9 +2523,11 @@ apiRouter.get('/telemetry/available/nodes', requirePermission('info', 'read'), (
           nodesWithWeather.push(node.nodeId);
         }
 
-        // Check if node has estimated position telemetry
+        // Check if node has estimated position telemetry AND doesn't have real GPS coordinates
+        // Only show uncertainty circle for nodes currently using estimated position
         const hasEstimatedPosition = telemetryTypes.some(t => estimatedPositionTypes.has(t));
-        if (hasEstimatedPosition) {
+        const hasRealPosition = !!(node.latitude && node.longitude);
+        if (hasEstimatedPosition && !hasRealPosition) {
           nodesWithEstimatedPosition.push(node.nodeId);
         }
       }
@@ -2792,8 +2794,10 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
               nodesWithWeather.push(node.nodeId);
             }
 
+            // Only show uncertainty circle for nodes currently using estimated position
             const hasEstimatedPosition = telemetryTypes.some(t => estimatedPositionTypes.has(t));
-            if (hasEstimatedPosition) {
+            const hasRealPosition = !!(node.latitude && node.longitude);
+            if (hasEstimatedPosition && !hasRealPosition) {
               nodesWithEstimatedPosition.push(node.nodeId);
             }
           }


### PR DESCRIPTION
## Summary
- Fix uncertainty circle to only appear when a node is **currently using** an estimated position
- Previously, the circle would persist even after a node reported real GPS coordinates

## Problem
The uncertainty circle (dashed circle around map markers) was appearing on nodes that had **ever** received an estimated position, even after they later reported real GPS coordinates. This happened because:
1. Estimated positions are stored as telemetry records in the database
2. The server checked for the existence of these records without considering if the node now has real GPS

## Solution
When building the `nodesWithEstimatedPosition` list, now check both conditions:
1. Node has estimated position telemetry records (existing check)
2. Node does **NOT** have real GPS coordinates in the nodes table (new check)

This ensures the uncertainty circle only displays when the node is actually using an estimated position.

## Test plan
- [ ] Node with estimated position only → circle appears
- [ ] Node with real GPS (no estimated) → no circle
- [ ] Node with both estimated AND real GPS → no circle (real GPS takes precedence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)