### PR TITLE
fix: sort dropdown overflow with long i18n translations

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2762,6 +2762,7 @@ body {
   cursor: pointer;
   transition: all 0.2s;
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .filter-popup-btn:hover {
@@ -3219,7 +3220,9 @@ body {
   padding: 0.4rem 0.6rem;
   border-radius: 6px;
   font-size: 0.85rem;
-  flex: 1;
+  flex: 1 1 0;
+  width: 0;
+  min-width: 0;
   cursor: pointer;
   transition: border-color 0.2s;
 }
@@ -3246,6 +3249,7 @@ body {
   align-items: center;
   justify-content: center;
   min-width: 40px;
+  flex-shrink: 0;
 }
 
 .sort-direction-btn:hover {
@@ -3869,7 +3873,6 @@ body {
   .sort-dropdown {
     padding: 0.3rem 0.4rem;
     font-size: 0.75rem;
-    min-width: 0;
   }
 
   .sort-direction-btn {


### PR DESCRIPTION
## Summary
- Fixes the node list sidebar layout breaking when using languages with longer translations (e.g. Russian "Сортировка: Короткое имя" vs English "Sort: Short Name")
- The `<select>` dropdown now respects flex container bounds via `flex: 1 1 0` + `width: 0` instead of expanding to its widest option text
- Filter and sort direction buttons get `flex-shrink: 0` so they maintain size while the dropdown absorbs width pressure

Closes #2081

## Test plan
- [x] All 10 system tests pass
- [ ] Verify sidebar layout in Russian language
- [ ] Verify sidebar layout in English (no regression)
- [ ] Check at narrow sidebar widths / mobile breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)