### PR TITLE
feat(map): add toggle for estimated positions on map

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -98,6 +98,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     setShowMqttNodes,
     showAnimations,
     setShowAnimations,
+    showEstimatedPositions,
+    setShowEstimatedPositions,
     animatedNodes,
     triggerNodeAnimation,
     mapCenterTarget,
@@ -1226,6 +1228,14 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                     />
                     <span>Show Animations</span>
                   </label>
+                  <label className="map-control-item">
+                    <input
+                      type="checkbox"
+                      checked={showEstimatedPositions}
+                      onChange={(e) => setShowEstimatedPositions(e.target.checked)}
+                    />
+                    <span>Show Estimated Positions</span>
+                  </label>
                   {canViewPacketMonitor && packetLogEnabled && (
                     <label className="map-control-item packet-monitor-toggle">
                       <input
@@ -1267,7 +1277,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               <SpiderfierController ref={spiderfierRef} zoomLevel={mapZoom} />
               <MapLegend />
               {nodesWithPosition
-                .filter(node => (showMqttNodes || !node.viaMqtt) && (showIncompleteNodes || isNodeComplete(node)))
+                .filter(node => (showMqttNodes || !node.viaMqtt) && (showIncompleteNodes || isNodeComplete(node)) && (showEstimatedPositions || !node.user?.id || !nodesWithEstimatedPosition.has(node.user.id)))
                 .map(node => {
                 const roleNum = typeof node.user?.role === 'string'
                   ? parseInt(node.user.role, 10)
@@ -1411,7 +1421,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               })}
 
               {/* Draw uncertainty circles for estimated positions */}
-              {nodesWithPosition
+              {showEstimatedPositions && nodesWithPosition
                 .filter(node => node.user?.id && nodesWithEstimatedPosition.has(node.user.id))
                 .map(node => {
                   // Calculate radius based on precision bits (higher precision = smaller circle)

--- a/src/contexts/MapContext.tsx
+++ b/src/contexts/MapContext.tsx
@@ -33,6 +33,8 @@ interface MapContextType {
   setShowMqttNodes: (show: boolean) => void;
   showAnimations: boolean;
   setShowAnimations: (show: boolean) => void;
+  showEstimatedPositions: boolean;
+  setShowEstimatedPositions: (show: boolean) => void;
   animatedNodes: Set<string>;
   triggerNodeAnimation: (nodeId: string) => void;
   mapCenterTarget: [number, number] | null;
@@ -67,6 +69,7 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
   const [showMotion, setShowMotionState] = useState<boolean>(true);
   const [showMqttNodes, setShowMqttNodesState] = useState<boolean>(true);
   const [showAnimations, setShowAnimationsState] = useState<boolean>(false);
+  const [showEstimatedPositions, setShowEstimatedPositionsState] = useState<boolean>(true);
   const [animatedNodes, setAnimatedNodes] = useState<Set<string>>(new Set());
   const [mapCenterTarget, setMapCenterTarget] = useState<[number, number] | null>(null);
   const [mapCenter, setMapCenter] = useState<[number, number] | null>(() => {
@@ -125,6 +128,11 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
   const setShowAnimations = React.useCallback((value: boolean) => {
     setShowAnimationsState(value);
     savePreferenceToServer({ showAnimations: value });
+  }, []);
+
+  const setShowEstimatedPositions = React.useCallback((value: boolean) => {
+    setShowEstimatedPositionsState(value);
+    savePreferenceToServer({ showEstimatedPositions: value });
   }, []);
 
   // Helper function to save preference to server
@@ -192,6 +200,9 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
             if (preferences.showAnimations !== undefined) {
               setShowAnimationsState(preferences.showAnimations);
             }
+            if (preferences.showEstimatedPositions !== undefined) {
+              setShowEstimatedPositionsState(preferences.showEstimatedPositions);
+            }
           }
           // If preferences is null (anonymous user), initial defaults are already set
         }
@@ -247,6 +258,8 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
         setShowMqttNodes,
         showAnimations,
         setShowAnimations,
+        showEstimatedPositions,
+        setShowEstimatedPositions,
         animatedNodes,
         triggerNodeAnimation,
         mapCenterTarget,


### PR DESCRIPTION
## Summary
- Adds a "Show Estimated Positions" checkbox to the Map Features panel
- When unchecked, hides nodes that only have estimated positions (no real GPS)
- When unchecked, hides uncertainty circles for estimated positions
- Default is ON (backward compatible)
- Preference is persisted to server for logged-in users

## Test plan
- [x] Build and deploy container locally
- [x] Verify checkbox appears in Map Features panel
- [x] Verify unchecking hides nodes with only estimated positions
- [x] Verify uncertainty circles are hidden when toggle is off
- [x] Run system tests (all passing)

## System Test Results
```
Configuration Import:     ✓ PASSED
Quick Start Test:         ✓ PASSED
Security Test:            ✓ PASSED
Reverse Proxy Test:       ✓ PASSED
Reverse Proxy + OIDC:     ✓ PASSED
Virtual Node CLI Test:    ✓ PASSED
Backup & Restore Test:    ✓ PASSED

==========================================
✓ ALL SYSTEM TESTS PASSED
==========================================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)