### PR TITLE
fix: position history not working on PostgreSQL/MySQL backends

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -793,7 +793,7 @@ apiRouter.get('/nodes/:nodeId/position-history', optionalAuth(), async (req, res
     }
 
     // Get only position-related telemetry (lat/lon/alt) for the node - much more efficient!
-    const positionTelemetry = databaseService.getPositionTelemetryByNode(nodeId, 1500, cutoffTime);
+    const positionTelemetry = await databaseService.getPositionTelemetryByNodeAsync(nodeId, 1500, cutoffTime);
 
     // Group by timestamp to get lat/lon pairs
     const positionMap = new Map<number, { lat?: number; lon?: number; alt?: number }>();
@@ -832,13 +832,13 @@ apiRouter.get('/nodes/:nodeId/position-history', optionalAuth(), async (req, res
 });
 
 // Alternative endpoint with limit parameter for fetching positions
-apiRouter.get('/nodes/:nodeId/positions', optionalAuth(), (req, res) => {
+apiRouter.get('/nodes/:nodeId/positions', optionalAuth(), async (req, res) => {
   try {
     const { nodeId } = req.params;
     const limit = req.query.limit ? parseInt(req.query.limit as string) : 2000;
 
     // Get only position-related telemetry (lat/lon/alt) for the node
-    const positionTelemetry = databaseService.getPositionTelemetryByNode(nodeId, limit);
+    const positionTelemetry = await databaseService.getPositionTelemetryByNodeAsync(nodeId, limit);
 
     // Group by timestamp to get lat/lon pairs
     const positionMap = new Map<number, { lat?: number; lon?: number; alt?: number }>();

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -4432,6 +4432,16 @@ class DatabaseService {
     return telemetry.map(t => this.normalizeBigInts(t));
   }
 
+  // Async version of getPositionTelemetryByNode - works for all database backends
+  async getPositionTelemetryByNodeAsync(nodeId: string, limit: number = 1500, sinceTimestamp?: number): Promise<DbTelemetry[]> {
+    if (this.telemetryRepo) {
+      // Cast to local DbTelemetry type (they have compatible structure)
+      return this.telemetryRepo.getPositionTelemetryByNode(nodeId, limit, sinceTimestamp) as unknown as Promise<DbTelemetry[]>;
+    }
+    // Fallback to sync method for SQLite when repo not available
+    return this.getPositionTelemetryByNode(nodeId, limit, sinceTimestamp);
+  }
+
   /**
    * Get the latest estimated positions for all nodes in a single query.
    * This is much more efficient than querying each node individually (N+1 problem).


### PR DESCRIPTION
## Summary

- Fixed position history not displaying on the map for PostgreSQL and MySQL users
- Users could see position packets in the Packet Monitor but the map showed no position history

## Root Cause

The position history API endpoints (`/api/nodes/:nodeId/position-history` and `/api/nodes/:nodeId/positions`) were calling a synchronous method `getPositionTelemetryByNode()` that explicitly returned an empty array for PostgreSQL and MySQL backends:

```typescript
// Line 4408-4410 in database.ts
if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
  return [];  // <-- Always returned empty!
}
```

## Fix

- Added async `getPositionTelemetryByNodeAsync()` wrapper in DatabaseService that delegates to the TelemetryRepository
- Updated both API endpoints to await the async method
- The TelemetryRepository already had working implementations for all three database backends

## Test plan

- [x] Build passes
- [x] All 2318 tests pass
- [ ] Test with PostgreSQL backend - position history should now display on map
- [ ] Test with MySQL backend - position history should now display on map
- [ ] Verify SQLite still works (regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)