### PR TITLE
Improve error handling for malformed JSON in API requests

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7686,6 +7686,15 @@ if (BASE_URL) {
 
 // Error handling middleware
 app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  // Handle JSON parsing errors with a helpful message
+  if (err instanceof SyntaxError && 'body' in err) {
+    logger.warn('JSON parsing error:', err.message);
+    return res.status(400).json({
+      error: 'Bad Request',
+      message: 'Invalid JSON in request body. Please check your JSON syntax.',
+    });
+  }
+
   logger.error('Unhandled error:', err);
   res.status(500).json({
     error: 'Internal server error',


### PR DESCRIPTION
## Summary
Returns a helpful 400 Bad Request error when JSON parsing fails instead of a generic 500 Internal Server Error.

This was discovered via discussion #1178 where a user was getting `{"error":"Internal server error","message":"Something went wrong"}` when sending a channel message via the API. The root cause was malformed JSON in their request (missing opening brace).

## Changes
- Added JSON SyntaxError detection in the global error handler
- Returns 400 with message: "Invalid JSON in request body. Please check your JSON syntax."

## Test plan
- [ ] Send a request with malformed JSON - should get 400 with helpful message
- [ ] Send a request with valid JSON - should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)