### PR TITLE
fix(migration): add PostgreSQL/MySQL support to migration 056

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.2.2
-appVersion: "3.2.2"
+version: 3.2.3
+appVersion: "3.2.3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Migration 056 (backup_history column fix) now supports PostgreSQL and MySQL
- Migration runs BEFORE schema SQL to fix tables before index creation fails
- Bumps version to 3.2.3

## Problem
v3.2.1 and v3.2.2 failed to start on PostgreSQL when `backup_history` table existed with incorrect schema. The error was:
```
error: column "timestamp" does not exist
  file: 'indexcmds.c', line: '1891', routine: 'ComputeIndexAttrs'
```

The schema SQL tried to create an index on `backup_history(timestamp)`, but the existing table didn't have that column.

## Solution
- Added `runMigration056Postgres()` and `runMigration056Mysql()` functions
- These migrations run BEFORE the schema SQL
- They check if the table has incorrect schema and recreate it if needed

## Test Plan
- [ ] Build succeeds
- [ ] Deploy to StationG2 (PostgreSQL) and verify startup
- [ ] Verify device backups work

🤖 Generated with [Claude Code](https://claude.com/claude-code)