### PR TITLE
feat(packets): add via_mqtt column to packet_log table

### DIFF
--- a/src/db/schema/mysql-create.ts
+++ b/src/db/schema/mysql-create.ts
@@ -300,6 +300,7 @@ export const MYSQL_SCHEMA_SQL = `
     created_at BIGINT,
     decrypted_by VARCHAR(16),
     decrypted_channel_id INT,
+    via_mqtt BOOLEAN,
     INDEX idx_packet_log_createdat (created_at)
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/src/db/schema/packets.ts
+++ b/src/db/schema/packets.ts
@@ -34,6 +34,7 @@ export const packetLogSqlite = sqliteTable('packet_log', {
   created_at: integer('created_at'),
   decrypted_by: text('decrypted_by'), // 'node' | 'server' | null
   decrypted_channel_id: integer('decrypted_channel_id'), // FK to channel_database.id
+  via_mqtt: integer('via_mqtt', { mode: 'boolean' }), // Whether packet was received via MQTT
 });
 
 // PostgreSQL schema
@@ -66,6 +67,7 @@ export const packetLogPostgres = pgTable('packet_log', {
   created_at: pgBigint('created_at', { mode: 'number' }),
   decrypted_by: pgText('decrypted_by'), // 'node' | 'server' | null
   decrypted_channel_id: pgInteger('decrypted_channel_id'), // FK to channel_database.id
+  via_mqtt: pgBoolean('via_mqtt'), // Whether packet was received via MQTT
 });
 
 // MySQL schema
@@ -98,6 +100,7 @@ export const packetLogMysql = mysqlTable('packet_log', {
   created_at: myBigint('created_at', { mode: 'number' }),
   decrypted_by: myVarchar('decrypted_by', { length: 16 }), // 'node' | 'server' | null
   decrypted_channel_id: myInt('decrypted_channel_id'), // FK to channel_database.id
+  via_mqtt: myBoolean('via_mqtt'), // Whether packet was received via MQTT
 });
 
 // Type inference

--- a/src/db/schema/postgres-create.ts
+++ b/src/db/schema/postgres-create.ts
@@ -279,7 +279,8 @@ export const POSTGRES_SCHEMA_SQL = `
     direction TEXT,
     created_at BIGINT,
     decrypted_by TEXT,
-    decrypted_channel_id INTEGER
+    decrypted_channel_id INTEGER,
+    via_mqtt BOOLEAN
   );
 
   CREATE TABLE IF NOT EXISTS backup_history (

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -622,7 +622,8 @@ class MeshtasticManager {
       encrypted: false,  // Outgoing packets are logged before encryption
       payload_preview: payloadPreview,
       metadata: JSON.stringify({ ...metadata, direction: 'tx' }),
-      direction: 'tx'
+      direction: 'tx',
+      via_mqtt: false,  // Outgoing packets are sent via direct connection, not MQTT
     });
   }
 
@@ -2429,6 +2430,7 @@ class MeshtasticManager {
           direction: fromNum === this.localNodeInfo?.nodeNum ? 'tx' : 'rx',
           decrypted_by: decryptedBy ?? undefined,
           decrypted_channel_id: decryptedChannelId ?? undefined,
+          via_mqtt: meshPacket.viaMqtt ?? false,
         });
         } // end else (not internal packet)
       }

--- a/src/server/migrations/057_add_packet_via_mqtt.ts
+++ b/src/server/migrations/057_add_packet_via_mqtt.ts
@@ -1,0 +1,113 @@
+/**
+ * Migration 057: Add via_mqtt column to packet_log table
+ *
+ * Adds transport mechanism tracking:
+ * - true: Packet was received via MQTT bridge
+ * - false: Packet was received via direct LoRa connection
+ *
+ * This allows filtering and distinguishing packet sources in the Packet Monitor.
+ * Fixes issue #1619.
+ */
+import type Database from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+export const migration = {
+  up: (db: Database.Database): void => {
+    logger.debug('Running migration 057: Add via_mqtt column to packet_log table');
+
+    try {
+      // Check if column already exists
+      const tableInfo = db.prepare('PRAGMA table_info(packet_log)').all() as { name: string }[];
+      const columnNames = tableInfo.map((col) => col.name);
+
+      if (!columnNames.includes('via_mqtt')) {
+        db.exec(`ALTER TABLE packet_log ADD COLUMN via_mqtt INTEGER DEFAULT 0`);
+        logger.debug('✅ Added via_mqtt column to packet_log table');
+      } else {
+        logger.debug('ℹ️  via_mqtt column already exists in packet_log table');
+      }
+
+      logger.debug('✅ Migration 057 completed successfully');
+    } catch (error: any) {
+      logger.error('❌ Migration 057 failed:', error);
+      throw error;
+    }
+  },
+
+  down: (_db: Database.Database): void => {
+    logger.debug('Reverting migration 057: Remove via_mqtt column from packet_log table');
+
+    try {
+      // Note: SQLite doesn't support DROP COLUMN easily in older versions
+      // For safety, we leave the column in place on rollback
+      // It won't affect functionality and can be cleaned up manually if needed
+      logger.debug('ℹ️  Migration 057 rollback: via_mqtt column left in place (SQLite limitation)');
+    } catch (error) {
+      logger.error('❌ Migration 057 rollback failed:', error);
+      throw error;
+    }
+  }
+};
+
+/**
+ * PostgreSQL migration: Add via_mqtt column to packet_log table
+ */
+export async function runMigration057Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.debug('Running migration 057 (PostgreSQL): Add via_mqtt column to packet_log table');
+
+  try {
+    // Check if column exists
+    const result = await client.query(`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'packet_log'
+        AND column_name = 'via_mqtt'
+    `);
+
+    if (result.rows.length === 0) {
+      await client.query(`ALTER TABLE packet_log ADD COLUMN via_mqtt BOOLEAN DEFAULT false`);
+      logger.debug('  Added via_mqtt column to packet_log table');
+    } else {
+      logger.debug('  via_mqtt column already exists in packet_log table');
+    }
+
+    logger.debug('Migration 057 (PostgreSQL) complete');
+  } catch (error) {
+    logger.error('Migration 057 (PostgreSQL) failed:', error);
+    throw error;
+  }
+}
+
+/**
+ * MySQL migration: Add via_mqtt column to packet_log table
+ */
+export async function runMigration057Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.debug('Running migration 057 (MySQL): Add via_mqtt column to packet_log table');
+
+  try {
+    const connection = await pool.getConnection();
+    try {
+      // Check if column exists
+      const [rows] = await connection.query(`
+        SELECT COLUMN_NAME FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'packet_log'
+        AND COLUMN_NAME = 'via_mqtt'
+      `) as [any[], any];
+
+      if (rows.length === 0) {
+        await connection.query(`ALTER TABLE packet_log ADD COLUMN via_mqtt BOOLEAN DEFAULT false`);
+        logger.debug('  Added via_mqtt column to packet_log table');
+      } else {
+        logger.debug('  via_mqtt column already exists in packet_log table');
+      }
+
+      logger.debug('Migration 057 (MySQL) complete');
+    } finally {
+      connection.release();
+    }
+  } catch (error) {
+    logger.error('Migration 057 (MySQL) failed:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `via_mqtt` column to packet_log table schema (SQLite, PostgreSQL, MySQL)
- Update `DbPacketLog` interface to include `via_mqtt` field
- Update packet logging to record `viaMqtt` value from mesh packets
- Add migration 057 with support for all database backends

This allows filtering and distinguishing packet sources (LoRa vs MQTT) in the Packet Monitor panel.

Fixes #1619

## Test plan
- [ ] Run test suite locally
- [ ] Test with SQLite database - verify via_mqtt column is added
- [ ] Test with PostgreSQL database - verify migration runs correctly
- [ ] Test with MySQL/MariaDB database - verify migration runs correctly
- [ ] Verify packets received via MQTT show `via_mqtt: true`
- [ ] Verify packets received via LoRa show `via_mqtt: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)