### PR TITLE
ci: add CodeQL security scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: +security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
## Summary

This adds a GitHub CodeQL workflow for automated security scanning of the JavaScript/TypeScript codebase.

**What it does:**
- Runs CodeQL analysis on every push to `main` and on pull requests
- Runs on a weekly schedule (Mondays at 6:00 UTC) for ongoing monitoring
- Uses the `security-extended` query suite for broader vulnerability coverage
- Results surface directly in GitHub's Security tab under Code Scanning

**Why:**

After forking MeshMonitor to run for my local mesh network, I enabled Dependabot and it flagged 36 known vulnerabilities in dependencies (19 high, 15 moderate, 2 low). While those are dependency-level issues, it made me realize there's no static analysis catching potential vulnerabilities in the application code itself.

CodeQL is free for public repositories and catches things like SQL injection, XSS, path traversal, and other common security issues — a nice complement to the Trivy scanning already in the CI pipeline.

**Scope:** This PR adds a single file (`.github/workflows/codeql.yml`) with no changes to application code.

Happy to adjust the schedule, trigger conditions, or query suite if you have preferences. Thanks for building MeshMonitor — it's been great for monitoring our deployment!