### PR TITLE
chore: bump version to 3.6.3

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.6.2
-appVersion: "3.6.2"
+version: 3.6.3
+appVersion: "3.6.3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Version bump to 3.6.3 across package.json, package-lock.json, Helm Chart, and Tauri config

## Changes since v3.6.2

### Features
- [#1950](https://github.com/Yeraze/meshmonitor/pull/1950) - Differentiate own vs others' tapback reactions by color

### Bug Fixes
- [#1954](https://github.com/Yeraze/meshmonitor/pull/1954) - Add networking support to LXC template (fixes [#1672](https://github.com/Yeraze/meshmonitor/issues/1672))
- [#1953](https://github.com/Yeraze/meshmonitor/pull/1953) - Consistent map pin click centering and popup positioning
- [#1952](https://github.com/Yeraze/meshmonitor/pull/1952) - Use actual data tables for node packet type distribution
- [#1942](https://github.com/Yeraze/meshmonitor/pull/1942) - Increase auto-responder script timeout from 10s to 30s

### Performance
- [#1944](https://github.com/Yeraze/meshmonitor/pull/1944) - Add server-side in-memory cache for link previews

### Other
- [#1946](https://github.com/Yeraze/meshmonitor/pull/1946) - Update deployment guide for accuracy
- [#1945](https://github.com/Yeraze/meshmonitor/pull/1945) - Clean up LXC template build workflow release notes
- [#1943](https://github.com/Yeraze/meshmonitor/pull/1943) - Translations update from Hosted Weblate (Russian)

### Issues Resolved
- [#1672](https://github.com/Yeraze/meshmonitor/issues/1672) - LXC deployment image/scenario on PM 9.1
- [#1936](https://github.com/Yeraze/meshmonitor/issues/1936) - Rounding to integers in graphs is still not fully fixed
- [#1934](https://github.com/Yeraze/meshmonitor/issues/1934) - Stations with icons as short name don't update on map
- [#1929](https://github.com/Yeraze/meshmonitor/issues/1929) - Short name incorrect
- [#1951](https://github.com/Yeraze/meshmonitor/issues/1951) - Traceroute results
- [#1949](https://github.com/Yeraze/meshmonitor/issues/1949) - Window off screen again

## Test plan
- [x] All 2,521 tests passing (115 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)