### PR TITLE
perf: batch SQL operations and COUNT query optimization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -223,7 +223,6 @@ function App() {
   const dmMessagesContainerRef = useRef<HTMLDivElement>(null);
   const lastScrollLoadTimeRef = useRef<number>(0); // Throttle scroll-triggered loads (200ms)
 
-  // const lastNotificationTime = useRef<number>(0) // Disabled for now
   // Detect base URL from pathname
   const detectBaseUrl = () => {
     const pathname = window.location.pathname;

--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -285,43 +285,34 @@ export class ChannelsRepository extends BaseRepository {
   async cleanupInvalidChannels(): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const toDelete = await db
-        .select({ id: channelsSqlite.id })
-        .from(channelsSqlite)
-        .where(or(lt(channelsSqlite.id, 0), gt(channelsSqlite.id, 7)));
-
-      for (const channel of toDelete) {
-        await db.delete(channelsSqlite).where(eq(channelsSqlite.id, channel.id));
+      const whereClause = or(lt(channelsSqlite.id, 0), gt(channelsSqlite.id, 7));
+      const result = await db.select({ count: count() }).from(channelsSqlite).where(whereClause);
+      const deleteCount = Number(result[0].count);
+      if (deleteCount > 0) {
+        await db.delete(channelsSqlite).where(whereClause);
       }
-
-      logger.debug(`Cleaned up ${toDelete.length} invalid channels (outside 0-7 range)`);
-      return toDelete.length;
+      logger.debug(`Cleaned up ${deleteCount} invalid channels (outside 0-7 range)`);
+      return deleteCount;
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const toDelete = await db
-        .select({ id: channelsMysql.id })
-        .from(channelsMysql)
-        .where(or(lt(channelsMysql.id, 0), gt(channelsMysql.id, 7)));
-
-      for (const channel of toDelete) {
-        await db.delete(channelsMysql).where(eq(channelsMysql.id, channel.id));
+      const whereClause = or(lt(channelsMysql.id, 0), gt(channelsMysql.id, 7));
+      const result = await db.select({ count: count() }).from(channelsMysql).where(whereClause);
+      const deleteCount = Number(result[0].count);
+      if (deleteCount > 0) {
+        await db.delete(channelsMysql).where(whereClause);
       }
-
-      logger.debug(`Cleaned up ${toDelete.length} invalid channels (outside 0-7 range)`);
-      return toDelete.length;
+      logger.debug(`Cleaned up ${deleteCount} invalid channels (outside 0-7 range)`);
+      return deleteCount;
     } else {
       const db = this.getPostgresDb();
-      const toDelete = await db
-        .select({ id: channelsPostgres.id })
-        .from(channelsPostgres)
-        .where(or(lt(channelsPostgres.id, 0), gt(channelsPostgres.id, 7)));
-
-      for (const channel of toDelete) {
-        await db.delete(channelsPostgres).where(eq(channelsPostgres.id, channel.id));
+      const whereClause = or(lt(channelsPostgres.id, 0), gt(channelsPostgres.id, 7));
+      const result = await db.select({ count: count() }).from(channelsPostgres).where(whereClause);
+      const deleteCount = Number(result[0].count);
+      if (deleteCount > 0) {
+        await db.delete(channelsPostgres).where(whereClause);
       }
-
-      logger.debug(`Cleaned up ${toDelete.length} invalid channels (outside 0-7 range)`);
-      return toDelete.length;
+      logger.debug(`Cleaned up ${deleteCount} invalid channels (outside 0-7 range)`);
+      return deleteCount;
     }
   }
 
@@ -333,61 +324,46 @@ export class ChannelsRepository extends BaseRepository {
   async cleanupEmptyChannels(): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const toDelete = await db
-        .select({ id: channelsSqlite.id })
-        .from(channelsSqlite)
-        .where(
-          and(
-            gt(channelsSqlite.id, 1),
-            isNull(channelsSqlite.psk),
-            isNull(channelsSqlite.role)
-          )
-        );
-
-      for (const channel of toDelete) {
-        await db.delete(channelsSqlite).where(eq(channelsSqlite.id, channel.id));
+      const whereClause = and(
+        gt(channelsSqlite.id, 1),
+        isNull(channelsSqlite.psk),
+        isNull(channelsSqlite.role)
+      );
+      const result = await db.select({ count: count() }).from(channelsSqlite).where(whereClause);
+      const deleteCount = Number(result[0].count);
+      if (deleteCount > 0) {
+        await db.delete(channelsSqlite).where(whereClause);
       }
-
-      logger.debug(`Cleaned up ${toDelete.length} empty channels (ID > 1, no PSK/role)`);
-      return toDelete.length;
+      logger.debug(`Cleaned up ${deleteCount} empty channels (ID > 1, no PSK/role)`);
+      return deleteCount;
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const toDelete = await db
-        .select({ id: channelsMysql.id })
-        .from(channelsMysql)
-        .where(
-          and(
-            gt(channelsMysql.id, 1),
-            isNull(channelsMysql.psk),
-            isNull(channelsMysql.role)
-          )
-        );
-
-      for (const channel of toDelete) {
-        await db.delete(channelsMysql).where(eq(channelsMysql.id, channel.id));
+      const whereClause = and(
+        gt(channelsMysql.id, 1),
+        isNull(channelsMysql.psk),
+        isNull(channelsMysql.role)
+      );
+      const result = await db.select({ count: count() }).from(channelsMysql).where(whereClause);
+      const deleteCount = Number(result[0].count);
+      if (deleteCount > 0) {
+        await db.delete(channelsMysql).where(whereClause);
       }
-
-      logger.debug(`Cleaned up ${toDelete.length} empty channels (ID > 1, no PSK/role)`);
-      return toDelete.length;
+      logger.debug(`Cleaned up ${deleteCount} empty channels (ID > 1, no PSK/role)`);
+      return deleteCount;
     } else {
       const db = this.getPostgresDb();
-      const toDelete = await db
-        .select({ id: channelsPostgres.id })
-        .from(channelsPostgres)
-        .where(
-          and(
-            gt(channelsPostgres.id, 1),
-            isNull(channelsPostgres.psk),
-            isNull(channelsPostgres.role)
-          )
-        );
-
-      for (const channel of toDelete) {
-        await db.delete(channelsPostgres).where(eq(channelsPostgres.id, channel.id));
+      const whereClause = and(
+        gt(channelsPostgres.id, 1),
+        isNull(channelsPostgres.psk),
+        isNull(channelsPostgres.role)
+      );
+      const result = await db.select({ count: count() }).from(channelsPostgres).where(whereClause);
+      const deleteCount = Number(result[0].count);
+      if (deleteCount > 0) {
+        await db.delete(channelsPostgres).where(whereClause);
       }
-
-      logger.debug(`Cleaned up ${toDelete.length} empty channels (ID > 1, no PSK/role)`);
-      return toDelete.length;
+      logger.debug(`Cleaned up ${deleteCount} empty channels (ID > 1, no PSK/role)`);
+      return deleteCount;
     }
   }
 }

--- a/src/db/repositories/neighbors.ts
+++ b/src/db/repositories/neighbors.ts
@@ -174,19 +174,22 @@ export class NeighborsRepository extends BaseRepository {
   async deleteAllNeighborInfo(): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const count = await db.select().from(neighborInfoSqlite);
+      const result = await db.select({ count: count() }).from(neighborInfoSqlite);
+      const deleteCount = Number(result[0].count);
       await db.delete(neighborInfoSqlite);
-      return count.length;
+      return deleteCount;
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const count = await db.select().from(neighborInfoMysql);
+      const result = await db.select({ count: count() }).from(neighborInfoMysql);
+      const deleteCount = Number(result[0].count);
       await db.delete(neighborInfoMysql);
-      return count.length;
+      return deleteCount;
     } else {
       const db = this.getPostgresDb();
-      const count = await db.select().from(neighborInfoPostgres);
+      const result = await db.select({ count: count() }).from(neighborInfoPostgres);
+      const deleteCount = Number(result[0].count);
       await db.delete(neighborInfoPostgres);
-      return count.length;
+      return deleteCount;
     }
   }
 

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -4,7 +4,7 @@
  * Handles all node-related database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, gt, lt, isNull, or, desc, asc, and, isNotNull, ne, sql, inArray } from 'drizzle-orm';
+import { eq, gt, lt, isNull, or, desc, asc, and, isNotNull, ne, sql, inArray, count } from 'drizzle-orm';
 import { nodesSqlite, nodesPostgres, nodesMysql } from '../schema/nodes.js';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbNode } from '../types.js';
@@ -176,16 +176,16 @@ export class NodesRepository extends BaseRepository {
   async getNodeCount(): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const result = await db.select().from(nodesSqlite);
-      return result.length;
+      const result = await db.select({ count: count() }).from(nodesSqlite);
+      return Number(result[0].count);
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const result = await db.select().from(nodesMysql);
-      return result.length;
+      const result = await db.select({ count: count() }).from(nodesMysql);
+      return Number(result[0].count);
     } else {
       const db = this.getPostgresDb();
-      const result = await db.select().from(nodesPostgres);
-      return result.length;
+      const result = await db.select({ count: count() }).from(nodesPostgres);
+      return Number(result[0].count);
     }
   }
 

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -721,25 +721,22 @@ export class TelemetryRepository extends BaseRepository {
   async deleteAllTelemetry(): Promise<number> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const count = await db
-        .select({ id: telemetrySqlite.id })
-        .from(telemetrySqlite);
+      const result = await db.select({ count: count() }).from(telemetrySqlite);
+      const deleteCount = Number(result[0].count);
       await db.delete(telemetrySqlite);
-      return count.length;
+      return deleteCount;
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const count = await db
-        .select({ id: telemetryMysql.id })
-        .from(telemetryMysql);
+      const result = await db.select({ count: count() }).from(telemetryMysql);
+      const deleteCount = Number(result[0].count);
       await db.delete(telemetryMysql);
-      return count.length;
+      return deleteCount;
     } else {
       const db = this.getPostgresDb();
-      const count = await db
-        .select({ id: telemetryPostgres.id })
-        .from(telemetryPostgres);
+      const result = await db.select({ count: count() }).from(telemetryPostgres);
+      const deleteCount = Number(result[0].count);
       await db.delete(telemetryPostgres);
-      return count.length;
+      return deleteCount;
     }
   }
 

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -565,43 +565,22 @@ export class TraceroutesRepository extends BaseRepository {
   async clearAllRecordHolders(): Promise<void> {
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      const holders = await db
-        .select({ id: routeSegmentsSqlite.id })
-        .from(routeSegmentsSqlite)
+      await db
+        .update(routeSegmentsSqlite)
+        .set({ isRecordHolder: false })
         .where(eq(routeSegmentsSqlite.isRecordHolder, true));
-
-      for (const h of holders) {
-        await db
-          .update(routeSegmentsSqlite)
-          .set({ isRecordHolder: false })
-          .where(eq(routeSegmentsSqlite.id, h.id));
-      }
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      const holders = await db
-        .select({ id: routeSegmentsMysql.id })
-        .from(routeSegmentsMysql)
+      await db
+        .update(routeSegmentsMysql)
+        .set({ isRecordHolder: false })
         .where(eq(routeSegmentsMysql.isRecordHolder, true));
-
-      for (const h of holders) {
-        await db
-          .update(routeSegmentsMysql)
-          .set({ isRecordHolder: false })
-          .where(eq(routeSegmentsMysql.id, h.id));
-      }
     } else {
       const db = this.getPostgresDb();
-      const holders = await db
-        .select({ id: routeSegmentsPostgres.id })
-        .from(routeSegmentsPostgres)
+      await db
+        .update(routeSegmentsPostgres)
+        .set({ isRecordHolder: false })
         .where(eq(routeSegmentsPostgres.isRecordHolder, true));
-
-      for (const h of holders) {
-        await db
-          .update(routeSegmentsPostgres)
-          .set({ isRecordHolder: false })
-          .where(eq(routeSegmentsPostgres.id, h.id));
-      }
     }
   }
 

--- a/src/server/meshtasticManager.duplicate-message.test.ts
+++ b/src/server/meshtasticManager.duplicate-message.test.ts
@@ -82,7 +82,6 @@ vi.mock('../utils/logger.js', () => ({
 vi.mock('./services/notificationService.js', () => ({
   notificationService: {
     checkAndSendNotifications: vi.fn(),
-    sendNotification: vi.fn(),
   },
 }));
 

--- a/src/server/services/appriseNotificationService.ts
+++ b/src/server/services/appriseNotificationService.ts
@@ -165,51 +165,6 @@ class AppriseNotificationService {
   }
 
   /**
-   * Send a notification via Apprise to all globally configured URLs
-   * @deprecated Use sendNotificationToUrls for per-user notifications
-   */
-  public async sendNotification(payload: AppriseNotificationPayload): Promise<boolean> {
-    if (!this.isAvailable()) {
-      logger.debug('⚠️  Apprise not available, skipping notification');
-      return false;
-    }
-
-    try {
-      const response = await fetch(`${this.config!.url}/notify`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          title: payload.title,
-          body: payload.body,
-          type: payload.type || 'info'
-        }),
-        signal: AbortSignal.timeout(10000)
-      });
-
-      if (!response.ok) {
-        let errorDetails = '';
-        try {
-          const errorData = await response.json();
-          errorDetails = errorData.error || JSON.stringify(errorData);
-        } catch {
-          errorDetails = await response.text();
-        }
-        logger.error(`❌ Apprise notification failed: ${response.status} - ${errorDetails}`);
-        return false;
-      }
-
-      const data = await response.json();
-      logger.debug(`✅ Sent Apprise notification: ${payload.title} (to ${data.sent_to || 0} services)`);
-      return true;
-    } catch (error: any) {
-      logger.error('❌ Failed to send Apprise notification:', error);
-      return false;
-    }
-  }
-
-  /**
    * Send a notification to specific Apprise URLs (per-user)
    * Uses the Apprise API with inline URLs instead of the global config
    */


### PR DESCRIPTION
## Summary

- **Batch DELETE in channels.ts**: Convert N+1 loop-DELETE to single `COUNT + DELETE WHERE` in `cleanupInvalidChannels()` and `cleanupEmptyChannels()`
- **Batch UPDATE in traceroutes.ts**: Convert N+1 loop-UPDATE to single `UPDATE WHERE` in `clearAllRecordHolders()`
- **COUNT optimization in nodes.ts**: Replace `SELECT * + .length` with `SELECT COUNT(*)` in `getNodeCount()`
- **COUNT optimization in neighbors.ts/telemetry.ts**: Replace `SELECT * / SELECT {id}` for counting with `SELECT COUNT(*)` in `deleteAllNeighborInfo()` and `deleteAllTelemetry()`
- **Dead code removal**: Remove deprecated `sendNotification()` from appriseNotificationService (zero callers), dead test mock, and commented-out ref in App.tsx

Follows up on PRs #2185, #2187, and #2186 to address remaining instances of the same anti-patterns.

**Net: -92 lines** (88 insertions, 180 deletions)

## Test plan
- [x] `npx vitest run` — 2938 tests passing across 139 test files
- [x] `npx tsc --noEmit` — clean compilation
- [ ] Docker build + system tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)