### PR TITLE
fix: allow 0 for traceroute expiration hours setting

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -7205,17 +7205,17 @@ class DatabaseService {
       return 24; // Default to 24 hours
     }
     const hours = parseInt(value, 10);
-    // Validate range (1-168 hours, i.e., 1 hour to 1 week)
-    if (isNaN(hours) || hours < 1 || hours > 168) {
+    // Validate range (0-168 hours; 0 = always re-traceroute, up to 1 week)
+    if (isNaN(hours) || hours < 0 || hours > 168) {
       return 24;
     }
     return hours;
   }
 
   setTracerouteExpirationHours(hours: number): void {
-    // Validate range (1-168 hours, i.e., 1 hour to 1 week)
-    if (hours < 1 || hours > 168) {
-      throw new Error('Traceroute expiration hours must be between 1 and 168 (1 week)');
+    // Validate range (0-168 hours; 0 = always re-traceroute, up to 1 week)
+    if (hours < 0 || hours > 168) {
+      throw new Error('Traceroute expiration hours must be between 0 and 168 (1 week)');
     }
     this.setSetting('tracerouteExpirationHours', hours.toString());
     logger.debug(`✅ Set traceroute expiration hours to: ${hours}`);


### PR DESCRIPTION
## Summary
The backend `DatabaseService` getter and setter for `tracerouteExpirationHours` rejected a value of 0 as invalid, even though the server route validation and frontend UI both accepted it. This caused a save error when users set the "Re-traceroute after" field to 0 hours (meaning "always re-traceroute").

## Changes
- Changed `getTracerouteExpirationHours()` validation from `hours < 1` to `hours < 0` so 0 falls back to default (24) only on invalid negative values
- Changed `setTracerouteExpirationHours()` validation from `hours < 1` to `hours < 0` to accept 0 as a valid value
- Updated error message to reflect the valid range: 0–168

## Issues Resolved
None

## Documentation Updates
No documentation changes needed — `docs/features/AUTO_TRACEROUTE_ANALYSIS.md` mentions the setting without specifying a range.

## Testing
- [x] Unit tests pass (2972 tests)
- [x] TypeScript compiles cleanly
- [ ] Set "Re-traceroute after" to 0 in AutoTraceroute settings — should save without error
- [ ] Verify traceroute expiration behavior with 0 value

🤖 Generated with [Claude Code](https://claude.com/claude-code)