### PR TITLE
feat: add time window schedule for Auto Traceroute and Remote Admin Scanner

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2146,6 +2146,8 @@
   "automation.auto_traceroute.no_log_entries": "No auto-traceroutes logged yet. Entries will appear here as traceroutes are sent.",
   "automation.auto_traceroute.sort_by_hops": "Prioritize Closer Nodes",
   "automation.auto_traceroute.sort_by_hops_description": "When enabled, nodes with fewer hops are tracerouted first. This is useful in dense networks where traceroutes to distant nodes often fail. When disabled, nodes are selected randomly.",
+  "automation.auto_traceroute.schedule_window": "Restrict to Time Window",
+  "automation.auto_traceroute.schedule_window_description": "Only run auto-traceroutes during the specified time window. Uses server-local time.",
 
   "automation.remote_admin_scanner.title": "Remote Admin Scanner",
   "automation.remote_admin_scanner.description": "Automatically scan mesh nodes to discover which ones have remote admin access enabled. Nodes with admin access can be remotely configured and monitored. The scanner sends DeviceMetadata requests and stores firmware information for successful responses.",
@@ -2165,6 +2167,11 @@
   "automation.remote_admin_scanner.status_has_admin": "Has remote admin access",
   "automation.remote_admin_scanner.status_no_admin": "No remote admin access",
   "automation.remote_admin_scanner.no_log_entries": "No scan results yet. Entries will appear here as nodes are scanned.",
+  "automation.remote_admin_scanner.schedule_window": "Restrict to Time Window",
+  "automation.remote_admin_scanner.schedule_window_description": "Only run remote admin scans during the specified time window. Uses server-local time.",
+
+  "automation.schedule.starting_at": "Starting At",
+  "automation.schedule.ending_at": "Ending At",
 
   "automation.time_sync.title": "Auto Time Sync",
   "automation.time_sync.description": "Automatically synchronize the MeshMonitor server time to nodes that have remote admin access. Useful for nodes without NTP or GPS time sync capabilities. Each interval syncs one eligible node.",

--- a/src/components/RemoteAdminScannerSection.tsx
+++ b/src/components/RemoteAdminScannerSection.tsx
@@ -19,6 +19,9 @@ interface ScanLogEntry {
 interface ScannerSettings {
   intervalMinutes: number;
   expirationHours: number;
+  scheduleEnabled: boolean;
+  scheduleStart: string;
+  scheduleEnd: string;
 }
 
 const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
@@ -32,6 +35,9 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
   const [localEnabled, setLocalEnabled] = useState(false);
   const [localInterval, setLocalInterval] = useState(5);
   const [expirationHours, setExpirationHours] = useState(168);
+  const [scheduleEnabled, setScheduleEnabled] = useState(false);
+  const [scheduleStart, setScheduleStart] = useState('00:00');
+  const [scheduleEnd, setScheduleEnd] = useState('00:00');
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -59,10 +65,17 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
           const interval = parseInt(data.remoteAdminScannerIntervalMinutes) || 0;
           const expiration = parseInt(data.remoteAdminScannerExpirationHours) || 168;
 
+          const schedEnabled = data.remoteAdminScheduleEnabled === 'true';
+          const schedStart = data.remoteAdminScheduleStart || '00:00';
+          const schedEnd = data.remoteAdminScheduleEnd || '00:00';
+
           setLocalEnabled(interval > 0);
           setLocalInterval(interval > 0 ? interval : 5);
           setExpirationHours(expiration);
-          setInitialSettings({ intervalMinutes: interval, expirationHours: expiration });
+          setScheduleEnabled(schedEnabled);
+          setScheduleStart(schedStart);
+          setScheduleEnd(schedEnd);
+          setInitialSettings({ intervalMinutes: interval, expirationHours: expiration, scheduleEnabled: schedEnabled, scheduleStart: schedStart, scheduleEnd: schedEnd });
         }
       } catch (error) {
         console.error('Failed to fetch scanner settings:', error);
@@ -152,9 +165,12 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
     const currentInterval = localEnabled ? localInterval : 0;
     const intervalChanged = currentInterval !== initialSettings.intervalMinutes;
     const expirationChanged = expirationHours !== initialSettings.expirationHours;
+    const scheduleEnabledChanged = scheduleEnabled !== (initialSettings.scheduleEnabled || false);
+    const scheduleStartChanged = scheduleStart !== (initialSettings.scheduleStart || '00:00');
+    const scheduleEndChanged = scheduleEnd !== (initialSettings.scheduleEnd || '00:00');
 
-    setHasChanges(intervalChanged || expirationChanged);
-  }, [localEnabled, localInterval, expirationHours, initialSettings]);
+    setHasChanges(intervalChanged || expirationChanged || scheduleEnabledChanged || scheduleStartChanged || scheduleEndChanged);
+  }, [localEnabled, localInterval, expirationHours, scheduleEnabled, scheduleStart, scheduleEnd, initialSettings]);
 
   // Reset local state to initial settings (used by SaveBar dismiss)
   const resetChanges = useCallback(() => {
@@ -162,6 +178,9 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
       setLocalEnabled(initialSettings.intervalMinutes > 0);
       setLocalInterval(initialSettings.intervalMinutes > 0 ? initialSettings.intervalMinutes : 5);
       setExpirationHours(initialSettings.expirationHours);
+      setScheduleEnabled(initialSettings.scheduleEnabled || false);
+      setScheduleStart(initialSettings.scheduleStart || '00:00');
+      setScheduleEnd(initialSettings.scheduleEnd || '00:00');
     }
   }, [initialSettings]);
 
@@ -176,6 +195,9 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
         body: JSON.stringify({
           remoteAdminScannerIntervalMinutes: intervalToSave.toString(),
           remoteAdminScannerExpirationHours: expirationHours.toString(),
+          remoteAdminScheduleEnabled: scheduleEnabled.toString(),
+          remoteAdminScheduleStart: scheduleStart,
+          remoteAdminScheduleEnd: scheduleEnd,
         }),
       });
 
@@ -187,7 +209,7 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
         throw new Error(`Server returned ${response.status}`);
       }
 
-      setInitialSettings({ intervalMinutes: intervalToSave, expirationHours });
+      setInitialSettings({ intervalMinutes: intervalToSave, expirationHours, scheduleEnabled, scheduleStart, scheduleEnd });
       setHasChanges(false);
       showToast(t('automation.remote_admin_scanner.settings_saved'), 'success');
     } catch (error) {
@@ -196,7 +218,7 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
     } finally {
       setIsSaving(false);
     }
-  }, [localEnabled, localInterval, expirationHours, baseUrl, csrfFetch, showToast, t]);
+  }, [localEnabled, localInterval, expirationHours, scheduleEnabled, scheduleStart, scheduleEnd, baseUrl, csrfFetch, showToast, t]);
 
   // Register with SaveBar
   useSaveBar({
@@ -335,6 +357,50 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
             disabled={!localEnabled}
             className="setting-input"
           />
+        </div>
+
+        {/* Schedule Time Window */}
+        <div className="setting-item" style={{ marginTop: '1rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <input
+              type="checkbox"
+              id="remoteAdminScheduleEnabled"
+              checked={scheduleEnabled}
+              onChange={(e) => setScheduleEnabled(e.target.checked)}
+              disabled={!localEnabled}
+              style={{ width: 'auto', margin: 0, marginRight: '0.5rem', cursor: 'pointer' }}
+            />
+            <label htmlFor="remoteAdminScheduleEnabled" style={{ margin: 0, cursor: 'pointer' }}>
+              {t('automation.remote_admin_scanner.schedule_window')}
+              <span className="setting-description" style={{ display: 'block', marginTop: '0.25rem' }}>
+                {t('automation.remote_admin_scanner.schedule_window_description')}
+              </span>
+            </label>
+          </div>
+          {scheduleEnabled && localEnabled && (
+            <div style={{ display: 'flex', gap: '1rem', marginTop: '0.75rem', marginLeft: '1.75rem', alignItems: 'center' }}>
+              <label style={{ margin: 0, fontSize: '13px' }}>
+                {t('automation.schedule.starting_at')}
+                <input
+                  type="time"
+                  value={scheduleStart}
+                  onChange={(e) => setScheduleStart(e.target.value)}
+                  style={{ marginLeft: '0.5rem' }}
+                  className="setting-input"
+                />
+              </label>
+              <label style={{ margin: 0, fontSize: '13px' }}>
+                {t('automation.schedule.ending_at')}
+                <input
+                  type="time"
+                  value={scheduleEnd}
+                  onChange={(e) => setScheduleEnd(e.target.value)}
+                  style={{ marginLeft: '0.5rem' }}
+                  className="setting-input"
+                />
+              </label>
+            </div>
+          )}
         </div>
 
         {/* Scan Log */}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4881,6 +4881,12 @@ apiRouter.post('/settings', requirePermission('settings', 'write'), (req, res) =
       'autoKeyManagementAutoPurge',
       'remoteAdminScannerIntervalMinutes',
       'remoteAdminScannerExpirationHours',
+      'tracerouteScheduleEnabled',
+      'tracerouteScheduleStart',
+      'tracerouteScheduleEnd',
+      'remoteAdminScheduleEnabled',
+      'remoteAdminScheduleStart',
+      'remoteAdminScheduleEnd',
       'geofenceTriggers',
     ];
     const filteredSettings: Record<string, string> = {};

--- a/src/server/utils/timeWindow.test.ts
+++ b/src/server/utils/timeWindow.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { isWithinTimeWindow } from './timeWindow.js';
+
+function mockTime(hours: number, minutes: number) {
+  const date = new Date(2025, 0, 15, hours, minutes, 0, 0);
+  vi.useFakeTimers();
+  vi.setSystemTime(date);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('isWithinTimeWindow', () => {
+  describe('same-day window (e.g. 08:00-17:00)', () => {
+    it('returns true when current time is within the window', () => {
+      mockTime(12, 0);
+      expect(isWithinTimeWindow('08:00', '17:00')).toBe(true);
+    });
+
+    it('returns true at exact start time', () => {
+      mockTime(8, 0);
+      expect(isWithinTimeWindow('08:00', '17:00')).toBe(true);
+    });
+
+    it('returns false at exact end time', () => {
+      mockTime(17, 0);
+      expect(isWithinTimeWindow('08:00', '17:00')).toBe(false);
+    });
+
+    it('returns false before window start', () => {
+      mockTime(7, 59);
+      expect(isWithinTimeWindow('08:00', '17:00')).toBe(false);
+    });
+
+    it('returns false after window end', () => {
+      mockTime(23, 0);
+      expect(isWithinTimeWindow('08:00', '17:00')).toBe(false);
+    });
+  });
+
+  describe('overnight window (e.g. 22:00-06:00)', () => {
+    it('returns true when current time is after start (late evening)', () => {
+      mockTime(23, 30);
+      expect(isWithinTimeWindow('22:00', '06:00')).toBe(true);
+    });
+
+    it('returns true when current time is before end (early morning)', () => {
+      mockTime(4, 0);
+      expect(isWithinTimeWindow('22:00', '06:00')).toBe(true);
+    });
+
+    it('returns true at exact start time', () => {
+      mockTime(22, 0);
+      expect(isWithinTimeWindow('22:00', '06:00')).toBe(true);
+    });
+
+    it('returns false at exact end time', () => {
+      mockTime(6, 0);
+      expect(isWithinTimeWindow('22:00', '06:00')).toBe(false);
+    });
+
+    it('returns false during daytime (outside window)', () => {
+      mockTime(12, 0);
+      expect(isWithinTimeWindow('22:00', '06:00')).toBe(false);
+    });
+
+    it('returns false just before start', () => {
+      mockTime(21, 59);
+      expect(isWithinTimeWindow('22:00', '06:00')).toBe(false);
+    });
+  });
+
+  describe('equal start and end (24h window)', () => {
+    it('returns true at any time', () => {
+      mockTime(0, 0);
+      expect(isWithinTimeWindow('08:00', '08:00')).toBe(true);
+
+      mockTime(12, 0);
+      expect(isWithinTimeWindow('08:00', '08:00')).toBe(true);
+
+      mockTime(23, 59);
+      expect(isWithinTimeWindow('08:00', '08:00')).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles midnight boundaries (00:00-06:00)', () => {
+      mockTime(0, 0);
+      expect(isWithinTimeWindow('00:00', '06:00')).toBe(true);
+
+      mockTime(3, 0);
+      expect(isWithinTimeWindow('00:00', '06:00')).toBe(true);
+
+      mockTime(6, 0);
+      expect(isWithinTimeWindow('00:00', '06:00')).toBe(false);
+    });
+
+    it('handles window ending at midnight (18:00-00:00)', () => {
+      mockTime(20, 0);
+      expect(isWithinTimeWindow('18:00', '00:00')).toBe(true);
+
+      mockTime(23, 59);
+      expect(isWithinTimeWindow('18:00', '00:00')).toBe(true);
+
+      mockTime(0, 0);
+      expect(isWithinTimeWindow('18:00', '00:00')).toBe(false);
+
+      mockTime(12, 0);
+      expect(isWithinTimeWindow('18:00', '00:00')).toBe(false);
+    });
+
+    it('handles 1-minute window', () => {
+      mockTime(12, 0);
+      expect(isWithinTimeWindow('12:00', '12:01')).toBe(true);
+
+      mockTime(12, 1);
+      expect(isWithinTimeWindow('12:00', '12:01')).toBe(false);
+    });
+  });
+});

--- a/src/server/utils/timeWindow.ts
+++ b/src/server/utils/timeWindow.ts
@@ -1,0 +1,30 @@
+/**
+ * Checks if the current server-local time falls within a time window.
+ *
+ * @param startTime - Start time in "HH:MM" format (24-hour)
+ * @param endTime - End time in "HH:MM" format (24-hour)
+ * @returns true if the current time is within the window
+ *
+ * Same-day window (e.g., 08:00-17:00): current >= start && current < end
+ * Overnight window (e.g., 22:00-06:00): current >= start || current < end
+ * Equal start/end: always active (24h window)
+ */
+export function isWithinTimeWindow(startTime: string, endTime: string): boolean {
+  if (startTime === endTime) return true;
+
+  const now = new Date();
+  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+
+  const [startH, startM] = startTime.split(':').map(Number);
+  const [endH, endM] = endTime.split(':').map(Number);
+  const startMinutes = startH * 60 + startM;
+  const endMinutes = endH * 60 + endM;
+
+  if (startMinutes < endMinutes) {
+    // Same-day window: e.g. 08:00-17:00
+    return currentMinutes >= startMinutes && currentMinutes < endMinutes;
+  } else {
+    // Overnight window: e.g. 22:00-06:00
+    return currentMinutes >= startMinutes || currentMinutes < endMinutes;
+  }
+}


### PR DESCRIPTION
## Summary
- Add optional "Restrict to Time Window" checkbox with start/end time inputs to both Auto Traceroute and Remote Admin Scanner sections
- Schedulers continue ticking on their interval but skip execution when outside the configured time window
- Shared `isWithinTimeWindow` utility handles same-day windows (08:00-17:00), overnight windows (22:00-06:00), and 24h windows (equal start/end)
- 6 new settings keys stored in the existing key-value settings table (no migration needed)
- 15 unit tests covering all time window scenarios

## Test plan
- [ ] Verify time window controls appear on Auto Traceroute section after "Sort by Hops"
- [ ] Verify time window controls appear on Remote Admin Scanner section after expiration hours
- [ ] Test same-day window (e.g., 08:00-17:00) and overnight window (e.g., 22:00-06:00)
- [ ] Verify settings persist across page reload
- [ ] Verify SaveBar shows changes when schedule settings are modified
- [ ] Verify schedule fields are disabled when the feature is disabled
- [ ] Run `npx vitest run src/server/utils/timeWindow.test.ts` — 15 tests pass
- [ ] Run `npx vitest run` — all 2430 tests pass
- [ ] Run `npx tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)