### PR TITLE
fix: memoize map marker icons to prevent position update interference

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1035,7 +1035,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     const isLocalNode = n.user?.id === currentNodeId;
     const hops = isLocalNode ? 0 : getEffectiveHops(n, nodeHopsCalculation, traceroutes, currentNodeNum);
     const shouldAnimate = showAnimations && animatedNodes.has(n.user?.id || '');
-    return `${n.nodeNum}-${hops}-${isSelected}-${n.user?.role}-${n.user?.shortName}-${showLabel || shouldAnimate}-${shouldAnimate}-${showRoute && isSelected}-${mapPinStyle}`;
+    return `${n.nodeNum}-${hops}-${isSelected}-${n.user?.role}-${n.user?.shortName}-${showLabel}-${shouldAnimate}-${showRoute && isSelected}-${mapPinStyle}`;
   }).join(',')]);
 
   // Calculate center point of all nodes for initial map view


### PR DESCRIPTION
## Summary
- Memoizes marker icons in `NodesTab.tsx` using `React.useMemo` to prevent unnecessary Leaflet DOM rebuilds that interfere with position updates
- React-Leaflet calls `setIcon()` whenever the icon prop reference changes, which destroys and recreates the entire icon DOM element. Since `createNodeIcon()` returned a new `L.DivIcon` on every render, this caused constant DOM rebuilds
- Icons are now keyed on visual properties (hops, selection state, role, shortName, zoom level, animation, pin style) so `setIcon()` is only called when the icon actually needs to change

Closes #1934

## Test plan
- [ ] Verify nodes with emoji short names update position on the map when new position data arrives
- [ ] Verify node icons still change appearance correctly when selected/deselected
- [ ] Verify hop-based coloring still works correctly
- [ ] Verify zoom-based label visibility still works
- [ ] Verify node animation (pulse) still works for newly heard nodes
- [ ] All 2512 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)