### PR TITLE
feat(auto-responder): add FROM_SHORT_NAME and FROM_LONG_NAME env vars

### DIFF
--- a/docs/developers/auto-responder-scripting.md
+++ b/docs/developers/auto-responder-scripting.md
@@ -149,6 +149,8 @@ All scripts receive these environment variables:
 |----------|-------------|---------|
 | `MESSAGE` | Full message text received | `"weather miami"` |
 | `FROM_NODE` | Sender's node number | `"123456789"` |
+| `FROM_SHORT_NAME` | Sender's short name (if known) | `"JOHN"` |
+| `FROM_LONG_NAME` | Sender's long name (if known) | `"John Doe"` |
 | `FROM_LAT` | Sender's latitude (if known) | `"25.7617"` |
 | `FROM_LON` | Sender's longitude (if known) | `"-80.1918"` |
 | `MM_LAT` | MeshMonitor node's latitude (if known) | `"25.7617"` |

--- a/docs/user-scripts.md
+++ b/docs/user-scripts.md
@@ -94,6 +94,8 @@ All scripts receive these environment variables:
 
 - `MESSAGE`: Full message text received
 - `FROM_NODE`: Sender's node number
+- `FROM_SHORT_NAME`: Sender's short name (if known)
+- `FROM_LONG_NAME`: Sender's long name (if known)
 - `FROM_LAT`: Sender's latitude (if known)
 - `FROM_LON`: Sender's longitude (if known)
 - `MM_LAT`: MeshMonitor node's latitude (if known)

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5781,11 +5781,21 @@ class MeshtasticManager {
                 MATCHED_PATTERN: matchedPattern || '',
               };
 
-              // Add location environment variables for the sender node (FROM_LAT, FROM_LON)
+              // Add sender node information environment variables
               const fromNode = databaseService.getNode(fromNum);
-              if (fromNode?.latitude != null && fromNode?.longitude != null) {
-                scriptEnv.FROM_LAT = String(fromNode.latitude);
-                scriptEnv.FROM_LON = String(fromNode.longitude);
+              if (fromNode) {
+                // Add node names (Issue #1099)
+                if (fromNode.shortName) {
+                  scriptEnv.FROM_SHORT_NAME = fromNode.shortName;
+                }
+                if (fromNode.longName) {
+                  scriptEnv.FROM_LONG_NAME = fromNode.longName;
+                }
+                // Add location (FROM_LAT, FROM_LON)
+                if (fromNode.latitude != null && fromNode.longitude != null) {
+                  scriptEnv.FROM_LAT = String(fromNode.latitude);
+                  scriptEnv.FROM_LON = String(fromNode.longitude);
+                }
               }
 
               // Add location environment variables for the MeshMonitor node (MM_LAT, MM_LON)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6988,6 +6988,8 @@ apiRouter.post('/scripts/test', requirePermission('settings', 'read'), async (re
       ...(process.env as Record<string, string>),
       MESSAGE: testMessage,
       FROM_NODE: '12345', // Test node number
+      FROM_SHORT_NAME: 'TEST', // Test short name
+      FROM_LONG_NAME: 'Test Node', // Test long name
       PACKET_ID: '99999', // Test packet ID
       TRIGGER: trigger,
     };


### PR DESCRIPTION
## Summary
- Add `FROM_SHORT_NAME` and `FROM_LONG_NAME` environment variables for Auto Responder scripts
- These allow scripts to personalize responses with the sender's node name
- Updated test script endpoint with matching test values
- Updated documentation in both developer and user script guides

Closes #1099

## Test plan
- [x] TypeScript type check passes
- [x] Production build completes successfully
- [x] All system tests pass

### Test Results
| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| Reverse Proxy Test | ✅ PASSED |
| Reverse Proxy + OIDC | ✅ PASSED |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)