### PR TITLE
fix(4.0-alpha): require sourceId on all purge/delete endpoints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3137,6 +3137,7 @@ function App() {
         headers: {
           'Content-Type': 'application/json',
         },
+        body: JSON.stringify({ sourceId }),
       });
 
       if (response.ok) {
@@ -3178,6 +3179,7 @@ function App() {
         headers: {
           'Content-Type': 'application/json',
         },
+        body: JSON.stringify({ sourceId }),
       });
 
       if (response.ok) {
@@ -3218,6 +3220,7 @@ function App() {
         headers: {
           'Content-Type': 'application/json',
         },
+        body: JSON.stringify({ sourceId }),
       });
 
       if (response.ok) {
@@ -3255,6 +3258,7 @@ function App() {
         headers: {
           'Content-Type': 'application/json',
         },
+        body: JSON.stringify({ sourceId }),
       });
 
       if (response.ok) {
@@ -3292,6 +3296,7 @@ function App() {
         headers: {
           'Content-Type': 'application/json',
         },
+        body: JSON.stringify({ sourceId }),
       });
 
       if (response.ok) {
@@ -3328,6 +3333,7 @@ function App() {
         headers: {
           'Content-Type': 'application/json',
         },
+        body: JSON.stringify({ sourceId }),
       });
 
       if (response.ok) {
@@ -3380,6 +3386,7 @@ function App() {
         headers: {
           'Content-Type': 'application/json',
         },
+        body: JSON.stringify({ sourceId }),
       });
 
       if (response.ok) {

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -317,17 +317,21 @@ export class TelemetryRepository extends BaseRepository {
    * Deletes only position-related telemetry types (latitude, longitude, altitude, etc.)
    * Keeps branching: MySQL doesn't support .returning().
    */
-  async purgePositionHistory(nodeNum: number): Promise<number> {
+  async purgePositionHistory(nodeNum: number, sourceId?: string): Promise<number> {
     const positionTypes = [
       'latitude', 'longitude', 'altitude',
       'ground_speed', 'ground_track',
       'estimated_latitude', 'estimated_longitude',
     ];
     const { telemetry } = this.tables;
-    const condition = and(
+    const conditions = [
       eq(telemetry.nodeNum, nodeNum),
-      inArray(telemetry.telemetryType, positionTypes)
-    );
+      inArray(telemetry.telemetryType, positionTypes),
+    ];
+    if (sourceId) {
+      conditions.push(eq(telemetry.sourceId, sourceId));
+    }
+    const condition = and(...conditions);
 
     if (this.isMySQL()) {
       const countResult = await this.db

--- a/src/server/routes/messageRoutes.test.ts
+++ b/src/server/routes/messageRoutes.test.ts
@@ -403,17 +403,39 @@ describe('Message Deletion Routes', () => {
       expect(response.body).toHaveProperty('message', 'Invalid node number');
     });
 
+    it('should return 400 when sourceId is missing', async () => {
+      const app = createApp({ id: 1, username: 'admin', isAdmin: true });
+      const response = await request(app).delete('/api/messages/nodes/123456/traceroutes');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('message', 'sourceId is required');
+    });
+
     it('should successfully purge traceroutes for admin user', async () => {
       const app = createApp({ id: 1, username: 'admin', isAdmin: true });
       mockTraceroutesRepo.deleteTraceroutesForNode.mockResolvedValue(15);
       vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
 
-      const response = await request(app).delete('/api/messages/nodes/123456/traceroutes');
+      const response = await request(app)
+        .delete('/api/messages/nodes/123456/traceroutes')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(200);
       expect(response.body).toHaveProperty('deletedCount', 15);
       expect(response.body).toHaveProperty('message', 'Node traceroutes purged successfully');
-      expect(mockTraceroutesRepo.deleteTraceroutesForNode).toHaveBeenCalledWith(123456);
+      expect(mockTraceroutesRepo.deleteTraceroutesForNode).toHaveBeenCalledWith(123456, 'source-a');
+    });
+
+    it('should scope purge to the provided sourceId', async () => {
+      const app = createApp({ id: 1, username: 'admin', isAdmin: true });
+      mockTraceroutesRepo.deleteTraceroutesForNode.mockResolvedValue(8);
+      vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
+
+      await request(app)
+        .delete('/api/messages/nodes/123456/traceroutes')
+        .send({ sourceId: 'source-b' });
+
+      expect(mockTraceroutesRepo.deleteTraceroutesForNode).toHaveBeenCalledWith(123456, 'source-b');
     });
 
     it('should successfully purge traceroutes for user with messages:write', async () => {
@@ -424,10 +446,12 @@ describe('Message Deletion Routes', () => {
       mockTraceroutesRepo.deleteTraceroutesForNode.mockResolvedValue(8);
       vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
 
-      const response = await request(app).delete('/api/messages/nodes/123456/traceroutes');
+      const response = await request(app)
+        .delete('/api/messages/nodes/123456/traceroutes')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(200);
-      expect(mockTraceroutesRepo.deleteTraceroutesForNode).toHaveBeenCalledWith(123456);
+      expect(mockTraceroutesRepo.deleteTraceroutesForNode).toHaveBeenCalledWith(123456, 'source-a');
     });
 
     it('should log audit event for traceroutes purge', async () => {
@@ -435,7 +459,9 @@ describe('Message Deletion Routes', () => {
       mockTraceroutesRepo.deleteTraceroutesForNode.mockResolvedValue(20);
       const auditLogSpy = vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
 
-      await request(app).delete('/api/messages/nodes/123456/traceroutes');
+      await request(app)
+        .delete('/api/messages/nodes/123456/traceroutes')
+        .send({ sourceId: 'source-a' });
 
       expect(auditLogSpy).toHaveBeenCalledWith(
         1,
@@ -468,17 +494,39 @@ describe('Message Deletion Routes', () => {
       expect(response.body).toHaveProperty('message', 'Invalid node number');
     });
 
+    it('should return 400 when sourceId is missing', async () => {
+      const app = createApp({ id: 1, username: 'admin', isAdmin: true });
+      const response = await request(app).delete('/api/messages/nodes/123456/position-history');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('message', 'sourceId is required');
+    });
+
     it('should successfully purge position history for admin', async () => {
       const app = createApp({ id: 1, username: 'admin', isAdmin: true });
       mockTelemetryRepo.purgePositionHistory.mockResolvedValue(18);
       vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
 
-      const response = await request(app).delete('/api/messages/nodes/123456/position-history');
+      const response = await request(app)
+        .delete('/api/messages/nodes/123456/position-history')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(200);
       expect(response.body).toHaveProperty('deletedCount', 18);
       expect(response.body).toHaveProperty('message', 'Node position history purged successfully');
-      expect(mockTelemetryRepo.purgePositionHistory).toHaveBeenCalledWith(123456);
+      expect(mockTelemetryRepo.purgePositionHistory).toHaveBeenCalledWith(123456, 'source-a');
+    });
+
+    it('should scope purge to the provided sourceId', async () => {
+      const app = createApp({ id: 1, username: 'admin', isAdmin: true });
+      mockTelemetryRepo.purgePositionHistory.mockResolvedValue(3);
+      vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
+
+      await request(app)
+        .delete('/api/messages/nodes/123456/position-history')
+        .send({ sourceId: 'source-b' });
+
+      expect(mockTelemetryRepo.purgePositionHistory).toHaveBeenCalledWith(123456, 'source-b');
     });
 
     it('should log audit event for position history purge', async () => {
@@ -486,7 +534,9 @@ describe('Message Deletion Routes', () => {
       mockTelemetryRepo.purgePositionHistory.mockResolvedValue(5);
       const auditLogSpy = vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
 
-      await request(app).delete('/api/messages/nodes/123456/position-history');
+      await request(app)
+        .delete('/api/messages/nodes/123456/position-history')
+        .send({ sourceId: 'source-a' });
 
       expect(auditLogSpy).toHaveBeenCalledWith(
         1,
@@ -580,17 +630,39 @@ describe('Message Deletion Routes', () => {
       expect(response.body).toHaveProperty('message', 'Invalid node number');
     });
 
+    it('should return 400 when sourceId is missing', async () => {
+      const app = createApp({ id: 1, username: 'admin', isAdmin: true });
+      const response = await request(app).delete('/api/messages/nodes/123456/telemetry');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('message', 'sourceId is required');
+    });
+
     it('should successfully purge telemetry for admin user', async () => {
       const app = createApp({ id: 1, username: 'admin', isAdmin: true });
       mockTelemetryRepo.purgeNodeTelemetry.mockResolvedValue(45);
       vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
 
-      const response = await request(app).delete('/api/messages/nodes/123456/telemetry');
+      const response = await request(app)
+        .delete('/api/messages/nodes/123456/telemetry')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(200);
       expect(response.body).toHaveProperty('deletedCount', 45);
       expect(response.body).toHaveProperty('message', 'Node telemetry purged successfully');
-      expect(mockTelemetryRepo.purgeNodeTelemetry).toHaveBeenCalledWith(123456);
+      expect(mockTelemetryRepo.purgeNodeTelemetry).toHaveBeenCalledWith(123456, 'source-a');
+    });
+
+    it('should scope purge to the provided sourceId', async () => {
+      const app = createApp({ id: 1, username: 'admin', isAdmin: true });
+      mockTelemetryRepo.purgeNodeTelemetry.mockResolvedValue(10);
+      vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
+
+      await request(app)
+        .delete('/api/messages/nodes/123456/telemetry')
+        .send({ sourceId: 'source-b' });
+
+      expect(mockTelemetryRepo.purgeNodeTelemetry).toHaveBeenCalledWith(123456, 'source-b');
     });
 
     it('should successfully purge telemetry for user with messages:write', async () => {
@@ -601,10 +673,12 @@ describe('Message Deletion Routes', () => {
       mockTelemetryRepo.purgeNodeTelemetry.mockResolvedValue(12);
       vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
 
-      const response = await request(app).delete('/api/messages/nodes/123456/telemetry');
+      const response = await request(app)
+        .delete('/api/messages/nodes/123456/telemetry')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(200);
-      expect(mockTelemetryRepo.purgeNodeTelemetry).toHaveBeenCalledWith(123456);
+      expect(mockTelemetryRepo.purgeNodeTelemetry).toHaveBeenCalledWith(123456, 'source-a');
     });
 
     it('should log audit event for telemetry purge', async () => {
@@ -612,7 +686,9 @@ describe('Message Deletion Routes', () => {
       mockTelemetryRepo.purgeNodeTelemetry.mockResolvedValue(30);
       const auditLogSpy = vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
 
-      await request(app).delete('/api/messages/nodes/123456/telemetry');
+      await request(app)
+        .delete('/api/messages/nodes/123456/telemetry')
+        .send({ sourceId: 'source-a' });
 
       expect(auditLogSpy).toHaveBeenCalledWith(
         1,

--- a/src/server/routes/messageRoutes.ts
+++ b/src/server/routes/messageRoutes.ts
@@ -457,9 +457,14 @@ router.delete('/nodes/:nodeNum/traceroutes', requireMessagesWrite, async (req, r
       });
     }
 
-    const deletedCount = await databaseService.traceroutes.deleteTraceroutesForNode(nodeNum);
+    const sourceId = (req.body?.sourceId || req.query?.sourceId) as string | undefined;
+    if (!sourceId) {
+      return res.status(400).json({ error: 'Bad request', message: 'sourceId is required' });
+    }
 
-    logger.info(`🗑️ User ${user?.username || 'anonymous'} purged ${deletedCount} traceroutes for node ${nodeNum}`);
+    const deletedCount = await databaseService.traceroutes.deleteTraceroutesForNode(nodeNum, sourceId);
+
+    logger.info(`🗑️ User ${user?.username || 'anonymous'} purged ${deletedCount} traceroutes for node ${nodeNum} (source=${sourceId})`);
 
     // Log to audit log (async for multi-database support)
     if (user?.id) {
@@ -467,7 +472,7 @@ router.delete('/nodes/:nodeNum/traceroutes', requireMessagesWrite, async (req, r
         user.id,
         'node_traceroutes_purged',
         'traceroute',
-        `Purged ${deletedCount} traceroutes for node ${nodeNum}`,
+        `Purged ${deletedCount} traceroutes for node ${nodeNum} (source=${sourceId})`,
         req.ip || ''
       );
     }
@@ -509,9 +514,14 @@ router.delete('/nodes/:nodeNum/telemetry', requireMessagesWrite, async (req, res
       });
     }
 
-    const deletedCount = await databaseService.telemetry.purgeNodeTelemetry(nodeNum);
+    const sourceId = (req.body?.sourceId || req.query?.sourceId) as string | undefined;
+    if (!sourceId) {
+      return res.status(400).json({ error: 'Bad request', message: 'sourceId is required' });
+    }
 
-    logger.info(`🗑️ User ${user?.username || 'anonymous'} purged ${deletedCount} telemetry records for node ${nodeNum}`);
+    const deletedCount = await databaseService.telemetry.purgeNodeTelemetry(nodeNum, sourceId);
+
+    logger.info(`🗑️ User ${user?.username || 'anonymous'} purged ${deletedCount} telemetry records for node ${nodeNum} (source=${sourceId})`);
 
     // Log to audit log (async for multi-database support)
     if (user?.id) {
@@ -519,7 +529,7 @@ router.delete('/nodes/:nodeNum/telemetry', requireMessagesWrite, async (req, res
         user.id,
         'node_telemetry_purged',
         'telemetry',
-        `Purged ${deletedCount} telemetry records for node ${nodeNum}`,
+        `Purged ${deletedCount} telemetry records for node ${nodeNum} (source=${sourceId})`,
         req.ip || ''
       );
     }
@@ -561,9 +571,14 @@ router.delete('/nodes/:nodeNum/position-history', requireMessagesWrite, async (r
       });
     }
 
-    const deletedCount = await databaseService.telemetry.purgePositionHistory(nodeNum);
+    const sourceId = (req.body?.sourceId || req.query?.sourceId) as string | undefined;
+    if (!sourceId) {
+      return res.status(400).json({ error: 'Bad request', message: 'sourceId is required' });
+    }
 
-    logger.info(`🗑️ User ${user?.username || 'anonymous'} purged ${deletedCount} position history records for node ${nodeNum}`);
+    const deletedCount = await databaseService.telemetry.purgePositionHistory(nodeNum, sourceId);
+
+    logger.info(`🗑️ User ${user?.username || 'anonymous'} purged ${deletedCount} position history records for node ${nodeNum} (source=${sourceId})`);
 
     // Log to audit log (async for multi-database support)
     if (user?.id) {
@@ -571,7 +586,7 @@ router.delete('/nodes/:nodeNum/position-history', requireMessagesWrite, async (r
         user.id,
         'node_position_history_purged',
         'telemetry',
-        `Purged ${deletedCount} position history records for node ${nodeNum}`,
+        `Purged ${deletedCount} position history records for node ${nodeNum} (source=${sourceId})`,
         req.ip || ''
       );
     }


### PR DESCRIPTION
## Summary
- All node purge and delete endpoints now require `sourceId` to scope operations to the correct source, preventing cross-source data deletion in multi-source deployments
- Frontend sends `sourceId` from `SourceContext` on all 7 affected calls: channel purge, DM purge, traceroute purge, telemetry purge, position history purge, node delete, purge-from-device
- Added `sourceId` parameter to `purgePositionHistory` in telemetry repository
- Updated and added tests verifying sourceId is required and forwarded to repositories

## Test plan
- [ ] Verify purging traceroutes for a node sends sourceId (check network tab)
- [ ] Verify purging telemetry for a node sends sourceId
- [ ] Verify purging position history sends sourceId
- [ ] Verify deleting a node sends sourceId
- [ ] Verify purge-from-device sends sourceId
- [ ] Verify all operations return 400 if sourceId is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)