### PR TITLE
fix(system-backup): include sources table in backup manifest

### DIFF
--- a/src/server/services/systemBackupService.test.ts
+++ b/src/server/services/systemBackupService.test.ts
@@ -43,7 +43,7 @@ vi.mock('../../services/database.js', () => ({
 
 // ─── Import service AFTER mocks ───────────────────────────────────────────────
 
-import { systemBackupService } from './systemBackupService.js';
+import { systemBackupService, BACKUP_TABLES } from './systemBackupService.js';
 
 // ─── Setup ────────────────────────────────────────────────────────────────────
 
@@ -274,5 +274,27 @@ describe('systemBackupService.deleteBackup', () => {
 
     await systemBackupService.deleteBackup('test');
     expect(fsMock.rmSync).toHaveBeenCalled();
+  });
+});
+
+// ─── BACKUP_TABLES manifest ──────────────────────────────────────────────────
+// Regression: every downstream table carries a sourceId FK to `sources`. If
+// `sources` is missing from the manifest, restoring a backup into a clean
+// install orphans every source-scoped row and loses all Source definitions.
+
+describe('BACKUP_TABLES manifest', () => {
+  it('includes the sources table', () => {
+    expect(BACKUP_TABLES).toContain('sources');
+  });
+
+  it('lists sources before any source-scoped child table', () => {
+    const sourcesIdx = BACKUP_TABLES.indexOf('sources');
+    expect(sourcesIdx).toBeGreaterThanOrEqual(0);
+    // Child tables that carry a sourceId FK — sources must come first so a
+    // future restore can recreate source definitions before inserting children.
+    for (const child of ['nodes', 'messages', 'telemetry', 'traceroutes', 'neighbor_info']) {
+      const childIdx = BACKUP_TABLES.indexOf(child);
+      expect(childIdx).toBeGreaterThan(sourcesIdx);
+    }
   });
 });

--- a/src/server/services/systemBackupService.ts
+++ b/src/server/services/systemBackupService.ts
@@ -14,7 +14,11 @@ const SYSTEM_BACKUP_DIR = process.env.SYSTEM_BACKUP_DIR || '/data/system-backups
 
 // All tables that should be backed up
 // NOTE: Excluded tables per ARCHITECTURE_LESSONS.md: sessions, push_subscriptions, backup_history, sqlite_sequence
-const BACKUP_TABLES = [
+export const BACKUP_TABLES = [
+  // 'sources' must come first: every downstream table carries a sourceId
+  // foreign key, so a future restore must recreate source definitions
+  // before inserting any source-scoped rows.
+  'sources',
   'nodes',
   'messages',
   'channels',


### PR DESCRIPTION
## Summary
The system backup's \`BACKUP_TABLES\` manifest omitted \`sources\`, so restoring into a clean install orphaned every \`sourceId\` FK — losing every Source row (name, type, config, enabled flag) and leaving all source-scoped tables pointing at non-existent sources.

- Added \`sources\` at the head of the manifest (restore order matters — parent table must exist before child inserts)
- Exported \`BACKUP_TABLES\` so tests can assert the invariant
- Added regression test asserting \`sources\` is present AND listed before any source-scoped child table

## Test plan
- [x] New regression test passes (pins manifest ordering)
- [ ] Full backup → wipe → restore round-trip on SQLite
- [ ] Confirm multi-source install preserves all Source definitions across restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)