### PR TITLE
fix: detect and recover from phantom TCP connections

### DIFF
--- a/src/server/tcpTransport.ts
+++ b/src/server/tcpTransport.ts
@@ -19,9 +19,11 @@ export class TcpTransport extends EventEmitter {
 
   // Stale connection detection
   private lastDataReceived: number = 0;
+  private lastMessageEmitted: number = 0;  // Last time a complete frame was successfully parsed
   private staleConnectionTimeout: number = 300000; // 5 minutes default (in milliseconds)
   private healthCheckInterval: NodeJS.Timeout | null = null;
   private readonly HEALTH_CHECK_INTERVAL_MS = 60000; // Check every minute
+  private readonly BUFFER_STALE_TIMEOUT_MS = 30000; // 30s: if buffer has data but no frames parsed, reset it
 
   // Configurable TCP timing
   private connectTimeoutMs: number = 10000; // 10 second default
@@ -107,8 +109,9 @@ export class TcpTransport extends EventEmitter {
         this.reconnectAttempts = 0;
         this.buffer = Buffer.alloc(0); // Reset buffer on new connection
 
-        // Initialize last data received timestamp
+        // Initialize timestamps
         this.lastDataReceived = Date.now();
+        this.lastMessageEmitted = Date.now();
 
         // Start stale connection monitoring
         this.startHealthCheck();
@@ -305,7 +308,8 @@ export class TcpTransport extends EventEmitter {
 
       logger.debug(`📥 Received frame: ${payloadLength} bytes`);
 
-      // Emit the message
+      // Emit the message and track last successful parse
+      this.lastMessageEmitted = Date.now();
       this.emit('message', new Uint8Array(payload));
 
       // Remove processed frame from buffer
@@ -391,10 +395,31 @@ export class TcpTransport extends EventEmitter {
       if (this.socket) {
         this.socket.destroy();
       }
-    } else {
-      // Log periodic health check status at debug level
-      const minutesSinceLastData = Math.floor(timeSinceLastData / 1000 / 60);
-      logger.debug(`💓 Connection health check: Last data received ${minutesSinceLastData} minute(s) ago`);
+      return;
     }
+
+    // Phantom connection detection: data arrives but no complete frames are parsed.
+    // This happens when a corrupted byte shifts frame alignment — the parser waits
+    // forever for a "phantom frame" while real data piles up unparsed. The connection
+    // looks alive (lastDataReceived updates) but no messages reach the application.
+    // Common with USB serial bridges that can inject noise bytes.
+    const timeSinceLastMessage = now - this.lastMessageEmitted;
+    if (this.buffer.length > 0 && timeSinceLastMessage > this.BUFFER_STALE_TIMEOUT_MS) {
+      logger.warn(`⚠️  Stale buffer detected: ${this.buffer.length} bytes buffered but no complete frame parsed for ${Math.floor(timeSinceLastMessage / 1000)}s. Resetting buffer to recover frame alignment.`);
+      this.buffer = Buffer.alloc(0);
+    } else if (timeSinceLastMessage > this.staleConnectionTimeout) {
+      // Data is arriving (lastDataReceived is fresh) but no messages are being parsed
+      // even after buffer reset — force reconnect
+      logger.warn(`⚠️  Phantom connection detected: Data arriving but no messages parsed for ${Math.floor(timeSinceLastMessage / 1000 / 60)} minute(s). Forcing reconnection...`);
+      this.emit('stale-connection', { timeSinceLastData: timeSinceLastMessage, timeout: this.staleConnectionTimeout });
+      if (this.socket) {
+        this.socket.destroy();
+      }
+      return;
+    }
+
+    // Log periodic health check status at debug level
+    const minutesSinceLastData = Math.floor(timeSinceLastData / 1000 / 60);
+    logger.debug(`💓 Connection health check: Last data received ${minutesSinceLastData} minute(s) ago, last message parsed ${Math.floor(timeSinceLastMessage / 1000)}s ago`);
   }
 }


### PR DESCRIPTION
## Summary

Fixes a phantom connection issue where USB serial bridge connections (like the RPi Docker setup) stop receiving mesh messages after several hours, even though sends still work and the connection appears alive.

**Root cause:** A corrupted byte from the serial bridge can shift the TCP frame parser's alignment. The parser then waits indefinitely for a "phantom frame" that will never arrive. Meanwhile:
- Real data keeps arriving → `lastDataReceived` updates → stale connection check passes
- Sends go through `socket.write()` independently → outbound works fine
- But no `message` events are emitted → application sees no incoming mesh traffic

**Fix — two-stage recovery in the health check:**
- **Buffer staleness (30s):** If the buffer has pending data but no complete frame has been parsed for 30 seconds, reset the buffer to recover frame alignment
- **Phantom connection (5min):** If data arrives but no messages are parsed even after buffer resets, force a full TCP reconnection

Also adds `lastMessageEmitted` timestamp tracking (separate from `lastDataReceived`) to distinguish "connection alive" from "connection productive."

## Test plan

- [x] TypeScript compiles clean
- [x] All 3,493 unit tests pass
- [ ] System tests (running in background)
- [ ] Deploy to Wynwood node and monitor for several hours to verify phantom connection recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)