### PR TITLE
fix: database audit phase 2 — PG/MySQL crash prevention and schema alignment

### DIFF
--- a/src/db/repositories/auth.ts
+++ b/src/db/repositories/auth.ts
@@ -91,9 +91,9 @@ export interface DbPermission {
   canViewOnMap: boolean;
   canRead: boolean;
   canWrite: boolean;
-  canDelete?: boolean; // PostgreSQL only
-  grantedAt?: number; // SQLite only
-  grantedBy?: number | null; // SQLite only
+  canDelete?: boolean; // PostgreSQL/MySQL only
+  grantedAt?: number;
+  grantedBy?: number | null;
 }
 
 /**
@@ -105,9 +105,9 @@ export interface CreatePermissionInput {
   canViewOnMap?: boolean;
   canRead?: boolean;
   canWrite?: boolean;
-  canDelete?: boolean; // PostgreSQL only
-  grantedAt?: number; // SQLite only
-  grantedBy?: number | null; // SQLite only
+  canDelete?: boolean; // PostgreSQL/MySQL only
+  grantedAt?: number;
+  grantedBy?: number | null;
 }
 
 /**
@@ -309,31 +309,28 @@ export class AuthRepository extends BaseRepository {
 
   /**
    * Create permission.
-   * Keeps branching: different columns per dialect (SQLite has grantedAt/grantedBy, others have canDelete).
+   * Keeps branching: SQLite doesn't have canDelete, PG/MySQL do.
+   * All backends now support grantedAt/grantedBy.
    */
   async createPermission(permission: CreatePermissionInput): Promise<number> {
     const { permissions } = this.tables;
+    const permissionWithGrantedAt = {
+      ...permission,
+      grantedAt: permission.grantedAt ?? Date.now(),
+    };
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
-      // SQLite requires grantedAt, doesn't have canDelete
-      const { canDelete, ...rest } = permission;
-      const sqlitePermission = {
-        ...rest,
-        grantedAt: permission.grantedAt ?? Date.now(),
-      };
-      const result = await db.insert(permissions).values(sqlitePermission);
+      // SQLite doesn't have canDelete
+      const { canDelete, ...rest } = permissionWithGrantedAt;
+      const result = await db.insert(permissions).values(rest);
       return Number(result.lastInsertRowid);
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
-      // MySQL doesn't have grantedAt/grantedBy but has canDelete
-      const { grantedAt, grantedBy, ...mysqlPermission } = permission;
-      const result = await db.insert(permissions).values(mysqlPermission);
+      const result = await db.insert(permissions).values(permissionWithGrantedAt);
       return Number(result[0].insertId);
     } else {
       const db = this.getPostgresDb();
-      // PostgreSQL doesn't have grantedAt/grantedBy
-      const { grantedAt, grantedBy, ...postgresPermission } = permission;
-      const result = await db.insert(permissions).values(postgresPermission).returning({ id: permissionsPostgres.id });
+      const result = await db.insert(permissions).values(permissionWithGrantedAt).returning({ id: permissionsPostgres.id });
       return result[0].id;
     }
   }

--- a/src/db/repositories/neighbors.ts
+++ b/src/db/repositories/neighbors.ts
@@ -4,7 +4,7 @@
  * Handles neighbor info database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, desc, and, gte, sql, count } from 'drizzle-orm';
+import { eq, desc, and, gte, lt, sql, count } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbNeighborInfo } from '../types.js';
 
@@ -134,6 +134,23 @@ export class NeighborsRepository extends BaseRepository {
   async deleteAllNeighborInfo(): Promise<void> {
     const { neighborInfo } = this.tables;
     await this.db.delete(neighborInfo);
+  }
+
+  /**
+   * Delete neighbor info records older than the specified number of days
+   */
+  async cleanupOldNeighborInfo(days: number = 30): Promise<number> {
+    const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
+    const { neighborInfo } = this.tables;
+    const toDelete = await this.db
+      .select({ count: count() })
+      .from(neighborInfo)
+      .where(lt(neighborInfo.timestamp, cutoff));
+    const total = Number(toDelete[0].count);
+    if (total > 0) {
+      await this.db.delete(neighborInfo).where(lt(neighborInfo.timestamp, cutoff));
+    }
+    return total;
   }
 
   /**

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -317,6 +317,24 @@ export class TraceroutesRepository extends BaseRepository {
   }
 
   /**
+   * Delete old route segments that are not record holders
+   */
+  async cleanupOldRouteSegments(days: number = 30): Promise<number> {
+    const cutoff = this.now() - (days * 24 * 60 * 60 * 1000);
+    const { routeSegments } = this.tables;
+    const toDelete = await this.db
+      .select({ count: count() })
+      .from(routeSegments)
+      .where(and(lt(routeSegments.timestamp, cutoff), eq(routeSegments.isRecordHolder, false)));
+    const total = Number(toDelete[0].count);
+    if (total > 0) {
+      await this.db.delete(routeSegments)
+        .where(and(lt(routeSegments.timestamp, cutoff), eq(routeSegments.isRecordHolder, false)));
+    }
+    return total;
+  }
+
+  /**
    * Delete all route segments
    */
   async deleteAllRouteSegments(): Promise<number> {

--- a/src/db/schema/auth.ts
+++ b/src/db/schema/auth.ts
@@ -69,6 +69,8 @@ export const permissionsPostgres = pgTable('permissions', {
   canRead: pgBoolean('canRead').notNull().default(false),
   canWrite: pgBoolean('canWrite').notNull().default(false),
   canDelete: pgBoolean('canDelete').notNull().default(false),
+  grantedAt: pgBigint('grantedAt', { mode: 'number' }),
+  grantedBy: pgInteger('grantedBy').references(() => usersPostgres.id, { onDelete: 'set null' }),
 });
 
 // ============ SESSIONS ============
@@ -172,6 +174,8 @@ export const permissionsMysql = mysqlTable('permissions', {
   canRead: myBoolean('canRead').notNull().default(false),
   canWrite: myBoolean('canWrite').notNull().default(false),
   canDelete: myBoolean('canDelete').notNull().default(false),
+  grantedAt: myBigint('grantedAt', { mode: 'number' }),
+  grantedBy: myInt('grantedBy').references(() => usersMysql.id, { onDelete: 'set null' }),
 });
 
 export const sessionsMysql = mysqlTable('sessions', {

--- a/src/server/migrations/001_v37_baseline.ts
+++ b/src/server/migrations/001_v37_baseline.ts
@@ -959,7 +959,9 @@ export async function runMigration001Postgres(client: PoolClient): Promise<void>
     "canViewOnMap" BOOLEAN NOT NULL DEFAULT false,
     "canRead" BOOLEAN NOT NULL DEFAULT false,
     "canWrite" BOOLEAN NOT NULL DEFAULT false,
-    "canDelete" BOOLEAN NOT NULL DEFAULT false
+    "canDelete" BOOLEAN NOT NULL DEFAULT false,
+    "grantedAt" BIGINT,
+    "grantedBy" INTEGER REFERENCES users(id) ON DELETE SET NULL
   );
 
   CREATE TABLE IF NOT EXISTS sessions (
@@ -977,6 +979,8 @@ export async function runMigration001Postgres(client: PoolClient): Promise<void>
     details TEXT,
     "ipAddress" TEXT,
     "userAgent" TEXT,
+    "valueBefore" TEXT,
+    "valueAfter" TEXT,
     timestamp BIGINT NOT NULL
   );
 
@@ -1494,7 +1498,10 @@ export async function runMigration001Mysql(pool: MySQLPool): Promise<void> {
       canRead BOOLEAN NOT NULL DEFAULT false,
       canWrite BOOLEAN NOT NULL DEFAULT false,
       canDelete BOOLEAN NOT NULL DEFAULT false,
-      FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
+      grantedAt BIGINT,
+      grantedBy INT,
+      FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (grantedBy) REFERENCES users(id) ON DELETE SET NULL
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
 
     `CREATE TABLE IF NOT EXISTS sessions (
@@ -1553,6 +1560,8 @@ export async function runMigration001Mysql(pool: MySQLPool): Promise<void> {
       details TEXT,
       ipAddress VARCHAR(255),
       userAgent TEXT,
+      valueBefore TEXT,
+      valueAfter TEXT,
       timestamp BIGINT NOT NULL,
       FOREIGN KEY (userId) REFERENCES users(id) ON DELETE SET NULL,
       INDEX idx_audit_log_timestamp (timestamp)

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -7369,6 +7369,16 @@ class DatabaseService {
   }
 
   cleanupOldRouteSegments(days: number = 30): number {
+    // For PostgreSQL/MySQL, fire-and-forget async cleanup
+    if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
+      if (this.traceroutesRepo) {
+        this.traceroutesRepo.cleanupOldRouteSegments(days).catch(err => {
+          logger.debug('Failed to cleanup old route segments:', err);
+        });
+      }
+      return 0;
+    }
+
     const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
     const stmt = this.db.prepare(`
       DELETE FROM route_segments
@@ -7382,6 +7392,16 @@ class DatabaseService {
    * Delete traceroutes older than the specified number of days
    */
   cleanupOldTraceroutes(days: number = 30): number {
+    // For PostgreSQL/MySQL, fire-and-forget async cleanup
+    if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
+      if (this.traceroutesRepo) {
+        this.traceroutesRepo.cleanupOldTraceroutes(days * 24).catch(err => {
+          logger.debug('Failed to cleanup old traceroutes:', err);
+        });
+      }
+      return 0;
+    }
+
     const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
     const stmt = this.db.prepare('DELETE FROM traceroutes WHERE timestamp < ?');
     const result = stmt.run(cutoff);
@@ -7392,6 +7412,16 @@ class DatabaseService {
    * Delete neighbor info records older than the specified number of days
    */
   cleanupOldNeighborInfo(days: number = 30): number {
+    // For PostgreSQL/MySQL, fire-and-forget async cleanup
+    if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
+      if (this.neighborsRepo) {
+        this.neighborsRepo.cleanupOldNeighborInfo(days).catch(err => {
+          logger.debug('Failed to cleanup old neighbor info:', err);
+        });
+      }
+      return 0;
+    }
+
     const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
     const stmt = this.db.prepare('DELETE FROM neighbor_info WHERE timestamp < ?');
     const result = stmt.run(cutoff);
@@ -7403,6 +7433,23 @@ class DatabaseService {
    * This can take a while on large databases and temporarily doubles disk usage
    */
   vacuum(): void {
+    // For PostgreSQL/MySQL, use native vacuum/optimize
+    if (this.drizzleDbType === 'postgres') {
+      logger.info('🧹 Running VACUUM on PostgreSQL database...');
+      this.postgresPool!.query('VACUUM').then(() => {
+        logger.info('✅ PostgreSQL VACUUM complete');
+      }).catch(err => {
+        logger.error('Failed to VACUUM PostgreSQL:', err);
+      });
+      return;
+    }
+    if (this.drizzleDbType === 'mysql') {
+      logger.info('🧹 Running OPTIMIZE TABLE on MySQL database...');
+      // MySQL OPTIMIZE TABLE requires table names; skip for now as it's not critical
+      logger.info('✅ MySQL OPTIMIZE TABLE skipped (not critical)');
+      return;
+    }
+
     logger.info('🧹 Running VACUUM on database...');
     this.db.exec('VACUUM');
     logger.info('✅ VACUUM complete');
@@ -7412,6 +7459,17 @@ class DatabaseService {
    * Get the current database file size in bytes
    */
   getDatabaseSize(): number {
+    // For PostgreSQL, use pg_database_size()
+    if (this.drizzleDbType === 'postgres') {
+      // Return 0 from sync context; use getDatabaseSizeAsync for accurate results
+      return 0;
+    }
+    // For MySQL, use information_schema
+    if (this.drizzleDbType === 'mysql') {
+      // Return 0 from sync context; use getDatabaseSizeAsync for accurate results
+      return 0;
+    }
+
     const stmt = this.db.prepare('SELECT page_count * page_size as size FROM pragma_page_count(), pragma_page_size()');
     const result = stmt.get() as { size: number } | undefined;
     return result?.size ?? 0;
@@ -8469,8 +8527,8 @@ class DatabaseService {
           [cutoff]
         );
         const userStats = await client.query(
-          `SELECT u.username, COUNT(*) as count FROM audit_log al LEFT JOIN users u ON al.user_id = u.id
-           WHERE al.timestamp >= $1 GROUP BY al.user_id, u.username ORDER BY count DESC LIMIT 10`,
+          `SELECT u.username, COUNT(*) as count FROM audit_log al LEFT JOIN users u ON al."userId" = u.id
+           WHERE al.timestamp >= $1 GROUP BY al."userId", u.username ORDER BY count DESC LIMIT 10`,
           [cutoff]
         );
         const dailyStats = await client.query(
@@ -8497,8 +8555,8 @@ class DatabaseService {
         [cutoff]
       );
       const [userRows] = await pool.query(
-        `SELECT u.username, COUNT(*) as count FROM audit_log al LEFT JOIN users u ON al.user_id = u.id
-         WHERE al.timestamp >= ? GROUP BY al.user_id ORDER BY count DESC LIMIT 10`,
+        `SELECT u.username, COUNT(*) as count FROM audit_log al LEFT JOIN users u ON al.userId = u.id
+         WHERE al.timestamp >= ? GROUP BY al.userId ORDER BY count DESC LIMIT 10`,
         [cutoff]
       );
       const [dailyRows] = await pool.query(
@@ -8521,6 +8579,16 @@ class DatabaseService {
 
   // Cleanup old audit logs
   cleanupAuditLogs(days: number): number {
+    // For PostgreSQL/MySQL, fire-and-forget async cleanup
+    if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
+      if (this.authRepo) {
+        this.authRepo.cleanupOldAuditLogs(days).catch(err => {
+          logger.debug('Failed to cleanup old audit logs:', err);
+        });
+      }
+      return 0;
+    }
+
     const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
     const stmt = this.db.prepare('DELETE FROM audit_log WHERE timestamp < ?');
     const result = stmt.run(cutoff);
@@ -10132,14 +10200,23 @@ class DatabaseService {
   }
 
   async cleanupOldTraceroutesAsync(days: number = 30): Promise<number> {
+    if ((this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') && this.traceroutesRepo) {
+      return this.traceroutesRepo.cleanupOldTraceroutes(days * 24);
+    }
     return this.cleanupOldTraceroutes(days);
   }
 
   async cleanupOldRouteSegmentsAsync(days: number = 30): Promise<number> {
+    if ((this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') && this.traceroutesRepo) {
+      return this.traceroutesRepo.cleanupOldRouteSegments(days);
+    }
     return this.cleanupOldRouteSegments(days);
   }
 
   async cleanupOldNeighborInfoAsync(days: number = 30): Promise<number> {
+    if ((this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') && this.neighborsRepo) {
+      return this.neighborsRepo.cleanupOldNeighborInfo(days);
+    }
     return this.cleanupOldNeighborInfo(days);
   }
 
@@ -10152,14 +10229,35 @@ class DatabaseService {
   }
 
   async cleanupAuditLogsAsync(days: number): Promise<number> {
+    if ((this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') && this.authRepo) {
+      return this.authRepo.cleanupOldAuditLogs(days);
+    }
     return this.cleanupAuditLogs(days);
   }
 
   async vacuumAsync(): Promise<void> {
+    if (this.drizzleDbType === 'postgres') {
+      await this.postgresPool!.query('VACUUM');
+      return;
+    }
+    if (this.drizzleDbType === 'mysql') {
+      // MySQL auto-manages space; OPTIMIZE TABLE requires table names
+      return;
+    }
     return this.vacuum();
   }
 
   async getDatabaseSizeAsync(): Promise<number> {
+    if (this.drizzleDbType === 'postgres') {
+      const result = await this.postgresPool!.query('SELECT pg_database_size(current_database()) as size');
+      return Number(result.rows[0]?.size ?? 0);
+    }
+    if (this.drizzleDbType === 'mysql') {
+      const [rows] = await this.mysqlPool!.query(
+        `SELECT SUM(data_length + index_length) as size FROM information_schema.tables WHERE table_schema = DATABASE()`
+      );
+      return Number((rows as any[])[0]?.size ?? 0);
+    }
     return this.getDatabaseSize();
   }
 


### PR DESCRIPTION
## Summary

Phase 2 of the database audit remediation. Fixes critical bugs that cause crashes on PostgreSQL/MySQL backends during scheduled maintenance (default 4:00 AM) and on admin pages.

### Critical Fixes
- **`getAuditStatsAsync`** — Fixed wrong column names (`user_id` → `"userId"` for PG, `userId` for MySQL) that caused 500 errors on the audit statistics page
- **6 maintenance methods** — Added PG/MySQL guards to `cleanupOldTraceroutes`, `cleanupOldRouteSegments`, `cleanupOldNeighborInfo`, `cleanupAuditLogs`, `vacuum`, `getDatabaseSize` which all crashed via `this.db.prepare()` on non-SQLite backends
- **Async wrappers** — Updated `cleanupOldTraceroutesAsync`, `cleanupOldRouteSegmentsAsync`, `cleanupOldNeighborInfoAsync`, `cleanupAuditLogsAsync`, `vacuumAsync`, `getDatabaseSizeAsync` to properly delegate to repos on PG/MySQL
- **Native DB operations** — `getDatabaseSizeAsync` now uses `pg_database_size()`/`information_schema` for PG/MySQL; `vacuumAsync` uses native PostgreSQL `VACUUM`

### Schema Alignment (Medium)
- Added `grantedAt`/`grantedBy` to PG/MySQL permission Drizzle schemas and baselines — enables Drizzle read/write of these columns
- Added `valueBefore`/`valueAfter` to PG/MySQL audit_log baselines for consistency with SQLite
- Removed auth repo branching that unnecessarily stripped `grantedAt`/`grantedBy` on PG/MySQL inserts

### New Repository Methods
- `TraceroutesRepository.cleanupOldRouteSegments(days)` — Drizzle-based cleanup for non-record-holder segments
- `NeighborsRepository.cleanupOldNeighborInfo(days)` — Drizzle-based cleanup for old neighbor info

## Test Plan
- [x] `npx vitest run` — 3070 tests pass, 0 failures
- [x] `npm run build` — no TypeScript errors
- [x] `./tests/system-tests.sh` — 9/10 pass (1 pre-existing flaky favorite count test)

## Files Changed
- `src/services/database.ts` — Guards + async wrapper fixes
- `src/db/repositories/traceroutes.ts` — New `cleanupOldRouteSegments` method
- `src/db/repositories/neighbors.ts` — New `cleanupOldNeighborInfo` method
- `src/db/repositories/auth.ts` — Simplified `createPermission` branching
- `src/db/schema/auth.ts` — Added `grantedAt`/`grantedBy` to PG/MySQL permission schemas
- `src/server/migrations/001_v37_baseline.ts` — Added missing columns to PG/MySQL baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)