### PR TITLE
fix: improve emoji detection and validate tapback emoji input

### DIFF
--- a/src/components/TapbackEmojiSettings.tsx
+++ b/src/components/TapbackEmojiSettings.tsx
@@ -4,6 +4,7 @@ import { useSettings } from '../contexts/SettingsContext';
 import { DEFAULT_TAPBACK_EMOJIS, type TapbackEmoji } from './EmojiPickerModal/EmojiPickerModal';
 import { useToast } from './ToastContainer';
 import { logger } from '../utils/logger';
+import { isEmoji } from '../utils/text';
 
 /**
  * TapbackEmojiSettings - Settings component for managing tapback emoji reactions
@@ -23,6 +24,12 @@ const TapbackEmojiSettings: React.FC = () => {
 
     if (!trimmedEmoji) {
       showToast(t('settings.tapback_emoji_required', 'Please enter an emoji'), 'error');
+      return;
+    }
+
+    // Validate that the input is actually an emoji (not regular text)
+    if (!isEmoji(trimmedEmoji)) {
+      showToast(t('settings.tapback_invalid_emoji', 'Please enter a valid emoji, not text'), 'error');
       return;
     }
 

--- a/src/utils/text.test.ts
+++ b/src/utils/text.test.ts
@@ -78,6 +78,12 @@ describe('text utilities', () => {
       expect(isEmoji('🎉')).toBe(true);
       expect(isEmoji('❤')).toBe(true);
       expect(isEmoji('👍')).toBe(true);
+      expect(isEmoji('✅')).toBe(true);
+    });
+
+    it('should return true for emoji with variation selectors', () => {
+      expect(isEmoji('❤️')).toBe(true);  // heart with variation selector
+      expect(isEmoji('☺️')).toBe(true);  // smiling face with variation selector
     });
 
     it('should return true for two surrogate pair emoji', () => {
@@ -86,10 +92,31 @@ describe('text utilities', () => {
       expect(isEmoji('🎉🎊')).toBe(true);
     });
 
+    it('should return true for emoji with skin tone modifiers', () => {
+      expect(isEmoji('👍🏻')).toBe(true);
+      expect(isEmoji('👍🏿')).toBe(true);
+      expect(isEmoji('🙋🏽')).toBe(true);
+    });
+
+    it('should return true for ZWJ sequences', () => {
+      expect(isEmoji('👨‍👩‍👧')).toBe(true);    // family
+      expect(isEmoji('🏳️‍🌈')).toBe(true);      // rainbow flag
+      expect(isEmoji('👩‍💻')).toBe(true);       // woman technologist
+    });
+
     it('should return false for text', () => {
       expect(isEmoji('hello')).toBe(false);
       expect(isEmoji('abc')).toBe(false);
       expect(isEmoji('A')).toBe(false);
+    });
+
+    it('should return false for digits and ASCII symbols that are technically emoji', () => {
+      // These are in the Unicode Emoji category but should NOT be treated as emoji reactions
+      expect(isEmoji('123')).toBe(false);
+      expect(isEmoji('0')).toBe(false);
+      expect(isEmoji('#')).toBe(false);
+      expect(isEmoji('*')).toBe(false);
+      expect(isEmoji('1')).toBe(false);
     });
 
     it('should return false for mixed emoji and text', () => {
@@ -109,11 +136,11 @@ describe('text utilities', () => {
       expect(isEmoji('🎉🎊🎁')).toBe(true);
     });
 
-    it('should handle number emoji based on string length', () => {
-      // Number emoji like 1️⃣ are complex sequences with length > 2
-      // The function checks string length, not grapheme count
-      expect(isEmoji('1️⃣')).toBe(false); // length is 3 (digit + variation selector + keycap)
-      expect(isEmoji('🔢')).toBe(true);   // single emoji, length 2
+    it('should handle keycap sequences', () => {
+      // Keycap sequences like 1️⃣ are complex and not commonly used as tapbacks
+      // The regex doesn't match these because they start with ASCII digits
+      expect(isEmoji('1️⃣')).toBe(false);
+      expect(isEmoji('🔢')).toBe(true);   // input numbers emoji
     });
   });
 });

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -36,14 +36,17 @@ export function formatByteCount(byteCount: number, maxBytes: number = 200): { te
 }
 
 /**
- * Check if a string consists primarily of emoji characters
- * Used for styling sender dots that use emoji as shortnames
+ * Check if a string consists only of emoji characters
+ * Used for styling sender dots that use emoji as shortnames, and for detecting tapback reactions
  *
  * @param content - The text to check
- * @returns True if the content is primarily emoji (1-2 emoji characters)
+ * @returns True if the content contains only emoji characters
  */
 export function isEmoji(content: string): boolean {
   if (!content) return false;
-  // Match emoji characters - allow any length to support skin tone modifiers and ZWJ sequences
-  return /^\p{Emoji}+$/u.test(content);
+  // Use Extended_Pictographic and Emoji_Presentation to match actual pictographic emojis
+  // This excludes ASCII characters like digits (#, *, 0-9) which are technically in the Emoji category
+  // but shouldn't be treated as emoji reactions
+  // Allows variation selectors (FE00-FE0F), ZWJ (200D), and emoji modifiers for sequences
+  return /^(?:[\p{Extended_Pictographic}\p{Emoji_Presentation}][\u{FE00}-\u{FE0F}\u{200D}\p{Emoji_Modifier}]*)+$/u.test(content);
 }


### PR DESCRIPTION
## Summary
- Fixed `isEmoji()` function to exclude digits, `#`, `*`, and other ASCII characters that were incorrectly matching as emoji
- Added validation to TapbackEmojiSettings to prevent non-emoji text from being saved as tapback options

## Root Cause
Users could enter any text (like "chilly") as a custom tapback emoji. When used, this text was sent with the Meshtastic `emoji: 1` flag, causing it to display as a tapback on iOS and be hidden from MeshMonitor's message list.

## Test plan
- [x] All 2312 unit tests pass
- [x] Manually verified emoji validation in tapback settings

🤖 Generated with [Claude Code](https://claude.ai/code)