### PR TITLE
fix(map): apply node filters to accuracy and uncertainty circles

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1606,7 +1606,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
               {/* Draw uncertainty circles for estimated positions */}
               {showEstimatedPositions && nodesWithPosition
-                .filter(node => node.user?.id && nodesWithEstimatedPosition.has(node.user.id))
+                .filter(node => node.user?.id && nodesWithEstimatedPosition.has(node.user.id) && (showMqttNodes || !node.viaMqtt) && (showIncompleteNodes || isNodeComplete(node)))
                 .map(node => {
                   // Calculate radius based on precision bits (higher precision = smaller circle)
                   // Meshtastic uses precision_bits to reduce coordinate precision
@@ -1639,7 +1639,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
               {/* Draw position accuracy circles for all nodes with precision data */}
               {showAccuracyCircles && nodesWithPosition
-                .filter(node => node.positionPrecisionBits !== undefined && node.positionPrecisionBits !== null && node.positionPrecisionBits > 0 && node.positionPrecisionBits < 32)
+                .filter(node => node.positionPrecisionBits !== undefined && node.positionPrecisionBits !== null && node.positionPrecisionBits > 0 && node.positionPrecisionBits < 32 && (showMqttNodes || !node.viaMqtt) && (showIncompleteNodes || isNodeComplete(node)))
                 .map(node => {
                   // Convert precision_bits to radius in meters
                   // precision_bits indicates how many bits of lat/lon are valid


### PR DESCRIPTION
## Summary
Accuracy circles and uncertainty circles were not respecting the same filters as node markers, causing circles to appear where no node pin was visible.

## Root Cause
When "Hide incomplete nodes" or "Hide MQTT nodes" filters were enabled, node markers were hidden but their associated accuracy/uncertainty circles still rendered on the map.

## Changes
Added the same filtering conditions to both circle renderers in `NodesTab.tsx`:
- `(showMqttNodes || !node.viaMqtt)` - respects MQTT node filter
- `(showIncompleteNodes || isNodeComplete(node))` - respects incomplete nodes filter

## Test Plan
- [ ] Enable "Show Accuracy Circles" on the map
- [ ] Enable "Hide incomplete nodes" in settings
- [ ] Verify that accuracy circles only appear for visible nodes
- [ ] Verify no orphan circles appear where nodes are hidden

Fixes #1411

🤖 Generated with [Claude Code](https://claude.com/claude-code)