### PR TITLE
fix: audit log FK constraint on channel migration at startup

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -11040,7 +11040,7 @@ class MeshtasticManager {
           details.push(`New channels on slots: ${newChannels.join(', ')} (default: no user permissions)`);
         }
         await databaseService.auditLogAsync(
-          0, // system user
+          null, // system operation — no user context at startup
           'channel_migration_on_startup',
           'channels',
           details.join('. '),


### PR DESCRIPTION
## Summary

Fixes `SQLITE_CONSTRAINT_FOREIGNKEY` error when writing audit log after channel migration on startup.

**Root cause:** The channel migration audit log entry used `userId: 0` as a "system user", but user ID 0 doesn't exist in the `users` table (auto-increment starts at 1). The foreign key constraint on `audit_log.userId` rejects the insert.

**Fix:** Changed to `null` — the column already allows NULL values and there's no user context during startup migration.

Reported by user in #2425.

## Test plan

- [x] TypeScript compiles clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)