### PR TITLE
fix: draggable overlay gets stuck off-screen on window resize

### DIFF
--- a/src/components/DraggableOverlay.tsx
+++ b/src/components/DraggableOverlay.tsx
@@ -26,11 +26,22 @@ export const DraggableOverlay: React.FC<DraggableOverlayProps> = ({
   const dragHandleRef = useRef<HTMLDivElement>(null);
   const [elementSize, setElementSize] = useState({ width: 200, height: 100 });
 
-  // Measure element size after mount
+  // Measure element size and keep it updated via ResizeObserver
   useEffect(() => {
-    if (containerRef.current) {
-      const rect = containerRef.current.getBoundingClientRect();
+    const el = containerRef.current;
+    if (!el) return;
+
+    const updateSize = () => {
+      const rect = el.getBoundingClientRect();
       setElementSize({ width: rect.width, height: rect.height });
+    };
+
+    updateSize();
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(updateSize);
+      observer.observe(el);
+      return () => observer.disconnect();
     }
   }, []);
 

--- a/src/hooks/useDraggable.ts
+++ b/src/hooks/useDraggable.ts
@@ -171,17 +171,25 @@ export function useDraggable(options: UseDraggableOptions): UseDraggableReturn {
     savePosition(id, defaultPosition);
   }, [id, defaultPosition]);
 
-  // Ensure position is valid on window resize (not on initial mount - let default position be used)
+  // Ensure position is valid on window resize or when element size changes
   useEffect(() => {
     const handleResize = () => {
-      setPosition(pos => constrainPosition(pos));
+      setPosition(pos => {
+        const constrained = constrainPosition(pos);
+        if (constrained.x !== pos.x || constrained.y !== pos.y) {
+          savePosition(id, constrained);
+        }
+        return constrained;
+      });
     };
 
+    // Re-constrain when element size changes (constrainPosition dependency updates)
+    handleResize();
+
     window.addEventListener('resize', handleResize);
-    // Don't run on mount - the default position is already appropriate
 
     return () => window.removeEventListener('resize', handleResize);
-  }, [constrainPosition]);
+  }, [constrainPosition, id]);
 
   return {
     position,


### PR DESCRIPTION
## Summary
- Map legend (and any DraggableOverlay) would get stuck off-screen when the browser window was resized smaller, unlike the Map Features panel which correctly constrains
- Added `ResizeObserver` in `DraggableOverlay` to continuously track element dimensions instead of measuring once on mount
- Updated `useDraggable` to re-constrain position whenever element size changes, not just on window resize events

## Test plan
- [x] Unit tests pass (16/16 MapLegend tests)
- [x] Verified legend snaps back into view when window is resized
- [x] Graceful fallback when `ResizeObserver` is unavailable (test environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)