### PR TITLE
fix: change default auto-traceroute interval from 3 to 15 minutes

### DIFF
--- a/src/components/AutoTracerouteSection.tsx
+++ b/src/components/AutoTracerouteSection.tsx
@@ -65,7 +65,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
   const csrfFetch = useCsrfFetch();
   const { showToast } = useToast();
   const [localEnabled, setLocalEnabled] = useState(intervalMinutes > 0);
-  const [localInterval, setLocalInterval] = useState(intervalMinutes > 0 ? intervalMinutes : 3);
+  const [localInterval, setLocalInterval] = useState(intervalMinutes > 0 ? intervalMinutes : 15);
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -116,7 +116,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
   // Update local state when props change
   useEffect(() => {
     setLocalEnabled(intervalMinutes > 0);
-    setLocalInterval(intervalMinutes > 0 ? intervalMinutes : 3);
+    setLocalInterval(intervalMinutes > 0 ? intervalMinutes : 15);
   }, [intervalMinutes]);
 
   // Fetch available nodes
@@ -261,7 +261,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
   // Reset local state to initial settings (used by SaveBar dismiss)
   const resetChanges = useCallback(() => {
     setLocalEnabled(intervalMinutes > 0);
-    setLocalInterval(intervalMinutes > 0 ? intervalMinutes : 3);
+    setLocalInterval(intervalMinutes > 0 ? intervalMinutes : 15);
     if (initialSettings) {
       setFilterEnabled(initialSettings.enabled);
       setSelectedNodeNums(initialSettings.nodeNums || []);


### PR DESCRIPTION
## Summary
- Changes the default auto-traceroute interval from 3 minutes to 15 minutes for new users enabling the feature
- Existing saved intervals are completely unaffected — this only changes the UI fallback when no interval has been saved yet
- Reduces potential traffic on large meshes from ~480 traceroutes/day to ~96/day per node by default

Closes #1875

## Test plan
- [ ] Fresh install or user who hasn't configured auto-traceroute: toggle on → interval should default to 15 minutes
- [ ] Existing user with saved interval (e.g. 5 min): toggle on → their saved value is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)