### PR TITLE
fix: MeshCore contacts not auto-updating on map and monitor page

### DIFF
--- a/src/components/MeshCore/MeshCoreTab.tsx
+++ b/src/components/MeshCore/MeshCoreTab.tsx
@@ -277,6 +277,7 @@ export const MeshCoreTab: React.FC<MeshCoreTabProps> = ({ baseUrl }) => {
       const data = await response.json();
       if (data.success) {
         setContacts(data.data);
+        setMeshCoreNodes(mapContactsToNodes(data.data));
       }
     } catch (err) {
       console.error('Refresh error:', err);

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -309,12 +309,13 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     setIsTouchDevice(checkTouch());
   }, []);
 
-  // Auto-fetch MeshCore contacts for map display when MeshCore is enabled
-  // This ensures nodes appear on the Nodes page even if MeshCoreTab hasn't been visited
+  // Poll MeshCore contacts for map display when MeshCore is enabled
+  // Refreshes every 10 seconds to keep map and node list in sync with device
   useEffect(() => {
-    if (!authStatus?.meshcoreEnabled || meshCoreNodes.length > 0) return;
+    if (!authStatus?.meshcoreEnabled) return;
     let cancelled = false;
-    (async () => {
+
+    const fetchMeshCoreContacts = async () => {
       try {
         const baseUrl = await api.getBaseUrl();
         const response = await csrfFetch(`${baseUrl}/api/meshcore/contacts`);
@@ -325,9 +326,16 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
       } catch {
         // MeshCore not connected or unavailable — no action needed
       }
-    })();
-    return () => { cancelled = true; };
-  }, [authStatus?.meshcoreEnabled, meshCoreNodes.length, setMeshCoreNodes, csrfFetch]);
+    };
+
+    fetchMeshCoreContacts();
+    const interval = setInterval(fetchMeshCoreContacts, 10000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [authStatus?.meshcoreEnabled, setMeshCoreNodes, csrfFetch]);
 
   // Ref for spiderfier controller to manage overlapping markers
   const spiderfierRef = useRef<SpiderfierControllerRef>(null);


### PR DESCRIPTION
## Summary
- **NodesTab**: Replaced one-time MeshCore contacts fetch with 10-second polling interval, guarded by `meshcoreEnabled` check
- **MeshCoreTab**: Added `setMeshCoreNodes()` call to the Refresh button handler so the map updates immediately alongside the local contacts state

Fixes the reported issue where MeshCore nodes only updated on the map when manually clicking "Refresh" on the Contacts List.

## Test plan
- [ ] Enable MeshCore and connect to a device
- [ ] Verify map markers update automatically without clicking Refresh
- [ ] Verify MeshCore Monitor page shows updated contacts automatically
- [ ] Click Refresh and verify map updates immediately
- [ ] Verify no polling occurs when MeshCore is disabled
- [ ] All 139 test files pass (2933 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)