### PR TITLE
fix: upgrade ARMv7 base image to node:22.22.1-bookworm-slim

### DIFF
--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -1,6 +1,6 @@
 # Build stage for ARMv7 (Raspberry Pi 2/3 32-bit)
 # Node.js 24 doesn't support ARMv7, so we use Node.js 22 LTS
-FROM node:22-slim AS builder
+FROM node:22.22.1-bookworm-slim AS builder
 
 WORKDIR /app
 
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/app/.tsc-cache \
     npm run build:server
 
 # Production stage for ARMv7
-FROM node:22-slim
+FROM node:22.22.1-bookworm-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Pins ARMv7 Dockerfile base image to `node:22.22.1-bookworm-slim`
- Fixes the same 4 Snyk vulnerabilities from PR #2445 (critical zlib overflow, medium systemd, low gnutls)

## Why not trixie-slim?
Snyk's PR #2445 proposed `node:22.22.1-trixie-slim`, but that image **does not publish an `arm/v7` manifest** — it only has amd64, arm64, ppc64le, and s390x. This would break ARMv7 builds for Raspberry Pi 2/3.

`node:22.22.1-bookworm-slim` has full `arm/v7` support and is based on the same Debian release we were already using (bookworm), just with a pinned Node.js version for security fixes.

## Test plan
- [x] Verified `node:22.22.1-bookworm-slim` has `arm/v7` in its manifest
- [x] Verified `node:22.22.1-trixie-slim` does NOT have `arm/v7`
- [ ] CI build passes

Supersedes #2445 (close that PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)