### PR TITLE
fix(docker): Include reset-admin.mjs script in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,9 @@ COPY scripts/upgrade-watchdog.sh /app/scripts/upgrade-watchdog.sh
 COPY scripts/test-docker-socket.sh /app/scripts/test-docker-socket.sh
 RUN chmod +x /app/scripts/upgrade-watchdog.sh /app/scripts/test-docker-socket.sh
 
+# Copy admin password reset script
+COPY reset-admin.mjs /app/reset-admin.mjs
+
 # Create data directory for SQLite database and Apprise configs
 RUN mkdir -p /data/apprise-config /data/scripts && chown -R node:node /data
 


### PR DESCRIPTION
## Summary
The admin password reset script (`reset-admin.mjs`) was not being copied into the Docker image, causing errors when users tried to reset their admin password:

```
Error: Cannot find module '/app/reset-admin.mjs'
```

## Fix
Added `COPY reset-admin.mjs /app/reset-admin.mjs` to the Dockerfile.

## Workaround (for existing deployments)
Until the next release, users can manually copy the script:
```bash
docker cp reset-admin.mjs meshmonitor:/app/reset-admin.mjs
docker compose exec meshmonitor node /app/reset-admin.mjs
```

## Test plan
- [ ] Build Docker image
- [ ] Run `docker compose exec meshmonitor node /app/reset-admin.mjs`
- [ ] Verify password reset works

🤖 Generated with [Claude Code](https://claude.com/claude-code)