### PR TITLE
fix: always verify auto_traceroute_nodes enabled column exists on startup

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -2125,14 +2125,10 @@ class DatabaseService {
   private runAutoTracerouteEnabledMigration(): void {
     try {
       const migrationKey = 'migration_060_auto_traceroute_enabled';
-      const migrationCompleted = this.getSetting(migrationKey);
-
-      if (migrationCompleted === 'completed') {
-        logger.debug('✅ Auto traceroute enabled column migration already completed');
-        return;
-      }
-
-      logger.debug('Running migration 060: Add enabled column to auto_traceroute_nodes...');
+      // Always run the migration check - it's idempotent and verifies
+      // the column exists regardless of whether it was previously marked complete.
+      // This guards against edge cases where the setting was marked complete
+      // but the column is actually missing (e.g., restored backups).
       autoTracerouteEnabledMigration.up(this.db);
       this.setSetting(migrationKey, 'completed');
       logger.debug('✅ Auto traceroute enabled column migration completed successfully');


### PR DESCRIPTION
## Summary
- Fixes `SqliteError: table auto_traceroute_nodes has no column named enabled` reported by Docker/SQLite users
- Removes the early-return guard in `runAutoTracerouteEnabledMigration()` that skipped migration 060 when marked complete
- The migration's `.up()` is already idempotent (checks `PRAGMA table_info` before adding the column), so running it every startup is safe and cheap (two PRAGMA queries)
- Guards against edge cases where the migration setting was marked complete but the column is missing (e.g., restored backups, volume issues)

Fixes #1860

## Test plan
- [x] Unit tests pass (2410 tests, 0 failures)
- [ ] Verify on a fresh SQLite database that the column is created
- [ ] Verify on a database where the column already exists that startup completes without error
- [ ] Verify on a database where the setting is marked complete but column is missing that the column gets added

🤖 Generated with [Claude Code](https://claude.com/claude-code)