### PR TITLE
fix: improve push notification scroll to message with retries

### DIFF
--- a/src/hooks/useNotificationNavigationHandler.ts
+++ b/src/hooks/useNotificationNavigationHandler.ts
@@ -9,7 +9,7 @@
  * 4. Scrolling to and highlighting the target message
  */
 
-import { useState, useEffect, type MutableRefObject } from 'react';
+import { useState, useEffect, useRef, type MutableRefObject } from 'react';
 import { logger } from '../utils/logger';
 import { usePushNotificationNavigation } from './usePushNotificationNavigation';
 
@@ -49,9 +49,20 @@ export function useNotificationNavigationHandler(
 ): void {
   const { pendingNavigation, clearPendingNavigation } = usePushNotificationNavigation();
   const [scrollToMessageId, setScrollToMessageId] = useState<string | null>(null);
+  
+  // Use ref to persist scroll target across re-renders
+  const scrollToMessageIdRef = useRef<string | null>(null);
 
   const { setActiveTab, setSelectedChannel, setSelectedDMNode, selectedChannelRef } = callbacks;
   const { connectionStatus, channels, activeTab, selectedChannel, selectedDMNode } = state;
+
+  // Sync ref with state
+  useEffect(() => {
+    scrollToMessageIdRef.current = scrollToMessageId;
+    if (scrollToMessageId) {
+      logger.debug(`📬 scrollToMessageId updated: ${scrollToMessageId}`);
+    }
+  }, [scrollToMessageId]);
 
   // Handle push notification click navigation
   // When a notification is clicked, navigate to the relevant channel/DM and scroll to the message
@@ -110,15 +121,33 @@ export function useNotificationNavigationHandler(
   ]);
 
   // Scroll to specific message after navigation from push notification
+  // Use a separate effect that only depends on scrollToMessageId to prevent unnecessary re-runs
   useEffect(() => {
     if (!scrollToMessageId) return;
 
-    // Wait for the messages to render, then scroll to the target message
-    const scrollTimer = setTimeout(() => {
-      const messageElement = document.querySelector(`[data-message-id="${scrollToMessageId}"]`);
+    logger.info(`📬 Starting scroll attempt for message: ${scrollToMessageId}, activeTab: ${activeTab}, selectedChannel: ${selectedChannel}, selectedDMNode: ${selectedDMNode}`);
+
+    // Retry mechanism - try multiple times with increasing delays
+    // This handles cases where messages are still loading
+    const maxRetries = 10;
+    let retryCount = 0;
+    let scrollTimer: ReturnType<typeof setTimeout> | null = null;
+    let cancelled = false;
+    const targetMessageId = scrollToMessageId; // Capture in closure
+
+    const attemptScroll = () => {
+      if (cancelled) return;
+      
+      // Check if we still need to scroll (state might have changed)
+      if (scrollToMessageIdRef.current !== targetMessageId) {
+        logger.debug(`📬 Scroll target changed, aborting scroll to: ${targetMessageId}`);
+        return;
+      }
+
+      const messageElement = document.querySelector(`[data-message-id="${targetMessageId}"]`);
 
       if (messageElement) {
-        logger.info(`📬 Scrolling to message: ${scrollToMessageId}`);
+        logger.info(`📬 Found message element, scrolling to: ${targetMessageId}`);
         messageElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
 
         // Add a brief highlight effect to the message
@@ -126,14 +155,48 @@ export function useNotificationNavigationHandler(
         setTimeout(() => {
           messageElement.classList.remove('message-highlight');
         }, 2000);
+
+        // Clear the scroll target after successful scroll
+        setScrollToMessageId(null);
       } else {
-        logger.warn(`📬 Message element not found for ID: ${scrollToMessageId}`);
+        retryCount++;
+        // Log all message elements to help debugging
+        if (retryCount === 1) {
+          const allMessageElements = document.querySelectorAll('[data-message-id]');
+          const messageIds = Array.from(allMessageElements).map(el => el.getAttribute('data-message-id'));
+          logger.debug(`📬 Looking for: ${targetMessageId}`);
+          logger.debug(`📬 Available message IDs (${allMessageElements.length}):`, 
+            messageIds.slice(0, 10)
+          );
+          // Check if target is in the list
+          if (!messageIds.includes(targetMessageId)) {
+            logger.debug(`📬 Target message NOT in available messages - may need to load older messages`);
+          }
+        }
+        
+        if (retryCount < maxRetries) {
+          // Linear backoff: 500ms, 1000ms, 1500ms, 2000ms, then cap at 2000ms
+          const delay = Math.min(500 * retryCount, 2000);
+          logger.debug(`📬 Message not found, retry ${retryCount}/${maxRetries} in ${delay}ms: ${targetMessageId}`);
+          scrollTimer = setTimeout(attemptScroll, delay);
+        } else {
+          logger.warn(`📬 Message element not found after ${maxRetries} retries: ${targetMessageId}`);
+          // Clear the scroll target to prevent infinite loop
+          setScrollToMessageId(null);
+        }
       }
+    };
 
-      // Clear the scroll target
-      setScrollToMessageId(null);
-    }, 300); // Wait for messages to render
+    // Initial delay to allow React to render the messages after tab/channel change
+    scrollTimer = setTimeout(attemptScroll, 600);
 
-    return () => clearTimeout(scrollTimer);
-  }, [scrollToMessageId, activeTab, selectedChannel, selectedDMNode]);
+    return () => {
+      cancelled = true;
+      if (scrollTimer) {
+        clearTimeout(scrollTimer);
+      }
+    };
+  // Only depend on scrollToMessageId - other values are logged but shouldn't trigger re-runs
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scrollToMessageId]);
 }


### PR DESCRIPTION
# MR: Fix scroll-to-message from push notification

## Summary
Improves the reliability of automatically scrolling to the target message when the user opens the app by clicking a push notification.

## Problem
In some cases (especially on cold start or during slow rendering), the target message DOM element is not yet rendered when the app attempts to call `scrollIntoView`, causing:
- The scroll to the message to fail.
- The scroll target to be lost due to re-renders/effects and the timer getting cancelled.

## Solution (what changed)
- Increases the initial delay to allow the message list to render (from 300ms to 600ms).
- Adds a robust retry mechanism (up to 10 attempts with linear backoff, capped at 2000ms).
- Persists the target `messageId` in a `ref` to survive re-renders and avoid stale scroll attempts.
- Fixes `useEffect` dependencies to prevent unnecessary timer cancellation.
- Adds a `cancelled` flag to prevent stale callbacks after cleanup.
- Keeps detailed logging to help diagnose cases where the message element cannot be found.

## Files changed
- [src/hooks/useNotificationNavigationHandler.ts](src/hooks/useNotificationNavigationHandler.ts)

## How to test (manual)
1. Receive a push notification that includes a `messageId` (channel or DM).
2. With the app closed (cold start), click the notification.
3. Verify that:
   - It navigates to the correct channel/DM.
   - It scrolls to the message and applies the temporary highlight.
4. Repeat with a slow network / slow render to validate the retry behavior.

## Tests
- `npm test -- --run`

## Risks / considerations
- Adds extra logs in failure scenarios (debug/warn/info depending on case).
- Retry logic only runs while `scrollToMessageId` is set; impact should be contained.