### PR TITLE
fix(map): hide accuracy circles and segments when traceroute is active

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1688,7 +1688,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
               {/* Draw uncertainty circles for estimated positions */}
               {showEstimatedPositions && nodesWithPosition
-                .filter(node => node.user?.id && nodesWithEstimatedPosition.has(node.user.id) && (showMqttNodes || !node.viaMqtt) && (showIncompleteNodes || isNodeComplete(node)))
+                .filter(node => node.user?.id && nodesWithEstimatedPosition.has(node.user.id) && (showMqttNodes || !node.viaMqtt) && (showIncompleteNodes || isNodeComplete(node)) && (!tracerouteNodeNums || tracerouteNodeNums.has(node.nodeNum)))
                 .map(node => {
                   // Calculate radius based on precision bits (higher precision = smaller circle)
                   // Meshtastic uses precision_bits to reduce coordinate precision
@@ -1777,6 +1777,11 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
                 // Filter out segments where either endpoint is not visible (Issue #1149)
                 if (visibleNodeNums && (!visibleNodeNums.has(ni.nodeNum) || !visibleNodeNums.has(ni.neighborNodeNum))) {
+                  return null;
+                }
+
+                // When traceroute is active, only show segments for nodes in the traceroute
+                if (tracerouteNodeNums && (!tracerouteNodeNums.has(ni.nodeNum) || !tracerouteNodeNums.has(ni.neighborNodeNum))) {
                   return null;
                 }
 


### PR DESCRIPTION
## Summary
- Adds traceroute filtering to uncertainty circles (estimated positions)
- Adds traceroute filtering to neighbor info segments (Polylines)

When showing a traceroute, only nodes involved in the traceroute should be visible. Previously, accuracy circles and neighbor segments remained visible for all nodes even when the traceroute filter was hiding most markers.

## Test plan
- [ ] Select a node to show its traceroute
- [ ] Verify uncertainty circles for non-traceroute nodes are hidden
- [ ] Verify neighbor info segments for non-traceroute nodes are hidden
- [ ] Dismiss traceroute and verify all elements reappear

Fixes #1626

🤖 Generated with [Claude Code](https://claude.com/claude-code)