### PR TITLE
Add curl installation to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN apk add --no-cache \
     python3 \
     py3-pip \
     py3-requests \
+    curl \
     supervisor \
     su-exec \
     && ln -sf /usr/bin/python3 /usr/bin/python \


### PR DESCRIPTION
curl is needed for the container healthcheck, but it apparently is not in the base image so it must be added. Without curl the container reports itself unhealthy all the time. This seems easier than changing the healthcheck command in the compose file to use something like wget.

After installing curl within the container, the healthcheck starts succeeding and reporting the container as healthy (seen here in the `lazydocker` tool):
<img width="776" height="255" alt="image" src="https://github.com/user-attachments/assets/09288e2b-8831-49bc-bd13-d07d253d06a7" />

