### PR TITLE
fix: auto-key repair on PostgreSQL/MySQL + device DB awareness

### DIFF
--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -29,6 +29,7 @@ import { isNodeComplete, isInfrastructureNode, hasValidPosition, parseNodeId } f
 import { getEffectiveHops } from '../utils/nodeHops';
 import { useMapContext } from '../contexts/MapContext';
 import { useSettings } from '../contexts/SettingsContext';
+import { useDeviceNodes } from '../hooks/useServerData';
 import HopCountDisplay from './HopCountDisplay';
 import LinkPreview from './LinkPreview';
 import NodeDetailsBlock from './NodeDetailsBlock';
@@ -275,6 +276,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   // Get settings and context for effective hops calculation
   const { nodeHopsCalculation } = useSettings();
   const { traceroutes, neighborInfo, setNeighborInfo } = useMapContext();
+  const deviceNodeNums = useDeviceNodes();
   const currentNodeNum = currentNodeId ? parseNodeId(currentNodeId) : null;
 
   // Local state for actions menu
@@ -1192,6 +1194,22 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                 }}
               >
                 {selectedNode.keyMismatchDetected ? '🔓' : '⚠️'} {selectedNode.keyMismatchDetected ? t('messages.key_mismatch') : t('messages.security_risk')}
+              </div>
+            )}
+
+            {/* Not in device DB warning - node exists in MeshMonitor but not on the radio */}
+            {selectedNodeNum !== undefined && deviceNodeNums.size > 0 && !deviceNodeNums.has(selectedNodeNum) && (
+              <div
+                style={{
+                  backgroundColor: 'var(--ctp-peach, #fab387)',
+                  color: 'var(--ctp-base, #1e1e2e)',
+                  padding: '10px 12px',
+                  marginBottom: '10px',
+                  borderRadius: '4px',
+                  textAlign: 'center',
+                }}
+              >
+                {t('messages.not_in_device_db', 'This node is not in your radio\'s database. Direct messages will fail until the node exchanges keys with your radio. Use "Exchange Node Info" to request key exchange.')}
               </div>
             )}
 

--- a/src/hooks/usePoll.ts
+++ b/src/hooks/usePoll.ts
@@ -157,6 +157,7 @@ export interface PollData {
   config?: PollConfig;
   deviceConfig?: DeviceConfig;
   traceroutes?: PollTraceroute[];
+  deviceNodeNums?: number[];
 }
 
 /**

--- a/src/hooks/useServerData.ts
+++ b/src/hooks/useServerData.ts
@@ -111,6 +111,21 @@ export function useDeviceConfig() {
 }
 
 /**
+ * Hook to access device node numbers (nodes in the connected radio's local database)
+ *
+ * @returns Set of node numbers in the radio's DB
+ */
+export function useDeviceNodes() {
+  const { data } = usePoll();
+  const prevRef = useRef<Set<number>>(new Set());
+  const deviceNodeNums = data?.deviceNodeNums;
+  if (deviceNodeNums && deviceNodeNums.length > 0) {
+    prevRef.current = new Set(deviceNodeNums);
+  }
+  return prevRef.current;
+}
+
+/**
  * Hook to access unread counts from the poll cache
  *
  * @returns Object with unread counts for channels and DMs

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -352,6 +352,7 @@ class MeshtasticManager {
   // Auto-welcome tracking to prevent race conditions
   private welcomingNodes: Set<number> = new Set();  // Track nodes currently being welcomed
   private autoFavoritingNodes = new Set<number>();  // Track nodes currently being auto-favorited
+  private deviceNodeNums: Set<number> = new Set();  // Nodes in the connected radio's local database
   private autoFavoriteSweepRunning = false;  // Prevent concurrent sweep operations
 
   // Virtual Node Server - Message capture for initialization sequence
@@ -615,6 +616,7 @@ class MeshtasticManager {
       this.initConfigCache = [];
       this.configCaptureComplete = false;
       this.isCapturingInitConfig = true;
+      this.deviceNodeNums.clear();
       logger.info('📸 Starting init config capture for virtual node server');
 
       // Send want_config_id to request full node DB and config
@@ -1264,7 +1266,7 @@ class MeshtasticManager {
    */
   private async processKeyRepairs(): Promise<void> {
     try {
-      const nodesNeedingRepair = databaseService.getNodesNeedingKeyRepair();
+      const nodesNeedingRepair = await databaseService.getNodesNeedingKeyRepairAsync();
 
       // Pre-fetch repair log for immediate purge skip check
       const recentRepairLog = this.keyRepairImmediatePurge ? await databaseService.getKeyRepairLogAsync(50) : [];
@@ -1314,7 +1316,7 @@ class MeshtasticManager {
           }
 
           // Mark as exhausted
-          databaseService.setKeyRepairState(node.nodeNum, { exhausted: true });
+          await databaseService.setKeyRepairStateAsync(node.nodeNum, { exhausted: true });
           databaseService.logKeyRepairAttempt(node.nodeNum, nodeName, 'exhausted', null);
           continue;
         }
@@ -1328,7 +1330,7 @@ class MeshtasticManager {
           await this.sendNodeInfoRequest(node.nodeNum, repairChannel);
 
           // Update repair state
-          databaseService.setKeyRepairState(node.nodeNum, {
+          await databaseService.setKeyRepairStateAsync(node.nodeNum, {
             attemptCount: node.attemptCount + 1,
             lastAttemptTime: now,
             startedAt: node.startedAt ?? now
@@ -5233,20 +5235,26 @@ class MeshtasticManager {
 
           // PKI errors from our local node (couldn't encrypt to target)
           if (isPkiError(errorReason) && fromNodeId === localNodeId) {
-            const errorDescription = errorReason === RoutingError.PKI_FAILED
-              ? 'PKI encryption failed on request - possible key mismatch. Use "Exchange Node Info" or purge node data to refresh keys.'
-              : 'Remote node missing public key on request - possible key mismatch. Use "Exchange Node Info" or purge node data to refresh keys.';
+            // PKI_UNKNOWN_PUBKEY when node isn't in the radio's DB is expected after
+            // factory reset or purge — don't flag it as a security issue
+            if ((errorReason === RoutingError.PKI_UNKNOWN_PUBKEY || errorReason === RoutingError.PKI_SEND_FAIL_PUBLIC_KEY) && !this.isNodeInDeviceDb(toNum)) {
+              logger.info(`🔐 PKI key error for node ${toNodeId} — node not in radio's database (expected after factory reset/purge)`);
+            } else {
+              const errorDescription = errorReason === RoutingError.PKI_FAILED
+                ? 'PKI encryption failed on request - possible key mismatch. Use "Exchange Node Info" or purge node data to refresh keys.'
+                : 'Remote node missing public key on request - possible key mismatch. Use "Exchange Node Info" or purge node data to refresh keys.';
 
-            logger.warn(`🔐 PKI error on request for node ${toNodeId}: ${errorDescription}`);
+              logger.warn(`🔐 PKI error on request for node ${toNodeId}: ${errorDescription}`);
 
-            databaseService.upsertNode({
-              nodeNum: toNum,
-              nodeId: toNodeId,
-              keyMismatchDetected: true,
-              keySecurityIssueDetails: errorDescription
-            });
-            dataEventEmitter.emitNodeUpdate(toNum, { keyMismatchDetected: true, keySecurityIssueDetails: errorDescription });
-            this.handlePkiError(toNum);
+              databaseService.upsertNode({
+                nodeNum: toNum,
+                nodeId: toNodeId,
+                keyMismatchDetected: true,
+                keySecurityIssueDetails: errorDescription
+              });
+              dataEventEmitter.emitNodeUpdate(toNum, { keyMismatchDetected: true, keySecurityIssueDetails: errorDescription });
+              this.handlePkiError(toNum);
+            }
           }
 
           // NO_CHANNEL from the target node (it couldn't decrypt our request)
@@ -5283,25 +5291,32 @@ class MeshtasticManager {
         // PKI_FAILED or PKI_UNKNOWN_PUBKEY - indicates key mismatch
         if (originalMessage.toNodeNum) {
           const targetNodeNum = originalMessage.toNodeNum;
-          const errorDescription = errorReason === RoutingError.PKI_FAILED
-            ? 'PKI encryption failed - possible key mismatch. Use "Exchange Node Info" or purge node data to refresh keys.'
-            : 'Remote node missing public key - possible key mismatch. Use "Exchange Node Info" or purge node data to refresh keys.';
 
-          logger.warn(`🔐 PKI error detected for node ${targetNodeId}: ${errorDescription}`);
+          // PKI_UNKNOWN_PUBKEY when node isn't in the radio's DB is expected after
+          // factory reset or purge — don't flag it as a security issue
+          if ((errorReason === RoutingError.PKI_UNKNOWN_PUBKEY || errorReason === RoutingError.PKI_SEND_FAIL_PUBLIC_KEY) && !this.isNodeInDeviceDb(targetNodeNum)) {
+            logger.info(`🔐 PKI key error for node ${targetNodeId} — node not in radio's database (expected after factory reset/purge)`);
+          } else {
+            const errorDescription = errorReason === RoutingError.PKI_FAILED
+              ? 'PKI encryption failed - possible key mismatch. Use "Exchange Node Info" or purge node data to refresh keys.'
+              : 'Remote node missing public key - possible key mismatch. Use "Exchange Node Info" or purge node data to refresh keys.';
 
-          // Flag the node with the key security issue
-          databaseService.upsertNode({
-            nodeNum: targetNodeNum,
-            nodeId: targetNodeId,
-            keyMismatchDetected: true,
-            keySecurityIssueDetails: errorDescription
-          });
+            logger.warn(`🔐 PKI error detected for node ${targetNodeId}: ${errorDescription}`);
 
-          // Emit event to notify UI of the key issue
-          dataEventEmitter.emitNodeUpdate(targetNodeNum, { keyMismatchDetected: true, keySecurityIssueDetails: errorDescription });
+            // Flag the node with the key security issue
+            databaseService.upsertNode({
+              nodeNum: targetNodeNum,
+              nodeId: targetNodeId,
+              keyMismatchDetected: true,
+              keySecurityIssueDetails: errorDescription
+            });
 
-          // Penalize Link Quality for PKI error (-5)
-          this.handlePkiError(targetNodeNum);
+            // Emit event to notify UI of the key issue
+            dataEventEmitter.emitNodeUpdate(targetNodeNum, { keyMismatchDetected: true, keySecurityIssueDetails: errorDescription });
+
+            // Penalize Link Quality for PKI error (-5)
+            this.handlePkiError(targetNodeNum);
+          }
         }
       }
 
@@ -5610,10 +5625,14 @@ class MeshtasticManager {
     try {
       logger.debug(`🏠 Processing NodeInfo for node ${nodeInfo.num}`);
 
-      const nodeId = `!${Number(nodeInfo.num).toString(16).padStart(8, '0')}`;
+      const nodeNum = Number(nodeInfo.num);
+      const nodeId = `!${nodeNum.toString(16).padStart(8, '0')}`;
+
+      // Track that this node exists in the radio's local database
+      this.deviceNodeNums.add(nodeNum);
 
       // Check if node already exists to determine if we should set isFavorite
-      const existingNode = databaseService.getNode(Number(nodeInfo.num));
+      const existingNode = databaseService.getNode(nodeNum);
 
       // Determine lastHeard value carefully to avoid incorrectly updating timestamps
       // during config sync. Only update lastHeard if:
@@ -9567,6 +9586,9 @@ class MeshtasticManager {
 
       await this.transport.send(adminPacket);
       logger.info(`✅ Sent remove_by_nodenum admin command for node ${nodeNum} (!${nodeNum.toString(16).padStart(8, '0')})`);
+
+      // Remove from device node tracking so the UI shows the "not in device DB" warning
+      this.deviceNodeNums.delete(nodeNum);
     } catch (error) {
       logger.error('❌ Error sending remove node admin message:', error);
       throw error;
@@ -10671,6 +10693,16 @@ class MeshtasticManager {
       nodeIp: this.getConfig().nodeIp,
       userDisconnected: this.userDisconnectedState
     };
+  }
+
+  // Get node numbers that exist in the connected radio's local database
+  getDeviceNodeNums(): number[] {
+    return Array.from(this.deviceNodeNums);
+  }
+
+  // Check if a node exists in the connected radio's local database
+  isNodeInDeviceDb(nodeNum: number): boolean {
+    return this.deviceNodeNums.has(nodeNum);
   }
 
   // Async version that fetches uptimes in a single bulk query - works with all DB backends

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3749,6 +3749,7 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
       config?: any;
       deviceConfig?: any;
       traceroutes?: any[];
+      deviceNodeNums?: number[];
     } = {};
 
     // Pre-compute shared values used across multiple sections
@@ -4050,6 +4051,9 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
     } catch (error) {
       logger.error('Error fetching traceroutes in poll:', error);
     }
+
+    // 10. Device node numbers (nodes in the connected radio's local database)
+    result.deviceNodeNums = meshtasticManager.getDeviceNodeNums();
 
     res.json(result);
   } catch (error) {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -7379,7 +7379,7 @@ class DatabaseService {
     exhausted: boolean;
     startedAt: number;
   } | null {
-    // For PostgreSQL/MySQL, key repair state is not yet implemented
+    // For PostgreSQL/MySQL, use async version
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       return null;
     }
@@ -7405,15 +7405,66 @@ class DatabaseService {
     };
   }
 
+  async getKeyRepairStateAsync(nodeNum: number): Promise<{
+    nodeNum: number;
+    attemptCount: number;
+    lastAttemptTime: number | null;
+    exhausted: boolean;
+    startedAt: number;
+  } | null> {
+    if (this.drizzleDbType === 'postgres') {
+      const client = await this.postgresPool!.connect();
+      try {
+        const result = await client.query(
+          `SELECT "nodeNum", "attemptCount", "lastAttemptTime", exhausted, "startedAt"
+           FROM auto_key_repair_state WHERE "nodeNum" = $1`,
+          [nodeNum]
+        );
+        if (result.rows.length === 0) return null;
+        const row = result.rows[0];
+        return {
+          nodeNum: Number(row.nodeNum),
+          attemptCount: row.attemptCount,
+          lastAttemptTime: row.lastAttemptTime ? Number(row.lastAttemptTime) : null,
+          exhausted: row.exhausted === 1,
+          startedAt: Number(row.startedAt),
+        };
+      } finally {
+        client.release();
+      }
+    } else if (this.drizzleDbType === 'mysql') {
+      const pool = this.mysqlPool!;
+      const [rows] = await pool.query(
+        `SELECT nodeNum, attemptCount, lastAttemptTime, exhausted, startedAt
+         FROM auto_key_repair_state WHERE nodeNum = ?`,
+        [nodeNum]
+      );
+      const resultRows = rows as any[];
+      if (resultRows.length === 0) return null;
+      const row = resultRows[0];
+      return {
+        nodeNum: Number(row.nodeNum),
+        attemptCount: row.attemptCount,
+        lastAttemptTime: row.lastAttemptTime ? Number(row.lastAttemptTime) : null,
+        exhausted: row.exhausted === 1,
+        startedAt: Number(row.startedAt),
+      };
+    }
+    // SQLite fallback
+    return this.getKeyRepairState(nodeNum);
+  }
+
   setKeyRepairState(nodeNum: number, state: {
     attemptCount?: number;
     lastAttemptTime?: number;
     exhausted?: boolean;
     startedAt?: number;
   }): void {
-    // For PostgreSQL/MySQL, key repair state is not yet implemented
+    // For PostgreSQL/MySQL, use async version
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      logger.debug(`setKeyRepairState not yet implemented for PostgreSQL/MySQL`);
+      this.setKeyRepairStateAsync(nodeNum, state).catch(err =>
+        logger.error('Error setting key repair state:', err)
+      );
       return;
     }
 
@@ -7449,6 +7500,80 @@ class DatabaseService {
     }
   }
 
+  async setKeyRepairStateAsync(nodeNum: number, state: {
+    attemptCount?: number;
+    lastAttemptTime?: number;
+    exhausted?: boolean;
+    startedAt?: number;
+  }): Promise<void> {
+    if (this.drizzleDbType === 'postgres') {
+      const client = await this.postgresPool!.connect();
+      try {
+        const existing = await this.getKeyRepairStateAsync(nodeNum);
+        const now = Date.now();
+        if (existing) {
+          await client.query(
+            `UPDATE auto_key_repair_state
+             SET "attemptCount" = $1, "lastAttemptTime" = $2, exhausted = $3
+             WHERE "nodeNum" = $4`,
+            [
+              state.attemptCount ?? existing.attemptCount,
+              state.lastAttemptTime ?? existing.lastAttemptTime,
+              (state.exhausted ?? existing.exhausted) ? 1 : 0,
+              nodeNum
+            ]
+          );
+        } else {
+          await client.query(
+            `INSERT INTO auto_key_repair_state ("nodeNum", "attemptCount", "lastAttemptTime", exhausted, "startedAt")
+             VALUES ($1, $2, $3, $4, $5)`,
+            [
+              nodeNum,
+              state.attemptCount ?? 0,
+              state.lastAttemptTime ?? null,
+              (state.exhausted ?? false) ? 1 : 0,
+              state.startedAt ?? now
+            ]
+          );
+        }
+      } finally {
+        client.release();
+      }
+    } else if (this.drizzleDbType === 'mysql') {
+      const pool = this.mysqlPool!;
+      const existing = await this.getKeyRepairStateAsync(nodeNum);
+      const now = Date.now();
+      if (existing) {
+        await pool.query(
+          `UPDATE auto_key_repair_state
+           SET attemptCount = ?, lastAttemptTime = ?, exhausted = ?
+           WHERE nodeNum = ?`,
+          [
+            state.attemptCount ?? existing.attemptCount,
+            state.lastAttemptTime ?? existing.lastAttemptTime,
+            (state.exhausted ?? existing.exhausted) ? 1 : 0,
+            nodeNum
+          ]
+        );
+      } else {
+        await pool.query(
+          `INSERT INTO auto_key_repair_state (nodeNum, attemptCount, lastAttemptTime, exhausted, startedAt)
+           VALUES (?, ?, ?, ?, ?)`,
+          [
+            nodeNum,
+            state.attemptCount ?? 0,
+            state.lastAttemptTime ?? null,
+            (state.exhausted ?? false) ? 1 : 0,
+            state.startedAt ?? now
+          ]
+        );
+      }
+    } else {
+      // SQLite fallback
+      this.setKeyRepairState(nodeNum, state);
+    }
+  }
+
   clearKeyRepairState(nodeNum: number): void {
     // For PostgreSQL/MySQL, delegate to async version
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
@@ -7474,32 +7599,9 @@ class DatabaseService {
     lastAttemptTime: number | null;
     startedAt: number | null;
   }[] {
-    // For PostgreSQL/MySQL, key repair state is not yet implemented
+    // For PostgreSQL/MySQL, use async version
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      // Return nodes with keyMismatchDetected from cache, without attempt tracking
-      const result: {
-        nodeNum: number;
-        nodeId: string;
-        longName: string | null;
-        shortName: string | null;
-        attemptCount: number;
-        lastAttemptTime: number | null;
-        startedAt: number | null;
-      }[] = [];
-      for (const node of this.nodesCache.values()) {
-        if (node.keyMismatchDetected) {
-          result.push({
-            nodeNum: node.nodeNum,
-            nodeId: node.nodeId,
-            longName: node.longName ?? null,
-            shortName: node.shortName ?? null,
-            attemptCount: 0,
-            lastAttemptTime: null,
-            startedAt: null,
-          });
-        }
-      }
-      return result;
+      return [];
     }
 
     // Get nodes with keyMismatchDetected=true that are not exhausted
@@ -7526,6 +7628,74 @@ class DatabaseService {
       lastAttemptTime: number | null;
       startedAt: number | null;
     }[];
+  }
+
+  async getNodesNeedingKeyRepairAsync(): Promise<{
+    nodeNum: number;
+    nodeId: string;
+    longName: string | null;
+    shortName: string | null;
+    attemptCount: number;
+    lastAttemptTime: number | null;
+    startedAt: number | null;
+  }[]> {
+    if (this.drizzleDbType === 'postgres') {
+      const client = await this.postgresPool!.connect();
+      try {
+        const result = await client.query(
+          `SELECT
+            n."nodeNum",
+            n."nodeId",
+            n."longName",
+            n."shortName",
+            COALESCE(s."attemptCount", 0) as "attemptCount",
+            s."lastAttemptTime",
+            s."startedAt"
+          FROM nodes n
+          LEFT JOIN auto_key_repair_state s ON n."nodeNum" = s."nodeNum"
+          WHERE n."keyMismatchDetected" = true
+            AND (s.exhausted IS NULL OR s.exhausted = 0)`
+        );
+        return result.rows.map((row: any) => ({
+          nodeNum: Number(row.nodeNum),
+          nodeId: row.nodeId,
+          longName: row.longName ?? null,
+          shortName: row.shortName ?? null,
+          attemptCount: Number(row.attemptCount),
+          lastAttemptTime: row.lastAttemptTime ? Number(row.lastAttemptTime) : null,
+          startedAt: row.startedAt ? Number(row.startedAt) : null,
+        }));
+      } finally {
+        client.release();
+      }
+    } else if (this.drizzleDbType === 'mysql') {
+      const pool = this.mysqlPool!;
+      const [rows] = await pool.query(
+        `SELECT
+          n.nodeNum,
+          n.nodeId,
+          n.longName,
+          n.shortName,
+          COALESCE(s.attemptCount, 0) as attemptCount,
+          s.lastAttemptTime,
+          s.startedAt
+        FROM nodes n
+        LEFT JOIN auto_key_repair_state s ON n.nodeNum = s.nodeNum
+        WHERE n.keyMismatchDetected = 1
+          AND (s.exhausted IS NULL OR s.exhausted = 0)`
+      );
+      return (rows as any[]).map((row: any) => ({
+        nodeNum: Number(row.nodeNum),
+        nodeId: row.nodeId,
+        longName: row.longName ?? null,
+        shortName: row.shortName ?? null,
+        attemptCount: Number(row.attemptCount),
+        lastAttemptTime: row.lastAttemptTime ? Number(row.lastAttemptTime) : null,
+        startedAt: row.startedAt ? Number(row.startedAt) : null,
+      }));
+    }
+    // SQLite fallback
+    return this.getNodesNeedingKeyRepair();
   }
 
   // Auto key repair log methods


### PR DESCRIPTION
## Summary

- **Fix auto-key repair infinite loop on PostgreSQL/MySQL**: The repair state tracking (`attemptCount`, `lastAttemptTime`, `exhausted`) was unimplemented for Postgres/MySQL — `getKeyRepairState` returned null, `setKeyRepairState` silently did nothing, and `getNodesNeedingKeyRepair` returned hardcoded zeros from cache. This caused "Exchange 1/3" to repeat infinitely. Added async implementations (`getKeyRepairStateAsync`, `setKeyRepairStateAsync`, `getNodesNeedingKeyRepairAsync`) that properly query the `auto_key_repair_state` table, and updated `processKeyRepairs` to use them.

- **Track radio's local node database in memory**: During device sync, the server now tracks which nodes exist in the connected radio's node DB via a `Set<number>`. This set is cleared on reconnect, populated during `processNodeInfoProtobuf`, and nodes are removed when `sendRemoveNode` purges them.

- **"Not in device DB" warning banner**: When selecting a DM node that isn't in the radio's database, an orange warning banner explains that messages will fail and suggests using "Exchange Node Info".

- **Suppress false security alerts for missing keys**: `PKI_UNKNOWN_PUBKEY` and `PKI_SEND_FAIL_PUBLIC_KEY` errors no longer trigger `keyMismatchDetected` when the target node simply isn't in the radio's database (e.g. after factory reset or purge). This is normal key management, not a security issue.

## Test plan

- [x] TypeScript type check passes
- [x] All 2953 unit tests pass
- [ ] Verify on PostgreSQL that auto-key repair progresses through Exchange 1/3, 2/3, 3/3
- [ ] Verify DM to a node not in radio's DB shows orange warning banner
- [ ] Verify PKI errors for nodes not in radio's DB do not create security alerts
- [ ] Verify nodes purged via auto-key repair are removed from device node tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)