### PR TITLE
fix: coerce admin keys to strings in ConfigurationTab (#2353)

### DIFF
--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -695,9 +695,22 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
         // Populate Security config
         if (config.deviceConfig?.security) {
           const sec = config.deviceConfig.security;
-          // Admin keys come as base64 strings
+          // Admin keys may come as base64 strings, Buffer-like objects, or byte arrays
+          // from the raw config endpoint — coerce all to strings for the UI
           if (sec.adminKey && Array.isArray(sec.adminKey)) {
-            setSecurityAdminKeys(sec.adminKey.length > 0 ? sec.adminKey : ['']);
+            const keys = sec.adminKey.map((key: any) => {
+              if (typeof key === 'string') return key;
+              // Handle JSON-serialized Buffer: { type: 'Buffer', data: [...] }
+              if (key && typeof key === 'object' && key.type === 'Buffer' && Array.isArray(key.data)) {
+                return btoa(String.fromCharCode(...key.data));
+              }
+              // Handle plain byte arrays
+              if (Array.isArray(key)) {
+                return btoa(String.fromCharCode(...key));
+              }
+              return String(key);
+            });
+            setSecurityAdminKeys(keys.length > 0 ? keys : ['']);
           }
           setSecurityIsManaged(sec.isManaged || false);
           setSecuritySerialEnabled(sec.serialEnabled !== false); // Default to true


### PR DESCRIPTION
## Summary

Fixes #2353 — "ne.trim is not a function" crash on Configuration page.

- **Root cause**: The `/api/config/current` endpoint returns raw protobuf admin keys as serialized Buffer objects (`{type:'Buffer', data:[...]}`) rather than base64 strings. `SecurityConfigSection` calls `.trim()` on these values during render, which crashes because they're objects, not strings.
- **Fix**: Convert admin keys to base64 strings when loading from the raw config endpoint in `ConfigurationTab.tsx`, matching the conversion already done by the formatted `/api/device/config/security` endpoint.
- Only affects users who have admin keys configured on their device.

## Test plan

- [ ] Configure admin keys on a device, load Configuration tab — should not crash
- [ ] Verify admin keys display correctly as base64 strings
- [ ] Save and reload — keys should persist
- [ ] Full test suite passes (2987 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)