### PR TITLE
ci: add PostgreSQL service to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-release
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: meshmonitor_test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     strategy:
       matrix:
         node-version: [20.x, 22.x, 24.x]


### PR DESCRIPTION
Release Pipeline failed on v3.10.0-RC1 because PostgreSQL wasn't configured as a service container. Added the same postgres:16 service block used in ci.yml and pr-tests.yml.

🤖 Generated with [Claude Code](https://claude.ai/code)