### PR TITLE
feat(ui): add Show on Map button to Messages tab and node popup

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -261,6 +261,8 @@
   "messages.dm_placeholder": "Send direct message to {{name}}...",
   "messages.traceroute_button": "Traceroute",
   "messages.traceroute_title": "Run traceroute to this node",
+  "messages.show_on_map": "Show on Map",
+  "messages.show_on_map_title": "Show this node on the map",
   "messages.history_button": "Show History",
   "messages.history_title": "View traceroute history for this node",
   "messages.exchange_position": "Exchange Position",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4192,6 +4192,14 @@ function App() {
             dmMessagesContainerRef={dmMessagesContainerRef}
             toggleIgnored={toggleIgnored}
             toggleFavorite={toggleFavorite}
+            handleShowOnMap={(nodeId: string) => {
+              const node = nodes.find((n) => n.user?.id === nodeId);
+              if (node?.position?.latitude != null && node?.position?.longitude != null) {
+                setSelectedNodeId(nodeId);
+                setMapCenterTarget([node.position.latitude, node.position.longitude]);
+                setActiveTab('nodes');
+              }
+            }}
           />
         )}
         {activeTab === 'info' && (
@@ -4463,6 +4471,19 @@ function App() {
                   }}
                 >
                   💬 Direct Message
+                </button>
+              )}
+              {node.user?.id && node.position?.latitude != null && node.position?.longitude != null && (
+                <button
+                  className="popup-dm-btn"
+                  onClick={() => {
+                    setSelectedNodeId(node.user!.id);
+                    setMapCenterTarget([node.position!.latitude!, node.position!.longitude!]);
+                    setActiveTab('nodes');
+                    setNodePopup(null);
+                  }}
+                >
+                  🗺️ Show on Map
                 </button>
               )}
             </div>

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -135,6 +135,9 @@ export interface MessagesTabProps {
   // Helper function
   shouldShowData: () => boolean;
 
+  // Navigation
+  handleShowOnMap: (nodeId: string) => void;
+
   // Refs from parent for scroll handling
   dmMessagesContainerRef: React.RefObject<HTMLDivElement | null>;
 }
@@ -193,6 +196,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   setShowPurgeDataModal,
   setEmojiPickerMessage,
   shouldShowData,
+  handleShowOnMap,
   dmMessagesContainerRef,
 }) => {
   const { t } = useTranslation();
@@ -883,6 +887,15 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                     title={selectedNode.isIgnored ? t('messages.unignore_node_title') : t('messages.ignore_node_title')}
                   >
                     {selectedNode.isIgnored ? t('messages.unignore_node') : t('messages.ignore_node')}
+                  </button>
+                )}
+                {selectedNode?.position?.latitude != null && selectedNode?.position?.longitude != null && (
+                  <button
+                    onClick={() => handleShowOnMap(selectedDMNode)}
+                    className="traceroute-btn"
+                    title={t('messages.show_on_map_title')}
+                  >
+                    🗺️ {t('messages.show_on_map')}
                   </button>
                 )}
                 {hasPermission('messages', 'write') && (


### PR DESCRIPTION
## Summary

- Adds a "Show on Map" button to the node popup (appears when clicking sender dots in Channels/Messages tabs)
- Adds a "Show on Map" button to the Messages tab button bar (for DM conversations)
- Buttons only appear when the node has valid position data (latitude/longitude)
- Clicking navigates to the Nodes/Map tab with the node selected and centered

Closes #1065

## Test plan

- [ ] Build completes successfully
- [ ] Click on a sender dot in the Channels tab - verify "Show on Map" button appears in popup (if node has position)
- [ ] Click "Show on Map" in node popup - verify it navigates to Map tab with node centered
- [ ] Select a DM conversation with a node that has position data
- [ ] Verify "Show on Map" button appears in the Messages tab button bar
- [ ] Click "Show on Map" in Messages tab - verify it navigates to Map tab with node centered
- [ ] Verify buttons do not appear for nodes without position data

## System Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| Reverse Proxy Test | ✅ PASSED |
| Reverse Proxy + OIDC | ✅ PASSED |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)