### PR TITLE
fix: resolve test upgrade staying pending with Invalid Date

### DIFF
--- a/scripts/upgrade-watchdog.sh
+++ b/scripts/upgrade-watchdog.sh
@@ -398,9 +398,9 @@ perform_upgrade() {
   fi
 
   trigger_data=$(cat "$TRIGGER_FILE")
-  version=$(echo "$trigger_data" | grep -o '"version":"[^"]*"' | cut -d'"' -f4)
-  backup_enabled=$(echo "$trigger_data" | grep -o '"backup":[^,}]*' | cut -d':' -f2)
-  upgrade_id=$(echo "$trigger_data" | grep -o '"upgradeId":"[^"]*"' | cut -d'"' -f4)
+  version=$(echo "$trigger_data" | grep -o '"version"[ ]*:[ ]*"[^"]*"' | sed 's/.*:.*"\(.*\)"/\1/')
+  backup_enabled=$(echo "$trigger_data" | grep -o '"backup"[ ]*:[ ]*[^,}]*' | sed 's/.*:[ ]*//')
+  upgrade_id=$(echo "$trigger_data" | grep -o '"upgradeId"[ ]*:[ ]*"[^"]*"' | sed 's/.*:.*"\(.*\)"/\1/')
 
   if [ -z "$version" ]; then
     version="latest"

--- a/src/components/configuration/AutoUpgradeTestSection.tsx
+++ b/src/components/configuration/AutoUpgradeTestSection.tsx
@@ -30,10 +30,14 @@ interface TriggerUpgradeResponse {
 interface UpgradeStatus {
   upgradeId: string;
   status: 'pending' | 'backing_up' | 'downloading' | 'restarting' | 'health_check' | 'cleanup' | 'complete' | 'failed' | 'rolling_back';
-  targetVersion: string;
-  startTime: string;
-  endTime?: string;
-  message?: string;
+  toVersion: string;
+  startedAt: string;
+  completedAt?: string;
+  error?: string;
+  fromVersion: string;
+  progress: number;
+  currentStep: string;
+  logs: string[];
 }
 
 const AutoUpgradeTestSection: React.FC<AutoUpgradeTestSectionProps> = ({ baseUrl }) => {
@@ -299,14 +303,14 @@ const AutoUpgradeTestSection: React.FC<AutoUpgradeTestSectionProps> = ({ baseUrl
               </span>
             </div>
             <div style={{ fontSize: '0.9rem', opacity: 0.9 }}>
-              <div>{t('auto_upgrade_test.target_version')}: {upgradeStatus.targetVersion}</div>
-              <div>{t('auto_upgrade_test.started')}: {new Date(upgradeStatus.startTime).toLocaleString()}</div>
-              {upgradeStatus.endTime && (
-                <div>{t('auto_upgrade_test.completed')}: {new Date(upgradeStatus.endTime).toLocaleString()}</div>
+              <div>{t('auto_upgrade_test.target_version')}: {upgradeStatus.toVersion}</div>
+              <div>{t('auto_upgrade_test.started')}: {new Date(upgradeStatus.startedAt).toLocaleString()}</div>
+              {upgradeStatus.completedAt && (
+                <div>{t('auto_upgrade_test.completed')}: {new Date(upgradeStatus.completedAt).toLocaleString()}</div>
               )}
-              {upgradeStatus.message && (
+              {upgradeStatus.error && (
                 <div style={{ marginTop: '0.5rem', fontStyle: 'italic' }}>
-                  {upgradeStatus.message}
+                  {upgradeStatus.error}
                 </div>
               )}
             </div>

--- a/src/server/services/upgradeService.ts
+++ b/src/server/services/upgradeService.ts
@@ -228,10 +228,33 @@ class UpgradeService {
         return null;
       }
 
-      const row = await databaseService.miscRepo.getUpgradeById(upgradeId);
+      let row = await databaseService.miscRepo.getUpgradeById(upgradeId);
 
       if (!row) {
         return null;
+      }
+
+      // Sync terminal states from watchdog status file if DB still shows in-progress
+      const IN_PROGRESS_STATUSES = ['pending', 'backing_up', 'downloading', 'restarting', 'health_check', 'cleanup'];
+      if (IN_PROGRESS_STATUSES.includes(row.status)) {
+        try {
+          if (fs.existsSync(UPGRADE_STATUS_FILE)) {
+            const fileStatus = fs.readFileSync(UPGRADE_STATUS_FILE, 'utf-8').trim().toLowerCase();
+            if (fileStatus === 'complete' || fileStatus === 'ready') {
+              logger.info(`🔄 Syncing upgrade ${upgradeId} status from file: ${row.status} -> complete`);
+              await databaseService.miscRepo.markUpgradeComplete(row.id);
+              const updated = await databaseService.miscRepo.getUpgradeById(upgradeId);
+              if (updated) row = updated;
+            } else if (fileStatus === 'failed') {
+              logger.info(`🔄 Syncing upgrade ${upgradeId} status from file: ${row.status} -> failed`);
+              await databaseService.miscRepo.markUpgradeFailed(row.id, 'Upgrade failed (detected from watchdog status)');
+              const updated = await databaseService.miscRepo.getUpgradeById(upgradeId);
+              if (updated) row = updated;
+            }
+          }
+        } catch (fileError) {
+          logger.debug('Could not read upgrade status file:', fileError);
+        }
       }
 
       // Safely parse logs JSON


### PR DESCRIPTION
## Summary
Fixes #2125

- **Watchdog JSON parsing**: grep patterns now handle optional whitespace in pretty-printed JSON trigger files (BusyBox-compatible `[ ]*` character classes instead of `\s`)
- **Frontend field mismatch**: `UpgradeStatus` interface updated to match backend API (`startedAt`/`completedAt`/`toVersion`/`error` instead of `startTime`/`endTime`/`targetVersion`/`message`), eliminating "Invalid Date" display
- **Per-ID status sync**: `getUpgradeStatus()` now checks the watchdog status file for terminal states (`complete`/`failed`) and syncs to DB, matching the existing pattern in `getActiveUpgrade()`

## Test plan
- [ ] Build and deploy dev container
- [ ] Navigate to Auto Upgrade test section
- [ ] Click "Test Upgrade Process"
- [ ] Verify UI shows valid dates and progresses through states
- [ ] After container restart, verify upgrade history shows "complete" with valid timestamps
- [ ] Run `npm test` — all 2911 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)