### PR TITLE
fix: quote PostgreSQL column aliases in packet distribution query

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -9634,8 +9634,8 @@ class DatabaseService {
         let query = `
           SELECT
             pl.from_node,
-            n."nodeId" as from_node_id,
-            n."longName" as from_node_longName,
+            n."nodeId" as "from_node_id",
+            n."longName" as "from_node_longName",
             COUNT(*) as count
           FROM packet_log pl
           LEFT JOIN nodes n ON pl.from_node = n."nodeNum"


### PR DESCRIPTION
## Summary
- Fix packet distribution charts showing raw node IDs instead of friendly names on PostgreSQL backends
- PostgreSQL folds unquoted column aliases to lowercase, so `as from_node_longName` becomes `from_node_longname` in the result set
- The JavaScript mapping accesses `row.from_node_longName` (camelCase N), which is `undefined` due to the case mismatch
- Fix: quote the aliases (`as "from_node_longName"`) to preserve case, matching the pattern already used in `getPacketLogsAsync`

## Test plan
- [x] Build passes
- [x] All 2351 tests pass
- [ ] Verify packet distribution charts show node names on PostgreSQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)