### PR TITLE
fix(ci): Add --legacy-peer-deps to npm ci commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Run linter
         run: npm run lint
@@ -81,7 +81,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Build frontend
         run: npm run build

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --prefer-offline --no-audit
+          npm ci --prefer-offline --no-audit --legacy-peer-deps
 
       - name: Check formatting
         run: |


### PR DESCRIPTION
## Summary
- Adds `--legacy-peer-deps` flag to all `npm ci` commands in CI workflows
- Resolves vitest peer dependency conflicts between @vitest/ui@4.0.16 and @vitest/coverage-v8@4.0.17
- Unblocks all Dependabot PRs which are currently failing due to ERESOLVE errors

## Background
The vitest ecosystem has conflicting peer dependencies:
- `@vitest/ui@4.0.16` requires `vitest@4.0.16`
- `@vitest/coverage-v8@4.0.17` requires `vitest@4.0.17`

This causes `npm ci` (which is strict about peer deps) to fail with ERESOLVE errors.

## Test plan
- [ ] PR CI passes with this change
- [ ] After merge, rebase Dependabot PRs and verify they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)