### PR TITLE
fix(telemetry): scope getLatestTelemetryValueForAllNodes by sourceId (#2831)

### DIFF
--- a/src/db/repositories/telemetry.extra.test.ts
+++ b/src/db/repositories/telemetry.extra.test.ts
@@ -519,6 +519,43 @@ describe('TelemetryRepository (expanded)', () => {
       const map = await repo.getLatestTelemetryValueForAllNodes('battery');
       expect(map.size).toBe(0);
     });
+
+    it('scopes results to the requested sourceId (issue #2831)', async () => {
+      // Same node has telemetry from two different sources. Without sourceId,
+      // we'd see whichever source has the most recent record. With sourceId,
+      // we should get exactly that source's most recent record.
+      const SOURCE_A = 'src-a';
+      const SOURCE_B = 'src-b';
+
+      await repo.insertTelemetry({
+        nodeId: NODE1,
+        nodeNum: NODE1_NUM,
+        telemetryType: 'battery',
+        timestamp: NOW - 2 * HOUR,
+        value: 70,
+        unit: '%',
+        createdAt: NOW - 2 * HOUR,
+      }, SOURCE_A);
+      await repo.insertTelemetry({
+        nodeId: NODE1,
+        nodeNum: NODE1_NUM,
+        telemetryType: 'battery',
+        timestamp: NOW - 1 * HOUR, // newest overall — would dominate without scope
+        value: 90,
+        unit: '%',
+        createdAt: NOW - 1 * HOUR,
+      }, SOURCE_B);
+
+      const mapA = await repo.getLatestTelemetryValueForAllNodes('battery', SOURCE_A);
+      expect(mapA.get(NODE1)).toBe(70);
+
+      const mapB = await repo.getLatestTelemetryValueForAllNodes('battery', SOURCE_B);
+      expect(mapB.get(NODE1)).toBe(90);
+
+      // Unfiltered behaviour preserved (latest across all sources).
+      const mapAll = await repo.getLatestTelemetryValueForAllNodes('battery');
+      expect(mapAll.get(NODE1)).toBe(90);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -303,46 +303,60 @@ export class TelemetryRepository extends BaseRepository {
    * Get latest telemetry value for a given type across all nodes in a single query.
    * Returns a Map of nodeId -> value.
    *
+   * When `sourceId` is provided, results are scoped to that source — required for
+   * correctness in multi-source deployments, where the same nodeId can have
+   * telemetry from multiple sources (issue #2831).
+   *
    * Keeps branching: PostgreSQL uses DISTINCT ON, SQLite/MySQL use subquery with MAX.
    * Different raw SQL and result shapes per dialect.
    */
-  async getLatestTelemetryValueForAllNodes(telemetryType: string): Promise<Map<string, number>> {
+  async getLatestTelemetryValueForAllNodes(
+    telemetryType: string,
+    sourceId?: string,
+  ): Promise<Map<string, number>> {
     const result = new Map<string, number>();
 
     if (this.isSQLite()) {
       const db = this.getSqliteDb();
+      const innerSourceFilter = sourceId ? sql`AND sourceId = ${sourceId}` : sql``;
+      const outerSourceFilter = sourceId ? sql`AND t.sourceId = ${sourceId}` : sql``;
       const rows = await db.all<{ nodeId: string; value: number }>(
         sql`SELECT t.nodeId, t.value FROM telemetry t
             INNER JOIN (
               SELECT nodeId, MAX(timestamp) as maxTs
-              FROM telemetry WHERE telemetryType = ${telemetryType}
+              FROM telemetry WHERE telemetryType = ${telemetryType} ${innerSourceFilter}
               GROUP BY nodeId
             ) latest ON t.nodeId = latest.nodeId AND t.timestamp = latest.maxTs
-            WHERE t.telemetryType = ${telemetryType}`
+            WHERE t.telemetryType = ${telemetryType} ${outerSourceFilter}`
       );
       for (const row of rows) {
         result.set(row.nodeId, Number(row.value));
       }
     } else if (this.isMySQL()) {
       const db = this.getMysqlDb();
+      const innerSourceFilter = sourceId ? sql`AND sourceId = ${sourceId}` : sql``;
+      const outerSourceFilter = sourceId ? sql`AND t.sourceId = ${sourceId}` : sql``;
       const [rows] = await (db as any).execute(
         sql`SELECT t.nodeId, t.value FROM telemetry t
             INNER JOIN (
               SELECT nodeId, MAX(timestamp) as maxTs
-              FROM telemetry WHERE telemetryType = ${telemetryType}
+              FROM telemetry WHERE telemetryType = ${telemetryType} ${innerSourceFilter}
               GROUP BY nodeId
             ) latest ON t.nodeId = latest.nodeId AND t.timestamp = latest.maxTs
-            WHERE t.telemetryType = ${telemetryType}`
+            WHERE t.telemetryType = ${telemetryType} ${outerSourceFilter}`
       );
       for (const row of rows as any[]) {
         result.set(row.nodeId, Number(row.value));
       }
     } else {
       const db = this.getPostgresDb();
+      const sourceFilter = sourceId
+        ? sql`AND ${this.col('sourceId')} = ${sourceId}`
+        : sql``;
       const rows = await db.execute(
         sql`SELECT DISTINCT ON (${this.col('nodeId')}) ${this.col('nodeId')}, value
             FROM telemetry
-            WHERE ${this.col('telemetryType')} = ${telemetryType}
+            WHERE ${this.col('telemetryType')} = ${telemetryType} ${sourceFilter}
             ORDER BY ${this.col('nodeId')}, timestamp DESC`
       );
       for (const row of rows.rows) {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -12072,7 +12072,10 @@ class MeshtasticManager implements ISourceManager {
 
   // Async version that fetches uptimes in a single bulk query - works with all DB backends
   async getAllNodesAsync(sourceId?: string): Promise<DeviceInfo[]> {
-    const uptimeMap = await databaseService.telemetry.getLatestTelemetryValueForAllNodes('uptimeSeconds');
+    const uptimeMap = await databaseService.telemetry.getLatestTelemetryValueForAllNodes(
+      'uptimeSeconds',
+      sourceId,
+    );
     const dbNodes = await databaseService.nodes.getAllNodes(sourceId);
     return dbNodes.map(node => this.mapDbNodeToDeviceInfo(node, uptimeMap.get(node.nodeId)));
   }

--- a/src/server/routes/v1/nodes.ts
+++ b/src/server/routes/v1/nodes.ts
@@ -38,8 +38,14 @@ async function hasNodesReadPermission(userId: number | null, isAdmin: boolean, s
 /**
  * Enrich node data with latest uptime from telemetry (async - works with all DB backends)
  */
-async function enrichNodesWithUptime(nodes: DbNode[]): Promise<(DbNode & { uptimeSeconds?: number })[]> {
-  const uptimeMap = await databaseService.telemetry.getLatestTelemetryValueForAllNodes('uptimeSeconds');
+async function enrichNodesWithUptime(
+  nodes: DbNode[],
+  sourceId?: string,
+): Promise<(DbNode & { uptimeSeconds?: number })[]> {
+  const uptimeMap = await databaseService.telemetry.getLatestTelemetryValueForAllNodes(
+    'uptimeSeconds',
+    sourceId,
+  );
   return nodes.map(node => ({
     ...node,
     uptimeSeconds: uptimeMap.get(node.nodeId)
@@ -88,8 +94,8 @@ router.get('/', async (req: Request, res: Response) => {
     // Strip location fields for nodes whose position came from an inaccessible channel
     const locationMaskedNodes = await maskNodeLocationByChannel(filteredNodes, user, sourceId);
 
-    // Enrich nodes with uptime data from telemetry
-    const enrichedNodes = await enrichNodesWithUptime(locationMaskedNodes);
+    // Enrich nodes with uptime data from telemetry (scoped to the requested source)
+    const enrichedNodes = await enrichNodesWithUptime(locationMaskedNodes, sourceId);
 
     res.json({
       success: true,

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -5907,8 +5907,11 @@ class DatabaseService {
   }
 
   /** @deprecated Use databaseService.telemetry.getLatestTelemetryValueForAllNodes() instead */
-  async getLatestTelemetryValueForAllNodesAsync(telemetryType: string): Promise<Map<string, number>> {
-    return this.telemetry.getLatestTelemetryValueForAllNodes(telemetryType);
+  async getLatestTelemetryValueForAllNodesAsync(
+    telemetryType: string,
+    sourceId?: string,
+  ): Promise<Map<string, number>> {
+    return this.telemetry.getLatestTelemetryValueForAllNodes(telemetryType, sourceId);
   }
 
   // Get distinct telemetry types per node (efficient for checking capabilities)


### PR DESCRIPTION
## Summary
Multi-source correctness gap discovered while investigating #2831. Both callers of \`getLatestTelemetryValueForAllNodes\` already filter their node list by sourceId, but the telemetry lookup itself ignored sourceId — so a node that exists in two sources would surface whichever source had the most recent telemetry record, not the one the caller asked for.

- \`src/server/routes/v1/nodes.ts:42\` — \`enrichNodesWithUptime()\` (called from \`GET /api/v1/nodes\`).
- \`src/server/meshtasticManager.ts:12075\` — \`getAllNodesAsync(sourceId?)\`.

Single-source deployments are unaffected. Multi-source deployments saw stale or cross-source uptime values in the dashboard.

## Changes
- \`src/db/repositories/telemetry.ts\` — adds optional \`sourceId?: string\` parameter; inner subquery (SQLite/MySQL) and \`DISTINCT ON\` query (PostgreSQL) all gain a conditional \`AND sourceId = ?\` filter.
- \`src/server/routes/v1/nodes.ts\` — \`enrichNodesWithUptime\` now accepts and forwards sourceId.
- \`src/server/meshtasticManager.ts\` — \`getAllNodesAsync\` forwards its sourceId to the telemetry lookup.
- \`src/services/database.ts\` — deprecated facade gets the same parameter so callers using it stay correct.
- \`src/db/repositories/telemetry.extra.test.ts\` — adds a regression test that inserts the same node into two sources and asserts each source's lookup returns the right value, plus that the unfiltered call preserves prior behaviour.

## Test plan
- [x] \`vitest run src/db/repositories/telemetry.extra.test.ts\` — 81 tests pass, including the new sourceId scoping case
- [x] \`vitest run src/server/routes/v1/v1-api.test.ts src/db/migrations.test.ts\` — green
- [x] \`tsc --noEmit\` — clean
- [ ] CI: SQLite/PG/MySQL branches all exercised
- [ ] Manual (multi-source environment): \`/api/v1/nodes?sourceId=A\` reports uptime from source A, \`?sourceId=B\` from source B

Refs #2831

🤖 Generated with [Claude Code](https://claude.com/claude-code)