### PR TITLE
Restore Docker image attestation features

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      attestations: write
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -64,10 +66,8 @@ jobs:
             org.opencontainers.image.description=Web tool for monitoring a Meshtastic Node Deployment over TCP/HTTP
           cache-from: type=gha,scope=main
           cache-to: type=gha,mode=max,scope=main
-          provenance: false
-          sbom: false
-        env:
-          DOCKER_BUILD_RECORD_UPLOAD: false
+          provenance: true
+          sbom: true
         timeout-minutes: 40
 
   # Build for armv7 using Node.js 22 (Debian slim)
@@ -77,6 +77,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      attestations: write
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -120,10 +122,8 @@ jobs:
             org.opencontainers.image.description=Web tool for monitoring a Meshtastic Node Deployment over TCP/HTTP
           cache-from: type=gha,scope=armv7
           cache-to: type=gha,mode=max,scope=armv7
-          provenance: false
-          sbom: false
-        env:
-          DOCKER_BUILD_RECORD_UPLOAD: false
+          provenance: true
+          sbom: true
         timeout-minutes: 40
 
   # Create multi-arch manifest combining all platforms


### PR DESCRIPTION
## Summary
Re-enable provenance and SBOM generation for Docker images that were previously disabled.

## Changes
- Added `attestations: write` and `id-token: write` permissions to build jobs
- Enabled `provenance: true` - generates cryptographically signed build provenance
- Enabled `sbom: true` - generates Software Bill of Materials
- Removed `DOCKER_BUILD_RECORD_UPLOAD: false` env vars

## Benefits
- **Provenance attestations**: Cryptographically signed metadata about where/how the image was built
- **SBOM**: List of all components and dependencies in the image
- **Supply chain security**: Helps users verify image authenticity and audit dependencies

## Test plan
- [ ] Trigger a release or manual workflow dispatch
- [ ] Verify attestations are generated and attached to the image
- [ ] Verify SBOM is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)