### PR TITLE
feat(ignored-nodes): make ignore list per-source

### DIFF
--- a/src/components/IgnoredNodesSection.tsx
+++ b/src/components/IgnoredNodesSection.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useToast } from './ToastContainer';
 import { useCsrfFetch } from '../hooks/useCsrfFetch';
+import { useSource } from '../contexts/SourceContext';
 
 interface IgnoredNodesSectionProps {
   baseUrl: string;
@@ -9,6 +10,7 @@ interface IgnoredNodesSectionProps {
 
 interface IgnoredNode {
   nodeNum: number;
+  sourceId: string;
   nodeId: string;
   longName: string | null;
   shortName: string | null;
@@ -20,14 +22,20 @@ const IgnoredNodesSection: React.FC<IgnoredNodesSectionProps> = ({ baseUrl }) =>
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { showToast } = useToast();
+  // sourceId is optional — when null/undefined the backend falls back to the
+  // caller's first permitted source. Explicit per-source lists live under this
+  // section once a source is active in <SourceProvider>.
+  const { sourceId: currentSourceId } = useSource();
 
   const [ignoredNodes, setIgnoredNodes] = useState<IgnoredNode[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [removingNodeNum, setRemovingNodeNum] = useState<number | null>(null);
 
+  const sourceQuery = currentSourceId ? `?sourceId=${encodeURIComponent(currentSourceId)}` : '';
+
   const fetchIgnoredNodes = useCallback(async () => {
     try {
-      const response = await csrfFetch(`${baseUrl}/api/ignored-nodes`);
+      const response = await csrfFetch(`${baseUrl}/api/ignored-nodes${sourceQuery}`);
       if (response.ok) {
         const data = await response.json();
         setIgnoredNodes(data);
@@ -37,7 +45,7 @@ const IgnoredNodesSection: React.FC<IgnoredNodesSectionProps> = ({ baseUrl }) =>
     } finally {
       setIsLoading(false);
     }
-  }, [baseUrl, csrfFetch]);
+  }, [baseUrl, csrfFetch, sourceQuery]);
 
   useEffect(() => {
     fetchIgnoredNodes();
@@ -46,7 +54,11 @@ const IgnoredNodesSection: React.FC<IgnoredNodesSectionProps> = ({ baseUrl }) =>
   const handleRemove = async (node: IgnoredNode) => {
     setRemovingNodeNum(node.nodeNum);
     try {
-      const response = await csrfFetch(`${baseUrl}/api/ignored-nodes/${node.nodeId}`, {
+      // Always target the row's own source — an aggregated list may mix rows
+      // from different sources, and we must not collapse that back to the
+      // "active" source on delete.
+      const deleteQuery = `?sourceId=${encodeURIComponent(node.sourceId)}`;
+      const response = await csrfFetch(`${baseUrl}/api/ignored-nodes/${node.nodeId}${deleteQuery}`, {
         method: 'DELETE',
       });
 

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 47 migrations registered', () => {
-    expect(registry.count()).toBe(47);
+  it('has all 48 migrations registered', () => {
+    expect(registry.count()).toBe(48);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,14 +12,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_selected_layer_to_user_map_preferences', () => {
+  it('last migration is rebuild_ignored_nodes_per_source', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(47);
-    expect(last.name).toContain('add_selected_layer_to_user_map_preferences');
+    expect(last.number).toBe(48);
+    expect(last.name).toContain('rebuild_ignored_nodes_per_source');
   });
 
-  it('migrations are sequentially numbered from 1 to 47', () => {
+  it('migrations are sequentially numbered from 1 to 48', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -59,6 +59,7 @@ import { migration as dropLegacyTraceroutesFkMigration, runMigration044Postgres,
 import { migration as dropLegacyRouteSegmentsFkMigration, runMigration045Postgres, runMigration045Mysql } from '../server/migrations/045_drop_legacy_route_segments_nodes_fk.js';
 import { migration as addUserMapPrefsIdSqliteMigration, runMigration046Postgres, runMigration046Mysql } from '../server/migrations/046_add_user_map_preferences_id_sqlite.js';
 import { migration as addSelectedLayerMigration, runMigration047Postgres, runMigration047Mysql } from '../server/migrations/047_add_selected_layer_to_user_map_preferences.js';
+import { migration as rebuildIgnoredNodesPerSourceMigration, runMigration048Postgres, runMigration048Mysql } from '../server/migrations/048_rebuild_ignored_nodes_per_source.js';
 
 // ============================================================================
 // Registry
@@ -729,4 +730,19 @@ registry.register({
   sqlite: (db) => addSelectedLayerMigration.up(db),
   postgres: (client) => runMigration047Postgres(client),
   mysql: (pool) => runMigration047Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 048: Rebuild ignored_nodes as per-source ((nodeNum, sourceId) PK
+// with FK to sources ON DELETE CASCADE). Drops the legacy global table and
+// backfills from nodes.isIgnored=1 so each source owns its own blocklist.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 48,
+  name: 'rebuild_ignored_nodes_per_source',
+  settingsKey: 'migration_048_rebuild_ignored_nodes_per_source',
+  sqlite: (db) => rebuildIgnoredNodesPerSourceMigration.up(db),
+  postgres: (client) => runMigration048Postgres(client),
+  mysql: (pool) => runMigration048Mysql(pool),
 });

--- a/src/db/repositories/ignoredNodes.test.ts
+++ b/src/db/repositories/ignoredNodes.test.ts
@@ -7,6 +7,11 @@
  * SQLite: always runs (in-memory)
  * PostgreSQL: requires test container on port 5433 (skipped if unavailable)
  * MySQL: requires test container on port 3307 (skipped if unavailable)
+ *
+ * Migration 048: the table is now per-source with composite PK (nodeNum, sourceId).
+ * The FK to sources(id) is enforced by the migration but intentionally omitted
+ * from the test CREATEs — these tests isolate repository semantics from the
+ * sources lifecycle.
  */
 import { describe, it, expect, beforeEach, afterEach, afterAll, beforeAll } from 'vitest';
 import * as schema from '../schema/index.js';
@@ -21,42 +26,47 @@ import {
   mysqlAvailable,
 } from './test-utils.js';
 
-// SQL for creating the ignored_nodes table per backend
+const SRC_A = 'source-a';
+const SRC_B = 'source-b';
+
 const SQLITE_CREATE = `
   CREATE TABLE IF NOT EXISTS ignored_nodes (
-    nodeNum INTEGER PRIMARY KEY,
+    nodeNum INTEGER NOT NULL,
+    sourceId TEXT NOT NULL,
     nodeId TEXT NOT NULL,
     longName TEXT,
     shortName TEXT,
     ignoredBy TEXT,
     ignoredAt INTEGER NOT NULL,
-    sourceId TEXT
+    PRIMARY KEY (nodeNum, sourceId)
   )
 `;
 
 const POSTGRES_CREATE = `
   DROP TABLE IF EXISTS ignored_nodes CASCADE;
   CREATE TABLE ignored_nodes (
-    "nodeNum" BIGINT PRIMARY KEY,
+    "nodeNum" BIGINT NOT NULL,
+    "sourceId" TEXT NOT NULL,
     "nodeId" TEXT NOT NULL,
     "longName" TEXT,
     "shortName" TEXT,
     "ignoredBy" TEXT,
     "ignoredAt" BIGINT NOT NULL,
-    "sourceId" TEXT
+    PRIMARY KEY ("nodeNum", "sourceId")
   )
 `;
 
 const MYSQL_CREATE = `
   DROP TABLE IF EXISTS ignored_nodes;
   CREATE TABLE ignored_nodes (
-    \`nodeNum\` BIGINT PRIMARY KEY,
+    \`nodeNum\` BIGINT NOT NULL,
+    \`sourceId\` VARCHAR(36) NOT NULL,
     \`nodeId\` VARCHAR(255) NOT NULL,
-    \`longName\` TEXT,
-    \`shortName\` TEXT,
-    \`ignoredBy\` TEXT,
+    \`longName\` VARCHAR(255),
+    \`shortName\` VARCHAR(255),
+    \`ignoredBy\` VARCHAR(255),
     \`ignoredAt\` BIGINT NOT NULL,
-    \`sourceId\` VARCHAR(36)
+    PRIMARY KEY (\`nodeNum\`, \`sourceId\`)
   )
 `;
 
@@ -80,11 +90,12 @@ function runIgnoredNodesTests(getBackend: () => TestBackend) {
       return;
     }
 
-    await repo.addIgnoredNodeAsync(12345, '!abcd1234', 'Test Node', 'TN', 'admin');
+    await repo.addIgnoredNodeAsync(12345, SRC_A, '!abcd1234', 'Test Node', 'TN', 'admin');
 
-    const nodes = await repo.getIgnoredNodesAsync();
+    const nodes = await repo.getIgnoredNodesAsync(SRC_A);
     expect(nodes).toHaveLength(1);
     expect(nodes[0].nodeNum).toBe(12345);
+    expect(nodes[0].sourceId).toBe(SRC_A);
     expect(nodes[0].nodeId).toBe('!abcd1234');
     expect(nodes[0].longName).toBe('Test Node');
     expect(nodes[0].shortName).toBe('TN');
@@ -92,17 +103,17 @@ function runIgnoredNodesTests(getBackend: () => TestBackend) {
     expect(nodes[0].ignoredAt).toBeGreaterThan(0);
   });
 
-  it('addIgnoredNodeAsync - upsert behavior (add same node twice)', async () => {
+  it('addIgnoredNodeAsync - upsert behavior on same (nodeNum, sourceId)', async () => {
     const backend = getBackend();
     if (!backend.available) {
       console.log(`⚠ Skipped: ${backend.skipReason}`);
       return;
     }
 
-    await repo.addIgnoredNodeAsync(12345, '!abcd1234', 'Original Name', 'ON', 'user1');
-    await repo.addIgnoredNodeAsync(12345, '!abcd1234', 'Updated Name', 'UN', 'user2');
+    await repo.addIgnoredNodeAsync(12345, SRC_A, '!abcd1234', 'Original Name', 'ON', 'user1');
+    await repo.addIgnoredNodeAsync(12345, SRC_A, '!abcd1234', 'Updated Name', 'UN', 'user2');
 
-    const nodes = await repo.getIgnoredNodesAsync();
+    const nodes = await repo.getIgnoredNodesAsync(SRC_A);
     expect(nodes).toHaveLength(1);
     expect(nodes[0].nodeNum).toBe(12345);
     expect(nodes[0].longName).toBe('Updated Name');
@@ -110,72 +121,115 @@ function runIgnoredNodesTests(getBackend: () => TestBackend) {
     expect(nodes[0].ignoredBy).toBe('user2');
   });
 
-  it('removeIgnoredNodeAsync - remove existing node', async () => {
+  it('addIgnoredNodeAsync - same nodeNum on different sources creates two rows', async () => {
     const backend = getBackend();
     if (!backend.available) {
       console.log(`⚠ Skipped: ${backend.skipReason}`);
       return;
     }
 
-    await repo.addIgnoredNodeAsync(12345, '!abcd1234', 'Test Node', 'TN', 'admin');
-    await repo.addIgnoredNodeAsync(67890, '!efgh5678', 'Other Node', 'OT', 'admin');
+    await repo.addIgnoredNodeAsync(12345, SRC_A, '!abcd1234', 'On A', 'A', 'admin');
+    await repo.addIgnoredNodeAsync(12345, SRC_B, '!abcd1234', 'On B', 'B', 'admin');
 
-    await repo.removeIgnoredNodeAsync(12345);
+    expect(await repo.isNodeIgnoredAsync(12345, SRC_A)).toBe(true);
+    expect(await repo.isNodeIgnoredAsync(12345, SRC_B)).toBe(true);
+
+    const onA = await repo.getIgnoredNodesAsync(SRC_A);
+    expect(onA).toHaveLength(1);
+    expect(onA[0].longName).toBe('On A');
+
+    const all = await repo.getIgnoredNodesAsync();
+    expect(all).toHaveLength(2);
+  });
+
+  it('removeIgnoredNodeAsync - scoped to source', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.addIgnoredNodeAsync(12345, SRC_A, '!abcd1234', 'On A', 'A', 'admin');
+    await repo.addIgnoredNodeAsync(12345, SRC_B, '!abcd1234', 'On B', 'B', 'admin');
+
+    await repo.removeIgnoredNodeAsync(12345, SRC_A);
+
+    expect(await repo.isNodeIgnoredAsync(12345, SRC_A)).toBe(false);
+    expect(await repo.isNodeIgnoredAsync(12345, SRC_B)).toBe(true);
+
+    const all = await repo.getIgnoredNodesAsync();
+    expect(all).toHaveLength(1);
+    expect(all[0].sourceId).toBe(SRC_B);
+  });
+
+  it('removeIgnoredNodeAsync - no-op for nonexistent (nodeNum, sourceId)', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.addIgnoredNodeAsync(12345, SRC_A, '!abcd1234', 'Test Node', 'TN', 'admin');
+
+    await repo.removeIgnoredNodeAsync(99999, SRC_A);
+    await repo.removeIgnoredNodeAsync(12345, SRC_B);
 
     const nodes = await repo.getIgnoredNodesAsync();
     expect(nodes).toHaveLength(1);
-    expect(nodes[0].nodeNum).toBe(67890);
   });
 
-  it('removeIgnoredNodeAsync - no-op for nonexistent node', async () => {
+  it('getIgnoredNodesAsync - returns all rows when no sourceId filter', async () => {
     const backend = getBackend();
     if (!backend.available) {
       console.log(`⚠ Skipped: ${backend.skipReason}`);
       return;
     }
 
-    await repo.addIgnoredNodeAsync(12345, '!abcd1234', 'Test Node', 'TN', 'admin');
+    expect(await repo.getIgnoredNodesAsync()).toHaveLength(0);
 
-    // Should not throw
-    await repo.removeIgnoredNodeAsync(99999);
+    await repo.addIgnoredNodeAsync(11111, SRC_A, '!node1', 'Node One', 'N1', 'admin');
+    await repo.addIgnoredNodeAsync(22222, SRC_A, '!node2', 'Node Two', 'N2', 'admin');
+    await repo.addIgnoredNodeAsync(33333, SRC_B, '!node3', 'Node Three', 'N3', null);
 
-    const nodes = await repo.getIgnoredNodesAsync();
-    expect(nodes).toHaveLength(1);
+    const all = await repo.getIgnoredNodesAsync();
+    expect(all).toHaveLength(3);
   });
 
-  it('getIgnoredNodesAsync - list all ignored nodes', async () => {
+  it('getIgnoredNodesAsync - filters by sourceId when provided', async () => {
     const backend = getBackend();
     if (!backend.available) {
       console.log(`⚠ Skipped: ${backend.skipReason}`);
       return;
     }
 
-    // Empty initially
-    const empty = await repo.getIgnoredNodesAsync();
-    expect(empty).toHaveLength(0);
+    await repo.addIgnoredNodeAsync(11111, SRC_A, '!node1', 'Node One', 'N1', 'admin');
+    await repo.addIgnoredNodeAsync(22222, SRC_A, '!node2', 'Node Two', 'N2', 'admin');
+    await repo.addIgnoredNodeAsync(33333, SRC_B, '!node3', 'Node Three', 'N3', null);
 
-    await repo.addIgnoredNodeAsync(11111, '!node1', 'Node One', 'N1', 'admin');
-    await repo.addIgnoredNodeAsync(22222, '!node2', 'Node Two', 'N2', 'admin');
-    await repo.addIgnoredNodeAsync(33333, '!node3', 'Node Three', 'N3', null);
+    const onA = await repo.getIgnoredNodesAsync(SRC_A);
+    expect(onA.map(n => n.nodeNum).sort()).toEqual([11111, 22222]);
 
-    const nodes = await repo.getIgnoredNodesAsync();
-    expect(nodes).toHaveLength(3);
+    const onB = await repo.getIgnoredNodesAsync(SRC_B);
+    expect(onB.map(n => n.nodeNum).sort()).toEqual([33333]);
 
-    const nodeNums = nodes.map(n => n.nodeNum).sort();
-    expect(nodeNums).toEqual([11111, 22222, 33333]);
+    const unknown = await repo.getIgnoredNodesAsync('nonexistent-source');
+    expect(unknown).toHaveLength(0);
   });
 
-  it('isNodeIgnoredAsync - true for ignored, false for not', async () => {
+  it('isNodeIgnoredAsync - per-source truthiness', async () => {
     const backend = getBackend();
     if (!backend.available) {
       console.log(`⚠ Skipped: ${backend.skipReason}`);
       return;
     }
 
-    await repo.addIgnoredNodeAsync(12345, '!abcd1234', 'Test Node', 'TN', 'admin');
+    await repo.addIgnoredNodeAsync(12345, SRC_A, '!abcd1234', 'Test Node', 'TN', 'admin');
 
-    expect(await repo.isNodeIgnoredAsync(12345)).toBe(true);
-    expect(await repo.isNodeIgnoredAsync(99999)).toBe(false);
+    expect(await repo.isNodeIgnoredAsync(12345, SRC_A)).toBe(true);
+    // Same nodeNum but different source — false. This is the new per-source
+    // semantic that migration 048 introduced.
+    expect(await repo.isNodeIgnoredAsync(12345, SRC_B)).toBe(false);
+    expect(await repo.isNodeIgnoredAsync(99999, SRC_A)).toBe(false);
   });
 
   it('addIgnoredNodeAsync - handles null optional fields', async () => {
@@ -185,9 +239,9 @@ function runIgnoredNodesTests(getBackend: () => TestBackend) {
       return;
     }
 
-    await repo.addIgnoredNodeAsync(12345, '!abcd1234');
+    await repo.addIgnoredNodeAsync(12345, SRC_A, '!abcd1234');
 
-    const nodes = await repo.getIgnoredNodesAsync();
+    const nodes = await repo.getIgnoredNodesAsync(SRC_A);
     expect(nodes).toHaveLength(1);
     expect(nodes[0].longName).toBeNull();
     expect(nodes[0].shortName).toBeNull();
@@ -263,3 +317,7 @@ describe.skipIf(!mysqlAvailable)('IgnoredNodesRepository - MySQL Backend', () =>
 
   runIgnoredNodesTests(() => backend);
 });
+
+// Re-export schema as a no-op reference so the import isn't dead if test-utils
+// ever evolves to consume it.
+void schema;

--- a/src/db/repositories/ignoredNodes.ts
+++ b/src/db/repositories/ignoredNodes.ts
@@ -1,34 +1,31 @@
 /**
  * Ignored Nodes Repository
  *
- * Handles persistence of node ignored status independently of the nodes table.
- * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
+ * Handles persistence of node ignored status per source. Supports SQLite,
+ * PostgreSQL, and MySQL through Drizzle ORM.
  *
- * **IMPORTANT — scoping model**
+ * **Scoping model (migration 048)**
  *
- * The `ignored_nodes` table is intentionally GLOBAL, not per-source. Ignoring a
- * node hides it across every source the user has access to. The rationale:
- * node identity (nodeNum) is globally unique on the mesh, so a spammer or
- * misbehaving device should be silenced regardless of which transport surfaced
- * them.
+ * The `ignored_nodes` table is PER-SOURCE. Keyed on composite `(nodeNum,
+ * sourceId)`, with `sourceId` as a foreign key to `sources(id)` ON DELETE
+ * CASCADE. Each source has its own independent blocklist. Ignoring a node on
+ * source A does NOT affect the same nodeNum's state on source B. This matches
+ * the per-source node identity model introduced by migration 029.
  *
- * The `sourceId` column on this table is informational only — it records which
- * source first flagged the node. The upsert conflict target is `nodeNum` alone,
- * so re-ignoring the same node from a different source updates the existing row
- * in place and does NOT create a second record. Callers must treat lookup,
- * removal, and iteration as global operations.
- *
- * When a node is un-ignored via the API, `server.ts` sweeps every source's
- * `nodes` row for that nodeNum to clear per-source ignore flags — see the
- * `DELETE /api/ignored-nodes/:nodeId` handler for the full pattern.
+ * The table persists ignored status independently of `nodes.isIgnored` so
+ * that when a node is pruned by `cleanupInactiveNodes` on a given source and
+ * later reappears on THAT SAME source, its ignored flag is restored. Cross-
+ * source propagation is intentionally absent — callers that want to ignore a
+ * node on every source must iterate sources themselves.
  */
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
 export interface IgnoredNodeRecord {
   nodeNum: number;
+  sourceId: string;
   nodeId: string;
   longName: string | null;
   shortName: string | null;
@@ -37,7 +34,9 @@ export interface IgnoredNodeRecord {
 }
 
 /**
- * Repository for ignored nodes operations
+ * Repository for ignored nodes operations. All lookup/mutation methods are
+ * scoped to a `sourceId`, matching the per-source PK introduced by
+ * migration 048.
  */
 export class IgnoredNodesRepository extends BaseRepository {
   constructor(db: DrizzleDatabase, dbType: DatabaseType) {
@@ -45,15 +44,15 @@ export class IgnoredNodesRepository extends BaseRepository {
   }
 
   /**
-   * Add a node to the persistent ignore list (upsert)
+   * Add a node to the per-source ignore list (upsert on (nodeNum, sourceId)).
    */
   async addIgnoredNodeAsync(
     nodeNum: number,
+    sourceId: string,
     nodeId: string,
     longName?: string | null,
     shortName?: string | null,
     ignoredBy?: string | null,
-    sourceId?: string,
   ): Promise<void> {
     const now = Date.now();
     const { ignoredNodes } = this.tables;
@@ -64,48 +63,51 @@ export class IgnoredNodesRepository extends BaseRepository {
       ignoredAt: now,
       ignoredBy: ignoredBy ?? null,
     };
-    const insertData: any = { nodeNum, ...setData };
-    if (sourceId) {
-      insertData.sourceId = sourceId;
-    }
+    const insertData: any = { nodeNum, sourceId, ...setData };
 
     await this.upsert(
       ignoredNodes,
       insertData,
-      ignoredNodes.nodeNum,
+      [ignoredNodes.nodeNum, ignoredNodes.sourceId],
       setData,
     );
 
-    logger.debug(`Added node ${nodeNum} (${nodeId}) to persistent ignore list`);
+    logger.debug(`Added node ${nodeNum} (${nodeId}) to ignore list for source ${sourceId}`);
   }
 
   /**
-   * Remove a node from the persistent ignore list
+   * Remove a node from the per-source ignore list.
    */
-  async removeIgnoredNodeAsync(nodeNum: number): Promise<void> {
+  async removeIgnoredNodeAsync(nodeNum: number, sourceId: string): Promise<void> {
     const { ignoredNodes } = this.tables;
-    await this.db.delete(ignoredNodes).where(eq(ignoredNodes.nodeNum, nodeNum));
-    logger.debug(`Removed node ${nodeNum} from persistent ignore list`);
+    await this.db
+      .delete(ignoredNodes)
+      .where(and(eq(ignoredNodes.nodeNum, nodeNum), eq(ignoredNodes.sourceId, sourceId)));
+    logger.debug(`Removed node ${nodeNum} from ignore list for source ${sourceId}`);
   }
 
   /**
-   * Get all persistently ignored nodes
+   * Get persistently ignored nodes. If `sourceId` is provided, scopes to that
+   * source; otherwise returns all entries across every source (for admin
+   * dashboards / aggregated views).
    */
-  async getIgnoredNodesAsync(): Promise<IgnoredNodeRecord[]> {
+  async getIgnoredNodesAsync(sourceId?: string): Promise<IgnoredNodeRecord[]> {
     const { ignoredNodes } = this.tables;
-    const rows = await this.db.select().from(ignoredNodes);
+    const rows = sourceId
+      ? await this.db.select().from(ignoredNodes).where(eq(ignoredNodes.sourceId, sourceId))
+      : await this.db.select().from(ignoredNodes);
     return this.normalizeBigInts(rows) as IgnoredNodeRecord[];
   }
 
   /**
-   * Check if a node is in the persistent ignore list
+   * Check if a node is in the ignore list for a given source.
    */
-  async isNodeIgnoredAsync(nodeNum: number): Promise<boolean> {
+  async isNodeIgnoredAsync(nodeNum: number, sourceId: string): Promise<boolean> {
     const { ignoredNodes } = this.tables;
     const rows = await this.db
       .select({ nodeNum: ignoredNodes.nodeNum })
       .from(ignoredNodes)
-      .where(eq(ignoredNodes.nodeNum, nodeNum));
+      .where(and(eq(ignoredNodes.nodeNum, nodeNum), eq(ignoredNodes.sourceId, sourceId)));
     return rows.length > 0;
   }
 
@@ -114,7 +116,7 @@ export class IgnoredNodesRepository extends BaseRepository {
    * to decide whether to restore the `isIgnored` flag on a returning node.
    * Returns false if the table doesn't exist yet (initial setup).
    */
-  isNodeIgnoredSqlite(nodeNum: number): boolean {
+  isNodeIgnoredSqlite(nodeNum: number, sourceId: string): boolean {
     if (!this.sqliteDb) throw new Error('isNodeIgnoredSqlite is SQLite-only');
     const db = this.sqliteDb;
     const { ignoredNodes } = this.tables;
@@ -122,7 +124,7 @@ export class IgnoredNodesRepository extends BaseRepository {
       const rows = db
         .select({ nodeNum: ignoredNodes.nodeNum })
         .from(ignoredNodes)
-        .where(eq(ignoredNodes.nodeNum, nodeNum))
+        .where(and(eq(ignoredNodes.nodeNum, nodeNum), eq(ignoredNodes.sourceId, sourceId)))
         .limit(1)
         .all();
       return rows.length > 0;

--- a/src/db/schema/ignoredNodes.ts
+++ b/src/db/schema/ignoredNodes.ts
@@ -2,60 +2,73 @@
  * Drizzle schema definition for the ignored_nodes table
  * Supports SQLite, PostgreSQL, and MySQL
  *
- * This table persists the ignored status of nodes independently of the nodes table,
- * so that when a node is pruned by cleanupInactiveNodes and later reappears,
- * its ignored status is automatically restored.
+ * Scoping model (migration 048): per-source. Each source has its own
+ * blocklist, keyed on `(nodeNum, sourceId)`. The `sourceId` column is a FK to
+ * `sources(id)` with ON DELETE CASCADE — when a source is removed, its
+ * ignored entries go with it. Ignoring on source A does NOT affect source B's
+ * blocklist, matching the per-source node identity model introduced by
+ * migration 029.
+ *
+ * The table persists the ignored status independently of `nodes.isIgnored` so
+ * that when a node is pruned by `cleanupInactiveNodes` on a given source and
+ * later reappears on THAT SAME source, its ignored flag is automatically
+ * restored.
  */
-import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, primaryKey as sqlitePrimaryKey } from 'drizzle-orm/sqlite-core';
 import {
   pgTable,
   text as pgText,
   bigint as pgBigint,
+  primaryKey as pgPrimaryKey,
 } from 'drizzle-orm/pg-core';
 import {
   mysqlTable,
   varchar as myVarchar,
   bigint as myBigint,
+  primaryKey as myPrimaryKey,
 } from 'drizzle-orm/mysql-core';
 
 // ============ IGNORED NODES (SQLite) ============
 
 export const ignoredNodesSqlite = sqliteTable('ignored_nodes', {
-  nodeNum: integer('nodeNum').primaryKey(),
+  nodeNum: integer('nodeNum').notNull(),
+  sourceId: text('sourceId').notNull(),
   nodeId: text('nodeId').notNull(),
   longName: text('longName'),
   shortName: text('shortName'),
   ignoredAt: integer('ignoredAt').notNull(),
   ignoredBy: text('ignoredBy'),
-  // Source association (nullable — NULL = legacy default source)
-  sourceId: text('sourceId'),
-});
+}, (table) => ({
+  pk: sqlitePrimaryKey({ columns: [table.nodeNum, table.sourceId] }),
+}));
 
 // ============ IGNORED NODES (PostgreSQL) ============
 
 export const ignoredNodesPostgres = pgTable('ignored_nodes', {
-  nodeNum: pgBigint('nodeNum', { mode: 'number' }).primaryKey(),
+  nodeNum: pgBigint('nodeNum', { mode: 'number' }).notNull(),
+  sourceId: pgText('sourceId').notNull(),
   nodeId: pgText('nodeId').notNull(),
   longName: pgText('longName'),
   shortName: pgText('shortName'),
   ignoredAt: pgBigint('ignoredAt', { mode: 'number' }).notNull(),
   ignoredBy: pgText('ignoredBy'),
-  // Source association (nullable — NULL = legacy default source)
-  sourceId: pgText('sourceId'),
-});
+}, (table) => ({
+  pk: pgPrimaryKey({ columns: [table.nodeNum, table.sourceId] }),
+}));
 
 // ============ IGNORED NODES (MySQL) ============
 
 export const ignoredNodesMysql = mysqlTable('ignored_nodes', {
-  nodeNum: myBigint('nodeNum', { mode: 'number' }).primaryKey(),
+  nodeNum: myBigint('nodeNum', { mode: 'number' }).notNull(),
+  sourceId: myVarchar('sourceId', { length: 36 }).notNull(),
   nodeId: myVarchar('nodeId', { length: 255 }).notNull(),
   longName: myVarchar('longName', { length: 255 }),
   shortName: myVarchar('shortName', { length: 255 }),
   ignoredAt: myBigint('ignoredAt', { mode: 'number' }).notNull(),
   ignoredBy: myVarchar('ignoredBy', { length: 255 }),
-  // Source association (nullable — NULL = legacy default source)
-  sourceId: myVarchar('sourceId', { length: 36 }),
-});
+}, (table) => ({
+  pk: myPrimaryKey({ columns: [table.nodeNum, table.sourceId] }),
+}));
 
 // ============ TYPE INFERENCE ============
 

--- a/src/server/migrations/048_rebuild_ignored_nodes_per_source.ts
+++ b/src/server/migrations/048_rebuild_ignored_nodes_per_source.ts
@@ -1,0 +1,199 @@
+/**
+ * Migration 048: Rebuild ignored_nodes as per-source.
+ *
+ * Previous design: `ignored_nodes` was a GLOBAL blocklist keyed on `nodeNum`
+ * alone, with `sourceId` stored as informational-only. Mixing a global
+ * persistence table with the per-source `nodes.isIgnored` flag produced
+ * confusing cross-source behaviour (ignoring on source A didn't propagate to
+ * source B's live flag; only eventual consistency via prune/restore).
+ *
+ * New design: `ignored_nodes` is now per-source, keyed on (nodeNum, sourceId)
+ * composite PK, with `sourceId` as a foreign key to `sources(id)` ON DELETE
+ * CASCADE. Each source has its own independent blocklist. The `nodes.isIgnored`
+ * column on each per-source node row remains the live mirror.
+ *
+ * Backfill strategy (per user direction): drop the existing table entirely
+ * and recreate the per-source blocklist from `nodes` where `isIgnored=1`.
+ * This avoids any NULL-sourceId edge cases and uses the live flag as the
+ * source of truth.
+ *
+ * The SQLite path drops + creates since the old table has no data worth
+ * preserving independently of `nodes.isIgnored`. PG/MySQL follow the same
+ * pattern.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+function now(): number {
+  return Date.now();
+}
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 048 (SQLite): Rebuilding ignored_nodes as per-source (nodeNum, sourceId)...');
+
+    // Idempotency: if the table already has the composite PK shape, skip.
+    try {
+      const pkCols = db
+        .prepare(`SELECT name FROM pragma_table_info('ignored_nodes') WHERE pk > 0 ORDER BY pk`)
+        .all() as Array<{ name: string }>;
+      const pkNames = pkCols.map(r => r.name);
+      if (pkNames.includes('nodeNum') && pkNames.includes('sourceId')) {
+        logger.debug('Migration 048 (SQLite): ignored_nodes already has composite PK, skipping');
+        return;
+      }
+    } catch {
+      // Table may not exist — proceed to create it.
+    }
+
+    const prevForeignKeys = (db.prepare(`PRAGMA foreign_keys`).get() as { foreign_keys: number }).foreign_keys;
+    db.prepare(`PRAGMA foreign_keys=OFF`).run();
+
+    const tx = db.transaction(() => {
+      db.prepare(`DROP TABLE IF EXISTS ignored_nodes`).run();
+
+      db.prepare(`
+        CREATE TABLE ignored_nodes (
+          nodeNum INTEGER NOT NULL,
+          sourceId TEXT NOT NULL,
+          nodeId TEXT NOT NULL,
+          longName TEXT,
+          shortName TEXT,
+          ignoredAt INTEGER NOT NULL,
+          ignoredBy TEXT,
+          PRIMARY KEY (nodeNum, sourceId),
+          FOREIGN KEY (sourceId) REFERENCES sources(id) ON DELETE CASCADE
+        )
+      `).run();
+
+      const ts = now();
+      db.prepare(`
+        INSERT INTO ignored_nodes (nodeNum, sourceId, nodeId, longName, shortName, ignoredAt, ignoredBy)
+        SELECT n.nodeNum, n.sourceId, n.nodeId, n.longName, n.shortName, ?, 'migration-048'
+        FROM nodes n
+        WHERE n.isIgnored = 1 AND n.sourceId IS NOT NULL
+      `).run(ts);
+
+      const count = (db.prepare(`SELECT COUNT(*) AS c FROM ignored_nodes`).get() as { c: number }).c;
+      logger.info(`Migration 048 (SQLite): rebuilt ignored_nodes from nodes.isIgnored, ${count} row(s) backfilled`);
+    });
+
+    try {
+      tx();
+    } finally {
+      if (prevForeignKeys) {
+        db.prepare(`PRAGMA foreign_keys=ON`).run();
+      }
+    }
+  },
+};
+
+export async function runMigration048Postgres(client: any): Promise<void> {
+  logger.info('Running migration 048 (PostgreSQL): Rebuilding ignored_nodes as per-source (nodeNum, sourceId)...');
+
+  // Idempotency: detect composite PK before dropping.
+  const pkRows = await client.query(`
+    SELECT a.attname
+    FROM pg_index i
+    JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+    WHERE i.indrelid = 'ignored_nodes'::regclass AND i.indisprimary
+  `).catch(() => ({ rows: [] as Array<{ attname: string }> }));
+  const pkNames = (pkRows.rows as Array<{ attname: string }>).map(r => r.attname);
+  if (pkNames.includes('nodeNum') && pkNames.includes('sourceId')) {
+    logger.debug('Migration 048 (PostgreSQL): ignored_nodes already has composite PK, skipping');
+    return;
+  }
+
+  await client.query('BEGIN');
+  try {
+    await client.query(`DROP TABLE IF EXISTS "ignored_nodes"`);
+
+    await client.query(`
+      CREATE TABLE "ignored_nodes" (
+        "nodeNum" BIGINT NOT NULL,
+        "sourceId" TEXT NOT NULL REFERENCES "sources"("id") ON DELETE CASCADE,
+        "nodeId" TEXT NOT NULL,
+        "longName" TEXT,
+        "shortName" TEXT,
+        "ignoredAt" BIGINT NOT NULL,
+        "ignoredBy" TEXT,
+        PRIMARY KEY ("nodeNum", "sourceId")
+      )
+    `);
+
+    const ts = now();
+    const backfill = await client.query(
+      `INSERT INTO "ignored_nodes" ("nodeNum", "sourceId", "nodeId", "longName", "shortName", "ignoredAt", "ignoredBy")
+       SELECT n."nodeNum", n."sourceId", n."nodeId", n."longName", n."shortName", $1, 'migration-048'
+       FROM "nodes" n
+       WHERE n."isIgnored" = true AND n."sourceId" IS NOT NULL`,
+      [ts]
+    );
+
+    await client.query('COMMIT');
+    logger.info(`Migration 048 (PostgreSQL): rebuilt ignored_nodes from nodes.isIgnored, ${backfill.rowCount ?? 0} row(s) backfilled`);
+  } catch (error) {
+    await client.query('ROLLBACK');
+    logger.error('Migration 048 (PostgreSQL) failed:', error);
+    throw error;
+  }
+}
+
+export async function runMigration048Mysql(pool: any): Promise<void> {
+  logger.info('Running migration 048 (MySQL): Rebuilding ignored_nodes as per-source (nodeNum, sourceId)...');
+
+  // Idempotency: detect composite PK before dropping.
+  const [pkRows] = await pool.query(`
+    SELECT COLUMN_NAME
+    FROM information_schema.KEY_COLUMN_USAGE
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'ignored_nodes'
+      AND CONSTRAINT_NAME = 'PRIMARY'
+    ORDER BY ORDINAL_POSITION
+  `);
+  const pkNames = (pkRows as Array<{ COLUMN_NAME: string }>).map(r => r.COLUMN_NAME);
+  if (pkNames.includes('nodeNum') && pkNames.includes('sourceId')) {
+    logger.debug('Migration 048 (MySQL): ignored_nodes already has composite PK, skipping');
+    return;
+  }
+
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+
+    await conn.query(`DROP TABLE IF EXISTS ignored_nodes`);
+
+    await conn.query(`
+      CREATE TABLE ignored_nodes (
+        nodeNum BIGINT NOT NULL,
+        sourceId VARCHAR(36) NOT NULL,
+        nodeId VARCHAR(255) NOT NULL,
+        longName VARCHAR(255),
+        shortName VARCHAR(255),
+        ignoredAt BIGINT NOT NULL,
+        ignoredBy VARCHAR(255),
+        PRIMARY KEY (nodeNum, sourceId),
+        CONSTRAINT fk_ignored_nodes_source FOREIGN KEY (sourceId) REFERENCES sources(id) ON DELETE CASCADE
+      )
+    `);
+
+    const ts = now();
+    const [result] = await conn.query(
+      `INSERT INTO ignored_nodes (nodeNum, sourceId, nodeId, longName, shortName, ignoredAt, ignoredBy)
+       SELECT n.nodeNum, n.sourceId, n.nodeId, n.longName, n.shortName, ?, 'migration-048'
+       FROM nodes n
+       WHERE n.isIgnored = 1 AND n.sourceId IS NOT NULL`,
+      [ts]
+    );
+
+    await conn.commit();
+    const affected = (result as { affectedRows?: number }).affectedRows ?? 0;
+    logger.info(`Migration 048 (MySQL): rebuilt ignored_nodes from nodes.isIgnored, ${affected} row(s) backfilled`);
+  } catch (error) {
+    await conn.rollback();
+    logger.error('Migration 048 (MySQL) failed:', error);
+    throw error;
+  } finally {
+    conn.release();
+  }
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -47,6 +47,7 @@ import { generateAnalyticsScript, AnalyticsProvider } from './utils/analyticsScr
 import { rewriteHtml } from './utils/htmlRewriter.js';
 import { migrateAutomationChannels } from './utils/automationChannelMigration.js';
 import { safeFetch, SsrfBlockedError } from './utils/ssrfGuard.js';
+import { resolveRequestSourceId } from './utils/sourceResolver.js';
 import { PortNum } from './constants/meshtastic.js';
 import settingsRoutes, { setSettingsCallbacks } from './routes/settingsRoutes.js';
 import { applyManagerSettings } from './applyManagerSettings.js';
@@ -1390,7 +1391,7 @@ apiRouter.get('/auto-favorite/status', requirePermission('nodes', 'read'), async
 apiRouter.post('/nodes/:nodeId/ignored', requirePermission('nodes', 'write', { sourceIdFrom: 'body' }), async (req, res) => {
   try {
     const { nodeId } = req.params;
-    const { isIgnored, syncToDevice = true, destinationNodeNum, sourceId: ignoreSourceId } = req.body;
+    const { isIgnored, syncToDevice = true, destinationNodeNum } = req.body;
 
     if (typeof isIgnored !== 'boolean') {
       const errorResponse: ApiErrorResponse = {
@@ -1402,11 +1403,14 @@ apiRouter.post('/nodes/:nodeId/ignored', requirePermission('nodes', 'write', { s
       return;
     }
 
-    if (typeof ignoreSourceId !== 'string' || ignoreSourceId.length === 0) {
+    // Per-source blocklist: accept sourceId from body, else fall back to the
+    // first source this caller has nodes:write on.
+    const ignoreSourceId = await resolveRequestSourceId(req, 'nodes', 'write');
+    if (!ignoreSourceId) {
       const errorResponse: ApiErrorResponse = {
-        error: 'sourceId is required',
+        error: 'No permitted source',
         code: 'MISSING_SOURCE_ID',
-        details: 'Request body must include a sourceId string',
+        details: 'Provide a sourceId, or ensure your account has nodes:write on at least one enabled source',
       };
       res.status(400).json(errorResponse);
       return;
@@ -1500,10 +1504,21 @@ apiRouter.post('/nodes/:nodeId/ignored', requirePermission('nodes', 'write', { s
   }
 });
 
-// Get persistent ignored nodes list
-apiRouter.get('/ignored-nodes', requirePermission('nodes', 'read'), async (_req, res) => {
+// Get per-source ignored nodes list. If `?sourceId=X` is omitted, returns the
+// first enabled source the caller has nodes:read on.
+apiRouter.get('/ignored-nodes', requirePermission('nodes', 'read'), async (req, res) => {
   try {
-    const ignoredNodes = await databaseService.ignoredNodes.getIgnoredNodesAsync();
+    const listSourceId = await resolveRequestSourceId(req, 'nodes', 'read');
+    if (!listSourceId) {
+      const errorResponse: ApiErrorResponse = {
+        error: 'No permitted source',
+        code: 'MISSING_SOURCE_ID',
+        details: 'Provide ?sourceId=, or ensure your account has nodes:read on at least one enabled source',
+      };
+      res.status(400).json(errorResponse);
+      return;
+    }
+    const ignoredNodes = await databaseService.ignoredNodes.getIgnoredNodesAsync(listSourceId);
     res.json(ignoredNodes);
   } catch (error) {
     logger.error('Error fetching ignored nodes:', error);
@@ -1516,7 +1531,8 @@ apiRouter.get('/ignored-nodes', requirePermission('nodes', 'read'), async (_req,
   }
 });
 
-// Remove node from persistent ignore list and un-ignore it
+// Remove a node from the per-source ignore list. If `?sourceId=X` is omitted,
+// operates on the first enabled source the caller has nodes:write on.
 apiRouter.delete('/ignored-nodes/:nodeId', requirePermission('nodes', 'write'), async (req, res) => {
   try {
     const { nodeId } = req.params;
@@ -1535,29 +1551,29 @@ apiRouter.delete('/ignored-nodes/:nodeId', requirePermission('nodes', 'write'), 
       return;
     }
 
-    const nodeNum = parseInt(nodeNumStr, 16);
-
-    // Remove from persistent ignore list
-    await databaseService.ignoredNodes.removeIgnoredNodeAsync(nodeNum);
-
-    // Also un-ignore the node record if it still exists across all sources
-    // (the persistent ignore table is not source-scoped, so we sweep every source)
-    try {
-      const allNodes = await databaseService.nodes.getAllNodes();
-      for (const n of allNodes) {
-        if (Number(n.nodeNum) !== nodeNum) continue;
-        const sId = (n as any).sourceId || 'default';
-        try {
-          await databaseService.setNodeIgnoredAsync(nodeNum, false, sId);
-        } catch {
-          // Node may not exist in nodes table for this source — OK
-        }
-      }
-    } catch {
-      // Node may not exist in nodes table - that's OK
+    const deleteSourceId = await resolveRequestSourceId(req, 'nodes', 'write');
+    if (!deleteSourceId) {
+      const errorResponse: ApiErrorResponse = {
+        error: 'No permitted source',
+        code: 'MISSING_SOURCE_ID',
+        details: 'Provide ?sourceId=, or ensure your account has nodes:write on at least one enabled source',
+      };
+      res.status(400).json(errorResponse);
+      return;
     }
 
-    res.json({ success: true, nodeNum });
+    const nodeNum = parseInt(nodeNumStr, 16);
+
+    // Remove from the per-source blocklist + clear the live mirror flag on
+    // the matching nodes row. Other sources' blocklists are untouched by design.
+    await databaseService.ignoredNodes.removeIgnoredNodeAsync(nodeNum, deleteSourceId);
+    try {
+      await databaseService.setNodeIgnoredAsync(nodeNum, false, deleteSourceId);
+    } catch {
+      // Node may not exist in nodes table for this source — OK, table-level removal already succeeded.
+    }
+
+    res.json({ success: true, nodeNum, sourceId: deleteSourceId });
   } catch (error) {
     logger.error('Error removing ignored node:', error);
     const errorResponse: ApiErrorResponse = {

--- a/src/server/utils/sourceResolver.ts
+++ b/src/server/utils/sourceResolver.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared helper for resolving a default sourceId from the authenticated
+ * caller's permissions. Used by non-v1 legacy endpoints (where the source is
+ * expressed as an optional query/body field rather than a path segment) to
+ * match the v1 behaviour in `routes/v1/sourceParam.ts` — callers that omit
+ * `sourceId` get the first enabled source they have the requested permission
+ * on, ordered by `createdAt` ASC.
+ *
+ * Admins bypass the per-source permission probe and always get the first
+ * enabled source.
+ */
+
+import type { Source } from '../../db/repositories/sources.js';
+import type { ResourceType, PermissionAction } from '../../types/permission.js';
+import databaseService from '../../services/database.js';
+
+export async function resolveDefaultSourceForUser(
+  userId: number,
+  isAdmin: boolean,
+  resource: ResourceType,
+  action: PermissionAction
+): Promise<Source | null> {
+  const allSources = await databaseService.sources.getAllSources();
+  const sorted = [...allSources]
+    .filter((s) => s.enabled)
+    .sort((a, b) => a.createdAt - b.createdAt);
+  if (sorted.length === 0) return null;
+
+  if (isAdmin) {
+    return sorted[0];
+  }
+
+  for (const source of sorted) {
+    const allowed = await databaseService.checkPermissionAsync(
+      userId,
+      resource,
+      action,
+      source.id
+    );
+    if (allowed) return source;
+  }
+  return null;
+}
+
+/**
+ * Resolve the effective sourceId for a request. Looks at (in order) the query
+ * string, request body, and finally the fallback "first permitted source"
+ * helper. Returns `null` if no source can be resolved — callers should 400.
+ */
+export async function resolveRequestSourceId(
+  req: { query: any; body?: any; user?: { id: number; isAdmin?: boolean } },
+  resource: ResourceType,
+  action: PermissionAction
+): Promise<string | null> {
+  const raw =
+    (typeof req.query?.sourceId === 'string' && req.query.sourceId) ||
+    (typeof req.body?.sourceId === 'string' && req.body.sourceId) ||
+    null;
+  if (raw) return raw;
+
+  const user = req.user;
+  if (!user) return null;
+
+  const defaultSource = await resolveDefaultSourceForUser(
+    user.id,
+    Boolean(user.isAdmin),
+    resource,
+    action
+  );
+  return defaultSource ? defaultSource.id : null;
+}

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -2028,13 +2028,13 @@ class DatabaseService {
           logger.error('Failed to upsert node:', err);
         });
 
-        // For newly discovered nodes, check persistent ignore list and restore status
+        // For newly discovered nodes, check per-source ignore list and restore status
         if (!existingNode && nodeData.nodeNum !== 4294967295) {
-          // Check if this node was previously ignored
+          // Check if this node was previously ignored on this source
           if (this.ignoredNodesRepo) {
-            this.ignoredNodes.isNodeIgnoredAsync(nodeData.nodeNum).then(wasIgnored => {
+            this.ignoredNodes.isNodeIgnoredAsync(nodeData.nodeNum, upsertSourceId).then(wasIgnored => {
               if (wasIgnored) {
-                logger.debug(`Restoring ignored status for returning node ${nodeData.nodeNum}`);
+                logger.debug(`Restoring ignored status for returning node ${nodeData.nodeNum} on source ${upsertSourceId}`);
                 updatedNode.isIgnored = true;
                 this.nodesCache.set(this.cacheKey(nodeData.nodeNum!, upsertSourceId), updatedNode);
                 if (this.nodesRepo) {
@@ -2043,7 +2043,7 @@ class DatabaseService {
                   });
                 }
               }
-            }).catch(err => logger.error('Failed to check persistent ignore list:', err));
+            }).catch(err => logger.error('Failed to check per-source ignore list:', err));
           }
         }
 
@@ -2085,10 +2085,10 @@ class DatabaseService {
 
     let wasIgnored = false;
     if (!existingNode) {
-      // Check if this node was previously ignored (persistent ignore list).
+      // Check if this node was previously ignored on this source (per-source blocklist).
       // Delegates to IgnoredNodesRepository so the raw SQL stays inside Drizzle-managed code.
-      if (this.ignoredNodesRepo) {
-        wasIgnored = this.ignoredNodesRepo.isNodeIgnoredSqlite(nodeData.nodeNum);
+      if (this.ignoredNodesRepo && upsertSourceIdSqlite) {
+        wasIgnored = this.ignoredNodesRepo.isNodeIgnoredSqlite(nodeData.nodeNum, upsertSourceIdSqlite);
       }
     }
 
@@ -6850,16 +6850,16 @@ class DatabaseService {
     const node = this.getNode(nodeNum, sourceId);
     const nodeId = node?.nodeId || `!${nodeNum.toString(16).padStart(8, '0')}`;
 
-    // Persist to/remove from the ignored_nodes table
+    // Persist to/remove from the per-source ignored_nodes table (migration 048).
     if (isIgnored) {
       this.ignoredNodes.addIgnoredNodeAsync(
-        nodeNum, nodeId, node?.longName, node?.shortName
+        nodeNum, sourceId, nodeId, node?.longName, node?.shortName
       ).catch(err => {
-        logger.error('Failed to add node to persistent ignore list:', err);
+        logger.error('Failed to add node to per-source ignore list:', err);
       });
     } else {
-      this.ignoredNodes.removeIgnoredNodeAsync(nodeNum).catch(err => {
-        logger.error('Failed to remove node from persistent ignore list:', err);
+      this.ignoredNodes.removeIgnoredNodeAsync(nodeNum, sourceId).catch(err => {
+        logger.error('Failed to remove node from per-source ignore list:', err);
       });
     }
 


### PR DESCRIPTION
## Summary

Converts `ignored_nodes` from a global blocklist to a per-source table keyed on `(nodeNum, sourceId)`, matching the per-source node identity model introduced for the `nodes` table in migration 029. Ignoring a node on source A no longer affects source B's state for the same nodeNum.

- **Migration 048** drops the legacy `ignored_nodes` and rebuilds it from `nodes.isIgnored=1`, so users retain effective ignore state without any cross-source bleed. New table has a FK to `sources(id)` with `ON DELETE CASCADE`.
- **Repository + facade** require `sourceId` on every operation; `addIgnoredNodeAsync` upserts on the composite PK, `removeIgnoredNodeAsync` / `isNodeIgnoredAsync` / `isNodeIgnoredSqlite` all scope by source.
- **Routes** (`POST /nodes/:nodeId/ignored`, `GET /ignored-nodes`, `DELETE /ignored-nodes/:nodeId`) accept an optional `sourceId` (body for POST, query for GET/DELETE). Missing sourceId falls back to the first enabled source the caller has `nodes:<action>` permission on, via a new shared helper `src/server/utils/sourceResolver.ts`. DELETE no longer sweeps every source — it operates on the resolved source only.
- **Frontend** (`IgnoredNodesSection`) reads the active `SourceContext`, sends `?sourceId=` on GET, and per-row DELETE targets the row's own source so aggregated views don't collapse back to the active source.

## Test plan

- [x] Repo suite rewritten: multi-backend per-source upsert, scoped remove, source-filtered list, per-source `isNodeIgnored` truthiness — 27 tests (9 SQLite + 18 PG/MySQL skipped without containers)
- [x] Migration registry test bumped: count 48, last migration `rebuild_ignored_nodes_per_source`
- [x] Full Vitest suite: **4423 passed / 0 failed** (513 skipped, 21 todo)
- [x] Dev container rebuilt (`docker-compose.dev.yml` sqlite, port 8081). Migration 048 ran: "rebuilt ignored_nodes from nodes.isIgnored, 0 row(s) backfilled". Volume preserved.
- [x] Compiled dist verified: composite PK in `ignoredNodesSqlite`, `isNodeIgnoredAsync(nodeNum, sourceId)` wired through service.
- [ ] Manual: ignore a node on source A via UI, confirm it does NOT appear ignored on source B (requires second source)
- [ ] Manual: confirm un-ignore on source A leaves source B's blocklist + `nodes.isIgnored` flag untouched
- [ ] Manual: `GET /api/ignored-nodes` without `?sourceId=` returns the caller's first-permitted source's list

🤖 Generated with [Claude Code](https://claude.com/claude-code)