### PR TITLE
fix: filter popup Reset All button not working

### DIFF
--- a/src/components/AdvancedNodeFilterPopup/AdvancedNodeFilterPopup.tsx
+++ b/src/components/AdvancedNodeFilterPopup/AdvancedNodeFilterPopup.tsx
@@ -47,6 +47,7 @@ export const AdvancedNodeFilterPopup: React.FC<AdvancedNodeFilterPopupProps> = (
 
   const handleReset = () => {
     onNodeFiltersChange(DEFAULT_FILTERS);
+    onSecurityFilterChange('all');
   };
 
   const handleRoleChange = (roleNum: number, checked: boolean) => {

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -36,7 +36,7 @@ import LinkQualityGraph from './LinkQualityGraph';
 import PacketStatsChart, { ChartDataEntry, DISTRIBUTION_COLORS } from './PacketStatsChart';
 import { getNodePacketDistribution } from '../services/packetApi';
 import { PacketDistributionStats } from '../types/packet';
-import { NodeFilterPopup } from './NodeFilterPopup';
+
 import { MessageStatusIndicator } from './MessageStatusIndicator';
 import RelayNodeModal from './RelayNodeModal';
 import TelemetryRequestModal, { TelemetryType } from './TelemetryRequestModal';
@@ -219,8 +219,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   securityFilter,
   channelFilter,
   showIncompleteNodes,
-  showNodeFilterPopup,
-  setShowNodeFilterPopup,
+  showNodeFilterPopup: _showNodeFilterPopup,
+  setShowNodeFilterPopup: _setShowNodeFilterPopup,
   isMessagesNodeListCollapsed,
   setIsMessagesNodeListCollapsed,
   tracerouteLoading,
@@ -687,7 +687,6 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
           )}
         </div>
 
-        <NodeFilterPopup isOpen={showNodeFilterPopup} onClose={() => setShowNodeFilterPopup(false)} />
 
         {!isMessagesNodeListCollapsed && (
           <div className="nodes-list">

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -29,7 +29,7 @@ import { TilesetSelector } from './TilesetSelector';
 import { MapCenterController } from './MapCenterController';
 import PacketMonitorPanel from './PacketMonitorPanel';
 import { getPacketStats } from '../services/packetApi';
-import { NodeFilterPopup } from './NodeFilterPopup';
+
 import { VectorTileLayer } from './VectorTileLayer';
 import { MapNodePopupContent } from './MapNodePopupContent';
 
@@ -2198,11 +2198,6 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
         </div>
       )}
 
-      {/* Node Filter Popup */}
-      <NodeFilterPopup
-        isOpen={showNodeFilterPopup}
-        onClose={() => setShowNodeFilterPopup(false)}
-      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Removed duplicate `NodeFilterPopup` from `NodesTab` and `MessagesTab` that was opening simultaneously with the `AdvancedNodeFilterPopup`, both triggered by the same `showNodeFilterPopup` state
- The old popup rendered on top (same z-index, later in DOM) and its overlay intercepted clicks, preventing the Reset All button from responding
- Updated `handleReset` to also reset the security filter to `'all'` so Reset All truly resets everything

## Test plan
- [ ] Open the map page and click the Filter button
- [ ] Change some filter settings (e.g., check a few checkboxes, change security filter)
- [ ] Click "Reset All" and verify all filters reset to defaults
- [ ] Verify only one popup opens (no duplicate/overlapping popups)
- [ ] Verify the Messages tab filter button also works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)