### PR TITLE
fix: increase Meshtastic connection timing defaults

### DIFF
--- a/src/server/config/environment.ts
+++ b/src/server/config/environment.ts
@@ -458,12 +458,12 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
   const meshtasticConnectTimeoutMs = parseInt32(
     'MESHTASTIC_CONNECT_TIMEOUT_MS',
     process.env.MESHTASTIC_CONNECT_TIMEOUT_MS,
-    10000 // 10 seconds default
+    60000 // 60 seconds default
   );
   const meshtasticReconnectInitialDelayMs = parseInt32(
     'MESHTASTIC_RECONNECT_INITIAL_DELAY_MS',
     process.env.MESHTASTIC_RECONNECT_INITIAL_DELAY_MS,
-    1000 // 1 second default
+    60000 // 60 seconds default
   );
   const meshtasticReconnectMaxDelayMs = parseInt32(
     'MESHTASTIC_RECONNECT_MAX_DELAY_MS',
@@ -473,7 +473,7 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
   const meshtasticModuleConfigDelayMs = parseInt32(
     'MESHTASTIC_MODULE_CONFIG_DELAY_MS',
     process.env.MESHTASTIC_MODULE_CONFIG_DELAY_MS,
-    100 // 100ms default
+    1000 // 1 second default
   );
   const timezoneRaw = process.env.TZ || 'UTC';
   let timezone = { value: timezoneRaw, wasProvided: process.env.TZ !== undefined };


### PR DESCRIPTION
## Summary
Updates default Meshtastic connection timing values based on community feedback in #2316. More conservative defaults reduce Node ID change issues during config sync, especially for direct MQTT over WiFi connections.

## Changes
| Setting | Before | After |
|---------|--------|-------|
| `MESHTASTIC_CONNECT_TIMEOUT_MS` | 10,000 (10s) | 60,000 (60s) |
| `MESHTASTIC_RECONNECT_INITIAL_DELAY_MS` | 1,000 (1s) | 60,000 (60s) |
| `MESHTASTIC_MODULE_CONFIG_DELAY_MS` | 100 (100ms) | 1,000 (1s) |
| `MESHTASTIC_RECONNECT_MAX_DELAY_MS` | 60,000 (60s) | unchanged |

All values remain overridable via environment variables.

## Issues Resolved
Relates to #2316

## Documentation Updates
No documentation changes needed — env vars are already documented

## Testing
- [x] TypeScript compiles cleanly
- [x] Default-only change, no logic changes
- [ ] Reviewer: verify improved stability with direct MQTT connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)