### PR TITLE
fix: auto-delete-by-distance reads per-source settings

### DIFF
--- a/src/server/services/autoDeleteByDistanceService.ts
+++ b/src/server/services/autoDeleteByDistanceService.ts
@@ -72,18 +72,18 @@ class AutoDeleteByDistanceService {
     const deletedNodes: DeletedNodeInfo[] = [];
 
     try {
-      // Read settings
-      const homeLat = parseFloat(await databaseService.settings.getSetting('autoDeleteByDistanceLat') || '');
-      const homeLon = parseFloat(await databaseService.settings.getSetting('autoDeleteByDistanceLon') || '');
-      const thresholdKm = parseFloat(await databaseService.settings.getSetting('autoDeleteByDistanceThresholdKm') || '100');
+      // Read settings (per-source with global fallback)
+      const homeLat = parseFloat(await databaseService.settings.getSettingForSource(sourceId, 'autoDeleteByDistanceLat') || '');
+      const homeLon = parseFloat(await databaseService.settings.getSettingForSource(sourceId, 'autoDeleteByDistanceLon') || '');
+      const thresholdKm = parseFloat(await databaseService.settings.getSettingForSource(sourceId, 'autoDeleteByDistanceThresholdKm') || '100');
 
       if (isNaN(homeLat) || isNaN(homeLon)) {
         logger.debug('⏭️ Auto-delete-by-distance: no home coordinate configured, skipping');
         return { deletedCount: 0 };
       }
 
-      // Get local node number to protect it
-      const localNodeNumStr = await databaseService.settings.getSetting('localNodeNum');
+      // Get local node number to protect it (per-source with global fallback)
+      const localNodeNumStr = await databaseService.settings.getSettingForSource(sourceId, 'localNodeNum');
       const localNodeNum = localNodeNumStr ? Number(localNodeNumStr) : null;
 
       // Get all nodes (must use async for PostgreSQL/MySQL)


### PR DESCRIPTION
## Summary
Auto Delete by Distance wasn't working because the delete cycle read home coordinates, threshold, and localNodeNum using `getSetting()` (global only). When settings are configured per-source, they're stored with a source prefix that `getSetting()` can't find — so the service always got NaN coordinates and skipped every run.

## Changes
- Changed `getSetting()` to `getSettingForSource(sourceId, ...)` for all four settings in the delete cycle (lat, lon, threshold, localNodeNum)
- This matches how the scheduler startup already reads `autoDeleteByDistanceEnabled` and `autoDeleteByDistanceIntervalHours`

## Issues Resolved
Reported by users — Auto Delete by Distance not deleting any nodes.

## Testing
- [x] Unit tests pass (4241 tests, 0 failures)
- [x] TypeScript compiles cleanly
- [ ] Manual: configure auto-delete per-source, verify nodes beyond threshold are deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)