### PR TITLE
chore(release): bump to 4.1.1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.1.0",
+  "version": "4.1.1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/public/news.json
+++ b/docs/public/news.json
@@ -1,7 +1,16 @@
 {
   "version": "1",
-  "lastUpdated": "2026-04-27T18:00:00Z",
+  "lastUpdated": "2026-04-30T20:00:00Z",
   "items": [
+    {
+      "minVersion": "4.1.1",
+      "id": "news-2026-04-30-v4.1.1-release",
+      "title": "MeshMonitor v4.1.1 — Notification preferences fix & kernel CVE posture",
+      "content": "## Action Required: Re-check your Notification preferences\n\nA bug introduced during the 4.0 multi-source migration was silently re-enabling several push notification categories — including **Notify on Traceroute** — for users whose preferences were carried over from the legacy single-source schema. If your traceroute (or new-node, MQTT, emoji) notifications have been firing despite the toggles being off, this is why.\n\n**After upgrading to 4.1.1, please open Notifications → review every toggle on every source.** Re-saving once per source will write a fresh per-source row and stop relying on the legacy fallback path entirely. See [#2867](https://github.com/Yeraze/meshmonitor/issues/2867) for the full root-cause analysis.\n\n## Security: CVE-2026-31431 (\"Copy Fail\") posture\n\nWe've published our position on the recent Linux kernel privilege-escalation CVE-2026-31431. **MeshMonitor itself is not directly susceptible** — the codebase does not invoke the kernel crypto API (`AF_ALG`/`algif`) — but unpatched host kernels remain exploitable by any local code execution. The Helm chart now defaults to `seccompProfile.type: RuntimeDefault`, which blocks the affected syscall path under most strict profiles, and `SECURITY.md` documents the recommended container hardening posture.\n\nOperators on shared or multi-tenant hosts should read the full advisory and update their kernels: [Discussion #2861](https://github.com/Yeraze/meshmonitor/discussions/2861).\n\n## Other fixes in 4.1.1\n\n- **Virtual Node MQTT uplink** — the primary channel was sent to mqtt-proxy clients with an empty name, causing the proxy to drop every uplink with `uplink_enabled=False`. The VN now mirrors the firmware fallback and synthesizes the channel name from the LoRa modem preset (e.g. `MediumFast`). [#2866](https://github.com/Yeraze/meshmonitor/pull/2866)",
+      "date": "2026-04-30T20:00:00Z",
+      "category": "release",
+      "priority": "important"
+    },
     {
       "minVersion": "4.0.0",
       "id": "news-2026-04-27-v4.0-release",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.1.0
-appVersion: "4.1.0"
+version: 4.1.1
+appVersion: "4.1.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

- Bumps the app version to **4.1.1** across the five canonical files: `package.json`, `package-lock.json`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, `helm/meshmonitor/Chart.yaml`.
- Adds a 4.1.1 entry to `docs/public/news.json` so the in-app news widget flags the two action items for upgrading users.

## What's in 4.1.1

- **#2868 — Notification preferences fallback fix (#2867)**. The legacy `push_prefs` fallback in `getUserNotificationPreferencesAsync` was hardcoding seven boolean toggles to defaults, ignoring the user's saved values. After migration 028 (which deletes per-source-NULL rows), affected users were silently getting `notifyOnTraceroute` (and others) flipped back to `true`. Fallback now reads every saved field; users should re-check their Notifications tab after upgrade.
- **#2866 — Virtual Node MQTT uplink primary channel name**. VN now mirrors the firmware fallback and synthesizes the slot-0 channel name from the LoRa modem preset (e.g. `MediumFast`) when the DB has no explicit name, so mqtt-proxy clients can match the topic and stop dropping uplinks.
- **News.json — kernel CVE posture**. References the new `SECURITY.md` advisory and Discussion #2861 covering CVE-2026-31431 ("Copy Fail") and the Helm chart's new `seccompProfile.type: RuntimeDefault` default.

## Test plan
- [x] All five version files match `4.1.1`
- [x] `package-lock.json` regenerated via `npm install --package-lock-only --legacy-peer-deps`
- [x] All modified JSON files parse cleanly
- [ ] CI green
- [ ] Tag created by GitHub on release publish (per project convention — no manual tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)