### PR TITLE
fix(admin): load and save fixed position lat/lng correctly

### DIFF
--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -1237,9 +1237,11 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
     };
 
     if (configState.position.fixedPosition) {
-      config.fixedLatitude = configState.position.fixedLatitude;
-      config.fixedLongitude = configState.position.fixedLongitude;
-      config.fixedAltitude = configState.position.fixedAltitude;
+      // Backend expects latitude/longitude/altitude (not fixedLatitude/fixedLongitude)
+      // It will send setFixedPosition admin message before setting the config
+      config.latitude = configState.position.fixedLatitude;
+      config.longitude = configState.position.fixedLongitude;
+      config.altitude = configState.position.fixedAltitude;
     }
 
     // Only include GPIO pins if they're set (not undefined)


### PR DESCRIPTION
## Summary
The Meshtastic `PositionConfig` protobuf doesn't have `fixedLatitude`/`fixedLongitude` fields - it only has a `fixedPosition` boolean flag. The actual coordinates for a fixed position are stored as the node's regular position data.

**Changes:**
- When loading position config with `fixedPosition=true`, fetch the node's lat/lng/altitude from the database
- When saving, map `fixedLatitude`/`fixedLongitude` → `latitude`/`longitude` so the backend can send the `setFixedPosition` admin message before setting the config

## How it works now
1. **Loading**: If `fixedPosition` is enabled, we look up the node's position from the database and populate the lat/lng fields
2. **Saving**: The frontend sends `latitude`/`longitude`/`altitude` (not `fixedLatitude`/etc), and the backend:
   - First sends a `setFixedPosition` admin message with the coordinates
   - Then sends the `setPositionConfig` with the `fixedPosition` flag

Fixes #1090

🤖 Generated with [Claude Code](https://claude.com/claude-code)