### PR TITLE
fix(auto-favorite): scope status fetch to active source (#2826)

### DIFF
--- a/src/components/AutoFavoriteSection.test.tsx
+++ b/src/components/AutoFavoriteSection.test.tsx
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import AutoFavoriteSection from './AutoFavoriteSection';
+import { SourceProvider } from '../contexts/SourceContext';
 
 // Mock the useCsrfFetch hook
 const mockCsrfFetch = vi.fn();
@@ -101,6 +102,30 @@ describe('AutoFavoriteSection Component', () => {
       const checkbox = screen.getByRole('checkbox');
       expect(checkbox).toBeInTheDocument();
       expect(checkbox).not.toBeChecked();
+    });
+  });
+
+  it('passes the active sourceId to /api/auto-favorite/status', async () => {
+    // Regression for #2826: the role/firmware status was always read from the
+    // legacy first source, so switching sources kept showing the wrong role.
+    render(
+      <SourceProvider sourceId="src-active" sourceName="Active">
+        <AutoFavoriteSection {...defaultProps} />
+      </SourceProvider>
+    );
+    await waitFor(() => {
+      expect(mockCsrfFetch).toHaveBeenCalledWith(
+        expect.stringMatching(/\/api\/auto-favorite\/status\?sourceId=src-active$/)
+      );
+    });
+  });
+
+  it('omits sourceId when no source is active (legacy single-source)', async () => {
+    render(<AutoFavoriteSection {...defaultProps} />);
+    await waitFor(() => {
+      expect(mockCsrfFetch).toHaveBeenCalledWith(
+        expect.stringMatching(/\/api\/auto-favorite\/status$/)
+      );
     });
   });
 });

--- a/src/components/AutoFavoriteSection.tsx
+++ b/src/components/AutoFavoriteSection.tsx
@@ -46,7 +46,7 @@ const AutoFavoriteSection: React.FC<AutoFavoriteSectionProps> = ({ baseUrl }) =>
     try {
       const [settingsRes, statusRes] = await Promise.all([
         csrfFetch(`${baseUrl}/api/settings${sourceQuery}`),
-        csrfFetch(`${baseUrl}/api/auto-favorite/status`),
+        csrfFetch(`${baseUrl}/api/auto-favorite/status${sourceQuery}`),
       ]);
       if (settingsRes.ok) {
         const settings = await settingsRes.json();
@@ -62,7 +62,7 @@ const AutoFavoriteSection: React.FC<AutoFavoriteSectionProps> = ({ baseUrl }) =>
     } catch (error) {
       console.error('Failed to fetch auto-favorite data:', error);
     }
-  }, [baseUrl, csrfFetch]);
+  }, [baseUrl, csrfFetch, sourceQuery]);
 
   useEffect(() => { fetchData(); }, [fetchData]);
 


### PR DESCRIPTION
## Summary
Fixes #2826 — Auto Favorite always read status (role/firmware/managed nodes) from the **first** registered source, even after switching to a different one. Multi-source users with one Client Base + one Client Mute saw the false warning *"Your node role is 'Client Mute' — Auto Favorite requires Router, Router Late, or Client Base"* on the perfectly-configured Client Base source.

## Root cause
`AutoFavoriteSection.tsx` fetched `/api/auto-favorite/status` **without** the `sourceQuery` fragment. The backend route at `server.ts:1345` falls back to the legacy `meshtasticManager` singleton when no `?sourceId=` is supplied — and that singleton is whichever source was registered first at startup. The settings fetch in the same component already passed `sourceQuery` correctly; the status fetch was an oversight.

## Fix
- Append `sourceQuery` to the `/api/auto-favorite/status` URL.
- Add `sourceQuery` to the `fetchData` `useCallback` deps so switching sources actually re-fetches.

## Test plan
- [x] Two new tests in `AutoFavoriteSection.test.tsx` assert the URL carries the active sourceId, and that the no-source legacy path still works.
- [x] `npx vitest run src/components/AutoFavoriteSection.test.tsx` — 6/6 pass.
- [ ] Manual repro per the issue: two sources (client_base + client_mute), select the client_base source, confirm warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)