### PR TITLE
fix(docker): switch to Debian slim base for ARMv7 support

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -6,7 +6,7 @@ logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
 
 [program:meshmonitor]
-command=su-exec node npm start
+command=gosu node npm start
 directory=/app
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
Node.js 24 Alpine images don't support `linux/arm/v7` (32-bit ARM), which is used by Raspberry Pi 2, Pi 3 (32-bit mode), and Pi Zero 2 W.

Instead of dropping ARMv7 support, switch to `node:24-slim` (Debian-based) which supports all three architectures.

## Changes
- Use `node:24-slim` instead of `node:24-alpine` for both build and runtime stages
- Replace `apk` with `apt-get` for package installation
- Replace `su-exec` with `gosu` (Debian equivalent)
- Add build dependencies (python3, make, g++) for native modules in builder stage

## Test plan
- [ ] Docker build succeeds for linux/amd64
- [ ] Docker build succeeds for linux/arm64
- [ ] Docker build succeeds for linux/arm/v7

## References
- [nodejs/docker-node#1277](https://github.com/nodejs/docker-node/issues/1277) - Alpine images dropped ARMv7 support for Node 14+

🤖 Generated with [Claude Code](https://claude.com/claude-code)