### PR TITLE
fix(automation): scope time sync / favorite / heap settings per-source

### DIFF
--- a/src/server/meshtasticManager.autoHeapManagement.test.ts
+++ b/src/server/meshtasticManager.autoHeapManagement.test.ts
@@ -22,6 +22,8 @@ vi.mock('../services/database.js', () => ({
     settings: {
       getSetting: mockGetSetting,
       setSetting: mockSetSetting,
+      getSettingForSource: vi.fn((_sourceId: string | null | undefined, key: string) => mockGetSetting(key)),
+      setSourceSetting: vi.fn((_sourceId: string, key: string, value: string) => mockSetSetting(key, value)),
       getAllSettings: vi.fn().mockResolvedValue({}),
       setSettings: vi.fn().mockResolvedValue(undefined),
     },

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1397,21 +1397,28 @@ class MeshtasticManager implements ISourceManager {
       this.timeSyncInterval = null;
     }
 
+    // Per-source reads: when saved via /api/settings/time-sync-nodes?sourceId=,
+    // these live at source:<id>:autoTimeSync* and fall back to global keys.
+    const enabledStr = await databaseService.settings.getSettingForSource(this.sourceId, 'autoTimeSyncEnabled');
+    const isEnabled = enabledStr === 'true';
+
     // Load settings from database if not already set
     if (this.timeSyncIntervalMinutes === 0) {
-      if (await databaseService.isAutoTimeSyncEnabledAsync()) {
-        this.timeSyncIntervalMinutes = await databaseService.getAutoTimeSyncIntervalMinutesAsync();
+      if (isEnabled) {
+        const intervalStr = await databaseService.settings.getSettingForSource(this.sourceId, 'autoTimeSyncIntervalMinutes');
+        const parsed = intervalStr ? parseInt(intervalStr, 10) : NaN;
+        this.timeSyncIntervalMinutes = isNaN(parsed) ? 15 : parsed;
       }
     }
 
     // If interval is 0 or time sync is disabled, scheduler is disabled
-    if (this.timeSyncIntervalMinutes === 0 || !await databaseService.isAutoTimeSyncEnabledAsync()) {
-      logger.info('🕐 Time sync scheduler is disabled');
+    if (this.timeSyncIntervalMinutes === 0 || !isEnabled) {
+      logger.info(`🕐 Time sync scheduler is disabled for source ${this.sourceId}`);
       return;
     }
 
     const intervalMs = this.timeSyncIntervalMinutes * 60 * 1000;
-    logger.info(`🕐 Starting time sync scheduler with ${this.timeSyncIntervalMinutes} minute interval`);
+    logger.info(`🕐 Starting time sync scheduler for source ${this.sourceId} with ${this.timeSyncIntervalMinutes} minute interval`);
 
     this.timeSyncInterval = setInterval(async () => {
       if (this.isConnected && this.localNodeInfo) {
@@ -9417,7 +9424,7 @@ class MeshtasticManager implements ISourceManager {
 
   private async checkAutoFavorite(nodeNum: number, nodeId: string): Promise<void> {
     try {
-      const autoFavoriteEnabled = await databaseService.settings.getSetting('autoFavoriteEnabled');
+      const autoFavoriteEnabled = await databaseService.settings.getSettingForSource(this.sourceId, 'autoFavoriteEnabled');
       if (autoFavoriteEnabled !== 'true') {
         return;
       }
@@ -9450,7 +9457,7 @@ class MeshtasticManager implements ISourceManager {
       if (targetNode.favoriteLocked) return;
 
       // Check if already in auto-favorite list (backward compat belt-and-suspenders)
-      const autoFavoriteNodesJson = await databaseService.settings.getSetting('autoFavoriteNodes') || '[]';
+      const autoFavoriteNodesJson = await databaseService.settings.getSettingForSource(this.sourceId, 'autoFavoriteNodes') || '[]';
       const autoFavoriteNodes: number[] = JSON.parse(autoFavoriteNodesJson);
       if (autoFavoriteNodes.includes(nodeNum)) {
         return; // Already auto-managed
@@ -9474,9 +9481,9 @@ class MeshtasticManager implements ISourceManager {
           logger.warn(`⚠️ Auto-favorited node ${nodeId} in DB but device sync failed:`, error);
         }
 
-        // Add to auto-favorite tracking list
+        // Add to auto-favorite tracking list (per-source)
         autoFavoriteNodes.push(nodeNum);
-        await databaseService.settings.setSetting('autoFavoriteNodes', JSON.stringify(autoFavoriteNodes));
+        await databaseService.settings.setSourceSetting(this.sourceId, 'autoFavoriteNodes', JSON.stringify(autoFavoriteNodes));
       } finally {
         this.autoFavoritingNodes.delete(nodeNum);
       }
@@ -9489,8 +9496,8 @@ class MeshtasticManager implements ISourceManager {
     if (this.autoFavoriteSweepRunning) return;
     this.autoFavoriteSweepRunning = true;
     try {
-      const autoFavoriteEnabled = await databaseService.settings.getSetting('autoFavoriteEnabled');
-      const autoFavoriteNodesJson = await databaseService.settings.getSetting('autoFavoriteNodes') || '[]';
+      const autoFavoriteEnabled = await databaseService.settings.getSettingForSource(this.sourceId, 'autoFavoriteEnabled');
+      const autoFavoriteNodesJson = await databaseService.settings.getSettingForSource(this.sourceId, 'autoFavoriteNodes') || '[]';
       const autoFavoriteNodes: number[] = JSON.parse(autoFavoriteNodesJson);
 
       if (autoFavoriteNodes.length === 0) {
@@ -9515,13 +9522,13 @@ class MeshtasticManager implements ISourceManager {
             logger.warn(`⚠️ Failed to unfavorite node ${nodeNum} during cleanup:`, error);
           }
         }
-        await databaseService.settings.setSetting('autoFavoriteNodes', '[]');
+        await databaseService.settings.setSourceSetting(this.sourceId, 'autoFavoriteNodes', '[]');
         return;
       }
 
       if (!this.supportsFavorites()) return;
 
-      const staleHours = parseInt(await databaseService.settings.getSetting('autoFavoriteStaleHours') || '72');
+      const staleHours = parseInt(await databaseService.settings.getSettingForSource(this.sourceId, 'autoFavoriteStaleHours') || '72');
       const staleThreshold = Date.now() / 1000 - (staleHours * 3600);
 
       // Get local node role for re-evaluation
@@ -9587,11 +9594,11 @@ class MeshtasticManager implements ISourceManager {
         }
       }
 
-      // Update the tracking list
+      // Update the tracking list (per-source)
       if (nodesToRemove.length > 0) {
         const removeSet = new Set(nodesToRemove);
         const remaining = autoFavoriteNodes.filter(n => !removeSet.has(n));
-        await databaseService.settings.setSetting('autoFavoriteNodes', JSON.stringify(remaining));
+        await databaseService.settings.setSourceSetting(this.sourceId, 'autoFavoriteNodes', JSON.stringify(remaining));
         logger.info(`🧹 Auto-favorite sweep: removed ${nodesToRemove.length}, remaining ${remaining.length}`);
       }
     } catch (error) {
@@ -9606,10 +9613,10 @@ class MeshtasticManager implements ISourceManager {
    * Called after each LocalStats telemetry packet from the local node.
    */
   private async checkAutoHeapManagement(heapFreeBytes: number | undefined, fromNum: number): Promise<void> {
-    const enabled = await databaseService.settings.getSetting('autoHeapManagementEnabled');
+    const enabled = await databaseService.settings.getSettingForSource(this.sourceId, 'autoHeapManagementEnabled');
     if (enabled !== 'true') return;
 
-    const thresholdStr = await databaseService.settings.getSetting('autoHeapManagementThresholdBytes');
+    const thresholdStr = await databaseService.settings.getSettingForSource(this.sourceId, 'autoHeapManagementThresholdBytes');
     const threshold = parseInt(thresholdStr || '20000');
 
     if (heapFreeBytes === undefined || heapFreeBytes >= threshold) return;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5602,8 +5602,10 @@ apiRouter.post('/settings/time-sync-nodes', requirePermission('settings', 'write
     if (intervalMinutes !== undefined) {
       timeSyncManager.setTimeSyncInterval(enabled ? Number(intervalMinutes) : 0);
     } else if (enabled !== undefined) {
-      // If only enabled/disabled changed, use existing interval
-      const currentInterval = await databaseService.getAutoTimeSyncIntervalMinutesAsync();
+      // If only enabled/disabled changed, use existing interval (per-source with global fallback)
+      const intervalStr = await databaseService.settings.getSettingForSource(timeSyncSourceId ?? null, 'autoTimeSyncIntervalMinutes');
+      const parsed = intervalStr ? parseInt(intervalStr, 10) : NaN;
+      const currentInterval = isNaN(parsed) ? 15 : parsed;
       timeSyncManager.setTimeSyncInterval(enabled ? currentInterval : 0);
     }
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -8389,12 +8389,24 @@ class DatabaseService {
     intervalMinutes: number;
   }> {
     const nodeNums = await this.misc.getAutoTimeSyncNodes(sourceId);
+    const read = (key: string) => this.settings.getSettingForSource(sourceId ?? null, key);
+    const [enabledStr, filterEnabledStr, expirationStr, intervalStr] = await Promise.all([
+      read('autoTimeSyncEnabled'),
+      read('autoTimeSyncNodeFilterEnabled'),
+      read('autoTimeSyncExpirationHours'),
+      read('autoTimeSyncIntervalMinutes'),
+    ]);
+    const parseIntDefault = (s: string | null, def: number): number => {
+      if (s === null || s === undefined || s === '') return def;
+      const n = parseInt(s, 10);
+      return isNaN(n) ? def : n;
+    };
     return {
-      enabled: this.isAutoTimeSyncEnabled(),
+      enabled: enabledStr === 'true',
       nodeNums,
-      filterEnabled: this.isAutoTimeSyncNodeFilterEnabled(),
-      expirationHours: this.getAutoTimeSyncExpirationHours(),
-      intervalMinutes: this.getAutoTimeSyncIntervalMinutes(),
+      filterEnabled: filterEnabledStr === 'true',
+      expirationHours: parseIntDefault(expirationStr, 24),
+      intervalMinutes: parseIntDefault(intervalStr, 15),
     };
   }
 
@@ -8408,6 +8420,22 @@ class DatabaseService {
     expirationHours?: number;
     intervalMinutes?: number;
   }, sourceId?: string): Promise<void> {
+    if (sourceId) {
+      const kv: Record<string, string> = {};
+      if (settings.enabled !== undefined) kv.autoTimeSyncEnabled = settings.enabled ? 'true' : 'false';
+      if (settings.filterEnabled !== undefined) kv.autoTimeSyncNodeFilterEnabled = settings.filterEnabled ? 'true' : 'false';
+      if (settings.expirationHours !== undefined) kv.autoTimeSyncExpirationHours = String(settings.expirationHours);
+      if (settings.intervalMinutes !== undefined) kv.autoTimeSyncIntervalMinutes = String(settings.intervalMinutes);
+      if (Object.keys(kv).length > 0) {
+        await this.settings.setSourceSettings(sourceId, kv);
+      }
+      if (settings.nodeNums !== undefined) {
+        await this.misc.setAutoTimeSyncNodes(settings.nodeNums, sourceId);
+      }
+      logger.debug(`✅ Updated per-source time sync filter settings (source=${sourceId})`);
+      return;
+    }
+
     if (settings.enabled !== undefined) {
       this.setAutoTimeSyncEnabled(settings.enabled);
     }
@@ -8433,13 +8461,23 @@ class DatabaseService {
     const activeHours = 48; // Only consider nodes heard in last 48 hours
     // lastHeard is stored in seconds, so convert cutoff to seconds
     const activeNodeCutoff = Math.floor((Date.now() - (activeHours * 60 * 60 * 1000)) / 1000);
-    const expirationHours = this.getAutoTimeSyncExpirationHours();
+
+    const read = (key: string) => this.settings.getSettingForSource(sourceId ?? null, key);
+    const [expirationStr, filterEnabledStr] = await Promise.all([
+      read('autoTimeSyncExpirationHours'),
+      read('autoTimeSyncNodeFilterEnabled'),
+    ]);
+    const expirationHours = (() => {
+      if (!expirationStr) return 24;
+      const n = parseInt(expirationStr, 10);
+      return isNaN(n) ? 24 : n;
+    })();
     // lastTimeSync is stored in milliseconds
     const expirationMsAgo = Date.now() - (expirationHours * 60 * 60 * 1000);
 
     // Get filter settings
     let filterNodeNums: number[] | undefined;
-    if (this.isAutoTimeSyncNodeFilterEnabled()) {
+    if (filterEnabledStr === 'true') {
       filterNodeNums = await this.misc.getAutoTimeSyncNodes(sourceId);
       if (filterNodeNums.length === 0) {
         // Filter is enabled but no nodes selected - skip


### PR DESCRIPTION
## Summary

Fixes a class of bugs where some automation features ignored the per-source scope the UI sent them. Enabling them for one Source applied them to every Source, and tracking state was shared.

- **Auto Time Sync**: scalar settings (`autoTimeSyncEnabled`, `autoTimeSyncIntervalMinutes`, `autoTimeSyncNodeFilterEnabled`, `autoTimeSyncExpirationHours`) were written/read from global keys even though the UI sent `sourceId`. The scheduler (`startTimeSyncScheduler`) and `getNodeNeedingTimeSyncAsync` also read globally. Now all per-source via `getSettingForSource` / `setSourceSettings`.
- **Auto Favorite**: `checkAutoFavorite` and `autoFavoriteSweep` now read `autoFavoriteEnabled`, `autoFavoriteStaleHours`, and the internal `autoFavoriteNodes` tracking list per-source (writes already used `/api/settings?sourceId=` — only the manager reads were wrong).
- **Auto Heap Management**: `checkAutoHeapManagement` now reads `autoHeapManagementEnabled` and `autoHeapManagementThresholdBytes` per-source.
- The POST `/api/settings/time-sync-nodes` fallback interval read is also per-source.

Matches the pattern already used by Auto-Traceroute and Auto-Announce (phase 2 of the multi-source automation refactor).

## Test plan

- [x] Repository suite (`src/db/repositories/`) — 394 passed
- [x] Full server suite (`src/server/`) — 2171 passed, 0 failed, 172s
- [x] Typecheck (`tsconfig.server.json`) — no new errors
- [ ] Manual: toggle Auto Time Sync on Source A only, confirm Source B does not schedule syncs
- [ ] Manual: toggle Auto Favorite on Source A only, confirm Source B's nodes are not auto-favorited
- [ ] Manual: toggle Auto Heap Management on Source A only, confirm Source B does not purge on low heap

🤖 Generated with [Claude Code](https://claude.com/claude-code)