### PR TITLE
chore: bump version to 4.0.0-beta.2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.0.0-beta.1
-appVersion: "4.0.0-beta.1"
+version: 4.0.0-beta.2
+appVersion: "4.0.0-beta.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.0.0-beta.1",
+      "version": "4.0.0-beta.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -4737,7 +4737,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5040,7 +5040,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5073,6 +5073,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7418,6 +7419,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -14369,7 +14371,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -15043,14 +15046,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -16551,7 +16546,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Version bump to 4.0.0-beta.2.

## Changes since v4.0.0-beta.1

### Features
- #2671 Store & Forward client support (Phase 0) — decode, display, and handle S&F messages
- #2677 Toggle delete vs ignore for auto-delete-by-distance (#2676)
- #2678 CodeQL security scanning workflow
- #2679 Prioritize nearby nodes in remote admin scanner (#2669)

### Bug Fixes
- #2697 Telemetry compound indexes + MySQL memory fix + log cleanup (#2605, #2646)
- #2675 Disabled channels persist in UI (#2666)
- #2673 Embed map respects global Default Map Center and URL params (#2668)
- #2672 Remote Admin Scanner uses configured time format (#2670)
- #2667 Source card kebab menu clipping and duplicate host:port prevention (#2682)
- #2664 Pass sourceId when logging packets to packet monitor

### Refactoring — Legacy SQL → Drizzle Remediation (complete)
- #2681 Convert user_map_preferences to Drizzle ORM
- #2683 Phase 1.1: Delete Permission model, route to authRepo
- #2684 Phase 1.2: Delete APIToken model, route to AuthRepository
- #2685 Phase 1.3: Delete User model, route to AuthRepository
- #2687 Phase 1.4: Convert sqliteSessionStore to DrizzleSessionStore
- #2688 Phase 2.1: Extract audit domain raw SQL
- #2689 Phase 2.2: Extract neighbors domain raw SQL
- #2690 Phase 2.3: Extract settings domain raw SQL
- #2691 Phase 2 Batch A: Extract channels + packetlog domains
- #2692 Phase 2 Batch B: Extract telemetry + traceroutes domains
- #2693 Phase 2.9: Triage init/import bootstrap SQL
- #2694 Task 2.10: Rewire messages domain to Drizzle repo
- #2695 Tasks 2.5 + 2.11: Rewire nodes + keyrepair + ignored_nodes
- #2696 Phase 3 close-out: Final 14 sites, ESLint rule, CLAUDE.md

### Dependencies
- #2658 lucide-react 1.7.0 → 1.8.0
- #2659 @tanstack/react-query-devtools 5.96.2 → 5.99.0
- #2660 better-sqlite3 12.8.0 → 12.9.0
- #2661 @tanstack/react-query 5.96.2 → 5.99.0
- #2662 globals 17.4.0 → 17.5.0
- #2665 Production dependencies group update (10 packages)

### Issues Resolved
- #2605 Performance degrades with large telemetry datasets
- #2610 Impossible to find node despite presence in database
- #2646 Error: Failed to fetch telemetry: 500 Internal Server Error
- #2666 Unable to remove channel
- #2668 Embed map ignores Default Map Center setting
- #2669 Remote Admin Scanner: Prioritize by distance/hops
- #2670 Remote Admin Scanner not using configured time format
- #2676 Radius ignore + bug some nodes not adding to ignore
- #2682 New sources UI delete option missing or hidden
- #2579 Monitor multiple Nodes in single instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)