### PR TITLE
fix: normalize neighbor_info timestamps for mixed seconds/ms data

### DIFF
--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -1583,8 +1583,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               const nodeNeighbors = neighborInfo.filter(ni => ni.nodeNum === nodeNum);
               if (nodeNeighbors.length === 0) return null;
 
-              // Get most recent timestamp
-              const mostRecent = Math.max(...nodeNeighbors.map(n => n.timestamp));
+              // Get most recent timestamp (normalize: old data in seconds, new in ms)
+              const mostRecent = Math.max(...nodeNeighbors.map(n => n.timestamp < 10_000_000_000 ? n.timestamp * 1000 : n.timestamp));
               const age = Math.floor((Date.now() - mostRecent) / (1000 * 60));
               const ageStr = age < 60 ? `${age}m ago` : `${Math.floor(age / 60)}h ago`;
 

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -2290,8 +2290,10 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 const distKm = calculateDistance(ni.nodeLatitude!, ni.nodeLongitude!, ni.neighborLatitude!, ni.neighborLongitude!);
                 const distStr = formatDistance(distKm, distanceUnit);
 
+                // Normalize timestamp: old data may be in seconds, new data in milliseconds
+                const tsMs = ni.timestamp < 10_000_000_000 ? ni.timestamp * 1000 : ni.timestamp;
                 // Data age (clamped to 0 to handle clock skew)
-                const ageMs = Math.max(0, Date.now() - ni.timestamp);
+                const ageMs = Math.max(0, Date.now() - tsMs);
                 const ageMin = Math.floor(ageMs / 60000);
                 const ageStr = ageMin < 60 ? `${ageMin}m ago` : `${Math.floor(ageMin / 60)}h ago`;
 
@@ -2343,7 +2345,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                             </div>
                           )}
                           <div className="route-usage">
-                            {t('direct_links.last_seen', 'Last seen')}: <strong>{formatDateTime(new Date(ni.timestamp), timeFormat, dateFormat)}</strong> ({ageStr})
+                            {t('direct_links.last_seen', 'Last seen')}: <strong>{formatDateTime(new Date(tsMs), timeFormat, dateFormat)}</strong> ({ageStr})
                           </div>
                         </div>
                       </Popup>


### PR DESCRIPTION
## Summary

Fixes incorrect "Last Seen" times in Neighbor Connection popups where old data showed dates in 1970.

**Root cause:** The `neighbor_info` table has a mix of timestamp formats — old rows store timestamps in **seconds**, new rows in **milliseconds**. The display code assumed all values were milliseconds.

**Fix:** Added a `toMs` heuristic (`< 10_000_000_000 = seconds → multiply by 1000`) to normalize timestamps before display. Applied to:
- NodesTab neighbor popup (Last Seen + age calculation)
- MessagesTab neighbor age calculation

Old data self-heals as new neighbor info arrives, but the display now handles both formats correctly in the meantime.

Closes #2458

## Test plan

- [x] TypeScript compiles clean
- [ ] Verify neighbor popups show correct dates for both old and new data

🤖 Generated with [Claude Code](https://claude.com/claude-code)