### PR TITLE
docs: Add Indiana Mesh to site gallery

### DIFF
--- a/docs/site-gallery.md
+++ b/docs/site-gallery.md
@@ -59,6 +59,14 @@ Running a public MeshMonitor instance? We'd love to feature it! **[File an issue
 
 ---
 
+### Indiana Mesh
+- **URL**: [meshmap.tranziq.net](https://meshmap.tranziq.net/)
+- **Network**: [CIMesh](https://cimesh.net/)
+- **Location**: Indiana, US
+- **Description**: Monitoring the State of Indiana Meshtastic Network with real-time updates and comprehensive coverage.
+
+---
+
 ## About the Site Gallery
 
 The Site Gallery showcases MeshMonitor instances that are publicly accessible. These sites demonstrate:


### PR DESCRIPTION
## Summary
- Adds Indiana Mesh (meshmap.tranziq.net) to the MeshMonitor Site Gallery
- Associated with the CIMesh network (cimesh.net)
- Located in Indiana, US

Closes #1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)