### PR TITLE
fix(channels): show correct encryption status in Device Channels view

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2605,6 +2605,8 @@
   "channels_config.disabled": "DISABLED",
   "channels_config.empty": "Empty",
   "channels_config.encrypted": "Encrypted",
+  "channels_config.encrypted_secure": "Encrypted (Custom Key)",
+  "channels_config.encrypted_default": "Default Key (Not Secure)",
   "channels_config.unencrypted": "Unencrypted",
   "channels_config.uplink": "Uplink",
   "channels_config.downlink": "Downlink",

--- a/src/components/configuration/ChannelsConfigSection.tsx
+++ b/src/components/configuration/ChannelsConfigSection.tsx
@@ -5,6 +5,22 @@ import { useToast } from '../ToastContainer';
 import { Channel } from '../../types/device';
 import { logger } from '../../utils/logger';
 
+// Default public PSK (base64 encoded value of single byte 0x01)
+const DEFAULT_PUBLIC_PSK = 'AQ==';
+
+type EncryptionStatus = 'none' | 'default' | 'secure';
+
+// Helper to determine encryption status
+const getEncryptionStatus = (psk: string | undefined | null): EncryptionStatus => {
+  if (!psk || psk === '') {
+    return 'none'; // No encryption
+  }
+  if (psk === DEFAULT_PUBLIC_PSK) {
+    return 'default'; // Default/public key - not secure
+  }
+  return 'secure'; // Custom key - encrypted
+};
+
 interface ChannelsConfigSectionProps {
   baseUrl?: string;
   channels: Channel[];
@@ -247,7 +263,16 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                   </h4>
                   {channel && (
                     <div style={{ marginTop: '0.5rem', fontSize: '0.9rem', color: 'var(--ctp-subtext1)' }}>
-                      <div>🔒 {channel.psk ? t('channels_config.encrypted') : t('channels_config.unencrypted')}</div>
+                      {(() => {
+                        const status = getEncryptionStatus(channel.psk);
+                        if (status === 'secure') {
+                          return <div title={t('channels.encrypted_secure')}>🔒 {t('channels_config.encrypted_secure')}</div>;
+                        } else if (status === 'default') {
+                          return <div title={t('channels.encrypted_default')}>🔐 {t('channels_config.encrypted_default')}</div>;
+                        } else {
+                          return <div title={t('channels.unencrypted')}>🔓 {t('channels_config.unencrypted')}</div>;
+                        }
+                      })()}
                       <div>
                         {channel.uplinkEnabled ? `↑ ${t('channels_config.uplink')} ` : ''}
                         {channel.downlinkEnabled ? `↓ ${t('channels_config.downlink')}` : ''}


### PR DESCRIPTION
## Summary
- Fixes default PSK channels (AQ==) showing as "Encrypted" when they use the public default key
- Now displays three distinct encryption states matching ChannelsTab.tsx:
  - 🔒 "Encrypted (Custom Key)" for custom PSK
  - 🔐 "Default Key (Not Secure)" for default public PSK (AQ==)
  - 🔓 "Unencrypted" for no PSK
- Adds hover tooltips with full descriptions

## Test plan
- [ ] Navigate to Device → Channels
- [ ] Verify channel with default PSK shows 🔐 "Default Key (Not Secure)"
- [ ] Verify channel with custom PSK shows 🔒 "Encrypted (Custom Key)"
- [ ] Verify channel with no PSK shows 🔓 "Unencrypted"
- [ ] Hover over icons to see tooltips

Fixes #1641

🤖 Generated with [Claude Code](https://claude.com/claude-code)