### PR TITLE
fix: filter empty distance buckets from dashboard widgets

### DIFF
--- a/src/components/DistanceDistributionWidget.tsx
+++ b/src/components/DistanceDistributionWidget.tsx
@@ -99,15 +99,13 @@ const DistanceDistributionWidget: React.FC<DistanceDistributionWidgetProps> = ({
       bucketCounts[idx]++;
     }
 
-    const result: DistanceBucket[] = bucketCounts.map((count, i) => {
-      const from = i * bucketSize;
-      const to = (i + 1) * bucketSize;
-      return {
-        label: `${from}–${to}`,
+    const result: DistanceBucket[] = bucketCounts
+      .map((count, i) => ({
+        label: `${i * bucketSize}–${(i + 1) * bucketSize}`,
         count,
         index: i,
-      };
-    });
+      }))
+      .filter(b => b.count > 0);
 
     return {
       buckets: result,

--- a/src/components/HopDistanceHeatmapWidget.tsx
+++ b/src/components/HopDistanceHeatmapWidget.tsx
@@ -120,12 +120,23 @@ const HopDistanceHeatmapWidget: React.FC<HopDistanceHeatmapWidgetProps> = ({
       g[hopIdx][distIdx]++;
     }
 
-    const max = Math.max(...g.flat(), 1);
+    // Filter out distance buckets where all hop counts are zero
+    const activeDistIndices: number[] = [];
+    for (let d = 0; d < numDistBuckets; d++) {
+      if (g.some(hopRow => hopRow[d] > 0)) {
+        activeDistIndices.push(d);
+      }
+    }
+
+    const filteredGrid = g.map(hopRow => activeDistIndices.map(d => hopRow[d]));
+    const filteredDistLabels = activeDistIndices.map(d => dLabels[d]);
+
+    const max = Math.max(...filteredGrid.flat(), 1);
 
     return {
-      grid: g,
+      grid: filteredGrid,
       hopLabels: hLabels,
-      distLabels: dLabels,
+      distLabels: filteredDistLabels,
       maxCount: max,
       skippedCount: skipped,
     };


### PR DESCRIPTION
## Summary

- **DistanceDistributionWidget**: Filter out distance buckets with 0 nodes so empty ranges don't appear as blank bars
- **HopDistanceHeatmapWidget**: Filter out distance bucket rows where all hop columns are 0

When an outlier node reports from extreme distance (e.g. 2000+ miles), the widgets were generating many empty intermediate buckets. Now only buckets containing actual nodes are displayed.

## Test plan
- [x] `npx vitest run` — 8/8 widget tests passing
- [ ] Visual verification on production instance with outlier node

🤖 Generated with [Claude Code](https://claude.ai/claude-code)