### PR TITLE
docs(security): kernel CVE policy + Helm seccomp default

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -116,6 +116,42 @@ The following are generally out of scope:
 - Issues requiring physical access to the server
 - Vulnerabilities in upstream dependencies (report those to the respective projects, but do let us know so we can update)
 
+## Operating System and Kernel CVEs
+
+MeshMonitor is a userspace Node.js application and does not patch host kernel
+vulnerabilities. Keeping the host kernel current is the operator's
+responsibility.
+
+For example, [CVE-2026-31431 ("Copy Fail")](https://nvd.nist.gov/vuln/detail/CVE-2026-31431)
+is a Linux kernel local privilege-escalation in the `authencesn` AEAD template
+that affects every Linux distribution shipping kernels ≥ 4.13. MeshMonitor's
+codebase does not invoke the kernel crypto API (`AF_ALG`/`algif`); the
+application itself is not directly susceptible. However, an unpatched host
+kernel can still be exploited by any local code execution — including any
+shell access that a future application-level vulnerability might grant inside
+the container. Patch host kernels promptly and track your distribution's
+advisories ([Debian](https://security-tracker.debian.org/), [SUSE](https://www.suse.com/security/),
+[Red Hat](https://access.redhat.com/security/security-updates/), [Ubuntu](https://ubuntu.com/security/cves)).
+
+### Container hardening recommendations
+
+For deployments on shared or multi-tenant hosts, apply these container-runtime
+defenses (the project's Helm chart and Dockerfile already enable most of them):
+
+- **Run with the runtime's default seccomp profile.** Do not pass
+  `--security-opt seccomp=unconfined` to `docker run` or set
+  `securityContext.seccompProfile.type: Unconfined` in Kubernetes. The Helm
+  chart now sets `seccompProfile.type: RuntimeDefault` by default
+  (`helm/meshmonitor/values.yaml`).
+- **Run as non-root.** The chart sets `runAsNonRoot: true` and `runAsUser: 1000`.
+- **Drop all Linux capabilities.** The chart sets `capabilities.drop: [ALL]`.
+- **Disallow privilege escalation.** The chart sets
+  `allowPrivilegeEscalation: false`.
+
+Operators using a custom seccomp profile should ensure it does not grant
+syscalls beyond the runtime default — in particular, the `socket(AF_ALG, ...)`
+syscall path used by CVE-2026-31431 is blocked under most strict profiles.
+
 ## Supported Versions
 
 Security updates are applied to the latest release only. We recommend always running the most recent version.

--- a/helm/meshmonitor/values.yaml
+++ b/helm/meshmonitor/values.yaml
@@ -121,3 +121,5 @@ securityContext:
   capabilities:
     drop:
       - ALL
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
## Summary

Response to CVE-2026-31431 ("Copy Fail" Linux kernel LPE, disclosed 2026-04-29).

**TL;DR:** MeshMonitor is *not* directly susceptible — the CVE is a kernel-level privilege escalation that requires local code execution; our userspace Node.js application doesn't invoke the kernel crypto API and the CVE doesn't change our network attack surface. But this PR ships two operator-facing improvements:

1. **`SECURITY.md` — new "Operating System and Kernel CVEs" section** that documents this stance, calls out CVE-2026-31431 by name, and lists the container-runtime hardening recommendations (most of which our Helm chart already applies).

2. **`helm/meshmonitor/values.yaml` — set `seccompProfile.type: RuntimeDefault`** on the container `securityContext`, alongside the existing `runAsNonRoot`, `allowPrivilegeEscalation: false`, and `capabilities.drop: [ALL]` baseline. Defense in depth: if some future application-level vuln gives an attacker shell access inside the container on an unpatched host, the seccomp default makes the AF_ALG syscall path harder to reach.

### Why `RuntimeDefault` and not a custom profile

`RuntimeDefault` is the K8s-recommended baseline that doesn't break legitimate functionality. A custom profile that explicitly denies `socket(AF_ALG, ...)` would more directly mitigate this specific CVE but ships ongoing maintenance cost as Node.js / native deps evolve. We can revisit if there's demand.

### Backwards compatibility

The Helm change is additive. Existing deployments without `seccompProfile` set continue to use the K8s default (`Unconfined`) — matching today's behavior. Operators upgrading get the hardened default automatically.

## Test plan

- [x] `helm lint helm/meshmonitor` — passes
- [x] `helm template` renders `seccompProfile.type: RuntimeDefault` at the container level
- [x] No code under `src/` changed → existing vitest suite (4576 passing as of PR #2858) is unaffected
- [ ] Visual review of SECURITY.md formatting in the GitHub render

🤖 Generated with [Claude Code](https://claude.com/claude-code)