### PR TITLE
chore: add CLAUDE.md guidelines, CI monitor skill, and PR creation hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | grep -qE '\\.tsx?$' && npx tsc --noEmit --pretty 2>&1 | head -20 || true",
+            "timeout": 60,
+            "statusMessage": "Type-checking..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.tool_input.command // empty'); echo \"$CMD\" | grep -q 'gh pr create' || exit 0; echo 'Running test suite before PR creation...' >&2; RESULT=$(npm test 2>&1); if echo \"$RESULT\" | grep -qE 'Tests.*failed'; then FAILS=$(echo \"$RESULT\" | grep -E 'Test Files|Tests ' | tail -2); echo \"{\\\"decision\\\": \\\"block\\\", \\\"reason\\\": \\\"Tests failed — fix before creating PR:\\n$FAILS\\\"}\"; else echo \"{\\\"hookSpecificOutput\\\": {\\\"hookEventName\\\": \\\"PreToolUse\\\", \\\"additionalContext\\\": \\\"All tests passed — PR creation approved.\\\"}}\"; fi",
+            "timeout": 300,
+            "statusMessage": "Running tests before PR creation..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/ci-monitor.md
+++ b/.claude/skills/ci-monitor.md
@@ -1,0 +1,83 @@
+# CI Monitor & Auto-Fix
+
+Monitor a PR's CI pipeline, auto-diagnose failures, apply targeted fixes, and re-push until green.
+
+## Usage
+
+Invoke with: `/ci-monitor <PR_NUMBER>`
+
+## Instructions
+
+### Phase 1: Monitor
+
+1. Get the PR branch name: `gh pr view $PR_NUMBER --json headRefName -q .headRefName`
+2. Ensure you're on that branch: `git checkout <branch> && git pull origin <branch>`
+3. Poll CI status every 60 seconds using: `gh run list --branch <branch> --limit 4 --json name,conclusion,status`
+4. Display status each cycle: ✓ for success, ✗ for failure, ⏳ for in-progress
+5. When all checks complete:
+   - If **ALL GREEN**: Report success and stop
+   - If **ANY RED**: Proceed to Phase 2
+
+### Phase 2: Diagnose
+
+1. Get the failing run ID: `gh run list --branch <branch> --limit 1 --json databaseId,conclusion -q '.[] | select(.conclusion == "failure") | .databaseId'`
+2. Fetch failure logs: `gh run view <run_id> --log-failed 2>&1`
+3. Extract error patterns — look for these common regressions:
+   - `error TS` — TypeScript compilation errors (missing async, null vs undefined, unused vars)
+   - `CHECK constraint failed: resource IN` — Permission resource name mismatch
+   - `mockReturnValue` on async functions — Should be `mockResolvedValue`
+   - `is not a function` — Missing method on repository or wrong import
+   - `Cannot read properties of undefined` — Null/undefined propagation from Drizzle repos
+   - `FAIL` lines — Test file names and assertion errors
+
+### Phase 3: Fix
+
+Apply a **minimal targeted fix** — touch ONLY the files related to the failure:
+
+1. For **TypeScript errors**: Read the file at the error line, understand the type mismatch, fix it
+   - `number | null` vs `number | undefined` → Add `?? undefined`
+   - Missing `async` keyword → Add it to the function
+   - Unused variable → Remove or prefix with `_`
+2. For **CHECK constraint errors**: Verify resource names match the valid list in migration 006
+3. For **Mock mismatches**: Change `mockReturnValue` to `mockResolvedValue` for async functions
+4. For **Missing methods**: Check if the method exists on the repository, add if missing
+
+After fixing:
+- Run the failing tests locally: `node_modules/.bin/vitest run <failing_test_file>`
+- If they pass, run the full suite: `npm test 2>&1 | tail -5`
+- Commit: `git add -A && git commit -m "fix: [describe the CI failure]" && git push`
+
+### Phase 4: Re-monitor
+
+After pushing the fix:
+1. Wait 30 seconds for CI to pick up the new commit
+2. Return to Phase 1
+3. **Maximum 3 fix cycles** — if CI is still red after 3 attempts, stop and report what was tried
+
+### Reporting
+
+When complete (success or max attempts reached), output a summary:
+
+```
+## CI Monitor Report for PR #XXXX
+
+**Branch:** <branch_name>
+**Result:** ✓ GREEN / ✗ STILL RED after N attempts
+
+### Actions Taken
+1. [Cycle 1] Fixed: <description> — Files: <list>
+2. [Cycle 2] Fixed: <description> — Files: <list>
+
+### Final CI Status
+- PR Tests: PASS/FAIL
+- CI: PASS/FAIL
+- Claude Code Review: PASS/FAIL
+```
+
+## Important Rules
+
+- **Never force-push** — always regular push
+- **Never modify files unrelated to the failure** — minimal fixes only
+- **Always run failing tests locally before pushing** — don't push blind fixes
+- **Check that the branch is up to date** before applying fixes
+- The `scripts/watch-ci.sh` script can be used for simple polling if you just need to wait

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@
 - Only the backend talks to the Node. the Frontend never talks directly to the node.
 
 
+## Code Modification Rules
+
+- After bulk find-and-replace or sed operations, always verify that modified functions have correct async/await signatures before running tests. Check that route handlers and callbacks are marked async if await was added inside them.
+
 ## Multi-Database Architecture (SQLite/PostgreSQL/MySQL)
 
 MeshMonitor supports three database backends. When working with database code:
@@ -61,6 +65,7 @@ When tests mock DatabaseService, they must provide async method mocks for authMi
 - Use shared constants from `src/server/constants/meshtastic.ts` for PortNum, RoutingError, and helper functions - never use magic numbers for protocol values
 - When updating the version, make sure you get all five files: package.json, package-lock.json (regenerate via `npm install --package-lock-only --legacy-peer-deps`), helm/meshmonitor/Chart.yaml, desktop/src-tauri/tauri.conf.json, and desktop/package.json
 - Prior to creating a PR, make sure to run the tests/system-tests.sh to ensure success and post the output report
+- After creating or updating a PR, use the `/ci-monitor` skill to monitor CI status and auto-fix any failures
 - When testing, our webserver has BASE_URL configured for /meshmonitor
   Completely shut down the container and tileserver before running system tests
 
@@ -82,6 +87,15 @@ When adding a new user-configurable setting:
 - **MUST** add the key to `src/server/constants/settings.ts` `VALID_SETTINGS_KEYS` — without this, the setting silently fails to save
 - In `SettingsTab.tsx`, the `handleSave` `useCallback` has a large dependency array — new `localFoo` state AND the context `setFoo` setter must be added to it, or the save callback uses stale values
 - See `src/contexts/SettingsContext.tsx` for the full state/setter/localStorage/server-load pattern
+
+## Database
+
+- This project has three database backends: SQLite, PostgreSQL, and MySQL. When modifying migrations or schema, always update ALL three backend baseline migrations consistently. Check column names, table names, and constraints match across all backends.
+
+## Testing
+
+- When migrating test mocks from sync to async patterns, use `mockResolvedValue` instead of `mockReturnValue` for any mocked function that is now async/returns a Promise.
+- All tests must pass (0 failures) before creating a PR. Run the full test suite, not just targeted tests, before committing migration or refactor work.
 
 ## Key Repair / NodeInfo Exchange Routing
 

--- a/scripts/watch-ci.sh
+++ b/scripts/watch-ci.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# watch-ci.sh — Poll CI pipeline status for a PR or branch
+# Usage: ./scripts/watch-ci.sh [PR_NUMBER|BRANCH_NAME]
+
+set -euo pipefail
+
+TARGET="${1:?Usage: watch-ci.sh <PR_NUMBER|BRANCH_NAME>}"
+INTERVAL=60
+
+if [[ "$TARGET" =~ ^[0-9]+$ ]]; then
+  BRANCH=$(gh pr view "$TARGET" --json headRefName -q .headRefName)
+  echo "Watching CI for PR #$TARGET (branch: $BRANCH)"
+else
+  BRANCH="$TARGET"
+  echo "Watching CI for branch: $BRANCH"
+fi
+
+echo "Polling every ${INTERVAL}s..."
+echo ""
+
+while true; do
+  TIMESTAMP=$(date '+%H:%M:%S')
+  RESULTS=$(gh run list --branch "$BRANCH" --limit 4 --json name,conclusion,status \
+    -q '.[] | "\(.name)|\(.status)|\(.conclusion)"' 2>/dev/null)
+
+  if [ -z "$RESULTS" ]; then
+    echo "[$TIMESTAMP] No CI runs found for branch $BRANCH"
+    sleep "$INTERVAL"
+    continue
+  fi
+
+  ALL_COMPLETE=true
+  ANY_FAILED=false
+
+  echo "[$TIMESTAMP] CI Status:"
+  while IFS='|' read -r NAME STATUS CONCLUSION; do
+    if [ "$STATUS" = "completed" ]; then
+      if [ "$CONCLUSION" = "success" ]; then
+        echo "  ✓ $NAME"
+      elif [ "$CONCLUSION" = "skipped" ]; then
+        echo "  ⊘ $NAME (skipped)"
+      else
+        echo "  ✗ $NAME ($CONCLUSION)"
+        ANY_FAILED=true
+      fi
+    else
+      echo "  ⏳ $NAME ($STATUS)"
+      ALL_COMPLETE=false
+    fi
+  done <<< "$RESULTS"
+  echo ""
+
+  if $ALL_COMPLETE; then
+    echo "═══════════════════════════════════"
+    if $ANY_FAILED; then
+      echo "✗ CI FAILED — check logs with: gh run list --branch $BRANCH"
+    else
+      echo "✓ CI PASSED — all checks green"
+    fi
+    echo "═══════════════════════════════════"
+
+    if command -v notify-send &>/dev/null; then
+      if $ANY_FAILED; then
+        notify-send "CI Failed" "Branch: $BRANCH" --urgency=critical
+      else
+        notify-send "CI Passed" "Branch: $BRANCH" --urgency=normal
+      fi
+    fi
+
+    exit $($ANY_FAILED && echo 1 || echo 0)
+  fi
+
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary

Developer experience improvements from lessons learned during database architecture remediation.

### Changes (4 files only)

- **CLAUDE.md**: Added Code Modification Rules, Database, and Testing sections
- **`.claude/skills/ci-monitor.md`**: New `/ci-monitor` skill — monitors CI, auto-diagnoses failures, applies targeted fixes (max 3 cycles)
- **`.claude/settings.json`**: PostToolUse hook for tsc after TS edits; PreToolUse hook blocking `gh pr create` if tests fail
- **`scripts/watch-ci.sh`**: Standalone CI polling script with desktop notifications

🤖 Generated with [Claude Code](https://claude.ai/code)