### PR TITLE
fix: use server time for lastHeard instead of device rxTime

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3762,8 +3762,8 @@ class MeshtasticManager {
       const nodeData: any = {
         nodeNum: fromNum,
         nodeId: nodeId,
-        // Cap lastHeard at current time to prevent stale timestamps from node clock issues
-        lastHeard: Math.min(meshPacket.rxTime ? Number(meshPacket.rxTime) : Date.now() / 1000, Date.now() / 1000),
+        // Use server time for lastHeard — rxTime from the device clock is unreliable
+        lastHeard: Date.now() / 1000,
         // Update channel from every firmware-decoded packet so outbound messages (DMs,
         // traceroutes, position requests) use the channel the node is actually communicating
         // on. Previously only set from NodeInfo, which could get stuck on a secondary channel.
@@ -4279,7 +4279,7 @@ class MeshtasticManager {
           const technicalData: any = {
             nodeNum: fromNum,
             nodeId: nodeId,
-            lastHeard: Math.min(meshPacket.rxTime ? Number(meshPacket.rxTime) : Date.now() / 1000, Date.now() / 1000),
+            lastHeard: Date.now() / 1000,
           };
           if (meshPacket.rxSnr && meshPacket.rxSnr !== 0) {
             technicalData.snr = meshPacket.rxSnr;
@@ -4296,7 +4296,7 @@ class MeshtasticManager {
             longitude: coords.longitude,
             altitude: position.altitude,
             // Cap lastHeard at current time to prevent stale timestamps from node clock issues
-            lastHeard: Math.min(meshPacket.rxTime ? Number(meshPacket.rxTime) : Date.now() / 1000, Date.now() / 1000),
+            lastHeard: Date.now() / 1000,
             positionChannel: channelIndex,
             positionPrecisionBits: precisionBits,
             positionGpsAccuracy: gpsAccuracy,
@@ -4387,8 +4387,8 @@ class MeshtasticManager {
         hwModel: user.hwModel,
         role: user.role,
         hopsAway: meshPacket.hopsAway,
-        // Cap lastHeard at current time to prevent stale timestamps from node clock issues
-        lastHeard: Math.min(meshPacket.rxTime ? Number(meshPacket.rxTime) : timestamp / 1000, Date.now() / 1000),
+        // Use server time for lastHeard — rxTime from the device clock is unreliable
+        lastHeard: Date.now() / 1000,
       };
 
       // Capture public key if present
@@ -4606,7 +4606,7 @@ class MeshtasticManager {
         nodeNum: fromNum,
         nodeId: nodeId,
         // Cap lastHeard at current time to prevent stale timestamps from node clock issues
-        lastHeard: Math.min(meshPacket.rxTime ? Number(meshPacket.rxTime) : Date.now() / 1000, Date.now() / 1000)
+        lastHeard: Date.now() / 1000
       };
 
       // Only include SNR/RSSI if they have valid values
@@ -4826,7 +4826,7 @@ class MeshtasticManager {
         nodeNum: fromNum,
         nodeId: nodeId,
         // Cap lastHeard at current time to prevent stale timestamps from node clock issues
-        lastHeard: Math.min(meshPacket.rxTime ? Number(meshPacket.rxTime) : Date.now() / 1000, Date.now() / 1000)
+        lastHeard: Date.now() / 1000
       };
 
       // Only include SNR/RSSI if they have valid values


### PR DESCRIPTION
## Summary

Fixes incorrect "last heard" times in the Node List where some nodes showed significantly wrong timestamps while the Packet Monitor was accurate.

**Root cause:** `lastHeard` was set from `meshPacket.rxTime` (the local Meshtastic device's clock) in 6 code paths, but from `Date.now()` (server clock) in others like traceroute processing. When the local node's clock drifts, all rxTime-based timestamps are wrong. Tracerouted nodes temporarily showed correct times because that handler used `Date.now()`, but the next regular packet overwrote it back to the wrong rxTime.

**Fix:** Use `Date.now() / 1000` consistently for all `lastHeard` updates. The server knows when it received each packet — that's the authoritative "last heard" time.

## Test plan

- [x] TypeScript compiles clean
- [ ] CI passes
- [ ] Deploy and verify Node List times are now consistently accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)