### PR TITLE
chore: bump version to 3.7.4

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.7.3
-appVersion: "3.7.3"
+version: 3.7.4
+appVersion: "3.7.4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.7.3",
+      "version": "3.7.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump version to 3.7.4 in package.json, package-lock.json, Helm Chart, and Tauri config

## Changes since v3.7.3
- #2075 fix: allow any origin when embed allowedOrigins is blank
- #2074 fix: exclude design plans from published docs
- #2072 docs: fix embed maps URL examples to match actual route
- #2071 fix: prevent stale position broadcasts from overwriting fixed position
- #2068 fix: use --entrypoint in Docker smoke tests
- #2067 fix: add embed.html to armv7 Dockerfile

## Test plan
- [x] Full test suite passes (2701 passed, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)