### PR TITLE
fix: defer new node notification until node info is complete

### DIFF
--- a/src/server/services/notificationService.ts
+++ b/src/server/services/notificationService.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../utils/logger.js';
+import { getHardwareModelName } from '../../utils/nodeHelpers.js';
 import { pushNotificationService } from './pushNotificationService.js';
 import { appriseNotificationService, AppriseNotificationPayload } from './appriseNotificationService.js';
 
@@ -134,14 +135,16 @@ class NotificationService {
 
   /**
    * Send notification for newly discovered node (bypasses normal filtering)
-   * Only sends if user has notifyOnNewNode enabled
+   * Only sends if user has notifyOnNewNode enabled.
+   * Called when a node transitions from incomplete to complete (has longName, shortName, hwModel).
    */
-  public async notifyNewNode(nodeId: string, longName: string, hopsAway: number | undefined): Promise<void> {
+  public async notifyNewNode(nodeId: string, longName: string, shortName: string, hwModel: number | undefined, hopsAway: number | undefined): Promise<void> {
     try {
       const hopsText = hopsAway !== undefined ? ` (${hopsAway} ${hopsAway === 1 ? 'hop' : 'hops'} away)` : '';
+      const hwModelText = hwModel !== undefined ? ` - ${getHardwareModelName(hwModel) || 'Unknown'}` : '';
       const payload: NotificationPayload = {
         title: '🆕 New Node Discovered',
-        body: `${longName || nodeId}${hopsText}`,
+        body: `${longName} (${shortName})${hwModelText}${hopsText}`,
         type: 'info'
       };
 
@@ -151,7 +154,7 @@ class NotificationService {
         appriseNotificationService.broadcastToPreferenceUsers('notifyOnNewNode', payload)
       ]);
 
-      logger.info(`📤 Sent new node notification for ${nodeId}`);
+      logger.info(`📤 Sent new node notification for ${longName} (${shortName}) [${nodeId}]`);
     } catch (error) {
       logger.error('❌ Error sending new node notification:', error);
     }


### PR DESCRIPTION
## Summary
- Defers "New Node Discovered" notifications until the node has complete info (longName, shortName, hwModel) instead of firing immediately on first packet when only a raw node ID is available
- Updates notification body format to `LongName (ShortName) - HW Model (N hops away)` for more useful alerts
- Tracks notified nodes via an in-memory Set to prevent duplicate notifications as node data arrives incrementally

## Test plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] All 115 test files pass (2521 tests)
- [x] Verified notification format via Apprise/Pushover test send
- [ ] Manual verification: confirm ephemeral/incomplete nodes no longer trigger notifications
- [ ] Manual verification: confirm notification fires once NODEINFO_APP packet provides full node details

🤖 Generated with [Claude Code](https://claude.com/claude-code)