### PR TITLE
fix: display human-readable names in device metadata

### DIFF
--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -7,7 +7,8 @@ import type { Channel } from '../types/device';
 import { ImportConfigModal } from './configuration/ImportConfigModal';
 import { ExportConfigModal } from './configuration/ExportConfigModal';
 import SectionNav from './SectionNav';
-import { encodePositionFlags, decodePositionFlags } from '../utils/positionFlags';
+import { encodePositionFlags, decodePositionFlags, decodePositionFlagNames } from '../utils/positionFlags';
+import { getHardwareModelName, getRoleName } from '../utils/nodeHelpers';
 import { DeviceConfigurationSection } from './admin-commands/DeviceConfigurationSection';
 import { ModuleConfigurationSection } from './admin-commands/ModuleConfigurationSection';
 import { useAdminCommandsState } from './admin-commands/useAdminCommandsState';
@@ -2481,10 +2482,10 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                   <span style={{ color: 'var(--ctp-text)' }}>{deviceMetadata.firmwareVersion}</span>
 
                   <span style={{ color: 'var(--ctp-subtext0)', fontWeight: 500 }}>{t('admin_commands.hardware_model', 'Hardware Model')}:</span>
-                  <span style={{ color: 'var(--ctp-text)' }}>{deviceMetadata.hwModel}</span>
+                  <span style={{ color: 'var(--ctp-text)' }}>{getHardwareModelName(deviceMetadata.hwModel) || deviceMetadata.hwModel}</span>
 
                   <span style={{ color: 'var(--ctp-subtext0)', fontWeight: 500 }}>{t('admin_commands.device_role', 'Device Role')}:</span>
-                  <span style={{ color: 'var(--ctp-text)' }}>{deviceMetadata.role}</span>
+                  <span style={{ color: 'var(--ctp-text)' }}>{getRoleName(deviceMetadata.role) || deviceMetadata.role}</span>
 
                   <span style={{ color: 'var(--ctp-subtext0)', fontWeight: 500 }}>{t('admin_commands.device_state_version', 'State Version')}:</span>
                   <span style={{ color: 'var(--ctp-text)' }}>{deviceMetadata.deviceStateVersion}</span>
@@ -2501,7 +2502,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                   </span>
 
                   <span style={{ color: 'var(--ctp-subtext0)', fontWeight: 500 }}>{t('admin_commands.position_flags', 'Position Flags')}:</span>
-                  <span style={{ color: 'var(--ctp-text)' }}>{deviceMetadata.positionFlags}</span>
+                  <span style={{ color: 'var(--ctp-text)' }}>{decodePositionFlagNames(deviceMetadata.positionFlags ?? 0)}</span>
                 </div>
               </div>
             )}

--- a/src/utils/positionFlags.ts
+++ b/src/utils/positionFlags.ts
@@ -74,3 +74,23 @@ export function decodePositionFlags(mask: number): PositionFlagsState {
   };
 }
 
+/**
+ * Decode position flags bit-mask into a list of human-readable flag names
+ * @param mask - Bit-mask value (number)
+ * @returns Comma-separated string of active flag names, or "None" if no flags set
+ */
+export function decodePositionFlagNames(mask: number): string {
+  const names: string[] = [];
+  if (mask & PositionFlag.ALTITUDE) names.push('Altitude');
+  if (mask & PositionFlag.ALTITUDE_MSL) names.push('Altitude MSL');
+  if (mask & PositionFlag.GEOIDAL_SEPARATION) names.push('Geoidal Separation');
+  if (mask & PositionFlag.DOP) names.push('DOP');
+  if (mask & PositionFlag.HVDOP) names.push('HVDOP');
+  if (mask & PositionFlag.SATINVIEW) names.push('Sats in View');
+  if (mask & PositionFlag.SEQ_NO) names.push('Seq No');
+  if (mask & PositionFlag.TIMESTAMP) names.push('Timestamp');
+  if (mask & PositionFlag.HEADING) names.push('Heading');
+  if (mask & PositionFlag.SPEED) names.push('Speed');
+  return names.length > 0 ? names.join(', ') : 'None';
+}
+


### PR DESCRIPTION
## Summary
- **Hardware Model**: Now shows "Heltec V3" instead of `43`
- **Device Role**: Now shows "CLIENT" instead of `0`
- **Position Flags**: Now shows "Altitude, DOP, Timestamp" instead of `137`
- Added `decodePositionFlagNames()` utility to `positionFlags.ts`

## Test plan
- [x] TypeScript compiles cleanly
- [x] Existing position flags tests pass
- [ ] Verify device metadata displays readable names after clicking "Retrieve Device Metadata"

🤖 Generated with [Claude Code](https://claude.com/claude-code)