### PR TITLE
chore(release): 4.0.1 hotfix

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.0.0",
+  "version": "4.0.1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.0.0
-appVersion: "4.0.0"
+version: 4.0.1
+appVersion: "4.0.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Bumps to **4.0.1** — first hotfix on the 4.0 line. Two fixes in this release prevent **data loss / data confusion** on upgrade and multi-source setups; the rest are smaller stability + dependency updates.

Version updates land in all five canonical files:
- `package.json`
- `package-lock.json`
- `helm/meshmonitor/Chart.yaml` (chart + appVersion)
- `desktop/package.json`
- `desktop/src-tauri/tauri.conf.json`

## Changes since v4.0.0

### Bugfixes
- **#2828** (closes **#2826**) — fix(auto-favorite): scope status fetch to active source. Multi-source users saw "Your node role is X — Auto Favorite requires …" warnings on correctly-configured Client Base sources because the role/firmware status was always read from the first registered source.
- **#2827** — fix(migrations): preserve legacy telemetry & neighbor_info on 3.12 → 4.0 upgrade. Migrations 039/040 previously `DELETE WHERE sourceId IS NULL` and silently wiped the entire v3.x telemetry + neighbor history. They now reassign those rows to the user's default source.
- **#2825** — fix(server): survive SIGTERM and DB-not-ready during long migrations.
- **#2824** (cherry-pick of **#2823**) — fix(sources): allow `virtualNode.port` to equal the source's own TCP port.
- **#2822** — fix(settings): stop re-POSTing `tracerouteIntervalMinutes` on hydration.

### Dependencies
- **#2821** — Snyk: node `24.14.1-alpine3.22` → `24.15.0-alpine3.22`.
- **#2820** — Snyk: node `24.14.0-alpine3.22` → `24.14.1-alpine3.22`.

### Pending (may also ride in 4.0.1 if merged in time)
- **#2829** — fix(migrate-db): support 4.0 multi-source data structures in the SQLite → PostgreSQL/MySQL CLI migration tool. Verified end-to-end (197,076/197,076 rows on a populated 4.0 dev DB; app boots clean against migrated PG).

## Test plan
- [ ] CI green on this branch
- [ ] After merge, GitHub release for `v4.0.1` (let GitHub create the tag)
- [ ] Helm chart artifact picks up `4.0.1`
- [ ] Desktop builds pick up `4.0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)