### PR TITLE
fix(i18n): Update purge warning to include local database

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1486,7 +1486,7 @@
   "config.reboot_sent_toast": "Reboot command sent!",
   "config.reboot_failed": "Failed to reboot device",
 
-  "config.purge_confirm": "Are you sure you want to purge the node database?\n\nThis will PERMANENTLY DELETE all stored node information from the device.\nThis action CANNOT be undone!\n\nThe device will automatically rebuild the database as it hears from nodes on the mesh.",
+  "config.purge_confirm": "Are you sure you want to purge the node database?\n\nThis will PERMANENTLY DELETE all stored node information from BOTH the device AND the local MeshMonitor database.\nThis action CANNOT be undone!\n\nThe device will automatically rebuild the database as it hears from nodes on the mesh.",
   "config.purge_success": "Node database purged successfully!",
   "config.purge_failed": "Failed to purge node database",
 


### PR DESCRIPTION
## Summary
- Updated the purge confirmation message to clarify that both the device's node database AND the local MeshMonitor database will be deleted
- This helps users understand the full impact of the purge operation before confirming

## Test plan
- [ ] Navigate to Admin -> Device Configuration
- [ ] Click "Purge Node Database"
- [ ] Verify the confirmation dialog mentions both the device and local MeshMonitor database

Closes #1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)