### PR TITLE
docs: add MeshManager Solar Forecast to user scripts gallery

### DIFF
--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -247,5 +247,27 @@
       "Powered by api.weather.gov (US National Weather Service)",
       "No API key required"
     ]
+  },
+  {
+    "name": "MeshManager Solar Forecast",
+    "filename": "solar-forecast.py",
+    "icon": "☀️",
+    "description": "Query MeshManager's solar forecast API and return an abbreviated summary with today's solar production forecast, percentage of historical average, and nodes at risk of low battery.",
+    "language": "Python",
+    "tags": ["Solar", "Forecast", "MeshManager", "Battery", "Monitoring"],
+    "githubPath": "Yeraze/meshmanager/main/examples/auto-responder-scripts/solar-forecast.py",
+    "exampleTrigger": "solar, forecast, sun",
+    "requirements": [
+      "Python 3.6+",
+      "MeshManager instance accessible via network",
+      "MESHMANAGER_URL environment variable"
+    ],
+    "author": "Yeraze",
+    "features": [
+      "Solar production forecast for today",
+      "Percentage of historical average output",
+      "Identifies nodes at risk of low battery",
+      "Formatted for mesh network 200-char limit"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

- Adds MeshManager Solar Forecast script to the User Scripts Gallery
- Script queries MeshManager's solar forecast API for today's solar production forecast
- Shows percentage of historical average output and identifies nodes at risk of low battery

Closes #1041

## Test plan

- [ ] Verify the script appears in the User Scripts Gallery
- [ ] Verify the GitHub link correctly resolves to the script file
- [ ] Test that all script metadata displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)