### PR TITLE
fix(dashboard): stabilize Unified source node count (#2805)

### DIFF
--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -6,12 +6,18 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { version } from '../../../package.json';
-import type { DashboardSource, SourceStatus } from '../../hooks/useDashboardData';
+import type { DashboardSource, SourceStatus, UnifiedStatus } from '../../hooks/useDashboardData';
 import { UNIFIED_SOURCE_ID } from '../../hooks/useDashboardData';
 
 interface DashboardSidebarProps {
   sources: DashboardSource[];
   statusMap: Map<string, SourceStatus | null>;
+  /**
+   * Aggregate status from /api/unified/status. When present, drives the
+   * Unified card's connection dot. Reachable for unauthenticated viewers,
+   * unlike the per-source statusMap which is gated by `sources:read`.
+   */
+  unifiedStatus?: UnifiedStatus | null;
   nodeCounts: Map<string, number>;
   selectedSourceId: string | null;
   onSelectSource: (id: string) => void;
@@ -159,6 +165,7 @@ const KebabMenu: React.FC<KebabMenuProps> = ({
 const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
   sources,
   statusMap,
+  unifiedStatus,
   nodeCounts,
   selectedSourceId,
   onSelectSource,
@@ -211,9 +218,15 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
         const status = statusMap.get(source.id);
         const isConnecting = !isUnified && connectingIds?.has(source.id) === true;
         // Unified is a virtual aggregate — show "connected" dot whenever any
-        // backing source is connected. There's nothing to connect to directly.
+        // backing source is connected. Prefer the server-computed
+        // `unifiedStatus.connected` (reachable to anonymous viewers) and fall
+        // back to scanning the per-source statusMap when the poll hasn't
+        // landed yet. The statusMap fallback alone would always read
+        // disconnected for unauthenticated users since /api/sources/:id/status
+        // requires sources:read.
         const unifiedConnected = isUnified
-          ? Array.from(statusMap.values()).some((s) => s?.connected === true)
+          ? unifiedStatus?.connected ??
+            Array.from(statusMap.values()).some((s) => s?.connected === true)
           : false;
         const { dotClass, label } = isUnified
           ? unifiedConnected

--- a/src/db/repositories/nodes.test.ts
+++ b/src/db/repositories/nodes.test.ts
@@ -398,6 +398,37 @@ function runNodesTests(getBackend: () => TestBackend) {
     expect(await repo.getNodeCount()).toBe(2);
   });
 
+  it('getDistinctNodeCount - dedupes nodes shared across sources (issue #2805)', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    expect(await repo.getDistinctNodeCount(['src-a', 'src-b'])).toBe(0);
+
+    // Two sources with one node in common (610) — distinct count must be 3,
+    // not 4. The previous Unified card formula summed per-source counts and
+    // would have returned 4 here.
+    await repo.upsertNode(makeNode(610), 'src-a');
+    await repo.upsertNode(makeNode(611), 'src-a');
+    await repo.upsertNode(makeNode(610), 'src-b');
+    await repo.upsertNode(makeNode(612), 'src-b');
+
+    expect(await repo.getDistinctNodeCount(['src-a'])).toBe(2);
+    expect(await repo.getDistinctNodeCount(['src-b'])).toBe(2);
+    expect(await repo.getDistinctNodeCount(['src-a', 'src-b'])).toBe(3);
+  });
+
+  it('getDistinctNodeCount - returns 0 for empty source list', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+    expect(await repo.getDistinctNodeCount([])).toBe(0);
+  });
+
   // --- updateNodeSecurityFlags ---
 
   it('updateNodeSecurityFlags - sets duplicate key flag and details', async () => {

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -4,7 +4,7 @@
  * Handles all node-related database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, gt, lt, isNull, or, desc, asc, and, isNotNull, ne, sql, inArray, count } from 'drizzle-orm';
+import { eq, gt, lt, isNull, or, desc, asc, and, isNotNull, ne, sql, inArray, count, countDistinct } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbNode } from '../types.js';
 import { logger } from '../../utils/logger.js';
@@ -129,6 +129,28 @@ export class NodesRepository extends BaseRepository {
     const { nodes } = this.tables;
     const result = await this.db.select({ count: count() }).from(nodes)
       .where(this.withSourceScope(nodes, sourceId));
+    return Number(result[0].count);
+  }
+
+  /**
+   * Count distinct nodeNums across the given source IDs.
+   *
+   * Used by the Unified source card so the displayed count reflects the
+   * deduped merged view (a node present in multiple sources counts once),
+   * matching what the user sees when Unified is selected. The previous
+   * fallback summed per-source counts, which over-counted shared nodes and
+   * made the Unified count drift as the user clicked between sources
+   * (issue #2805).
+   *
+   * Returns 0 when sourceIds is empty.
+   */
+  async getDistinctNodeCount(sourceIds: string[]): Promise<number> {
+    if (sourceIds.length === 0) return 0;
+    const { nodes } = this.tables;
+    const result = await this.db
+      .select({ count: countDistinct(nodes.nodeNum) })
+      .from(nodes)
+      .where(inArray(nodes.sourceId, sourceIds));
     return Number(result[0].count);
   }
 

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -100,6 +100,37 @@ export function useSourceStatuses(sourceIds: string[]): Map<string, SourceStatus
 }
 
 /**
+ * Aggregate status returned by GET /api/unified/status — a deduped count of
+ * nodes across every readable source plus a flag indicating whether at least
+ * one source is currently connected.
+ */
+export interface UnifiedStatus {
+  /** Distinct nodeNum count across every source the user can read. */
+  nodeCount: number;
+  /** True when any readable source is currently connected. */
+  connected: boolean;
+}
+
+/**
+ * Hook for the deduped Unified node count.
+ *
+ * The dashboard sidebar uses this so the Unified card displays a stable,
+ * accurate count regardless of which individual source is selected. It
+ * polls on the same cadence as the per-source status calls.
+ */
+export function useUnifiedStatus(): UnifiedStatus | null {
+  const { authStatus } = useAuth();
+  const isAuthenticated = authStatus?.authenticated ?? false;
+  const result = useQuery<UnifiedStatus>({
+    queryKey: ['dashboard', 'unified-status', isAuthenticated],
+    queryFn: () => fetchJson<UnifiedStatus>(`${appBasename}/api/unified/status`),
+    refetchInterval: DASHBOARD_POLL_INTERVAL,
+    retry: false,
+  });
+  return result.data ?? null;
+}
+
+/**
  * Return type for useDashboardSourceData
  */
 export interface DashboardSourceData {

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -38,6 +38,7 @@ vi.mock('../hooks/useDashboardData', () => ({
     isLoading: false,
     isError: false,
   })),
+  useUnifiedStatus: vi.fn(() => ({ nodeCount: 0, connected: false })),
   UNIFIED_SOURCE_ID: '__unified__',
 }));
 

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -17,6 +17,7 @@ import {
   useSourceStatuses,
   useDashboardSourceData,
   useDashboardUnifiedData,
+  useUnifiedStatus,
   UNIFIED_SOURCE_ID,
 } from '../hooks/useDashboardData';
 import type { DashboardSource } from '../hooks/useDashboardData';
@@ -92,6 +93,7 @@ function DashboardInner() {
   const { data: sources = [], isSuccess } = useDashboardSources();
   const sourceIds = sources.map((s) => s.id);
   const statusMap = useSourceStatuses(sourceIds);
+  const unifiedStatus = useUnifiedStatus();
 
   // Show a synthetic "Unified" entry in the sidebar only when the user has
   // configured 2+ sources — otherwise it would just duplicate the single
@@ -154,9 +156,10 @@ function DashboardInner() {
   // (added in sourceRoutes.ts), polled in parallel by useSourceStatuses. The
   // currently-selected source uses the live `sourceData.nodes.length` so the
   // counter updates immediately as new nodes arrive instead of waiting for the
-  // next status poll. The Unified entry uses the de-duped merged count when
-  // selected, otherwise the sum of all source statuses (a reasonable estimate
-  // before fan-out fetches happen).
+  // next status poll. The Unified entry uses the deduped count from
+  // /api/unified/status — a single source of truth that stays stable as the
+  // user clicks between sources (issue #2805). Falls back to the live merged
+  // count when Unified is selected and the polled value hasn't arrived yet.
   const nodeCounts = new Map<string, number>(
     sources.map((s) => {
       if (s.id === selectedSourceId) return [s.id, sourceData.nodes.length];
@@ -165,12 +168,9 @@ function DashboardInner() {
     }),
   );
   if (unifiedSource) {
-    if (isUnifiedSelected) {
-      nodeCounts.set(UNIFIED_SOURCE_ID, unifiedSourceData.nodes.length);
-    } else {
-      const sum = sources.reduce((acc, s) => acc + (statusMap.get(s.id)?.nodeCount ?? 0), 0);
-      nodeCounts.set(UNIFIED_SOURCE_ID, sum);
-    }
+    const polled = unifiedStatus?.nodeCount;
+    const fallback = isUnifiedSelected ? unifiedSourceData.nodes.length : 0;
+    nodeCounts.set(UNIFIED_SOURCE_ID, polled ?? fallback);
   }
 
   // ----- admin actions -----
@@ -421,6 +421,7 @@ function DashboardInner() {
         <DashboardSidebar
           sources={sidebarSources}
           statusMap={statusMap}
+          unifiedStatus={unifiedStatus}
           nodeCounts={nodeCounts}
           selectedSourceId={selectedSourceId}
           onSelectSource={setSelectedSourceId}

--- a/src/server/routes/unifiedRoutes.test.ts
+++ b/src/server/routes/unifiedRoutes.test.ts
@@ -26,6 +26,7 @@ vi.mock('../../services/database.js', () => ({
     },
     nodes: {
       getAllNodes: vi.fn(),
+      getDistinctNodeCount: vi.fn(),
     },
     telemetry: {
       getLatestTelemetryByNode: vi.fn(),
@@ -872,6 +873,52 @@ describe('Unified Routes', () => {
       expect(res.body).toHaveLength(1);
       expect(res.body[0].receptions).toHaveLength(2);
       expect(res.body[0].fromNodeLongName).toBe('Node One'); // src-b's node map won
+    });
+  });
+
+  // ── /status (deduped Unified node count, issue #2805) ────────────────────
+
+  describe('GET /status', () => {
+    it('returns the deduped distinct node count across readable sources', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
+      mockDb.nodes.getDistinctNodeCount.mockResolvedValue(42);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ nodeCount: 42, connected: false });
+      // Admin gets every source's id passed through.
+      expect(mockDb.nodes.getDistinctNodeCount).toHaveBeenCalledWith(['src-a', 'src-b']);
+    });
+
+    it('limits the count to sources the user has read permission on', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
+      mockDb.checkPermissionAsync.mockImplementation(
+        (_uid: number, _res: string, _act: string, sourceId: string) =>
+          Promise.resolve(sourceId === 'src-a'),
+      );
+      mockDb.nodes.getDistinctNodeCount.mockResolvedValue(7);
+
+      const app = createApp(regularUser);
+      const res = await request(app).get('/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.nodeCount).toBe(7);
+      expect(mockDb.nodes.getDistinctNodeCount).toHaveBeenCalledWith(['src-a']);
+    });
+
+    it('returns 0 when the user has no readable sources', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
+      mockDb.checkPermissionAsync.mockResolvedValue(false);
+      mockDb.nodes.getDistinctNodeCount.mockResolvedValue(0);
+
+      const app = createApp(regularUser);
+      const res = await request(app).get('/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ nodeCount: 0, connected: false });
+      expect(mockDb.nodes.getDistinctNodeCount).toHaveBeenCalledWith([]);
     });
   });
 

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -626,6 +626,52 @@ router.get('/telemetry', async (req: Request, res: Response) => {
 });
 
 /**
+ * GET /api/unified/status
+ *
+ * Returns the deduped node count and aggregate connection state across every
+ * source the authenticated user can read. The dashboard sidebar polls this so
+ * the Unified card displays a stable count regardless of which individual
+ * source is currently selected (issue #2805). Previously the sidebar fell
+ * back to a raw sum of per-source counts when Unified wasn't selected, which
+ * over-counted nodes shared between sources and made the value drift as the
+ * user switched between sources.
+ */
+router.get('/status', async (req: Request, res: Response) => {
+  try {
+    const user = (req as any).user;
+    const isAdmin = user?.isAdmin ?? false;
+    const sources = await databaseService.sources.getAllSources();
+
+    // `connected` reflects whether *any* source is currently up. It is not
+    // permission-scoped — same approach as /api/unified/sources-status, since
+    // connection state is operational signal, not user-scoped data. This also
+    // ensures the Unified card shows the correct connection dot for
+    // unauthenticated viewers.
+    const { sourceManagerRegistry } = await import('../sourceManagerRegistry.js');
+    const anyConnected = sources.some((source) => {
+      const manager = sourceManagerRegistry.getManager(source.id);
+      return manager?.getStatus().connected === true;
+    });
+
+    // nodeCount stays permission-scoped so an unauthenticated viewer can't
+    // infer the size of sources they aren't allowed to read.
+    const allowedIds: string[] = [];
+    for (const source of sources) {
+      const canRead = isAdmin || (user
+        ? await databaseService.checkPermissionAsync(user.id, 'nodes', 'read', source.id)
+        : false);
+      if (canRead) allowedIds.push(source.id);
+    }
+    const nodeCount = await databaseService.nodes.getDistinctNodeCount(allowedIds);
+
+    res.json({ nodeCount, connected: anyConnected });
+  } catch (error) {
+    logger.error('Error fetching unified status:', error);
+    res.status(500).json({ error: 'Failed to fetch unified status' });
+  }
+});
+
+/**
  * GET /api/unified/sources-status
  *
  * Returns connection status for all sources the user can access.


### PR DESCRIPTION
## Summary

Fixes #2805. The Unified source card showed an inconsistent node count that drifted depending on which source was currently selected.

The card was computing its count two different ways:
- **Selected:** deduped merged count (`unifiedSourceData.nodes.length`).
- **Not selected:** raw sum of per-source `statusMap.nodeCount` — over-counts any node present in multiple sources.

Plus, anonymous viewers always saw "disconnected" because the connection check fell back to a `statusMap` that's gated by `sources:read`.

## Fix

- New `GET /api/unified/status` returns `{ nodeCount, connected }`.
  - `nodeCount` is `COUNT(DISTINCT nodeNum)` across the user's readable sources (permission-scoped).
  - `connected` reflects whether **any** source is currently up — not permission-scoped, matching the existing `/api/unified/sources-status` (operational signal, not user data).
- New `useUnifiedStatus()` hook polls on the standard 15s dashboard cadence.
- `DashboardPage` and `DashboardSidebar` consume this single source of truth for the Unified card. The previous live-merged length is kept only as a pre-poll fallback when Unified is selected.

## Files

- `src/db/repositories/nodes.ts` — added `getDistinctNodeCount(sourceIds)` using Drizzle `countDistinct`.
- `src/server/routes/unifiedRoutes.ts` — added `GET /status`.
- `src/hooks/useDashboardData.ts` — added `useUnifiedStatus()` + `UnifiedStatus` type.
- `src/components/Dashboard/DashboardSidebar.tsx` — Unified dot prefers `unifiedStatus.connected`, falls back to `statusMap`.
- `src/pages/DashboardPage.tsx` — single formula for Unified count, threads `unifiedStatus` to the sidebar.

## Test plan

- [x] Unit: `nodes.getDistinctNodeCount` dedupes shared nodes across sources, handles empty list.
- [x] Route: `/api/unified/status` admin all-sources, regular-user permission filter, no-readable-sources case.
- [x] Hook + page tests updated to mock `useUnifiedStatus`.
- [x] All existing `unifiedRoutes` (42), `useDashboardData` (16), `DashboardSidebar`, and `DashboardPage` tests pass.
- [x] Manual: SQLite dev container at port 8081 — Unified card stays at deduped count regardless of selection; anonymous viewer sees "Connected" dot when at least one source is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)