### PR TITLE
fix: only show lock icon on manually-locked favorites

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1233,15 +1233,13 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                         >
                           {node.isFavorite ? '⭐' : '☆'}
                         </button>
-                        {node.isFavorite && toggleFavoriteLock && (
+                        {node.isFavorite && node.favoriteLocked && toggleFavoriteLock && (
                           <button
                             className="favorite-lock"
-                            title={node.favoriteLocked
-                              ? t('nodes.unlock_favorite', 'Unlock — let automation manage this favorite')
-                              : t('nodes.lock_favorite', 'Lock — prevent automation from changing this favorite')}
+                            title={t('nodes.unlock_favorite', 'Unlock — let automation manage this favorite')}
                             onClick={handleLockClick(node)}
                           >
-                            {node.favoriteLocked ? '🔒' : '🔓'}
+                            🔒
                           </button>
                         )}
                       </span>


### PR DESCRIPTION
## Summary

Auto-favorited nodes were displaying an unlocked padlock (🔓) in the node list, making it appear as though the lock was being set. The backend was correctly setting `favoriteLocked=false` for auto-favorites — this was purely a UI issue.

- Only show the 🔒 icon when `favoriteLocked` is `true` (manually locked)
- Auto-managed favorites now show no lock icon at all

## Test plan

- [ ] Enable auto-favorite, verify auto-favorited nodes show ⭐ with no lock icon
- [ ] Manually favorite a node, verify it shows ⭐🔒
- [ ] Unlock a manually-locked favorite via the lock button, verify lock icon disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)