### PR TITLE
feat: add extraEnv support to Helm chart

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -213,9 +213,9 @@ For Kubernetes deployments, use the Helm chart values file:
 
 ```yaml
 # values.yaml
-meshmonitor:
-  nodeIp: "192.168.1.100"
-  port: 3000
+env:
+  meshtasticNodeIp: "192.168.1.100"
+  port: "3001"
 
 ingress:
   enabled: true
@@ -223,6 +223,23 @@ ingress:
   tls:
     enabled: true
 ```
+
+For environment variables not covered by the built-in chart fields (CORS, reverse proxy, database, sessions, etc.), use `extraEnv`:
+
+```yaml
+extraEnv:
+  - name: ALLOWED_ORIGINS
+    value: "https://meshmonitor.example.com"
+  - name: TRUST_PROXY
+    value: "true"
+  - name: SESSION_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: meshmonitor-secrets
+        key: session-secret
+```
+
+This accepts standard Kubernetes env var syntax, including `valueFrom` for Secrets and ConfigMaps.
 
 See the [Production Deployment guide](/configuration/production) for complete Helm configuration.
 

--- a/docs/configuration/production.md
+++ b/docs/configuration/production.md
@@ -132,6 +132,31 @@ ingress:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 ```
 
+#### Additional Environment Variables
+
+The Helm chart exposes common settings (`MESHTASTIC_NODE_IP`, `PORT`, `BASE_URL`, etc.) as dedicated values fields. For any other environment variable — such as CORS, reverse proxy, database, or session settings — use `extraEnv`:
+
+```yaml
+# values.yaml
+extraEnv:
+  - name: ALLOWED_ORIGINS
+    value: "https://meshmonitor.example.com"
+  - name: TRUST_PROXY
+    value: "true"
+  - name: SESSION_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: meshmonitor-secrets
+        key: session-secret
+  - name: DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: meshmonitor-secrets
+        key: database-url
+```
+
+This accepts standard [Kubernetes env var syntax](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/), including `valueFrom` for referencing Secrets and ConfigMaps. See the [Environment Variables](/configuration/index) page for the full list of supported variables.
+
 Deploy:
 
 ```bash

--- a/helm/meshmonitor/templates/deployment.yaml
+++ b/helm/meshmonitor/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
         - name: AUTO_UPGRADE_ENABLED
           value: "true"
         {{- end }}
+        {{- if .Values.extraEnv }}
+        {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /api/health

--- a/helm/meshmonitor/values.yaml
+++ b/helm/meshmonitor/values.yaml
@@ -51,6 +51,25 @@ env:
   # Example: "/meshmonitor" for hosting at https://example.com/meshmonitor/
   baseUrl: ""
 
+# Additional environment variables
+# Use this to pass any environment variable to MeshMonitor that isn't
+# covered by the fields above (e.g., CORS, reverse proxy, database, etc.)
+# Format: standard Kubernetes env var syntax
+# Example:
+#   extraEnv:
+#     - name: ALLOWED_ORIGINS
+#       value: "https://meshmonitor.example.com"
+#     - name: TRUST_PROXY
+#       value: "true"
+#     - name: DATABASE_URL
+#       value: "postgresql://user:pass@host:5432/meshmonitor"
+#     - name: SESSION_SECRET
+#       valueFrom:
+#         secretKeyRef:
+#           name: meshmonitor-secrets
+#           key: session-secret
+extraEnv: []
+
 # Auto-upgrade configuration (Docker only)
 # Note: Kubernetes deployments should use kubectl/helm for upgrades
 autoupgrade:


### PR DESCRIPTION
## Summary
- Adds `extraEnv` field to Helm chart values for passing arbitrary environment variables
- Accepts standard Kubernetes env var syntax (plain values, `valueFrom` for Secrets/ConfigMaps)
- Updates deployment template to render extra env vars
- Updates docs (configuration index + production deployment guide)

## Problem
The Helm chart only exposed 5 hardcoded env vars (`MESHTASTIC_NODE_IP`, `MESHTASTIC_USE_TLS`, `NODE_ENV`, `PORT`, `BASE_URL`). Users deploying on Kubernetes had no way to configure CORS origins, reverse proxy trust, database URLs, session secrets, or any other MeshMonitor environment variable.

## Usage
```yaml
# values.yaml
extraEnv:
  - name: ALLOWED_ORIGINS
    value: "https://meshmonitor.example.com"
  - name: TRUST_PROXY
    value: "true"
  - name: SESSION_SECRET
    valueFrom:
      secretKeyRef:
        name: meshmonitor-secrets
        key: session-secret
```

## Test plan
- [x] Verified template renders correctly with empty `extraEnv` (default)
- [x] Documentation updated in both configuration index and production guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)