### PR TITLE
docs: add message delivery status icon documentation (#2118)

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -647,6 +647,20 @@ Nodes may also display role badges:
 
 **Tip:** Hover over any icon to see a tooltip with more details!
 
+### What do the message delivery status icons mean?
+
+When you send a message, a status icon appears next to it showing the delivery state:
+
+| Icon | Status | Meaning |
+|------|--------|---------|
+| ⏳ | **Pending** | Message is being sent, awaiting acknowledgment |
+| ✅ | **Delivered** | Message has been transmitted to the mesh network |
+| 🔒 | **Confirmed** | Message was received by the target node (direct messages only) |
+| ⏱️ | **Timeout** | No acknowledgment received after 30 seconds |
+| ❌ | **Failed** | Message failed to send due to a routing error or max retries exceeded |
+
+**Note:** Status icons only appear on messages you send. Hover over any icon to see a tooltip with more details.
+
 ---
 
 ### The map doesn't show any nodes

--- a/docs/plans/2026-03-03-message-status-documentation-design.md
+++ b/docs/plans/2026-03-03-message-status-documentation-design.md
@@ -1,0 +1,33 @@
+# Message Status Documentation Design
+
+**Date:** 2026-03-03
+**Issue:** #2118 - Add better documentation on message statuses
+
+## Problem
+
+Message delivery status icons are unclear to users. The FAQ documents node icons but not message delivery status icons. Also, the `status-confirmed` CSS class is missing styling.
+
+## Changes
+
+### 1. Fix `status-confirmed` CSS
+
+Add missing CSS rule for `.status-confirmed` using `var(--ctp-blue)` to match the existing pattern of colored status indicators.
+
+### 2. Add Message Status Section to FAQ
+
+Add a new section to `docs/faq.md` near the existing icon documentation (~line 600) with a table documenting all 5 message delivery states:
+
+| State | Icon | Tooltip | Meaning |
+|-------|------|---------|---------|
+| Failed | ❌ | Failed to send | Routing error or max retries exceeded |
+| Confirmed | 🔒 | Received by target node | DM confirmed received by recipient |
+| Delivered | ✅ | Transmitted to mesh | Message sent to the mesh network |
+| Pending | ⏳ | Sending... | Awaiting acknowledgment (< 30s) |
+| Timeout | ⏱️ | No acknowledgment received | No response after 30 seconds |
+
+Note: Status icons only appear on messages you send.
+
+### 3. Files to Modify
+
+- `src/App.css` - Add `.status-confirmed` CSS rule
+- `docs/faq.md` - Add message delivery status section

--- a/src/App.css
+++ b/src/App.css
@@ -2523,6 +2523,12 @@ body {
   font-weight: bold;
 }
 
+.status-confirmed {
+  color: var(--ctp-blue);
+  font-size: 0.8rem;
+  font-weight: bold;
+}
+
 .status-timeout {
   color: var(--ctp-peach);
   font-size: 0.8rem;


### PR DESCRIPTION
## Summary
- Added missing `.status-confirmed` CSS rule with blue color styling to match other status indicators
- Added "What do the message delivery status icons mean?" section to the FAQ with a table documenting all 5 message states (Pending, Delivered, Confirmed, Timeout, Failed)
- Verified existing tooltips already work correctly via i18n `title` attributes

Closes #2118

## Test plan
- [x] All 2903 tests pass (134 test files)
- [ ] Verify tooltips appear on hover in browser
- [ ] Verify confirmed icon (🔒) now shows blue color
- [ ] Verify FAQ page renders the new section correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)