### PR TITLE
fix(api): skip CSRF protection for Bearer token authenticated requests

### DIFF
--- a/src/server/middleware/csrf.ts
+++ b/src/server/middleware/csrf.ts
@@ -43,6 +43,15 @@ export function csrfProtection(req: Request, res: Response, next: NextFunction) 
     return next();
   }
 
+  // Skip CSRF check for API token authenticated requests (Bearer token)
+  // CSRF protection is for browser-based sessions using cookies
+  // API tokens are not stored in cookies and must be explicitly provided,
+  // so they are inherently protected against CSRF attacks
+  const authHeader = req.headers.authorization;
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    return next();
+  }
+
   // Skip CSRF check for endpoints that must be accessible without tokens
   // /csrf-token: Users need this to get a token before they have one
   // /auth/status: Public endpoint for checking auth state


### PR DESCRIPTION
## Summary

Fixes discussion #1178

The v1 API uses Bearer token authentication, which is inherently protected against CSRF attacks since:
1. Tokens are not stored in cookies
2. Tokens must be explicitly provided in the Authorization header
3. Attackers cannot trick a browser into adding a Bearer token

Previously, POST/PUT/DELETE requests to `/api/v1/*` endpoints would fail with "CSRF token required" even when using valid API tokens.

### Changes
- Modified CSRF middleware to skip protection when `Authorization: Bearer` header is present

## Test plan

```bash
# This should now work (previously returned CSRF error)
curl -X POST http://localhost:8080/meshmonitor/api/v1/messages \
  -H "Authorization: Bearer mm_v1_..." \
  -H "Content-Type: application/json" \
  -d '{"text": "Test message", "toNodeId": "!ffffffff"}'
```

- [ ] Verify POST to /api/v1/messages works with Bearer token
- [ ] Verify POST to /api/v1/messages still requires Bearer token (returns 401 without)
- [ ] Verify browser-based POST requests still require CSRF token

🤖 Generated with [Claude Code](https://claude.com/claude-code)