### PR TITLE
feat: add HAM Licensed checkbox to Node Identity

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2625,6 +2625,8 @@
   "node_identity.short_name_placeholder": "MESH",
   "node_identity.unmessageable": "Unmessageable",
   "node_identity.unmessageable_description": "Prevent others from sending direct messages to this node",
+  "node_identity.is_licensed": "Licensed (HAM)",
+  "node_identity.is_licensed_description": "Mark this node as a licensed amateur radio (HAM) operator. Long name should be set to your license number.",
   "node_identity.save_button": "Save Node Names",
 
   "neighbor_info.title": "Neighbor Info Module",
@@ -3216,6 +3218,8 @@
   "admin_commands.short_name_placeholder": "Device owner short name (max 4 chars)",
   "admin_commands.mark_unmessagable": "Mark as Unmessagable",
   "admin_commands.mark_unmessagable_description": "Prevent other nodes from sending messages to this device",
+  "admin_commands.mark_licensed": "Licensed (HAM)",
+  "admin_commands.mark_licensed_description": "Mark as a licensed amateur radio operator. Long name should be the license number.",
   "admin_commands.set_owner_button": "Set Owner",
 
   "admin_commands.radio_configuration": "Radio Configuration",

--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -440,7 +440,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             setOwnerConfig({
               longName: owner.longName,
               shortName: owner.shortName,
-              isUnmessagable: owner.isUnmessagable
+              isUnmessagable: owner.isUnmessagable,
+              isLicensed: owner.isLicensed
             });
             loaded.push('owner');
             setSectionLoadStatus(prev => ({ ...prev, owner: 'success' }));
@@ -953,7 +954,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
               setOwnerConfig({
                 longName: result.owner.longName,
                 shortName: result.owner.shortName,
-                isUnmessagable: result.owner.isUnmessagable
+                isUnmessagable: result.owner.isUnmessagable,
+                isLicensed: result.owner.isLicensed
               });
               setSectionLoadStatus(prev => ({ ...prev, owner: 'success' }));
               showToast(t('admin_commands.config_loaded_success', { configType: t('admin_commands.owner_config_short', 'Owner') }), 'success');
@@ -1405,7 +1407,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       await executeCommand('setOwner', {
         longName: configState.owner.longName.trim(),
         shortName: configState.owner.shortName.trim(),
-        isUnmessagable: configState.owner.isUnmessagable
+        isUnmessagable: configState.owner.isUnmessagable,
+        isLicensed: configState.owner.isLicensed
       });
     } catch (error) {
       // Error already handled by executeCommand (toast shown)
@@ -3020,6 +3023,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
         ownerLongName={configState.owner.longName}
         ownerShortName={configState.owner.shortName}
         ownerIsUnmessagable={configState.owner.isUnmessagable}
+        ownerIsLicensed={configState.owner.isLicensed}
         onOwnerConfigChange={handleOwnerConfigChange}
         onSaveOwnerConfig={handleSetOwner}
         deviceRole={configState.device.role}

--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -56,6 +56,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
   const [longName, setLongName] = useState('');
   const [shortName, setShortName] = useState('');
   const [isUnmessagable, setIsUnmessagable] = useState(false);
+  const [isLicensed, setIsLicensed] = useState(false);
   const [role, setRole] = useState<number>(0);
   const [nodeInfoBroadcastSecs, setNodeInfoBroadcastSecs] = useState(3600);
   const [tzdef, setTzdef] = useState('');
@@ -318,6 +319,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
           setLongName(config.localNodeInfo.longName || '');
           setShortName(config.localNodeInfo.shortName || '');
           setIsUnmessagable(config.localNodeInfo.isUnmessagable || false);
+          setIsLicensed(config.localNodeInfo.isLicensed || false);
         }
 
         // Populate device config
@@ -803,7 +805,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
     setIsSaving(true);
     setStatusMessage('');
     try {
-      await apiService.setNodeOwner(longName, shortName, isUnmessagable);
+      await apiService.setNodeOwner(longName, shortName, isUnmessagable, isLicensed);
       setStatusMessage(t('config.node_names_saved'));
       showToast(t('config.node_names_saved_toast'), 'success');
       // Node owner changes don't require reboot
@@ -1768,6 +1770,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
         if (config.localNodeInfo.longName !== undefined) setLongName(config.localNodeInfo.longName);
         if (config.localNodeInfo.shortName !== undefined) setShortName(config.localNodeInfo.shortName);
         if (config.localNodeInfo.isUnmessagable !== undefined) setIsUnmessagable(config.localNodeInfo.isUnmessagable);
+        if (config.localNodeInfo.isLicensed !== undefined) setIsLicensed(config.localNodeInfo.isLicensed);
       }
 
       setConfigChanges(changes);
@@ -2019,9 +2022,11 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
             longName={longName}
             shortName={shortName}
             isUnmessagable={isUnmessagable}
+            isLicensed={isLicensed}
             setLongName={setLongName}
             setShortName={setShortName}
             setIsUnmessagable={setIsUnmessagable}
+            setIsLicensed={setIsLicensed}
             isSaving={isSaving}
             onSave={handleSaveNodeOwner}
           />

--- a/src/components/admin-commands/DeviceConfigurationSection.tsx
+++ b/src/components/admin-commands/DeviceConfigurationSection.tsx
@@ -18,6 +18,7 @@ interface DeviceConfigurationSectionProps {
   ownerLongName: string;
   ownerShortName: string;
   ownerIsUnmessagable: boolean;
+  ownerIsLicensed: boolean;
   onOwnerConfigChange: (field: string, value: any) => void;
   onSaveOwnerConfig: () => Promise<void>;
 
@@ -95,6 +96,7 @@ export const DeviceConfigurationSection: React.FC<DeviceConfigurationSectionProp
   ownerLongName,
   ownerShortName,
   ownerIsUnmessagable,
+  ownerIsLicensed,
   onOwnerConfigChange,
   onSaveOwnerConfig,
   deviceRole,
@@ -214,6 +216,21 @@ export const DeviceConfigurationSection: React.FC<DeviceConfigurationSectionProp
             <div style={{ flex: 1 }}>
               <div>{t('admin_commands.mark_unmessagable')}</div>
               <span className="setting-description">{t('admin_commands.mark_unmessagable_description')}</span>
+            </div>
+          </label>
+        </div>
+        <div className="setting-item">
+          <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+            <input
+              type="checkbox"
+              checked={ownerIsLicensed}
+              onChange={(e) => onOwnerConfigChange('isLicensed', e.target.checked)}
+              disabled={isExecuting}
+              style={{ width: 'auto', margin: 0, flexShrink: 0 }}
+            />
+            <div style={{ flex: 1 }}>
+              <div>{t('admin_commands.mark_licensed')}</div>
+              <span className="setting-description">{t('admin_commands.mark_licensed_description')}</span>
             </div>
           </label>
         </div>

--- a/src/components/admin-commands/useAdminCommandsState.ts
+++ b/src/components/admin-commands/useAdminCommandsState.ts
@@ -108,6 +108,7 @@ export interface OwnerConfigState {
   longName: string;
   shortName: string;
   isUnmessagable: boolean;
+  isLicensed: boolean;
 }
 
 // Device Config State
@@ -281,6 +282,7 @@ const initialState: AdminCommandsState = {
     longName: '',
     shortName: '',
     isUnmessagable: false,
+    isLicensed: false,
   },
   device: {
     role: 0,

--- a/src/components/configuration/NodeIdentitySection.tsx
+++ b/src/components/configuration/NodeIdentitySection.tsx
@@ -6,9 +6,11 @@ interface NodeIdentitySectionProps {
   longName: string;
   shortName: string;
   isUnmessagable: boolean;
+  isLicensed: boolean;
   setLongName: (value: string) => void;
   setShortName: (value: string) => void;
   setIsUnmessagable: (value: boolean) => void;
+  setIsLicensed: (value: boolean) => void;
   isSaving: boolean;
   onSave: () => Promise<void>;
 }
@@ -17,9 +19,11 @@ const NodeIdentitySection: React.FC<NodeIdentitySectionProps> = ({
   longName,
   shortName,
   isUnmessagable,
+  isLicensed,
   setLongName,
   setShortName,
   setIsUnmessagable,
+  setIsLicensed,
   isSaving,
   onSave
 }) => {
@@ -27,7 +31,7 @@ const NodeIdentitySection: React.FC<NodeIdentitySectionProps> = ({
 
   // Track initial values for change detection
   const initialValuesRef = useRef({
-    longName, shortName, isUnmessagable
+    longName, shortName, isUnmessagable, isLicensed
   });
 
   // Calculate if there are unsaved changes
@@ -36,9 +40,10 @@ const NodeIdentitySection: React.FC<NodeIdentitySectionProps> = ({
     return (
       longName !== initial.longName ||
       shortName !== initial.shortName ||
-      isUnmessagable !== initial.isUnmessagable
+      isUnmessagable !== initial.isUnmessagable ||
+      isLicensed !== initial.isLicensed
     );
-  }, [longName, shortName, isUnmessagable]);
+  }, [longName, shortName, isUnmessagable, isLicensed]);
 
   // Reset to initial values (for SaveBar dismiss)
   const resetChanges = useCallback(() => {
@@ -46,15 +51,16 @@ const NodeIdentitySection: React.FC<NodeIdentitySectionProps> = ({
     setLongName(initial.longName);
     setShortName(initial.shortName);
     setIsUnmessagable(initial.isUnmessagable);
-  }, [setLongName, setShortName, setIsUnmessagable]);
+    setIsLicensed(initial.isLicensed);
+  }, [setLongName, setShortName, setIsUnmessagable, setIsLicensed]);
 
   // Update initial values after successful save
   const handleSave = useCallback(async () => {
     await onSave();
     initialValuesRef.current = {
-      longName, shortName, isUnmessagable
+      longName, shortName, isUnmessagable, isLicensed
     };
-  }, [onSave, longName, shortName, isUnmessagable]);
+  }, [onSave, longName, shortName, isUnmessagable, isLicensed]);
 
   // Register with SaveBar
   useSaveBar({
@@ -126,6 +132,21 @@ const NodeIdentitySection: React.FC<NodeIdentitySectionProps> = ({
           <div style={{ flex: 1 }}>
             <div>{t('node_identity.unmessageable')}</div>
             <span className="setting-description">{t('node_identity.unmessageable_description')}</span>
+          </div>
+        </label>
+      </div>
+      <div className="setting-item">
+        <label htmlFor="isLicensed" style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+          <input
+            id="isLicensed"
+            type="checkbox"
+            checked={isLicensed}
+            onChange={(e) => setIsLicensed(e.target.checked)}
+            style={{ marginTop: '0.2rem', flexShrink: 0 }}
+          />
+          <div style={{ flex: 1 }}>
+            <div>{t('node_identity.is_licensed')}</div>
+            <span className="setting-description">{t('node_identity.is_licensed_description')}</span>
           </div>
         </label>
       </div>

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -10985,14 +10985,14 @@ class MeshtasticManager {
   /**
    * Set node owner (long name and short name)
    */
-  async setNodeOwner(longName: string, shortName: string, isUnmessagable?: boolean): Promise<void> {
+  async setNodeOwner(longName: string, shortName: string, isUnmessagable?: boolean, isLicensed?: boolean): Promise<void> {
     if (!this.isConnected || !this.transport) {
       throw new Error('Not connected to Meshtastic node');
     }
 
     try {
-      logger.debug(`⚙️ Setting node owner: "${longName}" (${shortName}), isUnmessagable: ${isUnmessagable}`);
-      const setOwnerMsg = protobufService.createSetOwnerMessage(longName, shortName, isUnmessagable, new Uint8Array());
+      logger.debug(`⚙️ Setting node owner: "${longName}" (${shortName}), isUnmessagable: ${isUnmessagable}, isLicensed: ${isLicensed}`);
+      const setOwnerMsg = protobufService.createSetOwnerMessage(longName, shortName, isUnmessagable, new Uint8Array(), isLicensed);
       const adminPacket = protobufService.createAdminPacket(setOwnerMsg, this.localNodeInfo?.nodeNum || 0, this.localNodeInfo?.nodeNum);
 
       await this.transport.send(adminPacket);

--- a/src/server/protobufService.ts
+++ b/src/server/protobufService.ts
@@ -1687,7 +1687,7 @@ class ProtobufService {
    * @param isUnmessagable Optional flag to prevent others from sending direct messages
    * @param sessionPasskey Optional session passkey for authentication
    */
-  createSetOwnerMessage(longName: string, shortName: string, isUnmessagable?: boolean, sessionPasskey?: Uint8Array): Uint8Array {
+  createSetOwnerMessage(longName: string, shortName: string, isUnmessagable?: boolean, sessionPasskey?: Uint8Array, isLicensed?: boolean): Uint8Array {
     try {
       const root = getProtobufRoot();
       const AdminMessage = root?.lookupType('meshtastic.AdminMessage');
@@ -1699,7 +1699,8 @@ class ProtobufService {
       const userMsg = User.create({
         longName: longName,
         shortName: shortName,
-        isUnmessagable: isUnmessagable
+        isUnmessagable: isUnmessagable,
+        isLicensed: isLicensed
       });
 
       const adminMsgData: any = {
@@ -1714,7 +1715,7 @@ class ProtobufService {
       const adminMsg = AdminMessage.create(adminMsgData);
 
       const encoded = AdminMessage.encode(adminMsg).finish();
-      logger.debug(`⚙️ Created SetOwner admin message: "${longName}" (${shortName}), isUnmessagable: ${isUnmessagable}`);
+      logger.debug(`⚙️ Created SetOwner admin message: "${longName}" (${shortName}), isUnmessagable: ${isUnmessagable}, isLicensed: ${isLicensed}`);
       return encoded;
     } catch (error) {
       logger.error('Failed to create SetOwner message:', error);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6029,12 +6029,12 @@ apiRouter.post('/config/module/:moduleType', requirePermission('configuration', 
 
 apiRouter.post('/config/owner', requirePermission('configuration', 'write'), async (req, res) => {
   try {
-    const { longName, shortName, isUnmessagable } = req.body;
+    const { longName, shortName, isUnmessagable, isLicensed } = req.body;
     if (!longName || !shortName) {
       res.status(400).json({ error: 'longName and shortName are required' });
       return;
     }
-    await meshtasticManager.setNodeOwner(longName, shortName, isUnmessagable);
+    await meshtasticManager.setNodeOwner(longName, shortName, isUnmessagable, isLicensed);
     res.json({ success: true, message: 'Node owner updated' });
   } catch (error) {
     logger.error('Error setting node owner:', error);
@@ -6767,6 +6767,7 @@ apiRouter.post('/admin/load-owner', requireAdmin(), async (req, res) => {
           longName: localNodeInfo.longName || '' ,
           shortName: localNodeInfo.shortName || '' ,
           isUnmessagable: false,
+          isLicensed: false,
           publicKey: publicKeyBase64
         }});
       } else {
@@ -6779,7 +6780,8 @@ apiRouter.post('/admin/load-owner', requireAdmin(), async (req, res) => {
         return res.json({ owner: {
           longName: owner.longName || '' ,
           shortName: owner.shortName || '' ,
-          isUnmessagable: owner.isUnmessagable || false
+          isUnmessagable: owner.isUnmessagable || false,
+          isLicensed: owner.isLicensed || false
         }});
       } else {
         return res.status(404).json({ error: `Owner info not received from remote node ${destinationNodeNum}` });
@@ -7220,7 +7222,8 @@ apiRouter.post('/admin/commands', requireAdmin(), async (req, res) => {
           params.longName,
           params.shortName,
           params.isUnmessagable,
-          sessionPasskey || undefined
+          sessionPasskey || undefined,
+          params.isLicensed
         );
         break;
       case 'setChannel':

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -978,13 +978,13 @@ class ApiService {
     return response.json();
   }
 
-  async setNodeOwner(longName: string, shortName: string, isUnmessagable?: boolean) {
+  async setNodeOwner(longName: string, shortName: string, isUnmessagable?: boolean, isLicensed?: boolean) {
     await this.ensureBaseUrl();
     const response = await fetch(`${this.baseUrl}/api/config/owner`, {
       method: 'POST',
       headers: this.getHeadersWithCsrf(),
       credentials: 'include',
-      body: JSON.stringify({ longName, shortName, isUnmessagable }),
+      body: JSON.stringify({ longName, shortName, isUnmessagable, isLicensed }),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- Adds a "Licensed (HAM)" checkbox to both the **Configuration > Node Identity** section (local node) and the **Admin Commands > Device Configuration > Set Owner** section (remote nodes)
- Threads the Meshtastic `User` protobuf `is_licensed` field through the full stack, following the identical pattern as `isUnmessagable`
- Allows users to set/clear the HAM radio licensed flag, which affects node behavior on the mesh (e.g., long_name should be their license number)

Closes #1998

## Files Changed (10)
- **Backend**: `protobufService.ts`, `meshtasticManager.ts`, `server.ts` — add `isLicensed` parameter through the owner message creation chain
- **API**: `api.ts` — include `isLicensed` in `setNodeOwner()` request body
- **State**: `useAdminCommandsState.ts` — add `isLicensed` to `OwnerConfigState` interface and default state
- **UI**: `AdminCommandsTab.tsx`, `DeviceConfigurationSection.tsx`, `ConfigurationTab.tsx`, `NodeIdentitySection.tsx` — wire up the checkbox in both UI paths
- **i18n**: `en.json` — add translation keys for both Configuration and Admin Commands sections

## Test plan
- [x] `npx vitest run` — all 2546 tests pass (117 test files)
- [ ] **Local node (Configuration tab)**: Navigate to Configuration > Node Identity, verify HAM checkbox appears, toggle it, save, reload — should persist
- [ ] **Remote node (Admin Commands tab)**: Navigate to Admin Commands > Device Configuration > Set Owner, verify HAM checkbox appears, load config from remote node — should show current value, toggle and save — should persist

## System Tests
System tests fail on a pre-existing LoRa modem preset mismatch (`Expected: Long Fast, Actual: Medium Fast`) unrelated to this PR. This is a device configuration state issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)