### PR TITLE
feat: compact packet charts on Info tab (#1833)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1564,6 +1564,7 @@
   "info.tx_dropped": "TX Dropped:",
   "info.tx_relay": "TX Relay:",
   "info.tx_relay_canceled": "TX Relay Canceled:",
+  "info.radio_statistics": "Radio Statistics",
   "info.rx_statistics": "RX Statistics",
   "info.tx_statistics": "TX Statistics",
   "info.rx_good": "Good",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -2583,6 +2583,7 @@
     "position_config.gps_en_gpio": "Включение GPS GPIO",
     "backup_management.modal_title": "Сохраненные резервные копии",
     "telemetry_config.environment_interval": "Интервал обновления окружения (секунды)",
+    "info.radio_statistics": "Статистика радио",
     "info.rx_statistics": "Статистика RX",
     "automation.auto_ack.title": "Автоматическое подтверждение",
     "automation.auto_announce.scheduled_sends_description": "Используйте cron-выражение для планирования объявлений вместо фиксированного интервала",

--- a/src/App.css
+++ b/src/App.css
@@ -881,6 +881,18 @@ body {
   }
 }
 
+.packet-distribution-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 700px) {
+  .packet-distribution-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .info-section h3,
 .info-section-full-width h3,
 .info-section-wide h3 {


### PR DESCRIPTION
## Summary
- Combine "Packets by Device" and "Packets by Type" into a single **Packet Distribution** box with charts side by side
- Combine "RX Statistics" and "TX Statistics" into a single **Radio Statistics** box (single column width) with charts stacked vertically
- Fix tooltip text color on dark theme (was black on dark background, now uses theme text color)

### Layout changes
- Packet Distribution: full-width box, two charts side by side with stacked layout (donut above legend), responsive to single column on mobile
- Radio Statistics: single-column box, two charts stacked with horizontal layout (donut left, legend right)
- Long node names in legend now truncate with ellipsis

## Test plan
- [x] `npx vitest run` — 110 files, 2410 tests passing
- [x] Visual verification in dev container at localhost:8081/meshmonitor/
- [ ] Verify Radio Statistics box shows RX above TX in single column
- [ ] Verify Packet Distribution box shows Device and Type side by side
- [ ] Verify tooltips are readable on dark theme
- [ ] Verify responsive layout on narrow screens

Closes #1833

🤖 Generated with [Claude Code](https://claude.com/claude-code)