### PR TITLE
Add larger emoji display for sender dot bubbles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2138,6 +2138,12 @@ body {
   cursor: help;
 }
 
+.sender-dot.is-emoji {
+  font-size: 1.25rem;
+  font-weight: normal;
+  line-height: 1;
+}
+
 .message-bubble {
   max-width: 100%;
   padding: 0.75rem 1rem;

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -12,7 +12,7 @@ import { MeshMessage } from '../types/message';
 import { ResourceType } from '../types/permission';
 import { TimeFormat, DateFormat } from '../contexts/SettingsContext';
 import { formatMessageTime, getMessageDateSeparator, shouldShowDateSeparator } from '../utils/datetime';
-import { getUtf8ByteLength, formatByteCount } from '../utils/text';
+import { getUtf8ByteLength, formatByteCount, isEmoji } from '../utils/text';
 import { renderMessageWithLinks } from '../utils/linkRenderer';
 import HopCountDisplay from './HopCountDisplay';
 import LinkPreview from './LinkPreview';
@@ -548,7 +548,7 @@ export default function ChannelsTab({
                               <div className={`message-bubble-container ${isMine ? 'mine' : 'theirs'}`}>
                                 {!isMine && (
                                   <div
-                                    className="sender-dot clickable"
+                                    className={`sender-dot clickable ${isEmoji(getNodeShortName(msg.from)) ? 'is-emoji' : ''}`}
                                     title={t('channels.sender_click_title', { name: getNodeName(msg.from) })}
                                     onClick={e => handleSenderClick(msg.from, e)}
                                   >

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -20,7 +20,7 @@ import {
   shouldShowDateSeparator,
 } from '../utils/datetime';
 import { formatTracerouteRoute } from '../utils/traceroute';
-import { getUtf8ByteLength, formatByteCount } from '../utils/text';
+import { getUtf8ByteLength, formatByteCount, isEmoji } from '../utils/text';
 import { renderMessageWithLinks } from '../utils/linkRenderer';
 import { isNodeComplete, isInfrastructureNode, hasValidPosition } from '../utils/nodeHelpers';
 import HopCountDisplay from './HopCountDisplay';
@@ -912,7 +912,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       <div className={`message-bubble-container ${isMine ? 'mine' : 'theirs'}`}>
                         {!isMine && (
                           <div
-                            className="sender-dot clickable"
+                            className={`sender-dot clickable ${isEmoji(getNodeShortName(msg.from)) ? 'is-emoji' : ''}`}
                             title={`Click for ${getNodeName(msg.from)} details`}
                             onClick={e => handleSenderClick(msg.from, e)}
                           >

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -34,3 +34,16 @@ export function formatByteCount(byteCount: number, maxBytes: number = 200): { te
     className
   };
 }
+
+/**
+ * Check if a string consists primarily of emoji characters
+ * Used for styling sender dots that use emoji as shortnames
+ *
+ * @param content - The text to check
+ * @returns True if the content is primarily emoji (1-2 emoji characters)
+ */
+export function isEmoji(content: string): boolean {
+  if (!content) return false;
+  // Match emoji characters - the string should be 1-2 emoji with no other characters
+  return /^\p{Emoji}+$/u.test(content) && content.length <= 2;
+}


### PR DESCRIPTION
## Summary

- Added `isEmoji()` helper function to detect emoji-only shortnames
- Applied larger font size (1.25rem) for emoji sender dots in Channels and Messages tabs
- Makes emoji shortnames more visible and readable in message bubbles

## Changes

- `src/utils/text.ts`: Added `isEmoji()` function using Unicode regex
- `src/components/ChannelsTab.tsx`: Apply `is-emoji` class when shortname is emoji
- `src/components/MessagesTab.tsx`: Apply `is-emoji` class when shortname is emoji  
- `src/App.css`: Added `.sender-dot.is-emoji` styling

## Test plan

- [x] TypeScript type check passes
- [x] Build succeeds
- [x] All system tests pass
- [ ] Visual verification: emoji shortnames appear larger in sender dots

Closes #1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)