### PR TITLE
fix: Embed map respects global Default Map Center and URL params (#2668)

### DIFF
--- a/src/components/EmbedMap.tsx
+++ b/src/components/EmbedMap.tsx
@@ -264,12 +264,22 @@ export function EmbedMap({ profileId }: EmbedMapProps) {
 
   const tileset = getEmbedTileset(config.tileset);
 
+  // Optional URL-parameter overrides (issue #2668): ?lat=&lon=&zoom= let
+  // embedders pin a location without creating a new profile.
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlLat = parseFloat(urlParams.get('lat') ?? '');
+  const urlLon = parseFloat(urlParams.get('lon') ?? '');
+  const urlZoom = parseInt(urlParams.get('zoom') ?? '', 10);
+  const centerLat = Number.isFinite(urlLat) ? urlLat : config.defaultLat;
+  const centerLng = Number.isFinite(urlLon) ? urlLon : config.defaultLng;
+  const centerZoom = Number.isFinite(urlZoom) ? urlZoom : config.defaultZoom;
+
   return (
     <div style={{ width: '100%', height: '100%', position: 'relative' }}>
       <style>{embedPopupCss}</style>
       <MapContainer
-        center={[config.defaultLat, config.defaultLng]}
-        zoom={config.defaultZoom}
+        center={[centerLat, centerLng]}
+        zoom={centerZoom}
         style={{ width: '100%', height: '100%' }}
         zoomControl={true}
         attributionControl={true}

--- a/src/server/routes/embedPublicRoutes.ts
+++ b/src/server/routes/embedPublicRoutes.ts
@@ -25,14 +25,32 @@ router.get('/:profileId/config', createEmbedCspMiddleware(), (req: Request, res:
     return res.status(404).json({ error: 'Embed profile not found' });
   }
 
+  // Fall back to the global Default Map Center when the profile's coordinates
+  // are unset (0,0). Issue #2668 — embed profiles created before per-profile
+  // center was configured, or created without adjusting the default picker,
+  // would otherwise load over the Atlantic.
+  let defaultLat = profile.defaultLat;
+  let defaultLng = profile.defaultLng;
+  let defaultZoom = profile.defaultZoom;
+  if (defaultLat === 0 && defaultLng === 0) {
+    const globalLat = parseFloat(databaseService.getSetting('defaultMapCenterLat') ?? '');
+    const globalLon = parseFloat(databaseService.getSetting('defaultMapCenterLon') ?? '');
+    const globalZoom = parseInt(databaseService.getSetting('defaultMapCenterZoom') ?? '', 10);
+    if (Number.isFinite(globalLat) && Number.isFinite(globalLon)) {
+      defaultLat = globalLat;
+      defaultLng = globalLon;
+      if (Number.isFinite(globalZoom)) defaultZoom = globalZoom;
+    }
+  }
+
   // Return only public-facing configuration (exclude admin-only fields like name, allowedOrigins)
   res.json({
     id: profile.id,
     channels: profile.channels,
     tileset: profile.tileset,
-    defaultLat: profile.defaultLat,
-    defaultLng: profile.defaultLng,
-    defaultZoom: profile.defaultZoom,
+    defaultLat,
+    defaultLng,
+    defaultZoom,
     showTooltips: profile.showTooltips,
     showPopups: profile.showPopups,
     showLegend: profile.showLegend,


### PR DESCRIPTION
## Summary

When an embed profile is created without adjusting its per-profile center picker, it stored `defaultLat=0, defaultLng=0` and loaded the embedded map over the Atlantic — ignoring the global `Default Map Center` the user had configured. URL query parameters on the embed (`?lat=&lon=&zoom=`) were also silently ignored.

Two small fixes:
- **Server** (`embedPublicRoutes.ts`): when the profile's coordinates are unset (0,0), fall back to the global `defaultMapCenterLat/Lon/Zoom` settings.
- **Client** (`EmbedMap.tsx`): read `?lat=`, `?lon=`, `?zoom=` from the embed URL and override the config when valid numbers are present.

Fixes #2668

Note: the reporter also mentioned that old embed UUIDs returned "Embed profile not found" after v3.12.0 upgrade. That's flagged as a possible separate bug and is **not** addressed here.

## Test plan
- [x] Type check passes
- [x] `embedProfileRoutes`, `embedMiddleware`, `embedProfiles` tests pass (34/34)
- [ ] Verify new embed profile without a custom center loads on the configured global Default Map Center
- [ ] Verify `?lat=36.06&lon=-95.80&zoom=11` query overrides the profile default

🤖 Generated with [Claude Code](https://claude.com/claude-code)