### PR TITLE
feat: add tabs to map and node popups for better iOS scrolling

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1026,6 +1026,9 @@
   "node_popup.return_path": "Return",
   "node_popup.traceroute_failed": "No response received",
   "node_popup.view_traceroute_history": "View History",
+  "node_popup.tab_info": "Node Info",
+  "node_popup.tab_traceroute": "Traceroute",
+  "node_popup.no_recent_traceroute": "No recent traceroute data",
 
   "route_segment.title": "Traceroutes Using Segment",
   "route_segment.segment": "Segment",

--- a/src/App.css
+++ b/src/App.css
@@ -4337,6 +4337,48 @@ body {
   font-style: italic;
 }
 
+/* Tab Navigation for Map Popups */
+.node-popup-tabs {
+  display: flex;
+  gap: 0.25rem;
+  margin: 0.5rem 0;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--ctp-surface1);
+}
+
+.node-popup-tab {
+  flex: 1;
+  padding: 0.375rem 0.5rem;
+  background: var(--ctp-surface0);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  transition: background 0.2s, border-color 0.2s;
+  text-align: center;
+}
+
+.node-popup-tab:hover {
+  background: var(--ctp-surface1);
+}
+
+.node-popup-tab.active {
+  background: var(--ctp-blue);
+  border-color: var(--ctp-blue);
+}
+
+.node-popup-content {
+  min-height: 80px;
+}
+
+.node-popup-no-traceroute {
+  font-size: 0.875rem;
+  color: var(--ctp-subtext0);
+  font-style: italic;
+  padding: 0.5rem 0;
+}
+
 /* Legacy Route Popup Styles (for other popups) */
 .route-popup {
   min-width: 200px;

--- a/src/components/MapNodePopupContent.tsx
+++ b/src/components/MapNodePopupContent.tsx
@@ -1,0 +1,256 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { DeviceInfo } from '../types/device';
+import type { DbTraceroute } from '../services/database';
+import type { ResourceType } from '../types/permission';
+import { getHardwareModelName, getRoleName, parseNodeId, TRACEROUTE_DISPLAY_HOURS } from '../utils/nodeHelpers';
+import { formatDateTime, formatRelativeTime } from '../utils/datetime';
+import { formatTracerouteRoute } from '../utils/traceroute';
+
+type PopupTab = 'info' | 'traceroute';
+
+interface MapNodePopupContentProps {
+  node: DeviceInfo;
+  nodes: DeviceInfo[];
+  currentNodeId: string | null;
+  timeFormat: '12' | '24';
+  dateFormat: 'MM/DD/YYYY' | 'DD/MM/YYYY' | 'YYYY-MM-DD';
+  distanceUnit: 'km' | 'mi' | 'nm';
+  traceroutes: DbTraceroute[];
+  hasPermission: (resource: ResourceType, action: 'read' | 'write') => boolean;
+  onDMNode: () => void;
+  onTraceroute?: () => void;
+  connectionStatus?: string;
+  tracerouteLoading?: string | null;
+  getEffectiveHops: (node: DeviceInfo) => number;
+}
+
+export const MapNodePopupContent: React.FC<MapNodePopupContentProps> = ({
+  node,
+  nodes,
+  currentNodeId,
+  timeFormat,
+  dateFormat,
+  distanceUnit,
+  traceroutes,
+  hasPermission,
+  onDMNode,
+  onTraceroute,
+  connectionStatus,
+  tracerouteLoading,
+  getEffectiveHops,
+}) => {
+  const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState<PopupTab>('info');
+
+  // Check if traceroute tab should be available
+  const hasTracerouteFeatures = hasPermission('traceroute', 'write') && onTraceroute;
+
+  // Find the most recent traceroute between current node and this node
+  const recentTraceroute = (() => {
+    if (!currentNodeId || !node.user?.id || currentNodeId === node.user.id) return null;
+
+    const currentNodeNum = parseNodeId(currentNodeId);
+    if (currentNodeNum === null) return null;
+
+    const cutoff = Date.now() - TRACEROUTE_DISPLAY_HOURS * 60 * 60 * 1000;
+
+    return traceroutes
+      .filter(tr => {
+        const isRelevant =
+          (tr.fromNodeNum === currentNodeNum && tr.toNodeNum === node.nodeNum) ||
+          (tr.fromNodeNum === node.nodeNum && tr.toNodeNum === currentNodeNum);
+        return isRelevant && tr.timestamp >= cutoff;
+      })
+      .sort((a, b) => b.timestamp - a.timestamp)[0] || null;
+  })();
+
+  return (
+    <div className="node-popup">
+      {/* Header */}
+      <div className="node-popup-header">
+        <div className="node-popup-title">{node.user?.longName || `Node ${node.nodeNum}`}</div>
+        {node.user?.shortName && (
+          <div className="node-popup-subtitle">{node.user.shortName}</div>
+        )}
+      </div>
+
+      {/* Tab bar - only show if traceroute features are available */}
+      {hasTracerouteFeatures && (
+        <div className="node-popup-tabs">
+          <button
+            className={`node-popup-tab ${activeTab === 'info' ? 'active' : ''}`}
+            onClick={() => setActiveTab('info')}
+            title={t('node_popup.tab_info', 'Node Info')}
+          >
+            ℹ️
+          </button>
+          <button
+            className={`node-popup-tab ${activeTab === 'traceroute' ? 'active' : ''}`}
+            onClick={() => setActiveTab('traceroute')}
+            title={t('node_popup.tab_traceroute', 'Traceroute')}
+          >
+            📡
+          </button>
+        </div>
+      )}
+
+      {/* Info Tab Content */}
+      {(activeTab === 'info' || !hasTracerouteFeatures) && (
+        <div className="node-popup-content">
+          <div className="node-popup-grid">
+            {node.user?.id && (
+              <div className="node-popup-item">
+                <span className="node-popup-icon">🆔</span>
+                <span className="node-popup-value">{node.user.id}</span>
+              </div>
+            )}
+
+            {node.user?.role !== undefined && (() => {
+              const roleNum = typeof node.user.role === 'string'
+                ? parseInt(node.user.role, 10)
+                : node.user.role;
+              const roleName = getRoleName(roleNum);
+              return roleName ? (
+                <div className="node-popup-item">
+                  <span className="node-popup-icon">👤</span>
+                  <span className="node-popup-value">{roleName}</span>
+                </div>
+              ) : null;
+            })()}
+
+            {node.user?.hwModel !== undefined && (() => {
+              const hwModelName = getHardwareModelName(node.user.hwModel);
+              return hwModelName ? (
+                <div className="node-popup-item">
+                  <span className="node-popup-icon">🖥️</span>
+                  <span className="node-popup-value">{hwModelName}</span>
+                </div>
+              ) : null;
+            })()}
+
+            {node.snr != null && (
+              <div className="node-popup-item">
+                <span className="node-popup-icon">📶</span>
+                <span className="node-popup-value">{node.snr.toFixed(1)} dB</span>
+              </div>
+            )}
+
+            {(() => {
+              const popupHops = getEffectiveHops(node);
+              return popupHops < 999 ? (
+                <div className="node-popup-item">
+                  <span className="node-popup-icon">🔗</span>
+                  <span className="node-popup-value">{popupHops} hop{popupHops !== 1 ? 's' : ''}</span>
+                </div>
+              ) : null;
+            })()}
+
+            {node.position?.altitude != null && (
+              <div className="node-popup-item">
+                <span className="node-popup-icon">⛰️</span>
+                <span className="node-popup-value">{node.position.altitude}m</span>
+              </div>
+            )}
+
+            {node.deviceMetrics?.batteryLevel !== undefined && node.deviceMetrics.batteryLevel !== null && (
+              <div className="node-popup-item">
+                <span className="node-popup-icon">{node.deviceMetrics.batteryLevel === 101 ? '🔌' : '🔋'}</span>
+                <span className="node-popup-value">
+                  {node.deviceMetrics.batteryLevel === 101 ? 'Plugged In' : `${node.deviceMetrics.batteryLevel}%`}
+                </span>
+              </div>
+            )}
+          </div>
+
+          {node.lastHeard && (
+            <div className="node-popup-footer">
+              <span className="node-popup-icon">🕐</span>
+              {formatDateTime(new Date(node.lastHeard * 1000), timeFormat, dateFormat)}
+            </div>
+          )}
+
+          {/* Action button for info tab */}
+          {node.user?.id && hasPermission('messages', 'read') && (
+            <button className="node-popup-btn" onClick={onDMNode}>
+              💬 Direct Message
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Traceroute Tab Content */}
+      {activeTab === 'traceroute' && hasTracerouteFeatures && (
+        <div className="node-popup-content">
+          {/* Recent Traceroute Display */}
+          {recentTraceroute ? (
+            <div className="node-popup-traceroute">
+              <div className="traceroute-header">
+                <strong>{t('node_popup.last_traceroute')}</strong>
+                <span className="traceroute-age">
+                  ({formatRelativeTime(recentTraceroute.timestamp)})
+                </span>
+              </div>
+              {recentTraceroute.route && recentTraceroute.route !== 'null' ? (
+                <>
+                  <div className="traceroute-path">
+                    <span className="traceroute-label">{t('node_popup.forward_path')}:</span>
+                    <span className="traceroute-route">
+                      {formatTracerouteRoute(
+                        recentTraceroute.route,
+                        recentTraceroute.snrTowards,
+                        recentTraceroute.fromNodeNum,
+                        recentTraceroute.toNodeNum,
+                        nodes,
+                        distanceUnit
+                      )}
+                    </span>
+                  </div>
+                  {recentTraceroute.routeBack && recentTraceroute.routeBack !== 'null' && (
+                    <div className="traceroute-path">
+                      <span className="traceroute-label">{t('node_popup.return_path')}:</span>
+                      <span className="traceroute-route">
+                        {formatTracerouteRoute(
+                          recentTraceroute.routeBack,
+                          recentTraceroute.snrBack,
+                          recentTraceroute.toNodeNum,
+                          recentTraceroute.fromNodeNum,
+                          nodes,
+                          distanceUnit
+                        )}
+                      </span>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div className="traceroute-failed">
+                  {t('node_popup.traceroute_failed')}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="node-popup-no-traceroute">
+              {t('node_popup.no_recent_traceroute', 'No recent traceroute data')}
+            </div>
+          )}
+
+          {/* Traceroute action button */}
+          {node.user?.id && onTraceroute && (
+            <button
+              className="node-popup-btn"
+              onClick={onTraceroute}
+              disabled={connectionStatus !== 'connected' || tracerouteLoading === node.user?.id}
+            >
+              {tracerouteLoading === node.user?.id ? (
+                <span className="spinner"></span>
+              ) : (
+                '📡'
+              )}{' '}
+              {t('node_popup.traceroute', 'Traceroute')}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/NodePopup/NodePopup.css
+++ b/src/components/NodePopup/NodePopup.css
@@ -134,3 +134,46 @@
   font-size: 0.75rem;
   padding: 0.375rem 0.75rem;
 }
+
+/* Tab Navigation */
+.node-popup-tabs {
+  display: flex;
+  gap: 0.25rem;
+  margin: 0.5rem 0;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--ctp-surface1);
+}
+
+.node-popup-tab {
+  flex: 1;
+  padding: 0.375rem 0.5rem;
+  background: var(--ctp-surface0);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  transition: background 0.2s, border-color 0.2s;
+  text-align: center;
+}
+
+.node-popup-tab:hover {
+  background: var(--ctp-surface1);
+}
+
+.node-popup-tab.active {
+  background: var(--ctp-blue);
+  border-color: var(--ctp-blue);
+}
+
+/* Tab Content */
+.node-popup-content {
+  min-height: 80px;
+}
+
+.node-popup-no-traceroute {
+  font-size: 0.875rem;
+  color: var(--ctp-subtext0);
+  font-style: italic;
+  padding: 0.5rem 0;
+}


### PR DESCRIPTION
## Summary
- Adds tabbed interface to map node popups to fix iOS rubber-banding when scrolling long traceroute data
- Uses icon-only tabs (ℹ️ Info, 📡 Traceroute) to preserve space on small screens
- Tabs only appear when user has traceroute permissions

## Changes
- Create new `MapNodePopupContent` component for Leaflet map popups
- Update `NodesTab` to use new component, clean up unused imports
- Add tab support to `NodePopup` component for consistency
- Add CSS styles for tabs in both `App.css` and `NodePopup.css`
- Add translation keys for tab labels

## Test plan
- [ ] Verify map popup shows tabs when logged in with traceroute permissions
- [ ] Verify Info tab shows node details and DM button
- [ ] Verify Traceroute tab shows traceroute data and traceroute button
- [ ] Verify tabs do not appear for users without traceroute permissions
- [ ] Test scrolling on iOS device to confirm rubber-banding is resolved

Fixes #1705

🤖 Generated with [Claude Code](https://claude.com/claude-code)