### PR TITLE
feat: add Python requests library to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ WORKDIR /app
 RUN apk add --no-cache \
     python3 \
     py3-pip \
+    py3-requests \
     supervisor \
     su-exec \
     && ln -sf /usr/bin/python3 /usr/bin/python \

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -56,6 +56,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     python3-venv \
+    python3-requests \
     supervisor \
     gosu \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary
Add the Python `requests` library to the Docker images so user scripts can make HTTP calls.

## Changes
- **Dockerfile** (Alpine): Added `py3-requests` to apk install
- **Dockerfile.armv7** (Debian): Added `python3-requests` to apt-get install

## Use Case
User scripts that need to fetch data from external APIs (like the Aurora forecast script mentioned in the issue) can now use `import requests` without needing to manually install packages.

## Test plan
- [ ] Build Docker image and verify `python3 -c "import requests; print(requests.__version__)"` works

Fixes #1545

🤖 Generated with [Claude Code](https://claude.com/claude-code)