### PR TITLE
Add NSLocalNetworkUsageDescription for macOS local network permission

### DIFF
--- a/desktop/src-tauri/Info.plist
+++ b/desktop/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>MeshMonitor needs local network access to connect to your Meshtastic node on your local network.</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Adds `Info.plist` configuration to the macOS desktop app bundle
- Includes `NSLocalNetworkUsageDescription` to ensure macOS prompts the user for local network access permission
- Fixes issue where the macOS app sometimes wouldn't request local network access and couldn't connect to nodes

The Tauri build process merges this custom Info.plist with the generated one, adding the required key for macOS to properly prompt for local network permissions.

## Test plan

- [ ] Build macOS desktop app
- [ ] First launch should prompt for local network access
- [ ] App can connect to Meshtastic nodes on local network after granting permission
- [ ] Verified system tests pass on Linux (Info.plist only affects macOS bundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)