### PR TITLE
Fix mobile header height overridden by theme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1311,10 +1311,10 @@ body {
 }
 
 @media (max-width: 768px) {
-  /* Update layout dimensions for mobile */
+  /* Update layout dimensions for mobile - !important needed to override theme-specific selectors */
   :root {
-    --header-height: 48px;
-    --sidebar-width: 48px;
+    --header-height: 40px !important;
+    --sidebar-width: 48px !important;
   }
 
   /* Reduce font size globally on mobile */
@@ -1323,7 +1323,7 @@ body {
   }
 
   .app-header {
-    padding: 0.5rem;
+    padding: 0.25rem 0.5rem;
     /* height and left now use CSS variables that are updated in the :root above */
   }
 

--- a/src/components/AppHeader/AppHeader.css
+++ b/src/components/AppHeader/AppHeader.css
@@ -222,4 +222,12 @@
     width: 16px;
     height: 16px;
   }
+
+  .login-button {
+    padding: 4px 10px; /* Reduced height for mobile */
+    font-size: 0.8em;
+    gap: 4px;
+    line-height: 1;
+    margin-left: 8px;
+  }
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -52,10 +52,18 @@ const Sidebar: React.FC<SidebarProps> = ({
 
   // Update CSS custom property when sidebar collapse state changes
   React.useEffect(() => {
-    document.documentElement.style.setProperty(
-      '--sidebar-width',
-      isCollapsed ? '60px' : '240px'
-    );
+    const updateSidebarWidth = () => {
+      const isMobile = window.matchMedia('(max-width: 768px)').matches;
+      const collapsedWidth = isMobile ? '48px' : '60px';
+      document.documentElement.style.setProperty(
+        '--sidebar-width',
+        isCollapsed ? collapsedWidth : '240px'
+      );
+    };
+
+    updateSidebarWidth();
+    window.addEventListener('resize', updateSidebarWidth);
+    return () => window.removeEventListener('resize', updateSidebarWidth);
   }, [isCollapsed]);
 
   const NavItem: React.FC<{


### PR DESCRIPTION
## Summary

Follow-up to #1241. Fixes the issue where the mobile header height would start at 40px but then expand to 60px once JS applied the theme.

**Root cause:** The theme selectors (`:root[data-theme=mocha]`) have higher CSS specificity than the plain `:root` in the mobile media query, causing the 60px theme values to override the 40px mobile values.

**Fixes:**
- Add `!important` to mobile CSS variables (`--header-height: 40px`, `--sidebar-width: 48px`) to override theme-specific selectors
- Update `Sidebar.tsx` to use responsive sidebar width (48px on mobile via `matchMedia`, 60px on desktop)
- Reduce mobile login button size and header padding for better fit

Fixes #1237

## Test plan

- [x] Verify header stays at 40px on mobile after page load
- [x] Verify no overlap between header and map content
- [x] Verify login button is appropriately sized on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)