### PR TITLE
fix: stop falsely classifying nodes with default shortName as incomplete

### DIFF
--- a/src/utils/nodeHelpers.test.ts
+++ b/src/utils/nodeHelpers.test.ts
@@ -290,17 +290,20 @@ describe('Node Helpers', () => {
         expect(isNodeComplete(node)).toBe(false);
       });
 
-      it('should return false for node with default shortName (last 4 chars of nodeId)', () => {
+      it('should return true for node with default shortName (last 4 chars of nodeId)', () => {
+        // Meshtastic firmware uses last 4 hex chars as the default shortName.
+        // A node with a custom longName, default shortName, and valid hwModel
+        // has received NODEINFO and is complete.
         const node: DeviceInfo = {
           nodeNum: 123456789,
           user: {
             id: '!abc12345',
             longName: 'Test Node',
-            shortName: '2345', // Last 4 chars of node ID
+            shortName: '2345', // Last 4 chars of node ID - this is the firmware default
             hwModel: 9
           }
         };
-        expect(isNodeComplete(node)).toBe(false);
+        expect(isNodeComplete(node)).toBe(true);
       });
 
       it('should return false for node without hwModel', () => {
@@ -375,14 +378,16 @@ describe('Node Helpers', () => {
         expect(isNodeComplete(dbNode)).toBe(false);
       });
 
-      it('should return false for database node with default shortName', () => {
+      it('should return true for database node with default shortName', () => {
+        // Default shortName matching last 4 hex chars is normal for users who
+        // didn't customize it - the node still has valid NODEINFO.
         const dbNode = {
           nodeId: '!abc12345',
           longName: 'Test Node',
           shortName: '2345', // Default derived from last 4 chars of nodeId
           hwModel: 9
         };
-        expect(isNodeComplete(dbNode)).toBe(false);
+        expect(isNodeComplete(dbNode)).toBe(true);
       });
 
       it('should return false for database node without hwModel', () => {

--- a/src/utils/nodeHelpers.ts
+++ b/src/utils/nodeHelpers.ts
@@ -307,9 +307,6 @@ export const isNodeComplete = (node: DeviceInfo | DbNodeLike): boolean => {
   // Determine if this is a DeviceInfo (has 'user' property) or DbNodeLike
   const isDeviceInfo = 'user' in node;
 
-  // Get node ID for checking default names
-  const nodeId = isDeviceInfo ? node.user?.id : (node as DbNodeLike).nodeId;
-
   // Get fields - handle both DeviceInfo (user.field) and database node (field) formats
   const longName = isDeviceInfo ? node.user?.longName : (node as DbNodeLike).longName;
   const shortName = isDeviceInfo ? node.user?.shortName : (node as DbNodeLike).shortName;
@@ -320,17 +317,13 @@ export const isNodeComplete = (node: DeviceInfo | DbNodeLike): boolean => {
     return false;
   }
 
-  // Check if shortName exists and is not just the first 4 chars of nodeId
+  // Check if shortName exists
+  // Note: We do NOT check if shortName matches the default (last 4 hex chars of nodeId).
+  // Meshtastic firmware uses the last 4 hex chars as the default shortName, so many users
+  // have a valid NODEINFO with a default shortName. Matching the default does not mean
+  // the node is incomplete.
   if (!shortName) {
     return false;
-  }
-
-  // If we have a nodeId, verify shortName isn't just derived from it
-  if (nodeId && nodeId.startsWith('!')) {
-    const defaultShortName = nodeId.slice(-4);
-    if (shortName === defaultShortName) {
-      return false;
-    }
   }
 
   // Check if hwModel exists (proves we received NODEINFO_APP packet)


### PR DESCRIPTION
## Summary
- Removed the `shortName`-matches-default check from `isNodeComplete()` that was incorrectly hiding fully valid nodes
- In Meshtastic firmware, the default shortName is the last 4 hex chars of the node ID. Many users never customize it, so nodes with valid NODEINFO (custom longName, hwModel present) were being flagged as "incomplete"
- This regression was introduced in 3.6.2 by PR #1932, which correctly fixed shortName derivation from `substring(1,5)` to `slice(-4)` — but that also made the `isNodeComplete` check actually match real firmware defaults, causing false positives

## Root Cause
PR #1932 fixed shortName derivation to use `slice(-4)` (last 4 hex chars) to match Meshtastic convention. Before that fix, `isNodeComplete` compared against `substring(1,5)` (first 4 chars), which almost never matched real firmware defaults — so the bug was latent. After the fix, the check correctly matched, and every node whose user didn't customize their shortName got hidden.

## Fix
The remaining checks are sufficient to prove NODEINFO was received:
1. `longName` exists and is not the auto-generated `"Node !xxxxxxxx"` format
2. `shortName` exists (not empty/undefined)
3. `hwModel` is defined

## Test plan
- [x] Updated 2 existing tests to expect `true` for nodes with default shortName (DeviceInfo and DB formats)
- [x] All 59 nodeHelpers tests pass
- [ ] Verify nodes with default shortNames are visible when "Hide Incomplete Nodes" is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)