### PR TITLE
fix(database): Add logging for mark-as-read operations

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -7385,12 +7385,19 @@ class DatabaseService {
   }
 
   markChannelMessagesAsRead(channelId: number, userId: number | null, beforeTimestamp?: number): number {
+    logger.info(`[DatabaseService] markChannelMessagesAsRead called: channel=${channelId}, userId=${userId}, dbType=${this.drizzleDbType}`);
     // For PostgreSQL/MySQL, use async repo
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (this.notificationsRepo) {
-        this.notificationsRepo.markChannelMessagesAsRead(channelId, userId, beforeTimestamp).catch((error) => {
-          logger.debug(`[DatabaseService] Mark channel messages as read failed: ${error}`);
-        });
+        this.notificationsRepo.markChannelMessagesAsRead(channelId, userId, beforeTimestamp)
+          .then((count) => {
+            logger.info(`[DatabaseService] Marked ${count} channel ${channelId} messages as read for user ${userId}`);
+          })
+          .catch((error) => {
+            logger.error(`[DatabaseService] Mark channel messages as read failed: ${error}`);
+          });
+      } else {
+        logger.warn(`[DatabaseService] notificationsRepo is null, cannot mark messages as read`);
       }
       return 0; // Return 0 since we don't wait for the async result
     }
@@ -7413,12 +7420,19 @@ class DatabaseService {
   }
 
   markDMMessagesAsRead(localNodeId: string, remoteNodeId: string, userId: number | null, beforeTimestamp?: number): number {
+    logger.info(`[DatabaseService] markDMMessagesAsRead called: local=${localNodeId}, remote=${remoteNodeId}, userId=${userId}`);
     // For PostgreSQL/MySQL, use async repo
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (this.notificationsRepo) {
-        this.notificationsRepo.markDMMessagesAsRead(localNodeId, remoteNodeId, userId, beforeTimestamp).catch((error) => {
-          logger.debug(`[DatabaseService] Mark DM messages as read failed: ${error}`);
-        });
+        this.notificationsRepo.markDMMessagesAsRead(localNodeId, remoteNodeId, userId, beforeTimestamp)
+          .then((count) => {
+            logger.info(`[DatabaseService] Marked ${count} DM messages as read for user ${userId}`);
+          })
+          .catch((error) => {
+            logger.error(`[DatabaseService] Mark DM messages as read failed: ${error}`);
+          });
+      } else {
+        logger.warn(`[DatabaseService] notificationsRepo is null, cannot mark DM messages as read`);
       }
       return 0; // Return 0 since we don't wait for the async result
     }


### PR DESCRIPTION
## Summary

- Add INFO level logging for mark-as-read operations to help debug unread indicator issues
- Log errors at ERROR level instead of DEBUG for better visibility
- Warn if notificationsRepo is null

## Changes

- Log when `markChannelMessagesAsRead` is called with channel ID, user ID, and database type
- Log when `markDMMessagesAsRead` is called with node IDs and user ID
- Log success with count of messages marked as read
- Upgrade error logging from DEBUG to ERROR level

## Test plan

- [x] Verified logging appears when clicking on channels
- [x] Verified messages are being marked as read (60 messages in channel 0, 34 in channel 2)
- [x] Unread indicator clears correctly after viewing channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)