### PR TITLE
feat(config): add Transmit over LoRa option to Neighbor Info settings

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2070,6 +2070,8 @@
   "neighbor_info.enable_description": "Broadcast neighbor information to the mesh",
   "neighbor_info.interval": "Update Interval (seconds)",
   "neighbor_info.interval_description": "How often to send neighbor info (minimum: 14400 = 4 hours)",
+  "neighbor_info.transmit_over_lora": "Transmit over LoRa",
+  "neighbor_info.transmit_over_lora_description": "Broadcast neighbor info over LoRa in addition to MQTT and Phone API. Not available on channels with default key/name.",
   "neighbor_info.save_button": "Save NeighborInfo Config",
 
   "network_config.title": "Network Configuration",

--- a/public/locales/zh_Hans.json
+++ b/public/locales/zh_Hans.json
@@ -1934,6 +1934,8 @@
     "neighbor_info.enable_description": "向网格广播邻居信息",
     "neighbor_info.interval": "NeighborInfo 间隔（秒）",
     "neighbor_info.interval_description": "范围：14400-4294967295（默认：3600 = 1 小时，最小：14400 秒）",
+    "neighbor_info.transmit_over_lora": "通过 LoRa 传输",
+    "neighbor_info.transmit_over_lora_description": "除 MQTT 和手机 API 外，还通过 LoRa 广播邻居信息。在使用默认密钥/名称的频道上不可用。",
     "neighbor_info.save_button": "保存 NeighborInfo 配置",
     "network_config.title": "网络配置",
     "network_config.view_docs": "查看网络配置文档",

--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -74,6 +74,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
   // NeighborInfo Config State
   const [neighborInfoEnabled, setNeighborInfoEnabled] = useState(false);
   const [neighborInfoInterval, setNeighborInfoInterval] = useState(14400);
+  const [neighborInfoTransmitOverLora, setNeighborInfoTransmitOverLora] = useState(false);
 
   // Network Config State - store full config to avoid wiping fields when saving
   const [wifiEnabled, setWifiEnabled] = useState(false);
@@ -197,6 +198,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
         if (config.moduleConfig?.neighborInfo) {
           setNeighborInfoEnabled(config.moduleConfig.neighborInfo.enabled || false);
           setNeighborInfoInterval(config.moduleConfig.neighborInfo.updateInterval || 14400);
+          setNeighborInfoTransmitOverLora(config.moduleConfig.neighborInfo.transmitOverLora || false);
         }
 
         // Populate Network config - store full config to preserve all fields when saving
@@ -427,7 +429,8 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
 
       await apiService.setNeighborInfoConfig({
         enabled: neighborInfoEnabled,
-        updateInterval: validInterval
+        updateInterval: validInterval,
+        transmitOverLora: neighborInfoTransmitOverLora
       });
       setStatusMessage(t('config.neighbor_saved'));
       showToast(t('config.neighbor_saved_toast'), 'success');
@@ -761,6 +764,8 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
             setNeighborInfoEnabled={setNeighborInfoEnabled}
             neighborInfoInterval={neighborInfoInterval}
             setNeighborInfoInterval={setNeighborInfoInterval}
+            neighborInfoTransmitOverLora={neighborInfoTransmitOverLora}
+            setNeighborInfoTransmitOverLora={setNeighborInfoTransmitOverLora}
             isSaving={isSaving}
             onSave={handleSaveNeighborInfoConfig}
           />

--- a/src/components/configuration/NeighborInfoSection.tsx
+++ b/src/components/configuration/NeighborInfoSection.tsx
@@ -4,8 +4,10 @@ import { useTranslation } from 'react-i18next';
 interface NeighborInfoSectionProps {
   neighborInfoEnabled: boolean;
   neighborInfoInterval: number;
+  neighborInfoTransmitOverLora: boolean;
   setNeighborInfoEnabled: (value: boolean) => void;
   setNeighborInfoInterval: (value: number) => void;
+  setNeighborInfoTransmitOverLora: (value: boolean) => void;
   isSaving: boolean;
   onSave: () => Promise<void>;
 }
@@ -13,8 +15,10 @@ interface NeighborInfoSectionProps {
 const NeighborInfoSection: React.FC<NeighborInfoSectionProps> = ({
   neighborInfoEnabled,
   neighborInfoInterval,
+  neighborInfoTransmitOverLora,
   setNeighborInfoEnabled,
   setNeighborInfoInterval,
+  setNeighborInfoTransmitOverLora,
   isSaving,
   onSave
 }) => {
@@ -54,21 +58,38 @@ const NeighborInfoSection: React.FC<NeighborInfoSectionProps> = ({
         </label>
       </div>
       {neighborInfoEnabled && (
-        <div className="setting-item">
-          <label htmlFor="neighborInfoInterval">
-            {t('neighbor_info.interval')}
-            <span className="setting-description">{t('neighbor_info.interval_description')}</span>
-          </label>
-          <input
-            id="neighborInfoInterval"
-            type="number"
-            min="14400"
-            max="86400"
-            value={neighborInfoInterval}
-            onChange={(e) => setNeighborInfoInterval(parseInt(e.target.value))}
-            className="setting-input"
-          />
-        </div>
+        <>
+          <div className="setting-item">
+            <label htmlFor="neighborInfoInterval">
+              {t('neighbor_info.interval')}
+              <span className="setting-description">{t('neighbor_info.interval_description')}</span>
+            </label>
+            <input
+              id="neighborInfoInterval"
+              type="number"
+              min="14400"
+              max="86400"
+              value={neighborInfoInterval}
+              onChange={(e) => setNeighborInfoInterval(parseInt(e.target.value))}
+              className="setting-input"
+            />
+          </div>
+          <div className="setting-item">
+            <label htmlFor="neighborInfoTransmitOverLora" style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+              <input
+                id="neighborInfoTransmitOverLora"
+                type="checkbox"
+                checked={neighborInfoTransmitOverLora}
+                onChange={(e) => setNeighborInfoTransmitOverLora(e.target.checked)}
+                style={{ marginTop: '0.2rem', flexShrink: 0 }}
+              />
+              <div style={{ flex: 1 }}>
+                <div>{t('neighbor_info.transmit_over_lora')}</div>
+                <span className="setting-description">{t('neighbor_info.transmit_over_lora_description')}</span>
+              </div>
+            </label>
+          </div>
+        </>
       )}
       <button
         className="save-button"

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1213,6 +1213,10 @@ class MeshtasticManager {
               parsed.data.neighborInfo.enabled = false;
               logger.info('📊 Set neighborInfo.enabled to false (was undefined - Proto3 default)');
             }
+            if (parsed.data.neighborInfo.transmitOverLora === undefined) {
+              parsed.data.neighborInfo.transmitOverLora = false;
+              logger.info('📊 Set neighborInfo.transmitOverLora to false (was undefined - Proto3 default)');
+            }
 
             // Ensure numeric fields have explicit values (Proto3 omits 0)
             if (parsed.data.neighborInfo.updateInterval === undefined) {
@@ -1532,7 +1536,8 @@ class MeshtasticManager {
         ...moduleConfig.neighborInfo,
         // IMPORTANT: Proto3 omits boolean false and numeric 0 values from JSON serialization
         enabled: moduleConfig.neighborInfo.enabled !== undefined ? moduleConfig.neighborInfo.enabled : false,
-        updateInterval: moduleConfig.neighborInfo.updateInterval !== undefined ? moduleConfig.neighborInfo.updateInterval : 0
+        updateInterval: moduleConfig.neighborInfo.updateInterval !== undefined ? moduleConfig.neighborInfo.updateInterval : 0,
+        transmitOverLora: moduleConfig.neighborInfo.transmitOverLora !== undefined ? moduleConfig.neighborInfo.transmitOverLora : false
       };
 
       moduleConfig = {
@@ -1540,7 +1545,7 @@ class MeshtasticManager {
         neighborInfo: neighborInfoConfigWithDefaults
       };
 
-      logger.info(`[CONFIG] Returning NeighborInfo config with enabled=${neighborInfoConfigWithDefaults.enabled}, updateInterval=${neighborInfoConfigWithDefaults.updateInterval}`);
+      logger.info(`[CONFIG] Returning NeighborInfo config with enabled=${neighborInfoConfigWithDefaults.enabled}, updateInterval=${neighborInfoConfigWithDefaults.updateInterval}, transmitOverLora=${neighborInfoConfigWithDefaults.transmitOverLora}`);
     }
 
     // Apply Proto3 defaults to position config if it exists


### PR DESCRIPTION
## Summary
- Adds the "Transmit over LoRa" checkbox to the Neighbor Info configuration section
- This matches the options available in the official Meshtastic mobile apps (Android/iOS)
- Per the [official protobuf definition](https://github.com/meshtastic/protobufs/blob/master/meshtastic/module_config.proto), this controls whether NeighborInfo is transmitted over LoRa in addition to MQTT and PhoneAPI

## Changes
- Added `neighborInfoTransmitOverLora` state management in ConfigurationTab.tsx
- Updated NeighborInfoSection component with the new checkbox (shown when Neighbor Info is enabled)
- Added Proto3 default handling for `transmitOverLora` field in meshtasticManager.ts
- Added English and Chinese translations for the new setting

## Test plan
- [ ] Enable Neighbor Info module
- [ ] Verify the "Transmit over LoRa" checkbox appears
- [ ] Toggle the setting and save
- [ ] Verify the setting persists after page reload
- [ ] Verify the setting is sent to the device correctly

## Note on Update Interval
The issue mentioned wanting to reduce the minimum interval from 4 hours to 1 hour. This is a **Meshtastic firmware limitation**, not something MeshMonitor can change. The minimum of 14400 seconds (4 hours) is enforced by the device firmware itself.

Closes #1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)