### PR TITLE
feat: add homoglyph message optimization setting

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1348,6 +1348,8 @@
   "settings.packet_monitor_description": "Configure the mesh traffic monitor that displays all packets on the network. Requires both channels:read and messages:read permissions.",
   "settings.enable_audio_notifications": "Enable Audio Notifications",
   "settings.enable_audio_notifications_description": "Play a sound when new messages arrive. Disable this if you experience audio issues in your browser.",
+  "settings.homoglyph_enabled": "Homoglyph Message Optimization",
+  "settings.homoglyph_description": "Replace visually identical non-Latin characters (e.g. Cyrillic A\u2192A, C\u2192C) with Latin equivalents to reduce message size by ~20%. Does not affect message appearance.",
   "settings.hide_incomplete_nodes": "Hide Incomplete Nodes",
   "settings.hide_incomplete_description": "Hide nodes missing name or hardware info. On secure channels (custom PSK), incomplete nodes haven't been verified as being on your channel.",
   "settings.node_dimming_enabled": "Dim Inactive Nodes on Map",

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -177,6 +177,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   // Note: localHideIncompleteNodes is inverted from showIncompleteNodes because
   // the UI checkbox says "Hide" while the context uses "show" semantics
   const [localHideIncompleteNodes, setLocalHideIncompleteNodes] = useState(!showIncompleteNodes);
+  const [localHomoglyphEnabled, setLocalHomoglyphEnabled] = useState(false);
   const [isFetchingSolarEstimates, setIsFetchingSolarEstimates] = useState(false);
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -243,6 +244,11 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           // Load hide incomplete nodes setting
           setLocalHideIncompleteNodes(hideIncomplete);
           setShowIncompleteNodes(!hideIncomplete);
+
+          // Load homoglyph optimization setting
+          const homoglyphOn = settings.homoglyphEnabled === 'true';
+          setLocalHomoglyphEnabled(homoglyphOn);
+          setInitialHomoglyphEnabled(homoglyphOn);
         }
       } catch (error) {
         logger.error('Failed to fetch server settings:', error);
@@ -295,6 +301,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   // Note: We can't compare packet monitor settings to props since they're not in props
   // Instead, we'll track initial packet monitor values separately
   const [initialPacketMonitorSettings, setInitialPacketMonitorSettings] = useState({ enabled: false, maxCount: 1000, maxAgeHours: 24 });
+  const [initialHomoglyphEnabled, setInitialHomoglyphEnabled] = useState(false);
 
   useEffect(() => {
     const changed =
@@ -324,14 +331,15 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localSolarMonitoringLongitude !== solarMonitoringLongitude ||
       localSolarMonitoringAzimuth !== solarMonitoringAzimuth ||
       localSolarMonitoringDeclination !== solarMonitoringDeclination ||
-      localHideIncompleteNodes !== !showIncompleteNodes;
+      localHideIncompleteNodes !== !showIncompleteNodes ||
+      localHomoglyphEnabled !== initialHomoglyphEnabled;
     setHasChanges(changed);
   }, [localMaxNodeAge, localInactiveNodeThresholdHours, localInactiveNodeCheckIntervalMinutes, localInactiveNodeCooldownHours, localTemperatureUnit, localDistanceUnit, localPositionHistoryLineStyle, localTelemetryHours, localFavoriteTelemetryStorageDays, localPreferredSortField, localPreferredSortDirection, localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localTheme, localNodeHopsCalculation, localDashboardSortOption,
       maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTileset, mapPinStyle, theme, nodeHopsCalculation, preferredDashboardSortOption,
       localPacketLogEnabled, localPacketLogMaxCount, localPacketLogMaxAgeHours, initialPacketMonitorSettings,
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude, localSolarMonitoringAzimuth, localSolarMonitoringDeclination,
       solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination,
-      localHideIncompleteNodes, showIncompleteNodes]);
+      localHideIncompleteNodes, showIncompleteNodes, localHomoglyphEnabled, initialHomoglyphEnabled]);
 
   // Reset local state to current saved values (for SaveBar dismiss)
   const resetChanges = useCallback(() => {
@@ -362,12 +370,14 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalSolarMonitoringAzimuth(solarMonitoringAzimuth);
     setLocalSolarMonitoringDeclination(solarMonitoringDeclination);
     setLocalHideIncompleteNodes(!showIncompleteNodes);
+    setLocalHomoglyphEnabled(initialHomoglyphEnabled);
   }, [maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes,
       inactiveNodeCooldownHours, temperatureUnit, distanceUnit, telemetryVisualizationHours,
       favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat,
       dateFormat, mapTileset, mapPinStyle, theme, nodeHopsCalculation, preferredDashboardSortOption,
       initialPacketMonitorSettings, solarMonitoringEnabled, solarMonitoringLatitude,
-      solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes]);
+      solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes,
+      initialHomoglyphEnabled]);
 
   const handleSave = useCallback(async () => {
     setIsSaving(true);
@@ -397,7 +407,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         solarMonitoringLongitude: localSolarMonitoringLongitude.toString(),
         solarMonitoringAzimuth: localSolarMonitoringAzimuth.toString(),
         solarMonitoringDeclination: localSolarMonitoringDeclination.toString(),
-        hideIncompleteNodes: localHideIncompleteNodes ? '1' : '0'
+        hideIncompleteNodes: localHideIncompleteNodes ? '1' : '0',
+        homoglyphEnabled: String(localHomoglyphEnabled)
       };
 
       // Save to server
@@ -435,6 +446,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
 
       // Update initial packet monitor settings after successful save
       setInitialPacketMonitorSettings({ enabled: localPacketLogEnabled, maxCount: localPacketLogMaxCount, maxAgeHours: localPacketLogMaxAgeHours });
+      setInitialHomoglyphEnabled(localHomoglyphEnabled);
 
       showToast(t('settings.saved_success'), 'success');
       setHasChanges(false);
@@ -451,7 +463,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localTheme,
       localNodeHopsCalculation, localDashboardSortOption, localPacketLogEnabled, localPacketLogMaxCount, localPacketLogMaxAgeHours,
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude,
-      localSolarMonitoringAzimuth, localSolarMonitoringDeclination, localHideIncompleteNodes,
+      localSolarMonitoringAzimuth, localSolarMonitoringDeclination, localHideIncompleteNodes, localHomoglyphEnabled,
       onMaxNodeAgeChange, onInactiveNodeThresholdHoursChange, onInactiveNodeCheckIntervalMinutesChange,
       onInactiveNodeCooldownHoursChange, onTemperatureUnitChange, onDistanceUnitChange, onPositionHistoryLineStyleChange,
       onTelemetryVisualizationChange, onFavoriteTelemetryStorageDaysChange, onPreferredSortFieldChange,
@@ -1177,6 +1189,23 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           </h3>
           <p className="setting-description">
             {t('settings.enable_audio_notifications_description')}
+          </p>
+        </div>
+
+        <div className="settings-section">
+          <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: 0, cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={localHomoglyphEnabled}
+                onChange={(e) => setLocalHomoglyphEnabled(e.target.checked)}
+                style={{ cursor: 'pointer' }}
+              />
+              <span>{t('settings.homoglyph_enabled')}</span>
+            </label>
+          </h3>
+          <p className="setting-description">
+            {t('settings.homoglyph_description')}
           </p>
         </div>
 

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -18,6 +18,7 @@ import { messageQueueService } from './messageQueueService.js';
 import { normalizeTriggerPatterns } from '../utils/autoResponderUtils.js';
 import { isWithinTimeWindow } from './utils/timeWindow.js';
 import { isNodeComplete } from '../utils/nodeHelpers.js';
+import { applyHomoglyphOptimization } from '../utils/homoglyph.js';
 import { PortNum, RoutingError, isPkiError, getRoutingErrorName, CHANNEL_DB_OFFSET, TransportMechanism, MIN_TRACEROUTE_INTERVAL_MS } from './constants/meshtastic.js';
 import { createRequire } from 'module';
 import * as cron from 'node-cron';
@@ -6845,6 +6846,11 @@ class MeshtasticManager {
     }
 
     try {
+      // Apply homoglyph optimization if enabled (replace Cyrillic look-alikes with Latin to save bytes)
+      if (databaseService.getSetting('homoglyphEnabled') === 'true') {
+        text = applyHomoglyphOptimization(text);
+      }
+
       // Use the new protobuf service to create a proper text message
       // Note: PKI encryption is handled automatically by the firmware if it has the recipient's public key
       const { data: textMessageData, messageId } = meshtasticProtobufService.createTextMessage(text, destination, channel, replyId, emoji);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4984,6 +4984,7 @@ apiRouter.post('/settings', requirePermission('settings', 'write'), (req, res) =
       'autoPingIntervalSeconds',
       'autoPingMaxPings',
       'autoPingTimeoutSeconds',
+      'homoglyphEnabled',
     ];
     const filteredSettings: Record<string, string> = {};
 

--- a/src/utils/homoglyph.test.ts
+++ b/src/utils/homoglyph.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { applyHomoglyphOptimization } from './homoglyph';
+
+describe('applyHomoglyphOptimization', () => {
+  it('should replace Cyrillic uppercase homoglyphs with Latin equivalents', () => {
+    // Cyrillic А, В, Е, К, М, Н, О, Р, С, Т, Х
+    expect(applyHomoglyphOptimization('\u0410\u0412\u0415\u041A\u041C\u041D\u041E\u0420\u0421\u0422\u0425')).toBe('ABEKMHOPCТX'.replace('Т', 'T'));
+    // More precisely:
+    expect(applyHomoglyphOptimization('\u0410')).toBe('A');
+    expect(applyHomoglyphOptimization('\u0412')).toBe('B');
+    expect(applyHomoglyphOptimization('\u0415')).toBe('E');
+    expect(applyHomoglyphOptimization('\u041A')).toBe('K');
+    expect(applyHomoglyphOptimization('\u041C')).toBe('M');
+    expect(applyHomoglyphOptimization('\u041D')).toBe('H');
+    expect(applyHomoglyphOptimization('\u041E')).toBe('O');
+    expect(applyHomoglyphOptimization('\u0420')).toBe('P');
+    expect(applyHomoglyphOptimization('\u0421')).toBe('C');
+    expect(applyHomoglyphOptimization('\u0422')).toBe('T');
+    expect(applyHomoglyphOptimization('\u0425')).toBe('X');
+  });
+
+  it('should replace Cyrillic lowercase homoglyphs with Latin equivalents', () => {
+    expect(applyHomoglyphOptimization('\u0430')).toBe('a');
+    expect(applyHomoglyphOptimization('\u0435')).toBe('e');
+    expect(applyHomoglyphOptimization('\u043E')).toBe('o');
+    expect(applyHomoglyphOptimization('\u0440')).toBe('p');
+    expect(applyHomoglyphOptimization('\u0441')).toBe('c');
+    expect(applyHomoglyphOptimization('\u0443')).toBe('y');
+    expect(applyHomoglyphOptimization('\u0445')).toBe('x');
+  });
+
+  it('should replace extended Cyrillic homoglyphs', () => {
+    expect(applyHomoglyphOptimization('\u0405')).toBe('S'); // Ѕ
+    expect(applyHomoglyphOptimization('\u0406')).toBe('I'); // І
+    expect(applyHomoglyphOptimization('\u0408')).toBe('J'); // Ј
+    expect(applyHomoglyphOptimization('\u04AE')).toBe('Y'); // Ү
+    expect(applyHomoglyphOptimization('\u0417')).toBe('3'); // З
+    expect(applyHomoglyphOptimization('\u0455')).toBe('s'); // ѕ
+    expect(applyHomoglyphOptimization('\u0456')).toBe('i'); // і
+    expect(applyHomoglyphOptimization('\u0458')).toBe('j'); // ј
+  });
+
+  it('should not modify Latin characters', () => {
+    expect(applyHomoglyphOptimization('Hello World')).toBe('Hello World');
+  });
+
+  it('should not modify non-homoglyph Cyrillic characters', () => {
+    // Б, Г, Д, Ж, Л, Ф, Ц, Ч, Ш, Щ — these have no Latin look-alikes
+    const nonHomoglyphs = '\u0411\u0413\u0414\u0416\u041B\u0424\u0426\u0427\u0428\u0429';
+    expect(applyHomoglyphOptimization(nonHomoglyphs)).toBe(nonHomoglyphs);
+  });
+
+  it('should handle mixed Latin and Cyrillic text', () => {
+    // "Москва" with Cyrillic М, о, с → "Mocква" but only homoglyphs replaced
+    const input = '\u041C\u043E\u0441\u043A\u0432\u0430'; // Москва
+    const expected = 'Mocк\u0432a'; // M, o, c are Latin; к, в stay Cyrillic; а→a
+    expect(applyHomoglyphOptimization(input)).toBe(expected);
+  });
+
+  it('should return empty string for empty input', () => {
+    expect(applyHomoglyphOptimization('')).toBe('');
+  });
+
+  it('should handle text with no replaceable characters', () => {
+    expect(applyHomoglyphOptimization('12345!@#$%')).toBe('12345!@#$%');
+  });
+
+  it('should reduce UTF-8 byte size for Cyrillic text with homoglyphs', () => {
+    // Realistic Cyrillic sentence: "Москва - столица России" (Moscow is the capital of Russia)
+    // Contains homoglyphs: М→M, о→o, с→c, а→a, т→(no mapping), р→p, о→o, с→c, с→c, и→(no mapping)
+    const input = '\u041C\u043E\u0441\u043A\u0432\u0430 - \u0441\u0442\u043E\u043B\u0438\u0446\u0430 \u0420\u043E\u0441\u0441\u0438\u0438';
+    const result = applyHomoglyphOptimization(input);
+
+    const encoder = new TextEncoder();
+    const originalBytes = encoder.encode(input).length;
+    const optimizedBytes = encoder.encode(result).length;
+
+    // Each replaced Cyrillic char saves 1 byte (2 bytes → 1 byte)
+    expect(optimizedBytes).toBeLessThan(originalBytes);
+    // Verify the exact savings: М,о,с,а,с,о,а,Р,о,с,с = 11 homoglyphs = 11 bytes saved
+    expect(originalBytes - optimizedBytes).toBe(11);
+  });
+
+  it('should achieve ~20% byte reduction on homoglyph-heavy Cyrillic text', () => {
+    // All-homoglyph uppercase: АВЕКМНОРСТХ (11 chars, all replaceable)
+    const input = '\u0410\u0412\u0415\u041A\u041C\u041D\u041E\u0420\u0421\u0422\u0425';
+    const result = applyHomoglyphOptimization(input);
+
+    const encoder = new TextEncoder();
+    const originalBytes = encoder.encode(input).length;   // 22 bytes (11 × 2)
+    const optimizedBytes = encoder.encode(result).length;  // 11 bytes (11 × 1)
+
+    const reduction = (originalBytes - optimizedBytes) / originalBytes;
+    expect(reduction).toBe(0.5); // 50% reduction for all-homoglyph text
+  });
+
+  it('should not change byte size for pure Latin text', () => {
+    const input = 'Hello World 123';
+
+    const encoder = new TextEncoder();
+    const originalBytes = encoder.encode(input).length;
+    const optimizedBytes = encoder.encode(applyHomoglyphOptimization(input)).length;
+
+    expect(optimizedBytes).toBe(originalBytes);
+  });
+});

--- a/src/utils/homoglyph.ts
+++ b/src/utils/homoglyph.ts
@@ -1,0 +1,55 @@
+/**
+ * Homoglyph optimization for Meshtastic messages.
+ *
+ * Replaces visually identical Cyrillic (and other non-Latin) characters with their
+ * Latin equivalents to reduce message size. Cyrillic characters use 2 bytes in UTF-8
+ * vs 1 byte for Latin, saving ~20-25% on mixed-script messages.
+ *
+ * Mapping ported from the Meshtastic Android app (PR #4491).
+ */
+
+const HOMOGLYPH_MAP: Record<string, string> = {
+  // Uppercase Cyrillic → Latin
+  '\u0405': 'S',  // Ѕ → S
+  '\u0406': 'I',  // І → I
+  '\u0408': 'J',  // Ј → J
+  '\u0410': 'A',  // А → A
+  '\u0412': 'B',  // В → B
+  '\u0415': 'E',  // Е → E
+  '\u041A': 'K',  // К → K
+  '\u041C': 'M',  // М → M
+  '\u041D': 'H',  // Н → H
+  '\u041E': 'O',  // О → O
+  '\u0420': 'P',  // Р → P
+  '\u0421': 'C',  // С → C
+  '\u0422': 'T',  // Т → T
+  '\u0425': 'X',  // Х → X
+  '\u04AE': 'Y',  // Ү → Y
+  '\u0417': '3',  // З → 3
+
+  // Lowercase Cyrillic → Latin
+  '\u0430': 'a',  // а → a
+  '\u0435': 'e',  // е → e
+  '\u043E': 'o',  // о → o
+  '\u0440': 'p',  // р → p
+  '\u0441': 'c',  // с → c
+  '\u0443': 'y',  // у → y
+  '\u0445': 'x',  // х → x
+  '\u0455': 's',  // ѕ → s
+  '\u0456': 'i',  // і → i
+  '\u0458': 'j',  // ј → j
+};
+
+// Build regex from all keys
+const HOMOGLYPH_REGEX = new RegExp(
+  Object.keys(HOMOGLYPH_MAP).join('|'),
+  'g'
+);
+
+/**
+ * Replace visually identical non-Latin characters with Latin equivalents.
+ * This reduces UTF-8 byte size without changing the visual appearance of the text.
+ */
+export function applyHomoglyphOptimization(text: string): string {
+  return text.replace(HOMOGLYPH_REGEX, (char) => HOMOGLYPH_MAP[char] || char);
+}


### PR DESCRIPTION
## Summary
- Adds a toggleable **Homoglyph Message Optimization** setting that replaces visually identical Cyrillic characters with Latin equivalents before sending messages, reducing UTF-8 byte size (Cyrillic = 2 bytes, Latin = 1 byte)
- Server-side transform in `sendTextMessage()` catches all outbound paths (main API, v1 API, auto-ack, auto-announce, auto-responder, etc.)
- New shared utility `src/utils/homoglyph.ts` with 26 Cyrillic-to-Latin mappings ported from the [Meshtastic Android app (PR #4491)](https://github.com/meshtastic/Meshtastic-Android/pull/4491)

Closes #1997

### Files changed
| File | Change |
|------|--------|
| `src/utils/homoglyph.ts` | New utility with character mapping and `applyHomoglyphOptimization()` |
| `src/utils/homoglyph.test.ts` | 11 tests including byte-size reduction verification |
| `src/server/meshtasticManager.ts` | Transform in `sendTextMessage()` when setting enabled |
| `src/server/server.ts` | `homoglyphEnabled` added to `validKeys` whitelist |
| `src/components/SettingsTab.tsx` | Checkbox in Display Preferences section |
| `public/locales/en.json` | Translation strings for the new setting |

## Test plan
- [x] `npx vitest run` — all 118 test files pass (2554 tests)
- [ ] Build and deploy dev container
- [ ] Settings > Display Preferences: verify checkbox appears
- [ ] Enable, save, send a Cyrillic message — verify Latin substitution in sent message
- [ ] Disable, send again — verify no substitution
- [ ] Reset to defaults — verify homoglyph is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)