### PR TITLE
feat(messages): multiline compose (Enter sends, Shift+Enter newline)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1549,6 +1549,7 @@ body {
   .byte-counter {
     font-size: 0.65rem;
     right: 4px;
+    bottom: 4px;
     padding: 2px 4px;
   }
 
@@ -1765,11 +1766,12 @@ body {
 .message-input-container {
   display: flex;
   gap: 1rem;
-  align-items: center;
+  align-items: flex-end;
 }
 
 .message-input {
   flex: 1;
+  width: 100%;
   padding: 0.75rem 1rem;
   border: 2px solid var(--ctp-surface1);
   border-radius: var(--radius-lg);
@@ -1777,6 +1779,11 @@ body {
   background: var(--ctp-base);
   color: var(--ctp-text);
   transition: border-color 0.2s;
+  resize: none;
+  min-height: 2.75rem;
+  line-height: 1.4;
+  font-family: inherit;
+  box-sizing: border-box;
 }
 
 .message-input:focus {
@@ -2528,7 +2535,7 @@ body {
   position: relative;
   flex: 1;
   display: flex;
-  align-items: center;
+  align-items: stretch;
 }
 
 .input-with-counter .message-input {
@@ -2538,8 +2545,7 @@ body {
 .byte-counter {
   position: absolute;
   right: 8px;
-  top: 50%;
-  transform: translateY(-50%);
+  bottom: 8px;
   font-size: 0.75rem;
   color: var(--ctp-subtext0);
   font-family: var(--font-mono);

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -18,6 +18,7 @@ import { formatMessageTime, getMessageDateSeparator, shouldShowDateSeparator } f
 import { getUtf8ByteLength, formatByteCount, isEmoji } from '../utils/text';
 import { applyHomoglyphOptimization } from '../utils/homoglyph';
 import { renderMessageWithLinks } from '../utils/linkRenderer';
+import { useAutoResizeTextarea } from '../hooks/useAutoResizeTextarea';
 import HopCountDisplay from './HopCountDisplay';
 import LinkPreview from './LinkPreview';
 import RelayNodeModal from './RelayNodeModal';
@@ -184,7 +185,9 @@ export default function ChannelsTab({
   };
 
   // Refs
-  const channelMessageInputRef = useRef<HTMLInputElement>(null);
+  const channelMessageInputRef = useRef<HTMLTextAreaElement>(null);
+
+  useAutoResizeTextarea(channelMessageInputRef, newMessage);
 
   // State for "Jump to Bottom" button
   const [showJumpToBottom, setShowJumpToBottom] = useState(false);
@@ -951,13 +954,13 @@ export default function ChannelsTab({
                       {hasPermission(`channel_${selectedChannel}` as ResourceType, 'write') && selectedChannel >= 0 && selectedChannel < CHANNEL_DB_OFFSET && (
                         <div className="message-input-container">
                           <div className="input-with-counter">
-                            <input
+                            <textarea
                               ref={channelMessageInputRef}
-                              type="text"
                               value={newMessage}
                               onChange={e => setNewMessage(e.target.value)}
                               placeholder={t('channels.send_placeholder', { name: getChannelName(selectedChannel) })}
                               className="message-input"
+                              rows={1}
                               onFocus={e => {
                                 // On mobile, prevent iOS from scrolling the page excessively
                                 // Use a small delay to let iOS do its thing, then reset scroll
@@ -965,8 +968,16 @@ export default function ChannelsTab({
                                   e.target.scrollIntoView({ block: 'end', behavior: 'smooth' });
                                 }, 100);
                               }}
-                              onKeyPress={e => {
-                                if (e.key === 'Enter') {
+                              onKeyDown={e => {
+                                if (
+                                  e.key === 'Enter' &&
+                                  !e.shiftKey &&
+                                  !e.ctrlKey &&
+                                  !e.metaKey &&
+                                  !e.altKey &&
+                                  !e.nativeEvent.isComposing
+                                ) {
+                                  e.preventDefault();
                                   handleSendMessage(selectedChannel);
                                 }
                               }}

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -8,6 +8,7 @@
 import React, { useRef, useCallback, useState, useMemo, useEffect } from 'react';
 import '../styles/messages.css';
 import { useResizable } from '../hooks/useResizable';
+import { useAutoResizeTextarea } from '../hooks/useAutoResizeTextarea';
 import { useTranslation, Trans } from 'react-i18next';
 import { DeviceInfo, Channel } from '../types/device';
 import { MeshMessage } from '../types/message';
@@ -443,7 +444,9 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   });
 
   // Refs
-  const dmMessageInputRef = useRef<HTMLInputElement>(null);
+  const dmMessageInputRef = useRef<HTMLTextAreaElement>(null);
+
+  useAutoResizeTextarea(dmMessageInputRef, newMessage);
 
   // Helper functions
   const getNodeName = useCallback(
@@ -1523,15 +1526,23 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                 {hasPermission('messages', 'write') && (
                   <div className="message-input-container">
                     <div className="input-with-counter">
-                      <input
+                      <textarea
                         ref={dmMessageInputRef}
-                        type="text"
                         value={newMessage}
                         onChange={e => setNewMessage(e.target.value)}
                         placeholder={t('messages.dm_placeholder', { name: getNodeName(selectedDMNode) })}
                         className="message-input"
-                        onKeyPress={e => {
-                          if (e.key === 'Enter') {
+                        rows={1}
+                        onKeyDown={e => {
+                          if (
+                            e.key === 'Enter' &&
+                            !e.shiftKey &&
+                            !e.ctrlKey &&
+                            !e.metaKey &&
+                            !e.altKey &&
+                            !e.nativeEvent.isComposing
+                          ) {
+                            e.preventDefault();
                             handleSendDirectMessage(selectedDMNode);
                           }
                         }}

--- a/src/hooks/useAutoResizeTextarea.test.ts
+++ b/src/hooks/useAutoResizeTextarea.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for useAutoResizeTextarea
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+import { useAutoResizeTextarea } from './useAutoResizeTextarea';
+
+function setup(initialValue: string, scrollHeight: number, lineHeightPx = 20) {
+  const textarea = document.createElement('textarea');
+  textarea.style.lineHeight = `${lineHeightPx}px`;
+  textarea.style.padding = '0';
+  textarea.style.border = '0';
+  document.body.appendChild(textarea);
+
+  Object.defineProperty(textarea, 'scrollHeight', {
+    configurable: true,
+    get: () => scrollHeight,
+  });
+
+  return renderHook(
+    ({ value }) => {
+      const ref = useRef<HTMLTextAreaElement>(textarea);
+      useAutoResizeTextarea(ref, value);
+      return ref;
+    },
+    { initialProps: { value: initialValue } },
+  );
+}
+
+describe('useAutoResizeTextarea', () => {
+  it('grows textarea height to match content within max', () => {
+    const { result } = setup('one\ntwo', 60, 20);
+    const el = result.current.current!;
+    expect(el.style.height).toBe('60px');
+    expect(el.style.overflowY).toBe('hidden');
+  });
+
+  it('caps height at maxRows × lineHeight and switches to scroll', () => {
+    // 6 rows × 20px = 120px ceiling, content wants 400px
+    const { result } = setup('many lines', 400, 20);
+    const el = result.current.current!;
+    expect(el.style.height).toBe('120px');
+    expect(el.style.overflowY).toBe('auto');
+  });
+
+  it('recomputes when value changes', () => {
+    const textarea = document.createElement('textarea');
+    textarea.style.lineHeight = '20px';
+    document.body.appendChild(textarea);
+    let scrollHeight = 30;
+    Object.defineProperty(textarea, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+
+    const { result, rerender } = renderHook(
+      ({ value }) => {
+        const ref = useRef<HTMLTextAreaElement>(textarea);
+        useAutoResizeTextarea(ref, value);
+        return ref;
+      },
+      { initialProps: { value: 'short' } },
+    );
+    expect(result.current.current!.style.height).toBe('30px');
+
+    scrollHeight = 80;
+    rerender({ value: 'longer\ntext\nwith\nmore' });
+    expect(result.current.current!.style.height).toBe('80px');
+  });
+});

--- a/src/hooks/useAutoResizeTextarea.ts
+++ b/src/hooks/useAutoResizeTextarea.ts
@@ -1,0 +1,27 @@
+import { useLayoutEffect, type RefObject } from 'react';
+
+const DEFAULT_LINE_HEIGHT_PX = 20;
+
+export function useAutoResizeTextarea(
+  ref: RefObject<HTMLTextAreaElement | null>,
+  value: string,
+  maxRows = 6,
+): void {
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    const computed = getComputedStyle(el);
+    const lineHeight = parseFloat(computed.lineHeight) || DEFAULT_LINE_HEIGHT_PX;
+    const paddingY =
+      (parseFloat(computed.paddingTop) || 0) +
+      (parseFloat(computed.paddingBottom) || 0);
+    const borderY =
+      (parseFloat(computed.borderTopWidth) || 0) +
+      (parseFloat(computed.borderBottomWidth) || 0);
+    const max = lineHeight * maxRows + paddingY + borderY;
+    const next = Math.min(el.scrollHeight, max);
+    el.style.height = `${next}px`;
+    el.style.overflowY = el.scrollHeight > max ? 'auto' : 'hidden';
+  }, [ref, value, maxRows]);
+}


### PR DESCRIPTION
## Summary

- Swap DM and channel compose inputs from `<input type="text">` to `<textarea>`. Users can now type or paste multi-paragraph messages.
- Enter sends, Shift+Enter (and Ctrl/Meta/Alt+Enter) inserts a newline. IME composition guarded so CJK Enter-to-commit doesn't send.
- New `useAutoResizeTextarea` hook auto-grows the textarea up to 6 rows then switches to internal scroll.
- Byte counter overlay re-anchored to bottom-right so it doesn't overlay multi-line content.

## Why

Today the chat composer is `<input type="text">` — the browser blocks newlines on type and on paste, so users cannot author or even cleanly paste multi-paragraph messages.

## What didn't need to change

- Backend `POST /api/v1/messages`: `text.trim()` only strips edges; internal `\n` already passes through.
- `splitMessageForMeshtastic` in `meshtasticManager.ts` already prefers `\n` as a break point, so multi-line messages over the 200-byte limit split cleanly across the up-to-3 part budget.
- Message-bubble renderer already uses `whiteSpace: pre-line`, so received newlines display correctly.

## Files

- `src/hooks/useAutoResizeTextarea.ts` (+ test)
- `src/components/MessagesTab.tsx` — DM compose
- `src/components/ChannelsTab.tsx` — channel compose
- `src/App.css` — `.message-input` (resize:none, min-height, line-height, font-family, box-sizing), `.message-input-container` align-items: flex-end, `.byte-counter` anchored bottom-right (with mobile override).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — 0 errors (2 pre-existing warnings unrelated)
- [x] `npx vitest run` — 4468 passed, 0 failures
- [x] New hook unit tests — 3 pass
- [x] Manual: DM and channel compose, Enter sends, Shift+Enter newline, paste-multiline preserved, textarea auto-grows then scrolls, byte counter behaves
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)