### PR TITLE
fix: show info modal for Channel Database virtual channels

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -400,6 +400,13 @@
   "channels.purge_messages_title": "Purge all messages from this channel",
   "channels.purge_all_messages": "Purge All Messages",
   "channels.cannot_undo": "This action cannot be undone",
+  "channels.virtual_channel_info_title": "Virtual Channel Info",
+  "channels.description": "Description:",
+  "channels.source": "Source:",
+  "channels.channel_database": "Channel Database",
+  "channels.access_mode": "Access Mode:",
+  "channels.read_only": "Read-only",
+  "channels.packets_decrypted": "Packets Decrypted:",
 
   "dashboard.title": "Telemetry Dashboard",
   "dashboard.add_widget": "Add Widget",


### PR DESCRIPTION
## Summary

The Info link on virtual channels (from Channel Database) now shows a popup with channel details.

## Problem

Previously, clicking the "Info" link on a Channel Database channel did nothing because the code only looked for device channels (indices 0-7), not virtual channels (indices 100+).

## Solution

Added a Virtual Channel Info modal that displays:
- Channel name and number
- Encryption status (Secure/Default/Unencrypted)
- PSK (with show/hide toggle)
- Description (if set)
- Source indicator (Channel Database)
- Access mode (Read-only)
- Packets decrypted count (if > 0)

## Test Plan
- [ ] Click Info link on a device channel - should show existing modal
- [ ] Click Info link on a Channel Database channel - should show new virtual channel modal
- [ ] Verify PSK show/hide toggle works
- [ ] Verify modal closes on X button or clicking overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)