### PR TITLE
fix(desktop): Remove duplicate tray icon on Windows

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -12,10 +12,6 @@
   "app": {
     "withGlobalTauri": true,
     "windows": [],
-    "trayIcon": {
-      "iconPath": "icons/icon.png",
-      "iconAsTemplate": true
-    },
     "security": {
       "csp": null
     }


### PR DESCRIPTION
## Summary
- Removes the declarative `trayIcon` configuration from `tauri.conf.json`
- The tray icon was being created twice: once via config and once programmatically
- Keeping only the programmatic tray (`setup_tray()`) which has the proper menu and event handlers

Fixes #1413

## Root Cause
The `tauri.conf.json` had a `trayIcon` section that created one tray icon, and then `setup_tray()` in `main.rs` created a second one with the context menu. This resulted in two icons appearing in the Windows system tray.

## Test plan
- [ ] Build and run on Windows 10/11
- [ ] Verify only one tray icon appears
- [ ] Verify right-click menu works (Open, Settings, View Logs, etc.)
- [ ] Verify left-click opens the web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)