### PR TITLE
fix: Remote Admin Scanner uses configured time format (#2670)

### DIFF
--- a/src/components/RemoteAdminScannerSection.tsx
+++ b/src/components/RemoteAdminScannerSection.tsx
@@ -4,6 +4,8 @@ import { useToast } from './ToastContainer';
 import { useCsrfFetch } from '../hooks/useCsrfFetch';
 import { useSourceQuery } from '../hooks/useSourceQuery';
 import { useSaveBar } from '../hooks/useSaveBar';
+import { useSettings } from '../contexts/SettingsContext';
+import { formatDateTime } from '../utils/datetime';
 
 interface RemoteAdminScannerSectionProps {
   baseUrl: string;
@@ -32,6 +34,7 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
   const csrfFetch = useCsrfFetch();
   const sourceQuery = useSourceQuery();
   const { showToast } = useToast();
+  const { timeFormat, dateFormat } = useSettings();
 
   // Local state
   const [localEnabled, setLocalEnabled] = useState(false);
@@ -452,7 +455,7 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
                     {scanLog.map((entry) => (
                       <tr key={`${entry.nodeNum}-${entry.timestamp}`} style={{ borderTop: '1px solid var(--ctp-surface1)' }}>
                         <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-subtext0)' }}>
-                          {new Date(entry.timestamp).toLocaleString()}
+                          {formatDateTime(new Date(entry.timestamp), timeFormat, dateFormat)}
                         </td>
                         <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-text)' }}>
                           {entry.nodeName || `!${entry.nodeNum.toString(16).padStart(8, '0')}`}


### PR DESCRIPTION
## Summary

The `Recent Scan Results` table in the Remote Admin Scanner section rendered timestamps with `new Date(...).toLocaleString()`, ignoring the user's configured time/date format.

Fix: pull `timeFormat` and `dateFormat` from `useSettings()` and render via the shared `formatDateTime` helper, matching the pattern used elsewhere in the UI.

Fixes #2670

## Test plan
- [x] Type check passes
- [ ] Verify scan log timestamps respect Settings → General → Time/Date format

🤖 Generated with [Claude Code](https://claude.com/claude-code)