### PR TITLE
docs: add Emacs client to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ This project is licensed under the BSD-3-Clause License - see the [LICENSE](LICE
 - **GitHub Issues**: Report bugs and request features
 - **Documentation**: [meshmonitor.org](https://meshmonitor.org/)
 
+## Third-Party Clients
+
+- **[meshmonitor-chat.el](https://git.andros.dev/andros/meshmonitor-chat.el)** - Emacs chat client using the REST API v1. Channel and DM support, delivery confirmation, emoji reactions, polling.
+
 ## Acknowledgments
 
 - [Meshtastic](https://meshtastic.org/) - Open source mesh networking


### PR DESCRIPTION
## Summary

- Add a "Third-Party Clients" section to the README with a link to [meshmonitor-chat.el](https://git.andros.dev/andros/meshmonitor-chat.el), an Emacs chat client that connects to the MeshMonitor REST API v1.

## Details

meshmonitor-chat.el provides channel and DM chat from Emacs, with delivery confirmation, emoji reactions, node listing by hops, unread tracking and polling. It uses only the REST API v1 with Bearer token authentication, no additional dependencies on the MeshMonitor side.