### PR TITLE
fix(traceroute): stop labeling RF hops as MQTT/IP (#2859)

### DIFF
--- a/src/components/TracerouteWidget.tsx
+++ b/src/components/TracerouteWidget.tsx
@@ -14,7 +14,7 @@ import L from 'leaflet';
 import { useSettings } from '../contexts/SettingsContext';
 import { getTilesetById } from '../config/tilesets';
 import { useTraceroutes } from '../hooks/useTraceroutes';
-import { generateCurvedPath, getLineWeight, generateCurvedArrowMarkers, isMqttSnr } from '../utils/mapHelpers';
+import { generateCurvedPath, getLineWeight, generateCurvedArrowMarkers, isUnknownSnr } from '../utils/mapHelpers';
 import 'leaflet/dist/leaflet.css';
 
 // Component to fit map bounds
@@ -382,7 +382,7 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
                       📍
                     </span>
                   )}
-                  {hop.snr !== undefined && <span className="traceroute-snr">{isMqttSnr(hop.snr) ? 'IP' : `${hop.snr.toFixed(1)} dB`}</span>}
+                  {hop.snr !== undefined && <span className="traceroute-snr" title={isUnknownSnr(hop.snr) ? 'Unknown SNR (MQTT-bridged hop, decrypt failure, or old firmware)' : undefined}>{isUnknownSnr(hop.snr) ? '?' : `${hop.snr.toFixed(1)} dB`}</span>}
                 </span>
                 {idx < fullPath.length - 1 && <span className="traceroute-arrow">→</span>}
               </React.Fragment>

--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -14,7 +14,7 @@ import React, { useMemo, useState } from 'react';
 import { Popup, Polyline } from 'react-leaflet';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { calculateDistance, formatDistance } from '../utils/distance';
-import { generateCurvedArrowMarkers, generateCurvedPath, getLineWeight, getSegmentSnrColor, getSegmentSnrOpacity, getTemporalOpacityMultiplier, isMqttSnr } from '../utils/mapHelpers';
+import { generateCurvedArrowMarkers, generateCurvedPath, getLineWeight, getSegmentSnrColor, getSegmentSnrOpacity, getTemporalOpacityMultiplier, isUnknownSnr } from '../utils/mapHelpers';
 import { logger } from '../utils/logger';
 import type { DistanceUnit } from '../contexts/SettingsContext';
 
@@ -389,7 +389,7 @@ export function useTraceroutePaths({
               segmentSNRs.set(segmentKey, []);
             }
             segmentSNRs.get(segmentKey)!.push({ snr: snrValue, timestamp });
-            if (isMqttSnr(snrValue)) {
+            if (isUnknownSnr(snrValue)) {
               segmentHasMqtt.set(segmentKey, true);
             }
           }
@@ -436,7 +436,7 @@ export function useTraceroutePaths({
               segmentSNRs.set(segmentKey, []);
             }
             segmentSNRs.get(segmentKey)!.push({ snr: snrValue, timestamp });
-            if (isMqttSnr(snrValue)) {
+            if (isUnknownSnr(snrValue)) {
               segmentHasMqtt.set(segmentKey, true);
             }
           }
@@ -474,7 +474,7 @@ export function useTraceroutePaths({
         const segKey = segment.nodeNums.slice().sort().join('-');
         const snrData = segmentSNRs.get(segKey);
         if (!snrData || snrData.length === 0) return false; // Hide unknown segments at low zoom
-        const rfSnrs = snrData.filter(d => !isMqttSnr(d.snr)).map(d => d.snr);
+        const rfSnrs = snrData.filter(d => !isUnknownSnr(d.snr)).map(d => d.snr);
         if (rfSnrs.length === 0) return false; // Hide pure MQTT at low zoom
         const avgSnr = rfSnrs.reduce((sum, val) => sum + val, 0) / rfSnrs.length;
         return avgSnr >= -10; // Only good + medium quality links
@@ -804,7 +804,7 @@ export function useTraceroutePaths({
              );
              
              const weight = getLineWeight(forwardSegmentSnrs[i]);
-             const isMqtt = isMqttSnr(forwardSegmentSnrs[i]);
+             const isMqtt = isUnknownSnr(forwardSegmentSnrs[i]);
 
              allElements.push(
                <Polyline
@@ -909,7 +909,7 @@ export function useTraceroutePaths({
              );
              
              const weight = getLineWeight(backSegmentSnrs[i]);
-             const isMqtt = isMqttSnr(backSegmentSnrs[i]);
+             const isMqtt = isUnknownSnr(backSegmentSnrs[i]);
 
              allElements.push(
                <Polyline

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5669,7 +5669,7 @@ class MeshtasticManager implements ISourceManager {
           const node = await databaseService.nodes.getNode(nodeNum, tracerouteScopeSourceId);
           const nodeName = nodeNum === BROADCAST_ADDR ? '(unknown)' : (node?.longName || nodeId);
           const rawSnr = snrTowards[index];
-          const snr = rawSnr === undefined ? 'N/A' : rawSnr === -128 ? 'MQTT' : `${(rawSnr / 4).toFixed(1)}dB`;
+          const snr = rawSnr === undefined ? 'N/A' : rawSnr === -128 ? '?' : `${(rawSnr / 4).toFixed(1)}dB`;
           const dist = await calcDistance(fullPath[index], nodeNum);
           if (dist) {
             routeText += `  ${index + 2}. ${nodeName} (${nodeId}) - SNR: ${snr}, Distance: ${dist}\n`;
@@ -5745,7 +5745,7 @@ class MeshtasticManager implements ISourceManager {
           const node = await databaseService.nodes.getNode(nodeNum, tracerouteScopeSourceId);
           const nodeName = nodeNum === BROADCAST_ADDR ? '(unknown)' : (node?.longName || nodeId);
           const rawSnr = snrBack[index];
-          const snr = rawSnr === undefined ? 'N/A' : rawSnr === -128 ? 'MQTT' : `${(rawSnr / 4).toFixed(1)}dB`;
+          const snr = rawSnr === undefined ? 'N/A' : rawSnr === -128 ? '?' : `${(rawSnr / 4).toFixed(1)}dB`;
           const dist = await calcDistanceReturn(fullReturnPath[index], nodeNum);
           if (dist) {
             routeText += `  ${index + 2}. ${nodeName} (${nodeId}) - SNR: ${snr}, Distance: ${dist}\n`;

--- a/src/utils/mapHelpers.test.tsx
+++ b/src/utils/mapHelpers.test.tsx
@@ -5,7 +5,18 @@ import { describe, it, expect } from 'vitest';
 import { getRoleName } from './nodeHelpers';
 import { ROLE_NAMES } from '../constants/index.js';
 import { convertSpeed } from './speedConversion';
-import { isUnknownSnr, UNKNOWN_SNR_SENTINEL } from './mapHelpers';
+import {
+  isUnknownSnr,
+  UNKNOWN_SNR_SENTINEL,
+  interpolateColor,
+  getPositionHistoryColor,
+  getSegmentSnrColor,
+  getSegmentSnrOpacity,
+  getLineWeight,
+  getTemporalOpacityMultiplier,
+  generateCurvedPath,
+  generateHeadingAwarePath,
+} from './mapHelpers';
 
 describe('mapHelpers', () => {
   describe('isUnknownSnr (issue #2859)', () => {
@@ -29,6 +40,217 @@ describe('mapHelpers', () => {
 
     it('returns false for undefined', () => {
       expect(isUnknownSnr(undefined)).toBe(false);
+    });
+  });
+
+  describe('interpolateColor', () => {
+    const black = { r: 0, g: 0, b: 0 };
+    const white = { r: 255, g: 255, b: 255 };
+    const red = { r: 255, g: 0, b: 0 };
+
+    it('returns colorA at ratio 0', () => {
+      expect(interpolateColor(black, white, 0)).toBe('#000000');
+    });
+
+    it('returns colorB at ratio 1', () => {
+      expect(interpolateColor(black, white, 1)).toBe('#ffffff');
+    });
+
+    it('interpolates the midpoint', () => {
+      expect(interpolateColor(black, white, 0.5)).toBe('#808080');
+    });
+
+    it('produces zero-padded hex for low channel values', () => {
+      const result = interpolateColor(black, red, 0.05);
+      expect(result).toMatch(/^#[0-9a-f]{6}$/);
+    });
+  });
+
+  describe('getPositionHistoryColor', () => {
+    it('returns the new color for the only segment when total is 1', () => {
+      const result = getPositionHistoryColor(0, 1);
+      expect(result).toMatch(/^#[0-9a-f]{6}$/);
+    });
+
+    it('returns oldest color for index 0 of multi-segment path', () => {
+      const result = getPositionHistoryColor(0, 5);
+      // Default oldest is cyan-blue (0, 191, 255)
+      expect(result.toLowerCase()).toBe('#00bfff');
+    });
+
+    it('returns newest color for last index', () => {
+      const result = getPositionHistoryColor(4, 5);
+      // Default newest is orange-red (255, 69, 0)
+      expect(result.toLowerCase()).toBe('#ff4500');
+    });
+
+    it('honors override colorOld and colorNew', () => {
+      const oldC = { r: 0, g: 0, b: 0 };
+      const newC = { r: 255, g: 255, b: 255 };
+      expect(getPositionHistoryColor(0, 3, oldC, newC).toLowerCase()).toBe('#000000');
+      expect(getPositionHistoryColor(2, 3, oldC, newC).toLowerCase()).toBe('#ffffff');
+    });
+  });
+
+  describe('getSegmentSnrColor', () => {
+    const colors = { good: 'green', medium: 'yellow', poor: 'red' };
+
+    it('returns default when no SNR data', () => {
+      expect(getSegmentSnrColor(undefined, colors, 'gray')).toBe('gray');
+      expect(getSegmentSnrColor([], colors, 'gray')).toBe('gray');
+    });
+
+    it('ignores unknown-SNR values when computing average', () => {
+      // All entries are unknown-sentinel; should fall back to default
+      expect(
+        getSegmentSnrColor([{ snr: UNKNOWN_SNR_SENTINEL }], colors, 'gray')
+      ).toBe('gray');
+    });
+
+    it('returns good color for positive average SNR', () => {
+      expect(getSegmentSnrColor([{ snr: 5 }, { snr: 3 }], colors, 'gray')).toBe('green');
+    });
+
+    it('returns medium color for slightly negative SNR', () => {
+      expect(getSegmentSnrColor([{ snr: -5 }], colors, 'gray')).toBe('yellow');
+    });
+
+    it('returns poor color for very negative SNR', () => {
+      expect(getSegmentSnrColor([{ snr: -15 }, { snr: -18 }], colors, 'gray')).toBe('red');
+    });
+  });
+
+  describe('getSegmentSnrOpacity', () => {
+    it('returns 0.5 for explicit isMqtt=true', () => {
+      expect(getSegmentSnrOpacity(undefined, true)).toBe(0.5);
+    });
+
+    it('returns 0.5 for missing SNR data', () => {
+      expect(getSegmentSnrOpacity(undefined, false)).toBe(0.5);
+      expect(getSegmentSnrOpacity([], false)).toBe(0.5);
+    });
+
+    it('returns 0.5 when only unknown-SNR sentinels present', () => {
+      expect(getSegmentSnrOpacity([{ snr: UNKNOWN_SNR_SENTINEL }], false)).toBe(0.5);
+    });
+
+    it('scales opacity within [0.4, 0.85] for valid SNR', () => {
+      const opLow = getSegmentSnrOpacity([{ snr: -20 }], false);
+      const opHigh = getSegmentSnrOpacity([{ snr: 15 }], false);
+      expect(opLow).toBeCloseTo(0.4, 5);
+      expect(opHigh).toBeCloseTo(0.85, 5);
+    });
+
+    it('clamps very-out-of-range SNR values', () => {
+      const opVeryLow = getSegmentSnrOpacity([{ snr: -100 }], false);
+      const opVeryHigh = getSegmentSnrOpacity([{ snr: 100 }], false);
+      expect(opVeryLow).toBeCloseTo(0.4, 5);
+      expect(opVeryHigh).toBeCloseTo(0.85, 5);
+    });
+  });
+
+  describe('getLineWeight', () => {
+    it('returns default weight when SNR is undefined', () => {
+      expect(getLineWeight(undefined)).toBe(3);
+    });
+
+    it('maps -20 dB to weight 2', () => {
+      expect(getLineWeight(-20)).toBeCloseTo(2, 5);
+    });
+
+    it('maps +10 dB to weight 6', () => {
+      expect(getLineWeight(10)).toBeCloseTo(6, 5);
+    });
+
+    it('clamps SNR below -20 to weight 2', () => {
+      expect(getLineWeight(-100)).toBeCloseTo(2, 5);
+    });
+
+    it('clamps SNR above +10 to weight 6', () => {
+      expect(getLineWeight(50)).toBeCloseTo(6, 5);
+    });
+  });
+
+  describe('getTemporalOpacityMultiplier', () => {
+    it('returns 0.5 for undefined timestamp', () => {
+      expect(getTemporalOpacityMultiplier(undefined)).toBe(0.5);
+    });
+
+    it('returns 1.0 for fresh (<1h old) timestamps', () => {
+      const now = Date.now();
+      expect(getTemporalOpacityMultiplier(now)).toBe(1.0);
+      expect(getTemporalOpacityMultiplier(now - 30 * 60 * 1000)).toBe(1.0);
+    });
+
+    it('returns 0.2 for very old (>24h) timestamps', () => {
+      const now = Date.now();
+      expect(getTemporalOpacityMultiplier(now - 48 * 60 * 60 * 1000)).toBe(0.2);
+    });
+
+    it('decays smoothly between 1h and 24h', () => {
+      const now = Date.now();
+      const at12h = getTemporalOpacityMultiplier(now - 12 * 60 * 60 * 1000);
+      expect(at12h).toBeGreaterThan(0.2);
+      expect(at12h).toBeLessThan(1.0);
+    });
+  });
+
+  describe('generateCurvedPath', () => {
+    it('returns [start, end] when start equals end', () => {
+      const result = generateCurvedPath([10, 20], [10, 20]);
+      expect(result).toEqual([[10, 20], [10, 20]]);
+    });
+
+    it('produces (segments + 1) points', () => {
+      const result = generateCurvedPath([0, 0], [10, 10], 0.15, 8);
+      expect(result.length).toBe(9);
+    });
+
+    it('includes start and end as first and last points', () => {
+      const result = generateCurvedPath([0, 0], [10, 10], 0.15, 4);
+      expect(result[0]).toEqual([0, 0]);
+      expect(result[result.length - 1][0]).toBeCloseTo(10);
+      expect(result[result.length - 1][1]).toBeCloseTo(10);
+    });
+
+    it('exercises the normalizeDirection branch without throwing', () => {
+      // Forward and back paths use the canonical-direction curvature flip,
+      // ensuring forward A→B and back B→A curve on opposite sides
+      const fwd = generateCurvedPath([0, 0], [10, 10], 0.15, 4, true);
+      const back = generateCurvedPath([10, 10], [0, 0], 0.15, 4, true);
+      expect(fwd.length).toBe(5);
+      expect(back.length).toBe(5);
+    });
+  });
+
+  describe('generateHeadingAwarePath', () => {
+    it('returns [start, end] straight line when heading is undefined', () => {
+      const result = generateHeadingAwarePath([10, 20], [11, 21]);
+      expect(result).toEqual([[10, 20], [11, 21]]);
+    });
+
+    it('returns [start, end] when start equals end', () => {
+      const result = generateHeadingAwarePath([10, 20], [10, 20], 90);
+      expect(result).toEqual([[10, 20], [10, 20]]);
+    });
+
+    it('handles millidegree heading values', () => {
+      // heading > 360 should be interpreted as millidegrees
+      const result = generateHeadingAwarePath([0, 0], [1, 1], 90000, 5);
+      expect(result.length).toBe(11);
+      expect(result[0]).toEqual([0, 0]);
+    });
+
+    it('produces (segments + 1) points with valid heading', () => {
+      const result = generateHeadingAwarePath([0, 0], [5, 5], 45, 10, 6);
+      expect(result.length).toBe(7);
+    });
+
+    it('respects speed parameter for control point distance', () => {
+      const slow = generateHeadingAwarePath([0, 0], [5, 5], 45, 1, 4);
+      const fast = generateHeadingAwarePath([0, 0], [5, 5], 45, 30, 4);
+      // Fast and slow should produce different intermediate curves
+      expect(slow[2][0]).not.toEqual(fast[2][0]);
     });
   });
 

--- a/src/utils/mapHelpers.test.tsx
+++ b/src/utils/mapHelpers.test.tsx
@@ -5,8 +5,33 @@ import { describe, it, expect } from 'vitest';
 import { getRoleName } from './nodeHelpers';
 import { ROLE_NAMES } from '../constants/index.js';
 import { convertSpeed } from './speedConversion';
+import { isUnknownSnr, UNKNOWN_SNR_SENTINEL } from './mapHelpers';
 
 describe('mapHelpers', () => {
+  describe('isUnknownSnr (issue #2859)', () => {
+    it('returns true for the firmware INT8_MIN sentinel (-32 after /4 scaling)', () => {
+      expect(isUnknownSnr(UNKNOWN_SNR_SENTINEL)).toBe(true);
+      expect(isUnknownSnr(-32)).toBe(true);
+    });
+
+    it('returns false for SNR=0 (protobuf default — was a false positive in 4.1.0)', () => {
+      // Regression: PR #2302 treated 0 as MQTT, but 0 is just the protobuf default
+      // and appears for any unpopulated SNR slot, not only MQTT-bridged hops.
+      expect(isUnknownSnr(0)).toBe(false);
+    });
+
+    it('returns false for typical RF SNR values', () => {
+      expect(isUnknownSnr(5)).toBe(false);
+      expect(isUnknownSnr(-5)).toBe(false);
+      expect(isUnknownSnr(-15)).toBe(false);
+      expect(isUnknownSnr(10)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isUnknownSnr(undefined)).toBe(false);
+    });
+  });
+
   describe('getRoleName', () => {
     it('should return correct role names for all valid roles', () => {
       expect(getRoleName(0)).toBe('Client');

--- a/src/utils/mapHelpers.tsx
+++ b/src/utils/mapHelpers.tsx
@@ -6,22 +6,18 @@ import { convertSpeed } from './speedConversion';
 export { convertSpeed };
 
 /**
- * Scaled SNR sentinel for MQTT/unknown hops.
- * Raw Meshtastic value is -128 (INT8_MIN), divided by 4 = -32.
- * Indicates the hop used MQTT gateway or firmware too old to report SNR.
+ * Scaled SNR sentinel for unknown hops.
+ * Raw Meshtastic value is INT8_MIN (-128), divided by 4 = -32.
+ * Firmware writes this in TraceRouteModule::insertUnknownHops when a hop's
+ * SNR can't be filled in: MQTT-bridged leg, decrypt failure, relay-role node,
+ * or pre-snr-array firmware. It is NOT specifically an MQTT marker — the
+ * firmware uses it as a generic "unknown SNR" sentinel.
  */
-export const MQTT_SNR_SENTINEL = -32;
+export const UNKNOWN_SNR_SENTINEL = -32;
 
-/**
- * Scaled SNR zero sentinel for MQTT hops.
- * Many MQTT gateways leave SNR at protobuf default (0) instead of setting -128.
- * Raw 0 / 4 = 0.0 dB — treated as MQTT since real RF SNR of exactly 0 is rare.
- */
-export const MQTT_SNR_ZERO = 0;
-
-/** Returns true if the scaled SNR value indicates an MQTT/unknown hop */
-export const isMqttSnr = (snr: number | undefined): boolean =>
-  snr === MQTT_SNR_SENTINEL || snr === MQTT_SNR_ZERO;
+/** Returns true if the scaled SNR value is the firmware unknown-hop sentinel */
+export const isUnknownSnr = (snr: number | undefined): boolean =>
+  snr === UNKNOWN_SNR_SENTINEL;
 
 // Constants for arrow generation
 const ARROW_DISTANCE_THRESHOLD = 0.05; // One arrow per 0.05 degrees
@@ -171,7 +167,7 @@ export const getSegmentSnrColor = (
   defaultColor: string
 ): string => {
   if (!snrData || snrData.length === 0) return defaultColor;
-  const rfSnrs = snrData.filter(d => !isMqttSnr(d.snr)).map(d => d.snr);
+  const rfSnrs = snrData.filter(d => !isUnknownSnr(d.snr)).map(d => d.snr);
   if (rfSnrs.length === 0) return defaultColor;
   const avgSnr = rfSnrs.reduce((sum, val) => sum + val, 0) / rfSnrs.length;
   if (avgSnr > 0) return snrColors.good;
@@ -189,7 +185,7 @@ export const getSegmentSnrOpacity = (
 ): number => {
   if (isMqtt) return 0.5;
   if (!snrData || snrData.length === 0) return 0.5;
-  const rfSnrs = snrData.filter(d => !isMqttSnr(d.snr)).map(d => d.snr);
+  const rfSnrs = snrData.filter(d => !isUnknownSnr(d.snr)).map(d => d.snr);
   if (rfSnrs.length === 0) return 0.5;
   const avgSnr = rfSnrs.reduce((sum, val) => sum + val, 0) / rfSnrs.length;
   // Map from -20..+15 to 0.4..0.85
@@ -255,7 +251,7 @@ export const generateCurvedArrowMarkers = (
       <Marker key={`${pathKey}-arrow-${i}`} position={midPoint} icon={createArrowIcon(angle, color)}>
         {snr !== undefined && (
           <Tooltip permanent={false} direction="top" offset={[0, -10]}>
-            {snr.toFixed(1)} dB{isMqttSnr(snr) ? ' (IP)' : ''}
+            {isUnknownSnr(snr) ? '?' : `${snr.toFixed(1)} dB`}
           </Tooltip>
         )}
       </Marker>

--- a/src/utils/traceroute.tsx
+++ b/src/utils/traceroute.tsx
@@ -3,34 +3,35 @@ import { DeviceInfo } from '../types/device';
 import { calculateDistance, formatDistance } from './distance';
 
 /**
- * INT8_MIN (-128) is the Meshtastic sentinel value for unknown SNR.
- * This is used for MQTT gateways, older firmware, or nodes that couldn't decrypt.
- * When scaled by 4 (as stored in protobuf), this becomes -32 dB.
+ * INT8_MIN (-128) is the firmware sentinel for an unknown-SNR hop.
+ * TraceRouteModule::insertUnknownHops writes this when a hop's SNR can't
+ * be filled: MQTT-bridged leg, decrypt failure, relay-role node, or older
+ * firmware without snr arrays. It is NOT specifically an MQTT marker.
  */
 const INT8_MIN_SNR = -128;
 
 /**
- * Formats SNR value for display, showing "IP" for non-LoRa links
+ * Formats SNR value for display, showing "?" for unknown-SNR hops.
  */
 function formatSnrDisplay(snrValue: number | null): string {
   if (snrValue === null) return '';
-  // INT8_MIN (-128) or 0 (protobuf default) indicates IP gateway or unknown SNR
-  if (snrValue === INT8_MIN_SNR || snrValue === 0) {
-    return ' (IP)';
+  if (snrValue === INT8_MIN_SNR) {
+    return ' (?)';
   }
   return ` (${(snrValue / 4).toFixed(1)} dB)`;
 }
 
 /**
- * Formats SNR value for display as a React element, with MQTT styling
+ * Formats SNR value for display as a React element. Renders a "?" badge
+ * for unknown-SNR hops (firmware INT8_MIN sentinel).
  */
 function formatSnrElement(snrValue: number | null, key: string): React.ReactNode {
   if (snrValue === null) return null;
-  // INT8_MIN (-128) or 0 (protobuf default) indicates MQTT gateway or unknown SNR
-  if (snrValue === INT8_MIN_SNR || snrValue === 0) {
+  if (snrValue === INT8_MIN_SNR) {
     return (
       <span
         key={key}
+        title="Unknown SNR (MQTT-bridged hop, decrypt failure, or old firmware)"
         style={{
           marginLeft: '0.25rem',
           padding: '0.1rem 0.3rem',
@@ -41,7 +42,7 @@ function formatSnrElement(snrValue: number | null, key: string): React.ReactNode
           fontWeight: 500,
         }}
       >
-        MQTT
+        ?
       </span>
     );
   }


### PR DESCRIPTION
## Summary

Fixes #2859 — traceroutes labeled hops as "MQTT" / "IP" even when MQTT was disabled.

The 4.1.0 SNR sentinel detection (PR #2302) treated `snr === 0` as MQTT, but `0` is the protobuf default for an unset `int` field — so real RF hops with no SNR populated (and clean 0.0 dB readings) were being mislabeled.

Per Meshtastic firmware ([`TraceRouteModule::insertUnknownHops`](https://github.com/meshtastic/firmware/blob/master/src/modules/TraceRouteModule.cpp)), only `INT8_MIN (-128)` is the authoritative "unknown SNR" sentinel — and it covers **MQTT-bridged legs, decrypt failures, relay-role hops, *and* older firmware without snr arrays**, not just MQTT. There is no per-hop MQTT signal in the `RouteDiscovery` payload (`mesh.proto` has only `route`, `snr_towards`, `route_back`, `snr_back`).

## Changes

- **Drop** the `snr === 0` false-positive branch (`src/utils/mapHelpers.tsx`, `src/utils/traceroute.tsx`)
- **Rename** `isMqttSnr` → `isUnknownSnr`, `MQTT_SNR_SENTINEL` → `UNKNOWN_SNR_SENTINEL`; remove `MQTT_SNR_ZERO`
- **Relabel** user-facing "MQTT" / "(IP)" → "?" / "(?)" with hover tooltip explaining the possible causes (TracerouteWidget, traceroute formatter, map tooltip, server log)
- **Add** `isUnknownSnr` regression tests

The map-segment styling for unknown-SNR hops is preserved (visually distinguished), just no longer asserts they came via MQTT.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on touched files — no errors
- [x] `npx vitest run src/utils/mapHelpers.test.tsx` — 19 tests pass (4 new for `isUnknownSnr`)
- [x] Manual verification in dev container: hops with real SNR=0.0 dB now display "0.0 dB"; hops with INT8_MIN show "?" badge; map tooltips show "?" instead of "(IP)"
- [ ] CI system tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)