### PR TITLE
fix: Add missing txEnabled fields to Remote Admin LoRa config

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -2,6 +2,21 @@
 
 ## Current Sprint
 
+### Remote Admin LoRa Config Missing txEnabled Fields (#1328)
+
+**Completed:**
+- [x] Add txEnabled, overrideDutyCycle, paFanDisabled to LoRaConfigState interface
+- [x] Add defaults to initial state (txEnabled: true to prevent accidental TX disable)
+- [x] Update setLoRaConfig calls when loading config from remote node
+- [x] Update handleSetLoRaConfig to include the new fields when saving
+- [x] Add UI controls for txEnabled, overrideDutyCycle, paFanDisabled in Remote Admin
+- [x] Add translation keys for new settings
+
+**Summary:**
+Fixed a bug where saving Remote Admin LoRa configuration would silently disable transmission (txEnabled=false). The issue was that txEnabled, overrideDutyCycle, and paFanDisabled were missing from the Remote Admin LoRa state, causing protobuf to default boolean fields to false when saving. Added all three fields to the state interface, load callbacks, save handler, and UI.
+
+---
+
 ### Outgoing Mesh Commands in Packet Monitor (#1322)
 
 **Completed:**

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2831,6 +2831,12 @@
   "admin_commands.ignore_mqtt_description": "If enabled, the device will not process any packets received via LoRa that passed via MQTT anywhere on the path",
   "admin_commands.config_ok_to_mqtt": "OK to MQTT",
   "admin_commands.config_ok_to_mqtt_description": "If enabled, sets the ok_to_mqtt bit on outgoing packets, allowing them to be forwarded via MQTT",
+  "admin_commands.tx_enabled": "Transmit Enabled",
+  "admin_commands.tx_enabled_description": "Enable LoRa transmission. If disabled, the device will only receive packets.",
+  "admin_commands.override_duty_cycle": "Override Duty Cycle",
+  "admin_commands.override_duty_cycle_description": "Override the duty cycle limitation. Use with caution - may violate local regulations.",
+  "admin_commands.pa_fan_disabled": "PA Fan Disabled",
+  "admin_commands.pa_fan_disabled_description": "Disable the power amplifier cooling fan (for devices with PA fans)",
   "admin_commands.save_lora_config": "Save LoRa Config",
 
   "admin_commands.position_configuration": "Position Configuration",

--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -383,7 +383,10 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
           channelNum: config.channelNum,
           sx126xRxBoostedGain: config.sx126xRxBoostedGain,
           ignoreMqtt: config.ignoreMqtt,
-          configOkToMqtt: config.configOkToMqtt
+          configOkToMqtt: config.configOkToMqtt,
+          txEnabled: config.txEnabled !== false,  // Default to true if undefined
+          overrideDutyCycle: config.overrideDutyCycle ?? false,
+          paFanDisabled: config.paFanDisabled ?? false
         });
       });
       await new Promise(resolve => setTimeout(resolve, 200));
@@ -706,7 +709,10 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
               channelNum: config.channelNum,
               sx126xRxBoostedGain: config.sx126xRxBoostedGain,
               ignoreMqtt: config.ignoreMqtt,
-              configOkToMqtt: config.configOkToMqtt
+              configOkToMqtt: config.configOkToMqtt,
+              txEnabled: config.txEnabled !== false,  // Default to true if undefined
+              overrideDutyCycle: config.overrideDutyCycle ?? false,
+              paFanDisabled: config.paFanDisabled ?? false
             });
             break;
           case 'position':
@@ -1198,7 +1204,10 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       channelNum: configState.lora.channelNum,
       sx126xRxBoostedGain: configState.lora.sx126xRxBoostedGain,
       ignoreMqtt: configState.lora.ignoreMqtt,
-      configOkToMqtt: configState.lora.configOkToMqtt
+      configOkToMqtt: configState.lora.configOkToMqtt,
+      txEnabled: configState.lora.txEnabled,
+      overrideDutyCycle: configState.lora.overrideDutyCycle,
+      paFanDisabled: configState.lora.paFanDisabled
     };
 
     if (configState.lora.usePreset) {
@@ -2115,6 +2124,51 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             <div style={{ flex: 1 }}>
               <div>{t('admin_commands.config_ok_to_mqtt')}</div>
               <span className="setting-description">{t('admin_commands.config_ok_to_mqtt_description')}</span>
+            </div>
+          </label>
+        </div>
+        <div className="setting-item">
+          <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+            <input
+              type="checkbox"
+              checked={configState.lora.txEnabled}
+              onChange={(e) => setLoRaConfig({ txEnabled: e.target.checked })}
+              disabled={isExecuting}
+              style={{ width: 'auto', margin: 0, flexShrink: 0 }}
+            />
+            <div style={{ flex: 1 }}>
+              <div>{t('admin_commands.tx_enabled')}</div>
+              <span className="setting-description">{t('admin_commands.tx_enabled_description')}</span>
+            </div>
+          </label>
+        </div>
+        <div className="setting-item">
+          <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+            <input
+              type="checkbox"
+              checked={configState.lora.overrideDutyCycle}
+              onChange={(e) => setLoRaConfig({ overrideDutyCycle: e.target.checked })}
+              disabled={isExecuting}
+              style={{ width: 'auto', margin: 0, flexShrink: 0 }}
+            />
+            <div style={{ flex: 1 }}>
+              <div>{t('admin_commands.override_duty_cycle')}</div>
+              <span className="setting-description">{t('admin_commands.override_duty_cycle_description')}</span>
+            </div>
+          </label>
+        </div>
+        <div className="setting-item">
+          <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+            <input
+              type="checkbox"
+              checked={configState.lora.paFanDisabled}
+              onChange={(e) => setLoRaConfig({ paFanDisabled: e.target.checked })}
+              disabled={isExecuting}
+              style={{ width: 'auto', margin: 0, flexShrink: 0 }}
+            />
+            <div style={{ flex: 1 }}>
+              <div>{t('admin_commands.pa_fan_disabled')}</div>
+              <span className="setting-description">{t('admin_commands.pa_fan_disabled_description')}</span>
             </div>
           </label>
         </div>

--- a/src/components/admin-commands/useAdminCommandsState.ts
+++ b/src/components/admin-commands/useAdminCommandsState.ts
@@ -22,6 +22,9 @@ export interface LoRaConfigState {
   sx126xRxBoostedGain: boolean;
   ignoreMqtt: boolean;
   configOkToMqtt: boolean;
+  txEnabled: boolean;
+  overrideDutyCycle: boolean;
+  paFanDisabled: boolean;
 }
 
 // Position Config State
@@ -144,6 +147,9 @@ const initialState: AdminCommandsState = {
     sx126xRxBoostedGain: false,
     ignoreMqtt: false,
     configOkToMqtt: false,
+    txEnabled: true,  // Default to true - never accidentally disable transmission
+    overrideDutyCycle: false,
+    paFanDisabled: false,
   },
   position: {
     positionBroadcastSecs: 900,


### PR DESCRIPTION
## Summary

Fixes #1328 - Remote Administration of LoRa settings breaks the node transmission.

When saving Remote Admin LoRa configuration, the `txEnabled`, `overrideDutyCycle`, and `paFanDisabled` fields were missing from the frontend state. Since protobuf defaults missing boolean fields to `false`, this caused the node's transmission to be silently disabled whenever any LoRa config was saved via Remote Admin.

**Root Cause:** The Remote Admin `LoRaConfigState` interface didn't include these three critical fields that are present in the local Configuration tab.

## Changes

- Add `txEnabled`, `overrideDutyCycle`, `paFanDisabled` to `LoRaConfigState` interface
- Set `txEnabled: true` as default to prevent accidental TX disable
- Update config load callbacks to capture these fields from remote node
- Update `handleSetLoRaConfig` to include these fields when saving
- Add UI checkboxes for all three fields in Remote Admin LoRa section
- Add translation keys for new settings

## Test plan

- [ ] Open Remote Admin, select a remote node
- [ ] Load All Config or Load LoRa Config
- [ ] Verify txEnabled, Override Duty Cycle, and PA Fan Disabled checkboxes appear and show correct values
- [ ] Change a different LoRa setting (e.g., hop limit)
- [ ] Save LoRa Config
- [ ] Reload config from the node - verify txEnabled is still true (not silently set to false)
- [ ] Test toggling each new checkbox and saving - verify values are correctly saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)