### PR TITLE
fix: show server-decrypted messages in both database and radio channels (#2375)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3960,6 +3960,26 @@ class MeshtasticManager {
             logger.debug(`💾 Saved channel message from ${message.fromNodeId} on channel ${channelIndex}: "${messageText.substring(0, 30)}..." (replyId: ${message.replyId})`);
           }
 
+          // Dual-channel insertion: if server-decrypted and the packet has a radio channel,
+          // also insert a copy in the radio channel so both views show the message (#2375)
+          if (!isDirectMessage && context?.decryptedBy === 'server' && meshPacket.channel !== undefined) {
+            const radioChannelIndex = meshPacket.channel;
+            const radioChannel = await databaseService.channels.getChannelById(radioChannelIndex);
+            if (radioChannel) {
+              const radioCopy: TextMessage = {
+                ...message,
+                id: `${message.id}_radio`,
+                channel: radioChannelIndex,
+                decryptedBy: 'server',
+              };
+              const radioInserted = await databaseService.messages.insertMessage(radioCopy);
+              if (radioInserted) {
+                dataEventEmitter.emitNewMessage(radioCopy as any);
+                logger.debug(`💾 Also saved to radio channel ${radioChannelIndex} ("${radioChannel.name}")`);
+              }
+            }
+          }
+
           // Send push notification for new message
           await this.sendMessagePushNotification(message, messageText, isDirectMessage);
 


### PR DESCRIPTION
## Summary

Fixes #2375 — when a Channel Database entry has the same PSK as a physical radio channel, messages were only shown in the database channel. The radio channel showed no activity.

### Root Cause

When a packet arrives encrypted and the server-side Channel Database decrypts it first, the message is attributed solely to the database channel (`100 + channelDatabaseId`). The radio channel (`meshPacket.channel`) never receives a copy, even though it shares the same PSK.

### Fix

After inserting a server-decrypted message in the database channel, check if `meshPacket.channel` maps to a known radio channel. If so, insert a copy with the radio channel index so the message appears in both views. The copy uses a distinct ID (`_radio` suffix) to avoid dedup conflicts.

### Conditions for dual insertion
- Message was server-decrypted (`decryptedBy='server'`)
- Not a direct message
- `meshPacket.channel` maps to an existing radio channel in the channels table

## Files Changed

| File | Change |
|------|--------|
| `src/server/meshtasticManager.ts` | Add dual-channel insertion after server-decrypted message insert |

## Test plan

- [x] 3061 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)