### PR TITLE
fix: add Proto3 defaults for MQTT proxy and map reporting settings

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2847,7 +2847,10 @@ class MeshtasticManager {
         // IMPORTANT: Proto3 omits boolean false values from JSON serialization
         enabled: moduleConfig.mqtt.enabled !== undefined ? moduleConfig.mqtt.enabled : false,
         encryptionEnabled: moduleConfig.mqtt.encryptionEnabled !== undefined ? moduleConfig.mqtt.encryptionEnabled : false,
-        jsonEnabled: moduleConfig.mqtt.jsonEnabled !== undefined ? moduleConfig.mqtt.jsonEnabled : false
+        jsonEnabled: moduleConfig.mqtt.jsonEnabled !== undefined ? moduleConfig.mqtt.jsonEnabled : false,
+        tlsEnabled: moduleConfig.mqtt.tlsEnabled !== undefined ? moduleConfig.mqtt.tlsEnabled : false,
+        proxyToClientEnabled: moduleConfig.mqtt.proxyToClientEnabled !== undefined ? moduleConfig.mqtt.proxyToClientEnabled : false,
+        mapReportingEnabled: moduleConfig.mqtt.mapReportingEnabled !== undefined ? moduleConfig.mqtt.mapReportingEnabled : false
       };
 
       moduleConfig = {
@@ -6531,7 +6534,9 @@ class MeshtasticManager {
       enabled: mqttConfig.enabled !== undefined ? mqttConfig.enabled : false,
       encryptionEnabled: mqttConfig.encryptionEnabled !== undefined ? mqttConfig.encryptionEnabled : false,
       jsonEnabled: mqttConfig.jsonEnabled !== undefined ? mqttConfig.jsonEnabled : false,
-      tlsEnabled: mqttConfig.tlsEnabled !== undefined ? mqttConfig.tlsEnabled : false
+      tlsEnabled: mqttConfig.tlsEnabled !== undefined ? mqttConfig.tlsEnabled : false,
+      proxyToClientEnabled: mqttConfig.proxyToClientEnabled !== undefined ? mqttConfig.proxyToClientEnabled : false,
+      mapReportingEnabled: mqttConfig.mapReportingEnabled !== undefined ? mqttConfig.mapReportingEnabled : false
     };
 
     logger.debug('🔍 loraConfig being used:', JSON.stringify(loraConfigWithDefaults, null, 2));


### PR DESCRIPTION
## Summary
- Fix MQTT "Proxy to Client" setting not persisting correctly
- Fix MQTT "Map Reporting" setting not persisting correctly
- Add missing `tlsEnabled` default in one location

## Root Cause
Proto3 omits boolean `false` values from JSON serialization. When loading config from the device:
1. Device returns config without `proxyToClientEnabled` field (because it's `false`)
2. Frontend receives `undefined` instead of `false`
3. Setting appears unchecked, but saving `false` vs `undefined` behaves differently

## Fix
Added explicit Proto3 default handling for these MQTT boolean fields in both locations where MQTT config is processed:
- `proxyToClientEnabled`
- `mapReportingEnabled`
- `tlsEnabled` (was missing in one location)

## Test plan
- [x] TypeScript type check passes
- [x] Unit tests pass (2360 tests)
- [x] Manual testing:
  1. Go to Configuration → MQTT Config
  2. Toggle "Proxy to Client" ON → Save → Refresh → Verify stays ON
  3. Toggle "Proxy to Client" OFF → Save → Refresh → Verify stays OFF

🤖 Generated with [Claude Code](https://claude.ai/code)