### PR TITLE
chore: bump version to 4.0.0-beta12

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.0.0-beta11",
+  "version": "4.0.0-beta12",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.0.0-beta11",
+  "version": "4.0.0-beta12",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.0.0-beta11
-appVersion: "4.0.0-beta11"
+version: 4.0.0-beta12
+appVersion: "4.0.0-beta12"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta11",
+  "version": "4.0.0-beta12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.0.0-beta11",
+      "version": "4.0.0-beta12",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta11",
+  "version": "4.0.0-beta12",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Bumps version to `4.0.0-beta12` across the five required manifests: `package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml`, `desktop/src-tauri/tauri.conf.json`, `desktop/package.json`.

### Included since beta11

- fix(virtual-node): stop double-broadcasting inbound meshPackets (#2778, fixes #2776)
- fix(ui): map distance-delete log fields to camelCase (#2777)
- feat(v1-api): reshape v1 REST API for per-source scoping (#2775)
- feat(sources): add "auto-connect on startup" toggle (#2774, #2773)

## Test plan

- [ ] CI green
- [ ] Helm chart version bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)