### PR TITLE
fix: prevent false 'unsaved changes' prompt on Position Config load

### DIFF
--- a/src/components/configuration/PositionConfigSection.tsx
+++ b/src/components/configuration/PositionConfigSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useMemo, useCallback } from 'react';
+import React, { useState, useRef, useMemo, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { GPS_MODE_OPTIONS, POSITION_FLAGS } from './constants';
 import { useSaveBar } from '../../hooks/useSaveBar';
@@ -79,9 +79,41 @@ const PositionConfigSection: React.FC<PositionConfigSectionProps> = ({
     positionFlags, rxGpio, txGpio, gpsEnGpio
   });
 
+  // Track whether data has been loaded from server (use state to trigger re-render)
+  const [isDataLoaded, setIsDataLoaded] = useState(false);
+
+  // Update initial values when data is loaded from server
+  // This is detected by lat/long changing from default (0) to real values
+  useEffect(() => {
+    if (isDataLoaded) return; // Already loaded
+
+    const initial = initialValuesRef.current;
+    const latChanged = initial.fixedLatitude === 0 && fixedLatitude !== 0;
+    const lonChanged = initial.fixedLongitude === 0 && fixedLongitude !== 0;
+
+    // When position data loads from server, update the initial values
+    if (latChanged || lonChanged) {
+      initialValuesRef.current = {
+        positionBroadcastSecs, positionSmartEnabled, fixedPosition, fixedLatitude,
+        fixedLongitude, fixedAltitude, gpsUpdateInterval, gpsMode,
+        broadcastSmartMinimumDistance, broadcastSmartMinimumIntervalSecs,
+        positionFlags, rxGpio, txGpio, gpsEnGpio
+      };
+      setIsDataLoaded(true); // Trigger re-render to recalculate hasChanges
+    }
+  }, [isDataLoaded, fixedLatitude, fixedLongitude, positionBroadcastSecs, positionSmartEnabled, fixedPosition,
+      fixedAltitude, gpsUpdateInterval, gpsMode, broadcastSmartMinimumDistance,
+      broadcastSmartMinimumIntervalSecs, positionFlags, rxGpio, txGpio, gpsEnGpio]);
+
   // Calculate if there are unsaved changes
   const hasChanges = useMemo(() => {
+    // Check if data is still loading (lat/long will change from 0 to real values)
+    // Don't report changes until data has been loaded from the server
     const initial = initialValuesRef.current;
+    const stillLoading = !isDataLoaded && initial.fixedLatitude === 0 && initial.fixedLongitude === 0 &&
+                         (fixedLatitude !== 0 || fixedLongitude !== 0);
+    if (stillLoading) return false;
+
     return (
       positionBroadcastSecs !== initial.positionBroadcastSecs ||
       positionSmartEnabled !== initial.positionSmartEnabled ||
@@ -98,7 +130,7 @@ const PositionConfigSection: React.FC<PositionConfigSectionProps> = ({
       txGpio !== initial.txGpio ||
       gpsEnGpio !== initial.gpsEnGpio
     );
-  }, [positionBroadcastSecs, positionSmartEnabled, fixedPosition, fixedLatitude,
+  }, [isDataLoaded, positionBroadcastSecs, positionSmartEnabled, fixedPosition, fixedLatitude,
       fixedLongitude, fixedAltitude, gpsUpdateInterval, gpsMode,
       broadcastSmartMinimumDistance, broadcastSmartMinimumIntervalSecs,
       positionFlags, rxGpio, txGpio, gpsEnGpio]);


### PR DESCRIPTION
## Summary
- Fix bug where Position Config section incorrectly showed SaveBar after page load
- Issue occurred when Fixed Position is enabled and lat/long data loads from nodes
- Component now tracks when server data is loaded and updates baseline values accordingly

## Root Cause
When the page loaded:
1. Component initialized with `fixedLatitude=0, fixedLongitude=0` (defaults)
2. `initialValuesRef` captured these default values
3. When real position data loaded from nodes, props changed to actual lat/long
4. `hasChanges` compared real values to defaults (0,0) → incorrectly reported changes

## Fix
- Added `isDataLoaded` state to track when server data has been loaded
- Added `useEffect` to detect when lat/long changes from 0 to real values (indicating data load)
- Updated `hasChanges` to return `false` while data is still loading

## Test plan
- [x] TypeScript type check passes
- [x] Unit tests pass (2360 tests)
- [x] Manual testing: Navigate to Configuration → Position Config with Fixed Position enabled
- [x] Verify SaveBar does NOT appear on page load when position data loads

🤖 Generated with [Claude Code](https://claude.ai/code)