### PR TITLE
feat: add {TRANSPORT} token for auto-acknowledgment messages

### DIFF
--- a/src/components/AutoAcknowledgeSection.test.tsx
+++ b/src/components/AutoAcknowledgeSection.test.tsx
@@ -632,7 +632,7 @@ describe.skip('AutoAcknowledgeSection Component', () => {
   });
 
   describe('Token Insertion Buttons', () => {
-    it('should render all 9 token insertion buttons', () => {
+    it('should render all 10 token insertion buttons', () => {
       render(<AutoAcknowledgeSection {...defaultProps} />);
 
       expect(screen.getByText(/\+ \{NODE_ID\}/)).toBeInTheDocument();
@@ -644,6 +644,7 @@ describe.skip('AutoAcknowledgeSection Component', () => {
       expect(screen.getByText(/\+ \{FEATURES\}/)).toBeInTheDocument();
       expect(screen.getByText(/\+ \{NODECOUNT\}/)).toBeInTheDocument();
       expect(screen.getByText(/\+ \{DIRECTCOUNT\}/)).toBeInTheDocument();
+      expect(screen.getByText(/\+ \{TRANSPORT\}/)).toBeInTheDocument();
     });
 
     it('should insert token when button is clicked', async () => {

--- a/src/components/AutoAcknowledgeSection.tsx
+++ b/src/components/AutoAcknowledgeSection.tsx
@@ -187,6 +187,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
     sample = sample.replace(/{DIRECTCOUNT}/g, '8');
     sample = sample.replace(/{SNR}/g, '7.5');
     sample = sample.replace(/{RSSI}/g, '-95');
+    sample = sample.replace(/{TRANSPORT}/g, 'LoRa'); // Sample transport type
 
     return sample;
   };
@@ -473,7 +474,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
           <label htmlFor="autoAckMessage">
             {t('automation.auto_ack.message_multihop')}
             <span className="setting-description">
-              {t('automation.auto_ack.message_multihop_description')} {t('automation.auto_ack.available_tokens')} {'{NODE_ID}'}, {'{NUMBER_HOPS}'}, {'{HOPS}'}, {'{RABBIT_HOPS}'}, {'{DATE}'}, {'{TIME}'}, {'{VERSION}'}, {'{DURATION}'}, {'{FEATURES}'}, {'{NODECOUNT}'}, {'{DIRECTCOUNT}'}, {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{SNR}'}, {'{RSSI}'}
+              {t('automation.auto_ack.message_multihop_description')} {t('automation.auto_ack.available_tokens')} {'{NODE_ID}'}, {'{NUMBER_HOPS}'}, {'{HOPS}'}, {'{RABBIT_HOPS}'}, {'{DATE}'}, {'{TIME}'}, {'{VERSION}'}, {'{DURATION}'}, {'{FEATURES}'}, {'{NODECOUNT}'}, {'{DIRECTCOUNT}'}, {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{SNR}'}, {'{RSSI}'}, {'{TRANSPORT}'}
             </span>
           </label>
           <textarea
@@ -715,6 +716,22 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
             >
               + {'{RSSI}'}
             </button>
+            <button
+              type="button"
+              onClick={() => insertToken('{TRANSPORT}')}
+              disabled={!localEnabled}
+              style={{
+                padding: '0.25rem 0.5rem',
+                fontSize: '12px',
+                background: 'var(--ctp-surface2)',
+                border: '1px solid var(--ctp-overlay0)',
+                borderRadius: '4px',
+                cursor: localEnabled ? 'pointer' : 'not-allowed',
+                opacity: localEnabled ? 1 : 0.5
+              }}
+            >
+              + {'{TRANSPORT}'}
+            </button>
           </div>
         </div>
 
@@ -744,7 +761,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
           <label htmlFor="autoAckMessageDirect">
             {t('automation.auto_ack.message_direct')}
             <span className="setting-description">
-              {t('automation.auto_ack.message_direct_description')} {t('automation.auto_ack.available_tokens')} {'{NODE_ID}'}, {'{HOPS}'}, {'{NUMBER_HOPS}'}, {'{RABBIT_HOPS}'}, {'{DATE}'}, {'{TIME}'}, {'{VERSION}'}, {'{DURATION}'}, {'{FEATURES}'}, {'{NODECOUNT}'}, {'{DIRECTCOUNT}'}, {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{SNR}'}, {'{RSSI}'}
+              {t('automation.auto_ack.message_direct_description')} {t('automation.auto_ack.available_tokens')} {'{NODE_ID}'}, {'{HOPS}'}, {'{NUMBER_HOPS}'}, {'{RABBIT_HOPS}'}, {'{DATE}'}, {'{TIME}'}, {'{VERSION}'}, {'{DURATION}'}, {'{FEATURES}'}, {'{NODECOUNT}'}, {'{DIRECTCOUNT}'}, {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{SNR}'}, {'{RSSI}'}, {'{TRANSPORT}'}
             </span>
           </label>
           <textarea

--- a/src/server/meshtasticManager.autoack-templates.test.ts
+++ b/src/server/meshtasticManager.autoack-templates.test.ts
@@ -776,4 +776,61 @@ describe('MeshtasticManager - Auto-Acknowledge Message Template Token Replacemen
       expect(result).toBe('3');
     });
   });
+
+  describe('{TRANSPORT} token replacement', () => {
+    it('should replace {TRANSPORT} with LoRa when viaMqtt is false', () => {
+      const template = 'Received via {TRANSPORT}';
+      const viaMqtt = false;
+      const transport = viaMqtt === true ? 'MQTT' : 'LoRa';
+
+      const result = template.replace(/{TRANSPORT}/g, transport);
+
+      expect(result).toBe('Received via LoRa');
+    });
+
+    it('should replace {TRANSPORT} with MQTT when viaMqtt is true', () => {
+      const template = 'Received via {TRANSPORT}';
+      const viaMqtt = true;
+      const transport = viaMqtt === true ? 'MQTT' : 'LoRa';
+
+      const result = template.replace(/{TRANSPORT}/g, transport);
+
+      expect(result).toBe('Received via MQTT');
+    });
+
+    it('should replace {TRANSPORT} with LoRa when viaMqtt is undefined', () => {
+      const template = 'Received via {TRANSPORT}';
+      const viaMqtt = undefined;
+      const transport = viaMqtt === true ? 'MQTT' : 'LoRa';
+
+      const result = template.replace(/{TRANSPORT}/g, transport);
+
+      expect(result).toBe('Received via LoRa');
+    });
+
+    it('should handle {TRANSPORT} with other tokens', () => {
+      const template = 'From {NODE_ID}, {NUMBER_HOPS} hops via {TRANSPORT}';
+      const nodeId = '!a1b2c3d4';
+      const numberHops = 3;
+      const viaMqtt = true;
+      const transport = viaMqtt === true ? 'MQTT' : 'LoRa';
+
+      let result = template;
+      result = result.replace(/{NODE_ID}/g, nodeId);
+      result = result.replace(/{NUMBER_HOPS}/g, numberHops.toString());
+      result = result.replace(/{TRANSPORT}/g, transport);
+
+      expect(result).toBe('From !a1b2c3d4, 3 hops via MQTT');
+    });
+
+    it('should replace multiple {TRANSPORT} tokens', () => {
+      const template = 'Transport: {TRANSPORT} - Received via {TRANSPORT}';
+      const viaMqtt = false;
+      const transport = viaMqtt === true ? 'MQTT' : 'LoRa';
+
+      const result = template.replace(/{TRANSPORT}/g, transport);
+
+      expect(result).toBe('Transport: LoRa - Received via LoRa');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Implements issue #1253 - Adds a `{TRANSPORT}` token that displays the transport type (LoRa or MQTT) in auto-acknowledgment messages.

## Changes
- Add `viaMqtt` parameter to `replaceAcknowledgementTokens` function
- Add `{TRANSPORT}` token that returns "LoRa" or "MQTT" based on `viaMqtt` flag
- Update all call sites (auto-ack, HTTP triggers, text triggers) to pass `viaMqtt`
- Add `{TRANSPORT}` insert button to AutoAcknowledgeSection UI
- Add `{TRANSPORT}` to token documentation in settings
- Update sample preview to show TRANSPORT replacement
- Add 5 tests for `{TRANSPORT}` token behavior

## Example Usage
```
"Message ack, {HOPS} hops via {TRANSPORT}"
→ "Message ack, 3 hops via LoRa"
→ "Message ack, 3 hops via MQTT"
```

## Test Results
```
Configuration Import:     ✓ PASSED
Quick Start Test:         ✓ PASSED
Security Test:            ✓ PASSED
V1 API Test:              ✓ PASSED
Reverse Proxy Test:       ✓ PASSED
Reverse Proxy + OIDC:     ✓ PASSED
Virtual Node CLI Test:    ✓ PASSED
Backup & Restore Test:    ✗ FAILED (port conflict with dev tileserver - unrelated)
```

Closes #1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)