### PR TITLE
Add OLmesh.net to site gallery

### DIFF
--- a/docs/site-gallery.md
+++ b/docs/site-gallery.md
@@ -51,6 +51,14 @@ Running a public MeshMonitor instance? We'd love to feature it! **[File an issue
 
 ---
 
+### OLmesh.net - OberlausitzMesh Network
+- **URL**: [meshmonitor.olmesh.net](https://meshmonitor.olmesh.net)
+- **Network**: [OLmesh.net](https://olmesh.net/meshtastic)
+- **Location**: Saxony / Oberlausitz, Germany
+- **Description**: MeshMonitor for the OLmesh.net Community in Germany, covering the region of Saxony / Oberlausitz.
+
+---
+
 ## About the Site Gallery
 
 The Site Gallery showcases MeshMonitor instances that are publicly accessible. These sites demonstrate:


### PR DESCRIPTION
## Summary
Adds OLmesh.net - OberlausitzMesh Network to the site gallery.

- **URL**: https://meshmonitor.olmesh.net
- **Network**: https://olmesh.net/meshtastic
- **Location**: Saxony / Oberlausitz, Germany

Closes #1289

🤖 Generated with [Claude Code](https://claude.com/claude-code)