### PR TITLE
fix: Add detection and logging for virtual node ID mismatches

### DIFF
--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -594,6 +594,9 @@ export class VirtualNodeServer extends EventEmitter {
           logger.debug(`Virtual node: Using fallback firmware version: ${firmwareVersion}`);
         }
 
+        // Log the node ID being sent to help diagnose identity issues
+        logger.info(`Virtual node: Sending MyNodeInfo with nodeNum=${localNodeInfo.nodeNum} (${localNodeInfo.nodeId}) to ${clientId}`);
+
         const myNodeInfoMessage = await meshtasticProtobufService.createMyNodeInfo({
           myNodeNum: localNodeInfo.nodeNum,
           numBands: 13,
@@ -611,7 +614,7 @@ export class VirtualNodeServer extends EventEmitter {
           logger.debug(`Virtual node: ✓ Sent fresh MyNodeInfo from database`);
         }
       } else {
-        logger.warn(`Virtual node: No local node info available, skipping MyNodeInfo`);
+        logger.warn(`Virtual node: No local node info available, skipping MyNodeInfo - clients may have incorrect identity!`);
       }
 
       // === STEP 2: Rebuild and send all NodeInfo entries from database ===


### PR DESCRIPTION
## Summary

Adds safeguards to detect and warn when the physical node's ID changes, which can cause virtual node clients to appear as a different node on the mesh.

This addresses #1390 where users reported virtual nodes creating their own IDs.

## Changes

1. **Node ID mismatch detection**: When `processMyNodeInfo` receives a different node number than what's stored in the database, it logs a warning explaining possible causes
2. **Clear init config cache on ID change**: Forces virtual node clients to get fresh data when the physical node ID changes
3. **Clear init config cache on disconnect**: Ensures clean state when physical node reconnects (possibly as a different node)
4. **Enhanced logging**: Logs the exact node ID being sent to virtual node clients to help diagnose identity issues
5. **Improved warnings**: Better warning message when local node info is unavailable

## Root Cause Analysis

The issue occurs when:
- Physical node was factory reset (generates new node ID but keeps keys)
- Different physical node was connected to MeshMonitor
- Database has stale node ID from previous connection

When the stored `localNodeNum` doesn't match the actual physical node, virtual node clients receive the wrong MyNodeInfo and appear as a different node on the mesh.

## Test plan
- [x] Build passes
- [ ] Verify warning appears in logs when connecting a different node
- [ ] Verify virtual node clients receive correct node ID after reconnect

Relates to #1390

🤖 Generated with [Claude Code](https://claude.com/claude-code)