### PR TITLE
feat: treat single-emoji replies as tapback reactions

### DIFF
--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -573,7 +573,7 @@ export default function ChannelsTab({
                         messagesForChannel.map((msg, index) => {
                           const isMine = isMyMessage(msg);
                           const repliedMessage = msg.replyId ? findMessageById(msg.replyId, messageChannel) : null;
-                          const isReaction = msg.emoji === 1;
+                          const isReaction = msg.emoji === 1 || (msg.replyId != null && isEmoji(msg.text));
 
                           // Hide reactions (tapbacks) from main message list
                           if (isReaction) {
@@ -583,7 +583,7 @@ export default function ChannelsTab({
                           // Find ALL reactions in the full channel message list
                           const allChannelMessages = channelMessages[messageChannel] || [];
                           const reactions = allChannelMessages.filter(
-                            m => m.emoji === 1 && m.replyId && m.replyId.toString() === msg.id.split('_')[1]
+                            m => (m.emoji === 1 || isEmoji(m.text)) && m.replyId && m.replyId.toString() === msg.id.split('_')[1]
                           );
 
                           // Check if we should show a date separator

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -1065,12 +1065,12 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                 selectedDMMessages.map((msg, index) => {
                   const isTraceroute = msg.portnum === 70;
                   const isMine = isMyMessage(msg);
-                  const isReaction = msg.emoji === 1;
+                  const isReaction = msg.emoji === 1 || (msg.replyId != null && isEmoji(msg.text));
 
                   if (isReaction) return null;
 
                   const reactions = selectedDMMessages.filter(
-                    m => m.emoji === 1 && m.replyId && m.replyId.toString() === msg.id.split('_')[1]
+                    m => (m.emoji === 1 || isEmoji(m.text)) && m.replyId && m.replyId.toString() === msg.id.split('_')[1]
                   );
 
                   const repliedMessage = msg.replyId

--- a/src/utils/text.test.ts
+++ b/src/utils/text.test.ts
@@ -80,11 +80,10 @@ describe('text utilities', () => {
       expect(isEmoji('👍')).toBe(true);
     });
 
-    it('should return false for two surrogate pair emoji (length > 2)', () => {
-      // Two emoji like 😀😀 have string length 4 (each is 2 UTF-16 code units)
-      // This exceeds the length <= 2 check in the function
-      expect(isEmoji('😀😀')).toBe(false);
-      expect(isEmoji('🎉🎊')).toBe(false);
+    it('should return true for two surrogate pair emoji', () => {
+      // Two emoji like 😀😀 are still all-emoji strings
+      expect(isEmoji('😀😀')).toBe(true);
+      expect(isEmoji('🎉🎊')).toBe(true);
     });
 
     it('should return false for text', () => {
@@ -105,9 +104,9 @@ describe('text utilities', () => {
       expect(isEmoji(undefined as unknown as string)).toBe(false);
     });
 
-    it('should return false for more than 2 emoji', () => {
-      expect(isEmoji('😀😀😀')).toBe(false);
-      expect(isEmoji('🎉🎊🎁')).toBe(false);
+    it('should return true for more than 2 emoji', () => {
+      expect(isEmoji('😀😀😀')).toBe(true);
+      expect(isEmoji('🎉🎊🎁')).toBe(true);
     });
 
     it('should handle number emoji based on string length', () => {

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -44,6 +44,6 @@ export function formatByteCount(byteCount: number, maxBytes: number = 200): { te
  */
 export function isEmoji(content: string): boolean {
   if (!content) return false;
-  // Match emoji characters - the string should be 1-2 emoji with no other characters
-  return /^\p{Emoji}+$/u.test(content) && content.length <= 2;
+  // Match emoji characters - allow any length to support skin tone modifiers and ZWJ sequences
+  return /^\p{Emoji}+$/u.test(content);
 }


### PR DESCRIPTION
## Summary

- Emoji-only replies (e.g. replying with just 👍 to a message) now render as tapback pill buttons below the target message instead of full message bubbles
- Relaxed `isEmoji()` length restriction to support skin tone modifiers (👍🏻 = length 4) and ZWJ sequences
- Updated reaction detection in both `ChannelsTab` and `MessagesTab` to treat emoji-only replies the same as explicit tapbacks (`emoji: 1`)

## Test plan

- [ ] Run `npx vitest run` — all tests pass
- [ ] Send a reply with a single emoji (e.g. 👍) to a message — should render as a tapback pill, not a full message bubble
- [ ] Send a regular text reply — should still render as a normal reply with context
- [ ] Existing tapbacks (via emoji picker with `emoji: 1` flag) still work correctly
- [ ] Emoji with skin tone modifiers (e.g. 👍🏻) render as tapbacks when used as replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)