### PR TITLE
feat(admin): Show session passkey status for remote nodes

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2807,6 +2807,7 @@
   "admin_commands.local_node_indicator": "Local",
   "admin_commands.local_node_no_passkey": "✓ Local node - no session passkey required",
   "admin_commands.remote_node_passkey": "✓ Remote node - session passkey will be requested automatically",
+  "admin_commands.remote_node_passkey_acquired": "✓ Remote node - session passkey acquired ({{seconds}}s remaining)",
   "admin_commands.please_select_node": "Please select a node",
 
   "admin_commands.set_owner": "Set Owner",

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7540,6 +7540,32 @@ class MeshtasticManager {
   }
 
   /**
+   * Get session passkey status for a node
+   * @param nodeNum Node number
+   * @returns Status object with hasPasskey, expiresAt timestamp, and remainingSeconds
+   */
+  getSessionPasskeyStatus(nodeNum: number): { hasPasskey: boolean; expiresAt: number | null; remainingSeconds: number | null } {
+    const localNodeNum = this.localNodeInfo?.nodeNum || 0;
+
+    if (nodeNum === 0 || nodeNum === localNodeNum) {
+      // Local node
+      if (this.sessionPasskey && this.sessionPasskeyExpiry && Date.now() < this.sessionPasskeyExpiry) {
+        const remainingSeconds = Math.max(0, Math.floor((this.sessionPasskeyExpiry - Date.now()) / 1000));
+        return { hasPasskey: true, expiresAt: this.sessionPasskeyExpiry, remainingSeconds };
+      }
+      return { hasPasskey: false, expiresAt: null, remainingSeconds: null };
+    } else {
+      // Remote node
+      const stored = this.remoteSessionPasskeys.get(nodeNum);
+      if (stored && Date.now() < stored.expiry) {
+        const remainingSeconds = Math.max(0, Math.floor((stored.expiry - Date.now()) / 1000));
+        return { hasPasskey: true, expiresAt: stored.expiry, remainingSeconds };
+      }
+      return { hasPasskey: false, expiresAt: null, remainingSeconds: null };
+    }
+  }
+
+  /**
    * Request session passkey from the device (local node)
    */
   async requestSessionPasskey(): Promise<void> {


### PR DESCRIPTION
## Summary
- Display session passkey status for remote nodes in Admin Commands
- Shows countdown timer when a passkey has been acquired
- Updates dynamically when Load is clicked on any section

## Changes

### Backend
- Added `getSessionPasskeyStatus()` method to meshtasticManager
- Updated `ensure-session-passkey` endpoint to return expiry info
- Added new `session-passkey-status` endpoint for status-only queries

### Frontend
- Added passkey status state with countdown timer
- Display shows:
  - Local node: "✓ Local node - no session passkey required"
  - Remote node (no passkey): "✓ Remote node - session passkey will be requested automatically"
  - Remote node (with passkey): "✓ Remote node - session passkey acquired (Xs remaining)" (green text)
- Countdown updates every second
- Status refreshes after each successful Load operation

## Test plan
- [ ] Select a remote node in Admin Commands
- [ ] Verify initial status shows "session passkey will be requested automatically"
- [ ] Click Load on any config section
- [ ] Verify status changes to "session passkey acquired (Xs remaining)" in green
- [ ] Verify countdown decrements every second
- [ ] Verify status resets to "will be requested" when countdown reaches 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)