### PR TITLE
feat(news): add news popup feature for announcements

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -38,6 +38,10 @@ services:
     environment:
       - NODE_ENV=development
       - WORKSPACE_FOLDER=/workspace
+      # For testing news popup, point to local docs server running on host
+      # Start docs with: npm run docs:dev -- --port 4173
+      # Then access from container via host.docker.internal
+      - NEWS_FEED_URL=${NEWS_FEED_URL:-}
 
     # Keep container running (entrypoint will handle user switching)
     # Using 'bash -c' to ensure entrypoint runs first

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -96,6 +96,8 @@ services:
       - "8081:3001"
       - "4405:4404"
     restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - meshmonitor-sqlite-data:/data
     env_file: .env
@@ -115,6 +117,8 @@ services:
       - ACCESS_LOG_FORMAT=combined
       - ENABLE_VIRTUAL_NODE=${ENABLE_VIRTUAL_NODE:-true}
       - VIRTUAL_NODE_PORT=${VIRTUAL_NODE_PORT:-4404}
+      # News feed URL for testing - use host.docker.internal to access host machine
+      - NEWS_FEED_URL=${NEWS_FEED_URL:-}
 
   # MySQL service for testing dual-database support
   # Start with: docker compose -f docker-compose.dev.yml --profile mysql up -d

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -618,43 +618,69 @@ Nodes may also display role badges:
 
 **Problem:** When accessing MeshMonitor without logging in, the map appears empty even though logged-in users can see nodes.
 
-**Cause:** Node visibility in MeshMonitor is controlled by **channel read permissions**. Each node is associated with the channel it was last heard on, and users (including anonymous users) can only see nodes on channels they have read permission for. By default, anonymous users have no channel permissions.
+**Cause:** Node visibility in MeshMonitor is controlled by **channel permissions**. Each node is associated with the channel it was last heard on, and users (including anonymous users) can only see nodes on channels they have the appropriate permissions for. By default, anonymous users have no channel permissions.
 
-**Solution:** Configure channel read permissions for the anonymous user:
+**Solution:** Configure channel permissions for the anonymous user:
 
 1. **Login as admin**
 
 2. **Navigate to User Management:**
-   - Click your username in the top right corner
-   - Select "Admin Panel" from the dropdown
-   - Click "User Management"
+   - Go to **Settings > Users**
+   - Or click your username in the top right corner and select "Settings"
 
 3. **Find the anonymous user:**
    - Look for the user named **"anonymous"** in the user list
    - Click on it to edit permissions
 
-4. **Grant channel read permissions:**
+4. **Grant channel permissions:**
    - In the permissions section, find the channel permissions (e.g., `channel_0`, `channel_1`, etc.)
-   - Enable **read** permission for each channel you want anonymous users to see
-   - Most commonly, you'll want to enable `channel_0:read` (the primary channel)
+   - Enable **View Map** permission for each channel you want anonymous users to see on the map
+   - Optionally enable **Read** permission if you also want them to see messages
    - Click **Save**
 
-**Example configuration:**
-- `channel_0: read` - Anonymous users can see nodes on the primary channel
-- `channel_1: read` - Anonymous users can see nodes on channel 1
-- Leave other channels disabled to restrict visibility
+See [Understanding Channel Permissions](#understanding-channel-permissions) below for more details on the permission types.
 
-**How it works:**
-- Each node in the mesh has a `channel` field indicating which channel it was last heard on
-- When a user (logged in or anonymous) requests the node list, MeshMonitor filters results based on their channel read permissions
-- This allows administrators to control exactly which nodes are visible to public visitors
+---
 
-**Use cases:**
-- **Public dashboards:** Enable read permission on your public channel for anonymous users
-- **Private networks:** Keep all channel permissions disabled to require login
-- **Multi-channel setups:** Selectively expose only certain channels to anonymous visitors
+### Understanding Channel Permissions
 
-**Note:** This also affects the V1 API. API token users follow the same channel permission filtering based on their associated user account.
+As of **v3.1.0**, MeshMonitor uses a **tri-state permission system** for channels, giving administrators fine-grained control over what users can see and do:
+
+| Permission | Description |
+|------------|-------------|
+| **View Map** | User can see node positions on the map for nodes heard on this channel |
+| **Read** | User can read messages from this channel (in the Messages tab) |
+| **Write** | User can send messages to this channel (implies Read access) |
+
+**How permissions work:**
+
+- Each node is associated with the channel it was last heard on
+- **View Map** controls whether nodes appear on the map - this is the most common permission needed for public dashboards
+- **Read** controls access to the Messages tab for that channel
+- **Write** allows sending messages and automatically includes Read access
+
+**Example configurations:**
+
+| Use Case | View Map | Read | Write |
+|----------|----------|------|-------|
+| Public map-only dashboard | ✅ | ❌ | ❌ |
+| Read-only access (map + messages) | ✅ | ✅ | ❌ |
+| Full access | ✅ | ✅ | ✅ |
+| Hidden channel (logged-in users only) | ❌ | ❌ | ❌ |
+
+**Configuring the Anonymous user:**
+
+The **anonymous** user controls what unauthenticated visitors can see. Common setups:
+
+- **Public dashboard:** Enable `View Map` on `channel_0` (primary channel) for anonymous
+- **Private network:** Leave all permissions disabled - visitors must log in
+- **Selective exposure:** Enable `View Map` only on specific public channels
+
+**Important notes:**
+
+- Changes take effect immediately - no restart required
+- API token users follow the same permission filtering based on their associated user account
+- The V1 API respects these permissions for all node and message queries
 
 ---
 

--- a/docs/public/news.json
+++ b/docs/public/news.json
@@ -1,0 +1,14 @@
+{
+  "version": "1",
+  "lastUpdated": "2026-01-22T18:00:00Z",
+  "items": [
+    {
+      "id": "news-2026-01-22-permissions-update",
+      "title": "Important: User Permissions Changes",
+      "content": "MeshMonitor v3.1.0 introduced an updated **User Permissions** system to provide more granular control over channel access.\n\n## What's Changed\n\nChannel permissions now use a **tri-state system** with three separate controls:\n\n- **View Map** - Can see node positions on the map\n- **Read** - Can read messages from the channel\n- **Write** - Can send messages to the channel\n\nThis allows configurations like \"map-only\" access where users can see nodes but not read messages.\n\n## Action Required\n\nAdministrators should review their permission settings:\n\n1. Navigate to **Settings > Users** and review each user's permissions\n2. Pay special attention to the **Anonymous** user - this controls what unauthenticated visitors can see\n3. For each channel, verify the appropriate **View Map** and **Read** permissions are assigned\n\n## Common Issue: Blank Maps\n\nIf users report seeing blank maps, this is likely a permissions issue. The **View Map** permission must be enabled for a channel for users to see nodes on the map.\n\nSee our [FAQ: Why is my map blank?](https://meshmonitor.org/faq#the-map-is-blank-for-anonymous-not-logged-in-users) for troubleshooting steps.\n\nFor complete documentation on the new permission system, see [Understanding Channel Permissions](https://meshmonitor.org/faq#understanding-channel-permissions).",
+      "date": "2026-01-22T18:00:00Z",
+      "category": "feature",
+      "priority": "important"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "react-dom": "^19.2.3",
         "react-i18next": "^16.5.1",
         "react-leaflet": "^5.0.0",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.11.0",
         "recharts": "^3.5.1",
         "rotating-file-stream": "^3.2.7",
@@ -4318,6 +4319,14 @@
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4327,8 +4336,15 @@
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/express": {
       "version": "5.0.6",
@@ -4381,7 +4397,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -4426,7 +4441,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -4451,6 +4465,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/mysql": {
       "version": "2.15.27",
@@ -4525,7 +4544,6 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
-      "devOptional": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4625,8 +4643,7 @@
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -4901,8 +4918,7 @@
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "dev": true
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.2",
@@ -5816,6 +5832,15 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -6257,7 +6282,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6300,11 +6324,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6314,7 +6346,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6403,7 +6443,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6781,7 +6820,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -7015,6 +7053,18 @@
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -7130,7 +7180,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7147,7 +7196,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dev": true,
       "dependencies": {
         "dequal": "^2.0.0"
       },
@@ -8434,6 +8482,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -8602,6 +8659,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -9315,11 +9377,36 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "dev": true,
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -9383,6 +9470,15 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/html-void-elements": {
@@ -9608,6 +9704,11 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -9644,6 +9745,28 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -9779,6 +9902,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -9842,6 +9974,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -9895,6 +10036,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -10472,6 +10624,15 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -10606,11 +10767,103 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
-      "dev": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -10621,6 +10874,38 @@
         "unist-util-position": "^5.0.0",
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10663,11 +10948,179 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10683,11 +11136,106 @@
         "micromark-util-types": "^2.0.0"
       }
     },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
     "node_modules/micromark-util-encode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10699,11 +11247,61 @@
         }
       ]
     },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
     "node_modules/micromark-util-sanitize-uri": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10720,11 +11318,31 @@
         "micromark-util-symbol": "^2.0.0"
       }
     },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
     "node_modules/micromark-util-symbol": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10740,7 +11358,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -11325,6 +11942,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -11756,7 +12396,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
       "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -12169,6 +12808,32 @@
         "react-dom": "^19.0.0"
       }
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
@@ -12453,6 +13118,37 @@
       },
       "bin": {
         "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-directory": {
@@ -13323,7 +14019,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -13524,7 +14219,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "dev": true,
       "dependencies": {
         "character-entities-html4": "^2.0.0",
         "character-entities-legacy": "^3.0.0"
@@ -13602,6 +14296,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/superagent": {
@@ -13952,7 +14662,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -14220,6 +14938,24 @@
         "node": ">=4"
       }
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -14236,7 +14972,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -14249,7 +14984,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -14262,7 +14996,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -14275,7 +15008,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
       "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",
@@ -14290,7 +15022,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0"
@@ -14404,7 +15135,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
@@ -14418,7 +15148,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-stringify-position": "^4.0.0"
@@ -16490,7 +17219,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-dom": "^19.2.3",
     "react-i18next": "^16.5.1",
     "react-leaflet": "^5.0.0",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.11.0",
     "recharts": "^3.5.1",
     "rotating-file-stream": "^3.2.7",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3501,5 +3501,18 @@
 
   "common.never": "Never",
   "common.importing": "Importing...",
-  "common.deleting": "Deleting..."
+  "common.deleting": "Deleting...",
+
+  "news.title": "News",
+  "news.view_news": "View News",
+  "news.do_not_show_again": "Don't show this again",
+  "news.next": "Next",
+  "news.previous": "Previous",
+  "news.close": "Close",
+  "news.no_news": "No news at this time.",
+  "news.important": "Important",
+  "news.category.release": "Release",
+  "news.category.security": "Security",
+  "news.category.feature": "Feature",
+  "news.category.maintenance": "Maintenance"
 }

--- a/src/components/NewsPopup/NewsPopup.css
+++ b/src/components/NewsPopup/NewsPopup.css
@@ -1,0 +1,342 @@
+/**
+ * NewsPopup Styles
+ *
+ * Catppuccin-themed modal for displaying news announcements.
+ */
+
+/* Modal overlay - higher z-index for news */
+.news-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10002;
+}
+
+/* Modal content container */
+.news-modal-content {
+  background: var(--ctp-base);
+  border-radius: 12px;
+  padding: 0;
+  max-width: 600px;
+  width: 90%;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--ctp-surface0);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+/* Header styles */
+.news-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--ctp-surface0);
+  flex-shrink: 0;
+}
+
+.news-header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.news-modal-header h2 {
+  margin: 0;
+  color: var(--ctp-text);
+  font-size: 1.25rem;
+}
+
+.news-pagination {
+  color: var(--ctp-subtext0);
+  font-size: 0.875rem;
+  background: var(--ctp-surface0);
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+}
+
+/* Body styles */
+.news-modal-body {
+  padding: 1.5rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.news-loading,
+.news-empty {
+  text-align: center;
+  color: var(--ctp-subtext0);
+  padding: 2rem;
+}
+
+/* News item styles */
+.news-item {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.news-item-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+/* Category badges */
+.news-category {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  letter-spacing: 0.05em;
+}
+
+.news-category-release {
+  background: var(--ctp-blue);
+  color: var(--ctp-base);
+}
+
+.news-category-security {
+  background: var(--ctp-red);
+  color: var(--ctp-base);
+}
+
+.news-category-feature {
+  background: var(--ctp-green);
+  color: var(--ctp-base);
+}
+
+.news-category-maintenance {
+  background: var(--ctp-yellow);
+  color: var(--ctp-base);
+}
+
+/* Priority badge */
+.news-priority-important {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  background: var(--ctp-maroon);
+  color: var(--ctp-base);
+  letter-spacing: 0.05em;
+}
+
+/* Date */
+.news-date {
+  color: var(--ctp-subtext0);
+  font-size: 0.875rem;
+  margin-left: auto;
+}
+
+/* Title */
+.news-item-title {
+  margin: 0;
+  color: var(--ctp-text);
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+/* Content with markdown */
+.news-item-content {
+  color: var(--ctp-text);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.news-item-content p {
+  margin: 0 0 1rem 0;
+}
+
+.news-item-content p:last-child {
+  margin-bottom: 0;
+}
+
+.news-item-content a {
+  color: var(--ctp-blue);
+  text-decoration: none;
+}
+
+.news-item-content a:hover {
+  text-decoration: underline;
+}
+
+.news-item-content code {
+  background: var(--ctp-surface0);
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.875em;
+}
+
+.news-item-content pre {
+  background: var(--ctp-surface0);
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin: 1rem 0;
+}
+
+.news-item-content pre code {
+  background: none;
+  padding: 0;
+}
+
+.news-item-content ul,
+.news-item-content ol {
+  margin: 0.5rem 0;
+  padding-left: 1.5rem;
+}
+
+.news-item-content li {
+  margin: 0.25rem 0;
+}
+
+.news-item-content blockquote {
+  margin: 1rem 0;
+  padding-left: 1rem;
+  border-left: 3px solid var(--ctp-surface1);
+  color: var(--ctp-subtext0);
+}
+
+.news-item-content h1,
+.news-item-content h2,
+.news-item-content h3,
+.news-item-content h4 {
+  margin: 1.5rem 0 0.5rem 0;
+  color: var(--ctp-text);
+}
+
+.news-item-content h1:first-child,
+.news-item-content h2:first-child,
+.news-item-content h3:first-child,
+.news-item-content h4:first-child {
+  margin-top: 0;
+}
+
+/* Footer styles */
+.news-modal-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--ctp-surface0);
+  flex-shrink: 0;
+  gap: 1rem;
+}
+
+.news-footer-left {
+  flex: 1;
+}
+
+.news-footer-right {
+  display: flex;
+  gap: 0.75rem;
+}
+
+/* Don't show again checkbox */
+.news-dont-show-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--ctp-subtext0);
+  font-size: 0.875rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.news-dont-show-checkbox input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--ctp-blue);
+  cursor: pointer;
+}
+
+/* Buttons */
+.news-button {
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: none;
+}
+
+.news-button-primary {
+  background: var(--ctp-blue);
+  color: var(--ctp-base);
+}
+
+.news-button-primary:hover {
+  background: var(--ctp-sapphire);
+}
+
+.news-button-secondary {
+  background: var(--ctp-surface0);
+  color: var(--ctp-text);
+}
+
+.news-button-secondary:hover {
+  background: var(--ctp-surface1);
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .news-modal-content {
+    width: 95%;
+    max-height: 90vh;
+    border-radius: 8px;
+  }
+
+  .news-modal-header,
+  .news-modal-body,
+  .news-modal-footer {
+    padding: 1rem;
+  }
+
+  .news-header-left {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .news-item-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .news-date {
+    margin-left: 0;
+  }
+
+  .news-item-title {
+    font-size: 1.25rem;
+  }
+
+  .news-modal-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .news-footer-left {
+    order: 2;
+    text-align: center;
+  }
+
+  .news-footer-right {
+    order: 1;
+    justify-content: flex-end;
+  }
+}

--- a/src/components/NewsPopup/NewsPopup.tsx
+++ b/src/components/NewsPopup/NewsPopup.tsx
@@ -1,0 +1,261 @@
+/**
+ * NewsPopup Component
+ *
+ * Displays news announcements from meshmonitor.org in a modal popup.
+ * Supports markdown content, category badges, pagination, and dismissal.
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import ReactMarkdown from 'react-markdown';
+import type { NewsItem, NewsFeed } from '../../types/ui';
+import api from '../../services/api';
+import './NewsPopup.css';
+
+interface NewsPopupProps {
+  isOpen: boolean;
+  onClose: () => void;
+  forceShowAll?: boolean;
+  isAuthenticated: boolean;
+}
+
+export const NewsPopup: React.FC<NewsPopupProps> = ({
+  isOpen,
+  onClose,
+  forceShowAll = false,
+  isAuthenticated,
+}) => {
+  const { t } = useTranslation();
+  const [newsItems, setNewsItems] = useState<NewsItem[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  // Fetch news data when popup opens
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const feed: NewsFeed = await api.getNewsFeed();
+        let status: { lastSeenNewsId: string | null; dismissedNewsIds: string[] } | null = null;
+
+        if (isAuthenticated) {
+          status = await api.getUserNewsStatus();
+        }
+
+        // Filter items based on forceShowAll and user status
+        let items = feed.items || [];
+
+        if (!forceShowAll && status) {
+          const dismissedIds = new Set(status.dismissedNewsIds || []);
+          items = items.filter(item => {
+            // Always show important items
+            if (item.priority === 'important') return true;
+            // Hide dismissed items
+            return !dismissedIds.has(item.id);
+          });
+        }
+
+        setNewsItems(items);
+        setCurrentIndex(0);
+      } catch (error) {
+        console.error('Error fetching news:', error);
+        setNewsItems([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [isOpen, forceShowAll, isAuthenticated]);
+
+  // Reset state when popup closes
+  useEffect(() => {
+    if (!isOpen) {
+      setDontShowAgain(false);
+      setCurrentIndex(0);
+    }
+  }, [isOpen]);
+
+  const handleClose = useCallback(async () => {
+    // If "don't show again" is checked and we're authenticated, dismiss the current item
+    if (dontShowAgain && isAuthenticated && newsItems.length > 0) {
+      const currentItem = newsItems[currentIndex];
+      try {
+        await api.dismissNewsItem(currentItem.id);
+      } catch (error) {
+        console.error('Error dismissing news item:', error);
+      }
+    }
+    onClose();
+  }, [dontShowAgain, isAuthenticated, newsItems, currentIndex, onClose]);
+
+  const handleNext = useCallback(async () => {
+    // Dismiss current item if checkbox is checked
+    if (dontShowAgain && isAuthenticated && newsItems.length > 0) {
+      const currentItem = newsItems[currentIndex];
+      try {
+        await api.dismissNewsItem(currentItem.id);
+      } catch (error) {
+        console.error('Error dismissing news item:', error);
+      }
+    }
+
+    if (currentIndex < newsItems.length - 1) {
+      setCurrentIndex(prev => prev + 1);
+      setDontShowAgain(false);
+    } else {
+      onClose();
+    }
+  }, [currentIndex, newsItems.length, dontShowAgain, isAuthenticated, newsItems, onClose]);
+
+  const handlePrevious = useCallback(() => {
+    if (currentIndex > 0) {
+      setCurrentIndex(prev => prev - 1);
+      setDontShowAgain(false);
+    }
+  }, [currentIndex]);
+
+  const getCategoryLabel = (category: NewsItem['category']): string => {
+    switch (category) {
+      case 'release':
+        return t('news.category.release', 'Release');
+      case 'security':
+        return t('news.category.security', 'Security');
+      case 'feature':
+        return t('news.category.feature', 'Feature');
+      case 'maintenance':
+        return t('news.category.maintenance', 'Maintenance');
+      default:
+        return category;
+    }
+  };
+
+  const formatDate = (dateString: string): string => {
+    try {
+      const date = new Date(dateString);
+      return date.toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      });
+    } catch {
+      return dateString;
+    }
+  };
+
+  if (!isOpen) return null;
+
+  // Show loading state
+  if (loading) {
+    return (
+      <div className="modal-overlay news-modal-overlay" onClick={handleClose}>
+        <div className="modal-content news-modal-content" onClick={e => e.stopPropagation()}>
+          <div className="modal-header news-modal-header">
+            <h2>{t('news.title', 'News')}</h2>
+            <button className="modal-close" onClick={handleClose}>
+              &times;
+            </button>
+          </div>
+          <div className="modal-body news-modal-body">
+            <div className="news-loading">{t('common.loading', 'Loading...')}</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // No news items
+  if (newsItems.length === 0) {
+    return (
+      <div className="modal-overlay news-modal-overlay" onClick={handleClose}>
+        <div className="modal-content news-modal-content" onClick={e => e.stopPropagation()}>
+          <div className="modal-header news-modal-header">
+            <h2>{t('news.title', 'News')}</h2>
+            <button className="modal-close" onClick={handleClose}>
+              &times;
+            </button>
+          </div>
+          <div className="modal-body news-modal-body">
+            <div className="news-empty">{t('news.no_news', 'No news at this time.')}</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const currentItem = newsItems[currentIndex];
+  const isLastItem = currentIndex === newsItems.length - 1;
+
+  return (
+    <div className="modal-overlay news-modal-overlay" onClick={handleClose}>
+      <div className="modal-content news-modal-content" onClick={e => e.stopPropagation()}>
+        <div className="modal-header news-modal-header">
+          <div className="news-header-left">
+            <h2>{t('news.title', 'News')}</h2>
+            {newsItems.length > 1 && (
+              <span className="news-pagination">
+                {currentIndex + 1} / {newsItems.length}
+              </span>
+            )}
+          </div>
+          <button className="modal-close" onClick={handleClose}>
+            &times;
+          </button>
+        </div>
+
+        <div className="modal-body news-modal-body">
+          <div className="news-item">
+            <div className="news-item-header">
+              <span className={`news-category news-category-${currentItem.category}`}>
+                {getCategoryLabel(currentItem.category)}
+              </span>
+              {currentItem.priority === 'important' && (
+                <span className="news-priority-important">
+                  {t('news.important', 'Important')}
+                </span>
+              )}
+              <span className="news-date">{formatDate(currentItem.date)}</span>
+            </div>
+
+            <h3 className="news-item-title">{currentItem.title}</h3>
+
+            <div className="news-item-content">
+              <ReactMarkdown>{currentItem.content}</ReactMarkdown>
+            </div>
+          </div>
+        </div>
+
+        <div className="modal-footer news-modal-footer">
+          <div className="news-footer-left">
+            {isAuthenticated && !forceShowAll && (
+              <label className="news-dont-show-checkbox">
+                <input
+                  type="checkbox"
+                  checked={dontShowAgain}
+                  onChange={e => setDontShowAgain(e.target.checked)}
+                />
+                {t('news.do_not_show_again', "Don't show this again")}
+              </label>
+            )}
+          </div>
+
+          <div className="news-footer-right">
+            {currentIndex > 0 && (
+              <button className="news-button news-button-secondary" onClick={handlePrevious}>
+                {t('news.previous', 'Previous')}
+              </button>
+            )}
+            <button className="news-button news-button-primary" onClick={handleNext}>
+              {isLastItem ? t('news.close', 'Close') : t('news.next', 'Next')}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NewsPopup;

--- a/src/components/NewsPopup/index.ts
+++ b/src/components/NewsPopup/index.ts
@@ -1,0 +1,2 @@
+export { NewsPopup } from './NewsPopup';
+export { default } from './NewsPopup';

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -48,7 +48,8 @@
   font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
 }
 
-.github-link {
+.github-link,
+.news-link {
   color: var(--ctp-subtext0);
   display: flex;
   align-items: center;
@@ -57,7 +58,15 @@
   text-decoration: none;
 }
 
-.github-link:hover {
+.news-link {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.github-link:hover,
+.news-link:hover {
   color: var(--ctp-text);
 }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -20,6 +20,7 @@ interface SidebarProps {
   unreadCountsData?: UnreadCountsData | null;
   onMessagesClick: () => void;
   onChannelsClick?: () => void;
+  onNewsClick?: () => void;
   baseUrl: string;
   connectedNodeName?: string;
 }
@@ -33,6 +34,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   unreadCountsData,
   onMessagesClick,
   onChannelsClick,
+  onNewsClick,
   baseUrl,
   connectedNodeName
 }) => {
@@ -196,6 +198,15 @@ const Sidebar: React.FC<SidebarProps> = ({
         {!isCollapsed && (
           <>
             <span className="version-text">v{packageJson.version}</span>
+            <button
+              className="news-link"
+              onClick={onNewsClick}
+              title={t('news.view_news')}
+            >
+              <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+                <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"/>
+              </svg>
+            </button>
             <a
               href="https://github.com/Yeraze/meshmonitor"
               target="_blank"
@@ -210,17 +221,28 @@ const Sidebar: React.FC<SidebarProps> = ({
           </>
         )}
         {isCollapsed && (
-          <a
-            href="https://github.com/Yeraze/meshmonitor"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="github-link"
-            title={t('common.view_on_github')}
-          >
-            <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
-              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
-            </svg>
-          </a>
+          <>
+            <button
+              className="news-link"
+              onClick={onNewsClick}
+              title={t('news.view_news')}
+            >
+              <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+                <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"/>
+              </svg>
+            </button>
+            <a
+              href="https://github.com/Yeraze/meshmonitor"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="github-link"
+              title={t('common.view_on_github')}
+            >
+              <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
+              </svg>
+            </a>
+          </>
         )}
       </div>
 

--- a/src/db/repositories/index.ts
+++ b/src/db/repositories/index.ts
@@ -28,5 +28,5 @@ export type {
   PushSubscriptionInput,
 } from './notifications.js';
 export { MiscRepository } from './misc.js';
-export type { SolarEstimate, AutoTracerouteNode, UpgradeHistoryRecord, NewUpgradeHistory } from './misc.js';
+export type { SolarEstimate, AutoTracerouteNode, UpgradeHistoryRecord, NewUpgradeHistory, NewsCache, UserNewsStatus } from './misc.js';
 export { ChannelDatabaseRepository, type ChannelDatabaseInput, type ChannelDatabaseUpdate, type ChannelDatabasePermissionInput } from './channelDatabase.js';

--- a/src/db/schema/misc.ts
+++ b/src/db/schema/misc.ts
@@ -262,6 +262,57 @@ export const autoTracerouteNodesMysql = mysqlTable('auto_traceroute_nodes', {
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
 });
 
+// ============ NEWS CACHE ============
+// Stores cached news feed from meshmonitor.org
+
+export const newsCacheSqlite = sqliteTable('news_cache', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  feedData: text('feedData').notNull(), // JSON string of full feed
+  fetchedAt: integer('fetchedAt').notNull(),
+  sourceUrl: text('sourceUrl').notNull(),
+});
+
+export const newsCachePostgres = pgTable('news_cache', {
+  id: pgSerial('id').primaryKey(),
+  feedData: pgText('feedData').notNull(),
+  fetchedAt: pgBigint('fetchedAt', { mode: 'number' }).notNull(),
+  sourceUrl: pgText('sourceUrl').notNull(),
+});
+
+export const newsCacheMysql = mysqlTable('news_cache', {
+  id: mySerial('id').primaryKey(),
+  feedData: myText('feedData').notNull(),
+  fetchedAt: myBigint('fetchedAt', { mode: 'number' }).notNull(),
+  sourceUrl: myVarchar('sourceUrl', { length: 512 }).notNull(),
+});
+
+// ============ USER NEWS STATUS ============
+// Tracks which news items users have seen/dismissed
+
+export const userNewsStatusSqlite = sqliteTable('user_news_status', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  userId: integer('userId').notNull().references(() => usersSqlite.id, { onDelete: 'cascade' }),
+  lastSeenNewsId: text('lastSeenNewsId'),
+  dismissedNewsIds: text('dismissedNewsIds'), // JSON array of dismissed news IDs
+  updatedAt: integer('updatedAt').notNull(),
+});
+
+export const userNewsStatusPostgres = pgTable('user_news_status', {
+  id: pgSerial('id').primaryKey(),
+  userId: pgInteger('userId').notNull().references(() => usersPostgres.id, { onDelete: 'cascade' }),
+  lastSeenNewsId: pgText('lastSeenNewsId'),
+  dismissedNewsIds: pgText('dismissedNewsIds'),
+  updatedAt: pgBigint('updatedAt', { mode: 'number' }).notNull(),
+});
+
+export const userNewsStatusMysql = mysqlTable('user_news_status', {
+  id: mySerial('id').primaryKey(),
+  userId: myInt('userId').notNull().references(() => usersMysql.id, { onDelete: 'cascade' }),
+  lastSeenNewsId: myVarchar('lastSeenNewsId', { length: 128 }),
+  dismissedNewsIds: myText('dismissedNewsIds'),
+  updatedAt: myBigint('updatedAt', { mode: 'number' }).notNull(),
+});
+
 // Type inference exports
 export type BackupHistorySqlite = typeof backupHistorySqlite.$inferSelect;
 export type NewBackupHistorySqlite = typeof backupHistorySqlite.$inferInsert;
@@ -312,3 +363,17 @@ export type UpgradeHistoryMysql = typeof upgradeHistoryMysql.$inferSelect;
 export type NewUpgradeHistoryMysql = typeof upgradeHistoryMysql.$inferInsert;
 export type SolarEstimateMysql = typeof solarEstimatesMysql.$inferSelect;
 export type NewSolarEstimateMysql = typeof solarEstimatesMysql.$inferInsert;
+
+export type NewsCacheSqlite = typeof newsCacheSqlite.$inferSelect;
+export type NewNewsCacheSqlite = typeof newsCacheSqlite.$inferInsert;
+export type NewsCachePostgres = typeof newsCachePostgres.$inferSelect;
+export type NewNewsCachePostgres = typeof newsCachePostgres.$inferInsert;
+export type NewsCacheMysql = typeof newsCacheMysql.$inferSelect;
+export type NewNewsCacheMysql = typeof newsCacheMysql.$inferInsert;
+
+export type UserNewsStatusSqlite = typeof userNewsStatusSqlite.$inferSelect;
+export type NewUserNewsStatusSqlite = typeof userNewsStatusSqlite.$inferInsert;
+export type UserNewsStatusPostgres = typeof userNewsStatusPostgres.$inferSelect;
+export type NewUserNewsStatusPostgres = typeof userNewsStatusPostgres.$inferInsert;
+export type UserNewsStatusMysql = typeof userNewsStatusMysql.$inferSelect;
+export type NewUserNewsStatusMysql = typeof userNewsStatusMysql.$inferInsert;

--- a/src/server/migrations/054_add_news_tables.ts
+++ b/src/server/migrations/054_add_news_tables.ts
@@ -1,0 +1,190 @@
+/**
+ * Migration 054: Add news cache and user news status tables
+ *
+ * Creates two new tables:
+ * - news_cache: Stores the cached news feed from meshmonitor.org
+ * - user_news_status: Tracks which news items each user has seen/dismissed
+ *
+ * This enables the News Popup feature that shows announcements to users.
+ */
+
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.debug('Running migration 054: Add news tables');
+
+    try {
+      // Create news_cache table
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS news_cache (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          feedData TEXT NOT NULL,
+          fetchedAt INTEGER NOT NULL,
+          sourceUrl TEXT NOT NULL
+        )
+      `);
+
+      // Create user_news_status table
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS user_news_status (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          userId INTEGER NOT NULL,
+          lastSeenNewsId TEXT,
+          dismissedNewsIds TEXT,
+          updatedAt INTEGER NOT NULL,
+          FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
+        )
+      `);
+
+      // Create index on userId for faster lookups
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_user_news_status_userId ON user_news_status(userId)
+      `);
+
+      logger.debug('Migration 054 completed: news tables created');
+    } catch (error) {
+      logger.error('Migration 054 failed:', error);
+      throw error;
+    }
+  },
+
+  down: (db: Database): void => {
+    logger.debug('Running migration 054 down: Remove news tables');
+
+    try {
+      db.exec(`DROP TABLE IF EXISTS user_news_status`);
+      db.exec(`DROP TABLE IF EXISTS news_cache`);
+
+      logger.debug('Migration 054 rollback completed');
+    } catch (error) {
+      logger.error('Migration 054 rollback failed:', error);
+      throw error;
+    }
+  }
+};
+
+/**
+ * PostgreSQL migration: Add news tables
+ */
+export async function runMigration054Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.debug('Running migration 054 (PostgreSQL): Add news tables');
+
+  try {
+    // Check if news_cache table already exists
+    const newsCacheExists = await client.query(`
+      SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = 'news_cache'
+      )
+    `);
+
+    if (!newsCacheExists.rows[0].exists) {
+      await client.query(`
+        CREATE TABLE news_cache (
+          id SERIAL PRIMARY KEY,
+          "feedData" TEXT NOT NULL,
+          "fetchedAt" BIGINT NOT NULL,
+          "sourceUrl" TEXT NOT NULL
+        )
+      `);
+      logger.debug('Created news_cache table');
+    }
+
+    // Check if user_news_status table already exists
+    const userNewsStatusExists = await client.query(`
+      SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = 'user_news_status'
+      )
+    `);
+
+    if (!userNewsStatusExists.rows[0].exists) {
+      await client.query(`
+        CREATE TABLE user_news_status (
+          id SERIAL PRIMARY KEY,
+          "userId" INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          "lastSeenNewsId" TEXT,
+          "dismissedNewsIds" TEXT,
+          "updatedAt" BIGINT NOT NULL
+        )
+      `);
+
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS idx_user_news_status_userId ON user_news_status("userId")
+      `);
+      logger.debug('Created user_news_status table');
+    }
+
+    logger.debug('Migration 054 (PostgreSQL): news tables created');
+  } catch (error) {
+    logger.error('Migration 054 (PostgreSQL) failed:', error);
+    throw error;
+  }
+}
+
+/**
+ * MySQL migration: Add news tables
+ */
+export async function runMigration054Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.debug('Running migration 054 (MySQL): Add news tables');
+
+  try {
+    const connection = await pool.getConnection();
+    try {
+      // Check if news_cache table exists
+      const [newsCacheTables] = await connection.query(`
+        SELECT TABLE_NAME FROM information_schema.tables
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'news_cache'
+      `);
+
+      if ((newsCacheTables as any[]).length === 0) {
+        await connection.query(`
+          CREATE TABLE news_cache (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            feedData TEXT NOT NULL,
+            fetchedAt BIGINT NOT NULL,
+            sourceUrl VARCHAR(512) NOT NULL
+          )
+        `);
+        logger.debug('Created news_cache table');
+      }
+
+      // Check if user_news_status table exists
+      const [userNewsStatusTables] = await connection.query(`
+        SELECT TABLE_NAME FROM information_schema.tables
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'user_news_status'
+      `);
+
+      if ((userNewsStatusTables as any[]).length === 0) {
+        await connection.query(`
+          CREATE TABLE user_news_status (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            userId INT NOT NULL,
+            lastSeenNewsId VARCHAR(128),
+            dismissedNewsIds TEXT,
+            updatedAt BIGINT NOT NULL,
+            FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
+          )
+        `);
+
+        await connection.query(`
+          CREATE INDEX idx_user_news_status_userId ON user_news_status(userId)
+        `);
+        logger.debug('Created user_news_status table');
+      }
+
+      logger.debug('Migration 054 (MySQL): news tables created');
+    } finally {
+      connection.release();
+    }
+  } catch (error) {
+    logger.error('Migration 054 (MySQL) failed:', error);
+    throw error;
+  }
+}

--- a/src/server/routes/newsRoutes.ts
+++ b/src/server/routes/newsRoutes.ts
@@ -1,0 +1,166 @@
+/**
+ * News Routes
+ *
+ * API endpoints for news functionality:
+ * - GET /api/news - Get cached news feed
+ * - GET /api/user/news-status - Get user's news status
+ * - POST /api/user/news-status - Update user's news status
+ */
+
+import express from 'express';
+import { newsService } from '../services/newsService.js';
+import { requireAuth, optionalAuth } from '../auth/authMiddleware.js';
+import { logger } from '../../utils/logger.js';
+
+const router = express.Router();
+
+/**
+ * GET /api/news
+ * Get the cached news feed
+ * Public endpoint - no auth required
+ */
+router.get('/', optionalAuth(), async (_req, res) => {
+  try {
+    const feed = await newsService.getCachedNews();
+
+    if (!feed) {
+      res.json({
+        version: '1',
+        lastUpdated: new Date().toISOString(),
+        items: []
+      });
+      return;
+    }
+
+    res.json(feed);
+  } catch (error) {
+    logger.error('Error getting news feed:', error);
+    res.status(500).json({ error: 'Failed to get news feed' });
+  }
+});
+
+/**
+ * GET /api/user/news-status
+ * Get current user's news status (last seen, dismissed items)
+ * Requires authentication
+ */
+router.get('/user/status', requireAuth(), async (req, res) => {
+  try {
+    const userId = (req as any).user?.id;
+    if (!userId) {
+      res.status(401).json({ error: 'Not authenticated' });
+      return;
+    }
+
+    const status = await newsService.getUserNewsStatus(userId);
+
+    res.json({
+      lastSeenNewsId: status?.lastSeenNewsId || null,
+      dismissedNewsIds: status?.dismissedNewsIds || []
+    });
+  } catch (error) {
+    logger.error('Error getting user news status:', error);
+    res.status(500).json({ error: 'Failed to get news status' });
+  }
+});
+
+/**
+ * POST /api/user/news-status
+ * Update current user's news status
+ * Requires authentication
+ */
+router.post('/user/status', requireAuth(), async (req, res) => {
+  try {
+    const userId = (req as any).user?.id;
+    if (!userId) {
+      res.status(401).json({ error: 'Not authenticated' });
+      return;
+    }
+
+    const { lastSeenNewsId, dismissedNewsIds } = req.body;
+
+    // Validate input
+    if (dismissedNewsIds !== undefined && !Array.isArray(dismissedNewsIds)) {
+      res.status(400).json({ error: 'dismissedNewsIds must be an array' });
+      return;
+    }
+
+    await newsService.saveUserNewsStatus(
+      userId,
+      lastSeenNewsId ?? null,
+      Array.isArray(dismissedNewsIds) ? dismissedNewsIds : []
+    );
+
+    res.json({ success: true });
+  } catch (error) {
+    logger.error('Error saving user news status:', error);
+    res.status(500).json({ error: 'Failed to save news status' });
+  }
+});
+
+/**
+ * POST /api/news/dismiss/:id
+ * Dismiss a specific news item for the current user
+ * Requires authentication
+ */
+router.post('/dismiss/:id', requireAuth(), async (req, res) => {
+  try {
+    const userId = (req as any).user?.id;
+    if (!userId) {
+      res.status(401).json({ error: 'Not authenticated' });
+      return;
+    }
+
+    const newsId = req.params.id;
+    if (!newsId) {
+      res.status(400).json({ error: 'News ID required' });
+      return;
+    }
+
+    // Get current status
+    const currentStatus = await newsService.getUserNewsStatus(userId);
+    const dismissedIds = currentStatus?.dismissedNewsIds || [];
+
+    // Add to dismissed if not already there
+    if (!dismissedIds.includes(newsId)) {
+      dismissedIds.push(newsId);
+    }
+
+    await newsService.saveUserNewsStatus(
+      userId,
+      newsId, // Also update last seen to this item
+      dismissedIds
+    );
+
+    res.json({ success: true });
+  } catch (error) {
+    logger.error('Error dismissing news item:', error);
+    res.status(500).json({ error: 'Failed to dismiss news item' });
+  }
+});
+
+/**
+ * GET /api/news/unread
+ * Get unread news items for the current user
+ * Requires authentication
+ */
+router.get('/unread', requireAuth(), async (req, res) => {
+  try {
+    const userId = (req as any).user?.id;
+    if (!userId) {
+      res.status(401).json({ error: 'Not authenticated' });
+      return;
+    }
+
+    const unreadItems = await newsService.getUnreadNewsForUser(userId);
+
+    res.json({
+      items: unreadItems
+    });
+  } catch (error) {
+    logger.error('Error getting unread news:', error);
+    res.status(500).json({ error: 'Failed to get unread news' });
+  }
+});
+
+export default router;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -33,6 +33,7 @@ import { systemBackupService } from './services/systemBackupService.js';
 import { systemRestoreService } from './services/systemRestoreService.js';
 import { duplicateKeySchedulerService } from './services/duplicateKeySchedulerService.js';
 import { solarMonitoringService } from './services/solarMonitoringService.js';
+import { newsService } from './services/newsService.js';
 import { inactiveNodeNotificationService } from './services/inactiveNodeNotificationService.js';
 import { serverEventNotificationService } from './services/serverEventNotificationService.js';
 import { getUserNotificationPreferencesAsync, saveUserNotificationPreferencesAsync, applyNodeNamePrefix } from './utils/notificationFiltering.js';
@@ -399,6 +400,10 @@ setTimeout(async () => {
     solarMonitoringService.initialize();
     logger.debug('Solar monitoring service initialized');
 
+    // Initialize news service (fetches news from meshmonitor.org)
+    newsService.initialize();
+    logger.debug('News service initialized');
+
     // Initialize database maintenance service
     databaseMaintenanceService.initialize();
     logger.debug('Database maintenance service initialized');
@@ -604,6 +609,7 @@ import linkPreviewRoutes from './routes/linkPreviewRoutes.js';
 import scriptContentRoutes from './routes/scriptContentRoutes.js';
 import apiTokenRoutes from './routes/apiTokenRoutes.js';
 import channelDatabaseRoutes from './routes/channelDatabaseRoutes.js';
+import newsRoutes from './routes/newsRoutes.js';
 import v1Router from './routes/v1/index.js';
 
 // CSRF token endpoint (must be before CSRF protection middleware)
@@ -669,6 +675,9 @@ apiRouter.use('/packets', optionalAuth(), packetRoutes);
 
 // Solar monitoring routes
 apiRouter.use('/solar', optionalAuth(), solarRoutes);
+
+// News routes (public feed, authenticated status endpoints)
+apiRouter.use('/news', newsRoutes);
 
 // Upgrade routes (requires authentication)
 apiRouter.use('/upgrade', upgradeRoutes);

--- a/src/server/services/newsService.ts
+++ b/src/server/services/newsService.ts
@@ -1,0 +1,205 @@
+/**
+ * News Service
+ *
+ * Fetches and caches news from meshmonitor.org on a scheduled basis.
+ * The news is shown to users via a popup after login.
+ */
+
+import * as cron from 'node-cron';
+import databaseService from '../../services/database.js';
+import { logger } from '../../utils/logger.js';
+
+// News feed types
+export interface NewsItem {
+  id: string;
+  title: string;
+  content: string;
+  date: string;
+  category: 'release' | 'security' | 'feature' | 'maintenance';
+  priority: 'normal' | 'important';
+}
+
+export interface NewsFeed {
+  version: string;
+  lastUpdated: string;
+  items: NewsItem[];
+}
+
+const DEFAULT_NEWS_URL = 'https://meshmonitor.org/news.json';
+
+class NewsService {
+  private cronJob: cron.ScheduledTask | null = null;
+  private isInitialized = false;
+
+  /**
+   * Initialize the news service
+   * Sets up the cron job to fetch news every 6 hours
+   */
+  initialize(): void {
+    if (this.isInitialized) {
+      logger.warn('News service is already initialized');
+      return;
+    }
+
+    // Schedule to run every 6 hours (cron: "0 */6 * * *")
+    const cronExpression = '0 */6 * * *';
+
+    if (!cron.validate(cronExpression)) {
+      logger.error('Invalid cron expression for news service');
+      return;
+    }
+
+    this.cronJob = cron.schedule(
+      cronExpression,
+      async () => {
+        logger.info('News service cron job triggered');
+        await this.fetchAndCacheNews();
+      },
+      {
+        timezone: 'Etc/UTC'
+      }
+    );
+
+    // Explicitly start the cron job
+    this.cronJob.start();
+
+    this.isInitialized = true;
+    logger.info('News service initialized (runs every 6 hours)');
+
+    // Run initial fetch
+    logger.info('Running initial news fetch...');
+    this.fetchAndCacheNews().catch(err => {
+      logger.error('Initial news fetch failed:', err);
+    });
+  }
+
+  /**
+   * Fetch news from the configured URL and store in database
+   */
+  async fetchAndCacheNews(): Promise<void> {
+    try {
+      const url = process.env.NEWS_FEED_URL || DEFAULT_NEWS_URL;
+      logger.debug(`Fetching news from: ${url}`);
+
+      const response = await fetch(url, {
+        headers: {
+          'Accept': 'application/json',
+          'User-Agent': 'MeshMonitor News Service'
+        },
+        signal: AbortSignal.timeout(30000) // 30 second timeout
+      });
+
+      if (!response.ok) {
+        logger.error(`Failed to fetch news: HTTP ${response.status}`);
+        return;
+      }
+
+      const data = await response.json() as NewsFeed;
+
+      // Validate the feed structure
+      if (!data || !data.items || !Array.isArray(data.items)) {
+        logger.warn('Invalid news feed structure');
+        return;
+      }
+
+      // Store in database
+      await databaseService.saveNewsCacheAsync(JSON.stringify(data), url);
+
+      logger.info(`Stored news feed with ${data.items.length} items`);
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        logger.error('News fetch timed out');
+      } else {
+        logger.error('Error fetching or storing news:', error);
+      }
+    }
+  }
+
+  /**
+   * Stop the news service
+   */
+  stop(): void {
+    if (this.cronJob) {
+      this.cronJob.stop();
+      this.cronJob = null;
+      this.isInitialized = false;
+      logger.info('News service stopped');
+    }
+  }
+
+  /**
+   * Manually trigger a news fetch (for testing)
+   */
+  async triggerFetch(): Promise<void> {
+    logger.info('Manually triggering news fetch...');
+    await this.fetchAndCacheNews();
+  }
+
+  /**
+   * Get cached news feed from database
+   */
+  async getCachedNews(): Promise<NewsFeed | null> {
+    try {
+      const cache = await databaseService.getNewsCacheAsync();
+      if (!cache) {
+        return null;
+      }
+
+      const feed = JSON.parse(cache.feedData) as NewsFeed;
+      return feed;
+    } catch (error) {
+      logger.error('Error retrieving cached news:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Get user's news status
+   */
+  async getUserNewsStatus(userId: number): Promise<{ lastSeenNewsId: string | null; dismissedNewsIds: string[] } | null> {
+    try {
+      return await databaseService.getUserNewsStatusAsync(userId);
+    } catch (error) {
+      logger.error('Error retrieving user news status:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Update user's news status
+   */
+  async saveUserNewsStatus(userId: number, lastSeenNewsId: string | null, dismissedNewsIds: string[]): Promise<void> {
+    try {
+      await databaseService.saveUserNewsStatusAsync(userId, lastSeenNewsId, dismissedNewsIds);
+    } catch (error) {
+      logger.error('Error saving user news status:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get unread news for a user
+   * Returns news items that the user hasn't dismissed
+   */
+  async getUnreadNewsForUser(userId: number): Promise<NewsItem[]> {
+    try {
+      const feed = await this.getCachedNews();
+      if (!feed || !feed.items || feed.items.length === 0) {
+        return [];
+      }
+
+      const userStatus = await this.getUserNewsStatus(userId);
+      const dismissedIds = new Set(userStatus?.dismissedNewsIds || []);
+
+      // Filter out dismissed items
+      return feed.items.filter(item => !dismissedIds.has(item.id));
+    } catch (error) {
+      logger.error('Error getting unread news for user:', error);
+      return [];
+    }
+  }
+}
+
+// Export singleton instance
+export const newsService = new NewsService();
+export default newsService;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1251,6 +1251,73 @@ class ApiService {
   }> {
     return this.get('/api/channel-database/retroactive-decrypt/progress');
   }
+
+  // ==================== News API ====================
+
+  /**
+   * Get cached news feed
+   */
+  async getNewsFeed(): Promise<{
+    version: string;
+    lastUpdated: string;
+    items: Array<{
+      id: string;
+      title: string;
+      content: string;
+      date: string;
+      category: 'release' | 'security' | 'feature' | 'maintenance';
+      priority: 'normal' | 'important';
+    }>;
+  }> {
+    return this.get('/api/news');
+  }
+
+  /**
+   * Get user's news status (last seen, dismissed items)
+   */
+  async getUserNewsStatus(): Promise<{
+    lastSeenNewsId: string | null;
+    dismissedNewsIds: string[];
+  }> {
+    return this.get('/api/news/user/status');
+  }
+
+  /**
+   * Update user's news status
+   */
+  async updateUserNewsStatus(lastSeenNewsId: string | null, dismissedNewsIds: string[]): Promise<{
+    success: boolean;
+  }> {
+    return this.post('/api/news/user/status', {
+      lastSeenNewsId,
+      dismissedNewsIds,
+    });
+  }
+
+  /**
+   * Dismiss a specific news item
+   */
+  async dismissNewsItem(newsId: string): Promise<{
+    success: boolean;
+  }> {
+    return this.post(`/api/news/dismiss/${newsId}`);
+  }
+
+  /**
+   * Get unread news items for the current user
+   */
+  async getUnreadNews(): Promise<{
+    items: Array<{
+      id: string;
+      title: string;
+      content: string;
+      date: string;
+      category: 'release' | 'security' | 'feature' | 'maintenance';
+      priority: 'normal' | 'important';
+    }>;
+  }> {
+    return this.get('/api/news/unread');
+  }
 }
 
 // Channel Database types

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -92,3 +92,32 @@ export interface NodeFilters {
  * Security filter options
  */
 export type SecurityFilter = 'all' | 'flaggedOnly' | 'hideFlagged';
+
+/**
+ * News item from meshmonitor.org
+ */
+export interface NewsItem {
+  id: string;
+  title: string;
+  content: string;
+  date: string;
+  category: 'release' | 'security' | 'feature' | 'maintenance';
+  priority: 'normal' | 'important';
+}
+
+/**
+ * News feed containing multiple items
+ */
+export interface NewsFeed {
+  version: string;
+  lastUpdated: string;
+  items: NewsItem[];
+}
+
+/**
+ * User's news status (what they've seen/dismissed)
+ */
+export interface UserNewsStatus {
+  lastSeenNewsId: string | null;
+  dismissedNewsIds: string[];
+}


### PR DESCRIPTION
## Summary
- Adds a news popup system that displays announcements from meshmonitor.org to users after login
- News service fetches and caches news feed every 6 hours with configurable `NEWS_FEED_URL`
- NewsPopup component with markdown rendering, category badges, and pagination
- Per-user dismiss tracking persisted in database (works across browsers/sessions)
- Sidebar news button to view all announcements on demand
- Full support for SQLite, PostgreSQL, and MySQL backends
- Updates FAQ documentation with new "Understanding Channel Permissions" section explaining the tri-state permission system

## Test plan
- [x] Build passes
- [x] Test suite passes (87 files, 1990 tests)
- [x] Manual testing: login shows popup with news items
- [x] Manual testing: "Don't show again" checkbox dismisses items
- [x] Manual testing: sidebar news button shows all items
- [x] Verified database migrations work for all 3 backends
- [x] Verified NEWS_FEED_URL configuration works

🤖 Generated with [Claude Code](https://claude.com/claude-code)