### PR TITLE
fix: Correct RX/TX direction for packets from local node

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2181,7 +2181,7 @@ class MeshtasticManager {
           priority: meshPacket.priority ?? undefined,
           payload_preview: payloadPreview ?? undefined,
           metadata: JSON.stringify(metadata),
-          direction: 'rx'
+          direction: fromNum === this.localNodeInfo?.nodeNum ? 'tx' : 'rx'
         });
         } // end else (not internal packet)
       }


### PR DESCRIPTION
## Summary
- Fixes packets from the local node being incorrectly labeled as RX instead of TX in Packet Monitor

## Changes
- Check if packet's `from` address matches `localNodeInfo.nodeNum`
- Set `direction: 'tx'` for local node packets, `direction: 'rx'` for others

## Test plan
- [x] TypeScript typecheck passes
- [x] Build succeeds
- [ ] Verify packets from local node show as TX in Packet Monitor
- [ ] Verify packets from other nodes still show as RX

Closes #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)