### PR TITLE
fix: WebSocket connection and CSP for BASE_URL deployments

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -181,13 +181,15 @@ export function useWebSocket(enabled: boolean = true): WebSocketState {
       return;
     }
 
-    // Build the socket path respecting BASE_URL
+    // Build the socket URL and path respecting BASE_URL
+    // Explicit URL is required — Socket.io's auto-detection fails when a <base> tag is present
     const socketPath = `${appBasename}/socket.io`;
+    const socketUrl = `${window.location.protocol}//${window.location.host}`;
 
-    const socket = io({
+    const socket = io(socketUrl, {
       path: socketPath,
       withCredentials: true,
-      transports: ['websocket', 'polling'],
+      transports: ['polling', 'websocket'],
       reconnection: true,
       reconnectionAttempts: 10,
       reconnectionDelay: 1000,

--- a/src/server/middleware/dynamicCsp.ts
+++ b/src/server/middleware/dynamicCsp.ts
@@ -90,6 +90,9 @@ export async function getCachedTileHostnames(): Promise<string[]> {
 export async function buildConnectSrcDirective(isProduction: boolean, cookieSecure: boolean): Promise<string[]> {
   const connectSrc: string[] = [
     "'self'",
+    // WebSocket protocols for Socket.io real-time updates
+    'ws:',
+    'wss:',
     // Built-in tile servers
     'https://*.tile.openstreetmap.org',
     'https://*.basemaps.cartocdn.com',

--- a/src/server/middleware/embedMiddleware.ts
+++ b/src/server/middleware/embedMiddleware.ts
@@ -46,7 +46,7 @@ export function createEmbedCspMiddleware() {
         "script-src 'self' 'unsafe-inline'",
         "style-src 'self' 'unsafe-inline'",
         "img-src 'self' data: https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com https://server.arcgisonline.com",
-        "connect-src 'self' https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com https://server.arcgisonline.com",
+        "connect-src 'self' ws: wss: https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com https://server.arcgisonline.com",
         "worker-src 'self' blob:",
         `frame-ancestors ${frameAncestors}`,
       ];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
         singleFork: true,
       },
     },
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.paperclip/**',
+    ],
     env: {
       DATABASE_PATH: ':memory:',
     },


### PR DESCRIPTION
## Summary
- **WebSocket fix**: Socket.io `io()` called without a URL silently fails when a `<base>` tag is present in the HTML. Fixed by explicitly constructing the URL from `window.location` and using polling-first transport order (`['polling', 'websocket']`) to ensure initial connection succeeds before upgrading.
- **CSP fix**: Added `ws:` and `wss:` protocols to `connect-src` directive in both dynamic CSP and embed CSP middleware.
- **Test config**: Excluded `.paperclip/` worktree directories from vitest test discovery to prevent duplicate test runs.

## Test plan
- [x] All 184 test files pass (4305 tests passed)
- [x] Verified WebSocket connects successfully with BASE_URL=/meshmonitor
- [x] Verified polling indicator switches to lightning bolt (WebSocket) after fix
- [x] CSP header confirmed to include `ws: wss:` in connect-src

🤖 Generated with [Claude Code](https://claude.com/claude-code)