### PR TITLE
fix(telemetry): DB-level dedup backstop for duplicate packets

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 31 migrations registered', () => {
-    expect(registry.count()).toBe(31);
+  it('has all 32 migrations registered', () => {
+    expect(registry.count()).toBe(32);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,14 +12,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is drop_legacy_nodes_unique', () => {
+  it('last migration is telemetry_packet_dedupe', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(31);
-    expect(last.name).toContain('drop_legacy_nodes_unique');
+    expect(last.number).toBe(32);
+    expect(last.name).toContain('telemetry_packet_dedupe');
   });
 
-  it('migrations are sequentially numbered from 1 to 31', () => {
+  it('migrations are sequentially numbered from 1 to 32', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,7 +1,7 @@
 /**
  * Migration Registry Barrel File
  *
- * Registers all 31 migrations in sequential order for use by the migration runner.
+ * Registers all 32 migrations in sequential order for use by the migration runner.
  * Migration 001 is the v3.7 baseline (selfIdempotent — handles its own detection).
  * Migrations 002-011 were originally 078-087 and retain their original settingsKeys
  * for upgrade compatibility.
@@ -43,6 +43,7 @@ import { migration as addSourceIdToNotificationsMigration, runMigration028Postgr
 import { migration as nodesCompositePkMigration, runMigration029Postgres, runMigration029Mysql } from '../server/migrations/029_nodes_composite_pk.js';
 import { migration as addSourceIdToRouteSegmentsMigration, runMigration030Postgres, runMigration030Mysql } from '../server/migrations/030_add_source_id_to_route_segments.js';
 import { migration as dropLegacyNodesUniqueMigration, runMigration031Postgres, runMigration031Mysql } from '../server/migrations/031_drop_legacy_nodes_unique.js';
+import { migration as telemetryPacketDedupeMigration, runMigration032Postgres, runMigration032Mysql } from '../server/migrations/032_telemetry_packet_dedupe.js';
 
 // ============================================================================
 // Registry
@@ -452,4 +453,21 @@ registry.register({
   sqlite: (db) => dropLegacyNodesUniqueMigration.up(db),
   postgres: (client) => runMigration031Postgres(client),
   mysql: (pool) => runMigration031Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 032: Telemetry packet dedupe via soft unique constraint.
+// Adds a partial unique index on (sourceId, nodeNum, packetId, telemetryType)
+// so duplicate packets (e.g. re-broadcast through multiple mesh routers) are
+// silently dropped at insert time instead of producing duplicate rows.
+// See https://github.com/Yeraze/meshmonitor/issues/2629
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 32,
+  name: 'telemetry_packet_dedupe',
+  settingsKey: 'migration_032_telemetry_packet_dedupe',
+  sqlite: (db) => telemetryPacketDedupeMigration.up(db),
+  postgres: (client) => runMigration032Postgres(client),
+  mysql: (pool) => runMigration032Mysql(pool),
 });

--- a/src/db/repositories/telemetry.extra.test.ts
+++ b/src/db/repositories/telemetry.extra.test.ts
@@ -56,6 +56,14 @@ describe('TelemetryRepository (expanded)', () => {
       )
     `);
 
+    // Mirror the migration 032 partial unique index so repo-level dedupe
+    // behavior matches production. NULL packetId rows bypass the constraint.
+    db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS telemetry_source_packet_type_uniq
+        ON telemetry(sourceId, nodeNum, packetId, telemetryType)
+        WHERE packetId IS NOT NULL
+    `);
+
     drizzleDb = drizzle(db, { schema });
     repo = new TelemetryRepository(drizzleDb, 'sqlite');
   });
@@ -921,6 +929,117 @@ describe('TelemetryRepository (expanded)', () => {
       );
       expect(results.length).toBe(1);
       expect(results[0].value).toBe(3.7);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // insertTelemetry dedup — regression for issue #2629
+  // Same packet arriving via multiple mesh routers must not produce duplicate
+  // rows. Migration 032 adds a partial unique index on
+  // (sourceId, nodeNum, packetId, telemetryType) WHERE packetId IS NOT NULL,
+  // and insertTelemetry uses insertIgnore so collisions become silent no-ops.
+  // -------------------------------------------------------------------------
+  describe('insertTelemetry dedup (issue #2629)', () => {
+    const baseRow = (overrides: Partial<any> = {}) => ({
+      nodeId: NODE1,
+      nodeNum: NODE1_NUM,
+      telemetryType: 'batteryLevel',
+      timestamp: NOW - HOUR,
+      value: 80,
+      unit: '%',
+      createdAt: NOW,
+      packetId: 12345,
+      ...overrides,
+    });
+
+    it('silently skips duplicate (sourceId, nodeNum, packetId, telemetryType)', async () => {
+      const first = await repo.insertTelemetry(baseRow(), 'src-a');
+      const second = await repo.insertTelemetry(baseRow(), 'src-a');
+
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+
+      const rows = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, 'src-a');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].packetId).toBe(12345);
+    });
+
+    it('allows the same packetId with a different telemetryType (single packet, multiple metrics)', async () => {
+      // A single Meshtastic telemetry packet commonly produces multiple rows —
+      // one per metric type — all sharing the same packetId.
+      const a = await repo.insertTelemetry(baseRow({ telemetryType: 'batteryLevel', value: 80 }), 'src-a');
+      const b = await repo.insertTelemetry(baseRow({ telemetryType: 'voltage', value: 3.7 }), 'src-a');
+      const c = await repo.insertTelemetry(baseRow({ telemetryType: 'channelUtilization', value: 12 }), 'src-a');
+
+      expect(a).toBe(true);
+      expect(b).toBe(true);
+      expect(c).toBe(true);
+
+      const rows = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, 'src-a');
+      expect(rows).toHaveLength(3);
+      const types = new Set(rows.map(r => r.telemetryType));
+      expect(types.has('batteryLevel')).toBe(true);
+      expect(types.has('voltage')).toBe(true);
+      expect(types.has('channelUtilization')).toBe(true);
+    });
+
+    it('allows the same packetId under different sourceIds (independent meshes)', async () => {
+      const a = await repo.insertTelemetry(baseRow(), 'src-a');
+      const b = await repo.insertTelemetry(baseRow(), 'src-b');
+
+      expect(a).toBe(true);
+      expect(b).toBe(true);
+
+      const rowsA = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, 'src-a');
+      const rowsB = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, 'src-b');
+      expect(rowsA).toHaveLength(1);
+      expect(rowsB).toHaveLength(1);
+    });
+
+    it('allows multiple NULL-packetId rows (legacy / synthesized telemetry bypasses the constraint)', async () => {
+      // packetId is left unset on both inserts → stored as NULL.
+      // The partial index has WHERE packetId IS NOT NULL so neither row
+      // participates in the uniqueness check.
+      const a = await repo.insertTelemetry({
+        nodeId: NODE1,
+        nodeNum: NODE1_NUM,
+        telemetryType: 'batteryLevel',
+        timestamp: NOW - HOUR,
+        value: 80,
+        unit: '%',
+        createdAt: NOW,
+      }, 'src-a');
+      const b = await repo.insertTelemetry({
+        nodeId: NODE1,
+        nodeNum: NODE1_NUM,
+        telemetryType: 'batteryLevel',
+        timestamp: NOW - 2 * HOUR,
+        value: 75,
+        unit: '%',
+        createdAt: NOW,
+      }, 'src-a');
+
+      expect(a).toBe(true);
+      expect(b).toBe(true);
+
+      const rows = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, 'batteryLevel', 'src-a');
+      expect(rows).toHaveLength(2);
+      for (const row of rows) {
+        expect(row.packetId).toBeNull();
+      }
+    });
+
+    it('allows the same packetId across different nodeNums within the same source', async () => {
+      const a = await repo.insertTelemetry(baseRow({ nodeId: NODE1, nodeNum: NODE1_NUM }), 'src-a');
+      const b = await repo.insertTelemetry(baseRow({ nodeId: NODE2, nodeNum: NODE2_NUM }), 'src-a');
+
+      expect(a).toBe(true);
+      expect(b).toBe(true);
+
+      const rows1 = await repo.getTelemetryByNode(NODE1, 10, undefined, undefined, 0, undefined, 'src-a');
+      const rows2 = await repo.getTelemetryByNode(NODE2, 10, undefined, undefined, 0, undefined, 'src-a');
+      expect(rows1).toHaveLength(1);
+      expect(rows2).toHaveLength(1);
     });
   });
 });

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -17,9 +17,18 @@ export class TelemetryRepository extends BaseRepository {
   }
 
   /**
-   * Insert a telemetry record
+   * Insert a telemetry record.
+   *
+   * Uses insertIgnore so that rows colliding on the migration 032 unique
+   * index (sourceId, nodeNum, packetId, telemetryType) WHERE packetId IS NOT
+   * NULL are silently dropped. Same Meshtastic packet re-broadcast through
+   * multiple mesh routers must not produce duplicate rows.
+   *
+   * Returns true if a new row was inserted, false if it was a duplicate that
+   * got suppressed by the constraint. Rows with NULL packetId (legacy or
+   * synthesized telemetry) bypass the constraint and always insert.
    */
-  async insertTelemetry(telemetryData: DbTelemetry, sourceId?: string): Promise<void> {
+  async insertTelemetry(telemetryData: DbTelemetry, sourceId?: string): Promise<boolean> {
     const { telemetry } = this.tables;
     const values: any = {
       nodeId: telemetryData.nodeId,
@@ -39,7 +48,8 @@ export class TelemetryRepository extends BaseRepository {
       values.sourceId = sourceId;
     }
 
-    await this.db.insert(telemetry).values(values);
+    const result = await this.insertIgnore(telemetry, values);
+    return this.getAffectedRows(result) > 0;
   }
 
   /**

--- a/src/server/migrations/032_telemetry_packet_dedupe.ts
+++ b/src/server/migrations/032_telemetry_packet_dedupe.ts
@@ -1,0 +1,154 @@
+/**
+ * Migration 032: Telemetry packet dedupe via soft unique constraint.
+ *
+ * Context (issue #2629):
+ *   The same Meshtastic packet can arrive multiple times when mesh routers
+ *   re-broadcast it, producing duplicate telemetry rows — one per arrival,
+ *   per metric — all sharing the same packetId. A single telemetry packet
+ *   also legitimately produces multiple rows (one per metric type), so the
+ *   uniqueness key must include telemetryType.
+ *
+ *   This migration adds a DB-level backstop: a unique index on
+ *     (sourceId, nodeNum, packetId, telemetryType)
+ *   scoped to rows where packetId IS NOT NULL, so that any duplicate packet
+ *   insertion becomes a silent no-op (via insertIgnore) regardless of what
+ *   code path produced it. Rows with NULL packetId (legacy / synthesized
+ *   telemetry) still insert freely.
+ *
+ *   The migration first dedupes any existing duplicate rows, keeping the
+ *   lowest id per key tuple, then creates the index.
+ *
+ * Dialect notes:
+ *   - SQLite and PostgreSQL support partial unique indexes (WHERE clause).
+ *   - MySQL does NOT support partial unique indexes, so we create a plain
+ *     unique index. MySQL's UNIQUE index permits multiple rows with NULL
+ *     values in any indexed column (per SQL standard), so legacy rows with
+ *     NULL packetId still coexist — the constraint only bites when all four
+ *     columns are non-NULL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const INDEX_NAME = 'telemetry_source_packet_type_uniq';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 032 (SQLite): telemetry packet dedupe...');
+
+    // Dedupe existing rows: keep lowest id per (sourceId, nodeNum, packetId, telemetryType)
+    // where packetId IS NOT NULL. NULL packetId rows are left alone.
+    const deleteStmt = db.prepare(`
+      DELETE FROM telemetry
+      WHERE packetId IS NOT NULL
+        AND id NOT IN (
+          SELECT MIN(id) FROM telemetry
+          WHERE packetId IS NOT NULL
+          GROUP BY sourceId, nodeNum, packetId, telemetryType
+        )
+    `);
+    const result = deleteStmt.run();
+    if (result.changes > 0) {
+      logger.info(`Migration 032 (SQLite): deduped ${result.changes} duplicate telemetry rows`);
+    }
+
+    // Partial unique index (idempotent via IF NOT EXISTS)
+    db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS ${INDEX_NAME}
+        ON telemetry(sourceId, nodeNum, packetId, telemetryType)
+        WHERE packetId IS NOT NULL
+    `);
+
+    logger.info('Migration 032 complete (SQLite)');
+  },
+
+  down: (db: Database): void => {
+    db.exec(`DROP INDEX IF EXISTS ${INDEX_NAME}`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration032Postgres(client: any): Promise<void> {
+  logger.info('Running migration 032 (PostgreSQL): telemetry packet dedupe...');
+
+  // Dedupe: self-join delete keeping lowest id.
+  // IS NOT DISTINCT FROM handles the (unlikely) sourceId-NULL case symmetrically.
+  const deleteResult = await client.query(`
+    DELETE FROM telemetry a
+    USING telemetry b
+    WHERE a.id > b.id
+      AND a."packetId" IS NOT NULL
+      AND b."packetId" IS NOT NULL
+      AND a."sourceId" IS NOT DISTINCT FROM b."sourceId"
+      AND a."nodeNum" = b."nodeNum"
+      AND a."packetId" = b."packetId"
+      AND a."telemetryType" = b."telemetryType"
+  `);
+  if (deleteResult.rowCount && deleteResult.rowCount > 0) {
+    logger.info(`Migration 032 (PostgreSQL): deduped ${deleteResult.rowCount} duplicate telemetry rows`);
+  }
+
+  // Partial unique index (idempotent via IF NOT EXISTS)
+  await client.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS ${INDEX_NAME}
+      ON telemetry("sourceId", "nodeNum", "packetId", "telemetryType")
+      WHERE "packetId" IS NOT NULL
+  `);
+
+  logger.info('Migration 032 complete (PostgreSQL)');
+}
+
+// ============ MySQL ============
+
+export async function runMigration032Mysql(pool: any): Promise<void> {
+  logger.info('Running migration 032 (MySQL): telemetry packet dedupe...');
+
+  const conn = await pool.getConnection();
+  try {
+    // Dedupe existing rows: self-join delete keeping lowest id.
+    // For MySQL we need to handle sourceId NULL equivalence manually.
+    const [deleteResult] = await conn.query(`
+      DELETE t1 FROM telemetry t1
+      INNER JOIN telemetry t2
+        ON t1.id > t2.id
+       AND t1.packetId IS NOT NULL
+       AND t2.packetId IS NOT NULL
+       AND ((t1.sourceId = t2.sourceId) OR (t1.sourceId IS NULL AND t2.sourceId IS NULL))
+       AND t1.nodeNum = t2.nodeNum
+       AND t1.packetId = t2.packetId
+       AND t1.telemetryType = t2.telemetryType
+    `);
+    const affected = (deleteResult as any)?.affectedRows ?? 0;
+    if (affected > 0) {
+      logger.info(`Migration 032 (MySQL): deduped ${affected} duplicate telemetry rows`);
+    }
+
+    // MySQL does not support partial unique indexes — create a plain unique
+    // index. MySQL's UNIQUE permits multiple rows with NULL in indexed
+    // columns (SQL standard), so legacy NULL-packetId rows still coexist.
+    // Idempotency: guard via information_schema lookup.
+    const [existingIdxRows] = await conn.query(
+      `SELECT INDEX_NAME
+         FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'telemetry'
+          AND INDEX_NAME = ?`,
+      [INDEX_NAME]
+    );
+    if ((existingIdxRows as any[]).length === 0) {
+      await conn.query(
+        `CREATE UNIQUE INDEX \`${INDEX_NAME}\`
+           ON telemetry(sourceId, nodeNum, packetId, telemetryType)`
+      );
+      logger.info(`Migration 032 (MySQL): created unique index '${INDEX_NAME}'`);
+    } else {
+      logger.debug(`Migration 032 (MySQL): unique index '${INDEX_NAME}' already exists`);
+    }
+  } finally {
+    conn.release();
+  }
+
+  logger.info('Migration 032 complete (MySQL)');
+}


### PR DESCRIPTION
## Summary

Same Meshtastic packet can arrive multiple times when mesh routers re-broadcast it, producing duplicate telemetry rows all sharing the same packetId. This adds a defensive **database-level backstop** so duplicates are impossible regardless of which code path produced them — even if a new path forgets to dedupe, or the process restarts mid-stream.

The fix mirrors the existing `messages.insertMessage` pattern: partial unique index + `insertIgnore` + boolean return. No new plumbing, no new abstractions.

## Changes

- **Migration 032** (`src/server/migrations/032_telemetry_packet_dedupe.ts`)
  - Pre-dedupes existing rows by keeping the lowest `id` per `(sourceId, nodeNum, packetId, telemetryType)` tuple where `packetId IS NOT NULL`
  - Creates a **partial unique index** on `(sourceId, nodeNum, packetId, telemetryType) WHERE packetId IS NOT NULL` for SQLite & PostgreSQL
  - MySQL lacks partial indexes — uses a plain unique index, which still permits multiple NULL-packetId rows per SQL standard
- **`insertTelemetry`** now uses `insertIgnore` + `getAffectedRows` and returns `boolean` (`true` = inserted, `false` = silent dedup)
  - Caller impact is zero: all ~30 `meshtasticManager` callsites currently `await` without using the return value, so the signature change is strictly additive
- **Key tuple includes `telemetryType`** because a single telemetry packet legitimately produces multiple rows (one per metric — batteryLevel, voltage, channelUtilization, etc.)
- **NULL-`packetId` rows bypass the constraint** — legacy/synthesized telemetry without a packet still inserts freely
- 5 new regression tests in `telemetry.extra.test.ts`:
  - Duplicate silently skipped (`true` then `false`, one row persisted)
  - Same `packetId`, different `telemetryType` (single-packet multi-metric) → both persist
  - Same `packetId`, different `sourceId` (cross-mesh collision) → both persist
  - Two NULL-`packetId` inserts → both persist
  - Same `packetId`, different `nodeNum` (rare routing collision) → both persist

## Issues Resolved

Fixes #2629

## Documentation Updates

No documentation changes needed — this is a DB-layer backstop invisible to users and API consumers.

## Testing

- [x] Full unit suite: **4231 passed, 0 failures** (212 files, 471 skipped, 21 todo)
- [x] Targeted: `migrations.test.ts` + `telemetry.extra.test.ts` → **89 passed**
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] SQLite dev container deployed: migration 032 executes cleanly on startup (`[INFO] Running migration 032 (SQLite): telemetry packet dedupe...` / `[INFO] Migration 032 complete (SQLite)`), container healthy on port 8081
- [ ] Reviewer: verify Postgres migration (`COMPOSE_PROFILES=postgres`) applies cleanly — partial index should appear in `\d+ telemetry`
- [ ] Reviewer: verify MySQL migration (`COMPOSE_PROFILES=mysql`) applies cleanly — plain unique index should appear in `SHOW INDEX FROM telemetry`

## Out of Scope

- The in-memory LRU cache proposed in the issue body — deferred to a follow-up. This DB backstop is the minimum viable fix that prevents data corruption regardless of the code path.
- `packetId` nullability change — stays nullable; legacy/synthesized rows have no packet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)