### PR TITLE
fix: reduce node load to prevent firmware heap exhaustion

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -43,6 +43,9 @@ Configure push notifications for iOS, Android, and desktop browsers. Learn about
 ### [Custom Tile Servers](/configuration/custom-tile-servers)
 Configure custom map tile servers for offline operation, custom styling, or organizational branding. Supports both vector (.pbf) and raster (.png) tiles with TileServer GL, nginx caching proxy, or any standard XYZ tile server.
 
+### [Reducing Node Load](/configuration/node-load)
+Understand how MeshMonitor communicates with your Meshtastic node and how to tune settings to reduce memory pressure on constrained devices (ESP32, Heltec V3/V4, RAK4631).
+
 ## Environment Variables
 
 MeshMonitor can be configured using environment variables. Here are the most important ones:

--- a/docs/configuration/node-load.md
+++ b/docs/configuration/node-load.md
@@ -1,0 +1,68 @@
+# Reducing Node Load
+
+MeshMonitor communicates with your Meshtastic node over a persistent TCP connection, sending protobuf-encoded admin packets to request configuration, telemetry, and status data. On memory-constrained devices (ESP32-based boards like Heltec V3/V4, RAK4631), excessive traffic can contribute to heap memory exhaustion over time.
+
+::: tip
+This is primarily a firmware-side issue tracked at [meshtastic/firmware#9632](https://github.com/meshtastic/firmware/issues/9632). The recommendations below help reduce MeshMonitor's contribution to node memory pressure while the firmware fix is developed.
+:::
+
+## How MeshMonitor Communicates with the Node
+
+On every connection (or reconnect), MeshMonitor:
+
+1. **Sends `wantConfigId`** to request the full node database and channel configuration
+2. **Requests LoRa config** (1 admin packet)
+3. **Requests all module configs** (15 admin packets) — only on first connect, skipped on reconnect
+4. **Starts periodic schedulers** for traceroutes, LocalStats, time sync, announcements, etc.
+
+During normal operation, MeshMonitor sends:
+- **LocalStats requests** at a configurable interval (default: every 15 minutes)
+- **Auto-traceroute requests** based on configured interval
+- **Auto-acknowledge tapbacks and replies** when messages match the configured pattern
+- **Auto-welcome messages** when new nodes appear
+- **Auto-announce messages** on a schedule
+- **TCP keepalive probes** every 5 minutes
+
+## Features That Increase Node Load
+
+### Auto-Traceroute
+Sends traceroute requests to discovered nodes. On busy meshes with many nodes, this can generate significant traffic.
+
+**Recommendation:** Increase the interval to 15-30 minutes, or disable (set to 0) on ESP32-based nodes.
+
+### Remote Admin Scanner
+Periodically probes nodes for remote admin capability. Each probe is an admin packet.
+
+**Recommendation:** Increase the interval or disable if you don't need remote admin discovery.
+
+### Auto-Acknowledge (Auto-ACK)
+Responds to matching messages with tapback reactions and/or text replies. On high-traffic channels, this can generate many outgoing messages.
+
+**Recommendation:** On busy channels, be selective about which channels have auto-ACK enabled. All auto-ACK sends (both tapbacks and replies) are rate-limited through the message queue (30-second minimum spacing).
+
+### Auto-Announce
+Broadcasts announcement messages on a schedule. Each announcement is one outgoing message per configured channel.
+
+**Recommendation:** Use longer intervals (4-12 hours) on constrained nodes.
+
+### LocalStats Collection
+Requests device statistics (airtime, channel utilization, uptime) from the connected node.
+
+**Recommendation:** The default interval is 15 minutes. Increase to 30-60 minutes on constrained nodes, or set to 0 to disable entirely. This setting is available under **Settings > Node Management > LocalStats Collection Interval**.
+
+## Configuration Recommendations for Constrained Nodes
+
+If your node is experiencing heap exhaustion or frequent reboots:
+
+1. **Increase LocalStats interval** to 30+ minutes (Settings > Node Management)
+2. **Increase or disable auto-traceroute** (Settings > Auto-Traceroute)
+3. **Be selective with auto-ACK channels** — avoid enabling on high-traffic channels
+4. **Increase announcement intervals** to 4+ hours
+5. **Disable remote admin scanner** if not needed (set interval to 0)
+
+## Technical Details
+
+- **TCP keepalive:** 5 minutes (reduced from 1 minute to lower TCP stack overhead)
+- **Module config caching:** Module configs are only requested on the first connection after MeshMonitor starts. Reconnects skip these 15 admin packets.
+- **Message queue rate limiting:** All automated outgoing messages (auto-ACK tapbacks, auto-ACK replies, auto-welcome, auto-responder) go through a shared message queue with 30-second minimum spacing between sends.
+- **LocalStats initial delay:** The first LocalStats request is delayed 30 seconds after connection to let the node settle.

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1256,6 +1256,8 @@
   "settings.inactive_node_check_interval_description": "How often to check for inactive nodes (1-1440 minutes, default: 60)",
   "settings.inactive_node_cooldown_label": "Inactive Node Notification Cooldown (hours)",
   "settings.inactive_node_cooldown_description": "Minimum time between notifications for the same node (prevents spam, default: 24 hours)",
+  "settings.local_stats_interval_label": "LocalStats Collection Interval (minutes)",
+  "settings.local_stats_interval_description": "How often to request LocalStats from the connected node (0 = disabled, default: 15). Lower values increase node load.",
   "settings.display_prefs": "Display Preferences",
   "settings.sort_field_label": "Preferred Node List Sorting - Field",
   "settings.sort_field_description": "Default sorting field for the Node List on the main page",

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -178,6 +178,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   // the UI checkbox says "Hide" while the context uses "show" semantics
   const [localHideIncompleteNodes, setLocalHideIncompleteNodes] = useState(!showIncompleteNodes);
   const [localHomoglyphEnabled, setLocalHomoglyphEnabled] = useState(false);
+  const [localLocalStatsIntervalMinutes, setLocalLocalStatsIntervalMinutes] = useState(15);
+  const [initialLocalStatsIntervalMinutes, setInitialLocalStatsIntervalMinutes] = useState(15);
   const [isFetchingSolarEstimates, setIsFetchingSolarEstimates] = useState(false);
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -249,6 +251,11 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           const homoglyphOn = settings.homoglyphEnabled === 'true';
           setLocalHomoglyphEnabled(homoglyphOn);
           setInitialHomoglyphEnabled(homoglyphOn);
+
+          // Load LocalStats interval setting
+          const statsInterval = parseInt(settings.localStatsIntervalMinutes || '15', 10);
+          setLocalLocalStatsIntervalMinutes(statsInterval);
+          setInitialLocalStatsIntervalMinutes(statsInterval);
         }
       } catch (error) {
         logger.error('Failed to fetch server settings:', error);
@@ -332,14 +339,16 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localSolarMonitoringAzimuth !== solarMonitoringAzimuth ||
       localSolarMonitoringDeclination !== solarMonitoringDeclination ||
       localHideIncompleteNodes !== !showIncompleteNodes ||
-      localHomoglyphEnabled !== initialHomoglyphEnabled;
+      localHomoglyphEnabled !== initialHomoglyphEnabled ||
+      localLocalStatsIntervalMinutes !== initialLocalStatsIntervalMinutes;
     setHasChanges(changed);
   }, [localMaxNodeAge, localInactiveNodeThresholdHours, localInactiveNodeCheckIntervalMinutes, localInactiveNodeCooldownHours, localTemperatureUnit, localDistanceUnit, localPositionHistoryLineStyle, localTelemetryHours, localFavoriteTelemetryStorageDays, localPreferredSortField, localPreferredSortDirection, localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localTheme, localNodeHopsCalculation, localDashboardSortOption,
       maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTileset, mapPinStyle, theme, nodeHopsCalculation, preferredDashboardSortOption,
       localPacketLogEnabled, localPacketLogMaxCount, localPacketLogMaxAgeHours, initialPacketMonitorSettings,
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude, localSolarMonitoringAzimuth, localSolarMonitoringDeclination,
       solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination,
-      localHideIncompleteNodes, showIncompleteNodes, localHomoglyphEnabled, initialHomoglyphEnabled]);
+      localHideIncompleteNodes, showIncompleteNodes, localHomoglyphEnabled, initialHomoglyphEnabled,
+      localLocalStatsIntervalMinutes, initialLocalStatsIntervalMinutes]);
 
   // Reset local state to current saved values (for SaveBar dismiss)
   const resetChanges = useCallback(() => {
@@ -371,13 +380,14 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalSolarMonitoringDeclination(solarMonitoringDeclination);
     setLocalHideIncompleteNodes(!showIncompleteNodes);
     setLocalHomoglyphEnabled(initialHomoglyphEnabled);
+    setLocalLocalStatsIntervalMinutes(initialLocalStatsIntervalMinutes);
   }, [maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes,
       inactiveNodeCooldownHours, temperatureUnit, distanceUnit, telemetryVisualizationHours,
       favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat,
       dateFormat, mapTileset, mapPinStyle, theme, nodeHopsCalculation, preferredDashboardSortOption,
       initialPacketMonitorSettings, solarMonitoringEnabled, solarMonitoringLatitude,
       solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes,
-      initialHomoglyphEnabled]);
+      initialHomoglyphEnabled, initialLocalStatsIntervalMinutes]);
 
   const handleSave = useCallback(async () => {
     setIsSaving(true);
@@ -408,7 +418,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         solarMonitoringAzimuth: localSolarMonitoringAzimuth.toString(),
         solarMonitoringDeclination: localSolarMonitoringDeclination.toString(),
         hideIncompleteNodes: localHideIncompleteNodes ? '1' : '0',
-        homoglyphEnabled: String(localHomoglyphEnabled)
+        homoglyphEnabled: String(localHomoglyphEnabled),
+        localStatsIntervalMinutes: localLocalStatsIntervalMinutes.toString()
       };
 
       // Save to server
@@ -447,6 +458,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       // Update initial packet monitor settings after successful save
       setInitialPacketMonitorSettings({ enabled: localPacketLogEnabled, maxCount: localPacketLogMaxCount, maxAgeHours: localPacketLogMaxAgeHours });
       setInitialHomoglyphEnabled(localHomoglyphEnabled);
+      setInitialLocalStatsIntervalMinutes(localLocalStatsIntervalMinutes);
 
       showToast(t('settings.saved_success'), 'success');
       setHasChanges(false);
@@ -463,7 +475,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localTheme,
       localNodeHopsCalculation, localDashboardSortOption, localPacketLogEnabled, localPacketLogMaxCount, localPacketLogMaxAgeHours,
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude,
-      localSolarMonitoringAzimuth, localSolarMonitoringDeclination, localHideIncompleteNodes, localHomoglyphEnabled,
+      localSolarMonitoringAzimuth, localSolarMonitoringDeclination, localHideIncompleteNodes, localHomoglyphEnabled, localLocalStatsIntervalMinutes,
       onMaxNodeAgeChange, onInactiveNodeThresholdHoursChange, onInactiveNodeCheckIntervalMinutesChange,
       onInactiveNodeCooldownHoursChange, onTemperatureUnitChange, onDistanceUnitChange, onPositionHistoryLineStyleChange,
       onTelemetryVisualizationChange, onFavoriteTelemetryStorageDaysChange, onPreferredSortFieldChange,
@@ -859,6 +871,21 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               max="720"
               value={localInactiveNodeCooldownHours}
               onChange={(e) => setLocalInactiveNodeCooldownHours(parseInt(e.target.value))}
+              className="setting-input"
+            />
+          </div>
+          <div className="setting-item">
+            <label htmlFor="localStatsIntervalMinutes">
+              {t('settings.local_stats_interval_label')}
+              <span className="setting-description">{t('settings.local_stats_interval_description')}</span>
+            </label>
+            <input
+              id="localStatsIntervalMinutes"
+              type="number"
+              min="0"
+              max="60"
+              value={localLocalStatsIntervalMinutes}
+              onChange={(e) => setLocalLocalStatsIntervalMinutes(parseInt(e.target.value))}
               className="setting-input"
             />
           </div>

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -403,6 +403,18 @@ setTimeout(async () => {
       }
     }
 
+    // Load LocalStats collection interval
+    const localStatsInterval = databaseService.getSetting('localStatsIntervalMinutes');
+    if (localStatsInterval !== null) {
+      const intervalMinutes = parseInt(localStatsInterval);
+      if (!isNaN(intervalMinutes) && intervalMinutes >= 0 && intervalMinutes <= 60) {
+        meshtasticManager.setLocalStatsInterval(intervalMinutes);
+        logger.debug(
+          `✅ Loaded saved LocalStats interval: ${intervalMinutes} minutes${intervalMinutes === 0 ? ' (disabled)' : ''}`
+        );
+      }
+    }
+
     // NOTE: We no longer mark existing nodes as welcomed on startup.
     // This is now handled when autoWelcomeEnabled is first changed to 'true'
     // via the settings endpoint. This prevents welcoming existing nodes when
@@ -5046,6 +5058,7 @@ apiRouter.post('/settings', requirePermission('settings', 'write'), (req, res) =
       'autoFavoriteEnabled',
       'autoFavoriteStaleHours',
       'homoglyphEnabled',
+      'localStatsIntervalMinutes',
     ];
     const filteredSettings: Record<string, string> = {};
 
@@ -5392,6 +5405,14 @@ apiRouter.post('/settings', requirePermission('settings', 'write'), (req, res) =
       const interval = parseInt(filteredSettings.remoteAdminScannerIntervalMinutes);
       if (!isNaN(interval) && interval >= 0 && interval <= 60) {
         meshtasticManager.setRemoteAdminScannerInterval(interval);
+      }
+    }
+
+    // Apply LocalStats interval if changed
+    if ('localStatsIntervalMinutes' in filteredSettings) {
+      const interval = parseInt(filteredSettings.localStatsIntervalMinutes);
+      if (!isNaN(interval) && interval >= 0 && interval <= 60) {
+        meshtasticManager.setLocalStatsInterval(interval);
       }
     }
 

--- a/src/server/tcpTransport.ts
+++ b/src/server/tcpTransport.ts
@@ -67,7 +67,7 @@ export class TcpTransport extends EventEmitter {
       this.socket = new Socket();
 
       // Set socket options
-      this.socket.setKeepAlive(true, 60000); // Keep alive every 60 seconds
+      this.socket.setKeepAlive(true, 300000); // Keep alive every 5 minutes (app-layer health check handles dead connections)
       this.socket.setNoDelay(true); // Disable Nagle's algorithm for low latency
 
       // Connection timeout


### PR DESCRIPTION
## Summary

Closes #2013

Multiple mitigations to reduce traffic MeshMonitor sends to the connected Meshtastic node, addressing heap exhaustion on ESP32-based devices (Heltec V3/V4, RAK4631) reported in [meshtastic/firmware#9632](https://github.com/meshtastic/firmware/issues/9632).

- **TCP keepalive**: Increased from 60s to 300s (app-layer health check already detects dead connections)
- **Module config caching**: Skip 15 admin packets on reconnect; only fetch once per process lifetime. Added `refreshModuleConfigs()` public method for manual refresh
- **LocalStats interval**: Changed default from 5 to 15 minutes, added 30s initial delay after connect, made configurable via Settings UI (0-60 min, 0 = disabled)
- **Rate-limited automated sends**: Auto-ACK tapbacks and auto-welcome messages now route through the message queue, enforcing 30s minimum spacing between all automated outgoing messages
- **Documentation**: New `docs/configuration/node-load.md` with tuning recommendations for constrained devices

## Files Changed

| File | Change |
|------|--------|
| `src/server/tcpTransport.ts` | Keepalive 60s → 300s |
| `src/server/meshtasticManager.ts` | Module config caching, LocalStats 15m default + 30s delay, queue routing for tapback/welcome |
| `src/server/messageQueueService.ts` | Add `emoji` field to QueuedMessage interface and send paths |
| `src/server/server.ts` | Load/save `localStatsIntervalMinutes` setting |
| `src/components/SettingsTab.tsx` | LocalStats interval UI control |
| `public/locales/en.json` | i18n keys for LocalStats interval |
| `src/server/meshtasticManager.autowelcome.test.ts` | Updated tests for queue-based welcome sends |
| `docs/configuration/node-load.md` | New documentation page |
| `docs/configuration/index.md` | Link to new page |

## Test plan

- [x] All 2618 unit tests pass (121 files, 0 failures)
- [x] TypeScript compiles cleanly (server + frontend)
- [x] Vite frontend build succeeds
- [x] Docker build + deploy verified
- [ ] Verify stable TCP connection over 5+ minutes
- [ ] Check logs: first connect shows "Requesting all module configs", reconnect shows "Skipping module config request"
- [ ] Change LocalStats interval via Settings, verify scheduler restarts
- [ ] Verify auto-ACK tapbacks are rate-limited through message queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)