### PR TITLE
fix: Add PostgreSQL/MySQL cache sync for node modification methods

### DIFF
--- a/src/db/repositories/index.ts
+++ b/src/db/repositories/index.ts
@@ -20,3 +20,9 @@ export type {
 } from './auth.js';
 export { TraceroutesRepository } from './traceroutes.js';
 export { NeighborsRepository } from './neighbors.js';
+export { NotificationsRepository } from './notifications.js';
+export type {
+  DbPushSubscription,
+  NotificationPreferences,
+  PushSubscriptionInput,
+} from './notifications.js';

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -469,4 +469,25 @@ export class MessagesRepository extends BaseRepository {
       return true;
     }
   }
+
+  /**
+   * Delete all messages
+   */
+  async deleteAllMessages(): Promise<number> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const count = await db
+        .select({ id: messagesSqlite.id })
+        .from(messagesSqlite);
+      await db.delete(messagesSqlite);
+      return count.length;
+    } else {
+      const db = this.getPostgresDb();
+      const count = await db
+        .select({ id: messagesPostgres.id })
+        .from(messagesPostgres);
+      await db.delete(messagesPostgres);
+      return count.length;
+    }
+  }
 }

--- a/src/db/repositories/neighbors.ts
+++ b/src/db/repositories/neighbors.ts
@@ -130,4 +130,21 @@ export class NeighborsRepository extends BaseRepository {
       return result.length;
     }
   }
+
+  /**
+   * Delete all neighbor info
+   */
+  async deleteAllNeighborInfo(): Promise<number> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const count = await db.select().from(neighborInfoSqlite);
+      await db.delete(neighborInfoSqlite);
+      return count.length;
+    } else {
+      const db = this.getPostgresDb();
+      const count = await db.select().from(neighborInfoPostgres);
+      await db.delete(neighborInfoPostgres);
+      return count.length;
+    }
+  }
 }

--- a/src/db/repositories/notifications.ts
+++ b/src/db/repositories/notifications.ts
@@ -1,0 +1,463 @@
+/**
+ * Notifications Repository
+ *
+ * Handles all notification-related database operations including:
+ * - Push subscriptions (CRUD)
+ * - User notification preferences (CRUD)
+ *
+ * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
+ */
+import { eq, desc } from 'drizzle-orm';
+import {
+  pushSubscriptionsSqlite,
+  pushSubscriptionsPostgres,
+  userNotificationPreferencesSqlite,
+  userNotificationPreferencesPostgres,
+} from '../schema/notifications.js';
+import { BaseRepository, DrizzleDatabase } from './base.js';
+import { DatabaseType, DbPushSubscription } from '../types.js';
+import { logger } from '../../utils/logger.js';
+
+// Re-export for convenience
+export type { DbPushSubscription } from '../types.js';
+
+/**
+ * Notification preferences data structure (database-agnostic)
+ */
+export interface NotificationPreferences {
+  enableWebPush: boolean;
+  enableApprise: boolean;
+  enabledChannels: number[];
+  enableDirectMessages: boolean;
+  notifyOnEmoji: boolean;
+  notifyOnMqtt: boolean;
+  notifyOnNewNode: boolean;
+  notifyOnTraceroute: boolean;
+  notifyOnInactiveNode: boolean;
+  notifyOnServerEvents: boolean;
+  prefixWithNodeName: boolean;
+  monitoredNodes: string[];
+  whitelist: string[];
+  blacklist: string[];
+  appriseUrls: string[];
+}
+
+/**
+ * Input for creating/updating push subscriptions
+ */
+export interface PushSubscriptionInput {
+  userId?: number | null;
+  endpoint: string;
+  p256dhKey: string;
+  authKey: string;
+  userAgent?: string | null;
+}
+
+/**
+ * Repository for notification operations
+ */
+export class NotificationsRepository extends BaseRepository {
+  constructor(db: DrizzleDatabase, dbType: DatabaseType) {
+    super(db, dbType);
+  }
+
+  // ============ PUSH SUBSCRIPTIONS ============
+
+  /**
+   * Get all push subscriptions
+   */
+  async getAllSubscriptions(): Promise<DbPushSubscription[]> {
+    try {
+      if (this.isSQLite()) {
+        const db = this.getSqliteDb();
+        const rows = await db
+          .select()
+          .from(pushSubscriptionsSqlite)
+          .orderBy(desc(pushSubscriptionsSqlite.createdAt));
+        return rows.map(row => this.mapSubscriptionRow(row));
+      } else {
+        // PostgreSQL and MySQL use the same code path
+        const db = this.getPostgresDb();
+        const rows = await db
+          .select()
+          .from(pushSubscriptionsPostgres)
+          .orderBy(desc(pushSubscriptionsPostgres.createdAt));
+        return rows.map(row => this.mapSubscriptionRow(row));
+      }
+    } catch (error) {
+      logger.error('❌ Failed to get all subscriptions:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Get push subscriptions for a specific user
+   */
+  async getUserSubscriptions(userId: number | null | undefined): Promise<DbPushSubscription[]> {
+    try {
+      if (this.isSQLite()) {
+        const db = this.getSqliteDb();
+        const rows = userId
+          ? await db
+              .select()
+              .from(pushSubscriptionsSqlite)
+              .where(eq(pushSubscriptionsSqlite.userId, userId))
+              .orderBy(desc(pushSubscriptionsSqlite.createdAt))
+          : await db
+              .select()
+              .from(pushSubscriptionsSqlite)
+              .orderBy(desc(pushSubscriptionsSqlite.createdAt));
+        return rows.map(row => this.mapSubscriptionRow(row));
+      } else {
+        // PostgreSQL and MySQL use the same code path
+        const db = this.getPostgresDb();
+        const rows = userId
+          ? await db
+              .select()
+              .from(pushSubscriptionsPostgres)
+              .where(eq(pushSubscriptionsPostgres.userId, userId))
+              .orderBy(desc(pushSubscriptionsPostgres.createdAt))
+          : await db
+              .select()
+              .from(pushSubscriptionsPostgres)
+              .orderBy(desc(pushSubscriptionsPostgres.createdAt));
+        return rows.map(row => this.mapSubscriptionRow(row));
+      }
+    } catch (error) {
+      logger.error('❌ Failed to get user subscriptions:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Save a push subscription (insert or update by endpoint)
+   */
+  async saveSubscription(input: PushSubscriptionInput): Promise<void> {
+    const now = this.now();
+
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      await db
+        .insert(pushSubscriptionsSqlite)
+        .values({
+          userId: input.userId ?? null,
+          endpoint: input.endpoint,
+          p256dhKey: input.p256dhKey,
+          authKey: input.authKey,
+          userAgent: input.userAgent ?? null,
+          createdAt: now,
+          updatedAt: now,
+          lastUsedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: pushSubscriptionsSqlite.endpoint,
+          set: {
+            userId: input.userId ?? null,
+            p256dhKey: input.p256dhKey,
+            authKey: input.authKey,
+            userAgent: input.userAgent ?? null,
+            updatedAt: now,
+            lastUsedAt: now,
+          },
+        });
+    } else {
+      // PostgreSQL and MySQL use the same code path
+      const db = this.getPostgresDb();
+      await db
+        .insert(pushSubscriptionsPostgres)
+        .values({
+          userId: input.userId ?? null,
+          endpoint: input.endpoint,
+          p256dhKey: input.p256dhKey,
+          authKey: input.authKey,
+          userAgent: input.userAgent ?? null,
+          createdAt: now,
+          updatedAt: now,
+          lastUsedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: pushSubscriptionsPostgres.endpoint,
+          set: {
+            userId: input.userId ?? null,
+            p256dhKey: input.p256dhKey,
+            authKey: input.authKey,
+            userAgent: input.userAgent ?? null,
+            updatedAt: now,
+            lastUsedAt: now,
+          },
+        });
+    }
+  }
+
+  /**
+   * Remove a push subscription by endpoint
+   */
+  async removeSubscription(endpoint: string): Promise<void> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      await db
+        .delete(pushSubscriptionsSqlite)
+        .where(eq(pushSubscriptionsSqlite.endpoint, endpoint));
+    } else {
+      // PostgreSQL and MySQL use the same code path
+      const db = this.getPostgresDb();
+      await db
+        .delete(pushSubscriptionsPostgres)
+        .where(eq(pushSubscriptionsPostgres.endpoint, endpoint));
+    }
+  }
+
+  /**
+   * Update the last_used_at timestamp for a subscription
+   */
+  async updateSubscriptionLastUsed(endpoint: string): Promise<void> {
+    const now = this.now();
+
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      await db
+        .update(pushSubscriptionsSqlite)
+        .set({ lastUsedAt: now })
+        .where(eq(pushSubscriptionsSqlite.endpoint, endpoint));
+    } else {
+      // PostgreSQL and MySQL use the same code path
+      const db = this.getPostgresDb();
+      await db
+        .update(pushSubscriptionsPostgres)
+        .set({ lastUsedAt: now })
+        .where(eq(pushSubscriptionsPostgres.endpoint, endpoint));
+    }
+  }
+
+  // ============ USER NOTIFICATION PREFERENCES ============
+
+  /**
+   * Get notification preferences for a user
+   */
+  async getUserPreferences(userId: number): Promise<NotificationPreferences | null> {
+    if (!Number.isInteger(userId) || userId <= 0) {
+      logger.error(`❌ Invalid userId: ${userId}`);
+      return null;
+    }
+
+    try {
+      if (this.isSQLite()) {
+        const db = this.getSqliteDb();
+        const rows = await db
+          .select()
+          .from(userNotificationPreferencesSqlite)
+          .where(eq(userNotificationPreferencesSqlite.userId, userId))
+          .limit(1);
+
+        if (rows.length === 0) {
+          return null;
+        }
+
+        return this.mapPreferencesRow(rows[0]);
+      } else {
+        // PostgreSQL and MySQL use the same code path
+        const db = this.getPostgresDb();
+        const rows = await db
+          .select()
+          .from(userNotificationPreferencesPostgres)
+          .where(eq(userNotificationPreferencesPostgres.userId, userId))
+          .limit(1);
+
+        if (rows.length === 0) {
+          return null;
+        }
+
+        return this.mapPreferencesRow(rows[0]);
+      }
+    } catch (error) {
+      logger.error(`❌ Failed to get preferences for user ${userId}:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Save notification preferences for a user (insert or update)
+   */
+  async saveUserPreferences(userId: number, prefs: NotificationPreferences): Promise<boolean> {
+    if (!Number.isInteger(userId) || userId <= 0) {
+      logger.error(`❌ Invalid userId: ${userId}`);
+      return false;
+    }
+
+    const now = this.now();
+
+    try {
+      if (this.isSQLite()) {
+        const db = this.getSqliteDb();
+        await db
+          .insert(userNotificationPreferencesSqlite)
+          .values({
+            userId,
+            notifyOnMessage: prefs.enableWebPush,
+            notifyOnDirectMessage: prefs.enableDirectMessages,
+            notifyOnChannelMessage: false, // Deprecated, use enabledChannels
+            notifyOnEmoji: prefs.notifyOnEmoji,
+            notifyOnInactiveNode: prefs.notifyOnInactiveNode,
+            notifyOnServerEvents: prefs.notifyOnServerEvents,
+            prefixWithNodeName: prefs.prefixWithNodeName,
+            appriseEnabled: prefs.enableApprise,
+            appriseUrls: JSON.stringify(prefs.appriseUrls),
+            notifyOnMqtt: prefs.notifyOnMqtt,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .onConflictDoUpdate({
+            target: userNotificationPreferencesSqlite.userId,
+            set: {
+              notifyOnMessage: prefs.enableWebPush,
+              notifyOnDirectMessage: prefs.enableDirectMessages,
+              notifyOnEmoji: prefs.notifyOnEmoji,
+              notifyOnInactiveNode: prefs.notifyOnInactiveNode,
+              notifyOnServerEvents: prefs.notifyOnServerEvents,
+              prefixWithNodeName: prefs.prefixWithNodeName,
+              appriseEnabled: prefs.enableApprise,
+              appriseUrls: JSON.stringify(prefs.appriseUrls),
+              notifyOnMqtt: prefs.notifyOnMqtt,
+              updatedAt: now,
+            },
+          });
+        return true;
+      } else {
+        // PostgreSQL and MySQL use the same code path
+        const db = this.getPostgresDb();
+        await db
+          .insert(userNotificationPreferencesPostgres)
+          .values({
+            userId,
+            notifyOnMessage: prefs.enableWebPush,
+            notifyOnDirectMessage: prefs.enableDirectMessages,
+            notifyOnChannelMessage: false,
+            notifyOnEmoji: prefs.notifyOnEmoji,
+            notifyOnInactiveNode: prefs.notifyOnInactiveNode,
+            notifyOnServerEvents: prefs.notifyOnServerEvents,
+            prefixWithNodeName: prefs.prefixWithNodeName,
+            appriseEnabled: prefs.enableApprise,
+            appriseUrls: JSON.stringify(prefs.appriseUrls),
+            notifyOnMqtt: prefs.notifyOnMqtt,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .onConflictDoUpdate({
+            target: userNotificationPreferencesPostgres.userId,
+            set: {
+              notifyOnMessage: prefs.enableWebPush,
+              notifyOnDirectMessage: prefs.enableDirectMessages,
+              notifyOnEmoji: prefs.notifyOnEmoji,
+              notifyOnInactiveNode: prefs.notifyOnInactiveNode,
+              notifyOnServerEvents: prefs.notifyOnServerEvents,
+              prefixWithNodeName: prefs.prefixWithNodeName,
+              appriseEnabled: prefs.enableApprise,
+              appriseUrls: JSON.stringify(prefs.appriseUrls),
+              notifyOnMqtt: prefs.notifyOnMqtt,
+              updatedAt: now,
+            },
+          });
+        return true;
+      }
+    } catch (error) {
+      logger.error(`❌ Failed to save preferences for user ${userId}:`, error);
+      return false;
+    }
+  }
+
+  /**
+   * Get users who have a specific notification service enabled
+   */
+  async getUsersWithServiceEnabled(service: 'web_push' | 'apprise'): Promise<number[]> {
+    try {
+      if (this.isSQLite()) {
+        const db = this.getSqliteDb();
+        const column = service === 'web_push'
+          ? userNotificationPreferencesSqlite.notifyOnMessage
+          : userNotificationPreferencesSqlite.appriseEnabled;
+
+        const rows = await db
+          .select({ userId: userNotificationPreferencesSqlite.userId })
+          .from(userNotificationPreferencesSqlite)
+          .where(eq(column, true));
+
+        return rows.map(row => row.userId);
+      } else {
+        // PostgreSQL and MySQL use the same code path
+        const db = this.getPostgresDb();
+        const column = service === 'web_push'
+          ? userNotificationPreferencesPostgres.notifyOnMessage
+          : userNotificationPreferencesPostgres.appriseEnabled;
+
+        const rows = await db
+          .select({ userId: userNotificationPreferencesPostgres.userId })
+          .from(userNotificationPreferencesPostgres)
+          .where(eq(column, true));
+
+        return rows.map(row => row.userId);
+      }
+    } catch (error) {
+      logger.debug('No user_notification_preferences table yet, returning empty array');
+      return [];
+    }
+  }
+
+  /**
+   * Get users who have Apprise enabled (specific helper for AppriseNotificationService)
+   */
+  async getUsersWithAppriseEnabled(): Promise<number[]> {
+    return this.getUsersWithServiceEnabled('apprise');
+  }
+
+  // ============ PRIVATE HELPERS ============
+
+  /**
+   * Map a database row to DbPushSubscription
+   */
+  private mapSubscriptionRow(row: any): DbPushSubscription {
+    return this.normalizeBigInts({
+      id: row.id,
+      userId: row.userId,
+      endpoint: row.endpoint,
+      p256dhKey: row.p256dhKey,
+      authKey: row.authKey,
+      userAgent: row.userAgent,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      lastUsedAt: row.lastUsedAt,
+    });
+  }
+
+  /**
+   * Map a database row to NotificationPreferences
+   */
+  private mapPreferencesRow(row: any): NotificationPreferences {
+    // Parse JSON fields safely
+    const parseJsonArray = (value: string | null | undefined): string[] | number[] => {
+      if (!value) return [];
+      try {
+        return JSON.parse(value);
+      } catch {
+        return [];
+      }
+    };
+
+    return {
+      enableWebPush: Boolean(row.notifyOnMessage),
+      enableApprise: Boolean(row.appriseEnabled),
+      enabledChannels: [], // This needs to be handled separately - stored in different format
+      enableDirectMessages: Boolean(row.notifyOnDirectMessage),
+      notifyOnEmoji: row.notifyOnEmoji !== undefined ? Boolean(row.notifyOnEmoji) : true,
+      notifyOnMqtt: row.notifyOnMqtt !== undefined ? Boolean(row.notifyOnMqtt) : true,
+      notifyOnNewNode: true, // Default to enabled
+      notifyOnTraceroute: true, // Default to enabled
+      notifyOnInactiveNode: row.notifyOnInactiveNode !== undefined ? Boolean(row.notifyOnInactiveNode) : false,
+      notifyOnServerEvents: row.notifyOnServerEvents !== undefined ? Boolean(row.notifyOnServerEvents) : false,
+      prefixWithNodeName: row.prefixWithNodeName !== undefined ? Boolean(row.prefixWithNodeName) : false,
+      monitoredNodes: [], // Default to empty array
+      whitelist: [], // Default to empty array
+      blacklist: [], // Default to empty array
+      appriseUrls: parseJsonArray(row.appriseUrls) as string[],
+    };
+  }
+}

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -431,4 +431,25 @@ export class TelemetryRepository extends BaseRepository {
       return toDelete.length;
     }
   }
+
+  /**
+   * Delete all telemetry
+   */
+  async deleteAllTelemetry(): Promise<number> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const count = await db
+        .select({ id: telemetrySqlite.id })
+        .from(telemetrySqlite);
+      await db.delete(telemetrySqlite);
+      return count.length;
+    } else {
+      const db = this.getPostgresDb();
+      const count = await db
+        .select({ id: telemetryPostgres.id })
+        .from(telemetryPostgres);
+      await db.delete(telemetryPostgres);
+      return count.length;
+    }
+  }
 }

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -367,4 +367,46 @@ export class TraceroutesRepository extends BaseRepository {
       }
     }
   }
+
+  /**
+   * Delete all traceroutes
+   */
+  async deleteAllTraceroutes(): Promise<number> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const count = await db
+        .select({ id: traceroutesSqlite.id })
+        .from(traceroutesSqlite);
+      await db.delete(traceroutesSqlite);
+      return count.length;
+    } else {
+      const db = this.getPostgresDb();
+      const count = await db
+        .select({ id: traceroutesPostgres.id })
+        .from(traceroutesPostgres);
+      await db.delete(traceroutesPostgres);
+      return count.length;
+    }
+  }
+
+  /**
+   * Delete all route segments
+   */
+  async deleteAllRouteSegments(): Promise<number> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const count = await db
+        .select({ id: routeSegmentsSqlite.id })
+        .from(routeSegmentsSqlite);
+      await db.delete(routeSegmentsSqlite);
+      return count.length;
+    } else {
+      const db = this.getPostgresDb();
+      const count = await db
+        .select({ id: routeSegmentsPostgres.id })
+        .from(routeSegmentsPostgres);
+      await db.delete(routeSegmentsPostgres);
+      return count.length;
+    }
+  }
 }

--- a/src/db/schema/notifications.ts
+++ b/src/db/schema/notifications.ts
@@ -1,7 +1,7 @@
 /**
  * Drizzle schema definition for notification tables
  * Includes: push_subscriptions, user_notification_preferences, read_messages
- * Supports both SQLite and PostgreSQL
+ * Supports SQLite, PostgreSQL, and MySQL (MySQL uses PostgreSQL schema)
  */
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
 import { pgTable, text as pgText, integer as pgInteger, boolean as pgBoolean, bigint as pgBigint, serial as pgSerial } from 'drizzle-orm/pg-core';

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6676,9 +6676,9 @@ apiRouter.post('/system/restart', requirePermission('settings', 'write'), (_req,
 // ==========================================
 
 // Get VAPID public key and configuration status
-apiRouter.get('/push/vapid-key', optionalAuth(), (_req, res) => {
-  const publicKey = pushNotificationService.getPublicKey();
-  const status = pushNotificationService.getVapidStatus();
+apiRouter.get('/push/vapid-key', optionalAuth(), async (_req, res) => {
+  const publicKey = await pushNotificationService.getPublicKeyAsync();
+  const status = await pushNotificationService.getVapidStatusAsync();
 
   res.json({
     publicKey,
@@ -6687,8 +6687,8 @@ apiRouter.get('/push/vapid-key', optionalAuth(), (_req, res) => {
 });
 
 // Get push notification status
-apiRouter.get('/push/status', optionalAuth(), (_req, res) => {
-  const status = pushNotificationService.getVapidStatus();
+apiRouter.get('/push/status', optionalAuth(), async (_req, res) => {
+  const status = await pushNotificationService.getVapidStatusAsync();
   res.json(status);
 });
 

--- a/src/server/services/pushNotificationService.ts
+++ b/src/server/services/pushNotificationService.ts
@@ -1,9 +1,13 @@
 import webpush from 'web-push';
 import { getEnvironmentConfig } from '../config/environment.js';
 import { logger } from '../../utils/logger.js';
-import databaseService, { DbPushSubscription } from '../../services/database.js';
-import { getUserNotificationPreferences, shouldFilterNotification as shouldFilterNotificationUtil, applyNodeNamePrefix } from '../utils/notificationFiltering.js';
+import databaseService from '../../services/database.js';
+import type { DbPushSubscription } from '../../db/types.js';
+import { getUserNotificationPreferencesAsync, shouldFilterNotificationAsync, applyNodeNamePrefixAsync } from '../utils/notificationFiltering.js';
 import meshtasticManager from '../meshtasticManager.js';
+
+// Re-export DbPushSubscription for backward compatibility
+export type { DbPushSubscription } from '../../db/types.js';
 
 export interface PushNotificationPayload {
   title: string;
@@ -116,26 +120,26 @@ class PushNotificationService {
   /**
    * Get the public VAPID key for client-side subscription
    */
-  public getPublicKey(): string | null {
+  public async getPublicKeyAsync(): Promise<string | null> {
     const config = getEnvironmentConfig();
     if (config.vapidPublicKey) {
       return config.vapidPublicKey;
     }
-    return databaseService.getSetting('vapid_public_key');
+    return databaseService.getSettingAsync('vapid_public_key');
   }
 
   /**
    * Get VAPID configuration status
    */
-  public getVapidStatus(): {
+  public async getVapidStatusAsync(): Promise<{
     configured: boolean;
     publicKey: string | null;
     subject: string | null;
     subscriptionCount: number;
-  } {
-    const publicKey = this.getPublicKey();
-    const subject = databaseService.getSetting('vapid_subject');
-    const subscriptions = this.getAllSubscriptions();
+  }> {
+    const publicKey = await this.getPublicKeyAsync();
+    const subject = await databaseService.getSettingAsync('vapid_subject');
+    const subscriptions = await this.getAllSubscriptionsAsync();
 
     return {
       configured: this.isConfigured,
@@ -172,23 +176,17 @@ class PushNotificationService {
         throw new Error('Invalid subscription: missing keys');
       }
 
-      const now = Date.now();
-      const stmt = databaseService.db.prepare(`
-        INSERT OR REPLACE INTO push_subscriptions
-        (user_id, endpoint, p256dh_key, auth_key, user_agent, created_at, updated_at, last_used_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-      `);
+      if (!databaseService.notificationsRepo) {
+        throw new Error('Notifications repository not initialized');
+      }
 
-      stmt.run(
-        userId || null,
-        subscription.endpoint,
-        keys.p256dh,
-        keys.auth,
-        userAgent || null,
-        now,
-        now,
-        now
-      );
+      await databaseService.notificationsRepo.saveSubscription({
+        userId: userId ?? null,
+        endpoint: subscription.endpoint,
+        p256dhKey: keys.p256dh,
+        authKey: keys.auth,
+        userAgent: userAgent ?? null,
+      });
 
       logger.info(`✅ Saved push subscription for ${userId ? `user ${userId}` : 'anonymous user'}`);
     } catch (error) {
@@ -202,10 +200,11 @@ class PushNotificationService {
    */
   public async removeSubscription(endpoint: string): Promise<void> {
     try {
-      const stmt = databaseService.db.prepare(`
-        DELETE FROM push_subscriptions WHERE endpoint = ?
-      `);
-      stmt.run(endpoint);
+      if (!databaseService.notificationsRepo) {
+        throw new Error('Notifications repository not initialized');
+      }
+
+      await databaseService.notificationsRepo.removeSubscription(endpoint);
       logger.info('✅ Removed push subscription');
     } catch (error) {
       logger.error('❌ Failed to remove push subscription:', error);
@@ -214,28 +213,16 @@ class PushNotificationService {
   }
 
   /**
-   * Get all subscriptions for a user
+   * Get all subscriptions for a user (async)
    */
-  public getUserSubscriptions(userId?: number): DbPushSubscription[] {
+  public async getUserSubscriptionsAsync(userId?: number): Promise<DbPushSubscription[]> {
     try {
-      const stmt = databaseService.db.prepare(`
-        SELECT * FROM push_subscriptions
-        WHERE user_id = ? OR (user_id IS NULL AND ? IS NULL)
-        ORDER BY created_at DESC
-      `);
-      const rows = stmt.all(userId || null, userId || null) as any[];
-      // Map snake_case database columns to camelCase
-      return rows.map(row => ({
-        id: row.id,
-        userId: row.user_id,
-        endpoint: row.endpoint,
-        p256dhKey: row.p256dh_key,
-        authKey: row.auth_key,
-        userAgent: row.user_agent,
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
-        lastUsedAt: row.last_used_at
-      }));
+      if (!databaseService.notificationsRepo) {
+        logger.debug('Notifications repository not initialized');
+        return [];
+      }
+
+      return databaseService.notificationsRepo.getUserSubscriptions(userId);
     } catch (error) {
       logger.error('❌ Failed to get user subscriptions:', error);
       return [];
@@ -243,27 +230,16 @@ class PushNotificationService {
   }
 
   /**
-   * Get all active subscriptions
+   * Get all active subscriptions (async)
    */
-  public getAllSubscriptions(): DbPushSubscription[] {
+  public async getAllSubscriptionsAsync(): Promise<DbPushSubscription[]> {
     try {
-      const stmt = databaseService.db.prepare(`
-        SELECT * FROM push_subscriptions
-        ORDER BY created_at DESC
-      `);
-      const rows = stmt.all() as any[];
-      // Map snake_case database columns to camelCase
-      return rows.map(row => ({
-        id: row.id,
-        userId: row.user_id,
-        endpoint: row.endpoint,
-        p256dhKey: row.p256dh_key,
-        authKey: row.auth_key,
-        userAgent: row.user_agent,
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
-        lastUsedAt: row.last_used_at
-      }));
+      if (!databaseService.notificationsRepo) {
+        logger.debug('Notifications repository not initialized');
+        return [];
+      }
+
+      return databaseService.notificationsRepo.getAllSubscriptions();
     } catch (error) {
       logger.error('❌ Failed to get all subscriptions:', error);
       return [];
@@ -305,12 +281,9 @@ class PushNotificationService {
       );
 
       // Update last_used_at
-      const stmt = databaseService.db.prepare(`
-        UPDATE push_subscriptions
-        SET last_used_at = ?
-        WHERE endpoint = ?
-      `);
-      stmt.run(Date.now(), subscription.endpoint);
+      if (databaseService.notificationsRepo) {
+        await databaseService.notificationsRepo.updateSubscriptionLastUsed(subscription.endpoint);
+      }
 
       logger.debug(`✅ Sent push notification to subscription ${subscription.id}`);
       return true;
@@ -354,7 +327,7 @@ class PushNotificationService {
     userId: number | undefined,
     payload: PushNotificationPayload
   ): Promise<{ sent: number; failed: number }> {
-    const subscriptions = this.getUserSubscriptions(userId);
+    const subscriptions = await this.getUserSubscriptionsAsync(userId);
     let sent = 0;
     let failed = 0;
 
@@ -374,7 +347,7 @@ class PushNotificationService {
    * Broadcast a push notification to all subscriptions
    */
   public async broadcast(payload: PushNotificationPayload): Promise<{ sent: number; failed: number }> {
-    const subscriptions = this.getAllSubscriptions();
+    const subscriptions = await this.getAllSubscriptionsAsync();
     let sent = 0;
     let failed = 0;
 
@@ -405,7 +378,7 @@ class PushNotificationService {
       viaMqtt?: boolean;
     }
   ): Promise<{ sent: number; failed: number; filtered: number }> {
-    const subscriptions = this.getAllSubscriptions();
+    const subscriptions = await this.getAllSubscriptionsAsync();
     let sent = 0;
     let failed = 0;
     let filtered = 0;
@@ -421,14 +394,14 @@ class PushNotificationService {
       const userId = subscription.userId;
 
       // Skip if user should be filtered
-      if (this.shouldFilterNotification(userId, filterContext)) {
+      if (await this.shouldFilterNotificationAsync(userId, filterContext)) {
         logger.debug(`🔇 Filtered notification for user ${userId || 'anonymous'}: ${filterContext.messageText.substring(0, 30)}...`);
         filtered++;
         continue;
       }
 
       // Apply node name prefix if user has it enabled
-      const prefixedBody = applyNodeNamePrefix(userId, payload.body, localNodeName);
+      const prefixedBody = await applyNodeNamePrefixAsync(userId, payload.body, localNodeName);
       const notificationPayload = prefixedBody !== payload.body
         ? { ...payload, body: prefixedBody }
         : payload;
@@ -454,7 +427,7 @@ class PushNotificationService {
    * 3. MeshMonitor is typically for private mesh networks (trusted environment)
    * 4. Users can unsubscribe at any time or set up authentication + preferences
    */
-  private shouldFilterNotification(
+  private async shouldFilterNotificationAsync(
     userId: number | null | undefined,
     filterContext: {
       messageText: string;
@@ -462,7 +435,7 @@ class PushNotificationService {
       isDirectMessage: boolean;
       viaMqtt?: boolean;
     }
-  ): boolean {
+  ): Promise<boolean> {
     // Anonymous users get all notifications (no filtering) - they've opted in by subscribing
     if (!userId) {
       logger.debug('Anonymous user - no filtering applied (user opted in by subscribing)');
@@ -470,14 +443,14 @@ class PushNotificationService {
     }
 
     // Check if user has web push enabled
-    const prefs = getUserNotificationPreferences(userId);
+    const prefs = await getUserNotificationPreferencesAsync(userId);
     if (prefs && !prefs.enableWebPush) {
       logger.debug(`🔇 Web Push disabled for user ${userId}`);
       return true; // Filter - user has disabled web push
     }
 
     // Use shared filtering utility
-    return shouldFilterNotificationUtil(userId, filterContext);
+    return shouldFilterNotificationAsync(userId, filterContext);
   }
 
   /**
@@ -489,7 +462,7 @@ class PushNotificationService {
     payload: PushNotificationPayload,
     targetUserId?: number
   ): Promise<{ sent: number; failed: number; filtered: number }> {
-    const subscriptions = this.getAllSubscriptions();
+    const subscriptions = await this.getAllSubscriptionsAsync();
     let sent = 0;
     let failed = 0;
     let filtered = 0;
@@ -504,10 +477,10 @@ class PushNotificationService {
       localNodeName = localNodeInfo.longName;
     } else {
       // Fall back to database - get localNodeNum from settings and look up the node
-      const localNodeNumStr = databaseService.getSetting('localNodeNum');
+      const localNodeNumStr = await databaseService.getSettingAsync('localNodeNum');
       if (localNodeNumStr) {
         const localNodeNum = parseInt(localNodeNumStr, 10);
-        const localNode = databaseService.getNode(localNodeNum);
+        const localNode = await databaseService.nodesRepo?.getNode(localNodeNum);
         if (localNode?.longName) {
           localNodeName = localNode.longName;
           logger.debug(`📢 Using node name from database for prefix: ${localNodeName}`);
@@ -531,14 +504,14 @@ class PushNotificationService {
       }
 
       // Check if user has this preference enabled
-      const prefs = getUserNotificationPreferences(userId);
+      const prefs = await getUserNotificationPreferencesAsync(userId);
       if (!prefs || !prefs.enableWebPush || !prefs[preferenceKey]) {
         filtered++;
         continue;
       }
 
       // Apply node name prefix if user has it enabled
-      const prefixedBody = applyNodeNamePrefix(userId, payload.body, localNodeName);
+      const prefixedBody = await applyNodeNamePrefixAsync(userId, payload.body, localNodeName);
       const notificationPayload = prefixedBody !== payload.body
         ? { ...payload, body: prefixedBody }
         : payload;

--- a/src/server/utils/notificationFiltering.ts
+++ b/src/server/utils/notificationFiltering.ts
@@ -344,3 +344,167 @@ export function applyNodeNamePrefix(
   // Apply prefix
   return `[${nodeName}] ${body}`;
 }
+
+// ============ ASYNC VERSIONS ============
+// These versions use the notifications repository and work with PostgreSQL
+
+/**
+ * Load notification preferences for a user from the database (async version)
+ * Uses the notifications repository for database-agnostic queries
+ */
+export async function getUserNotificationPreferencesAsync(userId: number): Promise<NotificationPreferences | null> {
+  // Validate userId
+  if (!Number.isInteger(userId) || userId <= 0) {
+    logger.error(`❌ Invalid userId: ${userId}`);
+    return null;
+  }
+
+  try {
+    if (!databaseService.notificationsRepo) {
+      logger.debug('Notifications repository not initialized');
+      return null;
+    }
+
+    const prefs = await databaseService.notificationsRepo.getUserPreferences(userId);
+    if (prefs) {
+      return prefs;
+    }
+
+    // Fall back to old settings table for backward compatibility
+    const prefsJson = await databaseService.getSettingAsync(`push_prefs_${userId}`);
+    if (prefsJson) {
+      const oldPrefs = JSON.parse(prefsJson);
+      return {
+        enableWebPush: true, // Old users had push enabled
+        enableApprise: false, // New feature, default to disabled
+        enabledChannels: oldPrefs.enabledChannels || [],
+        enableDirectMessages: oldPrefs.enableDirectMessages !== undefined
+          ? oldPrefs.enableDirectMessages
+          : true,
+        notifyOnEmoji: true, // Default to enabled for backward compatibility
+        notifyOnMqtt: true, // Default to enabled for backward compatibility
+        notifyOnNewNode: true, // Default to enabled for backward compatibility
+        notifyOnTraceroute: true, // Default to enabled for backward compatibility
+        notifyOnInactiveNode: false, // Default to disabled
+        notifyOnServerEvents: false, // Default to disabled
+        prefixWithNodeName: false, // Default to disabled
+        monitoredNodes: [], // Default to empty array
+        whitelist: oldPrefs.whitelist || [],
+        blacklist: oldPrefs.blacklist || [],
+        appriseUrls: [] // Default to empty array
+      };
+    }
+
+    logger.debug(`No preferences found for user ${userId}`);
+    return null;
+  } catch (error) {
+    logger.error(`Failed to load preferences for user ${userId}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Get users who have a specific notification service enabled (async version)
+ */
+export async function getUsersWithServiceEnabledAsync(service: 'web_push' | 'apprise'): Promise<number[]> {
+  try {
+    if (!databaseService.notificationsRepo) {
+      logger.debug('Notifications repository not initialized');
+      return [];
+    }
+
+    return databaseService.notificationsRepo.getUsersWithServiceEnabled(service);
+  } catch (error) {
+    logger.debug('No user_notification_preferences table yet, returning empty array');
+    return [];
+  }
+}
+
+/**
+ * Check if a notification should be filtered for a specific user (async version)
+ */
+export async function shouldFilterNotificationAsync(
+  userId: number,
+  filterContext: NotificationFilterContext
+): Promise<boolean> {
+  // Validate userId
+  if (!Number.isInteger(userId) || userId <= 0) {
+    logger.error(`❌ Invalid userId: ${userId}`);
+    return false; // Allow on validation error (fail-open for UX)
+  }
+
+  // Load user preferences
+  const prefs = await getUserNotificationPreferencesAsync(userId);
+  if (!prefs) {
+    logger.debug(`No preferences for user ${userId}, allowing notification`);
+    return false; // Allow if no preferences found
+  }
+
+  const messageTextLower = filterContext.messageText.toLowerCase();
+
+  // WHITELIST (highest priority)
+  for (const word of prefs.whitelist) {
+    if (word && messageTextLower.includes(word.toLowerCase())) {
+      logger.debug(`✅ Whitelist match for user ${userId}: "${word}"`);
+      return false; // Don't filter
+    }
+  }
+
+  // BLACKLIST (second priority)
+  for (const word of prefs.blacklist) {
+    if (word && messageTextLower.includes(word.toLowerCase())) {
+      logger.debug(`🚫 Blacklist match for user ${userId}: "${word}"`);
+      return true; // Filter
+    }
+  }
+
+  // EMOJI CHECK (third priority)
+  if (!prefs.notifyOnEmoji && isEmojiOnlyMessage(filterContext.messageText)) {
+    logger.debug(`😀 Emoji-only message filtered for user ${userId}`);
+    return true; // Filter
+  }
+
+  // MQTT CHECK (fourth priority)
+  if (!prefs.notifyOnMqtt && filterContext.viaMqtt === true) {
+    logger.debug(`📡 MQTT message filtered for user ${userId}`);
+    return true; // Filter
+  }
+
+  // CHANNEL/DM CHECK (fifth priority)
+  if (filterContext.isDirectMessage) {
+    if (!prefs.enableDirectMessages) {
+      logger.debug(`🔇 Direct messages disabled for user ${userId}`);
+      return true; // Filter
+    }
+  } else {
+    if (!prefs.enabledChannels.includes(filterContext.channelId)) {
+      logger.debug(`🔇 Channel ${filterContext.channelId} disabled for user ${userId}`);
+      return true; // Filter
+    }
+  }
+
+  return false; // Don't filter (allow by default)
+}
+
+/**
+ * Apply node name prefix to a notification body if the user has it enabled (async version)
+ */
+export async function applyNodeNamePrefixAsync(
+  userId: number | null | undefined,
+  body: string,
+  nodeName: string | null | undefined
+): Promise<string> {
+  // No prefix if no user ID or node name
+  if (!userId || !nodeName) {
+    return body;
+  }
+
+  // Check user preferences
+  const prefs = await getUserNotificationPreferencesAsync(userId);
+  if (!prefs || !prefs.prefixWithNodeName) {
+    return body;
+  }
+
+  // Apply prefix
+  return `[${nodeName}] ${body}`;
+}


### PR DESCRIPTION
## Summary
- Fixes PostgreSQL/MySQL cache synchronization for all node modification methods
- Prevents "SQLite method 'prepare' called but using postgres database" errors
- Adds notifications repository for push subscriptions and user preferences
- All sync methods now update cache immediately and fire-and-forget async DB writes

## Changes
- Add `NotificationsRepository` for push subscriptions and preferences (supports SQLite, PostgreSQL, MySQL)
- Add `deleteAll*` methods to messages, telemetry, traceroutes, neighbors repositories
- Add generic `updateNode` method to nodes repository
- Update `deleteNode`/`purgeAllNodes` with async PostgreSQL/MySQL support
- Update `setNodeFavorite`/`setNodeIgnored` with cache sync
- Update `updateNodeSecurityFlags`/`updateNodeLowEntropyFlag` with cache sync
- Convert notification services to use async repository methods

## Test plan
- [ ] Build and typecheck pass
- [ ] Test with PostgreSQL database backend
- [ ] Test with MySQL database backend
- [ ] Verify node operations update correctly (favorite, ignore, delete)
- [ ] Verify notification services work with PostgreSQL/MySQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)