### PR TITLE
chore: update GPS coordinates helper links to latlong.net

### DIFF
--- a/src/components/PositionOverrideModal/PositionOverrideModal.tsx
+++ b/src/components/PositionOverrideModal/PositionOverrideModal.tsx
@@ -283,7 +283,7 @@ export const PositionOverrideModal: React.FC<PositionOverrideModalProps> = ({
 
                   <div className="position-override-link">
                     <a
-                      href="https://gps-coordinates.org/"
+                      href="https://www.latlong.net/"
                       target="_blank"
                       rel="noopener noreferrer"
                     >

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -1218,7 +1218,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
                 <label htmlFor="solarLatitude">
                   {t('settings.solar_latitude')}
                   <span className="setting-description">
-                    {t('settings.solar_latitude_description')} • <a href="https://gps-coordinates.org/" target="_blank" rel="noopener noreferrer" style={{ color: '#4a9eff', textDecoration: 'underline' }}>{t('settings.solar_find_coords')}</a>
+                    {t('settings.solar_latitude_description')} • <a href="https://www.latlong.net/" target="_blank" rel="noopener noreferrer" style={{ color: '#4a9eff', textDecoration: 'underline' }}>{t('settings.solar_find_coords')}</a>
                   </span>
                 </label>
                 <input

--- a/src/components/configuration/PositionConfigSection.tsx
+++ b/src/components/configuration/PositionConfigSection.tsx
@@ -227,7 +227,7 @@ const PositionConfigSection: React.FC<PositionConfigSectionProps> = ({
             <label htmlFor="fixedLatitude">
               {t('position_config.latitude')}
               <span className="setting-description">
-                {t('position_config.latitude_description')} • <a href="https://gps-coordinates.org/" target="_blank" rel="noopener noreferrer" style={{ color: '#4a9eff', textDecoration: 'underline' }}>{t('position_config.find_coordinates')}</a>
+                {t('position_config.latitude_description')} • <a href="https://www.latlong.net/" target="_blank" rel="noopener noreferrer" style={{ color: '#4a9eff', textDecoration: 'underline' }}>{t('position_config.find_coordinates')}</a>
               </span>
             </label>
             <input


### PR DESCRIPTION
## Summary
- Replace `gps-coordinates.org` links with `latlong.net` across the UI

## Files Changed
- `src/components/configuration/PositionConfigSection.tsx` - Fixed position latitude helper link
- `src/components/PositionOverrideModal/PositionOverrideModal.tsx` - Position override modal link
- `src/components/SettingsTab.tsx` - Solar monitoring latitude helper link

## Test plan
- [ ] Click "Find Coordinates" link in Device Configuration > Position > Fixed Position
- [ ] Click coordinates link in Position Override modal
- [ ] Click "Find Coordinates" link in Settings > Solar Monitoring
- [ ] Verify all open https://www.latlong.net/

🤖 Generated with [Claude Code](https://claude.com/claude-code)