### PR TITLE
fix(auto-favorite): populate firmwareVersion on local node restore

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3166,8 +3166,12 @@ class MeshtasticManager implements ISourceManager {
         const nodeNum = parseInt(savedNodeNum);
         logger.debug(`📱 Found saved local node info: ${savedNodeId} (${nodeNum})`);
 
-        // Try to get full node info from database
-        const node = await databaseService.nodes.getNode(nodeNum);
+        // Try to get full node info from database. Scope to this manager's own
+        // sourceId so we pick the right row in multi-source deployments — node
+        // rows with the same nodeNum exist for every source since migration 029
+        // made (nodeNum, sourceId) the composite PK, and a source-agnostic
+        // lookup may return a stale row whose firmwareVersion is NULL.
+        const node = await databaseService.nodes.getNode(nodeNum, this.sourceId);
         if (node) {
           this.localNodeInfo = {
             nodeNum: nodeNum,
@@ -3175,6 +3179,7 @@ class MeshtasticManager implements ISourceManager {
             longName: node.longName || 'Unknown',
             shortName: node.shortName || 'UNK',
             hwModel: node.hwModel || undefined,
+            firmwareVersion: (node as any).firmwareVersion || null,
             rebootCount: (node as any).rebootCount !== undefined ? (node as any).rebootCount : undefined,
             isLocked: false // Allow updates if MyNodeInfo arrives later
           } as any;
@@ -3336,8 +3341,10 @@ class MeshtasticManager implements ISourceManager {
     await databaseService.settings.setSetting(this.localNodeSettingKey('localNodeId'), nodeId);
     logger.debug(`💾 Saved local node info to settings: ${nodeId} (${nodeNum})`);
 
-    // Check if we already have this node with actual names in the database
-    const existingNode = await databaseService.nodes.getNode(nodeNum);
+    // Check if we already have this node with actual names in the database.
+    // Scoped to this manager's sourceId so we pick this source's row rather
+    // than an unrelated source's row for the same nodeNum.
+    const existingNode = await databaseService.nodes.getNode(nodeNum, this.sourceId);
 
     // Clear any erroneous security flags on the local node — we can't have a key mismatch with ourselves
     if (existingNode?.keyMismatchDetected || existingNode?.keySecurityIssueDetails) {


### PR DESCRIPTION
## Summary
- Automations → AutoFavorite section rendered `firmware version unknown` for some sources because `localNodeInfo.firmwareVersion` stayed null after a restart.
- Root cause: `meshtasticManager` looked up the local node row via `databaseService.nodes.getNode(nodeNum)` without a sourceId. Migration 029 made `(nodeNum, sourceId)` the composite PK, so the same nodeNum has a row per source. A source-agnostic lookup returns the first arbitrary row — often one with `firmwareVersion = NULL` — and the restore branch also forgot to copy the field.

## Fix
- `initializeLocalNodeInfoFromDatabase` (`meshtasticManager.ts:3174`): scope to `this.sourceId` and copy `firmwareVersion` into the restored `localNodeInfo`.
- Live `onMyNodeInfo` path (`meshtasticManager.ts:3347`): same `this.sourceId` scoping on `existingNode` lookup so the right row feeds the lock-and-copy branch that already set firmwareVersion.

## Test plan
- [x] 33 related vitest tests pass (`meshtasticManager.autoFavorite.test.ts`, `meshtasticManager.duplicate-message.test.ts`).
- [x] Manual: local dev container; `/api/auto-favorite/status?sourceId=<id>` now returns a non-null `firmwareVersion` for each configured source; UI no longer says "unknown".

🤖 Generated with [Claude Code](https://claude.com/claude-code)