### PR TITLE
fix: use actual data tables for node packet type distribution

### DIFF
--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -4,7 +4,7 @@
  * Handles all message-related database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, gt, lt, and, or, desc, sql } from 'drizzle-orm';
+import { eq, gt, gte, lt, and, or, desc, sql } from 'drizzle-orm';
 import { messagesSqlite, messagesPostgres, messagesMysql } from '../schema/messages.js';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbMessage } from '../types.js';
@@ -338,6 +338,61 @@ export class MessagesRepository extends BaseRepository {
     } else {
       const db = this.getPostgresDb();
       const result = await db.select().from(messagesPostgres);
+      return result.length;
+    }
+  }
+
+  /**
+   * Count messages sent from or to a specific node (by nodeNum).
+   */
+  async getMessageCountByNode(nodeNum: number, since?: number): Promise<number> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const conditions = [
+        or(
+          eq(messagesSqlite.fromNodeNum, nodeNum),
+          eq(messagesSqlite.toNodeNum, nodeNum),
+        ),
+      ];
+      if (since !== undefined) {
+        conditions.push(gte(messagesSqlite.timestamp, since));
+      }
+      const result = await db
+        .select()
+        .from(messagesSqlite)
+        .where(and(...conditions));
+      return result.length;
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      const conditions = [
+        or(
+          eq(messagesMysql.fromNodeNum, nodeNum),
+          eq(messagesMysql.toNodeNum, nodeNum),
+        ),
+      ];
+      if (since !== undefined) {
+        conditions.push(gte(messagesMysql.timestamp, since));
+      }
+      const result = await db
+        .select()
+        .from(messagesMysql)
+        .where(and(...conditions));
+      return result.length;
+    } else {
+      const db = this.getPostgresDb();
+      const conditions = [
+        or(
+          eq(messagesPostgres.fromNodeNum, nodeNum),
+          eq(messagesPostgres.toNodeNum, nodeNum),
+        ),
+      ];
+      if (since !== undefined) {
+        conditions.push(gte(messagesPostgres.timestamp, since));
+      }
+      const result = await db
+        .select()
+        .from(messagesPostgres)
+        .where(and(...conditions));
       return result.length;
     }
   }

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -140,6 +140,129 @@ export class TelemetryRepository extends BaseRepository {
   }
 
   /**
+   * Position telemetry types (from POSITION_APP packets, stored in the telemetry table)
+   */
+  private static POSITION_TYPES = ['latitude', 'longitude', 'altitude', 'ground_speed', 'ground_track', 'sats_in_view'];
+
+  /**
+   * Packet metadata types (extracted from any packet's headers, not from a specific portnum)
+   * These should be excluded from TELEMETRY_APP counts since they don't represent actual telemetry packets.
+   */
+  private static METADATA_TYPES = ['messageHops', 'snr_local', 'snr_remote', 'rssi', 'linkQuality'];
+
+  /**
+   * Count distinct position packets for a node.
+   * Position data is stored as individual telemetry rows per metric, so we count DISTINCT packetTimestamp
+   * to get the actual number of position packets received.
+   */
+  async getPositionPacketCountByNode(nodeId: string, since?: number): Promise<number> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const conditions = [
+        eq(telemetrySqlite.nodeId, nodeId),
+        inArray(telemetrySqlite.telemetryType, TelemetryRepository.POSITION_TYPES),
+      ];
+      if (since !== undefined) {
+        conditions.push(gte(telemetrySqlite.timestamp, since));
+      }
+      const result = await db
+        .select({ ts: telemetrySqlite.packetTimestamp })
+        .from(telemetrySqlite)
+        .where(and(...conditions))
+        .groupBy(telemetrySqlite.packetTimestamp);
+      return result.length;
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      const conditions = [
+        eq(telemetryMysql.nodeId, nodeId),
+        inArray(telemetryMysql.telemetryType, TelemetryRepository.POSITION_TYPES),
+      ];
+      if (since !== undefined) {
+        conditions.push(gte(telemetryMysql.timestamp, since));
+      }
+      const result = await db
+        .select({ ts: telemetryMysql.packetTimestamp })
+        .from(telemetryMysql)
+        .where(and(...conditions))
+        .groupBy(telemetryMysql.packetTimestamp);
+      return result.length;
+    } else {
+      const db = this.getPostgresDb();
+      const conditions = [
+        eq(telemetryPostgres.nodeId, nodeId),
+        inArray(telemetryPostgres.telemetryType, TelemetryRepository.POSITION_TYPES),
+      ];
+      if (since !== undefined) {
+        conditions.push(gte(telemetryPostgres.timestamp, since));
+      }
+      const result = await db
+        .select({ ts: telemetryPostgres.packetTimestamp })
+        .from(telemetryPostgres)
+        .where(and(...conditions))
+        .groupBy(telemetryPostgres.packetTimestamp);
+      return result.length;
+    }
+  }
+
+  /**
+   * Count distinct non-position telemetry packets for a node.
+   * Non-position telemetry includes battery, temperature, humidity, voltage, etc.
+   * Each packet generates multiple rows (one per metric), so we count DISTINCT packetTimestamp.
+   */
+  async getNonPositionTelemetryPacketCountByNode(nodeId: string, since?: number): Promise<number> {
+    // Exclude both position types and packet metadata types (rssi, snr, etc.)
+    // to only count actual TELEMETRY_APP packets (device metrics, environment, power, air quality)
+    const excludedTypes = [...TelemetryRepository.POSITION_TYPES, ...TelemetryRepository.METADATA_TYPES];
+
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const conditions = [
+        eq(telemetrySqlite.nodeId, nodeId),
+        not(inArray(telemetrySqlite.telemetryType, excludedTypes)),
+      ];
+      if (since !== undefined) {
+        conditions.push(gte(telemetrySqlite.timestamp, since));
+      }
+      const result = await db
+        .select({ ts: telemetrySqlite.packetTimestamp })
+        .from(telemetrySqlite)
+        .where(and(...conditions))
+        .groupBy(telemetrySqlite.packetTimestamp);
+      return result.length;
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      const conditions = [
+        eq(telemetryMysql.nodeId, nodeId),
+        not(inArray(telemetryMysql.telemetryType, excludedTypes)),
+      ];
+      if (since !== undefined) {
+        conditions.push(gte(telemetryMysql.timestamp, since));
+      }
+      const result = await db
+        .select({ ts: telemetryMysql.packetTimestamp })
+        .from(telemetryMysql)
+        .where(and(...conditions))
+        .groupBy(telemetryMysql.packetTimestamp);
+      return result.length;
+    } else {
+      const db = this.getPostgresDb();
+      const conditions = [
+        eq(telemetryPostgres.nodeId, nodeId),
+        not(inArray(telemetryPostgres.telemetryType, excludedTypes)),
+      ];
+      if (since !== undefined) {
+        conditions.push(gte(telemetryPostgres.timestamp, since));
+      }
+      const result = await db
+        .select({ ts: telemetryPostgres.packetTimestamp })
+        .from(telemetryPostgres)
+        .where(and(...conditions))
+        .groupBy(telemetryPostgres.packetTimestamp);
+      return result.length;
+    }
+  }
+
+  /**
    * Get telemetry by node with optional filters
    */
   async getTelemetryByNode(

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -393,6 +393,61 @@ export class TraceroutesRepository extends BaseRepository {
     }
   }
 
+  /**
+   * Count traceroutes involving a specific node (by nodeNum).
+   */
+  async getTracerouteCountByNode(nodeNum: number, since?: number): Promise<number> {
+    if (this.isSQLite()) {
+      const db = this.getSqliteDb();
+      const conditions = [
+        or(
+          eq(traceroutesSqlite.fromNodeNum, nodeNum),
+          eq(traceroutesSqlite.toNodeNum, nodeNum),
+        ),
+      ];
+      if (since !== undefined) {
+        conditions.push(gte(traceroutesSqlite.timestamp, since));
+      }
+      const result = await db
+        .select()
+        .from(traceroutesSqlite)
+        .where(and(...conditions));
+      return result.length;
+    } else if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      const conditions = [
+        or(
+          eq(traceroutesMysql.fromNodeNum, nodeNum),
+          eq(traceroutesMysql.toNodeNum, nodeNum),
+        ),
+      ];
+      if (since !== undefined) {
+        conditions.push(gte(traceroutesMysql.timestamp, since));
+      }
+      const result = await db
+        .select()
+        .from(traceroutesMysql)
+        .where(and(...conditions));
+      return result.length;
+    } else {
+      const db = this.getPostgresDb();
+      const conditions = [
+        or(
+          eq(traceroutesPostgres.fromNodeNum, nodeNum),
+          eq(traceroutesPostgres.toNodeNum, nodeNum),
+        ),
+      ];
+      if (since !== undefined) {
+        conditions.push(gte(traceroutesPostgres.timestamp, since));
+      }
+      const result = await db
+        .select()
+        .from(traceroutesPostgres)
+        .where(and(...conditions));
+      return result.length;
+    }
+  }
+
   // ============ ROUTE SEGMENTS ============
 
   /**

--- a/src/server/routes/packetRoutes.ts
+++ b/src/server/routes/packetRoutes.ts
@@ -176,6 +176,86 @@ router.get('/stats/distribution', requirePacketPermissions, async (req, res) => 
 });
 
 /**
+ * GET /api/packets/stats/node-distribution
+ * Get packet type distribution for a specific node by querying actual data tables
+ * (telemetry, messages, traceroutes) instead of the capped packet_log.
+ * Query params:
+ *   - node_id: The node's string ID (e.g. !b2a7be34) for telemetry lookups
+ *   - node_num: The node's numeric ID for message/traceroute lookups
+ *   - since: Unix timestamp (seconds) to filter from
+ */
+router.get('/stats/node-distribution', requirePacketPermissions, async (req, res) => {
+  try {
+    const nodeId = req.query.node_id as string | undefined;
+    const nodeNum = req.query.node_num ? parseInt(req.query.node_num as string, 10) : undefined;
+    const sinceParam = req.query.since ? parseInt(req.query.since as string, 10) : undefined;
+    // Convert since from seconds to milliseconds for data table queries
+    // (telemetry, messages, traceroutes all store timestamps in milliseconds)
+    const sinceMs = sinceParam !== undefined ? sinceParam * 1000 : undefined;
+
+    if (!nodeId && nodeNum === undefined) {
+      return res.status(400).json({ error: 'node_id or node_num is required' });
+    }
+
+    const byType: Array<{ portnum: number; portnum_name: string; count: number }> = [];
+    let total = 0;
+
+    // Query actual data tables in parallel
+    const [positionCount, telemetryCount, messageCount, tracerouteCount, nodeInfoFromLog] = await Promise.all([
+      // Position packets from telemetry table (uses milliseconds)
+      nodeId ? databaseService.getPositionPacketCountByNodeAsync(nodeId, sinceMs) : Promise.resolve(0),
+      // Non-position telemetry from telemetry table (uses milliseconds)
+      nodeId ? databaseService.getNonPositionTelemetryPacketCountByNodeAsync(nodeId, sinceMs) : Promise.resolve(0),
+      // Text messages from messages table (uses milliseconds)
+      nodeNum !== undefined ? databaseService.getMessageCountByNodeAsync(nodeNum, sinceMs) : Promise.resolve(0),
+      // Traceroutes from traceroutes table (uses milliseconds)
+      nodeNum !== undefined ? databaseService.getTracerouteCountByNodeAsync(nodeNum, sinceMs) : Promise.resolve(0),
+      // NodeInfo from packet_log (uses seconds - packet_log stores timestamps in seconds)
+      nodeNum !== undefined
+        ? packetLogService.getPacketCountsByPortnumAsync({ since: sinceParam, from_node: nodeNum })
+        : Promise.resolve([]),
+    ]);
+
+    if (positionCount > 0) {
+      byType.push({ portnum: 3, portnum_name: 'POSITION_APP', count: positionCount });
+      total += positionCount;
+    }
+    if (telemetryCount > 0) {
+      byType.push({ portnum: 67, portnum_name: 'TELEMETRY_APP', count: telemetryCount });
+      total += telemetryCount;
+    }
+    if (messageCount > 0) {
+      byType.push({ portnum: 1, portnum_name: 'TEXT_MESSAGE_APP', count: messageCount });
+      total += messageCount;
+    }
+    if (tracerouteCount > 0) {
+      byType.push({ portnum: 70, portnum_name: 'TRACEROUTE_APP', count: tracerouteCount });
+      total += tracerouteCount;
+    }
+
+    // Add NodeInfo count from packet_log (nodeinfo updates nodes table in-place, no separate storage)
+    const nodeInfoEntry = nodeInfoFromLog.find(e => e.portnum === 4);
+    if (nodeInfoEntry && nodeInfoEntry.count > 0) {
+      byType.push({ portnum: 4, portnum_name: 'NODEINFO_APP', count: nodeInfoEntry.count });
+      total += nodeInfoEntry.count;
+    }
+
+    // Sort by count descending
+    byType.sort((a, b) => b.count - a.count);
+
+    res.json({
+      byType,
+      byDevice: [],
+      total,
+      enabled: true,
+    });
+  } catch (error) {
+    logger.error('❌ Error fetching node packet distribution:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
  * GET /api/packets/export
  * Export packet logs as JSONL with optional filtering
  * IMPORTANT: Must be registered before /:id route to avoid route matching conflicts

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -4242,6 +4242,46 @@ class DatabaseService {
   }
 
   /**
+   * Count distinct position packets for a node from the telemetry table.
+   */
+  async getPositionPacketCountByNodeAsync(nodeId: string, since?: number): Promise<number> {
+    if (this.telemetryRepo) {
+      return this.telemetryRepo.getPositionPacketCountByNode(nodeId, since);
+    }
+    return 0;
+  }
+
+  /**
+   * Count distinct non-position telemetry packets for a node from the telemetry table.
+   */
+  async getNonPositionTelemetryPacketCountByNodeAsync(nodeId: string, since?: number): Promise<number> {
+    if (this.telemetryRepo) {
+      return this.telemetryRepo.getNonPositionTelemetryPacketCountByNode(nodeId, since);
+    }
+    return 0;
+  }
+
+  /**
+   * Count messages sent from or to a specific node.
+   */
+  async getMessageCountByNodeAsync(nodeNum: number, since?: number): Promise<number> {
+    if (this.messagesRepo) {
+      return this.messagesRepo.getMessageCountByNode(nodeNum, since);
+    }
+    return 0;
+  }
+
+  /**
+   * Count traceroutes involving a specific node.
+   */
+  async getTracerouteCountByNodeAsync(nodeNum: number, since?: number): Promise<number> {
+    if (this.traceroutesRepo) {
+      return this.traceroutesRepo.getTracerouteCountByNode(nodeNum, since);
+    }
+    return 0;
+  }
+
+  /**
    * Update node mobility status based on position telemetry
    * Checks if a node has moved more than 100 meters based on its last 500 position records
    * @param nodeId The node ID to check

--- a/src/services/packetApi.ts
+++ b/src/services/packetApi.ts
@@ -128,6 +128,24 @@ export const getPacketDistributionStats = async (since?: number, from_node?: num
 };
 
 /**
+ * Fetch packet type distribution for a specific node from actual data tables
+ * (telemetry, messages, traceroutes) instead of the capped packet_log.
+ */
+export const getNodePacketDistribution = async (
+  nodeId: string,
+  nodeNum: number,
+  since?: number,
+): Promise<PacketDistributionStats> => {
+  const params = new URLSearchParams();
+  params.append('node_id', nodeId);
+  params.append('node_num', nodeNum.toString());
+  if (since !== undefined) {
+    params.append('since', since.toString());
+  }
+  return api.get<PacketDistributionStats>(`/api/packets/stats/node-distribution?${params.toString()}`);
+};
+
+/**
  * Clear all packet logs (admin only)
  */
 export const clearPackets = async (): Promise<{ message: string; deletedCount: number }> => {


### PR DESCRIPTION
## Summary

- The "Packet Type Distribution" pie chart on the Node Details panel previously queried the `packet_log` table, which has a 1000-row rolling cap. For nodes with lower traffic, their packets got evicted before being counted, producing incomplete/misleading charts.
- Adds a new `GET /api/packets/stats/node-distribution` endpoint that queries the actual data tables (`telemetry`, `messages`, `traceroutes`) which have unlimited retention.
- Properly categorizes telemetry types: position types (lat/lon/alt/speed/track/sats_in_view) are counted as POSITION_APP, packet metadata types (rssi, snr, messageHops, linkQuality) are excluded from TELEMETRY_APP counts, and everything else (battery, voltage, temperature, etc.) counts as TELEMETRY_APP.
- Fixes a seconds-vs-milliseconds mismatch where the `since` filter was matching all-time data instead of just the last 24 hours.

## Test plan

- [x] Unit tests pass (2521 passed, 0 failed)
- [ ] Navigate to Messages > select a node (e.g., N4CRE Charlie) and verify the pie chart shows accurate counts
- [ ] Verify a position-only node shows Position + NodeInfo but no Telemetry slice
- [ ] Verify a node with device metrics shows both Position and Telemetry slices
- [ ] Compare counts against raw database queries to confirm accuracy
- [ ] Run system tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)