### PR TITLE
fix: Auto Favorite settings not persisting after save

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.7.0
-appVersion: "3.7.0"
+version: 3.7.1
+appVersion: "3.7.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5040,6 +5040,8 @@ apiRouter.post('/settings', requirePermission('settings', 'write'), (req, res) =
       'autoPingIntervalSeconds',
       'autoPingMaxPings',
       'autoPingTimeoutSeconds',
+      'autoFavoriteEnabled',
+      'autoFavoriteStaleHours',
       'homoglyphEnabled',
     ];
     const filteredSettings: Record<string, string> = {};


### PR DESCRIPTION
## Summary
- Fixes #2022 - Auto Favorite toggle reverts to disabled after saving
- Added `autoFavoriteEnabled` and `autoFavoriteStaleHours` to the `validKeys` allowlist in the POST `/api/settings` endpoint
- These keys were missing from the allowlist introduced in PR #2018, causing the settings to be silently dropped during request filtering — the save appeared to succeed but nothing was actually persisted
- Bumps version to 3.7.1

## Root Cause
The `validKeys` array in `server.ts` acts as an allowlist for which settings keys are accepted by `POST /api/settings`. When PR #2018 added the Auto Favorite feature, it added the frontend component, backend logic, and status endpoint, but forgot to add the two new settings keys to this allowlist. The settings were silently filtered out before reaching `databaseService.setSettings()`.

## Test plan
- [x] Build and deploy to Docker dev container
- [x] Verify `POST /api/settings` with `autoFavoriteEnabled=true` and `autoFavoriteStaleHours=48` returns success with the values
- [x] Verify `GET /api/settings` returns the persisted values after save
- [ ] UI: Toggle Auto Favorite on, click Save, refresh page — toggle should remain enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)