### PR TITLE
fix(virtual-node): remove 10-message history replay on client connect

### DIFF
--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -5,7 +5,6 @@ import meshtasticProtobufService from './meshtasticProtobufService.js';
 import protobufService from './protobufService.js';
 import { MeshtasticManager } from './meshtasticManager.js';
 import databaseService from '../services/database.js';
-import { PortNum } from './constants/meshtastic.js';
 
 export interface VirtualNodeConfig {
   port: number;


### PR DESCRIPTION
## Summary

Removes the 10-message history replay feature that was causing multiple issues with virtual node clients.

## Problems Fixed

1. **Duplicate messages** - Clients that don't deduplicate would show the same 10 messages on every reconnection
2. **Incorrect hop counts** - Cached messages had random/stale hop values (including -1) from database reconstruction
3. **Incorrect timestamps** - Historical messages had wrong dates
4. **Non-message content** - Traceroutes were appearing as chat messages

## Solution

Remove the message history replay entirely. Clients should rely on real-time message forwarding from the physical node instead. This ensures:
- Messages have correct hop counts from the actual mesh packet
- No duplicates on reconnection
- Only actual messages are shown (not traceroutes, telemetry, etc.)

## Test plan

- [x] Virtual node server tests pass (37 tests)
- [ ] Manual verification by issue reporters

Fixes #1608

🤖 Generated with [Claude Code](https://claude.com/claude-code)