### PR TITLE
fix(db): add selectedLayer column to legacy PG/MySQL user_map_preferences

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 46 migrations registered', () => {
-    expect(registry.count()).toBe(46);
+  it('has all 47 migrations registered', () => {
+    expect(registry.count()).toBe(47);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,14 +12,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_user_map_preferences_id_sqlite', () => {
+  it('last migration is add_selected_layer_to_user_map_preferences', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(46);
-    expect(last.name).toContain('add_user_map_preferences_id_sqlite');
+    expect(last.number).toBe(47);
+    expect(last.name).toContain('add_selected_layer_to_user_map_preferences');
   });
 
-  it('migrations are sequentially numbered from 1 to 46', () => {
+  it('migrations are sequentially numbered from 1 to 47', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -58,6 +58,7 @@ import { migration as dropLegacyNeighborInfoFkMigration, runMigration043Postgres
 import { migration as dropLegacyTraceroutesFkMigration, runMigration044Postgres, runMigration044Mysql } from '../server/migrations/044_drop_legacy_traceroutes_nodes_fk.js';
 import { migration as dropLegacyRouteSegmentsFkMigration, runMigration045Postgres, runMigration045Mysql } from '../server/migrations/045_drop_legacy_route_segments_nodes_fk.js';
 import { migration as addUserMapPrefsIdSqliteMigration, runMigration046Postgres, runMigration046Mysql } from '../server/migrations/046_add_user_map_preferences_id_sqlite.js';
+import { migration as addSelectedLayerMigration, runMigration047Postgres, runMigration047Mysql } from '../server/migrations/047_add_selected_layer_to_user_map_preferences.js';
 
 // ============================================================================
 // Registry
@@ -709,4 +710,23 @@ registry.register({
   sqlite: (db) => addUserMapPrefsIdSqliteMigration.up(db),
   postgres: (client) => runMigration046Postgres(client),
   mysql: (pool) => runMigration046Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 047: Add `selectedLayer` column to user_map_preferences on
+// PostgreSQL/MySQL. Pre-baseline (v3.6) deployments created the table with
+// `selectedNodeNum` instead; `CREATE TABLE IF NOT EXISTS` in baseline 001 is
+// a no-op on legacy tables, and migration 007 missed this column. Drizzle's
+// getMapPreferences selects every schema column and fails with
+// `column "selectedLayer" does not exist`. SQLite unaffected (bootstrap +
+// migration 046 ensure the column).
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 47,
+  name: 'add_selected_layer_to_user_map_preferences',
+  settingsKey: 'migration_047_add_selected_layer_to_user_map_preferences',
+  sqlite: (db) => addSelectedLayerMigration.up(db),
+  postgres: (client) => runMigration047Postgres(client),
+  mysql: (pool) => runMigration047Mysql(pool),
 });

--- a/src/server/migrations/047_add_selected_layer_to_user_map_preferences.ts
+++ b/src/server/migrations/047_add_selected_layer_to_user_map_preferences.ts
@@ -1,0 +1,61 @@
+/**
+ * Migration 047: Add missing `selectedLayer` column to user_map_preferences on
+ * PostgreSQL/MySQL.
+ *
+ * Pre-baseline (v3.6 and earlier) PG/MySQL deployments created
+ * `user_map_preferences` with a `selectedNodeNum` column and NO `selectedLayer`.
+ * The v3.7 baseline replaced `selectedNodeNum` with `selectedLayer`, but
+ * `CREATE TABLE IF NOT EXISTS` is a no-op on the pre-existing legacy table.
+ * Migration 007 backfilled other missing columns (map_tileset, show_*) but
+ * never added `selectedLayer`.
+ *
+ * Current Drizzle `getMapPreferences` selects every schema column, so PG
+ * fails on legacy tables with `column "selectedLayer" does not exist`. This
+ * migration idempotently adds the column. The stale `selectedNodeNum` column
+ * is left in place (nullable, harmless).
+ *
+ * SQLite is unaffected: bootstrap + migration 046 ensure the column exists.
+ */
+import type { Database } from 'better-sqlite3';
+
+export const migration = {
+  up(_db: Database): void {
+    // intentionally empty — SQLite handled by bootstrap + migration 046
+  },
+};
+
+export async function runMigration047Postgres(client: any): Promise<void> {
+  const tableExists = await client.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = 'user_map_preferences' LIMIT 1`
+  );
+  if (tableExists.rows.length === 0) {
+    return;
+  }
+
+  const col = await client.query(
+    `SELECT 1 FROM information_schema.columns
+     WHERE table_name = 'user_map_preferences' AND column_name = 'selectedLayer' LIMIT 1`
+  );
+  if (col.rows.length === 0) {
+    await client.query(`ALTER TABLE user_map_preferences ADD COLUMN "selectedLayer" TEXT`);
+  }
+}
+
+export async function runMigration047Mysql(pool: any): Promise<void> {
+  const [tables] = await pool.query(
+    `SELECT TABLE_NAME FROM information_schema.TABLES
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_map_preferences'`
+  );
+  if ((tables as any[]).length === 0) {
+    return;
+  }
+
+  const [rows] = await pool.query(
+    `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_map_preferences'
+       AND COLUMN_NAME = 'selectedLayer'`
+  );
+  if ((rows as any[]).length === 0) {
+    await pool.query(`ALTER TABLE user_map_preferences ADD COLUMN selectedLayer VARCHAR(64)`);
+  }
+}


### PR DESCRIPTION
## Summary

- **Bug**: Upgrading a v3.12 Postgres (or MySQL) deployment to v4.0 leaves `user_map_preferences` missing the `selectedLayer` column, breaking every map-preferences read with `DrizzleQueryError: column "selectedLayer" does not exist`.
- **Root cause**: Pre-baseline (v3.6) PG/MySQL created `user_map_preferences` with a `selectedNodeNum` column. The v3.7 baseline (migration 001) only creates the table via `CREATE TABLE IF NOT EXISTS`, which is a no-op on the pre-existing legacy table. Migration 007 backfilled `map_tileset` / `show_*` columns but never added `selectedLayer`, and migration 037 only covered `id` / `createdAt` / `updatedAt`.
- **Fix**: Add idempotent migration 047 that adds `"selectedLayer" TEXT` on PG and `selectedLayer VARCHAR(64)` on MySQL when the column is missing. SQLite is unaffected (bootstrap + migration 046 already ensure it). The stale `selectedNodeNum` column is left in place (nullable, harmless).

## Reproduction

```
[ERROR] [MiscRepository] Failed to get map preferences: DrizzleQueryError:
Failed query: select "id", "userId", "centerLat", "centerLng", "zoom",
"selectedLayer", "map_tileset", ... from "user_map_preferences" ...
cause: error: column "selectedLayer" does not exist
```

Reported by user upgrading production Postgres from 3.12 → 4.0.0-beta10.

## Test plan

- [x] Unit: `src/db/migrations.test.ts` updated to count 47 and expect new last-migration name — passes.
- [x] Build: `npm run build:server` passes.
- [x] Dev deploy (postgres profile) boots clean, migration 047 runs, no Drizzle errors.
- [x] Legacy repro: dropped `"selectedLayer"` column from PG + cleared settings row → restarted container → migration 047 re-added the column successfully.
- [ ] CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)