### PR TITLE
feat: add LLM Bridge to user scripts gallery

### DIFF
--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -476,5 +476,28 @@
       "Lightweight messages optimized for LoRa",
       "No external dependencies (stdlib only)"
     ]
+  },
+  {
+    "name": "LLM Bridge",
+    "filename": "mm_llm_bridge.py",
+    "icon": "📡🧠",
+    "description": "Interact with Large Language Models (OpenAI-compatible APIs, OpenClaw, Ollama, etc.) over Meshtastic. Enforces strict Meshtastic-safe response limits and automatically splits long answers to remain within radio constraints.",
+    "language": "Python",
+    "tags": ["AI", "LLM", "Ollama", "OpenAI", "Meshtastic", "Automation"],
+    "githubPath": "maxhayim/meshmonitor-llm-bridge/mm_llm_bridge.py",
+    "exampleTrigger": "!ask What is 5x5?",
+    "requirements": [
+      "Python 3.8+",
+      "Configured LLM endpoint (OpenAI-compatible API or Ollama)",
+      "Auto Responder rule pointing to /data/scripts/mm_llm_bridge.py"
+    ],
+    "author": "maxhayim",
+    "features": [
+      "Supports OpenAI-compatible APIs, OpenClaw, and Ollama",
+      "Automatic response splitting for Meshtastic radio limits",
+      "Configurable triggers (!ask, @claw, @ai)",
+      "HTTP retry logic with configurable timeout",
+      "Environment variable configuration for all settings"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- Adds the LLM Bridge script by @maxhayim to the User Scripts Gallery
- Supports OpenAI-compatible APIs, OpenClaw, and Ollama over Meshtastic
- Auto-splits long LLM responses to fit within radio message limits

Closes #1876

## Test plan
- [ ] Verify the script appears in the User Scripts Gallery page
- [ ] Verify the "View Details" modal loads and displays script code from GitHub
- [ ] Confirm tags, description, and metadata render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)