### PR TITLE
chore(release): cut 4.0.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.0.0-beta14",
+  "version": "4.0.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.0.0-beta14",
+  "version": "4.0.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/public/news.json
+++ b/docs/public/news.json
@@ -1,7 +1,16 @@
 {
   "version": "1",
-  "lastUpdated": "2026-04-21T18:00:00Z",
+  "lastUpdated": "2026-04-27T18:00:00Z",
   "items": [
+    {
+      "minVersion": "4.0.0",
+      "id": "news-2026-04-27-v4.0-release",
+      "title": "Welcome to MeshMonitor 4.0 — Multi-Source Is Here",
+      "content": "**Welcome to the new 4.0 multi-source MeshMonitor.** A single MeshMonitor can now connect to **multiple Meshtastic nodes at once**, each with its own Virtual Node, auto-responder, scheduler, and per-source permissions.\n\n## Action Required After Upgrade\n\n4.0 ships extensive schema migrations and a reorganized permission model. **Please review the following before relying on the upgrade in production:**\n\n- **Permissions** — The permission matrix is now per-source. Check **Settings → Users** and verify each user's access on every source transferred over correctly. See [Per-Source Permissions](https://meshmonitor.org/features/per-source-permissions).\n- **Automation** — Auto-responder, AutoTraceroute, Auto Favorite, Auto-Ping, Auto-Acknowledge, geofences, and other automation settings are now per-source. Open the **Automation** tab on each source and confirm everything migrated as expected.\n- **Configuration** — Several environment variables (including the Virtual Node env vars) are removed in 4.0. Per-source settings now live in the UI. See [Multi-Source](https://meshmonitor.org/features/multi-source).\n\n## Need Help?\n\n- Visit [meshmonitor.org](https://meshmonitor.org) for the full 4.0 documentation and migration guide.\n- Submit bugs at [github.com/Yeraze/meshmonitor/issues](https://github.com/Yeraze/meshmonitor/issues).\n- Join our [Discord](https://discord.gg/JVR3VBETQE) to discuss any issues you find or share what you're doing with 4.0.\n\nThanks for upgrading — happy meshing!",
+      "date": "2026-04-27T18:00:00Z",
+      "category": "release",
+      "priority": "important"
+    },
     {
       "minVersion": "3.12.0",
       "id": "news-2026-04-21-v4.0-coming-soon",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.0.0-beta14
-appVersion: "4.0.0-beta14"
+version: 4.0.0
+appVersion: "4.0.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta14",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.0.0-beta14",
+      "version": "4.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -4992,7 +4992,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5296,7 +5296,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5329,6 +5329,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7870,6 +7871,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -14911,7 +14913,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -15547,14 +15550,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -17058,7 +17053,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0-beta14",
+  "version": "4.0.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

- Bump version from `4.0.0-beta14` to `4.0.0` across all five version-bearing files (`package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml`, `desktop/src-tauri/tauri.conf.json`, `desktop/package.json`)
- Add `news-2026-04-27-v4.0-release` entry to `docs/public/news.json` (minVersion `4.0.0`) — welcomes users to the multi-source 4.0 release and reminds them to review per-source **Permissions** and **Automation** settings after upgrade, with links to meshmonitor.org, GitHub issues, and the Discord

## Test plan

- [ ] CI green (lint, all Test Suite jobs, Security Scan, ClamAV, CodeQL, Trivy, Snyk, Build Check, Docker Build)
- [ ] News popup renders correctly in dev container at `http://localhost:8081/meshmonitor/` after merge & redeploy
- [ ] Verify `4.0.0` shows in About / footer of running container
- [ ] System tests pass on self-hosted runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)