### PR TITLE
fix(dashboard): respect ignored/active filters and add Unified source

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -44,11 +44,16 @@ vi.mock('../../config/tilesets', () => ({
 // Test data
 // ---------------------------------------------------------------------------
 
+const nowSeconds = Math.floor(Date.now() / 1000);
+const recent = nowSeconds - 60; // 1 minute ago — well inside 24h window
+const stale = nowSeconds - 60 * 60 * 48; // 48h ago — outside default 24h window
+
 const nodeWithPosition = {
   user: { id: 'node-1', shortName: 'N1', longName: 'Node One' },
   position: { latitude: 35.0, longitude: -80.0 },
   hopsAway: 1,
   role: 1,
+  lastHeard: recent,
 };
 
 const nodeWithoutPosition = {
@@ -56,6 +61,7 @@ const nodeWithoutPosition = {
   position: null,
   hopsAway: 2,
   role: 1,
+  lastHeard: recent,
 };
 
 const nodeWithZeroPosition = {
@@ -63,6 +69,33 @@ const nodeWithZeroPosition = {
   position: { latitude: 0, longitude: 0 },
   hopsAway: 3,
   role: 1,
+  lastHeard: recent,
+};
+
+const ignoredNodeWithPosition = {
+  user: { id: 'node-4', shortName: 'N4', longName: 'Ignored Node' },
+  position: { latitude: 36.5, longitude: -81.5 },
+  hopsAway: 1,
+  role: 1,
+  lastHeard: recent,
+  isIgnored: true,
+};
+
+const staleNodeWithPosition = {
+  user: { id: 'node-5', shortName: 'N5', longName: 'Stale Node' },
+  position: { latitude: 36.0, longitude: -81.0 },
+  hopsAway: 1,
+  role: 1,
+  lastHeard: stale,
+};
+
+const staleFavoriteNodeWithPosition = {
+  user: { id: 'node-6', shortName: 'N6', longName: 'Stale Favorite' },
+  position: { latitude: 36.2, longitude: -81.2 },
+  hopsAway: 1,
+  role: 1,
+  lastHeard: stale,
+  isFavorite: true,
 };
 
 const neighborLinkWithPositions = {
@@ -91,6 +124,8 @@ const defaultProps = {
   tilesetId: 'osm',
   customTilesets: [],
   defaultCenter: { lat: 35.0, lng: -80.0 },
+  sourceId: null,
+  maxNodeAgeHours: 24,
 };
 
 // ---------------------------------------------------------------------------
@@ -163,5 +198,48 @@ describe('DashboardMap', () => {
       />,
     );
     expect(screen.queryByText('No node positions')).not.toBeInTheDocument();
+  });
+
+  it('does not render markers for ignored nodes even when they have a position', () => {
+    render(
+      <DashboardMap
+        {...defaultProps}
+        nodes={[nodeWithPosition, ignoredNodeWithPosition]}
+      />,
+    );
+    const markers = screen.getAllByTestId('map-marker');
+    expect(markers.length).toBe(1);
+  });
+
+  it('shows empty state when the only positioned node is ignored', () => {
+    render(
+      <DashboardMap
+        {...defaultProps}
+        nodes={[ignoredNodeWithPosition]}
+      />,
+    );
+    expect(screen.getByText('No node positions')).toBeInTheDocument();
+  });
+
+  it('does not render markers for stale (inactive) nodes outside the maxNodeAgeHours window', () => {
+    render(
+      <DashboardMap
+        {...defaultProps}
+        nodes={[nodeWithPosition, staleNodeWithPosition]}
+      />,
+    );
+    const markers = screen.getAllByTestId('map-marker');
+    expect(markers.length).toBe(1);
+  });
+
+  it('renders markers for stale nodes that are favorites (favorites bypass age filter)', () => {
+    render(
+      <DashboardMap
+        {...defaultProps}
+        nodes={[staleFavoriteNodeWithPosition]}
+      />,
+    );
+    const markers = screen.getAllByTestId('map-marker');
+    expect(markers.length).toBe(1);
   });
 });

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -23,6 +23,8 @@ export interface DashboardMapProps {
   customTilesets: CustomTileset[];
   defaultCenter: { lat: number; lng: number };
   sourceId: string | null;
+  /** Hours since lastHeard to count a node as "active". Favorites bypass this gate. */
+  maxNodeAgeHours: number;
 }
 
 /** Extract lat/lng from a node — handles both flat (API) and nested (position) shapes. */
@@ -74,11 +76,18 @@ export default function DashboardMap({
   customTilesets,
   defaultCenter,
   sourceId,
+  maxNodeAgeHours,
 }: DashboardMapProps) {
   const tileset = getTilesetById(tilesetId, customTilesets);
 
-  // Build array of nodes that have valid positions, with their resolved lat/lng
+  // Build array of nodes that have valid positions, with their resolved lat/lng.
+  // Mirrors NodesTab's processedNodes pipeline (App.tsx): ignored hidden, age cutoff
+  // bypassed by favorites. Dashboard has no "show ignored" / "show stale" toggle,
+  // so both filters apply unconditionally.
+  const cutoffTime = Date.now() / 1000 - maxNodeAgeHours * 60 * 60;
   const nodesWithPosition = nodes
+    .filter((n) => !n.isIgnored)
+    .filter((n) => n.isFavorite || (n.lastHeard != null && n.lastHeard >= cutoffTime))
     .map((n) => ({ node: n, pos: getNodeLatLng(n) }))
     .filter((entry): entry is { node: any; pos: { lat: number; lng: number } } => entry.pos !== null);
 

--- a/src/components/Dashboard/DashboardSidebar.test.tsx
+++ b/src/components/Dashboard/DashboardSidebar.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import DashboardSidebar from './DashboardSidebar';
 import type { DashboardSource, SourceStatus } from '../../hooks/useDashboardData';
+import { UNIFIED_SOURCE_ID } from '../../hooks/useDashboardData';
 
 const makeSources = (): DashboardSource[] => [
   { id: 'src-1', name: 'Source Alpha', type: 'tcp', enabled: true },
@@ -115,5 +116,81 @@ describe('DashboardSidebar', () => {
     expect(openButtons[1]).not.toBeDisabled();
     // src-3 (disabled) should be disabled
     expect(openButtons[2]).toBeDisabled();
+  });
+
+  describe('Unified pseudo-source', () => {
+    const unifiedSource: DashboardSource = {
+      id: UNIFIED_SOURCE_ID,
+      name: 'Unified',
+      type: '__unified__',
+      enabled: true,
+    };
+
+    const renderWithUnified = (props: Partial<typeof defaultProps> = {}) => {
+      const sourcesWithUnified = [unifiedSource, ...makeSources()];
+      const nodeCounts = new Map<string, number>([
+        [UNIFIED_SOURCE_ID, 7],
+        ['src-1', 5],
+        ['src-2', 3],
+        ['src-3', 0],
+      ]);
+      return renderSidebar({
+        sources: sourcesWithUnified,
+        nodeCounts,
+        ...props,
+      });
+    };
+
+    it('renders the Unified card when the synthetic source is in the list', () => {
+      renderWithUnified();
+      expect(screen.getByText('Unified')).toBeInTheDocument();
+    });
+
+    it('does NOT render an Open button for the Unified card', () => {
+      renderWithUnified();
+      // Three real sources still get Open buttons; the Unified card adds none.
+      const openButtons = screen.getAllByRole('button', { name: 'source.open' });
+      expect(openButtons).toHaveLength(3);
+    });
+
+    it('does NOT render a kebab menu for the Unified card even for admin users', () => {
+      renderWithUnified({ isAdmin: true });
+      // Three real sources keep their kebabs; Unified gets none.
+      const kebabs = screen.getAllByRole('button', { name: 'source.options' });
+      expect(kebabs).toHaveLength(3);
+    });
+
+    it('does NOT render a type/VN badge for the Unified card', () => {
+      renderWithUnified();
+      // The synthetic type token must never surface as a visible badge.
+      expect(screen.queryByText('__unified__')).not.toBeInTheDocument();
+    });
+
+    it('shows connected status when at least one backing source is connected', () => {
+      renderWithUnified();
+      const unifiedCard = screen.getByText('Unified').closest('.dashboard-source-card')!;
+      const dot = unifiedCard.querySelector('.dashboard-status-dot');
+      expect(dot).not.toBeNull();
+      expect(dot?.classList.contains('connected')).toBe(true);
+    });
+
+    it('shows disconnected status when no backing source is connected', () => {
+      const allDown: Map<string, SourceStatus | null> = new Map([
+        ['src-1', { sourceId: 'src-1', connected: false }],
+        ['src-2', { sourceId: 'src-2', connected: false }],
+        ['src-3', null],
+      ]);
+      renderWithUnified({ statusMap: allDown });
+      const unifiedCard = screen.getByText('Unified').closest('.dashboard-source-card')!;
+      const dot = unifiedCard.querySelector('.dashboard-status-dot');
+      expect(dot?.classList.contains('disconnected')).toBe(true);
+    });
+
+    it('selects Unified when its card is clicked', () => {
+      const onSelectSource = vi.fn();
+      renderWithUnified({ onSelectSource });
+      fireEvent.click(screen.getByText('Unified').closest('.dashboard-source-card')!);
+      expect(onSelectSource).toHaveBeenCalledWith(UNIFIED_SOURCE_ID);
+    });
   });
 });

--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { version } from '../../../package.json';
 import type { DashboardSource, SourceStatus } from '../../hooks/useDashboardData';
+import { UNIFIED_SOURCE_ID } from '../../hooks/useDashboardData';
 
 interface DashboardSidebarProps {
   sources: DashboardSource[];
@@ -206,11 +207,21 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
       </div>
 
       {sources.map((source) => {
+        const isUnified = source.id === UNIFIED_SOURCE_ID;
         const status = statusMap.get(source.id);
-        const isConnecting = connectingIds?.has(source.id) === true;
-        const { dotClass, label } = isConnecting
-          ? { dotClass: 'connecting', label: t('source.status_connecting') }
-          : getStatusInfo(source, status, t);
+        const isConnecting = !isUnified && connectingIds?.has(source.id) === true;
+        // Unified is a virtual aggregate — show "connected" dot whenever any
+        // backing source is connected. There's nothing to connect to directly.
+        const unifiedConnected = isUnified
+          ? Array.from(statusMap.values()).some((s) => s?.connected === true)
+          : false;
+        const { dotClass, label } = isUnified
+          ? unifiedConnected
+            ? { dotClass: 'connected', label: t('source.status_connected') }
+            : { dotClass: 'disconnected', label: t('source.status_disconnected') }
+          : isConnecting
+            ? { dotClass: 'connecting', label: t('source.status_connecting') }
+            : getStatusInfo(source, status, t);
         const nodeCount = nodeCounts.get(source.id) ?? 0;
         const isSelected = selectedSourceId === source.id;
 
@@ -238,10 +249,10 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
               <span className="dashboard-source-card-name" title={source.name}>
                 {source.name}
               </span>
-              {source.type !== 'meshtastic_tcp' && source.type !== 'meshtastic_mqtt' && (
+              {!isUnified && source.type !== 'meshtastic_tcp' && source.type !== 'meshtastic_mqtt' && (
                 <span className="dashboard-source-card-badge">{source.type}</span>
               )}
-              {(() => {
+              {!isUnified && (() => {
                 const vn = (source.config as any)?.virtualNode;
                 return vn?.enabled ? (
                   <span className="dashboard-source-card-badge" title={t('source.virtual_node_badge_title')}>
@@ -249,7 +260,7 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
                   </span>
                 ) : null;
               })()}
-              {isAdmin && (
+              {!isUnified && isAdmin && (
                 <KebabMenu
                   sourceId={source.id}
                   sourceEnabled={source.enabled}
@@ -276,7 +287,7 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
               ) : (
                 <span className="dashboard-lock-icon">🔒</span>
               )}
-              {isAdmin && source.enabled &&
+              {!isUnified && isAdmin && source.enabled &&
                 (source.config as any)?.autoConnect === false &&
                 !status?.connected &&
                 onConnectSource && (() => {
@@ -295,16 +306,18 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
                     </button>
                   );
                 })()}
-              <button
-                className="dashboard-open-btn"
-                disabled={!source.enabled}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  navigate(`/source/${source.id}`);
-                }}
-              >
-                {t('source.open')}
-              </button>
+              {!isUnified && (
+                <button
+                  className="dashboard-open-btn"
+                  disabled={!source.enabled}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    navigate(`/source/${source.id}`);
+                  }}
+                >
+                  {t('source.open')}
+                </button>
+              )}
             </div>
           </div>
         );

--- a/src/hooks/useDashboardData.test.ts
+++ b/src/hooks/useDashboardData.test.ts
@@ -11,6 +11,8 @@ import { createElement } from 'react';
 import {
   useDashboardSources,
   useDashboardSourceData,
+  useDashboardUnifiedData,
+  mergeUnifiedSourceData,
   type DashboardSource,
   type SourceStatus,
 } from './useDashboardData';
@@ -175,5 +177,238 @@ describe('useDashboardSourceData', () => {
     expect(result.current.channels).toEqual(mockChannels);
     expect(result.current.status).toEqual(mockStatus);
     expect(result.current.isError).toBe(false);
+  });
+});
+
+describe('mergeUnifiedSourceData', () => {
+  it('returns empty arrays when no sources provided', () => {
+    const merged = mergeUnifiedSourceData([]);
+    expect(merged.nodes).toEqual([]);
+    expect(merged.traceroutes).toEqual([]);
+    expect(merged.neighborInfo).toEqual([]);
+    expect(merged.channels).toEqual([]);
+  });
+
+  it('dedupes nodes by nodeNum and prefers field values from the freshest record', () => {
+    const merged = mergeUnifiedSourceData([
+      {
+        nodes: [{ nodeNum: 100, lastHeard: 1000, longName: 'Old' }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+      {
+        nodes: [{ nodeNum: 100, lastHeard: 2000, longName: 'New' }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+    ]);
+    expect(merged.nodes).toHaveLength(1);
+    expect((merged.nodes[0] as any).longName).toBe('New');
+    expect((merged.nodes[0] as any).lastHeard).toBe(2000);
+  });
+
+  it('keeps an older source\'s position when the freshest record has none (field-level merge)', () => {
+    // Reproduces the "node disappears on Unified" bug: source-1 hears the
+    // node most recently but with no GPS; source-2's older record had a
+    // valid position. The merged record must retain the position so the
+    // map can still draw a marker.
+    const merged = mergeUnifiedSourceData([
+      {
+        nodes: [
+          {
+            nodeNum: 200,
+            lastHeard: 5000,
+            longName: 'Roamer',
+            position: null,
+          },
+        ],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+      {
+        nodes: [
+          {
+            nodeNum: 200,
+            lastHeard: 1000,
+            longName: 'Roamer',
+            position: { latitude: 35.0, longitude: -80.0 },
+          },
+        ],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+    ]);
+    expect((merged.nodes[0] as any).position).toEqual({ latitude: 35.0, longitude: -80.0 });
+    expect((merged.nodes[0] as any).lastHeard).toBe(5000);
+  });
+
+  it('only marks merged node as ignored when EVERY source has it ignored', () => {
+    const oneIgnored = mergeUnifiedSourceData([
+      {
+        nodes: [{ nodeNum: 300, lastHeard: 100, isIgnored: true }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+      {
+        nodes: [{ nodeNum: 300, lastHeard: 200, isIgnored: false }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+    ]);
+    expect((oneIgnored.nodes[0] as any).isIgnored).toBe(false);
+
+    const allIgnored = mergeUnifiedSourceData([
+      {
+        nodes: [{ nodeNum: 301, lastHeard: 100, isIgnored: true }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+      {
+        nodes: [{ nodeNum: 301, lastHeard: 200, isIgnored: true }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+    ]);
+    expect((allIgnored.nodes[0] as any).isIgnored).toBe(true);
+  });
+
+  it('marks merged node as favorite when ANY source has it favorited', () => {
+    const merged = mergeUnifiedSourceData([
+      {
+        nodes: [{ nodeNum: 400, lastHeard: 100, isFavorite: false }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+      {
+        nodes: [{ nodeNum: 400, lastHeard: 50, isFavorite: true }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+    ]);
+    expect((merged.nodes[0] as any).isFavorite).toBe(true);
+  });
+
+  it('keeps distinct nodes from different sources', () => {
+    const merged = mergeUnifiedSourceData([
+      { nodes: [{ nodeNum: 1, lastHeard: 100 }], traceroutes: [], neighborInfo: [], channels: [] },
+      { nodes: [{ nodeNum: 2, lastHeard: 100 }], traceroutes: [], neighborInfo: [], channels: [] },
+    ]);
+    expect(merged.nodes).toHaveLength(2);
+  });
+
+  it('skips records missing a numeric nodeNum', () => {
+    const merged = mergeUnifiedSourceData([
+      {
+        nodes: [{ nodeNum: 1, lastHeard: 100 }, { lastHeard: 100 }, null as any, { nodeNum: 'bad', lastHeard: 100 }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+    ]);
+    expect(merged.nodes).toHaveLength(1);
+  });
+
+  it('concatenates traceroutes and neighborInfo across sources', () => {
+    const merged = mergeUnifiedSourceData([
+      { nodes: [], traceroutes: [{ id: 't1' }], neighborInfo: [{ id: 'n1' }], channels: [] },
+      { nodes: [], traceroutes: [{ id: 't2' }], neighborInfo: [{ id: 'n2' }], channels: [] },
+    ]);
+    expect(merged.traceroutes).toEqual([{ id: 't1' }, { id: 't2' }]);
+    expect(merged.neighborInfo).toEqual([{ id: 'n1' }, { id: 'n2' }]);
+  });
+
+  it('takes channels from the first source that has any', () => {
+    const merged = mergeUnifiedSourceData([
+      { nodes: [], traceroutes: [], neighborInfo: [], channels: [] },
+      { nodes: [], traceroutes: [], neighborInfo: [], channels: [{ id: 0, name: 'LongFast' }] },
+      { nodes: [], traceroutes: [], neighborInfo: [], channels: [{ id: 1, name: 'Other' }] },
+    ]);
+    expect(merged.channels).toEqual([{ id: 0, name: 'LongFast' }]);
+  });
+});
+
+describe('useDashboardUnifiedData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty defaults without fetching when disabled', async () => {
+    const { result } = renderHook(
+      () => useDashboardUnifiedData(['src-1', 'src-2'], false),
+      { wrapper: createWrapper() },
+    );
+
+    // Give React a tick to settle effects
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.nodes).toEqual([]);
+    expect(result.current.traceroutes).toEqual([]);
+    expect(result.current.neighborInfo).toEqual([]);
+    expect(result.current.channels).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('returns empty defaults when no sources are provided even if enabled', async () => {
+    const { result } = renderHook(() => useDashboardUnifiedData([], true), {
+      wrapper: createWrapper(),
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.nodes).toEqual([]);
+  });
+
+  it('fans out 4 fetches per source when enabled and merges deduped nodes', async () => {
+    // For each source we expect 4 endpoints: nodes, traceroutes, neighbor-info, channels.
+    // Returns whatever shape the URL implies; the same nodeNum is heard by both sources
+    // so the merge should keep the freshest entry.
+    mockFetch.mockImplementation((url: string) => {
+      const respond = (data: unknown) =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(data) });
+      if (url.endsWith('/sources/src-1/nodes')) return respond([{ nodeNum: 42, lastHeard: 100, longName: 'Old' }]);
+      if (url.endsWith('/sources/src-2/nodes')) return respond([{ nodeNum: 42, lastHeard: 200, longName: 'New' }]);
+      if (url.endsWith('/sources/src-1/traceroutes')) return respond([{ id: 'tr-1' }]);
+      if (url.endsWith('/sources/src-2/traceroutes')) return respond([{ id: 'tr-2' }]);
+      if (url.endsWith('/sources/src-1/neighbor-info')) return respond([{ id: 'ni-1' }]);
+      if (url.endsWith('/sources/src-2/neighbor-info')) return respond([]);
+      if (url.endsWith('/sources/src-1/channels')) return respond([{ id: 0, name: 'LongFast' }]);
+      if (url.endsWith('/sources/src-2/channels')) return respond([]);
+      return respond([]);
+    });
+
+    const { result } = renderHook(
+      () => useDashboardUnifiedData(['src-1', 'src-2'], true),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // 2 sources × 4 endpoints = 8 fetches
+    expect(mockFetch).toHaveBeenCalledTimes(8);
+    expect(result.current.nodes).toHaveLength(1);
+    expect((result.current.nodes[0] as any).longName).toBe('New');
+    expect(result.current.traceroutes).toEqual([{ id: 'tr-1' }, { id: 'tr-2' }]);
+    expect(result.current.neighborInfo).toEqual([{ id: 'ni-1' }]);
+    expect(result.current.channels).toEqual([{ id: 0, name: 'LongFast' }]);
   });
 });

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -39,6 +39,13 @@ export interface SourceStatus {
 export const DASHBOARD_POLL_INTERVAL = 15_000;
 
 /**
+ * Sentinel ID for the synthetic "Unified" source that aggregates nodes/links
+ * across every configured source. Not a real DB row — recognized by the
+ * sidebar and DashboardPage to switch into aggregated rendering.
+ */
+export const UNIFIED_SOURCE_ID = '__unified__';
+
+/**
  * Fetch helper that throws on non-ok so TanStack Query marks it as an error
  * and retries on the next poll interval (important for post-login refetch).
  */
@@ -191,6 +198,185 @@ export function useDashboardSourceData(sourceId: string | null): DashboardSource
     neighborInfo: neighborInfoQuery.data ?? [],
     channels: channelsQuery.data ?? [],
     status: statusQuery.data ?? null,
+    isLoading,
+    isError,
+  };
+}
+
+/**
+ * Merge a set of records describing the same node (heard by multiple sources)
+ * into a single composite. Whole-record "newest wins" loses information when
+ * the most-recently-heard packet lacks fields that older packets had — a
+ * source that just heard a routing packet (no position/user info) would
+ * eclipse another source's older but data-rich record. Instead:
+ *
+ * - Every scalar field is taken from the newest record that has a non-null
+ *   value for that field — so position survives even when the freshest
+ *   record didn't carry one.
+ * - `lastHeard` = max across sources.
+ * - `isFavorite` = OR across sources (favorited anywhere ⇒ favorited).
+ * - `isIgnored` = AND across sources (ignored only if every source has it
+ *   ignored). This matches Unified's "union of visible nodes" semantics:
+ *   if you can see this node on any individual source, you see it here.
+ * - `position` is special-cased to require BOTH lat and lng to be non-null
+ *   on the same source record — otherwise we'd splice a stale lat onto a
+ *   fresh lng and end up at (0, 0) or worse.
+ */
+function mergeNodeRecords(records: any[]): any {
+  const sortedNewestFirst = [...records].sort(
+    (a, b) => (b.lastHeard ?? -1) - (a.lastHeard ?? -1),
+  );
+
+  const merged: any = {};
+  for (const r of sortedNewestFirst) {
+    for (const [k, v] of Object.entries(r)) {
+      if (k === 'position' || k === 'isFavorite' || k === 'isIgnored' || k === 'lastHeard') continue;
+      if ((merged[k] === undefined || merged[k] === null) && v !== undefined && v !== null) {
+        merged[k] = v;
+      }
+    }
+  }
+
+  // Position: take the newest record that has both lat and lng (don't mix
+  // halves from different sources).
+  const withPosition = sortedNewestFirst.find(
+    (r) => r?.position?.latitude != null && r?.position?.longitude != null,
+  );
+  if (withPosition) merged.position = withPosition.position;
+
+  merged.lastHeard = sortedNewestFirst.reduce(
+    (acc: number | null, r) => {
+      const v = r.lastHeard;
+      if (typeof v !== 'number') return acc;
+      return acc == null || v > acc ? v : acc;
+    },
+    null,
+  );
+  merged.isFavorite = sortedNewestFirst.some((r) => r.isFavorite === true);
+  merged.isIgnored = sortedNewestFirst.length > 0 && sortedNewestFirst.every((r) => r.isIgnored === true);
+
+  return merged;
+}
+
+/**
+ * Merge the same record type fetched from N sources into a single array.
+ *
+ * - **Nodes**: grouped by nodeNum, then field-level merged via
+ *   `mergeNodeRecords` so position/user/role survive across sources.
+ * - **NeighborInfo / Traceroutes**: simply concatenated; each row is a
+ *   per-source observation and the map renders one polyline per row.
+ * - **Channels**: taken from the first source that returned any. The
+ *   dashboard map doesn't render channel data; we just need a non-empty
+ *   array so other consumers don't break.
+ */
+export function mergeUnifiedSourceData(
+  perSource: Array<{ nodes: unknown[]; traceroutes: unknown[]; neighborInfo: unknown[]; channels: unknown[] }>,
+): { nodes: unknown[]; traceroutes: unknown[]; neighborInfo: unknown[]; channels: unknown[] } {
+  const recordsByNum = new Map<number, any[]>();
+  const traceroutes: unknown[] = [];
+  const neighborInfo: unknown[] = [];
+  let channels: unknown[] = [];
+
+  for (const ps of perSource) {
+    for (const n of ps.nodes as any[]) {
+      if (n == null || typeof n.nodeNum !== 'number') continue;
+      const bucket = recordsByNum.get(n.nodeNum);
+      if (bucket) bucket.push(n);
+      else recordsByNum.set(n.nodeNum, [n]);
+    }
+    traceroutes.push(...ps.traceroutes);
+    neighborInfo.push(...ps.neighborInfo);
+    if (channels.length === 0 && ps.channels.length > 0) {
+      channels = ps.channels;
+    }
+  }
+
+  const nodes = Array.from(recordsByNum.values()).map(mergeNodeRecords);
+
+  return {
+    nodes,
+    traceroutes,
+    neighborInfo,
+    channels,
+  };
+}
+
+/**
+ * Hook that fetches the same per-source data as useDashboardSourceData but
+ * for *every* source in parallel, then merges into a single dataset for the
+ * synthetic "Unified" view. Disabled (returns empty) when `enabled` is false
+ * so we don't fan out N HTTP requests when the user isn't on the unified
+ * tab.
+ */
+export function useDashboardUnifiedData(
+  sourceIds: string[],
+  enabled: boolean,
+): DashboardSourceData {
+  const { authStatus } = useAuth();
+  const isAuthenticated = authStatus?.authenticated ?? false;
+
+  const queries = useQueries({
+    queries: sourceIds.flatMap((id) => [
+      {
+        queryKey: ['dashboard', 'nodes', id, isAuthenticated],
+        queryFn: () => fetchJson<unknown[]>(`${appBasename}/api/sources/${id}/nodes`),
+        enabled,
+        retry: false,
+        refetchInterval: DASHBOARD_POLL_INTERVAL,
+      },
+      {
+        queryKey: ['dashboard', 'traceroutes', id, isAuthenticated],
+        queryFn: () => fetchJson<unknown[]>(`${appBasename}/api/sources/${id}/traceroutes`),
+        enabled,
+        retry: false,
+        refetchInterval: DASHBOARD_POLL_INTERVAL,
+      },
+      {
+        queryKey: ['dashboard', 'neighborInfo', id, isAuthenticated],
+        queryFn: () => fetchJson<unknown[]>(`${appBasename}/api/sources/${id}/neighbor-info`),
+        enabled,
+        retry: false,
+        refetchInterval: DASHBOARD_POLL_INTERVAL,
+      },
+      {
+        queryKey: ['dashboard', 'channels', id, isAuthenticated],
+        queryFn: () => fetchJson<unknown[]>(`${appBasename}/api/sources/${id}/channels`),
+        enabled,
+        retry: false,
+        refetchInterval: DASHBOARD_POLL_INTERVAL,
+      },
+    ]),
+  });
+
+  if (!enabled || sourceIds.length === 0) {
+    return {
+      nodes: [],
+      traceroutes: [],
+      neighborInfo: [],
+      channels: [],
+      status: null,
+      isLoading: false,
+      isError: false,
+    };
+  }
+
+  const isLoading = queries.some((q) => q.isLoading);
+  const isError = queries.every((q) => q.isError);
+
+  // Group every 4 sequential queries back into one source's bundle, mirroring
+  // the order we registered them in (nodes, traceroutes, neighborInfo, channels).
+  const perSource = sourceIds.map((_, i) => ({
+    nodes: (queries[i * 4 + 0]?.data as unknown[] | undefined) ?? [],
+    traceroutes: (queries[i * 4 + 1]?.data as unknown[] | undefined) ?? [],
+    neighborInfo: (queries[i * 4 + 2]?.data as unknown[] | undefined) ?? [],
+    channels: (queries[i * 4 + 3]?.data as unknown[] | undefined) ?? [],
+  }));
+
+  const merged = mergeUnifiedSourceData(perSource);
+
+  return {
+    ...merged,
+    status: null,
     isLoading,
     isError,
   };

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -29,6 +29,16 @@ vi.mock('../hooks/useDashboardData', () => ({
     isLoading: false,
     isError: false,
   })),
+  useDashboardUnifiedData: vi.fn(() => ({
+    nodes: [],
+    traceroutes: [],
+    neighborInfo: [],
+    channels: [],
+    status: null,
+    isLoading: false,
+    isError: false,
+  })),
+  UNIFIED_SOURCE_ID: '__unified__',
 }));
 
 vi.mock('../contexts/AuthContext', () => ({

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -16,7 +16,10 @@ import {
   useDashboardSources,
   useSourceStatuses,
   useDashboardSourceData,
+  useDashboardUnifiedData,
+  UNIFIED_SOURCE_ID,
 } from '../hooks/useDashboardData';
+import type { DashboardSource } from '../hooks/useDashboardData';
 import DashboardSidebar from '../components/Dashboard/DashboardSidebar';
 import DashboardMap from '../components/Dashboard/DashboardMap';
 import LoginModal from '../components/LoginModal';
@@ -37,7 +40,7 @@ function DashboardInner() {
   const { authStatus } = useAuth();
   const { getToken } = useCsrf();
   const queryClient = useQueryClient();
-  const { mapTileset, customTilesets, defaultMapCenterLat, defaultMapCenterLon } = useSettings();
+  const { mapTileset, customTilesets, defaultMapCenterLat, defaultMapCenterLon, maxNodeAgeHours } = useSettings();
 
   /**
    * Invalidate the source list cache after a mutation so the sidebar
@@ -89,14 +92,42 @@ function DashboardInner() {
   const { data: sources = [], isSuccess } = useDashboardSources();
   const sourceIds = sources.map((s) => s.id);
   const statusMap = useSourceStatuses(sourceIds);
-  const sourceData = useDashboardSourceData(selectedSourceId);
 
-  // Auto-select first enabled source when list loads
+  // Show a synthetic "Unified" entry in the sidebar only when the user has
+  // configured 2+ sources — otherwise it would just duplicate the single
+  // source's data and add UI noise.
+  const showUnified = sources.length >= 2;
+  const isUnifiedSelected = selectedSourceId === UNIFIED_SOURCE_ID;
+
+  // Run both data hooks but disable whichever is not active so we don't fan
+  // out N parallel fetches when the user is on a single-source view.
+  const singleSourceData = useDashboardSourceData(isUnifiedSelected ? null : selectedSourceId);
+  const unifiedSourceData = useDashboardUnifiedData(sourceIds, isUnifiedSelected);
+  const sourceData = isUnifiedSelected ? unifiedSourceData : singleSourceData;
+
+  // Synthetic Unified pseudo-source for the sidebar. Recognized by its sentinel ID
+  // so DashboardSidebar can hide admin/open controls that don't apply.
+  const unifiedSource: DashboardSource | null = showUnified
+    ? {
+        id: UNIFIED_SOURCE_ID,
+        name: t('source.unified', 'Unified'),
+        type: '__unified__',
+        enabled: true,
+      }
+    : null;
+  const sidebarSources: DashboardSource[] = unifiedSource ? [unifiedSource, ...sources] : sources;
+
+  // Auto-select first enabled source when list loads. Default to Unified when
+  // the user has multiple sources — that's the most useful at-a-glance view.
   useEffect(() => {
     if (!isSuccess || sources.length === 0 || selectedSourceId !== null) return;
+    if (showUnified) {
+      setSelectedSourceId(UNIFIED_SOURCE_ID);
+      return;
+    }
     const firstEnabled = sources.find((s) => s.enabled);
     setSelectedSourceId(firstEnabled?.id ?? sources[0].id);
-  }, [isSuccess, sources, selectedSourceId]);
+  }, [isSuccess, sources, selectedSourceId, showUnified]);
 
   // Auto-show news popup when authenticated user has unread news.
   useEffect(() => {
@@ -123,7 +154,9 @@ function DashboardInner() {
   // (added in sourceRoutes.ts), polled in parallel by useSourceStatuses. The
   // currently-selected source uses the live `sourceData.nodes.length` so the
   // counter updates immediately as new nodes arrive instead of waiting for the
-  // next status poll.
+  // next status poll. The Unified entry uses the de-duped merged count when
+  // selected, otherwise the sum of all source statuses (a reasonable estimate
+  // before fan-out fetches happen).
   const nodeCounts = new Map<string, number>(
     sources.map((s) => {
       if (s.id === selectedSourceId) return [s.id, sourceData.nodes.length];
@@ -131,6 +164,14 @@ function DashboardInner() {
       return [s.id, status?.nodeCount ?? 0];
     }),
   );
+  if (unifiedSource) {
+    if (isUnifiedSelected) {
+      nodeCounts.set(UNIFIED_SOURCE_ID, unifiedSourceData.nodes.length);
+    } else {
+      const sum = sources.reduce((acc, s) => acc + (statusMap.get(s.id)?.nodeCount ?? 0), 0);
+      nodeCounts.set(UNIFIED_SOURCE_ID, sum);
+    }
+  }
 
   // ----- admin actions -----
   const onAddSource = () => {
@@ -378,7 +419,7 @@ function DashboardInner() {
       {/* Body */}
       <div className="dashboard-body">
         <DashboardSidebar
-          sources={sources}
+          sources={sidebarSources}
           statusMap={statusMap}
           nodeCounts={nodeCounts}
           selectedSourceId={selectedSourceId}
@@ -409,6 +450,7 @@ function DashboardInner() {
           customTilesets={customTilesets}
           defaultCenter={defaultCenter}
           sourceId={selectedSourceId}
+          maxNodeAgeHours={maxNodeAgeHours}
         />
       </div>
 


### PR DESCRIPTION
## Summary

- Dashboard map now hides ignored nodes and stale (inactive) nodes — favorites bypass the age cutoff. NodesTab already gated on these via `processedNodes`; `DashboardMap` was rendering everything the API returned.
- Adds a synthetic **Unified** entry to the sidebar when 2+ sources are configured. Selecting it aggregates nodes / traceroutes / neighbor-info from every source via a new `useDashboardUnifiedData` hook. Auto-selected on first load when present.
- Node merge is field-level (keyed on `nodeNum`): `lastHeard` = max, `isFavorite` = OR, `isIgnored` = AND, every other field from the freshest record that has a non-null value, position from the freshest source whose record has both lat+lng. This avoids the "node disappears on Unified" bug where a position-less recent packet on one source would eclipse a position-bearing older record on another.
- Sidebar hides Edit / Toggle / Delete / Open / type-badge controls for the Unified pseudo-source; status dot reflects "any backing source connected".

## Test plan

- [x] `npm test` — full suite 4450/0
- [x] New `mergeUnifiedSourceData` unit tests (field-level merge, position retention, ignored-AND, favorite-OR)
- [x] New `useDashboardUnifiedData` hook integration tests (no fetches when disabled, fans out 4×N when enabled, dedupes correctly)
- [x] New `DashboardMap` tests (ignored filter, stale filter, favorite-bypass-age)
- [x] New `DashboardSidebar` tests for Unified pseudo-source (no Open / kebab / type badge, synthetic status dot, click selects Unified)
- [x] Local container deploy — verified ignored nodes drop off the map and Unified merges nodes that previously disappeared

🤖 Generated with [Claude Code](https://claude.com/claude-code)