### PR TITLE
fix: skip MQTT-sourced neighbor info to prevent bogus map connections

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5369,6 +5369,12 @@ class MeshtasticManager {
 
       logger.info(`🏠 Neighbor info received from ${fromNodeId}:`, neighborInfo);
 
+      // Skip MQTT-sourced neighbor info - it represents remote mesh topology, not local connections
+      if (meshPacket.viaMqtt) {
+        logger.debug(`📡 Skipping MQTT-sourced neighbor info from ${fromNodeId}`);
+        return;
+      }
+
       // Get the sender node to determine their hopsAway
       let senderNode = databaseService.getNode(fromNum);
 


### PR DESCRIPTION
## Summary

- MQTT-relayed `NEIGHBORINFO_APP` packets represent remote mesh topology (other meshes hundreds of miles away), not local radio connections
- Saving them to the `neighbor_info` table creates misleading purple neighbor lines on the map spanning hundreds of miles between unrelated nodes
- Fix: skip `NEIGHBORINFO_APP` packets where `meshPacket.viaMqtt === true` in `processNeighborInfoProtobuf()`

## Details

When a Meshtastic node has MQTT enabled, it receives `NEIGHBORINFO_APP` packets from distant nodes via MQTT. These packets describe the radio neighbors of those remote nodes — connections that exist in some other mesh, not the user's local mesh. MeshMonitor was saving all of these, resulting in bogus neighbor connection lines on the map (e.g., lines to nodes 200+ miles away).

Local radio-received neighbor info (the useful data) is unaffected — it arrives with `viaMqtt: false` and continues to be processed normally.

Existing stale MQTT neighbor data will age out naturally via the `maxNodeAge` filter (default 24 hours).

## Test plan

- [ ] Verify neighbor info lines on map only show local radio connections
- [ ] Verify distant MQTT-only nodes no longer show purple neighbor lines
- [ ] Verify local nodes still show correct neighbor connections
- [ ] Check server logs for `Skipping MQTT-sourced neighbor info` debug messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)