### PR TITLE
feat: add rsyslog server setting to network configuration

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2824,6 +2824,8 @@
   "network_config.dns_description": "DNS server address (e.g., 8.8.8.8).",
   "network_config.ntp_server": "NTP Server",
   "network_config.ntp_server_description": "Custom NTP server address (default: meshtastic.pool.ntp.org). Maximum 33 characters.",
+  "network_config.rsyslog_server": "Rsyslog Server",
+  "network_config.rsyslog_server_description": "Remote syslog server address (e.g., 192.168.1.100:514). Leave blank to disable.",
   "network_config.save_button": "Save Network Config",
 
   "config.network_saved": "Network configuration saved",

--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -127,6 +127,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
   const [wifiSsid, setWifiSsid] = useState('');
   const [wifiPsk, setWifiPsk] = useState('');
   const [ntpServer, setNtpServer] = useState('');
+  const [rsyslogServer, setRsyslogServer] = useState('');
   const [addressMode, setAddressMode] = useState(0);
   const [ipv4Address, setIpv4Address] = useState('');
   const [ipv4Gateway, setIpv4Gateway] = useState('');
@@ -488,6 +489,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
           setWifiSsid(config.deviceConfig.network.wifiSsid || '');
           setWifiPsk(config.deviceConfig.network.wifiPsk || '');
           setNtpServer(config.deviceConfig.network.ntpServer || '');
+          setRsyslogServer(config.deviceConfig.network.rsyslogServer || '');
           setAddressMode(config.deviceConfig.network.addressMode ?? 0);
           // Static IP config
           if (config.deviceConfig.network.ipv4Config) {
@@ -1015,6 +1017,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
         wifiSsid,
         wifiPsk,
         ntpServer,
+        rsyslogServer,
         addressMode,
         // Static IP config - only include if using static address mode
         ipv4Config: addressMode === 1 ? {
@@ -1702,6 +1705,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
         // Update remaining network fields
         if (net.wifiPsk !== undefined) setWifiPsk(net.wifiPsk);
         if (net.ntpServer !== undefined) setNtpServer(net.ntpServer);
+        if (net.rsyslogServer !== undefined) setRsyslogServer(net.rsyslogServer);
         if (net.ipv4Config) {
           if (net.ipv4Config.ip !== undefined) setIpv4Address(net.ipv4Config.ip);
           if (net.ipv4Config.gateway !== undefined) setIpv4Gateway(net.ipv4Config.gateway);
@@ -2295,6 +2299,8 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
             setWifiPsk={setWifiPsk}
             ntpServer={ntpServer}
             setNtpServer={setNtpServer}
+            rsyslogServer={rsyslogServer}
+            setRsyslogServer={setRsyslogServer}
             addressMode={addressMode}
             setAddressMode={setAddressMode}
             ipv4Address={ipv4Address}

--- a/src/components/configuration/NetworkConfigSection.tsx
+++ b/src/components/configuration/NetworkConfigSection.tsx
@@ -17,6 +17,8 @@ interface NetworkConfigSectionProps {
   setWifiPsk: (value: string) => void;
   ntpServer: string;
   setNtpServer: (value: string) => void;
+  rsyslogServer: string;
+  setRsyslogServer: (value: string) => void;
   addressMode: number;
   setAddressMode: (value: number) => void;
   // Static IP config
@@ -42,6 +44,8 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
   setWifiPsk,
   ntpServer,
   setNtpServer,
+  rsyslogServer,
+  setRsyslogServer,
   addressMode,
   setAddressMode,
   ipv4Address,
@@ -60,7 +64,7 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
 
   // Track initial values for change detection
   const initialValuesRef = useRef({
-    wifiEnabled, wifiSsid, wifiPsk, ntpServer, addressMode,
+    wifiEnabled, wifiSsid, wifiPsk, ntpServer, rsyslogServer, addressMode,
     ipv4Address, ipv4Gateway, ipv4Subnet, ipv4Dns
   });
 
@@ -72,13 +76,14 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
       wifiSsid !== initial.wifiSsid ||
       wifiPsk !== initial.wifiPsk ||
       ntpServer !== initial.ntpServer ||
+      rsyslogServer !== initial.rsyslogServer ||
       addressMode !== initial.addressMode ||
       ipv4Address !== initial.ipv4Address ||
       ipv4Gateway !== initial.ipv4Gateway ||
       ipv4Subnet !== initial.ipv4Subnet ||
       ipv4Dns !== initial.ipv4Dns
     );
-  }, [wifiEnabled, wifiSsid, wifiPsk, ntpServer, addressMode,
+  }, [wifiEnabled, wifiSsid, wifiPsk, ntpServer, rsyslogServer, addressMode,
       ipv4Address, ipv4Gateway, ipv4Subnet, ipv4Dns]);
 
   // Reset to initial values (for SaveBar dismiss)
@@ -88,22 +93,23 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
     setWifiSsid(initial.wifiSsid);
     setWifiPsk(initial.wifiPsk);
     setNtpServer(initial.ntpServer);
+    setRsyslogServer(initial.rsyslogServer);
     setAddressMode(initial.addressMode);
     setIpv4Address(initial.ipv4Address);
     setIpv4Gateway(initial.ipv4Gateway);
     setIpv4Subnet(initial.ipv4Subnet);
     setIpv4Dns(initial.ipv4Dns);
-  }, [setWifiEnabled, setWifiSsid, setWifiPsk, setNtpServer, setAddressMode,
+  }, [setWifiEnabled, setWifiSsid, setWifiPsk, setNtpServer, setRsyslogServer, setAddressMode,
       setIpv4Address, setIpv4Gateway, setIpv4Subnet, setIpv4Dns]);
 
   // Update initial values after successful save
   const handleSave = useCallback(async () => {
     await onSave();
     initialValuesRef.current = {
-      wifiEnabled, wifiSsid, wifiPsk, ntpServer, addressMode,
+      wifiEnabled, wifiSsid, wifiPsk, ntpServer, rsyslogServer, addressMode,
       ipv4Address, ipv4Gateway, ipv4Subnet, ipv4Dns
     };
-  }, [onSave, wifiEnabled, wifiSsid, wifiPsk, ntpServer, addressMode,
+  }, [onSave, wifiEnabled, wifiSsid, wifiPsk, ntpServer, rsyslogServer, addressMode,
       ipv4Address, ipv4Gateway, ipv4Subnet, ipv4Dns]);
 
   // Register with SaveBar
@@ -321,6 +327,24 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
           value={ntpServer}
           onChange={(e) => setNtpServer(e.target.value)}
           placeholder="meshtastic.pool.ntp.org"
+          maxLength={33}
+          className="setting-input"
+          style={{ width: '400px' }}
+        />
+      </div>
+
+      {/* Rsyslog Server */}
+      <div className="setting-item">
+        <label htmlFor="rsyslogServer">
+          {t('network_config.rsyslog_server')}
+          <span className="setting-description">{t('network_config.rsyslog_server_description')}</span>
+        </label>
+        <input
+          id="rsyslogServer"
+          type="text"
+          value={rsyslogServer}
+          onChange={(e) => setRsyslogServer(e.target.value)}
+          placeholder="192.168.1.100:514"
           maxLength={33}
           className="setting-input"
           style={{ width: '400px' }}


### PR DESCRIPTION
## Summary

Adds rsyslog server field to Device Configuration > Network settings, allowing users to configure a remote syslog server address (e.g., `192.168.1.100:514`).

Backend protobuf support already existed in `protobufService.ts` — this adds the UI and wiring.

## Changes

| File | Change |
|------|--------|
| `src/components/ConfigurationTab.tsx` | State, load, save, and prop passing for `rsyslogServer` |
| `src/components/configuration/NetworkConfigSection.tsx` | Props, change detection, reset, and input field |
| `public/locales/en.json` | Translation keys for label and description |

## Test plan

- [x] `npx vitest run` — 3070 tests pass
- [x] `npm run build` — no TypeScript errors
- [x] Deploy on SQLite, verify field appears and persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)