### PR TITLE
Add additional vector tile layers for richer map display

### DIFF
--- a/src/components/VectorTileLayer.tsx
+++ b/src/components/VectorTileLayer.tsx
@@ -59,6 +59,23 @@ export function VectorTileLayer({ url, attribution, maxZoom = 14 }: VectorTileLa
           }
         },
         {
+          id: 'waterway',
+          type: 'line',
+          source: 'vector-tiles',
+          'source-layer': 'waterway',
+          paint: {
+            'line-color': '#a0c8f0',
+            'line-width': {
+              base: 1.3,
+              stops: [
+                [8, 1],
+                [14, 3],
+                [18, 6]
+              ]
+            }
+          }
+        },
+        {
           id: 'landuse',
           type: 'fill',
           source: 'vector-tiles',
@@ -94,6 +111,35 @@ export function VectorTileLayer({ url, attribution, maxZoom = 14 }: VectorTileLa
           paint: {
             'fill-color': '#d9d0c9',
             'fill-opacity': 0.7
+          }
+        },
+        {
+          id: 'aeroway-area',
+          type: 'fill',
+          source: 'vector-tiles',
+          'source-layer': 'aeroway',
+          filter: ['==', '$type', 'Polygon'],
+          paint: {
+            'fill-color': '#e8e8e8',
+            'fill-opacity': 0.8
+          }
+        },
+        {
+          id: 'aeroway-runway',
+          type: 'line',
+          source: 'vector-tiles',
+          'source-layer': 'aeroway',
+          filter: ['==', '$type', 'LineString'],
+          paint: {
+            'line-color': '#d0d0d0',
+            'line-width': {
+              base: 1.5,
+              stops: [
+                [10, 2],
+                [14, 8],
+                [18, 20]
+              ]
+            }
           }
         },
         {
@@ -139,6 +185,32 @@ export function VectorTileLayer({ url, attribution, maxZoom = 14 }: VectorTileLa
           }
         },
         {
+          id: 'road-label',
+          type: 'symbol',
+          source: 'vector-tiles',
+          'source-layer': 'transportation_name',
+          layout: {
+            'text-field': '{name}',
+            'text-font': ['Open Sans Regular'],
+            'symbol-placement': 'line',
+            'text-size': {
+              base: 1,
+              stops: [
+                [10, 10],
+                [14, 12],
+                [18, 14]
+              ]
+            },
+            'text-max-angle': 30,
+            'text-padding': 2
+          },
+          paint: {
+            'text-color': '#555',
+            'text-halo-color': '#fff',
+            'text-halo-width': 1.5
+          }
+        },
+        {
           id: 'place-label',
           type: 'symbol',
           source: 'vector-tiles',
@@ -156,6 +228,49 @@ export function VectorTileLayer({ url, attribution, maxZoom = 14 }: VectorTileLa
           },
           paint: {
             'text-color': '#333',
+            'text-halo-color': '#fff',
+            'text-halo-width': 1
+          }
+        },
+        {
+          id: 'water-label',
+          type: 'symbol',
+          source: 'vector-tiles',
+          'source-layer': 'water_name',
+          layout: {
+            'text-field': '{name}',
+            'text-font': ['Open Sans Regular'],
+            'text-size': {
+              base: 1,
+              stops: [
+                [8, 10],
+                [14, 14]
+              ]
+            }
+          },
+          paint: {
+            'text-color': '#5a8fc7',
+            'text-halo-color': '#fff',
+            'text-halo-width': 1
+          }
+        },
+        {
+          id: 'poi-label',
+          type: 'symbol',
+          source: 'vector-tiles',
+          'source-layer': 'poi',
+          minzoom: 14,
+          layout: {
+            'text-field': '{name}',
+            'text-font': ['Open Sans Regular'],
+            'text-size': 11,
+            'text-offset': [0, 0.8],
+            'text-anchor': 'top',
+            'icon-image': '',
+            'icon-size': 0.8
+          },
+          paint: {
+            'text-color': '#666',
             'text-halo-color': '#fff',
             'text-halo-width': 1
           }

--- a/src/utils/tileServerTest.ts
+++ b/src/utils/tileServerTest.ts
@@ -13,13 +13,18 @@ import Pbf from 'pbf';
  */
 export const EXPECTED_VECTOR_LAYERS = [
   'water',
+  'waterway',
   'landuse',
   'landcover',
   'park',
   'building',
+  'aeroway',
   'transportation',
+  'transportation_name',
   'boundary',
-  'place'
+  'place',
+  'water_name',
+  'poi'
 ] as const;
 
 export interface TileTestResult {


### PR DESCRIPTION
## Summary
- Adds `transportation_name` layer for street/road name labels
- Adds `waterway` layer for rivers, streams, and canals (blue lines)
- Adds `aeroway` layer for airport runways and terminal areas (gray fill/lines)
- Adds `water_name` layer for lake/river/ocean name labels (blue text)
- Adds `poi` layer for points of interest labels at zoom >= 14 (gray text)
- Updates tile server test utility to validate the new expected layers

This improves the vector tile map experience when using custom tile servers that follow the OpenMapTiles schema.

## Test plan
- [x] Verified build passes
- [x] All system tests pass (see below)
- [x] Tested with custom tile server at `http://sentry.yeraze.online:8082/data/v3/{z}/{x}/{y}.pbf`
- [x] Street names now visible on vector tile maps
- [x] Water feature labels display correctly
- [x] Airport runways render with appropriate styling

## System Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| V1 API Test | ✅ PASSED |
| Reverse Proxy Test | ✅ PASSED |
| Reverse Proxy + OIDC | ✅ PASSED |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)