### PR TITLE
fix(sources): allow virtualNode.port to equal source TCP port (#2823)

### DIFF
--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -27,9 +27,6 @@ async function validateVirtualNodeConfig(
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
     return { status: 400, error: 'virtualNode.port must be an integer between 1 and 65535' };
   }
-  if (typeof config.port === 'number' && port === config.port) {
-    return { status: 400, error: 'virtualNode.port cannot equal the source TCP port' };
-  }
   const all = await databaseService.sources.getAllSources();
   for (const s of all) {
     if (s.id === excludeSourceId) continue;


### PR DESCRIPTION
## Summary
- Removes the validation that rejected `virtualNode.port === config.port` when creating/updating a source.
- The source TCP port is on the remote node's IP (client conn). The virtual node port binds on the MeshMonitor host (server). Different interfaces — no real conflict.
- Restores 3.x behavior where users could expose their virtual node on the same port (e.g. 4403) as the upstream node.

Fixes #2823

## Test plan
- [ ] Add a `meshtastic_tcp` source with port 4403
- [ ] Configure a virtual node on the same source with port 4403 — save succeeds
- [ ] Confirm distinct-port virtual node still works
- [ ] Confirm port-collision between two virtual nodes is still rejected (409)
- [ ] Confirm port range validation (1–65535) still rejects out-of-range values

🤖 Generated with [Claude Code](https://claude.com/claude-code)