### PR TITLE
fix: correct admin permission resource names to match CHECK constraint

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -7914,7 +7914,14 @@ class DatabaseService {
       });
 
       // Grant all permissions for admin
-      const allResources = ['dashboard', 'nodes', 'messages', 'traceroutes', 'channels', 'configuration', 'info', 'notifications', 'audit', 'users', 'packets'];
+      // Resource names must match the CHECK constraint in the permissions table (set by migration 006)
+      const allResources = [
+        'dashboard', 'nodes', 'messages', 'settings', 'configuration', 'info',
+        'automation', 'connection', 'traceroute', 'audit', 'security', 'themes',
+        'channel_0', 'channel_1', 'channel_2', 'channel_3',
+        'channel_4', 'channel_5', 'channel_6', 'channel_7',
+        'nodes_private', 'meshcore', 'packetmonitor'
+      ];
       for (const resource of allResources) {
         await this.auth.createPermission({
           userId: adminId,


### PR DESCRIPTION
## Summary

The `ensureAdminUser` function used invalid resource names that violate the SQLite permissions table CHECK constraint, preventing admin/anonymous user creation on fresh installs. This was fixed in PR #2320 but the fix was lost during squash merge conflict resolution.

### Root cause
`allResources` contained: `traceroutes`, `channels`, `notifications`, `users`, `packets` — none of which are valid CHECK constraint values.

### Fix
Updated to match the CHECK constraint from migration 006: `dashboard`, `nodes`, `messages`, `settings`, `configuration`, `info`, `automation`, `connection`, `traceroute`, `audit`, `security`, `themes`, `channel_0`-`channel_7`, `nodes_private`, `meshcore`, `packetmonitor`.

🤖 Generated with [Claude Code](https://claude.ai/code)