### PR TITLE
chore: bump version to 3.2.4

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.2.3
-appVersion: "3.2.3"
+version: 3.2.4
+appVersion: "3.2.4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Bump version to 3.2.4 for release.

## Changes Since 3.2.3
- #1603 - Virtual node now sends message history to connecting clients
- #1604 - Sidebar pin button and fix upgrade banner auto-dismiss  
- #1605 - Desktop app virtual node config options

## Files Changed
- `package.json` - version 3.2.4
- `package-lock.json` - regenerated
- `helm/meshmonitor/Chart.yaml` - version 3.2.4
- `desktop/src-tauri/tauri.conf.json` - version 3.2.4

## System Test Results

**Test Run:** 2026-01-24 17:46:28 EST

| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| V1 API Test | ✅ PASSED |
| Reverse Proxy Test | ✅ PASSED |
| Reverse Proxy + OIDC | ✅ PASSED |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |
| Database Migration Test | ✅ PASSED |

## ✅ Overall Result: PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)