### PR TITLE
fix: preserve channel names when device sends empty names

### DIFF
--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -169,14 +169,17 @@ export class ChannelsRepository extends BaseRepository {
 
     if (existingChannel) {
       // Update existing channel
-      logger.info(`Updating channel ${existingChannel.id} from "${existingChannel.name}" to "${data.name}"`);
+      // Preserve existing non-empty name if incoming name is empty (fixes #1567)
+      // This prevents device reconnections from wiping channel names
+      const effectiveName = data.name || existingChannel.name;
+      logger.info(`Updating channel ${existingChannel.id}: name "${existingChannel.name}" -> "${effectiveName}" (incoming: "${data.name}")`);
 
       if (this.isSQLite()) {
         const db = this.getSqliteDb();
         await db
           .update(channelsSqlite)
           .set({
-            name: data.name,
+            name: effectiveName,
             psk: data.psk ?? existingChannel.psk,
             role: data.role ?? existingChannel.role,
             uplinkEnabled: data.uplinkEnabled ?? existingChannel.uplinkEnabled,
@@ -190,7 +193,7 @@ export class ChannelsRepository extends BaseRepository {
         await db
           .update(channelsMysql)
           .set({
-            name: data.name,
+            name: effectiveName,
             psk: data.psk ?? existingChannel.psk,
             role: data.role ?? existingChannel.role,
             uplinkEnabled: data.uplinkEnabled ?? existingChannel.uplinkEnabled,
@@ -204,7 +207,7 @@ export class ChannelsRepository extends BaseRepository {
         await db
           .update(channelsPostgres)
           .set({
-            name: data.name,
+            name: effectiveName,
             psk: data.psk ?? existingChannel.psk,
             role: data.role ?? existingChannel.role,
             uplinkEnabled: data.uplinkEnabled ?? existingChannel.uplinkEnabled,


### PR DESCRIPTION
## Summary
- Fixes issue where Android/iOS virtual node clients show "Channel Name" placeholder text instead of actual channel names
- Prevents device reconnections from overwriting existing channel names with empty strings

## Problem
When a Meshtastic device reconnects, it often sends channel configuration with empty name fields (especially for the default Primary channel). The `upsertChannel` function was unconditionally overwriting the database channel name with the incoming value, even when empty. This caused:
1. Existing channel names to be wiped on device reconnection
2. Android/iOS apps connected to the virtual node to display "Channel Name" placeholder

## Solution
When updating a channel, check if the incoming name is empty. If so, preserve the existing non-empty name from the database instead of overwriting it.

```typescript
const effectiveName = data.name || existingChannel.name;
```

## Test plan
- [x] TypeScript compiles without errors
- [x] All tests pass (2328 passed)
- [ ] Manual testing: Set a channel name, reconnect device, verify name is preserved
- [ ] Manual testing: Connect Android app to virtual node, verify channel names display correctly

Fixes #1567

🤖 Generated with [Claude Code](https://claude.com/claude-code)