### PR TITLE
Add hops indicator to Messages tab node list

### DIFF
--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -489,6 +489,19 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         <div className="node-name">
                           {node.isFavorite && <span className="favorite-indicator">⭐</span>}
                           <span className="node-name-text">{node.user?.longName || t('messages.node_fallback', { nodeNum: node.nodeNum })}</span>
+                          {node.hopsAway != null && (
+                            <span
+                              className="node-hops"
+                              title={t('nodes.hops_away')}
+                              style={{
+                                fontSize: '0.75rem',
+                                color: 'var(--ctp-subtext0)',
+                                marginLeft: '0.5rem',
+                              }}
+                            >
+                              🔗 {node.hopsAway}
+                            </span>
+                          )}
                         </div>
                         <div className="node-actions">
                           {(node.keyIsLowEntropy || node.duplicateKeyDetected) && (


### PR DESCRIPTION
## Summary
Display the number of hops (🔗) next to node names in the Messages tab's private conversations list, matching the style used on the Map tab.

Closes #1282

## Changes
- Added hops indicator span after node name in MessagesTab.tsx
- Shows `🔗 X` where X is the hop count
- Only displays when `hopsAway` is available
- Includes tooltip "Hops Away" on hover

## Test plan
- [ ] View Messages tab node list - nodes with hop data should show 🔗 indicator
- [ ] Hover over indicator - should show "Hops Away" tooltip
- [ ] Nodes without hop data should not show indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)