### PR TITLE
fix: map preferences not saving on PostgreSQL/MySQL backends

### DIFF
--- a/src/contexts/MapContext.tsx
+++ b/src/contexts/MapContext.tsx
@@ -83,7 +83,7 @@ interface MapProviderProps {
 }
 
 export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
-  const { getToken: getCsrfToken } = useCsrf();
+  const { getToken: getCsrfToken, refreshToken: refreshCsrfToken } = useCsrf();
 
   // Initialize with defaults (will be overridden by server preferences when loaded)
   const [showPaths, setShowPathsState] = useState<boolean>(false);
@@ -177,13 +177,10 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
   }, []);
 
   // Helper function to save preference to server
-  const savePreferenceToServer = React.useCallback(async (preference: Record<string, boolean | number | null>) => {
+  const savePreferenceToServer = React.useCallback(async (preference: Record<string, boolean | number | null>, isRetry = false) => {
     try {
       const baseUrl = await api.getBaseUrl();
       const csrfToken = getCsrfToken();
-      console.log('[MapContext] Saving preference to server:', preference);
-      console.log('[MapContext] CSRF token:', csrfToken ? 'present' : 'MISSING');
-      console.log('[MapContext] Base URL:', baseUrl);
 
       const headers: HeadersInit = { 'Content-Type': 'application/json' };
 
@@ -198,16 +195,24 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
         body: JSON.stringify(preference)
       });
 
-      console.log('[MapContext] Save response status:', response.status);
       if (!response.ok) {
+        // On CSRF failure, refresh token and retry once
+        if (response.status === 403 && !isRetry) {
+          const error = await response.json().catch(() => ({ error: '' }));
+          if (error.error && error.error.toLowerCase().includes('csrf')) {
+            console.warn('[MapContext] CSRF error - refreshing token and retrying...');
+            sessionStorage.removeItem('csrfToken');
+            await refreshCsrfToken();
+            return savePreferenceToServer(preference, true);
+          }
+        }
         const errorText = await response.text();
         console.error('[MapContext] Save failed:', errorText);
       }
     } catch (error) {
-      // Silently fail - localStorage will still work
       console.error('[MapContext] Failed to save map preference to server:', error);
     }
-  }, [getCsrfToken]);
+  }, [getCsrfToken, refreshCsrfToken]);
 
   // Create wrapper setter for positionHistoryHours that persists to server with debouncing
   const positionHistoryDebounceRef = useRef<NodeJS.Timeout | null>(null);

--- a/src/server/migrations/083_add_missing_map_preference_columns.ts
+++ b/src/server/migrations/083_add_missing_map_preference_columns.ts
@@ -1,0 +1,80 @@
+/**
+ * Migration 083: Add missing map preference columns to PostgreSQL/MySQL
+ *
+ * Migration 030 created user_map_preferences for SQLite with all columns,
+ * but Postgres/MySQL tables were created by Drizzle schema with only base columns.
+ * Migrations 031 (sorting), 063 (position_history_hours), 074 (meshcore_nodes),
+ * and 076 (accuracy/estimated) added some columns but the core feature columns
+ * (map_tileset, show_paths, show_neighbor_info, show_route, show_motion,
+ * show_mqtt_nodes, show_animations) were never added to Postgres/MySQL.
+ */
+
+import Database from 'better-sqlite3';
+import { PoolClient } from 'pg';
+import { Pool as MySQLPool } from 'mysql2/promise';
+import { logger } from '../../utils/logger.js';
+
+export function runMigration083Sqlite(_db: Database.Database): void {
+  // SQLite already has all columns from migration 030 — nothing to do
+  logger.debug('Migration 083: SQLite already has all map preference columns, skipping.');
+}
+
+export async function runMigration083Postgres(client: PoolClient): Promise<void> {
+  logger.info('Running migration 083: Add missing map preference columns (PostgreSQL)');
+
+  const columnsToAdd = [
+    { name: 'map_tileset', type: 'TEXT' },
+    { name: 'show_paths', type: 'BOOLEAN DEFAULT false' },
+    { name: 'show_neighbor_info', type: 'BOOLEAN DEFAULT false' },
+    { name: 'show_route', type: 'BOOLEAN DEFAULT true' },
+    { name: 'show_motion', type: 'BOOLEAN DEFAULT true' },
+    { name: 'show_mqtt_nodes', type: 'BOOLEAN DEFAULT true' },
+    { name: 'show_animations', type: 'BOOLEAN DEFAULT false' },
+    { name: 'created_at', type: 'BIGINT' },
+  ];
+
+  for (const col of columnsToAdd) {
+    const exists = await client.query(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name = 'user_map_preferences' AND column_name = $1`,
+      [col.name]
+    );
+
+    if (exists.rows.length === 0) {
+      await client.query(`ALTER TABLE user_map_preferences ADD COLUMN ${col.name} ${col.type}`);
+      logger.debug(`✅ Added ${col.name} column to user_map_preferences`);
+    }
+  }
+
+  logger.info('✅ Migration 083 completed: map preference columns added');
+}
+
+export async function runMigration083Mysql(pool: MySQLPool): Promise<void> {
+  logger.info('Running migration 083: Add missing map preference columns (MySQL)');
+
+  const columnsToAdd = [
+    { name: 'map_tileset', type: 'VARCHAR(255)' },
+    { name: 'show_paths', type: 'BOOLEAN DEFAULT false' },
+    { name: 'show_neighbor_info', type: 'BOOLEAN DEFAULT false' },
+    { name: 'show_route', type: 'BOOLEAN DEFAULT true' },
+    { name: 'show_motion', type: 'BOOLEAN DEFAULT true' },
+    { name: 'show_mqtt_nodes', type: 'BOOLEAN DEFAULT true' },
+    { name: 'show_animations', type: 'BOOLEAN DEFAULT false' },
+    { name: 'created_at', type: 'BIGINT' },
+  ];
+
+  for (const col of columnsToAdd) {
+    const [rows] = await pool.query(
+      `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+       WHERE TABLE_NAME = 'user_map_preferences' AND COLUMN_NAME = ?`,
+      [col.name]
+    );
+
+    if ((rows as any[]).length === 0) {
+      await pool.query(`ALTER TABLE user_map_preferences ADD COLUMN ${col.name} ${col.type}`);
+      logger.debug(`✅ Added ${col.name} column to user_map_preferences`);
+    }
+  }
+
+  logger.info('✅ Migration 083 completed: map preference columns added');
+}

--- a/src/server/routes/authRoutes.ts
+++ b/src/server/routes/authRoutes.ts
@@ -23,10 +23,19 @@ import { getEnvironmentConfig } from '../config/environment.js';
 const router = Router();
 
 function regenerateSession(req: Request): Promise<void> {
+  // Preserve CSRF token across session regeneration so the frontend's
+  // cached token remains valid after login (session regeneration creates
+  // a new session ID but should not invalidate the CSRF token)
+  const csrfToken = req.session.csrfToken;
   return new Promise((resolve, reject) => {
     req.session.regenerate((err) => {
       if (err) reject(err);
-      else resolve();
+      else {
+        if (csrfToken) {
+          req.session.csrfToken = csrfToken;
+        }
+        resolve();
+      }
     });
   });
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5065,19 +5065,14 @@ apiRouter.post('/settings/mark-all-welcomed', requirePermission('settings', 'wri
 // User Map Preferences endpoints
 
 // Get user's map preferences
-apiRouter.get('/user/map-preferences', optionalAuth(), (req, res) => {
+apiRouter.get('/user/map-preferences', optionalAuth(), async (req, res) => {
   try {
-    // For PostgreSQL/MySQL, map preferences not yet implemented
-    if (databaseService.drizzleDbType === 'postgres' || databaseService.drizzleDbType === 'mysql') {
-      return res.json({ preferences: null });
-    }
-
     // Anonymous users get null (will fall back to defaults in frontend)
     if (!req.user || req.user.username === 'anonymous') {
       return res.json({ preferences: null });
     }
 
-    const preferences = databaseService.userModel.getMapPreferences(req.user.id);
+    const preferences = await databaseService.getMapPreferencesAsync(req.user.id);
     res.json({ preferences });
   } catch (error) {
     logger.error('Error fetching user map preferences:', error);
@@ -5086,13 +5081,8 @@ apiRouter.get('/user/map-preferences', optionalAuth(), (req, res) => {
 });
 
 // Save user's map preferences
-apiRouter.post('/user/map-preferences', requireAuth(), (req, res) => {
+apiRouter.post('/user/map-preferences', requireAuth(), async (req, res) => {
   try {
-    // For PostgreSQL/MySQL, map preferences not yet implemented
-    if (databaseService.drizzleDbType === 'postgres' || databaseService.drizzleDbType === 'mysql') {
-      return res.json({ success: true, message: 'Map preferences not yet implemented for PostgreSQL' });
-    }
-
     // Prevent saving preferences for anonymous user
     if (req.user!.username === 'anonymous') {
       return res.status(403).json({ error: 'Cannot save preferences for anonymous user' });
@@ -5119,7 +5109,7 @@ apiRouter.post('/user/map-preferences', requireAuth(), (req, res) => {
     }
 
     // Save preferences
-    databaseService.userModel.saveMapPreferences(req.user!.id, {
+    await databaseService.saveMapPreferencesAsync(req.user!.id, {
       mapTileset,
       showPaths,
       showNeighborInfo,

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -88,6 +88,7 @@ import { migration as createGeofenceCooldownsMigration, runMigration079Postgres,
 import { migration as addFavoriteLockedMigration, runMigration080Postgres, runMigration080Mysql } from '../server/migrations/080_add_favorite_locked.js';
 import { migration as addTimeOffsetColumnsMigration, runMigration081Postgres, runMigration081Mysql } from '../server/migrations/081_add_time_offset_columns.js';
 import { migration as addPacketmonitorPermissionMigration, runMigration082Postgres, runMigration082Mysql } from '../server/migrations/082_add_packetmonitor_permission.js';
+import { runMigration083Sqlite, runMigration083Postgres, runMigration083Mysql } from '../server/migrations/083_add_missing_map_preference_columns.js';
 import { validateThemeDefinition as validateTheme } from '../utils/themeValidation.js';
 
 // Drizzle ORM imports for dual-database support
@@ -2605,6 +2606,19 @@ class DatabaseService {
       logger.debug('Add packetmonitor permission migration completed successfully');
     } catch (error) {
       logger.error('Error running migration 082:', error);
+    }
+
+    // Migration 083: Add missing map preference columns
+    const migrationKey083 = 'migration_083_map_preference_columns';
+    if (!this.getSetting(migrationKey083)) {
+      try {
+        logger.debug('Running migration 083: Add missing map preference columns...');
+        runMigration083Sqlite(this.db);
+        this.setSetting(migrationKey083, 'completed');
+        logger.debug('Migration 083 completed successfully');
+      } catch (error) {
+        logger.error('Error running migration 083:', error);
+      }
     }
   }
 
@@ -11659,6 +11673,9 @@ class DatabaseService {
       // Run migration 082: Add packetmonitor permission
       await runMigration082Postgres(client);
 
+      // Run migration 083: Add missing map preference columns
+      await runMigration083Postgres(client);
+
       // Verify all expected tables exist
       const result = await client.query(`
         SELECT table_name FROM information_schema.tables
@@ -11816,6 +11833,9 @@ class DatabaseService {
 
       // Run migration 082: Add packetmonitor permission
       await runMigration082Mysql(pool);
+
+      // Run migration 083: Add missing map preference columns
+      await runMigration083Mysql(pool);
 
       // Verify all expected tables exist
       const [rows] = await connection.query(`
@@ -12752,6 +12772,190 @@ class DatabaseService {
   async updateNodeTimeSyncAsync(nodeNum: number, timestamp: number): Promise<void> {
     if (this.nodesRepo) {
       await this.nodesRepo.updateNodeTimeSyncAsync(nodeNum, timestamp);
+    }
+  }
+
+  /**
+   * Get user's map preferences - works with all database backends
+   */
+  async getMapPreferencesAsync(userId: number): Promise<Record<string, any> | null> {
+    if (this.drizzleDbType === 'sqlite') {
+      return this.userModel.getMapPreferences(userId);
+    }
+
+    try {
+      const columns = `map_tileset, show_paths, show_neighbor_info, show_route, show_motion,
+        show_mqtt_nodes, show_meshcore_nodes, show_animations, show_accuracy_regions,
+        show_estimated_positions, position_history_hours`;
+
+      let row: any = null;
+
+      if (this.drizzleDbType === 'postgres' && this.postgresPool) {
+        const result = await this.postgresPool.query(
+          `SELECT ${columns} FROM user_map_preferences WHERE "userId" = $1`, [userId]
+        );
+        row = result.rows[0] || null;
+      } else if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
+        const [rows] = await this.mysqlPool.query(
+          `SELECT ${columns} FROM user_map_preferences WHERE userId = ?`, [userId]
+        );
+        row = (rows as any[])[0] || null;
+      }
+
+      if (!row) return null;
+
+      return {
+        mapTileset: row.map_tileset || null,
+        showPaths: Boolean(row.show_paths),
+        showNeighborInfo: Boolean(row.show_neighbor_info),
+        showRoute: Boolean(row.show_route),
+        showMotion: Boolean(row.show_motion),
+        showMqttNodes: Boolean(row.show_mqtt_nodes),
+        showMeshCoreNodes: Boolean(row.show_meshcore_nodes),
+        showAnimations: Boolean(row.show_animations),
+        showAccuracyRegions: Boolean(row.show_accuracy_regions),
+        showEstimatedPositions: Boolean(row.show_estimated_positions),
+        positionHistoryHours: row.position_history_hours ?? null,
+      };
+    } catch (error) {
+      logger.error(`[DatabaseService] Failed to get map preferences async: ${error}`);
+      return null;
+    }
+  }
+
+  /**
+   * Save user's map preferences - works with all database backends
+   */
+  async saveMapPreferencesAsync(userId: number, preferences: {
+    mapTileset?: string;
+    showPaths?: boolean;
+    showNeighborInfo?: boolean;
+    showRoute?: boolean;
+    showMotion?: boolean;
+    showMqttNodes?: boolean;
+    showMeshCoreNodes?: boolean;
+    showAnimations?: boolean;
+    showAccuracyRegions?: boolean;
+    showEstimatedPositions?: boolean;
+    positionHistoryHours?: number | null;
+  }): Promise<void> {
+    if (this.drizzleDbType === 'sqlite') {
+      this.userModel.saveMapPreferences(userId, preferences);
+      return;
+    }
+
+    const now = Date.now();
+
+    try {
+      // Check if row exists
+      let exists = false;
+      if (this.drizzleDbType === 'postgres' && this.postgresPool) {
+        const result = await this.postgresPool.query(
+          'SELECT "userId" FROM user_map_preferences WHERE "userId" = $1', [userId]
+        );
+        exists = (result.rows.length > 0);
+      } else if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
+        const [rows] = await this.mysqlPool.query(
+          'SELECT userId FROM user_map_preferences WHERE userId = ?', [userId]
+        );
+        exists = ((rows as any[]).length > 0);
+      }
+
+      if (exists) {
+        // Build dynamic UPDATE
+        const updates: string[] = [];
+        const params: any[] = [];
+        let paramIdx = 1; // For Postgres $N placeholders
+
+        const fieldMap: Record<string, string> = {
+          mapTileset: 'map_tileset',
+          showPaths: 'show_paths',
+          showNeighborInfo: 'show_neighbor_info',
+          showRoute: 'show_route',
+          showMotion: 'show_motion',
+          showMqttNodes: 'show_mqtt_nodes',
+          showMeshCoreNodes: 'show_meshcore_nodes',
+          showAnimations: 'show_animations',
+          showAccuracyRegions: 'show_accuracy_regions',
+          showEstimatedPositions: 'show_estimated_positions',
+          positionHistoryHours: 'position_history_hours',
+        };
+
+        for (const [key, col] of Object.entries(fieldMap)) {
+          const value = (preferences as any)[key];
+          if (value !== undefined) {
+            if (this.drizzleDbType === 'postgres') {
+              updates.push(`${col} = $${paramIdx++}`);
+            } else {
+              updates.push(`${col} = ?`);
+            }
+            // Convert booleans for storage
+            if (typeof value === 'boolean') {
+              params.push(value);
+            } else {
+              params.push(value);
+            }
+          }
+        }
+
+        if (updates.length > 0) {
+          if (this.drizzleDbType === 'postgres') {
+            updates.push(`"updatedAt" = $${paramIdx++}`);
+            params.push(now);
+            const sql = `UPDATE user_map_preferences SET ${updates.join(', ')} WHERE "userId" = $${paramIdx}`;
+            params.push(userId);
+            await this.postgresPool!.query(sql, params);
+          } else if (this.drizzleDbType === 'mysql') {
+            updates.push('updatedAt = ?');
+            params.push(now);
+            const sql = `UPDATE user_map_preferences SET ${updates.join(', ')} WHERE userId = ?`;
+            params.push(userId);
+            await this.mysqlPool!.query(sql, params);
+          }
+        }
+      } else {
+        // INSERT new row
+        const boolVal = (v: boolean | undefined, def: boolean) => v !== undefined ? v : def;
+
+        if (this.drizzleDbType === 'postgres' && this.postgresPool) {
+          await this.postgresPool.query(
+            `INSERT INTO user_map_preferences (
+              "userId", map_tileset, show_paths, show_neighbor_info, show_route, show_motion,
+              show_mqtt_nodes, show_meshcore_nodes, show_animations, show_accuracy_regions,
+              show_estimated_positions, position_history_hours, created_at, "updatedAt"
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+            [
+              userId, preferences.mapTileset || null,
+              boolVal(preferences.showPaths, false), boolVal(preferences.showNeighborInfo, false),
+              boolVal(preferences.showRoute, true), boolVal(preferences.showMotion, true),
+              boolVal(preferences.showMqttNodes, true), boolVal(preferences.showMeshCoreNodes, true),
+              boolVal(preferences.showAnimations, true), boolVal(preferences.showAccuracyRegions, false),
+              boolVal(preferences.showEstimatedPositions, true), preferences.positionHistoryHours ?? null,
+              now, now,
+            ]
+          );
+        } else if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
+          await this.mysqlPool.query(
+            `INSERT INTO user_map_preferences (
+              userId, map_tileset, show_paths, show_neighbor_info, show_route, show_motion,
+              show_mqtt_nodes, show_meshcore_nodes, show_animations, show_accuracy_regions,
+              show_estimated_positions, position_history_hours, created_at, updatedAt
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            [
+              userId, preferences.mapTileset || null,
+              boolVal(preferences.showPaths, false), boolVal(preferences.showNeighborInfo, false),
+              boolVal(preferences.showRoute, true), boolVal(preferences.showMotion, true),
+              boolVal(preferences.showMqttNodes, true), boolVal(preferences.showMeshCoreNodes, true),
+              boolVal(preferences.showAnimations, true), boolVal(preferences.showAccuracyRegions, false),
+              boolVal(preferences.showEstimatedPositions, true), preferences.positionHistoryHours ?? null,
+              now, now,
+            ]
+          );
+        }
+      }
+    } catch (error) {
+      logger.error(`[DatabaseService] Failed to save map preferences async: ${error}`);
+      throw error;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Map preference toggles (show paths, route, motion, MQTT nodes, etc.) were only functional on SQLite — PostgreSQL and MySQL endpoints returned "not yet implemented" stubs
- Added async `getMapPreferencesAsync`/`saveMapPreferencesAsync` methods to DatabaseService with proper SQL for each backend (handles camelCase vs snake_case column naming differences)
- Created migration 083 to add missing columns (`show_paths`, `show_route`, `show_motion`, `show_mqtt_nodes`, `show_neighbor_info`, `show_animations`, `map_tileset`, `created_at`) to PostgreSQL/MySQL tables
- Fixed CSRF token being lost during session regeneration on login, and added retry logic in MapContext for CSRF recovery

## Test plan
- [x] Unit tests pass (2953 passed)
- [x] System tests pass (all 10 suites)
- [x] Verified map preferences save/load via API on PostgreSQL
- [x] Verified map preferences save/load via API on MySQL
- [x] Verified CSRF token preserved across login session regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)