### PR TITLE
fix(channels): allow empty channel names; show "Primary" for blank slot 0 (#2855)

### DIFF
--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -319,6 +319,11 @@ export default function ChannelsTab({
     // First check device channels (0-7)
     const channel = channels.find(ch => ch.id === channelNum);
     if (channel) {
+      // Slot 0 with blank name displays as "Primary" — matches unifiedChannelDisplayName
+      // and the Meshtastic client convention of falling back to the modem preset label.
+      if (!channel.name?.trim() && channelNum === 0) {
+        return t('channels.primary');
+      }
       return channel.name;
     }
     // For channels >= CHANNEL_DB_OFFSET, check Channel Database entries

--- a/src/components/configuration/ChannelDatabaseSection.tsx
+++ b/src/components/configuration/ChannelDatabaseSection.tsx
@@ -384,11 +384,6 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
   const handleSaveChannel = async () => {
     if (!editingChannel) return;
 
-    if (!editingChannel.name.trim()) {
-      showToast(t('channel_database.toast_name_required'), 'error');
-      return;
-    }
-
     if (!editingChannel.psk.trim()) {
       showToast(t('channel_database.toast_psk_required'), 'error');
       return;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2770,9 +2770,10 @@ apiRouter.post('/channels/:slotId/import', requirePermission('channel_0', 'write
 
     const { name, psk, role, uplinkEnabled, downlinkEnabled, positionPrecision } = channel;
 
-    // Validate required fields
-    if (!name || typeof name !== 'string') {
-      return res.status(400).json({ error: 'Channel name is required' });
+    // Validate name type/length but allow empty string (parity with PUT /channels/:id;
+    // Meshtastic protocol allows blank slot-0 names — display falls back to "Primary").
+    if (typeof name !== 'string') {
+      return res.status(400).json({ error: 'Channel name must be a string' });
     }
 
     if (name.length > 11) {


### PR DESCRIPTION
## Summary

Fixes #2855. Aligns three sites with Meshtastic protocol behavior, where slot 0 may have an empty name and clients fall back to a default label (modem preset / "Primary").

- **`POST /api/channels/:slotId/import`** — now accepts an empty name string, matching `PUT /api/channels/:id` (which already documents this with the comment "allow empty names for unnamed channels"). Type/length validation is preserved.
- **Channel Database edit modal** (`ChannelDatabaseSection.tsx`) — no longer blocks save on a blank name. The underlying repo upsert already supports blank via `allowBlankName: true`.
- **`ChannelsTab.getChannelName()`** — falls back to `channels.primary` ("Primary") when slot 0 has a blank name, mirroring `unifiedChannelDisplayName` in `unifiedRoutes.ts`.

## Test plan
- [ ] Channel Database edit modal: save with blank name → succeeds (previously toast "Channel name is required")
- [ ] `POST /api/channels/0/import` with `{"channel":{"name":"",...}}` → 200 (previously 400)
- [ ] `POST /api/channels/0/import` with non-string name → still 400
- [ ] `POST /api/channels/0/import` with name >11 chars → still 400
- [ ] PUT slot 0 to `name=""` → messaging tab renders "Primary", not empty label
- [ ] Slot ≥1 with blank name still falls through to default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)