### PR TITLE
fix: allow commas in embed allowed origins input

### DIFF
--- a/src/components/settings/EmbedSettings.css
+++ b/src/components/settings/EmbedSettings.css
@@ -145,6 +145,34 @@
   line-height: 1.5;
 }
 
+/* Origin validation tags */
+.embed-origins-validation {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin-top: 0.5rem;
+}
+
+.embed-origin-tag {
+  display: inline-block;
+  font-size: 0.8rem;
+  font-family: monospace;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+}
+
+.embed-origin-tag.valid {
+  background: color-mix(in srgb, var(--ctp-green) 15%, transparent);
+  border: 1px solid var(--ctp-green);
+  color: var(--ctp-green);
+}
+
+.embed-origin-tag.invalid {
+  background: color-mix(in srgb, var(--ctp-red) 15%, transparent);
+  border: 1px solid var(--ctp-red);
+  color: var(--ctp-red);
+}
+
 /* Embed code textarea */
 .embed-code-textarea {
   width: 100%;

--- a/src/server/routes/embedProfileRoutes.test.ts
+++ b/src/server/routes/embedProfileRoutes.test.ts
@@ -221,6 +221,36 @@ describe('Embed Profile Admin Routes', () => {
       );
     });
 
+    it('accepts CSP wildcard origins like https://*.example.com', async () => {
+      mockDb.createEmbedProfileAsync.mockResolvedValue(sampleProfile);
+      const app = createApp();
+
+      await request(app)
+        .post('/api/embed-profiles')
+        .send({ name: 'Wildcard', allowedOrigins: ['https://*.example.com', 'http://*.test.org:8080'] });
+
+      expect(mockDb.createEmbedProfileAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedOrigins: ['https://*.example.com', 'http://*.test.org:8080'],
+        })
+      );
+    });
+
+    it('rejects invalid wildcard origins', async () => {
+      mockDb.createEmbedProfileAsync.mockResolvedValue(sampleProfile);
+      const app = createApp();
+
+      await request(app)
+        .post('/api/embed-profiles')
+        .send({ name: 'Bad Wildcard', allowedOrigins: ['https://*', 'https://*.', 'ftp://*.example.com'] });
+
+      expect(mockDb.createEmbedProfileAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedOrigins: [],
+        })
+      );
+    });
+
     it('returns 500 when database fails', async () => {
       mockDb.createEmbedProfileAsync.mockRejectedValue(new Error('db failure'));
       const app = createApp();


### PR DESCRIPTION
## Summary
- The allowed origins input field was impossible to type comma-separated values into — each comma was immediately consumed by the `onChange` handler which split/trimmed/filtered on every keystroke, removing trailing commas before the user could type the next origin
- Fix by storing raw input text in a separate state variable and only parsing into an array at save time
- Add real-time validation tags below the input showing valid (green) / invalid (red) origins as the user types
- Update server-side `isValidOrigin` to accept CSP wildcard host patterns like `https://*.example.com` (previously silently rejected)

## Changes
- **`EmbedSettings.tsx`** — Deferred comma parsing to save time; added client-side `isValidOrigin` and validation tag rendering
- **`EmbedSettings.css`** — Styled validation tags with themed green/red colors
- **`embedProfileRoutes.ts`** — Extended `isValidOrigin` to support `https://*.domain.com` wildcard patterns
- **`embedProfileRoutes.test.ts`** — Added tests for wildcard acceptance and invalid wildcard rejection

## Test plan
- [x] Full test suite passes (2703/2703)
- [ ] Verify typing `https://example.com, https://other.org` works smoothly in the Allowed Origins field
- [ ] Verify wildcard origins like `https://*.example.com` show as valid (green tag)
- [ ] Verify invalid entries like `not-a-url` show as invalid (red tag)
- [ ] Verify saving a profile with wildcard origins persists them correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)