### PR TITLE
fix: upgrade ignored_nodes.nodeNum to BIGINT for PostgreSQL/MySQL

### DIFF
--- a/src/db/schema/ignoredNodes.ts
+++ b/src/db/schema/ignoredNodes.ts
@@ -10,13 +10,11 @@ import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
 import {
   pgTable,
   text as pgText,
-  integer as pgInteger,
   bigint as pgBigint,
 } from 'drizzle-orm/pg-core';
 import {
   mysqlTable,
   varchar as myVarchar,
-  int as myInt,
   bigint as myBigint,
 } from 'drizzle-orm/mysql-core';
 
@@ -34,7 +32,7 @@ export const ignoredNodesSqlite = sqliteTable('ignored_nodes', {
 // ============ IGNORED NODES (PostgreSQL) ============
 
 export const ignoredNodesPostgres = pgTable('ignored_nodes', {
-  nodeNum: pgInteger('nodeNum').primaryKey(),
+  nodeNum: pgBigint('nodeNum', { mode: 'number' }).primaryKey(),
   nodeId: pgText('nodeId').notNull(),
   longName: pgText('longName'),
   shortName: pgText('shortName'),
@@ -45,7 +43,7 @@ export const ignoredNodesPostgres = pgTable('ignored_nodes', {
 // ============ IGNORED NODES (MySQL) ============
 
 export const ignoredNodesMysql = mysqlTable('ignored_nodes', {
-  nodeNum: myInt('nodeNum').primaryKey(),
+  nodeNum: myBigint('nodeNum', { mode: 'number' }).primaryKey(),
   nodeId: myVarchar('nodeId', { length: 255 }).notNull(),
   longName: myVarchar('longName', { length: 255 }),
   shortName: myVarchar('shortName', { length: 255 }),

--- a/src/server/migrations/077_upgrade_ignored_nodes_nodenum_bigint.ts
+++ b/src/server/migrations/077_upgrade_ignored_nodes_nodenum_bigint.ts
@@ -1,0 +1,93 @@
+/**
+ * Migration 077: Upgrade ignored_nodes.nodeNum from INTEGER to BIGINT
+ *
+ * Meshtastic node numbers are unsigned 32-bit values (up to ~4.3 billion),
+ * but PostgreSQL/MySQL INTEGER is signed 32-bit (max 2,147,483,647).
+ * This causes query failures for nodeNum values above INT4 max.
+ *
+ * SQLite is unaffected because its INTEGER type is 64-bit.
+ *
+ * Fixes: https://github.com/Yeraze/meshmonitor/issues/1973
+ */
+
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * SQLite migration: No changes needed
+ * SQLite INTEGER is already 64-bit
+ */
+export const migration = {
+  up: (_db: Database): void => {
+    logger.debug('Migration 077: SQLite INTEGER is already 64-bit, no changes needed');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 077 down: No changes needed for SQLite');
+  }
+};
+
+/**
+ * PostgreSQL migration: Upgrade ignored_nodes.nodeNum from INTEGER to BIGINT
+ */
+export async function runMigration077Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 077 (PostgreSQL): Upgrading ignored_nodes.nodeNum to BIGINT...');
+
+  try {
+    const result = await client.query(`
+      SELECT data_type FROM information_schema.columns
+      WHERE table_name = 'ignored_nodes' AND column_name = 'nodeNum'
+    `);
+
+    if (result.rows.length === 0) {
+      logger.debug('Table ignored_nodes or column nodeNum does not exist, skipping');
+      return;
+    }
+
+    if (result.rows[0].data_type === 'bigint') {
+      logger.debug('ignored_nodes.nodeNum is already BIGINT, skipping');
+      return;
+    }
+
+    await client.query(`ALTER TABLE ignored_nodes ALTER COLUMN "nodeNum" TYPE BIGINT`);
+    logger.debug('Upgraded ignored_nodes.nodeNum to BIGINT');
+  } catch (error: any) {
+    logger.error('Failed to upgrade ignored_nodes.nodeNum:', error.message);
+    throw error;
+  }
+
+  logger.info('Migration 077 complete (PostgreSQL): ignored_nodes.nodeNum upgraded to BIGINT');
+}
+
+/**
+ * MySQL migration: Upgrade ignored_nodes.nodeNum from INT to BIGINT
+ */
+export async function runMigration077Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 077 (MySQL): Upgrading ignored_nodes.nodeNum to BIGINT...');
+
+  try {
+    const [rows] = await pool.query(`
+      SELECT DATA_TYPE FROM information_schema.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'ignored_nodes' AND COLUMN_NAME = 'nodeNum'
+    `);
+
+    if (!Array.isArray(rows) || rows.length === 0) {
+      logger.debug('Table ignored_nodes or column nodeNum does not exist, skipping');
+      return;
+    }
+
+    if ((rows[0] as any).DATA_TYPE === 'bigint') {
+      logger.debug('ignored_nodes.nodeNum is already BIGINT, skipping');
+      return;
+    }
+
+    await pool.query(`ALTER TABLE ignored_nodes MODIFY COLUMN nodeNum BIGINT PRIMARY KEY`);
+    logger.debug('Upgraded ignored_nodes.nodeNum to BIGINT');
+  } catch (error: any) {
+    logger.error('Failed to upgrade ignored_nodes.nodeNum:', error.message);
+    throw error;
+  }
+
+  logger.info('Migration 077 complete (MySQL): ignored_nodes.nodeNum upgraded to BIGINT');
+}


### PR DESCRIPTION
## Summary
- Upgraded `ignored_nodes.nodeNum` from `INTEGER` to `BIGINT` in PostgreSQL and MySQL schemas — Meshtastic node numbers are unsigned 32-bit (up to ~4.3B) which overflows signed 32-bit INTEGER (max ~2.1B)
- Added migration 077 to `ALTER COLUMN` on existing databases (no-op for SQLite since its INTEGER is already 64-bit)
- Removed unused `pgInteger` and `myInt` imports from the schema file

Fixes #1973

## Test plan
- [x] Full test suite passes (2521 tests, 115 files)
- [x] Built and deployed on Postgres backend
- [x] Verified migration 077 ran successfully — `nodeNum` column is now `bigint`
- [x] Verified the exact failing node number from the bug report (`2733697270`) can be inserted and queried

🤖 Generated with [Claude Code](https://claude.com/claude-code)