### PR TITLE
fix: MeshCore repeater serial protocol — three bugs

### DIFF
--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -503,7 +503,7 @@ class MeshCoreManager extends EventEmitter {
     const SerialPortClass = SerialPort;
     const ReadlineParserClass = ReadlineParser;
 
-    return new Promise((resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       this.serialPort = new SerialPortClass({
         path: this.config!.serialPort!,
         baudRate: this.config!.baudRate || 115200,
@@ -524,6 +524,14 @@ class MeshCoreManager extends EventEmitter {
       this.parser.on('data', (data: string) => {
         this.handleSerialData(data.trim());
       });
+    });
+
+    // Wake up the repeater CLI with a CR and discard any buffered data
+    await new Promise<void>((resolve) => {
+      this.serialPort!.write('\r');
+      setTimeout(() => {
+        this.serialPort!.flush(() => resolve());
+      }, 500);
     });
   }
 
@@ -584,7 +592,9 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
-   * Send a command to Repeater firmware (text CLI)
+   * Send a command to Repeater firmware (text CLI).
+   * Repeater CLI uses \r as line terminator and echoes the command back.
+   * Response lines start with "  -> " prefix.
    */
   private async sendRepeaterCommand(command: string, timeout: number = 5000): Promise<string> {
     if (!this.serialPort?.isOpen) {
@@ -593,21 +603,33 @@ class MeshCoreManager extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       const cmdId = `cmd_${++this.commandId}`;
-      let response = '';
+      const lines: string[] = [];
+      let echoSeen = false;
 
       const timeoutHandle = setTimeout(() => {
         this.pendingCommands.delete(cmdId);
         this.removeListener('serial_data', dataHandler);
-        reject(new Error(`Command timeout: ${command}`));
+        // Resolve with whatever we have instead of rejecting on timeout,
+        // since the repeater doesn't send an explicit end-of-response marker
+        resolve(lines.join('\n').trim());
       }, timeout);
 
       const dataHandler = (data: string) => {
-        response += data + '\n';
-        if (data.includes('>') || data.includes('OK') || data.includes('Error')) {
+        // Skip the command echo
+        if (!echoSeen && data.replace(/\r/g, '').trim() === command.trim()) {
+          echoSeen = true;
+          return;
+        }
+
+        lines.push(data);
+        logger.debug(`[MeshCore] Response line: ${data}`);
+
+        // Check for response terminators
+        if (data.includes('-> >') || data.includes('OK') || data.includes('Error') || data.includes('Unknown command')) {
           clearTimeout(timeoutHandle);
           this.pendingCommands.delete(cmdId);
           this.removeListener('serial_data', dataHandler);
-          resolve(response.trim());
+          resolve(lines.join('\n').trim());
         }
       };
 
@@ -615,7 +637,7 @@ class MeshCoreManager extends EventEmitter {
       this.on('serial_data', dataHandler);
 
       logger.debug(`[MeshCore] TX: ${command}`);
-      this.serialPort!.write(command + '\n');
+      this.serialPort!.write(command + '\r');
     });
   }
 
@@ -680,7 +702,11 @@ class MeshCoreManager extends EventEmitter {
         const nameResponse = await this.sendRepeaterCommand('get name');
         const radioResponse = await this.sendRepeaterCommand('get radio');
 
-        const nameMatch = nameResponse.match(/name:\s*(.+)/i);
+        logger.debug(`[MeshCore] Name response: ${JSON.stringify(nameResponse)}`);
+        logger.debug(`[MeshCore] Radio response: ${JSON.stringify(radioResponse)}`);
+
+        // Repeater CLI returns "  -> > DeviceName" format
+        const nameMatch = nameResponse.match(/->\s*>\s*(.+)/);
         const radioMatch = radioResponse.match(/(\d+\.?\d*),\s*(\d+\.?\d*),\s*(\d+),\s*(\d+)/);
 
         this.localNode = {

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -162,12 +162,17 @@ router.post('/connect', meshcoreDeviceLimiter, requireAuth(), requirePermission(
       return res.status(400).json({ success: false, error: validation.error });
     }
 
+    // Read firmware type from env (controls direct serial vs Python bridge)
+    const firmwareTypeRaw = (process.env.MESHCORE_FIRMWARE_TYPE || 'companion').toLowerCase();
+    const firmwareType: 'companion' | 'repeater' = firmwareTypeRaw === 'repeater' ? 'repeater' : 'companion';
+
     const config = {
       connectionType: connectionType as ConnectionType || ConnectionType.SERIAL,
       serialPort,
       tcpHost,
       tcpPort: parsedTcpPort ?? 4403,
       baudRate: parsedBaudRate ?? 115200,
+      firmwareType,
     };
 
     const success = await meshcoreManager.connect(config);


### PR DESCRIPTION
## Summary

Fixes three bugs that prevented MeshCore repeater devices from working with `MESHCORE_FIRMWARE_TYPE=repeater`:

- **`firmwareType` not passed to `connect()`**: The `POST /api/meshcore/connect` route built a config from the request body but never included `firmwareType`, so the env var was ignored and the code always used the Python bridge (Companion) path — which fails on Repeater firmware.
- **Wrong line terminator**: `sendRepeaterCommand()` sent `\n` but the MeshCore repeater text CLI expects `\r`. The repeater silently ignored all commands.
- **Missing wake-up + wrong response parsing**: `connectSerialDirect()` didn't send the initial `\r` wake-up the repeater CLI requires. The response parser looked for `>` as a terminator, but repeater responses use `-> > value` format. Also added proper command echo filtering.

### MeshCore Repeater Protocol Details

The repeater firmware exposes a **text CLI over serial** (not binary protocol). Key protocol characteristics discovered from `meshcore-cli` source (`meshcore_cli/meshcore_cli.py`):

| Aspect | Detail |
|--------|--------|
| Line terminator | `\r` (carriage return) |
| Wake-up sequence | Send `\r`, wait 500ms, flush buffer |
| Command format | Plain ASCII, e.g. `get name\r`, `get radio\r`, `advert\r` |
| Response format | Echo of command, then `  -> > value` or `-> OK - message` |
| Baud rate | 115200 (default) |

This is distinct from Companion firmware which uses a binary framing protocol (`0x3c`/`0x3e` start bytes + 2-byte LE length + payload) via the `meshcore` Python library.

## Test plan

- [x] `npx vitest run src/server/routes/meshcoreRoutes.test.ts` — 31/31 pass
- [x] End-to-end tested with physical MeshCore repeater on `/dev/ttyACM1`
- [x] Verified device name ("QEM Shed Inside"), radio config (910.525 MHz, BW62.5, SF7), and advert send all work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)