### PR TITLE
fix(docker): add python symlink for user scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,11 +43,13 @@ FROM node:24-alpine
 WORKDIR /app
 
 # Install Python and dependencies for Apprise
+# Create python symlink for user scripts that use #!/usr/bin/env python
 RUN apk add --no-cache \
     python3 \
     py3-pip \
     supervisor \
     su-exec \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
     && python3 -m venv /opt/apprise-venv \
     && /opt/apprise-venv/bin/pip install --no-cache-dir apprise "paho-mqtt<2.0"
 


### PR DESCRIPTION
## Summary

- Adds symlink from `/usr/bin/python` to `/usr/bin/python3` in the Docker container
- Alpine Linux only provides `python3`, not `python`, causing user scripts to fail with ENOENT error

Fixes #1170

## Root Cause

When users try to run Python scripts from the User Scripts Gallery, they get:
```
error: spawn /usr/bin/python enoent
```

This is because Alpine Linux doesn't create a `/usr/bin/python` symlink by default - only `python3` exists.

## Test plan

- [x] Rebuild container with symlink
- [x] Verify `/usr/bin/python` exists and works
- [x] Verify `python --version` returns Python 3.12.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)