### PR TITLE
fix(migration): Drop default before changing column type in PostgreSQL

### DIFF
--- a/src/server/migrations/047_fix_position_override_boolean_types.ts
+++ b/src/server/migrations/047_fix_position_override_boolean_types.ts
@@ -62,6 +62,12 @@ export async function runMigration047Postgres(client: import('pg').PoolClient): 
       if (data_type === 'integer' || data_type === 'bigint') {
         logger.debug(`Converting ${column_name} from ${data_type} to BOOLEAN`);
 
+        // First, drop the default constraint (required before type change in PostgreSQL)
+        await client.query(`
+          ALTER TABLE nodes
+          ALTER COLUMN "${column_name}" DROP DEFAULT
+        `);
+
         // PostgreSQL can cast integer to boolean (0 = false, non-zero = true)
         await client.query(`
           ALTER TABLE nodes


### PR DESCRIPTION
## Summary
Fix migration 047 failing on PostgreSQL with "default cannot be cast automatically to type boolean".

## Problem
PostgreSQL requires dropping the DEFAULT constraint before changing a column's type. The migration was trying to change `INTEGER` to `BOOLEAN` while the default value was still set.

## Fix
Added `ALTER COLUMN ... DROP DEFAULT` before the `TYPE BOOLEAN` change.

## Test plan
- [ ] Deploy to PostgreSQL environment
- [ ] Verify migration completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)