### PR TITLE
feat: unified messages view with per-source isolation fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1561,7 +1561,7 @@ function App() {
     setChannelLoadingMore(prev => ({ ...prev, [selectedChannel]: true }));
 
     try {
-      const result = await api.getChannelMessages(selectedChannel, 100, offset);
+      const result = await api.getChannelMessages(selectedChannel, 100, offset, sourceId);
 
       if (result.messages.length > 0) {
         // Process timestamps for new messages
@@ -1632,7 +1632,7 @@ function App() {
     setDmLoadingMore(prev => ({ ...prev, [dmKey]: true }));
 
     try {
-      const result = await api.getDirectMessages(currentNodeId, selectedDMNode, 100, offset);
+      const result = await api.getDirectMessages(currentNodeId, selectedDMNode, 100, offset, sourceId);
 
       if (result.messages.length > 0) {
         // Process timestamps for new messages

--- a/src/components/Dashboard/DashboardSidebar.test.tsx
+++ b/src/components/Dashboard/DashboardSidebar.test.tsx
@@ -102,7 +102,7 @@ describe('DashboardSidebar', () => {
 
   it('shows sidebar navigation links', () => {
     renderSidebar();
-    expect(screen.getByText(/Unified Messages.*coming soon/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /💬 Unified Messages/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /📡 Unified Telemetry/ })).toBeInTheDocument();
   });
 

--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -244,9 +244,12 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
       })}
 
       <div className="dashboard-sidebar-links">
-        <span className="dashboard-sidebar-link coming-soon">
-          💬 Unified Messages (coming soon)
-        </span>
+        <button
+          className="dashboard-sidebar-link dashboard-sidebar-link--active"
+          onClick={() => navigate('/unified/messages')}
+        >
+          💬 Unified Messages
+        </button>
         <button
           className="dashboard-sidebar-link dashboard-sidebar-link--active"
           onClick={() => navigate('/unified/telemetry')}

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 30 migrations registered', () => {
-    expect(registry.count()).toBe(30);
+  it('has all 31 migrations registered', () => {
+    expect(registry.count()).toBe(31);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,14 +12,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_source_id_to_route_segments', () => {
+  it('last migration is drop_legacy_nodes_unique', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(30);
-    expect(last.name).toContain('add_source_id_to_route_segments');
+    expect(last.number).toBe(31);
+    expect(last.name).toContain('drop_legacy_nodes_unique');
   });
 
-  it('migrations are sequentially numbered from 1 to 30', () => {
+  it('migrations are sequentially numbered from 1 to 31', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,7 +1,7 @@
 /**
  * Migration Registry Barrel File
  *
- * Registers all 22 migrations in sequential order for use by the migration runner.
+ * Registers all 31 migrations in sequential order for use by the migration runner.
  * Migration 001 is the v3.7 baseline (selfIdempotent — handles its own detection).
  * Migrations 002-011 were originally 078-087 and retain their original settingsKeys
  * for upgrade compatibility.
@@ -42,6 +42,7 @@ import { migration as addSourceIdToKeyRepairLogMigration, runMigration027Postgre
 import { migration as addSourceIdToNotificationsMigration, runMigration028Postgres, runMigration028Mysql } from '../server/migrations/028_add_source_id_to_notifications.js';
 import { migration as nodesCompositePkMigration, runMigration029Postgres, runMigration029Mysql } from '../server/migrations/029_nodes_composite_pk.js';
 import { migration as addSourceIdToRouteSegmentsMigration, runMigration030Postgres, runMigration030Mysql } from '../server/migrations/030_add_source_id_to_route_segments.js';
+import { migration as dropLegacyNodesUniqueMigration, runMigration031Postgres, runMigration031Mysql } from '../server/migrations/031_drop_legacy_nodes_unique.js';
 
 // ============================================================================
 // Registry
@@ -434,4 +435,21 @@ registry.register({
   sqlite: (db) => addSourceIdToRouteSegmentsMigration.up(db),
   postgres: (client) => runMigration030Postgres(client),
   mysql: (pool) => runMigration030Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 031: Drop legacy standalone UNIQUE on nodes.nodeId.
+// Migration 029's Postgres path used an ILIKE pattern against
+// pg_get_constraintdef that failed to match the quoted column name, so the
+// old constraint survived on upgraded databases and blocked cross-source node
+// upserts. This migration drops it explicitly using pg_attribute.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 31,
+  name: 'drop_legacy_nodes_unique',
+  settingsKey: 'migration_031_drop_legacy_nodes_unique',
+  sqlite: (db) => dropLegacyNodesUniqueMigration.up(db),
+  postgres: (client) => runMigration031Postgres(client),
+  mysql: (pool) => runMigration031Mysql(pool),
 });

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -122,6 +122,39 @@ export class MessagesRepository extends BaseRepository {
   }
 
   /**
+   * Get messages in a channel strictly before a cursor timestamp (cursor-based pagination).
+   *
+   * @param channel    Channel number to filter on
+   * @param before     Exclusive upper-bound for COALESCE(rxTime, timestamp) in ms.
+   *                   If undefined, no upper bound is applied (returns newest `limit` rows).
+   * @param limit      Max rows to return
+   * @param sourceId   Optional source scope
+   */
+  async getMessagesBeforeInChannel(
+    channel: number,
+    before: number | undefined,
+    limit: number = 100,
+    sourceId?: string
+  ): Promise<DbMessage[]> {
+    const { messages } = this.tables;
+    const timeExpr = sql`COALESCE(${messages.rxTime}, ${messages.timestamp})`;
+    const conditions: (SQL | undefined)[] = [
+      eq(messages.channel, channel),
+      this.withSourceScope(messages, sourceId),
+    ];
+    if (before !== undefined) {
+      conditions.push(sql`${timeExpr} < ${before}`);
+    }
+    const result = await this.db
+      .select()
+      .from(messages)
+      .where(and(...conditions))
+      .orderBy(desc(timeExpr))
+      .limit(limit);
+    return this.normalizeBigInts(result) as DbMessage[];
+  }
+
+  /**
    * Get direct messages between two nodes
    */
   async getDirectMessages(nodeId1: string, nodeId2: string, limit: number = 100, offset: number = 0, sourceId?: string): Promise<DbMessage[]> {

--- a/src/pages/UnifiedMessagesPage.tsx
+++ b/src/pages/UnifiedMessagesPage.tsx
@@ -21,7 +21,7 @@
  *    receptions, so this is a pure view filter).
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { useAuth } from '../contexts/AuthContext';
@@ -217,9 +217,11 @@ export default function UnifiedMessagesPage() {
         out.push(m);
       }
     }
-    // Sort desc — polling can bring in new top-of-feed entries that merge with
-    // older pages; re-sort defensively so the feed is always monotonic.
-    out.sort((a, b) => b.timestamp - a.timestamp);
+    // Sort ascending (oldest → newest) so the chat-style layout pins the
+    // newest message to the bottom of the scroll container. Polling can bring
+    // in new entries on any page; re-sort defensively so the feed is always
+    // monotonic regardless of how TanStack merged the pages.
+    out.sort((a, b) => a.timestamp - b.timestamp);
     return out;
   }, [data?.pages]);
 
@@ -275,7 +277,69 @@ export default function UnifiedMessagesPage() {
     [filteredMessages]
   );
 
-  // ── Infinite scroll sentinel ──────────────────────────────────────────
+  // ── Scroll container management (chat-style: newest at bottom) ────────
+  // The scroll wrapper is the only scroll surface on this page. We manage
+  // scrollTop imperatively so that:
+  //   • on first load for a channel the user lands at the bottom,
+  //   • polling that appends a new tail keeps the user pinned at the bottom
+  //     IFF they were already there (otherwise we don't yank them away from
+  //     whatever they were reading),
+  //   • fetching an older page (prepend) preserves the user's visible spot
+  //     by shifting scrollTop by the exact growth in content height.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const wasAtBottomRef = useRef<boolean>(true);
+  const prevStateRef = useRef<{ len: number; firstKey: string; scrollHeight: number }>({
+    len: 0,
+    firstKey: '',
+    scrollHeight: 0,
+  });
+
+  // Reset bookkeeping when the channel changes so the next render pins
+  // to bottom.
+  useEffect(() => {
+    prevStateRef.current = { len: 0, firstKey: '', scrollHeight: 0 };
+    wasAtBottomRef.current = true;
+  }, [selectedChannel]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    wasAtBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+  }, []);
+
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const prev = prevStateRef.current;
+    const curLen = feedMessages.length;
+    const curFirstKey = feedMessages[0]?.dedupKey ?? '';
+
+    if (curLen === 0) {
+      prevStateRef.current = { len: 0, firstKey: '', scrollHeight: 0 };
+      return;
+    }
+
+    if (prev.len === 0) {
+      // Initial load for this channel: pin to the bottom.
+      el.scrollTop = el.scrollHeight;
+    } else if (curFirstKey !== prev.firstKey) {
+      // Prepended older messages from fetchNextPage. Keep the user's current
+      // viewpoint stable by shifting scrollTop by the delta in content height.
+      el.scrollTop = el.scrollTop + (el.scrollHeight - prev.scrollHeight);
+    } else if (wasAtBottomRef.current) {
+      // Appended new tail messages from polling. Stick to bottom iff the user
+      // was already pinned there.
+      el.scrollTop = el.scrollHeight;
+    }
+
+    prevStateRef.current = {
+      len: curLen,
+      firstKey: curFirstKey,
+      scrollHeight: el.scrollHeight,
+    };
+  }, [feedMessages]);
+
+  // ── Infinite scroll sentinel (at the TOP — scrolls up loads older) ────
   const sentinelRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const el = sentinelRef.current;
@@ -297,11 +361,12 @@ export default function UnifiedMessagesPage() {
   const openStats = useCallback((msg: UnifiedMessage) => setStatsFor(msg), []);
   const closeStats = useCallback(() => setStatsFor(null), []);
 
-  // Date-divider bookkeeping — walk the feed top-down (newest first).
+  // Date-divider bookkeeping — walk the feed top-down chronologically
+  // (oldest first) so each divider appears on the first message of its day.
   let lastDateLabel = '';
 
   return (
-    <div className="unified-page">
+    <div className="unified-page unified-page--chat">
       <div className="unified-header">
         <button className="unified-header__back" onClick={() => navigate('/')}>
           ← Sources
@@ -354,6 +419,7 @@ export default function UnifiedMessagesPage() {
         </div>
       </div>
 
+      <div className="unified-scroll" ref={scrollRef} onScroll={handleScroll}>
       <div className="unified-body">
         {!isAuthenticated && <div className="unified-empty">Sign in to view messages.</div>}
         {isAuthenticated && channelsError && <div className="unified-error">Failed to load channels.</div>}
@@ -364,6 +430,20 @@ export default function UnifiedMessagesPage() {
         {isAuthenticated && !loadingMessages && feedMessages.length === 0 && !messagesError && (
           <div className="unified-empty">
             {selectedChannel ? 'No messages on this channel yet.' : 'Choose a channel to begin.'}
+          </div>
+        )}
+
+        {/* Infinite scroll sentinel — at the TOP of the feed. Scroll up to
+            here and the intersection observer fires fetchNextPage, which
+            prepends older messages while the scroll-position preserving
+            useLayoutEffect keeps the user's viewpoint stable. */}
+        {feedMessages.length > 0 && (
+          <div ref={sentinelRef} className="unified-scroll-sentinel">
+            {isFetchingNextPage
+              ? 'Loading older messages…'
+              : hasNextPage
+                ? ''
+                : 'Beginning of history.'}
           </div>
         )}
 
@@ -451,17 +531,7 @@ export default function UnifiedMessagesPage() {
             </div>
           );
         })}
-
-        {/* Infinite scroll sentinel */}
-        {feedMessages.length > 0 && (
-          <div ref={sentinelRef} className="unified-scroll-sentinel">
-            {isFetchingNextPage
-              ? 'Loading older messages…'
-              : hasNextPage
-                ? ''
-                : 'End of history.'}
-          </div>
-        )}
+      </div>
       </div>
 
       {/* ── Reception stats modal ───────────────────────────────────────── */}

--- a/src/pages/UnifiedMessagesPage.tsx
+++ b/src/pages/UnifiedMessagesPage.tsx
@@ -1,44 +1,111 @@
 /**
  * Unified Messages Page
  *
- * Combines messages from all sources the user has read access to,
- * sorted newest-first. Each message is tagged with its source name.
+ * Cross-source message feed. Features:
+ *  - Channel selector driven by /api/unified/channels (name-based so the same
+ *    "Primary" channel collapses across sources even if they use different
+ *    slot numbers for it).
+ *  - Infinite scroll via TanStack `useInfiniteQuery` with a `before` timestamp
+ *    cursor — correct under streaming inserts (offset pagination would skew).
+ *  - Server-side dedup: the same mesh packet received by multiple sources
+ *    returns as ONE entry with a `receptions[]` array. Clicking a message
+ *    opens a modal that pivots that array into a per-source reception table
+ *    (hops / SNR / RSSI / rxTime), which is the whole point of the unified
+ *    view — you can see where the signal actually landed.
+ *  - Reactions (emoji tapbacks) are hidden from the main feed and rendered as
+ *    small bubbles on their parent message, matching MessagesTab behavior.
+ *  - Reply threading shows a quoted preview of the parent when `replyId` is
+ *    set, resolved from the already-loaded page cache.
+ *  - Source filter: optional dropdown that narrows to messages heard by a
+ *    specific source (client-side — the server-side dedup already bundled all
+ *    receptions, so this is a pure view filter).
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { useAuth } from '../contexts/AuthContext';
 import { appBasename } from '../init';
 import '../styles/unified.css';
 
-interface UnifiedMessage {
-  id: string;
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface Reception {
   sourceId: string;
   sourceName: string;
-  fromId?: string;
-  text?: string;
-  channel: number;
+  hopStart: number | null;
+  hopLimit: number | null;
+  rxSnr: number | null;
+  rxRssi: number | null;
+  rxTime: number | null;
   timestamp: number;
-  fromShortName?: string;
-  fromLongName?: string;
 }
+
+interface UnifiedMessage {
+  dedupKey: string;
+  requestId: number | null;
+  fromNodeNum: number;
+  fromNodeId: string;
+  fromNodeLongName?: string;
+  fromNodeShortName?: string;
+  toNodeNum: number;
+  toNodeId: string;
+  channel: number;
+  channelName: string;
+  text: string;
+  emoji: number | null;
+  replyId: number | null;
+  timestamp: number; // canonical (earliest heard)
+  receptions: Reception[];
+}
+
+interface UnifiedChannel {
+  name: string;
+  sources: Array<{ sourceId: string; sourceName: string; channelNumber: number }>;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────
+
+const PAGE_SIZE = 100;
+const POLL_INTERVAL_MS = 10_000;
 
 const SOURCE_COLORS = [
-  'var(--ctp-blue)', 'var(--ctp-mauve)', 'var(--ctp-green)',
-  'var(--ctp-red)', 'var(--ctp-yellow)', 'var(--ctp-teal)',
+  'var(--ctp-blue)',
+  'var(--ctp-mauve)',
+  'var(--ctp-green)',
+  'var(--ctp-peach)',
+  'var(--ctp-yellow)',
+  'var(--ctp-teal)',
+  'var(--ctp-pink)',
+  'var(--ctp-sapphire)',
 ];
 
-function getSourceColor(sourceId: string, sourceIds: string[]): string {
-  const idx = sourceIds.indexOf(sourceId);
-  return SOURCE_COLORS[idx % SOURCE_COLORS.length];
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * A message is a "reaction" (tapback) if the firmware marked it (emoji=1) OR
+ * it replies to something with a body that's just a single emoji char. This
+ * matches the detection used in MessagesTab so unified and per-source feeds
+ * agree.
+ */
+const EMOJI_RE = /\p{Extended_Pictographic}/u;
+
+function isReactionMessage(msg: UnifiedMessage): boolean {
+  if (msg.emoji === 1) return true;
+  if (msg.replyId != null && msg.text) {
+    const t = msg.text.trim();
+    // Short bodies that look emoji-ish count as reactions.
+    if (t.length > 0 && t.length <= 8 && EMOJI_RE.test(t)) return true;
+  }
+  return false;
 }
 
-function formatTime(timestamp: number): string {
-  return new Date(timestamp * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+function formatTime(timestampMs: number): string {
+  return new Date(timestampMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
-function formatDate(timestamp: number): string {
-  const d = new Date(timestamp * 1000);
+function formatDateDivider(timestampMs: number): string {
+  const d = new Date(timestampMs);
   const today = new Date();
   if (d.toDateString() === today.toDateString()) return 'Today';
   const yesterday = new Date(today);
@@ -47,115 +114,408 @@ function formatDate(timestamp: number): string {
   return d.toLocaleDateString();
 }
 
+function hopDisplay(start: number | null, limit: number | null): string {
+  if (start != null && limit != null) {
+    const hops = start - limit;
+    if (hops <= 0) return 'direct';
+    return `${hops} hop${hops > 1 ? 's' : ''}`;
+  }
+  if (start != null) return `start ${start}`;
+  if (limit != null) return `limit ${limit}`;
+  return '—';
+}
+
+function senderLabel(msg: UnifiedMessage): string {
+  return msg.fromNodeLongName || msg.fromNodeShortName || msg.fromNodeId || `!${msg.fromNodeNum.toString(16)}`;
+}
+
+function shortSenderLabel(msg: UnifiedMessage): string {
+  return msg.fromNodeShortName || msg.fromNodeLongName || msg.fromNodeId || `!${msg.fromNodeNum.toString(16)}`;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
 export default function UnifiedMessagesPage() {
   const navigate = useNavigate();
   const { authStatus } = useAuth();
   const isAuthenticated = authStatus?.authenticated ?? false;
 
-  const [messages, setMessages] = useState<UnifiedMessage[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
+  const [selectedChannel, setSelectedChannel] = useState<string>('');
+  const [sourceFilter, setSourceFilter] = useState<string>('');
+  const [statsFor, setStatsFor] = useState<UnifiedMessage | null>(null);
 
-  const fetchMessages = useCallback(async () => {
-    try {
-      const res = await fetch(`${appBasename}/api/unified/messages?limit=100`, {
+  // ── Channels query ────────────────────────────────────────────────────
+  const {
+    data: channels = [],
+    isLoading: loadingChannels,
+    isError: channelsError,
+  } = useQuery<UnifiedChannel[]>({
+    queryKey: ['unified', 'channels'],
+    queryFn: async () => {
+      const res = await fetch(`${appBasename}/api/unified/channels`, { credentials: 'include' });
+      if (!res.ok) throw new Error('Failed to load channels');
+      return res.json();
+    },
+    staleTime: 60_000,
+  });
+
+  // Auto-select the first channel when the list loads if nothing is picked yet.
+  useEffect(() => {
+    if (!selectedChannel && channels.length > 0) {
+      // Prefer a channel literally named "Primary" or "LongFast" if present.
+      const preferred = channels.find((c) => /^(primary|longfast)$/i.test(c.name));
+      setSelectedChannel(preferred?.name ?? channels[0].name);
+    }
+  }, [channels, selectedChannel]);
+
+  // ── Messages infinite query ───────────────────────────────────────────
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: loadingMessages,
+    isError: messagesError,
+    refetch,
+  } = useInfiniteQuery<UnifiedMessage[], Error>({
+    queryKey: ['unified', 'messages', selectedChannel],
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams();
+      if (selectedChannel) params.set('channel', selectedChannel);
+      params.set('limit', String(PAGE_SIZE));
+      if (pageParam !== undefined && pageParam !== null) {
+        params.set('before', String(pageParam));
+      }
+      const res = await fetch(`${appBasename}/api/unified/messages?${params.toString()}`, {
         credentials: 'include',
       });
-      if (!res.ok) { setError('Failed to load messages'); return; }
-      const data: UnifiedMessage[] = await res.json();
-      setMessages(data);
-      setError('');
-    } catch {
-      setError('Network error');
-    } finally {
-      setLoading(false);
+      if (!res.ok) throw new Error('Failed to load messages');
+      return res.json();
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage || lastPage.length < PAGE_SIZE) return undefined;
+      return lastPage[lastPage.length - 1].timestamp;
+    },
+    enabled: !!selectedChannel && isAuthenticated,
+    refetchInterval: POLL_INTERVAL_MS,
+    refetchOnWindowFocus: false,
+    // Only poll the first page (newest messages). Don't re-fetch old pages
+    // when polling; they're immutable once loaded.
+    refetchOnMount: true,
+  });
+
+  // ── Flatten + dedup pages by dedupKey ─────────────────────────────────
+  const allMessages = useMemo<UnifiedMessage[]>(() => {
+    if (!data?.pages) return [];
+    const seen = new Set<string>();
+    const out: UnifiedMessage[] = [];
+    for (const page of data.pages) {
+      for (const m of page) {
+        if (seen.has(m.dedupKey)) continue;
+        seen.add(m.dedupKey);
+        out.push(m);
+      }
     }
-  }, []);
+    // Sort desc — polling can bring in new top-of-feed entries that merge with
+    // older pages; re-sort defensively so the feed is always monotonic.
+    out.sort((a, b) => b.timestamp - a.timestamp);
+    return out;
+  }, [data?.pages]);
 
+  // ── All distinct sources heard across the loaded set ──────────────────
+  const sourcesInView = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const m of allMessages) {
+      for (const r of m.receptions) {
+        if (!map.has(r.sourceId)) map.set(r.sourceId, r.sourceName);
+      }
+    }
+    return Array.from(map.entries()).map(([id, name]) => ({ id, name }));
+  }, [allMessages]);
+
+  const sourceColor = useCallback(
+    (sourceId: string) => {
+      const idx = sourcesInView.findIndex((s) => s.id === sourceId);
+      return SOURCE_COLORS[(idx < 0 ? 0 : idx) % SOURCE_COLORS.length];
+    },
+    [sourcesInView]
+  );
+
+  // ── Apply source filter ───────────────────────────────────────────────
+  const filteredMessages = useMemo(() => {
+    if (!sourceFilter) return allMessages;
+    return allMessages.filter((m) => m.receptions.some((r) => r.sourceId === sourceFilter));
+  }, [allMessages, sourceFilter]);
+
+  // Build a quick index by requestId for reply preview + reaction grouping.
+  const byRequestId = useMemo(() => {
+    const map = new Map<number, UnifiedMessage>();
+    for (const m of allMessages) {
+      if (m.requestId != null) map.set(m.requestId, m);
+    }
+    return map;
+  }, [allMessages]);
+
+  // Group reactions onto their parent: parentRequestId → reactions[]
+  const reactionsByParent = useMemo(() => {
+    const map = new Map<number, UnifiedMessage[]>();
+    for (const m of allMessages) {
+      if (!isReactionMessage(m) || m.replyId == null) continue;
+      const list = map.get(m.replyId) ?? [];
+      list.push(m);
+      map.set(m.replyId, list);
+    }
+    return map;
+  }, [allMessages]);
+
+  // Non-reactions only — these drive the main feed.
+  const feedMessages = useMemo(
+    () => filteredMessages.filter((m) => !isReactionMessage(m)),
+    [filteredMessages]
+  );
+
+  // ── Infinite scroll sentinel ──────────────────────────────────────────
+  const sentinelRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    fetchMessages();
-    const interval = setInterval(fetchMessages, 10000);
-    return () => clearInterval(interval);
-  }, [fetchMessages]);
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { rootMargin: '200px' }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const sourceIds = Array.from(new Set(messages.map(m => m.sourceId)));
-  let lastDate = '';
+  // ── Render ────────────────────────────────────────────────────────────
+
+  const openStats = useCallback((msg: UnifiedMessage) => setStatsFor(msg), []);
+  const closeStats = useCallback(() => setStatsFor(null), []);
+
+  // Date-divider bookkeeping — walk the feed top-down (newest first).
+  let lastDateLabel = '';
 
   return (
     <div className="unified-page">
       <div className="unified-header">
-        <button className="unified-header__back" onClick={() => navigate('/')}>← Sources</button>
+        <button className="unified-header__back" onClick={() => navigate('/')}>
+          ← Sources
+        </button>
         <div className="unified-header__title">
           <h1>Unified Messages</h1>
-          <p>All sources combined · newest first</p>
+          <p>
+            {selectedChannel ? `#${selectedChannel}` : 'Select a channel'} · across all accessible sources
+          </p>
         </div>
-        <div className="unified-source-legend">
-          {sourceIds.map(sid => {
-            const name = messages.find(m => m.sourceId === sid)?.sourceName ?? sid;
-            const color = getSourceColor(sid, sourceIds);
-            return (
-              <span
-                key={sid}
-                className="unified-source-pill"
-                style={{ background: `color-mix(in srgb, ${color} 15%, transparent)`, color, border: `1px solid color-mix(in srgb, ${color} 35%, transparent)` }}
-              >
-                {name}
-              </span>
-            );
-          })}
+
+        <div className="unified-controls">
+          <select
+            className="unified-select"
+            value={selectedChannel}
+            onChange={(e) => setSelectedChannel(e.target.value)}
+            disabled={loadingChannels || channels.length === 0}
+            aria-label="Channel"
+          >
+            {channels.length === 0 && <option value="">No channels</option>}
+            {channels.map((c) => (
+              <option key={c.name} value={c.name}>
+                #{c.name} ({c.sources.length})
+              </option>
+            ))}
+          </select>
+
+          <select
+            className="unified-select"
+            value={sourceFilter}
+            onChange={(e) => setSourceFilter(e.target.value)}
+            aria-label="Source filter"
+          >
+            <option value="">All sources</option>
+            {sourcesInView.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+
+          <button
+            className="unified-header__back"
+            onClick={() => refetch()}
+            disabled={loadingMessages}
+            title="Refresh"
+          >
+            ↻
+          </button>
         </div>
       </div>
 
       <div className="unified-body">
-        {loading && <div className="unified-empty">Loading messages…</div>}
-        {error && <div className="unified-error">{error}</div>}
-
-        {!loading && !error && messages.length === 0 && (
+        {!isAuthenticated && <div className="unified-empty">Sign in to view messages.</div>}
+        {isAuthenticated && channelsError && <div className="unified-error">Failed to load channels.</div>}
+        {isAuthenticated && messagesError && <div className="unified-error">Failed to load messages.</div>}
+        {isAuthenticated && loadingMessages && feedMessages.length === 0 && (
+          <div className="unified-empty">Loading messages…</div>
+        )}
+        {isAuthenticated && !loadingMessages && feedMessages.length === 0 && !messagesError && (
           <div className="unified-empty">
-            {isAuthenticated
-              ? 'No messages found across your accessible sources.'
-              : 'Sign in to view messages.'}
+            {selectedChannel ? 'No messages on this channel yet.' : 'Choose a channel to begin.'}
           </div>
         )}
 
-        {messages.map((msg) => {
-          const dateLabel = formatDate(msg.timestamp);
-          const showDivider = dateLabel !== lastDate;
-          if (showDivider) lastDate = dateLabel;
-          const color = getSourceColor(msg.sourceId, sourceIds);
-          const sender = msg.fromLongName || msg.fromShortName || msg.fromId || 'Unknown';
-          const channelLabel = msg.channel === -1 ? 'DM' : `Ch${msg.channel}`;
+        {feedMessages.map((msg) => {
+          const dateLabel = formatDateDivider(msg.timestamp);
+          const showDivider = dateLabel !== lastDateLabel;
+          if (showDivider) lastDateLabel = dateLabel;
+
+          const primarySourceId = msg.receptions[0]?.sourceId ?? '';
+          const color = sourceColor(primarySourceId);
+          const receptionCount = msg.receptions.length;
+
+          const reactions = msg.requestId != null ? reactionsByParent.get(msg.requestId) ?? [] : [];
+
+          // Reply preview: look up parent by requestId.
+          const parent = msg.replyId != null ? byRequestId.get(msg.replyId) : undefined;
 
           return (
-            <div key={msg.id}>
+            <div key={msg.dedupKey}>
               {showDivider && (
                 <div className="unified-date-divider">
                   <span>{dateLabel}</span>
                 </div>
               )}
               <div
-                className="unified-msg-card"
+                className="unified-msg-card unified-msg-card--clickable"
                 style={{ borderLeftColor: color }}
+                onClick={() => openStats(msg)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    openStats(msg);
+                  }
+                }}
               >
                 <div className="unified-msg-card__meta">
-                  <span
-                    className="unified-msg-card__source-tag"
-                    style={{ background: `color-mix(in srgb, ${color} 15%, transparent)`, color }}
-                  >
-                    {msg.sourceName}
-                  </span>
-                  <span className="unified-msg-card__channel">{channelLabel}</span>
-                  <span className="unified-msg-card__sender">{sender}</span>
+                  {msg.receptions.map((r) => (
+                    <span
+                      key={r.sourceId}
+                      className="unified-msg-card__source-tag"
+                      style={{
+                        background: `color-mix(in srgb, ${sourceColor(r.sourceId)} 15%, transparent)`,
+                        color: sourceColor(r.sourceId),
+                        border: `1px solid color-mix(in srgb, ${sourceColor(r.sourceId)} 35%, transparent)`,
+                      }}
+                      title={`Heard by ${r.sourceName}`}
+                    >
+                      {r.sourceName}
+                    </span>
+                  ))}
+                  {receptionCount > 1 && (
+                    <span className="unified-msg-card__reception-count">
+                      heard by {receptionCount}
+                    </span>
+                  )}
+                  <span className="unified-msg-card__sender">{senderLabel(msg)}</span>
                   <span className="unified-msg-card__time">{formatTime(msg.timestamp)}</span>
                 </div>
+
+                {parent && (
+                  <div className="unified-reply-preview">
+                    <span className="unified-reply-preview__arrow">↳</span>
+                    <span className="unified-reply-preview__from">{shortSenderLabel(parent)}</span>
+                    <span className="unified-reply-preview__text">{parent.text || '(no text)'}</span>
+                  </div>
+                )}
+
                 <div className="unified-msg-card__text">
                   {msg.text || <em style={{ opacity: 0.4 }}>(no text)</em>}
                 </div>
+
+                {reactions.length > 0 && (
+                  <div className="unified-reactions">
+                    {reactions.map((r) => (
+                      <span key={r.dedupKey} className="unified-reaction" title={senderLabel(r)}>
+                        {r.text}
+                        <span className="unified-reaction__from">{shortSenderLabel(r)}</span>
+                      </span>
+                    ))}
+                  </div>
+                )}
               </div>
             </div>
           );
         })}
+
+        {/* Infinite scroll sentinel */}
+        {feedMessages.length > 0 && (
+          <div ref={sentinelRef} className="unified-scroll-sentinel">
+            {isFetchingNextPage
+              ? 'Loading older messages…'
+              : hasNextPage
+                ? ''
+                : 'End of history.'}
+          </div>
+        )}
       </div>
+
+      {/* ── Reception stats modal ───────────────────────────────────────── */}
+      {statsFor && (
+        <div className="unified-modal-overlay" onClick={closeStats}>
+          <div className="unified-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="unified-modal__header">
+              <h3>Reception details</h3>
+              <button className="unified-modal__close" onClick={closeStats} aria-label="Close">
+                ×
+              </button>
+            </div>
+            <div className="unified-modal__body">
+              <div className="unified-modal__summary">
+                <div className="unified-modal__sender">{senderLabel(statsFor)}</div>
+                <div className="unified-modal__text">{statsFor.text || '(no text)'}</div>
+                <div className="unified-modal__meta">
+                  Request ID: <code>{statsFor.requestId ?? '—'}</code> · Channel:{' '}
+                  <code>#{statsFor.channelName || statsFor.channel}</code>
+                </div>
+              </div>
+
+              <table className="unified-modal__table">
+                <thead>
+                  <tr>
+                    <th>Source</th>
+                    <th>Hops</th>
+                    <th>SNR</th>
+                    <th>RSSI</th>
+                    <th>Heard</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {statsFor.receptions.map((r) => (
+                    <tr key={r.sourceId}>
+                      <td>
+                        <span
+                          className="unified-modal__source-dot"
+                          style={{ background: sourceColor(r.sourceId) }}
+                        />
+                        {r.sourceName}
+                      </td>
+                      <td>{hopDisplay(r.hopStart, r.hopLimit)}</td>
+                      <td>{r.rxSnr != null ? `${r.rxSnr.toFixed(1)} dB` : '—'}</td>
+                      <td>{r.rxRssi != null ? `${r.rxRssi} dBm` : '—'}</td>
+                      <td>{formatTime(r.timestamp)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/UnifiedMessagesPage.tsx
+++ b/src/pages/UnifiedMessagesPage.tsx
@@ -43,6 +43,7 @@ interface Reception {
 
 interface UnifiedMessage {
   dedupKey: string;
+  packetId: number | null;
   requestId: number | null;
   fromNodeNum: number;
   fromNodeId: string;
@@ -250,16 +251,19 @@ export default function UnifiedMessagesPage() {
     return allMessages.filter((m) => m.receptions.some((r) => r.sourceId === sourceFilter));
   }, [allMessages, sourceFilter]);
 
-  // Build a quick index by requestId for reply preview + reaction grouping.
-  const byRequestId = useMemo(() => {
+  // Build a quick index by packet id for reply preview + reaction grouping.
+  // Meshtastic firmware sets `reply_id` to the parent's meshpacket id, not its
+  // requestId — so reactions (tapbacks) and reply previews must look up parents
+  // by packet id to match.
+  const byPacketId = useMemo(() => {
     const map = new Map<number, UnifiedMessage>();
     for (const m of allMessages) {
-      if (m.requestId != null) map.set(m.requestId, m);
+      if (m.packetId != null) map.set(m.packetId, m);
     }
     return map;
   }, [allMessages]);
 
-  // Group reactions onto their parent: parentRequestId → reactions[]
+  // Group reactions onto their parent: parent packetId → reactions[]
   const reactionsByParent = useMemo(() => {
     const map = new Map<number, UnifiedMessage[]>();
     for (const m of allMessages) {
@@ -456,10 +460,11 @@ export default function UnifiedMessagesPage() {
           const color = sourceColor(primarySourceId);
           const receptionCount = msg.receptions.length;
 
-          const reactions = msg.requestId != null ? reactionsByParent.get(msg.requestId) ?? [] : [];
+          const reactions = msg.packetId != null ? reactionsByParent.get(msg.packetId) ?? [] : [];
 
-          // Reply preview: look up parent by requestId.
-          const parent = msg.replyId != null ? byRequestId.get(msg.replyId) : undefined;
+          // Reply preview: look up parent by packet id (firmware's reply_id
+          // points at the parent's meshpacket id, not its requestId).
+          const parent = msg.replyId != null ? byPacketId.get(msg.replyId) : undefined;
 
           return (
             <div key={msg.dedupKey}>

--- a/src/server/migrations/031_drop_legacy_nodes_unique.ts
+++ b/src/server/migrations/031_drop_legacy_nodes_unique.ts
@@ -1,0 +1,128 @@
+/**
+ * Migration 031: Drop legacy standalone UNIQUE on nodes.nodeId
+ *
+ * Migration 029 rebuilt the nodes table with a composite (nodeNum, sourceId)
+ * PK and intended to drop the pre-refactor UNIQUE("nodeId") constraint as
+ * part of the same rebuild. The Postgres path located the old constraint by
+ * matching its definition text with the ILIKE pattern `%(nodeId)%`. The
+ * actual constraint def is `UNIQUE ("nodeId")` — the column name is quoted,
+ * so the substring `(nodeId)` is never present and the lookup silently
+ * returned zero rows. The drop was skipped and upgraded Postgres databases
+ * kept the old standalone unique alongside the new composite unique.
+ *
+ * Symptom: every cross-source node upsert (e.g. Sandbox2 receiving a node
+ * already known to Default) throws error 23505 on `nodes_nodeId_key`, which
+ * aborts `processIncomingData` before the message insert can run — so a
+ * second source appears to receive almost no nodes and no messages.
+ *
+ * This migration drops any remaining standalone UNIQUE or UNIQUE INDEX on
+ * `nodes.nodeId` alone. It is a no-op when the constraint is already gone.
+ *
+ * - SQLite: 029's table rebuild removed the old constraint (it was never in
+ *   the CREATE TABLE for `nodes_new`), so this is unconditionally a no-op.
+ * - MySQL: 029 enumerated UNIQUE indexes via information_schema and dropped
+ *   any index whose columns were exactly `nodeId`. No-op in the common case,
+ *   but kept as a defensive re-run.
+ * - PostgreSQL: drops every UNIQUE constraint/index on `nodes` whose column
+ *   list is exactly `nodeId`.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (_db: Database): void => {
+    // No-op: migration 029 rebuilt the nodes table without this constraint.
+    logger.debug('Migration 031 (SQLite): no-op, legacy unique already dropped by 029');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 031 down: not implemented (destructive)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration031Postgres(client: any): Promise<void> {
+  logger.info('Running migration 031 (PostgreSQL): dropping legacy standalone UNIQUE on nodes.nodeId...');
+
+  // Find every UNIQUE constraint on `nodes` whose column list is exactly
+  // `nodeId`. We join through pg_constraint → pg_attribute to get the column
+  // names directly rather than parsing the text of pg_get_constraintdef (which
+  // was what 029 tried to do — with the quoting bug that made it miss).
+  const uniqRows = await client.query(`
+    SELECT c.conname
+    FROM pg_constraint c
+    WHERE c.conrelid = 'nodes'::regclass
+      AND c.contype = 'u'
+      AND (
+        SELECT array_agg(a.attname ORDER BY a.attnum)
+        FROM unnest(c.conkey) AS k(attnum)
+        JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+      ) = ARRAY['nodeId']::name[]
+  `);
+
+  for (const row of uniqRows.rows) {
+    logger.info(`Migration 031 (PostgreSQL): dropping legacy unique constraint '${row.conname}'`);
+    await client.query(`ALTER TABLE "nodes" DROP CONSTRAINT IF EXISTS "${row.conname}"`);
+  }
+
+  // Also drop any UNIQUE INDEX (not backing a constraint) whose key is exactly
+  // `nodeId`. In practice the constraint drop above also removes its index,
+  // but a standalone unique index could have been created by an earlier tool.
+  const idxRows = await client.query(`
+    SELECT i.relname AS indexname
+    FROM pg_index ix
+    JOIN pg_class i ON i.oid = ix.indexrelid
+    JOIN pg_class t ON t.oid = ix.indrelid
+    WHERE t.relname = 'nodes'
+      AND ix.indisunique
+      AND NOT ix.indisprimary
+      AND (
+        SELECT array_agg(a.attname ORDER BY a.attnum)
+        FROM unnest(ix.indkey) AS k(attnum)
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+      ) = ARRAY['nodeId']::name[]
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_constraint c WHERE c.conindid = i.oid
+      )
+  `);
+
+  for (const row of idxRows.rows) {
+    logger.info(`Migration 031 (PostgreSQL): dropping legacy unique index '${row.indexname}'`);
+    await client.query(`DROP INDEX IF EXISTS "${row.indexname}"`);
+  }
+
+  logger.info('Migration 031 complete (PostgreSQL)');
+}
+
+// ============ MySQL ============
+
+export async function runMigration031Mysql(pool: any): Promise<void> {
+  logger.info('Running migration 031 (MySQL): dropping legacy standalone UNIQUE on nodes.nodeId...');
+
+  const conn = await pool.getConnection();
+  try {
+    const [uniqRows] = await conn.query(
+      `SELECT INDEX_NAME, GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS cols
+       FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE()
+         AND TABLE_NAME = 'nodes'
+         AND NON_UNIQUE = 0
+       GROUP BY INDEX_NAME`
+    );
+
+    for (const row of uniqRows as any[]) {
+      if (row.INDEX_NAME === 'PRIMARY') continue;
+      if (row.cols === 'nodeId') {
+        logger.info(`Migration 031 (MySQL): dropping legacy unique index '${row.INDEX_NAME}'`);
+        await conn.query(`ALTER TABLE nodes DROP INDEX \`${row.INDEX_NAME}\``);
+      }
+    }
+  } finally {
+    conn.release();
+  }
+
+  logger.info('Migration 031 complete (MySQL)');
+}

--- a/src/server/routes/unifiedRoutes.test.ts
+++ b/src/server/routes/unifiedRoutes.test.ts
@@ -1,7 +1,8 @@
 /**
  * Unified Routes Tests
  *
- * Tests for GET /api/unified/messages and GET /api/unified/telemetry.
+ * Tests for GET /api/unified/messages, /api/unified/channels, and
+ * /api/unified/telemetry.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -18,6 +19,10 @@ vi.mock('../../services/database.js', () => ({
     },
     messages: {
       getMessages: vi.fn(),
+      getMessagesBeforeInChannel: vi.fn(),
+    },
+    channels: {
+      getAllChannels: vi.fn(),
     },
     nodes: {
       getAllNodes: vi.fn(),
@@ -58,7 +63,6 @@ const createApp = (user: any = null): Express => {
   app.use((req: any, _res: any, next: any) => {
     if (user) {
       req.session.userId = user.id;
-      // Set findUserByIdAsync to return the right user for this session
       mockDb.findUserByIdAsync.mockResolvedValue(user);
     }
     next();
@@ -70,6 +74,51 @@ const createApp = (user: any = null): Express => {
 const SOURCE_A = { id: 'src-a', name: 'Source A', type: 'meshtastic_tcp', enabled: true };
 const SOURCE_B = { id: 'src-b', name: 'Source B', type: 'meshtastic_tcp', enabled: true };
 
+// Channel list fixtures — same name "Primary" lives at slot 0 on both sources.
+const CHANNELS_A = [
+  { id: 0, name: 'Primary', role: 1 },
+  { id: 1, name: 'Admin',   role: 2 },
+];
+const CHANNELS_B = [
+  { id: 0, name: 'Primary', role: 1 },
+];
+
+/** Build a message row the way the repo layer returns it (post-normalize). */
+function mkMsg(overrides: Record<string, any> = {}) {
+  return {
+    id: 'row-1',
+    fromNodeNum: 0xaabbccdd,
+    fromNodeId: '!aabbccdd',
+    toNodeNum: 0xffffffff,
+    toNodeId: '!ffffffff',
+    text: 'hello',
+    channel: 0,
+    portnum: 1,
+    requestId: 111,
+    timestamp: 1_700_000_000_000,
+    rxTime: 1_700_000_000_000,
+    hopStart: 3,
+    hopLimit: 3,
+    rxSnr: -5.5,
+    rxRssi: -110,
+    relayNode: null,
+    replyId: null,
+    emoji: null,
+    viaMqtt: null,
+    ackFailed: null,
+    routingErrorReceived: null,
+    deliveryState: null,
+    wantAck: null,
+    ackFromNode: null,
+    createdAt: 1_700_000_000_000,
+    decryptedBy: null,
+    ...overrides,
+  };
+}
+
+const NODE_ONE = { nodeId: '!aabbccdd', nodeNum: 0xaabbccdd, longName: 'Node One', shortName: 'N1' };
+const NODE_TWO = { nodeId: '!11223344', nodeNum: 0x11223344, longName: 'Node Two', shortName: 'N2' };
+
 describe('Unified Routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -77,39 +126,145 @@ describe('Unified Routes', () => {
     mockDb.findUserByUsernameAsync.mockResolvedValue(null);
     mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: false });
     mockDb.checkPermissionAsync.mockResolvedValue(true);
+    mockDb.nodes.getAllNodes.mockResolvedValue([NODE_ONE, NODE_TWO]);
   });
 
-  // ── /messages ─────────────────────────────────────────────────────────────
+  // ── /channels ─────────────────────────────────────────────────────────────
 
-  describe('GET /messages', () => {
-    it('returns merged messages from all accessible sources for admin', async () => {
+  describe('GET /channels', () => {
+    it('returns de-duplicated channel names across all accessible sources', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
+      mockDb.channels.getAllChannels.mockImplementation((sourceId: string) =>
+        Promise.resolve(sourceId === 'src-a' ? CHANNELS_A : CHANNELS_B)
+      );
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/channels');
+
+      expect(res.status).toBe(200);
+      // "Admin" (src-a only) and "Primary" (both)
+      expect(res.body).toHaveLength(2);
+      const primary = res.body.find((c: any) => c.name === 'Primary');
+      expect(primary.sources).toHaveLength(2);
+      expect(primary.sources.map((s: any) => s.sourceId).sort()).toEqual(['src-a', 'src-b']);
+      const admin = res.body.find((c: any) => c.name === 'Admin');
+      expect(admin.sources).toHaveLength(1);
+      expect(admin.sources[0].sourceId).toBe('src-a');
+    });
+
+    it('excludes sources the user cannot read', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
+      mockDb.checkPermissionAsync.mockImplementation(
+        (_uid: number, _r: string, _a: string, sourceId: string) =>
+          Promise.resolve(sourceId === 'src-a')
+      );
+      mockDb.channels.getAllChannels.mockImplementation((sourceId: string) =>
+        Promise.resolve(sourceId === 'src-a' ? CHANNELS_A : CHANNELS_B)
+      );
+
+      const app = createApp(regularUser);
+      const res = await request(app).get('/channels');
+
+      expect(res.status).toBe(200);
+      // src-b skipped entirely
+      for (const c of res.body) {
+        expect(c.sources.every((s: any) => s.sourceId === 'src-a')).toBe(true);
+      }
+    });
+
+    it('skips channels with empty names', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
+      mockDb.channels.getAllChannels.mockResolvedValue([
+        { id: 0, name: 'Primary', role: 1 },
+        { id: 1, name: '', role: 0 }, // disabled slot
+        { id: 2, name: '   ', role: 0 }, // whitespace-only
+      ]);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/channels');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].name).toBe('Primary');
+    });
+
+    it('returns 500 on database error', async () => {
+      mockDb.sources.getAllSources.mockRejectedValue(new Error('DB error'));
+      const app = createApp(adminUser);
+      const res = await request(app).get('/channels');
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // ── /messages (legacy: no channel filter) ─────────────────────────────────
+
+  describe('GET /messages (no channel filter)', () => {
+    it('returns merged messages wrapped with receptions array', async () => {
       mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
       mockDb.messages.getMessages
-        .mockResolvedValueOnce([
-          { id: '1', text: 'Hello', timestamp: 1000, channel: 0 },
-        ])
-        .mockResolvedValueOnce([
-          { id: '2', text: 'World', timestamp: 900, channel: 0 },
-        ]);
+        .mockResolvedValueOnce([mkMsg({ id: '1', text: 'Hello', requestId: 111, timestamp: 1000, rxTime: 1000, fromNodeNum: NODE_ONE.nodeNum })])
+        .mockResolvedValueOnce([mkMsg({ id: '2', text: 'World', requestId: 222, timestamp: 900,  rxTime: 900,  fromNodeNum: NODE_TWO.nodeNum })]);
 
       const app = createApp(adminUser);
       const res = await request(app).get('/messages?limit=50');
 
       expect(res.status).toBe(200);
       expect(res.body).toHaveLength(2);
-      // Should be sorted newest first
+      // Sorted newest first.
       expect(res.body[0].timestamp).toBe(1000);
-      expect(res.body[0].sourceName).toBe('Source A');
+      expect(res.body[0].receptions[0].sourceName).toBe('Source A');
+      expect(res.body[0].text).toBe('Hello');
       expect(res.body[1].timestamp).toBe(900);
-      expect(res.body[1].sourceName).toBe('Source B');
+      expect(res.body[1].receptions[0].sourceName).toBe('Source B');
+    });
+
+    it('de-duplicates the same (fromNodeNum, requestId) across sources into one entry with two receptions', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
+      // Same mesh packet heard by both sources — same fromNodeNum + requestId.
+      mockDb.messages.getMessages
+        .mockResolvedValueOnce([
+          mkMsg({ id: 'a1', fromNodeNum: NODE_ONE.nodeNum, requestId: 42, text: 'ping', timestamp: 2000, rxTime: 2000, rxSnr: -5,  rxRssi: -100 }),
+        ])
+        .mockResolvedValueOnce([
+          mkMsg({ id: 'b1', fromNodeNum: NODE_ONE.nodeNum, requestId: 42, text: 'ping', timestamp: 2100, rxTime: 2100, rxSnr: -8,  rxRssi: -115 }),
+        ]);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/messages?limit=50');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].requestId).toBe(42);
+      expect(res.body[0].receptions).toHaveLength(2);
+      // Canonical timestamp = earliest heard.
+      expect(res.body[0].timestamp).toBe(2000);
+      // Receptions sorted earliest-first.
+      expect(res.body[0].receptions[0].sourceId).toBe('src-a');
+      expect(res.body[0].receptions[1].sourceId).toBe('src-b');
+      expect(res.body[0].receptions[0].rxSnr).toBe(-5);
+      expect(res.body[0].receptions[1].rxSnr).toBe(-8);
+    });
+
+    it('resolves sender display names from the nodes table', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
+      mockDb.messages.getMessages.mockResolvedValue([
+        mkMsg({ id: '1', text: 'hi', fromNodeNum: NODE_ONE.nodeNum, requestId: 1 }),
+      ]);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/messages');
+
+      expect(res.status).toBe(200);
+      expect(res.body[0].fromNodeLongName).toBe('Node One');
+      expect(res.body[0].fromNodeShortName).toBe('N1');
     });
 
     it('respects limit parameter', async () => {
       mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
       mockDb.messages.getMessages.mockResolvedValue([
-        { id: '1', text: 'A', timestamp: 100, channel: 0 },
-        { id: '2', text: 'B', timestamp: 200, channel: 0 },
-        { id: '3', text: 'C', timestamp: 300, channel: 0 },
+        mkMsg({ id: '1', text: 'A', requestId: 1, timestamp: 100, rxTime: 100 }),
+        mkMsg({ id: '2', text: 'B', requestId: 2, timestamp: 200, rxTime: 200 }),
+        mkMsg({ id: '3', text: 'C', requestId: 3, timestamp: 300, rxTime: 300 }),
       ]);
 
       const app = createApp(adminUser);
@@ -119,48 +274,109 @@ describe('Unified Routes', () => {
       expect(res.body).toHaveLength(2);
     });
 
-    it('caps limit at 200', async () => {
+    it('caps limit at 500 (fetches 1000 per source for dedup headroom)', async () => {
       mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
       mockDb.messages.getMessages.mockResolvedValue([]);
 
       const app = createApp(adminUser);
       await request(app).get('/messages?limit=9999');
 
-      // getMessages should have been called with limit=200
-      expect(mockDb.messages.getMessages).toHaveBeenCalledWith(200, 0, SOURCE_A.id);
+      // fetchLimit = limit * 2 = 1000
+      expect(mockDb.messages.getMessages).toHaveBeenCalledWith(1000, 0, SOURCE_A.id);
     });
 
     it('skips sources the user has no read permission for', async () => {
       mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
-      // Grant access to A, deny for B
       mockDb.checkPermissionAsync.mockImplementation(
-        (_userId: number, _resource: string, _action: string, sourceId: string) =>
+        (_uid: number, _r: string, _a: string, sourceId: string) =>
           Promise.resolve(sourceId === 'src-a')
       );
       mockDb.messages.getMessages.mockResolvedValue([
-        { id: '1', text: 'Hi', timestamp: 1000, channel: 0 },
+        mkMsg({ id: '1', text: 'Hi', requestId: 7, fromNodeNum: NODE_ONE.nodeNum }),
       ]);
 
       const app = createApp(regularUser);
       const res = await request(app).get('/messages');
 
       expect(res.status).toBe(200);
-      // Only Source A messages should be present
-      expect(res.body.every((m: any) => m.sourceId === 'src-a')).toBe(true);
+      expect(res.body.every((m: any) => m.receptions.every((r: any) => r.sourceId === 'src-a'))).toBe(true);
       expect(mockDb.messages.getMessages).toHaveBeenCalledTimes(1);
     });
 
     it('returns 500 on database error', async () => {
       mockDb.sources.getAllSources.mockRejectedValue(new Error('DB error'));
-
       const app = createApp(adminUser);
       const res = await request(app).get('/messages');
-
       expect(res.status).toBe(500);
     });
   });
 
-  // ── /telemetry ────────────────────────────────────────────────────────────
+  // ── /messages (channel + before cursor) ──────────────────────────────────
+
+  describe('GET /messages (channel filter + cursor)', () => {
+    it('resolves channel name to per-source channel number and uses the cursor path', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
+      mockDb.channels.getAllChannels.mockResolvedValue(CHANNELS_A);
+      mockDb.messages.getMessagesBeforeInChannel.mockResolvedValue([
+        mkMsg({ id: 'a1', text: 'on-primary', requestId: 9, fromNodeNum: NODE_ONE.nodeNum, timestamp: 5000, rxTime: 5000 }),
+      ]);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/messages?channel=Primary&before=10000&limit=50');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].text).toBe('on-primary');
+      // Primary lives at slot 0 on SOURCE_A
+      expect(mockDb.messages.getMessagesBeforeInChannel).toHaveBeenCalledWith(
+        0,          // channel number
+        10000,      // before cursor
+        100,        // fetchLimit = limit*2
+        SOURCE_A.id
+      );
+    });
+
+    it('skips sources whose channel list does not contain the requested name', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
+      mockDb.channels.getAllChannels.mockImplementation((sourceId: string) =>
+        Promise.resolve(sourceId === 'src-a' ? CHANNELS_A : [{ id: 0, name: 'Other', role: 1 }])
+      );
+      mockDb.messages.getMessagesBeforeInChannel.mockResolvedValue([
+        mkMsg({ id: 'a1', text: 'a', requestId: 1, fromNodeNum: NODE_ONE.nodeNum }),
+      ]);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/messages?channel=Primary');
+
+      expect(res.status).toBe(200);
+      // Only SOURCE_A was queried.
+      expect(mockDb.messages.getMessagesBeforeInChannel).toHaveBeenCalledTimes(1);
+      expect(mockDb.messages.getMessagesBeforeInChannel).toHaveBeenCalledWith(0, undefined, expect.any(Number), 'src-a');
+      expect(res.body).toHaveLength(1);
+    });
+
+    it('de-duplicates identical packets heard on the same channel by multiple sources', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
+      mockDb.channels.getAllChannels.mockResolvedValue([{ id: 0, name: 'Primary', role: 1 }]);
+      mockDb.messages.getMessagesBeforeInChannel
+        .mockResolvedValueOnce([
+          mkMsg({ id: 'a1', fromNodeNum: NODE_ONE.nodeNum, requestId: 777, text: 'shared', timestamp: 1000, rxTime: 1000, rxSnr: -3 }),
+        ])
+        .mockResolvedValueOnce([
+          mkMsg({ id: 'b1', fromNodeNum: NODE_ONE.nodeNum, requestId: 777, text: 'shared', timestamp: 1200, rxTime: 1200, rxSnr: -9 }),
+        ]);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/messages?channel=Primary');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].receptions).toHaveLength(2);
+      expect(res.body[0].requestId).toBe(777);
+    });
+  });
+
+  // ── /telemetry (unchanged contract) ──────────────────────────────────────
 
   describe('GET /telemetry', () => {
     // Telemetry timestamps are stored in milliseconds (see meshtasticManager).
@@ -250,7 +466,6 @@ describe('Unified Routes', () => {
       const app = createApp(adminUser);
       const res = await request(app).get('/telemetry?hours=9999');
 
-      // Should succeed (no sources, empty result) and not error
       expect(res.status).toBe(200);
       expect(res.body).toEqual([]);
     });

--- a/src/server/routes/unifiedRoutes.test.ts
+++ b/src/server/routes/unifiedRoutes.test.ts
@@ -188,6 +188,45 @@ describe('Unified Routes', () => {
       expect(res.body[0].name).toBe('Primary');
     });
 
+    it('labels channel 0 as "Primary" when its name is empty', async () => {
+      // Real Meshtastic firmware leaves channel 0's name blank — the client
+      // renders the modem preset instead. Unified view must still surface it.
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
+      mockDb.channels.getAllChannels.mockResolvedValue([
+        { id: 0, name: '', role: 1 },       // unnamed primary
+        { id: 1, name: 'telemetry', role: 2 },
+      ]);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/channels');
+
+      expect(res.status).toBe(200);
+      const names = res.body.map((c: any) => c.name).sort();
+      expect(names).toEqual(['Primary', 'telemetry']);
+      const primary = res.body.find((c: any) => c.name === 'Primary');
+      expect(primary.sources[0].channelNumber).toBe(0);
+    });
+
+    it('skips disabled channels even when they have a default name', async () => {
+      // Firmware leaves slots 3-7 named "Channel 3".."Channel 7" with role=0
+      // (DISABLED). These are not real channels and must not show up.
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
+      mockDb.channels.getAllChannels.mockResolvedValue([
+        { id: 0, name: '', role: 1 },
+        { id: 1, name: 'telemetry', role: 2 },
+        { id: 3, name: 'Channel 3', role: 0 },
+        { id: 4, name: 'Channel 4', role: 0 },
+      ]);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/channels');
+
+      expect(res.status).toBe(200);
+      const names = res.body.map((c: any) => c.name);
+      expect(names).toEqual(expect.arrayContaining(['Primary', 'telemetry']));
+      expect(names).not.toEqual(expect.arrayContaining(['Channel 3', 'Channel 4']));
+    });
+
     it('returns 500 on database error', async () => {
       mockDb.sources.getAllSources.mockRejectedValue(new Error('DB error'));
       const app = createApp(adminUser);
@@ -373,6 +412,71 @@ describe('Unified Routes', () => {
       expect(res.body).toHaveLength(1);
       expect(res.body[0].receptions).toHaveLength(2);
       expect(res.body[0].requestId).toBe(777);
+    });
+
+    it('de-duplicates using the mesh packet id extracted from the row id when requestId is null', async () => {
+      // Real-world: received text messages store requestId=null — the mesh
+      // packet id lives as the last `_`-separated segment of the row id.
+      // Same packet received by two sources must collapse into one entry.
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
+      mockDb.channels.getAllChannels.mockResolvedValue([{ id: 0, name: 'Primary', role: 1 }]);
+      mockDb.messages.getMessagesBeforeInChannel
+        .mockResolvedValueOnce([
+          mkMsg({
+            id: 'src-a_3303011195_69761528',
+            fromNodeNum: 3303011195,
+            requestId: null,
+            text: 'Here comes the Rain',
+            timestamp: 1000, rxTime: 1000, rxSnr: 5.2,
+          }),
+        ])
+        .mockResolvedValueOnce([
+          mkMsg({
+            id: 'src-b_3303011195_69761528',
+            fromNodeNum: 3303011195,
+            requestId: null,
+            text: 'Here comes the Rain',
+            timestamp: 1200, rxTime: 1200, rxSnr: -3.1,
+          }),
+        ]);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/messages?channel=Primary');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].receptions).toHaveLength(2);
+      expect(res.body[0].text).toBe('Here comes the Rain');
+      // Canonical timestamp = earliest heard.
+      expect(res.body[0].timestamp).toBe(1000);
+      // Both source names present.
+      const names = res.body[0].receptions.map((r: any) => r.sourceName).sort();
+      expect(names).toEqual(['Source A', 'Source B']);
+    });
+
+    it('resolves "Primary" to channel 0 even when the source has a blank name for it', async () => {
+      // Matches real firmware behavior: channel 0 is PRIMARY, name is empty.
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
+      mockDb.channels.getAllChannels.mockResolvedValue([
+        { id: 0, name: '', role: 1 },
+        { id: 1, name: 'telemetry', role: 2 },
+      ]);
+      mockDb.messages.getMessagesBeforeInChannel.mockResolvedValue([
+        mkMsg({ id: 'a1', text: 'unnamed-primary', requestId: 11, fromNodeNum: NODE_ONE.nodeNum, timestamp: 5000, rxTime: 5000 }),
+      ]);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/messages?channel=Primary');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].text).toBe('unnamed-primary');
+      expect(mockDb.messages.getMessagesBeforeInChannel).toHaveBeenCalledWith(
+        0,
+        undefined,
+        expect.any(Number),
+        SOURCE_A.id
+      );
     });
   });
 

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -16,54 +16,260 @@ const router = Router();
 router.use(optionalAuth());
 
 /**
- * GET /api/unified/messages?limit=50
+ * GET /api/unified/channels
  *
- * Returns messages from all sources the user can read, merged by timestamp
- * (newest first). Each message includes `sourceId` and `sourceName`.
+ * Returns a de-duplicated list of channel names across every source the user
+ * has `messages:read` permission for. Each entry includes the list of sources
+ * that host a channel with that name (and what number it lives on per source),
+ * so the frontend can render a single "Primary" entry even when sources use
+ * different channel slots for it.
+ *
+ * Response shape:
+ * ```
+ * [
+ *   { name: "Primary", sources: [{ sourceId, sourceName, channelNumber }] },
+ *   { name: "LongFast", sources: [...] }
+ * ]
+ * ```
  */
-router.get('/messages', async (req: Request, res: Response) => {
+router.get('/channels', async (req: Request, res: Response) => {
   try {
-    const limit = Math.min(parseInt(req.query.limit as string || '50', 10), 200);
     const user = (req as any).user;
     const isAdmin = user?.isAdmin ?? false;
 
-    // Fetch all sources
     const sources = await databaseService.sources.getAllSources();
 
-    // For each source, check if user has messages read permission and fetch messages
-    const sourceMsgResults = await Promise.allSettled(
+    type ChannelSourceRef = { sourceId: string; sourceName: string; channelNumber: number };
+    const byName = new Map<string, ChannelSourceRef[]>();
+
+    await Promise.all(
       sources.map(async (source) => {
-        // Permission check: admin sees all, otherwise check per-source then global
         const canRead = isAdmin || (user
           ? await databaseService.checkPermissionAsync(user.id, 'messages', 'read', source.id)
           : false);
+        if (!canRead) return;
 
-        if (!canRead) return [];
-
-        const messages = await databaseService.messages.getMessages(limit, 0, source.id);
-        return messages.map(m => ({
-          ...m,
-          sourceId: source.id,
-          sourceName: source.name,
-        }));
+        try {
+          const chans = await databaseService.channels.getAllChannels(source.id);
+          for (const c of chans) {
+            const name = (c.name ?? '').trim();
+            if (!name) continue; // skip unnamed/disabled slots
+            const list = byName.get(name) ?? [];
+            list.push({
+              sourceId: source.id,
+              sourceName: source.name,
+              channelNumber: (c as any).id,
+            });
+            byName.set(name, list);
+          }
+        } catch (err) {
+          logger.warn(`Failed to load channels for source ${source.id}:`, err);
+        }
       })
     );
 
-    // Merge and sort by timestamp descending
-    const allMessages: Array<Record<string, unknown>> = [];
-    for (const result of sourceMsgResults) {
-      if (result.status === 'fulfilled') {
-        allMessages.push(...result.value);
-      }
+    const result = Array.from(byName.entries())
+      .map(([name, srcs]) => ({ name, sources: srcs }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    res.json(result);
+  } catch (error) {
+    logger.error('Error fetching unified channels:', error);
+    res.status(500).json({ error: 'Failed to fetch unified channels' });
+  }
+});
+
+/**
+ * GET /api/unified/messages?channel=<name>&before=<ms>&limit=<N>
+ *
+ * Returns messages from every source the user has `messages:read` permission
+ * for, merged into one stream and **de-duplicated across sources**.
+ *
+ * The same mesh packet received by multiple sources collapses into a single
+ * entry whose `receptions[]` array records how each source heard it (hop
+ * count, SNR, RSSI, rxTime). This lets the frontend compare reception quality
+ * across the fleet while still rendering one bubble per message.
+ *
+ * Query params:
+ *   ?channel=<name>   Filter by channel NAME (not number — sources may place
+ *                     the same name on different slots). If omitted, returns
+ *                     messages from all channels across all sources (legacy).
+ *   ?before=<ms>      Cursor: only include messages whose canonical time
+ *                     (COALESCE(rxTime, timestamp)) is strictly less than
+ *                     this. Used for infinite-scroll pagination.
+ *   ?limit=<N>        Max de-duplicated messages to return (default 100,
+ *                     cap 500).
+ *
+ * Response item shape:
+ *   {
+ *     dedupKey, requestId, fromNodeNum, fromNodeId,
+ *     fromNodeLongName, fromNodeShortName,
+ *     toNodeNum, toNodeId,
+ *     channel, channelName,
+ *     text, emoji, replyId,
+ *     timestamp,        // canonical (earliest rxTime seen)
+ *     receptions: [{ sourceId, sourceName, hopStart, hopLimit,
+ *                    rxSnr, rxRssi, rxTime, timestamp }]
+ *   }
+ */
+router.get('/messages', async (req: Request, res: Response) => {
+  try {
+    const channelName = ((req.query.channel as string) || '').trim();
+    const beforeRaw = req.query.before as string | undefined;
+    const before = beforeRaw ? parseInt(beforeRaw, 10) : undefined;
+    const limit = Math.min(parseInt((req.query.limit as string) || '100', 10), 500);
+    const user = (req as any).user;
+    const isAdmin = user?.isAdmin ?? false;
+
+    const sources = await databaseService.sources.getAllSources();
+
+    type Reception = {
+      sourceId: string;
+      sourceName: string;
+      hopStart: number | null;
+      hopLimit: number | null;
+      rxSnr: number | null;
+      rxRssi: number | null;
+      rxTime: number | null;
+      timestamp: number;
+    };
+    type Merged = {
+      dedupKey: string;
+      requestId: number | null;
+      fromNodeNum: number;
+      fromNodeId: string;
+      fromNodeLongName?: string;
+      fromNodeShortName?: string;
+      toNodeNum: number;
+      toNodeId: string;
+      channel: number;
+      channelName: string;
+      text: string;
+      emoji: number | null;
+      replyId: number | null;
+      timestamp: number;
+      receptions: Reception[];
+    };
+
+    const merged = new Map<string, Merged>();
+
+    // Fetch 2x limit per source so dedup can't starve the result set when
+    // multiple sources all heard the same packet.
+    const fetchLimit = limit * 2;
+
+    await Promise.all(
+      sources.map(async (source) => {
+        const canRead = isAdmin || (user
+          ? await databaseService.checkPermissionAsync(user.id, 'messages', 'read', source.id)
+          : false);
+        if (!canRead) return;
+
+        // Resolve channel name → channel number for THIS source.
+        let channelNumber: number | undefined;
+        if (channelName) {
+          try {
+            const chans = await databaseService.channels.getAllChannels(source.id);
+            const match = chans.find((c) => (c.name ?? '').trim() === channelName);
+            if (!match) return; // source has no matching channel → skip
+            channelNumber = (match as any).id;
+          } catch (err) {
+            logger.warn(`Failed to resolve channel '${channelName}' for source ${source.id}:`, err);
+            return;
+          }
+        }
+
+        // Fetch messages.
+        let msgs: Awaited<ReturnType<typeof databaseService.messages.getMessages>>;
+        if (channelNumber !== undefined) {
+          msgs = await databaseService.messages.getMessagesBeforeInChannel(
+            channelNumber,
+            before,
+            fetchLimit,
+            source.id
+          );
+        } else {
+          // Legacy: no channel filter. Cursor-less offset fetch.
+          msgs = await databaseService.messages.getMessages(fetchLimit, 0, source.id);
+          if (before !== undefined) {
+            msgs = msgs.filter((m) => (m.rxTime ?? m.timestamp) < before);
+          }
+        }
+
+        // Build node-name lookup for this source so we can resolve sender
+        // display names server-side (avoids needing a second /nodes call).
+        let nodeMap = new Map<number, { longName?: string; shortName?: string }>();
+        try {
+          const nodes = await databaseService.nodes.getAllNodes(source.id);
+          for (const n of nodes) {
+            nodeMap.set(Number(n.nodeNum), {
+              longName: n.longName ?? undefined,
+              shortName: n.shortName ?? undefined,
+            });
+          }
+        } catch (err) {
+          logger.warn(`Failed to load nodes for source ${source.id}:`, err);
+        }
+
+        for (const m of msgs) {
+          const canonical = (m.rxTime ?? m.timestamp) as number;
+          const reqId = (m.requestId ?? null) as number | null;
+          // Dedup key: prefer (fromNodeNum, requestId). Fallback for rows
+          // with null requestId (should be rare) groups by text + ~1s window.
+          const fromNum = Number(m.fromNodeNum);
+          const dedupKey = reqId != null
+            ? `${fromNum}:${reqId}`
+            : `${fromNum}:${m.text ?? ''}:${Math.floor(canonical / 1000)}`;
+
+          const reception: Reception = {
+            sourceId: source.id,
+            sourceName: source.name,
+            hopStart: m.hopStart ?? null,
+            hopLimit: m.hopLimit ?? null,
+            rxSnr: m.rxSnr ?? null,
+            rxRssi: m.rxRssi ?? null,
+            rxTime: m.rxTime ?? null,
+            timestamp: m.timestamp,
+          };
+
+          const existing = merged.get(dedupKey);
+          if (existing) {
+            existing.receptions.push(reception);
+            // Canonical = earliest heard
+            if (canonical < existing.timestamp) existing.timestamp = canonical;
+          } else {
+            const sender = nodeMap.get(fromNum);
+            merged.set(dedupKey, {
+              dedupKey,
+              requestId: reqId,
+              fromNodeNum: fromNum,
+              fromNodeId: m.fromNodeId,
+              fromNodeLongName: sender?.longName,
+              fromNodeShortName: sender?.shortName,
+              toNodeNum: Number(m.toNodeNum),
+              toNodeId: m.toNodeId,
+              channel: m.channel,
+              channelName,
+              text: m.text ?? '',
+              emoji: m.emoji ?? null,
+              replyId: m.replyId ?? null,
+              timestamp: canonical,
+              receptions: [reception],
+            });
+          }
+        }
+      })
+    );
+
+    // Sort receptions within each merged entry so the frontend modal renders
+    // them in a stable order (earliest-heard first).
+    for (const m of merged.values()) {
+      m.receptions.sort((a, b) => a.timestamp - b.timestamp);
     }
 
-    allMessages.sort((a, b) => {
-      const ta = (a.timestamp as number) ?? 0;
-      const tb = (b.timestamp as number) ?? 0;
-      return tb - ta;
-    });
+    const allMerged = Array.from(merged.values());
+    allMerged.sort((a, b) => b.timestamp - a.timestamp);
 
-    res.json(allMessages.slice(0, limit));
+    res.json(allMerged.slice(0, limit));
   } catch (error) {
     logger.error('Error fetching unified messages:', error);
     res.status(500).json({ error: 'Failed to fetch unified messages' });

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -149,7 +149,7 @@ router.get('/channels', async (req: Request, res: Response) => {
  *
  * Response item shape:
  *   {
- *     dedupKey, requestId, fromNodeNum, fromNodeId,
+ *     dedupKey, packetId, requestId, fromNodeNum, fromNodeId,
  *     fromNodeLongName, fromNodeShortName,
  *     toNodeNum, toNodeId,
  *     channel, channelName,
@@ -182,6 +182,7 @@ router.get('/messages', async (req: Request, res: Response) => {
     };
     type Merged = {
       dedupKey: string;
+      packetId: number | null;
       requestId: number | null;
       fromNodeNum: number;
       fromNodeId: string;
@@ -295,6 +296,7 @@ router.get('/messages', async (req: Request, res: Response) => {
             const sender = nodeMap.get(fromNum);
             merged.set(dedupKey, {
               dedupKey,
+              packetId,
               requestId: reqId,
               fromNodeNum: fromNum,
               fromNodeId: m.fromNodeId,

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -16,6 +16,53 @@ const router = Router();
 router.use(optionalAuth());
 
 /**
+ * Resolve a channel's display name for unified views.
+ *
+ * Meshtastic channel conventions:
+ *  - Channel 0 is always the PRIMARY channel. Its name is often blank because
+ *    the Meshtastic client shows the modem preset instead; we label it
+ *    "Primary" so it surfaces in the unified channel picker.
+ *  - Channels with `role === 0` are DISABLED — skip entirely.
+ *  - Any other channel with a blank name is a disabled/unused slot — skip.
+ *
+ * Returns `null` when the channel should be omitted from the unified list.
+ */
+const PRIMARY_CHANNEL_NAME = 'Primary';
+function unifiedChannelDisplayName(c: {
+  id: number;
+  name?: string | null;
+  role?: number | null;
+}): string | null {
+  if (c.role === 0) return null; // DISABLED
+  const name = (c.name ?? '').trim();
+  if (name) return name;
+  if (c.id === 0) return PRIMARY_CHANNEL_NAME;
+  return null;
+}
+
+/**
+ * Extract the Meshtastic packet id from a stored message row id.
+ *
+ * Message rows are keyed as `${sourceId}_${fromNodeNum}_${meshPacket.id}` so
+ * that the same mesh packet received by multiple sources does NOT collide on
+ * the primary key. The trailing numeric segment is the packet id set by the
+ * originating node — identical across every receiver. This is the ONLY
+ * reliable cross-source dedup key for received text messages because the
+ * `requestId` column is only populated for Virtual Node ACK tracking, not for
+ * ordinary received text.
+ *
+ * Returns `null` when the id does not end in a numeric segment (defensive —
+ * should not happen for rows inserted by the current ingestion path).
+ */
+function extractPacketIdFromRowId(rowId: string): number | null {
+  const parts = rowId.split('_');
+  if (parts.length < 2) return null;
+  const last = parts[parts.length - 1];
+  const n = Number.parseInt(last, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
  * GET /api/unified/channels
  *
  * Returns a de-duplicated list of channel names across every source the user
@@ -52,8 +99,8 @@ router.get('/channels', async (req: Request, res: Response) => {
         try {
           const chans = await databaseService.channels.getAllChannels(source.id);
           for (const c of chans) {
-            const name = (c.name ?? '').trim();
-            if (!name) continue; // skip unnamed/disabled slots
+            const name = unifiedChannelDisplayName(c as any);
+            if (!name) continue; // disabled or unused slot
             const list = byName.get(name) ?? [];
             list.push({
               sourceId: source.id,
@@ -165,11 +212,13 @@ router.get('/messages', async (req: Request, res: Response) => {
         if (!canRead) return;
 
         // Resolve channel name → channel number for THIS source.
+        // Uses the same display-name rules as GET /channels so that the
+        // unnamed Primary (channel 0) can be selected from the dropdown.
         let channelNumber: number | undefined;
         if (channelName) {
           try {
             const chans = await databaseService.channels.getAllChannels(source.id);
-            const match = chans.find((c) => (c.name ?? '').trim() === channelName);
+            const match = chans.find((c) => unifiedChannelDisplayName(c as any) === channelName);
             if (!match) return; // source has no matching channel → skip
             channelNumber = (match as any).id;
           } catch (err) {
@@ -213,12 +262,18 @@ router.get('/messages', async (req: Request, res: Response) => {
         for (const m of msgs) {
           const canonical = (m.rxTime ?? m.timestamp) as number;
           const reqId = (m.requestId ?? null) as number | null;
-          // Dedup key: prefer (fromNodeNum, requestId). Fallback for rows
-          // with null requestId (should be rare) groups by text + ~1s window.
           const fromNum = Number(m.fromNodeNum);
-          const dedupKey = reqId != null
-            ? `${fromNum}:${reqId}`
-            : `${fromNum}:${m.text ?? ''}:${Math.floor(canonical / 1000)}`;
+          // Dedup key priority:
+          //   1. Mesh packet id (extracted from the row id) — the only field
+          //      that is identical across sources for the same mesh packet.
+          //   2. requestId — populated for Virtual Node ACK tracking.
+          //   3. Text + 1s window — last-resort fallback, single-source only.
+          const packetId = extractPacketIdFromRowId(String((m as any).id ?? ''));
+          const dedupKey = packetId != null
+            ? `${fromNum}:p${packetId}`
+            : reqId != null
+              ? `${fromNum}:r${reqId}`
+              : `${fromNum}:${m.text ?? ''}:${Math.floor(canonical / 1000)}`;
 
           const reception: Reception = {
             sourceId: source.id,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2145,6 +2145,12 @@ apiRouter.get('/messages/channel/:channel', optionalAuth(), async (req, res) => 
     // Validate and clamp limit (1-500) and offset (0-50000) to prevent abuse
     const limit = Math.max(1, Math.min(parseInt(req.query.limit as string) || 100, 500));
     const offset = Math.max(0, Math.min(parseInt(req.query.offset as string) || 0, 50000));
+    // Optional source scope — when provided, messages are filtered to that
+    // source. Without it, the legacy unscoped behavior is preserved so older
+    // clients still work.
+    const sourceIdParam = typeof req.query.sourceId === 'string' && req.query.sourceId.length > 0
+      ? req.query.sourceId
+      : undefined;
 
     // Check if this is a Primary channel request and map to channel 0 messages
     let messageChannel = requestedChannel;
@@ -2164,8 +2170,12 @@ apiRouter.get('/messages/channel/:channel', optionalAuth(), async (req, res) => 
       });
     }
 
-    // Fetch limit+1 to accurately detect if more messages exist
-    const dbMessages = await databaseService.getMessagesByChannelAsync(messageChannel, limit + 1, offset);
+    // Fetch limit+1 to accurately detect if more messages exist. When a sourceId
+    // is provided, bypass the sync facade (which doesn't accept sourceId) and
+    // go directly through the repository so the query is source-scoped.
+    const dbMessages = sourceIdParam
+      ? (await databaseService.messages.getMessagesByChannel(messageChannel, limit + 1, offset, sourceIdParam)) as DbMessage[]
+      : await databaseService.getMessagesByChannelAsync(messageChannel, limit + 1, offset);
     const hasMore = dbMessages.length > limit;
     // Return only the requested limit
     const messages = dbMessages.slice(0, limit).map(transformDbMessageToMeshMessage);
@@ -2182,8 +2192,13 @@ apiRouter.get('/messages/direct/:nodeId1/:nodeId2', requirePermission('messages'
     // Validate and clamp limit (1-500) and offset (0-50000) to prevent abuse
     const limit = Math.max(1, Math.min(parseInt(req.query.limit as string) || 100, 500));
     const offset = Math.max(0, Math.min(parseInt(req.query.offset as string) || 0, 50000));
+    // Optional source scope — DM threads are per-source (each source has its
+    // own view of a node pair). When omitted, returns DMs across every source.
+    const sourceIdParam = typeof req.query.sourceId === 'string' && req.query.sourceId.length > 0
+      ? req.query.sourceId
+      : undefined;
     // Fetch limit+1 to accurately detect if more messages exist
-    const dbMessages = await databaseService.messages.getDirectMessages(nodeId1, nodeId2, limit + 1, offset) as DbMessage[];
+    const dbMessages = await databaseService.messages.getDirectMessages(nodeId1, nodeId2, limit + 1, offset, sourceIdParam) as DbMessage[];
     const hasMore = dbMessages.length > limit;
     // Return only the requested limit
     const messages = dbMessages.slice(0, limit).map(transformDbMessageToMeshMessage);
@@ -4333,39 +4348,18 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
     // 3. Messages (requires any channel permission OR messages permission)
     try {
       if (hasChannelsRead || hasMessagesRead) {
-        // Fetch all messages globally (no sourceId filter) so cross-source messages are included.
-        // When a sourceId is specified, remap each message's channel slot index to match the
-        // requesting source's slot layout using name+PSK channel equivalence.
-        const dbMessagesRaw = await databaseService.messages.getMessages(100);
+        // Scope messages to the requesting source. Per-source tabs must only
+        // see messages their own source actually ingested — cross-source
+        // visibility belongs in the dedicated unified views (/unified/messages).
+        // When no sourceId is provided (legacy single-source clients), fall
+        // back to the global fetch.
+        const dbMessagesRaw = pollSourceId
+          ? await databaseService.messages.getMessages(100, 0, pollSourceId)
+          : await databaseService.messages.getMessages(100);
 
-        let messages: MeshMessage[];
-        if (pollSourceId) {
-          // Build a channel equivalence map: (otherSourceId_slotIndex) -> requestingSource slotIndex
-          const allChannelsGlobal = await databaseService.channels.getAllChannels();
-          const myChannels = allChannelsGlobal.filter(c => (c as any).sourceId === pollSourceId);
-          const channelRemap = new Map<string, number>();
-          for (const myChannel of myChannels) {
-            if (!myChannel.name || myChannel.role === 0) continue;
-            for (const otherChannel of allChannelsGlobal) {
-              if ((otherChannel as any).sourceId === pollSourceId) continue;
-              if (otherChannel.name === myChannel.name && otherChannel.psk === myChannel.psk) {
-                channelRemap.set(`${(otherChannel as any).sourceId}_${otherChannel.id}`, myChannel.id);
-              }
-            }
-          }
-          // Remap each cross-source message's channel to the requesting source's equivalent slot
-          messages = dbMessagesRaw.map(msg => {
-            const msgSourceId = (msg as any).sourceId;
-            let channel = msg.channel;
-            if (channel !== -1 && msgSourceId && msgSourceId !== pollSourceId) {
-              const remapped = channelRemap.get(`${msgSourceId}_${channel}`);
-              if (remapped !== undefined) channel = remapped;
-            }
-            return transformDbMessageToMeshMessage({ ...msg, channel } as any as DbMessage);
-          });
-        } else {
-          messages = dbMessagesRaw.map(msg => transformDbMessageToMeshMessage(msg as any as DbMessage));
-        }
+        let messages: MeshMessage[] = dbMessagesRaw.map(
+          msg => transformDbMessageToMeshMessage(msg as any as DbMessage)
+        );
 
         // Filter messages based on permissions
         if (hasChannelsRead && !hasMessagesRead) {

--- a/src/server/services/webSocketService.ts
+++ b/src/server/services/webSocketService.ts
@@ -171,9 +171,10 @@ export function initializeWebSocket(
     const handler = async (event: DataEvent) => {
       // Source-aware filtering: if the client has joined source rooms, only forward
       // events that match one of those rooms. Legacy clients (no rooms) get all events.
-      // Exception: message:new events are globally visible across sources — broadcast to all.
+      // Unified views join every accessible source room, so they still see everything;
+      // per-source tabs join exactly one and stay isolated.
       const sourceRooms = Array.from(socket.rooms).filter(r => r.startsWith('source:'));
-      if (sourceRooms.length > 0 && event.sourceId && event.type !== 'message:new') {
+      if (sourceRooms.length > 0 && event.sourceId) {
         if (!sourceRooms.includes(`source:${event.sourceId}`)) {
           return; // Skip — event is from a source this client didn't join
         }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -531,11 +531,14 @@ class ApiService {
   async getChannelMessages(
     channel: number,
     limit: number = 100,
-    offset: number = 0
+    offset: number = 0,
+    sourceId?: string | null
   ): Promise<{ messages: MeshMessage[]; hasMore: boolean }> {
     await this.ensureBaseUrl();
+    const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+    if (sourceId) params.set('sourceId', sourceId);
     const response = await fetch(
-      `${this.baseUrl}/api/messages/channel/${channel}?limit=${limit}&offset=${offset}`,
+      `${this.baseUrl}/api/messages/channel/${channel}?${params.toString()}`,
       { credentials: 'include' }
     );
     if (!response.ok) throw new Error('Failed to fetch channel messages');
@@ -546,11 +549,14 @@ class ApiService {
     nodeId1: string,
     nodeId2: string,
     limit: number = 100,
-    offset: number = 0
+    offset: number = 0,
+    sourceId?: string | null
   ): Promise<{ messages: MeshMessage[]; hasMore: boolean }> {
     await this.ensureBaseUrl();
+    const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+    if (sourceId) params.set('sourceId', sourceId);
     const response = await fetch(
-      `${this.baseUrl}/api/messages/direct/${nodeId1}/${nodeId2}?limit=${limit}&offset=${offset}`,
+      `${this.baseUrl}/api/messages/direct/${nodeId1}/${nodeId2}?${params.toString()}`,
       { credentials: 'include' }
     );
     if (!response.ok) throw new Error('Failed to fetch direct messages');

--- a/src/styles/unified.css
+++ b/src/styles/unified.css
@@ -12,6 +12,28 @@
   font-family: var(--font-family, sans-serif);
 }
 
+/* Chat-style fixed-viewport layout for pages that pin content to the bottom
+   and scroll upward into history (UnifiedMessagesPage). Overrides the default
+   page flow so the messages column becomes the only scroll surface. */
+.unified-page--chat {
+  height: 100vh;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.unified-page--chat .unified-header {
+  flex-shrink: 0;
+}
+
+.unified-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-anchor: none; /* we manage scroll position imperatively */
+}
+
 /* ── Header bar ─────────────────────────────────────────────────────────── */
 
 .unified-header {

--- a/src/styles/unified.css
+++ b/src/styles/unified.css
@@ -224,6 +224,231 @@
   word-break: break-word;
 }
 
+/* ── Clickable message card (Unified Messages) ─────────────────────────── */
+
+.unified-msg-card--clickable {
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.unified-msg-card--clickable:hover {
+  background: var(--ctp-surface0);
+}
+
+.unified-msg-card--clickable:focus-visible {
+  outline: 2px solid var(--ctp-blue);
+  outline-offset: 2px;
+}
+
+.unified-msg-card__reception-count {
+  color: var(--ctp-green);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+/* Reply preview (↳ quoted parent) */
+.unified-reply-preview {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 4px 8px;
+  margin: 4px 0 6px;
+  background: var(--ctp-surface0);
+  border-left: 2px solid var(--ctp-overlay0);
+  border-radius: 0 6px 6px 0;
+  font-size: 12px;
+}
+
+.unified-reply-preview__arrow {
+  color: var(--ctp-overlay0);
+}
+
+.unified-reply-preview__from {
+  color: var(--ctp-subtext0);
+  font-weight: 600;
+}
+
+.unified-reply-preview__text {
+  color: var(--ctp-subtext0);
+  opacity: 0.8;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+/* Emoji reaction bubbles attached to parent message */
+.unified-reactions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+  padding-top: 6px;
+  border-top: 1px dashed var(--ctp-surface1);
+}
+
+.unified-reaction {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--ctp-surface0);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: 99px;
+  padding: 2px 8px;
+  font-size: 13px;
+}
+
+.unified-reaction__from {
+  color: var(--ctp-subtext0);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+/* Infinite-scroll sentinel */
+.unified-scroll-sentinel {
+  text-align: center;
+  padding: 16px 0 32px;
+  color: var(--ctp-overlay0);
+  font-size: 12px;
+  min-height: 32px;
+}
+
+/* ── Reception stats modal ─────────────────────────────────────────────── */
+
+.unified-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--ctp-crust) 70%, transparent);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+
+.unified-modal {
+  background: var(--ctp-mantle);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: 12px;
+  max-width: 640px;
+  width: 100%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+}
+
+.unified-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--ctp-surface0);
+}
+
+.unified-modal__header h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--ctp-text);
+}
+
+.unified-modal__close {
+  background: none;
+  border: none;
+  color: var(--ctp-subtext0);
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.unified-modal__close:hover {
+  background: var(--ctp-surface0);
+  color: var(--ctp-text);
+}
+
+.unified-modal__body {
+  padding: 16px 20px;
+  overflow-y: auto;
+}
+
+.unified-modal__summary {
+  background: var(--ctp-base);
+  border: 1px solid var(--ctp-surface0);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin-bottom: 16px;
+}
+
+.unified-modal__sender {
+  font-weight: 700;
+  color: var(--ctp-text);
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.unified-modal__text {
+  color: var(--ctp-text);
+  font-size: 14px;
+  line-height: 1.5;
+  word-break: break-word;
+  margin-bottom: 6px;
+}
+
+.unified-modal__meta {
+  font-size: 11px;
+  color: var(--ctp-overlay0);
+}
+
+.unified-modal__meta code {
+  background: var(--ctp-surface0);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--ctp-subtext0);
+}
+
+.unified-modal__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.unified-modal__table thead th {
+  text-align: left;
+  padding: 6px 10px;
+  color: var(--ctp-subtext0);
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--ctp-surface0);
+}
+
+.unified-modal__table tbody td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--ctp-surface0);
+  color: var(--ctp-text);
+}
+
+.unified-modal__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.unified-modal__source-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
 /* ── Telemetry source group ──────────────────────────────────────────────── */
 
 .unified-telem-source {


### PR DESCRIPTION
## Summary
Adds a cross-source Unified Messages view and fixes several per-source isolation bugs that caused messages to leak between source tabs. Also wires tapback reactions/replies in the unified view and fixes a DB migration that was preventing Sandbox-type sources from ingesting nodes on Postgres.

## Changes
- **Unified Messages page**: channel picker, cross-source dedup by meshpacket id, reception quality modal, infinite scroll, chat-style layout (newest at bottom, auto-scroll)
- **Unnamed Primary channel**: channel 0 with blank name now labeled "Primary" so it surfaces in the unified channel picker
- **Tapback reactions/replies**: unified API now returns `packetId`; UI indexes by packetId (matches firmware `reply_id` semantics — parent is a meshpacket id, not a requestId)
- **Per-source message isolation**:
  - `/api/poll` was fetching globally and channel-remapping results → per-source tabs saw other sources' messages. Now scoped to `sourceId` when provided.
  - `/api/messages/channel/:channel` and `/api/messages/direct/:nodeId1/:nodeId2` accept optional `sourceId` query param.
  - `api.getChannelMessages` / `api.getDirectMessages` pass `sourceId` from `SourceContext`.
- **WebSocket room filtering**: dropped the `message:new` exception so per-source tabs only receive events for their joined room.
- **Migration 031**: drop legacy standalone `UNIQUE` on `nodes.nodeId` using `pg_attribute` joining (migration 029's ILIKE pattern failed to match the quoted column name, blocking second-source node ingestion on Postgres).

## Issues Resolved
None (investigative bug fixes + feature work for the multi-source phase of 4.0).

## Documentation Updates
No documentation changes needed — unified views are newly exposed pages, feature-visible in the nav.

## Testing
- [x] Unit tests pass (4209 passed, 21 todo, 471 skipped)
- [x] TypeScript compiles cleanly
- [ ] Manual: unified messages view shows channel dropdown, "Primary" entry selectable, messages dedup across sources
- [ ] Manual: tapback reactions render grouped under parent; reply previews resolve
- [ ] Manual: per-source Messages tab only shows that source's messages (no cross-source leak)
- [ ] Manual: Postgres second source ingests nodes after migration 031

🤖 Generated with [Claude Code](https://claude.com/claude-code)