### PR TITLE
fix(i18n): preload English for fallback when translations are missing

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -31,7 +31,8 @@ i18n
   .use(initReactI18next)
   .init({
     fallbackLng: 'en',
-    load: 'currentOnly', 
+    load: 'currentOnly',
+    preload: ['en'], // Always load English for fallback when translations are missing
     debug: process.env.NODE_ENV === 'development',
 
     interpolation: {


### PR DESCRIPTION
## Summary

Fixes #1221 - Web interface unusable after upgrading from 2.21.5 due to missing translations appearing as blank/empty.

## Problem

After PR #1008 changed the i18n load strategy from `languageOnly` to `currentOnly` to fix Chinese (zh_Hans) translations, the fallback language (English) was no longer being loaded automatically. 

When a user selects German (or any non-English language) and a translation key is missing, instead of falling back to English, the text appeared blank/empty - making the interface unusable.

## Root Cause

```typescript
load: 'currentOnly',  // Only loads the selected language, not fallback
fallbackLng: 'en',    // This is set but English is never loaded!
```

## Solution

Add `preload: ['en']` to ensure English is always loaded alongside the selected language:

```typescript
load: 'currentOnly',
preload: ['en'],      // Always load English for fallback
fallbackLng: 'en',
```

This maintains the fix for Chinese (zh_Hans) while restoring proper fallback behavior.

## Test plan

- [ ] Select German language in settings
- [ ] Verify translated strings appear in German
- [ ] Verify untranslated strings fall back to English (not blank)
- [ ] Select Chinese (zh_Hans) and verify it still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)