### PR TITLE
fix: stop broadcasting stale public key in NodeInfo exchanges (#2275)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6403,24 +6403,18 @@ class MeshtasticManager {
 
     try {
       // Get local node's user info from database for exchange
+      // NOTE: We intentionally do NOT include publicKey here. The device's own firmware
+      // handles key distribution via its native NodeInfo broadcasts. If MeshMonitor's
+      // database has a stale key (e.g. after firmware update or NVS corruption), broadcasting
+      // it would cause other mesh nodes to store the wrong key, making the node appear as
+      // a new/untrusted identity. See issue #2275.
       const localNode = databaseService.getNode(this.localNodeInfo.nodeNum);
-      // Decode base64 public key to Uint8Array
-      let publicKeyBytes: Uint8Array | undefined;
-      if (localNode?.publicKey) {
-        try {
-          publicKeyBytes = new Uint8Array(Buffer.from(localNode.publicKey, 'base64'));
-          logger.info(`🔐 Including public key in NodeInfo exchange: ${localNode.publicKey.substring(0, 20)}... (${publicKeyBytes.length} bytes)`);
-        } catch (err) {
-          logger.warn('⚠️ Failed to decode public key from base64:', err);
-        }
-      }
       const localUserInfo = localNode ? {
         id: this.localNodeInfo.nodeId,
         longName: localNode.longName || 'Unknown',
         shortName: localNode.shortName || '????',
         hwModel: localNode.hwModel,
         role: localNode.role,
-        publicKey: publicKeyBytes
       } : undefined;
 
       const { data: nodeInfoRequestData, packetId, requestId } = meshtasticProtobufService.createNodeInfoRequestMessage(

--- a/src/server/meshtasticProtobufService.ts
+++ b/src/server/meshtasticProtobufService.ts
@@ -199,7 +199,7 @@ export class MeshtasticProtobufService {
   createNodeInfoRequestMessage(
     destination: number,
     channel?: number,
-    userInfo?: { id: string; longName: string; shortName: string; hwModel?: number; role?: number; publicKey?: Uint8Array }
+    userInfo?: { id: string; longName: string; shortName: string; hwModel?: number; role?: number }
   ): { data: Uint8Array; packetId: number; requestId: number } {
     const root = getProtobufRoot();
     if (!root) {
@@ -228,9 +228,9 @@ export class MeshtasticProtobufService {
         if (userInfo.role !== undefined) {
           userData.role = userInfo.role;
         }
-        if (userInfo.publicKey && userInfo.publicKey.length > 0) {
-          userData.publicKey = userInfo.publicKey;
-        }
+        // NOTE: publicKey is intentionally omitted. The device firmware handles its own
+        // key distribution. Broadcasting a DB-cached key risks distributing stale keys
+        // if the device has regenerated its key pair. See issue #2275.
       }
       // If no user info provided, send empty user (fallback behavior)
 


### PR DESCRIPTION
## Summary
- Remove public key from MeshMonitor-initiated NodeInfo exchanges and auto-announce broadcasts
- The device firmware handles its own key distribution via native NodeInfo broadcasts
- MeshMonitor should not re-broadcast cached key material that could be stale

## Problem
MeshMonitor was reading the local node's public key from its database and including it in every NodeInfo exchange (auto-announce, key repair, manual exchange). If the device regenerated its key pair (firmware update, NVS corruption, factory reset), the stale key would be broadcast to the mesh, causing other nodes to store the wrong key and treat the node as a new/untrusted identity.

Multiple users have reported this issue over several weeks.

Closes #2275

## Changes
- `meshtasticManager.ts`: Removed public key lookup and inclusion from `sendNodeInfoRequest()`
- `meshtasticProtobufService.ts`: Removed `publicKey` from `createNodeInfoRequestMessage()` interface

## Test plan
- [x] All 2953 unit tests pass
- [ ] Verify NodeInfo exchanges no longer include public key in packet monitor
- [ ] Verify device's native NodeInfo broadcasts still distribute the correct key
- [ ] Monitor for user reports of node identity changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)