### PR TITLE
feat: enhance traceroute visualization with focused view and distinct path colors

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4422,6 +4422,29 @@ body {
   font-weight: 500;
 }
 
+/* Dismiss traceroute button */
+.dismiss-traceroute-btn {
+  background: var(--ctp-surface1);
+  color: var(--ctp-text);
+  border: 1px solid var(--ctp-overlay0);
+  border-radius: 4px;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s;
+  margin: 0.25rem 0;
+}
+
+.dismiss-traceroute-btn:hover {
+  background: var(--ctp-surface2);
+  border-color: var(--ctp-mauve);
+}
+
+.dismiss-traceroute-btn:active {
+  background: var(--ctp-overlay0);
+}
+
 /* Map controls title */
 .map-controls-header {
   position: relative;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -345,6 +345,7 @@ function App() {
   const [themeColors, setThemeColors] = useState({
     mauve: '#cba6f7', // Default to Mocha theme colors
     red: '#f38ba8',
+    blue: '#89b4fa', // For forward traceroute path
     overlay0: '#6c7086', // For MQTT segments (muted gray)
   });
 
@@ -353,10 +354,11 @@ function App() {
     const rootStyle = getComputedStyle(document.documentElement);
     const mauve = rootStyle.getPropertyValue('--ctp-mauve').trim();
     const red = rootStyle.getPropertyValue('--ctp-red').trim();
+    const blue = rootStyle.getPropertyValue('--ctp-blue').trim();
     const overlay0 = rootStyle.getPropertyValue('--ctp-overlay0').trim();
 
-    if (mauve && red && overlay0) {
-      setThemeColors({ mauve, red, overlay0 });
+    if (mauve && red && blue && overlay0) {
+      setThemeColors({ mauve, red, blue, overlay0 });
     }
   }, [theme]);
 
@@ -3834,7 +3836,7 @@ function App() {
     return new Set(visibleNodes.map(n => n.nodeNum));
   }, [processedNodes, showMqttNodes, showIncompleteNodes, showEstimatedPositions, nodesWithEstimatedPosition]);
 
-  const { traceroutePathsElements, selectedNodeTraceroute } = useTraceroutePaths({
+  const { traceroutePathsElements, selectedNodeTraceroute, tracerouteNodeNums, tracerouteBounds } = useTraceroutePaths({
     showPaths,
     showRoute,
     selectedNodeId,
@@ -4019,6 +4021,8 @@ function App() {
             traceroutePathsElements={traceroutePathsElements}
             selectedNodeTraceroute={selectedNodeTraceroute}
             visibleNodeNums={visibleNodeNums}
+            tracerouteNodeNums={tracerouteNodeNums}
+            tracerouteBounds={tracerouteBounds}
           />
         )}
         {activeTab === 'channels' && (


### PR DESCRIPTION
## Summary
- When "Show Traceroute" is enabled and a node is selected, hide all map markers not involved in the traceroute path (including accuracy circles)
- Zoom to fit the entire traceroute bounding box instead of centering on just the selected node
- Add "Dismiss Traceroute" button to Map Features panel to restore all markers and clear selection
- Render forward path in blue and backward path in red for clear visual distinction

![Screen Recording 2026-01-20 at 1 43 12 PM](https://github.com/user-attachments/assets/4a249369-fe82-4c22-8c41-a44dffa19e2f)


## Test plan
- [ ] Enable "Show Traceroute" in Map Features
- [ ] Click on a node with traceroute data
- [ ] Verify only nodes in the traceroute path are visible on the map
- [ ] Verify the map zooms to fit the entire traceroute path
- [ ] Verify forward path is rendered in blue, backward path in red
- [ ] Click "Dismiss Traceroute" button and verify all nodes reappear
- [ ] Verify clicking nodes with "Show Traceroute" disabled still centers on the node normally

Closes #1533

🤖 Generated with [Claude Code](https://claude.com/claude-code)