### PR TITLE
fix: packet monitor ordering now considers milliseconds (#2364)

### DIFF
--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -970,7 +970,7 @@ export class MiscRepository extends BaseRepository {
           LEFT JOIN nodes from_nodes ON pl.from_node = from_nodes."nodeNum"
           LEFT JOIN nodes to_nodes ON pl.to_node = to_nodes."nodeNum"
           WHERE ${whereClause}
-          ORDER BY pl.timestamp DESC LIMIT ${limit} OFFSET ${offset}
+          ORDER BY pl.timestamp DESC, pl.created_at DESC LIMIT ${limit} OFFSET ${offset}
         `;
       } else {
         joinQuery = sql`
@@ -979,7 +979,7 @@ export class MiscRepository extends BaseRepository {
           LEFT JOIN nodes from_nodes ON pl.from_node = from_nodes.nodeNum
           LEFT JOIN nodes to_nodes ON pl.to_node = to_nodes.nodeNum
           WHERE ${whereClause}
-          ORDER BY pl.timestamp DESC LIMIT ${limit} OFFSET ${offset}
+          ORDER BY pl.timestamp DESC, pl.created_at DESC LIMIT ${limit} OFFSET ${offset}
         `;
       }
 


### PR DESCRIPTION
## Summary

Fixes the second part of #2364 — packet monitor ordering didn't consider milliseconds, so packets within the same second appeared in wrong order.

### Root Cause

The `packet_log` query used `ORDER BY pl.timestamp DESC` but `timestamp` is whole seconds (from Meshtastic protobuf `rxTime`). Packets arriving within the same second had undefined relative order.

### Fix

Added `pl.created_at DESC` as a secondary sort key. `created_at` is already stored as `Date.now()` (millisecond precision) on every packet insert, but wasn't used in the sort. Applied to both PostgreSQL and SQLite/MySQL query paths.

## Files Changed

| File | Change |
|------|--------|
| `src/db/repositories/misc.ts` | Add `created_at DESC` tiebreaker to both packet_log ORDER BY clauses |

## Test plan

- [x] 3052 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)