### PR TITLE
ci: add post-build smoke test for Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -126,10 +126,102 @@ jobs:
           sbom: true
         timeout-minutes: 40
 
+  # Smoke test: verify critical files are non-zero in each platform image
+  # Prevents publishing broken images (see issue #2046)
+  smoke-test:
+    runs-on: ubuntu-latest
+    needs: [build-main, build-armv7]
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - tag_suffix: main
+            platform: linux/amd64
+          - tag_suffix: main
+            platform: linux/arm64
+          - tag_suffix: armv7
+            platform: linux/arm/v7
+
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version and image name
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "image=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+      - name: Verify critical files are non-zero
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}-${{ matrix.tag_suffix }}"
+          PLATFORM="${{ matrix.platform }}"
+
+          echo "Smoke testing $IMAGE ($PLATFORM)"
+          echo "─────────────────────────────────────"
+
+          # Pull the image for this specific platform
+          docker pull --platform "$PLATFORM" "$IMAGE"
+
+          # Critical files that must be non-zero
+          FILES=(
+            "/usr/local/bin/docker-entrypoint.sh"
+            "/app/dist/server/server.js"
+            "/app/package.json"
+            "/etc/supervisord.conf"
+          )
+
+          FAILED=0
+          for FILE in "${FILES[@]}"; do
+            SIZE=$(docker run --rm --platform "$PLATFORM" "$IMAGE" stat -c%s "$FILE" 2>/dev/null || echo "MISSING")
+            if [ "$SIZE" = "MISSING" ]; then
+              echo "FAIL: $FILE is missing"
+              FAILED=1
+            elif [ "$SIZE" = "0" ]; then
+              echo "FAIL: $FILE is 0 bytes"
+              FAILED=1
+            else
+              echo "  OK: $FILE ($SIZE bytes)"
+            fi
+          done
+
+          # Verify node binary runs
+          NODE_VERSION=$(docker run --rm --platform "$PLATFORM" "$IMAGE" node --version 2>/dev/null || echo "FAILED")
+          if [[ "$NODE_VERSION" == v* ]]; then
+            echo "  OK: node $NODE_VERSION"
+          else
+            echo "FAIL: node binary not functional"
+            FAILED=1
+          fi
+
+          echo "─────────────────────────────────────"
+          if [ "$FAILED" -ne 0 ]; then
+            echo "SMOKE TEST FAILED for $PLATFORM"
+            exit 1
+          fi
+          echo "Smoke test passed for $PLATFORM"
+
   # Create multi-arch manifest combining all platforms
   create-manifest:
     runs-on: ubuntu-latest
-    needs: [build-main, build-armv7]
+    needs: [build-main, build-armv7, smoke-test]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

- Adds a **smoke-test** job to `docker-publish.yml` that runs after builds but **before** creating the multi-arch manifest
- Verifies critical files are non-zero on all 3 platforms (amd64, arm64, armv7) using QEMU
- Checks: `docker-entrypoint.sh`, `server.js`, `package.json`, `supervisord.conf`, and `node` binary
- If any file is missing or 0 bytes, the pipeline fails before publishing manifest tags

Prevents a repeat of #2046 where the v3.7.0 arm64 image shipped with 0-byte files causing crash loops on ARM64 devices.

Closes #2046

## Test plan

- [ ] Workflow YAML is valid (syntax check)
- [ ] Next release build triggers the smoke-test job
- [ ] Smoke test matrix runs for all 3 platforms
- [ ] `create-manifest` job waits for smoke-test to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)