### PR TITLE
fix: OSM tiles blocked by missing Referer header

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -169,6 +169,9 @@ const helmetConfig =
         },
         noSniff: true,
         xssFilter: true,
+        // Send origin as Referer for cross-origin requests (e.g. map tile fetches).
+        // Helmet defaults to no-referrer which violates OSM tile usage policy.
+        referrerPolicy: { policy: 'strict-origin-when-cross-origin' as const },
       }
     : {
         // Development or HTTP-only: no HSTS
@@ -180,6 +183,7 @@ const helmetConfig =
         },
         noSniff: true,
         xssFilter: true,
+        referrerPolicy: { policy: 'strict-origin-when-cross-origin' as const },
       };
 
 app.use(helmet(helmetConfig));


### PR DESCRIPTION
## Summary
- Helmet defaults `Referrer-Policy` to `no-referrer`, stripping the Referer header from all requests
- OSM tile servers require a Referer header per their usage policy, returning "Referer is required by tile usage policy" without one
- Changed to `strict-origin-when-cross-origin` (browser default without Helmet) so the origin is sent as Referer for cross-origin tile requests

Closes #2260

## Test plan
- [ ] Verify OSM tiles load without "Referer is required" errors
- [ ] Verify other tile providers (Carto, OpenTopo, ESRI) still work
- [ ] Verify response headers include `Referrer-Policy: strict-origin-when-cross-origin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)