### PR TITLE
fix: disabled channels persist in UI (#2666)

### DIFF
--- a/src/server/constants/channelRole.test.ts
+++ b/src/server/constants/channelRole.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeChannelRole,
+  CHANNEL_ROLE_DISABLED,
+  CHANNEL_ROLE_PRIMARY,
+  CHANNEL_ROLE_SECONDARY,
+} from './channelRole.js';
+
+describe('normalizeChannelRole', () => {
+  it('always returns PRIMARY for channel 0', () => {
+    expect(normalizeChannelRole({ index: 0 })).toBe(CHANNEL_ROLE_PRIMARY);
+    expect(normalizeChannelRole({ index: 0, role: CHANNEL_ROLE_DISABLED })).toBe(CHANNEL_ROLE_PRIMARY);
+    expect(normalizeChannelRole({ index: 0, role: CHANNEL_ROLE_SECONDARY })).toBe(CHANNEL_ROLE_PRIMARY);
+  });
+
+  it('normalizes empty secondary channel with undefined role to DISABLED (#2666)', () => {
+    // Firmware elides role=DISABLED on the wire — arrives as undefined
+    expect(normalizeChannelRole({ index: 2, settings: {} })).toBe(CHANNEL_ROLE_DISABLED);
+    expect(normalizeChannelRole({ index: 2, settings: { name: '' } })).toBe(CHANNEL_ROLE_DISABLED);
+    expect(normalizeChannelRole({ index: 7, settings: { psk: new Uint8Array(0) } })).toBe(CHANNEL_ROLE_DISABLED);
+  });
+
+  it('preserves undefined role when channel has a name (config update without role)', () => {
+    // Don't auto-disable a channel that's still configured — let the repo
+    // fall back to the existing role via nullish coalescing
+    expect(normalizeChannelRole({ index: 2, settings: { name: 'Gauntlet' } })).toBeUndefined();
+  });
+
+  it('preserves undefined role when channel has a PSK', () => {
+    expect(
+      normalizeChannelRole({ index: 2, settings: { psk: new Uint8Array([1, 2, 3]) } })
+    ).toBeUndefined();
+  });
+
+  it('keeps explicit DISABLED role on secondary slots', () => {
+    expect(normalizeChannelRole({ index: 2, role: CHANNEL_ROLE_DISABLED, settings: {} })).toBe(CHANNEL_ROLE_DISABLED);
+  });
+
+  it('keeps explicit SECONDARY role', () => {
+    expect(
+      normalizeChannelRole({ index: 3, role: CHANNEL_ROLE_SECONDARY, settings: { name: 'Work' } })
+    ).toBe(CHANNEL_ROLE_SECONDARY);
+  });
+
+  it('downgrades PRIMARY role on secondary slots to SECONDARY (defensive)', () => {
+    // Only channel 0 may be PRIMARY; defend against misconfigured firmware
+    expect(
+      normalizeChannelRole({ index: 4, role: CHANNEL_ROLE_PRIMARY, settings: { name: 'Oops' } })
+    ).toBe(CHANNEL_ROLE_SECONDARY);
+  });
+
+  it('treats falsy/missing settings gracefully', () => {
+    expect(normalizeChannelRole({ index: 5 })).toBe(CHANNEL_ROLE_DISABLED);
+  });
+});

--- a/src/server/constants/channelRole.ts
+++ b/src/server/constants/channelRole.ts
@@ -1,0 +1,58 @@
+/**
+ * Channel role normalization helpers.
+ *
+ * Firmware encodes Channel.role using proto3 semantics: the default value
+ * DISABLED(0) is elided from the wire, so a freshly-disabled channel decodes
+ * with role=undefined rather than role=0. Without compensating for that, the
+ * repository's `role ?? existingChannel.role` fallback preserves the stale
+ * SECONDARY role and the channel never leaves the UI (#2666).
+ */
+
+export const CHANNEL_ROLE_DISABLED = 0;
+export const CHANNEL_ROLE_PRIMARY = 1;
+export const CHANNEL_ROLE_SECONDARY = 2;
+
+export interface ChannelLike {
+  index: number;
+  role?: number;
+  settings?: {
+    name?: string;
+    psk?: { length?: number } | Uint8Array | null;
+  };
+}
+
+/**
+ * Resolve the effective role for an incoming firmware Channel message,
+ * compensating for proto3 default-value elision.
+ *
+ * Returns:
+ *   - PRIMARY(1) for channel 0 regardless of incoming role (channel 0 is
+ *     always primary by Meshtastic convention)
+ *   - DISABLED(0) for secondary slots (1-7) that arrive with no role, no
+ *     name, and no PSK — they are semantically empty and should clear any
+ *     stale record on disk
+ *   - SECONDARY(2) for secondary slots arriving with role=PRIMARY (defensive
+ *     override; only channel 0 may be PRIMARY)
+ *   - Otherwise, the original `channel.role` (may be undefined — the caller
+ *     must then defer to existing-record role via nullish coalescing)
+ */
+export function normalizeChannelRole(channel: ChannelLike): number | undefined {
+  if (channel.index === 0) {
+    return CHANNEL_ROLE_PRIMARY;
+  }
+
+  const incoming = channel.role;
+  const hasName = !!channel.settings?.name;
+  const psk = channel.settings?.psk;
+  const hasPsk = !!(psk && typeof psk === 'object' && 'length' in psk && (psk.length ?? 0) > 0);
+
+  if (incoming === undefined && !hasName && !hasPsk) {
+    return CHANNEL_ROLE_DISABLED;
+  }
+
+  if (incoming === CHANNEL_ROLE_PRIMARY) {
+    return CHANNEL_ROLE_SECONDARY;
+  }
+
+  return incoming;
+}

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -26,6 +26,7 @@ import { migrateAutomationChannels } from './utils/automationChannelMigration.js
 import { detectChannelMoves } from './utils/channelMoveDetection.js';
 import { applyHomoglyphOptimization } from '../utils/homoglyph.js';
 import { PortNum, RoutingError, isPkiError, getRoutingErrorName, CHANNEL_DB_OFFSET, TransportMechanism, isViaMqtt, MIN_TRACEROUTE_INTERVAL_MS, StoreForwardRequestResponse, getStoreForwardRequestResponseName } from './constants/meshtastic.js';
+import { normalizeChannelRole } from './constants/channelRole.js';
 import { isAutoFavoriteEligible } from './constants/autoFavorite.js';
 import { createRequire } from 'module';
 import { validateCron, scheduleCron, type CronJob } from './utils/cronScheduler.js';
@@ -3765,20 +3766,27 @@ class MeshtasticManager implements ISourceManager {
           // Extract position precision from module settings if available
           const positionPrecision = channel.settings.moduleSettings?.positionPrecision;
 
-          // Defensive channel role validation:
+          // Defensive channel role validation.
+          // Rules:
           // 1. Channel 0 must be PRIMARY (role=1), never DISABLED (role=0)
           // 2. Channels 1-7 must be SECONDARY (role=2) or DISABLED (role=0), never PRIMARY (role=1)
-          // A mesh network MUST have exactly ONE PRIMARY channel, and Channel 0 is conventionally PRIMARY
-          let channelRole = channel.role !== undefined ? channel.role : undefined;
+          // 3. Proto3 default-value elision (#2666): firmware strips role=DISABLED on the
+          //    wire, so an empty secondary slot arrives with role=undefined. Treat "no
+          //    role + no name + no PSK" as DISABLED so `?? existingChannel.role` in
+          //    upsertChannel doesn't preserve the stale SECONDARY role forever.
+          const channelRole = normalizeChannelRole(channel);
+
           if (channel.index === 0 && channel.role === 0) {
             logger.warn(`⚠️  Channel 0 received with role=DISABLED (0), overriding to PRIMARY (1)`);
-            channelRole = 1;  // PRIMARY
           }
 
           if (channel.index > 0 && channel.role === 1) {
             logger.warn(`⚠️  Channel ${channel.index} received with role=PRIMARY (1), overriding to SECONDARY (2)`);
             logger.warn(`⚠️  Only Channel 0 can be PRIMARY - all other channels must be SECONDARY or DISABLED`);
-            channelRole = 2;  // SECONDARY
+          }
+
+          if (channelRole === 0 && channel.role === undefined && channel.index > 0) {
+            logger.info(`📡 Channel ${channel.index} arrived empty — normalizing role to DISABLED(0) (#2666)`);
           }
 
           logger.info(`📡 Saving channel ${channel.index} (${displayName}) - role: ${channelRole}, positionPrecision: ${positionPrecision}`);


### PR DESCRIPTION
Closes #2666.

## Summary

- Firmware strips `role=DISABLED(0)` from Channel messages (proto3 default-value elision), so disabled secondary channels arrive with `role=undefined`.
- The repo's `role ?? existingChannel.role` fallback then preserves the stale SECONDARY role, and `/api/channels` keeps serving the zombie slot — messages on that channel mix into the primary feed.
- Added `normalizeChannelRole` helper: when a secondary slot (1-7) arrives with no role, no name, and no PSK, it is treated as DISABLED so `upsertChannel` persists role=0 and the `/api/channels` filter excludes it.

## Changes

- `src/server/constants/channelRole.ts` — new pure helper + role constants
- `src/server/constants/channelRole.test.ts` — unit tests covering all normalization paths (8 cases)
- `src/server/meshtasticManager.ts` — `processChannelProtobuf` uses the helper; defensive logging preserved

## Test plan

- [x] `npm test` — 4270 pass, 0 fail
- [ ] Manual: dev-deploy, disable a secondary channel on the connected firmware, reload config → channel disappears from UI and messages no longer bleed into primary