### PR TITLE
feat: generate default style.json from custom tileserver

### DIFF
--- a/src/components/MapStyleManager.tsx
+++ b/src/components/MapStyleManager.tsx
@@ -10,6 +10,9 @@ const MapStyleManager: React.FC = () => {
   const [fetchingUrl, setFetchingUrl] = useState(false);
   const [importUrl, setImportUrl] = useState('');
   const [importName, setImportName] = useState('');
+  const [tileJsonUrl, setTileJsonUrl] = useState('');
+  const [tileJsonName, setTileJsonName] = useState('');
+  const [generatingStyle, setGeneratingStyle] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const csrfFetch = useCsrfFetch();
 
@@ -80,6 +83,39 @@ const MapStyleManager: React.FC = () => {
       alert(`Import failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
     } finally {
       setFetchingUrl(false);
+    }
+  };
+
+  const handleGenerateFromTileserver = async () => {
+    if (!tileJsonUrl.trim()) return;
+    setGeneratingStyle(true);
+    try {
+      const baseUrl = await api.getBaseUrl();
+      const response = await csrfFetch(`${baseUrl}/api/map-styles/generate-from-tileserver`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tileJsonUrl: tileJsonUrl.trim(), name: tileJsonName.trim() || undefined }),
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({ error: 'Generation failed' }));
+        throw new Error(err.error ?? 'Generation failed');
+      }
+      const { style, filename } = await response.json() as { style: object; filename: string };
+      // Trigger browser download
+      const blob = new Blob([JSON.stringify(style, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(url);
+      setTileJsonUrl('');
+      setTileJsonName('');
+    } catch (err) {
+      console.error('Failed to generate map style from tileserver:', err);
+      alert(`Generation failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    } finally {
+      setGeneratingStyle(false);
     }
   };
 
@@ -169,6 +205,38 @@ const MapStyleManager: React.FC = () => {
             >
               {fetchingUrl ? 'Fetching...' : 'Fetch'}
             </button>
+          </div>
+
+          {/* Generate from tileserver */}
+          <div style={{ marginTop: '4px', borderTop: '1px solid var(--border-color, #eee)', paddingTop: '8px' }}>
+            <div style={{ fontSize: '0.85em', color: 'var(--text-muted, #888)', marginBottom: '4px' }}>
+              Generate a default style from your tileserver's TileJSON endpoint (e.g.{' '}
+              <code style={{ fontSize: '0.9em' }}>http://tileserver:8080/data/v3.json</code>).
+              Edit the downloaded file and upload it above.
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
+              <input
+                type="text"
+                placeholder="TileJSON URL (e.g. http://tileserver:8080/data/v3.json)"
+                value={tileJsonUrl}
+                onChange={(e) => setTileJsonUrl(e.target.value)}
+                style={{ flex: 2, minWidth: '200px', padding: '4px 8px', border: '1px solid var(--border-color, #ccc)', borderRadius: '3px', background: 'var(--input-bg, #fff)', color: 'var(--text-color, #000)' }}
+              />
+              <input
+                type="text"
+                placeholder="Name (optional)"
+                value={tileJsonName}
+                onChange={(e) => setTileJsonName(e.target.value)}
+                style={{ flex: 1, minWidth: '100px', padding: '4px 8px', border: '1px solid var(--border-color, #ccc)', borderRadius: '3px', background: 'var(--input-bg, #fff)', color: 'var(--text-color, #000)' }}
+              />
+              <button
+                className="button"
+                onClick={handleGenerateFromTileserver}
+                disabled={generatingStyle || !tileJsonUrl.trim()}
+              >
+                {generatingStyle ? 'Generating...' : 'Download Default Style'}
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/server/routes/mapStyleRoutes.test.ts
+++ b/src/server/routes/mapStyleRoutes.test.ts
@@ -4,7 +4,7 @@
  * Uses a real MapStyleService with a temp directory (no mocking of the service).
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from 'vitest';
 import express from 'express';
 import session from 'express-session';
 import request from 'supertest';
@@ -221,6 +221,193 @@ describe('MapStyle Routes', () => {
     it('returns 404 for nonexistent style', async () => {
       const res = await request(app).get('/styles/nonexistent-id/data');
       expect(res.status).toBe(404);
+    });
+  });
+
+  // ---- POST /generate-from-tileserver ---------------------------------------
+
+  describe('POST /generate-from-tileserver', () => {
+    let fetchSpy: MockInstance;
+
+    const VALID_TILEJSON = {
+      tilejson: '2.2.0',
+      name: 'My Custom Tiles',
+      attribution: '&copy; OSM Contributors',
+      minzoom: 0,
+      maxzoom: 14,
+      tiles: ['http://tileserver:8080/data/v3/{z}/{x}/{y}.pbf'],
+      vector_layers: [
+        { id: 'water', geometry_type: 'polygon' },
+        { id: 'building', geometry_type: 'polygon' },
+        { id: 'transportation', geometry_type: 'line' },
+        { id: 'place', geometry_type: 'point' },
+        { id: 'landuse' }, // no geometry_type — unknown
+      ],
+    };
+
+    beforeEach(() => {
+      fetchSpy = vi.spyOn(global, 'fetch');
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it('returns 400 when tileJsonUrl is missing', async () => {
+      const res = await request(app)
+        .post('/generate-from-tileserver')
+        .set('Content-Type', 'application/json')
+        .send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/tileJsonUrl/i);
+    });
+
+    it('returns 400 for an invalid URL', async () => {
+      const res = await request(app)
+        .post('/generate-from-tileserver')
+        .set('Content-Type', 'application/json')
+        .send({ tileJsonUrl: 'not-a-url' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/invalid/i);
+    });
+
+    it('returns 400 for non-http protocol', async () => {
+      const res = await request(app)
+        .post('/generate-from-tileserver')
+        .set('Content-Type', 'application/json')
+        .send({ tileJsonUrl: 'ftp://tileserver/data.json' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/http/i);
+    });
+
+    it('returns 400 when remote fetch fails with non-200 status', async () => {
+      fetchSpy.mockResolvedValueOnce(new Response('Not Found', { status: 404 }));
+      const res = await request(app)
+        .post('/generate-from-tileserver')
+        .set('Content-Type', 'application/json')
+        .send({ tileJsonUrl: 'http://tileserver:8080/data/v3.json' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/HTTP 404/);
+    });
+
+    it('returns 400 when remote fetch throws a network error', async () => {
+      fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      const res = await request(app)
+        .post('/generate-from-tileserver')
+        .set('Content-Type', 'application/json')
+        .send({ tileJsonUrl: 'http://tileserver:8080/data/v3.json' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/ECONNREFUSED/);
+    });
+
+    it('returns 400 when TileJSON has no tiles array', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify({ vector_layers: [{ id: 'water' }] }), { status: 200 })
+      );
+      const res = await request(app)
+        .post('/generate-from-tileserver')
+        .set('Content-Type', 'application/json')
+        .send({ tileJsonUrl: 'http://tileserver:8080/data/v3.json' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/tiles/i);
+    });
+
+    it('returns 400 when TileJSON has no vector_layers', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ tiles: ['http://tileserver/tiles/{z}/{x}/{y}.png'] }),
+          { status: 200 }
+        )
+      );
+      const res = await request(app)
+        .post('/generate-from-tileserver')
+        .set('Content-Type', 'application/json')
+        .send({ tileJsonUrl: 'http://tileserver:8080/data/v3.json' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/vector_layers/i);
+    });
+
+    it('returns 200 with a valid MapLibre GL v8 style for a well-formed TileJSON', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(VALID_TILEJSON), { status: 200 })
+      );
+      const res = await request(app)
+        .post('/generate-from-tileserver')
+        .set('Content-Type', 'application/json')
+        .send({ tileJsonUrl: 'http://tileserver:8080/data/v3.json' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.filename).toMatch(/\.json$/);
+      const style = res.body.style;
+      expect(style.version).toBe(8);
+      expect(typeof style.sources).toBe('object');
+      expect(Array.isArray(style.layers)).toBe(true);
+      expect(style.layers.length).toBeGreaterThan(0);
+    });
+
+    it('uses provided name in the generated style and filename', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(VALID_TILEJSON), { status: 200 })
+      );
+      const res = await request(app)
+        .post('/generate-from-tileserver')
+        .set('Content-Type', 'application/json')
+        .send({ tileJsonUrl: 'http://tileserver:8080/data/v3.json', name: 'My Map Style' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.style.name).toBe('My Map Style');
+      expect(res.body.filename).toContain('my_map_style');
+    });
+
+    it('generates layers for each vector layer in TileJSON', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(VALID_TILEJSON), { status: 200 })
+      );
+      const res = await request(app)
+        .post('/generate-from-tileserver')
+        .set('Content-Type', 'application/json')
+        .send({ tileJsonUrl: 'http://tileserver:8080/data/v3.json' });
+
+      expect(res.status).toBe(200);
+      const layers: { 'source-layer': string }[] = res.body.style.layers;
+      const sourceLayers = new Set(layers.map(l => l['source-layer']));
+      // All 5 vector layers should have at least one MapLibre layer
+      for (const vl of VALID_TILEJSON.vector_layers) {
+        expect(sourceLayers).toContain(vl.id);
+      }
+    });
+
+    it('uses correct layer types per geometry hint', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(VALID_TILEJSON), { status: 200 })
+      );
+      const res = await request(app)
+        .post('/generate-from-tileserver')
+        .set('Content-Type', 'application/json')
+        .send({ tileJsonUrl: 'http://tileserver:8080/data/v3.json' });
+
+      expect(res.status).toBe(200);
+      const layers: { id: string; type: string; 'source-layer': string }[] = res.body.style.layers;
+
+      // point → circle
+      const placeLayers = layers.filter(l => l['source-layer'] === 'place');
+      expect(placeLayers).toHaveLength(1);
+      expect(placeLayers[0].type).toBe('circle');
+
+      // line → line
+      const transportLayers = layers.filter(l => l['source-layer'] === 'transportation');
+      expect(transportLayers).toHaveLength(1);
+      expect(transportLayers[0].type).toBe('line');
+
+      // polygon → fill + line
+      const waterLayers = layers.filter(l => l['source-layer'] === 'water');
+      expect(waterLayers).toHaveLength(2);
+      expect(waterLayers.map(l => l.type).sort()).toEqual(['fill', 'line']);
+
+      // unknown → fill + line
+      const landuseLayers = layers.filter(l => l['source-layer'] === 'landuse');
+      expect(landuseLayers).toHaveLength(2);
+      expect(landuseLayers.map(l => l.type).sort()).toEqual(['fill', 'line']);
     });
   });
 });

--- a/src/server/routes/mapStyleRoutes.ts
+++ b/src/server/routes/mapStyleRoutes.ts
@@ -9,6 +9,7 @@ import express from 'express';
 import { MapStyleService } from '../services/mapStyleService.js';
 import { logger } from '../../utils/logger.js';
 import { requirePermission } from '../auth/authMiddleware.js';
+import { generateStyleFromTileJson, type TileJsonResponse } from '../utils/tileStyleGenerator.js';
 
 export function createMapStyleRouter(service: MapStyleService): Router {
   const router = Router();
@@ -183,6 +184,84 @@ export function createMapStyleRouter(service: MapStyleService): Router {
       return res.status(500).json({ error: message });
     }
   });
+
+  /**
+   * POST /api/map-styles/generate-from-tileserver
+   * Fetch a TileJSON endpoint and generate a default MapLibre GL style.json.
+   * Returns the generated style as JSON for the client to download.
+   */
+  router.post(
+    '/generate-from-tileserver',
+    requirePermission('settings', 'write'),
+    express.json(),
+    async (req: Request, res: Response) => {
+      try {
+        const { tileJsonUrl, name: requestedName } = req.body as {
+          tileJsonUrl?: string;
+          name?: string;
+        };
+
+        if (!tileJsonUrl || typeof tileJsonUrl !== 'string') {
+          return res.status(400).json({ error: 'Missing tileJsonUrl in request body' });
+        }
+
+        // Validate protocol
+        let parsedUrl: URL;
+        try {
+          parsedUrl = new URL(tileJsonUrl);
+        } catch {
+          return res.status(400).json({ error: 'Invalid tileJsonUrl: not a valid URL' });
+        }
+        if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+          return res.status(400).json({ error: 'Invalid tileJsonUrl: only http and https are supported' });
+        }
+
+        // Fetch TileJSON server-side (avoids CORS)
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 15000);
+
+        let tileJson: TileJsonResponse;
+        try {
+          const response = await fetch(tileJsonUrl, {
+            signal: controller.signal,
+            headers: { 'User-Agent': 'MeshMonitor/1.0' },
+          });
+          clearTimeout(timeoutId);
+          if (!response.ok) {
+            return res.status(400).json({ error: `Failed to fetch TileJSON: HTTP ${response.status}` });
+          }
+          tileJson = (await response.json()) as TileJsonResponse;
+        } catch (fetchError) {
+          clearTimeout(timeoutId);
+          const msg = fetchError instanceof Error ? fetchError.message : String(fetchError);
+          return res.status(400).json({ error: `Failed to fetch TileJSON: ${msg}` });
+        }
+
+        // Validate TileJSON structure
+        if (!Array.isArray(tileJson.tiles) || tileJson.tiles.length === 0) {
+          return res.status(400).json({
+            error: 'TileJSON is missing a tiles array. Ensure the URL points to a vector TileJSON endpoint.',
+          });
+        }
+        if (!Array.isArray(tileJson.vector_layers) || tileJson.vector_layers.length === 0) {
+          return res.status(400).json({
+            error:
+              'TileJSON has no vector_layers. This may be a raster tileset; only vector tilesets are supported for style generation.',
+          });
+        }
+
+        const name = requestedName?.trim() || tileJson.name || 'Generated Style';
+        const style = generateStyleFromTileJson(tileJson, { name });
+
+        logger.info(`[MapStyleRoutes] Generated style from TileJSON at: ${tileJsonUrl}`);
+        return res.json({ style, filename: `${name.replace(/[^a-z0-9_-]/gi, '_').toLowerCase()}-style.json` });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error('[MapStyleRoutes] Error generating style from tileserver:', error);
+        return res.status(500).json({ error: message });
+      }
+    }
+  );
 
   return router;
 }

--- a/src/server/utils/tileStyleGenerator.ts
+++ b/src/server/utils/tileStyleGenerator.ts
@@ -1,0 +1,182 @@
+/**
+ * Tile Style Generator
+ *
+ * Generates a default MapLibre GL v8 style.json from a TileJSON response.
+ * This is a pure utility module — no disk I/O, no HTTP calls.
+ */
+
+// ---------------------------------------------------------------------------
+// TileJSON types (subset of TileJSON 2.x spec)
+// ---------------------------------------------------------------------------
+
+export interface VectorLayer {
+  id: string;
+  description?: string;
+  minzoom?: number;
+  maxzoom?: number;
+  geometry_type?: 'polygon' | 'line' | 'point' | 'unknown' | string;
+  fields?: Record<string, string>;
+}
+
+export interface TileJsonResponse {
+  tilejson?: string;
+  name?: string;
+  description?: string;
+  attribution?: string;
+  minzoom?: number;
+  maxzoom?: number;
+  bounds?: [number, number, number, number];
+  center?: [number, number, number];
+  tiles: string[];
+  vector_layers?: VectorLayer[];
+}
+
+// ---------------------------------------------------------------------------
+// Default color palette per geometry type
+// ---------------------------------------------------------------------------
+
+const LAYER_COLORS: Record<string, { fill: string; line: string; circle: string }> = {
+  water:            { fill: '#a0c8f0', line: '#7aabdc', circle: '#a0c8f0' },
+  waterway:         { fill: '#a0c8f0', line: '#7aabdc', circle: '#7aabdc' },
+  landuse:          { fill: '#d4e8c0', line: '#b0cc98', circle: '#d4e8c0' },
+  landcover:        { fill: '#c8e0b0', line: '#a8c890', circle: '#c8e0b0' },
+  park:             { fill: '#b8d8a0', line: '#90b878', circle: '#b8d8a0' },
+  building:         { fill: '#d8d0c8', line: '#b8a898', circle: '#d8d0c8' },
+  transportation:   { fill: '#f0e8d0', line: '#e0c880', circle: '#e0c880' },
+  transportation_name: { fill: '#f0e8d0', line: '#e0c880', circle: '#e0c880' },
+  boundary:         { fill: '#e0d0f0', line: '#c0a8dc', circle: '#c0a8dc' },
+  place:            { fill: '#f8f0e0', line: '#d8c8a8', circle: '#f8c060' },
+  poi:              { fill: '#f0d0e8', line: '#d0a8c8', circle: '#e080c0' },
+  aeroway:          { fill: '#e8e8f0', line: '#c0c0d8', circle: '#c0c0d8' },
+  water_name:       { fill: '#a0c8f0', line: '#7aabdc', circle: '#7aabdc' },
+};
+
+const DEFAULT_COLOR = { fill: '#d8d8d8', line: '#b0b0b0', circle: '#888888' };
+
+function colorForLayer(layerId: string): { fill: string; line: string; circle: string } {
+  // Exact match first, then prefix match
+  if (LAYER_COLORS[layerId]) return LAYER_COLORS[layerId];
+  for (const key of Object.keys(LAYER_COLORS)) {
+    if (layerId.startsWith(key) || key.startsWith(layerId)) return LAYER_COLORS[key];
+  }
+  return DEFAULT_COLOR;
+}
+
+// ---------------------------------------------------------------------------
+// Layer builder helpers
+// ---------------------------------------------------------------------------
+
+function makeFillLayer(sourceId: string, layerId: string, color: string, opacity = 0.5) {
+  return {
+    id: `${layerId}-fill`,
+    type: 'fill',
+    source: sourceId,
+    'source-layer': layerId,
+    paint: {
+      'fill-color': color,
+      'fill-opacity': opacity,
+    },
+  };
+}
+
+function makeLineLayer(sourceId: string, layerId: string, color: string, width = 1) {
+  return {
+    id: `${layerId}-line`,
+    type: 'line',
+    source: sourceId,
+    'source-layer': layerId,
+    paint: {
+      'line-color': color,
+      'line-width': width,
+    },
+  };
+}
+
+function makeCircleLayer(sourceId: string, layerId: string, color: string, radius = 4) {
+  return {
+    id: `${layerId}-circle`,
+    type: 'circle',
+    source: sourceId,
+    'source-layer': layerId,
+    paint: {
+      'circle-color': color,
+      'circle-radius': radius,
+    },
+  };
+}
+
+/**
+ * Build MapLibre GL layers for a single vector tile source-layer.
+ * Selects layer types based on the `geometry_type` hint in TileJSON when available.
+ * Falls back to emitting fill + line layers for unknown geometry types.
+ */
+function buildLayersForVectorLayer(sourceId: string, vl: VectorLayer): object[] {
+  const colors = colorForLayer(vl.id);
+  const geom = (vl.geometry_type ?? 'unknown').toLowerCase();
+
+  if (geom === 'point') {
+    return [makeCircleLayer(sourceId, vl.id, colors.circle)];
+  }
+  if (geom === 'line') {
+    return [makeLineLayer(sourceId, vl.id, colors.line)];
+  }
+  if (geom === 'polygon') {
+    return [makeFillLayer(sourceId, vl.id, colors.fill), makeLineLayer(sourceId, vl.id, colors.line, 0.5)];
+  }
+
+  // Unknown geometry — emit fill + line as a safe default
+  return [makeFillLayer(sourceId, vl.id, colors.fill), makeLineLayer(sourceId, vl.id, colors.line, 0.5)];
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface GenerateStyleOptions {
+  /** Human-readable name stored in the style's `name` property */
+  name?: string;
+  /** Source ID to use in the style's sources and layers (default: "custom") */
+  sourceId?: string;
+}
+
+/**
+ * Generate a default MapLibre GL v8 style.json from a parsed TileJSON object.
+ *
+ * @param tileJson   Parsed TileJSON from the tileserver
+ * @param tileJsonUrl  Original URL used to fetch the TileJSON (not stored, used for tile URL resolution)
+ * @param options    Optional overrides
+ * @returns          A valid MapLibre GL style object
+ * @throws           If the TileJSON is missing required fields (`tiles`, `vector_layers`)
+ */
+export function generateStyleFromTileJson(
+  tileJson: TileJsonResponse,
+  options: GenerateStyleOptions = {}
+): object {
+  const sourceId = options.sourceId ?? 'custom';
+  const styleName = options.name ?? tileJson.name ?? 'Generated Style';
+
+  const vectorLayers = tileJson.vector_layers ?? [];
+
+  // Build all MapLibre layers
+  const layers: object[] = [];
+  for (const vl of vectorLayers) {
+    layers.push(...buildLayersForVectorLayer(sourceId, vl));
+  }
+
+  const style: Record<string, unknown> = {
+    version: 8,
+    name: styleName,
+    sources: {
+      [sourceId]: {
+        type: 'vector',
+        tiles: tileJson.tiles,
+        ...(tileJson.minzoom !== undefined ? { minzoom: tileJson.minzoom } : {}),
+        ...(tileJson.maxzoom !== undefined ? { maxzoom: tileJson.maxzoom } : {}),
+        ...(tileJson.attribution ? { attribution: tileJson.attribution } : {}),
+      },
+    },
+    layers,
+  };
+
+  return style;
+}


### PR DESCRIPTION
## Summary

Closes #2548 / resolves MM-69.

Users with custom MBTiles sources (Planetiler, etc.) need a `style.json` that references the specific `source-layer` names in their tileset. Previously there was no way to get a starter style for a custom tileserver — this PR adds a "Download Default Style" feature.

- **New utility** `src/server/utils/tileStyleGenerator.ts`: pure function that builds a valid MapLibre GL v8 `style.json` from a parsed TileJSON response. Assigns default colors and picks the correct layer type (fill/line/circle) based on the `geometry_type` hint in each `vector_layers` entry.
- **New backend route** `POST /api/map-styles/generate-from-tileserver`: fetches the TileJSON server-side (bypassing CORS), validates that `tiles` and `vector_layers` are present, and returns `{ style, filename }` for the client to download. Protected by `requirePermission('settings', 'write')`.
- **Updated `MapStyleManager.tsx`**: adds a "Generate from Tileserver" section below the existing URL import row. User enters their TileJSON URL (e.g. `http://tileserver:8080/data/v3.json`), clicks "Download Default Style", edits the downloaded file, and re-uploads via the existing upload flow.

## Test plan

- [ ] 11 new tests in `mapStyleRoutes.test.ts` — all passing (419 total tests pass)
- [ ] Valid TileJSON → downloaded style has `version: 8`, correct sources, one+ layer per vector_layer
- [ ] Missing `tileJsonUrl` → 400
- [ ] Non-http protocol → 400
- [ ] Non-200 from tileserver → 400 with HTTP status in message
- [ ] TileJSON missing `tiles` or `vector_layers` → 400 with descriptive error
- [ ] `geometry_type: "point"` → circle layer; `"line"` → line layer; `"polygon"` → fill + line; unknown → fill + line

🤖 Generated with [Claude Code](https://claude.com/claude-code)