### PR TITLE
fix: preserve AQ== PSK shorthand verbatim in channel database on save

### DIFF
--- a/src/server/routes/channelDatabaseRoutes.ts
+++ b/src/server/routes/channelDatabaseRoutes.ts
@@ -205,23 +205,13 @@ router.post('/', async (req: Request, res: Response) => {
       });
     }
 
-    // Validate PSK is valid Base64 and expand shorthand keys
-    let finalPsk = psk;
+    // Validate PSK is valid Base64 and store verbatim (including shorthand AQ==)
     let finalPskLength: number;
     try {
       const pskBuffer = Buffer.from(psk, 'base64');
 
-      // Expand shorthand PSK (1-byte keys like AQ==) to full 16-byte key
-      const expandedPsk = expandShorthandPsk(pskBuffer);
-      if (!expandedPsk) {
-        return res.status(400).json({
-          success: false,
-          error: 'Bad Request',
-          message: 'PSK value 0 means no encryption, which is not supported for channel database'
-        });
-      }
-
-      if (expandedPsk.length !== 16 && expandedPsk.length !== 32) {
+      // Validate raw PSK length: 1 byte (shorthand), 16 bytes (AES-128), or 32 bytes (AES-256)
+      if (pskBuffer.length !== 1 && pskBuffer.length !== 16 && pskBuffer.length !== 32) {
         return res.status(400).json({
           success: false,
           error: 'Bad Request',
@@ -229,12 +219,17 @@ router.post('/', async (req: Request, res: Response) => {
         });
       }
 
-      // Use expanded key if it was a shorthand
-      if (expandedPsk.length !== pskBuffer.length) {
-        finalPsk = expandedPsk.toString('base64');
-        logger.debug(`Expanded shorthand PSK (${pskBuffer.length} byte) to ${expandedPsk.length}-byte key`);
+      // Detect no-encryption case (PSK byte value 0x00)
+      if (!expandShorthandPsk(pskBuffer)) {
+        return res.status(400).json({
+          success: false,
+          error: 'Bad Request',
+          message: 'PSK value 0 means no encryption, which is not supported for channel database'
+        });
       }
-      finalPskLength = expandedPsk.length;
+
+      // Store the PSK verbatim — the decryption service expands shorthand keys at read time
+      finalPskLength = pskBuffer.length;
 
       // Validate pskLength if explicitly provided
       if (pskLength !== undefined && pskLength !== finalPskLength) {
@@ -254,7 +249,7 @@ router.post('/', async (req: Request, res: Response) => {
 
     const newChannelId = await databaseService.channelDatabase.createAsync({
       name,
-      psk: finalPsk,
+      psk,
       pskLength: finalPskLength,
       description: description ?? null,
       isEnabled: isEnabled ?? true,
@@ -432,23 +427,23 @@ router.put('/:id', async (req: Request, res: Response) => {
 
       try {
         const pskBuffer = Buffer.from(psk, 'base64');
-        const expandedPsk = expandShorthandPsk(pskBuffer);
-        if (!expandedPsk) {
-          return res.status(400).json({
-            success: false,
-            error: 'Bad Request',
-            message: 'PSK value 0 means no encryption, which is not supported for channel database'
-          });
-        }
-        if (expandedPsk.length !== 16 && expandedPsk.length !== 32) {
+        if (pskBuffer.length !== 1 && pskBuffer.length !== 16 && pskBuffer.length !== 32) {
           return res.status(400).json({
             success: false,
             error: 'Bad Request',
             message: 'PSK must be 1 byte (shorthand), 16 bytes (AES-128), or 32 bytes (AES-256) when decoded'
           });
         }
-        updates.psk = expandedPsk.length !== pskBuffer.length ? expandedPsk.toString('base64') : psk;
-        updates.pskLength = expandedPsk.length;
+        if (!expandShorthandPsk(pskBuffer)) {
+          return res.status(400).json({
+            success: false,
+            error: 'Bad Request',
+            message: 'PSK value 0 means no encryption, which is not supported for channel database'
+          });
+        }
+        // Store the PSK verbatim — the decryption service expands shorthand keys at read time
+        updates.psk = psk;
+        updates.pskLength = pskBuffer.length;
       } catch (_err) {
         return res.status(400).json({
           success: false,

--- a/src/server/routes/v1/channelDatabase.test.ts
+++ b/src/server/routes/v1/channelDatabase.test.ts
@@ -195,14 +195,24 @@ describe('POST /api/v1/channel-database', () => {
     expect(res.status).toBe(400);
   });
 
-  it('returns 400 when PSK length is wrong (not 16 or 32)', async () => {
-    // 8-byte PSK — not 16 or 32 bytes
+  it('returns 400 when PSK length is wrong (not 1, 16, or 32)', async () => {
+    // 8-byte PSK — not 1, 16, or 32 bytes
     const shortPsk = Buffer.alloc(8, 0x01).toString('base64');
     const res = await request(createApp(adminUser))
       .post('/api/v1/channel-database')
       .send({ name: 'New', psk: shortPsk });
     expect(res.status).toBe(400);
     expect(res.body.message).toMatch(/16 bytes|32 bytes/);
+  });
+
+  it('creates channel with shorthand PSK AQ== and stores it verbatim', async () => {
+    const res = await request(createApp(adminUser))
+      .post('/api/v1/channel-database')
+      .send({ name: 'Default Key Channel', psk: 'AQ==' });
+    expect(res.status).toBe(201);
+    expect(mockDb.channelDatabase.createAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ psk: 'AQ==', pskLength: 1 }),
+    );
   });
 
   it('creates channel and returns 201 for admin with valid PSK', async () => {

--- a/src/server/routes/v1/channelDatabase.ts
+++ b/src/server/routes/v1/channelDatabase.ts
@@ -203,23 +203,13 @@ router.post('/', async (req: Request, res: Response) => {
       });
     }
 
-    // Validate PSK is valid Base64 and expand shorthand keys
-    let finalPsk = psk;
+    // Validate PSK is valid Base64 and store verbatim (including shorthand AQ==)
     let finalPskLength: number;
     try {
       const pskBuffer = Buffer.from(psk, 'base64');
 
-      // Expand shorthand PSK (1-byte keys like AQ==) to full 16-byte key
-      const expandedPsk = expandShorthandPsk(pskBuffer);
-      if (!expandedPsk) {
-        return res.status(400).json({
-          success: false,
-          error: 'Bad Request',
-          message: 'PSK value 0 means no encryption, which is not supported for channel database'
-        });
-      }
-
-      if (expandedPsk.length !== 16 && expandedPsk.length !== 32) {
+      // Validate raw PSK length: 1 byte (shorthand), 16 bytes (AES-128), or 32 bytes (AES-256)
+      if (pskBuffer.length !== 1 && pskBuffer.length !== 16 && pskBuffer.length !== 32) {
         return res.status(400).json({
           success: false,
           error: 'Bad Request',
@@ -227,12 +217,17 @@ router.post('/', async (req: Request, res: Response) => {
         });
       }
 
-      // Use expanded key if it was a shorthand
-      if (expandedPsk.length !== pskBuffer.length) {
-        finalPsk = expandedPsk.toString('base64');
-        logger.debug(`Expanded shorthand PSK (${pskBuffer.length} byte) to ${expandedPsk.length}-byte key`);
+      // Detect no-encryption case (PSK byte value 0x00)
+      if (!expandShorthandPsk(pskBuffer)) {
+        return res.status(400).json({
+          success: false,
+          error: 'Bad Request',
+          message: 'PSK value 0 means no encryption, which is not supported for channel database'
+        });
       }
-      finalPskLength = expandedPsk.length;
+
+      // Store the PSK verbatim — the decryption service expands shorthand keys at read time
+      finalPskLength = pskBuffer.length;
 
       // Validate pskLength if explicitly provided
       if (pskLength !== undefined && pskLength !== finalPskLength) {
@@ -252,7 +247,7 @@ router.post('/', async (req: Request, res: Response) => {
 
     const newChannelId = await databaseService.channelDatabase.createAsync({
       name,
-      psk: finalPsk,
+      psk,
       pskLength: finalPskLength,
       description: description ?? null,
       isEnabled: isEnabled ?? true,
@@ -431,23 +426,23 @@ router.put('/:id', async (req: Request, res: Response) => {
 
       try {
         const pskBuffer = Buffer.from(psk, 'base64');
-        const expandedPsk = expandShorthandPsk(pskBuffer);
-        if (!expandedPsk) {
-          return res.status(400).json({
-            success: false,
-            error: 'Bad Request',
-            message: 'PSK value 0 means no encryption, which is not supported for channel database'
-          });
-        }
-        if (expandedPsk.length !== 16 && expandedPsk.length !== 32) {
+        if (pskBuffer.length !== 1 && pskBuffer.length !== 16 && pskBuffer.length !== 32) {
           return res.status(400).json({
             success: false,
             error: 'Bad Request',
             message: 'PSK must be 1 byte (shorthand), 16 bytes (AES-128), or 32 bytes (AES-256) when decoded'
           });
         }
-        updates.psk = expandedPsk.length !== pskBuffer.length ? expandedPsk.toString('base64') : psk;
-        updates.pskLength = expandedPsk.length;
+        if (!expandShorthandPsk(pskBuffer)) {
+          return res.status(400).json({
+            success: false,
+            error: 'Bad Request',
+            message: 'PSK value 0 means no encryption, which is not supported for channel database'
+          });
+        }
+        // Store the PSK verbatim — the decryption service expands shorthand keys at read time
+        updates.psk = psk;
+        updates.pskLength = pskBuffer.length;
       } catch (_err) {
         return res.status(400).json({
           success: false,


### PR DESCRIPTION
## Summary

- Channel Database was expanding shorthand PSK `AQ==` (1-byte sentinel meaning "use built-in default key") to the full 16-byte expanded key `1PG7OiApB1nwvP+rz05pAQ==` before storing
- The decryption service (`channelDecryptionService.ts`) already calls `expandShorthandPsk()` at read time, so expansion at the write path was redundant and destructive
- Fixed both `channelDatabaseRoutes.ts` and `v1/channelDatabase.ts` (both CREATE and UPDATE paths) to validate PSK length against the raw decoded bytes (accepting 1, 16, or 32), then store the PSK verbatim without expansion
- Added test case asserting `AQ==` is stored with `pskLength: 1` without modification

Fixes #2558

## Test plan
- [x] Run `npx vitest run src/server/routes/v1/channelDatabase.test.ts` — all 95 tests pass
- [x] Run full test suite — all 959 tests pass
- [x] New test: `creates channel with shorthand PSK AQ== and stores it verbatim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)