### PR TITLE
fix: use --entrypoint in Docker smoke tests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -190,7 +190,7 @@ jobs:
 
           FAILED=0
           for FILE in "${FILES[@]}"; do
-            SIZE=$(docker run --rm --platform "$PLATFORM" "$IMAGE" stat -c%s "$FILE" 2>/dev/null || echo "MISSING")
+            SIZE=$(docker run --rm --entrypoint stat --platform "$PLATFORM" "$IMAGE" -c%s "$FILE" 2>/dev/null || echo "MISSING")
             if [ "$SIZE" = "MISSING" ]; then
               echo "FAIL: $FILE is missing"
               FAILED=1
@@ -203,7 +203,7 @@ jobs:
           done
 
           # Verify node binary runs
-          NODE_VERSION=$(docker run --rm --platform "$PLATFORM" "$IMAGE" node --version 2>/dev/null || echo "FAILED")
+          NODE_VERSION=$(docker run --rm --entrypoint node --platform "$PLATFORM" "$IMAGE" --version 2>/dev/null || echo "FAILED")
           if [[ "$NODE_VERSION" == v* ]]; then
             echo "  OK: node $NODE_VERSION"
           else


### PR DESCRIPTION
## Summary

- The Docker smoke test runs `stat` and `node --version` inside the container, but the entrypoint script (`docker-entrypoint.sh`) runs first, outputting deployment/setup text that prevents capturing the actual command output
- This causes `node --version` to return the entrypoint output instead of a version string, failing the `v*` check
- Fix: use `--entrypoint stat` and `--entrypoint node` to bypass the container entrypoint

This was blocking the `create-manifest` step in the v3.7.3 Docker release, which prevented the final `3.7.3` and `latest` tags from being created.

## Test plan

- [ ] Docker Build workflow smoke tests pass on all 3 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)