### PR TITLE
fix: handle single quotes and env vars in script test arguments

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8456,8 +8456,13 @@ apiRouter.post('/scripts/test', requirePermission('settings', 'read'), async (re
     }
 
     // Common environment variables for all trigger types
-    scriptEnv.IP = process.env.MESHTASTIC_IP || process.env.NODE_IP || '127.0.0.1';
-    scriptEnv.PORT = process.env.MESHTASTIC_PORT || process.env.NODE_PORT || '4403';
+    // Support both MESHTASTIC_IP and IP for compatibility with different scripts
+    const meshtasticIp = process.env.MESHTASTIC_NODE_IP || process.env.MESHTASTIC_IP || process.env.NODE_IP || '127.0.0.1';
+    const meshtasticPort = process.env.MESHTASTIC_NODE_PORT || process.env.MESHTASTIC_PORT || process.env.NODE_PORT || '4403';
+    scriptEnv.IP = meshtasticIp;
+    scriptEnv.PORT = meshtasticPort;
+    scriptEnv.MESHTASTIC_IP = meshtasticIp;
+    scriptEnv.MESHTASTIC_PORT = meshtasticPort;
     scriptEnv.VERSION = process.env.VERSION || 'test';
 
     // Build script arguments if provided
@@ -8481,9 +8486,9 @@ apiRouter.post('/scripts/test', requirePermission('settings', 'read'), async (re
           .replace(/\{NODE_LON\}/g, mockNodeLon);
       }
 
-      // Split args respecting quotes
-      const argParts = expandedArgs.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
-      scriptArgList.push(...argParts.map((arg: string) => arg.replace(/^"|"$/g, '')));
+      // Split args respecting both single and double quotes
+      const argParts = expandedArgs.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
+      scriptArgList.push(...argParts.map((arg: string) => arg.replace(/^["']|["']$/g, '')));
     }
 
     try {


### PR DESCRIPTION
## Summary
- Fix script test endpoint to properly parse arguments with single quotes
- Set correct environment variables (`MESHTASTIC_IP`, `MESHTASTIC_PORT`) for script compatibility
- Read from correct env var names (`MESHTASTIC_NODE_IP`, `MESHTASTIC_NODE_PORT`)

Fixes #1766

## Problem
Two issues with the script test endpoint:

1. **Single quote handling**: Arguments like `--dest '!d3469dad'` had the single quotes passed literally to scripts instead of being stripped

2. **Environment variables**: The test endpoint set `IP` and `PORT` but scripts expected `MESHTASTIC_IP` and `MESHTASTIC_PORT`. Also, it read from non-existent `MESHTASTIC_IP` instead of the actual `MESHTASTIC_NODE_IP`

## Solution
1. Updated argument parsing regex to handle both single and double quotes
2. Now sets both `IP`/`PORT` and `MESHTASTIC_IP`/`MESHTASTIC_PORT` for compatibility
3. Reads from `MESHTASTIC_NODE_IP`/`MESHTASTIC_NODE_PORT` (the actual env var names)

## Test plan
- [x] Tested with single-quoted arguments: `--dest '!d3469dad'` → passes correctly
- [x] Tested with `--info` flag → script executes successfully
- [x] Verified `MESHTASTIC_IP` env var is set correctly from `MESHTASTIC_NODE_IP`

🤖 Generated with [Claude Code](https://claude.com/claude-code)