### PR TITLE
refactor(db): extract telemetry + traceroutes domains (Phase 2 Batch B)

### DIFF
--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -4,7 +4,7 @@
  * Handles solar estimates and auto-traceroute nodes database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, desc, asc, and, gte, lte, lt, inArray, sql, isNull } from 'drizzle-orm';
+import { eq, desc, asc, and, gte, lte, lt, inArray, notInArray, sql, isNull } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbCustomTheme, DbPacketLog, DbPacketCountByNode, DbPacketCountByPortnum, DbDistinctRelayNode } from '../types.js';
 import { logger } from '../../utils/logger.js';
@@ -1213,6 +1213,273 @@ export class MiscRepository extends BaseRepository {
     return rows.map((r: any) => ({
       nodeNum: Number(r.nodeNum),
       packetCount: Number(r.packetCount),
+    }));
+  }
+
+  // ============ auto_traceroute_log async methods (all backends) ============
+
+  /**
+   * Get the most recent auto-traceroute log rows (all backends).
+   * Boolean success is returned (null preserved).
+   */
+  async getAutoTracerouteLog(limit: number = 10, sourceId?: string): Promise<Array<{
+    id: number;
+    timestamp: number;
+    toNodeNum: number;
+    toNodeName: string | null;
+    success: boolean | null;
+  }>> {
+    try {
+      const { autoTracerouteLog } = this.tables;
+      const query = this.db
+        .select({
+          id: autoTracerouteLog.id,
+          timestamp: autoTracerouteLog.timestamp,
+          toNodeNum: autoTracerouteLog.toNodeNum,
+          toNodeName: autoTracerouteLog.toNodeName,
+          success: autoTracerouteLog.success,
+        })
+        .from(autoTracerouteLog);
+      const scoped = sourceId !== undefined
+        ? query.where(eq(autoTracerouteLog.sourceId, sourceId))
+        : query;
+      const rows = await scoped
+        .orderBy(desc(autoTracerouteLog.timestamp))
+        .limit(limit);
+      return (rows as any[]).map((r: any) => ({
+        id: Number(r.id),
+        timestamp: Number(r.timestamp),
+        toNodeNum: Number(r.toNodeNum),
+        toNodeName: r.toNodeName ?? null,
+        success: r.success === null || r.success === undefined ? null : Boolean(r.success),
+      }));
+    } catch (error) {
+      logger.error(`[MiscRepository] Failed to get auto traceroute log: ${error}`);
+      return [];
+    }
+  }
+
+  /**
+   * Insert an auto-traceroute attempt row and prune to the last 100 entries.
+   * Returns the inserted row id. Works for SQLite/Postgres/MySQL.
+   */
+  async logAutoTracerouteAttempt(toNodeNum: number, toNodeName: string | null, sourceId?: string): Promise<number> {
+    try {
+      const { autoTracerouteLog } = this.tables;
+      const now = Date.now();
+      const values: any = {
+        timestamp: now,
+        toNodeNum,
+        toNodeName,
+        success: null,
+        createdAt: now,
+        sourceId: sourceId ?? null,
+      };
+
+      let insertedId = 0;
+      if (this.isPostgres()) {
+        const result = await (this.db.insert(autoTracerouteLog).values(values) as any).returning({ id: autoTracerouteLog.id });
+        insertedId = Number((result as any[])[0]?.id ?? 0);
+      } else if (this.isMySQL()) {
+        const result = await this.db.insert(autoTracerouteLog).values(values);
+        insertedId = Number((result as any)?.[0]?.insertId ?? 0);
+      } else {
+        const result = await this.db.insert(autoTracerouteLog).values(values);
+        insertedId = Number((result as any)?.lastInsertRowid ?? 0);
+      }
+
+      // Prune older rows beyond the 100 most recent.
+      const keepRows = await this.db
+        .select({ id: autoTracerouteLog.id })
+        .from(autoTracerouteLog)
+        .orderBy(desc(autoTracerouteLog.timestamp))
+        .limit(100);
+      const keepIds = (keepRows as any[]).map((r) => Number(r.id));
+      if (keepIds.length > 0) {
+        await this.db
+          .delete(autoTracerouteLog)
+          .where(notInArray(autoTracerouteLog.id, keepIds));
+      }
+
+      return insertedId;
+    } catch (error) {
+      logger.error(`[MiscRepository] Failed to log auto traceroute attempt: ${error}`);
+      return 0;
+    }
+  }
+
+  /**
+   * Update the most recent pending auto-traceroute log row for a given
+   * destination node across all backends.
+   */
+  async updateAutoTracerouteResultByNode(toNodeNum: number, success: boolean): Promise<void> {
+    try {
+      const { autoTracerouteLog } = this.tables;
+      const rows = await this.db
+        .select({ id: autoTracerouteLog.id })
+        .from(autoTracerouteLog)
+        .where(and(eq(autoTracerouteLog.toNodeNum, toNodeNum), isNull(autoTracerouteLog.success))!)
+        .orderBy(desc(autoTracerouteLog.timestamp))
+        .limit(1);
+      if ((rows as any[]).length > 0) {
+        const id = Number(((rows as any[])[0]).id);
+        await this.db
+          .update(autoTracerouteLog)
+          .set({ success: success ? 1 : 0 } as any)
+          .where(eq(autoTracerouteLog.id, id));
+      }
+    } catch (error) {
+      logger.error(`[MiscRepository] Failed to update auto traceroute result: ${error}`);
+    }
+  }
+
+  // ============ auto_traceroute_nodes sync methods (SQLite only) ============
+
+  /**
+   * Synchronously get the list of auto-traceroute node nums ordered by
+   * creation time ascending (SQLite only).
+   */
+  getAutoTracerouteNodesSync(): number[] {
+    const db = this.getSqliteDb();
+    const { autoTracerouteNodes } = this.tables;
+    const rows = db
+      .select({ nodeNum: autoTracerouteNodes.nodeNum })
+      .from(autoTracerouteNodes)
+      .orderBy(asc(autoTracerouteNodes.createdAt))
+      .all();
+    return (rows as any[]).map((r) => Number(r.nodeNum));
+  }
+
+  /**
+   * Synchronously replace the auto-traceroute nodes set in a single
+   * transaction (SQLite only). Bad nodeNums are skipped.
+   */
+  setAutoTracerouteNodesSync(nodeNums: number[]): void {
+    const db = this.getSqliteDb();
+    const { autoTracerouteNodes } = this.tables;
+    const now = Date.now();
+    db.transaction((tx) => {
+      tx.delete(autoTracerouteNodes).run();
+      for (const nodeNum of nodeNums) {
+        try {
+          tx.insert(autoTracerouteNodes)
+            .values({ nodeNum, createdAt: now } as any)
+            .run();
+        } catch (error) {
+          logger.debug(`Skipping invalid nodeNum: ${nodeNum}`, error);
+        }
+      }
+    });
+  }
+
+  // ============ auto_traceroute_log sync methods (SQLite only) ============
+
+  /**
+   * Synchronously insert an auto-traceroute attempt row and prune to the last
+   * 100 entries (SQLite only). Returns the inserted row id.
+   */
+  logAutoTracerouteAttemptSync(toNodeNum: number, toNodeName: string | null, sourceId?: string): number {
+    const db = this.getSqliteDb();
+    const { autoTracerouteLog } = this.tables;
+    const now = Date.now();
+    const result = db
+      .insert(autoTracerouteLog)
+      .values({
+        timestamp: now,
+        toNodeNum,
+        toNodeName,
+        success: null,
+        createdAt: now,
+        sourceId: sourceId ?? null,
+      } as any)
+      .run() as any;
+
+    // Prune older rows beyond the 100 most recent.
+    const keepRows = db
+      .select({ id: autoTracerouteLog.id })
+      .from(autoTracerouteLog)
+      .orderBy(desc(autoTracerouteLog.timestamp))
+      .limit(100)
+      .all();
+    const keepIds = (keepRows as any[]).map((r) => Number(r.id));
+    if (keepIds.length > 0) {
+      db.delete(autoTracerouteLog)
+        .where(sql`id NOT IN (${sql.join(keepIds.map((id) => sql`${id}`), sql`, `)})`)
+        .run();
+    }
+
+    return Number(result?.lastInsertRowid ?? 0);
+  }
+
+  /**
+   * Synchronously mark an auto-traceroute log row's success flag (SQLite only).
+   */
+  updateAutoTracerouteResultSync(logId: number, success: boolean): void {
+    const db = this.getSqliteDb();
+    const { autoTracerouteLog } = this.tables;
+    db.update(autoTracerouteLog)
+      .set({ success: success ? 1 : 0 } as any)
+      .where(eq(autoTracerouteLog.id, logId))
+      .run();
+  }
+
+  /**
+   * Synchronously update the most recent pending auto-traceroute log row for
+   * a given destination node (SQLite only).
+   */
+  updateAutoTracerouteResultByNodeSync(toNodeNum: number, success: boolean): void {
+    const db = this.getSqliteDb();
+    const { autoTracerouteLog } = this.tables;
+    const rows = db
+      .select({ id: autoTracerouteLog.id })
+      .from(autoTracerouteLog)
+      .where(and(eq(autoTracerouteLog.toNodeNum, toNodeNum), isNull(autoTracerouteLog.success))!)
+      .orderBy(desc(autoTracerouteLog.timestamp))
+      .limit(1)
+      .all();
+    if (rows.length > 0) {
+      const id = Number((rows[0] as any).id);
+      db.update(autoTracerouteLog)
+        .set({ success: success ? 1 : 0 } as any)
+        .where(eq(autoTracerouteLog.id, id))
+        .run();
+    }
+  }
+
+  /**
+   * Synchronously fetch the most recent auto-traceroute log rows (SQLite only).
+   * Boolean success is returned (null preserved).
+   */
+  getAutoTracerouteLogSync(limit: number = 10, sourceId?: string): Array<{
+    id: number;
+    timestamp: number;
+    toNodeNum: number;
+    toNodeName: string | null;
+    success: boolean | null;
+  }> {
+    const db = this.getSqliteDb();
+    const { autoTracerouteLog } = this.tables;
+    const query = db
+      .select({
+        id: autoTracerouteLog.id,
+        timestamp: autoTracerouteLog.timestamp,
+        toNodeNum: autoTracerouteLog.toNodeNum,
+        toNodeName: autoTracerouteLog.toNodeName,
+        success: autoTracerouteLog.success,
+      })
+      .from(autoTracerouteLog);
+    const rows = (sourceId !== undefined
+      ? query.where(eq(autoTracerouteLog.sourceId, sourceId))
+      : query)
+      .orderBy(desc(autoTracerouteLog.timestamp))
+      .limit(limit)
+      .all();
+    return (rows as any[]).map((r: any) => ({
+      id: Number(r.id),
+      timestamp: Number(r.timestamp),
+      toNodeNum: Number(r.toNodeNum),
+      toNodeName: r.toNodeName ?? null,
+      success: r.success === null || r.success === undefined ? null : r.success === 1,
     }));
   }
 

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -9,6 +9,30 @@ import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbTelemetry } from '../types.js';
 
 /**
+ * Favorite telemetry entry: (nodeId, telemetryType) pair that should be
+ * retained longer than regular telemetry during purge operations.
+ */
+export interface TelemetryFavorite {
+  nodeId: string;
+  telemetryType: string;
+}
+
+/**
+ * Normalize a telemetry row from a sync SQLite Drizzle query to the legacy
+ * DbTelemetry shape expected by facade callers: converts `null` fields back
+ * to `undefined` and returns the same object reference when possible.
+ */
+function normalizeSyncTelemetryRow(row: any): any {
+  if (row == null) return row;
+  // Convert known nullable columns from null to undefined to match DbTelemetry
+  const nullable = ['unit', 'packetTimestamp', 'packetId', 'channel', 'precisionBits', 'gpsAccuracy', 'sourceId'] as const;
+  for (const k of nullable) {
+    if (row[k] === null) row[k] = undefined;
+  }
+  return row;
+}
+
+/**
  * Repository for telemetry operations
  */
 export class TelemetryRepository extends BaseRepository {
@@ -397,7 +421,7 @@ export class TelemetryRepository extends BaseRepository {
    * Build a SQL condition that matches any of the favorited (nodeId, telemetryType) pairs.
    * Returns null if favorites array is empty.
    */
-  private buildFavoritesCondition(
+  protected buildFavoritesCondition(
     favorites: Array<{ nodeId: string; telemetryType: string }>
   ): SQL | null {
     if (favorites.length === 0) return null;
@@ -834,5 +858,380 @@ export class TelemetryRepository extends BaseRepository {
     });
 
     return [...averagedRows.map(toDbTelemetry), ...rawRows.map(toDbTelemetry)];
+  }
+
+  /**
+   * Get latest telemetry record with non-null packetTimestamp per node.
+   * Used by time-offset diagnostics. SQLite/MySQL use INNER JOIN on MAX,
+   * PostgreSQL uses DISTINCT ON for efficiency.
+   */
+  async getLatestPacketTimestampsPerNode(
+    minValidTimestampMs: number,
+    sourceId?: string
+  ): Promise<Array<{ nodeNum: number; timestamp: number; packetTimestamp: number }>> {
+    if (this.isPostgres()) {
+      const db = this.getPostgresDb();
+      const sourceFilter = sourceId
+        ? sql` AND "sourceId" = ${sourceId}`
+        : sql``;
+      const result = await db.execute(sql`
+        SELECT DISTINCT ON ("nodeNum") "nodeNum", "timestamp", "packetTimestamp"
+        FROM telemetry
+        WHERE "packetTimestamp" IS NOT NULL AND "packetTimestamp" > ${minValidTimestampMs}${sourceFilter}
+        ORDER BY "nodeNum", "timestamp" DESC
+      `);
+      return result.rows.map((r: any) => ({
+        nodeNum: Number(r.nodeNum),
+        timestamp: Number(r.timestamp),
+        packetTimestamp: Number(r.packetTimestamp),
+      }));
+    }
+
+    if (this.isMySQL()) {
+      const db = this.getMysqlDb();
+      const sourceFilterOuter = sourceId ? sql` AND t.sourceId = ${sourceId}` : sql``;
+      const sourceFilterInner = sourceId ? sql` AND sourceId = ${sourceId}` : sql``;
+      const [rows] = await (db as any).execute(sql`
+        SELECT t.nodeNum, t.timestamp, t.packetTimestamp
+        FROM telemetry t
+        INNER JOIN (
+          SELECT nodeNum, MAX(timestamp) as maxTs
+          FROM telemetry
+          WHERE packetTimestamp IS NOT NULL AND packetTimestamp > ${minValidTimestampMs}${sourceFilterInner}
+          GROUP BY nodeNum
+        ) latest ON t.nodeNum = latest.nodeNum AND t.timestamp = latest.maxTs
+        WHERE t.packetTimestamp IS NOT NULL AND t.packetTimestamp > ${minValidTimestampMs}${sourceFilterOuter}
+      `);
+      return (rows as any[]).map((r: any) => ({
+        nodeNum: Number(r.nodeNum),
+        timestamp: Number(r.timestamp),
+        packetTimestamp: Number(r.packetTimestamp),
+      }));
+    }
+
+    // SQLite
+    const db = this.getSqliteDb();
+    const sourceFilterOuter = sourceId ? sql` AND t.sourceId = ${sourceId}` : sql``;
+    const sourceFilterInner = sourceId ? sql` AND sourceId = ${sourceId}` : sql``;
+    const rows = await db.all<{ nodeNum: number | bigint; timestamp: number; packetTimestamp: number }>(
+      sql`SELECT t.nodeNum, t.timestamp, t.packetTimestamp
+          FROM telemetry t
+          INNER JOIN (
+            SELECT nodeNum, MAX(timestamp) as maxTs
+            FROM telemetry
+            WHERE packetTimestamp IS NOT NULL AND packetTimestamp > ${minValidTimestampMs}${sourceFilterInner}
+            GROUP BY nodeNum
+          ) latest ON t.nodeNum = latest.nodeNum AND t.timestamp = latest.maxTs
+          WHERE t.packetTimestamp IS NOT NULL AND t.packetTimestamp > ${minValidTimestampMs}${sourceFilterOuter}`
+    );
+    return rows.map((r: any) => ({
+      nodeNum: Number(r.nodeNum),
+      timestamp: Number(r.timestamp),
+      packetTimestamp: Number(r.packetTimestamp),
+    }));
+  }
+
+  /**
+   * Delete all estimated position telemetry (estimated_latitude, estimated_longitude).
+   * Used during migration to force recalculation with a new algorithm.
+   * Returns the number of rows deleted.
+   */
+  async deleteAllEstimatedPositions(): Promise<number> {
+    const { telemetry } = this.tables;
+    const types = ['estimated_latitude', 'estimated_longitude'];
+    const condition = inArray(telemetry.telemetryType, types);
+
+    if (this.isMySQL()) {
+      const countRows = await this.db
+        .select({ id: telemetry.id })
+        .from(telemetry)
+        .where(condition);
+      const cnt = countRows.length;
+      await this.db.delete(telemetry).where(condition);
+      return cnt;
+    }
+    const deleted = await (this.db as any)
+      .delete(telemetry)
+      .where(condition)
+      .returning({ id: telemetry.id });
+    return deleted.length;
+  }
+
+  // ============ SQLite-only sync methods ============
+  // These exist because facade methods on DatabaseService have legacy sync
+  // signatures that non-test callers still depend on. For PG/MySQL callers
+  // use the async equivalents above.
+
+  /**
+   * Synchronously get total telemetry count (SQLite only).
+   */
+  getTelemetryCountSync(): number {
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    const rows = db.select({ count: count() }).from(telemetry).all();
+    return Number((rows[0] as any).count);
+  }
+
+  /**
+   * Synchronously count telemetry for a node with optional filters (SQLite only).
+   */
+  getTelemetryCountByNodeSync(
+    nodeId: string,
+    sinceTimestamp?: number,
+    beforeTimestamp?: number,
+    telemetryType?: string
+  ): number {
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    const conditions = [eq(telemetry.nodeId, nodeId)];
+    if (sinceTimestamp !== undefined) {
+      conditions.push(gte(telemetry.timestamp, sinceTimestamp));
+    }
+    if (beforeTimestamp !== undefined) {
+      conditions.push(lt(telemetry.timestamp, beforeTimestamp));
+    }
+    if (telemetryType !== undefined) {
+      conditions.push(eq(telemetry.telemetryType, telemetryType));
+    }
+    const rows = db
+      .select({ count: count() })
+      .from(telemetry)
+      .where(and(...conditions))
+      .all();
+    return Number((rows[0] as any).count);
+  }
+
+  /**
+   * Synchronously delete ALL telemetry for a given node (SQLite only).
+   * Returns the number of rows deleted.
+   */
+  deleteTelemetryByNodeSync(nodeNum: number): number {
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    const result = db
+      .delete(telemetry)
+      .where(eq(telemetry.nodeNum, nodeNum))
+      .run();
+    return Number((result as any).changes ?? 0);
+  }
+
+  /**
+   * Synchronously delete all telemetry rows (SQLite only).
+   * Returns the number of rows deleted.
+   */
+  deleteAllTelemetrySync(): number {
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    const result = db.delete(telemetry).run();
+    return Number((result as any).changes ?? 0);
+  }
+
+  /**
+   * Synchronously delete telemetry older than a cutoff timestamp (SQLite only).
+   * Returns the number of rows deleted.
+   */
+  deleteOldTelemetrySync(cutoffTimestamp: number): number {
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    const result = db
+      .delete(telemetry)
+      .where(lt(telemetry.timestamp, cutoffTimestamp))
+      .run();
+    return Number((result as any).changes ?? 0);
+  }
+
+  /**
+   * Synchronously insert a telemetry row via Drizzle query builder (SQLite only).
+   * Does NOT apply the unique-on-packetId suppression from insertTelemetry; this
+   * matches the legacy facade sync behavior which always inserts.
+   */
+  insertTelemetrySync(telemetryData: DbTelemetry, sourceId?: string): void {
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    const values: any = {
+      nodeId: telemetryData.nodeId,
+      nodeNum: telemetryData.nodeNum,
+      telemetryType: telemetryData.telemetryType,
+      timestamp: telemetryData.timestamp,
+      value: telemetryData.value,
+      unit: telemetryData.unit ?? null,
+      createdAt: telemetryData.createdAt,
+      packetTimestamp: telemetryData.packetTimestamp ?? null,
+      packetId: telemetryData.packetId ?? null,
+      channel: telemetryData.channel ?? null,
+      precisionBits: telemetryData.precisionBits ?? null,
+      gpsAccuracy: telemetryData.gpsAccuracy ?? null,
+    };
+    if (sourceId) {
+      values.sourceId = sourceId;
+    }
+    db.insert(telemetry).values(values).run();
+  }
+
+  /**
+   * Synchronously fetch telemetry for a node with optional filters (SQLite only).
+   */
+  getTelemetryByNodeSync(
+    nodeId: string,
+    limit: number = 100,
+    sinceTimestamp?: number,
+    beforeTimestamp?: number,
+    offset: number = 0,
+    telemetryType?: string
+  ): DbTelemetry[] {
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    const conditions = [eq(telemetry.nodeId, nodeId)];
+    if (sinceTimestamp !== undefined) conditions.push(gte(telemetry.timestamp, sinceTimestamp));
+    if (beforeTimestamp !== undefined) conditions.push(lt(telemetry.timestamp, beforeTimestamp));
+    if (telemetryType !== undefined) conditions.push(eq(telemetry.telemetryType, telemetryType));
+
+    const rows = db
+      .select()
+      .from(telemetry)
+      .where(and(...conditions))
+      .orderBy(desc(telemetry.timestamp))
+      .limit(limit)
+      .offset(offset)
+      .all();
+    return (rows as any[]).map((r) => normalizeSyncTelemetryRow(this.normalizeBigInts(r))) as DbTelemetry[];
+  }
+
+  /**
+   * Synchronously fetch telemetry by type (SQLite only).
+   */
+  getTelemetryByTypeSync(telemetryType: string, limit: number = 100): DbTelemetry[] {
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    const rows = db
+      .select()
+      .from(telemetry)
+      .where(eq(telemetry.telemetryType, telemetryType))
+      .orderBy(desc(telemetry.timestamp))
+      .limit(limit)
+      .all();
+    return (rows as any[]).map((r) => normalizeSyncTelemetryRow(this.normalizeBigInts(r))) as DbTelemetry[];
+  }
+
+  /**
+   * Synchronously get the latest record for each telemetry type for a node (SQLite only).
+   */
+  getLatestTelemetryByNodeSync(nodeId: string): DbTelemetry[] {
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    // Correlated subquery: latest row per (nodeId, telemetryType)
+    const rows = db
+      .select()
+      .from(telemetry)
+      .where(
+        and(
+          eq(telemetry.nodeId, nodeId),
+          sql`${telemetry.timestamp} = (
+            SELECT MAX(t2.timestamp) FROM ${telemetry} t2
+            WHERE t2.nodeId = ${telemetry.nodeId} AND t2.telemetryType = ${telemetry.telemetryType}
+          )`
+        )
+      )
+      .orderBy(telemetry.telemetryType)
+      .all();
+    return (rows as any[]).map((r) => normalizeSyncTelemetryRow(this.normalizeBigInts(r))) as DbTelemetry[];
+  }
+
+  /**
+   * Synchronously get the latest record for a specific telemetry type (SQLite only).
+   */
+  getLatestTelemetryForTypeSync(nodeId: string, telemetryType: string): DbTelemetry | null {
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    const rows = db
+      .select()
+      .from(telemetry)
+      .where(and(eq(telemetry.nodeId, nodeId), eq(telemetry.telemetryType, telemetryType)))
+      .orderBy(desc(telemetry.timestamp))
+      .limit(1)
+      .all();
+    if (rows.length === 0) return null;
+    return normalizeSyncTelemetryRow(this.normalizeBigInts(rows[0])) as DbTelemetry;
+  }
+
+  /**
+   * Synchronously get distinct telemetry types for a node (SQLite only).
+   */
+  getNodeTelemetryTypesSync(nodeId: string): string[] {
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    const rows = db
+      .selectDistinct({ telemetryType: telemetry.telemetryType })
+      .from(telemetry)
+      .where(eq(telemetry.nodeId, nodeId))
+      .all();
+    return (rows as any[]).map((r) => r.telemetryType);
+  }
+
+  /**
+   * Synchronously get all nodes with their telemetry types (SQLite only).
+   * Returns Map<nodeId, string[]>.
+   */
+  getAllNodesTelemetryTypesSync(): Map<string, string[]> {
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    const rows = db
+      .selectDistinct({ nodeId: telemetry.nodeId, telemetryType: telemetry.telemetryType })
+      .from(telemetry)
+      .all();
+    const map = new Map<string, string[]>();
+    for (const r of rows as any[]) {
+      const types = map.get(r.nodeId) || [];
+      if (!types.includes(r.telemetryType)) types.push(r.telemetryType);
+      map.set(r.nodeId, types);
+    }
+    return map;
+  }
+
+  /**
+   * Synchronously delete all estimated position telemetry (SQLite only).
+   * Returns rows deleted.
+   */
+  deleteAllEstimatedPositionsSync(): number {
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    const types = ['estimated_latitude', 'estimated_longitude'];
+    const result = db.delete(telemetry).where(inArray(telemetry.telemetryType, types)).run();
+    return Number((result as any).changes ?? 0);
+  }
+
+  /**
+   * Synchronously delete old telemetry with favorites retention (SQLite only).
+   * Non-favorited telemetry older than regularCutoffTimestamp is deleted.
+   * Favorited telemetry older than favoriteCutoffTimestamp is deleted.
+   * Returns { nonFavoritesDeleted, favoritesDeleted }.
+   */
+  deleteOldTelemetryWithFavoritesSync(
+    regularCutoffTimestamp: number,
+    favoriteCutoffTimestamp: number,
+    favorites: TelemetryFavorite[]
+  ): { nonFavoritesDeleted: number; favoritesDeleted: number } {
+    if (favorites.length === 0) {
+      const nonFavoritesDeleted = this.deleteOldTelemetrySync(regularCutoffTimestamp);
+      return { nonFavoritesDeleted, favoritesDeleted: 0 };
+    }
+
+    const db = this.getSqliteDb();
+    const { telemetry } = this.tables;
+    const favoritesCondition = this.buildFavoritesCondition(favorites)!;
+
+    const nonFavoritesResult = db
+      .delete(telemetry)
+      .where(and(lt(telemetry.timestamp, regularCutoffTimestamp), not(favoritesCondition)))
+      .run();
+    const nonFavoritesDeleted = Number((nonFavoritesResult as any).changes ?? 0);
+
+    const favoritesResult = db
+      .delete(telemetry)
+      .where(and(lt(telemetry.timestamp, favoriteCutoffTimestamp), favoritesCondition))
+      .run();
+    const favoritesDeleted = Number((favoritesResult as any).changes ?? 0);
+
+    return { nonFavoritesDeleted, favoritesDeleted };
   }
 }

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -416,4 +416,91 @@ export class TraceroutesRepository extends BaseRepository {
     }
     return total;
   }
+
+  // ============ SQLite-only sync methods ============
+
+  /**
+   * Synchronously delete all traceroutes (SQLite only).
+   * Returns the number of rows deleted.
+   */
+  deleteAllTraceroutesSync(): number {
+    const db = this.getSqliteDb();
+    const { traceroutes } = this.tables;
+    const result = db.delete(traceroutes).run();
+    return Number((result as any).changes ?? 0);
+  }
+
+  /**
+   * Synchronously delete all route segments (SQLite only).
+   * Returns the number of rows deleted.
+   */
+  deleteAllRouteSegmentsSync(): number {
+    const db = this.getSqliteDb();
+    const { routeSegments } = this.tables;
+    const result = db.delete(routeSegments).run();
+    return Number((result as any).changes ?? 0);
+  }
+
+  /**
+   * Synchronously delete traceroutes older than cutoffTimestamp (SQLite only).
+   * Returns the number of rows deleted.
+   */
+  deleteOldTraceroutesSync(cutoffTimestamp: number): number {
+    const db = this.getSqliteDb();
+    const { traceroutes } = this.tables;
+    const result = db
+      .delete(traceroutes)
+      .where(lt(traceroutes.timestamp, cutoffTimestamp))
+      .run();
+    return Number((result as any).changes ?? 0);
+  }
+
+  /**
+   * Synchronously delete all traceroutes where this node appears as source OR
+   * destination (SQLite only). Returns the number of rows deleted.
+   */
+  deleteTraceroutesInvolvingNodeSync(nodeNum: number): number {
+    const db = this.getSqliteDb();
+    const { traceroutes } = this.tables;
+    const result = db
+      .delete(traceroutes)
+      .where(or(eq(traceroutes.fromNodeNum, nodeNum), eq(traceroutes.toNodeNum, nodeNum))!)
+      .run();
+    return Number((result as any).changes ?? 0);
+  }
+
+  /**
+   * Synchronously delete all route segments where this node appears as source OR
+   * destination (SQLite only). Returns the number of rows deleted.
+   */
+  deleteRouteSegmentsInvolvingNodeSync(nodeNum: number): number {
+    const db = this.getSqliteDb();
+    const { routeSegments } = this.tables;
+    const result = db
+      .delete(routeSegments)
+      .where(or(eq(routeSegments.fromNodeNum, nodeNum), eq(routeSegments.toNodeNum, nodeNum))!)
+      .run();
+    return Number((result as any).changes ?? 0);
+  }
+
+  /**
+   * Synchronously get all traceroutes for the legacy runDataMigrations
+   * bootstrap flow (SQLite only).
+   */
+  getAllTraceroutesSync(): DbTraceroute[] {
+    const db = this.getSqliteDb();
+    const { traceroutes } = this.tables;
+    const rows = db
+      .select()
+      .from(traceroutes)
+      .orderBy(traceroutes.timestamp)
+      .all();
+    return (rows as any[]).map((r) => {
+      const n = this.normalizeBigInts(r) as any;
+      if (n.channel === null) n.channel = undefined;
+      if (n.routePositions === null) n.routePositions = undefined;
+      if (n.sourceId === null) n.sourceId = undefined;
+      return n as DbTraceroute;
+    });
+  }
 }

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -4,9 +4,9 @@
  * Handles traceroute and route segment database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, and, desc, lt, or, isNull, gte, notInArray, count } from 'drizzle-orm';
+import { eq, and, desc, lt, or, isNull, gte, notInArray, count, sql } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
-import { DatabaseType, DbTraceroute, DbRouteSegment } from '../types.js';
+import { DatabaseType, DbTraceroute, DbRouteSegment, DbNode } from '../types.js';
 
 /**
  * Repository for traceroute operations
@@ -481,6 +481,376 @@ export class TraceroutesRepository extends BaseRepository {
       .where(or(eq(routeSegments.fromNodeNum, nodeNum), eq(routeSegments.toNodeNum, nodeNum))!)
       .run();
     return Number((result as any).changes ?? 0);
+  }
+
+  /**
+   * Synchronously upsert a traceroute (SQLite only) mirroring the legacy
+   * facade `insertTraceroute` semantics:
+   *   1. If a recent pending row (route IS NULL) exists for this pair within
+   *      pendingTimeoutMs, update it in place (inverse direction because
+   *      response fromNum/toNum are swapped).
+   *   2. Otherwise insert a fresh row.
+   *   3. Prune older rows beyond historyLimit for this pair.
+   *
+   * The whole sequence runs in a single transaction.
+   */
+  upsertTracerouteSync(
+    tracerouteData: DbTraceroute,
+    pendingTimeoutMs: number,
+    historyLimit: number,
+    sourceId?: string
+  ): void {
+    const db = this.getSqliteDb();
+    const { traceroutes } = this.tables;
+    const nowTs = this.now();
+    const pendingSince = nowTs - pendingTimeoutMs;
+
+    db.transaction((tx) => {
+      // Step 1: find pending (inverse direction) within timeout window
+      const pendingConditions = [
+        eq(traceroutes.fromNodeNum, tracerouteData.toNodeNum),
+        eq(traceroutes.toNodeNum, tracerouteData.fromNodeNum),
+        isNull(traceroutes.route),
+        gte(traceroutes.timestamp, pendingSince),
+      ];
+      if (sourceId !== undefined) {
+        pendingConditions.push(eq(traceroutes.sourceId, sourceId));
+      }
+      const pendingRows = tx
+        .select({ id: traceroutes.id })
+        .from(traceroutes)
+        .where(and(...pendingConditions))
+        .orderBy(desc(traceroutes.timestamp))
+        .limit(1)
+        .all();
+
+      if (pendingRows.length > 0) {
+        const id = Number((pendingRows[0] as any).id);
+        tx.update(traceroutes)
+          .set({
+            route: tracerouteData.route || null,
+            routeBack: tracerouteData.routeBack || null,
+            snrTowards: tracerouteData.snrTowards || null,
+            snrBack: tracerouteData.snrBack || null,
+            timestamp: tracerouteData.timestamp,
+          })
+          .where(eq(traceroutes.id, id))
+          .run();
+      } else {
+        const values: any = {
+          fromNodeNum: tracerouteData.fromNodeNum,
+          toNodeNum: tracerouteData.toNodeNum,
+          fromNodeId: tracerouteData.fromNodeId,
+          toNodeId: tracerouteData.toNodeId,
+          route: tracerouteData.route || null,
+          routeBack: tracerouteData.routeBack || null,
+          snrTowards: tracerouteData.snrTowards || null,
+          snrBack: tracerouteData.snrBack || null,
+          timestamp: tracerouteData.timestamp,
+          createdAt: tracerouteData.createdAt,
+          sourceId: sourceId ?? null,
+        };
+        tx.insert(traceroutes).values(values).run();
+      }
+
+      // Step 3: prune — keep only the most recent `historyLimit` rows for
+      // this (fromNodeNum, toNodeNum[, sourceId]) pair.
+      const scopeConditions = [
+        eq(traceroutes.fromNodeNum, tracerouteData.fromNodeNum),
+        eq(traceroutes.toNodeNum, tracerouteData.toNodeNum),
+      ];
+      if (sourceId !== undefined) {
+        scopeConditions.push(eq(traceroutes.sourceId, sourceId));
+      }
+      const scopedWhere = and(...scopeConditions)!;
+
+      const keepRows = tx
+        .select({ id: traceroutes.id })
+        .from(traceroutes)
+        .where(scopedWhere)
+        .orderBy(desc(traceroutes.timestamp))
+        .limit(historyLimit)
+        .all();
+      const keepIds = (keepRows as any[]).map((r) => Number(r.id));
+      if (keepIds.length > 0) {
+        tx.delete(traceroutes)
+          .where(and(scopedWhere, notInArray(traceroutes.id, keepIds)))
+          .run();
+      }
+    });
+  }
+
+  /**
+   * Synchronously get traceroutes between a node pair in either direction
+   * (SQLite only).
+   */
+  getTraceroutesByNodesSync(
+    fromNodeNum: number,
+    toNodeNum: number,
+    limit: number = 10
+  ): DbTraceroute[] {
+    const db = this.getSqliteDb();
+    const { traceroutes } = this.tables;
+    const rows = db
+      .select()
+      .from(traceroutes)
+      .where(
+        or(
+          and(eq(traceroutes.fromNodeNum, fromNodeNum), eq(traceroutes.toNodeNum, toNodeNum)),
+          and(eq(traceroutes.fromNodeNum, toNodeNum), eq(traceroutes.toNodeNum, fromNodeNum))
+        )!
+      )
+      .orderBy(desc(traceroutes.timestamp))
+      .limit(limit)
+      .all();
+    return (rows as any[]).map((r) => this.normalizeTracerouteRow(r));
+  }
+
+  /**
+   * Synchronously get recent traceroutes (all pairs) (SQLite only).
+   */
+  getAllTraceroutesRecentSync(limit: number = 100): DbTraceroute[] {
+    const db = this.getSqliteDb();
+    const { traceroutes } = this.tables;
+    const rows = db
+      .select()
+      .from(traceroutes)
+      .orderBy(desc(traceroutes.timestamp))
+      .limit(limit)
+      .all();
+    return (rows as any[]).map((r) => this.normalizeTracerouteRow(r));
+  }
+
+  /**
+   * Synchronously get non-empty completed traceroutes (route IS NOT NULL and
+   * route != '[]') ordered ascending by timestamp. Used by legacy migration
+   * paths that hydrate route_segments from history. (SQLite only.)
+   */
+  getCompletedTraceroutesForMigrationSync(): Array<{
+    id: number;
+    fromNodeNum: number;
+    toNodeNum: number;
+    route: string | null;
+    snrTowards: string | null;
+    timestamp: number;
+  }> {
+    const db = this.getSqliteDb();
+    const { traceroutes } = this.tables;
+    const rows = db
+      .select({
+        id: traceroutes.id,
+        fromNodeNum: traceroutes.fromNodeNum,
+        toNodeNum: traceroutes.toNodeNum,
+        route: traceroutes.route,
+        snrTowards: traceroutes.snrTowards,
+        timestamp: traceroutes.timestamp,
+      })
+      .from(traceroutes)
+      .where(and(
+        sql`${traceroutes.route} IS NOT NULL`,
+        sql`${traceroutes.route} != '[]'`,
+      )!)
+      .orderBy(traceroutes.timestamp)
+      .all();
+    return (rows as any[]).map((r) => ({
+      id: Number(r.id),
+      fromNodeNum: Number(r.fromNodeNum),
+      toNodeNum: Number(r.toNodeNum),
+      route: r.route ?? null,
+      snrTowards: r.snrTowards ?? null,
+      timestamp: Number(r.timestamp),
+    }));
+  }
+
+  /**
+   * Synchronously return all candidate nodes eligible for auto-traceroute
+   * (SQLite only). A node is eligible when it has been heard within
+   * activeNodeCutoff (unix seconds) AND either:
+   *   - Has no successful traceroute and lastTracerouteRequest is null or
+   *     older than threeHoursCutoff (ms), OR
+   *   - Has at least one traceroute and lastTracerouteRequest is null or
+   *     older than expirationCutoff (ms).
+   *
+   * Sorted by lastHeard descending. Caller applies per-setting filters.
+   */
+  getEligibleTracerouteCandidatesSync(
+    localNodeNum: number,
+    activeNodeCutoffSec: number,
+    threeHoursCutoffMs: number,
+    expirationCutoffMs: number
+  ): DbNode[] {
+    const db = this.getSqliteDb();
+    const rows = db.all(sql`
+      SELECT n.*,
+        (SELECT COUNT(*) FROM traceroutes t
+         WHERE t.fromNodeNum = ${localNodeNum} AND t.toNodeNum = n.nodeNum) as hasTraceroute
+      FROM nodes n
+      WHERE n.nodeNum != ${localNodeNum}
+        AND n.lastHeard > ${activeNodeCutoffSec}
+        AND (
+          (
+            (SELECT COUNT(*) FROM traceroutes t
+             WHERE t.fromNodeNum = ${localNodeNum} AND t.toNodeNum = n.nodeNum) = 0
+            AND (n.lastTracerouteRequest IS NULL OR n.lastTracerouteRequest < ${threeHoursCutoffMs})
+          )
+          OR
+          (
+            (SELECT COUNT(*) FROM traceroutes t
+             WHERE t.fromNodeNum = ${localNodeNum} AND t.toNodeNum = n.nodeNum) > 0
+            AND (n.lastTracerouteRequest IS NULL OR n.lastTracerouteRequest < ${expirationCutoffMs})
+          )
+        )
+      ORDER BY n.lastHeard DESC
+    `) as any[];
+    return rows.map((r) => this.normalizeBigInts(r)) as DbNode[];
+  }
+
+  // ============ route_segments sync methods (SQLite only) ============
+
+  /**
+   * Synchronously insert a route segment row (SQLite only).
+   */
+  insertRouteSegmentSync(segmentData: DbRouteSegment, sourceId?: string): void {
+    const db = this.getSqliteDb();
+    const { routeSegments } = this.tables;
+    db.insert(routeSegments)
+      .values({
+        fromNodeNum: segmentData.fromNodeNum,
+        toNodeNum: segmentData.toNodeNum,
+        fromNodeId: segmentData.fromNodeId,
+        toNodeId: segmentData.toNodeId,
+        distanceKm: segmentData.distanceKm,
+        isRecordHolder: segmentData.isRecordHolder ?? false,
+        timestamp: segmentData.timestamp,
+        createdAt: segmentData.createdAt,
+        sourceId: sourceId ?? null,
+      } as any)
+      .run();
+  }
+
+  /**
+   * Synchronously return the longest route segment from the last 7 days
+   * (SQLite only). When sourceId is provided, scope to that source (matching
+   * NULL when `sourceId === null`-like semantics).
+   */
+  getLongestActiveRouteSegmentSync(sourceId?: string): DbRouteSegment | null {
+    const db = this.getSqliteDb();
+    const { routeSegments } = this.tables;
+    const cutoff = Date.now() - (7 * 24 * 60 * 60 * 1000);
+    const conditions: any[] = [gte(routeSegments.timestamp, cutoff)];
+    if (sourceId !== undefined) {
+      conditions.push(eq(routeSegments.sourceId, sourceId));
+    }
+    const rows = db
+      .select()
+      .from(routeSegments)
+      .where(and(...conditions)!)
+      .orderBy(desc(routeSegments.distanceKm))
+      .limit(1)
+      .all();
+    if (rows.length === 0) return null;
+    return this.normalizeRouteSegmentRow(rows[0]);
+  }
+
+  /**
+   * Synchronously return the current record-holder route segment (SQLite only).
+   */
+  getRecordHolderRouteSegmentSync(sourceId?: string): DbRouteSegment | null {
+    const db = this.getSqliteDb();
+    const { routeSegments } = this.tables;
+    const conditions: any[] = [eq(routeSegments.isRecordHolder, true)];
+    if (sourceId !== undefined) {
+      conditions.push(eq(routeSegments.sourceId, sourceId));
+    }
+    const rows = db
+      .select()
+      .from(routeSegments)
+      .where(and(...conditions)!)
+      .orderBy(desc(routeSegments.distanceKm))
+      .limit(1)
+      .all();
+    if (rows.length === 0) return null;
+    return this.normalizeRouteSegmentRow(rows[0]);
+  }
+
+  /**
+   * Synchronously clear the record-holder flag on all route segments (SQLite
+   * only). When sourceId is provided, only that source's segments are cleared.
+   */
+  clearRecordHolderSegmentSync(sourceId?: string): void {
+    const db = this.getSqliteDb();
+    const { routeSegments } = this.tables;
+    const conditions: any[] = [];
+    if (sourceId !== undefined) {
+      conditions.push(eq(routeSegments.sourceId, sourceId));
+    }
+    const stmt = db.update(routeSegments).set({ isRecordHolder: false } as any);
+    if (conditions.length > 0) {
+      stmt.where(and(...conditions)!).run();
+    } else {
+      stmt.run();
+    }
+  }
+
+  /**
+   * Synchronously delete route segments older than `days` that are not record
+   * holders (SQLite only). Returns the number of rows deleted.
+   */
+  cleanupOldRouteSegmentsSync(days: number = 30, sourceId?: string): number {
+    const db = this.getSqliteDb();
+    const { routeSegments } = this.tables;
+    const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
+    const conditions: any[] = [
+      lt(routeSegments.timestamp, cutoff),
+      eq(routeSegments.isRecordHolder, false),
+    ];
+    if (sourceId !== undefined) {
+      conditions.push(eq(routeSegments.sourceId, sourceId));
+    }
+    const result = db
+      .delete(routeSegments)
+      .where(and(...conditions)!)
+      .run();
+    return Number((result as any).changes ?? 0);
+  }
+
+  /**
+   * Synchronously delete traceroutes older than `days` (SQLite only).
+   * Returns the number of rows deleted.
+   */
+  cleanupOldTraceroutesSync(days: number = 30): number {
+    const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
+    return this.deleteOldTraceroutesSync(cutoff);
+  }
+
+  /**
+   * Helper: normalize route_segment row fields to match DbRouteSegment.
+   * SQLite stores booleans as integers; `normalizeBigInts` leaves them, so we
+   * coerce `isRecordHolder` explicitly.
+   */
+  private normalizeRouteSegmentRow(r: any): DbRouteSegment {
+    const n = this.normalizeBigInts(r) as any;
+    if (typeof n.isRecordHolder === 'number') {
+      n.isRecordHolder = n.isRecordHolder === 1;
+    } else if (n.isRecordHolder === null || n.isRecordHolder === undefined) {
+      n.isRecordHolder = false;
+    }
+    return n as DbRouteSegment;
+  }
+
+  /**
+   * Helper: convert nullable row fields back to undefined to match DbTraceroute.
+   */
+  private normalizeTracerouteRow(r: any): DbTraceroute {
+    const n = this.normalizeBigInts(r) as any;
+    if (n.channel === null) n.channel = undefined;
+    if (n.routePositions === null) n.routePositions = undefined;
+    if (n.sourceId === null) n.sourceId = undefined;
+    if (n.route === null) n.route = undefined;
+    if (n.routeBack === null) n.routeBack = undefined;
+    if (n.snrTowards === null) n.snrTowards = undefined;
+    if (n.snrBack === null) n.snrBack = undefined;
+    return n as DbTraceroute;
   }
 
   /**

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1096,6 +1096,7 @@ class DatabaseService {
       );
     `);
 
+    // eslint-disable-next-line no-restricted-syntax -- bootstrap: runs before migrations
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS telemetry (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -2882,71 +2883,7 @@ class DatabaseService {
     // (nodes without GPS/NTP often report 0 or boot-relative seconds)
     const MIN_VALID_TIMESTAMP_MS = 1577836800000;
 
-    if (this.drizzleDbType === 'postgres' && this.postgresPool) {
-      const sourceFilter = sourceId ? ' AND "sourceId" = $2' : '';
-      const params: any[] = [MIN_VALID_TIMESTAMP_MS];
-      if (sourceId) params.push(sourceId);
-      const result = await this.postgresPool.query(`
-        SELECT DISTINCT ON ("nodeNum") "nodeNum", "timestamp", "packetTimestamp"
-        FROM telemetry
-        WHERE "packetTimestamp" IS NOT NULL AND "packetTimestamp" > $1${sourceFilter}
-        ORDER BY "nodeNum", "timestamp" DESC
-      `, params);
-      return result.rows.map((r: any) => ({
-        nodeNum: Number(r.nodeNum),
-        timestamp: Number(r.timestamp),
-        packetTimestamp: Number(r.packetTimestamp)
-      }));
-    }
-
-    if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
-      const sourceFilter = sourceId ? ' AND t.sourceId = ?' : '';
-      const innerFilter = sourceId ? ' AND sourceId = ?' : '';
-      const params: any[] = [MIN_VALID_TIMESTAMP_MS];
-      if (sourceId) params.push(sourceId);
-      params.push(MIN_VALID_TIMESTAMP_MS);
-      if (sourceId) params.push(sourceId);
-      const [rows] = await this.mysqlPool.query(`
-        SELECT t.nodeNum, t.timestamp, t.packetTimestamp
-        FROM telemetry t
-        INNER JOIN (
-          SELECT nodeNum, MAX(timestamp) as maxTs
-          FROM telemetry
-          WHERE packetTimestamp IS NOT NULL AND packetTimestamp > ?${innerFilter}
-          GROUP BY nodeNum
-        ) latest ON t.nodeNum = latest.nodeNum AND t.timestamp = latest.maxTs
-        WHERE t.packetTimestamp IS NOT NULL AND t.packetTimestamp > ?${sourceFilter}
-      `, params) as any;
-      return (rows as any[]).map((r: any) => ({
-        nodeNum: Number(r.nodeNum),
-        timestamp: Number(r.timestamp),
-        packetTimestamp: Number(r.packetTimestamp)
-      }));
-    }
-
-    // SQLite
-    const sourceFilter = sourceId ? ' AND t.sourceId = ?' : '';
-    const innerFilter = sourceId ? ' AND sourceId = ?' : '';
-    const params: any[] = [MIN_VALID_TIMESTAMP_MS];
-    if (sourceId) params.push(sourceId);
-    params.push(MIN_VALID_TIMESTAMP_MS);
-    if (sourceId) params.push(sourceId);
-    const stmt = this.db.prepare(`
-      SELECT t.nodeNum, t.timestamp, t.packetTimestamp
-      FROM telemetry t
-      INNER JOIN (
-        SELECT nodeNum, MAX(timestamp) as maxTs
-        FROM telemetry
-        WHERE packetTimestamp IS NOT NULL AND packetTimestamp > ?${innerFilter}
-        GROUP BY nodeNum
-      ) latest ON t.nodeNum = latest.nodeNum AND t.timestamp = latest.maxTs
-      WHERE t.packetTimestamp IS NOT NULL AND t.packetTimestamp > ?${sourceFilter}
-    `);
-    return (stmt.all(...params) as any[]).map((r: any) => ({
-      nodeNum: Number(r.nodeNum),
-      timestamp: Number(r.timestamp),
-      packetTimestamp: Number(r.packetTimestamp)
-    }));
+    return this.telemetry.getLatestPacketTimestampsPerNode(MIN_VALID_TIMESTAMP_MS, sourceId);
   }
 
   // Message operations
@@ -3251,9 +3188,7 @@ class DatabaseService {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       return 0;
     }
-    const stmt = this.db.prepare('SELECT COUNT(*) as count FROM telemetry');
-    const result = stmt.get() as { count: number };
-    return Number(result.count);
+    return this.telemetry.getTelemetryCountSync();
   }
 
   /** @deprecated Use databaseService.telemetry.getTelemetryCount() instead */
@@ -3266,28 +3201,7 @@ class DatabaseService {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       return 0;
     }
-
-    let query = 'SELECT COUNT(*) as count FROM telemetry WHERE nodeId = ?';
-    const params: any[] = [nodeId];
-
-    if (sinceTimestamp !== undefined) {
-      query += ' AND timestamp >= ?';
-      params.push(sinceTimestamp);
-    }
-
-    if (beforeTimestamp !== undefined) {
-      query += ' AND timestamp < ?';
-      params.push(beforeTimestamp);
-    }
-
-    if (telemetryType !== undefined) {
-      query += ' AND telemetryType = ?';
-      params.push(telemetryType);
-    }
-
-    const stmt = this.db.prepare(query);
-    const result = stmt.get(...params) as { count: number };
-    return Number(result.count);
+    return this.telemetry.getTelemetryCountByNodeSync(nodeId, sinceTimestamp, beforeTimestamp, telemetryType);
   }
 
   /** @deprecated Use databaseService.telemetry.getTelemetryCountByNode() instead */
@@ -3624,9 +3538,7 @@ class DatabaseService {
     }
 
     // Delete all telemetry data for this node
-    const stmt = this.db.prepare('DELETE FROM telemetry WHERE nodeNum = ?');
-    const result = stmt.run(nodeNum);
-    return Number(result.changes);
+    return this.telemetry.deleteTelemetryByNodeSync(nodeNum);
   }
 
   deleteNode(nodeNum: number, sourceId: string): {
@@ -4087,22 +3999,7 @@ class DatabaseService {
       return;
     }
 
-    const stmt = this.db.prepare(`
-      INSERT INTO telemetry (
-        nodeId, nodeNum, telemetryType, timestamp, value, unit, createdAt, packetTimestamp
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-
-    stmt.run(
-      telemetryData.nodeId,
-      telemetryData.nodeNum,
-      telemetryData.telemetryType,
-      telemetryData.timestamp,
-      telemetryData.value,
-      telemetryData.unit || null,
-      telemetryData.createdAt,
-      telemetryData.packetTimestamp || null
-    );
+    this.telemetry.insertTelemetrySync(telemetryData);
 
     // Invalidate the telemetry types cache since we may have added a new type
     this.invalidateTelemetryTypesCache();
@@ -4117,36 +4014,7 @@ class DatabaseService {
   }
 
   getTelemetryByNode(nodeId: string, limit: number = 100, sinceTimestamp?: number, beforeTimestamp?: number, offset: number = 0, telemetryType?: string): DbTelemetry[] {
-    let query = `
-      SELECT * FROM telemetry
-      WHERE nodeId = ?
-    `;
-    const params: any[] = [nodeId];
-
-    if (sinceTimestamp !== undefined) {
-      query += ` AND timestamp >= ?`;
-      params.push(sinceTimestamp);
-    }
-
-    if (beforeTimestamp !== undefined) {
-      query += ` AND timestamp < ?`;
-      params.push(beforeTimestamp);
-    }
-
-    if (telemetryType !== undefined) {
-      query += ` AND telemetryType = ?`;
-      params.push(telemetryType);
-    }
-
-    query += `
-      ORDER BY timestamp DESC
-      LIMIT ? OFFSET ?
-    `;
-    params.push(limit, offset);
-
-    const stmt = this.db.prepare(query);
-    const telemetry = stmt.all(...params) as DbTelemetry[];
-    return telemetry.map(t => this.normalizeBigInts(t));
+    return this.telemetry.getTelemetryByNodeSync(nodeId, limit, sinceTimestamp, beforeTimestamp, offset, telemetryType) as unknown as DbTelemetry[];
   }
 
   /** @deprecated Use databaseService.telemetry.getTelemetryByNode() instead */
@@ -4408,12 +4276,7 @@ class DatabaseService {
    * Used during migration to force recalculation with new algorithm.
    */
   deleteAllEstimatedPositions(): number {
-    const stmt = this.db.prepare(`
-      DELETE FROM telemetry
-      WHERE telemetryType IN ('estimated_latitude', 'estimated_longitude')
-    `);
-    const result = stmt.run();
-    return result.changes;
+    return this.telemetry.deleteAllEstimatedPositionsSync();
   }
 
   // Cache for PostgreSQL telemetry data
@@ -6778,14 +6641,7 @@ class DatabaseService {
       return [];
     }
 
-    const stmt = this.db.prepare(`
-      SELECT * FROM telemetry
-      WHERE telemetryType = ?
-      ORDER BY timestamp DESC
-      LIMIT ?
-    `);
-    const telemetry = stmt.all(telemetryType, limit) as DbTelemetry[];
-    return telemetry.map(t => this.normalizeBigInts(t));
+    return this.telemetry.getTelemetryByTypeSync(telemetryType, limit) as unknown as DbTelemetry[];
   }
 
   /** @deprecated Use databaseService.telemetry.getTelemetryByType() instead */
@@ -6800,16 +6656,7 @@ class DatabaseService {
       return [];
     }
 
-    const stmt = this.db.prepare(`
-      SELECT * FROM telemetry t1
-      WHERE nodeId = ? AND timestamp = (
-        SELECT MAX(timestamp) FROM telemetry t2
-        WHERE t2.nodeId = t1.nodeId AND t2.telemetryType = t1.telemetryType
-      )
-      ORDER BY telemetryType ASC
-    `);
-    const telemetry = stmt.all(nodeId) as DbTelemetry[];
-    return telemetry.map(t => this.normalizeBigInts(t));
+    return this.telemetry.getLatestTelemetryByNodeSync(nodeId) as unknown as DbTelemetry[];
   }
 
   getLatestTelemetryForType(nodeId: string, telemetryType: string): DbTelemetry | null {
@@ -6820,14 +6667,7 @@ class DatabaseService {
       // The actual data will be fetched via API endpoints which can be async
       return null;
     }
-    const stmt = this.db.prepare(`
-      SELECT * FROM telemetry
-      WHERE nodeId = ? AND telemetryType = ?
-      ORDER BY timestamp DESC
-      LIMIT 1
-    `);
-    const telemetry = stmt.get(nodeId, telemetryType) as DbTelemetry | null;
-    return telemetry ? this.normalizeBigInts(telemetry) : null;
+    return this.telemetry.getLatestTelemetryForTypeSync(nodeId, telemetryType) as unknown as DbTelemetry | null;
   }
 
   /**
@@ -6864,12 +6704,7 @@ class DatabaseService {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       return [];
     }
-    const stmt = this.db.prepare(`
-      SELECT DISTINCT telemetryType FROM telemetry
-      WHERE nodeId = ?
-    `);
-    const results = stmt.all(nodeId) as Array<{ telemetryType: string }>;
-    return results.map(r => r.telemetryType);
+    return this.telemetry.getNodeTelemetryTypesSync(nodeId);
   }
 
   // Get all nodes with their telemetry types (cached for performance)
@@ -6899,16 +6734,7 @@ class DatabaseService {
     }
 
     // SQLite: query the database and update cache
-    const stmt = this.db.prepare(`
-      SELECT nodeId, GROUP_CONCAT(DISTINCT telemetryType) as types
-      FROM telemetry
-      GROUP BY nodeId
-    `);
-    const results = stmt.all() as Array<{ nodeId: string; types: string }>;
-    const map = new Map<string, string[]>();
-    results.forEach(r => {
-      map.set(r.nodeId, r.types ? r.types.split(',') : []);
-    });
+    const map = this.telemetry.getAllNodesTelemetryTypesSync();
 
     this.telemetryTypesCache = map;
     this.telemetryTypesCacheTime = now;
@@ -6937,16 +6763,7 @@ class DatabaseService {
     }
 
     // SQLite: query the database and update cache
-    const stmt = this.db.prepare(`
-      SELECT nodeId, GROUP_CONCAT(DISTINCT telemetryType) as types
-      FROM telemetry
-      GROUP BY nodeId
-    `);
-    const results = stmt.all() as Array<{ nodeId: string; types: string }>;
-    const map = new Map<string, string[]>();
-    results.forEach(r => {
-      map.set(r.nodeId, r.types ? r.types.split(',') : []);
-    });
+    const map = this.telemetry.getAllNodesTelemetryTypesSync();
 
     this.telemetryTypesCache = map;
     this.telemetryTypesCacheTime = now;
@@ -6981,9 +6798,9 @@ class DatabaseService {
     // Delete in order to respect foreign key constraints
     // First delete all child records that reference nodes
     this.db.exec('DELETE FROM messages');
-    this.db.exec('DELETE FROM telemetry');
-    this.db.exec('DELETE FROM traceroutes');
-    this.db.exec('DELETE FROM route_segments');
+    this.telemetry.deleteAllTelemetrySync();
+    this.traceroutes.deleteAllTraceroutesSync();
+    this.traceroutes.deleteAllRouteSegmentsSync();
     if (this.neighborsRepo) {
       // Use Drizzle repo for all backends (including SQLite)
       this.neighborsRepo.deleteAllNeighborInfo().catch(err =>
@@ -6992,6 +6809,8 @@ class DatabaseService {
     }
     // Finally delete the nodes themselves
     this.db.exec('DELETE FROM nodes');
+    // Telemetry cache invalidation after bulk purge
+    this.invalidateTelemetryTypesCache();
     logger.debug('✅ Successfully purged all nodes and related data');
   }
 
@@ -7003,6 +6822,7 @@ class DatabaseService {
       if (this.telemetryRepo) {
         this.telemetryRepo.deleteAllTelemetry().then(() => {
           logger.debug('✅ Successfully purged all telemetry');
+          this.invalidateTelemetryTypesCache();
         }).catch(err => {
           logger.error('Failed to purge all telemetry:', err);
         });
@@ -7012,7 +6832,8 @@ class DatabaseService {
       return;
     }
 
-    this.db.exec('DELETE FROM telemetry');
+    this.telemetry.deleteAllTelemetrySync();
+    this.invalidateTelemetryTypesCache();
   }
 
   purgeOldTelemetry(hoursToKeep: number, favoriteDaysToKeep?: number): number {
@@ -7064,10 +6885,10 @@ class DatabaseService {
 
     // If no favorite storage duration specified, purge all telemetry older than hoursToKeep
     if (!favoriteDaysToKeep) {
-      const stmt = this.db.prepare('DELETE FROM telemetry WHERE timestamp < ?');
-      const result = stmt.run(regularCutoffTime);
-      logger.debug(`🧹 Purged ${result.changes} old telemetry records (keeping last ${hoursToKeep} hours)`);
-      return Number(result.changes);
+      const deleted = this.telemetry.deleteOldTelemetrySync(regularCutoffTime);
+      logger.debug(`🧹 Purged ${deleted} old telemetry records (keeping last ${hoursToKeep} hours)`);
+      if (deleted > 0) this.invalidateTelemetryTypesCache();
+      return deleted;
     }
 
     // Get the list of favorited telemetry from settings
@@ -7083,42 +6904,28 @@ class DatabaseService {
 
     // If no favorites, just purge everything older than hoursToKeep
     if (favorites.length === 0) {
-      const stmt = this.db.prepare('DELETE FROM telemetry WHERE timestamp < ?');
-      const result = stmt.run(regularCutoffTime);
-      logger.debug(`🧹 Purged ${result.changes} old telemetry records (keeping last ${hoursToKeep} hours, no favorites)`);
-      return Number(result.changes);
+      const deleted = this.telemetry.deleteOldTelemetrySync(regularCutoffTime);
+      logger.debug(`🧹 Purged ${deleted} old telemetry records (keeping last ${hoursToKeep} hours, no favorites)`);
+      if (deleted > 0) this.invalidateTelemetryTypesCache();
+      return deleted;
     }
 
     // Calculate the cutoff time for favorited telemetry
     const favoriteCutoffTime = Date.now() - (favoriteDaysToKeep * 24 * 60 * 60 * 1000);
 
-    // Build a query to purge old telemetry, exempting favorited telemetry
-    // Purge non-favorited telemetry older than hoursToKeep
-    // Purge favorited telemetry older than favoriteDaysToKeep
-    let totalDeleted = 0;
-
-    // First, delete non-favorited telemetry older than regularCutoffTime
-    const conditions = favorites.map(() => '(nodeId = ? AND telemetryType = ?)').join(' OR ');
-    const params = favorites.flatMap(f => [f.nodeId, f.telemetryType]);
-
-    const deleteNonFavoritesStmt = this.db.prepare(
-      `DELETE FROM telemetry WHERE timestamp < ? AND NOT (${conditions})`
+    const { nonFavoritesDeleted, favoritesDeleted } = this.telemetry.deleteOldTelemetryWithFavoritesSync(
+      regularCutoffTime,
+      favoriteCutoffTime,
+      favorites
     );
-    const nonFavoritesResult = deleteNonFavoritesStmt.run(regularCutoffTime, ...params);
-    totalDeleted += Number(nonFavoritesResult.changes);
-
-    // Then, delete favorited telemetry older than favoriteCutoffTime
-    const deleteFavoritesStmt = this.db.prepare(
-      `DELETE FROM telemetry WHERE timestamp < ? AND (${conditions})`
-    );
-    const favoritesResult = deleteFavoritesStmt.run(favoriteCutoffTime, ...params);
-    totalDeleted += Number(favoritesResult.changes);
+    const totalDeleted = nonFavoritesDeleted + favoritesDeleted;
 
     logger.debug(
       `🧹 Purged ${totalDeleted} old telemetry records ` +
-      `(${nonFavoritesResult.changes} non-favorites older than ${hoursToKeep}h, ` +
-      `${favoritesResult.changes} favorites older than ${favoriteDaysToKeep}d)`
+      `(${nonFavoritesDeleted} non-favorites older than ${hoursToKeep}h, ` +
+      `${favoritesDeleted} favorites older than ${favoriteDaysToKeep}d)`
     );
+    if (totalDeleted > 0) this.invalidateTelemetryTypesCache();
     return totalDeleted;
   }
 
@@ -7130,11 +6937,13 @@ class DatabaseService {
 
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       await this.telemetry.deleteAllTelemetry();
+      this.invalidateTelemetryTypesCache();
       logger.debug('✅ Successfully purged all telemetry');
       return;
     }
 
-    this.db.exec('DELETE FROM telemetry');
+    this.telemetry.deleteAllTelemetrySync();
+    this.invalidateTelemetryTypesCache();
     logger.debug('✅ Successfully purged all telemetry');
   }
 
@@ -7178,12 +6987,12 @@ class DatabaseService {
       return totalDeleted;
     }
 
-    // SQLite: synchronous path
+    // SQLite: synchronous path via repository
     if (!favoriteDaysToKeep) {
-      const stmt = this.db.prepare('DELETE FROM telemetry WHERE timestamp < ?');
-      const result = stmt.run(regularCutoffTime);
-      logger.debug(`🧹 Purged ${result.changes} old telemetry records (keeping last ${hoursToKeep} hours)`);
-      return Number(result.changes);
+      const deleted = this.telemetry.deleteOldTelemetrySync(regularCutoffTime);
+      logger.debug(`🧹 Purged ${deleted} old telemetry records (keeping last ${hoursToKeep} hours)`);
+      if (deleted > 0) this.invalidateTelemetryTypesCache();
+      return deleted;
     }
 
     const favoritesStr = this.getSetting('telemetryFavorites');
@@ -7197,35 +7006,27 @@ class DatabaseService {
     }
 
     if (favorites.length === 0) {
-      const stmt = this.db.prepare('DELETE FROM telemetry WHERE timestamp < ?');
-      const result = stmt.run(regularCutoffTime);
-      logger.debug(`🧹 Purged ${result.changes} old telemetry records (keeping last ${hoursToKeep} hours, no favorites)`);
-      return Number(result.changes);
+      const deleted = this.telemetry.deleteOldTelemetrySync(regularCutoffTime);
+      logger.debug(`🧹 Purged ${deleted} old telemetry records (keeping last ${hoursToKeep} hours, no favorites)`);
+      if (deleted > 0) this.invalidateTelemetryTypesCache();
+      return deleted;
     }
 
     const favoriteCutoffTime = Date.now() - (favoriteDaysToKeep * 24 * 60 * 60 * 1000);
-    let totalDeleted = 0;
 
-    const conditions = favorites.map(() => '(nodeId = ? AND telemetryType = ?)').join(' OR ');
-    const params = favorites.flatMap(f => [f.nodeId, f.telemetryType]);
-
-    const deleteNonFavoritesStmt = this.db.prepare(
-      `DELETE FROM telemetry WHERE timestamp < ? AND NOT (${conditions})`
+    const { nonFavoritesDeleted, favoritesDeleted } = this.telemetry.deleteOldTelemetryWithFavoritesSync(
+      regularCutoffTime,
+      favoriteCutoffTime,
+      favorites
     );
-    const nonFavoritesResult = deleteNonFavoritesStmt.run(regularCutoffTime, ...params);
-    totalDeleted += Number(nonFavoritesResult.changes);
-
-    const deleteFavoritesStmt = this.db.prepare(
-      `DELETE FROM telemetry WHERE timestamp < ? AND (${conditions})`
-    );
-    const favoritesResult = deleteFavoritesStmt.run(favoriteCutoffTime, ...params);
-    totalDeleted += Number(favoritesResult.changes);
+    const totalDeleted = nonFavoritesDeleted + favoritesDeleted;
 
     logger.debug(
       `🧹 Purged ${totalDeleted} old telemetry records ` +
-      `(${nonFavoritesResult.changes} non-favorites older than ${hoursToKeep}h, ` +
-      `${favoritesResult.changes} favorites older than ${favoriteDaysToKeep}d)`
+      `(${nonFavoritesDeleted} non-favorites older than ${hoursToKeep}h, ` +
+      `${favoritesDeleted} favorites older than ${favoriteDaysToKeep}d)`
     );
+    if (totalDeleted > 0) this.invalidateTelemetryTypesCache();
     return totalDeleted;
   }
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1128,6 +1128,7 @@ class DatabaseService {
     // ROUTING TABLES
     // ============================================================
 
+    // eslint-disable-next-line no-restricted-syntax -- bootstrap: runs before migrations
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS traceroutes (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1145,6 +1146,7 @@ class DatabaseService {
       );
     `);
 
+    // eslint-disable-next-line no-restricted-syntax -- bootstrap: runs before migrations
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS route_segments (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1475,6 +1477,7 @@ class DatabaseService {
     // AUTOMATION TABLES
     // ============================================================
 
+    // eslint-disable-next-line no-restricted-syntax -- bootstrap: runs before migrations
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS auto_traceroute_nodes (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1484,6 +1487,7 @@ class DatabaseService {
       );
     `);
 
+    // eslint-disable-next-line no-restricted-syntax -- bootstrap: runs before migrations
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS auto_time_sync_nodes (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1493,6 +1497,7 @@ class DatabaseService {
       );
     `);
 
+    // eslint-disable-next-line no-restricted-syntax -- bootstrap: runs before migrations
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS auto_traceroute_log (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1682,6 +1687,7 @@ class DatabaseService {
     `);
 
     // Create index for efficient traceroute queries
+    // eslint-disable-next-line no-restricted-syntax -- bootstrap: runs before migrations
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_traceroutes_nodes
       ON traceroutes(fromNodeNum, toNodeNum, timestamp DESC);
@@ -1698,6 +1704,7 @@ class DatabaseService {
   }
 
   private createIndexes(): void {
+    // eslint-disable-next-line no-restricted-syntax -- bootstrap: runs before migrations
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_nodes_nodeId ON nodes(nodeId);
       CREATE INDEX IF NOT EXISTS idx_nodes_lastHeard ON nodes(lastHeard);
@@ -1733,9 +1740,8 @@ class DatabaseService {
     logger.debug('🔄 Running route segments migration...');
 
     try {
-      // Get ALL traceroutes from the database
-      const stmt = this.db.prepare('SELECT * FROM traceroutes ORDER BY timestamp ASC');
-      const allTraceroutes = stmt.all() as DbTraceroute[];
+      // Get ALL traceroutes from the database (bootstrap: runDataMigrations)
+      const allTraceroutes = this.traceroutes.getAllTraceroutesSync() as unknown as DbTraceroute[];
 
       logger.debug(`📊 Processing ${allTraceroutes.length} traceroutes for distance calculation...`);
 
@@ -3518,12 +3524,7 @@ class DatabaseService {
     }
 
     // Delete all traceroutes involving this node (either as source or destination)
-    const stmt = this.db.prepare(`
-      DELETE FROM traceroutes
-      WHERE fromNodeNum = ? OR toNodeNum = ?
-    `);
-    const result = stmt.run(nodeNum, nodeNum);
-    return Number(result.changes);
+    return this.traceroutes.deleteTraceroutesInvolvingNodeSync(nodeNum);
   }
 
   purgeNodeTelemetry(nodeNum: number): number {
@@ -3592,11 +3593,7 @@ class DatabaseService {
     const telemetryDeleted = this.purgeNodeTelemetry(nodeNum);
 
     // Delete route segments where this node is involved
-    const routeSegmentsStmt = this.db.prepare(`
-      DELETE FROM route_segments
-      WHERE fromNodeNum = ? OR toNodeNum = ?
-    `);
-    routeSegmentsStmt.run(nodeNum, nodeNum);
+    this.traceroutes.deleteRouteSegmentsInvolvingNodeSync(nodeNum);
 
     // Delete neighbor_info records where this node is involved (either as source or neighbor)
     if (this.neighborsRepo) {
@@ -4253,22 +4250,7 @@ class DatabaseService {
       return [];
     }
 
-    const query = `
-      SELECT id, fromNodeNum, toNodeNum, route, snrTowards, timestamp
-      FROM traceroutes
-      WHERE route IS NOT NULL AND route != '[]'
-      ORDER BY timestamp ASC
-    `;
-
-    const stmt = this.db.prepare(query);
-    return stmt.all() as Array<{
-      id: number;
-      fromNodeNum: number;
-      toNodeNum: number;
-      route: string | null;
-      snrTowards: string | null;
-      timestamp: number;
-    }>;
+    return this.traceroutesRepo!.getCompletedTraceroutesForMigrationSync();
   }
 
   /**
@@ -4586,127 +4568,13 @@ class DatabaseService {
       return;
     }
 
-    // SQLite: Wrap in transaction to prevent race conditions
-    const transaction = this.db.transaction(() => {
-      const now = Date.now();
-      const pendingTimeoutAgo = now - PENDING_TRACEROUTE_TIMEOUT_MS;
-
-      // Check if there's a pending traceroute request (with null route) within the timeout window
-      // NOTE: When a traceroute response comes in, fromNum is the destination (responder) and toNum is the local node (requester)
-      // But when we created the pending record, fromNodeNum was the local node and toNodeNum was the destination
-      // So we need to check the REVERSE direction (toNum -> fromNum instead of fromNum -> toNum)
-      const findPendingStmt = this.db.prepare(
-        sourceId !== undefined
-          ? `SELECT id FROM traceroutes
-             WHERE fromNodeNum = ? AND toNodeNum = ?
-             AND route IS NULL
-             AND timestamp >= ?
-             AND sourceId = ?
-             ORDER BY timestamp DESC
-             LIMIT 1`
-          : `SELECT id FROM traceroutes
-             WHERE fromNodeNum = ? AND toNodeNum = ?
-             AND route IS NULL
-             AND timestamp >= ?
-             ORDER BY timestamp DESC
-             LIMIT 1`
-      );
-
-      const pendingRecord = (sourceId !== undefined
-        ? findPendingStmt.get(
-            tracerouteData.toNodeNum,
-            tracerouteData.fromNodeNum,
-            pendingTimeoutAgo,
-            sourceId
-          )
-        : findPendingStmt.get(
-            tracerouteData.toNodeNum,
-            tracerouteData.fromNodeNum,
-            pendingTimeoutAgo
-          )) as { id: number } | undefined;
-
-      if (pendingRecord) {
-        // Update the existing pending record with the response data
-        const updateStmt = this.db.prepare(`
-          UPDATE traceroutes
-          SET route = ?, routeBack = ?, snrTowards = ?, snrBack = ?, timestamp = ?
-          WHERE id = ?
-        `);
-
-        updateStmt.run(
-          tracerouteData.route || null,
-          tracerouteData.routeBack || null,
-          tracerouteData.snrTowards || null,
-          tracerouteData.snrBack || null,
-          tracerouteData.timestamp,
-          pendingRecord.id
-        );
-      } else {
-        // No pending request found, insert a new traceroute record
-        const insertStmt = this.db.prepare(`
-          INSERT INTO traceroutes (
-            fromNodeNum, toNodeNum, fromNodeId, toNodeId, route, routeBack, snrTowards, snrBack, timestamp, createdAt, sourceId
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        `);
-
-        insertStmt.run(
-          tracerouteData.fromNodeNum,
-          tracerouteData.toNodeNum,
-          tracerouteData.fromNodeId,
-          tracerouteData.toNodeId,
-          tracerouteData.route || null,
-          tracerouteData.routeBack || null,
-          tracerouteData.snrTowards || null,
-          tracerouteData.snrBack || null,
-          tracerouteData.timestamp,
-          tracerouteData.createdAt,
-          sourceId ?? null
-        );
-      }
-
-      // Keep only the last N traceroutes for this source-destination pair
-      // Delete older traceroutes beyond the limit
-      const deleteOldStmt = this.db.prepare(
-        sourceId !== undefined
-          ? `DELETE FROM traceroutes
-             WHERE fromNodeNum = ? AND toNodeNum = ? AND sourceId = ?
-             AND id NOT IN (
-               SELECT id FROM traceroutes
-               WHERE fromNodeNum = ? AND toNodeNum = ? AND sourceId = ?
-               ORDER BY timestamp DESC
-               LIMIT ?
-             )`
-          : `DELETE FROM traceroutes
-             WHERE fromNodeNum = ? AND toNodeNum = ?
-             AND id NOT IN (
-               SELECT id FROM traceroutes
-               WHERE fromNodeNum = ? AND toNodeNum = ?
-               ORDER BY timestamp DESC
-               LIMIT ?
-             )`
-      );
-      if (sourceId !== undefined) {
-        deleteOldStmt.run(
-          tracerouteData.fromNodeNum,
-          tracerouteData.toNodeNum,
-          sourceId,
-          tracerouteData.fromNodeNum,
-          tracerouteData.toNodeNum,
-          sourceId,
-          TRACEROUTE_HISTORY_LIMIT
-        );
-      } else {
-        deleteOldStmt.run(
-          tracerouteData.fromNodeNum,
-          tracerouteData.toNodeNum,
-          tracerouteData.fromNodeNum,
-          tracerouteData.toNodeNum,
-          TRACEROUTE_HISTORY_LIMIT
-        );
-      }
-    });
-
-    transaction();
+    // SQLite: delegate to repository sync upsert (runs in a transaction)
+    this.traceroutes.upsertTracerouteSync(
+      tracerouteData,
+      PENDING_TRACEROUTE_TIMEOUT_MS,
+      TRACEROUTE_HISTORY_LIMIT,
+      sourceId
+    );
   }
 
   getTraceroutesByNodes(fromNodeNum: number, toNodeNum: number, limit: number = 10): DbTraceroute[] {
@@ -4731,16 +4599,7 @@ class DatabaseService {
     }
 
     // Search bidirectionally to capture traceroutes initiated from either direction
-    // This is especially important for 3rd party traceroutes (e.g., via Virtual Node)
-    // where the stored direction might be reversed from what's being queried
-    const stmt = this.db.prepare(`
-      SELECT * FROM traceroutes
-      WHERE (fromNodeNum = ? AND toNodeNum = ?) OR (fromNodeNum = ? AND toNodeNum = ?)
-      ORDER BY timestamp DESC
-      LIMIT ?
-    `);
-    const traceroutes = stmt.all(fromNodeNum, toNodeNum, toNodeNum, fromNodeNum, limit) as DbTraceroute[];
-    return traceroutes.map(t => this.normalizeBigInts(t));
+    return this.traceroutes.getTraceroutesByNodesSync(fromNodeNum, toNodeNum, limit) as unknown as DbTraceroute[];
   }
 
   getAllTraceroutes(limit: number = 100): DbTraceroute[] {
@@ -4765,13 +4624,7 @@ class DatabaseService {
       return this._traceroutesCache || [];
     }
 
-    const stmt = this.db.prepare(`
-      SELECT * FROM traceroutes
-      ORDER BY timestamp DESC
-      LIMIT ?
-    `);
-    const traceroutes = stmt.all(limit) as DbTraceroute[];
-    return traceroutes.map(t => this.normalizeBigInts(t));
+    return this.traceroutes.getAllTraceroutesRecentSync(limit) as unknown as DbTraceroute[];
   }
 
   getNodeNeedingTraceroute(localNodeNum: number): DbNode | null {
@@ -4821,40 +4674,12 @@ class DatabaseService {
     // Two categories:
     // 1. Nodes with no successful traceroute: retry every 3 hours
     // 2. Nodes with successful traceroute: retry every 24 hours
-    const stmt = this.db.prepare(`
-      SELECT n.*,
-        (SELECT COUNT(*) FROM traceroutes t
-         WHERE t.fromNodeNum = ? AND t.toNodeNum = n.nodeNum) as hasTraceroute
-      FROM nodes n
-      WHERE n.nodeNum != ?
-        AND n.lastHeard > ?
-        AND (
-          -- Category 1: No traceroute exists, and (never requested OR requested > 3 hours ago)
-          (
-            (SELECT COUNT(*) FROM traceroutes t
-             WHERE t.fromNodeNum = ? AND t.toNodeNum = n.nodeNum) = 0
-            AND (n.lastTracerouteRequest IS NULL OR n.lastTracerouteRequest < ?)
-          )
-          OR
-          -- Category 2: Traceroute exists, and (never requested OR requested > expiration hours ago)
-          (
-            (SELECT COUNT(*) FROM traceroutes t
-             WHERE t.fromNodeNum = ? AND t.toNodeNum = n.nodeNum) > 0
-            AND (n.lastTracerouteRequest IS NULL OR n.lastTracerouteRequest < ?)
-          )
-        )
-      ORDER BY n.lastHeard DESC
-    `);
-
-    let eligibleNodes = stmt.all(
-      localNodeNum,
+    let eligibleNodes = this.traceroutesRepo!.getEligibleTracerouteCandidatesSync(
       localNodeNum,
       activeNodeCutoff,
-      localNodeNum,
       now - THREE_HOURS_MS,
-      localNodeNum,
       now - EXPIRATION_MS
-    ) as DbNode[];
+    ) as unknown as DbNode[];
 
     // Apply last-heard filter (AND logic — applied before OR union filters)
     if (filterLastHeardEnabled) {
@@ -5254,51 +5079,26 @@ class DatabaseService {
     const fromNodeId = `!${fromNodeNum.toString(16).padStart(8, '0')}`;
     const toNodeId = `!${toNodeNum.toString(16).padStart(8, '0')}`;
 
-    const insertStmt = this.db.prepare(`
-      INSERT INTO traceroutes (
-        fromNodeNum, toNodeNum, fromNodeId, toNodeId, route, routeBack, snrTowards, snrBack, timestamp, createdAt, sourceId
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-
-    insertStmt.run(
-      fromNodeNum,
-      toNodeNum,
-      fromNodeId,
-      toNodeId,
-      null, // route will be null until response received
-      null, // routeBack will be null until response received
-      null, // snrTowards will be null until response received
-      null, // snrBack will be null until response received
-      now,
-      now,
-      sourceId ?? null
+    // upsertTracerouteSync handles insert + history prune in a transaction.
+    // Using a pending timeout of 0 guarantees no "pending match" occurs so
+    // we always insert a new pending record (matching legacy behavior).
+    this.traceroutes.upsertTracerouteSync(
+      {
+        fromNodeNum,
+        toNodeNum,
+        fromNodeId,
+        toNodeId,
+        route: null as unknown as string,
+        routeBack: null as unknown as string,
+        snrTowards: null as unknown as string,
+        snrBack: null as unknown as string,
+        timestamp: now,
+        createdAt: now,
+      } as DbTraceroute,
+      0,
+      TRACEROUTE_HISTORY_LIMIT,
+      sourceId
     );
-
-    // Keep only the last N traceroutes for this source-destination pair
-    const deleteOldStmt = this.db.prepare(
-      sourceId !== undefined
-        ? `DELETE FROM traceroutes
-           WHERE fromNodeNum = ? AND toNodeNum = ? AND sourceId = ?
-           AND id NOT IN (
-             SELECT id FROM traceroutes
-             WHERE fromNodeNum = ? AND toNodeNum = ? AND sourceId = ?
-             ORDER BY timestamp DESC
-             LIMIT ?
-           )`
-        : `DELETE FROM traceroutes
-           WHERE fromNodeNum = ? AND toNodeNum = ?
-           AND id NOT IN (
-             SELECT id FROM traceroutes
-             WHERE fromNodeNum = ? AND toNodeNum = ?
-             ORDER BY timestamp DESC
-             LIMIT ?
-           )`
-    );
-    if (sourceId !== undefined) {
-      deleteOldStmt.run(fromNodeNum, toNodeNum, sourceId, fromNodeNum, toNodeNum, sourceId, TRACEROUTE_HISTORY_LIMIT);
-    } else {
-      deleteOldStmt.run(fromNodeNum, toNodeNum, fromNodeNum, toNodeNum, TRACEROUTE_HISTORY_LIMIT);
-    }
   }
 
   // Auto-traceroute node filter methods
@@ -5306,42 +5106,14 @@ class DatabaseService {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       throw new Error(`SQLite method 'getAutoTracerouteNodes' called but using ${this.drizzleDbType} database. Use getAutoTracerouteNodesAsync() instead.`);
     }
-    const stmt = this.db.prepare(`
-      SELECT nodeNum FROM auto_traceroute_nodes
-      ORDER BY createdAt ASC
-    `);
-    const nodes = stmt.all() as { nodeNum: number }[];
-    return nodes.map(n => Number(n.nodeNum));
+    return this.misc!.getAutoTracerouteNodesSync();
   }
 
   setAutoTracerouteNodes(nodeNums: number[]): void {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       throw new Error(`SQLite method 'setAutoTracerouteNodes' called but using ${this.drizzleDbType} database. Use setAutoTracerouteNodesAsync() instead.`);
     }
-    const now = Date.now();
-
-    // Use a transaction for atomic operation
-    const deleteStmt = this.db.prepare('DELETE FROM auto_traceroute_nodes');
-    const insertStmt = this.db.prepare(`
-      INSERT INTO auto_traceroute_nodes (nodeNum, createdAt)
-      VALUES (?, ?)
-    `);
-
-    this.db.transaction(() => {
-      // Clear existing entries
-      deleteStmt.run();
-
-      // Insert new entries
-      for (const nodeNum of nodeNums) {
-        try {
-          insertStmt.run(nodeNum, now);
-        } catch (error) {
-          // Ignore duplicate entries or foreign key violations
-          logger.debug(`Skipping invalid nodeNum: ${nodeNum}`, error);
-        }
-      }
-    })();
-
+    this.misc!.setAutoTracerouteNodesSync(nodeNums);
     logger.debug(`✅ Set auto-traceroute filter to ${nodeNums.length} nodes`);
   }
 
@@ -5801,47 +5573,16 @@ class DatabaseService {
 
   // Auto-traceroute log methods
   logAutoTracerouteAttempt(toNodeNum: number, toNodeName: string | null, sourceId?: string): number {
-    const now = Date.now();
-    const stmt = this.db.prepare(`
-      INSERT INTO auto_traceroute_log (timestamp, to_node_num, to_node_name, success, created_at, sourceId)
-      VALUES (?, ?, ?, NULL, ?, ?)
-    `);
-    const result = stmt.run(now, toNodeNum, toNodeName, now, sourceId ?? null);
-
-    // Clean up old entries (keep last 100)
-    const cleanupStmt = this.db.prepare(`
-      DELETE FROM auto_traceroute_log
-      WHERE id NOT IN (
-        SELECT id FROM auto_traceroute_log
-        ORDER BY timestamp DESC
-        LIMIT 100
-      )
-    `);
-    cleanupStmt.run();
-
-    return result.lastInsertRowid as number;
+    return this.misc!.logAutoTracerouteAttemptSync(toNodeNum, toNodeName, sourceId);
   }
 
   updateAutoTracerouteResult(logId: number, success: boolean): void {
-    const stmt = this.db.prepare(`
-      UPDATE auto_traceroute_log SET success = ? WHERE id = ?
-    `);
-    stmt.run(success ? 1 : 0, logId);
+    this.misc!.updateAutoTracerouteResultSync(logId, success);
   }
 
   // Update the most recent pending auto-traceroute for a given destination
   updateAutoTracerouteResultByNode(toNodeNum: number, success: boolean): void {
-    const stmt = this.db.prepare(`
-      UPDATE auto_traceroute_log
-      SET success = ?
-      WHERE id = (
-        SELECT id FROM auto_traceroute_log
-        WHERE to_node_num = ? AND success IS NULL
-        ORDER BY timestamp DESC
-        LIMIT 1
-      )
-    `);
-    stmt.run(success ? 1 : 0, toNodeNum);
+    this.misc!.updateAutoTracerouteResultByNodeSync(toNodeNum, success);
   }
 
   getAutoTracerouteLog(limit: number = 10, sourceId?: string): {
@@ -5855,33 +5596,7 @@ class DatabaseService {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       return [];
     }
-
-    const stmt = sourceId
-      ? this.db.prepare(`
-          SELECT id, timestamp, to_node_num as toNodeNum, to_node_name as toNodeName, success
-          FROM auto_traceroute_log
-          WHERE sourceId = ?
-          ORDER BY timestamp DESC
-          LIMIT ?
-        `)
-      : this.db.prepare(`
-          SELECT id, timestamp, to_node_num as toNodeNum, to_node_name as toNodeName, success
-          FROM auto_traceroute_log
-          ORDER BY timestamp DESC
-          LIMIT ?
-        `);
-    const results = (sourceId ? stmt.all(sourceId, limit) : stmt.all(limit)) as {
-      id: number;
-      timestamp: number;
-      toNodeNum: number;
-      toNodeName: string | null;
-      success: number | null;
-    }[];
-
-    return results.map(r => ({
-      ...r,
-      success: r.success === null ? null : r.success === 1
-    }));
+    return this.misc!.getAutoTracerouteLogSync(limit, sourceId);
   }
 
   /**
@@ -5898,45 +5613,7 @@ class DatabaseService {
       // Fallback to sync for SQLite
       return this.getAutoTracerouteLog(limit, sourceId);
     }
-
-    try {
-      let results: any[] = [];
-
-      if (this.drizzleDbType === 'postgres' && this.postgresPool) {
-        const result = sourceId
-          ? await this.postgresPool.query(
-              `SELECT id, timestamp, to_node_num, to_node_name, success FROM auto_traceroute_log WHERE "sourceId" = $1 ORDER BY timestamp DESC LIMIT $2`,
-              [sourceId, limit]
-            )
-          : await this.postgresPool.query(
-              `SELECT id, timestamp, to_node_num, to_node_name, success FROM auto_traceroute_log ORDER BY timestamp DESC LIMIT $1`,
-              [limit]
-            );
-        results = result.rows || [];
-      } else if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
-        const [rows] = sourceId
-          ? await this.mysqlPool.query(
-              `SELECT id, timestamp, to_node_num, to_node_name, success FROM auto_traceroute_log WHERE sourceId = ? ORDER BY timestamp DESC LIMIT ?`,
-              [sourceId, limit]
-            )
-          : await this.mysqlPool.query(
-              `SELECT id, timestamp, to_node_num, to_node_name, success FROM auto_traceroute_log ORDER BY timestamp DESC LIMIT ?`,
-              [limit]
-            );
-        results = rows as any[] || [];
-      }
-
-      return results.map((r: any) => ({
-        id: Number(r.id),
-        timestamp: Number(r.timestamp),
-        toNodeNum: Number(r.to_node_num),
-        toNodeName: r.to_node_name,
-        success: r.success === null ? null : Boolean(r.success)
-      }));
-    } catch (error) {
-      logger.error(`[DatabaseService] Failed to get auto traceroute log async: ${error}`);
-      return [];
-    }
+    return this.misc!.getAutoTracerouteLog(limit, sourceId);
   }
 
   /**
@@ -5947,55 +5624,7 @@ class DatabaseService {
       // Fallback to sync for SQLite
       return this.logAutoTracerouteAttempt(toNodeNum, toNodeName, sourceId);
     }
-
-    const now = Date.now();
-
-    try {
-      let insertedId = 0;
-
-      if (this.drizzleDbType === 'postgres' && this.postgresPool) {
-        const result = await this.postgresPool.query(
-          `INSERT INTO auto_traceroute_log (timestamp, to_node_num, to_node_name, success, created_at, "sourceId")
-           VALUES ($1, $2, $3, NULL, $4, $5) RETURNING id`,
-          [now, toNodeNum, toNodeName, now, sourceId ?? null]
-        );
-        insertedId = result.rows[0]?.id || 0;
-
-        // Clean up old entries (keep last 100)
-        await this.postgresPool.query(`
-          DELETE FROM auto_traceroute_log
-          WHERE id NOT IN (
-            SELECT id FROM auto_traceroute_log
-            ORDER BY timestamp DESC
-            LIMIT 100
-          )
-        `);
-      } else if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
-        const [result] = await this.mysqlPool.query(
-          `INSERT INTO auto_traceroute_log (timestamp, to_node_num, to_node_name, success, created_at, sourceId)
-           VALUES (?, ?, ?, NULL, ?, ?)`,
-          [now, toNodeNum, toNodeName, now, sourceId ?? null]
-        ) as any;
-        insertedId = result.insertId || 0;
-
-        // Clean up old entries (keep last 100)
-        await this.mysqlPool.query(`
-          DELETE FROM auto_traceroute_log
-          WHERE id NOT IN (
-            SELECT id FROM (
-              SELECT id FROM auto_traceroute_log
-              ORDER BY timestamp DESC
-              LIMIT 100
-            ) AS keep_ids
-          )
-        `);
-      }
-
-      return insertedId;
-    } catch (error) {
-      logger.error(`[DatabaseService] Failed to log auto traceroute attempt async: ${error}`);
-      return 0;
-    }
+    return this.misc!.logAutoTracerouteAttempt(toNodeNum, toNodeName, sourceId);
   }
 
   /**
@@ -6007,36 +5636,7 @@ class DatabaseService {
       this.updateAutoTracerouteResultByNode(toNodeNum, success);
       return;
     }
-
-    try {
-      if (this.drizzleDbType === 'postgres' && this.postgresPool) {
-        await this.postgresPool.query(`
-          UPDATE auto_traceroute_log
-          SET success = $1
-          WHERE id = (
-            SELECT id FROM auto_traceroute_log
-            WHERE to_node_num = $2 AND success IS NULL
-            ORDER BY timestamp DESC
-            LIMIT 1
-          )
-        `, [success ? 1 : 0, toNodeNum]);
-      } else if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
-        await this.mysqlPool.query(`
-          UPDATE auto_traceroute_log
-          SET success = ?
-          WHERE id = (
-            SELECT id FROM (
-              SELECT id FROM auto_traceroute_log
-              WHERE to_node_num = ? AND success IS NULL
-              ORDER BY timestamp DESC
-              LIMIT 1
-            ) AS subq
-          )
-        `, [success ? 1 : 0, toNodeNum]);
-      }
-    } catch (error) {
-      logger.error(`[DatabaseService] Failed to update auto traceroute result async: ${error}`);
-    }
+    await this.misc!.updateAutoTracerouteResultByNode(toNodeNum, success);
   }
 
   // Auto key repair state methods
@@ -7240,23 +6840,7 @@ class DatabaseService {
     }
 
     // SQLite path
-    const stmt = this.db.prepare(`
-      INSERT INTO route_segments (
-        fromNodeNum, toNodeNum, fromNodeId, toNodeId, distanceKm, isRecordHolder, timestamp, createdAt, sourceId
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-
-    stmt.run(
-      segmentData.fromNodeNum,
-      segmentData.toNodeNum,
-      segmentData.fromNodeId,
-      segmentData.toNodeId,
-      segmentData.distanceKm,
-      segmentData.isRecordHolder ? 1 : 0,
-      segmentData.timestamp,
-      segmentData.createdAt,
-      sourceId ?? null,
-    );
+    this.traceroutesRepo!.insertRouteSegmentSync(segmentData, sourceId);
   }
 
   getLongestActiveRouteSegment(sourceId?: string): DbRouteSegment | null {
@@ -7264,25 +6848,7 @@ class DatabaseService {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       return null;
     }
-    // Get the longest segment from recent traceroutes (within last 7 days)
-    const cutoff = Date.now() - (7 * 24 * 60 * 60 * 1000);
-    const stmt = sourceId !== undefined
-      ? this.db.prepare(`
-          SELECT * FROM route_segments
-          WHERE timestamp > ? AND sourceId IS ?
-          ORDER BY distanceKm DESC
-          LIMIT 1
-        `)
-      : this.db.prepare(`
-          SELECT * FROM route_segments
-          WHERE timestamp > ?
-          ORDER BY distanceKm DESC
-          LIMIT 1
-        `);
-    const segment = (sourceId !== undefined
-      ? stmt.get(cutoff, sourceId)
-      : stmt.get(cutoff)) as DbRouteSegment | null;
-    return segment ? this.normalizeBigInts(segment) : null;
+    return this.traceroutesRepo!.getLongestActiveRouteSegmentSync(sourceId) as unknown as DbRouteSegment | null;
   }
 
   getRecordHolderRouteSegment(sourceId?: string): DbRouteSegment | null {
@@ -7290,23 +6856,7 @@ class DatabaseService {
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       return null;
     }
-    const stmt = sourceId !== undefined
-      ? this.db.prepare(`
-          SELECT * FROM route_segments
-          WHERE isRecordHolder = 1 AND sourceId IS ?
-          ORDER BY distanceKm DESC
-          LIMIT 1
-        `)
-      : this.db.prepare(`
-          SELECT * FROM route_segments
-          WHERE isRecordHolder = 1
-          ORDER BY distanceKm DESC
-          LIMIT 1
-        `);
-    const segment = (sourceId !== undefined
-      ? stmt.get(sourceId)
-      : stmt.get()) as DbRouteSegment | null;
-    return segment ? this.normalizeBigInts(segment) : null;
+    return this.traceroutesRepo!.getRecordHolderRouteSegmentSync(sourceId) as unknown as DbRouteSegment | null;
   }
 
   updateRecordHolderSegment(newSegment: DbRouteSegment, sourceId?: string): void {
@@ -7336,11 +6886,7 @@ class DatabaseService {
     if (!currentRecord || newSegment.distanceKm > currentRecord.distanceKm) {
       // Clear existing record holders for this source (IS NULL when scope is
       // global, exact match when scoped — keeps per-source records independent).
-      if (sourceId !== undefined) {
-        this.db.prepare('UPDATE route_segments SET isRecordHolder = 0 WHERE sourceId IS ?').run(sourceId);
-      } else {
-        this.db.exec('UPDATE route_segments SET isRecordHolder = 0');
-      }
+      this.traceroutesRepo!.clearRecordHolderSegmentSync(sourceId);
 
       // Insert new record holder
       this.insertRouteSegment({
@@ -7364,11 +6910,7 @@ class DatabaseService {
       return;
     }
 
-    if (sourceId !== undefined) {
-      this.db.prepare('UPDATE route_segments SET isRecordHolder = 0 WHERE sourceId IS ?').run(sourceId);
-    } else {
-      this.db.exec('UPDATE route_segments SET isRecordHolder = 0');
-    }
+    this.traceroutesRepo!.clearRecordHolderSegmentSync(sourceId);
     logger.debug('🗑️ Cleared record holder route segment');
   }
 
@@ -7383,22 +6925,7 @@ class DatabaseService {
       return 0;
     }
 
-    const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
-    if (sourceId !== undefined) {
-      const stmt = this.db.prepare(`
-        DELETE FROM route_segments
-        WHERE timestamp < ? AND isRecordHolder = 0 AND sourceId IS ?
-      `);
-      const result = stmt.run(cutoff, sourceId);
-      return Number(result.changes);
-    }
-
-    const stmt = this.db.prepare(`
-      DELETE FROM route_segments
-      WHERE timestamp < ? AND isRecordHolder = 0
-    `);
-    const result = stmt.run(cutoff);
-    return Number(result.changes);
+    return this.traceroutesRepo!.cleanupOldRouteSegmentsSync(days, sourceId);
   }
 
   /**
@@ -7415,10 +6942,7 @@ class DatabaseService {
       return 0;
     }
 
-    const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
-    const stmt = this.db.prepare('DELETE FROM traceroutes WHERE timestamp < ?');
-    const result = stmt.run(cutoff);
-    return Number(result.changes);
+    return this.traceroutesRepo!.cleanupOldTraceroutesSync(days);
   }
 
   /**


### PR DESCRIPTION
## Summary
Batches **Task 2.7 (telemetry)** and **Task 2.8 (traceroutes)** from the Drizzle ORM remediation plan into one PR.

- **Telemetry**: extracts all telemetry-table raw SQL from `src/services/database.ts` to `TelemetryRepository`, adding sync variants on `better-sqlite3` following the Phase 2.3 pattern. Cache invalidation (`invalidateTelemetryTypesCache`) still fires on the facade write path.
- **Traceroutes**: extracts all traceroute, `route_segments`, `auto_traceroute_nodes`, `auto_traceroute_log`, and `auto_time_sync_nodes` runtime SQL to `TraceroutesRepository` + `MiscRepository`. Retention-based purging preserved. Bootstrap CREATE TABLE/INDEX statements retained with `eslint-disable no-restricted-syntax -- bootstrap` markers (they run before migrations).

## Test plan
- [x] `npx tsc --noEmit` → exit 0
- [x] `vitest run src/db/repositories/telemetry src/db/repositories/traceroutes` → 114 pass / 29 skipped / 0 fail
- [x] `npm test` → 4209 pass / 0 fail
- [x] Runtime telemetry/traceroute `db.prepare`/`db.exec` in `database.ts` → 0 (only bootstrap-tagged CREATE TABLE remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)