### PR TITLE
chore: Release v2.21.15

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "2.21.14",
+  "version": "2.21.15",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 2.21.14
-appVersion: "2.21.14"
+version: 2.21.15
+appVersion: "2.21.15"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "2.21.14",
+  "version": "2.21.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "2.21.14",
+      "version": "2.21.15",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "2.21.14",
+  "version": "2.21.15",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Release v2.21.15

### Changes since v2.21.14

#### Features
- feat: Display last traceroute in node popup on map (#1379)
- feat: Filter CLIENT_MUTE from relay modal and mark router nodes (#1376)
- feat: Add GPS accuracy circles to map (#1377)
- feat: Add GPS satellites in view as telemetry graph (#1367)
- feat: Add PUID/PGID environment variable support for Docker (#1357)

#### Bug Fixes
- fix: Use precision_bits for accuracy circles instead of gpsAccuracy (#1381)
- fix: Filter out internal ADMIN_APP and ROUTING_APP packets from Packet Monitor (#1359)

#### Refactoring
- refactor: Extract Meshtastic protocol constants to shared file (#1360)

#### Documentation
- docs: Fix MESHTASTIC_STALE_CONNECTION_TIMEOUT default value (#1363)
- docs: Update documentation for protocol constants and packet filtering (#1361)

#### Dependencies
- chore(deps): update @tanstack/react-virtual, react-i18next, and globals (#1378)

#### Translations
- Translated using Weblate (Russian) (#1369, #1365)

### Test Results
- ✅ TypeScript typecheck passes
- ✅ Build succeeds
- ⚠️ System tests: Config import test has pre-existing modem preset sync issue (unrelated to this release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)