### PR TITLE
feat(map-analysis): use shared pin style for node markers

### DIFF
--- a/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
+++ b/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
@@ -1,34 +1,27 @@
 import { Marker, Popup } from 'react-leaflet';
 import { useMemo } from 'react';
-import L from 'leaflet';
 import {
   useDashboardSources,
   useDashboardUnifiedData,
 } from '../../../hooks/useDashboardData';
 import { useHopCounts } from '../../../hooks/useMapAnalysisData';
+import { useSettings } from '../../../contexts/SettingsContext';
 import { useMapAnalysisCtx } from '../MapAnalysisContext';
 import { resolveNodeLatLng, type MaybePositionedNode } from '../nodePositionUtil';
+import { createNodeIcon } from '../../../utils/mapIcons';
 
 interface NodeRecord extends MaybePositionedNode {
   nodeNum: number;
   sourceId?: string;
   longName?: string | null;
   shortName?: string | null;
+  user?: { role?: string | number | null } | null;
 }
 
 interface HopEntry {
   sourceId: string;
   nodeNum: number;
   hops: number;
-}
-
-function hopColor(hops: number | undefined): string {
-  if (hops === undefined) return '#6b7280';
-  if (hops === 0) return '#22c55e';
-  if (hops === 1) return '#84cc16';
-  if (hops === 2) return '#eab308';
-  if (hops === 3) return '#f97316';
-  return '#ef4444';
 }
 
 /**
@@ -43,9 +36,16 @@ function hopColor(hops: number | undefined): string {
  * inspector panel can react.
  */
 export default function NodeMarkersLayer() {
-  const { config, setSelected } = useMapAnalysisCtx();
+  const { config, selected, setSelected } = useMapAnalysisCtx();
+  const { mapPinStyle } = useSettings();
   const { data: sources = [] } = useDashboardSources();
-  const sourceIds = (sources as { id: string }[]).map((s) => s.id);
+  const sourceList = sources as Array<{ id: string; name: string }>;
+  const sourceIds = sourceList.map((s) => s.id);
+  const sourceNameById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const s of sourceList) m.set(s.id, s.name);
+    return m;
+  }, [sourceList]);
   const { nodes } = useDashboardUnifiedData(sourceIds, sourceIds.length > 0);
   const hop = useHopCounts({
     enabled: config.layers.hopShading.enabled,
@@ -75,30 +75,33 @@ export default function NodeMarkersLayer() {
       {filteredNodes.map(({ node: n, latLng }) => {
         const [lat, lon] = latLng!;
         const sourceId = n.sourceId ?? '';
-        const hops = hopByKey.get(`${sourceId}:${Number(n.nodeNum)}`);
-        const tinted = config.layers.hopShading.enabled;
-        const color = tinted ? hopColor(hops) : '#6698f5';
-        const icon =
-          tinted && typeof (L as { divIcon?: unknown }).divIcon === 'function'
-            ? (L as unknown as {
-                divIcon: (opts: {
-                  className: string;
-                  html: string;
-                  iconSize: [number, number];
-                  iconAnchor: [number, number];
-                }) => L.DivIcon;
-              }).divIcon({
-                className: 'map-analysis-node-marker',
-                html: `<div style="background:${color};width:14px;height:14px;border-radius:50%;border:2px solid #fff;"></div>`,
-                iconSize: [18, 18],
-                iconAnchor: [9, 9],
-              })
-            : undefined;
+        const hopVal = hopByKey.get(`${sourceId}:${Number(n.nodeNum)}`);
+        const hops =
+          config.layers.hopShading.enabled && hopVal !== undefined ? hopVal : 999;
+        const isSelected =
+          selected?.type === 'node' &&
+          selected.nodeNum === Number(n.nodeNum) &&
+          (selected.sourceId ?? '') === sourceId;
+        const roleNum =
+          typeof n.user?.role === 'string'
+            ? parseInt(n.user.role, 10)
+            : typeof n.user?.role === 'number'
+              ? n.user.role
+              : 0;
+        const isRouter = roleNum === 2;
+        const icon = createNodeIcon({
+          hops,
+          isSelected,
+          isRouter,
+          shortName: n.shortName ?? undefined,
+          showLabel: true,
+          pinStyle: mapPinStyle,
+        });
         return (
           <Marker
             key={`${sourceId}:${n.nodeNum}`}
             position={[lat, lon]}
-            {...(icon ? { icon } : {})}
+            icon={icon}
             eventHandlers={{
               click: () =>
                 setSelected({
@@ -112,8 +115,8 @@ export default function NodeMarkersLayer() {
               <strong>
                 {n.longName ?? n.shortName ?? `!${Number(n.nodeNum).toString(16)}`}
               </strong>
-              <div>Source: {sourceId || '(unknown)'}</div>
-              {hops !== undefined && <div>Hops: {hops}</div>}
+              <div>Source: {sourceNameById.get(sourceId) ?? sourceId ?? '(unknown)'}</div>
+              {hopVal !== undefined && <div>Hops: {hopVal}</div>}
             </Popup>
           </Marker>
         );


### PR DESCRIPTION
## Summary
- Map Analysis Markers layer now renders nodes with the same `createNodeIcon` helper used by the other maps, so pins match the user's pin-style setting (MeshMonitor / Official Meshtastic).
- Removes the bare default-Leaflet marker that previously showed alongside the hop-shading divIcon.
- Marker popup resolves the source UUID to its friendly name.
- Selection state is reflected via `isSelected`; hop shading colors via the standard hop palette (no-data grey when disabled).

## Test plan
- [x] `npx vitest run src/components/MapAnalysis/` (25/25 pass)
- [x] Local dev container rebuilt and served; visual: pins use the standard style; popup shows friendly source name.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)