### PR TITLE
fix(notifications): legacy prefs fallback honors saved notify* values (#2867)

### DIFF
--- a/src/server/utils/notificationFiltering.test.ts
+++ b/src/server/utils/notificationFiltering.test.ts
@@ -105,6 +105,75 @@ describe('getUserNotificationPreferencesAsync', () => {
     const result = await getUserNotificationPreferencesAsync(1);
     expect(result).toBeNull();
   });
+
+  // Regression coverage for issue #2867 — the legacy push_prefs fallback was
+  // hardcoding 7 fields to literal defaults, silently re-enabling push
+  // categories that the user had turned off pre-4.0. Migration 028 deletes
+  // user_notification_preferences rows with NULL sourceId, so users who
+  // haven't re-saved per-source rely entirely on this fallback.
+  describe('legacy push_prefs fallback respects saved values', () => {
+    beforeEach(() => {
+      mockDb.notifications.getUserPreferences.mockResolvedValue(null);
+    });
+
+    it('honors notifyOnTraceroute=false from the legacy blob', async () => {
+      mockDb.getSettingAsync.mockResolvedValue(JSON.stringify({
+        enableWebPush: true,
+        notifyOnTraceroute: false,
+      }));
+      const result = await getUserNotificationPreferencesAsync(7);
+      expect(result?.notifyOnTraceroute).toBe(false);
+    });
+
+    it('honors all notify* toggles when explicitly set in the legacy blob', async () => {
+      mockDb.getSettingAsync.mockResolvedValue(JSON.stringify({
+        enableWebPush: false,
+        enableDirectMessages: false,
+        notifyOnEmoji: false,
+        notifyOnMqtt: false,
+        notifyOnNewNode: false,
+        notifyOnTraceroute: false,
+        notifyOnInactiveNode: true,
+        notifyOnServerEvents: true,
+        prefixWithNodeName: true,
+      }));
+      const result = await getUserNotificationPreferencesAsync(7);
+      expect(result).toMatchObject({
+        enableWebPush: false,
+        enableDirectMessages: false,
+        notifyOnEmoji: false,
+        notifyOnMqtt: false,
+        notifyOnNewNode: false,
+        notifyOnTraceroute: false,
+        notifyOnInactiveNode: true,
+        notifyOnServerEvents: true,
+        prefixWithNodeName: true,
+      });
+    });
+
+    it('falls back to defaults only for fields absent from the legacy blob', async () => {
+      mockDb.getSettingAsync.mockResolvedValue(JSON.stringify({
+        notifyOnTraceroute: false,
+        // every other field is missing — must use defaults
+      }));
+      const result = await getUserNotificationPreferencesAsync(7);
+      expect(result?.notifyOnTraceroute).toBe(false);
+      expect(result?.notifyOnNewNode).toBe(true);   // default true
+      expect(result?.notifyOnEmoji).toBe(true);     // default true
+      expect(result?.notifyOnMqtt).toBe(true);      // default true
+      expect(result?.enableWebPush).toBe(true);     // default true
+      expect(result?.notifyOnInactiveNode).toBe(false); // default false
+    });
+
+    it('treats non-boolean stored values as missing and uses defaults', async () => {
+      mockDb.getSettingAsync.mockResolvedValue(JSON.stringify({
+        notifyOnTraceroute: 'no', // bad data — must NOT be coerced to true
+      }));
+      const result = await getUserNotificationPreferencesAsync(7);
+      // String 'no' is truthy but not a boolean — fall back to default true
+      expect(result?.notifyOnTraceroute).toBe(true);
+    });
+  });
 });
 
 // ─── saveUserNotificationPreferencesAsync ────────────────────────────────────

--- a/src/server/utils/notificationFiltering.ts
+++ b/src/server/utils/notificationFiltering.ts
@@ -96,30 +96,37 @@ export async function getUserNotificationPreferencesAsync(userId: number, source
       return prefs;
     }
 
-    // Fall back to old settings table for backward compatibility
+    // Fall back to old settings table for backward compatibility.
+    // Migration 028 deletes per-source rows that predate the per-source schema,
+    // so any user who hasn't re-saved preferences in 4.0+ relies entirely on
+    // this path. Hardcoding the notify* toggles to `true` here silently
+    // re-enabled push categories that the user had explicitly turned off in
+    // the legacy blob (issue #2867 — traceroute audio firing despite the
+    // toggle being off). Respect every saved value; only fall back to defaults
+    // when a field isn't present at all.
     const prefsJson = await databaseService.getSettingAsync(`push_prefs_${userId}`);
     if (prefsJson) {
       const oldPrefs = JSON.parse(prefsJson);
+      const boolOr = (value: unknown, fallback: boolean): boolean =>
+        typeof value === 'boolean' ? value : fallback;
       return {
-        enableWebPush: true, // Old users had push enabled
-        enableApprise: false, // New feature, default to disabled
+        enableWebPush: boolOr(oldPrefs.enableWebPush, true),
+        enableApprise: boolOr(oldPrefs.enableApprise, false),
         enabledChannels: oldPrefs.enabledChannels || [],
-        enableDirectMessages: oldPrefs.enableDirectMessages !== undefined
-          ? oldPrefs.enableDirectMessages
-          : true,
-        notifyOnEmoji: true, // Default to enabled for backward compatibility
-        notifyOnMqtt: true, // Default to enabled for backward compatibility
-        notifyOnNewNode: true, // Default to enabled for backward compatibility
-        notifyOnTraceroute: true, // Default to enabled for backward compatibility
-        notifyOnInactiveNode: false, // Default to disabled
-        notifyOnServerEvents: false, // Default to disabled
-        prefixWithNodeName: false, // Default to disabled
-        monitoredNodes: [], // Default to empty array
+        enableDirectMessages: boolOr(oldPrefs.enableDirectMessages, true),
+        notifyOnEmoji: boolOr(oldPrefs.notifyOnEmoji, true),
+        notifyOnMqtt: boolOr(oldPrefs.notifyOnMqtt, true),
+        notifyOnNewNode: boolOr(oldPrefs.notifyOnNewNode, true),
+        notifyOnTraceroute: boolOr(oldPrefs.notifyOnTraceroute, true),
+        notifyOnInactiveNode: boolOr(oldPrefs.notifyOnInactiveNode, false),
+        notifyOnServerEvents: boolOr(oldPrefs.notifyOnServerEvents, false),
+        prefixWithNodeName: boolOr(oldPrefs.prefixWithNodeName, false),
+        monitoredNodes: oldPrefs.monitoredNodes || [],
         whitelist: oldPrefs.whitelist || [],
         blacklist: oldPrefs.blacklist || [],
-        appriseUrls: [], // Default to empty array
-        mutedChannels: [],
-        mutedDMs: [],
+        appriseUrls: oldPrefs.appriseUrls || [],
+        mutedChannels: oldPrefs.mutedChannels || [],
+        mutedDMs: oldPrefs.mutedDMs || [],
       };
     }
 


### PR DESCRIPTION
## Summary
- Closes #2867 root cause: the legacy `push_prefs_${userId}` fallback in `getUserNotificationPreferencesAsync` was **hardcoding** seven boolean fields to literal defaults, ignoring whatever the user had saved.
- Migration 028 (4.0) deletes per-user `user_notification_preferences` rows that predate the per-source schema. Any user who hasn't re-saved their preferences per-source in 4.0+ falls through entirely to this fallback. Hardcoding silently re-enabled push categories the user had turned off before the upgrade — including traceroute, which is exactly the symptom @SteveHawk reports.
- Fix: read every saved field from the legacy blob via a `boolOr` helper that respects boolean values and only uses the default when the field is absent. Corrupt non-boolean values fall back to defaults, so bad data can't accidentally re-enable anything.

## Audit findings
| Field | Before | After |
| --- | --- | --- |
| `enableWebPush` | hardcoded `true` | respects `oldPrefs.enableWebPush` |
| `enableApprise` | hardcoded `false` | respects `oldPrefs.enableApprise` |
| `enableDirectMessages` | partial respect | full respect |
| `notifyOnEmoji` | hardcoded `true` | respects `oldPrefs.notifyOnEmoji` |
| `notifyOnMqtt` | hardcoded `true` | respects `oldPrefs.notifyOnMqtt` |
| `notifyOnNewNode` | hardcoded `true` | respects `oldPrefs.notifyOnNewNode` |
| `notifyOnTraceroute` | hardcoded `true` ← issue #2867 | respects `oldPrefs.notifyOnTraceroute` |
| `notifyOnInactiveNode` | hardcoded `false` | respects `oldPrefs.notifyOnInactiveNode` |
| `notifyOnServerEvents` | hardcoded `false` | respects `oldPrefs.notifyOnServerEvents` |
| `prefixWithNodeName` | hardcoded `false` | respects `oldPrefs.prefixWithNodeName` |
| `monitoredNodes` | hardcoded `[]` | respects `oldPrefs.monitoredNodes` |
| `appriseUrls` | hardcoded `[]` | respects `oldPrefs.appriseUrls` |
| `mutedChannels` | hardcoded `[]` | respects `oldPrefs.mutedChannels` |
| `mutedDMs` | hardcoded `[]` | respects `oldPrefs.mutedDMs` |

## Test plan
- [x] 4 new regression tests in `notificationFiltering.test.ts` (single-field override, all-toggles override, partial blob with default fall-through, non-boolean rejection) — full suite 48/48 passing
- [ ] CI green
- [ ] @SteveHawk verifies traceroute notifications stay quiet after upgrade to a build with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)