### PR TITLE
docs: fix Packet Monitor location in documentation

### DIFF
--- a/docs/features/packet-monitor.md
+++ b/docs/features/packet-monitor.md
@@ -4,7 +4,7 @@ The Packet Monitor is a diagnostic tool that displays raw Meshtastic packets as 
 
 ## Accessing the Packet Monitor
 
-The Packet Monitor is available in the Admin tab and requires appropriate permissions to view.
+The Packet Monitor appears at the bottom of the Map tab once enabled in Settings. It requires appropriate permissions to view.
 
 ## What the Packet Monitor Shows
 


### PR DESCRIPTION
## Summary
- Corrects documentation to state that Packet Monitor appears at the bottom of the Map tab (once enabled in Settings), not in the Admin tab

Fixes #1050

## Test plan
- [ ] Verify documentation renders correctly on docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)