### PR TITLE
fix: system backup history queries use wrong column names

### DIFF
--- a/src/server/services/systemBackupService.ts
+++ b/src/server/services/systemBackupService.ts
@@ -234,7 +234,7 @@ class SystemBackupService {
       if (!pool) throw new Error('PostgreSQL pool not initialized');
       await pool.query(
         `INSERT INTO system_backup_history
-         (dirname, timestamp, type, size, table_count, meshmonitor_version, schema_version, "createdAt")
+         ("backupPath", timestamp, "backupType", "totalSize", "tableCount", "appVersion", "schemaVersion", "createdAt")
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
         [dirname, timestamp, type, size, tableCount, meshmonitorVersion, schemaVersion, Date.now()]
       );
@@ -243,7 +243,7 @@ class SystemBackupService {
       if (!pool) throw new Error('MySQL pool not initialized');
       await pool.execute(
         `INSERT INTO system_backup_history
-         (dirname, timestamp, type, size, table_count, meshmonitor_version, schema_version, createdAt)
+         (backupPath, timestamp, backupType, totalSize, tableCount, appVersion, schemaVersion, createdAt)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
         [dirname, timestamp, type, size, tableCount, meshmonitorVersion, schemaVersion, Date.now()]
       );
@@ -251,7 +251,7 @@ class SystemBackupService {
       const db = databaseService.db;
       const stmt = db.prepare(`
         INSERT INTO system_backup_history
-        (dirname, timestamp, type, size, table_count, meshmonitor_version, schema_version, createdAt)
+        (backupPath, timestamp, backupType, totalSize, tableCount, appVersion, schemaVersion, createdAt)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `);
       stmt.run(dirname, timestamp, type, size, tableCount, meshmonitorVersion, schemaVersion, Date.now());
@@ -468,10 +468,11 @@ class SystemBackupService {
       const backupPath = path.join(SYSTEM_BACKUP_DIR, dirname);
 
       // Check if backup exists either in database or on disk
+      const bpCol = dbType === 'postgres' ? '"backupPath"' : 'backupPath';
       const row = await this.queryOne(
         dbType === 'postgres'
-          ? 'SELECT dirname FROM system_backup_history WHERE dirname = $1'
-          : 'SELECT dirname FROM system_backup_history WHERE dirname = ?',
+          ? `SELECT ${bpCol} FROM system_backup_history WHERE ${bpCol} = $1`
+          : `SELECT ${bpCol} FROM system_backup_history WHERE ${bpCol} = ?`,
         [dirname]
       );
 
@@ -490,8 +491,8 @@ class SystemBackupService {
       if (row) {
         await this.executeStatement(
           dbType === 'postgres'
-            ? 'DELETE FROM system_backup_history WHERE dirname = $1'
-            : 'DELETE FROM system_backup_history WHERE dirname = ?',
+            ? `DELETE FROM system_backup_history WHERE ${bpCol} = $1`
+            : `DELETE FROM system_backup_history WHERE ${bpCol} = ?`,
           [dirname]
         );
       }
@@ -531,10 +532,11 @@ class SystemBackupService {
 
       // Get oldest backups to delete
       const toDelete = totalBackups - limit;
+      const bpCol = dbType === 'postgres' ? '"backupPath"' : 'backupPath';
       const oldBackups = await this.queryRows(
         dbType === 'postgres'
-          ? 'SELECT dirname FROM system_backup_history ORDER BY timestamp ASC LIMIT $1'
-          : 'SELECT dirname FROM system_backup_history ORDER BY timestamp ASC LIMIT ?',
+          ? `SELECT ${bpCol} FROM system_backup_history ORDER BY timestamp ASC LIMIT $1`
+          : `SELECT ${bpCol} FROM system_backup_history ORDER BY timestamp ASC LIMIT ?`,
         [toDelete]
       );
 
@@ -542,7 +544,7 @@ class SystemBackupService {
 
       for (const backup of oldBackups) {
         // Delete directory from disk
-        const backupPath = path.join(SYSTEM_BACKUP_DIR, backup.dirname);
+        const backupPath = path.join(SYSTEM_BACKUP_DIR, backup.backupPath);
         if (fs.existsSync(backupPath)) {
           fs.rmSync(backupPath, { recursive: true, force: true });
         }
@@ -550,12 +552,12 @@ class SystemBackupService {
         // Delete from database
         await this.executeStatement(
           dbType === 'postgres'
-            ? 'DELETE FROM system_backup_history WHERE dirname = $1'
-            : 'DELETE FROM system_backup_history WHERE dirname = ?',
-          [backup.dirname]
+            ? `DELETE FROM system_backup_history WHERE ${bpCol} = $1`
+            : `DELETE FROM system_backup_history WHERE ${bpCol} = ?`,
+          [backup.backupPath]
         );
 
-        logger.debug(`  🗑️  Purged: ${backup.dirname}`);
+        logger.debug(`  🗑️  Purged: ${backup.backupPath}`);
       }
 
       logger.info(`✅ Purged ${oldBackups.length} old system backups`);


### PR DESCRIPTION
## Summary

Fixes "View Saved Backups" failing with `SqliteError: no such column: backupPath` on all database backends.

**Root cause**: The v3.7 baseline migration creates `system_backup_history` with camelCase columns (`backupPath`, `backupType`, `totalSize`, `tableCount`, `appVersion`, `schemaVersion`), but during the async refactoring the INSERT and SELECT queries were rewritten to use snake_case names (`dirname`, `type`, `size`, `table_count`, `meshmonitor_version`, `schema_version`). This meant:
- INSERTs silently failed — no backup history was ever recorded
- SELECTs threw "no such column" when listing backups

**Why tests didn't catch it**: The backup system test only checks HTTP 200 and that a backup dirname appears in the list. Since INSERTs were failing, listBackups returned empty arrays (no SQL error). The API exercise test only checks status codes.

Fixes #2419

## Changes

| File | Change |
|------|--------|
| `src/server/services/systemBackupService.ts` | Fixed all INSERT, SELECT, DELETE queries to use baseline camelCase column names with proper PG quoting |

## Test plan

- [x] `npx vitest run` — all tests pass
- [x] `npm run build` — no TypeScript errors
- [ ] Create a backup, verify it appears in "View Saved Backups"
- [ ] Verify on PostgreSQL backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)