### PR TITLE
fix: auto-assign IDs to geofence/timer triggers missing them

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1697,6 +1697,13 @@ class MeshtasticManager {
       return;
     }
 
+    // Auto-assign IDs to triggers missing them
+    for (let i = 0; i < timerTriggers.length; i++) {
+      if (!timerTriggers[i].id) {
+        timerTriggers[i].id = `timer-${i}`;
+      }
+    }
+
     // Schedule each enabled timer
     for (const trigger of timerTriggers) {
       if (!trigger.enabled) {
@@ -1764,6 +1771,13 @@ class MeshtasticManager {
     } catch (e) {
       logger.error('📍 Failed to parse geofenceTriggers setting:', e);
       return;
+    }
+
+    // Auto-assign IDs to triggers missing them (prevents shared state when id is undefined)
+    for (let i = 0; i < triggers.length; i++) {
+      if (!triggers[i].id) {
+        triggers[i].id = `geofence-${i}`;
+      }
     }
 
     const enabledTriggers = triggers.filter(t => t.enabled);


### PR DESCRIPTION
## Summary

- Auto-generate unique IDs (`geofence-N` / `timer-N`) for triggers that don't have an explicit `id` property
- Fixes geofence exit events never firing when entry+exit triggers are configured without IDs
- Also applies the same fix to timer triggers which had the same latent bug

## Root Cause

When triggers lack `id` properties, `trigger.id` is `undefined`. Since JavaScript Maps allow `undefined` as a key, all triggers share a single state `Set`. During `checkGeofencesForNode`, the entry trigger modifies the shared set (deleting the node) before the exit trigger reads it, so the exit condition `!isInside && wasInside` is always false.

## Test plan

- [x] 27 geofence-specific tests passing
- [x] 2701 total tests passing (128 test files)
- [x] Fix verified by code inspection — the auto-ID assignment happens immediately after JSON parse, before any trigger processing

Closes #2059

🤖 Generated with [Claude Code](https://claude.com/claude-code)