### PR TITLE
refactor(db): extract settings domain raw SQL (Phase 2.3)

### DIFF
--- a/src/db/repositories/settings.ts
+++ b/src/db/repositories/settings.ts
@@ -232,4 +232,85 @@ export class SettingsRepository extends BaseRepository {
       }
     }
   }
+
+  // ─── Synchronous SQLite variants ────────────────────────────────────────
+  // These use drizzle's sync query builder on better-sqlite3, which is truly
+  // synchronous. Needed because DatabaseService exposes sync getSetting/
+  // setSetting used during migrations (before async cache hydration completes).
+  // Only valid on SQLite — throw if called on PG/MySQL.
+
+  /**
+   * Synchronously get a single setting value (SQLite only).
+   */
+  getSettingSync(key: string): string | null {
+    const db = this.getSqliteDb();
+    const { settings } = this.tables;
+    const rows = db
+      .select({ value: settings.value })
+      .from(settings)
+      .where(eq(settings.key, key))
+      .limit(1)
+      .all();
+    return rows.length > 0 ? (rows[0] as any).value : null;
+  }
+
+  /**
+   * Synchronously get all settings (SQLite only).
+   */
+  getAllSettingsSync(): Record<string, string> {
+    const db = this.getSqliteDb();
+    const { settings } = this.tables;
+    const rows = db
+      .select({ key: settings.key, value: settings.value })
+      .from(settings)
+      .all();
+    const result: Record<string, string> = {};
+    for (const row of rows) {
+      result[(row as any).key] = (row as any).value;
+    }
+    return result;
+  }
+
+  /**
+   * Synchronously upsert a single setting (SQLite only).
+   */
+  setSettingSync(key: string, value: string): void {
+    const db = this.getSqliteDb();
+    const { settings } = this.tables;
+    const now = this.now();
+    db
+      .insert(settings)
+      .values({ key, value, createdAt: now, updatedAt: now })
+      .onConflictDoUpdate({ target: settings.key, set: { value, updatedAt: now } })
+      .run();
+  }
+
+  /**
+   * Synchronously upsert multiple settings in a transaction (SQLite only).
+   */
+  setSettingsSync(settings: Record<string, string>): void {
+    const db = this.getSqliteDb();
+    const entries = Object.entries(settings);
+    if (entries.length === 0) return;
+    const { settings: settingsTable } = this.tables;
+    const now = this.now();
+    db.transaction((tx) => {
+      for (const [key, value] of entries) {
+        tx
+          .insert(settingsTable)
+          .values({ key, value, createdAt: now, updatedAt: now })
+          .onConflictDoUpdate({ target: settingsTable.key, set: { value, updatedAt: now } })
+          .run();
+      }
+    });
+  }
+
+  /**
+   * Synchronously delete all settings (SQLite only).
+   */
+  deleteAllSettingsSync(): void {
+    const db = this.getSqliteDb();
+    const { settings } = this.tables;
+    db.delete(settings).run();
+  }
 }

--- a/src/services/database.service.test.ts
+++ b/src/services/database.service.test.ts
@@ -115,12 +115,22 @@ const mockTelemetryRepo = vi.hoisted(() => ({
   getLatestTelemetryValueForAllNodes: vi.fn().mockResolvedValue([]),
 }));
 
-const mockSettingsRepo = vi.hoisted(() => ({
-  getSetting: vi.fn().mockResolvedValue(null),
-  setSetting: vi.fn().mockResolvedValue(undefined),
-  deleteSetting: vi.fn().mockResolvedValue(undefined),
-  getAllSettings: vi.fn().mockResolvedValue([]),
-}));
+const mockSettingsRepo = vi.hoisted(() => {
+  const store = new Map<string, string>();
+  return {
+    getSetting: vi.fn().mockImplementation(async (key: string) => store.get(key) ?? null),
+    setSetting: vi.fn().mockImplementation(async (key: string, value: string) => { store.set(key, value); }),
+    deleteSetting: vi.fn().mockImplementation(async (key: string) => { store.delete(key); }),
+    getAllSettings: vi.fn().mockImplementation(async () => Object.fromEntries(store)),
+    getSettingSync: vi.fn().mockImplementation((key: string) => store.get(key) ?? null),
+    setSettingSync: vi.fn().mockImplementation((key: string, value: string) => { store.set(key, value); }),
+    setSettingsSync: vi.fn().mockImplementation((settings: Record<string, string>) => {
+      for (const [k, v] of Object.entries(settings)) store.set(k, v);
+    }),
+    getAllSettingsSync: vi.fn().mockImplementation(() => Object.fromEntries(store)),
+    deleteAllSettingsSync: vi.fn().mockImplementation(() => { store.clear(); }),
+  };
+});
 
 const mockChannelsRepo = vi.hoisted(() => ({
   getChannels: vi.fn().mockResolvedValue([]),
@@ -167,7 +177,7 @@ const mockEmbedProfileRepo = vi.hoisted(() => ({
 
 // Use classes (not mockReturnValue) since they're called with `new`
 vi.mock('../db/repositories/index.js', () => ({
-  SettingsRepository: class { getSetting = mockSettingsRepo.getSetting; setSetting = mockSettingsRepo.setSetting; deleteSetting = mockSettingsRepo.deleteSetting; getAllSettings = mockSettingsRepo.getAllSettings; },
+  SettingsRepository: class { getSetting = mockSettingsRepo.getSetting; setSetting = mockSettingsRepo.setSetting; deleteSetting = mockSettingsRepo.deleteSetting; getAllSettings = mockSettingsRepo.getAllSettings; getSettingSync = mockSettingsRepo.getSettingSync; setSettingSync = mockSettingsRepo.setSettingSync; setSettingsSync = mockSettingsRepo.setSettingsSync; getAllSettingsSync = mockSettingsRepo.getAllSettingsSync; deleteAllSettingsSync = mockSettingsRepo.deleteAllSettingsSync; },
   ChannelsRepository: class { getChannels = mockChannelsRepo.getChannels; getChannelById = mockChannelsRepo.getChannelById; upsertChannel = mockChannelsRepo.upsertChannel; },
   NodesRepository: class { getAllNodes = mockNodesRepo.getAllNodes; getNodeByNum = mockNodesRepo.getNodeByNum; upsertNode = mockNodesRepo.upsertNode; deleteNode = mockNodesRepo.deleteNode; getNodesWithKeySecurityIssues = mockNodesRepo.getNodesWithKeySecurityIssues; },
   MessagesRepository: class { getMessage = mockMessagesRepo.getMessage; getMessages = mockMessagesRepo.getMessages; searchMessages = mockMessagesRepo.searchMessages; insertMessage = mockMessagesRepo.insertMessage; deleteMessage = mockMessagesRepo.deleteMessage; },

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -9,7 +9,8 @@ import { getEnvironmentConfig } from '../server/config/environment.js';
 import { registry } from '../db/migrations.js';
 import { validateThemeDefinition as validateTheme } from '../utils/themeValidation.js';
 // Drizzle ORM imports for dual-database support
-import { createSQLiteDriver } from '../db/drivers/sqlite.js';
+import { drizzle as drizzleSqlite } from 'drizzle-orm/better-sqlite3';
+import * as drizzleSchema from '../db/schema/index.js';
 import { createPostgresDriver } from '../db/drivers/postgres.js';
 import { createMySQLDriver } from '../db/drivers/mysql.js';
 import { getDatabaseConfig, Database } from '../db/index.js';
@@ -631,7 +632,7 @@ class DatabaseService {
   /**
    * Async initialization of Drizzle ORM repositories
    */
-  private async initializeDrizzleRepositoriesAsync(dbPath: string): Promise<void> {
+  private async initializeDrizzleRepositoriesAsync(_dbPath: string): Promise<void> {
     try {
       logger.debug('[DatabaseService] Initializing Drizzle ORM repositories');
 
@@ -667,13 +668,12 @@ class DatabaseService {
         // Create MySQL schema if tables don't exist
         await this.createMySQLSchema(pool);
       } else {
-        // Use SQLite driver (default)
-        const { db } = createSQLiteDriver({
-          databasePath: dbPath,
-          enableWAL: false, // Already enabled on main connection
-          enableForeignKeys: false, // Already enabled on main connection
-        });
-        drizzleDb = db;
+        // Use SQLite driver (default).
+        // Bind Drizzle to the existing better-sqlite3 connection (this.db) so
+        // sync repository methods and raw sync paths observe schema changes
+        // (CREATE TABLE, migrations) immediately on the same connection — and
+        // so this branch runs synchronously (no awaits before repo init below).
+        drizzleDb = drizzleSqlite(this.db, { schema: drizzleSchema });
         this.drizzleDbType = 'sqlite';
       }
 
@@ -834,12 +834,14 @@ class DatabaseService {
     // Pre-3.7 detection: check BEFORE createTables() so we can distinguish
     // an existing pre-v3.7 database from a fresh install.
     // If settings table already exists at this point, it's from a previous installation.
+    // eslint-disable-next-line no-restricted-syntax -- bootstrap: runs before migrations (see Task 2.9)
     const settingsExists = this.db.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='settings'"
     ).all();
     if (settingsExists.length > 0) {
       // Check for v3.7+ markers: either the old migration_077 key (pre-clean-break)
       // or the new migration_078 key (post-clean-break baseline)
+      // eslint-disable-next-line no-restricted-syntax -- bootstrap: runs before migrations (see Task 2.9)
       const v37Key = this.db.prepare(
         "SELECT value FROM settings WHERE key IN ('migration_077_ignored_nodes_nodenum_bigint', 'migration_078_create_embed_profiles')"
       ).get();
@@ -7431,9 +7433,11 @@ class DatabaseService {
       }
       return this.settingsCache.get(key) ?? null;
     }
-    const stmt = this.db.prepare('SELECT value FROM settings WHERE key = ?');
-    const row = stmt.get(key) as { value: string } | undefined;
-    return row ? row.value : null;
+    // SQLite: route through repo's sync drizzle path (no raw SQL)
+    if (this.settingsRepo) {
+      return this.settingsRepo.getSettingSync(key);
+    }
+    return null;
   }
 
   getAllSettings(): Record<string, string> {
@@ -7449,13 +7453,11 @@ class DatabaseService {
       });
       return settings;
     }
-    const stmt = this.db.prepare('SELECT key, value FROM settings');
-    const rows = stmt.all() as Array<{ key: string; value: string }>;
-    const settings: Record<string, string> = {};
-    rows.forEach(row => {
-      settings[row.key] = row.value;
-    });
-    return settings;
+    // SQLite: route through repo's sync drizzle path (no raw SQL)
+    if (this.settingsRepo) {
+      return this.settingsRepo.getAllSettingsSync();
+    }
+    return {};
   }
 
   setSetting(key: string, value: string): void {
@@ -7471,15 +7473,10 @@ class DatabaseService {
       }
       return;
     }
-    const now = Date.now();
-    const stmt = this.db.prepare(`
-      INSERT INTO settings (key, value, createdAt, updatedAt)
-      VALUES (?, ?, ?, ?)
-      ON CONFLICT(key) DO UPDATE SET
-        value = excluded.value,
-        updatedAt = excluded.updatedAt
-    `);
-    stmt.run(key, value, now, now);
+    // SQLite: route through repo's sync drizzle path (no raw SQL)
+    if (this.settingsRepo) {
+      this.settingsRepo.setSettingSync(key, value);
+    }
   }
 
   setSettings(settings: Record<string, string>): void {
@@ -7496,20 +7493,10 @@ class DatabaseService {
       }
       return;
     }
-    const now = Date.now();
-    const stmt = this.db.prepare(`
-      INSERT INTO settings (key, value, createdAt, updatedAt)
-      VALUES (?, ?, ?, ?)
-      ON CONFLICT(key) DO UPDATE SET
-        value = excluded.value,
-        updatedAt = excluded.updatedAt
-    `);
-
-    this.db.transaction(() => {
-      Object.entries(settings).forEach(([key, value]) => {
-        stmt.run(key, value, now, now);
-      });
-    })();
+    // SQLite: route through repo's sync drizzle path (no raw SQL)
+    if (this.settingsRepo) {
+      this.settingsRepo.setSettingsSync(settings);
+    }
   }
 
   deleteAllSettings(): void {
@@ -7524,7 +7511,10 @@ class DatabaseService {
       return;
     }
     logger.debug('🔄 Resetting all settings to defaults');
-    this.db.exec('DELETE FROM settings');
+    // SQLite: route through repo's sync drizzle path (no raw SQL)
+    if (this.settingsRepo) {
+      this.settingsRepo.deleteAllSettingsSync();
+    }
   }
 
   // ============ ASYNC NOTIFICATION PREFERENCES METHODS ============


### PR DESCRIPTION
## Summary
- Extracts all settings-table raw SQL from `src/services/database.ts` (5 sites) into the existing `SettingsRepository`, which uses Drizzle ORM across SQLite/Postgres/MySQL.
- Adds sync wrapper methods to `SettingsRepository` that use Drizzle's sync query builder on the shared `better-sqlite3` connection, preserving the sync contract relied on by many non-test callers.
- Rebinds Drizzle SQLite to the existing `this.db` handle instead of opening a second connection — fixes a latent "no such table: settings" error during init.
- Bootstrap v3.7 marker probe at line 844 retained as raw SQL with an `eslint-disable` comment — it runs before migrations and predates repo init.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 4209 tests pass, 0 failures
- [x] `node_modules/.bin/vitest run src/db/repositories/settings.test.ts` — green
- [x] `rg -cn "FROM settings|INTO settings|UPDATE settings|DELETE FROM settings" src/services/database.ts` → 1 (bootstrap only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)