### PR TITLE
fix: use Windows-compatible commands for desktop release build

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -42,10 +42,15 @@ jobs:
       - name: Install main project dependencies
         run: npm ci
 
-      - name: Build main project (server + frontend)
+      - name: Build main project (frontend)
+        run: npm run build
+
+      - name: Build server (Windows-compatible)
         run: |
-          npm run build
-          npm run build:server
+          npx tsc --project tsconfig.server.json
+          New-Item -ItemType Directory -Force -Path "dist/server/routes/v1"
+          Copy-Item "src/server/routes/v1/openapi.yaml" "dist/server/routes/v1/"
+        shell: pwsh
 
       - name: Download Node.js for bundling
         run: |


### PR DESCRIPTION
## Summary
- Fixes the Windows Tauri desktop release build failure
- The `build:server` npm script uses Linux commands (`mkdir -p`, `cp`) that fail on Windows
- Split into separate steps using PowerShell for Windows compatibility

## Root Cause
The error was:
```
> tsc --project tsconfig.server.json && mkdir -p dist/server/routes/v1 && cp src/server/routes/v1/openapi.yaml dist/server/routes/v1/

The syntax of the command is incorrect.
```

## Changes
- Run `npx tsc --project tsconfig.server.json` directly
- Use `New-Item` PowerShell cmdlet to create directories
- Use `Copy-Item` PowerShell cmdlet to copy files

## Test plan
- [ ] Re-run the desktop release workflow for v2.21.0 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)