### PR TITLE
fix: enable PKI encryption for DMs sent from web UI

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6828,9 +6828,23 @@ class MeshtasticManager implements ISourceManager {
         text = applyHomoglyphOptimization(text);
       }
 
-      // Use the new protobuf service to create a proper text message
-      // Note: PKI encryption is handled automatically by the firmware if it has the recipient's public key
-      const { data: textMessageData, messageId } = meshtasticProtobufService.createTextMessage(text, destination, channel, replyId, emoji);
+      // For DMs, check if the target node has a public key — if so, request PKI encryption.
+      // The firmware handles the actual crypto, but for serial/TCP connections it only
+      // PKI-encrypts when the packet explicitly has pkiEncrypted=true.
+      let pkiEncrypted = false;
+      if (destination) {
+        try {
+          const targetNode = await databaseService.nodes.getNode(destination, this.sourceId);
+          if (targetNode?.publicKey) {
+            pkiEncrypted = true;
+            logger.debug(`🔐 DM to !${destination.toString(16).padStart(8, '0')} — requesting PKI encryption (node has public key)`);
+          }
+        } catch {
+          // If lookup fails, send without PKI — firmware will use channel encryption
+        }
+      }
+
+      const { data: textMessageData, messageId } = meshtasticProtobufService.createTextMessage(text, destination, channel, replyId, emoji, pkiEncrypted);
 
       await this.transport.send(textMessageData);
 

--- a/src/server/meshtasticProtobufService.ts
+++ b/src/server/meshtasticProtobufService.ts
@@ -429,7 +429,7 @@ export class MeshtasticProtobufService {
   /**
    * Create a text message ToRadio using proper protobuf encoding
    */
-  createTextMessage(text: string, destination?: number, channel?: number, replyId?: number, emoji?: number): { data: Uint8Array; messageId: number } {
+  createTextMessage(text: string, destination?: number, channel?: number, replyId?: number, emoji?: number, pkiEncrypted?: boolean): { data: Uint8Array; messageId: number } {
     const root = getProtobufRoot();
     if (!root) {
       logger.error('❌ Protobuf definitions not loaded');
@@ -453,13 +453,17 @@ export class MeshtasticProtobufService {
       const MeshPacket = root.lookupType('meshtastic.MeshPacket');
       // Ensure channel is valid (0-7) for Meshtastic, default to 0 if invalid
       const validChannel = (channel !== undefined && channel >= 0 && channel <= 7) ? channel : 0;
-      const meshPacket = MeshPacket.create({
+      const meshPacketFields: any = {
         id: messageId,
         to: destination || 0xFFFFFFFF, // Broadcast if no destination
         channel: validChannel,
         decoded: dataMessage,
-        wantAck: true
-      });
+        wantAck: true,
+      };
+      if (pkiEncrypted) {
+        meshPacketFields.pkiEncrypted = true;
+      }
+      const meshPacket = MeshPacket.create(meshPacketFields);
 
       logger.debug(`📤 Creating MeshPacket - ID: ${messageId}, to: ${(meshPacket as any).to.toString(16)}, channel: ${validChannel}, wantAck: ${(meshPacket as any).wantAck}`);
 


### PR DESCRIPTION
## Summary
DMs sent from MeshMonitor's web UI were transmitted unencrypted because the `pkiEncrypted` flag was not set on the MeshPacket. For serial/TCP connections (which MeshMonitor uses), the Meshtastic firmware only PKI-encrypts packets when this flag is explicitly `true`. This caused the official Meshtastic app to show duplicate chat channels — one encrypted (from the app) and one unencrypted (from MeshMonitor).

## Changes
- **`meshtasticProtobufService.ts`**: Added `pkiEncrypted` parameter to `createTextMessage()`. When true, sets `pkiEncrypted: true` on the MeshPacket — the firmware handles the actual Curve25519 encryption.
- **`meshtasticManager.ts`**: `sendTextMessage()` now looks up the destination node's public key from the database before sending. If the node has a public key, `pkiEncrypted=true` is passed through to the packet. Nodes without a public key fall back to channel-based (PSK) encryption as before.

## Issues Resolved
Fixes #2638

## Documentation Updates
No documentation changes needed

## Testing
- [x] Unit tests pass (4234 tests)
- [x] TypeScript compiles cleanly
- [ ] Send a DM from MeshMonitor web UI to a node with a public key — verify it appears in the encrypted chat channel on the official Meshtastic app (not as a duplicate unencrypted channel)
- [ ] Send a DM to a node without a public key — verify it still sends successfully via channel encryption
- [ ] Verify broadcast/channel messages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)