### PR TITLE
chore: bump version to 3.10.3

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "3.10.2",
+  "version": "3.10.3",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.10.2
-appVersion: "3.10.2"
+version: 3.10.3
+appVersion: "3.10.3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.10.2",
+      "version": "3.10.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/tests/test-config-import.sh
+++ b/tests/test-config-import.sh
@@ -240,9 +240,9 @@ wait_for_reconnect() {
     fi
 
     # Now wait for device to reconnect (reboot complete)
-    # UI waits up to 60 seconds for reconnect
-    echo "Waiting for device to reconnect (up to 60 seconds)..."
-    MAX_WAIT_RECONNECT=60
+    # Allow extra time for reconnect initial delay (default 60s) plus device reboot time
+    echo "Waiting for device to reconnect (up to 180 seconds)..."
+    MAX_WAIT_RECONNECT=180
     ELAPSED=0
 
     while [ $ELAPSED -lt $MAX_WAIT_RECONNECT ]; do


### PR DESCRIPTION
## Summary
Version bump to 3.10.3 for release.

## Changes
- Version bumped in all 5 files (package.json, package-lock.json, Chart.yaml, tauri.conf.json, desktop/package.json)
- Increased system test reconnect timeout to 180s to accommodate new MESHTASTIC_RECONNECT_INITIAL_DELAY_MS default (60s)

## System Test Results
All 11 tests passed:
- Configuration Import: PASSED
- Quick Start Test: PASSED
- Security Test: PASSED
- V1 API Test: PASSED
- Reverse Proxy Test: PASSED
- Reverse Proxy + OIDC: PASSED
- Virtual Node CLI Test: PASSED
- Backup & Restore Test: PASSED
- Database Migration Test: PASSED
- DB Backing Consistency: PASSED
- API Exercise (3 DBs): PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)