### PR TITLE
fix: upgrade service now works with PostgreSQL and MySQL

### DIFF
--- a/src/db/repositories/index.ts
+++ b/src/db/repositories/index.ts
@@ -28,4 +28,4 @@ export type {
   PushSubscriptionInput,
 } from './notifications.js';
 export { MiscRepository } from './misc.js';
-export type { SolarEstimate, AutoTracerouteNode } from './misc.js';
+export type { SolarEstimate, AutoTracerouteNode, UpgradeHistoryRecord, NewUpgradeHistory } from './misc.js';

--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -4,7 +4,7 @@
  * Handles solar estimates and auto-traceroute nodes database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, desc, asc, and, gte, lte } from 'drizzle-orm';
+import { eq, desc, asc, and, gte, lte, lt, inArray, sql } from 'drizzle-orm';
 import {
   solarEstimatesSqlite,
   solarEstimatesPostgres,
@@ -12,6 +12,9 @@ import {
   autoTracerouteNodesSqlite,
   autoTracerouteNodesPostgres,
   autoTracerouteNodesMysql,
+  upgradeHistorySqlite,
+  upgradeHistoryPostgres,
+  upgradeHistoryMysql,
 } from '../schema/misc.js';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType } from '../types.js';
@@ -29,6 +32,37 @@ export interface AutoTracerouteNode {
   nodeNum: number;
   enabled?: boolean;
   createdAt: number;
+}
+
+export interface UpgradeHistoryRecord {
+  id: string;
+  fromVersion: string;
+  toVersion: string;
+  deploymentMethod: string;
+  status: string;
+  progress?: number | null;
+  currentStep?: string | null;
+  logs?: string | null;
+  backupPath?: string | null;
+  startedAt?: number | null;
+  completedAt?: number | null;
+  initiatedBy?: string | null;
+  errorMessage?: string | null;
+  rollbackAvailable?: boolean | null;
+}
+
+export interface NewUpgradeHistory {
+  id: string;
+  fromVersion: string;
+  toVersion: string;
+  deploymentMethod: string;
+  status: string;
+  progress?: number;
+  currentStep?: string;
+  logs?: string;
+  startedAt?: number;
+  initiatedBy?: string;
+  rollbackAvailable?: boolean;
 }
 
 /**
@@ -290,6 +324,344 @@ export class MiscRepository extends BaseRepository {
     } else {
       const db = this.getPostgresDb();
       await db.delete(autoTracerouteNodesPostgres).where(eq(autoTracerouteNodesPostgres.nodeNum, nodeNum));
+    }
+  }
+
+  // ============ UPGRADE HISTORY ============
+
+  // Status values that indicate an upgrade is in progress
+  private readonly IN_PROGRESS_STATUSES = ['pending', 'backing_up', 'downloading', 'restarting', 'health_check'];
+
+  /**
+   * Create a new upgrade history record
+   */
+  async createUpgradeHistory(upgrade: NewUpgradeHistory): Promise<void> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      await db.insert(upgradeHistorySqlite).values({
+        id: upgrade.id,
+        fromVersion: upgrade.fromVersion,
+        toVersion: upgrade.toVersion,
+        deploymentMethod: upgrade.deploymentMethod,
+        status: upgrade.status,
+        progress: upgrade.progress ?? 0,
+        currentStep: upgrade.currentStep,
+        logs: upgrade.logs,
+        startedAt: upgrade.startedAt,
+        initiatedBy: upgrade.initiatedBy,
+        rollbackAvailable: upgrade.rollbackAvailable,
+      });
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      await db.insert(upgradeHistoryMysql).values({
+        id: upgrade.id,
+        fromVersion: upgrade.fromVersion,
+        toVersion: upgrade.toVersion,
+        deploymentMethod: upgrade.deploymentMethod,
+        status: upgrade.status,
+        progress: upgrade.progress ?? 0,
+        currentStep: upgrade.currentStep,
+        logs: upgrade.logs,
+        startedAt: upgrade.startedAt,
+        initiatedBy: upgrade.initiatedBy,
+        rollbackAvailable: upgrade.rollbackAvailable,
+      });
+    } else {
+      const db = this.getPostgresDb();
+      await db.insert(upgradeHistoryPostgres).values({
+        id: upgrade.id,
+        fromVersion: upgrade.fromVersion,
+        toVersion: upgrade.toVersion,
+        deploymentMethod: upgrade.deploymentMethod,
+        status: upgrade.status,
+        progress: upgrade.progress ?? 0,
+        currentStep: upgrade.currentStep,
+        logs: upgrade.logs,
+        startedAt: upgrade.startedAt,
+        initiatedBy: upgrade.initiatedBy,
+        rollbackAvailable: upgrade.rollbackAvailable,
+      });
+    }
+  }
+
+  /**
+   * Get upgrade history record by ID
+   */
+  async getUpgradeById(id: string): Promise<UpgradeHistoryRecord | null> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const results = await db
+        .select()
+        .from(upgradeHistorySqlite)
+        .where(eq(upgradeHistorySqlite.id, id))
+        .limit(1);
+      return results.length > 0 ? this.normalizeBigInts(results[0]) : null;
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      const results = await db
+        .select()
+        .from(upgradeHistoryMysql)
+        .where(eq(upgradeHistoryMysql.id, id))
+        .limit(1);
+      return results.length > 0 ? this.normalizeBigInts(results[0]) : null;
+    } else {
+      const db = this.getPostgresDb();
+      const results = await db
+        .select()
+        .from(upgradeHistoryPostgres)
+        .where(eq(upgradeHistoryPostgres.id, id))
+        .limit(1);
+      return results.length > 0 ? this.normalizeBigInts(results[0]) : null;
+    }
+  }
+
+  /**
+   * Get upgrade history (most recent first)
+   */
+  async getUpgradeHistoryList(limit: number = 10): Promise<UpgradeHistoryRecord[]> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const results = await db
+        .select()
+        .from(upgradeHistorySqlite)
+        .orderBy(desc(upgradeHistorySqlite.startedAt))
+        .limit(limit);
+      return this.normalizeBigInts(results);
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      const results = await db
+        .select()
+        .from(upgradeHistoryMysql)
+        .orderBy(desc(upgradeHistoryMysql.startedAt))
+        .limit(limit);
+      return this.normalizeBigInts(results);
+    } else {
+      const db = this.getPostgresDb();
+      const results = await db
+        .select()
+        .from(upgradeHistoryPostgres)
+        .orderBy(desc(upgradeHistoryPostgres.startedAt))
+        .limit(limit);
+      return this.normalizeBigInts(results);
+    }
+  }
+
+  /**
+   * Get the most recent upgrade record
+   */
+  async getLastUpgrade(): Promise<UpgradeHistoryRecord | null> {
+    const results = await this.getUpgradeHistoryList(1);
+    return results.length > 0 ? results[0] : null;
+  }
+
+  /**
+   * Find stale upgrades (stuck for too long)
+   */
+  async findStaleUpgrades(staleThreshold: number): Promise<UpgradeHistoryRecord[]> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const results = await db
+        .select()
+        .from(upgradeHistorySqlite)
+        .where(
+          and(
+            inArray(upgradeHistorySqlite.status, this.IN_PROGRESS_STATUSES),
+            lt(upgradeHistorySqlite.startedAt, staleThreshold)
+          )
+        );
+      return this.normalizeBigInts(results);
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      const results = await db
+        .select()
+        .from(upgradeHistoryMysql)
+        .where(
+          and(
+            inArray(upgradeHistoryMysql.status, this.IN_PROGRESS_STATUSES),
+            lt(upgradeHistoryMysql.startedAt, staleThreshold)
+          )
+        );
+      return this.normalizeBigInts(results);
+    } else {
+      const db = this.getPostgresDb();
+      const results = await db
+        .select()
+        .from(upgradeHistoryPostgres)
+        .where(
+          and(
+            inArray(upgradeHistoryPostgres.status, this.IN_PROGRESS_STATUSES),
+            lt(upgradeHistoryPostgres.startedAt, staleThreshold)
+          )
+        );
+      return this.normalizeBigInts(results);
+    }
+  }
+
+  /**
+   * Count in-progress upgrades (non-stale)
+   */
+  async countInProgressUpgrades(staleThreshold: number): Promise<number> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const result = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(upgradeHistorySqlite)
+        .where(
+          and(
+            inArray(upgradeHistorySqlite.status, this.IN_PROGRESS_STATUSES),
+            gte(upgradeHistorySqlite.startedAt, staleThreshold)
+          )
+        );
+      return Number(result[0]?.count ?? 0);
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      const result = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(upgradeHistoryMysql)
+        .where(
+          and(
+            inArray(upgradeHistoryMysql.status, this.IN_PROGRESS_STATUSES),
+            gte(upgradeHistoryMysql.startedAt, staleThreshold)
+          )
+        );
+      return Number(result[0]?.count ?? 0);
+    } else {
+      const db = this.getPostgresDb();
+      const result = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(upgradeHistoryPostgres)
+        .where(
+          and(
+            inArray(upgradeHistoryPostgres.status, this.IN_PROGRESS_STATUSES),
+            gte(upgradeHistoryPostgres.startedAt, staleThreshold)
+          )
+        );
+      return Number(result[0]?.count ?? 0);
+    }
+  }
+
+  /**
+   * Find the currently active upgrade (if any)
+   */
+  async findActiveUpgrade(staleThreshold: number): Promise<UpgradeHistoryRecord | null> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const results = await db
+        .select()
+        .from(upgradeHistorySqlite)
+        .where(
+          and(
+            inArray(upgradeHistorySqlite.status, this.IN_PROGRESS_STATUSES),
+            gte(upgradeHistorySqlite.startedAt, staleThreshold)
+          )
+        )
+        .orderBy(desc(upgradeHistorySqlite.startedAt))
+        .limit(1);
+      return results.length > 0 ? this.normalizeBigInts(results[0]) : null;
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      const results = await db
+        .select()
+        .from(upgradeHistoryMysql)
+        .where(
+          and(
+            inArray(upgradeHistoryMysql.status, this.IN_PROGRESS_STATUSES),
+            gte(upgradeHistoryMysql.startedAt, staleThreshold)
+          )
+        )
+        .orderBy(desc(upgradeHistoryMysql.startedAt))
+        .limit(1);
+      return results.length > 0 ? this.normalizeBigInts(results[0]) : null;
+    } else {
+      const db = this.getPostgresDb();
+      const results = await db
+        .select()
+        .from(upgradeHistoryPostgres)
+        .where(
+          and(
+            inArray(upgradeHistoryPostgres.status, this.IN_PROGRESS_STATUSES),
+            gte(upgradeHistoryPostgres.startedAt, staleThreshold)
+          )
+        )
+        .orderBy(desc(upgradeHistoryPostgres.startedAt))
+        .limit(1);
+      return results.length > 0 ? this.normalizeBigInts(results[0]) : null;
+    }
+  }
+
+  /**
+   * Mark an upgrade as failed
+   */
+  async markUpgradeFailed(id: string, errorMessage: string): Promise<void> {
+    const now = this.now();
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      await db
+        .update(upgradeHistorySqlite)
+        .set({
+          status: 'failed',
+          completedAt: now,
+          errorMessage: errorMessage,
+        })
+        .where(eq(upgradeHistorySqlite.id, id));
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      await db
+        .update(upgradeHistoryMysql)
+        .set({
+          status: 'failed',
+          completedAt: now,
+          errorMessage: errorMessage,
+        })
+        .where(eq(upgradeHistoryMysql.id, id));
+    } else {
+      const db = this.getPostgresDb();
+      await db
+        .update(upgradeHistoryPostgres)
+        .set({
+          status: 'failed',
+          completedAt: now,
+          errorMessage: errorMessage,
+        })
+        .where(eq(upgradeHistoryPostgres.id, id));
+    }
+  }
+
+  /**
+   * Mark an upgrade as complete
+   */
+  async markUpgradeComplete(id: string): Promise<void> {
+    const now = this.now();
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      await db
+        .update(upgradeHistorySqlite)
+        .set({
+          status: 'complete',
+          completedAt: now,
+          currentStep: 'Upgrade complete',
+        })
+        .where(eq(upgradeHistorySqlite.id, id));
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      await db
+        .update(upgradeHistoryMysql)
+        .set({
+          status: 'complete',
+          completedAt: now,
+          currentStep: 'Upgrade complete',
+        })
+        .where(eq(upgradeHistoryMysql.id, id));
+    } else {
+      const db = this.getPostgresDb();
+      await db
+        .update(upgradeHistoryPostgres)
+        .set({
+          status: 'complete',
+          completedAt: now,
+          currentStep: 'Upgrade complete',
+        })
+        .where(eq(upgradeHistoryPostgres.id, id));
     }
   }
 }


### PR DESCRIPTION
## Summary

- Fixed `UpgradeService` failing on PostgreSQL/MySQL with error: "SQLite method 'prepare' called but using postgres database"
- Added upgrade history methods to `MiscRepository` using Drizzle ORM for cross-database support
- Replaced all 11 `db.prepare()` calls in `upgradeService.ts` with async repository methods

## Changes

**`src/db/repositories/misc.ts`**
- Added `UpgradeHistoryRecord` and `NewUpgradeHistory` interfaces
- Added repository methods: `createUpgradeHistory`, `getUpgradeById`, `getUpgradeHistoryList`, `getLastUpgrade`, `findStaleUpgrades`, `countInProgressUpgrades`, `findActiveUpgrade`, `markUpgradeFailed`, `markUpgradeComplete`

**`src/server/services/upgradeService.ts`**
- Replaced all SQLite-specific `db.prepare()` calls with `databaseService.miscRepo` methods
- Removed the early return for PostgreSQL/MySQL in `getActiveUpgrade()` since it now works on all databases

**`src/db/repositories/index.ts`**
- Exported new types

## Test plan

- [x] TypeScript compilation passes
- [x] Unit tests pass (84 files, 1937 tests)
- [ ] Manual test: Trigger upgrade on PostgreSQL deployment (user's production instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)