### PR TITLE
fix: add MySQL service container to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,20 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+          MYSQL_DATABASE: meshmonitor_test
+        ports:
+          - 3307:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

The release pipeline was missing the MySQL service container that PR tests and CI workflows already have. This caused all MySQL backend repository tests to fail during the v3.11.0 release.

Copies the exact MySQL service configuration from `pr-tests.yml` into `release.yml`.

## Test plan

- [x] Config matches pr-tests.yml and ci.yml MySQL service blocks
- [ ] Next release should pass all MySQL tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)