### PR TITLE
feat(ui): add custom emoji option to tapback picker

### DIFF
--- a/src/components/EmojiPickerModal/EmojiPickerModal.css
+++ b/src/components/EmojiPickerModal/EmojiPickerModal.css
@@ -78,6 +78,64 @@
   transform: scale(0.95);
 }
 
+/* Custom emoji button styling */
+.emoji-picker-custom-btn {
+  background: var(--ctp-surface0);
+  font-size: 1rem !important;
+}
+
+.emoji-picker-custom-btn:hover {
+  background: var(--ctp-surface1);
+}
+
+/* Custom emoji input section */
+.emoji-picker-custom-input {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem 1rem;
+  border-top: 1px solid var(--ctp-surface0);
+}
+
+.emoji-picker-custom-input input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--ctp-surface1);
+  border-radius: 6px;
+  background: var(--ctp-surface0);
+  color: var(--ctp-text);
+  font-size: 1rem;
+}
+
+.emoji-picker-custom-input input:focus {
+  outline: none;
+  border-color: var(--ctp-blue);
+}
+
+.emoji-picker-custom-input input::placeholder {
+  color: var(--ctp-subtext0);
+}
+
+.emoji-picker-custom-input button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 6px;
+  background: var(--ctp-blue);
+  color: var(--ctp-base);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s, opacity 0.2s;
+}
+
+.emoji-picker-custom-input button:hover:not(:disabled) {
+  background: var(--ctp-sapphire);
+}
+
+.emoji-picker-custom-input button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Responsive adjustments */
 @media (max-width: 480px) {
   .emoji-picker-grid {
@@ -87,5 +145,13 @@
   .emoji-picker-item {
     font-size: 1.25rem;
     padding: 0.4rem;
+  }
+
+  .emoji-picker-custom-input {
+    flex-direction: column;
+  }
+
+  .emoji-picker-custom-input button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- Add a "Custom" button (✏️) to the emoji picker modal on Channels and Messages pages
- Allows users to enter any emoji from their keyboard for one-time use
- Input field appears below emoji grid when custom button is clicked

## Features
- Auto-focuses input for immediate typing
- Submit with Enter key or Send button
- Cancel with Escape key
- Responsive styling for mobile devices (stacks vertically)
- Max 10 character limit to prevent abuse

## Test plan
- [ ] Open Channels or Messages page
- [ ] Click 😄 button on any message to open emoji picker
- [ ] Verify ✏️ button appears at end of emoji grid
- [ ] Click ✏️ button - input field should appear and auto-focus
- [ ] Type or paste an emoji, press Enter - should send and close modal
- [ ] Reopen, click ✏️, press Escape - should hide input
- [ ] Test on mobile viewport - input should stack vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)