### PR TITLE
fix(packets): scope Packets by Device to source, fixing >100% percentages (#2794)

### DIFF
--- a/src/components/PacketRateGraphs.tsx
+++ b/src/components/PacketRateGraphs.tsx
@@ -15,6 +15,7 @@ import { usePacketRates, type PacketRatesResponse } from '../hooks/usePacketRate
 import { formatChartAxisTimestamp } from '../utils/datetime';
 import { useFavorites, useToggleFavorite } from '../hooks/useFavorites';
 import { useToast } from './ToastContainer';
+import { useSource } from '../contexts/SourceContext';
 
 // Telemetry type constants for favorites
 export const PACKET_RATE_RX_TYPE = 'packetRateRx';
@@ -118,12 +119,14 @@ const PacketRateGraphs: React.FC<PacketRateGraphsProps> = React.memo(
   ({ nodeId, telemetryHours = 24, baseUrl = '' }) => {
     const { t } = useTranslation();
     const { showToast } = useToast();
+    const { sourceId } = useSource();
 
     // Fetch packet rate data
     const { data: rateData, isLoading, error } = usePacketRates({
       nodeId,
       hours: telemetryHours,
       baseUrl,
+      sourceId,
     });
 
     // Favorites management

--- a/src/db/repositories/misc.packetlog.test.ts
+++ b/src/db/repositories/misc.packetlog.test.ts
@@ -171,3 +171,123 @@ describe('MiscRepository - Packet Log Queries', () => {
     });
   });
 });
+
+/**
+ * Regression tests for #2794 — getPacketCountsByNode must not multiply COUNT(*)
+ * by the number of sources when the same nodeNum appears in multiple rows of
+ * the nodes table (per-source composite PK since migration 029).
+ */
+describe('MiscRepository - getPacketCountsByNode multi-source regression (#2794)', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: MiscRepository;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+
+    // Mirror production composite PK (nodeNum, sourceId) so the same nodeNum
+    // can exist once per source.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS nodes (
+        nodeNum INTEGER NOT NULL,
+        sourceId TEXT NOT NULL,
+        nodeId TEXT,
+        longName TEXT,
+        shortName TEXT,
+        lastHeard INTEGER,
+        hopsAway INTEGER,
+        PRIMARY KEY (nodeNum, sourceId)
+      )
+    `);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS packet_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        packet_id INTEGER,
+        timestamp INTEGER NOT NULL,
+        from_node INTEGER NOT NULL,
+        from_node_id TEXT,
+        to_node INTEGER,
+        to_node_id TEXT,
+        channel INTEGER,
+        portnum INTEGER NOT NULL,
+        portnum_name TEXT,
+        encrypted INTEGER DEFAULT 0,
+        snr REAL,
+        rssi INTEGER,
+        hop_limit INTEGER,
+        hop_start INTEGER,
+        relay_node INTEGER,
+        payload_size INTEGER,
+        want_ack INTEGER DEFAULT 0,
+        priority INTEGER,
+        payload_preview TEXT,
+        metadata TEXT,
+        direction TEXT DEFAULT 'rx',
+        created_at INTEGER,
+        transport_mechanism TEXT,
+        decrypted_by TEXT,
+        decrypted_channel_id INTEGER,
+        sourceId TEXT
+      )
+    `);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS settings (
+        key TEXT PRIMARY KEY,
+        value TEXT
+      )
+    `);
+
+    drizzleDb = drizzle(db, { schema });
+    repo = new MiscRepository(drizzleDb as any, 'sqlite');
+
+    // Same node heard on two sources — produces two rows with the same nodeNum.
+    db.exec(`INSERT INTO nodes (nodeNum, sourceId, nodeId, longName, shortName) VALUES (100, 'srcA', '!00000064', 'Node Alpha (A)', 'ALPH')`);
+    db.exec(`INSERT INTO nodes (nodeNum, sourceId, nodeId, longName, shortName) VALUES (100, 'srcB', '!00000064', 'Node Alpha (B)', 'ALPH')`);
+    db.exec(`INSERT INTO nodes (nodeNum, sourceId, nodeId, longName, shortName) VALUES (200, 'srcA', '!000000c8', 'Node Beta', 'BETA')`);
+
+    const now = Date.now();
+    // Three packets from nodeNum 100 on srcA
+    for (let i = 1; i <= 3; i++) {
+      db.exec(`INSERT INTO packet_log (packet_id, timestamp, from_node, from_node_id, portnum, direction, created_at, sourceId) VALUES (${i}, ${now - i * 1000}, 100, '!00000064', 1, 'rx', ${now}, 'srcA')`);
+    }
+    // One packet from nodeNum 200 on srcA
+    db.exec(`INSERT INTO packet_log (packet_id, timestamp, from_node, from_node_id, portnum, direction, created_at, sourceId) VALUES (10, ${now}, 200, '!000000c8', 1, 'rx', ${now}, 'srcA')`);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('does not double-count packets when a nodeNum exists in multiple sources (unscoped)', async () => {
+    const counts = await repo.getPacketCountsByNode({});
+    const alpha = counts.find(c => c.from_node === 100);
+    expect(alpha).toBeDefined();
+    // 3 packets — NOT 6 (which would be 3 × 2 sources via the old JOIN).
+    expect(alpha!.count).toBe(3);
+  });
+
+  it('scopes to a single source when sourceId is provided', async () => {
+    const counts = await repo.getPacketCountsByNode({ sourceId: 'srcA' });
+    const alpha = counts.find(c => c.from_node === 100);
+    expect(alpha).toBeDefined();
+    expect(alpha!.count).toBe(3);
+    // When scoped, longName comes from the matching source
+    expect(alpha!.from_node_longName).toBe('Node Alpha (A)');
+  });
+
+  it('returns zero rows for a source that has no packets', async () => {
+    const counts = await repo.getPacketCountsByNode({ sourceId: 'srcB' });
+    expect(counts.length).toBe(0);
+  });
+
+  it('percentages against sum of counts stay <= 100%', async () => {
+    const counts = await repo.getPacketCountsByNode({});
+    const sum = counts.reduce((s, c) => s + c.count, 0);
+    expect(sum).toBe(4); // 3 from alpha + 1 from beta
+    for (const c of counts) {
+      expect(c.count / sum).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -1583,14 +1583,29 @@ export class MiscRepository extends BaseRepository {
       const longName = this.col('longName');
       const nodeNum = this.col('nodeNum');
 
+      // Aggregate on packet_log alone — joining `nodes` here would multiply
+      // COUNT(*) by the number of sources because `nodes` has composite PK
+      // (nodeNum, sourceId) since migration 029, so the same nodeNum appears
+      // once per source (#2794). Resolve longName via a scalar subquery that
+      // prefers the requested sourceId and otherwise picks one deterministically.
+      const nameConditions: any[] = [sql`n.${nodeNum} = agg.from_node`];
+      if (sourceId !== undefined) {
+        nameConditions.push(sql`n.${sql.identifier('sourceId')} = ${sourceId}`);
+      }
+      const nameWhere = this.combineConditions(nameConditions);
+
       const query = sql`
-        SELECT pl.from_node, pl.from_node_id, n.${longName} as from_node_longName, COUNT(*) as count
-        FROM packet_log pl
-        LEFT JOIN nodes n ON pl.from_node = n.${nodeNum}
-        WHERE ${whereClause}
-        GROUP BY pl.from_node, pl.from_node_id, n.${longName}
-        ORDER BY count DESC
-        LIMIT ${limit}
+        SELECT agg.from_node, agg.from_node_id,
+          (SELECT n.${longName} FROM nodes n WHERE ${nameWhere} LIMIT 1) as from_node_longName,
+          agg.count
+        FROM (
+          SELECT pl.from_node, pl.from_node_id, COUNT(*) as count
+          FROM packet_log pl
+          WHERE ${whereClause}
+          GROUP BY pl.from_node, pl.from_node_id
+          ORDER BY COUNT(*) DESC
+          LIMIT ${limit}
+        ) agg
       `;
 
       const rows = await this.executeQuery(query);

--- a/src/hooks/usePacketRates.ts
+++ b/src/hooks/usePacketRates.ts
@@ -40,6 +40,8 @@ interface UsePacketRatesOptions {
   hours?: number;
   /** Base URL for API requests (default: '') */
   baseUrl?: string;
+  /** Source ID to scope the query to (optional) */
+  sourceId?: string | null;
   /** Whether to enable the query (default: true) */
   enabled?: boolean;
 }
@@ -68,12 +70,16 @@ export function usePacketRates({
   nodeId,
   hours = 24,
   baseUrl = '',
+  sourceId,
   enabled = true,
 }: UsePacketRatesOptions) {
   return useQuery({
-    queryKey: ['packetRates', nodeId, hours],
+    queryKey: ['packetRates', nodeId, hours, sourceId ?? null],
     queryFn: async (): Promise<PacketRatesResponse> => {
-      const response = await fetch(`${baseUrl}/api/telemetry/${nodeId}/rates?hours=${hours}`);
+      const params = new URLSearchParams();
+      params.set('hours', String(hours));
+      if (sourceId) params.set('sourceId', sourceId);
+      const response = await fetch(`${baseUrl}/api/telemetry/${nodeId}/rates?${params.toString()}`);
 
       if (!response.ok) {
         throw new Error(`Failed to fetch packet rates: ${response.status} ${response.statusText}`);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4029,6 +4029,7 @@ apiRouter.get('/telemetry/:nodeId/rates', optionalAuth(), async (req, res) => {
       return res.status(403).json({ error: 'Insufficient permissions' });
     }
     const hoursParam = req.query.hours ? parseInt(req.query.hours as string) : 24;
+    const ratesSourceId = req.query.sourceId as string | undefined;
 
     // Calculate cutoff timestamp for filtering
     const cutoffTime = Date.now() - hoursParam * 60 * 60 * 1000;
@@ -4056,7 +4057,7 @@ apiRouter.get('/telemetry/:nodeId/rates', optionalAuth(), async (req, res) => {
       // Fetch telemetry for each packet type and calculate rates
       for (const type of packetTypes) {
         const telemetry = await databaseService.telemetry.getTelemetryByNode(
-          nodeId, 5000, cutoffTime, undefined, 0, type
+          nodeId, 5000, cutoffTime, undefined, 0, type, ratesSourceId
         );
 
         // Sort by timestamp ascending for rate calculation
@@ -4080,7 +4081,7 @@ apiRouter.get('/telemetry/:nodeId/rates', optionalAuth(), async (req, res) => {
         }
       }
     } else {
-      rates = await databaseService.getPacketRatesAsync(nodeId, packetTypes, cutoffTime);
+      rates = await databaseService.getPacketRatesAsync(nodeId, packetTypes, cutoffTime, ratesSourceId);
     }
 
     res.json(rates);

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -4000,7 +4000,8 @@ class DatabaseService {
   getPacketRates(
     nodeId: string,
     types: string[],
-    sinceTimestamp?: number
+    sinceTimestamp?: number,
+    sourceId?: string
   ): Record<string, Array<{ timestamp: number; ratePerMinute: number }>> {
     const result: Record<string, Array<{ timestamp: number; ratePerMinute: number }>> = {};
 
@@ -4030,6 +4031,11 @@ class DatabaseService {
     if (sinceTimestamp !== undefined) {
       query += ` AND timestamp >= ?`;
       params.push(sinceTimestamp);
+    }
+
+    if (sourceId !== undefined) {
+      query += ` AND sourceId = ?`;
+      params.push(sourceId);
     }
 
     query += ` ORDER BY telemetryType, timestamp ASC`;
@@ -4101,7 +4107,8 @@ class DatabaseService {
   async getPacketRatesAsync(
     nodeId: string,
     types: string[],
-    sinceTimestamp?: number
+    sinceTimestamp?: number,
+    sourceId?: string
   ): Promise<Record<string, Array<{ timestamp: number; ratePerMinute: number }>>> {
     const result: Record<string, Array<{ timestamp: number; ratePerMinute: number }>> = {};
     for (const type of types) {
@@ -4119,6 +4126,10 @@ class DatabaseService {
           params.push(sinceTimestamp);
           query += ` AND timestamp >= $${params.length}`;
         }
+        if (sourceId !== undefined) {
+          params.push(sourceId);
+          query += ` AND "sourceId" = $${params.length}`;
+        }
         query += ` ORDER BY "telemetryType", timestamp ASC`;
         const queryResult = await client.query(query, params);
         return this.calculatePacketRates(queryResult.rows, types);
@@ -4135,11 +4146,15 @@ class DatabaseService {
         params.push(sinceTimestamp);
         query += ` AND timestamp >= ?`;
       }
+      if (sourceId !== undefined) {
+        params.push(sourceId);
+        query += ` AND sourceId = ?`;
+      }
       query += ` ORDER BY telemetryType, timestamp ASC`;
       const [rows] = await pool.query(query, params);
       return this.calculatePacketRates(rows as any[], types);
     }
-    return this.getPacketRates(nodeId, types, sinceTimestamp);
+    return this.getPacketRates(nodeId, types, sinceTimestamp, sourceId);
   }
 
   private calculatePacketRates(


### PR DESCRIPTION
## Summary

Fixes #2794. On the Info page, "Packets by Device" percentages could exceed 100% whenever a node was heard on more than one source. Root cause: \`getPacketCountsByNode\` LEFT-JOINed \`nodes\` on \`nodeNum\` alone, but since migration 029 \`nodes\` has composite PK \`(nodeNum, sourceId)\` — the join multiplied COUNT(\*) by the number of sources while the denominator (from a separate query without the join) stayed correct.

Also closes a related source-scoping gap on the Info page: \`/api/telemetry/:nodeId/rates\` was not accepting \`sourceId\`, so the packet-rate graphs mixed rates across sources.

## Changes

- \`getPacketCountsByNode\` rewritten to aggregate on \`packet_log\` alone; \`longName\` resolved via a scalar subquery that prefers the requested \`sourceId\`, deterministic otherwise. Cross-DB safe (SQLite/PG/MySQL).
- \`/api/telemetry/:nodeId/rates\` now reads \`req.query.sourceId\` and forwards it into \`getPacketRatesAsync\` / \`getTelemetryByNode\`.
- \`getPacketRates\` (SQLite) and \`getPacketRatesAsync\` (PG/MySQL) accept an optional \`sourceId\` filter.
- \`usePacketRates\` hook accepts \`sourceId\` (added to query key + URL).
- \`PacketRateGraphs\` reads \`useSource()\` and passes it through.
- Regression tests in \`misc.packetlog.test.ts\` for the multi-source double-count, sourceId scoping, empty-source, and the invariant \`sum(count)/total ≤ 1\`.

## Test plan

- [x] New regression tests pass (\`npx vitest run src/db/repositories/misc.packetlog.test.ts\` → 13/13).
- [x] Related suites pass (\`packetRoutes\`, \`usePacketRates\`, \`PacketRateGraphs\`, \`database\` → 61/61).
- [x] Verified in dev container at \`:8081/meshmonitor/\`: Info → Packets by Device now sums to ~100%, no bar >100%.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)