### PR TITLE
feat(info): add Secrets section displaying node public/private keys

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1377,6 +1377,11 @@
   "info.device_config_unavailable": "Device configuration not available. Ensure connection is established.",
   "info.local_telemetry": "Local Node Telemetry",
 
+  "info.secrets": "Secrets",
+  "info.public_key": "Public Key:",
+  "info.private_key": "Private Key:",
+  "info.secrets_unavailable": "Security keys not available",
+
   "config.loading": "Loading configuration...",
   "config.warning_title": "WARNING",
   "config.warning_text": "Modifying these settings can break your Meshtastic node configuration.",

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1098,6 +1098,29 @@ class MeshtasticManager {
   }
 
   /**
+   * Get the local node's security keys (public and private)
+   * Private key is only available for the local node from the security config
+   * Returns base64-encoded keys
+   */
+  getSecurityKeys(): { publicKey: string | null; privateKey: string | null } {
+    const security = this.actualDeviceConfig?.security;
+    let publicKey: string | null = null;
+    let privateKey: string | null = null;
+
+    if (security) {
+      // Convert Uint8Array to base64 if present
+      if (security.publicKey && security.publicKey.length > 0) {
+        publicKey = Buffer.from(security.publicKey).toString('base64');
+      }
+      if (security.privateKey && security.privateKey.length > 0) {
+        privateKey = Buffer.from(security.privateKey).toString('base64');
+      }
+    }
+
+    return { publicKey, privateKey };
+  }
+
+  /**
    * Get the current device configuration
    */
   getCurrentConfig(): { deviceConfig: any; moduleConfig: any; localNodeInfo: any } {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2658,6 +2658,18 @@ apiRouter.get('/device/tx-status', optionalAuth(), async (_req, res) => {
   }
 });
 
+// Get security keys (public and private) for the local node
+// Private key is sensitive - requires authentication
+apiRouter.get('/device/security-keys', requireAuth(), async (_req, res) => {
+  try {
+    const keys = meshtasticManager.getSecurityKeys();
+    res.json(keys);
+  } catch (error) {
+    logger.error('Error getting security keys:', error);
+    res.status(500).json({ error: 'Failed to get security keys' });
+  }
+});
+
 // Consolidated polling endpoint - reduces multiple API calls to one
 apiRouter.get('/poll', optionalAuth(), async (req, res) => {
   logger.info('🔔 [POLL] Endpoint called');

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1039,6 +1039,19 @@ class ApiService {
     return response.json();
   }
 
+  async getSecurityKeys(): Promise<{ publicKey: string | null; privateKey: string | null }> {
+    await this.ensureBaseUrl();
+    const response = await fetch(`${this.baseUrl}/api/device/security-keys`, {
+      credentials: 'include'
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch security keys');
+    }
+
+    return response.json();
+  }
+
   async fetchLinkPreview(url: string) {
     await this.ensureBaseUrl();
     const response = await fetch(`${this.baseUrl}/api/link-preview?url=${encodeURIComponent(url)}`, {


### PR DESCRIPTION
## Summary
- Adds a new "Secrets" section to the Device Info page
- Displays the local node's public and private keys as base64-encoded read-only fields
- Only visible to authenticated users
- Keys are fetched from the device's security configuration

## Test plan
- [x] Build and deploy container
- [x] Verify Secrets section appears after MQTT Config section when authenticated
- [x] Verify keys display correctly in read-only input fields
- [x] Verify section is hidden for unauthenticated users
- [x] Verify API returns 401 for unauthenticated requests
- [x] System tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)