### PR TITLE
fix: use ApiService for direct-neighbors endpoint instead of hardcoded URL

### DIFF
--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -11,7 +11,7 @@ import { Channel } from '../types/device';
 import { MeshMessage } from '../types/message';
 import { ResourceType } from '../types/permission';
 import { TimeFormat, DateFormat } from '../contexts/SettingsContext';
-import type { ChannelDatabaseEntry } from '../services/api';
+import apiService, { type ChannelDatabaseEntry } from '../services/api';
 import { formatMessageTime, getMessageDateSeparator, shouldShowDateSeparator } from '../utils/datetime';
 import { getUtf8ByteLength, formatByteCount, isEmoji } from '../utils/text';
 import { renderMessageWithLinks } from '../utils/linkRenderer';
@@ -194,15 +194,8 @@ export default function ChannelsTab({
 
         // Fetch direct neighbor stats
         try {
-          const response = await fetch('/meshmonitor/api/direct-neighbors?hours=24', {
-            credentials: 'include'
-          });
-          if (response.ok) {
-            const data = await response.json();
-            if (data.success) {
-              setDirectNeighborStats(data.data);
-            }
-          }
+          const stats = await apiService.getDirectNeighborStats(24);
+          setDirectNeighborStats(stats);
         } catch (error) {
           console.error('Failed to fetch direct neighbor stats:', error);
         }

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -34,6 +34,7 @@ import TelemetryGraphs from './TelemetryGraphs';
 import { NodeFilterPopup } from './NodeFilterPopup';
 import { MessageStatusIndicator } from './MessageStatusIndicator';
 import RelayNodeModal from './RelayNodeModal';
+import apiService from '../services/api';
 
 // Types for node with message metadata
 interface NodeWithMessages extends DeviceInfo {
@@ -344,15 +345,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
 
         // Fetch direct neighbor stats
         try {
-          const response = await fetch('/meshmonitor/api/direct-neighbors?hours=24', {
-            credentials: 'include'
-          });
-          if (response.ok) {
-            const data = await response.json();
-            if (data.success) {
-              setDirectNeighborStats(data.data);
-            }
-          }
+          const stats = await apiService.getDirectNeighborStats(24);
+          setDirectNeighborStats(stats);
         } catch (error) {
           console.error('Failed to fetch direct neighbor stats:', error);
         }

--- a/src/components/PacketMonitorPanel.tsx
+++ b/src/components/PacketMonitorPanel.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { PacketLog, PacketFilters } from '../types/packet';
 import { clearPackets, exportPackets } from '../services/packetApi';
+import apiService from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 import { useSettings } from '../contexts/SettingsContext';
 import { useDeviceConfig, useNodes } from '../hooks/useServerData';
@@ -157,15 +158,8 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
 
     const fetchNeighborStats = async () => {
       try {
-        const response = await fetch('/meshmonitor/api/direct-neighbors?hours=24', {
-          credentials: 'include'
-        });
-        if (response.ok) {
-          const data = await response.json();
-          if (data.success) {
-            setDirectNeighborStats(data.data);
-          }
-        }
+        const stats = await apiService.getDirectNeighborStats(24);
+        setDirectNeighborStats(stats);
       } catch (error) {
         console.error('Failed to fetch direct neighbor stats:', error);
       }
@@ -218,15 +212,8 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
 
     // Fetch direct neighbor stats (refresh to ensure up-to-date data)
     try {
-      const response = await fetch('/meshmonitor/api/direct-neighbors?hours=24', {
-        credentials: 'include'
-      });
-      if (response.ok) {
-        const data = await response.json();
-        if (data.success) {
-          setDirectNeighborStats(data.data);
-        }
-      }
+      const stats = await apiService.getDirectNeighborStats(24);
+      setDirectNeighborStats(stats);
     } catch (error) {
       console.error('Failed to fetch direct neighbor stats:', error);
     }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -631,6 +631,18 @@ class ApiService {
     return data.nodes || [];
   }
 
+  async getDirectNeighborStats(hoursBack: number = 24): Promise<Record<number, { avgRssi: number; packetCount: number; lastHeard: number }>> {
+    await this.ensureBaseUrl();
+    const response = await fetch(`${this.baseUrl}/api/direct-neighbors?hours=${hoursBack}`, {
+      credentials: 'include',
+    });
+    if (!response.ok) {
+      throw new Error('Failed to fetch direct neighbor stats');
+    }
+    const data = await response.json();
+    return data.success ? data.data : {};
+  }
+
   async updateTracerouteInterval(minutes: number) {
     // Validate interval minutes
     const validatedMinutes = validateIntervalMinutes(minutes);


### PR DESCRIPTION
## Summary
- Add `getDirectNeighborStats` method to ApiService to centralize direct-neighbors API calls
- Update PacketMonitorPanel.tsx, MessagesTab.tsx, and ChannelsTab.tsx to use ApiService instead of hardcoded URLs

## Problem
The direct-neighbors API endpoint was hardcoded as `/meshmonitor/api/direct-neighbors` in three components. This caused 404 errors and "Failed to fetch direct neighbor stats" messages when `BASE_URL` is configured to something other than `/meshmonitor`.

## Solution
Replace hardcoded fetch calls with `apiService.getDirectNeighborStats()` which uses the dynamically resolved base URL from the application configuration.

## Test plan
- [ ] Verify "Request Neighbor Info" button works in Packet Monitor
- [ ] Verify relay node modal opens and shows neighbor stats
- [ ] Verify relay click in Messages tab works
- [ ] Verify relay click in Channels tab works

Fixes #1538

🤖 Generated with [Claude Code](https://claude.com/claude-code)