### PR TITLE
fix: update Channel Database help link to MeshMonitor docs

### DIFF
--- a/src/components/configuration/ChannelDatabaseSection.tsx
+++ b/src/components/configuration/ChannelDatabaseSection.tsx
@@ -310,7 +310,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
         <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           {t('channel_database.title')}
           <a
-            href="https://meshtastic.org/docs/configuration/radio/channels/#encryption"
+            href="https://meshmonitor.org/features/channel-database.html"
             target="_blank"
             rel="noopener noreferrer"
             style={{


### PR DESCRIPTION
## Summary
Update the ? help link next to Channel Database to point to our documentation.

## Change
- Old: `https://meshtastic.org/docs/configuration/radio/channels/#encryption`
- New: `https://meshmonitor.org/features/channel-database.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)