### PR TITLE
docs: add Utilization Alert to user scripts gallery

### DIFF
--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -572,5 +572,30 @@
       "WebSocket-based HA state change subscription",
       "Configurable via environment variables"
     ]
+  },
+  {
+    "name": "Utilization Alert",
+    "filename": "utilization-alert.py",
+    "icon": "📊",
+    "description": "Monitors channel utilization and air TX utilization per node on a schedule. Tracks how long each metric has been over the configured limit and only alerts after a sustained period (default 5 minutes). Once alerted, suppresses repeat notifications until the metric recovers and exceeds the limit again. Supports Discord rich embeds and generic webhook POST.",
+    "language": "Python",
+    "tags": ["Monitoring", "Alerting", "Alerts", "Cron", "Health Check", "Infrastructure", "Timer Trigger", "Automation"],
+    "gistId": "9314039d5088441dffb5d00e8f9df867",
+    "exampleTrigger": "Cron-based (e.g. */5 * * * * utilization-alert)",
+    "requirements": [
+      "Python 3.6+",
+      "MM_API_TOKEN (generate from MeshMonitor UI)",
+      "MM_ALERT_WEBHOOK_URL (Discord webhook or generic POST endpoint)",
+      "Optional: MM_API_URL, MM_CHANNEL_UTIL_LIMIT, MM_AIR_TX_UTIL_LIMIT, MM_OVER_MINUTES, MM_NODE_IDS"
+    ],
+    "author": "JonBons",
+    "features": [
+      "Sustained-over-limit detection with configurable threshold",
+      "Alert suppression until metric recovers and re-exceeds",
+      "Discord rich embed support",
+      "Generic webhook POST for non-Discord endpoints",
+      "Persistent state file for cross-run tracking",
+      "Configurable per-node monitoring via MM_NODE_IDS"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- Adds the **Utilization Alert** community script by @JonBons to the user scripts gallery
- Script monitors channel utilization and air TX utilization per node on a cron schedule, alerting only after sustained over-limit periods
- Supports Discord rich embeds and generic webhook POST

Closes #2109

## Test plan
- [ ] Verify the script appears in the user scripts gallery page
- [ ] Verify the gist link resolves and code loads in the gallery viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)