### PR TITLE
chore: bump version to 3.10.0-RC6

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "3.10.0-RC5",
+  "version": "3.10.0-RC6",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.10.0-RC5",
+  "version": "3.10.0-RC6",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.10.0-RC5
-appVersion: "3.10.0-RC5"
+version: 3.10.0-RC6
+appVersion: "3.10.0-RC6"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.10.0-RC5",
+  "version": "3.10.0-RC6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.10.0-RC5",
+      "version": "3.10.0-RC6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.10.0-RC5",
+  "version": "3.10.0-RC6",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Bump version to 3.10.0-RC6 across all 5 files.

### Changes since RC5
- **#2385** fix: database audit remediation across all 3 backends
- **#2386** fix: database audit phase 2 — PG/MySQL crash prevention and schema alignment
- **#2387** fix: traceroute duplication caused by bypassing deduplication logic
- **#2388** fix: packet monitor uses server time for consistent ordering
- **#2389** refactor: replace hardcoded PG column quotes with col() helper
- **#2390** fix: missing baseline columns + system backup column names + map preferences + API exercise test

🤖 Generated with [Claude Code](https://claude.com/claude-code)