### PR TITLE
refactor(db): extract channels + packetlog domains (Phase 2 Batch A)

### DIFF
--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -188,6 +188,29 @@ export class ChannelsRepository extends BaseRepository {
   }
 
   /**
+   * Clean up channels scoped to a source that have no name and no psk.
+   * Used by `cleanupInvalidChannelsAsync(sourceId)` — narrower semantics than
+   * `cleanupInvalidChannels()` (which uses id range 0–7).
+   */
+  async cleanupEmptyChannelsForSource(sourceId: string): Promise<number> {
+    const { channels } = this.tables;
+    const whereClause = and(
+      or(isNull(channels.name), eq(channels.name, '')),
+      or(isNull(channels.psk), eq(channels.psk, '')),
+      eq(channels.sourceId, sourceId)
+    );
+    const countRows = await this.db
+      .select({ count: count() })
+      .from(channels)
+      .where(whereClause);
+    const deleteCount = Number(countRows[0].count);
+    if (deleteCount > 0) {
+      await this.db.delete(channels).where(whereClause);
+    }
+    return deleteCount;
+  }
+
+  /**
    * Clean up invalid channels that shouldn't have been created
    * Meshtastic supports channels 0-7 (8 total channels)
    */
@@ -221,6 +244,139 @@ export class ChannelsRepository extends BaseRepository {
       await this.db.delete(channels).where(whereClause);
     }
     logger.debug(`Cleaned up ${deleteCount} empty channels (ID > 1, no PSK/role)`);
+    return deleteCount;
+  }
+
+  // ========== SYNC METHODS (SQLite only) ==========
+  // Used by legacy sync callers of DatabaseService. Throws on PG/MySQL.
+
+  /**
+   * Synchronously get a channel by id (SQLite only).
+   */
+  getChannelByIdSync(id: number): DbChannel | null {
+    const db = this.getSqliteDb();
+    const { channels } = this.tables;
+    const rows = db
+      .select()
+      .from(channels)
+      .where(eq(channels.id, id))
+      .limit(1)
+      .all();
+    if (rows.length === 0) return null;
+    return this.normalizeBigInts(rows[0]) as DbChannel;
+  }
+
+  /**
+   * Synchronously get all channels (SQLite only).
+   */
+  getAllChannelsSync(): DbChannel[] {
+    const db = this.getSqliteDb();
+    const { channels } = this.tables;
+    const rows = db
+      .select()
+      .from(channels)
+      .orderBy(channels.id)
+      .all();
+    return (rows as any[]).map((row) => this.normalizeBigInts(row)) as DbChannel[];
+  }
+
+  /**
+   * Synchronously count channels (SQLite only).
+   */
+  getChannelCountSync(): number {
+    const db = this.getSqliteDb();
+    const { channels } = this.tables;
+    const rows = db.select({ count: count() }).from(channels).all();
+    return Number((rows[0] as any).count);
+  }
+
+  /**
+   * Synchronously upsert a channel (SQLite only).
+   * Matches the legacy DatabaseService.upsertChannel semantics:
+   * - Does NOT preserve non-empty names across updates (overwrites with incoming)
+   * - Uses COALESCE-like behavior for nullable fields
+   * - Role rules already validated at call site
+   */
+  upsertChannelSync(channelData: ChannelInput): void {
+    const db = this.getSqliteDb();
+    const { channels } = this.tables;
+    const now = this.now();
+
+    // Look up existing row by id
+    const existingRows = db
+      .select()
+      .from(channels)
+      .where(eq(channels.id, channelData.id))
+      .limit(1)
+      .all();
+    const existing = existingRows.length > 0 ? (existingRows[0] as any) : null;
+
+    if (existing) {
+      // Update existing — COALESCE(new, old) semantics for nullable fields
+      const updateSet: any = {
+        name: channelData.name,
+        psk: channelData.psk ?? existing.psk,
+        role: channelData.role ?? existing.role,
+        uplinkEnabled: channelData.uplinkEnabled ?? existing.uplinkEnabled,
+        downlinkEnabled: channelData.downlinkEnabled ?? existing.downlinkEnabled,
+        positionPrecision: channelData.positionPrecision ?? existing.positionPrecision,
+        updatedAt: now,
+      };
+      db.update(channels).set(updateSet).where(eq(channels.id, existing.id)).run();
+      logger.info(`Updated channel ${existing.id} (sync)`);
+    } else {
+      // Insert new row
+      const newRow: any = {
+        id: channelData.id,
+        name: channelData.name,
+        psk: channelData.psk ?? null,
+        role: channelData.role ?? null,
+        uplinkEnabled: channelData.uplinkEnabled ?? true,
+        downlinkEnabled: channelData.downlinkEnabled ?? true,
+        positionPrecision: channelData.positionPrecision ?? null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      db.insert(channels).values(newRow).run();
+      logger.debug(`Created channel: ${channelData.name} (ID: ${channelData.id}) (sync)`);
+    }
+  }
+
+  /**
+   * Synchronously delete invalid channels (id < 0 or id > 7). (SQLite only).
+   * Returns the number of rows deleted.
+   */
+  cleanupInvalidChannelsSync(): number {
+    const db = this.getSqliteDb();
+    const { channels } = this.tables;
+    const whereClause = or(lt(channels.id, 0), gt(channels.id, 7));
+    const countRows = db.select({ count: count() }).from(channels).where(whereClause).all();
+    const deleteCount = Number((countRows[0] as any).count);
+    if (deleteCount > 0) {
+      db.delete(channels).where(whereClause).run();
+    }
+    logger.debug(`Cleaned up ${deleteCount} invalid channels (sync)`);
+    return deleteCount;
+  }
+
+  /**
+   * Synchronously delete empty channels (id > 1, no PSK, no role). (SQLite only).
+   * Returns the number of rows deleted.
+   */
+  cleanupEmptyChannelsSync(): number {
+    const db = this.getSqliteDb();
+    const { channels } = this.tables;
+    const whereClause = and(
+      gt(channels.id, 1),
+      isNull(channels.psk),
+      isNull(channels.role)
+    );
+    const countRows = db.select({ count: count() }).from(channels).where(whereClause).all();
+    const deleteCount = Number((countRows[0] as any).count);
+    if (deleteCount > 0) {
+      db.delete(channels).where(whereClause).run();
+    }
+    logger.debug(`Cleaned up ${deleteCount} empty channels (sync)`);
     return deleteCount;
   }
 }

--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -1171,6 +1171,135 @@ export class MiscRepository extends BaseRepository {
   }
 
   /**
+   * Synchronously clear all packet log rows (SQLite only).
+   * Returns number of rows deleted.
+   */
+  clearPacketLogsSync(): number {
+    const db = this.getSqliteDb();
+    const result = db.run(sql`DELETE FROM packet_log`) as any;
+    const changes = Number(result?.changes ?? 0);
+    logger.debug(`[MiscRepository] Cleared ${changes} packet log entries (sync)`);
+    return changes;
+  }
+
+  /**
+   * Synchronously cleanup packet logs older than cutoffTimestamp (SQLite only).
+   * Returns number of rows deleted.
+   */
+  cleanupOldPacketLogsSync(cutoffTimestamp: number): number {
+    const db = this.getSqliteDb();
+    const result = db.run(sql`DELETE FROM packet_log WHERE timestamp < ${cutoffTimestamp}`) as any;
+    return Number(result?.changes ?? 0);
+  }
+
+  /**
+   * Synchronously get packet counts per from_node since a given timestamp,
+   * excluding internal traffic. (SQLite only.)
+   */
+  getPacketCountsPerNodeSinceSync(options: {
+    since: number;
+    localNodeNum: number | null;
+  }): Array<{ nodeNum: number; packetCount: number }> {
+    const db = this.getSqliteDb();
+    const { since, localNodeNum } = options;
+    const ln = localNodeNum ?? -1;
+    const rows = db.all(sql`
+      SELECT from_node as nodeNum, COUNT(*) as packetCount
+      FROM packet_log
+      WHERE timestamp >= ${since}
+        AND NOT (from_node = ${ln} AND to_node = ${ln})
+      GROUP BY from_node
+    `) as any[];
+    return rows.map((r: any) => ({
+      nodeNum: Number(r.nodeNum),
+      packetCount: Number(r.packetCount),
+    }));
+  }
+
+  /**
+   * Get packet counts per from_node since a given timestamp, excluding internal
+   * traffic (packets where both ends are the local node). Used for spam
+   * detection / last-hour broadcaster stats.
+   */
+  async getPacketCountsPerNodeSince(options: {
+    since: number;
+    localNodeNum: number | null;
+    sourceId?: string;
+  }): Promise<Array<{ nodeNum: number; packetCount: number }>> {
+    const { since, localNodeNum, sourceId } = options;
+    const ln = localNodeNum ?? -1;
+    try {
+      const conditions: any[] = [
+        sql`timestamp >= ${since}`,
+        sql`NOT (from_node = ${ln} AND to_node = ${ln})`,
+      ];
+      if (sourceId !== undefined) conditions.push(sql`${sql.identifier('sourceId')} = ${sourceId}`);
+      const whereClause = this.combineConditions(conditions);
+
+      const rows = await this.executeQuery(sql`
+        SELECT from_node as "nodeNum", COUNT(*) as "packetCount"
+        FROM packet_log
+        WHERE ${whereClause}
+        GROUP BY from_node
+      `);
+
+      return (rows as any[]).map((r: any) => ({
+        nodeNum: Number(r.nodeNum ?? r.nodenum),
+        packetCount: Number(r.packetCount ?? r.packetcount),
+      }));
+    } catch (error) {
+      logger.error('[MiscRepository] Failed to get packet counts per node since:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Get top N broadcasters by packet count since a given timestamp, excluding
+   * internal traffic (packets where both ends are the local node).
+   */
+  async getTopBroadcastersSince(options: {
+    since: number;
+    limit: number;
+    localNodeNum: number | null;
+    sourceId?: string;
+  }): Promise<Array<{ nodeNum: number; shortName: string | null; longName: string | null; packetCount: number }>> {
+    const { since, limit, localNodeNum, sourceId } = options;
+    const ln = localNodeNum ?? -1;
+    try {
+      const longName = this.col('longName');
+      const shortName = this.col('shortName');
+      const nodeNum = this.col('nodeNum');
+
+      const conditions: any[] = [
+        sql`p.timestamp >= ${since}`,
+        sql`NOT (p.from_node = ${ln} AND p.to_node = ${ln})`,
+      ];
+      if (sourceId !== undefined) conditions.push(sql`p.${sql.identifier('sourceId')} = ${sourceId}`);
+      const whereClause = this.combineConditions(conditions);
+
+      const rows = await this.executeQuery(sql`
+        SELECT p.from_node as "nodeNum", n.${shortName} as "shortName", n.${longName} as "longName", COUNT(*) as "packetCount"
+        FROM packet_log p
+        LEFT JOIN nodes n ON p.from_node = n.${nodeNum}
+        WHERE ${whereClause}
+        GROUP BY p.from_node, n.${shortName}, n.${longName}
+        ORDER BY "packetCount" DESC
+        LIMIT ${limit}
+      `);
+
+      return (rows as any[]).map((r: any) => ({
+        nodeNum: Number(r.nodeNum ?? r.nodenum),
+        shortName: r.shortName ?? r.shortname ?? null,
+        longName: r.longName ?? r.longname ?? null,
+        packetCount: Number(r.packetCount ?? r.packetcount),
+      }));
+    } catch (error) {
+      logger.error('[MiscRepository] Failed to get top broadcasters since:', error);
+      return [];
+    }
+  }
+
+  /**
    * Get packet counts grouped by from_node (for distribution charts).
    * Returns top N nodes by packet count.
    */

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -2595,15 +2595,10 @@ class DatabaseService {
     const localNodeNumStr = this.getSetting('localNodeNum');
     const localNodeNum = localNodeNumStr ? parseInt(localNodeNumStr, 10) : null;
 
-    const stmt = this.db.prepare(`
-      SELECT from_node as nodeNum, COUNT(*) as packetCount
-      FROM packet_log
-      WHERE timestamp >= ?
-        AND NOT (from_node = ? AND to_node = ?)
-      GROUP BY from_node
-    `);
-
-    return stmt.all(oneHourAgo, localNodeNum || -1, localNodeNum || -1) as Array<{ nodeNum: number; packetCount: number }>;
+    return this.miscRepo!.getPacketCountsPerNodeSinceSync({
+      since: oneHourAgo,
+      localNodeNum,
+    });
   }
 
   /**
@@ -2619,62 +2614,11 @@ class DatabaseService {
       : this.getSetting('localNodeNum');
     const localNodeNum = localNodeNumStr ? parseInt(localNodeNumStr, 10) : null;
 
-    if (this.drizzleDbType === 'postgres' && this.postgresPool) {
-      try {
-        const sourceFilter = sourceId ? ' AND "sourceId" = $3' : '';
-        const params: any[] = [oneHourAgo, localNodeNum || -1];
-        if (sourceId) params.push(sourceId);
-        const result = await this.postgresPool.query(`
-          SELECT from_node as "nodeNum", COUNT(*)::int as "packetCount"
-          FROM packet_log
-          WHERE timestamp >= $1
-            AND NOT (from_node = $2 AND to_node = $2)${sourceFilter}
-          GROUP BY from_node
-        `, params);
-
-        return result.rows;
-      } catch (error) {
-        logger.error('Error getting packet counts per node (PostgreSQL):', error);
-        return [];
-      }
-    }
-
-    if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
-      try {
-        const sourceFilter = sourceId ? ' AND sourceId = ?' : '';
-        const params: any[] = [oneHourAgo, localNodeNum || -1, localNodeNum || -1];
-        if (sourceId) params.push(sourceId);
-        const [rows] = await this.mysqlPool.query(`
-          SELECT from_node as nodeNum, COUNT(*) as packetCount
-          FROM packet_log
-          WHERE timestamp >= ?
-            AND NOT (from_node = ? AND to_node = ?)${sourceFilter}
-          GROUP BY from_node
-        `, params) as any;
-
-        return rows.map((row: any) => ({
-          nodeNum: Number(row.nodeNum),
-          packetCount: Number(row.packetCount)
-        }));
-      } catch (error) {
-        logger.error('Error getting packet counts per node (MySQL):', error);
-        return [];
-      }
-    }
-
-    // SQLite fallback
-    if (sourceId) {
-      const stmt = this.db.prepare(`
-        SELECT from_node as nodeNum, COUNT(*) as packetCount
-        FROM packet_log
-        WHERE timestamp >= ?
-          AND NOT (from_node = ? AND to_node = ?)
-          AND sourceId = ?
-        GROUP BY from_node
-      `);
-      return stmt.all(oneHourAgo, localNodeNum || -1, localNodeNum || -1, sourceId) as Array<{ nodeNum: number; packetCount: number }>;
-    }
-    return this.getPacketCountsPerNodeLastHour();
+    return this.miscRepo!.getPacketCountsPerNodeSince({
+      since: oneHourAgo,
+      localNodeNum,
+      sourceId,
+    });
   }
 
   /**
@@ -2689,88 +2633,12 @@ class DatabaseService {
     const localNodeNumStr = this.getSetting('localNodeNum');
     const localNodeNum = localNodeNumStr ? parseInt(localNodeNumStr, 10) : null;
 
-    if (this.drizzleDbType === 'postgres' && this.postgresPool) {
-      try {
-        const sourceClause = sourceId ? `AND p."sourceId" = $4` : '';
-        const params: any[] = [oneHourAgo, limit, localNodeNum || -1];
-        if (sourceId) params.push(sourceId);
-        const result = await this.postgresPool.query(`
-          SELECT p.from_node as "nodeNum", n."shortName", n."longName", COUNT(*)::int as "packetCount"
-          FROM packet_log p
-          LEFT JOIN nodes n ON p.from_node = n."nodeNum"
-          WHERE p.timestamp >= $1
-            AND NOT (p.from_node = $3 AND p.to_node = $3)
-            ${sourceClause}
-          GROUP BY p.from_node, n."shortName", n."longName"
-          ORDER BY "packetCount" DESC
-          LIMIT $2
-        `, params);
-
-        return result.rows;
-      } catch (error) {
-        logger.error('Error getting top broadcasters (PostgreSQL):', error);
-        return [];
-      }
-    }
-
-    if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
-      try {
-        const sourceClause = sourceId ? `AND p.sourceId = ?` : '';
-        const params: any[] = [oneHourAgo, localNodeNum || -1, localNodeNum || -1];
-        if (sourceId) params.push(sourceId);
-        params.push(limit);
-        const [rows] = await this.mysqlPool.query(`
-          SELECT p.from_node as nodeNum, n.shortName, n.longName, COUNT(*) as packetCount
-          FROM packet_log p
-          LEFT JOIN nodes n ON p.from_node = n.nodeNum
-          WHERE p.timestamp >= ?
-            AND NOT (p.from_node = ? AND p.to_node = ?)
-            ${sourceClause}
-          GROUP BY p.from_node, n.shortName, n.longName
-          ORDER BY packetCount DESC
-          LIMIT ?
-        `, params) as any;
-
-        return rows.map((row: any) => ({
-          nodeNum: Number(row.nodeNum),
-          shortName: row.shortName,
-          longName: row.longName,
-          packetCount: Number(row.packetCount)
-        }));
-      } catch (error) {
-        logger.error('Error getting top broadcasters (MySQL):', error);
-        return [];
-      }
-    }
-
-    // SQLite - exclude packets where both from_node and to_node are the local node
-    if (sourceId) {
-      const stmt = this.db.prepare(`
-        SELECT p.from_node as nodeNum, n.shortName, n.longName, COUNT(*) as packetCount
-        FROM packet_log p
-        LEFT JOIN nodes n ON p.from_node = n.nodeNum
-        WHERE p.timestamp >= ?
-          AND NOT (p.from_node = ? AND p.to_node = ?)
-          AND p.sourceId = ?
-        GROUP BY p.from_node
-        ORDER BY packetCount DESC
-        LIMIT ?
-      `);
-      return stmt.all(oneHourAgo, localNodeNum || -1, localNodeNum || -1, sourceId, limit) as Array<{ nodeNum: number; shortName: string | null; longName: string | null; packetCount: number }>;
-    }
-
-    const stmt = this.db.prepare(`
-      SELECT p.from_node as nodeNum, n.shortName, n.longName, COUNT(*) as packetCount
-      FROM packet_log p
-      LEFT JOIN nodes n ON p.from_node = n.nodeNum
-      WHERE p.timestamp >= ?
-        AND NOT (p.from_node = ? AND p.to_node = ?)
-      GROUP BY p.from_node
-      ORDER BY packetCount DESC
-      LIMIT ?
-    `);
-
-    return stmt.all(oneHourAgo, localNodeNum || -1, localNodeNum || -1, limit) as Array<{ nodeNum: number; shortName: string | null; longName: string | null; packetCount: number }>;
+    return this.miscRepo!.getTopBroadcastersSince({
+      since: oneHourAgo,
+      limit,
+      localNodeNum,
+      sourceId,
+    });
   }
 
   /**
@@ -9220,47 +9088,14 @@ class DatabaseService {
     const enabled = await this.getSettingAsync('packet_log_enabled');
     if (enabled !== '1') return 0;
 
-    // For non-SQLite, use async repository
-    if (this.drizzleDbType !== 'sqlite') {
-      const id = await this.misc.insertPacketLog(packet, packet.sourceId ?? undefined);
-      const maxCountStr = await this.getSettingAsync('packet_log_max_count');
-      const maxCount = maxCountStr ? parseInt(maxCountStr, 10) : 1000;
-      await this.misc.enforcePacketLogMaxCount(maxCount);
-      return id;
-    }
-
-    // SQLite: use synchronous raw SQL for immediate consistency
-    const stmt = this.db.prepare(`
-      INSERT INTO packet_log (
-        packet_id, timestamp, from_node, from_node_id, to_node, to_node_id,
-        channel, portnum, portnum_name, encrypted, snr, rssi, hop_limit, hop_start,
-        relay_node, payload_size, want_ack, priority, payload_preview, metadata, direction,
-        transport_mechanism, decrypted_by, decrypted_channel_id, sourceId
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-    const result = stmt.run(
-      packet.packet_id ?? null, packet.timestamp, packet.from_node,
-      packet.from_node_id ?? null, packet.to_node ?? null, packet.to_node_id ?? null,
-      packet.channel ?? null, packet.portnum, packet.portnum_name ?? null,
-      packet.encrypted ? 1 : 0, packet.snr ?? null, packet.rssi ?? null,
-      packet.hop_limit ?? null, packet.hop_start ?? null, packet.relay_node ?? null,
-      packet.payload_size ?? null, packet.want_ack ? 1 : 0, packet.priority ?? null,
-      packet.payload_preview ?? null, packet.metadata ?? null, packet.direction ?? 'rx',
-      packet.transport_mechanism ?? null, packet.decrypted_by ?? null, packet.decrypted_channel_id ?? null,
-      packet.sourceId ?? null
-    );
-
-    // Enforce max count
-    const maxCountStr = this.getSetting('packet_log_max_count');
+    // All backends route through MiscRepository
+    const id = await this.misc.insertPacketLog(packet, packet.sourceId ?? undefined);
+    const maxCountStr = this.drizzleDbType === 'sqlite'
+      ? this.getSetting('packet_log_max_count')
+      : await this.getSettingAsync('packet_log_max_count');
     const maxCount = maxCountStr ? parseInt(maxCountStr, 10) : 1000;
-    const countStmt = this.db.prepare('SELECT COUNT(*) as count FROM packet_log');
-    const countResult = countStmt.get() as { count: number };
-    if (Number(countResult.count) > maxCount) {
-      const deleteCount = Number(countResult.count) - maxCount;
-      this.db.prepare(`DELETE FROM packet_log WHERE id IN (SELECT id FROM packet_log ORDER BY timestamp ASC LIMIT ?)`).run(deleteCount);
-    }
-
-    return Number(result.lastInsertRowid);
+    await this.misc.enforcePacketLogMaxCount(maxCount);
+    return id;
   }
 
   async getPacketLogsAsync(options: {
@@ -9268,74 +9103,22 @@ class DatabaseService {
     to_node?: number; channel?: number; encrypted?: boolean; since?: number;
     relay_node?: number | 'unknown'; sourceId?: string;
   }): Promise<DbPacketLog[]> {
-    if (this.drizzleDbType !== 'sqlite') return this.misc.getPacketLogs(options);
-    // SQLite fallback using raw SQL on main connection
-    const { offset = 0, limit = 100, portnum, from_node, to_node, channel, encrypted, since, relay_node, sourceId } = options;
-    let query = `
-      SELECT pl.*, from_nodes.longName as from_node_longName, to_nodes.longName as to_node_longName
-      FROM packet_log pl
-      LEFT JOIN nodes from_nodes ON pl.from_node = from_nodes.nodeNum
-      LEFT JOIN nodes to_nodes ON pl.to_node = to_nodes.nodeNum
-      WHERE 1=1
-    `;
-    const params: any[] = [];
-    if (sourceId !== undefined) { query += ' AND pl.sourceId = ?'; params.push(sourceId); }
-    if (portnum !== undefined) { query += ' AND pl.portnum = ?'; params.push(portnum); }
-    if (from_node !== undefined) { query += ' AND pl.from_node = ?'; params.push(from_node); }
-    if (to_node !== undefined) { query += ' AND pl.to_node = ?'; params.push(to_node); }
-    if (channel !== undefined) { query += ' AND pl.channel = ?'; params.push(channel); }
-    if (encrypted !== undefined) { query += ' AND pl.encrypted = ?'; params.push(encrypted ? 1 : 0); }
-    if (since !== undefined) { query += ' AND pl.timestamp >= ?'; params.push(since); }
-    if (relay_node === 'unknown') { query += ' AND pl.relay_node IS NULL'; }
-    else if (relay_node !== undefined) { query += ' AND pl.relay_node = ?'; params.push(relay_node); }
-    query += ' ORDER BY pl.timestamp DESC LIMIT ? OFFSET ?';
-    params.push(limit, offset);
-    const stmt = this.db.prepare(query);
-    return stmt.all(...params) as DbPacketLog[];
+    return this.misc.getPacketLogs(options);
   }
 
   async getPacketLogByIdAsync(id: number): Promise<DbPacketLog | null> {
-    if (this.drizzleDbType !== 'sqlite') return this.misc.getPacketLogById(id);
-    // SQLite fallback
-    const stmt = this.db.prepare(`
-      SELECT pl.*, from_nodes.longName as from_node_longName, to_nodes.longName as to_node_longName
-      FROM packet_log pl
-      LEFT JOIN nodes from_nodes ON pl.from_node = from_nodes.nodeNum
-      LEFT JOIN nodes to_nodes ON pl.to_node = to_nodes.nodeNum
-      WHERE pl.id = ?
-    `);
-    const result = stmt.get(id) as DbPacketLog | undefined;
-    return result || null;
+    return this.misc.getPacketLogById(id);
   }
 
   async getPacketLogCountAsync(options: {
     portnum?: number; from_node?: number; to_node?: number; channel?: number;
     encrypted?: boolean; since?: number; relay_node?: number | 'unknown'; sourceId?: string;
   } = {}): Promise<number> {
-    if (this.drizzleDbType !== 'sqlite') return this.misc.getPacketLogCount(options);
-    // SQLite fallback
-    const { portnum, from_node, to_node, channel, encrypted, since, relay_node, sourceId } = options;
-    let query = 'SELECT COUNT(*) as count FROM packet_log WHERE 1=1';
-    const params: any[] = [];
-    if (sourceId !== undefined) { query += ' AND sourceId = ?'; params.push(sourceId); }
-    if (portnum !== undefined) { query += ' AND portnum = ?'; params.push(portnum); }
-    if (from_node !== undefined) { query += ' AND from_node = ?'; params.push(from_node); }
-    if (to_node !== undefined) { query += ' AND to_node = ?'; params.push(to_node); }
-    if (channel !== undefined) { query += ' AND channel = ?'; params.push(channel); }
-    if (encrypted !== undefined) { query += ' AND encrypted = ?'; params.push(encrypted ? 1 : 0); }
-    if (since !== undefined) { query += ' AND timestamp >= ?'; params.push(since); }
-    if (relay_node === 'unknown') { query += ' AND relay_node IS NULL'; }
-    else if (relay_node !== undefined) { query += ' AND relay_node = ?'; params.push(relay_node); }
-    const stmt = this.db.prepare(query);
-    const result = stmt.get(...params) as { count: number };
-    return Number(result.count);
+    return this.misc.getPacketLogCount(options);
   }
 
   clearPacketLogs(): number {
-    const stmt = this.db.prepare('DELETE FROM packet_log');
-    const result = stmt.run();
-    logger.debug(`Cleared ${result.changes} packet log entries`);
-    return Number(result.changes);
+    return this.miscRepo!.clearPacketLogsSync();
   }
 
   async clearPacketLogsAsync(): Promise<number> {
@@ -9354,24 +9137,14 @@ class DatabaseService {
     portnum: number,
     metadata: string
   ): Promise<void> {
-    if (this.miscRepo) {
-      return this.miscRepo.updatePacketLogDecryption(id, decryptedBy, decryptedChannelId, portnum, metadata);
-    }
-    // SQLite fallback
-    const stmt = this.db.prepare(`
-      UPDATE packet_log SET decrypted_by = ?, decrypted_channel_id = ?,
-      portnum = ?, encrypted = 0, metadata = ? WHERE id = ?
-    `);
-    stmt.run(decryptedBy, decryptedChannelId, portnum, metadata, id);
+    return this.miscRepo!.updatePacketLogDecryption(id, decryptedBy, decryptedChannelId, portnum, metadata);
   }
 
   cleanupOldPacketLogs(): number {
     const maxAgeHoursStr = this.getSetting('packet_log_max_age_hours');
     const maxAgeHours = maxAgeHoursStr ? parseInt(maxAgeHoursStr, 10) : 24;
     const cutoffTimestamp = Date.now() - (maxAgeHours * 60 * 60 * 1000);
-    const stmt = this.db.prepare('DELETE FROM packet_log WHERE timestamp < ?');
-    const result = stmt.run(cutoffTimestamp);
-    return Number(result.changes);
+    return this.miscRepo!.cleanupOldPacketLogsSync(cutoffTimestamp);
   }
 
   async cleanupOldPacketLogsAsync(): Promise<number> {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -4083,60 +4083,20 @@ class DatabaseService {
       return;
     }
 
-    // SQLite path
-    let existingChannel: DbChannel | null = null;
-
-    // If we have an ID, check by ID FIRST
-    if (channelData.id !== undefined) {
-      existingChannel = this.getChannelById(channelData.id);
-      logger.info(`📝 getChannelById(${channelData.id}) returned: ${existingChannel ? `"${existingChannel.name}"` : 'null'}`);
+    // SQLite path — route through ChannelsRepository
+    if (channelData.id === undefined) {
+      logger.error(`❌ Cannot upsert channel without ID. Name: "${channelData.name}"`);
+      throw new Error('Channel ID is required for upsert operation');
     }
-
-    if (existingChannel) {
-      // Update existing channel (by name match or ID match)
-      logger.info(`📝 Updating channel ${existingChannel.id} from "${existingChannel.name}" to "${channelData.name}"`);
-      const stmt = this.db.prepare(`
-        UPDATE channels SET
-          name = ?,
-          psk = COALESCE(?, psk),
-          role = COALESCE(?, role),
-          uplinkEnabled = COALESCE(?, uplinkEnabled),
-          downlinkEnabled = COALESCE(?, downlinkEnabled),
-          positionPrecision = COALESCE(?, positionPrecision),
-          updatedAt = ?
-        WHERE id = ?
-      `);
-      const result = stmt.run(
-        channelData.name,
-        channelData.psk,
-        channelData.role !== undefined ? channelData.role : null,
-        channelData.uplinkEnabled !== undefined ? (channelData.uplinkEnabled ? 1 : 0) : null,
-        channelData.downlinkEnabled !== undefined ? (channelData.downlinkEnabled ? 1 : 0) : null,
-        channelData.positionPrecision !== undefined ? channelData.positionPrecision : null,
-        now,
-        existingChannel.id
-      );
-      logger.info(`✅ Updated channel ${existingChannel.id}, changes: ${result.changes}`);
-    } else {
-      // Create new channel
-      logger.debug(`📝 Creating new channel with ID: ${channelData.id !== undefined ? channelData.id : null}`);
-      const stmt = this.db.prepare(`
-        INSERT INTO channels (id, name, psk, role, uplinkEnabled, downlinkEnabled, positionPrecision, createdAt, updatedAt)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `);
-      const result = stmt.run(
-        channelData.id !== undefined ? channelData.id : null,
-        channelData.name,
-        channelData.psk || null,
-        channelData.role !== undefined ? channelData.role : null,
-        channelData.uplinkEnabled !== undefined ? (channelData.uplinkEnabled ? 1 : 0) : 1,
-        channelData.downlinkEnabled !== undefined ? (channelData.downlinkEnabled ? 1 : 0) : 1,
-        channelData.positionPrecision !== undefined ? channelData.positionPrecision : null,
-        now,
-        now
-      );
-      logger.debug(`Created channel: ${channelData.name} (ID: ${channelData.id !== undefined ? channelData.id : 'auto'}), lastInsertRowid: ${result.lastInsertRowid}`);
-    }
+    this.channelsRepo!.upsertChannelSync({
+      id: channelData.id,
+      name: channelData.name,
+      psk: channelData.psk,
+      role: channelData.role,
+      uplinkEnabled: channelData.uplinkEnabled,
+      downlinkEnabled: channelData.downlinkEnabled,
+      positionPrecision: channelData.positionPrecision,
+    });
   }
 
   getChannelById(id: number): DbChannel | null {
@@ -4152,12 +4112,11 @@ class DatabaseService {
       }
       return channel;
     }
-    const stmt = this.db.prepare('SELECT * FROM channels WHERE id = ?');
-    const channel = stmt.get(id) as DbChannel | null;
+    const channel = this.channelsRepo!.getChannelByIdSync(id);
     if (id === 0) {
       logger.info(`🔍 getChannelById(0) - RAW from DB: ${channel ? `name="${channel.name}" (length: ${channel.name?.length || 0})` : 'null'}`);
     }
-    return channel ? this.normalizeBigInts(channel) : null;
+    return channel;
   }
 
   getAllChannels(): DbChannel[] {
@@ -4169,9 +4128,7 @@ class DatabaseService {
       }
       return Array.from(this.channelsCache.values()).sort((a, b) => a.id - b.id);
     }
-    const stmt = this.db.prepare('SELECT * FROM channels ORDER BY id ASC');
-    const channels = stmt.all() as DbChannel[];
-    return channels.map(channel => this.normalizeBigInts(channel));
+    return this.channelsRepo!.getAllChannelsSync();
   }
 
   getChannelCount(): number {
@@ -4183,9 +4140,7 @@ class DatabaseService {
       }
       return this.channelsCache.size;
     }
-    const stmt = this.db.prepare('SELECT COUNT(*) as count FROM channels');
-    const result = stmt.get() as { count: number };
-    return Number(result.count);
+    return this.channelsRepo!.getChannelCountSync();
   }
 
   // Clean up invalid channels that shouldn't have been created
@@ -4209,10 +4164,9 @@ class DatabaseService {
       logger.debug(`🧹 Cleaned up ${count} invalid channels (outside 0-7 range)`);
       return count;
     }
-    const stmt = this.db.prepare(`DELETE FROM channels WHERE id < 0 OR id > 7`);
-    const result = stmt.run();
-    logger.debug(`🧹 Cleaned up ${result.changes} invalid channels (outside 0-7 range)`);
-    return Number(result.changes);
+    const deleted = this.channelsRepo!.cleanupInvalidChannelsSync();
+    logger.debug(`🧹 Cleaned up ${deleted} invalid channels (outside 0-7 range)`);
+    return deleted;
   }
 
   // Clean up channels that appear to be empty/unused
@@ -4237,15 +4191,9 @@ class DatabaseService {
       logger.debug(`🧹 Cleaned up ${count} empty channels (ID > 1, no PSK/role)`);
       return count;
     }
-    const stmt = this.db.prepare(`
-      DELETE FROM channels
-      WHERE id > 1
-      AND psk IS NULL
-      AND role IS NULL
-    `);
-    const result = stmt.run();
-    logger.debug(`🧹 Cleaned up ${result.changes} empty channels (ID > 1, no PSK/role)`);
-    return Number(result.changes);
+    const deleted = this.channelsRepo!.cleanupEmptyChannelsSync();
+    logger.debug(`🧹 Cleaned up ${deleted} empty channels (ID > 1, no PSK/role)`);
+    return deleted;
   }
 
   // Telemetry operations
@@ -10163,22 +10111,7 @@ class DatabaseService {
   async cleanupInvalidChannelsAsync(sourceId?: string): Promise<number> {
     if (sourceId) {
       // Channels with no name and no PSK scoped to a source
-      if (this.drizzleDbType === 'postgres' && this.postgresPool) {
-        const result = await this.postgresPool.query(
-          `DELETE FROM channels WHERE ("name" IS NULL OR "name" = '') AND ("psk" IS NULL OR "psk" = '') AND "sourceId" = $1`,
-          [sourceId]
-        );
-        return result.rowCount ?? 0;
-      }
-      if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
-        const [result] = await this.mysqlPool.query(
-          `DELETE FROM channels WHERE (name IS NULL OR name = '') AND (psk IS NULL OR psk = '') AND sourceId = ?`,
-          [sourceId]
-        ) as any;
-        return result.affectedRows ?? 0;
-      }
-      const stmt = this.db.prepare(`DELETE FROM channels WHERE (name IS NULL OR name = '') AND (psk IS NULL OR psk = '') AND sourceId = ?`);
-      return Number(stmt.run(sourceId).changes);
+      return this.channelsRepo!.cleanupEmptyChannelsForSource(sourceId);
     }
     return this.cleanupInvalidChannels();
   }


### PR DESCRIPTION
## Summary
Batches **Task 2.4 (channels)** and **Task 2.6 (packetlog)** from the Drizzle ORM remediation plan into one PR. All raw SQL targeting `channels` and `packet_log` tables now routes through the respective Drizzle repositories across SQLite/Postgres/MySQL.

- **Channels**: 10 → 0 raw-SQL sites in `database.ts`. Added sync variants (`getChannelByIdSync`, `getAllChannelsSync`, `upsertChannelSync`, etc.) following the Phase 2.3 sync-on-better-sqlite3 pattern. Added async `cleanupEmptyChannelsForSource(sourceId)` to collapse a 3-way backend fork.
- **Packetlog**: 17 → 0 raw-SQL sites in `database.ts`. Most repo methods already existed; added `getPacketCountsPerNodeSince(Async/Sync)`, `getTopBroadcastersSince`, `clearPacketLogsSync`, `cleanupOldPacketLogsSync`. Collapsed `insertPacketLogAsync` to always route through the dialect-agnostic repo.

`channelDatabase.ts` (separate user-facing store) untouched — out of scope.

## Test plan
- [x] `npx tsc --noEmit` → exit 0
- [x] `node_modules/.bin/vitest run src/db/repositories/channels.test.ts src/db/repositories/misc.packetlog.test.ts` → 25 pass, 32 skipped
- [x] `npm test` → 4209 pass / 0 fail / 499 skipped
- [x] `rg -cn "FROM channels|INTO channels|UPDATE channels|DELETE FROM channels|FROM packet_log|INTO packet_log|UPDATE packet_log|DELETE FROM packet_log" src/services/database.ts` → **0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)