### PR TITLE
fix(per-source): route scheduler restarts + autoWelcome tokens to the right source

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -9632,8 +9632,9 @@ class MeshtasticManager implements ISourceManager {
   private async replaceWelcomeTokens(message: string, nodeNum: number, _nodeId: string): Promise<string> {
     let result = message;
 
-    // Get node info
-    const node = await databaseService.nodes.getNode(nodeNum);
+    // Get node info (scoped to this source — the same nodeNum can have a row
+    // per source, and createdAt differs per source)
+    const node = await databaseService.nodes.getNode(nodeNum, this.sourceId);
 
     // {LONG_NAME} - Node long name
     if (result.includes('{LONG_NAME}')) {

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -120,9 +120,9 @@ export interface SettingsCallbacks {
   }) => void;
   restartInactiveNodeService?: (threshold: number, check: number, cooldown: number) => void;
   stopInactiveNodeService?: () => void;
-  restartAnnounceScheduler?: () => void;
-  restartTimerScheduler?: () => void;
-  restartGeofenceEngine?: () => void;
+  restartAnnounceScheduler?: (sourceId?: string | null) => void;
+  restartTimerScheduler?: (sourceId?: string | null) => void;
+  restartGeofenceEngine?: (sourceId?: string | null) => void;
   handleAutoWelcomeEnabled?: () => number;
   invalidateHtmlCache?: () => void;
   restartAutoDeleteByDistanceService?: (intervalHours: number, sourceId?: string | null) => void;
@@ -537,8 +537,28 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
 
     // Save to database
     if (sourceId) {
-      // Per-source: store with source: prefix, skip global side-effects
+      // Per-source: store with source: prefix
       await databaseService.settings.setSourceSettings(sourceId, filteredSettings);
+
+      // Per-source scheduler side-effects (announce / timer / geofence schedulers
+      // each read `getSettingForSource(this.sourceId, ...)`, so we must restart
+      // the scheduler on the matching source manager when its settings change).
+      const announceKeys = [
+        'autoAnnounceEnabled',
+        'autoAnnounceIntervalHours',
+        'autoAnnounceUseSchedule',
+        'autoAnnounceSchedule',
+      ];
+      if (announceKeys.some((key) => key in filteredSettings)) {
+        callbacks.restartAnnounceScheduler?.(sourceId);
+      }
+      if ('timerTriggers' in filteredSettings) {
+        callbacks.restartTimerScheduler?.(sourceId);
+      }
+      if ('geofenceTriggers' in filteredSettings) {
+        callbacks.restartGeofenceEngine?.(sourceId);
+      }
+
       return res.json({ success: true });
     }
 
@@ -675,15 +695,15 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
     ];
     const announceSettingsChanged = announceSettings.some((key) => key in filteredSettings);
     if (announceSettingsChanged) {
-      callbacks.restartAnnounceScheduler?.();
+      callbacks.restartAnnounceScheduler?.(null);
     }
 
     if ('timerTriggers' in filteredSettings) {
-      callbacks.restartTimerScheduler?.();
+      callbacks.restartTimerScheduler?.(null);
     }
 
     if ('geofenceTriggers' in filteredSettings) {
-      callbacks.restartGeofenceEngine?.();
+      callbacks.restartGeofenceEngine?.(null);
     }
 
     const distanceDeleteSettings = [

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -882,9 +882,36 @@ setSettingsCallbacks({
   restartInactiveNodeService: (threshold, check, cooldown) =>
     inactiveNodeNotificationService.start(threshold, check, cooldown),
   stopInactiveNodeService: () => inactiveNodeNotificationService.stop(),
-  restartAnnounceScheduler: () => meshtasticManager.restartAnnounceScheduler(),
-  restartTimerScheduler: () => meshtasticManager.restartTimerScheduler(),
-  restartGeofenceEngine: () => meshtasticManager.restartGeofenceEngine(),
+  restartAnnounceScheduler: (sourceId?: string | null) => {
+    if (sourceId) {
+      const mgr = sourceManagerRegistry.getManager(sourceId) as typeof meshtasticManager | undefined;
+      mgr?.restartAnnounceScheduler();
+    } else {
+      for (const mgr of sourceManagerRegistry.getAllManagers() as (typeof meshtasticManager)[]) {
+        mgr.restartAnnounceScheduler();
+      }
+    }
+  },
+  restartTimerScheduler: (sourceId?: string | null) => {
+    if (sourceId) {
+      const mgr = sourceManagerRegistry.getManager(sourceId) as typeof meshtasticManager | undefined;
+      mgr?.restartTimerScheduler();
+    } else {
+      for (const mgr of sourceManagerRegistry.getAllManagers() as (typeof meshtasticManager)[]) {
+        mgr.restartTimerScheduler();
+      }
+    }
+  },
+  restartGeofenceEngine: (sourceId?: string | null) => {
+    if (sourceId) {
+      const mgr = sourceManagerRegistry.getManager(sourceId) as typeof meshtasticManager | undefined;
+      mgr?.restartGeofenceEngine();
+    } else {
+      for (const mgr of sourceManagerRegistry.getAllManagers() as (typeof meshtasticManager)[]) {
+        mgr.restartGeofenceEngine();
+      }
+    }
+  },
   handleAutoWelcomeEnabled: () => { databaseService.handleAutoWelcomeEnabledAsync().catch(() => {}); return 0; },
   invalidateHtmlCache,
   restartAutoDeleteByDistanceService: (intervalHours: number) =>


### PR DESCRIPTION
## Summary

Fixes three source-correctness bugs affecting per-source automation:

- **POST `/api/settings?sourceId=<id>` never restarted schedulers.** The handler returned early after writing per-source settings, so `autoAnnounceSchedule`, `timerTriggers`, and `geofenceTriggers` edits only took effect on app restart.
- **Restart callbacks were hardwired to the primary manager.** Even on the global save path, `restartAnnounceScheduler` / `restartTimerScheduler` / `restartGeofenceEngine` ignored sourceId and only rescheduled the primary source — other source managers kept running the old config.
- **`replaceWelcomeTokens` looked up nodes without sourceId.** With the per-(nodeNum, sourceId) composite PK, the same nodeNum can have multiple rows, and `getNode(nodeNum)` returns whichever row the DB happens to pick first. Tokens like `{DURATION}` (derived from `createdAt`, which differs per source) could render values from a sibling source.

## Changes

- `src/server/routes/settingsRoutes.ts`: per-source save branch now fires `restartAnnounceScheduler(sourceId)` / `restartTimerScheduler(sourceId)` / `restartGeofenceEngine(sourceId)` when the matching keys change, before returning. Global save passes `sourceId=null`. Callback signatures now take `sourceId?: string | null`.
- `src/server/server.ts`: restart callbacks resolve via `sourceManagerRegistry.getManager(sourceId)`. `null` (global save) fans out to `getAllManagers()` so global fallbacks propagate to every source.
- `src/server/meshtasticManager.ts`: `replaceWelcomeTokens` scopes `getNode` by `this.sourceId`.

## Audit scope (no code changes needed — already source-scoped)

- Every scheduler entry point (`startAnnounceScheduler`, `startTimerScheduler`, `initGeofenceEngine`) reads settings via `getSettingForSource(this.sourceId, ...)`.
- Every send path (`this.messageQueue.enqueue`, `this.sendTextMessage`, etc.) is per-instance → per-source.
- `checkAutoWelcome`, `checkAutoAcknowledge`, `checkAutoResponder`, `sendAutoAnnouncement` are methods on the per-source manager using `this.sourceId` for all settings reads and the source's own row for `welcomedAt` / cooldowns.
- Frontend sections (`AutoAnnounceSection`, `AutoWelcomeSection`, `AutoAcknowledgeSection`, `AutoResponderSection`, `GeofenceTriggersSection`) all POST/GET with `?sourceId=<id>`; `AutomationContext` refetches on `sourceId` change.

## Deferred (out of scope)

Noted in code review, not fixed here:

- `welcomingNodes` in-memory lock is acquired at the top of `checkAutoWelcome` but only released inside `messageQueue.enqueue` callbacks — early-return paths (disabled, waiting-for-name, too-many-hops, local node) leak the lock. Pre-existing, not source-related.
- Cross-source welcome dedup for #2723 (same node welcomed once per enabled source). Current per-source toggle is already a user workaround; code-level cross-source dedup is a separate change.

## Test plan

- [x] Full Vitest suite: 4260 passed / 0 failed (216 files)
- [x] Typecheck clean (`tsc --noEmit`)
- [x] AutoWelcome focused tests: 51/51 pass
- [x] SettingsRoutes tests: 34/34 pass
- [ ] Deploy to dev container and verify per-source edits in the UI take effect immediately without an app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)