### PR TITLE
fix: prioritize nearby nodes in remote admin scanner (#2669)

### DIFF
--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -782,7 +782,8 @@ export class NodesRepository extends BaseRepository {
    * - Has a public key (required for admin)
    * - Active (lastHeard recent)
    * - Not checked recently (lastRemoteAdminCheck null or expired)
-   * Returns the most recently heard node matching these criteria
+   * Prioritizes nearby nodes: orders by hopsAway ASC (NULLs last), then lastHeard DESC.
+   * Without this priority, MQTT-flooded distant nodes can starve close-by admin scans.
    */
   async getNodeNeedingRemoteAdminCheckAsync(
     localNodeNum: number,
@@ -807,7 +808,7 @@ export class NodesRepository extends BaseRepository {
           this.withSourceScope(nodes, sourceId)
         )
       )
-      .orderBy(desc(nodes.lastHeard))
+      .orderBy(sql`${nodes.hopsAway} IS NULL`, asc(nodes.hopsAway), desc(nodes.lastHeard))
       .limit(1);
 
     if (results.length === 0) return null;


### PR DESCRIPTION
## Summary
- Reorder candidates in `getNodeNeedingRemoteAdminCheckAsync` by `hopsAway ASC` (NULLs last) then `lastHeard DESC`
- Fixes #2669: MQTT-flooded distant nodes were starving close-by nodes that never got scanned

## Why this is safe
- Each scan stamps `lastRemoteAdminCheck = now`, and the query filters out nodes scanned within `remoteAdminScannerExpirationHours` (default 168h / 1 week)
- A scanned node cannot reappear in the candidate set until the cooldown expires, so hops-priority cannot loop on the same nearby node

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/db/repositories/nodes.test.ts` — 28 passed
- [ ] CI green
- [ ] Verify on dev mesh that direct/1-hop nodes get scanned before distant MQTT nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)