### PR TITLE
fix: add embed.html to armv7 Dockerfile

### DIFF
--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -32,7 +32,7 @@ RUN if [ ! -f "protobufs/meshtastic/mesh.proto" ]; then \
     fi
 
 # Copy config files and source needed for builds
-COPY tsconfig.json tsconfig.server.json tsconfig.node.json vite.config.ts index.html ./
+COPY tsconfig.json tsconfig.server.json tsconfig.node.json vite.config.ts index.html embed.html ./
 COPY src ./src
 COPY public ./public
 


### PR DESCRIPTION
## Summary

- The embed maps feature (#2055) added `embed.html` as a Vite multi-page entry point but only updated the main `Dockerfile`, not `Dockerfile.armv7`
- This caused the armv7 Docker build to fail in the v3.7.3 release pipeline with `Could not resolve entry module "embed.html"`

## Test plan

- [ ] armv7 Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)