### PR TITLE
chore: Bump version to 3.0.0-RC4

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.0.0-RC3",
+  "version": "3.0.0-RC4",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.0.0-RC3
-appVersion: "3.0.0-RC3"
+version: 3.0.0-RC4
+appVersion: "3.0.0-RC4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.0.0-RC3",
+  "version": "3.0.0-RC4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.0.0-RC3",
+      "version": "3.0.0-RC4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.0.0-RC3",
+  "version": "3.0.0-RC4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump version to 3.0.0-RC4 in package.json, package-lock.json, Helm chart, and Tauri config

## Files Updated
- `package.json`
- `package-lock.json`
- `helm/meshmonitor/Chart.yaml`
- `desktop/src-tauri/tauri.conf.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)