### PR TITLE
feat: document relayNode in v1 API and serve OpenAPI spec publicly

### DIFF
--- a/src/server/routes/v1/docs.ts
+++ b/src/server/routes/v1/docs.ts
@@ -36,6 +36,16 @@ const options = {
   }
 };
 
+// Serve raw OpenAPI spec as JSON
+router.get('/openapi.json', (_req, res) => {
+  res.json(swaggerDocument);
+});
+
+// Serve raw OpenAPI spec as YAML
+router.get('/openapi.yaml', (_req, res) => {
+  res.type('text/yaml').sendFile(openapiPath);
+});
+
 // Serve Swagger UI
 router.use('/', swaggerUi.serve);
 router.get('/', swaggerUi.setup(swaggerDocument, options));

--- a/src/server/routes/v1/openapi.yaml
+++ b/src/server/routes/v1/openapi.yaml
@@ -378,37 +378,75 @@ components:
           example: "!e5f6g7h8"
         channel:
           type: integer
-          description: Channel number
+          description: Channel number (-1 for direct messages)
           example: 0
-        messageType:
-          type: string
-          description: Type of message
-          example: "text"
+        portnum:
+          type: integer
+          description: Port number (Meshtastic app type, e.g. 1=TEXT_MESSAGE_APP)
+          example: 1
         text:
           type: string
           description: Message text content
           example: "Hello from the mesh!"
         timestamp:
-          type: integer
-          description: Unix timestamp
-          example: 1699564800
+          type: string
+          format: date-time
+          description: Message timestamp (ISO 8601)
+          example: "2024-11-09T14:00:00.000Z"
         rxTime:
           type: integer
-          description: Receive timestamp
+          description: Receive timestamp (Unix seconds from radio)
           example: 1699564802
         rxSnr:
           type: number
           format: float
-          description: Receive SNR
+          description: Receive SNR (signal-to-noise ratio in dB)
           example: 9.5
         rxRssi:
           type: integer
           description: Receive RSSI in dBm
           example: -95
+        hopStart:
+          type: integer
+          description: Original hop count when the packet was sent
+          example: 3
         hopLimit:
           type: integer
-          description: Hop limit
-          example: 3
+          description: Remaining hop count when received
+          example: 1
+        relayNode:
+          type: integer
+          description: Node number of the last node that relayed this message (0 if received directly)
+          example: 2715451348
+        replyId:
+          type: integer
+          description: Request ID of the message this is a reply to
+          example: 123456789
+        emoji:
+          type: integer
+          description: Emoji reaction (Unicode code point)
+          example: 0
+        viaMqtt:
+          type: boolean
+          description: Whether the message was received via MQTT bridge
+          example: false
+        deliveryState:
+          type: string
+          description: Delivery state for outbound messages
+          enum: [delivered, confirmed, failed]
+          example: "delivered"
+        wantAck:
+          type: boolean
+          description: Whether the message requested acknowledgment
+          example: false
+        ackFailed:
+          type: boolean
+          description: Whether acknowledgment failed
+          example: false
+        routingErrorReceived:
+          type: boolean
+          description: Whether a routing error was received for this message
+          example: false
 
     MessageListResponse:
       type: object


### PR DESCRIPTION
## Summary
- **relayNode** field was already returned by the V1 messages endpoints but not documented in the OpenAPI spec — now documented along with other missing fields (`hopStart`, `viaMqtt`, `replyId`, `emoji`, `deliveryState`, `wantAck`, `ackFailed`, `routingErrorReceived`)
- **OpenAPI spec now publicly accessible** at `/api/v1/docs/openapi.json` and `/api/v1/docs/openapi.yaml` without requiring bearer token authentication

## Changes
- Updated `Message` schema in `openapi.yaml` to include all fields actually returned by the API
- Added `GET /openapi.json` and `GET /openapi.yaml` routes to `docs.ts`, served before the Swagger UI catch-all (both under the existing public `/docs` mount)

## Test plan
- [ ] `GET /api/v1/docs/openapi.json` returns full spec without auth
- [ ] `GET /api/v1/docs/openapi.yaml` returns full spec without auth
- [ ] Swagger UI at `/api/v1/docs` still works
- [ ] `GET /api/v1/messages` (with token) includes `relayNode` in response
- [ ] Verify unit tests pass (2410 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)