### PR TITLE
feat: show successful nodes first in Remote Admin Scanner log

### DIFF
--- a/src/components/RemoteAdminScannerSection.tsx
+++ b/src/components/RemoteAdminScannerSection.tsx
@@ -92,10 +92,9 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
           });
 
           // Build scan log from recent checks
-          const recentlyChecked = nodesWithPublicKey
+          // Show successful nodes first, then fill remaining slots with failed entries
+          const checkedNodes = nodesWithPublicKey
             .filter((n: any) => n.lastRemoteAdminCheck)
-            .sort((a: any, b: any) => (b.lastRemoteAdminCheck || 0) - (a.lastRemoteAdminCheck || 0))
-            .slice(0, 20)
             .map((n: any) => {
               let firmwareVersion = null;
               if (n.remoteAdminMetadata) {
@@ -114,7 +113,20 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
                 firmwareVersion,
               };
             });
-          setScanLog(recentlyChecked);
+
+          const successEntries = checkedNodes
+            .filter((e: ScanLogEntry) => e.hasRemoteAdmin)
+            .sort((a: ScanLogEntry, b: ScanLogEntry) => b.timestamp - a.timestamp);
+          const failedEntries = checkedNodes
+            .filter((e: ScanLogEntry) => !e.hasRemoteAdmin)
+            .sort((a: ScanLogEntry, b: ScanLogEntry) => b.timestamp - a.timestamp);
+
+          const maxEntries = 20;
+          const combined = [
+            ...successEntries,
+            ...failedEntries.slice(0, Math.max(0, maxEntries - successEntries.length)),
+          ];
+          setScanLog(combined);
         }
       } catch (error) {
         console.error('Failed to fetch scan log:', error);


### PR DESCRIPTION
## Summary
- Reorders the Remote Admin Scanner activity log so that nodes with remote admin **enabled** (successful scans) always appear at the top, sorted by most recent check time
- Remaining log slots (up to 20 total) are filled with failed scan entries
- Makes it easier to see at a glance which nodes have confirmed remote admin access

## Test plan
- [x] Verified build compiles without type errors
- [x] Deployed to dev container and visually confirmed successful nodes appear first in the log
- [ ] Check with mix of successful and failed entries to confirm ordering
- [ ] Verify log still shows "no entries" when no scans have been performed

🤖 Generated with [Claude Code](https://claude.com/claude-code)