### PR TITLE
fix(virtual-node): match physical radio's channel protobuf encoding

### DIFF
--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -180,7 +180,7 @@ export class ChannelsRepository extends BaseRepository {
           .update(channelsSqlite)
           .set({
             name: effectiveName,
-            psk: data.psk ?? existingChannel.psk,
+            psk: (data.psk !== undefined && data.psk !== '') ? data.psk : existingChannel.psk,
             role: data.role ?? existingChannel.role,
             uplinkEnabled: data.uplinkEnabled ?? existingChannel.uplinkEnabled,
             downlinkEnabled: data.downlinkEnabled ?? existingChannel.downlinkEnabled,
@@ -194,7 +194,7 @@ export class ChannelsRepository extends BaseRepository {
           .update(channelsMysql)
           .set({
             name: effectiveName,
-            psk: data.psk ?? existingChannel.psk,
+            psk: (data.psk !== undefined && data.psk !== '') ? data.psk : existingChannel.psk,
             role: data.role ?? existingChannel.role,
             uplinkEnabled: data.uplinkEnabled ?? existingChannel.uplinkEnabled,
             downlinkEnabled: data.downlinkEnabled ?? existingChannel.downlinkEnabled,
@@ -208,7 +208,7 @@ export class ChannelsRepository extends BaseRepository {
           .update(channelsPostgres)
           .set({
             name: effectiveName,
-            psk: data.psk ?? existingChannel.psk,
+            psk: (data.psk !== undefined && data.psk !== '') ? data.psk : existingChannel.psk,
             role: data.role ?? existingChannel.role,
             uplinkEnabled: data.uplinkEnabled ?? existingChannel.uplinkEnabled,
             downlinkEnabled: data.downlinkEnabled ?? existingChannel.downlinkEnabled,

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3355,7 +3355,7 @@ class MeshtasticManager {
         try {
           // Convert PSK buffer to base64 string if it exists
           let pskString: string | undefined;
-          if (channel.settings.psk) {
+          if (channel.settings.psk && channel.settings.psk.length > 0) {
             try {
               pskString = Buffer.from(channel.settings.psk).toString('base64');
             } catch (pskError) {

--- a/src/server/meshtasticProtobufService.ts
+++ b/src/server/meshtasticProtobufService.ts
@@ -1115,10 +1115,11 @@ export class MeshtasticProtobufService {
   async createChannel(channelData: {
     index: number;
     settings: {
-      name: string;
+      name?: string;
       psk?: Buffer;
-      uplinkEnabled: boolean;
-      downlinkEnabled: boolean;
+      uplinkEnabled?: boolean;
+      downlinkEnabled?: boolean;
+      positionPrecision?: number | null;
     };
     role: number;
   }): Promise<Uint8Array | null> {
@@ -1131,20 +1132,47 @@ export class MeshtasticProtobufService {
     try {
       const Channel = root.lookupType('meshtastic.Channel');
       const ChannelSettings = root.lookupType('meshtastic.ChannelSettings');
+      const ModuleSettings = root.lookupType('meshtastic.ModuleSettings');
       const FromRadio = root.lookupType('meshtastic.FromRadio');
 
-      const settings = ChannelSettings.create({
-        name: channelData.settings.name,
-        psk: channelData.settings.psk || Buffer.alloc(0),
-        uplinkEnabled: channelData.settings.uplinkEnabled,
-        downlinkEnabled: channelData.settings.downlinkEnabled,
-      });
+      // Build settings to match what the physical radio sends:
+      // - Only include non-default values (proto3 omits defaults on the wire)
+      // - Include moduleSettings.positionPrecision when available
+      // - Include PSK only when non-empty (empty = no encryption / red lock)
+      const settingsData: Record<string, any> = {};
 
-      const channel = Channel.create({
-        index: channelData.index,
-        settings: settings,
-        role: channelData.role,
-      });
+      if (channelData.settings.psk && channelData.settings.psk.length > 0) {
+        settingsData.psk = channelData.settings.psk;
+      }
+      if (channelData.settings.name) {
+        settingsData.name = channelData.settings.name;
+      }
+      // Only include uplink/downlink if true (false is proto3 default, radio omits it)
+      if (channelData.settings.uplinkEnabled) {
+        settingsData.uplinkEnabled = true;
+      }
+      if (channelData.settings.downlinkEnabled) {
+        settingsData.downlinkEnabled = true;
+      }
+      // Include moduleSettings with positionPrecision when available
+      if (channelData.settings.positionPrecision != null && channelData.settings.positionPrecision > 0) {
+        settingsData.moduleSettings = ModuleSettings.create({
+          positionPrecision: channelData.settings.positionPrecision,
+        });
+      }
+
+      const settings = ChannelSettings.create(settingsData);
+
+      // Only include non-default values in the Channel message
+      // (index=0 and role=DISABLED=0 are proto3 defaults)
+      const channelFields: Record<string, any> = { settings };
+      if (channelData.index !== 0) {
+        channelFields.index = channelData.index;
+      }
+      if (channelData.role !== 0) {
+        channelFields.role = channelData.role;
+      }
+      const channel = Channel.create(channelFields);
 
       const fromRadio = FromRadio.create({
         channel: channel,

--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -732,7 +732,59 @@ export class VirtualNodeServer extends EventEmitter {
 
       logger.info(`Virtual node: ✓ Sent ${allNodes.length} fresh NodeInfo entries from database`);
 
-      // === STEP 3: Rebuild and send channels from database ===
+      // === STEP 3: Send static config and moduleConfig from cache ===
+      // These must come BEFORE channels to match the Meshtastic firmware order:
+      //   myInfo → nodeInfo → config → moduleConfig → channels → metadata → configComplete
+      // The iOS app needs config (especially security config) before it can
+      // properly interpret channel PSK values.
+      let staticCount = 0;
+      for (const message of cachedMessages) {
+        // Skip dynamic message types (we already rebuilt those from DB)
+        if (message.type === 'myInfo' || message.type === 'nodeInfo') {
+          continue;
+        }
+
+        // Skip channels (rebuilt from DB in step 4)
+        if (message.type === 'channel') {
+          continue;
+        }
+
+        // Skip configComplete (we'll send a fresh one at the end)
+        if (message.type === 'configComplete') {
+          continue;
+        }
+
+        // Skip metadata (sent after channels in step 5)
+        if (message.type === 'metadata') {
+          continue;
+        }
+
+        // Skip generic/unrecognized FromRadio messages (e.g. rebooted, queueStatus, logRecord).
+        // Replaying a 'rebooted' message causes meshtastic clients to call _startConfig() and
+        // re-request config in a tight loop, since the new configId won't match our ConfigComplete.
+        if (message.type === 'fromRadio') {
+          continue;
+        }
+
+        // Check if client is still connected
+        const client = this.clients.get(clientId);
+        if (!client || client.socket.destroyed) {
+          logger.warn(`Virtual node: Client ${clientId} disconnected during config replay (sent ${sentCount} total messages)`);
+          return;
+        }
+
+        await this.sendToClient(clientId, message.data);
+        sentCount++;
+        staticCount++;
+
+        if (staticCount % this.LOG_EVERY_N_MESSAGES === 0) {
+          logger.debug(`Virtual node: Sent cached ${message.type} message (${staticCount} static messages)`);
+        }
+      }
+
+      logger.info(`Virtual node: ✓ Sent ${staticCount} cached static messages (config, moduleConfig)`);
+
+      // === STEP 4: Rebuild and send channels from database ===
       // Channels must be rebuilt from DB rather than sent from cache because the
       // physical radio often sends channels with empty name strings. The Android
       // app renders empty channel names as "Channel NAme", effectively wiping the
@@ -752,10 +804,11 @@ export class VirtualNodeServer extends EventEmitter {
         const channelMessage = await meshtasticProtobufService.createChannel({
           index: ch.id,
           settings: {
-            name: ch.name || '',
+            name: ch.name || undefined,
             psk: ch.psk ? Buffer.from(ch.psk, 'base64') : undefined,
-            uplinkEnabled: ch.uplinkEnabled,
-            downlinkEnabled: ch.downlinkEnabled,
+            uplinkEnabled: ch.uplinkEnabled ? true : undefined,
+            downlinkEnabled: ch.downlinkEnabled ? true : undefined,
+            positionPrecision: ch.positionPrecision,
           },
           role: ch.role ?? (ch.id === 0 ? 1 : 2),
         });
@@ -769,68 +822,33 @@ export class VirtualNodeServer extends EventEmitter {
       }
       logger.info(`Virtual node: ✓ Sent ${channelCount} channels from database (all slots)`);
 
-      // === STEP 4: Send static config data from cache (config, metadata) ===
-      let staticCount = 0;
+      // === STEP 5: Send metadata from cache ===
+      // Metadata comes after channels in the Meshtastic firmware order.
       for (const message of cachedMessages) {
-        // Skip dynamic message types (we already rebuilt those from DB)
-        if (message.type === 'myInfo' || message.type === 'nodeInfo') {
-          continue;
-        }
+        if (message.type !== 'metadata') continue;
 
-        // Skip channels (rebuilt from DB in step 3)
-        if (message.type === 'channel') {
-          continue;
-        }
-
-        // Skip configComplete (we'll send a fresh one at the end)
-        if (message.type === 'configComplete') {
-          continue;
-        }
-
-        // Skip generic/unrecognized FromRadio messages (e.g. rebooted, queueStatus, logRecord).
-        // Replaying a 'rebooted' message causes meshtastic clients to call _startConfig() and
-        // re-request config in a tight loop, since the new configId won't match our ConfigComplete.
-        if (message.type === 'fromRadio') {
-          continue;
-        }
-
-        // Check if client is still connected
         const client = this.clients.get(clientId);
         if (!client || client.socket.destroyed) {
-          logger.warn(`Virtual node: Client ${clientId} disconnected during config replay (sent ${sentCount} total messages)`);
+          logger.warn(`Virtual node: Client ${clientId} disconnected during metadata send`);
           return;
         }
 
-        // For metadata messages, rewrite firmware_version to indicate Virtual Node
-        let dataToSend = message.data;
-        if (message.type === 'metadata') {
-          const rewritten = await meshtasticProtobufService.rewriteMetadataFirmwareVersion(
-            message.data,
-            `-MM${packageJson.version}`
-          );
-          if (rewritten) {
-            dataToSend = rewritten;
-          }
-        }
-
-        // Send the cached static message (possibly with modified metadata)
-        await this.sendToClient(clientId, dataToSend);
+        const rewritten = await meshtasticProtobufService.rewriteMetadataFirmwareVersion(
+          message.data,
+          `-MM${packageJson.version}`
+        );
+        await this.sendToClient(clientId, rewritten || message.data);
         sentCount++;
         staticCount++;
-
-        if (staticCount % this.LOG_EVERY_N_MESSAGES === 0) {
-          logger.debug(`Virtual node: Sent cached ${message.type} message (${staticCount} static messages)`);
-        }
+        logger.debug(`Virtual node: ✓ Sent metadata`);
       }
-
-      logger.info(`Virtual node: ✓ Sent ${staticCount} cached static messages (config, metadata)`);
 
       // NOTE: Message history replay was removed in v3.2.6 (issue #1608)
       // Sending cached messages on each reconnection caused problems with clients
       // that don't deduplicate messages, leading to duplicate chats and incorrect
       // hop counts. Clients should rely on real-time message forwarding instead.
 
-      // === STEP 5: Send custom ConfigComplete with client's requested ID ===
+      // === STEP 6: Send custom ConfigComplete with client's requested ID ===
       const useConfigId = configId || 1;
       logger.info(`Virtual node: Sending ConfigComplete to ${clientId} with ID ${useConfigId}...`);
       const configComplete = await meshtasticProtobufService.createConfigComplete(useConfigId);


### PR DESCRIPTION
## Summary

Fixes iOS Meshtastic app showing **red lock** (insecure) for channels with 1-byte PSK keys and only displaying the primary channel (or sometimes blank) in channel settings when connected to the virtual node.

### Root Cause

Byte-level comparison of the physical radio's raw protobuf output vs the virtual node's reconstructed output revealed two encoding differences:

1. **Missing `moduleSettings.positionPrecision`** — The physical radio includes a `moduleSettings` sub-message on each channel with `positionPrecision` (e.g. 14 for default channels). The virtual node omitted this entirely. The iOS app uses this field to validate channel completeness, causing channels to appear missing from settings.

2. **Explicit proto3 default values on the wire** — The virtual node encoded `uplinkEnabled=false`, `downlinkEnabled=false`, `role=DISABLED(0)`, and `index=0` explicitly in the protobuf. In proto3, default values should be omitted — the decoder infers them. The physical radio omits these. The iOS app's parser didn't tolerate the extra bytes, causing channel data to be misparsed. For example, disabled channel slots were 14 bytes (virtual node) vs 6 bytes (physical radio).

After fixing both issues, the virtual node produces **byte-identical** channel messages to the physical radio.

### Additional fixes in this PR

- **Config message ordering** — Reordered the init config stream to match the Meshtastic firmware sequence: `myInfo → nodeInfo → config → moduleConfig → channels → metadata → configComplete`. Previously channels were sent before config/moduleConfig.
- **PSK preservation** — `processChannelProtobuf` now checks PSK buffer length (not just truthiness) to avoid storing empty Uint8Array as base64. `upsertChannel` won't overwrite a valid PSK with an empty string.

### Files changed

| File | Change |
|------|--------|
| `src/server/meshtasticProtobufService.ts` | Rewrote `createChannel()` to only include non-default proto3 values, add `moduleSettings.positionPrecision`, and match radio encoding |
| `src/server/virtualNodeServer.ts` | Reordered config stream (config/moduleConfig before channels), pass `positionPrecision` to `createChannel()`, send metadata after channels |
| `src/server/meshtasticManager.ts` | Added PSK buffer length check in `processChannelProtobuf` |
| `src/db/repositories/channels.ts` | Prevent empty string PSK from overwriting valid PSK in upsert (all 3 DB backends) |

## Test plan

- [x] Verified byte-identical protobuf output vs physical radio (all 8 channel slots)
- [x] Verified correct message ordering via diagnostic client
- [x] Tested on iOS Meshtastic app — all channels visible in settings, correct lock icons
- [x] Existing test suite passes (no new failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)