### PR TITLE
fix(multi-source): apply per-source scheduler settings to every manager at startup

### DIFF
--- a/src/server/applyManagerSettings.test.ts
+++ b/src/server/applyManagerSettings.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Regression test for the per-source scheduler bootstrap gap (see PR-follow-up
+ * to #2708-era auto-traceroute bug):
+ *
+ * On multi-source installs, only the singleton manager had per-source scheduler
+ * settings applied at startup. Additional `new MeshtasticManager(sourceId, ...)`
+ * instances kept class-field defaults, so auto-traceroute / LocalStats /
+ * key-repair silently never fired for any source after the first one.
+ *
+ * Pin the contract: applyManagerSettings() must call setTracerouteInterval,
+ * setLocalStatsInterval, and setKeyRepairSettings with values resolved via
+ * getSettingForSource (per-source → global fallback).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { applyManagerSettings } from './applyManagerSettings.js';
+
+type Settings = Record<string, string | null>;
+
+function makeDbStub(settings: Settings) {
+  return {
+    settings: {
+      async getSetting(key: string) {
+        return settings[key] ?? null;
+      },
+      async getSettingForSource(sourceId: string | null | undefined, key: string) {
+        if (sourceId) {
+          const scoped = settings[`source:${sourceId}:${key}`];
+          if (scoped !== undefined && scoped !== null) return scoped;
+        }
+        return settings[key] ?? null;
+      },
+    },
+  } as any;
+}
+
+function makeManagerStub() {
+  return {
+    setTracerouteInterval: vi.fn(),
+    setLocalStatsInterval: vi.fn(),
+    setKeyRepairSettings: vi.fn(),
+  } as any;
+}
+
+describe('applyManagerSettings — per-source scheduler bootstrap', () => {
+  it('applies per-source tracerouteIntervalMinutes when present', async () => {
+    const db = makeDbStub({
+      'source:SRC-A:tracerouteIntervalMinutes': '15',
+      tracerouteIntervalMinutes: '0',
+    });
+    const mgr = makeManagerStub();
+
+    await applyManagerSettings(mgr, 'SRC-A', db);
+
+    expect(mgr.setTracerouteInterval).toHaveBeenCalledWith(15);
+  });
+
+  it('falls back to global tracerouteIntervalMinutes when no per-source override', async () => {
+    const db = makeDbStub({ tracerouteIntervalMinutes: '10' });
+    const mgr = makeManagerStub();
+
+    await applyManagerSettings(mgr, 'SRC-B', db);
+
+    expect(mgr.setTracerouteInterval).toHaveBeenCalledWith(10);
+  });
+
+  it('applies per-source localStatsIntervalMinutes', async () => {
+    const db = makeDbStub({ 'source:SRC-A:localStatsIntervalMinutes': '7' });
+    const mgr = makeManagerStub();
+
+    await applyManagerSettings(mgr, 'SRC-A', db);
+
+    expect(mgr.setLocalStatsInterval).toHaveBeenCalledWith(7);
+  });
+
+  it('applies key repair settings with correct coercions', async () => {
+    const db = makeDbStub({
+      autoKeyManagementEnabled: 'true',
+      autoKeyManagementIntervalMinutes: '8',
+      autoKeyManagementMaxExchanges: '4',
+      autoKeyManagementAutoPurge: 'true',
+      autoKeyManagementImmediatePurge: 'false',
+    });
+    const mgr = makeManagerStub();
+
+    await applyManagerSettings(mgr, 'SRC-A', db);
+
+    expect(mgr.setKeyRepairSettings).toHaveBeenCalledWith({
+      enabled: true,
+      intervalMinutes: 8,
+      maxExchanges: 4,
+      autoPurge: true,
+      immediatePurge: false,
+    });
+  });
+
+  it('uses key repair defaults when settings are missing', async () => {
+    const db = makeDbStub({});
+    const mgr = makeManagerStub();
+
+    await applyManagerSettings(mgr, 'SRC-A', db);
+
+    expect(mgr.setKeyRepairSettings).toHaveBeenCalledWith({
+      enabled: false,
+      intervalMinutes: 5,
+      maxExchanges: 3,
+      autoPurge: false,
+      immediatePurge: false,
+    });
+  });
+
+  it('skips setTracerouteInterval when value out of range', async () => {
+    const db = makeDbStub({ 'source:SRC-A:tracerouteIntervalMinutes': '999' });
+    const mgr = makeManagerStub();
+
+    await applyManagerSettings(mgr, 'SRC-A', db);
+
+    expect(mgr.setTracerouteInterval).not.toHaveBeenCalled();
+  });
+
+  it('skips setTracerouteInterval when value is not a number', async () => {
+    const db = makeDbStub({ 'source:SRC-A:tracerouteIntervalMinutes': 'abc' });
+    const mgr = makeManagerStub();
+
+    await applyManagerSettings(mgr, 'SRC-A', db);
+
+    expect(mgr.setTracerouteInterval).not.toHaveBeenCalled();
+  });
+
+  it('allows 0 (disabled) for traceroute interval', async () => {
+    const db = makeDbStub({ 'source:SRC-A:tracerouteIntervalMinutes': '0' });
+    const mgr = makeManagerStub();
+
+    await applyManagerSettings(mgr, 'SRC-A', db);
+
+    expect(mgr.setTracerouteInterval).toHaveBeenCalledWith(0);
+  });
+
+  it('per-source value wins over global for both interval settings', async () => {
+    const db = makeDbStub({
+      tracerouteIntervalMinutes: '0',
+      localStatsIntervalMinutes: '60',
+      'source:SRC-A:tracerouteIntervalMinutes': '15',
+      'source:SRC-A:localStatsIntervalMinutes': '5',
+    });
+    const mgr = makeManagerStub();
+
+    await applyManagerSettings(mgr, 'SRC-A', db);
+
+    expect(mgr.setTracerouteInterval).toHaveBeenCalledWith(15);
+    expect(mgr.setLocalStatsInterval).toHaveBeenCalledWith(5);
+  });
+});

--- a/src/server/applyManagerSettings.ts
+++ b/src/server/applyManagerSettings.ts
@@ -1,0 +1,59 @@
+/**
+ * Apply per-source (fallback global) scheduler settings to a MeshtasticManager
+ * before it starts connecting. Without this, additional source managers stay at
+ * class-field defaults and ignore both per-source and global user settings —
+ * which manifests as only one source firing auto-traceroute / LocalStats /
+ * key-repair on a multi-source install.
+ *
+ * Called from `server.ts` once per source, before `sourceManagerRegistry.addManager`
+ * triggers `start*Scheduler`.
+ *
+ * Globally-scoped schedulers (Announce, Timer, DistanceDelete, RemoteAdminScanner,
+ * TimeSync) self-bootstrap inside their own `start*Scheduler` methods via
+ * `getSettingForSource(this.sourceId, ...)`, so this helper intentionally does
+ * NOT duplicate that work.
+ */
+import type { MeshtasticManager } from './meshtasticManager.js';
+import type databaseService from '../services/database.js';
+
+type DatabaseService = typeof databaseService;
+
+export async function applyManagerSettings(
+  manager: MeshtasticManager,
+  sourceId: string,
+  db: DatabaseService
+): Promise<void> {
+  const trInterval = await db.settings.getSettingForSource(sourceId, 'tracerouteIntervalMinutes');
+  if (trInterval !== null) {
+    const n = parseInt(trInterval, 10);
+    if (!isNaN(n) && n >= 0 && n <= 60) manager.setTracerouteInterval(n);
+  }
+
+  const lsInterval = await db.settings.getSettingForSource(sourceId, 'localStatsIntervalMinutes');
+  if (lsInterval !== null) {
+    const n = parseInt(lsInterval, 10);
+    if (!isNaN(n) && n >= 0 && n <= 60) manager.setLocalStatsInterval(n);
+  }
+
+  const [
+    keyRepairEnabled,
+    keyRepairInterval,
+    keyRepairMaxExchanges,
+    keyRepairAutoPurge,
+    keyRepairImmediatePurge,
+  ] = await Promise.all([
+    db.settings.getSetting('autoKeyManagementEnabled'),
+    db.settings.getSetting('autoKeyManagementIntervalMinutes'),
+    db.settings.getSetting('autoKeyManagementMaxExchanges'),
+    db.settings.getSetting('autoKeyManagementAutoPurge'),
+    db.settings.getSetting('autoKeyManagementImmediatePurge'),
+  ]);
+
+  manager.setKeyRepairSettings({
+    enabled: keyRepairEnabled === 'true',
+    intervalMinutes: keyRepairInterval ? parseInt(keyRepairInterval) : 5,
+    maxExchanges: keyRepairMaxExchanges ? parseInt(keyRepairMaxExchanges) : 3,
+    autoPurge: keyRepairAutoPurge === 'true',
+    immediatePurge: keyRepairImmediatePurge === 'true',
+  });
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -48,6 +48,7 @@ import { rewriteHtml } from './utils/htmlRewriter.js';
 import { migrateAutomationChannels } from './utils/automationChannelMigration.js';
 import { PortNum } from './constants/meshtastic.js';
 import settingsRoutes, { setSettingsCallbacks } from './routes/settingsRoutes.js';
+import { applyManagerSettings } from './applyManagerSettings.js';
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../../package.json');
@@ -391,49 +392,10 @@ setTimeout(async () => {
     // Wait for database initialization (critical for PostgreSQL/MySQL where repos are async)
     await databaseService.waitForReady();
 
-    // Load saved traceroute interval from database before connecting
-    const savedInterval = await databaseService.settings.getSetting('tracerouteIntervalMinutes');
-    if (savedInterval !== null) {
-      const intervalMinutes = parseInt(savedInterval);
-      if (!isNaN(intervalMinutes) && intervalMinutes >= 0 && intervalMinutes <= 60) {
-        meshtasticManager.setTracerouteInterval(intervalMinutes);
-        logger.debug(
-          `✅ Loaded saved traceroute interval: ${intervalMinutes} minutes${intervalMinutes === 0 ? ' (disabled)' : ''}`
-        );
-      }
-    }
-
-    // Load auto key repair settings
-    const keyRepairEnabled = await databaseService.settings.getSetting('autoKeyManagementEnabled');
-    const keyRepairInterval = await databaseService.settings.getSetting('autoKeyManagementIntervalMinutes');
-    const keyRepairMaxExchanges = await databaseService.settings.getSetting('autoKeyManagementMaxExchanges');
-    const keyRepairAutoPurge = await databaseService.settings.getSetting('autoKeyManagementAutoPurge');
-    const keyRepairImmediatePurge = await databaseService.settings.getSetting('autoKeyManagementImmediatePurge');
-
-    meshtasticManager.setKeyRepairSettings({
-      enabled: keyRepairEnabled === 'true',
-      intervalMinutes: keyRepairInterval ? parseInt(keyRepairInterval) : 5,
-      maxExchanges: keyRepairMaxExchanges ? parseInt(keyRepairMaxExchanges) : 3,
-      autoPurge: keyRepairAutoPurge === 'true',
-      immediatePurge: keyRepairImmediatePurge === 'true'
-    });
-    logger.debug('✅ Loaded auto key repair settings');
-
-    // Remote admin scanner: per-source managers bootstrap themselves via
-    // startRemoteAdminScanner() on connect (reads remoteAdminScannerIntervalMinutes
-    // via getSettingForSource). No global init required.
-
-    // Load LocalStats collection interval
-    const localStatsInterval = await databaseService.settings.getSetting('localStatsIntervalMinutes');
-    if (localStatsInterval !== null) {
-      const intervalMinutes = parseInt(localStatsInterval);
-      if (!isNaN(intervalMinutes) && intervalMinutes >= 0 && intervalMinutes <= 60) {
-        meshtasticManager.setLocalStatsInterval(intervalMinutes);
-        logger.debug(
-          `✅ Loaded saved LocalStats interval: ${intervalMinutes} minutes${intervalMinutes === 0 ? ' (disabled)' : ''}`
-        );
-      }
-    }
+    // Per-source scheduler settings are applied to each manager inside the
+    // `for (const source of enabledSources)` loop below via applyManagerSettings().
+    // Globally-scoped schedulers (Announce, Timer, DistanceDelete, RemoteAdminScanner,
+    // TimeSync) self-bootstrap inside their start*Scheduler methods — no action here.
 
     // NOTE: We no longer mark existing nodes as welcomed on startup.
     // This is now handled when autoWelcomeEnabled is first changed to 'true'
@@ -490,6 +452,7 @@ setTimeout(async () => {
               port: cfg.port,
               heartbeatIntervalSeconds: cfg.heartbeatIntervalSeconds,
             }, source.id);
+            await applyManagerSettings(meshtasticManager, source.id, databaseService);
             await sourceManagerRegistry.addManager(meshtasticManager);
             firstTcpSourceConfigured = true;
             logger.debug(`Started primary source manager via singleton: ${source.id}`);
@@ -500,6 +463,7 @@ setTimeout(async () => {
               port: cfg.port,
               heartbeatIntervalSeconds: cfg.heartbeatIntervalSeconds,
             });
+            await applyManagerSettings(manager, source.id, databaseService);
             await sourceManagerRegistry.addManager(manager);
           }
         } catch (err) {


### PR DESCRIPTION
## Summary
On multi-source installs only the **singleton** \`MeshtasticManager\` had scheduler settings applied at startup. Additional \`new MeshtasticManager(sourceId, ...)\` instances kept their class-field defaults (traceroute interval=0, key repair enabled=false), so **auto-traceroute and auto-key-repair silently never fired for any source after the first** — even when the per-source UI had them enabled.

Symptom reported: user had auto-traceroute enabled on 3 sources; only one source was actually sending traceroutes.

## Fix
Extracted \`applyManagerSettings(manager, sourceId, db)\` (src/server/applyManagerSettings.ts). Called once per source in server.ts **before** \`sourceManagerRegistry.addManager()\` triggers the connect → \`start*Scheduler\` chain.

Reads:
| Setting | Scope |
|---|---|
| \`tracerouteIntervalMinutes\` | per-source, falls back to global |
| \`localStatsIntervalMinutes\` | per-source, falls back to global |
| \`autoKeyManagementEnabled/IntervalMinutes/MaxExchanges/AutoPurge/ImmediatePurge\` | global (applied identically to every manager) |

Schedulers that already self-bootstrap via \`getSettingForSource\` (Announce, Timer, DistanceDelete, RemoteAdminScanner, TimeSync) are untouched. Removed the redundant global-only loader block in server.ts that only applied to the legacy singleton.

## Test plan
- [x] 9 new unit tests pin per-source > global precedence, range validation, and key-repair defaults
- [x] Full test suite: 4257/4257 passing
- [ ] Multi-source install: enable auto-traceroute on all sources, verify each source fires its own scheduled runs in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)