### PR TITLE
chore(dev): drop stale RATE_LIMIT_* compose overrides

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -83,9 +83,6 @@ services:
       - ACCESS_LOG_FORMAT=combined
       - ENABLE_VIRTUAL_NODE=${ENABLE_VIRTUAL_NODE:-true}  # Re-enabled on port 4405
       - VIRTUAL_NODE_PORT=${VIRTUAL_NODE_PORT:-4404}
-      - RATE_LIMIT_API=${RATE_LIMIT_API:-100}
-      - RATE_LIMIT_AUTH=${RATE_LIMIT_AUTH:-5}
-      - RATE_LIMIT_MESSAGES=${RATE_LIMIT_MESSAGES:-30}
 
   # SQLite service (default database)
   # Start with: docker compose -f docker-compose.dev.yml --profile sqlite up -d
@@ -131,11 +128,6 @@ services:
       - VIRTUAL_NODE_ALLOW_ADMIN_COMMANDS=${VIRTUAL_NODE_ALLOW_ADMIN_COMMANDS:-true}
       # News feed URL for testing - use host.docker.internal to access host machine
       - NEWS_FEED_URL=${NEWS_FEED_URL:-}
-      # Rate-limit overrides — bump during local testing to avoid 429s on
-      # repeated login / API calls. Defaults match production (100/5/30).
-      - RATE_LIMIT_API=${RATE_LIMIT_API:-100}
-      - RATE_LIMIT_AUTH=${RATE_LIMIT_AUTH:-5}
-      - RATE_LIMIT_MESSAGES=${RATE_LIMIT_MESSAGES:-30}
 
   # MySQL service for testing dual-database support
   # Start with: docker compose -f docker-compose.dev.yml --profile mysql up -d


### PR DESCRIPTION
## Summary
- Removed hardcoded `RATE_LIMIT_API=100 / AUTH=5 / MESSAGES=30` overrides from both meshmonitor service blocks in `docker-compose.dev.yml`.
- Lets the env-aware code defaults apply: **1000/5/30 prod, 10000/5/100 dev** (`src/server/middleware/rateLimiters.ts`, `src/server/config/environment.ts`).

## Why
The compose comment claimed the values "match production (100/5/30)", but production was bumped to 1000 some time ago and the dev default is 10000. The compose override pinned the dev container to the old, much tighter limits, causing `/poll`, `/sources` and `/unified/status` to 429 during normal UI use after any cluster of refetches (e.g. node delete).

Symptom that prompted the fix: deleting a node triggered enough re-fetch fan-out to exhaust the 100/15-min bucket; UI then displayed "node disconnected" because status calls were being rate-limited even though the device backend was healthy.

## Test plan
- [x] `docker compose -f docker-compose.dev.yml --profile sqlite up -d` — container starts
- [x] Startup log shows `RATE_LIMIT_API: 10000 req/min (default)` instead of `100 req/min (env)`
- [ ] UI loads under sustained navigation without 429s

🤖 Generated with [Claude Code](https://claude.com/claude-code)