### PR TITLE
fix(map): filter neighbor info segments when connected nodes are filtered (#1149)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4267,6 +4267,7 @@ function App() {
             markerRefs={markerRefs}
             traceroutePathsElements={traceroutePathsElements}
             selectedNodeTraceroute={selectedNodeTraceroute}
+            visibleNodeNums={visibleNodeNums}
           />
         )}
         {activeTab === 'channels' && (

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -48,6 +48,8 @@ interface NodesTabProps {
   markerRefs: React.MutableRefObject<Map<string, LeafletMarker>>;
   traceroutePathsElements: React.ReactNode;
   selectedNodeTraceroute: React.ReactNode;
+  /** Set of visible node numbers for filtering neighbor info segments (Issue #1149) */
+  visibleNodeNums?: Set<number>;
 }
 
 // Helper function to check if a date is today
@@ -82,6 +84,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   markerRefs,
   traceroutePathsElements,
   selectedNodeTraceroute,
+  visibleNodeNums,
 }) => {
   const { t } = useTranslation();
   // Use context hooks
@@ -1463,6 +1466,11 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               {showNeighborInfo && neighborInfo.length > 0 && neighborInfo.map((ni, idx) => {
                 // Skip if either node doesn't have position
                 if (!ni.nodeLatitude || !ni.nodeLongitude || !ni.neighborLatitude || !ni.neighborLongitude) {
+                  return null;
+                }
+
+                // Filter out segments where either endpoint is not visible (Issue #1149)
+                if (visibleNodeNums && (!visibleNodeNums.has(ni.nodeNum) || !visibleNodeNums.has(ni.neighborNodeNum))) {
                   return null;
                 }
 


### PR DESCRIPTION
## Summary
- Filter neighbor info segments when either endpoint node is filtered out
- Reuses the existing `visibleNodeNums` set already computed for traceroute filtering
- Applies the same approach as PR #1104 for traceroutes

## Changes
- Added `visibleNodeNums` prop to NodesTab component
- Pass `visibleNodeNums` from App.tsx to NodesTab
- Skip rendering neighbor info segments where either endpoint is not in the visible set

## Test plan
- [x] Build passes
- [x] TypeScript type check passes
- [ ] Configure multiple channels on nodes
- [ ] Filter by channel on map
- [ ] Verify neighbor info segments to filtered-out nodes are hidden

Closes #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)