### PR TITLE
feat: system tests CI on self-hosted runner

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -19,6 +19,10 @@ concurrency:
   group: system-tests
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   system-tests:
     name: System Tests (Hardware)


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs `tests/system-tests.sh` on the `meshmonitor-hw` self-hosted runner (physical Meshtastic node)
- **Path-filtered**: only triggers on server, DB, Docker, or test script changes
- **Label override**: add `system-test` label to any PR to trigger manually
- **Concurrency: 1** — hardware node is a shared resource, only one run at a time
- Posts test results as a collapsible PR comment and uploads `test-results.md` as an artifact
- Not a required check — won't block merges if the runner is offline or flaky

## Test plan
- [x] This PR itself should trigger the workflow (changes `.github/workflows/system-tests.yml`)
- [x] Verify runner picks up the job and runs system tests
- [ ] Verify results are posted as a PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)