### PR TITLE
fix: clear key mismatch warning after successful purge resolution (#2349)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -4358,33 +4358,38 @@ class MeshtasticManager {
           }
         }
 
-        // Existing block — only runs for PKI-error-based mismatches, NOT our proactive detection
+        // Clear mismatch flag when keys now match (post-purge resolution)
+        // or when a new key arrives (PKI-error-based resolution)
         if (!newMismatchDetected) {
           if (existingNode && existingNode.keyMismatchDetected) {
             const oldKey = existingNode.publicKey;
             const newKey = nodeData.publicKey;
 
             if (oldKey !== newKey) {
-              // Key has changed - the mismatch is fixed!
+              // Key has changed - the mismatch is fixed via new key
               logger.info(`🔐 Key mismatch RESOLVED for node ${nodeId} (${user.longName}) - received new key`);
-              nodeData.keyMismatchDetected = false;
-              nodeData.lastMeshReceivedKey = undefined;
-              // Don't clear keySecurityIssueDetails if there's a low-entropy issue
-              if (!isLowEntropy) {
-                nodeData.keySecurityIssueDetails = undefined;
-              }
-
-              // Clear the repair state and log success
-              databaseService.clearKeyRepairStateAsync(fromNum);
-              const nodeName = user.longName || user.shortName || nodeId;
-              databaseService.logKeyRepairAttemptAsync(fromNum, nodeName, 'fixed', true);
-
-              // Emit update to UI
-              dataEventEmitter.emitNodeUpdate(fromNum, {
-                keyMismatchDetected: false,
-                keySecurityIssueDetails: isLowEntropy ? nodeData.keySecurityIssueDetails : undefined
-              });
+            } else {
+              // Keys now match - the mismatch was fixed (e.g., device re-synced after purge)
+              logger.info(`🔐 Key mismatch RESOLVED for node ${nodeId} (${user.longName}) - keys now match`);
             }
+
+            nodeData.keyMismatchDetected = false;
+            nodeData.lastMeshReceivedKey = undefined;
+            // Don't clear keySecurityIssueDetails if there's a low-entropy issue
+            if (!isLowEntropy) {
+              nodeData.keySecurityIssueDetails = undefined;
+            }
+
+            // Clear the repair state and log success
+            databaseService.clearKeyRepairStateAsync(fromNum);
+            const nodeName = user.longName || user.shortName || nodeId;
+            databaseService.logKeyRepairAttemptAsync(fromNum, nodeName, 'fixed', true);
+
+            // Emit update to UI
+            dataEventEmitter.emitNodeUpdate(fromNum, {
+              keyMismatchDetected: false,
+              keySecurityIssueDetails: isLowEntropy ? nodeData.keySecurityIssueDetails : undefined
+            });
           }
         }
       }


### PR DESCRIPTION
## Summary

Fixes #2349 — the key mismatch warning persisted indefinitely even after a successful key exchange.

### Root Cause

After a successful immediate purge + NodeInfo exchange:
1. The device re-syncs and updates the stored key to match the mesh-received key
2. Next time mesh NodeInfo arrives, `existingNode.publicKey === nodeData.publicKey` (keys match), so the mismatch detection block at line 4311 is skipped
3. The clearing block at line 4362 runs, but `oldKey !== newKey` is **false** (keys already match), so it never clears the flag
4. `keyMismatchDetected` stays `true` forever in the database

### Fix

Remove the `oldKey !== newKey` gate on the clearing block. If `keyMismatchDetected` is true and we're not seeing a new mismatch, clear it regardless — keys matching means the mismatch is resolved.

## Files Changed

| File | Change |
|------|--------|
| `src/server/meshtasticManager.ts` | Clear `keyMismatchDetected` when keys match (post-purge) in addition to when a new key arrives |

## Test plan

- [x] 3052 tests pass, 0 failures
- [x] Logic handles both resolution paths: new key arrives (oldKey !== newKey) and keys stabilized (oldKey === newKey)

🤖 Generated with [Claude Code](https://claude.com/claude-code)