### PR TITLE
fix: rename legacy system_backup_history columns (#2419)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Migrations use a centralized registry in `src/db/migrations.ts`. Each migration 
 4. Make migrations **idempotent** — use try/catch for SQLite (`duplicate column`), `IF NOT EXISTS` for PostgreSQL, `information_schema` checks for MySQL
 5. **Column naming**: SQLite uses `snake_case`, PostgreSQL/MySQL use `camelCase` (quoted in PG raw SQL)
 
-**Current migration count:** 14 (latest: `014_add_messages_decrypted_by`)
+**Current migration count:** 16 (latest: `016_rename_system_backup_columns`)
 
 ## Testing
 

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 15 migrations registered', () => {
-    expect(registry.count()).toBe(15);
+  it('has all 16 migrations registered', () => {
+    expect(registry.count()).toBe(16);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,14 +12,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is the notification prefs unique constraint', () => {
+  it('last migration is the system backup column rename', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(15);
-    expect(last.name).toContain('notification_prefs_unique');
+    expect(last.number).toBe(16);
+    expect(last.name).toContain('rename_system_backup_columns');
   });
 
-  it('migrations are sequentially numbered from 1 to 15', () => {
+  it('migrations are sequentially numbered from 1 to 16', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,7 +1,7 @@
 /**
  * Migration Registry Barrel File
  *
- * Registers all 14 migrations in sequential order for use by the migration runner.
+ * Registers all 16 migrations in sequential order for use by the migration runner.
  * Migration 001 is the v3.7 baseline (selfIdempotent — handles its own detection).
  * Migrations 002-011 were originally 078-087 and retain their original settingsKeys
  * for upgrade compatibility.
@@ -27,6 +27,7 @@ import { migration as authAlignMigration, runMigration012Postgres, runMigration0
 import { migration as auditLogColumnsMigration, runMigration013Postgres, runMigration013Mysql } from '../server/migrations/013_add_audit_log_missing_columns.js';
 import { migration as messagesDecryptedByMigration, runMigration014Postgres, runMigration014Mysql } from '../server/migrations/014_add_messages_decrypted_by.js';
 import { migration as notificationPrefsUniqueMigration, runMigration015Postgres, runMigration015Mysql } from '../server/migrations/015_add_notification_prefs_unique.js';
+import { migration as renameSystemBackupColumnsMigration, runMigration016Postgres, runMigration016Mysql } from '../server/migrations/016_rename_system_backup_columns.js';
 
 // ============================================================================
 // Registry
@@ -198,4 +199,20 @@ registry.register({
   sqlite: (db) => notificationPrefsUniqueMigration.up(db),
   postgres: (client) => runMigration015Postgres(client),
   mysql: (pool) => runMigration015Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 016: Rename legacy system_backup_history columns
+// Pre-3.7 databases used dirname/type/size/table_count/meshmonitor_version/
+// schema_version; baseline CREATE TABLE IF NOT EXISTS didn't rename them.
+// Fixes: https://github.com/Yeraze/meshmonitor/issues/2419
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 16,
+  name: 'rename_system_backup_columns',
+  settingsKey: 'migration_016_rename_system_backup_columns',
+  sqlite: (db) => renameSystemBackupColumnsMigration.up(db),
+  postgres: (client) => runMigration016Postgres(client),
+  mysql: (pool) => runMigration016Mysql(pool),
 });

--- a/src/server/migrations/016_rename_system_backup_columns.ts
+++ b/src/server/migrations/016_rename_system_backup_columns.ts
@@ -1,0 +1,151 @@
+/**
+ * Migration 016: Rename legacy system_backup_history columns
+ *
+ * Pre-3.7 databases created system_backup_history with columns:
+ *   dirname, type, size, table_count, meshmonitor_version, schema_version
+ *
+ * The v3.7 baseline uses CREATE TABLE IF NOT EXISTS with new names, which
+ * doesn't alter an existing table. This migration renames the old columns:
+ *   dirname → backupPath
+ *   type → backupType
+ *   size → totalSize
+ *   table_count → tableCount
+ *   meshmonitor_version → appVersion
+ *   schema_version → schemaVersion
+ *
+ * Also adds the rowCount column if missing.
+ *
+ * Fixes: https://github.com/Yeraze/meshmonitor/issues/2419
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+// Column rename mapping: old → new
+const COLUMN_RENAMES: [string, string][] = [
+  ['dirname', 'backupPath'],
+  ['type', 'backupType'],
+  ['size', 'totalSize'],
+  ['table_count', 'tableCount'],
+  ['meshmonitor_version', 'appVersion'],
+  ['schema_version', 'schemaVersion'],
+];
+
+// ============ SQLite ============
+
+function sqliteColumnExists(db: Database, table: string, column: string): boolean {
+  const rows = db.pragma(`table_info(${table})`) as Array<{ name: string }>;
+  return rows.some(r => r.name === column);
+}
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 016 (SQLite): Renaming legacy system_backup_history columns...');
+
+    for (const [oldName, newName] of COLUMN_RENAMES) {
+      if (sqliteColumnExists(db, 'system_backup_history', oldName)) {
+        try {
+          db.exec(`ALTER TABLE system_backup_history RENAME COLUMN ${oldName} TO ${newName}`);
+          logger.debug(`Renamed system_backup_history.${oldName} → ${newName}`);
+        } catch (e: any) {
+          logger.warn(`Could not rename ${oldName} → ${newName}:`, e.message);
+        }
+      } else {
+        logger.debug(`system_backup_history.${oldName} does not exist (already renamed or new install), skipping`);
+      }
+    }
+
+    // Add rowCount if missing
+    if (!sqliteColumnExists(db, 'system_backup_history', 'rowCount')) {
+      try {
+        db.exec('ALTER TABLE system_backup_history ADD COLUMN rowCount INTEGER');
+        logger.debug('Added rowCount column to system_backup_history');
+      } catch (e: any) {
+        if (e.message?.includes('duplicate column')) {
+          logger.debug('system_backup_history.rowCount already exists, skipping');
+        } else {
+          logger.warn('Could not add rowCount to system_backup_history:', e.message);
+        }
+      }
+    }
+
+    logger.info('Migration 016 complete (SQLite): system_backup_history columns aligned');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 016 down: Not implemented (destructive column renames)');
+  }
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration016Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 016 (PostgreSQL): Renaming legacy system_backup_history columns...');
+
+  try {
+    for (const [oldName, newName] of COLUMN_RENAMES) {
+      const res = await client.query(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'system_backup_history' AND column_name = $1
+      `, [oldName]);
+
+      if (res.rows.length > 0) {
+        await client.query(`ALTER TABLE system_backup_history RENAME COLUMN "${oldName}" TO "${newName}"`);
+        logger.debug(`Renamed system_backup_history.${oldName} → ${newName}`);
+      } else {
+        logger.debug(`system_backup_history.${oldName} does not exist, skipping`);
+      }
+    }
+
+    // Add rowCount if missing
+    await client.query('ALTER TABLE system_backup_history ADD COLUMN IF NOT EXISTS "rowCount" INTEGER');
+    logger.debug('Ensured rowCount exists on system_backup_history');
+  } catch (error: any) {
+    logger.error('Migration 016 (PostgreSQL) failed:', error.message);
+    throw error;
+  }
+
+  logger.info('Migration 016 complete (PostgreSQL): system_backup_history columns aligned');
+}
+
+// ============ MySQL ============
+
+export async function runMigration016Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 016 (MySQL): Renaming legacy system_backup_history columns...');
+
+  try {
+    for (const [oldName, newName] of COLUMN_RENAMES) {
+      const [rows] = await pool.query(`
+        SELECT COLUMN_NAME FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'system_backup_history'
+          AND COLUMN_NAME = ?
+      `, [oldName]);
+
+      if (Array.isArray(rows) && rows.length > 0) {
+        await pool.query(`ALTER TABLE system_backup_history RENAME COLUMN ${oldName} TO ${newName}`);
+        logger.debug(`Renamed system_backup_history.${oldName} → ${newName}`);
+      } else {
+        logger.debug(`system_backup_history.${oldName} does not exist, skipping`);
+      }
+    }
+
+    // Add rowCount if missing
+    const [rcRows] = await pool.query(`
+      SELECT COLUMN_NAME FROM information_schema.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'system_backup_history'
+        AND COLUMN_NAME = 'rowCount'
+    `);
+    if (!Array.isArray(rcRows) || rcRows.length === 0) {
+      await pool.query('ALTER TABLE system_backup_history ADD COLUMN rowCount INTEGER');
+      logger.debug('Added rowCount to system_backup_history');
+    } else {
+      logger.debug('system_backup_history.rowCount already exists, skipping');
+    }
+  } catch (error: any) {
+    logger.error('Migration 016 (MySQL) failed:', error.message);
+    throw error;
+  }
+
+  logger.info('Migration 016 complete (MySQL): system_backup_history columns aligned');
+}


### PR DESCRIPTION
## Summary
- Adds migration 016 to rename legacy `system_backup_history` columns for pre-3.7 databases
- Old columns (`dirname`, `type`, `size`, `table_count`, `meshmonitor_version`, `schema_version`) are renamed to match current schema (`backupPath`, `backupType`, `totalSize`, `tableCount`, `appVersion`, `schemaVersion`)
- Also adds missing `rowCount` column
- Idempotent: safely skips columns that are already correctly named (new installs)

## Root Cause
The v3.7 baseline migration uses `CREATE TABLE IF NOT EXISTS` with the new column names, which doesn't alter tables that already exist. Users who had MeshMonitor before v3.7 retained the old column names, causing `SqliteError: no such column: backupPath` when viewing saved backups.

## Test plan
- [x] All 3086 tests pass (0 failures)
- [x] Migration registry test updated for 16 migrations
- [ ] Verify on a pre-3.7 SQLite database that backups list correctly after upgrade

Fixes #2419

🤖 Generated with [Claude Code](https://claude.com/claude-code)