### PR TITLE
chore: bump version to 3.6.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/public/news.json
+++ b/docs/public/news.json
@@ -1,7 +1,16 @@
 {
   "version": "1",
-  "lastUpdated": "2026-02-13T18:00:00Z",
+  "lastUpdated": "2026-02-16T18:00:00Z",
   "items": [
+    {
+      "minVersion": "3.6.0",
+      "id": "news-2026-02-16-auto-ping-vn-branding",
+      "title": "MeshMonitor v3.6.0 - Auto-Ping & Virtual Node Enhancements",
+      "content": "MeshMonitor v3.6.0 introduces the **Auto-Ping** automation feature for mesh network diagnostics and improves **Virtual Node** identification with firmware version branding.\n\n## Auto-Ping Automation\n\nA new DM-command driven **Auto-Ping** feature lets mesh users test connectivity and measure latency to your MeshMonitor node.\n\n### How It Works\n\n- Any mesh user can DM your node with `ping N` to start N pings at a configurable interval\n- Each ping sends a text DM and tracks ACK, NAK, and timeout responses\n- After all pings complete, a summary message is sent with **min/avg/max latency** and timeout count\n- Send `ping stop` to cancel an active session\n\n### Admin Controls\n\n- Configure ping **interval** (default 30s), **max pings** (default 20), and **timeout** (default 60s) in the Automation tab\n- Monitor active ping sessions in real-time with a stop button\n- Enable or disable the feature globally\n\n[Read more about Auto-Ping](https://meshmonitor.org/features/automation#auto-ping)\n\n## Virtual Node Firmware Branding\n\nVirtual Node connections now report a branded firmware version string (e.g., `2.6.6-MM3.6.0`), making it easy to identify that a client is connected through MeshMonitor rather than directly to a physical radio. This appears in both MyNodeInfo and DeviceMetadata responses.\n\n## Other Improvements\n\n- **Virtual Node channel stability** — Fixed an issue where `configComplete` broadcasts during physical radio reconnection could cause VN clients to lose their channel list ([#1920](https://github.com/Yeraze/meshmonitor/pull/1920))\n- **Telemetry packet ID tracking** — Telemetry records now include `packetId` from the originating mesh packet, enabling API consumers to de-duplicate data received via multiple mesh paths ([#1921](https://github.com/Yeraze/meshmonitor/pull/1921))\n- **Packet distribution fix** — Portnum filter now correctly applies to total count in the packet distribution API ([#1919](https://github.com/Yeraze/meshmonitor/pull/1919))\n- **Automation documentation** — Added missing docs for Auto-Ping, Auto Key Management, and Ignored Nodes ([#1918](https://github.com/Yeraze/meshmonitor/pull/1918))\n- **Poll optimization** — Batch queries for `/api/poll` and `/api/unread-counts` reduce database load ([#1909](https://github.com/Yeraze/meshmonitor/pull/1909))\n- **Mobile scroll fix** — Fixed infinite scroll and always-visible virtual channels on mobile ([#1907](https://github.com/Yeraze/meshmonitor/pull/1907))\n- **Dependency updates** — Updated serialport, @serialport/parser-readline, jose, jiti, sass, and sharp",
+      "date": "2026-02-16T18:00:00Z",
+      "category": "feature",
+      "priority": "important"
+    },
     {
       "minVersion": "3.5.0",
       "id": "news-2026-02-13-meshcore-support",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.5.1
-appVersion: "3.5.1"
+version: 3.6.0
+appVersion: "3.6.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "meshmonitor",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.5.1",
+      "version": "3.6.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@maplibre/maplibre-gl-leaflet": "^0.1.3",
-        "@serialport/parser-readline": "13.0.0",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-virtual": "^3.13.16",
         "@types/pbf": "^3.0.5",
@@ -4512,7 +4511,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4799,7 +4798,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
       "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -4831,6 +4830,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7124,6 +7124,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -13142,7 +13143,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -13784,14 +13786,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -15254,7 +15248,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bumps version from 3.5.1 to 3.6.0 in package.json, Helm chart, and Tauri config
- Adds news post for v3.6.0 highlighting Auto-Ping automation and Virtual Node firmware branding
- Regenerated package-lock.json

## Changes since v3.5.1
- **Auto-Ping automation** ([#1917](https://github.com/Yeraze/meshmonitor/pull/1917)) — DM-command driven ping sessions with latency tracking
- **Virtual Node channel fix + firmware branding** ([#1920](https://github.com/Yeraze/meshmonitor/pull/1920)) — Prevents VN channel disappearance, adds `-MM<version>` firmware suffix
- **Telemetry packetId** ([#1921](https://github.com/Yeraze/meshmonitor/pull/1921)) — Enables mesh packet deduplication via API
- **Packet distribution fix** ([#1919](https://github.com/Yeraze/meshmonitor/pull/1919)) — Portnum filter applies to total count
- **Automation docs** ([#1918](https://github.com/Yeraze/meshmonitor/pull/1918)) — Auto-Ping, Auto Key Management, Ignored Nodes
- **Poll optimization** ([#1909](https://github.com/Yeraze/meshmonitor/pull/1909)) — Batch queries for poll/unread-counts
- **Mobile scroll fix** ([#1907](https://github.com/Yeraze/meshmonitor/pull/1907)) — Infinite scroll + virtual channels on mobile
- Dependency updates: serialport 13.0.0, @serialport/parser-readline 13.0.0, jose, jiti, sass, sharp

## Test plan
- [ ] System tests pass
- [ ] CI passes
- [ ] Verify news post renders correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)