### PR TITLE
feat: add clear button to filter inputs

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -75,6 +75,7 @@
   "common.export": "Export",
   "common.import": "Import",
   "common.clear": "Clear",
+  "common.clear_filter": "Clear filter",
   "common.reset": "Reset",
   "common.apply": "Apply",
   "common.confirm": "Confirm",

--- a/src/App.css
+++ b/src/App.css
@@ -3134,6 +3134,41 @@ body {
   color: var(--ctp-overlay1);
 }
 
+/* Filter input wrapper with clear button */
+.filter-input-wrapper {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.filter-input-wrapper .filter-input-small {
+  padding-right: 2rem;
+}
+
+.filter-clear-btn {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  color: var(--ctp-overlay1);
+  cursor: pointer;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: color 0.2s, background-color 0.2s;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.filter-clear-btn:hover {
+  color: var(--ctp-text);
+  background-color: var(--ctp-surface2);
+}
+
 .sort-controls {
   display: flex;
   gap: 0.5rem;

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -606,13 +606,25 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
           )}
           {!isMessagesNodeListCollapsed && (
             <div className="node-controls">
-              <input
-                type="text"
-                placeholder={t('messages.filter_placeholder')}
-                value={messagesNodeFilter}
-                onChange={e => setMessagesNodeFilter(e.target.value)}
-                className="filter-input-small"
-              />
+              <div className="filter-input-wrapper">
+                <input
+                  type="text"
+                  placeholder={t('messages.filter_placeholder')}
+                  value={messagesNodeFilter}
+                  onChange={e => setMessagesNodeFilter(e.target.value)}
+                  className="filter-input-small"
+                />
+                {messagesNodeFilter && (
+                  <button
+                    className="filter-clear-btn"
+                    onClick={() => setMessagesNodeFilter('')}
+                    title={t('common.clear_filter')}
+                    type="button"
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
               <div className="sort-controls">
                 <select
                   value={dmFilter}

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1068,14 +1068,27 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
           )}
           {!isNodeListCollapsed && (
           <div className="node-controls">
-            <input
-              type="text"
-              placeholder={t('nodes.filter_placeholder')}
-              value={nodesNodeFilter}
-              onChange={(e) => setNodesNodeFilter(e.target.value)}
-              onMouseDown={stopPropagation}
-              className="filter-input-small"
-            />
+            <div className="filter-input-wrapper">
+              <input
+                type="text"
+                placeholder={t('nodes.filter_placeholder')}
+                value={nodesNodeFilter}
+                onChange={(e) => setNodesNodeFilter(e.target.value)}
+                onMouseDown={stopPropagation}
+                className="filter-input-small"
+              />
+              {nodesNodeFilter && (
+                <button
+                  className="filter-clear-btn"
+                  onClick={() => setNodesNodeFilter('')}
+                  onMouseDown={stopPropagation}
+                  title={t('common.clear_filter')}
+                  type="button"
+                >
+                  ✕
+                </button>
+              )}
+            </div>
             <div className="sort-controls">
               <button
                 className="filter-popup-btn"


### PR DESCRIPTION
## Summary
- Adds a ✕ clear button to filter inputs on Nodes and Messages tabs
- Button only appears when filter has text entered
- Allows users to quickly clear the filter with a single click

## Test plan
- [ ] Navigate to Nodes tab
- [ ] Type in the filter field
- [ ] Verify ✕ button appears
- [ ] Click button to clear filter
- [ ] Repeat for Messages tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)