### PR TITLE
fix: pre-populate MeshCore connection form from env vars

### DIFF
--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -268,6 +268,13 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
+   * Get configuration from environment variables (public accessor)
+   */
+  getEnvConfig(): MeshCoreConfig | null {
+    return this.getConfigFromEnv();
+  }
+
+  /**
    * Get configuration from environment variables
    */
   private getConfigFromEnv(): MeshCoreConfig | null {

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -41,6 +41,7 @@ vi.mock('../meshcoreManager.js', () => ({
       config: null,
     }),
     getLocalNode: vi.fn().mockReturnValue(null),
+    getEnvConfig: vi.fn().mockReturnValue(null),
     getAllNodes: vi.fn().mockReturnValue([]),
     getContacts: vi.fn().mockReturnValue([]),
     getRecentMessages: vi.fn().mockReturnValue([]),

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -122,6 +122,7 @@ router.get('/status', optionalAuth(), requirePermission('meshcore', 'read'), asy
   try {
     const status = meshcoreManager.getConnectionStatus();
     const localNode = meshcoreManager.getLocalNode();
+    const envConfig = meshcoreManager.getEnvConfig();
 
     res.json({
       success: true,
@@ -129,6 +130,7 @@ router.get('/status', optionalAuth(), requirePermission('meshcore', 'read'), asy
         ...status,
         localNode,
         deviceTypeName: MeshCoreDeviceType[status.deviceType],
+        envConfig,
       },
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Exposes `getConfigFromEnv()` via a new public `getEnvConfig()` method on `MeshCoreManager`
- Includes `envConfig` in the `GET /api/meshcore/status` response so the frontend can read env var values
- Pre-populates the MeshCore connection form (`connectionType`, `serialPort`, `tcpHost`, `tcpPort`) from env config on first load when not yet connected, using a `defaultsLoaded` ref to avoid overwriting user edits on subsequent polls

Closes #1960

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — all 31 meshcore route tests pass (added `getEnvConfig` mock)
- [ ] Set `MESHCORE_TCP_HOST` and `MESHCORE_TCP_PORT` in `.env`, start the app, verify the MeshCore tab shows TCP selected with correct host/port
- [ ] Set `MESHCORE_SERIAL_PORT` in `.env`, verify serial is selected with correct port
- [ ] With no env vars set, verify default form values remain unchanged (COM3, empty host, 4403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)