### PR TITLE
feat: include public key in NodeInfo exchange packets

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -265,6 +265,8 @@
   "messages.history_title": "View traceroute history for this node",
   "messages.exchange_position": "Exchange Position",
   "messages.exchange_position_title": "Request position exchange with this node",
+  "messages.exchange_user_info": "Exchange User Info",
+  "messages.exchange_user_info_title": "Request user info exchange with this node (triggers key exchange)",
   "messages.purge_data": "Purge Data",
   "messages.ignore_node": "Ignore Node",
   "messages.ignore_node_title": "Ignore this node (hide from map node list)",

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -102,6 +102,7 @@ export interface MessagesTabProps {
   // Loading states
   tracerouteLoading: string | null;
   positionLoading: string | null;
+  nodeInfoLoading: string | null;
 
   // Settings
   timeFormat: TimeFormat;
@@ -118,11 +119,13 @@ export interface MessagesTabProps {
   handleSendDirectMessage: (destinationNodeId: string) => Promise<void>;
   handleTraceroute: (nodeId: string) => Promise<void>;
   handleExchangePosition: (nodeId: string) => Promise<void>;
+  handleExchangeNodeInfo: (nodeId: string) => Promise<void>;
   handleDeleteMessage: (message: MeshMessage) => Promise<void>;
   handleSenderClick: (nodeId: string, event: React.MouseEvent) => void;
   handleSendTapback: (emoji: string, message: MeshMessage) => void;
   getRecentTraceroute: (nodeId: string) => TracerouteData | null;
   toggleIgnored: (node: DeviceInfo, event: React.MouseEvent) => Promise<void>;
+  toggleFavorite: (node: DeviceInfo, event: React.MouseEvent) => Promise<void>;
 
   // Modal controls
   setShowTracerouteHistoryModal: (show: boolean) => void;
@@ -168,6 +171,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   setIsMessagesNodeListCollapsed,
   tracerouteLoading,
   positionLoading,
+  nodeInfoLoading,
   timeFormat,
   dateFormat,
   temperatureUnit,
@@ -178,11 +182,13 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   handleSendDirectMessage,
   handleTraceroute,
   handleExchangePosition,
+  handleExchangeNodeInfo,
   handleDeleteMessage,
   handleSenderClick,
   handleSendTapback,
   getRecentTraceroute,
   toggleIgnored,
+  toggleFavorite,
   setShowTracerouteHistoryModal,
   setShowPurgeDataModal,
   setEmojiPickerMessage,
@@ -830,6 +836,35 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                   >
                     📍 {t('messages.exchange_position')}
                     {positionLoading === selectedDMNode && <span className="spinner"></span>}
+                  </button>
+                )}
+                {hasPermission('messages', 'write') && (
+                  <button
+                    onClick={() => handleExchangeNodeInfo(selectedDMNode)}
+                    disabled={connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode}
+                    className="traceroute-btn"
+                    title={t('messages.exchange_user_info_title')}
+                  >
+                    🔑 {t('messages.exchange_user_info')}
+                    {nodeInfoLoading === selectedDMNode && <span className="spinner"></span>}
+                  </button>
+                )}
+                {hasPermission('messages', 'write') && selectedNode && (
+                  <button
+                    onClick={(e) => toggleFavorite(selectedNode, e)}
+                    className="traceroute-btn"
+                    style={{
+                      backgroundColor: selectedNode.isFavorite ? '#f5a623' : '#6c757d',
+                      color: 'white',
+                      border: 'none',
+                      padding: '0.5rem 1rem',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      fontWeight: 'bold',
+                    }}
+                    title={selectedNode.isFavorite ? t('nodes.remove_from_favorites') : t('nodes.add_to_favorites')}
+                  >
+                    {selectedNode.isFavorite ? `⭐ ${t('nodes.remove_favorite')}` : `☆ ${t('nodes.add_favorite')}`}
                   </button>
                 )}
                 {hasPermission('messages', 'write') && selectedNode && (


### PR DESCRIPTION
## Summary
- Extract local node's public key from SecurityConfig during TCP connection
- Store local node public key to database for use in NodeInfo exchanges
- Fix base64 decoding bug when including public key in outgoing packets
- Add info-level logging for outgoing and incoming NodeInfo packets with keys
- Update /api/admin/load-owner endpoint to retrieve public key from database
- Remove unused requestLocalOwner() function

When the "Exchange User Info" button is clicked, the NodeInfo packet now includes our public key, enabling proper PKC key exchange between nodes.

## Test plan
- [x] Click "Exchange User Info" button and verify outgoing packet includes public key (107 bytes)
- [x] Verify incoming NodeInfo response includes remote node's public key
- [x] Verify logs show `🔐 Including public key in NodeInfo exchange` for outgoing packets
- [x] Verify logs show `🔐 Received NodeInfo with public key for` for incoming packets
- [x] Build passes
- [x] TypeScript type checking passes

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)