### PR TITLE
fix: mobile infinite scroll and always show virtual channels

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1486,11 +1486,8 @@ body {
     flex: 1;
     display: flex;
     flex-direction: column;
-    overflow-y: auto;
-    overflow-x: hidden;
+    overflow: hidden; /* Must be hidden so .messages-container is the scroll target for infinite scroll */
     min-height: 0;
-    /* Prevent scroll chaining to parent */
-    overscroll-behavior: contain;
   }
 
   /* Messages container fills available space and scrolls */
@@ -3679,12 +3676,13 @@ body {
     order: -2; /* Keep header at top when using flexbox order */
   }
 
-  /* Messages container should have minimum height and allow scrolling */
+  /* Messages container: constrain height so it scrolls independently from parent panel */
   .messages-split-view .dm-conversation-panel .messages-container {
-    flex: 1;
-    min-height: 200px; /* Ensure messages get reasonable space */
+    flex: 0 0 auto;
+    min-height: 200px;
     overflow-y: auto;
-    max-height: none;
+    max-height: 60vh; /* Constrain so messages-container is the scroll target for infinite scroll */
+    overscroll-behavior: contain;
   }
 
   /* Send form should be sticky at bottom of viewport */

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -265,6 +265,11 @@ export default function ChannelsTab({
     // Add channels from channel configurations first (these are authoritative)
     channels.forEach(ch => channelSet.add(ch.id));
 
+    // Add virtual channels from Channel Database
+    channelDatabaseEntries.forEach(entry => {
+      channelSet.add(CHANNEL_DB_OFFSET + entry.id);
+    });
+
     // Add channels from messages
     messages.forEach(msg => {
       channelSet.add(msg.channel);


### PR DESCRIPTION
## Summary
- **Fix mobile infinite scroll**: On mobile, both parent container and `.messages-container` had `overflow-y: auto`, causing the parent to scroll instead of the child. Since the scroll event listener is on `.messages-container`, infinite scroll never triggered. Fixed by making the parent `overflow: hidden` for channels and constraining `.messages-container` to `max-height: 60vh` for DMs (which need the parent to scroll for telemetry graphs below messages).
- **Always show virtual channels**: Channel Database virtual channels were missing from the channel list when they had no recent messages, because `getAvailableChannels()` only populated from device channels and messages. Now also adds entries from `channelDatabaseEntries`.

## Test plan
- [x] All 2465 unit tests pass
- [ ] Verify infinite scroll works on mobile for Channels tab
- [ ] Verify infinite scroll works on mobile for Messages (DM) tab
- [ ] Verify virtual channels from Channel Database always appear in channel list
- [ ] Verify desktop layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)