### PR TITLE
fix: simplify auto-upgrade sidecar to prevent port mapping loss

### DIFF
--- a/docs/public/news.json
+++ b/docs/public/news.json
@@ -1,7 +1,16 @@
 {
   "version": "1",
-  "lastUpdated": "2026-02-16T18:00:00Z",
+  "lastUpdated": "2026-02-21T18:00:00Z",
   "items": [
+    {
+      "minVersion": "3.6.5",
+      "id": "news-2026-02-21-auto-upgrade-sidecar-fix",
+      "title": "Auto-Upgrade Sidecar: One-Time Action Required",
+      "content": "MeshMonitor v3.6.5 fixes a bug where **Docker port mappings were lost after auto-upgrades** via the sidecar watchdog ([#1888](https://github.com/Yeraze/meshmonitor/issues/1888)).\n\n## What Changed\n\nThe upgrade watchdog script has been simplified to always use `docker compose up -d --force-recreate` when recreating containers. A fragile legacy code path that attempted to reverse-engineer container configuration from `docker inspect` output has been removed. This eliminates the root cause of lost port mappings, volumes, and environment variables after auto-upgrades.\n\n## Action Required\n\nBecause the watchdog script is embedded inside the sidecar container image, **existing sidecar containers must be recreated once** to pick up the fix. Run the following from your Docker Compose directory:\n\n```\ndocker compose -f docker-compose.yml -f docker-compose.upgrade.yml pull\ndocker compose -f docker-compose.yml -f docker-compose.upgrade.yml up -d\n```\n\nIf you use a single combined compose file (e.g., from the Docker Configurator), adjust the command accordingly:\n\n```\ndocker compose pull\ndocker compose up -d\n```\n\nAfter this one-time update, all future auto-upgrades will correctly preserve your port mappings, volumes, and environment variables.\n\n## Who Is Affected\n\nOnly users who have the **auto-upgrade sidecar** (`meshmonitor-upgrader`) enabled. If you don't use the auto-upgrade feature, no action is needed.",
+      "date": "2026-02-21T18:00:00Z",
+      "category": "maintenance",
+      "priority": "important"
+    },
     {
       "minVersion": "3.6.0",
       "id": "news-2026-02-16-auto-ping-vn-branding",


### PR DESCRIPTION
## Summary

- **Removes the fragile legacy `docker run` fallback path** from `recreate_container()` in the upgrade watchdog script. This path attempted to reverse-engineer container configuration (ports, volumes, env vars, networks) by parsing `docker inspect` output — the root cause of #1888 where Docker port mappings were lost after auto-upgrades.
- **Simplifies the compose path** by replacing the manual stop/remove/30s-wait loop with a single `docker compose up -d --force-recreate --no-deps` call, which handles everything atomically.
- **Adds `/compose` fallback** for compose directory resolution, so misconfigured `COMPOSE_PROJECT_DIR` no longer causes a silent fallback to the broken legacy path.
- **Adds port mapping verification logging** after container recreation for easier debugging.
- **Adds a news item** for v3.6.5 explaining the fix and instructing existing sidecar users to recreate their containers once.

Net change: **-169 lines, +79 lines** (90 lines removed).

Closes #1888

## Test plan

- [ ] Syntax check passes (`bash -n scripts/upgrade-watchdog.sh`)
- [ ] Unit tests pass (2521/2521)
- [ ] `news.json` validates as valid JSON
- [ ] Deploy with upgrade sidecar and verify compose directory resolution works
- [ ] Trigger an auto-upgrade and verify port mappings are preserved on the recreated container
- [ ] Test error case: remove compose files and verify clear error message
- [ ] Verify news item appears for users on v3.6.5+

🤖 Generated with [Claude Code](https://claude.com/claude-code)