### PR TITLE
fix: correct frequency display when channelNum is 0 (#2436)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6199,8 +6199,8 @@ class MeshtasticManager {
    * Calculate LoRa frequency from region and channel number (frequency slot)
    * Delegates to the utility function for better testability
    */
-  private calculateLoRaFrequency(region: number, channelNum: number, overrideFrequency: number, frequencyOffset: number, bandwidth: number = 250): string {
-    return calculateLoRaFrequency(region, channelNum, overrideFrequency, frequencyOffset, bandwidth);
+  private calculateLoRaFrequency(region: number, channelNum: number, overrideFrequency: number, frequencyOffset: number, bandwidth: number = 250, channelName?: string, modemPreset?: number): string {
+    return calculateLoRaFrequency(region, channelNum, overrideFrequency, frequencyOffset, bandwidth, channelName, modemPreset);
   }
 
   private async buildDeviceConfigFromActual(): Promise<any> {
@@ -6312,7 +6312,9 @@ class MeshtasticManager {
           loraConfigWithDefaults.channelNum !== undefined ? loraConfigWithDefaults.channelNum : 0,
           loraConfigWithDefaults.overrideFrequency !== undefined ? loraConfigWithDefaults.overrideFrequency : 0,
           loraConfigWithDefaults.frequencyOffset !== undefined ? loraConfigWithDefaults.frequencyOffset : 0,
-          typeof loraConfigWithDefaults.bandwidth === 'number' && loraConfigWithDefaults.bandwidth > 0 ? loraConfigWithDefaults.bandwidth : 250
+          typeof loraConfigWithDefaults.bandwidth === 'number' && loraConfigWithDefaults.bandwidth > 0 ? loraConfigWithDefaults.bandwidth : 250,
+          dbChannels.find(ch => ch.id === 0)?.name || undefined,
+          typeof loraConfigWithDefaults.modemPreset === 'number' ? loraConfigWithDefaults.modemPreset : undefined
         ),
         txEnabled: loraConfigWithDefaults.txEnabled !== undefined ? loraConfigWithDefaults.txEnabled : 'Unknown',
         sx126xRxBoostedGain: loraConfigWithDefaults.sx126xRxBoostedGain !== undefined ? loraConfigWithDefaults.sx126xRxBoostedGain : 'Unknown',

--- a/src/utils/loraFrequency.test.ts
+++ b/src/utils/loraFrequency.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateLoRaFrequency } from './loraFrequency';
+import { calculateLoRaFrequency, djb2Hash, getModemPresetChannelName } from './loraFrequency';
 
 describe('calculateLoRaFrequency', () => {
   // Default bandwidth is 250 kHz (LongFast preset)
@@ -12,9 +12,18 @@ describe('calculateLoRaFrequency', () => {
     // With 250 kHz BW: halfBwOffset = 0.125 MHz, spacing = 0.25 MHz
     // Slot 0: 902.0 + 0.125 + 0 = 902.125 MHz
 
-    it('should calculate correct frequency for channelNum 0 (hash default, slot 0)', () => {
+    it('should calculate correct frequency for channelNum 0 without channel name (falls back to slot 0)', () => {
       const result = calculateLoRaFrequency(1, 0, 0, 0);
       expect(result).toBe('902.125 MHz');
+    });
+
+    it('should use DJB2 hash of channel name when channelNum is 0', () => {
+      // "LongFast" hash: djb2Hash("LongFast") % 104 (US has 104 slots with 250kHz BW)
+      // This should NOT be slot 0, demonstrating the fix
+      const result = calculateLoRaFrequency(1, 0, 0, 0, 250, 'LongFast');
+      const expectedSlot = djb2Hash('LongFast') % 104;
+      const expectedFreq = 902.0 + 0.125 + (expectedSlot * 0.25);
+      expect(result).toBe(`${expectedFreq.toFixed(3)} MHz`);
     });
 
     it('should calculate correct frequency for channelNum 1 (slot 0)', () => {
@@ -173,10 +182,32 @@ describe('calculateLoRaFrequency', () => {
       expect(result).toBe('902.125 MHz'); // Same as default 250kHz
     });
 
-    it('should treat channelNum 0 as slot 0 (hash algorithm default)', () => {
-      // channelNum 0 means "use hash algorithm", which we default to slot 0
+    it('should fall back to slot 0 when channelNum is 0 and no channel name provided', () => {
       const result = calculateLoRaFrequency(1, 0, 0, 0);
       expect(result).toBe('902.125 MHz');
+    });
+
+    it('should use channel name hash when channelNum is 0 and name is provided', () => {
+      const result = calculateLoRaFrequency(1, 0, 0, 0, 250, 'MediumFast');
+      // Should not be slot 0
+      const slot = djb2Hash('MediumFast') % 104;
+      expect(slot).not.toBe(0);
+      const expectedFreq = 902.0 + 0.125 + (slot * 0.25);
+      expect(result).toBe(`${expectedFreq.toFixed(3)} MHz`);
+    });
+
+    it('should derive channel name from modem preset when name is empty', () => {
+      // Modem preset 4 = MediumFast; should produce same result as explicit name
+      const withName = calculateLoRaFrequency(1, 0, 0, 0, 250, 'MediumFast');
+      const withPreset = calculateLoRaFrequency(1, 0, 0, 0, 250, undefined, 4);
+      expect(withPreset).toBe(withName);
+    });
+
+    it('should calculate 913.125 MHz for MediumFast default in US (issue #2436)', () => {
+      // User reported: MediumFast default = channelNum 45 = 913.125 MHz
+      // With channelNum=0 and modemPreset=4 (MediumFast), hash should give slot 44
+      const result = calculateLoRaFrequency(1, 0, 0, 0, 250, undefined, 4);
+      expect(result).toBe('913.125 MHz');
     });
   });
 
@@ -200,6 +231,33 @@ describe('calculateLoRaFrequency', () => {
       // channelNum 1 = slot 0: 2400.0 + 0.125 = 2400.125 MHz
       const result = calculateLoRaFrequency(13, 1, 0, 0);
       expect(result).toBe('2400.125 MHz');
+    });
+  });
+
+  describe('DJB2 hash algorithm', () => {
+    it('should match firmware hash for empty string', () => {
+      expect(djb2Hash('')).toBe(5381);
+    });
+
+    it('should produce consistent hashes', () => {
+      expect(djb2Hash('LongFast')).toBe(djb2Hash('LongFast'));
+      expect(djb2Hash('MediumFast')).not.toBe(djb2Hash('LongFast'));
+    });
+
+    it('should produce unsigned 32-bit values', () => {
+      const hash = djb2Hash('LongFast');
+      expect(hash).toBeGreaterThanOrEqual(0);
+      expect(hash).toBeLessThanOrEqual(0xFFFFFFFF);
+    });
+
+    it('should compute correct slot for MediumFast in US region with 125kHz BW', () => {
+      // US region with 125kHz BW: numChannels = (928-902)/0.125 = 208
+      // User reports MediumFast default is slot 45
+      // We verify the hash produces a reasonable result (exact value depends on firmware matching)
+      const numChannels = Math.floor((928 - 902) / (125 / 1000));
+      const slot = djb2Hash('MediumFast') % numChannels;
+      expect(slot).toBeGreaterThanOrEqual(0);
+      expect(slot).toBeLessThan(numChannels);
     });
   });
 

--- a/src/utils/loraFrequency.ts
+++ b/src/utils/loraFrequency.ts
@@ -10,7 +10,8 @@
  * - channel_num: Frequency slot (0-based, derived from 1-based channelNum)
  *
  * Note: Meshtastic protobuf uses 1-based channelNum (1 = first channel, 0 = use hash algorithm).
- * The firmware converts to 0-based internally: channel_num = channelNum - 1
+ * When channelNum is 0, the firmware hashes the primary channel name using the DJB2 algorithm
+ * and takes modulo numChannels to determine the default frequency slot.
  * This function accepts the raw 1-based value from the device and converts it.
  *
  * References:
@@ -22,6 +23,8 @@
  * @param overrideFrequency - Override frequency in MHz (takes precedence if > 0)
  * @param frequencyOffset - Frequency offset in MHz to add to calculated frequency
  * @param bandwidth - Bandwidth in kHz (default 250 for LongFast preset)
+ * @param channelName - Primary channel name (used for hash when channelNum is 0)
+ * @param modemPreset - Modem preset number (used to derive channel name when name is empty)
  * @returns Formatted frequency string (e.g., "906.875 MHz") or "Unknown"/"Invalid channel"
  */
 export function calculateLoRaFrequency(
@@ -29,7 +32,9 @@ export function calculateLoRaFrequency(
   channelNum: number,
   overrideFrequency: number,
   frequencyOffset: number,
-  bandwidth: number = 250 // Default to LongFast preset (250 kHz)
+  bandwidth: number = 250, // Default to LongFast preset (250 kHz)
+  channelName?: string,
+  modemPreset?: number
 ): string {
   // If overrideFrequency is set (non-zero), use it (takes precedence over calculated frequency)
   if (overrideFrequency && overrideFrequency > 0) {
@@ -87,7 +92,7 @@ export function calculateLoRaFrequency(
   const channelSpacing = bw / 1000; // Convert to MHz
 
   // Calculate maximum number of channels that fit in the frequency range
-  const maxChannels = Math.floor((freqEnd - freqStart) / channelSpacing);
+  const numChannels = Math.floor((freqEnd - freqStart) / channelSpacing);
 
   // Validate channelNum (must be >= 0; 0 = hash algorithm, 1+ = explicit)
   if (channelNum < 0) {
@@ -95,12 +100,24 @@ export function calculateLoRaFrequency(
   }
 
   // Convert Meshtastic 1-based channelNum to 0-based slot index
-  // Meshtastic uses: 0 = use hash algorithm (default to slot 0), 1+ = explicit channel
-  // Firmware: channel_num = (channelNum ? channelNum - 1 : hash) % numChannels
-  const slotIndex = channelNum > 0 ? channelNum - 1 : 0;
+  // Firmware: channel_num = (channelNum ? channelNum - 1 : hash(channelName)) % numChannels
+  let slotIndex: number;
+  if (channelNum > 0) {
+    slotIndex = channelNum - 1;
+  } else {
+    // When channelNum is 0, firmware uses DJB2 hash of the channel name.
+    // If the channel name is empty (default config), derive it from the modem preset.
+    const hashName = channelName || getModemPresetChannelName(modemPreset);
+    if (hashName) {
+      slotIndex = djb2Hash(hashName) % numChannels;
+    } else {
+      // No channel name or preset available — can't compute hash, fall back to slot 0
+      slotIndex = 0;
+    }
+  }
 
   // Validate slot index
-  if (slotIndex < 0 || slotIndex >= maxChannels) {
+  if (slotIndex < 0 || slotIndex >= numChannels) {
     return 'Invalid channel';
   }
 
@@ -110,4 +127,50 @@ export function calculateLoRaFrequency(
   const calculatedFreq = freqStart + halfBwOffset + (slotIndex * channelSpacing) + (frequencyOffset || 0);
 
   return `${calculatedFreq.toFixed(3)} MHz`;
+}
+
+/**
+ * Map modem preset enum values to the CamelCase channel names used by the
+ * Meshtastic firmware for DJB2 hashing when the channel name is empty.
+ * These match the firmware's Channel::getName() fallback values.
+ *
+ * Reference: meshtastic/firmware ChannelFile.cpp
+ */
+const MODEM_PRESET_CHANNEL_NAMES: { [key: number]: string } = {
+  0: 'LongFast',
+  1: 'LongSlow',
+  2: 'VeryLongSlow',
+  3: 'MediumSlow',
+  4: 'MediumFast',
+  5: 'ShortSlow',
+  6: 'ShortFast',
+  7: 'LongModerate',
+};
+
+export function getModemPresetChannelName(modemPreset?: number): string | undefined {
+  if (modemPreset === undefined || modemPreset === null) return undefined;
+  return MODEM_PRESET_CHANNEL_NAMES[modemPreset];
+}
+
+/**
+ * DJB2 hash algorithm — matches the Meshtastic firmware's hash() function
+ * in RadioInterface.cpp. Used to compute the default frequency slot when
+ * channelNum is 0 (not explicitly set by the user).
+ *
+ * Reference: https://github.com/meshtastic/firmware/blob/master/src/mesh/RadioInterface.cpp
+ *   uint32_t hash(const char *str) {
+ *     uint32_t hash = 5381;
+ *     int c;
+ *     while ((c = *str++) != 0)
+ *       hash = ((hash << 5) + hash) + (unsigned char)c;
+ *     return hash;
+ *   }
+ */
+export function djb2Hash(str: string): number {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    // Use unsigned 32-bit arithmetic: hash * 33 + charCode
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) >>> 0;
+  }
+  return hash;
 }


### PR DESCRIPTION
## Summary
- Implements the Meshtastic firmware's DJB2 hash algorithm to compute the correct default frequency slot when `channelNum` is 0
- Derives channel name from modem preset when DB channel name is empty (common for default configs)
- Passes primary channel name and modem preset through to the frequency calculation

## Root Cause
When `channelNum` is 0 in the LoRa config, the firmware uses `hash(channelName) % numChannels` to pick the default frequency slot. MeshMonitor was defaulting to slot 0, showing 902.125 MHz instead of the correct 913.125 MHz for MediumFast in the US region.

## Verification
- MediumFast (preset 4) in US region: `djb2Hash("MediumFast") % 104 = 44` → 913.125 MHz (matches user report)
- LongFast (preset 0) in US region: `djb2Hash("LongFast") % 104 = 19` → 906.875 MHz (matches known default)

## Test plan
- [x] 39 frequency calculation tests pass (including new hash-based tests)
- [x] Full suite: 3110 tests pass, 0 failures
- [x] Specific test: MediumFast default produces 913.125 MHz (the exact frequency from issue #2436)

Fixes #2436

🤖 Generated with [Claude Code](https://claude.com/claude-code)