### PR TITLE
fix: stop system tests from rebuilding Docker image redundantly

### DIFF
--- a/tests/test-config-import.sh
+++ b/tests/test-config-import.sh
@@ -72,9 +72,7 @@ echo "Creating test docker-compose.yml..."
 cat > "$COMPOSE_FILE" <<'EOF'
 services:
   meshmonitor:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: meshmonitor:test
     container_name: meshmonitor-config-import-test
     ports:
       - "8084:3001"
@@ -91,13 +89,7 @@ EOF
 echo -e "${GREEN}✓${NC} Test config created"
 echo ""
 
-# Build and start
-echo "Building container..."
-docker compose -f "$COMPOSE_FILE" build --quiet
-
-echo -e "${GREEN}✓${NC} Build complete"
-echo ""
-
+# Start container
 echo "Starting container..."
 docker compose -f "$COMPOSE_FILE" up -d
 

--- a/tests/test-quick-start.sh
+++ b/tests/test-quick-start.sh
@@ -73,9 +73,7 @@ else
     cat > "$COMPOSE_FILE" <<EOF
 services:
   meshmonitor:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: meshmonitor:test
     container_name: meshmonitor-quick-start-test
     ports:
       - "8083:3001"
@@ -92,13 +90,7 @@ EOF
     echo -e "${GREEN}✓${NC} Test config created"
     echo ""
 
-    # Build and start
-    echo "Building container..."
-    docker compose -f "$COMPOSE_FILE" build --no-cache --quiet
-
-    echo -e "${GREEN}✓${NC} Build complete"
-    echo ""
-
+    # Start container
     echo "Starting container..."
     docker compose -f "$COMPOSE_FILE" up -d
 

--- a/tests/test-reverse-proxy-oidc.sh
+++ b/tests/test-reverse-proxy-oidc.sh
@@ -71,9 +71,7 @@ services:
       retries: 5
 
   meshmonitor:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: meshmonitor:test
     container_name: meshmonitor-oidc-test
     ports:
       - "8080:3001"
@@ -115,13 +113,6 @@ echo "Building mock OIDC provider..."
 docker compose -f "$COMPOSE_FILE" build mock-oidc --quiet
 
 echo -e "${GREEN}✓${NC} Mock OIDC build complete"
-echo ""
-
-# Build MeshMonitor
-echo "Building MeshMonitor container..."
-docker compose -f "$COMPOSE_FILE" build meshmonitor --quiet
-
-echo -e "${GREEN}✓${NC} MeshMonitor build complete"
 echo ""
 
 # Start services

--- a/tests/test-reverse-proxy.sh
+++ b/tests/test-reverse-proxy.sh
@@ -78,9 +78,7 @@ else
     cat > "$COMPOSE_FILE" <<'EOF'
 services:
   meshmonitor:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: meshmonitor:test
     container_name: meshmonitor-reverse-proxy-test
     ports:
       - "8080:3001"
@@ -104,13 +102,7 @@ EOF
     echo -e "${GREEN}✓${NC} Test config created"
     echo ""
 
-    # Build and start
-    echo "Building container..."
-    docker compose -f "$COMPOSE_FILE" build --quiet
-
-    echo -e "${GREEN}✓${NC} Build complete"
-    echo ""
-
+    # Start container
     echo "Starting container..."
     docker compose -f "$COMPOSE_FILE" up -d
 

--- a/tests/test-virtual-node-cli.sh
+++ b/tests/test-virtual-node-cli.sh
@@ -46,9 +46,7 @@ echo "Creating test docker-compose.yml with Virtual Node Server..."
 cat > "$COMPOSE_FILE" <<'EOF'
 services:
   meshmonitor:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: meshmonitor:test
     container_name: meshmonitor-virtual-node-cli-test
     ports:
       - "8086:3001"
@@ -68,13 +66,7 @@ EOF
 echo -e "${GREEN}✓${NC} Test config created"
 echo ""
 
-# Build and start
-echo "Building container..."
-docker compose -f "$COMPOSE_FILE" build --no-cache --quiet
-
-echo -e "${GREEN}✓${NC} Build complete"
-echo ""
-
+# Start container
 echo "Starting container..."
 docker compose -f "$COMPOSE_FILE" up -d
 


### PR DESCRIPTION
## Summary
- Switch 5 test scripts from `build: context: .` to `image: meshmonitor:test` in their compose templates, eliminating redundant Docker image rebuilds
- The bootstrap step in `system-tests.sh` already builds a fresh `meshmonitor:test` image with `--no-cache`; individual tests were rebuilding the same image unnecessarily, wasting time and risking BuildKit npm cache corruption
- Aligns these 5 tests with the pattern already used by `test-backup-restore.sh`, `test-db-migration.sh`, and `test-database-backing.sh`

### Files changed
| Test script | Build command removed |
|---|---|
| `test-quick-start.sh` | `docker compose build --no-cache --quiet` |
| `test-virtual-node-cli.sh` | `docker compose build --no-cache --quiet` |
| `test-config-import.sh` | `docker compose build --quiet` |
| `test-reverse-proxy.sh` | `docker compose build --quiet` |
| `test-reverse-proxy-oidc.sh` | `docker compose build meshmonitor --quiet` |

The mock-oidc build in `test-reverse-proxy-oidc.sh` is preserved since it has its own Dockerfile in `tests/mock-oidc/`.

## Test plan
- [x] Run `tests/system-tests.sh` — 9/10 tests pass
- [x] Confirm no `docker compose build` or `docker build` calls for meshmonitor after bootstrap (only mock-oidc builds)
- [x] Virtual Node CLI failure is pre-existing timing issue (admin user creation timeout), unrelated to this change

<details>
<summary>System test results</summary>

```
Configuration Import:     ✓ PASSED
Quick Start Test:         ✓ PASSED
Security Test:            ✓ PASSED
V1 API Test:              ✓ PASSED
Reverse Proxy Test:       ✓ PASSED
Reverse Proxy + OIDC:     ✓ PASSED
Virtual Node CLI Test:    ✗ FAILED (pre-existing timing issue)
Backup & Restore Test:    ✓ PASSED
Database Migration Test:  ✓ PASSED
DB Backing Consistency:   ✓ PASSED
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)