### PR TITLE
fix: MFA operations fail on SQLite

### DIFF
--- a/src/server/models/User.ts
+++ b/src/server/models/User.ts
@@ -174,6 +174,21 @@ export class UserModel {
       params.push(input.passwordLocked ? 1 : 0);
     }
 
+    if (input.mfaEnabled !== undefined) {
+      updates.push('mfa_enabled = ?');
+      params.push(input.mfaEnabled ? 1 : 0);
+    }
+
+    if (input.mfaSecret !== undefined) {
+      updates.push('mfa_secret = ?');
+      params.push(input.mfaSecret);
+    }
+
+    if (input.mfaBackupCodes !== undefined) {
+      updates.push('mfa_backup_codes = ?');
+      params.push(input.mfaBackupCodes);
+    }
+
     if (updates.length === 0) {
       return this.findById(id);
     }

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -10784,40 +10784,48 @@ class DatabaseService {
    * Update MFA secret and backup codes for a user.
    */
   async updateUserMfaSecretAsync(userId: number, secret: string, backupCodes: string): Promise<void> {
-    if (!this.authRepo) {
-      throw new Error('Auth repository not initialized');
+    if (this.authRepo) {
+      await this.authRepo.updateUser(userId, { mfaSecret: secret, mfaBackupCodes: backupCodes });
+      return;
     }
-    await this.authRepo.updateUser(userId, { mfaSecret: secret, mfaBackupCodes: backupCodes });
+    // Fallback to sync for SQLite
+    this.userModel.update(userId, { mfaSecret: secret, mfaBackupCodes: backupCodes });
   }
 
   /**
    * Clear MFA data for a user (disable MFA).
    */
   async clearUserMfaAsync(userId: number): Promise<void> {
-    if (!this.authRepo) {
-      throw new Error('Auth repository not initialized');
+    if (this.authRepo) {
+      await this.authRepo.updateUser(userId, { mfaEnabled: false, mfaSecret: null, mfaBackupCodes: null });
+      return;
     }
-    await this.authRepo.updateUser(userId, { mfaEnabled: false, mfaSecret: null, mfaBackupCodes: null });
+    // Fallback to sync for SQLite
+    this.userModel.update(userId, { mfaEnabled: false, mfaSecret: null, mfaBackupCodes: null });
   }
 
   /**
    * Enable MFA for a user (set mfaEnabled to true).
    */
   async enableUserMfaAsync(userId: number): Promise<void> {
-    if (!this.authRepo) {
-      throw new Error('Auth repository not initialized');
+    if (this.authRepo) {
+      await this.authRepo.updateUser(userId, { mfaEnabled: true });
+      return;
     }
-    await this.authRepo.updateUser(userId, { mfaEnabled: true });
+    // Fallback to sync for SQLite
+    this.userModel.update(userId, { mfaEnabled: true });
   }
 
   /**
    * Update backup codes for a user (after one is consumed).
    */
   async consumeBackupCodeAsync(userId: number, remainingCodes: string): Promise<void> {
-    if (!this.authRepo) {
-      throw new Error('Auth repository not initialized');
+    if (this.authRepo) {
+      await this.authRepo.updateUser(userId, { mfaBackupCodes: remainingCodes });
+      return;
     }
-    await this.authRepo.updateUser(userId, { mfaBackupCodes: remainingCodes });
+    // Fallback to sync for SQLite
+    this.userModel.update(userId, { mfaBackupCodes: remainingCodes });
   }
 
   // ============ ASYNC CHANNEL DATABASE METHODS ============

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -39,6 +39,9 @@ export interface UpdateUserInput {
   displayName?: string;
   isActive?: boolean;
   passwordLocked?: boolean;
+  mfaEnabled?: boolean;
+  mfaSecret?: string | null;
+  mfaBackupCodes?: string | null;
 }
 
 export interface UserSession {


### PR DESCRIPTION
## Summary
- MFA setup/disable/enable failed on SQLite with "Auth repository not initialized" because the 4 MFA async methods in `DatabaseService` only used `authRepo` (PostgreSQL/MySQL only)
- Added SQLite fallback via `UserModel.update()` in all 4 methods, following the same pattern as `updatePasswordAsync`
- Added `mfaEnabled`, `mfaSecret`, `mfaBackupCodes` fields to `UpdateUserInput` interface and `UserModel.update()` to support the fallback

## Test plan
- [x] `npx vitest run src/server/routes/mfaRoutes.test.ts` — 20/20 passed
- [x] `npx vitest run src/server/models/User.test.ts` — 21/21 passed
- [x] `npx tsc --noEmit` — clean

Closes #1828

🤖 Generated with [Claude Code](https://claude.com/claude-code)