### PR TITLE
release: v3.4.9 hotfix

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.4.8",
+  "version": "3.4.9",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/public/news.json
+++ b/docs/public/news.json
@@ -1,7 +1,16 @@
 {
   "version": "1",
-  "lastUpdated": "2026-02-08T18:00:00Z",
+  "lastUpdated": "2026-02-08T22:00:00Z",
   "items": [
+    {
+      "minVersion": "3.4.9",
+      "id": "news-2026-02-08-hotfix-mfa-sqlite",
+      "title": "MeshMonitor v3.4.9 - Hotfix: MFA on SQLite",
+      "content": "MeshMonitor v3.4.9 is a hotfix release addressing two bugs:\n\n- **MFA on SQLite** (#1828) - Two-factor authentication setup, enable, disable, and backup code operations failed on SQLite (the default database) with \"Auth repository not initialized\". MFA now works correctly on all database backends.\n- **News popup dismiss** (#1827) - The news popup dismiss checkbox was not persisting correctly.",
+      "date": "2026-02-08T22:00:00Z",
+      "category": "bugfix",
+      "priority": "important"
+    },
     {
       "minVersion": "3.4.8",
       "id": "news-2026-02-08-autoack-mfa",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.4.8
-appVersion: "3.4.8"
+version: 3.4.9
+appVersion: "3.4.9"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.4.8",
+  "version": "3.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.4.8",
+      "version": "3.4.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.4.8",
+  "version": "3.4.9",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Hotfix release v3.4.9 addressing bugs introduced/discovered since v3.4.8.

## Changes since v3.4.8

- **fix: MFA on SQLite** - #1829 (closes #1828) — MFA setup/enable/disable/backup code operations failed on SQLite with "Auth repository not initialized". Added SQLite fallback via `UserModel.update()`.
- **fix: News popup dismiss** - #1827 — News popup dismiss checkbox was not persisting correctly.

## Checklist
- [x] Version bumped in `package.json`, `package-lock.json`, `Chart.yaml`, `tauri.conf.json`
- [x] News item added for v3.4.9
- [ ] System tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)