### PR TITLE
fix: filter relay node dropdown by hop distance

### DIFF
--- a/src/db/repositories/misc.packetlog.test.ts
+++ b/src/db/repositories/misc.packetlog.test.ts
@@ -25,7 +25,8 @@ describe('MiscRepository - Packet Log Queries', () => {
         nodeId TEXT,
         longName TEXT,
         shortName TEXT,
-        lastHeard INTEGER
+        lastHeard INTEGER,
+        hopsAway INTEGER
       )
     `);
 
@@ -72,9 +73,9 @@ describe('MiscRepository - Packet Log Queries', () => {
     repo = new MiscRepository(drizzleDb as any, 'sqlite');
 
     // Insert test nodes
-    db.exec(`INSERT INTO nodes (nodeNum, nodeId, longName, shortName) VALUES (100, '!00000064', 'Node Alpha', 'ALPH')`);
-    db.exec(`INSERT INTO nodes (nodeNum, nodeId, longName, shortName) VALUES (200, '!000000c8', 'Node Beta', 'BETA')`);
-    db.exec(`INSERT INTO nodes (nodeNum, nodeId, longName, shortName) VALUES (300, '!0000012c', 'Node Gamma', 'GAMM')`);
+    db.exec(`INSERT INTO nodes (nodeNum, nodeId, longName, shortName, hopsAway) VALUES (100, '!00000064', 'Node Alpha', 'ALPH', 0)`);
+    db.exec(`INSERT INTO nodes (nodeNum, nodeId, longName, shortName, hopsAway) VALUES (200, '!000000c8', 'Node Beta', 'BETA', 1)`);
+    db.exec(`INSERT INTO nodes (nodeNum, nodeId, longName, shortName, hopsAway) VALUES (300, '!0000012c', 'Node Gamma', 'GAMM', 0)`);
 
     // Insert test packets
     const now = Math.floor(Date.now() / 1000);

--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -1034,9 +1034,12 @@ export class MiscRepository extends BaseRepository {
       const relayValues = (distinctRows as any[]).map((r: any) => Number(r.relay_node));
 
       const results: DbDistinctRelayNode[] = [];
+      const hopsAway = this.col('hopsAway');
       for (const rv of relayValues) {
+        // Only include nodes that could plausibly be relays:
+        // direct neighbors (hopsAway <= 1) or unknown hop distance (NULL)
         const matchRows = await this.executeQuery(
-          sql`SELECT ${longName}, ${shortName} FROM nodes WHERE (${nodeNum} & 255) = ${rv}`
+          sql`SELECT ${longName}, ${shortName} FROM nodes WHERE (${nodeNum} & 255) = ${rv} AND (${hopsAway} IS NULL OR ${hopsAway} <= 1)`
         );
         results.push({
           relay_node: rv,


### PR DESCRIPTION
## Summary
The "Last Hops" filter dropdown in the packet monitor showed all nodes whose lowest byte matched the relay_node value, regardless of proximity. This meant nodes several hops away appeared as relay candidates, while the "Last Hop" column correctly filtered to only direct neighbors or 1-hop nodes. The inconsistency confused users because selecting a filter showed different nodes than the column.

## Changes
- Added `hopsAway <= 1 OR hopsAway IS NULL` filter to `getDistinctRelayNodes()` in `src/db/repositories/misc.ts`
- Updated test in `misc.packetlog.test.ts` to include `hopsAway` column and values

## Issues Resolved
Fixes #2457

## Documentation Updates
No documentation changes needed

## Testing
- [x] Unit tests pass (3124 tests across 152 files)
- [x] TypeScript compiles cleanly
- [x] Existing `getDistinctRelayNodes` test updated and passing
- [ ] Reviewer: verify the Last Hops filter dropdown shows only plausible relay candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)