### PR TITLE
Add MQTT indicator icon to message hop count display

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2064,6 +2064,7 @@
   "messages.hops_other": "{{count}} hops",
   "messages.signal_info": "Signal strength (SNR/RSSI) - Direct message",
   "messages.click_for_relay": "Click to see potential relay nodes",
+  "messages.via_mqtt": "Received via MQTT",
 
   "link_preview.loading": "Loading preview...",
   "link_preview.image_alt": "Link preview",

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -639,6 +639,7 @@ export default function ChannelsTab({
                                           rxSnr={msg.rxSnr}
                                           rxRssi={msg.rxRssi}
                                           relayNode={msg.relayNode}
+                                          viaMqtt={msg.viaMqtt}
                                           onClick={() => handleRelayClick(msg)}
                                         />
                                       </span>

--- a/src/components/HopCountDisplay.tsx
+++ b/src/components/HopCountDisplay.tsx
@@ -7,6 +7,7 @@ interface HopCountDisplayProps {
   rxSnr?: number;
   rxRssi?: number;
   relayNode?: number;
+  viaMqtt?: boolean;
   onClick?: () => void;
 }
 
@@ -23,20 +24,33 @@ const HopCountDisplay: React.FC<HopCountDisplayProps> = ({
   rxSnr,
   rxRssi,
   relayNode,
+  viaMqtt,
   onClick,
 }) => {
   const { t } = useTranslation();
 
-  // Return null if either hop value is missing
+  // MQTT indicator component
+  const MqttIndicator = viaMqtt ? (
+    <span
+      style={{ marginLeft: '4px', opacity: 0.8 }}
+      title={t('messages.via_mqtt')}
+      aria-label={t('messages.via_mqtt')}
+      role="img"
+    >
+      🌐
+    </span>
+  ) : null;
+
+  // Return null if either hop value is missing (but show MQTT indicator if present)
   if (hopStart === undefined || hopLimit === undefined) {
-    return null;
+    return MqttIndicator;
   }
 
   const hopCount = hopStart - hopLimit;
 
   // Guard against malformed data (negative hop counts)
   if (hopCount < 0) {
-    return null;
+    return MqttIndicator;
   }
 
   // Check if this hop count is clickable (has relay node info)
@@ -62,20 +76,26 @@ const HopCountDisplay: React.FC<HopCountDisplayProps> = ({
       parts.push(`${rxRssi} dBm`);
     }
     return (
-      <span style={{ fontSize: '0.75em', marginLeft: '4px', opacity: 0.7 }} title={t('messages.signal_info')}>
-        ({parts.join(' / ')})
-      </span>
+      <>
+        <span style={{ fontSize: '0.75em', marginLeft: '4px', opacity: 0.7 }} title={t('messages.signal_info')}>
+          ({parts.join(' / ')})
+        </span>
+        {MqttIndicator}
+      </>
     );
   }
 
   return (
-    <span
-      style={{ fontSize: '0.75em', marginLeft: '4px', opacity: isClickable ? 1 : 0.7, ...clickableStyle }}
-      onClick={isClickable ? onClick : undefined}
-      title={isClickable ? t('messages.click_for_relay') : undefined}
-    >
-      ({t('messages.hops', { count: hopCount })})
-    </span>
+    <>
+      <span
+        style={{ fontSize: '0.75em', marginLeft: '4px', opacity: isClickable ? 1 : 0.7, ...clickableStyle }}
+        onClick={isClickable ? onClick : undefined}
+        title={isClickable ? t('messages.click_for_relay') : undefined}
+      >
+        ({t('messages.hops', { count: hopCount })})
+      </span>
+      {MqttIndicator}
+    </>
   );
 };
 

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -873,6 +873,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                 rxSnr={msg.rxSnr}
                                 rxRssi={msg.rxRssi}
                                 relayNode={msg.relayNode}
+                                viaMqtt={msg.viaMqtt}
                                 onClick={() => handleRelayClick(msg)}
                               />
                             </span>
@@ -989,6 +990,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                   rxSnr={msg.rxSnr}
                                   rxRssi={msg.rxRssi}
                                   relayNode={msg.relayNode}
+                                  viaMqtt={msg.viaMqtt}
                                   onClick={() => handleRelayClick(msg)}
                                 />
                               </span>


### PR DESCRIPTION
## Summary
Shows a 🌐 icon next to the hop count on messages that were received via MQTT. This helps users identify which messages traversed the MQTT bridge.

## Changes
- Added `viaMqtt` prop to `HopCountDisplay` component
- Updated `MessagesTab` and `ChannelsTab` to pass `viaMqtt` to the component
- Icon displays even if hop data is missing (as long as viaMqtt is true)
- Added translation key `messages.via_mqtt` for tooltip

## Test plan
- [ ] View messages in Channels tab - messages via MQTT should show 🌐 icon
- [ ] View messages in Messages tab - messages via MQTT should show 🌐 icon
- [ ] Hover over icon - should show "Received via MQTT" tooltip
- [ ] Messages without viaMqtt flag should not show the icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)