### PR TITLE
chore: bump version to 4.0.0-beta14

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.0.0-beta13",
+  "version": "4.0.0-beta14",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.0.0-beta13",
+  "version": "4.0.0-beta14",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.0.0-beta13
-appVersion: "4.0.0-beta13"
+version: 4.0.0-beta14
+appVersion: "4.0.0-beta14"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta13",
+  "version": "4.0.0-beta14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.0.0-beta13",
+      "version": "4.0.0-beta14",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta13",
+  "version": "4.0.0-beta14",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Version bump 4.0.0-beta13 → 4.0.0-beta14.

Files updated: \`package.json\`, \`package-lock.json\`, \`desktop/package.json\`, \`desktop/src-tauri/tauri.conf.json\`, \`helm/meshmonitor/Chart.yaml\`.

## Included since beta13

- #2801 — feat(channel-database): JSON export + format docs
- #2800 — fix(dashboard): respect ignored/active filters; add Unified source
- #2798 — chore(deps): npm audit fix
- #2674 — Translations update from Weblate

## Test plan

- [ ] CI green
- [ ] Helm lint passes
- [ ] Desktop bundle builds with new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)