### PR TITLE
fix(upgrade): MySQL migration 037 FK + packet-log timer crash (#2836)

### DIFF
--- a/src/server/migrations/037_add_id_to_user_map_preferences.ts
+++ b/src/server/migrations/037_add_id_to_user_map_preferences.ts
@@ -90,6 +90,35 @@ export async function runMigration037Mysql(pool: any): Promise<void> {
          AND CONSTRAINT_TYPE = 'PRIMARY KEY'`
     );
     if ((pkRows as any[]).length > 0) {
+      // Issue #2836: legacy MySQL deployments primary-key the table on a
+      // single column (typically `userId`) that is also referenced by an FK
+      // back to `users.id`. MySQL backs the FK with the PK's index; dropping
+      // the PK without first creating a non-PK index over the FK column
+      // leaves the FK "incorrectly formed" and ALTER fails with errno 150.
+      // Pre-create non-PK indexes covering every FK column on this table so
+      // each FK retains a backing index when the PK is dropped. Idempotent
+      // via information_schema check.
+      const [fkRows] = await pool.query(
+        `SELECT COLUMN_NAME, CONSTRAINT_NAME
+         FROM information_schema.KEY_COLUMN_USAGE
+         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_map_preferences'
+           AND REFERENCED_TABLE_NAME IS NOT NULL`
+      );
+      for (const fk of (fkRows as any[])) {
+        const colName: string = fk.COLUMN_NAME;
+        const indexName = `idx_ump_${colName}`;
+        const [existingIdx] = await pool.query(
+          `SELECT INDEX_NAME FROM information_schema.STATISTICS
+           WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_map_preferences'
+             AND COLUMN_NAME = ? AND INDEX_NAME != 'PRIMARY' LIMIT 1`,
+          [colName]
+        );
+        if ((existingIdx as any[]).length === 0) {
+          await pool.query(
+            `ALTER TABLE user_map_preferences ADD INDEX \`${indexName}\` (\`${colName}\`)`
+          );
+        }
+      }
       await pool.query(`ALTER TABLE user_map_preferences DROP PRIMARY KEY`);
     }
     await pool.query(`ALTER TABLE user_map_preferences ADD COLUMN id INT AUTO_INCREMENT PRIMARY KEY FIRST`);

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -7854,17 +7854,23 @@ class DatabaseService {
   }
 
   cleanupOldPacketLogs(): number {
+    // The packet-log cleanup timer (PacketLogService) starts on a fixed
+    // schedule and can fire while the database is still initializing —
+    // especially during the long PG/MySQL upgrade migrations (#2836). Bail
+    // out cleanly if the repository hasn't been wired up yet so the upgrade
+    // path doesn't crash with `Cannot read properties of null`.
+    if (!this.miscRepo) return 0;
     const maxAgeHoursStr = this.getSetting('packet_log_max_age_hours');
     const maxAgeHours = maxAgeHoursStr ? parseInt(maxAgeHoursStr, 10) : 24;
     const cutoffTimestamp = Date.now() - (maxAgeHours * 60 * 60 * 1000);
-    return this.miscRepo!.cleanupOldPacketLogsSync(cutoffTimestamp);
+    return this.miscRepo.cleanupOldPacketLogsSync(cutoffTimestamp);
   }
 
   async cleanupOldPacketLogsAsync(): Promise<number> {
+    if (!this.miscRepo) return 0;
     const maxAgeHoursStr = this.getSetting('packet_log_max_age_hours');
     const maxAgeHours = maxAgeHoursStr ? parseInt(maxAgeHoursStr, 10) : 24;
-    if (this.miscRepo) return this.miscRepo.cleanupOldPacketLogs(maxAgeHours);
-    return this.cleanupOldPacketLogs();
+    return this.miscRepo.cleanupOldPacketLogs(maxAgeHours);
   }
 
   async getPacketCountsByNodeAsync(options?: { since?: number; limit?: number; portnum?: number; sourceId?: string }): Promise<DbPacketCountByNode[]> {


### PR DESCRIPTION
## Summary

Two upgrade-path bugs reported in #2836. Both block 4.x upgrades on long-running MySQL deployments.

### 1. Migration 037 fails on `DROP PRIMARY KEY`

User log:
```
[INFO] Running migration 037 (MySQL): add id to user_map_preferences...
[ERROR] ❌ Failed to migrate auto-responder triggers:
  Error: Error on rename of './meshmonitor/#sql-alter-...' to
  './meshmonitor/user_map_preferences' (errno: 150 "Foreign key
  constraint is incorrectly formed")
  sql: 'ALTER TABLE user_map_preferences DROP PRIMARY KEY'
```

Root cause: pre-baseline MySQL deployments primary-key `user_map_preferences` on a single column (typically `userId`) that is *also* the FK column referencing `users.id`. MySQL backs the FK with the PK's index; dropping the PK leaves the FK without a valid backing index and the ALTER fails with errno 150.

Fix: enumerate every FK on the table via `information_schema.KEY_COLUMN_USAGE` and pre-create a non-PK index over each FK column before the `DROP PRIMARY KEY`. Idempotent — checks `information_schema.STATISTICS` before each `ADD INDEX`.

### 2. PacketLogService cleanup timer crashes the upgrade

```
[ERROR] ❌ Failed to cleanup packet logs:
  TypeError: Cannot read properties of null
    (reading 'cleanupOldPacketLogsSync')
    at DatabaseService.cleanupOldPacketLogs
    at PacketLogService.runCleanup (Timeout._onTimeout)
```

The cleanup timer fires on a fixed interval. On long PG/MySQL upgrade migrations the tick can land while `miscRepo` is still null (DB init hasn't completed yet). Sync path used `this.miscRepo!.cleanupOldPacketLogsSync(...)` which threw and bubbled up to a fatal exit.

Fix: guard both `cleanupOldPacketLogs` and `cleanupOldPacketLogsAsync` to no-op (return 0) when `miscRepo` is null. Also collapsed a redundant fallthrough in the async path that previously routed to the sync (SQLite-only) path on non-SQLite — the null guard had been masking the bug.

### Files

- `src/server/migrations/037_add_id_to_user_map_preferences.ts` — FK-aware DROP PRIMARY KEY for MySQL
- `src/services/database.ts` — null-guard packet-log cleanup methods

## Test plan

- [ ] CI green (vitest + system-tests).
- [ ] User to confirm the 4.0.x → main upgrade no longer fails at migration 037 on their MySQL deployment.

Closes #2836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)