### PR TITLE
perf(desktop): slim macOS bundles by installing prod-only deps

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -202,8 +202,10 @@ jobs:
           cp dist/cors-error.html desktop/resources/dist/
           cp package.json desktop/resources/
           cp package.json desktop/resources/dist/
-          # Copy node_modules (may take a while)
-          cp -r node_modules desktop/resources/dist/
+          cp package-lock.json desktop/resources/dist/
+          # Install production-only dependencies into the bundle (matches Windows step).
+          # Excludes dev deps — shrinks the debug build proportionally to the release build.
+          (cd desktop/resources/dist && npm ci --omit=dev --legacy-peer-deps --no-audit --no-fund)
 
       - name: Download Node.js binary for bundling
         run: |
@@ -308,8 +310,10 @@ jobs:
           cp dist/cors-error.html desktop/resources/dist/
           cp package.json desktop/resources/
           cp package.json desktop/resources/dist/
-          # Copy node_modules (may take a while)
-          cp -r node_modules desktop/resources/dist/
+          cp package-lock.json desktop/resources/dist/
+          # Install production-only dependencies into the bundle (matches Windows step).
+          # Excludes dev deps — shrinks the debug build proportionally to the release build.
+          (cd desktop/resources/dist && npm ci --omit=dev --legacy-peer-deps --no-audit --no-fund)
 
       - name: Download Node.js binary for bundling (x64)
         run: |

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -328,8 +328,10 @@ jobs:
           cp dist/cors-error.html desktop/resources/dist/
           cp package.json desktop/resources/
           cp package.json desktop/resources/dist/
-          # Copy node_modules
-          cp -r node_modules desktop/resources/dist/
+          cp package-lock.json desktop/resources/dist/
+          # Install production-only dependencies into the bundle (matches Windows step).
+          # Excludes dev deps (vitest, esbuild, drizzle-kit, tsx, etc) — shrinks the DMG by hundreds of MB.
+          (cd desktop/resources/dist && npm ci --omit=dev --legacy-peer-deps --no-audit --no-fund)
 
       # Sign all native binaries in node_modules for notarization
       # Native addons with JIT also need the entitlements
@@ -676,8 +678,10 @@ jobs:
           cp dist/cors-error.html desktop/resources/dist/
           cp package.json desktop/resources/
           cp package.json desktop/resources/dist/
-          # Copy node_modules
-          cp -r node_modules desktop/resources/dist/
+          cp package-lock.json desktop/resources/dist/
+          # Install production-only dependencies into the bundle (matches Windows step).
+          # Excludes dev deps (vitest, esbuild, drizzle-kit, tsx, etc) — shrinks the DMG by hundreds of MB.
+          (cd desktop/resources/dist && npm ci --omit=dev --legacy-peer-deps --no-audit --no-fund)
 
       # Sign all native binaries in node_modules for notarization
       # Native addons with JIT also need the entitlements


### PR DESCRIPTION
## Summary

Align the macOS Tauri bundling steps with the Windows step that's already on the prod-only-deps path. The macOS jobs were `cp -r node_modules` — copying the full dev+prod tree (vitest, esbuild, drizzle-kit, tsx, TypeScript sources, sourcemaps, caches) into the Tauri resource bundle. Dev-only deps account for ~200+ MB per DMG.

This mirrors what `build-windows` already does at `desktop-release.yml:100` and `desktop-ci.yml:96`, which is why the Windows `.exe` installer ships at ~47 MB.

## Changes

- `desktop-release.yml` — both `build-macos` (ARM64) and `build-macos-x64` now do `npm ci --omit=dev --legacy-peer-deps --no-audit --no-fund` inside `desktop/resources/dist/` instead of copying the root `node_modules` tree.
- `desktop-ci.yml` — same treatment applied to the PR test bundle steps so debug builds shrink proportionally.

No change to the native binary signing step — the `.node` files from prod deps (e.g., `better-sqlite3`) are still where the signing loop expects them.

## Expected impact

Measured on v4.0.0-beta6 through beta9:

| Artifact | Before | Expected After |
|---|---|---|
| macOS arm64 DMG | ~540 MB | <200 MB |
| macOS x64 DMG   | ~430 MB | <200 MB |
| Windows installer | ~47 MB | unchanged (already correct) |
| Linux amd64 tarball | ~473 MB | unchanged (not part of this fix) |

## Test plan

- [ ] Desktop CI job succeeds on this PR (validates the pruned bundle still builds & launches in debug mode).
- [ ] On merge + next release, confirm DMG sizes drop into the expected range.
- [ ] Smoke-test the shipped DMG: app launches, mesh database opens, server routes respond.

## Notes

- Linux server tarball (`meshmonitor-VERSION-amd64.tar.gz`) is produced by a separate release workflow and is out of scope for this PR. Its size (~473 MB) likely has a similar root cause and can be addressed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)