### PR TITLE
fix: support default key AQ== in Channel Database and fix permission check

### DIFF
--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -347,8 +347,15 @@ export default function ChannelsTab({
           return false;
         }
 
-        // Check if user has permission to read this channel
-        if (!hasPermission(`channel_${ch}` as ResourceType, 'read')) {
+        // Check permissions: Channel Database channels (>= 100) use channel database permissions,
+        // device channels (0-7) use standard channel permissions
+        if (ch >= CHANNEL_DB_OFFSET) {
+          // Channel Database channels are accessible if the entry exists in channelDatabaseEntries
+          const channelDbId = ch - CHANNEL_DB_OFFSET;
+          if (!channelDatabaseEntries.some(entry => entry.id === channelDbId)) {
+            return false;
+          }
+        } else if (!hasPermission(`channel_${ch}` as ResourceType, 'read')) {
           return false;
         }
 

--- a/src/server/constants/meshtastic.ts
+++ b/src/server/constants/meshtastic.ts
@@ -202,3 +202,52 @@ export const MIN_TRACEROUTE_INTERVAL_MS = 30 * 1000;
  * Messages longer than this will be truncated or need to be split.
  */
 export const MAX_MESSAGE_BYTES = 200;
+
+/**
+ * Meshtastic default channel encryption key.
+ * This is the well-known key used when PSK is set to shorthand value 1 (AQ== in base64).
+ */
+export const MESHTASTIC_DEFAULT_KEY = Buffer.from([
+  0xd4, 0xf1, 0xbb, 0x3a, 0x20, 0x29, 0x07, 0x59,
+  0xf0, 0xbc, 0xff, 0xab, 0xcf, 0x4e, 0x69, 0x01
+]);
+
+/**
+ * Expand a Meshtastic shorthand PSK (1 byte) to a full 16-byte key.
+ * Shorthand values:
+ *   0 = No crypto (returns null)
+ *   1 = Default key
+ *   2-10 = Default key with (value-1) added to last byte (simple1-simple9)
+ *
+ * @param pskBuffer The raw PSK buffer (may be 1 byte shorthand or full 16/32 byte key)
+ * @returns Expanded buffer (16 or 32 bytes) or null if no crypto
+ */
+export function expandShorthandPsk(pskBuffer: Buffer): Buffer | null {
+  if (pskBuffer.length === 0) {
+    return null; // No crypto
+  }
+
+  // Full-length keys pass through unchanged
+  if (pskBuffer.length === 16 || pskBuffer.length === 32) {
+    return pskBuffer;
+  }
+
+  // Shorthand: single byte
+  if (pskBuffer.length === 1) {
+    const shorthandValue = pskBuffer[0];
+    if (shorthandValue === 0) {
+      return null; // No crypto
+    }
+
+    // Copy the default key
+    const key = Buffer.from(MESHTASTIC_DEFAULT_KEY);
+    if (shorthandValue >= 2 && shorthandValue <= 10) {
+      // simple1-simple9: add (value-1) to last byte
+      key[15] = (key[15] + (shorthandValue - 1)) & 0xff;
+    }
+    return key;
+  }
+
+  // Invalid length
+  return null;
+}

--- a/src/server/routes/channelDatabaseRoutes.ts
+++ b/src/server/routes/channelDatabaseRoutes.ts
@@ -14,6 +14,7 @@ import databaseService from '../../services/database.js';
 import { requireAuth } from '../auth/authMiddleware.js';
 import { channelDecryptionService } from '../services/channelDecryptionService.js';
 import { retroactiveDecryptionService } from '../services/retroactiveDecryptionService.js';
+import { expandShorthandPsk } from '../constants/meshtastic.js';
 import { logger } from '../../utils/logger.js';
 
 const router = express.Router();
@@ -204,24 +205,43 @@ router.post('/', async (req: Request, res: Response) => {
       });
     }
 
-    // Validate PSK is valid Base64
+    // Validate PSK is valid Base64 and expand shorthand keys
+    let finalPsk = psk;
+    let finalPskLength: number;
     try {
       const pskBuffer = Buffer.from(psk, 'base64');
-      if (pskBuffer.length !== 16 && pskBuffer.length !== 32) {
+
+      // Expand shorthand PSK (1-byte keys like AQ==) to full 16-byte key
+      const expandedPsk = expandShorthandPsk(pskBuffer);
+      if (!expandedPsk) {
         return res.status(400).json({
           success: false,
           error: 'Bad Request',
-          message: 'PSK must be 16 bytes (AES-128) or 32 bytes (AES-256) when decoded'
+          message: 'PSK value 0 means no encryption, which is not supported for channel database'
         });
       }
 
-      // Validate pskLength matches actual length
-      const expectedLength = pskLength ?? pskBuffer.length;
-      if (expectedLength !== pskBuffer.length) {
+      if (expandedPsk.length !== 16 && expandedPsk.length !== 32) {
         return res.status(400).json({
           success: false,
           error: 'Bad Request',
-          message: `pskLength (${expectedLength}) does not match actual PSK length (${pskBuffer.length})`
+          message: 'PSK must be 1 byte (shorthand), 16 bytes (AES-128), or 32 bytes (AES-256) when decoded'
+        });
+      }
+
+      // Use expanded key if it was a shorthand
+      if (expandedPsk.length !== pskBuffer.length) {
+        finalPsk = expandedPsk.toString('base64');
+        logger.debug(`Expanded shorthand PSK (${pskBuffer.length} byte) to ${expandedPsk.length}-byte key`);
+      }
+      finalPskLength = expandedPsk.length;
+
+      // Validate pskLength if explicitly provided
+      if (pskLength !== undefined && pskLength !== finalPskLength) {
+        return res.status(400).json({
+          success: false,
+          error: 'Bad Request',
+          message: `pskLength (${pskLength}) does not match actual PSK length (${finalPskLength})`
         });
       }
     } catch (_err) {
@@ -234,8 +254,8 @@ router.post('/', async (req: Request, res: Response) => {
 
     const newChannelId = await databaseService.createChannelDatabaseEntryAsync({
       name,
-      psk,
-      pskLength: pskLength ?? Buffer.from(psk, 'base64').length,
+      psk: finalPsk,
+      pskLength: finalPskLength,
       description: description ?? null,
       isEnabled: isEnabled ?? true,
       createdBy: user?.id ?? null,
@@ -412,15 +432,23 @@ router.put('/:id', async (req: Request, res: Response) => {
 
       try {
         const pskBuffer = Buffer.from(psk, 'base64');
-        if (pskBuffer.length !== 16 && pskBuffer.length !== 32) {
+        const expandedPsk = expandShorthandPsk(pskBuffer);
+        if (!expandedPsk) {
           return res.status(400).json({
             success: false,
             error: 'Bad Request',
-            message: 'PSK must be 16 bytes (AES-128) or 32 bytes (AES-256) when decoded'
+            message: 'PSK value 0 means no encryption, which is not supported for channel database'
           });
         }
-        updates.psk = psk;
-        updates.pskLength = pskBuffer.length;
+        if (expandedPsk.length !== 16 && expandedPsk.length !== 32) {
+          return res.status(400).json({
+            success: false,
+            error: 'Bad Request',
+            message: 'PSK must be 1 byte (shorthand), 16 bytes (AES-128), or 32 bytes (AES-256) when decoded'
+          });
+        }
+        updates.psk = expandedPsk.length !== pskBuffer.length ? expandedPsk.toString('base64') : psk;
+        updates.pskLength = expandedPsk.length;
       } catch (_err) {
         return res.status(400).json({
           success: false,

--- a/src/server/routes/v1/channelDatabase.ts
+++ b/src/server/routes/v1/channelDatabase.ts
@@ -13,6 +13,7 @@ import express, { Request, Response } from 'express';
 import databaseService from '../../../services/database.js';
 import { channelDecryptionService } from '../../services/channelDecryptionService.js';
 import { retroactiveDecryptionService } from '../../services/retroactiveDecryptionService.js';
+import { expandShorthandPsk } from '../../constants/meshtastic.js';
 import { logger } from '../../../utils/logger.js';
 
 const router = express.Router();
@@ -202,24 +203,43 @@ router.post('/', async (req: Request, res: Response) => {
       });
     }
 
-    // Validate PSK is valid Base64
+    // Validate PSK is valid Base64 and expand shorthand keys
+    let finalPsk = psk;
+    let finalPskLength: number;
     try {
       const pskBuffer = Buffer.from(psk, 'base64');
-      if (pskBuffer.length !== 16 && pskBuffer.length !== 32) {
+
+      // Expand shorthand PSK (1-byte keys like AQ==) to full 16-byte key
+      const expandedPsk = expandShorthandPsk(pskBuffer);
+      if (!expandedPsk) {
         return res.status(400).json({
           success: false,
           error: 'Bad Request',
-          message: 'PSK must be 16 bytes (AES-128) or 32 bytes (AES-256) when decoded'
+          message: 'PSK value 0 means no encryption, which is not supported for channel database'
         });
       }
 
-      // Validate pskLength matches actual length
-      const expectedLength = pskLength ?? pskBuffer.length;
-      if (expectedLength !== pskBuffer.length) {
+      if (expandedPsk.length !== 16 && expandedPsk.length !== 32) {
         return res.status(400).json({
           success: false,
           error: 'Bad Request',
-          message: `pskLength (${expectedLength}) does not match actual PSK length (${pskBuffer.length})`
+          message: 'PSK must be 1 byte (shorthand), 16 bytes (AES-128), or 32 bytes (AES-256) when decoded'
+        });
+      }
+
+      // Use expanded key if it was a shorthand
+      if (expandedPsk.length !== pskBuffer.length) {
+        finalPsk = expandedPsk.toString('base64');
+        logger.debug(`Expanded shorthand PSK (${pskBuffer.length} byte) to ${expandedPsk.length}-byte key`);
+      }
+      finalPskLength = expandedPsk.length;
+
+      // Validate pskLength if explicitly provided
+      if (pskLength !== undefined && pskLength !== finalPskLength) {
+        return res.status(400).json({
+          success: false,
+          error: 'Bad Request',
+          message: `pskLength (${pskLength}) does not match actual PSK length (${finalPskLength})`
         });
       }
     } catch (_err) {
@@ -232,8 +252,8 @@ router.post('/', async (req: Request, res: Response) => {
 
     const newChannelId = await databaseService.createChannelDatabaseEntryAsync({
       name,
-      psk,
-      pskLength: pskLength ?? Buffer.from(psk, 'base64').length,
+      psk: finalPsk,
+      pskLength: finalPskLength,
       description: description ?? null,
       isEnabled: isEnabled ?? true,
       enforceNameValidation: enforceNameValidation ?? false,
@@ -411,15 +431,23 @@ router.put('/:id', async (req: Request, res: Response) => {
 
       try {
         const pskBuffer = Buffer.from(psk, 'base64');
-        if (pskBuffer.length !== 16 && pskBuffer.length !== 32) {
+        const expandedPsk = expandShorthandPsk(pskBuffer);
+        if (!expandedPsk) {
           return res.status(400).json({
             success: false,
             error: 'Bad Request',
-            message: 'PSK must be 16 bytes (AES-128) or 32 bytes (AES-256) when decoded'
+            message: 'PSK value 0 means no encryption, which is not supported for channel database'
           });
         }
-        updates.psk = psk;
-        updates.pskLength = pskBuffer.length;
+        if (expandedPsk.length !== 16 && expandedPsk.length !== 32) {
+          return res.status(400).json({
+            success: false,
+            error: 'Bad Request',
+            message: 'PSK must be 1 byte (shorthand), 16 bytes (AES-128), or 32 bytes (AES-256) when decoded'
+          });
+        }
+        updates.psk = expandedPsk.length !== pskBuffer.length ? expandedPsk.toString('base64') : psk;
+        updates.pskLength = expandedPsk.length;
       } catch (_err) {
         return res.status(400).json({
           success: false,

--- a/src/server/services/channelDecryptionService.test.ts
+++ b/src/server/services/channelDecryptionService.test.ts
@@ -87,13 +87,26 @@ describe('ChannelDecryptionService', () => {
     });
 
     it('should skip channels with invalid PSK length', async () => {
+      // Use a 20-byte key which is neither a valid shorthand (1), AES-128 (16), nor AES-256 (32)
+      const invalidPsk = Buffer.alloc(20, 0xab).toString('base64');
       (databaseService.getEnabledChannelDatabaseEntriesAsync as Mock).mockResolvedValue([
-        { id: 1, name: 'Invalid Channel', psk: testPskBase64, pskLength: 24 } // Wrong declared length
+        { id: 1, name: 'Invalid Channel', psk: invalidPsk, pskLength: 20 }
       ]);
 
       await channelDecryptionService.refreshChannelCache();
 
       expect(channelDecryptionService.getCacheSize()).toBe(0);
+    });
+
+    it('should expand shorthand PSK (AQ==) to full 16-byte key', async () => {
+      // AQ== is base64 for a single byte 0x01 (Meshtastic default key shorthand)
+      (databaseService.getEnabledChannelDatabaseEntriesAsync as Mock).mockResolvedValue([
+        { id: 1, name: 'Default Key Channel', psk: 'AQ==', pskLength: 1 }
+      ]);
+
+      await channelDecryptionService.refreshChannelCache();
+
+      expect(channelDecryptionService.getCacheSize()).toBe(1);
     });
 
     it('should skip channels without ID', async () => {

--- a/src/server/services/channelDecryptionService.ts
+++ b/src/server/services/channelDecryptionService.ts
@@ -13,7 +13,7 @@ import { createDecipheriv } from 'crypto';
 import { getProtobufRoot } from '../protobufLoader.js';
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
-import { CHANNEL_CACHE_TTL_MS } from '../constants/meshtastic.js';
+import { CHANNEL_CACHE_TTL_MS, expandShorthandPsk } from '../constants/meshtastic.js';
 
 export interface DecryptionResult {
   success: boolean;
@@ -116,25 +116,27 @@ class ChannelDecryptionService {
             continue;
           }
 
-          const pskBuffer = Buffer.from(channel.psk, 'base64');
+          const rawPskBuffer = Buffer.from(channel.psk, 'base64');
 
-          // Validate PSK length matches declared length
-          if (pskBuffer.length !== channel.pskLength) {
+          // Expand shorthand PSK (1-byte keys like AQ==) to full 16-byte key
+          const pskBuffer = expandShorthandPsk(rawPskBuffer);
+          if (!pskBuffer) {
             logger.warn(
-              `Channel "${channel.name}" (id=${channel.id}): PSK length mismatch. ` +
-                `Expected ${channel.pskLength}, got ${pskBuffer.length}. Skipping.`
+              `Channel "${channel.name}" (id=${channel.id}): PSK indicates no encryption. Skipping.`
             );
             continue;
           }
 
           // Validate PSK length is valid for AES
-          if (channel.pskLength !== 16 && channel.pskLength !== 32) {
+          if (pskBuffer.length !== 16 && pskBuffer.length !== 32) {
             logger.warn(
-              `Channel "${channel.name}" (id=${channel.id}): Invalid PSK length ${channel.pskLength}. ` +
+              `Channel "${channel.name}" (id=${channel.id}): Invalid PSK length ${pskBuffer.length}. ` +
                 `Must be 16 (AES-128) or 32 (AES-256). Skipping.`
             );
             continue;
           }
+
+          const pskLength = pskBuffer.length;
 
           // Compute expected channel hash if name validation is enabled
           const enforceNameValidation = channel.enforceNameValidation ?? false;
@@ -146,7 +148,7 @@ class ChannelDecryptionService {
             id: channel.id,
             name: channel.name,
             psk: pskBuffer,
-            pskLength: channel.pskLength,
+            pskLength,
             enforceNameValidation,
             expectedChannelHash,
             sortOrder: channel.sortOrder ?? 0,


### PR DESCRIPTION
## Summary
- **Server-side PSK expansion**: API routes now expand 1-byte shorthand Meshtastic PSKs (like `AQ==` for the default key) to the full 16-byte key before storing. Previously the server rejected these, requiring client-side expansion only.
- **Decryption service safety net**: The channel cache refresh now also expands shorthand PSKs, handling any legacy database entries that were stored with unexpanded keys.
- **Frontend permission fix**: Channel Database channels (>= `CHANNEL_DB_OFFSET`) were checked against standard channel permissions (`channel_101`, etc.) which don't exist in the permission system. Non-admin users could never see these channels in the Channels tab. Now checks channel database entries directly.

Closes #2218

## Root Cause Analysis
The bug had multiple contributing factors:
1. If `AQ==` was sent directly via the API (bypassing the frontend), the server rejected it as invalid (not 16 or 32 bytes)
2. The decryption service would skip any legacy entries with mismatched PSK lengths
3. Non-admin users couldn't see Channel Database channels at all due to the wrong permission check function being used

## Changes
| File | Change |
|------|--------|
| `src/server/constants/meshtastic.ts` | Added `MESHTASTIC_DEFAULT_KEY` constant and `expandShorthandPsk()` utility |
| `src/server/routes/channelDatabaseRoutes.ts` | Expand shorthand PSKs in create/update routes |
| `src/server/routes/v1/channelDatabase.ts` | Same expansion in v1 API routes |
| `src/server/services/channelDecryptionService.ts` | Expand shorthand PSKs during cache refresh |
| `src/server/services/channelDecryptionService.test.ts` | Updated invalid PSK test, added shorthand expansion test |
| `src/components/ChannelsTab.tsx` | Fixed permission check for channel DB channels |

## System Test Results (2026-03-11)

| Test Suite | Result |
|------------|--------|
| Configuration Import | PASSED |
| Quick Start Test | PASSED |
| Security Test | PASSED |
| V1 API Test | PASSED |
| Reverse Proxy Test | PASSED |
| Reverse Proxy + OIDC | PASSED |
| Virtual Node CLI Test | PASSED |
| Backup & Restore Test | PASSED |
| Database Migration Test | PASSED |
| DB Backing Consistency | PASSED |

## Test plan
- [x] Type-check passes (both server and frontend)
- [x] All 33 channel decryption unit tests pass (including new shorthand expansion test)
- [x] All 10 system tests pass
- [x] Verified `expandShorthandPsk` correctly expands `AQ==` (0x01) to the 16-byte default key

🤖 Generated with [Claude Code](https://claude.ai/code)