### PR TITLE
feat: allow disabling rate limits via env vars

### DIFF
--- a/src/server/config/environment.ratelimit.test.ts
+++ b/src/server/config/environment.ratelimit.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Rate Limit Environment Configuration Tests
+ *
+ * Tests the parseRateLimit() helper via getEnvironmentConfig() for the
+ * RATE_LIMIT_API, RATE_LIMIT_AUTH, and RATE_LIMIT_MESSAGES env vars.
+ * Special values ("unlimited", "0", "-1") should yield 0 (disabled sentinel).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { resetEnvironmentConfig, getEnvironmentConfig } from './environment.js';
+
+// In the test environment NODE_ENV defaults to 'development',
+// so the rate-limit defaults are: API=10000, Auth=100, Messages=100
+
+describe('Rate Limit Environment Configuration', () => {
+  const originalApi = process.env.RATE_LIMIT_API;
+  const originalAuth = process.env.RATE_LIMIT_AUTH;
+  const originalMessages = process.env.RATE_LIMIT_MESSAGES;
+
+  afterEach(() => {
+    // Restore original environment
+    if (originalApi !== undefined) {
+      process.env.RATE_LIMIT_API = originalApi;
+    } else {
+      delete process.env.RATE_LIMIT_API;
+    }
+    if (originalAuth !== undefined) {
+      process.env.RATE_LIMIT_AUTH = originalAuth;
+    } else {
+      delete process.env.RATE_LIMIT_AUTH;
+    }
+    if (originalMessages !== undefined) {
+      process.env.RATE_LIMIT_MESSAGES = originalMessages;
+    } else {
+      delete process.env.RATE_LIMIT_MESSAGES;
+    }
+    resetEnvironmentConfig();
+  });
+
+  describe('Default values', () => {
+    it('should use development defaults when env vars are not set', () => {
+      delete process.env.RATE_LIMIT_API;
+      delete process.env.RATE_LIMIT_AUTH;
+      delete process.env.RATE_LIMIT_MESSAGES;
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitApi).toBe(10000);
+      expect(config.rateLimitApiProvided).toBe(false);
+      expect(config.rateLimitAuth).toBe(100);
+      expect(config.rateLimitAuthProvided).toBe(false);
+      expect(config.rateLimitMessages).toBe(100);
+      expect(config.rateLimitMessagesProvided).toBe(false);
+    });
+  });
+
+  describe('Valid positive integer values', () => {
+    it('should accept custom positive integers for all rate limit vars', () => {
+      process.env.RATE_LIMIT_API = '500';
+      process.env.RATE_LIMIT_AUTH = '20';
+      process.env.RATE_LIMIT_MESSAGES = '60';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitApi).toBe(500);
+      expect(config.rateLimitApiProvided).toBe(true);
+      expect(config.rateLimitAuth).toBe(20);
+      expect(config.rateLimitAuthProvided).toBe(true);
+      expect(config.rateLimitMessages).toBe(60);
+      expect(config.rateLimitMessagesProvided).toBe(true);
+    });
+
+    it('should accept value of 1 as valid limit', () => {
+      process.env.RATE_LIMIT_API = '1';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitApi).toBe(1);
+      expect(config.rateLimitApiProvided).toBe(true);
+    });
+  });
+
+  describe('Unlimited / disabled via special values', () => {
+    it('should treat "unlimited" as disabled (value 0)', () => {
+      process.env.RATE_LIMIT_API = 'unlimited';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitApi).toBe(0);
+      expect(config.rateLimitApiProvided).toBe(true);
+    });
+
+    it('should treat "UNLIMITED" (uppercase) as disabled', () => {
+      process.env.RATE_LIMIT_AUTH = 'UNLIMITED';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitAuth).toBe(0);
+      expect(config.rateLimitAuthProvided).toBe(true);
+    });
+
+    it('should treat "Unlimited" (mixed case) as disabled', () => {
+      process.env.RATE_LIMIT_MESSAGES = 'Unlimited';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitMessages).toBe(0);
+      expect(config.rateLimitMessagesProvided).toBe(true);
+    });
+
+    it('should treat "0" as disabled', () => {
+      process.env.RATE_LIMIT_API = '0';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitApi).toBe(0);
+      expect(config.rateLimitApiProvided).toBe(true);
+    });
+
+    it('should treat "-1" as disabled', () => {
+      process.env.RATE_LIMIT_API = '-1';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitApi).toBe(0);
+      expect(config.rateLimitApiProvided).toBe(true);
+    });
+
+    it('should treat other negative numbers as disabled', () => {
+      process.env.RATE_LIMIT_API = '-100';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitApi).toBe(0);
+      expect(config.rateLimitApiProvided).toBe(true);
+    });
+
+    it('should handle "unlimited" with whitespace', () => {
+      process.env.RATE_LIMIT_API = '  unlimited  ';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitApi).toBe(0);
+      expect(config.rateLimitApiProvided).toBe(true);
+    });
+
+    it('should disable all three limiters independently', () => {
+      process.env.RATE_LIMIT_API = 'unlimited';
+      process.env.RATE_LIMIT_AUTH = '0';
+      process.env.RATE_LIMIT_MESSAGES = '-1';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitApi).toBe(0);
+      expect(config.rateLimitAuth).toBe(0);
+      expect(config.rateLimitMessages).toBe(0);
+    });
+  });
+
+  describe('Invalid input', () => {
+    it('should fall back to default for non-numeric strings', () => {
+      process.env.RATE_LIMIT_API = 'abc';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitApi).toBe(10000); // development default
+      expect(config.rateLimitApiProvided).toBe(false);
+    });
+
+    it('should fall back to default for empty string', () => {
+      process.env.RATE_LIMIT_API = '';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitApi).toBe(10000);
+      expect(config.rateLimitApiProvided).toBe(false);
+    });
+
+    it('should fall back to default for whitespace-only string', () => {
+      process.env.RATE_LIMIT_API = '   ';
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitApi).toBe(10000);
+      expect(config.rateLimitApiProvided).toBe(false);
+    });
+  });
+
+  describe('Mixed configuration', () => {
+    it('should allow some limiters disabled and others with custom values', () => {
+      process.env.RATE_LIMIT_API = 'unlimited';
+      process.env.RATE_LIMIT_AUTH = '50';
+      delete process.env.RATE_LIMIT_MESSAGES;
+      resetEnvironmentConfig();
+
+      const config = getEnvironmentConfig();
+
+      expect(config.rateLimitApi).toBe(0);
+      expect(config.rateLimitApiProvided).toBe(true);
+      expect(config.rateLimitAuth).toBe(50);
+      expect(config.rateLimitAuthProvided).toBe(true);
+      expect(config.rateLimitMessages).toBe(100); // development default
+      expect(config.rateLimitMessagesProvided).toBe(false);
+    });
+  });
+});

--- a/src/server/config/environment.ts
+++ b/src/server/config/environment.ts
@@ -66,6 +66,45 @@ function parseInt32(
 }
 
 /**
+ * Parse a rate limit environment variable.
+ * Accepts positive integers (normal limit), or special values to disable:
+ *   "unlimited" (case-insensitive), "0", "-1" → returns 0 (sentinel for disabled)
+ * In express-rate-limit v7+, max:0 blocks all requests, so callers must
+ * use `skip: () => true` when the value is 0.
+ */
+function parseRateLimit(
+  name: string,
+  envValue: string | undefined,
+  defaultValue: number
+): { value: number; wasProvided: boolean } {
+  if (envValue === undefined) {
+    return { value: defaultValue, wasProvided: false };
+  }
+
+  const trimmed = envValue.trim();
+
+  // Special "unlimited" keyword (case-insensitive)
+  if (trimmed.toLowerCase() === 'unlimited') {
+    logger.info(`ℹ️  ${name} set to "unlimited" — rate limiting disabled for this category`);
+    return { value: 0, wasProvided: true };
+  }
+
+  const parsed = parseInt(trimmed, 10);
+  if (isNaN(parsed)) {
+    logger.warn(`⚠️  Invalid ${name} value: "${envValue}". Expected integer or "unlimited". Using default: ${defaultValue}`);
+    return { value: defaultValue, wasProvided: false };
+  }
+
+  // 0 or negative → treat as "disable"
+  if (parsed <= 0) {
+    logger.info(`ℹ️  ${name} set to ${parsed} — rate limiting disabled for this category`);
+    return { value: 0, wasProvided: true };
+  }
+
+  return { value: parsed, wasProvided: true };
+}
+
+/**
  * Parse trust proxy setting
  * Supports: 'true', 'false', numbers (1, 2, etc.), or IP/CIDR strings
  * See: https://expressjs.com/en/guide/behind-proxies.html
@@ -478,9 +517,9 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
 
   // Rate Limiting
   // Defaults: API=1000/15min (~1req/sec), Auth=5/15min, Messages=30/min
-  const rateLimitApi = parseInt32('RATE_LIMIT_API', process.env.RATE_LIMIT_API, nodeEnv.value === 'development' ? 10000 : 1000);
-  const rateLimitAuth = parseInt32('RATE_LIMIT_AUTH', process.env.RATE_LIMIT_AUTH, nodeEnv.value === 'development' ? 100 : 5);
-  const rateLimitMessages = parseInt32('RATE_LIMIT_MESSAGES', process.env.RATE_LIMIT_MESSAGES, nodeEnv.value === 'development' ? 100 : 30);
+  const rateLimitApi = parseRateLimit('RATE_LIMIT_API', process.env.RATE_LIMIT_API, nodeEnv.value === 'development' ? 10000 : 1000);
+  const rateLimitAuth = parseRateLimit('RATE_LIMIT_AUTH', process.env.RATE_LIMIT_AUTH, nodeEnv.value === 'development' ? 100 : 5);
+  const rateLimitMessages = parseRateLimit('RATE_LIMIT_MESSAGES', process.env.RATE_LIMIT_MESSAGES, nodeEnv.value === 'development' ? 100 : 30);
 
   // Push Notifications (VAPID) - optional, can be stored in database instead
   const vapidPublicKey = {

--- a/src/server/middleware/rateLimiters.test.ts
+++ b/src/server/middleware/rateLimiters.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Rate Limiters Middleware Tests
+ *
+ * Tests that the rate limiters respect the "unlimited" / disabled sentinel (0)
+ * by using `skip: () => true`, and that normal positive limits still enforce.
+ *
+ * Because rateLimiters.ts reads getEnvironmentConfig() at module scope,
+ * we use vi.resetModules() + dynamic imports to re-evaluate with different mocks.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+
+// Mock dependencies before any import of rateLimiters
+vi.mock('../config/environment.js');
+vi.mock('../../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+async function createTestApp(envOverrides: Record<string, unknown>): Promise<Express> {
+  // Reset module registry so rateLimiters re-evaluates with new mock
+  vi.resetModules();
+
+  // Re-mock after reset
+  vi.doMock('../config/environment.js', () => ({
+    getEnvironmentConfig: () => ({
+      rateLimitApi: 10000,
+      rateLimitApiProvided: false,
+      rateLimitAuth: 100,
+      rateLimitAuthProvided: false,
+      rateLimitMessages: 100,
+      rateLimitMessagesProvided: false,
+      isProduction: false,
+      trustProxyProvided: true,
+      ...envOverrides,
+    }),
+  }));
+  vi.doMock('../../utils/logger.js', () => ({
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  }));
+
+  const { apiLimiter, authLimiter, messageLimiter } =
+    await import('./rateLimiters.js');
+
+  const app = express();
+  app.use('/api', apiLimiter, (_req, res) => res.json({ ok: true }));
+  app.use('/auth', authLimiter, (_req, res) => res.json({ ok: true }));
+  app.use('/messages', messageLimiter, (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe('Rate Limiters Middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('When rate limits are set to 0 (disabled)', () => {
+    it('should not throttle API requests when rateLimitApi is 0', async () => {
+      const app = await createTestApp({
+        rateLimitApi: 0,
+        rateLimitApiProvided: true,
+      });
+
+      // All requests should succeed — no throttling
+      for (let i = 0; i < 5; i++) {
+        const res = await request(app).get('/api');
+        expect(res.status).toBe(200);
+        expect(res.body.ok).toBe(true);
+      }
+    });
+
+    it('should not throttle auth requests when rateLimitAuth is 0', async () => {
+      const app = await createTestApp({
+        rateLimitAuth: 0,
+        rateLimitAuthProvided: true,
+      });
+
+      for (let i = 0; i < 5; i++) {
+        const res = await request(app).get('/auth');
+        expect(res.status).toBe(200);
+      }
+    });
+
+    it('should not throttle message requests when rateLimitMessages is 0', async () => {
+      const app = await createTestApp({
+        rateLimitMessages: 0,
+        rateLimitMessagesProvided: true,
+      });
+
+      for (let i = 0; i < 5; i++) {
+        const res = await request(app).get('/messages');
+        expect(res.status).toBe(200);
+      }
+    });
+
+    it('should allow all limiters disabled simultaneously', async () => {
+      const app = await createTestApp({
+        rateLimitApi: 0,
+        rateLimitApiProvided: true,
+        rateLimitAuth: 0,
+        rateLimitAuthProvided: true,
+        rateLimitMessages: 0,
+        rateLimitMessagesProvided: true,
+      });
+
+      const apiRes = await request(app).get('/api');
+      const authRes = await request(app).get('/auth');
+      const msgRes = await request(app).get('/messages');
+
+      expect(apiRes.status).toBe(200);
+      expect(authRes.status).toBe(200);
+      expect(msgRes.status).toBe(200);
+    });
+  });
+
+  describe('When rate limits are set to a small positive value', () => {
+    it('should enforce API rate limit after max requests exceeded', async () => {
+      const app = await createTestApp({
+        rateLimitApi: 2,
+        rateLimitApiProvided: true,
+      });
+
+      // First 2 should succeed
+      expect((await request(app).get('/api')).status).toBe(200);
+      expect((await request(app).get('/api')).status).toBe(200);
+
+      // Third should be rate-limited
+      const res = await request(app).get('/api');
+      expect(res.status).toBe(429);
+      expect(res.body.error).toContain('Too many requests');
+    });
+
+    it('should enforce auth rate limit after max requests exceeded', async () => {
+      // authLimiter has skipSuccessfulRequests: true, so successful (200)
+      // responses don't count. We need the handler to return a non-2xx status
+      // to trigger counting.
+      vi.resetModules();
+      vi.doMock('../config/environment.js', () => ({
+        getEnvironmentConfig: () => ({
+          rateLimitApi: 10000,
+          rateLimitApiProvided: false,
+          rateLimitAuth: 1,
+          rateLimitAuthProvided: true,
+          rateLimitMessages: 100,
+          rateLimitMessagesProvided: false,
+          isProduction: false,
+          trustProxyProvided: true,
+        }),
+      }));
+      vi.doMock('../../utils/logger.js', () => ({
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      }));
+
+      const { authLimiter } = await import('./rateLimiters.js');
+      const app = express();
+      // Return 401 so the request counts against the rate limit
+      app.use('/auth', authLimiter, (_req, res) => res.status(401).json({ error: 'bad creds' }));
+
+      expect((await request(app).get('/auth')).status).toBe(401);
+
+      const res = await request(app).get('/auth');
+      expect(res.status).toBe(429);
+      expect(res.body.error).toContain('Too many login attempts');
+    });
+
+    it('should enforce message rate limit after max requests exceeded', async () => {
+      const app = await createTestApp({
+        rateLimitMessages: 1,
+        rateLimitMessagesProvided: true,
+      });
+
+      expect((await request(app).get('/messages')).status).toBe(200);
+
+      const res = await request(app).get('/messages');
+      expect(res.status).toBe(429);
+      expect(res.body.error).toContain('Too many messages');
+    });
+  });
+
+  describe('Mixed configuration', () => {
+    it('should allow disabled API but enforce auth limits', async () => {
+      // authLimiter has skipSuccessfulRequests: true, so we need 401 responses
+      vi.resetModules();
+      vi.doMock('../config/environment.js', () => ({
+        getEnvironmentConfig: () => ({
+          rateLimitApi: 0,
+          rateLimitApiProvided: true,
+          rateLimitAuth: 1,
+          rateLimitAuthProvided: true,
+          rateLimitMessages: 100,
+          rateLimitMessagesProvided: false,
+          isProduction: false,
+          trustProxyProvided: true,
+        }),
+      }));
+      vi.doMock('../../utils/logger.js', () => ({
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      }));
+
+      const { apiLimiter, authLimiter } = await import('./rateLimiters.js');
+      const app = express();
+      app.use('/api', apiLimiter, (_req, res) => res.json({ ok: true }));
+      app.use('/auth', authLimiter, (_req, res) => res.status(401).json({ error: 'bad creds' }));
+
+      // API: unlimited — always 200
+      expect((await request(app).get('/api')).status).toBe(200);
+      expect((await request(app).get('/api')).status).toBe(200);
+      expect((await request(app).get('/api')).status).toBe(200);
+
+      // Auth: limit 1 — second request blocked (401 counts against the limit)
+      expect((await request(app).get('/auth')).status).toBe(401);
+      expect((await request(app).get('/auth')).status).toBe(429);
+    });
+  });
+
+  describe('Startup logging', () => {
+    it('should log "unlimited (disabled)" when rate limit is 0', async () => {
+      vi.resetModules();
+      const mockLogger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+      vi.doMock('../config/environment.js', () => ({
+        getEnvironmentConfig: () => ({
+          rateLimitApi: 0,
+          rateLimitApiProvided: true,
+          rateLimitAuth: 0,
+          rateLimitAuthProvided: true,
+          rateLimitMessages: 0,
+          rateLimitMessagesProvided: true,
+          isProduction: false,
+          trustProxyProvided: true,
+        }),
+      }));
+      vi.doMock('../../utils/logger.js', () => ({
+        logger: mockLogger,
+      }));
+
+      await import('./rateLimiters.js');
+
+      const infoCalls = mockLogger.info.mock.calls.map((c: unknown[]) => c[0]);
+      expect(infoCalls).toContainEqual(
+        expect.stringContaining('unlimited (disabled)')
+      );
+
+      // All three should show disabled
+      const disabledLogs = infoCalls.filter((msg: string) =>
+        msg.includes('unlimited (disabled)')
+      );
+      expect(disabledLogs).toHaveLength(3);
+    });
+
+    it('should log normal values when rate limit is a positive number', async () => {
+      vi.resetModules();
+      const mockLogger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+      vi.doMock('../config/environment.js', () => ({
+        getEnvironmentConfig: () => ({
+          rateLimitApi: 500,
+          rateLimitApiProvided: true,
+          rateLimitAuth: 10,
+          rateLimitAuthProvided: false,
+          rateLimitMessages: 30,
+          rateLimitMessagesProvided: false,
+          isProduction: false,
+          trustProxyProvided: true,
+        }),
+      }));
+      vi.doMock('../../utils/logger.js', () => ({
+        logger: mockLogger,
+      }));
+
+      await import('./rateLimiters.js');
+
+      const infoCalls = mockLogger.info.mock.calls.map((c: unknown[]) => c[0]);
+      expect(infoCalls).toContainEqual(
+        expect.stringContaining('500 requests per 15 minutes')
+      );
+      expect(infoCalls).toContainEqual(
+        expect.stringContaining('10 attempts per 15 minutes')
+      );
+      expect(infoCalls).toContainEqual(
+        expect.stringContaining('30 messages per minute')
+      );
+    });
+  });
+});

--- a/src/server/middleware/rateLimiters.ts
+++ b/src/server/middleware/rateLimiters.ts
@@ -24,9 +24,9 @@ const rateLimitConfig = {
 
 // Log rate limit configuration at startup
 logger.info('⏱️  Rate limit configuration:');
-logger.info(`   - API: ${env.rateLimitApi} requests per 15 minutes${env.rateLimitApiProvided ? ' (custom)' : ' (default)'}`);
-logger.info(`   - Auth: ${env.rateLimitAuth} attempts per 15 minutes${env.rateLimitAuthProvided ? ' (custom)' : ' (default)'}`);
-logger.info(`   - Messages: ${env.rateLimitMessages} messages per minute${env.rateLimitMessagesProvided ? ' (custom)' : ' (default)'}`);
+logger.info(`   - API: ${env.rateLimitApi === 0 ? 'unlimited (disabled)' : `${env.rateLimitApi} requests per 15 minutes`}${env.rateLimitApiProvided ? ' (custom)' : ' (default)'}`);
+logger.info(`   - Auth: ${env.rateLimitAuth === 0 ? 'unlimited (disabled)' : `${env.rateLimitAuth} attempts per 15 minutes`}${env.rateLimitAuthProvided ? ' (custom)' : ' (default)'}`);
+logger.info(`   - Messages: ${env.rateLimitMessages === 0 ? 'unlimited (disabled)' : `${env.rateLimitMessages} messages per minute`}${env.rateLimitMessagesProvided ? ' (custom)' : ' (default)'}`);
 
 // Log reverse proxy configuration warnings
 if (!env.trustProxyProvided && env.isProduction) {
@@ -50,6 +50,7 @@ export const apiLimiter = rateLimit({
     });
   },
   ...rateLimitConfig,
+  ...(env.rateLimitApi === 0 ? { skip: () => true } : {}),
 });
 
 // Strict rate limiting for authentication endpoints
@@ -70,6 +71,7 @@ export const authLimiter = rateLimit({
     });
   },
   ...rateLimitConfig,
+  ...(env.rateLimitAuth === 0 ? { skip: () => true } : {}),
 });
 
 // Moderate rate limiting for message sending
@@ -88,6 +90,7 @@ export const messageLimiter = rateLimit({
     });
   },
   ...rateLimitConfig,
+  ...(env.rateLimitMessages === 0 ? { skip: () => true } : {}),
 });
 
 // Rate limiting for MeshCore device operations (connect, disconnect, config changes)


### PR DESCRIPTION
## Summary

- Add `parseRateLimit()` helper in `environment.ts` that recognizes `"unlimited"` (case-insensitive), `"0"`, and `"-1"` as "disable this limiter" (sentinel value `0`)
- In `rateLimiters.ts`, spread `skip: () => true` into each configurable limiter when its value is `0` — this properly disables the limiter in express-rate-limit v7+ (where `max: 0` would block all requests)
- Updated startup logging to show `"unlimited (disabled)"` when a limiter is disabled
- `meshcoreDeviceLimiter` is unchanged (no env var, stays hardcoded)

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run` — 117 test files, 2546 tests passing (25 new tests added)
- [ ] Set `RATE_LIMIT_API=unlimited` → startup log shows "unlimited (disabled)", requests not throttled
- [ ] Set `RATE_LIMIT_API=-1` and `RATE_LIMIT_API=0` → same behavior
- [ ] Normal integer values still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)