### PR TITLE
chore: bump version to 3.8.7

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.8.6
-appVersion: "3.8.6"
+version: 3.8.7
+appVersion: "3.8.7"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.8.6",
+      "version": "3.8.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Version bump to 3.8.7 with release notes.

## Changes since v3.8.6

### Features
- **Configurable TCP timing and module config delay** ([#2216](https://github.com/Yeraze/meshmonitor/pull/2216)) — Closes [#2213](https://github.com/Yeraze/meshmonitor/issues/2213), [#2214](https://github.com/Yeraze/meshmonitor/issues/2214)
  - `MESHTASTIC_CONNECT_TIMEOUT_MS` — initial TCP connect timeout (default: 10s)
  - `MESHTASTIC_RECONNECT_INITIAL_DELAY_MS` — reconnect backoff base delay (default: 1s)
  - `MESHTASTIC_RECONNECT_MAX_DELAY_MS` — reconnect backoff cap (default: 60s)
  - `MESHTASTIC_MODULE_CONFIG_DELAY_MS` — delay between module config requests (default: 100ms)
- **Node ignore list for auto-acknowledge** ([#2212](https://github.com/Yeraze/meshmonitor/pull/2212)) — Suppress auto-ack for specific noisy/abusive nodes
- **Enhanced Node Status Widget** ([#2205](https://github.com/Yeraze/meshmonitor/pull/2205)) — Clickable node names, voltage column, uptime column

### Bug Fixes
- **Fix channel assignment for node communication** ([#2208](https://github.com/Yeraze/meshmonitor/pull/2208)) — Update node channel from all firmware-decoded packets instead of only NodeInfo, preventing nodes from getting stuck on wrong channel
- **Fix MQTT-sourced neighbor info creating bogus map connections** ([#2206](https://github.com/Yeraze/meshmonitor/pull/2206))
- **Fix iOS channel display ordering** ([#2204](https://github.com/Yeraze/meshmonitor/pull/2204)) — Match firmware config state machine order
- **Fix NodeStatusWidget excessive voltage re-fetching** ([#2207](https://github.com/Yeraze/meshmonitor/pull/2207)) — Replace raw fetch with React Query hook for caching/dedup

### Improvements
- **CSS design token consolidation** ([#2215](https://github.com/Yeraze/meshmonitor/pull/2215)) — Unified design tokens, fixed 42+ orphan variable references, fully themed LoginPage and TilesetSelector
- **Clarify Node Hops Calculation docs** ([#2211](https://github.com/Yeraze/meshmonitor/pull/2211)) — Document that "All messages" uses all packet types
- **Enhanced bug report template** ([#2209](https://github.com/Yeraze/meshmonitor/pull/2209))
- **Translation updates** ([#2196](https://github.com/Yeraze/meshmonitor/pull/2196))

🤖 Generated with [Claude Code](https://claude.ai/code)