### PR TITLE
fix: database audit remediation across all 3 backends

### DIFF
--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -662,25 +662,30 @@ export class NodesRepository extends BaseRepository {
     } else {
       // PostgreSQL
       const db = this.getPostgresDb();
+      const nodeNum = this.col('nodeNum');
+      const lastHeard = this.col('lastHeard');
+      const fromNodeNum = this.col('fromNodeNum');
+      const toNodeNum = this.col('toNodeNum');
+      const lastTracerouteRequest = this.col('lastTracerouteRequest');
       const results = await db.execute(sql`
         SELECT n.*
         FROM nodes n
-        WHERE n."nodeNum" != ${localNodeNum}
-          AND n."lastHeard" > ${activeNodeCutoffSeconds}
+        WHERE n.${nodeNum} != ${localNodeNum}
+          AND n.${lastHeard} > ${activeNodeCutoffSeconds}
           AND (
             (
               (SELECT COUNT(*) FROM traceroutes t
-               WHERE t."fromNodeNum" = ${localNodeNum} AND t."toNodeNum" = n."nodeNum") = 0
-              AND (n."lastTracerouteRequest" IS NULL OR n."lastTracerouteRequest" < ${threeHoursAgoMs})
+               WHERE t.${fromNodeNum} = ${localNodeNum} AND t.${toNodeNum} = n.${nodeNum}) = 0
+              AND (n.${lastTracerouteRequest} IS NULL OR n.${lastTracerouteRequest} < ${threeHoursAgoMs})
             )
             OR
             (
               (SELECT COUNT(*) FROM traceroutes t
-               WHERE t."fromNodeNum" = ${localNodeNum} AND t."toNodeNum" = n."nodeNum") > 0
-              AND (n."lastTracerouteRequest" IS NULL OR n."lastTracerouteRequest" < ${expirationMsAgo})
+               WHERE t.${fromNodeNum} = ${localNodeNum} AND t.${toNodeNum} = n.${nodeNum}) > 0
+              AND (n.${lastTracerouteRequest} IS NULL OR n.${lastTracerouteRequest} < ${expirationMsAgo})
             )
           )
-        ORDER BY n."lastHeard" DESC
+        ORDER BY n.${lastHeard} DESC
       `);
       // PostgreSQL returns { rows: [...] }
       const rows = (results as unknown as { rows: unknown[] }).rows as DbNode[];

--- a/src/server/migrations/001_v37_baseline.ts
+++ b/src/server/migrations/001_v37_baseline.ts
@@ -1424,6 +1424,7 @@ export async function runMigration001Mysql(pool: MySQLPool): Promise<void> {
       deliveryState VARCHAR(50),
       wantAck BOOLEAN,
       ackFromNode BIGINT,
+      decrypted_by VARCHAR(16),
       createdAt BIGINT NOT NULL,
       INDEX idx_messages_timestamp (timestamp),
       INDEX idx_messages_channel (channel)

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -2705,6 +2705,17 @@ class DatabaseService {
       `, [isExcessivePackets, packetRatePerHour, lastChecked, now, nodeNum]);
       return;
     }
+
+    // SQLite: synchronous update
+    const stmt = this.db.prepare(`
+      UPDATE nodes
+      SET isExcessivePackets = ?,
+          packetRatePerHour = ?,
+          packetRateLastChecked = ?,
+          updatedAt = ?
+      WHERE nodeNum = ?
+    `);
+    stmt.run(isExcessivePackets ? 1 : 0, packetRatePerHour, lastChecked, now, nodeNum);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes three issues found during a deep audit of the database layer across SQLite, PostgreSQL, and MySQL backends:

- **CRITICAL:** `updateNodeSpamFlagsAsync` had no SQLite fallback — spam detection flags (excessive packet warnings) silently failed to persist on SQLite deployments
- **MEDIUM:** MySQL baseline migration was missing `decrypted_by` column in the messages table (already covered by migration 014 for existing DBs, but fresh installs had an inconsistent baseline)
- **LOW:** `getEligibleNodesForTraceroute()` PostgreSQL branch used hardcoded `"columnName"` quotes instead of the `col()` helper, reducing maintainability

## Changes

| File | Change |
|------|--------|
| `src/services/database.ts` | Added SQLite `db.prepare()` path to `updateNodeSpamFlagsAsync` |
| `src/server/migrations/001_v37_baseline.ts` | Added `decrypted_by VARCHAR(16)` to MySQL messages CREATE TABLE |
| `src/db/repositories/nodes.ts` | Converted hardcoded PG column quotes to `col()` helper in `getEligibleNodesForTraceroute` |

## Test plan

- [x] Full test suite: 3070 tests pass, 0 failures
- [x] TypeScript build compiles cleanly
- [ ] System tests via `tests/system-tests.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)