### PR TITLE
fix: resolve traceroute race condition for fast-responding nodes (#2364)

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -5314,48 +5314,45 @@ class DatabaseService {
     }
   }
 
-  recordTracerouteRequest(fromNodeNum: number, toNodeNum: number): void {
+  async recordTracerouteRequest(fromNodeNum: number, toNodeNum: number): Promise<void> {
     const now = Date.now();
 
     // For PostgreSQL/MySQL, use async repository
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      // Fire async operations
-      (async () => {
-        try {
-          // Update the nodes table with last request time
-          if (this.nodesRepo) {
-            await this.nodesRepo.updateNodeLastTracerouteRequest(toNodeNum, now);
-          }
-
-          // Insert a pending traceroute record
-          if (this.traceroutesRepo) {
-            const fromNodeId = `!${fromNodeNum.toString(16).padStart(8, '0')}`;
-            const toNodeId = `!${toNodeNum.toString(16).padStart(8, '0')}`;
-
-            await this.traceroutesRepo.insertTraceroute({
-              fromNodeNum,
-              toNodeNum,
-              fromNodeId,
-              toNodeId,
-              route: null,  // null for pending (findPendingTraceroute checks for isNull)
-              routeBack: null,
-              snrTowards: null,
-              snrBack: null,
-              timestamp: now,
-              createdAt: now,
-            });
-
-            // Cleanup old traceroutes
-            await this.traceroutesRepo.cleanupOldTraceroutesForPair(
-              fromNodeNum,
-              toNodeNum,
-              TRACEROUTE_HISTORY_LIMIT
-            );
-          }
-        } catch (error) {
-          logger.error('[DatabaseService] Failed to record traceroute request:', error);
+      try {
+        // Update the nodes table with last request time
+        if (this.nodesRepo) {
+          await this.nodesRepo.updateNodeLastTracerouteRequest(toNodeNum, now);
         }
-      })();
+
+        // Insert a pending traceroute record
+        if (this.traceroutesRepo) {
+          const fromNodeId = `!${fromNodeNum.toString(16).padStart(8, '0')}`;
+          const toNodeId = `!${toNodeNum.toString(16).padStart(8, '0')}`;
+
+          await this.traceroutesRepo.insertTraceroute({
+            fromNodeNum,
+            toNodeNum,
+            fromNodeId,
+            toNodeId,
+            route: null,  // null for pending (findPendingTraceroute checks for isNull)
+            routeBack: null,
+            snrTowards: null,
+            snrBack: null,
+            timestamp: now,
+            createdAt: now,
+          });
+
+          // Cleanup old traceroutes
+          await this.traceroutesRepo.cleanupOldTraceroutesForPair(
+            fromNodeNum,
+            toNodeNum,
+            TRACEROUTE_HISTORY_LIMIT
+          );
+        }
+      } catch (error) {
+        logger.error('[DatabaseService] Failed to record traceroute request:', error);
+      }
       return;
     }
 
@@ -10206,7 +10203,7 @@ class DatabaseService {
 
   // Group 4: Traceroutes
   async recordTracerouteRequestAsync(fromNodeNum: number, toNodeNum: number): Promise<void> {
-    this.recordTracerouteRequest(fromNodeNum, toNodeNum);
+    await this.recordTracerouteRequest(fromNodeNum, toNodeNum);
   }
 
   async getAllTraceroutesForRecalculationAsync(): Promise<any[]> {


### PR DESCRIPTION
## Summary

Fixes #2364 — traceroutes showed "No response received" for nearby/fast-responding nodes despite the response being visible in logs and packet monitor.

### Root Cause

`recordTracerouteRequest()` for PostgreSQL/MySQL fired an **un-awaited async IIFE** to insert the pending traceroute record. For nearby nodes, the traceroute response arrived before the DB insert completed:

1. `sendTraceroute()` → sends packet, calls `await recordTracerouteRequestAsync()`
2. But the async wrapper called the inner method **without await** → returned immediately
3. Fast response arrives → `processTracerouteMessage()` runs
4. DB insert for the pending record is still in flight
5. Frontend reads stale DB state → shows "No response received"

### Fix

Made `recordTracerouteRequest()` properly async — removed the fire-and-forget IIFE and directly awaits the DB operations. The async wrapper now correctly awaits the inner method.

## Files Changed

| File | Change |
|------|--------|
| `src/services/database.ts` | Make `recordTracerouteRequest` async, remove un-awaited IIFE, await in async wrapper |

## Test plan

- [x] 3052 tests pass, 0 failures
- [x] SQLite path unchanged (already synchronous)
- [x] PostgreSQL/MySQL path now properly awaited

🤖 Generated with [Claude Code](https://claude.com/claude-code)