### PR TITLE
fix(admin): disable security config save button

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3093,6 +3093,7 @@
   "admin_commands.admin_channel_enabled": "Admin Channel Enabled",
   "admin_commands.admin_channel_enabled_description": "Allow incoming device control over the insecure legacy admin channel",
   "admin_commands.save_security_config": "Save Security Config",
+  "admin_commands.security_save_disabled": "Saving security config is temporarily disabled due to a firmware compatibility issue",
   "admin_commands.security_config_loaded": "Security config loaded successfully",
   "admin_commands.failed_load_security_config": "Failed to load security config",
 

--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -2605,13 +2605,14 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
         <button
           className="save-button"
           onClick={handleSetSecurityConfig}
-          disabled={isExecuting || selectedNodeNum === null}
+          disabled={true}
+          title={t('admin_commands.security_save_disabled')}
           style={{
-            opacity: (isExecuting || selectedNodeNum === null) ? 0.5 : 1,
-            cursor: (isExecuting || selectedNodeNum === null) ? 'not-allowed' : 'pointer'
+            opacity: 0.5,
+            cursor: 'not-allowed'
           }}
         >
-          {isExecuting ? t('common.saving') : t('admin_commands.save_security_config')}
+          {t('admin_commands.save_security_config')}
         </button>
       </CollapsibleSection>
 


### PR DESCRIPTION
Temporarily disable the Save Security Config button in the Remote Admin page due to a firmware compatibility issue where saving security config corrupts node keys.

Users can still load and view security config, but cannot save until the underlying issue is resolved.