### PR TITLE
fix: show integer values only on GPS Satellites chart Y-axis

### DIFF
--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -666,7 +666,12 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
                       tick={{ fontSize: 12 }}
                       tickFormatter={timestamp => formatChartAxisTimestamp(timestamp, globalTimeRange, timeFormat)}
                     />
-                    <YAxis yAxisId="left" tick={{ fontSize: 12 }} domain={['auto', 'auto']} />
+                    <YAxis
+                      yAxisId="left"
+                      tick={{ fontSize: 12 }}
+                      domain={['auto', 'auto']}
+                      allowDecimals={type !== 'sats_in_view'}
+                    />
                     <YAxis
                       yAxisId="right"
                       orientation="right"


### PR DESCRIPTION
## Summary
The GPS Satellites chart was showing decimal values (e.g., 3.5, 4.5) on the Y-axis, which doesn't make sense since you can't have a fractional number of satellites.

Fixes #1758

## Solution
Added `allowDecimals={false}` to the YAxis component when rendering the `sats_in_view` metric. This ensures the Y-axis only shows whole numbers.

## Test plan
- [ ] View a node's telemetry with GPS satellite data
- [ ] Verify the Y-axis shows only integer values (1, 2, 3, etc.)
- [ ] Verify other telemetry charts still show decimals where appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)