### PR TITLE
fix(messages): use correct endpoint for resending direct messages (#1130)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3019,7 +3019,9 @@ function App() {
     }, 50);
 
     try {
-      const endpoint = isDM ? `${baseUrl}/api/messages/dm` : `${baseUrl}/api/messages/send`;
+      // Use the same endpoint for both DMs and channel messages
+      // DMs include a destination parameter, channel messages include a channel parameter
+      const endpoint = `${baseUrl}/api/messages/send`;
       const body = isDM
         ? { text: message.text, destination: destinationNodeId }
         : { text: message.text, channel: messageChannel };


### PR DESCRIPTION
## Summary
- Fix resend message functionality for direct messages
- The `handleResendMessage` function was using a non-existent `/api/messages/dm` endpoint
- Changed to use `/api/messages/send` with a `destination` parameter (consistent with `handleSendDirectMessage`)

## Root Cause
The resend function had:
```tsx
const endpoint = isDM ? `${baseUrl}/api/messages/dm` : `${baseUrl}/api/messages/send`;
```

But `/api/messages/dm` doesn't exist - DMs should use `/api/messages/send` with a `destination` parameter, just like the regular send function does.

## Test plan
- [x] Build passes
- [ ] Send a direct message to a node
- [ ] Click the resend button on that message
- [ ] Verify the message is resent successfully (no 404 error)

Closes #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)