### PR TITLE
fix: implement route segment queries for PostgreSQL/MySQL backends

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2914,9 +2914,9 @@ apiRouter.get('/traceroutes/history/:fromNodeNum/:toNodeNum', (req, res) => {
 });
 
 // Get longest active route segment (within last 7 days)
-apiRouter.get('/route-segments/longest-active', requirePermission('info', 'read'), (_req, res) => {
+apiRouter.get('/route-segments/longest-active', requirePermission('info', 'read'), async (_req, res) => {
   try {
-    const segment = databaseService.getLongestActiveRouteSegment();
+    const segment = await databaseService.getLongestActiveRouteSegmentAsync();
     if (!segment) {
       res.json(null);
       return;
@@ -2940,9 +2940,9 @@ apiRouter.get('/route-segments/longest-active', requirePermission('info', 'read'
 });
 
 // Get record holder route segment
-apiRouter.get('/route-segments/record-holder', requirePermission('info', 'read'), (_req, res) => {
+apiRouter.get('/route-segments/record-holder', requirePermission('info', 'read'), async (_req, res) => {
   try {
-    const segment = databaseService.getRecordHolderRouteSegment();
+    const segment = await databaseService.getRecordHolderRouteSegmentAsync();
     if (!segment) {
       res.json(null);
       return;

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -7489,7 +7489,7 @@ class DatabaseService {
   }
 
   getLongestActiveRouteSegment(): DbRouteSegment | null {
-    // For PostgreSQL/MySQL, route segments not yet implemented
+    // For PostgreSQL/MySQL, use async version
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       return null;
     }
@@ -7505,8 +7505,17 @@ class DatabaseService {
     return segment ? this.normalizeBigInts(segment) : null;
   }
 
+  async getLongestActiveRouteSegmentAsync(): Promise<DbRouteSegment | null> {
+    if ((this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') && this.traceroutesRepo) {
+      const segment = await this.traceroutesRepo.getLongestActiveRouteSegment();
+      if (!segment) return null;
+      return { ...segment, isRecordHolder: segment.isRecordHolder ?? false };
+    }
+    return this.getLongestActiveRouteSegment();
+  }
+
   getRecordHolderRouteSegment(): DbRouteSegment | null {
-    // For PostgreSQL/MySQL, route segments not yet implemented
+    // For PostgreSQL/MySQL, use async version
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       return null;
     }
@@ -7518,6 +7527,15 @@ class DatabaseService {
     `);
     const segment = stmt.get() as DbRouteSegment | null;
     return segment ? this.normalizeBigInts(segment) : null;
+  }
+
+  async getRecordHolderRouteSegmentAsync(): Promise<DbRouteSegment | null> {
+    if ((this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') && this.traceroutesRepo) {
+      const segment = await this.traceroutesRepo.getRecordHolderRouteSegment();
+      if (!segment) return null;
+      return { ...segment, isRecordHolder: segment.isRecordHolder ?? false };
+    }
+    return this.getRecordHolderRouteSegment();
   }
 
   updateRecordHolderSegment(newSegment: DbRouteSegment): void {


### PR DESCRIPTION
## Summary
- Fix "Longest Active Route Segment" and "Record Holder Route Segment" boxes on the Info page returning empty for PostgreSQL/MySQL backends
- The sync methods had hardcoded `return null` stubs for PostgreSQL/MySQL, even though the repository layer already had full Drizzle ORM implementations
- Add `getLongestActiveRouteSegmentAsync()` and `getRecordHolderRouteSegmentAsync()` methods that delegate to the repository
- Update API routes to use the async versions

## Test plan
- [x] Build passes
- [x] All 2351 tests pass
- [x] Deployed and verified route segments display on PostgreSQL backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)