### PR TITLE
fix: add Auto Heap Management to automation SectionNav (MM-100)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4865,6 +4865,7 @@ function App() {
                 { id: 'auto-favorite', label: t('automation.auto_favorite.title', 'Auto Favorite') },
                 { id: 'auto-traceroute', label: t('automation.traceroute.title', 'Auto Traceroute') },
                 { id: 'auto-ping', label: t('automation.auto_ping.title', 'Auto Ping') },
+                { id: 'auto-heap-management', label: t('automation.auto_heap.title', 'Auto Heap Management') },
                 { id: 'remote-admin-scanner', label: t('automation.remote_admin_scanner.title', 'Remote Admin Scanner') },
                 { id: 'auto-time-sync', label: t('automation.time_sync.title', 'Auto Time Sync') },
                 { id: 'auto-acknowledge', label: t('automation.acknowledge.title', 'Auto Acknowledge') },


### PR DESCRIPTION
## Summary

- The `AutoHeapManagementSection` was added to the Automation tab content (PR #2555) with `id="auto-heap-management"`, but the corresponding `SectionNav` items entry was omitted
- This meant the section was visible by scrolling but had no navbar shortcut at the top of the Automation page
- Adds `{ id: 'auto-heap-management', label: t('automation.auto_heap.title', 'Auto Heap Management') }` to the SectionNav items list, positioned between Auto Ping and Remote Admin Scanner to match the section's DOM order

## Test plan

- [ ] Navigate to Automation tab — "Auto Heap Management" now appears in the section navbar
- [ ] Clicking "Auto Heap Management" in the navbar scrolls to the section
- [ ] All 4305 unit tests pass (confirmed locally)

Fixes [MM-100](/MM/issues/MM-100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)