### PR TITLE
fix: persist Node Hops Calculation and Dim Inactive Nodes settings

### DIFF
--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -419,7 +419,11 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         solarMonitoringDeclination: localSolarMonitoringDeclination.toString(),
         hideIncompleteNodes: localHideIncompleteNodes ? '1' : '0',
         homoglyphEnabled: String(localHomoglyphEnabled),
-        localStatsIntervalMinutes: localLocalStatsIntervalMinutes.toString()
+        localStatsIntervalMinutes: localLocalStatsIntervalMinutes.toString(),
+        nodeHopsCalculation: localNodeHopsCalculation,
+        nodeDimmingEnabled: nodeDimmingEnabled ? '1' : '0',
+        nodeDimmingStartHours: nodeDimmingStartHours.toString(),
+        nodeDimmingMinOpacity: nodeDimmingMinOpacity.toString(),
       };
 
       // Save to server

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -936,6 +936,36 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
             }
           }
 
+          if (settings.nodeHopsCalculation) {
+            const valid: NodeHopsCalculation[] = ['nodeinfo', 'traceroute', 'messages'];
+            if (valid.includes(settings.nodeHopsCalculation as NodeHopsCalculation)) {
+              setNodeHopsCalculationState(settings.nodeHopsCalculation as NodeHopsCalculation);
+              localStorage.setItem('nodeHopsCalculation', settings.nodeHopsCalculation);
+            }
+          }
+
+          if (settings.nodeDimmingEnabled !== undefined) {
+            const enabled = settings.nodeDimmingEnabled === '1' || settings.nodeDimmingEnabled === 'true';
+            setNodeDimmingEnabledState(enabled);
+            localStorage.setItem('nodeDimmingEnabled', enabled.toString());
+          }
+
+          if (settings.nodeDimmingStartHours !== undefined) {
+            const value = parseFloat(settings.nodeDimmingStartHours);
+            if (!isNaN(value) && value > 0) {
+              setNodeDimmingStartHoursState(value);
+              localStorage.setItem('nodeDimmingStartHours', value.toString());
+            }
+          }
+
+          if (settings.nodeDimmingMinOpacity !== undefined) {
+            const value = parseFloat(settings.nodeDimmingMinOpacity);
+            if (!isNaN(value) && value >= 0 && value <= 1) {
+              setNodeDimmingMinOpacityState(value);
+              localStorage.setItem('nodeDimmingMinOpacity', value.toString());
+            }
+          }
+
           logger.debug('✅ Settings loaded from server and applied to state');
 
           // Load user-specific map preferences (overrides global settings)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5095,6 +5095,10 @@ apiRouter.post('/settings', requirePermission('settings', 'write'), (req, res) =
       'autoFavoriteStaleHours',
       'homoglyphEnabled',
       'localStatsIntervalMinutes',
+      'nodeHopsCalculation',
+      'nodeDimmingEnabled',
+      'nodeDimmingStartHours',
+      'nodeDimmingMinOpacity',
     ];
     const filteredSettings: Record<string, string> = {};
 


### PR DESCRIPTION
## Summary

- **Node Hops Calculation** and **Dim Inactive Nodes on Map** settings were only stored in `localStorage`, never saved to the server database
- This caused them to revert to defaults on relogin, different browser, or cleared cache
- Adds `nodeHopsCalculation`, `nodeDimmingEnabled`, `nodeDimmingStartHours`, `nodeDimmingMinOpacity` to:
  - Server `validKeys` allowlist (`server.ts`)
  - Settings POST payload (`SettingsTab.tsx`)
  - Server settings load on startup (`SettingsContext.tsx`)

Fixes #2048

## Test plan

- [x] TypeScript compiles cleanly
- [x] All 2628 tests pass
- [ ] Set Node Hops Calculation to "All Messages", save, log out, log back in — setting persists
- [ ] Enable Dim Inactive Nodes, save, log out, log back in — setting persists
- [ ] Open in a different browser, verify settings are loaded from server

🤖 Generated with [Claude Code](https://claude.com/claude-code)