### PR TITLE
refactor: fix N+1 queries, timestamp units, and data integrity in neighbor info

### DIFF
--- a/src/db/repositories/neighbors.ts
+++ b/src/db/repositories/neighbors.ts
@@ -27,9 +27,11 @@ export class NeighborsRepository extends BaseRepository {
   }
 
   /**
-   * Insert or update neighbor info
+   * Insert a neighbor info record.
+   * Callers must delete old records for the node first to avoid duplicates
+   * (there is no unique constraint on nodeNum + neighborNodeNum).
    */
-  async upsertNeighborInfo(neighborData: DbNeighborInfo): Promise<void> {
+  async insertNeighborInfo(neighborData: DbNeighborInfo): Promise<void> {
     const { neighborInfo } = this.tables;
     const values = {
       nodeNum: neighborData.nodeNum,
@@ -41,6 +43,33 @@ export class NeighborsRepository extends BaseRepository {
     };
 
     await this.db.insert(neighborInfo).values(values);
+  }
+
+  /**
+   * Insert multiple neighbor info records in a single query.
+   * Callers must delete old records for the node first.
+   */
+  async insertNeighborInfoBatch(records: DbNeighborInfo[]): Promise<void> {
+    if (records.length === 0) return;
+    const { neighborInfo } = this.tables;
+    const values = records.map(r => ({
+      nodeNum: r.nodeNum,
+      neighborNodeNum: r.neighborNodeNum,
+      snr: r.snr ?? null,
+      lastRxTime: r.lastRxTime ?? null,
+      timestamp: r.timestamp,
+      createdAt: r.createdAt,
+    }));
+
+    await this.db.insert(neighborInfo).values(values);
+  }
+
+  /**
+   * Backwards-compatible alias for insertNeighborInfo
+   * @deprecated Use insertNeighborInfo instead
+   */
+  async upsertNeighborInfo(neighborData: DbNeighborInfo): Promise<void> {
+    return this.insertNeighborInfo(neighborData);
   }
 
   /**
@@ -73,14 +102,9 @@ export class NeighborsRepository extends BaseRepository {
   /**
    * Delete neighbor info for a node
    */
-  async deleteNeighborInfoForNode(nodeNum: number): Promise<number> {
+  async deleteNeighborInfoForNode(nodeNum: number): Promise<void> {
     const { neighborInfo } = this.tables;
-    const [{ deletedCount }] = await this.db
-      .select({ deletedCount: count() })
-      .from(neighborInfo)
-      .where(eq(neighborInfo.nodeNum, nodeNum));
     await this.db.delete(neighborInfo).where(eq(neighborInfo.nodeNum, nodeNum));
-    return deletedCount;
   }
 
   /**
@@ -93,14 +117,23 @@ export class NeighborsRepository extends BaseRepository {
   }
 
   /**
+   * Get neighbor count for a specific node
+   */
+  async getNeighborCountForNode(nodeNum: number): Promise<number> {
+    const { neighborInfo } = this.tables;
+    const result = await this.db
+      .select({ count: count() })
+      .from(neighborInfo)
+      .where(eq(neighborInfo.nodeNum, nodeNum));
+    return Number(result[0].count);
+  }
+
+  /**
    * Delete all neighbor info
    */
-  async deleteAllNeighborInfo(): Promise<number> {
+  async deleteAllNeighborInfo(): Promise<void> {
     const { neighborInfo } = this.tables;
-    const result = await this.db.select({ count: count() }).from(neighborInfo);
-    const deleteCount = Number(result[0].count);
     await this.db.delete(neighborInfo);
-    return deleteCount;
   }
 
   /**

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -43,6 +43,25 @@ export class NodesRepository extends BaseRepository {
   }
 
   /**
+   * Get multiple nodes by nodeNum in a single query
+   */
+  async getNodesByNums(nodeNums: number[]): Promise<Map<number, DbNode>> {
+    if (nodeNums.length === 0) return new Map();
+    const { nodes } = this.tables;
+    const result = await this.db
+      .select()
+      .from(nodes)
+      .where(inArray(nodes.nodeNum, nodeNums));
+
+    const map = new Map<number, DbNode>();
+    for (const row of result) {
+      const node = this.normalizeBigInts(row) as DbNode;
+      map.set(node.nodeNum, node);
+    }
+    return map;
+  }
+
+  /**
    * Get a node by nodeId
    */
   async getNodeByNodeId(nodeId: string): Promise<DbNode | null> {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5610,45 +5610,66 @@ class MeshtasticManager {
       }
 
       const senderHopsAway = senderNode?.hopsAway || 0;
-      const timestamp = Date.now();
+      const nowSeconds = Math.floor(Date.now() / 1000);
 
       // Process each neighbor in the list
       if (neighborInfo.neighbors && Array.isArray(neighborInfo.neighbors)) {
         logger.info(`📡 Processing ${neighborInfo.neighbors.length} neighbors from ${fromNodeId}`);
 
-        // Clear old neighbor info for this node before saving new data
-        // This ensures stale neighbors are removed when they drop from the mesh
-        await databaseService.neighbors.deleteNeighborInfoForNode(fromNum);
-
+        // Validate and collect neighbor node numbers upfront
+        const validNeighbors: Array<{ nodeNum: number; snr: number | null; lastRxTime: number | null }> = [];
         for (const neighbor of neighborInfo.neighbors) {
           const neighborNodeNum = Number(neighbor.nodeId);
-          const neighborNodeId = `!${neighborNodeNum.toString(16).padStart(8, '0')}`;
+          if (isNaN(neighborNodeNum) || neighborNodeNum <= 0) {
+            logger.warn(`⚠️ Skipping invalid neighbor nodeId from ${fromNodeId}: ${neighbor.nodeId}`);
+            continue;
+          }
+          validNeighbors.push({
+            nodeNum: neighborNodeNum,
+            snr: neighbor.snr != null ? Number(neighbor.snr) : null,
+            lastRxTime: neighbor.lastRxTime != null ? Number(neighbor.lastRxTime) : null,
+          });
+        }
 
-          // Check if neighbor node exists, if not create it with hopsAway = sender's hopsAway + 1
-          let neighborNode = await databaseService.nodes.getNode(neighborNodeNum);
-          if (!neighborNode) {
+        if (validNeighbors.length === 0) return;
+
+        // Batch-fetch all neighbor nodes in a single query to avoid N+1
+        const neighborNums = validNeighbors.map(n => n.nodeNum);
+        const existingNodes = await databaseService.nodes.getNodesByNums(neighborNums);
+
+        // Create placeholder nodes for any neighbors not yet in the database
+        for (const vn of validNeighbors) {
+          if (!existingNodes.has(vn.nodeNum)) {
+            const neighborNodeId = `!${vn.nodeNum.toString(16).padStart(8, '0')}`;
             await databaseService.nodes.upsertNode({
-              nodeNum: neighborNodeNum,
+              nodeNum: vn.nodeNum,
               nodeId: neighborNodeId,
               longName: `Node ${neighborNodeId}`,
               shortName: neighborNodeId.slice(-4),
               hopsAway: senderHopsAway + 1,
-              lastHeard: Date.now() / 1000
+              lastHeard: nowSeconds
             });
             logger.info(`➕ Created new node ${neighborNodeId} with hopsAway=${senderHopsAway + 1}`);
           }
+        }
 
-          // Save the neighbor relationship
-          await databaseService.neighbors.upsertNeighborInfo({
-            nodeNum: fromNum,
-            neighborNodeNum: neighborNodeNum,
-            snr: neighbor.snr ? Number(neighbor.snr) : null,
-            lastRxTime: neighbor.lastRxTime ? Number(neighbor.lastRxTime) : null,
-            timestamp: timestamp,
-            createdAt: Date.now()
-          });
+        // Delete old neighbors then batch-insert new ones
+        await databaseService.neighbors.deleteNeighborInfoForNode(fromNum);
 
-          logger.info(`🔗 Saved neighbor: ${fromNodeId} -> ${neighborNodeId}, SNR: ${neighbor.snr || 'N/A'}`);
+        const records = validNeighbors.map(vn => ({
+          nodeNum: fromNum,
+          neighborNodeNum: vn.nodeNum,
+          snr: vn.snr,
+          lastRxTime: vn.lastRxTime,
+          timestamp: nowSeconds,
+          createdAt: nowSeconds,
+        }));
+
+        await databaseService.neighbors.insertNeighborInfoBatch(records);
+
+        for (const vn of validNeighbors) {
+          const neighborNodeId = `!${vn.nodeNum.toString(16).padStart(8, '0')}`;
+          logger.debug(`🔗 Saved neighbor: ${fromNodeId} -> ${neighborNodeId}, SNR: ${vn.snr ?? 'N/A'}`);
         }
       }
     } catch (error) {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -7568,10 +7568,11 @@ class DatabaseService {
     this._neighborsByNodeCache.delete(nodeNum);
     this._neighborsCache = this._neighborsCache.filter(n => n.nodeNum !== nodeNum);
 
-    // Delete from database
-    const deleted = await this.neighbors.deleteNeighborInfoForNode(nodeNum);
-    logger.info(`Deleted ${deleted} neighbor records for node ${nodeNum}`);
-    return deleted;
+    // Count then delete from database
+    const count = await this.neighbors.getNeighborCountForNode(nodeNum);
+    await this.neighbors.deleteNeighborInfoForNode(nodeNum);
+    logger.info(`Deleted ${count} neighbor records for node ${nodeNum}`);
+    return count;
   }
 
   // Favorite operations


### PR DESCRIPTION
## Summary

- **Fix timestamp units**: `processNeighborInfoProtobuf` was storing `Date.now()` (milliseconds) while all other timestamps in the codebase use Unix seconds. This would prevent stale-data purges from ever firing since the stored values are 1000x larger than the seconds-based cutoffs
- **Eliminate N+1 query storm**: Add `getNodesByNums()` batch method to nodes repository — fetches all neighbor nodes in a single `WHERE nodeNum IN (...)` query. Reduces per-message queries from 4+3N (23+ for 10 neighbors) to ~5 total
- **Batch INSERT for neighbor records**: New `insertNeighborInfoBatch()` inserts all neighbor rows in a single multi-value INSERT instead of N individual INSERTs
- **Validate neighbor fields**: Skip neighbors with invalid `nodeId` (NaN, ≤ 0) with a warning log, preventing bad data writes to DB
- **Per-neighbor log changed to DEBUG**: Was INFO — with 100 nodes × 10 neighbors = 1,000+ log lines per cycle. Summary log at INFO level is sufficient
- **Rename `upsertNeighborInfo` → `insertNeighborInfo`**: The method was a plain INSERT, not an upsert. Backwards-compatible alias kept
- **Remove unnecessary SELECT COUNT before DELETE**: `deleteNeighborInfoForNode` was doing two queries when one suffices. Added separate `getNeighborCountForNode()` for callers that need the count

## Test plan

- [x] All 411 meshtasticManager tests pass (15 test files)
- [x] TypeScript compilation clean
- [x] Deployed to both production instances (qmic + qshd), watched logs for 5 minutes — no errors
- [x] No NeighborInfo broadcasts arrived during the test window (normal — broadcasts are hourly/multi-hourly), but all other packet processing worked correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)