### PR TITLE
fix(traceroute): skip processing our own outgoing traceroute responses (#1140)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2688,6 +2688,15 @@ class MeshtasticManager {
       const toNum = Number(meshPacket.to);
       const toNodeId = `!${toNum.toString(16).padStart(8, '0')}`;
 
+      // Skip traceroute responses FROM our local node (Issue #1140)
+      // When another node traceroutes us, we capture our own outgoing response.
+      // This response only has the forward path (route), not a meaningful return path (routeBack),
+      // which causes incorrect "direct line" route segments to be displayed on the map.
+      if (this.localNodeInfo && fromNum === this.localNodeInfo.nodeNum) {
+        logger.debug(`🗺️ Skipping traceroute response from local node ${fromNodeId} (our response to someone else's request)`);
+        return;
+      }
+
       logger.info(`🗺️ Traceroute response from ${fromNodeId}:`, JSON.stringify(routeDiscovery, null, 2));
 
       // Ensure from node exists in database (don't overwrite existing names)


### PR DESCRIPTION
## Summary
- Fixes incorrect "direct line" route segments shown on the map when another node traceroutes us
- Skip processing traceroute responses that originate from our local node

## Problem
When another node (A) sends a traceroute request to us (B):
1. Our firmware responds with a traceroute response
2. MeshMonitor captures our own outgoing response
3. This response only has the forward `route` (path TO us), but `routeBack` is empty
4. This causes a direct line to be drawn from us to the requester on the map

## Solution
Check if `fromNum` equals our local node number in `processTracerouteMessage()`. If so, skip processing since it's our own response to someone else's request, not a traceroute result we requested.

## Test plan
- [ ] Have another node traceroute your MeshMonitor node
- [ ] Verify no direct line appears on the map for the return path
- [ ] Verify traceroutes you initiate still work correctly
- [ ] Check logs for: `Skipping traceroute response from local node`

Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)