### PR TITLE
perf: use SQL COUNT(*) instead of loading entire tables for count queries

### DIFF
--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -4,7 +4,7 @@
  * Handles all channel-related database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, and, gt, isNull, or, lt } from 'drizzle-orm';
+import { eq, and, gt, isNull, or, lt, count } from 'drizzle-orm';
 import { channelsSqlite, channelsPostgres, channelsMysql } from '../schema/channels.js';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbChannel } from '../types.js';
@@ -120,22 +120,16 @@ export class ChannelsRepository extends BaseRepository {
   async getChannelCount(): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const result = await db
-        .select()
-        .from(channelsSqlite);
-      return result.length;
+      const result = await db.select({ count: count() }).from(channelsSqlite);
+      return Number(result[0].count);
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const result = await db
-        .select()
-        .from(channelsMysql);
-      return result.length;
+      const result = await db.select({ count: count() }).from(channelsMysql);
+      return Number(result[0].count);
     } else {
       const db = this.getPostgresDb();
-      const result = await db
-        .select()
-        .from(channelsPostgres);
-      return result.length;
+      const result = await db.select({ count: count() }).from(channelsPostgres);
+      return Number(result[0].count);
     }
   }
 

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -4,7 +4,7 @@
  * Handles all message-related database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, gt, lt, gte, and, or, desc, sql, like, ilike, inArray, isNotNull, ne, SQL } from 'drizzle-orm';
+import { eq, gt, lt, gte, and, or, desc, sql, like, ilike, inArray, isNotNull, ne, SQL, count } from 'drizzle-orm';
 import { messagesSqlite, messagesPostgres, messagesMysql } from '../schema/messages.js';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbMessage } from '../types.js';
@@ -335,16 +335,16 @@ export class MessagesRepository extends BaseRepository {
   async getMessageCount(): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const result = await db.select().from(messagesSqlite);
-      return result.length;
+      const result = await db.select({ count: count() }).from(messagesSqlite);
+      return Number(result[0].count);
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const result = await db.select().from(messagesMysql);
-      return result.length;
+      const result = await db.select({ count: count() }).from(messagesMysql);
+      return Number(result[0].count);
     } else {
       const db = this.getPostgresDb();
-      const result = await db.select().from(messagesPostgres);
-      return result.length;
+      const result = await db.select({ count: count() }).from(messagesPostgres);
+      return Number(result[0].count);
     }
   }
 
@@ -693,25 +693,22 @@ export class MessagesRepository extends BaseRepository {
   async deleteAllMessages(): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const count = await db
-        .select({ id: messagesSqlite.id })
-        .from(messagesSqlite);
+      const result = await db.select({ count: count() }).from(messagesSqlite);
+      const total = Number(result[0].count);
       await db.delete(messagesSqlite);
-      return count.length;
+      return total;
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const count = await db
-        .select({ id: messagesMysql.id })
-        .from(messagesMysql);
+      const result = await db.select({ count: count() }).from(messagesMysql);
+      const total = Number(result[0].count);
       await db.delete(messagesMysql);
-      return count.length;
+      return total;
     } else {
       const db = this.getPostgresDb();
-      const count = await db
-        .select({ id: messagesPostgres.id })
-        .from(messagesPostgres);
+      const result = await db.select({ count: count() }).from(messagesPostgres);
+      const total = Number(result[0].count);
       await db.delete(messagesPostgres);
-      return count.length;
+      return total;
     }
   }
 

--- a/src/db/repositories/neighbors.ts
+++ b/src/db/repositories/neighbors.ts
@@ -4,7 +4,7 @@
  * Handles neighbor info database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, desc, and, gte, sql } from 'drizzle-orm';
+import { eq, desc, and, gte, sql, count } from 'drizzle-orm';
 import { neighborInfoSqlite, neighborInfoPostgres, neighborInfoMysql } from '../schema/neighbors.js';
 import { packetLogSqlite, packetLogPostgres, packetLogMysql } from '../schema/packets.js';
 import { BaseRepository, DrizzleDatabase } from './base.js';
@@ -164,16 +164,16 @@ export class NeighborsRepository extends BaseRepository {
   async getNeighborCount(): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const result = await db.select().from(neighborInfoSqlite);
-      return result.length;
+      const result = await db.select({ count: count() }).from(neighborInfoSqlite);
+      return Number(result[0].count);
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const result = await db.select().from(neighborInfoMysql);
-      return result.length;
+      const result = await db.select({ count: count() }).from(neighborInfoMysql);
+      return Number(result[0].count);
     } else {
       const db = this.getPostgresDb();
-      const result = await db.select().from(neighborInfoPostgres);
-      return result.length;
+      const result = await db.select({ count: count() }).from(neighborInfoPostgres);
+      return Number(result[0].count);
     }
   }
 

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -4,7 +4,7 @@
  * Handles all telemetry-related database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, lt, gte, and, desc, inArray, or, not, SQL } from 'drizzle-orm';
+import { eq, lt, gte, and, desc, inArray, or, not, SQL, count } from 'drizzle-orm';
 import { telemetrySqlite, telemetryPostgres, telemetryMysql } from '../schema/telemetry.js';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbTelemetry } from '../types.js';
@@ -54,16 +54,16 @@ export class TelemetryRepository extends BaseRepository {
   async getTelemetryCount(): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const result = await db.select().from(telemetrySqlite);
-      return result.length;
+      const result = await db.select({ count: count() }).from(telemetrySqlite);
+      return Number(result[0].count);
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const result = await db.select().from(telemetryMysql);
-      return result.length;
+      const result = await db.select({ count: count() }).from(telemetryMysql);
+      return Number(result[0].count);
     } else {
       const db = this.getPostgresDb();
-      const result = await db.select().from(telemetryPostgres);
-      return result.length;
+      const result = await db.select({ count: count() }).from(telemetryPostgres);
+      return Number(result[0].count);
     }
   }
 

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -4,7 +4,7 @@
  * Handles traceroute and route segment database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, and, desc, lt, or, isNull, gte, notInArray } from 'drizzle-orm';
+import { eq, and, desc, lt, or, isNull, gte, notInArray, count } from 'drizzle-orm';
 import {
   traceroutesSqlite, traceroutesPostgres, traceroutesMysql,
   routeSegmentsSqlite, routeSegmentsPostgres, routeSegmentsMysql,
@@ -380,16 +380,16 @@ export class TraceroutesRepository extends BaseRepository {
   async getTracerouteCount(): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const result = await db.select().from(traceroutesSqlite);
-      return result.length;
+      const result = await db.select({ count: count() }).from(traceroutesSqlite);
+      return Number(result[0].count);
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const result = await db.select().from(traceroutesMysql);
-      return result.length;
+      const result = await db.select({ count: count() }).from(traceroutesMysql);
+      return Number(result[0].count);
     } else {
       const db = this.getPostgresDb();
-      const result = await db.select().from(traceroutesPostgres);
-      return result.length;
+      const result = await db.select({ count: count() }).from(traceroutesPostgres);
+      return Number(result[0].count);
     }
   }
 
@@ -611,25 +611,22 @@ export class TraceroutesRepository extends BaseRepository {
   async deleteAllTraceroutes(): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const count = await db
-        .select({ id: traceroutesSqlite.id })
-        .from(traceroutesSqlite);
+      const result = await db.select({ count: count() }).from(traceroutesSqlite);
+      const total = Number(result[0].count);
       await db.delete(traceroutesSqlite);
-      return count.length;
+      return total;
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const count = await db
-        .select({ id: traceroutesMysql.id })
-        .from(traceroutesMysql);
+      const result = await db.select({ count: count() }).from(traceroutesMysql);
+      const total = Number(result[0].count);
       await db.delete(traceroutesMysql);
-      return count.length;
+      return total;
     } else {
       const db = this.getPostgresDb();
-      const count = await db
-        .select({ id: traceroutesPostgres.id })
-        .from(traceroutesPostgres);
+      const result = await db.select({ count: count() }).from(traceroutesPostgres);
+      const total = Number(result[0].count);
       await db.delete(traceroutesPostgres);
-      return count.length;
+      return total;
     }
   }
 
@@ -639,25 +636,22 @@ export class TraceroutesRepository extends BaseRepository {
   async deleteAllRouteSegments(): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const count = await db
-        .select({ id: routeSegmentsSqlite.id })
-        .from(routeSegmentsSqlite);
+      const result = await db.select({ count: count() }).from(routeSegmentsSqlite);
+      const total = Number(result[0].count);
       await db.delete(routeSegmentsSqlite);
-      return count.length;
+      return total;
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const count = await db
-        .select({ id: routeSegmentsMysql.id })
-        .from(routeSegmentsMysql);
+      const result = await db.select({ count: count() }).from(routeSegmentsMysql);
+      const total = Number(result[0].count);
       await db.delete(routeSegmentsMysql);
-      return count.length;
+      return total;
     } else {
       const db = this.getPostgresDb();
-      const count = await db
-        .select({ id: routeSegmentsPostgres.id })
-        .from(routeSegmentsPostgres);
+      const result = await db.select({ count: count() }).from(routeSegmentsPostgres);
+      const total = Number(result[0].count);
       await db.delete(routeSegmentsPostgres);
-      return count.length;
+      return total;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace `SELECT * FROM table` + `.length` with Drizzle's `count()` aggregate across 5 repository files
- Affects `getTelemetryCount()`, `getTracerouteCount()`, `getMessageCount()`, `getNeighborCount()`, `getChannelCount()`
- Also fixes `deleteAllTraceroutes()`, `deleteAllRouteSegments()`, and `deleteAllMessages()` which loaded all rows just to get a count before deleting
- Uses `Number()` coercion for PostgreSQL bigint compatibility
- All changes applied consistently across all 3 database backends (SQLite, PostgreSQL, MySQL)

## Why
Count methods were doing `SELECT * FROM table` then returning `result.length`, loading every row into memory. For large tables (telemetry can have hundreds of thousands of rows, messages and traceroutes similarly), this causes unnecessary memory pressure and slow responses — especially on resource-constrained deployments like Raspberry Pi.

The fix uses SQL's native `COUNT(*)` which is handled entirely by the database engine without transferring row data.

## Example change
```typescript
// Before: loads ALL rows into Node.js memory
const result = await db.select().from(telemetrySqlite);
return result.length;

// After: database counts rows internally
const result = await db.select({ count: count() }).from(telemetrySqlite);
return Number(result[0].count);
```

## Files changed
- `src/db/repositories/telemetry.ts` — `getTelemetryCount()`
- `src/db/repositories/traceroutes.ts` — `getTracerouteCount()`, `deleteAllTraceroutes()`, `deleteAllRouteSegments()`
- `src/db/repositories/messages.ts` — `getMessageCount()`, `deleteAllMessages()`
- `src/db/repositories/neighbors.ts` — `getNeighborCount()`
- `src/db/repositories/channels.ts` — `getChannelCount()`

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx vitest run` — all tests pass (4 pre-existing failures in meshtasticProtobufService unrelated to this change)
- [ ] Verify count endpoints return correct values via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)