### PR TITLE
fix(admin): skip reloading configs that were already successfully loaded (#1115)

### DIFF
--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -3160,10 +3160,11 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             if (selectedNodeNum === null) {
               throw new Error(t('admin_commands.please_select_node'));
             }
-            
-            // Check if channels are already loaded
-            if (remoteNodeChannels.length > 0) {
-              // Channels already loaded, no need to reload
+
+            // Skip loading if channels were already successfully loaded
+            // This respects manual loading - user can load configs, retry failed ones,
+            // and then export without auto-reloading (fixes #1115)
+            if (sectionLoadStatus.channels === 'success') {
               return;
             }
             


### PR DESCRIPTION
## Summary

When clicking Export Configuration, now checks if channels were successfully loaded (`sectionLoadStatus.channels === 'success'`) instead of just checking if the channels array has data.

## Problem

For remote nodes (especially with multiple hops), config loading often fails intermittently. Previously, clicking Export would always try to reload channels if the array appeared empty, even if the user had already successfully loaded them via "Load All Config" and manual retries.

## Solution

Changed the check from:
```typescript
if (remoteNodeChannels.length > 0) {
  return; // Skip reload
}
```

To:
```typescript
if (sectionLoadStatus.channels === 'success') {
  return; // Skip reload
}
```

This allows users to:
1. Load configs manually using "Load All Config"
2. Retry failed sections individually until successful
3. Export without auto-reloading successfully loaded sections

## Test plan

- [x] TypeScript check passes
- [x] Build succeeds
- [x] System tests pass (see below)
- [ ] Manual test: Load configs for remote node, verify Export doesn't reload

## System Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| Reverse Proxy Test | ✅ PASSED |
| Reverse Proxy + OIDC | ✅ PASSED |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |

## Closes

Closes #1115

🤖 Generated with [Claude Code](https://claude.com/claude-code)