### PR TITLE
fix(lora): correct frequency calculation using official Meshtastic formula

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -4731,8 +4731,8 @@ class MeshtasticManager {
    * Calculate LoRa frequency from region and channel number (frequency slot)
    * Delegates to the utility function for better testability
    */
-  private calculateLoRaFrequency(region: number, channelNum: number, overrideFrequency: number, frequencyOffset: number): string {
-    return calculateLoRaFrequency(region, channelNum, overrideFrequency, frequencyOffset);
+  private calculateLoRaFrequency(region: number, channelNum: number, overrideFrequency: number, frequencyOffset: number, bandwidth: number = 250): string {
+    return calculateLoRaFrequency(region, channelNum, overrideFrequency, frequencyOffset, bandwidth);
   }
 
   private buildDeviceConfigFromActual(): any {
@@ -4841,7 +4841,8 @@ class MeshtasticManager {
           typeof loraConfigWithDefaults.region === 'number' ? loraConfigWithDefaults.region : 0,
           loraConfigWithDefaults.channelNum !== undefined ? loraConfigWithDefaults.channelNum : 0,
           loraConfigWithDefaults.overrideFrequency !== undefined ? loraConfigWithDefaults.overrideFrequency : 0,
-          loraConfigWithDefaults.frequencyOffset !== undefined ? loraConfigWithDefaults.frequencyOffset : 0
+          loraConfigWithDefaults.frequencyOffset !== undefined ? loraConfigWithDefaults.frequencyOffset : 0,
+          typeof loraConfigWithDefaults.bandwidth === 'number' && loraConfigWithDefaults.bandwidth > 0 ? loraConfigWithDefaults.bandwidth : 250
         ),
         txEnabled: loraConfigWithDefaults.txEnabled !== undefined ? loraConfigWithDefaults.txEnabled : 'Unknown',
         sx126xRxBoostedGain: loraConfigWithDefaults.sx126xRxBoostedGain !== undefined ? loraConfigWithDefaults.sx126xRxBoostedGain : 'Unknown',

--- a/src/utils/loraFrequency.test.ts
+++ b/src/utils/loraFrequency.test.ts
@@ -2,25 +2,36 @@ import { describe, it, expect } from 'vitest';
 import { calculateLoRaFrequency } from './loraFrequency';
 
 describe('calculateLoRaFrequency', () => {
-  describe('US region (region 1)', () => {
-    it('should calculate correct frequency for slot 18', () => {
-      const result = calculateLoRaFrequency(1, 18, 0, 0);
-      expect(result).toBe('906.375 MHz');
-    });
+  // Default bandwidth is 250 kHz (LongFast preset)
+  // Formula: freq = freqStart + (bw / 2000) + (channel_num * (bw / 1000))
 
-    it('should calculate correct frequency for slot 20 (LongFast default)', () => {
-      const result = calculateLoRaFrequency(1, 20, 0, 0);
-      expect(result).toBe('906.875 MHz');
-    });
+  describe('US region (region 1)', () => {
+    // US: freqStart = 902.0 MHz, freqEnd = 928.0 MHz
+    // With 250 kHz BW: halfBwOffset = 0.125 MHz, spacing = 0.25 MHz
+    // Slot 0: 902.0 + 0.125 + 0 = 902.125 MHz
 
     it('should calculate correct frequency for slot 0', () => {
       const result = calculateLoRaFrequency(1, 0, 0, 0);
-      expect(result).toBe('901.875 MHz');
+      expect(result).toBe('902.125 MHz');
     });
 
-    it('should calculate correct frequency for slot 103 (max)', () => {
+    it('should calculate correct frequency for slot 18', () => {
+      // 902.0 + 0.125 + (18 * 0.25) = 902.125 + 4.5 = 906.625 MHz
+      const result = calculateLoRaFrequency(1, 18, 0, 0);
+      expect(result).toBe('906.625 MHz');
+    });
+
+    it('should calculate correct frequency for slot 20 (LongFast default)', () => {
+      // 902.0 + 0.125 + (20 * 0.25) = 902.125 + 5.0 = 907.125 MHz
+      const result = calculateLoRaFrequency(1, 20, 0, 0);
+      expect(result).toBe('907.125 MHz');
+    });
+
+    it('should calculate correct frequency for slot 103 (max with 250kHz BW)', () => {
+      // US has (928-902)/0.25 = 104 slots (0-103)
+      // 902.0 + 0.125 + (103 * 0.25) = 902.125 + 25.75 = 927.875 MHz
       const result = calculateLoRaFrequency(1, 103, 0, 0);
-      expect(result).toBe('927.625 MHz');
+      expect(result).toBe('927.875 MHz');
     });
 
     it('should return "Invalid channel" for slot >= 104', () => {
@@ -29,42 +40,63 @@ describe('calculateLoRaFrequency', () => {
     });
 
     it('should apply frequency offset correctly', () => {
+      // 907.125 + 0.1 = 907.225 MHz
       const result = calculateLoRaFrequency(1, 20, 0, 0.1);
-      expect(result).toBe('906.975 MHz');
+      expect(result).toBe('907.225 MHz');
+    });
+
+    it('should calculate correctly with 125kHz bandwidth', () => {
+      // With 125 kHz BW: halfBwOffset = 0.0625 MHz, spacing = 0.125 MHz
+      // Slot 20: 902.0 + 0.0625 + (20 * 0.125) = 902.0625 + 2.5 = 904.5625 MHz
+      const result = calculateLoRaFrequency(1, 20, 0, 0, 125);
+      expect(result).toBe('904.563 MHz');
     });
   });
 
   describe('EU_433 region (region 2)', () => {
-    it('should calculate correct frequency for slot 4 (default)', () => {
-      const result = calculateLoRaFrequency(2, 4, 0, 0);
-      expect(result).toBe('433.875 MHz');
-    });
+    // EU_433: freqStart = 433.0 MHz, freqEnd = 434.0 MHz
+    // With 250 kHz BW: (434-433)/0.25 = 4 slots (0-3)
+    // Slot 0: 433.0 + 0.125 = 433.125 MHz
 
     it('should calculate correct frequency for slot 0', () => {
       const result = calculateLoRaFrequency(2, 0, 0, 0);
-      expect(result).toBe('433.075 MHz');
+      expect(result).toBe('433.125 MHz');
     });
 
-    it('should return "Invalid channel" for slot >= 5', () => {
-      const result = calculateLoRaFrequency(2, 5, 0, 0);
+    it('should calculate correct frequency for slot 3 (max with 250kHz BW)', () => {
+      // 433.0 + 0.125 + (3 * 0.25) = 433.125 + 0.75 = 433.875 MHz
+      const result = calculateLoRaFrequency(2, 3, 0, 0);
+      expect(result).toBe('433.875 MHz');
+    });
+
+    it('should return "Invalid channel" for slot >= 4', () => {
+      const result = calculateLoRaFrequency(2, 4, 0, 0);
       expect(result).toBe('Invalid channel');
     });
   });
 
   describe('EU_868 region (region 3)', () => {
-    it('should calculate correct frequency for slot 1 (default)', () => {
-      const result = calculateLoRaFrequency(3, 1, 0, 0);
+    // EU_868: freqStart = 869.4 MHz, freqEnd = 869.65 MHz (only 250 kHz span!)
+    // With 250 kHz BW: (869.65-869.4)/0.25 = 1 slot (only slot 0)
+    // Slot 0: 869.4 + 0.125 = 869.525 MHz
+
+    it('should calculate correct frequency for slot 0 (only valid slot with 250kHz BW)', () => {
+      const result = calculateLoRaFrequency(3, 0, 0, 0);
       expect(result).toBe('869.525 MHz');
     });
 
-    it('should calculate correct frequency for slot 0', () => {
-      const result = calculateLoRaFrequency(3, 0, 0, 0);
-      expect(result).toBe('869.325 MHz');
+    it('should return "Invalid channel" for slot >= 1 with 250kHz BW', () => {
+      // EU_868 only has 1 slot with 250kHz bandwidth
+      const result = calculateLoRaFrequency(3, 1, 0, 0);
+      expect(result).toBe('Invalid channel');
     });
 
-    it('should return "Invalid channel" for slot >= 2', () => {
-      const result = calculateLoRaFrequency(3, 2, 0, 0);
-      expect(result).toBe('Invalid channel');
+    it('should allow slot 1 with 125kHz bandwidth', () => {
+      // With 125 kHz BW: (869.65-869.4)/0.125 = 2 slots (0-1)
+      // Slot 1: 869.4 + 0.0625 + (1 * 0.125) = 869.4625 + 0.125 = 869.5875 MHz
+      // Note: JavaScript floating-point rounds 869.5875 to 869.587 with toFixed(3)
+      const result = calculateLoRaFrequency(3, 1, 0, 0, 125);
+      expect(result).toBe('869.587 MHz');
     });
   });
 
@@ -81,7 +113,7 @@ describe('calculateLoRaFrequency', () => {
 
     it('should ignore override frequency when zero', () => {
       const result = calculateLoRaFrequency(1, 20, 0, 0);
-      expect(result).toBe('906.875 MHz');
+      expect(result).toBe('907.125 MHz');
     });
   });
 
@@ -102,26 +134,55 @@ describe('calculateLoRaFrequency', () => {
     });
 
     it('should handle frequency offset correctly with negative values', () => {
+      // 907.125 - 0.1 = 907.025 MHz
       const result = calculateLoRaFrequency(1, 20, 0, -0.1);
-      expect(result).toBe('906.775 MHz');
+      expect(result).toBe('907.025 MHz');
+    });
+
+    it('should use default bandwidth when 0 is passed', () => {
+      const result = calculateLoRaFrequency(1, 0, 0, 0, 0);
+      expect(result).toBe('902.125 MHz'); // Same as default 250kHz
     });
   });
 
   describe('Other regions', () => {
     it('should calculate frequency for CN region (region 4)', () => {
+      // CN: freqStart = 470.0 MHz
+      // Slot 0: 470.0 + 0.125 = 470.125 MHz
       const result = calculateLoRaFrequency(4, 0, 0, 0);
-      expect(result).toBe('470.000 MHz');
+      expect(result).toBe('470.125 MHz');
     });
 
     it('should calculate frequency for JP region (region 5)', () => {
+      // JP: freqStart = 920.8 MHz
+      // Slot 0: 920.8 + 0.125 = 920.925 MHz
       const result = calculateLoRaFrequency(5, 0, 0, 0);
-      expect(result).toBe('920.600 MHz');
+      expect(result).toBe('920.925 MHz');
     });
 
     it('should calculate frequency for LORA_24 region (region 13)', () => {
+      // LORA_24: freqStart = 2400.0 MHz
+      // Slot 0: 2400.0 + 0.125 = 2400.125 MHz
       const result = calculateLoRaFrequency(13, 0, 0, 0);
-      expect(result).toBe('2400.000 MHz');
+      expect(result).toBe('2400.125 MHz');
+    });
+  });
+
+  describe('Bandwidth variations', () => {
+    it('should calculate correctly with 500kHz bandwidth', () => {
+      // US region, slot 0, 500kHz BW
+      // halfBwOffset = 0.25 MHz, spacing = 0.5 MHz
+      // 902.0 + 0.25 = 902.25 MHz
+      const result = calculateLoRaFrequency(1, 0, 0, 0, 500);
+      expect(result).toBe('902.250 MHz');
+    });
+
+    it('should calculate correctly with 62.5kHz bandwidth', () => {
+      // US region, slot 0, 62.5kHz BW
+      // halfBwOffset = 0.03125 MHz, spacing = 0.0625 MHz
+      // 902.0 + 0.03125 = 902.03125 MHz
+      const result = calculateLoRaFrequency(1, 0, 0, 0, 62.5);
+      expect(result).toBe('902.031 MHz');
     });
   });
 });
-

--- a/src/utils/loraFrequency.ts
+++ b/src/utils/loraFrequency.ts
@@ -1,29 +1,31 @@
 /**
- * Calculate LoRa frequency from region and channel number (frequency slot)
+ * Calculate LoRa frequency from region, channel number, and bandwidth
  *
- * Meshtastic uses dynamic frequency slots based on:
- * - Region (defines the ISM band, e.g., 902-928 MHz for US)
- * - Bandwidth (125kHz, 250kHz, 500kHz) - affects number of available slots
- * - Channel number (frequency slot) - determines the specific frequency
+ * Uses the official Meshtastic formula from RadioInterface.cpp:
+ *   freq = freqStart + (bw / 2000) + (channel_num * (bw / 1000))
  *
- * Frequency spacing is determined by bandwidth: narrower bandwidth allows more slots.
- * For US region with LongFast preset (250kHz BW): 104 slots with 0.25 MHz spacing
+ * Where:
+ * - freqStart: Region's starting frequency (MHz)
+ * - bw: Bandwidth in kHz (e.g., 250 for LongFast, 125 for LongSlow)
+ * - channel_num: Frequency slot (0-based)
  *
  * References:
+ * - https://github.com/meshtastic/firmware/blob/master/src/mesh/RadioInterface.cpp
  * - https://meshtastic.org/docs/overview/radio-settings/
- * - https://meshtastic.org/docs/settings/channel
  *
  * @param region - Region code (1=US, 2=EU_433, 3=EU_868, etc.)
  * @param channelNum - Channel number (frequency slot, 0-based)
  * @param overrideFrequency - Override frequency in MHz (takes precedence if > 0)
  * @param frequencyOffset - Frequency offset in MHz to add to calculated frequency
+ * @param bandwidth - Bandwidth in kHz (default 250 for LongFast preset)
  * @returns Formatted frequency string (e.g., "906.875 MHz") or "Unknown"/"Invalid channel"
  */
 export function calculateLoRaFrequency(
   region: number,
   channelNum: number,
   overrideFrequency: number,
-  frequencyOffset: number
+  frequencyOffset: number,
+  bandwidth: number = 250 // Default to LongFast preset (250 kHz)
 ): string {
   // If overrideFrequency is set (non-zero), use it (takes precedence over calculated frequency)
   if (overrideFrequency && overrideFrequency > 0) {
@@ -31,60 +33,67 @@ export function calculateLoRaFrequency(
     return `${freq.toFixed(3)} MHz`;
   }
 
-  // Frequency lookup table for Meshtastic frequency slots
-  // Format: region -> [baseFreq (MHz), slotSpacing (MHz), maxSlots]
-  // Note: Spacing depends on bandwidth - these values are for common presets (typically 250kHz BW)
-  // References: https://meshtastic.org/docs/overview/radio-settings/
-  // US region: 104 slots (0-103) for 250kHz BW, verified: slot 18=906.375, slot 20=906.875 (LongFast)
-  // EU_433: 5 slots (0-4) for LongFast, default slot 4 = 433.875 MHz (band: 433-434 MHz)
-  // EU_868: 2 slots (0-1) for LongFast, default slot 1 = 869.525 MHz (band: 869.40-869.65 MHz)
-  const regionFrequencyParams: { [key: number]: [number, number, number] } = {
-    1: [901.875, 0.25, 104],   // US: 901.875-927.875 MHz, 104 slots (250kHz BW), spacing=0.25 MHz
-    2: [433.075, 0.2, 5],      // EU_433: 433-434 MHz, 5 slots (0-4) with LongFast, default slot 4=433.875 MHz
-    3: [869.325, 0.2, 2],      // EU_868: 869.40-869.65 MHz, 2 slots (0-1) with LongFast, default slot 1=869.525 MHz
-    4: [470.0, 0.2, 95],      // CN: 470.0-489.8 MHz, 95 channels
-    5: [920.6, 0.2, 15],      // JP: 920.6-923.4 MHz, 15 channels
-    6: [915.0, 0.2, 72],      // ANZ: 915.0-927.8 MHz, 72 channels
-    7: [920.9, 0.2, 15],      // KR: 920.9-923.7 MHz, 15 channels
-    8: [920.6, 0.2, 15],      // TW: 920.6-923.4 MHz, 15 channels
-    9: [433.175, 0.2, 7],     // RU: 433.175-434.575 MHz, 7 channels
-    10: [865.0625, 0.2, 15],  // IN: 865.0625-867.8625 MHz, 15 channels
-    11: [865.0, 0.2, 15],     // NZ_865: 865.0-867.8 MHz, 15 channels
-    12: [920.6, 0.2, 15],     // TH: 920.6-923.4 MHz, 15 channels
-    13: [2400.0, 0.2, 15],    // LORA_24: 2400.0-2402.8 MHz, 15 channels
-    14: [433.175, 0.2, 7],    // UA_433: 433.175-434.575 MHz, 7 channels
-    15: [863.275, 0.2, 7],    // UA_868: 863.275-864.575 MHz, 7 channels
-    16: [433.175, 0.2, 7],    // MY_433: 433.175-434.575 MHz, 7 channels
-    17: [919.0, 0.2, 15],     // MY_919: 919.0-921.8 MHz, 15 channels
-    18: [923.0, 0.2, 15],     // SG_923: 923.0-925.8 MHz, 15 channels
-    19: [433.175, 0.2, 7],    // PH_433: 433.175-434.575 MHz, 7 channels
-    20: [863.275, 0.2, 7],    // PH_868: 863.275-864.575 MHz, 7 channels
-    21: [915.0, 0.2, 72],     // PH_915: 915.0-927.8 MHz, 72 channels
-    22: [433.175, 0.2, 7],    // ANZ_433: 433.175-434.575 MHz, 7 channels
-    23: [433.175, 0.2, 7],    // KZ_433: 433.175-434.575 MHz, 7 channels
-    24: [863.0, 0.2, 7],      // KZ_863: 863.0-864.4 MHz, 7 channels
-    25: [865.0, 0.2, 15],     // NP_865: 865.0-867.8 MHz, 15 channels
-    26: [902.0, 0.2, 72]      // BR_902: 902.0-914.8 MHz, 72 channels
+  // Region frequency bounds from Meshtastic firmware RadioInterface.cpp
+  // Format: region -> [freqStart (MHz), freqEnd (MHz)]
+  // Reference: RDEF macros in RadioInterface.cpp
+  const regionFrequencyBounds: { [key: number]: [number, number] } = {
+    1: [902.0, 928.0],      // US: 902-928 MHz (FCC Part 15)
+    2: [433.0, 434.0],      // EU_433: 433-434 MHz
+    3: [869.4, 869.65],     // EU_868: 869.4-869.65 MHz (EN300220)
+    4: [470.0, 510.0],      // CN: 470-510 MHz
+    5: [920.8, 923.8],      // JP: 920.8-923.8 MHz
+    6: [915.0, 928.0],      // ANZ: 915-928 MHz
+    7: [920.0, 923.0],      // KR: 920-923 MHz
+    8: [920.0, 925.0],      // TW: 920-925 MHz
+    9: [433.0, 434.79],     // RU: 433-434.79 MHz
+    10: [865.0, 867.0],     // IN: 865-867 MHz
+    11: [864.0, 868.0],     // NZ_865: 864-868 MHz
+    12: [920.0, 925.0],     // TH: 920-925 MHz
+    13: [2400.0, 2483.5],   // LORA_24: 2.4 GHz ISM
+    14: [433.0, 434.79],    // UA_433: 433-434.79 MHz
+    15: [868.0, 868.6],     // UA_868: 868-868.6 MHz
+    16: [433.0, 435.0],     // MY_433: 433-435 MHz
+    17: [919.0, 924.0],     // MY_919: 919-924 MHz
+    18: [920.0, 925.0],     // SG_923: 920-925 MHz
+    19: [433.0, 435.0],     // PH_433: 433-435 MHz
+    20: [868.0, 868.6],     // PH_868: 868-868.6 MHz
+    21: [915.0, 928.0],     // PH_915: 915-928 MHz
+    22: [433.0, 435.0],     // ANZ_433: 433-435 MHz
+    23: [433.0, 435.0],     // KZ_433: 433-435 MHz
+    24: [864.0, 865.0],     // KZ_863: 864-865 MHz (Note: region is named KZ_863 but uses 864-865)
+    25: [865.0, 867.0],     // NP_865: 865-867 MHz
+    26: [902.0, 907.5]      // BR_902: 902-907.5 MHz
   };
 
   if (!region || region === 0) {
     return 'Unknown';
   }
 
-  const params = regionFrequencyParams[region];
-  if (!params) {
+  const bounds = regionFrequencyBounds[region];
+  if (!bounds) {
     return 'Unknown';
   }
 
-  const [baseFreq, channelSpacing, maxChannels] = params;
+  const [freqStart, freqEnd] = bounds;
+
+  // Use bandwidth in kHz, default to 250 kHz (LongFast)
+  const bw = bandwidth > 0 ? bandwidth : 250;
+
+  // Calculate channel spacing based on bandwidth (bw is in kHz)
+  const channelSpacing = bw / 1000; // Convert to MHz
+
+  // Calculate maximum number of channels that fit in the frequency range
+  const maxChannels = Math.floor((freqEnd - freqStart) / channelSpacing);
 
   // Validate channel number
   if (channelNum < 0 || channelNum >= maxChannels) {
     return 'Invalid channel';
   }
 
-  // Calculate frequency: baseFreq + (channelNum * channelSpacing) + frequencyOffset
-  const calculatedFreq = baseFreq + (channelNum * channelSpacing) + (frequencyOffset || 0);
+  // Official Meshtastic formula from RadioInterface.cpp:
+  // freq = freqStart + (bw / 2000) + (channel_num * (bw / 1000))
+  const halfBwOffset = bw / 2000; // Half bandwidth in MHz
+  const calculatedFreq = freqStart + halfBwOffset + (channelNum * channelSpacing) + (frequencyOffset || 0);
+
   return `${calculatedFreq.toFixed(3)} MHz`;
 }
-


### PR DESCRIPTION
## Summary
- Fixes incorrect LoRa carrier frequency display for EU_868 and other regions
- Implements the official Meshtastic firmware formula: `freq = freqStart + (bw / 2000) + (channel_num * (bw / 1000))`
- Adds bandwidth parameter to dynamically calculate frequencies based on LoRa preset

## Problem
The previous implementation was missing the half-bandwidth offset (`bw / 2000`) from the frequency calculation, and had incorrect base frequencies for some regions. For example, EU_868 slot 0 should calculate to 869.525 MHz (869.4 + 0.125), not 869.325 MHz.

## Solution
- Updated `calculateLoRaFrequency()` to use the correct formula from `RadioInterface.cpp`
- Added bandwidth parameter (defaults to 250 kHz for LongFast preset)
- Updated region frequency bounds to match firmware values
- Dynamic max channel calculation based on bandwidth
- Updated caller in `meshtasticManager.ts` to pass actual bandwidth from LoRa config

Fixes #1127

## Test plan
- [x] All unit tests pass (26 tests in loraFrequency.test.ts)
- [x] TypeScript compiles without errors
- [ ] Manual verification with EU_868 region device

🤖 Generated with [Claude Code](https://claude.com/claude-code)