### PR TITLE
fix(source-attribution): telemetry, neighbor_info, v1 traceroutes sourceId scoping

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 38 migrations registered', () => {
-    expect(registry.count()).toBe(38);
+  it('has all 40 migrations registered', () => {
+    expect(registry.count()).toBe(40);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,11 +12,11 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is cleanup_orphan_notification_prefs', () => {
+  it('last migration is purge_null_sourceid_neighbor_info', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(38);
-    expect(last.name).toContain('cleanup_orphan_notification_prefs');
+    expect(last.number).toBe(40);
+    expect(last.name).toContain('purge_null_sourceid_neighbor_info');
   });
 
   it('migrations are sequentially numbered from 1 to 35', () => {

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,7 +1,7 @@
 /**
  * Migration Registry Barrel File
  *
- * Registers all 38 migrations in sequential order for use by the migration runner.
+ * Registers all 40 migrations in sequential order for use by the migration runner.
  * Migration 001 is the v3.7 baseline (selfIdempotent — handles its own detection).
  * Migrations 002-011 were originally 078-087 and retain their original settingsKeys
  * for upgrade compatibility.
@@ -50,6 +50,8 @@ import { migration as addIsStoreForwardServerMigration, runMigration035Postgres,
 import { migration as telemetryPerformanceIndexesMigration, runMigration036Postgres, runMigration036Mysql } from '../server/migrations/036_telemetry_performance_indexes.js';
 import { migration as userMapPrefsIdMigration, runMigration037Postgres, runMigration037Mysql } from '../server/migrations/037_add_id_to_user_map_preferences.js';
 import { migration as cleanupOrphanNotificationPrefsMigration, runMigration038Postgres, runMigration038Mysql } from '../server/migrations/038_cleanup_orphan_notification_prefs.js';
+import { migration as purgeNullSourceIdTelemetryMigration, runMigration039Postgres, runMigration039Mysql } from '../server/migrations/039_purge_null_sourceid_telemetry.js';
+import { migration as purgeNullSourceIdNeighborInfoMigration, runMigration040Postgres, runMigration040Mysql } from '../server/migrations/040_purge_null_sourceid_neighbor_info.js';
 
 // ============================================================================
 // Registry
@@ -572,4 +574,37 @@ registry.register({
   sqlite: (db) => cleanupOrphanNotificationPrefsMigration.up(db),
   postgres: (client) => runMigration038Postgres(client),
   mysql: (pool) => runMigration038Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 039: Purge telemetry rows with NULL sourceId.
+// Pre-beta4 write path never forwarded sourceId into telemetry inserts, so
+// every row since the sourceId column was added (021) was stranded — strict
+// source-scoped filtering made them invisible to TelemetryGraphs. Write path
+// is fixed; this discards the unreachable rows.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 39,
+  name: 'purge_null_sourceid_telemetry',
+  settingsKey: 'migration_039_purge_null_sourceid_telemetry',
+  sqlite: (db) => purgeNullSourceIdTelemetryMigration.up(db),
+  postgres: (client) => runMigration039Postgres(client),
+  mysql: (pool) => runMigration039Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 040: Purge neighbor_info rows with NULL sourceId.
+// Pre-fix, handleNeighborInfoApp didn't forward this.sourceId — the delete
+// wiped cross-source data and the insert wrote NULL-sourced rows invisible
+// to source-scoped reads. Write path is fixed; this discards stranded rows.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 40,
+  name: 'purge_null_sourceid_neighbor_info',
+  settingsKey: 'migration_040_purge_null_sourceid_neighbor_info',
+  sqlite: (db) => purgeNullSourceIdNeighborInfoMigration.up(db),
+  postgres: (client) => runMigration040Postgres(client),
+  mysql: (pool) => runMigration040Mysql(pool),
 });

--- a/src/db/repositories/neighbors.test.ts
+++ b/src/db/repositories/neighbors.test.ts
@@ -206,6 +206,54 @@ function runNeighborsTests(getBackend: () => TestBackend) {
     expect(all[0].nodeNum).toBe(999);
   });
 
+  it('insertNeighborInfoBatch - persists sourceId when provided', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.insertNeighborInfoBatch(
+      [makeNeighbor({ nodeNum: 100, neighborNodeNum: 200 })],
+      'source-A'
+    );
+
+    const scoped = await repo.getAllNeighborInfo('source-A');
+    expect(scoped).toHaveLength(1);
+    expect(scoped[0].sourceId).toBe('source-A');
+
+    const otherScope = await repo.getAllNeighborInfo('source-B');
+    expect(otherScope).toHaveLength(0);
+  });
+
+  it('deleteNeighborInfoForNode - scoped delete leaves other sources intact', async () => {
+    // Regression test for the cross-source wipe bug in
+    // meshtasticManager.handleNeighborInfoApp. Prior to the fix, a delete
+    // without sourceId would drop every source's rows for the node.
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.insertNeighborInfoBatch(
+      [makeNeighbor({ nodeNum: 100, neighborNodeNum: 200 })],
+      'source-A'
+    );
+    await repo.insertNeighborInfoBatch(
+      [makeNeighbor({ nodeNum: 100, neighborNodeNum: 300 })],
+      'source-B'
+    );
+
+    await repo.deleteNeighborInfoForNode(100, 'source-A');
+
+    const aRows = await repo.getAllNeighborInfo('source-A');
+    const bRows = await repo.getAllNeighborInfo('source-B');
+    expect(aRows).toHaveLength(0);
+    expect(bRows).toHaveLength(1);
+    expect(bRows[0].neighborNodeNum).toBe(300);
+  });
+
   it('getNeighborCount - returns total count', async () => {
     const backend = getBackend();
     if (!backend.available) {

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -608,13 +608,15 @@ export class TraceroutesRepository extends BaseRepository {
 
   /**
    * Synchronously get recent traceroutes (all pairs) (SQLite only).
+   * When sourceId is provided, restricts the result to that source.
    */
-  getAllTraceroutesRecentSync(limit: number = 100): DbTraceroute[] {
+  getAllTraceroutesRecentSync(limit: number = 100, sourceId?: string): DbTraceroute[] {
     const db = this.getSqliteDb();
     const { traceroutes } = this.tables;
     const rows = db
       .select()
       .from(traceroutes)
+      .where(this.withSourceScope(traceroutes, sourceId))
       .orderBy(desc(traceroutes.timestamp))
       .limit(limit)
       .all();

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -206,6 +206,7 @@ export interface DbNeighborInfo {
   lastRxTime?: number | null;
   timestamp: number;
   createdAt: number;
+  sourceId?: string | null;
 }
 
 /**

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -710,7 +710,7 @@ class MeshtasticManager implements ISourceManager {
           createdAt: now,
           packetTimestamp,
           packetId
-        });
+        }, this.sourceId);
       }
     }
   }
@@ -1784,7 +1784,7 @@ class MeshtasticManager implements ISourceManager {
         value: Math.round(avg * 100) / 100,
         unit: 's',
         createdAt: now,
-      });
+      }, this.sourceId);
       logger.debug(`⏱️ Saved time-offset telemetry: avg=${avg.toFixed(2)}s (${sampleCount} samples)`);
     } catch (error) {
       logger.error('❌ Error saving time-offset telemetry:', error);
@@ -1840,7 +1840,7 @@ class MeshtasticManager implements ISourceManager {
         timestamp: now,
         value: nodeCount,
         createdAt: now,
-      });
+      }, this.sourceId);
       await databaseService.insertTelemetryAsync({
         nodeId: this.localNodeInfo.nodeId,
         nodeNum: this.localNodeInfo.nodeNum,
@@ -1848,7 +1848,7 @@ class MeshtasticManager implements ISourceManager {
         timestamp: now,
         value: directCount,
         createdAt: now,
-      });
+      }, this.sourceId);
 
       logger.debug(`📊 Saved system node metrics: ${nodeCount} active nodes, ${directCount} direct nodes`);
     } catch (error) {
@@ -4103,7 +4103,7 @@ class MeshtasticManager implements ISourceManager {
           unit: 'hops',
           createdAt: Date.now(),
           packetId: meshPacket.id ? Number(meshPacket.id) : undefined,
-        });
+        }, this.sourceId);
 
         // Update Link Quality based on hop count comparison (skip local node — our own echoed packets aren't meaningful)
         if (!this.localNodeInfo || fromNum !== this.localNodeInfo.nodeNum) {
@@ -4695,18 +4695,18 @@ class MeshtasticManager implements ISourceManager {
           nodeId, nodeNum: fromNum, telemetryType: 'latitude',
           timestamp, value: coords.latitude, unit: '°', createdAt: now, packetTimestamp, packetId,
           channel: channelIndex, precisionBits, gpsAccuracy
-        });
+        }, this.sourceId);
         await databaseService.telemetry.insertTelemetry({
           nodeId, nodeNum: fromNum, telemetryType: 'longitude',
           timestamp, value: coords.longitude, unit: '°', createdAt: now, packetTimestamp, packetId,
           channel: channelIndex, precisionBits, gpsAccuracy
-        });
+        }, this.sourceId);
         if (position.altitude !== undefined && position.altitude !== null) {
           await databaseService.telemetry.insertTelemetry({
             nodeId, nodeNum: fromNum, telemetryType: 'altitude',
             timestamp, value: position.altitude, unit: 'm', createdAt: now, packetTimestamp, packetId,
             channel: channelIndex
-          });
+          }, this.sourceId);
         }
 
         // Store satellites in view for GPS accuracy tracking
@@ -4716,7 +4716,7 @@ class MeshtasticManager implements ISourceManager {
             nodeId, nodeNum: fromNum, telemetryType: 'sats_in_view',
             timestamp, value: satsInView, unit: 'sats', createdAt: now, packetTimestamp, packetId,
             channel: channelIndex
-          });
+          }, this.sourceId);
         }
 
         // Store ground speed if available (in m/s)
@@ -4726,7 +4726,7 @@ class MeshtasticManager implements ISourceManager {
             nodeId, nodeNum: fromNum, telemetryType: 'ground_speed',
             timestamp, value: groundSpeed, unit: 'm/s', createdAt: now, packetTimestamp, packetId,
             channel: channelIndex
-          });
+          }, this.sourceId);
         }
 
         // Store ground track/heading if available (in 1/100 degrees, convert to degrees)
@@ -4738,7 +4738,7 @@ class MeshtasticManager implements ISourceManager {
             nodeId, nodeNum: fromNum, telemetryType: 'ground_track',
             timestamp, value: headingDegrees, unit: '°', createdAt: now, packetTimestamp, packetId,
             channel: channelIndex
-          });
+          }, this.sourceId);
         }
 
         // Skip overwriting the local node's position from mesh broadcast packets when fixedPosition is enabled.
@@ -5005,7 +5005,7 @@ class MeshtasticManager implements ISourceManager {
             unit: 'dB',
             createdAt: timestamp,
             packetId
-          });
+          }, this.sourceId);
           const reason = !latestSnrTelemetry ? 'initial' :
                         latestSnrTelemetry.value !== meshPacket.rxSnr ? 'changed' : 'periodic';
           logger.debug(`📊 Saved local SNR telemetry: ${meshPacket.rxSnr} dB (${reason}, previous: ${latestSnrTelemetry?.value || 'N/A'})`);
@@ -5032,7 +5032,7 @@ class MeshtasticManager implements ISourceManager {
             unit: 'dBm',
             createdAt: timestamp,
             packetId
-          });
+          }, this.sourceId);
           const reason = !latestRssiTelemetry ? 'initial' :
                         latestRssiTelemetry.value !== meshPacket.rxRssi ? 'changed' : 'periodic';
           logger.debug(`📊 Saved RSSI telemetry: ${meshPacket.rxRssi} dBm (${reason}, previous: ${latestRssiTelemetry?.value || 'N/A'})`);
@@ -5107,31 +5107,31 @@ class MeshtasticManager implements ISourceManager {
           await databaseService.telemetry.insertTelemetry({
             nodeId, nodeNum: fromNum, telemetryType: 'batteryLevel',
             timestamp, value: deviceMetrics.batteryLevel, unit: '%', createdAt: now, packetTimestamp, packetId
-          });
+          }, this.sourceId);
         }
         if (deviceMetrics.voltage !== undefined && deviceMetrics.voltage !== null && !isNaN(deviceMetrics.voltage)) {
           await databaseService.telemetry.insertTelemetry({
             nodeId, nodeNum: fromNum, telemetryType: 'voltage',
             timestamp, value: deviceMetrics.voltage, unit: 'V', createdAt: now, packetTimestamp, packetId
-          });
+          }, this.sourceId);
         }
         if (deviceMetrics.channelUtilization !== undefined && deviceMetrics.channelUtilization !== null && !isNaN(deviceMetrics.channelUtilization)) {
           await databaseService.telemetry.insertTelemetry({
             nodeId, nodeNum: fromNum, telemetryType: 'channelUtilization',
             timestamp, value: deviceMetrics.channelUtilization, unit: '%', createdAt: now, packetTimestamp, packetId
-          });
+          }, this.sourceId);
         }
         if (deviceMetrics.airUtilTx !== undefined && deviceMetrics.airUtilTx !== null && !isNaN(deviceMetrics.airUtilTx)) {
           await databaseService.telemetry.insertTelemetry({
             nodeId, nodeNum: fromNum, telemetryType: 'airUtilTx',
             timestamp, value: deviceMetrics.airUtilTx, unit: '%', createdAt: now, packetTimestamp, packetId
-          });
+          }, this.sourceId);
         }
         if (deviceMetrics.uptimeSeconds !== undefined && deviceMetrics.uptimeSeconds !== null && !isNaN(deviceMetrics.uptimeSeconds)) {
           await databaseService.telemetry.insertTelemetry({
             nodeId, nodeNum: fromNum, telemetryType: 'uptimeSeconds',
             timestamp, value: deviceMetrics.uptimeSeconds, unit: 's', createdAt: now, packetTimestamp, packetId
-          });
+          }, this.sourceId);
         }
       } else if (telemetry.environmentMetrics) {
         const envMetrics = telemetry.environmentMetrics;
@@ -5195,7 +5195,7 @@ class MeshtasticManager implements ISourceManager {
             await databaseService.telemetry.insertTelemetry({
               nodeId, nodeNum: fromNum, telemetryType: String(voltageKey),
               timestamp, value: Number(voltage), unit: 'V', createdAt: now, packetTimestamp, packetId
-            });
+            }, this.sourceId);
           }
 
           // Save current for this channel
@@ -5204,7 +5204,7 @@ class MeshtasticManager implements ISourceManager {
             await databaseService.telemetry.insertTelemetry({
               nodeId, nodeNum: fromNum, telemetryType: String(currentKey),
               timestamp, value: Number(current), unit: 'mA', createdAt: now, packetTimestamp, packetId
-            });
+            }, this.sourceId);
           }
         }
       } else if (telemetry.airQualityMetrics) {
@@ -5319,19 +5319,19 @@ class MeshtasticManager implements ISourceManager {
         await databaseService.telemetry.insertTelemetry({
           nodeId, nodeNum: fromNum, telemetryType: 'paxcounterWifi',
           timestamp, value: paxcount.wifi, unit: 'devices', createdAt: now, packetId
-        });
+        }, this.sourceId);
       }
       if (paxcount.ble !== undefined && paxcount.ble !== null && !isNaN(paxcount.ble)) {
         await databaseService.telemetry.insertTelemetry({
           nodeId, nodeNum: fromNum, telemetryType: 'paxcounterBle',
           timestamp, value: paxcount.ble, unit: 'devices', createdAt: now, packetId
-        });
+        }, this.sourceId);
       }
       if (paxcount.uptime !== undefined && paxcount.uptime !== null && !isNaN(paxcount.uptime)) {
         await databaseService.telemetry.insertTelemetry({
           nodeId, nodeNum: fromNum, telemetryType: 'paxcounterUptime',
           timestamp, value: paxcount.uptime, unit: 's', createdAt: now, packetId
-        });
+        }, this.sourceId);
       }
 
       await databaseService.nodes.upsertNode(nodeData, this.sourceId);
@@ -5776,7 +5776,7 @@ class MeshtasticManager implements ISourceManager {
         unit: 'hops',
         createdAt: Date.now(),
         packetId: meshPacket.id ? Number(meshPacket.id) : undefined,
-      });
+      }, this.sourceId);
 
       // Emit WebSocket event for traceroute completion
       dataEventEmitter.emitTracerouteComplete(tracerouteRecord as any, this.sourceId);
@@ -6271,7 +6271,7 @@ class MeshtasticManager implements ISourceManager {
           value: finalLat,
           unit: '° (est)',
           createdAt: now
-        });
+        }, this.sourceId);
 
         await databaseService.telemetry.insertTelemetry({
           nodeId,
@@ -6281,7 +6281,7 @@ class MeshtasticManager implements ISourceManager {
           value: finalLon,
           unit: '° (est)',
           createdAt: now
-        });
+        }, this.sourceId);
 
         logger.debug(`📍 Estimated position for ${nodeId} (${node.longName || nodeId}): ${finalLat.toFixed(6)}, ${finalLon.toFixed(6)} (${weightingMethod})`);
       }
@@ -6374,8 +6374,9 @@ class MeshtasticManager implements ISourceManager {
           }
         }
 
-        // Delete old neighbors then batch-insert new ones
-        await databaseService.neighbors.deleteNeighborInfoForNode(fromNum);
+        // Delete old neighbors then batch-insert new ones — scoped to this source so
+        // a NeighborInfo packet from one source doesn't wipe another source's rows.
+        await databaseService.neighbors.deleteNeighborInfoForNode(fromNum, this.sourceId);
 
         const records = validNeighbors.map(vn => ({
           nodeNum: fromNum,
@@ -6386,7 +6387,7 @@ class MeshtasticManager implements ISourceManager {
           createdAt: nowMs,
         }));
 
-        await databaseService.neighbors.insertNeighborInfoBatch(records);
+        await databaseService.neighbors.insertNeighborInfoBatch(records, this.sourceId);
 
         for (const vn of validNeighbors) {
           const neighborNodeId = `!${vn.nodeNum.toString(16).padStart(8, '0')}`;
@@ -6684,18 +6685,18 @@ class MeshtasticManager implements ISourceManager {
           nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'latitude',
           timestamp: positionTelemetryData.timestamp, value: positionTelemetryData.latitude, unit: '°', createdAt: now,
           channel: positionTelemetryData.channel, precisionBits: positionTelemetryData.precisionBits
-        });
+        }, this.sourceId);
         await databaseService.telemetry.insertTelemetry({
           nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'longitude',
           timestamp: positionTelemetryData.timestamp, value: positionTelemetryData.longitude, unit: '°', createdAt: now,
           channel: positionTelemetryData.channel, precisionBits: positionTelemetryData.precisionBits
-        });
+        }, this.sourceId);
         if (positionTelemetryData.altitude !== undefined && positionTelemetryData.altitude !== null) {
           await databaseService.telemetry.insertTelemetry({
             nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'altitude',
             timestamp: positionTelemetryData.timestamp, value: positionTelemetryData.altitude, unit: 'm', createdAt: now,
             channel: positionTelemetryData.channel, precisionBits: positionTelemetryData.precisionBits
-          });
+          }, this.sourceId);
         }
         // Store ground speed if available (in m/s)
         if (positionTelemetryData.groundSpeed !== undefined && positionTelemetryData.groundSpeed > 0) {
@@ -6703,7 +6704,7 @@ class MeshtasticManager implements ISourceManager {
             nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'ground_speed',
             timestamp: positionTelemetryData.timestamp, value: positionTelemetryData.groundSpeed, unit: 'm/s', createdAt: now,
             channel: positionTelemetryData.channel
-          });
+          }, this.sourceId);
         }
         // Store ground track/heading if available (in 1/100 degrees, convert to degrees)
         if (positionTelemetryData.groundTrack !== undefined && positionTelemetryData.groundTrack > 0) {
@@ -6712,7 +6713,7 @@ class MeshtasticManager implements ISourceManager {
             nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'ground_track',
             timestamp: positionTelemetryData.timestamp, value: headingDegrees, unit: '°', createdAt: now,
             channel: positionTelemetryData.channel
-          });
+          }, this.sourceId);
         }
 
         // Update mobility detection for this node (fire and forget)
@@ -6729,35 +6730,35 @@ class MeshtasticManager implements ISourceManager {
           await databaseService.telemetry.insertTelemetry({
             nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'batteryLevel',
             timestamp: deviceMetricsTelemetryData.timestamp, value: deviceMetricsTelemetryData.batteryLevel, unit: '%', createdAt: now
-          });
+          }, this.sourceId);
         }
 
         if (deviceMetricsTelemetryData.voltage !== undefined && deviceMetricsTelemetryData.voltage !== null && !isNaN(deviceMetricsTelemetryData.voltage)) {
           await databaseService.telemetry.insertTelemetry({
             nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'voltage',
             timestamp: deviceMetricsTelemetryData.timestamp, value: deviceMetricsTelemetryData.voltage, unit: 'V', createdAt: now
-          });
+          }, this.sourceId);
         }
 
         if (deviceMetricsTelemetryData.channelUtilization !== undefined && deviceMetricsTelemetryData.channelUtilization !== null && !isNaN(deviceMetricsTelemetryData.channelUtilization)) {
           await databaseService.telemetry.insertTelemetry({
             nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'channelUtilization',
             timestamp: deviceMetricsTelemetryData.timestamp, value: deviceMetricsTelemetryData.channelUtilization, unit: '%', createdAt: now
-          });
+          }, this.sourceId);
         }
 
         if (deviceMetricsTelemetryData.airUtilTx !== undefined && deviceMetricsTelemetryData.airUtilTx !== null && !isNaN(deviceMetricsTelemetryData.airUtilTx)) {
           await databaseService.telemetry.insertTelemetry({
             nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'airUtilTx',
             timestamp: deviceMetricsTelemetryData.timestamp, value: deviceMetricsTelemetryData.airUtilTx, unit: '%', createdAt: now
-          });
+          }, this.sourceId);
         }
 
         if (deviceMetricsTelemetryData.uptimeSeconds !== undefined && deviceMetricsTelemetryData.uptimeSeconds !== null && !isNaN(deviceMetricsTelemetryData.uptimeSeconds)) {
           await databaseService.telemetry.insertTelemetry({
             nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'uptimeSeconds',
             timestamp: deviceMetricsTelemetryData.timestamp, value: deviceMetricsTelemetryData.uptimeSeconds, unit: 's', createdAt: now
-          });
+          }, this.sourceId);
         }
       }
 
@@ -6783,7 +6784,7 @@ class MeshtasticManager implements ISourceManager {
             value: nodeInfo.snr,
             unit: 'dB',
             createdAt: now
-          });
+          }, this.sourceId);
           const reason = !latestSnrTelemetry ? 'initial' :
                         latestSnrTelemetry.value !== nodeInfo.snr ? 'changed' : 'periodic';
           logger.debug(`📊 Saved remote SNR telemetry from NodeInfo: ${nodeInfo.snr} dB (${reason}, previous: ${latestSnrTelemetry?.value || 'N/A'})`);
@@ -12383,7 +12384,7 @@ class MeshtasticManager implements ISourceManager {
       value: quality,
       unit: 'quality',
       createdAt: Date.now(),
-    });
+    }, this.sourceId);
   }
 
   /**

--- a/src/server/migrations/039_purge_null_sourceid_telemetry.test.ts
+++ b/src/server/migrations/039_purge_null_sourceid_telemetry.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Migration 039 — Purge NULL-sourceId telemetry
+ *
+ * Validates the SQLite migration deletes stranded rows (sourceId IS NULL),
+ * preserves rows that carry a sourceId, and is idempotent on second run.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './039_purge_null_sourceid_telemetry.js';
+
+function createTelemetryTable(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE telemetry (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      nodeId TEXT NOT NULL,
+      nodeNum INTEGER NOT NULL,
+      telemetryType TEXT NOT NULL,
+      timestamp INTEGER NOT NULL,
+      value REAL NOT NULL,
+      unit TEXT,
+      createdAt INTEGER NOT NULL,
+      packetTimestamp INTEGER,
+      packetId INTEGER,
+      channel INTEGER,
+      precisionBits INTEGER,
+      gpsAccuracy INTEGER,
+      sourceId TEXT
+    )
+  `);
+}
+
+function insert(db: Database.Database, sourceId: string | null) {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO telemetry (nodeId, nodeNum, telemetryType, timestamp, value, unit, createdAt, sourceId)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run('!deadbeef', 0xdeadbeef, 'batteryLevel', now, 50, '%', now, sourceId);
+}
+
+describe('Migration 039 — purge NULL-sourceId telemetry', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createTelemetryTable(db);
+  });
+
+  it('deletes rows with NULL sourceId', () => {
+    insert(db, null);
+    insert(db, null);
+    insert(db, null);
+    expect((db.prepare(`SELECT COUNT(*) c FROM telemetry`).get() as any).c).toBe(3);
+
+    migration.up(db);
+
+    expect((db.prepare(`SELECT COUNT(*) c FROM telemetry`).get() as any).c).toBe(0);
+  });
+
+  it('preserves rows with a non-NULL sourceId', () => {
+    insert(db, 'source-A');
+    insert(db, 'source-B');
+    insert(db, null);
+
+    migration.up(db);
+
+    const rows = db.prepare(`SELECT sourceId FROM telemetry ORDER BY sourceId`).all() as any[];
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.sourceId)).toEqual(['source-A', 'source-B']);
+  });
+
+  it('is idempotent — running twice is a no-op after the first pass', () => {
+    insert(db, null);
+    insert(db, 'source-A');
+
+    migration.up(db);
+    migration.up(db);
+
+    const rows = db.prepare(`SELECT sourceId FROM telemetry`).all() as any[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sourceId).toBe('source-A');
+  });
+});

--- a/src/server/migrations/039_purge_null_sourceid_telemetry.ts
+++ b/src/server/migrations/039_purge_null_sourceid_telemetry.ts
@@ -1,0 +1,47 @@
+/**
+ * Migration 039: Purge telemetry rows with NULL sourceId.
+ *
+ * Before v4.0.0-beta4 the write path in meshtasticManager.ts never passed
+ * `this.sourceId` into `databaseService.insertTelemetry(...)`, so every
+ * telemetry row inserted since migration 021 introduced the column was
+ * persisted with `sourceId = NULL`. The read path filters strictly on
+ * equality (`withSourceScope`), so source-scoped views returned zero rows
+ * and the per-node TelemetryGraphs were empty.
+ *
+ * The write path is now fixed; this migration discards the stranded rows
+ * so the read path can reflect incoming, correctly-tagged data.
+ *
+ * Idempotent — re-running is a no-op once NULL rows are gone.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+export const migration = {
+  up(db: Database): void {
+    const res = db
+      .prepare(`DELETE FROM telemetry WHERE sourceId IS NULL`)
+      .run();
+    if (res.changes > 0) {
+      logger.info(`Migration 039: purged ${res.changes} telemetry rows with NULL sourceId`);
+    }
+  },
+};
+
+export async function runMigration039Postgres(client: any): Promise<void> {
+  const res = await client.query(
+    `DELETE FROM telemetry WHERE "sourceId" IS NULL`
+  );
+  if (res.rowCount && res.rowCount > 0) {
+    logger.info(`Migration 039: purged ${res.rowCount} telemetry rows with NULL sourceId (PG)`);
+  }
+}
+
+export async function runMigration039Mysql(pool: any): Promise<void> {
+  const [res] = await pool.query(
+    `DELETE FROM telemetry WHERE sourceId IS NULL`
+  );
+  const affected = (res as any).affectedRows ?? 0;
+  if (affected > 0) {
+    logger.info(`Migration 039: purged ${affected} telemetry rows with NULL sourceId (MySQL)`);
+  }
+}

--- a/src/server/migrations/040_purge_null_sourceid_neighbor_info.test.ts
+++ b/src/server/migrations/040_purge_null_sourceid_neighbor_info.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Migration 040 — Purge NULL-sourceId neighbor_info
+ *
+ * Validates the SQLite migration deletes rows with sourceId IS NULL,
+ * preserves rows that carry a sourceId, and is idempotent on second run.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './040_purge_null_sourceid_neighbor_info.js';
+
+function createNeighborInfoTable(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE neighbor_info (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      nodeNum INTEGER NOT NULL,
+      neighborNodeNum INTEGER NOT NULL,
+      snr REAL,
+      lastRxTime INTEGER,
+      timestamp INTEGER NOT NULL,
+      createdAt INTEGER NOT NULL,
+      sourceId TEXT
+    )
+  `);
+}
+
+function insert(db: Database.Database, sourceId: string | null) {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO neighbor_info (nodeNum, neighborNodeNum, snr, lastRxTime, timestamp, createdAt, sourceId)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(0xdeadbeef, 0xcafebabe, 5.5, now, now, now, sourceId);
+}
+
+describe('Migration 040 — purge NULL-sourceId neighbor_info', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createNeighborInfoTable(db);
+  });
+
+  it('deletes rows with NULL sourceId', () => {
+    insert(db, null);
+    insert(db, null);
+    insert(db, null);
+    expect((db.prepare(`SELECT COUNT(*) c FROM neighbor_info`).get() as any).c).toBe(3);
+
+    migration.up(db);
+
+    expect((db.prepare(`SELECT COUNT(*) c FROM neighbor_info`).get() as any).c).toBe(0);
+  });
+
+  it('preserves rows with a non-NULL sourceId', () => {
+    insert(db, 'source-A');
+    insert(db, 'source-B');
+    insert(db, null);
+
+    migration.up(db);
+
+    const rows = db.prepare(`SELECT sourceId FROM neighbor_info ORDER BY sourceId`).all() as any[];
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.sourceId)).toEqual(['source-A', 'source-B']);
+  });
+
+  it('is idempotent — running twice is a no-op after the first pass', () => {
+    insert(db, null);
+    insert(db, 'source-A');
+
+    migration.up(db);
+    migration.up(db);
+
+    const rows = db.prepare(`SELECT sourceId FROM neighbor_info`).all() as any[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sourceId).toBe('source-A');
+  });
+});

--- a/src/server/migrations/040_purge_null_sourceid_neighbor_info.ts
+++ b/src/server/migrations/040_purge_null_sourceid_neighbor_info.ts
@@ -1,0 +1,49 @@
+/**
+ * Migration 040: Purge neighbor_info rows with NULL sourceId.
+ *
+ * Before the fix in this release, `meshtasticManager.handleNeighborInfoApp`
+ * called `deleteNeighborInfoForNode(fromNum)` and `insertNeighborInfoBatch(
+ * records)` without forwarding `this.sourceId`. The repository treats an
+ * undefined sourceId as "no filter", so:
+ *   - the delete wiped every source's neighbor rows for that node, and
+ *   - the re-insert wrote NULL sourceId, making the rows invisible to the
+ *     source-scoped read path (`withSourceScope` strict equality).
+ *
+ * Write path is now fixed (both calls forward `this.sourceId`); this
+ * migration discards the stranded rows so future data reflects correct
+ * per-source attribution.
+ *
+ * Idempotent — re-running is a no-op once NULL rows are gone.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+export const migration = {
+  up(db: Database): void {
+    const res = db
+      .prepare(`DELETE FROM neighbor_info WHERE sourceId IS NULL`)
+      .run();
+    if (res.changes > 0) {
+      logger.info(`Migration 040: purged ${res.changes} neighbor_info rows with NULL sourceId`);
+    }
+  },
+};
+
+export async function runMigration040Postgres(client: any): Promise<void> {
+  const res = await client.query(
+    `DELETE FROM neighbor_info WHERE "sourceId" IS NULL`
+  );
+  if (res.rowCount && res.rowCount > 0) {
+    logger.info(`Migration 040: purged ${res.rowCount} neighbor_info rows with NULL sourceId (PG)`);
+  }
+}
+
+export async function runMigration040Mysql(pool: any): Promise<void> {
+  const [res] = await pool.query(
+    `DELETE FROM neighbor_info WHERE sourceId IS NULL`
+  );
+  const affected = (res as any).affectedRows ?? 0;
+  if (affected > 0) {
+    logger.info(`Migration 040: purged ${affected} neighbor_info rows with NULL sourceId (MySQL)`);
+  }
+}

--- a/src/server/routes/v1/traceroutes.ts
+++ b/src/server/routes/v1/traceroutes.ts
@@ -26,7 +26,7 @@ router.get('/', async (req: Request, res: Response) => {
     const sourceIdStr = typeof sourceId === 'string' ? sourceId : undefined;
     const maxLimit = parseInt(limit as string) || 100;
 
-    let traceroutes = databaseService.getAllTraceroutes();
+    let traceroutes = databaseService.getAllTraceroutes(maxLimit, sourceIdStr);
 
     // Apply filters
     if (fromNodeId) {
@@ -36,7 +36,7 @@ router.get('/', async (req: Request, res: Response) => {
       traceroutes = traceroutes.filter(t => t.toNodeId === toNodeId);
     }
 
-    // Apply limit
+    // Apply limit (redundant with the repo limit, but guards against fromNodeId/toNodeId pre-filtering)
     traceroutes = traceroutes.slice(0, maxLimit);
 
     // Mask traceroutes from channels the user cannot access
@@ -65,7 +65,7 @@ router.get('/:fromNodeId/:toNodeId', async (req: Request, res: Response) => {
   try {
     const { fromNodeId, toNodeId } = req.params;
     const sourceIdParam = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
-    const allTraceroutes = databaseService.getAllTraceroutes(100);
+    const allTraceroutes = databaseService.getAllTraceroutes(100, sourceIdParam);
     const traceroute = allTraceroutes.find(t => t.fromNodeId === fromNodeId && t.toNodeId === toNodeId);
 
     if (!traceroute) {

--- a/src/services/database.service.test.ts
+++ b/src/services/database.service.test.ts
@@ -408,7 +408,21 @@ describe('DatabaseService — insertTelemetryAsync', () => {
     mockTelemetryRepo.insertTelemetry.mockResolvedValue(undefined);
 
     await databaseService.insertTelemetryAsync(telemetryData as any);
-    expect(mockTelemetryRepo.insertTelemetry).toHaveBeenCalledWith(telemetryData);
+    expect(mockTelemetryRepo.insertTelemetry).toHaveBeenCalledWith(telemetryData, undefined);
+  });
+
+  it('forwards sourceId to telemetryRepo.insertTelemetry', async () => {
+    const telemetryData = {
+      nodeId: '!00003039',
+      telemetryType: 'device',
+      batteryLevel: 85,
+      timestamp: Date.now(),
+      createdAt: Date.now(),
+    };
+    mockTelemetryRepo.insertTelemetry.mockResolvedValue(undefined);
+
+    await databaseService.insertTelemetryAsync(telemetryData as any, 'src-abc');
+    expect(mockTelemetryRepo.insertTelemetry).toHaveBeenCalledWith(telemetryData, 'src-abc');
   });
 });
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -3627,14 +3627,14 @@ class DatabaseService {
   }
 
   // Telemetry operations
-  insertTelemetry(telemetryData: DbTelemetry): void {
+  insertTelemetry(telemetryData: DbTelemetry, sourceId?: string): void {
     // For PostgreSQL/MySQL, fire-and-forget async insert
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (this.telemetryRepo) {
         // Note: We removed the nodesCache check here because it was too aggressive -
         // it would skip telemetry for nodes that exist in the DB but not in the in-memory cache
         // (e.g., after server restart). The foreign key error handling below handles race conditions.
-        this.telemetryRepo.insertTelemetry(telemetryData).catch((error) => {
+        this.telemetryRepo.insertTelemetry(telemetryData, sourceId).catch((error) => {
           // Ignore foreign key violations - node might not be persisted yet
           const errorStr = String(error);
           if (errorStr.includes('foreign key') || errorStr.includes('violates')) {
@@ -3649,7 +3649,7 @@ class DatabaseService {
       return;
     }
 
-    this.telemetry.insertTelemetrySync(telemetryData);
+    this.telemetry.insertTelemetrySync(telemetryData, sourceId);
 
     // Invalidate the telemetry types cache since we may have added a new type
     this.invalidateTelemetryTypesCache();
@@ -3658,8 +3658,8 @@ class DatabaseService {
   /**
    * Async version of insertTelemetry - works with all database backends
    */
-  async insertTelemetryAsync(telemetryData: DbTelemetry): Promise<void> {
-    await this.telemetry.insertTelemetry(telemetryData);
+  async insertTelemetryAsync(telemetryData: DbTelemetry, sourceId?: string): Promise<void> {
+    await this.telemetry.insertTelemetry(telemetryData, sourceId);
     this.invalidateTelemetryTypesCache();
   }
 
@@ -4258,14 +4258,14 @@ class DatabaseService {
     return this.traceroutes.getTraceroutesByNodesSync(fromNodeNum, toNodeNum, limit) as unknown as DbTraceroute[];
   }
 
-  getAllTraceroutes(limit: number = 100): DbTraceroute[] {
+  getAllTraceroutes(limit: number = 100, sourceId?: string): DbTraceroute[] {
     // For PostgreSQL/MySQL, use cached traceroutes or return empty
     // Traceroute data is primarily real-time from mesh traffic
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       // Use traceroutesRepo if available - fire async and return cache
       if (this.traceroutesRepo) {
         // Fire async query and update cache in background
-        this.traceroutesRepo.getAllTraceroutes(limit).then(traceroutes => {
+        this.traceroutesRepo.getAllTraceroutes(limit, sourceId).then(traceroutes => {
           // Store in internal cache for next sync call (cast to local DbTraceroute type)
           this._traceroutesCache = traceroutes.map(t => ({
             ...t,
@@ -4280,7 +4280,7 @@ class DatabaseService {
       return this._traceroutesCache || [];
     }
 
-    return this.traceroutes.getAllTraceroutesRecentSync(limit) as unknown as DbTraceroute[];
+    return this.traceroutes.getAllTraceroutesRecentSync(limit, sourceId) as unknown as DbTraceroute[];
   }
 
   getNodeNeedingTraceroute(localNodeNum: number): DbNode | null {


### PR DESCRIPTION
## Summary

Three source-attribution bugs were masking data across TCP sources and stranding rows with NULL sourceId:

- **Telemetry write path** — ~38 `insertTelemetry`/`insertTelemetryAsync` call sites in `meshtasticManager.ts` were not passing `this.sourceId`, so rows landed with NULL sourceId and became invisible to the source-scoped read path. **Impact: 11,504 stranded rows** purged by migration 039.
- **neighbor_info write path** — `deleteNeighborInfoForNode` and `insertNeighborInfoBatch` at `meshtasticManager.ts:6378/6389` ignored `this.sourceId`. Because `withSourceScope(table, undefined)` returns `undefined`, Drizzle **dropped the WHERE clause on the delete**, turning every NeighborInfo packet into a cross-source destructive wipe of the other source's rows. Inserts then landed with NULL sourceId. **Impact: 3 stranded rows** purged by migration 040 — low count only because the wipe happened on every packet, so the damage was continuous rather than cumulative.
- **v1 traceroutes API** — `/api/v1/traceroutes?sourceId=X` extracted the query param but never passed it to `DatabaseService.getAllTraceroutes`. Clients got cross-source results. Facade now accepts `sourceId` and route handlers forward it.

## Root Cause

`withSourceScope(table, sourceId)` uses strict `eq(table.sourceId, sourceId)`. NULL never matches via `eq`, so stranded rows become read-invisible. When passed `undefined`, Drizzle's query builder drops the filter entirely — which is why neighbor_info's delete-then-insert pattern became destructive rather than just strand-inducing.

Why this wasn't caught earlier: these write paths predated the migration 029 composite-PK refactor on `nodes` (which made NULL sourceId structurally impossible on that table). The other source-scoped tables (`telemetry`, `neighbor_info`, `traceroutes`) kept nullable `sourceId` columns, so the omissions compiled and tested fine in single-source setups.

## Changes

- `src/server/meshtasticManager.ts` — thread `this.sourceId` through all telemetry + neighbor_info writes (83 line diff covers ~40 call sites)
- `src/services/database.ts` — `insertTelemetry(data, sourceId?)`, `insertTelemetryAsync(data, sourceId?)`, `getAllTraceroutes(limit, sourceId?)` facade signatures
- `src/db/repositories/traceroutes.ts` — `getAllTraceroutesRecentSync` now accepts `sourceId`, uses `withSourceScope`
- `src/db/types.ts` — `DbNeighborInfo.sourceId?: string | null`
- `src/server/routes/v1/traceroutes.ts` — lines 29, 68 forward sourceId to facade
- `src/server/migrations/039_purge_null_sourceid_telemetry.ts` — purge migration + test
- `src/server/migrations/040_purge_null_sourceid_neighbor_info.ts` — purge migration + test
- `src/db/migrations.ts` / `migrations.test.ts` — registry bumped to 40
- `src/db/repositories/neighbors.test.ts` — regression tests (cross-source wipe, sourceId persistence)
- `src/services/database.service.test.ts` — facade test for new sourceId param

## Data impact (live dev validation)

- Migration 039 purged **11,504 stranded telemetry rows**
- Migration 040 purged **3 stranded neighbor_info rows**
- Post-deploy: **0 NULL-sourceId rows** across both tables; ingestion rate ~32 rows/min; both TCP sources (sandbox/sentry) correctly attributed
- Packet plumbing audit confirmed lossless (no drops, no queue backlog, gap p99 < 200s per source)

## Test plan

- [x] Migration 039 unit tests (deletes NULL, preserves non-NULL, idempotent)
- [x] Migration 040 unit tests (same three cases)
- [x] neighbors.test.ts — insertNeighborInfoBatch persists sourceId when provided
- [x] neighbors.test.ts — scoped delete leaves other-source rows intact (cross-source wipe regression)
- [x] database.service.test.ts — `insertTelemetryAsync(data, sourceId)` forwards correctly
- [x] Full suite green (4245 tests) during development
- [x] Live container spot-check: 0 NULL-sourceId rows; fresh telemetry and neighbor_info rows carry correct sourceId
- [ ] CI pipeline
- [ ] system-tests workflow

## Non-Goals

- No change to `withSourceScope` semantics
- No UNKNOWN_APP work (separate audit confirmed those are legitimate decrypt failures on foreign channels, working as designed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)