### PR TITLE
feat: add Remote Admin icon and filter to map node list

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -188,6 +188,7 @@
   "nodes.has_telemetry": "Has Telemetry Data",
   "nodes.has_weather": "Has Weather Data",
   "nodes.has_pkc": "Has Public Key Cryptography",
+  "nodes.has_remote_admin": "Remote Admin Verified",
   "nodes.mobile_node": "Mobile Node (position varies > 1km)",
   "nodes.node_address": "Node Address",
   "nodes.last_heard": "Last Heard",
@@ -999,6 +1000,9 @@
   "node_filter.secure_channel_warning": "Recommended for secure channels.",
   "node_filter.hide_ignored": "Hide ignored nodes",
   "node_filter.ignored_help": "Ignored nodes can be un-ignored from the Node Details page.",
+  "node_filter.remote_admin_only": "Remote Admin available only",
+  "node_filter.remote_admin_help": "Show only nodes with verified Remote Admin capability.",
+  "node_filter.remote_admin": "Remote Admin",
 
   "relay_modal.title_ack": "Message Acknowledgment",
   "relay_modal.title_relay": "Message Relay Information",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,6 +182,7 @@ function App() {
       minHops: 0,
       maxHops: 10,
       showPKI: false,
+      showRemoteAdmin: false,
       showUnknown: false,
       showIgnored: false,
       deviceRoles: [] as number[], // Empty array means show all roles
@@ -3657,6 +3658,13 @@ function App() {
       // PKI filter
       if (nodeFilters.showPKI) {
         const matches = nodeId && nodesWithPKC.has(nodeId);
+        if (isShowMode && !matches) return false;
+        if (!isShowMode && matches) return false;
+      }
+
+      // Remote Admin filter
+      if (nodeFilters.showRemoteAdmin) {
+        const matches = !!node.hasRemoteAdmin;
         if (isShowMode && !matches) return false;
         if (!isShowMode && matches) return false;
       }

--- a/src/components/AdvancedNodeFilterPopup/AdvancedNodeFilterPopup.tsx
+++ b/src/components/AdvancedNodeFilterPopup/AdvancedNodeFilterPopup.tsx
@@ -25,6 +25,7 @@ const DEFAULT_FILTERS: NodeFilters = {
   minHops: 0,
   maxHops: 10,
   showPKI: false,
+  showRemoteAdmin: false,
   showUnknown: false,
   showIgnored: false,
   deviceRoles: [],
@@ -226,6 +227,18 @@ export const AdvancedNodeFilterPopup: React.FC<AdvancedNodeFilterPopupProps> = (
               <span className="filter-label-with-icon">
                 <span className="filter-icon">🔐</span>
                 <span>{t('node_filter.pkc', 'Public Key Crypto')}</span>
+              </span>
+            </label>
+
+            <label className="filter-checkbox">
+              <input
+                type="checkbox"
+                checked={nodeFilters.showRemoteAdmin}
+                onChange={e => onNodeFiltersChange({ ...nodeFilters, showRemoteAdmin: e.target.checked })}
+              />
+              <span className="filter-label-with-icon">
+                <span className="filter-icon">🛠️</span>
+                <span>{t('node_filter.remote_admin', 'Remote Admin')}</span>
               </span>
             </label>
 

--- a/src/components/NodeFilterPopup.tsx
+++ b/src/components/NodeFilterPopup.tsx
@@ -22,6 +22,8 @@ export const NodeFilterPopup: React.FC<NodeFilterPopupProps> = ({ isOpen, onClos
     setShowIncompleteNodes,
     showIgnoredNodes,
     setShowIgnoredNodes,
+    filterRemoteAdminOnly,
+    setFilterRemoteAdminOnly,
   } = useUI();
   const { channels } = useChannels();
 
@@ -126,6 +128,21 @@ export const NodeFilterPopup: React.FC<NodeFilterPopupProps> = ({ isOpen, onClos
             </label>
             <div className="filter-help-text">
               {t('node_filter.ignored_help')}
+            </div>
+          </div>
+
+          {/* Remote Admin Filter */}
+          <div className="filter-section">
+            <label className="filter-checkbox-label">
+              <input
+                type="checkbox"
+                checked={filterRemoteAdminOnly}
+                onChange={(e) => setFilterRemoteAdminOnly(e.target.checked)}
+              />
+              <span>{t('node_filter.remote_admin_only')}</span>
+            </label>
+            <div className="filter-help-text">
+              {t('node_filter.remote_admin_help')}
             </div>
           </div>
         </div>

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -250,6 +250,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     setShowNodeFilterPopup,
     isNodeListCollapsed,
     setIsNodeListCollapsed,
+    filterRemoteAdminOnly,
   } = useUI();
 
   const {
@@ -1078,9 +1079,13 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 if (!showIncompleteNodes && !isNodeComplete(node)) {
                   return false;
                 }
+                // Remote admin filter
+                if (filterRemoteAdminOnly && !node.hasRemoteAdmin) {
+                  return false;
+                }
                 return true;
               }).length;
-              const isFiltered = securityFilter !== 'all' || !showIncompleteNodes;
+              const isFiltered = securityFilter !== 'all' || !showIncompleteNodes || filterRemoteAdminOnly;
               return isFiltered ? `${filteredCount}/${processedNodes.length}` : processedNodes.length;
             })()})</h3>
           </div>
@@ -1186,6 +1191,11 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 return false;
               }
 
+              // Remote admin filter
+              if (filterRemoteAdminOnly && !node.hasRemoteAdmin) {
+                return false;
+              }
+
               return true;
             });
 
@@ -1237,6 +1247,9 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                       )}
                       {node.user?.id && nodesWithPKC.has(node.user.id) && (
                         <span className="node-indicator-icon" title={t('nodes.has_pkc')}>🔐</span>
+                      )}
+                      {node.hasRemoteAdmin && (
+                        <span className="node-indicator-icon" title={t('nodes.has_remote_admin')}>🛠️</span>
                       )}
                       {hasPermission('messages', 'read') && (
                         <button

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -121,6 +121,8 @@ interface UIContextType {
   setIsNodeListCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
   showIgnoredNodes: boolean;
   setShowIgnoredNodes: React.Dispatch<React.SetStateAction<boolean>>;
+  filterRemoteAdminOnly: boolean;
+  setFilterRemoteAdminOnly: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const UIContext = createContext<UIContextType | undefined>(undefined);
@@ -222,6 +224,7 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
   });
   // Default to hiding ignored nodes
   const [showIgnoredNodes, setShowIgnoredNodes] = useState<boolean>(false);
+  const [filterRemoteAdminOnly, setFilterRemoteAdminOnly] = useState<boolean>(false);
 
   // Wrapper setter for showMqttMessages that persists to localStorage
   const setShowMqttMessages = React.useCallback((value: React.SetStateAction<boolean>) => {
@@ -369,6 +372,8 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
         setIsNodeListCollapsed,
         showIgnoredNodes,
         setShowIgnoredNodes,
+        filterRemoteAdminOnly,
+        setFilterRemoteAdminOnly,
       }}
     >
       {children}

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -82,6 +82,7 @@ export interface NodeFilters {
   minHops: number;
   maxHops: number;
   showPKI: boolean;
+  showRemoteAdmin: boolean;
   showUnknown: boolean;
   showIgnored: boolean;
   deviceRoles: number[];


### PR DESCRIPTION
## Summary
- Adds a 🛠️ indicator icon in the map sidebar node list for nodes with verified Remote Admin capability (`hasRemoteAdmin === true`), positioned after the PKC icon (🔐)
- Adds a "Remote Admin" checkbox filter to the **Advanced Node Filter Popup** (map page) under Node Features, supporting both Show/Hide filter modes
- Adds a "Remote Admin available only" checkbox to the **Simple Node Filter Popup** (used in Messages tab) for filtering to Remote Admin nodes only
- Includes all necessary localization strings

## Test plan
- [x] `npx vitest run src/components/NodesTab.test.tsx` — 7/7 tests pass
- [ ] Visual check: nodes with `hasRemoteAdmin: true` show 🛠️ icon in map sidebar
- [ ] Filter popup: "Remote Admin" checkbox appears in Node Features section
- [ ] Filter works in both "Show only" and "Hide matching" modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)