### PR TITLE
fix: Use precision_bits for accuracy circles instead of gpsAccuracy

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1581,12 +1581,17 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                   );
                 })}
 
-              {/* Draw GPS accuracy circles for all nodes with position accuracy data */}
+              {/* Draw position accuracy circles for all nodes with precision data */}
               {showAccuracyCircles && nodesWithPosition
-                .filter(node => node.positionGpsAccuracy && node.positionGpsAccuracy > 0)
+                .filter(node => node.positionPrecisionBits !== undefined && node.positionPrecisionBits !== null && node.positionPrecisionBits > 0 && node.positionPrecisionBits < 32)
                 .map(node => {
-                  // Use the GPS accuracy value directly as the radius in meters
-                  const radiusMeters = node.positionGpsAccuracy!;
+                  // Convert precision_bits to radius in meters
+                  // precision_bits indicates how many bits of lat/lon are valid
+                  // Earth's circumference is ~40,075,000 meters
+                  // At N precision bits, accuracy is Earth's circumference / 2^N
+                  // Radius is half of that accuracy diameter
+                  const earthCircumference = 40_075_000; // meters
+                  const radiusMeters = earthCircumference / Math.pow(2, node.positionPrecisionBits!) / 2;
 
                   // Get hop color for the circle (same as marker)
                   const isLocalNode = node.user?.id === currentNodeId;

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -2006,6 +2006,9 @@ class DatabaseService {
           duplicateKeyDetected = COALESCE(?, duplicateKeyDetected),
           keyMismatchDetected = COALESCE(?, keyMismatchDetected),
           keySecurityIssueDetails = COALESCE(?, keySecurityIssueDetails),
+          positionChannel = COALESCE(?, positionChannel),
+          positionPrecisionBits = COALESCE(?, positionPrecisionBits),
+          positionTimestamp = COALESCE(?, positionTimestamp),
           updatedAt = ?
         WHERE nodeNum = ?
       `);
@@ -2041,6 +2044,9 @@ class DatabaseService {
         nodeData.duplicateKeyDetected !== undefined ? (nodeData.duplicateKeyDetected ? 1 : 0) : null,
         nodeData.keyMismatchDetected !== undefined ? (nodeData.keyMismatchDetected ? 1 : 0) : null,
         nodeData.keySecurityIssueDetails || null,
+        nodeData.positionChannel !== undefined ? nodeData.positionChannel : null,
+        nodeData.positionPrecisionBits !== undefined ? nodeData.positionPrecisionBits : null,
+        nodeData.positionTimestamp !== undefined ? nodeData.positionTimestamp : null,
         now,
         nodeData.nodeNum
       );
@@ -2052,8 +2058,9 @@ class DatabaseService {
           channelUtilization, airUtilTx, lastHeard, snr, rssi, firmwareVersion, channel,
           isFavorite, rebootCount, publicKey, hasPKC, lastPKIPacket, welcomedAt,
           keyIsLowEntropy, duplicateKeyDetected, keyMismatchDetected, keySecurityIssueDetails,
+          positionChannel, positionPrecisionBits, positionTimestamp,
           createdAt, updatedAt
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
       stmt.run(
@@ -2088,6 +2095,9 @@ class DatabaseService {
         nodeData.duplicateKeyDetected ? 1 : 0,
         nodeData.keyMismatchDetected ? 1 : 0,
         nodeData.keySecurityIssueDetails || null,
+        nodeData.positionChannel !== undefined ? nodeData.positionChannel : null,
+        nodeData.positionPrecisionBits !== undefined ? nodeData.positionPrecisionBits : null,
+        nodeData.positionTimestamp !== undefined ? nodeData.positionTimestamp : null,
         now,
         now
       );

--- a/src/types/device.ts
+++ b/src/types/device.ts
@@ -36,6 +36,7 @@ export interface DeviceInfo {
   keySecurityIssueDetails?: string;
   channel?: number;
   // Position precision fields
+  positionPrecisionBits?: number; // Position precision (0-32 bits, higher = more precise)
   positionGpsAccuracy?: number; // GPS accuracy in meters
   // Position override fields (positionOverrideEnabled is 0 or 1 from database)
   positionOverrideEnabled?: number;


### PR DESCRIPTION
## Summary
- Fixes accuracy circles feature from PR #1377 which wasn't working because `positionGpsAccuracy` isn't always available
- Uses `precision_bits` from Position packets to calculate circle radius
- Falls back to channel's `positionPrecision` setting when packet doesn't include precision_bits
- Sends `positionPrecisionBits` from backend to frontend for circle rendering

## Changes
- **src/types/device.ts**: Added `positionPrecisionBits` to DeviceInfo interface
- **src/server/meshtasticManager.ts**: 
  - Send `positionPrecisionBits` to frontend in getAllNodes()
  - Use channel's positionPrecision as fallback when parsing Position packets
- **src/components/NodesTab.tsx**: Calculate radius from precision_bits using formula: `radius = 40,075,000m / 2^precision_bits / 2`

## Test plan
- [x] Build passes
- [x] TypeScript typecheck passes
- [ ] Enable "Show Accuracy Circles" on Map tab
- [ ] Verify circles appear around nodes with precision data
- [ ] Verify circle sizes vary based on precision (lower bits = larger radius)

🤖 Generated with [Claude Code](https://claude.com/claude-code)