### PR TITLE
fix: remove incorrect Desktop Only label from packet monitor

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -456,7 +456,6 @@
     "admin_commands.config_import_export": "",
     "users.user_deactivated": "",
     "admin_commands.please_select_node_to_ignore": "",
-    "settings.packet_monitor_desktop_only": "",
     "security.failed_export": "",
     "system_backup.restore_warning_description": "",
     "lora_config.hop_limit": "",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1342,7 +1342,6 @@
   "settings.tapback_confirm_reset": "Reset tapback emojis to defaults? This will replace all your custom emojis.",
   "settings.tapback_reset_success": "Emojis reset to defaults",
   "settings.packet_monitor": "Packet Monitor",
-  "settings.packet_monitor_desktop_only": "(Desktop Only)",
   "settings.packet_monitor_description": "Configure the mesh traffic monitor that displays all packets on the network. Requires both channels:read and messages:read permissions.",
   "settings.enable_audio_notifications": "Enable Audio Notifications",
   "settings.enable_audio_notifications_description": "Play a sound when new messages arrive. Disable this if you experience audio issues in your browser.",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -468,7 +468,6 @@
     "admin_commands.config_import_export": "",
     "users.user_deactivated": "",
     "admin_commands.please_select_node_to_ignore": "",
-    "settings.packet_monitor_desktop_only": "",
     "security.failed_export": "",
     "system_backup.restore_warning_description": "",
     "lora_config.hop_limit": "",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -456,7 +456,6 @@
     "admin_commands.config_import_export": "",
     "users.user_deactivated": "",
     "admin_commands.please_select_node_to_ignore": "",
-    "settings.packet_monitor_desktop_only": "",
     "security.failed_export": "",
     "system_backup.restore_warning_description": "",
     "lora_config.hop_limit": "",

--- a/public/locales/nb_NO.json
+++ b/public/locales/nb_NO.json
@@ -204,7 +204,6 @@
     "users.user_deactivated": "",
     "admin_commands.please_select_node_to_ignore": "",
     "messages.traceroute_failed": "",
-    "settings.packet_monitor_desktop_only": "",
     "security.failed_export": "",
     "system_backup.restore_warning_description": "",
     "lora_config.hop_limit": "",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -1176,7 +1176,6 @@
     "settings.theme_tritanopia": "Тританопия (синяя слепота)",
     "settings.theme_custom": "Пользовательская тема",
     "settings.packet_monitor": "Мониторинг пакетов",
-    "settings.packet_monitor_desktop_only": "(Только для настольных компьютеров)",
     "settings.packet_monitor_description": "Настройте mesh traffic monitor, отображающий все пакеты в сети. Требуются оба канала: чтение и сообщения:разрешение на чтение.",
     "settings.hide_incomplete_description": "Скройте имена нод, в которых отсутствуют данные об оборудовании. В защищенных каналах (пользовательский PSK) неполные ноды не были одобрены как входящие в ваш канал.",
     "settings.solar_monitoring_description": "Настройте мониторинг солнечных панелей для оценки производительности. Спасибо {{link}} за их API для оценки солнечной энергии!",

--- a/public/locales/zh_Hans.json
+++ b/public/locales/zh_Hans.json
@@ -1086,7 +1086,6 @@
     "settings.theme_tritanopia": "蓝色盲友好",
     "settings.theme_custom": "自定义主题",
     "settings.packet_monitor": "数据包监视",
-    "settings.packet_monitor_desktop_only": "（仅桌面）",
     "settings.packet_monitor_description": "配置网格流量监视器以显示网络上所有数据包。需要 channels:read 与 messages:read 权限。",
     "settings.hide_incomplete_description": "隐藏缺少名称或硬件信息的节点。在安全频道（自定义 PSK）建议启用，避免显示未验证的节点。",
     "settings.solar_monitoring_description": "配置太阳能监测以估算产能。感谢 {{link}} 提供 Solar Estimates API！",

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -303,7 +303,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   // Ref for spiderfier controller to manage overlapping markers
   const spiderfierRef = useRef<SpiderfierControllerRef>(null);
 
-  // Packet Monitor state (desktop only)
+  // Packet Monitor state
   const [showPacketMonitor, setShowPacketMonitor] = useState(() => {
     // Load from localStorage
     const saved = localStorage.getItem('showPacketMonitor');
@@ -2179,7 +2179,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
         )}
       </div>
 
-      {/* Packet Monitor Panel (Desktop Only) */}
+      {/* Packet Monitor Panel */}
       {showPacketMonitor && canViewPacketMonitor && (
         <div
           className={`packet-monitor-container ${isPacketMonitorResizing ? 'resizing' : ''}`}

--- a/src/components/PacketMonitorPanel.css
+++ b/src/components/PacketMonitorPanel.css
@@ -1,4 +1,4 @@
-/* Packet Monitor Panel - Desktop Only */
+/* Packet Monitor Panel */
 .packet-monitor-panel {
   display: flex;
   flex-direction: column;

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -1149,7 +1149,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               />
               <span>{t('settings.packet_monitor')}</span>
             </label>
-            <span style={{ fontSize: '0.85rem', fontWeight: 'normal', color: 'var(--text-secondary)' }}>{t('settings.packet_monitor_desktop_only')}</span>
+
           </h3>
           <p className="setting-description">{t('settings.packet_monitor_description')}</p>
           <div className="packet-monitor-settings">


### PR DESCRIPTION
## Summary
- Removed the "(Desktop Only)" label from the packet monitor settings heading — the packet monitor works on all platforms, not just desktop
- Cleaned up related "desktop only" comments in NodesTab.tsx and PacketMonitorPanel.css
- Removed the `settings.packet_monitor_desktop_only` translation key from all 7 locale files (en, de, ru, fr, nb_NO, zh_Hans, es)

## Test plan
- [ ] Verify the settings page no longer shows "(Desktop Only)" next to Packet Monitor
- [ ] Verify packet monitor still functions correctly on desktop and mobile views

🤖 Generated with [Claude Code](https://claude.com/claude-code)