### PR TITLE
fix: zoom-based labels for MeshCore map markers

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -2091,7 +2091,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                         font-size: 10px;
                         font-weight: bold;
                       ">MC</div>
-                      <div style="
+                      ${showLabel ? `<div style="
                         position: absolute;
                         top: -20px;
                         left: 50%;
@@ -2102,7 +2102,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                         border-radius: 3px;
                         font-size: 11px;
                         white-space: nowrap;
-                      ">${node.name || 'MeshCore'}</div>
+                      ">${node.name || 'MeshCore'}</div>` : ''}
                     `,
                     iconSize: [24, 24],
                     iconAnchor: [12, 12],


### PR DESCRIPTION
## Summary

MeshCore node labels are now hidden when zoomed out, matching Meshtastic node behavior. Labels appear at zoom level 13+, while the "MC" circle marker is always visible.

Closes #2525

## Test plan

- [x] TypeScript compiles clean
- [ ] Zoom out — MeshCore labels should disappear, circles remain
- [ ] Zoom in past level 13 — labels reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)