### PR TITLE
feat: add gist support to gallery + Earthquake Alerts script (#1804)

### DIFF
--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -452,5 +452,29 @@
       "Recovery detection and notifications",
       "UTF-8 config with emoji support"
     ]
+  },
+  {
+    "name": "EQ (Earthquake Alerts)",
+    "filename": "mm_earthquake.py",
+    "icon": "🌎",
+    "description": "Automatically broadcasts USGS earthquake alerts for a configured location using Timer Triggers. Posts bulletins for NEW, UPDATED, and CLEARED alerts with smart deduplication to prevent mesh spam. Supports on-demand commands for earthquake summaries and detailed event info.",
+    "language": "Python",
+    "tags": ["Earthquake", "USGS", "Alerts", "Automation", "Timer Trigger", "GPS"],
+    "gistId": "1a8822b43981cab682c138fc4365cb90",
+    "exampleTrigger": "!eq, !eq detail 1, !eq help",
+    "requirements": [
+      "Python 3.8+",
+      "Internet connection for earthquake.usgs.gov",
+      "Configure EQ_LAT/EQ_LON in script"
+    ],
+    "author": "jeepnjonny",
+    "features": [
+      "Automatic alerts via Timer Triggers",
+      "Smart deduplication (NEW, UPDATED, CLEARED only)",
+      "On-demand earthquake summary queries",
+      "Configurable radius, magnitude threshold, and lookback window",
+      "Lightweight messages optimized for LoRa",
+      "No external dependencies (stdlib only)"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- Adds GitHub Gist support to the User Scripts Gallery, allowing scripts to be hosted as gists instead of requiring a full GitHub repository
- Adds the **EQ (Earthquake Alerts)** script by @jeepnjonny to the gallery (closes #1804)

### Gist Support Changes
- New optional `gistId` field in `user-scripts.json` for gist-hosted scripts
- `getSourceUrl()` returns `gist.github.com` URL when `gistId` is present
- `getGitHubApiUrl()` returns GitHub Gist API URL (CORS-friendly for public gists)
- `fetchScriptCode()` handles gist API response format (`files` object with raw content, not base64)

### New Script
- **EQ (Earthquake Alerts)** by jeepnjonny — broadcasts USGS earthquake alerts via Timer Triggers with smart deduplication, on-demand queries (!eq, !eq detail N, !eq help), configurable radius/magnitude/lookback

## Test plan
- [x] `npx vitest run` — 110 files, 2410 tests passing
- [ ] Visual verification: open docs gallery, confirm earthquake script appears
- [ ] Click "View Details" on earthquake script, verify code loads from gist
- [ ] Click "View Source" on earthquake script, verify links to gist page
- [ ] Verify existing (non-gist) scripts still load correctly

Closes #1804

🤖 Generated with [Claude Code](https://claude.com/claude-code)