### PR TITLE
docs: add new feature boxes and clean up internal documentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -127,14 +127,55 @@ export default defineConfig({
     lineNumbers: true
   },
 
-  // Ignore dead links in old documentation files
+  // Ignore dead links in old documentation files and excluded internal docs
   ignoreDeadLinks: [
     /^http:\/\/localhost/,
     (url) => {
-      return url.includes('/deployment/') || url.includes('/architecture/') || url.includes('/database/')
+      // Ignore links to excluded directories
+      if (url.includes('/deployment/') || url.includes('/architecture/') || url.includes('/database/') || url.includes('/operations/')) {
+        return true;
+      }
+      // Ignore links to excluded internal documentation files
+      const excludedDocs = [
+        'ARCHITECTURE_LESSONS', 'AUTHENTICATION', 'AUTH_IMPLEMENTATION_SUMMARY',
+        'CHANGE_PASSWORD_FEATURE', 'development-learnings', 'mqtt-vs-http-analysis',
+        'proxy-compatibility-analysis', 'PUSH_NOTIFICATIONS', 'REFACTORING_PLAN',
+        'SECURITY_AUDIT', 'TEST_UPDATES', 'v2.0.0-authentication-plan',
+        'v2.16-IMPLEMENTATION-SUMMARY', 'MACOS_CODE_SIGNING_SETUP',
+        'PERMISSIONS_QUICK_REFERENCE', 'security-duplicate-keys', 'security-low-entropy-keys',
+        'database-migration', 'meshtastic-config-import'
+      ];
+      return excludedDocs.some(doc => url.includes(doc));
     }
   ],
 
-  // Exclude old documentation directories from VitePress processing
-  srcExclude: ['**/architecture/**', '**/database/**', '**/api/**']
+  // Exclude old documentation directories and internal development docs from VitePress processing
+  // These are available on GitHub for developers who need them
+  srcExclude: [
+    '**/architecture/**',
+    '**/database/**',
+    '**/api/**',
+    '**/planning/**',
+    '**/operations/**',
+    // Internal development documentation (available on GitHub)
+    'ARCHITECTURE_LESSONS.md',
+    'AUTHENTICATION.md',
+    'AUTH_IMPLEMENTATION_SUMMARY.md',
+    'CHANGE_PASSWORD_FEATURE.md',
+    'development-learnings.md',
+    'mqtt-vs-http-analysis.md',
+    'proxy-compatibility-analysis.md',
+    'PUSH_NOTIFICATIONS.md',
+    'REFACTORING_PLAN.md',
+    'SECURITY_AUDIT.md',
+    'TEST_UPDATES.md',
+    'v2.0.0-authentication-plan.md',
+    'v2.16-IMPLEMENTATION-SUMMARY.md',
+    'MACOS_CODE_SIGNING_SETUP.md',
+    'PERMISSIONS_QUICK_REFERENCE.md',
+    'security-duplicate-keys.md',
+    'security-low-entropy-keys.md',
+    'database-migration.md',
+    'meshtastic-config-import.md'
+  ]
 })

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,22 @@ features:
   - icon: ☀️
     title: Solar Monitoring
     details: Integrate with forecast.solar to visualize expected solar production alongside telemetry data. Perfect for optimizing off-grid deployments and predicting power availability.
+
+  - icon: ⚡
+    title: Automation & Triggers
+    details: Create powerful automations with Auto-Responders, Scheduled Messages, Auto-Traceroute, and Geofence Triggers. Respond to keywords, schedule broadcasts, and trigger actions based on node locations.
+
+  - icon: 📍
+    title: Geofence Triggers
+    details: Define geographic zones on an interactive map and trigger automated responses when nodes enter, exit, or remain inside. Perfect for arrival notifications, asset tracking, and proximity alerts.
+
+  - icon: 📜
+    title: Custom Scripting
+    details: Extend MeshMonitor with custom Python or Bash scripts. Execute scripts on message events, geofence triggers, or scheduled intervals. Full access to message context and node information.
+
+  - icon: 🔧
+    title: Remote Administration
+    details: Change node connections on-the-fly without container restarts. Configure device settings, manage channels, and send admin commands directly from the web interface.
 ---
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Add 4 new feature boxes to the front page highlighting v3.4.0 capabilities
- Clean up internal development documentation from the website build

## New Feature Boxes
- **Automation & Triggers** - Auto-Responders, Scheduled Messages, Auto-Traceroute, Geofence Triggers
- **Geofence Triggers** - Location-based automation with interactive map zone editor
- **Custom Scripting** - Python/Bash script execution for advanced automation
- **Remote Administration** - In-app node connection and device configuration

## Documentation Cleanup
Excluded internal development docs from website (still available on GitHub):
- Architecture lessons, authentication plans, security audits
- Implementation summaries, refactoring plans
- Database migration guides, proxy analysis docs

## Test plan
- [ ] VitePress build succeeds (`npm run docs:build`)
- [ ] Front page shows new feature boxes
- [ ] Internal docs no longer appear in navigation/search

🤖 Generated with [Claude Code](https://claude.com/claude-code)