### PR TITLE
Add per-minute packet rate graphs to Info page

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1408,6 +1408,12 @@
   "info.device_config_unavailable": "Device configuration not available. Ensure connection is established.",
   "info.local_telemetry": "Local Node Telemetry",
 
+  "info.packet_rate_graphs": "Packet Rate Trends (per minute)",
+  "info.rx_rates": "RX Rates (packets/min)",
+  "info.tx_rates": "TX Rates (packets/min)",
+  "info.no_rate_data": "Insufficient data for rate calculation. Need at least 2 data points.",
+  "info.rate_error": "Error loading packet rate data.",
+
   "info.secrets": "Secrets",
   "info.public_key": "Public Key:",
   "info.private_key": "Private Key:",

--- a/src/components/Dashboard/components/DashboardGrid.tsx
+++ b/src/components/Dashboard/components/DashboardGrid.tsx
@@ -11,6 +11,7 @@ import {
 } from '@dnd-kit/core';
 import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import TelemetryChart from '../../TelemetryChart';
+import PacketRateChart, { isPacketRateType } from '../../PacketRateChart';
 import NodeStatusWidget from '../../NodeStatusWidget';
 import TracerouteWidget from '../../TracerouteWidget';
 import {
@@ -150,6 +151,22 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
             {favorites.map(favorite => {
               const key = `${favorite.nodeId}-${favorite.telemetryType}`;
               const node = nodes.get(favorite.nodeId);
+
+              // Use PacketRateChart for packet rate types
+              if (isPacketRateType(favorite.telemetryType)) {
+                return (
+                  <PacketRateChart
+                    key={key}
+                    id={key}
+                    favorite={favorite}
+                    node={node}
+                    hours={hours}
+                    baseUrl={baseUrl}
+                    globalTimeRange={globalTimeRange}
+                    onRemove={onRemoveFavorite}
+                  />
+                );
+              }
 
               return (
                 <TelemetryChart

--- a/src/components/InfoTab.tsx
+++ b/src/components/InfoTab.tsx
@@ -8,6 +8,7 @@ import { TemperatureUnit } from '../utils/temperature';
 import { TimeFormat, DateFormat } from '../contexts/SettingsContext';
 import { formatDateTime } from '../utils/datetime';
 import TelemetryGraphs from './TelemetryGraphs';
+import PacketRateGraphs from './PacketRateGraphs';
 import { version } from '../../package.json';
 import apiService from '../services/api';
 import { formatDistance } from '../utils/distance';
@@ -665,6 +666,12 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
         <div className="info-section-full-width">
           <h3>{t('info.local_telemetry')}</h3>
           <TelemetryGraphs nodeId={currentNodeId} temperatureUnit={temperatureUnit} telemetryHours={telemetryHours} baseUrl={baseUrl} />
+        </div>
+      )}
+
+      {currentNodeId && connectionStatus === 'connected' && (
+        <div className="info-section-full-width">
+          <PacketRateGraphs nodeId={currentNodeId} telemetryHours={telemetryHours} baseUrl={baseUrl} />
         </div>
       )}
 

--- a/src/components/PacketRateChart.tsx
+++ b/src/components/PacketRateChart.tsx
@@ -1,0 +1,336 @@
+/**
+ * PacketRateChart - Individual packet rate chart component for Dashboard
+ *
+ * This component displays packet rate statistics (RX or TX) as a multi-line chart.
+ * Used by the Dashboard to display favorited packet rate charts.
+ */
+
+import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ComposedChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { usePacketRates, type PacketRatesResponse } from '../hooks/usePacketRates';
+import { formatChartAxisTimestamp } from '../utils/datetime';
+import { PACKET_RATE_RX_TYPE, PACKET_RATE_TX_TYPE } from './PacketRateGraphs';
+import type { TelemetryNodeInfo } from '../types/device';
+
+interface FavoriteChart {
+  nodeId: string;
+  telemetryType: string;
+}
+
+interface PacketRateChartProps {
+  id: string;
+  favorite: FavoriteChart;
+  node: TelemetryNodeInfo | undefined;
+  hours: number;
+  baseUrl: string;
+  globalTimeRange: [number, number] | null;
+  onRemove: (nodeId: string, telemetryType: string) => void;
+}
+
+// RX metrics configuration
+const RX_METRICS = [
+  { key: 'numPacketsRx' as keyof PacketRatesResponse, label: 'Packets Received', color: '#a6e3a1' },
+  { key: 'numPacketsRxBad' as keyof PacketRatesResponse, label: 'Bad Packets', color: '#f38ba8' },
+  { key: 'numRxDupe' as keyof PacketRatesResponse, label: 'Duplicates', color: '#fab387' },
+];
+
+// TX metrics configuration
+const TX_METRICS = [
+  { key: 'numPacketsTx' as keyof PacketRatesResponse, label: 'Packets Transmitted', color: '#89b4fa' },
+  { key: 'numTxDropped' as keyof PacketRatesResponse, label: 'Dropped', color: '#f38ba8' },
+  { key: 'numTxRelay' as keyof PacketRatesResponse, label: 'Relayed', color: '#a6e3a1' },
+  { key: 'numTxRelayCanceled' as keyof PacketRatesResponse, label: 'Relay Canceled', color: '#fab387' },
+];
+
+/**
+ * Merge multiple rate data arrays into a single array for charting
+ */
+function mergeRateData(
+  data: PacketRatesResponse | undefined,
+  metrics: Array<{ key: keyof PacketRatesResponse; label: string; color: string }>
+): Array<Record<string, number | null>> {
+  if (!data) return [];
+
+  const allTimestamps = new Set<number>();
+  for (const metric of metrics) {
+    const metricData = data[metric.key];
+    if (metricData) {
+      for (const point of metricData) {
+        allTimestamps.add(point.timestamp);
+      }
+    }
+  }
+
+  if (allTimestamps.size === 0) return [];
+
+  const lookups: Record<string, Map<number, number>> = {};
+  for (const metric of metrics) {
+    const metricData = data[metric.key];
+    lookups[metric.key] = new Map();
+    if (metricData) {
+      for (const point of metricData) {
+        lookups[metric.key].set(point.timestamp, point.ratePerMinute);
+      }
+    }
+  }
+
+  const sortedTimestamps = Array.from(allTimestamps).sort((a, b) => a - b);
+  const result: Array<Record<string, number | null>> = [];
+
+  for (const timestamp of sortedTimestamps) {
+    const point: Record<string, number | null> = { timestamp };
+    for (const metric of metrics) {
+      const value = lookups[metric.key].get(timestamp);
+      point[metric.key] = value !== undefined ? value : null;
+    }
+    result.push(point);
+  }
+
+  // Insert gaps for breaks > 1 hour
+  const oneHour = 60 * 60 * 1000;
+  const dataWithGaps: Array<Record<string, number | null>> = [];
+
+  for (let i = 0; i < result.length; i++) {
+    dataWithGaps.push(result[i]);
+    if (i < result.length - 1) {
+      const timeDiff = (result[i + 1].timestamp as number) - (result[i].timestamp as number);
+      if (timeDiff > oneHour) {
+        const gapPoint: Record<string, number | null> = {
+          timestamp: (result[i].timestamp as number) + 1,
+        };
+        for (const metric of metrics) {
+          gapPoint[metric.key] = null;
+        }
+        dataWithGaps.push(gapPoint);
+      }
+    }
+  }
+
+  return dataWithGaps;
+}
+
+const PacketRateChart: React.FC<PacketRateChartProps> = ({
+  id,
+  favorite,
+  node,
+  hours,
+  baseUrl,
+  globalTimeRange,
+  onRemove,
+}) => {
+  const { t } = useTranslation();
+
+  // Determine if this is RX or TX chart
+  const isRxChart = favorite.telemetryType === PACKET_RATE_RX_TYPE;
+  const metrics = isRxChart ? RX_METRICS : TX_METRICS;
+
+  // Fetch packet rate data
+  const { data: rateData, isLoading, error } = usePacketRates({
+    nodeId: favorite.nodeId,
+    hours,
+    baseUrl,
+  });
+
+  // Get computed CSS color values for chart styling
+  const [chartColors, setChartColors] = useState({
+    base: '#1e1e2e',
+    surface0: '#45475a',
+    text: '#cdd6f4',
+  });
+
+  useEffect(() => {
+    const updateColors = () => {
+      const rootStyle = getComputedStyle(document.documentElement);
+      const base = rootStyle.getPropertyValue('--ctp-base').trim();
+      const surface0 = rootStyle.getPropertyValue('--ctp-surface0').trim();
+      const text = rootStyle.getPropertyValue('--ctp-text').trim();
+      if (base && surface0 && text) {
+        setChartColors({ base, surface0, text });
+      }
+    };
+    updateColors();
+    const observer = new MutationObserver(updateColors);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  // Prepare chart data
+  const chartData = useMemo(() => mergeRateData(rateData, metrics), [rateData, metrics]);
+
+  // Drag and drop support
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+
+  const handleRemoveClick = useCallback(() => {
+    onRemove(favorite.nodeId, favorite.telemetryType);
+  }, [favorite.nodeId, favorite.telemetryType, onRemove]);
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  // Get node name for display
+  const nodeName = node?.user?.longName || node?.user?.shortName || favorite.nodeId;
+  const chartTitle = isRxChart ? t('info.rx_rates') : t('info.tx_rates');
+  const label = `${nodeName} - ${chartTitle}`;
+
+  if (isLoading) {
+    return (
+      <div ref={setNodeRef} style={style} className="dashboard-chart-container">
+        <div className="dashboard-chart-header">
+          <div className="dashboard-drag-handle" {...attributes} {...listeners}>
+            ⋮⋮
+          </div>
+          <h3 className="dashboard-chart-title" title={label}>
+            {label}
+          </h3>
+          <button
+            className="dashboard-remove-btn"
+            onClick={handleRemoveClick}
+            aria-label={t('dashboard.remove_from_dashboard')}
+          >
+            ✕
+          </button>
+        </div>
+        <div className="dashboard-loading-chart">{t('dashboard.loading_chart')}</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div ref={setNodeRef} style={style} className="dashboard-chart-container">
+        <div className="dashboard-chart-header">
+          <div className="dashboard-drag-handle" {...attributes} {...listeners}>
+            ⋮⋮
+          </div>
+          <h3 className="dashboard-chart-title" title={label}>
+            {label}
+          </h3>
+          <button
+            className="dashboard-remove-btn"
+            onClick={handleRemoveClick}
+            aria-label={t('dashboard.remove_from_dashboard')}
+          >
+            ✕
+          </button>
+        </div>
+        <div className="dashboard-error-chart">{t('dashboard.error_chart')}</div>
+      </div>
+    );
+  }
+
+  if (chartData.length === 0) {
+    return (
+      <div ref={setNodeRef} style={style} className="dashboard-chart-container">
+        <div className="dashboard-chart-header">
+          <div className="dashboard-drag-handle" {...attributes} {...listeners}>
+            ⋮⋮
+          </div>
+          <h3 className="dashboard-chart-title" title={label}>
+            {label}
+          </h3>
+          <button
+            className="dashboard-remove-btn"
+            onClick={handleRemoveClick}
+            aria-label={t('dashboard.remove_from_dashboard')}
+          >
+            ✕
+          </button>
+        </div>
+        <div className="dashboard-no-data">{t('info.no_rate_data')}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={setNodeRef} style={style} className="dashboard-chart-container">
+      <div className="dashboard-chart-header">
+        <div className="dashboard-drag-handle" {...attributes} {...listeners}>
+          ⋮⋮
+        </div>
+        <h3 className="dashboard-chart-title" title={label}>
+          {label}
+        </h3>
+        <button
+          className="dashboard-remove-btn"
+          onClick={handleRemoveClick}
+          aria-label={t('dashboard.remove_from_dashboard')}
+        >
+          ✕
+        </button>
+      </div>
+      <ResponsiveContainer width="100%" height={200}>
+        <ComposedChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#ccc" />
+          <XAxis
+            dataKey="timestamp"
+            type="number"
+            domain={globalTimeRange || ['dataMin', 'dataMax']}
+            tick={{ fontSize: 12 }}
+            tickFormatter={timestamp => formatChartAxisTimestamp(timestamp, globalTimeRange)}
+          />
+          <YAxis tick={{ fontSize: 12 }} domain={[0, 'auto']} tickFormatter={value => value.toFixed(1)} />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: chartColors.base,
+              border: `1px solid ${chartColors.surface0}`,
+              borderRadius: '4px',
+              color: chartColors.text,
+            }}
+            labelStyle={{ color: chartColors.text }}
+            labelFormatter={value => {
+              const date = new Date(value);
+              return date.toLocaleString([], {
+                month: 'short',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+              });
+            }}
+            formatter={(value, name: string) => {
+              if (value === null || value === undefined) return ['-', name];
+              const numValue = typeof value === 'number' ? value : parseFloat(String(value));
+              if (isNaN(numValue)) return ['-', name];
+              return [`${numValue.toFixed(2)} pkts/min`, name];
+            }}
+          />
+          <Legend
+            verticalAlign="bottom"
+            height={36}
+            formatter={(value: string) => {
+              const metric = metrics.find(m => m.key === value);
+              return metric?.label || value;
+            }}
+          />
+          {metrics.map(metric => (
+            <Line
+              key={metric.key}
+              type="monotone"
+              dataKey={metric.key}
+              name={metric.key}
+              stroke={metric.color}
+              strokeWidth={2}
+              dot={false}
+              connectNulls={false}
+            />
+          ))}
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default PacketRateChart;
+
+// Helper to check if a telemetry type is a packet rate type
+export function isPacketRateType(telemetryType: string): boolean {
+  return telemetryType === PACKET_RATE_RX_TYPE || telemetryType === PACKET_RATE_TX_TYPE;
+}

--- a/src/components/PacketRateGraphs.tsx
+++ b/src/components/PacketRateGraphs.tsx
@@ -1,0 +1,329 @@
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  ComposedChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import './TelemetryGraphs.css';
+import { usePacketRates, type PacketRatesResponse } from '../hooks/usePacketRates';
+import { formatChartAxisTimestamp } from '../utils/datetime';
+import { useFavorites, useToggleFavorite } from '../hooks/useFavorites';
+import { useToast } from './ToastContainer';
+
+// Telemetry type constants for favorites
+export const PACKET_RATE_RX_TYPE = 'packetRateRx';
+export const PACKET_RATE_TX_TYPE = 'packetRateTx';
+
+interface PacketRateGraphsProps {
+  nodeId: string;
+  telemetryHours?: number;
+  baseUrl?: string;
+}
+
+// RX metrics configuration
+const RX_METRICS = [
+  { key: 'numPacketsRx' as keyof PacketRatesResponse, label: 'Packets Received', color: '#a6e3a1' },
+  { key: 'numPacketsRxBad' as keyof PacketRatesResponse, label: 'Bad Packets', color: '#f38ba8' },
+  { key: 'numRxDupe' as keyof PacketRatesResponse, label: 'Duplicates', color: '#fab387' },
+];
+
+// TX metrics configuration
+const TX_METRICS = [
+  { key: 'numPacketsTx' as keyof PacketRatesResponse, label: 'Packets Transmitted', color: '#89b4fa' },
+  { key: 'numTxDropped' as keyof PacketRatesResponse, label: 'Dropped', color: '#f38ba8' },
+  { key: 'numTxRelay' as keyof PacketRatesResponse, label: 'Relayed', color: '#a6e3a1' },
+  { key: 'numTxRelayCanceled' as keyof PacketRatesResponse, label: 'Relay Canceled', color: '#fab387' },
+];
+
+/**
+ * Merge multiple rate data arrays into a single array for charting
+ * Each data point will have a timestamp and rate values for each metric
+ */
+function mergeRateData(
+  data: PacketRatesResponse | undefined,
+  metrics: Array<{ key: keyof PacketRatesResponse; label: string; color: string }>
+): Array<Record<string, number | null>> {
+  if (!data) return [];
+
+  // Collect all unique timestamps
+  const allTimestamps = new Set<number>();
+  for (const metric of metrics) {
+    const metricData = data[metric.key];
+    if (metricData) {
+      for (const point of metricData) {
+        allTimestamps.add(point.timestamp);
+      }
+    }
+  }
+
+  if (allTimestamps.size === 0) return [];
+
+  // Create lookup maps for each metric
+  const lookups: Record<string, Map<number, number>> = {};
+  for (const metric of metrics) {
+    const metricData = data[metric.key];
+    lookups[metric.key] = new Map();
+    if (metricData) {
+      for (const point of metricData) {
+        lookups[metric.key].set(point.timestamp, point.ratePerMinute);
+      }
+    }
+  }
+
+  // Build merged data array
+  const sortedTimestamps = Array.from(allTimestamps).sort((a, b) => a - b);
+  const result: Array<Record<string, number | null>> = [];
+
+  for (const timestamp of sortedTimestamps) {
+    const point: Record<string, number | null> = { timestamp };
+    for (const metric of metrics) {
+      const value = lookups[metric.key].get(timestamp);
+      point[metric.key] = value !== undefined ? value : null;
+    }
+    result.push(point);
+  }
+
+  // Insert gaps for breaks > 1 hour
+  const oneHour = 60 * 60 * 1000;
+  const dataWithGaps: Array<Record<string, number | null>> = [];
+
+  for (let i = 0; i < result.length; i++) {
+    dataWithGaps.push(result[i]);
+
+    if (i < result.length - 1) {
+      const timeDiff = (result[i + 1].timestamp as number) - (result[i].timestamp as number);
+      if (timeDiff > oneHour) {
+        // Insert a gap point
+        const gapPoint: Record<string, number | null> = {
+          timestamp: (result[i].timestamp as number) + 1,
+        };
+        for (const metric of metrics) {
+          gapPoint[metric.key] = null;
+        }
+        dataWithGaps.push(gapPoint);
+      }
+    }
+  }
+
+  return dataWithGaps;
+}
+
+const PacketRateGraphs: React.FC<PacketRateGraphsProps> = React.memo(
+  ({ nodeId, telemetryHours = 24, baseUrl = '' }) => {
+    const { t } = useTranslation();
+    const { showToast } = useToast();
+
+    // Fetch packet rate data
+    const { data: rateData, isLoading, error } = usePacketRates({
+      nodeId,
+      hours: telemetryHours,
+      baseUrl,
+    });
+
+    // Favorites management
+    const { data: favorites = new Set<string>() } = useFavorites({ nodeId, baseUrl });
+
+    const toggleFavoriteMutation = useToggleFavorite({
+      baseUrl,
+      onError: message => showToast(message || t('telemetry.favorite_save_failed'), 'error'),
+    });
+
+    // Create stable callback for toggling favorites
+    const createToggleFavorite = useCallback(
+      (telemetryType: string) => () => {
+        toggleFavoriteMutation.mutate({
+          nodeId,
+          telemetryType,
+          currentFavorites: favorites,
+        });
+      },
+      [nodeId, favorites, toggleFavoriteMutation]
+    );
+
+    // Get computed CSS color values for chart styling
+    const [chartColors, setChartColors] = useState({
+      base: '#1e1e2e',
+      surface0: '#45475a',
+      text: '#cdd6f4',
+    });
+
+    // Update chart colors when theme changes
+    useEffect(() => {
+      const updateColors = () => {
+        const rootStyle = getComputedStyle(document.documentElement);
+        const base = rootStyle.getPropertyValue('--ctp-base').trim();
+        const surface0 = rootStyle.getPropertyValue('--ctp-surface0').trim();
+        const text = rootStyle.getPropertyValue('--ctp-text').trim();
+
+        if (base && surface0 && text) {
+          setChartColors({ base, surface0, text });
+        }
+      };
+
+      updateColors();
+      const observer = new MutationObserver(updateColors);
+      observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['class', 'data-theme'],
+      });
+
+      return () => observer.disconnect();
+    }, []);
+
+    // Prepare chart data
+    const rxChartData = useMemo(() => mergeRateData(rateData, RX_METRICS), [rateData]);
+    const txChartData = useMemo(() => mergeRateData(rateData, TX_METRICS), [rateData]);
+
+    // Calculate global time range for both charts
+    const globalTimeRange = useMemo((): [number, number] | null => {
+      const allData = [...rxChartData, ...txChartData];
+      if (allData.length === 0) return null;
+
+      const timestamps = allData.map(d => d.timestamp as number).filter(t => t > 0);
+      if (timestamps.length === 0) return null;
+
+      return [Math.min(...timestamps), Math.max(...timestamps)];
+    }, [rxChartData, txChartData]);
+
+    // Check if we have any data
+    const hasRxData = rxChartData.length > 0;
+    const hasTxData = txChartData.length > 0;
+    const hasAnyData = hasRxData || hasTxData;
+
+    if (isLoading) {
+      return (
+        <div className="telemetry-graphs">
+          <h3 className="telemetry-title">{t('info.packet_rate_graphs')}</h3>
+          <p className="telemetry-loading">{t('common.loading_indicator')}</p>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div className="telemetry-graphs">
+          <h3 className="telemetry-title">{t('info.packet_rate_graphs')}</h3>
+          <p className="telemetry-empty">{t('info.rate_error')}</p>
+        </div>
+      );
+    }
+
+    if (!hasAnyData) {
+      return (
+        <div className="telemetry-graphs">
+          <h3 className="telemetry-title">{t('info.packet_rate_graphs')}</h3>
+          <p className="telemetry-empty">{t('info.no_rate_data')}</p>
+        </div>
+      );
+    }
+
+    const renderChart = (
+      data: Array<Record<string, number | null>>,
+      metrics: Array<{ key: keyof PacketRatesResponse; label: string; color: string }>,
+      title: string,
+      telemetryType: string
+    ) => {
+      if (data.length === 0) return null;
+
+      const isFavorited = favorites.has(telemetryType);
+
+      return (
+        <div className="graph-container">
+          <div className="graph-header">
+            <h4 className="graph-title">{title}</h4>
+            <div className="graph-actions">
+              <button
+                className={`favorite-btn ${isFavorited ? 'favorited' : ''}`}
+                onClick={createToggleFavorite(telemetryType)}
+                aria-label={isFavorited ? t('telemetry.remove_favorite') : t('telemetry.add_favorite')}
+              >
+                {isFavorited ? '★' : '☆'}
+              </button>
+            </div>
+          </div>
+          <ResponsiveContainer width="100%" height={200}>
+            <ComposedChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#ccc" />
+              <XAxis
+                dataKey="timestamp"
+                type="number"
+                domain={globalTimeRange || ['dataMin', 'dataMax']}
+                tick={{ fontSize: 12 }}
+                tickFormatter={timestamp => formatChartAxisTimestamp(timestamp, globalTimeRange)}
+              />
+              <YAxis
+                tick={{ fontSize: 12 }}
+                domain={[0, 'auto']}
+                tickFormatter={value => value.toFixed(1)}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: chartColors.base,
+                  border: `1px solid ${chartColors.surface0}`,
+                  borderRadius: '4px',
+                  color: chartColors.text,
+                }}
+                labelStyle={{ color: chartColors.text }}
+                labelFormatter={value => {
+                  const date = new Date(value);
+                  return date.toLocaleString([], {
+                    month: 'short',
+                    day: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  });
+                }}
+                formatter={(value, name: string) => {
+                  if (value === null || value === undefined) return ['-', name];
+                  const numValue = typeof value === 'number' ? value : parseFloat(String(value));
+                  if (isNaN(numValue)) return ['-', name];
+                  return [`${numValue.toFixed(2)} pkts/min`, name];
+                }}
+              />
+              <Legend
+                verticalAlign="bottom"
+                height={36}
+                formatter={(value: string) => {
+                  const metric = metrics.find(m => m.key === value);
+                  return metric?.label || value;
+                }}
+              />
+              {metrics.map(metric => (
+                <Line
+                  key={metric.key}
+                  type="monotone"
+                  dataKey={metric.key}
+                  name={metric.key}
+                  stroke={metric.color}
+                  strokeWidth={2}
+                  dot={false}
+                  connectNulls={false}
+                />
+              ))}
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      );
+    };
+
+    return (
+      <div className="telemetry-graphs">
+        <h3 className="telemetry-title">{t('info.packet_rate_graphs')}</h3>
+        <div className="graphs-grid">
+          {hasRxData && renderChart(rxChartData, RX_METRICS, t('info.rx_rates'), PACKET_RATE_RX_TYPE)}
+          {hasTxData && renderChart(txChartData, TX_METRICS, t('info.tx_rates'), PACKET_RATE_TX_TYPE)}
+        </div>
+      </div>
+    );
+  }
+);
+
+PacketRateGraphs.displayName = 'PacketRateGraphs';
+
+export default PacketRateGraphs;

--- a/src/hooks/usePacketRates.ts
+++ b/src/hooks/usePacketRates.ts
@@ -1,0 +1,90 @@
+/**
+ * Packet rate data fetching hook using TanStack Query
+ *
+ * Provides a hook for fetching packet rate statistics (packets per minute)
+ * with automatic caching, deduplication, and periodic refetching.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * Rate data point from the backend
+ */
+export interface PacketRateData {
+  /** Unix timestamp in milliseconds */
+  timestamp: number;
+  /** Rate in packets per minute */
+  ratePerMinute: number;
+}
+
+/**
+ * Response from packet rates API
+ */
+export interface PacketRatesResponse {
+  numPacketsRx: PacketRateData[];
+  numPacketsRxBad: PacketRateData[];
+  numRxDupe: PacketRateData[];
+  numPacketsTx: PacketRateData[];
+  numTxDropped: PacketRateData[];
+  numTxRelay: PacketRateData[];
+  numTxRelayCanceled: PacketRateData[];
+}
+
+/**
+ * Options for usePacketRates hook
+ */
+interface UsePacketRatesOptions {
+  /** Node ID to fetch rates for */
+  nodeId: string;
+  /** Number of hours of historical data to fetch (default: 24) */
+  hours?: number;
+  /** Base URL for API requests (default: '') */
+  baseUrl?: string;
+  /** Whether to enable the query (default: true) */
+  enabled?: boolean;
+}
+
+/**
+ * Hook to fetch packet rate statistics for a specific node
+ *
+ * Uses TanStack Query for:
+ * - Automatic request deduplication
+ * - Caching with configurable stale time
+ * - Automatic background refetching every 60 seconds
+ * - Loading and error states
+ *
+ * @param options - Configuration options
+ * @returns TanStack Query result with packet rate data
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading, error } = usePacketRates({
+ *   nodeId: '!abcd1234',
+ *   hours: 24
+ * });
+ * ```
+ */
+export function usePacketRates({
+  nodeId,
+  hours = 24,
+  baseUrl = '',
+  enabled = true,
+}: UsePacketRatesOptions) {
+  return useQuery({
+    queryKey: ['packetRates', nodeId, hours],
+    queryFn: async (): Promise<PacketRatesResponse> => {
+      const response = await fetch(`${baseUrl}/api/telemetry/${nodeId}/rates?hours=${hours}`);
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch packet rates: ${response.status} ${response.statusText}`);
+      }
+
+      return response.json();
+    },
+    enabled: enabled && !!nodeId,
+    refetchInterval: 60000, // Refetch every 60 seconds (matches LocalStats polling)
+    staleTime: 55000, // Data considered fresh for 55 seconds
+    gcTime: 5 * 60 * 1000, // Keep in cache for 5 minutes
+    refetchOnWindowFocus: false,
+  });
+}


### PR DESCRIPTION
## Summary

- Add new telemetry graphs showing packet statistics as rates (packets/min) instead of absolute values
- **RX Rates graph**: numPacketsRx, numPacketsRxBad, numRxDupe  
- **TX Rates graph**: numPacketsTx, numTxDropped, numTxRelay, numTxRelayCanceled
- Rate calculation handles counter resets (device reboots) gracefully
- Favorites support - charts can be starred and appear on Telemetry Dashboard
- New backend API endpoint: `GET /api/telemetry/:nodeId/rates`

Closes #1274

## Test plan

- [ ] Navigate to Info tab, scroll to bottom to see "Packet Rate Trends" section
- [ ] Verify RX and TX rate graphs display with multiple colored lines
- [ ] Click star button to favorite a chart
- [ ] Navigate to Dashboard tab and verify favorited chart appears with proper styling
- [ ] Verify chart has drag handle, title, and X button matching other dashboard charts
- [ ] Test removing favorite from dashboard via X button

🤖 Generated with [Claude Code](https://claude.com/claude-code)