### PR TITLE
fix(db): resolve pg-pool starvation under NodeInfo burst (#2780)

### DIFF
--- a/src/db/drivers/mysql.ts
+++ b/src/db/drivers/mysql.ts
@@ -74,7 +74,9 @@ export async function createMySQLDriver(options: MySQLDriverOptions): Promise<{
   // Create Drizzle ORM instance
   const db = drizzle(pool, { schema, mode: 'default' });
 
-  logger.info('[MySQL Driver] Database initialized successfully');
+  logger.info(
+    `[MySQL Driver] Database initialized successfully (pool max=${maxConnections}, idle=${idleTimeoutMs}ms, connect=${connectionTimeoutMs}ms)`
+  );
 
   return {
     db,

--- a/src/db/drivers/postgres.ts
+++ b/src/db/drivers/postgres.ts
@@ -81,7 +81,9 @@ export async function createPostgresDriver(options: PostgresDriverOptions): Prom
   // Create Drizzle ORM instance
   const db = drizzle(pool, { schema });
 
-  logger.info('[PostgreSQL Driver] Database initialized successfully');
+  logger.info(
+    `[PostgreSQL Driver] Database initialized successfully (pool max=${maxConnections}, idle=${idleTimeoutMs}ms, connect=${connectionTimeoutMs}ms)`
+  );
 
   return {
     db,

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -82,14 +82,18 @@ export function getDatabaseConfig(): DatabaseConfig {
   const config = getEnvironmentConfig();
   const type = detectDatabaseType();
 
+  const poolSizeRaw = process.env.DATABASE_POOL_SIZE;
+  const parsedPoolSize = poolSizeRaw ? parseInt(poolSizeRaw, 10) : NaN;
+  const maxConnections = Number.isFinite(parsedPoolSize) && parsedPoolSize > 0 ? parsedPoolSize : 10;
+
   return {
     type,
     sqlitePath: config.databasePath,
     postgresUrl: type === 'postgres' ? config.databaseUrl : undefined,
-    postgresMaxConnections: 10,
+    postgresMaxConnections: maxConnections,
     postgresSsl: false,
     mysqlUrl: type === 'mysql' ? config.databaseUrl : undefined,
-    mysqlMaxConnections: 10,
+    mysqlMaxConnections: maxConnections,
   };
 }
 

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -915,27 +915,41 @@ export class MessagesRepository extends BaseRepository {
       }
     }
 
-    // Execute all operations in a transaction
+    // Execute all operations inside a Drizzle transaction so BEGIN/COMMIT
+    // land on the same pinned pool client. The previous implementation ran
+    // `executeRun(BEGIN)` through `db.execute()`, which grabs a fresh pool
+    // client per call on node-postgres — BEGIN would run on client A and
+    // release A back to the pool in "idle in transaction" state while
+    // subsequent statements ran on different clients. That leaked a pool
+    // slot per invocation (#2780).
+    //
+    // SQLite uses better-sqlite3 (sync). Drizzle's sqlite-core transaction
+    // refuses Promise-returning callbacks, so we branch on dialect: sync
+    // txn for SQLite, async for PG/MySQL.
     try {
-      await this.executeRun(sql`BEGIN`);
-
-      for (const op of operations) {
-        const result = await this.executeRun(op.sql);
-        const rows = this.getAffectedRows(result);
-        totalRowsAffected += rows;
-        logger.info(`📦 Message migration: ${op.description} (${rows} rows)`);
+      if (this.isSQLite()) {
+        (this.db as any).transaction((tx: any) => {
+          for (const op of operations) {
+            const result = tx.run(op.sql);
+            const rows = this.getAffectedRows(result);
+            totalRowsAffected += rows;
+            logger.info(`📦 Message migration: ${op.description} (${rows} rows)`);
+          }
+        });
+      } else {
+        await (this.db as any).transaction(async (tx: any) => {
+          for (const op of operations) {
+            const result = await tx.execute(op.sql);
+            const rows = this.getAffectedRows(result);
+            totalRowsAffected += rows;
+            logger.info(`📦 Message migration: ${op.description} (${rows} rows)`);
+          }
+        });
       }
-
-      await this.executeRun(sql`COMMIT`);
       logger.info(`📦 Message migration complete: ${moves.length} move(s), ${totalRowsAffected} total rows affected`);
       return { success: true, totalRowsAffected };
     } catch (error) {
-      logger.error('📦 Message migration failed, rolling back:', error);
-      try {
-        await this.executeRun(sql`ROLLBACK`);
-      } catch (rollbackError) {
-        logger.error('📦 Rollback also failed:', rollbackError);
-      }
+      logger.error('📦 Message migration failed, transaction rolled back:', error);
       throw error;
     }
   }

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -77,6 +77,59 @@ export class TelemetryRepository extends BaseRepository {
   }
 
   /**
+   * Insert multiple telemetry rows in a single statement. Reduces pool
+   * acquires during bursts like NodeInfo (position + device metrics + SNR
+   * can be ≥10 rows per packet). Uses multi-row VALUES with
+   * onConflictDoNothing on SQLite/PostgreSQL; MySQL falls back to serial
+   * inserts since our Drizzle version lacks multi-row ignore.
+   */
+  async insertTelemetryBatch(
+    rows: DbTelemetry[],
+    sourceId?: string
+  ): Promise<number> {
+    if (rows.length === 0) return 0;
+
+    const { telemetry } = this.tables;
+    const valuesArray = rows.map((r) => {
+      const v: any = {
+        nodeId: r.nodeId,
+        nodeNum: r.nodeNum,
+        telemetryType: r.telemetryType,
+        timestamp: r.timestamp,
+        value: r.value,
+        unit: r.unit ?? null,
+        createdAt: r.createdAt,
+        packetTimestamp: r.packetTimestamp ?? null,
+        packetId: r.packetId ?? null,
+        channel: r.channel ?? null,
+        precisionBits: r.precisionBits ?? null,
+        gpsAccuracy: r.gpsAccuracy ?? null,
+      };
+      if (sourceId) v.sourceId = sourceId;
+      return v;
+    });
+
+    if (this.isMySQL()) {
+      let inserted = 0;
+      for (const v of valuesArray) {
+        try {
+          const r = await this.db.insert(telemetry).values(v);
+          inserted += this.getAffectedRows(r);
+        } catch {
+          // Duplicate key — swallow, matches single insertIgnore semantics
+        }
+      }
+      return inserted;
+    }
+
+    const result = await (this.db as any)
+      .insert(telemetry)
+      .values(valuesArray)
+      .onConflictDoNothing();
+    return this.getAffectedRows(result);
+  }
+
+  /**
    * Get telemetry count
    */
   async getTelemetryCount(): Promise<number> {

--- a/src/server/meshtasticManager.autoFavorite.perSource.test.ts
+++ b/src/server/meshtasticManager.autoFavorite.perSource.test.ts
@@ -46,6 +46,7 @@ vi.mock('../services/database.js', () => ({
     },
     telemetry: {
       insertTelemetry: vi.fn().mockResolvedValue(undefined),
+      insertTelemetryBatch: vi.fn().mockResolvedValue(0),
       getLatestTelemetryForType: vi.fn().mockResolvedValue(null),
     },
     messages: {

--- a/src/server/meshtasticManager.autoHeapManagement.test.ts
+++ b/src/server/meshtasticManager.autoHeapManagement.test.ts
@@ -45,6 +45,7 @@ vi.mock('../services/database.js', () => ({
     },
     telemetry: {
       insertTelemetry: vi.fn().mockResolvedValue(undefined),
+      insertTelemetryBatch: vi.fn().mockResolvedValue(0),
       getLatestTelemetryForType: vi.fn().mockResolvedValue(null),
     },
     messages: {

--- a/src/server/meshtasticManager.autowelcome.test.ts
+++ b/src/server/meshtasticManager.autowelcome.test.ts
@@ -37,6 +37,7 @@ vi.mock('../services/database.js', () => ({
     },
     telemetry: {
       insertTelemetry: vi.fn().mockResolvedValue(undefined),
+      insertTelemetryBatch: vi.fn().mockResolvedValue(0),
       getLatestTelemetryForType: vi.fn().mockResolvedValue(null),
     },
     messages: {

--- a/src/server/meshtasticManager.duplicate-message.test.ts
+++ b/src/server/meshtasticManager.duplicate-message.test.ts
@@ -50,6 +50,7 @@ vi.mock('../services/database.js', () => ({
     },
     telemetry: {
       insertTelemetry: vi.fn().mockResolvedValue(undefined),
+      insertTelemetryBatch: vi.fn().mockResolvedValue(0),
       getLatestTelemetryForType: vi.fn().mockResolvedValue(null),
     },
     messages: {

--- a/src/server/meshtasticManager.node-identity-guards.test.ts
+++ b/src/server/meshtasticManager.node-identity-guards.test.ts
@@ -69,6 +69,7 @@ vi.mock('../services/database.js', () => ({
     },
     telemetry: {
       insertTelemetry: vi.fn().mockResolvedValue(undefined),
+      insertTelemetryBatch: vi.fn().mockResolvedValue(0),
       getLatestTelemetryForType: vi.fn().mockResolvedValue(null),
     },
     messages: {

--- a/src/server/meshtasticManager.traceroute-hops.test.ts
+++ b/src/server/meshtasticManager.traceroute-hops.test.ts
@@ -66,6 +66,7 @@ vi.mock('../services/database.js', () => ({
     },
     telemetry: {
       insertTelemetry: mockInsertTelemetry,
+      insertTelemetryBatch: vi.fn().mockResolvedValue(0),
       getLatestTelemetryForType: vi.fn().mockResolvedValue(null),
     },
     messages: {

--- a/src/server/meshtasticManager.tracerouteScheduler.test.ts
+++ b/src/server/meshtasticManager.tracerouteScheduler.test.ts
@@ -52,6 +52,7 @@ vi.mock('../services/database.js', () => ({
     },
     telemetry: {
       insertTelemetry: vi.fn().mockResolvedValue(undefined),
+      insertTelemetryBatch: vi.fn().mockResolvedValue(0),
       getLatestTelemetryForType: vi.fn().mockResolvedValue(null),
     },
     messages: {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -334,6 +334,18 @@ class MeshtasticManager implements ISourceManager {
   private keyRepairAutoPurge: boolean = false;   // Default: don't auto-purge
   private keyRepairImmediatePurge: boolean = false; // Default: don't immediately purge on detection
   private serverStartTime: number = Date.now();
+  // Bounded concurrency for inbound packet processing. Prevents pool
+  // starvation during NodeInfo/config-sync bursts (#2780): each handler does
+  // many serial DB awaits, and the transport emits packets without awaiting,
+  // so unbounded concurrency × serial pool checkouts would saturate pg-pool.
+  // Limit is read from PACKET_CONCURRENCY_LIMIT env var once (default 4).
+  private packetConcurrencyLimit: number = (() => {
+    const raw = process.env.PACKET_CONCURRENCY_LIMIT;
+    const parsed = raw ? parseInt(raw, 10) : NaN;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 4;
+  })();
+  private packetActiveCount: number = 0;
+  private packetWaiters: Array<() => void> = [];
   private localNodeInfo: {
     nodeNum: number;
     nodeId: string;
@@ -2814,7 +2826,40 @@ class MeshtasticManager implements ISourceManager {
     }
   }
 
+  /**
+   * Acquire a slot in the packet-processing semaphore. Resolves immediately
+   * if capacity is available; otherwise queues until a prior handler finishes.
+   * Pairs with releasePacketSlot() in a try/finally — see processIncomingData.
+   */
+  private acquirePacketSlot(): Promise<void> {
+    if (this.packetActiveCount < this.packetConcurrencyLimit) {
+      this.packetActiveCount++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.packetWaiters.push(() => {
+        this.packetActiveCount++;
+        resolve();
+      });
+    });
+  }
+
+  private releasePacketSlot(): void {
+    this.packetActiveCount--;
+    const next = this.packetWaiters.shift();
+    if (next) next();
+  }
+
   public async processIncomingData(data: Uint8Array, context?: ProcessingContext): Promise<void> {
+    await this.acquirePacketSlot();
+    try {
+      await this._processIncomingDataImpl(data, context);
+    } finally {
+      this.releasePacketSlot();
+    }
+  }
+
+  private async _processIncomingDataImpl(data: Uint8Array, context?: ProcessingContext): Promise<void> {
     try {
       if (data.length === 0) {
         return;
@@ -6543,7 +6588,6 @@ class MeshtasticManager implements ISourceManager {
           // from the node itself and are authoritative. The local node's own key from
           // device sync IS authoritative since the device knows its own key.
           const isLocalNode = this.localNodeInfo?.nodeNum === Number(nodeInfo.num);
-          const existingNode = await databaseService.nodes.getNode(Number(nodeInfo.num));
 
           // --- Check if device sync resolves a key mismatch ---
           let mismatchResolved = false;
@@ -6718,97 +6762,74 @@ class MeshtasticManager implements ISourceManager {
 
       logger.debug(`🏠 Updated node info: ${nodeData.longName || nodeId}`);
 
-      // Now insert position telemetry if we have it (after node exists in database)
+      // Collect all telemetry rows into one batch to minimize pool acquires.
+      // Before the fix for #2780 each of these was a separate await → separate
+      // pool checkout; a single NodeInfo with position + deviceMetrics + SNR
+      // could take ~11 checkouts and drain the pool under config-sync bursts.
+      const telemetryBatch: Array<any> = [];
+      const nodeNumForTelemetry = Number(nodeInfo.num);
+
+      // Position telemetry (requires node row to already exist — upsert above guarantees that)
       if (positionTelemetryData) {
         const now = Date.now();
-        await databaseService.telemetry.insertTelemetry({
-          nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'latitude',
+        telemetryBatch.push({
+          nodeId, nodeNum: nodeNumForTelemetry, telemetryType: 'latitude',
           timestamp: positionTelemetryData.timestamp, value: positionTelemetryData.latitude, unit: '°', createdAt: now,
           channel: positionTelemetryData.channel, precisionBits: positionTelemetryData.precisionBits
-        }, this.sourceId);
-        await databaseService.telemetry.insertTelemetry({
-          nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'longitude',
+        });
+        telemetryBatch.push({
+          nodeId, nodeNum: nodeNumForTelemetry, telemetryType: 'longitude',
           timestamp: positionTelemetryData.timestamp, value: positionTelemetryData.longitude, unit: '°', createdAt: now,
           channel: positionTelemetryData.channel, precisionBits: positionTelemetryData.precisionBits
-        }, this.sourceId);
+        });
         if (positionTelemetryData.altitude !== undefined && positionTelemetryData.altitude !== null) {
-          await databaseService.telemetry.insertTelemetry({
-            nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'altitude',
+          telemetryBatch.push({
+            nodeId, nodeNum: nodeNumForTelemetry, telemetryType: 'altitude',
             timestamp: positionTelemetryData.timestamp, value: positionTelemetryData.altitude, unit: 'm', createdAt: now,
             channel: positionTelemetryData.channel, precisionBits: positionTelemetryData.precisionBits
-          }, this.sourceId);
+          });
         }
-        // Store ground speed if available (in m/s)
         if (positionTelemetryData.groundSpeed !== undefined && positionTelemetryData.groundSpeed > 0) {
-          await databaseService.telemetry.insertTelemetry({
-            nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'ground_speed',
+          telemetryBatch.push({
+            nodeId, nodeNum: nodeNumForTelemetry, telemetryType: 'ground_speed',
             timestamp: positionTelemetryData.timestamp, value: positionTelemetryData.groundSpeed, unit: 'm/s', createdAt: now,
             channel: positionTelemetryData.channel
-          }, this.sourceId);
+          });
         }
-        // Store ground track/heading if available (in 1/100 degrees, convert to degrees)
         if (positionTelemetryData.groundTrack !== undefined && positionTelemetryData.groundTrack > 0) {
           const headingDegrees = positionTelemetryData.groundTrack / 100;
-          await databaseService.telemetry.insertTelemetry({
-            nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'ground_track',
+          telemetryBatch.push({
+            nodeId, nodeNum: nodeNumForTelemetry, telemetryType: 'ground_track',
             timestamp: positionTelemetryData.timestamp, value: headingDegrees, unit: '°', createdAt: now,
             channel: positionTelemetryData.channel
-          }, this.sourceId);
+          });
         }
-
-        // Update mobility detection for this node (fire and forget)
-        databaseService.updateNodeMobilityAsync(nodeId).catch(err =>
-          logger.error(`Failed to update mobility for ${nodeId}:`, err)
-        );
       }
 
-      // Insert device metrics telemetry if we have it (after node exists in database)
+      // Device metrics telemetry
       if (deviceMetricsTelemetryData) {
         const now = Date.now();
-
-        if (deviceMetricsTelemetryData.batteryLevel !== undefined && deviceMetricsTelemetryData.batteryLevel !== null && !isNaN(deviceMetricsTelemetryData.batteryLevel)) {
-          await databaseService.telemetry.insertTelemetry({
-            nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'batteryLevel',
-            timestamp: deviceMetricsTelemetryData.timestamp, value: deviceMetricsTelemetryData.batteryLevel, unit: '%', createdAt: now
-          }, this.sourceId);
-        }
-
-        if (deviceMetricsTelemetryData.voltage !== undefined && deviceMetricsTelemetryData.voltage !== null && !isNaN(deviceMetricsTelemetryData.voltage)) {
-          await databaseService.telemetry.insertTelemetry({
-            nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'voltage',
-            timestamp: deviceMetricsTelemetryData.timestamp, value: deviceMetricsTelemetryData.voltage, unit: 'V', createdAt: now
-          }, this.sourceId);
-        }
-
-        if (deviceMetricsTelemetryData.channelUtilization !== undefined && deviceMetricsTelemetryData.channelUtilization !== null && !isNaN(deviceMetricsTelemetryData.channelUtilization)) {
-          await databaseService.telemetry.insertTelemetry({
-            nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'channelUtilization',
-            timestamp: deviceMetricsTelemetryData.timestamp, value: deviceMetricsTelemetryData.channelUtilization, unit: '%', createdAt: now
-          }, this.sourceId);
-        }
-
-        if (deviceMetricsTelemetryData.airUtilTx !== undefined && deviceMetricsTelemetryData.airUtilTx !== null && !isNaN(deviceMetricsTelemetryData.airUtilTx)) {
-          await databaseService.telemetry.insertTelemetry({
-            nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'airUtilTx',
-            timestamp: deviceMetricsTelemetryData.timestamp, value: deviceMetricsTelemetryData.airUtilTx, unit: '%', createdAt: now
-          }, this.sourceId);
-        }
-
-        if (deviceMetricsTelemetryData.uptimeSeconds !== undefined && deviceMetricsTelemetryData.uptimeSeconds !== null && !isNaN(deviceMetricsTelemetryData.uptimeSeconds)) {
-          await databaseService.telemetry.insertTelemetry({
-            nodeId, nodeNum: Number(nodeInfo.num), telemetryType: 'uptimeSeconds',
-            timestamp: deviceMetricsTelemetryData.timestamp, value: deviceMetricsTelemetryData.uptimeSeconds, unit: 's', createdAt: now
-          }, this.sourceId);
-        }
+        const dm = deviceMetricsTelemetryData;
+        const maybePush = (type: string, value: any, unit: string) => {
+          if (value !== undefined && value !== null && !isNaN(value)) {
+            telemetryBatch.push({
+              nodeId, nodeNum: nodeNumForTelemetry, telemetryType: type,
+              timestamp: dm.timestamp, value, unit, createdAt: now
+            });
+          }
+        };
+        maybePush('batteryLevel', dm.batteryLevel, '%');
+        maybePush('voltage', dm.voltage, 'V');
+        maybePush('channelUtilization', dm.channelUtilization, '%');
+        maybePush('airUtilTx', dm.airUtilTx, '%');
+        maybePush('uptimeSeconds', dm.uptimeSeconds, 's');
       }
 
-      // Save SNR as telemetry if present in NodeInfo
+      // SNR telemetry — preserve "save only if changed OR ≥10 min" throttle.
+      // This must remain conditional on the existing latest row to avoid DB bloat.
       if (nodeInfo.snr != null && nodeInfo.snr !== -128) {
         const timestamp = nodeInfo.lastHeard ? Number(nodeInfo.lastHeard) * 1000 : Date.now();
         const now = Date.now();
-
-        // Save SNR telemetry with same logic as packet processing:
-        // Save if it has changed OR if 10+ minutes have passed since last save
         const latestSnrTelemetry = await databaseService.getLatestTelemetryForTypeAsync(nodeId, 'snr_remote');
         const tenMinutesMs = 10 * 60 * 1000;
         const shouldSaveSnr = !latestSnrTelemetry ||
@@ -6816,19 +6837,30 @@ class MeshtasticManager implements ISourceManager {
                               (now - latestSnrTelemetry.timestamp) >= tenMinutesMs;
 
         if (shouldSaveSnr) {
-          await databaseService.telemetry.insertTelemetry({
+          telemetryBatch.push({
             nodeId,
-            nodeNum: Number(nodeInfo.num),
+            nodeNum: nodeNumForTelemetry,
             telemetryType: 'snr_remote',
             timestamp,
             value: nodeInfo.snr,
             unit: 'dB',
             createdAt: now
-          }, this.sourceId);
+          });
           const reason = !latestSnrTelemetry ? 'initial' :
                         latestSnrTelemetry.value !== nodeInfo.snr ? 'changed' : 'periodic';
           logger.debug(`📊 Saved remote SNR telemetry from NodeInfo: ${nodeInfo.snr} dB (${reason}, previous: ${latestSnrTelemetry?.value || 'N/A'})`);
         }
+      }
+
+      if (telemetryBatch.length > 0) {
+        await databaseService.telemetry.insertTelemetryBatch(telemetryBatch, this.sourceId);
+      }
+
+      // Update mobility detection once position was persisted (fire and forget)
+      if (positionTelemetryData) {
+        databaseService.updateNodeMobilityAsync(nodeId).catch(err =>
+          logger.error(`Failed to update mobility for ${nodeId}:`, err)
+        );
       }
     } catch (error) {
       logger.error('❌ Error processing NodeInfo protobuf:', error);


### PR DESCRIPTION
## Summary

Fixes #2780. Reporter hit `timeout exceeded when trying to connect` from `pg-pool` during NodeInfo processing on a PG16 backend. Audit found five compounding issues, all addressed in this PR.

### Root causes & fixes

| # | Root cause | Fix |
|---|---|---|
| 1 | `DATABASE_POOL_SIZE` env var never read — pool max hardcoded to 10 even with `DATABASE_POOL_SIZE=25` set | Parse in `getDatabaseConfig()`; log effective max in driver init |
| 2 | `processNodeInfoProtobuf` re-fetched the same node twice per packet | Dropped duplicate `getNode` inside `user` block; reuse outer `existingNode` |
| 3 | Position + device metrics + SNR telemetry did up to 11 serial pool checkouts per NodeInfo | New `TelemetryRepository.insertTelemetryBatch` — single multi-row `INSERT ... ON CONFLICT DO NOTHING` for SQLite/PG, serial fallback for MySQL. `processNodeInfoProtobuf` batches into one call |
| 4 | `transport.on('message', ...)` fires without awaiting, so NodeInfo bursts ran unbounded concurrent handlers × serial pool acquires | FIFO semaphore (`PACKET_CONCURRENCY_LIMIT`, default 4) gates `processIncomingData` |
| 5 | `migrateMessagesForChannelMoves` issued `BEGIN`/`COMMIT` via `db.execute()` — each call checked out a fresh pool client, so BEGIN landed on client A, was released idle-in-transaction, COMMIT hit a different client. Leaked a pool slot per invocation | Rewritten to use `db.transaction()` (sync path for SQLite, async for PG/MySQL) so all statements share one pinned client |

Full audit write-up in the issue thread.

## Test plan

- [x] `vitest run` — 4423 pass / 0 fail
- [x] Migration tests (`messages.migration.test.ts`) — 9/9 pass on the new transaction path
- [x] Local dev container (SQLite) built and browsed — startup, node list, messaging all functional
- [x] New env vars documented in commit message (`DATABASE_POOL_SIZE`, `PACKET_CONCURRENCY_LIMIT`)
- [ ] CI green
- [ ] Reporter (#2780) confirms timeout eliminated under NodeInfo burst with `DATABASE_POOL_SIZE=25`

## New env vars

- `DATABASE_POOL_SIZE` — pg/mysql pool max (default 10). Previously silently ignored.
- `PACKET_CONCURRENCY_LIMIT` — max concurrent in-flight packet handlers (default 4). Bounds worst-case pool demand during NodeInfo bursts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)