### PR TITLE
fix: rename 'Most Active Node' to 'Most Recently Heard'

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1544,7 +1544,7 @@
 
   "info.recent_activity": "Recent Activity",
   "info.last_message": "Last Message:",
-  "info.most_active_node": "Most Active Node:",
+  "info.most_active_node": "Most Recently Heard:",
 
   "info.longest_route": "Longest Active Route Segment",
   "info.distance": "Distance:",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -1687,7 +1687,7 @@
     "extnotif_config.output_vibra_gpio_description": "Номер GPIO для вибромотора",
     "tileset_manager.field_max_zoom": "Максимальный зум",
     "gpio_summary.vibra_output": "Выход на вибромотор",
-    "info.most_active_node": "Самая активная нода:",
+    "info.most_active_node": "Последняя услышанная нода:",
     "rangetest_config.title": "Тест дальности",
     "admin_commands.ambientlighting_configuration": "Настройка освещения",
     "notifications.apprise_description": "Discord, Slack, электронная почта, SMS и т. д. (HTTPS не требуется)",

--- a/public/locales/zh_Hans.json
+++ b/public/locales/zh_Hans.json
@@ -1296,7 +1296,7 @@
     "info.load_average": "负载平均值：",
     "info.recent_activity": "近期活动",
     "info.last_message": "最后消息：",
-    "info.most_active_node": "最活跃节点：",
+    "info.most_active_node": "最近听到的节点：",
     "info.longest_route": "最长活跃路由段",
     "info.distance": "距离：",
     "info.from": "起点：",


### PR DESCRIPTION
## Summary
Fixes #1800 - The "Most Active Node" label was misleading.

The displayed value uses the `lastHeard` timestamp to find the node that was heard from most recently, **not** the node that sent the most messages. This caused confusion when comparing it to the packet distribution charts which rank nodes by message count.

## Changes
- Renamed label from "Most Active Node" to "Most Recently Heard" in:
  - English (`en.json`)
  - Russian (`ru.json`) 
  - Chinese Simplified (`zh_Hans.json`)

## Test plan
- [x] Verify label change in Info tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)