### PR TITLE
fix: save decrypted_by and decrypted_channel_id in packet log

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -8509,8 +8509,9 @@ class DatabaseService {
       INSERT INTO packet_log (
         packet_id, timestamp, from_node, from_node_id, to_node, to_node_id,
         channel, portnum, portnum_name, encrypted, snr, rssi, hop_limit, hop_start,
-        relay_node, payload_size, want_ack, priority, payload_preview, metadata, direction, transport_mechanism
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        relay_node, payload_size, want_ack, priority, payload_preview, metadata, direction,
+        transport_mechanism, decrypted_by, decrypted_channel_id
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const result = stmt.run(
@@ -8535,7 +8536,9 @@ class DatabaseService {
       packet.payload_preview ?? null,
       packet.metadata ?? null,
       packet.direction ?? 'rx',
-      packet.transport_mechanism ?? null
+      packet.transport_mechanism ?? null,
+      packet.decrypted_by ?? null,
+      packet.decrypted_channel_id ?? null
     );
 
     // Enforce max count limit
@@ -8609,6 +8612,8 @@ class DatabaseService {
         direction: packet.direction ?? 'rx',
         created_at: Date.now(),
         transport_mechanism: packet.transport_mechanism ?? null,
+        decrypted_by: packet.decrypted_by ?? null,
+        decrypted_channel_id: packet.decrypted_channel_id ?? null,
       };
 
       // Use type assertion to avoid complex type narrowing


### PR DESCRIPTION
## Summary
- Fix `insertPacketLog` to actually save `decrypted_by` and `decrypted_channel_id` columns
- These columns existed in the schema but were never populated during insert
- This enables the Packet Monitor to show 🔑 (server decrypted) and 🔓 (node decrypted) indicators

## Problem
The packet log schema had columns for tracking:
- `decrypted_by`: whether packet was decrypted by 'node' or 'server' (Channel Database)
- `decrypted_channel_id`: which Channel Database entry was used for decryption

However, `insertPacketLog()` never included these in the INSERT statement, so they were always NULL. The Packet Monitor UI checks these fields to show decryption indicators, but they were never populated.

## Solution
Added `decrypted_by` and `decrypted_channel_id` to both:
- Sync version (SQLite raw SQL INSERT)
- Async version (Drizzle ORM values object)

## Test plan
- [x] Build passes
- [x] All 23 packetLogService tests pass
- [x] All 174 database tests pass
- [ ] Manual: Add a channel to Channel Database, receive encrypted traffic, verify 🔑 icon appears in Packet Monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)