### PR TITLE
fix(api): add async support for clearing packet logs on PostgreSQL/MySQL

### DIFF
--- a/src/server/routes/packetRoutes.test.ts
+++ b/src/server/routes/packetRoutes.test.ts
@@ -215,6 +215,10 @@ describe('Packet Routes', () => {
       return result.changes;
     };
 
+    (DatabaseService as any).clearPacketLogsAsync = async () => {
+      return (DatabaseService as any).clearPacketLogs();
+    };
+
     (DatabaseService as any).cleanupOldPacketLogs = () => {
       const maxAgeHours = (DatabaseService as any).getSetting('packet_log_max_age_hours');
       const hours = maxAgeHours ? parseInt(maxAgeHours, 10) : 24;

--- a/src/server/routes/packetRoutes.ts
+++ b/src/server/routes/packetRoutes.ts
@@ -215,7 +215,7 @@ router.get('/:id', requirePacketPermissions, (req, res) => {
  * DELETE /api/packets
  * Clear all packet logs (admin only)
  */
-router.delete('/', requirePacketPermissions, (req, res) => {
+router.delete('/', requirePacketPermissions, async (req, res) => {
   try {
     const user = (req as any).user;
     const isAdmin = user?.isAdmin ?? false;
@@ -227,7 +227,7 @@ router.delete('/', requirePacketPermissions, (req, res) => {
       });
     }
 
-    const deletedCount = packetLogService.clearPackets();
+    const deletedCount = await packetLogService.clearPacketsAsync();
     logger.info(`🧹 Admin ${user.username} cleared ${deletedCount} packet logs`);
 
     // Log to audit log

--- a/src/server/services/packetLogService.ts
+++ b/src/server/services/packetLogService.ts
@@ -124,6 +124,13 @@ class PacketLogService {
   }
 
   /**
+   * Clear all packet logs - async version for PostgreSQL/MySQL
+   */
+  async clearPacketsAsync(): Promise<number> {
+    return databaseService.clearPacketLogsAsync();
+  }
+
+  /**
    * Check if packet logging is enabled
    */
   isEnabled(): boolean {


### PR DESCRIPTION
## Summary

Fixes the "Failed to clear packet logs" error when using the "Clear all packets" button in the packet monitor on PostgreSQL/MySQL/MariaDB deployments.

## Root Cause

The `clearPacketLogs()` method in `DatabaseService` only used SQLite-specific code (`this.db.prepare(...)`), which doesn't work when the database backend is PostgreSQL or MySQL. This caused an internal server error when users tried to clear packet logs.

## Changes

- **src/services/database.ts**: Add `clearPacketLogsAsync()` method with proper PostgreSQL and MySQL support
- **src/server/services/packetLogService.ts**: Add `clearPacketsAsync()` wrapper method
- **src/server/routes/packetRoutes.ts**: Update DELETE /api/packets route to use async method
- **src/server/routes/packetRoutes.test.ts**: Add mock for new async method

## Test plan

- [x] All unit tests pass (2222 tests)
- [x] Packet routes tests specifically pass (20 tests)
- [ ] Manual test on MariaDB deployment (reporter can verify)

Fixes #1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)