### PR TITLE
fix: channel database no longer shadows device channels with same PSK

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3988,22 +3988,39 @@ class MeshtasticManager {
             logger.debug(`💾 Saved channel message from ${message.fromNodeId} on channel ${channelIndex}: "${messageText.substring(0, 30)}..." (replyId: ${message.replyId})`);
           }
 
-          // Dual-channel insertion: if server-decrypted and the packet has a radio channel,
-          // also insert a copy in the radio channel so both views show the message (#2375)
-          if (!isDirectMessage && context?.decryptedBy === 'server' && meshPacket.channel !== undefined) {
-            const radioChannelIndex = meshPacket.channel;
-            const radioChannel = await databaseService.channels.getChannelById(radioChannelIndex);
-            if (radioChannel) {
-              const radioCopy: TextMessage = {
+          // Dual-channel insertion for server-decrypted messages (#2375, #2413)
+          // Messages should appear in BOTH the device channel and database channel views
+          if (!isDirectMessage && context?.decryptedBy === 'server' && context?.decryptedChannelId !== undefined) {
+            if (channelIndex < CHANNEL_DB_OFFSET) {
+              // Primary went to device channel — also insert into database channel
+              const dbChannelIndex = CHANNEL_DB_OFFSET + context.decryptedChannelId;
+              const dbCopy: TextMessage = {
                 ...message,
-                id: `${message.id}_radio`,
-                channel: radioChannelIndex,
+                id: `${message.id}_dbchan`,
+                channel: dbChannelIndex,
                 decryptedBy: 'server',
               };
-              const radioInserted = await databaseService.messages.insertMessage(radioCopy);
-              if (radioInserted) {
-                dataEventEmitter.emitNewMessage(radioCopy as any);
-                logger.debug(`💾 Also saved to radio channel ${radioChannelIndex} ("${radioChannel.name}")`);
+              const dbInserted = await databaseService.messages.insertMessage(dbCopy);
+              if (dbInserted) {
+                dataEventEmitter.emitNewMessage(dbCopy as any);
+                logger.debug(`💾 Also saved to database channel ${dbChannelIndex}`);
+              }
+            } else if (meshPacket.channel !== undefined) {
+              // Primary went to database channel — also insert into radio channel if it exists
+              const radioChannelIndex = meshPacket.channel;
+              const radioChannel = await databaseService.channels.getChannelById(radioChannelIndex);
+              if (radioChannel) {
+                const radioCopy: TextMessage = {
+                  ...message,
+                  id: `${message.id}_radio`,
+                  channel: radioChannelIndex,
+                  decryptedBy: 'server',
+                };
+                const radioInserted = await databaseService.messages.insertMessage(radioCopy);
+                if (radioInserted) {
+                  dataEventEmitter.emitNewMessage(radioCopy as any);
+                  logger.debug(`💾 Also saved to radio channel ${radioChannelIndex} ("${radioChannel.name}")`);
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary

Fixes the Channel Database "shadowing" bug where a database channel with the same PSK as a device channel would intercept all incoming messages, causing them to appear in the database channel view instead of the device channel.

**Root cause**: When server-side decryption matched a database channel, the message was always assigned to `CHANNEL_DB_OFFSET + dbChannelId`, even when a device channel had the identical PSK. This caused MQTT-proxied messages to show in the database channel chat window instead of the device channel.

**Fix**: After server-side decryption, check if any active device channel (0-7) has the same PSK as the matched database channel. If so, assign the message to the device channel slot instead. The database channel still gets decryption credit (counter incremented) and the encrypted packet is still forwarded to the physical node unchanged.

Fixes #2413, fixes #2375

## Changes

| File | Change |
|------|--------|
| `src/server/meshtasticManager.ts` | PSK comparison after server decryption to prefer device channels |

## Test plan

- [x] `npx vitest run` — 3070 tests pass
- [x] `npm run build` — no TypeScript errors
- [ ] User @LN4CY to verify: MQTT messages now appear in device channel instead of database channel when PSKs match

🤖 Generated with [Claude Code](https://claude.com/claude-code)