### PR TITLE
fix: macOS x64 build produces ARM64 binary instead of x86_64

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -231,6 +231,112 @@ jobs:
           retention-days: 7
           if-no-files-found: warn
 
+  build-macos-x64:
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-apple-darwin
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: 'desktop/src-tauri'
+
+      - name: Install main project dependencies
+        run: npm install --legacy-peer-deps
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Build server (TypeScript)
+        run: npx tsc --project tsconfig.server.json
+
+      - name: Copy OpenAPI spec
+        run: |
+          mkdir -p dist/server/routes/v1
+          cp src/server/routes/v1/openapi.yaml dist/server/routes/v1/
+
+      - name: Install desktop dependencies
+        working-directory: desktop
+        run: npm install
+
+      - name: Prepare desktop resources
+        run: |
+          mkdir -p desktop/resources/dist
+          mkdir -p desktop/resources/binaries
+          # Copy server-side compiled code
+          cp -r dist/server desktop/resources/dist/
+          cp -r dist/services desktop/resources/dist/
+          cp -r dist/utils desktop/resources/dist/
+          cp -r dist/types desktop/resources/dist/
+          cp -r dist/config desktop/resources/dist/
+          cp -r dist/constants desktop/resources/dist/
+          cp -r dist/contexts desktop/resources/dist/
+          # Copy frontend assets
+          cp -r dist/assets desktop/resources/dist/
+          cp -r dist/locales desktop/resources/dist/
+          # Copy pmtiles if it exists (may be in public or dist)
+          [ -d dist/pmtiles ] && cp -r dist/pmtiles desktop/resources/dist/ || true
+          [ -d public/pmtiles ] && cp -r public/pmtiles desktop/resources/dist/ || true
+          # Copy protobufs
+          cp -r protobufs desktop/resources/dist/
+          # Copy individual files
+          cp dist/index.html desktop/resources/dist/
+          cp dist/logo.png desktop/resources/dist/
+          cp dist/logo-original.png desktop/resources/dist/
+          cp dist/favicon.ico desktop/resources/dist/
+          cp dist/favicon-16x16.png desktop/resources/dist/
+          cp dist/favicon-32x32.png desktop/resources/dist/
+          cp dist/cors-detection.js desktop/resources/dist/
+          cp dist/cors-error.html desktop/resources/dist/
+          cp package.json desktop/resources/
+          cp package.json desktop/resources/dist/
+          # Copy node_modules (may take a while)
+          cp -r node_modules desktop/resources/dist/
+
+      - name: Download Node.js binary for bundling (x64)
+        run: |
+          NODE_VERSION="v24.12.0"
+          EXPECTED_SHA256="b82ea4c62fd08e250cab59d625e75d77cc5b0a3d60c6698ebee4545c88a169c5"
+          curl -L -o node.tar.gz "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-darwin-x64.tar.gz"
+          echo "${EXPECTED_SHA256}  node.tar.gz" | shasum -a 256 -c -
+          tar -xzf node.tar.gz
+          cp "node-${NODE_VERSION}-darwin-x64/bin/node" desktop/resources/binaries/node
+
+      - name: Run Rust linting
+        working-directory: desktop/src-tauri
+        run: cargo clippy --target x86_64-apple-darwin --all-targets --all-features -- -D warnings
+
+      - name: Run Rust tests
+        working-directory: desktop/src-tauri
+        run: cargo test --verbose
+
+      - name: Build Tauri app (debug, x64 cross-compile)
+        working-directory: desktop
+        run: npm run tauri:build -- --debug --target x86_64-apple-darwin --bundles app
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: meshmonitor-desktop-macos-x64-debug
+          path: desktop/src-tauri/target/x86_64-apple-darwin/debug/bundle/
+          retention-days: 7
+          if-no-files-found: warn
+
   lint-rust:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -725,14 +725,16 @@ jobs:
         run: npm install
 
       # Build the Tauri app (app bundle only, we'll create DMG after re-signing)
+      # IMPORTANT: --target is required because this runs on ARM64 (macos-14) but builds for x64
       - name: Build Tauri app (release)
         working-directory: desktop
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        run: npm run tauri:build -- --bundles app
+        run: npm run tauri:build -- --target x86_64-apple-darwin --bundles app
 
       # Re-sign node binary inside the app bundle with JIT entitlements
       # Tauri's signing strips our entitlements, so we need to re-apply them
+      # Note: cross-compiled output goes to target/x86_64-apple-darwin/release/
       - name: Re-sign node binary with JIT entitlements
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
@@ -742,7 +744,7 @@ jobs:
             exit 0
           fi
 
-          APP_PATH=$(find desktop/src-tauri/target/release/bundle/macos -name "*.app" -type d | head -1)
+          APP_PATH=$(find desktop/src-tauri/target/x86_64-apple-darwin/release/bundle/macos -name "*.app" -type d | head -1)
           if [ -z "$APP_PATH" ]; then
             echo "ERROR: Could not find .app bundle"
             exit 1
@@ -773,9 +775,9 @@ jobs:
       # Create DMG from the re-signed app
       - name: Create DMG
         run: |
-          APP_PATH=$(find desktop/src-tauri/target/release/bundle/macos -name "*.app" -type d | head -1)
+          APP_PATH=$(find desktop/src-tauri/target/x86_64-apple-darwin/release/bundle/macos -name "*.app" -type d | head -1)
           APP_NAME=$(basename "$APP_PATH" .app)
-          DMG_DIR="desktop/src-tauri/target/release/bundle/dmg"
+          DMG_DIR="desktop/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg"
           mkdir -p "$DMG_DIR"
 
           echo "Creating DMG from $APP_PATH..."
@@ -793,7 +795,7 @@ jobs:
             exit 0
           fi
 
-          DMG_PATH=$(find desktop/src-tauri/target/release/bundle/dmg -name "*.dmg" | head -1)
+          DMG_PATH=$(find desktop/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg -name "*.dmg" | head -1)
           echo "Notarizing $DMG_PATH..."
 
           xcrun notarytool submit "$DMG_PATH" \
@@ -817,10 +819,10 @@ jobs:
         id: rename_artifacts
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
-          DMG_PATH=$(find desktop/src-tauri/target/release/bundle/dmg -name "*.dmg" | head -1)
+          DMG_PATH=$(find desktop/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg -name "*.dmg" | head -1)
           if [ -n "$DMG_PATH" ]; then
             NEW_NAME="MeshMonitor-Desktop-${VERSION}-x64.dmg"
-            DESTINATION="desktop/src-tauri/target/release/bundle/dmg/$NEW_NAME"
+            DESTINATION="desktop/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/$NEW_NAME"
             cp "$DMG_PATH" "$DESTINATION"
             echo "DMG_PATH=$DESTINATION" >> $GITHUB_OUTPUT
             echo "DMG_NAME=$NEW_NAME" >> $GITHUB_OUTPUT
@@ -861,5 +863,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: meshmonitor-desktop-macos-x64-release
-          path: desktop/src-tauri/target/release/bundle/dmg/*.dmg
+          path: desktop/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
           retention-days: 30

--- a/docs/configuration/desktop.md
+++ b/docs/configuration/desktop.md
@@ -20,7 +20,7 @@ The desktop application:
 
 ### macOS
 - **Operating System**: macOS 11 (Big Sur) or later
-- **Architecture**: Apple Silicon (M1/M2/M3) native; Intel Macs can run via Rosetta 2
+- **Architecture**: Apple Silicon (M1/M2/M3) and Intel (x64) builds available
 - **Meshtastic Device**: A Meshtastic node with TCP API enabled
 - **Network**: Your Meshtastic node must be accessible via TCP (WiFi or Ethernet connected)
 
@@ -36,13 +36,15 @@ The desktop application:
 ### macOS
 
 1. Go to the [MeshMonitor Releases](https://github.com/Yeraze/MeshMonitor/releases) page
-2. Download the latest `MeshMonitor-Desktop-x.x.x-arm64.dmg`
+2. Download the appropriate DMG for your Mac:
+   - **Apple Silicon** (M1/M2/M3/M4): `MeshMonitor-Desktop-x.x.x-arm64.dmg`
+   - **Intel**: `MeshMonitor-Desktop-x.x.x-x64.dmg`
 3. Open the DMG file and drag MeshMonitor to your Applications folder
 4. Launch MeshMonitor from your Applications folder
 5. MeshMonitor will appear in your menu bar
 
-::: tip Apple Silicon Native
-The macOS version is compiled natively for Apple Silicon (M1/M2/M3). If you're using an Intel Mac, macOS will automatically run it through Rosetta 2.
+::: tip Choose the Right Build
+Download the DMG matching your Mac's processor. To check: Apple menu > About This Mac. If "Chip" says Apple M1/M2/M3/M4, use the arm64 build. If "Processor" says Intel, use the x64 build.
 :::
 
 ## First-Run Setup


### PR DESCRIPTION
## Summary

Fixes #2224

The x64 macOS build job runs on `macos-14` (ARM64 Apple Silicon) but the Tauri build command was missing `--target x86_64-apple-darwin`. This caused Cargo to default to the native ARM64 architecture, producing an ARM64 binary that was mislabeled as `x64.dmg`. Intel Mac users downloading this DMG would get a binary that cannot run on their hardware.

**Changes:**
- **Release workflow**: Add `--target x86_64-apple-darwin` to the Tauri build command in the x64 job, and update all output artifact paths from `target/release/bundle/` to `target/x86_64-apple-darwin/release/bundle/` (cross-compilation changes the output directory)
- **Documentation**: Fix incorrect claim that Intel Macs can run the ARM64 build via Rosetta 2 (Rosetta 2 translates x86_64→ARM64, not the reverse). Updated install instructions to list both DMG variants with guidance on choosing the right one.
- **CI workflow**: Add `build-macos-x64` job to `desktop-ci.yml` so x64 cross-compilation breakage is caught during CI, not at release time

## Test plan

- [ ] Trigger a desktop release workflow dispatch and verify the x64 DMG contains an actual x86_64 binary (`file` or `lipo -info` on the Mach-O)
- [ ] Verify ARM64 build still works (unchanged paths)
- [ ] Verify CI workflow runs both macOS jobs on desktop PRs

🤖 Generated with [Claude Code](https://claude.ai/code)