### PR TITLE
feat: reverse neighbor arrow direction and improve zoom visibility

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -2159,12 +2159,13 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                   : undefined;
 
                 // Calculate bearing for unidirectional arrow (degrees from north)
+                // Arrow points FROM neighbor TO node (neighbor→node = "I heard this neighbor")
                 // Scale longitude difference by cos(lat) to correct for latitude
                 const latMid = (ni.nodeLatitude! + ni.neighborLatitude!) / 2;
                 const bearing = !isBidirectional
                   ? Math.atan2(
-                      (ni.neighborLongitude! - ni.nodeLongitude!) * Math.cos(latMid * Math.PI / 180),
-                      ni.neighborLatitude! - ni.nodeLatitude!
+                      (ni.nodeLongitude! - ni.neighborLongitude!) * Math.cos(latMid * Math.PI / 180),
+                      ni.nodeLatitude! - ni.neighborLatitude!
                     ) * (180 / Math.PI)
                   : 0;
 
@@ -2182,7 +2183,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                         <div className="route-popup">
                           <h4>{t('direct_links.neighbor_connection', 'Neighbor Connection')}</h4>
                           <div className="route-endpoints">
-                            <strong>{ni.nodeName}</strong> {isBidirectional ? '↔' : '→'} <strong>{ni.neighborName}</strong>
+                            <strong>{ni.neighborName}</strong> {isBidirectional ? '↔' : '→'} <strong>{ni.nodeName}</strong>
                           </div>
                           {isBidirectional && (
                             <div className="route-usage" style={{ color: 'var(--ctp-green)' }}>
@@ -2205,16 +2206,21 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                         </div>
                       </Popup>
                     </Polyline>
-                    {/* Midpoint arrow for unidirectional lines */}
+                    {/* Direction arrows along unidirectional lines at 25%, 50%, 75% for visibility at any zoom */}
                     {!isBidirectional && ni.nodeLatitude && ni.neighborLatitude && (
-                      <Marker
-                        position={[
-                          (ni.nodeLatitude + ni.neighborLatitude) / 2,
-                          (ni.nodeLongitude! + ni.neighborLongitude!) / 2
-                        ]}
-                        icon={createArrowIcon(bearing, overlayColors.neighborLine)}
-                        interactive={false}
-                      />
+                      <>
+                        {[0.25, 0.5, 0.75].map(fraction => (
+                          <Marker
+                            key={`arrow-${fraction}`}
+                            position={[
+                              ni.neighborLatitude! + (ni.nodeLatitude! - ni.neighborLatitude!) * fraction,
+                              ni.neighborLongitude! + (ni.nodeLongitude! - ni.neighborLongitude!) * fraction
+                            ]}
+                            icon={createArrowIcon(bearing, overlayColors.neighborLine)}
+                            interactive={false}
+                          />
+                        ))}
+                      </>
                     )}
                   </React.Fragment>
                 );


### PR DESCRIPTION
## Summary
Neighbor arrows now point FROM the heard neighbor TO the receiving node, correctly representing the communication direction ("I received a packet from this neighbor with this signal strength"). The previous direction (node→neighbor) was misleading when combined with SNR-based line thickness, as the signal strength relates to the incoming direction.

Also improved arrow visibility at all zoom levels by placing arrows at 25%, 50%, and 75% along the line instead of just the midpoint.

## Changes
- Reversed bearing calculation to point neighbor→node instead of node→neighbor
- Updated popup text to show `Neighbor → Node` direction
- Placed 3 arrow markers along each unidirectional line (at 25%, 50%, 75%) for visibility at any zoom level

## Issues Resolved
Fixes #2456

## Documentation Updates
No documentation changes needed

## Testing
- [x] Unit tests pass (3124 tests across 152 files)
- [x] TypeScript compiles cleanly
- [ ] Reviewer: verify arrows point from neighbor toward the node that heard them
- [ ] Reviewer: verify arrows remain visible when zooming in on a neighbor connection
- [ ] Reviewer: verify popup shows correct direction (neighbor → node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)