### PR TITLE
fix(nodes): preserve favoriteLocked + positionOverride across upserts (#2743)

### DIFF
--- a/src/db/repositories/nodes.test.ts
+++ b/src/db/repositories/nodes.test.ts
@@ -497,6 +497,71 @@ function runNodesTests(getBackend: () => TestBackend) {
     expect(node!.favoriteLocked).toBe(true);
   });
 
+  it('upsertNode - preserves isFavorite when favoriteLocked=true (regression #2743)', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.upsertNode(makeNode(802), 'default');
+    await repo.setNodeFavorite(802, true, 'default', true);
+
+    // Simulate a NodeInfo sync from the device reporting isFavorite=false
+    await repo.upsertNode({ ...makeNode(802), isFavorite: false }, 'default');
+
+    const node = await repo.getNode(802);
+    expect(node!.isFavorite).toBe(true);
+    expect(node!.favoriteLocked).toBe(true);
+  });
+
+  it('upsertNode - allows isFavorite change when favoriteLocked=false', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.upsertNode(makeNode(803), 'default');
+    await repo.setNodeFavorite(803, true, 'default', false);
+
+    await repo.upsertNode({ ...makeNode(803), isFavorite: false }, 'default');
+
+    const node = await repo.getNode(803);
+    expect(node!.isFavorite).toBe(false);
+  });
+
+  it('upsertNode - preserves positionOverride columns across updates (regression #2743)', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.upsertNode({
+      ...makeNode(804),
+      positionOverrideEnabled: true,
+      latitudeOverride: 12.34,
+      longitudeOverride: 56.78,
+      altitudeOverride: 100,
+      positionOverrideIsPrivate: false,
+    } as any, 'default');
+
+    // Simulate a mesh position packet that updates raw lat/lon but carries no override fields
+    await repo.upsertNode({
+      ...makeNode(804),
+      latitude: 1.0,
+      longitude: 2.0,
+      altitude: 50,
+    }, 'default');
+
+    const node = await repo.getNode(804) as any;
+    expect(node!.positionOverrideEnabled).toBe(true);
+    expect(Number(node!.latitudeOverride)).toBeCloseTo(12.34);
+    expect(Number(node!.longitudeOverride)).toBeCloseTo(56.78);
+    expect(Number(node!.altitudeOverride)).toBe(100);
+  });
+
   // --- setNodeIgnored ---
 
   it('setNodeIgnored - toggles ignored status', async () => {

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -177,7 +177,9 @@ export class NodesRepository extends BaseRepository {
           rssi: nodeData.rssi ?? existingNode.rssi,
           firmwareVersion: nodeData.firmwareVersion ?? existingNode.firmwareVersion,
           channel: nodeData.channel ?? existingNode.channel,
-          isFavorite: nodeData.isFavorite ?? existingNode.isFavorite,
+          isFavorite: existingNode.favoriteLocked
+            ? existingNode.isFavorite
+            : (nodeData.isFavorite ?? existingNode.isFavorite),
           mobile: nodeData.mobile ?? existingNode.mobile,
           rebootCount: nodeData.rebootCount ?? existingNode.rebootCount,
           publicKey: nodeData.publicKey ?? existingNode.publicKey,
@@ -192,6 +194,11 @@ export class NodesRepository extends BaseRepository {
           positionChannel: nodeData.positionChannel ?? existingNode.positionChannel,
           positionPrecisionBits: nodeData.positionPrecisionBits ?? existingNode.positionPrecisionBits,
           positionTimestamp: this.coerceBigintField(nodeData.positionTimestamp ?? existingNode.positionTimestamp),
+          positionOverrideEnabled: nodeData.positionOverrideEnabled ?? existingNode.positionOverrideEnabled,
+          latitudeOverride: nodeData.latitudeOverride ?? existingNode.latitudeOverride,
+          longitudeOverride: nodeData.longitudeOverride ?? existingNode.longitudeOverride,
+          altitudeOverride: nodeData.altitudeOverride ?? existingNode.altitudeOverride,
+          positionOverrideIsPrivate: nodeData.positionOverrideIsPrivate ?? existingNode.positionOverrideIsPrivate,
           updatedAt: now,
         })
         .where(and(eq(nodes.nodeNum, nodeData.nodeNum), eq(nodes.sourceId, effectiveSourceId)));
@@ -234,6 +241,11 @@ export class NodesRepository extends BaseRepository {
         positionChannel: nodeData.positionChannel ?? null,
         positionPrecisionBits: nodeData.positionPrecisionBits ?? null,
         positionTimestamp: this.coerceBigintField(nodeData.positionTimestamp),
+        positionOverrideEnabled: nodeData.positionOverrideEnabled ?? false,
+        latitudeOverride: nodeData.latitudeOverride ?? null,
+        longitudeOverride: nodeData.longitudeOverride ?? null,
+        altitudeOverride: nodeData.altitudeOverride ?? null,
+        positionOverrideIsPrivate: nodeData.positionOverrideIsPrivate ?? false,
         createdAt: now,
         updatedAt: now,
       } as any;
@@ -281,6 +293,11 @@ export class NodesRepository extends BaseRepository {
         positionChannel: nodeData.positionChannel ?? null,
         positionPrecisionBits: nodeData.positionPrecisionBits ?? null,
         positionTimestamp: this.coerceBigintField(nodeData.positionTimestamp),
+        positionOverrideEnabled: nodeData.positionOverrideEnabled ?? false,
+        latitudeOverride: nodeData.latitudeOverride ?? null,
+        longitudeOverride: nodeData.longitudeOverride ?? null,
+        altitudeOverride: nodeData.altitudeOverride ?? null,
+        positionOverrideIsPrivate: nodeData.positionOverrideIsPrivate ?? false,
         updatedAt: now,
       };
 

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6479,11 +6479,32 @@ class MeshtasticManager implements ISourceManager {
       }
 
       // Always sync isFavorite from device to keep in sync with changes made while offline
-      // This ensures favorites are updated when reconnecting (fixes #213)
+      // This ensures favorites are updated when reconnecting (fixes #213).
+      // Exception: if favoriteLocked is set, the DB value wins and we re-push our
+      // locked flag to the device so it converges to what the user has pinned.
       if (nodeInfo.isFavorite !== undefined) {
-        nodeData.isFavorite = nodeInfo.isFavorite;
-        if (existingNode && existingNode.isFavorite !== nodeInfo.isFavorite) {
-          logger.debug(`⭐ Updating favorite status for node ${nodeId} from ${existingNode.isFavorite} to ${nodeInfo.isFavorite}`);
+        if (existingNode?.favoriteLocked) {
+          if (existingNode.isFavorite !== nodeInfo.isFavorite) {
+            logger.info(`🔒 Node ${nodeId} favoriteLocked — preserving DB isFavorite=${existingNode.isFavorite}, re-syncing to device (device reported ${nodeInfo.isFavorite})`);
+            nodeData.isFavorite = existingNode.isFavorite;
+            // Re-push the locked favorite state to the connected device
+            void (async () => {
+              try {
+                if (existingNode.isFavorite) {
+                  await this.sendFavoriteNode(nodeNum);
+                } else {
+                  await this.sendRemoveFavoriteNode(nodeNum);
+                }
+              } catch (err) {
+                logger.warn(`⚠️ Failed to re-sync locked favorite for node ${nodeId}:`, err);
+              }
+            })();
+          }
+        } else {
+          nodeData.isFavorite = nodeInfo.isFavorite;
+          if (existingNode && existingNode.isFavorite !== nodeInfo.isFavorite) {
+            logger.debug(`⭐ Updating favorite status for node ${nodeId} from ${existingNode.isFavorite} to ${nodeInfo.isFavorite}`);
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
Fixes #2743.

Two related bugs found while investigating the issue report:

1. **Position Override lost on Postgres/MySQL restart.** `setNodePositionOverride` in the PG/MySQL path updates the in-memory cache and then delegates persistence to `nodesRepo.upsertNode`. But `upsertNode`'s SET/INSERT objects did not include any override columns (`positionOverrideEnabled`, `latitudeOverride`, `longitudeOverride`, `altitudeOverride`, `positionOverrideIsPrivate`), so the override was never written to the DB. On container restart the cache rebuilt from the old DB state and the override vanished. SQLite was unaffected — it writes override columns via a dedicated raw UPDATE.

2. **Device NodeDB sync silently un-favorites locked nodes.** `processNodeInfoProtobuf` unconditionally copied `isFavorite` from the device NodeDB into `nodeData`, and `upsertNode` wrote it straight to the DB with no regard for `favoriteLocked`. Auto-favorite sweeps correctly check the lock, but any device sync where the radio has a stale/unfavorite state would wipe the user's lock.

## Changes
- `src/db/repositories/nodes.ts`
  - `upsertNode` UPDATE branch: guard `isFavorite` with `existingNode.favoriteLocked`
  - `upsertNode` UPDATE branch: include all 5 override columns, preserving via `nodeData.X ?? existingNode.X`
  - `upsertNode` INSERT branches (`newNode` + `upsertSet`): include override columns so initial inserts + conflict updates persist them
- `src/server/meshtasticManager.ts` `processNodeInfoProtobuf`: when `existingNode.favoriteLocked` and the device reports a divergent `isFavorite`, keep the DB value and re-push the locked state to the radio via `sendFavoriteNode` / `sendRemoveFavoriteNode` so the device converges to the user's intent
- `src/db/repositories/nodes.test.ts`: regression tests covering:
  - `upsertNode` preserves `isFavorite` when `favoriteLocked=true`
  - `upsertNode` allows `isFavorite` change when `favoriteLocked=false`
  - `upsertNode` preserves override columns across subsequent upserts (simulates mesh position packet clobber path)

## Test plan
- [x] `npx vitest run src/db/repositories/nodes.test.ts` — 31 pass
- [x] `npx vitest run src/db/repositories/ src/services/database.test.ts` — 435 pass
- [x] `npx vitest run src/server/meshtasticManager` — 449 pass
- [ ] Manual: mark a node `favoriteLocked=true`, trigger a device NodeDB sync where the radio reports `isFavorite=false`, confirm DB unchanged and a favorite sync packet is sent to the radio
- [ ] Manual (PG): set a position override via the UI, restart the container, confirm the override survives the restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)