### PR TITLE
fix(auth): distinguish rate-limit and CSRF expiry from bad credentials on login

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -182,6 +182,8 @@
   "auth.login_page_title": "MeshMonitor",
   "auth.login_with_oidc": "Login with OIDC",
   "auth.invalid_credentials": "Invalid username or password",
+  "auth.rate_limited": "Too many login attempts. Please try again in {{minutes}} minute(s).",
+  "auth.rate_limited_generic": "Too many login attempts. Please try again later.",
   "auth.local_auth_disabled": "Local authentication is disabled and OIDC is not configured. Please contact your administrator.",
   "auth.login_divider": "OR",
   "auth.logout": "Logout",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -184,6 +184,7 @@
   "auth.invalid_credentials": "Invalid username or password",
   "auth.rate_limited": "Too many login attempts. Please try again in {{minutes}} minute(s).",
   "auth.rate_limited_generic": "Too many login attempts. Please try again later.",
+  "auth.session_expired": "Your session has expired. Please refresh the page and try again.",
   "auth.local_auth_disabled": "Local authentication is disabled and OIDC is not configured. Please contact your administrator.",
   "auth.login_divider": "OR",
   "auth.logout": "Logout",

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -81,6 +81,11 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
         setError(minutes !== null
           ? t('auth.rate_limited', { minutes })
           : t('auth.rate_limited_generic'));
+      } else if (err instanceof ApiError && err.status === 403 && err.code?.startsWith('CSRF_')) {
+        // CSRF token is stale (e.g. server restarted, session rotated). The
+        // old "Session cookie" message pointed users at the wrong causes
+        // (#2783). Direct them at the real fix: reload the page.
+        setError(t('auth.session_expired'));
       } else if (err instanceof Error && err.message.includes('Session cookie')) {
         setError(err.message);
       } else {

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -9,6 +9,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { logger } from '../utils/logger';
+import { ApiError } from '../services/api';
 import Modal from './common/Modal';
 
 interface LoginModalProps {
@@ -71,8 +72,16 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
       setPassword('');
     } catch (err) {
       logger.error('Login error:', err);
-      // Check if this is a cookie configuration error
-      if (err instanceof Error && err.message.includes('Session cookie')) {
+      // Rate limit: surface as a distinct, non-credential-specific message so the
+      // user knows to wait rather than keep trying passwords (#2784).
+      if (err instanceof ApiError && err.status === 429) {
+        const minutes = err.retryAfterSeconds
+          ? Math.max(1, Math.ceil(err.retryAfterSeconds / 60))
+          : null;
+        setError(minutes !== null
+          ? t('auth.rate_limited', { minutes })
+          : t('auth.rate_limited_generic'));
+      } else if (err instanceof Error && err.message.includes('Session cookie')) {
         setError(err.message);
       } else {
         setError(t('auth.invalid_credentials'));

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -57,6 +57,11 @@ const LoginPage: React.FC = () => {
         setError(minutes !== null
           ? t('auth.rate_limited', { minutes })
           : t('auth.rate_limited_generic'));
+      } else if (err instanceof ApiError && err.status === 403 && err.code?.startsWith('CSRF_')) {
+        // CSRF token is stale (e.g. server restarted, session rotated). The
+        // old "Session cookie" message pointed users at the wrong causes
+        // (#2783). Direct them at the real fix: reload the page.
+        setError(t('auth.session_expired'));
       } else if (err instanceof Error && err.message.includes('Session cookie')) {
         setError(err.message);
       } else {

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -10,6 +10,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { logger } from '../utils/logger';
+import { ApiError } from '../services/api';
 import { version } from '../../package.json';
 import './LoginPage.css';
 
@@ -47,8 +48,16 @@ const LoginPage: React.FC = () => {
       setPassword('');
     } catch (err) {
       logger.error('Login error:', err);
-      // Check if this is a cookie configuration error
-      if (err instanceof Error && err.message.includes('Session cookie')) {
+      // Rate limit: surface as a distinct, non-credential-specific message so the
+      // user knows to wait rather than keep trying passwords (#2784).
+      if (err instanceof ApiError && err.status === 429) {
+        const minutes = err.retryAfterSeconds
+          ? Math.max(1, Math.ceil(err.retryAfterSeconds / 60))
+          : null;
+        setError(minutes !== null
+          ? t('auth.rate_limited', { minutes })
+          : t('auth.rate_limited_generic'));
+      } else if (err instanceof Error && err.message.includes('Session cookie')) {
         setError(err.message);
       } else {
         setError(t('auth.invalid_credentials'));

--- a/src/server/middleware/csrf.test.ts
+++ b/src/server/middleware/csrf.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { csrfProtection } from './csrf.js';
+
+function makeRes() {
+  const res: Partial<Response> & { statusCode?: number; body?: any } = {};
+  res.status = vi.fn((code: number) => {
+    res.statusCode = code;
+    return res as Response;
+  }) as any;
+  res.json = vi.fn((body: any) => {
+    res.body = body;
+    return res as Response;
+  }) as any;
+  return res as Response & { statusCode?: number; body?: any };
+}
+
+function makeReq(overrides: Record<string, any> = {}): Request {
+  return {
+    method: 'POST',
+    path: '/some-mutation',
+    headers: {},
+    body: {},
+    session: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+describe('csrfProtection middleware error codes (#2783)', () => {
+  it('returns code CSRF_SESSION_MISSING when session has no token', () => {
+    const req = makeReq({ session: {} as any, headers: { 'x-csrf-token': 'abc' } });
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    csrfProtection(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body.code).toBe('CSRF_SESSION_MISSING');
+  });
+
+  it('returns code CSRF_TOKEN_REQUIRED when request has no token', () => {
+    const req = makeReq({ session: { csrfToken: 'server-token' } as any });
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    csrfProtection(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body.code).toBe('CSRF_TOKEN_REQUIRED');
+  });
+
+  it('returns code CSRF_TOKEN_INVALID on length mismatch', () => {
+    const req = makeReq({
+      session: { csrfToken: 'a'.repeat(64) } as any,
+      headers: { 'x-csrf-token': 'short' },
+    });
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    csrfProtection(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body.code).toBe('CSRF_TOKEN_INVALID');
+  });
+
+  it('returns code CSRF_TOKEN_INVALID on same-length mismatch', () => {
+    const req = makeReq({
+      session: { csrfToken: 'a'.repeat(64) } as any,
+      headers: { 'x-csrf-token': 'b'.repeat(64) },
+    });
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    csrfProtection(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body.code).toBe('CSRF_TOKEN_INVALID');
+  });
+
+  it('calls next() when tokens match', () => {
+    const token = 'a'.repeat(64);
+    const req = makeReq({
+      session: { csrfToken: token } as any,
+      headers: { 'x-csrf-token': token },
+    });
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    csrfProtection(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBeUndefined();
+  });
+
+  it('skips CSRF check for GET requests', () => {
+    const req = makeReq({ method: 'GET' });
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    csrfProtection(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBeUndefined();
+  });
+
+  it('skips CSRF check for Bearer-authenticated requests', () => {
+    const req = makeReq({ headers: { authorization: 'Bearer token-xyz' } });
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    csrfProtection(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBeUndefined();
+  });
+});

--- a/src/server/middleware/csrf.ts
+++ b/src/server/middleware/csrf.ts
@@ -65,7 +65,8 @@ export function csrfProtection(req: Request, res: Response, next: NextFunction) 
   if (!sessionToken) {
     logger.warn(`CSRF validation failed: No session token for ${req.method} ${req.path}`);
     return res.status(403).json({
-      error: 'CSRF token missing. Please refresh the page and try again.'
+      error: 'CSRF token missing. Please refresh the page and try again.',
+      code: 'CSRF_SESSION_MISSING'
     });
   }
 
@@ -75,7 +76,8 @@ export function csrfProtection(req: Request, res: Response, next: NextFunction) 
   if (!requestToken) {
     logger.warn(`CSRF validation failed: No request token for ${req.method} ${req.path}`);
     return res.status(403).json({
-      error: 'CSRF token required. Please refresh the page and try again.'
+      error: 'CSRF token required. Please refresh the page and try again.',
+      code: 'CSRF_TOKEN_REQUIRED'
     });
   }
 
@@ -86,7 +88,8 @@ export function csrfProtection(req: Request, res: Response, next: NextFunction) 
   if (sessionBuffer.length !== requestBuffer.length) {
     logger.warn(`CSRF validation failed: Token length mismatch for ${req.method} ${req.path} (session: ${sessionBuffer.length}, request: ${requestBuffer.length})`);
     return res.status(403).json({
-      error: 'Invalid CSRF token. Please refresh the page and try again.'
+      error: 'Invalid CSRF token. Please refresh the page and try again.',
+      code: 'CSRF_TOKEN_INVALID'
     });
   }
 
@@ -94,7 +97,8 @@ export function csrfProtection(req: Request, res: Response, next: NextFunction) 
   if (!crypto.timingSafeEqual(sessionBuffer, requestBuffer)) {
     logger.warn(`CSRF validation failed: Token mismatch for ${req.method} ${req.path}`);
     return res.status(403).json({
-      error: 'Invalid CSRF token. Please refresh the page and try again.'
+      error: 'Invalid CSRF token. Please refresh the page and try again.',
+      code: 'CSRF_TOKEN_INVALID'
     });
   }
 

--- a/src/server/middleware/rateLimiters.ts
+++ b/src/server/middleware/rateLimiters.ts
@@ -76,8 +76,11 @@ export const apiLimiter = rateLimit({
 // Strict rate limiting for authentication endpoints
 // Configurable via RATE_LIMIT_AUTH environment variable
 // Default: 5 attempts per 15 minutes in production, 100 in development
+const AUTH_WINDOW_MS = 15 * 60 * 1000;
+const AUTH_WINDOW_SECONDS = Math.floor(AUTH_WINDOW_MS / 1000);
+
 export const authLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
+  windowMs: AUTH_WINDOW_MS,
   max: env.rateLimitAuth,
   skipSuccessfulRequests: true, // Don't count successful auth attempts
   message: 'Too many login attempts, please try again later',
@@ -85,9 +88,18 @@ export const authLimiter = rateLimit({
     const ip = req.ip || 'unknown';
     const username = req.body?.username || 'unknown';
     logger.warn(`🚫 Rate limit exceeded for AUTH - IP: ${ip}, Username: ${username}`);
+    // Prefer the RateLimit-Reset header (seconds remaining) set by express-rate-limit
+    // so the UI can show an accurate retry window rather than the full windowMs.
+    const resetHeader = res.getHeader('RateLimit-Reset');
+    const retryAfterSeconds = typeof resetHeader === 'string' || typeof resetHeader === 'number'
+      ? Number(resetHeader) || AUTH_WINDOW_SECONDS
+      : AUTH_WINDOW_SECONDS;
+    res.setHeader('Retry-After', retryAfterSeconds);
     res.status(429).json({
       error: 'Too many login attempts, please try again later',
-      retryAfter: '15 minutes'
+      code: 'AUTH_RATE_LIMITED',
+      retryAfter: '15 minutes',
+      retryAfterSeconds
     });
   },
   ...rateLimitConfig,

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -821,4 +821,67 @@ describe('ApiService BASE_URL Support', () => {
       }));
     });
   });
+
+  describe('ApiError handling', () => {
+    const createErrorResponse = (status: number, body: any, headers: Record<string, string> = {}) => ({
+      ok: false,
+      status,
+      headers: {
+        get: (name: string) => headers[name.toLowerCase()] ?? null,
+      },
+      json: async () => body,
+    });
+
+    beforeEach(() => {
+      (apiService as any).baseUrl = '';
+      (apiService as any).configFetched = true;
+      mockFetch.mockClear();
+    });
+
+    it('throws ApiError with status and code on 429 rate-limit response', async () => {
+      const { ApiError } = await import('./api');
+      mockFetch.mockResolvedValueOnce(createErrorResponse(429, {
+        error: 'Too many login attempts, please try again later',
+        code: 'AUTH_RATE_LIMITED',
+        retryAfter: '15 minutes',
+        retryAfterSeconds: 30,
+      }, { 'retry-after': '30' }));
+
+      const err = await apiService.post('/api/auth/login', { username: 'x', password: 'y' })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as any).status).toBe(429);
+      expect((err as any).code).toBe('AUTH_RATE_LIMITED');
+      expect((err as any).retryAfterSeconds).toBe(30);
+      expect((err as Error).message).toBe('Too many login attempts, please try again later');
+    });
+
+    it('throws ApiError with status 401 on credential failure', async () => {
+      const { ApiError } = await import('./api');
+      mockFetch.mockResolvedValueOnce(createErrorResponse(401, {
+        error: 'Invalid username or password',
+      }));
+
+      const err = await apiService.post('/api/auth/login', { username: 'x', password: 'y' })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as any).status).toBe(401);
+      expect((err as any).code).toBeUndefined();
+      expect((err as Error).message).toBe('Invalid username or password');
+    });
+
+    it('falls back to Retry-After header when body lacks retryAfterSeconds', async () => {
+      const { ApiError } = await import('./api');
+      mockFetch.mockResolvedValueOnce(createErrorResponse(429, {
+        error: 'Too many requests',
+      }, { 'retry-after': '42' }));
+
+      const err = await apiService.post('/api/x').catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as any).retryAfterSeconds).toBe(42);
+    });
+  });
 });

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -883,5 +883,35 @@ describe('ApiService BASE_URL Support', () => {
       expect(err).toBeInstanceOf(ApiError);
       expect((err as any).retryAfterSeconds).toBe(42);
     });
+
+    it('preserves CSRF code on 403 after a failed retry (#2783)', async () => {
+      const { ApiError } = await import('./api');
+      // First call: 403 with non-CSRF error -> NOT triggering refresh path,
+      // should throw ApiError directly with CSRF code for the UI to branch.
+      // Simulate the post-refresh retry throwing 403 CSRF_TOKEN_INVALID as it
+      // would if the retry also failed (request() only retries once).
+      mockFetch
+        .mockResolvedValueOnce(createErrorResponse(403, {
+          error: 'Invalid CSRF token. Please refresh the page and try again.',
+          code: 'CSRF_TOKEN_INVALID',
+        }))
+        // Refresh succeeds, but the retry fails again with CSRF error
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: { get: () => 'application/json' },
+          json: async () => ({ csrfToken: 'new-token' }),
+        })
+        .mockResolvedValueOnce(createErrorResponse(403, {
+          error: 'Invalid CSRF token. Please refresh the page and try again.',
+          code: 'CSRF_TOKEN_INVALID',
+        }));
+
+      const err = await apiService.post('/api/auth/login', { username: 'x', password: 'y' })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as any).status).toBe(403);
+      expect((err as any).code).toBe('CSRF_TOKEN_INVALID');
+    });
   });
 });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -9,6 +9,28 @@ import {
 } from '../utils/validation';
 import { logger } from '../utils/logger.js';
 
+/**
+ * Error thrown by ApiService.request when the server returns a non-OK response.
+ * Callers can distinguish by `status` (e.g. 429 for rate limit) and `code`
+ * (machine-readable identifier from the server body) to pick a UX-appropriate
+ * message instead of collapsing every failure to a single generic string.
+ */
+export class ApiError extends Error {
+  status: number;
+  code?: string;
+  body?: unknown;
+  retryAfterSeconds?: number;
+
+  constructor(message: string, status: number, options?: { code?: string; body?: unknown; retryAfterSeconds?: number }) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = options?.code;
+    this.body = options?.body;
+    this.retryAfterSeconds = options?.retryAfterSeconds;
+  }
+}
+
 class ApiService {
   private baseUrl = '';
   private configFetched = false;
@@ -112,8 +134,20 @@ class ApiService {
     }
 
     if (!response.ok) {
-      const error = await response.json().catch(() => ({ error: 'Request failed' }));
-      throw new Error(error.error || `Request failed with status ${response.status}`);
+      const body = await response.json().catch(() => ({ error: 'Request failed' })) as {
+        error?: string;
+        code?: string;
+        retryAfterSeconds?: number;
+      };
+      const message = body.error || `Request failed with status ${response.status}`;
+      const retryAfterHeader = response.headers.get('Retry-After');
+      const retryAfterSeconds = body.retryAfterSeconds
+        ?? (retryAfterHeader ? Number(retryAfterHeader) : undefined);
+      throw new ApiError(message, response.status, {
+        code: body.code,
+        body,
+        retryAfterSeconds: Number.isFinite(retryAfterSeconds) ? retryAfterSeconds : undefined,
+      });
     }
 
     return response.json();


### PR DESCRIPTION
## Summary

- Closes #2784: login rate-limit (HTTP 429) now shows "Too many login attempts. Please try again in N minute(s)." instead of "Invalid username or password", which was masking the real cause and burning the rate-limit budget as users retried correct credentials.
- Closes #2783: a stale CSRF token (e.g. after a server restart rotates the session store) now shows "Your session has expired. Please refresh the page and try again." instead of the misleading "Session cookie not working" template that pointed at HTTP/cookie/reverse-proxy as likely causes.

## Implementation

- **Server-side structured errors**
  - `src/server/middleware/rateLimiters.ts`: auth limiter 429 response now includes `code: 'AUTH_RATE_LIMITED'`, `retryAfterSeconds` derived from the `RateLimit-Reset` header, plus an explicit `Retry-After` response header.
  - `src/server/middleware/csrf.ts`: each 403 rejection tagged with a machine-readable code — `CSRF_SESSION_MISSING`, `CSRF_TOKEN_REQUIRED`, or `CSRF_TOKEN_INVALID`.
- **Client `ApiError`**
  - `src/services/api.ts`: new exported `ApiError extends Error` carrying `status`, `code`, `body`, and `retryAfterSeconds`. The generic `request()` method throws `ApiError` on non-OK responses instead of a plain `Error`. Existing `err instanceof Error` / `err.message` callers are unaffected.
- **Login UI branching**
  - `src/components/LoginPage.tsx` + `src/components/LoginModal.tsx`: on 429 show `auth.rate_limited` (minutes computed from `retryAfterSeconds`); on 403 with `code` starting `CSRF_` show `auth.session_expired`. Existing "Session cookie" branch preserved for the distinct post-login cookie-mismatch case.
- **Translations**
  - `public/locales/en.json`: added `auth.rate_limited`, `auth.rate_limited_generic`, `auth.session_expired`. Other locales fall back to English; happy to add translations as a follow-up.

## Test plan

- [x] `npx vitest run src/services/api.test.ts` — 49/49 pass, including new ApiError cases for 401, 429, Retry-After fallback, and CSRF 403 preservation after failed retry.
- [x] `npx vitest run src/server/middleware/csrf.test.ts` — 7 new tests covering each CSRF error code plus the GET/Bearer bypass paths.
- [x] `npx vitest run src/contexts/AuthContext.test.tsx` — 24/24 pass (no login-flow regressions).
- [x] `npx tsc --noEmit` clean.
- [x] Deployed via `docker-compose.dev.yml` (sqlite profile) and confirmed the compiled server bundle contains the new codes and strings.

## Manual verification notes

- 429 path: lower `RATE_LIMIT_AUTH` or exhaust the default 5/15-min window, then attempt another login — UI shows the new rate-limit message with a minutes-remaining figure.
- CSRF path: log in, then `docker restart meshmonitor-sqlite` to wipe the in-memory session store while keeping the browser's cookie/sessionStorage, then attempt to log in again — UI shows the new session-expired message instead of the cookie/proxy template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)