### PR TITLE
fix: push subscription upsert targets composite unique constraint

### DIFF
--- a/src/db/repositories/notifications.test.ts
+++ b/src/db/repositories/notifications.test.ts
@@ -78,13 +78,14 @@ const SQLITE_CREATE = `
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
     source_id TEXT NOT NULL DEFAULT '',
-    endpoint TEXT NOT NULL UNIQUE,
+    endpoint TEXT NOT NULL,
     p256dh_key TEXT NOT NULL,
     auth_key TEXT NOT NULL,
     user_agent TEXT,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL,
-    last_used_at INTEGER
+    last_used_at INTEGER,
+    UNIQUE(user_id, endpoint, source_id)
   );
 
   CREATE TABLE IF NOT EXISTS user_notification_preferences (
@@ -204,13 +205,14 @@ const POSTGRES_CREATE = `
     id SERIAL PRIMARY KEY,
     "userId" INTEGER REFERENCES users(id) ON DELETE CASCADE,
     "sourceId" TEXT NOT NULL DEFAULT '',
-    endpoint TEXT NOT NULL UNIQUE,
+    endpoint TEXT NOT NULL,
     "p256dhKey" TEXT NOT NULL,
     "authKey" TEXT NOT NULL,
     "userAgent" TEXT,
     "createdAt" BIGINT NOT NULL,
     "updatedAt" BIGINT NOT NULL,
-    "lastUsedAt" BIGINT
+    "lastUsedAt" BIGINT,
+    UNIQUE("userId", endpoint, "sourceId")
   );
 
   CREATE TABLE user_notification_preferences (
@@ -342,7 +344,7 @@ const MYSQL_CREATE = `
     createdAt BIGINT NOT NULL,
     updatedAt BIGINT NOT NULL,
     lastUsedAt BIGINT,
-    UNIQUE KEY unique_endpoint (endpoint(512))
+    UNIQUE KEY unique_user_endpoint_source (userId, endpoint(255), sourceId)
   );
 
   CREATE TABLE user_notification_preferences (

--- a/src/db/repositories/notifications.ts
+++ b/src/db/repositories/notifications.ts
@@ -161,7 +161,7 @@ export class NotificationsRepository extends BaseRepository {
       lastUsedAt: now,
     };
 
-    await this.upsert(pushSubscriptions, values, pushSubscriptions.endpoint, setData);
+    await this.upsert(pushSubscriptions, values, [pushSubscriptions.userId, pushSubscriptions.endpoint, pushSubscriptions.sourceId], setData);
   }
 
   /**


### PR DESCRIPTION
## Summary
Push notification subscription saves failed with "ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint" because the upsert targeted just `endpoint`, but migration 028 changed the unique constraint to `(userId, endpoint, sourceId)`.

## Changes
- Fixed `saveSubscription()` in `notifications.ts` to use the composite conflict target `[userId, endpoint, sourceId]`
- Updated test schemas (SQLite, PostgreSQL, MySQL) to use the composite unique constraint matching production

## Issues Resolved
Reported by user — push notification enable fails on all database backends.

## Testing
- [x] Unit tests pass (4241 tests, 0 failures)
- [x] TypeScript compiles cleanly
- [x] Notifications repository tests specifically pass (20 passed)
- [ ] Manual: enable push notifications in the UI — should succeed without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)