### PR TITLE
fix(desktop): strip Windows extended-length path prefix for Node.js

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -13,8 +13,8 @@ use tauri::{AppHandle, Manager, Runtime};
 #[cfg(windows)]
 fn strip_extended_length_prefix(path: PathBuf) -> PathBuf {
     let path_str = path.to_string_lossy();
-    if path_str.starts_with(r"\\?\") {
-        PathBuf::from(&path_str[4..])
+    if let Some(stripped) = path_str.strip_prefix(r"\\?\") {
+        PathBuf::from(stripped)
     } else {
         path
     }


### PR DESCRIPTION
## Summary
- Fixes Windows desktop app failing to start with `EISDIR: illegal operation on a directory, lstat 'C:'`
- Strips the `\\?\` prefix from Windows extended-length paths before passing to Node.js
- Node.js doesn't handle the extended-length path prefix correctly during module resolution

## Problem
On Windows, Tauri's `resource_dir()` returns paths with the `\\?\` prefix:
```
\\?\C:\Users\...\AppData\Local\MeshMonitor\dist
```

When Node.js receives this as its working directory, module resolution fails because it can't properly handle the prefix.

## Solution
Added `strip_extended_length_prefix()` helper that removes the `\\?\` prefix on Windows before passing paths to Node.js. The function is a no-op on other platforms.

## Test plan
- [ ] Windows desktop build passes CI
- [ ] Install the Windows release and verify the app starts correctly
- [ ] Check desktop.log shows paths without `\\?\` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)