### PR TITLE
fix(info): show per-source admin commands status in Virtual Node panel

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1683,7 +1683,9 @@
   "info.client_connected": "Connected:",
   "info.client_last_activity": "Last Activity:",
   "info.virtual_node_description": "The Virtual Node Server allows multiple Meshtastic mobile apps to connect simultaneously, reducing load on your physical node.",
-  "info.virtual_node_note": "Note: Admin commands are blocked for security. See .env.example for configuration details.",
+  "info.virtual_node_admin_commands": "Admin Commands:",
+  "info.virtual_node_admin_allowed": "Allowed",
+  "info.virtual_node_admin_blocked": "Blocked",
   "info.virtual_node_unavailable": "Virtual Node status unavailable",
 
   "info.network_stats": "Network Statistics",

--- a/src/components/InfoTab.tsx
+++ b/src/components/InfoTab.tsx
@@ -507,6 +507,7 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
                 {source.enabled && (
                   <>
                     <p><strong>{t('info.server_running')}</strong> {source.isRunning ? t('common.yes') : t('common.no')}</p>
+                    <p><strong>{t('info.virtual_node_admin_commands')}</strong> {source.allowAdminCommands ? t('info.virtual_node_admin_allowed') : t('info.virtual_node_admin_blocked')}</p>
                     <p><strong>{t('info.connected_clients')}</strong> {source.clientCount}</p>
 
                     {source.clients && source.clients.length > 0 && (
@@ -532,9 +533,6 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
 
                 <p style={{ fontSize: '0.9em', color: '#888', marginTop: '0.75rem' }}>
                   {t('info.virtual_node_description')}
-                </p>
-                <p style={{ fontSize: '0.85em', color: '#999', marginTop: '0.5rem', fontStyle: 'italic' }}>
-                  {t('info.virtual_node_note')}
                 </p>
               </>
             );

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2404,6 +2404,7 @@ apiRouter.get('/virtual-node/status', requireAuth(), (_req, res) => {
           sourceName,
           enabled: false,
           isRunning: false,
+          allowAdminCommands: false,
           clientCount: 0,
           clients: [],
         };
@@ -2413,6 +2414,7 @@ apiRouter.get('/virtual-node/status', requireAuth(), (_req, res) => {
         sourceName,
         enabled: true,
         isRunning: vn.isRunning(),
+        allowAdminCommands: vn.isAdminCommandsAllowed(),
         clientCount: vn.getClientCount(),
         clients: vn.getClientDetails(),
       };

--- a/src/server/virtualNodeServer.ts
+++ b/src/server/virtualNodeServer.ts
@@ -1180,4 +1180,8 @@ export class VirtualNodeServer extends EventEmitter {
   public isRunning(): boolean {
     return this.server !== null;
   }
+
+  public isAdminCommandsAllowed(): boolean {
+    return this.allowAdminCommands;
+  }
 }


### PR DESCRIPTION
## Summary
- Surface the per-source `virtualNode.allowAdminCommands` setting in the source Info panel's Virtual Node section instead of the old static note that always claimed admin commands were blocked.
- Add `allowAdminCommands` to each source in the `/api/virtual-node/status` response, sourced from the running `VirtualNodeServer` so reconfigures show up immediately.
- Drop the obsolete `.env.example` reference (4.0 dropped global VN config in favor of per-source).

## Why
On the Info panel for a source, the Virtual Node section claimed `Admin Commands are disabled` regardless of the source's actual `virtualNode.allowAdminCommands` value, because the message was a static i18n string with no link to the live config. Users toggling Allow Admin Commands on the source had no UI feedback that their change took effect.

## Changes
- `src/server/virtualNodeServer.ts` — new `isAdminCommandsAllowed()` getter
- `src/server/server.ts` — `/api/virtual-node/status` returns `allowAdminCommands` per source
- `src/components/InfoTab.tsx` — replace static note with dynamic `Admin Commands: Allowed / Blocked` row
- `public/locales/en.json` — drop `info.virtual_node_note`, add `info.virtual_node_admin_commands` / `_admin_allowed` / `_admin_blocked`

## Test plan
- [x] Built and deployed via docker-compose.dev.yml; verified built JS contains `isAdminCommandsAllowed` and `/api/virtual-node/status` returns `allowAdminCommands` per source
- [ ] In UI, toggle Allow Admin Commands on a source; confirm Info → Virtual Node flips between Allowed and Blocked
- [ ] Confirm a disabled-VN source still renders without the admin row

🤖 Generated with [Claude Code](https://claude.com/claude-code)