### PR TITLE
fix(migration): make backup_history migration more robust

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.2.1
-appVersion: "3.2.1"
+version: 3.2.2
+appVersion: "3.2.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Fixed migration 056 failing when `backup_history` table has unexpected schema
- Migration now handles various table states gracefully:
  - Creates table if it doesn't exist
  - Recreates table if schema is unexpected
  - Validates required columns before migration
  - Logs column names for debugging
- Bumps version to 3.2.2

## Problem
Upgrading to v3.2.1 failed on StationG2 with error: `column timestamp does not exist`

The migration assumed the table had specific old-style columns, but the actual table had a different schema without the `timestamp` column.

## Test Plan
- [ ] Build succeeds
- [ ] Deploy to StationG2 and verify startup
- [ ] Verify device backups work after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)