### PR TITLE
feat(packet-monitor): Show channel ID for encrypted packets

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1001,7 +1001,7 @@
   "packet_monitor.column.from": "From",
   "packet_monitor.column.to": "To",
   "packet_monitor.column.type": "Type",
-  "packet_monitor.column.ch": "Ch",
+  "packet_monitor.column.slot": "Slot",
   "packet_monitor.column.snr": "SNR",
   "packet_monitor.column.hops": "Hops",
   "packet_monitor.column.size": "Size",

--- a/src/components/PacketMonitorPanel.tsx
+++ b/src/components/PacketMonitorPanel.tsx
@@ -444,7 +444,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
                     <th style={{ width: '140px' }}>{t('packet_monitor.column.from')}</th>
                     <th style={{ width: '140px' }}>{t('packet_monitor.column.to')}</th>
                     <th style={{ width: '120px' }}>{t('packet_monitor.column.type')}</th>
-                    <th style={{ width: '50px' }}>{t('packet_monitor.column.ch')}</th>
+                    <th style={{ width: '70px' }}>{t('packet_monitor.column.slot')}</th>
                     <th style={{ width: '60px' }}>{t('packet_monitor.column.snr')}</th>
                     <th style={{ width: '60px' }}>{t('packet_monitor.column.hops')}</th>
                     <th style={{ width: '60px' }}>{t('packet_monitor.column.size')}</th>
@@ -569,8 +569,8 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
                           >
                             {packet.portnum_name || packet.portnum}
                           </td>
-                          <td className="channel" style={{ width: '50px' }} title={packet.encrypted && packet.channel !== undefined && packet.channel > 7 ? `Channel hash: ${packet.channel}` : undefined}>
-                            {packet.encrypted && packet.channel !== undefined && packet.channel > 7 ? '??' : (packet.channel ?? t('common.na'))}
+                          <td className="channel" style={{ width: '70px' }} title={packet.encrypted && packet.channel !== undefined && packet.channel > 7 ? `Encrypted channel (hash: ${packet.channel})` : undefined}>
+                            {packet.encrypted && packet.channel !== undefined && packet.channel > 7 ? `?? (ch: ${packet.channel})` : (packet.channel ?? t('common.na'))}
                           </td>
                           <td className="snr" style={{ width: '60px' }}>
                             {packet.snr !== null && packet.snr !== undefined ? `${packet.snr.toFixed(1)}` : t('common.na')}


### PR DESCRIPTION
## Summary
- Display encrypted channel as `?? (ch: XX)` instead of just `??`
- Allows identifying at a glance when multiple nodes are communicating on the same encrypted channel
- Updated tooltip to "Encrypted channel (hash: X)" for clarity
- Widened column from 50px to 70px to fit the longer text

## Before
```
Channel: ??
```

## After
```
Channel: ?? (ch: 42)
```

## Test plan
- [ ] Open Packet Monitor
- [ ] Observe encrypted packets
- [ ] Verify channel shows as `?? (ch: XX)` format
- [ ] Hover to see tooltip with full hash info

🤖 Generated with [Claude Code](https://claude.com/claude-code)