### PR TITLE
chore: bump version to 3.4.7

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.4.6
-appVersion: "3.4.6"
+version: 3.4.7
+appVersion: "3.4.7"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.4.6",
+      "version": "3.4.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump version from 3.4.6 to 3.4.7

## Changes since 3.4.6
- #1806 - Fix traceroute scheduler timer leaks and enforce minimum send interval
- #1807 - Add Auto Time Sync feature for nodes without NTP/GPS
- #1808 - Fix verifyResponse setting for geofence and auto-responder

## Test plan
- [x] Unit tests passed (108 files, 2360 tests)
- [x] System tests passed (9/9 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)