### PR TITLE
Emit WebSocket event when position packet updates node

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2278,6 +2278,9 @@ class MeshtasticManager {
           // Save position to nodes table (current position)
           databaseService.upsertNode(nodeData);
 
+          // Emit node update event to notify frontend via WebSocket
+          dataEventEmitter.emitNodeUpdate(fromNum, nodeData);
+
           // Save position to telemetry table (historical tracking with precision metadata)
           databaseService.insertTelemetry({
             nodeId, nodeNum: fromNum, telemetryType: 'latitude',


### PR DESCRIPTION
## Summary

- Added `dataEventEmitter.emitNodeUpdate()` call after processing position packets
- Previously, position packets updated the database but didn't notify the frontend via WebSocket
- This caused new nodes with position data to not appear on the map until the next poll cycle (5-30 seconds)
- Now immediately notifies frontend when a node's position is updated

## Root Cause

When a position packet was received:
1. ✅ Node data saved to database via `upsertNode()`
2. ❌ No WebSocket event emitted to frontend
3. Frontend only learned about the new node on next poll

NodeInfo packets already emitted `node:updated` events, but position packets didn't.

## Test plan

- [x] TypeScript type check passes
- [x] Server build succeeds
- [x] All system tests pass
- [ ] Verify nodes with position data appear immediately on map (requires live testing)

Fixes #1304

🤖 Generated with [Claude Code](https://claude.com/claude-code)