### PR TITLE
fix(admin): improve remote session passkey handling and fix favorite/ignore commands

### DIFF
--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -1064,7 +1064,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       return;
     }
     try {
-      await executeCommand('setFavoriteNode', { nodeNum: nodeManagementNodeNum });
+      await executeCommand('setFavoriteNode', { favoriteNodeNum: nodeManagementNodeNum });
       showToast(t('admin_commands.node_set_favorite', { nodeNum: nodeManagementNodeNum }), 'success');
       // Optimistically update state - use remote status if managing remote node, otherwise local
       if (isManagingRemoteNode) {
@@ -1093,7 +1093,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       return;
     }
     try {
-      await executeCommand('removeFavoriteNode', { nodeNum: nodeManagementNodeNum });
+      await executeCommand('removeFavoriteNode', { favoriteNodeNum: nodeManagementNodeNum });
       showToast(t('admin_commands.node_removed_favorite', { nodeNum: nodeManagementNodeNum }), 'success');
       // Optimistically update state - use remote status if managing remote node, otherwise local
       if (isManagingRemoteNode) {
@@ -1122,7 +1122,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       return;
     }
     try {
-      await executeCommand('setIgnoredNode', { nodeNum: nodeManagementNodeNum });
+      await executeCommand('setIgnoredNode', { targetNodeNum: nodeManagementNodeNum });
       showToast(t('admin_commands.node_set_ignored', { nodeNum: nodeManagementNodeNum }), 'success');
       // Optimistically update state - use remote status if managing remote node, otherwise local
       if (isManagingRemoteNode) {
@@ -1151,7 +1151,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       return;
     }
     try {
-      await executeCommand('removeIgnoredNode', { nodeNum: nodeManagementNodeNum });
+      await executeCommand('removeIgnoredNode', { targetNodeNum: nodeManagementNodeNum });
       showToast(t('admin_commands.node_removed_ignored', { nodeNum: nodeManagementNodeNum }), 'success');
       // Optimistically update state - use remote status if managing remote node, otherwise local
       if (isManagingRemoteNode) {


### PR DESCRIPTION
## Summary
- Improved session passkey handling for remote nodes with polling instead of fixed wait
- Fixed parameter collision bug that prevented favorite/ignore node commands from working
- Enhanced logging for better debugging visibility

## Problem
1. When using the Admin Commands page to load configuration from remote nodes, users frequently encountered "Failed to obtain session passkey for remote node X" errors. This was caused by:
   - Timeouts being too short for multi-hop mesh networks
   - Fixed wait times that couldn't adapt to fast or slow responses

2. The "Set as Favorite" and "Set as Ignored" commands always failed because the `nodeNum` parameter (target node) was being overwritten by the destination `nodeNum` due to JavaScript object spread behavior.

## Changes

### Timeout Improvements
| Operation | Old Timeout | New Timeout |
|-----------|-------------|-------------|
| Session Passkey (local) | 3s | 5s |
| Session Passkey (remote) | 3s → fixed 15s wait | 45s max with 500ms polling |
| Config Request (remote) | 10s | 20s |
| Channel Request (remote) | 8s | 16s |
| Owner Request (remote) | 3s | 10s |

### Polling vs Fixed Wait
- Changed from a fixed 15-second wait to polling every 500ms with a 45-second maximum
- This allows early exit when the passkey arrives quickly (common for nearby nodes)
- Provides longer total wait time for distant nodes on multi-hop mesh routes

### Parameter Collision Fix
- The API call was structured as: `{ command, nodeNum: selectedNodeNum, ...params }`
- For favorite/ignore commands, `params` contained `{ nodeNum: targetNodeNum }`, which overwrote the destination
- Renamed parameters to avoid collision:
  - `setFavoriteNode` / `removeFavoriteNode` → use `favoriteNodeNum`
  - `setIgnoredNode` / `removeIgnoredNode` → use `targetNodeNum`

### Logging Improvements
- Changed passkey logging from DEBUG to INFO level for better visibility
- Added logging when using cached session passkeys vs requesting new ones
- Clearer error messages when passkey requests time out

## Test plan
- [x] Typecheck passes
- [x] Build passes
- [x] System tests pass
- [x] Manual testing: remote node config loads successfully
- [x] Manual testing: Set as Favorite works on remote nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)