### PR TITLE
fix(traceroute): show relay placeholder hops as "Unknown"

### DIFF
--- a/src/components/TracerouteWidget.tsx
+++ b/src/components/TracerouteWidget.tsx
@@ -137,6 +137,9 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
 
   const getNodeName = useCallback(
     (nodeNum: number): string => {
+      // BROADCAST_ADDR (0xffffffff) is a firmware placeholder for a relay-role
+      // hop that refused to self-identify — render as "Unknown".
+      if (nodeNum === 4294967295) return 'Unknown';
       const nodeId = `!${nodeNum.toString(16).padStart(8, '0')}`;
       const node = nodes.get(nodeId);
       return node?.user?.longName || node?.user?.shortName || nodeId;
@@ -150,13 +153,13 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
     return date.toLocaleString();
   };
 
-  // Filter function to remove invalid/reserved node numbers from route arrays
+  // Filter function to remove invalid/reserved node numbers from route arrays.
+  // BROADCAST_ADDR (0xffffffff) is kept — it's the firmware placeholder for a
+  // relay-role hop that refused to self-identify and is rendered as "Unknown".
   const isValidRouteNode = (nodeNum: number): boolean => {
-    const BROADCAST_ADDR = 4294967295;
     if (nodeNum <= 3) return false;  // Reserved
     if (nodeNum === 255) return false;  // 0xff reserved
     if (nodeNum === 65535) return false;  // 0xffff invalid placeholder
-    if (nodeNum === BROADCAST_ADDR) return false;  // Broadcast
     return true;
   };
 

--- a/src/server/meshtasticManager.traceroute-hops.test.ts
+++ b/src/server/meshtasticManager.traceroute-hops.test.ts
@@ -399,7 +399,10 @@ describe('MeshtasticManager — traceroute intermediate hop handling (issues 261
     });
 
     const packet = makeTraceroutePacket(0xdddddddd, 0x11111111);
-    // Reserved: 0-3, 255, 65535, 4294967295 — must never be upserted as hops
+    // Reserved: 0-3, 255, 65535 — must never be upserted as hops.
+    // BROADCAST (4294967295) is KEPT in the route array (firmware inserts it
+    // as a placeholder for relay-role hops that refuse to self-identify) but
+    // must NOT be stub-upserted into the nodes table.
     const routeDiscovery = {
       route: [0, 1, 2, 3, 255, 65535, 4294967295, 0xaaaa7777],
       routeBack: [],
@@ -414,10 +417,39 @@ describe('MeshtasticManager — traceroute intermediate hop handling (issues 261
     // for this hop carried a `lastHeard` field.
     expect(upsertCallsFor(0xaaaa7777).length).toBeGreaterThanOrEqual(1);
     expect(upsertCallsWithLastHeardFor(0xaaaa7777)).toEqual([]);
-    // Reserved values must never have been upserted via the hop loop.
+    // Reserved values and BROADCAST must never have been upserted via the
+    // hop loop (BROADCAST is rendered as "Unknown" but never stored as a node).
     for (const reserved of [0, 1, 2, 3, 255, 65535, 4294967295]) {
       expect(upsertCallsFor(reserved)).toEqual([]);
     }
+  });
+
+  it('preserves BROADCAST_ADDR hops in the stored route without stub-creating them', async () => {
+    const stale = Math.floor(Date.now() / 1000) - 86_400;
+    mockGetNode.mockImplementation((nodeNum: number) => ({
+      nodeNum, nodeId: `!${nodeNum.toString(16)}`, longName: 'Node', shortName: 'ND', lastHeard: stale,
+    }));
+
+    const packet = makeTraceroutePacket(0xdddddddd, 0x11111111);
+    // Firmware placeholder (0xffffffff) for a relay-role hop — must be kept
+    // in the persisted route so the UI can render it as "Unknown".
+    const routeDiscovery = {
+      route: [0xaaaa1111, 4294967295, 0xaaaa2222],
+      routeBack: [],
+      snrTowards: [40, 30, 20, 10],
+      snrBack: [],
+    };
+
+    await (manager as any).processTracerouteMessage(packet, routeDiscovery);
+
+    // BROADCAST must NOT have been upserted as a node.
+    expect(upsertCallsFor(4294967295)).toEqual([]);
+
+    // The persisted route (first arg to insertTraceroute) must include BROADCAST.
+    expect(mockInsertTraceroute).toHaveBeenCalled();
+    const insertedRoute = mockInsertTraceroute.mock.calls[0][0].route;
+    const parsedRoute = JSON.parse(insertedRoute);
+    expect(parsedRoute).toEqual([0xaaaa1111, 4294967295, 0xaaaa2222]);
   });
 
   it('does not double-upsert the from/to nodes via the hop loop', async () => {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5419,12 +5419,15 @@ class MeshtasticManager implements ISourceManager {
       // - 0-3: Reserved per Meshtastic protocol
       // - 255 (0xff): Reserved for broadcast in some contexts
       // - 65535 (0xffff): Invalid placeholder value reported by users (Issue #1128)
-      // - 4294967295 (0xffffffff): Broadcast address
+      //
+      // NOTE: BROADCAST_ADDR (0xffffffff) is intentionally kept — the firmware
+      // inserts it as a placeholder when a REPEATER or CLIENT_HIDDEN/relay-role
+      // node refuses to add its own nodeNum to the route. Dropping it loses
+      // the knowledge that a hop occurred; we render it as "Unknown" instead.
       const isValidRouteNode = (nodeNum: number): boolean => {
         if (nodeNum <= 3) return false;  // Reserved
         if (nodeNum === 255) return false;  // 0xff reserved
         if (nodeNum === 65535) return false;  // 0xffff invalid placeholder
-        if (nodeNum === BROADCAST_ADDR) return false;  // Broadcast
         return true;
       };
 
@@ -5493,6 +5496,10 @@ class MeshtasticManager implements ISourceManager {
       for (const hopNum of routeBack) intermediateHops.add(hopNum);
       intermediateHops.delete(fromNum);
       intermediateHops.delete(toNum);
+      // BROADCAST_ADDR is a firmware placeholder for a relay-role hop that
+      // refused to self-identify. It is not a real node — do not create a
+      // stub row for it.
+      intermediateHops.delete(BROADCAST_ADDR);
       for (const hopNum of intermediateHops) {
         const hopId = `!${hopNum.toString(16).padStart(8, '0')}`;
         const existing = await databaseService.nodes.getNode(hopNum, this.sourceId ?? undefined);

--- a/src/utils/traceroute.tsx
+++ b/src/utils/traceroute.tsx
@@ -114,13 +114,15 @@ export function formatTracerouteRoute(
     return '(No response received)';
   }
 
-  // Filter function to remove invalid/reserved node numbers from route arrays
+  // Filter function to remove invalid/reserved node numbers from route arrays.
+  // BROADCAST_ADDR (0xffffffff) is intentionally NOT filtered — the firmware
+  // uses it as a placeholder for relay-role hops that refused to self-identify.
+  // It is rendered as "Unknown" below so the user knows a hop occurred.
   const BROADCAST_ADDR = 4294967295;
   const isValidRouteNode = (nodeNum: number): boolean => {
     if (nodeNum <= 3) return false;  // Reserved
     if (nodeNum === 255) return false;  // 0xff reserved
     if (nodeNum === 65535) return false;  // 0xffff invalid placeholder
-    if (nodeNum === BROADCAST_ADDR) return false;  // Broadcast
     return true;
   };
 
@@ -160,7 +162,7 @@ export function formatTracerouteRoute(
       if (renderedIndices.has(idx)) return;
 
       const node = nodes.find(n => n.nodeNum === nodeNum);
-      const nodeName = formatNodeName(nodeNum, nodes);
+      const nodeName = nodeNum === BROADCAST_ADDR ? 'Unknown' : formatNodeName(nodeNum, nodes);
 
       // Get SNR for this hop (SNR array corresponds to hops between nodes)
       const snrValue = snrArray[idx] !== undefined ? snrArray[idx] : null;
@@ -180,7 +182,8 @@ export function formatTracerouteRoute(
 
       // Highlight the segment if requested
       if (isSegmentStart) {
-        const nextNodeName = formatNodeName(fullPath[idx + 1], nodes);
+        const nextNodeNum = fullPath[idx + 1];
+        const nextNodeName = nextNodeNum === BROADCAST_ADDR ? 'Unknown' : formatNodeName(nextNodeNum, nodes);
         const nextSnrValue = snrArray[idx + 1] !== undefined ? snrArray[idx + 1] : null;
 
         pathElements.push(


### PR DESCRIPTION
## Summary

- Meshtastic firmware inserts `0xffffffff` (BROADCAST_ADDR) in the traceroute route array as a placeholder when a REPEATER or relay-role node forwards a packet without adding its own nodeNum.
- Previously MeshMonitor's filter treated this as an invalid/reserved value and dropped the hop entirely, which hid the fact that a relay participated in the path.
- This PR keeps BROADCAST_ADDR in the persisted route and renders it as `Unknown` in the traceroute display. The placeholder is still prevented from creating a stub row in the nodes table.

## Changes

- `src/server/meshtasticManager.ts` — removed BROADCAST from `isValidRouteNode`; added explicit `intermediateHops.delete(BROADCAST_ADDR)` before the stub-creation loop so the placeholder never becomes a fake node row. Existing `nodeNum === BROADCAST_ADDR ? '(unknown)' : ...` branches in the route-text renderer now actually fire.
- `src/utils/traceroute.tsx` — removed BROADCAST from the frontend filter; `formatTracerouteRoute` renders BROADCAST as `Unknown` in both the regular and highlight-segment branches.
- `src/components/TracerouteWidget.tsx` — `getNodeName` returns `Unknown` for BROADCAST; removed BROADCAST from the widget's parseRoute filter.
- `src/server/meshtasticManager.traceroute-hops.test.ts` — updated the "filters reserved values" test to reflect new behavior (BROADCAST retained in route, never stub-upserted) and added a dedicated test asserting BROADCAST is preserved in the persisted `insertTraceroute` call.

Map polyline rendering (`src/hooks/useTraceroutePaths.tsx`) is intentionally untouched — BROADCAST has no position so segment construction already skips it naturally.

## Test plan

- [x] `src/server/meshtasticManager.traceroute-hops.test.ts` — 7/7 pass
- [x] `src/utils/traceroute.test.ts` — passes
- [x] `src/App.traceroute-display.test.tsx` — 37/37 pass (with adjacent modal suites)
- [ ] Verify in a live deployment: trigger a traceroute through a Repeater-role node and confirm `Unknown` appears in the route text instead of the relay silently disappearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)