### PR TITLE
feat(ui): display node public key in Node Details

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1962,6 +1962,7 @@
   "node_details.connection": "Connection",
   "node_details.via_mqtt": "Via MQTT",
   "node_details.last_heard": "Last Heard",
+  "node_details.public_key": "Public Key",
 
   "messages.hops_one": "{{count}} hop",
   "messages.hops_other": "{{count}} hops",

--- a/src/components/NodeDetailsBlock.css
+++ b/src/components/NodeDetailsBlock.css
@@ -121,6 +121,20 @@
   color: var(--ctp-red);
 }
 
+/* Wide card styling - spans full width */
+.node-detail-card-wide {
+  grid-column: 1 / -1;
+}
+
+/* Public key styling */
+.node-detail-public-key {
+  font-family: monospace;
+  font-size: 0.85rem;
+  word-break: break-all;
+  user-select: all;
+  cursor: text;
+}
+
 /* Hardware Image Styling */
 .node-detail-card-hardware {
   /* Make hardware card larger to accommodate image */

--- a/src/components/NodeDetailsBlock.tsx
+++ b/src/components/NodeDetailsBlock.tsx
@@ -146,6 +146,7 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
   const { deviceMetrics, snr, rssi, lastHeard, hopsAway, viaMqtt, user, firmwareVersion } = node;
   const hwModel = user?.hwModel;
   const role = user?.role;
+  const publicKey = user?.publicKey;
   const hardwareImageUrl = getHardwareImageUrl(hwModel);
 
   return (
@@ -284,6 +285,16 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
             <div className="node-detail-label">{t('node_details.firmware')}</div>
             <div className="node-detail-value">
               {firmwareVersion}
+            </div>
+          </div>
+        )}
+
+        {/* Public Key */}
+        {publicKey && (
+          <div className="node-detail-card node-detail-card-wide">
+            <div className="node-detail-label">{t('node_details.public_key')}</div>
+            <div className="node-detail-value node-detail-public-key" title={publicKey}>
+              {publicKey}
             </div>
           </div>
         )}

--- a/src/types/device.ts
+++ b/src/types/device.ts
@@ -6,6 +6,7 @@ export interface DeviceInfo {
     shortName?: string
     hwModel?: number
     role?: string
+    publicKey?: string
   }
   position?: {
     latitude: number


### PR DESCRIPTION
## Summary
- Adds the node's public key (PKC) to the Node Details panel when available
- Displays in a full-width card with monospace font for readability
- Users can select the entire key by clicking (user-select: all)
- Key is shown with word-break for long keys

## Changes
- `src/types/device.ts`: Added `publicKey` to `DeviceInfo.user` interface
- `src/components/NodeDetailsBlock.tsx`: Added public key display card
- `src/components/NodeDetailsBlock.css`: Added styles for wide card and public key formatting
- `public/locales/en.json`: Added translation key `node_details.public_key`

## Test plan
- [ ] View a node with PKC enabled - public key should appear in Node Details
- [ ] View a node without PKC - public key field should not appear
- [ ] Click on public key text - should select entire key for copying
- [ ] TypeScript compilation passes

Closes #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)