### PR TITLE
feat: add optional channel name validation for channel database entries

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3708,6 +3708,8 @@
   "channel_database.toast_decryption_started": "Retroactive decryption started",
   "channel_database.toast_decryption_failed": "Failed to start retroactive decryption",
   "channel_database.toast_decryption_completed": "Decryption completed: {{decrypted}} of {{total}} packets decrypted",
+  "channel_database.enforce_name_validation": "Enforce Channel Name Validation",
+  "channel_database.enforce_name_validation_description": "Only attempt decryption if the packet's channel hash matches. Allows multiple virtual channels with the same key but different names.",
 
   "common.never": "Never",
   "common.importing": "Importing...",

--- a/src/components/configuration/ChannelDatabaseSection.tsx
+++ b/src/components/configuration/ChannelDatabaseSection.tsx
@@ -60,6 +60,7 @@ interface ChannelEditState {
   psk: string;
   description: string;
   isEnabled: boolean;
+  enforceNameValidation: boolean;
 }
 
 const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin, rebroadcastMode }) => {
@@ -141,7 +142,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
       name: '',
       psk: '',
       description: '',
-      isEnabled: true
+      isEnabled: true,
+      enforceNameValidation: false
     });
     setShowEditModal(true);
   };
@@ -152,7 +154,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
       name: channel.name,
       psk: channel.psk || '',
       description: channel.description || '',
-      isEnabled: channel.isEnabled
+      isEnabled: channel.isEnabled,
+      enforceNameValidation: channel.enforceNameValidation ?? false
     });
     setShowEditModal(true);
   };
@@ -210,7 +213,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
           name: editingChannel.name,
           psk: finalPsk,
           description: editingChannel.description || undefined,
-          isEnabled: editingChannel.isEnabled
+          isEnabled: editingChannel.isEnabled,
+          enforceNameValidation: editingChannel.enforceNameValidation
         });
         showToast(t('channel_database.toast_channel_updated'), 'success');
       } else {
@@ -219,7 +223,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
           name: editingChannel.name,
           psk: finalPsk,
           description: editingChannel.description || undefined,
-          isEnabled: editingChannel.isEnabled
+          isEnabled: editingChannel.isEnabled,
+          enforceNameValidation: editingChannel.enforceNameValidation
         });
         showToast(t('channel_database.toast_channel_created'), 'success');
 
@@ -727,6 +732,22 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 </div>
                 <span className="setting-description" style={{ marginLeft: '1.75rem' }}>
                   {t('channel_database.is_enabled_description')}
+                </span>
+              </label>
+            </div>
+
+            <div className="setting-item">
+              <label style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                  <input
+                    type="checkbox"
+                    checked={editingChannel.enforceNameValidation}
+                    onChange={(e) => setEditingChannel({ ...editingChannel, enforceNameValidation: e.target.checked })}
+                  />
+                  <span>{t('channel_database.enforce_name_validation')}</span>
+                </div>
+                <span className="setting-description" style={{ marginLeft: '1.75rem' }}>
+                  {t('channel_database.enforce_name_validation_description')}
                 </span>
               </label>
             </div>

--- a/src/db/repositories/channelDatabase.ts
+++ b/src/db/repositories/channelDatabase.ts
@@ -26,6 +26,7 @@ export interface ChannelDatabaseInput {
   pskLength: number; // 16 for AES-128, 32 for AES-256
   description?: string | null;
   isEnabled?: boolean;
+  enforceNameValidation?: boolean;
   createdBy?: number | null;
 }
 
@@ -38,6 +39,7 @@ export interface ChannelDatabaseUpdate {
   pskLength?: number;
   description?: string | null;
   isEnabled?: boolean;
+  enforceNameValidation?: boolean;
 }
 
 /**
@@ -174,6 +176,7 @@ export class ChannelDatabaseRepository extends BaseRepository {
         pskLength: data.pskLength,
         description: data.description ?? null,
         isEnabled: data.isEnabled ?? true,
+        enforceNameValidation: data.enforceNameValidation ?? false,
         decryptedPacketCount: 0,
         lastDecryptedAt: null,
         createdBy: data.createdBy ?? null,
@@ -192,6 +195,7 @@ export class ChannelDatabaseRepository extends BaseRepository {
         pskLength: data.pskLength,
         description: data.description ?? null,
         isEnabled: data.isEnabled ?? true,
+        enforceNameValidation: data.enforceNameValidation ?? false,
         decryptedPacketCount: 0,
         lastDecryptedAt: null,
         createdBy: data.createdBy ?? null,
@@ -209,6 +213,7 @@ export class ChannelDatabaseRepository extends BaseRepository {
         pskLength: data.pskLength,
         description: data.description ?? null,
         isEnabled: data.isEnabled ?? true,
+        enforceNameValidation: data.enforceNameValidation ?? false,
         decryptedPacketCount: 0,
         lastDecryptedAt: null,
         createdBy: data.createdBy ?? null,
@@ -569,6 +574,7 @@ export class ChannelDatabaseRepository extends BaseRepository {
       pskLength: row.pskLength,
       description: row.description,
       isEnabled: Boolean(row.isEnabled),
+      enforceNameValidation: Boolean(row.enforceNameValidation),
       decryptedPacketCount: row.decryptedPacketCount,
       lastDecryptedAt: row.lastDecryptedAt,
       createdBy: row.createdBy,
@@ -585,6 +591,7 @@ export class ChannelDatabaseRepository extends BaseRepository {
       pskLength: row.pskLength,
       description: row.description,
       isEnabled: row.isEnabled,
+      enforceNameValidation: row.enforceNameValidation,
       decryptedPacketCount: row.decryptedPacketCount,
       lastDecryptedAt: row.lastDecryptedAt ? Number(row.lastDecryptedAt) : null,
       createdBy: row.createdBy,
@@ -601,6 +608,7 @@ export class ChannelDatabaseRepository extends BaseRepository {
       pskLength: row.pskLength,
       description: row.description,
       isEnabled: Boolean(row.isEnabled),
+      enforceNameValidation: Boolean(row.enforceNameValidation),
       decryptedPacketCount: row.decryptedPacketCount,
       lastDecryptedAt: row.lastDecryptedAt ? Number(row.lastDecryptedAt) : null,
       createdBy: row.createdBy,

--- a/src/db/schema/channelDatabase.ts
+++ b/src/db/schema/channelDatabase.ts
@@ -34,6 +34,7 @@ export const channelDatabaseSqlite = sqliteTable('channel_database', {
   pskLength: integer('psk_length').notNull(), // 16 for AES-128, 32 for AES-256
   description: text('description'),
   isEnabled: integer('is_enabled', { mode: 'boolean' }).notNull().default(true),
+  enforceNameValidation: integer('enforce_name_validation', { mode: 'boolean' }).notNull().default(false),
   decryptedPacketCount: integer('decrypted_packet_count').notNull().default(0),
   lastDecryptedAt: integer('last_decrypted_at'),
   createdBy: integer('created_by').references(() => usersSqlite.id, { onDelete: 'set null' }),
@@ -66,6 +67,7 @@ export const channelDatabasePostgres = pgTable('channel_database', {
   pskLength: pgInteger('pskLength').notNull(), // 16 for AES-128, 32 for AES-256
   description: pgText('description'),
   isEnabled: pgBoolean('isEnabled').notNull().default(true),
+  enforceNameValidation: pgBoolean('enforceNameValidation').notNull().default(false),
   decryptedPacketCount: pgInteger('decryptedPacketCount').notNull().default(0),
   lastDecryptedAt: pgBigint('lastDecryptedAt', { mode: 'number' }),
   createdBy: pgInteger('createdBy').references(() => usersPostgres.id, { onDelete: 'set null' }),
@@ -98,6 +100,7 @@ export const channelDatabaseMysql = mysqlTable('channel_database', {
   pskLength: myInt('pskLength').notNull(), // 16 for AES-128, 32 for AES-256
   description: myText('description'),
   isEnabled: myBoolean('isEnabled').notNull().default(true),
+  enforceNameValidation: myBoolean('enforceNameValidation').notNull().default(false),
   decryptedPacketCount: myInt('decryptedPacketCount').notNull().default(0),
   lastDecryptedAt: myBigint('lastDecryptedAt', { mode: 'number' }),
   createdBy: myInt('createdBy').references(() => usersMysql.id, { onDelete: 'set null' }),

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -275,6 +275,7 @@ export interface DbChannelDatabase {
   pskLength: number; // 16 for AES-128, 32 for AES-256
   description?: string | null;
   isEnabled: boolean;
+  enforceNameValidation: boolean;
   decryptedPacketCount: number;
   lastDecryptedAt?: number | null;
   createdBy?: number | null;

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2862,7 +2862,8 @@ class MeshtasticManager {
         const decryptionResult = await channelDecryptionService.tryDecrypt(
           meshPacket.encrypted,
           packetId,
-          fromNum
+          fromNum,
+          meshPacket.channel
         );
 
         if (decryptionResult.success) {

--- a/src/server/migrations/064_add_enforce_name_validation.ts
+++ b/src/server/migrations/064_add_enforce_name_validation.ts
@@ -1,0 +1,148 @@
+/**
+ * Migration 064: Add enforce_name_validation column to channel_database
+ *
+ * Adds a boolean column to control whether channel name hash validation is enforced
+ * during decryption. When enabled, the server only attempts decryption if the
+ * packet's channel hash matches the expected hash (computed from stored name + PSK).
+ * This allows multiple virtual channels with the same key but different names to
+ * sort messages correctly.
+ */
+
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.debug('Running migration 064: Add enforce_name_validation to channel_database');
+
+    try {
+      // Check if column already exists
+      const tableInfo = db.pragma('table_info(channel_database)') as { name: string }[];
+      const columnExists = tableInfo.some(col => col.name === 'enforce_name_validation');
+
+      if (columnExists) {
+        logger.debug('enforce_name_validation column already exists, skipping migration');
+        return;
+      }
+
+      // Add the column with default value of false (0)
+      db.exec(`
+        ALTER TABLE channel_database ADD COLUMN enforce_name_validation INTEGER NOT NULL DEFAULT 0
+      `);
+
+      logger.debug('Migration 064 completed: enforce_name_validation column added to channel_database');
+    } catch (error) {
+      logger.error('Migration 064 failed:', error);
+      throw error;
+    }
+  },
+
+  down: (db: Database): void => {
+    logger.debug('Running migration 064 down: Remove enforce_name_validation column');
+
+    try {
+      // SQLite doesn't support DROP COLUMN directly, need to recreate table
+      db.exec(`
+        CREATE TABLE channel_database_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT NOT NULL,
+          psk TEXT NOT NULL,
+          psk_length INTEGER NOT NULL,
+          description TEXT,
+          is_enabled INTEGER NOT NULL DEFAULT 1,
+          decrypted_packet_count INTEGER NOT NULL DEFAULT 0,
+          last_decrypted_at INTEGER,
+          created_by INTEGER,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
+        )
+      `);
+
+      db.exec(`
+        INSERT INTO channel_database_new (id, name, psk, psk_length, description, is_enabled, decrypted_packet_count, last_decrypted_at, created_by, created_at, updated_at)
+        SELECT id, name, psk, psk_length, description, is_enabled, decrypted_packet_count, last_decrypted_at, created_by, created_at, updated_at
+        FROM channel_database
+      `);
+
+      db.exec(`DROP TABLE channel_database`);
+      db.exec(`ALTER TABLE channel_database_new RENAME TO channel_database`);
+
+      logger.debug('Migration 064 rollback completed');
+    } catch (error) {
+      logger.error('Migration 064 rollback failed:', error);
+      throw error;
+    }
+  }
+};
+
+/**
+ * PostgreSQL migration: Add enforceNameValidation column to channel_database
+ */
+export async function runMigration064Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.debug('Running migration 064 (PostgreSQL): Add enforceNameValidation column to channel_database');
+
+  try {
+    // Check if column already exists
+    const columnExists = await client.query(`
+      SELECT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'channel_database'
+          AND column_name = 'enforceNameValidation'
+      )
+    `);
+
+    if (columnExists.rows[0].exists) {
+      logger.debug('enforceNameValidation column already exists, skipping migration');
+      return;
+    }
+
+    // Add the column
+    await client.query(`
+      ALTER TABLE channel_database ADD COLUMN "enforceNameValidation" BOOLEAN NOT NULL DEFAULT false
+    `);
+
+    logger.debug('Migration 064 (PostgreSQL): enforceNameValidation column added to channel_database');
+  } catch (error) {
+    logger.error('Migration 064 (PostgreSQL) failed:', error);
+    throw error;
+  }
+}
+
+/**
+ * MySQL migration: Add enforceNameValidation column to channel_database
+ */
+export async function runMigration064Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.debug('Running migration 064 (MySQL): Add enforceNameValidation column to channel_database');
+
+  try {
+    const connection = await pool.getConnection();
+    try {
+      // Check if column already exists
+      const [columns] = await connection.query(`
+        SELECT COLUMN_NAME FROM information_schema.columns
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'channel_database'
+          AND COLUMN_NAME = 'enforceNameValidation'
+      `);
+
+      if ((columns as any[]).length > 0) {
+        logger.debug('enforceNameValidation column already exists, skipping migration');
+        return;
+      }
+
+      // Add the column
+      await connection.query(`
+        ALTER TABLE channel_database ADD COLUMN enforceNameValidation BOOLEAN NOT NULL DEFAULT false
+      `);
+
+      logger.debug('Migration 064 (MySQL): enforceNameValidation column added to channel_database');
+    } finally {
+      connection.release();
+    }
+  } catch (error) {
+    logger.error('Migration 064 (MySQL) failed:', error);
+    throw error;
+  }
+}

--- a/src/server/routes/v1/channelDatabase.ts
+++ b/src/server/routes/v1/channelDatabase.ts
@@ -30,6 +30,7 @@ function transformChannelForResponse(channel: any, includeFullPsk: boolean = fal
     psk: includeFullPsk ? channel.psk : undefined,
     description: channel.description,
     isEnabled: channel.isEnabled,
+    enforceNameValidation: channel.enforceNameValidation ?? false,
     decryptedPacketCount: channel.decryptedPacketCount,
     lastDecryptedAt: channel.lastDecryptedAt,
     createdBy: channel.createdBy,
@@ -144,7 +145,7 @@ router.post('/', async (req: Request, res: Response) => {
       });
     }
 
-    const { name, psk, pskLength, description, isEnabled } = req.body;
+    const { name, psk, pskLength, description, isEnabled, enforceNameValidation } = req.body;
 
     // Validate required fields
     if (!name || typeof name !== 'string') {
@@ -197,6 +198,7 @@ router.post('/', async (req: Request, res: Response) => {
       pskLength: pskLength ?? Buffer.from(psk, 'base64').length,
       description: description ?? null,
       isEnabled: isEnabled ?? true,
+      enforceNameValidation: enforceNameValidation ?? false,
       createdBy: user?.id ?? null,
     });
 
@@ -267,7 +269,7 @@ router.put('/:id', async (req: Request, res: Response) => {
       });
     }
 
-    const { name, psk, pskLength, description, isEnabled } = req.body;
+    const { name, psk, pskLength, description, isEnabled, enforceNameValidation } = req.body;
     const updates: any = {};
 
     if (name !== undefined) {
@@ -324,6 +326,10 @@ router.put('/:id', async (req: Request, res: Response) => {
 
     if (isEnabled !== undefined) {
       updates.isEnabled = Boolean(isEnabled);
+    }
+
+    if (enforceNameValidation !== undefined) {
+      updates.enforceNameValidation = Boolean(enforceNameValidation);
     }
 
     if (Object.keys(updates).length === 0) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1250,6 +1250,7 @@ class ApiService {
     pskLength?: number;
     description?: string;
     isEnabled?: boolean;
+    enforceNameValidation?: boolean;
   }): Promise<{
     success: boolean;
     data: ChannelDatabaseEntry;
@@ -1268,6 +1269,7 @@ class ApiService {
       psk?: string;
       description?: string;
       isEnabled?: boolean;
+      enforceNameValidation?: boolean;
     }
   ): Promise<{
     success: boolean;
@@ -1386,6 +1388,7 @@ export interface ChannelDatabaseEntry {
   psk?: string;
   description: string | null;
   isEnabled: boolean;
+  enforceNameValidation: boolean;
   decryptedPacketCount: number;
   lastDecryptedAt: number | null;
   createdBy: number | null;


### PR DESCRIPTION
## Summary
- Adds "Enforce Channel Name Validation" checkbox to Channel Database entries
- When enabled, server only attempts decryption if packet's channel hash matches expected hash (computed from channel name + PSK)
- Allows multiple virtual channels with same key but different names to correctly sort messages

## Technical Details
Meshtastic transmits an 8-bit channel hash with encrypted packets:
```
hash = xorHash(channel_name_bytes) ^ xorHash(psk_bytes)
```
This PR implements hash validation to filter decryption candidates.

## Changes
- Database migration (064) for SQLite, PostgreSQL, and MySQL
- Schema updates across all three database backends
- `xorHash` and `computeChannelHash` utilities in decryption service
- Channel hash filtering in `tryDecrypt` when validation is enabled
- Frontend checkbox control with description
- Comprehensive test coverage for hash computation and filtering

## Test plan
- [x] All 9 system tests pass
- [x] TypeScript builds successfully
- [ ] Manual testing: Create two channels with same PSK, different names, both with "Enforce" checked
- [ ] Verify messages are sorted into correct virtual channels
- [ ] Verify unchecked channels work as before (backward compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)