### PR TITLE
fix(telemetry): Clarify device-reported node counts in graph labels

### DIFF
--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -77,6 +77,19 @@ const TELEMETRY_LABELS: Record<string, string> = {
   paxcounterWifi: 'Paxcounter WiFi',
   paxcounterBle: 'Paxcounter BLE',
   paxcounterUptime: 'Paxcounter Uptime',
+  // LocalStats metrics (from connected Meshtastic device)
+  uptimeSeconds: 'Device Uptime',
+  numOnlineNodes: 'Online Nodes (Device)',
+  numTotalNodes: 'Total Nodes (Device)',
+  numPacketsTx: 'Packets TX (Device)',
+  numPacketsRx: 'Packets RX (Device)',
+  numPacketsRxBad: 'Bad Packets RX (Device)',
+  numRxDupe: 'Duplicate Packets (Device)',
+  numTxRelay: 'Relayed TX (Device)',
+  numTxRelayCanceled: 'Canceled Relay TX (Device)',
+  numTxDropped: 'Dropped TX (Device)',
+  heapTotalBytes: 'Heap Total (Device)',
+  heapFreeBytes: 'Heap Free (Device)',
 };
 
 // Export for external use (returns English labels for sorting/filtering compatibility)

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -399,6 +399,25 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
         paxcounterWifi: 'Paxcounter WiFi',
         paxcounterBle: 'Paxcounter BLE',
         paxcounterUptime: 'Paxcounter Uptime',
+        // LocalStats metrics (from connected Meshtastic device)
+        uptimeSeconds: 'Device Uptime',
+        numOnlineNodes: 'Online Nodes (Device)',
+        numTotalNodes: 'Total Nodes (Device)',
+        numPacketsTx: 'Packets TX (Device)',
+        numPacketsRx: 'Packets RX (Device)',
+        numPacketsRxBad: 'Bad Packets RX (Device)',
+        numRxDupe: 'Duplicate Packets (Device)',
+        numTxRelay: 'Relayed TX (Device)',
+        numTxRelayCanceled: 'Canceled Relay TX (Device)',
+        numTxDropped: 'Dropped TX (Device)',
+        heapTotalBytes: 'Heap Total (Device)',
+        heapFreeBytes: 'Heap Free (Device)',
+        // HostMetrics (for Linux devices)
+        hostUptimeSeconds: 'Host Uptime',
+        hostFreememBytes: 'Host Free Memory',
+        hostLoad1: 'Host Load (1 min)',
+        hostLoad5: 'Host Load (5 min)',
+        hostLoad15: 'Host Load (15 min)',
       };
       return labels[type] || type;
     };


### PR DESCRIPTION
## Summary

- Add "(Device)" suffix to LocalStats telemetry labels to clarify data source
- Addresses user confusion where Info page graphs show different node counts than the map or `{NODECOUNT}` token

### The Issue

Users reported confusion when:
- Map shows 90 nodes
- Info page graphs show 45 online, 80 total
- `{NODECOUNT}` token shows 90

### The Explanation

These are measuring different things:
| Source | What it measures |
|--------|------------------|
| Map / `{NODECOUNT}` | MeshMonitor's database |
| Info page graphs | Device's LocalStats (`numOnlineNodes`, `numTotalNodes`) |

The Meshtastic device maintains its own node database which can differ from MeshMonitor's due to different retention policies, device resets, etc.

### The Fix

Updated graph labels to clarify the source:
- `numOnlineNodes` → **"Online Nodes (Device)"**
- `numTotalNodes` → **"Total Nodes (Device)"**
- Plus all other LocalStats/HostMetrics with appropriate suffixes

## Test plan

- [x] Build passes
- [ ] Verify Info page graphs show "(Device)" suffix on node count labels
- [ ] Verify Dashboard telemetry charts show updated labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)