### PR TITLE
fix: enforce channel-based permission checks on telemetry/position endpoints

### DIFF
--- a/src/server/routes/v1/positionHistory.ts
+++ b/src/server/routes/v1/positionHistory.ts
@@ -9,6 +9,7 @@
 import express, { Request, Response } from 'express';
 import databaseService from '../../../services/database.js';
 import { logger } from '../../../utils/logger.js';
+import { checkNodeChannelAccess } from '../../utils/nodeEnhancer.js';
 
 const router = express.Router();
 
@@ -67,6 +68,12 @@ router.get('/:nodeId/position-history', async (req: Request, res: Response) => {
     }
 
     const { nodeId } = req.params;
+
+    // Check channel-based access for this node
+    if (!await checkNodeChannelAccess(nodeId, user)) {
+      return res.status(403).json({ success: false, error: 'Forbidden', message: 'Insufficient permissions' });
+    }
+
     const { since, before, limit, offset } = req.query;
 
     const maxLimit = Math.min(parseInt(limit as string) || 1000, 10000);

--- a/src/server/routes/v1/v1-api.test.ts
+++ b/src/server/routes/v1/v1-api.test.ts
@@ -1205,12 +1205,14 @@ describe('GET /api/v1/nodes/:nodeId/position-history', () => {
 
   it('should return 403 for private-position node without nodes_private:read', async () => {
     const databaseService = await import('../../../services/database.js');
-    vi.mocked(databaseService.default.getNode).mockReturnValueOnce({
-      nodeId: '2882400001', node_id: 2882400001, positionOverrideIsPrivate: true
-    } as any);
+    // getNode is called twice: once by checkNodeChannelAccess, once by the privacy check
+    vi.mocked(databaseService.default.getNode)
+      .mockReturnValueOnce({ channel: 0, positionOverrideIsPrivate: true } as any)
+      .mockReturnValueOnce({ channel: 0, positionOverrideIsPrivate: true } as any);
     vi.mocked(databaseService.default.getUserPermissionSetAsync).mockResolvedValue({
       nodes: { read: true },
-      nodes_private: { read: false }
+      nodes_private: { read: false },
+      channel_0: { viewOnMap: true, read: true, write: true }
     } as any);
 
     const response = await request(app)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -38,7 +38,7 @@ import { inactiveNodeNotificationService } from './services/inactiveNodeNotifica
 import { serverEventNotificationService } from './services/serverEventNotificationService.js';
 import { getUserNotificationPreferencesAsync, saveUserNotificationPreferencesAsync, applyNodeNamePrefix } from './utils/notificationFiltering.js';
 import { upgradeService } from './services/upgradeService.js';
-import { enhanceNodeForClient, filterNodesByChannelPermission } from './utils/nodeEnhancer.js';
+import { enhanceNodeForClient, filterNodesByChannelPermission, checkNodeChannelAccess } from './utils/nodeEnhancer.js';
 import { dynamicCspMiddleware, refreshTileHostnameCache } from './middleware/dynamicCsp.js';
 import { PortNum } from './constants/meshtastic.js';
 
@@ -808,6 +808,11 @@ apiRouter.get('/nodes/:nodeId/position-history', optionalAuth(), async (req, res
   try {
     const { nodeId } = req.params;
 
+    // Check channel-based access for this node
+    if (!await checkNodeChannelAccess(nodeId, req.user)) {
+      return res.status(403).json({ error: 'Insufficient permissions' });
+    }
+
     // Allow hours parameter for future use, but default to fetching ALL position history
     // This ensures we capture movement that may have happened long ago
     // Validate hours: must be positive integer, max 8760 (1 year)
@@ -876,6 +881,12 @@ apiRouter.get('/nodes/:nodeId/position-history', optionalAuth(), async (req, res
 apiRouter.get('/nodes/:nodeId/positions', optionalAuth(), async (req, res) => {
   try {
     const { nodeId } = req.params;
+
+    // Check channel-based access for this node
+    if (!await checkNodeChannelAccess(nodeId, req.user)) {
+      return res.status(403).json({ error: 'Insufficient permissions' });
+    }
+
     const limit = req.query.limit ? parseInt(req.query.limit as string) : 2000;
 
     // Get only position-related telemetry (lat/lon/alt) for the node
@@ -1325,6 +1336,11 @@ apiRouter.delete('/ignored-nodes/:nodeId', requirePermission('nodes', 'write'), 
 apiRouter.get('/nodes/:nodeId/position-override', optionalAuth(), async (req, res) => {
   try {
     const { nodeId } = req.params;
+
+    // Check channel-based access for this node
+    if (!await checkNodeChannelAccess(nodeId, req.user)) {
+      return res.status(403).json({ error: 'Insufficient permissions' });
+    }
 
     // Convert nodeId (hex string like !a1b2c3d4) to nodeNum (integer)
     const nodeNumStr = nodeId.replace('!', '');
@@ -3247,6 +3263,11 @@ apiRouter.get('/telemetry/:nodeId', optionalAuth(), async (req, res) => {
     }
 
     const { nodeId } = req.params;
+
+    // Check channel-based access for this node
+    if (!await checkNodeChannelAccess(nodeId, req.user)) {
+      return res.status(403).json({ error: 'Insufficient permissions' });
+    }
     const hoursParam = req.query.hours ? parseInt(req.query.hours as string) : 24;
 
     // Calculate cutoff timestamp for filtering
@@ -3304,6 +3325,11 @@ apiRouter.get('/telemetry/:nodeId/rates', optionalAuth(), async (req, res) => {
     }
 
     const { nodeId } = req.params;
+
+    // Check channel-based access for this node
+    if (!await checkNodeChannelAccess(nodeId, req.user)) {
+      return res.status(403).json({ error: 'Insufficient permissions' });
+    }
     const hoursParam = req.query.hours ? parseInt(req.query.hours as string) : 24;
 
     // Calculate cutoff timestamp for filtering
@@ -3381,6 +3407,11 @@ apiRouter.get('/telemetry/:nodeId/smarthops', optionalAuth(), async (req, res) =
     }
 
     const { nodeId } = req.params;
+
+    // Check channel-based access for this node
+    if (!await checkNodeChannelAccess(nodeId, req.user)) {
+      return res.status(403).json({ error: 'Insufficient permissions' });
+    }
     // Validate and clamp hours (1-168, default 24)
     const hoursParam = Math.max(1, Math.min(168, parseInt(req.query.hours as string) || 24));
     // Validate and clamp interval (5-60 minutes, default 15)
@@ -3412,6 +3443,11 @@ apiRouter.get('/telemetry/:nodeId/linkquality', optionalAuth(), async (req, res)
     }
 
     const { nodeId } = req.params;
+
+    // Check channel-based access for this node
+    if (!await checkNodeChannelAccess(nodeId, req.user)) {
+      return res.status(403).json({ error: 'Insufficient permissions' });
+    }
     // Validate and clamp hours (1-168, default 24)
     const hoursParam = Math.max(1, Math.min(168, parseInt(req.query.hours as string) || 24));
 


### PR DESCRIPTION
## Summary

- Adds `checkNodeChannelAccess()` helper to `nodeEnhancer.ts` that resolves a nodeId to its channel and verifies the user has `viewOnMap` permission for that channel
- Gates 10 telemetry and position endpoints behind channel permission checks, closing AUTHZ-VULN-02 (pentest finding: knowing a nodeId bypassed channel filtering)
- Supports both hex (`!abcdef01`) and decimal (`2882400001`) nodeId formats for session API and v1 API compatibility

### Endpoints protected

**Session API (server.ts):** `GET /telemetry/:nodeId`, `/telemetry/:nodeId/rates`, `/telemetry/:nodeId/smarthops`, `/telemetry/:nodeId/linkquality`, `/nodes/:nodeId/position-history`, `/nodes/:nodeId/positions`, `/nodes/:nodeId/position-override`

**v1 API:** `GET /api/v1/telemetry?nodeId=...`, `GET /api/v1/telemetry/:nodeId`, `GET /api/v1/nodes/:nodeId/position-history`

## Test plan

- [x] `npx tsc --noEmit` — clean compilation
- [x] `npx vitest run` — all 2627 tests pass (121 files, 0 failures)
- [x] 8 new unit tests for `checkNodeChannelAccess` (admin bypass, channel match/mismatch, default channel, null node, anonymous, undefined, no-permission)
- [ ] Manual: anonymous user with `channel_0:viewOnMap` only → telemetry for channel-0 node returns data, non-channel-0 node returns 403
- [ ] Manual: admin user → all telemetry accessible regardless of channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)