### PR TITLE
fix: auto-recover from stale SQLite SHM files after upgrades

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -621,13 +621,7 @@ class DatabaseService {
     }
 
     // Now attempt to open the database with better error handling
-    try {
-      this.db = this.openSqliteDatabase(dbPath, dbDir);
-    } catch (error: unknown) {
-      const err = error as Error & { code?: string };
-      logger.error('═══════════════════════════════════════════════════════════');
-      throw new Error(`Database initialization failed: ${err.message}`);
-    }
+    this.db = this.openSqliteDatabase(dbPath, dbDir);
 
     // Initialize models
     this.userModel = new UserModel(this.db);
@@ -5204,11 +5198,12 @@ class DatabaseService {
 
       // Stale SHM file from a previous version — remove it and retry
       const shmPath = `${dbPath}-shm`;
-      if (err.code?.startsWith('SQLITE_IOERR') && fs.existsSync(shmPath)) {
+      const isShmError = err.code === 'SQLITE_IOERR_SHMSIZE' || err.code === 'SQLITE_IOERR_SHMMAP';
+      if (isShmError) {
         logger.warn('⚠️  SQLite SHM file appears stale (common after upgrades)');
         logger.warn(`   Removing ${shmPath} and retrying — data is safe in the WAL`);
+        fs.rmSync(shmPath, { force: true });
         try {
-          fs.unlinkSync(shmPath);
           return attemptOpen();
         } catch (retryError: unknown) {
           const retryErr = retryError as Error & { code?: string };


### PR DESCRIPTION
## Summary

Automatically recovers from `SQLITE_IOERR_SHMSIZE` errors that occur after container upgrades, and prevents the issue from recurring by checkpointing WAL on shutdown.

Fixes #2303

## Problem

When upgrading MeshMonitor (e.g. 3.9.4 → 3.9.5), the new container may use a different Node.js version and therefore a different build of the `better-sqlite3` native module. If the previous container wasn't cleanly shut down (or the WAL wasn't fully checkpointed), the leftover `.db-shm` (shared memory) file can be incompatible with the new SQLite version, causing:

```
Error: disk I/O error
Error code: SQLITE_IOERR_SHMSIZE
```

The database itself is fine — SQLite just can't work with the stale SHM file.

## What Changed

### 1. Startup recovery: `openSqliteDatabase()` method
**File:** `src/services/database.ts`

Extracted database opening into a dedicated method with retry logic:

- **First attempt**: Opens database normally
- **On `SQLITE_IOERR*`**: If a `.db-shm` file exists, logs a warning, deletes it, and retries. SQLite automatically reconstructs the SHM from the WAL file — no data loss
- **On other errors**: Falls through to existing diagnostic logging (`SQLITE_CANTOPEN`, etc.)

The recovery is scoped narrowly:
- Only triggers on `SQLITE_IOERR*` error codes (not other failures)
- Only deletes the `.db-shm` file (never the `.db-wal` — that contains uncommitted data)
- Only retries once — if the retry also fails, it throws the original error

### 2. Graceful shutdown: WAL checkpoint before close
**File:** `src/services/database.ts` — `close()` method

Added `PRAGMA wal_checkpoint(TRUNCATE)` before closing the database connection. This flushes the WAL back into the main database file and removes the WAL/SHM files, so they don't linger across container restarts or upgrades.

The checkpoint is wrapped in a try/catch — if it fails (e.g. database already in a bad state), shutdown continues normally.

## How it works in practice

**Before this fix (upgrade scenario):**
1. User runs `docker pull` + `docker compose up -d`
2. New container starts with updated Node.js / better-sqlite3
3. Old `.db-shm` file is incompatible → `SQLITE_IOERR_SHMSIZE` → crash loop
4. User must manually delete `.db-shm` from the host filesystem

**After this fix:**
1. User runs `docker pull` + `docker compose up -d`
2. New container detects stale SHM, removes it, retries successfully
3. On next shutdown, WAL is checkpointed so the issue won't recur

## Test plan

- [ ] Normal startup with clean database works as before
- [ ] Startup with a stale/corrupt `.db-shm` file auto-recovers (can test by writing garbage to the shm file before starting)
- [ ] Graceful shutdown (`docker compose down`) checkpoints WAL (verify `.db-shm` and `.db-wal` are removed or zero-length after clean stop)
- [ ] `SQLITE_CANTOPEN` and other non-IOERR errors still produce helpful diagnostic messages
- [ ] Run `tests/system-tests.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)