### PR TITLE
fix: source card kebab menu clipping and duplicate host:port prevention

### DIFF
--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -111,6 +111,20 @@ router.post('/', requirePermission('sources', 'write'), async (req: Request, res
       return res.status(vnErr.status).json({ error: vnErr.error });
     }
 
+    // Prevent duplicate host:port combinations
+    if (type === 'meshtastic_tcp' && config.host && config.port) {
+      const existing = await databaseService.sources.getAllSources();
+      const duplicate = existing.find((s) => {
+        const cfg = s.config as any;
+        return cfg?.host === config.host && cfg?.port === config.port;
+      });
+      if (duplicate) {
+        return res.status(409).json({
+          error: `A source already exists with host ${config.host}:${config.port} ("${duplicate.name}")`,
+        });
+      }
+    }
+
     const source = await databaseService.sources.createSource({
       id: uuidv4(),
       name: name.trim(),
@@ -162,6 +176,21 @@ router.put('/:id', requirePermission('sources', 'write'), async (req: Request, r
       const vnErr = await validateVirtualNodeConfig(existing.type, config, existing.id);
       if (vnErr) {
         return res.status(vnErr.status).json({ error: vnErr.error });
+      }
+
+      // Prevent duplicate host:port combinations (exclude self)
+      if (existing.type === 'meshtastic_tcp' && config.host && config.port) {
+        const allSources = await databaseService.sources.getAllSources();
+        const duplicate = allSources.find((s) => {
+          if (s.id === req.params.id) return false;
+          const cfg = s.config as any;
+          return cfg?.host === config.host && cfg?.port === config.port;
+        });
+        if (duplicate) {
+          return res.status(409).json({
+            error: `A source already exists with host ${config.host}:${config.port} ("${duplicate.name}")`,
+          });
+        }
       }
     }
 

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -124,14 +124,14 @@
   border: 1px solid transparent;
   cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
-  overflow: hidden;
 }
 
 /* Faint Meshtastic logo watermark behind the tile. Uses a ::before overlay so
    it sits behind the content but above the card background, and doesn't steal
    pointer events from the card's click handler.  The official Meshtastic logo
    fills the entire card as a subtle background graphic identifying the source
-   type at a glance.  Inlined as a data URL to avoid BASE_URL path issues. */
+   type at a glance.  Inlined as a data URL to avoid BASE_URL path issues.
+   Watermark is clipped to card bounds via border-radius + overflow on ::before. */
 .dashboard-source-card.has-meshtastic-watermark::before {
   content: '';
   position: absolute;
@@ -142,6 +142,8 @@
   background-position: center;
   opacity: 0.07;
   pointer-events: none;
+  border-radius: inherit;
+  overflow: hidden;
 }
 
 .dashboard-source-card > * {


### PR DESCRIPTION
## Summary
- **Kebab menu clipping fix**: Removed `overflow: hidden` from `.dashboard-source-card` so the dropdown menu renders outside card bounds. Moved `border-radius` and `overflow: hidden` to the `::before` watermark pseudo-element to keep it clipped properly.
- **Duplicate source prevention**: Added host:port uniqueness validation on both create (`POST /api/sources`) and update (`PUT /api/sources/:id`) routes for `meshtastic_tcp` sources. Returns 409 with the conflicting source name.

## Test plan
- [ ] Open dashboard with multiple source cards — verify kebab (three-dot) menu opens fully without clipping
- [ ] Verify Meshtastic watermark still respects card border-radius (no overflow)
- [ ] Try creating a new source with the same host:port as an existing one — verify 409 error with helpful message
- [ ] Try updating a source to use another source's host:port — verify 409 error
- [ ] Verify updating a source keeping its own host:port succeeds (self-exclusion works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)