### PR TITLE
fix(nodes): set channel when processing NodeInfo mesh packets (#1100)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2249,6 +2249,8 @@ class MeshtasticManager {
       const fromNum = Number(meshPacket.from);
       const nodeId = `!${fromNum.toString(16).padStart(8, '0')}`;
       const timestamp = Date.now();
+      // Extract channel from mesh packet - this tells us which channel the node was heard on
+      const channelIndex = meshPacket.channel !== undefined ? meshPacket.channel : undefined;
       const nodeData: any = {
         nodeNum: fromNum,
         nodeId: nodeId,
@@ -2257,8 +2259,13 @@ class MeshtasticManager {
         hwModel: user.hwModel,
         role: user.role,
         hopsAway: meshPacket.hopsAway,
-        lastHeard: meshPacket.rxTime ? Number(meshPacket.rxTime) : timestamp / 1000
+        lastHeard: meshPacket.rxTime ? Number(meshPacket.rxTime) : timestamp / 1000,
+        channel: channelIndex
       };
+
+      if (channelIndex !== undefined) {
+        logger.debug(`📡 NodeInfo message for ${nodeId}: received on channel ${channelIndex}`);
+      }
 
       // Capture public key if present
       if (user.publicKey && user.publicKey.length > 0) {


### PR DESCRIPTION
## Summary
- Fix nodes from open/public channels appearing in private channels after node database reset
- Extract channel index from mesh packets when processing NODEINFO_APP messages
- Store the channel with the node data so nodes are correctly associated with their channel

## Root Cause
In `processNodeInfoMessageProtobuf`, the `channel` field was not being extracted from `meshPacket.channel` when creating the `nodeData` object. This meant nodes discovered via mesh packets (common after a DB reset) had no channel association, causing them to appear in whatever channel was selected.

## Changes
- `src/server/meshtasticManager.ts`: Add `channel: meshPacket.channel` extraction in `processNodeInfoMessageProtobuf`, consistent with how `processPositionMessageProtobuf` and `processNodeInfoProtobuf` handle channel extraction

## Test plan
- [x] TypeScript compiles without errors
- [x] Build succeeds
- [x] System tests pass (see below)

## System Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| Reverse Proxy Test | ✅ PASSED |
| Reverse Proxy + OIDC | ✅ PASSED |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |

Fixes #1100

🤖 Generated with [Claude Code](https://claude.com/claude-code)