### PR TITLE
feat(traceroute): add hop count prioritization for auto-traceroute

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1867,6 +1867,8 @@
   "automation.auto_traceroute.status_success": "Success",
   "automation.auto_traceroute.status_failed": "Failed",
   "automation.auto_traceroute.no_log_entries": "No auto-traceroutes logged yet. Entries will appear here as traceroutes are sent.",
+  "automation.auto_traceroute.sort_by_hops": "Prioritize Closer Nodes",
+  "automation.auto_traceroute.sort_by_hops_description": "When enabled, nodes with fewer hops are tracerouted first. This is useful in dense networks where traceroutes to distant nodes often fail. When disabled, nodes are selected randomly.",
 
   "automation.timer_triggers.section_title": "Timed Events",
   "automation.timer_triggers.description": "Schedule scripts or text messages to run automatically using cron expressions",

--- a/src/components/AutoTracerouteSection.tsx
+++ b/src/components/AutoTracerouteSection.tsx
@@ -41,6 +41,7 @@ interface FilterSettings {
   filterHwModelsEnabled: boolean;
   filterRegexEnabled: boolean;
   expirationHours: number;
+  sortByHops: boolean;
 }
 
 interface TracerouteLogEntry {
@@ -81,6 +82,9 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
 
   // Expiration hours - how long before re-tracerouting a node
   const [expirationHours, setExpirationHours] = useState(24);
+
+  // Sort by hops - prioritize closer nodes for traceroute
+  const [sortByHops, setSortByHops] = useState(false);
 
   // Auto-traceroute log
   const [tracerouteLog, setTracerouteLog] = useState<TracerouteLogEntry[]>([]);
@@ -143,6 +147,8 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
           setFilterRegexEnabled(data.filterRegexEnabled !== false);
           // Load expiration hours (default to 24 if not set)
           setExpirationHours(data.expirationHours || 24);
+          // Load sort by hops setting (default to false)
+          setSortByHops(data.sortByHops || false);
           setInitialSettings(data);
         }
       } catch (error) {
@@ -202,12 +208,15 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
     // Check expiration hours change
     const expirationHoursChanged = expirationHours !== (initialSettings.expirationHours || 24);
 
+    // Check sort by hops change
+    const sortByHopsChanged = sortByHops !== (initialSettings.sortByHops || false);
+
     const changed = intervalChanged || filterEnabledChanged || nodesChanged || channelsChanged || rolesChanged || hwModelsChanged || regexChanged ||
       filterNodesEnabledChanged || filterChannelsEnabledChanged || filterRolesEnabledChanged || filterHwModelsEnabledChanged || filterRegexEnabledChanged ||
-      expirationHoursChanged;
+      expirationHoursChanged || sortByHopsChanged;
     setHasChanges(changed);
   }, [localEnabled, localInterval, intervalMinutes, filterEnabled, selectedNodeNums, filterChannels, filterRoles, filterHwModels, filterNameRegex, initialSettings,
-      filterNodesEnabled, filterChannelsEnabled, filterRolesEnabled, filterHwModelsEnabled, filterRegexEnabled, expirationHours]);
+      filterNodesEnabled, filterChannelsEnabled, filterRolesEnabled, filterHwModelsEnabled, filterRegexEnabled, expirationHours, sortByHops]);
 
   // Helper to get role from node (could be at top level or in user object)
   const getNodeRole = (node: Node): number | undefined => {
@@ -384,6 +393,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
           filterHwModelsEnabled,
           filterRegexEnabled,
           expirationHours,
+          sortByHops,
         })
       });
 
@@ -410,6 +420,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
         filterHwModelsEnabled,
         filterRegexEnabled,
         expirationHours,
+        sortByHops,
       });
 
       setHasChanges(false);
@@ -576,6 +587,26 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
             disabled={!localEnabled}
             className="setting-input"
           />
+        </div>
+
+        {/* Sort by Hops Option */}
+        <div className="setting-item" style={{ marginTop: '1rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <input
+              type="checkbox"
+              id="sortByHops"
+              checked={sortByHops}
+              onChange={(e) => setSortByHops(e.target.checked)}
+              disabled={!localEnabled}
+              style={{ width: 'auto', margin: 0, marginRight: '0.5rem', cursor: 'pointer' }}
+            />
+            <label htmlFor="sortByHops" style={{ margin: 0, cursor: 'pointer' }}>
+              {t('automation.auto_traceroute.sort_by_hops')}
+              <span className="setting-description" style={{ display: 'block', marginTop: '0.25rem' }}>
+                {t('automation.auto_traceroute.sort_by_hops_description')}
+              </span>
+            </label>
+          </div>
         </div>
 
         {/* Node Filter Section */}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3885,7 +3885,7 @@ apiRouter.post('/settings/traceroute-nodes', requirePermission('settings', 'writ
     const {
       enabled, nodeNums, filterChannels, filterRoles, filterHwModels, filterNameRegex,
       filterNodesEnabled, filterChannelsEnabled, filterRolesEnabled, filterHwModelsEnabled, filterRegexEnabled,
-      expirationHours
+      expirationHours, sortByHops
     } = req.body;
 
     // Validate input
@@ -3958,12 +3958,14 @@ apiRouter.post('/settings/traceroute-nodes', requirePermission('settings', 'writ
     let validatedFilterRolesEnabled: boolean | undefined;
     let validatedFilterHwModelsEnabled: boolean | undefined;
     let validatedFilterRegexEnabled: boolean | undefined;
+    let validatedSortByHops: boolean | undefined;
     try {
       validatedFilterNodesEnabled = validateOptionalBoolean(filterNodesEnabled, 'filterNodesEnabled');
       validatedFilterChannelsEnabled = validateOptionalBoolean(filterChannelsEnabled, 'filterChannelsEnabled');
       validatedFilterRolesEnabled = validateOptionalBoolean(filterRolesEnabled, 'filterRolesEnabled');
       validatedFilterHwModelsEnabled = validateOptionalBoolean(filterHwModelsEnabled, 'filterHwModelsEnabled');
       validatedFilterRegexEnabled = validateOptionalBoolean(filterRegexEnabled, 'filterRegexEnabled');
+      validatedSortByHops = validateOptionalBoolean(sortByHops, 'sortByHops');
     } catch (error) {
       return res.status(400).json({ error: (error as Error).message });
     }
@@ -3991,6 +3993,7 @@ apiRouter.post('/settings/traceroute-nodes', requirePermission('settings', 'writ
       filterHwModelsEnabled: validatedFilterHwModelsEnabled,
       filterRegexEnabled: validatedFilterRegexEnabled,
       expirationHours: validatedExpirationHours,
+      sortByHops: validatedSortByHops,
     });
 
     // Get the updated settings to return (includes resolved default values)


### PR DESCRIPTION
## Summary

Adds a "Prioritize Closer Nodes" option to the Auto Traceroute settings. When enabled, nodes with fewer hops are tracerouted first instead of random selection. This is useful in dense networks where traceroutes to distant nodes often fail.

- Add `sortByHops` setting to database service with getter/setter methods
- Update `getNodeNeedingTraceroute()` to sort by `hopsAway` when enabled (nodes with undefined hops are placed last)
- Add UI toggle checkbox in AutoTracerouteSection component
- Add English translation strings for the new option
- Update server endpoint to validate and persist the new setting

Closes #1223

## Test plan

- [x] TypeScript type checking passes
- [x] Unit tests pass
- [x] System tests pass
- [ ] Manual testing: Enable "Prioritize Closer Nodes" option in Automation > Auto Traceroute
- [ ] Verify setting persists after page refresh
- [ ] Verify closer nodes (lower hopsAway) are selected first when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)