### PR TITLE
feat: configurable zoom level for neighbor info lines (#2245)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1370,6 +1370,8 @@
   "settings.position_history_line_style_description": "How position history paths are drawn on the map",
   "settings.position_history_line_style_linear": "Linear (straight lines)",
   "settings.position_history_line_style_spline": "Spline (curved based on heading)",
+  "settings.neighbor_info_min_zoom_label": "Neighbor Info Minimum Zoom Level",
+  "settings.neighbor_info_min_zoom_description": "Neighbor info lines are hidden on the map when zoomed out below this level (1-18). Lower values show lines at wider zoom levels.",
   "settings.telemetry_hours_label": "Telemetry Visualization (Hours)",
   "settings.telemetry_hours_description": "How many hours of telemetry data to display in graphs (1-168)",
   "settings.fav_telemetry_label": "Favorite Telemetry Storage Length (Days)",

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -293,6 +293,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     nodeDimmingMinOpacity,
     maxNodeAgeHours,
     nodeHopsCalculation,
+    neighborInfoMinZoom,
     overlayColors,
   } = useSettings();
 
@@ -2048,7 +2049,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 ];
 
                 // Zoom-adaptive: hide neighbor lines at low zoom
-                if (mapZoom < 12) return null;
+                if (mapZoom < neighborInfoMinZoom) return null;
 
                 return (
                   <Polyline

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -149,7 +149,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     nodeHopsCalculation,
     setNodeHopsCalculation,
     preferredDashboardSortOption,
-    setPreferredDashboardSortOption
+    setPreferredDashboardSortOption,
+    neighborInfoMinZoom,
+    setNeighborInfoMinZoom
   } = useSettings();
   const { showIncompleteNodes, setShowIncompleteNodes } = useUI();
 
@@ -169,6 +171,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   const [localDateFormat, setLocalDateFormat] = useState(dateFormat);
   const [localMapTileset, setLocalMapTileset] = useState(mapTileset);
   const [localMapPinStyle, setLocalMapPinStyle] = useState(mapPinStyle);
+  const [localNeighborInfoMinZoom, setLocalNeighborInfoMinZoom] = useState(neighborInfoMinZoom);
   const [localTheme, setLocalTheme] = useState(theme);
   const [localNodeHopsCalculation, setLocalNodeHopsCalculation] = useState(nodeHopsCalculation);
   const [localDashboardSortOption, setLocalDashboardSortOption] = useState<DashboardSortOption>(preferredDashboardSortOption);
@@ -315,6 +318,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalDateFormat(dateFormat);
     setLocalMapTileset(mapTileset);
     setLocalMapPinStyle(mapPinStyle);
+    setLocalNeighborInfoMinZoom(neighborInfoMinZoom);
     setLocalTheme(theme);
     setLocalNodeHopsCalculation(nodeHopsCalculation);
     setLocalDashboardSortOption(preferredDashboardSortOption);
@@ -366,6 +370,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localDateFormat !== dateFormat ||
       localMapTileset !== mapTileset ||
       localMapPinStyle !== mapPinStyle ||
+      localNeighborInfoMinZoom !== neighborInfoMinZoom ||
       localTheme !== theme ||
       localNodeHopsCalculation !== nodeHopsCalculation ||
       localDashboardSortOption !== preferredDashboardSortOption ||
@@ -386,8 +391,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localAnalyticsProvider !== initialAnalyticsProvider ||
       JSON.stringify(localAnalyticsConfig) !== initialAnalyticsConfig;
     setHasChanges(changed);
-  }, [localMaxNodeAge, localInactiveNodeThresholdHours, localInactiveNodeCheckIntervalMinutes, localInactiveNodeCooldownHours, localTemperatureUnit, localDistanceUnit, localPositionHistoryLineStyle, localTelemetryHours, localFavoriteTelemetryStorageDays, localPreferredSortField, localPreferredSortDirection, localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localTheme, localNodeHopsCalculation, localDashboardSortOption,
-      maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTileset, mapPinStyle, theme, nodeHopsCalculation, preferredDashboardSortOption,
+  }, [localMaxNodeAge, localInactiveNodeThresholdHours, localInactiveNodeCheckIntervalMinutes, localInactiveNodeCooldownHours, localTemperatureUnit, localDistanceUnit, localPositionHistoryLineStyle, localTelemetryHours, localFavoriteTelemetryStorageDays, localPreferredSortField, localPreferredSortDirection, localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localNeighborInfoMinZoom, localTheme, localNodeHopsCalculation, localDashboardSortOption,
+      maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTileset, mapPinStyle, neighborInfoMinZoom, theme, nodeHopsCalculation, preferredDashboardSortOption,
       localPacketLogEnabled, localPacketLogMaxCount, localPacketLogMaxAgeHours, initialPacketMonitorSettings,
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude, localSolarMonitoringAzimuth, localSolarMonitoringDeclination,
       solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination,
@@ -435,7 +440,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   }, [maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes,
       inactiveNodeCooldownHours, temperatureUnit, distanceUnit, telemetryVisualizationHours,
       favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat,
-      dateFormat, mapTileset, mapPinStyle, theme, nodeHopsCalculation, preferredDashboardSortOption,
+      dateFormat, mapTileset, mapPinStyle, neighborInfoMinZoom, theme, nodeHopsCalculation, preferredDashboardSortOption,
       initialPacketMonitorSettings, solarMonitoringEnabled, solarMonitoringLatitude,
       solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes,
       initialHomoglyphEnabled, initialLocalStatsIntervalMinutes, initialNodeDimmingSettings,
@@ -461,6 +466,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         dateFormat: localDateFormat,
         mapTileset: localMapTileset,
         mapPinStyle: localMapPinStyle,
+        neighborInfoMinZoom: localNeighborInfoMinZoom.toString(),
         theme: localTheme,
         packet_log_enabled: localPacketLogEnabled ? '1' : '0',
         packet_log_max_count: localPacketLogMaxCount.toString(),
@@ -504,6 +510,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       onDateFormatChange(localDateFormat);
       onMapTilesetChange(localMapTileset);
       onMapPinStyleChange(localMapPinStyle);
+      setNeighborInfoMinZoom(localNeighborInfoMinZoom);
       onThemeChange(localTheme);
       setNodeHopsCalculation(localNodeHopsCalculation);
       setPreferredDashboardSortOption(localDashboardSortOption);
@@ -538,7 +545,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localInactiveNodeCheckIntervalMinutes, localInactiveNodeCooldownHours,
       localTemperatureUnit, localDistanceUnit, localPositionHistoryLineStyle, localTelemetryHours,
       localFavoriteTelemetryStorageDays, localPreferredSortField, localPreferredSortDirection,
-      localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localTheme,
+      localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localNeighborInfoMinZoom, localTheme,
       localNodeHopsCalculation, localDashboardSortOption, localPacketLogEnabled, localPacketLogMaxCount, localPacketLogMaxAgeHours,
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude,
       localSolarMonitoringAzimuth, localSolarMonitoringDeclination, localHideIncompleteNodes, localHomoglyphEnabled, localLocalStatsIntervalMinutes,
@@ -546,7 +553,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       onInactiveNodeCooldownHoursChange, onTemperatureUnitChange, onDistanceUnitChange, onPositionHistoryLineStyleChange,
       onTelemetryVisualizationChange, onFavoriteTelemetryStorageDaysChange, onPreferredSortFieldChange,
       onPreferredSortDirectionChange, onTimeFormatChange, onDateFormatChange, onMapTilesetChange,
-      onMapPinStyleChange, onThemeChange, setNodeHopsCalculation, setPreferredDashboardSortOption, onSolarMonitoringEnabledChange,
+      onMapPinStyleChange, setNeighborInfoMinZoom, onThemeChange, setNodeHopsCalculation, setPreferredDashboardSortOption, onSolarMonitoringEnabledChange,
       onSolarMonitoringLatitudeChange, onSolarMonitoringLongitudeChange, onSolarMonitoringAzimuthChange,
       onSolarMonitoringDeclinationChange, setShowIncompleteNodes, showToast, t,
       nodeDimmingEnabled, nodeDimmingStartHours, nodeDimmingMinOpacity,
@@ -1113,6 +1120,27 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               <option value="linear">{t('settings.position_history_line_style_linear')}</option>
               <option value="spline">{t('settings.position_history_line_style_spline')}</option>
             </select>
+          </div>
+          <div className="setting-item">
+            <label htmlFor="neighborInfoMinZoom">
+              {t('settings.neighbor_info_min_zoom_label')}
+              <span className="setting-description">{t('settings.neighbor_info_min_zoom_description')}</span>
+            </label>
+            <input
+              id="neighborInfoMinZoom"
+              type="number"
+              min="1"
+              max="18"
+              value={localNeighborInfoMinZoom}
+              onChange={(e) => {
+                const value = parseInt(e.target.value);
+                if (value >= 1 && value <= 18) {
+                  setLocalNeighborInfoMinZoom(value);
+                }
+              }}
+              className="setting-input"
+              style={{ width: '100px' }}
+            />
           </div>
           {isAdmin && (
             <div id="settings-embed">

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -61,6 +61,7 @@ interface SettingsContextType {
   overlayScheme: OverlayScheme;
   overlayColors: OverlayColors;
   mapPinStyle: MapPinStyle;
+  neighborInfoMinZoom: number;
   theme: Theme;
   language: string;
   customThemes: CustomTheme[];
@@ -97,6 +98,7 @@ interface SettingsContextType {
   setDateFormat: (format: DateFormat) => void;
   setMapTileset: (tilesetId: TilesetId) => void;
   setMapPinStyle: (style: MapPinStyle) => void;
+  setNeighborInfoMinZoom: (zoom: number) => void;
   setTheme: (theme: Theme) => void;
   setLanguage: (language: string) => void;
   loadCustomThemes: () => Promise<void>;
@@ -219,6 +221,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
   const [mapPinStyle, setMapPinStyleState] = useState<MapPinStyle>(() => {
     const saved = localStorage.getItem('mapPinStyle');
     return (saved === 'official' ? 'official' : 'meshmonitor') as MapPinStyle;
+  });
+
+  const [neighborInfoMinZoom, setNeighborInfoMinZoomState] = useState<number>(() => {
+    const saved = localStorage.getItem('neighborInfoMinZoom');
+    return saved ? parseInt(saved, 10) : 12;
   });
 
   const [theme, setThemeState] = useState<Theme>(() => {
@@ -425,6 +432,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
   const setMapPinStyle = (style: MapPinStyle) => {
     setMapPinStyleState(style);
     localStorage.setItem('mapPinStyle', style);
+  };
+
+  const setNeighborInfoMinZoom = (zoom: number) => {
+    setNeighborInfoMinZoomState(zoom);
+    localStorage.setItem('neighborInfoMinZoom', String(zoom));
   };
 
   /**
@@ -862,6 +874,14 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
             localStorage.setItem('mapPinStyle', settings.mapPinStyle);
           }
 
+          if (settings.neighborInfoMinZoom !== undefined) {
+            const zoom = parseInt(settings.neighborInfoMinZoom, 10);
+            if (!isNaN(zoom)) {
+              setNeighborInfoMinZoomState(zoom);
+              localStorage.setItem('neighborInfoMinZoom', String(zoom));
+            }
+          }
+
           if (settings.theme) {
             // Accept any theme (built-in or custom)
             setThemeState(settings.theme as Theme);
@@ -1052,6 +1072,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     overlayScheme,
     overlayColors,
     mapPinStyle,
+    neighborInfoMinZoom,
     theme,
     language,
     customThemes,
@@ -1088,6 +1109,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     setDateFormat,
     setMapTileset,
     setMapPinStyle,
+    setNeighborInfoMinZoom,
     setTheme,
     setLanguage,
     loadCustomThemes,
@@ -1142,6 +1164,7 @@ export const useMapSettings = () => {
   return {
     mapTileset: s.mapTileset, setMapTileset: s.setMapTileset,
     mapPinStyle: s.mapPinStyle, setMapPinStyle: s.setMapPinStyle,
+    neighborInfoMinZoom: s.neighborInfoMinZoom, setNeighborInfoMinZoom: s.setNeighborInfoMinZoom,
     overlayScheme: s.overlayScheme, overlayColors: s.overlayColors,
     customTilesets: s.customTilesets,
     addCustomTileset: s.addCustomTileset, updateCustomTileset: s.updateCustomTileset, deleteCustomTileset: s.deleteCustomTileset,

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -113,6 +113,7 @@ export const VALID_SETTINGS_KEYS = [
   'nodeDimmingMinOpacity',
   'analyticsProvider',
   'analyticsConfig',
+  'neighborInfoMinZoom',
 ] as const;
 
 export type ValidSettingKey = typeof VALID_SETTINGS_KEYS[number];


### PR DESCRIPTION
## Summary

- Adds a "Neighbor Info Minimum Zoom Level" setting to the Map section of the Settings page
- Replaces the hardcoded zoom level 12 threshold with a user-configurable value (1-18)
- Default remains 12 (previous behavior), but users can lower it to see neighbor info lines at wider zoom levels

## Changes

- **`src/server/constants/settings.ts`**: Added `neighborInfoMinZoom` to valid settings allowlist
- **`src/contexts/SettingsContext.tsx`**: Added state, setter, server load/save, exposed via `useMapSettings`
- **`src/components/SettingsTab.tsx`**: Added number input in the Map section with save/reset support
- **`src/components/NodesTab.tsx`**: Uses setting instead of hardcoded `12`
- **`public/locales/en.json`**: Added translation keys

## Test plan

- [x] Setting appears in Map section of Settings page
- [x] Value saves and persists across page reloads
- [x] Neighbor info lines respect the configured zoom level on the map
- [x] Default value of 12 preserves existing behavior

Closes #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)