### PR TITLE
perf: convert N+1 delete loops to batch DELETE operations

### DIFF
--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -394,37 +394,28 @@ export class MessagesRepository extends BaseRepository {
   async purgeChannelMessages(channel: number): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const toDelete = await db
-        .select({ id: messagesSqlite.id })
+      const [{ deletedCount }] = await db
+        .select({ deletedCount: count() })
         .from(messagesSqlite)
         .where(eq(messagesSqlite.channel, channel));
-
-      for (const msg of toDelete) {
-        await db.delete(messagesSqlite).where(eq(messagesSqlite.id, msg.id));
-      }
-      return toDelete.length;
+      await db.delete(messagesSqlite).where(eq(messagesSqlite.channel, channel));
+      return deletedCount;
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const toDelete = await db
-        .select({ id: messagesMysql.id })
+      const [{ deletedCount }] = await db
+        .select({ deletedCount: count() })
         .from(messagesMysql)
         .where(eq(messagesMysql.channel, channel));
-
-      for (const msg of toDelete) {
-        await db.delete(messagesMysql).where(eq(messagesMysql.id, msg.id));
-      }
-      return toDelete.length;
+      await db.delete(messagesMysql).where(eq(messagesMysql.channel, channel));
+      return deletedCount;
     } else {
       const db = this.getPostgresDb();
-      const toDelete = await db
-        .select({ id: messagesPostgres.id })
+      const [{ deletedCount }] = await db
+        .select({ deletedCount: count() })
         .from(messagesPostgres)
         .where(eq(messagesPostgres.channel, channel));
-
-      for (const msg of toDelete) {
-        await db.delete(messagesPostgres).where(eq(messagesPostgres.id, msg.id));
-      }
-      return toDelete.length;
+      await db.delete(messagesPostgres).where(eq(messagesPostgres.channel, channel));
+      return deletedCount;
     }
   }
 
@@ -434,61 +425,49 @@ export class MessagesRepository extends BaseRepository {
   async purgeDirectMessages(nodeNum: number): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const toDelete = await db
-        .select({ id: messagesSqlite.id })
+      const condition = and(
+        or(
+          eq(messagesSqlite.fromNodeNum, nodeNum),
+          eq(messagesSqlite.toNodeNum, nodeNum)
+        ),
+        sql`${messagesSqlite.toNodeId} != '!ffffffff'`
+      );
+      const [{ deletedCount }] = await db
+        .select({ deletedCount: count() })
         .from(messagesSqlite)
-        .where(
-          and(
-            or(
-              eq(messagesSqlite.fromNodeNum, nodeNum),
-              eq(messagesSqlite.toNodeNum, nodeNum)
-            ),
-            sql`${messagesSqlite.toNodeId} != '!ffffffff'`
-          )
-        );
-
-      for (const msg of toDelete) {
-        await db.delete(messagesSqlite).where(eq(messagesSqlite.id, msg.id));
-      }
-      return toDelete.length;
+        .where(condition);
+      await db.delete(messagesSqlite).where(condition);
+      return deletedCount;
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const toDelete = await db
-        .select({ id: messagesMysql.id })
+      const condition = and(
+        or(
+          eq(messagesMysql.fromNodeNum, nodeNum),
+          eq(messagesMysql.toNodeNum, nodeNum)
+        ),
+        sql`${messagesMysql.toNodeId} != '!ffffffff'`
+      );
+      const [{ deletedCount }] = await db
+        .select({ deletedCount: count() })
         .from(messagesMysql)
-        .where(
-          and(
-            or(
-              eq(messagesMysql.fromNodeNum, nodeNum),
-              eq(messagesMysql.toNodeNum, nodeNum)
-            ),
-            sql`${messagesMysql.toNodeId} != '!ffffffff'`
-          )
-        );
-
-      for (const msg of toDelete) {
-        await db.delete(messagesMysql).where(eq(messagesMysql.id, msg.id));
-      }
-      return toDelete.length;
+        .where(condition);
+      await db.delete(messagesMysql).where(condition);
+      return deletedCount;
     } else {
       const db = this.getPostgresDb();
-      const toDelete = await db
-        .select({ id: messagesPostgres.id })
+      const condition = and(
+        or(
+          eq(messagesPostgres.fromNodeNum, nodeNum),
+          eq(messagesPostgres.toNodeNum, nodeNum)
+        ),
+        sql`${messagesPostgres.toNodeId} != '!ffffffff'`
+      );
+      const [{ deletedCount }] = await db
+        .select({ deletedCount: count() })
         .from(messagesPostgres)
-        .where(
-          and(
-            or(
-              eq(messagesPostgres.fromNodeNum, nodeNum),
-              eq(messagesPostgres.toNodeNum, nodeNum)
-            ),
-            sql`${messagesPostgres.toNodeId} != '!ffffffff'`
-          )
-        );
-
-      for (const msg of toDelete) {
-        await db.delete(messagesPostgres).where(eq(messagesPostgres.id, msg.id));
-      }
-      return toDelete.length;
+        .where(condition);
+      await db.delete(messagesPostgres).where(condition);
+      return deletedCount;
     }
   }
 
@@ -500,37 +479,28 @@ export class MessagesRepository extends BaseRepository {
 
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const toDelete = await db
-        .select({ id: messagesSqlite.id })
+      const [{ deletedCount }] = await db
+        .select({ deletedCount: count() })
         .from(messagesSqlite)
         .where(lt(messagesSqlite.timestamp, cutoff));
-
-      for (const msg of toDelete) {
-        await db.delete(messagesSqlite).where(eq(messagesSqlite.id, msg.id));
-      }
-      return toDelete.length;
+      await db.delete(messagesSqlite).where(lt(messagesSqlite.timestamp, cutoff));
+      return deletedCount;
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const toDelete = await db
-        .select({ id: messagesMysql.id })
+      const [{ deletedCount }] = await db
+        .select({ deletedCount: count() })
         .from(messagesMysql)
         .where(lt(messagesMysql.timestamp, cutoff));
-
-      for (const msg of toDelete) {
-        await db.delete(messagesMysql).where(eq(messagesMysql.id, msg.id));
-      }
-      return toDelete.length;
+      await db.delete(messagesMysql).where(lt(messagesMysql.timestamp, cutoff));
+      return deletedCount;
     } else {
       const db = this.getPostgresDb();
-      const toDelete = await db
-        .select({ id: messagesPostgres.id })
+      const [{ deletedCount }] = await db
+        .select({ deletedCount: count() })
         .from(messagesPostgres)
         .where(lt(messagesPostgres.timestamp, cutoff));
-
-      for (const msg of toDelete) {
-        await db.delete(messagesPostgres).where(eq(messagesPostgres.id, msg.id));
-      }
-      return toDelete.length;
+      await db.delete(messagesPostgres).where(lt(messagesPostgres.timestamp, cutoff));
+      return deletedCount;
     }
   }
 

--- a/src/db/repositories/neighbors.ts
+++ b/src/db/repositories/neighbors.ts
@@ -124,37 +124,28 @@ export class NeighborsRepository extends BaseRepository {
   async deleteNeighborInfoForNode(nodeNum: number): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const toDelete = await db
-        .select({ id: neighborInfoSqlite.id })
+      const [{ deletedCount }] = await db
+        .select({ deletedCount: count() })
         .from(neighborInfoSqlite)
         .where(eq(neighborInfoSqlite.nodeNum, nodeNum));
-
-      for (const n of toDelete) {
-        await db.delete(neighborInfoSqlite).where(eq(neighborInfoSqlite.id, n.id));
-      }
-      return toDelete.length;
+      await db.delete(neighborInfoSqlite).where(eq(neighborInfoSqlite.nodeNum, nodeNum));
+      return deletedCount;
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const toDelete = await db
-        .select({ id: neighborInfoMysql.id })
+      const [{ deletedCount }] = await db
+        .select({ deletedCount: count() })
         .from(neighborInfoMysql)
         .where(eq(neighborInfoMysql.nodeNum, nodeNum));
-
-      for (const n of toDelete) {
-        await db.delete(neighborInfoMysql).where(eq(neighborInfoMysql.id, n.id));
-      }
-      return toDelete.length;
+      await db.delete(neighborInfoMysql).where(eq(neighborInfoMysql.nodeNum, nodeNum));
+      return deletedCount;
     } else {
       const db = this.getPostgresDb();
-      const toDelete = await db
-        .select({ id: neighborInfoPostgres.id })
+      const [{ deletedCount }] = await db
+        .select({ deletedCount: count() })
         .from(neighborInfoPostgres)
         .where(eq(neighborInfoPostgres.nodeNum, nodeNum));
-
-      for (const n of toDelete) {
-        await db.delete(neighborInfoPostgres).where(eq(neighborInfoPostgres.id, n.id));
-      }
-      return toDelete.length;
+      await db.delete(neighborInfoPostgres).where(eq(neighborInfoPostgres.nodeNum, nodeNum));
+      return deletedCount;
     }
   }
 


### PR DESCRIPTION
## Summary
- Replace fetch-all-IDs-then-loop-delete patterns with single `DELETE WHERE` queries
- Affects 4 methods across 2 repository files, all 3 database backends (SQLite/PostgreSQL/MySQL)
- Uses `COUNT(*)` before `DELETE` when the caller needs the deleted row count

## Methods fixed

### `src/db/repositories/messages.ts`
- **`purgeChannelMessages(channel)`** — was selecting all message IDs for a channel, then deleting one-by-one in a loop
- **`purgeDirectMessages(nodeNum)`** — same pattern for direct messages matching a node number
- **`cleanupOldMessages(days)`** — same pattern for messages older than N days

### `src/db/repositories/neighbors.ts`
- **`deleteNeighborInfoForNode(nodeNum)`** — was selecting all neighbor IDs for a node, then deleting individually

## Why
These methods were fetching all matching IDs with SELECT, then deleting one-by-one in a `for` loop. For large datasets (e.g., purging thousands of old messages), this created hundreds or thousands of individual DELETE queries instead of a single batch operation.

## Example change
```typescript
// Before (N+1 queries — 1 SELECT + N DELETEs):
const toDelete = await db.select({ id: messages.id }).from(messages).where(eq(messages.channel, channel));
for (const msg of toDelete) {
  await db.delete(messages).where(eq(messages.id, msg.id));
}
return toDelete.length;

// After (2 queries — 1 COUNT + 1 DELETE):
const [{ count: deletedCount }] = await db.select({ count: count() }).from(messages).where(eq(messages.channel, channel));
await db.delete(messages).where(eq(messages.channel, channel));
return Number(deletedCount);
```

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx vitest run` — all tests pass (4 pre-existing failures unrelated to this change)
- [ ] Test message purge/cleanup via admin UI or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)