### PR TITLE
fix: traceroute duplication caused by bypassing deduplication logic

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5147,7 +5147,9 @@ class MeshtasticManager {
         createdAt: Date.now()
       };
 
-      await databaseService.traceroutes.insertTraceroute(tracerouteRecord);
+      // Use DatabaseService.insertTraceroute() (not repo directly) for deduplication:
+      // It checks for pending traceroute requests and updates them instead of inserting duplicates
+      databaseService.insertTraceroute(tracerouteRecord);
 
       // Store traceroute hop count as telemetry for Smart Hops tracking
       // Hop count is route.length + 1 (intermediate hops + final hop to destination)


### PR DESCRIPTION
## Summary

- **Root cause:** `meshtasticManager.ts` called `databaseService.traceroutes.insertTraceroute()` (the repository directly), bypassing the deduplication logic in `databaseService.insertTraceroute()` 
- The DatabaseService method checks for pending traceroute requests (created when a traceroute is sent) and **updates** them with the response data instead of inserting a new record
- By going directly to the repo, every response created a new record alongside the existing pending record, causing duplicate entries in traceroute history

## Fix

One-line change: redirect the call from the repository's `insertTraceroute()` to the DatabaseService's `insertTraceroute()` which contains the deduplication logic.

## Test Plan
- [x] `npx vitest run` — 3070 tests pass, 0 failures
- [x] `npm run build` — no TypeScript errors
- [x] `./tests/system-tests.sh` — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)