### PR TITLE
fix: consistent map pin click centering and popup positioning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3743,8 +3743,9 @@ function App() {
 
   // Function to center map on a specific node
   const centerMapOnNode = useCallback((node: DeviceInfo) => {
-    if (node.position && node.position.latitude != null && node.position.longitude != null) {
-      setMapCenterTarget([node.position.latitude, node.position.longitude]);
+    const effectivePos = getEffectivePosition(node);
+    if (effectivePos.latitude != null && effectivePos.longitude != null) {
+      setMapCenterTarget([effectivePos.latitude, effectivePos.longitude]);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- **Fixed map pin clicks not panning/zooming to center the node** — the spiderfier kept stale marker references after React-Leaflet recreated markers (e.g., toggling Show Traceroute), so click listeners never fired on the visible marker
- **Fixed popup positioning** — closing Leaflet's native popup toggle and reopening after a 100ms delay matches the consistent sidebar click behavior
- **Fixed `centerMapOnNode` using raw position** — now uses `getEffectivePosition()` to respect position overrides (Issue #1526)

## Changes
- `src/hooks/useMarkerSpiderfier.ts`: Replace stale markers in spiderfier when a new object arrives at the same position, so click listeners are always on the visible marker
- `src/components/NodesTab.tsx`: Tag markers with `_meshNodeId` for reliable identification; control popup open/close timing to match sidebar behavior
- `src/App.tsx`: Use `getEffectivePosition()` in `centerMapOnNode` for correct centering with position overrides

## Test plan
- [ ] Click a map pin — should zoom to 15 and center the node with popup visible
- [ ] Enable then disable "Show Traceroute" — clicking pins should still pan/zoom correctly
- [ ] Re-click the same selected pin — should re-center and keep popup open (not close it)
- [ ] Click nodes from sidebar — existing behavior should not regress
- [ ] `npx vitest run` — 115 test files, 2521 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)