### PR TITLE
fix: respect distance unit setting for position history speed display

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1818,9 +1818,12 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                             const converted = startPos.groundSpeed * 3.6;
                             // If converted > 200 km/h, assume raw is already in km/h
                             const speedKmh = converted > 200 ? startPos.groundSpeed : converted;
+                            // Convert to mph if user prefers miles
+                            const speed = distanceUnit === 'mi' ? speedKmh * 0.621371 : speedKmh;
+                            const unit = distanceUnit === 'mi' ? 'mph' : 'km/h';
                             return (
                               <div className="route-usage">
-                                <strong>Speed:</strong> {speedKmh.toFixed(1)} km/h
+                                <strong>Speed:</strong> {speed.toFixed(1)} {unit}
                               </div>
                             );
                           })()}
@@ -1845,7 +1848,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 const historyArrows = generatePositionHistoryArrows(
                   filteredHistory,
                   segmentColors,
-                  30
+                  30,
+                  distanceUnit
                 );
                 elements.push(...historyArrows);
 

--- a/src/utils/mapHelpers.tsx
+++ b/src/utils/mapHelpers.tsx
@@ -323,12 +323,14 @@ const getCardinalDirection = (heading: number): string => {
  * @param historyItems Array of position history items with full data
  * @param colors Array of colors for each position
  * @param maxArrows Maximum number of arrows to generate
+ * @param distanceUnit User's preferred distance unit ('km' or 'mi')
  * @returns Array of Marker components with clickable popups
  */
 export const generatePositionHistoryArrows = (
   historyItems: PositionHistoryItem[],
   colors: string[],
-  maxArrows: number = 30
+  maxArrows: number = 30,
+  distanceUnit: 'km' | 'mi' = 'km'
 ): React.ReactElement[] => {
   const arrows: React.ReactElement[] = [];
   const itemCount = historyItems.length;
@@ -380,13 +382,17 @@ export const generatePositionHistoryArrows = (
     const dateStr = date.toLocaleDateString();
     const timeStr = date.toLocaleTimeString();
 
-    // Format speed (convert from m/s to km/h)
+    // Format speed (convert from m/s to km/h, then to mph if needed)
     // Some devices may report in different units - sanity check for reasonable values
-    let speedKmh: string | null = null;
+    let speedDisplay: string | null = null;
+    let speedUnit = distanceUnit === 'mi' ? 'mph' : 'km/h';
     if (item.groundSpeed !== undefined) {
       const converted = item.groundSpeed * 3.6;
       // If converted speed > 200 km/h, assume raw value is already in km/h
-      speedKmh = converted > 200 ? item.groundSpeed.toFixed(1) : converted.toFixed(1);
+      const speedKmh = converted > 200 ? item.groundSpeed : converted;
+      // Convert to mph if user prefers miles
+      const speed = distanceUnit === 'mi' ? speedKmh * 0.621371 : speedKmh;
+      speedDisplay = speed.toFixed(1);
     }
 
     // Format heading
@@ -410,8 +416,8 @@ export const generatePositionHistoryArrows = (
           <div className="position-history-popup">
             <div><strong>Date:</strong> {dateStr}</div>
             <div><strong>Time:</strong> {timeStr}</div>
-            {speedKmh !== null && (
-              <div><strong>Speed:</strong> {speedKmh} km/h</div>
+            {speedDisplay !== null && (
+              <div><strong>Speed:</strong> {speedDisplay} {speedUnit}</div>
             )}
             {headingStr !== null && (
               <div><strong>Heading:</strong> {headingStr}</div>


### PR DESCRIPTION
## Summary
- Convert speed display in position history popups to use user's preferred distance unit
- Shows km/h when distance unit is kilometers, mph when set to miles

## Test plan
- [ ] Set distance unit to kilometers in settings
- [ ] View position history popup - verify speed shows in km/h
- [ ] Set distance unit to miles in settings
- [ ] View position history popup - verify speed shows in mph

🤖 Generated with [Claude Code](https://claude.com/claude-code)