### PR TITLE
fix(docker): add curl for container healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,10 @@ FROM node:24-alpine
 
 WORKDIR /app
 
-# Install Python and dependencies for Apprise
+# Install curl (for healthchecks), Python and dependencies for Apprise
 # Create python symlink for user scripts that use #!/usr/bin/env python
 RUN apk add --no-cache \
+    curl \
     python3 \
     py3-pip \
     py3-requests \


### PR DESCRIPTION
## Summary
- Adds `curl` to the Docker image for healthcheck support
- Updates comment to document curl's purpose

## Problem
The documentation recommends a healthcheck using curl:
```yaml
healthcheck:
  test: ["CMD", "curl", "-f", "http://localhost:3001/api/health"]
```

However, the `node:24-alpine` base image doesn't include curl, causing containers to report as "unhealthy" when users follow the docs.

## Test plan
- [ ] Build the Docker image: `docker compose -f docker-compose.dev.yml build meshmonitor`
- [ ] Run container with healthcheck and verify it reports healthy
- [ ] Verify `curl` is available inside the container: `docker exec meshmonitor curl --version`

Closes #1613

🤖 Generated with [Claude Code](https://claude.com/claude-code)