### PR TITLE
fix(ui): persist toggle settings in localStorage

### DIFF
--- a/src/contexts/MapContext.tsx
+++ b/src/contexts/MapContext.tsx
@@ -69,7 +69,10 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
   const [showMotion, setShowMotionState] = useState<boolean>(true);
   const [showMqttNodes, setShowMqttNodesState] = useState<boolean>(true);
   const [showAnimations, setShowAnimationsState] = useState<boolean>(false);
-  const [showEstimatedPositions, setShowEstimatedPositionsState] = useState<boolean>(true);
+  const [showEstimatedPositions, setShowEstimatedPositionsState] = useState<boolean>(() => {
+    const saved = localStorage.getItem('showEstimatedPositions');
+    return saved !== null ? saved === 'true' : true; // Default to true
+  });
   const [animatedNodes, setAnimatedNodes] = useState<Set<string>>(new Set());
   const [mapCenterTarget, setMapCenterTarget] = useState<[number, number] | null>(null);
   const [mapCenter, setMapCenter] = useState<[number, number] | null>(() => {
@@ -132,6 +135,7 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
 
   const setShowEstimatedPositions = React.useCallback((value: boolean) => {
     setShowEstimatedPositionsState(value);
+    localStorage.setItem('showEstimatedPositions', value.toString());
     savePreferenceToServer({ showEstimatedPositions: value });
   }, []);
 

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -120,7 +120,10 @@ const updateHash = (tab: TabType) => {
 export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
   // Initialize activeTab from URL hash, or default to 'nodes'
   const [activeTab, setActiveTab] = useState<TabType>(() => getTabFromHash());
-  const [showMqttMessages, setShowMqttMessages] = useState<boolean>(false);
+  const [showMqttMessagesState, setShowMqttMessagesState] = useState<boolean>(() => {
+    const saved = localStorage.getItem('showMqttMessages');
+    return saved !== null ? saved === 'true' : false; // Default to false
+  });
   const [error, setError] = useState<string | null>(null);
   const [tracerouteLoading, setTracerouteLoading] = useState<string | null>(null);
   const [nodeFilter, setNodeFilter] = useState<string>(''); // Deprecated - kept for backward compatibility
@@ -178,6 +181,15 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
   // Default to hiding ignored nodes
   const [showIgnoredNodes, setShowIgnoredNodes] = useState<boolean>(false);
 
+  // Wrapper setter for showMqttMessages that persists to localStorage
+  const setShowMqttMessages = React.useCallback((value: React.SetStateAction<boolean>) => {
+    setShowMqttMessagesState(prevValue => {
+      const newValue = typeof value === 'function' ? value(prevValue) : value;
+      localStorage.setItem('showMqttMessages', newValue.toString());
+      return newValue;
+    });
+  }, []);
+
   // Sync activeTab to URL hash when activeTab changes
   useEffect(() => {
     updateHash(activeTab);
@@ -199,7 +211,7 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
       value={{
         activeTab,
         setActiveTab,
-        showMqttMessages,
+        showMqttMessages: showMqttMessagesState,
         setShowMqttMessages,
         error,
         setError,


### PR DESCRIPTION
## Summary
- Show Estimated Positions on Map now persists via localStorage (fixes #1052)
- Show MQTT Messages on Channels now persists via localStorage

## Changes
- **MapContext.tsx**: Added localStorage initialization and persistence for `showEstimatedPositions`
- **UIContext.tsx**: Added localStorage initialization and wrapper setter for `showMqttMessages`

## Behavior
- Both settings now load from localStorage on page load
- Changes are saved to localStorage immediately when toggled
- For logged-in users, server preferences still take priority when available
- Anonymous users and first-time visitors get consistent defaults

## Test plan
- [ ] Toggle "Show Estimated Positions" on Map, refresh page - setting should persist
- [ ] Toggle "Show MQTT Messages" on Channels, refresh page - setting should persist
- [ ] Clear localStorage and verify defaults work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)