### PR TITLE
Release v2.21.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ test-results.md
 
 # Log directories
 meshmonitor-logs/
+
+# Desktop (Tauri) build artifacts
+desktop/src-tauri/target/
+desktop/src-tauri/binaries/
+desktop/resources/

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "2.21.7",
+  "version": "2.21.8",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/configuration/desktop.md
+++ b/docs/configuration/desktop.md
@@ -37,32 +37,9 @@ The desktop application:
 
 1. Go to the [MeshMonitor Releases](https://github.com/Yeraze/MeshMonitor/releases) page
 2. Download the latest `MeshMonitor-Desktop-x.x.x-arm64.dmg`
-3. **Remove quarantine attribute** to prevent "damaged" errors:
-   ```bash
-   xattr -d com.apple.quarantine ~/Downloads/MeshMonitor-Desktop-*.dmg
-   ```
-4. Open the DMG file and drag MeshMonitor to your Applications folder
-5. **Remove quarantine from the app**:
-   ```bash
-   xattr -dr com.apple.quarantine /Applications/MeshMonitor.app
-   ```
-6. **First launch**: Right-click (or Control-click) MeshMonitor and select "Open"
-   - macOS will ask you to confirm opening an app from an unidentified developer
-   - Click "Open" to proceed
-7. MeshMonitor will appear in your menu bar
-
-::: warning macOS Gatekeeper
-MeshMonitor is not code-signed with an Apple Developer certificate. Downloaded apps are marked with a quarantine attribute that causes macOS to show a misleading "damaged" error message. The commands above remove this attribute. This is safe - the app is not actually damaged.
-
-If you prefer not to use the command line, you can also:
-1. Try to open the app normally
-2. Go to **System Settings → Privacy & Security**
-3. Click **"Open Anyway"** next to the MeshMonitor message
-:::
-
-::: tip Why isn't it code-signed?
-Code signing requires an Apple Developer account ($99/year) and ongoing maintenance for notarization. As an open-source project, we've chosen to make the app freely available without this cost. If you're concerned about security, you can build the app from source yourself.
-:::
+3. Open the DMG file and drag MeshMonitor to your Applications folder
+4. Launch MeshMonitor from your Applications folder
+5. MeshMonitor will appear in your menu bar
 
 ::: tip Apple Silicon Native
 The macOS version is compiled natively for Apple Silicon (M1/M2/M3). If you're using an Intel Mac, macOS will automatically run it through Rosetta 2.
@@ -297,27 +274,6 @@ If another application is using port 8080:
 1. Open Settings from the tray/menu bar
 2. Change the "Web UI Port" to a different port (e.g., 8081)
 3. Save and restart
-
-### macOS: "MeshMonitor cannot be opened"
-
-If macOS prevents you from opening MeshMonitor:
-1. Go to System Settings > Privacy & Security
-2. Scroll down to find MeshMonitor with an "Open Anyway" button
-3. Click "Open Anyway" and confirm
-
-### macOS: "Application is Damaged"
-
-If you see "MeshMonitor is damaged and can't be opened" when trying to launch:
-
-This happens because the app isn't code-signed with an Apple Developer certificate. To fix this:
-
-1. Open Terminal
-2. Run: `xattr -cr /Applications/MeshMonitor.app`
-3. Try launching MeshMonitor again
-
-::: tip What does this do?
-The `xattr -cr` command removes macOS quarantine attributes that are added when downloading files from the internet. This is safe for apps you trust.
-:::
 
 ### macOS: App not appearing in menu bar
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,35 +4,6 @@ This page covers common issues and questions from MeshMonitor users. For develop
 
 ## 🚨 Common Issues
 
-### macOS says MeshMonitor is "damaged" and can't be opened
-
-**Problem:** When trying to open the MeshMonitor Desktop app on macOS, you see an error message saying the app is "damaged" and should be moved to the trash.
-
-**Cause:** This is **not** actual damage. macOS applies a "quarantine" attribute to files downloaded from the internet. For unsigned apps (apps without an Apple Developer certificate), macOS shows this misleading error message as a security measure.
-
-**Solution:** Remove the quarantine attribute using Terminal:
-
-```bash
-# After downloading the DMG
-xattr -d com.apple.quarantine ~/Downloads/MeshMonitor-Desktop-*.dmg
-
-# After installing to Applications
-xattr -dr com.apple.quarantine /Applications/MeshMonitor.app
-```
-
-**Alternative method (GUI):**
-1. Try to open MeshMonitor normally
-2. Go to **System Settings → Privacy & Security**
-3. Scroll down to find the message about MeshMonitor
-4. Click **"Open Anyway"**
-
-**Why isn't it code-signed?**
-Code signing requires an Apple Developer account ($99/year) and ongoing maintenance. As an open-source project, we've chosen to make the app freely available without this cost. The app is safe to use - you can verify this by building it from source yourself.
-
-::: tip
-This is the same issue faced by many open-source macOS applications. The quarantine removal is safe and only affects MeshMonitor, not your system security.
-:::
-
 ### I see a blank white screen when accessing MeshMonitor
 
 **Problem:** You can access MeshMonitor's URL, but the page is completely blank or you see CORS errors in the browser console.

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.21.7
-appVersion: "2.21.7"
+version: 2.21.8
+appVersion: "2.21.8"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.21.7",
+  "version": "2.21.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.21.7",
+      "version": "2.21.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.21.7",
+  "version": "2.21.8",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

- Version bump: 2.21.7 → 2.21.8
- Remove macOS Gatekeeper workaround documentation (binary is now signed)
- Add desktop build artifacts to .gitignore

## Changes since v2.21.7

- #1241 - Fix mobile UI layout issues (double scroll, header spacing)
- #1242 - Fix mobile header height being overridden by JS/theme

## Documentation Updates

- Removed FAQ entry about macOS "damaged" error
- Simplified macOS installation to 5 steps (no xattr commands needed)
- Removed Gatekeeper troubleshooting section

🤖 Generated with [Claude Code](https://claude.com/claude-code)