### PR TITLE
docs: add TechTucson BBS and Mail scripts to user scripts gallery

### DIFF
--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -597,5 +597,49 @@
       "Persistent state file for cross-run tracking",
       "Configurable per-node monitoring via MM_NODE_IDS"
     ]
+  },
+  {
+    "name": "Mesh DM BBS",
+    "filename": "bbs.py",
+    "icon": "📡",
+    "description": "Lightweight Meshtastic DM bulletin board system for low-bandwidth LoRa networks. Supports multiple boards with optional password protection, paginated reading, post management, and admin override. Stores state in JSON files.",
+    "language": "Python",
+    "tags": ["BBS", "Bulletin Board", "Messaging", "Community", "DM"],
+    "githubPath": "TechTucson/MeshMonitor-BBS-AND-MAIL/bbs.py",
+    "exampleTrigger": "bbs help, bbs boards, bbs read <board>, bbs post <board> <subject> | <message>",
+    "requirements": [
+      "Python 3 (included in MeshMonitor)",
+      "/data/bbs/ directory (created automatically)"
+    ],
+    "author": "TechTucson",
+    "features": [
+      "Multiple boards with optional password protection",
+      "Post, read, and delete messages",
+      "Paginated output for long listings",
+      "Admin override password for moderation",
+      "Persistent JSON storage in /data/bbs/"
+    ]
+  },
+  {
+    "name": "Mesh Mail Bot",
+    "filename": "mail.py",
+    "icon": "✉️",
+    "description": "Private DM-only mail system for Meshtastic nodes. Send, check, read, and delete mail between node IDs. Features receiver-only access controls and admin purge capability. Stores mail in JSON files.",
+    "language": "Python",
+    "tags": ["Mail", "Messaging", "DM", "Private", "Communication"],
+    "githubPath": "TechTucson/MeshMonitor-BBS-AND-MAIL/mail.py",
+    "exampleTrigger": "mail help, mail send <!node_id> <subject> | <message>, mail check, mail read <id>",
+    "requirements": [
+      "Python 3 (included in MeshMonitor)",
+      "/data/mail/ directory (created automatically)"
+    ],
+    "author": "TechTucson",
+    "features": [
+      "Send private mail between node IDs",
+      "Inbox check and read with pagination",
+      "Receiver-only access controls",
+      "Admin purge with override password",
+      "Persistent JSON storage in /data/mail/"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Adds two community-contributed scripts from [TechTucson/MeshMonitor-BBS-AND-MAIL](https://github.com/TechTucson/MeshMonitor-BBS-AND-MAIL) to the user scripts gallery:

- **Mesh DM BBS** - Lightweight bulletin board system with multiple boards, password protection, pagination, and admin moderation
- **Mesh Mail Bot** - Private DM mail system for sending/receiving mail between node IDs with receiver-only access controls

## Files Changed

| File | Change |
|------|--------|
| `docs/.vitepress/data/user-scripts.json` | Add 2 new script entries |

🤖 Generated with [Claude Code](https://claude.com/claude-code)