### PR TITLE
fix(per-source): scope Info page data to active source

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.0.0-beta5",
+  "version": "4.0.0-beta6",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.0.0-beta5",
+  "version": "4.0.0-beta6",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.0.0-beta5
-appVersion: "4.0.0-beta5"
+version: 4.0.0-beta6
+appVersion: "4.0.0-beta6"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta5",
+  "version": "4.0.0-beta6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.0.0-beta5",
+      "version": "4.0.0-beta6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta5",
+  "version": "4.0.0-beta6",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/components/InfoTab.tsx
+++ b/src/components/InfoTab.tsx
@@ -17,6 +17,7 @@ import { getDeviceRoleName } from '../utils/deviceRole';
 import { getPacketDistributionStats } from '../services/packetApi';
 import { PacketDistributionStats } from '../types/packet';
 import PacketStatsChart, { ChartDataEntry, DISTRIBUTION_COLORS } from './PacketStatsChart';
+import { useSource } from '../contexts/SourceContext';
 
 interface RouteSegment {
   id: number;
@@ -71,6 +72,7 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
 }) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
+  const { sourceId: activeSourceId } = useSource();
   const [longestActiveSegment, setLongestActiveSegment] = useState<RouteSegment | null>(null);
   const [recordHolderSegment, setRecordHolderSegment] = useState<RouteSegment | null>(null);
   const [loadingSegments, setLoadingSegments] = useState(false);
@@ -122,7 +124,8 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
     if (connectionStatus !== 'connected' || !currentNodeId) return;
 
     try {
-      const response = await fetch(`${baseUrl}/api/telemetry/${currentNodeId}?hours=1`);
+      const srcQs = activeSourceId ? `&sourceId=${encodeURIComponent(activeSourceId)}` : '';
+      const response = await fetch(`${baseUrl}/api/telemetry/${currentNodeId}?hours=1${srcQs}`);
       if (!response.ok) throw new Error('Failed to fetch local stats');
       const data = await response.json();
 
@@ -164,8 +167,8 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
     setLoadingSegments(true);
     try {
       const [longest, recordHolder] = await Promise.all([
-        apiService.getLongestActiveRouteSegment(),
-        apiService.getRecordHolderRouteSegment()
+        apiService.getLongestActiveRouteSegment(activeSourceId),
+        apiService.getRecordHolderRouteSegment(activeSourceId)
       ]);
       setLongestActiveSegment(longest);
       setRecordHolderSegment(recordHolder);
@@ -181,7 +184,7 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
 
     setLoadingSecurityKeys(true);
     try {
-      const keys = await apiService.getSecurityKeys();
+      const keys = await apiService.getSecurityKeys(activeSourceId);
       setSecurityKeys(keys);
     } catch (error) {
       logger.error('Error fetching security keys:', error);
@@ -205,14 +208,14 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
       }
       // 'all' = undefined (no since filter)
 
-      const distribution = await getPacketDistributionStats(since);
+      const distribution = await getPacketDistributionStats(since, undefined, undefined, activeSourceId ?? undefined);
       setPacketDistribution(distribution);
     } catch (error) {
       logger.error('Error fetching packet distribution:', error);
     } finally {
       setLoadingDistribution(false);
     }
-  }, [connectionStatus, distributionTimeRange]);
+  }, [connectionStatus, distributionTimeRange, activeSourceId]);
 
   const fetchPortnumNodeDistribution = useCallback(async () => {
     if (connectionStatus !== 'connected' || selectedPortnum === null) return;
@@ -227,14 +230,14 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
         since = now - 86400;
       }
 
-      const distribution = await getPacketDistributionStats(since, undefined, selectedPortnum);
+      const distribution = await getPacketDistributionStats(since, undefined, selectedPortnum, activeSourceId ?? undefined);
       setPortnumNodeDistribution(distribution);
     } catch (error) {
       logger.error('Error fetching portnum node distribution:', error);
     } finally {
       setLoadingPortnumNodes(false);
     }
-  }, [connectionStatus, selectedPortnum, distributionTimeRange]);
+  }, [connectionStatus, selectedPortnum, distributionTimeRange, activeSourceId]);
 
   const handleClearRecordHolder = async () => {
     setShowConfirmDialog(true);
@@ -243,7 +246,7 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
   const confirmClearRecordHolder = async () => {
     setShowConfirmDialog(false);
     try {
-      await apiService.clearRecordHolderSegment();
+      await apiService.clearRecordHolderSegment(activeSourceId);
       setRecordHolderSegment(null);
       showToast(t('info.record_cleared'), 'success');
     } catch (error) {
@@ -260,7 +263,7 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
     fetchRouteSegments();
     const interval = setInterval(fetchRouteSegments, 60000); // Refresh every minute
     return () => clearInterval(interval);
-  }, [connectionStatus]);
+  }, [connectionStatus, activeSourceId]);
 
   useEffect(() => {
     fetchVirtualNodeStatus();
@@ -278,12 +281,12 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
     fetchLocalStats();
     const interval = setInterval(fetchLocalStats, 60000); // Refresh every minute
     return () => clearInterval(interval);
-  }, [connectionStatus, currentNodeId]);
+  }, [connectionStatus, currentNodeId, activeSourceId]);
 
   useEffect(() => {
     fetchSecurityKeys();
     // Only fetch once when connected and authenticated - keys don't change frequently
-  }, [connectionStatus, isAuthenticated]);
+  }, [connectionStatus, isAuthenticated, activeSourceId]);
 
   useEffect(() => {
     fetchPacketDistribution();
@@ -482,46 +485,53 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
         <div className="info-section">
           <h3>{t('info.virtual_node')}</h3>
           {loadingVirtualNode && <p>{t('common.loading_indicator')}</p>}
-          {!loadingVirtualNode && virtualNodeStatus && (
-            <>
-              <p><strong>{t('info.virtual_node_status')}</strong> {virtualNodeStatus.enabled ? t('common.enabled') : t('common.disabled')}</p>
-              {virtualNodeStatus.enabled && (
-                <>
-                  <p><strong>{t('info.server_running')}</strong> {virtualNodeStatus.isRunning ? t('common.yes') : t('common.no')}</p>
-                  <p><strong>{t('info.connected_clients')}</strong> {virtualNodeStatus.clientCount}</p>
+          {(() => {
+            if (loadingVirtualNode) return null;
+            const sources = Array.isArray(virtualNodeStatus?.sources) ? virtualNodeStatus.sources : [];
+            const source = activeSourceId
+              ? sources.find((s: any) => s.sourceId === activeSourceId)
+              : sources[0];
+            if (!source) {
+              return <p className="no-data">{t('info.virtual_node_unavailable')}</p>;
+            }
+            return (
+              <>
+                <p><strong>{t('info.virtual_node_status')}</strong> {source.enabled ? t('common.enabled') : t('common.disabled')}</p>
+                {source.enabled && (
+                  <>
+                    <p><strong>{t('info.server_running')}</strong> {source.isRunning ? t('common.yes') : t('common.no')}</p>
+                    <p><strong>{t('info.connected_clients')}</strong> {source.clientCount}</p>
 
-                  {virtualNodeStatus.clients && virtualNodeStatus.clients.length > 0 && (
-                    <div style={{ marginTop: '0.75rem', fontSize: '0.9em' }}>
-                      <strong>{t('info.client_details')}</strong>
-                      {virtualNodeStatus.clients.map((client: any) => (
-                        <div key={client.id} style={{
-                          marginTop: '0.5rem',
-                          padding: '0.5rem',
-                          backgroundColor: 'var(--ctp-surface0)',
-                          borderRadius: '4px'
-                        }}>
-                          <p style={{ margin: '0.25rem 0' }}><strong>{t('info.client_id')}</strong> {client.id}</p>
-                          <p style={{ margin: '0.25rem 0' }}><strong>{t('info.client_ip')}</strong> {client.ip}</p>
-                          <p style={{ margin: '0.25rem 0' }}><strong>{t('info.client_connected')}</strong> {formatDateTime(new Date(client.connectedAt), timeFormat, dateFormat)}</p>
-                          <p style={{ margin: '0.25rem 0' }}><strong>{t('info.client_last_activity')}</strong> {formatDateTime(new Date(client.lastActivity), timeFormat, dateFormat)}</p>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </>
-              )}
+                    {source.clients && source.clients.length > 0 && (
+                      <div style={{ marginTop: '0.75rem', fontSize: '0.9em' }}>
+                        <strong>{t('info.client_details')}</strong>
+                        {source.clients.map((client: any) => (
+                          <div key={client.id} style={{
+                            marginTop: '0.5rem',
+                            padding: '0.5rem',
+                            backgroundColor: 'var(--ctp-surface0)',
+                            borderRadius: '4px'
+                          }}>
+                            <p style={{ margin: '0.25rem 0' }}><strong>{t('info.client_id')}</strong> {client.id}</p>
+                            <p style={{ margin: '0.25rem 0' }}><strong>{t('info.client_ip')}</strong> {client.ip}</p>
+                            <p style={{ margin: '0.25rem 0' }}><strong>{t('info.client_connected')}</strong> {formatDateTime(new Date(client.connectedAt), timeFormat, dateFormat)}</p>
+                            <p style={{ margin: '0.25rem 0' }}><strong>{t('info.client_last_activity')}</strong> {formatDateTime(new Date(client.lastActivity), timeFormat, dateFormat)}</p>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </>
+                )}
 
-              <p style={{ fontSize: '0.9em', color: '#888', marginTop: '0.75rem' }}>
-                {t('info.virtual_node_description')}
-              </p>
-              <p style={{ fontSize: '0.85em', color: '#999', marginTop: '0.5rem', fontStyle: 'italic' }}>
-                {t('info.virtual_node_note')}
-              </p>
-            </>
-          )}
-          {!loadingVirtualNode && !virtualNodeStatus && (
-            <p className="no-data">{t('info.virtual_node_unavailable')}</p>
-          )}
+                <p style={{ fontSize: '0.9em', color: '#888', marginTop: '0.75rem' }}>
+                  {t('info.virtual_node_description')}
+                </p>
+                <p style={{ fontSize: '0.85em', color: '#999', marginTop: '0.5rem', fontStyle: 'italic' }}>
+                  {t('info.virtual_node_note')}
+                </p>
+              </>
+            );
+          })()}
         </div>
 
         <div className="info-section">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -840,9 +840,10 @@ class ApiService {
     return response.json();
   }
 
-  async getLongestActiveRouteSegment() {
+  async getLongestActiveRouteSegment(sourceId?: string | null) {
     await this.ensureBaseUrl();
-    const response = await fetch(`${this.baseUrl}/api/route-segments/longest-active`);
+    const qs = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
+    const response = await fetch(`${this.baseUrl}/api/route-segments/longest-active${qs}`);
 
     if (!response.ok) {
       throw new Error('Failed to fetch longest active route segment');
@@ -851,9 +852,10 @@ class ApiService {
     return response.json();
   }
 
-  async getRecordHolderRouteSegment() {
+  async getRecordHolderRouteSegment(sourceId?: string | null) {
     await this.ensureBaseUrl();
-    const response = await fetch(`${this.baseUrl}/api/route-segments/record-holder`);
+    const qs = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
+    const response = await fetch(`${this.baseUrl}/api/route-segments/record-holder${qs}`);
 
     if (!response.ok) {
       throw new Error('Failed to fetch record holder route segment');
@@ -862,9 +864,10 @@ class ApiService {
     return response.json();
   }
 
-  async clearRecordHolderSegment() {
+  async clearRecordHolderSegment(sourceId?: string | null) {
     await this.ensureBaseUrl();
-    const response = await fetch(`${this.baseUrl}/api/route-segments/record-holder`, {
+    const qs = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
+    const response = await fetch(`${this.baseUrl}/api/route-segments/record-holder${qs}`, {
       method: 'DELETE',
       headers: this.getHeadersWithCsrf(),
       credentials: 'include',
@@ -1272,9 +1275,10 @@ class ApiService {
     return response.json();
   }
 
-  async getSecurityKeys(): Promise<{ publicKey: string | null; privateKey: string | null }> {
+  async getSecurityKeys(sourceId?: string | null): Promise<{ publicKey: string | null; privateKey: string | null }> {
     await this.ensureBaseUrl();
-    const response = await fetch(`${this.baseUrl}/api/device/security-keys`, {
+    const qs = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
+    const response = await fetch(`${this.baseUrl}/api/device/security-keys${qs}`, {
       credentials: 'include'
     });
 


### PR DESCRIPTION
## Summary
- Virtual Node block on the Info page showed **Disabled** on every source because the backend `/api/virtual-node/status` now returns `{ sources: [...] }` and the client still read the old flat shape. Now reads the active source via `useSource()` and filters the array (fallback: first entry for legacy root views).
- Scopes the rest of the Info page's fetches (route segments, record-holder clear, security keys, local telemetry stats, packet distribution, portnum node distribution) to the active source by passing `sourceId` to existing source-aware endpoints.
- Added optional `sourceId` param to four `api.ts` wrappers (`getLongestActiveRouteSegment`, `getRecordHolderRouteSegment`, `clearRecordHolderSegment`, `getSecurityKeys`). All backward-compatible — calls without a sourceId behave as before.
- useEffect dependency arrays include `activeSourceId` so the Info page refetches on source switch inside a `SourceProvider`.
- **Bumps version 4.0.0-beta5 → 4.0.0-beta6** across all five manifests (package.json, package-lock.json, helm Chart.yaml, desktop/package.json, desktop/src-tauri/tauri.conf.json).

## Why
`/source/<id>/info` was surfacing primary-source data (or stale cross-source aggregates) regardless of which source the user had selected, with the Virtual Node status being the most visible symptom (always "Disabled").

## Test plan
- [ ] Open `/source/<id>/info` for a source with Virtual Node **enabled** → block shows Status: Enabled, Server Running, clients list.
- [ ] Open `/source/<other-id>/info` for a source with Virtual Node **disabled** → block shows Status: Disabled, no client list.
- [ ] Switch between sources without full reload → Info page refetches (route segments, record holder, security keys, telemetry stats, packet distribution) for the new source.
- [ ] Legacy root view (no SourceProvider) still renders the primary source's Info data.
- [ ] `Clear record holder` button clears only the active source's record.
- [ ] UI footer shows `4.0.0-beta6` after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)