### PR TITLE
fix(sources): remove FE virtualNode port == source port block (#2823)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4221,7 +4221,6 @@
   "source.form.error_port_range": "Port must be 1–65535",
   "source.form.error_heartbeat_range": "Heartbeat must be 0 (disabled) or 1–3600 seconds",
   "source.form.error_vn_port_range": "Virtual Node port must be 1–65535",
-  "source.form.error_vn_port_collision": "Virtual Node port cannot equal the source TCP port",
   "source.form.error_save_failed": "Save failed",
   "source.form.error_network": "Network error",
   "source.virtual_node_badge_title": "Virtual Node",

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -229,10 +229,6 @@ function DashboardInner() {
         setFormError(t('source.form.error_vn_port_range'));
         return;
       }
-      if (vnPort === port) {
-        setFormError(t('source.form.error_vn_port_collision'));
-        return;
-      }
       vnConfig = { enabled: true, port: vnPort, allowAdminCommands: formVnAllowAdmin };
     }
 


### PR DESCRIPTION
## Summary
- Backend accepted `virtualNode.port == source.port` after #2823, but the dashboard form still blocked save with `error_vn_port_collision`, so users could not reach the relaxed validation. Reported by @ogarcia in #2823.
- Removes the FE collision check in `DashboardPage.tsx` and the now-orphaned i18n string.

## Test plan
- [ ] Open a TCP source with `port: 4403`, enable Virtual Node, set VN port to `4403`, save — succeeds.
- [ ] VN port out-of-range (0, 65536) still rejected with `error_vn_port_range`.
- [ ] No remaining references to `error_vn_port_collision` (`grep` clean).

Fixes #2823

🤖 Generated with [Claude Code](https://claude.com/claude-code)