### PR TITLE
feat(messages): add sticky/pinned nodes in Messages tab

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -268,6 +268,8 @@
   "messages.exclude_infrastructure": "Exclude Infrastructure",
   "messages.node_fallback": "Node {{nodeNum}}",
   "messages.key_security_issue": "Key security issue detected",
+  "messages.pin_node": "Pin to top of list",
+  "messages.unpin_node": "Unpin from top of list",
   "messages.no_messages_preview": "No messages",
   "messages.total_messages_title": "Total Messages",
   "messages.no_nodes": "No nodes available",

--- a/src/App.css
+++ b/src/App.css
@@ -3321,6 +3321,20 @@ body {
   color: rgba(30, 30, 46, 0.8);
 }
 
+.node-short.sticky {
+  background: var(--ctp-yellow);
+  color: var(--ctp-base);
+}
+
+.node-short .pin-indicator {
+  margin-right: 0.25rem;
+  font-size: 0.7rem;
+}
+
+.node-short:hover {
+  opacity: 0.8;
+}
+
 .node-details {
   display: flex;
   justify-content: space-between;

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -273,6 +273,36 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   // Telemetry request modal state
   const [showTelemetryRequestModal, setShowTelemetryRequestModal] = useState(false);
 
+  // Sticky nodes - pinned to top of list regardless of sorting (stored in localStorage)
+  const [stickyNodes, setStickyNodes] = useState<Set<number>>(() => {
+    try {
+      const stored = localStorage.getItem('meshmonitor-sticky-dm-nodes');
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        return new Set(Array.isArray(parsed) ? parsed : []);
+      }
+    } catch {
+      // Ignore parse errors
+    }
+    return new Set();
+  });
+
+  // Toggle sticky status for a node
+  const toggleStickyNode = useCallback((nodeNum: number, e: React.MouseEvent) => {
+    e.stopPropagation(); // Don't select the node when toggling sticky
+    setStickyNodes(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(nodeNum)) {
+        newSet.delete(nodeNum);
+      } else {
+        newSet.add(nodeNum);
+      }
+      // Persist to localStorage
+      localStorage.setItem('meshmonitor-sticky-dm-nodes', JSON.stringify([...newSet]));
+      return newSet;
+    });
+  }, []);
+
   // Admin scan state
   const [adminScanLoading, setAdminScanLoading] = useState<string | null>(null);
   const { showToast } = useToast();
@@ -479,6 +509,9 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   // Sort and filter nodes based on dmFilter
   const sortedNodesWithMessages = [...nodesWithMessages]
     .filter(node => {
+      // Sticky nodes always pass through filters
+      if (stickyNodes.has(node.nodeNum)) return true;
+
       // Apply filter conditions
       switch (dmFilter) {
         case 'unread':
@@ -500,6 +533,12 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
       }
     })
     .sort((a, b) => {
+      // Sticky nodes always come first
+      const aSticky = stickyNodes.has(a.nodeNum);
+      const bSticky = stickyNodes.has(b.nodeNum);
+      if (aSticky && !bSticky) return -1;
+      if (!aSticky && bSticky) return 1;
+
       // For hops-based filters, sort by hops ascending
       if (['hops', 'favorites', 'withPosition', 'noInfra'].includes(dmFilter)) {
         return sortByHops(a, b);
@@ -510,6 +549,9 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
 
   // Filter for display
   const filteredNodes = sortedNodesWithMessages.filter(node => {
+    // Sticky nodes always pass through filters
+    if (stickyNodes.has(node.nodeNum)) return true;
+
     if (securityFilter === 'flaggedOnly') {
       if (!node.keyIsLowEntropy && !node.duplicateKeyDetected && !node.keySecurityIssueDetails) return false;
     } else if (securityFilter === 'hideFlagged') {
@@ -627,7 +669,15 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                               {node.keyMismatchDetected ? '🔓' : '⚠️'}
                             </span>
                           )}
-                          <div className="node-short">{node.user?.shortName || '-'}</div>
+                          <div
+                            className={`node-short ${stickyNodes.has(node.nodeNum) ? 'sticky' : ''}`}
+                            onClick={(e) => toggleStickyNode(node.nodeNum, e)}
+                            title={stickyNodes.has(node.nodeNum) ? t('messages.unpin_node') : t('messages.pin_node')}
+                            style={{ cursor: 'pointer' }}
+                          >
+                            {stickyNodes.has(node.nodeNum) && <span className="pin-indicator">📌</span>}
+                            {node.user?.shortName || '-'}
+                          </div>
                         </div>
                       </div>
 


### PR DESCRIPTION
## Summary
Allows users to pin nodes to the top of the conversation list in the Messages tab.

**How to use:**
- Click on a node's **short name box** (e.g., "ABCD") to pin/unpin it

**Pinned nodes:**
- Always appear at the top of the list regardless of sorting
- Bypass all filters (dropdown filter, security filter, channel filter, search)
- Show a 📌 indicator and yellow background
- Persist across browser sessions via localStorage

## Test plan
- [ ] Go to Messages tab
- [ ] Click on a node's short name to pin it - verify 📌 appears and background turns yellow
- [ ] Apply various filters (Unread, Recent, Favorites, etc.) - verify pinned node stays visible
- [ ] Click short name again to unpin - verify indicator disappears
- [ ] Refresh page - verify pins persist

Fixes #1647

🤖 Generated with [Claude Code](https://claude.com/claude-code)