### PR TITLE
fix(ui): distance-delete log shows empty counts and NaN thresholds

### DIFF
--- a/src/components/AutoDeleteByDistanceSection.tsx
+++ b/src/components/AutoDeleteByDistanceSection.tsx
@@ -28,8 +28,8 @@ interface AutoDeleteByDistanceSectionProps {
 interface LogEntry {
   id: number;
   timestamp: number;
-  nodes_deleted: number;
-  threshold_km: number;
+  nodesDeleted: number;
+  thresholdKm: number;
   details: Array<{ nodeId: string; nodeName: string; distanceKm: number }>;
 }
 
@@ -448,10 +448,10 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
                         {new Date(Number(entry.timestamp)).toLocaleString()}
                       </td>
                       <td style={{ padding: '0.5rem', textAlign: 'center' }}>
-                        {entry.nodes_deleted}
+                        {entry.nodesDeleted}
                       </td>
                       <td style={{ padding: '0.5rem', textAlign: 'center' }}>
-                        {Math.round(toDisplayUnit(entry.threshold_km))}
+                        {Math.round(toDisplayUnit(entry.thresholdKm))}
                       </td>
                     </tr>
                   ))}


### PR DESCRIPTION
## Summary
- The Auto Delete by Distance activity log rendered empty delete counts and `NaN` for the threshold column.
- Backend repository returns Drizzle entities with camelCase TS keys (`nodesDeleted`, `thresholdKm`), but the React component's `LogEntry` interface and table cells used snake_case (`nodes_deleted`, `threshold_km`), so every field resolved to `undefined` — producing blanks and `Math.round(toDisplayUnit(undefined))` → `NaN`.
- Renamed the interface fields and render accessors to match the API shape.

## Test plan
- [ ] Open Settings → Automation → Auto Delete by Distance → Activity Log
- [ ] Confirm existing log rows show the correct "Nodes Deleted" count and "Threshold Used" distance (no `NaN`)
- [ ] Trigger "Run Now" with a home coordinate set and verify the new log entry renders with real values

🤖 Generated with [Claude Code](https://claude.com/claude-code)