### PR TITLE
chore: bump version to 3.5.1

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.5.0
-appVersion: "3.5.0"
+version: 3.5.1
+appVersion: "3.5.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump version from 3.5.0 to 3.5.1 across all version files: `package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml`, and `desktop/src-tauri/tauri.conf.json`

## Test plan
- [x] `npm test` — all 2465 tests pass
- [x] System tests — all 9 tests pass (config import, quick start, security, V1 API, reverse proxy, OIDC, virtual node CLI, backup/restore, database migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)