### PR TITLE
Update Claude Code Action to v1 and refactor configuration

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -52,7 +52,7 @@ You need to configure **one** of the following authentication methods:
 You can customize the review prompt in the workflow file:
 
 ```yaml
-direct_prompt: |
+prompt: |
   Please review this pull request and provide feedback on:
   - Code quality and best practices
   - Potential bugs or issues

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,47 +38,28 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}  # Required to avoid OIDC token errors
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
-
           # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
             - Security concerns
             - Test coverage
-            
+
             Be constructive and helpful in your feedback.
+
+          # Optional: Specify model via claude_args (defaults to Claude Sonnet 4)
+          # claude_args: --model claude-opus-4-1-20250805
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
+
           # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
+          # claude_args: --allowedTools "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,33 +32,20 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
-          
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
-          
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-          
+
+          # Optional: Specify model via claude_args (defaults to Claude Sonnet 4)
+          # claude_args: --model claude-opus-4-1-20250805
+
           # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
-          
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
+          # claude_args: --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+
+          # Optional: Add custom instructions
+          # claude_args: --system-prompt "Follow our coding standards"
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -109,13 +109,13 @@ jobs:
 
       - name: Triage with Claude
         if: steps.check-permissions.outputs.has_write_access == 'true'
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.CLAUDE_GITHUB_TOKEN }}
-          model: "claude-sonnet-4-20250514"
+          claude_args: --model claude-sonnet-4-20250514
 
-          direct_prompt: |
+          prompt: |
             🤖 **Automated Issue Triage**
 
             A new issue has been submitted. Your job is to provide an initial response following these STRICT guidelines:
@@ -264,13 +264,13 @@ jobs:
           fetch-depth: 1
 
       - name: Triage with Claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.CLAUDE_GITHUB_TOKEN }}
-          model: "claude-sonnet-4-20250514"
+          claude_args: --model claude-sonnet-4-20250514
 
-          direct_prompt: |
+          prompt: |
             🤖 **Automated Issue Triage** (Manual Trigger)
 
             A maintainer has requested AI triage for this issue. Your job is to provide an initial response following these STRICT guidelines:
@@ -480,13 +480,13 @@ jobs:
 
       - name: Follow-up Analysis with Claude
         if: steps.check-permissions.outputs.has_write_access == 'true' && steps.check-bug.outputs.should_analyze == 'true'
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.CLAUDE_GITHUB_TOKEN }}
-          model: "claude-sonnet-4-20250514"
+          claude_args: --model claude-sonnet-4-20250514
 
-          direct_prompt: |
+          prompt: |
             🤖 **Automated Follow-up Analysis**
 
             The user has responded to a bug report with additional information. Your job is to analyze their response and determine next steps.


### PR DESCRIPTION
## Summary
Updates all GitHub workflows to use the stable v1 release of the Claude Code Action instead of the beta version, and refactors the action configuration to use the new unified `claude_args` parameter format.

## Key Changes
- **Version upgrade**: Changed `anthropics/claude-code-action@beta` to `anthropics/claude-code-action@v1` across all workflow files
  - Updated in `claude-code-review.yml`
  - Updated in `claude.yml`
  - Updated in `issue-triage.yml` (3 occurrences)

- **Configuration refactoring**: Migrated from individual parameters to unified `claude_args` format
  - Replaced `direct_prompt` with `prompt` parameter
  - Replaced `model` parameter with `claude_args: --model <model-name>`
  - Replaced `allowed_tools` parameter with `claude_args: --allowedTools <tools>`
  - Replaced `custom_instructions` with `claude_args: --system-prompt <instructions>`

- **Documentation updates**: Updated README.md to reflect the new `prompt` parameter name in code examples

- **Cleanup**: Removed obsolete commented-out configuration examples and options that are no longer supported in v1

## Notable Details
- All model specifications now use the `claude_args` format (e.g., `--model claude-sonnet-4-20250514`)
- The new `prompt` parameter replaces the previous `direct_prompt` naming convention
- Maintained all existing functionality while adopting the new action API
- Preserved optional configuration comments for future customization

https://claude.ai/code/session_016hpUNfnwMmv7he3xLcSmEm