### PR TITLE
feat: Add PUID/PGID environment variable support for Docker

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -5,35 +5,65 @@ set -e
 # If PUID and/or PGID environment variables are set, modify the node user/group
 # to match those IDs. This is useful for NAS systems like Synology where the
 # host directory ownership may differ from the default container user.
+#
+# Note: Alpine Linux doesn't have usermod/groupmod, so we use sed to modify
+# /etc/passwd and /etc/group directly. This is the standard approach for Alpine.
 
 PUID=${PUID:-1000}
 PGID=${PGID:-1000}
+
+# Validate PUID/PGID are numeric and in valid range (0-65534)
+validate_id() {
+    local id="$1"
+    local name="$2"
+    if ! echo "$id" | grep -qE '^[0-9]+$'; then
+        echo "ERROR: $name must be a numeric value, got: $id" >&2
+        exit 1
+    fi
+    if [ "$id" -lt 0 ] || [ "$id" -gt 65534 ]; then
+        echo "ERROR: $name must be between 0 and 65534, got: $id" >&2
+        exit 1
+    fi
+}
+
+validate_id "$PUID" "PUID"
+validate_id "$PGID" "PGID"
 
 # Get current node user/group IDs
 CURRENT_UID=$(id -u node)
 CURRENT_GID=$(id -g node)
 
-# Only modify if IDs differ from current
+# Track if we need to update the GID in passwd (only if PGID actually changed)
+NEW_GID="$CURRENT_GID"
+
+# Only modify group if GID differs from current
 if [ "$PGID" != "$CURRENT_GID" ]; then
     echo "Setting node group GID to $PGID..."
     # Delete existing group with target GID if it exists (and isn't node's group)
     EXISTING_GROUP=$(getent group "$PGID" 2>/dev/null | cut -d: -f1 || true)
     if [ -n "$EXISTING_GROUP" ] && [ "$EXISTING_GROUP" != "node" ]; then
+        echo "  Removing conflicting group: $EXISTING_GROUP"
         delgroup "$EXISTING_GROUP" 2>/dev/null || true
     fi
-    # Modify node group GID
+    # Modify node group GID in /etc/group
     sed -i "s/^node:x:$CURRENT_GID:/node:x:$PGID:/" /etc/group
+    NEW_GID="$PGID"
 fi
 
+# Only modify user if UID differs from current
 if [ "$PUID" != "$CURRENT_UID" ]; then
     echo "Setting node user UID to $PUID..."
     # Delete existing user with target UID if it exists (and isn't node)
     EXISTING_USER=$(getent passwd "$PUID" 2>/dev/null | cut -d: -f1 || true)
     if [ -n "$EXISTING_USER" ] && [ "$EXISTING_USER" != "node" ]; then
+        echo "  Removing conflicting user: $EXISTING_USER"
         deluser "$EXISTING_USER" 2>/dev/null || true
     fi
-    # Modify node user UID and GID
-    sed -i "s/^node:x:$CURRENT_UID:$CURRENT_GID:/node:x:$PUID:$PGID:/" /etc/passwd
+    # Modify node user UID and GID in /etc/passwd
+    sed -i "s/^node:x:$CURRENT_UID:$CURRENT_GID:/node:x:$PUID:$NEW_GID:/" /etc/passwd
+elif [ "$NEW_GID" != "$CURRENT_GID" ]; then
+    # UID unchanged but GID changed - update GID reference in passwd
+    sed -i "s/^node:x:$CURRENT_UID:$CURRENT_GID:/node:x:$CURRENT_UID:$NEW_GID:/" /etc/passwd
 fi
 
 # Copy upgrade-related scripts to shared data volume


### PR DESCRIPTION
## Summary
- Add support for PUID and PGID environment variables to allow custom user/group ID mapping in Docker containers
- Particularly useful for NAS systems like Synology where host directory ownership may differ from the default container user

## Changes
- Modified `docker/docker-entrypoint.sh` to detect and apply PUID/PGID at container startup
- Automatically modifies `/etc/passwd` and `/etc/group` to update the `node` user's UID/GID
- Sets correct ownership on `/data` and `/app/dist` directories after user modification

## Usage
```yaml
services:
  meshmonitor:
    image: ghcr.io/yeraze/meshmonitor:latest
    environment:
      - PUID=1001  # Your host user's UID
      - PGID=1002  # Your host user's GID
    volumes:
      - ./data:/data
```

If not specified, PUID defaults to 1000 and PGID defaults to 1000 (matching the default `node` user in the container).

Closes #1355

## Test plan
- [x] Tested container with default PUID/PGID (1000:1000) - works correctly
- [x] Tested container with custom PUID=1001 PGID=1002 - user modified correctly
- [x] Verified `/data` directory ownership is set correctly
- [x] All 8 system tests pass

## System Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| V1 API Test | ✅ PASSED |
| Reverse Proxy Test | ✅ PASSED |
| Reverse Proxy + OIDC | ✅ PASSED |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)