### PR TITLE
ci: add Node.js 25.x to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x, 25.x]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- Adds Node.js 25.x to the CI test matrix in `ci.yml` (now tests 20.x, 22.x, 24.x, 25.x)
- All 2521 unit tests pass on Node 25.6.0 (verified locally)
- The only requirement for Node 25 is rebuilding native modules (`better-sqlite3`), which `npm install` handles automatically in CI

Relates to #1976

## Test plan

- [ ] CI passes on all 4 Node.js versions (20, 22, 24, 25)
- [ ] No regressions on existing Node versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)