### PR TITLE
fix: migration 084 fails when auto_key_repair_log table doesn't exist

### DIFF
--- a/src/server/migrations/084_add_key_mismatch_columns.ts
+++ b/src/server/migrations/084_add_key_mismatch_columns.ts
@@ -10,18 +10,24 @@ export function runMigration084Sqlite(db: Database): void {
     db.exec("ALTER TABLE nodes ADD COLUMN lastMeshReceivedKey TEXT");
   }
 
-  const hasOldKeyFragment = db.prepare(
-    "SELECT COUNT(*) as count FROM pragma_table_info('auto_key_repair_log') WHERE name='oldKeyFragment'"
+  // auto_key_repair_log may not exist if user never enabled auto-key management (created in migration 046)
+  const hasRepairLogTable = db.prepare(
+    "SELECT COUNT(*) as count FROM sqlite_master WHERE type='table' AND name='auto_key_repair_log'"
   ).get() as { count: number };
-  if (hasOldKeyFragment.count === 0) {
-    db.exec("ALTER TABLE auto_key_repair_log ADD COLUMN oldKeyFragment TEXT");
-  }
+  if (hasRepairLogTable.count > 0) {
+    const hasOldKeyFragment = db.prepare(
+      "SELECT COUNT(*) as count FROM pragma_table_info('auto_key_repair_log') WHERE name='oldKeyFragment'"
+    ).get() as { count: number };
+    if (hasOldKeyFragment.count === 0) {
+      db.exec("ALTER TABLE auto_key_repair_log ADD COLUMN oldKeyFragment TEXT");
+    }
 
-  const hasNewKeyFragment = db.prepare(
-    "SELECT COUNT(*) as count FROM pragma_table_info('auto_key_repair_log') WHERE name='newKeyFragment'"
-  ).get() as { count: number };
-  if (hasNewKeyFragment.count === 0) {
-    db.exec("ALTER TABLE auto_key_repair_log ADD COLUMN newKeyFragment TEXT");
+    const hasNewKeyFragment = db.prepare(
+      "SELECT COUNT(*) as count FROM pragma_table_info('auto_key_repair_log') WHERE name='newKeyFragment'"
+    ).get() as { count: number };
+    if (hasNewKeyFragment.count === 0) {
+      db.exec("ALTER TABLE auto_key_repair_log ADD COLUMN newKeyFragment TEXT");
+    }
   }
 }
 
@@ -33,18 +39,24 @@ export async function runMigration084Postgres(client: PoolClient): Promise<void>
     await client.query('ALTER TABLE nodes ADD COLUMN "lastMeshReceivedKey" TEXT');
   }
 
-  const oldKeyCheck = await client.query(
-    "SELECT column_name FROM information_schema.columns WHERE table_name = 'auto_key_repair_log' AND column_name = 'oldKeyFragment'"
+  // auto_key_repair_log may not exist if user never enabled auto-key management (created in migration 046)
+  const hasRepairLogTable = await client.query(
+    "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'auto_key_repair_log'"
   );
-  if (oldKeyCheck.rows.length === 0) {
-    await client.query('ALTER TABLE auto_key_repair_log ADD COLUMN "oldKeyFragment" VARCHAR(8)');
-  }
+  if (hasRepairLogTable.rows.length > 0) {
+    const oldKeyCheck = await client.query(
+      "SELECT column_name FROM information_schema.columns WHERE table_name = 'auto_key_repair_log' AND column_name = 'oldKeyFragment'"
+    );
+    if (oldKeyCheck.rows.length === 0) {
+      await client.query('ALTER TABLE auto_key_repair_log ADD COLUMN "oldKeyFragment" VARCHAR(8)');
+    }
 
-  const newKeyCheck = await client.query(
-    "SELECT column_name FROM information_schema.columns WHERE table_name = 'auto_key_repair_log' AND column_name = 'newKeyFragment'"
-  );
-  if (newKeyCheck.rows.length === 0) {
-    await client.query('ALTER TABLE auto_key_repair_log ADD COLUMN "newKeyFragment" VARCHAR(8)');
+    const newKeyCheck = await client.query(
+      "SELECT column_name FROM information_schema.columns WHERE table_name = 'auto_key_repair_log' AND column_name = 'newKeyFragment'"
+    );
+    if (newKeyCheck.rows.length === 0) {
+      await client.query('ALTER TABLE auto_key_repair_log ADD COLUMN "newKeyFragment" VARCHAR(8)');
+    }
   }
 }
 
@@ -56,17 +68,24 @@ export async function runMigration084Mysql(pool: Pool): Promise<void> {
     await pool.query('ALTER TABLE nodes ADD COLUMN lastMeshReceivedKey VARCHAR(128)');
   }
 
-  const [oldKeyRows] = await pool.query(
-    "SELECT COLUMN_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'auto_key_repair_log' AND column_name = 'oldKeyFragment'"
+  // auto_key_repair_log may not exist if user never enabled auto-key management (created in migration 046)
+  const [repairLogTable] = await pool.query(
+    "SELECT TABLE_NAME FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'auto_key_repair_log'"
   );
-  if ((oldKeyRows as any[]).length === 0) {
-    await pool.query('ALTER TABLE auto_key_repair_log ADD COLUMN oldKeyFragment VARCHAR(8)');
-  }
+  if ((repairLogTable as any[]).length > 0) {
+    const [oldKeyRows] = await pool.query(
+      "SELECT COLUMN_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'auto_key_repair_log' AND column_name = 'oldKeyFragment'"
+    );
+    if ((oldKeyRows as any[]).length === 0) {
+      await pool.query('ALTER TABLE auto_key_repair_log ADD COLUMN oldKeyFragment VARCHAR(8)');
+    }
 
-  const [newKeyRows] = await pool.query(
-    "SELECT COLUMN_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'auto_key_repair_log' AND column_name = 'newKeyFragment'"
-  );
-  if ((newKeyRows as any[]).length === 0) {
-    await pool.query('ALTER TABLE auto_key_repair_log ADD COLUMN newKeyFragment VARCHAR(8)');
+    const [newKeyRows] = await pool.query(
+      "SELECT COLUMN_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'auto_key_repair_log'"
+      + " AND column_name = 'newKeyFragment'"
+    );
+    if ((newKeyRows as any[]).length === 0) {
+      await pool.query('ALTER TABLE auto_key_repair_log ADD COLUMN newKeyFragment VARCHAR(8)');
+    }
   }
 }

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -7649,9 +7649,24 @@ class DatabaseService {
     if (this.drizzleDbType === 'postgres') {
       const client = await (this as any).pgPool.connect();
       try {
+        // Check if table exists (may not exist if auto-key management was never enabled)
+        const tableCheck = await client.query(
+          "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'auto_key_repair_log'"
+        );
+        if (tableCheck.rows.length === 0) {
+          return [];
+        }
+
+        // Check if migration 084 columns exist
+        const colCheck = await client.query(
+          "SELECT column_name FROM information_schema.columns WHERE table_name = 'auto_key_repair_log' AND column_name = 'oldKeyFragment'"
+        );
+        const selectCols = colCheck.rows.length > 0
+          ? 'id, timestamp, "nodeNum", "nodeName", action, success, "oldKeyFragment", "newKeyFragment"'
+          : 'id, timestamp, "nodeNum", "nodeName", action, success';
+
         const result = await client.query(
-          `SELECT id, timestamp, "nodeNum", "nodeName", action, success, "oldKeyFragment", "newKeyFragment"
-           FROM auto_key_repair_log ORDER BY timestamp DESC LIMIT $1`,
+          `SELECT ${selectCols} FROM auto_key_repair_log ORDER BY timestamp DESC LIMIT $1`,
           [limit]
         );
         return result.rows.map((row: any) => ({
@@ -7669,9 +7684,25 @@ class DatabaseService {
       }
     } else if (this.drizzleDbType === 'mysql') {
       const pool = (this as any).mysqlPool;
+
+      // Check if table exists (may not exist if auto-key management was never enabled)
+      const [tableRows] = await pool.query(
+        "SELECT TABLE_NAME FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'auto_key_repair_log'"
+      );
+      if ((tableRows as any[]).length === 0) {
+        return [];
+      }
+
+      // Check if migration 084 columns exist
+      const [colRows] = await pool.query(
+        "SELECT COLUMN_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'auto_key_repair_log' AND column_name = 'oldKeyFragment'"
+      );
+      const selectCols = (colRows as any[]).length > 0
+        ? 'id, timestamp, nodeNum, nodeName, action, success, oldKeyFragment, newKeyFragment'
+        : 'id, timestamp, nodeNum, nodeName, action, success';
+
       const [rows] = await pool.query(
-        `SELECT id, timestamp, nodeNum, nodeName, action, success, oldKeyFragment, newKeyFragment
-         FROM auto_key_repair_log ORDER BY timestamp DESC LIMIT ?`,
+        `SELECT ${selectCols} FROM auto_key_repair_log ORDER BY timestamp DESC LIMIT ?`,
         [limit]
       );
       return (rows as any[]).map((row: any) => ({
@@ -7685,9 +7716,24 @@ class DatabaseService {
         newKeyFragment: row.newKeyFragment || null,
       }));
     }
-    // SQLite — query directly with new columns (available after migration 084)
+    // SQLite — check if table exists first (may not exist if auto-key management was never enabled)
+    const hasTable = this.db.prepare(
+      "SELECT COUNT(*) as count FROM sqlite_master WHERE type='table' AND name='auto_key_repair_log'"
+    ).get() as { count: number };
+    if (hasTable.count === 0) {
+      return [];
+    }
+
+    // Check if migration 084 columns exist
+    const hasOldKeyCol = this.db.prepare(
+      "SELECT COUNT(*) as count FROM pragma_table_info('auto_key_repair_log') WHERE name='oldKeyFragment'"
+    ).get() as { count: number };
+    const selectCols = hasOldKeyCol.count > 0
+      ? 'id, timestamp, nodeNum, nodeName, action, success, oldKeyFragment, newKeyFragment'
+      : 'id, timestamp, nodeNum, nodeName, action, success';
+
     const rows = this.db.prepare(`
-      SELECT id, timestamp, nodeNum, nodeName, action, success, oldKeyFragment, newKeyFragment
+      SELECT ${selectCols}
       FROM auto_key_repair_log ORDER BY timestamp DESC LIMIT ?
     `).all(limit) as any[];
     return rows.map((row: any) => ({


### PR DESCRIPTION
## Summary
- Migration 084 assumed `auto_key_repair_log` table always exists, but it's only created when auto-key management is first enabled (migration 046)
- When the table doesn't exist, the ALTER TABLE fails silently, preventing `lastMeshReceivedKey` from being added to the `nodes` table
- This causes Security page errors (`no such column: lastMeshReceivedKey`) on fresh upgrades to 3.9.0
- Fixed all three database backends (SQLite, PostgreSQL, MySQL) to check table existence before altering
- Also made `getKeyRepairLogAsync` gracefully handle missing table/columns on all backends

Closes #2247

## Test plan
- [x] All 10 system tests pass
- [x] Security page `/api/security/issues` returns valid data
- [x] Security page `/api/security/key-mismatches` returns valid data
- [x] TypeScript compiles cleanly

## System Test Results

| Test Suite | Result |
|------------|--------|
| Configuration Import | ✅ PASSED |
| Quick Start Test | ✅ PASSED |
| Security Test | ✅ PASSED |
| V1 API Test | ✅ PASSED |
| Reverse Proxy Test | ✅ PASSED |
| Reverse Proxy + OIDC | ✅ PASSED |
| Virtual Node CLI Test | ✅ PASSED |
| Backup & Restore Test | ✅ PASSED |
| Database Migration Test | ✅ PASSED |
| DB Backing Consistency | ✅ PASSED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)