### PR TITLE
fix(channels): preserve disabled channels in database

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2184,6 +2184,7 @@ class MeshtasticManager {
       const displayName = channelName || `Channel ${channel.index}`; // For logging only
       const hasValidConfig = channel.settings.name !== undefined ||
                             channel.settings.psk ||
+                            channel.role === 0 || // DISABLED role (explicitly set)
                             channel.role === 1 || // PRIMARY role
                             channel.role === 2 || // SECONDARY role
                             channel.index === 0;   // Always include channel 0


### PR DESCRIPTION
## Summary
- Fix bug where setting a channel to DISABLED (role=0) would cause it to be deleted from the database

## Root Cause
In `processChannelProtobuf`, the `hasValidConfig` check only allowed channels with:
- A defined name, OR
- A PSK, OR
- role=1 (PRIMARY), OR
- role=2 (SECONDARY), OR
- index=0

When a channel was set to DISABLED and the device echoed back the config without a name/PSK, the channel failed the `hasValidConfig` check and was not saved, effectively deleting it.

## Fix
Add `channel.role === 0` (DISABLED) to the `hasValidConfig` condition so explicitly disabled channels are preserved in the database.

## Test plan
- [ ] Set a channel to DISABLED in Device → Channels
- [ ] Verify the channel remains visible with "Disabled" status
- [ ] Verify the channel can be re-enabled by changing the role back

Fixes #1640

🤖 Generated with [Claude Code](https://claude.com/claude-code)