### PR TITLE
Fix payload_size calculation to include encrypted payload

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3408,7 +3408,7 @@ class MeshtasticManager {
           hop_limit: meshPacket.hopLimit ?? undefined,
           hop_start: meshPacket.hopStart ?? undefined,
           relay_node: meshPacket.relayNode ?? undefined,
-          payload_size: meshPacket.decoded?.payload?.length ?? undefined,
+          payload_size: meshPacket.decoded?.payload?.length ?? meshPacket.encrypted?.length ?? undefined,
           want_ack: meshPacket.wantAck ?? false,
           priority: meshPacket.priority ?? undefined,
           payload_preview: payloadPreview ?? undefined,


### PR DESCRIPTION
## Summary
Updated the `payload_size` calculation in the mesh packet serialization to fall back to the encrypted payload length when the decoded payload is not available.

## Key Changes
- Modified `payload_size` field assignment to check both `meshPacket.decoded?.payload?.length` and `meshPacket.encrypted?.length`
- This ensures that packets with encrypted payloads (where decoded payload may be unavailable) still report an accurate payload size

## Implementation Details
The change adds a fallback mechanism using the nullish coalescing operator (`??`). When a mesh packet's decoded payload is unavailable, the payload size will now be determined from the encrypted payload length instead of defaulting to `undefined`. This provides more complete packet metadata for encrypted messages.

https://claude.ai/code/session_01LMNP8ACrVKKvaSi9s5um2o