### PR TITLE
feat(ui): add unified SaveBar component for settings changes

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -145,6 +145,8 @@
   "common.hours_ago": "{{count}}h ago",
   "common.days_ago": "{{count}}d ago",
 
+  "savebar.save_changes_to": "Save changes to {{section}}",
+
   "auth.login": "Login",
   "auth.username": "Username",
   "auth.password": "Password",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,8 @@ import { useTraceroutePaths } from './hooks/useTraceroutePaths';
 import { useNotificationNavigationHandler } from './hooks/useNotificationNavigationHandler';
 import LoginModal from './components/LoginModal';
 import LoginPage from './components/LoginPage';
+import { SaveBarProvider } from './contexts/SaveBarContext';
+import { SaveBar } from './components/SaveBar';
 
 // Track pending favorite requests outside component to persist across remounts
 // Maps nodeNum -> expected isFavorite state
@@ -4505,6 +4507,9 @@ function App() {
         systemStatus={systemStatus}
         onClose={() => setShowStatusModal(false)}
       />
+
+      {/* SaveBar for unified save/dismiss actions */}
+      <SaveBar />
     </div>
   );
 }
@@ -4543,7 +4548,9 @@ const AppWithToast = () => {
           <MessagingProvider baseUrl={initialBaseUrl}>
             <UIProvider>
               <ToastProvider>
-                <App />
+                <SaveBarProvider>
+                  <App />
+                </SaveBarProvider>
               </ToastProvider>
             </UIProvider>
           </MessagingProvider>

--- a/src/components/SaveBar/SaveBar.css
+++ b/src/components/SaveBar/SaveBar.css
@@ -1,0 +1,171 @@
+.save-bar {
+  position: fixed;
+  left: var(--sidebar-width, 200px);
+  right: 0;
+  bottom: 0;
+  z-index: 10000;
+  background: var(--ctp-surface0);
+  border-top: 2px solid var(--ctp-green);
+  animation: saveBarSlideIn 0.3s ease-out;
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.15);
+}
+
+/* When sidebar is collapsed */
+.sidebar-collapsed .save-bar {
+  left: var(--sidebar-collapsed-width, 60px);
+}
+
+@keyframes saveBarSlideIn {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.save-bar-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem;
+  max-width: 100%;
+}
+
+.save-bar-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.save-bar-section-tabs {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.save-bar-tab {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--ctp-surface2);
+  border-radius: 4px;
+  background: var(--ctp-surface1);
+  color: var(--ctp-text);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.save-bar-tab:hover:not(:disabled) {
+  background: var(--ctp-surface2);
+}
+
+.save-bar-tab.active {
+  background: var(--ctp-green);
+  color: var(--ctp-base);
+  border-color: var(--ctp-green);
+}
+
+.save-bar-tab:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.save-bar-message {
+  color: var(--ctp-text);
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.save-bar-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.save-bar-dismiss {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--ctp-surface2);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--ctp-subtext0);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.save-bar-dismiss:hover:not(:disabled) {
+  background: var(--ctp-surface1);
+  color: var(--ctp-text);
+}
+
+.save-bar-dismiss:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.save-bar-save {
+  padding: 0.5rem 1.5rem;
+  border: none;
+  border-radius: 4px;
+  background: var(--ctp-green);
+  color: var(--ctp-base);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.save-bar-save:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.save-bar-save:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.save-bar-badge {
+  position: absolute;
+  top: -8px;
+  right: 16px;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 10px;
+  background: var(--ctp-red);
+  color: var(--ctp-base);
+  font-size: 0.75rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+  .save-bar {
+    left: 0;
+  }
+
+  .save-bar-content {
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+  }
+
+  .save-bar-left {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .save-bar-section-tabs {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .save-bar-actions {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/src/components/SaveBar/SaveBar.tsx
+++ b/src/components/SaveBar/SaveBar.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSaveBarContext, SaveBarSection } from '../../contexts/SaveBarContext';
+import './SaveBar.css';
+
+export const SaveBar: React.FC = () => {
+  const { t } = useTranslation();
+  const { sections, activeSection, setActiveSection } = useSaveBarContext();
+
+  // Get sections with changes
+  const sectionsWithChanges: SaveBarSection[] = [];
+  sections.forEach(section => {
+    if (section.hasChanges) {
+      sectionsWithChanges.push(section);
+    }
+  });
+
+  // Don't render if no sections have changes
+  if (sectionsWithChanges.length === 0) {
+    return null;
+  }
+
+  // Get the active section, defaulting to the first one with changes
+  const currentSectionId = activeSection || sectionsWithChanges[0]?.id;
+  const currentSection = currentSectionId ? sections.get(currentSectionId) : null;
+
+  // If active section no longer has changes, pick the first one that does
+  const effectiveSection = currentSection?.hasChanges
+    ? currentSection
+    : sectionsWithChanges[0];
+
+  if (!effectiveSection) {
+    return null;
+  }
+
+  const handleSave = async () => {
+    await effectiveSection.onSave();
+  };
+
+  const handleDismiss = () => {
+    effectiveSection.onDismiss();
+  };
+
+  const handleSectionClick = (sectionId: string) => {
+    setActiveSection(sectionId);
+  };
+
+  return (
+    <div className="save-bar">
+      <div className="save-bar-content">
+        <div className="save-bar-left">
+          {sectionsWithChanges.length > 1 && (
+            <div className="save-bar-section-tabs">
+              {sectionsWithChanges.map(section => (
+                <button
+                  key={section.id}
+                  className={`save-bar-tab ${section.id === effectiveSection.id ? 'active' : ''}`}
+                  onClick={() => handleSectionClick(section.id)}
+                  disabled={section.isSaving}
+                >
+                  {section.sectionName}
+                </button>
+              ))}
+            </div>
+          )}
+          <span className="save-bar-message">
+            {t('savebar.save_changes_to', { section: effectiveSection.sectionName })}
+          </span>
+        </div>
+        <div className="save-bar-actions">
+          <button
+            className="save-bar-dismiss"
+            onClick={handleDismiss}
+            disabled={effectiveSection.isSaving}
+          >
+            {t('common.dismiss')}
+          </button>
+          <button
+            className="save-bar-save"
+            onClick={handleSave}
+            disabled={effectiveSection.isSaving}
+          >
+            {effectiveSection.isSaving ? t('common.saving') : t('common.save')}
+          </button>
+        </div>
+      </div>
+      {sectionsWithChanges.length > 1 && (
+        <div className="save-bar-badge">
+          {sectionsWithChanges.length}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SaveBar;

--- a/src/components/SaveBar/index.ts
+++ b/src/components/SaveBar/index.ts
@@ -1,0 +1,1 @@
+export { SaveBar, default } from './SaveBar';

--- a/src/components/TimerTriggersSection.tsx
+++ b/src/components/TimerTriggersSection.tsx
@@ -5,6 +5,7 @@ import { TimerTrigger, TimerResponseType, ScriptMetadata } from './auto-responde
 import { useToast } from './ToastContainer';
 import { useCsrfFetch } from '../hooks/useCsrfFetch';
 import { Channel } from '../types/device';
+import { useSaveBar } from '../hooks/useSaveBar';
 
 /**
  * Get language emoji for display
@@ -145,7 +146,7 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
     }
   }, [newCronExpression, t]);
 
-  const handleSave = async () => {
+  const handleSaveForSaveBar = useCallback(async () => {
     setIsSaving(true);
     try {
       const response = await csrfFetch(`${baseUrl}/api/settings`, {
@@ -167,11 +168,22 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
     } finally {
       setIsSaving(false);
     }
-  };
+  }, [localTriggers, baseUrl, csrfFetch, showToast, t, onTriggersChange]);
 
-  const handleCancel = () => {
+  // Reset local state to props (used by SaveBar dismiss)
+  const resetChanges = useCallback(() => {
     setLocalTriggers(triggers);
-  };
+  }, [triggers]);
+
+  // Register with SaveBar
+  useSaveBar({
+    id: 'timer-triggers',
+    sectionName: t('automation.timer_triggers.title', 'Timer Triggers'),
+    hasChanges,
+    isSaving,
+    onSave: handleSaveForSaveBar,
+    onDismiss: resetChanges
+  });
 
   const handleAddTrigger = () => {
     if (!newName.trim()) {
@@ -264,19 +276,6 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
             ?
           </a>
         </h2>
-        <button
-          onClick={handleSave}
-          disabled={!hasChanges || isSaving}
-          className="btn-primary"
-          style={{
-            padding: '0.5rem 1.5rem',
-            fontSize: '14px',
-            opacity: hasChanges ? 1 : 0.5,
-            cursor: hasChanges ? 'pointer' : 'not-allowed'
-          }}
-        >
-          {isSaving ? t('common.saving') : t('automation.save_changes')}
-        </button>
       </div>
 
       <div className="settings-section">
@@ -512,33 +511,6 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
             borderRadius: '8px',
           }}>
             {t('automation.timer_triggers.no_timers', 'No timer triggers configured. Add one above to schedule automatic script execution.')}
-          </div>
-        )}
-
-        {/* Save/Cancel Buttons */}
-        {hasChanges && (
-          <div style={{
-            display: 'flex',
-            gap: '0.5rem',
-            justifyContent: 'flex-end',
-            marginTop: '1rem',
-            paddingTop: '1rem',
-            borderTop: '1px solid var(--ctp-surface1)',
-          }}>
-            <button
-              onClick={handleCancel}
-              className="settings-button"
-              disabled={isSaving}
-            >
-              {t('common.cancel', 'Cancel')}
-            </button>
-            <button
-              onClick={handleSave}
-              className="settings-button settings-button-primary"
-              disabled={isSaving}
-            >
-              {isSaving ? t('common.saving', 'Saving...') : t('common.save', 'Save Changes')}
-            </button>
           </div>
         )}
       </div>

--- a/src/contexts/SaveBarContext.tsx
+++ b/src/contexts/SaveBarContext.tsx
@@ -1,0 +1,75 @@
+import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+
+export interface SaveBarSection {
+  id: string;
+  sectionName: string;
+  hasChanges: boolean;
+  isSaving: boolean;
+  onSave: () => Promise<void>;
+  onDismiss: () => void;
+}
+
+interface SaveBarContextType {
+  sections: Map<string, SaveBarSection>;
+  registerSection: (section: SaveBarSection) => void;
+  unregisterSection: (id: string) => void;
+  updateSection: (id: string, updates: Partial<SaveBarSection>) => void;
+  activeSection: string | null;
+  setActiveSection: (id: string | null) => void;
+}
+
+const SaveBarContext = createContext<SaveBarContextType | undefined>(undefined);
+
+export const SaveBarProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [sections, setSections] = useState<Map<string, SaveBarSection>>(new Map());
+  const [activeSection, setActiveSection] = useState<string | null>(null);
+
+  const registerSection = useCallback((section: SaveBarSection) => {
+    setSections(prev => {
+      const next = new Map(prev);
+      next.set(section.id, section);
+      return next;
+    });
+  }, []);
+
+  const unregisterSection = useCallback((id: string) => {
+    setSections(prev => {
+      const next = new Map(prev);
+      next.delete(id);
+      return next;
+    });
+    setActiveSection(current => current === id ? null : current);
+  }, []);
+
+  const updateSection = useCallback((id: string, updates: Partial<SaveBarSection>) => {
+    setSections(prev => {
+      const existing = prev.get(id);
+      if (!existing) return prev;
+
+      const next = new Map(prev);
+      next.set(id, { ...existing, ...updates });
+      return next;
+    });
+  }, []);
+
+  return (
+    <SaveBarContext.Provider value={{
+      sections,
+      registerSection,
+      unregisterSection,
+      updateSection,
+      activeSection,
+      setActiveSection
+    }}>
+      {children}
+    </SaveBarContext.Provider>
+  );
+};
+
+export const useSaveBarContext = (): SaveBarContextType => {
+  const context = useContext(SaveBarContext);
+  if (!context) {
+    throw new Error('useSaveBarContext must be used within a SaveBarProvider');
+  }
+  return context;
+};

--- a/src/hooks/useSaveBar.ts
+++ b/src/hooks/useSaveBar.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useSaveBarContext, SaveBarSection } from '../contexts/SaveBarContext';
+
+export interface UseSaveBarOptions {
+  id: string;
+  sectionName: string;
+  hasChanges: boolean;
+  isSaving: boolean;
+  onSave: () => Promise<void>;
+  onDismiss: () => void;
+}
+
+/**
+ * Hook for components to register with the unified SaveBar.
+ * When hasChanges is true, the SaveBar will appear allowing the user to save or dismiss changes.
+ */
+export const useSaveBar = (options: UseSaveBarOptions): void => {
+  const { id, sectionName, hasChanges, isSaving, onSave, onDismiss } = options;
+  const { registerSection, unregisterSection, updateSection, setActiveSection, activeSection } = useSaveBarContext();
+
+  // Store callbacks in refs to avoid triggering effects on callback identity changes
+  const onSaveRef = useRef(onSave);
+  const onDismissRef = useRef(onDismiss);
+
+  useEffect(() => {
+    onSaveRef.current = onSave;
+  }, [onSave]);
+
+  useEffect(() => {
+    onDismissRef.current = onDismiss;
+  }, [onDismiss]);
+
+  // Stable wrappers that use refs
+  const stableOnSave = useCallback(async () => {
+    await onSaveRef.current();
+  }, []);
+
+  const stableOnDismiss = useCallback(() => {
+    onDismissRef.current();
+  }, []);
+
+  // Register section on mount, unregister on unmount
+  useEffect(() => {
+    const section: SaveBarSection = {
+      id,
+      sectionName,
+      hasChanges,
+      isSaving,
+      onSave: stableOnSave,
+      onDismiss: stableOnDismiss
+    };
+    registerSection(section);
+
+    return () => {
+      unregisterSection(id);
+    };
+  }, [id, sectionName, registerSection, unregisterSection, stableOnSave, stableOnDismiss]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Update hasChanges and isSaving when they change
+  useEffect(() => {
+    updateSection(id, { hasChanges, isSaving });
+  }, [id, hasChanges, isSaving, updateSection]);
+
+  // Auto-select this section when it has changes and nothing else is selected
+  useEffect(() => {
+    if (hasChanges && !activeSection) {
+      setActiveSection(id);
+    }
+  }, [hasChanges, activeSection, id, setActiveSection]);
+};


### PR DESCRIPTION
## Summary
- Replace individual Save buttons across 30+ components with a unified SaveBar that appears as a fixed bar at the bottom of the viewport when changes are detected
- Fixed bottom bar immune to scroll, shows "Save changes to [Section Name]" with Save/Dismiss buttons
- Smooth slide-in animation with consistent UX across all settings and configuration sections
- Supports multiple sections with unsaved changes (shows count badge)

## Components Migrated

### Automation Sections (8)
- AutoAnnounceSection, AutoAcknowledgeSection, AutoWelcomeSection
- AutoResponderSection, AutoTracerouteSection, AutoKeyManagementSection
- RemoteAdminScannerSection, TimerTriggersSection

### Configuration Sections (22)
- DeviceConfigSection, DisplayConfigSection, PowerConfigSection
- NetworkConfigSection, MQTTConfigSection, LoRaConfigSection
- PositionConfigSection, TelemetryConfigSection, StoreForwardConfigSection
- CannedMessageConfigSection, AudioConfigSection, SerialConfigSection
- AmbientLightingConfigSection, DetectionSensorConfigSection
- ExternalNotificationConfigSection, PaxcounterConfigSection
- RangeTestConfigSection, RemoteHardwareConfigSection
- SecurityConfigSection, NeighborInfoSection, NodeIdentitySection

### Settings & Self-Contained Sections (4)
- SettingsTab
- BackupManagementSection, DatabaseMaintenanceSection, SystemBackupSection

## New Files
- `src/contexts/SaveBarContext.tsx` - Context provider and types
- `src/components/SaveBar/SaveBar.tsx` - Main SaveBar component
- `src/components/SaveBar/SaveBar.css` - Styles with fixed positioning and animation
- `src/hooks/useSaveBar.ts` - Hook for component registration

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm test` passes (2222 tests)
- [ ] Navigate to Settings tab, change a value - SaveBar appears at bottom
- [ ] Click Dismiss - changes reset, bar disappears
- [ ] Click Save - saves successfully, bar disappears
- [ ] Navigate to Configuration sections, verify SaveBar works for each
- [ ] Make changes in two sections - verify count badge appears
- [ ] Scroll page - verify SaveBar stays fixed at bottom
- [ ] Test on mobile viewport - bar should be responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)