### PR TITLE
fix(vns): respond to heartbeat packets to prevent iOS client disconnection

### DIFF
--- a/src/server/meshtasticProtobufService.ts
+++ b/src/server/meshtasticProtobufService.ts
@@ -1085,6 +1085,44 @@ export class MeshtasticProtobufService {
   }
 
   /**
+   * Create QueueStatus FromRadio message
+   * Used as a heartbeat response to keep iOS clients connected
+   */
+  async createQueueStatus(options?: {
+    res?: number;
+    free?: number;
+    maxlen?: number;
+    meshPacketId?: number;
+  }): Promise<Uint8Array | null> {
+    const root = getProtobufRoot();
+    if (!root) {
+      logger.error('❌ Protobuf definitions not loaded');
+      return null;
+    }
+
+    try {
+      const FromRadio = root.lookupType('meshtastic.FromRadio');
+      const QueueStatus = root.lookupType('meshtastic.QueueStatus');
+
+      const queueStatus = QueueStatus.create({
+        res: options?.res ?? 0,
+        free: options?.free ?? 32,
+        maxlen: options?.maxlen ?? 32,
+        meshPacketId: options?.meshPacketId ?? 0,
+      });
+
+      const fromRadio = FromRadio.create({
+        queueStatus: queueStatus,
+      });
+
+      return FromRadio.encode(fromRadio).finish();
+    } catch (error) {
+      logger.error('❌ Failed to create QueueStatus:', error);
+      return null;
+    }
+  }
+
+  /**
    * Create FromRadio message wrapping a MeshPacket
    * Used for processing outgoing messages locally so they appear in the web UI
    *


### PR DESCRIPTION
## Summary

Fixes iOS Meshtastic clients disconnecting from Virtual Node Server after ~1 minute.

## Problem

iOS Meshtastic clients send `ToRadio.heartbeat` every ~5 seconds and start a timeout timer. If no framed packet is received within that window, the client assumes the connection is dead and disconnects.

The Virtual Node Server was treating heartbeats as "no response needed", causing iOS clients to disconnect after about a minute.

## Solution

Send a `QueueStatus` response when a heartbeat is received. This lightweight message satisfies the iOS client's expectation of receiving a framed packet after sending a heartbeat.

## Changes

- **`meshtasticProtobufService.ts`**: Added `createQueueStatus()` method to create FromRadio messages with QueueStatus payload
- **`virtualNodeServer.ts`**: Updated heartbeat handler to send QueueStatus response instead of just logging

## Test plan

- [ ] iOS client connects to VNS and stays connected for > 1 minute
- [ ] Verify QueueStatus responses are sent in logs (`sending QueueStatus response`)
- [ ] Android/other clients continue to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)