### PR TITLE
fix: add server build step to desktop release workflow

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -43,7 +43,9 @@ jobs:
         run: npm ci
 
       - name: Build main project (server + frontend)
-        run: npm run build
+        run: |
+          npm run build
+          npm run build:server
 
       - name: Download Node.js for bundling
         run: |


### PR DESCRIPTION
## Summary
- Fixes the Windows Tauri desktop release build failure
- The workflow was missing the `npm run build:server` step
- Without this, `dist/server/` doesn't exist and the copy step fails

## Root Cause
- Line 46 only ran `npm run build` (frontend: `tsc && vite build`)
- But the server files require `npm run build:server` (`tsc --project tsconfig.server.json`)
- Line 61 tried to copy `dist/server/*` which didn't exist

## Test plan
- [x] Workflow syntax is valid
- [ ] Re-run the desktop release workflow for v2.21.0 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)