### PR TITLE
feat: add node filter to packet monitor

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1065,6 +1065,8 @@
   "packet_monitor.filter.decoded_only": "Decoded Only",
   "packet_monitor.filter.hide_own": "Hide Own Packets",
   "packet_monitor.filter.clear": "Clear Filters",
+  "packet_monitor.filter.all_nodes": "All Nodes",
+  "packet_monitor.filter.from_node_tooltip": "Filter by source node",
   "packet_monitor.rate_limit_warning": "Rate limit reached. Infinite scrolling paused for 15 minutes. Current packets will continue to update.",
   "packet_monitor.loading": "Loading packets...",
   "packet_monitor.no_packets": "No packets logged yet",

--- a/src/components/PacketMonitorPanel.tsx
+++ b/src/components/PacketMonitorPanel.tsx
@@ -512,6 +512,22 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
               <option value="false">{t('packet_monitor.filter.decoded_only')}</option>
             </select>
 
+            <select
+              value={filters.from_node ?? ''}
+              onChange={e => setFilters({ ...filters, from_node: e.target.value ? parseInt(e.target.value) : undefined })}
+              title={t('packet_monitor.filter.from_node_tooltip')}
+            >
+              <option value="">{t('packet_monitor.filter.all_nodes')}</option>
+              {nodes
+                .filter(node => node.user?.id)
+                .sort((a, b) => (a.user?.longName || '').localeCompare(b.user?.longName || ''))
+                .map(node => (
+                  <option key={node.nodeNum} value={node.nodeNum}>
+                    {node.user?.longName || node.user?.shortName || `!${node.nodeNum.toString(16).padStart(8, '0')}`}
+                  </option>
+                ))}
+            </select>
+
             <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
               <input
                 type="checkbox"


### PR DESCRIPTION
## Summary

- Adds a node filter dropdown to the packet monitor panel
- Allows filtering packets by source node to make debugging easier
- Leverages existing `from_node` field in PacketFilters interface

## Test plan

- [ ] Open packet monitor
- [ ] Verify "All Nodes" is selected by default
- [ ] Select a specific node from dropdown
- [ ] Verify only packets from that node are displayed
- [ ] Clear filter by selecting "All Nodes" again

🤖 Generated with [Claude Code](https://claude.com/claude-code)