### PR TITLE
docs: add better-sqlite3 rebuild troubleshooting to LXC guide

### DIFF
--- a/docs/deployment/PROXMOX_LXC_GUIDE.md
+++ b/docs/deployment/PROXMOX_LXC_GUIDE.md
@@ -522,6 +522,24 @@ ip addr show
 ip route show
 ```
 
+#### Native Module Crash on Startup
+
+If MeshMonitor fails to start after a fresh deployment with errors related to `better-sqlite3`, the pre-built native binary may not be compatible with your LXC container's platform. Rebuild it from source:
+
+```bash
+systemctl stop meshmonitor
+apt update
+apt install -y build-essential python3 make g++
+cd /opt/meshmonitor
+npm rebuild better-sqlite3 --build-from-source
+systemctl start meshmonitor
+```
+
+Verify it's running:
+```bash
+systemctl status meshmonitor --no-pager -l
+```
+
 #### Database Locked Errors
 
 **Check for stale processes**:


### PR DESCRIPTION
## Summary

- Add troubleshooting section for LXC deployments where `better-sqlite3` pre-built binary doesn't match the container's platform
- Documents the `npm rebuild better-sqlite3 --build-from-source` workaround reported by a user on a fresh 3.8.2 LXC deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)