### PR TITLE
fix: replace raw fetch with React Query hook for voltage fallback

### DIFF
--- a/src/components/NodeStatusWidget.tsx
+++ b/src/components/NodeStatusWidget.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { type NodeInfo } from './TelemetryChart';
+import { useNodeVoltages } from '../hooks/useTelemetry';
 
 interface NodeStatusWidgetProps {
   id: string;
@@ -37,12 +38,6 @@ interface NodeStatusRow {
   rssi: number | null;
   voltage: number | null;
   uptimeSeconds: number | null;
-}
-
-interface TelemetryRow {
-  telemetryType?: string;
-  timestamp: number;
-  value: number;
 }
 
 type NodeStatusInfo = NodeInfo & {
@@ -68,7 +63,6 @@ const NodeStatusWidget: React.FC<NodeStatusWidgetProps> = ({
   const { t } = useTranslation();
   const [searchQuery, setSearchQuery] = useState('');
   const [showSearch, setShowSearch] = useState(false);
-  const [fallbackVoltageByNode, setFallbackVoltageByNode] = useState<Map<string, number>>(new Map());
   const searchRef = useRef<HTMLDivElement>(null);
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
@@ -93,75 +87,16 @@ const NodeStatusWidget: React.FC<NodeStatusWidgetProps> = ({
     }
   }, [showSearch]);
 
-  // Load latest voltage telemetry for nodes that don't currently expose voltage on /api/nodes.
-  useEffect(() => {
-    let isCancelled = false;
+  // Fetch fallback voltages for nodes missing voltage via React Query (cached, deduplicated)
+  const missingVoltageNodeIds = useMemo(() => {
+    return nodeIds.filter(nodeId => {
+      const node = nodes.get(nodeId) as NodeStatusInfo | undefined;
+      const voltage = node?.deviceMetrics?.voltage ?? node?.voltage;
+      return voltage === undefined || voltage === null;
+    });
+  }, [nodeIds, nodes]);
 
-    const loadFallbackVoltages = async () => {
-      const missingVoltageNodeIds = nodeIds.filter(nodeId => {
-        const node = nodes.get(nodeId) as NodeStatusInfo | undefined;
-        const voltage = node?.deviceMetrics?.voltage ?? node?.voltage;
-        return voltage === undefined || voltage === null;
-      });
-
-      if (missingVoltageNodeIds.length === 0) {
-        return;
-      }
-
-      const fetches = missingVoltageNodeIds.map(async nodeId => {
-        try {
-          const response = await fetch(
-            `${baseUrl}/api/telemetry/${encodeURIComponent(nodeId)}?hours=720`
-          );
-          if (!response.ok) return null;
-          const data = await response.json();
-
-          // Support both response shapes:
-          // - Legacy endpoint: DbTelemetry[]
-          // - V1 endpoint shape: { data: DbTelemetry[] }
-          const telemetryRows: TelemetryRow[] = Array.isArray(data)
-            ? data
-            : Array.isArray(data?.data)
-              ? data.data
-              : [];
-
-          const voltageRows = telemetryRows.filter(
-            (row: TelemetryRow) => row.telemetryType === 'voltage'
-          );
-          if (voltageRows.length === 0) return null;
-
-          const latest = voltageRows.reduce((prev, current) =>
-            current.timestamp > prev.timestamp ? current : prev
-          );
-          const value = Number(latest.value);
-          if (Number.isNaN(value)) return null;
-
-          return { nodeId, value };
-        } catch {
-          return null;
-        }
-      });
-
-      const results = await Promise.all(fetches);
-      if (isCancelled) return;
-
-      setFallbackVoltageByNode(prev => {
-        const next = new Map(prev);
-        results.forEach(result => {
-          if (result) {
-            next.set(result.nodeId, result.value);
-          }
-        });
-        return next;
-      });
-    };
-
-    loadFallbackVoltages();
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [baseUrl, nodeIds, nodes]);
+  const fallbackVoltageByNode = useNodeVoltages({ nodeIds: missingVoltageNodeIds, baseUrl });
 
   // Build node status rows sorted by last heard (most recent first)
   const nodeRows = useMemo((): NodeStatusRow[] => {

--- a/src/hooks/useTelemetry.ts
+++ b/src/hooks/useTelemetry.ts
@@ -7,7 +7,7 @@
  * refetch capabilities.
  */
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueries } from '@tanstack/react-query';
 
 /**
  * Telemetry data point from the backend
@@ -224,4 +224,65 @@ export function useSolarEstimatesLatest({
     gcTime: 10 * 60 * 1000, // Keep in cache for 10 minutes
     refetchOnWindowFocus: false,
   });
+}
+
+/**
+ * Options for useNodeVoltages hook
+ */
+interface UseNodeVoltagesOptions {
+  /** Node IDs that need fallback voltage data */
+  nodeIds: string[];
+  /** Base URL for API requests (default: '') */
+  baseUrl?: string;
+}
+
+/**
+ * Hook to fetch latest voltage telemetry for multiple nodes
+ *
+ * Uses useQueries to leverage TanStack Query caching and deduplication
+ * per node, avoiding redundant fetches on re-renders.
+ *
+ * @param options - Configuration options
+ * @returns Map of nodeId to latest voltage value
+ */
+export function useNodeVoltages({ nodeIds, baseUrl = '' }: UseNodeVoltagesOptions): Map<string, number> {
+  const results = useQueries({
+    queries: nodeIds.map(nodeId => ({
+      queryKey: ['nodeVoltage', nodeId],
+      queryFn: async (): Promise<{ nodeId: string; value: number } | null> => {
+        try {
+          const response = await fetch(`${baseUrl}/api/telemetry/${encodeURIComponent(nodeId)}?hours=720`);
+          if (!response.ok) return null;
+          const data = await response.json();
+
+          const telemetryRows: TelemetryData[] = Array.isArray(data) ? data : [];
+          const voltageRows = telemetryRows.filter(row => row.telemetryType === 'voltage');
+          if (voltageRows.length === 0) return null;
+
+          const latest = voltageRows.reduce((prev, current) =>
+            current.timestamp > prev.timestamp ? current : prev
+          );
+          const value = Number(latest.value);
+          if (Number.isNaN(value)) return null;
+
+          return { nodeId, value };
+        } catch {
+          return null;
+        }
+      },
+      staleTime: 5 * 60 * 1000, // Fresh for 5 minutes
+      gcTime: 10 * 60 * 1000, // Cache for 10 minutes
+      refetchInterval: 5 * 60 * 1000, // Refetch every 5 minutes
+      refetchOnWindowFocus: false,
+    })),
+  });
+
+  const voltageMap = new Map<string, number>();
+  results.forEach(result => {
+    if (result.data) {
+      voltageMap.set(result.data.nodeId, result.data.value);
+    }
+  });
+
+  return voltageMap;
 }


### PR DESCRIPTION
## Summary

- Replaces the raw `useEffect` + `fetch()` in `NodeStatusWidget` with a new `useNodeVoltages` hook built on TanStack Query's `useQueries`
- Fixes excessive API calls caused by unstable `nodes` Map and `nodeIds` array references in the `useEffect` dependency array, which triggered re-fetches on every parent render
- Each node's voltage query is individually cached (5 min stale time, 5 min refetch interval) and deduplicated by React Query

Follow-up to PR #2205.

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] All 2937 tests pass (`npx vitest run`)
- [ ] System tests (`tests/system-tests.sh`)

🤖 Generated with [Claude Code](https://claude.ai/code)