### PR TITLE
feat: configurable TCP timing and module config delay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,20 @@ MESHTASTIC_NODE_IP=192.168.1.100
 # TCP port for Meshtastic node connection (default: 4403)
 MESHTASTIC_TCP_PORT=4403
 
+# TCP Connection Timing (OPTIONAL - for advanced troubleshooting)
+# Initial TCP connection timeout in milliseconds (default: 10000 = 10 seconds)
+# MESHTASTIC_CONNECT_TIMEOUT_MS=10000
+
+# Reconnect backoff: initial delay and maximum delay in milliseconds
+# Reconnects use exponential backoff: initial * 2^(attempt-1), capped at max
+# Set initial = max for a fixed delay between reconnects
+# MESHTASTIC_RECONNECT_INITIAL_DELAY_MS=1000
+# MESHTASTIC_RECONNECT_MAX_DELAY_MS=60000
+
+# Delay between consecutive module config requests in milliseconds (default: 100)
+# Increase if your node shows queue overflow during config loading
+# MESHTASTIC_MODULE_CONFIG_DELAY_MS=100
+
 # MeshCore Configuration (OPTIONAL)
 # Enable MeshCore protocol support for monitoring MeshCore mesh networks
 # When enabled, adds /api/meshcore endpoints and MeshCore tab in the UI

--- a/docs/ARCHITECTURE_LESSONS.md
+++ b/docs/ARCHITECTURE_LESSONS.md
@@ -166,6 +166,17 @@ if (pendingOp) {
 # Set via environment variable (in milliseconds)
 MESHTASTIC_STALE_CONNECTION_TIMEOUT=300000  # 5 minutes (default)
 MESHTASTIC_STALE_CONNECTION_TIMEOUT=0       # Disable (not recommended)
+
+# TCP connect/reconnect timing (for advanced troubleshooting)
+MESHTASTIC_CONNECT_TIMEOUT_MS=10000         # Initial TCP connect timeout (default: 10s)
+MESHTASTIC_RECONNECT_INITIAL_DELAY_MS=1000  # First reconnect delay (default: 1s)
+MESHTASTIC_RECONNECT_MAX_DELAY_MS=60000     # Max reconnect delay cap (default: 60s)
+# Reconnect uses exponential backoff: initial * 2^(attempt-1), capped at max
+# Set initial = max for fixed delay (e.g., both = 60000 for 1-minute fixed delay)
+
+# Module config request throttling
+MESHTASTIC_MODULE_CONFIG_DELAY_MS=100       # Delay between config requests (default: 100ms)
+# Increase to 250-1000ms if device shows queue overflow during config loading
 ```
 
 **Why Needed**:
@@ -181,6 +192,8 @@ MESHTASTIC_STALE_CONNECTION_TIMEOUT=0       # Disable (not recommended)
 - Manual reconnect fixes the issue
 
 **Related**: Issue #492 - Serial-connected device stops responding after idle
+**Related**: Issue #2213 - Configurable TCP connect/reconnect timing
+**Related**: Issue #2214 - Configurable module config request delay
 
 ---
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -74,6 +74,10 @@ MeshMonitor can be configured using environment variables. Here are the most imp
 | `MESHTASTIC_NODE_IP` | IP address of your Meshtastic node | `192.168.1.100` |
 | `MESHTASTIC_TCP_PORT` | TCP port for Meshtastic connection | `4403` |
 | `MESHTASTIC_STALE_CONNECTION_TIMEOUT` | Connection timeout in milliseconds before reconnecting if no data received | `300000` (5 minutes) |
+| `MESHTASTIC_CONNECT_TIMEOUT_MS` | Initial TCP connection timeout in milliseconds | `10000` (10 seconds) |
+| `MESHTASTIC_RECONNECT_INITIAL_DELAY_MS` | Initial delay before first reconnect attempt (base for exponential backoff) | `1000` (1 second) |
+| `MESHTASTIC_RECONNECT_MAX_DELAY_MS` | Maximum delay between reconnect attempts (backoff cap) | `60000` (60 seconds) |
+| `MESHTASTIC_MODULE_CONFIG_DELAY_MS` | Delay between consecutive module config requests to avoid overwhelming the device | `100` (100ms) |
 
 ### Virtual Node Variables
 

--- a/src/server/config/environment.ts
+++ b/src/server/config/environment.ts
@@ -206,6 +206,14 @@ export interface EnvironmentConfig {
   meshtasticTcpPortProvided: boolean;
   meshtasticStaleConnectionTimeout: number;
   meshtasticStaleConnectionTimeoutProvided: boolean;
+  meshtasticConnectTimeoutMs: number;
+  meshtasticConnectTimeoutMsProvided: boolean;
+  meshtasticReconnectInitialDelayMs: number;
+  meshtasticReconnectInitialDelayMsProvided: boolean;
+  meshtasticReconnectMaxDelayMs: number;
+  meshtasticReconnectMaxDelayMsProvided: boolean;
+  meshtasticModuleConfigDelayMs: number;
+  meshtasticModuleConfigDelayMsProvided: boolean;
   timezone: string;
   timezoneProvided: boolean;
 
@@ -447,6 +455,26 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
     process.env.MESHTASTIC_STALE_CONNECTION_TIMEOUT,
     300000 // 5 minutes default (in milliseconds)
   );
+  const meshtasticConnectTimeoutMs = parseInt32(
+    'MESHTASTIC_CONNECT_TIMEOUT_MS',
+    process.env.MESHTASTIC_CONNECT_TIMEOUT_MS,
+    10000 // 10 seconds default
+  );
+  const meshtasticReconnectInitialDelayMs = parseInt32(
+    'MESHTASTIC_RECONNECT_INITIAL_DELAY_MS',
+    process.env.MESHTASTIC_RECONNECT_INITIAL_DELAY_MS,
+    1000 // 1 second default
+  );
+  const meshtasticReconnectMaxDelayMs = parseInt32(
+    'MESHTASTIC_RECONNECT_MAX_DELAY_MS',
+    process.env.MESHTASTIC_RECONNECT_MAX_DELAY_MS,
+    60000 // 60 seconds default
+  );
+  const meshtasticModuleConfigDelayMs = parseInt32(
+    'MESHTASTIC_MODULE_CONFIG_DELAY_MS',
+    process.env.MESHTASTIC_MODULE_CONFIG_DELAY_MS,
+    100 // 100ms default
+  );
   const timezoneRaw = process.env.TZ || 'UTC';
   let timezone = { value: timezoneRaw, wasProvided: process.env.TZ !== undefined };
 
@@ -615,6 +643,14 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
     meshtasticTcpPortProvided: meshtasticTcpPort.wasProvided,
     meshtasticStaleConnectionTimeout: meshtasticStaleConnectionTimeout.value,
     meshtasticStaleConnectionTimeoutProvided: meshtasticStaleConnectionTimeout.wasProvided,
+    meshtasticConnectTimeoutMs: meshtasticConnectTimeoutMs.value,
+    meshtasticConnectTimeoutMsProvided: meshtasticConnectTimeoutMs.wasProvided,
+    meshtasticReconnectInitialDelayMs: meshtasticReconnectInitialDelayMs.value,
+    meshtasticReconnectInitialDelayMsProvided: meshtasticReconnectInitialDelayMs.wasProvided,
+    meshtasticReconnectMaxDelayMs: meshtasticReconnectMaxDelayMs.value,
+    meshtasticReconnectMaxDelayMsProvided: meshtasticReconnectMaxDelayMs.wasProvided,
+    meshtasticModuleConfigDelayMs: meshtasticModuleConfigDelayMs.value,
+    meshtasticModuleConfigDelayMsProvided: meshtasticModuleConfigDelayMs.wasProvided,
     timezone: timezone.value,
     timezoneProvided: timezone.wasProvided,
 

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -552,9 +552,11 @@ class MeshtasticManager {
       // Create TCP transport
       this.transport = new TcpTransport();
 
-      // Configure stale connection timeout from environment
+      // Configure connection timing from environment
       const env = getEnvironmentConfig();
       this.transport.setStaleConnectionTimeout(env.meshtasticStaleConnectionTimeout);
+      this.transport.setConnectTimeout(env.meshtasticConnectTimeoutMs);
+      this.transport.setReconnectTiming(env.meshtasticReconnectInitialDelayMs, env.meshtasticReconnectMaxDelayMs);
 
       // Setup event handlers
       this.transport.on('connect', () => {
@@ -9936,8 +9938,8 @@ class MeshtasticManager {
     for (const configType of moduleConfigTypes) {
       try {
         await this.requestModuleConfig(configType);
-        // Small delay between requests to avoid overwhelming the device
-        await new Promise(resolve => setTimeout(resolve, 100));
+        // Configurable delay between requests to avoid overwhelming the device
+        await new Promise(resolve => setTimeout(resolve, getEnvironmentConfig().meshtasticModuleConfigDelayMs));
       } catch (error) {
         logger.error(`❌ Failed to request module config type ${configType}:`, error);
         // Continue with other configs even if one fails

--- a/src/server/tcpTransport.ts
+++ b/src/server/tcpTransport.ts
@@ -23,6 +23,11 @@ export class TcpTransport extends EventEmitter {
   private healthCheckInterval: NodeJS.Timeout | null = null;
   private readonly HEALTH_CHECK_INTERVAL_MS = 60000; // Check every minute
 
+  // Configurable TCP timing
+  private connectTimeoutMs: number = 10000; // 10 second default
+  private reconnectInitialDelayMs: number = 1000; // 1 second default
+  private reconnectMaxDelayMs: number = 60000; // 60 second default
+
   // Protocol constants
   private readonly START1 = 0x94;
   private readonly START2 = 0xc3;
@@ -40,6 +45,23 @@ export class TcpTransport extends EventEmitter {
     }
 
     logger.debug(`⏱️  Stale connection timeout set to ${timeoutMs}ms (${Math.floor(timeoutMs / 1000 / 60)} minute(s))`);
+  }
+
+  /**
+   * Set the initial TCP connection timeout in milliseconds
+   */
+  setConnectTimeout(timeoutMs: number): void {
+    this.connectTimeoutMs = timeoutMs;
+    logger.debug(`⏱️  TCP connect timeout set to ${timeoutMs}ms`);
+  }
+
+  /**
+   * Set the reconnect backoff parameters in milliseconds
+   */
+  setReconnectTiming(initialDelayMs: number, maxDelayMs: number): void {
+    this.reconnectInitialDelayMs = initialDelayMs;
+    this.reconnectMaxDelayMs = maxDelayMs;
+    logger.debug(`⏱️  Reconnect timing: initial=${initialDelayMs}ms, max=${maxDelayMs}ms`);
   }
 
   async connect(host: string, port: number = 4403): Promise<void> {
@@ -76,7 +98,7 @@ export class TcpTransport extends EventEmitter {
           this.socket.destroy();
           reject(new Error('Connection timeout'));
         }
-      }, 10000); // 10 second timeout
+      }, this.connectTimeoutMs);
 
       this.socket.once('connect', () => {
         clearTimeout(connectTimeout);
@@ -138,8 +160,8 @@ export class TcpTransport extends EventEmitter {
 
     this.reconnectAttempts++;
 
-    // Exponential backoff: 1s, 2s, 4s, 8s, 16s, 32s, 60s (capped at 60s)
-    const delay = Math.min(Math.pow(2, this.reconnectAttempts - 1) * 1000, 60000);
+    // Exponential backoff: initialDelay * 2^(attempts-1), capped at maxDelay
+    const delay = Math.min(Math.pow(2, this.reconnectAttempts - 1) * this.reconnectInitialDelayMs, this.reconnectMaxDelayMs);
 
     logger.debug(`🔄 Reconnecting in ${delay / 1000}s (attempt ${this.reconnectAttempts})...`);
 


### PR DESCRIPTION
## Summary
- Adds 4 new environment variables for advanced TCP connection tuning, requested by users for troubleshooting node boot/reboot behavior and reducing API flood on lower-memory devices
- `MESHTASTIC_CONNECT_TIMEOUT_MS` — initial TCP connect timeout (default: 10s)
- `MESHTASTIC_RECONNECT_INITIAL_DELAY_MS` — first reconnect delay, base for exponential backoff (default: 1s)
- `MESHTASTIC_RECONNECT_MAX_DELAY_MS` — backoff cap (default: 60s). Set initial = max for fixed delay.
- `MESHTASTIC_MODULE_CONFIG_DELAY_MS` — delay between module config requests (default: 100ms)
- All defaults preserve existing behavior — no change for current users

Closes #2213
Closes #2214

## Test plan
- [x] All 10 system tests pass
- [ ] Verify default behavior unchanged (no env vars set)
- [ ] Test with custom values (e.g., `MESHTASTIC_CONNECT_TIMEOUT_MS=60000`)
- [ ] Test fixed reconnect delay (`RECONNECT_INITIAL=60000`, `RECONNECT_MAX=60000`)
- [ ] Test increased module config delay (`MESHTASTIC_MODULE_CONFIG_DELAY_MS=500`)

🤖 Generated with [Claude Code](https://claude.ai/code)