### PR TITLE
fix(4.0-alpha): migration 029 FK crash, heartbeat liveness, dashboard polish

### DIFF
--- a/public/meshtastic-icon.svg
+++ b/public/meshtastic-icon.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Meshtastic-styled icon: stylized antenna mast with three concentric mesh
+  waves. Used both as the per-source type badge and as a faint watermark
+  behind source tiles in the dashboard sidebar (src/styles/dashboard.css).
+  Uses currentColor so it picks up text color in the badge context, and
+  inherits opacity from the background-image rule for the watermark.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <!-- antenna mast -->
+  <line x1="32" y1="20" x2="32" y2="56" />
+  <!-- antenna base/dish -->
+  <circle cx="32" cy="20" r="3" fill="currentColor" stroke="none" />
+  <!-- inner wave -->
+  <path d="M22 26 Q32 18 42 26" />
+  <!-- middle wave -->
+  <path d="M16 22 Q32 8 48 22" />
+  <!-- outer wave -->
+  <path d="M10 18 Q32 -2 54 18" />
+  <!-- ground line -->
+  <line x1="22" y1="56" x2="42" y2="56" />
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2059,7 +2059,8 @@ function App() {
 
       while (attempts < maxAttempts) {
         try {
-          const response = await authFetch(`${baseUrl}/api/connection`);
+          const connQuery = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
+          const response = await authFetch(`${baseUrl}/api/connection${connQuery}`);
           if (response.ok) {
             const status = await response.json();
             if (status.connected) {
@@ -2139,8 +2140,13 @@ function App() {
     const urlBase = providedBaseUrl !== undefined ? providedBaseUrl : baseUrl;
 
     try {
-      // Use consolidated polling endpoint to check connection status
-      const response = await authFetch(`${urlBase}/api/poll`);
+      // Use consolidated polling endpoint to check connection status.
+      // When inside a SourceProvider (multi-source dashboard), pass sourceId
+      // so the server reads from the correct manager — otherwise the header
+      // would show the legacy singleton's status, which is "disconnected" in
+      // 4.0 multi-source mode.
+      const pollQuery = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
+      const response = await authFetch(`${urlBase}/api/poll${pollQuery}`);
       if (response.ok) {
         const pollData = await response.json();
         const status = pollData.connection;

--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -5,6 +5,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { DashboardSource, SourceStatus } from '../../hooks/useDashboardData';
+import { appBasename } from '../../init';
 
 interface DashboardSidebarProps {
   sources: DashboardSource[];
@@ -151,10 +152,19 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
         const nodeCount = nodeCounts.get(source.id) ?? 0;
         const isSelected = selectedSourceId === source.id;
 
+        // Show the Meshtastic logo as a faint watermark for any meshtastic-typed
+        // source. Other source types render without a watermark.
+        const isMeshtastic =
+          source.type === 'meshtastic_tcp' || source.type === 'meshtastic_mqtt';
+        const cardClassName =
+          'dashboard-source-card' +
+          (isSelected ? ' selected' : '') +
+          (isMeshtastic ? ' has-meshtastic-watermark' : '');
+
         return (
           <div
             key={source.id}
-            className={`dashboard-source-card${isSelected ? ' selected' : ''}`}
+            className={cardClassName}
             onClick={() => onSelectSource(source.id)}
             role="button"
             tabIndex={0}
@@ -166,7 +176,16 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
               <span className="dashboard-source-card-name" title={source.name}>
                 {source.name}
               </span>
-              <span className="dashboard-source-card-badge">{source.type}</span>
+              {source.type === 'meshtastic_tcp' || source.type === 'meshtastic_mqtt' ? (
+                <img
+                  src={`${appBasename}/meshtastic-icon.svg`}
+                  alt="Meshtastic"
+                  title={source.type}
+                  className="dashboard-source-card-type-icon"
+                />
+              ) : (
+                <span className="dashboard-source-card-badge">{source.type}</span>
+              )}
               {(() => {
                 const vn = (source.config as any)?.virtualNode;
                 return vn?.enabled ? (

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -30,6 +30,8 @@ export interface SourceStatus {
   sourceName?: string;
   sourceType?: string;
   connected: boolean;
+  /** Total nodes heard by this source — populated by GET /api/sources/:id/status. */
+  nodeCount?: number;
   [key: string]: unknown;
 }
 

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -81,12 +81,17 @@ function DashboardInner() {
     setSelectedSourceId(firstEnabled?.id ?? sources[0].id);
   }, [isSuccess, sources, selectedSourceId]);
 
-  // Build node-count map — selected source gets real count, others get 0
+  // Build node-count map. Each source's count comes from its /status response
+  // (added in sourceRoutes.ts), polled in parallel by useSourceStatuses. The
+  // currently-selected source uses the live `sourceData.nodes.length` so the
+  // counter updates immediately as new nodes arrive instead of waiting for the
+  // next status poll.
   const nodeCounts = new Map<string, number>(
-    sources.map((s) => [
-      s.id,
-      s.id === selectedSourceId ? sourceData.nodes.length : 0,
-    ]),
+    sources.map((s) => {
+      if (s.id === selectedSourceId) return [s.id, sourceData.nodes.length];
+      const status = statusMap.get(s.id);
+      return [s.id, status?.nodeCount ?? 0];
+    }),
   );
 
   // ----- admin actions -----

--- a/src/server/migrations/029_nodes_composite_pk.test.ts
+++ b/src/server/migrations/029_nodes_composite_pk.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Migration 029 — nodes composite PK
+ *
+ * Regression test for the FOREIGN KEY constraint crash on 4.0 alpha upgrade.
+ * The migration performs a SQLite table rebuild (CREATE new + copy + DROP +
+ * RENAME), which the SQLite docs explicitly warn must run with
+ * `PRAGMA foreign_keys = OFF` — otherwise unrelated orphan rows elsewhere in
+ * the database can trip the rebuild. This test reproduces that scenario by
+ * seeding a pre-existing orphan row in user_notification_preferences, running
+ * the migration with foreign_keys=ON, and asserting it completes successfully.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './029_nodes_composite_pk.js';
+
+function createBaseSchema(db: Database.Database) {
+  // Minimal subset of the v3.7 + migrations 020–028 schema: enough tables for
+  // migration 029 to do its job, plus at least one FK-bearing table so the
+  // rebuild will trip FK checks if the pragma isn't handled.
+  db.exec(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT NOT NULL
+    );
+
+    CREATE TABLE nodes (
+      nodeNum INTEGER PRIMARY KEY,
+      nodeId TEXT UNIQUE NOT NULL,
+      longName TEXT,
+      shortName TEXT,
+      hwModel INTEGER,
+      role INTEGER,
+      hopsAway INTEGER,
+      lastMessageHops INTEGER,
+      viaMqtt INTEGER,
+      macaddr TEXT,
+      latitude REAL,
+      longitude REAL,
+      altitude REAL,
+      batteryLevel INTEGER,
+      voltage REAL,
+      channelUtilization REAL,
+      airUtilTx REAL,
+      lastHeard INTEGER,
+      snr REAL,
+      rssi INTEGER,
+      lastTracerouteRequest INTEGER,
+      firmwareVersion TEXT,
+      channel INTEGER,
+      isFavorite INTEGER DEFAULT 0,
+      favoriteLocked INTEGER DEFAULT 0,
+      isIgnored INTEGER DEFAULT 0,
+      mobile INTEGER DEFAULT 0,
+      rebootCount INTEGER,
+      publicKey TEXT,
+      lastMeshReceivedKey TEXT,
+      hasPKC INTEGER,
+      lastPKIPacket INTEGER,
+      keyIsLowEntropy INTEGER,
+      duplicateKeyDetected INTEGER,
+      keyMismatchDetected INTEGER,
+      keySecurityIssueDetails TEXT,
+      isExcessivePackets INTEGER DEFAULT 0,
+      packetRatePerHour INTEGER,
+      packetRateLastChecked INTEGER,
+      isTimeOffsetIssue INTEGER DEFAULT 0,
+      timeOffsetSeconds INTEGER,
+      welcomedAt INTEGER,
+      positionChannel INTEGER,
+      positionPrecisionBits INTEGER,
+      positionGpsAccuracy REAL,
+      positionHdop REAL,
+      positionTimestamp INTEGER,
+      positionOverrideEnabled INTEGER DEFAULT 0,
+      latitudeOverride REAL,
+      longitudeOverride REAL,
+      altitudeOverride REAL,
+      positionOverrideIsPrivate INTEGER DEFAULT 0,
+      hasRemoteAdmin INTEGER DEFAULT 0,
+      lastRemoteAdminCheck INTEGER,
+      remoteAdminMetadata TEXT,
+      lastTimeSync INTEGER,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL,
+      sourceId TEXT
+    );
+
+    CREATE TABLE sources (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL,
+      config TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL,
+      createdBy INTEGER
+    );
+
+    -- FK-bearing table so the rebuild has something to trip on if the
+    -- migration forgets to disable foreign_keys during DROP/RENAME.
+    CREATE TABLE user_notification_preferences (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      pref TEXT,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    );
+  `);
+}
+
+function insertLegacyNode(db: Database.Database, nodeNum: number) {
+  db.prepare(
+    `INSERT INTO nodes (nodeNum, nodeId, createdAt, updatedAt) VALUES (?, ?, ?, ?)`,
+  ).run(nodeNum, `!${nodeNum.toString(16).padStart(8, '0')}`, 1, 1);
+}
+
+describe('Migration 029 — nodes composite PK', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    createBaseSchema(db);
+  });
+
+  it('rebuilds nodes to composite PK even with a pre-existing orphan FK row', () => {
+    // Seed: one user, three legacy nodes with NULL sourceId, no sources yet.
+    db.prepare(`INSERT INTO users (id, username) VALUES (1, 'admin')`).run();
+    insertLegacyNode(db, 100);
+    insertLegacyNode(db, 200);
+    insertLegacyNode(db, 300);
+
+    // Pre-existing orphan row referencing a user that doesn't exist. Simulates
+    // drift that a long-running v3 database might accumulate. Temporarily
+    // disable FKs to plant the row — we're modeling state that already exists
+    // on disk, not testing the normal insert path.
+    db.pragma('foreign_keys = OFF');
+    db.prepare(
+      `INSERT INTO user_notification_preferences (user_id, pref) VALUES (999, 'dark')`,
+    ).run();
+    db.pragma('foreign_keys = ON');
+
+    // Should NOT throw. Before the fix this raised SQLITE_CONSTRAINT_FOREIGNKEY
+    // during the DROP/RENAME phase of the table rebuild.
+    expect(() => migration.up(db)).not.toThrow();
+
+    // Verify the composite PK shape after rebuild.
+    const tableInfo = db.prepare(`PRAGMA table_info(nodes)`).all() as Array<{ name: string; pk: number }>;
+    const pkCols = tableInfo.filter(c => c.pk > 0).map(c => c.name).sort();
+    expect(pkCols).toEqual(['nodeNum', 'sourceId']);
+
+    // The synthesized default source must exist, and all legacy nodes must
+    // now point at it.
+    const srcCount = (db.prepare(`SELECT COUNT(*) c FROM sources`).get() as { c: number }).c;
+    expect(srcCount).toBe(1);
+    const nullSourceCount = (db.prepare(`SELECT COUNT(*) c FROM nodes WHERE sourceId IS NULL`).get() as { c: number }).c;
+    expect(nullSourceCount).toBe(0);
+    const migratedNodeCount = (db.prepare(`SELECT COUNT(*) c FROM nodes`).get() as { c: number }).c;
+    expect(migratedNodeCount).toBe(3);
+  });
+
+  it('restores foreign_keys pragma after the rebuild completes', () => {
+    db.prepare(`INSERT INTO users (id, username) VALUES (1, 'admin')`).run();
+    insertLegacyNode(db, 100);
+
+    expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+    migration.up(db);
+    expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+  });
+
+  it('is idempotent when run a second time', () => {
+    db.prepare(`INSERT INTO users (id, username) VALUES (1, 'admin')`).run();
+    insertLegacyNode(db, 100);
+
+    migration.up(db);
+    // Second run must not throw and must not mutate the already-migrated schema.
+    expect(() => migration.up(db)).not.toThrow();
+
+    const tableInfo = db.prepare(`PRAGMA table_info(nodes)`).all() as Array<{ name: string; pk: number }>;
+    const pkCount = tableInfo.filter(c => c.pk > 0).length;
+    expect(pkCount).toBe(2);
+  });
+});

--- a/src/server/migrations/029_nodes_composite_pk.ts
+++ b/src/server/migrations/029_nodes_composite_pk.ts
@@ -153,6 +153,18 @@ export const migration = {
       WHERE type = 'index' AND tbl_name = 'nodes' AND sql IS NOT NULL
     `).all() as Array<{ name: string; sql: string }>;
 
+    // SQLite's documented table-rebuild pattern REQUIRES foreign_keys=OFF
+    // (https://www.sqlite.org/lang_altertable.html, section "Making Other Kinds
+    // Of Table Schema Changes"). Without this, DROP TABLE / RENAME TABLE can
+    // trip FOREIGN KEY constraint failures from unrelated orphan rows in the
+    // database — we saw this on upgrade with 955 legacy nodes and pre-existing
+    // user_notification_preferences rows. The pragma is a no-op inside an
+    // active transaction, so it MUST be set before tx() runs.
+    const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
+    if (prevForeignKeys) {
+      db.pragma('foreign_keys = OFF');
+    }
+
     const tx = db.transaction(() => {
       // Count nodes requiring backfill (rows with NULL sourceId).
       const nullNodesRow = db.prepare(`SELECT COUNT(*) as c FROM nodes WHERE sourceId IS NULL`).get() as { c: number };
@@ -223,6 +235,22 @@ export const migration = {
 
     try {
       tx();
+
+      // Per SQLite docs: after a table rebuild with FKs disabled, verify that
+      // the rebuild didn't leave any orphaned rows. foreign_key_check returns
+      // one row per violating row — empty result means the schema is healthy.
+      if (prevForeignKeys) {
+        const violations = db.prepare(`PRAGMA foreign_key_check`).all() as Array<{ table: string; rowid: number; parent: string; fkid: number }>;
+        if (violations.length > 0) {
+          // Log but don't fail — these violations pre-existed the migration
+          // and we don't want to prevent the upgrade from completing. The same
+          // rows were already being tolerated before the rebuild.
+          logger.warn(
+            `Migration 029 (SQLite): foreign_key_check reports ${violations.length} pre-existing orphan row(s); tolerating:`,
+            violations.slice(0, 5),
+          );
+        }
+      }
     } catch (err: any) {
       const msg = String(err?.message || err);
       if (/already exists/i.test(msg) || /duplicate column/i.test(msg)) {
@@ -230,6 +258,12 @@ export const migration = {
         return;
       }
       throw err;
+    } finally {
+      // Always restore the original FK state — even on success, we must not
+      // leave the database in a looser mode than we found it.
+      if (prevForeignKeys) {
+        db.pragma('foreign_keys = ON');
+      }
     }
 
     logger.info('Migration 029 complete (SQLite)');

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -256,6 +256,11 @@ router.delete('/:id', requirePermission('sources', 'write'), async (req: Request
 });
 
 // Get source status (connection state from registry)
+//
+// Includes a `nodeCount` field so the dashboard sidebar can show how many nodes
+// each source has heard without having to fetch every source's full node list
+// (the sidebar polls /status for every source on a 15s interval, but the
+// expensive /nodes endpoint is only fetched for the *selected* source).
 router.get('/:id/status', requirePermission('sources', 'read'), async (req: Request, res: Response) => {
   try {
     const source = await databaseService.sources.getSource(req.params.id);
@@ -269,7 +274,9 @@ router.get('/:id/status', requirePermission('sources', 'read'), async (req: Requ
       sourceType: source.type,
       connected: false,
     };
-    res.json(status);
+    // Cheap COUNT(*) — never throws on empty source.
+    const nodeCount = await databaseService.nodes.getNodeCount(source.id).catch(() => 0);
+    res.json({ ...status, nodeCount });
   } catch (error) {
     logger.error('Error fetching source status:', error);
     res.status(500).json({ error: 'Failed to fetch source status' });

--- a/src/server/tcpTransport.test.ts
+++ b/src/server/tcpTransport.test.ts
@@ -77,18 +77,22 @@ describe('TcpTransport — heartbeat (issue 2609)', () => {
     expect(sendSpy).toHaveBeenCalledWith(payload);
   });
 
-  it('updates lastDataReceived on successful heartbeat send (fixes stale detector cycling on quiet nodes)', async () => {
-    // Start the clock an hour in the past so a naive "lastDataReceived" would be ancient
-    (transport as any).lastDataReceived = Date.now() - 3_600_000;
+  it('does NOT update lastDataReceived on heartbeat send (kernel buffers mask dead hosts; liveness must come from the firmware reply)', async () => {
+    // The firmware replies to every ToRadio.heartbeat with a FromRadio.queueStatus.
+    // That reply arrives via handleIncomingData() and refreshes lastDataReceived
+    // naturally. Updating lastDataReceived from the *send* side would mask dead
+    // hosts because socket.write() to a dead remote keeps "succeeding" for many
+    // minutes while the kernel send buffer fills.
+    const initial = Date.now() - 3_600_000;
+    (transport as any).lastDataReceived = initial;
 
     transport.setHeartbeatInterval(5_000, () => new Uint8Array([0x00]));
     (transport as any).startHeartbeat();
 
-    const before = (transport as any).lastDataReceived;
     await vi.advanceTimersByTimeAsync(5_000);
-    const after = (transport as any).lastDataReceived;
 
-    expect(after).toBeGreaterThan(before);
+    expect((transport as any).lastDataReceived).toBe(initial);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
   });
 
   it('does not update lastDataReceived when send throws (so stale detector can still fire on dead links)', async () => {

--- a/src/server/tcpTransport.ts
+++ b/src/server/tcpTransport.ts
@@ -26,13 +26,20 @@ export class TcpTransport extends EventEmitter implements ITransport {
   private readonly HEALTH_CHECK_INTERVAL_MS = 60000; // Check every minute
   private readonly BUFFER_STALE_TIMEOUT_MS = 30000; // 30s: if buffer has data but no frames parsed, reset it
 
-  // Configurable keepalive heartbeat (issue 2609).
-  // When `heartbeatIntervalMs > 0`, the transport calls `heartbeatPayloadFactory()`
-  // on a timer and writes the returned bytes to the socket. This is used to keep
-  // quiet Meshtastic nodes (CLIENT_MUTE) from being declared stale by the
-  // passive-data health check. A successful heartbeat write also resets
-  // `lastDataReceived`, so the heartbeat doubles as the liveness signal for the
-  // stale detector.
+  // Configurable keepalive heartbeat (issues 2609 / 2616).
+  // When `heartbeatIntervalMs > 0`, the transport sends a Meshtastic
+  // `ToRadio.heartbeat` on a timer. The firmware replies to every heartbeat
+  // with a `FromRadio.queueStatus` (local-only, zero radio cost), which arrives
+  // back via `handleIncomingData()` and refreshes `lastDataReceived`. This
+  // gives us a real bidirectional liveness signal:
+  //   - Quiet (CLIENT_MUTE) nodes stay "alive" because the QueueStatus reply
+  //     keeps `lastDataReceived` fresh — fixing the original 2609 cycling.
+  //   - Truly dead hosts STOP replying within ~30s, so the stale detector trips
+  //     in `heartbeatIntervalMs * 3` instead of waiting for the 5-min idle
+  //     timeout or the OS-level TCP keepalive (~12 min).
+  // We must NOT update `lastDataReceived` from the heartbeat *send* itself —
+  // the kernel buffers writes to dead hosts for many minutes, so a "successful"
+  // send proves nothing.
   private heartbeatIntervalMs: number = 0;
   private heartbeatPayloadFactory: (() => Uint8Array | Promise<Uint8Array>) | null = null;
   private heartbeatTimer: NodeJS.Timeout | null = null;
@@ -396,11 +403,17 @@ export class TcpTransport extends EventEmitter implements ITransport {
   }
 
   /**
-   * Start periodic health check for stale connections
+   * Start periodic health check for stale connections.
+   *
+   * When the heartbeat is active, the firmware sends back a `queueStatus` for
+   * every heartbeat we send, so a healthy node refreshes `lastDataReceived` at
+   * least every `heartbeatIntervalMs`. We can therefore poll on a much faster
+   * cadence and trip the stale detector in `heartbeatIntervalMs * 3` rather
+   * than waiting for the default 5-minute idle timeout.
    */
   private startHealthCheck(): void {
     // Don't start if timeout is disabled
-    if (this.staleConnectionTimeout === 0) {
+    if (this.staleConnectionTimeout === 0 && this.heartbeatIntervalMs === 0) {
       logger.debug('⏱️  Stale connection detection disabled (timeout = 0)');
       return;
     }
@@ -408,12 +421,20 @@ export class TcpTransport extends EventEmitter implements ITransport {
     // Stop any existing interval
     this.stopHealthCheck();
 
-    // Start periodic check
+    // When heartbeat is active, check at half the heartbeat interval so we
+    // detect a missed reply within ~1.5 heartbeat intervals.
+    const checkInterval = this.heartbeatIntervalMs > 0
+      ? Math.max(5000, Math.floor(this.heartbeatIntervalMs / 2))
+      : this.HEALTH_CHECK_INTERVAL_MS;
+
     this.healthCheckInterval = setInterval(() => {
       this.checkConnection();
-    }, this.HEALTH_CHECK_INTERVAL_MS);
+    }, checkInterval);
 
-    logger.debug(`⏱️  Stale connection monitoring started (timeout: ${Math.floor(this.staleConnectionTimeout / 1000 / 60)} minutes, check interval: ${this.HEALTH_CHECK_INTERVAL_MS / 1000}s)`);
+    const effectiveTimeoutMs = this.heartbeatIntervalMs > 0
+      ? this.heartbeatIntervalMs * 3
+      : this.staleConnectionTimeout;
+    logger.debug(`⏱️  Stale connection monitoring started (effective timeout: ${Math.floor(effectiveTimeoutMs / 1000)}s, check interval: ${checkInterval / 1000}s, heartbeat: ${this.heartbeatIntervalMs > 0 ? `${this.heartbeatIntervalMs / 1000}s` : 'off'})`);
   }
 
   /**
@@ -456,15 +477,15 @@ export class TcpTransport extends EventEmitter implements ITransport {
       try {
         const payload = await this.heartbeatPayloadFactory();
         await this.send(payload);
-        // Successful heartbeat write counts as fresh activity for the
-        // stale-connection detector. Without this, quiet nodes still cycle.
-        this.lastDataReceived = Date.now();
+        // DO NOT touch lastDataReceived here. socket.write() to a dead host
+        // succeeds for many minutes (kernel buffer), so updating
+        // lastDataReceived on send would mask dead hosts. Liveness comes from
+        // the firmware's `FromRadio.queueStatus` reply, which is received via
+        // handleIncomingData() and refreshes lastDataReceived naturally.
         logger.debug(`💓 Heartbeat sent (${payload.length} bytes)`);
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         logger.warn(`💔 Heartbeat send failed: ${msg}`);
-        // Intentionally do NOT update lastDataReceived on failure — let the
-        // stale detector fire so a truly dead link gets reconnected.
       }
     }, this.heartbeatIntervalMs);
 
@@ -483,28 +504,38 @@ export class TcpTransport extends EventEmitter implements ITransport {
   }
 
   /**
-   * Check if connection has become stale (no data received for too long)
+   * Check if connection has become stale (no data received for too long).
+   *
+   * If a heartbeat is configured, the effective timeout is `heartbeatIntervalMs * 3`
+   * because the firmware replies to every heartbeat with a `FromRadio.queueStatus`.
+   * Missing three consecutive replies means the node is dead.
    */
   private checkConnection(): void {
     if (!this.isConnected) {
       return; // Not connected, nothing to check
     }
 
-    if (this.staleConnectionTimeout === 0) {
+    // Effective timeout: 3x heartbeat interval when heartbeat is on, otherwise
+    // the user-configured idle timeout.
+    const effectiveTimeoutMs = this.heartbeatIntervalMs > 0
+      ? this.heartbeatIntervalMs * 3
+      : this.staleConnectionTimeout;
+
+    if (effectiveTimeoutMs === 0) {
       return; // Timeout disabled
     }
 
     const now = Date.now();
     const timeSinceLastData = now - this.lastDataReceived;
 
-    if (timeSinceLastData > this.staleConnectionTimeout) {
-      const minutesSinceLastData = Math.floor(timeSinceLastData / 1000 / 60);
-      const timeoutMinutes = Math.floor(this.staleConnectionTimeout / 1000 / 60);
+    if (timeSinceLastData > effectiveTimeoutMs) {
+      const secondsSinceLastData = Math.floor(timeSinceLastData / 1000);
+      const timeoutSeconds = Math.floor(effectiveTimeoutMs / 1000);
 
-      logger.warn(`⚠️  Stale connection detected: No data received for ${minutesSinceLastData} minute(s) (timeout: ${timeoutMinutes} minute(s)). Forcing reconnection...`);
+      logger.warn(`⚠️  Stale connection detected: No data received for ${secondsSinceLastData}s (timeout: ${timeoutSeconds}s${this.heartbeatIntervalMs > 0 ? ', heartbeat active' : ''}). Forcing reconnection...`);
 
       // Emit a custom event for stale connection
-      this.emit('stale-connection', { timeSinceLastData, timeout: this.staleConnectionTimeout });
+      this.emit('stale-connection', { timeSinceLastData, timeout: effectiveTimeoutMs });
 
       // Force reconnection by destroying the socket
       if (this.socket) {

--- a/src/services/database.traceroute-filters.test.ts
+++ b/src/services/database.traceroute-filters.test.ts
@@ -4,7 +4,7 @@
  * These tests verify the AND filter logic that runs after nodes are fetched
  * from the database but before the OR/UNION filters are applied.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // The filter logic extracted as pure functions for testability.
 // These mirror the inline filter logic in getNodeNeedingTraceroute / getNodeNeedingTracerouteAsync.
@@ -30,7 +30,20 @@ function applyHopRangeFilter(nodes: TestNode[], enabled: boolean, min: number, m
 }
 
 describe('Auto-Traceroute Filters', () => {
-  const nowSeconds = Math.floor(Date.now() / 1000);
+  // Pin time so the boundary-case "heard 1 hour ago with a 1-hour window"
+  // doesn't flake on slow CI: the `nowSeconds` captured at describe-load and
+  // the `Date.now()` inside applyLastHeardFilter must see the same second.
+  const FIXED_NOW_MS = 1_700_000_000_000;
+  const nowSeconds = Math.floor(FIXED_NOW_MS / 1000);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW_MS);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   // Helper to create a node with lastHeard relative to now
   const makeNode = (nodeNum: number, hoursAgo: number | null, hopsAway: number | null = null): TestNode => ({

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -84,6 +84,7 @@
 /* ── Source cards ────────────────────────────────────────────────────────── */
 
 .dashboard-source-card {
+  position: relative;
   margin: 4px 8px;
   padding: 10px;
   background: var(--ctp-surface0);
@@ -91,6 +92,30 @@
   border: 1px solid transparent;
   cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
+  overflow: hidden;
+}
+
+/* Faint Meshtastic watermark behind the tile. Uses a ::before overlay so it
+   sits behind the content but above the card background, and doesn't steal
+   pointer events from the card's click handler. */
+.dashboard-source-card.has-meshtastic-watermark::before {
+  content: '';
+  position: absolute;
+  right: -10px;
+  bottom: -12px;
+  width: 80px;
+  height: 80px;
+  background-image: url('/meshtastic-icon.svg');
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: bottom right;
+  opacity: 0.06;
+  pointer-events: none;
+  color: var(--ctp-text);
+}
+
+.dashboard-source-card > * {
+  position: relative;
 }
 
 .dashboard-source-card:hover {
@@ -131,6 +156,15 @@
   flex-shrink: 0;
 }
 
+/* Meshtastic type indicator — replaces the verbose "MESHTASTIC_TCP" badge. */
+.dashboard-source-card-type-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--ctp-subtext1);
+  opacity: 0.75;
+}
+
 .dashboard-source-card-status {
   display: flex;
   align-items: center;
@@ -167,12 +201,17 @@
 .dashboard-source-card-actions {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 6px;
   margin-top: 6px;
 }
 
+/* Fixed-width Open button so every source tile has the same shape regardless
+   of how many digits the node count has ("0 nodes" vs "12345 nodes"). The
+   actions row pushes the count and button to opposite ends via space-between. */
 .dashboard-open-btn {
-  flex: 1;
+  flex: 0 0 auto;
+  width: 80px;
   background: var(--ctp-blue);
   color: var(--ctp-base);
   border: none;


### PR DESCRIPTION
## Summary

Three follow-up fixes for 4.0 alpha users:

1. **Migration 029 FK crash (critical upgrade blocker)** — SQLite table rebuild on the `nodes` composite PK was tripping `FOREIGN KEY constraint failed` for users whose v3 databases had accumulated orphan rows in unrelated FK-bearing tables (e.g. `user_notification_preferences` pointing at deleted users). SQLite docs require `foreign_keys = OFF` around CREATE/COPY/DROP/RENAME. Now toggled outside the transaction with `foreign_key_check` afterward (logs pre-existing orphans but tolerates them), and restored in a `finally`. Includes a regression test that seeds an orphan row and reproduces the crash.

2. **TcpTransport heartbeat liveness (#2609 follow-up)** — The heartbeat previously stamped `lastDataReceived` on the *send* side, which masked dead hosts because `socket.write()` to a dead remote keeps "succeeding" for many minutes while the kernel buffer fills. Now relies on the firmware's `FromRadio.queueStatus` reply (sent automatically in response to every `ToRadio.heartbeat`) — quiet CLIENT_MUTE nodes stay alive via the reply, and truly dead hosts are detected in `heartbeatIntervalMs * 3` instead of the 5-minute idle timeout. Health check cadence scales with heartbeat interval. Test updated to assert `lastDataReceived` is NOT bumped on send.

3. **Dashboard UI polish** —
   - Per-source node counts in the sidebar were hard-coded to `0` for every non-selected source. Exposed `nodeCount` on `/api/sources/:id/status` (cheap `COUNT(*)` per poll) and read from the status map. Selected source still uses live `sourceData.nodes.length` for immediate updates.
   - Replaced the `MESHTASTIC_TCP` / `MESHTASTIC_MQTT` text badges with an inline Meshtastic antenna+waves SVG icon; also added a faint watermark of the same icon behind meshtastic source tiles via a `::before` pseudo-element (opacity 0.06).
   - Fixed inconsistent `Open` button width (was `flex: 1` so it shrank based on sibling width — "0 nodes" vs "12345 nodes"). Pinned to fixed `80px` with `space-between` justification.
   - Header `/api/connection` and `/api/poll` now include `sourceId` when inside a `SourceProvider`, so the header status reflects the correct per-source manager instead of the legacy singleton (always disconnected in 4.0).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] Targeted vitest — 13/13 pass (`029_nodes_composite_pk.test.ts` + `tcpTransport.test.ts`)
- [x] Full vitest suite — 4184/4184 pass (211 files)
- [x] `tests/system-tests.sh` — all 11 suites pass (Configuration Import, Quick Start, Security, V1 API, Reverse Proxy, Reverse Proxy+OIDC, Virtual Node CLI, Backup & Restore, DB Migration, DB Backing Consistency, API Exercise across sqlite/postgres/mysql)
- [ ] Manual smoke: upgrade a v3-alpha db with orphan notification_preferences rows → migration 029 runs cleanly
- [ ] Manual smoke: physically disconnect a TCP source → stale detector fires within ~3 heartbeat intervals
- [ ] Manual smoke: multi-source dashboard shows correct per-source node counts, icon badge, and consistent Open button

🤖 Generated with [Claude Code](https://claude.com/claude-code)