### PR TITLE
feat: toggle delete vs ignore for auto-delete-by-distance (#2676)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -587,6 +587,7 @@ function App() {
     autoDeleteByDistanceThresholdKm, setAutoDeleteByDistanceThresholdKm,
     autoDeleteByDistanceLat, setAutoDeleteByDistanceLat,
     autoDeleteByDistanceLon, setAutoDeleteByDistanceLon,
+    autoDeleteByDistanceAction, setAutoDeleteByDistanceAction,
   } = useAutomation();
 
   // Check tab permissions and redirect if unauthorized
@@ -1161,6 +1162,9 @@ function App() {
           }
           if (settings.autoDeleteByDistanceLon !== undefined) {
             setAutoDeleteByDistanceLon(settings.autoDeleteByDistanceLon ? parseFloat(settings.autoDeleteByDistanceLon) : null);
+          }
+          if (settings.autoDeleteByDistanceAction !== undefined) {
+            setAutoDeleteByDistanceAction(settings.autoDeleteByDistanceAction === 'ignore' ? 'ignore' : 'delete');
           }
 
           if (settings.timerTriggers) {
@@ -5083,6 +5087,8 @@ function App() {
                   onThresholdChange={setAutoDeleteByDistanceThresholdKm}
                   onHomeLatChange={setAutoDeleteByDistanceLat}
                   onHomeLonChange={setAutoDeleteByDistanceLon}
+                  action={autoDeleteByDistanceAction}
+                  onActionChange={setAutoDeleteByDistanceAction}
                 />
               </div>
               <div id="ignored-nodes">

--- a/src/components/AutoDeleteByDistanceSection.tsx
+++ b/src/components/AutoDeleteByDistanceSection.tsx
@@ -21,6 +21,8 @@ interface AutoDeleteByDistanceSectionProps {
   onThresholdChange: (km: number) => void;
   onHomeLatChange: (lat: number | null) => void;
   onHomeLonChange: (lon: number | null) => void;
+  action: 'delete' | 'ignore';
+  onActionChange: (action: 'delete' | 'ignore') => void;
 }
 
 interface LogEntry {
@@ -45,6 +47,8 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
   onThresholdChange,
   onHomeLatChange,
   onHomeLonChange,
+  action,
+  onActionChange,
 }) => {
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
@@ -58,6 +62,7 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
   const [localThresholdKm, setLocalThresholdKm] = useState(thresholdKm);
   const [localHomeLat, setLocalHomeLat] = useState<string>(homeLat != null ? String(homeLat) : '');
   const [localHomeLon, setLocalHomeLon] = useState<string>(homeLon != null ? String(homeLon) : '');
+  const [localAction, setLocalAction] = useState<'delete' | 'ignore'>(action);
 
   // Activity log
   const [logEntries, setLogEntries] = useState<LogEntry[]>([]);
@@ -80,6 +85,7 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
   useEffect(() => { setLocalThresholdKm(thresholdKm); }, [thresholdKm]);
   useEffect(() => { setLocalHomeLat(homeLat != null ? String(homeLat) : ''); }, [homeLat]);
   useEffect(() => { setLocalHomeLon(homeLon != null ? String(homeLon) : ''); }, [homeLon]);
+  useEffect(() => { setLocalAction(action); }, [action]);
 
   // Detect unsaved changes
   const hasChanges =
@@ -87,7 +93,8 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
     localIntervalHours !== intervalHours ||
     localThresholdKm !== thresholdKm ||
     (localHomeLat !== (homeLat != null ? String(homeLat) : '')) ||
-    (localHomeLon !== (homeLon != null ? String(homeLon) : ''));
+    (localHomeLon !== (homeLon != null ? String(homeLon) : '')) ||
+    localAction !== action;
 
   // Fetch log entries
   const fetchLog = useCallback(async () => {
@@ -124,6 +131,7 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
         autoDeleteByDistanceEnabled: String(localEnabled),
         autoDeleteByDistanceIntervalHours: String(localIntervalHours),
         autoDeleteByDistanceThresholdKm: String(localThresholdKm),
+        autoDeleteByDistanceAction: localAction,
       };
 
       const lat = parseFloat(localHomeLat);
@@ -143,6 +151,7 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
         onThresholdChange(localThresholdKm);
         onHomeLatChange(!isNaN(lat) ? lat : null);
         onHomeLonChange(!isNaN(lon) ? lon : null);
+        onActionChange(localAction);
         showToast(t('automation.settings_saved', 'Settings saved'), 'success');
       } else {
         const err = await response.json();
@@ -154,9 +163,9 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
       setIsSaving(false);
     }
   }, [
-    localEnabled, localIntervalHours, localThresholdKm, localHomeLat, localHomeLon,
-    csrfFetch, baseUrl, onEnabledChange, onIntervalChange, onThresholdChange,
-    onHomeLatChange, onHomeLonChange, showToast, t,
+    localEnabled, localIntervalHours, localThresholdKm, localHomeLat, localHomeLon, localAction,
+    csrfFetch, baseUrl, sourceQuery, onEnabledChange, onIntervalChange, onThresholdChange,
+    onHomeLatChange, onHomeLonChange, onActionChange, showToast, t,
   ]);
 
   const resetChanges = useCallback(() => {
@@ -165,7 +174,8 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
     setLocalThresholdKm(thresholdKm);
     setLocalHomeLat(homeLat != null ? String(homeLat) : '');
     setLocalHomeLon(homeLon != null ? String(homeLon) : '');
-  }, [enabled, intervalHours, thresholdKm, homeLat, homeLon]);
+    setLocalAction(action);
+  }, [enabled, intervalHours, thresholdKm, homeLat, homeLon, action]);
 
   useSaveBar({
     id: 'auto-delete-by-distance',
@@ -347,6 +357,55 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
               </option>
             ))}
           </select>
+        </div>
+
+        {/* Action toggle: Delete vs Ignore */}
+        <div className="setting-item" style={{ marginTop: '1rem' }}>
+          <label>
+            {t('automation.distance_delete.action', 'Action for nodes beyond threshold')}
+          </label>
+          <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', marginTop: '0.25rem' }}>
+            <label style={{ display: 'inline-flex', alignItems: 'center', gap: '0.25rem', cursor: localEnabled ? 'pointer' : 'not-allowed' }}>
+              <input
+                type="radio"
+                name="autoDeleteByDistanceAction"
+                value="delete"
+                checked={localAction === 'delete'}
+                onChange={() => setLocalAction('delete')}
+                disabled={!localEnabled}
+                style={{ width: 'auto', margin: 0, cursor: localEnabled ? 'pointer' : 'not-allowed' }}
+              />
+              {t('automation.distance_delete.action_delete', 'Delete node')}
+            </label>
+            <label style={{ display: 'inline-flex', alignItems: 'center', gap: '0.25rem', cursor: localEnabled ? 'pointer' : 'not-allowed', marginLeft: '1rem' }}>
+              <input
+                type="radio"
+                name="autoDeleteByDistanceAction"
+                value="ignore"
+                checked={localAction === 'ignore'}
+                onChange={() => setLocalAction('ignore')}
+                disabled={!localEnabled}
+                style={{ width: 'auto', margin: 0, cursor: localEnabled ? 'pointer' : 'not-allowed' }}
+              />
+              {t('automation.distance_delete.action_ignore', 'Ignore node')}
+            </label>
+          </div>
+          <p style={{
+            marginTop: '0.5rem',
+            marginLeft: 0,
+            padding: '0.5rem 0.75rem',
+            background: 'var(--ctp-surface0)',
+            border: '1px solid var(--ctp-surface2)',
+            borderLeft: '3px solid var(--ctp-yellow)',
+            borderRadius: '4px',
+            color: 'var(--ctp-subtext1)',
+            fontSize: '12px',
+            lineHeight: '1.5',
+          }}>
+            {localAction === 'delete'
+              ? t('automation.distance_delete.note_delete', 'A deleted node may return if it continues to broadcast. Choose Ignore to suppress it persistently on the device.')
+              : t('automation.distance_delete.note_ignore', 'Ignored nodes are hidden and synced to the connected device (requires firmware ≥ 2.7.0).')}
+          </p>
         </div>
 
         {homeLat == null && (

--- a/src/contexts/AutomationContext.tsx
+++ b/src/contexts/AutomationContext.tsx
@@ -98,6 +98,8 @@ interface AutomationContextType {
   setAutoDeleteByDistanceLat: React.Dispatch<React.SetStateAction<number | null>>;
   autoDeleteByDistanceLon: number | null;
   setAutoDeleteByDistanceLon: React.Dispatch<React.SetStateAction<number | null>>;
+  autoDeleteByDistanceAction: 'delete' | 'ignore';
+  setAutoDeleteByDistanceAction: React.Dispatch<React.SetStateAction<'delete' | 'ignore'>>;
   timerTriggers: TimerTrigger[];
   setTimerTriggers: React.Dispatch<React.SetStateAction<TimerTrigger[]>>;
   geofenceTriggers: GeofenceTrigger[];
@@ -162,6 +164,7 @@ export const AutomationProvider: React.FC<AutomationProviderProps> = ({ children
   const [autoDeleteByDistanceThresholdKm, setAutoDeleteByDistanceThresholdKm] = useState<number>(100);
   const [autoDeleteByDistanceLat, setAutoDeleteByDistanceLat] = useState<number | null>(null);
   const [autoDeleteByDistanceLon, setAutoDeleteByDistanceLon] = useState<number | null>(null);
+  const [autoDeleteByDistanceAction, setAutoDeleteByDistanceAction] = useState<'delete' | 'ignore'>('delete');
   const [timerTriggers, setTimerTriggers] = useState<TimerTrigger[]>([]);
   const [geofenceTriggers, setGeofenceTriggers] = useState<GeofenceTrigger[]>([]);
 
@@ -257,6 +260,7 @@ export const AutomationProvider: React.FC<AutomationProviderProps> = ({ children
         if (s.autoDeleteByDistanceThresholdKm !== undefined) setAutoDeleteByDistanceThresholdKm(num('autoDeleteByDistanceThresholdKm', 100));
         if (s.autoDeleteByDistanceLat !== undefined) setAutoDeleteByDistanceLat(s.autoDeleteByDistanceLat ? num('autoDeleteByDistanceLat', 0) : null);
         if (s.autoDeleteByDistanceLon !== undefined) setAutoDeleteByDistanceLon(s.autoDeleteByDistanceLon ? num('autoDeleteByDistanceLon', 0) : null);
+        if (s.autoDeleteByDistanceAction !== undefined) setAutoDeleteByDistanceAction(s.autoDeleteByDistanceAction === 'ignore' ? 'ignore' : 'delete');
 
         if (s.timerTriggers !== undefined) setTimerTriggers(jsonArr<TimerTrigger>('timerTriggers', []));
         if (s.geofenceTriggers !== undefined) setGeofenceTriggers(jsonArr<GeofenceTrigger>('geofenceTriggers', []));
@@ -318,6 +322,7 @@ export const AutomationProvider: React.FC<AutomationProviderProps> = ({ children
         autoDeleteByDistanceThresholdKm, setAutoDeleteByDistanceThresholdKm,
         autoDeleteByDistanceLat, setAutoDeleteByDistanceLat,
         autoDeleteByDistanceLon, setAutoDeleteByDistanceLon,
+        autoDeleteByDistanceAction, setAutoDeleteByDistanceAction,
         timerTriggers, setTimerTriggers,
         geofenceTriggers, setGeofenceTriggers,
       }}

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -97,6 +97,7 @@ export const VALID_SETTINGS_KEYS = [
   'autoDeleteByDistanceThresholdKm',
   'autoDeleteByDistanceLat',
   'autoDeleteByDistanceLon',
+  'autoDeleteByDistanceAction',
   'remoteAdminScannerIntervalMinutes',
   'remoteAdminScannerExpirationHours',
   'tracerouteScheduleEnabled',

--- a/src/server/services/autoDeleteByDistanceService.ts
+++ b/src/server/services/autoDeleteByDistanceService.ts
@@ -97,6 +97,12 @@ class AutoDeleteByDistanceService {
       // If sourceId provided, scope to that source; otherwise scan all sources
       const allNodes = await databaseService.nodes.getAllNodes(sourceId);
 
+      // Throttle device syncs so firmware admin queue doesn't back up on
+      // large MQTT meshes with hundreds of nodes to ignore per cycle.
+      const SYNC_DELAY_MS = 5000;
+      let firmwareUnsupported = false;
+      let pendingSyncDelay = false;
+
       for (const node of allNodes) {
         // Protect local node
         if (localNodeNum != null && Number(node.nodeNum) === localNodeNum) {
@@ -128,20 +134,35 @@ class AutoDeleteByDistanceService {
 
           try {
             if (action === 'ignore') {
-              await databaseService.setNodeIgnoredAsync(nodeNum, true, nodeSourceId);
+              // Skip nodes already marked ignored — nothing to do in DB,
+              // and the device already knows (or tried once this session).
+              if (node.isIgnored) {
+                continue;
+              }
 
-              // Best-effort sync to device; tolerate pre-2.7 firmware
-              const manager = (sourceManagerRegistry.getManager(nodeSourceId) as typeof meshtasticManager) ?? meshtasticManager;
-              try {
-                await manager.sendIgnoredNode(nodeNum);
-              } catch (syncError) {
-                if (syncError instanceof Error && syncError.message === 'FIRMWARE_NOT_SUPPORTED') {
-                  logger.debug(`ℹ️ Auto-delete-by-distance: firmware does not support ignored nodes for ${nodeNum}, skipped device sync`);
-                } else {
-                  logger.warn(`⚠️ Auto-delete-by-distance: failed to sync ignored status to device for node ${nodeNum}:`, syncError);
+              await databaseService.setNodeIgnoredAsync(nodeNum, true, nodeSourceId);
+              processedNodes.push(nodeInfo);
+
+              // Device sync: throttled + short-circuit on unsupported firmware
+              if (!firmwareUnsupported) {
+                if (pendingSyncDelay) {
+                  await new Promise((resolve) => setTimeout(resolve, SYNC_DELAY_MS));
+                }
+                const manager = (sourceManagerRegistry.getManager(nodeSourceId) as typeof meshtasticManager) ?? meshtasticManager;
+                try {
+                  await manager.sendIgnoredNode(nodeNum);
+                  pendingSyncDelay = true;
+                } catch (syncError) {
+                  if (syncError instanceof Error && syncError.message === 'FIRMWARE_NOT_SUPPORTED') {
+                    logger.debug(`ℹ️ Auto-delete-by-distance: firmware does not support ignored nodes; skipping device sync for remaining nodes this cycle`);
+                    firmwareUnsupported = true;
+                  } else {
+                    logger.warn(`⚠️ Auto-delete-by-distance: failed to sync ignored status to device for node ${nodeNum}:`, syncError);
+                    // Still throttle after a failed send — firmware may be busy
+                    pendingSyncDelay = true;
+                  }
                 }
               }
-              processedNodes.push(nodeInfo);
             } else {
               await databaseService.deleteNodeAsync(nodeNum, nodeSourceId);
               processedNodes.push(nodeInfo);

--- a/src/server/services/autoDeleteByDistanceService.ts
+++ b/src/server/services/autoDeleteByDistanceService.ts
@@ -1,11 +1,16 @@
 import { logger } from '../../utils/logger.js';
 import databaseService from '../../services/database.js';
 import { calculateDistance } from '../../utils/distance.js';
+import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+import meshtasticManager from '../meshtasticManager.js';
 
-interface DeletedNodeInfo {
+type DistanceAction = 'delete' | 'ignore';
+
+interface ProcessedNodeInfo {
   nodeId: string;
   nodeName: string;
   distanceKm: number;
+  action: DistanceAction;
 }
 
 class AutoDeleteByDistanceService {
@@ -69,13 +74,15 @@ class AutoDeleteByDistanceService {
     }
 
     this.isRunning = true;
-    const deletedNodes: DeletedNodeInfo[] = [];
+    const processedNodes: ProcessedNodeInfo[] = [];
 
     try {
       // Read settings (per-source with global fallback)
       const homeLat = parseFloat(await databaseService.settings.getSettingForSource(sourceId, 'autoDeleteByDistanceLat') || '');
       const homeLon = parseFloat(await databaseService.settings.getSettingForSource(sourceId, 'autoDeleteByDistanceLon') || '');
       const thresholdKm = parseFloat(await databaseService.settings.getSettingForSource(sourceId, 'autoDeleteByDistanceThresholdKm') || '100');
+      const actionRaw = (await databaseService.settings.getSettingForSource(sourceId, 'autoDeleteByDistanceAction')) || 'delete';
+      const action: DistanceAction = actionRaw === 'ignore' ? 'ignore' : 'delete';
 
       if (isNaN(homeLat) || isNaN(homeLon)) {
         logger.debug('⏭️ Auto-delete-by-distance: no home coordinate configured, skipping');
@@ -110,16 +117,37 @@ class AutoDeleteByDistanceService {
         const distance = calculateDistance(homeLat, homeLon, node.latitude, node.longitude);
 
         if (distance > thresholdKm) {
+          const nodeSourceId = (node as any).sourceId || sourceId || 'default';
+          const nodeNum = Number(node.nodeNum);
+          const nodeInfo: ProcessedNodeInfo = {
+            nodeId: node.nodeId || `!${nodeNum.toString(16)}`,
+            nodeName: node.longName || node.shortName || `Node ${node.nodeNum}`,
+            distanceKm: Math.round(distance * 10) / 10,
+            action,
+          };
+
           try {
-            const nodeSourceId = (node as any).sourceId || sourceId || 'default';
-            await databaseService.deleteNodeAsync(Number(node.nodeNum), nodeSourceId);
-            deletedNodes.push({
-              nodeId: node.nodeId || `!${Number(node.nodeNum).toString(16)}`,
-              nodeName: node.longName || node.shortName || `Node ${node.nodeNum}`,
-              distanceKm: Math.round(distance * 10) / 10,
-            });
+            if (action === 'ignore') {
+              await databaseService.setNodeIgnoredAsync(nodeNum, true, nodeSourceId);
+
+              // Best-effort sync to device; tolerate pre-2.7 firmware
+              const manager = (sourceManagerRegistry.getManager(nodeSourceId) as typeof meshtasticManager) ?? meshtasticManager;
+              try {
+                await manager.sendIgnoredNode(nodeNum);
+              } catch (syncError) {
+                if (syncError instanceof Error && syncError.message === 'FIRMWARE_NOT_SUPPORTED') {
+                  logger.debug(`ℹ️ Auto-delete-by-distance: firmware does not support ignored nodes for ${nodeNum}, skipped device sync`);
+                } else {
+                  logger.warn(`⚠️ Auto-delete-by-distance: failed to sync ignored status to device for node ${nodeNum}:`, syncError);
+                }
+              }
+              processedNodes.push(nodeInfo);
+            } else {
+              await databaseService.deleteNodeAsync(nodeNum, nodeSourceId);
+              processedNodes.push(nodeInfo);
+            }
           } catch (error) {
-            logger.error(`❌ Auto-delete-by-distance: failed to delete node ${node.nodeNum}:`, error);
+            logger.error(`❌ Auto-delete-by-distance: failed to ${action} node ${node.nodeNum}:`, error);
           }
         }
       }
@@ -128,15 +156,16 @@ class AutoDeleteByDistanceService {
       const now = Date.now();
       this.lastRunAt = now;
 
-      await this.logRunAsync(now, deletedNodes.length, thresholdKm, deletedNodes, sourceId);
+      await this.logRunAsync(now, processedNodes.length, thresholdKm, processedNodes, sourceId);
 
-      if (deletedNodes.length > 0) {
-        logger.info(`🗑️ Auto-delete-by-distance: deleted ${deletedNodes.length} node(s) beyond ${thresholdKm} km`);
+      if (processedNodes.length > 0) {
+        const verb = action === 'ignore' ? 'ignored' : 'deleted';
+        logger.info(`🗑️ Auto-delete-by-distance: ${verb} ${processedNodes.length} node(s) beyond ${thresholdKm} km`);
       } else {
         logger.debug('✅ Auto-delete-by-distance: no nodes beyond threshold');
       }
 
-      return { deletedCount: deletedNodes.length };
+      return { deletedCount: processedNodes.length };
     } catch (error) {
       logger.error('❌ Auto-delete-by-distance: error during run:', error);
       return { deletedCount: 0 };
@@ -152,7 +181,7 @@ class AutoDeleteByDistanceService {
     timestamp: number,
     nodesDeleted: number,
     thresholdKm: number,
-    details: DeletedNodeInfo[],
+    details: ProcessedNodeInfo[],
     sourceId?: string
   ): Promise<void> {
     try {


### PR DESCRIPTION
## Summary
- Replace single-action "delete" behavior in Auto Delete by Distance with a mutually-exclusive toggle: **Delete node** or **Ignore node**.
- When **Ignore** is selected, the node is marked ignored in MeshMonitor and the ignore state is synced back to the connected device for persistence (firmware ≥ 2.7.0; pre-2.7 firmware falls back gracefully with a debug log).
- Adds a note box near the toggle explaining the tradeoff — a deleted node can return if it keeps broadcasting, while an ignored node stays suppressed on the device.

Closes #2676

## Test plan
- [x] Full Vitest suite green locally (214 files / 4270 tests passed)
- [x] Typecheck clean (`npx tsc --noEmit`)
- [ ] Deploy dev container, confirm toggle persists across reload
- [ ] With firmware ≥ 2.7.0, verify ignored nodes appear in `ignored_nodes` and device sync succeeds
- [ ] With pre-2.7 firmware, verify the cycle still marks nodes ignored in DB and logs FIRMWARE_NOT_SUPPORTED debug line rather than failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)