### PR TITLE
Add DHCP client and networking service enablement to LXC template

### DIFF
--- a/lxc/build-lxc-template.sh
+++ b/lxc/build-lxc-template.sh
@@ -103,6 +103,7 @@ chroot "$ROOTFS_DIR" apt-get install -y --no-install-recommends \
     systemd \
     systemd-sysv \
     ifupdown \
+    isc-dhcp-client \
     iproute2 \
     dbus \
     nano \
@@ -119,6 +120,9 @@ source /etc/network/interfaces.d/*
 EOF
 
 mkdir -p "$ROOTFS_DIR/etc/network/interfaces.d"
+
+# Enable networking service so ifupdown brings up interfaces at boot
+chroot "$ROOTFS_DIR" systemctl enable networking.service
 
 # Generate locale
 echo "en_US.UTF-8 UTF-8" >> "$ROOTFS_DIR/etc/locale.gen"

--- a/tests/test-lxc-template.sh
+++ b/tests/test-lxc-template.sh
@@ -237,6 +237,32 @@ run_tests() {
         test_result "Locale configuration" "WARN" "Locale may not be configured"
     fi
 
+    # Test 15: Check for DHCP client (required for network to come up)
+    if [ -f "$TEMP_DIR/sbin/dhclient" ] || [ -f "$TEMP_DIR/usr/sbin/dhclient" ]; then
+        test_result "DHCP client (dhclient) exists" "PASS"
+    else
+        test_result "DHCP client (dhclient) exists" "FAIL" "No DHCP client found - networking will not work"
+    fi
+
+    # Test 16: Check for network interfaces configuration
+    if [ -f "$TEMP_DIR/etc/network/interfaces" ]; then
+        if grep -q "source /etc/network/interfaces.d" "$TEMP_DIR/etc/network/interfaces"; then
+            test_result "Network interfaces config" "PASS"
+        else
+            test_result "Network interfaces config" "WARN" "Missing interfaces.d source directive"
+        fi
+    else
+        test_result "Network interfaces config" "FAIL" "/etc/network/interfaces not found"
+    fi
+
+    # Test 17: Check that networking.service is enabled
+    if [ -L "$TEMP_DIR/etc/systemd/system/multi-user.target.wants/networking.service" ] || \
+       [ -L "$TEMP_DIR/etc/systemd/system/network-online.target.wants/networking.service" ]; then
+        test_result "networking.service enabled" "PASS"
+    else
+        test_result "networking.service enabled" "FAIL" "networking.service not enabled - interfaces won't come up at boot"
+    fi
+
     echo ""
     echo "========================================"
     echo "Test Summary"


### PR DESCRIPTION
## Summary
This PR improves network configuration in LXC container templates by ensuring DHCP client is installed and the networking service is properly enabled at boot time.

## Key Changes
- **Install DHCP client**: Added `isc-dhcp-client` package to the base LXC template to enable automatic network configuration via DHCP
- **Enable networking service**: Added systemctl command to enable `networking.service` so network interfaces are brought up automatically at container boot
- **Add validation tests**: Implemented three new test cases (Tests 15-17) to verify:
  - DHCP client (`dhclient`) is present in the container
  - Network interfaces configuration file exists and includes the interfaces.d source directive
  - networking.service is properly enabled via systemd symlinks

## Implementation Details
- The DHCP client installation is added to the apt-get package list in the build script
- The networking service is enabled using `systemctl enable` within the container's chroot environment
- The test suite validates both the presence of required components and their proper configuration, providing clear PASS/WARN/FAIL messages with diagnostic information
- Tests check for networking.service symlinks in both `multi-user.target.wants` and `network-online.target.wants` directories to handle different systemd configurations

https://claude.ai/code/session_01D2utKgM4JnQ4ivQhiVX7fD