### PR TITLE
fix(notifications): scope channels per-source + drop legacy unique

### DIFF
--- a/src/components/NotificationsTab.tsx
+++ b/src/components/NotificationsTab.tsx
@@ -97,9 +97,13 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
   useEffect(() => {
     checkNotificationStatus();
     loadVapidStatus();
+  }, []);
+
+  // Reload source-scoped data whenever the active source changes
+  useEffect(() => {
     loadChannels();
     loadNodes();
-  }, []);
+  }, [currentSourceId]);
 
   // Fetch available nodes
   const loadNodes = async () => {
@@ -167,7 +171,8 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
 
   const loadChannels = async () => {
     try {
-      const response = await api.get<Channel[]>('/api/channels');
+      const channelsQs = currentSourceId ? `?sourceId=${encodeURIComponent(currentSourceId)}` : '';
+      const response = await api.get<Channel[]>(`/api/channels${channelsQs}`);
       const channelList = Array.isArray(response) ? response : [];
       setChannels(channelList);
 

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 50 migrations registered', () => {
-    expect(registry.count()).toBe(50);
+  it('has all 51 migrations registered', () => {
+    expect(registry.count()).toBe(51);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,14 +12,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is promote_globals_to_default_source', () => {
+  it('last migration is drop_legacy_notif_prefs_userid_unique', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(50);
-    expect(last.name).toContain('promote_globals_to_default_source');
+    expect(last.number).toBe(51);
+    expect(last.name).toContain('drop_legacy_notif_prefs_userid_unique');
   });
 
-  it('migrations are sequentially numbered from 1 to 50', () => {
+  it('migrations are sequentially numbered from 1 to 51', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -62,6 +62,7 @@ import { migration as addSelectedLayerMigration, runMigration047Postgres, runMig
 import { migration as rebuildIgnoredNodesPerSourceMigration, runMigration048Postgres, runMigration048Mysql } from '../server/migrations/048_rebuild_ignored_nodes_per_source.js';
 import { migration as perfCompositeIndexesMigration, runMigration049Postgres, runMigration049Mysql } from '../server/migrations/049_perf_composite_indexes.js';
 import { migration as promoteGlobalsToDefaultSourceMigration, runMigration050Postgres, runMigration050Mysql } from '../server/migrations/050_promote_globals_to_default_source.js';
+import { migration as dropLegacyNotifPrefsUserIdUniqueMigration, runMigration051Postgres, runMigration051Mysql } from '../server/migrations/051_drop_legacy_notif_prefs_userid_unique.js';
 
 // ============================================================================
 // Registry
@@ -779,4 +780,21 @@ registry.register({
   sqlite: (db) => promoteGlobalsToDefaultSourceMigration.up(db),
   postgres: (client) => runMigration050Postgres(client),
   mysql: (pool) => runMigration050Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 051: Drop legacy single-column UNIQUE on
+// user_notification_preferences.userId. Migration 028 only dropped one of the
+// two possible constraint names; PostgreSQL deployments where the constraint
+// was originally auto-named with a `_key` suffix still block per-source
+// notification preference upserts. Defensive across PG/MySQL/SQLite.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 51,
+  name: 'drop_legacy_notif_prefs_userid_unique',
+  settingsKey: 'migration_051_drop_legacy_notif_prefs_userid_unique',
+  sqlite: (db) => dropLegacyNotifPrefsUserIdUniqueMigration.up(db),
+  postgres: (client) => runMigration051Postgres(client),
+  mysql: (pool) => runMigration051Mysql(pool),
 });

--- a/src/server/migrations/051_drop_legacy_notif_prefs_userid_unique.ts
+++ b/src/server/migrations/051_drop_legacy_notif_prefs_userid_unique.ts
@@ -1,0 +1,94 @@
+/**
+ * Migration 051: Drop legacy single-column UNIQUE on
+ * user_notification_preferences.userId.
+ *
+ * Migration 028 made notification preferences per-source by introducing the
+ * composite UNIQUE on ("userId", "sourceId"), and tried to drop the old
+ * single-column UNIQUE constraint added by migration 015. However, it only
+ * targeted the constraint name `user_notification_preferences_userId_unique`
+ * (the name 015 used). On databases that were originally created from a
+ * Drizzle schema that declared `.unique()` at the column level, PostgreSQL
+ * auto-named the constraint `user_notification_preferences_userId_key`, which
+ * survived migration 028 and continues to block per-source upserts with:
+ *
+ *   duplicate key value violates unique constraint
+ *   "user_notification_preferences_userId_key"
+ *
+ * MySQL has the analogous problem: 015 created `idx_user_notification_preferences_userId`,
+ * which 028 never dropped.
+ *
+ * This migration is defensive — it drops every single-column UNIQUE on
+ * userId by both known names, leaving the composite (userId, sourceId)
+ * constraint from 028 intact.
+ */
+import type Database from 'better-sqlite3';
+
+// SQLite migration: 028 already drops idx_user_notification_preferences_user_id.
+// Repeat defensively in case anyone added a different variant.
+export const migration = {
+  up: (db: Database.Database) => {
+    try {
+      db.exec(`DROP INDEX IF EXISTS idx_user_notification_preferences_user_id`);
+    } catch {
+      // Ignore — index may not exist
+    }
+    try {
+      db.exec(`DROP INDEX IF EXISTS idx_user_notification_preferences_userId`);
+    } catch {
+      // Ignore — index may not exist
+    }
+  },
+};
+
+// PostgreSQL migration
+export async function runMigration051Postgres(client: any): Promise<void> {
+  // Drop both known names. Both are no-ops if the constraint doesn't exist.
+  await client.query(`
+    ALTER TABLE user_notification_preferences
+    DROP CONSTRAINT IF EXISTS "user_notification_preferences_userId_unique"
+  `);
+  await client.query(`
+    ALTER TABLE user_notification_preferences
+    DROP CONSTRAINT IF EXISTS "user_notification_preferences_userId_key"
+  `);
+
+  // Belt-and-braces: drop any remaining single-column UNIQUE on userId
+  // that isn't the composite (userId, sourceId) we want to keep.
+  const { rows } = await client.query(`
+    SELECT con.conname AS name
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+    WHERE ns.nspname = 'public'
+      AND rel.relname = 'user_notification_preferences'
+      AND con.contype = 'u'
+      AND array_length(con.conkey, 1) = 1
+      AND EXISTS (
+        SELECT 1 FROM pg_attribute att
+        WHERE att.attrelid = rel.oid
+          AND att.attnum = con.conkey[1]
+          AND att.attname = 'userId'
+      )
+  `);
+  for (const row of rows as Array<{ name: string }>) {
+    await client.query(
+      `ALTER TABLE user_notification_preferences DROP CONSTRAINT IF EXISTS "${row.name}"`
+    );
+  }
+}
+
+// MySQL migration
+export async function runMigration051Mysql(pool: any): Promise<void> {
+  // Drop the legacy single-column unique index from migration 015.
+  const [rows] = await pool.query(
+    `SELECT INDEX_NAME FROM information_schema.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE()
+       AND TABLE_NAME = 'user_notification_preferences'
+       AND INDEX_NAME = 'idx_user_notification_preferences_userId'`
+  );
+  if (Array.isArray(rows) && rows.length > 0) {
+    await pool.query(
+      `ALTER TABLE user_notification_preferences DROP INDEX idx_user_notification_preferences_userId`
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Fixes two production bugs on the **Notifications** tab:

1. **Channel list ignored the active source.** `NotificationsTab.loadChannels()` called `/api/channels` with no `sourceId`, and the init `useEffect` only ran on mount, so switching the source never refreshed channels or nodes. Now passes `?sourceId=` and re-runs `loadChannels` / `loadNodes` whenever `currentSourceId` changes.

2. **Saving preferences on a non-default source failed** with `duplicate key value violates unique constraint "user_notification_preferences_userId_key"` on PostgreSQL. Migration 028 introduced the composite `UNIQUE (userId, sourceId)` and tried to drop the legacy single-column `UNIQUE` from migration 015, but only by the constraint name `_userId_unique`. Databases originally created from a Drizzle schema that used a column-level `.unique()` ended up with the auto-named `_userId_key`, which survived 028 and continues to block per-source upserts. New migration **051** drops both known names, defensively scans `pg_constraint` for any remaining single-column `UNIQUE` on `userId`, and drops the analogous MySQL legacy index.

## Files

- `src/components/NotificationsTab.tsx` — source-scope `loadChannels`, re-run loaders on source change
- `src/server/migrations/051_drop_legacy_notif_prefs_userid_unique.ts` (new)
- `src/db/migrations.ts` — register 051
- `src/db/migrations.test.ts` — count → 51, last name updated

## Test plan

- [x] Migration registry tests pass (9/9, count = 51)
- [x] Built and deployed dev container; confirmed `dist/server/migrations/051_*.js` present and migration ran cleanly at startup
- [x] Notifications tab: switching the source picker updates the channel list to match the selected source
- [x] Saving preferences on a non-default source no longer hits the legacy `_userId_key` constraint
- [ ] CI: full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)