### PR TITLE
fix: handle StatusMessageConfig module type gracefully

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2397,6 +2397,9 @@ class MeshtasticManager {
             }
           }
           break;
+        default:
+          logger.debug(`⚠️ Unhandled message type: ${parsed.type}`);
+          break;
       }
 
       logger.debug(`✅ Processed message type: ${parsed.type}`);
@@ -9151,7 +9154,8 @@ class MeshtasticManager {
         const moduleConfigMap: { [key: number]: string } = {
           0: 'mqtt',
           5: 'telemetry',
-          9: 'neighborInfo'
+          9: 'neighborInfo',
+          13: 'statusmessage'
         };
         const configKey = moduleConfigMap[configType];
         if (configKey) {
@@ -9200,7 +9204,8 @@ class MeshtasticManager {
             const moduleConfigMap: { [key: number]: string } = {
               0: 'mqtt',
               5: 'telemetry',
-              9: 'neighborInfo'
+              9: 'neighborInfo',
+              13: 'statusmessage'
             };
             const configKey = moduleConfigMap[configType];
             if (configKey && nodeConfig.moduleConfig?.[configKey]) {
@@ -9624,7 +9629,8 @@ class MeshtasticManager {
       9,  // NEIGHBORINFO_CONFIG
       10, // AMBIENTLIGHTING_CONFIG
       11, // DETECTIONSENSOR_CONFIG
-      12  // PAXCOUNTER_CONFIG
+      12, // PAXCOUNTER_CONFIG
+      13  // STATUSMESSAGE_CONFIG
     ];
 
     logger.info('📦 Requesting all module configs for complete backup...');

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5866,7 +5866,8 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
               'neighborinfo': 'neighborInfo',
               'ambientlighting': 'ambientLighting',
               'detectionsensor': 'detectionSensor',
-              'paxcounter': 'paxcounter'
+              'paxcounter': 'paxcounter',
+              'statusmessage': 'statusmessage'
             };
             const moduleKey = moduleConfigMap[configType];
             if (moduleKey && !currentConfig?.moduleConfig?.[moduleKey]) needsRequest = true;
@@ -6068,6 +6069,7 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
           case 'ambientlighting':
           case 'detectionsensor':
           case 'paxcounter':
+          case 'statusmessage':
             const moduleConfigMap: { [key: string]: string } = {
               'serial': 'serial',
               'extnotif': 'externalNotification',
@@ -6080,7 +6082,8 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
               'neighborinfo': 'neighborInfo',
               'ambientlighting': 'ambientLighting',
               'detectionsensor': 'detectionSensor',
-              'paxcounter': 'paxcounter'
+              'paxcounter': 'paxcounter',
+              'statusmessage': 'statusmessage'
             };
             const moduleKey = moduleConfigMap[configType];
             if (moduleKey && finalConfig.moduleConfig?.[moduleKey]) {
@@ -6119,7 +6122,8 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
           'neighborinfo': { type: 9, isModule: true }, // NEIGHBORINFO_CONFIG (module)
           'ambientlighting': { type: 10, isModule: true }, // AMBIENTLIGHTING_CONFIG (module)
           'detectionsensor': { type: 11, isModule: true }, // DETECTIONSENSOR_CONFIG (module)
-          'paxcounter': { type: 12, isModule: true } // PAXCOUNTER_CONFIG (module)
+          'paxcounter': { type: 12, isModule: true }, // PAXCOUNTER_CONFIG (module)
+          'statusmessage': { type: 13, isModule: true } // STATUSMESSAGE_CONFIG (module)
         };
 
         const configInfo = configTypeMap[configType];


### PR DESCRIPTION
## Summary
- Adds support for `StatusMessageConfig` (module config type 13 / `STATUSMESSAGE_CONFIG`) across all hardcoded config type maps in `meshtasticManager.ts` and `server.ts`
- Adds a `default:` case in the `processIncomingData` switch to log unhandled message types at debug level instead of silently ignoring them
- Prevents connection drops when a Meshtastic node with newer firmware sends config types MeshMonitor doesn't yet recognize

Closes #1764

## Changes
**`src/server/meshtasticManager.ts`:**
- Added type 13 (`statusmessage`) to both remote node `moduleConfigMap` objects (cache clearing and response polling)
- Added `13 // STATUSMESSAGE_CONFIG` to the `requestAllModuleConfigs()` array
- Added `default:` case in `processIncomingData()` switch for graceful handling of unknown message types

**`src/server/server.ts`:**
- Added `'statusmessage': 'statusmessage'` to both `moduleConfigMap` objects (needs-request check and config lookup)
- Added `case 'statusmessage':` to the module config switch/case block
- Added `'statusmessage': { type: 13, isModule: true }` to the remote node `configTypeMap`

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm test` — 107 test files, 2351 tests passing
- [x] `npm run lint` — no new issues
- [x] Deployed to dev container, verified connection to node works
- [x] Confirmed all 14 module config types (0-13) are requested during backup
- [x] No errors or "Unknown module config type" messages in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)