### PR TITLE
fix: SQLite migrations 083/084 skipped due to early return in 082

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -2598,19 +2598,16 @@ class DatabaseService {
 
   private runAddPacketmonitorPermissionMigration(): void {
     // Run migration 082: Add packetmonitor permission resource
-    try {
-      const migrationKey = 'migration_082_packetmonitor_permission';
-      const migrationStatus = this.getSetting(migrationKey);
-      if (migrationStatus === 'completed') {
-        logger.debug('Migration 082 (add packetmonitor permission) already completed');
-        return;
+    const migrationKey082 = 'migration_082_packetmonitor_permission';
+    if (!this.getSetting(migrationKey082)) {
+      try {
+        logger.debug('Running migration 082: Add packetmonitor permission...');
+        addPacketmonitorPermissionMigration.up(this.db);
+        this.setSetting(migrationKey082, 'completed');
+        logger.debug('Add packetmonitor permission migration completed successfully');
+      } catch (error) {
+        logger.error('Error running migration 082:', error);
       }
-      logger.debug('Running migration 082: Add packetmonitor permission...');
-      addPacketmonitorPermissionMigration.up(this.db);
-      this.setSetting(migrationKey, 'completed');
-      logger.debug('Add packetmonitor permission migration completed successfully');
-    } catch (error) {
-      logger.error('Error running migration 082:', error);
     }
 
     // Migration 083: Add missing map preference columns


### PR DESCRIPTION
## Summary
SQLite users upgrading from versions before 3.9 were missing the `lastMeshReceivedKey` column (migration 084), causing all node queries to crash with `SqliteError: no such column: "lastMeshReceivedKey"`. This broke auto-delete-by-distance and other features that query the nodes table.

The root cause was that migrations 083 and 084 were nested inside the `runAddPacketmonitorPermissionMigration()` method (migration 082). Once 082 was marked complete on first startup, subsequent restarts would `return` early, permanently skipping 083 and 084. PostgreSQL and MySQL were unaffected as they run each migration independently.

## Changes
- Replaced migration 082's early-return pattern (`if completed → return`) with the same guard pattern used by 083/084 (`if (!getSetting) { try { ... } }`)
- No functional change to what migration 082 does — only removes the early exit that blocked 083/084

## Issues Resolved
Fixes #2296

## Documentation Updates
No documentation changes needed.

## Testing
- [x] Unit tests pass (2972 tests)
- [x] TypeScript compiles cleanly
- [ ] Verify on a SQLite instance that was missing `lastMeshReceivedKey` — column should be added on restart
- [ ] Verify auto-delete-by-distance runs without errors after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)