### PR TITLE
chore(release): bump version to 4.0.0-beta8

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.0.0-beta7",
+  "version": "4.0.0-beta8",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.0.0-beta7",
+  "version": "4.0.0-beta8",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.0.0-beta7
-appVersion: "4.0.0-beta7"
+version: 4.0.0-beta8
+appVersion: "4.0.0-beta8"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta7",
+  "version": "4.0.0-beta8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.0.0-beta7",
+      "version": "4.0.0-beta8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta7",
+  "version": "4.0.0-beta8",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

- Bumps all five version files from `4.0.0-beta7` → `4.0.0-beta8`: `package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`.

## Changes included since beta7

**Fixes**
- #2755 fix(traceroute): preserve relay-role placeholder hops as "Unknown"
- #2754 fix(migrations): tolerate legacy telemetry→nodes FK on 3.x → 4.0 upgrade
- #2752 fix(dashboard): default new source heartbeat to 30s
- #2751 fix(lxc): correct Documentation URLs in systemd units

**Docs**
- #2753 docs: refresh 4.0 docs for multi-source release

**Dependencies**
- #2738 bump uuid 13.0.0 → 14.0.0 (requires node@20+, CI matrix already 20–25)
- #2657 bump maplibre-gl 5.22.0 → 5.23.0
- #2735 bump github/codeql-action 3 → 4
- #2734 bump actions/checkout 4 → 6
- #2733 bump actions/upload-pages-artifact 4 → 5
- #2732 bump lewagon/wait-on-check-action 1.6.1 → 1.7.0

## Test plan

- [ ] CI green (test suites 20.x / 22.x / 24.x / 25.x, Security, ClamAV, CodeQL, Trivy, Snyk, Docker Build, Build Check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)