### PR TITLE
fix(messages): Set default height for messages container with internal scroll

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -768,11 +768,12 @@ body {
   /* Content determines height - parent nodes-main-content handles scrolling */
 }
 
-/* Desktop: messages container displays all messages, no internal scroll */
+/* Desktop: messages container scrolls internally with default height */
 .dm-conversation-panel .messages-container {
-  flex: none; /* Override flex: 1 - don't stretch, use natural height */
-  overflow-y: visible; /* Override overflow-y: auto - no internal scroll */
-  min-height: 100px;
+  flex: none; /* Don't stretch, use fixed height */
+  overflow-y: auto; /* Enable internal scrolling for lengthy conversations */
+  min-height: 200px;
+  height: 400px; /* Default height for messages area */
 }
 
 /* DM Resize Handle - hidden since page scrolls naturally now */


### PR DESCRIPTION
## Summary
- Sets a default 400px height for the messages container on desktop
- Enables internal scrolling (`overflow-y: auto`) so lengthy conversations scroll within the messages area
- Keeps the message input, action buttons, and telemetry graphs visible without excessive scrolling

This improves the UX by providing a consistent messages area size while still allowing the rest of the page content to remain accessible.

## Test plan
- [ ] Open a DM conversation with many messages
- [ ] Verify the messages area has a fixed height and scrolls internally
- [ ] Verify the send form and action buttons remain visible below the messages area

🤖 Generated with [Claude Code](https://claude.com/claude-code)