### PR TITLE
fix: remove duplicate emoji from Sky and Sea Alert script name

### DIFF
--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -362,7 +362,7 @@
     ]
   },
   {
-    "name": "✈️ 🛥️ Sky and Sea Alert",
+    "name": "Sky and Sea Alert",
     "filename": "sky_and_sea_alert.py",
     "icon": "✈️",
     "description": "A script that delivers simple, emoji-based alerts when aircraft fly overhead or vessels pass nearby, using local ADS-B/AIS receivers or official cloud APIs.",


### PR DESCRIPTION
## Summary
- Removes emoji prefix (`✈️ 🛥️`) from the `name` field of the Sky and Sea Alert script in the user scripts gallery
- The gallery template already renders `script.icon` (`✈️`) before `script.name`, so having emojis in both caused duplicate plane emojis in the display

Fixes the display issue reported in #1624

## Test plan
- [ ] Verify the Sky and Sea Alert script card in the gallery shows a single plane emoji followed by "Sky and Sea Alert"

🤖 Generated with [Claude Code](https://claude.com/claude-code)