### PR TITLE
chore(release): bump version to 4.0.0-beta4

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.0.0-beta3",
+  "version": "4.0.0-beta4",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.0.0-beta3",
+  "version": "4.0.0-beta4",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.0.0-beta3
-appVersion: "4.0.0-beta3"
+version: 4.0.0-beta4
+appVersion: "4.0.0-beta4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta3",
+  "version": "4.0.0-beta4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.0.0-beta3",
+      "version": "4.0.0-beta4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta3",
+  "version": "4.0.0-beta4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bumps version from `4.0.0-beta3` → `4.0.0-beta4` across all five version files.

## Files Updated
- `package.json`
- `package-lock.json` (regenerated)
- `desktop/package.json`
- `desktop/src-tauri/tauri.conf.json`
- `helm/meshmonitor/Chart.yaml` (both `version` and `appVersion`)

## Test plan
- [ ] CI passes
- [ ] System Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)