### PR TITLE
fix(i18n): Add missing channel edit translations

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3060,6 +3060,8 @@
   "admin_commands.downlink_enabled_description": "Allow this channel to receive messages from MQTT",
   "admin_commands.position_precision": "Location Precision (bits)",
   "admin_commands.position_precision_description": "Number of bits for position data (0-32). Higher = more precise. 32 = full precision.",
+  "admin_commands.edit_channel": "Edit Channel {{slot}}",
+  "admin_commands.save_channel": "Save Channel",
   "admin_commands.please_select_node_export": "Please select a node",
   "admin_commands.reboot_delay_label": "Reboot delay (seconds)",
   "admin_commands.reboot_device": "Reboot Device",


### PR DESCRIPTION
## Summary
- Adds two missing translation keys for the channel edit modal:
  - `admin_commands.edit_channel` - Modal title
  - `admin_commands.save_channel` - Save button text

Fixes remaining translation issues from #1420

## Test plan
- [ ] Open Admin Commands → Channel Configuration
- [ ] Click Edit on a channel
- [ ] Verify "Edit Channel X" title is displayed correctly
- [ ] Verify "Save Channel" button text is displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)