### PR TITLE
fix(notifications): dedup users in preference broadcasts; clean up orphan source prefs

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,5 @@
+name: meshmonitor
+
 services:
   tileserver:
     image: maptiler/tileserver-gl-light:latest

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 37 migrations registered', () => {
-    expect(registry.count()).toBe(37);
+  it('has all 38 migrations registered', () => {
+    expect(registry.count()).toBe(38);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,11 +12,11 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_id_to_user_map_preferences', () => {
+  it('last migration is cleanup_orphan_notification_prefs', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(37);
-    expect(last.name).toContain('add_id_to_user_map_preferences');
+    expect(last.number).toBe(38);
+    expect(last.name).toContain('cleanup_orphan_notification_prefs');
   });
 
   it('migrations are sequentially numbered from 1 to 35', () => {

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,7 +1,7 @@
 /**
  * Migration Registry Barrel File
  *
- * Registers all 37 migrations in sequential order for use by the migration runner.
+ * Registers all 38 migrations in sequential order for use by the migration runner.
  * Migration 001 is the v3.7 baseline (selfIdempotent — handles its own detection).
  * Migrations 002-011 were originally 078-087 and retain their original settingsKeys
  * for upgrade compatibility.
@@ -49,6 +49,7 @@ import { migration as addViaStoreForwardMigration, runMigration034Postgres, runM
 import { migration as addIsStoreForwardServerMigration, runMigration035Postgres, runMigration035Mysql } from '../server/migrations/035_add_is_store_forward_server.js';
 import { migration as telemetryPerformanceIndexesMigration, runMigration036Postgres, runMigration036Mysql } from '../server/migrations/036_telemetry_performance_indexes.js';
 import { migration as userMapPrefsIdMigration, runMigration037Postgres, runMigration037Mysql } from '../server/migrations/037_add_id_to_user_map_preferences.js';
+import { migration as cleanupOrphanNotificationPrefsMigration, runMigration038Postgres, runMigration038Mysql } from '../server/migrations/038_cleanup_orphan_notification_prefs.js';
 
 // ============================================================================
 // Registry
@@ -555,4 +556,20 @@ registry.register({
   sqlite: (db) => userMapPrefsIdMigration.up(db),
   postgres: (client) => runMigration037Postgres(client),
   mysql: (pool) => runMigration037Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 038: Delete orphan source-scoped notification rows.
+// Source deletes don't cascade to user_notification_preferences /
+// push_subscriptions, leaving dangling rows that cause duplicate-notification
+// fan-out (one extra notification per orphan row per broadcast).
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 38,
+  name: 'cleanup_orphan_notification_prefs',
+  settingsKey: 'migration_038_cleanup_orphan_notification_prefs',
+  sqlite: (db) => cleanupOrphanNotificationPrefsMigration.up(db),
+  postgres: (client) => runMigration038Postgres(client),
+  mysql: (pool) => runMigration038Mysql(pool),
 });

--- a/src/db/repositories/notifications.ts
+++ b/src/db/repositories/notifications.ts
@@ -322,7 +322,10 @@ export class NotificationsRepository extends BaseRepository {
         .from(userNotificationPreferences)
         .where(eq(column, true));
 
-      return rows.map((row: any) => row.userId);
+      // Dedup: a user with prefs rows for multiple sources would appear N times
+      // and produce N duplicate notifications during preference broadcasts.
+      const ids = rows.map((row: any) => row.userId as number);
+      return Array.from(new Set<number>(ids));
     } catch (error) {
       logger.debug('No user_notification_preferences table yet, returning empty array');
       return [];

--- a/src/server/migrations/038_cleanup_orphan_notification_prefs.ts
+++ b/src/server/migrations/038_cleanup_orphan_notification_prefs.ts
@@ -49,8 +49,15 @@ export async function runMigration038Postgres(client: any): Promise<void> {
 }
 
 export async function runMigration038Mysql(pool: any): Promise<void> {
+  // Anti-join with explicit COLLATE on both sides — sourceId columns added by
+  // later migrations may carry a different collation (utf8mb4_unicode_ci) than
+  // sources.id (utf8mb4_0900_ai_ci on MySQL 8 defaults), which makes a plain
+  // IN-subquery throw "Illegal mix of collations".
   const [unpRes] = await pool.query(
-    `DELETE FROM user_notification_preferences WHERE sourceId NOT IN (SELECT id FROM sources)`
+    `DELETE unp FROM user_notification_preferences unp
+     LEFT JOIN sources s
+       ON unp.sourceId COLLATE utf8mb4_unicode_ci = s.id COLLATE utf8mb4_unicode_ci
+     WHERE s.id IS NULL`
   );
   const unpAffected = (unpRes as any).affectedRows ?? 0;
   if (unpAffected > 0) {
@@ -58,7 +65,10 @@ export async function runMigration038Mysql(pool: any): Promise<void> {
   }
 
   const [pushRes] = await pool.query(
-    `DELETE FROM push_subscriptions WHERE sourceId NOT IN (SELECT id FROM sources)`
+    `DELETE ps FROM push_subscriptions ps
+     LEFT JOIN sources s
+       ON ps.sourceId COLLATE utf8mb4_unicode_ci = s.id COLLATE utf8mb4_unicode_ci
+     WHERE s.id IS NULL`
   );
   const pushAffected = (pushRes as any).affectedRows ?? 0;
   if (pushAffected > 0) {

--- a/src/server/migrations/038_cleanup_orphan_notification_prefs.ts
+++ b/src/server/migrations/038_cleanup_orphan_notification_prefs.ts
@@ -1,0 +1,67 @@
+/**
+ * Migration 038: Delete orphan source-scoped notification rows.
+ *
+ * Source deletes don't cascade to user_notification_preferences or
+ * push_subscriptions, so deleting a source leaves dangling rows pointing at a
+ * non-existent sourceId. Those rows cause duplicate-notification fan-out:
+ * getUsersWithServiceEnabled() returns the same userId once per row, so a user
+ * with prefs rows for N sources (orphan or live) receives N notifications for
+ * every preference broadcast.
+ *
+ * Idempotent — safe to run repeatedly. Does not add a foreign key (would
+ * require table recreation on SQLite); cleanup is one-shot.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+export const migration = {
+  up(db: Database): void {
+    const unp = db
+      .prepare(`DELETE FROM user_notification_preferences WHERE source_id NOT IN (SELECT id FROM sources)`)
+      .run();
+    if (unp.changes > 0) {
+      logger.info(`Migration 038: deleted ${unp.changes} orphan user_notification_preferences rows`);
+    }
+
+    const push = db
+      .prepare(`DELETE FROM push_subscriptions WHERE source_id NOT IN (SELECT id FROM sources)`)
+      .run();
+    if (push.changes > 0) {
+      logger.info(`Migration 038: deleted ${push.changes} orphan push_subscriptions rows`);
+    }
+  },
+};
+
+export async function runMigration038Postgres(client: any): Promise<void> {
+  const unp = await client.query(
+    `DELETE FROM user_notification_preferences WHERE "sourceId" NOT IN (SELECT id FROM sources)`
+  );
+  if (unp.rowCount && unp.rowCount > 0) {
+    logger.info(`Migration 038: deleted ${unp.rowCount} orphan user_notification_preferences rows (PG)`);
+  }
+
+  const push = await client.query(
+    `DELETE FROM push_subscriptions WHERE "sourceId" NOT IN (SELECT id FROM sources)`
+  );
+  if (push.rowCount && push.rowCount > 0) {
+    logger.info(`Migration 038: deleted ${push.rowCount} orphan push_subscriptions rows (PG)`);
+  }
+}
+
+export async function runMigration038Mysql(pool: any): Promise<void> {
+  const [unpRes] = await pool.query(
+    `DELETE FROM user_notification_preferences WHERE sourceId NOT IN (SELECT id FROM sources)`
+  );
+  const unpAffected = (unpRes as any).affectedRows ?? 0;
+  if (unpAffected > 0) {
+    logger.info(`Migration 038: deleted ${unpAffected} orphan user_notification_preferences rows (MySQL)`);
+  }
+
+  const [pushRes] = await pool.query(
+    `DELETE FROM push_subscriptions WHERE sourceId NOT IN (SELECT id FROM sources)`
+  );
+  const pushAffected = (pushRes as any).affectedRows ?? 0;
+  if (pushAffected > 0) {
+    logger.info(`Migration 038: deleted ${pushAffected} orphan push_subscriptions rows (MySQL)`);
+  }
+}


### PR DESCRIPTION
## Summary

- **Root cause:** `getUsersWithServiceEnabled()` returned userIds **per row** in `user_notification_preferences`. A user with prefs rows for N sources (live or orphan) was returned N times → `broadcastToPreferenceUsers` looped N times → user received N duplicate notifications for traceroutes, new-node, inactive-node, and server-event broadcasts.
- **Fix 1 (one line):** Wrap the result in a `Set` to dedup userIds.
- **Fix 2 (migration 038):** Delete dangling prefs rows pointing at non-existent sources. Source deletes don't cascade today, so orphan rows accumulate and would re-introduce the bug.
- **Bonus (`docker-compose.dev.yml`):** Pin compose project name to `meshmonitor` so worktree invocations don't fork to a separate volume (fixes the perceived "dev DB keeps getting purged" issue).

## Test plan

- [x] `migrations.test.ts` — count + last-name expectations updated to 38
- [x] `notificationService.test.ts` — 21/21 pass
- [x] `notifications` repo tests — 20 pass / 40 skipped
- [x] `notificationFiltering.test.ts` — 44/44 pass
- [x] Verified live: rebuilt dev container, migration 038 deleted 1 orphan row in user's actual database
- [x] User confirmed traceroute notifications no longer duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)