### PR TITLE
chore: add TODO for replacing GPL-licensed session store

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -2,6 +2,25 @@
 
 ## Current Sprint
 
+### Replace GPL-licensed Session Store (#1177)
+
+**Priority: HIGH** - License compatibility issue
+
+The `better-sqlite3-session-store` package is GPL-3.0-only licensed, which conflicts with MeshMonitor's BSD-3-Clause license. This is actual code being imported and linked, not just data definitions.
+
+**Tasks:**
+- [ ] Write custom SQLite session store using `better-sqlite3` (MIT licensed)
+- [ ] Implement express-session Store interface: `get`, `set`, `destroy`, `touch`
+- [ ] Add session cleanup for expired sessions
+- [ ] Remove `better-sqlite3-session-store` dependency
+- [ ] Update `src/server/auth/sessionConfig.ts` to use new store
+- [ ] Test session persistence across restarts
+- [ ] Run system tests
+
+**Reference:** The existing store is ~72 lines. We already use `better-sqlite3` directly (MIT licensed).
+
+---
+
 ### MQTT Traceroute Visualization (#893)
 
 **Completed:**


### PR DESCRIPTION
## Summary

Adds a TODO item to track replacing the `better-sqlite3-session-store` package which is GPL-3.0-only licensed.

This is more significant than the protobufs licensing question raised in #1177 because it's actual code being imported and linked into the application, not just data definitions.

## Plan

Write a custom SQLite session store (~50-70 lines) using the MIT-licensed `better-sqlite3` package we already depend on. The express-session Store interface is simple: `get`, `set`, `destroy`, `touch`.

Related to #1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)