### PR TITLE
fix: hide accuracy region for nodes with overridden positions

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1889,6 +1889,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                   // Check precision data exists
                   if (node.positionPrecisionBits === undefined || node.positionPrecisionBits === null) return false;
                   if (node.positionPrecisionBits <= 0 || node.positionPrecisionBits >= 32) return false;
+                  // Don't show accuracy region for nodes with overridden positions
+                  if (node.positionIsOverride) return false;
                   // Apply standard filters
                   if (!showMqttNodes && node.viaMqtt) return false;
                   if (!showIncompleteNodes && !isNodeComplete(node)) return false;


### PR DESCRIPTION
## Summary
- When a user manually overrides a node's position via "Override Location", the accuracy region rectangle no longer displays on the map
- Adds a `positionIsOverride` check to the accuracy region filter in `NodesTab.tsx` — since user-provided coordinates are exact, the old GPS precision region is misleading

Closes #1908

## Test plan
- [x] `npm run test:run` — all 2465 tests pass
- [ ] Build + deploy dev container, set a node's position override, confirm no accuracy rectangle appears for that node
- [ ] Verify nodes without overridden positions still show accuracy regions normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)