### PR TITLE
docs: add NWI Mesh Net to site gallery

### DIFF
--- a/docs/site-gallery.md
+++ b/docs/site-gallery.md
@@ -59,6 +59,14 @@ Running a public MeshMonitor instance? We'd love to feature it! **[File an issue
 
 ---
 
+### NWI Mesh Net
+- **URL**: [meshview.nwimesh.net](https://meshview.nwimesh.net/)
+- **Network**: [NWIMesh.net](https://nwimesh.net/)
+- **Location**: Northwest Indiana, US
+- **Description**: A regional mesh network serving Northwest Indiana (Lake, Porter, Newton, Jasper, and LaPorte counties) with a cross-lake link extending connectivity to Chicago.
+
+---
+
 ### Indiana Mesh
 - **URL**: [meshmap.tranziq.net](https://meshmap.tranziq.net/)
 - **Network**: [CIMesh](https://cimesh.net/)


### PR DESCRIPTION
## Summary
Adds the NWI Mesh Net MeshMonitor instance to the site gallery as requested.

## Changes
- Added NWI Mesh Net entry to `docs/site-gallery.md`

## Issues Resolved
Closes #2465

## Testing
- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)