### PR TITLE
fix(settings): scope per-source reads to per-source namespace only

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 49 migrations registered', () => {
-    expect(registry.count()).toBe(49);
+  it('has all 50 migrations registered', () => {
+    expect(registry.count()).toBe(50);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,14 +12,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is perf_composite_indexes', () => {
+  it('last migration is promote_globals_to_default_source', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(49);
-    expect(last.name).toContain('perf_composite_indexes');
+    expect(last.number).toBe(50);
+    expect(last.name).toContain('promote_globals_to_default_source');
   });
 
-  it('migrations are sequentially numbered from 1 to 49', () => {
+  it('migrations are sequentially numbered from 1 to 50', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -61,6 +61,7 @@ import { migration as addUserMapPrefsIdSqliteMigration, runMigration046Postgres,
 import { migration as addSelectedLayerMigration, runMigration047Postgres, runMigration047Mysql } from '../server/migrations/047_add_selected_layer_to_user_map_preferences.js';
 import { migration as rebuildIgnoredNodesPerSourceMigration, runMigration048Postgres, runMigration048Mysql } from '../server/migrations/048_rebuild_ignored_nodes_per_source.js';
 import { migration as perfCompositeIndexesMigration, runMigration049Postgres, runMigration049Mysql } from '../server/migrations/049_perf_composite_indexes.js';
+import { migration as promoteGlobalsToDefaultSourceMigration, runMigration050Postgres, runMigration050Mysql } from '../server/migrations/050_promote_globals_to_default_source.js';
 
 // ============================================================================
 // Registry
@@ -762,4 +763,20 @@ registry.register({
   sqlite: (db) => perfCompositeIndexesMigration.up(db),
   postgres: (client) => runMigration049Postgres(client),
   mysql: (pool) => runMigration049Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 050: Promote legacy global per-source settings (and orphan
+// NULL-sourceId rows in auto_traceroute_nodes / auto_time_sync_nodes) to the
+// default source's namespace, so single-source pre-4.x users don't lose
+// configuration after the global-fallback in getSettingForSource is removed.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 50,
+  name: 'promote_globals_to_default_source',
+  settingsKey: 'migration_050_promote_globals_to_default_source',
+  sqlite: (db) => promoteGlobalsToDefaultSourceMigration.up(db),
+  postgres: (client) => runMigration050Postgres(client),
+  mysql: (pool) => runMigration050Mysql(pool),
 });

--- a/src/db/repositories/perSource.test.ts
+++ b/src/db/repositories/perSource.test.ts
@@ -139,11 +139,14 @@ describe('per-source isolation (Phase 2a–2f)', () => {
       expect(a).toBe('true');
     });
 
-    it('falls back to global when no per-source override exists', async () => {
+    it('returns null when no per-source override exists, even if global is set', async () => {
+      // Issue #2839 / #2840: previous fallback to the global value caused
+      // multi-source automation spam and post-upgrade UI/runtime mismatches.
+      // Each source must own its config independently.
       await h.settings.setSetting('autoPingEnabled', 'false');
 
       const a = await h.settings.getSettingForSource('A', 'autoPingEnabled');
-      expect(a).toBe('false');
+      expect(a).toBeNull();
     });
 
     it('returns global when sourceId is null/undefined', async () => {

--- a/src/db/repositories/settings.ts
+++ b/src/db/repositories/settings.ts
@@ -188,14 +188,19 @@ export class SettingsRepository extends BaseRepository {
   }
 
   /**
-   * Get a setting for a specific source, falling back to the global value when
-   * no per-source override exists. Pass `null`/`undefined` for sourceId to get
-   * the plain global setting.
+   * Get a setting for a specific source. Returns ONLY the per-source value
+   * (null if no per-source override exists). Pass `null`/`undefined` for
+   * sourceId to read the un-namespaced global setting.
+   *
+   * The previous behaviour fell back to the global value when no per-source
+   * override existed; that fallback was the root cause of issue #2839
+   * (multi-source automation spam) and #2840 (auto-traceroute UI mismatch
+   * after upgrade). Migration 050 promotes legacy globals into the default
+   * source's namespace so single-source pre-4.x users keep their config.
    */
   async getSettingForSource(sourceId: string | null | undefined, key: string): Promise<string | null> {
     if (sourceId) {
-      const prefixed = await this.getSetting(`${this.sourcePrefix(sourceId)}${key}`);
-      if (prefixed !== null && prefixed !== undefined) return prefixed;
+      return await this.getSetting(`${this.sourcePrefix(sourceId)}${key}`);
     }
     return await this.getSetting(key);
   }

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -144,3 +144,127 @@ export const VALID_SETTINGS_KEYS = [
 ] as const;
 
 export type ValidSettingKey = typeof VALID_SETTINGS_KEYS[number];
+
+/**
+ * Settings keys that are scoped per-source.
+ *
+ * These are read by per-source MeshtasticManager instances via
+ * `databaseService.settings.getSettingForSource(this.sourceId, key)`. After
+ * removing the global fallback (issue #2839), reads of these keys for a
+ * source that has no per-source override return null — the caller's own
+ * default kicks in, which is the correct behaviour for multi-source setups.
+ *
+ * The list is derived by grepping `getSettingForSource(...)` call sites in
+ * the server. Update when adding a new per-source setting.
+ *
+ * Used by:
+ *   - Migration 050 — promotes legacy global values into the default source's
+ *     namespace on upgrade so single-source v3.x users don't lose config.
+ *   - Future audit / lint rules that may want to assert that all per-source
+ *     reads target a registered key.
+ */
+export const PER_SOURCE_SETTINGS_KEYS = [
+  // Auto-ack
+  'autoAckChannels',
+  'autoAckCooldownSeconds',
+  'autoAckDirectEnabled',
+  'autoAckDirectMessages',
+  'autoAckDirectReplyEnabled',
+  'autoAckDirectTapbackEnabled',
+  'autoAckEnabled',
+  'autoAckIgnoredNodes',
+  'autoAckMessage',
+  'autoAckMessageDirect',
+  'autoAckMultihopEnabled',
+  'autoAckMultihopReplyEnabled',
+  'autoAckMultihopTapbackEnabled',
+  'autoAckRegex',
+  'autoAckSkipIncompleteNodes',
+  'autoAckUseDM',
+  // Auto-announce
+  'autoAnnounceChannelIndexes',
+  'autoAnnounceEnabled',
+  'autoAnnounceIntervalHours',
+  'autoAnnounceMessage',
+  'autoAnnounceNodeInfoChannels',
+  'autoAnnounceNodeInfoDelaySeconds',
+  'autoAnnounceNodeInfoEnabled',
+  'autoAnnounceOnStart',
+  'autoAnnounceSchedule',
+  'autoAnnounceUseSchedule',
+  // Auto-delete by distance
+  'autoDeleteByDistanceAction',
+  'autoDeleteByDistanceEnabled',
+  'autoDeleteByDistanceIntervalHours',
+  'autoDeleteByDistanceLat',
+  'autoDeleteByDistanceLon',
+  'autoDeleteByDistanceThresholdKm',
+  // Auto-favorite
+  'autoFavoriteEnabled',
+  'autoFavoriteNodes',
+  'autoFavoriteStaleHours',
+  // Auto-heap-management
+  'autoHeapManagementEnabled',
+  'autoHeapManagementThresholdBytes',
+  // Auto-key-management
+  'autoKeyManagementEnabled',
+  // Auto-ping
+  'autoPingEnabled',
+  'autoPingIntervalSeconds',
+  'autoPingMaxPings',
+  'autoPingTimeoutSeconds',
+  // Auto-responder (the feature the screenshots in #2839 call "Automations")
+  'autoResponderEnabled',
+  'autoResponderSkipIncompleteNodes',
+  'autoResponderTriggers',
+  // Auto-time-sync
+  'autoTimeSyncEnabled',
+  'autoTimeSyncIntervalMinutes',
+  // Auto-welcome
+  'autoWelcomeEnabled',
+  'autoWelcomeMaxHops',
+  'autoWelcomeMessage',
+  'autoWelcomeTarget',
+  'autoWelcomeWaitForName',
+  // Misc per-source
+  'externalUrl',
+  'geofenceTriggers',
+  'lastAnnouncementTime',
+  'localNodeNum',
+  'localStatsIntervalMinutes',
+  'timerTriggers',
+  // Remote admin
+  'remoteAdminScannerIntervalMinutes',
+  'remoteAdminScheduleEnabled',
+  'remoteAdminScheduleEnd',
+  'remoteAdminScheduleStart',
+  // Security digest
+  'securityDigestAppriseUrl',
+  'securityDigestFormat',
+  'securityDigestReportType',
+  'securityDigestSuppressEmpty',
+  // Traceroute scheduler / filters
+  'tracerouteIntervalMinutes',
+  'tracerouteScheduleEnabled',
+  'tracerouteScheduleEnd',
+  'tracerouteScheduleStart',
+  'tracerouteNodeFilterEnabled',
+  'tracerouteFilterChannels',
+  'tracerouteFilterRoles',
+  'tracerouteFilterHwModels',
+  'tracerouteFilterNameRegex',
+  'tracerouteFilterNodesEnabled',
+  'tracerouteFilterChannelsEnabled',
+  'tracerouteFilterRolesEnabled',
+  'tracerouteFilterHwModelsEnabled',
+  'tracerouteFilterRegexEnabled',
+  'tracerouteExpirationHours',
+  'tracerouteSortByHops',
+  'tracerouteFilterLastHeardEnabled',
+  'tracerouteFilterLastHeardHours',
+  'tracerouteFilterHopsEnabled',
+  'tracerouteFilterHopsMin',
+  'tracerouteFilterHopsMax',
+] as const;
+
+export type PerSourceSettingKey = typeof PER_SOURCE_SETTINGS_KEYS[number];

--- a/src/server/migrations/050_promote_globals_to_default_source.test.ts
+++ b/src/server/migrations/050_promote_globals_to_default_source.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Migration 050 — Promote legacy global per-source settings (and orphan
+ * NULL-sourceId rows in auto_traceroute_nodes / auto_time_sync_nodes) to the
+ * default source's namespace. Validates the upgrade path that keeps
+ * single-source pre-4.x users' configuration after the global fallback in
+ * `getSettingForSource` is removed.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './050_promote_globals_to_default_source.js';
+
+function createSchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE sources (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL,
+      config TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL,
+      createdBy INTEGER
+    );
+    CREATE TABLE settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL
+    );
+    CREATE TABLE auto_traceroute_nodes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      nodeNum INTEGER NOT NULL,
+      enabled INTEGER DEFAULT 1,
+      createdAt INTEGER NOT NULL,
+      sourceId TEXT
+    );
+    CREATE TABLE auto_time_sync_nodes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      nodeNum INTEGER NOT NULL,
+      enabled INTEGER DEFAULT 1,
+      createdAt INTEGER NOT NULL,
+      sourceId TEXT
+    );
+  `);
+}
+
+function insertSource(db: Database.Database, id: string, createdAt: number) {
+  db.prepare(`
+    INSERT INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+    VALUES (?, ?, 'meshtastic_tcp', '{}', 1, ?, ?)
+  `).run(id, `Source ${id}`, createdAt, createdAt);
+}
+
+function insertSetting(db: Database.Database, key: string, value: string) {
+  const ts = Date.now();
+  db.prepare(`INSERT INTO settings (key, value, createdAt, updatedAt) VALUES (?, ?, ?, ?)`).run(key, value, ts, ts);
+}
+
+function getSetting(db: Database.Database, key: string): string | null {
+  const row = db.prepare(`SELECT value FROM settings WHERE key = ?`).get(key) as { value: string } | undefined;
+  return row?.value ?? null;
+}
+
+describe('Migration 050 — promote globals to default source', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createSchema(db);
+  });
+
+  it('promotes legacy global per-source keys into source:{defaultId}: namespace', () => {
+    insertSource(db, 'src-old', 1000);
+    insertSource(db, 'src-new', 2000);
+    insertSetting(db, 'autoResponderEnabled', 'true');
+    insertSetting(db, 'autoResponderTriggers', '[{"trigger":"hi","response":"hello"}]');
+    insertSetting(db, 'tracerouteIntervalMinutes', '30');
+
+    migration.up(db);
+
+    expect(getSetting(db, 'source:src-old:autoResponderEnabled')).toBe('true');
+    expect(getSetting(db, 'source:src-old:autoResponderTriggers')).toBe('[{"trigger":"hi","response":"hello"}]');
+    expect(getSetting(db, 'source:src-old:tracerouteIntervalMinutes')).toBe('30');
+    // The newer source must NOT inherit
+    expect(getSetting(db, 'source:src-new:autoResponderEnabled')).toBeNull();
+    expect(getSetting(db, 'source:src-new:tracerouteIntervalMinutes')).toBeNull();
+  });
+
+  it('preserves the original global value (non-destructive)', () => {
+    insertSource(db, 'src-old', 1000);
+    insertSetting(db, 'autoResponderEnabled', 'true');
+
+    migration.up(db);
+
+    expect(getSetting(db, 'autoResponderEnabled')).toBe('true');
+  });
+
+  it('does NOT overwrite an existing per-source override', () => {
+    insertSource(db, 'src-old', 1000);
+    insertSetting(db, 'autoResponderEnabled', 'true'); // legacy global
+    insertSetting(db, 'source:src-old:autoResponderEnabled', 'false'); // user already saved per-source
+
+    migration.up(db);
+
+    expect(getSetting(db, 'source:src-old:autoResponderEnabled')).toBe('false');
+  });
+
+  it('skips keys that have no global value', () => {
+    insertSource(db, 'src-old', 1000);
+    // No globals set at all
+
+    migration.up(db);
+
+    // Migration should run cleanly with no per-source keys created
+    const rows = db
+      .prepare(`SELECT key FROM settings WHERE key LIKE 'source:%'`)
+      .all() as Array<{ key: string }>;
+    expect(rows).toHaveLength(0);
+  });
+
+  it('is idempotent — re-running does not duplicate or change data', () => {
+    insertSource(db, 'src-old', 1000);
+    insertSetting(db, 'autoResponderEnabled', 'true');
+
+    migration.up(db);
+    migration.up(db);
+
+    const rows = db
+      .prepare(`SELECT key, value FROM settings WHERE key = 'source:src-old:autoResponderEnabled'`)
+      .all() as Array<{ key: string; value: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].value).toBe('true');
+  });
+
+  it('backfills NULL-sourceId rows in auto_traceroute_nodes to the default source', () => {
+    insertSource(db, 'src-old', 1000);
+    insertSource(db, 'src-new', 2000);
+    const ts = Date.now();
+    db.prepare(`INSERT INTO auto_traceroute_nodes (nodeNum, createdAt, sourceId) VALUES (?, ?, ?)`).run(0xdeadbeef, ts, null);
+    db.prepare(`INSERT INTO auto_traceroute_nodes (nodeNum, createdAt, sourceId) VALUES (?, ?, ?)`).run(0xcafebabe, ts, null);
+    db.prepare(`INSERT INTO auto_traceroute_nodes (nodeNum, createdAt, sourceId) VALUES (?, ?, ?)`).run(0x12345678, ts, 'src-new');
+
+    migration.up(db);
+
+    const rows = db.prepare(`SELECT nodeNum, sourceId FROM auto_traceroute_nodes ORDER BY nodeNum`).all() as Array<{ nodeNum: number; sourceId: string | null }>;
+    expect(rows).toHaveLength(3);
+    const oldSrcRows = rows.filter((r) => r.sourceId === 'src-old');
+    const newSrcRows = rows.filter((r) => r.sourceId === 'src-new');
+    expect(oldSrcRows).toHaveLength(2);
+    expect(newSrcRows).toHaveLength(1);
+    // No NULL sourceIds remain
+    expect(rows.every((r) => r.sourceId !== null)).toBe(true);
+  });
+
+  it('backfills NULL-sourceId rows in auto_time_sync_nodes to the default source', () => {
+    insertSource(db, 'src-old', 1000);
+    const ts = Date.now();
+    db.prepare(`INSERT INTO auto_time_sync_nodes (nodeNum, createdAt, sourceId) VALUES (?, ?, ?)`).run(0xdeadbeef, ts, null);
+
+    migration.up(db);
+
+    const row = db.prepare(`SELECT sourceId FROM auto_time_sync_nodes WHERE nodeNum = ?`).get(0xdeadbeef) as { sourceId: string };
+    expect(row.sourceId).toBe('src-old');
+  });
+
+  it('synthesizes a default source when sources table is empty', () => {
+    insertSetting(db, 'autoResponderEnabled', 'true');
+
+    migration.up(db);
+
+    const sources = db.prepare(`SELECT id FROM sources`).all() as Array<{ id: string }>;
+    expect(sources).toHaveLength(1);
+    const id = sources[0].id;
+    expect(getSetting(db, `source:${id}:autoResponderEnabled`)).toBe('true');
+  });
+});

--- a/src/server/migrations/050_promote_globals_to_default_source.ts
+++ b/src/server/migrations/050_promote_globals_to_default_source.ts
@@ -1,0 +1,260 @@
+/**
+ * Migration 050: Promote legacy global per-source settings (and orphan
+ * NULL-sourceId rows in auto_traceroute_nodes / auto_time_sync_nodes) to the
+ * default source's namespace.
+ *
+ * Background: Pre-4.x MeshMonitor stored automation, scheduler, and other
+ * runtime settings under un-namespaced keys (e.g. `autoResponderEnabled`).
+ * 4.x introduced per-source settings via the `source:{id}:{key}` prefix.
+ * `getSettingForSource` previously fell back to the global key when no
+ * per-source override existed, which produced a cluster of bugs:
+ *
+ *   - #2839: secondary sources inherited the main source's automation
+ *     config and fired duplicate responses.
+ *   - #2840: auto-traceroute UI showed empty after upgrade because the
+ *     "Specific Nodes" list lived on `auto_traceroute_nodes` rows whose
+ *     `sourceId` was NULL (pre-multi-source vintage), but the read filtered
+ *     by the default source's id.
+ *   - "Notifications need uncheck/recheck after upgrade": settings reads
+ *     fell back to global, so the runtime kept working off the legacy
+ *     value while the UI (querying per-source state) showed defaults.
+ *
+ * Together with the helper change in `src/db/repositories/settings.ts`
+ * removing the global fallback, this migration makes upgraded single-source
+ * installs land in a state where the default source owns all the user's
+ * existing config and secondary sources start clean.
+ *
+ * Idempotency: registry's `settingsKey` blocks re-runs at the harness
+ * level. The internal SQL also uses INSERT ... ON CONFLICT DO NOTHING /
+ * INSERT IGNORE so a manual re-run wouldn't clobber existing per-source
+ * overrides.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+import { PER_SOURCE_SETTINGS_KEYS } from '../constants/settings.js';
+import {
+  ensureDefaultSourceIdSqlite,
+  ensureDefaultSourceIdPostgres,
+  ensureDefaultSourceIdMysql,
+} from './_legacyDefaultSource.js';
+
+const LABEL = 'Migration 050';
+
+function now(): number {
+  return Date.now();
+}
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): promoting legacy global settings to default source`);
+
+    const defaultSourceId = ensureDefaultSourceIdSqlite(db, LABEL);
+    if (!defaultSourceId) {
+      logger.debug(`${LABEL} (SQLite): sources table missing, nothing to promote`);
+      return;
+    }
+
+    const tx = db.transaction(() => {
+      let promoted = 0;
+      const ts = now();
+
+      const insert = db.prepare(
+        `INSERT INTO settings (key, value, createdAt, updatedAt)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(key) DO NOTHING`
+      );
+      const readGlobal = db.prepare(`SELECT value FROM settings WHERE key = ?`);
+
+      for (const key of PER_SOURCE_SETTINGS_KEYS) {
+        const globalRow = readGlobal.get(key) as { value: string } | undefined;
+        if (!globalRow) continue;
+
+        const prefixedKey = `source:${defaultSourceId}:${key}`;
+        const result = insert.run(prefixedKey, globalRow.value, ts, ts);
+        if (result.changes > 0) promoted++;
+      }
+
+      if (promoted > 0) {
+        logger.info(`${LABEL} (SQLite): promoted ${promoted} setting(s) into source:${defaultSourceId}:`);
+      }
+
+      // Backfill orphan NULL-sourceId rows in auto_traceroute_nodes and
+      // auto_time_sync_nodes. Same legacy issue: the column was added in
+      // migration 024 but pre-existing rows kept NULL.
+      let backfillTraceroute = 0;
+      let backfillTimesync = 0;
+      try {
+        const r = db
+          .prepare(`UPDATE auto_traceroute_nodes SET sourceId = ? WHERE sourceId IS NULL`)
+          .run(defaultSourceId);
+        backfillTraceroute = r.changes ?? 0;
+      } catch {
+        // table missing on very old DBs — fine
+      }
+      try {
+        const r = db
+          .prepare(`UPDATE auto_time_sync_nodes SET sourceId = ? WHERE sourceId IS NULL`)
+          .run(defaultSourceId);
+        backfillTimesync = r.changes ?? 0;
+      } catch {
+        // table missing — fine
+      }
+
+      if (backfillTraceroute > 0) {
+        logger.info(`${LABEL} (SQLite): backfilled ${backfillTraceroute} auto_traceroute_nodes row(s) -> ${defaultSourceId}`);
+      }
+      if (backfillTimesync > 0) {
+        logger.info(`${LABEL} (SQLite): backfilled ${backfillTimesync} auto_time_sync_nodes row(s) -> ${defaultSourceId}`);
+      }
+    });
+
+    tx();
+  },
+};
+
+export async function runMigration050Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): promoting legacy global settings to default source`);
+
+  const defaultSourceId = await ensureDefaultSourceIdPostgres(client, LABEL);
+  if (!defaultSourceId) {
+    logger.debug(`${LABEL} (PostgreSQL): sources table missing, nothing to promote`);
+    return;
+  }
+
+  await client.query('BEGIN');
+  try {
+    let promoted = 0;
+    const ts = now();
+
+    for (const key of PER_SOURCE_SETTINGS_KEYS) {
+      const globalRes = await client.query(
+        `SELECT value FROM settings WHERE key = $1`,
+        [key],
+      );
+      if (globalRes.rowCount === 0) continue;
+
+      const prefixedKey = `source:${defaultSourceId}:${key}`;
+      const ins = await client.query(
+        `INSERT INTO settings (key, value, "createdAt", "updatedAt")
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (key) DO NOTHING`,
+        [prefixedKey, globalRes.rows[0].value, ts, ts],
+      );
+      if ((ins.rowCount ?? 0) > 0) promoted++;
+    }
+
+    if (promoted > 0) {
+      logger.info(`${LABEL} (PostgreSQL): promoted ${promoted} setting(s) into source:${defaultSourceId}:`);
+    }
+
+    let backfillTraceroute = 0;
+    let backfillTimesync = 0;
+    try {
+      const r = await client.query(
+        `UPDATE auto_traceroute_nodes SET "sourceId" = $1 WHERE "sourceId" IS NULL`,
+        [defaultSourceId],
+      );
+      backfillTraceroute = r.rowCount ?? 0;
+    } catch {
+      // table missing — fine
+    }
+    try {
+      const r = await client.query(
+        `UPDATE auto_time_sync_nodes SET "sourceId" = $1 WHERE "sourceId" IS NULL`,
+        [defaultSourceId],
+      );
+      backfillTimesync = r.rowCount ?? 0;
+    } catch {
+      // table missing — fine
+    }
+
+    if (backfillTraceroute > 0) {
+      logger.info(`${LABEL} (PostgreSQL): backfilled ${backfillTraceroute} auto_traceroute_nodes row(s) -> ${defaultSourceId}`);
+    }
+    if (backfillTimesync > 0) {
+      logger.info(`${LABEL} (PostgreSQL): backfilled ${backfillTimesync} auto_time_sync_nodes row(s) -> ${defaultSourceId}`);
+    }
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    logger.error(`${LABEL} (PostgreSQL) failed:`, error);
+    throw error;
+  }
+}
+
+export async function runMigration050Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): promoting legacy global settings to default source`);
+
+  const defaultSourceId = await ensureDefaultSourceIdMysql(pool, LABEL);
+  if (!defaultSourceId) {
+    logger.debug(`${LABEL} (MySQL): sources table missing, nothing to promote`);
+    return;
+  }
+
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+
+    let promoted = 0;
+    const ts = now();
+
+    for (const key of PER_SOURCE_SETTINGS_KEYS) {
+      const [globalRows] = await conn.query(
+        `SELECT value FROM settings WHERE \`key\` = ?`,
+        [key],
+      );
+      const row = (globalRows as Array<{ value: string }>)[0];
+      if (!row) continue;
+
+      const prefixedKey = `source:${defaultSourceId}:${key}`;
+      const [ins] = await conn.query(
+        `INSERT IGNORE INTO settings (\`key\`, \`value\`, createdAt, updatedAt)
+         VALUES (?, ?, ?, ?)`,
+        [prefixedKey, row.value, ts, ts],
+      );
+      const affected = (ins as { affectedRows?: number }).affectedRows ?? 0;
+      if (affected > 0) promoted++;
+    }
+
+    if (promoted > 0) {
+      logger.info(`${LABEL} (MySQL): promoted ${promoted} setting(s) into source:${defaultSourceId}:`);
+    }
+
+    let backfillTraceroute = 0;
+    let backfillTimesync = 0;
+    try {
+      const [r] = await conn.query(
+        `UPDATE auto_traceroute_nodes SET sourceId = ? WHERE sourceId IS NULL`,
+        [defaultSourceId],
+      );
+      backfillTraceroute = (r as { affectedRows?: number }).affectedRows ?? 0;
+    } catch {
+      // table missing — fine
+    }
+    try {
+      const [r] = await conn.query(
+        `UPDATE auto_time_sync_nodes SET sourceId = ? WHERE sourceId IS NULL`,
+        [defaultSourceId],
+      );
+      backfillTimesync = (r as { affectedRows?: number }).affectedRows ?? 0;
+    } catch {
+      // table missing — fine
+    }
+
+    if (backfillTraceroute > 0) {
+      logger.info(`${LABEL} (MySQL): backfilled ${backfillTraceroute} auto_traceroute_nodes row(s) -> ${defaultSourceId}`);
+    }
+    if (backfillTimesync > 0) {
+      logger.info(`${LABEL} (MySQL): backfilled ${backfillTimesync} auto_time_sync_nodes row(s) -> ${defaultSourceId}`);
+    }
+
+    await conn.commit();
+  } catch (error) {
+    await conn.rollback();
+    logger.error(`${LABEL} (MySQL) failed:`, error);
+    throw error;
+  } finally {
+    conn.release();
+  }
+}

--- a/src/services/database.traceroutePerSource.test.ts
+++ b/src/services/database.traceroutePerSource.test.ts
@@ -133,8 +133,10 @@ describe('DatabaseService - per-source auto-traceroute filters', () => {
     expect(b.filterHopsMax).toBe(9);
   });
 
-  it('falls back to global values when a source has no override', async () => {
-    // Write a global config (no sourceId). Legacy path.
+  it('returns defaults (no global fallback) when a source has no override', async () => {
+    // Issue #2839 / #2840: each source must own its config independently.
+    // A legacy global value must NOT leak into a per-source read; the
+    // upgrade path is handled by migration 050, not by silent fallback.
     await dbService.setTracerouteFilterSettingsAsync({
       enabled: true,
       nodeNums: [],
@@ -157,12 +159,12 @@ describe('DatabaseService - per-source auto-traceroute filters', () => {
     });
 
     const scoped = await dbService.getTracerouteFilterSettingsAsync(SOURCE_A);
-    expect(scoped.filterChannels).toEqual([4]);
-    expect(scoped.filterNameRegex).toBe('global-regex');
-    expect(scoped.expirationHours).toBe(36);
-    expect(scoped.filterLastHeardHours).toBe(72);
-    expect(scoped.filterHopsMin).toBe(2);
-    expect(scoped.filterHopsMax).toBe(8);
+    expect(scoped.filterChannels).toEqual([]);
+    expect(scoped.filterNameRegex).toBe('.*');
+    expect(scoped.expirationHours).toBe(24);
+    expect(scoped.filterLastHeardHours).toBe(168);
+    expect(scoped.filterHopsMin).toBe(0);
+    expect(scoped.filterHopsMax).toBe(10);
   });
 
   it('changing source A does not leak into source B', async () => {


### PR DESCRIPTION
## Summary

Removes the silent global fallback in `getSettingForSource(sourceId, key)`. When a sourceId is provided, the read returns ONLY the per-source value (null if absent). `null`/`undefined` sourceId still reads the un-namespaced global key for legitimate global lookups.

## Bugs Fixed

- **#2839** — Multi-source automation spam. Secondary sources read the legacy global automation config (set when the user only had one source) and fired duplicate responses on every received message.
- **#2840** — Auto-traceroute UI shows empty after 3.12 → 4.0 upgrade. Runtime kept ticking off the legacy global, but the UI fetched per-source state which was empty post-upgrade.
- **Notifications need uncheck/recheck after upgrade** (newly reported). Same shape as #2840 — saving the same value writes to the per-source namespace, after which UI and runtime finally agree.

## What Changed

### Helper change
`src/db/repositories/settings.ts` — `getSettingForSource` no longer falls back to global when sourceId is set.

### Migration 050 (idempotent across SQLite/PostgreSQL/MySQL)
On first boot:
1. **Promotes** each `PER_SOURCE_SETTINGS_KEYS` legacy global into `source:{defaultId}:{key}` so single-source pre-4.x users keep their automation/traceroute/scheduler config across upgrade.
2. **Backfills** rows with NULL `sourceId` in `auto_traceroute_nodes` and `auto_time_sync_nodes` onto the default source. The column was added in migration 024 but pre-existing rows kept NULL — that's why the auto-traceroute "Specific Nodes" list looked empty after upgrade.

The non-destructive design keeps the legacy global keys in place; the next per-source save through the UI is what eventually shadows them.

### Single source of truth
`PER_SOURCE_SETTINGS_KEYS` in `src/server/constants/settings.ts` lists all ~80 per-source keys. Migration 050 drives off this list. Add new per-source settings here.

### Test updates
- `src/db/repositories/perSource.test.ts` — flipped the fallback assertion to expect `null` instead of the global value, with a comment pointing at #2839 / #2840.
- `src/services/database.traceroutePerSource.test.ts` — same flip for the traceroute filter case.

## Behavioural impact for users

- **Single-source pre-4.x users**: Migration copies their existing config onto the default source. After upgrade UI and runtime agree. No duplicate firing because there's only one source.
- **Multi-source 4.x users with #2839 active**: Default source keeps its config (via promotion). Secondary sources start clean — automations off until explicitly configured per source. Correct end-state.
- **Fresh installs**: Migration is a no-op (no globals to promote).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — 0 errors (8 warnings consistent with existing migration code style — same `any` typing on pg/mysql client/pool that migration 048 has)
- [x] `npx vitest run` — **4476 passed, 0 failures**, 8 new migration unit tests passing
- [x] Migration 050 unit tests cover: empty/no-globals, promotion, no-overwrite of existing per-source override, idempotent re-run, NULL-sourceId backfill for both `auto_traceroute_nodes` and `auto_time_sync_nodes`, default-source synthesis when sources table is empty
- [x] Manual: deployed locally on the maintainer's existing dev SQLite DB. Migration 050 promoted 10 legacy global settings cleanly. Container healthy.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)