### PR TITLE
fix: change traceroute MQTT label to IP for non-LoRa hops (#2443)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1041,7 +1041,7 @@
   "map.legend.unidirectional": "One-way",
   "map.legend.thickerBrighter": "Thicker line = stronger signal",
   "map.legend.otherLines": "Other Lines",
-  "map.legend.mqtt": "MQTT",
+  "map.legend.mqtt": "IP",
   "map.legend.traceroute": "Traceroute",
   "map.legend.tracerouteForward": "Traceroute \u2192",
   "map.legend.tracerouteReturn": "Traceroute \u2190",

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -52,7 +52,7 @@ const MapLegend: React.FC<MapLegendProps> = ({ positionHistory }) => {
   // Other overlay line types (non-neighbor)
   const otherLineItems: LinkLegendItem[] = [
     { color: overlayColors.tracerouteForward, width: 2, dashArray: '3,6', opacity: 1, label: t('map.legend.traceroute', 'Traceroute') },
-    { color: overlayColors.mqttSegment, width: 2, dashArray: '3,6', opacity: 1, label: t('map.legend.mqtt', 'MQTT') },
+    { color: overlayColors.mqttSegment, width: 2, dashArray: '3,6', opacity: 1, label: t('map.legend.mqtt', 'IP') },
   ];
 
   const formatTime = (timestamp: number) => {

--- a/src/components/TracerouteWidget.tsx
+++ b/src/components/TracerouteWidget.tsx
@@ -379,7 +379,7 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
                       📍
                     </span>
                   )}
-                  {hop.snr !== undefined && <span className="traceroute-snr">{isMqttSnr(hop.snr) ? 'MQTT' : `${hop.snr.toFixed(1)} dB`}</span>}
+                  {hop.snr !== undefined && <span className="traceroute-snr">{isMqttSnr(hop.snr) ? 'IP' : `${hop.snr.toFixed(1)} dB`}</span>}
                 </span>
                 {idx < fullPath.length - 1 && <span className="traceroute-arrow">→</span>}
               </React.Fragment>

--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -484,7 +484,7 @@ export function useTraceroutePaths({
             <div className="route-popup">
               <h4>Route Segment</h4>
               {isMqttSegment && (
-                <div className="mqtt-badge">via MQTT</div>
+                <div className="mqtt-badge">via IP</div>
               )}
               <div className="route-endpoints">
                 <strong
@@ -785,7 +785,7 @@ export function useTraceroutePaths({
                      {forwardSegmentSnrs[i] !== undefined && (
                         <div className="route-usage" style={{ marginTop: '8px', borderTop: '1px solid var(--ctp-surface0)', paddingTop: '4px' }}>
                           Segment SNR: <strong>{forwardSegmentSnrs[i]?.toFixed(1)} dB</strong>
-                          {isMqtt && ' (MQTT)'}
+                          {isMqtt && ' (IP)'}
                         </div>
                      )}
                    </div>
@@ -888,7 +888,7 @@ export function useTraceroutePaths({
                      {backSegmentSnrs[i] !== undefined && (
                         <div className="route-usage" style={{ marginTop: '8px', borderTop: '1px solid var(--ctp-surface0)', paddingTop: '4px' }}>
                           Segment SNR: <strong>{backSegmentSnrs[i]?.toFixed(1)} dB</strong>
-                          {isMqtt && ' (MQTT)'}
+                          {isMqtt && ' (IP)'}
                         </div>
                      )}
                    </div>

--- a/src/utils/mapHelpers.tsx
+++ b/src/utils/mapHelpers.tsx
@@ -253,7 +253,7 @@ export const generateCurvedArrowMarkers = (
       <Marker key={`${pathKey}-arrow-${i}`} position={midPoint} icon={createArrowIcon(angle, color)}>
         {snr !== undefined && (
           <Tooltip permanent={false} direction="top" offset={[0, -10]}>
-            {snr.toFixed(1)} dB{isMqttSnr(snr) ? ' (MQTT)' : ''}
+            {snr.toFixed(1)} dB{isMqttSnr(snr) ? ' (IP)' : ''}
           </Tooltip>
         )}
       </Marker>

--- a/src/utils/traceroute.tsx
+++ b/src/utils/traceroute.tsx
@@ -10,13 +10,13 @@ import { calculateDistance, formatDistance } from './distance';
 const INT8_MIN_SNR = -128;
 
 /**
- * Formats SNR value for display, showing "MQTT" for unknown/MQTT links
+ * Formats SNR value for display, showing "IP" for non-LoRa links
  */
 function formatSnrDisplay(snrValue: number | null): string {
   if (snrValue === null) return '';
-  // INT8_MIN (-128) or 0 (protobuf default) indicates MQTT gateway or unknown SNR
+  // INT8_MIN (-128) or 0 (protobuf default) indicates IP gateway or unknown SNR
   if (snrValue === INT8_MIN_SNR || snrValue === 0) {
-    return ' (MQTT)';
+    return ' (IP)';
   }
   return ` (${(snrValue / 4).toFixed(1)} dB)`;
 }


### PR DESCRIPTION
## Summary
- Changes "MQTT" to "IP" in traceroute displays where the SNR sentinel value indicates a non-LoRa hop
- The SNR sentinel (-128 or 0) just means "no radio SNR available" — it could be MQTT, UDP multicast, or API transport

## Scope
Only traceroute/SNR-sentinel displays are changed:
- `TracerouteWidget.tsx` — hop SNR display
- `useTraceroutePaths.tsx` — segment popup badge and SNR labels
- `mapHelpers.tsx` — arrow tooltip
- `traceroute.tsx` — SNR format function
- `MapLegend.tsx` + `en.json` — map legend label

The `viaMqtt`-based indicators on nodes/messages are **NOT** changed — those are specifically set by the firmware's `viaMqtt` protobuf flag.

## Test plan
- [x] Full suite: 3110 tests pass, 0 failures

Fixes #2443

🤖 Generated with [Claude Code](https://claude.com/claude-code)