### PR TITLE
fix(security): close URL-hash bypass on permission-gated tabs (#2699)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -601,9 +601,26 @@ function App() {
 
     const isAdmin = authStatus?.user?.isAdmin || false;
     const isAuthenticated = authStatus?.authenticated || false;
+    const meshcoreEnabled = authStatus?.meshcoreEnabled || false;
+
+    // Mirrors Sidebar.tsx hasAnyChannelPermission — channels tab is reachable
+    // if the user can read at least one channel (channel_0..channel_7).
+    const hasAnyChannelPermission = () => {
+      for (let i = 0; i < 8; i++) {
+        if (hasPermission(`channel_${i}` as ResourceType, 'read')) {
+          return true;
+        }
+      }
+      return false;
+    };
 
     // Define permission requirements for each protected tab
     const tabPermissions: Record<string, () => boolean> = {
+      dashboard: () => hasPermission('dashboard', 'read'),
+      info: () => hasPermission('info', 'read'),
+      messages: () => hasPermission('messages', 'read'),
+      channels: hasAnyChannelPermission,
+      meshcore: () => meshcoreEnabled && hasPermission('meshcore', 'read'),
       settings: () => hasPermission('settings', 'read'),
       automation: () => hasPermission('automation', 'read'),
       configuration: () => hasPermission('configuration', 'read'),
@@ -612,7 +629,7 @@ function App() {
       admin: () => isAdmin,
       audit: () => hasPermission('audit', 'read'),
       security: () => hasPermission('security', 'read'),
-      packetmonitor: () => hasPermission('packetmonitor', 'read'),
+      packetmonitor: () => packetLogEnabled && hasPermission('packetmonitor', 'read'),
     };
 
     // Check if current tab requires permission
@@ -622,7 +639,7 @@ function App() {
       logger.info(`[Auth] Redirecting from '${activeTab}' tab - insufficient permissions`);
       setActiveTab('nodes');
     }
-  }, [activeTab, authStatus, authLoading, hasPermission, setActiveTab]);
+  }, [activeTab, authStatus, authLoading, hasPermission, setActiveTab, packetLogEnabled]);
 
   // Helper function to safely parse node IDs to node numbers
   const parseNodeId = useCallback((nodeId: string): number => {


### PR DESCRIPTION
## Summary

Fixes #2699 — anonymous/limited users could load permission-gated tabs (e.g. `dashboard`) via URL hash like `#dashboard` even though the Sidebar correctly hid the icon. The tab shell rendered, fired API calls that 403'd, and surfaced toast spam + UI layout disclosure.

Root cause: the redirect map at `src/App.tsx:606` (`tabPermissions`) only listed a subset of the gated tabs that the Sidebar guards. Tabs not in the map are reachable via direct hash navigation.

## Changes

`src/App.tsx` — extend `tabPermissions` to mirror Sidebar gating:

| Tab | Added/Changed |
|---|---|
| `dashboard` | added (`dashboard:read`) — fixes #2699 |
| `info` | added (`info:read`) |
| `messages` | added (`messages:read`) |
| `channels` | added (any `channel_N:read`, mirrors `Sidebar.hasAnyChannelPermission`) |
| `meshcore` | added (`meshcoreEnabled` server flag + `meshcore:read`) |
| `packetmonitor` | tightened to also require `packetLogEnabled` flag |

Backend routes already enforce `requirePermission` server-side, so no data was leaked — this closes the UX/info-disclosure half.

## Test plan

- [ ] Log in as anonymous (no `dashboard:read`); navigate to `/#dashboard` → expect redirect to `nodes` tab
- [ ] Repeat with `#info`, `#messages`, `#channels`, `#meshcore`, `#packetmonitor`
- [ ] Log in as admin; confirm all tabs still load normally
- [ ] Disable `meshcoreEnabled` server-side; admin navigating to `#meshcore` should redirect
- [ ] Disable packet log; admin navigating to `#packetmonitor` should redirect
- [ ] Verify console shows `[Auth] Redirecting from '<tab>' tab - insufficient permissions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)