### PR TITLE
fix(ui): wrap long unbroken strings in message bubbles

### DIFF
--- a/src/styles/messages.css
+++ b/src/styles/messages.css
@@ -104,6 +104,7 @@
 
 .message-text-row .message-text {
   flex: 0 1 auto;
+  min-width: 0;
 }
 
 .message-text-row .message-meta {
@@ -116,6 +117,8 @@
   margin: 0;
   line-height: 1.3;
   font-size: 0.95rem;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* Clickable links in messages */


### PR DESCRIPTION
## Summary

Fixes [#2686](https://github.com/Yeraze/meshmonitor/issues/2686) — long character sequences without spaces (URLs, base64 blobs, gibberish) broke the chat layout and added a horizontal scrollbar that persisted until the message was deleted.

Two CSS issues compounded:

1. `.message-bubble .message-text` used legacy `word-wrap: break-word`, which doesn't break ultra-long unbroken strings. Added `overflow-wrap: anywhere` and `word-break: break-word`.
2. `.message-text-row .message-text` was a flex item without `min-width: 0`, so it refused to shrink below intrinsic content width — long string forced the bubble past its `max-width: 100%` constraint. Added `min-width: 0`.

3 lines of CSS, no JS/TSX changes.

## Test plan

- [x] Full vitest suite passes (4209 tests, 0 failures)
- [x] In-browser verification: 200-char unbroken string `aaa...` injected into a 300px-wide synthetic message bubble. Wrapped cleanly across multiple lines, timestamp positioned correctly, no horizontal scrollbar.
- [ ] Manual review on dev container — open chat, send a long unbroken string

🤖 Generated with [Claude Code](https://claude.com/claude-code)