### PR TITLE
fix(messages): exclude traceroute rows from UI message window (#2741)

### DIFF
--- a/src/db/repositories/messages.exclude-portnums.test.ts
+++ b/src/db/repositories/messages.exclude-portnums.test.ts
@@ -1,0 +1,139 @@
+/**
+ * MessagesRepository.getMessages — excludePortnums filter.
+ *
+ * Regression coverage for issue #2741: traceroute responses (portnum 70) were
+ * stored in the `messages` table alongside text DMs and consumed slots in the
+ * capped fetch window, so a successful traceroute would evict a real DM from
+ * the 100-row window the UI pulls from. The fix adds an `excludePortnums`
+ * argument; UI-facing callers pass `[70]` so traceroutes do not displace DMs.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { MessagesRepository } from './messages.js';
+import * as schema from '../schema/index.js';
+
+describe('MessagesRepository.getMessages excludePortnums', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: MessagesRepository;
+
+  const LOCAL_NUM = 0x12345678;
+  const LOCAL_ID = '!12345678';
+  const PEER_NUM = 0x87654321;
+  const PEER_ID = '!87654321';
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+
+    db.exec(`
+      CREATE TABLE nodes (
+        nodeNum INTEGER PRIMARY KEY,
+        nodeId TEXT NOT NULL UNIQUE,
+        longName TEXT,
+        shortName TEXT
+      )
+    `);
+    db.exec(`
+      INSERT INTO nodes (nodeNum, nodeId) VALUES (${LOCAL_NUM}, '${LOCAL_ID}');
+      INSERT INTO nodes (nodeNum, nodeId) VALUES (${PEER_NUM}, '${PEER_ID}');
+    `);
+
+    db.exec(`
+      CREATE TABLE messages (
+        id TEXT PRIMARY KEY,
+        fromNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+        toNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+        fromNodeId TEXT NOT NULL,
+        toNodeId TEXT NOT NULL,
+        text TEXT NOT NULL,
+        channel INTEGER NOT NULL DEFAULT 0,
+        portnum INTEGER,
+        requestId INTEGER,
+        timestamp INTEGER NOT NULL,
+        rxTime INTEGER,
+        hopStart INTEGER,
+        hopLimit INTEGER,
+        relayNode INTEGER,
+        replyId INTEGER,
+        emoji INTEGER,
+        viaMqtt INTEGER,
+        viaStoreForward INTEGER DEFAULT 0,
+        rxSnr REAL,
+        rxRssi REAL,
+        ackFailed INTEGER,
+        routingErrorReceived INTEGER,
+        deliveryState TEXT,
+        wantAck INTEGER,
+        ackFromNode INTEGER,
+        createdAt INTEGER NOT NULL,
+        decrypted_by TEXT,
+        sourceId TEXT
+      )
+    `);
+
+    drizzleDb = drizzle(db, { schema });
+    repo = new MessagesRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  const insert = (id: string, portnum: number | null, rxTime: number, text = 'x') => {
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO messages (id, fromNodeNum, toNodeNum, fromNodeId, toNodeId, text, channel, portnum, timestamp, rxTime, createdAt)
+       VALUES (?, ?, ?, ?, ?, ?, -1, ?, ?, ?, ?)`
+    ).run(id, LOCAL_NUM, PEER_NUM, LOCAL_ID, PEER_ID, text, portnum, rxTime, rxTime, now);
+  };
+
+  it('drops traceroute rows (portnum 70) when excluded', async () => {
+    insert('text-1', 1, 1000);
+    insert('trace-1', 70, 2000);
+    insert('text-2', 1, 3000);
+
+    const all = await repo.getMessages(100);
+    expect(all).toHaveLength(3);
+
+    const filtered = await repo.getMessages(100, 0, undefined, [70]);
+    expect(filtered.map(m => m.id).sort()).toEqual(['text-1', 'text-2']);
+  });
+
+  it('keeps rows whose portnum is NULL (legacy data predates the column)', async () => {
+    insert('legacy', null, 1000);
+    insert('trace', 70, 2000);
+
+    const filtered = await repo.getMessages(100, 0, undefined, [70]);
+    expect(filtered.map(m => m.id)).toEqual(['legacy']);
+  });
+
+  it('does not evict real DMs when a traceroute is inserted (issue #2741)', async () => {
+    // Simulate a tight cap: 3 DMs in the table, then a traceroute arrives.
+    insert('dm-old', 1, 1000);
+    insert('dm-mid', 1, 2000);
+    insert('dm-recent', 1, 3000);
+    insert('trace', 70, 4000);
+
+    // Without the filter, limit=3 returns the 3 newest — which now includes
+    // the traceroute and drops dm-old. This is the bug.
+    const unfiltered = await repo.getMessages(3);
+    expect(unfiltered.map(m => m.id)).toContain('trace');
+    expect(unfiltered.map(m => m.id)).not.toContain('dm-old');
+
+    // With the filter, all 3 DMs survive the same capped window.
+    const filtered = await repo.getMessages(3, 0, undefined, [70]);
+    expect(filtered.map(m => m.id).sort()).toEqual(['dm-mid', 'dm-old', 'dm-recent']);
+  });
+
+  it('is a no-op when excludePortnums is empty or omitted', async () => {
+    insert('a', 1, 1000);
+    insert('b', 70, 2000);
+
+    const omitted = await repo.getMessages(100);
+    const empty = await repo.getMessages(100, 0, undefined, []);
+
+    expect(omitted.map(m => m.id).sort()).toEqual(['a', 'b']);
+    expect(empty.map(m => m.id).sort()).toEqual(['a', 'b']);
+  });
+});

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -4,7 +4,7 @@
  * Handles all message-related database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, gt, lt, gte, and, or, desc, sql, like, ilike, inArray, isNotNull, ne, SQL, count } from 'drizzle-orm';
+import { eq, gt, lt, gte, and, or, desc, sql, like, ilike, inArray, isNotNull, isNull, ne, notInArray, SQL, count } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbMessage } from '../types.js';
 import { logger } from '../../utils/logger.js';
@@ -91,14 +91,30 @@ export class MessagesRepository extends BaseRepository {
   }
 
   /**
-   * Get messages with pagination, ordered by rxTime/timestamp desc
+   * Get messages with pagination, ordered by rxTime/timestamp desc.
+   *
+   * `excludePortnums` drops rows whose portnum matches any in the list. NULL
+   * portnums are always retained (legacy rows predate the column). UI feeds
+   * pass `[PortNum.TRACEROUTE_APP]` so traceroute rows don't consume the
+   * fixed-size window the client filters down to text messages (issue #2741).
    */
-  async getMessages(limit: number = 100, offset: number = 0, sourceId?: string): Promise<DbMessage[]> {
+  async getMessages(
+    limit: number = 100,
+    offset: number = 0,
+    sourceId?: string,
+    excludePortnums?: number[],
+  ): Promise<DbMessage[]> {
     const { messages } = this.tables;
+    const whereClause = (excludePortnums && excludePortnums.length > 0)
+      ? and(
+          this.withSourceScope(messages, sourceId),
+          or(isNull(messages.portnum), notInArray(messages.portnum, excludePortnums)),
+        )
+      : this.withSourceScope(messages, sourceId);
     const result = await this.db
       .select()
       .from(messages)
-      .where(this.withSourceScope(messages, sourceId))
+      .where(whereClause)
       .orderBy(desc(sql`COALESCE(${messages.rxTime}, ${messages.timestamp})`))
       .limit(limit)
       .offset(offset);

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -12141,7 +12141,11 @@ class MeshtasticManager implements ISourceManager {
   }
 
   async getRecentMessages(limit: number = 50, sourceId?: string): Promise<MeshMessage[]> {
-    const dbMessages = await databaseService.messages.getMessages(limit, 0, sourceId);
+    // Exclude traceroute responses: the UI filters them out of message lists
+    // anyway (they render from the `traceroutes` table), so including them
+    // here only wastes slots in the fixed-size window and evicts real DMs
+    // (issue #2741).
+    const dbMessages = await databaseService.messages.getMessages(limit, 0, sourceId, [PortNum.TRACEROUTE_APP]);
     return dbMessages.map(msg => ({
       id: msg.id,
       from: msg.fromNodeId,

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -6,6 +6,7 @@ import { logger } from '../../utils/logger.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { MeshtasticManager } from '../meshtasticManager.js';
 import { filterNodesByChannelPermission, maskNodeLocationByChannel } from '../utils/nodeEnhancer.js';
+import { PortNum } from '../constants/meshtastic.js';
 
 const router = Router();
 
@@ -373,7 +374,11 @@ router.get('/:id/messages', requirePermission('messages', 'read', { sourceIdFrom
 
     const limit = Math.min(parseInt(req.query.limit as string) || 100, 500);
     const offset = parseInt(req.query.offset as string) || 0;
-    const messages = await databaseService.messages.getMessages(limit, offset, source.id);
+    // Exclude traceroute responses from the per-source UI feed. The client
+    // filters them out anyway (they render from the `traceroutes` table);
+    // letting them occupy slots in the capped window evicts real DMs
+    // (issue #2741).
+    const messages = await databaseService.messages.getMessages(limit, offset, source.id, [PortNum.TRACEROUTE_APP]);
     res.json(messages);
   } catch (error) {
     logger.error('Error fetching messages for source:', error);

--- a/src/server/routes/unifiedRoutes.test.ts
+++ b/src/server/routes/unifiedRoutes.test.ts
@@ -321,7 +321,7 @@ describe('Unified Routes', () => {
       await request(app).get('/messages?limit=9999');
 
       // fetchLimit = limit * 2 = 1000
-      expect(mockDb.messages.getMessages).toHaveBeenCalledWith(1000, 0, SOURCE_A.id);
+      expect(mockDb.messages.getMessages).toHaveBeenCalledWith(1000, 0, SOURCE_A.id, [70]);
     });
 
     it('skips sources the user has no read permission for', async () => {

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -9,6 +9,7 @@ import { Router, Request, Response } from 'express';
 import databaseService from '../../services/database.js';
 import { optionalAuth } from '../auth/authMiddleware.js';
 import { logger } from '../../utils/logger.js';
+import { PortNum } from '../constants/meshtastic.js';
 
 const router = Router();
 
@@ -279,7 +280,10 @@ router.get('/messages', async (req: Request, res: Response) => {
           );
         } else {
           // Legacy: no channel filter. Cursor-less offset fetch.
-          msgs = await databaseService.messages.getMessages(fetchLimit, 0, source.id);
+          // Exclude traceroute responses — the UI filters them out of message
+          // lists, so they'd only waste slots in the capped window and evict
+          // real DMs (issue #2741).
+          msgs = await databaseService.messages.getMessages(fetchLimit, 0, source.id, [PortNum.TRACEROUTE_APP]);
           if (before !== undefined) {
             msgs = msgs.filter((m) => (m.rxTime ?? m.timestamp) < before);
           }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4346,9 +4346,13 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
         // visibility belongs in the dedicated unified views (/unified/messages).
         // When no sourceId is provided (legacy single-source clients), fall
         // back to the global fetch.
+        // Exclude traceroute responses from the poll window. The UI filters
+        // them out of message lists (they render from the `traceroutes`
+        // table), so including them only wastes slots in the fixed-size
+        // window and evicts real DMs (issue #2741).
         const dbMessagesRaw = pollSourceId
-          ? await databaseService.messages.getMessages(100, 0, pollSourceId)
-          : await databaseService.messages.getMessages(100);
+          ? await databaseService.messages.getMessages(100, 0, pollSourceId, [PortNum.TRACEROUTE_APP])
+          : await databaseService.messages.getMessages(100, 0, undefined, [PortNum.TRACEROUTE_APP]);
 
         let messages: MeshMessage[] = dbMessagesRaw.map(
           msg => transformDbMessageToMeshMessage(msg as any as DbMessage)


### PR DESCRIPTION
## Summary
- Fixes #2741 — a successful traceroute made the last DM with that node disappear on reload.
- Root cause: traceroute responses are saved to the `messages` table (portnum=70), but the UI's DM view filters them out (`portnum === 1`). Every UI feed is capped at 100 rows, so each traceroute displaced one real DM out of the window. Repeating drained all DMs.
- Fix: add an optional `excludePortnums` arg to `MessagesRepository.getMessages` and pass `[TRACEROUTE_APP]` from every UI-facing caller (poll, `/api/sources/:id/messages`, `getRecentMessages`, unified legacy fetch). NULL-portnum rows are preserved for legacy data. Public v1 API, cache warming, and export paths are unchanged.

## Changed callers
- `src/server/server.ts` — `/api/poll` message window
- `src/server/meshtasticManager.ts` — `getRecentMessages` (feeds `/api/messages`)
- `src/server/routes/sourceRoutes.ts` — `/api/sources/:id/messages`
- `src/server/routes/unifiedRoutes.ts` — legacy no-channel unified fetch

## Test plan
- [x] New regression test file `messages.exclude-portnums.test.ts` — 4 tests including the explicit #2741 scenario (traceroute arriving causes oldest DM to fall off the capped window unless filter is applied).
- [x] Full messages-repo suite green (35 tests).
- [x] Server/route suites unaffected (131 tests green: sourceRoutes, messageRoutes, meshtasticManager).
- [ ] Manually verify in dev container: send DMs to a node, run a successful traceroute, reload — DMs should remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)