### PR TITLE
fix: copy server files to correct paths in desktop release workflow

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -65,12 +65,31 @@ jobs:
         shell: pwsh
 
       - name: Copy server files to Tauri resources
+        shell: cmd
         run: |
-          New-Item -ItemType Directory -Force -Path "desktop/resources/dist"
-          Copy-Item -Recurse "dist/server/*" "desktop/resources/dist/"
-          Copy-Item -Recurse "node_modules" "desktop/resources/dist/node_modules"
-          Copy-Item "package.json" "desktop/resources/package.json"
-        shell: pwsh
+          if not exist desktop\resources\dist mkdir desktop\resources\dist
+          xcopy /E /I /Y dist\server desktop\resources\dist\server
+          xcopy /E /I /Y dist\services desktop\resources\dist\services
+          xcopy /E /I /Y dist\utils desktop\resources\dist\utils
+          xcopy /E /I /Y dist\types desktop\resources\dist\types
+          xcopy /E /I /Y dist\config desktop\resources\dist\config
+          xcopy /E /I /Y dist\constants desktop\resources\dist\constants
+          xcopy /E /I /Y dist\contexts desktop\resources\dist\contexts
+          xcopy /E /I /Y dist\assets desktop\resources\dist\assets
+          xcopy /E /I /Y dist\locales desktop\resources\dist\locales
+          xcopy /E /I /Y dist\pmtiles desktop\resources\dist\pmtiles
+          xcopy /E /I /Y protobufs desktop\resources\dist\protobufs
+          copy dist\index.html desktop\resources\dist\index.html
+          copy dist\logo.png desktop\resources\dist\logo.png
+          copy dist\logo-original.png desktop\resources\dist\logo-original.png
+          copy dist\favicon.ico desktop\resources\dist\favicon.ico
+          copy dist\favicon-16x16.png desktop\resources\dist\favicon-16x16.png
+          copy dist\favicon-32x32.png desktop\resources\dist\favicon-32x32.png
+          copy dist\cors-detection.js desktop\resources\dist\cors-detection.js
+          copy dist\cors-error.html desktop\resources\dist\cors-error.html
+          copy package.json desktop\resources\package.json
+          robocopy node_modules desktop\resources\dist\node_modules /E /NFL /NDL /NJH /NJS /NC /NS /NP
+          if %ERRORLEVEL% leq 7 exit /b 0
 
       - name: Install desktop dependencies
         working-directory: desktop


### PR DESCRIPTION
## Summary
- Fixed the desktop release workflow to copy server files to the correct directory structure
- The old workflow copied `dist/server/*` contents directly to `desktop/resources/dist/`, placing `server.js` at `dist/server.js`
- The Rust code at `lib.rs:51` expects `dist/server/server.js`
- Added all missing directories (`services`, `utils`, `types`, `config`, `constants`, `contexts`, `assets`, `locales`, `pmtiles`, `protobufs`) that the server imports via relative paths
- Added static files needed for the desktop app
- Now matches the `desktop-ci.yml` approach using cmd shell with xcopy/robocopy

## Test plan
- [ ] Trigger desktop release workflow manually with workflow_dispatch
- [ ] Verify the NSIS installer is built successfully
- [ ] Verify the installed desktop app can start the backend server without path errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)