### PR TITLE
feat(map-analysis): show neighbor link and trail details in inspector

### DIFF
--- a/src/components/MapAnalysis/AnalysisInspectorPanel.test.tsx
+++ b/src/components/MapAnalysis/AnalysisInspectorPanel.test.tsx
@@ -75,7 +75,9 @@ describe('AnalysisInspectorPanel', () => {
         <AnalysisInspectorPanel />
       </Wrapper>,
     );
-    expect(screen.getByText(/click a node or route segment/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/click a node, route segment, neighbor link, or trail/i),
+    ).toBeInTheDocument();
   });
 
   it('renders node detail when a node is selected', () => {

--- a/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
+++ b/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
@@ -40,10 +40,15 @@ export default function AnalysisInspectorPanel() {
   if (!selected) {
     return (
       <aside className="map-analysis-inspector">
-        <div className="empty">Click a node or route segment</div>
+        <div className="empty">Click a node, route segment, neighbor link, or trail</div>
       </aside>
     );
   }
+
+  const formatTime = (ms: number | undefined): string => {
+    if (!ms) return '—';
+    return new Date(ms).toLocaleString();
+  };
 
   const sourceName = (id: string | undefined): string => {
     if (!id) return '—';
@@ -99,6 +104,75 @@ export default function AnalysisInspectorPanel() {
           <dd>{hops ?? '—'}</dd>
           <dt>Position</dt>
           <dd>{ll ? `${ll[0].toFixed(5)}, ${ll[1].toFixed(5)}` : '—'}</dd>
+        </dl>
+      </aside>
+    );
+  }
+
+  if (selected.type === 'neighbor') {
+    const fromNode = findNode(selected.nodeNum ?? 0, selected.sourceId);
+    const toNode = findNode(selected.neighborNum ?? 0, selected.sourceId);
+    const fromName = nodeName(fromNode, selected.nodeNum ?? 0);
+    const toName = nodeName(toNode, selected.neighborNum ?? 0);
+    const snr = selected.snr;
+    return (
+      <aside className="map-analysis-inspector">
+        <h3>Neighbor Link</h3>
+        <div className="subtitle">
+          !{(selected.nodeNum ?? 0).toString(16)} ↔ !{(selected.neighborNum ?? 0).toString(16)}
+        </div>
+        <hr />
+        <dl>
+          <dt>Node</dt>
+          <dd>{fromName}</dd>
+          <dt>Neighbor</dt>
+          <dd>{toName}</dd>
+          <dt>Source</dt>
+          <dd>{sourceName(selected.sourceId)}</dd>
+          <dt>SNR</dt>
+          <dd>{snr === null || snr === undefined ? '—' : `${snr.toFixed(2)} dB`}</dd>
+          <dt>Reported</dt>
+          <dd>{formatTime(selected.timestamp)}</dd>
+        </dl>
+      </aside>
+    );
+  }
+
+  if (selected.type === 'trail') {
+    const node = findNode(selected.nodeNum ?? 0, selected.sourceId);
+    const name = nodeName(node, selected.nodeNum ?? 0);
+    const durationMs =
+      selected.endMs !== undefined && selected.startMs !== undefined
+        ? selected.endMs - selected.startMs
+        : undefined;
+    const durationStr =
+      durationMs === undefined
+        ? '—'
+        : durationMs < 60_000
+          ? `${Math.round(durationMs / 1000)}s`
+          : durationMs < 3_600_000
+            ? `${Math.round(durationMs / 60_000)}m`
+            : `${(durationMs / 3_600_000).toFixed(1)}h`;
+    return (
+      <aside className="map-analysis-inspector">
+        <h3>Position Trail</h3>
+        <div className="subtitle">
+          !{(selected.nodeNum ?? 0).toString(16)} · {selected.nodeNum}
+        </div>
+        <hr />
+        <dl>
+          <dt>Node</dt>
+          <dd>{name}</dd>
+          <dt>Source</dt>
+          <dd>{sourceName(selected.sourceId)}</dd>
+          <dt>Points</dt>
+          <dd>{selected.pointCount ?? '—'}</dd>
+          <dt>Start</dt>
+          <dd>{formatTime(selected.startMs)}</dd>
+          <dt>End</dt>
+          <dd>{formatTime(selected.endMs)}</dd>
+          <dt>Duration</dt>
+          <dd>{durationStr}</dd>
         </dl>
       </aside>
     );

--- a/src/components/MapAnalysis/MapAnalysisContext.tsx
+++ b/src/components/MapAnalysis/MapAnalysisContext.tsx
@@ -2,11 +2,19 @@ import { createContext, useContext, useState, ReactNode } from 'react';
 import { useMapAnalysisConfig } from '../../hooks/useMapAnalysisConfig';
 
 export interface SelectedTarget {
-  type: 'node' | 'segment';
+  type: 'node' | 'segment' | 'neighbor' | 'trail';
   nodeNum?: number;
   sourceId?: string;
   fromNodeNum?: number;
   toNodeNum?: number;
+  // neighbor-specific
+  neighborNum?: number;
+  snr?: number | null;
+  timestamp?: number;
+  // trail-specific
+  pointCount?: number;
+  startMs?: number;
+  endMs?: number;
 }
 
 type CtxShape = ReturnType<typeof useMapAnalysisConfig> & {

--- a/src/components/MapAnalysis/layers/NeighborLinksLayer.tsx
+++ b/src/components/MapAnalysis/layers/NeighborLinksLayer.tsx
@@ -32,7 +32,7 @@ interface NodeRecord extends MaybePositionedNode {
  * sharing the same source. Edge opacity is derived from SNR.
  */
 export default function NeighborLinksLayer() {
-  const { config } = useMapAnalysisCtx();
+  const { config, setSelected } = useMapAnalysisCtx();
   const layer = config.layers.neighbors;
   const { data: sources = [] } = useDashboardSources();
   const sourceIds =
@@ -63,14 +63,32 @@ export default function NeighborLinksLayer() {
     (t >= ts.windowStartMs && t <= ts.windowEndMs);
 
   const edges = useMemo(() => {
-    const out: Array<{ key: string; positions: [number, number][]; opacity: number }> = [];
+    const out: Array<{
+      key: string;
+      positions: [number, number][];
+      opacity: number;
+      sourceId: string;
+      nodeNum: number;
+      neighborNum: number;
+      snr: number | null;
+      timestamp?: number;
+    }> = [];
     const items = (data as { items?: NeighborEdge[] } | undefined)?.items ?? [];
     const filtered = items.filter((e) => inWindow(e.timestamp ?? 0));
     for (const e of filtered) {
       const a = positionByKey.get(`${e.sourceId}:${Number(e.nodeNum)}`);
       const b = positionByKey.get(`${e.sourceId}:${Number(e.neighborNum)}`);
       if (!a || !b) continue;
-      out.push({ key: String(e.id), positions: [a, b], opacity: snrToOpacity(e.snr) });
+      out.push({
+        key: String(e.id),
+        positions: [a, b],
+        opacity: snrToOpacity(e.snr),
+        sourceId: e.sourceId,
+        nodeNum: Number(e.nodeNum),
+        neighborNum: Number(e.neighborNum),
+        snr: e.snr,
+        timestamp: e.timestamp,
+      });
     }
     return out;
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -83,6 +101,17 @@ export default function NeighborLinksLayer() {
           key={e.key}
           positions={e.positions}
           pathOptions={{ color: '#06b6d4', weight: 1, opacity: e.opacity, dashArray: '4 4' }}
+          eventHandlers={{
+            click: () =>
+              setSelected({
+                type: 'neighbor',
+                sourceId: e.sourceId,
+                nodeNum: e.nodeNum,
+                neighborNum: e.neighborNum,
+                snr: e.snr,
+                timestamp: e.timestamp,
+              }),
+          }}
         />
       ))}
     </>

--- a/src/components/MapAnalysis/layers/PositionTrailsLayer.tsx
+++ b/src/components/MapAnalysis/layers/PositionTrailsLayer.tsx
@@ -24,7 +24,7 @@ interface PositionRecord {
  * Nodes with fewer than 2 fixes are skipped.
  */
 export default function PositionTrailsLayer() {
-  const { config } = useMapAnalysisCtx();
+  const { config, setSelected } = useMapAnalysisCtx();
   const layer = config.layers.trails;
   const { data: sources = [] } = useDashboardSources();
   const sourceIds =
@@ -53,11 +53,32 @@ export default function PositionTrailsLayer() {
       arr.push({ ts: p.timestamp, pos: [p.latitude, p.longitude] });
       grouped.set(key, arr);
     }
-    const out: Array<{ key: string; positions: [number, number][]; color: string }> = [];
+    const out: Array<{
+      key: string;
+      positions: [number, number][];
+      color: string;
+      sourceId: string;
+      nodeNum: number;
+      pointCount: number;
+      startMs: number;
+      endMs: number;
+    }> = [];
     for (const [key, arr] of grouped) {
       if (arr.length < 2) continue;
       arr.sort((a, b) => a.ts - b.ts);
-      out.push({ key, positions: arr.map((x) => x.pos), color: colorForKey(key) });
+      const colonIdx = key.indexOf(':');
+      const sourceId = colonIdx >= 0 ? key.slice(0, colonIdx) : '';
+      const nodeNum = colonIdx >= 0 ? Number(key.slice(colonIdx + 1)) : 0;
+      out.push({
+        key,
+        positions: arr.map((x) => x.pos),
+        color: colorForKey(key),
+        sourceId,
+        nodeNum,
+        pointCount: arr.length,
+        startMs: arr[0].ts,
+        endMs: arr[arr.length - 1].ts,
+      });
     }
     return out;
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -70,6 +91,17 @@ export default function PositionTrailsLayer() {
           key={t.key}
           positions={t.positions}
           pathOptions={{ color: t.color, weight: 2, opacity: 0.7 }}
+          eventHandlers={{
+            click: () =>
+              setSelected({
+                type: 'trail',
+                sourceId: t.sourceId,
+                nodeNum: t.nodeNum,
+                pointCount: t.pointCount,
+                startMs: t.startMs,
+                endMs: t.endMs,
+              }),
+          }}
         />
       ))}
     </>


### PR DESCRIPTION
## Summary
- Click a neighbor link or position trail on the Map Analysis canvas to open its details in the right-side inspector.
- Neighbor cards: endpoints, source, SNR, report timestamp.
- Trail cards: node, source, point count, start/end/duration.

## Changes
- Extended `SelectedTarget` union with `'neighbor'` and `'trail'` variants.
- Added click handlers on `NeighborLinksLayer` and `PositionTrailsLayer` polylines.
- New inspector cards in `AnalysisInspectorPanel` for both selection types.
- Updated empty-state placeholder text + matching test.

## Test plan
- [x] Unit: `AnalysisInspectorPanel.test.tsx` (3/3 pass)
- [x] Local dev container: built and deployed; bundle contains "Neighbor Link"/"Position Trail" strings; user verified click → inspector renders.
- [ ] CI: lint + full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)