### PR TITLE
fix: auto-responder Cyrillic params mangled by homoglyph normalization

### DIFF
--- a/src/server/meshtasticManager.autoresponder-regex.test.ts
+++ b/src/server/meshtasticManager.autoresponder-regex.test.ts
@@ -143,9 +143,15 @@ describe('Auto Responder - Regex Parameter Matching', () => {
     const match = normalizedMessage.match(regex);
 
     if (match) {
+      // Try to extract params from original text to preserve full Unicode characters.
+      // Homoglyph normalization can mangle Cyrillic words (e.g., "Барнаул" → "Бapнayл")
+      // which breaks geocoding APIs. The regex usually matches original text too since
+      // param patterns like [^\s]+ accept any non-whitespace character.
+      const originalMatch = message.match(regex);
+
       const extractedParams: Record<string, string> = {};
       params.forEach((param, index) => {
-        extractedParams[param.name] = match[index + 1];
+        extractedParams[param.name] = originalMatch?.[index + 1] ?? match[index + 1];
       });
       return { matches: true, params: extractedParams };
     }
@@ -592,6 +598,17 @@ describe('Auto Responder - Regex Parameter Matching', () => {
       const result = testTriggerMatch(trigger, message);
       expect(result.matches).toBe(true);
       expect(result.params).toEqual({ city: 'Moscow' });
+    });
+
+    it('should preserve Cyrillic parameter values from original text (Issue #2258)', () => {
+      // Latin trigger "w {location}" with Cyrillic location parameter
+      // The parameter should be extracted as pure Cyrillic, not mixed encoding
+      const trigger = 'w {location}';
+      const message = 'w \u0411\u0430\u0440\u043D\u0430\u0443\u043B'; // w Барнаул
+      const result = testTriggerMatch(trigger, message);
+      expect(result.matches).toBe(true);
+      // Should be pure Cyrillic "Барнаул", NOT mixed "Бapнayл"
+      expect(result.params).toEqual({ location: '\u0411\u0430\u0440\u043D\u0430\u0443\u043B' });
     });
 
     it('should not match completely different Cyrillic words', () => {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7588,10 +7588,16 @@ class MeshtasticManager {
           const triggerMatch = normalizedText.match(triggerRegex);
 
           if (triggerMatch) {
-            // Extract parameters
+            // Extract parameters from original text when possible to preserve full
+            // Unicode characters. Homoglyph normalization can mangle Cyrillic words
+            // (e.g., "Барнаул" → "Бapнayл") which breaks geocoding APIs.
+            // The regex usually matches original text too since param patterns like
+            // [^\s]+ accept any non-whitespace character.
+            const originalMatch = message.text.match(triggerRegex);
+
             extractedParams = {};
             params.forEach((param, index) => {
-              extractedParams[param.name] = triggerMatch[index + 1];
+              extractedParams[param.name] = originalMatch?.[index + 1] ?? triggerMatch[index + 1];
             });
             matchedPattern = origPatternStr;
             break; // Found a match, stop trying other patterns


### PR DESCRIPTION
## Summary
- Homoglyph normalization replaces some Cyrillic chars with visually identical Latin ones (а→a, р→p, у→y), creating mixed-encoding strings like "Бapнayл" instead of "Барнаул"
- Parameter extraction was using the normalized text, so scripts/APIs received mangled values that geocoding services couldn't parse
- Now extracts parameters from original message text when possible, preserving full Unicode for downstream use
- Added test case verifying Cyrillic parameter preservation

Closes #2258

## Test plan
- [x] All 60 auto-responder regex tests pass including new Cyrillic test
- [x] TypeScript compiles cleanly
- [ ] Verify `w Барнаул` (Cyrillic) returns weather data instead of geocoding error
- [ ] Verify `w Barnaul` (Latin) still works
- [ ] Verify Cyrillic triggers with Cyrillic params still match correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)