### PR TITLE
fix: upgrade telemetry packetId to BIGINT for PostgreSQL/MySQL

### DIFF
--- a/src/db/schema/mysql-create.ts
+++ b/src/db/schema/mysql-create.ts
@@ -115,7 +115,7 @@ export const MYSQL_SCHEMA_SQL = `
     unit VARCHAR(255),
     createdAt BIGINT NOT NULL,
     packetTimestamp BIGINT,
-    packetId INT,
+    packetId BIGINT,
     channel INT,
     precisionBits INT,
     gpsAccuracy DOUBLE,

--- a/src/db/schema/postgres-create.ts
+++ b/src/db/schema/postgres-create.ts
@@ -110,7 +110,7 @@ export const POSTGRES_SCHEMA_SQL = `
     unit TEXT,
     "createdAt" BIGINT NOT NULL,
     "packetTimestamp" BIGINT,
-    "packetId" INTEGER,
+    "packetId" BIGINT,
     channel INTEGER,
     "precisionBits" INTEGER,
     "gpsAccuracy" DOUBLE PRECISION

--- a/src/db/schema/telemetry.ts
+++ b/src/db/schema/telemetry.ts
@@ -37,7 +37,7 @@ export const telemetryPostgres = pgTable('telemetry', {
   unit: pgText('unit'),
   createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
   packetTimestamp: pgBigint('packetTimestamp', { mode: 'number' }),
-  packetId: pgInteger('packetId'),
+  packetId: pgBigint('packetId', { mode: 'number' }),
   // Position precision tracking metadata
   channel: pgInteger('channel'),
   precisionBits: pgInteger('precisionBits'),
@@ -55,7 +55,7 @@ export const telemetryMysql = mysqlTable('telemetry', {
   unit: myVarchar('unit', { length: 32 }),
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
   packetTimestamp: myBigint('packetTimestamp', { mode: 'number' }),
-  packetId: myInt('packetId'),
+  packetId: myBigint('packetId', { mode: 'number' }),
   // Position precision tracking metadata
   channel: myInt('channel'),
   precisionBits: myInt('precisionBits'),

--- a/src/server/migrations/075_upgrade_telemetry_packetid_bigint.ts
+++ b/src/server/migrations/075_upgrade_telemetry_packetid_bigint.ts
@@ -1,0 +1,78 @@
+/**
+ * Migration 075: Upgrade telemetry packetId from INTEGER to BIGINT
+ *
+ * Meshtastic packet IDs are unsigned 32-bit values (up to ~4.3 billion),
+ * but PostgreSQL/MySQL INTEGER is signed 32-bit (max 2,147,483,647).
+ * This causes insert failures for packetId values above INT4 max.
+ *
+ * SQLite is unaffected because its INTEGER type is 64-bit.
+ */
+
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * SQLite migration: No changes needed
+ * SQLite INTEGER is already 64-bit
+ */
+export const migration = {
+  up: (_db: Database): void => {
+    logger.debug('Migration 075: SQLite INTEGER is already 64-bit, no changes needed');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 075 down: No changes needed for SQLite');
+  }
+};
+
+/**
+ * PostgreSQL migration: Upgrade packetId from INTEGER to BIGINT
+ */
+export async function runMigration075Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 075 (PostgreSQL): Upgrading telemetry.packetId to BIGINT...');
+
+  try {
+    const result = await client.query(`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'telemetry' AND column_name = 'packetId'
+    `);
+
+    if (result.rows.length > 0) {
+      await client.query(`ALTER TABLE telemetry ALTER COLUMN "packetId" TYPE BIGINT`);
+      logger.debug('Upgraded telemetry.packetId to BIGINT');
+    } else {
+      logger.debug('Column telemetry.packetId does not exist, skipping');
+    }
+  } catch (error: any) {
+    logger.error('Failed to upgrade telemetry.packetId:', error.message);
+    throw error;
+  }
+
+  logger.info('Migration 075 complete (PostgreSQL): telemetry.packetId upgraded to BIGINT');
+}
+
+/**
+ * MySQL migration: Upgrade packetId from INT to BIGINT
+ */
+export async function runMigration075Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 075 (MySQL): Upgrading telemetry.packetId to BIGINT...');
+
+  try {
+    const [rows] = await pool.query(`
+      SELECT COLUMN_NAME FROM information_schema.COLUMNS
+      WHERE TABLE_NAME = 'telemetry' AND COLUMN_NAME = 'packetId'
+    `);
+
+    if (Array.isArray(rows) && rows.length > 0) {
+      await pool.query(`ALTER TABLE telemetry MODIFY COLUMN packetId BIGINT`);
+      logger.debug('Upgraded telemetry.packetId to BIGINT');
+    } else {
+      logger.debug('Column telemetry.packetId does not exist, skipping');
+    }
+  } catch (error: any) {
+    logger.error('Failed to upgrade telemetry.packetId:', error.message);
+    throw error;
+  }
+
+  logger.info('Migration 075 complete (MySQL): telemetry.packetId upgraded to BIGINT');
+}


### PR DESCRIPTION
## Summary
- Upgrades `telemetry.packetId` column from INTEGER (32-bit signed, max ~2.1B) to BIGINT to support unsigned 32-bit Meshtastic packet IDs (up to ~4.3B)
- Adds migration 075 for PostgreSQL (`ALTER COLUMN TYPE BIGINT`) and MySQL (`MODIFY COLUMN BIGINT`); SQLite is unaffected (already 64-bit)
- Updates Drizzle schema definitions and CREATE scripts for new installations

Fixes #1964

## Test plan
- [x] Unit tests pass (115 files, 2521 tests)
- [x] Docker build succeeds
- [x] Database backing consistency test passes across SQLite, PostgreSQL, and MySQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)