### PR TITLE
fix(desktop): copy package.json to dist for all platforms

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -90,6 +90,7 @@ jobs:
           copy dist\cors-detection.js desktop\resources\dist\cors-detection.js
           copy dist\cors-error.html desktop\resources\dist\cors-error.html
           copy package.json desktop\resources\package.json
+          copy package.json desktop\resources\dist\package.json
           robocopy node_modules desktop\resources\dist\node_modules /E /NFL /NDL /NJH /NJS /NC /NS /NP
           if %ERRORLEVEL% leq 7 exit /b 0
 
@@ -197,6 +198,7 @@ jobs:
           cp dist/cors-detection.js desktop/resources/dist/
           cp dist/cors-error.html desktop/resources/dist/
           cp package.json desktop/resources/
+          cp package.json desktop/resources/dist/
           # Copy node_modules (may take a while)
           cp -r node_modules desktop/resources/dist/
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -245,6 +245,7 @@ jobs:
           cp dist/cors-detection.js desktop/resources/dist/
           cp dist/cors-error.html desktop/resources/dist/
           cp package.json desktop/resources/
+          cp package.json desktop/resources/dist/
           # Copy node_modules
           cp -r node_modules desktop/resources/dist/
 


### PR DESCRIPTION
## Summary

Copy `package.json` to `desktop/resources/dist/` to fix missing file error during desktop app runtime.

This extends the fix from #1098 to cover all platforms and build types.

## Changes

Adds `package.json` copy to `dist/` directory in:
- ✅ `desktop-release.yml` Windows build (from #1098)
- ✅ `desktop-release.yml` macOS build
- ✅ `desktop-ci.yml` Windows build
- ✅ `desktop-ci.yml` macOS build

## Root Cause

The Rust desktop code (`lib.rs:87`) expects `package.json` in the `dist/` directory:
```rust
let package_json_path = server_dir.join("package.json");
```

Credit to @ssp97 for identifying the issue in #1098.

Closes #1098

🤖 Generated with [Claude Code](https://claude.com/claude-code)