### PR TITLE
docs: add Tulsa/Broken Arrow Mesh to site gallery

### DIFF
--- a/docs/site-gallery.md
+++ b/docs/site-gallery.md
@@ -75,6 +75,14 @@ Running a public MeshMonitor instance? We'd love to feature it! **[File an issue
 
 ---
 
+### Tulsa/Broken Arrow Mesh
+- **URL**: [mesh.b33rman.com](https://mesh.b33rman.com/)
+- **Network**: [Tulsa Meshtastic](https://www.tulsa-meshtastic.com/) / [OKMesh](https://okmesh.org/)
+- **Location**: Tulsa/Broken Arrow, Oklahoma, US
+- **Description**: Monitoring the Tulsa and Broken Arrow area Meshtastic network.
+
+---
+
 ## About the Site Gallery
 
 The Site Gallery showcases MeshMonitor instances that are publicly accessible. These sites demonstrate:


### PR DESCRIPTION
Adds Tulsa/Broken Arrow Mesh (mesh.b33rman.com) to the site gallery. Closes #2522.