### PR TITLE
feat(scripts): update PirateWeatherADV to v2 (closes #2728)

### DIFF
--- a/examples/auto-responder-scripts/PirateWeatherADV.py
+++ b/examples/auto-responder-scripts/PirateWeatherADV.py
@@ -1,71 +1,119 @@
 #!/usr/bin/env python3
-# mm_meta:
-#   name: Pirate Weather ADV
-#   emoji: 🌦️
-#   language: Python
 """
-Weather script for mesh network auto-responders using the Pirate Weather API.
+PirateWeatherADV — Weather script for mesh network auto-responders.
+Uses the Pirate Weather API for data and OpenStreetMap Nominatim for geocoding.
 
-Resolution order — the script tries each source in order and uses the first that works:
-  1. CLI argument          — location passed directly to the script (e.g. Timed Events)
-  2. PARAM_location env var — location string set by the auto-responder trigger pipeline
-  3. FROM_LAT / FROM_LON   — GPS coordinates sent by the requesting node
-  4. LOCAL_LAT / LOCAL_LON — GPS coordinates configured on the local node (fallback)
+TWO SEPARATE TRIGGERS:
 
-Note: A leading "weather" keyword is automatically stripped from the location string in
-both CLI arguments and PARAM_location, so both of these work:
-  peterborough,ontario,canada
+  weather / w  — Current conditions only (single message)
+    Output example:
+      Weather for Peterborough, Ontario, Canada: Misty.
+      Currently 40°F / 4°C (feels like 32°F / 0°C).
+      Today: High 47°F / 8°C, Low 38°F / 3°C.
+      Humidity: 96%, Wind: 9 mph.
+
+  forecast / f — 7-day forecast (split into as many messages as needed)
+    Output example (message 1 of 2):
+      7-Day Forecast - Peterborough, Ontario, Canada:
+      Mon: Misty. Hi 40°F/4°C Lo 33°F/1°C 💧85%
+      Tue: Cloudy. Hi 47°F/8°C Lo 38°F/3°C 💧40%
+      Wed: Partly Cloudy. Hi 52°F/11°C Lo 41°F/5°C 💧15%
+    Output example (message 2 of 2):
+      Thu: Clear. Hi 55°F/13°C Lo 43°F/6°C
+      Fri: Rain. Hi 48°F/9°C Lo 39°F/4°C 💧90%
+      Sat: Cloudy. Hi 44°F/7°C Lo 36°F/2°C 💧50%
+      Sun: Clear. Hi 50°F/10°C Lo 38°F/3°C 💧10%
+
+GPS MODE (no location typed):
+  Both triggers fall back to GPS coordinates in this order:
+    1. FROM_LAT / FROM_LON  — GPS sent by the requesting node
+    2. LOCAL_LAT / LOCAL_LON — local node GPS (also accepts MM_LAT / MM_LON)
+  GPS mode output uses emoji format with a reverse-geocoded city name.
+  GPS mode example output:
+    📍 Peterborough, CA
+    🌡️ 40°F / 4°C (feels like 32°F / 0°C)
+    📊 Forecast: Misty
+    ↕️ High: 47°F / 8°C  Low: 38°F / 3°C
+    💧 Humidity: 96%  💨 Wind: 9 mph
+
+INPUT FORMATS (spaces after commas are fine, all produce identical results):
   weather peterborough,ontario,canada
+  weather peterborough, ontario, canada
+  w peterborough, ontario, canada
+  forecast peterborough, ontario, canada
+  f peterborough, ontario, canada
 
-When a location string is used, output matches the original format:
-  Weather for Peterborough, Ontario, Canada: Misty. Currently 40°F (feels like 32°F).
-  Today: High 47°F, Low 38°F. Humidity: 96%, Wind: 9 mph.
-
-When GPS coordinates are used, output uses the emoji format with a reverse-geocoded city:
-  📍 Peterborough, Ontario
-  🌡️ Temperature: 40°F (feels like 32°F)
-  📊 Forecast: Misty
-  ↕️ High: 47°F  Low: 38°F
-  💧 Humidity: 96%  💨 Wind: 9 mph
+MODE DETECTION ORDER (how the script decides weather vs forecast):
+  1. TRIGGER env var  — MeshMonitor sets this to the matched trigger pattern.
+                        Most reliable source; checked first.
+  2. MESSAGE env var  — Full original message typed by the user. Fallback if
+                        TRIGGER alone doesn't identify the mode.
+  3. PARAM_mode       — Explicit override env var ('forecast' or 'weather').
+                        Useful for Timed Events.
+  4. Leading keyword  — Keyword at the start of CLI arg or PARAM_location
+                        (e.g. "forecast peterborough,ontario,canada").
+  5. Default          — 'weather' if none of the above match.
 
 All weather data is sourced exclusively from Pirate Weather (pirateweather.net).
 Location names are resolved via OpenStreetMap Nominatim (free, no API key needed).
 
 Requirements:
 - Python 3.6+
-- PIRATE_WEATHER_API_KEY environment variable (get free key from https://pirateweather.net/)
+- PIRATE_WEATHER_API_KEY environment variable (get free key at https://pirateweather.net/)
 
 Setup:
-1. Get API key from https://pirateweather.net/
+1. Get a free API key from https://pirateweather.net/
 2. Add to docker-compose.yaml environment variables:
    - PIRATE_WEATHER_API_KEY=your_api_key_here
-   - LOCAL_LAT=your_latitude      # fallback GPS for local node
-   - LOCAL_LON=your_longitude
+   - LOCAL_LAT=your_latitude      # optional GPS fallback for local node
+   - LOCAL_LON=your_longitude     # (MM_LAT / MM_LON also accepted as aliases)
 3. Ensure volume mapping in docker-compose.yaml:
    - ./scripts:/data/scripts
 4. Copy PirateWeatherADV.py to scripts/ directory
 5. Make executable: chmod +x scripts/PirateWeatherADV.py
-6. Configure triggers in your auto-responder:
-   - Trigger: weather               (GPS mode — uses node coordinates)
-   - Trigger: weather {location:.+} (location mode — user types a place name)
-   - Response Type: script
-   - Response: /data/scripts/PirateWeatherADV.py
+
+MeshMonitor Auto Responder Configuration:
+  Navigate to Settings → Automation → Auto Responder → Add Trigger.
+  Create TWO trigger entries, each pointing to the same script:
+
+  Trigger 1 — Current conditions (weather / w):
+    Trigger field:  weather, weather {location:.+}, w {location:.+}
+    Response type:  Script
+    Script path:    /data/scripts/PirateWeatherADV.py
+
+  Trigger 2 — 7-day forecast (forecast / f):
+    Trigger field:  forecast, forecast {location:.+}, f {location:.+}
+    Response type:  Script
+    Script path:    /data/scripts/PirateWeatherADV.py
+
+  The comma-separated patterns in each trigger field allow one entry to handle
+  both the bare keyword (GPS mode) and the keyword + location variants.
+  MeshMonitor sets the TRIGGER env var to the matched pattern, which the script
+  uses to reliably determine weather vs forecast mode regardless of whether
+  PARAM_location contains the keyword.
 
 Local testing:
-  GPS mode:
-    TEST_MODE=true FROM_LAT=43.55 FROM_LON=-78.49 PIRATE_WEATHER_API_KEY=your_key python3 PirateWeatherADV.py
-  Location mode:
+  Current conditions by location:
     TEST_MODE=true PARAM_location="peterborough,ontario,canada" PIRATE_WEATHER_API_KEY=your_key python3 PirateWeatherADV.py
-  CLI argument mode (e.g. Timed Events):
+  7-day forecast by location:
+    TEST_MODE=true PARAM_location="forecast peterborough,ontario,canada" PIRATE_WEATHER_API_KEY=your_key python3 PirateWeatherADV.py
+  GPS mode — current conditions:
+    TEST_MODE=true FROM_LAT=43.55 FROM_LON=-78.49 PIRATE_WEATHER_API_KEY=your_key python3 PirateWeatherADV.py
+  GPS mode — forecast (simulate forecast trigger):
+    TEST_MODE=true TRIGGER=forecast FROM_LAT=43.55 FROM_LON=-78.49 PIRATE_WEATHER_API_KEY=your_key python3 PirateWeatherADV.py
+  CLI argument — current conditions (Timed Events):
     TEST_MODE=true PIRATE_WEATHER_API_KEY=your_key python3 PirateWeatherADV.py peterborough,ontario,canada
+  CLI argument — forecast (Timed Events):
+    TEST_MODE=true PIRATE_WEATHER_API_KEY=your_key python3 PirateWeatherADV.py forecast peterborough,ontario,canada
 """
 
 import os
 import sys
 import json
+import time
 import urllib.request
 import urllib.parse
-from typing import Optional, Tuple, Dict, Any
+from typing import Optional, Tuple, Dict, List, Any
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +122,37 @@ from typing import Optional, Tuple, Dict, Any
 
 PIRATE_WEATHER_API_KEY = os.environ.get('PIRATE_WEATHER_API_KEY', '')
 TEST_MODE = os.environ.get('TEST_MODE', 'false').lower() == 'true'
+
+# MeshMonitor enforces a 200-char max per message and a 10-second script timeout.
+# Network timeouts: geocode 3s + API 4s + reverse geocode 3s = 10s worst case.
+MSG_LIMIT = 200
+
+# Day-of-week abbreviations indexed by Python's tm_wday (0=Mon … 6=Sun)
+DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+# Trigger keywords that identify forecast mode
+FORECAST_KEYWORDS = ('forecast', 'f')
+# Trigger keywords that identify weather (current conditions) mode
+WEATHER_KEYWORDS  = ('weather', 'w')
+
+
+# ---------------------------------------------------------------------------
+# Unit conversion
+# ---------------------------------------------------------------------------
+
+def to_c(f: float) -> float:
+    """Convert Fahrenheit to Celsius."""
+    return (f - 32) * 5 / 9
+
+
+def fmt_temp(f: float) -> str:
+    """Format a temperature as XX°F / XX°C."""
+    return f'{f:.0f}°F / {to_c(f):.0f}°C'
+
+
+def fmt_temp_compact(f: float) -> str:
+    """Compact temperature format for forecast lines: XX°F/XX°C."""
+    return f'{f:.0f}°F/{to_c(f):.0f}°C'
 
 
 # ---------------------------------------------------------------------------
@@ -97,13 +176,13 @@ def _parse_coords(lat_str: str, lon_str: str, label: str) -> Optional[Tuple[floa
 def geocode_location(location: str) -> Optional[Tuple[float, float]]:
     """
     Forward-geocode a location string to (lat, lon) using Nominatim.
-    Returns None if the location cannot be found.
+    Returns None if the location cannot be found or the request fails.
     """
     try:
         params = {'q': location, 'format': 'json', 'limit': 1}
         url = 'https://nominatim.openstreetmap.org/search?' + urllib.parse.urlencode(params)
         req = urllib.request.Request(url, headers={'User-Agent': 'PirateWeatherADV/1.0'})
-        with urllib.request.urlopen(req, timeout=10) as resp:
+        with urllib.request.urlopen(req, timeout=3) as resp:
             data = json.loads(resp.read().decode('utf-8'))
         if data:
             return (float(data[0]['lat']), float(data[0]['lon']))
@@ -114,14 +193,14 @@ def geocode_location(location: str) -> Optional[Tuple[float, float]]:
 
 def reverse_geocode_city(lat: float, lon: float) -> str:
     """
-    Reverse-geocode (lat, lon) to a human-readable city name using Nominatim.
-    Falls back to raw coordinates if the lookup fails.
+    Reverse-geocode (lat, lon) to a city name using Nominatim.
+    Returns a raw coordinate string if the lookup fails.
     """
     try:
         params = {'lat': lat, 'lon': lon, 'format': 'json', 'zoom': 10}
         url = 'https://nominatim.openstreetmap.org/reverse?' + urllib.parse.urlencode(params)
         req = urllib.request.Request(url, headers={'User-Agent': 'PirateWeatherADV/1.0'})
-        with urllib.request.urlopen(req, timeout=8) as resp:
+        with urllib.request.urlopen(req, timeout=3) as resp:
             data = json.loads(resp.read().decode('utf-8'))
 
         address = data.get('address') or {}
@@ -132,7 +211,7 @@ def reverse_geocode_city(lat: float, lon: float) -> str:
             or address.get('hamlet')
             or address.get('county')
         )
-        state = address.get('state', '')
+        state        = address.get('state', '')
         country_code = address.get('country_code', '').upper()
 
         if city:
@@ -149,81 +228,152 @@ def reverse_geocode_city(lat: float, lon: float) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Label formatter
+# ---------------------------------------------------------------------------
+
+def _fmt_label(location: str) -> str:
+    """
+    Build a clean display label from a raw location string.
+    Splits on commas, capitalises each part carefully so:
+      - Abbreviations (ON, NY, CA) are preserved in upper case
+      - Apostrophes (St. John's) are not mangled by str.title()
+      - Empty parts from double/trailing commas are skipped
+    """
+    def _fmt_part(part: str) -> str:
+        words = part.strip().split()
+        out = []
+        for w in words:
+            if not w:
+                continue
+            if w.isupper() and len(w) <= 3:
+                out.append(w)
+            else:
+                out.append(w[0].upper() + w[1:])
+        return ' '.join(out)
+
+    parts = [p.strip() for p in location.split(',') if p.strip()]
+    return ', '.join(_fmt_part(p) for p in parts)
+
+
+# ---------------------------------------------------------------------------
 # Input resolution
 # ---------------------------------------------------------------------------
 
-def resolve_input() -> Tuple[Optional[Tuple[float, float]], Optional[str], str]:
+def resolve_input() -> Tuple[Optional[Tuple[float, float]], Optional[str], str, str]:
     """
-    Determine the source of the weather lookup.
+    Determine coordinates, display label, output mode (weather/forecast),
+    and input mode (location/gps).
 
     Returns:
-      (coords, location_label, mode)
+      (coords, label, output_mode, input_mode)
 
-      coords         — (lat, lon) or None if nothing could be resolved
-      location_label — display name for the response (only set in 'location' mode)
-      mode           — 'location' (user typed a place) or 'gps' (node coordinates)
+      coords      — (lat, lon) or None if nothing could be resolved
+      label       — display name string, or None if GPS mode
+      output_mode — 'weather' (current conditions) or 'forecast' (7-day)
+      input_mode  — 'location' or 'gps'
 
-    Resolution order:
-      1. PARAM_location — user-supplied location string, geocoded via Nominatim
-      2. FROM_LAT / FROM_LON — GPS from the requesting node
-      3. LOCAL_LAT / LOCAL_LON — GPS from the local node (fallback)
+    Resolution order for location:
+      1. CLI arguments (e.g. Timed Events)
+      2. PARAM_location env var (trigger pipeline)
+
+    Resolution order for coordinates when no location string given:
+      3. FROM_LAT / FROM_LON  — requesting node GPS
+      4. LOCAL_LAT / LOCAL_LON or MM_LAT / MM_LON — local node GPS
+
+    Output mode is determined by:
+      - The leading keyword in the location string (forecast/f vs weather/w)
+      - PARAM_mode env var as a fallback override ('forecast' or 'f')
+      - Defaults to 'weather' if no keyword is found
     """
-    # 1. Check for CLI argument first (e.g. Timed Events passing "peterborough,ontario,canada")
-    #    then fall back to PARAM_location env var (set by trigger pipeline)
+    # ---------------------------------------------------------------------------
+    # Determine output_mode from multiple sources, in priority order:
+    #
+    # 1. TRIGGER env var — MeshMonitor sets this to the pattern that matched
+    #    e.g. "forecast {location:.+}" or "forecast" — most reliable source.
+    # 2. MESSAGE env var — full original message, e.g. "forecast peterborough..."
+    #    Used as fallback when TRIGGER doesn't contain the keyword.
+    # 3. PARAM_mode env var — explicit override, useful for Timed Events.
+    # 4. Leading keyword in the CLI arg or PARAM_location string.
+    # 5. Default: 'weather'
+    # ---------------------------------------------------------------------------
+
+    output_mode = 'weather'  # default
+
+    # 1. Check TRIGGER env var (most reliable — set by MeshMonitor)
+    trigger = os.environ.get('TRIGGER', '').strip().lower()
+    if any(trigger == kw or trigger.startswith(kw + ' ') or trigger.startswith(kw + ',')
+           for kw in FORECAST_KEYWORDS):
+        output_mode = 'forecast'
+    elif any(trigger == kw or trigger.startswith(kw + ' ') or trigger.startswith(kw + ',')
+             for kw in WEATHER_KEYWORDS):
+        output_mode = 'weather'
+
+    # 2. Check full MESSAGE env var as fallback
+    if output_mode == 'weather':  # only if not already determined
+        message = os.environ.get('MESSAGE', '').strip().lower()
+        if any(message == kw or message.startswith(kw + ' ') or message.startswith(kw + ',')
+               for kw in FORECAST_KEYWORDS):
+            output_mode = 'forecast'
+
+    # 3. PARAM_mode explicit override
+    param_mode = os.environ.get('PARAM_mode', '').strip().lower()
+    if param_mode in ('forecast', 'f'):
+        output_mode = 'forecast'
+    elif param_mode in ('weather', 'w'):
+        output_mode = 'weather'
+
+    # Gather raw location string: CLI args first, then PARAM_location
     location = ''
     if len(sys.argv) > 1:
         location = ' '.join(sys.argv[1:]).strip()
     if not location:
         location = os.environ.get('PARAM_location', '').strip()
 
-    # Strip leading "weather" keyword if someone includes it in either source
-    # e.g. "weather peterborough,ontario,canada" → "peterborough,ontario,canada"
-    if location.lower().startswith('weather'):
-        location = location[len('weather'):].strip()
+    # 4. Detect and strip leading keyword from the location string itself
+    #    (handles CLI args and direct PARAM_location with keyword prefix)
+    loc_lower = location.lower()
+    stripped = False
+    for kw in FORECAST_KEYWORDS:
+        if loc_lower == kw or loc_lower.startswith(kw + ' ') or loc_lower.startswith(kw + ','):
+            output_mode = 'forecast'
+            location = location[len(kw):].strip()
+            stripped = True
+            break
+    if not stripped:
+        for kw in WEATHER_KEYWORDS:
+            if loc_lower == kw or loc_lower.startswith(kw + ' ') or loc_lower.startswith(kw + ','):
+                output_mode = 'weather'
+                location = location[len(kw):].strip()
+                break
 
+    # If we have a location string, geocode it
     if location and location.lower() not in ('help', 'h', '?'):
-        coords = geocode_location(location)
-        # Build a clean display label from the raw input.
-        # Split on commas, then capitalise each part carefully so that short
-        # all-caps tokens (province/state codes like "ON", "NY", "CA") are
-        # preserved, and apostrophes (e.g. "st. john's" → "St. John's")
-        # aren't mangled by str.title().
-        def _fmt(part: str) -> str:
-            words = part.strip().split()
-            out = []
-            for w in words:
-                if not w:
-                    continue
-                if w.isupper() and len(w) <= 3:   # looks like an abbreviation
-                    out.append(w)
-                else:
-                    out.append(w[0].upper() + w[1:])
-            return ' '.join(out)
-
-        label = ', '.join(_fmt(part) for part in location.split(','))
+        # Normalise: strip spaces around commas, filter empty parts
+        parts = [p.strip() for p in location.split(',') if p.strip()]
+        location_normalised = ','.join(parts)
+        coords = geocode_location(location_normalised)
+        label  = _fmt_label(location)
         if coords:
-            return (coords, label, 'location')
+            return (coords, label, output_mode, 'location')
         else:
-            # Geocoding failed — return None so main() can report the error
-            return (None, label, 'location')
+            return (None, label, output_mode, 'location')
 
-    # 2. Requesting node GPS
+    # No location string — fall back to GPS coordinates
     from_lat = os.environ.get('FROM_LAT', '').strip()
     from_lon = os.environ.get('FROM_LON', '').strip()
     if from_lat and from_lon:
         coords = _parse_coords(from_lat, from_lon, 'requesting node')
         if coords:
-            return (coords, None, 'gps')
+            return (coords, None, output_mode, 'gps')
 
-    # 3. Local node GPS fallback
-    local_lat = os.environ.get('LOCAL_LAT', '').strip()
-    local_lon = os.environ.get('LOCAL_LON', '').strip()
+    local_lat = (os.environ.get('LOCAL_LAT', '') or os.environ.get('MM_LAT', '')).strip()
+    local_lon = (os.environ.get('LOCAL_LON', '') or os.environ.get('MM_LON', '')).strip()
     if local_lat and local_lon:
         coords = _parse_coords(local_lat, local_lon, 'local node')
         if coords:
-            return (coords, None, 'gps')
+            return (coords, None, output_mode, 'gps')
 
-    return (None, None, 'gps')
+    return (None, None, output_mode, 'gps')
 
 
 # ---------------------------------------------------------------------------
@@ -232,26 +382,22 @@ def resolve_input() -> Tuple[Optional[Tuple[float, float]], Optional[str], str]:
 
 def get_weather(lat: float, lon: float) -> Dict[str, Any]:
     """
-    Fetch current weather from Pirate Weather for (lat, lon).
+    Fetch current conditions and 7-day daily forecast from Pirate Weather.
 
-    Returns:
-      {'data': {...}} on success, or {'error': '...'} on failure.
+    Returns {'data': {...}} on success or {'error': '...'} on failure.
     """
     if not PIRATE_WEATHER_API_KEY:
-        return {
-            'error': 'Pirate Weather API key not configured. '
-                     'Please set PIRATE_WEATHER_API_KEY environment variable.'
-        }
+        return {'error': 'PIRATE_WEATHER_API_KEY not set. Get a free key at pirateweather.net.'}
 
     try:
         url = f'https://api.pirateweather.net/forecast/{PIRATE_WEATHER_API_KEY}/{lat},{lon}'
         req = urllib.request.Request(url)
-        with urllib.request.urlopen(req, timeout=10) as resp:
+        with urllib.request.urlopen(req, timeout=4) as resp:
             data = json.loads(resp.read().decode('utf-8'))
 
-        current      = data.get('currently') or {}
+        current       = data.get('currently') or {}
         daily_periods = (data.get('daily') or {}).get('data') or []
-        today        = daily_periods[0] if daily_periods else {}
+        today         = daily_periods[0] if daily_periods else {}
 
         temp       = current.get('temperature')
         feels_like = current.get('apparentTemperature')
@@ -264,14 +410,42 @@ def get_weather(lat: float, lon: float) -> Dict[str, Any]:
         if temp is None or feels_like is None:
             return {'error': 'Pirate Weather returned incomplete data (missing temperature).'}
 
+        # Timezone offset in seconds (offset field is a float, e.g. -5.0 or 5.5)
+        tz_offset_sec = int((data.get('offset') or 0) * 3600)
+
+        # Build 7-day forecast list from all available daily periods.
+        # Use 8 entries so we always have a full 7-day lookahead regardless
+        # of what day of the week today is (index 0 = today, so 8 covers today
+        # plus 7 future days, and build_forecast_messages caps output at 7 days).
+        forecast = []
+        for day in daily_periods[:8]:
+            day_time   = day.get('time')
+            day_high   = day.get('temperatureHigh')
+            day_low    = day.get('temperatureLow')
+            day_sum    = day.get('summary') or 'N/A'
+            day_precip = day.get('precipProbability') or 0
+
+            if day_time is None or day_high is None or day_low is None:
+                continue
+
+            forecast.append({
+                'time':        day_time,
+                'summary':     day_sum,
+                'high':        day_high,
+                'low':         day_low,
+                'precip_prob': day_precip,
+            })
+
         return {'data': {
-            'temp':       temp,
-            'feels_like': feels_like,
-            'summary':    summary,
-            'humidity':   humidity,
-            'wind_speed': wind_speed,
-            'high_temp':  high_temp,
-            'low_temp':   low_temp,
+            'temp':          temp,
+            'feels_like':    feels_like,
+            'summary':       summary,
+            'humidity':      humidity,
+            'wind_speed':    wind_speed,
+            'high_temp':     high_temp,
+            'low_temp':      low_temp,
+            'forecast':      forecast,
+            'tz_offset_sec': tz_offset_sec,
         }}
 
     except urllib.error.HTTPError as e:
@@ -281,45 +455,145 @@ def get_weather(lat: float, lon: float) -> Dict[str, Any]:
     except json.JSONDecodeError:
         return {'error': 'Invalid response from Pirate Weather API'}
     except Exception as e:
-        return {'error': f'Unexpected error: {str(e)}'}
+        # Sanitise exception message — strip API key if it appears
+        err_msg = str(e).replace(PIRATE_WEATHER_API_KEY, '***') if PIRATE_WEATHER_API_KEY else str(e)
+        return {'error': f'Unexpected error: {err_msg}'}
 
 
 # ---------------------------------------------------------------------------
 # Response formatters
 # ---------------------------------------------------------------------------
 
-def format_location_response(label: str, d: dict) -> str:
+def format_weather(label: str, d: dict) -> str:
     """
-    Original single-line text format used when the user typed a location name.
+    Format current conditions as a single message string.
+
     Example:
-      Weather for Peterborough, Ontario, Canada: Misty. Currently 40°F (feels like 32°F).
-      Today: High 47°F, Low 38°F. Humidity: 96%, Wind: 9 mph.
+      Weather for Peterborough, Ontario, Canada: Misty.
+      Currently 40°F / 4°C (feels like 32°F / 0°C).
+      Today: High 47°F / 8°C, Low 38°F / 3°C.
+      Humidity: 96%, Wind: 9 mph.
     """
-    response = (
+    msg = (
         f'Weather for {label}: {d["summary"]}. '
-        f'Currently {d["temp"]:.0f}°F (feels like {d["feels_like"]:.0f}°F). '
+        f'Currently {fmt_temp(d["temp"])} (feels like {fmt_temp(d["feels_like"])}). '
     )
     if d['high_temp'] is not None and d['low_temp'] is not None:
-        response += f'Today: High {d["high_temp"]:.0f}°F, Low {d["low_temp"]:.0f}°F. '
-    response += f'Humidity: {d["humidity"]*100:.0f}%, Wind: {d["wind_speed"]:.0f} mph.'
-    return response
+        msg += f'Today: High {fmt_temp(d["high_temp"])}, Low {fmt_temp(d["low_temp"])}. '
+    msg += f'Humidity: {d["humidity"]*100:.0f}%, Wind: {d["wind_speed"]:.0f} mph.'
+    return msg
 
 
-def format_gps_response(lat: float, lon: float, d: dict) -> str:
+def format_weather_gps(lat: float, lon: float, d: dict) -> str:
     """
-    Emoji multi-line format used when coordinates come from the node GPS.
-    City name is reverse-geocoded from the coordinates.
+    Format current conditions in emoji style for GPS mode.
+
+    Example:
+      📍 Peterborough, CA
+      🌡️ 40°F / 4°C (feels like 32°F / 0°C)
+      📊 Forecast: Misty
+      ↕️ High: 47°F / 8°C  Low: 38°F / 3°C
+      💧 Humidity: 96%  💨 Wind: 9 mph
     """
-    city_name = reverse_geocode_city(lat, lon)
+    city = reverse_geocode_city(lat, lon)
     lines = [
-        f'📍 {city_name}',
-        f'🌡️ Temperature: {d["temp"]:.0f}°F (feels like {d["feels_like"]:.0f}°F)',
+        f'📍 {city}',
+        f'🌡️ {fmt_temp(d["temp"])} (feels like {fmt_temp(d["feels_like"])})',
         f'📊 Forecast: {d["summary"]}',
     ]
     if d['high_temp'] is not None and d['low_temp'] is not None:
-        lines.append(f'↕️ High: {d["high_temp"]:.0f}°F  Low: {d["low_temp"]:.0f}°F')
+        lines.append(f'↕️ High: {fmt_temp(d["high_temp"])}  Low: {fmt_temp(d["low_temp"])}')
     lines.append(f'💧 Humidity: {d["humidity"]*100:.0f}%  💨 Wind: {d["wind_speed"]:.0f} mph')
     return '\n'.join(lines)
+
+
+def build_forecast_messages(label: str, d: dict) -> List[str]:
+    """
+    Build the 7-day forecast as a list of messages, each within MSG_LIMIT bytes.
+
+    The first message starts with a header line. Subsequent day lines are packed
+    into messages greedily. If a day line starts a new message, that message
+    begins directly with the day line (no repeated header).
+
+    Returns a list of message strings (may be empty if no forecast data).
+    """
+    forecast = d.get('forecast', [])
+    if not forecast:
+        return []
+
+    tz_offset = d.get('tz_offset_sec', 0)
+    header    = f'7-Day Forecast - {label}:'
+
+    # Build all day lines first — cap at 7 days regardless of how many
+    # entries were returned (we fetch 8 to guarantee 7 future days exist)
+    day_lines = []
+    for day in forecast[:7]:
+        try:
+            local_ts = day['time'] + tz_offset
+            day_name = DAY_NAMES[time.gmtime(local_ts).tm_wday]
+        except Exception:
+            day_name = '???'
+
+        high   = day['high']
+        low    = day['low']
+        summ   = day['summary']
+        precip = day['precip_prob']
+
+        hi_str     = fmt_temp_compact(high)
+        lo_str     = fmt_temp_compact(low)
+        precip_str = f' 💧{precip*100:.0f}%' if precip else ''
+
+        line = f'{day_name}: {summ}. Hi {hi_str} Lo {lo_str}{precip_str}'
+        # Safety: if a single line exceeds MSG_LIMIT (e.g. very long API summary),
+        # truncate it so MeshMonitor never silently drops characters.
+        while len(line.encode('utf-8')) > MSG_LIMIT:
+            line = line[:-1]
+        day_lines.append(line)
+
+    if not day_lines:
+        return []
+
+    # Pack day lines into messages greedily, respecting MSG_LIMIT bytes
+    messages = []
+    current  = header  # first message always starts with the header
+
+    for line in day_lines:
+        candidate = current + '\n' + line if current else line
+
+        if len(candidate.encode('utf-8')) <= MSG_LIMIT:
+            current = candidate
+        else:
+            # Current message is full — save it and start a new one
+            if current:
+                messages.append(current)
+            # New message starts with just the day line (no repeated header)
+            current = line
+
+    # Don't forget the last message
+    if current:
+        messages.append(current)
+
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+def emit(messages: List[str]) -> None:
+    """
+    Print the correct MeshMonitor JSON output format and flush stdout.
+
+    Single message  → {"response": "..."}
+    Multiple messages → {"responses": ["msg1", "msg2", ...]}
+    """
+    if not messages:
+        print(json.dumps({'response': 'No data to display.'}))
+    elif len(messages) == 1:
+        print(json.dumps({'response': messages[0]}))
+    else:
+        print(json.dumps({'responses': messages}))
+    sys.stdout.flush()
 
 
 # ---------------------------------------------------------------------------
@@ -328,52 +602,70 @@ def format_gps_response(lat: float, lon: float, d: dict) -> str:
 
 def main():
     try:
-        coords, label, mode = resolve_input()
+        coords, label, output_mode, input_mode = resolve_input()
 
+        if TEST_MODE:
+            trigger = os.environ.get('TRIGGER', '(none)')
+            print(
+                f'TRIGGER={trigger!r} | output_mode={output_mode} | '
+                f'input_mode={input_mode} | coords={coords} | label={label}',
+                file=sys.stderr
+            )
+
+        # Handle no-location / no-GPS case
         if coords is None:
-            if mode == 'location' and label:
-                response = (
-                    f'Could not find location: "{label}". '
-                    'Try a more specific format, e.g. "peterborough,ontario,canada".'
-                )
+            if input_mode == 'location' and label:
+                emit([f'Could not find location: "{label}". '
+                      'Try e.g. "weather peterborough,ontario,canada".'])
             else:
-                response = (
+                emit([
                     'No location or GPS data available. '
-                    'Options: '
-                    '(1) Send "weather peterborough,ontario,canada" to query by location. '
-                    '(2) Add a CLI argument in your Timed Event: "peterborough,ontario,canada". '
-                    '(3) Ensure your node has GPS (FROM_LAT/FROM_LON). '
-                    '(4) Configure LOCAL_LAT/LOCAL_LON as a GPS fallback.'
-                )
-        else:
-            lat, lon = coords
+                    'Options: (1) Send "weather city,province,country". '
+                    '(2) Use CLI arg in Timed Event: "peterborough,ontario,canada". '
+                    '(3) Ensure node has GPS (FROM_LAT/FROM_LON). '
+                    '(4) Set LOCAL_LAT/LOCAL_LON in docker-compose.'
+                ])
+            return
+
+        lat, lon = coords
+
+        result = get_weather(lat, lon)
+        if 'error' in result:
+            emit([f'Error: {result["error"]}'])
+            return
+
+        d = result['data']
+
+        if output_mode == 'forecast':
+            # Use typed label or reverse-geocoded city name for GPS mode
+            fc_label = label if label else reverse_geocode_city(lat, lon)
+            messages = build_forecast_messages(fc_label, d)
+            if not messages:
+                emit(['No forecast data available.'])
+            else:
+                emit(messages)
+
+                if TEST_MODE:
+                    for i, msg in enumerate(messages, 1):
+                        print(f'\n--- FORECAST MSG {i} ---\n{msg}', file=sys.stderr)
+                    print('--- END TEST ---\n', file=sys.stderr)
+
+        else:  # output_mode == 'weather'
+            if input_mode == 'location':
+                msg = format_weather(label, d)
+            else:
+                msg = format_weather_gps(lat, lon, d)
+
+            emit([msg])
 
             if TEST_MODE:
-                print(f'Mode: {mode} | Coords: {lat}, {lon} | Label: {label}', file=sys.stderr)
-
-            result = get_weather(lat, lon)
-
-            if 'error' in result:
-                response = f'Error: {result["error"]}'
-            elif mode == 'location':
-                response = format_location_response(label, result['data'])
-            else:
-                response = format_gps_response(lat, lon, result['data'])
-
-        print(json.dumps({'response': response}))
-        sys.stdout.flush()
-
-        if TEST_MODE:
-            print(f'\n--- TEST MODE OUTPUT ---\n{response}\n--- END TEST ---\n', file=sys.stderr)
+                print(f'\n--- WEATHER MSG ---\n{msg}\n--- END TEST ---\n', file=sys.stderr)
 
     except Exception as e:
-        error_msg = f'Error: {str(e)}'
-        print(json.dumps({'response': error_msg}))
-        sys.stdout.flush()
-
+        emit([f'Error: {str(e)}'])
         if TEST_MODE:
-            print(f'\n--- TEST MODE ERROR ---\n{error_msg}\n--- END TEST ---\n', file=sys.stderr)
-
+            import traceback
+            traceback.print_exc(file=sys.stderr)
         sys.exit(0)
 
 

--- a/examples/auto-responder-scripts/README.md
+++ b/examples/auto-responder-scripts/README.md
@@ -158,6 +158,32 @@ Complete Pirate Weather API integration with Nominatim geocoding. Supports flexi
    - **Response**: `/data/scripts/PirateWeather.py` (or select from script dropdown if available)
    - Click **"Save Changes"**
 
+### PirateWeatherADV.py (Python)
+Advanced Pirate Weather integration with two separate triggers: current conditions and 7-day forecast. Uses Nominatim for geocoding/reverse-geocoding, accepts city/zip/coordinates, and falls back to GPS from the requesting node (or the local node) when no location is supplied. Outputs temperatures in both Fahrenheit and Celsius. The 7-day forecast splits across multiple 200-char messages automatically.
+
+**Requirements:**
+- `PIRATE_WEATHER_API_KEY` environment variable (get free key from https://pirateweather.net/)
+- `LOCAL_LAT` / `LOCAL_LON` env vars (optional GPS fallback)
+- Python 3.6+
+
+**Triggers:**
+- `weather, w, weather {location:.+}, w {location:.+}` — current conditions (single message)
+- `forecast, f, forecast {location:.+}, f {location:.+}` — 7-day forecast (multi-message)
+
+**Example messages:**
+- `weather` — uses requesting node's GPS (or LOCAL_LAT/LOCAL_LON)
+- `weather Peterborough, Ontario, Canada`
+- `forecast 90210`
+- `f Paris, France`
+
+**Setup:**
+1. Get API key from https://pirateweather.net/
+2. Add `PIRATE_WEATHER_API_KEY=your_key` (and optionally `LOCAL_LAT` / `LOCAL_LON`) to docker-compose.yaml
+3. Copy `PirateWeatherADV.py` to your `./scripts/` directory and `chmod +x` it
+4. Configure two triggers in MeshMonitor UI (Settings → Automation → Auto Responder):
+   - Pattern `weather, w, weather {location:.+}, w {location:.+}` → Script `/data/scripts/PirateWeatherADV.py`
+   - Pattern `forecast, f, forecast {location:.+}, f {location:.+}` → Script `/data/scripts/PirateWeatherADV.py`
+
 ### info.sh (Shell)
 System information script showing uptime.
 


### PR DESCRIPTION
## Summary
- Updates `examples/auto-responder-scripts/PirateWeatherADV.py` to v2 (submitted by @Nullvoid3771 in #2728)
- Adds new `forecast` / `f` trigger for 7-day forecasts; existing `weather` / `w` trigger now returns current conditions only
- Dual Fahrenheit/Celsius temperatures; overflow-safe forecast splits across multiple 200-char messages
- README entry added under "Example Scripts" documenting both triggers, env vars, and setup

## Test plan
- [x] `python3 -m py_compile` on the new script (syntax OK)
- [ ] Manual smoke test: configure both triggers, send `weather` (GPS fallback) and `forecast 90210` from a test node
- [ ] Verify multi-message forecast output is queued and rate-limited correctly

Closes #2728

🤖 Generated with [Claude Code](https://claude.com/claude-code)