### PR TITLE
fix: auto-mark messages as read when viewing channel or DM

### DIFF
--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -427,6 +427,7 @@ export default function ChannelsTab({
                   setSelectedChannel(channelId);
                   selectedChannelRef.current = channelId;
                   setReplyingTo(null);
+                  markMessagesAsRead(undefined, channelId);
                   setUnreadCounts(prev => {
                     const updated = { ...prev, [channelId]: 0 };
                     logger.debug('📝 Setting unread counts:', updated);
@@ -470,6 +471,7 @@ export default function ChannelsTab({
                       setSelectedChannel(channelId);
                       selectedChannelRef.current = channelId;
                       setReplyingTo(null);
+                      markMessagesAsRead(undefined, channelId);
                       setUnreadCounts(prev => {
                         const updated = { ...prev, [channelId]: 0 };
                         logger.debug('📝 Setting unread counts:', updated);

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -789,8 +789,10 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       key={node.nodeNum}
                       className={`node-item ${selectedDMNode === node.user?.id ? 'selected' : ''}`}
                       onClick={() => {
-                        setSelectedDMNode(node.user?.id || '');
+                        const nodeId = node.user?.id || '';
+                        setSelectedDMNode(nodeId);
                         setReplyingTo(null);
+                        if (nodeId) markMessagesAsRead(undefined, -1, nodeId);
                       }}
                     >
                       <div className="node-header">
@@ -950,8 +952,10 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
             className="node-dropdown-select"
             value={selectedDMNode || ''}
             onChange={e => {
-              setSelectedDMNode(e.target.value);
+              const nodeId = e.target.value;
+              setSelectedDMNode(nodeId);
               setReplyingTo(null);
+              if (nodeId) markMessagesAsRead(undefined, -1, nodeId);
             }}
           >
             <option value="">{t('messages.select_conversation')}</option>


### PR DESCRIPTION
## Summary

Fixes the unread message indicator persisting even after viewing a channel. The red dot would reappear on every poll because selecting a channel only cleared the count in local React state — never telling the server.

Fixes #2423

### Root Cause
Both ChannelsTab and MessagesTab called `setUnreadCounts(prev => ({...prev, [channelId]: 0}))` on channel/node selection, which cleared the UI indicator. But `markMessagesAsRead()` was never called, so the server still returned unread counts on the next poll and the indicator came back.

### Fix
Added `markMessagesAsRead(undefined, channelId)` calls in 4 locations:
- ChannelsTab: dropdown selection + button click
- MessagesTab: DM node click + dropdown selection

## Changes

| File | Change |
|------|--------|
| `src/components/ChannelsTab.tsx` | Auto-mark on channel selection (2 locations) |
| `src/components/MessagesTab.tsx` | Auto-mark on DM node selection (2 locations) |

## Test plan
- [x] All tests pass
- [x] `npm run build` — no TypeScript errors
- [x] Deploy, receive message, see unread dot, click channel — dot clears and stays cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)