### PR TITLE
feat(ui): increase font size for hop count and message time

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1200,7 +1200,7 @@ body {
 
 .message-time {
   color: var(--ctp-overlay2);
-  font-size: 0.8rem;
+  font-size: 0.9rem;
   margin-left: auto;
   font-family: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
 }
@@ -2280,7 +2280,7 @@ body {
 }
 
 .message-bubble .message-time {
-  font-size: 0.7rem;
+  font-size: 0.85rem;
   margin-top: 0.25rem;
   opacity: 0.7;
   text-align: right;
@@ -3839,7 +3839,7 @@ body {
 }
 
 .hop-count {
-  font-size: 11px;
+  font-size: 0.85rem;
   color: var(--ctp-overlay1);
   font-style: italic;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
Improved readability of hop count and message timestamps in the Channels panel by increasing font sizes.

## Changes
| Class | Before | After |
|-------|--------|-------|
| `.message-time` | 0.8rem (~13px) | 0.9rem (~14px) |
| `.message-bubble .message-time` | 0.7rem (~11px) | 0.85rem (~14px) |
| `.hop-count` | 11px | 0.85rem (~14px) |

## Test Plan
- [ ] View Channels tab and verify message timestamps are more readable
- [ ] Verify hop count display is larger and easier to read
- [ ] Check that the layout still looks balanced

Fixes #1433

🤖 Generated with [Claude Code](https://claude.com/claude-code)