### PR TITLE
feat: icon style toggle — Lucide or emoji sidebar icons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -279,6 +279,7 @@ function App() {
     dateFormat,
     mapTileset,
     mapPinStyle,
+    iconStyle,
     theme,
     language,
     solarMonitoringEnabled,
@@ -305,6 +306,7 @@ function App() {
     setDateFormat,
     setMapTileset,
     setMapPinStyle,
+    setIconStyle,
     setTheme,
     setLanguage,
     setSolarMonitoringEnabled,
@@ -4804,6 +4806,7 @@ function App() {
             dateFormat={dateFormat}
             mapTileset={mapTileset}
             mapPinStyle={mapPinStyle}
+            iconStyle={iconStyle}
             theme={theme}
             language={language}
             solarMonitoringEnabled={solarMonitoringEnabled}
@@ -4829,6 +4832,7 @@ function App() {
             onDateFormatChange={setDateFormat}
             onMapTilesetChange={setMapTileset}
             onMapPinStyleChange={setMapPinStyle}
+            onIconStyleChange={setIconStyle}
             onThemeChange={setTheme}
             onLanguageChange={setLanguage}
             onSolarMonitoringEnabledChange={setSolarMonitoringEnabled}

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -32,6 +32,7 @@ type PositionHistoryLineStyle = 'linear' | 'spline';
 type TimeFormat = '12' | '24';
 type DateFormat = 'MM/DD/YYYY' | 'DD/MM/YYYY' | 'YYYY-MM-DD';
 type MapPinStyle = 'meshmonitor' | 'official';
+type IconStyle = 'lucide' | 'emoji';
 
 interface SettingsTabProps {
   maxNodeAgeHours: number;
@@ -49,6 +50,7 @@ interface SettingsTabProps {
   dateFormat: DateFormat;
   mapTileset: TilesetId;
   mapPinStyle: MapPinStyle;
+  iconStyle: IconStyle;
   theme: Theme;
   language: string;
   solarMonitoringEnabled: boolean;
@@ -74,6 +76,7 @@ interface SettingsTabProps {
   onDateFormatChange: (format: DateFormat) => void;
   onMapTilesetChange: (tilesetId: TilesetId) => void;
   onMapPinStyleChange: (style: MapPinStyle) => void;
+  onIconStyleChange: (style: IconStyle) => void;
   onThemeChange: (theme: Theme) => void;
   onLanguageChange: (language: string) => void;
   onSolarMonitoringEnabledChange: (enabled: boolean) => void;
@@ -99,6 +102,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   dateFormat,
   mapTileset,
   mapPinStyle,
+  iconStyle,
   theme,
   language,
   solarMonitoringEnabled,
@@ -124,6 +128,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   onDateFormatChange,
   onMapTilesetChange,
   onMapPinStyleChange,
+  onIconStyleChange,
   onThemeChange,
   onLanguageChange,
   onSolarMonitoringEnabledChange,
@@ -178,6 +183,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   const [localDateFormat, setLocalDateFormat] = useState(dateFormat);
   const [localMapTileset, setLocalMapTileset] = useState(mapTileset);
   const [localMapPinStyle, setLocalMapPinStyle] = useState(mapPinStyle);
+  const [localIconStyle, setLocalIconStyle] = useState(iconStyle);
   const [localNeighborInfoMinZoom, setLocalNeighborInfoMinZoom] = useState(neighborInfoMinZoom);
   const [localDefaultMapCenterLat, setLocalDefaultMapCenterLat] = useState<number | null>(defaultMapCenterLat);
   const [localDefaultMapCenterLon, setLocalDefaultMapCenterLon] = useState<number | null>(defaultMapCenterLon);
@@ -328,6 +334,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalDateFormat(dateFormat);
     setLocalMapTileset(mapTileset);
     setLocalMapPinStyle(mapPinStyle);
+    setLocalIconStyle(iconStyle);
     setLocalNeighborInfoMinZoom(neighborInfoMinZoom);
     setLocalDefaultMapCenterLat(defaultMapCenterLat);
     setLocalDefaultMapCenterLon(defaultMapCenterLon);
@@ -383,6 +390,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localDateFormat !== dateFormat ||
       localMapTileset !== mapTileset ||
       localMapPinStyle !== mapPinStyle ||
+      localIconStyle !== iconStyle ||
       localNeighborInfoMinZoom !== neighborInfoMinZoom ||
       localDefaultMapCenterLat !== defaultMapCenterLat ||
       localDefaultMapCenterLon !== defaultMapCenterLon ||
@@ -407,8 +415,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localAnalyticsProvider !== initialAnalyticsProvider ||
       JSON.stringify(localAnalyticsConfig) !== initialAnalyticsConfig;
     setHasChanges(changed);
-  }, [localMaxNodeAge, localInactiveNodeThresholdHours, localInactiveNodeCheckIntervalMinutes, localInactiveNodeCooldownHours, localTemperatureUnit, localDistanceUnit, localPositionHistoryLineStyle, localTelemetryHours, localFavoriteTelemetryStorageDays, localPreferredSortField, localPreferredSortDirection, localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localNeighborInfoMinZoom, localDefaultMapCenterLat, localDefaultMapCenterLon, localDefaultMapCenterZoom, localTheme, localNodeHopsCalculation, localDashboardSortOption,
-      maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTileset, mapPinStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, theme, nodeHopsCalculation, preferredDashboardSortOption,
+  }, [localMaxNodeAge, localInactiveNodeThresholdHours, localInactiveNodeCheckIntervalMinutes, localInactiveNodeCooldownHours, localTemperatureUnit, localDistanceUnit, localPositionHistoryLineStyle, localTelemetryHours, localFavoriteTelemetryStorageDays, localPreferredSortField, localPreferredSortDirection, localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localIconStyle, localNeighborInfoMinZoom, localDefaultMapCenterLat, localDefaultMapCenterLon, localDefaultMapCenterZoom, localTheme, localNodeHopsCalculation, localDashboardSortOption,
+      maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTileset, mapPinStyle, iconStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, theme, nodeHopsCalculation, preferredDashboardSortOption,
       localPacketLogEnabled, localPacketLogMaxCount, localPacketLogMaxAgeHours, initialPacketMonitorSettings,
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude, localSolarMonitoringAzimuth, localSolarMonitoringDeclination,
       solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination,
@@ -434,6 +442,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalDateFormat(dateFormat);
     setLocalMapTileset(mapTileset);
     setLocalMapPinStyle(mapPinStyle);
+    setLocalIconStyle(iconStyle);
     setLocalDefaultMapCenterLat(defaultMapCenterLat);
     setLocalDefaultMapCenterLon(defaultMapCenterLon);
     setLocalDefaultMapCenterZoom(defaultMapCenterZoom);
@@ -459,7 +468,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   }, [maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes,
       inactiveNodeCooldownHours, temperatureUnit, distanceUnit, telemetryVisualizationHours,
       favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat,
-      dateFormat, mapTileset, mapPinStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, theme, nodeHopsCalculation, preferredDashboardSortOption,
+      dateFormat, mapTileset, mapPinStyle, iconStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, theme, nodeHopsCalculation, preferredDashboardSortOption,
       initialPacketMonitorSettings, solarMonitoringEnabled, solarMonitoringLatitude,
       solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes,
       initialHomoglyphEnabled, initialLocalStatsIntervalMinutes, initialNodeDimmingSettings,
@@ -485,6 +494,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         dateFormat: localDateFormat,
         mapTileset: localMapTileset,
         mapPinStyle: localMapPinStyle,
+        iconStyle: localIconStyle,
         neighborInfoMinZoom: localNeighborInfoMinZoom.toString(),
         defaultMapCenterLat: localDefaultMapCenterLat !== null ? localDefaultMapCenterLat.toString() : '',
         defaultMapCenterLon: localDefaultMapCenterLon !== null ? localDefaultMapCenterLon.toString() : '',
@@ -532,6 +542,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       onDateFormatChange(localDateFormat);
       onMapTilesetChange(localMapTileset);
       onMapPinStyleChange(localMapPinStyle);
+      onIconStyleChange(localIconStyle);
       setNeighborInfoMinZoom(localNeighborInfoMinZoom);
       setDefaultMapCenterLat(localDefaultMapCenterLat);
       setDefaultMapCenterLon(localDefaultMapCenterLon);
@@ -570,7 +581,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localInactiveNodeCheckIntervalMinutes, localInactiveNodeCooldownHours,
       localTemperatureUnit, localDistanceUnit, localPositionHistoryLineStyle, localTelemetryHours,
       localFavoriteTelemetryStorageDays, localPreferredSortField, localPreferredSortDirection,
-      localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localNeighborInfoMinZoom, localDefaultMapCenterLat, localDefaultMapCenterLon, localDefaultMapCenterZoom, localTheme,
+      localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localIconStyle, localNeighborInfoMinZoom, localDefaultMapCenterLat, localDefaultMapCenterLon, localDefaultMapCenterZoom, localTheme,
       localNodeHopsCalculation, localDashboardSortOption, localPacketLogEnabled, localPacketLogMaxCount, localPacketLogMaxAgeHours,
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude,
       localSolarMonitoringAzimuth, localSolarMonitoringDeclination, localHideIncompleteNodes, localHomoglyphEnabled, localLocalStatsIntervalMinutes,
@@ -1104,6 +1115,21 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
             >
               <option value="meshmonitor">{t('settings.map_pin_meshmonitor')}</option>
               <option value="official">{t('settings.map_pin_official')}</option>
+            </select>
+          </div>
+          <div className="setting-item">
+            <label htmlFor="iconStyle">
+              {t('settings.icon_style_label', 'Icon Style')}
+              <span className="setting-description">{t('settings.icon_style_description', 'Choose between modern Lucide icons or classic emoji icons for the navigation sidebar.')}</span>
+            </label>
+            <select
+              id="iconStyle"
+              value={localIconStyle}
+              onChange={(e) => setLocalIconStyle(e.target.value as IconStyle)}
+              className="setting-input"
+            >
+              <option value="lucide">{t('settings.icon_style_lucide', 'Lucide (Modern)')}</option>
+              <option value="emoji">{t('settings.icon_style_emoji', 'Emoji (Classic)')}</option>
             </select>
           </div>
           <TapbackEmojiSettings />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Map, MessageSquare, Mail, Search, Info, LayoutDashboard, Radio, Activity,
@@ -7,7 +7,48 @@ import {
 import './Sidebar.css';
 import { TabType } from '../types/ui';
 import { ResourceType } from '../types/permission';
+import { useSettings } from '../contexts/SettingsContext';
 import packageJson from '../../package.json';
+
+/** Emoji fallbacks for each navigation icon */
+const EMOJI_ICONS: Record<string, string> = {
+  nodes: '🗺️',
+  channels: '💬',
+  messages: '📧',
+  search: '🔍',
+  info: 'ℹ️',
+  dashboard: '📊',
+  meshcore: '📻',
+  packetmonitor: '📈',
+  settings: '⚙️',
+  automation: '🤖',
+  configuration: '📡',
+  notifications: '🔔',
+  users: '👥',
+  admin: '⚡',
+  audit: '📋',
+  security: '🛡️',
+};
+
+/** Lucide icon components for each navigation icon */
+const LUCIDE_ICONS: Record<string, React.ReactNode> = {
+  nodes: <Map size={20} />,
+  channels: <MessageSquare size={20} />,
+  messages: <Mail size={20} />,
+  search: <Search size={20} />,
+  info: <Info size={20} />,
+  dashboard: <LayoutDashboard size={20} />,
+  meshcore: <Radio size={20} />,
+  packetmonitor: <Activity size={20} />,
+  settings: <Settings size={20} />,
+  automation: <Bot size={20} />,
+  configuration: <Satellite size={20} />,
+  notifications: <Bell size={20} />,
+  users: <Users size={20} />,
+  admin: <Zap size={20} />,
+  audit: <ClipboardList size={20} />,
+  security: <Shield size={20} />,
+};
 
 interface UnreadCountsData {
   channels?: {[channelId: number]: number};
@@ -49,6 +90,15 @@ const Sidebar: React.FC<SidebarProps> = ({
   packetLogEnabled
 }) => {
   const { t } = useTranslation();
+  const { iconStyle } = useSettings();
+
+  const icon = useMemo(() => {
+    const useEmoji = iconStyle === 'emoji';
+    return (name: string) => useEmoji
+      ? <span style={{ fontSize: '1.2rem' }}>{EMOJI_ICONS[name] || '❓'}</span>
+      : (LUCIDE_ICONS[name] || null);
+  }, [iconStyle]);
+
   // Start collapsed (narrow/icon-only) by default for cleaner desktop UI
   const [isCollapsed, setIsCollapsed] = useState(true);
   // Pin state persisted to localStorage - when pinned, sidebar won't auto-collapse on nav click
@@ -157,12 +207,12 @@ const Sidebar: React.FC<SidebarProps> = ({
       <nav className="sidebar-nav">
         <SectionHeader title={t('nav.section_main')} />
         <div className="sidebar-section">
-          <NavItem id="nodes" label={t('nav.nodes')} icon={<Map size={20} />} />
+          <NavItem id="nodes" label={t('nav.nodes')} icon={icon('nodes')} />
           {hasAnyChannelPermission() && (
             <NavItem
               id="channels"
               label={t('nav.channels')}
-              icon={<MessageSquare size={20} />}
+              icon={icon('channels')}
               onClick={onChannelsClick}
               showNotification={
                 unreadCountsData?.channels
@@ -175,7 +225,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             <NavItem
               id="messages"
               label={t('nav.messages')}
-              icon={<Mail size={20} />}
+              icon={icon('messages')}
               onClick={onMessagesClick}
               showNotification={
                 unreadCountsData?.directMessages
@@ -193,37 +243,37 @@ const Sidebar: React.FC<SidebarProps> = ({
               }}
               title={isCollapsed ? t('nav.search') : ''}
             >
-              <span className="nav-icon"><Search size={20} /></span>
+              <span className="nav-icon">{icon('search')}</span>
               {!isCollapsed && <span className="nav-label">{t('nav.search')}</span>}
             </button>
           )}
           {hasPermission('info', 'read') && (
-            <NavItem id="info" label={t('nav.info')} icon={<Info size={20} />} />
+            <NavItem id="info" label={t('nav.info')} icon={icon('info')} />
           )}
           {hasPermission('dashboard', 'read') && (
-            <NavItem id="dashboard" label={t('nav.dashboard')} icon={<LayoutDashboard size={20} />} />
+            <NavItem id="dashboard" label={t('nav.dashboard')} icon={icon('dashboard')} />
           )}
           {meshcoreEnabled && hasPermission('meshcore', 'read') && (
-            <NavItem id="meshcore" label={t('nav.meshcore', 'MeshCore')} icon={<Radio size={20} />} />
+            <NavItem id="meshcore" label={t('nav.meshcore', 'MeshCore')} icon={icon('meshcore')} />
           )}
           {packetLogEnabled && hasPermission('packetmonitor', 'read') && (
-            <NavItem id="packetmonitor" label={t('nav.packet_monitor', 'Packet Monitor')} icon={<Activity size={20} />} />
+            <NavItem id="packetmonitor" label={t('nav.packet_monitor', 'Packet Monitor')} icon={icon('packetmonitor')} />
           )}
         </div>
 
         <SectionHeader title={t('nav.section_configuration')} />
         <div className="sidebar-section">
           {hasPermission('settings', 'read') && (
-            <NavItem id="settings" label={t('nav.settings')} icon={<Settings size={20} />} />
+            <NavItem id="settings" label={t('nav.settings')} icon={icon('settings')} />
           )}
           {hasPermission('automation', 'read') && (
-            <NavItem id="automation" label={t('nav.automation')} icon={<Bot size={20} />} />
+            <NavItem id="automation" label={t('nav.automation')} icon={icon('automation')} />
           )}
           {hasPermission('configuration', 'read') && (
-            <NavItem id="configuration" label={t('nav.device')} icon={<Satellite size={20} />} />
+            <NavItem id="configuration" label={t('nav.device')} icon={icon('configuration')} />
           )}
           {isAuthenticated && (
-            <NavItem id="notifications" label={t('nav.notifications')} icon={<Bell size={20} />} />
+            <NavItem id="notifications" label={t('nav.notifications')} icon={icon('notifications')} />
           )}
         </div>
 
@@ -233,15 +283,15 @@ const Sidebar: React.FC<SidebarProps> = ({
             <div className="sidebar-section">
               {isAdmin && (
                 <>
-                  <NavItem id="users" label={t('nav.users')} icon={<Users size={20} />} />
-                  <NavItem id="admin" label={t('nav.admin_commands')} icon={<Zap size={20} />} />
+                  <NavItem id="users" label={t('nav.users')} icon={icon('users')} />
+                  <NavItem id="admin" label={t('nav.admin_commands')} icon={icon('admin')} />
                 </>
               )}
               {hasPermission('audit', 'read') && (
-                <NavItem id="audit" label={t('nav.audit_log')} icon={<ClipboardList size={20} />} />
+                <NavItem id="audit" label={t('nav.audit_log')} icon={icon('audit')} />
               )}
               {hasPermission('security', 'read') && (
-                <NavItem id="security" label={t('nav.security')} icon={<Shield size={20} />} />
+                <NavItem id="security" label={t('nav.security')} icon={icon('security')} />
               )}
             </div>
           </>

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -15,6 +15,7 @@ export type PositionHistoryLineStyle = 'linear' | 'spline';
 export type TimeFormat = '12' | '24';
 export type DateFormat = 'MM/DD/YYYY' | 'DD/MM/YYYY' | 'YYYY-MM-DD';
 export type MapPinStyle = 'meshmonitor' | 'official';
+export type IconStyle = 'lucide' | 'emoji';
 export type NodeHopsCalculation = 'nodeinfo' | 'traceroute' | 'messages';
 
 // Built-in theme types
@@ -61,6 +62,7 @@ interface SettingsContextType {
   overlayScheme: OverlayScheme;
   overlayColors: OverlayColors;
   mapPinStyle: MapPinStyle;
+  iconStyle: IconStyle;
   neighborInfoMinZoom: number;
   defaultMapCenterLat: number | null;
   defaultMapCenterLon: number | null;
@@ -101,6 +103,7 @@ interface SettingsContextType {
   setDateFormat: (format: DateFormat) => void;
   setMapTileset: (tilesetId: TilesetId) => void;
   setMapPinStyle: (style: MapPinStyle) => void;
+  setIconStyle: (style: IconStyle) => void;
   setNeighborInfoMinZoom: (zoom: number) => void;
   setDefaultMapCenterLat: (lat: number | null) => void;
   setDefaultMapCenterLon: (lon: number | null) => void;
@@ -227,6 +230,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
   const [mapPinStyle, setMapPinStyleState] = useState<MapPinStyle>(() => {
     const saved = localStorage.getItem('mapPinStyle');
     return (saved === 'official' ? 'official' : 'meshmonitor') as MapPinStyle;
+  });
+
+  const [iconStyle, setIconStyleState] = useState<IconStyle>(() => {
+    const saved = localStorage.getItem('iconStyle');
+    return (saved === 'emoji' ? 'emoji' : 'lucide') as IconStyle;
   });
 
   const [neighborInfoMinZoom, setNeighborInfoMinZoomState] = useState<number>(() => {
@@ -451,6 +459,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
   const setMapPinStyle = (style: MapPinStyle) => {
     setMapPinStyleState(style);
     localStorage.setItem('mapPinStyle', style);
+  };
+
+  const setIconStyle = (style: IconStyle) => {
+    setIconStyleState(style);
+    localStorage.setItem('iconStyle', style);
   };
 
   const setNeighborInfoMinZoom = (zoom: number) => {
@@ -918,6 +931,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
             localStorage.setItem('mapPinStyle', settings.mapPinStyle);
           }
 
+          if (settings.iconStyle) {
+            setIconStyleState(settings.iconStyle as IconStyle);
+            localStorage.setItem('iconStyle', settings.iconStyle);
+          }
+
           if (settings.neighborInfoMinZoom !== undefined) {
             const zoom = parseInt(settings.neighborInfoMinZoom, 10);
             if (!isNaN(zoom)) {
@@ -1147,6 +1165,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     overlayScheme,
     overlayColors,
     mapPinStyle,
+    iconStyle,
     neighborInfoMinZoom,
     defaultMapCenterLat,
     defaultMapCenterLon,
@@ -1187,6 +1206,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     setDateFormat,
     setMapTileset,
     setMapPinStyle,
+    setIconStyle,
     setNeighborInfoMinZoom,
     setDefaultMapCenterLat,
     setDefaultMapCenterLon,
@@ -1245,6 +1265,7 @@ export const useMapSettings = () => {
   return {
     mapTileset: s.mapTileset, setMapTileset: s.setMapTileset,
     mapPinStyle: s.mapPinStyle, setMapPinStyle: s.setMapPinStyle,
+    iconStyle: s.iconStyle, setIconStyle: s.setIconStyle,
     neighborInfoMinZoom: s.neighborInfoMinZoom, setNeighborInfoMinZoom: s.setNeighborInfoMinZoom,
     overlayScheme: s.overlayScheme, overlayColors: s.overlayColors,
     customTilesets: s.customTilesets,

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -56,6 +56,7 @@ export const VALID_SETTINGS_KEYS = [
   'autoResponderTriggers',
   'autoResponderSkipIncompleteNodes',
   'timerTriggers',
+  'iconStyle',
   'preferredSortField',
   'preferredSortDirection',
   'preferredDashboardSortOption',


### PR DESCRIPTION
## Summary

Adds a setting to switch between modern Lucide icons and classic emoji icons for the navigation sidebar. Addresses user feedback that the Lucide icons are not preferred by all users.

Closes #2308

### Features
- New "Icon Style" dropdown in Settings > Appearance
- Choose between "Lucide (Modern)" and "Emoji (Classic)"
- Immediate visual switch without page reload
- Setting persisted to server and localStorage

### Implementation
- Centralized icon mapping in `Sidebar.tsx` with `LUCIDE_ICONS` and `EMOJI_ICONS` lookup tables
- `iconStyle` setting follows existing pattern (settings constant, SettingsContext, SettingsTab)
- Only affects sidebar navigation icons (16 icons) — packet monitor controls stay as Lucide

## Changes

| File | Change |
|------|--------|
| `src/server/constants/settings.ts` | Added `iconStyle` to valid settings keys |
| `src/contexts/SettingsContext.tsx` | IconStyle type, state, setter, server load |
| `src/components/SettingsTab.tsx` | Local state, save/reset, dropdown UI |
| `src/components/Sidebar.tsx` | Centralized icon maps, conditional rendering |
| `src/App.tsx` | Pass iconStyle/setIconStyle props |

## Test plan

- [x] `npx vitest run` — 3070 tests pass
- [x] `npm run build` — no TypeScript errors
- [x] Deploy, toggle to emoji, verify all 16 sidebar icons change
- [x] Toggle back to lucide, verify icons restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)