### PR TITLE
docs: Add Radio Identity + QTH script to user scripts gallery

### DIFF
--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -269,5 +269,29 @@
       "Identifies nodes at risk of low battery",
       "Formatted for mesh network 200-char limit"
     ]
+  },
+  {
+    "name": "Radio Identity + QTH",
+    "filename": "mm_radio_id_qth.py",
+    "icon": "📟",
+    "description": "Register radio identities (Ham callsign, GMRS callsign/unit, CB handle, or Club alias) and request on-demand QTH responses with Maidenhead grid and optional distance/bearing to MeshMonitor station.",
+    "language": "Python",
+    "tags": ["Ham Radio", "GMRS", "CB", "Callsign", "QTH", "Maidenhead", "Grid", "Identity"],
+    "githubPath": "maxhayim/meshmonitor-radio-id-qth",
+    "exampleTrigger": "!id ham {callsign}, !id gmrs {callsign}, !qth",
+    "requirements": [
+      "Python 3 (included in MeshMonitor)",
+      "Script executable (chmod +x)",
+      "Optional: MM_LAT/MM_LON for distance/bearing",
+      "Optional: /data/scripts/ write access for persistence"
+    ],
+    "author": "maxhayim",
+    "features": [
+      "Register Ham, GMRS, CB, or Club identities",
+      "QTH response with Maidenhead grid locator",
+      "Distance and bearing to MeshMonitor station",
+      "Privacy-safe (only reports requester's position)",
+      "Persistent identity storage in JSON"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Add meshmonitor-radio-id-qth by @maxhayim to the user scripts gallery.

This script allows operators to:
- Register radio identities (Ham callsign, GMRS callsign/unit, CB handle, or Club alias)
- Request QTH responses with Maidenhead grid locator
- Get distance and bearing to MeshMonitor station (when configured)

### Script Features
- Register Ham, GMRS, CB, or Club identities
- QTH response with Maidenhead grid locator
- Distance and bearing to MeshMonitor station
- Privacy-safe (only reports requester's position)
- Persistent identity storage in JSON

### Repository
https://github.com/maxhayim/meshmonitor-radio-id-qth

Closes #1391

## Test plan
- [x] Verify JSON is valid
- [x] Verify script appears in user scripts gallery page

🤖 Generated with [Claude Code](https://claude.com/claude-code)