### PR TITLE
fix: time offset flags not persisted on SQLite (#2378)

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -2794,6 +2794,16 @@ class DatabaseService {
       `, [isTimeOffsetIssue, timeOffsetSeconds, now, nodeNum]);
       return;
     }
+
+    // SQLite: synchronous update
+    const stmt = this.db.prepare(`
+      UPDATE nodes
+      SET isTimeOffsetIssue = ?,
+          timeOffsetSeconds = ?,
+          updatedAt = ?
+      WHERE nodeNum = ?
+    `);
+    stmt.run(isTimeOffsetIssue ? 1 : 0, timeOffsetSeconds, now, nodeNum);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #2378 — time offset detected in backend logs but not displayed in frontend, with duplicate log messages every scan cycle.

### Root Cause

`updateNodeTimeOffsetFlagsAsync()` had UPDATE paths for PostgreSQL and MySQL but **no SQLite path** — it silently returned without writing. The sync version (`updateNodeTimeOffsetFlags`) had the SQLite path, but the scheduler calls the async version.

### Impact

1. **Frontend empty**: `getNodesWithTimeOffsetIssues()` queries `WHERE isTimeOffsetIssue = 1` but the flag was never set
2. **Duplicate logs**: The dedup check reads `node.isTimeOffsetIssue` from DB — always false since it was never written, so `stateChanged` was always true and the warning logged every scan

### Fix

Added the missing SQLite UPDATE path to `updateNodeTimeOffsetFlagsAsync()`, matching the pattern from the sync version.

## Files Changed

| File | Change |
|------|--------|
| `src/services/database.ts` | Add SQLite path to `updateNodeTimeOffsetFlagsAsync` |

## Test plan

- [x] 3061 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)