### PR TITLE
fix(db): portable two-step delete for packet log retention (#2846)

### DIFF
--- a/src/db/repositories/misc.packetlog.test.ts
+++ b/src/db/repositories/misc.packetlog.test.ts
@@ -197,6 +197,41 @@ describe('MiscRepository - Packet Log Queries', () => {
       expect(after).toBe(0);
     });
   });
+
+  // Regression: discussion #2846 — MariaDB rejects
+  // `DELETE ... WHERE id IN (SELECT ... LIMIT ?)` with ER_NOT_SUPPORTED_YET.
+  // The implementation must be a portable two-step delete (select ids, then
+  // delete by id list), not a DELETE-with-LIMIT-subquery.
+  describe('enforcePacketLogMaxCount (#2846)', () => {
+    it('deletes the oldest rows down to maxCount', async () => {
+      const before = await repo.getPacketLogCount();
+      expect(before).toBe(3);
+
+      // Seed packet timestamps: pkt 3 is oldest (now - 60000), pkt 1 & 2 are newer.
+      await repo.enforcePacketLogMaxCount(2);
+
+      const after = await repo.getPacketLogCount();
+      expect(after).toBe(2);
+
+      // The oldest packet (packet_id 3) must be the one removed.
+      const remaining = await repo.getPacketLogs({});
+      const remainingIds = remaining.map((p) => p.packet_id).sort();
+      expect(remainingIds).toEqual([1, 2]);
+    });
+
+    it('is a no-op when row count is at or below maxCount', async () => {
+      await repo.enforcePacketLogMaxCount(3);
+      expect(await repo.getPacketLogCount()).toBe(3);
+
+      await repo.enforcePacketLogMaxCount(10);
+      expect(await repo.getPacketLogCount()).toBe(3);
+    });
+
+    it('handles a maxCount of 0 by deleting every row', async () => {
+      await repo.enforcePacketLogMaxCount(0);
+      expect(await repo.getPacketLogCount()).toBe(0);
+    });
+  });
 });
 
 /**

--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -970,18 +970,27 @@ export class MiscRepository extends BaseRepository {
    */
   async enforcePacketLogMaxCount(maxCount: number): Promise<void> {
     try {
+      const { packetLog } = this.tables;
       const countResult = await this.db
         .select({ count: sql<number>`count(*)` })
-        .from(this.tables.packetLog);
+        .from(packetLog);
       const currentCount = Number(countResult[0]?.count ?? 0);
 
       if (currentCount > maxCount) {
         const deleteCount = currentCount - maxCount;
-        // Use raw SQL for the DELETE with subquery — Drizzle doesn't support DELETE ... WHERE id IN (SELECT ...)
-        await this.executeRun(
-          sql`DELETE FROM packet_log WHERE id IN (SELECT id FROM packet_log ORDER BY timestamp ASC LIMIT ${deleteCount})`
-        );
-        logger.debug(`[MiscRepository] Deleted ${deleteCount} old packets to enforce max count of ${maxCount}`);
+        // Two-step delete: MariaDB rejects `DELETE ... WHERE id IN (SELECT ... LIMIT ?)`
+        // (ER_NOT_SUPPORTED_YET). Select oldest IDs first, then delete by ID list.
+        const oldest = await this.db
+          .select({ id: packetLog.id })
+          .from(packetLog)
+          .orderBy(asc(packetLog.timestamp))
+          .limit(deleteCount);
+
+        if (oldest.length > 0) {
+          const ids = oldest.map((row: { id: number }) => row.id);
+          await this.db.delete(packetLog).where(inArray(packetLog.id, ids));
+        }
+        logger.debug(`[MiscRepository] Deleted ${oldest.length} old packets to enforce max count of ${maxCount}`);
       }
     } catch (error) {
       logger.error('[MiscRepository] Failed to enforce packet log max count:', error);


### PR DESCRIPTION
## Summary

- Fixes packet log retention silently failing on MariaDB (discussion #2846).
- `MiscRepository.enforcePacketLogMaxCount` was running `DELETE FROM packet_log WHERE id IN (SELECT id FROM packet_log ORDER BY timestamp ASC LIMIT ?)` — MariaDB rejects this form with `ER_NOT_SUPPORTED_YET` ("LIMIT & IN/ALL/ANY/SOME subquery"). SQLite/PostgreSQL accept it, so the bug only surfaced for a MariaDB user.
- Replaced the raw subquery DELETE with a portable two-step Drizzle query: select the oldest IDs (`ORDER BY timestamp ASC LIMIT N`), then delete by id list via `inArray()`. No raw SQL, identical behavior on all three backends.

## Reported error

```
[ERROR] [MiscRepository] Failed to enforce packet log max count: DrizzleQueryError: Failed query: DELETE FROM packet_log WHERE id IN (SELECT id FROM packet_log ORDER BY timestamp ASC LIMIT ?)
  cause: Error: This version of MariaDB doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery'
```

Reference: https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/selecting-data/subqueries/subquery-limitations

## Test plan

- [x] `npx vitest run src/db/repositories/misc.packetlog.test.ts` — 18 pass (15 prior + 3 new)
- [x] New regression tests under `enforcePacketLogMaxCount (#2846)`:
  - shrinks to `maxCount` and removes the oldest row first
  - no-op when current count is at or below `maxCount`
  - `maxCount = 0` clears the table
- [ ] CI green across the full suite
- [ ] Verified by reporter on MariaDB (no more `ER_NOT_SUPPORTED_YET` in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)