### PR TITLE
fix: resolve MySQL/PostgreSQL node loss during init config sync

### DIFF
--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -377,55 +377,63 @@ export class NodesRepository extends BaseRepository {
         updatedAt: now,
       };
 
+      // All databases use atomic upsert to prevent race conditions where
+      // concurrent getNode() calls both return null and then both try to INSERT
+      const upsertSet = {
+        nodeId: nodeData.nodeId,
+        longName: nodeData.longName ?? null,
+        shortName: nodeData.shortName ?? null,
+        hwModel: nodeData.hwModel ?? null,
+        role: nodeData.role ?? null,
+        hopsAway: nodeData.hopsAway ?? null,
+        viaMqtt: nodeData.viaMqtt ?? null,
+        macaddr: nodeData.macaddr ?? null,
+        latitude: nodeData.latitude ?? null,
+        longitude: nodeData.longitude ?? null,
+        altitude: nodeData.altitude ?? null,
+        batteryLevel: nodeData.batteryLevel ?? null,
+        voltage: nodeData.voltage ?? null,
+        channelUtilization: nodeData.channelUtilization ?? null,
+        airUtilTx: nodeData.airUtilTx ?? null,
+        lastHeard: this.coerceBigintField(nodeData.lastHeard),
+        snr: nodeData.snr ?? null,
+        rssi: nodeData.rssi ?? null,
+        firmwareVersion: nodeData.firmwareVersion ?? null,
+        channel: nodeData.channel ?? null,
+        isFavorite: nodeData.isFavorite ?? false,
+        // Note: mobile is NOT included here - it's only set by updateNodeMobility
+        // to prevent overwriting the computed mobility flag on conflict
+        rebootCount: nodeData.rebootCount ?? null,
+        publicKey: nodeData.publicKey ?? null,
+        hasPKC: nodeData.hasPKC ?? null,
+        lastPKIPacket: this.coerceBigintField(nodeData.lastPKIPacket),
+        welcomedAt: this.coerceBigintField(nodeData.welcomedAt),
+        keyIsLowEntropy: nodeData.keyIsLowEntropy ?? null,
+        duplicateKeyDetected: nodeData.duplicateKeyDetected ?? null,
+        keyMismatchDetected: nodeData.keyMismatchDetected ?? null,
+        keySecurityIssueDetails: nodeData.keySecurityIssueDetails ?? null,
+        positionChannel: nodeData.positionChannel ?? null,
+        positionPrecisionBits: nodeData.positionPrecisionBits ?? null,
+        positionTimestamp: this.coerceBigintField(nodeData.positionTimestamp),
+        updatedAt: now,
+      };
+
       if (this.isSQLite()) {
         const db = this.getSqliteDb();
-        await db.insert(nodesSqlite).values(newNode);
+        await db.insert(nodesSqlite).values(newNode).onConflictDoUpdate({
+          target: nodesSqlite.nodeNum,
+          set: upsertSet,
+        });
       } else if (this.isMySQL()) {
         const db = this.getMysqlDb();
-        await db.insert(nodesMysql).values(newNode);
+        await db.insert(nodesMysql).values(newNode).onDuplicateKeyUpdate({
+          set: upsertSet,
+        });
       } else {
-        // PostgreSQL - use ON CONFLICT DO UPDATE for atomic upsert to prevent race conditions
         const db = this.getPostgresDb();
         await db.insert(nodesPostgres).values(newNode).onConflictDoUpdate({
           target: nodesPostgres.nodeNum,
-          set: {
-            nodeId: nodeData.nodeId,
-            longName: nodeData.longName ?? null,
-            shortName: nodeData.shortName ?? null,
-            hwModel: nodeData.hwModel ?? null,
-            role: nodeData.role ?? null,
-            hopsAway: nodeData.hopsAway ?? null,
-            viaMqtt: nodeData.viaMqtt ?? null,
-            macaddr: nodeData.macaddr ?? null,
-            latitude: nodeData.latitude ?? null,
-            longitude: nodeData.longitude ?? null,
-            altitude: nodeData.altitude ?? null,
-            batteryLevel: nodeData.batteryLevel ?? null,
-            voltage: nodeData.voltage ?? null,
-            channelUtilization: nodeData.channelUtilization ?? null,
-            airUtilTx: nodeData.airUtilTx ?? null,
-            lastHeard: this.coerceBigintField(nodeData.lastHeard),
-            snr: nodeData.snr ?? null,
-            rssi: nodeData.rssi ?? null,
-            firmwareVersion: nodeData.firmwareVersion ?? null,
-            channel: nodeData.channel ?? null,
-            isFavorite: nodeData.isFavorite ?? false,
-            // Note: mobile is NOT included here - it's only set by updateNodeMobility
-            // to prevent overwriting the computed mobility flag on conflict
-            rebootCount: nodeData.rebootCount ?? null,
-            publicKey: nodeData.publicKey ?? null,
-            hasPKC: nodeData.hasPKC ?? null,
-            lastPKIPacket: this.coerceBigintField(nodeData.lastPKIPacket),
-            welcomedAt: this.coerceBigintField(nodeData.welcomedAt),
-            keyIsLowEntropy: nodeData.keyIsLowEntropy ?? null,
-            duplicateKeyDetected: nodeData.duplicateKeyDetected ?? null,
-            keyMismatchDetected: nodeData.keyMismatchDetected ?? null,
-            keySecurityIssueDetails: nodeData.keySecurityIssueDetails ?? null,
-            positionChannel: nodeData.positionChannel ?? null,
-            positionPrecisionBits: nodeData.positionPrecisionBits ?? null,
-            positionTimestamp: this.coerceBigintField(nodeData.positionTimestamp),
-            updatedAt: now,
-          },
+          set: upsertSet,
         });
       }
     }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -362,6 +362,9 @@ systemRestoreService.markRestoreStarted();
 // Initialize Meshtastic connection
 setTimeout(async () => {
   try {
+    // Wait for database initialization (critical for PostgreSQL/MySQL where repos are async)
+    await databaseService.waitForReady();
+
     // Load saved traceroute interval from database before connecting
     const savedInterval = databaseService.getSetting('tracerouteIntervalMinutes');
     if (savedInterval !== null) {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -4386,7 +4386,9 @@ class DatabaseService {
       }
 
       // Update the mobile flag in the database using repository
-      await this.nodesRepo!.updateNodeMobility(nodeId, isMobile);
+      if (this.nodesRepo) {
+        await this.nodesRepo.updateNodeMobility(nodeId, isMobile);
+      }
 
       // Also update the cache so getAllNodes() returns the updated value
       for (const [nodeNum, cachedNode] of this.nodesCache.entries()) {
@@ -7541,6 +7543,11 @@ class DatabaseService {
   async setSettingAsync(key: string, value: string): Promise<void> {
     if (this.settingsRepo) {
       await this.settingsRepo.setSetting(key, value);
+      return;
+    }
+    // For PostgreSQL/MySQL without repo, just update cache (don't recurse into setSetting)
+    if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
+      this.settingsCache.set(key, value);
       return;
     }
     // Fallback to sync for SQLite if repo not ready


### PR DESCRIPTION
## Summary

Fixes three bugs that caused most nodes from the device's NodeDB to be silently dropped during the initial config sync on MySQL/PostgreSQL backends. After a fresh MySQL deployment, only ~16 nodes were stored despite the device sending 149+ unique NodeInfo packets.

- **Race condition**: Meshtastic connection started (`setTimeout` with no delay) before async Drizzle repository initialization completed. `nodesRepo` was null when NodeInfo packets arrived, causing `upsertNode()` to silently return. Fixed by awaiting `databaseService.waitForReady()` before connecting.
- **Infinite recursion**: `setSettingAsync()` on MySQL/PostgreSQL fell back to `setSetting()` when `settingsRepo` was null, which called `setSettingAsync()` again, causing a stack overflow. Fixed by updating cache directly when repo isn't available.
- **Duplicate key errors**: Concurrent `getNode()` calls both returned null, then both tried to INSERT, causing MySQL duplicate key errors. Fixed by using atomic upsert (`onDuplicateKeyUpdate` for MySQL, `onConflictDoUpdate` for SQLite) matching the existing PostgreSQL pattern.

Also fixed `updateNodeMobilityAsync` crash on null `nodesRepo` (non-null assertion → null guard).

## Test plan

- [x] `npx tsc --noEmit` — no compilation errors
- [x] `npx vitest run` — 115 test files, 2521 tests pass
- [x] `tests/system-tests.sh` — all 9 system tests pass
- [x] Fresh MySQL deploy: 201+ nodes stored (was ~16), all with names, 149 with positions
- [x] No duplicate key errors, stack overflows, or nodesRepo null crashes in logs

## System Test Results

```
Configuration Import:     ✓ PASSED
Quick Start Test:         ✓ PASSED
Security Test:            ✓ PASSED
V1 API Test:              ✓ PASSED
Reverse Proxy Test:       ✓ PASSED
Reverse Proxy + OIDC:     ✓ PASSED
Virtual Node CLI Test:    ✓ PASSED
Backup & Restore Test:    ✓ PASSED
Database Migration Test:  ✓ PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)