### PR TITLE
docs: add Milwaukee City Mesh to site gallery

### DIFF
--- a/docs/site-gallery.md
+++ b/docs/site-gallery.md
@@ -44,6 +44,13 @@ Running a public MeshMonitor instance? We'd love to feature it! **[File an issue
 
 ---
 
+### Milwaukee City Mesh
+- **URL**: [mkemesh.my.id](https://mkemesh.my.id)
+- **Network**: [Meshconsin](https://meshconsin.org/)
+- **Description**: Monitoring Milwaukee City mesh network.
+
+---
+
 ## About the Site Gallery
 
 The Site Gallery showcases MeshMonitor instances that are publicly accessible. These sites demonstrate:


### PR DESCRIPTION
## Summary
- Adds Milwaukee City Mesh (mkemesh.my.id) to the Site Gallery
- Network: Meshconsin (meshconsin.org)
- Monitoring Milwaukee City mesh network

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)