### PR TITLE
fix: prevent duplicate traceroute pending records (#2364)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3817,12 +3817,16 @@ class MeshtasticManager {
         }
       }
       // Preserve the 'from' and 'to' node order for virtual node traceroute requests.
-      // This ensures subsequent responses correctly correlate with this request 
+      // This ensures subsequent responses correctly correlate with this request
       // to update route and signal characteristics in the database.
+      // Skip if from our own node — sendTraceroute() already recorded the request.
       else if (normalizedPortNum === PortNum.TRACEROUTE_APP) {
         const fromNum = meshPacket.from ? Number(meshPacket.from) : 0;
         const toNum = meshPacket.to ? Number(meshPacket.to) : 0;
-        await databaseService.recordTracerouteRequestAsync(fromNum, toNum);
+        const localNodeNum = this.localNodeInfo?.nodeNum;
+        if (fromNum !== localNodeNum) {
+          await databaseService.recordTracerouteRequestAsync(fromNum, toNum);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes the remaining part of #2364 — traceroute history showed two entries per request, with the second being an empty "No response received" that overwrote the correct entry in the UI.

### Root Cause

When MeshMonitor sends a traceroute:
1. `sendTraceroute()` records a pending traceroute in the database ✓
2. The physical node echoes the outgoing packet back
3. `processMeshPacket()` catches the echo (undecodable TRACEROUTE_APP packet) and records it **again** as a second pending entry
4. The response matches one entry, but the other stays as permanent "No response received"
5. The UI shows the latest entry (the empty one), hiding the correct result

### Fix

Skip recording in the echo path when the packet originates from our own node (`fromNum === localNodeNum`), since `sendTraceroute()` already recorded it. Virtual node client traceroutes (different `from` node) are still recorded correctly.

## Files Changed

| File | Change |
|------|--------|
| `src/server/meshtasticManager.ts` | Skip duplicate recording for own-node traceroute echoes |

## Test plan

- [x] 3061 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)