### PR TITLE
fix: packet type filter shows incorrect 'Other' count in distribution chart

### DIFF
--- a/src/server/routes/packetRoutes.ts
+++ b/src/server/routes/packetRoutes.ts
@@ -160,7 +160,7 @@ router.get('/stats/distribution', requirePacketPermissions, async (req, res) => 
     const [byDevice, byType, total] = await Promise.all([
       packetLogService.getPacketCountsByNodeAsync({ since, limit: 10, portnum }),
       packetLogService.getPacketCountsByPortnumAsync({ since, from_node }),
-      packetLogService.getPacketCountAsync({ since, from_node })
+      packetLogService.getPacketCountAsync({ since, from_node, portnum })
     ]);
 
     res.json({


### PR DESCRIPTION
## Summary
- Fixes the "Nodes by Packet Type" chart on the Info Panel showing a massive "Other" block when filtering by a specific packet type (e.g., Neighbor Info)
- **Root cause**: The `/api/packets/stats/distribution` endpoint was not passing the `portnum` filter to `getPacketCountAsync()`, so `total` returned the count of *all* packets instead of just the filtered type
- One-line fix: added `portnum` to the `getPacketCountAsync` call in `src/server/routes/packetRoutes.ts:163`

## Test plan
- [x] Existing packet route tests pass (20/20)
- [ ] Verify in UI: select "Neighbor Info" in the portnum dropdown — chart should show only the source nodes with no "Other" block (unless there are >10 distinct sources)
- [ ] Verify the main "Packet Distribution" charts (without portnum filter) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)