### PR TITLE
feat: differentiate own vs others' tapback reactions by color

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4040,15 +4040,28 @@ body {
   align-items: center;
   justify-content: center;
   padding: 2px 6px;
-  background: var(--ctp-surface1);
-  border: 1px solid var(--ctp-surface2);
   border-radius: 12px;
   font-size: 14px;
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
-.reaction:hover {
+.reaction.mine {
+  background: var(--ctp-blue);
+  border: 1px solid var(--ctp-blue);
+}
+
+.reaction.theirs {
+  background: var(--ctp-surface1);
+  border: 1px solid var(--ctp-surface2);
+}
+
+.reaction.mine:hover {
+  background: var(--ctp-sapphire);
+  transform: scale(1.1);
+}
+
+.reaction.theirs:hover {
   background: var(--ctp-surface2);
   transform: scale(1.1);
 }

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -728,7 +728,7 @@ export default function ChannelsTab({
                                         {reactions.map(reaction => (
                                           <span
                                             key={reaction.id}
-                                            className="reaction"
+                                            className={`reaction ${isMyMessage(reaction) ? 'mine' : 'theirs'}`}
                                             title={t('channels.reaction_tooltip', { name: getNodeShortName(reaction.from) })}
                                             onClick={() => handleSendTapback(reaction.text, msg)}
                                           >

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -1259,7 +1259,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                 {reactions.map(reaction => (
                                   <span
                                     key={reaction.id}
-                                    className="reaction"
+                                    className={`reaction ${isMyMessage(reaction) ? 'mine' : 'theirs'}`}
                                     title={t('messages.reaction_tooltip', { name: getNodeShortName(reaction.from) })}
                                     onClick={() => handleSendTapback(reaction.text, msg)}
                                   >


### PR DESCRIPTION
## Summary
- Apply the same mine/theirs color scheme used for message bubbles to tapback emoji reactions
- Own reactions appear in blue (matching sent message color), others' in gray surface (matching received message color)
- Applied consistently to both MessagesTab (DMs) and ChannelsTab (channels)

## Test plan
- [ ] Send a tapback reaction on a message — verify it appears in blue
- [ ] Receive a tapback reaction from another node — verify it appears in gray
- [ ] Test in both DM and channel views
- [ ] Verify hover effects work correctly on both mine/theirs reactions
- [ ] Test with different Catppuccin themes (light/dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)