### PR TITLE
fix: reduce noisy INFO logs from poll endpoint and getDeviceConfig

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5771,12 +5771,12 @@ class MeshtasticManager {
   // Configuration retrieval methods
   async getDeviceConfig(): Promise<any> {
     // Return config data from what we've received via TCP stream
-    logger.info('🔍 getDeviceConfig called - actualDeviceConfig.lora present:', !!this.actualDeviceConfig?.lora);
-    logger.info('🔍 getDeviceConfig called - actualModuleConfig present:', !!this.actualModuleConfig);
+    logger.debug('🔍 getDeviceConfig called - actualDeviceConfig.lora present:', !!this.actualDeviceConfig?.lora);
+    logger.debug('🔍 getDeviceConfig called - actualModuleConfig present:', !!this.actualModuleConfig);
 
     if (this.actualDeviceConfig?.lora || this.actualModuleConfig) {
       logger.debug('Using actualDeviceConfig:', JSON.stringify(this.actualDeviceConfig, null, 2));
-      logger.info('✅ Returning device config from actualDeviceConfig');
+      logger.debug('✅ Returning device config from actualDeviceConfig');
       return this.buildDeviceConfigFromActual();
     }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3731,7 +3731,7 @@ apiRouter.get('/device/security-keys', requireAuth(), async (_req, res) => {
 
 // Consolidated polling endpoint - reduces multiple API calls to one
 apiRouter.get('/poll', optionalAuth(), async (req, res) => {
-  logger.info('🔔 [POLL] Endpoint called');
+  logger.debug('🔔 [POLL] Endpoint called');
   try {
     const result: {
       connection?: any;


### PR DESCRIPTION
## Summary
- Downgraded 4 repetitive log messages from `logger.info` to `logger.debug`:
  - `[POLL] Endpoint called` in server.ts
  - `getDeviceConfig called - actualDeviceConfig.lora present` in meshtasticManager.ts
  - `getDeviceConfig called - actualModuleConfig present` in meshtasticManager.ts
  - `Returning device config from actualDeviceConfig` in meshtasticManager.ts
- These fire on every poll cycle and flood production logs with no actionable information
- Warnings and error-state messages (e.g. "No device config available yet") remain at INFO level

Closes #2219

## System Test Results (2026-03-11)

| Test Suite | Result |
|------------|--------|
| Configuration Import | PASSED |
| Quick Start Test | PASSED |
| Security Test | PASSED |
| V1 API Test | PASSED |
| Reverse Proxy Test | PASSED |
| Reverse Proxy + OIDC | PASSED |
| Virtual Node CLI Test | PASSED |
| Backup & Restore Test | PASSED |
| Database Migration Test | PASSED |
| DB Backing Consistency | PASSED |

## Test plan
- [x] Type-check passes
- [x] All 10 system tests pass
- [x] Verified poll log lines no longer appear in production container logs
- [x] Verified they still appear when LOG_LEVEL=debug

🤖 Generated with [Claude Code](https://claude.ai/code)