### PR TITLE
feat: add Verify Response option to Geofence Triggers

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2158,6 +2158,7 @@
   "automation.geofence_triggers.channel_help": "Output will be sent to this channel",
   "automation.geofence_triggers.channel_none": "None (no mesh output)",
   "automation.geofence_triggers.channel_none_help": "Script handles its own output (e.g., external integrations)",
+  "automation.geofence_triggers.verify_response": "Verify Response (enable 3-retry delivery confirmation - DM only)",
   "automation.geofence_triggers.add": "Add Geofence Trigger",
   "automation.geofence_triggers.added": "Geofence trigger added",
   "automation.geofence_triggers.saved": "Geofence triggers saved",

--- a/src/components/GeofenceTriggersSection.tsx
+++ b/src/components/GeofenceTriggersSection.tsx
@@ -84,6 +84,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
   const [newScriptArgs, setNewScriptArgs] = useState('');
   const [newResponse, setNewResponse] = useState('');
   const [newChannel, setNewChannel] = useState<number | 'dm' | 'none'>('dm');
+  const [newVerifyResponse, setNewVerifyResponse] = useState(false);
 
   // Edit mode state
   const [editingTriggerId, setEditingTriggerId] = useState<string | null>(null);
@@ -193,6 +194,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
             scriptPath: newResponseType === 'script' ? newScriptPath : undefined,
             scriptArgs: newResponseType === 'script' && newScriptArgs.trim() ? newScriptArgs.trim() : undefined,
             channel: newChannel,
+            verifyResponse: newChannel === 'dm' ? newVerifyResponse : false,
           };
         }
         return t;
@@ -214,6 +216,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
         scriptPath: newResponseType === 'script' ? newScriptPath : undefined,
         scriptArgs: newResponseType === 'script' && newScriptArgs.trim() ? newScriptArgs.trim() : undefined,
         channel: newChannel,
+        verifyResponse: newChannel === 'dm' ? newVerifyResponse : false,
       };
       setLocalTriggers([...localTriggers, newTrigger]);
       showToast(t('automation.geofence_triggers.added', 'Geofence trigger added'), 'success');
@@ -231,6 +234,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
     setNewScriptArgs('');
     setNewResponse('');
     setNewChannel('dm');
+    setNewVerifyResponse(false);
   };
 
   const handleRemoveTrigger = (id: string) => {
@@ -256,6 +260,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
     setNewScriptArgs(trigger.scriptArgs ?? '');
     setNewResponse(trigger.response ?? '');
     setNewChannel(trigger.channel);
+    setNewVerifyResponse(trigger.verifyResponse ?? false);
   };
 
   const handleCancelEdit = () => {
@@ -271,6 +276,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
     setNewScriptArgs('');
     setNewResponse('');
     setNewChannel('dm');
+    setNewVerifyResponse(false);
   };
 
   const formatLastRun = (timestamp?: number) => {
@@ -586,6 +592,27 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
                   ? t('automation.geofence_triggers.channel_none_help', 'Script handles its own output (e.g., external integrations)')
                   : t('automation.geofence_triggers.channel_help', 'Output will be sent to this channel')}
               </div>
+              {/* Verify Response checkbox - only for DM channel */}
+              {newResponseType === 'text' && (
+                <div style={{ paddingLeft: '0.5rem', marginTop: '0.25rem' }}>
+                  <label style={{
+                    display: 'block',
+                    fontSize: '0.85rem',
+                    cursor: newChannel === 'dm' ? 'pointer' : 'not-allowed',
+                    color: 'var(--ctp-subtext0)',
+                    opacity: newChannel === 'dm' ? 1 : 0.5
+                  }}>
+                    <input
+                      type="checkbox"
+                      checked={newVerifyResponse}
+                      onChange={(e) => setNewVerifyResponse(e.target.checked)}
+                      disabled={newChannel !== 'dm'}
+                      style={{ marginRight: '0.5rem', cursor: newChannel === 'dm' ? 'pointer' : 'not-allowed' }}
+                    />
+                    <span>{t('automation.geofence_triggers.verify_response', 'Verify Response (enable 3-retry delivery confirmation - DM only)')}</span>
+                  </label>
+                </div>
+              )}
             </div>
 
             {/* Add/Save Button */}
@@ -743,6 +770,18 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
         }}>
           {trigger.enabled ? 'ENABLED' : 'DISABLED'}
         </span>
+        {trigger.verifyResponse && (
+          <span style={{
+            fontSize: '0.7rem',
+            padding: '0.15rem 0.4rem',
+            background: 'var(--ctp-peach)',
+            color: 'var(--ctp-base)',
+            borderRadius: '3px',
+            fontWeight: 'bold',
+          }}>
+            VERIFY
+          </span>
+        )}
         <button
           onClick={onToggleEnabled}
           style={{

--- a/src/components/auto-responder/types.ts
+++ b/src/components/auto-responder/types.ts
@@ -75,6 +75,7 @@ export interface GeofenceTrigger {
   scriptPath?: string; // Path to script in /data/scripts/ (when responseType is 'script')
   scriptArgs?: string; // Optional CLI arguments for script execution (supports token expansion)
   channel: number | 'dm' | 'none'; // Channel index (0-7), 'dm' for direct message, or 'none' for scripts with no mesh output
+  verifyResponse?: boolean; // Enable retry logic (3 attempts) for DM messages
   lastRun?: number; // Unix timestamp of last execution
   lastResult?: 'success' | 'error';
   lastError?: string;

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -207,6 +207,7 @@ interface GeofenceTriggerConfig {
   scriptPath?: string;
   scriptArgs?: string; // Optional CLI arguments for script execution (supports token expansion)
   channel: number | 'dm' | 'none';
+  verifyResponse?: boolean; // Enable retry logic (3 attempts) for DM messages
   lastRun?: number;
   lastResult?: 'success' | 'error';
   lastError?: string;


### PR DESCRIPTION
## Summary

Add the same "Verify Response (enable 3-retry delivery confirmation)" feature that exists in AutoResponder to Geofence Triggers.

## Changes

- Add `verifyResponse` field to GeofenceTrigger type (frontend and backend)
- Add checkbox UI in the geofence trigger form (only enabled for DM channel)
- Display "VERIFY" badge on triggers with verifyResponse enabled  
- Add translation key for the checkbox label

## How it works

The retry logic is already handled by `messageQueueService` which implements:
- 3 retry attempts for DM messages
- 30-second intervals between retries
- ACK tracking for delivery confirmation

The `verifyResponse` flag is a UI indicator showing the user that retry is enabled for that trigger.

## Test plan

- [x] Build passes
- [x] All 2318 tests pass
- [ ] Create a geofence trigger with DM channel and verify checkbox is enabled
- [ ] Create a geofence trigger with channel broadcast and verify checkbox is disabled
- [ ] Verify "VERIFY" badge appears on triggers with verifyResponse enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)