### PR TITLE
fix: packet monitor uses server time for consistent ordering

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3658,7 +3658,7 @@ class MeshtasticManager {
 
         packetLogService.logPacket({
           packet_id: meshPacket.id ?? undefined,
-          timestamp: meshPacket.rxTime ? Number(meshPacket.rxTime) : Math.floor(Date.now() / 1000),
+          timestamp: Math.floor(Date.now() / 1000), // Use server time for consistent ordering (rxTime preserved in metadata.rx_time)
           from_node: fromNum,
           from_node_id: fromNodeId ?? undefined,
           to_node: toNum ?? undefined,


### PR DESCRIPTION
## Summary

- Incoming packets in the packet monitor used `meshPacket.rxTime` (device clock) for timestamps, while outgoing packets used `Date.now()` (server clock)
- When the connected device's clock drifts even slightly from the server, this causes responses to appear *before* their requests in the packet monitor
- Now both incoming and outgoing packets use server time consistently
- The original `rxTime` is still preserved in packet metadata (`rx_time`) for debugging

Addresses timing comments in #2364

## Test Plan
- [x] `npx vitest run` — 3070 tests pass, 0 failures
- [x] `npm run build` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)