### PR TITLE
fix: preserve traceroute request node order from virtual node

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3779,6 +3779,14 @@ class MeshtasticManager {
             logger.debug(`🤷 Unhandled portnum: ${normalizedPortNum} (${meshtasticProtobufService.getPortNumName(portnum)})`);
         }
       }
+      // Preserve the 'from' and 'to' node order for virtual node traceroute requests.
+      // This ensures subsequent responses correctly correlate with this request 
+      // to update route and signal characteristics in the database.
+      else if (normalizedPortNum === PortNum.TRACEROUTE_APP) {
+        const fromNum = meshPacket.from ? Number(meshPacket.from) : 0;
+        const toNum = meshPacket.to ? Number(meshPacket.to) : 0;
+        databaseService.recordTracerouteRequest(fromNum, toNum);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

This PR fixes incorrect node ordering when handling traceroute request packets from a virtual node.

For `PortNum.TRACEROUTE_APP`, the request must be stored in the database with the original `from` and `to` node order. Without this, the corresponding response may be matched incorrectly and update the wrong route or signal characteristics.

## Changes

- Added explicit handling for traceroute request packets from virtual nodes
- Preserved the original `from` / `to` node order before saving the request
- Ensured follow-up traceroute responses update the correct database record

## Testing

- Verified traceroute request handling for virtual nodes
- Confirmed the request is stored with the correct node order
- Confirmed subsequent response processing updates the expected route and signal data

## Notes

- This bug was not previously reported
- The change is limited to traceroute request persistence logic
