### PR TITLE
fix: allow any origin when embed allowedOrigins is blank

### DIFF
--- a/docs/features/embed-maps.md
+++ b/docs/features/embed-maps.md
@@ -75,7 +75,7 @@ A list of domains permitted to embed this map. This controls the CSP `frame-ance
 - `https://*.example.com` — allow all subdomains
 - `*` — allow any origin (not recommended for production)
 
-If no origins are specified, only the MeshMonitor host itself (`'self'`) can embed the map.
+If no origins are specified, any site can embed the map. For production deployments, it is recommended to restrict this to specific trusted domains.
 
 ## Embedding on Your Website
 

--- a/src/server/middleware/embedMiddleware.test.ts
+++ b/src/server/middleware/embedMiddleware.test.ts
@@ -119,7 +119,7 @@ describe('Embed CSP Middleware', () => {
     expect(csp).toContain("worker-src 'self' blob:");
   });
 
-  it('handles profile with empty allowedOrigins', async () => {
+  it('handles profile with empty allowedOrigins by allowing any origin', async () => {
     mockDb.getEmbedProfileByIdAsync.mockResolvedValue({ ...sampleProfile, allowedOrigins: [] });
     const app = createApp();
 
@@ -127,8 +127,7 @@ describe('Embed CSP Middleware', () => {
 
     expect(response.status).toBe(200);
     const csp = response.headers['content-security-policy'];
-    expect(csp).toContain("frame-ancestors 'self'");
-    // Should NOT contain extra origins
+    expect(csp).toContain('frame-ancestors *');
     expect(csp).not.toContain('https://example.com');
   });
 

--- a/src/server/middleware/embedMiddleware.ts
+++ b/src/server/middleware/embedMiddleware.ts
@@ -35,7 +35,10 @@ export function createEmbedCspMiddleware() {
       res.removeHeader('X-Frame-Options');
 
       // Build frame-ancestors directive
-      const frameAncestors = ['\'self\'', ...profile.allowedOrigins].join(' ');
+      // Empty allowedOrigins means allow any origin (wildcard)
+      const frameAncestors = profile.allowedOrigins.length === 0
+        ? '*'
+        : ['\'self\'', ...profile.allowedOrigins].join(' ');
 
       // Build a minimal embed-specific CSP
       const cspDirectives = [


### PR DESCRIPTION
## Summary
- The embed settings UI says **"Leave blank to allow any origin"** but the middleware was setting CSP `frame-ancestors` to `'self'` only — blocking all external iframe embedding (reported in #2070)
- Fix the middleware to use `frame-ancestors *` when `allowedOrigins` is empty, matching the UI text
- Update docs to reflect that blank means "allow any origin" with a recommendation to restrict for production

## Changes
- **`src/server/middleware/embedMiddleware.ts`** — Use `*` wildcard when `allowedOrigins` is empty instead of `'self'`
- **`src/server/middleware/embedMiddleware.test.ts`** — Update test to expect `frame-ancestors *` for empty origins
- **`docs/features/embed-maps.md`** — Update Allowed Origins docs to match new behavior

## Test plan
- [x] Embed middleware unit tests pass (8/8)
- [ ] Verify embed works in iframe from external origin with blank allowedOrigins
- [ ] Verify embed is restricted when specific origins are configured

Closes #2070

🤖 Generated with [Claude Code](https://claude.com/claude-code)