### PR TITLE
fix: exclude MQTT-bridged nodes from auto-favourite

### DIFF
--- a/src/server/constants/autoFavorite.ts
+++ b/src/server/constants/autoFavorite.ts
@@ -18,12 +18,14 @@ interface AutoFavoriteTarget {
   hopsAway?: number | null;
   role?: number | null;
   isFavorite?: boolean | null;
+  viaMqtt?: boolean | null;
 }
 
 /**
  * Determines if a target node is eligible for auto-favoriting.
  * - Local must be ROUTER, ROUTER_LATE, or CLIENT_BASE
  * - Target must be 0-hop (hopsAway === 0)
+ * - Target must not have been received via MQTT
  * - Target must not already be favorited
  * - For ROUTER/ROUTER_LATE local: target must also be ROUTER/ROUTER_LATE/CLIENT_BASE
  * - For CLIENT_BASE local: any role is eligible
@@ -36,6 +38,9 @@ export function isAutoFavoriteEligible(
     return false;
   }
   if (target.hopsAway == null || target.hopsAway !== 0) {
+    return false;
+  }
+  if (target.viaMqtt) {
     return false;
   }
   if (target.isFavorite) {

--- a/src/server/meshtasticManager.autoFavorite.test.ts
+++ b/src/server/meshtasticManager.autoFavorite.test.ts
@@ -47,6 +47,19 @@ describe('isAutoFavoriteEligible', () => {
   it('returns true for ROUTER_LATE local with 0-hop ROUTER target', () => {
     expect(isAutoFavoriteEligible(DeviceRole.ROUTER_LATE, { hopsAway: 0, role: DeviceRole.ROUTER, isFavorite: false })).toBe(true);
   });
+
+  it('returns false for 0-hop node received via MQTT', () => {
+    expect(isAutoFavoriteEligible(DeviceRole.ROUTER, { hopsAway: 0, role: DeviceRole.ROUTER, isFavorite: false, viaMqtt: true })).toBe(false);
+  });
+
+  it('returns true for 0-hop non-MQTT node', () => {
+    expect(isAutoFavoriteEligible(DeviceRole.ROUTER, { hopsAway: 0, role: DeviceRole.ROUTER, isFavorite: false, viaMqtt: false })).toBe(true);
+  });
+
+  it('returns true when viaMqtt is null/undefined (backwards compat)', () => {
+    expect(isAutoFavoriteEligible(DeviceRole.ROUTER, { hopsAway: 0, role: DeviceRole.ROUTER, isFavorite: false, viaMqtt: null })).toBe(true);
+    expect(isAutoFavoriteEligible(DeviceRole.ROUTER, { hopsAway: 0, role: DeviceRole.ROUTER, isFavorite: false, viaMqtt: undefined })).toBe(true);
+  });
 });
 
 describe('isAutoFavoriteValidRole', () => {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -9128,6 +9128,12 @@ class MeshtasticManager {
           reason = `no longer 0-hop (hopsAway=${node.hopsAway})`;
         }
 
+        // Check if received via MQTT (not a true RF neighbor)
+        if (!shouldRemove && node.viaMqtt === true) {
+          shouldRemove = true;
+          reason = 'received via MQTT';
+        }
+
         // Check role eligibility changed (for ROUTER/ROUTER_LATE local)
         if (!shouldRemove && localNode) {
           if (!isAutoFavoriteEligible(localNode.role, { ...node, isFavorite: false })) {


### PR DESCRIPTION
## Summary
- Adds `viaMqtt` check to `isAutoFavoriteEligible()` so MQTT-bridged 0-hop nodes are no longer auto-favourited
- Adds explicit MQTT check in `autoFavoriteSweep()` to remove already-tracked MQTT nodes with a clear log reason
- Adds 3 test cases covering MQTT=true, MQTT=false, and null/undefined backwards compatibility

Fixes #2085

## Test plan
- [x] `npx vitest run src/server/meshtasticManager.autoFavorite.test.ts` — all 19 tests pass
- [x] `npx tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)