### PR TITLE
chore: bump version to 3.3.1

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.3.0
-appVersion: "3.3.0"
+version: 3.3.1
+appVersion: "3.3.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump version to 3.3.1 across package.json, package-lock.json, Helm Chart.yaml, and Tauri config

## System Test Results
- Configuration Import: PASSED
- Quick Start Test: PASSED
- Security Test: PASSED
- V1 API Test: PASSED
- Reverse Proxy Test: PASSED
- Reverse Proxy + OIDC: PASSED
- Virtual Node CLI Test: PASSED
- Backup & Restore Test: FAILED (pre-existing — tries to pull non-existent public image)
- Database Migration Test: FAILED (pre-existing — same docker pull issue)

## Changes since v3.3.0
- #1665 fix: add missing enabled column to auto_traceroute_nodes table
- #1667 fix: correct reset-admin.mjs database path, account state, and multi-database support
- #1664 docs: add Link Quality & Smart Hops documentation page

🤖 Generated with [Claude Code](https://claude.com/claude-code)