### PR TITLE
docs: align README/docs/helm with 4.0 multi-source architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ services:
     volumes:
       - meshmonitor-data:/data
     environment:
-      - MESHTASTIC_NODE_IP=192.168.1.100  # Change to your node's IP
+      - MESHTASTIC_NODE_IP=192.168.1.100  # Seeds the first source on first boot; manage more from Dashboard → Sources
     restart: unless-stopped
 
 volumes:
@@ -216,6 +216,7 @@ MeshMonitor supports multiple deployment methods:
 
 ## Key Features
 
+- **Multi-Source (4.0)** - Monitor multiple Meshtastic nodes from a single deployment; per-source permissions, schedulers, and Virtual Nodes
 - **Real-time Mesh Monitoring** - Live node discovery, telemetry, and message tracking
 - **Modern UI** - Catppuccin theme with message reactions and threading
 - **Interactive Maps** - Node positions and network topology visualization
@@ -253,7 +254,7 @@ npm install
 
 # Configure environment
 cp .env.example .env
-# Edit .env with your Meshtastic node's IP address
+# Edit .env to seed the first source (MESHTASTIC_NODE_IP / MESHTASTIC_TCP_PORT); additional nodes are added later via Dashboard → Sources
 
 # Start development servers
 npm run dev:full

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -8,8 +8,15 @@ This document provides comprehensive documentation for all MeshMonitor API endpo
 
 **Content Type:** `application/json`
 
+::: warning MeshMonitor 4.0 — Per-Source API
+Endpoints listed in this reference without a `sourceId` segment (e.g. `GET /api/nodes`, `GET /api/messages`) are **legacy root-path endpoints**. They still work but now emit an HTTP `Warning: 299` header: `"v1 root-path scoping is deprecated; use /api/v1/sources/:sourceId/... instead"` and will be removed in a future release.
+
+New integrations should use the **per-source v1 API**: `/api/v1/sources/{sourceId}/nodes`, `/api/v1/sources/{sourceId}/messages`, `/api/v1/sources/{sourceId}/telemetry`, etc. Get the list of sources from `GET /api/v1/sources`.
+:::
+
 ## Table of Contents
 
+- [Per-Source v1 API (recommended)](#per-source-v1-api-recommended)
 - [Health & Status](#health--status)
 - [Node Management](#node-management)
 - [Message Operations](#message-operations)
@@ -20,6 +27,47 @@ This document provides comprehensive documentation for all MeshMonitor API endpo
 - [Data Management](#data-management)
 - [Statistics](#statistics)
 - [Authentication](#authentication)
+
+---
+
+## Per-Source v1 API (recommended)
+
+The v1 API scopes every mesh resource by the source (mesh node connection) it belongs to. Most listing endpoints have a per-source equivalent under `/api/v1/sources/{sourceId}/...`.
+
+### GET /api/v1/sources
+List all configured sources. Authentication required.
+
+**Response:**
+```json
+{
+  "sources": [
+    {
+      "id": "01J3ABCDEFG...",
+      "name": "Home Base",
+      "type": "meshtastic_tcp",
+      "enabled": true,
+      "host": "192.168.1.100",
+      "port": 4403
+    }
+  ]
+}
+```
+
+### Per-source resource endpoints
+
+Replace `{sourceId}` with the `id` returned above.
+
+| Legacy (deprecated)   | Per-source v1 (recommended)                    |
+| --------------------- | ---------------------------------------------- |
+| `GET /api/nodes`      | `GET /api/v1/sources/{sourceId}/nodes`         |
+| `GET /api/messages`   | `GET /api/v1/sources/{sourceId}/messages`      |
+| `GET /api/channels`   | `GET /api/v1/sources/{sourceId}/channels`      |
+| `GET /api/telemetry`  | `GET /api/v1/sources/{sourceId}/telemetry`     |
+| `GET /api/traceroutes`| `GET /api/v1/sources/{sourceId}/traceroutes`   |
+| `GET /api/network`    | `GET /api/v1/sources/{sourceId}/network`       |
+| `GET /api/packets`    | `GET /api/v1/sources/{sourceId}/packets`       |
+
+Legacy endpoints return the above `Warning: 299` header and will be removed in a future release.
 
 ---
 
@@ -43,7 +91,7 @@ Comprehensive system status including database, memory, and version information.
 **Response:**
 ```json
 {
-  "version": "2.0.0",
+  "version": "4.0.0",
   "nodeVersion": "v22.0.0",
   "platform": "linux",
   "architecture": "x64",

--- a/docs/api/REST_API.md
+++ b/docs/api/REST_API.md
@@ -10,7 +10,27 @@ The MeshMonitor API provides RESTful endpoints for managing Meshtastic mesh netw
 
 ## Authentication
 
-Currently, the API does not require authentication. All endpoints are publicly accessible when the application is running.
+Most endpoints require authentication. MeshMonitor supports:
+
+- **Session cookies** — from a browser login (`POST /api/auth/login`)
+- **Bearer tokens** — long-lived API tokens issued from the Settings UI; send as `Authorization: Bearer <token>`
+
+Public endpoints are limited to health checks and the optional anonymous read-only mode (`DISABLE_ANONYMOUS=false`).
+
+## API Versioning & Per-Source Scoping (4.0)
+
+MeshMonitor 4.0 reshaped the REST API to scope resources by **source** (a mesh node connection). New code should use the v1 per-source paths:
+
+- `GET /api/v1/sources` — list sources
+- `GET /api/v1/sources/{sourceId}/nodes` — nodes for a specific source
+- `GET /api/v1/sources/{sourceId}/messages` — messages for a specific source
+- `GET /api/v1/sources/{sourceId}/telemetry` — telemetry for a specific source
+- `GET /api/v1/sources/{sourceId}/traceroutes` — traceroutes for a specific source
+- `GET /api/v1/sources/{sourceId}/channels` — channels for a specific source
+
+::: warning Deprecated root-path endpoints
+The legacy root-scoped endpoints below (`GET /api/nodes`, `GET /api/messages`, `GET /api/channels`, `GET /api/telemetry`, `GET /api/traceroutes`, `GET /api/network`, `GET /api/packets`) still work but respond with an HTTP `Warning: 299` header: `"v1 root-path scoping is deprecated; use /api/v1/sources/:sourceId/... instead"`. They will be removed in a future release.
+:::
 
 ## Error Handling
 

--- a/docs/database-migration.md
+++ b/docs/database-migration.md
@@ -1,23 +1,23 @@
 # Database Migration Guide
 
-This guide explains how to migrate your MeshMonitor data from SQLite (v2.x) to PostgreSQL or MySQL (v3.x).
+This guide explains how to migrate your MeshMonitor data from SQLite to PostgreSQL or MySQL. Applies to MeshMonitor 3.x and 4.x.
 
 ## Overview
 
-MeshMonitor 3.x supports three database backends:
+MeshMonitor supports three database backends (since 3.x):
 - **SQLite** (default) - Great for small to medium deployments
 - **PostgreSQL** - Recommended for larger deployments or high availability
 - **MySQL/MariaDB** - Alternative for environments already running MySQL
 
 ## Prerequisites
 
-- MeshMonitor 3.x Docker image (v3.0.0-beta7 or later)
+- MeshMonitor Docker image v3.0.0-beta7 or later (4.x recommended)
 - Access to your existing SQLite database file
 - PostgreSQL or MySQL server (can be a Docker container)
 
 ## Migration Steps
 
-### Step 1: Stop and Backup Your v2.x Instance
+### Step 1: Stop and Backup Your Existing Instance
 
 ```bash
 # Stop the existing MeshMonitor container
@@ -103,7 +103,7 @@ Start MeshMonitor temporarily to create the database schema:
 # Add to your docker-compose.yml
 services:
   meshmonitor:
-    image: ghcr.io/yeraze/meshmonitor:3.0.0-beta7
+    image: ghcr.io/yeraze/meshmonitor:latest
     container_name: meshmonitor
     environment:
       # For PostgreSQL:
@@ -242,8 +242,8 @@ services:
       - "3000:3001"
     environment:
       DATABASE_URL: postgres://meshmonitor:${POSTGRES_PASSWORD:-changeme}@postgres:5432/meshmonitor
-      MESHTASTIC_NODE_HOST: ${MESHTASTIC_NODE_HOST}
-      MESHTASTIC_NODE_PORT: ${MESHTASTIC_NODE_PORT:-4403}
+      MESHTASTIC_NODE_IP: ${MESHTASTIC_NODE_IP}
+      MESHTASTIC_TCP_PORT: ${MESHTASTIC_TCP_PORT:-4403}
       BASE_URL: ${BASE_URL:-/}
     depends_on:
       postgres:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,7 +80,7 @@ services:
     volumes:
       - meshmonitor-data:/data
     environment:
-      - MESHTASTIC_NODE_IP=192.168.1.100  # Change to your node's IP
+      - MESHTASTIC_NODE_IP=192.168.1.100  # Seeds the first source on first boot; add more nodes from Dashboard → Sources
       - ALLOWED_ORIGINS=http://localhost:8080  # Required for CORS
 
 volumes:
@@ -145,14 +145,16 @@ This configuration is ideal for:
 
 ## Optional Configuration
 
-### Different Node IP
+### Change the Bootstrap Source Address
 
-If your Meshtastic node is at a different IP:
+`MESHTASTIC_NODE_IP` only seeds the **first** source on initial install. To change where that first source points _before_ the database is initialized, set a different IP:
 
 ```bash
 export MESHTASTIC_NODE_IP=192.168.5.25
 docker compose up -d
 ```
+
+After first boot, edit the source from **Dashboard → Sources → Edit** instead. Changing the env var post-bootstrap has no effect on an existing source.
 
 ### Custom Timezone
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,7 +100,7 @@ services:
     volumes:
       - meshmonitor-data:/data
     environment:
-      - MESHTASTIC_NODE_IP=192.168.1.100  # Change to your node's IP
+      - MESHTASTIC_NODE_IP=192.168.1.100  # Seeds the first source on first boot; add more from Dashboard → Sources
       - ALLOWED_ORIGINS=http://localhost:8080  # Required for CORS
     restart: unless-stopped
 

--- a/helm/meshmonitor/values.yaml
+++ b/helm/meshmonitor/values.yaml
@@ -33,12 +33,14 @@ ingress:
     #     - meshmonitor.local
 
 # Environment variables
-# Required configuration for Meshtastic node connection
+# Seed values for the first Meshtastic source on first boot.
+# MeshMonitor 4.0 manages additional sources via the Dashboard → Sources UI;
+# changing these values after bootstrap does NOT reconfigure the existing source.
 env:
-  # IP address of your Meshtastic node (REQUIRED)
+  # IP address of the bootstrap source (seeds the first source on a fresh install)
   meshtasticNodeIp: "192.168.1.100"
 
-  # Enable HTTPS connection to node (REQUIRED)
+  # Enable HTTPS connection to node (optional)
   meshtasticUseTls: "false"
 
   # Environment mode (optional)


### PR DESCRIPTION
## Summary

Documentation accuracy pass against the shipped MeshMonitor 4.0 per-source architecture. No functional changes; only user-facing docs, Helm values comments, and API reference. Addresses 8 findings from a full audit of README + `docs/` + `helm/` against 4.0 behavior introduced in PRs #2770, #2773, #2775, #2789, #2790, #2791.

### What changed

- **README.md** — Quick Start env-var comment now explains `MESHTASTIC_NODE_IP` seeds the _first_ source on first boot (further sources managed via Dashboard → Sources). New **Multi-Source (4.0)** bullet under Key Features. Local-dev `.env` comment clarified.
- **docs/getting-started.md** — matching bootstrap comment; the "Different Node IP" section renamed to **"Change the Bootstrap Source Address"** with a note that post-bootstrap changes happen in the Sources UI.
- **docs/index.md** — matching bootstrap comment.
- **docs/api/REST_API.md** — replaces the (incorrect) "API does not require authentication" statement with session-cookie + Bearer-token summary. New **API Versioning & Per-Source Scoping (4.0)** section lists the `/api/v1/sources/{sourceId}/...` paths and documents the `Warning: 299` deprecation header on legacy root-path endpoints.
- **docs/api/API_REFERENCE.md** — adds a 4.0 warning box at the top, a new **Per-Source v1 API** section (with legacy→v1 mapping table) and TOC entry. Stale sample version `2.0.0` → `4.0.0`.
- **docs/database-migration.md** — drops the "v2.x → v3.x" framing (applies to 3.x and 4.x), updates example image tag to `latest`, and fixes two wrong env var names (`MESHTASTIC_NODE_HOST`/`_PORT` → `MESHTASTIC_NODE_IP` / `MESHTASTIC_TCP_PORT`).
- **helm/meshmonitor/values.yaml** — `meshtasticNodeIp` comment no longer labels it "REQUIRED primary config"; documented as the bootstrap seed for the first source.

### Explicitly _not_ changed
- `docs/features/multi-source.md` — already accurate and comprehensive (virtual nodes, per-source scoping, permissions, 3.x → 4.x migration notes).
- `desktop/README.md` — audit found it already accurate in this area.
- `CHANGELOG.md` — already correctly describes the 4.0 reshape.

## Test plan
- [ ] VitePress site renders without broken anchors (new `#per-source-v1-api-recommended` anchor on `docs/api/API_REFERENCE.md`, `:::warning`/`:::tip` containers, table)
- [ ] Spot-check the copy in Quick Start reads cleanly and doesn't contradict the existing "5. Manage Sources (new in 4.0)" section already present in `getting-started.md`
- [ ] Helm `values.yaml` still parses (comment-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)