### PR TITLE
fix(server): survive SIGTERM and DB-not-ready during long migrations

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -594,6 +594,9 @@ setTimeout(async () => {
 const TELEMETRY_RETENTION_HOURS = 168; // 7 days
 setInterval(async () => {
   try {
+    // Long migrations (e.g. on big MySQL telemetry tables) can keep the DB
+    // unready well past the first tick — wait before touching repos.
+    await databaseService.waitForReady();
     // Get favorite telemetry storage days from settings (defaults to 7 if not set)
     const favoriteDaysStr = await databaseService.settings.getSetting('favoriteTelemetryStorageDays');
     const favoriteDays = favoriteDaysStr ? parseInt(favoriteDaysStr) : 7;
@@ -609,6 +612,10 @@ setInterval(async () => {
 // Run initial purge on startup
 setTimeout(async () => {
   try {
+    // Wait for DB ready: on a fresh upgrade, schema migrations (e.g. 032 dedupe
+    // on a large MySQL telemetry table) can run longer than this 5s delay,
+    // and accessing databaseService.settings before init throws.
+    await databaseService.waitForReady();
     // Get favorite telemetry storage days from settings (defaults to 7 if not set)
     const favoriteDaysStr = await databaseService.settings.getSetting('favoriteTelemetryStorageDays');
     const favoriteDays = favoriteDaysStr ? parseInt(favoriteDaysStr) : 7;
@@ -9903,10 +9910,7 @@ process.on('SIGINT', () => {
 function gracefulShutdown(reason: string): void {
   logger.info(`🛑 Initiating graceful shutdown: ${reason}`);
 
-  // Stop accepting new connections
-  server.close(() => {
-    logger.debug('✅ HTTP server closed');
-
+  const shutdownDependencies = (): void => {
     // Disconnect from Meshtastic
     try {
       meshtasticManager.disconnect();
@@ -9925,7 +9929,20 @@ function gracefulShutdown(reason: string): void {
 
     logger.info('✅ Graceful shutdown complete');
     process.exit(0);
-  });
+  };
+
+  // SIGTERM can arrive during startup (e.g. while long migrations run on a
+  // big MySQL telemetry table) before app.listen() has assigned `server`.
+  // Don't crash on undefined here — just close the rest and exit.
+  if (server) {
+    server.close(() => {
+      logger.debug('✅ HTTP server closed');
+      shutdownDependencies();
+    });
+  } else {
+    logger.info('HTTP server not yet started — skipping server.close()');
+    shutdownDependencies();
+  }
 
   // Force shutdown after 10 seconds if graceful shutdown hangs
   setTimeout(() => {


### PR DESCRIPTION
## Summary

Two startup-path bugs surface on v3.x→4.0 upgrades when migration 032 (telemetry packet dedupe + UNIQUE INDEX) runs longer than 5 seconds — a real scenario on MySQL deployments with large telemetry tables.

- **`Error: Database not initialized` from initial telemetry purge.** The 5s `setTimeout` in `server.ts` fired before `databaseService.waitForReady()` resolved, hitting the `databaseService.settings` getter before `settingsRepo` was assigned. Now both the initial purge and the hourly purge `await databaseService.waitForReady()` first, matching the existing pattern at `server.ts:396` for Meshtastic init.
- **`TypeError: Cannot read properties of undefined (reading 'close')` on SIGTERM.** When SIGTERM arrived during migrations (docker stop, healthcheck timeout), `gracefulShutdown` called `server.close()` before `app.listen()` had assigned the module-level `server` variable. The handler now guards on `server` being defined and otherwise proceeds straight to closing the database / disconnecting Meshtastic and exiting cleanly.

Migration 032 itself is unchanged here — it is idempotent and resumes on the next start. These fixes prevent the upgrade from looking broken (crashy logs) while the long migration is still doing its work.

Repro from a user upgrading 3.12 → 4.0 on MySQL:
```
[INFO] Running migration 032 (MySQL): telemetry packet dedupe...
[ERROR] Error during initial telemetry purge: Error: Database not initialized
    at get settings (file:///app/dist/services/database.js:177:19)
    at Timeout._onTimeout (file:///app/dist/server/server.js:535:55)
[INFO] 🛑 Initiating graceful shutdown: SIGTERM received
TypeError: Cannot read properties of undefined (reading 'close')
    at gracefulShutdown (file:///app/dist/server/server.js:8754:12)
```

## Test plan

- [ ] Boot fresh container on MySQL with sizeable telemetry table; confirm migration 032 finishes without the "Database not initialized" log line.
- [ ] During a long migration, send SIGTERM (docker stop) and verify graceful shutdown logs `HTTP server not yet started — skipping server.close()` and exits 0 instead of crashing.
- [ ] Existing CI suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)