### PR TITLE
chore: bump version to 2.21.7

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "2.21.6",
+  "version": "2.21.7",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.21.6
-appVersion: "2.21.6"
+version: 2.21.7
+appVersion: "2.21.7"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.21.6",
+  "version": "2.21.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.21.6",
+      "version": "2.21.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.21.6",
+  "version": "2.21.7",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

- Bump version to 2.21.7 in package.json, Helm chart, and Tauri config

## Files Changed

- `package.json` - version 2.21.6 → 2.21.7
- `package-lock.json` - regenerated
- `helm/meshmonitor/Chart.yaml` - version and appVersion 2.21.6 → 2.21.7
- `desktop/src-tauri/tauri.conf.json` - version 2.21.6 → 2.21.7

## System Test Results

```
==========================================
System Test Results
==========================================

Configuration Import:     ✓ PASSED
Quick Start Test:         ✓ PASSED
Security Test:            ✓ PASSED
V1 API Test:              ✓ PASSED
Reverse Proxy Test:       ✓ PASSED
Reverse Proxy + OIDC:     ✓ PASSED
Virtual Node CLI:         ✓ PASSED
Backup & Restore:         ✓ PASSED

==========================================
All tests passed!
==========================================
```

## Test plan

- [x] All system tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)