### PR TITLE
fix(api): use read permission instead of viewOnMap for V1 API nodes

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.2.3
-appVersion: "3.2.3"
+version: 3.2.4
+appVersion: "3.2.4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- V1 API `/nodes` endpoint now uses `read` permission instead of `viewOnMap`
- Adds backwards compatibility for users without channel permissions
- Bumps version to 3.2.4

## Problem
External tools like MeshManager using the V1 API were getting 0 nodes because:
1. The endpoint used `filterNodesByChannelPermission` which checks `viewOnMap`
2. `viewOnMap` is for map display, not API data access
3. Users without explicit channel permissions (older users, or users with only `nodes:read`) got empty permission sets and all nodes were filtered out

## Solution
- Created new `filterNodesByChannelReadPermission` function that checks `channel_X:read`
- Added backwards compatibility: users with `nodes:read` but no channel permissions see all nodes
- V1 nodes endpoint now uses the new function

## Test Plan
- [x] Build succeeds
- [x] V1 API tests pass (43 tests)
- [x] nodeEnhancer tests pass (12 tests)
- [ ] Deploy and verify external tools get nodes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)