### PR TITLE
refactor: extract channel checkbox inline styles to CSS classes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4944,6 +4944,57 @@ body {
   border-color: var(--ctp-overlay0);
 }
 
+/* Channel Checkbox List Styles */
+.channel-checkbox-list {
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  background: var(--ctp-surface1);
+  border-radius: 4px;
+}
+
+.channel-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.channel-checkbox-row:not(:last-child) {
+  margin-bottom: 0.5rem;
+}
+
+.channel-checkbox-row input[type="checkbox"] {
+  width: auto;
+  min-width: 16px;
+  margin: 0;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.channel-checkbox-row input[type="checkbox"]:disabled {
+  cursor: not-allowed;
+}
+
+.channel-checkbox-row label {
+  cursor: pointer;
+  white-space: nowrap;
+  margin-bottom: 0;
+  font-weight: normal;
+  font-size: 0.9rem;
+}
+
+.channel-checkbox-row label.primary-channel {
+  color: var(--ctp-yellow);
+}
+
+.channel-checkbox-row label.dm-channel {
+  color: var(--ctp-sky);
+}
+
+.channel-checkbox-row input[type="checkbox"]:disabled + label {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 /* Danger Zone Styles */
 .danger-zone {
   border: 2px solid var(--ctp-red);

--- a/src/components/AutoAnnounceSection.tsx
+++ b/src/components/AutoAnnounceSection.tsx
@@ -509,23 +509,9 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
               {t('automation.auto_announce.broadcast_channel_description')}
             </span>
           </label>
-          <div style={{
-            marginTop: '0.5rem',
-            padding: '0.75rem',
-            background: 'var(--ctp-surface1)',
-            borderRadius: '4px'
-          }}>
-            {channels.map((channel, idx) => (
-              <div
-                key={channel.id}
-                style={{
-                  display: 'flex',
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  gap: '0.5rem',
-                  marginBottom: idx < channels.length - 1 ? '0.5rem' : 0
-                }}
-              >
+          <div className="channel-checkbox-list">
+            {channels.map((channel) => (
+              <div key={channel.id} className="channel-checkbox-row">
                 <input
                   type="checkbox"
                   id={`announce-channel-${channel.id}`}
@@ -538,21 +524,10 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
                     }
                   }}
                   disabled={!localEnabled}
-                  style={{
-                    width: 'auto',
-                    minWidth: '16px',
-                    margin: 0,
-                    cursor: localEnabled ? 'pointer' : 'not-allowed',
-                    flexShrink: 0
-                  }}
                 />
                 <label
                   htmlFor={`announce-channel-${channel.id}`}
-                  style={{
-                    color: channel.id === 0 ? 'var(--ctp-yellow)' : 'inherit',
-                    cursor: localEnabled ? 'pointer' : 'not-allowed',
-                    whiteSpace: 'nowrap'
-                  }}
+                  className={channel.id === 0 ? 'primary-channel' : undefined}
                 >
                   {channel.name || `Channel ${channel.id}`}
                 </label>
@@ -766,23 +741,9 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
                     {t('automation.auto_announce.nodeinfo_channels_description')}
                   </span>
                 </label>
-                <div style={{
-                  marginTop: '0.5rem',
-                  padding: '0.75rem',
-                  background: 'var(--ctp-surface1)',
-                  borderRadius: '4px'
-                }}>
-                  {channels.map((channel, idx) => (
-                    <div
-                      key={channel.id}
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'row',
-                        alignItems: 'center',
-                        gap: '0.5rem',
-                        marginBottom: idx < channels.length - 1 ? '0.5rem' : 0
-                      }}
-                    >
+                <div className="channel-checkbox-list">
+                  {channels.map((channel) => (
+                    <div key={channel.id} className="channel-checkbox-row">
                       <input
                         type="checkbox"
                         id={`nodeinfo-channel-${channel.id}`}
@@ -795,21 +756,10 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
                           }
                         }}
                         disabled={!localEnabled}
-                        style={{
-                          width: 'auto',
-                          minWidth: '16px',
-                          margin: 0,
-                          cursor: localEnabled ? 'pointer' : 'not-allowed',
-                          flexShrink: 0
-                        }}
                       />
                       <label
                         htmlFor={`nodeinfo-channel-${channel.id}`}
-                        style={{
-                          color: channel.id === 0 ? 'var(--ctp-yellow)' : 'inherit',
-                          cursor: localEnabled ? 'pointer' : 'not-allowed',
-                          whiteSpace: 'nowrap'
-                        }}
+                        className={channel.id === 0 ? 'primary-channel' : undefined}
                       >
                         {channel.name || `Channel ${channel.id}`}
                         {channel.id === 0 && ' (Primary)'}

--- a/src/components/AutoResponderSection.tsx
+++ b/src/components/AutoResponderSection.tsx
@@ -1341,14 +1341,8 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
             <label style={{ fontSize: '0.85rem', fontWeight: 'bold', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem', display: 'block' }}>
               Channels:
             </label>
-            <div style={{
-              marginTop: '0.25rem',
-              padding: '0.5rem',
-              background: 'var(--ctp-surface1)',
-              borderRadius: '4px',
-              maxWidth: '400px'
-            }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.4rem' }}>
+            <div className="channel-checkbox-list" style={{ marginTop: '0.25rem' }}>
+              <div className="channel-checkbox-row">
                 <input
                   type="checkbox"
                   id="new-trigger-channel-dm"
@@ -1362,14 +1356,13 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                     }
                   }}
                   disabled={!localEnabled}
-                  style={{ width: 'auto', minWidth: '16px', margin: 0, cursor: localEnabled ? 'pointer' : 'not-allowed', flexShrink: 0 }}
                 />
-                <label htmlFor="new-trigger-channel-dm" style={{ cursor: localEnabled ? 'pointer' : 'not-allowed', color: 'var(--ctp-sky)' }}>
+                <label htmlFor="new-trigger-channel-dm" className="dm-channel">
                   {t('auto_responder.direct_messages')}
                 </label>
               </div>
-              {channels.map((channel, idx) => (
-                <div key={channel.id} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: idx < channels.length - 1 ? '0.4rem' : 0 }}>
+              {channels.map((channel) => (
+                <div key={channel.id} className="channel-checkbox-row">
                   <input
                     type="checkbox"
                     id={`new-trigger-channel-${channel.id}`}
@@ -1382,9 +1375,11 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                       }
                     }}
                     disabled={!localEnabled}
-                    style={{ width: 'auto', minWidth: '16px', margin: 0, cursor: localEnabled ? 'pointer' : 'not-allowed', flexShrink: 0 }}
                   />
-                  <label htmlFor={`new-trigger-channel-${channel.id}`} style={{ cursor: localEnabled ? 'pointer' : 'not-allowed', color: channel.id === 0 ? 'var(--ctp-yellow)' : 'inherit' }}>
+                  <label
+                    htmlFor={`new-trigger-channel-${channel.id}`}
+                    className={channel.id === 0 ? 'primary-channel' : undefined}
+                  >
                     Channel {channel.id}: {channel.name}
                   </label>
                 </div>

--- a/src/components/auto-responder/TriggerItem.tsx
+++ b/src/components/auto-responder/TriggerItem.tsx
@@ -274,9 +274,9 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
             )}
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.5rem' }}>
               <label style={{ minWidth: '80px', fontSize: '0.9rem', fontWeight: 'bold' }}>Channels:</label>
-              <div style={{ flex: '1', padding: '0.5rem', background: 'var(--ctp-surface1)', borderRadius: '4px' }}>
+              <div className="channel-checkbox-list" style={{ flex: 1 }}>
                 {editResponseType === 'script' && (
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.4rem' }}>
+                  <div className="channel-checkbox-row">
                     <input
                       type="checkbox"
                       id={`edit-channel-none-${trigger.id}`}
@@ -290,14 +290,13 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                           setEditChannels(['dm']);
                         }
                       }}
-                      style={{ width: 'auto', minWidth: '16px', margin: 0, cursor: 'pointer', flexShrink: 0 }}
                     />
-                    <label htmlFor={`edit-channel-none-${trigger.id}`} style={{ cursor: 'pointer', color: 'var(--ctp-subtext0)' }}>
+                    <label htmlFor={`edit-channel-none-${trigger.id}`} style={{ color: 'var(--ctp-subtext0)' }}>
                       {t('auto_responder.channel_none', 'None (no mesh output)')}
                     </label>
                   </div>
                 )}
-                <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.4rem' }}>
+                <div className="channel-checkbox-row">
                   <input
                     type="checkbox"
                     id={`edit-channel-dm-${trigger.id}`}
@@ -311,14 +310,13 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                         setEditVerifyResponse(false);
                       }
                     }}
-                    style={{ width: 'auto', minWidth: '16px', margin: 0, cursor: editChannels.includes('none') ? 'not-allowed' : 'pointer', flexShrink: 0 }}
                   />
-                  <label htmlFor={`edit-channel-dm-${trigger.id}`} style={{ cursor: editChannels.includes('none') ? 'not-allowed' : 'pointer', color: 'var(--ctp-sky)' }}>
+                  <label htmlFor={`edit-channel-dm-${trigger.id}`} className="dm-channel">
                     Direct Messages
                   </label>
                 </div>
-                {channels.map((channel, idx) => (
-                  <div key={channel.id} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: idx < channels.length - 1 ? '0.4rem' : 0 }}>
+                {channels.map((channel) => (
+                  <div key={channel.id} className="channel-checkbox-row">
                     <input
                       type="checkbox"
                       id={`edit-channel-${channel.id}-${trigger.id}`}
@@ -331,9 +329,11 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                           setEditChannels(editChannels.filter(ch => ch !== channel.id));
                         }
                       }}
-                      style={{ width: 'auto', minWidth: '16px', margin: 0, cursor: editChannels.includes('none') ? 'not-allowed' : 'pointer', flexShrink: 0 }}
                     />
-                    <label htmlFor={`edit-channel-${channel.id}-${trigger.id}`} style={{ cursor: editChannels.includes('none') ? 'not-allowed' : 'pointer', color: channel.id === 0 ? 'var(--ctp-yellow)' : 'inherit' }}>
+                    <label
+                      htmlFor={`edit-channel-${channel.id}-${trigger.id}`}
+                      className={channel.id === 0 ? 'primary-channel' : undefined}
+                    >
                       Channel {channel.id}: {channel.name}
                     </label>
                   </div>


### PR DESCRIPTION
## Summary
- Add reusable `.channel-checkbox-list` and `.channel-checkbox-row` CSS classes to `App.css` for the multi-channel checkbox UI pattern introduced in #2078
- Replace inline `style={{...}}` props with CSS classes across `AutoAnnounceSection`, `AutoResponderSection`, and `TriggerItem`
- Normalize inconsistent spacing (padding `0.5rem` vs `0.75rem`, gap `0.4rem` vs `0.5rem`) to consistent values
- Add proper disabled-state styling (cursor, opacity) via CSS selectors instead of conditional inline styles

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 2733 tests passed
- [ ] Visual: verify channel checkboxes in Auto Announce (broadcast + nodeinfo sections)
- [ ] Visual: verify channel checkboxes in Auto Responder add-trigger form
- [ ] Visual: verify channel checkboxes in TriggerItem edit mode
- [ ] Verify disabled state styling when automation is toggled off

🤖 Generated with [Claude Code](https://claude.com/claude-code)