### PR TITLE
feat: add global settings page accessible from dashboard sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 - Always use context7 when I need code generation, setup or configuration steps, or library/API documentation. This means you should automatically use the Context7 MCP tools to resolve library id and get library docs without me having to explicitly ask.
 - Default admin account is username 'admin' and password 'changeme' . Sometime the password is 'changeme1'
-- use serena MCP for code search and analysis without me explicitly having to ask.
+- use serena MCP for code search and analysis without me explicitly having to ask. Prefer Serena's symbolic tools (`find_symbol`, `get_symbols_overview`, `find_referencing_symbols`, `search_for_pattern`) over grep/Grep for navigating code — they understand symbol relationships and are more precise.
 - use superpowers for planning and workflow management without me having to ask
 - IMPORTANT: Review docs/ARCHITECTURE_LESSONS.md before implementing node communication, state management, backup/restore, asynchronous operations, or database changes. These patterns prevent common mistakes.
 - Only the backend talks to the Node. the Frontend never talks directly to the node.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4834,6 +4834,7 @@ function App() {
         {activeTab === 'settings' && (
           <ErrorBoundary fallbackTitle="Settings failed to load">
           <SettingsTab
+            mode="source"
             maxNodeAgeHours={maxNodeAgeHours}
             inactiveNodeThresholdHours={inactiveNodeThresholdHours}
             inactiveNodeCheckIntervalMinutes={inactiveNodeCheckIntervalMinutes}

--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -4,6 +4,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { version } from '../../../package.json';
 import type { DashboardSource, SourceStatus } from '../../hooks/useDashboardData';
 
 interface DashboardSidebarProps {
@@ -233,6 +234,46 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
         >
           📡 Unified Telemetry
         </button>
+      </div>
+
+      <div className="dashboard-sidebar-footer">
+        <span className="dashboard-sidebar-version">v{version}</span>
+        <div className="dashboard-sidebar-footer-icons">
+          {isAdmin && (
+            <button
+              className="dashboard-sidebar-footer-btn"
+              title="Settings"
+              onClick={() => navigate('/settings')}
+            >
+              ⚙️
+            </button>
+          )}
+          <button
+            className="dashboard-sidebar-footer-btn"
+            title="News"
+            disabled
+          >
+            📰
+          </button>
+          <a
+            className="dashboard-sidebar-footer-btn"
+            href="https://github.com/Yeraze/meshmonitor"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="GitHub"
+          >
+            🐙
+          </a>
+          <a
+            className="dashboard-sidebar-footer-btn"
+            href="https://meshmonitor.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Website"
+          >
+            🔗
+          </a>
+        </div>
       </div>
     </aside>
   );

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -87,7 +87,20 @@ interface SettingsTabProps {
   onSolarMonitoringLongitudeChange: (longitude: number) => void;
   onSolarMonitoringAzimuthChange: (azimuth: number) => void;
   onSolarMonitoringDeclinationChange: (declination: number) => void;
+  mode?: 'global' | 'source';
 }
+
+const GLOBAL_SECTIONS = new Set([
+  'settings-language', 'settings-units', 'settings-appearance', 'settings-map',
+  'settings-backup', 'settings-maintenance', 'settings-auto-upgrade', 'settings-analytics',
+]);
+
+const SOURCE_SECTIONS = new Set([
+  'settings-sorting', 'settings-node-display', 'settings-telemetry',
+  'settings-notifications', 'settings-packet-monitor', 'settings-solar',
+  'settings-firmware', 'settings-reset-ui', 'settings-source-overrides',
+  'settings-management', 'settings-danger',
+]);
 
 const SettingsTab: React.FC<SettingsTabProps> = ({
   maxNodeAgeHours,
@@ -138,8 +151,12 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   onSolarMonitoringLatitudeChange,
   onSolarMonitoringLongitudeChange,
   onSolarMonitoringAzimuthChange,
-  onSolarMonitoringDeclinationChange
+  onSolarMonitoringDeclinationChange,
+  mode
 }) => {
+  const show = (sectionId: string) =>
+    !mode || (mode === 'global' ? GLOBAL_SECTIONS.has(sectionId) : SOURCE_SECTIONS.has(sectionId));
+
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { authStatus } = useAuth();
@@ -918,9 +935,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         ...(sourceCount >= 2 ? [{ id: 'settings-source-overrides', label: t('settings.source_overrides', 'Source Overrides') }] : []),
         { id: 'settings-management', label: t('settings.settings_management') },
         { id: 'settings-danger', label: t('settings.danger_zone') },
-      ]} />
+      ].filter(item => show(item.id))} />
       <div className="settings-content settings-multi-column">
-        <div id="settings-language" className="settings-section">
+        {show('settings-language') && <div id="settings-language" className="settings-section">
           <h3>{t('settings.language')}</h3>
           <div className="setting-item">
             <label htmlFor="language">
@@ -942,9 +959,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               Weblate
             </a>
           </p>
-        </div>
+        </div>}
 
-        <div id="settings-units" className="settings-section">
+        {show('settings-units') && <div id="settings-units" className="settings-section">
           <h3>{t('settings.units_and_formats')}</h3>
           <div className="setting-item">
             <label htmlFor="timeFormat">
@@ -1007,9 +1024,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               <option value="mi">{t('settings.dist_mi')}</option>
             </select>
           </div>
-        </div>
+        </div>}
 
-        <div id="settings-sorting" className="settings-section">
+        {show('settings-sorting') && <div id="settings-sorting" className="settings-section">
           <h3>{t('settings.sorting')}</h3>
           <div className="setting-item">
             <label htmlFor="preferredSortField">
@@ -1065,9 +1082,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               <option value="type-desc">{t('settings.dashboard_sort_type_desc')}</option>
             </select>
           </div>
-        </div>
+        </div>}
 
-        <div id="settings-appearance" className="settings-section">
+        {show('settings-appearance') && <div id="settings-appearance" className="settings-section">
           <h3>{t('settings.appearance')}</h3>
           <div className="setting-item">
             <label htmlFor="theme">
@@ -1146,9 +1163,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
             </select>
           </div>
           <TapbackEmojiSettings />
-        </div>
+        </div>}
 
-        <div id="settings-map" className="settings-section">
+        {show('settings-map') && <div id="settings-map" className="settings-section">
           <h3>{t('settings.map')}</h3>
           <div className="setting-item">
             <label htmlFor="mapTileset">
@@ -1237,9 +1254,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               <EmbedSettings />
             </div>
           )}
-        </div>
+        </div>}
 
-        <div id="settings-node-display" className="settings-section">
+        {show('settings-node-display') && <div id="settings-node-display" className="settings-section">
           <h3>{t('settings.node_display')}</h3>
           <div className="setting-item">
             <label htmlFor="maxNodeAge">
@@ -1396,9 +1413,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               </div>
             </>
           )}
-        </div>
+        </div>}
 
-        <div id="settings-telemetry" className="settings-section">
+        {show('settings-telemetry') && <div id="settings-telemetry" className="settings-section">
           <h3>{t('settings.telemetry')}</h3>
           <div className="setting-item">
             <label htmlFor="telemetryVisualizationHours">
@@ -1430,9 +1447,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               className="setting-input"
             />
           </div>
-        </div>
+        </div>}
 
-        <div id="settings-notifications" className="settings-section">
+        {show('settings-notifications') && <div id="settings-notifications" className="settings-section">
           <h3>{t('settings.notifications_and_security')}</h3>
           <div className="setting-item">
             <label>
@@ -1462,9 +1479,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               <span className="setting-description">{t('settings.homoglyph_description')}</span>
             </label>
           </div>
-        </div>
+        </div>}
 
-        <div id="settings-packet-monitor" className="settings-section">
+        {show('settings-packet-monitor') && <div id="settings-packet-monitor" className="settings-section">
           <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
             <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: 0, cursor: 'pointer' }}>
               <input
@@ -1487,9 +1504,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               onMaxAgeHoursChange={setLocalPacketLogMaxAgeHours}
             />
           </div>
-        </div>
+        </div>}
 
-        <div id="settings-solar" className="settings-section">
+        {show('settings-solar') && <div id="settings-solar" className="settings-section">
           <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
             <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', margin: 0, cursor: 'pointer' }}>
               <input
@@ -1590,19 +1607,19 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               </div>
             </>
           )}
-        </div>
+        </div>}
 
-        <div id="settings-backup">
+        {show('settings-backup') && <div id="settings-backup">
           <SystemBackupSection />
-        </div>
+        </div>}
 
-        <DatabaseMaintenanceSection />
+        {show('settings-maintenance') && <DatabaseMaintenanceSection />}
 
-        <AutoUpgradeTestSection baseUrl={baseUrl} />
+        {show('settings-auto-upgrade') && <AutoUpgradeTestSection baseUrl={baseUrl} />}
 
-        {isAdmin && firmwareOtaEnabled && <FirmwareUpdateSection baseUrl={baseUrl} />}
+        {show('settings-firmware') && isAdmin && firmwareOtaEnabled && <FirmwareUpdateSection baseUrl={baseUrl} />}
 
-        <div id="settings-reset-ui" className="settings-section">
+        {show('settings-reset-ui') && <div id="settings-reset-ui" className="settings-section">
           <h3>{t('settings.reset_ui_positions')}</h3>
           <p className="setting-description">{t('settings.reset_ui_positions_description')}</p>
           <button
@@ -1620,9 +1637,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           >
             {t('settings.reset_ui_positions_button')}
           </button>
-        </div>
+        </div>}
 
-        {isAdmin && (
+        {show('settings-analytics') && isAdmin && (
         <div id="settings-analytics" className="settings-section">
           <h3>{t('settings.analytics')}</h3>
 
@@ -1766,13 +1783,13 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         </div>
         )}
 
-        <SourceSettingsPanel
+        {show('settings-source-overrides') && <SourceSettingsPanel
           baseUrl={baseUrl}
           globalMaxNodeAgeHours={maxNodeAgeHours}
           globalTracerouteIntervalMinutes={60}
-        />
+        />}
 
-        <div id="settings-management" className="settings-section">
+        {show('settings-management') && <div id="settings-management" className="settings-section">
           <h3>{t('settings.settings_management')}</h3>
           <p className="setting-description">{t('settings.settings_management_description')}</p>
           <div className="settings-buttons">
@@ -1784,9 +1801,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               {t('settings.reset_defaults')}
             </button>
           </div>
-        </div>
+        </div>}
 
-        <div id="settings-danger" className="settings-section danger-zone">
+        {show('settings-danger') && <div id="settings-danger" className="settings-section danger-zone">
           <h3>⚠️ {t('settings.danger_zone')}</h3>
           <p className="danger-zone-description">{t('settings.danger_zone_description')}</p>
 
@@ -1861,7 +1878,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               </button>
             </div>
           )}
-        </div>
+        </div>}
       </div>
     </div>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,6 +15,7 @@ import DashboardPage from './pages/DashboardPage.tsx';
 import AnalysisPage from './pages/AnalysisPage.tsx';
 import UnifiedMessagesPage from './pages/UnifiedMessagesPage.tsx';
 import UnifiedTelemetryPage from './pages/UnifiedTelemetryPage.tsx';
+import GlobalSettingsPage from './pages/GlobalSettingsPage.tsx';
 import './index.css';
 import { AuthProvider } from './contexts/AuthContext';
 import { CsrfProvider } from './contexts/CsrfContext';
@@ -88,6 +89,12 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
             <Route
               path="analysis"
               element={sharedProviders(<AnalysisPage />)}
+            />
+
+            {/* Global settings */}
+            <Route
+              path="settings"
+              element={sharedProviders(<GlobalSettingsPage />)}
             />
 
             {/* Dashboard / landing page */}

--- a/src/pages/GlobalSettingsPage.tsx
+++ b/src/pages/GlobalSettingsPage.tsx
@@ -1,0 +1,155 @@
+/**
+ * GlobalSettingsPage — standalone page for global (non-source-specific) settings.
+ *
+ * Renders SettingsTab in `mode="global"` so only global sections are shown:
+ * Language, Units & Formats, Appearance, Map, System Backup, Database
+ * Maintenance, Auto-Upgrade, and Analytics.
+ */
+
+import { useNavigate } from 'react-router-dom';
+import { SettingsProvider, useSettings } from '../contexts/SettingsContext';
+import { UIProvider } from '../contexts/UIContext';
+import { SaveBarProvider } from '../contexts/SaveBarContext';
+import { ToastProvider } from '../components/ToastContainer';
+import { SaveBar } from '../components/SaveBar';
+import SettingsTab from '../components/SettingsTab';
+import { appBasename } from '../init';
+import '../styles/settings.css';
+
+function GlobalSettingsInner() {
+  const navigate = useNavigate();
+  const {
+    maxNodeAgeHours,
+    inactiveNodeThresholdHours,
+    inactiveNodeCheckIntervalMinutes,
+    inactiveNodeCooldownHours,
+    temperatureUnit,
+    distanceUnit,
+    positionHistoryLineStyle,
+    telemetryVisualizationHours,
+    favoriteTelemetryStorageDays,
+    preferredSortField,
+    preferredSortDirection,
+    timeFormat,
+    dateFormat,
+    mapTileset,
+    mapPinStyle,
+    iconStyle,
+    theme,
+    language,
+    solarMonitoringEnabled,
+    solarMonitoringLatitude,
+    solarMonitoringLongitude,
+    solarMonitoringAzimuth,
+    solarMonitoringDeclination,
+    setMaxNodeAgeHours,
+    setInactiveNodeThresholdHours,
+    setInactiveNodeCheckIntervalMinutes,
+    setInactiveNodeCooldownHours,
+    setTemperatureUnit,
+    setDistanceUnit,
+    setPositionHistoryLineStyle,
+    setTelemetryVisualizationHours,
+    setFavoriteTelemetryStorageDays,
+    setPreferredSortField,
+    setPreferredSortDirection,
+    setTimeFormat,
+    setDateFormat,
+    setMapTileset,
+    setMapPinStyle,
+    setIconStyle,
+    setTheme,
+    setLanguage,
+    setSolarMonitoringEnabled,
+    setSolarMonitoringLatitude,
+    setSolarMonitoringLongitude,
+    setSolarMonitoringAzimuth,
+    setSolarMonitoringDeclination,
+  } = useSettings();
+
+  return (
+    <div style={{ maxWidth: 1200, margin: '0 auto', padding: '1rem' }}>
+      <button
+        onClick={() => navigate('/')}
+        style={{
+          background: 'none',
+          border: 'none',
+          color: 'var(--accent-color)',
+          cursor: 'pointer',
+          fontSize: '0.9rem',
+          marginBottom: '0.5rem',
+          padding: 0,
+        }}
+      >
+        ← Back to Dashboard
+      </button>
+      <SettingsTab
+        mode="global"
+        maxNodeAgeHours={maxNodeAgeHours}
+        inactiveNodeThresholdHours={inactiveNodeThresholdHours}
+        inactiveNodeCheckIntervalMinutes={inactiveNodeCheckIntervalMinutes}
+        inactiveNodeCooldownHours={inactiveNodeCooldownHours}
+        temperatureUnit={temperatureUnit}
+        distanceUnit={distanceUnit}
+        positionHistoryLineStyle={positionHistoryLineStyle}
+        telemetryVisualizationHours={telemetryVisualizationHours}
+        favoriteTelemetryStorageDays={favoriteTelemetryStorageDays}
+        preferredSortField={preferredSortField}
+        preferredSortDirection={preferredSortDirection}
+        timeFormat={timeFormat}
+        dateFormat={dateFormat}
+        mapTileset={mapTileset}
+        mapPinStyle={mapPinStyle}
+        iconStyle={iconStyle}
+        theme={theme}
+        language={language}
+        solarMonitoringEnabled={solarMonitoringEnabled}
+        solarMonitoringLatitude={solarMonitoringLatitude}
+        solarMonitoringLongitude={solarMonitoringLongitude}
+        solarMonitoringAzimuth={solarMonitoringAzimuth}
+        solarMonitoringDeclination={solarMonitoringDeclination}
+        currentNodeId=""
+        nodes={[]}
+        baseUrl={appBasename}
+        onMaxNodeAgeChange={setMaxNodeAgeHours}
+        onInactiveNodeThresholdHoursChange={setInactiveNodeThresholdHours}
+        onInactiveNodeCheckIntervalMinutesChange={setInactiveNodeCheckIntervalMinutes}
+        onInactiveNodeCooldownHoursChange={setInactiveNodeCooldownHours}
+        onTemperatureUnitChange={setTemperatureUnit}
+        onDistanceUnitChange={setDistanceUnit}
+        onPositionHistoryLineStyleChange={setPositionHistoryLineStyle}
+        onTelemetryVisualizationChange={setTelemetryVisualizationHours}
+        onFavoriteTelemetryStorageDaysChange={setFavoriteTelemetryStorageDays}
+        onPreferredSortFieldChange={setPreferredSortField}
+        onPreferredSortDirectionChange={setPreferredSortDirection}
+        onTimeFormatChange={setTimeFormat}
+        onDateFormatChange={setDateFormat}
+        onMapTilesetChange={setMapTileset}
+        onMapPinStyleChange={setMapPinStyle}
+        onIconStyleChange={setIconStyle}
+        onThemeChange={setTheme}
+        onLanguageChange={setLanguage}
+        onSolarMonitoringEnabledChange={setSolarMonitoringEnabled}
+        onSolarMonitoringLatitudeChange={setSolarMonitoringLatitude}
+        onSolarMonitoringLongitudeChange={setSolarMonitoringLongitude}
+        onSolarMonitoringAzimuthChange={setSolarMonitoringAzimuth}
+        onSolarMonitoringDeclinationChange={setSolarMonitoringDeclination}
+      />
+    </div>
+  );
+}
+
+export default function GlobalSettingsPage() {
+  return (
+    <SettingsProvider>
+      <UIProvider>
+        <ToastProvider>
+          <SaveBarProvider>
+            <GlobalSettingsInner />
+            <SaveBar />
+          </SaveBarProvider>
+        </ToastProvider>
+      </UIProvider>
+    </SettingsProvider>
+  );
+}

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -330,6 +330,52 @@
   color: var(--ctp-sapphire);
 }
 
+/* ── Sidebar footer ─────────────────────────────────────────────────────── */
+
+.dashboard-sidebar-footer {
+  padding: 8px 12px;
+  border-top: 1px solid var(--ctp-surface0);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.dashboard-sidebar-version {
+  font-size: 10px;
+  color: var(--ctp-subtext0);
+  opacity: 0.6;
+}
+
+.dashboard-sidebar-footer-icons {
+  display: flex;
+  gap: 6px;
+}
+
+.dashboard-sidebar-footer-btn {
+  background: none;
+  border: none;
+  padding: 4px 6px;
+  font-size: 14px;
+  cursor: pointer;
+  border-radius: 4px;
+  color: var(--ctp-subtext0);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s;
+}
+
+.dashboard-sidebar-footer-btn:hover:not(:disabled) {
+  background-color: var(--ctp-surface0);
+}
+
+.dashboard-sidebar-footer-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
 /* ── Map panel ───────────────────────────────────────────────────────────── */
 
 .dashboard-map-container {


### PR DESCRIPTION
## Summary

Split the monolithic `SettingsTab` into global and per-source modes so instance-wide settings (theme, locale, backups, maintenance, etc.) are managed from the dashboard rather than buried inside a single source context. Adds a sidebar footer bar on the dashboard with version, a Settings gear (admin only), and quick links.

This untangles a long-standing mismatch in the multi-source architecture: settings like Language, Appearance, Map tiles, System Backups, and Database Maintenance apply to the whole instance, not to one Meshtastic source, so they do not belong inside a `/source/:id` context.

## Changes

- `SettingsTab` accepts a new `mode?: 'global' | 'source'` prop and filters sections via a `show()` helper backed by `GLOBAL_SECTIONS` / `SOURCE_SECTIONS` sets
- Global mode shows: Language, Units & Formats, Appearance, Map, System Backup, Database Maintenance, Auto-Upgrade Testing, Analytics
- Source mode shows: Sorting, Node Display, Telemetry, Notifications & Security, Packet Monitor, Solar Monitoring, Firmware Updates, Reset UI Positions, Danger Zone
- New `src/pages/GlobalSettingsPage.tsx` at route `/settings`, wrapping `SettingsTab` with the full provider chain (`SettingsProvider`, `UIProvider`, `ToastProvider`, `SaveBarProvider`, plus `<SaveBar />`)
- `src/main.tsx` adds the `/settings` route
- `DashboardSidebar` gets a footer bar with version string, Settings gear (gated on `isAdmin`), News placeholder (disabled), GitHub link, Website link
- `dashboard.css` adds styles for the footer bar
- `src/App.tsx` passes `mode='source'` to the per-source `SettingsTab`
- `CLAUDE.md`: prefer Serena symbolic tools (`find_symbol`, `get_symbols_overview`, `find_referencing_symbols`, `search_for_pattern`) over grep

## Issues Resolved

None — groundwork for the 4.0 multi-source architecture.

## Documentation Updates

No user-facing docs updated. Feature docs for Settings will be updated when the 4.0 multi-source UI lands.

## Testing

- [x] Unit tests pass (4190 tests, 0 failures)
- [x] TypeScript compiles cleanly
- [x] Dev container rebuilt and `/settings` route verified in browser
- [ ] Admin: visit dashboard, click gear in sidebar footer → see global-only sections
- [ ] Non-admin: gear button is hidden in sidebar footer
- [ ] Per-source settings (`/source/:id` → Settings) still works and shows only source-scoped sections
- [ ] Verify Back to Dashboard button returns to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)