### PR TITLE
Fix config import: LoRa modem preset not applied on second import

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2410,6 +2410,8 @@ apiRouter.post('/channels/import-config', requirePermission('configuration', 'wr
     try {
       logger.info(`🔄 Beginning edit settings transaction for import`);
       await meshtasticManager.beginEditSettings();
+      // Allow device time to enter edit mode before sending config messages
+      await new Promise((resolve) => setTimeout(resolve, 500));
       logger.info(`✅ Edit settings transaction started`);
     } catch (error) {
       logger.error(`❌ Failed to begin edit settings transaction:`, error);
@@ -2440,6 +2442,8 @@ apiRouter.post('/channels/import-config', requirePermission('configuration', 'wr
             positionPrecision: channel.positionPrecision,
           });
 
+          // Allow device time to process channel config before sending the next message
+          await new Promise((resolve) => setTimeout(resolve, 300));
           importedChannels.push({ index: i, name: channel.name || '(unnamed)' });
           logger.info(`✅ Imported channel ${i}`);
         } catch (error) {
@@ -2466,6 +2470,9 @@ apiRouter.post('/channels/import-config', requirePermission('configuration', 'wr
 
         logger.info(`📥 LoRa config with txEnabled defaulted: txEnabled=${loraConfigToImport.txEnabled}`);
         await meshtasticManager.setLoRaConfig(loraConfigToImport);
+        // LoRa config triggers heavier processing (frequency calculations, radio reconfiguration)
+        // so allow extra time before committing
+        await new Promise((resolve) => setTimeout(resolve, 500));
         loraImported = true;
         requiresReboot = true; // LoRa config requires reboot when committed
         logger.info(`✅ Imported LoRa config`);


### PR DESCRIPTION
## Summary
- Add processing delays between admin messages in the config import endpoint to prevent the device from receiving a `commitEditSettings` before it finishes processing the LoRa config change
- Without delays, channel updates (fast in-memory writes) always succeed, but LoRa config (heavier radio reconfiguration) gets lost when the commit arrives too early
- Adds ~2-3s total to a typical import (500ms + N×300ms + 500ms), matching how the Meshtastic Python CLI handles admin operations

## Test plan
- [x] Unit tests pass (2521 passed, 0 failures)
- [x] System tests pass (all 9 suites)
- [x] Config import test verifies both first and second imports apply correctly
- [x] Second import LoRa modem preset now correctly changes from Long Fast → Medium Fast

| Test Suite | Result |
|------------|--------|
| Configuration Import | PASSED |
| Quick Start Test | PASSED |
| Security Test | PASSED |
| V1 API Test | PASSED |
| Reverse Proxy Test | PASSED |
| Reverse Proxy + OIDC | PASSED |
| Virtual Node CLI Test | PASSED |
| Backup & Restore Test | PASSED |
| Database Migration Test | PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)