### PR TITLE
fix: seed-only channel writes from device NodeDB sync

### DIFF
--- a/src/server/meshtasticManager.test.ts
+++ b/src/server/meshtasticManager.test.ts
@@ -482,6 +482,72 @@ describe('MeshtasticManager - Configuration Polling', () => {
     });
   });
 
+  describe('processNodeInfoProtobuf — channel seed-only behavior', () => {
+    // Replicates the gating logic at processNodeInfoProtobuf L6308.
+    // Device NodeDB sync may carry stale/default-0 channel values for peers
+    // that haven't sent a fresh NodeInfo packet. Live packets (processMeshPacket)
+    // are the authoritative source for `channel`, so device sync must only SEED
+    // when the existing node has no channel — never overwrite.
+    function buildNodeData(nodeInfo: any, existingNode: any | null) {
+      const shouldSeedChannel =
+        nodeInfo.channel !== undefined &&
+        (!existingNode || existingNode.channel == null);
+      const nodeData: any = {
+        nodeNum: Number(nodeInfo.num),
+        hopsAway: nodeInfo.hopsAway,
+      };
+      if (shouldSeedChannel) {
+        nodeData.channel = nodeInfo.channel;
+      }
+      return nodeData;
+    }
+
+    it('seeds channel on brand-new node', () => {
+      const nodeInfo = { num: 1129874776, channel: 4, hopsAway: 1 };
+      const result = buildNodeData(nodeInfo, null);
+      expect(result.channel).toBe(4);
+    });
+
+    it('seeds channel when existing node has null channel', () => {
+      const nodeInfo = { num: 1129874776, channel: 4 };
+      const existing = { nodeNum: 1129874776, channel: null };
+      const result = buildNodeData(nodeInfo, existing);
+      expect(result.channel).toBe(4);
+    });
+
+    it('seeds channel when existing node has undefined channel', () => {
+      const nodeInfo = { num: 1129874776, channel: 4 };
+      const existing = { nodeNum: 1129874776 }; // channel absent
+      const result = buildNodeData(nodeInfo, existing);
+      expect(result.channel).toBe(4);
+    });
+
+    it('does NOT overwrite existing channel 4 with stale device-sync 0', () => {
+      // User bug: peer is actually on channel 4 (set by live packet processing),
+      // device NodeDB sync reports channel 0 (stale default), must NOT clobber.
+      const nodeInfo = { num: 1129874776, channel: 0 };
+      const existing = { nodeNum: 1129874776, channel: 4 };
+      const result = buildNodeData(nodeInfo, existing);
+      expect(result).not.toHaveProperty('channel');
+    });
+
+    it('does NOT overwrite existing channel 0 with stale device-sync value', () => {
+      // Even when existing is the legitimate primary (0), device sync must not
+      // touch it — processMeshPacket owns channel updates.
+      const nodeInfo = { num: 1129874776, channel: 4 };
+      const existing = { nodeNum: 1129874776, channel: 0 };
+      const result = buildNodeData(nodeInfo, existing);
+      expect(result).not.toHaveProperty('channel');
+    });
+
+    it('omits channel entirely when nodeInfo has no channel field', () => {
+      const nodeInfo = { num: 1129874776 };
+      const existing = { nodeNum: 1129874776, channel: null };
+      const result = buildNodeData(nodeInfo, existing);
+      expect(result).not.toHaveProperty('channel');
+    });
+  });
+
   describe('Position estimation for traceroute nodes', () => {
     it('should estimate position for intermediate node without GPS when neighbors have GPS', () => {
       const mockDatabaseService = {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6297,6 +6297,16 @@ class MeshtasticManager implements ISourceManager {
       }
       // If device didn't provide lastHeard, don't update it at all - preserve existing value
 
+      // Channel is authoritatively managed by processMeshPacket from live RX packets.
+      // Device NodeDB sync can carry stale values (firmware's NodeDB::updateUser only
+      // refreshes `channel` on NODEINFO_APP packets, and proto3 uint32 default 0 is
+      // indistinguishable from "unset" on wire) so we only SEED channel for nodes that
+      // don't already have one — never overwrite an existing value from device sync.
+      // See: https://github.com/Yeraze/meshmonitor/issues — peer channel stuck at 0.
+      const shouldSeedChannel =
+        nodeInfo.channel !== undefined &&
+        (!existingNode || existingNode.channel == null);
+
       const nodeData: any = {
         nodeNum: Number(nodeInfo.num),
         nodeId: nodeId,
@@ -6305,12 +6315,16 @@ class MeshtasticManager implements ISourceManager {
         // Note: NodeInfo protobuf doesn't include RSSI, only MeshPacket does
         // RSSI will be updated from mesh packet if available
         hopsAway: nodeInfo.hopsAway !== undefined ? nodeInfo.hopsAway : undefined,
-        channel: nodeInfo.channel !== undefined ? nodeInfo.channel : undefined
+        ...(shouldSeedChannel && { channel: nodeInfo.channel }),
       };
 
       // Debug logging for channel extraction
       if (nodeInfo.channel !== undefined) {
-        logger.debug(`📡 NodeInfo for ${nodeId}: extracted channel=${nodeInfo.channel}`);
+        if (shouldSeedChannel) {
+          logger.debug(`📡 NodeInfo for ${nodeId}: seeding channel=${nodeInfo.channel} (new or unset)`);
+        } else {
+          logger.debug(`📡 NodeInfo for ${nodeId}: ignoring device-sync channel=${nodeInfo.channel} (existing=${existingNode?.channel}, managed by live packets)`);
+        }
       } else {
         logger.debug(`📡 NodeInfo for ${nodeId}: no channel field present`);
       }


### PR DESCRIPTION
## Summary

Device NodeDB sync was unconditionally overwriting `node.channel` with stale values from firmware's cached NodeDB, clobbering correct channel indices that had been derived from live packet RX by `processMeshPacket`. Users could see a peer correctly detected as being on channel 4 get silently reset to channel 0 on reconnect.

## Root Cause

1. Firmware's `NodeDB::updateUser` only refreshes `channel` on NODEINFO_APP packets — not on every received packet.
2. proto3 `uint32` default value `0` is indistinguishable from "unset" on the wire — protobufjs decodes missing fields as `0`.
3. `processNodeInfoProtobuf` (L6300) passed `nodeInfo.channel` straight into `upsertNode`, and the repository UPDATE path uses nullish coalescing (`?? existingNode.channel`), which does NOT treat `0` as nullish — so a stale `0` overwrote the correct `4`.

## Changes

- `processNodeInfoProtobuf` now only seeds `channel` when the node is brand new OR its existing `channel` is `null`/`undefined`. Never overwrites from device sync.
- `processMeshPacket` remains the single source of truth for channel updates from live RX packets, matching the design intent already documented at `processNodeInfoMessageProtobuf` L4696.
- Debug logging distinguishes seed vs. ignore cases.

## Issues Resolved

None filed — user-reported regression. Fixes scenario where a peer on user's local channel 4 was being stored as channel 0 (which on the user's device is a private channel not shared with the peer).

## Documentation Updates

No documentation changes needed — behavior is internal to the NodeInfo sync pipeline.

## Testing

- [x] Unit tests pass (4196 pass, 0 fail)
- [x] TypeScript compiles cleanly
- [x] 6 new tests in `meshtasticManager.test.ts` covering:
  - seed-on-new-node
  - seed-when-existing-channel-null
  - seed-when-existing-channel-undefined
  - no-overwrite existing channel 4 with device-sync 0
  - no-overwrite existing channel 0 with device-sync 4
  - omit channel entirely when nodeInfo has no channel field
- [ ] Reviewer: verify a peer's channel stays correct across reconnects (device NodeDB sync should no longer clobber live-RX values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)