### PR TITLE
refactor: frontend review batch 1 — shared modal, toast theming, accessibility

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -542,6 +542,26 @@ body {
   padding-bottom: env(safe-area-inset-bottom); /* Account for iPhone home indicator */
 }
 
+/* Skip to content link - hidden until focused via keyboard */
+.skip-to-content {
+  position: absolute;
+  top: -100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--ctp-blue);
+  color: var(--ctp-crust);
+  padding: 0.5rem 1rem;
+  border-radius: 0 0 8px 8px;
+  z-index: 100000;
+  text-decoration: none;
+  font-weight: 600;
+  transition: top 0.2s ease;
+}
+
+.skip-to-content:focus {
+  top: 0;
+}
+
 .app {
   min-height: 100vh;
   min-height: 100dvh; /* Use dynamic viewport height for mobile browsers */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4399,6 +4399,9 @@ function App() {
 
   return (
     <div className="app">
+      <a href="#main-content" className="skip-to-content">
+        Skip to content
+      </a>
       <AdvancedNodeFilterPopup
         isOpen={showNodeFilterPopup}
         nodeFilters={nodeFilters}
@@ -4560,7 +4563,7 @@ function App() {
         onSearchClick={() => setIsSearchOpen(true)}
       />
 
-      <main className="app-main">
+      <main id="main-content" className="app-main">
         {error && (
           <div className="error-panel">
             <h3>Connection Error</h3>

--- a/src/components/ChangePasswordModal.tsx
+++ b/src/components/ChangePasswordModal.tsx
@@ -8,6 +8,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import api from '../services/api';
 import { logger } from '../utils/logger';
+import Modal from './common/Modal';
 
 interface ChangePasswordModalProps {
   isOpen: boolean;
@@ -22,8 +23,6 @@ const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({ isOpen, onClo
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
-
-  if (!isOpen) return null;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -87,90 +86,81 @@ const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({ isOpen, onClo
   };
 
   return (
-    <div className="modal-overlay" onClick={handleClose}>
-      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-        <div className="modal-header">
-          <h2>{t('change_password.title')}</h2>
-          <button className="close-button" onClick={handleClose}>×</button>
+    <Modal isOpen={isOpen} onClose={handleClose} title={t('change_password.title')}>
+      <form onSubmit={handleSubmit}>
+        <div className="form-group">
+          <label htmlFor="current-password">{t('change_password.current_password')}</label>
+          <input
+            id="current-password"
+            type="password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            disabled={loading || success}
+            required
+            autoComplete="current-password"
+          />
         </div>
 
-        <div className="modal-body">
-          <form onSubmit={handleSubmit}>
-            <div className="form-group">
-              <label htmlFor="current-password">{t('change_password.current_password')}</label>
-              <input
-                id="current-password"
-                type="password"
-                value={currentPassword}
-                onChange={(e) => setCurrentPassword(e.target.value)}
-                disabled={loading || success}
-                required
-                autoComplete="current-password"
-              />
-            </div>
-
-            <div className="form-group">
-              <label htmlFor="new-password">{t('change_password.new_password')}</label>
-              <input
-                id="new-password"
-                type="password"
-                value={newPassword}
-                onChange={(e) => setNewPassword(e.target.value)}
-                disabled={loading || success}
-                required
-                autoComplete="new-password"
-                minLength={8}
-              />
-              <small className="form-hint">{t('change_password.min_length_hint')}</small>
-            </div>
-
-            <div className="form-group">
-              <label htmlFor="confirm-password">{t('change_password.confirm_password')}</label>
-              <input
-                id="confirm-password"
-                type="password"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                disabled={loading || success}
-                required
-                autoComplete="new-password"
-                minLength={8}
-              />
-            </div>
-
-            {error && (
-              <div className="error-message">
-                {error}
-              </div>
-            )}
-
-            {success && (
-              <div className="success-message">
-                {t('change_password.success')}
-              </div>
-            )}
-
-            <div className="modal-actions">
-              <button
-                type="button"
-                className="button button-secondary"
-                onClick={handleClose}
-                disabled={loading}
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                type="submit"
-                className="button button-primary"
-                disabled={loading || success || !currentPassword || !newPassword || !confirmPassword}
-              >
-                {loading ? t('change_password.changing') : t('change_password.title')}
-              </button>
-            </div>
-          </form>
+        <div className="form-group">
+          <label htmlFor="new-password">{t('change_password.new_password')}</label>
+          <input
+            id="new-password"
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            disabled={loading || success}
+            required
+            autoComplete="new-password"
+            minLength={8}
+          />
+          <small className="form-hint">{t('change_password.min_length_hint')}</small>
         </div>
-      </div>
-    </div>
+
+        <div className="form-group">
+          <label htmlFor="confirm-password">{t('change_password.confirm_password')}</label>
+          <input
+            id="confirm-password"
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            disabled={loading || success}
+            required
+            autoComplete="new-password"
+            minLength={8}
+          />
+        </div>
+
+        {error && (
+          <div className="error-message">
+            {error}
+          </div>
+        )}
+
+        {success && (
+          <div className="success-message">
+            {t('change_password.success')}
+          </div>
+        )}
+
+        <div className="modal-actions">
+          <button
+            type="button"
+            className="button button-secondary"
+            onClick={handleClose}
+            disabled={loading}
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="submit"
+            className="button button-primary"
+            disabled={loading || success || !currentPassword || !newPassword || !confirmPassword}
+          >
+            {loading ? t('change_password.changing') : t('change_password.title')}
+          </button>
+        </div>
+      </form>
+    </Modal>
   );
 };
 

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -743,6 +743,7 @@ export default function ChannelsTab({
                                             className="resend-button"
                                             onClick={() => handleResendMessage(msg)}
                                             title={t('channels.resend_button_title')}
+                                            aria-label={t('channels.resend_button_title')}
                                           >
                                             ↻
                                           </button>
@@ -754,6 +755,7 @@ export default function ChannelsTab({
                                               channelMessageInputRef.current?.focus();
                                             }}
                                             title={t('channels.reply_button_title')}
+                                            aria-label={t('channels.reply_button_title')}
                                           >
                                             ↩
                                           </button>
@@ -765,6 +767,7 @@ export default function ChannelsTab({
                                           className="emoji-picker-button"
                                           onClick={() => setEmojiPickerMessage(msg)}
                                           title={t('channels.emoji_button_title')}
+                                          aria-label={t('channels.emoji_button_title')}
                                         >
                                           😄
                                         </button>
@@ -773,6 +776,7 @@ export default function ChannelsTab({
                                         className="delete-button"
                                         onClick={() => handleDeleteMessage(msg)}
                                         title={t('channels.delete_button_title')}
+                                        aria-label={t('channels.delete_button_title')}
                                       >
                                         🗑️
                                       </button>
@@ -839,6 +843,7 @@ export default function ChannelsTab({
                             className="reply-indicator-close"
                             onClick={() => setReplyingTo(null)}
                             title={t('channels.cancel_reply_title')}
+                            aria-label={t('channels.cancel_reply_title')}
                           >
                             ×
                           </button>
@@ -876,6 +881,7 @@ export default function ChannelsTab({
                             onClick={() => { onSendBell?.(selectedChannel, newMessage); setNewMessage(''); }}
                             className="send-btn channel-action-btn"
                             title="Send alert bell"
+                            aria-label="Send alert bell"
                           >
                             🔔
                           </button>
@@ -883,6 +889,7 @@ export default function ChannelsTab({
                             onClick={() => onSendPosition?.(selectedChannel)}
                             className="send-btn channel-action-btn"
                             title="Send position"
+                            aria-label="Send position"
                           >
                             📍
                           </button>
@@ -927,7 +934,7 @@ export default function ChannelsTab({
               <div className="modal-content channel-info-modal" onClick={e => e.stopPropagation()}>
                 <div className="modal-header">
                   <h2>{t('channels.info_modal_title')}</h2>
-                  <button className="modal-close" onClick={handleCloseModal}>
+                  <button className="modal-close" onClick={handleCloseModal} aria-label={t('common.close')}>
                     ×
                   </button>
                 </div>
@@ -1085,7 +1092,7 @@ export default function ChannelsTab({
           <div className="modal-content channel-info-modal" onClick={e => e.stopPropagation()}>
             <div className="modal-header">
               <h2>{t('channels.virtual_channel_info_title', 'Virtual Channel Info')}</h2>
-              <button className="modal-close" onClick={() => setVirtualChannelInfoModal(null)}>
+              <button className="modal-close" onClick={() => setVirtualChannelInfoModal(null)} aria-label={t('common.close')}>
                 ×
               </button>
             </div>

--- a/src/components/CustomThemeManagement.tsx
+++ b/src/components/CustomThemeManagement.tsx
@@ -239,17 +239,17 @@ const ThemeCard: React.FC<ThemeCardProps> = ({
           </button>
 
           {canWrite && !theme.is_builtin && (
-            <button onClick={onEdit} className="btn-icon" title={t('common.edit')}>
+            <button onClick={onEdit} className="btn-icon" title={t('common.edit')} aria-label={t('common.edit')}>
               ✏️
             </button>
           )}
 
-          <button onClick={onClone} className="btn-icon" title={t('theme_management.clone')}>
+          <button onClick={onClone} className="btn-icon" title={t('theme_management.clone')} aria-label={t('theme_management.clone')}>
             📋
           </button>
 
           {canWrite && !theme.is_builtin && (
-            <button onClick={onDelete} className="btn-icon btn-danger" title={t('common.delete')}>
+            <button onClick={onDelete} className="btn-icon btn-danger" title={t('common.delete')} aria-label={t('common.delete')}>
               🗑️
             </button>
           )}

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -9,6 +9,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { logger } from '../utils/logger';
+import Modal from './common/Modal';
 
 interface LoginModalProps {
   isOpen: boolean;
@@ -51,8 +52,6 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
       setError(null);
     }
   }, [isOpen]);
-
-  if (!isOpen) return null;
 
   const handleLocalLogin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -124,40 +123,106 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-        <div className="modal-header">
-          <h2>{mfaRequired ? t('mfa.login_title') : t('auth.login')}</h2>
-          <button className="close-button" onClick={onClose}>×</button>
-        </div>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={mfaRequired ? t('mfa.login_title') : t('auth.login')}
+    >
+      {mfaRequired ? (
+        /* MFA Verification Step */
+        <form onSubmit={handleMfaSubmit}>
+          <div className="mfa-prompt" style={{ textAlign: 'center', marginBottom: '8px' }}>
+            <p style={{ color: 'var(--ctp-subtext0)', fontSize: '14px', margin: 0 }}>
+              {useBackupCode ? t('mfa.backup_code_prompt') : t('mfa.login_prompt')}
+            </p>
+          </div>
 
-        <div className="modal-body">
-          {mfaRequired ? (
-            /* MFA Verification Step */
-            <form onSubmit={handleMfaSubmit}>
-              <div className="mfa-prompt" style={{ textAlign: 'center', marginBottom: '8px' }}>
-                <p style={{ color: '#4a5568', fontSize: '14px', margin: 0 }}>
-                  {useBackupCode ? t('mfa.backup_code_prompt') : t('mfa.login_prompt')}
-                </p>
+          <div className="form-group">
+            <label htmlFor="mfa-code">
+              {useBackupCode ? t('mfa.backup_code_label') : t('mfa.code_label')}
+            </label>
+            <input
+              ref={mfaInputRef}
+              id="mfa-code"
+              type="text"
+              value={mfaCode}
+              onChange={(e) => setMfaCode(e.target.value)}
+              placeholder={useBackupCode ? t('mfa.backup_code_placeholder') : t('mfa.login_placeholder')}
+              disabled={loading}
+              required
+              autoComplete="one-time-code"
+              maxLength={useBackupCode ? 8 : 6}
+              pattern={useBackupCode ? undefined : '[0-9]{6}'}
+              inputMode={useBackupCode ? undefined : 'numeric'}
+            />
+          </div>
+
+          {error && (
+            <div className="error-message">
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className="button button-primary"
+            disabled={loading || !mfaCode}
+          >
+            {loading ? t('mfa.verifying') : t('mfa.verify_button')}
+          </button>
+
+          <div className="mfa-actions" style={{ display: 'flex', justifyContent: 'center', gap: '16px', marginTop: '8px' }}>
+            <button
+              type="button"
+              className="button-link"
+              style={{ background: 'none', border: 'none', color: 'var(--ctp-blue)', cursor: 'pointer', fontSize: '13px', textDecoration: 'underline', padding: '4px' }}
+              onClick={() => {
+                setUseBackupCode(!useBackupCode);
+                setMfaCode('');
+                setError(null);
+              }}
+            >
+              {useBackupCode ? t('mfa.use_totp_code') : t('mfa.use_backup_code')}
+            </button>
+            <button
+              type="button"
+              className="button-link"
+              style={{ background: 'none', border: 'none', color: 'var(--ctp-blue)', cursor: 'pointer', fontSize: '13px', textDecoration: 'underline', padding: '4px' }}
+              onClick={handleBackToLogin}
+            >
+              {t('mfa.back_to_login')}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <>
+          {/* Local Authentication */}
+          {!localAuthDisabled && (
+            <form onSubmit={handleLocalLogin}>
+              <div className="form-group">
+                <label htmlFor="username">{t('auth.username')}</label>
+                <input
+                  ref={usernameInputRef}
+                  id="username"
+                  type="text"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  disabled={loading}
+                  required
+                  autoComplete="username"
+                />
               </div>
 
               <div className="form-group">
-                <label htmlFor="mfa-code">
-                  {useBackupCode ? t('mfa.backup_code_label') : t('mfa.code_label')}
-                </label>
+                <label htmlFor="password">{t('auth.password')}</label>
                 <input
-                  ref={mfaInputRef}
-                  id="mfa-code"
-                  type="text"
-                  value={mfaCode}
-                  onChange={(e) => setMfaCode(e.target.value)}
-                  placeholder={useBackupCode ? t('mfa.backup_code_placeholder') : t('mfa.login_placeholder')}
+                  id="password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
                   disabled={loading}
                   required
-                  autoComplete="one-time-code"
-                  maxLength={useBackupCode ? 8 : 6}
-                  pattern={useBackupCode ? undefined : '[0-9]{6}'}
-                  inputMode={useBackupCode ? undefined : 'numeric'}
+                  autoComplete="current-password"
                 />
               </div>
 
@@ -170,120 +235,49 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
               <button
                 type="submit"
                 className="button button-primary"
-                disabled={loading || !mfaCode}
+                disabled={loading || !username || !password}
               >
-                {loading ? t('mfa.verifying') : t('mfa.verify_button')}
+                {loading ? t('auth.logging_in') : t('auth.login')}
               </button>
-
-              <div className="mfa-actions" style={{ display: 'flex', justifyContent: 'center', gap: '16px', marginTop: '8px' }}>
-                <button
-                  type="button"
-                  className="button-link"
-                  style={{ background: 'none', border: 'none', color: '#667eea', cursor: 'pointer', fontSize: '13px', textDecoration: 'underline', padding: '4px' }}
-                  onClick={() => {
-                    setUseBackupCode(!useBackupCode);
-                    setMfaCode('');
-                    setError(null);
-                  }}
-                >
-                  {useBackupCode ? t('mfa.use_totp_code') : t('mfa.use_backup_code')}
-                </button>
-                <button
-                  type="button"
-                  className="button-link"
-                  style={{ background: 'none', border: 'none', color: '#667eea', cursor: 'pointer', fontSize: '13px', textDecoration: 'underline', padding: '4px' }}
-                  onClick={handleBackToLogin}
-                >
-                  {t('mfa.back_to_login')}
-                </button>
-              </div>
             </form>
-          ) : (
+          )}
+
+          {/* Divider between auth methods */}
+          {!localAuthDisabled && oidcEnabled && (
+            <div className="login-divider">
+              <span>{t('common.or')}</span>
+            </div>
+          )}
+
+          {/* OIDC Authentication */}
+          {oidcEnabled && (
             <>
-              {/* Local Authentication */}
-              {!localAuthDisabled && (
-                <form onSubmit={handleLocalLogin}>
-                  <div className="form-group">
-                    <label htmlFor="username">{t('auth.username')}</label>
-                    <input
-                      ref={usernameInputRef}
-                      id="username"
-                      type="text"
-                      value={username}
-                      onChange={(e) => setUsername(e.target.value)}
-                      disabled={loading}
-                      required
-                      autoComplete="username"
-                    />
-                  </div>
-
-                  <div className="form-group">
-                    <label htmlFor="password">{t('auth.password')}</label>
-                    <input
-                      id="password"
-                      type="password"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      disabled={loading}
-                      required
-                      autoComplete="current-password"
-                    />
-                  </div>
-
-                  {error && (
-                    <div className="error-message">
-                      {error}
-                    </div>
-                  )}
-
-                  <button
-                    type="submit"
-                    className="button button-primary"
-                    disabled={loading || !username || !password}
-                  >
-                    {loading ? t('auth.logging_in') : t('auth.login')}
-                  </button>
-                </form>
-              )}
-
-              {/* Divider between auth methods */}
-              {!localAuthDisabled && oidcEnabled && (
-                <div className="login-divider">
-                  <span>{t('common.or')}</span>
-                </div>
-              )}
-
-              {/* OIDC Authentication */}
-              {oidcEnabled && (
-                <>
-                  {error && localAuthDisabled && (
-                    <div className="error-message">
-                      {error}
-                    </div>
-                  )}
-
-                  <button
-                    type="button"
-                    className="button button-secondary"
-                    onClick={handleOIDCLogin}
-                    disabled={loading}
-                  >
-                    {t('auth.login_with_oidc')}
-                  </button>
-                </>
-              )}
-
-              {/* Show message if only OIDC is available */}
-              {localAuthDisabled && !oidcEnabled && (
+              {error && localAuthDisabled && (
                 <div className="error-message">
-                  {t('auth.local_disabled_no_oidc')}
+                  {error}
                 </div>
               )}
+
+              <button
+                type="button"
+                className="button button-secondary"
+                onClick={handleOIDCLogin}
+                disabled={loading}
+              >
+                {t('auth.login_with_oidc')}
+              </button>
             </>
           )}
-        </div>
-      </div>
-    </div>
+
+          {/* Show message if only OIDC is available */}
+          {localAuthDisabled && !oidcEnabled && (
+            <div className="error-message">
+              {t('auth.local_disabled_no_oidc')}
+            </div>
+          )}
+        </>
+      )}
+    </Modal>
   );
 };
 

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -748,6 +748,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                     className="filter-clear-btn"
                     onClick={() => setMessagesNodeFilter('')}
                     title={t('common.clear_filter')}
+                    aria-label={t('common.clear_filter')}
                     type="button"
                   >
                     ✕
@@ -1331,6 +1332,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                   className="resend-button"
                                   onClick={() => handleResendMessage(msg)}
                                   title={t('messages.resend_button_title')}
+                                  aria-label={t('messages.resend_button_title')}
                                 >
                                   ↻
                                 </button>
@@ -1342,6 +1344,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                     dmMessageInputRef.current?.focus();
                                   }}
                                   title={t('messages.reply_button_title')}
+                                  aria-label={t('messages.reply_button_title')}
                                 >
                                   ↩
                                 </button>
@@ -1350,6 +1353,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                 className="emoji-picker-button"
                                 onClick={() => setEmojiPickerMessage(msg)}
                                 title={t('messages.emoji_button_title')}
+                                aria-label={t('messages.emoji_button_title')}
                               >
                                 😄
                               </button>
@@ -1357,6 +1361,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                 className="delete-button"
                                 onClick={() => handleDeleteMessage(msg)}
                                 title={t('messages.delete_button_title')}
+                                aria-label={t('messages.delete_button_title')}
                               >
                                 🗑️
                               </button>
@@ -1435,7 +1440,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       <div className="reply-indicator-label">{t('messages.replying_to', { name: getNodeName(replyingTo.from) })}</div>
                       <div className="reply-indicator-text">{replyingTo.text}</div>
                     </div>
-                    <button className="reply-indicator-close" onClick={() => setReplyingTo(null)} title={t('messages.cancel_reply_title')}>
+                    <button className="reply-indicator-close" onClick={() => setReplyingTo(null)} title={t('messages.cancel_reply_title')} aria-label={t('messages.cancel_reply_title')}>
                       ×
                     </button>
                   </div>
@@ -1464,6 +1469,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       onClick={() => { onSendBell?.(selectedDMNode, newMessage); setNewMessage(''); }}
                       className="send-btn channel-action-btn"
                       title="Send alert bell"
+                      aria-label="Send alert bell"
                     >
                       🔔
                     </button>
@@ -1471,6 +1477,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       onClick={() => handleSendDirectMessage(selectedDMNode)}
                       disabled={!newMessage.trim()}
                       className="send-btn"
+                      aria-label={t('common.send')}
                     >
                       →
                     </button>
@@ -1740,6 +1747,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       }}
                       disabled={connectionStatus !== 'connected' || positionLoading === selectedDMNode}
                       title={t('messages.exchange_position_channel')}
+                      aria-label={t('messages.exchange_position_channel')}
                       style={{
                         padding: '0.5rem 0.5rem',
                         backgroundColor: 'var(--ctp-blue)',

--- a/src/components/NodeStatusWidget.tsx
+++ b/src/components/NodeStatusWidget.tsx
@@ -144,7 +144,7 @@ const NodeStatusWidget: React.FC<NodeStatusWidgetProps> = ({
           ⋮⋮
         </span>
         <h3 className="dashboard-chart-title">{t('dashboard.widget.node_status.title')}</h3>
-        <button className="dashboard-remove-btn" onClick={onRemove} title={t('dashboard.remove_widget')}>
+        <button className="dashboard-remove-btn" onClick={onRemove} title={t('dashboard.remove_widget')} aria-label={t('dashboard.remove_widget')}>
           ×
         </button>
       </div>
@@ -211,6 +211,7 @@ const NodeStatusWidget: React.FC<NodeStatusWidgetProps> = ({
                         className="node-status-remove-node"
                         onClick={() => onRemoveNode(row.nodeId)}
                         title={t('dashboard.widget.node_status.remove_node')}
+                        aria-label={t('dashboard.widget.node_status.remove_node')}
                       >
                         ×
                       </button>

--- a/src/components/PacketMonitorPanel.tsx
+++ b/src/components/PacketMonitorPanel.tsx
@@ -424,7 +424,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
       <div className="packet-monitor-panel">
         <div className="packet-monitor-header">
           <h3>{t('packet_monitor.title')}</h3>
-          <button className="close-btn" onClick={onClose}>
+          <button className="close-btn" onClick={onClose} aria-label={t('common.close')}>
             ×
           </button>
         </div>
@@ -453,29 +453,31 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
               className="control-btn"
               onClick={() => setAutoScroll(!autoScroll)}
               title={autoScroll ? t('packet_monitor.pause_autoscroll') : t('packet_monitor.resume_autoscroll')}
+              aria-label={autoScroll ? t('packet_monitor.pause_autoscroll') : t('packet_monitor.resume_autoscroll')}
             >
               {autoScroll ? '⏸️' : '▶️'}
             </button>
-            <button className="control-btn" onClick={() => setShowFilters(!showFilters)} title={t('packet_monitor.toggle_filters')}>
+            <button className="control-btn" onClick={() => setShowFilters(!showFilters)} title={t('packet_monitor.toggle_filters')} aria-label={t('packet_monitor.toggle_filters')}>
               🔍
             </button>
             <button
               className="control-btn"
               onClick={handleExport}
               title={t('packet_monitor.export_title')}
+              aria-label={t('packet_monitor.export_title')}
               disabled={total === 0}
             >
               📥
             </button>
             {authStatus?.user?.isAdmin && (
-              <button className="control-btn" onClick={handleClear} title={t('packet_monitor.clear_all')}>
+              <button className="control-btn" onClick={handleClear} title={t('packet_monitor.clear_all')} aria-label={t('packet_monitor.clear_all')}>
                 🗑️
               </button>
             )}
-            <button className="control-btn" onClick={handlePopout} title={t('packet_monitor.popout')}>
+            <button className="control-btn" onClick={handlePopout} title={t('packet_monitor.popout')} aria-label={t('packet_monitor.popout')}>
               ⧉
             </button>
-            <button className="close-btn" onClick={onClose}>
+            <button className="close-btn" onClick={onClose} aria-label={t('common.close')}>
               ×
             </button>
           </div>
@@ -833,7 +835,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
             <div className="packet-detail-content" onClick={e => e.stopPropagation()}>
               <div className="packet-detail-header">
                 <h4>{t('packet_monitor.details_title')}</h4>
-                <button className="close-btn" onClick={() => setSelectedPacket(null)}>
+                <button className="close-btn" onClick={() => setSelectedPacket(null)} aria-label={t('common.close')}>
                   ×
                 </button>
               </div>

--- a/src/components/PositionOverrideModal/PositionOverrideModal.tsx
+++ b/src/components/PositionOverrideModal/PositionOverrideModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import Modal from '../common/Modal';
 import './PositionOverrideModal.css';
 
 interface Node {
@@ -98,7 +99,7 @@ export const PositionOverrideModal: React.FC<PositionOverrideModalProps> = ({
     setError(null);
   }, [enabled, latitude, longitude, altitude, isPrivate]);
 
-  if (!isOpen || !selectedNode) return null;
+  if (!selectedNode) return null;
 
   const nodeName = selectedNode.user?.id ? getNodeName(selectedNode.user.id) : '';
 
@@ -170,155 +171,150 @@ export const PositionOverrideModal: React.FC<PositionOverrideModalProps> = ({
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content position-override-modal" onClick={e => e.stopPropagation()}>
-        <div className="modal-header">
-          <h2>{t('position_override.title', { nodeName })}</h2>
-          <button className="modal-close" onClick={onClose} disabled={saving}>
-            &times;
-          </button>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t('position_override.title', { nodeName })}
+      className="position-override-modal"
+    >
+      {loading ? (
+        <div className="position-override-loading">
+          {t('common.loading')}...
         </div>
-        <div className="modal-body">
-          {loading ? (
-            <div className="position-override-loading">
-              {t('common.loading')}...
-            </div>
-          ) : (
-            <>
-              <p className="position-override-description">
-                {t('position_override.description')}
-              </p>
+      ) : (
+        <>
+          <p className="position-override-description">
+            {t('position_override.description')}
+          </p>
 
-              <div className="position-override-checkbox-group">
-                <div className="position-override-checkbox">
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={enabled}
-                      onChange={e => setEnabled(e.target.checked)}
-                      disabled={saving}
-                    />
-                    {t('position_override.use_position')}
-                  </label>
-                </div>
-
-                {enabled && (
-                  <div className="position-override-checkbox private-checkbox">
-                    <label>
-                      <input
-                        type="checkbox"
-                        checked={isPrivate}
-                        onChange={e => setIsPrivate(e.target.checked)}
-                        disabled={saving}
-                      />
-                      {t('position_override.private')}
-                      <span className="field-description">
-                        {t('position_override.private_description')}
-                      </span>
-                    </label>
-                  </div>
-                )}
-              </div>
-
-              {enabled && (
-                <div className="position-override-fields">
-                  <div className="position-override-field">
-                    <label htmlFor="override-latitude">
-                      {t('position_override.latitude')}
-                      <span className="field-description">
-                        {t('position_override.latitude_description')}
-                      </span>
-                    </label>
-                    <input
-                      id="override-latitude"
-                      type="number"
-                      step="0.000001"
-                      min="-90"
-                      max="90"
-                      value={latitude}
-                      onChange={handleLatitudeChange}
-                      disabled={saving}
-                      className={latError ? 'input-error' : ''}
-                    />
-                    {latError && <span className="error-message">{latError}</span>}
-                  </div>
-
-                  <div className="position-override-field">
-                    <label htmlFor="override-longitude">
-                      {t('position_override.longitude')}
-                      <span className="field-description">
-                        {t('position_override.longitude_description')}
-                      </span>
-                    </label>
-                    <input
-                      id="override-longitude"
-                      type="number"
-                      step="0.000001"
-                      min="-180"
-                      max="180"
-                      value={longitude}
-                      onChange={handleLongitudeChange}
-                      disabled={saving}
-                      className={lngError ? 'input-error' : ''}
-                    />
-                    {lngError && <span className="error-message">{lngError}</span>}
-                  </div>
-
-                  <div className="position-override-field">
-                    <label htmlFor="override-altitude">
-                      {t('position_override.altitude')}
-                      <span className="field-description">
-                        {t('position_override.altitude_description')}
-                      </span>
-                    </label>
-                    <input
-                      id="override-altitude"
-                      type="number"
-                      step="1"
-                      value={altitude}
-                      onChange={e => setAltitude(e.target.value)}
-                      disabled={saving}
-                    />
-                  </div>
-
-                  <div className="position-override-link">
-                    <a
-                      href="https://www.latlong.net/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {t('position_override.find_coordinates')}
-                    </a>
-                  </div>
-                </div>
-              )}
-
-              {error && (
-                <div className="position-override-error">
-                  {error}
-                </div>
-              )}
-
-              <div className="position-override-actions">
-                <button
-                  className="cancel-btn"
-                  onClick={onClose}
+          <div className="position-override-checkbox-group">
+            <div className="position-override-checkbox">
+              <label>
+                <input
+                  type="checkbox"
+                  checked={enabled}
+                  onChange={e => setEnabled(e.target.checked)}
                   disabled={saving}
-                >
-                  {t('common.cancel')}
-                </button>
-                <button
-                  className="save-btn"
-                  onClick={handleSave}
-                  disabled={saving || (enabled && (latError !== null || lngError !== null))}
-                >
-                  {saving ? t('common.saving') : t('common.save')}
-                </button>
+                />
+                {t('position_override.use_position')}
+              </label>
+            </div>
+
+            {enabled && (
+              <div className="position-override-checkbox private-checkbox">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={isPrivate}
+                    onChange={e => setIsPrivate(e.target.checked)}
+                    disabled={saving}
+                  />
+                  {t('position_override.private')}
+                  <span className="field-description">
+                    {t('position_override.private_description')}
+                  </span>
+                </label>
               </div>
-            </>
+            )}
+          </div>
+
+          {enabled && (
+            <div className="position-override-fields">
+              <div className="position-override-field">
+                <label htmlFor="override-latitude">
+                  {t('position_override.latitude')}
+                  <span className="field-description">
+                    {t('position_override.latitude_description')}
+                  </span>
+                </label>
+                <input
+                  id="override-latitude"
+                  type="number"
+                  step="0.000001"
+                  min="-90"
+                  max="90"
+                  value={latitude}
+                  onChange={handleLatitudeChange}
+                  disabled={saving}
+                  className={latError ? 'input-error' : ''}
+                />
+                {latError && <span className="error-message">{latError}</span>}
+              </div>
+
+              <div className="position-override-field">
+                <label htmlFor="override-longitude">
+                  {t('position_override.longitude')}
+                  <span className="field-description">
+                    {t('position_override.longitude_description')}
+                  </span>
+                </label>
+                <input
+                  id="override-longitude"
+                  type="number"
+                  step="0.000001"
+                  min="-180"
+                  max="180"
+                  value={longitude}
+                  onChange={handleLongitudeChange}
+                  disabled={saving}
+                  className={lngError ? 'input-error' : ''}
+                />
+                {lngError && <span className="error-message">{lngError}</span>}
+              </div>
+
+              <div className="position-override-field">
+                <label htmlFor="override-altitude">
+                  {t('position_override.altitude')}
+                  <span className="field-description">
+                    {t('position_override.altitude_description')}
+                  </span>
+                </label>
+                <input
+                  id="override-altitude"
+                  type="number"
+                  step="1"
+                  value={altitude}
+                  onChange={e => setAltitude(e.target.value)}
+                  disabled={saving}
+                />
+              </div>
+
+              <div className="position-override-link">
+                <a
+                  href="https://www.latlong.net/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {t('position_override.find_coordinates')}
+                </a>
+              </div>
+            </div>
           )}
-        </div>
-      </div>
-    </div>
+
+          {error && (
+            <div className="position-override-error">
+              {error}
+            </div>
+          )}
+
+          <div className="position-override-actions">
+            <button
+              className="cancel-btn"
+              onClick={onClose}
+              disabled={saving}
+            >
+              {t('common.cancel')}
+            </button>
+            <button
+              className="save-btn"
+              onClick={handleSave}
+              disabled={saving || (enabled && (latError !== null || lngError !== null))}
+            >
+              {saving ? t('common.saving') : t('common.save')}
+            </button>
+          </div>
+        </>
+      )}
+    </Modal>
   );
 };

--- a/src/components/PurgeDataModal/PurgeDataModal.tsx
+++ b/src/components/PurgeDataModal/PurgeDataModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { BasicNodeInfo } from '../../types/device';
+import Modal from '../common/Modal';
 import './PurgeDataModal.css';
 
 interface PurgeDataModalProps {
@@ -30,7 +31,7 @@ export const PurgeDataModal: React.FC<PurgeDataModalProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  if (!isOpen || !selectedNode) return null;
+  if (!selectedNode) return null;
 
   const nodeName = selectedNode.user?.id ? getNodeName(selectedNode.user.id) : '';
 
@@ -63,47 +64,42 @@ export const PurgeDataModal: React.FC<PurgeDataModalProps> = ({
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content purge-modal" onClick={e => e.stopPropagation()}>
-        <div className="modal-header">
-          <h2>{t('purgeModal.title', { nodeName })}</h2>
-          <button className="modal-close" onClick={onClose}>
-            &times;
-          </button>
-        </div>
-        <div className="modal-body">
-          <p className="purge-warning">
-            {t('purgeModal.warning')}
-          </p>
-          <div className="purge-actions-row">
-            <button onClick={handlePurgeMessages} className="danger-btn purge-btn">
-              {t('purgeModal.purgeMessages')}
-            </button>
-            <button onClick={handlePurgeTraceroutes} className="danger-btn purge-btn">
-              {t('purgeModal.purgeTraceroutes')}
-            </button>
-            <button onClick={handlePurgeTelemetry} className="danger-btn purge-btn">
-              {t('purgeModal.purgeTelemetry')}
-            </button>
-            <button onClick={handlePurgePositionHistory} className="danger-btn purge-btn">
-              {t('purgeModal.purgePositionHistory')}
-            </button>
-          </div>
-          <hr className="purge-divider" />
-          <p className="purge-section-title">{t('purgeModal.deleteNodeTitle')}</p>
-          <p className="purge-section-description">
-            {t('purgeModal.deleteNodeDescription')}
-          </p>
-          <div className="purge-actions-column">
-            <button onClick={handleDeleteNode} className="danger-btn purge-btn-full delete-local">
-              {t('purgeModal.deleteLocal')}
-            </button>
-            <button onClick={handlePurgeFromDevice} className="danger-btn purge-btn-full delete-device">
-              {t('purgeModal.deleteDevice')}
-            </button>
-          </div>
-        </div>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t('purgeModal.title', { nodeName })}
+      className="purge-modal"
+    >
+      <p className="purge-warning">
+        {t('purgeModal.warning')}
+      </p>
+      <div className="purge-actions-row">
+        <button onClick={handlePurgeMessages} className="danger-btn purge-btn">
+          {t('purgeModal.purgeMessages')}
+        </button>
+        <button onClick={handlePurgeTraceroutes} className="danger-btn purge-btn">
+          {t('purgeModal.purgeTraceroutes')}
+        </button>
+        <button onClick={handlePurgeTelemetry} className="danger-btn purge-btn">
+          {t('purgeModal.purgeTelemetry')}
+        </button>
+        <button onClick={handlePurgePositionHistory} className="danger-btn purge-btn">
+          {t('purgeModal.purgePositionHistory')}
+        </button>
       </div>
-    </div>
+      <hr className="purge-divider" />
+      <p className="purge-section-title">{t('purgeModal.deleteNodeTitle')}</p>
+      <p className="purge-section-description">
+        {t('purgeModal.deleteNodeDescription')}
+      </p>
+      <div className="purge-actions-column">
+        <button onClick={handleDeleteNode} className="danger-btn purge-btn-full delete-local">
+          {t('purgeModal.deleteLocal')}
+        </button>
+        <button onClick={handlePurgeFromDevice} className="danger-btn purge-btn-full delete-device">
+          {t('purgeModal.deleteDevice')}
+        </button>
+      </div>
+    </Modal>
   );
 };

--- a/src/components/RouteSegmentTraceroutesModal.tsx
+++ b/src/components/RouteSegmentTraceroutesModal.tsx
@@ -5,6 +5,7 @@ import { formatDateTime } from '../utils/datetime';
 import { DeviceInfo } from '../types/device';
 import { useSettings } from '../contexts/SettingsContext';
 import { formatNodeName, formatTracerouteRoute } from '../utils/traceroute';
+import Modal from './common/Modal';
 
 interface RouteSegmentTraceroutesModalProps {
   nodeNum1: number;
@@ -70,114 +71,113 @@ const RouteSegmentTraceroutesModal: React.FC<RouteSegmentTraceroutesModalProps> 
   }, [traceroutes, nodeNum1, nodeNum2]);
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content" onClick={(e) => e.stopPropagation()} style={{ maxWidth: '900px', maxHeight: '80vh' }}>
-        <div className="modal-header">
-          <h2>{t('route_segment.title')}</h2>
-          <button className="modal-close" onClick={onClose}>×</button>
+    <Modal
+      isOpen={true}
+      onClose={onClose}
+      title={t('route_segment.title')}
+      maxWidth="900px"
+      style={{ maxHeight: '80vh' }}
+    >
+      <div style={{ overflowY: 'auto', maxHeight: 'calc(80vh - 100px)' }}>
+        <div style={{ marginBottom: '1.5rem' }}>
+          <strong>{t('route_segment.segment')}:</strong> {node1Name} ↔ {node2Name}
         </div>
 
-        <div className="modal-body" style={{ padding: '1.5rem', overflowY: 'auto', maxHeight: 'calc(80vh - 100px)' }}>
-          <div style={{ marginBottom: '1.5rem' }}>
-            <strong>{t('route_segment.segment')}:</strong> {node1Name} ↔ {node2Name}
+        {relevantTraceroutes.length === 0 && (
+          <div style={{ textAlign: 'center', padding: '2rem', color: 'var(--ctp-subtext0)' }}>
+            {t('route_segment.no_traceroutes')}
           </div>
+        )}
 
-          {relevantTraceroutes.length === 0 && (
-            <div style={{ textAlign: 'center', padding: '2rem', color: 'var(--ctp-subtext0)' }}>
-              {t('route_segment.no_traceroutes')}
-            </div>
-          )}
+        {relevantTraceroutes.length > 0 && (
+          <div>
+            <p style={{ marginBottom: '1rem', color: 'var(--ctp-subtext0)' }}>
+              {t('route_segment.showing_count', { count: relevantTraceroutes.length })}
+            </p>
 
-          {relevantTraceroutes.length > 0 && (
-            <div>
-              <p style={{ marginBottom: '1rem', color: 'var(--ctp-subtext0)' }}>
-                {t('route_segment.showing_count', { count: relevantTraceroutes.length })}
-              </p>
+            {relevantTraceroutes.map((tr, index) => {
+              const age = Math.floor((Date.now() - (tr.timestamp || tr.createdAt || Date.now())) / (1000 * 60));
+              const ageStr = age < 60
+                ? t('common.minutes_ago', { count: age })
+                : age < 1440
+                  ? t('common.hours_ago', { count: Math.floor(age / 60) })
+                  : t('common.days_ago', { count: Math.floor(age / 1440) });
 
-              {relevantTraceroutes.map((tr, index) => {
-                const age = Math.floor((Date.now() - (tr.timestamp || tr.createdAt || Date.now())) / (1000 * 60));
-                const ageStr = age < 60
-                  ? t('common.minutes_ago', { count: age })
-                  : age < 1440
-                    ? t('common.hours_ago', { count: Math.floor(age / 60) })
-                    : t('common.days_ago', { count: Math.floor(age / 1440) });
+              const fromNode = nodes.find(n => n.nodeNum === tr.fromNodeNum);
+              const toNode = nodes.find(n => n.nodeNum === tr.toNodeNum);
+              const fromName = fromNode?.user?.longName || fromNode?.user?.shortName || tr.fromNodeId;
+              const toName = toNode?.user?.longName || toNode?.user?.shortName || tr.toNodeId;
 
-                const fromNode = nodes.find(n => n.nodeNum === tr.fromNodeNum);
-                const toNode = nodes.find(n => n.nodeNum === tr.toNodeNum);
-                const fromName = fromNode?.user?.longName || fromNode?.user?.shortName || tr.fromNodeId;
-                const toName = toNode?.user?.longName || toNode?.user?.shortName || tr.toNodeId;
-
-                return (
-                  <div
-                    key={tr.id || index}
-                    style={{
-                      marginBottom: '1.5rem',
-                      padding: '1rem',
-                      background: 'var(--ctp-surface0)',
-                      border: '1px solid var(--ctp-surface2)',
-                      borderRadius: '8px',
-                    }}
-                  >
-                    <div style={{ marginBottom: '0.75rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                      <div>
-                        <strong>#{relevantTraceroutes.length - index}</strong>{' '}
-                        <span style={{ color: 'var(--ctp-subtext0)' }}>
-                          {fromName} → {toName}
-                        </span>
-                        <span style={{ marginLeft: '1rem', color: 'var(--ctp-subtext0)' }}>
-                          {formatDateTime(new Date(tr.timestamp || tr.createdAt || Date.now()), timeFormat, dateFormat)}
-                        </span>
-                      </div>
-                      <span style={{ fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>
-                        {ageStr}
-                      </span>
-                    </div>
-
-                    <div style={{ marginBottom: '0.5rem' }}>
-                      <strong style={{ color: 'var(--ctp-green)' }}>→ {t('traceroute_history.forward')}:</strong>{' '}
-                      <span style={{ fontFamily: 'monospace', fontSize: '0.95em' }}>
-                        {formatTracerouteRoute(
-                          tr.route,
-                          tr.snrTowards,
-                          tr.fromNodeNum,
-                          tr.toNodeNum,
-                          nodes,
-                          distanceUnit,
-                          {
-                            highlightSegment: true,
-                            highlightNodeNum1: nodeNum1,
-                            highlightNodeNum2: nodeNum2
-                          }
-                        )}
-                      </span>
-                    </div>
-
+              return (
+                <div
+                  key={tr.id || index}
+                  style={{
+                    marginBottom: '1.5rem',
+                    padding: '1rem',
+                    background: 'var(--ctp-surface0)',
+                    border: '1px solid var(--ctp-surface2)',
+                    borderRadius: '8px',
+                  }}
+                >
+                  <div style={{ marginBottom: '0.75rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                     <div>
-                      <strong style={{ color: 'var(--ctp-yellow)' }}>← {t('traceroute_history.return')}:</strong>{' '}
-                      <span style={{ fontFamily: 'monospace', fontSize: '0.95em' }}>
-                        {formatTracerouteRoute(
-                          tr.routeBack,
-                          tr.snrBack,
-                          tr.toNodeNum,
-                          tr.fromNodeNum,
-                          nodes,
-                          distanceUnit,
-                          {
-                            highlightSegment: true,
-                            highlightNodeNum1: nodeNum1,
-                            highlightNodeNum2: nodeNum2
-                          }
-                        )}
+                      <strong>#{relevantTraceroutes.length - index}</strong>{' '}
+                      <span style={{ color: 'var(--ctp-subtext0)' }}>
+                        {fromName} → {toName}
+                      </span>
+                      <span style={{ marginLeft: '1rem', color: 'var(--ctp-subtext0)' }}>
+                        {formatDateTime(new Date(tr.timestamp || tr.createdAt || Date.now()), timeFormat, dateFormat)}
                       </span>
                     </div>
+                    <span style={{ fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>
+                      {ageStr}
+                    </span>
                   </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
+
+                  <div style={{ marginBottom: '0.5rem' }}>
+                    <strong style={{ color: 'var(--ctp-green)' }}>→ {t('traceroute_history.forward')}:</strong>{' '}
+                    <span style={{ fontFamily: 'monospace', fontSize: '0.95em' }}>
+                      {formatTracerouteRoute(
+                        tr.route,
+                        tr.snrTowards,
+                        tr.fromNodeNum,
+                        tr.toNodeNum,
+                        nodes,
+                        distanceUnit,
+                        {
+                          highlightSegment: true,
+                          highlightNodeNum1: nodeNum1,
+                          highlightNodeNum2: nodeNum2
+                        }
+                      )}
+                    </span>
+                  </div>
+
+                  <div>
+                    <strong style={{ color: 'var(--ctp-yellow)' }}>← {t('traceroute_history.return')}:</strong>{' '}
+                    <span style={{ fontFamily: 'monospace', fontSize: '0.95em' }}>
+                      {formatTracerouteRoute(
+                        tr.routeBack,
+                        tr.snrBack,
+                        tr.toNodeNum,
+                        tr.fromNodeNum,
+                        nodes,
+                        distanceUnit,
+                        {
+                          highlightSegment: true,
+                          highlightNodeNum1: nodeNum1,
+                          highlightNodeNum2: nodeNum2
+                        }
+                      )}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/components/SystemStatusModal/SystemStatusModal.css
+++ b/src/components/SystemStatusModal/SystemStatusModal.css
@@ -21,63 +21,6 @@
   font-size: 1rem;
 }
 
-/* Modal base styles (shared - could be moved to shared CSS) */
-.modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 10001;
-}
-
-.modal-content {
-  background: var(--ctp-base);
-  border-radius: 8px;
-  padding: 0;
-  max-width: 500px;
-  width: 90%;
-  max-height: 80vh;
-  overflow: auto;
-  border: 1px solid var(--ctp-surface0);
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 1.5rem;
-  border-bottom: 1px solid var(--ctp-surface0);
-}
-
-.modal-header h2 {
-  margin: 0;
-  color: var(--ctp-text);
-  font-size: 1.25rem;
-}
-
-.modal-close {
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  color: var(--ctp-subtext0);
-  cursor: pointer;
-  padding: 0;
-  line-height: 1;
-}
-
-.modal-close:hover {
-  color: var(--ctp-text);
-}
-
-.modal-body {
-  padding: 1.5rem;
-}
-
 /* Responsive adjustments */
 @media (max-width: 600px) {
   .status-grid {

--- a/src/components/SystemStatusModal/SystemStatusModal.tsx
+++ b/src/components/SystemStatusModal/SystemStatusModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { SystemStatus } from '../../types/ui';
+import Modal from '../common/Modal';
 import './SystemStatusModal.css';
 
 interface SystemStatusModalProps {
@@ -16,64 +17,54 @@ export const SystemStatusModal: React.FC<SystemStatusModalProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  if (!isOpen || !systemStatus) return null;
+  if (!systemStatus) return null;
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content" onClick={e => e.stopPropagation()}>
-        <div className="modal-header">
-          <h2>{t('system_status.title', 'System Status')}</h2>
-          <button className="modal-close" onClick={onClose}>
-            &times;
-          </button>
+    <Modal isOpen={isOpen} onClose={onClose} title={t('system_status.title', 'System Status')}>
+      <div className="status-grid">
+        <div className="status-item">
+          <strong>{t('system_status.version', 'Version')}:</strong>
+          <span>{systemStatus.version}</span>
         </div>
-        <div className="modal-body">
-          <div className="status-grid">
-            <div className="status-item">
-              <strong>{t('system_status.version', 'Version')}:</strong>
-              <span>{systemStatus.version}</span>
-            </div>
-            <div className="status-item">
-              <strong>{t('system_status.node_version', 'Node.js Version')}:</strong>
-              <span>{systemStatus.nodeVersion}</span>
-            </div>
-            <div className="status-item">
-              <strong>{t('system_status.uptime', 'Uptime')}:</strong>
-              <span>{systemStatus.uptime}</span>
-            </div>
-            <div className="status-item">
-              <strong>{t('system_status.platform', 'Platform')}:</strong>
-              <span>
-                {systemStatus.platform} ({systemStatus.architecture})
-              </span>
-            </div>
-            <div className="status-item">
-              <strong>{t('system_status.environment', 'Environment')}:</strong>
-              <span>{systemStatus.environment}</span>
-            </div>
-            <div className="status-item">
-              <strong>{t('system_status.memory_heap_used', 'Memory (Heap Used)')}:</strong>
-              <span>{systemStatus.memoryUsage.heapUsed}</span>
-            </div>
-            <div className="status-item">
-              <strong>{t('system_status.memory_heap_total', 'Memory (Heap Total)')}:</strong>
-              <span>{systemStatus.memoryUsage.heapTotal}</span>
-            </div>
-            <div className="status-item">
-              <strong>{t('system_status.memory_rss', 'Memory (RSS)')}:</strong>
-              <span>{systemStatus.memoryUsage.rss}</span>
-            </div>
-            {systemStatus.database && (
-              <div className="status-item">
-                <strong>{t('system_status.database', 'Database')}:</strong>
-                <span>
-                  {systemStatus.database.type} {systemStatus.database.version}
-                </span>
-              </div>
-            )}
+        <div className="status-item">
+          <strong>{t('system_status.node_version', 'Node.js Version')}:</strong>
+          <span>{systemStatus.nodeVersion}</span>
+        </div>
+        <div className="status-item">
+          <strong>{t('system_status.uptime', 'Uptime')}:</strong>
+          <span>{systemStatus.uptime}</span>
+        </div>
+        <div className="status-item">
+          <strong>{t('system_status.platform', 'Platform')}:</strong>
+          <span>
+            {systemStatus.platform} ({systemStatus.architecture})
+          </span>
+        </div>
+        <div className="status-item">
+          <strong>{t('system_status.environment', 'Environment')}:</strong>
+          <span>{systemStatus.environment}</span>
+        </div>
+        <div className="status-item">
+          <strong>{t('system_status.memory_heap_used', 'Memory (Heap Used)')}:</strong>
+          <span>{systemStatus.memoryUsage.heapUsed}</span>
+        </div>
+        <div className="status-item">
+          <strong>{t('system_status.memory_heap_total', 'Memory (Heap Total)')}:</strong>
+          <span>{systemStatus.memoryUsage.heapTotal}</span>
+        </div>
+        <div className="status-item">
+          <strong>{t('system_status.memory_rss', 'Memory (RSS)')}:</strong>
+          <span>{systemStatus.memoryUsage.rss}</span>
+        </div>
+        {systemStatus.database && (
+          <div className="status-item">
+            <strong>{t('system_status.database', 'Database')}:</strong>
+            <span>
+              {systemStatus.database.type} {systemStatus.database.version}
+            </span>
           </div>
-        </div>
+        )}
       </div>
-    </div>
+    </Modal>
   );
 };

--- a/src/components/TelemetryRequestModal.tsx
+++ b/src/components/TelemetryRequestModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
+import Modal from './common/Modal';
 import './TelemetryRequestModal.css';
 
 export type TelemetryType = 'device' | 'environment' | 'airQuality' | 'power';
@@ -24,12 +25,6 @@ const TelemetryRequestModal: React.FC<TelemetryRequestModalProps> = ({
 
   if (!isOpen) return null;
 
-  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
-  };
-
   const telemetryTypes: { type: TelemetryType; icon: string; translationKey: string; description: string }[] = [
     { type: 'device', icon: '📱', translationKey: 'messages.telemetry_type_device', description: 'messages.telemetry_type_device_desc' },
     { type: 'environment', icon: '🌡️', translationKey: 'messages.telemetry_type_environment', description: 'messages.telemetry_type_environment_desc' },
@@ -38,39 +33,34 @@ const TelemetryRequestModal: React.FC<TelemetryRequestModalProps> = ({
   ];
 
   const modalContent = (
-    <div className="modal-overlay" onClick={handleBackdropClick}>
-      <div className="modal-content telemetry-request-modal">
-        <div className="modal-header">
-          <h2>{t('messages.request_telemetry')}</h2>
-          <button className="modal-close" onClick={onClose} aria-label={t('common.close')}>
-            ×
-          </button>
-        </div>
-        <div className="modal-body">
-          <p className="telemetry-modal-subtitle">
-            {t('messages.select_telemetry_type', { nodeName })}
-          </p>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t('messages.request_telemetry')}
+      className="telemetry-request-modal"
+    >
+      <p className="telemetry-modal-subtitle">
+        {t('messages.select_telemetry_type', { nodeName })}
+      </p>
 
-          <div className="telemetry-types-list">
-            {telemetryTypes.map(({ type, icon, translationKey, description }) => (
-              <button
-                key={type}
-                className="telemetry-type-button"
-                onClick={() => onRequest(type)}
-                disabled={loading}
-              >
-                <span className="telemetry-type-icon">{icon}</span>
-                <div className="telemetry-type-info">
-                  <span className="telemetry-type-name">{t(translationKey)}</span>
-                  <span className="telemetry-type-description">{t(description)}</span>
-                </div>
-                {loading && <span className="spinner"></span>}
-              </button>
-            ))}
-          </div>
-        </div>
+      <div className="telemetry-types-list">
+        {telemetryTypes.map(({ type, icon, translationKey, description }) => (
+          <button
+            key={type}
+            className="telemetry-type-button"
+            onClick={() => onRequest(type)}
+            disabled={loading}
+          >
+            <span className="telemetry-type-icon">{icon}</span>
+            <div className="telemetry-type-info">
+              <span className="telemetry-type-name">{t(translationKey)}</span>
+              <span className="telemetry-type-description">{t(description)}</span>
+            </div>
+            {loading && <span className="spinner"></span>}
+          </button>
+        ))}
       </div>
-    </div>
+    </Modal>
   );
 
   return createPortal(modalContent, document.body);

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -18,10 +18,10 @@ const Toast: React.FC<ToastProps> = ({ id, message, type, duration = 5000, onClo
   }, [id, duration, onClose]);
 
   const backgroundColor = {
-    success: '#4caf50',
-    error: '#f44336',
-    warning: '#ff9800',
-    info: '#2196f3'
+    success: 'var(--ctp-green)',
+    error: 'var(--ctp-red)',
+    warning: 'var(--ctp-peach)',
+    info: 'var(--ctp-blue)'
   }[type];
 
   const icon = {
@@ -35,7 +35,7 @@ const Toast: React.FC<ToastProps> = ({ id, message, type, duration = 5000, onClo
     <div
       style={{
         backgroundColor,
-        color: 'white',
+        color: 'var(--ctp-crust, #1e1e2e)',
         padding: '1rem 1.5rem',
         borderRadius: '4px',
         boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
@@ -52,10 +52,11 @@ const Toast: React.FC<ToastProps> = ({ id, message, type, duration = 5000, onClo
       <span style={{ flex: 1, fontSize: '0.95rem' }}>{message}</span>
       <button
         onClick={() => onClose(id)}
+        aria-label="Close notification"
         style={{
           background: 'none',
           border: 'none',
-          color: 'white',
+          color: 'var(--ctp-crust, #1e1e2e)',
           fontSize: '1.25rem',
           cursor: 'pointer',
           padding: '0 0.25rem',

--- a/src/components/TracerouteHistoryModal.tsx
+++ b/src/components/TracerouteHistoryModal.tsx
@@ -6,6 +6,7 @@ import { formatDateTime } from '../utils/datetime';
 import { DeviceInfo } from '../types/device';
 import { useSettings } from '../contexts/SettingsContext';
 import { formatTracerouteRoute } from '../utils/traceroute';
+import Modal from './common/Modal';
 
 interface TracerouteHistoryModalProps {
   fromNodeNum: number;
@@ -89,110 +90,109 @@ const TracerouteHistoryModal: React.FC<TracerouteHistoryModalProps> = ({
   }, [traceroutes, showFailedTraceroutes]);
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content" onClick={(e) => e.stopPropagation()} style={{ maxWidth: '900px', maxHeight: '80vh' }}>
-        <div className="modal-header">
-          <h2>{t('traceroute_history.title')}</h2>
-          <button className="modal-close" onClick={onClose}>×</button>
+    <Modal
+      isOpen={true}
+      onClose={onClose}
+      title={t('traceroute_history.title')}
+      maxWidth="900px"
+      style={{ maxHeight: '80vh' }}
+    >
+      <div style={{ overflowY: 'auto', maxHeight: 'calc(80vh - 100px)' }}>
+        <div style={{ marginBottom: '1.5rem' }}>
+          <strong>{t('traceroute_history.from')}:</strong> {fromNodeName} → <strong>{t('traceroute_history.to')}:</strong> {toNodeName}
         </div>
 
-        <div className="modal-body" style={{ padding: '1.5rem', overflowY: 'auto', maxHeight: 'calc(80vh - 100px)' }}>
-          <div style={{ marginBottom: '1.5rem' }}>
-            <strong>{t('traceroute_history.from')}:</strong> {fromNodeName} → <strong>{t('traceroute_history.to')}:</strong> {toNodeName}
+        <div style={{ marginBottom: '1rem' }}>
+          <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', userSelect: 'none' }}>
+            <input
+              type="checkbox"
+              checked={showFailedTraceroutes}
+              onChange={(e) => setShowFailedTraceroutes(e.target.checked)}
+              style={{ marginRight: '0.5rem', cursor: 'pointer' }}
+            />
+            {t('traceroute_history.show_failed')}
+          </label>
+        </div>
+
+        {loading && (
+          <div style={{ textAlign: 'center', padding: '2rem' }}>
+            <div className="spinner"></div>
+            <p>{t('traceroute_history.loading')}</p>
           </div>
+        )}
 
-          <div style={{ marginBottom: '1rem' }}>
-            <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', userSelect: 'none' }}>
-              <input
-                type="checkbox"
-                checked={showFailedTraceroutes}
-                onChange={(e) => setShowFailedTraceroutes(e.target.checked)}
-                style={{ marginRight: '0.5rem', cursor: 'pointer' }}
-              />
-              {t('traceroute_history.show_failed')}
-            </label>
+        {error && (
+          <div style={{ padding: '1rem', background: 'var(--ctp-red)', color: 'var(--ctp-base)', borderRadius: '4px' }}>
+            {error}
           </div>
+        )}
 
-          {loading && (
-            <div style={{ textAlign: 'center', padding: '2rem' }}>
-              <div className="spinner"></div>
-              <p>{t('traceroute_history.loading')}</p>
-            </div>
-          )}
+        {!loading && !error && filteredTraceroutes.length === 0 && (
+          <div style={{ textAlign: 'center', padding: '2rem', color: 'var(--ctp-subtext0)' }}>
+            {traceroutes.length === 0 ? t('traceroute_history.no_history') : t('traceroute_history.no_matches')}
+          </div>
+        )}
 
-          {error && (
-            <div style={{ padding: '1rem', background: 'var(--ctp-red)', color: 'var(--ctp-base)', borderRadius: '4px' }}>
-              {error}
-            </div>
-          )}
+        {!loading && !error && filteredTraceroutes.length > 0 && (
+          <div>
+            <p style={{ marginBottom: '1rem', color: 'var(--ctp-subtext0)' }}>
+              {t('traceroute_history.showing_count', { count: filteredTraceroutes.length })}
+              {!showFailedTraceroutes && traceroutes.length > filteredTraceroutes.length && (
+                <span> {t('traceroute_history.failed_hidden', { count: traceroutes.length - filteredTraceroutes.length })}</span>
+              )}
+            </p>
 
-          {!loading && !error && filteredTraceroutes.length === 0 && (
-            <div style={{ textAlign: 'center', padding: '2rem', color: 'var(--ctp-subtext0)' }}>
-              {traceroutes.length === 0 ? t('traceroute_history.no_history') : t('traceroute_history.no_matches')}
-            </div>
-          )}
+            {filteredTraceroutes.map((tr: TracerouteWithHops, index: number) => {
+              const age = Math.floor((Date.now() - tr.timestamp) / (1000 * 60));
+              const ageStr = age < 60
+                ? t('common.minutes_ago', { count: age })
+                : age < 1440
+                  ? t('common.hours_ago', { count: Math.floor(age / 60) })
+                  : t('common.days_ago', { count: Math.floor(age / 1440) });
 
-          {!loading && !error && filteredTraceroutes.length > 0 && (
-            <div>
-              <p style={{ marginBottom: '1rem', color: 'var(--ctp-subtext0)' }}>
-                {t('traceroute_history.showing_count', { count: filteredTraceroutes.length })}
-                {!showFailedTraceroutes && traceroutes.length > filteredTraceroutes.length && (
-                  <span> {t('traceroute_history.failed_hidden', { count: traceroutes.length - filteredTraceroutes.length })}</span>
-                )}
-              </p>
-
-              {filteredTraceroutes.map((tr: TracerouteWithHops, index: number) => {
-                const age = Math.floor((Date.now() - tr.timestamp) / (1000 * 60));
-                const ageStr = age < 60
-                  ? t('common.minutes_ago', { count: age })
-                  : age < 1440
-                    ? t('common.hours_ago', { count: Math.floor(age / 60) })
-                    : t('common.days_ago', { count: Math.floor(age / 1440) });
-
-                return (
-                  <div
-                    key={tr.id || index}
-                    style={{
-                      marginBottom: '1.5rem',
-                      padding: '1rem',
-                      background: 'var(--ctp-surface0)',
-                      border: '1px solid var(--ctp-surface2)',
-                      borderRadius: '8px',
-                    }}
-                  >
-                    <div style={{ marginBottom: '0.75rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                      <div>
-                        <strong>#{filteredTraceroutes.length - index}</strong>
-                        <span style={{ marginLeft: '1rem', color: 'var(--ctp-subtext0)' }}>
-                          {formatDateTime(new Date(tr.timestamp), timeFormat, dateFormat)}
-                        </span>
-                      </div>
-                      <span style={{ fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>
-                        {ageStr}
-                      </span>
-                    </div>
-
-                    <div style={{ marginBottom: '0.5rem' }}>
-                      <strong style={{ color: 'var(--ctp-green)' }}>→ {t('traceroute_history.forward')}:</strong>{' '}
-                      <span style={{ fontFamily: 'monospace', fontSize: '0.95em' }}>
-                        {formatTracerouteRoute(tr.route, tr.snrTowards, tr.fromNodeNum, tr.toNodeNum, nodes, distanceUnit)}
-                      </span>
-                    </div>
-
+              return (
+                <div
+                  key={tr.id || index}
+                  style={{
+                    marginBottom: '1.5rem',
+                    padding: '1rem',
+                    background: 'var(--ctp-surface0)',
+                    border: '1px solid var(--ctp-surface2)',
+                    borderRadius: '8px',
+                  }}
+                >
+                  <div style={{ marginBottom: '0.75rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                     <div>
-                      <strong style={{ color: 'var(--ctp-yellow)' }}>← {t('traceroute_history.return')}:</strong>{' '}
-                      <span style={{ fontFamily: 'monospace', fontSize: '0.95em' }}>
-                        {formatTracerouteRoute(tr.routeBack, tr.snrBack, tr.toNodeNum, tr.fromNodeNum, nodes, distanceUnit)}
+                      <strong>#{filteredTraceroutes.length - index}</strong>
+                      <span style={{ marginLeft: '1rem', color: 'var(--ctp-subtext0)' }}>
+                        {formatDateTime(new Date(tr.timestamp), timeFormat, dateFormat)}
                       </span>
                     </div>
+                    <span style={{ fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>
+                      {ageStr}
+                    </span>
                   </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
+
+                  <div style={{ marginBottom: '0.5rem' }}>
+                    <strong style={{ color: 'var(--ctp-green)' }}>→ {t('traceroute_history.forward')}:</strong>{' '}
+                    <span style={{ fontFamily: 'monospace', fontSize: '0.95em' }}>
+                      {formatTracerouteRoute(tr.route, tr.snrTowards, tr.fromNodeNum, tr.toNodeNum, nodes, distanceUnit)}
+                    </span>
+                  </div>
+
+                  <div>
+                    <strong style={{ color: 'var(--ctp-yellow)' }}>← {t('traceroute_history.return')}:</strong>{' '}
+                    <span style={{ fontFamily: 'monospace', fontSize: '0.95em' }}>
+                      {formatTracerouteRoute(tr.routeBack, tr.snrBack, tr.toNodeNum, tr.fromNodeNum, nodes, distanceUnit)}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/components/TracerouteWidget.tsx
+++ b/src/components/TracerouteWidget.tsx
@@ -404,7 +404,7 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
           {t('dashboard.widget.traceroute.title')}
           {targetNodeName ? `: ${targetNodeName}` : ''}
         </h3>
-        <button className="dashboard-remove-btn" onClick={onRemove} title={t('dashboard.remove_widget')}>
+        <button className="dashboard-remove-btn" onClick={onRemove} title={t('dashboard.remove_widget')} aria-label={t('dashboard.remove_widget')}>
           ×
         </button>
       </div>

--- a/src/components/common/Modal.css
+++ b/src/components/common/Modal.css
@@ -1,0 +1,56 @@
+/* Shared Modal Base Styles */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10001;
+}
+
+.modal-content {
+  background: var(--ctp-base);
+  border-radius: 8px;
+  padding: 0;
+  max-width: 500px;
+  width: 90%;
+  max-height: 80vh;
+  overflow: auto;
+  border: 1px solid var(--ctp-surface0);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--ctp-surface0);
+}
+
+.modal-header h2 {
+  margin: 0;
+  color: var(--ctp-text);
+  font-size: 1.25rem;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--ctp-subtext0);
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+.modal-close:hover {
+  color: var(--ctp-text);
+}
+
+.modal-body {
+  padding: 1.5rem;
+}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useRef, useCallback } from 'react';
+import './Modal.css';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+  /** Additional CSS class for the modal-content container */
+  className?: string;
+  /** Inline styles for the modal-content container */
+  style?: React.CSSProperties;
+  /** Override the default max-width (500px from CSS) */
+  maxWidth?: string;
+  /** Whether clicking the overlay closes the modal (default: true) */
+  closeOnOverlayClick?: boolean;
+  /** Whether pressing ESC closes the modal (default: true) */
+  closeOnEsc?: boolean;
+  /** CSS class for the overlay (default: 'modal-overlay') */
+  overlayClassName?: string;
+}
+
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+  className,
+  style,
+  maxWidth,
+  closeOnOverlayClick = true,
+  closeOnEsc = true,
+  overlayClassName = 'modal-overlay',
+}) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Capture the element that had focus before the modal opened
+  useEffect(() => {
+    if (isOpen) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+    }
+  }, [isOpen]);
+
+  // Restore focus when modal closes
+  useEffect(() => {
+    if (!isOpen && previousFocusRef.current) {
+      previousFocusRef.current.focus();
+      previousFocusRef.current = null;
+    }
+  }, [isOpen]);
+
+  // Focus the modal content when it opens
+  useEffect(() => {
+    if (isOpen && contentRef.current) {
+      contentRef.current.focus();
+    }
+  }, [isOpen]);
+
+  // ESC key handler
+  useEffect(() => {
+    if (!isOpen || !closeOnEsc) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, closeOnEsc, onClose]);
+
+  // Focus trap
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key !== 'Tab' || !contentRef.current) return;
+
+    const focusableElements = contentRef.current.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+
+    if (focusableElements.length === 0) return;
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (e.shiftKey) {
+      if (document.activeElement === firstElement) {
+        e.preventDefault();
+        lastElement.focus();
+      }
+    } else {
+      if (document.activeElement === lastElement) {
+        e.preventDefault();
+        firstElement.focus();
+      }
+    }
+  }, []);
+
+  // Prevent body scroll when modal is open
+  useEffect(() => {
+    if (isOpen) {
+      const originalOverflow = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = originalOverflow;
+      };
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (closeOnOverlayClick && e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  const contentStyle: React.CSSProperties = {
+    ...style,
+    ...(maxWidth ? { maxWidth } : {}),
+  };
+
+  return (
+    <div
+      className={overlayClassName}
+      onClick={handleOverlayClick}
+      role="presentation"
+    >
+      <div
+        ref={contentRef}
+        className={`modal-content${className ? ` ${className}` : ''}`}
+        style={contentStyle}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-title"
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <h2 id="modal-title">{title}</h2>
+          <button
+            className="modal-close"
+            onClick={onClose}
+            aria-label="Close dialog"
+          >
+            ×
+          </button>
+        </div>
+        <div className="modal-body">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;


### PR DESCRIPTION
## Summary

First batch of the comprehensive frontend review, focusing on quick wins and high-impact improvements:

- **Shared Modal component** (`src/components/common/Modal.tsx`) — Replaces duplicated modal boilerplate across 7+ components with a single reusable component that includes ESC key handling, focus trap, click-outside-to-close, ARIA attributes (`role="dialog"`, `aria-modal`), body scroll lock, and focus restoration
- **Toast theming** — Replaced 4 hardcoded Material Design colors (`#4caf50`, `#f44336`, `#ff9800`, `#2196f3`) with Catppuccin CSS variables so toasts now respect the active theme
- **Accessibility** — Added `aria-label` to 35+ icon-only buttons (PacketMonitorPanel, MessagesTab, ChannelsTab, CustomThemeManagement, Dashboard widgets), bringing total `aria-*` attributes from 37 to 72. Added skip-to-content link for keyboard navigation.

### Modals refactored to use shared component:
- ChangePasswordModal, LoginModal, TracerouteHistoryModal
- RouteSegmentTraceroutesModal, PurgeDataModal, SystemStatusModal
- PositionOverrideModal, TelemetryRequestModal

### Stats
- `aria-*` count: 37 → 72 (+95%)
- Modal code deduplication: ~58 lines of boilerplate removed per modal
- Net: +916 / -758 lines (new shared component + aria-labels offset removed duplication)

## Test plan
- [x] `npx vitest run` — 2,921 tests pass, 0 failures
- [x] `npx tsc --noEmit` — clean compile
- [ ] Visual inspection: open/close each refactored modal, verify ESC key and click-outside work
- [ ] Switch between Catppuccin themes, verify toast colors adapt
- [ ] Tab through page, verify skip-to-content link appears on focus
- [ ] Verify aria-labels with screen reader or browser accessibility inspector

🤖 Generated with [Claude Code](https://claude.com/claude-code)