### PR TITLE
fix: OIDC init retries on failure instead of permanently disabling

### DIFF
--- a/src/server/auth/oidcAuth.ts
+++ b/src/server/auth/oidcAuth.ts
@@ -85,6 +85,16 @@ function scheduleRetry(): void {
 }
 
 /**
+ * Clean up pending retry timers for graceful shutdown
+ */
+export function cleanupOIDC(): void {
+  if (retryTimeout) {
+    clearTimeout(retryTimeout);
+    retryTimeout = null;
+  }
+}
+
+/**
  * Check if OIDC is enabled and initialized
  * Returns true if OIDC is configured (even if init temporarily failed and is retrying)
  */


### PR DESCRIPTION
## Summary

If OIDC discovery failed during startup (network timeout, provider briefly unavailable), the `isInitialized` flag was set to `true` but `oidcConfig` stayed `null` — permanently disabling OIDC until container restart. This caused the login page to show "Local authentication is disabled and OIDC is not configured" for users with local auth disabled + OIDC configured.

### Root Cause
```typescript
} catch (error) {
    isInitialized = true;  // Prevents retry forever
    return false;           // oidcConfig stays null
}
```

### Fix
- `isOIDCEnabled()` now returns `true` if OIDC was configured but init failed — keeps the OIDC login button visible
- Auto-retries OIDC discovery up to 10 times at 30-second intervals
- Clears retry state on success

## Test Plan
- [x] `npx vitest run` — 3070 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)