### PR TITLE
chore: release v3.10.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "3.10.0-RC8",
+  "version": "3.10.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.10.0-RC8",
+  "version": "3.10.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/public/news.json
+++ b/docs/public/news.json
@@ -1,7 +1,16 @@
 {
   "version": "1",
-  "lastUpdated": "2026-03-15T18:00:00Z",
+  "lastUpdated": "2026-03-24T20:00:00Z",
   "items": [
+    {
+      "minVersion": "3.10.0",
+      "id": "news-2026-03-24-v3.10.0-database-refactor",
+      "title": "MeshMonitor v3.10.0 — Major Database Refactoring & Channel Management",
+      "content": "MeshMonitor v3.10.0 is a major release featuring a comprehensive database architecture overhaul — **5,672 lines of code removed** across 278 files while adding new features and fixing dozens of bugs.\n\n## New Features\n\n- **Channel drag-and-drop reorder** — Rearrange device channel slots with automatic message history migration so your chat history follows the channel\n- **Dead nodes report** — New Security tab section showing nodes not heard from in 7+ days with bulk delete capability\n- **Rsyslog server setting** — Configure remote syslog server in Device Configuration > Network\n- **Polar grid map overlay** — Visual polar grid overlay for directional analysis\n- **Configurable default map center** — Set your preferred starting map location\n- **Auto responder environment variables** — Expose auto responder tokens as environment variables for external scripts\n- **Millisecond packet timestamps** — Sub-second precision in packet monitor with dedicated date column\n- **OIDC retry on failure** — Authentication no longer permanently disables if OIDC provider is temporarily unavailable\n\n## Database Architecture Improvements\n\n- **Full async migration** — All synchronous database calls replaced with async equivalents across all three backends\n- **Repository pattern** — Monolithic DatabaseService decomposed into domain-specific repositories (nodes, messages, telemetry, channels, etc.)\n- **Centralized migration registry** — Clean v3.7 baseline with standardized migration system\n- **N+1 query elimination** — Bulk queries replace per-node loops in security scanner, neighbor info, and node listing\n- **Cross-database helpers** — New `col()`, `upsert()`, `insertIgnore()`, and `getAffectedRows()` helpers eliminate backend-specific branching\n\n## Bug Fixes\n\n- Channel database no longer shadows device channels with the same PSK\n- PostgreSQL connection pool exhaustion with large meshes (200+ nodes)\n- Local node no longer self-flags security warnings or bounces link quality\n- Key mismatch warnings now properly clear after resolution on all backends\n- Traceroute race conditions and duplication issues resolved\n- Admin keys no longer show as [object Object] in security config\n- MQTT detection and visual distinction in traceroutes improved\n- Packet monitor shows node names instead of hex IDs on PostgreSQL",
+      "date": "2026-03-24T20:00:00Z",
+      "category": "release",
+      "priority": "important"
+    },
     {
       "minVersion": "3.9.4",
       "id": "news-2026-03-15-distance-delete-traceroute",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.10.0-RC8
-appVersion: "3.10.0-RC8"
+version: 3.10.0
+appVersion: "3.10.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.10.0-RC8",
+  "version": "3.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.10.0-RC8",
+      "version": "3.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.10.0-RC8",
+  "version": "3.10.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## MeshMonitor v3.10.0

Major release featuring comprehensive database architecture refactoring — **5,672 lines of code removed** across 278 files — plus new features and dozens of bug fixes.

### New Features
- Channel drag-and-drop reorder with message history migration (#2411)
- Dead nodes report with bulk delete on Security tab (#2414)
- Rsyslog server setting in network configuration (#2410)
- Polar grid map overlay (#2359)
- Configurable default map center (#2350)
- Auto responder tokens as environment variables (#2356)
- Millisecond packet timestamps with date column (#2403)
- OIDC retry on initialization failure (#2402)

### Database Architecture
- Full async migration — all sync calls replaced (Phase 1-4: #2323, #2324, #2325, #2328, #2330, #2332, #2335)
- Repository pattern decomposition (#2309, #2310)
- Centralized migration registry with v3.7 baseline (#2315)
- N+1 query elimination (#2336, #2339, #2404)
- Cross-database helpers: col(), upsert(), insertIgnore(), getAffectedRows() (#2372, #2374, #2376, #2389)

### Bug Fixes
- Channel database no longer shadows device channels with same PSK (#2415, #2413, #2375)
- PG pool exhaustion with 200+ nodes (#2404)
- Local node self-flagging security warnings (#2407)
- Key mismatch warnings not clearing (#2406)
- Admin keys showing [object Object] (#2408)
- Traceroute race conditions and duplication (#2366, #2380, #2387)
- MQTT detection in traceroutes (#2302)
- PKI_UNKNOWN_PUBKEY key mismatch flagging (#2382)
- PG packet monitor showing hex IDs (#2406)
- Time offset flags not persisted on SQLite (#2379)
- Maintenance service scheduling drift (#2338)

### News
- Added v3.10.0 news.json entry for in-app notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)