### PR TITLE
fix(traceroute): improve position estimation with SNR weighting and time decay

### DIFF
--- a/src/server/migrations/038_recalculate_estimated_positions.ts
+++ b/src/server/migrations/038_recalculate_estimated_positions.ts
@@ -1,0 +1,42 @@
+/**
+ * Migration: Recalculate estimated positions
+ *
+ * This migration clears all existing estimated positions and sets a flag
+ * to trigger recalculation from historical traceroutes on next startup.
+ * The new algorithm aggregates multiple traceroutes with time-weighted averaging
+ * for more accurate position estimation.
+ */
+import Database from 'better-sqlite3';
+
+export const migration = {
+  up: (db: Database.Database): void => {
+    // Delete all existing estimated position telemetry records
+    // This forces a clean recalculation with the new algorithm
+    const deleteStmt = db.prepare(`
+      DELETE FROM telemetry
+      WHERE telemetryType IN ('estimated_latitude', 'estimated_longitude')
+    `);
+    const result = deleteStmt.run();
+
+    // Log how many records were deleted (available in console if debug enabled)
+    console.log(`Migration 038: Deleted ${result.changes} estimated position telemetry records`);
+
+    // Set a flag to indicate that historical positions need to be recalculated
+    // This will be checked on startup by the MeshtasticManager
+    const now = Date.now();
+    const flagStmt = db.prepare(`
+      INSERT OR REPLACE INTO settings (key, value, createdAt, updatedAt)
+      VALUES ('recalculate_estimated_positions', 'pending', ?, ?)
+    `);
+    flagStmt.run(now, now);
+  },
+
+  down: (db: Database.Database): void => {
+    // Remove the recalculation flag
+    // Note: Deleted telemetry records cannot be recovered
+    const stmt = db.prepare(`
+      DELETE FROM settings WHERE key = 'recalculate_estimated_positions'
+    `);
+    stmt.run();
+  }
+};

--- a/src/server/migrations/039_recalculate_estimated_positions_fix.ts
+++ b/src/server/migrations/039_recalculate_estimated_positions_fix.ts
@@ -1,0 +1,38 @@
+/**
+ * Migration: Recalculate estimated positions (fix)
+ *
+ * This migration clears all existing estimated positions and triggers
+ * recalculation to fix an issue where the route order was reversed
+ * in the initial implementation.
+ */
+import Database from 'better-sqlite3';
+
+export const migration = {
+  up: (db: Database.Database): void => {
+    // Delete all existing estimated position telemetry records
+    // These were calculated with reversed route order
+    const deleteStmt = db.prepare(`
+      DELETE FROM telemetry
+      WHERE telemetryType IN ('estimated_latitude', 'estimated_longitude')
+    `);
+    const result = deleteStmt.run();
+
+    console.log(`Migration 039: Deleted ${result.changes} estimated position telemetry records (fix)`);
+
+    // Set the recalculation flag to pending to trigger recalculation
+    const now = Date.now();
+    const flagStmt = db.prepare(`
+      INSERT OR REPLACE INTO settings (key, value, createdAt, updatedAt)
+      VALUES ('recalculate_estimated_positions', 'pending', ?, ?)
+    `);
+    flagStmt.run(now, now);
+  },
+
+  down: (db: Database.Database): void => {
+    // Note: Deleted telemetry records cannot be recovered
+    const stmt = db.prepare(`
+      DELETE FROM settings WHERE key = 'recalculate_estimated_positions'
+    `);
+    stmt.run();
+  }
+};


### PR DESCRIPTION
## Summary

- **Fixed critical bug** where timestamp handling in time-weighted averaging caused NaN positions and NOT NULL constraint failures (timestamps were being multiplied by 1000 when already in milliseconds)
- Added **SNR-based weighting** for position estimation using signal strength from traceroute data
- Implemented **time-weighted averaging** with 24-hour half-life, giving more weight to recent traceroutes
- Added migrations to clear and recalculate existing estimated positions with the improved algorithm

## Changes

### Bug Fix
The time-weighted averaging code at `meshtasticManager.ts:3143` was incorrectly multiplying telemetry timestamps by 1000, when they're already stored in milliseconds. This caused:
- Age calculations to be negative (~55,940 years in the "future")
- `Math.exp()` to return `Infinity`
- `finalLat/finalLon` to become `NaN`
- SQL NOT NULL constraint failures

### New Features
- SNR-weighted position estimation places nodes more accurately between neighbors based on signal strength
- Time-weighted averaging aggregates multiple traceroutes, with recent data weighted more heavily
- Historical recalculation on startup when triggered by migration

### Database Changes
- Added `getRecentEstimatedPositions()` method for fetching historical estimates
- Added `getAllTraceroutesForRecalculation()` for migration support
- Migrations 038 and 039 clear old estimates and trigger recalculation

## Test plan
- [x] Verified position estimation updates in real-time when running traceroutes
- [x] Confirmed no more NOT NULL errors in logs
- [x] Tested with SDGMRS Brickell node - positions now update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)