### PR TITLE
chore: bump version to 3.10.0-RC8

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "3.10.0-RC7",
+  "version": "3.10.0-RC8",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.10.0-RC7",
+  "version": "3.10.0-RC8",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.10.0-RC7
-appVersion: "3.10.0-RC7"
+version: 3.10.0-RC8
+appVersion: "3.10.0-RC8"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.10.0-RC7",
+  "version": "3.10.0-RC8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.10.0-RC7",
+      "version": "3.10.0-RC8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.10.0-RC7",
+  "version": "3.10.0-RC8",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Version bump to 3.10.0-RC8.

## Changes since RC7

### Features
- feat: channel drag-and-drop reorder with message migration (#2411)
- feat: add rsyslog server setting to network configuration (#2410)

### Bug Fixes
- fix: PG packet monitor names and key mismatch flag not clearing (#2406)
- fix: prevent local node from self-flagging security warnings (#2407)
- fix: admin keys showing as [object Object] in security config UI (#2408)

🤖 Generated with [Claude Code](https://claude.com/claude-code)