### PR TITLE
fix: derive short name from last 4 hex chars of node ID

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3487,7 +3487,7 @@ function App() {
 
   const getNodeShortName = (nodeId: string): string => {
     const node = nodes.find(n => n.user?.id === nodeId);
-    return (node?.user?.shortName && node.user.shortName.trim()) || nodeId.substring(1, 5);
+    return (node?.user?.shortName && node.user.shortName.trim()) || nodeId.slice(-4);
   };
 
   const getAvailableChannels = (): number[] => {

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -179,7 +179,7 @@ export default function ChannelsTab({
       nodeNum: node.nodeNum,
       nodeId: node.user?.id || `!${node.nodeNum.toString(16).padStart(8, '0')}`,
       longName: node.user?.longName || `Node ${node.nodeNum}`,
-      shortName: node.user?.shortName || node.nodeNum.toString(16).substring(0, 4),
+      shortName: node.user?.shortName || node.nodeNum.toString(16).padStart(8, '0').slice(-4),
       hopsAway: node.hopsAway,
       role: typeof node.user?.role === 'string' ? parseInt(node.user.role, 10) : node.user?.role,
       avgDirectRssi: stats?.avgRssi,

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -340,7 +340,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
       nodeNum: node.nodeNum,
       nodeId: node.user?.id || `!${node.nodeNum.toString(16).padStart(8, '0')}`,
       longName: node.user?.longName || `Node ${node.nodeNum}`,
-      shortName: node.user?.shortName || node.nodeNum.toString(16).substring(0, 4),
+      shortName: node.user?.shortName || node.nodeNum.toString(16).padStart(8, '0').slice(-4),
       hopsAway: node.hopsAway,
       role: typeof node.user?.role === 'string' ? parseInt(node.user.role, 10) : node.user?.role,
       avgDirectRssi: stats?.avgRssi,
@@ -363,7 +363,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   const getNodeShortName = useCallback(
     (nodeId: string): string => {
       const node = nodes.find(n => n.user?.id === nodeId);
-      return (node?.user?.shortName && node.user.shortName.trim()) || nodeId.substring(1, 5);
+      return (node?.user?.shortName && node.user.shortName.trim()) || nodeId.slice(-4);
     },
     [nodes]
   );

--- a/src/components/PacketMonitorPanel.tsx
+++ b/src/components/PacketMonitorPanel.tsx
@@ -250,7 +250,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
       nodeNum: node.nodeNum,
       nodeId: node.user?.id || `!${node.nodeNum.toString(16).padStart(8, '0')}`,
       longName: node.user?.longName || `Node ${node.nodeNum}`,
-      shortName: node.user?.shortName || node.nodeNum.toString(16).substring(0, 4),
+      shortName: node.user?.shortName || node.nodeNum.toString(16).padStart(8, '0').slice(-4),
       hopsAway: node.hopsAway,
       role: typeof node.user?.role === 'string' ? parseInt(node.user.role, 10) : node.user?.role,
       avgDirectRssi: stats?.avgRssi,

--- a/src/components/admin-commands/nodeOptionsUtils.ts
+++ b/src/components/admin-commands/nodeOptionsUtils.ts
@@ -58,7 +58,7 @@ export function buildNodeOptions(
         nodeNum: node.nodeNum,
         nodeId: nodeId,
         longName: longName || `Node ${nodeId}`,
-        shortName: shortName || (nodeId.startsWith('!') ? nodeId.substring(1, 5) : nodeId.substring(0, 4)),
+        shortName: shortName || nodeId.slice(-4),
         isLocal: false,
         isFavorite: node.isFavorite ?? false,
         isIgnored: node.isIgnored ?? false,

--- a/src/server/meshtasticManager.autowelcome.test.ts
+++ b/src/server/meshtasticManager.autowelcome.test.ts
@@ -152,7 +152,7 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
         nodeNum: 999999,
         nodeId: '!000f423f',
         longName: 'Test Node',
-        shortName: '000f', // Default short name (first 4 chars after !)
+        shortName: '423f', // Default short name (last 4 chars of nodeId)
         hwModel: 0,
         createdAt: Date.now(),
         updatedAt: Date.now(),

--- a/src/server/meshtasticManager.test.ts
+++ b/src/server/meshtasticManager.test.ts
@@ -618,7 +618,7 @@ describe('MeshtasticManager - Configuration Polling', () => {
         nodeNum,
         nodeId,
         longName: `Node ${nodeId}`,
-        shortName: nodeId.substring(1, 5),
+        shortName: nodeId.slice(-4),
         lastHeard: Date.now() / 1000,
       });
 

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3419,7 +3419,7 @@ class MeshtasticManager {
       // Only set default name if this is a brand new node
       if (!existingNode) {
         nodeData.longName = `Node ${nodeId}`;
-        nodeData.shortName = nodeId.substring(1, 5);
+        nodeData.shortName = nodeId.slice(-4);
       }
 
       // Only include SNR/RSSI if they have valid values
@@ -3538,7 +3538,7 @@ class MeshtasticManager {
             nodeNum: fromNum,
             nodeId: fromNodeId,
             longName: `Node ${fromNodeId}`,
-            shortName: fromNodeId.substring(1, 5),
+            shortName: fromNodeId.slice(-4),
             lastHeard: Date.now() / 1000,
             createdAt: Date.now(),
             updatedAt: Date.now()
@@ -4365,7 +4365,7 @@ class MeshtasticManager {
           nodeNum: fromNum,
           nodeId: fromNodeId,
           longName: `Node ${fromNodeId}`,
-          shortName: fromNodeId.substring(1, 5),
+          shortName: fromNodeId.slice(-4),
           lastHeard: Date.now() / 1000
         });
       } else {
@@ -4384,7 +4384,7 @@ class MeshtasticManager {
           nodeNum: toNum,
           nodeId: toNodeId,
           longName: `Node ${toNodeId}`,
-          shortName: toNodeId.substring(1, 5),
+          shortName: toNodeId.slice(-4),
           lastHeard: Date.now() / 1000
         });
       } else {
@@ -4988,7 +4988,7 @@ class MeshtasticManager {
             nodeNum,
             nodeId,
             longName: `Node ${nodeId}`,
-            shortName: nodeId.substring(1, 5),
+            shortName: nodeId.slice(-4),
             lastHeard: Date.now() / 1000
           });
           node = databaseService.getNode(nodeNum);
@@ -5134,7 +5134,7 @@ class MeshtasticManager {
           nodeNum: fromNum,
           nodeId: fromNodeId,
           longName: `Node ${fromNodeId}`,
-          shortName: fromNodeId.substring(1, 5),
+          shortName: fromNodeId.slice(-4),
           lastHeard: Date.now() / 1000
         });
         senderNode = databaseService.getNode(fromNum);
@@ -5162,7 +5162,7 @@ class MeshtasticManager {
               nodeNum: neighborNodeNum,
               nodeId: neighborNodeId,
               longName: `Node ${neighborNodeId}`,
-              shortName: neighborNodeId.substring(1, 5),
+              shortName: neighborNodeId.slice(-4),
               hopsAway: senderHopsAway + 1,
               lastHeard: Date.now() / 1000
             });
@@ -5594,7 +5594,7 @@ class MeshtasticManager {
           nodeNum: nodeNum,
           nodeId: nodeId,
           longName: possibleName.longName || `Node ${nodeId}`,
-          shortName: possibleName.shortName || nodeId.substring(1, 5),
+          shortName: possibleName.shortName || nodeId.slice(-4),
           hwModel: possibleName.hwModel || 0,
           lastHeard: Date.now() / 1000,
           snr: possibleName.snr,
@@ -6566,7 +6566,7 @@ class MeshtasticManager {
           nodeNum: fromNodeNum,
           nodeId: fromNodeId,
           longName: fromNodeId === 'unknown' ? 'Unknown Node' : fromNodeId,
-          shortName: fromNodeId === 'unknown' ? 'UNK' : fromNodeId.substring(1, 5),
+          shortName: fromNodeId === 'unknown' ? 'UNK' : fromNodeId.slice(-4),
           hwModel: 0,
           lastHeard: Date.now() / 1000,
           createdAt: Date.now(),
@@ -6593,7 +6593,7 @@ class MeshtasticManager {
           nodeNum: toNodeNum,
           nodeId: toNodeId,
           longName: toNodeId === '!ffffffff' ? 'Broadcast' : toNodeId,
-          shortName: toNodeId === '!ffffffff' ? 'BCST' : toNodeId.substring(1, 5),
+          shortName: toNodeId === '!ffffffff' ? 'BCST' : toNodeId.slice(-4),
           hwModel: 0,
           lastHeard: Date.now() / 1000,
           createdAt: Date.now(),
@@ -8833,7 +8833,7 @@ class MeshtasticManager {
           logger.debug(`⏭️  Skipping auto-welcome for ${nodeId} - waiting for proper name (current: ${node.longName})`);
           return;
         }
-        if (!node.shortName || node.shortName === nodeId.substring(1, 5)) {
+        if (!node.shortName || node.shortName === nodeId.slice(-4)) {
           logger.debug(`⏭️  Skipping auto-welcome for ${nodeId} - waiting for proper short name (current: ${node.shortName})`);
           return;
         }

--- a/src/utils/nodeHelpers.test.ts
+++ b/src/utils/nodeHelpers.test.ts
@@ -171,13 +171,13 @@ describe('Node Helpers', () => {
       expect(getNodeShortName(mockNodes, '!abc12345')).toBe('TNA');
     });
 
-    it('should extract first 4 chars from node ID if no short name', () => {
-      expect(getNodeShortName(mockNodes, '!def67890')).toBe('def6'); // Whitespace-only short name
-      expect(getNodeShortName(mockNodes, '!ghi11111')).toBe('ghi1'); // Empty short name
+    it('should extract last 4 chars from node ID if no short name', () => {
+      expect(getNodeShortName(mockNodes, '!def67890')).toBe('7890'); // Whitespace-only short name
+      expect(getNodeShortName(mockNodes, '!ghi11111')).toBe('1111'); // Empty short name
     });
 
-    it('should extract first 4 chars for unknown nodes', () => {
-      expect(getNodeShortName(mockNodes, '!xyz99999')).toBe('xyz9');
+    it('should extract last 4 chars for unknown nodes', () => {
+      expect(getNodeShortName(mockNodes, '!xyz99999')).toBe('9999');
     });
 
     it('should handle node IDs shorter than 5 characters', () => {
@@ -194,7 +194,7 @@ describe('Node Helpers', () => {
     });
 
     it('should handle empty nodes array', () => {
-      expect(getNodeShortName([], '!test1234')).toBe('test');
+      expect(getNodeShortName([], '!test1234')).toBe('1234');
     });
 
     it('should trim whitespace from short names', () => {
@@ -290,13 +290,13 @@ describe('Node Helpers', () => {
         expect(isNodeComplete(node)).toBe(false);
       });
 
-      it('should return false for node with default shortName (first 4 chars of nodeId)', () => {
+      it('should return false for node with default shortName (last 4 chars of nodeId)', () => {
         const node: DeviceInfo = {
           nodeNum: 123456789,
           user: {
             id: '!abc12345',
             longName: 'Test Node',
-            shortName: 'abc1', // First 4 chars of node ID without !
+            shortName: '2345', // Last 4 chars of node ID
             hwModel: 9
           }
         };
@@ -379,7 +379,7 @@ describe('Node Helpers', () => {
         const dbNode = {
           nodeId: '!abc12345',
           longName: 'Test Node',
-          shortName: 'abc1', // Default derived from nodeId
+          shortName: '2345', // Default derived from last 4 chars of nodeId
           hwModel: 9
         };
         expect(isNodeComplete(dbNode)).toBe(false);

--- a/src/utils/nodeHelpers.ts
+++ b/src/utils/nodeHelpers.ts
@@ -270,7 +270,7 @@ export const getNodeShortName = (nodes: DeviceInfo[], nodeId: string): string =>
   // Safely extract substring from nodeId
   // Node IDs are typically formatted as !XXXXXXXX (8 hex chars)
   if (nodeId.length >= 5 && nodeId.startsWith('!')) {
-    return nodeId.substring(1, 5);
+    return nodeId.slice(-4);
   }
 
   // Fallback to full nodeId if it's too short or doesn't match expected format
@@ -327,7 +327,7 @@ export const isNodeComplete = (node: DeviceInfo | DbNodeLike): boolean => {
 
   // If we have a nodeId, verify shortName isn't just derived from it
   if (nodeId && nodeId.startsWith('!')) {
-    const defaultShortName = nodeId.substring(1, 5);
+    const defaultShortName = nodeId.slice(-4);
     if (shortName === defaultShortName) {
       return false;
     }


### PR DESCRIPTION
## Summary
- Fixed default short name derivation to use the **last 4** hex characters of the node ID instead of the first 4, matching standard Meshtastic convention (e.g., `!12344f7b` → `4f7b` instead of `1234`)
- Updated all 10 affected files across frontend components, backend manager, utility helpers, and tests
- For `nodeNum`-based derivations, added `padStart(8, '0')` to ensure correct 8-char hex before slicing last 4

Closes #1929

## Test plan
- [x] `nodeHelpers.test.ts` — 59/59 passing
- [x] `meshtasticManager.test.ts` — 35/35 passing
- [x] `meshtasticManager.autowelcome.test.ts` — 18/18 passing
- [x] Full test suite — 2511 passing, 0 failures related to this change
- [ ] Visual verification in running instance that node short names display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)