### PR TITLE
fix: add CSS type declarations for TypeScript 6 compatibility

### DIFF
--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -1,0 +1,5 @@
+// Type declarations for CSS imports (required by TypeScript 6+)
+declare module '*.css' {
+  const content: Record<string, string>;
+  export default content;
+}


### PR DESCRIPTION
## Summary

Fixes Docker build and Build Check CI failures after the TypeScript 6 upgrade (#2508).

**Root cause:** TypeScript 6 is stricter about side-effect CSS imports (`import './file.css'`), requiring type declarations. The server build (`tsconfig.server.json`) was failing with `error TS2882: Cannot find module or type declarations for side-effect import`.

**Fix:** Added `src/types/css.d.ts` with a `declare module '*.css'` declaration — standard practice for bundler-based TypeScript projects.

## Test plan

- [x] `tsc --project tsconfig.server.json --noEmit` passes
- [ ] CI Build Check passes
- [ ] Docker Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)