### PR TITLE
feat: add chronological SNR chart to route segment popup

### DIFF
--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -10,13 +10,114 @@
  * selectedNodeTraceroute useMemo blocks in App.tsx.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Popup, Polyline } from 'react-leaflet';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { calculateDistance, formatDistance } from '../utils/distance';
 import { generateCurvedArrowMarkers, generateCurvedPath, getLineWeight, getSegmentSnrColor, getSegmentSnrOpacity, getTemporalOpacityMultiplier, isMqttSnr } from '../utils/mapHelpers';
 import { logger } from '../utils/logger';
 import type { DistanceUnit } from '../contexts/SettingsContext';
+
+/** Small component for route segment SNR chart with time-of-day / chronological toggle */
+function SegmentSnrChart({ chartData }: {
+  chartData: Array<{ timeDecimal: number; timeLabel: string; snr: number; fullTimestamp: number }>;
+}) {
+  const [mode, setMode] = useState<'timeOfDay' | 'chronological'>('timeOfDay');
+
+  const chronoData = useMemo(() =>
+    [...chartData].sort((a, b) => a.fullTimestamp - b.fullTimestamp).map(d => {
+      const date = new Date(d.fullTimestamp);
+      const month = (date.getMonth() + 1).toString().padStart(2, '0');
+      const day = date.getDate().toString().padStart(2, '0');
+      const hours = date.getHours().toString().padStart(2, '0');
+      const minutes = date.getMinutes().toString().padStart(2, '0');
+      return { ...d, chronoLabel: `${month}/${day} ${hours}:${minutes}`, chronoTime: d.fullTimestamp };
+    }), [chartData]);
+
+  return (
+    <div className="snr-timeline-chart">
+      <div style={{ display: 'flex', gap: '4px', marginBottom: '6px' }}>
+        <button
+          className={`node-popup-tab ${mode === 'timeOfDay' ? 'active' : ''}`}
+          style={{ fontSize: '10px', padding: '2px 8px', border: '1px solid var(--ctp-surface2)', borderRadius: '4px', cursor: 'pointer', background: mode === 'timeOfDay' ? 'var(--ctp-blue)' : 'var(--ctp-surface0)', color: mode === 'timeOfDay' ? 'var(--ctp-base)' : 'var(--ctp-subtext1)' }}
+          onClick={e => { e.stopPropagation(); setMode('timeOfDay'); }}
+        >
+          Time of Day
+        </button>
+        <button
+          className={`node-popup-tab ${mode === 'chronological' ? 'active' : ''}`}
+          style={{ fontSize: '10px', padding: '2px 8px', border: '1px solid var(--ctp-surface2)', borderRadius: '4px', cursor: 'pointer', background: mode === 'chronological' ? 'var(--ctp-blue)' : 'var(--ctp-surface0)', color: mode === 'chronological' ? 'var(--ctp-base)' : 'var(--ctp-subtext1)' }}
+          onClick={e => { e.stopPropagation(); setMode('chronological'); }}
+        >
+          Over Time
+        </button>
+      </div>
+      <ResponsiveContainer width="100%" height={150}>
+        {mode === 'timeOfDay' ? (
+          <LineChart data={chartData} margin={{ top: 10, right: 10, left: -20, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--ctp-surface2)" />
+            <XAxis
+              dataKey="timeDecimal"
+              type="number"
+              domain={[0, 24]}
+              ticks={[0, 6, 12, 18, 24]}
+              tickFormatter={value => {
+                const hours = Math.floor(value);
+                const minutes = Math.round((value - hours) * 60);
+                return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+              }}
+              tick={{ fill: 'var(--ctp-subtext1)', fontSize: 10 }}
+              stroke="var(--ctp-surface2)"
+            />
+            <YAxis
+              tick={{ fill: 'var(--ctp-subtext1)', fontSize: 10 }}
+              stroke="var(--ctp-surface2)"
+              label={{ value: 'SNR (dB)', angle: -90, position: 'insideLeft', style: { fill: 'var(--ctp-subtext1)', fontSize: 10 } }}
+            />
+            <Tooltip
+              contentStyle={{ backgroundColor: 'var(--ctp-surface0)', border: '1px solid var(--ctp-surface2)', borderRadius: '4px', fontSize: '12px' }}
+              labelStyle={{ color: 'var(--ctp-text)' }}
+              labelFormatter={value => {
+                const item = chartData.find(d => d.timeDecimal === value);
+                return item ? item.timeLabel : String(value);
+              }}
+            />
+            <Line type="monotone" dataKey="snr" stroke="var(--ctp-mauve)" strokeWidth={2} dot={{ fill: 'var(--ctp-mauve)', r: 3 }} />
+          </LineChart>
+        ) : (
+          <LineChart data={chronoData} margin={{ top: 10, right: 10, left: -20, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--ctp-surface2)" />
+            <XAxis
+              dataKey="chronoTime"
+              type="number"
+              domain={['dataMin', 'dataMax']}
+              tickFormatter={value => {
+                const date = new Date(value);
+                return `${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getDate().toString().padStart(2, '0')}`;
+              }}
+              tick={{ fill: 'var(--ctp-subtext1)', fontSize: 10 }}
+              stroke="var(--ctp-surface2)"
+            />
+            <YAxis
+              tick={{ fill: 'var(--ctp-subtext1)', fontSize: 10 }}
+              stroke="var(--ctp-surface2)"
+              label={{ value: 'SNR (dB)', angle: -90, position: 'insideLeft', style: { fill: 'var(--ctp-subtext1)', fontSize: 10 } }}
+            />
+            <Tooltip
+              contentStyle={{ backgroundColor: 'var(--ctp-surface0)', border: '1px solid var(--ctp-surface2)', borderRadius: '4px', fontSize: '12px' }}
+              labelStyle={{ color: 'var(--ctp-text)' }}
+              labelFormatter={value => {
+                const item = chronoData.find(d => d.chronoTime === value);
+                return item ? item.chronoLabel : String(value);
+              }}
+            />
+            <Line type="monotone" dataKey="snr" stroke="var(--ctp-mauve)" strokeWidth={2} dot={{ fill: 'var(--ctp-mauve)', r: 3 }} />
+          </LineChart>
+        )}
+      </ResponsiveContainer>
+    </div>
+  );
+}
 
 /**
  * Minimal node data needed for traceroute rendering
@@ -585,56 +686,7 @@ export function useTraceroutePaths({
                         <span className="stat-value">{snrStats.count}</span>
                       </div>
                       {chartData && (
-                        <div className="snr-timeline-chart">
-                          <ResponsiveContainer width="100%" height={150}>
-                            <LineChart data={chartData} margin={{ top: 10, right: 10, left: -20, bottom: 5 }}>
-                              <CartesianGrid strokeDasharray="3 3" stroke="var(--ctp-surface2)" />
-                              <XAxis
-                                dataKey="timeDecimal"
-                                type="number"
-                                domain={[0, 24]}
-                                ticks={[0, 6, 12, 18, 24]}
-                                tickFormatter={value => {
-                                  const hours = Math.floor(value);
-                                  const minutes = Math.round((value - hours) * 60);
-                                  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
-                                }}
-                                tick={{ fill: 'var(--ctp-subtext1)', fontSize: 10 }}
-                                stroke="var(--ctp-surface2)"
-                              />
-                              <YAxis
-                                tick={{ fill: 'var(--ctp-subtext1)', fontSize: 10 }}
-                                stroke="var(--ctp-surface2)"
-                                label={{
-                                  value: 'SNR (dB)',
-                                  angle: -90,
-                                  position: 'insideLeft',
-                                  style: { fill: 'var(--ctp-subtext1)', fontSize: 10 },
-                                }}
-                              />
-                              <Tooltip
-                                contentStyle={{
-                                  backgroundColor: 'var(--ctp-surface0)',
-                                  border: '1px solid var(--ctp-surface2)',
-                                  borderRadius: '4px',
-                                  fontSize: '12px',
-                                }}
-                                labelStyle={{ color: 'var(--ctp-text)' }}
-                                labelFormatter={value => {
-                                  const item = chartData!.find(d => d.timeDecimal === value);
-                                  return item ? item.timeLabel : String(value);
-                                }}
-                              />
-                              <Line
-                                type="monotone"
-                                dataKey="snr"
-                                stroke="var(--ctp-mauve)"
-                                strokeWidth={2}
-                                dot={{ fill: 'var(--ctp-mauve)', r: 3 }}
-                              />
-                            </LineChart>
-                          </ResponsiveContainer>
-                        </div>
+                        <SegmentSnrChart chartData={chartData} />
                       )}
                     </>
                   )}


### PR DESCRIPTION
## Summary
Adds a "Time of Day" / "Over Time" toggle to the route segment popup's SNR chart. The existing chart plots SNR by hour of day (0-24h) to show daily patterns. The new chronological view plots SNR by actual date/time to track signal quality improvement or degradation over days.

Uses the same traceroute data already loaded in the hook — no new API calls needed. The toggle buttons follow the same visual pattern as the node popup's info/traceroute tabs.

## Changes
- Extracted inline chart into `SegmentSnrChart` component with toggle state
- Added chronological view: data sorted by `fullTimestamp`, X-axis shows MM/DD dates
- Toggle buttons styled consistently with existing node popup tabs
- Existing "Time of Day" chart preserved as default view

## Issues Resolved
Fixes #2464

## Documentation Updates
No documentation changes needed

## Testing
- [x] Unit tests pass (3124 tests across 152 files)
- [x] TypeScript compiles cleanly
- [ ] Reviewer: click a route segment on the map, verify both chart modes work
- [ ] Reviewer: toggle between "Time of Day" and "Over Time" views
- [ ] Reviewer: verify chronological chart shows dates on X-axis with SNR trend

🤖 Generated with [Claude Code](https://claude.com/claude-code)