### PR TITLE
fix(dashboard): default new source heartbeat to 30s

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -76,7 +76,7 @@ function DashboardInner() {
   const [formVnEnabled, setFormVnEnabled] = useState(false);
   const [formVnPort, setFormVnPort] = useState('');
   const [formVnAllowAdmin, setFormVnAllowAdmin] = useState(false);
-  const [formHeartbeat, setFormHeartbeat] = useState('0'); // seconds, 0 = disabled (issue 2609)
+  const [formHeartbeat, setFormHeartbeat] = useState('30'); // seconds, 0 = disabled (issue 2609)
   const [formError, setFormError] = useState('');
   const [formSaving, setFormSaving] = useState(false);
 
@@ -136,7 +136,7 @@ function DashboardInner() {
     setFormVnEnabled(false);
     setFormVnPort('');
     setFormVnAllowAdmin(false);
-    setFormHeartbeat('0');
+    setFormHeartbeat('30');
     setFormError('');
     setShowSourceModal(true);
   };


### PR DESCRIPTION
## Summary
- Add Source form defaults heartbeat interval to 30 seconds (was 0/disabled)
- Edit Source still reads `heartbeatIntervalSeconds` from stored config — no change to existing sources

## Test plan
- [ ] Open Dashboard → Add Source → confirm heartbeat field shows `30`
- [ ] Edit an existing source with heartbeat already set → confirm stored value is preserved
- [ ] Edit an existing source without heartbeat configured → confirm it still shows `0` (disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)