### PR TITLE
fix: persist telemetry widget display options to backend (MM-80)

### DIFF
--- a/docs/superpowers/specs/2026-04-01-telemetry-widget-backend-persistence-design.md
+++ b/docs/superpowers/specs/2026-04-01-telemetry-widget-backend-persistence-design.md
@@ -1,0 +1,69 @@
+# Telemetry Widget Display Options Backend Persistence
+
+**Issue:** MM-80  
+**Date:** 2026-04-01  
+**Status:** Approved
+
+## Problem
+
+`useWidgetMode` and `useWidgetRange` store telemetry widget display preferences (chart/gauge/numeric mode and gauge min/max limits) in `localStorage` only. As a result:
+
+1. Settings are per-browser — anonymous users always see the default chart view regardless of admin configuration.
+2. Any user can change their local view (no permission enforcement).
+3. The gauge SVG is unconstrained in width, making it visually too large.
+
+## Solution
+
+### 1. Backend Settings Keys
+
+Add to `src/server/constants/settings.ts` `VALID_SETTINGS_KEYS`:
+
+- `telemetryWidgetModes` — JSON-serialized `Record<string, WidgetMode>` keyed by `${nodeId}_${type}`
+- `telemetryWidgetRanges` — JSON-serialized `Record<string, {min: number, max: number}>` keyed by `${nodeId}_${type}`
+
+### 2. Backend-Synced Hooks
+
+Rewrite `useWidgetMode.ts` using TanStack Query (same pattern as `useFavorites`):
+
+- `useWidgetMode(nodeId, type)` returns `[mode, setMode]`
+- On mount: fetches `/api/settings`, reads `telemetryWidgetModes`, falls back to `'chart'`
+- `setMode(m)`: updates optimistic cache and POSTs to `/api/settings` via CSRF fetch
+- QueryKey: `['widgetModes']` (shared across all widgets, avoids per-widget fetches)
+
+Rewrite `useWidgetRange.ts` the same way:
+
+- QueryKey: `['widgetRanges']`
+- Falls back to `DEFAULT_GAUGE_RANGES[type]` then `{min:0, max:100}`
+
+### 3. Permission Enforcement
+
+`TelemetryGraphWidget` calls `useAuth()`:
+
+- Mode toggle buttons (`~`, `⊙`, `#`) are only rendered if `hasPermission('settings', 'write')` is true
+- Gauge range inputs are passed through a `canEditRange` prop to `TelemetryGauge`
+- `TelemetryGauge` only renders the `gauge-range-row` when `canEditRange` is true
+
+Anonymous users and read-only users see the persisted display mode (set by an admin) but cannot change it.
+
+### 4. Gauge Size Fix
+
+Add `max-width: 200px` to `.telemetry-gauge` in `TelemetryGraphs.css`. The SVG uses `width="100%"` which causes it to expand beyond its natural size in wide containers.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/server/constants/settings.ts` | Add `telemetryWidgetModes`, `telemetryWidgetRanges` |
+| `src/hooks/useWidgetMode.ts` | Rewrite with TanStack Query backend sync |
+| `src/hooks/useWidgetRange.ts` | Rewrite with TanStack Query backend sync |
+| `src/hooks/useWidgetMode.test.ts` | Update tests for new async implementation |
+| `src/hooks/useWidgetRange.test.ts` | Update tests for new async implementation |
+| `src/components/TelemetryGraphs.tsx` | Add `useAuth()`, hide mode toggles for non-writers, pass `canEditRange` |
+| `src/components/TelemetryGauge.tsx` | Accept `canEditRange` prop, hide range row |
+| `src/components/TelemetryGraphs.css` | Add `max-width: 200px` to `.telemetry-gauge` |
+
+## Non-Goals
+
+- No migration needed: new settings keys default to empty (widgets fall back to `'chart'` mode)
+- No database schema change: settings are stored as JSON in the existing settings table
+- localStorage is removed from both hooks (backend is the source of truth)

--- a/src/components/TelemetryGauge.tsx
+++ b/src/components/TelemetryGauge.tsx
@@ -10,6 +10,7 @@ interface TelemetryGaugeProps {
   timestamp: number;
   nodeId: string;
   onRangeChange: (range: WidgetRange) => void;
+  canEditRange?: boolean;
 }
 
 const SWEEP_DEG = 200;
@@ -38,6 +39,7 @@ const TelemetryGauge: React.FC<TelemetryGaugeProps> = ({
   color,
   timestamp,
   onRangeChange,
+  canEditRange = false,
 }) => {
   const cx = 100;
   const cy = 90;
@@ -108,23 +110,25 @@ const TelemetryGauge: React.FC<TelemetryGaugeProps> = ({
           {timeStr}
         </text>
       </svg>
-      <div className="gauge-range-row">
-        <input
-          type="number"
-          className="gauge-range-input"
-          value={min}
-          onChange={handleMinChange}
-          aria-label="Gauge minimum"
-        />
-        <span className="gauge-range-dash">───</span>
-        <input
-          type="number"
-          className="gauge-range-input"
-          value={max}
-          onChange={handleMaxChange}
-          aria-label="Gauge maximum"
-        />
-      </div>
+      {canEditRange && (
+        <div className="gauge-range-row">
+          <input
+            type="number"
+            className="gauge-range-input"
+            value={min}
+            onChange={handleMinChange}
+            aria-label="Gauge minimum"
+          />
+          <span className="gauge-range-dash">───</span>
+          <input
+            type="number"
+            className="gauge-range-input"
+            value={max}
+            onChange={handleMaxChange}
+            aria-label="Gauge maximum"
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/TelemetryGraphs.css
+++ b/src/components/TelemetryGraphs.css
@@ -158,6 +158,8 @@
   flex-direction: column;
   align-items: center;
   padding: 8px 0;
+  max-width: 200px;
+  margin: 0 auto;
 }
 
 .gauge-range-row {

--- a/src/components/TelemetryGraphs.test.tsx
+++ b/src/components/TelemetryGraphs.test.tsx
@@ -44,6 +44,15 @@ const renderWithProviders = (component: React.ReactElement) => {
   return render(component, { wrapper: TestWrapper });
 };
 
+// Mock AuthContext so tests don't require AuthProvider
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    hasPermission: () => true,
+    isAdmin: true,
+    authenticated: true,
+  }),
+}));
+
 // Mock Recharts components to avoid rendering issues in tests
 vi.mock('recharts', () => ({
   ComposedChart: ({ children }: { children?: React.ReactNode }) => <div data-testid="line-chart">{children}</div>,

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -10,6 +10,7 @@ import { useTelemetry, useSolarEstimates, type TelemetryData } from '../hooks/us
 import { useFavorites, useToggleFavorite } from '../hooks/useFavorites';
 import { formatChartAxisTimestamp, formatTime } from '../utils/datetime';
 import { useSettings, type TimeFormat } from '../contexts/SettingsContext';
+import { useAuth } from '../contexts/AuthContext';
 import { ChartData } from '../types/ui';
 import { useWidgetMode } from '../hooks/useWidgetMode';
 import { useWidgetRange } from '../hooks/useWidgetRange';
@@ -112,6 +113,7 @@ interface TelemetryGraphWidgetProps {
   prepareChartData: (data: TelemetryData[], isTemperature?: boolean, globalMinTime?: number) => ChartData[];
   timeFormat: TimeFormat;
   t: (key: string, opts?: Record<string, unknown>) => string;
+  canEditSettings: boolean;
 }
 
 const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
@@ -139,6 +141,7 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
   prepareChartData,
   timeFormat,
   t,
+  canEditSettings,
 }) => {
   const [mode, setMode] = useWidgetMode(nodeId, type);
   const [range, setRange] = useWidgetRange(nodeId, type);
@@ -182,32 +185,34 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
           {label} {unit && `(${unit})`}
         </h4>
         <div className="graph-actions">
-          <div className="mode-toggle-group" role="group" aria-label="Display mode">
-            <button
-              className={`mode-toggle-btn ${mode === 'chart' ? 'active' : ''}`}
-              onClick={() => setMode('chart')}
-              title="Chart"
-              aria-label="Chart mode"
-            >
-              ~
-            </button>
-            <button
-              className={`mode-toggle-btn ${mode === 'gauge' ? 'active' : ''}`}
-              onClick={() => setMode('gauge')}
-              title="Gauge"
-              aria-label="Gauge mode"
-            >
-              ⊙
-            </button>
-            <button
-              className={`mode-toggle-btn ${mode === 'numeric' ? 'active' : ''}`}
-              onClick={() => setMode('numeric')}
-              title="Numeric"
-              aria-label="Numeric mode"
-            >
-              #
-            </button>
-          </div>
+          {canEditSettings && (
+            <div className="mode-toggle-group" role="group" aria-label="Display mode">
+              <button
+                className={`mode-toggle-btn ${mode === 'chart' ? 'active' : ''}`}
+                onClick={() => setMode('chart')}
+                title="Chart"
+                aria-label="Chart mode"
+              >
+                ~
+              </button>
+              <button
+                className={`mode-toggle-btn ${mode === 'gauge' ? 'active' : ''}`}
+                onClick={() => setMode('gauge')}
+                title="Gauge"
+                aria-label="Gauge mode"
+              >
+                ⊙
+              </button>
+              <button
+                className={`mode-toggle-btn ${mode === 'numeric' ? 'active' : ''}`}
+                onClick={() => setMode('numeric')}
+                title="Numeric"
+                aria-label="Numeric mode"
+              >
+                #
+              </button>
+            </div>
+          )}
           {solarMonitoringEnabled && (
             <button
               className={`solar-toggle-btn ${getSolarVisibility(type) ? 'active' : ''}`}
@@ -260,6 +265,7 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
           timestamp={latest.timestamp}
           nodeId={nodeId}
           onRangeChange={setRange}
+          canEditRange={canEditSettings}
         />
       ) : mode === 'numeric' && latest ? (
         <TelemetryNumericLabel
@@ -376,6 +382,8 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
     const csrfFetch = useCsrfFetch();
     const { showToast } = useToast();
     const { solarMonitoringEnabled, timeFormat } = useSettings();
+    const { hasPermission } = useAuth();
+    const canEditSettings = hasPermission('settings', 'write');
     const [openMenu, setOpenMenu] = useState<string | null>(null);
     const [menuPosition, setMenuPosition] = useState<{
       x: number;
@@ -939,6 +947,7 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
               prepareChartData={prepareChartData}
               timeFormat={timeFormat}
               t={t as (key: string, opts?: Record<string, unknown>) => string}
+              canEditSettings={canEditSettings}
             />
           ))}
         </div>

--- a/src/hooks/useWidgetMode.test.ts
+++ b/src/hooks/useWidgetMode.test.ts
@@ -1,42 +1,102 @@
 /**
  * @vitest-environment jsdom
  */
-import { renderHook, act } from '@testing-library/react';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
 import { useWidgetMode } from './useWidgetMode';
+
+const mockCsrfFetch = vi.fn();
+
+vi.mock('./useCsrfFetch', () => ({
+  useCsrfFetch: () => mockCsrfFetch,
+}));
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  };
+}
 
 describe('useWidgetMode', () => {
   beforeEach(() => {
-    localStorage.clear();
+    vi.clearAllMocks();
+    // Default: empty modes from backend
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    }));
+    mockCsrfFetch.mockResolvedValue({ ok: true });
   });
 
-  it('returns chart as default mode', () => {
-    const { result } = renderHook(() => useWidgetMode('node1', 'temperature'));
-    expect(result.current[0]).toBe('chart');
+  it('returns chart as default mode when backend has no data', async () => {
+    const { result } = renderHook(() => useWidgetMode('node1', 'temperature'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current[0]).toBe('chart'));
   });
 
-  it('persists mode to localStorage', () => {
-    const { result } = renderHook(() => useWidgetMode('node1', 'temperature'));
+  it('returns mode from backend settings', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        telemetryWidgetModes: JSON.stringify({ 'node1_temperature': 'gauge' }),
+      }),
+    }));
+    const { result } = renderHook(() => useWidgetMode('node1', 'temperature'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current[0]).toBe('gauge'));
+  });
+
+  it('calls backend when mode is changed', async () => {
+    const { result } = renderHook(() => useWidgetMode('node1', 'temperature'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current[0]).toBe('chart'));
+
+    act(() => {
+      result.current[1]('numeric');
+    });
+
+    await waitFor(() => expect(mockCsrfFetch).toHaveBeenCalledWith(
+      '/api/settings',
+      expect.objectContaining({ method: 'POST' }),
+    ));
+  });
+
+  it('optimistically updates mode before backend response', async () => {
+    mockCsrfFetch.mockImplementation(() => new Promise(resolve => setTimeout(() => resolve({ ok: true }), 100)));
+    const { result } = renderHook(() => useWidgetMode('node1', 'temperature'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current[0]).toBe('chart'));
+
     act(() => {
       result.current[1]('gauge');
     });
-    expect(result.current[0]).toBe('gauge');
-    expect(localStorage.getItem('telemetry_widget_mode_node1_temperature')).toBe('gauge');
+
+    await waitFor(() => expect(result.current[0]).toBe('gauge'));
   });
 
-  it('reads persisted mode from localStorage on init', () => {
-    localStorage.setItem('telemetry_widget_mode_node1_batteryLevel', 'numeric');
-    const { result } = renderHook(() => useWidgetMode('node1', 'batteryLevel'));
-    expect(result.current[0]).toBe('numeric');
-  });
+  it('uses separate keys per nodeId and type', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        telemetryWidgetModes: JSON.stringify({ 'node1_temperature': 'gauge' }),
+      }),
+    }));
+    const wrapper = createWrapper();
+    const { result: r1 } = renderHook(() => useWidgetMode('node1', 'temperature'), { wrapper });
+    const { result: r2 } = renderHook(() => useWidgetMode('node2', 'temperature'), { wrapper });
 
-  it('uses separate keys per nodeId and type', () => {
-    const { result: r1 } = renderHook(() => useWidgetMode('node1', 'temperature'));
-    const { result: r2 } = renderHook(() => useWidgetMode('node2', 'temperature'));
-    act(() => {
-      r1.current[1]('gauge');
+    await waitFor(() => {
+      expect(r1.current[0]).toBe('gauge');
+      expect(r2.current[0]).toBe('chart');
     });
-    expect(r1.current[0]).toBe('gauge');
-    expect(r2.current[0]).toBe('chart');
   });
 });

--- a/src/hooks/useWidgetMode.ts
+++ b/src/hooks/useWidgetMode.ts
@@ -1,15 +1,64 @@
-import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCsrfFetch } from './useCsrfFetch';
 
 export type WidgetMode = 'chart' | 'gauge' | 'numeric';
 
+type WidgetModeMap = Record<string, WidgetMode>;
+
+function fetchWidgetModes(): Promise<WidgetModeMap> {
+  return fetch('/api/settings')
+    .then(res => (res.ok ? res.json() : {}))
+    .then((settings: Record<string, unknown>) => {
+      if (!settings.telemetryWidgetModes) return {};
+      try {
+        return JSON.parse(settings.telemetryWidgetModes as string) as WidgetModeMap;
+      } catch {
+        return {};
+      }
+    })
+    .catch(() => ({}));
+}
+
 export function useWidgetMode(nodeId: string, type: string): [WidgetMode, (m: WidgetMode) => void] {
-  const key = `telemetry_widget_mode_${nodeId}_${type}`;
-  const [mode, setModeState] = useState<WidgetMode>(
-    () => (localStorage.getItem(key) as WidgetMode | null) ?? 'chart'
-  );
+  const key = `${nodeId}_${type}`;
+  const queryClient = useQueryClient();
+  const csrfFetch = useCsrfFetch();
+
+  const { data: modes } = useQuery<WidgetModeMap>({
+    queryKey: ['widgetModes'],
+    queryFn: fetchWidgetModes,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (newModes: WidgetModeMap) => {
+      const res = await csrfFetch('/api/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ telemetryWidgetModes: JSON.stringify(newModes) }),
+      });
+      if (!res.ok) throw new Error(`Failed to save widget mode: ${res.status}`);
+    },
+    onMutate: async (newModes: WidgetModeMap) => {
+      await queryClient.cancelQueries({ queryKey: ['widgetModes'] });
+      const previous = queryClient.getQueryData<WidgetModeMap>(['widgetModes']);
+      queryClient.setQueryData<WidgetModeMap>(['widgetModes'], newModes);
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData<WidgetModeMap>(['widgetModes'], context.previous);
+      }
+    },
+  });
+
+  const mode: WidgetMode = modes?.[key] ?? 'chart';
+
   const setMode = (m: WidgetMode) => {
-    localStorage.setItem(key, m);
-    setModeState(m);
+    const current = queryClient.getQueryData<WidgetModeMap>(['widgetModes']) ?? {};
+    mutation.mutate({ ...current, [key]: m });
   };
+
   return [mode, setMode];
 }

--- a/src/hooks/useWidgetRange.test.ts
+++ b/src/hooks/useWidgetRange.test.ts
@@ -1,43 +1,98 @@
 /**
  * @vitest-environment jsdom
  */
-import { renderHook, act } from '@testing-library/react';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
 import { useWidgetRange, DEFAULT_GAUGE_RANGES } from './useWidgetRange';
+
+const mockCsrfFetch = vi.fn();
+
+vi.mock('./useCsrfFetch', () => ({
+  useCsrfFetch: () => mockCsrfFetch,
+}));
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  };
+}
 
 describe('useWidgetRange', () => {
   beforeEach(() => {
-    localStorage.clear();
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    }));
+    mockCsrfFetch.mockResolvedValue({ ok: true });
   });
 
-  it('returns default range for known type (batteryLevel)', () => {
-    const { result } = renderHook(() => useWidgetRange('node1', 'batteryLevel'));
-    expect(result.current[0]).toEqual({ min: 0, max: 100 });
+  it('returns default range for known type (batteryLevel)', async () => {
+    const { result } = renderHook(() => useWidgetRange('node1', 'batteryLevel'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current[0]).toEqual({ min: 0, max: 100 }));
   });
 
-  it('returns default range for known type (temperature)', () => {
-    const { result } = renderHook(() => useWidgetRange('node1', 'temperature'));
-    expect(result.current[0]).toEqual(DEFAULT_GAUGE_RANGES.temperature);
+  it('returns default range for known type (temperature)', async () => {
+    const { result } = renderHook(() => useWidgetRange('node1', 'temperature'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current[0]).toEqual(DEFAULT_GAUGE_RANGES.temperature));
   });
 
-  it('returns fallback [0,100] for unknown type', () => {
-    const { result } = renderHook(() => useWidgetRange('node1', 'unknownMetric'));
-    expect(result.current[0]).toEqual({ min: 0, max: 100 });
+  it('returns fallback [0,100] for unknown type', async () => {
+    const { result } = renderHook(() => useWidgetRange('node1', 'unknownMetric'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current[0]).toEqual({ min: 0, max: 100 }));
   });
 
-  it('persists range to localStorage', () => {
-    const { result } = renderHook(() => useWidgetRange('node1', 'temperature'));
+  it('returns range from backend settings', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        telemetryWidgetRanges: JSON.stringify({ 'node1_temperature': { min: -40, max: 85 } }),
+      }),
+    }));
+    const { result } = renderHook(() => useWidgetRange('node1', 'temperature'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current[0]).toEqual({ min: -40, max: 85 }));
+  });
+
+  it('calls backend when range is changed', async () => {
+    const { result } = renderHook(() => useWidgetRange('node1', 'temperature'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current[0]).toEqual(DEFAULT_GAUGE_RANGES.temperature));
+
     act(() => {
       result.current[1]({ min: -40, max: 85 });
     });
-    expect(result.current[0]).toEqual({ min: -40, max: 85 });
-    const stored = JSON.parse(localStorage.getItem('telemetry_widget_range_node1_temperature')!);
-    expect(stored).toEqual({ min: -40, max: 85 });
+
+    await waitFor(() => expect(mockCsrfFetch).toHaveBeenCalledWith(
+      '/api/settings',
+      expect.objectContaining({ method: 'POST' }),
+    ));
   });
 
-  it('reads persisted range from localStorage on init', () => {
-    localStorage.setItem('telemetry_widget_range_node1_humidity', JSON.stringify({ min: 10, max: 90 }));
-    const { result } = renderHook(() => useWidgetRange('node1', 'humidity'));
-    expect(result.current[0]).toEqual({ min: 10, max: 90 });
+  it('optimistically updates range before backend response', async () => {
+    mockCsrfFetch.mockImplementation(() => new Promise(resolve => setTimeout(() => resolve({ ok: true }), 100)));
+    const { result } = renderHook(() => useWidgetRange('node1', 'temperature'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current[0]).toEqual(DEFAULT_GAUGE_RANGES.temperature));
+
+    act(() => {
+      result.current[1]({ min: -40, max: 85 });
+    });
+
+    await waitFor(() => expect(result.current[0]).toEqual({ min: -40, max: 85 }));
   });
 });

--- a/src/hooks/useWidgetRange.ts
+++ b/src/hooks/useWidgetRange.ts
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCsrfFetch } from './useCsrfFetch';
 
 export interface WidgetRange {
   min: number;
@@ -15,23 +16,61 @@ export const DEFAULT_GAUGE_RANGES: Record<string, WidgetRange> = {
 
 const DEFAULT_RANGE: WidgetRange = { min: 0, max: 100 };
 
-export function useWidgetRange(nodeId: string, type: string): [WidgetRange, (r: WidgetRange) => void] {
-  const key = `telemetry_widget_range_${nodeId}_${type}`;
-  const [range, setRangeState] = useState<WidgetRange>(() => {
-    const stored = localStorage.getItem(key);
-    if (stored) {
+type WidgetRangeMap = Record<string, WidgetRange>;
+
+function fetchWidgetRanges(): Promise<WidgetRangeMap> {
+  return fetch('/api/settings')
+    .then(res => (res.ok ? res.json() : {}))
+    .then((settings: Record<string, unknown>) => {
+      if (!settings.telemetryWidgetRanges) return {};
       try {
-        return JSON.parse(stored) as WidgetRange;
+        return JSON.parse(settings.telemetryWidgetRanges as string) as WidgetRangeMap;
       } catch {
-        // fall through to default
+        return {};
       }
-    }
-    return DEFAULT_GAUGE_RANGES[type] ?? DEFAULT_RANGE;
+    })
+    .catch(() => ({}));
+}
+
+export function useWidgetRange(nodeId: string, type: string): [WidgetRange, (r: WidgetRange) => void] {
+  const key = `${nodeId}_${type}`;
+  const queryClient = useQueryClient();
+  const csrfFetch = useCsrfFetch();
+
+  const { data: ranges } = useQuery<WidgetRangeMap>({
+    queryKey: ['widgetRanges'],
+    queryFn: fetchWidgetRanges,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
   });
 
+  const mutation = useMutation({
+    mutationFn: async (newRanges: WidgetRangeMap) => {
+      const res = await csrfFetch('/api/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ telemetryWidgetRanges: JSON.stringify(newRanges) }),
+      });
+      if (!res.ok) throw new Error(`Failed to save widget range: ${res.status}`);
+    },
+    onMutate: async (newRanges: WidgetRangeMap) => {
+      await queryClient.cancelQueries({ queryKey: ['widgetRanges'] });
+      const previous = queryClient.getQueryData<WidgetRangeMap>(['widgetRanges']);
+      queryClient.setQueryData<WidgetRangeMap>(['widgetRanges'], newRanges);
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData<WidgetRangeMap>(['widgetRanges'], context.previous);
+      }
+    },
+  });
+
+  const range: WidgetRange = ranges?.[key] ?? DEFAULT_GAUGE_RANGES[type] ?? DEFAULT_RANGE;
+
   const setRange = (r: WidgetRange) => {
-    localStorage.setItem(key, JSON.stringify(r));
-    setRangeState(r);
+    const current = queryClient.getQueryData<WidgetRangeMap>(['widgetRanges']) ?? {};
+    mutation.mutate({ ...current, [key]: r });
   };
 
   return [range, setRange];

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -130,6 +130,8 @@ export const VALID_SETTINGS_KEYS = [
   'securityDigestSuppressEmpty',
   'securityDigestFormat',
   'activeMapStyleId',
+  'telemetryWidgetModes',
+  'telemetryWidgetRanges',
 ] as const;
 
 export type ValidSettingKey = typeof VALID_SETTINGS_KEYS[number];


### PR DESCRIPTION
## Summary

Telemetry widget display preferences (chart/gauge/numeric mode and gauge min/max limits) were stored in `localStorage` only, meaning anonymous users always saw the default chart view regardless of admin configuration, and any user could locally change modes without permission. This PR moves widget mode and range persistence to the backend settings API and enforces `settings` write permission for changing them.

## Changes

- Add `telemetryWidgetModes` and `telemetryWidgetRanges` to `VALID_SETTINGS_KEYS` in `settings.ts`
- Rewrite `useWidgetMode` and `useWidgetRange` hooks to sync with `/api/settings` via TanStack Query (optimistic updates, same pattern as `useFavorites`)
- Hide mode toggle buttons (`~`/`⊙`/`#`) from users without `settings` write permission
- Hide gauge range inputs from users without `settings` write permission (`canEditRange` prop on `TelemetryGauge`)
- Constrain gauge SVG to `max-width: 200px` to prevent oversized display in wide containers
- Update tests for the new async backend-synced implementation

## Issues Resolved

Fixes #80

## Documentation Updates

No documentation changes needed — this is a bug fix for internal settings persistence.

## Testing

- [x] Unit tests pass (32 tests in changed files, all passing)
- [x] TypeScript compiles cleanly
- [ ] Verify admin can change widget mode (gauge/numeric/chart) and it persists for anonymous users
- [ ] Verify anonymous users cannot see mode toggle buttons
- [ ] Verify gauge size is no longer oversized in wide containers
- [ ] Verify gauge min/max range inputs are hidden for non-admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)