### PR TITLE
fix: add networking support to LXC template

### DIFF
--- a/lxc/build-lxc-template.sh
+++ b/lxc/build-lxc-template.sh
@@ -101,7 +101,24 @@ chroot "$ROOTFS_DIR" apt-get install -y --no-install-recommends \
     procps \
     locales \
     systemd \
-    systemd-sysv
+    systemd-sysv \
+    ifupdown \
+    iproute2 \
+    dbus \
+    nano \
+    iputils-ping
+
+# Create /etc/network/interfaces for Proxmox networking support
+cat > "$ROOTFS_DIR/etc/network/interfaces" << EOF
+# Loopback
+auto lo
+iface lo inet loopback
+
+# Include Proxmox-managed interface configurations
+source /etc/network/interfaces.d/*
+EOF
+
+mkdir -p "$ROOTFS_DIR/etc/network/interfaces.d"
 
 # Generate locale
 echo "en_US.UTF-8 UTF-8" >> "$ROOTFS_DIR/etc/locale.gen"


### PR DESCRIPTION
## Summary
- Adds networking packages (`ifupdown`, `iproute2`, `dbus`, `nano`, `iputils-ping`) to the LXC template build script
- Creates `/etc/network/interfaces` with Proxmox-compatible configuration (loopback + `source /etc/network/interfaces.d/*`)
- Creates the `/etc/network/interfaces.d/` directory for Proxmox-managed interface configs

## Problem
LXC containers built with `debootstrap --variant=minbase` have no networking support. Users reported (#1672) that network interfaces couldn't be enabled, `/etc/network/interfaces` was missing, and basic tools like `nano` were absent.

## Root Cause
The `minbase` variant only includes essential packages. Proxmox expects `ifupdown` and `/etc/network/interfaces` to manage LXC container networking — it writes per-interface config files to `/etc/network/interfaces.d/` which `ifupdown` applies on boot.

## Test plan
- [ ] Verify packages are valid Debian bookworm packages (they are standard)
- [ ] Verify `/etc/network/interfaces` format is correct for Proxmox
- [ ] Build and test LXC template on a Proxmox system
- [ ] Confirm container gets DHCP address and can reach the network

Fixes #1672

🤖 Generated with [Claude Code](https://claude.com/claude-code)