### PR TITLE
fix(virtual-node): stop double-broadcasting inbound packets (#2776)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -4215,19 +4215,6 @@ class MeshtasticManager implements ISourceManager {
       }
     }
 
-    // Phase 7: Mirror every accepted inbound MeshPacket to this source's
-    // virtual-node clients so VN consumers see live mesh traffic. Broadcast all
-    // PortNums — the whole point of a virtual node is to reflect the mesh.
-    if (this.virtualNodeServer) {
-      try {
-        const fromRadioData = await meshtasticProtobufService.createFromRadioWithPacket(meshPacket);
-        if (fromRadioData) {
-          await this.virtualNodeServer.broadcastToClients(fromRadioData);
-        }
-      } catch (error) {
-        logger.error(`Virtual node: Failed to broadcast inbound packet for source ${this.sourceId}:`, error);
-      }
-    }
   }
 
   /**

--- a/src/server/meshtasticManager.virtualNode.test.ts
+++ b/src/server/meshtasticManager.virtualNode.test.ts
@@ -170,7 +170,11 @@ describe('MeshtasticManager — Virtual Node wiring', () => {
     expect(broadcastMock).not.toHaveBeenCalled();
   });
 
-  it('processMeshPacket broadcasts inbound packets when VN is enabled', async () => {
+  // Regression test for #2776: processMeshPacket MUST NOT broadcast to VN clients.
+  // processIncomingData already broadcasts the raw FromRadio bytes upstream.
+  // A second broadcast here caused every inbound meshPacket to be duplicated to
+  // clients like the Meshtastic Android app (and echoed VN-originated packets).
+  it('processMeshPacket does not broadcast (broadcast happens in processIncomingData)', async () => {
     const mgr = new MeshtasticManager('src-1', {
       host: '127.0.0.1',
       port: 4403,
@@ -182,8 +186,8 @@ describe('MeshtasticManager — Virtual Node wiring', () => {
     const pkt = { id: 1, from: 2, to: 0xffffffff, channel: 0, decoded: { portnum: 1, payload: new Uint8Array() } };
     await (mgr as any).processMeshPacket(pkt);
 
-    expect(createFromRadioWithPacketMock).toHaveBeenCalledWith(pkt);
-    expect(broadcastMock).toHaveBeenCalledWith(expect.any(Uint8Array));
+    expect(broadcastMock).not.toHaveBeenCalled();
+    expect(createFromRadioWithPacketMock).not.toHaveBeenCalled();
   });
 
   it('processMeshPacket does not throw when VN is disabled', async () => {


### PR DESCRIPTION
## Summary

Fixes #2776 — every packet arriving at a virtual-node client (e.g. the Meshtastic Android app) was duplicated.

- `processIncomingData` already broadcasts the raw `FromRadio` bytes to virtual-node clients on ingress.
- Phase 7 (PR #2611) added a second `broadcastToClients` call inside `processMeshPacket`, so every inbound meshPacket reached VN clients twice.
- The second broadcast also ignored the `skipVirtualNodeBroadcast` context flag, causing VN-originated outgoing messages to echo back to the client that sent them.

Removes the redundant broadcast in `processMeshPacket` and converts the test that asserted the buggy behavior into a regression test that guarantees `processMeshPacket` never broadcasts (broadcasting is solely the job of `processIncomingData`).

## Test plan

- [x] `vitest run src/server/meshtasticManager.virtualNode.test.ts` — 9/9 passing locally
- [ ] CI green
- [ ] Manual: enable VirtualNode, connect Meshtastic Android app, send message from an outside node, verify only a single copy arrives in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)