### PR TITLE
chore(release): bump version to 4.0.2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.0.1",
+  "version": "4.0.2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.0.1
-appVersion: "4.0.1"
+version: 4.0.2
+appVersion: "4.0.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Bump version to **4.0.2**. Ships the Notifications-tab fixes from #2843:

- Channel list now scopes to the selected source
- Drops legacy single-column `UNIQUE` on `user_notification_preferences.userId` (constraint name `_userId_key`) that survived migration 028 on PostgreSQL deployments and blocked per-source preference upserts (new migration **051**)

## Files

- `package.json` → 4.0.2
- `package-lock.json` (regenerated via `npm install --package-lock-only --legacy-peer-deps`)
- `desktop/package.json` → 4.0.2
- `desktop/src-tauri/tauri.conf.json` → 4.0.2
- `helm/meshmonitor/Chart.yaml` → version + appVersion 4.0.2

## Test plan

- [x] All five version files updated
- [x] `package-lock.json` regenerated
- [ ] CI green