### PR TITLE
docs: Update documentation for protocol constants and packet filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ tools to resolve library id and get library docs without me having to explicitly
 - Our container doesn't have sqlite3 as a binary available.
 - When testing locally, use the docker-compose.dev.yml to build the local code.  Also, always make sure the proper code was deployed once the container is launched.
 - Official meshtastic protobuf definitions can be found at https://github.com/meshtastic/protobufs/
+- Use shared constants from `src/server/constants/meshtastic.ts` for PortNum, RoutingError, and helper functions - never use magic numbers for protocol values
 - When updating the version, make sure you get both the package.json, Helm chart, and Tauri config.. and regenerate the package-lock
 - Prior to creating a PR, make sure to run the tests/system-tests.sh to ensure success and post the output report
 - When testing, our webserver has BASE_URL configured for /meshmonitor
+  Completely shut down the container and tileserver before running system tests

--- a/docs/ARCHITECTURE_LESSONS.md
+++ b/docs/ARCHITECTURE_LESSONS.md
@@ -48,6 +48,33 @@ Frontend → Backend API → Command Queue → Serial/TCP → Node
 
 **Location**: `src/services/telemetry.ts` - NodeInfo handling (PR #427)
 
+### Protocol Constants
+
+**Lesson**: Magic numbers for protocol values lead to scattered, hard-to-maintain code.
+
+**Solution**: Use shared constants from `src/server/constants/meshtastic.ts`:
+
+```typescript
+import { PortNum, RoutingError, isPkiError, getPortNumName } from './constants/meshtastic.js';
+
+// Use constants instead of magic numbers
+if (portnum === PortNum.TEXT_MESSAGE_APP) { ... }
+if (isPkiError(errorReason)) { ... }
+
+// Get human-readable names for logging
+logger.info(`Received ${getPortNumName(portnum)} packet`);
+```
+
+**Available Constants**:
+- `PortNum` - All Meshtastic application port numbers
+- `RoutingError` - Routing error codes
+- `getPortNumName(portnum)` - Convert port number to name
+- `getRoutingErrorName(code)` - Convert error code to name
+- `isPkiError(code)` - Check if error is PKI-related
+- `isInternalPortNum(portnum)` - Check if port is internal (ADMIN/ROUTING)
+
+**Location**: `src/server/constants/meshtastic.ts`
+
 ### Config Management Complexity
 
 **Pattern**: The wantConfigId/ConfigComplete handshake requires careful state machine management.
@@ -494,5 +521,5 @@ class BackgroundTask {
 
 ---
 
-**Last Updated**: 2025-01-15
-**Related PRs**: #427, #429, #430, #431, #432, #433
+**Last Updated**: 2026-01-02
+**Related PRs**: #427, #429, #430, #431, #432, #433, #1359 (packet filtering), #1360 (protocol constants)

--- a/docs/features/packet-monitor.md
+++ b/docs/features/packet-monitor.md
@@ -28,8 +28,9 @@ The Packet Monitor displays **only incoming packets** received from the mesh net
 
 ### Packets That Do NOT Appear
 
-The following packets sent **by MeshMonitor** are not logged to the Packet Monitor:
+The following packets are not logged to the Packet Monitor:
 
+**Outgoing packets sent by MeshMonitor:**
 - **Outgoing text messages** - Messages you send via the chat interface
 - **Outgoing traceroute requests** - Traceroutes initiated manually or by Auto Traceroute
 - **Outgoing position requests** - Position exchange requests
@@ -37,7 +38,13 @@ The following packets sent **by MeshMonitor** are not logged to the Packet Monit
 - **Auto-welcome messages** - Welcome messages sent to new nodes
 - **Auto-announcements** - Scheduled announcement messages
 
-This is by design - the Packet Monitor shows what is received from the mesh, not what MeshMonitor transmits.
+**Internal management packets (to/from local node):**
+- **ADMIN_APP (6)** - Administrative packets for local device configuration
+- **ROUTING_APP (5)** - Routing acknowledgments to/from your connected node
+
+These internal packets are filtered to reduce noise and keep the log focused on actual mesh traffic. ADMIN and ROUTING packets between remote nodes on the mesh are still logged.
+
+This is by design - the Packet Monitor shows mesh network traffic, not MeshMonitor's internal operations or local device management.
 
 ## Filtering Packets
 


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Add guidance to use shared constants from `src/server/constants/meshtastic.ts` instead of magic numbers
- **ARCHITECTURE_LESSONS.md**: Add new "Protocol Constants" section documenting PortNum, RoutingError, and helper functions
- **packet-monitor.md**: Document that internal ADMIN_APP and ROUTING_APP packets to/from local node are filtered from the packet log

## Test plan
- [ ] Documentation renders correctly on docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)