### PR TITLE
fix: admin keys showing as [object Object] in security config UI

### DIFF
--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -708,7 +708,16 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
               if (Array.isArray(key)) {
                 return btoa(String.fromCharCode(...key));
               }
-              return String(key);
+              // Handle JSON-serialized Uint8Array or other objects with numeric values
+              if (key && typeof key === 'object') {
+                try {
+                  const bytes = Object.values(key) as number[];
+                  return btoa(String.fromCharCode(...bytes));
+                } catch {
+                  // fall through
+                }
+              }
+              return '';
             });
             setSecurityAdminKeys(keys.length > 0 ? keys : ['']);
           }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -207,6 +207,32 @@ let embedOriginsCache: string[] = [];
 let embedOriginsCacheTime = 0;
 const EMBED_ORIGINS_CACHE_TTL = 60000;
 
+/** Convert protobuf bytes (Uint8Array, Buffer, byte array, or object) to base64 string */
+function bytesToBase64(key: any): string {
+  if (key instanceof Uint8Array || Buffer.isBuffer(key)) {
+    return Buffer.from(key).toString('base64');
+  }
+  if (key && typeof key === 'object' && key.type === 'Buffer' && Array.isArray(key.data)) {
+    return Buffer.from(key.data).toString('base64');
+  }
+  if (Array.isArray(key)) {
+    return Buffer.from(key).toString('base64');
+  }
+  if (typeof key === 'string') {
+    return key;
+  }
+  // Handle generic iterables/objects with byte data (e.g., protobuf Bytes wrappers)
+  if (key && typeof key === 'object') {
+    try {
+      return Buffer.from(Object.values(key) as number[]).toString('base64');
+    } catch {
+      // fall through
+    }
+  }
+  logger.warn('Unknown admin key format:', typeof key, key);
+  return '';
+}
+
 function refreshEmbedOriginsCache(): void {
   databaseService.embedProfiles.getAllAsync().then(profiles => {
     embedOriginsCache = [...new Set(
@@ -5924,26 +5950,7 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
               // Convert admin keys from Uint8Array to base64 strings for UI
               const localAdminKeys = finalConfig.deviceConfig.security.adminKey || [];
               config = {
-                adminKeys: localAdminKeys.map((key: any) => {
-                  if (key instanceof Uint8Array || Buffer.isBuffer(key)) {
-                    return Buffer.from(key).toString('base64');
-                  }
-                  // Handle JSON-serialized Buffer objects (e.g., { type: 'Buffer', data: [...] })
-                  if (key && typeof key === 'object' && key.type === 'Buffer' && Array.isArray(key.data)) {
-                    return Buffer.from(key.data).toString('base64');
-                  }
-                  // Handle array of bytes
-                  if (Array.isArray(key)) {
-                    return Buffer.from(key).toString('base64');
-                  }
-                  // Already a string (base64)
-                  if (typeof key === 'string') {
-                    return key;
-                  }
-                  // Fallback - try to convert
-                  logger.warn('Unknown admin key format:', typeof key, key);
-                  return String(key);
-                }),
+                adminKeys: localAdminKeys.map((key: any) => bytesToBase64(key)),
                 isManaged: finalConfig.deviceConfig.security.isManaged,
                 serialEnabled: finalConfig.deviceConfig.security.serialEnabled,
                 debugLogApiEnabled: finalConfig.deviceConfig.security.debugLogApiEnabled,
@@ -6135,26 +6142,7 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
             // Convert admin keys from Uint8Array to base64 strings for UI
             const remoteAdminKeys = remoteConfig.adminKey || [];
             config = {
-              adminKeys: remoteAdminKeys.map((key: any) => {
-                if (key instanceof Uint8Array || Buffer.isBuffer(key)) {
-                  return Buffer.from(key).toString('base64');
-                }
-                // Handle JSON-serialized Buffer objects (e.g., { type: 'Buffer', data: [...] })
-                if (key && typeof key === 'object' && key.type === 'Buffer' && Array.isArray(key.data)) {
-                  return Buffer.from(key.data).toString('base64');
-                }
-                // Handle array of bytes
-                if (Array.isArray(key)) {
-                  return Buffer.from(key).toString('base64');
-                }
-                // Already a string (base64)
-                if (typeof key === 'string') {
-                  return key;
-                }
-                // Fallback - try to convert
-                logger.warn('Unknown admin key format:', typeof key, key);
-                return String(key);
-              }),
+              adminKeys: remoteAdminKeys.map((key: any) => bytesToBase64(key)),
               isManaged: remoteConfig.isManaged,
               serialEnabled: remoteConfig.serialEnabled,
               debugLogApiEnabled: remoteConfig.debugLogApiEnabled,


### PR DESCRIPTION
## Summary

Remote Admin keys on the Device Configuration page displayed as `[object Object]` instead of base64 strings, on both SQLite and PostgreSQL backends.

**Root cause**: Protobuf `bytes` fields serialize to plain objects with numeric keys when JSON-encoded (e.g., `{"0": 72, "1": 101, ...}`). Both server and frontend key conversion code only handled `Uint8Array`, `Buffer`, and plain arrays — not these generic objects, so they fell through to `String(key)` which produced `[object Object]`.

**Fix**: 
- Server: extracted shared `bytesToBase64()` helper with generic object fallback via `Object.values()`
- Frontend: added same `Object.values()` conversion for generic byte objects in `ConfigurationTab.tsx`

## Changes

| File | Change |
|------|--------|
| `src/server/server.ts` | `bytesToBase64()` helper, replaced inline conversion in both local and remote config paths |
| `src/components/ConfigurationTab.tsx` | Added generic object→base64 conversion for admin keys |

## Test plan

- [x] `npx vitest run` — 3070 tests pass
- [x] `npm run build` — no TypeScript errors
- [x] Deploy on SQLite, verify admin keys display correctly
- [ ] Verify on PostgreSQL backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)