### PR TITLE
Add node ignore list to auto-acknowledge automation

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2141,6 +2141,8 @@
   "automation.auto_ack.security_description": "Protect against sending messages to nodes that may not be on your channel",
   "automation.auto_ack.skip_incomplete": "Skip incomplete nodes",
   "automation.auto_ack.skip_incomplete_description": "Don't auto-acknowledge messages from nodes that are missing name or hardware info. Recommended for secure channels to avoid responding to nodes that may have overheard your encrypted traffic.",
+  "automation.auto_ack.node_ignore_list": "Node Ignore List",
+  "automation.auto_ack.node_ignore_list_description": "Do not auto-acknowledge messages from these node IDs. Enter one per line or comma-separated using !xxxxxxxx format.",
   "automation.auto_ack.message_multihop": "Acknowledgment Message Template (Multi-hop Messages)",
   "automation.auto_ack.message_multihop_description": "Message to send for multi-hop messages (hop count > 0).",
   "automation.auto_ack.message_direct": "Acknowledgment Message Template (Direct Connections - 0 Hops)",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -529,6 +529,7 @@ function App() {
     autoAckDirectMessages, setAutoAckDirectMessages,
     autoAckUseDM, setAutoAckUseDM,
     autoAckSkipIncompleteNodes, setAutoAckSkipIncompleteNodes,
+    autoAckIgnoredNodes, setAutoAckIgnoredNodes,
     autoAckTapbackEnabled, setAutoAckTapbackEnabled,
     autoAckReplyEnabled, setAutoAckReplyEnabled,
     autoAckDirectEnabled, setAutoAckDirectEnabled,
@@ -962,6 +963,10 @@ function App() {
 
           if (settings.autoAckSkipIncompleteNodes !== undefined) {
             setAutoAckSkipIncompleteNodes(settings.autoAckSkipIncompleteNodes === 'true');
+          }
+
+          if (settings.autoAckIgnoredNodes !== undefined) {
+            setAutoAckIgnoredNodes(settings.autoAckIgnoredNodes);
           }
 
           if (settings.autoAckTapbackEnabled !== undefined) {
@@ -4872,6 +4877,7 @@ function App() {
                   directMessagesEnabled={autoAckDirectMessages}
                   useDM={autoAckUseDM}
                   skipIncompleteNodes={autoAckSkipIncompleteNodes}
+                  ignoredNodes={autoAckIgnoredNodes}
                   tapbackEnabled={autoAckTapbackEnabled}
                   replyEnabled={autoAckReplyEnabled}
                   directEnabled={autoAckDirectEnabled}
@@ -4890,6 +4896,7 @@ function App() {
                   onDirectMessagesChange={setAutoAckDirectMessages}
                   onUseDMChange={setAutoAckUseDM}
                   onSkipIncompleteNodesChange={setAutoAckSkipIncompleteNodes}
+                  onIgnoredNodesChange={setAutoAckIgnoredNodes}
                   onTapbackEnabledChange={setAutoAckTapbackEnabled}
                   onReplyEnabledChange={setAutoAckReplyEnabled}
                   onDirectEnabledChange={setAutoAckDirectEnabled}

--- a/src/components/AutoAcknowledgeSection.tsx
+++ b/src/components/AutoAcknowledgeSection.tsx
@@ -17,6 +17,7 @@ interface AutoAcknowledgeSectionProps {
   directMessagesEnabled: boolean;
   useDM: boolean;
   skipIncompleteNodes: boolean;
+  ignoredNodes: string;
   tapbackEnabled: boolean;
   replyEnabled: boolean;
   // New direct/multihop settings
@@ -35,6 +36,7 @@ interface AutoAcknowledgeSectionProps {
   onDirectMessagesChange: (enabled: boolean) => void;
   onUseDMChange: (enabled: boolean) => void;
   onSkipIncompleteNodesChange: (enabled: boolean) => void;
+  onIgnoredNodesChange: (ignoredNodes: string) => void;
   onTapbackEnabledChange: (enabled: boolean) => void;
   onReplyEnabledChange: (enabled: boolean) => void;
   // New direct/multihop callbacks
@@ -64,6 +66,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
   directMessagesEnabled,
   useDM,
   skipIncompleteNodes,
+  ignoredNodes,
   tapbackEnabled,
   replyEnabled,
   directEnabled,
@@ -81,6 +84,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
   onDirectMessagesChange,
   onUseDMChange,
   onSkipIncompleteNodesChange,
+  onIgnoredNodesChange,
   onTapbackEnabledChange,
   onReplyEnabledChange,
   onDirectEnabledChange,
@@ -104,6 +108,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
   const [localDirectMessagesEnabled, setLocalDirectMessagesEnabled] = useState(directMessagesEnabled);
   const [localUseDM, setLocalUseDM] = useState(useDM);
   const [localSkipIncompleteNodes, setLocalSkipIncompleteNodes] = useState(skipIncompleteNodes);
+  const [localIgnoredNodes, setLocalIgnoredNodes] = useState(ignoredNodes || '');
   const [localTapbackEnabled, setLocalTapbackEnabled] = useState(tapbackEnabled);
   const [localReplyEnabled, setLocalReplyEnabled] = useState(replyEnabled);
   const [localDirectEnabled, setLocalDirectEnabled] = useState(directEnabled);
@@ -128,6 +133,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
     setLocalDirectMessagesEnabled(directMessagesEnabled);
     setLocalUseDM(useDM);
     setLocalSkipIncompleteNodes(skipIncompleteNodes);
+    setLocalIgnoredNodes(ignoredNodes || '');
     setLocalTapbackEnabled(tapbackEnabled);
     setLocalReplyEnabled(replyEnabled);
     setLocalDirectEnabled(directEnabled);
@@ -139,14 +145,14 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
     if (testMessagesProp) {
       setTestMessages(testMessagesProp);
     }
-  }, [enabled, regex, message, messageDirect, enabledChannels, directMessagesEnabled, useDM, skipIncompleteNodes, tapbackEnabled, replyEnabled, directEnabled, directTapbackEnabled, directReplyEnabled, multihopEnabled, multihopTapbackEnabled, multihopReplyEnabled, testMessagesProp]);
+  }, [enabled, regex, message, messageDirect, enabledChannels, directMessagesEnabled, useDM, skipIncompleteNodes, ignoredNodes, tapbackEnabled, replyEnabled, directEnabled, directTapbackEnabled, directReplyEnabled, multihopEnabled, multihopTapbackEnabled, multihopReplyEnabled, testMessagesProp]);
 
   // Check if any settings have changed
   useEffect(() => {
     const channelsChanged = JSON.stringify(localEnabledChannels.sort()) !== JSON.stringify(enabledChannels.sort());
-    const changed = localEnabled !== enabled || localRegex !== regex || localMessage !== message || localMessageDirect !== messageDirect || channelsChanged || localDirectMessagesEnabled !== directMessagesEnabled || localUseDM !== useDM || localSkipIncompleteNodes !== skipIncompleteNodes || localTapbackEnabled !== tapbackEnabled || localReplyEnabled !== replyEnabled || localDirectEnabled !== directEnabled || localDirectTapbackEnabled !== directTapbackEnabled || localDirectReplyEnabled !== directReplyEnabled || localMultihopEnabled !== multihopEnabled || localMultihopTapbackEnabled !== multihopTapbackEnabled || localMultihopReplyEnabled !== multihopReplyEnabled || testMessages !== (testMessagesProp || 'test\nTest message\nping\nPING\nHello world\nTESTING 123');
+    const changed = localEnabled !== enabled || localRegex !== regex || localMessage !== message || localMessageDirect !== messageDirect || channelsChanged || localDirectMessagesEnabled !== directMessagesEnabled || localUseDM !== useDM || localSkipIncompleteNodes !== skipIncompleteNodes || localIgnoredNodes !== (ignoredNodes || '') || localTapbackEnabled !== tapbackEnabled || localReplyEnabled !== replyEnabled || localDirectEnabled !== directEnabled || localDirectTapbackEnabled !== directTapbackEnabled || localDirectReplyEnabled !== directReplyEnabled || localMultihopEnabled !== multihopEnabled || localMultihopTapbackEnabled !== multihopTapbackEnabled || localMultihopReplyEnabled !== multihopReplyEnabled || testMessages !== (testMessagesProp || 'test\nTest message\nping\nPING\nHello world\nTESTING 123');
     setHasChanges(changed);
-  }, [localEnabled, localRegex, localMessage, localMessageDirect, localEnabledChannels, localDirectMessagesEnabled, localUseDM, localSkipIncompleteNodes, localTapbackEnabled, localReplyEnabled, localDirectEnabled, localDirectTapbackEnabled, localDirectReplyEnabled, localMultihopEnabled, localMultihopTapbackEnabled, localMultihopReplyEnabled, testMessages, enabled, regex, message, messageDirect, enabledChannels, directMessagesEnabled, useDM, skipIncompleteNodes, tapbackEnabled, replyEnabled, directEnabled, directTapbackEnabled, directReplyEnabled, multihopEnabled, multihopTapbackEnabled, multihopReplyEnabled, testMessagesProp]);
+  }, [localEnabled, localRegex, localMessage, localMessageDirect, localEnabledChannels, localDirectMessagesEnabled, localUseDM, localSkipIncompleteNodes, localIgnoredNodes, localTapbackEnabled, localReplyEnabled, localDirectEnabled, localDirectTapbackEnabled, localDirectReplyEnabled, localMultihopEnabled, localMultihopTapbackEnabled, localMultihopReplyEnabled, testMessages, enabled, regex, message, messageDirect, enabledChannels, directMessagesEnabled, useDM, skipIncompleteNodes, ignoredNodes, tapbackEnabled, replyEnabled, directEnabled, directTapbackEnabled, directReplyEnabled, multihopEnabled, multihopTapbackEnabled, multihopReplyEnabled, testMessagesProp]);
 
   // Reset local state to props (used by SaveBar dismiss)
   const resetChanges = useCallback(() => {
@@ -158,6 +164,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
     setLocalDirectMessagesEnabled(directMessagesEnabled);
     setLocalUseDM(useDM);
     setLocalSkipIncompleteNodes(skipIncompleteNodes);
+    setLocalIgnoredNodes(ignoredNodes || '');
     setLocalTapbackEnabled(tapbackEnabled);
     setLocalReplyEnabled(replyEnabled);
     setLocalDirectEnabled(directEnabled);
@@ -167,7 +174,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
     setLocalMultihopTapbackEnabled(multihopTapbackEnabled);
     setLocalMultihopReplyEnabled(multihopReplyEnabled);
     setTestMessages(testMessagesProp || 'test\nTest message\nping\nPING\nHello world\nTESTING 123');
-  }, [enabled, regex, message, messageDirect, enabledChannels, directMessagesEnabled, useDM, skipIncompleteNodes, tapbackEnabled, replyEnabled, directEnabled, directTapbackEnabled, directReplyEnabled, multihopEnabled, multihopTapbackEnabled, multihopReplyEnabled, testMessagesProp]);
+  }, [enabled, regex, message, messageDirect, enabledChannels, directMessagesEnabled, useDM, skipIncompleteNodes, ignoredNodes, tapbackEnabled, replyEnabled, directEnabled, directTapbackEnabled, directReplyEnabled, multihopEnabled, multihopTapbackEnabled, multihopReplyEnabled, testMessagesProp]);
 
   // Validate regex pattern for safety
   const validateRegex = (pattern: string): { valid: boolean; error?: string } => {
@@ -270,6 +277,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
           autoAckDirectMessages: String(localDirectMessagesEnabled),
           autoAckUseDM: String(localUseDM),
           autoAckSkipIncompleteNodes: String(localSkipIncompleteNodes),
+          autoAckIgnoredNodes: localIgnoredNodes,
           autoAckTapbackEnabled: String(localTapbackEnabled),
           autoAckReplyEnabled: String(localReplyEnabled),
           autoAckDirectEnabled: String(localDirectEnabled),
@@ -299,6 +307,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
       onDirectMessagesChange(localDirectMessagesEnabled);
       onUseDMChange(localUseDM);
       onSkipIncompleteNodesChange(localSkipIncompleteNodes);
+      onIgnoredNodesChange(localIgnoredNodes);
       onTapbackEnabledChange(localTapbackEnabled);
       onReplyEnabledChange(localReplyEnabled);
       onDirectEnabledChange(localDirectEnabled);
@@ -317,7 +326,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
     } finally {
       setIsSaving(false);
     }
-  }, [localRegex, localEnabled, localMessage, localMessageDirect, localEnabledChannels, localDirectMessagesEnabled, localUseDM, localSkipIncompleteNodes, localTapbackEnabled, localReplyEnabled, localDirectEnabled, localDirectTapbackEnabled, localDirectReplyEnabled, localMultihopEnabled, localMultihopTapbackEnabled, localMultihopReplyEnabled, testMessages, baseUrl, csrfFetch, showToast, t, onEnabledChange, onRegexChange, onMessageChange, onMessageDirectChange, onChannelsChange, onDirectMessagesChange, onUseDMChange, onSkipIncompleteNodesChange, onTapbackEnabledChange, onReplyEnabledChange, onDirectEnabledChange, onDirectTapbackEnabledChange, onDirectReplyEnabledChange, onMultihopEnabledChange, onMultihopTapbackEnabledChange, onMultihopReplyEnabledChange, onTestMessagesChange]);
+  }, [localRegex, localEnabled, localMessage, localMessageDirect, localEnabledChannels, localDirectMessagesEnabled, localUseDM, localSkipIncompleteNodes, localIgnoredNodes, localTapbackEnabled, localReplyEnabled, localDirectEnabled, localDirectTapbackEnabled, localDirectReplyEnabled, localMultihopEnabled, localMultihopTapbackEnabled, localMultihopReplyEnabled, testMessages, baseUrl, csrfFetch, showToast, t, onEnabledChange, onRegexChange, onMessageChange, onMessageDirectChange, onChannelsChange, onDirectMessagesChange, onUseDMChange, onSkipIncompleteNodesChange, onIgnoredNodesChange, onTapbackEnabledChange, onReplyEnabledChange, onDirectEnabledChange, onDirectTapbackEnabledChange, onDirectReplyEnabledChange, onMultihopEnabledChange, onMultihopTapbackEnabledChange, onMultihopReplyEnabledChange, onTestMessagesChange]);
 
   // Register with SaveBar
   useSaveBar({
@@ -482,6 +491,29 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
           </div>
           <div style={{ marginTop: '0.5rem', marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
             {t('automation.auto_ack.skip_incomplete_description')}
+          </div>
+
+          <div style={{ marginTop: '1rem' }}>
+            <label htmlFor="autoAckIgnoredNodes" style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 'bold' }}>
+              {t('automation.auto_ack.node_ignore_list')}
+            </label>
+            <div style={{ marginBottom: '0.5rem', fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+              {t('automation.auto_ack.node_ignore_list_description')}
+            </div>
+            <textarea
+              id="autoAckIgnoredNodes"
+              value={localIgnoredNodes}
+              onChange={(e) => setLocalIgnoredNodes(e.target.value)}
+              placeholder={`!a1b2c3d4\n!d5c4b3a2`}
+              disabled={!localEnabled}
+              className="setting-input"
+              rows={3}
+              style={{
+                fontFamily: 'monospace',
+                resize: 'vertical',
+                minHeight: '70px'
+              }}
+            />
           </div>
         </div>
 

--- a/src/contexts/AutomationContext.tsx
+++ b/src/contexts/AutomationContext.tsx
@@ -18,6 +18,8 @@ interface AutomationContextType {
   setAutoAckUseDM: React.Dispatch<React.SetStateAction<boolean>>;
   autoAckSkipIncompleteNodes: boolean;
   setAutoAckSkipIncompleteNodes: React.Dispatch<React.SetStateAction<boolean>>;
+  autoAckIgnoredNodes: string;
+  setAutoAckIgnoredNodes: React.Dispatch<React.SetStateAction<string>>;
   autoAckTapbackEnabled: boolean;
   setAutoAckTapbackEnabled: React.Dispatch<React.SetStateAction<boolean>>;
   autoAckReplyEnabled: boolean;
@@ -102,6 +104,7 @@ export const AutomationProvider: React.FC<AutomationProviderProps> = ({ children
   const [autoAckDirectMessages, setAutoAckDirectMessages] = useState<boolean>(false);
   const [autoAckUseDM, setAutoAckUseDM] = useState<boolean>(false);
   const [autoAckSkipIncompleteNodes, setAutoAckSkipIncompleteNodes] = useState<boolean>(false);
+  const [autoAckIgnoredNodes, setAutoAckIgnoredNodes] = useState<string>('');
   const [autoAckTapbackEnabled, setAutoAckTapbackEnabled] = useState<boolean>(false);
   const [autoAckReplyEnabled, setAutoAckReplyEnabled] = useState<boolean>(true); // Default true for backward compatibility
   const [autoAckDirectEnabled, setAutoAckDirectEnabled] = useState<boolean>(true);
@@ -147,6 +150,7 @@ export const AutomationProvider: React.FC<AutomationProviderProps> = ({ children
         autoAckDirectMessages, setAutoAckDirectMessages,
         autoAckUseDM, setAutoAckUseDM,
         autoAckSkipIncompleteNodes, setAutoAckSkipIncompleteNodes,
+        autoAckIgnoredNodes, setAutoAckIgnoredNodes,
         autoAckTapbackEnabled, setAutoAckTapbackEnabled,
         autoAckReplyEnabled, setAutoAckReplyEnabled,
         autoAckDirectEnabled, setAutoAckDirectEnabled,

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -25,6 +25,7 @@ export const VALID_SETTINGS_KEYS = [
   'autoAckDirectMessages',
   'autoAckUseDM',
   'autoAckSkipIncompleteNodes',
+  'autoAckIgnoredNodes',
   'autoAckTapbackEnabled',
   'autoAckReplyEnabled',
   'autoAckDirectEnabled',

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6552,12 +6552,29 @@ class MeshtasticManager {
       // Check channel-specific settings
       const autoAckChannels = databaseService.getSetting('autoAckChannels');
       const autoAckDirectMessages = databaseService.getSetting('autoAckDirectMessages');
+      const autoAckIgnoredNodes = databaseService.getSetting('autoAckIgnoredNodes');
 
       // Parse enabled channels (comma-separated list of channel indices)
       const enabledChannels = autoAckChannels
         ? autoAckChannels.split(',').map(c => parseInt(c.trim())).filter(n => !isNaN(n))
         : [];
       const dmEnabled = autoAckDirectMessages === 'true';
+
+      // Parse optional node ignore list. Supports canonical !xxxxxxxx entries.
+      const ignoredNodeNums = new Set<number>();
+      if (autoAckIgnoredNodes) {
+        const ignoredNodeIds = autoAckIgnoredNodes
+          .split(/[\s,]+/)
+          .map(token => token.trim().toLowerCase())
+          .filter(Boolean);
+
+        for (const nodeId of ignoredNodeIds) {
+          const normalizedNodeId = nodeId.startsWith('!') ? nodeId.slice(1) : nodeId;
+          if (/^[0-9a-f]{8}$/.test(normalizedNodeId)) {
+            ignoredNodeNums.add(parseInt(normalizedNodeId, 16));
+          }
+        }
+      }
 
       // Check if auto-ack is enabled for this channel/DM
       if (isDirectMessage) {
@@ -6578,6 +6595,11 @@ class MeshtasticManager {
       const localNodeNum = databaseService.getSetting('localNodeNum');
       if (localNodeNum && parseInt(localNodeNum) === fromNum) {
         logger.debug('⏭️  Skipping auto-acknowledge for message from local node');
+        return;
+      }
+
+      if (ignoredNodeNums.has(fromNum)) {
+        logger.debug(`⏭️  Skipping auto-acknowledge for ignored node !${fromNum.toString(16).padStart(8, '0')}`);
         return;
       }
 

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -81,6 +81,26 @@ export function validateCustomTilesets(tilesets: any[]): boolean {
   return true;
 }
 
+function normalizeIgnoredNodeIds(rawValue: string): string {
+  const tokens = rawValue
+    .split(/[\s,]+/)
+    .map(token => token.trim().toLowerCase())
+    .filter(Boolean);
+
+  const normalized = new Set<string>();
+
+  for (const token of tokens) {
+    if (!/^!?[0-9a-f]{8}$/.test(token)) {
+      throw new Error('Node ignore list entries must be 8-digit hex node IDs (example: !b29fa8d4)');
+    }
+
+    const hex = token.startsWith('!') ? token.slice(1) : token;
+    normalized.add(`!${hex}`);
+  }
+
+  return [...normalized].join(',');
+}
+
 // ─── Side-effect callbacks ───────────────────────────────────────────────
 // These are injected by server.ts so the route handler doesn't directly
 // depend on meshtasticManager / inactiveNodeNotificationService / etc.
@@ -169,6 +189,16 @@ router.post('/', requirePermission('settings', 'write'), (req: Request, res: Res
         .map((c) => parseInt(c.trim()))
         .filter((n) => !isNaN(n) && n >= 0 && n < 8);
       filteredSettings.autoAckChannels = validChannels.join(',');
+    }
+
+    if ('autoAckIgnoredNodes' in filteredSettings) {
+      try {
+        filteredSettings.autoAckIgnoredNodes = normalizeIgnoredNodeIds(filteredSettings.autoAckIgnoredNodes);
+      } catch (error) {
+        return res.status(400).json({
+          error: error instanceof Error ? error.message : 'Invalid node ignore list format',
+        });
+      }
     }
 
     // Validate inactive node notification settings

--- a/src/server/server.settings-persistence.test.ts
+++ b/src/server/server.settings-persistence.test.ts
@@ -122,6 +122,7 @@ function validTestValue(key: string, suffix = ''): string {
   const VALID_VALUES: Record<string, string> = {
     autoAckRegex: 'hello',
     autoAckChannels: '0,1',
+    autoAckIgnoredNodes: '!b29fa8d4,!a1b2c3d4',
     inactiveNodeThresholdHours: '24',
     inactiveNodeCheckIntervalMinutes: '60',
     inactiveNodeCooldownHours: '24',


### PR DESCRIPTION
Added 'Node Ignore List' to the auto-acknowledge automation component. This allows us to ignore nodes that are too noisy or abusive
format:
Do not auto-acknowledge messages from these node IDs. 
Enter one per line or comma-separated using !xxxxxxxx format.