### PR TITLE
fix(auto-responder): honor script "private" field for DM override

### DIFF
--- a/docs/developers/auto-responder-scripting.md
+++ b/docs/developers/auto-responder-scripting.md
@@ -197,7 +197,23 @@ Scripts must print JSON to stdout:
 }
 ```
 
-**Optional fields** (reserved for future use):
+**Optional fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `responses` | `string[]` | Multiple response messages. If present, `response` is ignored. Each item is sent as its own mesh packet. |
+| `private` | `boolean` | Overrides the reply target. `true` forces a DM to the sender; `false` forces a reply on the channel where the trigger fired (even if the trigger was a DM). When omitted, the reply follows the original message (DM → DM, channel → channel). |
+
+**Example: force a DM reply**
+
+```python
+print(json.dumps({
+    "response": "Here is your private link",
+    "private": True,
+}))
+```
+
+**Reserved for future use:**
 ```json
 {
   "response": "Your response text",

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -8773,8 +8773,14 @@ class MeshtasticManager implements ISourceManager {
                 return;
               }
 
-              // Respond on the channel the message came from
-              const isDM = isDirectMessage;
+              // Respond on the channel the message came from, unless the script
+              // explicitly overrides the target via the "private" field:
+              //   - "private": true  -> force DM reply to the sender
+              //   - "private": false -> force channel reply even if the trigger was a DM
+              let isDM = isDirectMessage;
+              if (typeof scriptOutput.private === 'boolean') {
+                isDM = scriptOutput.private;
+              }
               // For DMs: use 3 attempts if verifyResponse is enabled, otherwise just 1 attempt
               const maxAttempts = isDM ? (trigger.verifyResponse ? 3 : 1) : 1;
               const target = isDM ? `!${message.fromNodeNum.toString(16).padStart(8, '0')}` : `channel ${message.channel}`;


### PR DESCRIPTION
## Summary
Auto-responder scripts can emit `{"response": "...", "private": true}` (pattern used by the MeshMonitor-BBS example and others) to request the reply be sent back to the sender as a DM instead of broadcast to the triggering channel. The handler previously hardcoded the reply target to match the incoming message type, so `private: true` had no effect and responses always went back out on the same channel.

This change makes the script handler honor the `private` boolean when present: `true` forces a DM, `false` forces a channel reply, and omission preserves the current mirror-the-incoming-message behavior.

## Changes
- `src/server/meshtasticManager.ts` — when script output has a boolean `private` field, use it to override `isDM` before enqueueing responses.
- `docs/developers/auto-responder-scripting.md` — documented the `private` and `responses` optional fields in the JSON output format.

## Issues Resolved
Fixes #2730

## Documentation Updates
Added an "Optional fields" table and a Python example to `docs/developers/auto-responder-scripting.md` describing `private` and `responses` in the script JSON output contract.

## Testing
- [ ] Unit tests pass
- [ ] TypeScript compiles cleanly (verified locally with `tsc --noEmit -p tsconfig.server.json`)
- [ ] Broadcast a channel message that fires a script returning `{"response": "hi", "private": true}` — reply should arrive as a DM to the sender, not to the channel.
- [ ] Send a DM that fires a script returning `{"response": "hi", "private": false}` — reply should go to the channel the sender was on, not back as a DM.
- [ ] Send a DM that fires a script returning `{"response": "hi"}` (no `private` field) — reply should arrive as a DM (existing behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)