### PR TITLE
feat: add per-portnum node distribution chart on Info page

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -347,6 +347,7 @@
   "messages.shared_key_with": "This key is shared with: ",
   "messages.switch_to_title": "Switch to {{name}}",
   "messages.select_from_list": "Select a conversation from the list to view messages",
+  "messages.packet_type_distribution": "Packet Type Distribution (24h)",
 
   "channels.title": "Channels",
   "channels.title_with_count": "Channels ({{count}})",
@@ -1657,6 +1658,10 @@
   "info.all_data": "All Data",
   "info.other_devices": "Other",
   "info.no_packet_data": "No packet data available",
+  "info.select_packet_type": "Select a packet type to see which nodes are sending it",
+  "info.packets_by_type_nodes": "Nodes by Packet Type",
+  "info.nodes_sending_type": "Nodes Sending {{type}}",
+  "info.no_packets_for_type": "No packets found for this type in the selected time range",
 
   "config.loading": "Loading configuration...",
   "config.warning_title": "WARNING",

--- a/src/components/InfoTab.tsx
+++ b/src/components/InfoTab.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 import { DeviceInfo, Channel } from '../types/device';
 import { MeshMessage } from '../types/message';
 import { ConnectionStatus } from '../types/ui';
@@ -17,146 +16,7 @@ import { useToast } from './ToastContainer';
 import { getDeviceRoleName } from '../utils/deviceRole';
 import { getPacketDistributionStats } from '../services/packetApi';
 import { PacketDistributionStats } from '../types/packet';
-
-// Chart data entry interface
-interface ChartDataEntry {
-  name: string;
-  value: number;
-  color: string;
-  [key: string]: string | number;  // Index signature for Recharts compatibility
-}
-
-// Reusable packet statistics chart component
-interface PacketStatsChartProps {
-  title: string;
-  data: ChartDataEntry[];
-  total: number;
-  chartId: string;
-  wide?: boolean;
-  bare?: boolean;
-  stacked?: boolean;
-  headerExtra?: React.ReactNode;
-}
-
-const PacketStatsChart: React.FC<PacketStatsChartProps> = React.memo(({ title, data, total, chartId, wide = false, bare = false, stacked = false, headerExtra }) => {
-  const filteredData = useMemo(() => data.filter(d => d.value > 0), [data]);
-
-  if (filteredData.length === 0) return null;
-
-  const chartSize = 140;
-  const innerRadius = 30;
-  const outerRadius = 55;
-
-  const pieChart = (
-    <div style={{ width: `${chartSize}px`, height: `${chartSize}px`, flexShrink: 0 }}>
-      <ResponsiveContainer width="100%" height="100%">
-        <PieChart>
-          <Pie
-            data={filteredData}
-            cx="50%"
-            cy="50%"
-            innerRadius={innerRadius}
-            outerRadius={outerRadius}
-            paddingAngle={2}
-            dataKey="value"
-          >
-            {filteredData.map((entry, index) => (
-              <Cell key={`${chartId}-cell-${index}`} fill={entry.color} />
-            ))}
-          </Pie>
-          <Tooltip
-            formatter={(value, _name, props) => {
-              if (value === null || value === undefined) return ['-', ''];
-              const numValue = typeof value === 'number' ? value : parseFloat(String(value));
-              if (isNaN(numValue)) return ['-', ''];
-              const pct = total > 0 ? ((numValue / total) * 100).toFixed(1) : '0';
-              const entryName = props?.payload?.name || '';
-              return [`${numValue.toLocaleString()} (${pct}%)`, entryName];
-            }}
-            contentStyle={{
-              backgroundColor: 'var(--ctp-surface0)',
-              border: '1px solid var(--ctp-surface2)',
-              borderRadius: '4px',
-              fontSize: '0.85em',
-            }}
-            itemStyle={{
-              color: 'var(--ctp-text)',
-            }}
-          />
-        </PieChart>
-      </ResponsiveContainer>
-    </div>
-  );
-
-  const legend = (
-    <div style={{ fontSize: '0.85em', minWidth: 0, overflow: 'hidden' }}>
-      {filteredData.map((entry, index) => {
-        const pct = total > 0 ? ((entry.value / total) * 100).toFixed(1) : '0';
-        return (
-          <p key={`${chartId}-legend-${index}`} style={{ margin: '0.25rem 0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-            <span style={{
-              display: 'inline-block',
-              width: '10px',
-              height: '10px',
-              backgroundColor: entry.color,
-              marginRight: '0.5rem',
-              borderRadius: '2px',
-              flexShrink: 0,
-            }}></span>
-            {entry.name}: {pct}% ({entry.value.toLocaleString()})
-          </p>
-        );
-      })}
-    </div>
-  );
-
-  // Bare mode: no wrapper div, used inside a parent combined section
-  if (bare) {
-    // Stacked: chart above legend (for distribution charts in side-by-side grid)
-    if (stacked) {
-      return (
-        <div style={{ overflow: 'hidden' }}>
-          <h3 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>{title}</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.5rem' }}>
-            {pieChart}
-            {legend}
-          </div>
-        </div>
-      );
-    }
-    // Horizontal: chart left, legend right (for RX/TX in stacked box)
-    return (
-      <div style={{ overflow: 'hidden' }}>
-        <h3 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>{title}</h3>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-          {pieChart}
-          {legend}
-        </div>
-      </div>
-    );
-  }
-
-  // Standalone mode: horizontal layout (chart left, legend right)
-  const content = (
-    <>
-      <h3>{title}</h3>
-      {headerExtra}
-      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-        {pieChart}
-        {legend}
-      </div>
-    </>
-  );
-
-  // When used standalone, wrap in info-section
-  if (wide) {
-    return <div className="info-section-wide">{content}</div>;
-  }
-
-  return <div className="info-section">{content}</div>;
-});
-
-PacketStatsChart.displayName = 'PacketStatsChart';
+import PacketStatsChart, { ChartDataEntry, DISTRIBUTION_COLORS } from './PacketStatsChart';
 
 interface RouteSegment {
   id: number;
@@ -226,6 +86,9 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
   const [packetDistribution, setPacketDistribution] = useState<PacketDistributionStats | null>(null);
   const [distributionTimeRange, setDistributionTimeRange] = useState<'hour' | '24h' | 'all'>('24h');
   const [loadingDistribution, setLoadingDistribution] = useState(false);
+  const [selectedPortnum, setSelectedPortnum] = useState<number | null>(4); // Default to NODEINFO_APP
+  const [portnumNodeDistribution, setPortnumNodeDistribution] = useState<PacketDistributionStats | null>(null);
+  const [loadingPortnumNodes, setLoadingPortnumNodes] = useState(false);
 
   const fetchVirtualNodeStatus = async () => {
     if (connectionStatus !== 'connected') return;
@@ -351,6 +214,28 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
     }
   }, [connectionStatus, distributionTimeRange]);
 
+  const fetchPortnumNodeDistribution = useCallback(async () => {
+    if (connectionStatus !== 'connected' || selectedPortnum === null) return;
+
+    setLoadingPortnumNodes(true);
+    try {
+      let since: number | undefined;
+      const now = Math.floor(Date.now() / 1000);
+      if (distributionTimeRange === 'hour') {
+        since = now - 3600;
+      } else if (distributionTimeRange === '24h') {
+        since = now - 86400;
+      }
+
+      const distribution = await getPacketDistributionStats(since, undefined, selectedPortnum);
+      setPortnumNodeDistribution(distribution);
+    } catch (error) {
+      logger.error('Error fetching portnum node distribution:', error);
+    } finally {
+      setLoadingPortnumNodes(false);
+    }
+  }, [connectionStatus, selectedPortnum, distributionTimeRange]);
+
   const handleClearRecordHolder = async () => {
     setShowConfirmDialog(true);
   };
@@ -405,6 +290,14 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
     const interval = setInterval(fetchPacketDistribution, 60000); // Refresh every minute
     return () => clearInterval(interval);
   }, [fetchPacketDistribution]);
+
+  useEffect(() => {
+    if (selectedPortnum !== null) {
+      fetchPortnumNodeDistribution();
+      const interval = setInterval(fetchPortnumNodeDistribution, 60000);
+      return () => clearInterval(interval);
+    }
+  }, [fetchPortnumNodeDistribution, selectedPortnum]);
 
   // Helper function to format uptime
   const formatUptime = (uptimeSeconds: number): string => {
@@ -702,12 +595,6 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
 
         {/* Packet Distribution Charts - only shown when packet monitor is enabled */}
         {packetDistribution?.enabled && (() => {
-          // Color palette for distribution charts (Catppuccin-compatible)
-          const DISTRIBUTION_COLORS = [
-            '#89b4fa', '#a6e3a1', '#fab387', '#f5c2e7', '#cba6f7',
-            '#94e2d5', '#f9e2af', '#f38ba8', '#89dceb', '#b4befe', '#9399b2'
-          ];
-
           // Prepare device data with "Other" grouping
           const deviceData: ChartDataEntry[] = packetDistribution.byDevice.map((d, i) => ({
             name: d.from_node_longName || d.from_node_id || `Node ${d.from_node}`,
@@ -810,6 +697,92 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
             </>
           );
         })()}
+
+        {/* Per-portnum node distribution - separate section */}
+        {packetDistribution?.enabled && packetDistribution.byType.length > 0 && (
+          <div className="info-section">
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
+              <h3 style={{ margin: 0 }}>{t('info.packets_by_type_nodes')}</h3>
+              <select
+                id="portnum-select"
+                value={selectedPortnum ?? ''}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setSelectedPortnum(val ? parseInt(val, 10) : null);
+                  if (!val) setPortnumNodeDistribution(null);
+                }}
+                style={{
+                  padding: '0.25rem 0.5rem',
+                  fontSize: '0.85em',
+                  borderRadius: '4px',
+                  border: '1px solid var(--ctp-surface2)',
+                  background: 'var(--ctp-surface0)',
+                  color: 'var(--ctp-text)',
+                }}
+              >
+                <option value="">--</option>
+                {[...packetDistribution.byType]
+                  .sort((a, b) => b.count - a.count)
+                  .map((p) => (
+                    <option key={p.portnum} value={p.portnum}>
+                      {p.portnum_name.replace(/_APP$/, '').replace(/_/g, ' ')} ({p.count})
+                    </option>
+                  ))}
+              </select>
+            </div>
+
+            {selectedPortnum !== null && loadingPortnumNodes && (
+              <p style={{ fontSize: '0.9em', color: '#888' }}>{t('common.loading_indicator')}</p>
+            )}
+
+            {selectedPortnum !== null && !loadingPortnumNodes && portnumNodeDistribution && (() => {
+              if (portnumNodeDistribution.byDevice.length === 0) {
+                return (
+                  <p style={{ color: '#888', fontStyle: 'italic', fontSize: '0.9em' }}>
+                    {t('info.no_packets_for_type')}
+                  </p>
+                );
+              }
+
+              const portnumDeviceData: ChartDataEntry[] = portnumNodeDistribution.byDevice.map((d, i) => ({
+                name: d.from_node_longName || d.from_node_id || `Node ${d.from_node}`,
+                value: d.count,
+                color: DISTRIBUTION_COLORS[i % DISTRIBUTION_COLORS.length]
+              }));
+
+              const portnumDeviceTotal = portnumDeviceData.reduce((sum, d) => sum + d.value, 0);
+              const portnumOtherCount = portnumNodeDistribution.total - portnumDeviceTotal;
+              if (portnumOtherCount > 0) {
+                portnumDeviceData.push({
+                  name: t('info.other_devices'),
+                  value: portnumOtherCount,
+                  color: DISTRIBUTION_COLORS[10]
+                });
+              }
+
+              const selectedTypeName = packetDistribution.byType
+                .find((p) => p.portnum === selectedPortnum)
+                ?.portnum_name.replace(/_APP$/, '').replace(/_/g, ' ') ?? `Port ${selectedPortnum}`;
+
+              return (
+                <PacketStatsChart
+                  title={t('info.nodes_sending_type', { type: selectedTypeName })}
+                  data={portnumDeviceData}
+                  total={portnumNodeDistribution.total}
+                  chartId="portnum-nodes"
+                  bare
+                  stacked
+                />
+              );
+            })()}
+
+            {selectedPortnum === null && (
+              <p style={{ color: '#888', fontStyle: 'italic', fontSize: '0.9em' }}>
+                {t('info.select_packet_type')}
+              </p>
+            )}
+          </div>
+        )}
 
         {localStats?.hostUptimeSeconds !== undefined && (
           <div className="info-section">

--- a/src/components/PacketStatsChart.tsx
+++ b/src/components/PacketStatsChart.tsx
@@ -1,0 +1,150 @@
+import React, { useMemo } from 'react';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
+
+// Color palette for distribution charts (Catppuccin-compatible)
+export const DISTRIBUTION_COLORS = [
+  '#89b4fa', '#a6e3a1', '#fab387', '#f5c2e7', '#cba6f7',
+  '#94e2d5', '#f9e2af', '#f38ba8', '#89dceb', '#b4befe', '#9399b2'
+];
+
+// Chart data entry interface
+export interface ChartDataEntry {
+  name: string;
+  value: number;
+  color: string;
+  [key: string]: string | number;  // Index signature for Recharts compatibility
+}
+
+// Reusable packet statistics chart component
+export interface PacketStatsChartProps {
+  title: string;
+  data: ChartDataEntry[];
+  total: number;
+  chartId: string;
+  wide?: boolean;
+  bare?: boolean;
+  stacked?: boolean;
+  headerExtra?: React.ReactNode;
+}
+
+const PacketStatsChart: React.FC<PacketStatsChartProps> = React.memo(({ title, data, total, chartId, wide = false, bare = false, stacked = false, headerExtra }) => {
+  const filteredData = useMemo(() => data.filter(d => d.value > 0), [data]);
+
+  if (filteredData.length === 0) return null;
+
+  const chartSize = 140;
+  const innerRadius = 30;
+  const outerRadius = 55;
+
+  const pieChart = (
+    <div style={{ width: `${chartSize}px`, height: `${chartSize}px`, flexShrink: 0 }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie
+            data={filteredData}
+            cx="50%"
+            cy="50%"
+            innerRadius={innerRadius}
+            outerRadius={outerRadius}
+            paddingAngle={2}
+            dataKey="value"
+          >
+            {filteredData.map((entry, index) => (
+              <Cell key={`${chartId}-cell-${index}`} fill={entry.color} />
+            ))}
+          </Pie>
+          <Tooltip
+            formatter={(value, _name, props) => {
+              if (value === null || value === undefined) return ['-', ''];
+              const numValue = typeof value === 'number' ? value : parseFloat(String(value));
+              if (isNaN(numValue)) return ['-', ''];
+              const pct = total > 0 ? ((numValue / total) * 100).toFixed(1) : '0';
+              const entryName = props?.payload?.name || '';
+              return [`${numValue.toLocaleString()} (${pct}%)`, entryName];
+            }}
+            contentStyle={{
+              backgroundColor: 'var(--ctp-surface0)',
+              border: '1px solid var(--ctp-surface2)',
+              borderRadius: '4px',
+              fontSize: '0.85em',
+            }}
+            itemStyle={{
+              color: 'var(--ctp-text)',
+            }}
+          />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+
+  const legend = (
+    <div style={{ fontSize: '0.85em', minWidth: 0, overflow: 'hidden' }}>
+      {filteredData.map((entry, index) => {
+        const pct = total > 0 ? ((entry.value / total) * 100).toFixed(1) : '0';
+        return (
+          <p key={`${chartId}-legend-${index}`} style={{ margin: '0.25rem 0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <span style={{
+              display: 'inline-block',
+              width: '10px',
+              height: '10px',
+              backgroundColor: entry.color,
+              marginRight: '0.5rem',
+              borderRadius: '2px',
+              flexShrink: 0,
+            }}></span>
+            {entry.name}: {pct}% ({entry.value.toLocaleString()})
+          </p>
+        );
+      })}
+    </div>
+  );
+
+  // Bare mode: no wrapper div, used inside a parent combined section
+  if (bare) {
+    // Stacked: chart above legend (for distribution charts in side-by-side grid)
+    if (stacked) {
+      return (
+        <div style={{ overflow: 'hidden' }}>
+          <h3 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>{title}</h3>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.5rem' }}>
+            {pieChart}
+            {legend}
+          </div>
+        </div>
+      );
+    }
+    // Horizontal: chart left, legend right (for RX/TX in stacked box)
+    return (
+      <div style={{ overflow: 'hidden' }}>
+        <h3 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>{title}</h3>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+          {pieChart}
+          {legend}
+        </div>
+      </div>
+    );
+  }
+
+  // Standalone mode: horizontal layout (chart left, legend right)
+  const content = (
+    <>
+      <h3>{title}</h3>
+      {headerExtra}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+        {pieChart}
+        {legend}
+      </div>
+    </>
+  );
+
+  // When used standalone, wrap in info-section
+  if (wide) {
+    return <div className="info-section-wide">{content}</div>;
+  }
+
+  return <div className="info-section">{content}</div>;
+});
+
+PacketStatsChart.displayName = 'PacketStatsChart';
+
+export default PacketStatsChart;

--- a/src/server/routes/packetRoutes.ts
+++ b/src/server/routes/packetRoutes.ts
@@ -153,12 +153,14 @@ router.get('/stats/distribution', requirePacketPermissions, async (req, res) => 
     }
 
     const since = req.query.since ? parseInt(req.query.since as string, 10) : undefined;
+    const from_node = req.query.from_node ? parseInt(req.query.from_node as string, 10) : undefined;
+    const portnum = req.query.portnum ? parseInt(req.query.portnum as string, 10) : undefined;
 
     // Fetch distribution data - limit to top 10 devices
     const [byDevice, byType, total] = await Promise.all([
-      packetLogService.getPacketCountsByNodeAsync({ since, limit: 10 }),
-      packetLogService.getPacketCountsByPortnumAsync({ since }),
-      packetLogService.getPacketCountAsync({ since })
+      packetLogService.getPacketCountsByNodeAsync({ since, limit: 10, portnum }),
+      packetLogService.getPacketCountsByPortnumAsync({ since, from_node }),
+      packetLogService.getPacketCountAsync({ since, from_node })
     ]);
 
     res.json({

--- a/src/server/services/packetLogService.ts
+++ b/src/server/services/packetLogService.ts
@@ -2,7 +2,7 @@ import databaseService, { DbPacketLog, DbPacketCountByNode, DbPacketCountByPortn
 import { logger } from '../../utils/logger.js';
 
 class PacketLogService {
-  private cleanupInterval: NodeJS.Timeout | null = null;
+  private cleanupInterval: ReturnType<typeof setInterval> | null = null;
   private readonly CLEANUP_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
 
   constructor() {
@@ -157,14 +157,14 @@ class PacketLogService {
   /**
    * Get packet counts grouped by node (for distribution charts)
    */
-  async getPacketCountsByNodeAsync(options?: { since?: number; limit?: number }): Promise<DbPacketCountByNode[]> {
+  async getPacketCountsByNodeAsync(options?: { since?: number; limit?: number; portnum?: number }): Promise<DbPacketCountByNode[]> {
     return databaseService.getPacketCountsByNodeAsync(options);
   }
 
   /**
    * Get packet counts grouped by portnum (for distribution charts)
    */
-  async getPacketCountsByPortnumAsync(options?: { since?: number }): Promise<DbPacketCountByPortnum[]> {
+  async getPacketCountsByPortnumAsync(options?: { since?: number; from_node?: number }): Promise<DbPacketCountByPortnum[]> {
     return databaseService.getPacketCountsByPortnumAsync(options);
   }
 

--- a/src/services/packetApi.ts
+++ b/src/services/packetApi.ts
@@ -112,10 +112,16 @@ export const exportPackets = async (filters?: PacketFilters): Promise<void> => {
 /**
  * Fetch packet distribution statistics (by device and by type)
  */
-export const getPacketDistributionStats = async (since?: number): Promise<PacketDistributionStats> => {
+export const getPacketDistributionStats = async (since?: number, from_node?: number, portnum?: number): Promise<PacketDistributionStats> => {
   const params = new URLSearchParams();
   if (since !== undefined) {
     params.append('since', since.toString());
+  }
+  if (from_node !== undefined) {
+    params.append('from_node', from_node.toString());
+  }
+  if (portnum !== undefined) {
+    params.append('portnum', portnum.toString());
   }
   const query = params.toString();
   return api.get<PacketDistributionStats>(`/api/packets/stats/distribution${query ? `?${query}` : ''}`);


### PR DESCRIPTION
## Summary
- Adds a new "Nodes by Packet Type" section on the Info page with a dropdown to select a packet type and a donut chart showing which nodes are sending that type
- Defaults to NODEINFO_APP so the chart is visible immediately on page load
- Extracts `PacketStatsChart` into its own reusable component (`src/components/PacketStatsChart.tsx`)
- Adds `portnum` filter to `getPacketCountsByNodeAsync` and `from_node` filter to `getPacketCountsByPortnumAsync` across all 3 database backends (SQLite, PostgreSQL, MySQL)
- Adds per-node packet type distribution chart on MessagesTab node details panel
- Respects the existing time range selector (1h / 24h / All)

Closes #1891 (part 2)

## Test plan
- [x] `npm test` — 2465 tests pass, 0 failures
- [ ] Navigate to Info page, verify existing By Device / By Type charts still work
- [ ] Verify new "Nodes by Packet Type" box appears with NODEINFO selected by default
- [ ] Change dropdown selection — verify chart updates for different packet types
- [ ] Change time range — verify portnum chart updates accordingly
- [ ] Select `--` from dropdown — verify hint message shown instead of chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)