### PR TITLE
fix: snapshot node positions at traceroute time (#1862)

### DIFF
--- a/src/db/schema/traceroutes.ts
+++ b/src/db/schema/traceroutes.ts
@@ -3,7 +3,7 @@
  * Supports SQLite, PostgreSQL, and MySQL
  */
 import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
-import { pgTable, text as pgText, real as pgReal, boolean as pgBoolean, bigint as pgBigint, serial as pgSerial } from 'drizzle-orm/pg-core';
+import { pgTable, text as pgText, real as pgReal, doublePrecision as pgDouble, boolean as pgBoolean, bigint as pgBigint, serial as pgSerial } from 'drizzle-orm/pg-core';
 import { mysqlTable, varchar as myVarchar, text as myText, double as myDouble, boolean as myBoolean, bigint as myBigint, serial as mySerial } from 'drizzle-orm/mysql-core';
 import { nodesSqlite, nodesPostgres, nodesMysql } from './nodes.js';
 
@@ -18,6 +18,7 @@ export const traceroutesSqlite = sqliteTable('traceroutes', {
   routeBack: text('routeBack'), // JSON string of return path
   snrTowards: text('snrTowards'), // JSON string of SNR values
   snrBack: text('snrBack'), // JSON string of return SNR values
+  routePositions: text('routePositions'), // JSON: { nodeNum: { lat, lng, alt? } } position snapshot at traceroute time
   timestamp: integer('timestamp').notNull(),
   createdAt: integer('createdAt').notNull(),
 });
@@ -30,6 +31,10 @@ export const routeSegmentsSqlite = sqliteTable('route_segments', {
   toNodeId: text('toNodeId').notNull(),
   distanceKm: real('distanceKm').notNull(),
   isRecordHolder: integer('isRecordHolder', { mode: 'boolean' }).default(false),
+  fromLatitude: real('fromLatitude'), // latitude of fromNode at recording time
+  fromLongitude: real('fromLongitude'), // longitude of fromNode at recording time
+  toLatitude: real('toLatitude'), // latitude of toNode at recording time
+  toLongitude: real('toLongitude'), // longitude of toNode at recording time
   timestamp: integer('timestamp').notNull(),
   createdAt: integer('createdAt').notNull(),
 });
@@ -45,6 +50,7 @@ export const traceroutesPostgres = pgTable('traceroutes', {
   routeBack: pgText('routeBack'), // JSON string of return path
   snrTowards: pgText('snrTowards'), // JSON string of SNR values
   snrBack: pgText('snrBack'), // JSON string of return SNR values
+  routePositions: pgText('routePositions'), // JSON: { nodeNum: { lat, lng, alt? } } position snapshot at traceroute time
   timestamp: pgBigint('timestamp', { mode: 'number' }).notNull(),
   createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
 });
@@ -57,6 +63,10 @@ export const routeSegmentsPostgres = pgTable('route_segments', {
   toNodeId: pgText('toNodeId').notNull(),
   distanceKm: pgReal('distanceKm').notNull(),
   isRecordHolder: pgBoolean('isRecordHolder').default(false),
+  fromLatitude: pgDouble('fromLatitude'), // latitude of fromNode at recording time
+  fromLongitude: pgDouble('fromLongitude'), // longitude of fromNode at recording time
+  toLatitude: pgDouble('toLatitude'), // latitude of toNode at recording time
+  toLongitude: pgDouble('toLongitude'), // longitude of toNode at recording time
   timestamp: pgBigint('timestamp', { mode: 'number' }).notNull(),
   createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
 });
@@ -72,6 +82,7 @@ export const traceroutesMysql = mysqlTable('traceroutes', {
   routeBack: myText('routeBack'), // JSON string of return path
   snrTowards: myText('snrTowards'), // JSON string of SNR values
   snrBack: myText('snrBack'), // JSON string of return SNR values
+  routePositions: myText('routePositions'), // JSON: { nodeNum: { lat, lng, alt? } } position snapshot at traceroute time
   timestamp: myBigint('timestamp', { mode: 'number' }).notNull(),
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
 });
@@ -84,6 +95,10 @@ export const routeSegmentsMysql = mysqlTable('route_segments', {
   toNodeId: myVarchar('toNodeId', { length: 32 }).notNull(),
   distanceKm: myDouble('distanceKm').notNull(),
   isRecordHolder: myBoolean('isRecordHolder').default(false),
+  fromLatitude: myDouble('fromLatitude'), // latitude of fromNode at recording time
+  fromLongitude: myDouble('fromLongitude'), // longitude of fromNode at recording time
+  toLatitude: myDouble('toLatitude'), // latitude of toNode at recording time
+  toLongitude: myDouble('toLongitude'), // longitude of toNode at recording time
   timestamp: myBigint('timestamp', { mode: 'number' }).notNull(),
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
 });

--- a/src/hooks/usePoll.ts
+++ b/src/hooks/usePoll.ts
@@ -108,6 +108,7 @@ export interface PollTraceroute {
   routeBack: string;
   snrTowards: string;
   snrBack: string;
+  routePositions?: string; // JSON: { [nodeNum]: { lat, lng, alt? } } - position snapshot at traceroute time
   timestamp: number;
   createdAt: number;
   hopCount: number;

--- a/src/server/migrations/069_add_traceroute_positions.ts
+++ b/src/server/migrations/069_add_traceroute_positions.ts
@@ -1,0 +1,280 @@
+/**
+ * Migration 069: Add position snapshot columns to traceroutes and route_segments tables
+ *
+ * Fixes issue #1862: Traceroutes through moving nodes show incorrect positions
+ *
+ * traceroutes table:
+ * - routePositions (TEXT) - JSON object mapping nodeNum to {lat, lng, alt?} at traceroute time
+ *
+ * route_segments table:
+ * - fromLatitude (REAL) - latitude of fromNode at recording time
+ * - fromLongitude (REAL) - longitude of fromNode at recording time
+ * - toLatitude (REAL) - latitude of toNode at recording time
+ * - toLongitude (REAL) - longitude of toNode at recording time
+ */
+
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.debug('Running migration 069: Add position snapshot columns to traceroutes and route_segments');
+
+    try {
+      // Check traceroutes columns
+      const tracerouteColumns = db.pragma("table_info('traceroutes')") as Array<{ name: string }>;
+      const tracerouteColumnNames = new Set(tracerouteColumns.map((col) => col.name));
+
+      if (!tracerouteColumnNames.has('routePositions')) {
+        db.exec(`ALTER TABLE traceroutes ADD COLUMN routePositions TEXT`);
+        logger.debug('Added routePositions column to traceroutes table');
+      } else {
+        logger.debug('routePositions column already exists, skipping');
+      }
+
+      // Check route_segments columns
+      const segmentColumns = db.pragma("table_info('route_segments')") as Array<{ name: string }>;
+      const segmentColumnNames = new Set(segmentColumns.map((col) => col.name));
+
+      if (!segmentColumnNames.has('fromLatitude')) {
+        db.exec(`ALTER TABLE route_segments ADD COLUMN fromLatitude REAL`);
+        logger.debug('Added fromLatitude column to route_segments table');
+      } else {
+        logger.debug('fromLatitude column already exists, skipping');
+      }
+
+      if (!segmentColumnNames.has('fromLongitude')) {
+        db.exec(`ALTER TABLE route_segments ADD COLUMN fromLongitude REAL`);
+        logger.debug('Added fromLongitude column to route_segments table');
+      } else {
+        logger.debug('fromLongitude column already exists, skipping');
+      }
+
+      if (!segmentColumnNames.has('toLatitude')) {
+        db.exec(`ALTER TABLE route_segments ADD COLUMN toLatitude REAL`);
+        logger.debug('Added toLatitude column to route_segments table');
+      } else {
+        logger.debug('toLatitude column already exists, skipping');
+      }
+
+      if (!segmentColumnNames.has('toLongitude')) {
+        db.exec(`ALTER TABLE route_segments ADD COLUMN toLongitude REAL`);
+        logger.debug('Added toLongitude column to route_segments table');
+      } else {
+        logger.debug('toLongitude column already exists, skipping');
+      }
+
+      logger.debug('Migration 069 completed: Position snapshot columns added');
+    } catch (error) {
+      logger.error('Migration 069 failed:', error);
+      throw error;
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Running migration 069 down: Remove position snapshot columns');
+
+    try {
+      logger.debug('Note: SQLite DROP COLUMN requires version 3.35.0+');
+      logger.debug('The position snapshot columns will remain but will not be used');
+
+      logger.debug('Migration 069 rollback completed');
+    } catch (error) {
+      logger.error('Migration 069 rollback failed:', error);
+      throw error;
+    }
+  }
+};
+
+/**
+ * PostgreSQL migration: Add position snapshot columns
+ */
+export async function runMigration069Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.debug('Running migration 069 (PostgreSQL): Add position snapshot columns');
+
+  try {
+    // Check and add routePositions column to traceroutes
+    const routePositionsExists = await client.query(`
+      SELECT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'traceroutes'
+          AND column_name = 'routePositions'
+      )
+    `);
+
+    if (!routePositionsExists.rows[0].exists) {
+      await client.query(`ALTER TABLE traceroutes ADD COLUMN "routePositions" TEXT`);
+      logger.debug('Added routePositions column to traceroutes table');
+    } else {
+      logger.debug('routePositions column already exists, skipping');
+    }
+
+    // Check and add fromLatitude column to route_segments
+    const fromLatitudeExists = await client.query(`
+      SELECT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'route_segments'
+          AND column_name = 'fromLatitude'
+      )
+    `);
+
+    if (!fromLatitudeExists.rows[0].exists) {
+      await client.query(`ALTER TABLE route_segments ADD COLUMN "fromLatitude" DOUBLE PRECISION`);
+      logger.debug('Added fromLatitude column to route_segments table');
+    } else {
+      logger.debug('fromLatitude column already exists, skipping');
+    }
+
+    // Check and add fromLongitude column to route_segments
+    const fromLongitudeExists = await client.query(`
+      SELECT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'route_segments'
+          AND column_name = 'fromLongitude'
+      )
+    `);
+
+    if (!fromLongitudeExists.rows[0].exists) {
+      await client.query(`ALTER TABLE route_segments ADD COLUMN "fromLongitude" DOUBLE PRECISION`);
+      logger.debug('Added fromLongitude column to route_segments table');
+    } else {
+      logger.debug('fromLongitude column already exists, skipping');
+    }
+
+    // Check and add toLatitude column to route_segments
+    const toLatitudeExists = await client.query(`
+      SELECT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'route_segments'
+          AND column_name = 'toLatitude'
+      )
+    `);
+
+    if (!toLatitudeExists.rows[0].exists) {
+      await client.query(`ALTER TABLE route_segments ADD COLUMN "toLatitude" DOUBLE PRECISION`);
+      logger.debug('Added toLatitude column to route_segments table');
+    } else {
+      logger.debug('toLatitude column already exists, skipping');
+    }
+
+    // Check and add toLongitude column to route_segments
+    const toLongitudeExists = await client.query(`
+      SELECT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'route_segments'
+          AND column_name = 'toLongitude'
+      )
+    `);
+
+    if (!toLongitudeExists.rows[0].exists) {
+      await client.query(`ALTER TABLE route_segments ADD COLUMN "toLongitude" DOUBLE PRECISION`);
+      logger.debug('Added toLongitude column to route_segments table');
+    } else {
+      logger.debug('toLongitude column already exists, skipping');
+    }
+
+    logger.debug('Migration 069 (PostgreSQL): Position snapshot columns added');
+  } catch (error) {
+    logger.error('Migration 069 (PostgreSQL) failed:', error);
+    throw error;
+  }
+}
+
+/**
+ * MySQL migration: Add position snapshot columns
+ */
+export async function runMigration069Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.debug('Running migration 069 (MySQL): Add position snapshot columns');
+
+  try {
+    const connection = await pool.getConnection();
+    try {
+      // Check and add routePositions column to traceroutes
+      const [routePositionsCols] = await connection.query(`
+        SELECT COLUMN_NAME FROM information_schema.columns
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'traceroutes'
+          AND COLUMN_NAME = 'routePositions'
+      `);
+
+      if ((routePositionsCols as any[]).length === 0) {
+        await connection.query(`ALTER TABLE traceroutes ADD COLUMN routePositions TEXT`);
+        logger.debug('Added routePositions column to traceroutes table');
+      } else {
+        logger.debug('routePositions column already exists, skipping');
+      }
+
+      // Check and add fromLatitude column to route_segments
+      const [fromLatCols] = await connection.query(`
+        SELECT COLUMN_NAME FROM information_schema.columns
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'route_segments'
+          AND COLUMN_NAME = 'fromLatitude'
+      `);
+
+      if ((fromLatCols as any[]).length === 0) {
+        await connection.query(`ALTER TABLE route_segments ADD COLUMN fromLatitude DOUBLE`);
+        logger.debug('Added fromLatitude column to route_segments table');
+      } else {
+        logger.debug('fromLatitude column already exists, skipping');
+      }
+
+      // Check and add fromLongitude column to route_segments
+      const [fromLngCols] = await connection.query(`
+        SELECT COLUMN_NAME FROM information_schema.columns
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'route_segments'
+          AND COLUMN_NAME = 'fromLongitude'
+      `);
+
+      if ((fromLngCols as any[]).length === 0) {
+        await connection.query(`ALTER TABLE route_segments ADD COLUMN fromLongitude DOUBLE`);
+        logger.debug('Added fromLongitude column to route_segments table');
+      } else {
+        logger.debug('fromLongitude column already exists, skipping');
+      }
+
+      // Check and add toLatitude column to route_segments
+      const [toLatCols] = await connection.query(`
+        SELECT COLUMN_NAME FROM information_schema.columns
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'route_segments'
+          AND COLUMN_NAME = 'toLatitude'
+      `);
+
+      if ((toLatCols as any[]).length === 0) {
+        await connection.query(`ALTER TABLE route_segments ADD COLUMN toLatitude DOUBLE`);
+        logger.debug('Added toLatitude column to route_segments table');
+      } else {
+        logger.debug('toLatitude column already exists, skipping');
+      }
+
+      // Check and add toLongitude column to route_segments
+      const [toLngCols] = await connection.query(`
+        SELECT COLUMN_NAME FROM information_schema.columns
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'route_segments'
+          AND COLUMN_NAME = 'toLongitude'
+      `);
+
+      if ((toLngCols as any[]).length === 0) {
+        await connection.query(`ALTER TABLE route_segments ADD COLUMN toLongitude DOUBLE`);
+        logger.debug('Added toLongitude column to route_segments table');
+      } else {
+        logger.debug('toLongitude column already exists, skipping');
+      }
+
+      logger.debug('Migration 069 (MySQL): Position snapshot columns added');
+    } finally {
+      connection.release();
+    }
+  } catch (error) {
+    logger.error('Migration 069 (MySQL) failed:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes #1862: Traceroutes through moving nodes now render at the correct historical positions instead of the node's current location
- Adds migration 069 to store position snapshots in `traceroutes.routePositions` (JSON) and `route_segments.fromLatitude/fromLongitude/toLatitude/toLongitude` columns across all three database backends (SQLite, PostgreSQL, MySQL)
- Backend snapshots all node positions at traceroute completion time via `processTracerouteMessage()`
- Frontend prefers snapshot positions over current positions when rendering, with graceful fallback for legacy data

## Test plan

- [x] `npx vitest run` — all 110 test files pass (2410 tests, 0 failures)
- [ ] Build: `docker compose -f docker-compose.dev.yml build`
- [ ] Start: `docker compose -f docker-compose.dev.yml up -d`
- [ ] Verify migration 069 ran (check logs for "migration 069")
- [ ] Trigger a traceroute from the web UI
- [ ] Check API response includes `routePositions` field: `./scripts/api-test.sh get /api/traceroutes/recent | jq '.[0].routePositions'`
- [ ] Verify traceroute renders correctly on the map with snapshot positions
- [ ] Verify old traceroutes (without snapshot data) still render using current node positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)