### PR TITLE
ci: add PostgreSQL to CI for multi-database test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,21 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: meshmonitor_test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     strategy:
       matrix:
         node-version: [20.x, 22.x, 24.x, 25.x]

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -24,6 +24,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: meshmonitor_test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/src/db/repositories/telemetry.multidb.test.ts
+++ b/src/db/repositories/telemetry.multidb.test.ts
@@ -151,6 +151,12 @@ describe('TelemetryRepository - PostgreSQL Backend', () => {
       `);
       console.log('✓ PostgreSQL connection established');
     } catch (error) {
+      if (process.env.CI === 'true') {
+        throw new Error(
+          'PostgreSQL is required in CI but not available on port 5433. ' +
+          'Check the GitHub Actions service container configuration.'
+        );
+      }
       console.log('⚠ PostgreSQL not available, skipping PostgreSQL tests');
       console.log('  Run: docker run -d --name meshmonitor-test-postgres -e POSTGRES_USER=test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=meshmonitor_test -p 5433:5432 postgres:16');
       pgAvailable = false;


### PR DESCRIPTION
## Summary

Adds PostgreSQL as a service container in CI so multi-database tests actually run instead of silently skipping.

### Changes

1. **`.github/workflows/ci.yml`** — Added `postgres:16` service on port 5433 with health checks
2. **`.github/workflows/pr-tests.yml`** — Same service added to Quick Tests job
3. **`src/db/repositories/telemetry.multidb.test.ts`** — When `CI=true` and PostgreSQL isn't available, the test now **fails** instead of silently skipping. Local runs without Postgres still skip gracefully.

### Why

The multi-database telemetry tests were silently skipping in CI because no PostgreSQL container was available. This meant PostgreSQL-specific bugs could ship without being caught — exactly the class of issues (BIGINT overflow, migration ordering) that motivated the database architecture remediation.

### Service Configuration
```yaml
services:
  postgres:
    image: postgres:16
    env:
      POSTGRES_USER: test
      POSTGRES_PASSWORD: test
      POSTGRES_DB: meshmonitor_test
    ports:
      - 5433:5432
```

Matches the existing test expectations in `telemetry.multidb.test.ts`.

## Test plan
- [x] All 3,017 tests pass locally (Postgres tests skip gracefully without CI=true)
- [ ] CI passes with PostgreSQL service running
- [ ] Multi-database tests execute (not skip) in CI

🤖 Generated with [Claude Code](https://claude.ai/code)