### PR TITLE
fix: exclude design plans from published docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -170,6 +170,7 @@ export default defineConfig({
     '**/database/**',
     '**/api/**',
     '**/planning/**',
+    '**/plans/**',
     '**/operations/**',
     // Internal development documentation (available on GitHub)
     'ARCHITECTURE_LESSONS.md',


### PR DESCRIPTION
## Summary
- Adds `**/plans/**` to the VitePress `srcExclude` list so internal design plan documents in `docs/plans/` are not published on the website
- Plans remain accessible in the GitHub repo for developer reference

## Test plan
- [ ] Verify the docs site builds without errors
- [ ] Confirm plan files no longer appear in the published site
- [ ] Confirm existing documentation pages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)