### PR TITLE
docs: fix embed maps URL examples to match actual route

### DIFF
--- a/docs/features/embed-maps.md
+++ b/docs/features/embed-maps.md
@@ -83,23 +83,24 @@ After saving a profile, click the **Copy Embed Code** button to copy a ready-to-
 
 ```html
 <iframe
-  src="https://your-meshmonitor.example.com/meshmonitor/embed/PROFILE_ID/embed.html"
+  src="https://your-meshmonitor.example.com/embed/PROFILE_ID"
   width="800"
   height="600"
-  style="border: none;"
-  allow="geolocation"
+  frameborder="0"
+  style="border:0"
+  allowfullscreen
 ></iframe>
 ```
 
-Replace the URL with your actual MeshMonitor URL and the profile ID. Adjust `width` and `height` to fit your site layout — the map is fully responsive and fills the iframe.
+Replace the URL with your actual MeshMonitor URL and the profile ID. If you have a `BASE_URL` configured (e.g., `/meshmonitor`), include it before `/embed/` (e.g., `.../meshmonitor/embed/PROFILE_ID`). Adjust `width` and `height` to fit your site layout — the map is fully responsive and fills the iframe.
 
 ::: tip Responsive Sizing
 For a responsive embed, use percentage-based or viewport-based sizing:
 ```html
 <iframe
-  src="https://your-meshmonitor.example.com/meshmonitor/embed/PROFILE_ID/embed.html"
+  src="https://your-meshmonitor.example.com/embed/PROFILE_ID"
   style="border: none; width: 100%; height: 500px;"
-  allow="geolocation"
+  allowfullscreen
 ></iframe>
 ```
 :::


### PR DESCRIPTION
## Summary
- Fixed incorrect embed URL examples in `docs/features/embed-maps.md` that showed `/embed/PROFILE_ID/embed.html` instead of the actual route `/embed/PROFILE_ID`
- Updated iframe attributes to match the actual generated embed code
- Added note about `BASE_URL` configuration for users with non-root deployments

Related to #2070 — user was getting "Embed profile not found" which may have been caused by following the incorrect URL in documentation.

## Test plan
- [ ] Verify the URLs in the documentation match the actual embed route pattern in `embedPublicRoutes.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)