### PR TITLE
fix(unified): channel-name save, cross-source routing, picker drift

### DIFF
--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -88,8 +88,18 @@ export class ChannelsRepository extends BaseRepository {
    *
    * When sourceId is provided the lookup uses (id, sourceId) so each source
    * manages its own independent set of channel slots.
+   *
+   * `opts.allowBlankName` distinguishes user-driven saves (where blank truly
+   * means "clear the name") from device-config ingest (where blank typically
+   * means "the device transmitted an empty name slot, don't wipe what we
+   * already had" — see #1567). The PUT /api/channels/:id route should pass
+   * `true`; the channel-info ingest path should pass `false`/omit.
    */
-  async upsertChannel(channelData: ChannelInput, sourceId?: string): Promise<void> {
+  async upsertChannel(
+    channelData: ChannelInput,
+    sourceId?: string,
+    opts?: { allowBlankName?: boolean },
+  ): Promise<void> {
     const now = this.now();
     let data = { ...channelData };
     const { channels } = this.tables;
@@ -113,9 +123,14 @@ export class ChannelsRepository extends BaseRepository {
 
     if (existingChannel) {
       // Update existing channel
-      // Preserve existing non-empty name if incoming name is empty (fixes #1567)
-      // This prevents device reconnections from wiping channel names
-      const effectiveName = data.name || existingChannel.name;
+      // For ingest paths: preserve existing non-empty name when incoming name
+      // is blank (fixes #1567 — device reconnects sometimes report empty names
+      // for slots whose names we already learned).
+      // For user-driven saves (`opts.allowBlankName`): blank means blank.
+      const incomingName = data.name ?? '';
+      const effectiveName = (opts?.allowBlankName || incomingName !== '')
+        ? incomingName
+        : existingChannel.name;
       logger.debug(`Updating channel ${existingChannel.id}: name "${existingChannel.name}" -> "${effectiveName}"`);
 
       const updateSet: any = {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -4390,8 +4390,21 @@ class MeshtasticManager implements ISourceManager {
           // This prevents database channels from "shadowing" device channels with the same key (#2375, #2413)
           const dbChannel = await databaseService.channelDatabase.getByIdAsync(context.decryptedChannelId);
           const deviceChannels = await databaseService.channels.getAllChannels(this.sourceId);
+          // Match by BOTH psk AND name. Channels share PSK by default — Meshtastic
+          // ships with the sentinel `AQ==` (single byte 0x01) on every preset
+          // slot. Matching on PSK alone would route every default-PSK packet to
+          // whatever slot scans first (typically slot 0 = primary), no matter
+          // which named slot actually originated the packet. The on-wire channel
+          // hash is `xorHash(name) ^ xorHash(psk)`, so name participates in the
+          // identity — two slots with the same PSK but different names are
+          // genuinely different channels and must not be conflated.
+          const dbName = (dbChannel?.name ?? '').trim();
           const matchingDeviceChannel = dbChannel?.psk
-            ? deviceChannels.find(dc => dc.psk === dbChannel.psk && dc.role !== 0)
+            ? deviceChannels.find(dc =>
+                dc.psk === dbChannel.psk
+                && (dc.name ?? '').trim() === dbName
+                && dc.role !== 0,
+              )
             : null;
 
           if (matchingDeviceChannel) {

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -154,7 +154,27 @@ router.get('/channels', async (req: Request, res: Response) => {
     ]);
 
     type ChannelSourceRef = { sourceId: string; sourceName: string; channelNumber: number };
-    const byName = new Map<string, ChannelSourceRef[]>();
+    // Group case-insensitively so cross-device casing drift (e.g. one source
+    // stores "primary", another stores "" → "Primary") doesn't split the
+    // unified picker into two entries that each show only half the messages.
+    // Key is `name.toLowerCase()`; we keep the first-seen casing for display
+    // but upgrade to a non-synthesized casing when one shows up later, so a
+    // device-set name wins over the synthetic `Primary` fallback.
+    const byName = new Map<string, { displayName: string; sources: ChannelSourceRef[] }>();
+    const upsert = (name: string, ref: ChannelSourceRef) => {
+      const key = name.toLowerCase();
+      const entry = byName.get(key);
+      if (entry) {
+        entry.sources.push(ref);
+        // Prefer a device-stored casing over the synthetic "Primary" fallback;
+        // otherwise keep first-seen.
+        if (entry.displayName === PRIMARY_CHANNEL_NAME && name !== PRIMARY_CHANNEL_NAME) {
+          entry.displayName = name;
+        }
+      } else {
+        byName.set(key, { displayName: name, sources: [ref] });
+      }
+    };
 
     await Promise.all(
       sources.map(async (source) => {
@@ -179,13 +199,11 @@ router.get('/channels', async (req: Request, res: Response) => {
                 )
               : false);
             if (!canReadChannel) continue;
-            const list = byName.get(name) ?? [];
-            list.push({
+            upsert(name, {
               sourceId: source.id,
               sourceName: source.name,
               channelNumber: channelNum,
             });
-            byName.set(name, list);
           }
         } catch (err) {
           logger.warn(`Failed to load channels for source ${source.id}:`, err);
@@ -205,19 +223,17 @@ router.get('/channels', async (req: Request, res: Response) => {
           if (!canReadVirtualChannel(vc.id, readableVirtualIds)) continue;
           const name = (vc.name ?? '').trim();
           if (!name) continue;
-          const list = byName.get(name) ?? [];
-          list.push({
+          upsert(name, {
             sourceId: source.id,
             sourceName: source.name,
             channelNumber: CHANNEL_DB_OFFSET + vc.id,
           });
-          byName.set(name, list);
         }
       })
     );
 
-    const result = Array.from(byName.entries())
-      .map(([name, srcs]) => ({ name, sources: srcs }))
+    const result = Array.from(byName.values())
+      .map(({ displayName, sources: srcs }) => ({ name: displayName, sources: srcs }))
       .sort((a, b) => a.name.localeCompare(b.name));
 
     res.json(result);
@@ -356,9 +372,16 @@ router.get('/messages', async (req: Request, res: Response) => {
           const chans = chansResult.value;
           const resolved: number[] = [];
 
+          // Match channel name case-insensitively. The unified picker groups
+          // names case-insensitively (see `/channels` upsert helper), so the
+          // resolver here must too — otherwise a source whose stored name
+          // differs only in casing (e.g. "primary" vs "Primary") returns zero
+          // messages even though the picker showed a single entry.
+          const channelNameLower = channelName.toLowerCase();
+
           // Physical slot match.
           const match = chans?.find(
-            (c) => unifiedChannelDisplayName(c as any) === channelName
+            (c) => (unifiedChannelDisplayName(c as any) ?? '').toLowerCase() === channelNameLower
           );
           if (match) {
             const physNum = (match as any).id as number;
@@ -377,7 +400,7 @@ router.get('/messages', async (req: Request, res: Response) => {
           // we union the stored channel numbers (physical slot and synthetic
           // CHANNEL_DB_OFFSET+vcId) so the unified stream includes both.
           for (const vc of vcsOnSource) {
-            if ((vc.name ?? '').trim() === channelName && vc.id != null) {
+            if ((vc.name ?? '').trim().toLowerCase() === channelNameLower && vc.id != null) {
               resolved.push(CHANNEL_DB_OFFSET + vc.id);
             }
           }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2678,8 +2678,15 @@ apiRouter.put('/channels/:id', requirePermission('channel_0', 'write'), async (r
           : existingChannel.positionPrecision,
     };
 
-    // Update channel in database
-    await databaseService.channels.upsertChannel(updatedChannelData);
+    // Update channel in database. Scope to the requesting source so each
+    // source's channel row is independent. `allowBlankName: true` lets the
+    // user clear a stored channel name — without it, the ingest-protection
+    // coalesce in upsertChannel silently keeps the old name (#1567 backfire).
+    await databaseService.channels.upsertChannel(
+      updatedChannelData,
+      typeof chanSourceId === 'string' && chanSourceId.length > 0 ? chanSourceId : undefined,
+      { allowBlankName: true },
+    );
 
     // Send channel configuration to Meshtastic device
     const chanUpdateManager = (chanSourceId

--- a/tests/test-v1-api.sh
+++ b/tests/test-v1-api.sh
@@ -262,6 +262,24 @@ fi
 
 echo -e "${GREEN}✓ API Token generated: ${API_TOKEN:0:15}...${NC}"
 
+# Resolve the gauntlet channel slot dynamically. Project rule: use the
+# "gauntlet" channel for testing, never primary. Hardcoding a slot index
+# (e.g. `channel: 3`) drifts every time channels get reordered on the test
+# device — and a wrong index can land the message on the wrong channel
+# entirely if the test device's slot N happens to share a PSK (notably the
+# default `AQ==`) with another slot.
+GAUNTLET_SLOT=$(curl -sS -H "Authorization: Bearer $API_TOKEN" \
+    "${BASE_URL}/api/v1/channels" \
+    | jq -r '.data[]? | select((.name // "") | ascii_downcase == "gauntlet") | .id' \
+    | head -n1)
+
+if [ -z "$GAUNTLET_SLOT" ] || ! [[ "$GAUNTLET_SLOT" =~ ^[0-9]+$ ]]; then
+    echo -e "${YELLOW}⚠ No 'gauntlet' channel found on the test device — falling back to slot 3${NC}"
+    GAUNTLET_SLOT=3
+else
+    echo -e "${GREEN}✓ Resolved gauntlet channel to slot ${GAUNTLET_SLOT}${NC}"
+fi
+
 echo ""
 echo "=========================================="
 echo "Step 2: Test V1 API Endpoints"
@@ -372,13 +390,14 @@ echo ""
 # do NOT require CSRF tokens (which would be needed for session auth)
 
 # Test: POST to messages endpoint without CSRF token (should work with Bearer)
-# Uses channel 3 (gauntlet) for testing per project rules
+# Uses the gauntlet channel for testing per project rules. Slot is resolved
+# dynamically above so this stays correct even when channels get reordered.
 run_test "POST /api/v1/messages without CSRF token succeeds with Bearer auth" \
     "RESPONSE=\$(curl -sS -w '\\n%{http_code}' \
         -H 'Authorization: Bearer $API_TOKEN' \
         -H 'Content-Type: application/json' \
         -X POST '${BASE_URL}/api/v1/messages' \
-        -d '{\"text\": \"API v1 test message\", \"channel\": 3}')
+        -d '{\"text\": \"API v1 test message\", \"channel\": ${GAUNTLET_SLOT}}')
     HTTP_CODE=\$(echo \"\$RESPONSE\" | tail -n1)
     BODY=\$(echo \"\$RESPONSE\" | head -n -1)
     # Should NOT get 403 CSRF error - expect 201 (created) or 503 (not connected)


### PR DESCRIPTION
## Summary

Five small, related fixes touching the channel-edit flow and the unified message view. Reported by user testing against a multi-source dev setup.

### Bugs fixed

1. **Channel-edit save kept reverting blanks back to the prior name.** `upsertChannel` had a hard-coded coalesce (`data.name || existingChannel.name`) added in #1567 to stop device reconnects from wiping known names — but it also silently swallowed user-driven blanking. Added an explicit `opts.allowBlankName` switch; only the PUT route opts in.
2. **Wrong source's channel row got updated.** `PUT /api/channels/:id` was calling `upsertChannel` without `sourceId`, so the per-source row lookup fell back to ID-only. Threaded `sourceId` through.
3. **Unified Messages picker showed two entries for the same logical channel** when sources had different casing on the channel name (e.g. one stored `"primary"`, another stored blank → synthesized `"Primary"`). Each entry contained only that source's half of the conversation. `/channels` and `/messages` now group/match case-insensitively.
4. **Server-decrypted messages routed to slot 0 instead of the correct named slot.** PSK-only matching collided on Meshtastic's default `AQ==` PSK (shipped on every preset slot), so `find()` always returned slot 0. Channel hash is `xorHash(name) ^ xorHash(psk)`, so name participates in identity — match now requires both PSK and name.
5. **`tests/test-v1-api.sh` hardcoded `channel: 3`** with a stale comment claiming that's gauntlet. Slot has drifted on dev devices. Now resolves the gauntlet slot dynamically via `/api/v1/channels` and falls back to 3 only if no gauntlet channel is found.

### Files

- `src/db/repositories/channels.ts` — new `opts.allowBlankName`
- `src/server/server.ts` — PUT route passes sourceId + allowBlankName
- `src/server/routes/unifiedRoutes.ts` — case-insensitive grouping/matching in `/channels` and `/messages`
- `src/server/meshtasticManager.ts` — server-decrypted slot match requires PSK + name
- `tests/test-v1-api.sh` — gauntlet slot resolved dynamically

## Test plan

- [x] `tests/system-tests.sh` — all 11 phases PASS, 137/137 endpoints across sqlite/postgres/mysql.
- [x] User-verified: clearing channel name in the Sandbox edit dialog now persists a blank in the DB row for that source.
- [x] User-verified: Unified Messages picker collapses cross-device casing into a single entry; messages from both sources merge into a single bubble with `receptions[]` per source.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)