### PR TITLE
fix(map): preserve position override across WebSocket node updates (#2847)

### DIFF
--- a/src/hooks/mergeNodeUpdate.test.ts
+++ b/src/hooks/mergeNodeUpdate.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { mergeNodeUpdate } from './mergeNodeUpdate';
+import type { DeviceInfo } from '../types/device';
+
+const baseNode: DeviceInfo = {
+  nodeNum: 1234,
+  user: { id: '!000004d2', longName: 'Test', shortName: 'T' },
+  position: { latitude: 10, longitude: 20, altitude: 100 },
+};
+
+describe('mergeNodeUpdate', () => {
+  it('rebuilds position from flat lat/lng/alt when override not active', () => {
+    const merged = mergeNodeUpdate(baseNode, {
+      latitude: 30,
+      longitude: 40,
+      altitude: 200,
+    } as any);
+    expect(merged.position).toEqual({ latitude: 30, longitude: 40, altitude: 200 });
+  });
+
+  it('falls back to existing altitude when update has no altitude', () => {
+    const merged = mergeNodeUpdate(baseNode, {
+      latitude: 30,
+      longitude: 40,
+    } as any);
+    expect(merged.position).toEqual({ latitude: 30, longitude: 40, altitude: 100 });
+  });
+
+  it('preserves existing position when update has no lat/lng', () => {
+    const merged = mergeNodeUpdate(baseNode, { snr: 5 } as any);
+    expect(merged.position).toEqual({ latitude: 10, longitude: 20, altitude: 100 });
+  });
+
+  it('does NOT overwrite position when override is active on the merged node (regression: PR #2848 follow-up)', () => {
+    const nodeWithOverride: DeviceInfo = {
+      ...baseNode,
+      positionOverrideEnabled: true,
+      latitudeOverride: 50,
+      longitudeOverride: 60,
+      altitudeOverride: 500,
+      position: { latitude: 50, longitude: 60, altitude: 500 },
+    } as any;
+
+    const merged = mergeNodeUpdate(nodeWithOverride, {
+      latitude: 30,
+      longitude: 40,
+      altitude: 200,
+    } as any);
+
+    // Override coords must remain — incoming device GPS packet must NOT
+    // displace the user-set override on the client side.
+    expect(merged.position).toEqual({ latitude: 50, longitude: 60, altitude: 500 });
+    expect((merged as any).positionOverrideEnabled).toBe(true);
+  });
+
+  it('respects override flag arriving in the update itself', () => {
+    const merged = mergeNodeUpdate(baseNode, {
+      positionOverrideEnabled: true,
+      latitudeOverride: 50,
+      longitudeOverride: 60,
+      latitude: 30,
+      longitude: 40,
+    } as any);
+
+    // Update enables override AND carries device GPS — override must win.
+    expect(merged.position).toEqual({ latitude: 10, longitude: 20, altitude: 100 });
+  });
+
+  it('rebuilds position when override is enabled but coords are missing (incomplete override)', () => {
+    const incomplete: DeviceInfo = {
+      ...baseNode,
+      positionOverrideEnabled: true,
+      latitudeOverride: null,
+      longitudeOverride: null,
+    } as any;
+
+    const merged = mergeNodeUpdate(incomplete, {
+      latitude: 30,
+      longitude: 40,
+    } as any);
+
+    expect(merged.position).toEqual({ latitude: 30, longitude: 40, altitude: 100 });
+  });
+
+  it('merges non-position fields normally', () => {
+    const merged = mergeNodeUpdate(baseNode, { snr: 7.5, rssi: -80 } as any);
+    expect(merged.snr).toBe(7.5);
+    expect(merged.rssi).toBe(-80);
+    expect(merged.position).toEqual(baseNode.position);
+  });
+});

--- a/src/hooks/mergeNodeUpdate.ts
+++ b/src/hooks/mergeNodeUpdate.ts
@@ -1,0 +1,37 @@
+import type { DeviceInfo } from '../types/device';
+
+/**
+ * Merge a partial node update (typically from a WebSocket `node:updated` event)
+ * into the existing client-side node, rebuilding the nested `position` object
+ * from flat lat/lng/alt fields when present.
+ *
+ * Skips position rebuild when the merged node has an active user-set override
+ * (`positionOverrideEnabled === true` with non-null override coords) — incoming
+ * device GPS packets must not displace the override on the client (issue #2847).
+ */
+export function mergeNodeUpdate(
+  node: DeviceInfo,
+  nodeUpdate: Partial<DeviceInfo>,
+): DeviceInfo {
+  const merged = { ...node, ...nodeUpdate };
+
+  const hasOverride =
+    (merged as any).positionOverrideEnabled === true &&
+    (merged as any).latitudeOverride != null &&
+    (merged as any).longitudeOverride != null;
+  if (hasOverride) {
+    return merged;
+  }
+
+  const lat = (nodeUpdate as any).latitude;
+  const lng = (nodeUpdate as any).longitude;
+  if (lat != null && lng != null) {
+    merged.position = {
+      latitude: lat,
+      longitude: lng,
+      altitude: (nodeUpdate as any).altitude ?? node.position?.altitude,
+    };
+  }
+
+  return merged;
+}

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -9,6 +9,7 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { io, Socket } from 'socket.io-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { sourcePollQueryKey, type PollData, type RawMessage } from './usePoll';
+import { mergeNodeUpdate } from './mergeNodeUpdate';
 import type { DeviceInfo, Channel } from '../types/device';
 import { appBasename } from '../init';
 import { useSource } from '../contexts/SourceContext';
@@ -91,23 +92,9 @@ export function useWebSocket(enabled: boolean = true): WebSocketState {
     queryClient.setQueryData<PollData>(key, (old) => {
       if (!old?.nodes) return old;
 
-      const updatedNodes = old.nodes.map((node) => {
-        if (node.nodeNum === nodeNum) {
-          const merged = { ...node, ...nodeUpdate };
-          // Rebuild nested position object from flat DB fields sent via WebSocket
-          const lat = (nodeUpdate as any).latitude;
-          const lng = (nodeUpdate as any).longitude;
-          if (lat != null && lng != null) {
-            merged.position = {
-              latitude: lat,
-              longitude: lng,
-              altitude: (nodeUpdate as any).altitude ?? node.position?.altitude,
-            };
-          }
-          return merged;
-        }
-        return node;
-      });
+      const updatedNodes = old.nodes.map((node) =>
+        node.nodeNum === nodeNum ? mergeNodeUpdate(node, nodeUpdate) : node
+      );
 
       return { ...old, nodes: updatedNodes };
     });

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -4870,8 +4870,20 @@ class MeshtasticManager implements ISourceManager {
           // Save position to nodes table (current position)
           await databaseService.nodes.upsertNode(nodeData, this.sourceId);
 
-          // Emit node update event to notify frontend via WebSocket
-          dataEventEmitter.emitNodeUpdate(fromNum, nodeData, this.sourceId);
+          // Emit node update event to notify frontend via WebSocket. When a
+          // user-set override is active for this node, strip the GPS coords
+          // from the payload so clients (which rebuild node.position from these
+          // fields) don't overwrite the override on the map (issue #2847).
+          const hasPositionOverride = existingNode?.positionOverrideEnabled === true
+            && existingNode?.latitudeOverride != null
+            && existingNode?.longitudeOverride != null;
+          if (hasPositionOverride) {
+            const { latitude: _lat, longitude: _lng, altitude: _alt, ...emitData } = nodeData;
+            void _lat; void _lng; void _alt;
+            dataEventEmitter.emitNodeUpdate(fromNum, emitData, this.sourceId);
+          } else {
+            dataEventEmitter.emitNodeUpdate(fromNum, nodeData, this.sourceId);
+          }
 
           // Update mobility detection for this node (fire and forget)
           databaseService.updateNodeMobilityAsync(nodeId).catch(err =>


### PR DESCRIPTION
## Summary

Follow-up to PR #2848. Two paths still reintroduced device GPS over a user-set override after that fix landed, matching the regression report from @drveni:

> *"I manually set the location on the map and hit Save. The node stays there for a moment, but as soon as the next telemetry packet (Position/Status) arrives from the node, it jumps back to the original hardware-defined coordinates."*

### Root cause

PR #2848 covered backend read surfaces (`/api/nodes`, `/api/topology`, embeds, etc.) via `getEffectiveDbNodePosition`, but **the WebSocket merge path was untouched**:

1. **Server** (`meshtasticManager` Position handler) emitted the raw GPS payload in `node:updated` regardless of override state.
2. **Client** (`useWebSocket.updateNodeInCache`) unconditionally rebuilt the nested `position` object from flat `latitude`/`longitude`/`altitude` in that payload, wiping the override on the map.

End result: `/api/nodes` correctly returned the override on poll, but the next Position packet came in via WebSocket and overwrote it on the client cache before the user noticed.

### Fix

- **Extract** the WebSocket merge into a pure helper `mergeNodeUpdate` that skips the `position` rebuild when the merged node has `positionOverrideEnabled === true` with non-null override coords.
- **Server-side guard** (defense in depth): in the inbound Position packet handler, strip `latitude`/`longitude`/`altitude` from the `node:updated` emit payload when the existing node has an active override. Other consumers of the WebSocket event (third-party integrations, future clients) get a clean contract.
- **7 regression tests** covering: override active, override-active update, incomplete override, update-carries-override, non-position field merge, altitude fallback.

### Files

- `src/hooks/mergeNodeUpdate.ts` — new pure helper
- `src/hooks/mergeNodeUpdate.test.ts` — 7 regression tests
- `src/hooks/useWebSocket.ts` — uses helper, removes inline merge logic
- `src/server/meshtasticManager.ts` — guards emit when override active

## Test plan

- [x] Unit tests added (`mergeNodeUpdate.test.ts`, 7 cases)
- [x] Full suite passes locally — 4576 passed / 0 failed
- [ ] Manual verification with an active node: set override, observe Position packet arrival, confirm map stays on override coords
- [ ] @drveni to confirm fix on his Postgres-16 / IP-node setup

Closes the regression reported on PR #2848.

🤖 Generated with [Claude Code](https://claude.com/claude-code)