### PR TITLE
chore: bump version to 3.4.13

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.4.12",
+  "version": "3.4.13",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.4.12
-appVersion: "3.4.12"
+version: 3.4.13
+appVersion: "3.4.13"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.4.12",
+  "version": "3.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.4.12",
+      "version": "3.4.13",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.4.12",
+  "version": "3.4.13",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump version to 3.4.13 in package.json, Helm chart, and Tauri config

## Test plan
All 9 system tests passed:

| Test | Result |
|------|--------|
| Configuration Import | PASSED |
| Quick Start Test | PASSED |
| Security Test | PASSED |
| V1 API Test | PASSED |
| Reverse Proxy Test | PASSED |
| Reverse Proxy + OIDC | PASSED |
| Virtual Node CLI Test | PASSED |
| Backup & Restore Test | PASSED |
| Database Migration Test | PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)