### PR TITLE
feat: add v1 API node action endpoints

### DIFF
--- a/src/server/routes/v1/actions.test.ts
+++ b/src/server/routes/v1/actions.test.ts
@@ -1,0 +1,532 @@
+/**
+ * v1 API — actions endpoint tests
+ *
+ * Covers POST /api/v1/sources/:sourceId/actions/{traceroute,request-position,
+ * request-nodeinfo,request-neighbors} including:
+ *   - 200 happy paths
+ *   - 400 missing/invalid destination
+ *   - 401 unauthenticated
+ *   - 403 insufficient permissions (per-source)
+ *   - 429 rate-limited (request-neighbors)
+ *   - 403 not-local/0-hop (request-neighbors)
+ *   - per-source scoping of permission checks and manager lookup
+ *   - canonical message ID format for system messages
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+import { neighborInfoRateLimitMap } from './actions.js';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Shared test constants
+// ──────────────────────────────────────────────────────────────────────────────
+
+const SOURCE_A = 'source-a-uuid';
+const SOURCE_B = 'source-b-uuid';
+
+const LOCAL_NODE_NUM = 0xdeadbeef;
+const LOCAL_NODE_ID = '!deadbeef';
+const DEST_NUM = 0xa1b2c3d4;
+
+const adminUser  = { id: 1, username: 'admin',  isActive: true, isAdmin: true  };
+const normalUser = { id: 2, username: 'normal', isActive: true, isAdmin: false };
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Mock: databaseService
+// ──────────────────────────────────────────────────────────────────────────────
+
+vi.mock('../../../services/database.js', () => ({
+  default: {
+    checkPermissionAsync: vi.fn(),
+    nodes: {
+      getNode: vi.fn(),
+    },
+    messages: {
+      insertMessage: vi.fn(),
+    },
+  },
+}));
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Mock: resolveSourceManager — returns a per-call mock manager
+// ──────────────────────────────────────────────────────────────────────────────
+
+const mockManager = {
+  sendTraceroute:        vi.fn(),
+  sendPositionRequest:   vi.fn(),
+  sendNodeInfoRequest:   vi.fn(),
+  sendNeighborInfoRequest: vi.fn(),
+  getLocalNodeInfo:      vi.fn(),
+};
+
+vi.mock('../../utils/resolveSourceManager.js', () => ({
+  resolveSourceManager: vi.fn(() => mockManager),
+}));
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Import after mocks
+// ──────────────────────────────────────────────────────────────────────────────
+
+import databaseService from '../../../services/database.js';
+import { resolveSourceManager } from '../../utils/resolveSourceManager.js';
+import actionsRouter from './actions.js';
+
+const mockDb = databaseService as any;
+const mockResolveSourceManager = resolveSourceManager as ReturnType<typeof vi.fn>;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// App factory
+// ──────────────────────────────────────────────────────────────────────────────
+
+function buildApp(user: typeof adminUser | typeof normalUser | null): Express {
+  const app = express();
+  app.use(express.json());
+  // Simulate requireAPIToken setting req.user
+  app.use((req: any, _res, next) => {
+    if (user) req.user = user;
+    next();
+  });
+  // Mount with mergeParams so :sourceId is visible inside the router
+  app.use('/api/v1/sources/:sourceId/actions', actionsRouter);
+  return app;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function post(app: Express, sourceId: string, path: string, body: object) {
+  return request(app)
+    .post(`/api/v1/sources/${sourceId}/actions/${path}`)
+    .send(body)
+    .set('Content-Type', 'application/json');
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Setup / teardown
+// ──────────────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  neighborInfoRateLimitMap.clear();
+
+  // Default: grant all permissions
+  mockDb.checkPermissionAsync.mockResolvedValue(true);
+  // Default: no node found → channel 0
+  mockDb.nodes.getNode.mockResolvedValue(null);
+  // Default: insertMessage succeeds
+  mockDb.messages.insertMessage.mockResolvedValue(true);
+  // Default: manager resolves to mockManager for any sourceId
+  mockResolveSourceManager.mockReturnValue(mockManager);
+  // Default: local node is available
+  mockManager.getLocalNodeInfo.mockReturnValue({ nodeNum: LOCAL_NODE_NUM, nodeId: LOCAL_NODE_ID });
+  // Default: send operations succeed
+  mockManager.sendTraceroute.mockResolvedValue(undefined);
+  mockManager.sendPositionRequest.mockResolvedValue({ packetId: 1001, requestId: 2001 });
+  mockManager.sendNodeInfoRequest.mockResolvedValue({ packetId: 1002, requestId: 2002 });
+  mockManager.sendNeighborInfoRequest.mockResolvedValue({ packetId: 1003, requestId: 2003 });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// POST /traceroute
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('POST /traceroute', () => {
+  it('returns 200 and calls sendTraceroute with correct args', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'traceroute', { destination: `!${DEST_NUM.toString(16)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.destination).toBe(`!${DEST_NUM.toString(16).padStart(8, '0')}`);
+    expect(mockManager.sendTraceroute).toHaveBeenCalledWith(DEST_NUM, 0);
+    expect(mockResolveSourceManager).toHaveBeenCalledWith(SOURCE_A);
+  });
+
+  it('uses the node channel from the database', async () => {
+    mockDb.nodes.getNode.mockResolvedValue({ channel: 3, hopsAway: 1 });
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'traceroute', { destination: `!${DEST_NUM.toString(16)}` });
+
+    expect(res.status).toBe(200);
+    expect(mockManager.sendTraceroute).toHaveBeenCalledWith(DEST_NUM, 3);
+    expect(mockDb.nodes.getNode).toHaveBeenCalledWith(DEST_NUM, SOURCE_A);
+  });
+
+  it('accepts channel override in request body', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'traceroute', { destination: `!${DEST_NUM.toString(16)}`, channel: 5 });
+
+    expect(res.status).toBe(200);
+    expect(mockManager.sendTraceroute).toHaveBeenCalledWith(DEST_NUM, 5);
+  });
+
+  it('returns 400 when destination is missing', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'traceroute', {});
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 400 for nodeNum 0 (invalid destination)', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'traceroute', { nodeNum: 0 });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when user is not authenticated', async () => {
+    const app = buildApp(null);
+    const res = await post(app, SOURCE_A, 'traceroute', { destination: '!a1b2c3d4' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user lacks traceroute:write on the source', async () => {
+    mockDb.checkPermissionAsync.mockResolvedValue(false);
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'traceroute', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.required).toBe('traceroute:write');
+  });
+
+  it('passes sourceId to checkPermissionAsync (per-source)', async () => {
+    const app = buildApp(normalUser);
+    await post(app, SOURCE_A, 'traceroute', { destination: '!a1b2c3d4' });
+
+    const permCalls = mockDb.checkPermissionAsync.mock.calls;
+    expect(permCalls.length).toBeGreaterThan(0);
+    expect(permCalls[0][3]).toBe(SOURCE_A);
+  });
+
+  it('uses SOURCE_B manager when sourceId is SOURCE_B', async () => {
+    const managerB = { ...mockManager, sendTraceroute: vi.fn().mockResolvedValue(undefined) };
+    mockResolveSourceManager.mockImplementation((id: string) => (id === SOURCE_B ? managerB : mockManager));
+
+    const app = buildApp(normalUser);
+    await post(app, SOURCE_B, 'traceroute', { destination: '!a1b2c3d4' });
+
+    expect(managerB.sendTraceroute).toHaveBeenCalled();
+    expect(mockManager.sendTraceroute).not.toHaveBeenCalled();
+  });
+
+  it('admin bypasses permission check', async () => {
+    mockDb.checkPermissionAsync.mockResolvedValue(false);
+    const app = buildApp(adminUser);
+    const res = await post(app, SOURCE_A, 'traceroute', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(200);
+    expect(mockDb.checkPermissionAsync).not.toHaveBeenCalled();
+  });
+
+  it('accepts decimal nodeNum', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'traceroute', { nodeNum: DEST_NUM });
+    expect(res.status).toBe(200);
+    expect(mockManager.sendTraceroute).toHaveBeenCalledWith(DEST_NUM, expect.any(Number));
+  });
+
+  it('accepts 0x-prefixed hex destination', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'traceroute', { destination: `0x${DEST_NUM.toString(16)}` });
+    expect(res.status).toBe(200);
+    expect(mockManager.sendTraceroute).toHaveBeenCalledWith(DEST_NUM, expect.any(Number));
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// POST /request-position
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('POST /request-position', () => {
+  it('returns 200 and calls sendPositionRequest', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-position', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockManager.sendPositionRequest).toHaveBeenCalled();
+  });
+
+  it('inserts system message with canonical ID format', async () => {
+    const app = buildApp(normalUser);
+    await post(app, SOURCE_A, 'request-position', { destination: '!a1b2c3d4' });
+
+    expect(mockDb.messages.insertMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: `${SOURCE_A}_${LOCAL_NODE_NUM}_1001`,
+      }),
+      SOURCE_A
+    );
+  });
+
+  it('passes sourceId as second arg to insertMessage', async () => {
+    const app = buildApp(normalUser);
+    await post(app, SOURCE_A, 'request-position', { destination: '!a1b2c3d4' });
+
+    const [, passedSourceId] = mockDb.messages.insertMessage.mock.calls[0];
+    expect(passedSourceId).toBe(SOURCE_A);
+  });
+
+  it('omits requestId for broadcast destination', async () => {
+    const app = buildApp(normalUser);
+    await post(app, SOURCE_A, 'request-position', { destination: '!ffffffff' });
+
+    const [msg] = mockDb.messages.insertMessage.mock.calls[0];
+    expect(msg.requestId).toBeUndefined();
+    expect(msg.text).toBe('Position broadcast sent');
+  });
+
+  it('stores DM as channel -1 when channel is 0', async () => {
+    const app = buildApp(normalUser);
+    await post(app, SOURCE_A, 'request-position', { destination: '!a1b2c3d4' });
+
+    const [msg] = mockDb.messages.insertMessage.mock.calls[0];
+    expect(msg.channel).toBe(-1);
+  });
+
+  it('stores non-zero channel as-is', async () => {
+    const app = buildApp(normalUser);
+    await post(app, SOURCE_A, 'request-position', { destination: '!a1b2c3d4', channel: 2 });
+
+    const [msg] = mockDb.messages.insertMessage.mock.calls[0];
+    expect(msg.channel).toBe(2);
+  });
+
+  it('skips insertMessage when localNodeInfo is null', async () => {
+    mockManager.getLocalNodeInfo.mockReturnValue(null);
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-position', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(200);
+    expect(mockDb.messages.insertMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for missing destination', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-position', {});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const app = buildApp(null);
+    const res = await post(app, SOURCE_A, 'request-position', { destination: '!a1b2c3d4' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user lacks messages:write on source', async () => {
+    mockDb.checkPermissionAsync.mockResolvedValue(false);
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-position', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.required).toBe('messages:write');
+  });
+
+  it('passes sourceId to checkPermissionAsync', async () => {
+    const app = buildApp(normalUser);
+    await post(app, SOURCE_A, 'request-position', { destination: '!a1b2c3d4' });
+
+    expect(mockDb.checkPermissionAsync.mock.calls[0][3]).toBe(SOURCE_A);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// POST /request-nodeinfo
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('POST /request-nodeinfo', () => {
+  it('returns 200 and calls sendNodeInfoRequest', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-nodeinfo', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockManager.sendNodeInfoRequest).toHaveBeenCalled();
+  });
+
+  it('inserts system message with canonical ID format', async () => {
+    const app = buildApp(normalUser);
+    await post(app, SOURCE_A, 'request-nodeinfo', { destination: '!a1b2c3d4' });
+
+    expect(mockDb.messages.insertMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: `${SOURCE_A}_${LOCAL_NODE_NUM}_1002`,
+        requestId: 2002,
+      }),
+      SOURCE_A
+    );
+  });
+
+  it('returns 400 for missing destination', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-nodeinfo', {});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const app = buildApp(null);
+    const res = await post(app, SOURCE_A, 'request-nodeinfo', { destination: '!a1b2c3d4' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user lacks messages:write on source', async () => {
+    mockDb.checkPermissionAsync.mockResolvedValue(false);
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-nodeinfo', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.required).toBe('messages:write');
+  });
+
+  it('passes sourceId to checkPermissionAsync', async () => {
+    const app = buildApp(normalUser);
+    await post(app, SOURCE_A, 'request-nodeinfo', { destination: '!a1b2c3d4' });
+
+    expect(mockDb.checkPermissionAsync.mock.calls[0][3]).toBe(SOURCE_A);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// POST /request-neighbors
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('POST /request-neighbors', () => {
+  it('returns 200 for the local node', async () => {
+    mockManager.getLocalNodeInfo.mockReturnValue({ nodeNum: DEST_NUM, nodeId: '!a1b2c3d4' });
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-neighbors', { destination: `!${DEST_NUM.toString(16)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockManager.sendNeighborInfoRequest).toHaveBeenCalled();
+  });
+
+  it('returns 200 for a 0-hop node', async () => {
+    mockDb.nodes.getNode.mockResolvedValue({ hopsAway: 0, channel: 1 });
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-neighbors', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 403 for a non-local non-0-hop node', async () => {
+    mockDb.nodes.getNode.mockResolvedValue({ hopsAway: 2, channel: 0 });
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-neighbors', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/0-hop/);
+  });
+
+  it('returns 403 for unknown node (not in DB)', async () => {
+    mockDb.nodes.getNode.mockResolvedValue(null);
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-neighbors', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 429 when rate-limited', async () => {
+    mockDb.nodes.getNode.mockResolvedValue({ hopsAway: 0, channel: 0 });
+    // Pre-populate rate limit for SOURCE_A
+    neighborInfoRateLimitMap.set(`${SOURCE_A}:${DEST_NUM}`, Date.now());
+
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-neighbors', { destination: `!${DEST_NUM.toString(16)}` });
+
+    expect(res.status).toBe(429);
+    expect(res.body).toHaveProperty('retryAfter');
+  });
+
+  it('rate limit is per-source: SOURCE_B not affected by SOURCE_A limit', async () => {
+    mockDb.nodes.getNode.mockResolvedValue({ hopsAway: 0, channel: 0 });
+    // Pre-populate rate limit for SOURCE_A only
+    neighborInfoRateLimitMap.set(`${SOURCE_A}:${DEST_NUM}`, Date.now());
+
+    const app = buildApp(normalUser);
+    const resB = await post(app, SOURCE_B, 'request-neighbors', { destination: `!${DEST_NUM.toString(16)}` });
+
+    expect(resB.status).toBe(200);
+  });
+
+  it('returns 400 for missing destination', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-neighbors', {});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const app = buildApp(null);
+    const res = await post(app, SOURCE_A, 'request-neighbors', { destination: '!a1b2c3d4' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user lacks traceroute:write on source', async () => {
+    mockDb.checkPermissionAsync.mockResolvedValue(false);
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'request-neighbors', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.required).toBe('traceroute:write');
+  });
+
+  it('passes sourceId to checkPermissionAsync', async () => {
+    mockDb.nodes.getNode.mockResolvedValue({ hopsAway: 0, channel: 0 });
+    const app = buildApp(normalUser);
+    await post(app, SOURCE_A, 'request-neighbors', { destination: '!a1b2c3d4' });
+
+    expect(mockDb.checkPermissionAsync.mock.calls[0][3]).toBe(SOURCE_A);
+  });
+
+  it('passes sourceId to getNode for source scoping', async () => {
+    mockDb.nodes.getNode.mockResolvedValue({ hopsAway: 0, channel: 0 });
+    const app = buildApp(normalUser);
+    await post(app, SOURCE_A, 'request-neighbors', { destination: '!a1b2c3d4' });
+
+    expect(mockDb.nodes.getNode).toHaveBeenCalledWith(expect.any(Number), SOURCE_A);
+  });
+
+  it('rate-limit key includes sourceId to prevent cross-source interference', async () => {
+    mockDb.nodes.getNode.mockResolvedValue({ hopsAway: 0, channel: 0 });
+    const app = buildApp(normalUser);
+    await post(app, SOURCE_A, 'request-neighbors', { destination: `!${DEST_NUM.toString(16)}` });
+
+    expect(neighborInfoRateLimitMap.has(`${SOURCE_A}:${DEST_NUM}`)).toBe(true);
+    expect(neighborInfoRateLimitMap.has(`${SOURCE_B}:${DEST_NUM}`)).toBe(false);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// resolveDestination edge cases
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('destination resolution edge cases', () => {
+  it('accepts nodeId key as alias for destination', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'traceroute', { nodeId: '!a1b2c3d4' });
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts nodeNum key as alias for destination', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'traceroute', { nodeNum: DEST_NUM });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects plain hex without prefix (ambiguous)', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'traceroute', { destination: 'a1b2c3d4' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects nodeNum out of valid range', async () => {
+    const app = buildApp(normalUser);
+    const res = await post(app, SOURCE_A, 'traceroute', { nodeNum: 0x1FFFFFFFF });
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/server/routes/v1/actions.test.ts
+++ b/src/server/routes/v1/actions.test.ts
@@ -39,6 +39,13 @@ const normalUser = { id: 2, username: 'normal', isActive: true, isAdmin: false }
 vi.mock('../../../services/database.js', () => ({
   default: {
     checkPermissionAsync: vi.fn(),
+    sources: {
+      // attachSource resolves :sourceId via this call before any handler
+      // logic runs. Tests that exercise unknown sources can override it
+      // per-case to return null.
+      getSource: vi.fn(),
+      getAllSources: vi.fn(),
+    },
     nodes: {
       getNode: vi.fn(),
     },
@@ -113,6 +120,19 @@ beforeEach(() => {
 
   // Default: grant all permissions
   mockDb.checkPermissionAsync.mockResolvedValue(true);
+  // Default: any sourceId resolves to a stub source row so attachSource
+  // proceeds to the handler. Tests can override per-case.
+  mockDb.sources.getSource.mockImplementation(async (id: string) => ({
+    id,
+    name: id,
+    type: 'meshtastic_tcp',
+    config: {},
+    enabled: true,
+    createdAt: 0,
+    updatedAt: 0,
+    createdBy: null,
+  }));
+  mockDb.sources.getAllSources.mockResolvedValue([]);
   // Default: no node found → channel 0
   mockDb.nodes.getNode.mockResolvedValue(null);
   // Default: insertMessage succeeds
@@ -191,7 +211,7 @@ describe('POST /traceroute', () => {
     const res = await post(app, SOURCE_A, 'traceroute', { destination: '!a1b2c3d4' });
 
     expect(res.status).toBe(403);
-    expect(res.body.required).toBe('traceroute:write');
+    expect(res.body.required).toEqual({ resource: 'traceroute', action: 'write', sourceId: SOURCE_A });
   });
 
   it('passes sourceId to checkPermissionAsync (per-source)', async () => {
@@ -324,7 +344,7 @@ describe('POST /request-position', () => {
     const res = await post(app, SOURCE_A, 'request-position', { destination: '!a1b2c3d4' });
 
     expect(res.status).toBe(403);
-    expect(res.body.required).toBe('messages:write');
+    expect(res.body.required).toEqual({ resource: 'messages', action: 'write', sourceId: SOURCE_A });
   });
 
   it('passes sourceId to checkPermissionAsync', async () => {
@@ -380,7 +400,7 @@ describe('POST /request-nodeinfo', () => {
     const res = await post(app, SOURCE_A, 'request-nodeinfo', { destination: '!a1b2c3d4' });
 
     expect(res.status).toBe(403);
-    expect(res.body.required).toBe('messages:write');
+    expect(res.body.required).toEqual({ resource: 'messages', action: 'write', sourceId: SOURCE_A });
   });
 
   it('passes sourceId to checkPermissionAsync', async () => {
@@ -472,7 +492,7 @@ describe('POST /request-neighbors', () => {
     const res = await post(app, SOURCE_A, 'request-neighbors', { destination: '!a1b2c3d4' });
 
     expect(res.status).toBe(403);
-    expect(res.body.required).toBe('traceroute:write');
+    expect(res.body.required).toEqual({ resource: 'traceroute', action: 'write', sourceId: SOURCE_A });
   });
 
   it('passes sourceId to checkPermissionAsync', async () => {
@@ -528,5 +548,35 @@ describe('destination resolution edge cases', () => {
     const app = buildApp(normalUser);
     const res = await post(app, SOURCE_A, 'traceroute', { nodeNum: 0x1FFFFFFFF });
     expect(res.status).toBe(400);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// `default` source alias — resolved by attachSource
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('default source alias', () => {
+  it('resolves `default` to the first enabled source the admin can see', async () => {
+    mockDb.sources.getAllSources.mockResolvedValue([
+      { id: SOURCE_A, name: 'A', type: 'meshtastic_tcp', config: {}, enabled: true,  createdAt: 1, updatedAt: 1, createdBy: null },
+      { id: SOURCE_B, name: 'B', type: 'meshtastic_tcp', config: {}, enabled: true,  createdAt: 2, updatedAt: 2, createdBy: null },
+    ]);
+
+    const app = buildApp(adminUser);
+    const res = await post(app, 'default', 'traceroute', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(200);
+    // attachSource normalises req.params.sourceId to the resolved UUID, so the
+    // handler asks the registry for SOURCE_A (the earliest-createdAt enabled row).
+    expect(mockResolveSourceManager).toHaveBeenCalledWith(SOURCE_A);
+  });
+
+  it('returns 404 when no enabled source exists for `default`', async () => {
+    mockDb.sources.getAllSources.mockResolvedValue([]);
+
+    const app = buildApp(adminUser);
+    const res = await post(app, 'default', 'traceroute', { destination: '!a1b2c3d4' });
+
+    expect(res.status).toBe(404);
   });
 });

--- a/src/server/routes/v1/actions.ts
+++ b/src/server/routes/v1/actions.ts
@@ -1,66 +1,103 @@
 /**
  * v1 API - Node Actions Endpoint
  *
- * Provides POST actions for interacting with mesh nodes:
- * traceroute, position request, nodeinfo exchange, and neighbor info request.
+ * POST actions for interacting with mesh nodes: traceroute, position request,
+ * nodeinfo exchange, and neighbor info request. Requires Bearer token auth.
+ * All operations are scoped to the source identified by :sourceId.
  *
- * These endpoints mirror the internal API actions but are accessible
- * via Bearer token authentication for external clients.
+ * Permissions:
+ *   traceroute, request-neighbors  → traceroute:write (per source)
+ *   request-position, request-nodeinfo → messages:write (per source)
  */
 
 import express, { Request, Response } from 'express';
 import databaseService from '../../../services/database.js';
-import meshtasticManager from '../../meshtasticManager.js';
+import { resolveSourceManager } from '../../utils/resolveSourceManager.js';
 import { hasPermission } from '../../auth/authMiddleware.js';
 import { logger } from '../../../utils/logger.js';
 import { PortNum } from '../../constants/meshtastic.js';
 
-const router = express.Router();
+const router = express.Router({ mergeParams: true });
 
 /**
- * Resolve a node destination from the request body.
- * Accepts nodeId string (e.g. "!a1b2c3d4") or nodeNum number.
- * Returns the numeric node number or null if invalid.
+ * Resolve a destination node number from the request body.
+ * Accepts:
+ *   destination / nodeId / nodeNum  — any of the three keys
+ *   "!a1b2c3d4"  — !-prefixed hex (standard Meshtastic nodeId)
+ *   "0xa1b2c3d4" — 0x-prefixed hex
+ *   2712847316   — plain decimal number
+ *   "2712847316" — decimal string
+ *
+ * Returns null when absent, ambiguous, or out of the valid nodeNum range
+ * (1 – 0xFFFFFFFF).  nodeNum 0 is explicitly excluded: it means "broadcast"
+ * on some firmware paths but is not a valid single-node destination here.
  */
 function resolveDestination(body: any): number | null {
-  const { destination, nodeId, nodeNum } = body;
-  const raw = destination || nodeId || nodeNum;
-  if (!raw) return null;
+  const raw = body?.destination ?? body?.nodeId ?? body?.nodeNum;
+  if (raw == null) return null;
 
-  if (typeof raw === 'number') return raw;
-  if (typeof raw === 'string') {
-    // Handle "!hex" format
+  let num: number;
+  if (typeof raw === 'number') {
+    num = raw;
+  } else if (typeof raw === 'string') {
     if (raw.startsWith('!')) {
-      const num = parseInt(raw.slice(1), 16);
-      return isNaN(num) ? null : num;
+      num = parseInt(raw.slice(1), 16);
+    } else if (raw.startsWith('0x') || raw.startsWith('0X')) {
+      num = parseInt(raw, 16);
+    } else {
+      // Only accept unambiguous decimal strings — plain hex without prefix is
+      // indistinguishable from decimal and is therefore rejected.
+      num = parseInt(raw, 10);
     }
-    // Handle plain hex or decimal string
-    const num = parseInt(raw, raw.startsWith('0x') ? 16 : 10);
-    return isNaN(num) ? null : num;
+  } else {
+    return null;
   }
-  return null;
+
+  if (!Number.isInteger(num) || num <= 0 || num > 0xFFFFFFFF) return null;
+  return num;
 }
 
 /**
- * POST /api/v1/actions/traceroute
- * Send a traceroute to a destination node
+ * Source-scoped rate-limit map for request-neighbors.
+ * Key: "${sourceId}:${destinationNum}".  Pruned on every insert to avoid
+ * unbounded growth (entries older than 2× the limit are removed).
  */
+const neighborInfoRateLimitMap = new Map<string, number>();
+const NEIGHBOR_INFO_RATE_LIMIT_MS = 180_000;
+
+function pruneNeighborRateLimit(): void {
+  const cutoff = Date.now() - NEIGHBOR_INFO_RATE_LIMIT_MS * 2;
+  for (const [key, ts] of neighborInfoRateLimitMap) {
+    if (ts < cutoff) neighborInfoRateLimitMap.delete(key);
+  }
+}
+
+// POST /traceroute ─────────────────────────────────────────────────────────────
+
 router.post('/traceroute', async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;
-    if (!user?.isAdmin && !(user ? await hasPermission(user, 'traceroute', 'write') : false)) {
+    if (!user) {
+      return res.status(401).json({ success: false, error: 'Unauthorized', message: 'Authentication required' });
+    }
+
+    const sourceId = req.params.sourceId as string;
+    if (!user.isAdmin && !(await hasPermission(user, 'traceroute', 'write', sourceId))) {
       return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'traceroute:write' });
     }
 
     const destinationNum = resolveDestination(req.body);
-    if (!destinationNum) {
+    if (destinationNum === null) {
       return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
     }
 
-    const node = await databaseService.nodes.getNode(destinationNum);
-    const channel = node?.channel ?? 0;
+    const manager = resolveSourceManager(sourceId);
+    const node = await databaseService.nodes.getNode(destinationNum, sourceId);
+    const channel = (typeof req.body.channel === 'number' && req.body.channel >= 0 && req.body.channel <= 7)
+      ? req.body.channel
+      : (node?.channel ?? 0);
 
-    await meshtasticManager.sendTraceroute(destinationNum, channel);
+    await manager.sendTraceroute(destinationNum, channel);
 
     res.json({
       success: true,
@@ -76,50 +113,56 @@ router.post('/traceroute', async (req: Request, res: Response) => {
   }
 });
 
-/**
- * POST /api/v1/actions/request-position
- * Request position from a destination node
- */
+// POST /request-position ───────────────────────────────────────────────────────
+
 router.post('/request-position', async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;
-    if (!user?.isAdmin && !(user ? await hasPermission(user, 'messages', 'write') : false)) {
+    if (!user) {
+      return res.status(401).json({ success: false, error: 'Unauthorized', message: 'Authentication required' });
+    }
+
+    const sourceId = req.params.sourceId as string;
+    if (!user.isAdmin && !(await hasPermission(user, 'messages', 'write', sourceId))) {
       return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'messages:write' });
     }
 
     const destinationNum = resolveDestination(req.body);
-    if (!destinationNum) {
+    if (destinationNum === null) {
       return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
     }
 
-    const node = await databaseService.nodes.getNode(destinationNum);
+    const manager = resolveSourceManager(sourceId);
+    const node = await databaseService.nodes.getNode(destinationNum, sourceId);
     const channel = (typeof req.body.channel === 'number' && req.body.channel >= 0 && req.body.channel <= 7)
       ? req.body.channel
       : (node?.channel ?? 0);
 
-    const { packetId, requestId } = await meshtasticManager.sendPositionRequest(destinationNum, channel);
+    const { packetId, requestId } = await manager.sendPositionRequest(destinationNum, channel);
 
-    // Create system message like the internal endpoint does
-    const localNodeInfo = meshtasticManager.getLocalNodeInfo();
+    const localNodeInfo = manager.getLocalNodeInfo();
     const isBroadcast = destinationNum === 0xFFFFFFFF;
 
     if (localNodeInfo) {
       const timestamp = Date.now();
       const messageChannel = channel === 0 ? -1 : channel;
-      await databaseService.messages.insertMessage({
-        id: `${packetId}`,
-        fromNodeNum: localNodeInfo.nodeNum,
-        toNodeNum: destinationNum,
-        fromNodeId: localNodeInfo.nodeId,
-        toNodeId: `!${destinationNum.toString(16).padStart(8, '0')}`,
-        text: isBroadcast ? 'Position broadcast sent' : 'Position exchange requested',
-        channel: messageChannel,
-        portnum: PortNum.TEXT_MESSAGE_APP,
-        ...(isBroadcast ? {} : { requestId }),
-        timestamp,
-        rxTime: timestamp,
-        createdAt: timestamp,
-      });
+      await databaseService.messages.insertMessage(
+        {
+          id: `${sourceId}_${localNodeInfo.nodeNum}_${packetId}`,
+          fromNodeNum: localNodeInfo.nodeNum,
+          toNodeNum: destinationNum,
+          fromNodeId: localNodeInfo.nodeId,
+          toNodeId: `!${destinationNum.toString(16).padStart(8, '0')}`,
+          text: isBroadcast ? 'Position broadcast sent' : 'Position exchange requested',
+          channel: messageChannel,
+          portnum: PortNum.TEXT_MESSAGE_APP,
+          ...(isBroadcast ? {} : { requestId }),
+          timestamp,
+          rxTime: timestamp,
+          createdAt: timestamp,
+        },
+        sourceId
+      );
     }
 
     res.json({
@@ -136,47 +179,55 @@ router.post('/request-position', async (req: Request, res: Response) => {
   }
 });
 
-/**
- * POST /api/v1/actions/request-nodeinfo
- * Request node info exchange (triggers key exchange for DMs)
- */
+// POST /request-nodeinfo ───────────────────────────────────────────────────────
+
 router.post('/request-nodeinfo', async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;
-    if (!user?.isAdmin && !(user ? await hasPermission(user, 'messages', 'write') : false)) {
+    if (!user) {
+      return res.status(401).json({ success: false, error: 'Unauthorized', message: 'Authentication required' });
+    }
+
+    const sourceId = req.params.sourceId as string;
+    if (!user.isAdmin && !(await hasPermission(user, 'messages', 'write', sourceId))) {
       return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'messages:write' });
     }
 
     const destinationNum = resolveDestination(req.body);
-    if (!destinationNum) {
+    if (destinationNum === null) {
       return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
     }
 
-    const node = await databaseService.nodes.getNode(destinationNum);
-    const channel = node?.channel ?? 0;
+    const manager = resolveSourceManager(sourceId);
+    const node = await databaseService.nodes.getNode(destinationNum, sourceId);
+    const channel = (typeof req.body.channel === 'number' && req.body.channel >= 0 && req.body.channel <= 7)
+      ? req.body.channel
+      : (node?.channel ?? 0);
 
-    const { packetId, requestId } = await meshtasticManager.sendNodeInfoRequest(destinationNum, channel);
+    const { packetId, requestId } = await manager.sendNodeInfoRequest(destinationNum, channel);
 
-    // Create system message like the internal endpoint does
-    const localNodeInfo = meshtasticManager.getLocalNodeInfo();
+    const localNodeInfo = manager.getLocalNodeInfo();
 
     if (localNodeInfo) {
       const timestamp = Date.now();
       const messageChannel = channel === 0 ? -1 : channel;
-      await databaseService.messages.insertMessage({
-        id: `${packetId}`,
-        fromNodeNum: localNodeInfo.nodeNum,
-        toNodeNum: destinationNum,
-        fromNodeId: localNodeInfo.nodeId,
-        toNodeId: `!${destinationNum.toString(16).padStart(8, '0')}`,
-        text: 'User info exchange requested',
-        channel: messageChannel,
-        portnum: PortNum.TEXT_MESSAGE_APP,
-        requestId,
-        timestamp,
-        rxTime: timestamp,
-        createdAt: timestamp,
-      });
+      await databaseService.messages.insertMessage(
+        {
+          id: `${sourceId}_${localNodeInfo.nodeNum}_${packetId}`,
+          fromNodeNum: localNodeInfo.nodeNum,
+          toNodeNum: destinationNum,
+          fromNodeId: localNodeInfo.nodeId,
+          toNodeId: `!${destinationNum.toString(16).padStart(8, '0')}`,
+          text: 'User info exchange requested',
+          channel: messageChannel,
+          portnum: PortNum.TEXT_MESSAGE_APP,
+          requestId,
+          timestamp,
+          rxTime: timestamp,
+          createdAt: timestamp,
+        },
+        sourceId
+      );
     }
 
     res.json({
@@ -193,29 +244,29 @@ router.post('/request-nodeinfo', async (req: Request, res: Response) => {
   }
 });
 
-/**
- * POST /api/v1/actions/request-neighbors
- * Request neighbor info from a node (only local or 0-hop nodes)
- */
-const neighborInfoRequestTimestamps = new Map<number, number>();
-const NEIGHBOR_INFO_RATE_LIMIT_MS = 180_000;
+// POST /request-neighbors ──────────────────────────────────────────────────────
 
 router.post('/request-neighbors', async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;
-    if (!user?.isAdmin && !(user ? await hasPermission(user, 'traceroute', 'write') : false)) {
+    if (!user) {
+      return res.status(401).json({ success: false, error: 'Unauthorized', message: 'Authentication required' });
+    }
+
+    const sourceId = req.params.sourceId as string;
+    if (!user.isAdmin && !(await hasPermission(user, 'traceroute', 'write', sourceId))) {
       return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'traceroute:write' });
     }
 
     const destinationNum = resolveDestination(req.body);
-    if (!destinationNum) {
+    if (destinationNum === null) {
       return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
     }
 
-    // Eligibility check: only local node or 0-hop nodes
-    const localNodeNum = meshtasticManager.getLocalNodeInfo()?.nodeNum;
-    const node = await databaseService.nodes.getNode(destinationNum);
-    const isLocalNode = localNodeNum != null && Number(destinationNum) === Number(localNodeNum);
+    const manager = resolveSourceManager(sourceId);
+    const localNodeNum = manager.getLocalNodeInfo()?.nodeNum;
+    const node = await databaseService.nodes.getNode(destinationNum, sourceId);
+    const isLocalNode = localNodeNum != null && destinationNum === localNodeNum;
     const isDirectNode = node != null && node.hopsAway != null && Number(node.hopsAway) === 0;
 
     if (!isLocalNode && !isDirectNode) {
@@ -225,10 +276,10 @@ router.post('/request-neighbors', async (req: Request, res: Response) => {
       });
     }
 
-    // Rate limiting per destination
-    const lastRequest = neighborInfoRequestTimestamps.get(Number(destinationNum));
+    const rateLimitKey = `${sourceId}:${destinationNum}`;
+    const lastRequest = neighborInfoRateLimitMap.get(rateLimitKey);
     const now = Date.now();
-    if (lastRequest && (now - lastRequest) < NEIGHBOR_INFO_RATE_LIMIT_MS) {
+    if (lastRequest !== undefined && (now - lastRequest) < NEIGHBOR_INFO_RATE_LIMIT_MS) {
       const retryAfter = Math.ceil((NEIGHBOR_INFO_RATE_LIMIT_MS - (now - lastRequest)) / 1000);
       return res.status(429).json({
         success: false,
@@ -237,9 +288,14 @@ router.post('/request-neighbors', async (req: Request, res: Response) => {
       });
     }
 
-    const channel = node?.channel ?? 0;
-    await meshtasticManager.sendNeighborInfoRequest(destinationNum, channel);
-    neighborInfoRequestTimestamps.set(Number(destinationNum), now);
+    pruneNeighborRateLimit();
+
+    const channel = (typeof req.body.channel === 'number' && req.body.channel >= 0 && req.body.channel <= 7)
+      ? req.body.channel
+      : (node?.channel ?? 0);
+
+    await manager.sendNeighborInfoRequest(destinationNum, channel);
+    neighborInfoRateLimitMap.set(rateLimitKey, now);
 
     res.json({
       success: true,
@@ -255,4 +311,5 @@ router.post('/request-neighbors', async (req: Request, res: Response) => {
   }
 });
 
+export { neighborInfoRateLimitMap };
 export default router;

--- a/src/server/routes/v1/actions.ts
+++ b/src/server/routes/v1/actions.ts
@@ -238,7 +238,7 @@ router.post('/request-neighbors', async (req: Request, res: Response) => {
     }
 
     const channel = node?.channel ?? 0;
-    const { packetId, requestId } = await meshtasticManager.sendNeighborInfoRequest(destinationNum, channel);
+    await meshtasticManager.sendNeighborInfoRequest(destinationNum, channel);
     neighborInfoRequestTimestamps.set(Number(destinationNum), now);
 
     res.json({

--- a/src/server/routes/v1/actions.ts
+++ b/src/server/routes/v1/actions.ts
@@ -1,0 +1,258 @@
+/**
+ * v1 API - Node Actions Endpoint
+ *
+ * Provides POST actions for interacting with mesh nodes:
+ * traceroute, position request, nodeinfo exchange, and neighbor info request.
+ *
+ * These endpoints mirror the internal API actions but are accessible
+ * via Bearer token authentication for external clients.
+ */
+
+import express, { Request, Response } from 'express';
+import databaseService from '../../../services/database.js';
+import meshtasticManager from '../../meshtasticManager.js';
+import { hasPermission } from '../../auth/authMiddleware.js';
+import { logger } from '../../../utils/logger.js';
+import { PortNum } from '../../constants/meshtastic.js';
+
+const router = express.Router();
+
+/**
+ * Resolve a node destination from the request body.
+ * Accepts nodeId string (e.g. "!a1b2c3d4") or nodeNum number.
+ * Returns the numeric node number or null if invalid.
+ */
+function resolveDestination(body: any): number | null {
+  const { destination, nodeId, nodeNum } = body;
+  const raw = destination || nodeId || nodeNum;
+  if (!raw) return null;
+
+  if (typeof raw === 'number') return raw;
+  if (typeof raw === 'string') {
+    // Handle "!hex" format
+    if (raw.startsWith('!')) {
+      const num = parseInt(raw.slice(1), 16);
+      return isNaN(num) ? null : num;
+    }
+    // Handle plain hex or decimal string
+    const num = parseInt(raw, raw.startsWith('0x') ? 16 : 10);
+    return isNaN(num) ? null : num;
+  }
+  return null;
+}
+
+/**
+ * POST /api/v1/actions/traceroute
+ * Send a traceroute to a destination node
+ */
+router.post('/traceroute', async (req: Request, res: Response) => {
+  try {
+    const user = (req as any).apiTokenUser;
+    if (!user?.isAdmin && !hasPermission(user?.permissions, 'traceroute', 'write')) {
+      return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'traceroute:write' });
+    }
+
+    const destinationNum = resolveDestination(req.body);
+    if (!destinationNum) {
+      return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
+    }
+
+    const node = await databaseService.nodes.getNode(destinationNum);
+    const channel = node?.channel ?? 0;
+
+    await meshtasticManager.sendTraceroute(destinationNum, channel);
+
+    res.json({
+      success: true,
+      data: {
+        destination: `!${destinationNum.toString(16).padStart(8, '0')}`,
+        channel,
+        message: 'Traceroute request sent',
+      },
+    });
+  } catch (error) {
+    logger.error('[v1/actions] Error sending traceroute:', error);
+    res.status(500).json({ success: false, error: 'Failed to send traceroute' });
+  }
+});
+
+/**
+ * POST /api/v1/actions/request-position
+ * Request position from a destination node
+ */
+router.post('/request-position', async (req: Request, res: Response) => {
+  try {
+    const user = (req as any).apiTokenUser;
+    if (!user?.isAdmin && !hasPermission(user?.permissions, 'messages', 'write')) {
+      return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'messages:write' });
+    }
+
+    const destinationNum = resolveDestination(req.body);
+    if (!destinationNum) {
+      return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
+    }
+
+    const node = await databaseService.nodes.getNode(destinationNum);
+    const channel = (typeof req.body.channel === 'number' && req.body.channel >= 0 && req.body.channel <= 7)
+      ? req.body.channel
+      : (node?.channel ?? 0);
+
+    const { packetId, requestId } = await meshtasticManager.sendPositionRequest(destinationNum, channel);
+
+    // Create system message like the internal endpoint does
+    const localNodeInfo = meshtasticManager.getLocalNodeInfo();
+    const isBroadcast = destinationNum === 0xFFFFFFFF;
+
+    if (localNodeInfo) {
+      const timestamp = Date.now();
+      const messageChannel = channel === 0 ? -1 : channel;
+      await databaseService.messages.insertMessage({
+        id: `${packetId}`,
+        fromNodeNum: localNodeInfo.nodeNum,
+        toNodeNum: destinationNum,
+        fromNodeId: localNodeInfo.nodeId,
+        toNodeId: `!${destinationNum.toString(16).padStart(8, '0')}`,
+        text: isBroadcast ? 'Position broadcast sent' : 'Position exchange requested',
+        channel: messageChannel,
+        portnum: PortNum.TEXT_MESSAGE_APP,
+        ...(isBroadcast ? {} : { requestId }),
+        timestamp,
+        rxTime: timestamp,
+        createdAt: timestamp,
+      });
+    }
+
+    res.json({
+      success: true,
+      data: {
+        destination: `!${destinationNum.toString(16).padStart(8, '0')}`,
+        channel,
+        message: 'Position request sent',
+      },
+    });
+  } catch (error) {
+    logger.error('[v1/actions] Error requesting position:', error);
+    res.status(500).json({ success: false, error: 'Failed to request position' });
+  }
+});
+
+/**
+ * POST /api/v1/actions/request-nodeinfo
+ * Request node info exchange (triggers key exchange for DMs)
+ */
+router.post('/request-nodeinfo', async (req: Request, res: Response) => {
+  try {
+    const user = (req as any).apiTokenUser;
+    if (!user?.isAdmin && !hasPermission(user?.permissions, 'messages', 'write')) {
+      return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'messages:write' });
+    }
+
+    const destinationNum = resolveDestination(req.body);
+    if (!destinationNum) {
+      return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
+    }
+
+    const node = await databaseService.nodes.getNode(destinationNum);
+    const channel = node?.channel ?? 0;
+
+    const { packetId, requestId } = await meshtasticManager.sendNodeInfoRequest(destinationNum, channel);
+
+    // Create system message like the internal endpoint does
+    const localNodeInfo = meshtasticManager.getLocalNodeInfo();
+
+    if (localNodeInfo) {
+      const timestamp = Date.now();
+      const messageChannel = channel === 0 ? -1 : channel;
+      await databaseService.messages.insertMessage({
+        id: `${packetId}`,
+        fromNodeNum: localNodeInfo.nodeNum,
+        toNodeNum: destinationNum,
+        fromNodeId: localNodeInfo.nodeId,
+        toNodeId: `!${destinationNum.toString(16).padStart(8, '0')}`,
+        text: 'User info exchange requested',
+        channel: messageChannel,
+        portnum: PortNum.TEXT_MESSAGE_APP,
+        requestId,
+        timestamp,
+        rxTime: timestamp,
+        createdAt: timestamp,
+      });
+    }
+
+    res.json({
+      success: true,
+      data: {
+        destination: `!${destinationNum.toString(16).padStart(8, '0')}`,
+        channel,
+        message: 'NodeInfo request sent (key exchange initiated)',
+      },
+    });
+  } catch (error) {
+    logger.error('[v1/actions] Error requesting nodeinfo:', error);
+    res.status(500).json({ success: false, error: 'Failed to request node info' });
+  }
+});
+
+/**
+ * POST /api/v1/actions/request-neighbors
+ * Request neighbor info from a node (only local or 0-hop nodes)
+ */
+const neighborInfoRequestTimestamps = new Map<number, number>();
+const NEIGHBOR_INFO_RATE_LIMIT_MS = 180_000;
+
+router.post('/request-neighbors', async (req: Request, res: Response) => {
+  try {
+    const user = (req as any).apiTokenUser;
+    if (!user?.isAdmin && !hasPermission(user?.permissions, 'traceroute', 'write')) {
+      return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'traceroute:write' });
+    }
+
+    const destinationNum = resolveDestination(req.body);
+    if (!destinationNum) {
+      return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
+    }
+
+    // Eligibility check: only local node or 0-hop nodes
+    const localNodeNum = meshtasticManager.getLocalNodeInfo()?.nodeNum;
+    const node = await databaseService.nodes.getNode(destinationNum);
+    const isLocalNode = localNodeNum != null && Number(destinationNum) === Number(localNodeNum);
+    const isDirectNode = node != null && node.hopsAway != null && Number(node.hopsAway) === 0;
+
+    if (!isLocalNode && !isDirectNode) {
+      return res.status(403).json({
+        success: false,
+        error: 'Neighbor info requests are only allowed for the local node or directly-heard (0-hop) nodes',
+      });
+    }
+
+    // Rate limiting per destination
+    const lastRequest = neighborInfoRequestTimestamps.get(Number(destinationNum));
+    const now = Date.now();
+    if (lastRequest && (now - lastRequest) < NEIGHBOR_INFO_RATE_LIMIT_MS) {
+      const retryAfter = Math.ceil((NEIGHBOR_INFO_RATE_LIMIT_MS - (now - lastRequest)) / 1000);
+      return res.status(429).json({
+        success: false,
+        error: 'Rate limited: firmware limits neighbor info responses to once per 3 minutes',
+        retryAfter,
+      });
+    }
+
+    const channel = node?.channel ?? 0;
+    const { packetId, requestId } = await meshtasticManager.sendNeighborInfoRequest(destinationNum, channel);
+    neighborInfoRequestTimestamps.set(Number(destinationNum), now);
+
+    res.json({
+      success: true,
+      data: {
+        destination: `!${destinationNum.toString(16).padStart(8, '0')}`,
+        channel,
+        message: 'Neighbor info request sent',
+      },
+    });
+  } catch (error) {
+    logger.error('[v1/actions] Error requesting neighbor info:', error);
+    res.status(500).json({ success: false, error: 'Failed to request neighbor info' });
+  }
+});
+
+export default router;

--- a/src/server/routes/v1/actions.ts
+++ b/src/server/routes/v1/actions.ts
@@ -5,17 +5,19 @@
  * nodeinfo exchange, and neighbor info request. Requires Bearer token auth.
  * All operations are scoped to the source identified by :sourceId.
  *
- * Permissions:
- *   traceroute, request-neighbors  → traceroute:write (per source)
- *   request-position, request-nodeinfo → messages:write (per source)
+ * Permissions (enforced by per-route `attachSource` middleware so the
+ * `default` source alias, per-source 403, and the canonical `req.source` shape
+ * match every other v1 resource):
+ *   traceroute, request-neighbors      → traceroute:write
+ *   request-position, request-nodeinfo → messages:write
  */
 
 import express, { Request, Response } from 'express';
 import databaseService from '../../../services/database.js';
 import { resolveSourceManager } from '../../utils/resolveSourceManager.js';
-import { hasPermission } from '../../auth/authMiddleware.js';
 import { logger } from '../../../utils/logger.js';
 import { PortNum } from '../../constants/meshtastic.js';
+import { attachSource } from './sourceParam.js';
 
 const router = express.Router({ mergeParams: true });
 
@@ -74,18 +76,9 @@ function pruneNeighborRateLimit(): void {
 
 // POST /traceroute ─────────────────────────────────────────────────────────────
 
-router.post('/traceroute', async (req: Request, res: Response) => {
+router.post('/traceroute', attachSource('traceroute', 'write'), async (req: Request, res: Response) => {
   try {
-    const user = (req as any).user;
-    if (!user) {
-      return res.status(401).json({ success: false, error: 'Unauthorized', message: 'Authentication required' });
-    }
-
     const sourceId = req.params.sourceId as string;
-    if (!user.isAdmin && !(await hasPermission(user, 'traceroute', 'write', sourceId))) {
-      return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'traceroute:write' });
-    }
-
     const destinationNum = resolveDestination(req.body);
     if (destinationNum === null) {
       return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
@@ -115,18 +108,9 @@ router.post('/traceroute', async (req: Request, res: Response) => {
 
 // POST /request-position ───────────────────────────────────────────────────────
 
-router.post('/request-position', async (req: Request, res: Response) => {
+router.post('/request-position', attachSource('messages', 'write'), async (req: Request, res: Response) => {
   try {
-    const user = (req as any).user;
-    if (!user) {
-      return res.status(401).json({ success: false, error: 'Unauthorized', message: 'Authentication required' });
-    }
-
     const sourceId = req.params.sourceId as string;
-    if (!user.isAdmin && !(await hasPermission(user, 'messages', 'write', sourceId))) {
-      return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'messages:write' });
-    }
-
     const destinationNum = resolveDestination(req.body);
     if (destinationNum === null) {
       return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
@@ -181,18 +165,9 @@ router.post('/request-position', async (req: Request, res: Response) => {
 
 // POST /request-nodeinfo ───────────────────────────────────────────────────────
 
-router.post('/request-nodeinfo', async (req: Request, res: Response) => {
+router.post('/request-nodeinfo', attachSource('messages', 'write'), async (req: Request, res: Response) => {
   try {
-    const user = (req as any).user;
-    if (!user) {
-      return res.status(401).json({ success: false, error: 'Unauthorized', message: 'Authentication required' });
-    }
-
     const sourceId = req.params.sourceId as string;
-    if (!user.isAdmin && !(await hasPermission(user, 'messages', 'write', sourceId))) {
-      return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'messages:write' });
-    }
-
     const destinationNum = resolveDestination(req.body);
     if (destinationNum === null) {
       return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });
@@ -246,18 +221,9 @@ router.post('/request-nodeinfo', async (req: Request, res: Response) => {
 
 // POST /request-neighbors ──────────────────────────────────────────────────────
 
-router.post('/request-neighbors', async (req: Request, res: Response) => {
+router.post('/request-neighbors', attachSource('traceroute', 'write'), async (req: Request, res: Response) => {
   try {
-    const user = (req as any).user;
-    if (!user) {
-      return res.status(401).json({ success: false, error: 'Unauthorized', message: 'Authentication required' });
-    }
-
     const sourceId = req.params.sourceId as string;
-    if (!user.isAdmin && !(await hasPermission(user, 'traceroute', 'write', sourceId))) {
-      return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'traceroute:write' });
-    }
-
     const destinationNum = resolveDestination(req.body);
     if (destinationNum === null) {
       return res.status(400).json({ success: false, error: 'Destination node is required (destination, nodeId, or nodeNum)' });

--- a/src/server/routes/v1/actions.ts
+++ b/src/server/routes/v1/actions.ts
@@ -47,8 +47,8 @@ function resolveDestination(body: any): number | null {
  */
 router.post('/traceroute', async (req: Request, res: Response) => {
   try {
-    const user = (req as any).apiTokenUser;
-    if (!user?.isAdmin && !hasPermission(user?.permissions, 'traceroute', 'write')) {
+    const user = (req as any).user;
+    if (!user?.isAdmin && !(user ? await hasPermission(user, 'traceroute', 'write') : false)) {
       return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'traceroute:write' });
     }
 
@@ -82,8 +82,8 @@ router.post('/traceroute', async (req: Request, res: Response) => {
  */
 router.post('/request-position', async (req: Request, res: Response) => {
   try {
-    const user = (req as any).apiTokenUser;
-    if (!user?.isAdmin && !hasPermission(user?.permissions, 'messages', 'write')) {
+    const user = (req as any).user;
+    if (!user?.isAdmin && !(user ? await hasPermission(user, 'messages', 'write') : false)) {
       return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'messages:write' });
     }
 
@@ -142,8 +142,8 @@ router.post('/request-position', async (req: Request, res: Response) => {
  */
 router.post('/request-nodeinfo', async (req: Request, res: Response) => {
   try {
-    const user = (req as any).apiTokenUser;
-    if (!user?.isAdmin && !hasPermission(user?.permissions, 'messages', 'write')) {
+    const user = (req as any).user;
+    if (!user?.isAdmin && !(user ? await hasPermission(user, 'messages', 'write') : false)) {
       return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'messages:write' });
     }
 
@@ -202,8 +202,8 @@ const NEIGHBOR_INFO_RATE_LIMIT_MS = 180_000;
 
 router.post('/request-neighbors', async (req: Request, res: Response) => {
   try {
-    const user = (req as any).apiTokenUser;
-    if (!user?.isAdmin && !hasPermission(user?.permissions, 'traceroute', 'write')) {
+    const user = (req as any).user;
+    if (!user?.isAdmin && !(user ? await hasPermission(user, 'traceroute', 'write') : false)) {
       return res.status(403).json({ success: false, error: 'Insufficient permissions', required: 'traceroute:write' });
     }
 

--- a/src/server/routes/v1/index.ts
+++ b/src/server/routes/v1/index.ts
@@ -128,6 +128,10 @@ router.use(
   attachSource('info', 'read'),
   statusRouter
 );
+// Actions endpoints (traceroute / position / nodeinfo / neighbors) mix two
+// permission resources — `traceroute:write` and `messages:write` — so they
+// apply `attachSource` per-route inside `actionsRouter` rather than at the
+// mount level.
 router.use('/sources/:sourceId/actions', actionsRouter);
 
 // Deprecated legacy routes (root-scoped). Same handlers, but gated by the

--- a/src/server/routes/v1/index.ts
+++ b/src/server/routes/v1/index.ts
@@ -40,6 +40,7 @@ import statusRouter from './status.js';
 import sourcesRouter from './sources.js';
 import { attachSource } from './sourceParam.js';
 import { deprecationShim } from './deprecatedShim.js';
+import actionsRouter from './actions.js';
 
 const router = express.Router();
 
@@ -69,6 +70,7 @@ router.get('/', (_req, res) => {
       status: '/api/v1/sources/{sourceId}/status',
       channelDatabase: '/api/v1/channel-database',
       solar: '/api/v1/solar',
+      actions: '/api/v1/actions',
     },
     note:
       'Per-source paths are canonical. Legacy root paths (e.g. /api/v1/nodes?sourceId=...) ' +
@@ -80,6 +82,7 @@ router.get('/', (_req, res) => {
 router.use('/sources', sourcesRouter);
 router.use('/solar', solarRouter);
 router.use('/channel-database', channelDatabaseRouter);
+router.use('/actions', actionsRouter);
 
 // Per-source canonical routes. `attachSource(resource, action)` resolves the
 // :sourceId param (including the `default` alias) and enforces the

--- a/src/server/routes/v1/index.ts
+++ b/src/server/routes/v1/index.ts
@@ -70,7 +70,7 @@ router.get('/', (_req, res) => {
       status: '/api/v1/sources/{sourceId}/status',
       channelDatabase: '/api/v1/channel-database',
       solar: '/api/v1/solar',
-      actions: '/api/v1/actions',
+      actions: '/api/v1/sources/{sourceId}/actions',
     },
     note:
       'Per-source paths are canonical. Legacy root paths (e.g. /api/v1/nodes?sourceId=...) ' +
@@ -82,7 +82,6 @@ router.get('/', (_req, res) => {
 router.use('/sources', sourcesRouter);
 router.use('/solar', solarRouter);
 router.use('/channel-database', channelDatabaseRouter);
-router.use('/actions', actionsRouter);
 
 // Per-source canonical routes. `attachSource(resource, action)` resolves the
 // :sourceId param (including the `default` alias) and enforces the
@@ -129,6 +128,7 @@ router.use(
   attachSource('info', 'read'),
   statusRouter
 );
+router.use('/sources/:sourceId/actions', actionsRouter);
 
 // Deprecated legacy routes (root-scoped). Same handlers, but gated by the
 // `deprecationShim` that stamps a `Warning: 299` header on every response

--- a/src/server/routes/v1/v1-api.test.ts
+++ b/src/server/routes/v1/v1-api.test.ts
@@ -377,6 +377,7 @@ describe('GET /api/v1/', () => {
     // Deployment-global resources stay at the root.
     expect(response.body.endpoints.solar).toBe('/api/v1/solar');
     expect(response.body.endpoints.channelDatabase).toBe('/api/v1/channel-database');
+    expect(response.body.endpoints.actions).toBe('/api/v1/actions');
     expect(response.body.note).toMatch(/Legacy root paths/i);
   });
 });

--- a/src/server/routes/v1/v1-api.test.ts
+++ b/src/server/routes/v1/v1-api.test.ts
@@ -377,7 +377,7 @@ describe('GET /api/v1/', () => {
     // Deployment-global resources stay at the root.
     expect(response.body.endpoints.solar).toBe('/api/v1/solar');
     expect(response.body.endpoints.channelDatabase).toBe('/api/v1/channel-database');
-    expect(response.body.endpoints.actions).toBe('/api/v1/actions');
+    expect(response.body.endpoints.actions).toBe('/api/v1/sources/{sourceId}/actions');
     expect(response.body.note).toMatch(/Legacy root paths/i);
   });
 });


### PR DESCRIPTION
## Summary

Add POST endpoints under `/api/v1/actions/` for interacting with mesh nodes via Bearer token authentication:

- `POST /api/v1/actions/traceroute` - Send traceroute to a node
- `POST /api/v1/actions/request-position` - Request position from a node
- `POST /api/v1/actions/request-nodeinfo` - Request node info exchange (key exchange for DMs)
- `POST /api/v1/actions/request-neighbors` - Request neighbor info (local/0-hop nodes only)

## Motivation

The internal API (`/api/traceroute`, `/api/position/request`, etc.) requires session cookies + CSRF tokens, making it inaccessible to external API clients that use Bearer token authentication.

This is needed for tools like [meshmonitor-chat.el](https://git.andros.dev/andros/meshmonitor-chat.el) (Emacs client) and any CLI/script that uses the v1 API with tokens.

## Details

- Follows the same v1 API patterns as existing endpoints (status, messages, nodes)
- Accepts `destination` as nodeId (`"!a1b2c3d4"`), nodeNum (number), or hex string
- Replicates the same permission checks, rate limits, and system message creation as the internal endpoints
- Neighbor info requests maintain the 180s rate limit per destination and 0-hop eligibility check

## Request body

```json
{
  "destination": "!a1b2c3d4"
}
```

Or alternatively: `{ "nodeId": "!a1b2c3d4" }` or `{ "nodeNum": 48596172 }`

## Test plan

- [ ] Verify traceroute sends via Bearer token
- [ ] Verify position request sends and creates system message
- [ ] Verify nodeinfo request triggers key exchange
- [ ] Verify neighbor info respects 0-hop restriction and rate limit
- [ ] Verify permission checks (traceroute:write, messages:write)
- [ ] Verify 400 response for missing destination
- [ ] Verify 403 for insufficient permissions