### PR TITLE
docs: update Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ This project is licensed under the BSD-3-Clause License - see the [LICENSE](LICE
 
 ## Community & Support
 
-- **Discord**: [Join our Discord](https://discord.gg/aeeQbKN5) - Chat with the community and get help
+- **Discord**: [Join our Discord](https://discord.gg/JVR3VBETQE) - Chat with the community and get help
 - **GitHub Issues**: Report bugs and request features
 - **Documentation**: [meshmonitor.org](https://meshmonitor.org/)
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -103,7 +103,7 @@ export default defineConfig({
     },
 
     socialLinks: [
-      { icon: 'discord', link: 'https://discord.gg/SdMfbmTGH' },
+      { icon: 'discord', link: 'https://discord.gg/JVR3VBETQE' },
       { icon: 'github', link: 'https://github.com/yeraze/meshmonitor' }
     ],
 

--- a/docs/development/claude-getting-started.md
+++ b/docs/development/claude-getting-started.md
@@ -508,7 +508,7 @@ meshmonitor/
 
 - **Documentation**: https://meshmonitor.org/
 - **GitHub Issues**: https://github.com/Yeraze/meshmonitor/issues
-- **Discord**: https://discord.gg/SdMfbmTGH
+- **Discord**: https://discord.gg/JVR3VBETQE
 - **FAQ**: [/faq](/faq)
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,7 +157,7 @@ Manage users, permissions, and authentication with a comprehensive admin interfa
 
 ## Community & Support
 
-- **Discord**: [Join our Discord](https://discord.gg/SdMfbmTGH) - Chat with the community and get help
+- **Discord**: [Join our Discord](https://discord.gg/JVR3VBETQE) - Chat with the community and get help
 - **GitHub**: [github.com/yeraze/meshmonitor](https://github.com/yeraze/meshmonitor)
 - **Issues**: Report bugs and request features on GitHub Issues
 - **License**: BSD-3-Clause


### PR DESCRIPTION
## Summary
- Update Discord invite link to https://discord.gg/JVR3VBETQE across all documentation and configuration files

## Files Changed
- `README.md` - Main readme
- `docs/.vitepress/config.mts` - VitePress social link icon
- `docs/index.md` - Documentation homepage
- `docs/development/claude-getting-started.md` - Getting started guide

## Test plan
- [ ] Verify Discord link in VitePress site header navigates to correct server
- [ ] Verify Discord links in documentation pages work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)