### PR TITLE
fix(migrations): tolerate legacy telemetry→nodes FK on 3.x → 4.0 upgrade

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 40 migrations registered', () => {
-    expect(registry.count()).toBe(40);
+  it('has all 41 migrations registered', () => {
+    expect(registry.count()).toBe(41);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,11 +12,11 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is purge_null_sourceid_neighbor_info', () => {
+  it('last migration is drop_legacy_telemetry_nodes_fk', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(40);
-    expect(last.name).toContain('purge_null_sourceid_neighbor_info');
+    expect(last.number).toBe(41);
+    expect(last.name).toContain('drop_legacy_telemetry_nodes_fk');
   });
 
   it('migrations are sequentially numbered from 1 to 35', () => {

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -52,6 +52,7 @@ import { migration as userMapPrefsIdMigration, runMigration037Postgres, runMigra
 import { migration as cleanupOrphanNotificationPrefsMigration, runMigration038Postgres, runMigration038Mysql } from '../server/migrations/038_cleanup_orphan_notification_prefs.js';
 import { migration as purgeNullSourceIdTelemetryMigration, runMigration039Postgres, runMigration039Mysql } from '../server/migrations/039_purge_null_sourceid_telemetry.js';
 import { migration as purgeNullSourceIdNeighborInfoMigration, runMigration040Postgres, runMigration040Mysql } from '../server/migrations/040_purge_null_sourceid_neighbor_info.js';
+import { migration as dropLegacyTelemetryFkMigration, runMigration041Postgres, runMigration041Mysql } from '../server/migrations/041_drop_legacy_telemetry_nodes_fk.js';
 
 // ============================================================================
 // Registry
@@ -607,4 +608,24 @@ registry.register({
   sqlite: (db) => purgeNullSourceIdNeighborInfoMigration.up(db),
   postgres: (client) => runMigration040Postgres(client),
   mysql: (pool) => runMigration040Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 041: Drop legacy telemetry→nodes(nodeNum) FK on SQLite.
+// Legacy v3.x databases carry a FK `telemetry.nodeNum REFERENCES
+// nodes(nodeNum)` that became structurally invalid once 029 swapped nodes to
+// a composite PK. Every DML on telemetry raises
+// `foreign key mismatch - "telemetry" referencing "nodes"` with FKs enabled.
+// This migration rebuilds the SQLite telemetry table without the FK so
+// future migrations don't have to toggle foreign_keys=OFF. PG/MySQL baselines
+// never declared this FK; no-op there.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 41,
+  name: 'drop_legacy_telemetry_nodes_fk',
+  settingsKey: 'migration_041_drop_legacy_telemetry_nodes_fk',
+  sqlite: (db) => dropLegacyTelemetryFkMigration.up(db),
+  postgres: (client) => runMigration041Postgres(client),
+  mysql: (pool) => runMigration041Mysql(pool),
 });

--- a/src/server/migrations/032_telemetry_packet_dedupe.test.ts
+++ b/src/server/migrations/032_telemetry_packet_dedupe.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Migration 032 — telemetry packet dedupe
+ *
+ * Regression for 4.0.0-beta7 bootloop: legacy v3.x databases carry
+ * `telemetry.nodeNum REFERENCES nodes(nodeNum)`. After migration 029 swapped
+ * nodes to a composite PK (nodeNum, sourceId), that FK is structurally
+ * invalid — any DELETE on telemetry with foreign_keys=ON raises
+ * "foreign key mismatch - telemetry referencing nodes". 032 is the first
+ * post-029 migration to DELETE from telemetry, so it was the first to crash.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './032_telemetry_packet_dedupe.js';
+
+function createTelemetryTable(db: Database.Database, withLegacyFk: boolean) {
+  if (withLegacyFk) {
+    db.exec(`
+      CREATE TABLE nodes (
+        nodeNum INTEGER NOT NULL,
+        sourceId TEXT NOT NULL,
+        PRIMARY KEY (nodeNum, sourceId)
+      );
+    `);
+  }
+  db.exec(`
+    CREATE TABLE telemetry (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      nodeId TEXT NOT NULL,
+      nodeNum INTEGER NOT NULL,
+      telemetryType TEXT NOT NULL,
+      timestamp INTEGER NOT NULL,
+      value REAL NOT NULL,
+      unit TEXT,
+      createdAt INTEGER NOT NULL,
+      packetTimestamp INTEGER,
+      packetId INTEGER,
+      channel INTEGER,
+      precisionBits INTEGER,
+      gpsAccuracy REAL,
+      sourceId TEXT
+      ${withLegacyFk ? ', FOREIGN KEY (nodeNum) REFERENCES nodes(nodeNum)' : ''}
+    )
+  `);
+}
+
+function insertRow(
+  db: Database.Database,
+  opts: { sourceId: string | null; nodeNum: number; packetId: number | null; telemetryType: string },
+) {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO telemetry (nodeId, nodeNum, telemetryType, timestamp, value, unit, createdAt, packetId, sourceId)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    `!${opts.nodeNum.toString(16).padStart(8, '0')}`,
+    opts.nodeNum,
+    opts.telemetryType,
+    now,
+    42,
+    '%',
+    now,
+    opts.packetId,
+    opts.sourceId,
+  );
+}
+
+describe('Migration 032 — telemetry packet dedupe', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createTelemetryTable(db, false);
+  });
+
+  it('dedupes rows with the same (sourceId, nodeNum, packetId, telemetryType)', () => {
+    insertRow(db, { sourceId: 'src-1', nodeNum: 1, packetId: 100, telemetryType: 'batteryLevel' });
+    insertRow(db, { sourceId: 'src-1', nodeNum: 1, packetId: 100, telemetryType: 'batteryLevel' });
+    insertRow(db, { sourceId: 'src-1', nodeNum: 1, packetId: 100, telemetryType: 'voltage' });
+
+    migration.up(db);
+
+    const rows = db.prepare(`SELECT * FROM telemetry ORDER BY id`).all() as any[];
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.telemetryType).sort()).toEqual(['batteryLevel', 'voltage']);
+  });
+
+  it('keeps NULL-packetId rows intact', () => {
+    insertRow(db, { sourceId: 'src-1', nodeNum: 1, packetId: null, telemetryType: 'batteryLevel' });
+    insertRow(db, { sourceId: 'src-1', nodeNum: 1, packetId: null, telemetryType: 'batteryLevel' });
+
+    migration.up(db);
+
+    const rows = db.prepare(`SELECT * FROM telemetry`).all() as any[];
+    expect(rows).toHaveLength(2);
+  });
+
+  it('creates the partial unique index', () => {
+    migration.up(db);
+    const idx = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name='telemetry_source_packet_type_uniq'`)
+      .get();
+    expect(idx).toBeTruthy();
+  });
+
+  it('is idempotent — second run is a no-op', () => {
+    insertRow(db, { sourceId: 'src-1', nodeNum: 1, packetId: 100, telemetryType: 'batteryLevel' });
+    insertRow(db, { sourceId: 'src-1', nodeNum: 1, packetId: 100, telemetryType: 'batteryLevel' });
+
+    migration.up(db);
+    migration.up(db);
+
+    const rows = db.prepare(`SELECT * FROM telemetry`).all() as any[];
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe('Migration 032 — legacy FK regression', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    createTelemetryTable(db, true);
+  });
+
+  it('runs without raising "foreign key mismatch" when telemetry has legacy FK to nodes(nodeNum)', () => {
+    // Seed with FKs off — the broken FK would block the INSERT itself otherwise.
+    db.pragma('foreign_keys = OFF');
+    insertRow(db, { sourceId: 'src-1', nodeNum: 1, packetId: 100, telemetryType: 'batteryLevel' });
+    insertRow(db, { sourceId: 'src-1', nodeNum: 1, packetId: 100, telemetryType: 'batteryLevel' });
+    db.pragma('foreign_keys = ON');
+
+    expect(() => migration.up(db)).not.toThrow();
+
+    const rows = db.prepare(`SELECT * FROM telemetry`).all() as any[];
+    expect(rows).toHaveLength(1);
+  });
+
+  it('restores foreign_keys=ON after running', () => {
+    db.pragma('foreign_keys = OFF');
+    insertRow(db, { sourceId: 'src-1', nodeNum: 1, packetId: 100, telemetryType: 'batteryLevel' });
+    db.pragma('foreign_keys = ON');
+    migration.up(db);
+    expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+  });
+});

--- a/src/server/migrations/032_telemetry_packet_dedupe.ts
+++ b/src/server/migrations/032_telemetry_packet_dedupe.ts
@@ -37,28 +37,46 @@ export const migration = {
   up: (db: Database): void => {
     logger.info('Running migration 032 (SQLite): telemetry packet dedupe...');
 
-    // Dedupe existing rows: keep lowest id per (sourceId, nodeNum, packetId, telemetryType)
-    // where packetId IS NOT NULL. NULL packetId rows are left alone.
-    const deleteStmt = db.prepare(`
-      DELETE FROM telemetry
-      WHERE packetId IS NOT NULL
-        AND id NOT IN (
-          SELECT MIN(id) FROM telemetry
-          WHERE packetId IS NOT NULL
-          GROUP BY sourceId, nodeNum, packetId, telemetryType
-        )
-    `);
-    const result = deleteStmt.run();
-    if (result.changes > 0) {
-      logger.info(`Migration 032 (SQLite): deduped ${result.changes} duplicate telemetry rows`);
+    // Legacy v3.x databases carry `telemetry.nodeNum REFERENCES nodes(nodeNum)`.
+    // Migration 029 rebuilt nodes with composite PK (nodeNum, sourceId), which
+    // makes that FK structurally invalid (parent column no longer unique).
+    // With foreign_keys=ON any DELETE on telemetry then raises
+    // "foreign key mismatch - telemetry referencing nodes". Disable FK
+    // enforcement for this migration and restore it in finally. See 029/030
+    // for the same pattern.
+    const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
+    if (prevForeignKeys) {
+      db.pragma('foreign_keys = OFF');
     }
 
-    // Partial unique index (idempotent via IF NOT EXISTS)
-    db.exec(`
-      CREATE UNIQUE INDEX IF NOT EXISTS ${INDEX_NAME}
-        ON telemetry(sourceId, nodeNum, packetId, telemetryType)
+    try {
+      // Dedupe existing rows: keep lowest id per (sourceId, nodeNum, packetId, telemetryType)
+      // where packetId IS NOT NULL. NULL packetId rows are left alone.
+      const deleteStmt = db.prepare(`
+        DELETE FROM telemetry
         WHERE packetId IS NOT NULL
-    `);
+          AND id NOT IN (
+            SELECT MIN(id) FROM telemetry
+            WHERE packetId IS NOT NULL
+            GROUP BY sourceId, nodeNum, packetId, telemetryType
+          )
+      `);
+      const result = deleteStmt.run();
+      if (result.changes > 0) {
+        logger.info(`Migration 032 (SQLite): deduped ${result.changes} duplicate telemetry rows`);
+      }
+
+      // Partial unique index (idempotent via IF NOT EXISTS)
+      db.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS ${INDEX_NAME}
+          ON telemetry(sourceId, nodeNum, packetId, telemetryType)
+          WHERE packetId IS NOT NULL
+      `);
+    } finally {
+      if (prevForeignKeys) {
+        db.pragma('foreign_keys = ON');
+      }
+    }
 
     logger.info('Migration 032 complete (SQLite)');
   },

--- a/src/server/migrations/039_purge_null_sourceid_telemetry.test.ts
+++ b/src/server/migrations/039_purge_null_sourceid_telemetry.test.ts
@@ -80,3 +80,65 @@ describe('Migration 039 — purge NULL-sourceId telemetry', () => {
     expect(rows[0].sourceId).toBe('source-A');
   });
 });
+
+/**
+ * Regression for 4.0.0-beta7 bootloop: legacy v3.x databases carry
+ * `telemetry.nodeNum REFERENCES nodes(nodeNum)`. After migration 029 swaps
+ * nodes to a composite PK, that FK is structurally invalid and any DELETE
+ * on telemetry with foreign_keys=ON raises "foreign key mismatch -
+ * telemetry referencing nodes". 039 must tolerate this.
+ */
+describe('Migration 039 — legacy FK regression', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    db.exec(`
+      CREATE TABLE nodes (
+        nodeNum INTEGER NOT NULL,
+        sourceId TEXT NOT NULL,
+        PRIMARY KEY (nodeNum, sourceId)
+      );
+      CREATE TABLE telemetry (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        nodeId TEXT NOT NULL,
+        nodeNum INTEGER NOT NULL,
+        telemetryType TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        value REAL NOT NULL,
+        unit TEXT,
+        createdAt INTEGER NOT NULL,
+        packetTimestamp INTEGER,
+        packetId INTEGER,
+        channel INTEGER,
+        precisionBits INTEGER,
+        gpsAccuracy REAL,
+        sourceId TEXT,
+        FOREIGN KEY (nodeNum) REFERENCES nodes(nodeNum)
+      );
+    `);
+  });
+
+  it('runs without raising "foreign key mismatch" even with legacy FK + composite PK', () => {
+    // Seed with FKs off — the broken FK would block the INSERT itself otherwise.
+    db.pragma('foreign_keys = OFF');
+    insert(db, null);
+    insert(db, 'source-A');
+    db.pragma('foreign_keys = ON');
+
+    expect(() => migration.up(db)).not.toThrow();
+
+    const rows = db.prepare(`SELECT sourceId FROM telemetry`).all() as any[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sourceId).toBe('source-A');
+  });
+
+  it('restores foreign_keys=ON after running', () => {
+    db.pragma('foreign_keys = OFF');
+    insert(db, null);
+    db.pragma('foreign_keys = ON');
+    migration.up(db);
+    expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+  });
+});

--- a/src/server/migrations/039_purge_null_sourceid_telemetry.ts
+++ b/src/server/migrations/039_purge_null_sourceid_telemetry.ts
@@ -18,11 +18,26 @@ import { logger } from '../../utils/logger.js';
 
 export const migration = {
   up(db: Database): void {
-    const res = db
-      .prepare(`DELETE FROM telemetry WHERE sourceId IS NULL`)
-      .run();
-    if (res.changes > 0) {
-      logger.info(`Migration 039: purged ${res.changes} telemetry rows with NULL sourceId`);
+    // Legacy v3.x databases carry `telemetry.nodeNum REFERENCES nodes(nodeNum)`.
+    // Migration 029 rebuilt nodes with composite PK, so the FK is structurally
+    // invalid and DELETE on telemetry raises "foreign key mismatch" with
+    // foreign_keys=ON. Disable FK enforcement for this migration and restore
+    // in finally. See 029/030/032 for the same pattern.
+    const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
+    if (prevForeignKeys) {
+      db.pragma('foreign_keys = OFF');
+    }
+    try {
+      const res = db
+        .prepare(`DELETE FROM telemetry WHERE sourceId IS NULL`)
+        .run();
+      if (res.changes > 0) {
+        logger.info(`Migration 039: purged ${res.changes} telemetry rows with NULL sourceId`);
+      }
+    } finally {
+      if (prevForeignKeys) {
+        db.pragma('foreign_keys = ON');
+      }
     }
   },
 };

--- a/src/server/migrations/041_drop_legacy_telemetry_nodes_fk.test.ts
+++ b/src/server/migrations/041_drop_legacy_telemetry_nodes_fk.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Migration 041 — Drop legacy telemetry→nodes(nodeNum) FK
+ *
+ * Legacy v3.x SQLite databases carry a `telemetry.nodeNum REFERENCES
+ * nodes(nodeNum)` FK. After migration 029 rebuilt nodes with a composite
+ * PK, that FK is structurally invalid. This migration rebuilds telemetry
+ * without the FK so future DML doesn't need to toggle foreign_keys.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './041_drop_legacy_telemetry_nodes_fk.js';
+
+function createLegacySchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE nodes (
+      nodeNum INTEGER NOT NULL,
+      sourceId TEXT NOT NULL,
+      PRIMARY KEY (nodeNum, sourceId)
+    );
+    CREATE TABLE telemetry (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      nodeId TEXT NOT NULL,
+      nodeNum INTEGER NOT NULL,
+      telemetryType TEXT NOT NULL,
+      timestamp INTEGER NOT NULL,
+      value REAL NOT NULL,
+      unit TEXT,
+      createdAt INTEGER NOT NULL,
+      packetTimestamp INTEGER,
+      packetId INTEGER,
+      channel INTEGER,
+      precisionBits INTEGER,
+      gpsAccuracy REAL,
+      sourceId TEXT,
+      FOREIGN KEY (nodeNum) REFERENCES nodes(nodeNum)
+    );
+    CREATE INDEX idx_telemetry_nodenum ON telemetry(nodeNum);
+    CREATE INDEX idx_telemetry_timestamp ON telemetry(timestamp);
+  `);
+}
+
+function createBaselineSchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE nodes (
+      nodeNum INTEGER NOT NULL,
+      sourceId TEXT NOT NULL,
+      PRIMARY KEY (nodeNum, sourceId)
+    );
+    CREATE TABLE telemetry (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      nodeId TEXT NOT NULL,
+      nodeNum INTEGER NOT NULL,
+      telemetryType TEXT NOT NULL,
+      timestamp INTEGER NOT NULL,
+      value REAL NOT NULL,
+      unit TEXT,
+      createdAt INTEGER NOT NULL,
+      packetTimestamp INTEGER,
+      packetId INTEGER,
+      channel INTEGER,
+      precisionBits INTEGER,
+      gpsAccuracy REAL,
+      sourceId TEXT
+    );
+  `);
+}
+
+function hasLegacyFk(db: Database.Database): boolean {
+  const rows = db.prepare(`PRAGMA foreign_key_list(telemetry)`).all() as Array<{
+    table: string;
+    from: string;
+    to: string;
+  }>;
+  return rows.some((r) => String(r.table).toLowerCase() === 'nodes' && r.from === 'nodeNum');
+}
+
+function insertTelemetry(db: Database.Database, nodeNum: number, sourceId: string | null) {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO telemetry (nodeId, nodeNum, telemetryType, timestamp, value, unit, createdAt, sourceId)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(`!${nodeNum.toString(16).padStart(8, '0')}`, nodeNum, 'batteryLevel', now, 42, '%', now, sourceId);
+}
+
+describe('Migration 041 — drop legacy telemetry FK', () => {
+  let db: Database.Database;
+
+  describe('legacy schema with FK present', () => {
+    beforeEach(() => {
+      db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      createLegacySchema(db);
+      // Seed with FKs off — the broken FK blocks INSERT with FKs on.
+      db.pragma('foreign_keys = OFF');
+      insertTelemetry(db, 100, 'src-1');
+      insertTelemetry(db, 200, null);
+      db.pragma('foreign_keys = ON');
+    });
+
+    it('removes the FK from telemetry', () => {
+      expect(hasLegacyFk(db)).toBe(true);
+      migration.up(db);
+      expect(hasLegacyFk(db)).toBe(false);
+    });
+
+    it('preserves all telemetry rows', () => {
+      migration.up(db);
+      const rows = db.prepare(`SELECT id, nodeNum, sourceId FROM telemetry ORDER BY id`).all() as any[];
+      expect(rows).toHaveLength(2);
+      expect(rows[0].nodeNum).toBe(100);
+      expect(rows[0].sourceId).toBe('src-1');
+      expect(rows[1].nodeNum).toBe(200);
+      expect(rows[1].sourceId).toBeNull();
+    });
+
+    it('recreates non-auto indexes', () => {
+      migration.up(db);
+      const idxs = db
+        .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='telemetry' AND name NOT LIKE 'sqlite_autoindex_%'`)
+        .all() as Array<{ name: string }>;
+      const names = idxs.map((r) => r.name).sort();
+      expect(names).toContain('idx_telemetry_nodenum');
+      expect(names).toContain('idx_telemetry_timestamp');
+    });
+
+    it('restores foreign_keys=ON after running', () => {
+      migration.up(db);
+      expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+    });
+
+    it('allows DELETE on telemetry after the rebuild', () => {
+      migration.up(db);
+      expect(() => db.prepare(`DELETE FROM telemetry WHERE sourceId IS NULL`).run()).not.toThrow();
+      const remaining = db.prepare(`SELECT COUNT(*) c FROM telemetry`).get() as any;
+      expect(remaining.c).toBe(1);
+    });
+
+    it('is idempotent — second run is a no-op', () => {
+      migration.up(db);
+      expect(() => migration.up(db)).not.toThrow();
+      expect(hasLegacyFk(db)).toBe(false);
+    });
+  });
+
+  describe('baseline schema without FK', () => {
+    beforeEach(() => {
+      db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      createBaselineSchema(db);
+      insertTelemetry(db, 100, 'src-1');
+    });
+
+    it('is a no-op when no legacy FK is present', () => {
+      expect(hasLegacyFk(db)).toBe(false);
+      migration.up(db);
+      expect(hasLegacyFk(db)).toBe(false);
+      const rows = db.prepare(`SELECT COUNT(*) c FROM telemetry`).get() as any;
+      expect(rows.c).toBe(1);
+    });
+  });
+});

--- a/src/server/migrations/041_drop_legacy_telemetry_nodes_fk.ts
+++ b/src/server/migrations/041_drop_legacy_telemetry_nodes_fk.ts
@@ -1,0 +1,150 @@
+/**
+ * Migration 041: Drop legacy `telemetry.nodeNum REFERENCES nodes(nodeNum)` FK
+ *
+ * Context:
+ *   Legacy SQLite databases created by pre-baseline Drizzle pushes carry a
+ *   foreign key declaration `telemetry.nodeNum REFERENCES nodes(nodeNum)`.
+ *   Migration 029 rebuilt `nodes` with a composite PRIMARY KEY
+ *   (nodeNum, sourceId), which makes that FK structurally invalid — nodeNum
+ *   alone is no longer unique in the parent, so SQLite raises
+ *
+ *     SqliteError: foreign key mismatch - "telemetry" referencing "nodes"
+ *
+ *   on any DELETE/INSERT/ALTER on `telemetry` while foreign_keys=ON. PRs
+ *   #2740 (029/030) and this migration's sibling commits (032/039) paper
+ *   over individual call sites by toggling foreign_keys=OFF for their DML,
+ *   but every future migration that touches `telemetry` would need the same
+ *   dance. This migration removes the FK permanently by rebuilding the
+ *   `telemetry` table without it, aligned to the baseline (v3.7+) schema.
+ *
+ *   The baseline schema for fresh installs never declared this FK, so the
+ *   rebuild is a no-op on non-legacy databases (idempotency check skips out
+ *   when no FK is present).
+ *
+ * Dialect notes:
+ *   - SQLite: legacy FK exists only here; rebuild.
+ *   - PostgreSQL / MySQL: never had this FK (baseline schema for those
+ *     backends created `telemetry` without any FK). No-op.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+// Columns expected on the rebuilt telemetry table, in stable order. Must match
+// the post-021 SQLite schema (baseline + sourceId from migration 021).
+const TELEMETRY_COLUMNS_SQLITE = `
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  nodeId TEXT NOT NULL,
+  nodeNum INTEGER NOT NULL,
+  telemetryType TEXT NOT NULL,
+  timestamp INTEGER NOT NULL,
+  value REAL NOT NULL,
+  unit TEXT,
+  createdAt INTEGER NOT NULL,
+  packetTimestamp INTEGER,
+  packetId INTEGER,
+  channel INTEGER,
+  precisionBits INTEGER,
+  gpsAccuracy REAL,
+  sourceId TEXT
+`;
+
+const TELEMETRY_COLUMN_LIST = `
+  id, nodeId, nodeNum, telemetryType, timestamp, value, unit, createdAt,
+  packetTimestamp, packetId, channel, precisionBits, gpsAccuracy, sourceId
+`;
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    // Idempotency: if telemetry has no FK, skip. pragma foreign_key_list
+    // returns one row per FK declared on the table.
+    const fkRows = db.prepare(`PRAGMA foreign_key_list(telemetry)`).all() as Array<{
+      id: number;
+      seq: number;
+      table: string;
+      from: string;
+      to: string;
+    }>;
+
+    const legacyFk = fkRows.find(
+      (r) => String(r.table).toLowerCase() === 'nodes' && r.from === 'nodeNum',
+    );
+    if (!legacyFk) {
+      logger.debug('Migration 041 (SQLite): no legacy telemetry→nodes FK present, skipping');
+      return;
+    }
+
+    logger.info('Migration 041 (SQLite): rebuilding telemetry to drop legacy FK to nodes(nodeNum)...');
+
+    // Standard SQLite table-rebuild requires foreign_keys=OFF
+    // (https://www.sqlite.org/lang_altertable.html). legacy_alter_table=ON
+    // prevents SQLite from validating the (now broken) FK during RENAME.
+    const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
+    if (prevForeignKeys) {
+      db.pragma('foreign_keys = OFF');
+    }
+    const prevLegacyAlter = db.pragma('legacy_alter_table', { simple: true }) as number;
+    if (!prevLegacyAlter) {
+      db.pragma('legacy_alter_table = ON');
+    }
+
+    // Snapshot existing indexes so we can recreate them on the rebuilt table.
+    // We skip SQLite's auto-indexes (they come back automatically with the
+    // rebuilt table) and skip anything without SQL text (can't recreate).
+    const existingIndexes = db.prepare(`
+      SELECT name, sql FROM sqlite_master
+      WHERE type = 'index' AND tbl_name = 'telemetry' AND sql IS NOT NULL
+    `).all() as Array<{ name: string; sql: string }>;
+
+    const tx = db.transaction(() => {
+      db.exec(`CREATE TABLE telemetry_new (${TELEMETRY_COLUMNS_SQLITE})`);
+      db.exec(`
+        INSERT INTO telemetry_new (${TELEMETRY_COLUMN_LIST})
+        SELECT ${TELEMETRY_COLUMN_LIST} FROM telemetry
+      `);
+      db.exec(`DROP TABLE telemetry`);
+      db.exec(`ALTER TABLE telemetry_new RENAME TO telemetry`);
+
+      for (const idx of existingIndexes) {
+        if (idx.name.startsWith('sqlite_autoindex_')) continue;
+        try {
+          db.exec(idx.sql);
+        } catch (err) {
+          logger.warn(`Migration 041 (SQLite): failed to recreate index ${idx.name}:`, err);
+        }
+      }
+    });
+
+    try {
+      tx();
+    } finally {
+      if (prevForeignKeys) {
+        db.pragma('foreign_keys = ON');
+      }
+      if (!prevLegacyAlter) {
+        db.pragma('legacy_alter_table = OFF');
+      }
+    }
+
+    logger.info('Migration 041 complete (SQLite)');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 041 down: not implemented (re-adding the broken FK is undesirable)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration041Postgres(_client: any): Promise<void> {
+  // PostgreSQL baseline never declared this FK. No-op.
+  logger.debug('Migration 041 (PostgreSQL): no-op (no legacy telemetry FK on PG)');
+}
+
+// ============ MySQL ============
+
+export async function runMigration041Mysql(_pool: any): Promise<void> {
+  // MySQL baseline never declared this FK. No-op.
+  logger.debug('Migration 041 (MySQL): no-op (no legacy telemetry FK on MySQL)');
+}


### PR DESCRIPTION
## Summary

Legacy v3.x SQLite databases carry a `telemetry.nodeNum REFERENCES nodes(nodeNum)` FK from pre-baseline Drizzle pushes. Migration 029 rebuilds `nodes` with a composite PK (`nodeNum, sourceId`), making that FK structurally invalid. Any DML on `telemetry` with `foreign_keys=ON` then raises:

```
SqliteError: foreign key mismatch - "telemetry" referencing "nodes"
```

On beta7 this crashes the container into a bootloop during upgrade. PR #2740 patched 029/030 but missed the subsequent post-029 migrations that touch `telemetry` — 032 is the first to DELETE from telemetry and is reliably the first to crash.

## Fix

- **032 + 039 (hotfix):** wrap SQLite DELETEs in `foreign_keys=OFF` save/restore, matching the pattern 029/030 already use. This unblocks the bootloop on existing installs.
- **041 (permanent):** new migration that rebuilds the SQLite `telemetry` table without the dangling FK so future migrations don't need the dance. No-op on PG/MySQL (baseline never declared this FK) and on SQLite databases without the legacy FK.

## Reproduction

Exact user-reported error reproduced locally with a 10-line script:
1. Create `nodes` (nodeNum PK) + `telemetry` with FK to `nodes(nodeNum)`.
2. Rebuild `nodes` to composite PK (simulating 029).
3. Run `DELETE FROM telemetry ...` with `foreign_keys=ON`.
4. → `SqliteError: foreign key mismatch - "telemetry" referencing "nodes"`.

After fix: DELETE succeeds; post-041 rebuild: FK is gone entirely.

## Test plan

- [x] New regression test on 032 seeds telemetry with legacy FK + composite-PK nodes, asserts `migration.up()` does not throw and restores `foreign_keys=ON`.
- [x] New regression test on 039 covers the same scenario.
- [x] New 041 test suite asserts: removes FK, preserves rows, recreates indexes, restores pragmas, allows subsequent DELETE, is idempotent, and is a no-op on baseline schema without the FK.
- [x] `src/db/migrations.test.ts` updated for new count (40 → 41) and last migration name.
- [x] Full migrations/db test suite: 453 passed / 0 failed.
- [x] `npx tsc --noEmit` clean.

## Upgrade path for affected users

Users hitting the bootloop on beta7 will recover automatically on next start once this ships — 032 and 039 no longer crash, and 041 permanently removes the broken FK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)