### PR TITLE
fix(messages): use packetId (last segment) as replyId for replies/tapbacks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2951,12 +2951,14 @@ function App() {
       return;
     }
 
-    // Extract replyId from replyingTo message if present
+    // Extract replyId from replyingTo message if present.
+    // Message ID format is `${sourceId}_${nodeNum}_${packetId}` — the packetId
+    // is always the last segment, so use slice(-1) to be robust to format changes.
     let replyId: number | undefined = undefined;
     if (replyingTo) {
       const idParts = replyingTo.id.split('_');
-      if (idParts.length > 1) {
-        replyId = parseInt(idParts[1], 10);
+      if (idParts.length >= 2) {
+        replyId = parseInt(idParts[idParts.length - 1], 10);
       }
     }
 
@@ -3042,13 +3044,15 @@ function App() {
       return;
     }
 
-    // Extract replyId from original message
+    // Extract replyId from original message.
+    // Message ID format is `${sourceId}_${nodeNum}_${packetId}` — the packetId
+    // is always the last segment, so use slice(-1) to be robust to format changes.
     const idParts = originalMessage.id.split('_');
     if (idParts.length < 2) {
       setError('Cannot send reaction: invalid message format');
       return;
     }
-    const replyId = parseInt(idParts[1], 10);
+    const replyId = parseInt(idParts[idParts.length - 1], 10);
 
     // Validate replyId is a valid number
     if (isNaN(replyId) || replyId < 0) {
@@ -3478,12 +3482,14 @@ function App() {
     // Use channel ID directly - no mapping needed
     const messageChannel = channel;
 
-    // Extract replyId from replyingTo message if present
+    // Extract replyId from replyingTo message if present.
+    // Message ID format is `${sourceId}_${nodeNum}_${packetId}` — the packetId
+    // is always the last segment, so use slice(-1) to be robust to format changes.
     let replyId: number | undefined = undefined;
     if (replyingTo) {
       const idParts = replyingTo.id.split('_');
-      if (idParts.length > 1) {
-        replyId = parseInt(idParts[1], 10);
+      if (idParts.length >= 2) {
+        replyId = parseInt(idParts[idParts.length - 1], 10);
       }
     }
 


### PR DESCRIPTION
## Summary
- Tapbacks (and tap-to-reply) sent from the UI never reached the mesh — the recipient never saw the reaction.
- Root cause: commit 17f32c1ef changed the message ID format from `{nodeNum}_{packetId}` to `{sourceId}_{nodeNum}_{packetId}` (multi-source uniqueness, see `meshtasticManager.ts:7029`). The frontend reply/tapback handlers in `App.tsx` still grabbed `idParts[1]`, which is now the sender's node number — not the packet ID. Mesh peers looked up the wrong ID and silently dropped the reaction.
- Fix: take the last segment of the ID (`idParts[idParts.length - 1]`) at all three send-side sites in `App.tsx` (DM reply, channel reply, tapback). Display-side lookups in `ChannelsTab.tsx` and `MessagesTab.tsx` already use `.pop()` for the same reason, so this aligns send-side with receive-side and is robust to future format prefixes.

## Verification
- Verified locally in dev container: channel-7 tapback ✓ (`replyId` in DB now matches the original packet's `id` last segment, e.g. 4167400998 instead of the sender nodeNum 1333428877). DM tapback ✓.
- `npm run typecheck` clean. `vitest run src/App.test` passes.

## Test plan
- [ ] CI green
- [ ] Send a tapback on a channel — recipient device shows the reaction
- [ ] Send a tapback in a DM — recipient device shows the reaction
- [ ] Reply (non-tapback) to a channel message — recipient sees it as a reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)