### PR TITLE
chore(codeql): scope scans to app code; dismiss 25 test/dev false positives

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,12 @@
+name: "MeshMonitor CodeQL config"
+
+queries:
+  - uses: security-extended
+
+paths-ignore:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "tests/**"
+  - "generate-vapid-keys.js"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
-          queries: +security-extended
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4


### PR DESCRIPTION
## Summary

First of 4 planned PRs cleaning up the 91 open CodeQL code-scanning alerts.

- Adds `.github/codeql/codeql-config.yml` with `paths-ignore` for `**/*.test.ts`, `**/*.test.tsx`, `**/*.spec.*`, `tests/**`, and `generate-vapid-keys.js`. Same query suite (`security-extended`) — just loaded via config now so it can carry the path filter.
- Wires the config into `.github/workflows/codeql.yml` (drops the inline `queries:` line).
- Manually dismissed 25 alerts that are pure false positives so the audit trail has a reason rather than relying on the next scan to auto-close them:
  - 21× `js/clear-text-cookie` across `*.test.ts` — test fixtures using `session({ secret: 'test', cookie: { secure: false } })`.
  - 4× `js/clear-text-logging` — the one-shot `generate-vapid-keys.js` CLI tool (prints keys for the user to paste into `.env`) and two test harnesses (`tests/mock-oidc/server.js`, `tests/api-status-ws-token-test.mjs`).

`public/cors-detection.js` is **NOT** excluded — that file ships to browsers and its log-injection finding is real; it'll be addressed in the follow-up PR that cleans up `src/utils/logger.ts` log injection.

## Expected Outcome

After the next CodeQL analysis run:
- Open alert count drops from **91 → ~66**.
- The only `js/clear-text-cookie` alert left should be the single real one in `src/server/auth/sessionConfig.ts` (the runtime-configurable `cookieSecure` flag).
- Remaining findings all represent real code to fix in PRs 2–4.

## Test Plan

- [ ] `CodeQL Analysis` workflow runs green on this PR using the new config
- [ ] Post-merge: verify open alert count drops to ~66 via `gh api repos/Yeraze/meshmonitor/code-scanning/alerts?state=open --jq length`
- [ ] Verify no alerts were dismissed from non-test/non-CLI paths: `gh api "repos/Yeraze/meshmonitor/code-scanning/alerts?state=dismissed" --jq '[.[] | .most_recent_instance.location.path] | unique'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)