### PR TITLE
fix: PG packet monitor names and key mismatch flag not clearing

### DIFF
--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -838,6 +838,9 @@ export class MiscRepository extends BaseRepository {
       to_node: row.to_node != null ? Number(row.to_node) : row.to_node,
       relay_node: row.relay_node != null ? Number(row.relay_node) : row.relay_node,
       created_at: row.created_at != null ? Number(row.created_at) : row.created_at,
+      // PostgreSQL lowercases unquoted aliases — normalize for frontend
+      from_node_longName: row.from_node_longName ?? row.from_node_longname ?? null,
+      to_node_longName: row.to_node_longName ?? row.to_node_longname ?? null,
     } as DbPacketLog;
   }
 

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -164,10 +164,10 @@ export class NodesRepository extends BaseRepository {
           lastPKIPacket: this.coerceBigintField(nodeData.lastPKIPacket ?? existingNode.lastPKIPacket),
           // Don't update welcomedAt here - it's managed by markNodeAsWelcomedIfNotAlready
           // to avoid race conditions where this upsert overwrites a concurrent welcome update
-          keyIsLowEntropy: nodeData.keyIsLowEntropy ?? existingNode.keyIsLowEntropy,
-          duplicateKeyDetected: nodeData.duplicateKeyDetected ?? existingNode.duplicateKeyDetected,
-          keyMismatchDetected: nodeData.keyMismatchDetected ?? existingNode.keyMismatchDetected,
-          keySecurityIssueDetails: nodeData.keySecurityIssueDetails ?? existingNode.keySecurityIssueDetails,
+          keyIsLowEntropy: nodeData.keyIsLowEntropy !== undefined ? nodeData.keyIsLowEntropy : existingNode.keyIsLowEntropy,
+          duplicateKeyDetected: nodeData.duplicateKeyDetected !== undefined ? nodeData.duplicateKeyDetected : existingNode.duplicateKeyDetected,
+          keyMismatchDetected: nodeData.keyMismatchDetected !== undefined ? nodeData.keyMismatchDetected : existingNode.keyMismatchDetected,
+          keySecurityIssueDetails: nodeData.keySecurityIssueDetails !== undefined ? nodeData.keySecurityIssueDetails : existingNode.keySecurityIssueDetails,
           positionChannel: nodeData.positionChannel ?? existingNode.positionChannel,
           positionPrecisionBits: nodeData.positionPrecisionBits ?? existingNode.positionPrecisionBits,
           positionTimestamp: this.coerceBigintField(nodeData.positionTimestamp ?? existingNode.positionTimestamp),

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2723,7 +2723,7 @@ class MeshtasticManager {
                     logger.warn(`⚠️ Low-entropy key detected for local node ${localNodeId}!`);
                   } else {
                     updateData.keyIsLowEntropy = false;
-                    updateData.keySecurityIssueDetails = undefined;
+                    updateData.keySecurityIssueDetails = null;
                   }
 
                   await databaseService.nodes.upsertNode(updateData);
@@ -4322,7 +4322,7 @@ class MeshtasticManager {
           // Explicitly clear the flag when key is NOT low-entropy
           // This ensures that if a node regenerates their key, the flag is cleared immediately
           nodeData.keyIsLowEntropy = false;
-          nodeData.keySecurityIssueDetails = undefined;
+          nodeData.keySecurityIssueDetails = null;
         }
 
         // Check if this node had a key mismatch that is now fixed
@@ -4398,10 +4398,10 @@ class MeshtasticManager {
             }
 
             nodeData.keyMismatchDetected = false;
-            nodeData.lastMeshReceivedKey = undefined;
+            nodeData.lastMeshReceivedKey = null;
             // Don't clear keySecurityIssueDetails if there's a low-entropy issue
             if (!isLowEntropy) {
-              nodeData.keySecurityIssueDetails = undefined;
+              nodeData.keySecurityIssueDetails = null;
             }
 
             // Clear the repair state and log success
@@ -5884,7 +5884,7 @@ class MeshtasticManager {
               // Explicitly clear the flag when key is NOT low-entropy
               // This ensures that if a node regenerates their key, the flag is cleared immediately
               nodeData.keyIsLowEntropy = false;
-              nodeData.keySecurityIssueDetails = undefined;
+              nodeData.keySecurityIssueDetails = null;
             }
           }
         }

--- a/src/server/routes/securityRoutes.ts
+++ b/src/server/routes/securityRoutes.ts
@@ -275,7 +275,7 @@ router.post('/nodes/:nodeNum/clear', requirePermission('security', 'write'), asy
       keyIsLowEntropy: false,
       duplicateKeyDetected: false,
       keyMismatchDetected: false,
-      keySecurityIssueDetails: undefined, // This will now properly clear the field
+      keySecurityIssueDetails: null, // null explicitly clears the field (undefined would preserve existing value)
     });
 
     // Clear time offset flags


### PR DESCRIPTION
## Summary

Two bugs affecting PostgreSQL (and key clearing on all backends):

### 1. Packet Monitor showing hex IDs instead of node names on PostgreSQL
- **Root cause**: PostgreSQL lowercases unquoted column aliases. `SELECT ... as from_node_longName` returns `from_node_longname` in PG results, but frontend expects `from_node_longName`.
- **Fix**: `normalizePacketLogRow` now checks both cases: `row.from_node_longName ?? row.from_node_longname`

### 2. Key mismatch warning never clearing
- **Root cause**: Code set `nodeData.keySecurityIssueDetails = undefined` to clear the field, but the upsert used `??` (nullish coalescing) which treats `undefined` as "not provided" and falls back to the existing DB value — so the warning persisted forever.
- **Fix**: Changed clear assignments to `null`, and updated upsert to use `!== undefined` checks so `null` explicitly clears the field.

## Changes

| File | Change |
|------|--------|
| `src/db/repositories/misc.ts` | Normalize PG lowercase aliases in `normalizePacketLogRow` |
| `src/db/repositories/nodes.ts` | Use `!== undefined` for security flag fields in upsert |
| `src/server/meshtasticManager.ts` | Use `null` instead of `undefined` to clear security fields |
| `src/server/routes/securityRoutes.ts` | Same `null` fix for manual security flag clear |

## Test plan

- [x] `npx vitest run` — 3070 tests pass
- [x] `npm run build` — no TypeScript errors
- [ ] Verify packet monitor shows node names on PostgreSQL
- [ ] Verify key mismatch warning clears after NodeInfo exchange on PostgreSQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)