### PR TITLE
fix: Use consistent nullish coalescing for txEnabled config

### DIFF
--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -384,7 +384,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
           sx126xRxBoostedGain: config.sx126xRxBoostedGain,
           ignoreMqtt: config.ignoreMqtt,
           configOkToMqtt: config.configOkToMqtt,
-          txEnabled: config.txEnabled !== false,  // Default to true if undefined
+          txEnabled: config.txEnabled ?? true,  // Default to true if undefined
           overrideDutyCycle: config.overrideDutyCycle ?? false,
           paFanDisabled: config.paFanDisabled ?? false
         });
@@ -710,7 +710,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
               sx126xRxBoostedGain: config.sx126xRxBoostedGain,
               ignoreMqtt: config.ignoreMqtt,
               configOkToMqtt: config.configOkToMqtt,
-              txEnabled: config.txEnabled !== false,  // Default to true if undefined
+              txEnabled: config.txEnabled ?? true,  // Default to true if undefined
               overrideDutyCycle: config.overrideDutyCycle ?? false,
               paFanDisabled: config.paFanDisabled ?? false
             });


### PR DESCRIPTION
## Summary

Follow-up to #1333 - addresses code review feedback about consistency.

Changes `config.txEnabled !== false` to `config.txEnabled ?? true` to match the pattern used for `overrideDutyCycle` and `paFanDisabled` which use `?? false`.

Both approaches are functionally equivalent, but nullish coalescing is cleaner and more consistent.

## Test plan

- [ ] Verify build passes
- [ ] No functional change - behavior is identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)