### PR TITLE
fix: prevent tapback responses from using DM routing

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7437,13 +7437,12 @@ class MeshtasticManager {
 
         logger.debug(`🤖 Auto-acknowledging with tapback ${hopEmoji} (${hopsTraveled} hops) to ${target}`);
 
-        // Send tapback reaction using sendTextMessage with emoji flag
-        // Use same routing logic as message reply: respect alwaysUseDM flag
+        // Tapbacks always reply on the original channel (not affected by alwaysUseDM)
         try {
           await this.sendTextMessage(
             hopEmoji,
-            (alwaysUseDM || isDirectMessage) ? 0 : channelIndex,
-            (alwaysUseDM || isDirectMessage) ? fromNum : undefined,
+            isDirectMessage ? 0 : channelIndex,
+            isDirectMessage ? fromNum : undefined,
             packetId, // replyId - react to the original message
             1 // emoji flag = 1 for tapback/reaction
           );


### PR DESCRIPTION
## Summary
- Tapback emoji reactions were incorrectly sent as DMs when "Always reply via DM" (`autoAckUseDM`) was enabled, causing most Meshtastic clients to drop them (the original channel message can't be found in a DM context)
- Removed `alwaysUseDM` from tapback routing logic so tapbacks always reply on the original channel/DM
- Text replies continue to correctly respect the `alwaysUseDM` setting

## Test plan
- [x] `npx tsc --noEmit` — no new type errors
- [x] `npx vitest run` — all 2465 tests pass
- [ ] Manual: enable both tapback and "Always reply via DM" → send a channel message that triggers auto-ack → tapback should appear on the channel, text reply should go as DM

🤖 Generated with [Claude Code](https://claude.com/claude-code)