### PR TITLE
fix(ui): include publicKey in poll response and resize card

### DIFF
--- a/src/components/NodeDetailsBlock.css
+++ b/src/components/NodeDetailsBlock.css
@@ -126,6 +126,11 @@
   grid-column: 1 / -1;
 }
 
+/* 2-column card styling - spans 2 columns */
+.node-detail-card-2col {
+  grid-column: span 2;
+}
+
 /* Public key styling */
 .node-detail-public-key {
   font-family: monospace;
@@ -177,7 +182,8 @@
     font-size: 1rem;
   }
 
-  .node-detail-card-hardware {
+  .node-detail-card-hardware,
+  .node-detail-card-2col {
     grid-column: span 1;
   }
 

--- a/src/components/NodeDetailsBlock.tsx
+++ b/src/components/NodeDetailsBlock.tsx
@@ -291,7 +291,7 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
 
         {/* Public Key */}
         {publicKey && (
-          <div className="node-detail-card node-detail-card-wide">
+          <div className="node-detail-card node-detail-card-2col">
             <div className="node-detail-label">{t('node_details.public_key')}</div>
             <div className="node-detail-value node-detail-public-key" title={publicKey}>
               {publicKey}

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7521,7 +7521,8 @@ class MeshtasticManager {
           id: node.nodeId,
           longName: node.longName || '',
           shortName: node.shortName || '',
-          hwModel: node.hwModel
+          hwModel: node.hwModel,
+          publicKey: node.publicKey
         },
         deviceMetrics: {
           batteryLevel: node.batteryLevel,


### PR DESCRIPTION
## Summary
- Fixed public key not showing in Node Details panel by adding `publicKey` to user object in `getAllNodes()` method
- Changed Public Key card from full-width to 2-column layout (matching the Hardware card size)
- Added responsive CSS for mobile view

## Context
Follow-up to #1061 - the Public Key field was added to the UI component but wasn't being returned from the `/api/poll` endpoint which the frontend uses for node data.

## Test plan
- [x] Verified public key appears in Node Details panel for nodes with keys
- [x] Verified card size matches Hardware card (2-column span)
- [x] Build succeeds
- CI tests will run automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)