### PR TITLE
fix(dashboard): improve Link Quality chart for sparse data

### DIFF
--- a/src/components/LinkQualityChart.tsx
+++ b/src/components/LinkQualityChart.tsx
@@ -52,36 +52,18 @@ function getQualityLabel(quality: number, t: (key: string) => string): string {
 }
 
 /**
- * Process link quality data and insert gaps for breaks > 1 hour
+ * Process link quality data for charting
  */
-function processLinkQualityData(data: LinkQualityData[] | undefined): Array<Record<string, number | null>> {
+function processLinkQualityData(data: LinkQualityData[] | undefined): Array<Record<string, number>> {
   if (!data || data.length === 0) return [];
 
-  // Sort by timestamp ascending
-  const sorted = [...data].sort((a, b) => a.timestamp - b.timestamp);
-
-  const oneHour = 60 * 60 * 1000;
-  const result: Array<Record<string, number | null>> = [];
-
-  for (let i = 0; i < sorted.length; i++) {
-    result.push({
-      timestamp: sorted[i].timestamp,
-      quality: sorted[i].quality,
-    });
-
-    if (i < sorted.length - 1) {
-      const timeDiff = sorted[i + 1].timestamp - sorted[i].timestamp;
-      if (timeDiff > oneHour) {
-        // Insert a gap point
-        result.push({
-          timestamp: sorted[i].timestamp + 1,
-          quality: null,
-        });
-      }
-    }
-  }
-
-  return result;
+  // Sort by timestamp ascending and map to chart format
+  return [...data]
+    .sort((a, b) => a.timestamp - b.timestamp)
+    .map(d => ({
+      timestamp: d.timestamp,
+      quality: d.quality,
+    }));
 }
 
 const LinkQualityChart: React.FC<LinkQualityChartProps> = ({
@@ -289,8 +271,8 @@ const LinkQualityChart: React.FC<LinkQualityChartProps> = ({
               return [`${numValue}/10 (${getQualityLabel(numValue, t)})`, t('info.link_quality_label')];
             }}
           />
-          <Area type="monotone" dataKey="quality" stroke="none" fill={`url(#qualityGradient-${id})`} connectNulls={false} />
-          <Line type="monotone" dataKey="quality" stroke="#89b4fa" strokeWidth={2} dot={false} connectNulls={false} />
+          <Area type="monotone" dataKey="quality" stroke="none" fill={`url(#qualityGradient-${id})`} />
+          <Line type="monotone" dataKey="quality" stroke="#89b4fa" strokeWidth={2} dot={{ r: 3, fill: '#89b4fa', strokeWidth: 0 }} />
         </ComposedChart>
       </ResponsiveContainer>
     </div>


### PR DESCRIPTION
## Summary
- Apply same fix from #1648 to Dashboard's `LinkQualityChart` component
- Remove gap detection that was inserting null values for >1 hour breaks
- Add dots at data points for better visibility of sparse data
- Remove `connectNulls={false}` props that were preventing line interpolation

This makes the Dashboard's Link Quality chart behavior consistent with the Telemetry tab's Link Quality graph.

## Test plan
- [ ] Navigate to Dashboard with a favorited Link Quality chart
- [ ] Verify chart displays continuous lines between data points
- [ ] Verify dots appear at each data point
- [ ] Verify no gaps appear for time breaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)