### PR TITLE
fix(db): telemetry compound indexes + MySQL memory fix + log cleanup

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 35 migrations registered', () => {
-    expect(registry.count()).toBe(35);
+  it('has all 36 migrations registered', () => {
+    expect(registry.count()).toBe(36);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,11 +12,11 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_is_store_forward_server', () => {
+  it('last migration is telemetry_performance_indexes', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(35);
-    expect(last.name).toContain('add_is_store_forward_server');
+    expect(last.number).toBe(36);
+    expect(last.name).toContain('telemetry_performance_indexes');
   });
 
   it('migrations are sequentially numbered from 1 to 35', () => {

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -47,6 +47,7 @@ import { migration as telemetryPacketDedupeMigration, runMigration032Postgres, r
 import { migration as perSourcePermissionsMigration, runMigration033Postgres, runMigration033Mysql } from '../server/migrations/033_per_source_permissions.js';
 import { migration as addViaStoreForwardMigration, runMigration034Postgres, runMigration034Mysql } from '../server/migrations/034_add_via_store_forward.js';
 import { migration as addIsStoreForwardServerMigration, runMigration035Postgres, runMigration035Mysql } from '../server/migrations/035_add_is_store_forward_server.js';
+import { migration as telemetryPerformanceIndexesMigration, runMigration036Postgres, runMigration036Mysql } from '../server/migrations/036_telemetry_performance_indexes.js';
 
 // ============================================================================
 // Registry
@@ -520,4 +521,20 @@ registry.register({
   sqlite: (db) => addIsStoreForwardServerMigration.up(db),
   postgres: (client) => runMigration035Postgres(client),
   mysql: (pool) => runMigration035Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 036: Add compound indexes to telemetry table.
+// PG/MySQL only had single-column indexes on nodeNum and timestamp. With 450k+
+// rows, queries degrade to full table scans. Adds (nodeId, telemetryType,
+// timestamp DESC) and (nodeNum, timestamp DESC) compound indexes.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 36,
+  name: 'telemetry_performance_indexes',
+  settingsKey: 'migration_036_telemetry_performance_indexes',
+  sqlite: (db) => telemetryPerformanceIndexesMigration.up(db),
+  postgres: (client) => runMigration036Postgres(client),
+  mysql: (pool) => runMigration036Mysql(pool),
 });

--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -51,9 +51,6 @@ export class ChannelsRepository extends BaseRepository {
     if (result.length === 0) return null;
 
     const channel = result[0];
-    if (id === 0) {
-      logger.info(`getChannelById(0) - RAW from DB: ${channel ? `name="${channel.name}" (length: ${channel.name?.length || 0})` : 'null'}`);
-    }
     return this.normalizeBigInts(channel) as DbChannel;
   }
 
@@ -109,18 +106,17 @@ export class ChannelsRepository extends BaseRepository {
       data.role = 2;
     }
 
-    logger.info(`upsertChannel called with ID: ${data.id}, name: "${data.name}" (length: ${data.name.length})`);
+    logger.debug(`upsertChannel called with ID: ${data.id}, name: "${data.name}"`);
 
     // Look up existing channel using composite key when sourceId is available
     const existingChannel = await this.getChannelById(data.id, sourceId);
-    logger.info(`getChannelById(${data.id}, sourceId=${sourceId ?? 'none'}) returned: ${existingChannel ? `"${existingChannel.name}"` : 'null'}`);
 
     if (existingChannel) {
       // Update existing channel
       // Preserve existing non-empty name if incoming name is empty (fixes #1567)
       // This prevents device reconnections from wiping channel names
       const effectiveName = data.name || existingChannel.name;
-      logger.info(`Updating channel ${existingChannel.id}: name "${existingChannel.name}" -> "${effectiveName}" (incoming: "${data.name}")`);
+      logger.debug(`Updating channel ${existingChannel.id}: name "${existingChannel.name}" -> "${effectiveName}"`);
 
       const updateSet: any = {
         name: effectiveName,
@@ -151,7 +147,7 @@ export class ChannelsRepository extends BaseRepository {
         await this.db.update(channels).set(updateSet).where(updateWhere);
       }
 
-      logger.info(`Updated channel ${existingChannel.id}`);
+      logger.debug(`Updated channel ${existingChannel.id}`);
     } else {
       // Create new channel
       logger.debug(`Creating new channel with ID: ${data.id}`);

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -323,10 +323,10 @@ export class TelemetryRepository extends BaseRepository {
 
     if (this.isMySQL()) {
       const countResult = await this.db
-        .select({ id: telemetry.id })
+        .select({ cnt: count() })
         .from(telemetry)
         .where(condition);
-      if (countResult.length === 0) return false;
+      if (Number(countResult[0]?.cnt ?? 0) === 0) return false;
       await this.db.delete(telemetry).where(condition);
       return true;
     } else {
@@ -369,10 +369,10 @@ export class TelemetryRepository extends BaseRepository {
 
     if (this.isMySQL()) {
       const countResult = await this.db
-        .select({ id: telemetry.id })
+        .select({ cnt: count() })
         .from(telemetry)
         .where(condition);
-      const cnt = countResult.length;
+      const cnt = Number(countResult[0]?.cnt ?? 0);
       await this.db.delete(telemetry).where(condition);
       return cnt;
     } else {
@@ -402,10 +402,10 @@ export class TelemetryRepository extends BaseRepository {
 
     if (this.isMySQL()) {
       const countResult = await this.db
-        .select({ id: telemetry.id })
+        .select({ cnt: count() })
         .from(telemetry)
         .where(lt(telemetry.timestamp, cutoffTimestamp));
-      const cnt = countResult.length;
+      const cnt = Number(countResult[0]?.cnt ?? 0);
       await this.db.delete(telemetry).where(lt(telemetry.timestamp, cutoffTimestamp));
       return cnt;
     } else {
@@ -463,20 +463,20 @@ export class TelemetryRepository extends BaseRepository {
     if (this.isMySQL()) {
       // MySQL doesn't support .returning(), so count before deleting
       const nonFavoritesCount = await this.db
-        .select({ id: telemetry.id })
+        .select({ cnt: count() })
         .from(telemetry)
         .where(and(lt(telemetry.timestamp, regularCutoffTimestamp), not(favoritesCondition!)));
-      nonFavoritesDeleted = nonFavoritesCount.length;
+      nonFavoritesDeleted = Number(nonFavoritesCount[0]?.cnt ?? 0);
 
       await this.db
         .delete(telemetry)
         .where(and(lt(telemetry.timestamp, regularCutoffTimestamp), not(favoritesCondition!)));
 
       const favoritesCount = await this.db
-        .select({ id: telemetry.id })
+        .select({ cnt: count() })
         .from(telemetry)
         .where(and(lt(telemetry.timestamp, effectiveFavoriteCutoff), favoritesCondition!));
-      favoritesDeleted = favoritesCount.length;
+      favoritesDeleted = Number(favoritesCount[0]?.cnt ?? 0);
 
       await this.db
         .delete(telemetry)
@@ -512,10 +512,10 @@ export class TelemetryRepository extends BaseRepository {
 
     if (this.isMySQL()) {
       const countResult = await this.db
-        .select({ id: telemetry.id })
+        .select({ cnt: count() })
         .from(telemetry)
         .where(condition);
-      const cnt = countResult.length;
+      const cnt = Number(countResult[0]?.cnt ?? 0);
       await this.db.delete(telemetry).where(condition);
       return cnt;
     } else {
@@ -943,10 +943,10 @@ export class TelemetryRepository extends BaseRepository {
 
     if (this.isMySQL()) {
       const countRows = await this.db
-        .select({ id: telemetry.id })
+        .select({ cnt: count() })
         .from(telemetry)
         .where(condition);
-      const cnt = countRows.length;
+      const cnt = Number(countRows[0]?.cnt ?? 0);
       await this.db.delete(telemetry).where(condition);
       return cnt;
     }

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3789,8 +3789,7 @@ class MeshtasticManager implements ISourceManager {
             logger.info(`📡 Channel ${channel.index} arrived empty — normalizing role to DISABLED(0) (#2666)`);
           }
 
-          logger.info(`📡 Saving channel ${channel.index} (${displayName}) - role: ${channelRole}, positionPrecision: ${positionPrecision}`);
-          logger.info(`📡 Database will store name as: "${channelName}" (length: ${channelName.length})`);
+          logger.debug(`📡 Saving channel ${channel.index} (${displayName}) - role: ${channelRole}`);
 
           await databaseService.channels.upsertChannel({
             id: channel.index,

--- a/src/server/migrations/036_telemetry_performance_indexes.ts
+++ b/src/server/migrations/036_telemetry_performance_indexes.ts
@@ -1,0 +1,67 @@
+/**
+ * Migration 036: Add compound indexes to telemetry table for query performance.
+ *
+ * PostgreSQL and MySQL were created with only single-column indexes on nodeNum
+ * and timestamp. The SQLite bootstrap had additional indexes (nodeId, telemetryType,
+ * and a compound position_lookup index) that PG/MySQL never received.
+ *
+ * With 450k+ telemetry rows, queries like getLatestTelemetryValueForAllNodes(),
+ * getTelemetryForNode(), and getAllNodesTelemetryTypes() degrade to full table
+ * scans without compound indexes.
+ *
+ * This migration adds the missing indexes to all three backends (idempotent).
+ */
+import type { Database } from 'better-sqlite3';
+
+// SQLite migration
+export const migration = {
+  up(db: Database) {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_telemetry_nodeid ON telemetry(nodeId)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_telemetry_type ON telemetry(telemetryType)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_telemetry_position_lookup ON telemetry(nodeId, telemetryType, timestamp DESC)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_telemetry_nodenum_timestamp ON telemetry(nodeNum, timestamp DESC)`);
+  },
+};
+
+// PostgreSQL migration
+export async function runMigration036Postgres(client: any): Promise<void> {
+  await client.query(`CREATE INDEX IF NOT EXISTS idx_telemetry_nodeid ON telemetry("nodeId")`);
+  await client.query(`CREATE INDEX IF NOT EXISTS idx_telemetry_type ON telemetry("telemetryType")`);
+  await client.query(`CREATE INDEX IF NOT EXISTS idx_telemetry_position_lookup ON telemetry("nodeId", "telemetryType", timestamp DESC)`);
+  await client.query(`CREATE INDEX IF NOT EXISTS idx_telemetry_nodenum_timestamp ON telemetry("nodeNum", timestamp DESC)`);
+}
+
+// MySQL migration
+export async function runMigration036Mysql(pool: any): Promise<void> {
+  const [rows] = await pool.query(`
+    SELECT INDEX_NAME FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'telemetry' AND INDEX_NAME = 'idx_telemetry_nodeid'
+  `);
+  if ((rows as any[]).length === 0) {
+    await pool.query(`CREATE INDEX idx_telemetry_nodeid ON telemetry(nodeId)`);
+  }
+
+  const [rows2] = await pool.query(`
+    SELECT INDEX_NAME FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'telemetry' AND INDEX_NAME = 'idx_telemetry_type'
+  `);
+  if ((rows2 as any[]).length === 0) {
+    await pool.query(`CREATE INDEX idx_telemetry_type ON telemetry(telemetryType)`);
+  }
+
+  const [rows3] = await pool.query(`
+    SELECT INDEX_NAME FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'telemetry' AND INDEX_NAME = 'idx_telemetry_position_lookup'
+  `);
+  if ((rows3 as any[]).length === 0) {
+    await pool.query(`CREATE INDEX idx_telemetry_position_lookup ON telemetry(nodeId, telemetryType, timestamp DESC)`);
+  }
+
+  const [rows4] = await pool.query(`
+    SELECT INDEX_NAME FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'telemetry' AND INDEX_NAME = 'idx_telemetry_nodenum_timestamp'
+  `);
+  if ((rows4 as any[]).length === 0) {
+    await pool.query(`CREATE INDEX idx_telemetry_nodenum_timestamp ON telemetry(nodeNum, timestamp DESC)`);
+  }
+}

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -3546,9 +3546,6 @@ class DatabaseService {
       return channel;
     }
     const channel = this.channelsRepo!.getChannelByIdSync(id);
-    if (id === 0) {
-      logger.info(`🔍 getChannelById(0) - RAW from DB: ${channel ? `name="${channel.name}" (length: ${channel.name?.length || 0})` : 'null'}`);
-    }
     return channel;
   }
 


### PR DESCRIPTION
## Summary

- **Migration 036**: Adds compound indexes to telemetry table for PostgreSQL and MySQL. These were present in SQLite bootstrap but never added via migration, causing full table scans on 450k+ row tables and database timeouts.
  - `(nodeId, telemetryType, timestamp DESC)` — covers getLatestTelemetryValueForAllNodes, getTelemetryForNode, getAllNodesTelemetryTypes
  - `(nodeNum, timestamp DESC)` — covers DISTINCT ON queries like getLatestPacketTimestampsPerNode
  - Single-column `nodeId` and `telemetryType` indexes (PG/MySQL had neither)
- **MySQL memory fix**: 6 delete methods were doing `SELECT id FROM telemetry WHERE ...` to count rows before deleting — loading potentially 100k+ row IDs into a JS array. Replaced with `SELECT COUNT(*)`.
- **Log spam fix**: Removed leftover `getChannelById(0) - RAW from DB` debug logging that fired on every incoming message on channel 0, flooding user logs. Downgraded other channel upsert/update logs to debug level.

## Test plan

- [x] All 211 test files pass (4209 tests, 0 failures)
- [x] TypeScript compilation clean (`tsc --noEmit` exit 0)
- [x] Migration 036 is idempotent (IF NOT EXISTS / information_schema checks)
- [ ] CI passes
- [ ] Verify indexes created on fresh SQLite deploy
- [ ] Verify PG users report improved query times after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)