### PR TITLE
fix(per-source): Auto Announce Send Now + Virtual Node bootstrap and scoping

### DIFF
--- a/.claude/agents/docker-dev-deployer.md
+++ b/.claude/agents/docker-dev-deployer.md
@@ -8,6 +8,52 @@ memory: project
 
 You are an elite DevOps engineer specializing in Docker-based development workflows for the MeshMonitor project. Your sole responsibility is to reliably build, deploy, and verify the MeshMonitor dev container so it is ready for testing.
 
+## ⛔ STOP — READ FIRST: VOLUME SAFETY (NON-NEGOTIABLE)
+
+**Past incident (2026-04-18):** This agent executed a command that destroyed the user's `meshmonitor_meshmonitor-sqlite-data` volume, wiping all sources, nodes, messages, users, and settings. The user had explicitly said "do not wipe volumes". Data was not recoverable. This must never happen again.
+
+**Before running ANY docker/docker compose command, check it against this list:**
+
+### ❌ ABSOLUTELY FORBIDDEN (never run, not even once, not even to "clean up")
+- `docker compose down -v` — the `-v` destroys named volumes
+- `docker compose down --volumes`
+- `docker compose rm -v` / `docker compose rm -fv` / `docker compose rm -sv` / any `rm` with `-v`
+- `docker compose up --renew-anon-volumes` / `--force-recreate` combined with anything that touches volumes
+- `docker volume rm ...` (any volume)
+- `docker volume prune` (with or without `-f`)
+- `docker system prune --volumes` / `docker system prune -a --volumes`
+- `docker compose down` followed by renaming the project/compose file (different project name = different volume namespace = old data orphaned)
+
+### ✅ ALLOWED (these are the ONLY docker commands you may run)
+- `docker compose -f docker-compose.dev.yml build` (with or without `--no-cache`)
+- `docker compose -f docker-compose.dev.yml up -d` — recreates containers, preserves volumes
+- `docker compose -f docker-compose.dev.yml stop` / `restart`
+- `docker compose -f docker-compose.dev.yml down` **(NO `-v`, NO `--volumes`)**
+- `docker compose -f docker-compose.dev.yml logs`
+- `docker compose -f docker-compose.dev.yml ps`
+- `docker ps`, `docker logs`, `docker exec`, `docker inspect`
+- `docker volume ls`, `docker volume inspect` (read-only)
+
+### Mandatory pre-flight (do this EVERY invocation before any `up`/`down`/`build`)
+
+1. Run `docker volume ls | grep meshmonitor` and record the exact volume names + creation timestamps in your response.
+2. State explicitly in your reply: "Preserving volumes: <list>"
+3. If any step you are about to take could conceivably remove or recreate a volume, **STOP and ask the user first**. Do not proceed on assumption.
+4. After `up -d`, run `docker volume ls | grep meshmonitor` again and compare. If the creation timestamp of the data volume changed, you destroyed the user's data — report it immediately.
+
+### Interpretation rules
+
+- "Fresh rebuild", "clean build", "from scratch", "reset the container", "blow it away" — these refer to the **image**, never the **volume**. Rebuild with `docker compose build --no-cache`, then `up -d`. Do NOT touch volumes.
+- "Deploy" / "redeploy" = `build` + `up -d`. Never involves `down -v`.
+- If a volume appears corrupt or a migration error suggests wiping the DB, **STOP and ask the user**. Never decide on your own that data loss is acceptable.
+- If you cannot complete the task without removing a volume, report the blocker and ask — do not work around it.
+
+### Cognitive traps to watch for
+- "The agent said they're just tests" — irrelevant. Real data lives in real volumes named `meshmonitor_*`. Never wipe any volume whose name starts with `meshmonitor_` or matches an active compose project.
+- "I'll use `--no-cache` to fix the stale code issue" — good, but this only affects the image. Do NOT also add `-v` to the `down` step.
+- "Let me clean up old containers first" — use `docker compose down` (no flags) or `docker compose rm` (no `-v`). Never add `-v` for "cleanliness".
+- "The schema migration failed, I'll just recreate the DB" — NO. Stop and ask the user. The user's data is not yours to delete.
+
 ## Core Responsibilities
 
 1. **Pre-flight Checks**
@@ -40,11 +86,7 @@ You are an elite DevOps engineer specializing in Docker-based development workfl
 
 ## Critical Rules
 
-- **NEVER destroy named volumes.** The SQLite DB, PostgreSQL data, MySQL data, and backups live in named volumes (e.g. `meshmonitor_meshmonitor-sqlite-data`). Losing them wipes the user's nodes, messages, users, settings, and backups.
-  - ❌ FORBIDDEN: `docker compose down -v`, `docker compose down --volumes`, `docker compose rm -v`, `docker compose rm -f -s -v`, `docker volume rm ...`, `docker volume prune`, `docker system prune --volumes`, `--renew-anon-volumes`
-  - ✅ ALLOWED: `docker compose down` (no `-v`), `docker compose stop`, `docker compose restart`, `docker compose up -d` (recreates containers, preserves volumes), `docker compose build`, `docker compose build --no-cache`
-  - A "fresh rebuild" means rebuild the **image**, not the volume. The image is the compiled code; the volume is the user's data. Never conflate them.
-  - If you believe the volume *must* be wiped, STOP and ask the user explicitly first.
+- Volume safety rules are defined at the top of this file under "⛔ STOP — READ FIRST". Those rules are load-bearing — do not skip them.
 - The container does NOT have `sqlite3` binary available — don't try to use it
 - Only the backend talks to the Meshtastic node; never assume frontend-direct access
 - Never run Docker dev container and local npm dev server simultaneously — notify the user if they need to switch
@@ -63,12 +105,14 @@ You are an elite DevOps engineer specializing in Docker-based development workfl
 ## Self-Verification Checklist
 
 Before declaring success, confirm:
+- [ ] **Volume creation timestamp is UNCHANGED from pre-flight snapshot** (if it changed, you destroyed the user's data — report immediately)
 - [ ] Build completed without errors
 - [ ] Container is in `running` state (not restarting)
 - [ ] Logs show successful startup (migrations done, server listening)
 - [ ] HTTP endpoint at /meshmonitor responds
 - [ ] Deployed code matches expected version/changes
 - [ ] No error/fatal log lines in monitoring window
+- [ ] No `-v` or `--volumes` flag appeared in any docker command you ran
 
 **Update your agent memory** as you discover Docker build quirks, common startup failure modes, log patterns indicating success/failure, cache invalidation issues, and profile/port conflict scenarios. This builds institutional knowledge about the MeshMonitor dev deployment workflow.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -54,6 +54,9 @@ services:
     ports:
       - "8081:3001"  # Changed to 8081 to avoid conflict with devcontainer
       - "4405:4404"  # Virtual Node Server on unique external port
+      - "4503:4503"  # Per-source VN
+      - "4504:4504"  # Per-source VN
+      - "4505:4505"  # Per-source VN
     restart: unless-stopped
     volumes:
       - meshmonitor-data:/data
@@ -97,6 +100,9 @@ services:
     ports:
       - "8081:3001"
       - "4405:4404"
+      - "4503:4503"  # Per-source VN
+      - "4504:4504"  # Per-source VN
+      - "4505:4505"  # Per-source VN
     restart: unless-stopped
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -164,6 +170,9 @@ services:
     ports:
       - "8081:3001"
       - "4405:4404"
+      - "4503:4503"  # Per-source VN
+      - "4504:4504"  # Per-source VN
+      - "4505:4505"  # Per-source VN
     restart: unless-stopped
     volumes:
       - meshmonitor-mysql-data:/data

--- a/src/components/AutoAnnounceSection.tsx
+++ b/src/components/AutoAnnounceSection.tsx
@@ -6,6 +6,7 @@ import { Channel } from '../types/device';
 import { useToast } from './ToastContainer';
 import { useCsrfFetch } from '../hooks/useCsrfFetch';
 import { useSourceQuery } from '../hooks/useSourceQuery';
+import { useSource } from '../contexts/SourceContext';
 import { useSaveBar } from '../hooks/useSaveBar';
 
 interface AutoAnnounceSectionProps {
@@ -64,6 +65,7 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const sourceQuery = useSourceQuery();
+  const { sourceId: currentSourceId } = useSource();
   const { showToast } = useToast();
   const [localEnabled, setLocalEnabled] = useState(enabled);
   const [localInterval, setLocalInterval] = useState(intervalHours || 6);
@@ -296,7 +298,8 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
     try {
       const response = await csrfFetch(`${baseUrl}/api/announce/send`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' }
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(currentSourceId ? { sourceId: currentSourceId } : {})
       });
 
       if (!response.ok) {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -424,9 +424,20 @@ class MeshtasticManager implements ISourceManager {
    * Apply a source config after construction.
    * Used to configure the legacy singleton when sources are loaded from DB at startup.
    */
-  configureSource(config: { host?: string; port?: number; heartbeatIntervalSeconds?: number }, sourceId?: string): void {
-    this.sourceConfigOverride = config;
+  configureSource(config: { host?: string; port?: number; heartbeatIntervalSeconds?: number; virtualNode?: VirtualNodeConfig }, sourceId?: string): void {
+    this.sourceConfigOverride = {
+      host: config.host,
+      port: config.port,
+      heartbeatIntervalSeconds: config.heartbeatIntervalSeconds,
+    };
     if (sourceId) this.sourceId = sourceId;
+    if (config.virtualNode?.enabled && !this.virtualNodeServer) {
+      this.virtualNodeServer = new VirtualNodeServer({
+        port: config.virtualNode.port,
+        allowAdminCommands: config.virtualNode.allowAdminCommands,
+        meshtasticManager: this,
+      });
+    }
   }
 
   async start(): Promise<void> {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -451,6 +451,7 @@ setTimeout(async () => {
               host: cfg.host,
               port: cfg.port,
               heartbeatIntervalSeconds: cfg.heartbeatIntervalSeconds,
+              virtualNode: cfg.virtualNode,
             }, source.id);
             await applyManagerSettings(meshtasticManager, source.id, databaseService);
             await sourceManagerRegistry.addManager(meshtasticManager);
@@ -462,6 +463,7 @@ setTimeout(async () => {
               host: cfg.host,
               port: cfg.port,
               heartbeatIntervalSeconds: cfg.heartbeatIntervalSeconds,
+              virtualNode: cfg.virtualNode,
             });
             await applyManagerSettings(manager, source.id, databaseService);
             await sourceManagerRegistry.addManager(manager);

--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -459,8 +459,7 @@ export class VirtualNodeServer extends EventEmitter {
                     const targetNodeNum = Number(adminMsg.setFavoriteNode);
                     logger.info(`⭐ Virtual node: Intercepted setFavoriteNode for node ${targetNodeNum} from ${clientId}`);
 
-                    // Update database (virtual node server has no source context — default)
-                    await databaseService.nodes.setNodeFavorite(targetNodeNum, true, 'default');
+                    await databaseService.nodes.setNodeFavorite(targetNodeNum, true, this.config.meshtasticManager.sourceId);
                     logger.debug(`✅ Virtual node: Updated database - node ${targetNodeNum} is now favorite`);
 
                     // Don't block - let the command through to the physical node
@@ -471,8 +470,7 @@ export class VirtualNodeServer extends EventEmitter {
                     const targetNodeNum = Number(adminMsg.removeFavoriteNode);
                     logger.info(`☆ Virtual node: Intercepted removeFavoriteNode for node ${targetNodeNum} from ${clientId}`);
 
-                    // Update database (virtual node server has no source context — default)
-                    await databaseService.nodes.setNodeFavorite(targetNodeNum, false, 'default');
+                    await databaseService.nodes.setNodeFavorite(targetNodeNum, false, this.config.meshtasticManager.sourceId);
                     logger.debug(`✅ Virtual node: Updated database - node ${targetNodeNum} is no longer favorite`);
 
                     // Don't block - let the command through to the physical node
@@ -715,7 +713,8 @@ export class VirtualNodeServer extends EventEmitter {
    * (including disabled ones with role=0) are sent to match real firmware behavior.
    */
   private async sendChannelsFromDb(clientId: string): Promise<{ sent: number; disconnected: boolean }> {
-    const dbChannels = await databaseService.channels.getAllChannels();
+    const sourceId = this.config.meshtasticManager.sourceId;
+    const dbChannels = await databaseService.channels.getAllChannels(sourceId);
     let sent = 0;
     for (const ch of dbChannels) {
       const client = this.clients.get(clientId);
@@ -889,7 +888,7 @@ export class VirtualNodeServer extends EventEmitter {
       // --- STEP 1: MyNodeInfo (rebuilt from DB) ---
       const localNodeInfo = this.config.meshtasticManager.getLocalNodeInfo();
       if (localNodeInfo) {
-        const localNode = await databaseService.nodes.getNode(localNodeInfo.nodeNum);
+        const localNode = await databaseService.nodes.getNode(localNodeInfo.nodeNum, this.config.meshtasticManager.sourceId);
 
         let firmwareVersion = (localNodeInfo as any).firmwareVersion;
         if (!firmwareVersion && localNode?.firmwareVersion) {


### PR DESCRIPTION
## Summary

- **Auto Announce Send Now** now includes `sourceId` in the POST body so non-default sources dispatch the announcement through the correct manager instead of silently falling back to the default.
- **Virtual Node** is now actually started at server boot — `configureSource()` and the per-source `new MeshtasticManager()` both dropped the `virtualNode` field from the source config during the 4.0 refactor, so the VN server was never constructed on startup and clients got "connection refused".
- **Virtual Node queries are now source-scoped** — `sendChannelsFromDb`, the local-node lookup in `sendInitialConfig`, and the `setNodeFavorite` admin-intercept handlers no longer pull from every source or hard-code `'default'`. Addresses the bug where `meshtastic -t host:<vn-port> --info` returned ~10 channels (sum of every source's channels) instead of the single source's.
- Dev `docker-compose.dev.yml` now publishes VN ports 4503/4504/4505 so per-source Virtual Nodes are reachable from the host.
- `.claude/agents/docker-dev-deployer.md` hardened with an explicit allow/deny list after a prior volume-destroying incident.

Relates to #2719 (Virtual Node not working after update to MM 4) — the "enabling has no effect" symptom in that issue is the VN-not-started bug fixed here. The 4403 port-collision UX gripe from #2719 is **not** addressed in this PR.

## Test plan

- [ ] Restart container with a source that has `virtualNode.enabled=true` — confirm "Virtual node server listening on port N" in logs
- [ ] `meshtastic -t <host>:<vn-port> --info` returns only that source's channels (≤8), not merged
- [ ] Click Send Now on Auto Announce while viewing a non-default source — announcement appears on that source's node, not the default
- [ ] Favorite a node via the connected app → DB row for `(nodeNum, sourceId)` of the VN's owning source is updated, not `(nodeNum, 'default')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)