### PR TITLE
fix(docs): correct azimuth values in solar monitoring documentation

### DIFF
--- a/docs/features/solar-monitoring.md
+++ b/docs/features/solar-monitoring.md
@@ -25,11 +25,12 @@ To enable solar monitoring, navigate to **Settings** and configure the following
   - 0° = Horizontal (flat)
   - 90° = Vertical
   - Most installations use 20-40° depending on latitude
-- **Azimuth**: Compass direction your panels face (0-360 degrees)
-  - 0° = North
-  - 90° = East
-  - 180° = South (optimal in Northern Hemisphere)
-  - 270° = West
+- **Azimuth**: Compass direction your panels face (-180 to 180 degrees)
+  - -180° = North
+  - -90° = East
+  - 0° = South (optimal in Northern Hemisphere)
+  - 90° = West
+  - 180° = North
 
 #### Additional Configuration Details
 


### PR DESCRIPTION
## Summary
- Corrects the azimuth parameter documentation to match the official forecast.solar API specification
- Changes range from incorrect `0-360` to correct `-180 to 180`
- Fixes compass direction mapping: `0 = South` (not North) per [forecast.solar API docs](https://doc.forecast.solar/api:estimate)

The actual application code (SettingsTab.tsx, locale files) was already correct - only the documentation was wrong.

## Test plan
- [ ] Documentation-only change, no functional impact
- [ ] Verify published docs at meshmonitor.org/features/solar-monitoring.html after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)