### PR TITLE
fix: Improve Remote Admin config load reliability

### DIFF
--- a/src/components/admin-commands/DeviceConfigurationSection.tsx
+++ b/src/components/admin-commands/DeviceConfigurationSection.tsx
@@ -65,6 +65,19 @@ interface DeviceConfigurationSectionProps {
   onBluetoothConfigChange: (field: string, value: any) => void;
   onSaveBluetoothConfig: () => Promise<void>;
 
+  // Network Config
+  networkWifiEnabled: boolean;
+  networkWifiSsid: string;
+  networkWifiPsk: string;
+  networkNtpServer: string;
+  networkAddressMode: number;
+  networkIpv4Address: string;
+  networkIpv4Gateway: string;
+  networkIpv4Subnet: string;
+  networkIpv4Dns: string;
+  onNetworkConfigChange: (field: string, value: any) => void;
+  onSaveNetworkConfig: () => Promise<void>;
+
   // Common
   isExecuting: boolean;
   selectedNodeNum: number | null;
@@ -74,6 +87,7 @@ interface DeviceConfigurationSectionProps {
   deviceHeaderActions?: React.ReactNode;
   positionHeaderActions?: React.ReactNode;
   bluetoothHeaderActions?: React.ReactNode;
+  networkHeaderActions?: React.ReactNode;
 }
 
 export const DeviceConfigurationSection: React.FC<DeviceConfigurationSectionProps> = ({
@@ -121,12 +135,24 @@ export const DeviceConfigurationSection: React.FC<DeviceConfigurationSectionProp
   bluetoothFixedPin,
   onBluetoothConfigChange,
   onSaveBluetoothConfig,
+  networkWifiEnabled,
+  networkWifiSsid,
+  networkWifiPsk,
+  networkNtpServer,
+  networkAddressMode,
+  networkIpv4Address,
+  networkIpv4Gateway,
+  networkIpv4Subnet,
+  networkIpv4Dns,
+  onNetworkConfigChange,
+  onSaveNetworkConfig,
   isExecuting,
   selectedNodeNum,
   ownerHeaderActions,
   deviceHeaderActions,
   positionHeaderActions,
   bluetoothHeaderActions,
+  networkHeaderActions,
 }) => {
   const { t } = useTranslation();
 
@@ -756,6 +782,198 @@ export const DeviceConfigurationSection: React.FC<DeviceConfigurationSectionProp
           }}
         >
           {isExecuting ? t('common.saving') : t('admin_commands.save_bluetooth_config', 'Save Bluetooth Config')}
+        </button>
+      </CollapsibleSection>
+
+      {/* Network Configuration */}
+      <CollapsibleSection
+        id="admin-network-config"
+        title={t('admin_commands.network_configuration', 'Network Configuration')}
+        defaultExpanded={false}
+        headerActions={networkHeaderActions}
+      >
+        {/* WiFi Enabled */}
+        <div className="setting-item">
+          <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+            <input
+              type="checkbox"
+              checked={networkWifiEnabled}
+              onChange={(e) => onNetworkConfigChange('wifiEnabled', e.target.checked)}
+              disabled={isExecuting}
+              style={{ width: 'auto', margin: 0, flexShrink: 0 }}
+            />
+            <div style={{ flex: 1 }}>
+              <div>{t('admin_commands.wifi_enabled', 'WiFi Enabled')}</div>
+              <span className="setting-description">{t('admin_commands.wifi_enabled_description', 'Enable WiFi on this device')}</span>
+            </div>
+          </label>
+        </div>
+
+        {/* WiFi Settings - only show when WiFi is enabled */}
+        {networkWifiEnabled && (
+          <>
+            {/* WiFi SSID */}
+            <div className="setting-item">
+              <label>
+                {t('admin_commands.wifi_ssid', 'WiFi SSID')}
+                <span className="setting-description">{t('admin_commands.wifi_ssid_description', 'Network name to connect to')}</span>
+              </label>
+              <input
+                type="text"
+                value={networkWifiSsid}
+                onChange={(e) => onNetworkConfigChange('wifiSsid', e.target.value)}
+                disabled={isExecuting}
+                placeholder="MyNetwork"
+                maxLength={32}
+                className="setting-input"
+                style={{ width: '100%', maxWidth: '600px' }}
+              />
+            </div>
+
+            {/* WiFi Password */}
+            <div className="setting-item">
+              <label>
+                {t('admin_commands.wifi_psk', 'WiFi Password')}
+                <span className="setting-description">{t('admin_commands.wifi_psk_description', 'Network password')}</span>
+              </label>
+              <input
+                type="password"
+                value={networkWifiPsk}
+                onChange={(e) => onNetworkConfigChange('wifiPsk', e.target.value)}
+                disabled={isExecuting}
+                placeholder="••••••••"
+                maxLength={63}
+                className="setting-input"
+                style={{ width: '100%', maxWidth: '600px' }}
+              />
+            </div>
+
+            {/* Address Mode */}
+            <div className="setting-item">
+              <label>
+                {t('admin_commands.address_mode', 'Address Mode')}
+                <span className="setting-description">{t('admin_commands.address_mode_description', 'IP address assignment method')}</span>
+              </label>
+              <select
+                value={networkAddressMode}
+                onChange={(e) => onNetworkConfigChange('addressMode', parseInt(e.target.value))}
+                disabled={isExecuting}
+                className="setting-input"
+                style={{ width: '100%', maxWidth: '600px' }}
+              >
+                <option value={0}>DHCP</option>
+                <option value={1}>Static</option>
+              </select>
+            </div>
+
+            {/* Static IP Settings - only show when address mode is STATIC (1) */}
+            {networkAddressMode === 1 && (
+              <div style={{
+                marginLeft: '1rem',
+                paddingLeft: '1rem',
+                borderLeft: '2px solid var(--ctp-surface2)',
+                marginTop: '1rem'
+              }}>
+                <h4 style={{ marginBottom: '1rem', color: 'var(--ctp-subtext0)' }}>
+                  {t('admin_commands.static_ip_settings', 'Static IP Settings')}
+                </h4>
+
+                {/* IP Address */}
+                <div className="setting-item">
+                  <label>
+                    {t('admin_commands.ip_address', 'IP Address')}
+                  </label>
+                  <input
+                    type="text"
+                    value={networkIpv4Address}
+                    onChange={(e) => onNetworkConfigChange('ipv4Address', e.target.value)}
+                    disabled={isExecuting}
+                    placeholder="192.168.1.100"
+                    className="setting-input"
+                    style={{ width: '100%', maxWidth: '300px' }}
+                  />
+                </div>
+
+                {/* Gateway */}
+                <div className="setting-item">
+                  <label>
+                    {t('admin_commands.gateway', 'Gateway')}
+                  </label>
+                  <input
+                    type="text"
+                    value={networkIpv4Gateway}
+                    onChange={(e) => onNetworkConfigChange('ipv4Gateway', e.target.value)}
+                    disabled={isExecuting}
+                    placeholder="192.168.1.1"
+                    className="setting-input"
+                    style={{ width: '100%', maxWidth: '300px' }}
+                  />
+                </div>
+
+                {/* Subnet */}
+                <div className="setting-item">
+                  <label>
+                    {t('admin_commands.subnet', 'Subnet Mask')}
+                  </label>
+                  <input
+                    type="text"
+                    value={networkIpv4Subnet}
+                    onChange={(e) => onNetworkConfigChange('ipv4Subnet', e.target.value)}
+                    disabled={isExecuting}
+                    placeholder="255.255.255.0"
+                    className="setting-input"
+                    style={{ width: '100%', maxWidth: '300px' }}
+                  />
+                </div>
+
+                {/* DNS */}
+                <div className="setting-item">
+                  <label>
+                    {t('admin_commands.dns', 'DNS Server')}
+                  </label>
+                  <input
+                    type="text"
+                    value={networkIpv4Dns}
+                    onChange={(e) => onNetworkConfigChange('ipv4Dns', e.target.value)}
+                    disabled={isExecuting}
+                    placeholder="8.8.8.8"
+                    className="setting-input"
+                    style={{ width: '100%', maxWidth: '300px' }}
+                  />
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* NTP Server - always show */}
+        <div className="setting-item" style={{ marginTop: networkWifiEnabled ? '1rem' : 0 }}>
+          <label>
+            {t('admin_commands.ntp_server', 'NTP Server')}
+            <span className="setting-description">{t('admin_commands.ntp_server_description', 'Time synchronization server')}</span>
+          </label>
+          <input
+            type="text"
+            value={networkNtpServer}
+            onChange={(e) => onNetworkConfigChange('ntpServer', e.target.value)}
+            disabled={isExecuting}
+            placeholder="meshtastic.pool.ntp.org"
+            maxLength={33}
+            className="setting-input"
+            style={{ width: '100%', maxWidth: '600px' }}
+          />
+        </div>
+
+        <button
+          className="save-button"
+          onClick={onSaveNetworkConfig}
+          disabled={isExecuting || selectedNodeNum === null}
+          style={{
+            opacity: (isExecuting || selectedNodeNum === null) ? 0.5 : 1,
+            cursor: (isExecuting || selectedNodeNum === null) ? 'not-allowed' : 'pointer'
+          }}
+        >
+          {isExecuting ? t('common.saving') : t('admin_commands.save_network_config', 'Save Network Config')}
         </button>
       </CollapsibleSection>
     </CollapsibleSection>

--- a/src/components/admin-commands/useAdminCommandsState.ts
+++ b/src/components/admin-commands/useAdminCommandsState.ts
@@ -83,6 +83,19 @@ export interface BluetoothConfigState {
   fixedPin: number;
 }
 
+// Network Config State
+export interface NetworkConfigState {
+  wifiEnabled: boolean;
+  wifiSsid: string;
+  wifiPsk: string;
+  ntpServer: string;
+  addressMode: number;
+  ipv4Address: string;
+  ipv4Gateway: string;
+  ipv4Subnet: string;
+  ipv4Dns: string;
+}
+
 // NeighborInfo Config State
 export interface NeighborInfoConfigState {
   enabled: boolean;
@@ -110,6 +123,7 @@ export interface AdminCommandsState {
   mqtt: MQTTConfigState;
   security: SecurityConfigState;
   bluetooth: BluetoothConfigState;
+  network: NetworkConfigState;
   neighborInfo: NeighborInfoConfigState;
   owner: OwnerConfigState;
   device: DeviceConfigState;
@@ -123,6 +137,7 @@ type AdminCommandsAction =
   | { type: 'SET_MQTT_CONFIG'; payload: Partial<MQTTConfigState> }
   | { type: 'SET_SECURITY_CONFIG'; payload: Partial<SecurityConfigState> }
   | { type: 'SET_BLUETOOTH_CONFIG'; payload: Partial<BluetoothConfigState> }
+  | { type: 'SET_NETWORK_CONFIG'; payload: Partial<NetworkConfigState> }
   | { type: 'SET_NEIGHBORINFO_CONFIG'; payload: Partial<NeighborInfoConfigState> }
   | { type: 'SET_OWNER_CONFIG'; payload: Partial<OwnerConfigState> }
   | { type: 'SET_DEVICE_CONFIG'; payload: Partial<DeviceConfigState> }
@@ -199,6 +214,17 @@ const initialState: AdminCommandsState = {
     mode: 0,
     fixedPin: 0,
   },
+  network: {
+    wifiEnabled: false,
+    wifiSsid: '',
+    wifiPsk: '',
+    ntpServer: '',
+    addressMode: 0,
+    ipv4Address: '',
+    ipv4Gateway: '',
+    ipv4Subnet: '',
+    ipv4Dns: '',
+  },
   neighborInfo: {
     enabled: false,
     updateInterval: 14400,
@@ -249,6 +275,11 @@ function adminCommandsReducer(state: AdminCommandsState, action: AdminCommandsAc
       return {
         ...state,
         bluetooth: { ...state.bluetooth, ...action.payload },
+      };
+    case 'SET_NETWORK_CONFIG':
+      return {
+        ...state,
+        network: { ...state.network, ...action.payload },
       };
     case 'SET_NEIGHBORINFO_CONFIG':
       return {
@@ -367,6 +398,11 @@ export function useAdminCommandsState() {
     dispatch({ type: 'SET_BLUETOOTH_CONFIG', payload: config });
   }, []);
 
+  // Network config actions
+  const setNetworkConfig = useCallback((config: Partial<NetworkConfigState>) => {
+    dispatch({ type: 'SET_NETWORK_CONFIG', payload: config });
+  }, []);
+
   // NeighborInfo config actions
   const setNeighborInfoConfig = useCallback((config: Partial<NeighborInfoConfigState>) => {
     dispatch({ type: 'SET_NEIGHBORINFO_CONFIG', payload: config });
@@ -404,6 +440,8 @@ export function useAdminCommandsState() {
     removeAdminKey,
     // Bluetooth
     setBluetoothConfig,
+    // Network
+    setNetworkConfig,
     // NeighborInfo
     setNeighborInfoConfig,
     // Owner

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7985,10 +7985,13 @@ class MeshtasticManager {
             // Map device config types to their keys
             const deviceConfigMap: { [key: number]: string } = {
               0: 'device',
-              1: 'position',  // POSITION_CONFIG (was incorrectly 6)
-              5: 'lora',
-              6: 'bluetooth',  // BLUETOOTH_CONFIG (for completeness)
-              7: 'security'  // SECURITY_CONFIG
+              1: 'position',  // POSITION_CONFIG
+              2: 'power',     // POWER_CONFIG
+              3: 'network',   // NETWORK_CONFIG
+              4: 'display',   // DISPLAY_CONFIG
+              5: 'lora',      // LORA_CONFIG
+              6: 'bluetooth', // BLUETOOTH_CONFIG
+              7: 'security'   // SECURITY_CONFIG
             };
             const configKey = deviceConfigMap[configType];
             if (configKey && nodeConfig.deviceConfig?.[configKey]) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5242,6 +5242,7 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
         const configTypeMap: { [key: string]: { type: number; isModule: boolean } } = {
           'device': { type: 0, isModule: false },  // DEVICE_CONFIG
           'position': { type: 1, isModule: false }, // POSITION_CONFIG
+          'network': { type: 3, isModule: false },  // NETWORK_CONFIG
           'lora': { type: 5, isModule: false },      // LORA_CONFIG
           'bluetooth': { type: 6, isModule: false }, // BLUETOOTH_CONFIG
           'security': { type: 7, isModule: false },  // SECURITY_CONFIG
@@ -6241,6 +6242,12 @@ apiRouter.post('/admin/commands', requireAdmin(), async (req, res) => {
           return res.status(400).json({ error: 'config is required for setBluetoothConfig' });
         }
         adminMessage = protobufService.createSetDeviceConfigMessageGeneric('bluetooth', params.config, sessionPasskey || undefined);
+        break;
+      case 'setNetworkConfig':
+        if (!params.config) {
+          return res.status(400).json({ error: 'config is required for setNetworkConfig' });
+        }
+        adminMessage = protobufService.createSetNetworkConfigMessage(params.config, sessionPasskey || undefined);
         break;
       case 'setNeighborInfoConfig':
         if (!params.config) {


### PR DESCRIPTION
## Summary

- Add session passkey pre-request before individual config loads to prevent timeout failures on slow mesh networks
- Add consistent retry logic (2 retries with exponential backoff) to all config section loads, matching the channel loading pattern
- Previously only channel loads had retry logic; now device, lora, position, mqtt, security, bluetooth, neighborinfo, and owner configs all have retry support
- Fix admin keys not rendering in Security Configuration UI by handling various protobuf serialization formats
- Add Network Configuration section to Remote Admin for managing WiFi/network settings on remote nodes

## Changes

| Section | Before | After |
|---------|--------|-------|
| Config loads (device, lora, etc.) | No retries | 2 retries, exponential backoff |
| Owner config | No retries | 2 retries, exponential backoff |
| Session passkey | Not pre-requested | Pre-requested for remote nodes |
| Admin keys | Only Uint8Array/Buffer | All formats (Buffer, JSON-serialized, byte arrays, strings) |
| Network config | Not available | Full WiFi/IP configuration support |

Retryable errors: 404, timeout, "not received", "not reachable"

## New Network Configuration Features

- WiFi enable/disable toggle
- WiFi SSID and password inputs
- Address mode selection (DHCP/Static)
- Static IP settings (IP address, gateway, subnet mask, DNS)
- NTP server configuration

## Test plan

- [ ] Select a remote node on Remote Admin page
- [ ] Click individual "Load" buttons (device, lora, neighborinfo, etc.)
- [ ] Verify loads complete successfully or retry on transient failures
- [ ] Verify NeighborInfo section loads and saves correctly
- [ ] Verify Security Configuration admin keys display correctly after loading
- [ ] Verify Network Configuration loads and displays WiFi/IP settings
- [ ] Verify Network Configuration can save changes to remote node

🤖 Generated with [Claude Code](https://claude.com/claude-code)