### PR TITLE
chore: bump version to 4.0.0-beta9

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.0.0-beta8",
+  "version": "4.0.0-beta9",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.0.0-beta8",
+  "version": "4.0.0-beta9",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.0.0-beta8
-appVersion: "4.0.0-beta8"
+version: 4.0.0-beta9
+appVersion: "4.0.0-beta9"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta8",
+  "version": "4.0.0-beta9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.0.0-beta8",
+      "version": "4.0.0-beta9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta8",
+  "version": "4.0.0-beta9",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

- Bumps version to `4.0.0-beta9` across all five version files.
- Ships PR #2761: migration 040 fix + three new migrations (042/043/044) that drop legacy `nodes(nodeNum)` FKs from `messages`, `neighbor_info`, `traceroutes`. Unblocks users hitting the `foreign key mismatch` crash when upgrading legacy v3.x SQLite databases to beta8.

## Files bumped

- `package.json`
- `package-lock.json` (regenerated via `npm install --package-lock-only --legacy-peer-deps`)
- `helm/meshmonitor/Chart.yaml` (both `version` and `appVersion`)
- `desktop/src-tauri/tauri.conf.json`
- `desktop/package.json`

## Test plan

- [x] All five version strings confirmed at 4.0.0-beta9.
- [x] Lock file regenerated — no stray dependency changes.
- [ ] CI green on all required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)