### PR TITLE
fix: map position updates for mobile/tracker nodes + WebSocket position bug

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -90,7 +90,18 @@ export function useWebSocket(enabled: boolean = true): WebSocketState {
 
       const updatedNodes = old.nodes.map((node) => {
         if (node.nodeNum === nodeNum) {
-          return { ...node, ...nodeUpdate };
+          const merged = { ...node, ...nodeUpdate };
+          // Rebuild nested position object from flat DB fields sent via WebSocket
+          const lat = (nodeUpdate as any).latitude;
+          const lng = (nodeUpdate as any).longitude;
+          if (lat != null && lng != null) {
+            merged.position = {
+              latitude: lat,
+              longitude: lng,
+              altitude: (nodeUpdate as any).altitude ?? node.position?.altitude,
+            };
+          }
+          return merged;
         }
         return node;
       });


### PR DESCRIPTION
## Summary
- **Smarter precision gating for mobile/tracker nodes**: Reduced the stale position threshold from 12 hours to 10 minutes for mobile nodes (`mobile=1`), Tracker (role 5), and TAK Tracker (role 10). Stationary nodes retain the 12-hour threshold. This prevents a high-precision position from "locking" a mobile node's map marker for hours.
- **Fixed WebSocket position update bug**: The `node:updated` WebSocket event sends flat `latitude`/`longitude` fields from the DB, but the frontend `DeviceInfo` expects a nested `position` object. The shallow merge in `updateNodeInCache` never updated the nested object, so map markers only moved on full poll refreshes. Now rebuilds the nested `position` when flat lat/lng fields are present.

## Test plan
- [x] Unit tests: 29 precision tests pass (6 new for mobile/tracker thresholds)
- [x] Full test suite: 2578 tests pass (118 files)
- [x] System tests: 8/10 pass — 2 failures are pre-existing port 8080 conflicts with unrelated `meshmanager-nginx-dev` container (Reverse Proxy and OIDC tests)
- [ ] Manual: Connect a Tracker node sending frequent positions, confirm map marker moves within seconds instead of ~30 min

### System Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| V1 API Test | ✅ PASSED |
| Reverse Proxy Test | ❌ FAILED (port 8080 conflict) |
| Reverse Proxy + OIDC | ❌ FAILED (port 8080 conflict) |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |
| Database Migration Test | ✅ PASSED |
| DB Backing Consistency | ✅ PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)