### PR TITLE
fix: restore URL hash navigation for bookmarks and direct links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,7 +96,7 @@ L.Icon.Default.mergeOptions({
 
 function App() {
   const { t } = useTranslation();
-  const { authStatus, hasPermission } = useAuth();
+  const { authStatus, hasPermission, loading: authLoading } = useAuth();
   const { getToken: getCsrfToken, refreshToken: refreshCsrfToken } = useCsrf();
   const webSocketConnected = useWebSocketConnected();
   const { showToast } = useToast();
@@ -544,6 +544,12 @@ function App() {
   // Check tab permissions and redirect if unauthorized
   // This prevents users from accessing protected tabs via direct URL navigation
   useEffect(() => {
+    // Wait for auth to finish loading before checking permissions
+    // This prevents false redirects when navigating via URL hash
+    if (authLoading) {
+      return;
+    }
+
     const isAdmin = authStatus?.user?.isAdmin || false;
     const isAuthenticated = authStatus?.authenticated || false;
 
@@ -566,7 +572,7 @@ function App() {
       logger.info(`[Auth] Redirecting from '${activeTab}' tab - insufficient permissions`);
       setActiveTab('nodes');
     }
-  }, [activeTab, authStatus, hasPermission, setActiveTab]);
+  }, [activeTab, authStatus, authLoading, hasPermission, setActiveTab]);
 
   // Helper function to safely parse node IDs to node numbers
   const parseNodeId = useCallback((nodeId: string): number => {


### PR DESCRIPTION
## Summary
- Fix URL hash navigation (`#settings`, `#channels`, etc.) not working for bookmarks and direct links
- Pages were redirecting back to map/nodes because permission check ran before auth loaded

## Root Cause
The permission check in `App.tsx` was running immediately when `activeTab` changed, but `authStatus` hadn't finished loading yet. This caused the permission check to fail and redirect to `nodes`.

## Fix
Added `authLoading` check to skip permission verification until auth is ready:
```typescript
if (authLoading) {
  return;  // Skip permission check until auth is ready
}
```

## Test plan
- [x] Build succeeds
- [x] System tests pass (all 9 test suites)
- [ ] Navigate directly to `http://localhost:8081/meshmonitor#channels` - should stay on channels
- [ ] Login, then navigate to `http://localhost:8081/meshmonitor#settings` - should stay on settings
- [ ] Use browser back/forward buttons - hash navigation should work
- [ ] Bookmark a page and reopen - should navigate to correct tab

## System Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| V1 API Test | ✅ PASSED |
| Reverse Proxy Test | ✅ PASSED |
| Reverse Proxy + OIDC | ✅ PASSED |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |
| Database Migration Test | ✅ PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)