### PR TITLE
fix: auto-connect MeshCore on startup and update docs (MM-31)

### DIFF
--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -37,8 +37,13 @@ MeshCore is disabled by default. To enable it, set the following environment var
 | `MESHCORE_BAUD_RATE` | No | `115200` | Baud rate for serial connection |
 | `MESHCORE_TCP_HOST` | Conditional | - | TCP host address. Required for TCP connections. |
 | `MESHCORE_TCP_PORT` | No | `4403` | TCP port for network connection |
+| `MESHCORE_FIRMWARE_TYPE` | No | `companion` | Set to `repeater` for Repeater devices. Companion and Room Server devices use the default. |
 
 You must provide **either** `MESHCORE_SERIAL_PORT` (for USB serial) **or** `MESHCORE_TCP_HOST` (for TCP network) when MeshCore is enabled.
+
+::: tip
+`ENABLE_VIRTUAL_NODE` is a separate feature for proxying the Meshtastic protocol to mobile apps — it has **no relation** to MeshCore connectivity. Do not set it expecting it to affect MeshCore behavior.
+:::
 
 ### Docker Compose Example
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -496,6 +496,22 @@ setTimeout(async () => {
     await meshtasticManager.connect();
     logger.debug('Meshtastic manager connected successfully');
 
+    // Auto-connect MeshCore if enabled via environment variables
+    if (process.env.MESHCORE_ENABLED === 'true') {
+      const meshcoreConfig = meshcoreManager.getEnvConfig();
+      if (meshcoreConfig) {
+        logger.info('[MeshCore] Auto-connecting on startup...');
+        const connected = await meshcoreManager.connect();
+        if (connected) {
+          logger.info('[MeshCore] Auto-connected successfully on startup');
+        } else {
+          logger.warn('[MeshCore] Auto-connect on startup failed — use the MeshCore tab to retry');
+        }
+      } else {
+        logger.warn('[MeshCore] MESHCORE_ENABLED=true but no serial port or TCP host configured');
+      }
+    }
+
     // Initialize backup scheduler
     backupSchedulerService.initialize(meshtasticManager);
     logger.debug('Backup scheduler initialized');
@@ -733,6 +749,7 @@ import newsRoutes from './routes/newsRoutes.js';
 import tileServerRoutes from './routes/tileServerTest.js';
 import v1Router from './routes/v1/index.js';
 import meshcoreRoutes from './routes/meshcoreRoutes.js';
+import meshcoreManager from './meshcoreManager.js';
 import embedProfileRoutes from './routes/embedProfileRoutes.js';
 import { createEmbedCspMiddleware } from './middleware/embedMiddleware.js';
 import embedPublicRoutes from './routes/embedPublicRoutes.js';


### PR DESCRIPTION
## Summary

Fixes [GitHub issue #2528](https://github.com/Yeraze/meshmonitor/issues/2528) — user configured `MESHCORE_SERIAL_PORT` but couldn't figure out how to make the MeshCore node appear in the UI.

**Root causes found and fixed:**

- **Code bug**: `MESHCORE_ENABLED=true` did not auto-connect on startup despite the docs claiming it would. Users had to manually click Connect in the MeshCore tab after each restart.
- **Missing docs**: `MESHCORE_FIRMWARE_TYPE` env var was absent from the environment variable table in `docs/features/meshcore.md`.
- **User confusion**: `ENABLE_VIRTUAL_NODE=true` is unrelated to MeshCore but users were setting it when trying to get MeshCore working — added a clarifying tip.

**Changes:**

- `src/server/server.ts`: Added MeshCore auto-connect in the startup sequence. If `MESHCORE_ENABLED=true` and serial/TCP env vars are set, calls `meshcoreManager.connect()` automatically after Meshtastic connects.
- `docs/features/meshcore.md`: Added `MESHCORE_FIRMWARE_TYPE` row to env var table; added tip block clarifying `ENABLE_VIRTUAL_NODE` is unrelated to MeshCore.

## Test plan

- [ ] Set `MESHCORE_ENABLED=true` and `MESHCORE_SERIAL_PORT=/dev/ttyACM0` — confirm MeshCore auto-connects at startup without manual UI action
- [ ] Check logs for `[MeshCore] Auto-connected successfully on startup`
- [ ] Set only `MESHCORE_ENABLED=true` with no port/host — confirm warning log appears and server still starts normally
- [ ] Verify `MESHCORE_FIRMWARE_TYPE` appears in docs env var table
- [ ] Verify tip about `ENABLE_VIRTUAL_NODE` appears in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)