### PR TITLE
feat(nodes): add position override for nodes (#1128)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2679,5 +2679,23 @@
   "admin_commands.load_section": "Load {{section}}",
   "admin_commands.load_button": "Load",
   "admin_commands.section_loaded": "Section loaded successfully",
-  "admin_commands.section_load_failed": "Failed to load section"
+  "admin_commands.section_load_failed": "Failed to load section",
+
+  "messages.override_position": "Override Position",
+  "messages.override_position_title": "Set a custom position for this node",
+
+  "position_override.title": "Position Override: {{nodeName}}",
+  "position_override.description": "Override this node's position on the map. When enabled, this custom position will be used instead of the GPS or estimated position for map display and distance calculations.",
+  "position_override.use_position": "Use this custom position",
+  "position_override.latitude": "Latitude",
+  "position_override.latitude_description": "Range: -90 to 90 (decimal degrees)",
+  "position_override.latitude_error": "Latitude must be between -90 and 90",
+  "position_override.longitude": "Longitude",
+  "position_override.longitude_description": "Range: -180 to 180 (decimal degrees)",
+  "position_override.longitude_error": "Longitude must be between -180 and 180",
+  "position_override.altitude": "Altitude (optional)",
+  "position_override.altitude_description": "Elevation above sea level in meters",
+  "position_override.find_coordinates": "Find your GPS coordinates here",
+  "position_override.save_success": "Position override saved successfully",
+  "position_override.save_error": "Failed to save position override"
 }

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -131,6 +131,7 @@ export interface MessagesTabProps {
   // Modal controls
   setShowTracerouteHistoryModal: (show: boolean) => void;
   setShowPurgeDataModal: (show: boolean) => void;
+  setShowPositionOverrideModal: (show: boolean) => void;
   setEmojiPickerMessage: (message: MeshMessage | null) => void;
 
   // Helper function
@@ -196,6 +197,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   toggleFavorite,
   setShowTracerouteHistoryModal,
   setShowPurgeDataModal,
+  setShowPositionOverrideModal,
   setEmojiPickerMessage,
   shouldShowData,
   handleShowOnMap,
@@ -908,6 +910,24 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                     title={t('messages.show_on_map_title')}
                   >
                     🗺️ {t('messages.show_on_map')}
+                  </button>
+                )}
+                {hasPermission('nodes', 'write') && (
+                  <button
+                    onClick={() => setShowPositionOverrideModal(true)}
+                    className="traceroute-btn"
+                    style={{
+                      backgroundColor: '#6c757d',
+                      color: 'white',
+                      border: 'none',
+                      padding: '0.5rem 1rem',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      fontWeight: 'bold',
+                    }}
+                    title={t('messages.override_position_title')}
+                  >
+                    📍 {t('messages.override_position')}
                   </button>
                 )}
                 {hasPermission('messages', 'write') && (

--- a/src/components/PositionOverrideModal/PositionOverrideModal.css
+++ b/src/components/PositionOverrideModal/PositionOverrideModal.css
@@ -1,0 +1,156 @@
+.position-override-modal {
+  max-width: 500px;
+}
+
+.position-override-loading {
+  text-align: center;
+  padding: 2rem;
+  color: var(--ctp-subtext0);
+}
+
+.position-override-description {
+  margin-bottom: 1.5rem;
+  color: var(--ctp-subtext0);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.position-override-checkbox {
+  margin-bottom: 1.5rem;
+}
+
+.position-override-checkbox label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.position-override-checkbox input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.position-override-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.position-override-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.position-override-field label {
+  font-weight: 500;
+  color: var(--ctp-text);
+}
+
+.position-override-field .field-description {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--ctp-subtext0);
+  font-weight: normal;
+  margin-top: 2px;
+}
+
+.position-override-field input {
+  padding: 0.75rem;
+  border: 1px solid var(--ctp-surface1);
+  border-radius: 4px;
+  background-color: var(--ctp-surface0);
+  color: var(--ctp-text);
+  font-size: 1rem;
+}
+
+.position-override-field input:focus {
+  outline: none;
+  border-color: var(--ctp-blue);
+  box-shadow: 0 0 0 2px rgba(137, 180, 250, 0.2);
+}
+
+.position-override-field input.input-error {
+  border-color: var(--ctp-red);
+}
+
+.position-override-field input.input-error:focus {
+  box-shadow: 0 0 0 2px rgba(243, 139, 168, 0.2);
+}
+
+.position-override-field .error-message {
+  color: var(--ctp-red);
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+}
+
+.position-override-link {
+  margin-top: 0.5rem;
+}
+
+.position-override-link a {
+  color: var(--ctp-blue);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.position-override-link a:hover {
+  text-decoration: underline;
+}
+
+.position-override-error {
+  background-color: rgba(243, 139, 168, 0.1);
+  border: 1px solid var(--ctp-red);
+  color: var(--ctp-red);
+  padding: 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.position-override-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.position-override-actions .cancel-btn {
+  background-color: var(--ctp-surface1);
+  color: var(--ctp-text);
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 1rem;
+}
+
+.position-override-actions .cancel-btn:hover:not(:disabled) {
+  background-color: var(--ctp-surface2);
+}
+
+.position-override-actions .save-btn {
+  background-color: var(--ctp-blue);
+  color: var(--ctp-base);
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 1rem;
+}
+
+.position-override-actions .save-btn:hover:not(:disabled) {
+  background-color: var(--ctp-sapphire);
+}
+
+.position-override-actions .save-btn:disabled,
+.position-override-actions .cancel-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/components/PositionOverrideModal/PositionOverrideModal.tsx
+++ b/src/components/PositionOverrideModal/PositionOverrideModal.tsx
@@ -1,0 +1,300 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import './PositionOverrideModal.css';
+
+interface Node {
+  nodeNum: number;
+  user?: {
+    id: string;
+    longName?: string;
+    shortName?: string;
+  };
+}
+
+interface PositionOverride {
+  enabled: boolean;
+  latitude?: number;
+  longitude?: number;
+  altitude?: number;
+}
+
+interface PositionOverrideModalProps {
+  isOpen: boolean;
+  selectedNode: Node | null;
+  onClose: () => void;
+  onSave: (nodeNum: number, data: PositionOverride) => Promise<void>;
+  getNodeName: (nodeId: string) => string;
+  baseUrl: string;
+}
+
+export const PositionOverrideModal: React.FC<PositionOverrideModalProps> = ({
+  isOpen,
+  selectedNode,
+  onClose,
+  onSave,
+  getNodeName,
+  baseUrl,
+}) => {
+  const { t } = useTranslation();
+  const [enabled, setEnabled] = useState(false);
+  const [latitude, setLatitude] = useState<string>('');
+  const [longitude, setLongitude] = useState<string>('');
+  const [altitude, setAltitude] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Validation state
+  const [latError, setLatError] = useState<string | null>(null);
+  const [lngError, setLngError] = useState<string | null>(null);
+
+  // Track if we've loaded data for current modal session to prevent poll refresh from resetting
+  const loadedForNodeRef = useRef<string | null>(null);
+
+  // Extract node ID to use as stable dependency
+  const nodeId = selectedNode?.user?.id;
+
+  // Load current override when modal opens (only once per modal session)
+  useEffect(() => {
+    if (isOpen && nodeId && loadedForNodeRef.current !== nodeId) {
+      loadedForNodeRef.current = nodeId;
+      setLoading(true);
+      setError(null);
+      fetch(`${baseUrl}/api/nodes/${nodeId}/position-override`, {
+        credentials: 'include',
+      })
+        .then(res => {
+          if (res.ok) return res.json();
+          throw new Error('Failed to load position override');
+        })
+        .then((data: PositionOverride) => {
+          setEnabled(data.enabled);
+          setLatitude(data.latitude?.toString() ?? '');
+          setLongitude(data.longitude?.toString() ?? '');
+          setAltitude(data.altitude?.toString() ?? '');
+        })
+        .catch(err => {
+          console.error('Error loading position override:', err);
+          // Reset to defaults if load fails
+          setEnabled(false);
+          setLatitude('');
+          setLongitude('');
+          setAltitude('');
+        })
+        .finally(() => setLoading(false));
+    }
+    // Reset the ref when modal closes so it reloads on next open
+    if (!isOpen) {
+      loadedForNodeRef.current = null;
+    }
+  }, [isOpen, nodeId, baseUrl]);
+
+  // Reset error state when values change
+  useEffect(() => {
+    setError(null);
+  }, [enabled, latitude, longitude, altitude]);
+
+  if (!isOpen || !selectedNode) return null;
+
+  const nodeName = selectedNode.user?.id ? getNodeName(selectedNode.user.id) : '';
+
+  const validateLatitude = (value: string): boolean => {
+    const num = parseFloat(value);
+    if (isNaN(num) || num < -90 || num > 90) {
+      setLatError(t('position_override.latitude_error'));
+      return false;
+    }
+    setLatError(null);
+    return true;
+  };
+
+  const validateLongitude = (value: string): boolean => {
+    const num = parseFloat(value);
+    if (isNaN(num) || num < -180 || num > 180) {
+      setLngError(t('position_override.longitude_error'));
+      return false;
+    }
+    setLngError(null);
+    return true;
+  };
+
+  const handleSave = async () => {
+    setError(null);
+
+    // Validate if enabled
+    if (enabled) {
+      const latValid = validateLatitude(latitude);
+      const lngValid = validateLongitude(longitude);
+      if (!latValid || !lngValid) {
+        return;
+      }
+    }
+
+    setSaving(true);
+    try {
+      await onSave(selectedNode.nodeNum, {
+        enabled,
+        latitude: enabled ? parseFloat(latitude) : undefined,
+        longitude: enabled ? parseFloat(longitude) : undefined,
+        altitude: enabled && altitude ? parseFloat(altitude) : undefined,
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save position override');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleLatitudeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLatitude(e.target.value);
+    if (e.target.value) {
+      validateLatitude(e.target.value);
+    } else {
+      setLatError(null);
+    }
+  };
+
+  const handleLongitudeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLongitude(e.target.value);
+    if (e.target.value) {
+      validateLongitude(e.target.value);
+    } else {
+      setLngError(null);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content position-override-modal" onClick={e => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2>{t('position_override.title', { nodeName })}</h2>
+          <button className="modal-close" onClick={onClose} disabled={saving}>
+            &times;
+          </button>
+        </div>
+        <div className="modal-body">
+          {loading ? (
+            <div className="position-override-loading">
+              {t('common.loading')}...
+            </div>
+          ) : (
+            <>
+              <p className="position-override-description">
+                {t('position_override.description')}
+              </p>
+
+              <div className="position-override-checkbox">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={enabled}
+                    onChange={e => setEnabled(e.target.checked)}
+                    disabled={saving}
+                  />
+                  {t('position_override.use_position')}
+                </label>
+              </div>
+
+              {enabled && (
+                <div className="position-override-fields">
+                  <div className="position-override-field">
+                    <label htmlFor="override-latitude">
+                      {t('position_override.latitude')}
+                      <span className="field-description">
+                        {t('position_override.latitude_description')}
+                      </span>
+                    </label>
+                    <input
+                      id="override-latitude"
+                      type="number"
+                      step="0.000001"
+                      min="-90"
+                      max="90"
+                      value={latitude}
+                      onChange={handleLatitudeChange}
+                      disabled={saving}
+                      className={latError ? 'input-error' : ''}
+                    />
+                    {latError && <span className="error-message">{latError}</span>}
+                  </div>
+
+                  <div className="position-override-field">
+                    <label htmlFor="override-longitude">
+                      {t('position_override.longitude')}
+                      <span className="field-description">
+                        {t('position_override.longitude_description')}
+                      </span>
+                    </label>
+                    <input
+                      id="override-longitude"
+                      type="number"
+                      step="0.000001"
+                      min="-180"
+                      max="180"
+                      value={longitude}
+                      onChange={handleLongitudeChange}
+                      disabled={saving}
+                      className={lngError ? 'input-error' : ''}
+                    />
+                    {lngError && <span className="error-message">{lngError}</span>}
+                  </div>
+
+                  <div className="position-override-field">
+                    <label htmlFor="override-altitude">
+                      {t('position_override.altitude')}
+                      <span className="field-description">
+                        {t('position_override.altitude_description')}
+                      </span>
+                    </label>
+                    <input
+                      id="override-altitude"
+                      type="number"
+                      step="1"
+                      value={altitude}
+                      onChange={e => setAltitude(e.target.value)}
+                      disabled={saving}
+                    />
+                  </div>
+
+                  <div className="position-override-link">
+                    <a
+                      href="https://gps-coordinates.org/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {t('position_override.find_coordinates')}
+                    </a>
+                  </div>
+                </div>
+              )}
+
+              {error && (
+                <div className="position-override-error">
+                  {error}
+                </div>
+              )}
+
+              <div className="position-override-actions">
+                <button
+                  className="cancel-btn"
+                  onClick={onClose}
+                  disabled={saving}
+                >
+                  {t('common.cancel')}
+                </button>
+                <button
+                  className="save-btn"
+                  onClick={handleSave}
+                  disabled={saving || (enabled && (latError !== null || lngError !== null))}
+                >
+                  {saving ? t('common.saving') : t('common.save')}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/PositionOverrideModal/index.ts
+++ b/src/components/PositionOverrideModal/index.ts
@@ -1,0 +1,1 @@
+export { PositionOverrideModal } from './PositionOverrideModal';

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -57,6 +57,12 @@ export interface DeviceInfo {
   snr?: number;
   rssi?: number;
   mobile?: number; // Database field: 0 = not mobile, 1 = mobile (moved >100m)
+  // Position override fields
+  positionOverrideEnabled?: number;
+  latitudeOverride?: number;
+  longitudeOverride?: number;
+  altitudeOverride?: number;
+  positionIsOverride?: boolean;
 }
 
 export interface MeshMessage {
@@ -7865,6 +7871,20 @@ class MeshtasticManager {
           longitude: node.longitude,
           altitude: node.altitude
         };
+      }
+
+      // Add position override fields
+      if (node.positionOverrideEnabled !== null && node.positionOverrideEnabled !== undefined) {
+        deviceInfo.positionOverrideEnabled = node.positionOverrideEnabled;
+      }
+      if (node.latitudeOverride !== null && node.latitudeOverride !== undefined) {
+        deviceInfo.latitudeOverride = node.latitudeOverride;
+      }
+      if (node.longitudeOverride !== null && node.longitudeOverride !== undefined) {
+        deviceInfo.longitudeOverride = node.longitudeOverride;
+      }
+      if (node.altitudeOverride !== null && node.altitudeOverride !== undefined) {
+        deviceInfo.altitudeOverride = node.altitudeOverride;
       }
 
       return deviceInfo;

--- a/src/server/migrations/040_add_position_override_to_nodes.ts
+++ b/src/server/migrations/040_add_position_override_to_nodes.ts
@@ -1,0 +1,97 @@
+/**
+ * Migration 040: Add position override columns to nodes table
+ *
+ * Adds columns to allow users to manually override a node's position.
+ * When enabled, this override takes precedence over GPS and estimated positions
+ * for map display and distance calculations.
+ */
+
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.debug('Running migration 040: Add position override columns to nodes table');
+
+    try {
+      // Check which columns already exist
+      const columns = db.pragma("table_info('nodes')") as Array<{ name: string }>;
+      const columnNames = new Set(columns.map((col) => col.name));
+
+      // Add positionOverrideEnabled column
+      if (!columnNames.has('positionOverrideEnabled')) {
+        db.exec(`
+          ALTER TABLE nodes ADD COLUMN positionOverrideEnabled INTEGER DEFAULT 0;
+        `);
+        logger.debug('✅ Added positionOverrideEnabled column to nodes table');
+      } else {
+        logger.debug('✅ positionOverrideEnabled column already exists, skipping');
+      }
+
+      // Add latitudeOverride column
+      if (!columnNames.has('latitudeOverride')) {
+        db.exec(`
+          ALTER TABLE nodes ADD COLUMN latitudeOverride REAL;
+        `);
+        logger.debug('✅ Added latitudeOverride column to nodes table');
+      } else {
+        logger.debug('✅ latitudeOverride column already exists, skipping');
+      }
+
+      // Add longitudeOverride column
+      if (!columnNames.has('longitudeOverride')) {
+        db.exec(`
+          ALTER TABLE nodes ADD COLUMN longitudeOverride REAL;
+        `);
+        logger.debug('✅ Added longitudeOverride column to nodes table');
+      } else {
+        logger.debug('✅ longitudeOverride column already exists, skipping');
+      }
+
+      // Add altitudeOverride column
+      if (!columnNames.has('altitudeOverride')) {
+        db.exec(`
+          ALTER TABLE nodes ADD COLUMN altitudeOverride REAL;
+        `);
+        logger.debug('✅ Added altitudeOverride column to nodes table');
+      } else {
+        logger.debug('✅ altitudeOverride column already exists, skipping');
+      }
+
+      // Create index for efficient filtering of nodes with position override
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_nodes_position_override ON nodes(positionOverrideEnabled);
+      `);
+      logger.debug('✅ Created index on positionOverrideEnabled column');
+
+      logger.debug('✅ Migration 040 completed: position override columns added to nodes table');
+    } catch (error) {
+      logger.error('❌ Migration 040 failed:', error);
+      throw error;
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Running migration 040 down: Remove position override columns from nodes table');
+
+    try {
+      // SQLite doesn't support DROP COLUMN directly until version 3.35.0
+      // For older versions, we'd need to recreate the table without the columns
+      // But for this case, we'll just note that the columns can remain
+      logger.debug('⚠️  Note: SQLite DROP COLUMN requires version 3.35.0+');
+      logger.debug('⚠️  The position override columns will remain but will not be used');
+
+      // For SQLite 3.35.0+, uncomment the following:
+      // db.exec(`DROP INDEX IF EXISTS idx_nodes_position_override;`);
+      // db.exec(`ALTER TABLE nodes DROP COLUMN positionOverrideEnabled;`);
+      // db.exec(`ALTER TABLE nodes DROP COLUMN latitudeOverride;`);
+      // db.exec(`ALTER TABLE nodes DROP COLUMN longitudeOverride;`);
+      // db.exec(`ALTER TABLE nodes DROP COLUMN altitudeOverride;`);
+
+      logger.debug('✅ Migration 040 rollback completed');
+    } catch (error) {
+      logger.error('❌ Migration 040 rollback failed:', error);
+      throw error;
+    }
+  }
+};

--- a/src/types/device.ts
+++ b/src/types/device.ts
@@ -34,6 +34,12 @@ export interface DeviceInfo {
   duplicateKeyDetected?: boolean
   keySecurityIssueDetails?: string
   channel?: number
+  // Position override fields (positionOverrideEnabled is 0 or 1 from database)
+  positionOverrideEnabled?: number
+  latitudeOverride?: number
+  longitudeOverride?: number
+  altitudeOverride?: number
+  positionIsOverride?: boolean
 }
 
 export interface Channel {
@@ -68,4 +74,9 @@ export interface DbNode extends Partial<DeviceInfo> {
   createdAt?: number
   updatedAt?: number
   lastTracerouteRequest?: number
+  // Position override fields (stored in database)
+  positionOverrideEnabled?: number // 0 or 1 in SQLite
+  latitudeOverride?: number
+  longitudeOverride?: number
+  altitudeOverride?: number
 }


### PR DESCRIPTION
## Summary

- Add "Override Position" button to Node Details page (Messages tab) next to Purge Data button
- New modal allows setting custom lat/lng/alt coordinates with validation
- Position override persists server-side and takes precedence over GPS/estimated positions
- Override automatically applied to map display and distance calculations

## Changes

### New Files
- `src/server/migrations/040_add_position_override_to_nodes.ts` - Database migration
- `src/components/PositionOverrideModal/` - Modal component with CSS

### Modified Files
- `src/services/database.ts` - Added position override methods
- `src/server/server.ts` - Added API endpoints and position priority logic
- `src/server/meshtasticManager.ts` - Added position override fields to DeviceInfo
- `src/types/device.ts` - Added type definitions
- `src/components/MessagesTab.tsx` - Added Override Position button
- `src/App.tsx` - Integrated modal state and handler
- `public/locales/en.json` - Added translations

## Test plan

- [x] Build passes
- [x] TypeScript checks pass
- [x] System tests pass
- [x] Manual testing: Set position override for a node
- [x] Manual testing: Verify map shows override position
- [x] Manual testing: Clear override and verify node reverts to GPS/estimated
- [x] Manual testing: Validate lat/lng input rejection for out-of-range values

## System Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| Reverse Proxy Test | ✅ PASSED |
| Reverse Proxy + OIDC | ✅ PASSED |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |

Closes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)