### PR TITLE
fix: zoom to node when Show Traceroute enabled but no traceroute exists

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -500,9 +500,20 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
       }
       setSelectedNodeId(nodeId);
       // When showRoute is enabled, let TracerouteBoundsController handle the zoom
-      // to fit the entire traceroute path instead of just centering on the node
+      // to fit the entire traceroute path instead of just centering on the node.
+      // But if the node has no valid traceroute, fall back to centering on it.
       if (!showRoute) {
         centerMapOnNode(node);
+      } else {
+        const hasTraceroute = traceroutes.some(tr => {
+          const matches = tr.toNodeId === nodeId || tr.fromNodeId === nodeId;
+          if (!matches) return false;
+          return tr.route && tr.route !== 'null' && tr.route !== '' &&
+                 tr.routeBack && tr.routeBack !== 'null' && tr.routeBack !== '';
+        });
+        if (!hasTraceroute) {
+          centerMapOnNode(node);
+        }
       }
       // Auto-collapse node list on mobile when a node with position is clicked
       if (window.innerWidth <= 768) {
@@ -514,7 +525,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
         }
       }
     };
-  }, [selectedNodeId, setSelectedNodeId, centerMapOnNode, setIsNodeListCollapsed, showRoute]);
+  }, [selectedNodeId, setSelectedNodeId, centerMapOnNode, setIsNodeListCollapsed, showRoute, traceroutes]);
 
   const handleFavoriteClick = useCallback((node: DeviceInfo) => {
     return (e: React.MouseEvent) => toggleFavorite(node, e);


### PR DESCRIPTION
## Summary

- When "Show Traceroute" is checked, clicking a node that has no valid traceroute data now falls back to centering/zooming the map on that node
- Previously, clicking such a node did nothing because `centerMapOnNode()` was skipped and `TracerouteBoundsController` had no bounds to fit
- Traceroute validity check mirrors the same logic used in `useTraceroutePaths` (checks for non-null, non-empty route and routeBack)

## Test plan

- [ ] Run `npx vitest run` — all tests pass
- [ ] Enable "Show Traceroute" on map, click a node with no traceroute — map should zoom to the node
- [ ] Click a node that has a valid traceroute — map should still zoom to fit the full traceroute path
- [ ] Disable "Show Traceroute", click any node — map should zoom to node as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)