### PR TITLE
fix: persist showAccuracyRegions and showEstimatedPositions map preferences

### DIFF
--- a/src/server/migrations/076_add_accuracy_and_estimated_position_prefs.ts
+++ b/src/server/migrations/076_add_accuracy_and_estimated_position_prefs.ts
@@ -1,0 +1,128 @@
+/**
+ * Migration 076: Add show_accuracy_regions and show_estimated_positions columns to user_map_preferences
+ *
+ * These boolean columns allow the "Show Accuracy Regions" and "Show Estimated Positions"
+ * map feature toggles to persist across page reloads, matching all other map toggles.
+ */
+
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * SQLite migration: Add show_accuracy_regions and show_estimated_positions columns
+ */
+export const migration = {
+  up: (db: Database): void => {
+    logger.debug('Running migration 076: Adding show_accuracy_regions and show_estimated_positions columns...');
+
+    const tableInfo = db.prepare('PRAGMA table_info(user_map_preferences)').all() as Array<{ name: string }>;
+
+    const hasAccuracyRegions = tableInfo.some((col) => col.name === 'show_accuracy_regions');
+    if (!hasAccuracyRegions) {
+      db.prepare('ALTER TABLE user_map_preferences ADD COLUMN show_accuracy_regions INTEGER DEFAULT 0 CHECK (show_accuracy_regions IN (0, 1))').run();
+      logger.debug('✅ Added show_accuracy_regions column to user_map_preferences');
+    } else {
+      logger.debug('Column show_accuracy_regions already exists, skipping');
+    }
+
+    const hasEstimatedPositions = tableInfo.some((col) => col.name === 'show_estimated_positions');
+    if (!hasEstimatedPositions) {
+      db.prepare('ALTER TABLE user_map_preferences ADD COLUMN show_estimated_positions INTEGER DEFAULT 1 CHECK (show_estimated_positions IN (0, 1))').run();
+      logger.debug('✅ Added show_estimated_positions column to user_map_preferences');
+    } else {
+      logger.debug('Column show_estimated_positions already exists, skipping');
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 076 down: SQLite does not support dropping columns');
+  },
+};
+
+/**
+ * PostgreSQL migration: Add show_accuracy_regions and show_estimated_positions columns
+ */
+export async function runMigration076Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 076 (PostgreSQL): Adding show_accuracy_regions and show_estimated_positions columns...');
+
+  try {
+    const result1 = await client.query(`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'user_map_preferences' AND column_name = 'show_accuracy_regions'
+    `);
+
+    if (result1.rows.length === 0) {
+      await client.query(`
+        ALTER TABLE user_map_preferences
+        ADD COLUMN show_accuracy_regions BOOLEAN DEFAULT FALSE
+      `);
+      logger.debug('✅ Added show_accuracy_regions column to user_map_preferences');
+    } else {
+      logger.debug('Column show_accuracy_regions already exists, skipping');
+    }
+
+    const result2 = await client.query(`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'user_map_preferences' AND column_name = 'show_estimated_positions'
+    `);
+
+    if (result2.rows.length === 0) {
+      await client.query(`
+        ALTER TABLE user_map_preferences
+        ADD COLUMN show_estimated_positions BOOLEAN DEFAULT TRUE
+      `);
+      logger.debug('✅ Added show_estimated_positions column to user_map_preferences');
+    } else {
+      logger.debug('Column show_estimated_positions already exists, skipping');
+    }
+  } catch (error: any) {
+    logger.error('Failed to add accuracy/estimated position columns:', error.message);
+    throw error;
+  }
+
+  logger.info('✅ Migration 076 complete (PostgreSQL)');
+}
+
+/**
+ * MySQL migration: Add show_accuracy_regions and show_estimated_positions columns
+ */
+export async function runMigration076Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 076 (MySQL): Adding show_accuracy_regions and show_estimated_positions columns...');
+
+  try {
+    const [rows1] = await pool.query(`
+      SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_NAME = 'user_map_preferences' AND COLUMN_NAME = 'show_accuracy_regions'
+    `);
+
+    if ((rows1 as any[]).length === 0) {
+      await pool.query(`
+        ALTER TABLE user_map_preferences
+        ADD COLUMN show_accuracy_regions TINYINT(1) DEFAULT 0
+      `);
+      logger.debug('✅ Added show_accuracy_regions column to user_map_preferences');
+    } else {
+      logger.debug('Column show_accuracy_regions already exists, skipping');
+    }
+
+    const [rows2] = await pool.query(`
+      SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_NAME = 'user_map_preferences' AND COLUMN_NAME = 'show_estimated_positions'
+    `);
+
+    if ((rows2 as any[]).length === 0) {
+      await pool.query(`
+        ALTER TABLE user_map_preferences
+        ADD COLUMN show_estimated_positions TINYINT(1) DEFAULT 1
+      `);
+      logger.debug('✅ Added show_estimated_positions column to user_map_preferences');
+    } else {
+      logger.debug('Column show_estimated_positions already exists, skipping');
+    }
+  } catch (error: any) {
+    logger.error('Failed to add accuracy/estimated position columns:', error.message);
+    throw error;
+  }
+
+  logger.info('✅ Migration 076 complete (MySQL)');
+}

--- a/src/server/models/User.ts
+++ b/src/server/models/User.ts
@@ -405,6 +405,8 @@ export class UserModel {
         show_mqtt_nodes as showMqttNodes,
         show_meshcore_nodes as showMeshCoreNodes,
         show_animations as showAnimations,
+        show_accuracy_regions as showAccuracyRegions,
+        show_estimated_positions as showEstimatedPositions,
         position_history_hours as positionHistoryHours
       FROM user_map_preferences
       WHERE user_id = ?
@@ -422,6 +424,8 @@ export class UserModel {
       showMqttNodes: Boolean(row.showMqttNodes),
       showMeshCoreNodes: Boolean(row.showMeshCoreNodes),
       showAnimations: Boolean(row.showAnimations),
+      showAccuracyRegions: Boolean(row.showAccuracyRegions),
+      showEstimatedPositions: Boolean(row.showEstimatedPositions),
       positionHistoryHours: row.positionHistoryHours ?? null,
     };
   }
@@ -438,6 +442,8 @@ export class UserModel {
     showMqttNodes?: boolean;
     showMeshCoreNodes?: boolean;
     showAnimations?: boolean;
+    showAccuracyRegions?: boolean;
+    showEstimatedPositions?: boolean;
     positionHistoryHours?: number | null;
   }): void {
     const now = Date.now();
@@ -482,6 +488,14 @@ export class UserModel {
         updates.push('show_animations = ?');
         params.push(preferences.showAnimations ? 1 : 0);
       }
+      if (preferences.showAccuracyRegions !== undefined) {
+        updates.push('show_accuracy_regions = ?');
+        params.push(preferences.showAccuracyRegions ? 1 : 0);
+      }
+      if (preferences.showEstimatedPositions !== undefined) {
+        updates.push('show_estimated_positions = ?');
+        params.push(preferences.showEstimatedPositions ? 1 : 0);
+      }
       if (preferences.positionHistoryHours !== undefined) {
         updates.push('position_history_hours = ?');
         params.push(preferences.positionHistoryHours);
@@ -505,8 +519,9 @@ export class UserModel {
         INSERT INTO user_map_preferences (
           user_id, map_tileset, show_paths, show_neighbor_info,
           show_route, show_motion, show_mqtt_nodes, show_meshcore_nodes, show_animations,
+          show_accuracy_regions, show_estimated_positions,
           position_history_hours, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
       stmt.run(
@@ -519,6 +534,8 @@ export class UserModel {
         preferences.showMqttNodes !== undefined ? (preferences.showMqttNodes ? 1 : 0) : 1, // default true
         preferences.showMeshCoreNodes !== undefined ? (preferences.showMeshCoreNodes ? 1 : 0) : 1, // default true
         preferences.showAnimations ? 1 : 0,
+        preferences.showAccuracyRegions ? 1 : 0, // default false
+        preferences.showEstimatedPositions !== undefined ? (preferences.showEstimatedPositions ? 1 : 0) : 1, // default true
         preferences.positionHistoryHours ?? null,
         now,
         now

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5537,10 +5537,10 @@ apiRouter.post('/user/map-preferences', requireAuth(), (req, res) => {
       return res.status(403).json({ error: 'Cannot save preferences for anonymous user' });
     }
 
-    const { mapTileset, showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showMeshCoreNodes, showAnimations, positionHistoryHours } = req.body;
+    const { mapTileset, showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showMeshCoreNodes, showAnimations, showAccuracyRegions, showEstimatedPositions, positionHistoryHours } = req.body;
 
     // Validate boolean values
-    const booleanFields = { showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showMeshCoreNodes, showAnimations };
+    const booleanFields = { showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showMeshCoreNodes, showAnimations, showAccuracyRegions, showEstimatedPositions };
     for (const [key, value] of Object.entries(booleanFields)) {
       if (value !== undefined && typeof value !== 'boolean') {
         return res.status(400).json({ error: `${key} must be a boolean` });
@@ -5567,6 +5567,8 @@ apiRouter.post('/user/map-preferences', requireAuth(), (req, res) => {
       showMqttNodes,
       showMeshCoreNodes,
       showAnimations,
+      showAccuracyRegions,
+      showEstimatedPositions,
       positionHistoryHours,
     });
 


### PR DESCRIPTION
## Summary
- **Show Accuracy Regions** and **Show Estimated Positions** map toggles were not persisting across page reloads
- The frontend was sending these values to the server API, but the server silently dropped them — they were missing from the POST handler, the UserModel save/get methods, and the database schema
- Adds migration 076 with `show_accuracy_regions` and `show_estimated_positions` columns for all three DB backends (SQLite, PostgreSQL, MySQL)

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 2521 tests pass (115 test files)
- [x] Deployed to dev container (SQLite profile) and verified app loads
- [ ] Toggle "Show Accuracy Regions" on, reload page, verify it stays on
- [ ] Toggle "Show Estimated Positions" off, reload page, verify it stays off

🤖 Generated with [Claude Code](https://claude.com/claude-code)