### PR TITLE
security(codeql): PR 4 — medium severity + singleton findings

### DIFF
--- a/public/cors-detection.js
+++ b/public/cors-detection.js
@@ -2,6 +2,19 @@
 let corsErrorCount = 0;
 let appLoaded = false;
 
+// Strip ASCII C0/C1 control chars + DEL before logging untrusted input to
+// prevent log-injection (CWE-117). Built via RegExp() so this source file
+// never contains literal control characters.
+const CORS_CONTROL_CHAR_RE = new RegExp('[\\x00-\\x1F\\x7F-\\x9F]+', 'g');
+function sanitizeForLog(value) {
+  if (typeof value === 'string') return value.replace(CORS_CONTROL_CHAR_RE, ' ');
+  try {
+    return String(value).replace(CORS_CONTROL_CHAR_RE, ' ');
+  } catch (_e) {
+    return '[unprintable]';
+  }
+}
+
 // Detect PWA standalone mode (iOS and standard)
 const isStandalone = window.matchMedia('(display-mode: standalone)').matches
   || window.navigator.standalone === true;
@@ -47,7 +60,7 @@ window.fetch = function(...args) {
     if (errorMessage.includes('cors') || errorMessage.includes('access-control') ||
         errorMessage.includes('cross-origin') || errorName.includes('cors')) {
       corsErrorCount++;
-      console.log('[CORS Detection] CORS fetch error on', url, 'count:', corsErrorCount);
+      console.log('[CORS Detection] CORS fetch error on', sanitizeForLog(url), 'count:', corsErrorCount);
       if (corsErrorCount >= 2) {
         redirectToCorsError();
       }
@@ -59,7 +72,7 @@ window.fetch = function(...args) {
         const urlStr = typeof url === 'string' ? url : url.toString();
         if (urlStr.includes('/api/') || urlStr.includes('/auth/')) {
           corsErrorCount++;
-          console.log('[CORS Detection] Likely CORS error (failed to fetch API)', url, 'count:', corsErrorCount);
+          console.log('[CORS Detection] Likely CORS error (failed to fetch API)', sanitizeForLog(url), 'count:', corsErrorCount);
           if (corsErrorCount >= 2) {
             redirectToCorsError();
           }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -632,9 +632,14 @@ function App() {
       packetmonitor: () => packetLogEnabled && hasPermission('packetmonitor', 'read'),
     };
 
-    // Check if current tab requires permission
-    const permissionCheck = tabPermissions[activeTab];
-    if (permissionCheck && !permissionCheck()) {
+    // Check if current tab requires permission. `activeTab` is user-controllable
+    // (via URL hash) so only look it up when it is an own-property on the
+    // hard-coded `tabPermissions` object — this prevents walking the
+    // prototype chain into things like `toString`.
+    const permissionCheck = Object.prototype.hasOwnProperty.call(tabPermissions, activeTab)
+      ? (tabPermissions as Record<string, () => boolean>)[activeTab]
+      : undefined;
+    if (typeof permissionCheck === 'function' && !permissionCheck()) {
       // User doesn't have permission - redirect to nodes tab
       logger.info(`[Auth] Redirecting from '${activeTab}' tab - insufficient permissions`);
       setActiveTab('nodes');

--- a/src/server/auth/sessionConfig.ts
+++ b/src/server/auth/sessionConfig.ts
@@ -116,6 +116,11 @@ export function getSessionConfig(): session.SessionOptions {
   logger.info(`   - Cookie sameSite: ${env.cookieSameSite}`);
   logger.info(`   - Environment: ${env.nodeEnv}`);
 
+  // `secure: env.cookieSecure` is intentionally runtime-configurable so
+  // installations running behind HTTP-terminating reverse proxies can still
+  // keep sessions working. Operators deploying over HTTPS must set
+  // COOKIE_SECURE=true — the environment loader emits a loud warning in
+  // production when it is left unset. See src/server/config/environment.ts.
   return {
     store,
     secret: env.sessionSecret,

--- a/src/server/routes/tileServerTest.ts
+++ b/src/server/routes/tileServerTest.ts
@@ -233,7 +233,16 @@ function checkLayerCompatibility(foundLayers: string[]): {
 /**
  * Test a single tile URL
  */
-async function testTileUrl(url: string, timeout: number = 5000): Promise<TileTestResult> {
+// Cap user-supplied timeouts so a large value cannot hold a request / abort
+// controller open long enough to cause resource exhaustion.
+const MAX_TILE_TEST_TIMEOUT_MS = 30_000;
+function clampTimeout(raw: unknown): number {
+  const n = typeof raw === 'number' && Number.isFinite(raw) ? raw : 5000;
+  return Math.max(1000, Math.min(n, MAX_TILE_TEST_TIMEOUT_MS));
+}
+
+async function testTileUrl(url: string, rawTimeout: number = 5000): Promise<TileTestResult> {
+  const timeout = clampTimeout(rawTimeout);
   const startTime = Date.now();
   const result: TileTestResult = {
     success: false,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8860,8 +8860,16 @@ interface ScriptMetadata {
  * Strips HTML tags and limits length
  */
 const sanitizeMetadataValue = (value: string, maxLength: number = 100): string => {
-  // Strip HTML tags
-  const stripped = value.replace(/<[^>]*>/g, '');
+  // Strip HTML tags. A single pass is not enough because a stripped tag can
+  // leave a new tag behind (e.g. `<scr<script>ipt>` → `<script>`), so loop
+  // until the replacement is a fixed point.
+  let stripped = value;
+  // Bound the loop so a pathological input can't keep us iterating forever.
+  for (let i = 0; i < 10; i++) {
+    const next = stripped.replace(/<[^>]*>/g, '');
+    if (next === stripped) break;
+    stripped = next;
+  }
   // Limit length
   return stripped.substring(0, maxLength).trim();
 };
@@ -9526,7 +9534,15 @@ apiRouter.post(
       }
 
       const scriptsDir = getScriptsDirectory();
-      const filePath = path.join(scriptsDir, sanitizedFilename);
+      const resolvedScriptsDir = path.resolve(scriptsDir);
+      const filePath = path.resolve(path.join(scriptsDir, sanitizedFilename));
+
+      // Defense in depth: reject any filename that, after resolution, would
+      // escape the scripts directory (e.g. symlink tricks or odd basename edge
+      // cases). path.basename() already stripped path components above.
+      if (!filePath.startsWith(resolvedScriptsDir + path.sep)) {
+        return res.status(400).json({ error: 'Invalid filename' });
+      }
 
       // Ensure scripts directory exists
       if (!fs.existsSync(scriptsDir)) {

--- a/src/server/services/deviceBackupService.ts
+++ b/src/server/services/deviceBackupService.ts
@@ -93,10 +93,13 @@ class YAMLGenerator {
         return value;
       }
 
-      // Escape strings that need quoting (contains special YAML chars)
-      // Note: base64: values and tzdef are excluded above, so : in those won't trigger quoting
+      // Escape strings that need quoting (contains special YAML chars).
+      // Note: base64: values and tzdef are excluded above, so `:` in those
+      // won't trigger quoting here. We must escape backslashes BEFORE quotes
+      // so a value like `foo\\"` doesn't round-trip as an unterminated escape.
       if (value.includes(':') || value.includes('#') || value.includes('\n') || value.startsWith(' ') || value.endsWith(' ')) {
-        return `"${value.replace(/"/g, '\\"')}"`;
+        const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        return `"${escaped}"`;
       }
       return value;
     }

--- a/src/server/services/firmwareUpdateService.ts
+++ b/src/server/services/firmwareUpdateService.ts
@@ -15,6 +15,7 @@ import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as net from 'net';
 import * as path from 'path';
+import { assertSafeUrl, SsrfBlockedError } from '../utils/ssrfGuard.js';
 import { logger } from '../../utils/logger.js';
 import databaseService from '../../services/database.js';
 import meshtasticManager from '../meshtasticManager.js';
@@ -716,6 +717,19 @@ export class FirmwareUpdateService {
     });
 
     try {
+      // Block SSRF targets (private IPs, link-local, loopback) and non-http(s)
+      // schemes before opening a fetch. Defense in depth — downloadUrl
+      // originates from release metadata but is user-influenced via release
+      // selection.
+      try {
+        await assertSafeUrl(downloadUrl);
+      } catch (ssrfError) {
+        if (ssrfError instanceof SsrfBlockedError) {
+          throw new Error(`Refusing to download firmware from disallowed URL (${ssrfError.reason})`);
+        }
+        throw ssrfError;
+      }
+
       const tempDir = fs.mkdtempSync(path.join(DATA_DIR, 'firmware-tmp-'));
       this.tempDir = tempDir;
 
@@ -725,10 +739,22 @@ export class FirmwareUpdateService {
       }
 
       const arrayBuffer = await response.arrayBuffer();
-      const zipPath = path.join(tempDir, 'firmware.zip');
-      fs.writeFileSync(zipPath, Buffer.from(arrayBuffer));
-
       const downloadSize = arrayBuffer.byteLength;
+
+      // Cap download size at 100 MB — largest legitimate Meshtastic firmware
+      // release is ~20 MB. Prevents an attacker-controlled URL from exhausting
+      // disk space.
+      const MAX_FIRMWARE_BYTES = 100 * 1024 * 1024;
+      if (downloadSize > MAX_FIRMWARE_BYTES) {
+        throw new Error(`Firmware download exceeds ${MAX_FIRMWARE_BYTES} byte limit (got ${downloadSize})`);
+      }
+
+      const zipPath = path.resolve(path.join(tempDir, 'firmware.zip'));
+      const resolvedTempDir = path.resolve(tempDir);
+      if (!zipPath.startsWith(resolvedTempDir + path.sep)) {
+        throw new Error('Refusing to write firmware zip outside of temp directory');
+      }
+      fs.writeFileSync(zipPath, Buffer.from(arrayBuffer));
 
       this.updateStatus({
         state: 'awaiting-confirm',
@@ -1114,7 +1140,16 @@ export class FirmwareUpdateService {
    * device stranded in OTA loader mode.
    */
   private uploadOtaFirmware(host: string, port: number, firmwarePath: string): Promise<void> {
-    const fileBuffer = fs.readFileSync(firmwarePath);
+    // Only allow reading firmware from paths rooted under DATA_DIR. This
+    // closes the file-access-to-http path where an attacker-influenced
+    // `firmwarePath` could exfiltrate arbitrary local files over the OTA
+    // socket.
+    const resolvedDataDir = path.resolve(DATA_DIR);
+    const resolvedFirmwarePath = path.resolve(firmwarePath);
+    if (!resolvedFirmwarePath.startsWith(resolvedDataDir + path.sep)) {
+      return Promise.reject(new Error('Refusing to upload firmware from outside data directory'));
+    }
+    const fileBuffer = fs.readFileSync(resolvedFirmwarePath);
     const size = fileBuffer.length;
     const sha256 = createHash('sha256').update(fileBuffer).digest('hex');
     const header = `OTA ${size} ${sha256}\n`;

--- a/src/server/services/geojsonService.ts
+++ b/src/server/services/geojsonService.ts
@@ -192,8 +192,15 @@ export class GeoJsonService {
       updatedAt: now,
     };
 
-    // Write GeoJSON file
-    fs.writeFileSync(path.join(this.dataDir, filename), content, 'utf-8');
+    // Write GeoJSON file — resolve both paths and enforce prefix match so an
+    // adversarial future `filename` (e.g. from refactoring) can never escape
+    // the data directory.
+    const resolvedDataDir = path.resolve(this.dataDir);
+    const filePath = path.resolve(path.join(this.dataDir, filename));
+    if (!filePath.startsWith(resolvedDataDir + path.sep)) {
+      throw new Error('Refusing to write GeoJSON file outside data directory');
+    }
+    fs.writeFileSync(filePath, content, 'utf-8');
 
     // Update manifest
     manifest.layers.push(layer);

--- a/src/server/services/upgradeService.ts
+++ b/src/server/services/upgradeService.ts
@@ -51,12 +51,20 @@ class UpgradeService {
    * This prevents race conditions and partial writes
    */
   private atomicWriteFile(filePath: string, content: string): void {
-    const tempPath = `${filePath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2)}`;
+    // Defense in depth: all callers pass compile-time constants (UPGRADE_TRIGGER_FILE
+    // or UPGRADE_STATUS_FILE), but enforce prefix check so a future caller with
+    // a tainted filePath can never escape DATA_DIR.
+    const resolvedDataDir = path.resolve(DATA_DIR);
+    const resolvedFilePath = path.resolve(filePath);
+    if (!resolvedFilePath.startsWith(resolvedDataDir + path.sep)) {
+      throw new Error('Refusing to write upgrade file outside data directory');
+    }
+    const tempPath = `${resolvedFilePath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2)}`;
     try {
       // Write to temporary file first
       fs.writeFileSync(tempPath, content, { mode: 0o644 });
       // Atomic rename (replaces target file if it exists)
-      fs.renameSync(tempPath, filePath);
+      fs.renameSync(tempPath, resolvedFilePath);
     } catch (error) {
       // Clean up temp file if rename failed
       try {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -71,7 +71,11 @@ class ApiService {
     if (['POST', 'PUT', 'DELETE', 'PATCH'].includes(method.toUpperCase())) {
       const csrfToken = this.getCsrfToken();
       const tokenStatus = csrfToken ? `Found (${csrfToken.substring(0,8)}...)` : 'NOT FOUND';
-      console.log(`[API] ${method} ${endpoint} - CSRF token:`, tokenStatus);
+      // Pass method/endpoint as separate args rather than interpolating them
+      // into the format string — console.log treats the first arg as a format
+      // string under some runtimes and caller-controlled %s/%d can break
+      // formatting.
+      console.log('[API]', method, endpoint, '- CSRF token:', tokenStatus);
 
       // Also check sessionStorage directly
       const directCheck = sessionStorage.getItem('csrfToken');

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -34,6 +34,21 @@ function shouldLog(level: LogLevel): boolean {
   return LOG_LEVEL_ORDER.indexOf(level) >= LOG_LEVEL_ORDER.indexOf(currentLevel);
 }
 
+// Match ASCII C0 controls (incl. \r and \n), DEL, and C1 controls.
+// Used to defang untrusted strings before they reach console.log so an
+// attacker can't inject new log lines (CWE-117). Built via new RegExp to
+// avoid literal control characters in this source file.
+const CONTROL_CHAR_RE = new RegExp('[\\x00-\\x1F\\x7F-\\x9F]+', 'g');
+
+function sanitizeForLog(arg: unknown): unknown {
+  if (typeof arg !== 'string') return arg;
+  return arg.replace(CONTROL_CHAR_RE, ' ');
+}
+
+function sanitizeArgs(args: unknown[]): unknown[] {
+  return args.map(sanitizeForLog);
+}
+
 export const logger = {
   /**
    * Debug logging - only shown when log level is debug
@@ -41,7 +56,7 @@ export const logger = {
    */
   debug: (...args: any[]) => {
     if (shouldLog('debug')) {
-      console.log('[DEBUG]', ...args);
+      console.log('[DEBUG]', ...sanitizeArgs(args));
     }
   },
 
@@ -51,7 +66,7 @@ export const logger = {
    */
   info: (...args: any[]) => {
     if (shouldLog('info')) {
-      console.log('[INFO]', ...args);
+      console.log('[INFO]', ...sanitizeArgs(args));
     }
   },
 
@@ -61,7 +76,7 @@ export const logger = {
    */
   warn: (...args: any[]) => {
     if (shouldLog('warn')) {
-      console.warn('[WARN]', ...args);
+      console.warn('[WARN]', ...sanitizeArgs(args));
     }
   },
 
@@ -71,7 +86,7 @@ export const logger = {
    */
   error: (...args: any[]) => {
     if (shouldLog('error')) {
-      console.error('[ERROR]', ...args);
+      console.error('[ERROR]', ...sanitizeArgs(args));
     }
   }
 };


### PR DESCRIPTION
## Summary
Final phase of the CodeQL `security-extended` cleanup (plan at `.claude/plans/while-this-runs-github-hazy-lamport.md`). Resolves the remaining medium and singleton findings after PRs 1–3.

- log-injection defanged at the logger & CORS-detection boundary (control-char stripping).
- http-to-file-access writes now `path.resolve` + prefix-check their destination (script import, upgrade trigger, firmware download, GeoJSON layer). Firmware download additionally gets an SSRF guard and a 100 MB size cap.
- file-access-to-http OTA upload restricted to files under `DATA_DIR`.
- incomplete-multi-character-sanitization (metadata HTML strip): loop until fixed point so `<scr<script>ipt>` cannot survive.
- incomplete-sanitization (YAML string quote): escape backslashes before quotes so `\"` cannot round-trip as an unterminated escape.
- resource-exhaustion (tile server test): clamp user timeouts to [1s, 30s].
- tainted-format-string (api.ts): split method/endpoint out of the console.log format string.
- unvalidated-dynamic-method-call (App.tsx tab permissions): own-property + `typeof === 'function'` check before invoking, so a URL-hash-driven `activeTab` cannot reach into the prototype chain.

`clear-text-cookie` (alert #44) is intentionally runtime-configurable via `COOKIE_SECURE` — the env loader warns loudly in production when unset. Alert dismissed as false positive with a pointer to the config code, and a short comment added at `sessionConfig.ts:L119` so a future reader doesn't re-flag it.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 4320 passed, 509 skipped, 21 todo, 0 failures
- [ ] CI green
- [ ] Post-merge: CodeQL rescan shows the targeted rule counts drop to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)