### PR TITLE
feat(admin): set hasRemoteAdmin flag on successful remote operations

### DIFF
--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -1301,6 +1301,9 @@ export class NodesRepository extends BaseRepository {
 
   /**
    * Update a node's remote admin status
+   * @param nodeNum The node number to update
+   * @param hasRemoteAdmin Whether the node has remote admin access
+   * @param metadata Optional metadata to save (if null, existing metadata is preserved)
    */
   async updateNodeRemoteAdminStatusAsync(
     nodeNum: number,
@@ -1309,39 +1312,40 @@ export class NodesRepository extends BaseRepository {
   ): Promise<void> {
     const now = Date.now();
 
+    // Build update object - only include metadata if provided (not null)
+    const baseUpdate = {
+      hasRemoteAdmin: hasRemoteAdmin,
+      lastRemoteAdminCheck: now,
+      updatedAt: now,
+    };
+
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
+      const updateData = metadata !== null
+        ? { ...baseUpdate, remoteAdminMetadata: metadata }
+        : baseUpdate;
       await db
         .update(nodesSqlite)
-        .set({
-          hasRemoteAdmin: hasRemoteAdmin,
-          lastRemoteAdminCheck: now,
-          remoteAdminMetadata: metadata,
-          updatedAt: now,
-        })
+        .set(updateData as any)
         .where(eq(nodesSqlite.nodeNum, nodeNum));
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
+      const updateData = metadata !== null
+        ? { ...baseUpdate, remoteAdminMetadata: metadata }
+        : baseUpdate;
       await db
         .update(nodesMysql)
-        .set({
-          hasRemoteAdmin: hasRemoteAdmin,
-          lastRemoteAdminCheck: now,
-          remoteAdminMetadata: metadata,
-          updatedAt: now,
-        })
+        .set(updateData as any)
         .where(eq(nodesMysql.nodeNum, nodeNum));
     } else {
       // PostgreSQL
       const db = this.getPostgresDb();
+      const updateData = metadata !== null
+        ? { ...baseUpdate, remoteAdminMetadata: metadata }
+        : baseUpdate;
       await db
         .update(nodesPostgres)
-        .set({
-          hasRemoteAdmin: hasRemoteAdmin,
-          lastRemoteAdminCheck: now,
-          remoteAdminMetadata: metadata,
-          updatedAt: now,
-        })
+        .set(updateData as any)
         .where(eq(nodesPostgres.nodeNum, nodeNum));
     }
   }


### PR DESCRIPTION
## Summary

- Update `/api/admin/get-device-metadata` to save metadata to database and set `hasRemoteAdmin=true` after successful retrieval from remote node
- Update `/api/admin/commands` to set `hasRemoteAdmin=true` after any successful admin command on a remote node  
- Modify `updateNodeRemoteAdminStatusAsync` to preserve existing metadata when only updating the flag (pass `null` to skip metadata update)

This allows nodes to be recognized as having remote admin access after any successful operation from the Remote Admin page, not just from the Remote Admin Scanner.

## Test plan

- [ ] Select a remote node on Remote Admin page
- [ ] Execute any admin command (e.g., reboot, save config)
- [ ] Verify node's `hasRemoteAdmin` flag is set to `true`
- [ ] Click "Retrieve Device Metadata" for a remote node
- [ ] Verify metadata is saved and `hasRemoteAdmin` is set to `true`
- [ ] Verify existing metadata is preserved when running subsequent commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)