### PR TITLE
fix: hide Show MeshCore toggle when disabled and persist its state

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -280,7 +280,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     nodeHopsCalculation,
   } = useSettings();
 
-  const { hasPermission } = useAuth();
+  const { hasPermission, authStatus } = useAuth();
 
   // Parse current node ID to get node number for effective hops calculation
   const currentNodeNum = currentNodeId ? parseNodeId(currentNodeId) : null;
@@ -1590,6 +1590,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                     />
                     <span>Show MQTT</span>
                   </label>
+                  {authStatus?.meshcoreEnabled && (
                   <label className="map-control-item">
                     <input
                       type="checkbox"
@@ -1598,6 +1599,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                     />
                     <span>Show MeshCore</span>
                   </label>
+                  )}
                   <label className="map-control-item">
                     <input
                       type="checkbox"

--- a/src/server/migrations/074_add_show_meshcore_nodes_preference.ts
+++ b/src/server/migrations/074_add_show_meshcore_nodes_preference.ts
@@ -1,0 +1,90 @@
+/**
+ * Migration 074: Add show_meshcore_nodes column to user_map_preferences
+ *
+ * Adds the show_meshcore_nodes boolean column so the "Show MeshCore" map
+ * feature toggle persists across page loads, matching all other map toggles.
+ */
+
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * SQLite migration: Add show_meshcore_nodes column
+ */
+export const migration = {
+  up: (db: Database): void => {
+    logger.debug('Running migration 074: Adding show_meshcore_nodes column...');
+
+    const tableInfo = db.prepare('PRAGMA table_info(user_map_preferences)').all() as Array<{ name: string }>;
+    const columnExists = tableInfo.some((col) => col.name === 'show_meshcore_nodes');
+
+    if (!columnExists) {
+      db.prepare('ALTER TABLE user_map_preferences ADD COLUMN show_meshcore_nodes INTEGER DEFAULT 1 CHECK (show_meshcore_nodes IN (0, 1))').run();
+      logger.debug('✅ Added show_meshcore_nodes column to user_map_preferences');
+    } else {
+      logger.debug('Column show_meshcore_nodes already exists, skipping');
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 074 down: SQLite does not support dropping columns');
+  },
+};
+
+/**
+ * PostgreSQL migration: Add show_meshcore_nodes column
+ */
+export async function runMigration074Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 074 (PostgreSQL): Adding show_meshcore_nodes column...');
+
+  try {
+    const result = await client.query(`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'user_map_preferences' AND column_name = 'show_meshcore_nodes'
+    `);
+
+    if (result.rows.length === 0) {
+      await client.query(`
+        ALTER TABLE user_map_preferences
+        ADD COLUMN show_meshcore_nodes BOOLEAN DEFAULT TRUE
+      `);
+      logger.debug('✅ Added show_meshcore_nodes column to user_map_preferences');
+    } else {
+      logger.debug('Column show_meshcore_nodes already exists, skipping');
+    }
+  } catch (error: any) {
+    logger.error('Failed to add show_meshcore_nodes column:', error.message);
+    throw error;
+  }
+
+  logger.info('✅ Migration 074 complete (PostgreSQL)');
+}
+
+/**
+ * MySQL migration: Add show_meshcore_nodes column
+ */
+export async function runMigration074Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 074 (MySQL): Adding show_meshcore_nodes column...');
+
+  try {
+    const [rows] = await pool.query(`
+      SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_NAME = 'user_map_preferences' AND COLUMN_NAME = 'show_meshcore_nodes'
+    `);
+
+    if ((rows as any[]).length === 0) {
+      await pool.query(`
+        ALTER TABLE user_map_preferences
+        ADD COLUMN show_meshcore_nodes TINYINT(1) DEFAULT 1
+      `);
+      logger.debug('✅ Added show_meshcore_nodes column to user_map_preferences');
+    } else {
+      logger.debug('Column show_meshcore_nodes already exists, skipping');
+    }
+  } catch (error: any) {
+    logger.error('Failed to add show_meshcore_nodes column:', error.message);
+    throw error;
+  }
+
+  logger.info('✅ Migration 074 complete (MySQL)');
+}

--- a/src/server/models/User.ts
+++ b/src/server/models/User.ts
@@ -403,6 +403,7 @@ export class UserModel {
         show_route as showRoute,
         show_motion as showMotion,
         show_mqtt_nodes as showMqttNodes,
+        show_meshcore_nodes as showMeshCoreNodes,
         show_animations as showAnimations,
         position_history_hours as positionHistoryHours
       FROM user_map_preferences
@@ -419,6 +420,7 @@ export class UserModel {
       showRoute: Boolean(row.showRoute),
       showMotion: Boolean(row.showMotion),
       showMqttNodes: Boolean(row.showMqttNodes),
+      showMeshCoreNodes: Boolean(row.showMeshCoreNodes),
       showAnimations: Boolean(row.showAnimations),
       positionHistoryHours: row.positionHistoryHours ?? null,
     };
@@ -434,6 +436,7 @@ export class UserModel {
     showRoute?: boolean;
     showMotion?: boolean;
     showMqttNodes?: boolean;
+    showMeshCoreNodes?: boolean;
     showAnimations?: boolean;
     positionHistoryHours?: number | null;
   }): void {
@@ -471,6 +474,10 @@ export class UserModel {
         updates.push('show_mqtt_nodes = ?');
         params.push(preferences.showMqttNodes ? 1 : 0);
       }
+      if (preferences.showMeshCoreNodes !== undefined) {
+        updates.push('show_meshcore_nodes = ?');
+        params.push(preferences.showMeshCoreNodes ? 1 : 0);
+      }
       if (preferences.showAnimations !== undefined) {
         updates.push('show_animations = ?');
         params.push(preferences.showAnimations ? 1 : 0);
@@ -497,9 +504,9 @@ export class UserModel {
       const stmt = this.db.prepare(`
         INSERT INTO user_map_preferences (
           user_id, map_tileset, show_paths, show_neighbor_info,
-          show_route, show_motion, show_mqtt_nodes, show_animations,
+          show_route, show_motion, show_mqtt_nodes, show_meshcore_nodes, show_animations,
           position_history_hours, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
       stmt.run(
@@ -510,6 +517,7 @@ export class UserModel {
         preferences.showRoute !== undefined ? (preferences.showRoute ? 1 : 0) : 1, // default true
         preferences.showMotion !== undefined ? (preferences.showMotion ? 1 : 0) : 1, // default true
         preferences.showMqttNodes !== undefined ? (preferences.showMqttNodes ? 1 : 0) : 1, // default true
+        preferences.showMeshCoreNodes !== undefined ? (preferences.showMeshCoreNodes ? 1 : 0) : 1, // default true
         preferences.showAnimations ? 1 : 0,
         preferences.positionHistoryHours ?? null,
         now,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5527,10 +5527,10 @@ apiRouter.post('/user/map-preferences', requireAuth(), (req, res) => {
       return res.status(403).json({ error: 'Cannot save preferences for anonymous user' });
     }
 
-    const { mapTileset, showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showAnimations, positionHistoryHours } = req.body;
+    const { mapTileset, showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showMeshCoreNodes, showAnimations, positionHistoryHours } = req.body;
 
     // Validate boolean values
-    const booleanFields = { showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showAnimations };
+    const booleanFields = { showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showMeshCoreNodes, showAnimations };
     for (const [key, value] of Object.entries(booleanFields)) {
       if (value !== undefined && typeof value !== 'boolean') {
         return res.status(400).json({ error: `${key} must be a boolean` });
@@ -5555,6 +5555,7 @@ apiRouter.post('/user/map-preferences', requireAuth(), (req, res) => {
       showRoute,
       showMotion,
       showMqttNodes,
+      showMeshCoreNodes,
       showAnimations,
       positionHistoryHours,
     });


### PR DESCRIPTION
## Summary
- Hide the "Show MeshCore" checkbox in the map Features panel when `MESHCORE_ENABLED` is not set, matching the sidebar behavior
- Fix persistence of the Show MeshCore toggle — the frontend was sending the preference but the backend silently dropped it at every layer (no DB column, not in the User model, not in the server route)
- Add migration 074 to create `show_meshcore_nodes` column in `user_map_preferences` for SQLite, PostgreSQL, and MySQL

## Test plan
- [x] With `MESHCORE_ENABLED=false` (default), verify the "Show MeshCore" checkbox is not visible in map Features panel
- [ ] With `MESHCORE_ENABLED=true`, verify the checkbox appears and toggles MeshCore nodes on the map
- [ ] Toggle "Show MeshCore" off, reload the page, verify it stays off
- [ ] Toggle "Show MeshCore" on, reload the page, verify it stays on
- [ ] Verify other map feature toggles still persist correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)