### PR TITLE
feat: Add GPS satellites in view as telemetry graph

### DIFF
--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -378,6 +378,7 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
         ch8Voltage: 'Channel 8 Voltage',
         ch8Current: 'Channel 8 Current',
         altitude: 'Altitude',
+        sats_in_view: 'GPS Satellites',
         // Air Quality metrics
         pm10Standard: 'PM1.0 (Standard)',
         pm25Standard: 'PM2.5 (Standard)',
@@ -432,6 +433,7 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
         ch8Voltage: '#d8c088',
         ch8Current: '#ffbf6b',
         altitude: '#74c0fc',
+        sats_in_view: '#f9e2af', // Yellow for satellite count
         // Air Quality metrics - using earthy/green tones for PM and blue/purple for particles
         pm10Standard: '#a6da95', // Light green
         pm25Standard: '#8bd5ca', // Teal

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2556,6 +2556,16 @@ class MeshtasticManager {
             });
           }
 
+          // Store satellites in view for GPS accuracy tracking
+          const satsInView = position.satsInView ?? position.sats_in_view;
+          if (satsInView !== undefined && satsInView > 0) {
+            databaseService.insertTelemetry({
+              nodeId, nodeNum: fromNum, telemetryType: 'sats_in_view',
+              timestamp, value: satsInView, unit: 'sats', createdAt: now, packetTimestamp,
+              channel: channelIndex
+            });
+          }
+
           // Update mobility detection for this node
           databaseService.updateNodeMobility(nodeId);
 


### PR DESCRIPTION
## Summary
- Store `satsInView` from position packets as telemetry data
- Add "GPS Satellites" label and yellow color in telemetry graphs
- Only stores when satsInView > 0 (requires node to have SATINVIEW position flag enabled)

Users can now graph GPS satellite count over time alongside other metrics like altitude, battery, and signal quality. This helps diagnose GPS accuracy issues.

Closes #1366

## Test plan
- [ ] Verify telemetry is stored when position packets with satsInView are received
- [ ] Verify "GPS Satellites" graph appears in node telemetry view

🤖 Generated with [Claude Code](https://claude.com/claude-code)