### PR TITLE
fix(virtual-node): Don't send config while radio is restarting

### DIFF
--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -562,6 +562,14 @@ export class VirtualNodeServer extends EventEmitter {
   private async sendInitialConfig(clientId: string, configId?: number): Promise<void> {
     logger.info(`Virtual node: Starting to send initial config to ${clientId}${configId ? ` (ID: ${configId})` : ''}`);
     try {
+      // Check if config capture is complete before sending anything
+      // This prevents sending partial/incomplete config when the radio is restarting
+      if (!this.config.meshtasticManager.isInitConfigCaptureComplete()) {
+        logger.warn(`Virtual node: Config capture not yet complete, cannot send config to ${clientId}`);
+        logger.warn(`Virtual node: Physical node may be restarting - client should retry after initialization completes`);
+        return;
+      }
+
       // Get cached init config with type metadata from meshtasticManager
       const cachedMessages = this.config.meshtasticManager.getCachedInitConfig();
 


### PR DESCRIPTION
## Summary

- Check `isInitConfigCaptureComplete()` before sending any config data to virtual node clients
- If config capture isn't complete (radio restarting), log a warning and return early without sending partial config
- Prevents clients (MQTT proxy, meshtastic CLI) from getting stuck in a reconnect loop

## Problem

When the physical radio restarts unexpectedly, the virtual node server would get stuck in a broken state:

1. Radio restarts → config capture resets to incomplete
2. Client connects and requests config (`wantConfigId`)
3. Virtual node sends partial config (missing local node info)
4. Client receives incomplete config → reports "connection LOST"
5. Client reconnects and requests again → same result → infinite loop

Even after the radio recovered, the virtual node remained stuck because clients kept rapidly reconnecting.

## Solution

Added a check at the start of `sendInitialConfig()` to verify that config capture is complete before sending anything. If the physical node is still initializing (radio restarting), we now:
- Log a warning explaining the situation
- Return early without sending any config
- Let the client retry after initialization completes

This prevents the broken state where partial config causes client reconnect loops.

Fixes #1443

## Test plan

- [ ] Build completes successfully
- [ ] Unit tests pass
- [ ] Verify virtual node rejects config requests during radio restart
- [ ] Verify virtual node works normally after radio initialization completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)