### PR TITLE
chore: bump version to 3.4.11

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.4.10
-appVersion: "3.4.10"
+version: 3.4.11
+appVersion: "3.4.11"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.4.10",
+      "version": "3.4.11",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -4191,7 +4191,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4478,7 +4478,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
       "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -4511,6 +4511,7 @@
       "version": "19.2.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6804,6 +6805,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -12768,7 +12770,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -13410,14 +13413,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -14825,7 +14820,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/tests/test-reverse-proxy-oidc.sh
+++ b/tests/test-reverse-proxy-oidc.sh
@@ -19,7 +19,7 @@ NC='\033[0m' # No Color
 COMPOSE_FILE="docker-compose.oidc-test.yml"
 MESHMONITOR_CONTAINER="meshmonitor-oidc-test"
 OIDC_CONTAINER="mock-oidc-provider"
-TEST_PORT="8081"  # Same port as reverse-proxy test (tests run sequentially)
+TEST_PORT="8080"  # Must match the port meshdev.yeraze.online proxies to
 TEST_DOMAIN="https://meshdev.yeraze.online"
 TEST_URL="$TEST_DOMAIN"
 OIDC_ISSUER="https://oidc-mock.yeraze.online"
@@ -76,7 +76,7 @@ services:
       dockerfile: Dockerfile
     container_name: meshmonitor-oidc-test
     ports:
-      - "8081:3001"
+      - "8080:3001"
     volumes:
       - meshmonitor-oidc-test-data:/data
     environment:

--- a/tests/test-reverse-proxy.sh
+++ b/tests/test-reverse-proxy.sh
@@ -17,7 +17,7 @@ NC='\033[0m' # No Color
 
 COMPOSE_FILE="docker-compose.reverse-proxy-test.yml"
 CONTAINER_NAME="meshmonitor-reverse-proxy-test"
-TEST_PORT="8081"
+TEST_PORT="8080"
 
 # Configuration
 if [ -n "$TEST_EXTERNAL_PROXY_URL" ]; then
@@ -83,7 +83,7 @@ services:
       dockerfile: Dockerfile
     container_name: meshmonitor-reverse-proxy-test
     ports:
-      - "8081:3001"
+      - "8080:3001"
     volumes:
       - meshmonitor-reverse-proxy-test-data:/data
     environment:


### PR DESCRIPTION
## Summary
- Bump version to 3.4.11 across package.json, package-lock.json, Helm chart, and Tauri config
- Fix reverse proxy and OIDC system tests using wrong port (8081 → 8080) to match `meshdev.yeraze.online` proxy target

## Test plan
- [x] Unit tests: 2,410 passed, 0 failures (110 test files)
- [x] System tests: 9/9 passed (after port fix)
  - Configuration Import, Quick Start, Security, V1 API, Reverse Proxy, OIDC, Virtual Node CLI, Backup & Restore, Database Migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)