### PR TITLE
feat(security): add IFRAME_ALLOWED_ORIGINS env var (#2788)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,26 @@ MESHTASTIC_TCP_PORT=4403
 # For production deployments, it's best practice to explicitly set this value
 ALLOWED_ORIGINS=http://localhost:8080
 
+# Iframe Embedding Configuration
+# IFRAME_ALLOWED_ORIGINS: Comma-separated list of origins allowed to embed
+# MeshMonitor in an <iframe>. By default MeshMonitor sends X-Frame-Options: DENY,
+# which blocks all iframe embedding.
+#
+# Set this to allow embedding in e.g. a Node-RED dashboard, Home Assistant panel,
+# or internal portal. When set, X-Frame-Options is dropped and CSP frame-ancestors
+# is used instead.
+#
+# Single origin (Node-RED dashboard):
+#   IFRAME_ALLOWED_ORIGINS=http://192.168.1.50:1880
+#
+# Multiple origins:
+#   IFRAME_ALLOWED_ORIGINS=http://192.168.1.50:1880,https://portal.example.com
+#
+# Any origin (NOT recommended for production):
+#   IFRAME_ALLOWED_ORIGINS=*
+#
+# IFRAME_ALLOWED_ORIGINS=
+
 # Web Push Notification Configuration (VAPID keys)
 # Generate keys by running: node generate-vapid-keys.js
 # VAPID_PUBLIC_KEY=your-public-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ test-results.txt
 
 # Git worktrees
 .worktrees/
+
+# Scratch/local-only test harnesses
+scratch/

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -100,6 +100,21 @@ See the [Virtual Node Server guide](/configuration/virtual-node) for details.
 | `SESSION_MAX_AGE` | Session cookie lifetime in milliseconds | `86400000` (24 hours) |
 | `SESSION_ROLLING` | Reset session expiry on each request (keeps active users logged in) | `true` |
 | `ALLOWED_ORIGINS` | **REQUIRED for HTTPS/reverse proxy**: Comma-separated list of allowed CORS origins | `http://localhost:8080, http://localhost:3001` |
+| `IFRAME_ALLOWED_ORIGINS` | Comma-separated list of origins allowed to embed MeshMonitor in an `<iframe>` (e.g. a Node-RED dashboard). Use `*` to allow any origin. When unset, iframe embedding is blocked. | *(unset - iframe blocked)* |
+
+::: tip Embedding MeshMonitor in an iframe
+By default MeshMonitor sends `X-Frame-Options: DENY`, which blocks browsers from rendering it inside an `<iframe>`. To embed MeshMonitor in another page (for example a Node-RED dashboard, Home Assistant panel, or internal portal), set `IFRAME_ALLOWED_ORIGINS` to the origin(s) that will host the frame:
+```yaml
+environment:
+  # Allow a single Node-RED dashboard
+  - IFRAME_ALLOWED_ORIGINS=http://192.168.1.50:1880
+  # Or multiple origins
+  - IFRAME_ALLOWED_ORIGINS=http://192.168.1.50:1880,https://portal.example.com
+  # Or any origin (not recommended for production)
+  - IFRAME_ALLOWED_ORIGINS=*
+```
+When set, MeshMonitor drops the `X-Frame-Options` header and enforces the same policy via CSP `frame-ancestors`. Only origins in the list (plus the server's own origin) can embed the UI.
+:::
 
 ::: tip Running Multiple Instances
 If you're running multiple MeshMonitor instances on the same host (different ports), set `SESSION_COOKIE_NAME` to a unique value for each instance to avoid session cookie conflicts:

--- a/src/server/config/environment.iframeAllowedOrigins.test.ts
+++ b/src/server/config/environment.iframeAllowedOrigins.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for IFRAME_ALLOWED_ORIGINS configuration
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { loadEnvironmentConfig, resetEnvironmentConfig } from './environment.js';
+
+describe('Environment Configuration - IFRAME_ALLOWED_ORIGINS', () => {
+  const originalValue = process.env.IFRAME_ALLOWED_ORIGINS;
+
+  beforeEach(() => {
+    resetEnvironmentConfig();
+  });
+
+  afterEach(() => {
+    if (originalValue !== undefined) {
+      process.env.IFRAME_ALLOWED_ORIGINS = originalValue;
+    } else {
+      delete process.env.IFRAME_ALLOWED_ORIGINS;
+    }
+    resetEnvironmentConfig();
+  });
+
+  it('defaults to empty array when IFRAME_ALLOWED_ORIGINS is not set', () => {
+    delete process.env.IFRAME_ALLOWED_ORIGINS;
+    const config = loadEnvironmentConfig();
+
+    expect(config.iframeAllowedOrigins).toEqual([]);
+    expect(config.iframeAllowedOriginsProvided).toBe(false);
+  });
+
+  it('parses a single origin', () => {
+    process.env.IFRAME_ALLOWED_ORIGINS = 'http://192.168.1.50:1880';
+    const config = loadEnvironmentConfig();
+
+    expect(config.iframeAllowedOrigins).toEqual(['http://192.168.1.50:1880']);
+    expect(config.iframeAllowedOriginsProvided).toBe(true);
+  });
+
+  it('parses a comma-separated list of origins', () => {
+    process.env.IFRAME_ALLOWED_ORIGINS = 'http://a.example,https://b.example';
+    const config = loadEnvironmentConfig();
+
+    expect(config.iframeAllowedOrigins).toEqual([
+      'http://a.example',
+      'https://b.example',
+    ]);
+  });
+
+  it('trims whitespace and drops empty entries', () => {
+    process.env.IFRAME_ALLOWED_ORIGINS = ' http://a.example , , https://b.example ';
+    const config = loadEnvironmentConfig();
+
+    expect(config.iframeAllowedOrigins).toEqual([
+      'http://a.example',
+      'https://b.example',
+    ]);
+  });
+
+  it('accepts a wildcard origin', () => {
+    process.env.IFRAME_ALLOWED_ORIGINS = '*';
+    const config = loadEnvironmentConfig();
+
+    expect(config.iframeAllowedOrigins).toEqual(['*']);
+  });
+
+  it('treats an empty string as "provided" but empty list', () => {
+    process.env.IFRAME_ALLOWED_ORIGINS = '';
+    const config = loadEnvironmentConfig();
+
+    expect(config.iframeAllowedOrigins).toEqual([]);
+    expect(config.iframeAllowedOriginsProvided).toBe(true);
+  });
+});

--- a/src/server/config/environment.ts
+++ b/src/server/config/environment.ts
@@ -174,6 +174,8 @@ export interface EnvironmentConfig {
   baseUrlProvided: boolean;
   allowedOrigins: string[];
   allowedOriginsProvided: boolean;
+  iframeAllowedOrigins: string[];
+  iframeAllowedOriginsProvided: boolean;
   trustProxy: boolean | number | string;
   trustProxyProvided: boolean;
   versionCheckDisabled: boolean;
@@ -353,6 +355,13 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
       ? allowedOriginsRaw.split(',').map(o => o.trim()).filter(o => o.length > 0)
       : ['http://localhost:8080', 'http://localhost:3001'],
     wasProvided: allowedOriginsRaw !== undefined
+  };
+  const iframeAllowedOriginsRaw = process.env.IFRAME_ALLOWED_ORIGINS;
+  const iframeAllowedOrigins = {
+    value: iframeAllowedOriginsRaw
+      ? iframeAllowedOriginsRaw.split(',').map(o => o.trim()).filter(o => o.length > 0)
+      : [],
+    wasProvided: iframeAllowedOriginsRaw !== undefined
   };
   const trustProxy = parseTrustProxy('TRUST_PROXY', process.env.TRUST_PROXY, false);
 
@@ -643,6 +652,7 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
   logger.info(`   LOG_LEVEL: ${logLevel.value} (${src(logLevel.wasProvided)})`);
   logger.info(`   TZ: ${timezone.value} (${src(timezone.wasProvided)})`);
   logger.info(`   ALLOWED_ORIGINS: ${allowedOrigins.value || '*'} (${src(allowedOrigins.wasProvided)})`);
+  logger.info(`   IFRAME_ALLOWED_ORIGINS: ${iframeAllowedOrigins.value.length > 0 ? iframeAllowedOrigins.value.join(',') : '(not set - iframe embedding blocked)'} (${src(iframeAllowedOrigins.wasProvided)})`);
   logger.info(`   TRUST_PROXY: ${trustProxy.value} (${src(trustProxy.wasProvided)})`);
   logger.info(`   VERSION_CHECK_DISABLED: ${versionCheckDisabled}`);
   logger.info('   --- Session/Security ---');
@@ -721,6 +731,8 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
     baseUrlProvided,
     allowedOrigins: allowedOrigins.value,
     allowedOriginsProvided: allowedOrigins.wasProvided,
+    iframeAllowedOrigins: iframeAllowedOrigins.value,
+    iframeAllowedOriginsProvided: iframeAllowedOrigins.wasProvided,
     trustProxy: trustProxy.value,
     trustProxyProvided: trustProxy.wasProvided,
     versionCheckDisabled: versionCheckDisabled,

--- a/src/server/middleware/dynamicCsp.test.ts
+++ b/src/server/middleware/dynamicCsp.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for dynamic CSP header construction, focused on the
+ * `frame-ancestors` directive driven by IFRAME_ALLOWED_ORIGINS.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+    },
+  },
+}));
+
+import { buildCspHeader } from './dynamicCsp.js';
+
+function directivesFromHeader(header: string): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const part of header.split(';')) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const spaceIdx = trimmed.indexOf(' ');
+    if (spaceIdx === -1) {
+      map[trimmed] = '';
+    } else {
+      map[trimmed.slice(0, spaceIdx)] = trimmed.slice(spaceIdx + 1);
+    }
+  }
+  return map;
+}
+
+describe('buildCspHeader - frame-ancestors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('omits frame-ancestors when iframeAllowedOrigins is empty', async () => {
+    const header = await buildCspHeader(true, true, []);
+    const directives = directivesFromHeader(header);
+
+    expect(directives['frame-ancestors']).toBeUndefined();
+  });
+
+  it('omits frame-ancestors when iframeAllowedOrigins is not provided', async () => {
+    const header = await buildCspHeader(true, true);
+    const directives = directivesFromHeader(header);
+
+    expect(directives['frame-ancestors']).toBeUndefined();
+  });
+
+  it('sets frame-ancestors with self + origins when list is provided', async () => {
+    const header = await buildCspHeader(true, true, [
+      'http://192.168.1.50:1880',
+      'https://nodered.example.com',
+    ]);
+    const directives = directivesFromHeader(header);
+
+    expect(directives['frame-ancestors']).toBe(
+      "'self' http://192.168.1.50:1880 https://nodered.example.com"
+    );
+  });
+
+  it('collapses to wildcard when "*" is in the list', async () => {
+    const header = await buildCspHeader(true, true, ['*']);
+    const directives = directivesFromHeader(header);
+
+    expect(directives['frame-ancestors']).toBe('*');
+  });
+
+  it('collapses to wildcard even when "*" is mixed with specific origins', async () => {
+    const header = await buildCspHeader(true, true, ['http://a.example', '*']);
+    const directives = directivesFromHeader(header);
+
+    expect(directives['frame-ancestors']).toBe('*');
+  });
+
+  it('does not touch frame-src when iframeAllowedOrigins is set', async () => {
+    // frame-src controls what WE embed, unrelated to who can embed us.
+    const header = await buildCspHeader(true, true, ['http://a.example']);
+    const directives = directivesFromHeader(header);
+
+    expect(directives['frame-src']).toBe("'none'");
+  });
+});

--- a/src/server/middleware/dynamicCsp.ts
+++ b/src/server/middleware/dynamicCsp.ts
@@ -136,7 +136,11 @@ async function getAnalyticsCspFromSettings(): Promise<{ scriptSrc: string[]; con
 /**
  * Build the full CSP header value
  */
-export async function buildCspHeader(isProduction: boolean, cookieSecure: boolean): Promise<string> {
+export async function buildCspHeader(
+  isProduction: boolean,
+  cookieSecure: boolean,
+  iframeAllowedOrigins: string[] = []
+): Promise<string> {
   const connectSrc = await buildConnectSrcDirective(isProduction, cookieSecure);
   const analyticsCsp = await getAnalyticsCspFromSettings();
 
@@ -178,6 +182,13 @@ export async function buildCspHeader(isProduction: boolean, cookieSecure: boolea
     'form-action': ["'self'"],
   };
 
+  if (iframeAllowedOrigins.length > 0) {
+    const hasWildcard = iframeAllowedOrigins.includes('*');
+    directives['frame-ancestors'] = hasWildcard
+      ? ['*']
+      : ["'self'", ...iframeAllowedOrigins];
+  }
+
   return Object.entries(directives)
     .map(([key, values]) => `${key} ${values.join(' ')}`)
     .join('; ');
@@ -187,7 +198,11 @@ export async function buildCspHeader(isProduction: boolean, cookieSecure: boolea
  * Middleware to set dynamic CSP header
  * This replaces helmet's static CSP with a dynamic one that includes custom tile servers
  */
-export function dynamicCspMiddleware(isProduction: boolean, cookieSecure: boolean) {
+export function dynamicCspMiddleware(
+  isProduction: boolean,
+  cookieSecure: boolean,
+  iframeAllowedOrigins: string[] = []
+) {
   // Initialize cache on first call (fire-and-forget)
   if (cacheTimestamp === 0) {
     refreshTileHostnameCache().catch(err =>
@@ -197,7 +212,7 @@ export function dynamicCspMiddleware(isProduction: boolean, cookieSecure: boolea
 
   return async (_req: Request, res: Response, next: NextFunction) => {
     try {
-      const cspHeader = await buildCspHeader(isProduction, cookieSecure);
+      const cspHeader = await buildCspHeader(isProduction, cookieSecure, iframeAllowedOrigins);
       res.setHeader('Content-Security-Policy', cspHeader);
       next();
     } catch (error) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -162,6 +162,13 @@ if (env.trustProxyProvided) {
 // For Quick Start: default to HTTP-friendly (no HSTS) even in production
 // Only enable HSTS when COOKIE_SECURE explicitly set to 'true'
 // CSP is handled dynamically by dynamicCspMiddleware to support custom tile servers
+// frameguard (X-Frame-Options) is disabled when IFRAME_ALLOWED_ORIGINS is set;
+// iframe embedding policy is then enforced via CSP frame-ancestors instead.
+const iframeEmbeddingEnabled = env.iframeAllowedOrigins.length > 0;
+const frameguardConfig = iframeEmbeddingEnabled
+  ? false as const
+  : { action: 'deny' as const };
+
 const helmetConfig =
   env.isProduction && env.cookieSecure
     ? {
@@ -171,9 +178,7 @@ const helmetConfig =
           includeSubDomains: true,
           preload: true,
         },
-        frameguard: {
-          action: 'deny' as const,
-        },
+        frameguard: frameguardConfig,
         noSniff: true,
         xssFilter: true,
         // Send origin as Referer for cross-origin requests (e.g. map tile fetches).
@@ -185,9 +190,7 @@ const helmetConfig =
         contentSecurityPolicy: false, // Handled by dynamicCspMiddleware
         hsts: false, // Disable HSTS when not using secure cookies or in development
         crossOriginOpenerPolicy: false, // Disable COOP for HTTP - browser ignores it on non-HTTPS anyway
-        frameguard: {
-          action: 'deny' as const,
-        },
+        frameguard: frameguardConfig,
         noSniff: true,
         xssFilter: true,
         referrerPolicy: { policy: 'strict-origin-when-cross-origin' as const },
@@ -195,8 +198,9 @@ const helmetConfig =
 
 app.use(helmet(helmetConfig));
 
-// Dynamic CSP middleware - adds custom tile server hostnames from database
-app.use(dynamicCspMiddleware(env.isProduction, env.cookieSecure));
+// Dynamic CSP middleware - adds custom tile server hostnames from database,
+// and sets frame-ancestors from IFRAME_ALLOWED_ORIGINS when configured.
+app.use(dynamicCspMiddleware(env.isProduction, env.cookieSecure, env.iframeAllowedOrigins));
 
 // Security: CORS configuration with allowed origins
 const getAllowedOrigins = () => {


### PR DESCRIPTION
## Summary
- Closes #2788 — adds `IFRAME_ALLOWED_ORIGINS` env var that lets users embed MeshMonitor in an `<iframe>` (Node-RED dashboards, Home Assistant panels, internal portals, etc.).
- When unset, existing behavior is preserved: `X-Frame-Options: DENY`, no CSP `frame-ancestors`.
- When set, `X-Frame-Options` is dropped and the policy is enforced via CSP `frame-ancestors` scoped to the listed origins (or `*` for any).

## Changes
- `src/server/config/environment.ts` — parses `IFRAME_ALLOWED_ORIGINS` (comma-separated, `*` wildcard supported), exposes `iframeAllowedOrigins[]` + `iframeAllowedOriginsProvided` on the config.
- `src/server/server.ts` — disables Helmet `frameguard` when iframe origins are set; passes origins to `dynamicCspMiddleware`.
- `src/server/middleware/dynamicCsp.ts` — `buildCspHeader` / `dynamicCspMiddleware` now accept `iframeAllowedOrigins` and emit `frame-ancestors` accordingly. `*` in the list collapses to wildcard; otherwise `'self'` + the listed origins.
- `.env.example` and `docs/configuration/index.md` — documented the new variable with examples.
- `.gitignore` — ignore scratch/ (local test harness dir, not committed).

## Tests
- `src/server/config/environment.iframeAllowedOrigins.test.ts` — 6 tests: default-empty, single origin, comma list, whitespace handling, wildcard, "provided but empty".
- `src/server/middleware/dynamicCsp.test.ts` — 6 tests: directive omitted when empty/unprovided, `'self'` + listed origins, wildcard, wildcard-wins-when-mixed, `frame-src` untouched.
- All 104 tests in `src/server/config/` + `src/server/middleware/` pass.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/server/config/ src/server/middleware/` — 104 pass
- [x] Lint on modified files — no new errors (1 pre-existing unused-var error in environment.ts:502 is unchanged by this PR)
- [x] Manual: deployed dev container with `IFRAME_ALLOWED_ORIGINS=http://localhost:8090`, loaded a sibling page that embeds `http://localhost:8081/meshmonitor/` in an `<iframe>`, confirmed it renders (would have been blocked by `X-Frame-Options: DENY` previously). Startup log confirms env var is read.
- [ ] CI green

## Notes
Because the iframe parent and MeshMonitor are typically on different origins, session cookies need `COOKIE_SAMESITE=none` + HTTPS + `COOKIE_SECURE=true` to flow through the frame. That's an orthogonal concern and the existing settings still govern it — this PR only unblocks the rendering-level X-Frame-Options / CSP gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)