### PR TITLE
refactor: add getAffectedRows() helper to eliminate result extraction branching

### DIFF
--- a/src/db/repositories/auth.ts
+++ b/src/db/repositories/auth.ts
@@ -523,79 +523,30 @@ export class AuthRepository extends BaseRepository {
   async revokeApiToken(tokenId: number, revokedBy: number): Promise<boolean> {
     const now = this.now();
     const { apiTokens } = this.tables;
-    if (this.isSQLite()) {
-      const db = this.getSqliteDb();
-      const result = await db
-        .update(apiTokens)
-        .set({ isActive: false, revokedAt: now, revokedBy })
-        .where(and(
-          eq(apiTokens.id, tokenId),
-          eq(apiTokens.isActive, true)
-        ));
-      return (result.changes ?? 0) > 0;
-    } else if (this.isMySQL()) {
-      const db = this.getMysqlDb();
-      const result = await db
-        .update(apiTokens)
-        .set({ isActive: false, revokedAt: now, revokedBy })
-        .where(and(
-          eq(apiTokens.id, tokenId),
-          eq(apiTokens.isActive, true)
-        ));
-      return (result[0].affectedRows ?? 0) > 0;
-    } else {
-      const db = this.getPostgresDb();
-      const result = await db
-        .update(apiTokens)
-        .set({ isActive: false, revokedAt: now, revokedBy })
-        .where(and(
-          eq(apiTokens.id, tokenId),
-          eq(apiTokens.isActive, true)
-        ))
-        .returning({ id: apiTokensPostgres.id });
-      return result.length > 0;
-    }
+    const result = await this.db
+      .update(apiTokens)
+      .set({ isActive: false, revokedAt: now, revokedBy })
+      .where(and(
+        eq(apiTokens.id, tokenId),
+        eq(apiTokens.isActive, true)
+      ));
+    return this.getAffectedRows(result) > 0;
   }
 
   /**
    * Revoke all active API tokens for a user.
-   * Keeps branching: different result shapes for affected row count.
    */
   async revokeAllUserApiTokens(userId: number, revokedBy: number): Promise<number> {
     const now = this.now();
     const { apiTokens } = this.tables;
-    if (this.isSQLite()) {
-      const db = this.getSqliteDb();
-      const result = await db
-        .update(apiTokens)
-        .set({ isActive: false, revokedAt: now, revokedBy })
-        .where(and(
-          eq(apiTokens.userId, userId),
-          eq(apiTokens.isActive, true)
-        ));
-      return result.changes ?? 0;
-    } else if (this.isMySQL()) {
-      const db = this.getMysqlDb();
-      const result = await db
-        .update(apiTokens)
-        .set({ isActive: false, revokedAt: now, revokedBy })
-        .where(and(
-          eq(apiTokens.userId, userId),
-          eq(apiTokens.isActive, true)
-        ));
-      return result[0].affectedRows ?? 0;
-    } else {
-      const db = this.getPostgresDb();
-      const result = await db
-        .update(apiTokens)
-        .set({ isActive: false, revokedAt: now, revokedBy })
-        .where(and(
-          eq(apiTokens.userId, userId),
-          eq(apiTokens.isActive, true)
-        ))
-        .returning({ id: apiTokensPostgres.id });
-      return result.length;
-    }
+    const result = await this.db
+      .update(apiTokens)
+      .set({ isActive: false, revokedAt: now, revokedBy })
+      .where(and(
+        eq(apiTokens.userId, userId),
+        eq(apiTokens.isActive, true)
+      ));
+    return this.getAffectedRows(result);
   }
 
   /**

--- a/src/db/repositories/base.ts
+++ b/src/db/repositories/base.ts
@@ -156,6 +156,22 @@ export abstract class BaseRepository {
   }
 
   /**
+   * Extract affected row count from a mutation result.
+   * Normalizes across SQLite (.changes), PostgreSQL (.rowCount), and MySQL ([0].affectedRows).
+   */
+  protected getAffectedRows(result: any): number {
+    if (this.isSQLite()) {
+      return Number(result?.changes ?? 0);
+    }
+    if (this.isMySQL()) {
+      // MySQL execute() returns [ResultSetHeader, FieldPacket[]]
+      return Number((result as any)?.[0]?.affectedRows ?? 0);
+    }
+    // PostgreSQL
+    return Number((result as any)?.rowCount ?? 0);
+  }
+
+  /**
    * Get current timestamp in milliseconds
    */
   protected now(): number {

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -51,31 +51,21 @@ export class MessagesRepository extends BaseRepository {
       decryptedBy: messageData.decryptedBy ?? null,
     };
 
-    if (this.isSQLite()) {
-      const db = this.getSqliteDb();
-      const result = await db
+    let result: any;
+    if (this.isMySQL()) {
+      // MySQL uses onDuplicateKeyUpdate as equivalent of onConflictDoNothing
+      result = await this.getMysqlDb()
         .insert(messages)
         .values(values)
-        .onConflictDoNothing();
-      // SQLite Drizzle returns { changes: number } - 0 means conflict (no insert)
-      return (result as any).changes > 0;
-    } else if (this.isMySQL()) {
-      const db = this.getMysqlDb();
-      const result = await db
-        .insert(messages)
-        .values(values)
-        .onDuplicateKeyUpdate({ set: { id: messageData.id } }); // MySQL equivalent of onConflictDoNothing
-      // MySQL returns affectedRows: 1 for insert, 0 for duplicate with same values
-      return (result as any)[0]?.affectedRows > 0;
+        .onDuplicateKeyUpdate({ set: { id: messageData.id } });
     } else {
-      const db = this.getPostgresDb();
-      const result = await db
+      // SQLite and PostgreSQL both support onConflictDoNothing
+      result = await this.db
         .insert(messages)
         .values(values)
         .onConflictDoNothing();
-      // PostgreSQL returns rowCount: 0 on conflict
-      return (result as any).rowCount > 0;
     }
+    return this.getAffectedRows(result) > 0;
   }
 
   /**

--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -1030,14 +1030,7 @@ export class MiscRepository extends BaseRepository {
   async clearPacketLogs(): Promise<number> {
     try {
       const results = await this.executeRun(sql`DELETE FROM packet_log`);
-      let deletedCount: number;
-      if (this.isMySQL()) {
-        deletedCount = (results as any)[0]?.affectedRows ?? 0;
-      } else if (this.isPostgres()) {
-        deletedCount = (results as any).rowCount ?? 0;
-      } else {
-        deletedCount = (results as any).changes ?? (results as any).rowsAffected ?? 0;
-      }
+      const deletedCount = this.getAffectedRows(results);
       logger.debug(`[MiscRepository] Cleared ${deletedCount} packet log entries`);
       return deletedCount;
     } catch (error) {
@@ -1056,14 +1049,7 @@ export class MiscRepository extends BaseRepository {
       const results = await this.executeRun(
         sql`DELETE FROM packet_log WHERE timestamp < ${cutoffTimestamp}`
       );
-      let deleted: number;
-      if (this.isMySQL()) {
-        deleted = (results as any)[0]?.affectedRows ?? 0;
-      } else if (this.isPostgres()) {
-        deleted = (results as any).rowCount ?? 0;
-      } else {
-        deleted = (results as any).changes ?? (results as any).rowsAffected ?? 0;
-      }
+      const deleted = this.getAffectedRows(results);
       if (deleted > 0) {
         logger.debug(`[MiscRepository] Cleaned up ${deleted} packet log entries older than ${maxAgeHours} hours`);
       }


### PR DESCRIPTION
## Summary

Phase 2 of the Drizzle refactor — adds `BaseRepository.getAffectedRows(result)` helper that normalizes affected row counts across all three database backends.

### The helper
```typescript
protected getAffectedRows(result: any): number {
  // SQLite: result.changes
  // PostgreSQL: result.rowCount
  // MySQL: result[0].affectedRows
}
```

### Methods simplified

| File | Method | Before | After |
|------|--------|--------|-------|
| `misc.ts` | `clearPacketLogs` | 8-line 3-way branch | 1 line |
| `misc.ts` | `cleanupOldPacketLogs` | 8-line 3-way branch | 1 line |
| `auth.ts` | `deactivateApiToken` | 3 typed-db paths (33 lines) | Single `this.db` path (10 lines) |
| `auth.ts` | `revokeAllUserApiTokens` | 3 typed-db paths (33 lines) | Single `this.db` path (10 lines) |
| `messages.ts` | `insertMessage` | 3 typed-db paths | MySQL branch + shared path |

### Not changed (yet)
`notifications.ts` methods use a different pattern where MySQL results are already destructured from the tuple. These need a different approach and are deferred.

## Files Changed

| File | Change |
|------|--------|
| `src/db/repositories/base.ts` | Add `getAffectedRows()` helper |
| `src/db/repositories/misc.ts` | Simplify 2 methods |
| `src/db/repositories/auth.ts` | Simplify 2 methods from 3-way to single path |
| `src/db/repositories/messages.ts` | Simplify insertMessage result extraction |

## Test plan

- [x] 3061 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)