### PR TITLE
feat: add RayHunter monitor script to script gallery

### DIFF
--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -499,5 +499,28 @@
       "HTTP retry logic with configurable timeout",
       "Environment variable configuration for all settings"
     ]
+  },
+  {
+    "name": "RayHunter Monitor",
+    "filename": "rayhunter-monitor.py",
+    "icon": "📡",
+    "description": "Monitors an EFF RayHunter device for IMSI catcher / cell-site simulator warnings and broadcasts alerts on the mesh. Polls the current analysis for Low, Medium, and High severity events and formats a concise alert message.",
+    "language": "Python",
+    "tags": ["Security", "Monitoring", "Timer Trigger", "Alerting", "RayHunter", "IMSI Catcher"],
+    "githubPath": "Yeraze/meshmonitor/examples/auto-responder-scripts/rayhunter-monitor.py",
+    "exampleTrigger": "Timer Trigger (e.g. every 5 minutes)",
+    "requirements": [
+      "Python 3.8+ (standard library only, zero external dependencies)",
+      "EFF RayHunter device on the network (default http://192.168.1.1:8080)"
+    ],
+    "author": "MeshMonitor",
+    "features": [
+      "Polls RayHunter current recording for active warnings",
+      "Parses NDJSON analysis reports for Low/Medium/High severity events",
+      "Formatted mesh-friendly alert messages with severity counts",
+      "Silent when no warnings (no unnecessary mesh traffic)",
+      "Configurable RayHunter URL via --url flag or RAYHUNTER_URL env var",
+      "--always-report flag for testing"
+    ]
   }
 ]

--- a/examples/auto-responder-scripts/rayhunter-monitor.py
+++ b/examples/auto-responder-scripts/rayhunter-monitor.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+RayHunter Monitor - Timer Trigger script for MeshMonitor
+
+Polls a RayHunter instance for the current analysis and reports
+any warnings (Low/Medium/High severity events) found.
+
+Configure as a MeshMonitor Timer Trigger with:
+  - Script Path: /data/scripts/rayhunter-monitor.py
+  - Script Args: --url http://192.168.1.1:8080 (optional, this is the default)
+  - Channel: your desired broadcast channel
+  - Cron: e.g. */5 * * * * (every 5 minutes)
+
+Environment variables (optional):
+  RAYHUNTER_URL - Base URL of the RayHunter instance (default: http://192.168.1.1:8080)
+"""
+
+import argparse
+import json
+import os
+import sys
+from urllib.request import urlopen, Request
+from urllib.error import URLError
+
+DEFAULT_URL = "http://192.168.1.1:8080"
+SEVERITY_ORDER = {"Informational": 0, "Low": 1, "Medium": 2, "High": 3}
+SEVERITY_EMOJI = {"Low": "⚠️", "Medium": "🟠", "High": "🔴"}
+
+
+def fetch_json(url):
+    req = Request(url, headers={"Accept": "application/json"})
+    with urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read().decode())
+
+
+def fetch_text(url):
+    req = Request(url, headers={"Accept": "application/json"})
+    with urlopen(req, timeout=10) as resp:
+        return resp.read().decode()
+
+
+def get_current_entry(base_url):
+    manifest = fetch_json(f"{base_url}/api/qmdl-manifest")
+    return manifest.get("current_entry")
+
+
+def parse_analysis_report(ndjson_text):
+    """Parse NDJSON analysis report. First line is metadata, rest are rows."""
+    lines = [l.strip() for l in ndjson_text.strip().split("\n") if l.strip()]
+    if not lines:
+        return None, []
+
+    metadata = json.loads(lines[0])
+    rows = []
+    for line in lines[1:]:
+        row = json.loads(line)
+        rows.append(row)
+    return metadata, rows
+
+
+def extract_warnings(rows):
+    """Extract non-informational events from analysis rows."""
+    warnings = []
+    for row in rows:
+        # Each row has a list of events (one per analyzer), most are null
+        events = row.get("events", [])
+        timestamp = row.get("packet_timestamp", "")
+        for event in events:
+            if event is None:
+                continue
+            event_type = event.get("event_type", "Informational")
+            if event_type != "Informational":
+                warnings.append({
+                    "severity": event_type,
+                    "message": event.get("message", "Unknown"),
+                    "timestamp": timestamp,
+                })
+    return warnings
+
+
+def format_response(warnings, entry_name):
+    """Format warnings into a mesh broadcast message."""
+    if not warnings:
+        return None
+
+    # Count by severity
+    counts = {}
+    for w in warnings:
+        sev = w["severity"]
+        counts[sev] = counts.get(sev, 0) + 1
+
+    # Build summary header
+    parts = []
+    for sev in ("High", "Medium", "Low"):
+        if sev in counts:
+            emoji = SEVERITY_EMOJI.get(sev, "")
+            parts.append(f"{emoji}{counts[sev]} {sev}")
+
+    header = f"RayHunter Alert: {', '.join(parts)}"
+
+    # Add highest-severity warning details (keep message short for mesh)
+    worst = max(warnings, key=lambda w: SEVERITY_ORDER.get(w["severity"], 0))
+    detail = worst["message"]
+    # Truncate detail to keep within mesh message limits
+    if len(detail) > 150:
+        detail = detail[:147] + "..."
+
+    return f"{header}\n{detail}"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="RayHunter Monitor for MeshMonitor")
+    parser.add_argument("--url", default=None, help="RayHunter base URL")
+    parser.add_argument("--always-report", action="store_true",
+                        help="Report even when no warnings found (for testing)")
+    args = parser.parse_args()
+
+    base_url = (args.url
+                or os.environ.get("RAYHUNTER_URL")
+                or DEFAULT_URL).rstrip("/")
+
+    try:
+        entry = get_current_entry(base_url)
+        if not entry:
+            if args.always_report:
+                print(json.dumps({"response": "RayHunter: No active recording"}))
+            sys.exit(0)
+
+        entry_name = entry["name"]
+        ndjson = fetch_text(f"{base_url}/api/analysis-report/{entry_name}")
+        metadata, rows = parse_analysis_report(ndjson)
+
+        if not rows:
+            if args.always_report:
+                print(json.dumps({"response": f"RayHunter: Recording {entry_name} active, no analysis rows yet"}))
+            sys.exit(0)
+
+        warnings = extract_warnings(rows)
+
+        if warnings:
+            message = format_response(warnings, entry_name)
+            print(json.dumps({"response": message}))
+        elif args.always_report:
+            print(json.dumps({"response": f"RayHunter: {len(rows)} packets analyzed, no warnings"}))
+
+    except URLError as e:
+        print(json.dumps({"response": f"RayHunter: Cannot reach device ({e.reason})"}),
+              file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(json.dumps({"response": f"RayHunter: Error - {e}"}),
+              file=sys.stderr)
+        sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `rayhunter-monitor.py` Timer Trigger script that polls an EFF RayHunter device for IMSI catcher / cell-site simulator warnings and broadcasts alerts on the mesh
- Add gallery entry to `user-scripts.json` so it appears in the Script Gallery docs page

## How it works
1. Fetches the current recording from RayHunter's `/api/qmdl-manifest`
2. Fetches the NDJSON analysis report for that recording via `/api/analysis-report/{name}`
3. Parses each row for Low/Medium/High severity events
4. If warnings are found, outputs a formatted alert message for mesh broadcast
5. Stays silent when no warnings (no unnecessary mesh traffic)

Example alert output:
```
RayHunter Alert: 🔴1 High, ⚠️2 Low
<details of the worst warning>
```

## Configuration
- **Script Path:** `/data/scripts/rayhunter-monitor.py`
- **Script Args:** `--url http://192.168.1.1:8080` (optional, this is the default)
- **Channel:** desired broadcast channel
- **Cron:** e.g. `*/5 * * * *`

## Test plan
- [x] JSON validation passes on `user-scripts.json`
- [x] `npx vitest run` — all 113 test files pass (2465 tests)
- [x] Tested script against live RayHunter instance (returned correct status)
- [x] Deployed to dev container and configured as Timer Trigger — runs successfully on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)