### PR TITLE
feat(admin): add telemetry configuration to remote admin

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -34,6 +34,32 @@
 
 ## Current Sprint
 
+### Remote Admin Telemetry Configuration (#1589)
+
+**Completed:**
+- [x] Add TelemetryConfigState interface to useAdminCommandsState.ts
+  - 10 telemetry configuration fields (device interval, environment, air quality, power)
+  - SET_TELEMETRY_CONFIG action type and reducer case
+  - setTelemetryConfig callback function
+- [x] Add telemetry section to ModuleConfigurationSection.tsx
+  - Device Telemetry: update interval
+  - Environment Telemetry: enabled, interval, screen display, Fahrenheit
+  - Advanced Settings (collapsible): Air Quality and Power metrics
+- [x] Wire telemetry in AdminCommandsTab.tsx
+  - Add telemetry to sectionLoadStatus initial state
+  - handleTelemetryConfigChange and handleSetTelemetryConfig callbacks
+  - Case for loading telemetry config in handleLoadSingleConfig
+  - Pass telemetry props to ModuleConfigurationSection
+- [x] Add setTelemetryConfig case to server.ts admin/commands endpoint
+- [x] Add telemetry (config type 5) to moduleConfigMap in meshtasticManager.ts
+- [x] Add telemetry_config_short translation key to en.json
+- [x] Build successful, TypeScript check passed
+
+**Summary:**
+Added Telemetry Configuration section to the Admin Commands tab's Module Configuration area. Users can now remotely configure device metrics interval, environment sensors (enabled, interval, screen, Fahrenheit), air quality metrics, and power metrics for remote nodes.
+
+---
+
 ### Channel-Based Node Visibility (Discussion #1503)
 
 **Completed:**

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3234,6 +3234,7 @@
   "admin_commands.channels_config_short": "Channels",
   "admin_commands.bluetooth_config_short": "Bluetooth",
   "admin_commands.neighborinfo_config_short": "Neighbor Info",
+  "admin_commands.telemetry_config_short": "Telemetry",
   "admin_commands.load_section": "Load {{section}}",
   "admin_commands.load_button": "Load",
   "admin_commands.section_loaded": "Section loaded successfully",

--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -42,6 +42,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
     setNeighborInfoConfig,
     setOwnerConfig,
     setDeviceConfig,
+    setTelemetryConfig,
   } = useAdminCommandsState();
 
   // UI and non-config state (keep as useState for now)
@@ -97,6 +98,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
     bluetooth: 'idle',
     network: 'idle',
     neighborinfo: 'idle',
+    telemetry: 'idle',
     owner: 'idle',
     channels: 'idle'
   });
@@ -967,6 +969,20 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                   transmitOverLora: config.transmitOverLora
                 });
                 break;
+              case 'telemetry':
+                setTelemetryConfig({
+                  deviceUpdateInterval: config.deviceUpdateInterval ?? 900,
+                  environmentUpdateInterval: config.environmentUpdateInterval ?? 900,
+                  environmentMeasurementEnabled: config.environmentMeasurementEnabled ?? false,
+                  environmentScreenEnabled: config.environmentScreenEnabled ?? false,
+                  environmentDisplayFahrenheit: config.environmentDisplayFahrenheit ?? false,
+                  airQualityEnabled: config.airQualityEnabled ?? false,
+                  airQualityInterval: config.airQualityInterval ?? 900,
+                  powerMeasurementEnabled: config.powerMeasurementEnabled ?? false,
+                  powerUpdateInterval: config.powerUpdateInterval ?? 900,
+                  powerScreenEnabled: config.powerScreenEnabled ?? false
+                });
+                break;
             }
             setSectionLoadStatus(prev => ({ ...prev, [configType]: 'success' }));
             showToast(t('admin_commands.config_loaded_success', { configType: t(`admin_commands.${configType}_config_short`, configType) }), 'success');
@@ -1611,6 +1627,32 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       console.error('Set NeighborInfo config command failed:', error);
     }
   }, [configState.neighborInfo, executeCommand]);
+
+  const handleTelemetryConfigChange = useCallback((field: string, value: any) => {
+    setTelemetryConfig({ [field]: value });
+  }, [setTelemetryConfig]);
+
+  const handleSetTelemetryConfig = useCallback(async () => {
+    const config: any = {
+      deviceUpdateInterval: configState.telemetry.deviceUpdateInterval,
+      environmentUpdateInterval: configState.telemetry.environmentUpdateInterval,
+      environmentMeasurementEnabled: configState.telemetry.environmentMeasurementEnabled,
+      environmentScreenEnabled: configState.telemetry.environmentScreenEnabled,
+      environmentDisplayFahrenheit: configState.telemetry.environmentDisplayFahrenheit,
+      airQualityEnabled: configState.telemetry.airQualityEnabled,
+      airQualityInterval: configState.telemetry.airQualityInterval,
+      powerMeasurementEnabled: configState.telemetry.powerMeasurementEnabled,
+      powerUpdateInterval: configState.telemetry.powerUpdateInterval,
+      powerScreenEnabled: configState.telemetry.powerScreenEnabled
+    };
+
+    try {
+      await executeCommand('setTelemetryConfig', { config });
+    } catch (error) {
+      // Error already handled by executeCommand (toast shown)
+      console.error('Set Telemetry config command failed:', error);
+    }
+  }, [configState.telemetry, executeCommand]);
 
   const handleAdminKeyChange = (index: number, value: string) => {
     setAdminKey(index, value);
@@ -2828,10 +2870,23 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
         neighborInfoTransmitOverLora={configState.neighborInfo.transmitOverLora}
         onNeighborInfoConfigChange={handleNeighborInfoConfigChange}
         onSaveNeighborInfoConfig={handleSetNeighborInfoConfig}
+        telemetryDeviceUpdateInterval={configState.telemetry.deviceUpdateInterval}
+        telemetryEnvironmentUpdateInterval={configState.telemetry.environmentUpdateInterval}
+        telemetryEnvironmentMeasurementEnabled={configState.telemetry.environmentMeasurementEnabled}
+        telemetryEnvironmentScreenEnabled={configState.telemetry.environmentScreenEnabled}
+        telemetryEnvironmentDisplayFahrenheit={configState.telemetry.environmentDisplayFahrenheit}
+        telemetryAirQualityEnabled={configState.telemetry.airQualityEnabled}
+        telemetryAirQualityInterval={configState.telemetry.airQualityInterval}
+        telemetryPowerMeasurementEnabled={configState.telemetry.powerMeasurementEnabled}
+        telemetryPowerUpdateInterval={configState.telemetry.powerUpdateInterval}
+        telemetryPowerScreenEnabled={configState.telemetry.powerScreenEnabled}
+        onTelemetryConfigChange={handleTelemetryConfigChange}
+        onSaveTelemetryConfig={handleSetTelemetryConfig}
         isExecuting={isExecuting}
         selectedNodeNum={selectedNodeNum}
         mqttHeaderActions={renderSectionLoadButton('mqtt')}
         neighborInfoHeaderActions={renderSectionLoadButton('neighborinfo')}
+        telemetryHeaderActions={renderSectionLoadButton('telemetry')}
       />
 
       {/* Import/Export Configuration Section */}

--- a/src/components/admin-commands/ModuleConfigurationSection.tsx
+++ b/src/components/admin-commands/ModuleConfigurationSection.tsx
@@ -31,6 +31,20 @@ interface ModuleConfigurationSectionProps {
   onNeighborInfoConfigChange: (field: string, value: any) => void;
   onSaveNeighborInfoConfig: () => Promise<void>;
 
+  // Telemetry Config
+  telemetryDeviceUpdateInterval: number;
+  telemetryEnvironmentUpdateInterval: number;
+  telemetryEnvironmentMeasurementEnabled: boolean;
+  telemetryEnvironmentScreenEnabled: boolean;
+  telemetryEnvironmentDisplayFahrenheit: boolean;
+  telemetryAirQualityEnabled: boolean;
+  telemetryAirQualityInterval: number;
+  telemetryPowerMeasurementEnabled: boolean;
+  telemetryPowerUpdateInterval: number;
+  telemetryPowerScreenEnabled: boolean;
+  onTelemetryConfigChange: (field: string, value: any) => void;
+  onSaveTelemetryConfig: () => Promise<void>;
+
   // Common
   isExecuting: boolean;
   selectedNodeNum: number | null;
@@ -38,6 +52,7 @@ interface ModuleConfigurationSectionProps {
   // Section header actions (load buttons)
   mqttHeaderActions?: React.ReactNode;
   neighborInfoHeaderActions?: React.ReactNode;
+  telemetryHeaderActions?: React.ReactNode;
 }
 
 export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProps> = ({
@@ -56,10 +71,23 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
   neighborInfoTransmitOverLora,
   onNeighborInfoConfigChange,
   onSaveNeighborInfoConfig,
+  telemetryDeviceUpdateInterval,
+  telemetryEnvironmentUpdateInterval,
+  telemetryEnvironmentMeasurementEnabled,
+  telemetryEnvironmentScreenEnabled,
+  telemetryEnvironmentDisplayFahrenheit,
+  telemetryAirQualityEnabled,
+  telemetryAirQualityInterval,
+  telemetryPowerMeasurementEnabled,
+  telemetryPowerUpdateInterval,
+  telemetryPowerScreenEnabled,
+  onTelemetryConfigChange,
+  onSaveTelemetryConfig,
   isExecuting,
   selectedNodeNum,
   mqttHeaderActions,
   neighborInfoHeaderActions,
+  telemetryHeaderActions,
 }) => {
   const { t } = useTranslation();
 
@@ -262,6 +290,218 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
           }}
         >
           {isExecuting ? t('common.saving') : t('admin_commands.save_neighbor_info_config', 'Save Neighbor Info Config')}
+        </button>
+      </CollapsibleSection>
+
+      {/* Telemetry Config Section */}
+      <CollapsibleSection
+        id="admin-telemetry-config"
+        title={t('admin_commands.telemetry_configuration', 'Telemetry Configuration')}
+        nested={true}
+        headerActions={telemetryHeaderActions}
+      >
+        {/* Device Telemetry */}
+        <h4 style={{ margin: '0.5rem 0 0.75rem', color: 'var(--ctp-subtext0)' }}>
+          {t('telemetry_config.device_section', 'Device Telemetry')}
+        </h4>
+        <div className="setting-item">
+          <label>
+            {t('telemetry_config.device_interval', 'Device Update Interval (seconds)')}
+            <span className="setting-description">{t('telemetry_config.device_interval_description', 'How often to collect and transmit device metrics (battery, voltage, etc.)')}</span>
+          </label>
+          <input
+            type="number"
+            min="0"
+            value={telemetryDeviceUpdateInterval}
+            onChange={(e) => onTelemetryConfigChange('deviceUpdateInterval', parseInt(e.target.value) || 0)}
+            disabled={isExecuting}
+            className="setting-input"
+            style={{ width: '100%', maxWidth: '600px' }}
+            placeholder="900"
+          />
+        </div>
+
+        {/* Environment Telemetry */}
+        <h4 style={{ margin: '1rem 0 0.75rem', color: 'var(--ctp-subtext0)' }}>
+          {t('telemetry_config.environment_section', 'Environment Telemetry')}
+        </h4>
+        <div className="setting-item">
+          <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+            <input
+              type="checkbox"
+              checked={telemetryEnvironmentMeasurementEnabled}
+              onChange={(e) => onTelemetryConfigChange('environmentMeasurementEnabled', e.target.checked)}
+              disabled={isExecuting}
+              style={{ width: 'auto', margin: 0, flexShrink: 0 }}
+            />
+            <div style={{ flex: 1 }}>
+              <div>{t('telemetry_config.environment_enabled', 'Environment Measurement Enabled')}</div>
+              <span className="setting-description">{t('telemetry_config.environment_enabled_description', 'Enable collection of environment sensor data (temperature, humidity, etc.)')}</span>
+            </div>
+          </label>
+        </div>
+        {telemetryEnvironmentMeasurementEnabled && (
+          <>
+            <div className="setting-item">
+              <label>
+                {t('telemetry_config.environment_interval', 'Environment Update Interval (seconds)')}
+                <span className="setting-description">{t('telemetry_config.environment_interval_description', 'How often to collect and transmit environment metrics')}</span>
+              </label>
+              <input
+                type="number"
+                min="0"
+                value={telemetryEnvironmentUpdateInterval}
+                onChange={(e) => onTelemetryConfigChange('environmentUpdateInterval', parseInt(e.target.value) || 0)}
+                disabled={isExecuting}
+                className="setting-input"
+                style={{ width: '100%', maxWidth: '600px' }}
+                placeholder="900"
+              />
+            </div>
+            <div className="setting-item">
+              <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+                <input
+                  type="checkbox"
+                  checked={telemetryEnvironmentScreenEnabled}
+                  onChange={(e) => onTelemetryConfigChange('environmentScreenEnabled', e.target.checked)}
+                  disabled={isExecuting}
+                  style={{ width: 'auto', margin: 0, flexShrink: 0 }}
+                />
+                <div style={{ flex: 1 }}>
+                  <div>{t('telemetry_config.environment_screen', 'Show on Device Screen')}</div>
+                  <span className="setting-description">{t('telemetry_config.environment_screen_description', 'Display environment data on the device screen')}</span>
+                </div>
+              </label>
+            </div>
+            <div className="setting-item">
+              <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+                <input
+                  type="checkbox"
+                  checked={telemetryEnvironmentDisplayFahrenheit}
+                  onChange={(e) => onTelemetryConfigChange('environmentDisplayFahrenheit', e.target.checked)}
+                  disabled={isExecuting}
+                  style={{ width: 'auto', margin: 0, flexShrink: 0 }}
+                />
+                <div style={{ flex: 1 }}>
+                  <div>{t('telemetry_config.environment_fahrenheit', 'Display in Fahrenheit')}</div>
+                  <span className="setting-description">{t('telemetry_config.environment_fahrenheit_description', 'Display temperature in Fahrenheit instead of Celsius')}</span>
+                </div>
+              </label>
+            </div>
+          </>
+        )}
+
+        {/* Advanced Settings (Air Quality & Power) */}
+        <CollapsibleSection
+          id="admin-telemetry-advanced"
+          title={t('telemetry_config.advanced_settings', 'Advanced Settings')}
+          nested={true}
+        >
+          {/* Air Quality */}
+          <h4 style={{ margin: '0.5rem 0 0.75rem', color: 'var(--ctp-subtext0)' }}>
+            {t('telemetry_config.air_quality_section', 'Air Quality Metrics')}
+          </h4>
+          <div className="setting-item">
+            <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+              <input
+                type="checkbox"
+                checked={telemetryAirQualityEnabled}
+                onChange={(e) => onTelemetryConfigChange('airQualityEnabled', e.target.checked)}
+                disabled={isExecuting}
+                style={{ width: 'auto', margin: 0, flexShrink: 0 }}
+              />
+              <div style={{ flex: 1 }}>
+                <div>{t('telemetry_config.air_quality_enabled', 'Air Quality Enabled')}</div>
+                <span className="setting-description">{t('telemetry_config.air_quality_enabled_description', 'Enable air quality sensor collection')}</span>
+              </div>
+            </label>
+          </div>
+          {telemetryAirQualityEnabled && (
+            <div className="setting-item">
+              <label>
+                {t('telemetry_config.air_quality_interval', 'Air Quality Interval (seconds)')}
+                <span className="setting-description">{t('telemetry_config.air_quality_interval_description', 'How often to collect air quality metrics')}</span>
+              </label>
+              <input
+                type="number"
+                min="0"
+                value={telemetryAirQualityInterval}
+                onChange={(e) => onTelemetryConfigChange('airQualityInterval', parseInt(e.target.value) || 0)}
+                disabled={isExecuting}
+                className="setting-input"
+                style={{ width: '100%', maxWidth: '600px' }}
+                placeholder="900"
+              />
+            </div>
+          )}
+
+          {/* Power Metrics */}
+          <h4 style={{ margin: '1rem 0 0.75rem', color: 'var(--ctp-subtext0)' }}>
+            {t('telemetry_config.power_section', 'Power Metrics')}
+          </h4>
+          <div className="setting-item">
+            <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+              <input
+                type="checkbox"
+                checked={telemetryPowerMeasurementEnabled}
+                onChange={(e) => onTelemetryConfigChange('powerMeasurementEnabled', e.target.checked)}
+                disabled={isExecuting}
+                style={{ width: 'auto', margin: 0, flexShrink: 0 }}
+              />
+              <div style={{ flex: 1 }}>
+                <div>{t('telemetry_config.power_enabled', 'Power Measurement Enabled')}</div>
+                <span className="setting-description">{t('telemetry_config.power_enabled_description', 'Enable power metrics collection (INA sensors)')}</span>
+              </div>
+            </label>
+          </div>
+          {telemetryPowerMeasurementEnabled && (
+            <>
+              <div className="setting-item">
+                <label>
+                  {t('telemetry_config.power_interval', 'Power Update Interval (seconds)')}
+                  <span className="setting-description">{t('telemetry_config.power_interval_description', 'How often to collect power metrics')}</span>
+                </label>
+                <input
+                  type="number"
+                  min="0"
+                  value={telemetryPowerUpdateInterval}
+                  onChange={(e) => onTelemetryConfigChange('powerUpdateInterval', parseInt(e.target.value) || 0)}
+                  disabled={isExecuting}
+                  className="setting-input"
+                  style={{ width: '100%', maxWidth: '600px' }}
+                  placeholder="900"
+                />
+              </div>
+              <div className="setting-item">
+                <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+                  <input
+                    type="checkbox"
+                    checked={telemetryPowerScreenEnabled}
+                    onChange={(e) => onTelemetryConfigChange('powerScreenEnabled', e.target.checked)}
+                    disabled={isExecuting}
+                    style={{ width: 'auto', margin: 0, flexShrink: 0 }}
+                  />
+                  <div style={{ flex: 1 }}>
+                    <div>{t('telemetry_config.power_screen', 'Show Power on Screen')}</div>
+                    <span className="setting-description">{t('telemetry_config.power_screen_description', 'Display power metrics on the device screen')}</span>
+                  </div>
+                </label>
+              </div>
+            </>
+          )}
+        </CollapsibleSection>
+
+        <button
+          className="save-button"
+          onClick={onSaveTelemetryConfig}
+          disabled={isExecuting || selectedNodeNum === null}
+          style={{
+            marginTop: '1rem',
+            opacity: (isExecuting || selectedNodeNum === null) ? 0.5 : 1,
+            cursor: (isExecuting || selectedNodeNum === null) ? 'not-allowed' : 'pointer'
+          }}
+        >
+          {isExecuting ? t('common.saving') : t('telemetry_config.save_button', 'Save Telemetry Config')}
         </button>
       </CollapsibleSection>
     </CollapsibleSection>

--- a/src/components/admin-commands/useAdminCommandsState.ts
+++ b/src/components/admin-commands/useAdminCommandsState.ts
@@ -116,6 +116,20 @@ export interface DeviceConfigState {
   nodeInfoBroadcastSecs: number;
 }
 
+// Telemetry Config State
+export interface TelemetryConfigState {
+  deviceUpdateInterval: number;
+  environmentUpdateInterval: number;
+  environmentMeasurementEnabled: boolean;
+  environmentScreenEnabled: boolean;
+  environmentDisplayFahrenheit: boolean;
+  airQualityEnabled: boolean;
+  airQualityInterval: number;
+  powerMeasurementEnabled: boolean;
+  powerUpdateInterval: number;
+  powerScreenEnabled: boolean;
+}
+
 // Combined Admin Commands State
 export interface AdminCommandsState {
   lora: LoRaConfigState;
@@ -127,6 +141,7 @@ export interface AdminCommandsState {
   neighborInfo: NeighborInfoConfigState;
   owner: OwnerConfigState;
   device: DeviceConfigState;
+  telemetry: TelemetryConfigState;
 }
 
 // Action types
@@ -141,6 +156,7 @@ type AdminCommandsAction =
   | { type: 'SET_NEIGHBORINFO_CONFIG'; payload: Partial<NeighborInfoConfigState> }
   | { type: 'SET_OWNER_CONFIG'; payload: Partial<OwnerConfigState> }
   | { type: 'SET_DEVICE_CONFIG'; payload: Partial<DeviceConfigState> }
+  | { type: 'SET_TELEMETRY_CONFIG'; payload: Partial<TelemetryConfigState> }
   | { type: 'SET_ADMIN_KEY'; payload: { index: number; value: string } }
   | { type: 'ADD_ADMIN_KEY' }
   | { type: 'REMOVE_ADMIN_KEY'; payload: number }
@@ -239,6 +255,18 @@ const initialState: AdminCommandsState = {
     role: 0,
     nodeInfoBroadcastSecs: 3600,
   },
+  telemetry: {
+    deviceUpdateInterval: 900,
+    environmentUpdateInterval: 900,
+    environmentMeasurementEnabled: false,
+    environmentScreenEnabled: false,
+    environmentDisplayFahrenheit: false,
+    airQualityEnabled: false,
+    airQualityInterval: 900,
+    powerMeasurementEnabled: false,
+    powerUpdateInterval: 900,
+    powerScreenEnabled: false,
+  },
 };
 
 function adminCommandsReducer(state: AdminCommandsState, action: AdminCommandsAction): AdminCommandsState {
@@ -295,6 +323,11 @@ function adminCommandsReducer(state: AdminCommandsState, action: AdminCommandsAc
       return {
         ...state,
         device: { ...state.device, ...action.payload },
+      };
+    case 'SET_TELEMETRY_CONFIG':
+      return {
+        ...state,
+        telemetry: { ...state.telemetry, ...action.payload },
       };
     case 'SET_ADMIN_KEY':
       const newKeys = [...state.security.adminKeys];
@@ -418,6 +451,11 @@ export function useAdminCommandsState() {
     dispatch({ type: 'SET_DEVICE_CONFIG', payload: config });
   }, []);
 
+  // Telemetry config actions
+  const setTelemetryConfig = useCallback((config: Partial<TelemetryConfigState>) => {
+    dispatch({ type: 'SET_TELEMETRY_CONFIG', payload: config });
+  }, []);
+
   // Reset all configs
   const resetAll = useCallback(() => {
     dispatch({ type: 'RESET_ALL' });
@@ -448,6 +486,8 @@ export function useAdminCommandsState() {
     setOwnerConfig,
     // Device
     setDeviceConfig,
+    // Telemetry
+    setTelemetryConfig,
     // Reset
     resetAll,
   };

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -8334,6 +8334,7 @@ class MeshtasticManager {
       if (isModuleConfig) {
         const moduleConfigMap: { [key: number]: string } = {
           0: 'mqtt',
+          5: 'telemetry',
           9: 'neighborInfo'
         };
         const configKey = moduleConfigMap[configType];
@@ -8382,6 +8383,7 @@ class MeshtasticManager {
             // Map module config types to their keys
             const moduleConfigMap: { [key: number]: string } = {
               0: 'mqtt',
+              5: 'telemetry',
               9: 'neighborInfo'
             };
             const configKey = moduleConfigMap[configType];

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6741,6 +6741,12 @@ apiRouter.post('/admin/commands', requireAdmin(), async (req, res) => {
         }
         adminMessage = protobufService.createSetNeighborInfoConfigMessage(params.config, sessionPasskey || undefined);
         break;
+      case 'setTelemetryConfig':
+        if (!params.config) {
+          return res.status(400).json({ error: 'config is required for setTelemetryConfig' });
+        }
+        adminMessage = protobufService.createSetModuleConfigMessageGeneric('telemetry', params.config, sessionPasskey || undefined);
+        break;
       case 'setSecurityConfig':
         if (!params.config) {
           return res.status(400).json({ error: 'config is required for setSecurityConfig' });


### PR DESCRIPTION
## Summary

- Add Telemetry Configuration section to the Admin Commands tab's Module Configuration area
- Users can now remotely configure telemetry settings on Meshtastic nodes with admin access
- Supports Device, Environment, Air Quality, and Power telemetry settings

## Changes

- Add `TelemetryConfigState` interface with 10 configuration fields to `useAdminCommandsState.ts`
- Add telemetry UI section to `ModuleConfigurationSection.tsx` with collapsible Advanced Settings
- Wire telemetry handlers and props in `AdminCommandsTab.tsx`
- Add `setTelemetryConfig` case to server admin/commands endpoint
- Add telemetry (config type 5) to `moduleConfigMap` in `meshtasticManager.ts`
- Add `telemetry_config_short` translation key

## UI Structure

```
Module Configuration
├── MQTT Configuration (existing)
├── Neighbor Info Configuration (existing)
└── Telemetry Configuration (NEW)
    ├── [Load Button]
    ├── Device Telemetry
    │   └── Device Update Interval
    ├── Environment Telemetry
    │   ├── Environment Enabled (checkbox)
    │   ├── Update Interval (conditional)
    │   ├── Show on Screen (checkbox)
    │   └── Display Fahrenheit (checkbox)
    ├── Advanced Settings (collapsible)
    │   ├── Air Quality (enabled + interval)
    │   └── Power Metrics (enabled + interval + screen)
    └── [Save Button]
```

## Test plan

- [ ] Navigate to Admin Commands tab
- [ ] Select a remote node with admin access
- [ ] Expand Module Configuration > Telemetry Configuration
- [ ] Click "Load" button - verify fields populate with node's current config
- [ ] Modify telemetry settings (e.g., enable environment measurement)
- [ ] Click "Save Telemetry Config" - verify toast notification shows success
- [ ] Click "Load" again to verify settings persisted on the node

Closes #1589

🤖 Generated with [Claude Code](https://claude.ai/code)