### PR TITLE
feat: add bell and position broadcast buttons (#2113, #2114)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1310,6 +1310,13 @@ body {
   cursor: not-allowed;
 }
 
+.channel-action-btn {
+  min-width: 32px !important;
+  width: 32px !important;
+  padding: 0.5rem !important;
+  font-size: 0.85rem;
+}
+
 /* Responsive design */
 /* Channel Styles */
 .channels-table {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3456,6 +3456,77 @@ function App() {
     }
   };
 
+  // Send a bell character (0x07) on a channel, optionally prepended to current text
+  const handleSendBell = async (channel: number, currentText: string) => {
+    if (connectionStatus !== 'connected') return;
+
+    const bellText = currentText.trim() ? `\x07${currentText}` : '\x07';
+    setNewMessage('');
+
+    try {
+      const response = await authFetch(`${baseUrl}/api/messages/send`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: bellText, channel }),
+      });
+
+      if (response.ok) {
+        setTimeout(() => refetchPoll(), 1000);
+      } else {
+        const errorData = await response.json();
+        setError(`Failed to send bell: ${errorData.error}`);
+      }
+    } catch (err) {
+      setError(`Failed to send bell: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    }
+  };
+
+  // Send a bell character (0x07) as a direct message
+  const handleSendBellDM = async (destinationNodeId: string, currentText: string) => {
+    if (connectionStatus !== 'connected') return;
+
+    const bellText = currentText.trim() ? `\x07${currentText}` : '\x07';
+    setNewMessage('');
+
+    try {
+      const response = await authFetch(`${baseUrl}/api/messages/send`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: bellText, channel: 0, destination: destinationNodeId }),
+      });
+
+      if (response.ok) {
+        logger.debug('Bell DM sent successfully');
+      } else {
+        setError('Failed to send bell DM');
+      }
+    } catch (err) {
+      setError(`Failed to send bell DM: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    }
+  };
+
+  // Broadcast local node's position on a channel
+  const handleSendPosition = async (channel: number) => {
+    if (connectionStatus !== 'connected') return;
+
+    try {
+      const response = await authFetch(`${baseUrl}/api/position/request`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ destination: 4294967295, channel }),
+      });
+
+      if (response.ok) {
+        setTimeout(() => refetchPoll(), 1000);
+      } else {
+        const errorData = await response.json();
+        setError(`Failed to send position: ${errorData.error}`);
+      }
+    } catch (err) {
+      setError(`Failed to send position: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    }
+  };
+
   // Resend a message (for own messages)
   const handleResendMessage = async (message: MeshMessage) => {
     if (!message.text?.trim() || connectionStatus !== 'connected') {
@@ -4490,6 +4561,8 @@ function App() {
             handleSendTapback={handleSendTapback}
             handlePurgeChannelMessages={handlePurgeChannelMessages}
             handleSenderClick={handleSenderClick}
+            onSendBell={handleSendBell}
+            onSendPosition={handleSendPosition}
             shouldShowData={shouldShowData}
             getNodeName={getNodeName}
             getNodeShortName={getNodeShortName}
@@ -4545,6 +4618,7 @@ function App() {
             baseUrl={baseUrl}
             hasPermission={hasPermission}
             handleSendDirectMessage={handleSendDirectMessage}
+            onSendBell={handleSendBellDM}
             handleResendMessage={handleResendMessage}
             handleTraceroute={handleTraceroute}
             handleExchangePosition={handleExchangePosition}

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -102,6 +102,8 @@ export interface ChannelsTabProps {
   handleSendTapback: (emoji: string, message: MeshMessage) => void;
   handlePurgeChannelMessages: (channelId: number) => Promise<void>;
   handleSenderClick: (nodeId: string, event: React.MouseEvent) => void;
+  onSendBell?: (channel: number, text: string) => Promise<void>;
+  onSendPosition?: (channel: number) => Promise<void>;
 
   // Helper functions
   shouldShowData: () => boolean;
@@ -152,6 +154,8 @@ export default function ChannelsTab({
   handleSendTapback,
   handlePurgeChannelMessages,
   handleSenderClick,
+  onSendBell,
+  onSendPosition,
   shouldShowData,
   getNodeName,
   getNodeShortName,
@@ -868,6 +872,20 @@ export default function ChannelsTab({
                               {byteCountDisplay.text}
                             </div>
                           </div>
+                          <button
+                            onClick={() => { onSendBell?.(selectedChannel, newMessage); setNewMessage(''); }}
+                            className="send-btn channel-action-btn"
+                            title="Send alert bell"
+                          >
+                            🔔
+                          </button>
+                          <button
+                            onClick={() => onSendPosition?.(selectedChannel)}
+                            className="send-btn channel-action-btn"
+                            title="Send position"
+                          >
+                            📍
+                          </button>
                           <button
                             onClick={() => handleSendMessage(selectedChannel)}
                             disabled={!newMessage.trim()}

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -166,6 +166,7 @@ export interface MessagesTabProps {
 
   // Handlers
   handleSendDirectMessage: (destinationNodeId: string) => Promise<void>;
+  onSendBell?: (destination: string, text: string) => Promise<void>;
   handleResendMessage: (message: MeshMessage) => Promise<void>;
   handleTraceroute: (nodeId: string) => Promise<void>;
   handleExchangePosition: (nodeId: string, channel?: number) => Promise<void>;
@@ -243,6 +244,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   baseUrl,
   hasPermission,
   handleSendDirectMessage,
+  onSendBell,
   handleResendMessage,
   handleTraceroute,
   handleExchangePosition,
@@ -1383,6 +1385,13 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         {byteCountDisplay.text}
                       </div>
                     </div>
+                    <button
+                      onClick={() => { onSendBell?.(selectedDMNode, newMessage); setNewMessage(''); }}
+                      className="send-btn channel-action-btn"
+                      title="Send alert bell"
+                    >
+                      🔔
+                    </button>
                     <button
                       onClick={() => handleSendDirectMessage(selectedDMNode)}
                       disabled={!newMessage.trim()}

--- a/src/server/meshtasticProtobufService.ts
+++ b/src/server/meshtasticProtobufService.ts
@@ -154,13 +154,16 @@ export class MeshtasticProtobufService {
       // Encode the Position as payload
       const payload = Position.encode(positionMessage).finish();
 
+      // For broadcast (0xFFFFFFFF), don't request response or ACK — just broadcast position
+      const isBroadcast = destination === 0xFFFFFFFF;
+
       // Create the Data message with POSITION_APP portnum
       const Data = root.lookupType('meshtastic.Data');
       const dataMessage = Data.create({
         portnum: PortNum.POSITION_APP,
         payload: payload,
         dest: destination,
-        wantResponse: true, // Request position exchange from destination
+        wantResponse: !isBroadcast, // Only request position exchange for unicast
         requestId: requestId
       });
 
@@ -171,7 +174,7 @@ export class MeshtasticProtobufService {
         to: destination,
         channel: channel || 0,
         decoded: dataMessage,
-        wantAck: true, // We want to know if the message was delivered
+        wantAck: !isBroadcast, // Broadcast packets don't get ACKed
         hopLimit: 3 // Default hop limit for position exchange
       });
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2926,6 +2926,8 @@ apiRouter.post('/position/request', requirePermission('messages', 'write'), asyn
       }`
     );
 
+    const isBroadcast = destinationNum === 0xFFFFFFFF;
+
     if (localNodeInfo) {
       // Create a system message to record the position request using the actual packet ID and requestId
       const messageId = `${packetId}`;
@@ -2935,7 +2937,7 @@ apiRouter.post('/position/request', requirePermission('messages', 'write'), asyn
       const messageChannel = channel === 0 ? -1 : channel;
 
       logger.info(
-        `📍 Inserting position request system message to database: ${messageId} (channel: ${messageChannel}, packetId: ${packetId}, requestId: ${requestId})`
+        `📍 Inserting position request system message to database: ${messageId} (channel: ${messageChannel}, packetId: ${packetId}, requestId: ${requestId}, broadcast: ${isBroadcast})`
       );
       databaseService.insertMessage({
         id: messageId,
@@ -2943,10 +2945,11 @@ apiRouter.post('/position/request', requirePermission('messages', 'write'), asyn
         toNodeNum: destinationNum,
         fromNodeId: localNodeInfo.nodeId,
         toNodeId: `!${destinationNum.toString(16).padStart(8, '0')}`,
-        text: 'Position exchange requested',
+        text: isBroadcast ? 'Position broadcast sent' : 'Position exchange requested',
         channel: messageChannel,
         portnum: PortNum.TEXT_MESSAGE_APP, // Shows in DM view (DM filter requires TEXT_MESSAGE_APP)
-        requestId: requestId, // Store requestId for ACK matching
+        // Broadcast packets don't get ACKed, so omit requestId to avoid permanent pending state
+        ...(isBroadcast ? {} : { requestId: requestId }),
         timestamp: timestamp,
         rxTime: timestamp,
         createdAt: timestamp,

--- a/src/utils/linkRenderer.tsx
+++ b/src/utils/linkRenderer.tsx
@@ -11,6 +11,9 @@ const URL_REGEX = /(https?:\/\/[^\s]+)|(www\.[^\s]+)/gi;
 export function renderMessageWithLinks(text: string): React.ReactNode[] {
   if (!text) return [];
 
+  // Replace bell character (0x07) with visible indicator
+  text = text.replace(/\x07/g, '(Alert Bell) \u{1F514} ');
+
   const parts: React.ReactNode[] = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;


### PR DESCRIPTION
## Summary

- **Bell button (🔔)**: Added to both Channels and Messages (DM) pages. Sends ASCII 0x07 bell character to trigger external notifications on receiving nodes. Optionally prepends bell to typed text. Renders as "(Alert Bell) 🔔" in chat display instead of empty bubble.
- **Position button (📍)**: Added to Channels page only. Broadcasts the local node's position on the selected channel using `POST /api/position/request` with broadcast destination (`0xFFFFFFFF`).
- **Broadcast-safe position packets**: For broadcast destinations, sets `wantAck=false` and `wantResponse=false` so the radio actually transmits the packet. System message omits `requestId` to avoid permanent pending state.

<img width="840" height="651" alt="Screenshot 2026-03-03 at 12 30 45 PM" src="https://github.com/user-attachments/assets/7d5c26dc-bdc1-44f2-81c6-1626a7f9023c" />


## Files Changed

| File | Change |
|---|---|
| `src/App.tsx` | `handleSendBell`, `handleSendBellDM`, `handleSendPosition` handlers; pass to ChannelsTab/MessagesTab |
| `src/components/ChannelsTab.tsx` | 🔔 and 📍 buttons, updated props interface |
| `src/components/MessagesTab.tsx` | 🔔 button, updated props interface |
| `src/App.css` | `.channel-action-btn` sizing class |
| `src/utils/linkRenderer.tsx` | Render `\x07` bell char as "(Alert Bell) 🔔" |
| `src/server/meshtasticProtobufService.ts` | Disable wantAck/wantResponse for broadcast position |
| `src/server/server.ts` | Omit requestId for broadcast system messages |

## Test Plan

- [x] `npm run build` — no type errors
- [x] `npx vitest run` — 130 test files passed, 2775 tests passed
- [x] Manual: 🔔 on channel sends bell character, displays as "(Alert Bell) 🔔"
- [x] Manual: Type text + 🔔 sends bell prepended to text
- [x] Manual: 📍 on channel broadcasts position, shows "Position broadcast sent"
- [x] Manual: 🔔 in DM sends bell character to selected node

Closes #2113, closes #2114

🤖 Generated with [Claude Code](https://claude.com/claude-code)