### PR TITLE
perf(db): composite indexes + raise PG/MySQL pool default (#2831)

### DIFF
--- a/src/db/drivers/postgres.ts
+++ b/src/db/drivers/postgres.ts
@@ -78,6 +78,18 @@ export async function createPostgresDriver(options: PostgresDriverOptions): Prom
     logger.debug('[PostgreSQL Driver] New client connected to pool');
   });
 
+  // Issue #2831: warn when the pool is saturated so operators can spot
+  // starvation without enabling debug logging.
+  const POOL_WATCH_INTERVAL_MS = 30_000;
+  const poolWatcher = setInterval(() => {
+    if (pool.waitingCount > 0) {
+      logger.warn(
+        `[PostgreSQL Driver] Pool saturated: ${pool.waitingCount} waiter(s), ${pool.totalCount}/${maxConnections} connections, ${pool.idleCount} idle. Consider raising DATABASE_POOL_SIZE.`
+      );
+    }
+  }, POOL_WATCH_INTERVAL_MS);
+  poolWatcher.unref?.();
+
   // Create Drizzle ORM instance
   const db = drizzle(pool, { schema });
 
@@ -90,6 +102,7 @@ export async function createPostgresDriver(options: PostgresDriverOptions): Prom
     pool,
     close: async () => {
       logger.debug('[PostgreSQL Driver] Closing connection pool');
+      clearInterval(poolWatcher);
       await pool.end();
     },
   };

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -84,7 +84,9 @@ export function getDatabaseConfig(): DatabaseConfig {
 
   const poolSizeRaw = process.env.DATABASE_POOL_SIZE;
   const parsedPoolSize = poolSizeRaw ? parseInt(poolSizeRaw, 10) : NaN;
-  const maxConnections = Number.isFinite(parsedPoolSize) && parsedPoolSize > 0 ? parsedPoolSize : 10;
+  // Default raised from 10 → 20 (issue #2831): the previous default starved
+  // PG/MySQL pools under modest concurrent load (dashboard fan-out + schedulers).
+  const maxConnections = Number.isFinite(parsedPoolSize) && parsedPoolSize > 0 ? parsedPoolSize : 20;
 
   return {
     type,

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 48 migrations registered', () => {
-    expect(registry.count()).toBe(48);
+  it('has all 49 migrations registered', () => {
+    expect(registry.count()).toBe(49);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,14 +12,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is rebuild_ignored_nodes_per_source', () => {
+  it('last migration is perf_composite_indexes', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(48);
-    expect(last.name).toContain('rebuild_ignored_nodes_per_source');
+    expect(last.number).toBe(49);
+    expect(last.name).toContain('perf_composite_indexes');
   });
 
-  it('migrations are sequentially numbered from 1 to 48', () => {
+  it('migrations are sequentially numbered from 1 to 49', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -60,6 +60,7 @@ import { migration as dropLegacyRouteSegmentsFkMigration, runMigration045Postgre
 import { migration as addUserMapPrefsIdSqliteMigration, runMigration046Postgres, runMigration046Mysql } from '../server/migrations/046_add_user_map_preferences_id_sqlite.js';
 import { migration as addSelectedLayerMigration, runMigration047Postgres, runMigration047Mysql } from '../server/migrations/047_add_selected_layer_to_user_map_preferences.js';
 import { migration as rebuildIgnoredNodesPerSourceMigration, runMigration048Postgres, runMigration048Mysql } from '../server/migrations/048_rebuild_ignored_nodes_per_source.js';
+import { migration as perfCompositeIndexesMigration, runMigration049Postgres, runMigration049Mysql } from '../server/migrations/049_perf_composite_indexes.js';
 
 // ============================================================================
 // Registry
@@ -745,4 +746,20 @@ registry.register({
   sqlite: (db) => rebuildIgnoredNodesPerSourceMigration.up(db),
   postgres: (client) => runMigration048Postgres(client),
   mysql: (pool) => runMigration048Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 049: Composite indexes for hot query patterns (issue #2831)
+// telemetry (telemetryType, nodeId, timestamp DESC), telemetry (sourceId,
+// nodeId, telemetryType), messages (sourceId, timestamp DESC),
+// neighbor_info (sourceId, nodeNum).
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 49,
+  name: 'perf_composite_indexes',
+  settingsKey: 'migration_049_perf_composite_indexes',
+  sqlite: (db) => perfCompositeIndexesMigration.up(db),
+  postgres: (client) => runMigration049Postgres(client),
+  mysql: (pool) => runMigration049Mysql(pool),
 });

--- a/src/server/migrations/049_perf_composite_indexes.ts
+++ b/src/server/migrations/049_perf_composite_indexes.ts
@@ -1,0 +1,63 @@
+/**
+ * Migration 049: Add composite indexes to back hot query patterns.
+ *
+ * Issue #2831 traced PG connection-pool starvation to source-scoped + ordered
+ * queries that fall back to seq-scan or sort because the existing single-column
+ * indexes are not selective enough.
+ *
+ * - telemetry (telemetryType, nodeId, timestamp DESC):
+ *     supports getLatestTelemetryValueForAllNodes() which filters by
+ *     telemetryType and DISTINCTs on nodeId ordered by timestamp DESC.
+ * - telemetry (sourceId, nodeId, telemetryType):
+ *     supports getAllNodesTelemetryTypes(sourceId) (DISTINCT nodeId, type
+ *     within a source).
+ * - messages (sourceId, timestamp DESC):
+ *     supports the paginated getMessages(limit, offset, sourceId) query —
+ *     before this index PG had to sort the matching rows.
+ * - neighbor_info (sourceId, nodeNum):
+ *     post-mig 048 neighbor lookups are per-source; the table only had a
+ *     standalone (nodeNum) index.
+ *
+ * All indexes are idempotent (CREATE INDEX IF NOT EXISTS on SQLite/PG,
+ * information_schema check on MySQL).
+ */
+import type { Database } from 'better-sqlite3';
+
+// SQLite migration
+export const migration = {
+  up(db: Database) {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_telemetry_type_node_ts ON telemetry(telemetryType, nodeId, timestamp DESC)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_telemetry_source_node_type ON telemetry(sourceId, nodeId, telemetryType)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_source_timestamp ON messages(sourceId, timestamp DESC)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_neighbor_info_source_nodenum ON neighbor_info(sourceId, nodeNum)`);
+  },
+};
+
+// PostgreSQL migration
+export async function runMigration049Postgres(client: any): Promise<void> {
+  await client.query(`CREATE INDEX IF NOT EXISTS idx_telemetry_type_node_ts ON telemetry("telemetryType", "nodeId", timestamp DESC)`);
+  await client.query(`CREATE INDEX IF NOT EXISTS idx_telemetry_source_node_type ON telemetry("sourceId", "nodeId", "telemetryType")`);
+  await client.query(`CREATE INDEX IF NOT EXISTS idx_messages_source_timestamp ON messages("sourceId", timestamp DESC)`);
+  await client.query(`CREATE INDEX IF NOT EXISTS idx_neighbor_info_source_nodenum ON neighbor_info("sourceId", "nodeNum")`);
+}
+
+// MySQL migration
+export async function runMigration049Mysql(pool: any): Promise<void> {
+  const indexes: Array<{ table: string; name: string; cols: string }> = [
+    { table: 'telemetry', name: 'idx_telemetry_type_node_ts', cols: 'telemetryType, nodeId, timestamp DESC' },
+    { table: 'telemetry', name: 'idx_telemetry_source_node_type', cols: 'sourceId, nodeId, telemetryType' },
+    { table: 'messages', name: 'idx_messages_source_timestamp', cols: 'sourceId, timestamp DESC' },
+    { table: 'neighbor_info', name: 'idx_neighbor_info_source_nodenum', cols: 'sourceId, nodeNum' },
+  ];
+
+  for (const idx of indexes) {
+    const [rows] = await pool.query(
+      `SELECT INDEX_NAME FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?`,
+      [idx.table, idx.name]
+    );
+    if ((rows as any[]).length === 0) {
+      await pool.query(`CREATE INDEX ${idx.name} ON ${idx.table}(${idx.cols})`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Investigation of #2831 (cascading 503s after 4.0.1 upgrade on PostgreSQL) traced the symptom to upstream proxy timeouts caused by PG connection-pool starvation. Two structural problems compound under modest load (1 source, ~700 nodes):

1. **Default pool size = 10** is too small for the dashboard fan-out + scheduled pollers in 4.0. Raised default to **20** (still env-overridable via \`DATABASE_POOL_SIZE\`).
2. Several hot queries fall back to seq-scan or sort because the existing single-column indexes are not selective enough. Migration 049 adds the missing composite indexes:

| Table | Index | Backs |
| --- | --- | --- |
| telemetry | (telemetryType, nodeId, timestamp DESC) | \`getLatestTelemetryValueForAllNodes()\` |
| telemetry | (sourceId, nodeId, telemetryType) | \`getAllNodesTelemetryTypes(sourceId)\` |
| messages | (sourceId, timestamp DESC) | paginated \`getMessages(limit, offset, sourceId)\` |
| neighbor_info | (sourceId, nodeNum) | per-source lookups after migration 048 |

Also adds a 30 s pool-saturation watcher that logs at WARN when there are queued waiters, so operators can confirm starvation without enabling debug logging.

## Test plan
- [x] \`vitest run src/db/migrations.test.ts\` — registry count, sequencing, and last-name updated
- [x] \`tsc --noEmit\` — clean
- [ ] CI: SQLite, PostgreSQL, MySQL backends all run mig 049 idempotently (CREATE INDEX IF NOT EXISTS on SQLite/PG, information_schema check on MySQL)
- [ ] Manual: re-running the migration after first apply is a no-op
- [ ] Manual: with \`DATABASE_POOL_SIZE=2\` and a tight loop of API calls, the pool watcher should emit a WARN within 30 s

## Notes
- Migration is idempotent on all three backends.
- Does **not** address the related correctness gap in \`getLatestTelemetryValueForAllNodes\` (it doesn't filter by sourceId in multi-source setups). That's a separate issue and out of scope for this PR.

Refs #2831

🤖 Generated with [Claude Code](https://claude.com/claude-code)