### PR TITLE
refactor(db): Phase 3 close-out — final 14 sites, ESLint rule, CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,13 @@ When adding a new user-configurable setting:
 - Schema definitions live in `src/db/schema/` — one file per domain, with separate table definitions per backend (SQLite/PostgreSQL/MySQL).
 - When modifying schema, ensure column names and types are consistent across all three backend definitions.
 
+### Raw SQL Ban
+
+- `src/services/database.ts` is raw-SQL-free. All domain queries live in `src/db/repositories/*`.
+- ESLint rule (`no-restricted-syntax`) forbids `this.db.prepare`, `this.db.exec`, `postgresPool.query`, `mysqlPool.query` outside `src/server/migrations/**` and test files.
+- Intentional exceptions (bootstrap, diagnostic, system metadata) must carry an `// eslint-disable-next-line no-restricted-syntax -- <reason>` comment.
+- When adding a query: add an async method to the appropriate repo, expose via DatabaseService facade with `Async` suffix.
+
 ### Migration Registry System
 
 Migrations use a centralized registry in `src/db/migrations.ts`. Each migration is registered with functions for all three backends.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,40 @@ export default [
       ],
       'no-control-regex': 'off',
       'prefer-const': 'warn',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "CallExpression[callee.object.property.name='db'][callee.property.name='prepare']",
+          message: "Raw SQL forbidden outside src/server/migrations/. Use Drizzle repository in src/db/repositories/. For intentional raw (bootstrap/diagnostic), add eslint-disable-next-line with reason.",
+        },
+        {
+          selector: "CallExpression[callee.object.property.name='db'][callee.property.name='exec']",
+          message: "Raw SQL forbidden outside src/server/migrations/. Use Drizzle repository in src/db/repositories/. For intentional raw (bootstrap/diagnostic), add eslint-disable-next-line with reason.",
+        },
+        {
+          selector: "CallExpression[callee.object.property.name='postgresPool'][callee.property.name='query']",
+          message: "Raw SQL forbidden outside src/server/migrations/. Use Drizzle repository in src/db/repositories/. For intentional raw (bootstrap/diagnostic), add eslint-disable-next-line with reason.",
+        },
+        {
+          selector: "CallExpression[callee.object.property.name='mysqlPool'][callee.property.name='query']",
+          message: "Raw SQL forbidden outside src/server/migrations/. Use Drizzle repository in src/db/repositories/. For intentional raw (bootstrap/diagnostic), add eslint-disable-next-line with reason.",
+        },
+      ],
+    },
+  },
+  {
+    // Migrations are allowed to use raw SQL — they predate the schema/repos.
+    // Test files are allowed to use raw SQL for fixture setup/verification.
+    files: [
+      'src/server/migrations/**',
+      'src/db/migrations.ts',
+      '**/*.test.ts',
+      '**/*.test.tsx',
+      '**/*.spec.ts',
+      '**/*.spec.tsx',
+    ],
+    rules: {
+      'no-restricted-syntax': 'off',
     },
   },
   {

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -904,6 +904,77 @@ export class NodesRepository extends BaseRepository {
       .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
   }
 
+  /**
+   * Update spam detection flags for a node, scoped per-source (Drizzle, all backends).
+   * Used by DatabaseService.updateNodeSpamFlagsAsync for PG/MySQL paths.
+   */
+  async updateNodeExcessivePacketsAsync(
+    nodeNum: number,
+    isExcessivePackets: boolean,
+    packetRatePerHour: number,
+    lastChecked: number,
+    sourceId: string
+  ): Promise<void> {
+    const now = Date.now();
+    const { nodes } = this.tables;
+    await this.db
+      .update(nodes)
+      .set({
+        isExcessivePackets,
+        packetRatePerHour,
+        packetRateLastChecked: lastChecked,
+        updatedAt: now,
+      } as any)
+      .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+  }
+
+  /**
+   * Update time offset detection flags for a node, scoped per-source (Drizzle, all backends).
+   * Used by DatabaseService.updateNodeTimeOffsetFlagsAsync for PG/MySQL paths.
+   */
+  async updateNodeTimeOffsetAsync(
+    nodeNum: number,
+    isTimeOffsetIssue: boolean,
+    timeOffsetSeconds: number | null,
+    sourceId: string
+  ): Promise<void> {
+    const now = Date.now();
+    const { nodes } = this.tables;
+    await this.db
+      .update(nodes)
+      .set({
+        isTimeOffsetIssue,
+        timeOffsetSeconds,
+        updatedAt: now,
+      } as any)
+      .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+  }
+
+  /**
+   * Delete inactive nodes for a specific source (Drizzle, all backends).
+   * Returns the count of rows deleted. Mirrors deleteInactiveNodesForSourceSqlite,
+   * but works on Postgres/MySQL via Drizzle's async delete builder.
+   */
+  async cleanupInactiveNodesForSourceAsync(days: number, sourceId: string): Promise<number> {
+    const cutoff = this.now() - (days * 24 * 60 * 60 * 1000);
+    const { nodes } = this.tables;
+
+    // Pre-count rows that will match so we can return an accurate affected count
+    // across all backends (the per-driver result shape varies for delete()).
+    const matching = await this.db
+      .select({ nodeNum: nodes.nodeNum })
+      .from(nodes)
+      .where(and(lt(nodes.lastHeard, cutoff), eq(nodes.sourceId, sourceId)));
+
+    if (matching.length === 0) return 0;
+
+    await this.db
+      .delete(nodes)
+      .where(and(lt(nodes.lastHeard, cutoff), eq(nodes.sourceId, sourceId)));
+
+    return matching.length;
+  }
+
   // ===========================================================================
   // SQLite-only synchronous variants (for legacy sync facade delegations)
   // These mirror the async versions above but run on better-sqlite3 synchronously

--- a/src/db/repositories/notifications.ts
+++ b/src/db/repositories/notifications.ts
@@ -7,7 +7,7 @@
  *
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, desc, sql, and, or, lte } from 'drizzle-orm';
+import { eq, desc, sql, and, or, lte, isNull, ne } from 'drizzle-orm';
 import {
   readMessagesSqlite,
 } from '../schema/notifications.js';
@@ -734,6 +734,145 @@ export class NotificationsRepository extends BaseRepository {
       }
     } catch (error) {
       logger.error(`Failed to mark messages as read by IDs:`, error);
+    }
+  }
+
+  // ============ UNREAD COUNTS (Drizzle, all backends) ============
+
+  /**
+   * Build a `read_messages` LEFT JOIN ON-clause that mirrors the legacy
+   * `m.id = rm.messageId AND rm.userId IS NULL` (anonymous) or
+   * `m.id = rm.messageId AND rm.userId = ?` (authenticated) pattern used by
+   * the unread-count queries.
+   *
+   * Note: the SQLite schema uses `messageId` as the PRIMARY KEY (no separate
+   * `userId` per row prior to multi-user). The PG/MySQL schemas use `userId`
+   * as a real column. Drizzle handles the column-name mapping per dialect.
+   */
+  private unreadJoinOn(userId: number | null) {
+    const messages = this.tables.messages;
+    const readMessages = this.tables.readMessages;
+    if (userId === null) {
+      // Anonymous: any read row at all blocks the message from showing as unread
+      return eq(messages.id, readMessages.messageId);
+    }
+    return and(
+      eq(messages.id, readMessages.messageId),
+      eq(readMessages.userId, userId)
+    );
+  }
+
+  /**
+   * Count unread channel messages grouped by channel (excludes DMs / channel = -1).
+   * Returns `{ [channelId]: number }`.
+   */
+  async getUnreadCountsByChannelAsync(
+    userId: number | null,
+    localNodeId?: string
+  ): Promise<{ [channelId: number]: number }> {
+    const messages = this.tables.messages;
+    const readMessages = this.tables.readMessages;
+
+    const conditions = [
+      isNull(readMessages.messageId),
+      ne(messages.channel, -1),
+      eq(messages.portnum, 1),
+    ];
+    if (localNodeId) {
+      conditions.push(ne(messages.fromNodeId, localNodeId));
+    }
+
+    try {
+      const rows: any[] = await this.db
+        .select({
+          channel: messages.channel,
+          count: sql<number>`COUNT(*)`,
+        })
+        .from(messages)
+        .leftJoin(readMessages, this.unreadJoinOn(userId)!)
+        .where(and(...conditions))
+        .groupBy(messages.channel);
+
+      const counts: { [channelId: number]: number } = {};
+      for (const row of rows) {
+        counts[Number(row.channel)] = Number(row.count);
+      }
+      return counts;
+    } catch (error) {
+      logger.error('Error getting unread counts by channel:', error);
+      return {};
+    }
+  }
+
+  /**
+   * Count unread DMs from a single remote node to the local node.
+   */
+  async getUnreadDMCountAsync(
+    localNodeId: string,
+    remoteNodeId: string,
+    userId: number | null
+  ): Promise<number> {
+    const messages = this.tables.messages;
+    const readMessages = this.tables.readMessages;
+
+    try {
+      const rows: any[] = await this.db
+        .select({ count: sql<number>`COUNT(*)` })
+        .from(messages)
+        .leftJoin(readMessages, this.unreadJoinOn(userId)!)
+        .where(
+          and(
+            isNull(readMessages.messageId),
+            eq(messages.portnum, 1),
+            eq(messages.channel, -1),
+            eq(messages.fromNodeId, remoteNodeId),
+            eq(messages.toNodeId, localNodeId)
+          )
+        );
+      return Number(rows[0]?.count ?? 0);
+    } catch (error) {
+      logger.error('Error getting unread DM count:', error);
+      return 0;
+    }
+  }
+
+  /**
+   * Count unread DMs for the local node grouped by remote sender.
+   * Returns `{ [fromNodeId]: number }`.
+   */
+  async getBatchUnreadDMCountsAsync(
+    localNodeId: string,
+    userId: number | null
+  ): Promise<{ [fromNodeId: string]: number }> {
+    const messages = this.tables.messages;
+    const readMessages = this.tables.readMessages;
+
+    try {
+      const rows: any[] = await this.db
+        .select({
+          fromNodeId: messages.fromNodeId,
+          count: sql<number>`COUNT(*)`,
+        })
+        .from(messages)
+        .leftJoin(readMessages, this.unreadJoinOn(userId)!)
+        .where(
+          and(
+            isNull(readMessages.messageId),
+            eq(messages.portnum, 1),
+            eq(messages.channel, -1),
+            eq(messages.toNodeId, localNodeId)
+          )
+        )
+        .groupBy(messages.fromNodeId);
+
+      const counts: { [fromNodeId: string]: number } = {};
+      for (const row of rows) {
+        counts[row.fromNodeId] = Number(row.count);
+      }
+      return counts;
+    } catch (error) {
+      logger.error('Error getting batch unread DM counts:', error);
+      return {};
     }
   }
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -346,12 +346,14 @@ class DatabaseService {
   async getDatabaseVersion(): Promise<string> {
     try {
       if (this.drizzleDbType === 'postgres' && this.postgresPool) {
+        // eslint-disable-next-line no-restricted-syntax -- system diagnostic query, not domain data
         const result = await this.postgresPool.query('SELECT version()');
         const fullVersion = result.rows?.[0]?.version || 'Unknown';
         // Extract just the version number from "PostgreSQL 16.2 (Debian 16.2-1.pgdg120+2) on x86_64-pc-linux-gnu..."
         const match = fullVersion.match(/PostgreSQL\s+([\d.]+)/);
         return match ? match[1] : fullVersion.split(' ').slice(0, 2).join(' ');
       } else if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
+        // eslint-disable-next-line no-restricted-syntax -- system diagnostic query, not domain data
         const [rows] = await this.mysqlPool.query('SELECT version() as version');
         return (rows as any[])?.[0]?.version || 'Unknown';
       } else if (this.db) {
@@ -2513,34 +2515,18 @@ class DatabaseService {
    * Update the spam detection flags for a node (async), scoped per-source.
    */
   async updateNodeSpamFlagsAsync(nodeNum: number, isExcessivePackets: boolean, packetRatePerHour: number, lastChecked: number, sourceId: string): Promise<void> {
-    const now = Date.now();
-
-    if (this.drizzleDbType === 'postgres' && this.postgresPool) {
-      await this.postgresPool.query(`
-        UPDATE nodes
-        SET "isExcessivePackets" = $1,
-            "packetRatePerHour" = $2,
-            "packetRateLastChecked" = $3,
-            "updatedAt" = $4
-        WHERE "nodeNum" = $5 AND "sourceId" = $6
-      `, [isExcessivePackets, packetRatePerHour, lastChecked, now, nodeNum, sourceId]);
-      return;
-    }
-
-    if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
-      await this.mysqlPool.query(`
-        UPDATE nodes
-        SET isExcessivePackets = ?,
-            packetRatePerHour = ?,
-            packetRateLastChecked = ?,
-            updatedAt = ?
-        WHERE nodeNum = ? AND sourceId = ?
-      `, [isExcessivePackets, packetRatePerHour, lastChecked, now, nodeNum, sourceId]);
+    if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
+      await this.nodesRepo!.updateNodeExcessivePacketsAsync(
+        nodeNum,
+        isExcessivePackets,
+        packetRatePerHour,
+        lastChecked,
+        sourceId
+      );
       return;
     }
 
     // SQLite: synchronous update
-    void now;
     this.nodesRepo!.updateNodeSpamFlagsSqlite(nodeNum, isExcessivePackets, packetRatePerHour, lastChecked, sourceId);
   }
 
@@ -2612,32 +2598,17 @@ class DatabaseService {
    * sourceId is required post-migration 029.
    */
   async updateNodeTimeOffsetFlagsAsync(nodeNum: number, isTimeOffsetIssue: boolean, timeOffsetSeconds: number | null, sourceId: string): Promise<void> {
-    const now = Date.now();
-
-    if (this.drizzleDbType === 'postgres' && this.postgresPool) {
-      await this.postgresPool.query(`
-        UPDATE nodes
-        SET "isTimeOffsetIssue" = $1,
-            "timeOffsetSeconds" = $2,
-            "updatedAt" = $3
-        WHERE "nodeNum" = $4 AND "sourceId" = $5
-      `, [isTimeOffsetIssue, timeOffsetSeconds, now, nodeNum, sourceId]);
-      return;
-    }
-
-    if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
-      await this.mysqlPool.query(`
-        UPDATE nodes
-        SET isTimeOffsetIssue = ?,
-            timeOffsetSeconds = ?,
-            updatedAt = ?
-        WHERE nodeNum = ? AND sourceId = ?
-      `, [isTimeOffsetIssue, timeOffsetSeconds, now, nodeNum, sourceId]);
+    if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
+      await this.nodesRepo!.updateNodeTimeOffsetAsync(
+        nodeNum,
+        isTimeOffsetIssue,
+        timeOffsetSeconds,
+        sourceId
+      );
       return;
     }
 
     // SQLite
-    void now;
     this.nodesRepo!.updateNodeTimeOffsetFlagsSqlite(nodeNum, isTimeOffsetIssue, timeOffsetSeconds, sourceId);
   }
 
@@ -7608,211 +7579,29 @@ class DatabaseService {
   }
 
   /**
-   * Async version of getUnreadCountsByChannel for PostgreSQL/MySQL
+   * Async version of getUnreadCountsByChannel for PostgreSQL/MySQL.
+   * Delegates to NotificationsRepository for Drizzle-based execution on all backends.
    */
   async getUnreadCountsByChannelAsync(userId: number | null, localNodeId?: string): Promise<{[channelId: number]: number}> {
-    // For SQLite, use sync version
+    // For SQLite, use sync version (legacy compatibility)
     if (this.drizzleDbType !== 'postgres' && this.drizzleDbType !== 'mysql') {
       return this.getUnreadCountsByChannel(userId, localNodeId);
     }
-
-    // PostgreSQL implementation using postgresPool
-    if (this.drizzleDbType === 'postgres' && this.postgresPool) {
-      try {
-        let query: string;
-        let params: any[];
-
-        if (userId === null) {
-          // Anonymous user - check for messages not in read_messages at all
-          query = `
-            SELECT m.channel, COUNT(*) as count
-            FROM messages m
-            LEFT JOIN read_messages rm ON m.id = rm."messageId"
-            WHERE rm."messageId" IS NULL
-              AND m.channel != -1
-              AND m.portnum = 1
-              ${localNodeId ? 'AND m."fromNodeId" != $1' : ''}
-            GROUP BY m.channel
-          `;
-          params = localNodeId ? [localNodeId] : [];
-        } else {
-          // Authenticated user - check for messages not read by this user
-          query = `
-            SELECT m.channel, COUNT(*) as count
-            FROM messages m
-            LEFT JOIN read_messages rm ON m.id = rm."messageId" AND rm."userId" = $1
-            WHERE rm."messageId" IS NULL
-              AND m.channel != -1
-              AND m.portnum = 1
-              ${localNodeId ? 'AND m."fromNodeId" != $2' : ''}
-            GROUP BY m.channel
-          `;
-          params = localNodeId ? [userId, localNodeId] : [userId];
-        }
-
-        const result = await this.postgresPool.query(query, params);
-        const counts: {[channelId: number]: number} = {};
-
-        result.rows.forEach((row: any) => {
-          counts[Number(row.channel)] = Number(row.count);
-        });
-
-        return counts;
-      } catch (error) {
-        logger.error('Error getting unread counts by channel:', error);
-        return {};
-      }
-    }
-
-    // MySQL implementation using mysqlPool
-    if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
-      try {
-        let query: string;
-        let params: any[];
-
-        if (userId === null) {
-          query = `
-            SELECT m.channel, COUNT(*) as count
-            FROM messages m
-            LEFT JOIN read_messages rm ON m.id = rm.messageId
-            WHERE rm.messageId IS NULL
-              AND m.channel != -1
-              AND m.portnum = 1
-              ${localNodeId ? 'AND m.fromNodeId != ?' : ''}
-            GROUP BY m.channel
-          `;
-          params = localNodeId ? [localNodeId] : [];
-        } else {
-          query = `
-            SELECT m.channel, COUNT(*) as count
-            FROM messages m
-            LEFT JOIN read_messages rm ON m.id = rm.messageId AND rm.userId = ?
-            WHERE rm.messageId IS NULL
-              AND m.channel != -1
-              AND m.portnum = 1
-              ${localNodeId ? 'AND m.fromNodeId != ?' : ''}
-            GROUP BY m.channel
-          `;
-          params = localNodeId ? [userId, localNodeId] : [userId];
-        }
-
-        const [rows] = await this.mysqlPool.query(query, params) as any;
-        const counts: {[channelId: number]: number} = {};
-
-        for (const row of rows) {
-          counts[Number(row.channel)] = Number(row.count);
-        }
-
-        return counts;
-      } catch (error) {
-        logger.error('Error getting unread counts by channel:', error);
-        return {};
-      }
-    }
-
-    return {};
+    if (!this.notificationsRepo) return {};
+    return this.notificationsRepo.getUnreadCountsByChannelAsync(userId, localNodeId);
   }
 
   /**
-   * Async version of getUnreadDMCount for PostgreSQL/MySQL
+   * Async version of getUnreadDMCount for PostgreSQL/MySQL.
+   * Delegates to NotificationsRepository for Drizzle-based execution on all backends.
    */
   async getUnreadDMCountAsync(localNodeId: string, remoteNodeId: string, userId: number | null): Promise<number> {
     // For SQLite, use sync version
     if (this.drizzleDbType !== 'postgres' && this.drizzleDbType !== 'mysql') {
       return this.getUnreadDMCount(localNodeId, remoteNodeId, userId);
     }
-
-    // PostgreSQL implementation using postgresPool
-    if (this.drizzleDbType === 'postgres' && this.postgresPool) {
-      try {
-        let query: string;
-        let params: any[];
-
-        if (userId === null) {
-          query = `
-            SELECT COUNT(*) as count
-            FROM messages m
-            LEFT JOIN read_messages rm ON m.id = rm."messageId"
-            WHERE rm."messageId" IS NULL
-              AND m.portnum = 1
-              AND m.channel = -1
-              AND m."fromNodeId" = $1
-              AND m."toNodeId" = $2
-          `;
-          params = [remoteNodeId, localNodeId];
-        } else {
-          query = `
-            SELECT COUNT(*) as count
-            FROM messages m
-            LEFT JOIN read_messages rm ON m.id = rm."messageId" AND rm."userId" = $1
-            WHERE rm."messageId" IS NULL
-              AND m.portnum = 1
-              AND m.channel = -1
-              AND m."fromNodeId" = $2
-              AND m."toNodeId" = $3
-          `;
-          params = [userId, remoteNodeId, localNodeId];
-        }
-
-        const result = await this.postgresPool.query(query, params);
-
-        if (result.rows.length > 0) {
-          return Number(result.rows[0].count);
-        }
-
-        return 0;
-      } catch (error) {
-        logger.error('Error getting unread DM count:', error);
-        return 0;
-      }
-    }
-
-    // MySQL implementation using mysqlPool
-    if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
-      try {
-        let query: string;
-        let params: any[];
-
-        if (userId === null) {
-          query = `
-            SELECT COUNT(*) as count
-            FROM messages m
-            LEFT JOIN read_messages rm ON m.id = rm.messageId
-            WHERE rm.messageId IS NULL
-              AND m.portnum = 1
-              AND m.channel = -1
-              AND m.fromNodeId = ?
-              AND m.toNodeId = ?
-          `;
-          params = [remoteNodeId, localNodeId];
-        } else {
-          query = `
-            SELECT COUNT(*) as count
-            FROM messages m
-            LEFT JOIN read_messages rm ON m.id = rm.messageId AND rm.userId = ?
-            WHERE rm.messageId IS NULL
-              AND m.portnum = 1
-              AND m.channel = -1
-              AND m.fromNodeId = ?
-              AND m.toNodeId = ?
-          `;
-          params = [userId, remoteNodeId, localNodeId];
-        }
-
-        const [rows] = await this.mysqlPool.query(query, params) as any;
-
-        if (rows.length > 0) {
-          return Number(rows[0].count);
-        }
-
-        return 0;
-      } catch (error) {
-        logger.error('Error getting unread DM count:', error);
-        return 0;
-      }
-    }
-
-    return 0;
+    if (!this.notificationsRepo) return 0;
+    return this.notificationsRepo.getUnreadDMCountAsync(localNodeId, remoteNodeId, userId);
   }
 
   /**
@@ -7851,102 +7640,15 @@ class DatabaseService {
 
   /**
    * Async version of getBatchUnreadDMCounts for PostgreSQL/MySQL support.
+   * Delegates to NotificationsRepository for Drizzle-based execution on all backends.
    */
   async getBatchUnreadDMCountsAsync(localNodeId: string, userId: number | null): Promise<{ [fromNodeId: string]: number }> {
     // For SQLite, use sync version
     if (this.drizzleDbType !== 'postgres' && this.drizzleDbType !== 'mysql') {
       return this.getBatchUnreadDMCounts(localNodeId, userId);
     }
-
-    // PostgreSQL implementation
-    if (this.drizzleDbType === 'postgres' && this.postgresPool) {
-      try {
-        let query: string;
-        let params: any[];
-
-        if (userId === null) {
-          query = `
-            SELECT m."fromNodeId", COUNT(*) as count
-            FROM messages m
-            LEFT JOIN read_messages rm ON m.id = rm."messageId"
-            WHERE rm."messageId" IS NULL
-              AND m.portnum = 1
-              AND m.channel = -1
-              AND m."toNodeId" = $1
-            GROUP BY m."fromNodeId"
-          `;
-          params = [localNodeId];
-        } else {
-          query = `
-            SELECT m."fromNodeId", COUNT(*) as count
-            FROM messages m
-            LEFT JOIN read_messages rm ON m.id = rm."messageId" AND rm."userId" = $1
-            WHERE rm."messageId" IS NULL
-              AND m.portnum = 1
-              AND m.channel = -1
-              AND m."toNodeId" = $2
-            GROUP BY m."fromNodeId"
-          `;
-          params = [userId, localNodeId];
-        }
-
-        const result = await this.postgresPool.query(query, params);
-        const counts: { [fromNodeId: string]: number } = {};
-        for (const row of result.rows) {
-          counts[row.fromNodeId] = Number(row.count);
-        }
-        return counts;
-      } catch (error) {
-        logger.error('Error getting batch unread DM counts:', error);
-        return {};
-      }
-    }
-
-    // MySQL implementation using mysqlPool
-    if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
-      try {
-        let query: string;
-        let params: any[];
-
-        if (userId === null) {
-          query = `
-            SELECT m.fromNodeId, COUNT(*) as count
-            FROM messages m
-            LEFT JOIN read_messages rm ON m.id = rm.messageId
-            WHERE rm.messageId IS NULL
-              AND m.portnum = 1
-              AND m.channel = -1
-              AND m.toNodeId = ?
-            GROUP BY m.fromNodeId
-          `;
-          params = [localNodeId];
-        } else {
-          query = `
-            SELECT m.fromNodeId, COUNT(*) as count
-            FROM messages m
-            LEFT JOIN read_messages rm ON m.id = rm.messageId AND rm.userId = ?
-            WHERE rm.messageId IS NULL
-              AND m.portnum = 1
-              AND m.channel = -1
-              AND m.toNodeId = ?
-            GROUP BY m.fromNodeId
-          `;
-          params = [userId, localNodeId];
-        }
-
-        const [rows] = await this.mysqlPool.query(query, params) as any;
-        const counts: { [fromNodeId: string]: number } = {};
-        for (const row of rows) {
-          counts[row.fromNodeId] = Number(row.count);
-        }
-        return counts;
-      } catch (error) {
-        logger.error('Error getting batch unread DM counts:', error);
-        return {};
-      }
-    }
-
-    return {};
+    if (!this.notificationsRepo) return {};
+    return this.notificationsRepo.getBatchUnreadDMCountsAsync(localNodeId, userId);
   }
 
   cleanupOldReadMessages(days: number): number {
@@ -8736,15 +8438,10 @@ class DatabaseService {
 
   async cleanupInactiveNodesAsync(days: number = 30, sourceId?: string): Promise<number> {
     if (sourceId) {
+      if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
+        return this.nodesRepo!.cleanupInactiveNodesForSourceAsync(days, sourceId);
+      }
       const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
-      if (this.drizzleDbType === 'postgres' && this.postgresPool) {
-        const result = await this.postgresPool.query(`DELETE FROM nodes WHERE "lastHeard" < $1 AND "sourceId" = $2`, [cutoff, sourceId]);
-        return result.rowCount ?? 0;
-      }
-      if (this.drizzleDbType === 'mysql' && this.mysqlPool) {
-        const [result] = await this.mysqlPool.query(`DELETE FROM nodes WHERE lastHeard < ? AND sourceId = ?`, [cutoff, sourceId]) as any;
-        return result.affectedRows ?? 0;
-      }
       return this.nodesRepo!.deleteInactiveNodesForSourceSqlite(cutoff, sourceId);
     }
     return this.cleanupInactiveNodes(days);


### PR DESCRIPTION
## Summary

Closes the Drizzle ORM remediation effort (`docs/superpowers/plans/2026-04-14-legacy-sql-drizzle-remediation.md`). Final phase of the multi-month migration: 238 raw SQL sites → 0 untagged in \`src/services/database.ts\`.

### Changes

- **14 final untagged raw SQL sites rewired**:
  - 2 sites: nodes \`isExcessivePackets\`/\`packetRatePerHour\` UPDATE → \`updateNodeExcessivePacketsAsync\`
  - 2 sites: nodes \`isTimeOffsetIssue\`/\`timeOffsetSeconds\` UPDATE → \`updateNodeTimeOffsetAsync\`
  - 2 sites: channel unread COUNT → \`getUnreadCountsByChannelAsync\`
  - 2 sites: DM unread COUNT → \`getUnreadDMCountAsync\`
  - 2 sites: batch DM unread COUNT → \`getBatchUnreadDMCountsAsync\`
  - 2 sites: \`DELETE FROM nodes\` by source → \`cleanupInactiveNodesForSourceAsync\`
  - 2 sites: \`SELECT version()\` diagnostic — tagged with \`eslint-disable\` (legitimate system query, not domain data)
- **ESLint rule added** (\`no-restricted-syntax\`): bans \`this.db.prepare\`, \`this.db.exec\`, \`postgresPool.query\`, \`mysqlPool.query\` outside \`src/server/migrations/**\` and test files
- **CLAUDE.md updated** with new "Raw SQL Ban" subsection

### Architecture Summary

| Metric | Before | After |
|---|---|---|
| Total raw SQL in \`database.ts\` | 238 | 83 (all tagged/migrations) |
| Untagged raw SQL in \`database.ts\` | 238 | **0** ✅ |
| Repositories | 2 | 18 |

## Test plan
- [x] \`npx tsc --noEmit\` — exit 0
- [x] \`npm test\` — 4209 passing, 0 failures, 499 skipped
- [ ] CI green on PG + MySQL backends
- [ ] System tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)