### PR TITLE
fix: traceroute history always empty on PostgreSQL/MySQL

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2922,7 +2922,7 @@ apiRouter.get('/traceroutes/recent', (req, res) => {
 });
 
 // Get traceroute history for a specific source-destination pair
-apiRouter.get('/traceroutes/history/:fromNodeNum/:toNodeNum', (req, res) => {
+apiRouter.get('/traceroutes/history/:fromNodeNum/:toNodeNum', async (req, res) => {
   try {
     const fromNodeNum = parseInt(req.params.fromNodeNum);
     const toNodeNum = parseInt(req.params.toNodeNum);
@@ -2946,7 +2946,7 @@ apiRouter.get('/traceroutes/history/:fromNodeNum/:toNodeNum', (req, res) => {
       return;
     }
 
-    const traceroutes = databaseService.getTraceroutesByNodes(fromNodeNum, toNodeNum, limit);
+    const traceroutes = await databaseService.getTraceroutesByNodesAsync(fromNodeNum, toNodeNum, limit);
 
     const traceroutesWithHops = traceroutes.map(tr => {
       let hopCount = 999;

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -5569,6 +5569,25 @@ class DatabaseService {
     return traceroutes.map(t => this.normalizeBigInts(t));
   }
 
+  /**
+   * Async version of getTraceroutesByNodes for PostgreSQL/MySQL
+   */
+  async getTraceroutesByNodesAsync(fromNodeNum: number, toNodeNum: number, limit: number = 10): Promise<DbTraceroute[]> {
+    if (this.traceroutesRepo) {
+      const traceroutes = await this.traceroutesRepo.getTraceroutesByNodes(fromNodeNum, toNodeNum, limit);
+      return traceroutes.map(t => ({
+        ...t,
+        route: t.route || '',
+        routeBack: t.routeBack || '',
+        snrTowards: t.snrTowards || '',
+        snrBack: t.snrBack || '',
+      })) as DbTraceroute[];
+    }
+
+    // Fallback to sync for SQLite
+    return this.getTraceroutesByNodes(fromNodeNum, toNodeNum, limit);
+  }
+
   getAllTraceroutes(limit: number = 100): DbTraceroute[] {
     // For PostgreSQL/MySQL, use cached traceroutes or return empty
     // Traceroute data is primarily real-time from mesh traffic


### PR DESCRIPTION
## Summary
- Traceroute history modal on the Messages page always showed empty results when using PostgreSQL or MySQL backends
- Root cause: the route handler called the sync `getTraceroutesByNodes()` which uses a fire-and-forget cache pattern — it fires a background async query and immediately returns the cache (always empty `[]` on first call)
- Added `getTraceroutesByNodesAsync()` to `DatabaseService` that properly `await`s the repository query
- Made the `/api/traceroutes/history/:fromNodeNum/:toNodeNum` route handler `async`

## Test plan
- [x] All 2360 unit tests pass
- [ ] Deploy with PostgreSQL backend and verify traceroute history modal shows data
- [ ] Verify SQLite backend still works (fallback to sync method)

🤖 Generated with [Claude Code](https://claude.com/claude-code)