### PR TITLE
fix(notifications): allow saving preferences with no channels enabled

### DIFF
--- a/src/components/NotificationsTab.tsx
+++ b/src/components/NotificationsTab.tsx
@@ -182,10 +182,6 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
     try {
       const response = await api.get<NotificationPreferences>('/api/push/preferences');
 
-      if (response.enabledChannels.length === 0 && channels.length > 0) {
-        response.enabledChannels = channels.map(c => c.id);
-      }
-
       setPreferences(response);
       setWhitelistText(response.whitelist.join('\n'));
       setBlacklistText(response.blacklist.join('\n'));


### PR DESCRIPTION
## Summary
- Remove auto-populate logic that re-enabled all channels on page load when enabledChannels was empty
- This was preventing users from saving a configuration with all notification channels disabled

## Problem
When a user unchecked all notification channels and clicked Save, the preferences would save correctly to the database. However, on next page load, the `loadPreferences` function had code that would detect the empty `enabledChannels` array and automatically re-populate it with all available channels. This made it impossible to have no channels enabled.

## Test plan
- [x] Go to Notifications page
- [x] Uncheck all channel notification checkboxes
- [x] Click Save
- [x] Refresh the page
- [x] Verify all channels remain unchecked

🤖 Generated with [Claude Code](https://claude.com/claude-code)