### PR TITLE
fix(db): resolve 4.0-beta8 migration 040 crash on legacy v3.x SQLite DBs

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 41 migrations registered', () => {
-    expect(registry.count()).toBe(41);
+  it('has all 44 migrations registered', () => {
+    expect(registry.count()).toBe(44);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,14 +12,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is drop_legacy_telemetry_nodes_fk', () => {
+  it('last migration is drop_legacy_traceroutes_nodes_fk', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(41);
-    expect(last.name).toContain('drop_legacy_telemetry_nodes_fk');
+    expect(last.number).toBe(44);
+    expect(last.name).toContain('drop_legacy_traceroutes_nodes_fk');
   });
 
-  it('migrations are sequentially numbered from 1 to 35', () => {
+  it('migrations are sequentially numbered from 1 to 44', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,7 +1,7 @@
 /**
  * Migration Registry Barrel File
  *
- * Registers all 40 migrations in sequential order for use by the migration runner.
+ * Registers all 44 migrations in sequential order for use by the migration runner.
  * Migration 001 is the v3.7 baseline (selfIdempotent — handles its own detection).
  * Migrations 002-011 were originally 078-087 and retain their original settingsKeys
  * for upgrade compatibility.
@@ -53,6 +53,9 @@ import { migration as cleanupOrphanNotificationPrefsMigration, runMigration038Po
 import { migration as purgeNullSourceIdTelemetryMigration, runMigration039Postgres, runMigration039Mysql } from '../server/migrations/039_purge_null_sourceid_telemetry.js';
 import { migration as purgeNullSourceIdNeighborInfoMigration, runMigration040Postgres, runMigration040Mysql } from '../server/migrations/040_purge_null_sourceid_neighbor_info.js';
 import { migration as dropLegacyTelemetryFkMigration, runMigration041Postgres, runMigration041Mysql } from '../server/migrations/041_drop_legacy_telemetry_nodes_fk.js';
+import { migration as dropLegacyMessagesFkMigration, runMigration042Postgres, runMigration042Mysql } from '../server/migrations/042_drop_legacy_messages_nodes_fk.js';
+import { migration as dropLegacyNeighborInfoFkMigration, runMigration043Postgres, runMigration043Mysql } from '../server/migrations/043_drop_legacy_neighbor_info_nodes_fk.js';
+import { migration as dropLegacyTraceroutesFkMigration, runMigration044Postgres, runMigration044Mysql } from '../server/migrations/044_drop_legacy_traceroutes_nodes_fk.js';
 
 // ============================================================================
 // Registry
@@ -628,4 +631,41 @@ registry.register({
   sqlite: (db) => dropLegacyTelemetryFkMigration.up(db),
   postgres: (client) => runMigration041Postgres(client),
   mysql: (pool) => runMigration041Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migrations 042-044: Drop remaining legacy child-table FKs to nodes(nodeNum).
+// Same shape as 041: legacy Drizzle-push databases declared FKs on messages,
+// neighbor_info, and traceroutes pointing at nodes(nodeNum), which became
+// structurally invalid once 029 moved nodes to a composite PK. Rebuilding
+// these tables once drops the broken FKs permanently so future DML migrations
+// don't have to toggle foreign_keys=OFF. PG/MySQL baselines never declared
+// these FKs; no-op there.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 42,
+  name: 'drop_legacy_messages_nodes_fk',
+  settingsKey: 'migration_042_drop_legacy_messages_nodes_fk',
+  sqlite: (db) => dropLegacyMessagesFkMigration.up(db),
+  postgres: (client) => runMigration042Postgres(client),
+  mysql: (pool) => runMigration042Mysql(pool),
+});
+
+registry.register({
+  number: 43,
+  name: 'drop_legacy_neighbor_info_nodes_fk',
+  settingsKey: 'migration_043_drop_legacy_neighbor_info_nodes_fk',
+  sqlite: (db) => dropLegacyNeighborInfoFkMigration.up(db),
+  postgres: (client) => runMigration043Postgres(client),
+  mysql: (pool) => runMigration043Mysql(pool),
+});
+
+registry.register({
+  number: 44,
+  name: 'drop_legacy_traceroutes_nodes_fk',
+  settingsKey: 'migration_044_drop_legacy_traceroutes_nodes_fk',
+  sqlite: (db) => dropLegacyTraceroutesFkMigration.up(db),
+  postgres: (client) => runMigration044Postgres(client),
+  mysql: (pool) => runMigration044Mysql(pool),
 });

--- a/src/server/migrations/040_purge_null_sourceid_neighbor_info.test.ts
+++ b/src/server/migrations/040_purge_null_sourceid_neighbor_info.test.ts
@@ -73,4 +73,54 @@ describe('Migration 040 — purge NULL-sourceId neighbor_info', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].sourceId).toBe('source-A');
   });
+
+  it('succeeds on legacy schema: neighbor_info FK to nodes(nodeNum) + composite nodes PK', () => {
+    // Reproduces the 4.0-beta8 upgrade failure:
+    //   - Pre-029: nodes PK was (nodeNum); neighbor_info.nodeNum FK → nodes(nodeNum)
+    //   - Migration 029 rebuilt nodes with composite PK (nodeNum, sourceId)
+    //   - neighbor_info FK is now structurally invalid (nodeNum alone not unique)
+    //   - With foreign_keys=ON, DELETE raises "foreign key mismatch"
+    const legacyDb = new Database(':memory:');
+    try {
+      // Seed with FKs off — the broken FK otherwise blocks even INSERT.
+      legacyDb.pragma('foreign_keys = OFF');
+      legacyDb.exec(`
+        CREATE TABLE nodes (
+          nodeNum INTEGER NOT NULL,
+          sourceId TEXT NOT NULL,
+          PRIMARY KEY (nodeNum, sourceId)
+        );
+        CREATE TABLE neighbor_info (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          nodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+          neighborNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+          snr REAL,
+          lastRxTime INTEGER,
+          timestamp INTEGER NOT NULL,
+          createdAt INTEGER NOT NULL,
+          sourceId TEXT
+        );
+      `);
+      const now = Date.now();
+      legacyDb
+        .prepare(
+          `INSERT INTO neighbor_info (nodeNum, neighborNodeNum, snr, lastRxTime, timestamp, createdAt, sourceId)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(1, 2, 5.5, now, now, now, null);
+
+      // Mirror the production state at migration time: FK enforcement on,
+      // structurally-invalid FK still declared in the schema.
+      legacyDb.pragma('foreign_keys = ON');
+
+      expect(() => migration.up(legacyDb)).not.toThrow();
+
+      expect(
+        (legacyDb.prepare(`SELECT COUNT(*) c FROM neighbor_info`).get() as any).c
+      ).toBe(0);
+      expect(legacyDb.pragma('foreign_keys', { simple: true })).toBe(1);
+    } finally {
+      legacyDb.close();
+    }
+  });
 });

--- a/src/server/migrations/040_purge_null_sourceid_neighbor_info.ts
+++ b/src/server/migrations/040_purge_null_sourceid_neighbor_info.ts
@@ -20,11 +20,28 @@ import { logger } from '../../utils/logger.js';
 
 export const migration = {
   up(db: Database): void {
-    const res = db
-      .prepare(`DELETE FROM neighbor_info WHERE sourceId IS NULL`)
-      .run();
-    if (res.changes > 0) {
-      logger.info(`Migration 040: purged ${res.changes} neighbor_info rows with NULL sourceId`);
+    // Legacy v3.x databases carry `neighbor_info.nodeNum REFERENCES nodes(nodeNum)`
+    // and `neighbor_info.neighborNodeNum REFERENCES nodes(nodeNum)`. Migration 029
+    // rebuilt nodes with composite PK (nodeNum, sourceId), so these FKs are
+    // structurally invalid and DELETE on neighbor_info raises
+    // "foreign key mismatch" with foreign_keys=ON. Disable FK enforcement for
+    // this migration and restore in finally. See 029/030/032/039 for the same
+    // pattern.
+    const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
+    if (prevForeignKeys) {
+      db.pragma('foreign_keys = OFF');
+    }
+    try {
+      const res = db
+        .prepare(`DELETE FROM neighbor_info WHERE sourceId IS NULL`)
+        .run();
+      if (res.changes > 0) {
+        logger.info(`Migration 040: purged ${res.changes} neighbor_info rows with NULL sourceId`);
+      }
+    } finally {
+      if (prevForeignKeys) {
+        db.pragma('foreign_keys = ON');
+      }
     }
   },
 };

--- a/src/server/migrations/042_drop_legacy_messages_nodes_fk.test.ts
+++ b/src/server/migrations/042_drop_legacy_messages_nodes_fk.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Migration 042 — Drop legacy messages→nodes(nodeNum) FKs
+ *
+ * Legacy v3.x SQLite databases carry `messages.fromNodeNum` and
+ * `messages.toNodeNum` FKs REFERENCES nodes(nodeNum). After migration 029
+ * rebuilt nodes with a composite PK, those FKs are structurally invalid.
+ * This migration rebuilds messages without the FKs so future DML doesn't
+ * need to toggle foreign_keys.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './042_drop_legacy_messages_nodes_fk.js';
+
+function createLegacySchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE nodes (
+      nodeNum INTEGER NOT NULL,
+      sourceId TEXT NOT NULL,
+      PRIMARY KEY (nodeNum, sourceId)
+    );
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      fromNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+      toNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+      fromNodeId TEXT NOT NULL,
+      toNodeId TEXT NOT NULL,
+      text TEXT NOT NULL,
+      channel INTEGER NOT NULL DEFAULT 0,
+      portnum INTEGER,
+      requestId INTEGER,
+      timestamp INTEGER NOT NULL,
+      rxTime INTEGER,
+      hopStart INTEGER,
+      hopLimit INTEGER,
+      relayNode INTEGER,
+      replyId INTEGER,
+      emoji INTEGER,
+      viaMqtt INTEGER,
+      viaStoreForward INTEGER,
+      rxSnr REAL,
+      rxRssi REAL,
+      ackFailed INTEGER,
+      routingErrorReceived INTEGER,
+      deliveryState TEXT,
+      wantAck INTEGER,
+      ackFromNode INTEGER,
+      createdAt INTEGER NOT NULL,
+      decrypted_by TEXT,
+      sourceId TEXT
+    );
+    CREATE INDEX idx_messages_from ON messages(fromNodeNum);
+    CREATE INDEX idx_messages_timestamp ON messages(timestamp);
+  `);
+}
+
+function createBaselineSchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE nodes (
+      nodeNum INTEGER NOT NULL,
+      sourceId TEXT NOT NULL,
+      PRIMARY KEY (nodeNum, sourceId)
+    );
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      fromNodeNum INTEGER NOT NULL,
+      toNodeNum INTEGER NOT NULL,
+      fromNodeId TEXT NOT NULL,
+      toNodeId TEXT NOT NULL,
+      text TEXT NOT NULL,
+      channel INTEGER NOT NULL DEFAULT 0,
+      portnum INTEGER,
+      requestId INTEGER,
+      timestamp INTEGER NOT NULL,
+      rxTime INTEGER,
+      hopStart INTEGER,
+      hopLimit INTEGER,
+      relayNode INTEGER,
+      replyId INTEGER,
+      emoji INTEGER,
+      viaMqtt INTEGER,
+      viaStoreForward INTEGER,
+      rxSnr REAL,
+      rxRssi REAL,
+      ackFailed INTEGER,
+      routingErrorReceived INTEGER,
+      deliveryState TEXT,
+      wantAck INTEGER,
+      ackFromNode INTEGER,
+      createdAt INTEGER NOT NULL,
+      decrypted_by TEXT,
+      sourceId TEXT
+    );
+  `);
+}
+
+function hasLegacyFk(db: Database.Database): boolean {
+  const rows = db.prepare(`PRAGMA foreign_key_list(messages)`).all() as Array<{
+    table: string;
+    from: string;
+    to: string;
+  }>;
+  return rows.some((r) => String(r.table).toLowerCase() === 'nodes');
+}
+
+function insertMessage(db: Database.Database, id: string, from: number, to: number, sourceId: string | null) {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO messages (id, fromNodeNum, toNodeNum, fromNodeId, toNodeId, text, channel, timestamp, createdAt, sourceId)
+     VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?)`,
+  ).run(id, from, to, `!${from.toString(16)}`, `!${to.toString(16)}`, 'hi', now, now, sourceId);
+}
+
+describe('Migration 042 — drop legacy messages FK', () => {
+  let db: Database.Database;
+
+  describe('legacy schema with FK present', () => {
+    beforeEach(() => {
+      db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      createLegacySchema(db);
+      db.pragma('foreign_keys = OFF');
+      insertMessage(db, 'msg-1', 100, 200, 'src-1');
+      insertMessage(db, 'msg-2', 300, 400, null);
+      db.pragma('foreign_keys = ON');
+    });
+
+    it('removes the FKs from messages', () => {
+      expect(hasLegacyFk(db)).toBe(true);
+      migration.up(db);
+      expect(hasLegacyFk(db)).toBe(false);
+    });
+
+    it('preserves all messages rows', () => {
+      migration.up(db);
+      const rows = db.prepare(`SELECT id, fromNodeNum, toNodeNum, sourceId FROM messages ORDER BY id`).all() as any[];
+      expect(rows).toHaveLength(2);
+      expect(rows[0].id).toBe('msg-1');
+      expect(rows[0].fromNodeNum).toBe(100);
+      expect(rows[0].sourceId).toBe('src-1');
+      expect(rows[1].sourceId).toBeNull();
+    });
+
+    it('recreates non-auto indexes', () => {
+      migration.up(db);
+      const idxs = db
+        .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='messages' AND name NOT LIKE 'sqlite_autoindex_%'`)
+        .all() as Array<{ name: string }>;
+      const names = idxs.map((r) => r.name).sort();
+      expect(names).toContain('idx_messages_from');
+      expect(names).toContain('idx_messages_timestamp');
+    });
+
+    it('restores foreign_keys=ON after running', () => {
+      migration.up(db);
+      expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+    });
+
+    it('allows DELETE on messages after the rebuild', () => {
+      migration.up(db);
+      expect(() => db.prepare(`DELETE FROM messages WHERE sourceId IS NULL`).run()).not.toThrow();
+      const remaining = db.prepare(`SELECT COUNT(*) c FROM messages`).get() as any;
+      expect(remaining.c).toBe(1);
+    });
+
+    it('is idempotent — second run is a no-op', () => {
+      migration.up(db);
+      expect(() => migration.up(db)).not.toThrow();
+      expect(hasLegacyFk(db)).toBe(false);
+    });
+  });
+
+  describe('baseline schema without FK', () => {
+    beforeEach(() => {
+      db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      createBaselineSchema(db);
+      insertMessage(db, 'msg-1', 100, 200, 'src-1');
+    });
+
+    it('is a no-op when no legacy FK is present', () => {
+      expect(hasLegacyFk(db)).toBe(false);
+      migration.up(db);
+      expect(hasLegacyFk(db)).toBe(false);
+      const rows = db.prepare(`SELECT COUNT(*) c FROM messages`).get() as any;
+      expect(rows.c).toBe(1);
+    });
+  });
+});

--- a/src/server/migrations/042_drop_legacy_messages_nodes_fk.ts
+++ b/src/server/migrations/042_drop_legacy_messages_nodes_fk.ts
@@ -1,0 +1,163 @@
+/**
+ * Migration 042: Drop legacy `messages.fromNodeNum`/`toNodeNum` REFERENCES
+ * `nodes(nodeNum)` FKs.
+ *
+ * Context:
+ *   Legacy SQLite databases created by pre-baseline Drizzle pushes carry
+ *   foreign key declarations on `messages.fromNodeNum` and `messages.toNodeNum`
+ *   pointing at `nodes(nodeNum)`. Migration 029 rebuilt `nodes` with a
+ *   composite PRIMARY KEY (nodeNum, sourceId), which makes those FKs
+ *   structurally invalid — any DML on `messages` with foreign_keys=ON raises:
+ *
+ *     SqliteError: foreign key mismatch - "messages" referencing "nodes"
+ *
+ *   Follows the same approach as 041 (telemetry): rebuild the table once
+ *   without the FKs so future migrations don't need to toggle
+ *   foreign_keys=OFF on every call site.
+ *
+ *   The v3.7 baseline never declared these FKs, so the rebuild is a no-op on
+ *   non-legacy databases (idempotency check skips out when no FK is present).
+ *
+ * Dialect notes:
+ *   - SQLite: legacy FKs exist only here; rebuild.
+ *   - PostgreSQL / MySQL: never had these FKs. No-op.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+// Columns expected on `messages` per current Drizzle schema
+// (src/db/schema/messages.ts). Order mirrors the schema declaration order.
+const MESSAGES_COLUMNS_SQLITE = `
+  id TEXT PRIMARY KEY,
+  fromNodeNum INTEGER NOT NULL,
+  toNodeNum INTEGER NOT NULL,
+  fromNodeId TEXT NOT NULL,
+  toNodeId TEXT NOT NULL,
+  text TEXT NOT NULL,
+  channel INTEGER NOT NULL DEFAULT 0,
+  portnum INTEGER,
+  requestId INTEGER,
+  timestamp INTEGER NOT NULL,
+  rxTime INTEGER,
+  hopStart INTEGER,
+  hopLimit INTEGER,
+  relayNode INTEGER,
+  replyId INTEGER,
+  emoji INTEGER,
+  viaMqtt INTEGER,
+  viaStoreForward INTEGER,
+  rxSnr REAL,
+  rxRssi REAL,
+  ackFailed INTEGER,
+  routingErrorReceived INTEGER,
+  deliveryState TEXT,
+  wantAck INTEGER,
+  ackFromNode INTEGER,
+  createdAt INTEGER NOT NULL,
+  decrypted_by TEXT,
+  sourceId TEXT
+`;
+
+const MESSAGES_EXPECTED_COLUMNS = [
+  'id', 'fromNodeNum', 'toNodeNum', 'fromNodeId', 'toNodeId', 'text', 'channel',
+  'portnum', 'requestId', 'timestamp', 'rxTime', 'hopStart', 'hopLimit',
+  'relayNode', 'replyId', 'emoji', 'viaMqtt', 'viaStoreForward', 'rxSnr',
+  'rxRssi', 'ackFailed', 'routingErrorReceived', 'deliveryState', 'wantAck',
+  'ackFromNode', 'createdAt', 'decrypted_by', 'sourceId',
+];
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    const fkRows = db.prepare(`PRAGMA foreign_key_list(messages)`).all() as Array<{
+      id: number;
+      seq: number;
+      table: string;
+      from: string;
+      to: string;
+    }>;
+
+    const legacyFk = fkRows.find(
+      (r) => String(r.table).toLowerCase() === 'nodes',
+    );
+    if (!legacyFk) {
+      logger.debug('Migration 042 (SQLite): no legacy messages→nodes FK present, skipping');
+      return;
+    }
+
+    logger.info('Migration 042 (SQLite): rebuilding messages to drop legacy FK to nodes(nodeNum)...');
+
+    const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
+    if (prevForeignKeys) {
+      db.pragma('foreign_keys = OFF');
+    }
+    const prevLegacyAlter = db.pragma('legacy_alter_table', { simple: true }) as number;
+    if (!prevLegacyAlter) {
+      db.pragma('legacy_alter_table = ON');
+    }
+
+    // Intersect expected columns with live columns so upgrades from odd
+    // migration histories still work.
+    const liveCols = new Set(
+      (db.prepare(`PRAGMA table_info(messages)`).all() as Array<{ name: string }>).map(
+        (r) => r.name,
+      ),
+    );
+    const copyCols = MESSAGES_EXPECTED_COLUMNS.filter((c) => liveCols.has(c));
+    const copyList = copyCols.join(', ');
+
+    const existingIndexes = db.prepare(`
+      SELECT name, sql FROM sqlite_master
+      WHERE type = 'index' AND tbl_name = 'messages' AND sql IS NOT NULL
+    `).all() as Array<{ name: string; sql: string }>;
+
+    const tx = db.transaction(() => {
+      db.exec(`CREATE TABLE messages_new (${MESSAGES_COLUMNS_SQLITE})`);
+      db.exec(`
+        INSERT INTO messages_new (${copyList})
+        SELECT ${copyList} FROM messages
+      `);
+      db.exec(`DROP TABLE messages`);
+      db.exec(`ALTER TABLE messages_new RENAME TO messages`);
+
+      for (const idx of existingIndexes) {
+        if (idx.name.startsWith('sqlite_autoindex_')) continue;
+        try {
+          db.exec(idx.sql);
+        } catch (err) {
+          logger.warn(`Migration 042 (SQLite): failed to recreate index ${idx.name}:`, err);
+        }
+      }
+    });
+
+    try {
+      tx();
+    } finally {
+      if (prevForeignKeys) {
+        db.pragma('foreign_keys = ON');
+      }
+      if (!prevLegacyAlter) {
+        db.pragma('legacy_alter_table = OFF');
+      }
+    }
+
+    logger.info('Migration 042 complete (SQLite)');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 042 down: not implemented (re-adding the broken FK is undesirable)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration042Postgres(_client: any): Promise<void> {
+  logger.debug('Migration 042 (PostgreSQL): no-op (no legacy messages FK on PG)');
+}
+
+// ============ MySQL ============
+
+export async function runMigration042Mysql(_pool: any): Promise<void> {
+  logger.debug('Migration 042 (MySQL): no-op (no legacy messages FK on MySQL)');
+}

--- a/src/server/migrations/043_drop_legacy_neighbor_info_nodes_fk.test.ts
+++ b/src/server/migrations/043_drop_legacy_neighbor_info_nodes_fk.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Migration 043 — Drop legacy neighbor_info→nodes(nodeNum) FKs
+ *
+ * Legacy v3.x SQLite databases carry `neighbor_info.nodeNum` and
+ * `neighbor_info.neighborNodeNum` FKs REFERENCES nodes(nodeNum). After
+ * migration 029 rebuilt nodes with a composite PK, those FKs are
+ * structurally invalid — this was the root of the 4.0-beta8 migration 040
+ * crash. This migration rebuilds neighbor_info without the FKs.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './043_drop_legacy_neighbor_info_nodes_fk.js';
+
+function createLegacySchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE nodes (
+      nodeNum INTEGER NOT NULL,
+      sourceId TEXT NOT NULL,
+      PRIMARY KEY (nodeNum, sourceId)
+    );
+    CREATE TABLE neighbor_info (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      nodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+      neighborNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+      snr REAL,
+      lastRxTime INTEGER,
+      timestamp INTEGER NOT NULL,
+      createdAt INTEGER NOT NULL,
+      sourceId TEXT
+    );
+    CREATE INDEX idx_neighbor_info_node ON neighbor_info(nodeNum);
+    CREATE INDEX idx_neighbor_info_timestamp ON neighbor_info(timestamp);
+  `);
+}
+
+function createBaselineSchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE nodes (
+      nodeNum INTEGER NOT NULL,
+      sourceId TEXT NOT NULL,
+      PRIMARY KEY (nodeNum, sourceId)
+    );
+    CREATE TABLE neighbor_info (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      nodeNum INTEGER NOT NULL,
+      neighborNodeNum INTEGER NOT NULL,
+      snr REAL,
+      lastRxTime INTEGER,
+      timestamp INTEGER NOT NULL,
+      createdAt INTEGER NOT NULL,
+      sourceId TEXT
+    );
+  `);
+}
+
+function hasLegacyFk(db: Database.Database): boolean {
+  const rows = db.prepare(`PRAGMA foreign_key_list(neighbor_info)`).all() as Array<{
+    table: string;
+    from: string;
+    to: string;
+  }>;
+  return rows.some((r) => String(r.table).toLowerCase() === 'nodes');
+}
+
+function insertNeighbor(db: Database.Database, node: number, neighbor: number, sourceId: string | null) {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO neighbor_info (nodeNum, neighborNodeNum, snr, lastRxTime, timestamp, createdAt, sourceId)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(node, neighbor, 5.5, now, now, now, sourceId);
+}
+
+describe('Migration 043 — drop legacy neighbor_info FK', () => {
+  let db: Database.Database;
+
+  describe('legacy schema with FK present', () => {
+    beforeEach(() => {
+      db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      createLegacySchema(db);
+      db.pragma('foreign_keys = OFF');
+      insertNeighbor(db, 100, 200, 'src-1');
+      insertNeighbor(db, 300, 400, null);
+      db.pragma('foreign_keys = ON');
+    });
+
+    it('removes the FKs from neighbor_info', () => {
+      expect(hasLegacyFk(db)).toBe(true);
+      migration.up(db);
+      expect(hasLegacyFk(db)).toBe(false);
+    });
+
+    it('preserves all neighbor_info rows', () => {
+      migration.up(db);
+      const rows = db.prepare(`SELECT nodeNum, neighborNodeNum, sourceId FROM neighbor_info ORDER BY id`).all() as any[];
+      expect(rows).toHaveLength(2);
+      expect(rows[0].nodeNum).toBe(100);
+      expect(rows[0].sourceId).toBe('src-1');
+      expect(rows[1].nodeNum).toBe(300);
+      expect(rows[1].sourceId).toBeNull();
+    });
+
+    it('recreates non-auto indexes', () => {
+      migration.up(db);
+      const idxs = db
+        .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='neighbor_info' AND name NOT LIKE 'sqlite_autoindex_%'`)
+        .all() as Array<{ name: string }>;
+      const names = idxs.map((r) => r.name).sort();
+      expect(names).toContain('idx_neighbor_info_node');
+      expect(names).toContain('idx_neighbor_info_timestamp');
+    });
+
+    it('restores foreign_keys=ON after running', () => {
+      migration.up(db);
+      expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+    });
+
+    it('allows DELETE on neighbor_info after the rebuild', () => {
+      migration.up(db);
+      expect(() => db.prepare(`DELETE FROM neighbor_info WHERE sourceId IS NULL`).run()).not.toThrow();
+      const remaining = db.prepare(`SELECT COUNT(*) c FROM neighbor_info`).get() as any;
+      expect(remaining.c).toBe(1);
+    });
+
+    it('is idempotent — second run is a no-op', () => {
+      migration.up(db);
+      expect(() => migration.up(db)).not.toThrow();
+      expect(hasLegacyFk(db)).toBe(false);
+    });
+  });
+
+  describe('baseline schema without FK', () => {
+    beforeEach(() => {
+      db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      createBaselineSchema(db);
+      insertNeighbor(db, 100, 200, 'src-1');
+    });
+
+    it('is a no-op when no legacy FK is present', () => {
+      expect(hasLegacyFk(db)).toBe(false);
+      migration.up(db);
+      expect(hasLegacyFk(db)).toBe(false);
+      const rows = db.prepare(`SELECT COUNT(*) c FROM neighbor_info`).get() as any;
+      expect(rows.c).toBe(1);
+    });
+  });
+});

--- a/src/server/migrations/043_drop_legacy_neighbor_info_nodes_fk.ts
+++ b/src/server/migrations/043_drop_legacy_neighbor_info_nodes_fk.ts
@@ -1,0 +1,137 @@
+/**
+ * Migration 043: Drop legacy `neighbor_info.nodeNum`/`neighborNodeNum`
+ * REFERENCES `nodes(nodeNum)` FKs.
+ *
+ * Context:
+ *   Legacy SQLite databases created by pre-baseline Drizzle pushes carry
+ *   foreign key declarations on `neighbor_info.nodeNum` and
+ *   `neighbor_info.neighborNodeNum` pointing at `nodes(nodeNum)`.
+ *   Migration 029 rebuilt `nodes` with a composite PRIMARY KEY
+ *   (nodeNum, sourceId), which makes those FKs structurally invalid — any
+ *   DML on `neighbor_info` with foreign_keys=ON raises:
+ *
+ *     SqliteError: foreign key mismatch - "neighbor_info" referencing "nodes"
+ *
+ *   This was the exact failure surfaced by migration 040 in 4.0-beta8.
+ *   Rebuilds the table once without the FKs so future migrations don't need
+ *   to toggle foreign_keys=OFF on every call site.
+ *
+ *   The v3.7 baseline never declared these FKs, so the rebuild is a no-op on
+ *   non-legacy databases (idempotency check skips out when no FK is present).
+ *
+ * Dialect notes:
+ *   - SQLite: legacy FKs exist only here; rebuild.
+ *   - PostgreSQL / MySQL: never had these FKs. No-op.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const NEIGHBOR_INFO_COLUMNS_SQLITE = `
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  nodeNum INTEGER NOT NULL,
+  neighborNodeNum INTEGER NOT NULL,
+  snr REAL,
+  lastRxTime INTEGER,
+  timestamp INTEGER NOT NULL,
+  createdAt INTEGER NOT NULL,
+  sourceId TEXT
+`;
+
+const NEIGHBOR_INFO_EXPECTED_COLUMNS = [
+  'id', 'nodeNum', 'neighborNodeNum', 'snr', 'lastRxTime', 'timestamp',
+  'createdAt', 'sourceId',
+];
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    const fkRows = db.prepare(`PRAGMA foreign_key_list(neighbor_info)`).all() as Array<{
+      id: number;
+      seq: number;
+      table: string;
+      from: string;
+      to: string;
+    }>;
+
+    const legacyFk = fkRows.find(
+      (r) => String(r.table).toLowerCase() === 'nodes',
+    );
+    if (!legacyFk) {
+      logger.debug('Migration 043 (SQLite): no legacy neighbor_info→nodes FK present, skipping');
+      return;
+    }
+
+    logger.info('Migration 043 (SQLite): rebuilding neighbor_info to drop legacy FK to nodes(nodeNum)...');
+
+    const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
+    if (prevForeignKeys) {
+      db.pragma('foreign_keys = OFF');
+    }
+    const prevLegacyAlter = db.pragma('legacy_alter_table', { simple: true }) as number;
+    if (!prevLegacyAlter) {
+      db.pragma('legacy_alter_table = ON');
+    }
+
+    const liveCols = new Set(
+      (db.prepare(`PRAGMA table_info(neighbor_info)`).all() as Array<{ name: string }>).map(
+        (r) => r.name,
+      ),
+    );
+    const copyCols = NEIGHBOR_INFO_EXPECTED_COLUMNS.filter((c) => liveCols.has(c));
+    const copyList = copyCols.join(', ');
+
+    const existingIndexes = db.prepare(`
+      SELECT name, sql FROM sqlite_master
+      WHERE type = 'index' AND tbl_name = 'neighbor_info' AND sql IS NOT NULL
+    `).all() as Array<{ name: string; sql: string }>;
+
+    const tx = db.transaction(() => {
+      db.exec(`CREATE TABLE neighbor_info_new (${NEIGHBOR_INFO_COLUMNS_SQLITE})`);
+      db.exec(`
+        INSERT INTO neighbor_info_new (${copyList})
+        SELECT ${copyList} FROM neighbor_info
+      `);
+      db.exec(`DROP TABLE neighbor_info`);
+      db.exec(`ALTER TABLE neighbor_info_new RENAME TO neighbor_info`);
+
+      for (const idx of existingIndexes) {
+        if (idx.name.startsWith('sqlite_autoindex_')) continue;
+        try {
+          db.exec(idx.sql);
+        } catch (err) {
+          logger.warn(`Migration 043 (SQLite): failed to recreate index ${idx.name}:`, err);
+        }
+      }
+    });
+
+    try {
+      tx();
+    } finally {
+      if (prevForeignKeys) {
+        db.pragma('foreign_keys = ON');
+      }
+      if (!prevLegacyAlter) {
+        db.pragma('legacy_alter_table = OFF');
+      }
+    }
+
+    logger.info('Migration 043 complete (SQLite)');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 043 down: not implemented (re-adding the broken FK is undesirable)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration043Postgres(_client: any): Promise<void> {
+  logger.debug('Migration 043 (PostgreSQL): no-op (no legacy neighbor_info FK on PG)');
+}
+
+// ============ MySQL ============
+
+export async function runMigration043Mysql(_pool: any): Promise<void> {
+  logger.debug('Migration 043 (MySQL): no-op (no legacy neighbor_info FK on MySQL)');
+}

--- a/src/server/migrations/044_drop_legacy_traceroutes_nodes_fk.test.ts
+++ b/src/server/migrations/044_drop_legacy_traceroutes_nodes_fk.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Migration 044 — Drop legacy traceroutes→nodes(nodeNum) FKs
+ *
+ * Legacy v3.x SQLite databases carry `traceroutes.fromNodeNum` and
+ * `traceroutes.toNodeNum` FKs REFERENCES nodes(nodeNum). After migration 029
+ * rebuilt nodes with a composite PK, those FKs are structurally invalid.
+ * This migration rebuilds traceroutes without the FKs.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './044_drop_legacy_traceroutes_nodes_fk.js';
+
+function createLegacySchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE nodes (
+      nodeNum INTEGER NOT NULL,
+      sourceId TEXT NOT NULL,
+      PRIMARY KEY (nodeNum, sourceId)
+    );
+    CREATE TABLE traceroutes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      fromNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+      toNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+      fromNodeId TEXT NOT NULL,
+      toNodeId TEXT NOT NULL,
+      route TEXT,
+      routeBack TEXT,
+      snrTowards TEXT,
+      snrBack TEXT,
+      routePositions TEXT,
+      channel INTEGER,
+      timestamp INTEGER NOT NULL,
+      createdAt INTEGER NOT NULL,
+      sourceId TEXT
+    );
+    CREATE INDEX idx_traceroutes_from ON traceroutes(fromNodeNum);
+    CREATE INDEX idx_traceroutes_timestamp ON traceroutes(timestamp);
+  `);
+}
+
+function createBaselineSchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE nodes (
+      nodeNum INTEGER NOT NULL,
+      sourceId TEXT NOT NULL,
+      PRIMARY KEY (nodeNum, sourceId)
+    );
+    CREATE TABLE traceroutes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      fromNodeNum INTEGER NOT NULL,
+      toNodeNum INTEGER NOT NULL,
+      fromNodeId TEXT NOT NULL,
+      toNodeId TEXT NOT NULL,
+      route TEXT,
+      routeBack TEXT,
+      snrTowards TEXT,
+      snrBack TEXT,
+      routePositions TEXT,
+      channel INTEGER,
+      timestamp INTEGER NOT NULL,
+      createdAt INTEGER NOT NULL,
+      sourceId TEXT
+    );
+  `);
+}
+
+function hasLegacyFk(db: Database.Database): boolean {
+  const rows = db.prepare(`PRAGMA foreign_key_list(traceroutes)`).all() as Array<{
+    table: string;
+    from: string;
+    to: string;
+  }>;
+  return rows.some((r) => String(r.table).toLowerCase() === 'nodes');
+}
+
+function insertTraceroute(db: Database.Database, from: number, to: number, sourceId: string | null) {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO traceroutes (fromNodeNum, toNodeNum, fromNodeId, toNodeId, timestamp, createdAt, sourceId)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(from, to, `!${from.toString(16)}`, `!${to.toString(16)}`, now, now, sourceId);
+}
+
+describe('Migration 044 — drop legacy traceroutes FK', () => {
+  let db: Database.Database;
+
+  describe('legacy schema with FK present', () => {
+    beforeEach(() => {
+      db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      createLegacySchema(db);
+      db.pragma('foreign_keys = OFF');
+      insertTraceroute(db, 100, 200, 'src-1');
+      insertTraceroute(db, 300, 400, null);
+      db.pragma('foreign_keys = ON');
+    });
+
+    it('removes the FKs from traceroutes', () => {
+      expect(hasLegacyFk(db)).toBe(true);
+      migration.up(db);
+      expect(hasLegacyFk(db)).toBe(false);
+    });
+
+    it('preserves all traceroutes rows', () => {
+      migration.up(db);
+      const rows = db.prepare(`SELECT fromNodeNum, toNodeNum, sourceId FROM traceroutes ORDER BY id`).all() as any[];
+      expect(rows).toHaveLength(2);
+      expect(rows[0].fromNodeNum).toBe(100);
+      expect(rows[0].sourceId).toBe('src-1');
+      expect(rows[1].fromNodeNum).toBe(300);
+      expect(rows[1].sourceId).toBeNull();
+    });
+
+    it('recreates non-auto indexes', () => {
+      migration.up(db);
+      const idxs = db
+        .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='traceroutes' AND name NOT LIKE 'sqlite_autoindex_%'`)
+        .all() as Array<{ name: string }>;
+      const names = idxs.map((r) => r.name).sort();
+      expect(names).toContain('idx_traceroutes_from');
+      expect(names).toContain('idx_traceroutes_timestamp');
+    });
+
+    it('restores foreign_keys=ON after running', () => {
+      migration.up(db);
+      expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+    });
+
+    it('allows DELETE on traceroutes after the rebuild', () => {
+      migration.up(db);
+      expect(() => db.prepare(`DELETE FROM traceroutes WHERE sourceId IS NULL`).run()).not.toThrow();
+      const remaining = db.prepare(`SELECT COUNT(*) c FROM traceroutes`).get() as any;
+      expect(remaining.c).toBe(1);
+    });
+
+    it('is idempotent — second run is a no-op', () => {
+      migration.up(db);
+      expect(() => migration.up(db)).not.toThrow();
+      expect(hasLegacyFk(db)).toBe(false);
+    });
+  });
+
+  describe('baseline schema without FK', () => {
+    beforeEach(() => {
+      db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      createBaselineSchema(db);
+      insertTraceroute(db, 100, 200, 'src-1');
+    });
+
+    it('is a no-op when no legacy FK is present', () => {
+      expect(hasLegacyFk(db)).toBe(false);
+      migration.up(db);
+      expect(hasLegacyFk(db)).toBe(false);
+      const rows = db.prepare(`SELECT COUNT(*) c FROM traceroutes`).get() as any;
+      expect(rows.c).toBe(1);
+    });
+  });
+});

--- a/src/server/migrations/044_drop_legacy_traceroutes_nodes_fk.ts
+++ b/src/server/migrations/044_drop_legacy_traceroutes_nodes_fk.ts
@@ -1,0 +1,143 @@
+/**
+ * Migration 044: Drop legacy `traceroutes.fromNodeNum`/`toNodeNum` REFERENCES
+ * `nodes(nodeNum)` FKs.
+ *
+ * Context:
+ *   Legacy SQLite databases created by pre-baseline Drizzle pushes carry
+ *   foreign key declarations on `traceroutes.fromNodeNum` and
+ *   `traceroutes.toNodeNum` pointing at `nodes(nodeNum)`. Migration 029
+ *   rebuilt `nodes` with a composite PRIMARY KEY (nodeNum, sourceId), which
+ *   makes those FKs structurally invalid — any DML on `traceroutes` with
+ *   foreign_keys=ON raises:
+ *
+ *     SqliteError: foreign key mismatch - "traceroutes" referencing "nodes"
+ *
+ *   Rebuilds the table once without the FKs so future migrations don't need
+ *   to toggle foreign_keys=OFF on every call site.
+ *
+ *   The v3.7 baseline never declared these FKs, so the rebuild is a no-op on
+ *   non-legacy databases (idempotency check skips out when no FK is present).
+ *
+ * Dialect notes:
+ *   - SQLite: legacy FKs exist only here; rebuild.
+ *   - PostgreSQL / MySQL: never had these FKs. No-op.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const TRACEROUTES_COLUMNS_SQLITE = `
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  fromNodeNum INTEGER NOT NULL,
+  toNodeNum INTEGER NOT NULL,
+  fromNodeId TEXT NOT NULL,
+  toNodeId TEXT NOT NULL,
+  route TEXT,
+  routeBack TEXT,
+  snrTowards TEXT,
+  snrBack TEXT,
+  routePositions TEXT,
+  channel INTEGER,
+  timestamp INTEGER NOT NULL,
+  createdAt INTEGER NOT NULL,
+  sourceId TEXT
+`;
+
+const TRACEROUTES_EXPECTED_COLUMNS = [
+  'id', 'fromNodeNum', 'toNodeNum', 'fromNodeId', 'toNodeId', 'route',
+  'routeBack', 'snrTowards', 'snrBack', 'routePositions', 'channel',
+  'timestamp', 'createdAt', 'sourceId',
+];
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    const fkRows = db.prepare(`PRAGMA foreign_key_list(traceroutes)`).all() as Array<{
+      id: number;
+      seq: number;
+      table: string;
+      from: string;
+      to: string;
+    }>;
+
+    const legacyFk = fkRows.find(
+      (r) => String(r.table).toLowerCase() === 'nodes',
+    );
+    if (!legacyFk) {
+      logger.debug('Migration 044 (SQLite): no legacy traceroutes→nodes FK present, skipping');
+      return;
+    }
+
+    logger.info('Migration 044 (SQLite): rebuilding traceroutes to drop legacy FK to nodes(nodeNum)...');
+
+    const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
+    if (prevForeignKeys) {
+      db.pragma('foreign_keys = OFF');
+    }
+    const prevLegacyAlter = db.pragma('legacy_alter_table', { simple: true }) as number;
+    if (!prevLegacyAlter) {
+      db.pragma('legacy_alter_table = ON');
+    }
+
+    const liveCols = new Set(
+      (db.prepare(`PRAGMA table_info(traceroutes)`).all() as Array<{ name: string }>).map(
+        (r) => r.name,
+      ),
+    );
+    const copyCols = TRACEROUTES_EXPECTED_COLUMNS.filter((c) => liveCols.has(c));
+    const copyList = copyCols.join(', ');
+
+    const existingIndexes = db.prepare(`
+      SELECT name, sql FROM sqlite_master
+      WHERE type = 'index' AND tbl_name = 'traceroutes' AND sql IS NOT NULL
+    `).all() as Array<{ name: string; sql: string }>;
+
+    const tx = db.transaction(() => {
+      db.exec(`CREATE TABLE traceroutes_new (${TRACEROUTES_COLUMNS_SQLITE})`);
+      db.exec(`
+        INSERT INTO traceroutes_new (${copyList})
+        SELECT ${copyList} FROM traceroutes
+      `);
+      db.exec(`DROP TABLE traceroutes`);
+      db.exec(`ALTER TABLE traceroutes_new RENAME TO traceroutes`);
+
+      for (const idx of existingIndexes) {
+        if (idx.name.startsWith('sqlite_autoindex_')) continue;
+        try {
+          db.exec(idx.sql);
+        } catch (err) {
+          logger.warn(`Migration 044 (SQLite): failed to recreate index ${idx.name}:`, err);
+        }
+      }
+    });
+
+    try {
+      tx();
+    } finally {
+      if (prevForeignKeys) {
+        db.pragma('foreign_keys = ON');
+      }
+      if (!prevLegacyAlter) {
+        db.pragma('legacy_alter_table = OFF');
+      }
+    }
+
+    logger.info('Migration 044 complete (SQLite)');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 044 down: not implemented (re-adding the broken FK is undesirable)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration044Postgres(_client: any): Promise<void> {
+  logger.debug('Migration 044 (PostgreSQL): no-op (no legacy traceroutes FK on PG)');
+}
+
+// ============ MySQL ============
+
+export async function runMigration044Mysql(_pool: any): Promise<void> {
+  logger.debug('Migration 044 (MySQL): no-op (no legacy traceroutes FK on MySQL)');
+}


### PR DESCRIPTION
## Summary

- **Root cause**: Migration 029 rebuilt `nodes` with composite PK `(nodeNum, sourceId)`, but legacy v3.x Drizzle-push baselines carry FKs on `messages`, `neighbor_info`, `traceroutes`, and `telemetry` that reference `nodes(nodeNum)` alone. With `foreign_keys = ON`, SQLite raises `foreign key mismatch` on any DML touching those tables — including migration 040's purge of NULL-sourceId neighbor rows. This is the 4.0-beta8 upgrade blocker reported via container logs.
- **Immediate fix (migration 040)**: wrap the DELETE in a `foreign_keys = OFF` guard, matching the pattern already used in migration 039.
- **Durable fix (migrations 042/043/044)**: extend 041's telemetry treatment to the remaining three legacy FKs — rebuild `messages`, `neighbor_info`, `traceroutes` without the broken FKs so future DML on these tables never needs to toggle foreign keys again. No more whack-a-mole.

## Notes

- Each new migration is idempotent via `PRAGMA foreign_key_list` check — no-op on baseline schemas that never carried the FK.
- Column copy uses live `PRAGMA table_info` intersection with an expected-columns list, so columns added by subsequent migrations on already-upgraded DBs survive the rebuild.
- Non-auto indexes are recreated inside the same transaction.
- Postgres/MySQL paths are no-ops — those backends never declared these FKs against the composite PK.
- No version bump in this PR per request.

## Test plan

- [x] Added regression test to `040_purge_null_sourceid_neighbor_info.test.ts` reproducing the legacy-FK + composite-PK crash.
- [x] New `042/043/044_*.test.ts` each cover: FK removal, row preservation, index recreation, `foreign_keys=ON` restoration, post-rebuild DELETE, idempotency, and baseline no-op.
- [x] `src/db/migrations.test.ts` updated: count 41 → 44, last migration name `drop_legacy_traceroutes_nodes_fk`.
- [x] Full test suite: 4342/4342 passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)