### PR TITLE
fix(messages): neighbor info display and stale data cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -280,7 +280,6 @@ function App() {
   const {
     showPaths,
     showRoute,
-    showNeighborInfo,
     showMqttNodes,
     showEstimatedPositions,
     setMapCenterTarget,
@@ -1309,9 +1308,9 @@ function App() {
   // Traceroutes are now synced via the poll mechanism (processPollData)
   // This provides consistent data across Dashboard Widget, Node View, and Traceroute History Modal
 
-  // Fetch neighbor info when showNeighborInfo is enabled
+  // Fetch neighbor info when connected (needed for both map display and Messages tab)
   useEffect(() => {
-    if (showNeighborInfo && shouldShowData()) {
+    if (shouldShowData()) {
       fetchNeighborInfo();
       // Only auto-refresh when connected (not when viewing cached data)
       if (connectionStatus === 'connected') {
@@ -1319,7 +1318,7 @@ function App() {
         return () => clearInterval(interval);
       }
     }
-  }, [showNeighborInfo, connectionStatus]);
+  }, [connectionStatus]);
 
   // Fetch position history when a mobile node is selected
   useEffect(() => {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3896,6 +3896,10 @@ class MeshtasticManager {
       if (neighborInfo.neighbors && Array.isArray(neighborInfo.neighbors)) {
         logger.info(`📡 Processing ${neighborInfo.neighbors.length} neighbors from ${fromNodeId}`);
 
+        // Clear old neighbor info for this node before saving new data
+        // This ensures stale neighbors are removed when they drop from the mesh
+        databaseService.clearNeighborInfoForNode(fromNum);
+
         for (const neighbor of neighborInfo.neighbors) {
           const neighborNodeNum = Number(neighbor.nodeId);
           const neighborNodeId = `!${neighborNodeNum.toString(16).padStart(8, '0')}`;


### PR DESCRIPTION
## Summary
Fixes neighbor info not appearing in Messages tab and prevents stale neighbor data accumulation.

## Changes
- **Fetch neighbor info when connected** - Previously, neighbor info was only fetched when the map's "Show Neighbor Info" setting was enabled. Now it's fetched whenever connected, so the Messages tab neighbor display works independently.
- **Clear old neighbor info before saving new** - When receiving a NeighborInfo packet from a node, old entries for that node are now deleted before inserting new ones. This ensures stale neighbors are removed when they drop from the mesh.

## Test plan
- [x] Build succeeds
- [x] Unit tests pass (1974 tests)
- [x] Manual testing: Neighbor info box now appears in Messages tab DM view
- [x] Manual testing: Neighbor info updates correctly when new data received

🤖 Generated with [Claude Code](https://claude.com/claude-code)