### PR TITLE
docs: add MeMon Network Health Monitor to user scripts gallery

### DIFF
--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -429,5 +429,28 @@
       "Easy to create wrapper scripts for specific actions",
       "JSON output for integration with MeshMonitor"
     ]
+  },
+  {
+    "name": "MeMon - Network Health Monitor",
+    "filename": "memon.py",
+    "icon": "🌐",
+    "description": "Monitors router and DNS resolver health with intelligent alerting. Supports Auto Responder (on-demand status checks) and Timer Trigger (scheduled monitoring with failure streak tracking, alert backoff, and recovery detection). Prevents alert spam through configurable thresholds.",
+    "language": "Python",
+    "tags": ["Network", "Monitoring", "DNS", "Router", "Health Check", "Auto Responder", "Timer Trigger", "Alerting"],
+    "githubPath": "DagBertelsen/MeMon/memon.py",
+    "exampleTrigger": "netcheck status, netcheck router, netcheck dns",
+    "requirements": [
+      "Python 3.5+ (standard library only, zero external dependencies)",
+      "memon.config.json configuration file (see README for examples)"
+    ],
+    "author": "DagBertelsen",
+    "features": [
+      "Router health checks (HTTPS, HTTP, or TCP socket)",
+      "DNS resolver monitoring with multiple servers",
+      "Failure streak tracking with alert backoff",
+      "Dual mode: Auto Responder (stateless) or Timer Trigger (stateful)",
+      "Recovery detection and notifications",
+      "UTF-8 config with emoji support"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
Adds MeMon - Network Health Monitor to the User Scripts Gallery per request in #1810.

## Script Details
- **Name:** MeMon - Network Health Monitor
- **Author:** DagBertelsen
- **Language:** Python
- **GitHub:** https://github.com/DagBertelsen/MeMon

## Features
- Router health checks (HTTPS, HTTP, or TCP socket methods)
- DNS resolver monitoring with multiple servers
- Dual mode operation:
  - **Auto Responder**: On-demand status checks via commands (status, router, dns)
  - **Timer Trigger**: Scheduled monitoring with failure streak tracking
- Intelligent alerting with backoff logic to prevent mesh spam
- Recovery detection and notifications
- Zero external dependencies (Python 3.5+ standard library only)

## Requirements
- Python 3.5+
- memon.config.json configuration file

Closes #1810

🤖 Generated with [Claude Code](https://claude.ai/code)