### PR TITLE
refactor: replace hardcoded PG column quotes with col() helper

### DIFF
--- a/src/db/repositories/notifications.ts
+++ b/src/db/repositories/notifications.ts
@@ -377,20 +377,20 @@ export class NotificationsRepository extends BaseRepository {
         let result;
         if (beforeTimestamp !== undefined) {
           result = await db.execute(sql`
-            INSERT INTO read_messages ("messageId", "userId", "readAt")
+            INSERT INTO read_messages (${this.col('messageId')}, ${this.col('userId')}, ${this.col('readAt')})
             SELECT id, ${effectiveUserId}, ${now} FROM messages
             WHERE channel = ${channelId}
               AND portnum = 1
               AND timestamp <= ${beforeTimestamp}
-            ON CONFLICT ("messageId", "userId") DO NOTHING
+            ON CONFLICT (${this.col('messageId')}, ${this.col('userId')}) DO NOTHING
           `);
         } else {
           result = await db.execute(sql`
-            INSERT INTO read_messages ("messageId", "userId", "readAt")
+            INSERT INTO read_messages (${this.col('messageId')}, ${this.col('userId')}, ${this.col('readAt')})
             SELECT id, ${effectiveUserId}, ${now} FROM messages
             WHERE channel = ${channelId}
               AND portnum = 1
-            ON CONFLICT ("messageId", "userId") DO NOTHING
+            ON CONFLICT (${this.col('messageId')}, ${this.col('userId')}) DO NOTHING
           `);
         }
         return Number(result.rowCount ?? 0);
@@ -495,24 +495,24 @@ export class NotificationsRepository extends BaseRepository {
         let result;
         if (beforeTimestamp !== undefined) {
           result = await db.execute(sql`
-            INSERT INTO read_messages ("messageId", "userId", "readAt")
+            INSERT INTO read_messages (${this.col('messageId')}, ${this.col('userId')}, ${this.col('readAt')})
             SELECT id, ${effectiveUserId}, ${now} FROM messages
-            WHERE (("fromNodeId" = ${localNodeId} AND "toNodeId" = ${remoteNodeId})
-                OR ("fromNodeId" = ${remoteNodeId} AND "toNodeId" = ${localNodeId}))
+            WHERE ((${this.col('fromNodeId')} = ${localNodeId} AND ${this.col('toNodeId')} = ${remoteNodeId})
+                OR (${this.col('fromNodeId')} = ${remoteNodeId} AND ${this.col('toNodeId')} = ${localNodeId}))
               AND portnum = 1
               AND channel = -1
               AND timestamp <= ${beforeTimestamp}
-            ON CONFLICT ("messageId", "userId") DO NOTHING
+            ON CONFLICT (${this.col('messageId')}, ${this.col('userId')}) DO NOTHING
           `);
         } else {
           result = await db.execute(sql`
-            INSERT INTO read_messages ("messageId", "userId", "readAt")
+            INSERT INTO read_messages (${this.col('messageId')}, ${this.col('userId')}, ${this.col('readAt')})
             SELECT id, ${effectiveUserId}, ${now} FROM messages
-            WHERE (("fromNodeId" = ${localNodeId} AND "toNodeId" = ${remoteNodeId})
-                OR ("fromNodeId" = ${remoteNodeId} AND "toNodeId" = ${localNodeId}))
+            WHERE ((${this.col('fromNodeId')} = ${localNodeId} AND ${this.col('toNodeId')} = ${remoteNodeId})
+                OR (${this.col('fromNodeId')} = ${remoteNodeId} AND ${this.col('toNodeId')} = ${localNodeId}))
               AND portnum = 1
               AND channel = -1
-            ON CONFLICT ("messageId", "userId") DO NOTHING
+            ON CONFLICT (${this.col('messageId')}, ${this.col('userId')}) DO NOTHING
           `);
         }
         return Number(result.rowCount ?? 0);
@@ -597,12 +597,12 @@ export class NotificationsRepository extends BaseRepository {
       } else if (this.isPostgres()) {
         const db = this.getPostgresDb();
         const result = await db.execute(sql`
-          INSERT INTO read_messages ("messageId", "userId", "readAt")
+          INSERT INTO read_messages (${this.col('messageId')}, ${this.col('userId')}, ${this.col('readAt')})
           SELECT id, ${effectiveUserId}, ${now} FROM messages
-          WHERE ("fromNodeId" = ${localNodeId} OR "toNodeId" = ${localNodeId})
+          WHERE (${this.col('fromNodeId')} = ${localNodeId} OR ${this.col('toNodeId')} = ${localNodeId})
             AND portnum = 1
             AND channel = -1
-          ON CONFLICT ("messageId", "userId") DO NOTHING
+          ON CONFLICT (${this.col('messageId')}, ${this.col('userId')}) DO NOTHING
         `);
         return Number(result.rowCount ?? 0);
       } else {
@@ -654,9 +654,9 @@ export class NotificationsRepository extends BaseRepository {
         const db = this.getPostgresDb();
         for (const messageId of messageIds) {
           await db.execute(sql`
-            INSERT INTO read_messages ("messageId", "userId", "readAt")
+            INSERT INTO read_messages (${this.col('messageId')}, ${this.col('userId')}, ${this.col('readAt')})
             VALUES (${messageId}, ${effectiveUserId}, ${now})
-            ON CONFLICT ("messageId", "userId") DO NOTHING
+            ON CONFLICT (${this.col('messageId')}, ${this.col('userId')}) DO NOTHING
           `);
         }
       } else {

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -238,10 +238,10 @@ export class TelemetryRepository extends BaseRepository {
     } else {
       const db = this.getPostgresDb();
       const rows = await db.execute(
-        sql`SELECT DISTINCT ON ("nodeId") "nodeId", value
+        sql`SELECT DISTINCT ON (${this.col('nodeId')}) ${this.col('nodeId')}, value
             FROM telemetry
-            WHERE "telemetryType" = ${telemetryType}
-            ORDER BY "nodeId", timestamp DESC`
+            WHERE ${this.col('telemetryType')} = ${telemetryType}
+            ORDER BY ${this.col('nodeId')}, timestamp DESC`
       );
       for (const row of rows.rows) {
         result.set(row.nodeId as string, Number(row.value));


### PR DESCRIPTION
## Summary

- Replaced ~20 hardcoded `"columnName"` PostgreSQL column references with `${this.col('columnName')}` in raw SQL
- The `col()` helper from `BaseRepository` returns dialect-aware quoting: `"quoted"` for PG, unquoted for SQLite/MySQL
- Makes the notification and telemetry repos consistent with the pattern used in other repos (e.g., `nodes.ts`)

## Files Changed
- `src/db/repositories/notifications.ts` — 17 replacements across 4 PG code blocks
- `src/db/repositories/telemetry.ts` — 3 replacements in 1 PG code block

## Test Plan
- [x] `npx vitest run` — 3070 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)