### PR TITLE
feat: make favorite nodes always visible regardless of age

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3548,7 +3548,9 @@ function App() {
   const processedNodes = useMemo((): DeviceInfo[] => {
     const cutoffTime = Date.now() / 1000 - maxNodeAgeHours * 60 * 60;
 
+    // Age filter (favorites are always visible)
     const ageFiltered = nodes.filter(node => {
+      if (node.isFavorite) return true;
       if (!node.lastHeard) return false;
       return node.lastHeard >= cutoffTime;
     });

--- a/src/hooks/useProcessedNodes.ts
+++ b/src/hooks/useProcessedNodes.ts
@@ -180,8 +180,9 @@ export function useProcessedNodes(options: UseProcessedNodesOptions = {}) {
   const processedNodes = useMemo((): DeviceInfo[] => {
     const cutoffTime = Date.now() / 1000 - maxNodeAgeHours * 60 * 60;
 
-    // Step 1: Age filter
+    // Step 1: Age filter (favorites are always visible)
     const ageFiltered = nodes.filter(node => {
+      if (node.isFavorite) return true;
       if (!node.lastHeard) return false;
       return node.lastHeard >= cutoffTime;
     });


### PR DESCRIPTION
## Summary
Favorite nodes are now exempt from the `maxNodeAgeHours` expiration filter. They will always appear in the node list and on the map, even if they haven't been heard from recently.

This addresses the frustration of seeing favorite/direct nodes disappear when they broadcast infrequently (e.g., solar-powered nodes that only send position updates rarely).

Closes #1773

## Changes
- `src/hooks/useProcessedNodes.ts` - Add `isFavorite` check to age filter
- `src/App.tsx` - Add `isFavorite` check to age filter (duplicate filtering logic)

## Test plan
- [x] Unit tests pass (2351 passed)
- [x] Build succeeds
- [ ] Mark a node as favorite, set maxNodeAgeHours to 1 hour
- [ ] Verify favorite node remains visible even after it would normally expire
- [ ] Verify non-favorite nodes still expire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)