### PR TITLE
Messages tab improvements: failed traceroute display and resizable send section

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -299,6 +299,8 @@
   "messages.traceroute_forward": "→ Forward:",
   "messages.traceroute_return": "← Return:",
   "messages.last_traced": "Last traced {{time}}",
+  "messages.traceroute_failed": "Failed",
+  "messages.resize_handle_title": "Drag to resize",
   "messages.security_issue_title": "Security Issue",
   "messages.issue_details": "Issue Details",
   "messages.low_entropy_warning": "This node uses a known low-entropy cryptographic key. ",

--- a/src/App.css
+++ b/src/App.css
@@ -766,13 +766,61 @@ body {
   height: 100%;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+}
+
+/* Desktop: messages container fills remaining space */
+.dm-conversation-panel .messages-container {
+  flex: 1;
+  min-height: 100px;
   overflow-y: auto;
 }
 
-/* Desktop: constrain DM messages container height */
-.dm-conversation-panel .messages-container {
-  max-height: calc(100vh - var(--header-height) - 24rem);
-  min-height: 200px;
+/* DM Resize Handle - for resizing between messages and send section */
+.dm-resize-handle {
+  height: 8px;
+  cursor: ns-resize;
+  background: transparent;
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+  position: relative;
+  margin: 0 -1rem;
+  padding: 0 1rem;
+}
+
+.dm-resize-handle:hover,
+.dm-resize-handle.resizing {
+  background: var(--primary-color, var(--ctp-blue));
+}
+
+.dm-resize-handle::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 40px;
+  height: 4px;
+  background: var(--border-color, var(--ctp-surface2));
+  border-radius: 2px;
+  transition: background 0.2s ease;
+}
+
+.dm-resize-handle:hover::before,
+.dm-resize-handle.resizing::before {
+  background: var(--primary-color, var(--ctp-blue));
+}
+
+/* DM Send Section - wrapper for send form and info below */
+.dm-send-section {
+  flex-shrink: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.dm-send-section.resizing {
+  pointer-events: none;
 }
 
 .no-selection {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2274,30 +2274,11 @@ function App() {
           return false;
         }
 
-        // Filter out failed traceroutes (where both directions are null)
+        // Include all traceroutes, even failed ones
         // null or 'null' = failed (no response received)
         // [] = successful with 0 hops (direct connection)
         // [hops] = successful with intermediate hops
-        let routeData = null;
-        let routeBackData = null;
-
-        try {
-          if (tr.route && tr.route !== 'null') {
-            routeData = JSON.parse(tr.route);
-          }
-          if (tr.routeBack && tr.routeBack !== 'null') {
-            routeBackData = JSON.parse(tr.routeBack);
-          }
-        } catch (e) {
-          // If parsing fails, treat as null (failed)
-          console.error('Error parsing traceroute data:', e);
-        }
-
-        // A traceroute is successful if at least one direction has data (even if empty array)
-        const hasForwardData = routeData !== null;
-        const hasReturnData = routeBackData !== null;
-
-        return hasForwardData || hasReturnData;
+        return true;
       })
       .sort((a, b) => b.timestamp - a.timestamp);
 


### PR DESCRIPTION
## Summary
- Show Last Traceroute even when both directions failed (no longer filtered out)
- Add "(Failed)" indicator when traceroute has no response from either direction
- Add resizable divider between messages list and send section on desktop
  - Uses useResizable hook for drag-to-resize functionality
  - Persists resize preference to localStorage
  - Hidden on mobile for better UX

Closes #1277

## Test plan
- [ ] Select a DM conversation with a failed traceroute - should now display with "(Failed)" indicator
- [ ] On desktop, hover over the divider between messages and send section - should show resize cursor
- [ ] Drag the divider up/down to resize the send section
- [ ] Refresh the page - resize preference should persist
- [ ] On mobile, verify the resize handle is not visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)