### PR TITLE
chore: bump version to 3.10.2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "3.10.1",
+  "version": "3.10.2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.10.1
-appVersion: "3.10.1"
+version: 3.10.2
+appVersion: "3.10.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Bump version to 3.10.2 across all 5 version files.

## Changes since v3.10.1

### Bug Fixes
- #2438 fix: rename legacy system_backup_history columns (#2419)
- #2442 fix: add missing api_tokens name column (#2435)
- #2444 fix: correct frequency display when channelNum is 0 (#2436)
- #2449 fix: change traceroute MQTT label to IP for non-LoRa hops (#2443)
- #2450 fix: replace node-cron with croner for missed execution recovery (#2409)
- #2451 fix: auto-mark incoming messages as read when viewing channel (#2316)
- #2434 fix: packet monitor renders on mobile devices

### Features
- #2433 feat: detect channel moves on startup, migrate messages and permissions
- #2439 feat: migrate automation channels on channel move (#2425)
- #2448 feat: add extraEnv support to Helm chart

### Security
- #2446 fix: upgrade ARMv7 base image to node:22.22.1-bookworm-slim
- #2447 security upgrade node to 22.22.2-bookworm-slim

🤖 Generated with [Claude Code](https://claude.com/claude-code)