### PR TITLE
fix: broadcast outgoing text messages to virtual node clients

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6703,6 +6703,29 @@ class MeshtasticManager {
         }
       }
 
+      // Broadcast outgoing text message to virtual node clients as a proper FromRadio
+      const virtualNodeServer = (global as any).virtualNodeServer;
+      if (virtualNodeServer && localNodeNum) {
+        try {
+          const fromRadioData = await meshtasticProtobufService.createFromRadioTextMessage({
+            fromNodeNum: parseInt(localNodeNum),
+            toNodeNum: destination || 0xffffffff,
+            text: text,
+            channel: destination ? -1 : channel,
+            timestamp: Date.now(),
+            requestId: messageId,
+            replyId: replyId || null,
+            emoji: emoji || null,
+          });
+          if (fromRadioData) {
+            await virtualNodeServer.broadcastToClients(fromRadioData);
+            logger.debug(`📡 Broadcasted outgoing text message to virtual node clients`);
+          }
+        } catch (error) {
+          logger.error('Virtual node: Failed to broadcast outgoing text message:', error);
+        }
+      }
+
       return messageId;
     } catch (error) {
       logger.error('Error sending message:', error);


### PR DESCRIPTION
## Summary
- Fixes virtual node clients (Potato, Home Assistant) not seeing outgoing text messages sent from the MeshMonitor web UI
- After sending a message to the physical node and saving to the database, constructs a proper `FromRadio`-wrapped `MeshPacket` using the existing `createFromRadioTextMessage()` helper and broadcasts it to all connected virtual node clients
- Non-blocking: broadcast errors are logged but don't fail the send operation

Closes #1859

## Test plan
- [x] Unit tests pass (2410 passed, 0 failures)
- [ ] Manual test: send a message from MeshMonitor web UI and verify it appears correctly in a Potato/Meshtastic app connected via virtual node
- [ ] Verify both channel broadcasts and DMs are received by virtual node clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)