### PR TITLE
fix: move internal scripts to separate directory to avoid bind mount conflicts

### DIFF
--- a/docker-compose.upgrade-test.yml
+++ b/docker-compose.upgrade-test.yml
@@ -33,7 +33,7 @@ services:
       - STATUS_FILE=/data/.upgrade-status
       - CHECK_INTERVAL=5
       - COMPOSE_PROJECT_DIR=/compose
-    command: /data/scripts/upgrade-watchdog.sh
+    command: /data/.meshmonitor-internal/upgrade-watchdog.sh
     depends_on:
       - meshmonitor
     networks:

--- a/docker-compose.upgrade.yml
+++ b/docker-compose.upgrade.yml
@@ -8,8 +8,8 @@
 # and automatically pulls new images and restarts the main container when
 # an upgrade is requested through the MeshMonitor UI.
 #
-# Note: The upgrade-watchdog.sh script is automatically deployed to the shared
-# /data/scripts directory by the meshmonitor container on startup.
+# Note: The upgrade-watchdog.sh script is automatically deployed to
+# /data/.meshmonitor-internal directory by the meshmonitor container on startup.
 
 services:
   meshmonitor:
@@ -37,7 +37,7 @@ services:
       - CHECK_INTERVAL=5
       - COMPOSE_PROJECT_DIR=/compose
       - COMPOSE_PROJECT_NAME=meshmonitor
-    command: /data/scripts/upgrade-watchdog.sh
+    command: /data/.meshmonitor-internal/upgrade-watchdog.sh
     depends_on:
       - meshmonitor
     networks:

--- a/docs/.vitepress/theme/DockerComposeConfigurator.vue
+++ b/docs/.vitepress/theme/DockerComposeConfigurator.vue
@@ -825,7 +825,7 @@ const dockerComposeYaml = computed(() => {
     lines.push('      - CHECK_INTERVAL=5')
     lines.push('      - COMPOSE_PROJECT_DIR=/compose')
     lines.push('      - COMPOSE_PROJECT_NAME=meshmonitor')
-    lines.push('    command: /data/scripts/upgrade-watchdog.sh')
+    lines.push('    command: /data/.meshmonitor-internal/upgrade-watchdog.sh')
     lines.push('    depends_on:')
     lines.push('      - meshmonitor')
     lines.push('    logging:')

--- a/scripts/upgrade-watchdog.sh
+++ b/scripts/upgrade-watchdog.sh
@@ -13,7 +13,7 @@ CONTAINER_NAME="${CONTAINER_NAME:-meshmonitor}"
 IMAGE_NAME="${IMAGE_NAME:-ghcr.io/yeraze/meshmonitor}"
 COMPOSE_PROJECT_DIR="${COMPOSE_PROJECT_DIR:-/compose}"
 DOCKER_SOCKET_TEST_REQUEST="${DOCKER_SOCKET_TEST_REQUEST:-/data/.docker-socket-test-request}"
-DOCKER_SOCKET_TEST_SCRIPT="${DOCKER_SOCKET_TEST_SCRIPT:-/data/scripts/test-docker-socket.sh}"
+DOCKER_SOCKET_TEST_SCRIPT="${DOCKER_SOCKET_TEST_SCRIPT:-/data/.meshmonitor-internal/test-docker-socket.sh}"
 
 # Colors for output
 RED='\033[0;31m'


### PR DESCRIPTION
## Summary
- Move internal MeshMonitor scripts from `/data/scripts/` to `/data/.meshmonitor-internal/`
- Keep `/data/scripts/` purely for user scripts (which may be bind-mounted)

## Problem
During upgrades, the docker-entrypoint.sh was deploying internal MeshMonitor scripts (upgrade-watchdog.sh, test-docker-socket.sh) to `/data/scripts/`. When users bind-mount their custom scripts directory (`./scripts:/data/scripts`), this could cause the bind mount to become "shadowed" during upgrades, making user scripts inaccessible until container restart.

From the user report in #1518:
> From the docker logs, it appears that during an upgrade, the mounted volume is overwritten/removed(?) at the point of "Deploying scripts to /data/scripts/...". The script still exists on the host and docker indicates the volume is still mounted. Restarting the container temporarily restores the mapped volume and scripts.

## Solution
Move internal scripts to a dedicated hidden directory `/data/.meshmonitor-internal/` that users would never bind-mount, avoiding any potential conflicts with user script directories.

## Files Changed
- `docker/docker-entrypoint.sh` - Deploy to new location
- `scripts/upgrade-watchdog.sh` - Look for test script in new location  
- `docker-compose.upgrade.yml` - Update command path
- `docker-compose.upgrade-test.yml` - Update command path
- `docs/.vitepress/theme/DockerComposeConfigurator.vue` - Generate correct paths

## Test plan
- [ ] Build Docker image and verify internal scripts are deployed to `/data/.meshmonitor-internal/`
- [ ] Verify user scripts in bind-mounted `/data/scripts/` are not affected
- [ ] Verify upgrade watchdog works with new script location

Fixes #1518

🤖 Generated with [Claude Code](https://claude.com/claude-code)