### PR TITLE
fix(auth): isolate permissions per source; stop cross-source grant leaks

### DIFF
--- a/src/components/AuditLogTab.test.tsx
+++ b/src/components/AuditLogTab.test.tsx
@@ -113,7 +113,7 @@ describe('AuditLogTab', () => {
   const createAuthStatus = (overrides: any = {}) => ({
     authenticated: true,
     user: { id: 1, username: 'admin', email: null, displayName: null, authProvider: 'local' as const, isAdmin: true, isActive: true, createdAt: Date.now(), lastLoginAt: Date.now() },
-    permissions: { audit: { read: true, write: true } },
+    permissions: { global: { audit: { read: true, write: true } }, bySource: {} },
     oidcEnabled: false,
     localAuthDisabled: false,
     ...overrides
@@ -149,7 +149,7 @@ describe('AuditLogTab', () => {
     it('should show error message when user lacks audit read permission', () => {
       const authStatus = createAuthStatus({
         user: { id: 1, username: 'user', email: null, displayName: null, authProvider: 'local' as const, isAdmin: false, isActive: true, createdAt: Date.now(), lastLoginAt: Date.now() },
-        permissions: { audit: { read: false, write: false } }
+        permissions: { global: { audit: { read: false, write: false } }, bySource: {} }
       });
 
       render(

--- a/src/components/AuditLogTab.tsx
+++ b/src/components/AuditLogTab.tsx
@@ -234,7 +234,7 @@ const AuditLogTab: React.FC = () => {
   const uniqueActions = Array.from(new Set(stats?.actionStats.map(s => s.action) || []));
   const uniqueResources = ['auth', 'users', 'permissions', 'settings', 'nodes', 'messages', 'telemetry', 'connection', 'audit'];
 
-  if (!authStatus?.permissions?.audit?.read) {
+  if (!authStatus?.permissions?.global?.audit?.read) {
     return (
       <div className="audit-log-tab">
         <div className="error-message">

--- a/src/components/CustomThemeManagement.tsx
+++ b/src/components/CustomThemeManagement.tsx
@@ -17,7 +17,7 @@ export const CustomThemeManagement: React.FC = () => {
   const [editingTheme, setEditingTheme] = useState<CustomTheme | null>(null);
   const [baseTheme, setBaseTheme] = useState<BuiltInTheme | CustomTheme | undefined>(undefined);
 
-  const canWrite = authStatus?.permissions?.themes?.write || false;
+  const canWrite = authStatus?.permissions?.global?.themes?.write || false;
 
   const handleCreateNew = () => {
     setEditingTheme(null);

--- a/src/components/ThemeEditor.tsx
+++ b/src/components/ThemeEditor.tsx
@@ -220,7 +220,7 @@ export const ThemeEditor: React.FC<ThemeEditorProps> = ({
     URL.revokeObjectURL(url);
   };
 
-  const canSave = authStatus?.permissions?.themes?.write && validationErrors.length === 0 && name.trim().length > 0;
+  const canSave = authStatus?.permissions?.global?.themes?.write && validationErrors.length === 0 && name.trim().length > 0;
 
   return (
     <div className="theme-editor">

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -48,12 +48,19 @@ const mockUser = {
   lastLoginAt: null,
 };
 
+const TEST_SOURCE_ID = 'src-a';
+
 const mockAuthStatus = {
   authenticated: true,
   user: mockUser,
   permissions: {
-    nodes: { read: true, write: false },
-    messages: { read: true, write: true },
+    global: {},
+    bySource: {
+      [TEST_SOURCE_ID]: {
+        nodes: { read: true, write: false },
+        messages: { read: true, write: true },
+      },
+    },
   },
   channelDbPermissions: {
     1: { viewOnMap: true, read: true },
@@ -179,7 +186,7 @@ describe('hasPermission', () => {
     const adminStatus = {
       ...mockAuthStatus,
       user: { ...mockUser, isAdmin: true },
-      permissions: {},
+      permissions: { global: {}, bySource: {} },
     };
     mockApi.get.mockImplementation((url: string) => {
       if (url === '/api/auth/status') return Promise.resolve(adminStatus);
@@ -194,18 +201,28 @@ describe('hasPermission', () => {
     expect(result.current.hasPermission('messages', 'write')).toBe(true);
   });
 
-  it('returns true for resource with read permission', async () => {
+  it('returns true for resource with read permission (sourcey — pass sourceId)', async () => {
     const { result } = renderHook(() => useAuth(), { wrapper });
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(result.current.hasPermission('nodes', 'read')).toBe(true);
+    expect(result.current.hasPermission('nodes', 'read', { sourceId: TEST_SOURCE_ID })).toBe(true);
+  });
+
+  it('returns false for sourcey resource without sourceId (no cross-source leak)', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // `nodes` is granted on TEST_SOURCE_ID only. Without an explicit sourceId
+    // and outside a SourceProvider, the check must return false — this is the
+    // fix for the cross-source permission leak.
+    expect(result.current.hasPermission('nodes', 'read')).toBe(false);
   });
 
   it('returns false for resource without write permission', async () => {
     const { result } = renderHook(() => useAuth(), { wrapper });
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(result.current.hasPermission('nodes', 'write')).toBe(false);
+    expect(result.current.hasPermission('nodes', 'write', { sourceId: TEST_SOURCE_ID })).toBe(false);
   });
 
   it('returns false for unknown resource', async () => {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -4,10 +4,12 @@
  * Manages user authentication state, login/logout, and permissions
  */
 
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
 import api from '../services/api';
 import { logger } from '../utils/logger';
-import type { PermissionSet } from '../types/permission';
+import type { PermissionSet, SourcedPermissionSet } from '../types/permission';
+import { isSourceyResource } from '../types/permission';
+import { useSource } from './SourceContext';
 
 export interface User {
   id: number;
@@ -30,7 +32,12 @@ export interface ChannelDbPermissionSet {
 export interface AuthStatus {
   authenticated: boolean;
   user: User | null;
-  permissions: PermissionSet;
+  /**
+   * Permissions split into non-sourcey (`global`) and per-source (`bySource`).
+   * No cross-source union — callers must ask about a specific source via
+   * `hasPermission(resource, action, { sourceId })` or via SourceContext.
+   */
+  permissions: SourcedPermissionSet;
   channelDbPermissions: ChannelDbPermissionSet;
   oidcEnabled: boolean;
   localAuthDisabled: boolean;
@@ -51,7 +58,22 @@ interface AuthContextType {
   loginWithOIDC: () => Promise<void>;
   logout: () => Promise<void>;
   refreshAuth: () => Promise<void>;
-  hasPermission: (resource: keyof PermissionSet, action: 'read' | 'write') => boolean;
+  /**
+   * Check if the user has a permission.
+   *   - For global (non-sourcey) resources: checked against permissions.global.
+   *   - For sourcey resources: checked against permissions.bySource[targetSourceId]
+   *     where targetSourceId = opts.sourceId ?? current SourceContext sourceId.
+   *     If no sourceId is available, the check returns false (no cross-source
+   *     union — prevents grant leaks across sources).
+   *   - Pass `{ anySource: true }` for cross-source aggregators (unified views):
+   *     for sourcey resources the check returns true if ANY source has the
+   *     grant. Only use this on views that are intentionally source-agnostic.
+   */
+  hasPermission: (
+    resource: keyof PermissionSet,
+    action: 'read' | 'write',
+    opts?: { sourceId?: string | null; anySource?: boolean }
+  ) => boolean;
   hasChannelDbPermission: (channelDbId: number, action: 'viewOnMap' | 'read') => boolean;
 }
 
@@ -97,7 +119,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setAuthStatus({
         authenticated: false,
         user: null,
-        permissions: {},
+        permissions: { global: {}, bySource: {} },
         channelDbPermissions: {},
         oidcEnabled: false,
         localAuthDisabled: false,
@@ -214,26 +236,55 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }, [refreshAuth]);
 
-  // Check if user has specific permission
-  const hasPermission = useCallback((resource: keyof PermissionSet, action: 'read' | 'write'): boolean => {
-    // If authenticated and admin, grant all permissions
-    if (authStatus?.authenticated && authStatus.user?.isAdmin) {
-      return true;
-    }
+  // Check if user has specific permission.
+  // Callers may pass an explicit sourceId via `opts.sourceId`. When omitted,
+  // `useAuth()` fills it in from the active SourceContext (see useAuth below).
+  // For sourcey resources with no resolved sourceId, returns false — there is
+  // intentionally no cross-source OR-union here.
+  const hasPermission = useCallback(
+    (
+      resource: keyof PermissionSet,
+      action: 'read' | 'write',
+      opts?: { sourceId?: string | null; anySource?: boolean }
+    ): boolean => {
+      // If authenticated and admin, grant all permissions
+      if (authStatus?.authenticated && authStatus.user?.isAdmin) {
+        return true;
+      }
 
-    // Check permissions (works for both authenticated and anonymous users)
-    // Anonymous user permissions are returned in authStatus.permissions when not authenticated
-    if (!authStatus) {
+      // Check permissions (works for both authenticated and anonymous users)
+      // Anonymous user permissions are returned in authStatus.permissions when not authenticated
+      if (!authStatus) {
+        return false;
+      }
+
+      if (isSourceyResource(resource)) {
+        if (opts?.anySource) {
+          for (const sourceMap of Object.values(authStatus.permissions.bySource)) {
+            if (sourceMap[resource]?.[action] === true) return true;
+          }
+          return false;
+        }
+        const targetSourceId = opts?.sourceId ?? null;
+        if (!targetSourceId) return false;
+        const sourceMap = authStatus.permissions.bySource[targetSourceId];
+        const resourcePermissions = sourceMap?.[resource];
+        return resourcePermissions?.[action] === true;
+      }
+
+      // Non-sourcey (global) resources: prefer the global map, but fall back
+      // to any per-source row as well. This covers databases where global
+      // grants (security, audit, themes, …) were historically saved under a
+      // sourceId by the admin PUT endpoint before it learned to split.
+      const resourcePermissions = authStatus.permissions.global[resource];
+      if (resourcePermissions?.[action] === true) return true;
+      for (const sourceMap of Object.values(authStatus.permissions.bySource)) {
+        if (sourceMap[resource]?.[action] === true) return true;
+      }
       return false;
-    }
-
-    const resourcePermissions = authStatus.permissions[resource];
-    if (!resourcePermissions) {
-      return false;
-    }
-
-    return resourcePermissions[action] === true;
-  }, [authStatus]);
+    },
+    [authStatus]
+  );
 
   // Check if user has specific channel database (virtual channel) permission
   const hasChannelDbPermission = useCallback((channelDbId: number, action: 'viewOnMap' | 'read'): boolean => {
@@ -278,5 +329,22 @@ export const useAuth = (): AuthContextType => {
   if (context === undefined) {
     throw new Error('useAuth must be used within an AuthProvider');
   }
-  return context;
+
+  // Resolve "current source" from SourceContext at the call site so components
+  // inside <SourceProvider sourceId={X}> get their permission checks scoped to
+  // X automatically. Outside a SourceProvider, `currentSourceId` is null and
+  // sourcey permission checks (without an explicit sourceId) return false.
+  const { sourceId: currentSourceId } = useSource();
+
+  const boundHasPermission: AuthContextType['hasPermission'] = useMemo(
+    () =>
+      (resource, action, opts) =>
+        context.hasPermission(resource, action, {
+          sourceId: opts?.sourceId !== undefined ? opts.sourceId : currentSourceId,
+          anySource: opts?.anySource,
+        }),
+    [context, currentSourceId]
+  );
+
+  return { ...context, hasPermission: boundHasPermission };
 };

--- a/src/pages/UnifiedMessagesPage.tsx
+++ b/src/pages/UnifiedMessagesPage.tsx
@@ -142,8 +142,17 @@ function shortSenderLabel(msg: UnifiedMessage): string {
 export default function UnifiedMessagesPage() {
   const navigate = useNavigate();
   const { t } = useTranslation();
-  const { authStatus } = useAuth();
+  const { authStatus, hasPermission } = useAuth();
   const isAuthenticated = authStatus?.authenticated ?? false;
+  // Unified Messages is cross-source: allow whenever the user (including
+  // anonymous) has read on messages or any channel on ANY source.
+  const canReadAnyMessages =
+    isAuthenticated && authStatus?.user?.isAdmin
+      ? true
+      : hasPermission('messages', 'read', { anySource: true }) ||
+        [0, 1, 2, 3, 4, 5, 6, 7].some((n) =>
+          hasPermission(`channel_${n}` as keyof import('../types/permission').PermissionSet, 'read', { anySource: true })
+        );
 
   const [selectedChannel, setSelectedChannel] = useState<string>('');
   const [sourceFilter, setSourceFilter] = useState<string>('');
@@ -202,7 +211,7 @@ export default function UnifiedMessagesPage() {
       if (!lastPage || lastPage.length < PAGE_SIZE) return undefined;
       return lastPage[lastPage.length - 1].timestamp;
     },
-    enabled: !!selectedChannel && isAuthenticated,
+    enabled: !!selectedChannel && canReadAnyMessages,
     refetchInterval: POLL_INTERVAL_MS,
     refetchOnWindowFocus: false,
     // Only poll the first page (newest messages). Don't re-fetch old pages
@@ -431,13 +440,13 @@ export default function UnifiedMessagesPage() {
 
       <div className="unified-scroll" ref={scrollRef} onScroll={handleScroll}>
       <div className="unified-body">
-        {!isAuthenticated && <div className="unified-empty">{t('unified.messages.sign_in_required')}</div>}
-        {isAuthenticated && channelsError && <div className="unified-error">{t('unified.messages.failed_channels')}</div>}
-        {isAuthenticated && messagesError && <div className="unified-error">{t('unified.messages.failed_messages')}</div>}
-        {isAuthenticated && loadingMessages && feedMessages.length === 0 && (
+        {!canReadAnyMessages && <div className="unified-empty">{t('unified.messages.sign_in_required')}</div>}
+        {canReadAnyMessages && channelsError && <div className="unified-error">{t('unified.messages.failed_channels')}</div>}
+        {canReadAnyMessages && messagesError && <div className="unified-error">{t('unified.messages.failed_messages')}</div>}
+        {canReadAnyMessages && loadingMessages && feedMessages.length === 0 && (
           <div className="unified-empty">{t('unified.messages.loading')}</div>
         )}
-        {isAuthenticated && !loadingMessages && feedMessages.length === 0 && !messagesError && (
+        {canReadAnyMessages && !loadingMessages && feedMessages.length === 0 && !messagesError && (
           <div className="unified-empty">
             {selectedChannel ? t('unified.messages.empty_channel') : t('unified.messages.choose_channel')}
           </div>

--- a/src/server/routes/authRoutes.test.ts
+++ b/src/server/routes/authRoutes.test.ts
@@ -69,6 +69,10 @@ describe('Authentication Routes', () => {
     (DatabaseService as any).findUserByUsernameAsync = async (username: string) => userModel.findByUsername(username);
     (DatabaseService as any).authenticateAsync = async (username: string, password: string) => userModel.authenticate(username, password);
     (DatabaseService as any).getUserPermissionSetAsync = async (userId: number) => permissionModel.getUserPermissionSet(userId);
+    (DatabaseService as any).getUserPermissionSetsBySourceAsync = async (userId: number) => ({
+      global: await permissionModel.getUserPermissionSet(userId),
+      bySource: {},
+    });
     (DatabaseService as any).drizzleDbType = 'sqlite';
     (DatabaseService as any).updatePasswordAsync = async (userId: number, newPassword: string) => userModel.updatePassword(userId, newPassword);
 
@@ -245,8 +249,8 @@ describe('Authentication Routes', () => {
         .get('/api/auth/status')
         .expect(200);
 
-      expect(response.body.permissions.dashboard).toBeDefined();
-      expect(response.body.permissions.dashboard.read).toBe(true);
+      expect(response.body.permissions.global.dashboard).toBeDefined();
+      expect(response.body.permissions.global.dashboard.read).toBe(true);
     });
   });
 
@@ -667,7 +671,7 @@ describe('Authentication Routes', () => {
         .expect(200);
 
       expect(response.body.authenticated).toBe(false);
-      expect(response.body.permissions).toEqual({});
+      expect(response.body.permissions).toEqual({ global: {}, bySource: {} });
       expect(response.body.anonymousDisabled).toBe(true);
     });
 
@@ -743,7 +747,7 @@ describe('Authentication Routes', () => {
       expect(response.body.authenticated).toBe(true);
       expect(response.body.user.username).toBe('testuser');
       expect(response.body.permissions).toBeTruthy();
-      expect(response.body.permissions.dashboard).toBeDefined();
+      expect(response.body.permissions.global.dashboard).toBeDefined();
     });
 
     it('should work with both DISABLE_ANONYMOUS and DISABLE_LOCAL_AUTH', async () => {
@@ -759,7 +763,7 @@ describe('Authentication Routes', () => {
       expect(response.body.anonymousDisabled).toBe(true);
       expect(response.body.localAuthDisabled).toBe(true);
       expect(response.body.authenticated).toBe(false);
-      expect(response.body.permissions).toEqual({});
+      expect(response.body.permissions).toEqual({ global: {}, bySource: {} });
     });
   });
 

--- a/src/server/routes/authRoutes.ts
+++ b/src/server/routes/authRoutes.ts
@@ -66,8 +66,8 @@ router.get('/status', async (req: Request, res: Response) => {
       // Return anonymous user permissions for unauthenticated users (if anonymous is enabled)
       const anonymousUser = await databaseService.findUserByUsernameAsync('anonymous');
       const anonymousPermissions = anonymousUser && anonymousUser.isActive && !anonymousDisabled
-        ? await databaseService.getUserPermissionSetAsync(anonymousUser.id)
-        : {};
+        ? await databaseService.getUserPermissionSetsBySourceAsync(anonymousUser.id)
+        : { global: {}, bySource: {} };
 
       return res.json({
         authenticated: false,
@@ -92,8 +92,8 @@ router.get('/status', async (req: Request, res: Response) => {
       // Return anonymous user permissions (if anonymous is enabled)
       const anonymousUser = await databaseService.findUserByUsernameAsync('anonymous');
       const anonymousPermissions = anonymousUser && anonymousUser.isActive && !anonymousDisabled
-        ? await databaseService.getUserPermissionSetAsync(anonymousUser.id)
-        : {};
+        ? await databaseService.getUserPermissionSetsBySourceAsync(anonymousUser.id)
+        : { global: {}, bySource: {} };
 
       return res.json({
         authenticated: false,
@@ -106,8 +106,8 @@ router.get('/status', async (req: Request, res: Response) => {
       });
     }
 
-    // Get user permissions
-    const permissions = await databaseService.getUserPermissionSetAsync(user.id);
+    // Get user permissions split global vs per-source (no cross-source merge)
+    const permissions = await databaseService.getUserPermissionSetsBySourceAsync(user.id);
 
     // Don't send sensitive fields to client
     const { passwordHash, mfaSecret, mfaBackupCodes, ...safeUser } = user;

--- a/src/server/routes/messageRoutes.test.ts
+++ b/src/server/routes/messageRoutes.test.ts
@@ -63,6 +63,14 @@ describe('Message Deletion Routes', () => {
       messages: { read: true, write: true, viewOnMap: false },
       dashboard: { read: true, write: true, viewOnMap: false },
     });
+    // Per-source split (default: messages:write granted on source-a so DELETE /:id
+    // passes the "has any write grant" gate). Individual tests override this.
+    (databaseService as any).getUserPermissionSetsBySourceAsync = vi.fn().mockResolvedValue({
+      global: {},
+      bySource: {
+        'source-a': { messages: { read: true, write: true, viewOnMap: false } },
+      },
+    });
     (databaseService as any).checkPermissionAsync = vi.fn().mockResolvedValue(true);
     // Set up traceroutes repo mock
     Object.defineProperty(databaseService, 'messages', {
@@ -134,9 +142,9 @@ describe('Message Deletion Routes', () => {
       };
 
       vi.spyOn(databaseService, 'getMessageAsync').mockResolvedValue(mockChannelMessage as any);
-      vi.spyOn(databaseService, 'getUserPermissionSetAsync').mockResolvedValue({
-        messages: { read: false, write: false },
-        channel_0: { read: false, write: false }
+      (databaseService as any).getUserPermissionSetsBySourceAsync = vi.fn().mockResolvedValue({
+        global: {},
+        bySource: {},
       });
 
       const response = await request(app).delete('/api/messages/msg-channel');
@@ -154,15 +162,15 @@ describe('Message Deletion Routes', () => {
       };
 
       vi.spyOn(databaseService, 'getMessageAsync').mockResolvedValue(mockDMMessage as any);
-      vi.spyOn(databaseService, 'getUserPermissionSetAsync').mockResolvedValue({
-        messages: { read: false, write: false },
-        channel_0: { read: false, write: false }
+      (databaseService as any).getUserPermissionSetsBySourceAsync = vi.fn().mockResolvedValue({
+        global: {},
+        bySource: {},
       });
 
       const response = await request(app).delete('/api/messages/msg-dm');
 
       expect(response.status).toBe(403);
-      expect(response.body.message).toContain('messages:write');
+      expect(response.body.message).toContain('write permission');
     });
 
     it('should allow user with channels:write to delete channel messages', async () => {
@@ -170,15 +178,20 @@ describe('Message Deletion Routes', () => {
       const mockChannelMessage = {
         id: 'msg-channel',
         channel: 5,
+        sourceId: 'source-a',
         text: 'Channel message'
       };
 
       vi.spyOn(databaseService, 'getMessageAsync').mockResolvedValue(mockChannelMessage as any);
       mockMessagesRepo.deleteMessage.mockResolvedValue(true);
       const auditLogSpy = vi.spyOn(databaseService, 'auditLogAsync').mockResolvedValue(undefined);
-      vi.spyOn(databaseService, 'getUserPermissionSetAsync').mockResolvedValue({
-        channel_5: { read: true, write: true }
+      (databaseService as any).getUserPermissionSetsBySourceAsync = vi.fn().mockResolvedValue({
+        global: {},
+        bySource: {
+          'source-a': { channel_5: { read: true, write: true } },
+        },
       });
+      (databaseService as any).checkPermissionAsync = vi.fn().mockResolvedValue(true);
 
       const response = await request(app).delete('/api/messages/msg-channel');
 
@@ -294,13 +307,11 @@ describe('Message Deletion Routes', () => {
   });
 
   describe('DELETE /api/messages/direct-messages/:nodeNum - DM purge', () => {
-    it('should return 403 for users without messages:write', async () => {
+    it('should return 403 for users without messages:write on this source', async () => {
       const app = createApp({ id: 2, username: 'user', isAdmin: false });
-      vi.spyOn(databaseService, 'getUserPermissionSetAsync').mockResolvedValue({
-        messages: { read: false, write: false }
-      });
+      (databaseService as any).checkPermissionAsync = vi.fn().mockResolvedValue(false);
 
-      const response = await request(app).delete('/api/messages/direct-messages/123456');
+      const response = await request(app).delete('/api/messages/direct-messages/123456?sourceId=source-a');
 
       expect(response.status).toBe(403);
       expect(response.body.message).toContain('messages:write');
@@ -308,7 +319,7 @@ describe('Message Deletion Routes', () => {
 
     it('should return 400 for invalid node number', async () => {
       const app = createApp({ id: 1, username: 'admin', isAdmin: true });
-      const response = await request(app).delete('/api/messages/direct-messages/invalid');
+      const response = await request(app).delete('/api/messages/direct-messages/invalid?sourceId=source-a');
 
       expect(response.status).toBe(400);
       expect(response.body).toHaveProperty('message', 'Invalid node number');
@@ -383,13 +394,13 @@ describe('Message Deletion Routes', () => {
   });
 
   describe('DELETE /api/messages/nodes/:nodeNum/traceroutes - Node traceroutes purge', () => {
-    it('should return 403 for users without messages:write', async () => {
+    it('should return 403 for users without messages:write on this source', async () => {
       const app = createApp({ id: 2, username: 'user', isAdmin: false });
-      vi.spyOn(databaseService, 'getUserPermissionSetAsync').mockResolvedValue({
-        messages: { read: false, write: false }
-      });
+      (databaseService as any).checkPermissionAsync = vi.fn().mockResolvedValue(false);
 
-      const response = await request(app).delete('/api/messages/nodes/123456/traceroutes');
+      const response = await request(app)
+        .delete('/api/messages/nodes/123456/traceroutes')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(403);
       expect(response.body.message).toContain('messages:write');
@@ -397,7 +408,9 @@ describe('Message Deletion Routes', () => {
 
     it('should return 400 for invalid node number', async () => {
       const app = createApp({ id: 1, username: 'admin', isAdmin: true });
-      const response = await request(app).delete('/api/messages/nodes/invalid/traceroutes');
+      const response = await request(app)
+        .delete('/api/messages/nodes/invalid/traceroutes')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(400);
       expect(response.body).toHaveProperty('message', 'Invalid node number');
@@ -474,13 +487,13 @@ describe('Message Deletion Routes', () => {
   });
 
   describe('DELETE /api/messages/nodes/:nodeNum/position-history - Node position history purge', () => {
-    it('should return 403 for users without messages:write', async () => {
+    it('should return 403 for users without messages:write on this source', async () => {
       const app = createApp({ id: 2, username: 'user', isAdmin: false });
-      vi.spyOn(databaseService, 'getUserPermissionSetAsync').mockResolvedValue({
-        messages: { read: false, write: false }
-      });
+      (databaseService as any).checkPermissionAsync = vi.fn().mockResolvedValue(false);
 
-      const response = await request(app).delete('/api/messages/nodes/123456/position-history');
+      const response = await request(app)
+        .delete('/api/messages/nodes/123456/position-history')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(403);
       expect(response.body.message).toContain('messages:write');
@@ -488,7 +501,9 @@ describe('Message Deletion Routes', () => {
 
     it('should return 400 for invalid node number', async () => {
       const app = createApp({ id: 1, username: 'admin', isAdmin: true });
-      const response = await request(app).delete('/api/messages/nodes/invalid/position-history');
+      const response = await request(app)
+        .delete('/api/messages/nodes/invalid/position-history')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(400);
       expect(response.body).toHaveProperty('message', 'Invalid node number');
@@ -549,20 +564,18 @@ describe('Message Deletion Routes', () => {
   });
 
   describe('DELETE /api/messages/nodes/:nodeNum - Delete entire node', () => {
-    it('should return 403 for users without messages:write', async () => {
+    it('should return 403 for users without messages:write on this source', async () => {
       const app = createApp({ id: 2, username: 'user', isAdmin: false });
-      vi.spyOn(databaseService, 'getUserPermissionSetAsync').mockResolvedValue({
-        messages: { read: false, write: false }
-      });
+      (databaseService as any).checkPermissionAsync = vi.fn().mockResolvedValue(false);
 
-      const response = await request(app).delete('/api/messages/nodes/123456');
+      const response = await request(app).delete('/api/messages/nodes/123456?sourceId=source-a');
 
       expect(response.status).toBe(403);
     });
 
     it('should return 400 for invalid node number', async () => {
       const app = createApp({ id: 1, username: 'admin', isAdmin: true });
-      const response = await request(app).delete('/api/messages/nodes/invalid');
+      const response = await request(app).delete('/api/messages/nodes/invalid?sourceId=source-a');
 
       expect(response.status).toBe(400);
       expect(response.body).toHaveProperty('message', 'Invalid node number');
@@ -610,13 +623,13 @@ describe('Message Deletion Routes', () => {
   });
 
   describe('DELETE /api/messages/nodes/:nodeNum/telemetry - Node telemetry purge', () => {
-    it('should return 403 for users without messages:write', async () => {
+    it('should return 403 for users without messages:write on this source', async () => {
       const app = createApp({ id: 2, username: 'user', isAdmin: false });
-      vi.spyOn(databaseService, 'getUserPermissionSetAsync').mockResolvedValue({
-        messages: { read: false, write: false }
-      });
+      (databaseService as any).checkPermissionAsync = vi.fn().mockResolvedValue(false);
 
-      const response = await request(app).delete('/api/messages/nodes/123456/telemetry');
+      const response = await request(app)
+        .delete('/api/messages/nodes/123456/telemetry')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(403);
       expect(response.body.message).toContain('messages:write');
@@ -624,7 +637,9 @@ describe('Message Deletion Routes', () => {
 
     it('should return 400 for invalid node number', async () => {
       const app = createApp({ id: 1, username: 'admin', isAdmin: true });
-      const response = await request(app).delete('/api/messages/nodes/invalid/telemetry');
+      const response = await request(app)
+        .delete('/api/messages/nodes/invalid/telemetry')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(400);
       expect(response.body).toHaveProperty('message', 'Invalid node number');
@@ -827,7 +842,9 @@ describe('Message Deletion Routes', () => {
       const originalManager = (global as any).meshtasticManager;
       delete (global as any).meshtasticManager;
 
-      const response = await request(app).post('/api/messages/nodes/123456/purge-from-device');
+      const response = await request(app)
+        .post('/api/messages/nodes/123456/purge-from-device')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(500);
       expect(response.body.error).toBe('Internal server error');
@@ -843,7 +860,9 @@ describe('Message Deletion Routes', () => {
         sendRemoveNode: vi.fn().mockResolvedValue(undefined),
       };
 
-      const response = await request(app).post('/api/messages/nodes/invalid/purge-from-device');
+      const response = await request(app)
+        .post('/api/messages/nodes/invalid/purge-from-device')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(400);
       expect(response.body.message).toContain('Invalid node number');
@@ -858,7 +877,9 @@ describe('Message Deletion Routes', () => {
         sendRemoveNode: vi.fn(),
       };
 
-      const response = await request(app).post('/api/messages/nodes/123456/purge-from-device');
+      const response = await request(app)
+        .post('/api/messages/nodes/123456/purge-from-device')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(400);
       expect(response.body.message).toContain('Cannot purge the local node');
@@ -866,13 +887,13 @@ describe('Message Deletion Routes', () => {
       delete (global as any).meshtasticManager;
     });
 
-    it('should return 403 when user lacks messages:write permission', async () => {
+    it('should return 403 when user lacks messages:write permission on this source', async () => {
       const app = createApp({ id: 2, username: 'user', isAdmin: false });
-      (databaseService as any).getUserPermissionSetAsync = vi.fn().mockResolvedValue({
-        messages: { read: true, write: false },
-      });
+      (databaseService as any).checkPermissionAsync = vi.fn().mockResolvedValue(false);
 
-      const response = await request(app).post('/api/messages/nodes/123456/purge-from-device');
+      const response = await request(app)
+        .post('/api/messages/nodes/123456/purge-from-device')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(403);
     });
@@ -888,7 +909,9 @@ describe('Message Deletion Routes', () => {
         configurable: true,
       });
 
-      const response = await request(app).post('/api/messages/nodes/123456/purge-from-device');
+      const response = await request(app)
+        .post('/api/messages/nodes/123456/purge-from-device')
+        .send({ sourceId: 'source-a' });
 
       expect(response.status).toBe(500);
       expect(response.body.error).toBe('Device communication error');

--- a/src/server/routes/messageRoutes.ts
+++ b/src/server/routes/messageRoutes.ts
@@ -10,32 +10,45 @@ import { ResourceType } from '../../types/permission.js';
 const router = express.Router();
 
 /**
- * Permission middleware - require messages:write for DM deletions
+ * Permission middleware - require messages:write for DM / node-scoped deletions.
+ * Scoped to a source: caller must supply sourceId via body or query.
  */
 const requireMessagesWrite: RequestHandler = async (req, res, next) => {
   const user = (req as any).user;
   const userId = user?.id ?? null;
-
-  // Get user permissions (async for multi-database support)
-  const permissions = userId !== null
-    ? await databaseService.getUserPermissionSetAsync(userId)
-    : {};
-
-  // Check if user is admin
   const isAdmin = user?.isAdmin ?? false;
+
+  // Resolve sourceId from body or query — required for messages:write
+  const rawSourceId = (req.body && req.body.sourceId) ?? (req.query && req.query.sourceId);
+  if (rawSourceId === undefined || rawSourceId === null || rawSourceId === '') {
+    return res.status(400).json({
+      error: 'Bad request',
+      message: 'sourceId is required'
+    });
+  }
+  if (typeof rawSourceId !== 'string') {
+    return res.status(400).json({
+      error: 'Bad request',
+      message: 'Invalid sourceId'
+    });
+  }
+  const sourceId: string = rawSourceId;
+  (req as any).scopedSourceId = sourceId;
 
   if (isAdmin) {
     return next();
   }
 
-  // Check messages:write permission
-  const hasMessagesWrite = permissions.messages?.write === true;
+  // Check messages:write permission scoped to source
+  const hasMessagesWrite = userId !== null
+    ? await databaseService.checkPermissionAsync(userId, 'messages', 'write', sourceId)
+    : false;
 
   if (!hasMessagesWrite) {
-    logger.warn(`❌ Permission denied for message deletion - messages:write=${hasMessagesWrite}`);
+    logger.warn(`❌ Permission denied for message deletion - messages:write source=${sourceId}`);
     return res.status(403).json({
       error: 'Forbidden',
-      message: 'You need messages:write permission to delete messages'
+      message: `You need messages:write permission for source ${sourceId} to delete messages`
     });
   }
 
@@ -101,7 +114,8 @@ router.get('/search', async (req: Request, res: Response) => {
     const userId = user?.id ?? null;
     const isAdmin = user?.isAdmin ?? false;
 
-    const { q, caseSensitive, scope, channels, fromNodeId, startDate, endDate, limit, offset } = req.query;
+    const { q, caseSensitive, scope, channels, fromNodeId, startDate, endDate, limit, offset, sourceId } = req.query;
+    const sourceIdStr = typeof sourceId === 'string' && sourceId.length > 0 ? sourceId : undefined;
 
     if (!q || typeof q !== 'string' || q.trim().length === 0) {
       return res.status(400).json({
@@ -125,11 +139,14 @@ router.get('/search', async (req: Request, res: Response) => {
     const startDateNum = startDate ? parseInt(startDate as string) : undefined;
     const endDateNum = endDate ? parseInt(endDate as string) : undefined;
 
-    // Get accessible channels for permission filtering
+    // Get accessible channels for permission filtering. When sourceId is given,
+    // scope strictly to that source (no cross-source leak). When absent, union
+    // across sources — caller then sees whatever the union allows. Results are
+    // further filtered to sourceIdStr below when provided.
     let accessibleChannels: Set<number> | null = null;
     if (!isAdmin) {
       const permissions = userId !== null
-        ? await databaseService.getUserPermissionSetAsync(userId)
+        ? await databaseService.getUserPermissionSetAsync(userId, sourceIdStr)
         : {};
 
       accessibleChannels = new Set<number>();
@@ -172,8 +189,13 @@ router.get('/search', async (req: Request, res: Response) => {
         offset: searchOffset
       });
 
-      results.push(...searchResult.messages.map(m => ({ ...m, source: 'standard' })));
-      total += searchResult.total;
+      // When sourceId is specified, restrict results to that source.
+      const filtered = sourceIdStr
+        ? searchResult.messages.filter((m: any) => m.sourceId === sourceIdStr)
+        : searchResult.messages;
+
+      results.push(...filtered.map(m => ({ ...m, source: 'standard' })));
+      total += sourceIdStr ? filtered.length : searchResult.total;
     }
 
     // Search MeshCore messages (in-memory filter)
@@ -228,17 +250,19 @@ router.delete('/:id', async (req, res) => {
     const userId = user?.id ?? null;
     const isAdmin = user?.isAdmin ?? false;
 
-    // Get permissions first (before checking message existence for security)
-    const permissions = userId !== null
-      ? await databaseService.getUserPermissionSetAsync(userId)
-      : {};
+    // Gate by "has any write grant" without cross-source leak: fetch the split
+    // permission set and check if the user has messages:write or any channel_N:write
+    // on ANY source. This preserves the pre-existing timing-safe "don't reveal
+    // message existence" behavior; the specific per-source permission check happens
+    // after we load the message and know its sourceId.
+    const sets = userId !== null
+      ? await databaseService.getUserPermissionSetsBySourceAsync(userId)
+      : { global: {}, bySource: {} };
 
-    // Check if user has any write permission at all (messages or any channel)
-    const hasMessagesWrite = permissions.messages?.write === true;
-    const hasAnyChannelWrite = Object.keys(permissions).some(key =>
-      key.startsWith('channel_') && permissions[key as keyof typeof permissions]?.write === true
-    );
-    const hasAnyWritePermission = isAdmin || hasMessagesWrite || hasAnyChannelWrite;
+    const sourceMaps = Object.values(sets.bySource);
+    const hasAnyWritePermission = isAdmin
+      || sourceMaps.some(m => m.messages?.write === true)
+      || sourceMaps.some(m => Object.keys(m).some(k => k.startsWith('channel_') && m[k as keyof typeof m]?.write === true));
 
     if (!hasAnyWritePermission) {
       return res.status(403).json({
@@ -258,24 +282,36 @@ router.delete('/:id', async (req, res) => {
 
     // Determine if this is a channel or DM message
     const isChannelMessage = message.channel !== 0;
+    const messageSourceId = (message as any).sourceId as string | undefined;
 
-    // Check specific permission for this message type
+    // Check specific permission for this message type, scoped to the message's source
     if (!isAdmin) {
+      if (!messageSourceId) {
+        // Legacy message without sourceId — deny for per-source callers
+        return res.status(403).json({
+          error: 'Forbidden',
+          message: 'Message has no source association; cannot be deleted by non-admin'
+        });
+      }
       if (isChannelMessage) {
         const channelResource = `channel_${message.channel}` as import('../../types/permission.js').ResourceType;
-        const hasChannelWrite = permissions[channelResource]?.write === true;
+        const hasChannelWrite = userId !== null
+          ? await databaseService.checkPermissionAsync(userId, channelResource, 'write', messageSourceId)
+          : false;
         if (!hasChannelWrite) {
           return res.status(403).json({
             error: 'Forbidden',
-            message: `You need ${channelResource}:write permission to delete messages from this channel`
+            message: `You need ${channelResource}:write permission for source ${messageSourceId} to delete messages from this channel`
           });
         }
       } else {
-        const hasMessagesWrite = permissions.messages?.write === true;
+        const hasMessagesWrite = userId !== null
+          ? await databaseService.checkPermissionAsync(userId, 'messages', 'write', messageSourceId)
+          : false;
         if (!hasMessagesWrite) {
           return res.status(403).json({
             error: 'Forbidden',
-            message: 'You need messages:write permission to delete direct messages'
+            message: `You need messages:write permission for source ${messageSourceId} to delete direct messages`
           });
         }
       }

--- a/src/server/routes/packetRoutes.ts
+++ b/src/server/routes/packetRoutes.ts
@@ -73,9 +73,11 @@ const requirePacketPermissions: RequestHandler = async (req, res, next) => {
     const sourceIdQ = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
     (req as any).scopedSourceId = sourceIdQ;
 
-    // Get user permissions (works for both authenticated and anonymous users)
+    // Get user permissions scoped to the requested source (null sourceId falls
+    // back to the legacy merged map — callers without a source get the same
+    // behavior as before).
     const permissions = userId !== null
-      ? await databaseService.getUserPermissionSetAsync(userId)
+      ? await databaseService.getUserPermissionSetAsync(userId, sourceIdQ)
       : {};
 
     // Check if user is admin (admins have all permissions)

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -106,21 +106,32 @@ router.get('/channels', async (req: Request, res: Response) => {
 
     await Promise.all(
       sources.map(async (source) => {
-        const canRead = isAdmin || (user
+        // Check messages:read once per source (covers DMs and acts as "broad
+        // read" grant). Per-channel read is checked individually below.
+        const canReadMessages = isAdmin || (user
           ? await databaseService.checkPermissionAsync(user.id, 'messages', 'read', source.id)
           : false);
-        if (!canRead) return;
 
         try {
           const chans = await databaseService.channels.getAllChannels(source.id);
           for (const c of chans) {
             const name = unifiedChannelDisplayName(c as any);
             if (!name) continue; // disabled or unused slot
+            const channelNum = (c as any).id as number;
+            const canReadChannel = canReadMessages || (user
+              ? await databaseService.checkPermissionAsync(
+                  user.id,
+                  `channel_${channelNum}`,
+                  'read',
+                  source.id,
+                )
+              : false);
+            if (!canReadChannel) continue;
             const list = byName.get(name) ?? [];
             list.push({
               sourceId: source.id,
               sourceName: source.name,
-              channelNumber: (c as any).id,
+              channelNumber: channelNum,
             });
             byName.set(name, list);
           }
@@ -222,10 +233,9 @@ router.get('/messages', async (req: Request, res: Response) => {
 
     await Promise.all(
       sources.map(async (source) => {
-        const canRead = isAdmin || (user
+        const canReadMessages = isAdmin || (user
           ? await databaseService.checkPermissionAsync(user.id, 'messages', 'read', source.id)
           : false);
-        if (!canRead) return;
 
         // Resolve channel name → channel number AND build node-name map in
         // parallel. Both are independent reads against this source's DB slice
@@ -233,6 +243,9 @@ router.get('/messages', async (req: Request, res: Response) => {
         // instead of running them back-to-back.
         const nodeMap = new Map<number, { longName?: string; shortName?: string }>();
         let channelNumber: number | undefined;
+        // Channels on this source the user can read. Populated only when
+        // needed (no channelName → we have to filter per channel).
+        let allowedChannelsOnSource: Set<number> | null = null;
 
         const [chansResult, nodesResult] = await Promise.allSettled([
           channelName
@@ -255,6 +268,33 @@ router.get('/messages', async (req: Request, res: Response) => {
           );
           if (!match) return; // source has no matching channel → skip
           channelNumber = (match as any).id;
+
+          // Gate: either broad messages:read or specific channel_N:read grant.
+          const canReadChannel = canReadMessages || (user
+            ? await databaseService.checkPermissionAsync(
+                user.id,
+                `channel_${channelNumber}`,
+                'read',
+                source.id,
+              )
+            : false);
+          if (!canReadChannel) return;
+        } else {
+          // No channel filter: build the set of channels on this source the
+          // user can actually read. Skip the source entirely if empty.
+          allowedChannelsOnSource = new Set<number>();
+          for (let n = 0; n <= 7; n++) {
+            const allow = canReadMessages || (user
+              ? await databaseService.checkPermissionAsync(
+                  user.id,
+                  `channel_${n}`,
+                  'read',
+                  source.id,
+                )
+              : false);
+            if (allow) allowedChannelsOnSource.add(n);
+          }
+          if (allowedChannelsOnSource.size === 0 && !canReadMessages) return;
         }
 
         if (nodesResult.status === 'fulfilled') {
@@ -286,6 +326,15 @@ router.get('/messages', async (req: Request, res: Response) => {
           msgs = await databaseService.messages.getMessages(fetchLimit, 0, source.id, [PortNum.TRACEROUTE_APP]);
           if (before !== undefined) {
             msgs = msgs.filter((m) => (m.rxTime ?? m.timestamp) < before);
+          }
+          // Filter to channels the user can read on this source. DMs (no
+          // channel or explicitly -1) require the broader messages:read grant.
+          if (allowedChannelsOnSource) {
+            msgs = msgs.filter((m) => {
+              const ch = (m as any).channel;
+              if (ch == null || ch === -1) return canReadMessages;
+              return allowedChannelsOnSource!.has(ch);
+            });
           }
         }
 

--- a/src/server/routes/userRoutes.test.ts
+++ b/src/server/routes/userRoutes.test.ts
@@ -146,6 +146,10 @@ describe('User Management Routes', () => {
     (DatabaseService as any).getUserPermissionSetAsync = async (userId: number) => {
       return permissionModel.getUserPermissionSet(userId);
     };
+    (DatabaseService as any).getUserPermissionSetsBySourceAsync = async (userId: number) => ({
+      global: await permissionModel.getUserPermissionSet(userId),
+      bySource: {},
+    });
     (DatabaseService as any).clearUserMfaAsync = async (userId: number) => {
       return await userModel.update(userId, { mfaEnabled: false, mfaSecret: null, mfaBackupCodes: null } as any);
     };

--- a/src/server/routes/userRoutes.ts
+++ b/src/server/routes/userRoutes.ts
@@ -9,7 +9,7 @@ import { requireAdmin } from '../auth/authMiddleware.js';
 import { createLocalUser, resetUserPassword, setUserPassword } from '../auth/localAuth.js';
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
-import { PermissionSet } from '../../types/permission.js';
+import { PermissionSet, isSourceyResource, ResourceType } from '../../types/permission.js';
 const router = Router();
 
 // All routes require admin
@@ -363,7 +363,18 @@ router.get('/:id/permissions', async (req: Request, res: Response) => {
     }
 
     const sourceId = (req.query.sourceId as string | undefined) || undefined;
-    const permissions = await databaseService.getUserPermissionSetAsync(userId, sourceId);
+
+    // Merge the user's global (non-sourcey) grants on top of their per-source
+    // grants so the admin UI can edit both in one form. The PUT handler routes
+    // each resource back to the correct scope.
+    const { global, bySource } = await databaseService.getUserPermissionSetsBySourceAsync(userId);
+    const perSource = sourceId ? (bySource[sourceId] ?? {}) : {};
+    const permissions: PermissionSet = { ...perSource };
+    for (const [resource, perms] of Object.entries(global)) {
+      if (!isSourceyResource(resource as ResourceType)) {
+        (permissions as any)[resource] = perms;
+      }
+    }
 
     return res.json({ permissions });
   } catch (error) {
@@ -399,26 +410,53 @@ router.put('/:id/permissions', async (req: Request, res: Response) => {
       }
     }
 
-    // All permissions are per-source — sourceId is required
-    if (!sourceId) {
+    // Split the incoming map by resource type:
+    //   - sourcey resources (channels, messages, nodes, etc.) → require sourceId,
+    //     stored with that sourceId.
+    //   - non-sourcey resources (dashboard, audit, security, themes, sources,
+    //     settings, info, meshcore) → stored globally with sourceId = NULL,
+    //     regardless of whatever sourceId the admin UI had in scope.
+    const sourceyEntries = Object.entries(permissions).filter(([r]) => isSourceyResource(r as ResourceType));
+    const globalEntries = Object.entries(permissions).filter(([r]) => !isSourceyResource(r as ResourceType));
+
+    if (sourceyEntries.length > 0 && !sourceId) {
       return res.status(400).json({
-        error: 'sourceId is required — all permissions are per-source'
+        error: 'sourceId is required when updating per-source permissions'
       });
     }
 
-    // Delete only permissions in the given scope, then recreate
-    await databaseService.auth.deletePermissionsForUserByScope(userId, sourceId ?? null);
-    for (const [resource, perms] of Object.entries(permissions)) {
-      await databaseService.auth.createPermission({
-        userId,
-        resource,
-        canViewOnMap: perms.viewOnMap ?? false,
-        canRead: perms.read,
-        canWrite: perms.write,
-        grantedBy: req.user!.id,
-        grantedAt: Date.now(),
-        sourceId: sourceId ?? null,
-      });
+    // Replace the per-source scope if we're touching sourcey resources
+    if (sourceId) {
+      await databaseService.auth.deletePermissionsForUserByScope(userId, sourceId);
+      for (const [resource, perms] of sourceyEntries) {
+        await databaseService.auth.createPermission({
+          userId,
+          resource,
+          canViewOnMap: perms.viewOnMap ?? false,
+          canRead: perms.read,
+          canWrite: perms.write,
+          grantedBy: req.user!.id,
+          grantedAt: Date.now(),
+          sourceId,
+        });
+      }
+    }
+
+    // Replace the global (sourceId IS NULL) scope for non-sourcey resources
+    if (globalEntries.length > 0) {
+      await databaseService.auth.deletePermissionsForUserByScope(userId, null);
+      for (const [resource, perms] of globalEntries) {
+        await databaseService.auth.createPermission({
+          userId,
+          resource,
+          canViewOnMap: perms.viewOnMap ?? false,
+          canRead: perms.read,
+          canWrite: perms.write,
+          grantedBy: req.user!.id,
+          grantedAt: Date.now(),
+          sourceId: null,
+        });
+      }
     }
 
     // Audit log

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -8,6 +8,7 @@ import { getEnvironmentConfig } from '../server/config/environment.js';
 
 import { registry } from '../db/migrations.js';
 import { validateThemeDefinition as validateTheme } from '../utils/themeValidation.js';
+import { isSourceyResource } from '../types/permission.js';
 // Drizzle ORM imports for dual-database support
 import { drizzle as drizzleSqlite } from 'drizzle-orm/better-sqlite3';
 import * as drizzleSchema from '../db/schema/index.js';
@@ -8015,19 +8016,35 @@ class DatabaseService {
       return false;
     };
 
-    // All resources are now sourcey (per-source).
-    // When sourceId is provided, check for an exact match.
-    // When sourceId is omitted, grant access if the user has the permission on ANY source.
-    if (sourceId) {
+    const sourcey = isSourceyResource(resource as any);
+
+    if (sourcey) {
+      // Per-source resource. With sourceId → exact-match. Without sourceId →
+      // union across sources (legacy callers that don't scope their lookup).
+      if (sourceId) {
+        for (const perm of permissions) {
+          if (perm.resource === resource && (perm as any).sourceId === sourceId) {
+            return check(perm);
+          }
+        }
+        return false;
+      }
       for (const perm of permissions) {
-        if (perm.resource === resource && (perm as any).sourceId === sourceId) {
-          return check(perm);
+        if (perm.resource === resource && (perm as any).sourceId) {
+          if (check(perm)) return true;
         }
       }
       return false;
     }
 
-    // No sourceId — check if user has this permission on any source
+    // Non-sourcey (global) resource. Prefer the canonical sourceId=NULL row,
+    // then fall back to any per-source row — covers databases where the admin
+    // PUT endpoint historically saved global grants under a sourceId.
+    for (const perm of permissions) {
+      if (perm.resource === resource && !(perm as any).sourceId) {
+        if (check(perm)) return true;
+      }
+    }
     for (const perm of permissions) {
       if (perm.resource === resource && (perm as any).sourceId) {
         if (check(perm)) return true;
@@ -8071,6 +8088,37 @@ class DatabaseService {
     }
 
     return permissionSet;
+  }
+
+  /**
+   * Return the user's permissions split into `global` (non-sourcey rows where
+   * sourceId IS NULL) and `bySource` (per-source rows keyed by sourceId).
+   * Does NOT OR-merge across sources. Callers that need to answer a permission
+   * question must pick a specific source or use the global map.
+   */
+  async getUserPermissionSetsBySourceAsync(userId: number): Promise<{
+    global: Record<string, { viewOnMap?: boolean; read: boolean; write: boolean }>;
+    bySource: Record<string, Record<string, { viewOnMap?: boolean; read: boolean; write: boolean }>>;
+  }> {
+    const permissions = await this.auth.getPermissionsForUser(userId);
+    const global: Record<string, { viewOnMap?: boolean; read: boolean; write: boolean }> = {};
+    const bySource: Record<string, Record<string, { viewOnMap?: boolean; read: boolean; write: boolean }>> = {};
+
+    for (const perm of permissions) {
+      const entry = {
+        viewOnMap: (perm as any).canViewOnMap ?? false,
+        read: perm.canRead,
+        write: perm.canWrite,
+      };
+      const sid = (perm as any).sourceId as string | null | undefined;
+      if (sid) {
+        (bySource[sid] ??= {})[perm.resource] = entry;
+      } else {
+        global[perm.resource] = entry;
+      }
+    }
+
+    return { global, bySource };
   }
 
   /**

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -58,6 +58,33 @@ export type PermissionSet = Partial<{
   };
 }>;
 
+/**
+ * Resources whose permissions are scoped per-source. Matches the SOURCEY_RESOURCES
+ * set used by migration 033. Grants on these resources always carry a sourceId.
+ */
+export const SOURCEY_RESOURCES: readonly ResourceType[] = [
+  'channel_0', 'channel_1', 'channel_2', 'channel_3',
+  'channel_4', 'channel_5', 'channel_6', 'channel_7',
+  'messages', 'nodes', 'nodes_private', 'traceroute',
+  'packetmonitor', 'configuration', 'connection', 'automation',
+] as const;
+
+const SOURCEY_RESOURCE_SET = new Set<ResourceType>(SOURCEY_RESOURCES);
+
+export function isSourceyResource(resource: ResourceType): boolean {
+  return SOURCEY_RESOURCE_SET.has(resource);
+}
+
+/**
+ * Response shape for the split permission model: non-sourcey grants live in
+ * `global`; per-source grants are keyed by sourceId in `bySource`. Replaces
+ * the old OR-merged single map that leaked grants across sources.
+ */
+export interface SourcedPermissionSet {
+  global: PermissionSet;
+  bySource: Record<string, PermissionSet>;
+}
+
 export interface ResourceDefinition {
   id: ResourceType;
   name: string;


### PR DESCRIPTION
## Summary
- Fixed a cross-source permission leak: a user granted `channel_3:read` on source-A would see channel_3 features and data on every other source because `/api/auth/status` returned an OR-merged permission map and downstream handlers consumed that merged view instead of a source-scoped one.
- `/api/auth/status` now returns `permissions: { global, bySource: { [sourceId]: PermissionSet } }`. No cross-source union in the response.
- `AuthContext.hasPermission(resource, action, opts?)` dispatches by resource kind:
  - non-sourcey → `global[resource]`
  - sourcey → `bySource[opts.sourceId ?? SourceContext.sourceId]`; returns `false` when no sourceId is resolvable (no silent union).
  - `opts.anySource: true` for cross-source aggregators (Unified Messages) that intentionally want "granted on any source."
- Backend `checkPermissionAsync` is now sourcey-aware: per-source exact match for sourcey resources; prefer `sourceId IS NULL` for global resources, fall back to any per-source row (covers legacy rows saved under a sourceId before the PUT split landed).
- `PUT /api/users/:id/permissions` splits the incoming map by resource kind — non-sourcey → `sourceId = NULL`; sourcey → the provided sourceId. `GET` merges global grants into the per-source view for the admin editor.
- `requireMessagesWrite` middleware now requires sourceId and scopes `messages:write`. `DELETE /api/messages/:id` checks permission against the message's own sourceId. `packetRoutes` passes sourceId through.
- `/api/unified/channels` and `/api/unified/messages` include a channel on a source if the user has `messages:read` OR `channel_N:read` for that specific channel on that source; DMs still require `messages:read`.
- `UnifiedMessagesPage` gates on cross-source read grant instead of `authStatus.authenticated`, so anonymous users with per-source channel grants can view the unified feed.
- Frontend components that read `authStatus.permissions` directly (`AuditLogTab`, `CustomThemeManagement`, `ThemeEditor`) updated to the new `.global.*` shape.

## Test plan
- [x] Full vitest suite: 4359 passing (0 failing) after the refactor.
- [x] New per-source scoping coverage in `AuthContext`, `authRoutes`, `messageRoutes`, and `userRoutes` tests.
- [x] Manual verification in dev container: granted anonymous `channel_0:read` on one source only; Sidebar/Unified Messages correctly hide the channel on other sources; verified the target source still shows messages; verified `security`/`audit`/`themes` (global resources) work after the PUT split + fallback.
- [ ] Self-hosted System Tests on PR push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)