### PR TITLE
fix: remove numTxRelayCanceled from TX pie chart

### DIFF
--- a/src/components/InfoTab.tsx
+++ b/src/components/InfoTab.tsx
@@ -482,13 +482,13 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
           const txTotal = localStats.numPacketsTx || 0;
           const txDropped = localStats.numTxDropped || 0;
           const txRelay = localStats.numTxRelay || 0;
-          const txRelayCanceled = localStats.numTxRelayCanceled || 0;
-          const txDirect = Math.max(0, txTotal - txDropped - txRelay - txRelayCanceled);
+          // Note: numTxRelayCanceled is NOT part of numPacketsTx - it counts packets
+          // that were never transmitted because another node relayed first
+          const txDirect = Math.max(0, txTotal - txDropped - txRelay);
           const txData: ChartDataEntry[] = [
             { name: t('info.tx_direct'), value: txDirect, color: '#89b4fa' },
             { name: t('info.tx_relay_short'), value: txRelay, color: '#a6e3a1' },
             { name: t('info.tx_dropped_short'), value: txDropped, color: '#f38ba8' },
-            { name: t('info.tx_canceled_short'), value: txRelayCanceled, color: '#fab387' },
           ];
           return (
             <PacketStatsChart


### PR DESCRIPTION
## Summary
- Remove `numTxRelayCanceled` from the TX Statistics pie chart
- Fix calculation of `txDirect` to only subtract relay and dropped packets

## Problem
The TX pie chart incorrectly included `numTxRelayCanceled` as a component of `numPacketsTx`. However, according to the Meshtastic protobuf definition, `numTxRelayCanceled` counts "packets we canceled relaying because someone else did it first" - these packets were **never transmitted**, so they shouldn't be part of the TX breakdown.

This caused:
1. The pie chart totals to be incorrect
2. The "TX Direct" calculation to be wrong (too low)
3. Visual confusion when `numTxRelayCanceled` was very high

## Solution
- Removed `numTxRelayCanceled` from the pie chart data
- Updated `txDirect` formula: `txTotal - txDropped - txRelay` (removed `- txRelayCanceled`)

The TX pie chart now correctly shows:
- **TX Direct**: packets originated by this node
- **TX Relay**: packets relayed for other nodes  
- **TX Dropped**: packets dropped due to full queue

## Test plan
- [ ] Verify TX pie chart displays correctly on Info page
- [ ] Verify pie chart segments add up to total TX packets

🤖 Generated with [Claude Code](https://claude.com/claude-code)