### PR TITLE
fix(info): Show most recent message timestamp in Recent Activity

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4106,6 +4106,7 @@ function App() {
             nodes={nodes}
             channels={channels}
             messages={messages}
+            channelMessages={channelMessages}
             currentNodeId={currentNodeId}
             temperatureUnit={temperatureUnit}
             telemetryHours={telemetryVisualizationHours}

--- a/src/components/InfoTab.tsx
+++ b/src/components/InfoTab.tsx
@@ -117,6 +117,7 @@ interface InfoTabProps {
   nodes: DeviceInfo[];
   channels: Channel[];
   messages: MeshMessage[];
+  channelMessages?: { [key: number]: MeshMessage[] };
   currentNodeId: string;
   temperatureUnit: TemperatureUnit;
   telemetryHours: number;
@@ -136,6 +137,7 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
   nodes,
   channels,
   messages,
+  channelMessages = {},
   currentNodeId,
   temperatureUnit,
   telemetryHours,
@@ -601,7 +603,18 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
 
         <div className="info-section">
           <h3>{t('info.recent_activity')}</h3>
-          <p><strong>{t('info.last_message')}</strong> {messages.length > 0 ? formatDateTime(messages[0].timestamp, timeFormat, dateFormat) : t('common.none')}</p>
+          <p><strong>{t('info.last_message')}</strong> {(() => {
+            // Combine all messages from DMs and all channels
+            const allMessages = [
+              ...messages,
+              ...Object.values(channelMessages).flat()
+            ];
+            if (allMessages.length === 0) return t('common.none');
+            const mostRecent = allMessages.reduce((latest, msg) =>
+              msg.timestamp.getTime() > latest.timestamp.getTime() ? msg : latest
+            );
+            return formatDateTime(mostRecent.timestamp, timeFormat, dateFormat);
+          })()}</p>
           <p><strong>{t('info.most_active_node')}</strong> {
             nodes.length > 0 ?
             nodes.reduce((prev, current) =>


### PR DESCRIPTION
## Summary
- Fixes the "Last Message" field in the Recent Activity section on the Info Panel showing a stale date from several days ago
- The issue was that `messages[0]` was used assuming the first element was the most recent, but the array wasn't guaranteed to be sorted by timestamp
- Now uses `reduce()` to find the message with the highest timestamp

## Test plan
- [ ] Open the Info tab and verify "Recent Activity > Last Message" shows the correct recent timestamp
- [ ] Send a new message and verify the timestamp updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)