### PR TITLE
chore: Bump version to 2.21.13

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "2.21.12",
+  "version": "2.21.13",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.21.12
-appVersion: "2.21.11"
+version: 2.21.13
+appVersion: "2.21.13"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.21.12",
+  "version": "2.21.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.21.12",
+      "version": "2.21.13",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.21.12",
+  "version": "2.21.13",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump version from 2.21.12 to 2.21.13
- Updates package.json, package-lock.json, Helm Chart, and Tauri config

## Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| V1 API Test | ✅ PASSED |
| Reverse Proxy Test | ✅ PASSED |
| Reverse Proxy + OIDC | ✅ PASSED |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |

> Note: Backup & Restore test initially failed due to port conflict with tileserver (8082), passed when run separately.

## Test plan
- [x] Run system tests locally
- [x] All test suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)