### PR TITLE
Release v2.21.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ MeshMonitor supports multiple deployment methods:
   - [Manual Installation Guide](docs/deployment/DEPLOYMENT_GUIDE.md#manual-nodejs-deployment)
   - For development or custom setups
 
+- **🖥️ Desktop Apps** - Native applications for Windows and macOS
+  - Download from [GitHub Releases](https://github.com/Yeraze/meshmonitor/releases)
+  - Runs as a system tray application
+  - Windows (.exe) and macOS (.dmg) installers available
+
 ## Key Features
 
 - **Real-time Mesh Monitoring** - Live node discovery, telemetry, and message tracking

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "2.21.2",
+  "version": "2.21.3",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.21.2
-appVersion: "2.21.2"
+version: 2.21.3
+appVersion: "2.21.3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.21.2",
+  "version": "2.21.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.21.2",
+      "version": "2.21.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.21.2",
+  "version": "2.21.3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Release v2.21.3 with new features and bug fixes.

## Changes since v2.21.2

### Features
- **Tile Server Test Button** - Add connectivity validation for custom tile servers (#1123, #1095)
- **Export Configuration UX** - Improved export configuration experience (#1109, #1055)

### Bug Fixes
- **Three-tier encryption indicator** - Show red/yellow/green based on encryption status (#1122, #1120)
- **Remote session passkey handling** - Fix favorite/ignore commands (#1119)
- **Desktop Windows path fix** - Strip extended-length path prefix for Node.js (#1118)
- **CI/CD fixes** - Docker image naming and release pipeline (#1114, #1112, #1111, #1110)

### Documentation
- Add Desktop Apps (Windows/macOS) to README deployment options

## Version Updates
- package.json: 2.21.2 → 2.21.3
- Helm Chart: 2.21.2 → 2.21.3
- Tauri config: 2.21.2 → 2.21.3

## Test plan

- [x] Version numbers updated consistently
- [x] README updated with desktop deployment option

🤖 Generated with [Claude Code](https://claude.com/claude-code)