### PR TITLE
fix(db): drop legacy route_segments FK + add map_prefs id on SQLite

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 44 migrations registered', () => {
-    expect(registry.count()).toBe(44);
+  it('has all 46 migrations registered', () => {
+    expect(registry.count()).toBe(46);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,14 +12,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is drop_legacy_traceroutes_nodes_fk', () => {
+  it('last migration is add_user_map_preferences_id_sqlite', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(44);
-    expect(last.name).toContain('drop_legacy_traceroutes_nodes_fk');
+    expect(last.number).toBe(46);
+    expect(last.name).toContain('add_user_map_preferences_id_sqlite');
   });
 
-  it('migrations are sequentially numbered from 1 to 44', () => {
+  it('migrations are sequentially numbered from 1 to 46', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -56,6 +56,8 @@ import { migration as dropLegacyTelemetryFkMigration, runMigration041Postgres, r
 import { migration as dropLegacyMessagesFkMigration, runMigration042Postgres, runMigration042Mysql } from '../server/migrations/042_drop_legacy_messages_nodes_fk.js';
 import { migration as dropLegacyNeighborInfoFkMigration, runMigration043Postgres, runMigration043Mysql } from '../server/migrations/043_drop_legacy_neighbor_info_nodes_fk.js';
 import { migration as dropLegacyTraceroutesFkMigration, runMigration044Postgres, runMigration044Mysql } from '../server/migrations/044_drop_legacy_traceroutes_nodes_fk.js';
+import { migration as dropLegacyRouteSegmentsFkMigration, runMigration045Postgres, runMigration045Mysql } from '../server/migrations/045_drop_legacy_route_segments_nodes_fk.js';
+import { migration as addUserMapPrefsIdSqliteMigration, runMigration046Postgres, runMigration046Mysql } from '../server/migrations/046_add_user_map_preferences_id_sqlite.js';
 
 // ============================================================================
 // Registry
@@ -668,4 +670,43 @@ registry.register({
   sqlite: (db) => dropLegacyTraceroutesFkMigration.up(db),
   postgres: (client) => runMigration044Postgres(client),
   mysql: (pool) => runMigration044Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 045: Drop legacy route_segments→nodes(nodeNum) FK on SQLite.
+// Same shape as 041-044: legacy Drizzle-push databases declared a FK on
+// route_segments pointing at nodes(nodeNum), which became structurally
+// invalid once 029 moved nodes to a composite PK. Migration 030 had to
+// toggle foreign_keys=OFF to work around this; since then the broken FK
+// has caused every DELETE on route_segments (node purge, auto-delete, and
+// maintenance cleanup) to fail with "foreign key mismatch". This rebuild
+// drops the FK permanently. PG/MySQL baselines never declared it; no-op.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 45,
+  name: 'drop_legacy_route_segments_nodes_fk',
+  settingsKey: 'migration_045_drop_legacy_route_segments_nodes_fk',
+  sqlite: (db) => dropLegacyRouteSegmentsFkMigration.up(db),
+  postgres: (client) => runMigration045Postgres(client),
+  mysql: (pool) => runMigration045Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 046: Add missing id/createdAt/updatedAt to SQLite
+// user_map_preferences. Migration 037 added these columns on PG/MySQL but
+// its SQLite branch is a no-op because it assumes the bootstrap
+// `CREATE TABLE IF NOT EXISTS` block creates `id`. That block never updates
+// pre-existing legacy tables, so Drizzle's `.select()` in getMapPreferences
+// fails with `no such column: "id"`. This rebuilds the table to match the
+// current schema. PG/MySQL already covered by 037; no-op there.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 46,
+  name: 'add_user_map_preferences_id_sqlite',
+  settingsKey: 'migration_046_add_user_map_preferences_id_sqlite',
+  sqlite: (db) => addUserMapPrefsIdSqliteMigration.up(db),
+  postgres: (client) => runMigration046Postgres(client),
+  mysql: (pool) => runMigration046Mysql(pool),
 });

--- a/src/server/migrations/045_drop_legacy_route_segments_nodes_fk.test.ts
+++ b/src/server/migrations/045_drop_legacy_route_segments_nodes_fk.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Migration 045 — Drop legacy route_segments→nodes(nodeNum) FKs
+ *
+ * Legacy v3.x SQLite databases carry `route_segments.fromNodeNum` and
+ * `route_segments.toNodeNum` FKs REFERENCES nodes(nodeNum). After migration
+ * 029 rebuilt nodes with a composite PK, those FKs are structurally invalid.
+ * This migration rebuilds route_segments without the FKs.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './045_drop_legacy_route_segments_nodes_fk.js';
+
+function createLegacySchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE nodes (
+      nodeNum INTEGER NOT NULL,
+      sourceId TEXT NOT NULL,
+      PRIMARY KEY (nodeNum, sourceId)
+    );
+    CREATE TABLE route_segments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      fromNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+      toNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
+      fromNodeId TEXT NOT NULL,
+      toNodeId TEXT NOT NULL,
+      distanceKm REAL NOT NULL,
+      isRecordHolder INTEGER DEFAULT 0,
+      fromLatitude REAL,
+      fromLongitude REAL,
+      toLatitude REAL,
+      toLongitude REAL,
+      timestamp INTEGER NOT NULL,
+      createdAt INTEGER NOT NULL,
+      sourceId TEXT
+    );
+    CREATE INDEX idx_route_segments_from_to ON route_segments(fromNodeNum, toNodeNum);
+    CREATE INDEX idx_route_segments_source_id ON route_segments(sourceId);
+    CREATE INDEX idx_route_segments_distance ON route_segments(distanceKm DESC);
+  `);
+}
+
+function createBaselineSchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE nodes (
+      nodeNum INTEGER NOT NULL,
+      sourceId TEXT NOT NULL,
+      PRIMARY KEY (nodeNum, sourceId)
+    );
+    CREATE TABLE route_segments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      fromNodeNum INTEGER NOT NULL,
+      toNodeNum INTEGER NOT NULL,
+      fromNodeId TEXT NOT NULL,
+      toNodeId TEXT NOT NULL,
+      distanceKm REAL NOT NULL,
+      isRecordHolder INTEGER DEFAULT 0,
+      fromLatitude REAL,
+      fromLongitude REAL,
+      toLatitude REAL,
+      toLongitude REAL,
+      timestamp INTEGER NOT NULL,
+      createdAt INTEGER NOT NULL,
+      sourceId TEXT
+    );
+  `);
+}
+
+function hasLegacyFk(db: Database.Database): boolean {
+  const rows = db.prepare(`PRAGMA foreign_key_list(route_segments)`).all() as Array<{
+    table: string;
+    from: string;
+    to: string;
+  }>;
+  return rows.some((r) => String(r.table).toLowerCase() === 'nodes');
+}
+
+function insertSegment(db: Database.Database, from: number, to: number, sourceId: string | null) {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO route_segments
+      (fromNodeNum, toNodeNum, fromNodeId, toNodeId, distanceKm, isRecordHolder,
+       fromLatitude, fromLongitude, toLatitude, toLongitude, timestamp, createdAt, sourceId)
+     VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    from, to,
+    `!${from.toString(16)}`, `!${to.toString(16)}`,
+    12.5,
+    10.1, 20.2, 10.3, 20.4,
+    now, now, sourceId,
+  );
+}
+
+describe('Migration 045 — drop legacy route_segments FK', () => {
+  let db: Database.Database;
+
+  describe('legacy schema with FK present', () => {
+    beforeEach(() => {
+      db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      createLegacySchema(db);
+      // Insert parent nodes so legacy FK inserts succeed under FK enforcement.
+      db.prepare(`INSERT INTO nodes (nodeNum, sourceId) VALUES (?, ?)`).run(100, 'src-1');
+      db.prepare(`INSERT INTO nodes (nodeNum, sourceId) VALUES (?, ?)`).run(200, 'src-1');
+      db.prepare(`INSERT INTO nodes (nodeNum, sourceId) VALUES (?, ?)`).run(300, 'src-1');
+      db.prepare(`INSERT INTO nodes (nodeNum, sourceId) VALUES (?, ?)`).run(400, 'src-1');
+      // Legacy FK is structurally broken (refs non-unique col), so any INSERT
+      // fails with "foreign key mismatch" when FKs are on. Turn off for seed.
+      db.pragma('foreign_keys = OFF');
+      insertSegment(db, 100, 200, 'src-1');
+      insertSegment(db, 300, 400, null);
+      db.pragma('foreign_keys = ON');
+    });
+
+    it('removes the FKs from route_segments', () => {
+      expect(hasLegacyFk(db)).toBe(true);
+      migration.up(db);
+      expect(hasLegacyFk(db)).toBe(false);
+    });
+
+    it('preserves all route_segments rows', () => {
+      migration.up(db);
+      const rows = db.prepare(
+        `SELECT fromNodeNum, toNodeNum, sourceId, distanceKm FROM route_segments ORDER BY id`
+      ).all() as any[];
+      expect(rows).toHaveLength(2);
+      expect(rows[0].fromNodeNum).toBe(100);
+      expect(rows[0].toNodeNum).toBe(200);
+      expect(rows[0].sourceId).toBe('src-1');
+      expect(rows[0].distanceKm).toBe(12.5);
+      expect(rows[1].fromNodeNum).toBe(300);
+      expect(rows[1].sourceId).toBeNull();
+    });
+
+    it('recreates non-auto indexes', () => {
+      migration.up(db);
+      const idxs = db
+        .prepare(
+          `SELECT name FROM sqlite_master
+           WHERE type='index' AND tbl_name='route_segments'
+             AND name NOT LIKE 'sqlite_autoindex_%'`,
+        )
+        .all() as Array<{ name: string }>;
+      const names = idxs.map((r) => r.name).sort();
+      expect(names).toContain('idx_route_segments_from_to');
+      expect(names).toContain('idx_route_segments_source_id');
+      expect(names).toContain('idx_route_segments_distance');
+    });
+
+    it('restores foreign_keys=ON after running', () => {
+      migration.up(db);
+      expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+    });
+
+    it('allows DELETE on route_segments after the rebuild', () => {
+      migration.up(db);
+      expect(() =>
+        db.prepare(`DELETE FROM route_segments WHERE sourceId IS NULL`).run()
+      ).not.toThrow();
+      const remaining = db.prepare(`SELECT COUNT(*) c FROM route_segments`).get() as any;
+      expect(remaining.c).toBe(1);
+    });
+
+    it('allows DELETE by fromNodeNum/toNodeNum (node purge path)', () => {
+      migration.up(db);
+      expect(() =>
+        db.prepare(
+          `DELETE FROM route_segments WHERE fromNodeNum = ? OR toNodeNum = ?`
+        ).run(100, 100)
+      ).not.toThrow();
+      const remaining = db.prepare(`SELECT COUNT(*) c FROM route_segments`).get() as any;
+      expect(remaining.c).toBe(1);
+    });
+
+    it('is idempotent — second run is a no-op', () => {
+      migration.up(db);
+      expect(() => migration.up(db)).not.toThrow();
+      expect(hasLegacyFk(db)).toBe(false);
+    });
+  });
+
+  describe('baseline schema without FK', () => {
+    beforeEach(() => {
+      db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      createBaselineSchema(db);
+      insertSegment(db, 100, 200, 'src-1');
+    });
+
+    it('is a no-op when no legacy FK is present', () => {
+      expect(hasLegacyFk(db)).toBe(false);
+      migration.up(db);
+      expect(hasLegacyFk(db)).toBe(false);
+      const rows = db.prepare(`SELECT COUNT(*) c FROM route_segments`).get() as any;
+      expect(rows.c).toBe(1);
+    });
+  });
+});

--- a/src/server/migrations/045_drop_legacy_route_segments_nodes_fk.ts
+++ b/src/server/migrations/045_drop_legacy_route_segments_nodes_fk.ts
@@ -1,0 +1,149 @@
+/**
+ * Migration 045: Drop legacy `route_segments.fromNodeNum`/`toNodeNum`
+ * REFERENCES `nodes(nodeNum)` FKs.
+ *
+ * Context:
+ *   Legacy SQLite databases created by pre-baseline Drizzle pushes carry
+ *   foreign key declarations on `route_segments.fromNodeNum` and
+ *   `route_segments.toNodeNum` pointing at `nodes(nodeNum)`. Migration 029
+ *   rebuilt `nodes` with a composite PRIMARY KEY (nodeNum, sourceId), which
+ *   makes those FKs structurally invalid — any DML on `route_segments` with
+ *   foreign_keys=ON raises:
+ *
+ *     SqliteError: foreign key mismatch - "route_segments" referencing "nodes"
+ *
+ *   This reliably breaks node deletion, auto-delete-by-distance, purge-all,
+ *   and the database-maintenance pass that prunes old route_segments rows.
+ *   Migration 030 worked around the same issue by toggling foreign_keys=OFF
+ *   during its rebuild, but left the underlying broken FK in place.
+ *
+ *   This migration rebuilds the table once without the FKs — the same
+ *   shape used by 041-044 for telemetry/messages/neighbor_info/traceroutes.
+ *
+ *   The v3.7 baseline never declared these FKs, so the rebuild is a no-op
+ *   on non-legacy databases (idempotency check skips out when no FK is
+ *   present).
+ *
+ * Dialect notes:
+ *   - SQLite: legacy FKs exist only here; rebuild.
+ *   - PostgreSQL / MySQL: never had these FKs. No-op.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const ROUTE_SEGMENTS_COLUMNS_SQLITE = `
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  fromNodeNum INTEGER NOT NULL,
+  toNodeNum INTEGER NOT NULL,
+  fromNodeId TEXT NOT NULL,
+  toNodeId TEXT NOT NULL,
+  distanceKm REAL NOT NULL,
+  isRecordHolder INTEGER DEFAULT 0,
+  fromLatitude REAL,
+  fromLongitude REAL,
+  toLatitude REAL,
+  toLongitude REAL,
+  timestamp INTEGER NOT NULL,
+  createdAt INTEGER NOT NULL,
+  sourceId TEXT
+`;
+
+const ROUTE_SEGMENTS_EXPECTED_COLUMNS = [
+  'id', 'fromNodeNum', 'toNodeNum', 'fromNodeId', 'toNodeId', 'distanceKm',
+  'isRecordHolder', 'fromLatitude', 'fromLongitude', 'toLatitude',
+  'toLongitude', 'timestamp', 'createdAt', 'sourceId',
+];
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    const fkRows = db.prepare(`PRAGMA foreign_key_list(route_segments)`).all() as Array<{
+      id: number;
+      seq: number;
+      table: string;
+      from: string;
+      to: string;
+    }>;
+
+    const legacyFk = fkRows.find(
+      (r) => String(r.table).toLowerCase() === 'nodes',
+    );
+    if (!legacyFk) {
+      logger.debug('Migration 045 (SQLite): no legacy route_segments→nodes FK present, skipping');
+      return;
+    }
+
+    logger.info('Migration 045 (SQLite): rebuilding route_segments to drop legacy FK to nodes(nodeNum)...');
+
+    const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
+    if (prevForeignKeys) {
+      db.pragma('foreign_keys = OFF');
+    }
+    const prevLegacyAlter = db.pragma('legacy_alter_table', { simple: true }) as number;
+    if (!prevLegacyAlter) {
+      db.pragma('legacy_alter_table = ON');
+    }
+
+    const liveCols = new Set(
+      (db.prepare(`PRAGMA table_info(route_segments)`).all() as Array<{ name: string }>).map(
+        (r) => r.name,
+      ),
+    );
+    const copyCols = ROUTE_SEGMENTS_EXPECTED_COLUMNS.filter((c) => liveCols.has(c));
+    const copyList = copyCols.join(', ');
+
+    const existingIndexes = db.prepare(`
+      SELECT name, sql FROM sqlite_master
+      WHERE type = 'index' AND tbl_name = 'route_segments' AND sql IS NOT NULL
+    `).all() as Array<{ name: string; sql: string }>;
+
+    const tx = db.transaction(() => {
+      db.exec(`CREATE TABLE route_segments_new (${ROUTE_SEGMENTS_COLUMNS_SQLITE})`);
+      db.exec(`
+        INSERT INTO route_segments_new (${copyList})
+        SELECT ${copyList} FROM route_segments
+      `);
+      db.exec(`DROP TABLE route_segments`);
+      db.exec(`ALTER TABLE route_segments_new RENAME TO route_segments`);
+
+      for (const idx of existingIndexes) {
+        if (idx.name.startsWith('sqlite_autoindex_')) continue;
+        try {
+          db.exec(idx.sql);
+        } catch (err) {
+          logger.warn(`Migration 045 (SQLite): failed to recreate index ${idx.name}:`, err);
+        }
+      }
+    });
+
+    try {
+      tx();
+    } finally {
+      if (prevForeignKeys) {
+        db.pragma('foreign_keys = ON');
+      }
+      if (!prevLegacyAlter) {
+        db.pragma('legacy_alter_table = OFF');
+      }
+    }
+
+    logger.info('Migration 045 complete (SQLite)');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 045 down: not implemented (re-adding the broken FK is undesirable)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration045Postgres(_client: any): Promise<void> {
+  logger.debug('Migration 045 (PostgreSQL): no-op (no legacy route_segments FK on PG)');
+}
+
+// ============ MySQL ============
+
+export async function runMigration045Mysql(_pool: any): Promise<void> {
+  logger.debug('Migration 045 (MySQL): no-op (no legacy route_segments FK on MySQL)');
+}

--- a/src/server/migrations/046_add_user_map_preferences_id_sqlite.test.ts
+++ b/src/server/migrations/046_add_user_map_preferences_id_sqlite.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Migration 046 — Add missing `id` / `createdAt` / `updatedAt` columns to
+ * SQLite user_map_preferences on legacy databases.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './046_add_user_map_preferences_id_sqlite.js';
+
+function createUsers(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT NOT NULL UNIQUE
+    );
+  `);
+  db.prepare(`INSERT INTO users (id, username) VALUES (?, ?)`).run(1, 'admin');
+  db.prepare(`INSERT INTO users (id, username) VALUES (?, ?)`).run(2, 'user2');
+}
+
+function createLegacyMapPrefs(db: Database.Database) {
+  // Legacy SQLite table: no id column, uses user_id directly (post migration 007),
+  // carries the snake_case feature columns migration 007 added.
+  db.exec(`
+    CREATE TABLE user_map_preferences (
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      centerLat REAL,
+      centerLng REAL,
+      zoom REAL,
+      selectedLayer TEXT,
+      map_tileset TEXT,
+      show_paths INTEGER DEFAULT 0,
+      show_neighbor_info INTEGER DEFAULT 0,
+      show_route INTEGER DEFAULT 1,
+      show_motion INTEGER DEFAULT 1,
+      show_mqtt_nodes INTEGER DEFAULT 1,
+      show_meshcore_nodes INTEGER DEFAULT 1,
+      show_animations INTEGER DEFAULT 0,
+      show_accuracy_regions INTEGER DEFAULT 0,
+      show_estimated_positions INTEGER DEFAULT 0,
+      position_history_hours INTEGER,
+      createdAt INTEGER,
+      updatedAt INTEGER
+    );
+    CREATE INDEX idx_user_map_prefs_user ON user_map_preferences(user_id);
+  `);
+}
+
+function createModernMapPrefs(db: Database.Database) {
+  // Modern table already has id column — migration should be a no-op.
+  db.exec(`
+    CREATE TABLE user_map_preferences (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      centerLat REAL,
+      centerLng REAL,
+      zoom REAL,
+      selectedLayer TEXT,
+      map_tileset TEXT,
+      show_paths INTEGER DEFAULT 0,
+      show_neighbor_info INTEGER DEFAULT 0,
+      show_route INTEGER DEFAULT 1,
+      show_motion INTEGER DEFAULT 1,
+      show_mqtt_nodes INTEGER DEFAULT 1,
+      show_meshcore_nodes INTEGER DEFAULT 1,
+      show_animations INTEGER DEFAULT 0,
+      show_accuracy_regions INTEGER DEFAULT 0,
+      show_estimated_positions INTEGER DEFAULT 0,
+      position_history_hours INTEGER,
+      createdAt INTEGER,
+      updatedAt INTEGER
+    );
+  `);
+}
+
+function hasIdColumn(db: Database.Database): boolean {
+  const cols = db.prepare(`PRAGMA table_info(user_map_preferences)`).all() as Array<{ name: string }>;
+  return cols.some((c) => c.name === 'id');
+}
+
+describe('Migration 046 — add user_map_preferences id on SQLite', () => {
+  let db: Database.Database;
+
+  describe('legacy schema without id', () => {
+    beforeEach(() => {
+      db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      createUsers(db);
+      createLegacyMapPrefs(db);
+      db.prepare(`
+        INSERT INTO user_map_preferences
+          (user_id, centerLat, centerLng, zoom, selectedLayer, map_tileset,
+           show_paths, show_neighbor_info, show_route, show_motion,
+           show_mqtt_nodes, show_meshcore_nodes, show_animations,
+           show_accuracy_regions, show_estimated_positions,
+           position_history_hours, createdAt, updatedAt)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        1, 40.0, -100.0, 6, 'osm', 'custom',
+        1, 0, 1, 1,
+        1, 0, 0,
+        1, 1,
+        24, 1000, 2000,
+      );
+      db.prepare(`
+        INSERT INTO user_map_preferences
+          (user_id, centerLat, centerLng, zoom, selectedLayer, map_tileset,
+           show_paths, show_neighbor_info, show_route, show_motion,
+           show_mqtt_nodes, show_meshcore_nodes, show_animations,
+           show_accuracy_regions, show_estimated_positions,
+           position_history_hours, createdAt, updatedAt)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        2, 50.0, -110.0, 8, 'satellite', null,
+        0, 1, 0, 0,
+        0, 1, 1,
+        0, 0,
+        null, 1001, 2001,
+      );
+    });
+
+    it('adds the id column', () => {
+      expect(hasIdColumn(db)).toBe(false);
+      migration.up(db);
+      expect(hasIdColumn(db)).toBe(true);
+    });
+
+    it('preserves all user preference rows', () => {
+      migration.up(db);
+      const rows = db.prepare(
+        `SELECT user_id, centerLat, centerLng, zoom, selectedLayer, map_tileset,
+                show_paths, show_neighbor_info, show_route, show_motion,
+                show_mqtt_nodes, show_meshcore_nodes, show_animations,
+                show_accuracy_regions, show_estimated_positions,
+                position_history_hours, createdAt, updatedAt
+         FROM user_map_preferences ORDER BY user_id`,
+      ).all() as any[];
+      expect(rows).toHaveLength(2);
+      expect(rows[0].user_id).toBe(1);
+      expect(rows[0].selectedLayer).toBe('osm');
+      expect(rows[0].map_tileset).toBe('custom');
+      expect(rows[0].show_paths).toBe(1);
+      expect(rows[0].position_history_hours).toBe(24);
+      expect(rows[0].createdAt).toBe(1000);
+      expect(rows[1].user_id).toBe(2);
+      expect(rows[1].show_neighbor_info).toBe(1);
+      expect(rows[1].position_history_hours).toBeNull();
+    });
+
+    it('assigns unique sequential id values', () => {
+      migration.up(db);
+      const ids = db.prepare(`SELECT id FROM user_map_preferences ORDER BY user_id`).all() as Array<{ id: number }>;
+      expect(ids).toHaveLength(2);
+      expect(ids[0].id).toBeTypeOf('number');
+      expect(ids[0].id).toBeGreaterThan(0);
+      expect(ids[1].id).not.toBe(ids[0].id);
+    });
+
+    it('allows SELECT id (the regression case from production logs)', () => {
+      migration.up(db);
+      expect(() =>
+        db.prepare(`SELECT id, user_id, createdAt, updatedAt FROM user_map_preferences WHERE user_id = ?`).all(1)
+      ).not.toThrow();
+    });
+
+    it('restores foreign_keys=ON after running', () => {
+      migration.up(db);
+      expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+    });
+
+    it('is idempotent — second run is a no-op', () => {
+      migration.up(db);
+      expect(() => migration.up(db)).not.toThrow();
+      expect(hasIdColumn(db)).toBe(true);
+    });
+  });
+
+  describe('modern schema already has id', () => {
+    beforeEach(() => {
+      db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      createUsers(db);
+      createModernMapPrefs(db);
+      db.prepare(
+        `INSERT INTO user_map_preferences (user_id, createdAt, updatedAt) VALUES (?, ?, ?)`,
+      ).run(1, 1000, 2000);
+    });
+
+    it('is a no-op when id already exists', () => {
+      const before = db.prepare(`SELECT id, user_id FROM user_map_preferences`).all() as any[];
+      migration.up(db);
+      const after = db.prepare(`SELECT id, user_id FROM user_map_preferences`).all() as any[];
+      expect(after).toEqual(before);
+    });
+  });
+
+  describe('table does not exist', () => {
+    beforeEach(() => {
+      db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      createUsers(db);
+    });
+
+    it('is a no-op when the table does not exist', () => {
+      expect(() => migration.up(db)).not.toThrow();
+    });
+  });
+});

--- a/src/server/migrations/046_add_user_map_preferences_id_sqlite.ts
+++ b/src/server/migrations/046_add_user_map_preferences_id_sqlite.ts
@@ -1,0 +1,158 @@
+/**
+ * Migration 046: Add missing `id` / `createdAt` / `updatedAt` columns to
+ * `user_map_preferences` on SQLite.
+ *
+ * Context:
+ *   Migration 037 ensured `id`, `createdAt`, and `updatedAt` exist on
+ *   PostgreSQL/MySQL `user_map_preferences`, but its SQLite counterpart is
+ *   a no-op — it assumes the bootstrap `CREATE TABLE IF NOT EXISTS` block
+ *   in src/services/database.ts already creates the table with those
+ *   columns. That is only true for fresh installs. Legacy v3.x SQLite
+ *   databases created the table before the bootstrap declared `id`, so
+ *   `CREATE TABLE IF NOT EXISTS` is a no-op and the column never materialises.
+ *
+ *   Drizzle's getMapPreferences does `.select()` (SELECT *), which references
+ *   every schema column including `id`, `createdAt`, and `updatedAt`. On
+ *   those legacy SQLite tables this raises:
+ *
+ *     SqliteError: no such column: "id" - should this be a string literal in single-quotes?
+ *
+ *   SQLite can't add a PRIMARY KEY via ALTER TABLE, so we rebuild the
+ *   table. All snake_case feature columns (`show_*`, `map_tileset`, etc.)
+ *   are guaranteed to exist here because migration 007 already added them.
+ *   Legacy camelCase variants (showAccuracyRegions, showEstimatedPositions,
+ *   showMeshCoreNodes, sortBy, sortDirection, userId) are not part of the
+ *   current Drizzle schema and are intentionally dropped during the rebuild.
+ *
+ * Dialect notes:
+ *   - SQLite: rebuild table to add missing `id`, `createdAt`, `updatedAt`.
+ *   - PostgreSQL / MySQL: no-op (migration 037 already handled them).
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const TABLE_COLUMNS_SQLITE = `
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  centerLat REAL,
+  centerLng REAL,
+  zoom REAL,
+  selectedLayer TEXT,
+  map_tileset TEXT,
+  show_paths INTEGER DEFAULT 0,
+  show_neighbor_info INTEGER DEFAULT 0,
+  show_route INTEGER DEFAULT 1,
+  show_motion INTEGER DEFAULT 1,
+  show_mqtt_nodes INTEGER DEFAULT 1,
+  show_meshcore_nodes INTEGER DEFAULT 1,
+  show_animations INTEGER DEFAULT 0,
+  show_accuracy_regions INTEGER DEFAULT 0,
+  show_estimated_positions INTEGER DEFAULT 0,
+  position_history_hours INTEGER,
+  createdAt INTEGER,
+  updatedAt INTEGER
+`;
+
+const COPY_COLUMNS = [
+  'user_id',
+  'centerLat', 'centerLng', 'zoom', 'selectedLayer',
+  'map_tileset',
+  'show_paths', 'show_neighbor_info', 'show_route', 'show_motion',
+  'show_mqtt_nodes', 'show_meshcore_nodes', 'show_animations',
+  'show_accuracy_regions', 'show_estimated_positions',
+  'position_history_hours',
+  'createdAt', 'updatedAt',
+];
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    const tableExists = db.prepare(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='user_map_preferences'`,
+    ).get() as { name: string } | undefined;
+    if (!tableExists) {
+      logger.debug('Migration 046 (SQLite): user_map_preferences table does not exist, skipping');
+      return;
+    }
+
+    const cols = db.prepare(`PRAGMA table_info(user_map_preferences)`).all() as Array<{ name: string }>;
+    const liveCols = new Set(cols.map((c) => c.name));
+    if (liveCols.has('id')) {
+      logger.debug('Migration 046 (SQLite): user_map_preferences.id already exists, skipping');
+      return;
+    }
+
+    logger.info('Migration 046 (SQLite): rebuilding user_map_preferences to add id/createdAt/updatedAt...');
+
+    // Must disable FK enforcement during the rebuild so the child-table
+    // REFERENCES users(id) doesn't trip parent-key checks mid-swap, and so
+    // any preexisting broken FKs elsewhere don't block the DDL.
+    const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
+    if (prevForeignKeys) {
+      db.pragma('foreign_keys = OFF');
+    }
+    const prevLegacyAlter = db.pragma('legacy_alter_table', { simple: true }) as number;
+    if (!prevLegacyAlter) {
+      db.pragma('legacy_alter_table = ON');
+    }
+
+    const copyCols = COPY_COLUMNS.filter((c) => liveCols.has(c));
+    const copyList = copyCols.join(', ');
+
+    const existingIndexes = db.prepare(`
+      SELECT name, sql FROM sqlite_master
+      WHERE type='index' AND tbl_name='user_map_preferences' AND sql IS NOT NULL
+    `).all() as Array<{ name: string; sql: string }>;
+
+    const tx = db.transaction(() => {
+      db.exec(`CREATE TABLE user_map_preferences_new (${TABLE_COLUMNS_SQLITE})`);
+      if (copyList.length > 0) {
+        db.exec(`
+          INSERT INTO user_map_preferences_new (${copyList})
+          SELECT ${copyList} FROM user_map_preferences
+        `);
+      }
+      db.exec(`DROP TABLE user_map_preferences`);
+      db.exec(`ALTER TABLE user_map_preferences_new RENAME TO user_map_preferences`);
+
+      for (const idx of existingIndexes) {
+        if (idx.name.startsWith('sqlite_autoindex_')) continue;
+        try {
+          db.exec(idx.sql);
+        } catch (err) {
+          logger.warn(`Migration 046 (SQLite): failed to recreate index ${idx.name}:`, err);
+        }
+      }
+    });
+
+    try {
+      tx();
+    } finally {
+      if (prevForeignKeys) {
+        db.pragma('foreign_keys = ON');
+      }
+      if (!prevLegacyAlter) {
+        db.pragma('legacy_alter_table = OFF');
+      }
+    }
+
+    logger.info('Migration 046 complete (SQLite)');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 046 down: not implemented (column drop is destructive)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration046Postgres(_client: any): Promise<void> {
+  logger.debug('Migration 046 (PostgreSQL): no-op (migration 037 already ensured id/createdAt/updatedAt)');
+}
+
+// ============ MySQL ============
+
+export async function runMigration046Mysql(_pool: any): Promise<void> {
+  logger.debug('Migration 046 (MySQL): no-op (migration 037 already ensured id/createdAt/updatedAt)');
+}


### PR DESCRIPTION
## Summary

Two unrelated migrations fixing SQLite errors observed in production logs on legacy databases upgraded from v3.x.

### Issue 1 — `route_segments` FK broken (migration 045)

Legacy SQLite DBs still have `route_segments.fromNodeNum/toNodeNum REFERENCES nodes(nodeNum)`. Migration 029 moved `nodes` to a composite PK `(nodeNum, sourceId)`, so the FK is structurally invalid. Every DML on `route_segments` raises:

```
SqliteError: foreign key mismatch - "route_segments" referencing "nodes"
```

Observed failures in the field:
- `Error deleting node <num>@<sourceId>`
- `Auto-delete-by-distance: failed to delete node <num>`
- `Error purging all nodes`
- `Error purging node database`
- `Database maintenance failed` (in `cleanupOldRouteSegmentsAsync`)

Migrations 041–044 dropped the same legacy FK on telemetry / messages / neighbor_info / traceroutes but skipped route_segments. Migration 030 worked around it by toggling `foreign_keys=OFF` during its rebuild but left the broken FK in place. **Migration 045 rebuilds route_segments without the FK, matching the 041–044 pattern.**

### Issue 2 — `user_map_preferences.id` missing on SQLite (migration 046)

Migration 037 added `id` / `createdAt` / `updatedAt` on PostgreSQL / MySQL but its SQLite branch is a no-op — it assumes bootstrap's `CREATE TABLE IF NOT EXISTS` creates them, which never updates pre-existing legacy tables. Drizzle's `.select()` in `getMapPreferences` then references `id`:

```
[MiscRepository] Failed to get map preferences:
  SqliteError: no such column: "id"
```

**Migration 046 rebuilds the SQLite table with id/createdAt/updatedAt, preserving all existing rows.** PG/MySQL remain covered by 037 — no-op.

## Behavior

Both migrations:
- Match the 041–044 rebuild shape (CREATE new → INSERT SELECT → DROP → RENAME).
- Idempotent — skip when legacy FK is absent / `id` column is present / table is missing.
- Preserve rows and recreate non-auto indexes.
- Toggle `foreign_keys` and `legacy_alter_table` safely and restore afterwards.
- PG/MySQL: no-op (044 / 037 already covered those backends).

## Files

- `src/server/migrations/045_drop_legacy_route_segments_nodes_fk.ts` + test (8 cases)
- `src/server/migrations/046_add_user_map_preferences_id_sqlite.ts` + test (9 cases)
- `src/db/migrations.ts` — registers 045, 046
- `src/db/migrations.test.ts` — count 44 → 46, last-migration + sequence assertions bumped

## Test plan

- [x] `vitest run src/server/migrations/045_drop_legacy_route_segments_nodes_fk.test.ts src/server/migrations/046_add_user_map_preferences_id_sqlite.test.ts src/db/migrations.test.ts` → 25/25 passing
- [x] Full migration suite (`src/server/migrations` + `src/db/migrations.test.ts` + `src/db/repositories/traceroutes.test.ts` + `src/db/repositories/schemaIntegrity.test.ts`) → 109 passing, 24 skipped, 0 failing
- [x] Dev container built on commit 35e9512a, deployed on SQLite profile against an existing legacy DB; post-migration schema clean, no `foreign key mismatch` or `no such column: "id"` in logs
- [x] Manual verification: user confirmed node delete / auto-delete / map preferences all work after migrations run

🤖 Generated with [Claude Code](https://claude.com/claude-code)