### PR TITLE
fix: route scripts through Virtual Node to prevent connection conflicts

### DIFF
--- a/examples/auto-responder-scripts/remote-admin.py
+++ b/examples/auto-responder-scripts/remote-admin.py
@@ -28,8 +28,11 @@ Usage as a standalone script:
     ./remote-admin.py --ip 192.168.1.100 --dest !abcd1234 --reboot
 
 Environment variables (set automatically by MeshMonitor):
-    MESHTASTIC_IP      - IP address of the connected Meshtastic node
-    MESHTASTIC_PORT    - TCP port (usually 4403)
+    MESHTASTIC_IP      - IP address to connect to. When the Virtual Node is enabled,
+                         this points to 127.0.0.1 (the Virtual Node) so commands are
+                         relayed through MeshMonitor's existing connection instead of
+                         opening a second TCP connection to the physical node.
+    MESHTASTIC_PORT    - TCP port (physical node port, or Virtual Node port when enabled)
     NODE_ID            - Node ID that triggered the event
     NODE_NUM           - Node number (decimal)
     NODE_LONG_NAME     - Node's long name (if known)

--- a/examples/auto-responder-scripts/remote-admin.sh
+++ b/examples/auto-responder-scripts/remote-admin.sh
@@ -26,8 +26,10 @@
 #   ./remote-admin.sh --set lora.region US
 #
 # Environment variables (set automatically by MeshMonitor):
-#   MESHTASTIC_IP   - IP address of connected node
-#   MESHTASTIC_PORT - TCP port (usually 4403)
+#   MESHTASTIC_IP   - IP address to connect to. When the Virtual Node is enabled,
+#                     this points to 127.0.0.1 (the Virtual Node) so commands are
+#                     relayed through MeshMonitor's existing connection.
+#   MESHTASTIC_PORT - TCP port (physical node port, or Virtual Node port when enabled)
 #   NODE_ID         - Destination node ID (e.g., !abcd1234) - for Geofence/AutoResponder
 #
 # All arguments are passed directly to the meshtastic CLI.

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8460,9 +8460,17 @@ apiRouter.post('/scripts/test', requirePermission('settings', 'read'), async (re
     }
 
     // Common environment variables for all trigger types
-    // Support both MESHTASTIC_IP and IP for compatibility with different scripts
-    const meshtasticIp = process.env.MESHTASTIC_NODE_IP || process.env.MESHTASTIC_IP || process.env.NODE_IP || '127.0.0.1';
-    const meshtasticPort = process.env.MESHTASTIC_NODE_PORT || process.env.MESHTASTIC_PORT || process.env.NODE_PORT || '4403';
+    // When Virtual Node is enabled, route scripts through it to avoid opening a
+    // second TCP connection to the physical node (which kills MeshMonitor's connection)
+    let meshtasticIp: string;
+    let meshtasticPort: string;
+    if (env.enableVirtualNode) {
+      meshtasticIp = '127.0.0.1';
+      meshtasticPort = String(env.virtualNodePort);
+    } else {
+      meshtasticIp = process.env.MESHTASTIC_NODE_IP || process.env.MESHTASTIC_IP || process.env.NODE_IP || '127.0.0.1';
+      meshtasticPort = process.env.MESHTASTIC_NODE_PORT || process.env.MESHTASTIC_PORT || process.env.NODE_PORT || '4403';
+    }
     scriptEnv.IP = meshtasticIp;
     scriptEnv.PORT = meshtasticPort;
     scriptEnv.MESHTASTIC_IP = meshtasticIp;


### PR DESCRIPTION
## Summary
- When scripts (e.g. `remote-admin.py`) use the `meshtastic` CLI with `--host`, they open a second TCP connection to the physical node. Since nodes only support one TCP client, this kills MeshMonitor's connection causing `ERR_STREAM_DESTROYED` errors and a full reconnection cycle.
- When the Virtual Node is enabled, `MESHTASTIC_IP`/`MESHTASTIC_PORT` env vars now point to `127.0.0.1:<virtual_node_port>` so scripts relay commands through MeshMonitor's existing connection.
- Adds a localhost bypass in the Virtual Node's admin command blocking so container-internal scripts can send admin commands without requiring `VIRTUAL_NODE_ALLOW_ADMIN_COMMANDS=true`. The `addContact` PKI corruption guard (#1487) remains enforced for all clients including localhost.

Closes #1766

## Changes
- **`src/server/meshtasticManager.ts`**: Add `getScriptConnectionConfig()` method; update geofence, timer, and auto-responder callsites to use it
- **`src/server/virtualNodeServer.ts`**: Add `isLocalhostClient()` helper; restructure admin blocking to check `addContact` universally first, then bypass remaining blocking for localhost clients
- **`src/server/server.ts`**: Update script test endpoint to use Virtual Node config when enabled
- **`examples/auto-responder-scripts/remote-admin.py`**: Update docstring
- **`examples/auto-responder-scripts/remote-admin.sh`**: Update docstring

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 2351 tests passed, 0 failures
- [x] `npm run typecheck` passes
- [ ] Deploy to dev container and verify Virtual Node is running
- [ ] Test script execution with `remote-admin.py` — verify MeshMonitor's connection is NOT disrupted
- [ ] Verify external (non-localhost) clients are still blocked from admin commands
- [ ] Run `tests/system-tests.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)