### PR TITLE
fix: harden unified routes + migration 031 verification

### DIFF
--- a/src/server/migrations/031_drop_legacy_nodes_unique.ts
+++ b/src/server/migrations/031_drop_legacy_nodes_unique.ts
@@ -94,6 +94,49 @@ export async function runMigration031Postgres(client: any): Promise<void> {
     await client.query(`DROP INDEX IF EXISTS "${row.indexname}"`);
   }
 
+  // Verification: re-run the same discovery queries and confirm nothing
+  // survived the drops. If anything remains we log an error so operators see
+  // the failure in logs (we do NOT throw — the app still starts, since the
+  // degraded state is the pre-031 behavior the migration is trying to fix).
+  const verifyConstraints = await client.query(`
+    SELECT c.conname
+    FROM pg_constraint c
+    WHERE c.conrelid = 'nodes'::regclass
+      AND c.contype = 'u'
+      AND (
+        SELECT array_agg(a.attname ORDER BY a.attnum)
+        FROM unnest(c.conkey) AS k(attnum)
+        JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+      ) = ARRAY['nodeId']::name[]
+  `);
+  const verifyIndexes = await client.query(`
+    SELECT i.relname AS indexname
+    FROM pg_index ix
+    JOIN pg_class i ON i.oid = ix.indexrelid
+    JOIN pg_class t ON t.oid = ix.indrelid
+    WHERE t.relname = 'nodes'
+      AND ix.indisunique
+      AND NOT ix.indisprimary
+      AND (
+        SELECT array_agg(a.attname ORDER BY a.attnum)
+        FROM unnest(ix.indkey) AS k(attnum)
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+      ) = ARRAY['nodeId']::name[]
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_constraint c WHERE c.conindid = i.oid
+      )
+  `);
+
+  if (verifyConstraints.rows.length > 0 || verifyIndexes.rows.length > 0) {
+    logger.error(
+      'Migration 031 verification FAILED: legacy unique on nodes.nodeId still present. ' +
+      `constraints=${JSON.stringify(verifyConstraints.rows)} ` +
+      `indexes=${JSON.stringify(verifyIndexes.rows)}`
+    );
+  } else {
+    logger.info('Migration 031 (PostgreSQL): verified no legacy unique on nodes.nodeId remains');
+  }
+
   logger.info('Migration 031 complete (PostgreSQL)');
 }
 

--- a/src/server/routes/unifiedRoutes.test.ts
+++ b/src/server/routes/unifiedRoutes.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express, { Express } from 'express';
 import session from 'express-session';
 import request from 'supertest';
-import unifiedRoutes from './unifiedRoutes.js';
+import unifiedRoutes, { extractPacketIdFromRowId } from './unifiedRoutes.js';
 import databaseService from '../../services/database.js';
 
 vi.mock('../../services/database.js', () => ({
@@ -581,6 +581,98 @@ describe('Unified Routes', () => {
       const res = await request(app).get('/telemetry');
 
       expect(res.status).toBe(500);
+    });
+
+    it('keeps per-node telemetry lookups parallel and tolerates a single-node failure', async () => {
+      // When one node's telemetry fetch rejects, the endpoint should still
+      // return entries for the other nodes in the same source rather than
+      // failing the whole source. Also verifies getLatestTelemetryByNode is
+      // called once per node (parallel fan-out, not sequential).
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
+      mockDb.nodes.getAllNodes.mockResolvedValue([
+        { nodeId: '!aabbccdd', nodeNum: 0xaabbccdd, longName: 'Node One', shortName: 'N1' },
+        { nodeId: '!11223344', nodeNum: 0x11223344, longName: 'Node Two', shortName: 'N2' },
+      ]);
+      mockDb.telemetry.getLatestTelemetryByNode.mockImplementation((nodeId: string) => {
+        if (nodeId === '!aabbccdd') {
+          return Promise.reject(new Error('boom'));
+        }
+        return Promise.resolve([
+          { nodeId: '!11223344', nodeNum: 0x11223344, telemetryType: 'battery_level', value: 90, timestamp: recentTs },
+        ]);
+      });
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/telemetry');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].nodeLongName).toBe('Node Two');
+      expect(mockDb.telemetry.getLatestTelemetryByNode).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── /messages (partial-failure isolation) ────────────────────────────────
+
+  describe('GET /messages partial failures', () => {
+    it('keeps other sources working when a single source node lookup fails', async () => {
+      // nodes.getAllNodes throws for src-a but the message still comes through
+      // (without sender longName). src-b operates normally.
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
+      mockDb.channels.getAllChannels.mockResolvedValue([{ id: 0, name: 'Primary', role: 1 }]);
+      mockDb.nodes.getAllNodes.mockImplementation((sourceId: string) => {
+        if (sourceId === 'src-a') return Promise.reject(new Error('nodes boom'));
+        return Promise.resolve([NODE_ONE]);
+      });
+      mockDb.messages.getMessagesBeforeInChannel.mockImplementation(
+        (_ch: number, _before: any, _lim: number, sourceId: string) =>
+          Promise.resolve([
+            mkMsg({
+              id: `${sourceId}_${NODE_ONE.nodeNum}_42`,
+              text: `from ${sourceId}`,
+              fromNodeNum: NODE_ONE.nodeNum,
+              timestamp: sourceId === 'src-a' ? 1000 : 2000,
+              rxTime: sourceId === 'src-a' ? 1000 : 2000,
+            }),
+          ])
+      );
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/messages?channel=Primary');
+
+      expect(res.status).toBe(200);
+      // Dedup on packet id 42 across sources → single entry, 2 receptions
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].receptions).toHaveLength(2);
+      expect(res.body[0].fromNodeLongName).toBe('Node One'); // src-b's node map won
+    });
+  });
+
+  // ── extractPacketIdFromRowId unit tests ──────────────────────────────────
+
+  describe('extractPacketIdFromRowId', () => {
+    it('parses the trailing numeric segment', () => {
+      expect(extractPacketIdFromRowId('src-a_1234_567890')).toBe(567890);
+    });
+
+    it('returns null for empty, non-string, or oversized input', () => {
+      expect(extractPacketIdFromRowId('')).toBeNull();
+      expect(extractPacketIdFromRowId(123 as any)).toBeNull();
+      expect(extractPacketIdFromRowId(null as any)).toBeNull();
+      expect(extractPacketIdFromRowId(undefined as any)).toBeNull();
+      expect(extractPacketIdFromRowId('x'.repeat(300))).toBeNull();
+    });
+
+    it('returns null for ids without an underscore-separated numeric tail', () => {
+      expect(extractPacketIdFromRowId('no-underscore')).toBeNull();
+      expect(extractPacketIdFromRowId('src_a_12abc')).toBeNull();
+      expect(extractPacketIdFromRowId('src_a_')).toBeNull();
+    });
+
+    it('rejects values outside unsigned 32-bit range', () => {
+      expect(extractPacketIdFromRowId('src_a_4294967295')).toBe(0xffffffff); // max valid
+      expect(extractPacketIdFromRowId('src_a_4294967296')).toBeNull(); // one over
+      expect(extractPacketIdFromRowId('src_a_99999999999')).toBeNull();
     });
   });
 });

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -51,15 +51,29 @@ function unifiedChannelDisplayName(c: {
  * `requestId` column is only populated for Virtual Node ACK tracking, not for
  * ordinary received text.
  *
- * Returns `null` when the id does not end in a numeric segment (defensive —
- * should not happen for rows inserted by the current ingestion path).
+ * Defensive validation (rowId comes from DB so trusted, but cheap to harden):
+ *  - non-string or empty → null
+ *  - unreasonably long (>256 chars) → null, guards against malformed input
+ *  - trailing segment must be a non-negative finite integer within the
+ *    Meshtastic packet id range (unsigned 32-bit)
+ *
+ * Returns `null` when the id cannot be parsed to a valid packet id.
  */
-function extractPacketIdFromRowId(rowId: string): number | null {
+const MAX_ROW_ID_LENGTH = 256;
+const MAX_PACKET_ID = 0xffffffff; // unsigned 32-bit
+export function extractPacketIdFromRowId(rowId: unknown): number | null {
+  if (typeof rowId !== 'string' || rowId.length === 0 || rowId.length > MAX_ROW_ID_LENGTH) {
+    return null;
+  }
   const parts = rowId.split('_');
   if (parts.length < 2) return null;
   const last = parts[parts.length - 1];
+  // Reject anything that isn't pure digits — Number.parseInt would otherwise
+  // accept things like "12abc" → 12.
+  if (!/^\d+$/.test(last)) return null;
   const n = Number.parseInt(last, 10);
-  return Number.isFinite(n) ? n : null;
+  if (!Number.isFinite(n) || n < 0 || n > MAX_PACKET_ID) return null;
+  return n;
 }
 
 /**
@@ -212,23 +226,49 @@ router.get('/messages', async (req: Request, res: Response) => {
           : false);
         if (!canRead) return;
 
-        // Resolve channel name → channel number for THIS source.
-        // Uses the same display-name rules as GET /channels so that the
-        // unnamed Primary (channel 0) can be selected from the dropdown.
+        // Resolve channel name → channel number AND build node-name map in
+        // parallel. Both are independent reads against this source's DB slice
+        // and used only inside this per-source block, so we can fan them out
+        // instead of running them back-to-back.
+        const nodeMap = new Map<number, { longName?: string; shortName?: string }>();
         let channelNumber: number | undefined;
+
+        const [chansResult, nodesResult] = await Promise.allSettled([
+          channelName
+            ? databaseService.channels.getAllChannels(source.id)
+            : Promise.resolve(null),
+          databaseService.nodes.getAllNodes(source.id),
+        ]);
+
         if (channelName) {
-          try {
-            const chans = await databaseService.channels.getAllChannels(source.id);
-            const match = chans.find((c) => unifiedChannelDisplayName(c as any) === channelName);
-            if (!match) return; // source has no matching channel → skip
-            channelNumber = (match as any).id;
-          } catch (err) {
-            logger.warn(`Failed to resolve channel '${channelName}' for source ${source.id}:`, err);
+          if (chansResult.status === 'rejected') {
+            logger.warn(
+              `Failed to resolve channel '${channelName}' for source ${source.id}:`,
+              chansResult.reason
+            );
             return;
           }
+          const chans = chansResult.value;
+          const match = chans?.find(
+            (c) => unifiedChannelDisplayName(c as any) === channelName
+          );
+          if (!match) return; // source has no matching channel → skip
+          channelNumber = (match as any).id;
         }
 
-        // Fetch messages.
+        if (nodesResult.status === 'fulfilled') {
+          for (const n of nodesResult.value) {
+            nodeMap.set(Number(n.nodeNum), {
+              longName: n.longName ?? undefined,
+              shortName: n.shortName ?? undefined,
+            });
+          }
+        } else {
+          logger.warn(`Failed to load nodes for source ${source.id}:`, nodesResult.reason);
+        }
+
+        // Fetch messages. Kept sequential after the channel lookup because the
+        // query depends on `channelNumber`.
         let msgs: Awaited<ReturnType<typeof databaseService.messages.getMessages>>;
         if (channelNumber !== undefined) {
           msgs = await databaseService.messages.getMessagesBeforeInChannel(
@@ -243,21 +283,6 @@ router.get('/messages', async (req: Request, res: Response) => {
           if (before !== undefined) {
             msgs = msgs.filter((m) => (m.rxTime ?? m.timestamp) < before);
           }
-        }
-
-        // Build node-name lookup for this source so we can resolve sender
-        // display names server-side (avoids needing a second /nodes call).
-        let nodeMap = new Map<number, { longName?: string; shortName?: string }>();
-        try {
-          const nodes = await databaseService.nodes.getAllNodes(source.id);
-          for (const n of nodes) {
-            nodeMap.set(Number(n.nodeNum), {
-              longName: n.longName ?? undefined,
-              shortName: n.shortName ?? undefined,
-            });
-          }
-        } catch (err) {
-          logger.warn(`Failed to load nodes for source ${source.id}:`, err);
         }
 
         for (const m of msgs) {
@@ -292,6 +317,18 @@ router.get('/messages', async (req: Request, res: Response) => {
             existing.receptions.push(reception);
             // Canonical = earliest heard
             if (canonical < existing.timestamp) existing.timestamp = canonical;
+            // Upgrade sender display names if a later source knows the node
+            // and the first-seen entry didn't. Common when one source's
+            // nodes.getAllNodes failed or simply hasn't learned the sender yet.
+            if (!existing.fromNodeLongName || !existing.fromNodeShortName) {
+              const sender = nodeMap.get(fromNum);
+              if (sender?.longName && !existing.fromNodeLongName) {
+                existing.fromNodeLongName = sender.longName;
+              }
+              if (sender?.shortName && !existing.fromNodeShortName) {
+                existing.fromNodeShortName = sender.shortName;
+              }
+            }
           } else {
             const sender = nodeMap.get(fromNum);
             merged.set(dedupKey, {
@@ -365,9 +402,27 @@ router.get('/telemetry', async (req: Request, res: Response) => {
         const nodes = await databaseService.nodes.getAllNodes(source.id);
         const entries: Array<Record<string, unknown>> = [];
 
-        for (const node of nodes) {
-          const latest = await databaseService.telemetry.getLatestTelemetryByNode(node.nodeId);
-          for (const t of latest) {
+        // Fan out per-node telemetry lookups in parallel rather than awaiting
+        // each one sequentially. On a multi-source deployment the sequential
+        // form was the dominant cost of /api/unified/telemetry — O(sources *
+        // nodes) serial round trips through Drizzle.
+        const perNodeLatest = await Promise.all(
+          nodes.map((node) =>
+            databaseService.telemetry
+              .getLatestTelemetryByNode(node.nodeId)
+              .then((latest) => ({ node, latest }))
+              .catch((err) => {
+                logger.warn(
+                  `Failed to load telemetry for node ${node.nodeId} (source ${source.id}):`,
+                  err
+                );
+                return { node, latest: [] as Array<{ timestamp: number }> };
+              })
+          )
+        );
+
+        for (const { node, latest } of perNodeLatest) {
+          for (const t of latest as any[]) {
             if (t.timestamp >= cutoff) {
               entries.push({
                 ...t,


### PR DESCRIPTION
## Summary
Follow-ups from the PR #2632 Claude Code Review. Targeted, low-risk fixes addressing the highest-value code-quality items from that review — defensive input validation, real N+1 removal in unified telemetry, per-source failure isolation, and a migration 031 post-drop verification step.

Larger items from the review (frontend component tests, configurable polling interval, caching layer, rate limiting, breaking response-shape changes) are intentionally deferred to their own PRs.

## Changes
- **`extractPacketIdFromRowId`** — validate input type, bound length (<=256), require pure digits, reject outside unsigned-32-bit range. Exported for direct unit testing.
- **`/api/unified/messages`**:
  - Per-source channel and node lookups now fan out via `Promise.allSettled` instead of awaiting sequentially. A single failure on one source no longer blocks the rest of that source's pipeline.
  - Dedup merge upgrades sender display names when a later source knows the node and the first-seen entry didn't. Fixes a regression where a failed `nodes.getAllNodes()` on one source left the merged entry unnamed even when another source had it.
- **`/api/unified/telemetry`** — parallelize per-node `getLatestTelemetryByNode` calls (the real N+1 the reviewer flagged). Per-node failures degrade to empty lists rather than failing the whole source.
- **Migration 031 (PostgreSQL)** — re-run the discovery queries after the drops, log an error if anything survived. Non-fatal: the degraded state is the pre-031 baseline.
- **6 new unit tests** covering the packet-id helper, telemetry parallel-failure case, and cross-source sender-name upgrade (30/30 in `unifiedRoutes.test.ts` green).

## Issues Resolved
None directly — these are polish/hardening items surfaced by the PR #2632 review.

## Documentation Updates
No documentation changes needed — all changes are internal hardening.

## Testing
- [x] Unit tests pass (4215 passed, 6 new)
- [x] TypeScript compiles cleanly
- [ ] Manual: unified messages view still dedupes cross-source packets correctly
- [ ] Manual: unified telemetry view still renders for multi-source deployments
- [ ] Manual: Postgres second-source upgrade logs "verified no legacy unique on nodes.nodeId remains"

## Deferred Follow-ups (not in this PR)
1. Frontend component tests for `UnifiedMessagesPage.tsx`
2. Configurable polling interval (settings plumbing)
3. Caching layer for channel/node lookups
4. Rate limiting on unified endpoints
5. Partial error reporting via response-shape change

🤖 Generated with [Claude Code](https://claude.com/claude-code)