### PR TITLE
fix: normalize homoglyphs in autoresponder matching

### DIFF
--- a/src/server/meshtasticManager.autoresponder-regex.test.ts
+++ b/src/server/meshtasticManager.autoresponder-regex.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { applyHomoglyphOptimization } from '../utils/homoglyph.js';
 
 /**
  * Auto Responder Regex Parameter Matching Tests
@@ -68,27 +69,32 @@ describe('Auto Responder - Regex Parameter Matching', () => {
     trigger: string,
     message: string
   ): { matches: boolean; params?: Record<string, string> } => {
+    // Normalize both trigger and message through homoglyph mapping (Issue #2136)
+    // This ensures triggers match regardless of Cyrillic/Latin homoglyph substitution
+    const normalizedTrigger = applyHomoglyphOptimization(trigger);
+    const normalizedMessage = applyHomoglyphOptimization(message);
+
     // Extract parameters with optional regex patterns
-    const params = extractParameters(trigger);
+    const params = extractParameters(normalizedTrigger);
 
     // Build regex pattern from trigger by escaping and replacing parameters
     let pattern = '';
 
-    // Process the trigger string manually to avoid double-escaping issues
+    // Process the normalized trigger string manually to avoid double-escaping issues
     let i = 0;
     const replacements: Array<{ start: number; end: number; replacement: string }> = [];
 
-    while (i < trigger.length) {
-      if (trigger[i] === '{') {
+    while (i < normalizedTrigger.length) {
+      if (normalizedTrigger[i] === '{') {
         const startPos = i;
         let depth = 1;
         let endPos = -1;
 
         // Find the matching closing brace
-        for (let j = i + 1; j < trigger.length && depth > 0; j++) {
-          if (trigger[j] === '{') {
+        for (let j = i + 1; j < normalizedTrigger.length && depth > 0; j++) {
+          if (normalizedTrigger[j] === '{') {
             depth++;
-          } else if (trigger[j] === '}') {
+          } else if (normalizedTrigger[j] === '}') {
             depth--;
             if (depth === 0) {
               endPos = j;
@@ -117,14 +123,14 @@ describe('Auto Responder - Regex Parameter Matching', () => {
     }
 
     // Build the final pattern by replacing placeholders
-    for (let i = 0; i < trigger.length; i++) {
+    for (let i = 0; i < normalizedTrigger.length; i++) {
       const replacement = replacements.find(r => r.start === i);
       if (replacement) {
         pattern += replacement.replacement;
         i = replacement.end - 1; // -1 because loop will increment
       } else {
         // Escape special regex characters in literal parts
-        const char = trigger[i];
+        const char = normalizedTrigger[i];
         if (/[.*+?^${}()|[\]\\]/.test(char)) {
           pattern += '\\' + char;
         } else {
@@ -134,7 +140,7 @@ describe('Auto Responder - Regex Parameter Matching', () => {
     }
 
     const regex = new RegExp(`^${pattern}$`, 'i');
-    const match = message.match(regex);
+    const match = normalizedMessage.match(regex);
 
     if (match) {
       const extractedParams: Record<string, string> = {};
@@ -544,6 +550,55 @@ describe('Auto Responder - Regex Parameter Matching', () => {
       expect(result2.matches).toBe(true);
       expect(result2.matchedPattern).toBe('ask {message}');
       expect(result2.params).toEqual({ message: 'how' });
+    });
+  });
+
+  describe('Homoglyph Normalization (Issue #2136)', () => {
+    it('should match Cyrillic trigger against homoglyph-optimized message', () => {
+      // Trigger written in pure Cyrillic, but sender has homoglyphs enabled
+      // so their message went through applyHomoglyphOptimization before sending
+      const trigger = '\u041F\u0440\u0438\u0432\u0435\u0442'; // Привет (pure Cyrillic)
+      const message = applyHomoglyphOptimization(trigger); // Same word after homoglyph optimization
+      const result = testTriggerMatch(trigger, message);
+      expect(result.matches).toBe(true);
+    });
+
+    it('should match homoglyph-optimized trigger against Cyrillic message', () => {
+      // Admin wrote trigger with Latin chars, incoming message is pure Cyrillic
+      const trigger = 'Mocк\u0432a'; // "Москва" with М→M, о→o, с→c, а→a
+      const message = '\u041C\u043E\u0441\u043A\u0432\u0430'; // Москва (pure Cyrillic)
+      const result = testTriggerMatch(trigger, message);
+      expect(result.matches).toBe(true);
+    });
+
+    it('should match when both sides have mixed Cyrillic/Latin', () => {
+      const trigger = '\u041C\u043E\u0441\u043A\u0432\u0430'; // Москва (pure Cyrillic)
+      const message = 'Mocк\u0432a'; // Москва with some homoglyph replacements
+      const result = testTriggerMatch(trigger, message);
+      expect(result.matches).toBe(true);
+    });
+
+    it('should still match pure Latin triggers against Latin messages', () => {
+      const result = testTriggerMatch('hello', 'hello');
+      expect(result.matches).toBe(true);
+    });
+
+    it('should match Cyrillic trigger with parameters against homoglyph message', () => {
+      // Trigger: "погода {city}" in Cyrillic
+      const trigger = '\u043F\u043E\u0433\u043E\u0434\u0430 {city}'; // погода {city}
+      // Message: same word after homoglyph optimization + parameter value
+      const cyrillic = '\u043F\u043E\u0433\u043E\u0434\u0430'; // погода
+      const message = applyHomoglyphOptimization(cyrillic) + ' Moscow';
+      const result = testTriggerMatch(trigger, message);
+      expect(result.matches).toBe(true);
+      expect(result.params).toEqual({ city: 'Moscow' });
+    });
+
+    it('should not match completely different Cyrillic words', () => {
+      const trigger = '\u041F\u0440\u0438\u0432\u0435\u0442'; // Привет
+      const message = '\u041F\u043E\u043A\u0430'; // Пока (different word)
+      const result = testTriggerMatch(trigger, message);
+      expect(result.matches).toBe(false);
     });
   });
 });

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -8373,6 +8373,11 @@ class MeshtasticManager {
         return;
       }
 
+      // Normalize message text through homoglyph mapping so triggers match regardless of
+      // whether the sender applied homoglyph optimization (Cyrillic→Latin substitution).
+      // This ensures "Москва" and "Mocквa" both match the same trigger pattern.
+      const normalizedText = applyHomoglyphOptimization(message.text);
+
       logger.info(`🤖 Auto-responder checking message on ${isDirectMessage ? 'DM' : `channel ${message.channel}`}: "${message.text}"`);
 
       // Try to match message against triggers
@@ -8403,7 +8408,9 @@ class MeshtasticManager {
         let extractedParams: Record<string, string> = {};
 
         // Try each pattern until one matches
-        for (const patternStr of patterns) {
+        for (const origPatternStr of patterns) {
+          // Normalize trigger pattern through homoglyph mapping to match normalized message text
+          const patternStr = applyHomoglyphOptimization(origPatternStr);
           // Extract parameters with optional regex patterns from trigger pattern
           interface ParamSpec {
             name: string;
@@ -8514,7 +8521,7 @@ class MeshtasticManager {
           }
 
           const triggerRegex = new RegExp(`^${pattern}$`, 'i');
-          const triggerMatch = message.text.match(triggerRegex);
+          const triggerMatch = normalizedText.match(triggerRegex);
 
           if (triggerMatch) {
             // Extract parameters
@@ -8522,7 +8529,7 @@ class MeshtasticManager {
             params.forEach((param, index) => {
               extractedParams[param.name] = triggerMatch[index + 1];
             });
-            matchedPattern = patternStr;
+            matchedPattern = origPatternStr;
             break; // Found a match, stop trying other patterns
           }
         }


### PR DESCRIPTION
## Summary

Fixes #2136

- Normalizes both incoming message text and trigger patterns through homoglyph mapping (`applyHomoglyphOptimization`) before autoresponder pattern matching
- This ensures triggers written in Cyrillic still match when the sender has homoglyph optimization enabled (which replaces Cyrillic chars with visually identical Latin equivalents)
- Works bidirectionally: Cyrillic triggers match Latin-optimized messages, and Latin-optimized triggers match Cyrillic messages
- Added 6 new test cases covering Cyrillic↔Latin homoglyph matching scenarios

## Test plan

- [x] All 59 autoresponder regex tests pass (53 existing + 6 new)
- [x] All 11 homoglyph tests pass
- [x] All 33 auto-responder utils tests pass
- [ ] Manual test: configure a Cyrillic trigger, send a homoglyph-optimized message, verify it matches
- [ ] System tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)