### PR TITLE
fix(backup): add missing backup tables to PostgreSQL/MySQL schemas

### DIFF
--- a/src/db/schema/mysql-create.ts
+++ b/src/db/schema/mysql-create.ts
@@ -305,15 +305,29 @@ export const MYSQL_SCHEMA_SQL = `
 
   CREATE TABLE IF NOT EXISTS backup_history (
     id INT AUTO_INCREMENT PRIMARY KEY,
+    nodeId VARCHAR(255),
+    nodeNum BIGINT,
     filename VARCHAR(255) NOT NULL,
     filePath TEXT NOT NULL,
-    sizeBytes BIGINT NOT NULL,
-    schemaVersion INT NOT NULL,
-    nodeCount INT,
-    messageCount INT,
+    fileSize BIGINT,
+    backupType VARCHAR(50) NOT NULL,
+    timestamp BIGINT NOT NULL,
     createdAt BIGINT NOT NULL,
-    createdBy TEXT,
-    notes TEXT
+    INDEX idx_backup_history_timestamp (timestamp DESC)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+  CREATE TABLE IF NOT EXISTS system_backup_history (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    dirname VARCHAR(255) NOT NULL UNIQUE,
+    timestamp BIGINT NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    size BIGINT NOT NULL,
+    table_count INT NOT NULL,
+    meshmonitor_version VARCHAR(32) NOT NULL,
+    schema_version INT NOT NULL,
+    createdAt BIGINT NOT NULL,
+    INDEX idx_system_backup_history_timestamp (timestamp DESC),
+    INDEX idx_system_backup_history_type (type)
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
   CREATE TABLE IF NOT EXISTS upgrade_history (
@@ -453,6 +467,7 @@ export const MYSQL_TABLE_NAMES = [
   'user_notification_preferences',
   'packet_log',
   'backup_history',
+  'system_backup_history',
   'upgrade_history',
   'custom_themes',
   'user_map_preferences',

--- a/src/db/schema/postgres-create.ts
+++ b/src/db/schema/postgres-create.ts
@@ -284,15 +284,26 @@ export const POSTGRES_SCHEMA_SQL = `
 
   CREATE TABLE IF NOT EXISTS backup_history (
     id SERIAL PRIMARY KEY,
+    "nodeId" TEXT,
+    "nodeNum" BIGINT,
     filename TEXT NOT NULL,
     "filePath" TEXT NOT NULL,
-    "sizeBytes" BIGINT NOT NULL,
-    "schemaVersion" INTEGER NOT NULL,
-    "nodeCount" INTEGER,
-    "messageCount" INTEGER,
-    "createdAt" BIGINT NOT NULL,
-    "createdBy" TEXT,
-    notes TEXT
+    "fileSize" BIGINT,
+    "backupType" TEXT NOT NULL,
+    timestamp BIGINT NOT NULL,
+    "createdAt" BIGINT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS system_backup_history (
+    id SERIAL PRIMARY KEY,
+    dirname TEXT NOT NULL UNIQUE,
+    timestamp BIGINT NOT NULL,
+    type TEXT NOT NULL,
+    size BIGINT NOT NULL,
+    table_count INTEGER NOT NULL,
+    meshmonitor_version TEXT NOT NULL,
+    schema_version INTEGER NOT NULL,
+    "createdAt" BIGINT NOT NULL
   );
 
   CREATE TABLE IF NOT EXISTS upgrade_history (
@@ -414,6 +425,9 @@ export const POSTGRES_SCHEMA_SQL = `
   CREATE INDEX IF NOT EXISTS idx_sessions_expire ON sessions(expire);
   CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp ON audit_log(timestamp);
   CREATE INDEX IF NOT EXISTS idx_packet_log_createdat ON packet_log(created_at);
+  CREATE INDEX IF NOT EXISTS idx_backup_history_timestamp ON backup_history(timestamp DESC);
+  CREATE INDEX IF NOT EXISTS idx_system_backup_history_timestamp ON system_backup_history(timestamp DESC);
+  CREATE INDEX IF NOT EXISTS idx_system_backup_history_type ON system_backup_history(type);
 `;
 
 export const POSTGRES_TABLE_NAMES = [
@@ -435,6 +449,7 @@ export const POSTGRES_TABLE_NAMES = [
   'user_notification_preferences',
   'packet_log',
   'backup_history',
+  'system_backup_history',
   'upgrade_history',
   'custom_themes',
   'user_map_preferences',

--- a/src/server/migrations/056_fix_backup_history_columns.ts
+++ b/src/server/migrations/056_fix_backup_history_columns.ts
@@ -1,0 +1,120 @@
+/**
+ * Migration 056: Fix backup_history column names
+ *
+ * The original migration 013 created backup_history with column names:
+ * - filepath (lowercase)
+ * - type
+ * - size
+ *
+ * But the current backupFileService.ts expects:
+ * - filePath (camelCase)
+ * - backupType
+ * - fileSize
+ *
+ * This migration renames the columns to match the service expectations.
+ * SQLite requires recreating the table to rename columns.
+ */
+
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.debug('Running migration 056: Fix backup_history column names');
+
+    try {
+      // Check if we need to migrate (if old column names exist)
+      const tableInfo = db.prepare("PRAGMA table_info(backup_history)").all() as any[];
+      const hasOldColumns = tableInfo.some((col: any) => col.name === 'filepath' || col.name === 'type' || col.name === 'size');
+      const hasNewColumns = tableInfo.some((col: any) => col.name === 'filePath' || col.name === 'backupType' || col.name === 'fileSize');
+
+      if (hasNewColumns && !hasOldColumns) {
+        logger.debug('backup_history already has new column names, skipping migration');
+        return;
+      }
+
+      if (!hasOldColumns && !hasNewColumns) {
+        logger.debug('backup_history table does not exist or has unexpected schema, skipping migration');
+        return;
+      }
+
+      // SQLite doesn't support RENAME COLUMN in older versions, so we need to recreate the table
+      db.exec(`
+        -- Create new table with correct column names
+        CREATE TABLE IF NOT EXISTS backup_history_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          nodeId TEXT,
+          nodeNum INTEGER,
+          filename TEXT NOT NULL,
+          filePath TEXT NOT NULL,
+          fileSize INTEGER,
+          backupType TEXT NOT NULL,
+          timestamp INTEGER NOT NULL,
+          createdAt INTEGER NOT NULL
+        );
+
+        -- Copy data from old table to new table
+        INSERT INTO backup_history_new (id, filename, filePath, fileSize, backupType, timestamp, createdAt)
+        SELECT id, filename, filepath, size, type, timestamp, createdAt
+        FROM backup_history;
+
+        -- Drop old table
+        DROP TABLE backup_history;
+
+        -- Rename new table to original name
+        ALTER TABLE backup_history_new RENAME TO backup_history;
+
+        -- Recreate indexes
+        CREATE INDEX IF NOT EXISTS idx_backup_history_timestamp ON backup_history(timestamp DESC);
+      `);
+
+      logger.debug('Successfully migrated backup_history columns');
+    } catch (error: any) {
+      if (error.message && error.message.includes('no such table')) {
+        logger.debug('backup_history table does not exist, skipping migration');
+      } else {
+        logger.error('Migration 056 failed:', error);
+        throw error;
+      }
+    }
+  },
+
+  down: (db: Database): void => {
+    logger.debug('Reverting migration 056: Restore old backup_history column names');
+
+    try {
+      db.exec(`
+        -- Create table with old column names
+        CREATE TABLE IF NOT EXISTS backup_history_old (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          filename TEXT NOT NULL UNIQUE,
+          filepath TEXT NOT NULL,
+          timestamp INTEGER NOT NULL,
+          type TEXT NOT NULL CHECK(type IN ('manual', 'automatic')),
+          size INTEGER NOT NULL,
+          createdAt INTEGER NOT NULL
+        );
+
+        -- Copy data back
+        INSERT INTO backup_history_old (id, filename, filepath, timestamp, type, size, createdAt)
+        SELECT id, filename, filePath, timestamp, backupType, fileSize, createdAt
+        FROM backup_history;
+
+        -- Drop new table
+        DROP TABLE backup_history;
+
+        -- Rename to original name
+        ALTER TABLE backup_history_old RENAME TO backup_history;
+
+        -- Recreate indexes
+        CREATE INDEX IF NOT EXISTS idx_backup_history_timestamp ON backup_history(timestamp DESC);
+        CREATE INDEX IF NOT EXISTS idx_backup_history_type ON backup_history(type);
+      `);
+
+      logger.debug('Successfully reverted backup_history columns');
+    } catch (error) {
+      logger.error('Migration 056 rollback failed:', error);
+      throw error;
+    }
+  }
+};


### PR DESCRIPTION
## Summary

- Add `system_backup_history` table to `postgres-create.ts` and `mysql-create.ts` for new deployments
- Fix `backup_history` schema to use correct column names for device backups (`nodeId`, `nodeNum`, `filePath`, `fileSize`, `backupType`, `timestamp`)
- Add migration 056 to rename SQLite `backup_history` columns from old names (`filepath`, `type`, `size`) to new names (`filePath`, `backupType`, `fileSize`)

This ensures starting from a blank database works correctly for all three backends (SQLite, PostgreSQL, MySQL).

Relates to #1575

## Test plan

- [ ] Verify build succeeds
- [ ] Test fresh PostgreSQL deployment - both device and system backups should work
- [ ] Test fresh MySQL deployment - both device and system backups should work  
- [ ] Test existing SQLite deployment - migration 056 should rename columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)