### PR TITLE
chore: bump version to 3.8.5

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "3.8.4",
+  "version": "3.8.5",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/PERMISSIONS_QUICK_REFERENCE.md
+++ b/docs/PERMISSIONS_QUICK_REFERENCE.md
@@ -17,6 +17,9 @@
 | **audit** | Audit log viewing | None | GET /api/audit<br>GET /api/audit/:id<br>GET /api/audit/stats/summary | POST /api/audit/cleanup |
 | **security** | Security scanning | None | GET /api/security/issues<br>GET /api/security/scanner/status<br>GET /api/security/export | POST /api/security/scanner/scan |
 | **themes** | Custom themes | Read Only | - | POST /api/themes<br>PUT /api/themes/:slug<br>DELETE /api/themes/:slug |
+| **packetmonitor** | Packet Monitor access | Read Only | GET /api/packets<br>GET /api/packets/stats<br>GET /api/packets/export<br>GET /api/packets/:id | - (read-only) |
+| **nodes_private** | Private node data | None | - | - |
+| **meshcore** | MeshCore features | None | - | - |
 
 ## Key Database Tables
 
@@ -65,9 +68,9 @@ permissions (
 dashboard: R W      messages: R W       audit: R W
 nodes: R W          settings: R W       security: R W
 channel_0: R W      configuration: R W  themes: R W
-channel_1: R W      automation: R W
-channel_2: R W      connection: R W
-channel_3: R W      traceroute: R W
+channel_1: R W      automation: R W     packetmonitor: R -
+channel_2: R W      connection: R W     nodes_private: R W
+channel_3: R W      traceroute: R W     meshcore: R W
 channel_4: R W
 channel_5: R W
 channel_6: R W
@@ -79,9 +82,9 @@ channel_7: R W
 dashboard: R -      messages: R -       audit: - -
 nodes: R -          settings: - -       security: - -
 channel_0: R -      configuration: - -  themes: R -
-channel_1: R -      automation: - -
-channel_2: R -      connection: R -
-channel_3: R -      traceroute: R -
+channel_1: R -      automation: - -     packetmonitor: R -
+channel_2: R -      connection: R -     nodes_private: - -
+channel_3: R -      traceroute: R -     meshcore: - -
 channel_4: R -
 channel_5: R -
 channel_6: R -
@@ -101,7 +104,8 @@ export type ResourceType =
   | 'automation' | 'connection' | 'traceroute'
   | 'audit' | 'security' | 'themes'
   | 'channel_0' | 'channel_1' | 'channel_2' | 'channel_3'
-  | 'channel_4' | 'channel_5' | 'channel_6' | 'channel_7';
+  | 'channel_4' | 'channel_5' | 'channel_6' | 'channel_7'
+  | 'nodes_private' | 'meshcore' | 'packetmonitor';
 
 export type PermissionAction = 'read' | 'write';
 
@@ -182,6 +186,15 @@ Logs to: audit_log
 - Automatically migrated to individual channel_0-7 permissions
 - Old 'channels' permissions are split: read → all channels read, write → all channels write
 
+### Packet Monitor Permission (v3.8.5+)
+- `packetmonitor:read` controls access to the Packet Monitor feature
+- Read-only — no write permission exists
+- Once access is granted, packets are filtered by the user's other permissions:
+  - Encrypted packets are always visible
+  - Decrypted channel packets require `channel_N:read` on the corresponding channel
+  - TEXT_MESSAGE_APP DMs require `messages:read`
+  - Admin users bypass all filtering
+
 ### No Node-Specific Permissions
 - 'nodes' resource is global
 - Cannot restrict access to specific nodes
@@ -204,6 +217,8 @@ Logs to: audit_log
 | Middleware | `/src/server/auth/authMiddleware.ts` |
 | User management API | `/src/server/routes/userRoutes.ts` |
 | Frontend UI | `/src/components/UsersTab.tsx` |
-| Database migrations | `/src/server/migrations/001-024*.ts` |
+| Database migrations | `/src/server/migrations/001-082*.ts` |
 | Per-channel migration | `/src/server/migrations/024_add_per_channel_permissions.ts` |
+| Packet monitor permission | `/src/server/migrations/082_add_packetmonitor_permission.ts` |
+| Packet routes (server-side filtering) | `/src/server/routes/packetRoutes.ts` |
 

--- a/docs/features/packet-monitor.md
+++ b/docs/features/packet-monitor.md
@@ -6,7 +6,12 @@ The Packet Monitor is a diagnostic tool that displays raw Meshtastic packets as 
 
 ## Accessing the Packet Monitor
 
-The Packet Monitor appears at the bottom of the Map tab once enabled in Settings. It requires appropriate permissions to view.
+The Packet Monitor is available in two locations:
+
+- **Sidebar tab** — Click the Packet Monitor icon in the sidebar for a full-page view
+- **Map panel** — The Packet Monitor also appears at the bottom of the Map tab
+
+Both views require the `packetmonitor:read` permission and must be enabled in Settings.
 
 ## What the Packet Monitor Shows
 
@@ -83,11 +88,31 @@ Each packet entry shows:
 
 ## Permissions
 
-Viewing the Packet Monitor requires:
-- `channel_0:read` permission
-- `messages:read` permission
+### Access Permission
 
-These permissions are typically granted to admin users or can be configured per-user in the Admin tab.
+Viewing the Packet Monitor requires the `packetmonitor:read` permission. This is granted by default to all users (including Anonymous). Administrators can revoke it per-user in **Settings > Users**. The Packet Monitor permission is read-only — there is no write mode.
+
+### Packet Filtering by Permission
+
+Once a user has access to the Packet Monitor, the packets they see are filtered based on their other permissions:
+
+| Packet Type | Permission Required |
+|-------------|-------------------|
+| Encrypted packets | None — always visible (content is unreadable) |
+| Decrypted channel packets | `channel_N:read` for the packet's channel (0-7) |
+| Direct Messages (TEXT_MESSAGE_APP to a specific node) | `messages:read` (Direct Messages: Read) |
+| Other decrypted packets (POSITION, TELEMETRY, etc.) | `channel_N:read` for the packet's channel |
+| Packets with no channel info | Always visible |
+
+Admin users bypass all filtering and see all packets.
+
+::: tip Example
+A user with `packetmonitor:read`, `channel_0:read`, and `channel_1:read` (but no `messages:read`) will see:
+- All encrypted packets
+- Decrypted packets on channels 0 and 1
+- Non-DM packets on channels 0 and 1
+- **Not** direct message text packets (they need `messages:read` for those)
+:::
 
 ## Use Cases
 

--- a/docs/public/news.json
+++ b/docs/public/news.json
@@ -1,7 +1,16 @@
 {
   "version": "1",
-  "lastUpdated": "2026-03-03T18:00:00Z",
+  "lastUpdated": "2026-03-09T18:00:00Z",
   "items": [
+    {
+      "minVersion": "3.8.5",
+      "id": "news-2026-03-09-packet-monitor-permissions",
+      "title": "MeshMonitor v3.8.5 - Packet Monitor Permission & Filtering",
+      "content": "MeshMonitor v3.8.5 introduces a dedicated **Packet Monitor** permission resource and granular packet filtering based on channel and message permissions.\n\n## New Packet Monitor Permission\n\nThe Packet Monitor now has its own **packetmonitor:read** permission, replacing the previous requirement for `channel_0:read + messages:read`. This gives administrators more precise control over who can access the packet monitoring feature.\n\n## Action Required\n\nAdministrators should review their user permissions:\n\n1. Navigate to **Settings > Users** and select each user\n2. Verify the **Packet Monitor** read permission is set appropriately\n3. New users and the Anonymous user receive **Packet Monitor: Read** by default\n4. The Packet Monitor permission is read-only — there is no write mode\n\n## Channel-Based Packet Filtering\n\nPacket Monitor now filters packets based on your channel permissions:\n\n- **Encrypted packets** are always visible (content is unreadable anyway)\n- **Decrypted channel packets** require **Read** permission on the corresponding channel (channel_0 through channel_7)\n- **Direct Message packets** (TEXT_MESSAGE_APP to a specific node) require **Direct Messages: Read** permission\n- **Admin users** bypass all filtering and see all packets\n\nThis means non-admin users will only see packets from channels they have access to, while still being able to see encrypted traffic for signal analysis.\n\n## Other Changes\n\n- **Packet Monitor sidebar tab** — Packet Monitor is now accessible as a dedicated sidebar tab in addition to the map panel ([#2180](https://github.com/Yeraze/meshmonitor/pull/2180))\n- **Virtual Node config loop fix** — Prevents reconnect loops caused by cached `rebooted` messages ([#2182](https://github.com/Yeraze/meshmonitor/pull/2182))\n- **Debug cleanup** — Removed stale debug logging and backup file ([#2183](https://github.com/Yeraze/meshmonitor/pull/2183))\n- **Dependency updates** — Updated mysql2, express-rate-limit, pg, recharts, and GitHub Actions",
+      "date": "2026-03-09T18:00:00Z",
+      "category": "feature",
+      "priority": "important"
+    },
     {
       "minVersion": "3.8.0",
       "id": "news-2026-03-03-firmware-management",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.8.4
-appVersion: "3.8.4"
+version: 3.8.5
+appVersion: "3.8.5"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.8.4",
+      "version": "3.8.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -4488,7 +4488,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4787,7 +4787,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -4820,6 +4820,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7154,6 +7155,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -13219,7 +13221,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -13861,14 +13864,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -15350,7 +15345,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

- Bump version to 3.8.5 across package.json, Helm chart, Tauri config, and desktop package.json
- Add news entry for Packet Monitor permission system with admin action reminder
- Update Packet Monitor documentation with new permission model, sidebar tab access, and channel/DM filtering details
- Update permissions quick reference with `packetmonitor`, `nodes_private`, and `meshcore` resources

## Changes since 3.8.4

- **Packet Monitor sidebar tab** — Dedicated sidebar navigation item (#2180)
- **Packet Monitor permission** — New `packetmonitor:read` permission resource (#2181)
- **Channel-based packet filtering** — Server-side filtering by channel and DM permissions (#2181)
- **Virtual Node config loop fix** — Prevent reconnect loops from cached rebooted messages (#2182)
- **Debug cleanup** — Remove stale debug logging and backup file (#2183)
- **Dependency updates** — mysql2, express-rate-limit, pg, recharts, GitHub Actions

## Test plan

- [ ] Version numbers correct in all 4 files
- [ ] News entry renders correctly in frontend
- [ ] Packet Monitor docs accurate on website
- [ ] System tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)