### PR TITLE
fix: reduce CPU usage on mobile by optimizing status timer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1845,15 +1845,21 @@ function App() {
   }, [connectionStatus]);
 
   // Timer to update message status indicators (timeout detection after 30s)
+  // Only runs when on channels/messages tabs to reduce CPU usage on mobile (#1769)
   const [, setStatusTick] = useState(0);
   useEffect(() => {
+    // Only run timer when viewing messaging tabs where status indicators are visible
+    if (activeTab !== 'channels' && activeTab !== 'messages') {
+      return;
+    }
+
     const interval = setInterval(() => {
       // Force re-render to update message status indicators
       setStatusTick(prev => prev + 1);
-    }, 1000); // Update every second
+    }, 5000); // Update every 5 seconds (reduced from 1s for mobile performance)
 
     return () => clearInterval(interval);
-  }, []);
+  }, [activeTab]);
 
   const requestFullNodeDatabase = async () => {
     try {


### PR DESCRIPTION
## Summary
- Only run message status update timer when on channels/messages tabs (not on other tabs like Users, Info, etc.)
- Increase timer interval from 1 second to 5 seconds (the 30-second timeout detection doesn't need sub-second precision)

## Impact
- ~95% reduction in timer-related CPU usage when on non-messaging tabs
- ~80% reduction in timer-related CPU usage when on messaging tabs
- Should significantly improve battery life on mobile devices

## Root Cause
The previous implementation ran a `setInterval` every 1 second that forced a React re-render of the entire App component tree, regardless of which tab the user was on. This was needed to detect when pending messages hit the 30-second timeout so the status indicator could change from ⏳ to ⏱️.

## Test plan
- [ ] Open MeshMonitor on mobile browser
- [ ] Navigate to different tabs (Users, Info, Nodes)
- [ ] Verify CPU usage is lower than before
- [ ] Navigate to Channels/Messages tab
- [ ] Send a message and verify status indicator still updates (may take up to 5s now)

Fixes #1769

🤖 Generated with [Claude Code](https://claude.com/claude-code)