### PR TITLE
fix(settings): stop re-POSTing tracerouteIntervalMinutes on hydration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -952,12 +952,6 @@ function App() {
             }
           }
 
-          if (settings.tracerouteIntervalMinutes) {
-            const value = parseInt(settings.tracerouteIntervalMinutes);
-            setTracerouteIntervalMinutes(value);
-            localStorage.setItem('tracerouteIntervalMinutes', value.toString());
-          }
-
           if (settings.temperatureUnit) {
             setTemperatureUnit(settings.temperatureUnit as TemperatureUnit);
             localStorage.setItem('temperatureUnit', settings.temperatureUnit);

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1011,6 +1011,14 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
             }
           }
 
+          if (settings.tracerouteIntervalMinutes !== undefined) {
+            const value = parseInt(settings.tracerouteIntervalMinutes);
+            if (!isNaN(value)) {
+              setTracerouteIntervalMinutesState(value);
+              localStorage.setItem('tracerouteIntervalMinutes', value.toString());
+            }
+          }
+
           if (settings.preferredSortField) {
             setPreferredSortFieldState(settings.preferredSortField as SortField);
             localStorage.setItem('preferredSortField', settings.preferredSortField);


### PR DESCRIPTION
## Summary
- App boot was reading `tracerouteIntervalMinutes` from `/api/settings` and piping it through the public async setter (`setTracerouteIntervalMinutes`), which POSTs back to `/api/settings/traceroute-interval`. When the stored value sits outside the route's 0–60 range (e.g. a legacy `300`), every page load logs a 400 in the browser console.
- Moves hydration into `SettingsContext.loadServerSettings` using the state-only `setTracerouteIntervalMinutesState`, and drops the duplicate handler in `App.tsx` so UI hydration no longer echoes the server's value back at the server.
- User-initiated changes (Settings UI → `onIntervalChange={setTracerouteIntervalMinutes}`) still hit the POST route, so the actual save path is unchanged.

## Test plan
- [ ] Load the app with a server-side `tracerouteIntervalMinutes` outside 0–60; confirm no 400 in console for `/api/settings/traceroute-interval`.
- [ ] Verify the Settings UI still shows the stored value.
- [ ] Change the interval in the Settings UI; confirm the POST fires and persists.
- [ ] Reload; confirm the new value is hydrated without re-POSTing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)