### PR TITLE
fix: packet monitor renders on mobile devices

### DIFF
--- a/src/components/PacketMonitorPanel.css
+++ b/src/components/PacketMonitorPanel.css
@@ -8,10 +8,17 @@
   overflow: hidden;
 }
 
-/* Hide on mobile */
+/* Mobile: allow packet monitor to render everywhere except map overlay */
 @media (max-width: 768px) {
-  .packet-monitor-panel {
-    display: none !important;
+  .packet-monitor-panel .packet-monitor-header {
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 8px 12px;
+  }
+
+  .packet-monitor-panel .packet-table-container {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
 }
 

--- a/src/components/PacketMonitorPanel.tsx
+++ b/src/components/PacketMonitorPanel.tsx
@@ -18,6 +18,7 @@ import './PacketMonitorPanel.css';
 interface PacketMonitorPanelProps {
   onClose: () => void;
   onNodeClick?: (nodeId: string) => void;
+  standalone?: boolean;
 }
 
 
@@ -55,7 +56,7 @@ const safeJsonParse = <T,>(value: string | null, fallback: T): T => {
   }
 };
 
-const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNodeClick }) => {
+const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNodeClick, standalone }) => {
   const { t } = useTranslation();
   const { hasPermission, authStatus } = useAuth();
   const { timeFormat, dateFormat } = useSettings();
@@ -446,7 +447,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
 
   if (!canView) {
     return (
-      <div className="packet-monitor-panel">
+      <div className={`packet-monitor-panel${standalone ? ' packet-monitor-standalone' : ''}`}>
         <div className="packet-monitor-header">
           <h3>{t('packet_monitor.title')}</h3>
           <button className="close-btn" onClick={onClose} aria-label={t('common.close')}>
@@ -464,7 +465,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
 
   return (
     <>
-      <div className="packet-monitor-panel">
+      <div className={`packet-monitor-panel${standalone ? ' packet-monitor-standalone' : ''}`}>
         <div className="packet-monitor-header">
           <h3>{t('packet_monitor.title')}</h3>
           <div

--- a/src/pages/PacketMonitorPage.tsx
+++ b/src/pages/PacketMonitorPage.tsx
@@ -33,6 +33,7 @@ const PacketMonitorContent: React.FC = () => {
       background: 'var(--bg-primary)'
     }}>
       <PacketMonitorPanel
+        standalone
         onClose={() => window.close()}
         onNodeClick={(nodeId) => {
           // In pop-out mode, we can't navigate to node details


### PR DESCRIPTION
## Summary

Fixes packet monitor not rendering on mobile devices. The CSS had a blanket hide rule on `.packet-monitor-panel` at 768px that hid it everywhere — sidebar tab, standalone page, and map overlay.

Only the map overlay should be hidden on mobile (already handled by `.packet-monitor-container` in App.css). Removed the panel-level hide rule and added mobile-friendly styles instead.

## Changes

| File | Change |
|------|--------|
| `src/components/PacketMonitorPanel.css` | Removed `display: none` rule, added mobile scroll/wrap styles |
| `src/components/PacketMonitorPanel.tsx` | Added `standalone` prop |
| `src/pages/PacketMonitorPage.tsx` | Pass `standalone` to panel |

## Test plan
- [x] npm run build — no errors
- [x] Mobile: sidebar packet monitor tab renders
- [x] Mobile: standalone /packet-monitor page renders
- [x] Desktop: map overlay still hides on resize below 768px