### PR TITLE
feat(dashboard): add per-chart solar overlay toggle

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1129,6 +1129,8 @@
   "settings.solar_fetch_now": "Fetch Estimates Now",
   "settings.solar_fetching": "Fetching...",
   "settings.solar_fetch_description": "Manually trigger a solar estimate fetch from Forecast.Solar. Estimates are automatically fetched every hour at :05 past the hour.",
+  "settings.solar_fetch_success": "Solar estimates fetched successfully",
+  "settings.solar_fetch_failed": "Failed to fetch solar estimates",
   "settings.settings_management": "Settings Management",
   "settings.settings_management_description": "Changes are not applied until saved. Settings are stored on the server and persist across all browsers.",
   "settings.saving": "Saving...",
@@ -1260,6 +1262,8 @@
   "dashboard.widget.traceroute.show_map": "Show map",
   "dashboard.widget.traceroute.hide_map": "Hide map",
   "dashboard.widget.traceroute.no_position_warning": "Some nodes have no position data",
+  "dashboard.show_solar": "Show solar overlay",
+  "dashboard.hide_solar": "Hide solar overlay",
 
   "info.title": "Device Information & Configuration",
   "info.connection_status": "Connection Status",
@@ -1924,6 +1928,8 @@
   "telemetry.add_favorite": "Add to favorites",
   "telemetry.more_options": "More options",
   "telemetry.purge_data": "Purge Data",
+  "telemetry.show_solar": "Show solar overlay",
+  "telemetry.hide_solar": "Hide solar overlay",
 
   "node_details.title": "Node Details",
   "node_details.expand": "Expand node details",

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -312,6 +312,13 @@
   min-width: 0;
 }
 
+.dashboard-chart-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
 .dashboard-remove-btn {
   background: none;
   border: none;
@@ -331,6 +338,31 @@
 
 .dashboard-remove-btn:hover {
   color: var(--ctp-red);
+}
+
+/* Solar toggle button */
+.solar-toggle-btn {
+  background: none;
+  border: none;
+  color: var(--ctp-surface2);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.solar-toggle-btn:hover {
+  color: var(--ctp-yellow);
+}
+
+.solar-toggle-btn.active {
+  color: var(--ctp-yellow);
 }
 
 .dashboard-no-data {

--- a/src/components/Dashboard/components/DashboardGrid.tsx
+++ b/src/components/Dashboard/components/DashboardGrid.tsx
@@ -52,6 +52,11 @@ interface DashboardGridProps {
 
   // Permissions
   canEdit?: boolean;
+
+  // Solar monitoring
+  solarMonitoringEnabled?: boolean;
+  getSolarVisibility?: (nodeId: string, telemetryType: string) => boolean;
+  onToggleSolar?: (nodeId: string, telemetryType: string, show: boolean) => void;
 }
 
 const DashboardGrid: React.FC<DashboardGridProps> = ({
@@ -76,6 +81,9 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
   favoritesCount,
   filteredCount,
   canEdit = true,
+  solarMonitoringEnabled = false,
+  getSolarVisibility,
+  onToggleSolar,
 }) => {
   const { t } = useTranslation();
 
@@ -157,6 +165,9 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
                   solarEstimates={solarEstimates}
                   onRemove={onRemoveFavorite}
                   onDataLoaded={onDataLoaded}
+                  showSolar={getSolarVisibility ? getSolarVisibility(favorite.nodeId, favorite.telemetryType) : true}
+                  onToggleSolar={onToggleSolar}
+                  solarMonitoringEnabled={solarMonitoringEnabled}
                 />
               );
             })}

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -59,6 +59,9 @@ interface TelemetryChartProps {
   solarEstimates: Map<number, number>;
   onRemove: (nodeId: string, telemetryType: string) => void;
   onDataLoaded?: (key: string, data: TelemetryData[]) => void;
+  showSolar?: boolean;
+  onToggleSolar?: (nodeId: string, telemetryType: string, show: boolean) => void;
+  solarMonitoringEnabled?: boolean;
 }
 
 // Translation keys for telemetry types
@@ -217,6 +220,9 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
     solarEstimates,
     onRemove,
     onDataLoaded,
+    showSolar = true,
+    onToggleSolar,
+    solarMonitoringEnabled = false,
   }) => {
     const { t } = useTranslation();
 
@@ -253,6 +259,12 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
     const handleRemoveClick = useCallback(() => {
       onRemove(favorite.nodeId, favorite.telemetryType);
     }, [favorite.nodeId, favorite.telemetryType, onRemove]);
+
+    const handleSolarToggle = useCallback(() => {
+      if (onToggleSolar) {
+        onToggleSolar(favorite.nodeId, favorite.telemetryType, !showSolar);
+      }
+    }, [favorite.nodeId, favorite.telemetryType, showSolar, onToggleSolar]);
 
     const style = {
       transform: CSS.Transform.toString(transform),
@@ -341,9 +353,21 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
           >
             {nodeName} - {label} {unit && `(${unit})`}
           </h3>
-          <button className="dashboard-remove-btn" onClick={handleRemoveClick} aria-label={t('dashboard.remove_from_dashboard')}>
-            ✕
-          </button>
+          <div className="dashboard-chart-actions">
+            {solarMonitoringEnabled && (
+              <button
+                className={`solar-toggle-btn ${showSolar ? 'active' : ''}`}
+                onClick={handleSolarToggle}
+                aria-label={showSolar ? t('dashboard.hide_solar') : t('dashboard.show_solar')}
+                title={showSolar ? t('dashboard.hide_solar') : t('dashboard.show_solar')}
+              >
+                {showSolar ? '\u2600' : '\u263C'}
+              </button>
+            )}
+            <button className="dashboard-remove-btn" onClick={handleRemoveClick} aria-label={t('dashboard.remove_from_dashboard')}>
+              ✕
+            </button>
+          </div>
         </div>
 
         <ResponsiveContainer width="100%" height={200}>
@@ -377,7 +401,7 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
                 });
               }}
             />
-            {solarEstimates.size > 0 && (
+            {showSolar && solarEstimates.size > 0 && (
               <Area
                 yAxisId="right"
                 type="monotone"

--- a/src/components/TelemetryGraphs.css
+++ b/src/components/TelemetryGraphs.css
@@ -60,7 +60,8 @@
 }
 
 .favorite-btn,
-.graph-menu-btn {
+.graph-menu-btn,
+.solar-toggle-btn {
   background: none;
   border: none;
   font-size: 1.2rem;
@@ -76,11 +77,13 @@
 }
 
 .favorite-btn:hover,
-.graph-menu-btn:hover {
+.graph-menu-btn:hover,
+.solar-toggle-btn:hover {
   color: var(--ctp-yellow);
 }
 
-.favorite-btn.favorited {
+.favorite-btn.favorited,
+.solar-toggle-btn.active {
   color: var(--ctp-yellow);
 }
 

--- a/src/components/TelemetryGraphs.test.tsx
+++ b/src/components/TelemetryGraphs.test.tsx
@@ -10,6 +10,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import TelemetryGraphs from './TelemetryGraphs';
 import { ToastProvider } from './ToastContainer';
 import { CsrfProvider } from '../contexts/CsrfContext';
+import { SettingsProvider } from '../contexts/SettingsContext';
 
 // Create a new QueryClient for each test
 const createTestQueryClient = () =>
@@ -30,7 +31,9 @@ let testQueryClient: QueryClient;
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (
   <QueryClientProvider client={testQueryClient}>
     <CsrfProvider>
-      <ToastProvider>{children}</ToastProvider>
+      <SettingsProvider>
+        <ToastProvider>{children}</ToastProvider>
+      </SettingsProvider>
     </CsrfProvider>
   </QueryClientProvider>
 );

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3698,6 +3698,7 @@ apiRouter.post('/settings', requirePermission('settings', 'write'), (req, res) =
       'telemetryFavorites',
       'telemetryCustomOrder',
       'dashboardWidgets',
+      'dashboardSolarVisibility',
       'autoAckEnabled',
       'autoAckRegex',
       'autoAckMessage',


### PR DESCRIPTION
## Summary
- Add a sun icon toggle button to telemetry charts that allows users to show/hide the solar monitoring overlay on individual charts
- Toggle button appears next to the remove button on Dashboard charts and next to the favorite star on the Telemetry page
- Button only visible when solar monitoring is enabled in settings
- Default ON for power/environmental telemetry (battery, voltage, temperature, humidity, pressure)
- Default OFF for other telemetry types (packets, nodes, PAX, altitude, uptime)
- Dashboard toggle state persists to database for all users
- Telemetry page toggle state is session-only (per browser tab)

## Test plan
- [ ] Verify sun toggle button appears on Dashboard charts when solar monitoring is enabled
- [ ] Verify sun toggle button appears on Telemetry page charts when solar monitoring is enabled
- [ ] Verify toggling hides/shows the solar overlay on charts
- [ ] Verify Dashboard toggle state persists across page reloads
- [ ] Verify Dashboard toggle state is visible to anonymous users in other browsers
- [ ] Verify button is hidden when solar monitoring is disabled in settings
- [ ] Verify default states: ON for battery/voltage/temp, OFF for packets/nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)