### PR TITLE
fix: poll interval respects WebSocket state internally

### DIFF
--- a/src/hooks/usePoll.test.ts
+++ b/src/hooks/usePoll.test.ts
@@ -22,6 +22,11 @@ vi.mock('./useCsrfFetch', () => ({
   useCsrfFetch: () => mockFetch,
 }));
 
+// Mock useWebSocketConnected (defaults to disconnected for tests)
+vi.mock('../contexts/WebSocketContext', () => ({
+  useWebSocketConnected: () => false,
+}));
+
 // Helper to create a wrapper with QueryClient
 function createWrapper() {
   const queryClient = new QueryClient({


### PR DESCRIPTION
## Summary
- `usePoll()` now calls `useWebSocketConnected()` internally instead of relying on callers to pass `webSocketConnected`
- Fixes `/api/poll` firing every 5s instead of 30s when WebSocket is connected
- Root cause: multiple TanStack Query observers sharing `['poll']` key — the shortest `refetchInterval` (5s default) always won

## Test plan
- [x] All 2618 tests pass
- [x] TypeScript compiles clean
- [ ] Verify `/api/poll` fires every ~30s when WebSocket is connected (tested in dev container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)