### PR TITLE
fix: remove duplicate Docker job from release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,71 +132,13 @@ jobs:
           path: meshmonitor-*.tar.gz
           retention-days: 7
 
-  docker-release:
-    name: Docker Release
-    runs-on: ubuntu-latest
-    needs: [validate-release, test-suite]
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        if: vars.DOCKERHUB_USERNAME != ''
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}
-            ${{ vars.DOCKERHUB_USERNAME && format('docker.io/{0}/meshmonitor', vars.DOCKERHUB_USERNAME) || '' }}
-          tags: |
-            type=semver,pattern={{version}},value=${{ needs.validate-release.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.validate-release.outputs.version }}
-            type=semver,pattern={{major}},value=${{ needs.validate-release.outputs.version }}
-            type=raw,value=latest
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ needs.validate-release.outputs.version }}
-            BUILD_DATE=${{ github.event.release.created_at || github.event.repository.updated_at }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+  # Docker build is handled by docker-publish.yml workflow
+  # which uses separate Dockerfiles for Node 24 (amd64/arm64) and Node 22 (armv7)
 
   update-release:
     name: Update Release
     runs-on: ubuntu-latest
-    needs: [validate-release, test-suite, build-artifacts, docker-release]
+    needs: [validate-release, test-suite, build-artifacts]
     if: github.event_name == 'release'
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Removes the duplicate `docker-release` job from release.yml that was failing
- Docker builds are exclusively handled by `docker-publish.yml` now
- The removed job was using the old single-Dockerfile approach that doesn't support ARMv7 with Node 24

## Changes
- Removed `docker-release` job from `.github/workflows/release.yml`
- Updated `update-release` job to no longer depend on `docker-release`
- Added comment explaining that Docker builds are handled by docker-publish.yml

## Test plan
- [ ] Merge this PR
- [ ] The Release Pipeline workflow should now complete successfully (it only needs to pass tests, build artifacts, and update the release)
- [ ] Docker builds continue to be handled by the docker-publish.yml workflow which was already tested and working

🤖 Generated with [Claude Code](https://claude.com/claude-code)