### PR TITLE
fix(i18n): treat empty strings as missing translations for proper fallback

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -33,8 +33,8 @@ i18n
     fallbackLng: 'en',
     load: 'currentOnly',
     preload: ['en'], // Always load English for fallback when translations are missing
+    returnEmptyString: false, // Treat empty strings as missing translations (triggers fallback)
     debug: process.env.NODE_ENV === 'development',
-    returnEmptyString: false, // Until all translations are available
     interpolation: {
       escapeValue: false, // React already escapes values
     },

--- a/src/server/migrations/042_add_relay_node_to_packet_log.ts
+++ b/src/server/migrations/042_add_relay_node_to_packet_log.ts
@@ -5,6 +5,15 @@ export const migration = {
   up: (db: Database.Database): void => {
     logger.debug('Running migration 042: Add relay_node field to packet_log table...');
 
+    // Check if column already exists
+    const columns = db.pragma("table_info('packet_log')") as Array<{ name: string }>;
+    const columnNames = new Set(columns.map((col) => col.name));
+
+    if (columnNames.has('relay_node')) {
+      logger.debug('✅ relay_node column already exists, skipping');
+      return;
+    }
+
     // Add relay_node column to packet_log table to store which node relayed the packet
     db.exec(`
       ALTER TABLE packet_log ADD COLUMN relay_node INTEGER;


### PR DESCRIPTION
## Summary
- Improves `returnEmptyString` comment to be more descriptive
- Fixes migration 042 idempotency issue

## Problem
Migration 042 (`add_relay_node_to_packet_log`) was failing on restart with "duplicate column" error because it lacked an idempotency check. This happens when the column was manually added or the migration ran but the completion flag wasn't set.

## Solution
Added column existence check before attempting to add the `relay_node` column, following the pattern used by other migrations in the codebase.

## Test plan
- [x] System tests pass (8/8)
- [x] Container restarts successfully without migration errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)