### PR TITLE
fix: accept new nodeNum on reboot and fix isLocked desync

### DIFF
--- a/src/server/meshtasticManager.test.ts
+++ b/src/server/meshtasticManager.test.ts
@@ -992,6 +992,108 @@ describe('MeshtasticManager - Configuration Polling', () => {
     });
   });
 
+  describe('Local node name update from NodeInfo (isLocked bypass)', () => {
+    // Simulates the localNodeInfo update logic in processNodeInfoProtobuf
+    function simulateNodeInfoUpdate(
+      localNodeInfo: { nodeNum: number; longName: string | null; shortName: string | null; isLocked: boolean },
+      nodeInfo: { num: number; user?: { longName?: string; shortName?: string } }
+    ) {
+      // This mirrors the fixed logic in processNodeInfoProtobuf:
+      // Always update localNodeInfo from NodeInfo regardless of isLocked,
+      // because NodeInfo is the authoritative source for names.
+      if (localNodeInfo && localNodeInfo.nodeNum === Number(nodeInfo.num)) {
+        if (nodeInfo.user && nodeInfo.user.longName && nodeInfo.user.shortName) {
+          localNodeInfo.longName = nodeInfo.user.longName;
+          localNodeInfo.shortName = nodeInfo.user.shortName;
+          localNodeInfo.isLocked = true;
+        }
+      }
+      return localNodeInfo;
+    }
+
+    it('should update local node name from NodeInfo even when isLocked is true', () => {
+      // Scenario: name changed outside MeshMonitor (e.g., via Meshtastic app)
+      const localNodeInfo = {
+        nodeNum: 1000,
+        longName: 'Old Name',
+        shortName: 'OLD',
+        isLocked: true,  // Already locked from initial connection
+      };
+
+      const nodeInfo = {
+        num: 1000,
+        user: { longName: 'New Name', shortName: 'NEW' },
+      };
+
+      const result = simulateNodeInfoUpdate(localNodeInfo, nodeInfo);
+
+      expect(result.longName).toBe('New Name');
+      expect(result.shortName).toBe('NEW');
+      expect(result.isLocked).toBe(true);
+    });
+
+    it('should update local node name on initial config when isLocked was set by processMyNodeInfo', () => {
+      // Scenario: fresh start, processMyNodeInfo locked with DB name,
+      // then NodeInfo arrives with the device's current name
+      const localNodeInfo = {
+        nodeNum: 1000,
+        longName: 'DB Cached Name',
+        shortName: 'DB',
+        isLocked: true,  // Locked by processMyNodeInfo from DB data
+      };
+
+      const nodeInfo = {
+        num: 1000,
+        user: { longName: 'Device Current Name', shortName: 'DEV' },
+      };
+
+      const result = simulateNodeInfoUpdate(localNodeInfo, nodeInfo);
+
+      // Device's name should win — it's the source of truth
+      expect(result.longName).toBe('Device Current Name');
+      expect(result.shortName).toBe('DEV');
+    });
+
+    it('should not update localNodeInfo for a different node', () => {
+      const localNodeInfo = {
+        nodeNum: 1000,
+        longName: 'My Node',
+        shortName: 'MY',
+        isLocked: true,
+      };
+
+      const nodeInfo = {
+        num: 2000,  // Different node
+        user: { longName: 'Other Node', shortName: 'OTH' },
+      };
+
+      const result = simulateNodeInfoUpdate(localNodeInfo, nodeInfo);
+
+      // Should not be changed
+      expect(result.longName).toBe('My Node');
+      expect(result.shortName).toBe('MY');
+    });
+
+    it('should not update localNodeInfo when NodeInfo has no user data', () => {
+      const localNodeInfo = {
+        nodeNum: 1000,
+        longName: 'My Node',
+        shortName: 'MY',
+        isLocked: false,
+      };
+
+      const nodeInfo = {
+        num: 1000,
+        // No user data
+      };
+
+      const result = simulateNodeInfoUpdate(localNodeInfo, nodeInfo);
+
+      expect(result.longName).toBe('My Node');
+      expect(result.isLocked).toBe(false);  // Should not lock without complete info
+    });
+  });
+
   describe('Reboot-induced node ID change detection', () => {
     // Helper to simulate processMyNodeInfo logic for device_id handling
     function simulateProcessMyNodeInfo(
@@ -1018,11 +1120,13 @@ describe('MeshtasticManager - Configuration Polling', () => {
       const previousNodeId = mockDb.settings['localNodeId'] || null;
 
       let result: {
-        action: 'rejected_new_nodenum' | 'accepted_new_nodenum' | 'no_change' | 'first_connection';
+        action: 'merged_and_accepted' | 'accepted_new_nodenum' | 'no_change' | 'first_connection';
         nodeNum: number;
         nodeId: string;
         deviceIdStored?: boolean;
         initCacheCleared?: boolean;
+        oldNodeDeleted?: boolean;
+        mergedFrom?: number;
       };
 
       if (previousNodeNum && previousNodeId) {
@@ -1031,13 +1135,36 @@ describe('MeshtasticManager - Configuration Polling', () => {
           const storedDeviceId = mockDb.settings['localDeviceId'] || null;
 
           if (deviceId && storedDeviceId && deviceId === storedDeviceId) {
-            // Same device rebooted - reject new nodeNum
+            // Same device rebooted — accept new nodeNum, merge old node data, delete ghost
+            const oldNode = mockDb.nodes[prevNum] || null;
+            const newNode = mockDb.nodes[nodeNum] || null;
+
+            // Upsert new node with merged metadata
+            mockDb.nodes[nodeNum] = {
+              nodeNum: nodeNum,
+              nodeId: nodeId,
+              longName: newNode?.longName || oldNode?.longName || null,
+              shortName: newNode?.shortName || oldNode?.shortName || null,
+              hwModel: newNode?.hwModel || oldNode?.hwModel || myNodeInfo.hwModel || 0,
+              hasRemoteAdmin: true,
+              rebootCount: myNodeInfo.rebootCount,
+            };
+
+            // Delete old ghost
+            delete mockDb.nodes[prevNum];
+
+            // Update settings to new nodeNum/nodeId
+            mockDb.settings['localNodeNum'] = nodeNum.toString();
+            mockDb.settings['localNodeId'] = nodeId;
+
             result = {
-              action: 'rejected_new_nodenum',
-              nodeNum: prevNum,
-              nodeId: previousNodeId,
+              action: 'merged_and_accepted',
+              nodeNum: nodeNum,
+              nodeId: nodeId,
               deviceIdStored: false,
-              initCacheCleared: false,
+              initCacheCleared: true,
+              oldNodeDeleted: true,
+              mergedFrom: prevNum,
             };
             return result;
           } else {
@@ -1081,7 +1208,7 @@ describe('MeshtasticManager - Configuration Polling', () => {
       return result;
     }
 
-    it('should reject new nodeNum when same device_id reboots with different nodeNum', () => {
+    it('should accept and merge when same device reboots with different nodeNum', () => {
       const deviceIdBytes = new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10]);
       const deviceIdHex = Buffer.from(deviceIdBytes).toString('hex');
 
@@ -1104,15 +1231,21 @@ describe('MeshtasticManager - Configuration Polling', () => {
         deviceId: deviceIdBytes,  // Same device_id
       }, mockDb);
 
-      // Should reject the new nodeNum and keep the original
-      expect(result.action).toBe('rejected_new_nodenum');
-      expect(result.nodeNum).toBe(1555400904);  // Original preserved
-      expect(result.nodeId).toBe('!5ca874c8');   // Original preserved
-      expect(result.initCacheCleared).toBe(false);
+      // Should accept the new nodeNum and merge old node data
+      expect(result.action).toBe('merged_and_accepted');
+      expect(result.nodeNum).toBe(903529635);  // New nodeNum accepted
+      expect(result.initCacheCleared).toBe(true);
+      expect(result.oldNodeDeleted).toBe(true);
+      expect(result.mergedFrom).toBe(1555400904);
 
-      // Settings should NOT be updated with new nodeNum
-      expect(mockDb.settings.localNodeNum).toBe('1555400904');
-      expect(mockDb.settings.localNodeId).toBe('!5ca874c8');
+      // Settings should be updated to new nodeNum
+      expect(mockDb.settings.localNodeNum).toBe('903529635');
+      expect(mockDb.settings.localNodeId).toBe('!35dac4a3');
+
+      // Old ghost should be deleted, new node should have merged longName
+      expect(mockDb.nodes[1555400904]).toBeUndefined();
+      expect(mockDb.nodes[903529635]).toBeDefined();
+      expect(mockDb.nodes[903529635].longName).toBe('Test Node');
     });
 
     it('should accept new nodeNum when device_id differs (genuinely different device)', () => {
@@ -1268,7 +1401,6 @@ describe('MeshtasticManager - Configuration Polling', () => {
       const deviceIdBytes = new Uint8Array([0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89]);
       const deviceIdHex = Buffer.from(deviceIdBytes).toString('hex');
 
-      const upsertCalls: any[] = [];
       const mockDb = {
         settings: {
           localNodeNum: '1555400904',
@@ -1280,7 +1412,7 @@ describe('MeshtasticManager - Configuration Polling', () => {
         } as Record<number, any>,
       };
 
-      // First, simulate the reboot with different nodeNum
+      // Simulate the reboot with different nodeNum
       const result = simulateProcessMyNodeInfo({
         myNodeNum: 999999999,  // Firmware assigned different nodeNum
         hwModel: 31,
@@ -1288,15 +1420,21 @@ describe('MeshtasticManager - Configuration Polling', () => {
         deviceId: deviceIdBytes,
       }, mockDb);
 
-      // Should reject and keep original
-      expect(result.action).toBe('rejected_new_nodenum');
-      expect(result.nodeNum).toBe(1555400904);
+      // Should merge and accept new nodeNum
+      expect(result.action).toBe('merged_and_accepted');
+      expect(result.nodeNum).toBe(999999999);
+      expect(result.oldNodeDeleted).toBe(true);
 
-      // The new nodeNum (999999999) should NOT appear in settings
-      expect(mockDb.settings.localNodeNum).toBe('1555400904');
+      // Settings should point to new nodeNum
+      expect(mockDb.settings.localNodeNum).toBe('999999999');
 
-      // No node with nodeNum 999999999 should be created (verified by action being rejected)
-      expect(result.action).not.toBe('accepted_new_nodenum');
+      // Old node gone, new node has merged data — no duplicates
+      expect(mockDb.nodes[1555400904]).toBeUndefined();
+      expect(mockDb.nodes[999999999]).toBeDefined();
+      expect(mockDb.nodes[999999999].longName).toBe('My Node');
+
+      // Only one node should exist
+      expect(Object.keys(mockDb.nodes).length).toBe(1);
     });
   });
 });

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2875,29 +2875,71 @@ class MeshtasticManager {
 
         if (deviceId && storedDeviceId && deviceId === storedDeviceId) {
           // Same physical device rebooted with a different nodeNum.
-          // Reject the new nodeNum and keep the stored one to prevent ghost duplicates.
-          logger.info(`📱 Reboot detected for same device (device_id: ${deviceId}), keeping original nodeNum ${previousNodeId} (${prevNum}) instead of ${nodeId} (${nodeNum})`);
+          // Accept the new nodeNum, merge old node metadata into it, and delete the old ghost.
+          // The firmware is already broadcasting on the new nodeNum, so we must match it.
+          logger.info(`📱 Reboot detected for same device (device_id: ${deviceId}), accepting new nodeNum ${nodeId} (${nodeNum}) and merging from old ${previousNodeId} (${prevNum})`);
 
-          // Update rebootCount on the existing node
+          // Fetch old node data to merge
+          const oldNode = databaseService.getNode(prevNum);
+
+          // Check if new nodeNum already exists as a known mesh peer (edge case)
+          const newNode = databaseService.getNode(nodeNum);
+
+          // Upsert new node with merged metadata — new node's existing data takes priority,
+          // falls back to old node's data for missing fields
           databaseService.upsertNode({
-            nodeNum: prevNum,
-            nodeId: previousNodeId,
+            nodeNum: nodeNum,
+            nodeId: nodeId,
+            longName: newNode?.longName || oldNode?.longName || undefined,
+            shortName: newNode?.shortName || oldNode?.shortName || undefined,
+            hwModel: newNode?.hwModel || oldNode?.hwModel || myNodeInfo.hwModel || 0,
+            firmwareVersion: (newNode as any)?.firmwareVersion || (oldNode as any)?.firmwareVersion || undefined,
+            macaddr: (newNode as any)?.macaddr || (oldNode as any)?.macaddr || undefined,
+            publicKey: (newNode as any)?.publicKey || (oldNode as any)?.publicKey || undefined,
+            latitude: newNode?.latitude || oldNode?.latitude || undefined,
+            longitude: newNode?.longitude || oldNode?.longitude || undefined,
+            altitude: newNode?.altitude || oldNode?.altitude || undefined,
+            isFavorite: newNode?.isFavorite || oldNode?.isFavorite || false,
+            isIgnored: newNode?.isIgnored || oldNode?.isIgnored || false,
+            hasRemoteAdmin: true, // Local node always has admin
             rebootCount: myNodeInfo.rebootCount !== undefined ? myNodeInfo.rebootCount : undefined,
-            hasRemoteAdmin: true,
           });
 
-          // Restore localNodeInfo with the original (correct) nodeNum
-          const existingNode = databaseService.getNode(prevNum);
+          // Delete old ghost node (cascades messages, traceroutes, neighbors, telemetry)
+          databaseService.deleteNode(prevNum);
+          logger.info(`🗑️ Deleted old ghost node ${previousNodeId} (${prevNum})`);
+
+          // Update settings to new nodeNum/nodeId — localDeviceId stays the same
+          databaseService.setSetting('localNodeNum', nodeNum.toString());
+          databaseService.setSetting('localNodeId', nodeId);
+
+          // Clear init config cache to force VN clients to get fresh config with correct identity
+          this.initConfigCache = [];
+          logger.info(`📸 Cleared init config cache due to same-device reboot merge`);
+
+          // Set localNodeInfo with new nodeNum and merged metadata
+          const mergedLongName = newNode?.longName || oldNode?.longName || null;
           this.localNodeInfo = {
-            nodeNum: prevNum,
-            nodeId: previousNodeId,
-            longName: existingNode?.longName || null,
-            shortName: existingNode?.shortName || null,
-            hwModel: existingNode?.hwModel || myNodeInfo.hwModel || undefined,
-            firmwareVersion: (existingNode as any)?.firmwareVersion || null,
+            nodeNum: nodeNum,
+            nodeId: nodeId,
+            longName: mergedLongName,
+            shortName: newNode?.shortName || oldNode?.shortName || null,
+            hwModel: newNode?.hwModel || oldNode?.hwModel || myNodeInfo.hwModel || undefined,
+            firmwareVersion: (newNode as any)?.firmwareVersion || (oldNode as any)?.firmwareVersion || null,
             rebootCount: myNodeInfo.rebootCount !== undefined ? myNodeInfo.rebootCount : undefined,
-            isLocked: !!(existingNode?.longName && existingNode.longName !== 'Local Device'),
+            isLocked: !!(mergedLongName && mergedLongName !== 'Local Device'),
           } as any;
+
+          // Schedule deferred sendRemoveNode to clean up old nodeNum from physical device's NodeDB
+          const prevNumToRemove = prevNum;
+          setTimeout(async () => {
+            try {
+              await this.sendRemoveNode(prevNumToRemove);
+              logger.info(`✅ Removed old nodeNum ${previousNodeId} (${prevNumToRemove}) from device NodeDB after reboot merge`);
+            } catch (err) {
+              logger.warn(`⚠️ Could not remove old nodeNum ${previousNodeId} (${prevNumToRemove}) from device NodeDB (non-fatal):`, err);
+            }
+          }, 5000);
 
           return;
         } else {
@@ -5562,10 +5604,18 @@ class MeshtasticManager {
         };
       }
 
-      // If this is the local node, update localNodeInfo with names (only if not locked)
-      if (this.localNodeInfo && this.localNodeInfo.nodeNum === Number(nodeInfo.num) && !this.localNodeInfo.isLocked) {
-        logger.debug(`📱 Updating local node info with names from NodeInfo`);
+      // If this is the local node, always update localNodeInfo with names from NodeInfo.
+      // NodeInfo is the authoritative source for node identity — names may have been changed
+      // outside MeshMonitor (e.g., via Meshtastic app), so we must accept the device's truth
+      // regardless of isLocked state. isLocked only prevents processMyNodeInfo (which doesn't
+      // carry names) from overwriting with incomplete data.
+      if (this.localNodeInfo && this.localNodeInfo.nodeNum === Number(nodeInfo.num)) {
         if (nodeInfo.user && nodeInfo.user.longName && nodeInfo.user.shortName) {
+          const nameChanged = this.localNodeInfo.longName !== nodeInfo.user.longName ||
+            this.localNodeInfo.shortName !== nodeInfo.user.shortName;
+          if (nameChanged) {
+            logger.info(`📱 Local node name updated: "${this.localNodeInfo.longName}" → "${nodeInfo.user.longName}" (${nodeInfo.user.shortName})`);
+          }
           this.localNodeInfo.longName = nodeInfo.user.longName;
           this.localNodeInfo.shortName = nodeInfo.user.shortName;
           this.localNodeInfo.isLocked = true;  // Lock it now that we have complete info
@@ -11691,6 +11741,14 @@ class MeshtasticManager {
     if (!this.isConnected) {
       logger.debug('⚠️ Not connected, attempting to reconnect...');
       await this.connect();
+    }
+
+    // Clear isLocked so processMyNodeInfo can run (updates hwModel, rebootCount, etc.)
+    // and processNodeInfoProtobuf can update localNodeInfo with fresh names.
+    // The whole point of a manual refresh is to get fresh data from the device.
+    if (this.localNodeInfo) {
+      this.localNodeInfo.isLocked = false;
+      logger.debug('🔓 Cleared localNodeInfo lock for config refresh');
     }
 
     // Send want_config_id to trigger node to send updated info


### PR DESCRIPTION
## Summary

- **Accept new nodeNum on same-device reboot** instead of rejecting it. The old approach (from PR #2091) caused identity mismatches because the firmware was already broadcasting on the new nodeNum while MeshMonitor kept using the old one — resulting in conflicting NodeInfo packets, wrong VN client identities, and mismatched admin packets.
- **Fix isLocked desync** where node names changed outside MeshMonitor (e.g., via the Meshtastic app or after factory reset + reconfiguration) were never picked up. The `isLocked` flag on `localNodeInfo` was blocking updates from `processNodeInfoProtobuf` — the authoritative source for node identity.

## Changes

### `src/server/meshtasticManager.ts`

1. **`processMyNodeInfo` same-device-reboot branch** (~line 2876): Rewritten from "reject new nodeNum" to "accept + merge". Fetches old node data, merges metadata into the new node entry (new node's data takes priority), deletes the old ghost, updates settings, clears `initConfigCache`, and schedules a deferred `sendRemoveNode` to clean up the old nodeNum from the physical device's NodeDB.

2. **`processNodeInfoProtobuf`** (~line 5608): Removed the `!isLocked` guard so NodeInfo always updates `localNodeInfo` for the local node. NodeInfo is the device's source of truth for names — the lock should only prevent `processMyNodeInfo` (which doesn't carry names) from overwriting with incomplete data. Adds an info log when names change.

3. **`refreshNodeDatabase`** (~line 11737): Clears `isLocked` before sending `want_config_id` so `processMyNodeInfo` can also run during manual refresh to update hwModel, rebootCount, etc.

### `src/server/meshtasticManager.test.ts`

- Updated `simulateProcessMyNodeInfo` helper: new `merged_and_accepted` action replaces `rejected_new_nodenum`
- **Test 1** renamed and rewritten: verifies merge behavior (new nodeNum accepted, old ghost deleted, metadata merged)
- **Test 8** rewritten: verifies no duplicate nodes after merge (one node with merged data)
- **4 new tests** for NodeInfo name update behavior: updates when locked, updates on initial config, skips different node, skips missing user data

## Test plan

- [x] `npx vitest run` — 2771 tests passed (4 new)
- [x] Docker build succeeds
- [x] Dev container deployed and verified new code is running
- [ ] `tests/system-tests.sh` — run before merge
- [ ] Manual: Connect device, simulate reboot with new nodeNum, verify merge
- [ ] Manual: Change node name via Meshtastic app, click Reload Config, verify name updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)