### PR TITLE
fix: backup modal UI cleanup — wider modal, styled buttons, spacing

### DIFF
--- a/src/components/configuration/SystemBackupSection.tsx
+++ b/src/components/configuration/SystemBackupSection.tsx
@@ -441,20 +441,20 @@ const SystemBackupSection: React.FC = () => {
                   <tbody>
                     {backupList.map((backup) => (
                       <tr key={backup.dirname}>
-                        <td style={{ fontFamily: 'monospace', fontSize: '0.9rem' }}>{backup.dirname}</td>
+                        <td className="backup-dirname">{backup.dirname}</td>
                         <td>{formatTimestamp(backup.timestamp)}</td>
                         <td>
                           <span className={`backup-type-badge ${backup.type}`}>
                             {backup.type === 'automatic' ? t('backup_management.type_auto') : t('backup_management.type_manual')}
                           </span>
                         </td>
-                        <td style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+                        <td className="backup-version">
                           v{backup.meshmonitorVersion}
                         </td>
-                        <td style={{ textAlign: 'center' }}>{backup.tableCount}</td>
+                        <td className="backup-tables-count">{backup.tableCount}</td>
                         <td>{formatFileSize(backup.size)}</td>
                         <td>
-                          <div style={{ display: 'flex', gap: '0.5rem' }}>
+                          <div className="backup-action-group">
                             <button
                               className="backup-action-button download"
                               onClick={() => handleDownloadBackup(backup.dirname)}

--- a/src/styles/BackupManagement.css
+++ b/src/styles/BackupManagement.css
@@ -16,11 +16,81 @@
   background-color: #000000;
   padding: 2rem;
   border-radius: 8px;
-  max-width: 800px;
-  width: 90%;
+  max-width: 90vw;
+  width: fit-content;
+  min-width: 600px;
   max-height: 80vh;
   overflow: auto;
   margin-left: var(--sidebar-width, 60px);
+}
+
+/* Override generic modal-content max-width for backup modals */
+.modal-content.backup-modal {
+  max-width: 90vw;
+  width: fit-content;
+  min-width: 600px;
+}
+
+.modal-content.backup-modal .backup-list {
+  padding: 0 1.5rem;
+}
+
+.modal-content.backup-modal .modal-footer {
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--ctp-surface0);
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* Emoji action buttons — styled consistently */
+.backup-action-button {
+  background: var(--ctp-surface0);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 1.1rem;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+  padding: 0;
+}
+
+.backup-action-button:hover {
+  background: var(--ctp-surface1);
+  transform: translateY(-1px);
+}
+
+.backup-action-button.download:hover {
+  background: var(--ctp-green);
+  border-color: var(--ctp-green);
+}
+
+.backup-action-button.delete:hover {
+  background: var(--ctp-red);
+  border-color: var(--ctp-red);
+}
+
+.backup-version {
+  font-size: 0.85rem;
+  color: var(--ctp-subtext0);
+}
+
+.backup-dirname {
+  font-family: monospace;
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.backup-tables-count {
+  text-align: center;
+}
+
+.backup-action-group {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .backup-modal-content h3 {
@@ -57,6 +127,7 @@
 .backup-filename {
   font-family: monospace;
   font-size: 0.9rem;
+  white-space: nowrap;
 }
 
 .backup-date {


### PR DESCRIPTION
## Summary
- Override generic `.modal-content` max-width (500px) for backup modals so the 7-column table fits
- Style emoji action buttons (📥 🗑️) with background, borders, and color-coded hover effects
- Add proper padding to modal footer and backup list content area
- Replace inline styles with CSS classes for consistency

## Test plan
- [ ] Open Configuration > System Backup > View Saved Backups
- [ ] Verify modal is wide enough for the table content
- [ ] Verify download/delete emoji buttons have styled backgrounds and hover effects
- [ ] Verify Close button has spacing from modal edges
- [ ] Verify mobile layout still works (card-style rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)