### PR TITLE
fix(virtual-node): Prevent PKI key corruption from addContact messages

### DIFF
--- a/src/server/meshtasticProtobufService.ts
+++ b/src/server/meshtasticProtobufService.ts
@@ -1003,13 +1003,13 @@ export class MeshtasticProtobufService {
       const DeviceMetrics = root.lookupType('meshtastic.DeviceMetrics');
       const FromRadio = root.lookupType('meshtastic.FromRadio');
 
-      // Convert hex string publicKey to Uint8Array if present
+      // Convert base64 publicKey to Uint8Array if present
+      // Note: Public keys are stored as base64 in the database
       let publicKeyBytes: Uint8Array | undefined;
       if (info.user.publicKey && info.user.publicKey.length > 0) {
         try {
-          // Remove any whitespace and convert hex string to bytes
-          const hexStr = info.user.publicKey.replace(/\s/g, '');
-          publicKeyBytes = new Uint8Array(hexStr.match(/.{1,2}/g)?.map(byte => parseInt(byte, 16)) || []);
+          // Decode base64 string to bytes
+          publicKeyBytes = new Uint8Array(Buffer.from(info.user.publicKey, 'base64'));
         } catch (error) {
           logger.warn(`Failed to convert publicKey to bytes for node ${info.user.id}:`, error);
         }


### PR DESCRIPTION
## Summary
Fixes two bugs that caused Virtual Node clients (iOS Meshtastic app) to corrupt the physical node's PKI key store:

1. **Fixed base64 vs hex encoding mismatch** (`meshtasticProtobufService.ts`)
   - `createNodeInfo()` was treating public keys as hex strings, but the database stores them as base64
   - This caused garbage public keys to be sent to Virtual Node clients
   - iOS app would then generate placeholder keys for nodes with invalid keys

2. **Block addContact admin messages** (`virtualNodeServer.ts`)
   - Self-addressed admin commands were allowed through without inspection
   - `addContact` messages contain public keys that can overwrite valid keys on the physical node
   - Now decodes self-addressed ADMIN_APP messages to check for and block `addContact`

## Root cause analysis
When an iOS Meshtastic app connects to the Virtual Node:
1. MeshMonitor sends NodeInfo with corrupted public keys (hex decode of base64 = garbage)
2. iOS app receives invalid keys, generates placeholder garbage keys
3. When iOS app sends a DM, it first sends `addContact` with the garbage key
4. `addContact` is self-addressed (from === to), so it bypassed filtering
5. MeshMonitor forwarded it to the physical node, corrupting its key store
6. All subsequent PKI-encrypted DMs to that node fail with `PKI_FAILED (34)`

## Test plan
- [x] Unit tests pass (84 test files, 1923 tests)
- [ ] Manual test with iOS Meshtastic app connecting to Virtual Node
- [ ] Verify public keys are correctly sent to Virtual Node clients
- [ ] Verify DMs from iOS app work without corrupting PKI keys

Fixes #1487

🤖 Generated with [Claude Code](https://claude.com/claude-code)