### PR TITLE
chore: add rebase-strategy auto to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       day: "monday"
       time: "04:00"
     open-pull-requests-limit: 10
+    rebase-strategy: "auto"
     reviewers:
       - "yeraze"
     labels:
@@ -41,6 +42,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "04:00"
+    rebase-strategy: "auto"
     reviewers:
       - "yeraze"
     labels:
@@ -54,6 +56,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "04:00"
+    rebase-strategy: "auto"
     reviewers:
       - "yeraze"
     labels:


### PR DESCRIPTION
## Summary
- Adds `rebase-strategy: auto` to all dependabot ecosystems (npm, github-actions, docker)
- This tells dependabot to automatically rebase PRs when the base branch changes

This helps keep dependabot PRs up-to-date, though complex package-lock.json conflicts may still require manual `@dependabot recreate` commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)