### PR TITLE
feat: add {TOTALNODES} token for automation messages

### DIFF
--- a/src/components/AutoAcknowledgeSection.tsx
+++ b/src/components/AutoAcknowledgeSection.tsx
@@ -203,6 +203,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
 
     sample = sample.replace(/{NODECOUNT}/g, '42');
     sample = sample.replace(/{DIRECTCOUNT}/g, '8');
+    sample = sample.replace(/{TOTALNODES}/g, '156');
     sample = sample.replace(/{SNR}/g, '7.5');
     sample = sample.replace(/{RSSI}/g, '-95');
     sample = sample.replace(/{TRANSPORT}/g, 'LoRa'); // Sample transport type
@@ -489,7 +490,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
           <label htmlFor="autoAckMessage">
             {t('automation.auto_ack.message_multihop')}
             <span className="setting-description">
-              {t('automation.auto_ack.message_multihop_description')} {t('automation.auto_ack.available_tokens')} {'{NODE_ID}'}, {'{NUMBER_HOPS}'}, {'{HOPS}'}, {'{RABBIT_HOPS}'}, {'{DATE}'}, {'{TIME}'}, {'{VERSION}'}, {'{DURATION}'}, {'{FEATURES}'}, {'{NODECOUNT}'}, {'{DIRECTCOUNT}'}, {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{SNR}'}, {'{RSSI}'}, {'{TRANSPORT}'}
+              {t('automation.auto_ack.message_multihop_description')} {t('automation.auto_ack.available_tokens')} {'{NODE_ID}'}, {'{NUMBER_HOPS}'}, {'{HOPS}'}, {'{RABBIT_HOPS}'}, {'{DATE}'}, {'{TIME}'}, {'{VERSION}'}, {'{DURATION}'}, {'{FEATURES}'}, {'{NODECOUNT}'}, {'{DIRECTCOUNT}'}, {'{TOTALNODES}'}, {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{SNR}'}, {'{RSSI}'}, {'{TRANSPORT}'}
             </span>
           </label>
           <textarea
@@ -669,6 +670,22 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
             </button>
             <button
               type="button"
+              onClick={() => insertToken('{TOTALNODES}')}
+              disabled={!localEnabled}
+              style={{
+                padding: '0.25rem 0.5rem',
+                fontSize: '12px',
+                background: 'var(--ctp-surface2)',
+                border: '1px solid var(--ctp-overlay0)',
+                borderRadius: '4px',
+                cursor: localEnabled ? 'pointer' : 'not-allowed',
+                opacity: localEnabled ? 1 : 0.5
+              }}
+            >
+              + {'{TOTALNODES}'}
+            </button>
+            <button
+              type="button"
               onClick={() => insertToken('{LONG_NAME}')}
               disabled={!localEnabled}
               style={{
@@ -776,7 +793,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
           <label htmlFor="autoAckMessageDirect">
             {t('automation.auto_ack.message_direct')}
             <span className="setting-description">
-              {t('automation.auto_ack.message_direct_description')} {t('automation.auto_ack.available_tokens')} {'{NODE_ID}'}, {'{HOPS}'}, {'{NUMBER_HOPS}'}, {'{RABBIT_HOPS}'}, {'{DATE}'}, {'{TIME}'}, {'{VERSION}'}, {'{DURATION}'}, {'{FEATURES}'}, {'{NODECOUNT}'}, {'{DIRECTCOUNT}'}, {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{SNR}'}, {'{RSSI}'}, {'{TRANSPORT}'}
+              {t('automation.auto_ack.message_direct_description')} {t('automation.auto_ack.available_tokens')} {'{NODE_ID}'}, {'{HOPS}'}, {'{NUMBER_HOPS}'}, {'{RABBIT_HOPS}'}, {'{DATE}'}, {'{TIME}'}, {'{VERSION}'}, {'{DURATION}'}, {'{FEATURES}'}, {'{NODECOUNT}'}, {'{DIRECTCOUNT}'}, {'{TOTALNODES}'}, {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{SNR}'}, {'{RSSI}'}, {'{TRANSPORT}'}
             </span>
           </label>
           <textarea

--- a/src/components/AutoAnnounceSection.tsx
+++ b/src/components/AutoAnnounceSection.tsx
@@ -271,6 +271,7 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
 
     sample = sample.replace(/{NODECOUNT}/g, '42');
     sample = sample.replace(/{DIRECTCOUNT}/g, '8');
+    sample = sample.replace(/{TOTALNODES}/g, '156');
 
     return sample;
   };
@@ -612,6 +613,22 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
               }}
             >
               + {'{DIRECTCOUNT}'}
+            </button>
+            <button
+              type="button"
+              onClick={createInsertTokenHandler('{TOTALNODES}')}
+              disabled={!localEnabled}
+              style={{
+                padding: '0.25rem 0.5rem',
+                fontSize: '12px',
+                background: 'var(--ctp-surface2)',
+                border: '1px solid var(--ctp-overlay0)',
+                borderRadius: '4px',
+                cursor: localEnabled ? 'pointer' : 'not-allowed',
+                opacity: localEnabled ? 1 : 0.5
+              }}
+            >
+              + {'{TOTALNODES}'}
             </button>
           </div>
         </div>

--- a/src/components/AutoWelcomeSection.tsx
+++ b/src/components/AutoWelcomeSection.tsx
@@ -189,6 +189,7 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
     sample = sample.replace(/{FEATURES}/g, '🗺️ 🤖 📢');
     sample = sample.replace(/{NODECOUNT}/g, '15');
     sample = sample.replace(/{DIRECTCOUNT}/g, '3');
+    sample = sample.replace(/{TOTALNODES}/g, '156');
 
     return sample;
   };
@@ -321,7 +322,7 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
           <label htmlFor="welcomeMessage">
             {t('automation.auto_welcome.message_label')}
             <span className="setting-description">
-              {t('automation.auto_welcome.message_description')} {t('automation.available_tokens')}: {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{VERSION}'}, {'{DURATION}'}, {'{FEATURES}'}, {'{NODECOUNT}'}, {'{DIRECTCOUNT}'}
+              {t('automation.auto_welcome.message_description')} {t('automation.available_tokens')}: {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{VERSION}'}, {'{DURATION}'}, {'{FEATURES}'}, {'{NODECOUNT}'}, {'{DIRECTCOUNT}'}, {'{TOTALNODES}'}
             </span>
           </label>
           <textarea
@@ -346,7 +347,8 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
               '{DURATION}',
               '{FEATURES}',
               '{NODECOUNT}',
-              '{DIRECTCOUNT}'
+              '{DIRECTCOUNT}',
+              '{TOTALNODES}'
             ].map(token => (
               <button
                 key={token}

--- a/src/components/GeofenceTriggersSection.tsx
+++ b/src/components/GeofenceTriggersSection.tsx
@@ -27,7 +27,8 @@ const AVAILABLE_TOKENS = [
   { token: '{DISTANCE_TO_CENTER}', description: 'Distance to geofence center (km)' },
   { token: '{IP}', description: 'Connected Meshtastic node IP address' },
   { token: '{VERSION}', description: 'MeshMonitor version' },
-  { token: '{NODECOUNT}', description: 'Total active nodes' },
+  { token: '{NODECOUNT}', description: 'Active nodes (filtered by maxNodeAgeHours)' },
+  { token: '{TOTALNODES}', description: 'Total nodes ever seen' },
 ];
 
 const getLanguageEmoji = (language: string): string => {

--- a/src/components/TimerTriggersSection.tsx
+++ b/src/components/TimerTriggersSection.tsx
@@ -37,8 +37,9 @@ const AVAILABLE_TOKENS = [
   { token: '{VERSION}', description: 'MeshMonitor version' },
   { token: '{DURATION}', description: 'Server uptime' },
   { token: '{FEATURES}', description: 'Enabled features as emojis' },
-  { token: '{NODECOUNT}', description: 'Total active nodes' },
+  { token: '{NODECOUNT}', description: 'Active nodes (filtered by maxNodeAgeHours)' },
   { token: '{DIRECTCOUNT}', description: 'Direct nodes (0 hops)' },
+  { token: '{TOTALNODES}', description: 'Total nodes ever seen' },
 ];
 
 interface TimerTriggersSectionProps {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -8139,6 +8139,12 @@ class MeshtasticManager {
       result = result.replace(/{DIRECTCOUNT}/g, directCount.toString());
     }
 
+    // {TOTALNODES} - Total nodes (all nodes ever seen, regardless of when last heard)
+    if (result.includes('{TOTALNODES}')) {
+      const allNodes = databaseService.getAllNodes();
+      result = result.replace(/{TOTALNODES}/g, allNodes.length.toString());
+    }
+
     return result;
   }
 
@@ -8278,6 +8284,13 @@ class MeshtasticManager {
       const directCount = nodes.filter((n: any) => n.hopsAway === 0).length;
       logger.info(`📢 Token replacement - DIRECTCOUNT: ${directCount} direct nodes out of ${nodes.length} active nodes`);
       result = result.replace(/{DIRECTCOUNT}/g, directCount.toString());
+    }
+
+    // {TOTALNODES} - Total nodes (all nodes ever seen, regardless of when last heard)
+    if (result.includes('{TOTALNODES}')) {
+      const allNodes = databaseService.getAllNodes();
+      logger.info(`📢 Token replacement - TOTALNODES: ${allNodes.length} total nodes`);
+      result = result.replace(/{TOTALNODES}/g, allNodes.length.toString());
     }
 
     // {IP} - Meshtastic node IP address


### PR DESCRIPTION
## Summary
- Adds new `{TOTALNODES}` token that returns total count of all nodes ever seen (regardless of lastHeard)
- Complements existing `{NODECOUNT}` token which filters by `maxNodeAgeHours` setting
- Resolves confusion where automation showed 6 nodes while dashboard showed 51 nodes

Closes #1730

## Changes
- **Backend**: Added `{TOTALNODES}` token replacement to both `replaceAnnouncementTokens` and `replaceWelcomeTokens` functions
- **Frontend**: Added token buttons and sample preview support to:
  - Auto-Welcome Section
  - Auto-Acknowledge Section  
  - Auto-Announce Section
  - Geofence Triggers Section
  - Timer Triggers Section

## Test plan
- [ ] Verify `{TOTALNODES}` appears in automation message configuration UIs
- [ ] Verify sample preview shows correct replacement (156 in preview)
- [ ] Test actual token replacement in automation messages shows total node count
- [ ] Verify `{NODECOUNT}` still works as before (active nodes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)