### PR TITLE
fix: Update tests for async database methods

### DIFF
--- a/src/server/routes/apiTokenRoutes.test.ts
+++ b/src/server/routes/apiTokenRoutes.test.ts
@@ -15,7 +15,13 @@ vi.mock('../../services/database.js', () => ({
     userModel: {
       findById: vi.fn()
     },
-    auditLog: vi.fn()
+    auditLog: vi.fn(),
+    // Async methods required by authMiddleware
+    drizzleDbType: 'sqlite',
+    findUserByIdAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn(),
+    checkPermissionAsync: vi.fn(),
+    getUserPermissionSetAsync: vi.fn()
   }
 }));
 
@@ -29,6 +35,11 @@ const mockDatabase = databaseService as unknown as {
     findById: ReturnType<typeof vi.fn>;
   };
   auditLog: ReturnType<typeof vi.fn>;
+  // Async methods
+  findUserByIdAsync: ReturnType<typeof vi.fn>;
+  findUserByUsernameAsync: ReturnType<typeof vi.fn>;
+  checkPermissionAsync: ReturnType<typeof vi.fn>;
+  getUserPermissionSetAsync: ReturnType<typeof vi.fn>;
 };
 
 const defaultUser = {
@@ -69,6 +80,14 @@ describe('API Token Routes', () => {
     vi.clearAllMocks();
     mockDatabase.userModel.findById.mockReturnValue(defaultUser);
     mockDatabase.apiTokenModel.getUserToken.mockReturnValue(null);
+    // Configure async mocks for authMiddleware
+    mockDatabase.findUserByIdAsync.mockResolvedValue(defaultUser);
+    mockDatabase.findUserByUsernameAsync.mockResolvedValue(null);
+    mockDatabase.checkPermissionAsync.mockResolvedValue(true);
+    mockDatabase.getUserPermissionSetAsync.mockResolvedValue({
+      resources: {},
+      isAdmin: false
+    });
   });
 
   it('requires authentication for token endpoints', async () => {

--- a/src/server/routes/auditRoutes.test.ts
+++ b/src/server/routes/auditRoutes.test.ts
@@ -216,6 +216,24 @@ describe('Audit Log Routes', () => {
       return result.changes;
     };
 
+    // Add async method mocks for authMiddleware compatibility
+    (DatabaseService as any).drizzleDbType = 'sqlite';
+    (DatabaseService as any).findUserByIdAsync = async (id: number) => {
+      return userModel.findById(id);
+    };
+    (DatabaseService as any).findUserByUsernameAsync = async (username: string) => {
+      return userModel.findByUsername(username);
+    };
+    (DatabaseService as any).checkPermissionAsync = async (userId: number, resource: string, action: string) => {
+      return permissionModel.check(userId, resource, action);
+    };
+    (DatabaseService as any).getUserPermissionSetAsync = async (userId: number) => {
+      return permissionModel.getUserPermissionSet(userId);
+    };
+    (DatabaseService as any).authenticateAsync = async (username: string, password: string) => {
+      return userModel.authenticate(username, password);
+    };
+
     // Add test middleware to inject sessions for testing
     // This must come AFTER session middleware but BEFORE routes
     app.use((req, _res, next) => {

--- a/src/server/routes/packetRoutes.test.ts
+++ b/src/server/routes/packetRoutes.test.ts
@@ -199,6 +199,15 @@ describe('Packet Routes', () => {
       return result.count;
     };
 
+    // Async versions that wrap the sync methods
+    (DatabaseService as any).getPacketLogsAsync = async (options: any) => {
+      return (DatabaseService as any).getPacketLogs(options);
+    };
+
+    (DatabaseService as any).getPacketLogCountAsync = async (options: any = {}) => {
+      return (DatabaseService as any).getPacketLogCount(options);
+    };
+
     (DatabaseService as any).clearPacketLogs = () => {
       const result = db.prepare('DELETE FROM packet_log').run();
       return result.changes;
@@ -210,6 +219,21 @@ describe('Packet Routes', () => {
       const cutoffTime = Math.floor(Date.now() / 1000) - (hours * 60 * 60);
       const result = db.prepare('DELETE FROM packet_log WHERE timestamp < ?').run(cutoffTime);
       return result.changes;
+    };
+
+    // Add async method mocks for authMiddleware compatibility
+    (DatabaseService as any).drizzleDbType = 'sqlite';
+    (DatabaseService as any).findUserByIdAsync = async (id: number) => {
+      return userModel.findById(id);
+    };
+    (DatabaseService as any).findUserByUsernameAsync = async (username: string) => {
+      return userModel.findByUsername(username);
+    };
+    (DatabaseService as any).checkPermissionAsync = async (userId: number, resource: string, action: string) => {
+      return permissionModel.check(userId, resource, action);
+    };
+    (DatabaseService as any).getUserPermissionSetAsync = async (userId: number) => {
+      return permissionModel.getUserPermissionSet(userId);
     };
 
     // Mock req.user for permission checking

--- a/src/server/routes/userRoutes.test.ts
+++ b/src/server/routes/userRoutes.test.ts
@@ -73,6 +73,27 @@ describe('User Management Routes', () => {
     (DatabaseService as any).userModel = userModel;
     (DatabaseService as any).permissionModel = permissionModel;
     (DatabaseService as any).auditLog = () => {};
+    (DatabaseService as any).drizzleDbType = 'sqlite';
+
+    // Add async method mocks that delegate to sync methods
+    (DatabaseService as any).findUserByIdAsync = async (id: number) => {
+      return userModel.findById(id);
+    };
+    (DatabaseService as any).findUserByUsernameAsync = async (username: string) => {
+      return userModel.findByUsername(username);
+    };
+    (DatabaseService as any).checkPermissionAsync = async (userId: number, resource: string, action: string) => {
+      return permissionModel.check(userId, resource, action);
+    };
+    (DatabaseService as any).authenticateAsync = async (username: string, password: string) => {
+      return userModel.authenticate(username, password);
+    };
+    (DatabaseService as any).updatePasswordAsync = async (userId: number, newPassword: string) => {
+      return userModel.updatePassword(userId, newPassword);
+    };
+    (DatabaseService as any).getUserPermissionSetAsync = async (userId: number) => {
+      return permissionModel.getUserPermissionSet(userId);
+    };
 
     app.use('/api/auth', authRoutes);
     app.use('/api/users', userRoutes);

--- a/src/server/routes/v1/v1-api.test.ts
+++ b/src/server/routes/v1/v1-api.test.ts
@@ -108,11 +108,18 @@ vi.mock('../../../services/database.js', () => {
       getMessages: vi.fn(() => testMessages),
       getMessagesByChannel: vi.fn(() => testMessages),
       getMessagesAfterTimestamp: vi.fn(() => testMessages),
-      // Telemetry methods
+      // Telemetry methods (sync - legacy)
       getTelemetryByNode: vi.fn(() => testTelemetry),
       getTelemetryCountByNode: vi.fn(() => testTelemetry.length),
       getTelemetryByType: vi.fn(() => testTelemetry),
       getTelemetryCount: vi.fn(() => testTelemetry.length),
+      // Telemetry methods (async)
+      getTelemetryByNodeAsync: vi.fn(async () => testTelemetry),
+      getTelemetryCountByNodeAsync: vi.fn(async () => testTelemetry.length),
+      getTelemetryByTypeAsync: vi.fn(async () => testTelemetry),
+      getTelemetryCountAsync: vi.fn(async () => testTelemetry.length),
+      // Nodes async method
+      getAllNodesAsync: vi.fn(async () => testNodes),
       // Traceroutes methods
       getAllTraceroutes: vi.fn(() => testTraceroutes)
     }

--- a/src/server/utils/nodeEnhancer.test.ts
+++ b/src/server/utils/nodeEnhancer.test.ts
@@ -27,63 +27,63 @@ describe('nodeEnhancer: enhanceNodeForClient', () => {
   const regularUser = { username: 'user1' };
   const anonymousUser = { username: 'anonymous' };
 
-  it('should mask private override for anonymous user', () => {
-    const result = enhanceNodeForClient(mockNode, anonymousUser);
-    
+  it('should mask private override for anonymous user', async () => {
+    const result = await enhanceNodeForClient(mockNode, anonymousUser);
+
     // Should NOT use override position
     expect(result.position.latitude).toBe(10);
     expect(result.position.longitude).toBe(20);
     expect(result.positionIsOverride).toBe(false);
-    
+
     // Sensitive fields should be deleted
     expect(result.latitudeOverride).toBeUndefined();
     expect(result.longitudeOverride).toBeUndefined();
   });
 
-  it('should mask private override for logged-in user without permission', () => {
-    const result = enhanceNodeForClient(mockNode, regularUser);
-    
+  it('should mask private override for logged-in user without permission', async () => {
+    const result = await enhanceNodeForClient(mockNode, regularUser);
+
     expect(result.position.latitude).toBe(10);
     expect(result.positionIsOverride).toBe(false);
     expect(result.latitudeOverride).toBeUndefined();
   });
 
-  it('should show private override for user with permission', () => {
-    const result = enhanceNodeForClient(mockNode, adminUser);
-    
+  it('should show private override for user with permission', async () => {
+    const result = await enhanceNodeForClient(mockNode, adminUser);
+
     // Should use override position
     expect(result.position.latitude).toBe(30);
     expect(result.position.longitude).toBe(40);
     expect(result.positionIsOverride).toBe(true);
-    
+
     // Sensitive fields should be PRESERVED
     expect(result.latitudeOverride).toBe(30);
     expect(result.longitudeOverride).toBe(40);
   });
 
-  it('should show public override for everyone', () => {
+  it('should show public override for everyone', async () => {
     const publicNode = { ...mockNode, positionOverrideIsPrivate: 0 };
-    
-    const anonResult = enhanceNodeForClient(publicNode, anonymousUser);
+
+    const anonResult = await enhanceNodeForClient(publicNode, anonymousUser);
     expect(anonResult.position.latitude).toBe(30);
     expect(anonResult.positionIsOverride).toBe(true);
-    
-    const userResult = enhanceNodeForClient(publicNode, regularUser);
+
+    const userResult = await enhanceNodeForClient(publicNode, regularUser);
     expect(userResult.position.latitude).toBe(30);
   });
 
-  it('should fall back to estimated position if no regular position exists', () => {
+  it('should fall back to estimated position if no regular position exists', async () => {
     const nodeWithoutPos = {
       ...mockNode,
       position: null,
       positionOverrideEnabled: 0
     };
-    
+
     const estimatedPositions = new Map();
     estimatedPositions.set('!00000001', { latitude: 50, longitude: 60 });
-    
-    const result = enhanceNodeForClient(nodeWithoutPos, regularUser, estimatedPositions);
-    
+
+    const result = await enhanceNodeForClient(nodeWithoutPos, regularUser, estimatedPositions);
+
     expect(result.position.latitude).toBe(50);
     expect(result.position.longitude).toBe(60);
     expect(result.positionIsOverride).toBe(false);


### PR DESCRIPTION
## Summary
- Make nodeEnhancer tests async to match the now-async `enhanceNodeForClient` function signature
- Add async telemetry method mocks (`getTelemetryByNodeAsync`, `getTelemetryCountByNodeAsync`, etc.) to v1-api tests

These fixes address the test failures in the v3.0.0-beta6 release pipeline where:
1. `nodeEnhancer.test.ts` was calling an async function synchronously, resulting in undefined properties
2. `v1-api.test.ts` was missing mocks for the new async telemetry methods

## Test plan
- [ ] CI pipeline passes all tests
- [ ] nodeEnhancer tests pass
- [ ] v1-api tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)