### PR TITLE
fix(migrations): handle legacy FK to nodes(nodeNum) on 3.12 → 4.0 upgrade

### DIFF
--- a/src/server/migrations/029_nodes_composite_pk.test.ts
+++ b/src/server/migrations/029_nodes_composite_pk.test.ts
@@ -179,4 +179,71 @@ describe('Migration 029 — nodes composite PK', () => {
     const pkCount = tableInfo.filter(c => c.pk > 0).length;
     expect(pkCount).toBe(2);
   });
+
+  // Regression: reported by MeshMATIC upgrading 3.12.0 → 4.0.0-beta6 (discussion #2619).
+  // Legacy databases carry FOREIGN KEY (nodeNum) REFERENCES nodes(nodeNum) on
+  // telemetry and route_segments (inherited from pre-baseline schema or an
+  // older Drizzle push). Rebuilding nodes to a composite PK leaves nodeNum
+  // alone no-longer-unique, which trips SQLite's RENAME-time FK compatibility
+  // check ("foreign key mismatch - telemetry referencing nodes") even with
+  // foreign_keys=OFF.
+  it('completes when child tables carry legacy FK to nodes(nodeNum)', () => {
+    db.exec(`
+      CREATE TABLE telemetry (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        nodeNum INTEGER NOT NULL,
+        telemetryType TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        value REAL NOT NULL,
+        createdAt INTEGER NOT NULL,
+        FOREIGN KEY (nodeNum) REFERENCES nodes(nodeNum)
+      );
+
+      CREATE TABLE route_segments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        fromNodeNum INTEGER NOT NULL,
+        toNodeNum INTEGER NOT NULL,
+        fromNodeId TEXT NOT NULL,
+        toNodeId TEXT NOT NULL,
+        distanceKm REAL NOT NULL,
+        isRecordHolder INTEGER DEFAULT 0,
+        timestamp INTEGER NOT NULL,
+        createdAt INTEGER NOT NULL,
+        FOREIGN KEY (fromNodeNum) REFERENCES nodes(nodeNum),
+        FOREIGN KEY (toNodeNum) REFERENCES nodes(nodeNum)
+      );
+
+      CREATE TABLE traceroutes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        fromNodeNum INTEGER NOT NULL,
+        toNodeNum INTEGER NOT NULL,
+        timestamp INTEGER NOT NULL,
+        FOREIGN KEY (fromNodeNum) REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+        FOREIGN KEY (toNodeNum) REFERENCES nodes(nodeNum) ON DELETE CASCADE
+      );
+    `);
+
+    db.prepare(`INSERT INTO users (id, username) VALUES (1, 'admin')`).run();
+    insertLegacyNode(db, 100);
+    insertLegacyNode(db, 200);
+
+    db.prepare(
+      `INSERT INTO telemetry (nodeNum, telemetryType, timestamp, value, createdAt)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(100, 'voltage', 1, 3.7, 1);
+    db.prepare(
+      `INSERT INTO route_segments (fromNodeNum, toNodeNum, fromNodeId, toNodeId, distanceKm, timestamp, createdAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(100, 200, '!00000064', '!000000c8', 1.2, 1, 1);
+
+    expect(() => migration.up(db)).not.toThrow();
+
+    const tableInfo = db.prepare(`PRAGMA table_info(nodes)`).all() as Array<{ name: string; pk: number }>;
+    const pkCols = tableInfo.filter(c => c.pk > 0).map(c => c.name).sort();
+    expect(pkCols).toEqual(['nodeNum', 'sourceId']);
+
+    // Child rows survive the rebuild.
+    expect((db.prepare(`SELECT COUNT(*) c FROM telemetry`).get() as { c: number }).c).toBe(1);
+    expect((db.prepare(`SELECT COUNT(*) c FROM route_segments`).get() as { c: number }).c).toBe(1);
+  });
 });

--- a/src/server/migrations/029_nodes_composite_pk.ts
+++ b/src/server/migrations/029_nodes_composite_pk.ts
@@ -165,6 +165,21 @@ export const migration = {
       db.pragma('foreign_keys = OFF');
     }
 
+    // Legacy databases (upgrades from pre-baseline v3 or early Drizzle pushes)
+    // carry FK declarations like `telemetry.nodeNum REFERENCES nodes(nodeNum)`
+    // and `route_segments.fromNodeNum REFERENCES nodes(nodeNum)`. When we
+    // rebuild nodes to a composite PK (nodeNum, sourceId), nodeNum alone is no
+    // longer unique, so SQLite's RENAME-time FK compatibility check raises
+    // "foreign key mismatch — <child> referencing nodes" even with FK
+    // enforcement disabled. Switching legacy_alter_table=ON tells SQLite to
+    // skip the rewrite/validation during RENAME, which is exactly what we
+    // want here: the child FKs are already unenforceable and the app doesn't
+    // rely on DB-level FK integrity to the nodes table.
+    const prevLegacyAlter = db.pragma('legacy_alter_table', { simple: true }) as number;
+    if (!prevLegacyAlter) {
+      db.pragma('legacy_alter_table = ON');
+    }
+
     const tx = db.transaction(() => {
       // Count nodes requiring backfill (rows with NULL sourceId).
       const nullNodesRow = db.prepare(`SELECT COUNT(*) as c FROM nodes WHERE sourceId IS NULL`).get() as { c: number };
@@ -239,16 +254,33 @@ export const migration = {
       // Per SQLite docs: after a table rebuild with FKs disabled, verify that
       // the rebuild didn't leave any orphaned rows. foreign_key_check returns
       // one row per violating row — empty result means the schema is healthy.
+      // foreign_key_check itself raises "foreign key mismatch" when a child
+      // FK references a now-non-unique parent column (legacy DBs with
+      // telemetry.nodeNum → nodes(nodeNum) hit this after the composite PK
+      // swap). Swallow that — the FK is unenforceable post-rebuild and the
+      // app doesn't depend on it.
       if (prevForeignKeys) {
-        const violations = db.prepare(`PRAGMA foreign_key_check`).all() as Array<{ table: string; rowid: number; parent: string; fkid: number }>;
-        if (violations.length > 0) {
-          // Log but don't fail — these violations pre-existed the migration
-          // and we don't want to prevent the upgrade from completing. The same
-          // rows were already being tolerated before the rebuild.
-          logger.warn(
-            `Migration 029 (SQLite): foreign_key_check reports ${violations.length} pre-existing orphan row(s); tolerating:`,
-            violations.slice(0, 5),
-          );
+        try {
+          const violations = db.prepare(`PRAGMA foreign_key_check`).all() as Array<{ table: string; rowid: number; parent: string; fkid: number }>;
+          if (violations.length > 0) {
+            // Log but don't fail — these violations pre-existed the migration
+            // and we don't want to prevent the upgrade from completing. The
+            // same rows were already being tolerated before the rebuild.
+            logger.warn(
+              `Migration 029 (SQLite): foreign_key_check reports ${violations.length} pre-existing orphan row(s); tolerating:`,
+              violations.slice(0, 5),
+            );
+          }
+        } catch (checkErr: any) {
+          const checkMsg = String(checkErr?.message || checkErr);
+          if (/foreign key mismatch/i.test(checkMsg)) {
+            logger.warn(
+              'Migration 029 (SQLite): legacy child FKs to nodes(nodeNum) no longer match composite PK; tolerating:',
+              checkMsg,
+            );
+          } else {
+            throw checkErr;
+          }
         }
       }
     } catch (err: any) {
@@ -259,10 +291,13 @@ export const migration = {
       }
       throw err;
     } finally {
-      // Always restore the original FK state — even on success, we must not
-      // leave the database in a looser mode than we found it.
+      // Always restore the original pragma state — even on success, we must
+      // not leave the database in a looser mode than we found it.
       if (prevForeignKeys) {
         db.pragma('foreign_keys = ON');
+      }
+      if (!prevLegacyAlter) {
+        db.pragma('legacy_alter_table = OFF');
       }
     }
 

--- a/src/server/migrations/030_add_source_id_to_route_segments.test.ts
+++ b/src/server/migrations/030_add_source_id_to_route_segments.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Migration 030 — route_segments sourceId
+ *
+ * Regression for discussion #2619: legacy SQLite databases carry
+ * `route_segments.fromNodeNum/toNodeNum REFERENCES nodes(nodeNum)` FKs from
+ * pre-baseline schemas. After migration 029 rebuilds nodes with a composite
+ * PK (nodeNum, sourceId), the nodeNum column alone is no longer unique, so
+ * SQLite's ALTER TABLE compatibility check raises "foreign key mismatch —
+ * route_segments referencing nodes" the moment 030 tries to add a column.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './030_add_source_id_to_route_segments.js';
+
+function createPost029Schema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE nodes (
+      nodeNum INTEGER NOT NULL,
+      nodeId TEXT NOT NULL,
+      sourceId TEXT NOT NULL,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL,
+      PRIMARY KEY (nodeNum, sourceId),
+      UNIQUE (nodeId, sourceId)
+    );
+
+    -- Legacy FK to nodes(nodeNum) carried over from pre-baseline schema.
+    CREATE TABLE route_segments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      fromNodeNum INTEGER NOT NULL,
+      toNodeNum INTEGER NOT NULL,
+      fromNodeId TEXT NOT NULL,
+      toNodeId TEXT NOT NULL,
+      distanceKm REAL NOT NULL,
+      isRecordHolder INTEGER DEFAULT 0,
+      fromLatitude REAL,
+      fromLongitude REAL,
+      toLatitude REAL,
+      toLongitude REAL,
+      timestamp INTEGER NOT NULL,
+      createdAt INTEGER NOT NULL,
+      FOREIGN KEY (fromNodeNum) REFERENCES nodes(nodeNum),
+      FOREIGN KEY (toNodeNum) REFERENCES nodes(nodeNum)
+    );
+
+    CREATE TABLE traceroutes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      fromNodeNum INTEGER NOT NULL,
+      toNodeNum INTEGER NOT NULL,
+      route TEXT,
+      routePositions TEXT,
+      timestamp INTEGER NOT NULL,
+      sourceId TEXT
+    );
+  `);
+}
+
+describe('Migration 030 — route_segments sourceId', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    createPost029Schema(db);
+  });
+
+  it('adds sourceId and rebuilds from traceroutes with legacy FK to nodes(nodeNum)', () => {
+    // Seed nodes (composite PK) + one traceroute with a position snapshot.
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)`,
+    ).run(100, '!00000064', 'src-1', now, now);
+    db.prepare(
+      `INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)`,
+    ).run(200, '!000000c8', 'src-1', now, now);
+
+    const positions = JSON.stringify({
+      '100': { lat: 47.0, lng: 8.0 },
+      '200': { lat: 47.1, lng: 8.1 },
+    });
+    db.prepare(
+      `INSERT INTO traceroutes (fromNodeNum, toNodeNum, route, routePositions, timestamp, sourceId)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(200, 100, '[]', positions, now, 'src-1');
+
+    // One legacy row — will be cleared by the migration.
+    db.pragma('foreign_keys = OFF');
+    db.prepare(
+      `INSERT INTO route_segments
+       (fromNodeNum, toNodeNum, fromNodeId, toNodeId, distanceKm, timestamp, createdAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(100, 200, '!00000064', '!000000c8', 12.3, now, now);
+    db.pragma('foreign_keys = ON');
+
+    expect(() => migration.up(db)).not.toThrow();
+
+    const cols = db.prepare(`PRAGMA table_info(route_segments)`).all() as Array<{ name: string }>;
+    expect(cols.some((c) => c.name === 'sourceId')).toBe(true);
+
+    // Rebuild should have re-emitted one segment per consecutive hop pair.
+    const rebuilt = db
+      .prepare(`SELECT fromNodeNum, toNodeNum, sourceId FROM route_segments`)
+      .all() as Array<{ fromNodeNum: number; toNodeNum: number; sourceId: string | null }>;
+    expect(rebuilt.length).toBe(1);
+    expect(rebuilt[0].sourceId).toBe('src-1');
+  });
+
+  it('restores foreign_keys pragma after the rebuild completes', () => {
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)`,
+    ).run(100, '!00000064', 'src-1', now, now);
+
+    expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+    migration.up(db);
+    expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+  });
+
+  it('is idempotent when the column already exists', () => {
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)`,
+    ).run(100, '!00000064', 'src-1', now, now);
+
+    migration.up(db);
+    expect(() => migration.up(db)).not.toThrow();
+
+    const cols = db.prepare(`PRAGMA table_info(route_segments)`).all() as Array<{ name: string }>;
+    expect(cols.filter((c) => c.name === 'sourceId').length).toBe(1);
+  });
+});

--- a/src/server/migrations/030_add_source_id_to_route_segments.ts
+++ b/src/server/migrations/030_add_source_id_to_route_segments.ts
@@ -142,6 +142,23 @@ export const migration = {
     const cols = db.prepare(`PRAGMA table_info(route_segments)`).all() as Array<{ name: string }>;
     const hasSourceId = cols.some((c) => c.name === 'sourceId');
 
+    // Legacy databases carry `route_segments.fromNodeNum/toNodeNum REFERENCES
+    // nodes(nodeNum)` FKs. Migration 029 swapped nodes to a composite PK
+    // (nodeNum, sourceId), so nodeNum alone is no longer unique and the FK is
+    // structurally broken. Any ALTER/DELETE/INSERT on route_segments then
+    // trips SQLite's FK compatibility check with "foreign key mismatch" —
+    // even with foreign_keys=OFF, ALTER TABLE still validates parent key
+    // matching unless legacy_alter_table=ON. Disable both for the rebuild
+    // and restore them in finally.
+    const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
+    if (prevForeignKeys) {
+      db.pragma('foreign_keys = OFF');
+    }
+    const prevLegacyAlter = db.pragma('legacy_alter_table', { simple: true }) as number;
+    if (!prevLegacyAlter) {
+      db.pragma('legacy_alter_table = ON');
+    }
+
     const tx = db.transaction(() => {
       if (!hasSourceId) {
         db.exec(`ALTER TABLE route_segments ADD COLUMN sourceId TEXT`);
@@ -218,6 +235,13 @@ export const migration = {
         return;
       }
       throw err;
+    } finally {
+      if (prevForeignKeys) {
+        db.pragma('foreign_keys = ON');
+      }
+      if (!prevLegacyAlter) {
+        db.pragma('legacy_alter_table = OFF');
+      }
     }
 
     logger.info('Migration 030 complete (SQLite)');


### PR DESCRIPTION
## Summary
- Legacy SQLite databases (pre-baseline v3) carry `telemetry.nodeNum`, `route_segments.fromNodeNum/toNodeNum`, and similar FKs referencing `nodes(nodeNum)`. Migration 029 swaps nodes to a composite PK `(nodeNum, sourceId)` → nodeNum alone is no longer unique → SQLite raises "foreign key mismatch" during the nodes RENAME (029) and again on the route_segments ALTER (030), even with `foreign_keys=OFF`, because `legacy_alter_table=OFF` still cross-validates parent/child keys.
- **029**: enable `legacy_alter_table=ON` around the rebuild; swallow `foreign key mismatch` from the post-rebuild `PRAGMA foreign_key_check` (FKs are unenforceable after the PK change and the app doesn't rely on DB-level integrity to nodes); restore both pragmas in `finally`.
- **030**: add the matching `foreign_keys=OFF` + `legacy_alter_table=ON` save/restore — it previously ran without either, so `ALTER TABLE route_segments ADD COLUMN sourceId` tripped the same mismatch and kept crashing/restarting the container indefinitely.
- Regression tests now seed `telemetry`/`route_segments`/`traceroutes` with FKs to `nodes(nodeNum)` — the existing 029 test only planted an FK to `users`, so this scenario was never exercised.

Reported in discussion #2619 (MeshMATIC, upgrading 3.12.0 → 4.0.0-beta6).

## Test plan
- [x] `npx vitest run src/server/migrations/` — 30/30 pass (new 030 test file + new 029 case)
- [x] Full suite: 4264/4264 pass (217 files)
- [ ] MeshMATIC re-tests 3.12.0 → beta7 upgrade on the affected SQLite DB
- [ ] Consider follow-up: PostgreSQL 029 path drops `nodes_pkey` without cascading FKs — likely needs a similar audit for PG/MySQL users with child-FK databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)