### PR TITLE
fix: disable OTA firmware updates on Tauri desktop builds

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -187,7 +187,9 @@ pub fn start_backend<R: Runtime>(app: &AppHandle<R>) -> Result<Child, String> {
             } else {
                 "false"
             },
-        );
+        )
+        .env("IS_DESKTOP", "true")
+        .env("FIRMWARE_CHECK_ENABLED", "false");
 
     log_to_file(&logs_path, "Environment variables set");
     log_to_file(&logs_path, &format!("PORT: {}", config.web_port));

--- a/docs/firmware-ota-prerequisites.md
+++ b/docs/firmware-ota-prerequisites.md
@@ -18,6 +18,7 @@ Before using OTA updates, your setup must meet **all** of the following:
 | **Firmware >= 2.7.18** | The node must already be running firmware version 2.7.18 or later. Earlier versions do not support the OTA update command. |
 | **OTA bootloader installed** | A one-time USB flash of the OTA bootloader partition is required before the first OTA update. See below. |
 | **Admin access** | Only MeshMonitor administrators can initiate firmware updates. |
+| **Docker/server deployment** | OTA updates are only available when running MeshMonitor via Docker or as a standalone server. The desktop app (Windows/macOS) does not currently support OTA updates. |
 
 ### Connection Type Limitation
 

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -191,6 +191,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   const [isDocker, setIsDocker] = useState<boolean | null>(null);
   const [isRestarting, setIsRestarting] = useState(false);
   const [databaseType, setDatabaseType] = useState<'sqlite' | 'postgres' | 'mysql' | null>(null);
+  const [firmwareOtaEnabled, setFirmwareOtaEnabled] = useState(false);
   const { showToast } = useToast();
 
   // Fetch system status to determine if running in Docker
@@ -221,6 +222,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           if (data.databaseType) {
             setDatabaseType(data.databaseType);
           }
+          setFirmwareOtaEnabled(!!data.firmwareOtaEnabled);
         }
       } catch (error) {
         logger.error('Failed to fetch database type:', error);
@@ -794,7 +796,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         // Only show Database Maintenance for SQLite - it uses SQLite-specific features like VACUUM
         ...(databaseType === 'sqlite' ? [{ id: 'settings-maintenance', label: t('maintenance.title', 'Database Maintenance') }] : []),
         ...(isAdmin ? [{ id: 'settings-embed', label: t('settings.embed_maps', 'Embed Maps') }] : []),
-        ...(isAdmin ? [{ id: 'settings-firmware', label: t('firmware.title', 'Firmware Updates') }] : []),
+        ...(isAdmin && firmwareOtaEnabled ? [{ id: 'settings-firmware', label: t('firmware.title', 'Firmware Updates') }] : []),
         { id: 'settings-management', label: t('settings.settings_management') },
         { id: 'settings-danger', label: t('settings.danger_zone') },
       ]} />
@@ -1435,7 +1437,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           </div>
         )}
 
-        {isAdmin && <FirmwareUpdateSection baseUrl={baseUrl} />}
+        {isAdmin && firmwareOtaEnabled && <FirmwareUpdateSection baseUrl={baseUrl} />}
 
         <div id="settings-management" className="settings-section">
           <h3>{t('settings.settings_management')}</h3>

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -702,6 +702,7 @@ apiRouter.get('/health', (_req, res) => {
     version: packageJson.version,
     uptime: Date.now() - serverStartTime,
     databaseType: databaseService.drizzleDbType,
+    firmwareOtaEnabled: process.env.IS_DESKTOP !== 'true',
   });
 });
 


### PR DESCRIPTION
## Summary
- Sets `IS_DESKTOP=true` and `FIRMWARE_CHECK_ENABLED=false` in the Tauri launcher to identify desktop builds and suppress firmware GitHub polling
- Exposes `firmwareOtaEnabled` flag from the `/api/health` endpoint (defaults to `true` unless `IS_DESKTOP=true`)
- Gates the Firmware Updates sidebar entry and `<FirmwareUpdateSection>` component on the new flag in the frontend
- Documents the Docker/server-only requirement in the OTA prerequisites table

## Test plan
- [x] All 76 firmware tests pass (`firmwareUpdateService.test.ts` + `firmwareUpdateRoutes.test.ts`)
- [ ] Verify `/api/health` returns `firmwareOtaEnabled: true` in Docker
- [ ] Verify firmware section appears for admin users in Docker
- [ ] Verify firmware section is hidden in Tauri desktop builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)