### PR TITLE
fix: respect verifyResponse setting for geofence and auto-responder

### DIFF
--- a/src/server/messageQueueService.ts
+++ b/src/server/messageQueueService.ts
@@ -55,12 +55,17 @@ class MessageQueueService {
    * Add a message to the queue
    * For DMs: destination = node number, channel = undefined
    * For channels: destination = 0, channel = channel index (0-7)
+   * @param maxAttemptsOverride - Override the default max attempts (1 for channels, 3 for DMs).
+   *                              Use 1 to disable retries, or 3 for retry with verification.
    */
-  enqueue(text: string, destination: number, replyId?: number, onSuccess?: () => void, onFailure?: (reason: string) => void, channel?: number): string {
+  enqueue(text: string, destination: number, replyId?: number, onSuccess?: () => void, onFailure?: (reason: string) => void, channel?: number, maxAttemptsOverride?: number): string {
     const messageId = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
     // Channel messages don't support ACKs, so only attempt once
-    const maxAttempts = channel !== undefined ? 1 : this.MAX_ATTEMPTS;
+    // For DMs, use override if provided, otherwise default to MAX_ATTEMPTS
+    const maxAttempts = maxAttemptsOverride !== undefined
+      ? maxAttemptsOverride
+      : (channel !== undefined ? 1 : this.MAX_ATTEMPTS);
 
     const queuedMessage: QueuedMessage = {
       id: messageId,


### PR DESCRIPTION
## Summary
- Fixed the "Verify Response" checkbox being ignored for geofence triggers and auto-responder
- DM messages were always retrying 3 times regardless of the checkbox setting
- Now properly respects the setting: disabled = 1 attempt, enabled = 3 attempts

## Changes
- Added `maxAttemptsOverride` parameter to `messageQueueService.enqueue()` to allow callers to specify retry behavior
- Updated 4 call sites to pass the correct max attempts based on `trigger.verifyResponse`:
  - Geofence text responses
  - Geofence script responses
  - Auto-responder text responses
  - Auto-responder script responses

## Test plan
- [ ] Create a geofence trigger with DM channel and "Verify Response" **disabled**
- [ ] Trigger the geofence and verify only 1 delivery attempt is made
- [ ] Enable "Verify Response" and verify 3 attempts are made on failure
- [ ] Test same behavior with auto-responder triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)