### PR TITLE
refactor: add upsert() and insertIgnore() helpers to eliminate conflict handling duplication

### DIFF
--- a/src/db/repositories/auth.ts
+++ b/src/db/repositories/auth.ts
@@ -683,28 +683,10 @@ export class AuthRepository extends BaseRepository {
 
   /**
    * Set session (upsert).
-   * Keeps branching: MySQL uses onDuplicateKeyUpdate vs onConflictDoUpdate.
    */
   async setSession(sid: string, sess: string, expire: number): Promise<void> {
     const { sessions } = this.tables;
-    if (this.isMySQL()) {
-      const db = this.getMysqlDb();
-      await db
-        .insert(sessions)
-        .values({ sid, sess, expire })
-        .onDuplicateKeyUpdate({
-          set: { sess, expire },
-        });
-    } else {
-      // SQLite and PostgreSQL both use onConflictDoUpdate
-      await (this.db as any)
-        .insert(sessions)
-        .values({ sid, sess, expire })
-        .onConflictDoUpdate({
-          target: sessions.sid,
-          set: { sess, expire },
-        });
-    }
+    await this.upsert(sessions, { sid, sess, expire }, sessions.sid, { sess, expire });
   }
 
   /**

--- a/src/db/repositories/base.ts
+++ b/src/db/repositories/base.ts
@@ -172,6 +172,51 @@ export abstract class BaseRepository {
   }
 
   /**
+   * Insert with upsert (ON CONFLICT DO UPDATE / ON DUPLICATE KEY UPDATE).
+   * Normalizes across SQLite/PostgreSQL (onConflictDoUpdate) and MySQL (onDuplicateKeyUpdate).
+   *
+   * @param table - Drizzle table from this.tables
+   * @param values - Row values to insert
+   * @param target - Conflict target column (for SQLite/PG onConflictDoUpdate)
+   * @param updateSet - Columns to update on conflict
+   */
+  protected async upsert(table: any, values: any, target: any, updateSet: any): Promise<any> {
+    if (this.isMySQL()) {
+      return this.getMysqlDb()
+        .insert(table)
+        .values(values)
+        .onDuplicateKeyUpdate({ set: updateSet });
+    }
+    return (this.db as any)
+      .insert(table)
+      .values(values)
+      .onConflictDoUpdate({ target, set: updateSet });
+  }
+
+  /**
+   * Insert and ignore duplicates (ON CONFLICT DO NOTHING).
+   * Normalizes across SQLite/PostgreSQL (onConflictDoNothing) and MySQL (try/catch).
+   *
+   * @param table - Drizzle table from this.tables
+   * @param values - Row values to insert
+   * @returns The raw insert result
+   */
+  protected async insertIgnore(table: any, values: any): Promise<any> {
+    if (this.isMySQL()) {
+      // MySQL lacks onConflictDoNothing — use try/catch to swallow duplicate key errors
+      try {
+        return await this.db.insert(table).values(values);
+      } catch {
+        return null;
+      }
+    }
+    return (this.db as any)
+      .insert(table)
+      .values(values)
+      .onConflictDoNothing();
+  }
+
+  /**
    * Get current timestamp in milliseconds
    */
   protected now(): number {

--- a/src/db/repositories/ignoredNodes.ts
+++ b/src/db/repositories/ignoredNodes.ts
@@ -46,22 +46,12 @@ export class IgnoredNodesRepository extends BaseRepository {
       ignoredBy: ignoredBy ?? null,
     };
 
-    if (this.isMySQL()) {
-      const db = this.getMysqlDb();
-      await db
-        .insert(ignoredNodes)
-        .values({ nodeNum, ...setData })
-        .onDuplicateKeyUpdate({ set: setData });
-    } else {
-      // SQLite and PostgreSQL both use onConflictDoUpdate
-      await (this.db as any)
-        .insert(ignoredNodes)
-        .values({ nodeNum, ...setData })
-        .onConflictDoUpdate({
-          target: ignoredNodes.nodeNum,
-          set: setData,
-        });
-    }
+    await this.upsert(
+      ignoredNodes,
+      { nodeNum, ...setData },
+      ignoredNodes.nodeNum,
+      setData,
+    );
 
     logger.debug(`Added node ${nodeNum} (${nodeId}) to persistent ignore list`);
   }

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -51,20 +51,7 @@ export class MessagesRepository extends BaseRepository {
       decryptedBy: messageData.decryptedBy ?? null,
     };
 
-    let result: any;
-    if (this.isMySQL()) {
-      // MySQL uses onDuplicateKeyUpdate as equivalent of onConflictDoNothing
-      result = await this.getMysqlDb()
-        .insert(messages)
-        .values(values)
-        .onDuplicateKeyUpdate({ set: { id: messageData.id } });
-    } else {
-      // SQLite and PostgreSQL both support onConflictDoNothing
-      result = await this.db
-        .insert(messages)
-        .values(values)
-        .onConflictDoNothing();
-    }
+    const result = await this.insertIgnore(messages, values);
     return this.getAffectedRows(result) > 0;
   }
 

--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -110,22 +110,7 @@ export class MiscRepository extends BaseRepository {
       fetched_at: estimate.fetched_at,
     };
 
-    if (this.isMySQL()) {
-      const db = this.getMysqlDb();
-      await db
-        .insert(solarEstimates)
-        .values(values)
-        .onDuplicateKeyUpdate({ set: setData });
-    } else {
-      // SQLite and PostgreSQL both use onConflictDoUpdate
-      await (this.db as any)
-        .insert(solarEstimates)
-        .values(values)
-        .onConflictDoUpdate({
-          target: solarEstimates.timestamp,
-          set: setData,
-        });
-    }
+    await this.upsert(solarEstimates, values, solarEstimates.timestamp, setData);
   }
 
   /**
@@ -198,22 +183,7 @@ export class MiscRepository extends BaseRepository {
     const now = this.now();
     const { autoTracerouteNodes } = this.tables;
 
-    if (this.isMySQL()) {
-      // MySQL doesn't have onConflictDoNothing, use try/catch
-      try {
-        await this.db
-          .insert(autoTracerouteNodes)
-          .values({ nodeNum, createdAt: now });
-      } catch {
-        // Ignore duplicate key errors
-      }
-    } else {
-      // SQLite and PostgreSQL support onConflictDoNothing
-      await (this.db as any)
-        .insert(autoTracerouteNodes)
-        .values({ nodeNum, createdAt: now })
-        .onConflictDoNothing();
-    }
+    await this.insertIgnore(autoTracerouteNodes, { nodeNum, createdAt: now });
   }
 
   /**
@@ -584,22 +554,7 @@ export class MiscRepository extends BaseRepository {
     const now = this.now();
     const { autoTimeSyncNodes } = this.tables;
 
-    if (this.isMySQL()) {
-      // MySQL doesn't have onConflictDoNothing, use try/catch
-      try {
-        await this.db
-          .insert(autoTimeSyncNodes)
-          .values({ nodeNum, createdAt: now });
-      } catch {
-        // Ignore duplicate key errors
-      }
-    } else {
-      // SQLite and PostgreSQL support onConflictDoNothing
-      await (this.db as any)
-        .insert(autoTimeSyncNodes)
-        .values({ nodeNum, createdAt: now })
-        .onConflictDoNothing();
-    }
+    await this.insertIgnore(autoTimeSyncNodes, { nodeNum, createdAt: now });
   }
 
   /**

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -257,18 +257,7 @@ export class NodesRepository extends BaseRepository {
         updatedAt: now,
       };
 
-      if (this.isMySQL()) {
-        const db = this.getMysqlDb();
-        await db.insert(nodes).values(newNode).onDuplicateKeyUpdate({
-          set: upsertSet,
-        });
-      } else {
-        // SQLite and PostgreSQL both use onConflictDoUpdate
-        await (this.db as any).insert(nodes).values(newNode).onConflictDoUpdate({
-          target: nodes.nodeNum,
-          set: upsertSet,
-        });
-      }
+      await this.upsert(nodes, newNode, nodes.nodeNum, upsertSet);
     }
   }
 

--- a/src/db/repositories/notifications.ts
+++ b/src/db/repositories/notifications.ts
@@ -129,22 +129,7 @@ export class NotificationsRepository extends BaseRepository {
       lastUsedAt: now,
     };
 
-    if (this.isMySQL()) {
-      const db = this.getMysqlDb();
-      await db
-        .insert(pushSubscriptions)
-        .values(values)
-        .onDuplicateKeyUpdate({ set: setData });
-    } else {
-      // SQLite and PostgreSQL both use onConflictDoUpdate
-      await (this.db as any)
-        .insert(pushSubscriptions)
-        .values(values)
-        .onConflictDoUpdate({
-          target: pushSubscriptions.endpoint,
-          set: setData,
-        });
-    }
+    await this.upsert(pushSubscriptions, values, pushSubscriptions.endpoint, setData);
   }
 
   /**

--- a/src/db/repositories/settings.ts
+++ b/src/db/repositories/settings.ts
@@ -51,24 +51,12 @@ export class SettingsRepository extends BaseRepository {
     const now = this.now();
     const { settings } = this.tables;
 
-    if (this.isMySQL()) {
-      const db = this.getMysqlDb();
-      await db
-        .insert(settings)
-        .values({ key, value, createdAt: now, updatedAt: now })
-        .onDuplicateKeyUpdate({
-          set: { value, updatedAt: now },
-        });
-    } else {
-      // SQLite and PostgreSQL both use onConflictDoUpdate
-      await (this.db as any)
-        .insert(settings)
-        .values({ key, value, createdAt: now, updatedAt: now })
-        .onConflictDoUpdate({
-          target: settings.key,
-          set: { value, updatedAt: now },
-        });
-    }
+    await this.upsert(
+      settings,
+      { key, value, createdAt: now, updatedAt: now },
+      settings.key,
+      { value, updatedAt: now },
+    );
   }
 
   /**
@@ -84,27 +72,13 @@ export class SettingsRepository extends BaseRepository {
 
     const { settings: settingsTable } = this.tables;
 
-    if (this.isMySQL()) {
-      const db = this.getMysqlDb();
-      for (const [key, value] of entries) {
-        await db
-          .insert(settingsTable)
-          .values({ key, value, createdAt: now, updatedAt: now })
-          .onDuplicateKeyUpdate({
-            set: { value, updatedAt: now },
-          });
-      }
-    } else {
-      // SQLite and PostgreSQL both use onConflictDoUpdate
-      for (const [key, value] of entries) {
-        await (this.db as any)
-          .insert(settingsTable)
-          .values({ key, value, createdAt: now, updatedAt: now })
-          .onConflictDoUpdate({
-            target: settingsTable.key,
-            set: { value, updatedAt: now },
-          });
-      }
+    for (const [key, value] of entries) {
+      await this.upsert(
+        settingsTable,
+        { key, value, createdAt: now, updatedAt: now },
+        settingsTable.key,
+        { value, updatedAt: now },
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

Phase 3 of the Drizzle refactor — adds two BaseRepository helpers that abstract away the `onConflictDoUpdate` vs `onDuplicateKeyUpdate` and `onConflictDoNothing` vs try/catch differences between database backends.

### New helpers

**`upsert(table, values, target, updateSet)`**
- SQLite/PG: `.insert(table).values(v).onConflictDoUpdate({ target, set: updateSet })`
- MySQL: `.insert(table).values(v).onDuplicateKeyUpdate({ set: updateSet })`

**`insertIgnore(table, values)`**
- SQLite/PG: `.insert(table).values(v).onConflictDoNothing()`
- MySQL: try/catch to swallow duplicate key errors

### 10 call sites simplified

| File | Method | Pattern |
|------|--------|---------|
| `settings.ts` | `setSetting` | upsert |
| `settings.ts` | `setSettings` | upsert |
| `ignoredNodes.ts` | `addIgnoredNodeAsync` | upsert |
| `misc.ts` | `upsertSolarEstimate` | upsert |
| `misc.ts` | `addAutoTracerouteNode` | insertIgnore |
| `misc.ts` | `addAutoTimeSyncNode` | insertIgnore |
| `nodes.ts` | `upsertNode` | upsert |
| `notifications.ts` | `saveSubscription` | upsert |
| `auth.ts` | `setSession` | upsert |
| `messages.ts` | `insertMessage` | insertIgnore |

### Not changed
- `notifications.ts` bulk mark-as-read methods (raw SQL with structural differences between backends)
- `notifications.ts` `saveUserPreferences` (SQLite has different column set)
- `telemetry.ts` / `traceroutes.ts` DELETE patterns (`.returning()` issue — future phase)

## Files Changed

| File | Change |
|------|--------|
| `src/db/repositories/base.ts` | Add `upsert()` and `insertIgnore()` helpers |
| `src/db/repositories/settings.ts` | Simplify 2 methods |
| `src/db/repositories/ignoredNodes.ts` | Simplify 1 method |
| `src/db/repositories/misc.ts` | Simplify 3 methods |
| `src/db/repositories/nodes.ts` | Simplify 1 method |
| `src/db/repositories/notifications.ts` | Simplify 1 method |
| `src/db/repositories/auth.ts` | Simplify 1 method |
| `src/db/repositories/messages.ts` | Simplify 1 method |

## Test plan

- [x] 3061 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)