### PR TITLE
feat: add rebroadcast mode warnings for Channel Database feature

### DIFF
--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -2383,6 +2383,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
         <div id="config-channel-database">
           <ChannelDatabaseSection
             isAdmin={authStatus?.user?.isAdmin ?? false}
+            rebroadcastMode={rebroadcastMode}
           />
         </div>
 

--- a/src/components/configuration/ChannelDatabaseSection.tsx
+++ b/src/components/configuration/ChannelDatabaseSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import apiService, { ChannelDatabaseEntry, RetroactiveDecryptionProgress } from '../../services/api';
 import { useToast } from '../ToastContainer';
 import { logger } from '../../utils/logger';
+import { REBROADCAST_MODE_OPTIONS } from './constants';
 
 /**
  * Meshtastic default channel key (shorthand value 1)
@@ -50,6 +51,7 @@ function uint8ArrayToBase64(arr: Uint8Array): string {
 
 interface ChannelDatabaseSectionProps {
   isAdmin: boolean;
+  rebroadcastMode?: number;
 }
 
 interface ChannelEditState {
@@ -60,9 +62,12 @@ interface ChannelEditState {
   isEnabled: boolean;
 }
 
-const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin }) => {
+const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin, rebroadcastMode }) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
+
+  // Get the rebroadcast mode name for warning display
+  const rebroadcastModeName = REBROADCAST_MODE_OPTIONS.find(opt => opt.value === rebroadcastMode)?.name || 'UNKNOWN';
 
   const [channels, setChannels] = useState<ChannelDatabaseEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -390,6 +395,35 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
         <p className="setting-description" style={{ marginBottom: '1rem' }}>
           {t('channel_database.description')}
         </p>
+
+        {/* Rebroadcast Mode Warning */}
+        {rebroadcastMode !== undefined && rebroadcastMode !== 0 && (
+          <div
+            style={{
+              backgroundColor: 'var(--ctp-peach)',
+              color: 'var(--ctp-base)',
+              padding: '1rem',
+              borderRadius: '8px',
+              marginBottom: '1rem',
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: '0.75rem'
+            }}
+          >
+            <span style={{ fontSize: '1.5rem', lineHeight: 1 }}>⚠️</span>
+            <div>
+              <strong style={{ display: 'block', marginBottom: '0.25rem' }}>
+                {t('channel_database.rebroadcast_warning_title', 'Rebroadcast Mode Warning')}
+              </strong>
+              <span>
+                {t('channel_database.rebroadcast_warning_message',
+                  'Your node\'s Rebroadcast Mode is set to "{{mode}}". For the Channel Database to decrypt packets from other nodes, Rebroadcast Mode should be set to "ALL". Otherwise, encrypted packets from distant nodes may not be forwarded to MeshMonitor for analysis.',
+                  { mode: rebroadcastModeName }
+                )}
+              </span>
+            </div>
+          </div>
+        )}
 
         {/* Retroactive Decryption Progress */}
         {decryptionProgress && (decryptionProgress.status === 'running' || decryptionProgress.status === 'pending') && (

--- a/src/components/configuration/DeviceConfigSection.tsx
+++ b/src/components/configuration/DeviceConfigSection.tsx
@@ -496,6 +496,28 @@ const DeviceConfigSection: React.FC<DeviceConfigSectionProps> = ({
             </option>
           ))}
         </select>
+        {rebroadcastMode !== 0 && (
+          <div
+            style={{
+              backgroundColor: 'var(--ctp-peach)',
+              color: 'var(--ctp-base)',
+              padding: '0.75rem',
+              borderRadius: '6px',
+              marginTop: '0.5rem',
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: '0.5rem',
+              fontSize: '0.9rem'
+            }}
+          >
+            <span style={{ fontSize: '1.1rem', lineHeight: 1 }}>⚠️</span>
+            <span>
+              {t('device_config.rebroadcast_warning',
+                'This mode may prevent the Channel Database from decrypting packets from distant nodes, as encrypted packets won\'t be forwarded to MeshMonitor for analysis.'
+              )}
+            </span>
+          </div>
+        )}
       </div>
 
       {/* Buzzer Mode */}


### PR DESCRIPTION
## Summary
- Add warning banner at top of Channel Database section when Rebroadcast Mode is not set to "ALL", explaining that encrypted packets from distant nodes may not be forwarded for decryption
- Add inline warning below the Rebroadcast Mode dropdown in Device Config section with the same guidance

## Context
When Rebroadcast Mode is set to something other than "ALL" (e.g., LOCAL_ONLY, KNOWN_ONLY, NONE), the node won't forward encrypted packets from distant nodes to MeshMonitor, which means the Channel Database feature can't decrypt those packets for analysis.

## Test plan
- [ ] Navigate to Device Configuration and change Rebroadcast Mode to something other than "ALL"
- [ ] Verify inline warning appears below the dropdown
- [ ] Navigate to Channel Database section
- [ ] Verify banner warning appears at the top showing the current mode
- [ ] Change Rebroadcast Mode back to "ALL" and verify both warnings disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)