### PR TITLE
fix: Correct incomplete githubPath URLs in user scripts gallery

### DIFF
--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -234,7 +234,7 @@
     "description": "Weather bot that uses nodes lat/long to pull current data from api.weather.gov. Falls back to local instance GPS info if none was provided by the requesting node.",
     "language": "JavaScript",
     "tags": ["Weather", "Node.js", "API", "GPS"],
-    "githubPath": "Yoss101/MM-Weather",
+    "githubPath": "Yoss101/MM-Weather/index.js",
     "exampleTrigger": "wthr, weather",
     "requirements": [
       "Node.js (included in MeshMonitor)",
@@ -277,7 +277,7 @@
     "description": "Register radio identities (Ham callsign, GMRS callsign/unit, CB handle, or Club alias) and request on-demand QTH responses with Maidenhead grid and optional distance/bearing to MeshMonitor station.",
     "language": "Python",
     "tags": ["Ham Radio", "GMRS", "CB", "Callsign", "QTH", "Maidenhead", "Grid", "Identity"],
-    "githubPath": "maxhayim/meshmonitor-radio-id-qth",
+    "githubPath": "maxhayim/meshmonitor-radio-id-qth/mm_radio_id_qth.py",
     "exampleTrigger": "!id ham {callsign}, !id gmrs {callsign}, !qth",
     "requirements": [
       "Python 3 (included in MeshMonitor)",


### PR DESCRIPTION
## Summary
- Fixed MM-Weather script missing filename in githubPath (`Yoss101/MM-Weather` → `Yoss101/MM-Weather/index.js`)
- Fixed Radio Identity + QTH script missing filename in githubPath (`maxhayim/meshmonitor-radio-id-qth` → `maxhayim/meshmonitor-radio-id-qth/mm_radio_id_qth.py`)

These paths require at least 3 parts (`username/repo/filename`) for the gallery's URL parsing to generate correct GitHub links.

## Test plan
- [ ] Verify "View Source" link works for MM-Weather script in gallery
- [ ] Verify "View Source" link works for Radio Identity + QTH script in gallery
- [ ] Verify code preview loads correctly for both scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)