### PR TITLE
feat: add Delete Channel button to channel configuration

### DIFF
--- a/src/components/configuration/ChannelsConfigSection.tsx
+++ b/src/components/configuration/ChannelsConfigSection.tsx
@@ -259,6 +259,34 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
     }
   };
 
+  const handleDeleteChannel = async (slotId: number) => {
+    // Channel 0 (Primary) cannot be deleted
+    if (slotId === 0) {
+      showToast(t('channels_config.toast_cannot_delete_primary', 'Cannot delete the primary channel'), 'error');
+      return;
+    }
+
+    if (!confirm(t('channels_config.confirm_delete', `Are you sure you want to delete channel ${slotId}? This will disable the channel on the device.`))) {
+      return;
+    }
+
+    try {
+      await apiService.updateChannel(slotId, {
+        name: '',
+        psk: '',
+        role: 0, // DISABLED
+        uplinkEnabled: false,
+        downlinkEnabled: false,
+      });
+      showToast(t('channels_config.toast_channel_deleted', { slot: slotId }), 'success');
+      onChannelsUpdated?.();
+    } catch (error) {
+      logger.error('Error deleting channel:', error);
+      const errorMsg = error instanceof Error ? error.message : t('channels_config.toast_delete_failed', 'Failed to delete channel');
+      showToast(errorMsg, 'error');
+    }
+  };
+
   const handleExportChannel = async (channelId: number) => {
     try {
       await apiService.exportChannel(channelId);
@@ -537,6 +565,22 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                   >
                     📤 {t('common.import')}
                   </button>
+                  {slotId > 0 && channel && channel.role !== 0 && (
+                    <button
+                      onClick={() => handleDeleteChannel(slotId)}
+                      style={{
+                        padding: '0.5rem 0.75rem',
+                        fontSize: '0.9rem',
+                        backgroundColor: 'var(--ctp-red)',
+                        color: 'var(--ctp-base)',
+                        border: 'none',
+                        borderRadius: '4px',
+                        cursor: 'pointer'
+                      }}
+                    >
+                      🗑️ {t('common.delete')}
+                    </button>
+                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Adds a Delete button for non-primary channels in the Configuration → Channels section. Deleting sets the channel role to DISABLED (0) with empty name/PSK — the standard Meshtastic way to remove a channel.

- Red delete button with trash icon, only shown for active non-primary channels (slot > 0)
- Confirmation dialog before deletion
- Primary channel (slot 0) cannot be deleted
- Uses existing `updateChannel` API — no backend changes

Closes #2530

## Test plan

- [x] TypeScript compiles clean
- [ ] Delete a secondary channel — should disable it on the device
- [ ] Verify primary channel has no delete button
- [ ] Verify disabled channels don't show delete button

🤖 Generated with [Claude Code](https://claude.com/claude-code)