### PR TITLE
feat: show location indicators on all location-enabled channels

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -411,6 +411,7 @@
   "channels.packets_decrypted": "Packets Decrypted:",
   "channels.location_sharing": "Location Sharing",
   "channels.location_auto_position": "Active (auto-position updates)",
+  "channels.location_enabled": "Enabled (location shared)",
   "channels.location_disabled": "Disabled",
 
   "dashboard.title": "Telemetry Dashboard",
@@ -2914,6 +2915,8 @@
   "channels_config.toast_channel_imported": "Channel imported to slot {{slot}} successfully!",
   "channels_config.toast_import_failed": "Failed to import channel",
   "channels_config.toast_key_generated": "Generated new AES256 key",
+  "channels_config.location_auto_broadcast": "Location: Auto-broadcast",
+  "channels_config.location_enabled": "Location: Enabled",
 
   "mqtt_config.title": "MQTT Module",
   "mqtt_config.view_docs": "View MQTT Configuration Documentation",

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -385,7 +385,9 @@ export default function ChannelsTab({
                   const uplink = channelConfig?.uplinkEnabled ? '↑' : '';
                   const downlink = channelConfig?.downlinkEnabled ? '↓' : '';
                   const encryptionIcon = encryptionStatus === 'secure' ? '🔒' : encryptionStatus === 'default' ? '🔐' : '🔓';
-                  const locationIcon = channelId === autoPositionChannelId ? '📍' : '';
+                  const channelConfig2 = channels.find(c => c.id === channelId);
+                  const hasLocation = (channelConfig2?.positionPrecision ?? 0) > 0;
+                  const locationIcon = channelId === autoPositionChannelId ? '📍' : hasLocation ? '📌' : '';
 
                   return (
                     <option key={channelId} value={channelId}>
@@ -453,6 +455,14 @@ export default function ChannelsTab({
                               title={t('channels.location_auto_position')}
                             >
                               📍
+                            </span>
+                          )}
+                          {channelId !== autoPositionChannelId && (channels.find(c => c.id === channelId)?.positionPrecision ?? 0) > 0 && (
+                            <span
+                              className="location-icon"
+                              title={t('channels.location_enabled')}
+                            >
+                              📌
                             </span>
                           )}
                           <a
@@ -937,6 +947,10 @@ export default function ChannelsTab({
                         {selectedChannelConfig.id === autoPositionChannelId ? (
                           <span className="status-enabled">
                             {t('channels.location_auto_position')}
+                          </span>
+                        ) : (selectedChannelConfig.positionPrecision ?? 0) > 0 ? (
+                          <span className="status-enabled">
+                            {t('channels.location_enabled')}
                           </span>
                         ) : (
                           <span className="status-disabled">{t('channels.location_disabled')}</span>

--- a/src/components/configuration/ChannelsConfigSection.tsx
+++ b/src/components/configuration/ChannelsConfigSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import apiService from '../../services/api';
 import { useToast } from '../ToastContainer';
@@ -50,6 +50,14 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
   const [importFileContent, setImportFileContent] = useState<string>('');
   const [isSaving, setIsSaving] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Compute auto-position channel: lowest-index channel with positionPrecision > 0
+  const autoPositionChannelId = useMemo(() => {
+    const sorted = [...channels]
+      .filter(ch => (ch.positionPrecision ?? 0) > 0)
+      .sort((a, b) => a.id - b.id);
+    return sorted.length > 0 ? sorted[0].id : null;
+  }, [channels]);
 
   // Create array of 8 slots (0-7) with channel data
   const channelSlots = Array.from({ length: 8 }, (_, index) => {
@@ -278,6 +286,13 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                         {channel.downlinkEnabled ? `↓ ${t('channels_config.downlink')}` : ''}
                         {!channel.uplinkEnabled && !channel.downlinkEnabled && t('channels_config.no_bridge')}
                       </div>
+                      {(channel.positionPrecision ?? 0) > 0 && (
+                        <div>
+                          {slotId === autoPositionChannelId
+                            ? `📍 ${t('channels_config.location_auto_broadcast')}`
+                            : `📌 ${t('channels_config.location_enabled')}`}
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- Channels with `positionPrecision > 0` that aren't the auto-broadcast channel now show a 📌 indicator (dropdown, button grid, info modal)
- Auto-broadcast channel continues to show 📍
- Device Configuration page channel cards now show location status (📍 Auto-broadcast / 📌 Enabled)
- Added translation keys for the new states

## Files Changed
- `src/components/ChannelsTab.tsx` — dropdown, button grid, info modal
- `src/components/configuration/ChannelsConfigSection.tsx` — channel cards
- `public/locales/en.json` — 3 new translation keys

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 2563 unit tests pass
- [x] Visual verification on Channels page (dropdown, buttons, info modal)
- [x] Visual verification on Device Configuration page (channel cards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)