### PR TITLE
feat(dashboard): wire up News popup on main Dashboard page

### DIFF
--- a/.claude/agents/docker-dev-deployer.md
+++ b/.claude/agents/docker-dev-deployer.md
@@ -40,6 +40,11 @@ You are an elite DevOps engineer specializing in Docker-based development workfl
 
 ## Critical Rules
 
+- **NEVER destroy named volumes.** The SQLite DB, PostgreSQL data, MySQL data, and backups live in named volumes (e.g. `meshmonitor_meshmonitor-sqlite-data`). Losing them wipes the user's nodes, messages, users, settings, and backups.
+  - ❌ FORBIDDEN: `docker compose down -v`, `docker compose down --volumes`, `docker compose rm -v`, `docker compose rm -f -s -v`, `docker volume rm ...`, `docker volume prune`, `docker system prune --volumes`, `--renew-anon-volumes`
+  - ✅ ALLOWED: `docker compose down` (no `-v`), `docker compose stop`, `docker compose restart`, `docker compose up -d` (recreates containers, preserves volumes), `docker compose build`, `docker compose build --no-cache`
+  - A "fresh rebuild" means rebuild the **image**, not the volume. The image is the compiled code; the volume is the user's data. Never conflate them.
+  - If you believe the volume *must* be wiped, STOP and ask the user explicitly first.
 - The container does NOT have `sqlite3` binary available — don't try to use it
 - Only the backend talks to the Meshtastic node; never assume frontend-direct access
 - Never run Docker dev container and local npm dev server simultaneously — notify the user if they need to switch

--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -23,6 +23,8 @@ interface DashboardSidebarProps {
   mobileOpen?: boolean;
   /** Called to close the drawer on mobile (after selecting a source or tapping backdrop). */
   onMobileClose?: () => void;
+  /** Opens the News popup when the footer news button is clicked. */
+  onNewsClick?: () => void;
 }
 
 function getStatusInfo(
@@ -134,6 +136,7 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
   onDeleteSource,
   mobileOpen = false,
   onMobileClose,
+  onNewsClick,
 }) => {
   const navigate = useNavigate();
 
@@ -282,7 +285,8 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
           <button
             className="dashboard-sidebar-footer-btn"
             title="News"
-            disabled
+            onClick={onNewsClick}
+            disabled={!onNewsClick}
           >
             📰
           </button>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -20,7 +20,10 @@ import DashboardSidebar from '../components/Dashboard/DashboardSidebar';
 import DashboardMap from '../components/Dashboard/DashboardMap';
 import LoginModal from '../components/LoginModal';
 import UserMenu from '../components/UserMenu';
+import { NewsPopup } from '../components/NewsPopup';
 import { ToastProvider } from '../components/ToastContainer';
+import api from '../services/api';
+import { logger } from '../utils/logger';
 import { appBasename } from '../init';
 import '../styles/dashboard.css';
 
@@ -58,6 +61,10 @@ function DashboardInner() {
   // Mobile drawer state — hamburger toggles; source selection auto-closes.
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
+  // News popup state — auto-opens on unread news, can be reopened via sidebar footer button.
+  const [showNewsPopup, setShowNewsPopup] = useState(false);
+  const [forceShowAllNews, setForceShowAllNews] = useState(false);
+
   // Source add/edit modal state
   const [showSourceModal, setShowSourceModal] = useState(false);
   const [editingSourceId, setEditingSourceId] = useState<string | null>(null);
@@ -83,6 +90,27 @@ function DashboardInner() {
     const firstEnabled = sources.find((s) => s.enabled);
     setSelectedSourceId(firstEnabled?.id ?? sources[0].id);
   }, [isSuccess, sources, selectedSourceId]);
+
+  // Auto-show news popup when authenticated user has unread news.
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await api.getUnreadNews();
+        if (cancelled) return;
+        if (response.items && response.items.length > 0) {
+          setForceShowAllNews(false);
+          setShowNewsPopup(true);
+        }
+      } catch (err) {
+        logger.debug('Failed to fetch unread news:', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated]);
 
   // Build node-count map. Each source's count comes from its /status response
   // (added in sourceRoutes.ts), polled in parallel by useSourceStatuses. The
@@ -281,6 +309,10 @@ function DashboardInner() {
           onDeleteSource={onDeleteSource}
           mobileOpen={mobileSidebarOpen}
           onMobileClose={() => setMobileSidebarOpen(false)}
+          onNewsClick={() => {
+            setForceShowAllNews(true);
+            setShowNewsPopup(true);
+          }}
         />
 
         <DashboardMap
@@ -297,6 +329,17 @@ function DashboardInner() {
 
       {/* Login modal */}
       <LoginModal isOpen={showLogin} onClose={() => setShowLogin(false)} />
+
+      {/* News popup — auto-opens on unread news, reopened via sidebar footer. */}
+      <NewsPopup
+        isOpen={showNewsPopup}
+        onClose={() => {
+          setShowNewsPopup(false);
+          setForceShowAllNews(false);
+        }}
+        forceShowAll={forceShowAllNews}
+        isAuthenticated={isAuthenticated}
+      />
 
       {/* Delete confirmation dialog */}
       {deleteConfirm && (


### PR DESCRIPTION
## Summary

- Wires the 📰 button in the Dashboard sidebar footer to open `NewsPopup` (previously disabled).
- Auto-opens `NewsPopup` for authenticated users with unread news on the Dashboard page — matches existing App.tsx behavior.
- Hardens the `docker-dev-deployer` agent to never destroy named volumes during rebuilds, after a "fresh clean build" wiped the SQLite data volume (`meshmonitor_meshmonitor-sqlite-data`) on 2026-04-17.

## Changes

- `src/components/Dashboard/DashboardSidebar.tsx` — new `onNewsClick?: () => void` prop; the News button fires it and only renders disabled when no handler is passed.
- `src/pages/DashboardPage.tsx` — adds `showNewsPopup` / `forceShowAllNews` state, `useEffect` polling `api.getUnreadNews()` on auth, and renders `<NewsPopup>`. Matches App.tsx semantics exactly (close clears both flags; manual open sets `forceShowAll=true`).
- `.claude/agents/docker-dev-deployer.md` — forbids `down -v`, `--volumes`, `volume rm`, `volume prune`, `system prune --volumes`, and `--renew-anon-volumes` in the Critical Rules section, with the allowed rebuild commands listed.

## Test plan

- [ ] Load the Dashboard as an authenticated user with unread news → popup auto-opens, same look/feel as legacy.
- [ ] Dismiss popup; reopen via 📰 button → shows full feed (`forceShowAll=true`).
- [ ] Close popup; no repeat auto-open until new items appear.
- [ ] Load as unauthenticated user → popup does not auto-open; 📰 button still opens it manually and shows no-news state.
- [ ] Pagination / Previous/Next / "Don't show again" all work (inherited from `NewsPopup`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)