### PR TITLE
feat: Add GPS accuracy circles to map

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -126,6 +126,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     setShowAnimations,
     showEstimatedPositions,
     setShowEstimatedPositions,
+    showAccuracyCircles,
+    setShowAccuracyCircles,
     animatedNodes,
     triggerNodeAnimation,
     mapCenterTarget,
@@ -1281,6 +1283,14 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                     />
                     <span>Show Estimated Positions</span>
                   </label>
+                  <label className="map-control-item">
+                    <input
+                      type="checkbox"
+                      checked={showAccuracyCircles}
+                      onChange={(e) => setShowAccuracyCircles(e.target.checked)}
+                    />
+                    <span>Show Accuracy Circles</span>
+                  </label>
                   {canViewPacketMonitor && packetLogEnabled && (
                     <label className="map-control-item packet-monitor-toggle">
                       <input
@@ -1493,6 +1503,34 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                         opacity: 0.4,
                         weight: 2,
                         dashArray: '5, 5'
+                      }}
+                    />
+                  );
+                })}
+
+              {/* Draw GPS accuracy circles for all nodes with position accuracy data */}
+              {showAccuracyCircles && nodesWithPosition
+                .filter(node => node.positionGpsAccuracy && node.positionGpsAccuracy > 0)
+                .map(node => {
+                  // Use the GPS accuracy value directly as the radius in meters
+                  const radiusMeters = node.positionGpsAccuracy!;
+
+                  // Get hop color for the circle (same as marker)
+                  const isLocalNode = node.user?.id === currentNodeId;
+                  const hops = isLocalNode ? 0 : (node.hopsAway ?? 999);
+                  const color = getHopColor(hops);
+
+                  return (
+                    <Circle
+                      key={`accuracy-${node.nodeNum}`}
+                      center={[node.position!.latitude, node.position!.longitude]}
+                      radius={radiusMeters}
+                      pathOptions={{
+                        color: color,
+                        fillColor: color,
+                        fillOpacity: 0.08,
+                        opacity: 0.5,
+                        weight: 1,
                       }}
                     />
                   );

--- a/src/contexts/MapContext.tsx
+++ b/src/contexts/MapContext.tsx
@@ -35,6 +35,8 @@ interface MapContextType {
   setShowAnimations: (show: boolean) => void;
   showEstimatedPositions: boolean;
   setShowEstimatedPositions: (show: boolean) => void;
+  showAccuracyCircles: boolean;
+  setShowAccuracyCircles: (show: boolean) => void;
   animatedNodes: Set<string>;
   triggerNodeAnimation: (nodeId: string) => void;
   mapCenterTarget: [number, number] | null;
@@ -73,6 +75,7 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
     const saved = localStorage.getItem('showEstimatedPositions');
     return saved !== null ? saved === 'true' : true; // Default to true
   });
+  const [showAccuracyCircles, setShowAccuracyCirclesState] = useState<boolean>(false);
   const [animatedNodes, setAnimatedNodes] = useState<Set<string>>(new Set());
   const [mapCenterTarget, setMapCenterTarget] = useState<[number, number] | null>(null);
   const [mapCenter, setMapCenter] = useState<[number, number] | null>(() => {
@@ -137,6 +140,11 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
     setShowEstimatedPositionsState(value);
     localStorage.setItem('showEstimatedPositions', value.toString());
     savePreferenceToServer({ showEstimatedPositions: value });
+  }, []);
+
+  const setShowAccuracyCircles = React.useCallback((value: boolean) => {
+    setShowAccuracyCirclesState(value);
+    savePreferenceToServer({ showAccuracyCircles: value });
   }, []);
 
   // Helper function to save preference to server
@@ -207,6 +215,9 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
             if (preferences.showEstimatedPositions !== undefined) {
               setShowEstimatedPositionsState(preferences.showEstimatedPositions);
             }
+            if (preferences.showAccuracyCircles !== undefined) {
+              setShowAccuracyCirclesState(preferences.showAccuracyCircles);
+            }
           }
           // If preferences is null (anonymous user), initial defaults are already set
         }
@@ -264,6 +275,8 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
         setShowAnimations,
         showEstimatedPositions,
         setShowEstimatedPositions,
+        showAccuracyCircles,
+        setShowAccuracyCircles,
         animatedNodes,
         triggerNodeAnimation,
         mapCenterTarget,

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -59,6 +59,8 @@ export interface DeviceInfo {
   snr?: number;
   rssi?: number;
   mobile?: number; // Database field: 0 = not mobile, 1 = mobile (moved >100m)
+  // Position precision fields
+  positionGpsAccuracy?: number; // GPS accuracy in meters
   // Position override fields
   positionOverrideEnabled?: number;
   latitudeOverride?: number;
@@ -8631,6 +8633,11 @@ class MeshtasticManager {
           longitude: node.longitude,
           altitude: node.altitude
         };
+      }
+
+      // Add GPS accuracy for position precision circles
+      if (node.positionGpsAccuracy !== null && node.positionGpsAccuracy !== undefined) {
+        deviceInfo.positionGpsAccuracy = node.positionGpsAccuracy;
       }
 
       // Add position override fields

--- a/src/types/device.ts
+++ b/src/types/device.ts
@@ -35,6 +35,8 @@ export interface DeviceInfo {
   keyMismatchDetected?: boolean;
   keySecurityIssueDetails?: string;
   channel?: number;
+  // Position precision fields
+  positionGpsAccuracy?: number; // GPS accuracy in meters
   // Position override fields (positionOverrideEnabled is 0 or 1 from database)
   positionOverrideEnabled?: number;
   latitudeOverride?: number;


### PR DESCRIPTION
## Summary
- Add "Show Accuracy Circles" toggle in the Map Features panel
- Display circles around nodes based on their GPS accuracy (positionGpsAccuracy)
- Circle radius equals the GPS accuracy in meters
- Circles are colored based on hop count (consistent with node markers)

This helps visualize position uncertainty for nodes with varying GPS precision, addressing the issue where some nodes report positions that are miles off.

## Changes
- `src/contexts/MapContext.tsx`: Add `showAccuracyCircles` toggle with server persistence
- `src/server/meshtasticManager.ts`: Expose `positionGpsAccuracy` in DeviceInfo
- `src/types/device.ts`: Add `positionGpsAccuracy` field to frontend DeviceInfo
- `src/components/NodesTab.tsx`: Add checkbox and render accuracy circles

## Screenshots
The accuracy circles appear as semi-transparent circles around nodes when enabled:
- Larger circles = lower GPS precision
- Smaller circles = higher GPS precision

## Test plan
- [x] Build passes
- [x] TypeScript passes
- [x] System tests pass
- [ ] Toggle checkbox in Map Features panel
- [ ] Verify circles appear for nodes with GPS accuracy data
- [ ] Verify circles are appropriately sized based on accuracy

Closes #1374

🤖 Generated with [Claude Code](https://claude.com/claude-code)