### PR TITLE
chore: bump version to 3.7.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.6.6",
+  "version": "3.7.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/public/news.json
+++ b/docs/public/news.json
@@ -1,7 +1,16 @@
 {
   "version": "1",
-  "lastUpdated": "2026-02-21T18:00:00Z",
+  "lastUpdated": "2026-02-25T18:00:00Z",
   "items": [
+    {
+      "minVersion": "3.7.0",
+      "id": "news-2026-02-25-auto-favorite",
+      "title": "MeshMonitor v3.7.0 - Auto Favorite for Zero-Cost Hop Routing",
+      "content": "MeshMonitor v3.7.0 introduces **Auto Favorite**, a new automation feature that automatically favorites eligible nearby nodes for [zero-cost hop routing](https://meshtastic.org/blog/zero-cost-hops-favorite-routers/) on Meshtastic firmware 2.7+.\n\n## Auto Favorite\n\nWhen enabled on a **Router**, **Router Late**, or **Client Base** node, MeshMonitor automatically detects nearby 0-hop nodes and favorites them on your device — preserving hop counts across your mesh infrastructure without manual configuration.\n\n### How It Works\n\n- **Event-driven**: Eligible nodes are favorited as soon as they are detected (on NodeInfo updates)\n- **Periodic cleanup**: A sweep runs every 60 minutes to unfavorite nodes that have gone stale, moved out of range, or changed roles\n- **Manual favorites are never touched** — only auto-managed nodes are swept\n\n### Eligibility Rules\n\n| Your Node Role | Auto-Favorites |\n|---|---|\n| Client Base | All 0-hop nodes (any role) |\n| Router / Router Late | 0-hop Router, Router Late, and Client Base nodes |\n\n### Configuration\n\nFind **Auto Favorite** in the **Automation** tab. Configure the staleness threshold (default 72 hours) — nodes not heard from within this period are automatically unfavorited. The UI shows warnings if your firmware or node role doesn't support the feature.\n\n[Read more about zero-cost hops](https://meshtastic.org/blog/zero-cost-hops-favorite-routers/)\n\n## Other Improvements\n\n- **Position precision accuracy estimates** — Channel UI now shows estimated accuracy for position precision settings ([#2008](https://github.com/Yeraze/meshmonitor/pull/2008))\n- **Location indicators on all channels** — All location-enabled channels now show location sharing indicators ([#2007](https://github.com/Yeraze/meshmonitor/pull/2007))\n- **Packet routes fix** — Packet routes now use async DB methods for PostgreSQL/MySQL compatibility ([#2016](https://github.com/Yeraze/meshmonitor/pull/2016))\n- **Duplicate chat messages fix** — Prevented duplicate outgoing messages in chat ([#2015](https://github.com/Yeraze/meshmonitor/pull/2015))\n- **Map position updates** — Fixed position updates for mobile/tracker nodes and a WebSocket position bug ([#2014](https://github.com/Yeraze/meshmonitor/pull/2014))\n- **Homoglyph byte count** — Corrected optimized byte count display when homoglyph setting is enabled ([#2009](https://github.com/Yeraze/meshmonitor/pull/2009))\n- **Dependency updates** — Updated production dependencies ([#1992](https://github.com/Yeraze/meshmonitor/pull/1992))",
+      "date": "2026-02-25T18:00:00Z",
+      "category": "feature",
+      "priority": "important"
+    },
     {
       "minVersion": "3.6.5",
       "id": "news-2026-02-21-auto-upgrade-sidecar-fix",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.6.6
-appVersion: "3.6.6"
+version: 3.7.0
+appVersion: "3.7.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "meshmonitor",
-  "version": "3.6.6",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.6.6",
+      "version": "3.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@maplibre/maplibre-gl-leaflet": "^0.1.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-virtual": "^3.13.16",
         "@types/pbf": "^3.0.5",
@@ -4485,7 +4484,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4784,7 +4783,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
       "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -4816,6 +4815,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7115,6 +7115,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -13165,7 +13166,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -13807,14 +13809,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -15297,7 +15291,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.6.6",
+  "version": "3.7.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

- Bumps version from 3.6.6 to 3.7.0 across package.json, Helm Chart, and Tauri config
- Adds news post for v3.7.0 highlighting the Auto Favorite feature

## Changes Since v3.6.6

### Features
- **Auto Favorite** automation for zero-cost hop routing ([#2018](https://github.com/Yeraze/meshmonitor/pull/2018))
- Position precision accuracy estimates on channel UI ([#2008](https://github.com/Yeraze/meshmonitor/pull/2008))
- Location indicators on all location-enabled channels ([#2007](https://github.com/Yeraze/meshmonitor/pull/2007))

### Bug Fixes
- Packet routes use async DB methods for PostgreSQL/MySQL ([#2016](https://github.com/Yeraze/meshmonitor/pull/2016))
- Prevent duplicate outgoing messages in chat ([#2015](https://github.com/Yeraze/meshmonitor/pull/2015))
- Map position updates for mobile/tracker nodes and WebSocket position bug ([#2014](https://github.com/Yeraze/meshmonitor/pull/2014))
- Show optimized byte count when homoglyph setting is enabled ([#2009](https://github.com/Yeraze/meshmonitor/pull/2009))

### Maintenance
- Clean up root markdown files ([#2011](https://github.com/Yeraze/meshmonitor/pull/2011))
- Bump production dependencies ([#1992](https://github.com/Yeraze/meshmonitor/pull/1992))
- Bump rollup dependencies ([#1993](https://github.com/Yeraze/meshmonitor/pull/1993), [#1996](https://github.com/Yeraze/meshmonitor/pull/1996))

## System Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | PASSED |
| Quick Start Test | PASSED |
| Security Test | PASSED |
| V1 API Test | PASSED |
| Reverse Proxy Test | PASSED |
| Reverse Proxy + OIDC | PASSED |
| Virtual Node CLI Test | PASSED |
| Backup & Restore Test | PASSED |
| Database Migration Test | PASSED |
| DB Backing Consistency | PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)