### PR TITLE
feat: add favorite lock toggle and filter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,6 +174,9 @@ function App() {
         if (parsed.showIgnored === undefined) {
           parsed.showIgnored = false;
         }
+        if (parsed.showFavoriteLocked === undefined) {
+          parsed.showFavoriteLocked = false;
+        }
         return parsed;
       } catch (e) {
         logger.error('Failed to parse saved node filters:', e);
@@ -192,6 +195,7 @@ function App() {
       showRemoteAdmin: false,
       showUnknown: false,
       showIgnored: false,
+      showFavoriteLocked: false,
       deviceRoles: [] as number[], // Empty array means show all roles
       channels: [] as number[],
     };
@@ -3919,6 +3923,13 @@ function App() {
         return false;
       }
 
+      // Favorite locked filter
+      if (nodeFilters.showFavoriteLocked) {
+        const matches = !!node.favoriteLocked;
+        if (isShowMode && !matches) return false;
+        if (!isShowMode && matches) return false;
+      }
+
       // Device role filter
       if (nodeFilters.deviceRoles.length > 0) {
         const role = typeof node.user?.role === 'number' ? node.user.role : parseInt(node.user?.role || '0');
@@ -4696,6 +4707,7 @@ function App() {
             onFocusMessageHandled={() => setFocusMessageId(null)}
             toggleIgnored={toggleIgnored}
             toggleFavorite={toggleFavorite}
+            toggleFavoriteLock={toggleFavoriteLock}
             handleShowOnMap={(nodeId: string) => {
               const node = nodes.find(n => n.user?.id === nodeId);
               if (node?.position?.latitude != null && node?.position?.longitude != null) {

--- a/src/components/AdvancedNodeFilterPopup/AdvancedNodeFilterPopup.tsx
+++ b/src/components/AdvancedNodeFilterPopup/AdvancedNodeFilterPopup.tsx
@@ -28,6 +28,7 @@ const DEFAULT_FILTERS: NodeFilters = {
   showRemoteAdmin: false,
   showUnknown: false,
   showIgnored: false,
+  showFavoriteLocked: false,
   deviceRoles: [],
   channels: [],
 };
@@ -276,6 +277,18 @@ export const AdvancedNodeFilterPopup: React.FC<AdvancedNodeFilterPopupProps> = (
               <span className="filter-label-with-icon">
                 <span className="filter-icon">🚫</span>
                 <span>{t('node_filter.ignored', 'Show ignored nodes')}</span>
+              </span>
+            </label>
+
+            <label className="filter-checkbox">
+              <input
+                type="checkbox"
+                checked={nodeFilters.showFavoriteLocked}
+                onChange={e => onNodeFiltersChange({ ...nodeFilters, showFavoriteLocked: e.target.checked })}
+              />
+              <span className="filter-label-with-icon">
+                <span className="filter-icon">🔒</span>
+                <span>{t('node_filter.favorite_locked', 'Favorite locked')}</span>
               </span>
             </label>
           </div>

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -179,6 +179,7 @@ export interface MessagesTabProps {
   getRecentTraceroute: (nodeId: string) => TracerouteData | null;
   toggleIgnored: (node: DeviceInfo, event: React.MouseEvent) => Promise<void>;
   toggleFavorite: (node: DeviceInfo, event: React.MouseEvent) => Promise<void>;
+  toggleFavoriteLock: (node: DeviceInfo, event: React.MouseEvent) => Promise<void>;
 
   // Modal controls
   setShowTracerouteHistoryModal: (show: boolean) => void;
@@ -257,6 +258,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   getRecentTraceroute,
   toggleIgnored,
   toggleFavorite,
+  toggleFavoriteLock,
   setShowTracerouteHistoryModal,
   setShowPurgeDataModal,
   setShowPositionOverrideModal,
@@ -1103,6 +1105,15 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                               }}
                             >
                               {selectedNode.isFavorite ? `⭐ ${t('nodes.remove_favorite')}` : `☆ ${t('nodes.add_favorite')}`}
+                            </button>
+                            <button
+                              className="actions-menu-item"
+                              onClick={(e) => {
+                                toggleFavoriteLock(selectedNode, e);
+                                setShowActionsMenu(false);
+                              }}
+                            >
+                              {selectedNode.favoriteLocked ? `🔓 ${t('nodes.unlock_favorite', 'Remove Favorite Lock')}` : `🔒 ${t('nodes.lock_favorite', 'Set Favorite Lock')}`}
                             </button>
                             <button
                               className="actions-menu-item"

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -86,6 +86,7 @@ export interface NodeFilters {
   showRemoteAdmin: boolean;
   showUnknown: boolean;
   showIgnored: boolean;
+  showFavoriteLocked: boolean;
   deviceRoles: number[];
   channels: number[];
 }


### PR DESCRIPTION
## Summary
- Adds **Set Favorite Lock / Remove Favorite Lock** option to the Node Details Actions Dropdown in MessagesTab, allowing explicit management of the favorite lock state
- Adds **Favorite locked** checkbox to the Advanced Node Filter Popup on the main map page, making it easy to find nodes with locked favorites
- Includes backward compatibility for saved filter state in localStorage

## Test plan
- [ ] Open Node Details → Actions Dropdown → verify "Set Favorite Lock" / "Remove Favorite Lock" option appears
- [ ] Toggle the lock and verify the node's lock state changes
- [ ] Open Advanced Node Filter on the map → verify "Favorite locked" checkbox appears
- [ ] Enable the filter in Show mode → verify only locked-favorite nodes appear
- [ ] Enable the filter in Hide mode → verify locked-favorite nodes are hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)