### PR TITLE
fix: telemetry gauge/numeric mode display bugs (MM-99)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -876,7 +876,9 @@ function App() {
         } catch (error) {
           logger.error('Failed to load config:', error);
           setNodeAddress('192.168.1.100');
-          setBaseUrl('');
+          // Keep initialBaseUrl detected from pathname — resetting to '' would break
+          // API calls when BASE_URL is configured on the server.
+          configBaseUrl = initialBaseUrl;
         }
 
         // Load settings from server

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -458,24 +458,32 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
           </div>
         </div>
 
-        {mode === 'gauge' && latest ? (
-          <TelemetryGauge
-            value={latest.value}
-            min={range.min}
-            max={range.max}
-            unit={unit}
-            color={color}
-            timestamp={latest.timestamp}
-            nodeId={favorite.nodeId}
-            onRangeChange={setRange}
-          />
-        ) : mode === 'numeric' && latest ? (
-          <TelemetryNumericLabel
-            value={latest.value}
-            unit={unit}
-            color={color}
-            timestamp={latest.timestamp}
-          />
+        {mode === 'gauge' ? (
+          latest ? (
+            <TelemetryGauge
+              value={latest.value}
+              min={range.min}
+              max={range.max}
+              unit={unit}
+              color={color}
+              timestamp={latest.timestamp}
+              nodeId={favorite.nodeId}
+              onRangeChange={setRange}
+            />
+          ) : (
+            <div className="dashboard-no-data">{t('dashboard.no_chart_data')}</div>
+          )
+        ) : mode === 'numeric' ? (
+          latest ? (
+            <TelemetryNumericLabel
+              value={latest.value}
+              unit={unit}
+              color={color}
+              timestamp={latest.timestamp}
+            />
+          ) : (
+            <div className="dashboard-no-data">{t('dashboard.no_chart_data')}</div>
+          )
         ) : (
           <ResponsiveContainer width="100%" height={200}>
             <ComposedChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -255,25 +255,33 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
         </div>
       </div>
 
-      {mode === 'gauge' && latest ? (
-        <TelemetryGauge
-          value={latest.value}
-          min={range.min}
-          max={range.max}
-          unit={unit}
-          color={color}
-          timestamp={latest.timestamp}
-          nodeId={nodeId}
-          onRangeChange={setRange}
-          canEditRange={canEditSettings}
-        />
-      ) : mode === 'numeric' && latest ? (
-        <TelemetryNumericLabel
-          value={latest.value}
-          unit={unit}
-          color={color}
-          timestamp={latest.timestamp}
-        />
+      {mode === 'gauge' ? (
+        latest ? (
+          <TelemetryGauge
+            value={latest.value}
+            min={range.min}
+            max={range.max}
+            unit={unit}
+            color={color}
+            timestamp={latest.timestamp}
+            nodeId={nodeId}
+            onRangeChange={setRange}
+            canEditRange={canEditSettings}
+          />
+        ) : (
+          <div className="telemetry-no-data">{t('telemetry.no_data')}</div>
+        )
+      ) : mode === 'numeric' ? (
+        latest ? (
+          <TelemetryNumericLabel
+            value={latest.value}
+            unit={unit}
+            color={color}
+            timestamp={latest.timestamp}
+          />
+        ) : (
+          <div className="telemetry-no-data">{t('telemetry.no_data')}</div>
+        )
       ) : (
         <ResponsiveContainer width="100%" height={200}>
           <ComposedChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>


### PR DESCRIPTION
## Summary

- **Root Cause 1 — Silent mode fallback**: The conditional rendering `mode === 'gauge' && latest` silently fell back to showing the chart whenever `latest` was null (e.g. when a widget had no data). Gauge and numeric modes now show a clear "no data" message instead, so the mode change is always visually reflected.

- **Root Cause 2 — POST /api/settings 404**: In `App.tsx`, the `initializeApp()` startup function had a catch block that called `setBaseUrl('')` on any config fetch failure. This reset the React `baseUrl` state from the correct pathname-detected value (e.g. `/meshmonitor`) to empty string, causing all subsequent settings saves from child components (`useToggleFavorite`, `handleToggleSolar`) to POST to `/api/settings` instead of `/meshmonitor/api/settings`, returning 404 when `BASE_URL` is configured on the server. The fix keeps `initialBaseUrl` on failure.

## Changes

- `src/App.tsx`: Preserve `initialBaseUrl` instead of `''` when config fetch fails
- `src/components/TelemetryGraphs.tsx`: Separate mode check from null-latest check in `TelemetryGraphWidget`
- `src/components/TelemetryChart.tsx`: Same fix for dashboard favorite chart widgets

## Test plan

- [ ] Click ⊙ gauge button on a telemetry widget with data — gauge renders correctly
- [ ] Click # numeric button — numeric value renders correctly
- [ ] Click ~ chart button — chart renders correctly
- [ ] Mode persists across page navigation (localStorage-backed)
- [ ] No 404 in console when toggling favorites or solar visibility
- [ ] If server temporarily returns error on `/api/config`, the app still uses the correct base URL for subsequent API calls
- [ ] All existing tests pass (4 pre-existing failures in `meshtasticProtobufService.test.ts` are unrelated)

Fixes: MM-99

🤖 Generated with [Claude Code](https://claude.com/claude-code)