### PR TITLE
fix: improve packet monitor button contrast and detail popup

### DIFF
--- a/src/components/PacketMonitorPanel.css
+++ b/src/components/PacketMonitorPanel.css
@@ -55,6 +55,7 @@
   padding: 6px 10px;
   cursor: pointer;
   font-size: 14px;
+  color: var(--text-primary);
   transition: all 0.2s;
 }
 
@@ -433,6 +434,36 @@
   color: var(--text-primary);
   font-size: 13px;
   word-break: break-word;
+}
+
+.packet-detail-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.detail-row-full {
+  grid-template-columns: 1fr;
+}
+
+.detail-row-full .detail-label {
+  margin-bottom: 4px;
+}
+
+.detail-value-json {
+  background: var(--bg-secondary);
+  padding: 8px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  font-family: 'Courier New', monospace;
+  font-size: 11px;
+  line-height: 1.4;
+  max-height: 200px;
+  overflow-y: auto;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-primary);
 }
 
 .payload-content,

--- a/src/components/PacketMonitorPanel.tsx
+++ b/src/components/PacketMonitorPanel.tsx
@@ -888,7 +888,30 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
                     Object.entries(displayData).filter(([, v]) => v !== undefined && v !== null)
                   );
 
-                  return <pre className="packet-json">{JSON.stringify(cleanedData, null, 2)}</pre>;
+                  // Format field names for display (snake_case → Title Case)
+                  const formatLabel = (key: string) => key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+
+                  return (
+                    <div className="packet-detail-fields">
+                      {Object.entries(cleanedData).map(([key, value]) => {
+                        // Show decoded_payload and complex objects as formatted JSON
+                        if (typeof value === 'object' && value !== null) {
+                          return (
+                            <div key={key} className="detail-row detail-row-full">
+                              <span className="detail-label">{formatLabel(key)}</span>
+                              <pre className="detail-value-json">{JSON.stringify(value, null, 2)}</pre>
+                            </div>
+                          );
+                        }
+                        return (
+                          <div key={key} className="detail-row">
+                            <span className="detail-label">{formatLabel(key)}</span>
+                            <span className="detail-value">{String(value)}</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  );
                 })()}
               </div>
             </div>


### PR DESCRIPTION
## Summary

- **Button contrast**: Add `color: var(--text-primary)` to `.control-btn` so header buttons are visible on dark themes (was inheriting black text on dark blue background)
- **Detail popup**: Replace raw JSON dump with structured labeled rows — field names displayed as Title Case labels with values alongside, complex objects (like decoded_payload) shown as formatted JSON blocks

Fixes #2194

## Test plan
- [x] Visual verification on dark theme — buttons now readable
- [x] Packet detail popup shows structured fields instead of raw JSON

🤖 Generated with [Claude Code](https://claude.ai/claude-code)