### PR TITLE
fix: news popup dismiss checkbox not persisting

### DIFF
--- a/src/components/NewsPopup/NewsPopup.tsx
+++ b/src/components/NewsPopup/NewsPopup.tsx
@@ -148,9 +148,9 @@ export const NewsPopup: React.FC<NewsPopupProps> = ({
       // Scroll content to top for new item
       contentRef.current?.scrollTo({ top: 0, behavior: 'instant' });
     } else {
-      onClose();
+      handleClose();
     }
-  }, [currentIndex, newsItems.length, onClose]);
+  }, [currentIndex, newsItems.length, handleClose]);
 
   const handlePrevious = useCallback(() => {
     if (currentIndex > 0) {


### PR DESCRIPTION
## Summary

- The "Close" button on the last news item called `onClose()` directly, bypassing `handleClose()` which processes the dismiss checkbox and updates `lastSeenNewsId`
- This caused important news items to reappear on every page load even after checking "Don't show these again"
- Fix: `handleNext` now calls `handleClose()` instead of `onClose()` when on the last item

## Test plan

- [ ] Open the news popup, check "Don't show these again", click Close
- [ ] Reload the page — news popup should not reappear
- [ ] Open news popup via menu (force show), verify items still display
- [ ] Verify clicking X button still dismisses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)