### PR TITLE
feat: add Packet Monitor as sidebar tab

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -25,6 +25,7 @@
   "nav.pin_sidebar": "Pin sidebar open",
   "nav.unpin_sidebar": "Unpin sidebar",
   "nav.search": "Search",
+  "nav.packet_monitor": "Packet Monitor",
 
   "search.title": "Search Messages",
   "search.placeholder": "Search for text in messages...",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import NodesTab from './components/NodesTab';
 import MessagesTab from './components/MessagesTab';
 import ChannelsTab from './components/ChannelsTab';
 import { MeshCoreTab } from './components/MeshCore';
+import PacketMonitorPanel from './components/PacketMonitorPanel';
 import AutoAcknowledgeSection from './components/AutoAcknowledgeSection';
 import AutoTracerouteSection from './components/AutoTracerouteSection';
 import AutoAnnounceSection from './components/AutoAnnounceSection';
@@ -54,6 +55,7 @@ import { MeshMessage } from './types/message';
 import { SortField, SortDirection, NodeFilters } from './types/ui';
 import { ResourceType } from './types/permission';
 import api, { type ChannelDatabaseEntry } from './services/api';
+import { getPacketStats } from './services/packetApi';
 import { logger } from './utils/logger';
 // generateArrowMarkers moved to useTraceroutePaths hook
 import { isNodeComplete, getEffectivePosition } from './utils/nodeHelpers';
@@ -148,6 +150,7 @@ function App() {
   const [emojiPickerMessage, setEmojiPickerMessage] = useState<MeshMessage | null>(null);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [focusMessageId, setFocusMessageId] = useState<string | null>(null);
+  const [packetLogEnabled, setPacketLogEnabled] = useState(false);
 
   // Check if mobile viewport and default to collapsed on mobile
   const isMobileViewport = () => window.innerWidth <= 768;
@@ -444,6 +447,20 @@ function App() {
     checkUnreadNews();
   }, [authStatus?.authenticated]);
 
+  // Check if packet logging is enabled on the server
+  useEffect(() => {
+    const checkPacketLogStatus = async () => {
+      if (!authStatus?.authenticated) return;
+      try {
+        const stats = await getPacketStats();
+        setPacketLogEnabled(stats.enabled === true);
+      } catch {
+        logger.debug('Failed to fetch packet log status');
+      }
+    };
+    checkPacketLogStatus();
+  }, [authStatus?.authenticated]);
+
   // Messaging context
   const {
     selectedDMNode,
@@ -569,6 +586,7 @@ function App() {
       admin: () => isAdmin,
       audit: () => hasPermission('audit', 'read'),
       security: () => hasPermission('security', 'read'),
+      packetmonitor: () => hasPermission('messages', 'read') && Array.from({ length: 8 }, (_, i) => hasPermission(`channel_${i}` as ResourceType, 'read')).some(Boolean),
     };
 
     // Check if current tab requires permission
@@ -4525,6 +4543,7 @@ function App() {
         baseUrl={baseUrl}
         connectedNodeName={connectedNodeName}
         meshcoreEnabled={authStatus?.meshcoreEnabled || false}
+        packetLogEnabled={packetLogEnabled}
         onSearchClick={() => setIsSearchOpen(true)}
       />
 
@@ -4991,6 +5010,11 @@ function App() {
           </ErrorBoundary>
         )}
         {activeTab === 'meshcore' && <ErrorBoundary fallbackTitle="MeshCore failed to load"><MeshCoreTab baseUrl={baseUrl} /></ErrorBoundary>}
+        {activeTab === 'packetmonitor' && (
+          <ErrorBoundary fallbackTitle="Packet Monitor failed to load">
+            <PacketMonitorPanel onClose={() => setActiveTab('nodes')} />
+          </ErrorBoundary>
+        )}
       </main>
 
       {/* Node Popup */}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  Map, MessageSquare, Mail, Search, Info, LayoutDashboard, Radio,
+  Map, MessageSquare, Mail, Search, Info, LayoutDashboard, Radio, Activity,
   Settings, Bot, Satellite, Bell, Users, Zap, ClipboardList, Shield,
 } from 'lucide-react';
 import './Sidebar.css';
@@ -29,6 +29,7 @@ interface SidebarProps {
   baseUrl: string;
   connectedNodeName?: string;
   meshcoreEnabled?: boolean;
+  packetLogEnabled?: boolean;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
@@ -44,7 +45,8 @@ const Sidebar: React.FC<SidebarProps> = ({
   onSearchClick,
   baseUrl,
   connectedNodeName,
-  meshcoreEnabled
+  meshcoreEnabled,
+  packetLogEnabled
 }) => {
   const { t } = useTranslation();
   // Start collapsed (narrow/icon-only) by default for cleaner desktop UI
@@ -203,6 +205,9 @@ const Sidebar: React.FC<SidebarProps> = ({
           )}
           {meshcoreEnabled && hasPermission('meshcore', 'read') && (
             <NavItem id="meshcore" label={t('nav.meshcore', 'MeshCore')} icon={<Radio size={20} />} />
+          )}
+          {packetLogEnabled && hasAnyChannelPermission() && hasPermission('messages', 'read') && (
+            <NavItem id="packetmonitor" label={t('nav.packet_monitor', 'Packet Monitor')} icon={<Activity size={20} />} />
           )}
         </div>
 

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -51,7 +51,7 @@ interface UIProviderProps {
 }
 
 // Valid tab types for hash validation
-const VALID_TABS: TabType[] = ['nodes', 'channels', 'messages', 'info', 'settings', 'automation', 'dashboard', 'configuration', 'notifications', 'users', 'audit', 'security', 'themes', 'admin', 'meshcore'];
+const VALID_TABS: TabType[] = ['nodes', 'channels', 'messages', 'info', 'settings', 'automation', 'dashboard', 'configuration', 'notifications', 'users', 'audit', 'security', 'themes', 'admin', 'meshcore', 'packetmonitor'];
 
 // Helper to get tab from URL hash
 const getTabFromHash = (): TabType => {

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -13,7 +13,8 @@ export type TabType =
   | 'security'
   | 'themes'
   | 'admin'
-  | 'meshcore';
+  | 'meshcore'
+  | 'packetmonitor';
 
 export type SortField = 'longName' | 'shortName' | 'id' | 'lastHeard' | 'snr' | 'battery' | 'hwModel' | 'hops';
 


### PR DESCRIPTION
## Summary
- Adds Packet Monitor as a dedicated sidebar navigation item with Activity icon
- Full-page view when selected, alongside the existing map-embedded split-view panel
- Gated by same permissions: packet logging enabled + channel read + messages read
- Accessible via URL hash `#packetmonitor`

Closes #2179

## Test plan
- [x] All 10 system tests pass
- [x] TypeScript compiles cleanly
- [x] Verified sidebar icon appears when packet logging is enabled
- [x] Full-page packet monitor renders correctly
- [x] Map-embedded packet monitor still works independently
- [x] Close button navigates back to Nodes tab

$(cat test-results.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)