### PR TITLE
fix: invalidate map size when packet monitor is resized

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1949,7 +1949,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 lon={defaultMapCenterLon}
                 zoom={defaultMapCenterZoom}
               />
-              <MapResizeHandler trigger={`${showPacketMonitor}-${isNodeListCollapsed}`} />
+              <MapResizeHandler trigger={`${showPacketMonitor}-${isNodeListCollapsed}-${packetMonitorHeight}`} />
               <SpiderfierController ref={spiderfierRef} zoomLevel={mapZoom} />
               <MapLegend
                 positionHistory={positionHistoryLegendData}


### PR DESCRIPTION
## Summary
When users drag the packet monitor panel to resize it, the Leaflet map's container height changes dynamically via CSS, but Leaflet was never notified of the size change. This caused gray areas to appear where tiles weren't loaded for the newly exposed map region. The fix adds `packetMonitorHeight` to the `MapResizeHandler` trigger so `invalidateSize()` is called (debounced 300ms) after every resize drag completes.

## Changes
- `src/components/NodesTab.tsx`: Add `packetMonitorHeight` to the `MapResizeHandler` trigger string so the map recalculates its size after the packet monitor panel is resized

## Issues Resolved
Fixes #2418

## Documentation Updates
No documentation changes needed — this is an internal rendering fix with no user-facing behavior change beyond eliminating the gray areas.

## Testing
- [x] Unit tests pass (pre-existing failures in a separate worktree, unrelated to this change)
- [x] TypeScript compiles cleanly
- [ ] Open map tab → enable Packet Monitor → drag it up → open node list → hide node list → drag packet monitor to a different height — verify no gray areas remain on the map
- [ ] Confirm map redraws correctly after dragging packet monitor on mobile (landscape → portrait orientation change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)