### PR TITLE
fix: use python3 interpreter path in Docker container

### DIFF
--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -60,6 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     supervisor \
     gosu \
     && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
     && python3 -m venv /opt/apprise-venv \
     && /opt/apprise-venv/bin/pip install --no-cache-dir apprise "paho-mqtt<2.0"
 

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1604,7 +1604,7 @@ class MeshtasticManager {
 
     switch (ext) {
       case 'js': case 'mjs': interpreter = isDev ? 'node' : '/usr/local/bin/node'; break;
-      case 'py': interpreter = isDev ? 'python' : '/usr/bin/python'; break;
+      case 'py': interpreter = isDev ? 'python' : '/usr/bin/python3'; break;
       case 'sh': interpreter = isDev ? 'sh' : '/bin/sh'; break;
       default:
         this.updateGeofenceTriggerResult(trigger.id, 'error', `Unsupported script extension: ${ext}`);
@@ -1856,7 +1856,7 @@ class MeshtasticManager {
         interpreter = isDev ? 'node' : '/usr/local/bin/node';
         break;
       case 'py':
-        interpreter = isDev ? 'python' : '/usr/bin/python';
+        interpreter = isDev ? 'python' : '/usr/bin/python3';
         break;
       case 'sh':
         interpreter = isDev ? 'sh' : '/bin/sh';
@@ -7498,7 +7498,7 @@ class MeshtasticManager {
                 interpreter = isDev ? 'node' : '/usr/local/bin/node';
                 break;
               case 'py':
-                interpreter = isDev ? 'python' : '/usr/bin/python';
+                interpreter = isDev ? 'python' : '/usr/bin/python3';
                 break;
               case 'sh':
                 interpreter = isDev ? 'sh' : '/bin/sh';

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8309,7 +8309,7 @@ apiRouter.post('/scripts/test', requirePermission('settings', 'read'), async (re
         interpreter = isDev ? 'node' : '/usr/local/bin/node';
         break;
       case 'py':
-        interpreter = isDev ? 'python' : '/usr/bin/python';
+        interpreter = isDev ? 'python' : '/usr/bin/python3';
         break;
       case 'sh':
         interpreter = isDev ? 'sh' : '/bin/sh';


### PR DESCRIPTION
## Summary
- Fixes Python script execution failures in Docker container on ARMv7
- Changed interpreter path from `/usr/bin/python` to `/usr/bin/python3` in server code
- Added missing python symlink to `Dockerfile.armv7`

## Root Cause
The **ARMv7 Dockerfile** (`Dockerfile.armv7`) uses Debian slim and was missing the `/usr/bin/python` symlink that exists in the main Alpine-based Dockerfile.

| Dockerfile | Base Image | `/usr/bin/python` | `/usr/bin/python3` |
|------------|------------|-------------------|-------------------|
| Dockerfile | Alpine | ✅ symlink | ✅ exists |
| Dockerfile.armv7 | Debian slim | ❌ **missing** | ✅ exists |

## Solution
Two-part fix for maximum compatibility:

1. **Server code**: Use `/usr/bin/python3` directly (works everywhere)
2. **Dockerfile.armv7**: Add the missing symlink for user scripts that use `#!/usr/bin/env python`

Now both `python` and `python3` work on all architectures:
- ✅ amd64 (Alpine)
- ✅ arm64 (Alpine)  
- ✅ armv7 (Debian slim)

## Changes
- `server.ts`: 1 occurrence updated
- `meshtasticManager.ts`: 3 occurrences updated
- `Dockerfile.armv7`: Added `ln -sf /usr/bin/python3 /usr/bin/python`

Closes #1722

## Test plan
- [x] TypeScript compiles without errors
- [x] Unit tests pass (106 passed)
- [ ] Build and test on ARMv7 device

🤖 Generated with [Claude Code](https://claude.com/claude-code)