### PR TITLE
fix(db): backfill id/createdAt/updatedAt on legacy user_map_preferences (PG/MySQL)

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 36 migrations registered', () => {
-    expect(registry.count()).toBe(36);
+  it('has all 37 migrations registered', () => {
+    expect(registry.count()).toBe(37);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,11 +12,11 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is telemetry_performance_indexes', () => {
+  it('last migration is add_id_to_user_map_preferences', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(36);
-    expect(last.name).toContain('telemetry_performance_indexes');
+    expect(last.number).toBe(37);
+    expect(last.name).toContain('add_id_to_user_map_preferences');
   });
 
   it('migrations are sequentially numbered from 1 to 35', () => {

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,7 +1,7 @@
 /**
  * Migration Registry Barrel File
  *
- * Registers all 35 migrations in sequential order for use by the migration runner.
+ * Registers all 37 migrations in sequential order for use by the migration runner.
  * Migration 001 is the v3.7 baseline (selfIdempotent — handles its own detection).
  * Migrations 002-011 were originally 078-087 and retain their original settingsKeys
  * for upgrade compatibility.
@@ -48,6 +48,7 @@ import { migration as perSourcePermissionsMigration, runMigration033Postgres, ru
 import { migration as addViaStoreForwardMigration, runMigration034Postgres, runMigration034Mysql } from '../server/migrations/034_add_via_store_forward.js';
 import { migration as addIsStoreForwardServerMigration, runMigration035Postgres, runMigration035Mysql } from '../server/migrations/035_add_is_store_forward_server.js';
 import { migration as telemetryPerformanceIndexesMigration, runMigration036Postgres, runMigration036Mysql } from '../server/migrations/036_telemetry_performance_indexes.js';
+import { migration as userMapPrefsIdMigration, runMigration037Postgres, runMigration037Mysql } from '../server/migrations/037_add_id_to_user_map_preferences.js';
 
 // ============================================================================
 // Registry
@@ -537,4 +538,21 @@ registry.register({
   sqlite: (db) => telemetryPerformanceIndexesMigration.up(db),
   postgres: (client) => runMigration036Postgres(client),
   mysql: (pool) => runMigration036Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 037: Backfill missing user_map_preferences columns on PG/MySQL.
+// Pre-baseline (v3.7) deployments lacked `id`, `createdAt`, and `updatedAt`.
+// Drizzle's getMapPreferences (PR #2681) selects all schema columns, so PG
+// fails with `column "id" does not exist` on those legacy tables.
+// SQLite is unaffected (bootstrap creates the table with the right schema).
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 37,
+  name: 'add_id_to_user_map_preferences',
+  settingsKey: 'migration_037_add_id_to_user_map_preferences',
+  sqlite: (db) => userMapPrefsIdMigration.up(db),
+  postgres: (client) => runMigration037Postgres(client),
+  mysql: (pool) => runMigration037Mysql(pool),
 });

--- a/src/server/migrations/037_add_id_to_user_map_preferences.ts
+++ b/src/server/migrations/037_add_id_to_user_map_preferences.ts
@@ -1,0 +1,113 @@
+/**
+ * Migration 037: Backfill missing user_map_preferences columns on PostgreSQL/MySQL.
+ *
+ * Pre-baseline (v3.7) PostgreSQL/MySQL deployments created user_map_preferences
+ * via Drizzle's pre-Drizzle-ORM raw SQL with only base columns and no `id`
+ * primary key. The v3.7 baseline (migration 001) creates the table with the
+ * full schema, but only when the table does not already exist — `CREATE TABLE
+ * IF NOT EXISTS` is a no-op on pre-existing tables.
+ *
+ * After PR #2681 moved getMapPreferences to Drizzle, the generated
+ * `SELECT *`-style query references every schema column, including `id`,
+ * `createdAt`, and `updatedAt`. PG fails with `column "id" does not exist`
+ * for those legacy tables.
+ *
+ * This migration idempotently ensures `id`, `createdAt`, and `updatedAt`
+ * exist on PG/MySQL `user_map_preferences`. If a primary key already exists
+ * but is not `id`, it is dropped first so `id` can become the new PK.
+ *
+ * SQLite is unaffected: the bootstrap in src/services/database.ts creates
+ * the table with the correct schema before any migration runs.
+ */
+import type { Database } from 'better-sqlite3';
+
+export const migration = {
+  // No-op on SQLite: bootstrap already creates user_map_preferences with id,
+  // createdAt, and updatedAt before migrations run.
+  up(_db: Database): void {
+    // intentionally empty
+  },
+};
+
+export async function runMigration037Postgres(client: any): Promise<void> {
+  const tableExists = await client.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = 'user_map_preferences' LIMIT 1`
+  );
+  if (tableExists.rows.length === 0) {
+    return;
+  }
+
+  const idCol = await client.query(
+    `SELECT 1 FROM information_schema.columns
+     WHERE table_name = 'user_map_preferences' AND column_name = 'id' LIMIT 1`
+  );
+  if (idCol.rows.length === 0) {
+    const pk = await client.query(
+      `SELECT constraint_name FROM information_schema.table_constraints
+       WHERE table_name = 'user_map_preferences' AND constraint_type = 'PRIMARY KEY' LIMIT 1`
+    );
+    if (pk.rows.length > 0) {
+      const name = pk.rows[0].constraint_name;
+      await client.query(`ALTER TABLE user_map_preferences DROP CONSTRAINT "${name}"`);
+    }
+    await client.query(`ALTER TABLE user_map_preferences ADD COLUMN id SERIAL PRIMARY KEY`);
+  }
+
+  const createdAtCol = await client.query(
+    `SELECT 1 FROM information_schema.columns
+     WHERE table_name = 'user_map_preferences' AND column_name = 'createdAt' LIMIT 1`
+  );
+  if (createdAtCol.rows.length === 0) {
+    await client.query(`ALTER TABLE user_map_preferences ADD COLUMN "createdAt" BIGINT`);
+  }
+
+  const updatedAtCol = await client.query(
+    `SELECT 1 FROM information_schema.columns
+     WHERE table_name = 'user_map_preferences' AND column_name = 'updatedAt' LIMIT 1`
+  );
+  if (updatedAtCol.rows.length === 0) {
+    await client.query(`ALTER TABLE user_map_preferences ADD COLUMN "updatedAt" BIGINT`);
+  }
+}
+
+export async function runMigration037Mysql(pool: any): Promise<void> {
+  const [tables] = await pool.query(
+    `SELECT TABLE_NAME FROM information_schema.TABLES
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_map_preferences'`
+  );
+  if ((tables as any[]).length === 0) {
+    return;
+  }
+
+  const [idRows] = await pool.query(
+    `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_map_preferences' AND COLUMN_NAME = 'id'`
+  );
+  if ((idRows as any[]).length === 0) {
+    const [pkRows] = await pool.query(
+      `SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_map_preferences'
+         AND CONSTRAINT_TYPE = 'PRIMARY KEY'`
+    );
+    if ((pkRows as any[]).length > 0) {
+      await pool.query(`ALTER TABLE user_map_preferences DROP PRIMARY KEY`);
+    }
+    await pool.query(`ALTER TABLE user_map_preferences ADD COLUMN id INT AUTO_INCREMENT PRIMARY KEY FIRST`);
+  }
+
+  const [createdAtRows] = await pool.query(
+    `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_map_preferences' AND COLUMN_NAME = 'createdAt'`
+  );
+  if ((createdAtRows as any[]).length === 0) {
+    await pool.query(`ALTER TABLE user_map_preferences ADD COLUMN createdAt BIGINT`);
+  }
+
+  const [updatedAtRows] = await pool.query(
+    `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_map_preferences' AND COLUMN_NAME = 'updatedAt'`
+  );
+  if ((updatedAtRows as any[]).length === 0) {
+    await pool.query(`ALTER TABLE user_map_preferences ADD COLUMN updatedAt BIGINT`);
+  }
+}


### PR DESCRIPTION
## Summary

Pre-baseline (v3.7) PostgreSQL/MySQL deployments created `user_map_preferences` without an `id` primary key or `createdAt`/`updatedAt` columns. The v3.7 baseline (migration 001) creates the full schema only when the table doesn't already exist (`CREATE TABLE IF NOT EXISTS`), so legacy tables persisted into v4.

After PR #2681 moved `getMapPreferences` to Drizzle, the generated query references every schema column. PG fails on legacy tables with:

```
DrizzleQueryError: column "id" does not exist
    at MiscRepository.getMapPreferences (file:///app/dist/db/repositories/misc.js:1424:26)
```

Reported by a user running `4.0.0-beta.2` (PG backend).

## Changes

New migration `037_add_id_to_user_map_preferences.ts`. Idempotently:

- adds `id SERIAL PRIMARY KEY` (PG) / `INT AUTO_INCREMENT PK` (MySQL), dropping any pre-existing PK constraint first so `id` can become the new PK
- adds `"createdAt" BIGINT` if missing
- adds `"updatedAt" BIGINT` if missing

SQLite is a no-op — the bootstrap in `src/services/database.ts` creates the table with `id`/`userId`/`createdAt`/`updatedAt` before any migration runs, so SQLite tables already match the Drizzle schema.

`migrations.test.ts` bumped to 37 / `add_id_to_user_map_preferences`.

## Test plan

- [ ] Fresh PG install: migration is no-op (id already exists from baseline)
- [ ] Legacy PG install (pre-v3.7 table without id): migration adds `id`, `createdAt`, `updatedAt`; map preferences load without error
- [ ] Same for MySQL
- [ ] SQLite: unaffected; existing tests pass
- [ ] `npx vitest run src/db/migrations.test.ts` — 9/9 pass
- [ ] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)