### PR TITLE
feat: highlight selected node during traceroute

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4739,6 +4739,15 @@ body {
   animation: node-pulse 1s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+.node-icon-highlight {
+  animation: node-highlight-pulse 2s ease-in-out infinite;
+}
+
+@keyframes node-highlight-pulse {
+  0%, 100% { filter: drop-shadow(0 0 4px rgba(137, 180, 250, 0.6)); }
+  50% { filter: drop-shadow(0 0 12px rgba(137, 180, 250, 1)); }
+}
+
 /* Footer Styles */
 .app-footer {
   background: var(--ctp-crust);

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1565,6 +1565,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                   shortName: node.user?.shortName,
                   showLabel: showLabel || shouldAnimate, // Show label when animating OR zoomed in
                   animate: shouldAnimate,
+                  highlightSelected: showRoute && isSelected,
                   pinStyle: mapPinStyle
                 });
 

--- a/src/utils/mapIcons.ts
+++ b/src/utils/mapIcons.ts
@@ -44,9 +44,10 @@ export function createNodeIcon(options: {
   shortName?: string;
   showLabel: boolean;
   animate?: boolean;
+  highlightSelected?: boolean;
   pinStyle?: 'meshmonitor' | 'official';
 }): L.DivIcon {
-  const { hops, isSelected, isRouter, shortName, showLabel, animate = false, pinStyle = 'meshmonitor' } = options;
+  const { hops, isSelected, isRouter, shortName, showLabel, animate = false, highlightSelected = false, pinStyle = 'meshmonitor' } = options;
   const color = getHopColor(hops);
   const size = isSelected ? 60 : 48;
   const strokeWidth = isSelected ? 3 : 2;
@@ -63,8 +64,13 @@ export function createNodeIcon(options: {
       </svg>
     `;
 
+    const classes = [
+      animate ? 'node-icon-pulse' : '',
+      highlightSelected ? 'node-icon-highlight' : ''
+    ].filter(Boolean).join(' ');
+
     const html = `
-      <div class="${animate ? 'node-icon-pulse' : ''}" style="position: relative; width: ${circleSize}px; height: ${circleSize}px;">
+      <div class="${classes}" style="position: relative; width: ${circleSize}px; height: ${circleSize}px;">
         ${markerSvg}
       </div>
     `;
@@ -125,8 +131,13 @@ export function createNodeIcon(options: {
     ">${shortName}</div>
   ` : '';
 
+  const classes = [
+    animate ? 'node-icon-pulse' : '',
+    highlightSelected ? 'node-icon-highlight' : ''
+  ].filter(Boolean).join(' ');
+
   const html = `
-    <div class="${animate ? 'node-icon-pulse' : ''}" style="position: relative; width: ${size}px; height: ${size}px;">
+    <div class="${classes}" style="position: relative; width: ${size}px; height: ${size}px;">
       ${markerSvg}
       ${label}
     </div>


### PR DESCRIPTION
## Summary
- Adds a persistent pulsing blue glow ring around the selected endpoint node when "Show Traceroute" is active
- The glow uses a `drop-shadow` CSS animation that pulses every 2 seconds
- Only activates when both `showRoute` is enabled and the node is the selected endpoint

Closes #1841

## Changes
- `src/utils/mapIcons.ts` — Added `highlightSelected` option to `createNodeIcon()`, applies `node-icon-highlight` CSS class
- `src/App.css` — Added `.node-icon-highlight` animation with `node-highlight-pulse` keyframes
- `src/components/NodesTab.tsx` — Passes `highlightSelected: showRoute && isSelected` to `createNodeIcon()`

## Test plan
- [x] `npx vitest run` — 110 test files passed, 2410 tests passing, 0 failures
- [ ] Enable "Show Traceroute" on a node with traceroute data — confirm selected node has pulsing blue glow
- [ ] Confirm non-selected nodes do NOT have the glow
- [ ] Disable "Show Traceroute" — confirm glow disappears
- [ ] Select a node without traceroute active — confirm normal behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)