### PR TITLE
fix: MFA verification broken on SQLite - missing columns in SELECT queries

### DIFF
--- a/src/server/models/Permission.test.ts
+++ b/src/server/models/Permission.test.ts
@@ -17,6 +17,7 @@ import { migration as passwordLockedMigration } from '../migrations/023_add_pass
 import { migration as perChannelPermissionsMigration } from '../migrations/024_add_per_channel_permissions.js';
 import { migration as nodesPrivatePermissionMigration } from '../migrations/044_add_nodes_private_permission.js';
 import { migration as viewOnMapPermissionMigration } from '../migrations/053_add_view_on_map_permission.js';
+import { migration as mfaMigration } from '../migrations/068_add_mfa_columns.js';
 
 describe('PermissionModel', () => {
   let db: Database.Database;
@@ -41,6 +42,7 @@ describe('PermissionModel', () => {
     perChannelPermissionsMigration.up(db);
     nodesPrivatePermissionMigration.up(db);
     viewOnMapPermissionMigration.up(db);
+    mfaMigration.up(db);
 
     // Create model instances
     userModel = new UserModel(db);

--- a/src/server/models/User.ts
+++ b/src/server/models/User.ts
@@ -78,6 +78,7 @@ export class UserModel {
         id, username, password_hash as passwordHash, email, display_name as displayName,
         auth_provider as authProvider, oidc_subject as oidcSubject,
         is_admin as isAdmin, is_active as isActive, password_locked as passwordLocked,
+        mfa_enabled as mfaEnabled, mfa_secret as mfaSecret, mfa_backup_codes as mfaBackupCodes,
         created_at as createdAt, last_login_at as lastLoginAt, created_by as createdBy
       FROM users
       WHERE id = ?
@@ -98,6 +99,7 @@ export class UserModel {
         id, username, password_hash as passwordHash, email, display_name as displayName,
         auth_provider as authProvider, oidc_subject as oidcSubject,
         is_admin as isAdmin, is_active as isActive, password_locked as passwordLocked,
+        mfa_enabled as mfaEnabled, mfa_secret as mfaSecret, mfa_backup_codes as mfaBackupCodes,
         created_at as createdAt, last_login_at as lastLoginAt, created_by as createdBy
       FROM users
       WHERE username = ?
@@ -118,6 +120,7 @@ export class UserModel {
         id, username, password_hash as passwordHash, email, display_name as displayName,
         auth_provider as authProvider, oidc_subject as oidcSubject,
         is_admin as isAdmin, is_active as isActive, password_locked as passwordLocked,
+        mfa_enabled as mfaEnabled, mfa_secret as mfaSecret, mfa_backup_codes as mfaBackupCodes,
         created_at as createdAt, last_login_at as lastLoginAt, created_by as createdBy
       FROM users
       WHERE oidc_subject = ?
@@ -138,6 +141,7 @@ export class UserModel {
         id, username, password_hash as passwordHash, email, display_name as displayName,
         auth_provider as authProvider, oidc_subject as oidcSubject,
         is_admin as isAdmin, is_active as isActive, password_locked as passwordLocked,
+        mfa_enabled as mfaEnabled, mfa_secret as mfaSecret, mfa_backup_codes as mfaBackupCodes,
         created_at as createdAt, last_login_at as lastLoginAt, created_by as createdBy
       FROM users
       ORDER BY created_at DESC
@@ -301,6 +305,7 @@ export class UserModel {
         id, username, password_hash as passwordHash, email, display_name as displayName,
         auth_provider as authProvider, oidc_subject as oidcSubject,
         is_admin as isAdmin, is_active as isActive, password_locked as passwordLocked,
+        mfa_enabled as mfaEnabled, mfa_secret as mfaSecret, mfa_backup_codes as mfaBackupCodes,
         created_at as createdAt, last_login_at as lastLoginAt, created_by as createdBy
       FROM users
       WHERE LOWER(email) = LOWER(?)

--- a/src/server/routes/auditRoutes.test.ts
+++ b/src/server/routes/auditRoutes.test.ts
@@ -20,6 +20,7 @@ import { migration as passwordLockedMigration } from '../migrations/023_add_pass
 import { migration as perChannelPermissionsMigration } from '../migrations/024_add_per_channel_permissions.js';
 import { migration as nodesPrivatePermissionMigration } from '../migrations/044_add_nodes_private_permission.js';
 import { migration as viewOnMapPermissionMigration } from '../migrations/053_add_view_on_map_permission.js';
+import { migration as mfaMigration } from '../migrations/068_add_mfa_columns.js';
 import auditRoutes from './auditRoutes.js';
 import authRoutes from './authRoutes.js';
 
@@ -88,6 +89,7 @@ describe('Audit Log Routes', () => {
     perChannelPermissionsMigration.up(db);
     nodesPrivatePermissionMigration.up(db);
     viewOnMapPermissionMigration.up(db);
+    mfaMigration.up(db);
 
     userModel = new UserModel(db);
     permissionModel = new PermissionModel(db);

--- a/src/server/routes/authRoutes.test.ts
+++ b/src/server/routes/authRoutes.test.ts
@@ -22,6 +22,7 @@ import { migration as passwordLockedMigration } from '../migrations/023_add_pass
 import { migration as perChannelPermissionsMigration } from '../migrations/024_add_per_channel_permissions.js';
 import { migration as nodesPrivatePermissionMigration } from '../migrations/044_add_nodes_private_permission.js';
 import { migration as viewOnMapPermissionMigration } from '../migrations/053_add_view_on_map_permission.js';
+import { migration as mfaMigration } from '../migrations/068_add_mfa_columns.js';
 import authRoutes from './authRoutes.js';
 
 // Mock the DatabaseService to prevent auto-initialization
@@ -67,6 +68,7 @@ describe('Authentication Routes', () => {
     perChannelPermissionsMigration.up(db);
     nodesPrivatePermissionMigration.up(db);
     viewOnMapPermissionMigration.up(db);
+    mfaMigration.up(db);
 
     userModel = new UserModel(db);
     permissionModel = new PermissionModel(db);

--- a/src/server/routes/packetRoutes.test.ts
+++ b/src/server/routes/packetRoutes.test.ts
@@ -22,6 +22,7 @@ import { migration as passwordLockedMigration } from '../migrations/023_add_pass
 import { migration as perChannelPermissionsMigration } from '../migrations/024_add_per_channel_permissions.js';
 import { migration as nodesPrivatePermissionMigration } from '../migrations/044_add_nodes_private_permission.js';
 import { migration as viewOnMapPermissionMigration } from '../migrations/053_add_view_on_map_permission.js';
+import { migration as mfaMigration } from '../migrations/068_add_mfa_columns.js';
 import packetRoutes from './packetRoutes.js';
 
 // Mock the DatabaseService to prevent auto-initialization
@@ -72,6 +73,7 @@ describe('Packet Routes', () => {
     perChannelPermissionsMigration.up(db);
     nodesPrivatePermissionMigration.up(db);
     viewOnMapPermissionMigration.up(db);
+    mfaMigration.up(db);
 
     userModel = new UserModel(db);
     permissionModel = new PermissionModel(db);

--- a/src/server/routes/userRoutes.test.ts
+++ b/src/server/routes/userRoutes.test.ts
@@ -22,6 +22,7 @@ import { migration as passwordLockedMigration } from '../migrations/023_add_pass
 import { migration as perChannelPermissionsMigration } from '../migrations/024_add_per_channel_permissions.js';
 import { migration as nodesPrivatePermissionMigration } from '../migrations/044_add_nodes_private_permission.js';
 import { migration as viewOnMapPermissionMigration } from '../migrations/053_add_view_on_map_permission.js';
+import { migration as mfaMigration } from '../migrations/068_add_mfa_columns.js';
 import userRoutes from './userRoutes.js';
 import authRoutes from './authRoutes.js';
 
@@ -67,6 +68,7 @@ describe('User Management Routes', () => {
     perChannelPermissionsMigration.up(db);
     nodesPrivatePermissionMigration.up(db);
     viewOnMapPermissionMigration.up(db);
+    mfaMigration.up(db);
 
     userModel = new UserModel(db);
     permissionModel = new PermissionModel(db);

--- a/src/server/services/mfa.test.ts
+++ b/src/server/services/mfa.test.ts
@@ -53,6 +53,14 @@ describe('MfaService', () => {
       expect(result.otpauthUrl).toContain('alice');
     });
 
+    it('should not produce a double-issuer in the label', () => {
+      const result = service.generateSecret('testuser');
+
+      // The URI should NOT contain MeshMonitor:MeshMonitor (double issuer)
+      expect(result.otpauthUrl).not.toContain('MeshMonitor%3AMeshMonitor');
+      expect(result.otpauthUrl).not.toContain('MeshMonitor:MeshMonitor');
+    });
+
     it('should return a non-empty secret', () => {
       const result = service.generateSecret('testuser');
 

--- a/src/server/services/mfa.ts
+++ b/src/server/services/mfa.ts
@@ -24,7 +24,7 @@ export class MfaService {
     const otpauthUrl = generateURI({
       secret,
       issuer: SERVICE_NAME,
-      label: `${SERVICE_NAME}:${username}`
+      label: username
     });
     return { secret, otpauthUrl };
   }


### PR DESCRIPTION
## Summary
- Add `mfa_enabled`, `mfa_secret`, `mfa_backup_codes` to all 5 UserModel SQLite SELECT queries (`findById`, `findByUsername`, `findByOIDCSubject`, `findAll`, `findByEmail`) — these were missing, causing `mfaSecret` to always be `null` on SQLite
- Fix double-issuer in otpauth URI (`MeshMonitor:MeshMonitor:username` → `MeshMonitor:username`) in `mfa.ts`
- Add MFA migration (068) to 6 test files that use in-memory SQLite, and add new tests for MFA field retrieval and URI format

Follows up on #1829 which fixed the "Auth repository not initialized" error for MFA write operations.

## Test plan
- [x] `npx vitest run src/server/models/User.test.ts` — 24 tests pass (3 new MFA field tests)
- [x] `npx vitest run src/server/services/mfa.test.ts` — 27 tests pass (1 new double-issuer test)
- [x] `npx vitest run src/server/routes/mfaRoutes.test.ts` — 20 tests pass
- [x] Full test suite: 110/110 files pass, 2410 tests pass
- [x] TypeScript typecheck passes
- [x] Built and deployed on SQLite container, verified MFA columns present in deployed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)