### PR TITLE
fix(cors): Allow X-CSRF-Token header in CORS configuration

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -211,6 +211,7 @@ app.use(
     },
     credentials: true,
     optionsSuccessStatus: 200,
+    allowedHeaders: ['Content-Type', 'X-CSRF-Token', 'Authorization'],
   })
 );
 


### PR DESCRIPTION
## Summary

- Fix CORS configuration to explicitly allow `X-CSRF-Token` header
- Resolves "Failed to save security configuration: Request failed" error when saving security config

## Root Cause

The CORS configuration was missing `allowedHeaders`, which caused browsers to strip custom headers like `X-CSRF-Token` from cross-origin requests. This resulted in CSRF validation failures with "No request token" errors.

## Changes

Added `allowedHeaders: ['Content-Type', 'X-CSRF-Token', 'Authorization']` to the CORS middleware configuration.

## Test plan

- [x] Reproduced the issue locally
- [x] Verified fix allows security config to save successfully
- [x] Confirmed CSRF token is now properly received by the server

Closes #1459

🤖 Generated with [Claude Code](https://claude.com/claude-code)