### PR TITLE
fix(sqlite): convert source_id raw SQL to Drizzle sync helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - **Unified views**: Cross-source Messages and Telemetry pages show fleet-wide activity across all connected gateways
   - **Real-time updates**: WebSocket rooms are scoped per source; clients only receive events for the sources they have access to
   - **Backward compatible**: Existing single-source deployments upgrade automatically — legacy rows are assigned to the default source on startup
+  - **Fix ([#2631](https://github.com/Yeraze/meshmonitor/issues/2631))**: Fresh SQLite installs crashed with `SqliteError: no such column: source_id` when fetching node telemetry. Three raw SQL sites in `DatabaseService` referenced the column as `source_id` while the schema defines `sourceId`. Converted `purgeChannelMessages`, `purgeDirectMessages`, and `getTelemetryByNodeAveraged` to dispatch through new Drizzle-backed sync helpers on the repositories so column names come from the schema and the drift can't recur
 
 - **Homepage Refresh** ([#2542](https://github.com/Yeraze/meshmonitor/pull/2542)): MeshMonitor.org homepage redesigned for clarity and accuracy.
   - **New hero section**: Updated headline ("Your mesh. Your data."), new tagline, and hero image showing the interactive map

--- a/src/db/repositories/messages.purge.test.ts
+++ b/src/db/repositories/messages.purge.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Messages Repository - purge sync helpers tests (SQLite-only)
+ *
+ * Regression coverage for issue #2631: the facade's SQLite branch previously
+ * used raw SQL with `source_id`, but the schema column is `sourceId` — any
+ * call with a sourceId parameter crashed. The sync helpers added to the repo
+ * use Drizzle query builders so column names come from the schema.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { MessagesRepository } from './messages.js';
+import * as schema from '../schema/index.js';
+
+describe('MessagesRepository sync purge helpers', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: MessagesRepository;
+
+  const NODE1_NUM = 0xaabbccdd;
+  const NODE1_ID = '!aabbccdd';
+  const NODE2_NUM = 0x11223344;
+  const NODE2_ID = '!11223344';
+  const NODE3_NUM = 0x55667788;
+  const NODE3_ID = '!55667788';
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+
+    db.exec(`
+      CREATE TABLE nodes (
+        nodeNum INTEGER PRIMARY KEY,
+        nodeId TEXT NOT NULL UNIQUE,
+        longName TEXT,
+        shortName TEXT
+      )
+    `);
+
+    db.exec(`
+      INSERT INTO nodes (nodeNum, nodeId) VALUES (${NODE1_NUM}, '${NODE1_ID}');
+      INSERT INTO nodes (nodeNum, nodeId) VALUES (${NODE2_NUM}, '${NODE2_ID}');
+      INSERT INTO nodes (nodeNum, nodeId) VALUES (${NODE3_NUM}, '${NODE3_ID}');
+    `);
+
+    db.exec(`
+      CREATE TABLE messages (
+        id TEXT PRIMARY KEY,
+        fromNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+        toNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+        fromNodeId TEXT NOT NULL,
+        toNodeId TEXT NOT NULL,
+        text TEXT NOT NULL,
+        channel INTEGER NOT NULL DEFAULT 0,
+        portnum INTEGER,
+        requestId INTEGER,
+        timestamp INTEGER NOT NULL,
+        rxTime INTEGER,
+        hopStart INTEGER,
+        hopLimit INTEGER,
+        relayNode INTEGER,
+        replyId INTEGER,
+        emoji INTEGER,
+        viaMqtt INTEGER,
+        rxSnr REAL,
+        rxRssi REAL,
+        ackFailed INTEGER,
+        routingErrorReceived INTEGER,
+        deliveryState TEXT,
+        wantAck INTEGER,
+        ackFromNode INTEGER,
+        createdAt INTEGER NOT NULL,
+        decrypted_by TEXT,
+        sourceId TEXT
+      )
+    `);
+
+    drizzleDb = drizzle(db, { schema });
+    repo = new MessagesRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  const insertMsg = async (
+    id: string,
+    fromNum: number,
+    fromId: string,
+    toNum: number,
+    toId: string,
+    channel: number,
+    sourceId?: string
+  ) => {
+    await repo.insertMessage(
+      {
+        id,
+        fromNodeNum: fromNum,
+        toNodeNum: toNum,
+        fromNodeId: fromId,
+        toNodeId: toId,
+        text: 'msg',
+        channel,
+        portnum: 1,
+        timestamp: Date.now(),
+        rxTime: Date.now(),
+        createdAt: Date.now(),
+      } as any,
+      sourceId
+    );
+  };
+
+  describe('purgeChannelMessagesSqlite', () => {
+    it('does not throw when called with a sourceId (issue #2631 regression)', async () => {
+      await insertMsg('m1', NODE1_NUM, NODE1_ID, NODE2_NUM, NODE2_ID, 0, 'src-a');
+      expect(() => repo.purgeChannelMessagesSqlite(0, 'src-a')).not.toThrow();
+    });
+
+    it('purges only messages on the given channel and source', async () => {
+      await insertMsg('m1', NODE1_NUM, NODE1_ID, NODE2_NUM, NODE2_ID, 0, 'src-a');
+      await insertMsg('m2', NODE1_NUM, NODE1_ID, NODE2_NUM, NODE2_ID, 0, 'src-b');
+      await insertMsg('m3', NODE1_NUM, NODE1_ID, NODE2_NUM, NODE2_ID, 1, 'src-a');
+
+      const deleted = repo.purgeChannelMessagesSqlite(0, 'src-a');
+      expect(deleted).toBe(1);
+
+      const remaining = db.prepare('SELECT id FROM messages ORDER BY id').all() as { id: string }[];
+      expect(remaining.map(r => r.id)).toEqual(['m2', 'm3']);
+    });
+
+    it('purges all sources for the channel when sourceId is undefined', async () => {
+      await insertMsg('m1', NODE1_NUM, NODE1_ID, NODE2_NUM, NODE2_ID, 0, 'src-a');
+      await insertMsg('m2', NODE1_NUM, NODE1_ID, NODE2_NUM, NODE2_ID, 0, 'src-b');
+      await insertMsg('m3', NODE1_NUM, NODE1_ID, NODE2_NUM, NODE2_ID, 1, 'src-a');
+
+      const deleted = repo.purgeChannelMessagesSqlite(0);
+      expect(deleted).toBe(2);
+
+      const remaining = db.prepare('SELECT id FROM messages').all() as { id: string }[];
+      expect(remaining.map(r => r.id)).toEqual(['m3']);
+    });
+  });
+
+  describe('purgeDirectMessagesSqlite', () => {
+    it('does not throw when called with a sourceId (issue #2631 regression)', async () => {
+      await insertMsg('m1', NODE1_NUM, NODE1_ID, NODE2_NUM, NODE2_ID, 0, 'src-a');
+      expect(() => repo.purgeDirectMessagesSqlite(NODE1_NUM, 'src-a')).not.toThrow();
+    });
+
+    it('purges only DMs involving the node on the given source', async () => {
+      // DM src-a: m1
+      await insertMsg('m1', NODE1_NUM, NODE1_ID, NODE2_NUM, NODE2_ID, 0, 'src-a');
+      // DM src-b: m2
+      await insertMsg('m2', NODE2_NUM, NODE2_ID, NODE1_NUM, NODE1_ID, 0, 'src-b');
+      // Unrelated DM on src-a between NODE3 ↔ NODE2: m3
+      await insertMsg('m3', NODE3_NUM, NODE3_ID, NODE2_NUM, NODE2_ID, 0, 'src-a');
+
+      const deleted = repo.purgeDirectMessagesSqlite(NODE1_NUM, 'src-a');
+      expect(deleted).toBe(1);
+
+      const remaining = db.prepare('SELECT id FROM messages ORDER BY id').all() as { id: string }[];
+      expect(remaining.map(r => r.id)).toEqual(['m2', 'm3']);
+    });
+
+    it('excludes broadcast messages (!ffffffff)', async () => {
+      // Add the broadcast target node so the foreign key holds
+      db.exec(`INSERT OR IGNORE INTO nodes (nodeNum, nodeId) VALUES (${0xffffffff}, '!ffffffff')`);
+
+      // Broadcast looks like a DM by fromNode, but toNodeId is !ffffffff
+      await insertMsg('bcast', NODE1_NUM, NODE1_ID, 0xffffffff, '!ffffffff', 0, 'src-a');
+      await insertMsg('dm', NODE1_NUM, NODE1_ID, NODE2_NUM, NODE2_ID, 0, 'src-a');
+
+      const deleted = repo.purgeDirectMessagesSqlite(NODE1_NUM, 'src-a');
+      expect(deleted).toBe(1); // only the DM
+
+      const remaining = db.prepare('SELECT id FROM messages ORDER BY id').all() as { id: string }[];
+      expect(remaining.map(r => r.id)).toEqual(['bcast']);
+    });
+  });
+});

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -258,6 +258,46 @@ export class MessagesRepository extends BaseRepository {
   }
 
   /**
+   * SQLite-only synchronous purge of channel messages. Mirrors
+   * `purgeChannelMessages()` but returns the count synchronously so the
+   * sync `DatabaseService` facade can use it directly. Uses Drizzle query
+   * builders so column names come from the schema.
+   */
+  purgeChannelMessagesSqlite(channel: number, sourceId?: string): number {
+    if (!this.sqliteDb) {
+      throw new Error('purgeChannelMessagesSqlite is SQLite-only');
+    }
+    const db = this.sqliteDb;
+    const messages = this.tables.messages;
+    const condition = and(eq(messages.channel, channel), this.withSourceScope(messages, sourceId));
+    const result = db.delete(messages).where(condition).run();
+    return Number(result.changes);
+  }
+
+  /**
+   * SQLite-only synchronous purge of direct messages to/from a node.
+   * Mirrors `purgeDirectMessages()` — excludes broadcast messages
+   * (`toNodeId != '!ffffffff'`) and scopes by source when provided.
+   */
+  purgeDirectMessagesSqlite(nodeNum: number, sourceId?: string): number {
+    if (!this.sqliteDb) {
+      throw new Error('purgeDirectMessagesSqlite is SQLite-only');
+    }
+    const db = this.sqliteDb;
+    const messages = this.tables.messages;
+    const condition = and(
+      or(
+        eq(messages.fromNodeNum, nodeNum),
+        eq(messages.toNodeNum, nodeNum)
+      ),
+      ne(messages.toNodeId, '!ffffffff'),
+      this.withSourceScope(messages, sourceId)
+    );
+    const result = db.delete(messages).where(condition).run();
+    return Number(result.changes);
+  }
+
+  /**
    * Cleanup old messages
    */
   async cleanupOldMessages(days: number = 30): Promise<number> {

--- a/src/db/repositories/telemetry.extra.test.ts
+++ b/src/db/repositories/telemetry.extra.test.ts
@@ -842,4 +842,85 @@ describe('TelemetryRepository (expanded)', () => {
       expect(results).toHaveLength(0);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // getTelemetryByNodeAveragedSqlite — regression for issue #2631
+  // The pre-Drizzle raw SQL used `source_id` while the schema column is
+  // `sourceId`, so any call with a sourceId parameter crashed on SQLite. These
+  // tests exercise the Drizzle-backed sync helper with sourceId scoping to
+  // prevent recurrence.
+  // -------------------------------------------------------------------------
+  describe('getTelemetryByNodeAveragedSqlite', () => {
+    const insertWithSource = async (
+      nodeId: string,
+      nodeNum: number,
+      telemetryType: string,
+      timestamp: number,
+      value: number,
+      sourceId: string | undefined
+    ) => {
+      await repo.insertTelemetry(
+        { nodeId, nodeNum, telemetryType, timestamp, value, unit: '%', createdAt: NOW },
+        sourceId
+      );
+    };
+
+    it('does not throw when called with a sourceId (issue #2631 regression)', async () => {
+      await insertWithSource(NODE1, NODE1_NUM, 'voltage', NOW - HOUR, 3.7, 'src-a');
+      expect(() =>
+        repo.getTelemetryByNodeAveragedSqlite(NODE1, undefined, 3, undefined, 'src-a')
+      ).not.toThrow();
+    });
+
+    it('scopes averaged results to the provided sourceId', async () => {
+      // Same node in two sources with different voltages
+      await insertWithSource(NODE1, NODE1_NUM, 'voltage', NOW - HOUR, 3.7, 'src-a');
+      await insertWithSource(NODE1, NODE1_NUM, 'voltage', NOW - 30 * 60 * 1000, 3.8, 'src-a');
+      await insertWithSource(NODE1, NODE1_NUM, 'voltage', NOW - HOUR, 4.1, 'src-b');
+
+      const fromA = repo.getTelemetryByNodeAveragedSqlite(NODE1, undefined, 3, undefined, 'src-a');
+      const fromB = repo.getTelemetryByNodeAveragedSqlite(NODE1, undefined, 3, undefined, 'src-b');
+
+      expect(fromA.length).toBeGreaterThan(0);
+      expect(fromB.length).toBeGreaterThan(0);
+      // src-a averages 3.7 and 3.8; src-b has only 4.1
+      const aValues = fromA.map(r => r.value);
+      const bValues = fromB.map(r => r.value);
+      expect(aValues.every(v => v < 4.0)).toBe(true);
+      expect(bValues.every(v => v > 4.0)).toBe(true);
+    });
+
+    it('returns rows from all sources when sourceId is undefined', async () => {
+      await insertWithSource(NODE1, NODE1_NUM, 'voltage', NOW - HOUR, 3.7, 'src-a');
+      await insertWithSource(NODE1, NODE1_NUM, 'voltage', NOW - 30 * 60 * 1000, 4.1, 'src-b');
+
+      const all = repo.getTelemetryByNodeAveragedSqlite(NODE1, undefined, 3, undefined, undefined);
+      // Both sources contribute (different time buckets → separate rows)
+      expect(all.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('fetches raw-value types unaveraged under sourceId scope', async () => {
+      // batteryLevel is in RAW_VALUE_TYPES — should come through raw, scoped to source
+      await insertWithSource(NODE1, NODE1_NUM, 'batteryLevel', NOW - HOUR, 80, 'src-a');
+      await insertWithSource(NODE1, NODE1_NUM, 'batteryLevel', NOW - HOUR, 20, 'src-b');
+
+      const results = repo.getTelemetryByNodeAveragedSqlite(NODE1, undefined, 3, undefined, 'src-a');
+      const battery = results.filter(r => r.telemetryType === 'batteryLevel');
+      expect(battery.length).toBe(1);
+      expect(battery[0].value).toBe(80);
+    });
+
+    it('respects sinceTimestamp together with sourceId', async () => {
+      const oldTs = NOW - 48 * HOUR;
+      const recentTs = NOW - HOUR;
+      await insertWithSource(NODE1, NODE1_NUM, 'voltage', oldTs, 3.0, 'src-a');
+      await insertWithSource(NODE1, NODE1_NUM, 'voltage', recentTs, 3.7, 'src-a');
+
+      const results = repo.getTelemetryByNodeAveragedSqlite(
+        NODE1, NOW - 24 * HOUR, 3, undefined, 'src-a'
+      );
+      expect(results.length).toBe(1);
+      expect(results[0].value).toBe(3.7);
+    });
+  });
 });

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -691,4 +691,138 @@ export class TelemetryRepository extends BaseRepository {
         quality: record.value,
       }));
   }
+
+  /**
+   * Telemetry types stored as discrete integer values where averaging produces
+   * meaningless floats. These are fetched raw instead of through AVG() grouping.
+   */
+  private static readonly RAW_VALUE_TYPES = [
+    'sats_in_view',
+    'messageHops',
+    'batteryLevel',
+    'numOnlineNodes', 'numTotalNodes',
+    'numPacketsTx', 'numPacketsRx', 'numPacketsRxBad',
+    'numRxDupe', 'numTxRelay', 'numTxRelayCanceled', 'numTxDropped',
+    'systemNodeCount', 'systemDirectNodeCount',
+    'paxcounterWifi', 'paxcounterBle',
+    'particles03um', 'particles05um', 'particles10um',
+    'particles25um', 'particles50um', 'particles100um',
+    'co2', 'iaq',
+  ];
+
+  /**
+   * SQLite-only synchronous averaged telemetry query used by the facade's
+   * sync `getTelemetryByNodeAveraged()`. Buckets timestamps into fixed
+   * intervals and averages continuous types; fetches discrete types raw.
+   *
+   * Uses Drizzle query builders against the SQLite client so column names
+   * come from the schema (avoids the snake_case/camelCase drift that caused
+   * issue #2631).
+   */
+  getTelemetryByNodeAveragedSqlite(
+    nodeId: string,
+    sinceTimestamp: number | undefined,
+    intervalMinutes: number,
+    maxHours: number | undefined,
+    sourceId: string | undefined
+  ): DbTelemetry[] {
+    if (!this.sqliteDb) {
+      throw new Error('getTelemetryByNodeAveragedSqlite is SQLite-only');
+    }
+    const db = this.sqliteDb;
+    const telemetry = this.tables.telemetry;
+    const rawTypes = TelemetryRepository.RAW_VALUE_TYPES;
+    const intervalMs = intervalMinutes * 60 * 1000;
+
+    // Build WHERE conditions shared by averaged and count queries
+    const baseConditions = [eq(telemetry.nodeId, nodeId)];
+    if (sourceId !== undefined) {
+      baseConditions.push(eq(telemetry.sourceId, sourceId));
+    }
+    if (sinceTimestamp !== undefined) {
+      baseConditions.push(gte(telemetry.timestamp, sinceTimestamp));
+    }
+
+    // Averaged query: exclude raw types, group by time bucket
+    const bucketExpr = sql<number>`CAST((${telemetry.timestamp} / ${intervalMs}) * ${intervalMs} AS INTEGER)`;
+    const bucketGroupExpr = sql`CAST(${telemetry.timestamp} / ${intervalMs} AS INTEGER)`;
+
+    // Determine limit based on maxHours
+    let averagedLimit: number | undefined;
+    if (maxHours !== undefined) {
+      const pointsPerHour = 60 / intervalMinutes;
+      // Count distinct telemetry types for this node (excluding raw types is
+      // not strictly necessary — the multiplier is a conservative upper bound)
+      const countRows = db
+        .select({ typeCount: sql<number>`COUNT(DISTINCT ${telemetry.telemetryType})` })
+        .from(telemetry)
+        .where(and(...baseConditions))
+        .all();
+      const typeCount = Number(countRows[0]?.typeCount ?? 1) || 1;
+      const expectedPointsPerType = (maxHours + 1) * pointsPerHour;
+      averagedLimit = Math.ceil(expectedPointsPerType * typeCount * 1.5);
+    }
+
+    const averagedBuilder = db
+      .select({
+        nodeId: telemetry.nodeId,
+        nodeNum: telemetry.nodeNum,
+        telemetryType: telemetry.telemetryType,
+        timestamp: bucketExpr.as('timestamp'),
+        value: sql<number>`AVG(${telemetry.value})`.as('value'),
+        unit: telemetry.unit,
+        createdAt: sql<number>`MIN(${telemetry.createdAt})`.as('createdAt'),
+      })
+      .from(telemetry)
+      .where(and(...baseConditions, not(inArray(telemetry.telemetryType, rawTypes))))
+      .groupBy(
+        telemetry.nodeId,
+        telemetry.nodeNum,
+        telemetry.telemetryType,
+        bucketGroupExpr,
+        telemetry.unit
+      )
+      .orderBy(sql`timestamp DESC`);
+
+    const averagedRows = averagedLimit !== undefined
+      ? averagedBuilder.limit(averagedLimit).all()
+      : averagedBuilder.all();
+
+    // Raw values query: include only raw types, no averaging
+    const rawBuilder = db
+      .select({
+        nodeId: telemetry.nodeId,
+        nodeNum: telemetry.nodeNum,
+        telemetryType: telemetry.telemetryType,
+        timestamp: telemetry.timestamp,
+        value: telemetry.value,
+        unit: telemetry.unit,
+        createdAt: telemetry.createdAt,
+      })
+      .from(telemetry)
+      .where(and(...baseConditions, inArray(telemetry.telemetryType, rawTypes)))
+      .orderBy(desc(telemetry.timestamp));
+
+    let rawRows;
+    if (maxHours !== undefined) {
+      // Raw values are sparse — ~10/hour/type upper bound with 50% padding
+      const rawLimit = Math.ceil((maxHours + 1) * 10 * rawTypes.length * 1.5);
+      rawRows = rawBuilder.limit(rawLimit).all();
+    } else {
+      rawRows = rawBuilder.all();
+    }
+
+    // Convert rows to DbTelemetry shape (null unit → undefined)
+    const toDbTelemetry = (r: any): DbTelemetry => ({
+      nodeId: r.nodeId,
+      nodeNum: Number(r.nodeNum),
+      telemetryType: r.telemetryType,
+      timestamp: Number(r.timestamp),
+      value: Number(r.value),
+      unit: r.unit ?? undefined,
+      createdAt: Number(r.createdAt),
+    });
+
+    return [...averagedRows.map(toDbTelemetry), ...rawRows.map(toDbTelemetry)];
+  }
 }

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -3708,16 +3708,13 @@ class DatabaseService {
       return 0;
     }
 
-    // When sourceId is provided, restrict deletion to that source
-    if (sourceId) {
-      const stmt = this.db.prepare('DELETE FROM messages WHERE channel = ? AND source_id = ?');
-      const result = stmt.run(channel, sourceId);
-      return Number(result.changes);
+    // SQLite: dispatch to Drizzle-backed repo sync helper. Column names come
+    // from the schema, so the `sourceId` vs `source_id` mismatch that caused
+    // issue #2631 on SQLite can't recur.
+    if (this.messagesRepo) {
+      return this.messagesRepo.purgeChannelMessagesSqlite(channel, sourceId);
     }
-
-    const stmt = this.db.prepare('DELETE FROM messages WHERE channel = ?');
-    const result = stmt.run(channel);
-    return Number(result.changes);
+    return 0;
   }
 
   purgeDirectMessages(nodeNum: number, sourceId?: string): number {
@@ -3731,27 +3728,11 @@ class DatabaseService {
       return 0;
     }
 
-    // Delete all DMs to/from this node
-    // DMs are identified by fromNodeNum/toNodeNum pairs, regardless of channel.
-    // When sourceId is provided, restrict deletion to that source.
-    if (sourceId) {
-      const stmt = this.db.prepare(`
-        DELETE FROM messages
-        WHERE (fromNodeNum = ? OR toNodeNum = ?)
-        AND toNodeId != '!ffffffff'
-        AND source_id = ?
-      `);
-      const result = stmt.run(nodeNum, nodeNum, sourceId);
-      return Number(result.changes);
+    // SQLite: dispatch to Drizzle-backed repo sync helper.
+    if (this.messagesRepo) {
+      return this.messagesRepo.purgeDirectMessagesSqlite(nodeNum, sourceId);
     }
-
-    const stmt = this.db.prepare(`
-      DELETE FROM messages
-      WHERE (fromNodeNum = ? OR toNodeNum = ?)
-      AND toNodeId != '!ffffffff'
-    `);
-    const result = stmt.run(nodeNum, nodeNum);
-    return Number(result.changes);
+    return 0;
   }
 
   purgeNodeTraceroutes(nodeNum: number): number {
@@ -4679,144 +4660,20 @@ class DatabaseService {
       actualIntervalMinutes = 3;
     }
 
-    // Calculate the interval in milliseconds
-    const intervalMs = actualIntervalMinutes * 60 * 1000;
-
-    // Telemetry types that should use raw values instead of averaging
-    // These are discrete integer values where averaging produces meaningless floats
-    const rawValueTypes = [
-      'sats_in_view',
-      'messageHops',
-      'batteryLevel',
-      'numOnlineNodes', 'numTotalNodes',
-      'numPacketsTx', 'numPacketsRx', 'numPacketsRxBad',
-      'numRxDupe', 'numTxRelay', 'numTxRelayCanceled', 'numTxDropped',
-      'systemNodeCount', 'systemDirectNodeCount',
-      'paxcounterWifi', 'paxcounterBle',
-      'particles03um', 'particles05um', 'particles10um',
-      'particles25um', 'particles50um', 'particles100um',
-      'co2', 'iaq',
-    ];
-
-    // Build the query to group and average telemetry data by time intervals
-    // Exclude raw value types from this query - they'll be fetched separately
-    let query = `
-      SELECT
-        nodeId,
-        nodeNum,
-        telemetryType,
-        CAST((timestamp / ?) * ? AS INTEGER) as timestamp,
-        AVG(value) as value,
-        unit,
-        MIN(createdAt) as createdAt
-      FROM telemetry
-      WHERE nodeId = ?
-        AND telemetryType NOT IN (${rawValueTypes.map(() => '?').join(', ')})
-    `;
-    const params: any[] = [intervalMs, intervalMs, nodeId, ...rawValueTypes];
-
-    // Scope to this source so nodes that exist in multiple sources don't mix telemetry
-    if (sourceId !== undefined) {
-      query += ` AND source_id = ?`;
-      params.push(sourceId);
+    // SQLite: delegate to Drizzle-backed repo sync helper. Keeps column names
+    // aligned with the schema (fixes issue #2631 where raw SQL used
+    // `source_id` while the schema column is `sourceId`).
+    if (!this.telemetryRepo) {
+      return [];
     }
-
-    if (sinceTimestamp !== undefined) {
-      query += ` AND timestamp >= ?`;
-      params.push(sinceTimestamp);
-    }
-
-    query += `
-      GROUP BY
-        nodeId,
-        nodeNum,
-        telemetryType,
-        CAST(timestamp / ? AS INTEGER),
-        unit
-      ORDER BY timestamp DESC
-    `;
-    params.push(intervalMs);
-
-    // Add limit based on max hours if specified
-    // Calculate points per hour based on the actual interval used
-    if (maxHours !== undefined) {
-      const pointsPerHour = 60 / actualIntervalMinutes;
-
-      // Query the actual number of distinct telemetry types for this node
-      // This is more efficient than using a blanket multiplier
-      let countQuery = `
-        SELECT COUNT(DISTINCT telemetryType) as typeCount
-        FROM telemetry
-        WHERE nodeId = ?
-      `;
-      const countParams: any[] = [nodeId];
-      if (sourceId !== undefined) {
-        countQuery += ` AND source_id = ?`;
-        countParams.push(sourceId);
-      }
-      if (sinceTimestamp !== undefined) {
-        countQuery += ` AND timestamp >= ?`;
-        countParams.push(sinceTimestamp);
-      }
-
-      const countStmt = this.db.prepare(countQuery);
-      const result = countStmt.get(...countParams) as { typeCount: number } | undefined;
-      const telemetryTypeCount = result?.typeCount || 1;
-
-      // Calculate limit: expected data points per type × number of types
-      // Add 50% padding to account for data density variations and ensure we don't cut off
-      const expectedPointsPerType = (maxHours + 1) * pointsPerHour;
-      const limit = Math.ceil(expectedPointsPerType * telemetryTypeCount * 1.5);
-
-      query += ` LIMIT ?`;
-      params.push(limit);
-    }
-
-    const stmt = this.db.prepare(query);
-    const telemetry = stmt.all(...params) as DbTelemetry[];
-
-    // Fetch raw values for types that shouldn't be averaged (sparse integer data)
-    let rawQuery = `
-      SELECT
-        nodeId,
-        nodeNum,
-        telemetryType,
-        timestamp,
-        value,
-        unit,
-        createdAt
-      FROM telemetry
-      WHERE nodeId = ?
-        AND telemetryType IN (${rawValueTypes.map(() => '?').join(', ')})
-    `;
-    const rawParams: any[] = [nodeId, ...rawValueTypes];
-
-    if (sourceId !== undefined) {
-      rawQuery += ` AND source_id = ?`;
-      rawParams.push(sourceId);
-    }
-
-    if (sinceTimestamp !== undefined) {
-      rawQuery += ` AND timestamp >= ?`;
-      rawParams.push(sinceTimestamp);
-    }
-
-    rawQuery += ` ORDER BY timestamp DESC`;
-
-    // Apply same limit logic for raw data
-    if (maxHours !== undefined) {
-      // For raw data, limit based on expected frequency (~10 per hour max for position data)
-      const rawLimit = Math.ceil((maxHours + 1) * 10 * rawValueTypes.length * 1.5);
-      rawQuery += ` LIMIT ?`;
-      rawParams.push(rawLimit);
-    }
-
-    const rawStmt = this.db.prepare(rawQuery);
-    const rawTelemetry = rawStmt.all(...rawParams) as DbTelemetry[];
-
-    // Combine averaged and raw telemetry
-    const combined = [...telemetry, ...rawTelemetry];
-    return combined.map(t => this.normalizeBigInts(t));
+    const rows = this.telemetryRepo.getTelemetryByNodeAveragedSqlite(
+      nodeId,
+      sinceTimestamp,
+      actualIntervalMinutes,
+      maxHours,
+      sourceId
+    );
+    return rows.map(t => this.normalizeBigInts(t));
   }
 
   /**


### PR DESCRIPTION
## Summary

Fresh 4.0 alpha SQLite installs crashed with `SqliteError: no such column: source_id` whenever a call reached `getTelemetryByNodeAveraged`, `purgeChannelMessages`, or `purgeDirectMessages` with a `sourceId` argument — which happens on every install that auto-creates a default source. Three raw SQL sites in `DatabaseService` referenced the column as `source_id` while the SQLite schema defines it as `sourceId` (camelCase, matching Postgres/MySQL via Drizzle).

Rather than re-rename the raw SQL, this PR converts the three sites to dispatch through new Drizzle-backed sync helpers on the repositories. Column names now come from the schema, so the snake_case/camelCase drift that caused #2631 cannot recur.

## Changes

- **`src/db/repositories/messages.ts`** — New sync helpers `purgeChannelMessagesSqlite()` and `purgeDirectMessagesSqlite()` using Drizzle `delete().where().run()`
- **`src/db/repositories/telemetry.ts`** — New sync helper `getTelemetryByNodeAveragedSqlite()` using Drizzle `select().groupBy()` with `sql` templates for the `CAST((timestamp / ?) * ? AS INTEGER)` time-bucket expression
- **`src/services/database.ts`** — SQLite branches in `purgeChannelMessages`, `purgeDirectMessages`, and `getTelemetryByNodeAveraged` now dispatch to the new sync helpers. Removed ~140 lines of raw SQL
- **`src/db/repositories/telemetry.extra.test.ts`** — 5 new regression tests exercising `sourceId` scoping (crash regression, per-source filtering, unscoped fetch, raw-type scoping, `sinceTimestamp` interaction)
- **`src/db/repositories/messages.purge.test.ts`** — New file with 6 tests for both purge sync helpers (crash regression, per-source isolation, broadcast `!ffffffff` exclusion)
- **`CHANGELOG.md`** — Bug fix entry under the 4.0 multi-source section

## Issues Resolved

Fixes #2631

## Documentation Updates

- `CHANGELOG.md` updated with a bug fix entry under the Unreleased 4.0 multi-source architecture section. No user-facing docs affected.

## Testing

- [x] Unit tests pass (4226 tests total; 11 new regression tests added for this fix)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Dev container built and deployed; container logs clean (no SqliteError, no uncaught exceptions)
- [x] Reviewer verify: on a fresh SQLite install with a default source, navigate to any node's telemetry charts and confirm no crash in container logs
- [x] Reviewer verify: delete a channel's messages via the admin UI and confirm only that channel+source's messages are deleted (not other sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)