### PR TITLE
fix: Calculate hopsAway from hopStart/hopLimit in NodeInfo messages

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -2,6 +2,23 @@
 
 ## Current Sprint
 
+### NodeInfo hopsAway Calculation Bug (#1310)
+
+**Completed:**
+- [x] Identify bug: `processNodeInfoMessageProtobuf` was reading `meshPacket.hopsAway` which doesn't exist
+- [x] Fix: Calculate hopsAway from `hopStart - hopLimit` (like we do for text messages)
+- [x] Update debug logging to show calculated value
+
+**Summary:**
+Fixed a bug where nodes would show incorrect hop counts (e.g., 6+ hops when actually direct). The issue was that `processNodeInfoMessageProtobuf` was trying to read `meshPacket.hopsAway`, but MeshPacket doesn't have this field - it has `hopStart` and `hopLimit`. Since `hopsAway` was always `undefined`, nodes never got their hop count updated from NODEINFO_APP packets.
+
+**Verification:**
+- `processNodeInfoProtobuf` (direct NodeInfo events) - uses `nodeInfo.hopsAway` ✅
+- `processNodeInfoMessageProtobuf` (NODEINFO_APP packets) - now calculates `hopStart - hopLimit` ✅
+- `upsertNode` COALESCE logic correctly updates when value provided, keeps existing when not ✅
+
+---
+
 ### Remote Admin LoRa Config Missing txEnabled Fields (#1328)
 
 **Completed:**


### PR DESCRIPTION
## Summary

Fixes #1310 - Direct nodes showing incorrect hop counts (e.g., 6+ hops when actually direct).

**Root Cause:** `processNodeInfoMessageProtobuf` was reading `meshPacket.hopsAway`, but `MeshPacket` doesn't have this field. It has `hopStart` and `hopLimit` instead. Since `hopsAway` was always `undefined`, nodes were never getting their hop count updated from NODEINFO_APP packets.

**Fix:** Calculate `hopsAway` from the MeshPacket fields:
```
hopsAway = hopStart - hopLimit
```
Where:
- `hopStart` = initial hop limit when packet was sent  
- `hopLimit` = remaining hops when packet was received
- difference = number of hops the packet traveled

This matches how we calculate hops for text messages (lines 5672-5680).

## Test plan

- [ ] Build passes
- [ ] Connect to a mesh network
- [ ] Observe nodes receiving NODEINFO_APP packets
- [ ] Verify hopsAway is now correctly populated in the database
- [ ] Verify map shows correct hop colors for nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)