### PR TITLE
fix: prevent fractional values in integer telemetry graphs

### DIFF
--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -12,6 +12,21 @@ import { formatChartAxisTimestamp, formatTime } from '../utils/datetime';
 import { useSettings } from '../contexts/SettingsContext';
 import { ChartData } from '../types/ui';
 
+/** Telemetry types that represent discrete integer values where fractional display is meaningless */
+const INTEGER_TELEMETRY_TYPES = new Set([
+  'sats_in_view',
+  'messageHops',
+  'batteryLevel',
+  'numOnlineNodes', 'numTotalNodes',
+  'numPacketsTx', 'numPacketsRx', 'numPacketsRxBad',
+  'numRxDupe', 'numTxRelay', 'numTxRelayCanceled', 'numTxDropped',
+  'systemNodeCount', 'systemDirectNodeCount',
+  'paxcounterWifi', 'paxcounterBle',
+  'particles03um', 'particles05um', 'particles10um',
+  'particles25um', 'particles50um', 'particles100um',
+  'co2', 'iaq',
+]);
+
 interface TelemetryGraphsProps {
   nodeId: string;
   temperatureUnit?: TemperatureUnit;
@@ -708,7 +723,8 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
                       yAxisId="left"
                       tick={{ fontSize: 12 }}
                       domain={['auto', 'auto']}
-                      allowDecimals={type !== 'sats_in_view'}
+                      allowDecimals={!INTEGER_TELEMETRY_TYPES.has(type)}
+                      tickFormatter={INTEGER_TELEMETRY_TYPES.has(type) ? (v: number) => Math.round(v).toString() : undefined}
                     />
                     <YAxis
                       yAxisId="right"

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -5307,7 +5307,19 @@ class DatabaseService {
 
     // Telemetry types that should use raw values instead of averaging
     // These are discrete integer values where averaging produces meaningless floats
-    const rawValueTypes = ['sats_in_view'];
+    const rawValueTypes = [
+      'sats_in_view',
+      'messageHops',
+      'batteryLevel',
+      'numOnlineNodes', 'numTotalNodes',
+      'numPacketsTx', 'numPacketsRx', 'numPacketsRxBad',
+      'numRxDupe', 'numTxRelay', 'numTxRelayCanceled', 'numTxDropped',
+      'systemNodeCount', 'systemDirectNodeCount',
+      'paxcounterWifi', 'paxcounterBle',
+      'particles03um', 'particles05um', 'particles10um',
+      'particles25um', 'particles50um', 'particles100um',
+      'co2', 'iaq',
+    ];
 
     // Build the query to group and average telemetry data by time intervals
     // Exclude raw value types from this query - they'll be fetched separately


### PR DESCRIPTION
## Summary
- Expands `rawValueTypes` in the telemetry query to include all discrete integer types (`messageHops`, `batteryLevel`, node counts, packet counts, particle counts, `co2`, `iaq`), so they bypass `AVG()` bucketing and return raw values
- Adds `INTEGER_TELEMETRY_TYPES` set in `TelemetryGraphs.tsx` to suppress decimal ticks on the Y-axis for those types
- Adds `tickFormatter` to round any residual float tick labels for integer types

Fixes #1936

## Test plan
- [x] `npx tsc --noEmit` passes (only pre-existing serialport type errors)
- [x] `npx vitest run` — 2512 tests pass
- [x] Deployed to dev container and verified `messageHops` graph shows integer-only values
- [ ] Verify float metrics (voltage, temperature, channelUtilization) still display with decimals and averaging
- [ ] Verify other integer metrics (batteryLevel, node counts, packet counts) show integer-only values

🤖 Generated with [Claude Code](https://claude.com/claude-code)