### PR TITLE
fix(maintenance): run OPTIMIZE TABLE on MySQL to reclaim space after cleanup

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -8544,7 +8544,18 @@ class DatabaseService {
       return;
     }
     if (this.drizzleDbType === 'mysql') {
-      // MySQL auto-manages space; OPTIMIZE TABLE requires table names
+      // InnoDB doesn't reclaim space automatically after bulk deletes; run
+      // OPTIMIZE TABLE on each maintenance-cleaned table so the daily job
+      // actually shrinks the tablespace. OPTIMIZE TABLE on InnoDB is remapped
+      // to ALTER TABLE … FORCE which is an online DDL rebuild.
+      const optimizeTables = ['messages', 'traceroutes', 'route_segments', 'neighbor_info'];
+      for (const table of optimizeTables) {
+        try {
+          await this.mysqlPool!.query(`OPTIMIZE TABLE \`${table}\``);
+        } catch (err) {
+          logger.debug(`OPTIMIZE TABLE ${table} failed:`, err);
+        }
+      }
       return;
     }
     return this.vacuum();


### PR DESCRIPTION
## Summary
\`vacuumAsync\` was a no-op on MySQL, so the daily maintenance run deleted rows but never shrank the tablespace. InnoDB marks deleted rows as free but doesn't return the pages to the OS — the file only grows.

- Switched the MySQL branch of \`vacuumAsync\` to iterate the maintenance-cleaned tables (\`messages\`, \`traceroutes\`, \`route_segments\`, \`neighbor_info\`) and run \`OPTIMIZE TABLE\` on each
- On InnoDB, \`OPTIMIZE TABLE\` is remapped to an online \`ALTER TABLE … FORCE\` rebuild, which reclaims the space
- Wrapped each call in try/catch so one table failing (e.g. locked, unsupported engine) doesn't abort the whole maintenance cycle
- SQLite and Postgres paths unchanged

## Test plan
- [ ] MySQL dev container: run maintenance, confirm .ibd files shrink after large delete
- [ ] Verify SQLite VACUUM and Postgres VACUUM behavior unchanged
- [ ] No new ESLint restricted-syntax warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)