### PR TITLE
fix: enable receiving incoming messages on MeshCore companion devices

### DIFF
--- a/scripts/meshcore-bridge.py
+++ b/scripts/meshcore-bridge.py
@@ -193,13 +193,13 @@ class MeshCoreBridge:
         if self.meshcore:
             try:
                 self.meshcore.stop_auto_message_fetching()
-            except Exception:
-                pass
+            except Exception as e:
+                print(json.dumps({'type': 'event', 'event_type': 'debug', 'data': {'message': f'Error stopping auto-fetch: {e}'}}), flush=True)
             for sub in self.subscriptions:
                 try:
                     self.meshcore.unsubscribe(sub)
-                except Exception:
-                    pass
+                except Exception as e:
+                    print(json.dumps({'type': 'event', 'event_type': 'debug', 'data': {'message': f'Error unsubscribing: {e}'}}), flush=True)
         self.subscriptions = []
 
     async def cmd_disconnect(self, cmd_id: str) -> dict:

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -447,7 +447,9 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
-   * Handle unsolicited events from the Python bridge (incoming messages)
+   * Handle unsolicited events from the Python bridge (incoming messages).
+   * sender_timestamp from the MeshCore protocol is Unix epoch in seconds;
+   * we convert to milliseconds for JS Date compatibility.
    */
   private handleBridgeEvent(event: { event_type: string; data: any }): void {
     const { event_type, data } = event;
@@ -466,7 +468,7 @@ class MeshCoreManager extends EventEmitter {
     } else if (event_type === 'channel_message') {
       const message: MeshCoreMessage = {
         id: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-        fromPublicKey: `channel-${data.channel_idx}`,
+        fromPublicKey: MeshCoreManager.channelPublicKey(data.channel_idx),
         text: data.text,
         timestamp: data.sender_timestamp ? data.sender_timestamp * 1000 : Date.now(),
         snr: data.snr,
@@ -477,6 +479,11 @@ class MeshCoreManager extends EventEmitter {
     } else {
       logger.debug(`[MeshCore] Unknown bridge event: ${event_type}`);
     }
+  }
+
+  /** Generate a synthetic public key identifier for channel messages */
+  private static channelPublicKey(channelIdx: number): string {
+    return `channel-${channelIdx}`;
   }
 
   // ============ Direct Serial Methods (for Repeater) ============


### PR DESCRIPTION
## Summary

- The Python bridge (`meshcore-bridge.py`) was purely request/response — it never subscribed to incoming message events from the meshcore library, so replies and broadcasts from remote nodes were silently dropped
- Subscribe to `CONTACT_MSG_RECV` and `CHANNEL_MSG_RECV` events via the meshcore Python library's event system
- Call `start_auto_message_fetching()` to automatically poll the device when `MESSAGES_WAITING` push notifications arrive
- Push incoming messages as unsolicited JSON events to Node.js over stdout
- Handle event messages in `handleBridgeResponse` → `handleBridgeEvent` on the Node.js side

Fixes #2149

## System Test Results

```
Configuration Import:     ✓ PASSED
Quick Start Test:         ✓ PASSED
Security Test:            ✓ PASSED
V1 API Test:              ✓ PASSED
Reverse Proxy Test:       ✓ PASSED
Reverse Proxy + OIDC:     ✓ PASSED
Virtual Node CLI Test:    ✓ PASSED
Backup & Restore Test:    ✓ PASSED
Database Migration Test:  ✓ PASSED
DB Backing Consistency:   ✓ PASSED
```

## Test plan

- [ ] Connect to a MeshCore Companion device
- [ ] Send a message to a remote node
- [ ] Verify the remote node's reply appears in the MeshCore messages panel
- [ ] Verify channel/broadcast messages appear
- [ ] Verify disconnect cleans up subscriptions properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)