### PR TITLE
fix: pass sourceId when logging packets to packet monitor

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -82,3 +82,45 @@ node -e "const db = require('better-sqlite3')('data/meshmonitor.db'); db.prepare
 - The test key pattern (all `0x01` bytes) is deliberately weak to simulate keys generated with insufficient randomness
 - This is only for development and testing purposes
 - The hash of this test key is added to `src/services/lowEntropyKeyService.ts` in the `LOW_ENTROPY_HASHES` array
+
+---
+
+## setup-dev-config.sh
+
+Seeds a fresh MeshMonitor instance with default dev/test configuration. Run this after nuking the database volume to restore a working test setup.
+
+### What it configures
+
+- **Two sources**: Sentry (192.168.5.106:4403) and Sandbox (host.docker.internal:4404)
+- **Auto-acknowledge**: Enabled on each source's gauntlet channel with test regex
+- **Packet monitor**: Enabled globally and per-source
+
+### Usage
+
+```bash
+# After starting the dev container:
+./scripts/setup-dev-config.sh
+
+# With custom source hosts:
+SOURCE1_HOST=192.168.1.100 SOURCE2_HOST=192.168.1.200 ./scripts/setup-dev-config.sh
+
+# Skip source creation (just configure settings for existing sources):
+SKIP_SOURCES=true ./scripts/setup-dev-config.sh
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `API_BASE_URL` | `http://localhost:8081/meshmonitor` | MeshMonitor base URL |
+| `API_USER` | `admin` | Login username |
+| `API_PASS` | `changeme1` | Login password |
+| `SOURCE1_NAME` | `Sentry` | Source 1 display name |
+| `SOURCE1_HOST` | `192.168.5.106` | Source 1 TCP host |
+| `SOURCE1_PORT` | `4403` | Source 1 TCP port |
+| `SOURCE1_GAUNTLET` | `7` | Source 1 gauntlet channel index |
+| `SOURCE2_NAME` | `Sandbox` | Source 2 display name |
+| `SOURCE2_HOST` | `host.docker.internal` | Source 2 TCP host |
+| `SOURCE2_PORT` | `4404` | Source 2 TCP port |
+| `SOURCE2_GAUNTLET` | `2` | Source 2 gauntlet channel index |
+| `SKIP_SOURCES` | `false` | Skip source creation, only configure settings |

--- a/scripts/setup-dev-config.sh
+++ b/scripts/setup-dev-config.sh
@@ -1,0 +1,271 @@
+#!/bin/bash
+# Setup Default Dev/Test Configuration
+#
+# Seeds a fresh MeshMonitor instance with a reasonable default test configuration:
+#   - Two sources (Sentry + Sandbox) connected via TCP
+#   - Auto-acknowledge enabled on the gauntlet channel for each source
+#   - Packet monitor enabled
+#
+# Usage:
+#   ./scripts/setup-dev-config.sh              # Uses defaults
+#   SOURCE1_HOST=192.168.5.106 ./scripts/setup-dev-config.sh  # Override source 1 host
+#
+# Environment variables:
+#   API_BASE_URL     - Base URL (default: http://localhost:8081/meshmonitor)
+#   API_USER         - Username (default: admin)
+#   API_PASS         - Password (default: changeme1)
+#   SOURCE1_NAME     - Source 1 name (default: Sentry)
+#   SOURCE1_HOST     - Source 1 TCP host (default: 192.168.5.106)
+#   SOURCE1_PORT     - Source 1 TCP port (default: 4403)
+#   SOURCE1_GAUNTLET - Source 1 gauntlet channel index (default: 7)
+#   SOURCE2_NAME     - Source 2 name (default: Sandbox)
+#   SOURCE2_HOST     - Source 2 TCP host (default: host.docker.internal)
+#   SOURCE2_PORT     - Source 2 TCP port (default: 4404)
+#   SOURCE2_GAUNTLET - Source 2 gauntlet channel index (default: 2)
+#   SKIP_SOURCES     - Set to "true" to skip source creation (just configure settings)
+
+set -euo pipefail
+
+# ─── Configuration ────────────────────────────────────────────────────────────
+
+API_BASE_URL="${API_BASE_URL:-http://localhost:8081/meshmonitor}"
+API_USER="${API_USER:-admin}"
+API_PASS="${API_PASS:-changeme1}"
+
+SOURCE1_NAME="${SOURCE1_NAME:-Sentry}"
+SOURCE1_HOST="${SOURCE1_HOST:-192.168.5.106}"
+SOURCE1_PORT="${SOURCE1_PORT:-4403}"
+SOURCE1_GAUNTLET="${SOURCE1_GAUNTLET:-7}"
+
+SOURCE2_NAME="${SOURCE2_NAME:-Sandbox}"
+SOURCE2_HOST="${SOURCE2_HOST:-host.docker.internal}"
+SOURCE2_PORT="${SOURCE2_PORT:-4404}"
+SOURCE2_GAUNTLET="${SOURCE2_GAUNTLET:-2}"
+
+SKIP_SOURCES="${SKIP_SOURCES:-false}"
+
+COOKIE_FILE="/tmp/meshmonitor-setup-cookies.txt"
+CSRF_FILE="/tmp/meshmonitor-setup-csrf.txt"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+cleanup() {
+  rm -f "$COOKIE_FILE" "$CSRF_FILE"
+}
+trap cleanup EXIT
+
+get_csrf_token() {
+  local response
+  response=$(curl -sf -c "$COOKIE_FILE" "${API_BASE_URL}/api/csrf-token")
+  local token
+  token=$(echo "$response" | jq -r '.csrfToken // empty')
+  if [ -z "$token" ]; then
+    echo -e "${RED}Failed to get CSRF token${NC}" >&2
+    return 1
+  fi
+  echo "$token" > "$CSRF_FILE"
+  echo "$token"
+}
+
+login() {
+  echo -e "${BLUE}Logging in as ${API_USER}...${NC}"
+  local csrf
+  csrf=$(get_csrf_token)
+
+  local response
+  response=$(curl -sf -b "$COOKIE_FILE" -c "$COOKIE_FILE" \
+    -X POST "${API_BASE_URL}/api/auth/login" \
+    -H "Content-Type: application/json" \
+    -H "X-CSRF-Token: $csrf" \
+    -d "{\"username\":\"${API_USER}\",\"password\":\"${API_PASS}\"}")
+
+  local username
+  username=$(echo "$response" | jq -r '.user.username // empty')
+  if [ -z "$username" ]; then
+    echo -e "${RED}Login failed${NC}" >&2
+    echo "$response" >&2
+    return 1
+  fi
+  echo -e "${GREEN}Logged in as: ${username}${NC}"
+}
+
+api_post() {
+  local endpoint="$1"
+  local data="$2"
+  local csrf
+  csrf=$(cat "$CSRF_FILE")
+  curl -sf -b "$COOKIE_FILE" -c "$COOKIE_FILE" \
+    -X POST "${API_BASE_URL}${endpoint}" \
+    -H "Content-Type: application/json" \
+    -H "X-CSRF-Token: $csrf" \
+    -d "$data"
+}
+
+api_get() {
+  local endpoint="$1"
+  curl -sf -b "$COOKIE_FILE" "${API_BASE_URL}${endpoint}"
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}  MeshMonitor Dev Config Setup${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Wait for the server to be ready
+echo -e "${YELLOW}Waiting for server to be ready...${NC}"
+for i in $(seq 1 30); do
+  if curl -sf "${API_BASE_URL}/api/csrf-token" > /dev/null 2>&1; then
+    echo -e "${GREEN}Server is ready${NC}"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo -e "${RED}Server not ready after 30 seconds. Is it running?${NC}"
+    exit 1
+  fi
+  sleep 1
+done
+
+login
+
+# ─── Sources ──────────────────────────────────────────────────────────────────
+
+SOURCE1_ID=""
+SOURCE2_ID=""
+
+if [ "$SKIP_SOURCES" = "true" ]; then
+  echo -e "${YELLOW}Skipping source creation (SKIP_SOURCES=true)${NC}"
+  # Still need to fetch existing source IDs for per-source settings
+  SOURCES=$(api_get "/api/sources")
+  SOURCE1_ID=$(echo "$SOURCES" | jq -r --arg name "$SOURCE1_NAME" '.[] | select(.name == $name) | .id // empty')
+  SOURCE2_ID=$(echo "$SOURCES" | jq -r --arg name "$SOURCE2_NAME" '.[] | select(.name == $name) | .id // empty')
+else
+  # Check for existing sources
+  SOURCES=$(api_get "/api/sources" 2>/dev/null || echo "[]")
+  SOURCE_COUNT=$(echo "$SOURCES" | jq 'length')
+
+  echo -e "${BLUE}Found ${SOURCE_COUNT} existing source(s)${NC}"
+
+  # Look for sources by name
+  SOURCE1_ID=$(echo "$SOURCES" | jq -r --arg name "$SOURCE1_NAME" '.[] | select(.name == $name) | .id // empty')
+  SOURCE2_ID=$(echo "$SOURCES" | jq -r --arg name "$SOURCE2_NAME" '.[] | select(.name == $name) | .id // empty')
+
+  # Create Source 1 if it doesn't exist
+  if [ -z "$SOURCE1_ID" ]; then
+    echo -e "${YELLOW}Creating source: ${SOURCE1_NAME} (${SOURCE1_HOST}:${SOURCE1_PORT})${NC}"
+    RESULT=$(api_post "/api/sources" "{
+      \"name\": \"${SOURCE1_NAME}\",
+      \"type\": \"meshtastic_tcp\",
+      \"config\": {
+        \"host\": \"${SOURCE1_HOST}\",
+        \"port\": ${SOURCE1_PORT}
+      },
+      \"enabled\": true
+    }")
+    SOURCE1_ID=$(echo "$RESULT" | jq -r '.id // empty')
+    if [ -z "$SOURCE1_ID" ]; then
+      echo -e "${RED}Failed to create source 1${NC}"
+      echo "$RESULT" >&2
+      exit 1
+    fi
+    echo -e "${GREEN}Created ${SOURCE1_NAME}: ${SOURCE1_ID}${NC}"
+  else
+    echo -e "${GREEN}${SOURCE1_NAME} already exists: ${SOURCE1_ID}${NC}"
+  fi
+
+  # Create Source 2 if it doesn't exist
+  if [ -z "$SOURCE2_ID" ]; then
+    echo -e "${YELLOW}Creating source: ${SOURCE2_NAME} (${SOURCE2_HOST}:${SOURCE2_PORT})${NC}"
+    RESULT=$(api_post "/api/sources" "{
+      \"name\": \"${SOURCE2_NAME}\",
+      \"type\": \"meshtastic_tcp\",
+      \"config\": {
+        \"host\": \"${SOURCE2_HOST}\",
+        \"port\": ${SOURCE2_PORT}
+      },
+      \"enabled\": true
+    }")
+    SOURCE2_ID=$(echo "$RESULT" | jq -r '.id // empty')
+    if [ -z "$SOURCE2_ID" ]; then
+      echo -e "${RED}Failed to create source 2${NC}"
+      echo "$RESULT" >&2
+      exit 1
+    fi
+    echo -e "${GREEN}Created ${SOURCE2_NAME}: ${SOURCE2_ID}${NC}"
+  else
+    echo -e "${GREEN}${SOURCE2_NAME} already exists: ${SOURCE2_ID}${NC}"
+  fi
+fi
+
+# ─── Global Settings ─────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${BLUE}Configuring global settings...${NC}"
+
+api_post "/api/settings" '{
+  "packet_log_enabled": "1",
+  "packet_log_max_count": "10000",
+  "packet_log_max_age_hours": "48"
+}' > /dev/null
+
+echo -e "${GREEN}  Packet monitor: enabled (max 10000 packets, 48h retention)${NC}"
+
+# ─── Per-Source Settings ──────────────────────────────────────────────────────
+
+configure_auto_ack() {
+  local source_id="$1"
+  local source_name="$2"
+  local gauntlet_channel="$3"
+
+  if [ -z "$source_id" ]; then
+    echo -e "${YELLOW}  Skipping auto-ack for ${source_name} (no source ID)${NC}"
+    return
+  fi
+
+  echo -e "${BLUE}Configuring auto-ack for ${source_name} (channel ${gauntlet_channel})...${NC}"
+
+  api_post "/api/settings?sourceId=${source_id}" "{
+    \"autoAckEnabled\": \"true\",
+    \"autoAckChannels\": \"${gauntlet_channel}\",
+    \"autoAckRegex\": \"^(test|ping|hello)\",
+    \"autoAckReplyEnabled\": \"true\",
+    \"autoAckDirectEnabled\": \"true\",
+    \"autoAckMessage\": \"Acknowledged! MeshMonitor received your message.\",
+    \"autoAckCooldownSeconds\": \"60\",
+    \"packet_log_enabled\": \"1\"
+  }" > /dev/null
+
+  echo -e "${GREEN}  ${source_name}: auto-ack on channel ${gauntlet_channel}, packet monitor enabled${NC}"
+}
+
+echo ""
+configure_auto_ack "$SOURCE1_ID" "$SOURCE1_NAME" "$SOURCE1_GAUNTLET"
+configure_auto_ack "$SOURCE2_ID" "$SOURCE2_NAME" "$SOURCE2_GAUNTLET"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${BLUE}========================================${NC}"
+echo -e "${GREEN}  Configuration Complete!${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+echo -e "  ${SOURCE1_NAME}: ${SOURCE1_ID:-not configured}"
+echo -e "    Host: ${SOURCE1_HOST}:${SOURCE1_PORT}"
+echo -e "    Gauntlet channel: ${SOURCE1_GAUNTLET}"
+echo -e "    Auto-ack: enabled"
+echo ""
+echo -e "  ${SOURCE2_NAME}: ${SOURCE2_ID:-not configured}"
+echo -e "    Host: ${SOURCE2_HOST}:${SOURCE2_PORT}"
+echo -e "    Gauntlet channel: ${SOURCE2_GAUNTLET}"
+echo -e "    Auto-ack: enabled"
+echo ""
+echo -e "  Packet monitor: enabled (global + per-source)"
+echo ""

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -253,6 +253,7 @@ export interface DbPacketLog {
   decrypted_by?: 'node' | 'server' | null;
   decrypted_channel_id?: number | null;
   transport_mechanism?: number | null;
+  sourceId?: string | null;
 }
 
 /**

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1047,6 +1047,7 @@ class MeshtasticManager implements ISourceManager {
       metadata: JSON.stringify({ ...metadata, direction: 'tx' }),
       direction: 'tx',
       transport_mechanism: TransportMechanism.INTERNAL,  // Outgoing packets are sent via direct connection
+      sourceId: this.sourceId,
     });
   }
 
@@ -3996,6 +3997,7 @@ class MeshtasticManager implements ISourceManager {
           decrypted_channel_id: decryptedChannelId ?? undefined,
           // Note: ?? (nullish coalescing) correctly preserves 0 (INTERNAL), only defaults on null/undefined
           transport_mechanism: meshPacket.transportMechanism ?? TransportMechanism.LORA,
+          sourceId: this.sourceId,
         });
         } // end else (not internal packet)
       }

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -9718,7 +9718,7 @@ class DatabaseService {
 
     // For non-SQLite, use async repository
     if (this.drizzleDbType !== 'sqlite') {
-      const id = await this.misc.insertPacketLog(packet);
+      const id = await this.misc.insertPacketLog(packet, packet.sourceId ?? undefined);
       const maxCountStr = await this.getSettingAsync('packet_log_max_count');
       const maxCount = maxCountStr ? parseInt(maxCountStr, 10) : 1000;
       await this.misc.enforcePacketLogMaxCount(maxCount);
@@ -9731,8 +9731,8 @@ class DatabaseService {
         packet_id, timestamp, from_node, from_node_id, to_node, to_node_id,
         channel, portnum, portnum_name, encrypted, snr, rssi, hop_limit, hop_start,
         relay_node, payload_size, want_ack, priority, payload_preview, metadata, direction,
-        transport_mechanism, decrypted_by, decrypted_channel_id
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        transport_mechanism, decrypted_by, decrypted_channel_id, sourceId
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     const result = stmt.run(
       packet.packet_id ?? null, packet.timestamp, packet.from_node,
@@ -9742,7 +9742,8 @@ class DatabaseService {
       packet.hop_limit ?? null, packet.hop_start ?? null, packet.relay_node ?? null,
       packet.payload_size ?? null, packet.want_ack ? 1 : 0, packet.priority ?? null,
       packet.payload_preview ?? null, packet.metadata ?? null, packet.direction ?? 'rx',
-      packet.transport_mechanism ?? null, packet.decrypted_by ?? null, packet.decrypted_channel_id ?? null
+      packet.transport_mechanism ?? null, packet.decrypted_by ?? null, packet.decrypted_channel_id ?? null,
+      packet.sourceId ?? null
     );
 
     // Enforce max count


### PR DESCRIPTION
## Summary
Packet Monitor UI showed zero packets despite packets being received and processed. The root cause was that `sourceId` was not being passed when logging packets, so all packets were stored with `NULL` sourceId. The frontend filters by the active source's ID, resulting in no matches.

Also adds a dev config setup script (`scripts/setup-dev-config.sh`) to seed a fresh instance with default test configuration after database resets.

## Changes
- Added `sourceId: this.sourceId` to both incoming and outgoing packet logging in `meshtasticManager.ts`
- Added `sourceId` column to the SQLite INSERT statement in `database.ts`
- Added `sourceId` forwarding for non-SQLite (PostgreSQL/MySQL) path in `database.ts`
- Added `sourceId` field to `DbPacketLog` type definition in `types.ts`
- Added `scripts/setup-dev-config.sh` — seeds two sources, auto-ack on gauntlet, packet monitor enabled
- Updated `scripts/README.md` with setup script documentation

## Issues Resolved
None (discovered during testing)

## Documentation Updates
- Updated `scripts/README.md` with setup-dev-config.sh documentation

## Testing
- [x] Unit tests pass
- [x] TypeScript compiles cleanly
- [x] Verified packets now appear in Packet Monitor UI for both sources
- [x] Verified sourceId is correctly stored in database for both incoming and outgoing packets
- [x] Verified per-source filtering works correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)