### PR TITLE
feat: Add ability to request neighbor info from remote nodes

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -293,6 +293,8 @@
   "messages.exchange_position_title": "Request position exchange with this node",
   "messages.exchange_user_info": "Exchange User Info",
   "messages.exchange_user_info_title": "Request user info exchange with this node (triggers key exchange)",
+  "messages.request_neighbor_info": "Request Neighbors",
+  "messages.request_neighbor_info_title": "Request neighbor info from this node (requires NeighborInfo module enabled)",
   "messages.actions_menu": "Actions",
   "messages.actions_menu_title": "Node actions menu",
   "messages.purge_data": "Purge Data",

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -139,6 +139,7 @@ export interface MessagesTabProps {
   tracerouteLoading: string | null;
   positionLoading: string | null;
   nodeInfoLoading: string | null;
+  neighborInfoLoading: string | null;
 
   // Settings
   timeFormat: TimeFormat;
@@ -157,6 +158,7 @@ export interface MessagesTabProps {
   handleTraceroute: (nodeId: string) => Promise<void>;
   handleExchangePosition: (nodeId: string) => Promise<void>;
   handleExchangeNodeInfo: (nodeId: string) => Promise<void>;
+  handleRequestNeighborInfo: (nodeId: string) => Promise<void>;
   handleDeleteMessage: (message: MeshMessage) => Promise<void>;
   handleSenderClick: (nodeId: string, event: React.MouseEvent) => void;
   handleSendTapback: (emoji: string, message: MeshMessage) => void;
@@ -213,6 +215,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   tracerouteLoading,
   positionLoading,
   nodeInfoLoading,
+  neighborInfoLoading,
   timeFormat,
   dateFormat,
   temperatureUnit,
@@ -225,6 +228,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   handleTraceroute,
   handleExchangePosition,
   handleExchangeNodeInfo,
+  handleRequestNeighborInfo,
   handleDeleteMessage,
   handleSenderClick,
   handleSendTapback,
@@ -1294,6 +1298,28 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                   }}
                 >
                   {positionLoading === selectedDMNode ? <span className="spinner"></span> : '📍'} {t('messages.exchange_position')}
+                </button>
+              )}
+
+              {/* Request Neighbor Info */}
+              {hasPermission('traceroute', 'write') && (
+                <button
+                  onClick={() => handleRequestNeighborInfo(selectedDMNode)}
+                  disabled={connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode}
+                  style={{
+                    flex: '1 1 auto',
+                    minWidth: '120px',
+                    padding: '0.5rem 1rem',
+                    backgroundColor: 'var(--ctp-blue)',
+                    color: 'var(--ctp-base)',
+                    border: 'none',
+                    borderRadius: '4px',
+                    cursor: connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode ? 'not-allowed' : 'pointer',
+                    opacity: connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode ? 0.5 : 1,
+                    fontSize: '0.9rem'
+                  }}
+                >
+                  {neighborInfoLoading === selectedDMNode ? <span className="spinner"></span> : '🏠'} {t('messages.request_neighbor_info')}
                 </button>
               )}
             </div>


### PR DESCRIPTION
## Summary

- Add "Request Neighbors" button in Messages tab to request NeighborInfo from remote nodes
- Target node responds with its neighbor list, which is automatically stored in the database
- Similar to the feature added in Android app (PR #3709)

## Changes

1. **Protobuf Service** - `createNeighborInfoRequestMessage()` creates NEIGHBORINFO_APP packet with `wantResponse: true`
2. **Manager** - `sendNeighborInfoRequest()` sends the request and broadcasts to virtual node clients
3. **API** - `POST /api/neighborinfo/request` endpoint (uses traceroute permission)
4. **Frontend** - Handler in App.tsx, button in MessagesTab.tsx

## Requirements

- Target node must have **NeighborInfo module enabled** (broadcast interval can be 0)
- Target node firmware must support on-demand neighbor info requests (firmware PR #8523)
- Firmware rate-limits responses to **one every 3 minutes**

## Test plan
- [x] TypeScript type check passes
- [x] Build succeeds
- [x] Button appears in Messages tab node details
- [x] Request is sent (visible in logs)
- [x] Response handling uses existing `processNeighborInfoProtobuf()` code

Note: Response depends on target node firmware support. Tested with request being sent successfully; response handling relies on existing code path.

Closes #1373

🤖 Generated with [Claude Code](https://claude.com/claude-code)