### PR TITLE
fix: Auto Responder replies now work on channels

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6413,7 +6413,7 @@ class MeshtasticManager {
                 messageQueueService.enqueue(
                   truncated,
                   triggerChannel === 'dm' ? message.fromNodeNum : 0, // destination: node number for DM, 0 for channel
-                  (trigger.verifyResponse && isFirstMessage) ? packetId : undefined,
+                  isFirstMessage ? packetId : undefined, // Reply to original message for first response
                   () => {
                     logger.info(`✅ Script response ${index + 1}/${scriptResponses.length} delivered to ${target}`);
                   },
@@ -6480,7 +6480,7 @@ class MeshtasticManager {
             messageQueueService.enqueue(
               msg,
               triggerChannel === 'dm' ? message.fromNodeNum : 0, // destination: node number for DM, 0 for channel
-              (trigger.verifyResponse && isFirstMessage) ? packetId : undefined, // Only reply to original for first message if verifyResponse is enabled
+              isFirstMessage ? packetId : undefined, // Reply to original message for first response
               () => {
                 logger.info(`✅ Auto-response ${index + 1}/${messagesToSend.length} delivered to ${target}`);
               },


### PR DESCRIPTION
## Summary

- Fixes Auto Responder responses not being marked as "replies" when responding on channels
- The first auto-response is now always a reply to the triggering message

## Problem

When Auto Responder was configured to respond on a channel (not DM), the response was not marked as a "reply" to the original message. This happened because the reply-to functionality was incorrectly tied to the `verifyResponse` setting, which is automatically disabled for channel-based triggers (since channels don't support ACKs).

## Root Cause

The code conflated two separate concepts:
1. **`replyId`** - Sets the packet as a "reply" to the original message (visual threading)
2. **`verifyResponse`** - Enables retry/ACK logic for delivery confirmation

The condition `(trigger.verifyResponse && isFirstMessage)` meant:
- DM with verifyResponse=true: Reply ✅
- DM with verifyResponse=false: No reply ❌
- Channel (verifyResponse forced to false): No reply ❌

## Fix

Changed the condition from:
```typescript
(trigger.verifyResponse && isFirstMessage) ? packetId : undefined
```
To:
```typescript
isFirstMessage ? packetId : undefined
```

Now the first response is always a "reply" to the original message, as expected from an Auto *Responder*.

## Test plan

- [ ] Configure Auto Responder trigger for a channel
- [ ] Send a message that matches the trigger from another node
- [ ] Verify the auto-response is marked as a reply to the original message
- [ ] Verify DM triggers still work correctly with and without verifyResponse

Fixes #1351

🤖 Generated with [Claude Code](https://claude.com/claude-code)