### PR TITLE
chore: bump version to 4.0.0-beta13

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.0.0-beta12",
+  "version": "4.0.0-beta13",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.0.0-beta12",
+  "version": "4.0.0-beta13",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.0.0-beta12
-appVersion: "4.0.0-beta12"
+version: 4.0.0-beta13
+appVersion: "4.0.0-beta13"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta12",
+  "version": "4.0.0-beta13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.0.0-beta12",
+      "version": "4.0.0-beta13",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta12",
+  "version": "4.0.0-beta13",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Version bump to 4.0.0-beta13. Rolls up recent fixes including #2794 (Packets by Device source-scoping).

## Test plan

- [x] All five version files updated: \`package.json\`, \`package-lock.json\`, \`helm/meshmonitor/Chart.yaml\`, \`desktop/package.json\`, \`desktop/src-tauri/tauri.conf.json\`.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)