### PR TITLE
fix: remove nodesCache check that was skipping telemetry inserts

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -4568,12 +4568,9 @@ class DatabaseService {
     // For PostgreSQL/MySQL, fire-and-forget async insert
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (this.telemetryRepo) {
-        // Check if node exists in cache - if not, skip telemetry insert
-        // This prevents foreign key constraint violations during race conditions
-        if (!this.nodesCache.has(telemetryData.nodeNum)) {
-          logger.debug(`[DatabaseService] Skipping telemetry insert - node ${telemetryData.nodeNum} not in cache yet`);
-          return;
-        }
+        // Note: We removed the nodesCache check here because it was too aggressive -
+        // it would skip telemetry for nodes that exist in the DB but not in the in-memory cache
+        // (e.g., after server restart). The foreign key error handling below handles race conditions.
         this.telemetryRepo.insertTelemetry(telemetryData).catch((error) => {
           // Ignore foreign key violations - node might not be persisted yet
           const errorStr = String(error);


### PR DESCRIPTION
## Summary
- Removes overly-aggressive `nodesCache` check in `insertTelemetry()` for PostgreSQL/MySQL backends
- This check was silently skipping telemetry inserts for nodes that exist in the database but not in the in-memory cache (e.g., after server restart)
- Position history was not being saved properly for PostgreSQL/MySQL backends

## Root Cause
The check on line 4573 would skip telemetry inserts if the node wasn't in `nodesCache`:
```typescript
if (!this.nodesCache.has(telemetryData.nodeNum)) {
  logger.debug(`Skipping telemetry insert - node not in cache yet`);
  return;  // ← Silently drops telemetry!
}
```

The foreign key error handling that follows already handles the race condition case where a node doesn't exist yet.

## Test plan
- [x] Verified with PostgreSQL backend - position telemetry now saves correctly
- [x] Verified 128 latitude/longitude records saved after fix
- [ ] Test with MySQL backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)