### PR TITLE
fix: allow deselecting nodes by clicking again in map node list

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -492,7 +492,13 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   // Stable callback factories for node item interactions
   const handleNodeClick = useCallback((node: DeviceInfo) => {
     return () => {
-      setSelectedNodeId(node.user?.id || null);
+      const nodeId = node.user?.id || null;
+      // Toggle selection: if already selected, deselect; otherwise select
+      if (selectedNodeId === nodeId) {
+        setSelectedNodeId(null);
+        return;
+      }
+      setSelectedNodeId(nodeId);
       // When showRoute is enabled, let TracerouteBoundsController handle the zoom
       // to fit the entire traceroute path instead of just centering on the node
       if (!showRoute) {
@@ -508,7 +514,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
         }
       }
     };
-  }, [setSelectedNodeId, centerMapOnNode, setIsNodeListCollapsed, showRoute]);
+  }, [selectedNodeId, setSelectedNodeId, centerMapOnNode, setIsNodeListCollapsed, showRoute]);
 
   const handleFavoriteClick = useCallback((node: DeviceInfo) => {
     return (e: React.MouseEvent) => toggleFavorite(node, e);


### PR DESCRIPTION
## Summary

- Clicking on an already-selected node in the node list now deselects it
- Map returns to showing all nodes when a node is deselected
- Previously there was no way to deselect a node once selected

Fixes #1656

## Changes

Modified `handleNodeClick` in `NodesTab.tsx` to toggle selection:
- If clicked node is already selected → deselect (set `selectedNodeId` to `null`)
- Otherwise → select the node as before

## Test plan

- [x] TypeScript type check passes
- [x] Unit tests pass (2248 tests)
- [ ] Manual: Click node in list → node selected, only that node shown
- [ ] Manual: Click same node again → node deselected, all nodes shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)