### PR TITLE
fix(migrations): preserve legacy telemetry & neighbor data on 3.12 → 4.0 upgrade

### DIFF
--- a/src/server/migrations/039_purge_null_sourceid_telemetry.test.ts
+++ b/src/server/migrations/039_purge_null_sourceid_telemetry.test.ts
@@ -1,15 +1,27 @@
 /**
- * Migration 039 — Purge NULL-sourceId telemetry
+ * Migration 039 — Reassign NULL-sourceId telemetry to the default source
  *
- * Validates the SQLite migration deletes stranded rows (sourceId IS NULL),
- * preserves rows that carry a sourceId, and is idempotent on second run.
+ * Validates that legacy v3.x telemetry rows (sourceId IS NULL) are migrated
+ * onto the user's default source instead of being purged. Earlier versions
+ * of this migration deleted those rows, silently wiping telemetry history
+ * on the v3.x → v4.0 upgrade.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { migration } from './039_purge_null_sourceid_telemetry.js';
 
-function createTelemetryTable(db: Database.Database) {
+function createSchema(db: Database.Database) {
   db.exec(`
+    CREATE TABLE sources (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL,
+      config TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL,
+      createdBy INTEGER
+    );
     CREATE TABLE telemetry (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       nodeId TEXT NOT NULL,
@@ -25,11 +37,18 @@ function createTelemetryTable(db: Database.Database) {
       precisionBits INTEGER,
       gpsAccuracy INTEGER,
       sourceId TEXT
-    )
+    );
   `);
 }
 
-function insert(db: Database.Database, sourceId: string | null) {
+function insertSource(db: Database.Database, id: string, createdAt: number) {
+  db.prepare(`
+    INSERT INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+    VALUES (?, ?, 'meshtastic_tcp', '{}', 1, ?, ?)
+  `).run(id, `Source ${id}`, createdAt, createdAt);
+}
+
+function insertTelemetry(db: Database.Database, sourceId: string | null) {
   const now = Date.now();
   db.prepare(
     `INSERT INTO telemetry (nodeId, nodeNum, telemetryType, timestamp, value, unit, createdAt, sourceId)
@@ -37,54 +56,110 @@ function insert(db: Database.Database, sourceId: string | null) {
   ).run('!deadbeef', 0xdeadbeef, 'batteryLevel', now, 50, '%', now, sourceId);
 }
 
-describe('Migration 039 — purge NULL-sourceId telemetry', () => {
+describe('Migration 039 — reassign NULL-sourceId telemetry', () => {
   let db: Database.Database;
 
   beforeEach(() => {
     db = new Database(':memory:');
-    createTelemetryTable(db);
+    createSchema(db);
   });
 
-  it('deletes rows with NULL sourceId', () => {
-    insert(db, null);
-    insert(db, null);
-    insert(db, null);
-    expect((db.prepare(`SELECT COUNT(*) c FROM telemetry`).get() as any).c).toBe(3);
+  it('reassigns NULL rows to the existing default (oldest) source', () => {
+    insertSource(db, 'src-old', 1000);
+    insertSource(db, 'src-new', 2000);
+    insertTelemetry(db, null);
+    insertTelemetry(db, null);
+    insertTelemetry(db, null);
 
-    migration.up(db);
-
-    expect((db.prepare(`SELECT COUNT(*) c FROM telemetry`).get() as any).c).toBe(0);
-  });
-
-  it('preserves rows with a non-NULL sourceId', () => {
-    insert(db, 'source-A');
-    insert(db, 'source-B');
-    insert(db, null);
-
-    migration.up(db);
-
-    const rows = db.prepare(`SELECT sourceId FROM telemetry ORDER BY sourceId`).all() as any[];
-    expect(rows).toHaveLength(2);
-    expect(rows.map((r) => r.sourceId)).toEqual(['source-A', 'source-B']);
-  });
-
-  it('is idempotent — running twice is a no-op after the first pass', () => {
-    insert(db, null);
-    insert(db, 'source-A');
-
-    migration.up(db);
     migration.up(db);
 
     const rows = db.prepare(`SELECT sourceId FROM telemetry`).all() as any[];
-    expect(rows).toHaveLength(1);
-    expect(rows[0].sourceId).toBe('source-A');
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row.sourceId).toBe('src-old');
+    }
+  });
+
+  it('preserves rows that already carry a sourceId', () => {
+    insertSource(db, 'src-old', 1000);
+    insertTelemetry(db, 'source-A');
+    insertTelemetry(db, 'source-B');
+    insertTelemetry(db, null);
+
+    migration.up(db);
+
+    const rows = db.prepare(`SELECT sourceId FROM telemetry ORDER BY id`).all() as any[];
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.sourceId)).toEqual(['source-A', 'source-B', 'src-old']);
+  });
+
+  it('synthesizes a default source when sources table is empty', () => {
+    insertTelemetry(db, null);
+    insertTelemetry(db, null);
+
+    migration.up(db);
+
+    const sources = db.prepare(`SELECT id FROM sources`).all() as any[];
+    expect(sources).toHaveLength(1);
+    const synthId = sources[0].id;
+
+    const telemetry = db.prepare(`SELECT sourceId FROM telemetry`).all() as any[];
+    expect(telemetry).toHaveLength(2);
+    for (const row of telemetry) {
+      expect(row.sourceId).toBe(synthId);
+    }
+  });
+
+  it('is idempotent — running twice is a no-op after the first pass', () => {
+    insertSource(db, 'src-old', 1000);
+    insertTelemetry(db, null);
+    insertTelemetry(db, 'source-A');
+
+    migration.up(db);
+    const sourcesAfterFirst = db.prepare(`SELECT id FROM sources ORDER BY createdAt`).all() as any[];
+
+    migration.up(db);
+    const sourcesAfterSecond = db.prepare(`SELECT id FROM sources ORDER BY createdAt`).all() as any[];
+
+    expect(sourcesAfterSecond).toEqual(sourcesAfterFirst);
+    const rows = db.prepare(`SELECT sourceId FROM telemetry ORDER BY id`).all() as any[];
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.sourceId)).toEqual(['src-old', 'source-A']);
+  });
+
+  it('skips when sources table does not yet exist', () => {
+    const bareDb = new Database(':memory:');
+    try {
+      bareDb.exec(`
+        CREATE TABLE telemetry (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          nodeId TEXT NOT NULL,
+          nodeNum INTEGER NOT NULL,
+          telemetryType TEXT NOT NULL,
+          timestamp INTEGER NOT NULL,
+          value REAL NOT NULL,
+          unit TEXT,
+          createdAt INTEGER NOT NULL,
+          sourceId TEXT
+        );
+      `);
+      insertTelemetry(bareDb, null);
+
+      expect(() => migration.up(bareDb)).not.toThrow();
+
+      const rows = bareDb.prepare(`SELECT sourceId FROM telemetry`).all() as any[];
+      expect(rows).toHaveLength(1);
+      expect(rows[0].sourceId).toBeNull();
+    } finally {
+      bareDb.close();
+    }
   });
 });
 
 /**
  * Regression for 4.0.0-beta7 bootloop: legacy v3.x databases carry
  * `telemetry.nodeNum REFERENCES nodes(nodeNum)`. After migration 029 swaps
- * nodes to a composite PK, that FK is structurally invalid and any DELETE
+ * nodes to a composite PK, that FK is structurally invalid and any write
  * on telemetry with foreign_keys=ON raises "foreign key mismatch -
  * telemetry referencing nodes". 039 must tolerate this.
  */
@@ -95,6 +170,16 @@ describe('Migration 039 — legacy FK regression', () => {
     db = new Database(':memory:');
     db.pragma('foreign_keys = ON');
     db.exec(`
+      CREATE TABLE sources (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL,
+        config TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        createdAt INTEGER NOT NULL,
+        updatedAt INTEGER NOT NULL,
+        createdBy INTEGER
+      );
       CREATE TABLE nodes (
         nodeNum INTEGER NOT NULL,
         sourceId TEXT NOT NULL,
@@ -118,25 +203,25 @@ describe('Migration 039 — legacy FK regression', () => {
         FOREIGN KEY (nodeNum) REFERENCES nodes(nodeNum)
       );
     `);
+    insertSource(db, 'src-old', 1000);
   });
 
   it('runs without raising "foreign key mismatch" even with legacy FK + composite PK', () => {
-    // Seed with FKs off — the broken FK would block the INSERT itself otherwise.
     db.pragma('foreign_keys = OFF');
-    insert(db, null);
-    insert(db, 'source-A');
+    insertTelemetry(db, null);
+    insertTelemetry(db, 'source-A');
     db.pragma('foreign_keys = ON');
 
     expect(() => migration.up(db)).not.toThrow();
 
-    const rows = db.prepare(`SELECT sourceId FROM telemetry`).all() as any[];
-    expect(rows).toHaveLength(1);
-    expect(rows[0].sourceId).toBe('source-A');
+    const rows = db.prepare(`SELECT sourceId FROM telemetry ORDER BY id`).all() as any[];
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.sourceId)).toEqual(['src-old', 'source-A']);
   });
 
   it('restores foreign_keys=ON after running', () => {
     db.pragma('foreign_keys = OFF');
-    insert(db, null);
+    insertTelemetry(db, null);
     db.pragma('foreign_keys = ON');
     migration.up(db);
     expect(db.pragma('foreign_keys', { simple: true })).toBe(1);

--- a/src/server/migrations/039_purge_null_sourceid_telemetry.ts
+++ b/src/server/migrations/039_purge_null_sourceid_telemetry.ts
@@ -1,38 +1,64 @@
 /**
- * Migration 039: Purge telemetry rows with NULL sourceId.
+ * Migration 039: Backfill telemetry rows with NULL sourceId.
  *
- * Before v4.0.0-beta4 the write path in meshtasticManager.ts never passed
- * `this.sourceId` into `databaseService.insertTelemetry(...)`, so every
- * telemetry row inserted since migration 021 introduced the column was
- * persisted with `sourceId = NULL`. The read path filters strictly on
- * equality (`withSourceScope`), so source-scoped views returned zero rows
- * and the per-node TelemetryGraphs were empty.
+ * Two upgrade paths produce telemetry rows with `sourceId = NULL`:
+ *  - v3.x → v4.0 upgrade: legacy single-source databases. Migration 021
+ *    added the column nullable; v3 never wrote a value.
+ *  - 4.0.0-beta1..beta3 write-path bug: meshtasticManager.ts didn't forward
+ *    `this.sourceId` into `insertTelemetry`. Fixed in beta4.
  *
- * The write path is now fixed; this migration discards the stranded rows
- * so the read path can reflect incoming, correctly-tagged data.
+ * Both states are equivalent — the rows belong to the user's "default"
+ * source (the only source that existed when they were captured). Earlier
+ * versions of this migration deleted them, which silently wiped the entire
+ * telemetry history on upgrade. Reassign instead.
  *
- * Idempotent — re-running is a no-op once NULL rows are gone.
+ * Idempotent — once every row has a sourceId, re-runs update 0 rows.
  */
 import type { Database } from 'better-sqlite3';
 import { logger } from '../../utils/logger.js';
+import {
+  ensureDefaultSourceIdSqlite,
+  ensureDefaultSourceIdPostgres,
+  ensureDefaultSourceIdMysql,
+} from './_legacyDefaultSource.js';
 
 export const migration = {
   up(db: Database): void {
     // Legacy v3.x databases carry `telemetry.nodeNum REFERENCES nodes(nodeNum)`.
     // Migration 029 rebuilt nodes with composite PK, so the FK is structurally
-    // invalid and DELETE on telemetry raises "foreign key mismatch" with
-    // foreign_keys=ON. Disable FK enforcement for this migration and restore
-    // in finally. See 029/030/032 for the same pattern.
+    // invalid and any write on telemetry raises "foreign key mismatch" with
+    // foreign_keys=ON. Disable FK enforcement and restore in finally. See
+    // 029/030/032/040 for the same pattern.
     const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
     if (prevForeignKeys) {
       db.pragma('foreign_keys = OFF');
     }
     try {
+      const nullCountRow = db
+        .prepare(`SELECT COUNT(*) AS c FROM telemetry WHERE sourceId IS NULL`)
+        .get() as { c: number } | undefined;
+      const nullCount = nullCountRow?.c ?? 0;
+      if (nullCount === 0) {
+        return;
+      }
+
+      const defaultSourceId = ensureDefaultSourceIdSqlite(db, 'Migration 039');
+      if (!defaultSourceId) {
+        // Sources table doesn't exist yet (db never ran migration 020). Leave
+        // rows alone — server.ts startup will assign once a source is registered.
+        logger.warn(
+          `Migration 039: ${nullCount} NULL-sourceId telemetry rows but no sources table; skipping`
+        );
+        return;
+      }
+
       const res = db
-        .prepare(`DELETE FROM telemetry WHERE sourceId IS NULL`)
-        .run();
+        .prepare(`UPDATE telemetry SET sourceId = ? WHERE sourceId IS NULL`)
+        .run(defaultSourceId);
       if (res.changes > 0) {
-        logger.info(`Migration 039: purged ${res.changes} telemetry rows with NULL sourceId`);
+        logger.info(
+          `Migration 039: assigned ${res.changes} legacy telemetry rows to default source '${defaultSourceId}'`
+        );
       }
     } finally {
       if (prevForeignKeys) {
@@ -43,20 +69,58 @@ export const migration = {
 };
 
 export async function runMigration039Postgres(client: any): Promise<void> {
+  const nullRes = await client.query(
+    `SELECT COUNT(*)::int AS c FROM telemetry WHERE "sourceId" IS NULL`
+  );
+  const nullCount = nullRes.rows[0]?.c ?? 0;
+  if (nullCount === 0) {
+    return;
+  }
+
+  const defaultSourceId = await ensureDefaultSourceIdPostgres(client, 'Migration 039');
+  if (!defaultSourceId) {
+    logger.warn(
+      `Migration 039: ${nullCount} NULL-sourceId telemetry rows but no sources table; skipping (PG)`
+    );
+    return;
+  }
+
   const res = await client.query(
-    `DELETE FROM telemetry WHERE "sourceId" IS NULL`
+    `UPDATE telemetry SET "sourceId" = $1 WHERE "sourceId" IS NULL`,
+    [defaultSourceId],
   );
   if (res.rowCount && res.rowCount > 0) {
-    logger.info(`Migration 039: purged ${res.rowCount} telemetry rows with NULL sourceId (PG)`);
+    logger.info(
+      `Migration 039: assigned ${res.rowCount} legacy telemetry rows to default source '${defaultSourceId}' (PG)`
+    );
   }
 }
 
 export async function runMigration039Mysql(pool: any): Promise<void> {
+  const [nullRows] = await pool.query(
+    `SELECT COUNT(*) AS c FROM telemetry WHERE sourceId IS NULL`
+  );
+  const nullCount = Number((nullRows as any[])[0]?.c ?? 0);
+  if (nullCount === 0) {
+    return;
+  }
+
+  const defaultSourceId = await ensureDefaultSourceIdMysql(pool, 'Migration 039');
+  if (!defaultSourceId) {
+    logger.warn(
+      `Migration 039: ${nullCount} NULL-sourceId telemetry rows but no sources table; skipping (MySQL)`
+    );
+    return;
+  }
+
   const [res] = await pool.query(
-    `DELETE FROM telemetry WHERE sourceId IS NULL`
+    `UPDATE telemetry SET sourceId = ? WHERE sourceId IS NULL`,
+    [defaultSourceId],
   );
   const affected = (res as any).affectedRows ?? 0;
   if (affected > 0) {
-    logger.info(`Migration 039: purged ${affected} telemetry rows with NULL sourceId (MySQL)`);
+    logger.info(
+      `Migration 039: assigned ${affected} legacy telemetry rows to default source '${defaultSourceId}' (MySQL)`
+    );
   }
 }

--- a/src/server/migrations/040_purge_null_sourceid_neighbor_info.test.ts
+++ b/src/server/migrations/040_purge_null_sourceid_neighbor_info.test.ts
@@ -1,15 +1,27 @@
 /**
- * Migration 040 — Purge NULL-sourceId neighbor_info
+ * Migration 040 — Reassign NULL-sourceId neighbor_info to the default source
  *
- * Validates the SQLite migration deletes rows with sourceId IS NULL,
- * preserves rows that carry a sourceId, and is idempotent on second run.
+ * Validates that legacy v3.x neighbor_info rows (sourceId IS NULL) are
+ * migrated onto the user's default source instead of being purged. Earlier
+ * versions of this migration deleted those rows, silently wiping neighbor
+ * history on the v3.x → v4.0 upgrade.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { migration } from './040_purge_null_sourceid_neighbor_info.js';
 
-function createNeighborInfoTable(db: Database.Database) {
+function createSchema(db: Database.Database) {
   db.exec(`
+    CREATE TABLE sources (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL,
+      config TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL,
+      createdBy INTEGER
+    );
     CREATE TABLE neighbor_info (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       nodeNum INTEGER NOT NULL,
@@ -19,11 +31,18 @@ function createNeighborInfoTable(db: Database.Database) {
       timestamp INTEGER NOT NULL,
       createdAt INTEGER NOT NULL,
       sourceId TEXT
-    )
+    );
   `);
 }
 
-function insert(db: Database.Database, sourceId: string | null) {
+function insertSource(db: Database.Database, id: string, createdAt: number) {
+  db.prepare(`
+    INSERT INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+    VALUES (?, ?, 'meshtastic_tcp', '{}', 1, ?, ?)
+  `).run(id, `Source ${id}`, createdAt, createdAt);
+}
+
+function insertNeighbor(db: Database.Database, sourceId: string | null) {
   const now = Date.now();
   db.prepare(
     `INSERT INTO neighbor_info (nodeNum, neighborNodeNum, snr, lastRxTime, timestamp, createdAt, sourceId)
@@ -31,47 +50,71 @@ function insert(db: Database.Database, sourceId: string | null) {
   ).run(0xdeadbeef, 0xcafebabe, 5.5, now, now, now, sourceId);
 }
 
-describe('Migration 040 — purge NULL-sourceId neighbor_info', () => {
+describe('Migration 040 — reassign NULL-sourceId neighbor_info', () => {
   let db: Database.Database;
 
   beforeEach(() => {
     db = new Database(':memory:');
-    createNeighborInfoTable(db);
+    createSchema(db);
   });
 
-  it('deletes rows with NULL sourceId', () => {
-    insert(db, null);
-    insert(db, null);
-    insert(db, null);
-    expect((db.prepare(`SELECT COUNT(*) c FROM neighbor_info`).get() as any).c).toBe(3);
+  it('reassigns NULL rows to the existing default (oldest) source', () => {
+    insertSource(db, 'src-old', 1000);
+    insertSource(db, 'src-new', 2000);
+    insertNeighbor(db, null);
+    insertNeighbor(db, null);
+    insertNeighbor(db, null);
 
-    migration.up(db);
-
-    expect((db.prepare(`SELECT COUNT(*) c FROM neighbor_info`).get() as any).c).toBe(0);
-  });
-
-  it('preserves rows with a non-NULL sourceId', () => {
-    insert(db, 'source-A');
-    insert(db, 'source-B');
-    insert(db, null);
-
-    migration.up(db);
-
-    const rows = db.prepare(`SELECT sourceId FROM neighbor_info ORDER BY sourceId`).all() as any[];
-    expect(rows).toHaveLength(2);
-    expect(rows.map((r) => r.sourceId)).toEqual(['source-A', 'source-B']);
-  });
-
-  it('is idempotent — running twice is a no-op after the first pass', () => {
-    insert(db, null);
-    insert(db, 'source-A');
-
-    migration.up(db);
     migration.up(db);
 
     const rows = db.prepare(`SELECT sourceId FROM neighbor_info`).all() as any[];
-    expect(rows).toHaveLength(1);
-    expect(rows[0].sourceId).toBe('source-A');
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row.sourceId).toBe('src-old');
+    }
+  });
+
+  it('preserves rows that already carry a sourceId', () => {
+    insertSource(db, 'src-old', 1000);
+    insertNeighbor(db, 'source-A');
+    insertNeighbor(db, 'source-B');
+    insertNeighbor(db, null);
+
+    migration.up(db);
+
+    const rows = db.prepare(`SELECT sourceId FROM neighbor_info ORDER BY id`).all() as any[];
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.sourceId)).toEqual(['source-A', 'source-B', 'src-old']);
+  });
+
+  it('synthesizes a default source when sources table is empty', () => {
+    insertNeighbor(db, null);
+    insertNeighbor(db, null);
+
+    migration.up(db);
+
+    const sources = db.prepare(`SELECT id FROM sources`).all() as any[];
+    expect(sources).toHaveLength(1);
+    const synthId = sources[0].id;
+
+    const rows = db.prepare(`SELECT sourceId FROM neighbor_info`).all() as any[];
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.sourceId).toBe(synthId);
+    }
+  });
+
+  it('is idempotent — running twice is a no-op after the first pass', () => {
+    insertSource(db, 'src-old', 1000);
+    insertNeighbor(db, null);
+    insertNeighbor(db, 'source-A');
+
+    migration.up(db);
+    migration.up(db);
+
+    const rows = db.prepare(`SELECT sourceId FROM neighbor_info ORDER BY id`).all() as any[];
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.sourceId)).toEqual(['src-old', 'source-A']);
   });
 
   it('succeeds on legacy schema: neighbor_info FK to nodes(nodeNum) + composite nodes PK', () => {
@@ -79,12 +122,21 @@ describe('Migration 040 — purge NULL-sourceId neighbor_info', () => {
     //   - Pre-029: nodes PK was (nodeNum); neighbor_info.nodeNum FK → nodes(nodeNum)
     //   - Migration 029 rebuilt nodes with composite PK (nodeNum, sourceId)
     //   - neighbor_info FK is now structurally invalid (nodeNum alone not unique)
-    //   - With foreign_keys=ON, DELETE raises "foreign key mismatch"
+    //   - With foreign_keys=ON, any write raises "foreign key mismatch"
     const legacyDb = new Database(':memory:');
     try {
-      // Seed with FKs off — the broken FK otherwise blocks even INSERT.
       legacyDb.pragma('foreign_keys = OFF');
       legacyDb.exec(`
+        CREATE TABLE sources (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          type TEXT NOT NULL,
+          config TEXT NOT NULL,
+          enabled INTEGER NOT NULL DEFAULT 1,
+          createdAt INTEGER NOT NULL,
+          updatedAt INTEGER NOT NULL,
+          createdBy INTEGER
+        );
         CREATE TABLE nodes (
           nodeNum INTEGER NOT NULL,
           sourceId TEXT NOT NULL,
@@ -101,6 +153,7 @@ describe('Migration 040 — purge NULL-sourceId neighbor_info', () => {
           sourceId TEXT
         );
       `);
+      insertSource(legacyDb, 'src-old', 1000);
       const now = Date.now();
       legacyDb
         .prepare(
@@ -109,15 +162,13 @@ describe('Migration 040 — purge NULL-sourceId neighbor_info', () => {
         )
         .run(1, 2, 5.5, now, now, now, null);
 
-      // Mirror the production state at migration time: FK enforcement on,
-      // structurally-invalid FK still declared in the schema.
       legacyDb.pragma('foreign_keys = ON');
 
       expect(() => migration.up(legacyDb)).not.toThrow();
 
-      expect(
-        (legacyDb.prepare(`SELECT COUNT(*) c FROM neighbor_info`).get() as any).c
-      ).toBe(0);
+      const rows = legacyDb.prepare(`SELECT sourceId FROM neighbor_info`).all() as any[];
+      expect(rows).toHaveLength(1);
+      expect(rows[0].sourceId).toBe('src-old');
       expect(legacyDb.pragma('foreign_keys', { simple: true })).toBe(1);
     } finally {
       legacyDb.close();

--- a/src/server/migrations/040_purge_null_sourceid_neighbor_info.ts
+++ b/src/server/migrations/040_purge_null_sourceid_neighbor_info.ts
@@ -1,42 +1,62 @@
 /**
- * Migration 040: Purge neighbor_info rows with NULL sourceId.
+ * Migration 040: Backfill neighbor_info rows with NULL sourceId.
  *
- * Before the fix in this release, `meshtasticManager.handleNeighborInfoApp`
- * called `deleteNeighborInfoForNode(fromNum)` and `insertNeighborInfoBatch(
- * records)` without forwarding `this.sourceId`. The repository treats an
- * undefined sourceId as "no filter", so:
- *   - the delete wiped every source's neighbor rows for that node, and
- *   - the re-insert wrote NULL sourceId, making the rows invisible to the
- *     source-scoped read path (`withSourceScope` strict equality).
+ * Two upgrade paths produce neighbor_info rows with `sourceId = NULL`:
+ *  - v3.x → v4.0 upgrade: legacy single-source databases. Migration 021
+ *    added the column nullable; v3 never wrote a value.
+ *  - 4.0 beta write-path bug: `meshtasticManager.handleNeighborInfoApp`
+ *    didn't forward `this.sourceId` into delete/insert. Fixed in beta4.
  *
- * Write path is now fixed (both calls forward `this.sourceId`); this
- * migration discards the stranded rows so future data reflects correct
- * per-source attribution.
+ * Both states are equivalent — the rows belong to the user's "default"
+ * source. Earlier versions of this migration deleted them, which silently
+ * wiped neighbor history on upgrade. Reassign instead.
  *
- * Idempotent — re-running is a no-op once NULL rows are gone.
+ * Idempotent — once every row has a sourceId, re-runs update 0 rows.
  */
 import type { Database } from 'better-sqlite3';
 import { logger } from '../../utils/logger.js';
+import {
+  ensureDefaultSourceIdSqlite,
+  ensureDefaultSourceIdPostgres,
+  ensureDefaultSourceIdMysql,
+} from './_legacyDefaultSource.js';
 
 export const migration = {
   up(db: Database): void {
     // Legacy v3.x databases carry `neighbor_info.nodeNum REFERENCES nodes(nodeNum)`
     // and `neighbor_info.neighborNodeNum REFERENCES nodes(nodeNum)`. Migration 029
     // rebuilt nodes with composite PK (nodeNum, sourceId), so these FKs are
-    // structurally invalid and DELETE on neighbor_info raises
-    // "foreign key mismatch" with foreign_keys=ON. Disable FK enforcement for
-    // this migration and restore in finally. See 029/030/032/039 for the same
-    // pattern.
+    // structurally invalid and writes on neighbor_info raise "foreign key
+    // mismatch" with foreign_keys=ON. Disable FK enforcement and restore in
+    // finally. See 029/030/032/039 for the same pattern.
     const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
     if (prevForeignKeys) {
       db.pragma('foreign_keys = OFF');
     }
     try {
+      const nullCountRow = db
+        .prepare(`SELECT COUNT(*) AS c FROM neighbor_info WHERE sourceId IS NULL`)
+        .get() as { c: number } | undefined;
+      const nullCount = nullCountRow?.c ?? 0;
+      if (nullCount === 0) {
+        return;
+      }
+
+      const defaultSourceId = ensureDefaultSourceIdSqlite(db, 'Migration 040');
+      if (!defaultSourceId) {
+        logger.warn(
+          `Migration 040: ${nullCount} NULL-sourceId neighbor_info rows but no sources table; skipping`
+        );
+        return;
+      }
+
       const res = db
-        .prepare(`DELETE FROM neighbor_info WHERE sourceId IS NULL`)
-        .run();
+        .prepare(`UPDATE neighbor_info SET sourceId = ? WHERE sourceId IS NULL`)
+        .run(defaultSourceId);
       if (res.changes > 0) {
-        logger.info(`Migration 040: purged ${res.changes} neighbor_info rows with NULL sourceId`);
+        logger.info(
+          `Migration 040: assigned ${res.changes} legacy neighbor_info rows to default source '${defaultSourceId}'`
+        );
       }
     } finally {
       if (prevForeignKeys) {
@@ -47,20 +67,58 @@ export const migration = {
 };
 
 export async function runMigration040Postgres(client: any): Promise<void> {
+  const nullRes = await client.query(
+    `SELECT COUNT(*)::int AS c FROM neighbor_info WHERE "sourceId" IS NULL`
+  );
+  const nullCount = nullRes.rows[0]?.c ?? 0;
+  if (nullCount === 0) {
+    return;
+  }
+
+  const defaultSourceId = await ensureDefaultSourceIdPostgres(client, 'Migration 040');
+  if (!defaultSourceId) {
+    logger.warn(
+      `Migration 040: ${nullCount} NULL-sourceId neighbor_info rows but no sources table; skipping (PG)`
+    );
+    return;
+  }
+
   const res = await client.query(
-    `DELETE FROM neighbor_info WHERE "sourceId" IS NULL`
+    `UPDATE neighbor_info SET "sourceId" = $1 WHERE "sourceId" IS NULL`,
+    [defaultSourceId],
   );
   if (res.rowCount && res.rowCount > 0) {
-    logger.info(`Migration 040: purged ${res.rowCount} neighbor_info rows with NULL sourceId (PG)`);
+    logger.info(
+      `Migration 040: assigned ${res.rowCount} legacy neighbor_info rows to default source '${defaultSourceId}' (PG)`
+    );
   }
 }
 
 export async function runMigration040Mysql(pool: any): Promise<void> {
+  const [nullRows] = await pool.query(
+    `SELECT COUNT(*) AS c FROM neighbor_info WHERE sourceId IS NULL`
+  );
+  const nullCount = Number((nullRows as any[])[0]?.c ?? 0);
+  if (nullCount === 0) {
+    return;
+  }
+
+  const defaultSourceId = await ensureDefaultSourceIdMysql(pool, 'Migration 040');
+  if (!defaultSourceId) {
+    logger.warn(
+      `Migration 040: ${nullCount} NULL-sourceId neighbor_info rows but no sources table; skipping (MySQL)`
+    );
+    return;
+  }
+
   const [res] = await pool.query(
-    `DELETE FROM neighbor_info WHERE sourceId IS NULL`
+    `UPDATE neighbor_info SET sourceId = ? WHERE sourceId IS NULL`,
+    [defaultSourceId],
   );
   const affected = (res as any).affectedRows ?? 0;
   if (affected > 0) {
-    logger.info(`Migration 040: purged ${affected} neighbor_info rows with NULL sourceId (MySQL)`);
+    logger.info(
+      `Migration 040: assigned ${affected} legacy neighbor_info rows to default source '${defaultSourceId}' (MySQL)`
+    );
   }
 }

--- a/src/server/migrations/_legacyDefaultSource.ts
+++ b/src/server/migrations/_legacyDefaultSource.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared helper used by data-migration backfills (029, 039, 040, ...) that
+ * need to assign legacy NULL-sourceId rows to a "default" source on upgrade
+ * from pre-multi-source databases (v3.x → v4.0).
+ *
+ * Strategy:
+ *  - If the sources table already has at least one row, use the oldest as
+ *    the default (matches server.ts startup `assignNullSourceIds`).
+ *  - Otherwise, synthesize a `meshtastic_tcp` source from environment vars.
+ *    The app will reuse / update / replace it on the next boot.
+ *
+ * Each migration owns its own UPDATE — only the default-source resolution
+ * is shared here.
+ */
+import type { Database } from 'better-sqlite3';
+import { randomUUID } from 'crypto';
+import { logger } from '../../utils/logger.js';
+
+interface LegacyDefaultSource {
+  id: string;
+  name: string;
+  type: string;
+  config: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export function buildLegacyDefaultSource(): LegacyDefaultSource {
+  const now = Date.now();
+  const host = process.env.MESHTASTIC_NODE_IP || 'meshtastic.local';
+  const port = parseInt(process.env.MESHTASTIC_TCP_PORT || '4403', 10) || 4403;
+  return {
+    id: randomUUID(),
+    name: 'Default',
+    type: 'meshtastic_tcp',
+    config: JSON.stringify({ host, port }),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Resolve the default sourceId for a SQLite migration. Synthesizes one if
+ * the sources table is empty. Returns null if the sources table does not
+ * exist (older databases that haven't yet run migration 020).
+ */
+export function ensureDefaultSourceIdSqlite(
+  db: Database,
+  migrationLabel: string,
+): string | null {
+  const sourcesExists = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='sources'`)
+    .get();
+  if (!sourcesExists) {
+    return null;
+  }
+
+  const existing = db
+    .prepare(`SELECT id FROM sources ORDER BY createdAt ASC, rowid ASC LIMIT 1`)
+    .get() as { id: string } | undefined;
+  if (existing?.id) {
+    return existing.id;
+  }
+
+  const legacy = buildLegacyDefaultSource();
+  logger.info(`${migrationLabel}: sources table empty; creating default source '${legacy.id}'`);
+  db.prepare(`
+    INSERT INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+    VALUES (?, ?, ?, ?, 1, ?, ?)
+  `).run(legacy.id, legacy.name, legacy.type, legacy.config, legacy.createdAt, legacy.updatedAt);
+  return legacy.id;
+}
+
+export async function ensureDefaultSourceIdPostgres(
+  client: any,
+  migrationLabel: string,
+): Promise<string | null> {
+  const tableCheck = await client.query(
+    `SELECT to_regclass('public.sources') AS reg`
+  );
+  if (!tableCheck.rows[0]?.reg) {
+    return null;
+  }
+
+  const existing = await client.query(
+    `SELECT id FROM sources ORDER BY "createdAt" ASC, id ASC LIMIT 1`
+  );
+  if (existing.rows[0]?.id) {
+    return existing.rows[0].id;
+  }
+
+  const legacy = buildLegacyDefaultSource();
+  logger.info(`${migrationLabel}: sources table empty; creating default source '${legacy.id}' (PG)`);
+  await client.query(
+    `INSERT INTO sources (id, name, type, config, enabled, "createdAt", "updatedAt")
+     VALUES ($1, $2, $3, $4, true, $5, $6)`,
+    [legacy.id, legacy.name, legacy.type, legacy.config, legacy.createdAt, legacy.updatedAt],
+  );
+  return legacy.id;
+}
+
+export async function ensureDefaultSourceIdMysql(
+  pool: any,
+  migrationLabel: string,
+): Promise<string | null> {
+  const conn = await pool.getConnection();
+  try {
+    const [tableRows] = await conn.query(
+      `SELECT COUNT(*) AS c FROM information_schema.tables
+       WHERE table_schema = DATABASE() AND table_name = 'sources'`
+    );
+    if (!Number((tableRows as any[])[0]?.c ?? 0)) {
+      return null;
+    }
+
+    const [existingRows] = await conn.query(
+      `SELECT id FROM sources ORDER BY createdAt ASC, id ASC LIMIT 1`
+    );
+    const existing = (existingRows as any[])[0];
+    if (existing?.id) {
+      return existing.id;
+    }
+
+    const legacy = buildLegacyDefaultSource();
+    logger.info(`${migrationLabel}: sources table empty; creating default source '${legacy.id}' (MySQL)`);
+    await conn.query(
+      `INSERT INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, 1, ?, ?)`,
+      [legacy.id, legacy.name, legacy.type, legacy.config, legacy.createdAt, legacy.updatedAt],
+    );
+    return legacy.id;
+  } finally {
+    conn.release();
+  }
+}


### PR DESCRIPTION
## Summary
- Migrations 039 (telemetry) and 040 (neighbor_info) previously `DELETE WHERE sourceId IS NULL`. On a v3.12 → v4.0 upgrade that wipes the entire telemetry and neighbor history, because v3.x never wrote a sourceId — the column was added in migration 021 as nullable.
- Both migrations now resolve the user's default source (oldest row in `sources`, synthesized from env vars if empty — same pattern as migration 029) and `UPDATE … SET sourceId = <default> WHERE sourceId IS NULL`. Idempotent.
- Shared resolution helper extracted to `src/server/migrations/_legacyDefaultSource.ts` so future per-source backfills can reuse the same logic.

## Why DELETE was wrong here
The DELETE was added to clean up rows produced by a 4.0-beta write-path bug (`meshtasticManager` not forwarding `this.sourceId` into `insertTelemetry` / neighbor delete+insert). That same NULL state is also the *normal* state of every v3.x row. The migration couldn't tell the two apart, so 3.12 users lost everything on upgrade. UPDATE handles both cases correctly: legacy v3 rows get attached to the user's only source, and beta-bug rows get attached to the same source they were *meant* to be tagged with.

## Order-of-operations
- Migration 029 already runs first and creates a default source if there are NULL-sourceId nodes, so 039/040 always find one in normal upgrade flow.
- If the sources table somehow doesn't exist yet (unmigrated DB), the migration logs a warning and skips. `server.ts` startup `assignNullSourceIds` then handles the rows once a source is registered.
- Foreign-key pragma handling preserved unchanged — legacy v3 FKs from `telemetry`/`neighbor_info` to `nodes(nodeNum)` are structurally invalid after 029 swaps nodes to a composite PK, so writes still need `foreign_keys = OFF`.

## Test plan
- [x] `npx vitest run src/server/migrations/039_purge_null_sourceid_telemetry.test.ts src/server/migrations/040_purge_null_sourceid_neighbor_info.test.ts` — 12/12 pass (reassignment, idempotency, sources-empty synthesis, legacy FK regression, no-sources-table skip)
- [x] `npx vitest run src/db/migrations.test.ts` — registry count/order unchanged (still 48 migrations)
- [ ] CI: full test suite + Postgres + MySQL migration paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)