### PR TITLE
feat: persistent ignored nodes list

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3785,5 +3785,18 @@
   "news.category.release": "Release",
   "news.category.security": "Security",
   "news.category.feature": "Feature",
-  "news.category.maintenance": "Maintenance"
+  "news.category.maintenance": "Maintenance",
+
+  "automation.ignored_nodes.title": "Ignored Nodes",
+  "automation.ignored_nodes.description": "Nodes on this list will remain ignored even after being pruned by inactive node cleanup. When they reappear, their ignored status will be automatically restored.",
+  "automation.ignored_nodes.total_ignored": "Ignored Nodes",
+  "automation.ignored_nodes.empty": "No nodes are currently ignored.",
+  "automation.ignored_nodes.col_node_id": "Node ID",
+  "automation.ignored_nodes.col_long_name": "Long Name",
+  "automation.ignored_nodes.col_short_name": "Short Name",
+  "automation.ignored_nodes.col_ignored_at": "Ignored At",
+  "automation.ignored_nodes.col_actions": "Actions",
+  "automation.ignored_nodes.unignore": "Un-ignore",
+  "automation.ignored_nodes.removed": "{{name}} has been un-ignored.",
+  "automation.ignored_nodes.remove_failed": "Failed to un-ignore node. Please try again."
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import AutoKeyManagementSection from './components/AutoKeyManagementSection';
 import TimerTriggersSection from './components/TimerTriggersSection';
 import GeofenceTriggersSection from './components/GeofenceTriggersSection';
 import RemoteAdminScannerSection from './components/RemoteAdminScannerSection';
+import IgnoredNodesSection from './components/IgnoredNodesSection';
 import SectionNav from './components/SectionNav';
 import { ToastProvider, useToast } from './components/ToastContainer';
 import { RebootModal } from './components/RebootModal';
@@ -4428,6 +4429,7 @@ function App() {
                 { id: 'auto-key-management', label: t('automation.auto_key_management.title', 'Auto Key Management') },
                 { id: 'timer-triggers', label: t('automation.timer_triggers.title', 'Timer Triggers') },
                 { id: 'geofence-triggers', label: t('automation.geofence_triggers.title', 'Geofence Triggers') },
+                { id: 'ignored-nodes', label: t('automation.ignored_nodes.title', 'Ignored Nodes') },
               ]}
             />
             <div className="settings-content">
@@ -4551,6 +4553,11 @@ function App() {
                   nodes={nodes}
                   baseUrl={baseUrl}
                   onTriggersChange={setGeofenceTriggers}
+                />
+              </div>
+              <div id="ignored-nodes">
+                <IgnoredNodesSection
+                  baseUrl={baseUrl}
                 />
               </div>
             </div>

--- a/src/components/IgnoredNodesSection.tsx
+++ b/src/components/IgnoredNodesSection.tsx
@@ -1,0 +1,230 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useToast } from './ToastContainer';
+import { useCsrfFetch } from '../hooks/useCsrfFetch';
+
+interface IgnoredNodesSectionProps {
+  baseUrl: string;
+}
+
+interface IgnoredNode {
+  nodeNum: number;
+  nodeId: string;
+  longName: string | null;
+  shortName: string | null;
+  ignoredAt: number;
+  ignoredBy: string | null;
+}
+
+const IgnoredNodesSection: React.FC<IgnoredNodesSectionProps> = ({ baseUrl }) => {
+  const { t } = useTranslation();
+  const csrfFetch = useCsrfFetch();
+  const { showToast } = useToast();
+
+  const [ignoredNodes, setIgnoredNodes] = useState<IgnoredNode[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [removingNodeNum, setRemovingNodeNum] = useState<number | null>(null);
+
+  const fetchIgnoredNodes = useCallback(async () => {
+    try {
+      const response = await csrfFetch(`${baseUrl}/api/ignored-nodes`);
+      if (response.ok) {
+        const data = await response.json();
+        setIgnoredNodes(data);
+      }
+    } catch (error) {
+      console.error('Failed to fetch ignored nodes:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [baseUrl, csrfFetch]);
+
+  useEffect(() => {
+    fetchIgnoredNodes();
+  }, [fetchIgnoredNodes]);
+
+  const handleRemove = async (node: IgnoredNode) => {
+    setRemovingNodeNum(node.nodeNum);
+    try {
+      const response = await csrfFetch(`${baseUrl}/api/ignored-nodes/${node.nodeId}`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok) {
+        if (response.status === 403) {
+          showToast(t('automation.insufficient_permissions'), 'error');
+          return;
+        }
+        throw new Error(`Server returned ${response.status}`);
+      }
+
+      setIgnoredNodes(prev => prev.filter(n => n.nodeNum !== node.nodeNum));
+      showToast(
+        t('automation.ignored_nodes.removed', { name: node.longName || node.nodeId }),
+        'success'
+      );
+    } catch (error) {
+      console.error('Failed to remove ignored node:', error);
+      showToast(t('automation.ignored_nodes.remove_failed'), 'error');
+    } finally {
+      setRemovingNodeNum(null);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="automation-section-header" style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '2rem',
+      }}>
+        {t('common.loading')}...
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="automation-section-header" style={{
+        display: 'flex',
+        alignItems: 'center',
+        marginBottom: '1.5rem',
+        padding: '1rem 1.25rem',
+        background: 'var(--ctp-surface1)',
+        border: '1px solid var(--ctp-surface2)',
+        borderRadius: '8px'
+      }}>
+        <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          {t('automation.ignored_nodes.title', 'Ignored Nodes')}
+          <a
+            href="https://meshmonitor.org/features/automation#ignored-nodes"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              fontSize: '1.2rem',
+              color: '#89b4fa',
+              textDecoration: 'none',
+              marginLeft: '0.5rem'
+            }}
+            title={t('automation.view_docs')}
+          >
+            ?
+          </a>
+        </h2>
+      </div>
+
+      <div className="settings-section">
+        <p style={{ marginBottom: '1rem', color: '#666', lineHeight: '1.5', marginLeft: '1.75rem' }}>
+          {t('automation.ignored_nodes.description', 'Nodes on this list will remain ignored even after being pruned by inactive node cleanup. When they reappear, their ignored status will be automatically restored.')}
+        </p>
+
+        {/* Stats */}
+        <div style={{
+          marginLeft: '1.75rem',
+          marginBottom: '1.5rem',
+          padding: '1rem',
+          background: 'var(--ctp-surface0)',
+          border: '1px solid var(--ctp-surface2)',
+          borderRadius: '6px',
+          display: 'flex',
+          gap: '2rem',
+        }}>
+          <div>
+            <div style={{ fontSize: '24px', fontWeight: 600, color: 'var(--ctp-red)' }}>
+              {ignoredNodes.length}
+            </div>
+            <div style={{ fontSize: '12px', color: 'var(--ctp-subtext0)' }}>
+              {t('automation.ignored_nodes.total_ignored', 'Ignored Nodes')}
+            </div>
+          </div>
+        </div>
+
+        {/* Ignored Nodes Table */}
+        <div style={{
+          border: '1px solid var(--ctp-surface2)',
+          borderRadius: '6px',
+          overflow: 'hidden',
+          marginLeft: '1.75rem'
+        }}>
+          {ignoredNodes.length === 0 ? (
+            <div style={{
+              padding: '1rem',
+              textAlign: 'center',
+              color: 'var(--ctp-subtext0)',
+              fontSize: '12px'
+            }}>
+              {t('automation.ignored_nodes.empty', 'No nodes are currently ignored.')}
+            </div>
+          ) : (
+            <table style={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontSize: '12px'
+            }}>
+              <thead>
+                <tr style={{ background: 'var(--ctp-surface1)' }}>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: 500 }}>
+                    {t('automation.ignored_nodes.col_node_id', 'Node ID')}
+                  </th>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: 500 }}>
+                    {t('automation.ignored_nodes.col_long_name', 'Long Name')}
+                  </th>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: 500 }}>
+                    {t('automation.ignored_nodes.col_short_name', 'Short Name')}
+                  </th>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: 500 }}>
+                    {t('automation.ignored_nodes.col_ignored_at', 'Ignored At')}
+                  </th>
+                  <th style={{ padding: '0.5rem 0.75rem', textAlign: 'center', fontWeight: 500 }}>
+                    {t('automation.ignored_nodes.col_actions', 'Actions')}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {ignoredNodes.map((node) => (
+                  <tr key={node.nodeNum} style={{ borderTop: '1px solid var(--ctp-surface1)' }}>
+                    <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-text)', fontFamily: 'monospace' }}>
+                      {node.nodeId}
+                    </td>
+                    <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-text)' }}>
+                      {node.longName || '-'}
+                    </td>
+                    <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-text)' }}>
+                      {node.shortName || '-'}
+                    </td>
+                    <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-subtext0)' }}>
+                      {new Date(node.ignoredAt).toLocaleString()}
+                    </td>
+                    <td style={{ padding: '0.4rem 0.75rem', textAlign: 'center' }}>
+                      <button
+                        onClick={() => handleRemove(node)}
+                        disabled={removingNodeNum === node.nodeNum}
+                        style={{
+                          padding: '0.25rem 0.5rem',
+                          fontSize: '11px',
+                          background: 'var(--ctp-red)',
+                          color: 'var(--ctp-base)',
+                          border: 'none',
+                          borderRadius: '4px',
+                          cursor: removingNodeNum === node.nodeNum ? 'not-allowed' : 'pointer',
+                          opacity: removingNodeNum === node.nodeNum ? 0.5 : 1,
+                        }}
+                      >
+                        {removingNodeNum === node.nodeNum
+                          ? t('common.loading', 'Loading...')
+                          : t('automation.ignored_nodes.unignore', 'Un-ignore')}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default IgnoredNodesSection;

--- a/src/db/repositories/ignoredNodes.ts
+++ b/src/db/repositories/ignoredNodes.ts
@@ -1,0 +1,177 @@
+/**
+ * Ignored Nodes Repository
+ *
+ * Handles persistence of node ignored status independently of the nodes table.
+ * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
+ */
+import { eq } from 'drizzle-orm';
+import { ignoredNodesSqlite, ignoredNodesPostgres, ignoredNodesMysql } from '../schema/ignoredNodes.js';
+import { BaseRepository, DrizzleDatabase } from './base.js';
+import { DatabaseType } from '../types.js';
+import { logger } from '../../utils/logger.js';
+
+export interface IgnoredNodeRecord {
+  nodeNum: number;
+  nodeId: string;
+  longName: string | null;
+  shortName: string | null;
+  ignoredAt: number;
+  ignoredBy: string | null;
+}
+
+/**
+ * Repository for ignored nodes operations
+ */
+export class IgnoredNodesRepository extends BaseRepository {
+  constructor(db: DrizzleDatabase, dbType: DatabaseType) {
+    super(db, dbType);
+  }
+
+  /**
+   * Add a node to the persistent ignore list (upsert)
+   */
+  async addIgnoredNodeAsync(
+    nodeNum: number,
+    nodeId: string,
+    longName?: string | null,
+    shortName?: string | null,
+    ignoredBy?: string | null,
+  ): Promise<void> {
+    const now = Date.now();
+
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      // SQLite upsert via INSERT OR REPLACE
+      await db
+        .insert(ignoredNodesSqlite)
+        .values({
+          nodeNum,
+          nodeId,
+          longName: longName ?? null,
+          shortName: shortName ?? null,
+          ignoredAt: now,
+          ignoredBy: ignoredBy ?? null,
+        })
+        .onConflictDoUpdate({
+          target: ignoredNodesSqlite.nodeNum,
+          set: {
+            nodeId,
+            longName: longName ?? null,
+            shortName: shortName ?? null,
+            ignoredAt: now,
+            ignoredBy: ignoredBy ?? null,
+          },
+        });
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      await db
+        .insert(ignoredNodesMysql)
+        .values({
+          nodeNum,
+          nodeId,
+          longName: longName ?? null,
+          shortName: shortName ?? null,
+          ignoredAt: now,
+          ignoredBy: ignoredBy ?? null,
+        })
+        .onDuplicateKeyUpdate({
+          set: {
+            nodeId,
+            longName: longName ?? null,
+            shortName: shortName ?? null,
+            ignoredAt: now,
+            ignoredBy: ignoredBy ?? null,
+          },
+        });
+    } else {
+      const db = this.getPostgresDb();
+      await db
+        .insert(ignoredNodesPostgres)
+        .values({
+          nodeNum,
+          nodeId,
+          longName: longName ?? null,
+          shortName: shortName ?? null,
+          ignoredAt: now,
+          ignoredBy: ignoredBy ?? null,
+        })
+        .onConflictDoUpdate({
+          target: ignoredNodesPostgres.nodeNum,
+          set: {
+            nodeId,
+            longName: longName ?? null,
+            shortName: shortName ?? null,
+            ignoredAt: now,
+            ignoredBy: ignoredBy ?? null,
+          },
+        });
+    }
+
+    logger.debug(`Added node ${nodeNum} (${nodeId}) to persistent ignore list`);
+  }
+
+  /**
+   * Remove a node from the persistent ignore list
+   */
+  async removeIgnoredNodeAsync(nodeNum: number): Promise<void> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      await db.delete(ignoredNodesSqlite).where(eq(ignoredNodesSqlite.nodeNum, nodeNum));
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      await db.delete(ignoredNodesMysql).where(eq(ignoredNodesMysql.nodeNum, nodeNum));
+    } else {
+      const db = this.getPostgresDb();
+      await db.delete(ignoredNodesPostgres).where(eq(ignoredNodesPostgres.nodeNum, nodeNum));
+    }
+
+    logger.debug(`Removed node ${nodeNum} from persistent ignore list`);
+  }
+
+  /**
+   * Get all persistently ignored nodes
+   */
+  async getIgnoredNodesAsync(): Promise<IgnoredNodeRecord[]> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const rows = await db.select().from(ignoredNodesSqlite);
+      return rows.map(r => this.normalizeBigInts(r) as IgnoredNodeRecord);
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      const rows = await db.select().from(ignoredNodesMysql);
+      return rows.map(r => this.normalizeBigInts(r) as IgnoredNodeRecord);
+    } else {
+      const db = this.getPostgresDb();
+      const rows = await db.select().from(ignoredNodesPostgres);
+      return rows.map(r => this.normalizeBigInts(r) as IgnoredNodeRecord);
+    }
+  }
+
+  /**
+   * Check if a node is in the persistent ignore list
+   */
+  async isNodeIgnoredAsync(nodeNum: number): Promise<boolean> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const rows = await db
+        .select({ nodeNum: ignoredNodesSqlite.nodeNum })
+        .from(ignoredNodesSqlite)
+        .where(eq(ignoredNodesSqlite.nodeNum, nodeNum));
+      return rows.length > 0;
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      const rows = await db
+        .select({ nodeNum: ignoredNodesMysql.nodeNum })
+        .from(ignoredNodesMysql)
+        .where(eq(ignoredNodesMysql.nodeNum, nodeNum));
+      return rows.length > 0;
+    } else {
+      const db = this.getPostgresDb();
+      const rows = await db
+        .select({ nodeNum: ignoredNodesPostgres.nodeNum })
+        .from(ignoredNodesPostgres)
+        .where(eq(ignoredNodesPostgres.nodeNum, nodeNum));
+      return rows.length > 0;
+    }
+  }
+}

--- a/src/db/repositories/index.ts
+++ b/src/db/repositories/index.ts
@@ -30,3 +30,4 @@ export type {
 export { MiscRepository } from './misc.js';
 export type { SolarEstimate, AutoTracerouteNode, UpgradeHistoryRecord, NewUpgradeHistory, NewsCache, UserNewsStatus, BackupHistory } from './misc.js';
 export { ChannelDatabaseRepository, type ChannelDatabaseInput, type ChannelDatabaseUpdate, type ChannelDatabasePermissionInput } from './channelDatabase.js';
+export { IgnoredNodesRepository, type IgnoredNodeRecord } from './ignoredNodes.js';

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -864,9 +864,15 @@ export class NodesRepository extends BaseRepository {
         .select({ nodeNum: nodesSqlite.nodeNum })
         .from(nodesSqlite)
         .where(
-          or(
-            lt(nodesSqlite.lastHeard, cutoff),
-            isNull(nodesSqlite.lastHeard)
+          and(
+            or(
+              lt(nodesSqlite.lastHeard, cutoff),
+              isNull(nodesSqlite.lastHeard)
+            ),
+            or(
+              eq(nodesSqlite.isIgnored, false),
+              isNull(nodesSqlite.isIgnored)
+            )
           )
         );
 
@@ -880,9 +886,15 @@ export class NodesRepository extends BaseRepository {
         .select({ nodeNum: nodesMysql.nodeNum })
         .from(nodesMysql)
         .where(
-          or(
-            lt(nodesMysql.lastHeard, cutoff),
-            isNull(nodesMysql.lastHeard)
+          and(
+            or(
+              lt(nodesMysql.lastHeard, cutoff),
+              isNull(nodesMysql.lastHeard)
+            ),
+            or(
+              eq(nodesMysql.isIgnored, false),
+              isNull(nodesMysql.isIgnored)
+            )
           )
         );
 
@@ -896,9 +908,15 @@ export class NodesRepository extends BaseRepository {
         .select({ nodeNum: nodesPostgres.nodeNum })
         .from(nodesPostgres)
         .where(
-          or(
-            lt(nodesPostgres.lastHeard, cutoff),
-            isNull(nodesPostgres.lastHeard)
+          and(
+            or(
+              lt(nodesPostgres.lastHeard, cutoff),
+              isNull(nodesPostgres.lastHeard)
+            ),
+            or(
+              eq(nodesPostgres.isIgnored, false),
+              isNull(nodesPostgres.isIgnored)
+            )
           )
         );
 
@@ -1024,7 +1042,12 @@ export class NodesRepository extends BaseRepository {
       const toDelete = await db
         .select({ nodeNum: nodesSqlite.nodeNum })
         .from(nodesSqlite)
-        .where(or(lt(nodesSqlite.lastHeard, cutoffTimestamp), isNull(nodesSqlite.lastHeard)));
+        .where(
+          and(
+            or(lt(nodesSqlite.lastHeard, cutoffTimestamp), isNull(nodesSqlite.lastHeard)),
+            or(eq(nodesSqlite.isIgnored, false), isNull(nodesSqlite.isIgnored))
+          )
+        );
 
       for (const node of toDelete) {
         await db.delete(nodesSqlite).where(eq(nodesSqlite.nodeNum, node.nodeNum));
@@ -1035,7 +1058,12 @@ export class NodesRepository extends BaseRepository {
       const toDelete = await db
         .select({ nodeNum: nodesMysql.nodeNum })
         .from(nodesMysql)
-        .where(or(lt(nodesMysql.lastHeard, cutoffTimestamp), isNull(nodesMysql.lastHeard)));
+        .where(
+          and(
+            or(lt(nodesMysql.lastHeard, cutoffTimestamp), isNull(nodesMysql.lastHeard)),
+            or(eq(nodesMysql.isIgnored, false), isNull(nodesMysql.isIgnored))
+          )
+        );
 
       for (const node of toDelete) {
         await db.delete(nodesMysql).where(eq(nodesMysql.nodeNum, node.nodeNum));
@@ -1046,7 +1074,12 @@ export class NodesRepository extends BaseRepository {
       const toDelete = await db
         .select({ nodeNum: nodesPostgres.nodeNum })
         .from(nodesPostgres)
-        .where(or(lt(nodesPostgres.lastHeard, cutoffTimestamp), isNull(nodesPostgres.lastHeard)));
+        .where(
+          and(
+            or(lt(nodesPostgres.lastHeard, cutoffTimestamp), isNull(nodesPostgres.lastHeard)),
+            or(eq(nodesPostgres.isIgnored, false), isNull(nodesPostgres.isIgnored))
+          )
+        );
 
       for (const node of toDelete) {
         await db.delete(nodesPostgres).where(eq(nodesPostgres.nodeNum, node.nodeNum));

--- a/src/db/schema/ignoredNodes.ts
+++ b/src/db/schema/ignoredNodes.ts
@@ -1,0 +1,63 @@
+/**
+ * Drizzle schema definition for the ignored_nodes table
+ * Supports SQLite, PostgreSQL, and MySQL
+ *
+ * This table persists the ignored status of nodes independently of the nodes table,
+ * so that when a node is pruned by cleanupInactiveNodes and later reappears,
+ * its ignored status is automatically restored.
+ */
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import {
+  pgTable,
+  text as pgText,
+  integer as pgInteger,
+  bigint as pgBigint,
+} from 'drizzle-orm/pg-core';
+import {
+  mysqlTable,
+  varchar as myVarchar,
+  int as myInt,
+  bigint as myBigint,
+} from 'drizzle-orm/mysql-core';
+
+// ============ IGNORED NODES (SQLite) ============
+
+export const ignoredNodesSqlite = sqliteTable('ignored_nodes', {
+  nodeNum: integer('nodeNum').primaryKey(),
+  nodeId: text('nodeId').notNull(),
+  longName: text('longName'),
+  shortName: text('shortName'),
+  ignoredAt: integer('ignoredAt').notNull(),
+  ignoredBy: text('ignoredBy'),
+});
+
+// ============ IGNORED NODES (PostgreSQL) ============
+
+export const ignoredNodesPostgres = pgTable('ignored_nodes', {
+  nodeNum: pgInteger('nodeNum').primaryKey(),
+  nodeId: pgText('nodeId').notNull(),
+  longName: pgText('longName'),
+  shortName: pgText('shortName'),
+  ignoredAt: pgBigint('ignoredAt', { mode: 'number' }).notNull(),
+  ignoredBy: pgText('ignoredBy'),
+});
+
+// ============ IGNORED NODES (MySQL) ============
+
+export const ignoredNodesMysql = mysqlTable('ignored_nodes', {
+  nodeNum: myInt('nodeNum').primaryKey(),
+  nodeId: myVarchar('nodeId', { length: 255 }).notNull(),
+  longName: myVarchar('longName', { length: 255 }),
+  shortName: myVarchar('shortName', { length: 255 }),
+  ignoredAt: myBigint('ignoredAt', { mode: 'number' }).notNull(),
+  ignoredBy: myVarchar('ignoredBy', { length: 255 }),
+});
+
+// ============ TYPE INFERENCE ============
+
+export type IgnoredNodeSqlite = typeof ignoredNodesSqlite.$inferSelect;
+export type NewIgnoredNodeSqlite = typeof ignoredNodesSqlite.$inferInsert;
+export type IgnoredNodePostgres = typeof ignoredNodesPostgres.$inferSelect;
+export type NewIgnoredNodePostgres = typeof ignoredNodesPostgres.$inferInsert;
+export type IgnoredNodeMysql = typeof ignoredNodesMysql.$inferSelect;
+export type NewIgnoredNodeMysql = typeof ignoredNodesMysql.$inferInsert;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -26,3 +26,6 @@ export * from './misc.js';
 
 // Channel Database tables
 export * from './channelDatabase.js';
+
+// Ignored Nodes table
+export * from './ignoredNodes.js';

--- a/src/db/schema/mysql-create.ts
+++ b/src/db/schema/mysql-create.ts
@@ -479,4 +479,5 @@ export const MYSQL_TABLE_NAMES = [
   'auto_key_repair_log',
   'channel_database',
   'channel_database_permissions',
+  'ignored_nodes',
 ];

--- a/src/db/schema/postgres-create.ts
+++ b/src/db/schema/postgres-create.ts
@@ -461,4 +461,5 @@ export const POSTGRES_TABLE_NAMES = [
   'auto_key_repair_log',
   'channel_database',
   'channel_database_permissions',
+  'ignored_nodes',
 ];

--- a/src/server/migrations/066_add_ignored_nodes_table.ts
+++ b/src/server/migrations/066_add_ignored_nodes_table.ts
@@ -1,0 +1,128 @@
+/**
+ * Migration 066: Add ignored_nodes table
+ *
+ * Creates a persistent ignored_nodes table that survives node deletion.
+ * When cleanupInactiveNodes() prunes a node, its ignored status is preserved
+ * in this table. When the node reappears, the ignored status is restored.
+ */
+
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.debug('Running migration 066: Add ignored_nodes table');
+
+    try {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS ignored_nodes (
+          nodeNum INTEGER PRIMARY KEY,
+          nodeId TEXT NOT NULL,
+          longName TEXT,
+          shortName TEXT,
+          ignoredAt INTEGER NOT NULL,
+          ignoredBy TEXT
+        )
+      `);
+
+      logger.debug('Migration 066 completed: ignored_nodes table created');
+    } catch (error) {
+      logger.error('Migration 066 failed:', error);
+      throw error;
+    }
+  },
+
+  down: (db: Database): void => {
+    logger.debug('Running migration 066 down: Remove ignored_nodes table');
+
+    try {
+      db.exec(`DROP TABLE IF EXISTS ignored_nodes`);
+
+      logger.debug('Migration 066 rollback completed');
+    } catch (error) {
+      logger.error('Migration 066 rollback failed:', error);
+      throw error;
+    }
+  }
+};
+
+/**
+ * PostgreSQL migration: Add ignored_nodes table
+ */
+export async function runMigration066Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.debug('Running migration 066 (PostgreSQL): Add ignored_nodes table');
+
+  try {
+    // Check if table already exists
+    const tableExists = await client.query(`
+      SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = 'ignored_nodes'
+      )
+    `);
+
+    if (tableExists.rows[0].exists) {
+      logger.debug('ignored_nodes table already exists, skipping migration');
+      return;
+    }
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS ignored_nodes (
+        "nodeNum" INTEGER PRIMARY KEY,
+        "nodeId" TEXT NOT NULL,
+        "longName" TEXT,
+        "shortName" TEXT,
+        "ignoredAt" BIGINT NOT NULL,
+        "ignoredBy" TEXT
+      )
+    `);
+
+    logger.debug('Migration 066 (PostgreSQL): ignored_nodes table created');
+  } catch (error) {
+    logger.error('Migration 066 (PostgreSQL) failed:', error);
+    throw error;
+  }
+}
+
+/**
+ * MySQL migration: Add ignored_nodes table
+ */
+export async function runMigration066Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.debug('Running migration 066 (MySQL): Add ignored_nodes table');
+
+  try {
+    const connection = await pool.getConnection();
+    try {
+      // Check if table already exists
+      const [tables] = await connection.query(`
+        SELECT TABLE_NAME FROM information_schema.tables
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'ignored_nodes'
+      `);
+
+      if ((tables as any[]).length > 0) {
+        logger.debug('ignored_nodes table already exists, skipping migration');
+        return;
+      }
+
+      await connection.query(`
+        CREATE TABLE IF NOT EXISTS ignored_nodes (
+          nodeNum INT PRIMARY KEY,
+          nodeId VARCHAR(255) NOT NULL,
+          longName VARCHAR(255),
+          shortName VARCHAR(255),
+          ignoredAt BIGINT NOT NULL,
+          ignoredBy VARCHAR(255)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+      `);
+
+      logger.debug('Migration 066 (MySQL): ignored_nodes table created');
+    } finally {
+      connection.release();
+    }
+  } catch (error) {
+    logger.error('Migration 066 (MySQL) failed:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #1796 - Ignored nodes lose their status when pruned by inactive node cleanup
- Adds a persistent `ignored_nodes` table that survives node deletion across all 3 database backends
- When a previously-ignored node reappears, its ignored status is automatically restored
- Adds management UI in the Automation tab to view and un-ignore nodes

## Changes
- **New migration 066**: Creates `ignored_nodes` table (SQLite, PostgreSQL, MySQL)
- **New `IgnoredNodesRepository`**: CRUD operations for the persistent ignore list
- **`setNodeIgnored()`**: Now persists to/removes from the `ignored_nodes` table
- **`cleanupInactiveNodes()` / `deleteInactiveNodes()`**: Skip nodes with `isIgnored=true`
- **`upsertNode()`**: Checks the persistent ignore list when creating a new node and restores ignored status
- **API routes**: `GET /api/ignored-nodes` and `DELETE /api/ignored-nodes/:nodeId`
- **`IgnoredNodesSection`** component in the Automation tab

## Test plan
- [x] `npm run build && npm run build:server` passes
- [x] `npm run test:run` — 107 test files, 2351 tests passed
- [x] Docker dev build and deploy — migration runs, table created in PostgreSQL
- [x] Ignore a node via existing context menu — appears in Automation > Ignored Nodes
- [x] Un-ignore via the management section — node removed from list
- [ ] Run `tests/system-tests.sh` for full system validation
- [ ] Verify ignored node survives cleanup cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)