### PR TITLE
security: resolve 20 high-severity CodeQL alerts (PR 3)

### DIFF
--- a/src/db/repositories/settings.ts
+++ b/src/db/repositories/settings.ts
@@ -212,9 +212,17 @@ export class SettingsRepository extends BaseRepository {
    */
   async setSourceSettings(sourceId: string, kv: Record<string, string>): Promise<void> {
     const prefix = this.sourcePrefix(sourceId);
-    const prefixed: Record<string, string> = {};
+    const prefixed: Record<string, string> = Object.create(null);
     for (const [k, v] of Object.entries(kv)) {
-      prefixed[`${prefix}${k}`] = v;
+      // Only accept simple setting key names to prevent property-injection
+      // on the in-memory record we build here.
+      if (!/^[A-Za-z0-9_.-]+$/.test(k)) continue;
+      Object.defineProperty(prefixed, `${prefix}${k}`, {
+        value: v,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
     }
     await this.setSettings(prefixed);
   }

--- a/src/server/routes/authRoutes.ts
+++ b/src/server/routes/authRoutes.ts
@@ -491,6 +491,15 @@ router.get('/oidc/login', async (req: Request, res: Response) => {
     const codeVerifier = generateRandomString(128);
     const nonce = generateRandomString(32);
 
+    // Regenerate session before storing OIDC flow state to prevent
+    // session-fixation attacks where an attacker pre-seeds a session id.
+    try {
+      await regenerateSession(req);
+    } catch (err) {
+      logger.error('Session regeneration failed:', err);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+
     // Store in session
     req.session.oidcState = state;
     req.session.oidcCodeVerifier = codeVerifier;

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -737,14 +737,20 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
       }
     }
 
-    // Audit log with before/after values
+    // Audit log with before/after values.
+    // Allowlist check is explicit here so static analyzers can see that
+    // `key` cannot be an attacker-controlled property name like `__proto__`.
+    const validKeySet = new Set<string>(VALID_SETTINGS_KEYS as readonly string[]);
     const changedSettings: Record<string, { before: string | undefined; after: string }> = {};
     Object.keys(filteredSettings).forEach((key) => {
+      if (!validKeySet.has(key)) return;
       if (currentSettings[key] !== filteredSettings[key]) {
-        changedSettings[key] = {
-          before: currentSettings[key],
-          after: filteredSettings[key],
-        };
+        Object.defineProperty(changedSettings, key, {
+          value: { before: currentSettings[key], after: filteredSettings[key] },
+          enumerable: true,
+          writable: true,
+          configurable: true,
+        });
       }
     });
 

--- a/src/server/routes/tileServerTest.ts
+++ b/src/server/routes/tileServerTest.ts
@@ -6,12 +6,8 @@
 
 import express from 'express';
 import net from 'net';
-import dns from 'dns';
-import { promisify } from 'util';
 import { logger } from '../../utils/logger.js';
-import { safeFetch, SsrfBlockedError } from '../utils/ssrfGuard.js';
-
-const dnsLookup = promisify(dns.lookup);
+import { assertSafeUrl, safeFetch, SsrfBlockedError } from '../utils/ssrfGuard.js';
 
 const router = express.Router();
 
@@ -506,13 +502,16 @@ router.post('/autodetect', async (req, res) => {
   // This prevents hanging when the server is completely unreachable
   const testPort = parseInt(port || '80', 10);
 
-  // First verify DNS resolution works
+  // SSRF guard: validate that host resolves to a non-blocked IP (metadata,
+  // loopback, link-local etc.) before we TCP-connect to it below.
   try {
-    await Promise.race([
-      dnsLookup(host),
-      new Promise((_, reject) => setTimeout(() => reject(new Error('DNS timeout')), 2000))
-    ]);
+    await assertSafeUrl(`http://${host}:${testPort}/`);
   } catch (error) {
+    if (error instanceof SsrfBlockedError) {
+      logger.warn(`[TileServerTest] Autodetect host blocked by SSRF guard (${error.reason}): ${host}`);
+      result.errors.push('Target address is not allowed.');
+      return res.json(result);
+    }
     logger.warn(`DNS lookup failed for ${host}: ${error instanceof Error ? error.message : 'unknown'}`);
     result.errors.push(`Cannot resolve hostname "${host}". Check the server address.`);
     return res.json(result);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5387,6 +5387,13 @@ apiRouter.post('/settings/traceroute-nodes', requirePermission('settings', 'writ
       if (typeof filterNameRegex !== 'string') {
         return res.status(400).json({ error: 'Invalid filterNameRegex value. Must be a string.' });
       }
+      // Length cap + catastrophic-backtracking pattern check to prevent ReDoS
+      if (filterNameRegex.length > 200) {
+        return res.status(400).json({ error: 'filterNameRegex too long (max 200 characters).' });
+      }
+      if (/(\.\*){2,}|(\+.*\+)|(\*.*\*)|(\{[0-9]{3,}\})|(\{[0-9]+,\})/.test(filterNameRegex)) {
+        return res.status(400).json({ error: 'filterNameRegex too complex or may cause performance issues.' });
+      }
       // Test that regex is valid
       try {
         new RegExp(filterNameRegex);
@@ -8981,9 +8988,9 @@ const scriptsEndpoint = (_req: any, res: any) => {
 };
 
 if (BASE_URL) {
-  app.get(`${BASE_URL}/api/scripts`, scriptsEndpoint);
+  app.get(`${BASE_URL}/api/scripts`, apiLimiter, scriptsEndpoint);
 }
-app.get('/api/scripts', scriptsEndpoint);
+app.get('/api/scripts', apiLimiter, scriptsEndpoint);
 
 // Script test endpoint - allows testing script execution with sample parameters
 // Supports triggerType: 'auto-responder' (default), 'geofence', or 'timer'
@@ -9048,10 +9055,24 @@ apiRouter.post('/scripts/test', requirePermission('settings', 'read'), async (re
 
     // Auto-responder: Extract parameters from test message using trigger pattern
     if (triggerType === 'auto-responder') {
-      const patterns = normalizeTriggerPatterns(trigger);
+      const allPatterns = normalizeTriggerPatterns(trigger);
+      // Cap the number of candidate patterns to prevent user input from
+      // driving an unbounded match loop.
+      const MAX_PATTERNS = 100;
+      const patterns = allPatterns.slice(0, MAX_PATTERNS);
 
       // Try each pattern until one matches
       for (const patternStr of patterns) {
+        // ReDoS guard: reject overly long patterns and classic catastrophic-
+        // backtracking shapes before compiling. Script-trigger patterns are
+        // admin-authored but CodeQL flags the regex compile below as
+        // user-controlled, so we enforce the same bounds the UI does.
+        if (patternStr.length > 500) {
+          return res.status(400).json({ error: 'Trigger pattern too long (max 500 characters).' });
+        }
+        if (/(\.\*){2,}|(\+.*\+)|(\*.*\*)|(\{[0-9]{3,}\})|(\{[0-9]+,\})/.test(patternStr)) {
+          return res.status(400).json({ error: 'Trigger pattern too complex or may cause performance issues.' });
+        }
         interface ParamSpec {
           name: string;
           pattern?: string;
@@ -9161,7 +9182,17 @@ apiRouter.post('/scripts/test', requirePermission('settings', 'read'), async (re
         if (triggerMatch) {
           extractedParams = {};
           params.forEach((param, index) => {
-            extractedParams[param.name] = triggerMatch[index + 1];
+            // Guard against prototype-pollution / remote-property-injection:
+            // only accept simple identifier-style names, never `__proto__` etc.
+            if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(param.name)) {
+              return;
+            }
+            Object.defineProperty(extractedParams, param.name, {
+              value: triggerMatch[index + 1],
+              enumerable: true,
+              writable: true,
+              configurable: true,
+            });
           });
           matchedPattern = patternStr;
           break;

--- a/src/server/services/firmwareUpdateService.ts
+++ b/src/server/services/firmwareUpdateService.ts
@@ -669,7 +669,15 @@ export class FirmwareUpdateService {
       }
 
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-      const backupPath = path.join(BACKUP_DIR, `config-${nodeId}-${timestamp}.yaml`);
+      // Sanitize nodeId: strip any characters that could escape BACKUP_DIR.
+      const safeNodeId = String(nodeId).replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 64) || 'unknown';
+      const candidatePath = path.join(BACKUP_DIR, `config-${safeNodeId}-${timestamp}.yaml`);
+      // Defense-in-depth: verify resolved path is still under BACKUP_DIR.
+      const resolvedBackupDir = path.resolve(BACKUP_DIR);
+      const backupPath = path.resolve(candidatePath);
+      if (!backupPath.startsWith(resolvedBackupDir + path.sep)) {
+        throw new Error('Refusing to write backup outside of backup directory');
+      }
       fs.writeFileSync(backupPath, result.stdout, 'utf-8');
 
       this.updateStatus({
@@ -1035,13 +1043,21 @@ export class FirmwareUpdateService {
    * Throws if the backup file does not exist or the CLI command fails.
    */
   async restoreBackup(gatewayIp: string, backupPath: string): Promise<void> {
-    if (!fs.existsSync(backupPath)) {
-      throw new Error(`Backup file not found: ${backupPath}`);
+    // Restrict restorable paths to files inside BACKUP_DIR. Without this a
+    // caller could pass an arbitrary path (e.g. /etc/passwd) and use the
+    // existsSync check as a filesystem-probe oracle.
+    const resolvedBackupDir = path.resolve(BACKUP_DIR);
+    const resolvedBackup = path.resolve(backupPath);
+    if (!resolvedBackup.startsWith(resolvedBackupDir + path.sep)) {
+      throw new Error('Backup path is outside the allowed backup directory');
+    }
+    if (!fs.existsSync(resolvedBackup)) {
+      throw new Error(`Backup file not found: ${resolvedBackup}`);
     }
 
     const result = await this.runCliCommand('meshtastic', [
       '--host', gatewayIp,
-      '--configure', backupPath,
+      '--configure', resolvedBackup,
     ]);
 
     if (result.exitCode !== 0) {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -66,13 +66,25 @@ setCatchHandler(async ({ request }) => {
 // Use includes() instead of startsWith() to work with BASE_URL prefixes (e.g., /meshmonitor/api/)
 registerRoute(({ url }) => url.pathname.includes('/api/'), new NetworkOnly());
 
-// Handle map tiles from all supported providers (cache first)
+// Handle map tiles from all supported providers (cache first).
+// Use an exact-host allowlist (with optional subdomain match) instead of
+// substring .includes() so that hostnames like
+// "tile.openstreetmap.org.attacker.example" are NOT matched.
+const MAP_TILE_HOSTS = new Set([
+  'tile.openstreetmap.org',
+  'basemaps.cartocdn.com',
+  'tile.opentopomap.org',
+  'server.arcgisonline.com',
+]);
+function isAllowedTileHost(hostname: string): boolean {
+  if (MAP_TILE_HOSTS.has(hostname)) return true;
+  for (const allowed of MAP_TILE_HOSTS) {
+    if (hostname.endsWith('.' + allowed)) return true;
+  }
+  return false;
+}
 registerRoute(
-  ({ url }) =>
-    url.hostname.includes('tile.openstreetmap.org') ||
-    url.hostname.includes('basemaps.cartocdn.com') ||
-    url.hostname.includes('tile.opentopomap.org') ||
-    url.hostname.includes('server.arcgisonline.com'),
+  ({ url }) => isAllowedTileHost(url.hostname),
   new CacheFirst({
     cacheName: 'map-tiles',
     plugins: [

--- a/src/utils/autoResponderUtils.ts
+++ b/src/utils/autoResponderUtils.ts
@@ -13,17 +13,25 @@
  * splitTriggerPatterns("hello,hi {name}") // ["hello", "hi {name}"]
  * splitTriggerPatterns("weather {city, state}") // ["weather {city, state}"]
  */
+const MAX_TRIGGER_STR_LENGTH = 10000;
+
 export function splitTriggerPatterns(triggerStr: string): string[] {
   if (!triggerStr.trim()) {
     return [];
   }
-  
+
+  // Clamp to a sane upper bound so a user-supplied value can't drive
+  // an unbounded loop here.
+  const bounded = triggerStr.length > MAX_TRIGGER_STR_LENGTH
+    ? triggerStr.slice(0, MAX_TRIGGER_STR_LENGTH)
+    : triggerStr;
+
   const patterns: string[] = [];
   let currentPattern = '';
   let braceDepth = 0;
-  
-  for (let i = 0; i < triggerStr.length; i++) {
-    const char = triggerStr[i];
+
+  for (let i = 0; i < bounded.length; i++) {
+    const char = bounded[i];
     
     if (char === '{') {
       braceDepth++;


### PR DESCRIPTION
## Summary

Third PR in the CodeQL cleanup plan ([plan](/.claude/plans/while-this-runs-github-hazy-lamport.md)). Addresses 20 high-severity alerts across 8 rules.

### Fixes by rule

- **js/request-forgery (1)** — `assertSafeUrl()` guard before raw TCP connect in `tileServerTest` autodetect.
- **js/session-fixation (1)** — regenerate session before storing OIDC PKCE state at `/oidc/login`.
- **js/regex-injection (3)** — length + catastrophic-backtracking guards on `filterNameRegex` (server.ts) and script-trigger patterns before compiling.
- **js/loop-bound-injection (2)** — cap trigger-string length in `splitTriggerPatterns`; cap trigger-pattern array size in script test endpoint.
- **js/missing-rate-limiting (2)** — apply `apiLimiter` to `/api/scripts` routes that were registered outside the rate-limited `apiRouter`.
- **js/remote-property-injection (3)** — allowlist / `Object.defineProperty` guards on script-test `extractedParams`, `changedSettings` audit log, and `setSourceSettings` prefix map.
- **js/path-injection (2)** — sanitize `nodeId` + resolve/prefix-check in `backupConfig`; resolve + prefix-check in `restoreBackup`.
- **js/incomplete-url-substring-sanitization (4)** — service worker map-tile allowlist switched from `hostname.includes()` to exact/suffix match against a `Set`.

### Remaining PR 3 alerts (to be dismissed)

- **js/user-controlled-bypass × 9** (mfaRoutes, meshcoreRoutes, authRoutes) — benign `if (token)` / `else if (backupCode)` branches checking *presence* of user input. Actual verification happens in `mfaService.verifyToken()` / `verifyBackupCode()`. False positives.
- **js/insecure-helmet-configuration × 1** (server.ts:195) — `contentSecurityPolicy: false` is intentional because `dynamicCspMiddleware` applies a full CSP header per-request, including custom tile server hostnames from the DB. Will be dismissed with rationale.
- **js/session-fixation × 1** (meshcoreRoutes.ts:371) — the route is a proxy to log into a *remote* meshtastic node (`/admin/login`), it never writes to `req.session`. False positive.

## Test plan

- [x] `vitest run` on affected route/service/utils test files — all pass (275/275)
- [x] `npm run typecheck` — clean
- [ ] CI green on the new branch
- [ ] Post-merge: rescan drops high-severity alert count by ~20