### PR TITLE
fix: hide MeshCore sidebar when MESHCORE_ENABLED is not set

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4236,6 +4236,7 @@ function App() {
         }}
         baseUrl={baseUrl}
         connectedNodeName={connectedNodeName}
+        meshcoreEnabled={authStatus?.meshcoreEnabled || false}
       />
 
       <main className="app-main">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -23,6 +23,7 @@ interface SidebarProps {
   onNewsClick?: () => void;
   baseUrl: string;
   connectedNodeName?: string;
+  meshcoreEnabled?: boolean;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
@@ -36,7 +37,8 @@ const Sidebar: React.FC<SidebarProps> = ({
   onChannelsClick,
   onNewsClick,
   baseUrl,
-  connectedNodeName
+  connectedNodeName,
+  meshcoreEnabled
 }) => {
   const { t } = useTranslation();
   // Start collapsed (narrow/icon-only) by default for cleaner desktop UI
@@ -174,7 +176,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           {hasPermission('dashboard', 'read') && (
             <NavItem id="dashboard" label={t('nav.dashboard')} icon="📊" />
           )}
-          {hasPermission('meshcore', 'read') && (
+          {meshcoreEnabled && hasPermission('meshcore', 'read') && (
             <NavItem id="meshcore" label={t('nav.meshcore', 'MeshCore')} icon="📶" />
           )}
         </div>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -35,6 +35,7 @@ export interface AuthStatus {
   oidcEnabled: boolean;
   localAuthDisabled: boolean;
   anonymousDisabled: boolean;
+  meshcoreEnabled: boolean;
 }
 
 export interface LoginResult {
@@ -100,7 +101,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         channelDbPermissions: {},
         oidcEnabled: false,
         localAuthDisabled: false,
-        anonymousDisabled: false
+        anonymousDisabled: false,
+        meshcoreEnabled: false
       });
     } finally {
       setLoading(false);

--- a/src/server/routes/authRoutes.ts
+++ b/src/server/routes/authRoutes.ts
@@ -57,7 +57,8 @@ router.get('/status', async (req: Request, res: Response) => {
         permissions: anonymousPermissions,
         oidcEnabled: isOIDCEnabled(),
         localAuthDisabled,
-        anonymousDisabled
+        anonymousDisabled,
+        meshcoreEnabled: process.env.MESHCORE_ENABLED === 'true'
       });
     }
 
@@ -82,7 +83,8 @@ router.get('/status', async (req: Request, res: Response) => {
         permissions: anonymousPermissions,
         oidcEnabled: isOIDCEnabled(),
         localAuthDisabled,
-        anonymousDisabled
+        anonymousDisabled,
+        meshcoreEnabled: process.env.MESHCORE_ENABLED === 'true'
       });
     }
 
@@ -98,7 +100,8 @@ router.get('/status', async (req: Request, res: Response) => {
       permissions,
       oidcEnabled: isOIDCEnabled(),
       localAuthDisabled,
-      anonymousDisabled
+      anonymousDisabled,
+      meshcoreEnabled: process.env.MESHCORE_ENABLED === 'true'
     });
   } catch (error) {
     logger.error('Error getting auth status:', error);


### PR DESCRIPTION
## Summary
- Expose `meshcoreEnabled` flag from backend via `/api/auth/status` (checks `MESHCORE_ENABLED` env var)
- Gate the MeshCore sidebar nav item on `meshcoreEnabled` in addition to existing permission check
- Prevents users from seeing a broken MeshCore tab when the feature is not enabled

## Changes
- **`src/server/routes/authRoutes.ts`** — Added `meshcoreEnabled: process.env.MESHCORE_ENABLED === 'true'` to all three `/status` response paths
- **`src/contexts/AuthContext.tsx`** — Added `meshcoreEnabled: boolean` to `AuthStatus` interface and error fallback
- **`src/components/Sidebar.tsx`** — Added `meshcoreEnabled` prop and gated MeshCore nav item on it
- **`src/App.tsx`** — Pass `meshcoreEnabled` from auth status to Sidebar

## Test plan
- [x] `npx tsc --noEmit` — no new type errors
- [x] `npx vitest run` — all 113 test files pass (2465 tests)
- [x] Verified unauthenticated `/api/auth/status` returns `meshcoreEnabled: false`
- [x] Verified authenticated `/api/auth/status` returns `meshcoreEnabled: false`
- [x] Manual: confirm MeshCore tab hidden when `MESHCORE_ENABLED` is unset
- [ ] Manual: confirm MeshCore tab visible when `MESHCORE_ENABLED=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)