### PR TITLE
chore: bump version to 3.11.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "3.10.4",
+  "version": "3.11.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "3.10.4",
+  "version": "3.11.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 3.10.4
-appVersion: "3.10.4"
+version: 3.11.0
+appVersion: "3.11.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "3.10.4",
+  "version": "3.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "3.10.4",
+      "version": "3.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "3.10.4",
+  "version": "3.11.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

- Bump version to 3.11.0 across all five version files

## Changes since 3.10.4

- feat: GeoJSON/KML/KMZ overlay layer support (#2488, closes #2487)
- fix: audit log FK constraint on channel migration at startup (#2486)
- fix: duplicate cron jobs after multiple reconnects (#2489)

🤖 Generated with [Claude Code](https://claude.com/claude-code)