### PR TITLE
feat(ui): add Script Gallery link to Script Management section

### DIFF
--- a/src/components/auto-responder/ScriptManagement.tsx
+++ b/src/components/auto-responder/ScriptManagement.tsx
@@ -126,6 +126,26 @@ const ScriptManagement: React.FC<ScriptManagementProps> = ({
                 </button>
               </>
             )}
+            <a
+              href="https://meshmonitor.org/user-scripts.html"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                padding: '0.5rem 1rem',
+                fontSize: '0.875rem',
+                background: 'var(--ctp-mauve)',
+                color: 'var(--ctp-base)',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                fontWeight: 'bold',
+                textDecoration: 'none',
+                display: 'inline-flex',
+                alignItems: 'center'
+              }}
+            >
+              Script Gallery
+            </a>
           </div>
 
           {availableScripts.length === 0 ? (


### PR DESCRIPTION
## Summary

- Adds a "Script Gallery" button to the Automation tab's Script Management section
- Links to the community script gallery at https://meshmonitor.org/user-scripts.html
- Opens in a new tab with proper `rel="noopener noreferrer"` for security
- Button styled consistently with other action buttons (Import Script, Export Scripts)

## Test plan

- [ ] Open Automation tab and expand Script Management section
- [ ] Verify "Script Gallery" button appears in the button row
- [ ] Click the button and verify it opens meshmonitor.org/user-scripts.html in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)