### PR TITLE
docs: add Community Add-ons section with AI Responder

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -27,6 +27,7 @@ export default defineConfig({
         items: [
           { text: 'Features', link: '/features/settings' },
           { text: 'Configuration', link: '/configuration/' },
+          { text: 'Add-ons', link: '/add-ons/' },
           { text: 'Development', link: '/development/' }
         ]
       },
@@ -66,7 +67,6 @@ export default defineConfig({
             { text: 'BLE Bridge', link: '/configuration/ble-bridge' },
             { text: 'Serial Bridge', link: '/configuration/serial-bridge' },
             { text: 'Virtual Node', link: '/configuration/virtual-node' },
-            { text: 'MQTT Client Proxy', link: '/configuration/mqtt-proxy' },
             { text: '🗺️ Custom Tile Servers', link: '/configuration/custom-tile-servers' },
             { text: 'SSO Setup', link: '/configuration/sso' },
             { text: 'Reverse Proxy', link: '/configuration/reverse-proxy' },
@@ -81,6 +81,16 @@ export default defineConfig({
           items: [
             { text: 'Deployment Guide', link: '/deployment/DEPLOYMENT_GUIDE' },
             { text: '📦 Proxmox LXC', link: '/deployment/PROXMOX_LXC_GUIDE' }
+          ]
+        }
+      ],
+      '/add-ons/': [
+        {
+          text: 'Community Add-ons',
+          items: [
+            { text: 'Overview', link: '/add-ons/' },
+            { text: 'MQTT Client Proxy', link: '/add-ons/mqtt-proxy' },
+            { text: 'AI Responder', link: '/add-ons/ai-responder' }
           ]
         }
       ],

--- a/docs/.vitepress/theme/DockerComposeConfigurator.vue
+++ b/docs/.vitepress/theme/DockerComposeConfigurator.vue
@@ -477,7 +477,7 @@
         <p class="field-help">
           Adds an MQTT proxy container that routes MQTT traffic through MeshMonitor instead of directly from your node.
           Useful when your node has unreliable WiFi or when you want MQTT without running mobile apps.
-          <a href="/configuration/mqtt-proxy" target="_blank">Learn more</a>
+          <a href="/add-ons/mqtt-proxy" target="_blank">Learn more</a>
         </p>
       </div>
 

--- a/docs/add-ons/ai-responder.md
+++ b/docs/add-ons/ai-responder.md
@@ -1,0 +1,226 @@
+# AI Responder
+
+The AI Responder is an optional sidecar container that transforms your Meshtastic node into an AI-powered assistant. Users on the mesh can ask questions, have conversations, and get intelligent responses — all through standard Meshtastic messaging.
+
+::: tip Credit
+The AI Responder was created by [LN4CY](https://github.com/LN4CY/ai-responder). MeshMonitor integrates it as an optional Docker sidecar.
+:::
+
+## Overview
+
+The AI Responder connects to MeshMonitor's Virtual Node (port 4404) and monitors configured channels for messages prefixed with `!ai`. It supports multiple AI providers — from local models via Ollama for privacy-focused deployments, to cloud providers like Google Gemini, OpenAI, and Anthropic for more powerful responses.
+
+Key features:
+- **Multi-provider support**: Ollama (local), Google Gemini, OpenAI, Anthropic Claude
+- **Per-user conversation history**: Each user gets isolated conversation context
+- **Session mode**: Continuous conversations in DMs without repeating the `!ai` prefix
+- **Mesh-optimized**: Responses tuned for LoRa message size limits (~200 characters)
+- **Automatic reconnection**: Resilient connection with 10-second retry loop
+
+## How It Works
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     Your Server                         │
+│                                                         │
+│  ┌────────────────┐     ┌──────────────┐                │
+│  │  MeshMonitor   │────►│ AI Responder │                │
+│  │  (port 3001)   │     │  (sidecar)   │                │
+│  │                │     │              │                │
+│  │  Virtual Node  │◄────│  TCP Client  │                │
+│  │  (port 4404)   │     │              │───► AI Provider│
+│  └────────┬───────┘     └──────────────┘    (Ollama,   │
+│           │                                  Gemini,   │
+│           │                                  OpenAI,   │
+│           │                                  Claude)   │
+└───────────┼─────────────────────────────────────────────┘
+            │
+            │ TCP (port 4403)
+            ▼
+    ┌───────────────┐
+    │  Meshtastic   │
+    │    Node       │
+    └───────────────┘
+```
+
+**Key Points:**
+1. The AI Responder connects to MeshMonitor's Virtual Node (port 4404)
+2. It monitors configured channels for `!ai` messages
+3. Questions are forwarded to the configured AI provider
+4. Responses are sent back through the mesh network
+
+## Quick Start
+
+### Prerequisites
+
+1. **Virtual Node enabled** — The AI Responder requires MeshMonitor's Virtual Node feature (`ENABLE_VIRTUAL_NODE=true`)
+2. **AI provider** — Either a local Ollama instance or a cloud API key (Gemini, OpenAI, or Anthropic)
+
+### Docker Compose Setup
+
+Add the AI Responder to your existing `docker-compose.yml`:
+
+```yaml
+services:
+  meshmonitor:
+    image: ghcr.io/yeraze/meshmonitor:latest
+    # ... your existing MeshMonitor configuration ...
+    environment:
+      - ENABLE_VIRTUAL_NODE=true
+      - VIRTUAL_NODE_PORT=4404
+      # ... other environment variables ...
+
+  # AI Responder - AI-powered mesh assistant
+  # Credit: https://github.com/LN4CY/ai-responder
+  ai-responder:
+    image: ghcr.io/ln4cy/ai-responder:latest
+    container_name: meshmonitor-ai-responder
+    restart: unless-stopped
+    environment:
+      - INTERFACE_TYPE=tcp
+      - MESHTASTIC_HOST=meshmonitor
+      - MESHTASTIC_PORT=4404
+      - AI_PROVIDER=ollama           # or: gemini, openai, anthropic
+      - OLLAMA_HOST=ollama           # if using Ollama
+      - ADMIN_NODE_ID=!your_admin_id # your node ID for admin commands
+      - ALLOWED_CHANNELS=0           # comma-separated channel indices
+    volumes:
+      - ai-data:/app/data
+    depends_on:
+      - meshmonitor
+
+  # Optional: Local AI with Ollama
+  ollama:
+    image: ollama/ollama:latest
+    container_name: meshmonitor-ollama
+    restart: unless-stopped
+    volumes:
+      - ollama-data:/root/.ollama
+
+volumes:
+  ai-data:
+  ollama-data:
+```
+
+### Deploy and Initialize
+
+```bash
+# Start the stack
+docker compose up -d
+
+# If using Ollama, pull a model
+docker exec -it meshmonitor-ollama ollama pull llama3.2:1b
+```
+
+## Configuration Options
+
+The AI Responder is configured via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `INTERFACE_TYPE` | `tcp` | Connection type: `tcp` or `serial` |
+| `MESHTASTIC_HOST` | `meshmonitor` | Hostname of MeshMonitor (use Docker service name) |
+| `MESHTASTIC_PORT` | `4404` | Virtual Node port |
+| `AI_PROVIDER` | `ollama` | AI provider: `ollama`, `gemini`, `openai`, or `anthropic` |
+| `OLLAMA_HOST` | `ollama` | Ollama service hostname (when using Ollama) |
+| `GEMINI_API_KEY` | - | Google Gemini API key |
+| `OPENAI_API_KEY` | - | OpenAI API key |
+| `ANTHROPIC_API_KEY` | - | Anthropic API key |
+| `ADMIN_NODE_ID` | - | Node ID with admin privileges (e.g., `!1234abcd`) |
+| `ALLOWED_CHANNELS` | `0,3` | Comma-separated list of channel indices to monitor |
+| `HISTORY_MAX_MESSAGES` | `1000` | Maximum stored messages per user |
+| `HISTORY_MAX_BYTES` | `2097152` | Maximum history file size (bytes) |
+| `CHUNK_DELAY` | `15` | Seconds between message chunks |
+| `CONNECTION_RETRY_INTERVAL` | `10` | Seconds between reconnection attempts |
+
+## Supported AI Providers
+
+| Provider | Type | Best For |
+|----------|------|----------|
+| **Ollama** | Local | Privacy-focused deployments, no internet required |
+| **Google Gemini** | Cloud | Powerful responses with optional grounding (search/maps) |
+| **OpenAI** | Cloud | GPT-powered responses |
+| **Anthropic** | Cloud | Claude-powered responses |
+
+Admins can switch providers at runtime using the `!ai -p` command.
+
+## User Commands
+
+### Basic Usage
+
+| Command | Description |
+|---------|-------------|
+| `!ai <question>` | Ask a question (required in channels, one-off in DMs) |
+| `!ai -h` | Show help menu |
+
+### Session Management (DM Only)
+
+| Command | Description |
+|---------|-------------|
+| `!ai -n [name]` | Start a continuous conversation session |
+| `!ai -end` | End the active session |
+
+Sessions allow back-and-forth conversation in DMs without repeating the `!ai` prefix. They auto-timeout after 5 minutes of inactivity.
+
+### Conversation History
+
+| Command | Description |
+|---------|-------------|
+| `!ai -c ls` | List saved conversations (max 10 slots per user) |
+| `!ai -c [name/number]` | Load a previous conversation |
+| `!ai -c rm [name/number]` | Delete a specific conversation |
+| `!ai -c rm all` | Clear all saved conversations |
+| `!ai -m` | Show context usage and storage stats |
+
+### Admin Commands
+
+| Command | Description |
+|---------|-------------|
+| `!ai -p` | List available AI providers |
+| `!ai -p [provider]` | Switch AI provider (admin only) |
+
+## Channel vs. DM Behavior
+
+| Feature | Channel | DM |
+|---------|---------|-----|
+| `!ai` prefix required | Every message | First message only (in session) |
+| Session mode | Not available | Available via `!ai -n` |
+| Conversation history | Per-channel, per-user | Per-user |
+| Slot usage | Does not count | Uses 1 of 10 slots |
+
+## Troubleshooting
+
+### Checking Logs
+
+```bash
+docker compose logs ai-responder -f
+```
+
+### Common Issues
+
+#### "Connection refused" or "Cannot connect"
+- Ensure MeshMonitor is running and Virtual Node is enabled
+- Verify `MESHTASTIC_HOST` matches your MeshMonitor service name
+- Check that `MESHTASTIC_PORT` matches your Virtual Node port (default: 4404)
+
+#### No response to `!ai` messages
+- Verify the channel index is in `ALLOWED_CHANNELS`
+- Check that the AI provider is configured correctly
+- If using Ollama, ensure a model has been pulled (`docker exec ollama ollama list`)
+
+#### Slow or truncated responses
+- LoRa messages are limited in size; responses are automatically chunked
+- Adjust `CHUNK_DELAY` if responses are being dropped
+- Cloud providers generally give faster responses than local Ollama
+
+#### Provider API errors
+- Verify your API key is correct for the selected provider
+- Check that the provider service is reachable from the container
+- Review logs for specific error messages
+
+## Related Documentation
+
+- [Virtual Node](/configuration/virtual-node) - Required for AI Responder
+- [MQTT Client Proxy](/add-ons/mqtt-proxy) - Another community add-on by LN4CY
+- [Community Add-ons Overview](/add-ons/) - All available add-ons
+- [LN4CY ai-responder Repository](https://github.com/LN4CY/ai-responder) - Full documentation and source code

--- a/docs/add-ons/index.md
+++ b/docs/add-ons/index.md
@@ -1,0 +1,68 @@
+# Community Add-ons
+
+Community add-ons are third-party sidecar containers that extend MeshMonitor's capabilities. They connect to MeshMonitor's [Virtual Node](/configuration/virtual-node) (TCP port 4404) to interact with your Meshtastic mesh network.
+
+::: warning Third-Party Projects
+These add-ons are developed and maintained by outside contributors, not the MeshMonitor team. While we've tested them and include them in our documentation, please direct bug reports and feature requests to each project's own repository.
+:::
+
+## Available Add-ons
+
+### [MQTT Client Proxy](/add-ons/mqtt-proxy)
+Route MQTT traffic through MeshMonitor instead of relying on your node's WiFi connection. Ideal for nodes with unreliable WiFi, serial/BLE-connected devices, or when you want server-grade MQTT reliability.
+
+**By [LN4CY](https://github.com/LN4CY/mqtt-proxy)**
+
+### [AI Responder](/add-ons/ai-responder)
+Transform your Meshtastic node into an AI-powered assistant. Users on the mesh can ask questions, have conversations, and get intelligent responses through multiple AI providers (Ollama, Gemini, OpenAI, Anthropic).
+
+**By [LN4CY](https://github.com/LN4CY/ai-responder)**
+
+## How Add-ons Work
+
+All community add-ons connect to MeshMonitor through the Virtual Node server:
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   Your Server                       │
+│                                                     │
+│  ┌────────────────┐     ┌────────────────────────┐  │
+│  │  MeshMonitor   │◄───►│  MQTT Proxy            │  │
+│  │                │     │  (sidecar)             │  │
+│  │  Virtual Node  │     └────────────────────────┘  │
+│  │  (port 4404)   │                                 │
+│  │                │     ┌────────────────────────┐  │
+│  │                │◄───►│  AI Responder          │  │
+│  │                │     │  (sidecar)             │  │
+│  └───────┬────────┘     └────────────────────────┘  │
+│          │                                          │
+└──────────┼──────────────────────────────────────────┘
+           │ TCP (port 4403)
+           ▼
+   ┌───────────────┐
+   │  Meshtastic   │
+   │    Node       │
+   └───────────────┘
+```
+
+### Prerequisites
+
+All add-ons require:
+1. **Virtual Node enabled** in MeshMonitor (`ENABLE_VIRTUAL_NODE=true`)
+2. **Virtual Node port exposed** (default: 4404)
+3. **Docker networking** so sidecar containers can reach MeshMonitor
+
+### Deploying Add-ons
+
+The easiest way to deploy add-ons is with the [Docker Compose Configurator](/configurator), which can generate the appropriate configuration. You can also add them manually to your existing `docker-compose.yml`.
+
+## Building Your Own Add-on
+
+If you're interested in building a sidecar that integrates with MeshMonitor:
+
+1. **Connect via TCP** to the Virtual Node port (default 4404)
+2. **Use the Meshtastic protobuf protocol** — the same protocol used by official Meshtastic mobile apps
+3. **Libraries**: Use the official [meshtastic Python library](https://github.com/meshtastic/python) or any client that speaks the Meshtastic TCP protocol
+4. **Reference**: See the [official protobuf definitions](https://github.com/meshtastic/protobufs/) for message formats
+
+Want your add-on listed here? Open a [discussion on GitHub](https://github.com/yeraze/meshmonitor/discussions)!

--- a/docs/add-ons/mqtt-proxy.md
+++ b/docs/add-ons/mqtt-proxy.md
@@ -3,7 +3,7 @@
 The MQTT Client Proxy is an optional sidecar container that enables reliable MQTT connectivity for MeshMonitor deployments. It routes MQTT traffic through MeshMonitor instead of relying on your Meshtastic node's WiFi connection.
 
 ::: tip Credit
-The MQTT Proxy was created by [LN4CY](https://github.com/LN4CY/mqtt-proxy). MeshMonitor integrates it as an optional Docker sidecar.
+The MQTT Proxy was created by [LN4CY](https://github.com/LN4CY/mqtt-proxy). MeshMonitor integrates it as an optional Docker sidecar. See also: [AI Responder](/add-ons/ai-responder), another add-on by the same author.
 :::
 
 ## Overview
@@ -214,6 +214,8 @@ The proxy writes a health file at `/tmp/healthy` that Docker uses for health che
 - [Virtual Node](/configuration/virtual-node) - Required for MQTT Proxy
 - [Device Configuration](/features/device#mqtt-configuration) - Node MQTT settings
 - [Docker Configurator](/configurator) - Generate deployment configs
+- [AI Responder](/add-ons/ai-responder) - Another community add-on by LN4CY
+- [Community Add-ons Overview](/add-ons/) - All available add-ons
 - [LN4CY mqtt-proxy Repository](https://github.com/LN4CY/mqtt-proxy) - Original project
 
 ## License Note

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -259,6 +259,10 @@ MeshMonitor logs to stdout/stderr by default. Configure log aggregation in your 
 - **Kubernetes**: Logs are available via `kubectl logs`
 - **Bare Metal**: Redirect output to log files or use a process manager like systemd
 
+## Community Add-ons
+
+Looking for the MQTT Client Proxy, AI Responder, or other sidecar containers? These have moved to the [Community Add-ons](/add-ons/) section.
+
 ## Next Steps
 
 - [Connect Serial/USB devices](/configuration/serial-bridge)
@@ -267,3 +271,4 @@ MeshMonitor logs to stdout/stderr by default. Configure log aggregation in your 
 - [Set up SSO](/configuration/sso)
 - [Configure a reverse proxy](/configuration/reverse-proxy)
 - [Deploy to production](/configuration/production)
+- [Browse community add-ons](/add-ons/)

--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -9,7 +9,7 @@ If you encounter any issues with your configuration:
 - **Connection issues**: See our [troubleshooting guides](/getting-started#troubleshooting)
 - **BLE setup**: Check the [BLE Bridge documentation](/configuration/ble-bridge)
 - **Serial/USB setup**: Check the [Serial Bridge documentation](/configuration/serial-bridge)
-- **MQTT Proxy setup**: Check the [MQTT Client Proxy documentation](/configuration/mqtt-proxy)
+- **MQTT Proxy setup**: Check the [MQTT Client Proxy documentation](/add-ons/mqtt-proxy)
 - **Production deployment**: Review the [Production Deployment guide](/configuration/production)
 - **Reverse proxy**: See [Reverse Proxy Configuration](/configuration/reverse-proxy)
 
@@ -47,7 +47,7 @@ After deploying with the generated configuration:
 - **Automatic Self-Upgrade**: Enable one-click upgrades through the web UI with the upgrade watchdog sidecar.
 - **Offline Map Tiles**: Add TileServer GL for serving offline map tiles when internet connectivity is limited.
 - **Auto Responder Scripts**: Mount a scripts directory for custom automation scripts.
-- **MQTT Client Proxy**: Route MQTT traffic through MeshMonitor instead of your node's WiFi. Useful for nodes with unreliable connectivity or when using Serial/BLE connections. See [MQTT Client Proxy documentation](/configuration/mqtt-proxy).
+- **MQTT Client Proxy**: Route MQTT traffic through MeshMonitor instead of your node's WiFi. Useful for nodes with unreliable connectivity or when using Serial/BLE connections. See [MQTT Client Proxy documentation](/add-ons/mqtt-proxy).
 
 ## Advanced Topics
 
@@ -58,4 +58,4 @@ For more complex deployments, check out these resources:
 - [SSO/OIDC Authentication](/configuration/sso)
 - [Custom SSL Certificates](/configuration/reverse-proxy)
 - [Database Optimization](/configuration/production#database-optimization)
-- [MQTT Client Proxy](/configuration/mqtt-proxy) - Reliable MQTT for nodes with unreliable WiFi
+- [MQTT Client Proxy](/add-ons/mqtt-proxy) - Reliable MQTT for nodes with unreliable WiFi

--- a/docs/features/device.md
+++ b/docs/features/device.md
@@ -1122,7 +1122,7 @@ Configure network settings including WiFi, NTP, and static IP addresses.
 - More reliable connectivity via Docker containers with health checks
 
 ::: tip MeshMonitor Integration
-When using MeshMonitor, enable this option and deploy the [MQTT Client Proxy sidecar](/configuration/mqtt-proxy). The proxy container handles all MQTT forwarding automatically.
+When using MeshMonitor, enable this option and deploy the [MQTT Client Proxy sidecar](/add-ons/mqtt-proxy). The proxy container handles all MQTT forwarding automatically.
 
 Credit: MQTT Proxy by [LN4CY](https://github.com/LN4CY/mqtt-proxy)
 :::


### PR DESCRIPTION
## Summary
- Creates a new **Community Add-ons** documentation section (`/add-ons/`) for third-party sidecar containers
- Moves MQTT Client Proxy docs from `/configuration/mqtt-proxy` to `/add-ons/mqtt-proxy`
- Adds new **AI Responder** documentation page with setup, configuration, commands, and troubleshooting
- Updates VitePress nav/sidebar and all cross-references across the docs

## Changes
- **New**: `docs/add-ons/index.md` — Add-ons landing page with overview, architecture diagram, and developer guidelines
- **New**: `docs/add-ons/ai-responder.md` — AI Responder docs (Docker setup, config table, user commands, troubleshooting)
- **Moved**: `docs/configuration/mqtt-proxy.md` → `docs/add-ons/mqtt-proxy.md`
- **Updated**: `docs/.vitepress/config.mts` — Added "Add-ons" to nav dropdown and new sidebar section
- **Updated**: `docs/.vitepress/theme/DockerComposeConfigurator.vue`, `docs/configurator.md`, `docs/features/device.md`, `docs/configuration/index.md` — Updated all mqtt-proxy cross-references

Closes #1984

## Test plan
- [x] All 117 test files pass (2546 tests)
- [ ] Verify VitePress dev server renders the new add-ons sidebar section
- [ ] Verify all three add-on pages render correctly (overview, mqtt-proxy, ai-responder)
- [ ] Verify no broken internal links (old `/configuration/mqtt-proxy` paths are all updated)
- [ ] Verify Docker Compose Configurator "Learn more" link points to `/add-ons/mqtt-proxy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)