### PR TITLE
fix: rotate TelemetryGauge arc 90° clockwise to horseshoe orientation (MM-67)

### DIFF
--- a/src/components/TelemetryGauge.tsx
+++ b/src/components/TelemetryGauge.tsx
@@ -13,7 +13,7 @@ interface TelemetryGaugeProps {
 }
 
 const SWEEP_DEG = 200;
-const START_DEG = 270 - SWEEP_DEG / 2; // 170 degrees from positive x-axis (clockwise from top)
+const START_DEG = 360 - SWEEP_DEG / 2; // 260 degrees — arc centered at top (12 o'clock), gap opens at bottom
 
 function polarToCartesian(cx: number, cy: number, r: number, angleDeg: number) {
   const rad = ((angleDeg - 90) * Math.PI) / 180;


### PR DESCRIPTION
## Summary

The telemetry gauge widget was rendering as a "C" shape opening to the right instead of the standard horseshoe/U shape with the gap at the bottom. This fix corrects the arc's start angle so the gauge is centered at the 12 o'clock position (top), giving it the expected orientation for analog-style gauges.

## Changes

- `src/components/TelemetryGauge.tsx`: Changed `START_DEG` from `270 - SWEEP_DEG / 2` (centers arc at 9 o'clock) to `360 - SWEEP_DEG / 2` (centers arc at 12 o'clock). Arc now spans from ~260° (lower-left, ~8:40) to ~100° (lower-right, ~3:20), sweeping through the top.

## Issues Resolved

Resolves MM-67 (child of MM-66)

## Documentation Updates

No documentation changes needed — this is a visual bug fix.

## Testing

- [x] Unit tests pass (418 tests, 38 test files)
- [x] TypeScript compiles cleanly
- [ ] Visual: Open a telemetry widget in gauge mode — arc should display as a horseshoe/U shape with the gap at the bottom, not a C-shape opening to the right

🤖 Generated with [Claude Code](https://claude.com/claude-code)