### PR TITLE
chore(tooling): exit-code-driven CI/Release watchers + /release-monitor skill

### DIFF
--- a/.claude/commands/ci-monitor.md
+++ b/.claude/commands/ci-monitor.md
@@ -8,50 +8,78 @@ Invoke with: `/ci-monitor <PR_NUMBER>`
 
 ## Instructions
 
-### Phase 1: Monitor
+### Phase 1: Wait for CI (delegated to script — saves tokens)
 
-1. Get the PR branch name: `gh pr view $PR_NUMBER --json headRefName -q .headRefName`
-2. Ensure you're on that branch: `git checkout <branch> && git pull origin <branch>`
-3. Poll CI status every 60 seconds using: `gh run list --branch <branch> --limit 4 --json name,conclusion,status`
-4. Display status each cycle: ✓ for success, ✗ for failure, ⏳ for in-progress
-5. When all checks complete:
-   - If **ALL GREEN**: Report success and stop
-   - If **ANY RED**: Proceed to Phase 2
+**Do not poll the GitHub API yourself.** Run `scripts/watch-ci.sh` and read its exit code:
+
+```bash
+bash scripts/watch-ci.sh -q <PR_NUMBER>
+echo "EXIT=$?"
+```
+
+The script polls every 60s, blocks until the picture is decided, and emits exactly **one** terminal line plus an exit code:
+
+| Exit | Meaning | What you do |
+| ---- | ------- | ----------- |
+| `0`  | All workflows ended in `success` or `skipped` | Report success and stop |
+| `1`  | At least one workflow ended in `failure` / `cancelled` / `timed_out` | Proceed to Phase 2 |
+| `2`  | Usage / GitHub API error (bad PR number, gh auth failure) | Stop, report the error to the user |
+
+The `-q` flag suppresses per-cycle status; you only see the final pass/fail line, which keeps the polling out of your context window. Drop the `-q` flag if you want to debug.
+
+Before running, make sure you're on the PR's branch:
+
+```bash
+gh pr view <PR_NUMBER> --json headRefName -q .headRefName     # confirm branch
+git checkout <branch> && git pull origin <branch>             # if not already there
+```
+
+The Bash tool's default 2-minute timeout is too short for full CI runs — pass an explicit timeout (e.g. `1800000` ms = 30 min) when invoking `watch-ci.sh`. If the run is expected to take longer than 30 min (system tests, slow runners), use `run_in_background` and monitor the background task.
 
 ### Phase 2: Diagnose
 
-1. Get the failing run ID: `gh run list --branch <branch> --limit 1 --json databaseId,conclusion -q '.[] | select(.conclusion == "failure") | .databaseId'`
-2. Fetch failure logs: `gh run view <run_id> --log-failed 2>&1`
-3. Extract error patterns — look for these common regressions:
+Only reached when `watch-ci.sh` returned exit code `1`.
+
+1. Identify the failing run:
+   ```bash
+   gh run list --branch <branch> --limit 20 \
+     --json databaseId,name,conclusion \
+     -q '.[] | select(.conclusion=="failure" or .conclusion=="cancelled" or .conclusion=="timed_out") | "\(.databaseId) \(.name)"'
+   ```
+2. Fetch the failing logs (use a sandbox so the output doesn't flood context):
+   ```bash
+   gh run view <run_id> --log-failed
+   ```
+3. Match against known regression patterns:
    - `error TS` — TypeScript compilation errors (missing async, null vs undefined, unused vars)
    - `CHECK constraint failed: resource IN` — Permission resource name mismatch
-   - `mockReturnValue` on async functions — Should be `mockResolvedValue`
-   - `is not a function` — Missing method on repository or wrong import
-   - `Cannot read properties of undefined` — Null/undefined propagation from Drizzle repos
-   - `FAIL` lines — Test file names and assertion errors
+   - `mockReturnValue` on async functions → should be `mockResolvedValue`
+   - `is not a function` — missing method on repository or wrong import
+   - `Cannot read properties of undefined` — null/undefined propagation from Drizzle repos
+   - `FAIL` lines — test file names and assertion errors
 
 ### Phase 3: Fix
 
 Apply a **minimal targeted fix** — touch ONLY the files related to the failure:
 
-1. For **TypeScript errors**: Read the file at the error line, understand the type mismatch, fix it
-   - `number | null` vs `number | undefined` → Add `?? undefined`
-   - Missing `async` keyword → Add it to the function
-   - Unused variable → Remove or prefix with `_`
-2. For **CHECK constraint errors**: Verify resource names match the valid list in migration 006
-3. For **Mock mismatches**: Change `mockReturnValue` to `mockResolvedValue` for async functions
-4. For **Missing methods**: Check if the method exists on the repository, add if missing
+1. **TypeScript errors** — read the file at the error line, understand the type mismatch, fix it
+   - `number | null` vs `number | undefined` → add `?? undefined`
+   - Missing `async` keyword → add it to the function
+   - Unused variable → remove or prefix with `_`
+2. **CHECK constraint errors** — verify resource names match the valid list in migration 006
+3. **Mock mismatches** — change `mockReturnValue` to `mockResolvedValue` for async functions
+4. **Missing methods** — verify the method exists on the repository, add if missing
 
 After fixing:
-- Run the failing tests locally: `node_modules/.bin/vitest run <failing_test_file>`
-- If they pass, run the full suite: `npm test 2>&1 | tail -5`
-- Commit: `git add -A && git commit -m "fix: [describe the CI failure]" && git push`
+- Run the failing test file locally first: `node_modules/.bin/vitest run <failing_test_file>`
+- If green, run the relevant suite: `npm test 2>&1 | tail -5`
+- Commit and push: `git add -A && git commit -m "fix: <describe>" && git push`
 
 ### Phase 4: Re-monitor
 
 After pushing the fix:
-1. Wait 30 seconds for CI to pick up the new commit
-2. Return to Phase 1
+1. Wait ~30 seconds for CI to pick up the new commit (otherwise the script may observe the old run)
+2. Run `bash scripts/watch-ci.sh -q <PR_NUMBER>` again — back to Phase 1's exit-code dispatch
 3. **Maximum 3 fix cycles** — if CI is still red after 3 attempts, stop and report what was tried
 
 ### Reporting
@@ -80,4 +108,4 @@ When complete (success or max attempts reached), output a summary:
 - **Never modify files unrelated to the failure** — minimal fixes only
 - **Always run failing tests locally before pushing** — don't push blind fixes
 - **Check that the branch is up to date** before applying fixes
-- The `scripts/watch-ci.sh` script can be used for simple polling if you just need to wait
+- **Don't poll `gh run list` in a loop yourself.** Delegate the wait to `scripts/watch-ci.sh -q <PR>` and dispatch on its exit code. That's the whole point of the script — it keeps polling output out of the model's context.

--- a/.claude/commands/release-monitor.md
+++ b/.claude/commands/release-monitor.md
@@ -1,0 +1,93 @@
+# Release Monitor & Auto-Diagnose
+
+Monitor a release's pipeline workflows (release.yml, docker-publish.yml, desktop-release.yml), diagnose failures, and either auto-rerun on infrastructure flakes or surface root-cause analysis.
+
+## Usage
+
+Invoke with: `/release-monitor [TAG]`
+
+Tag is optional (used for log lines and notifications). Filtering is by `--event release` so the script picks up whichever release was most recently published.
+
+## Instructions
+
+### Phase 1: Wait for release workflows (delegated to script — saves tokens)
+
+**Do not poll the GitHub API yourself.** Run `scripts/watch-release.sh` and read its exit code:
+
+```bash
+bash scripts/watch-release.sh -q [TAG]
+echo "EXIT=$?"
+```
+
+The script polls every 60s, blocks until every release-event workflow is decided, and emits exactly **one** terminal line plus an exit code:
+
+| Exit | Meaning | What you do |
+| ---- | ------- | ----------- |
+| `0`  | All release workflows ended in `success` or `skipped` | Report success and stop |
+| `1`  | At least one release workflow ended in `failure` / `cancelled` / `timed_out` | Proceed to Phase 2 |
+| `2`  | Usage / GitHub API error | Stop, report the error to the user |
+
+The `-q` flag suppresses per-cycle status; you only see the final pass/fail line. Drop the `-q` flag if you want to debug the polling loop itself.
+
+Release workflows can take 30+ minutes (Docker multi-arch builds, Tauri Windows/macOS/Linux builds), so always pass an explicit Bash timeout — `3600000` ms (1 hour) is a safe default — or use `run_in_background` and check the task on completion.
+
+### Phase 2: Diagnose
+
+Only reached when `watch-release.sh` returned exit code `1`.
+
+1. Identify the failing workflow run(s):
+   ```bash
+   gh run list --limit 10 --event release \
+     --json databaseId,name,conclusion \
+     -q '.[] | select(.conclusion=="failure" or .conclusion=="cancelled" or .conclusion=="timed_out") | "\(.databaseId) \(.name)"'
+   ```
+2. Fetch the failing logs:
+   ```bash
+   gh run view <run_id> --log-failed
+   ```
+3. Categorize the failure:
+   - **Infrastructure / network / runner-loss / timeout** — flaky CI, not the code.
+     Examples: "The runner has received a shutdown signal", "Error: connect ETIMEDOUT", "EOF on push of layer", any 5xx from ghcr.io/dockerhub.
+     **Action:** auto-retry with `gh run rerun <run_id>` and return to Phase 1.
+   - **Image not found for platform / linux/arm64 not available** — Dockerfile base image regression.
+     **Action:** prepare a fix on a branch (do not auto-rerun), prompt user.
+   - **Test failure / build failure** — real regression.
+     **Action:** diagnose root cause from the log, prepare a fix, prompt user before pushing.
+   - **Auth / permission denied / 401 from ghcr.io** — token / secret issue, cannot auto-fix.
+     **Action:** stop and report to user with the exact log line.
+
+### Phase 3: Auto-retry (only for transient infra failures)
+
+```bash
+gh run rerun <run_id>
+sleep 30                                  # let GitHub spawn the new run
+bash scripts/watch-release.sh -q [TAG]    # back to Phase 1
+echo "EXIT=$?"
+```
+
+**Maximum 2 retries per workflow.** If a workflow fails twice, treat it as a real failure and stop.
+
+### Phase 4: Reporting
+
+```
+## Release Monitor Report for TAG
+
+**Release:** <tag or "latest">
+**Result:** ✓ ALL GREEN / ✗ FAILED — <workflow name> (<conclusion>)
+
+### Workflows
+- ✓ Release Pipeline
+- ✓ Docker Build and Publish
+- ✗ Desktop Release — failure (rerun #1 also failed)
+
+### Failure analysis
+<log excerpt + categorization + recommended next step>
+```
+
+## Important Rules
+
+- **Never push tags or recreate releases manually.** GitHub creates the tag when you publish a release; the project policy says let it.
+- **Auto-rerun only for infrastructure flakes** — don't blindly retry test/build failures.
+- **Cap retries at 2 per workflow.** Three failures = real problem, escalate.
+- **Don't poll `gh run list` in a loop yourself.** Delegate the wait to `scripts/watch-release.sh -q [TAG]` and dispatch on its exit code. That's the whole point of the script — it keeps polling output out of the model's context.
+- **Pair with `/ci-monitor` semantics.** This skill is the release-pipeline counterpart; `/ci-monitor` watches per-PR CI runs.

--- a/.claude/skills/ci-monitor.md
+++ b/.claude/skills/ci-monitor.md
@@ -8,50 +8,78 @@ Invoke with: `/ci-monitor <PR_NUMBER>`
 
 ## Instructions
 
-### Phase 1: Monitor
+### Phase 1: Wait for CI (delegated to script — saves tokens)
 
-1. Get the PR branch name: `gh pr view $PR_NUMBER --json headRefName -q .headRefName`
-2. Ensure you're on that branch: `git checkout <branch> && git pull origin <branch>`
-3. Poll CI status every 60 seconds using: `gh run list --branch <branch> --limit 4 --json name,conclusion,status`
-4. Display status each cycle: ✓ for success, ✗ for failure, ⏳ for in-progress
-5. When all checks complete:
-   - If **ALL GREEN**: Report success and stop
-   - If **ANY RED**: Proceed to Phase 2
+**Do not poll the GitHub API yourself.** Run `scripts/watch-ci.sh` and read its exit code:
+
+```bash
+bash scripts/watch-ci.sh -q <PR_NUMBER>
+echo "EXIT=$?"
+```
+
+The script polls every 60s, blocks until the picture is decided, and emits exactly **one** terminal line plus an exit code:
+
+| Exit | Meaning | What you do |
+| ---- | ------- | ----------- |
+| `0`  | All workflows ended in `success` or `skipped` | Report success and stop |
+| `1`  | At least one workflow ended in `failure` / `cancelled` / `timed_out` | Proceed to Phase 2 |
+| `2`  | Usage / GitHub API error (bad PR number, gh auth failure) | Stop, report the error to the user |
+
+The `-q` flag suppresses per-cycle status; you only see the final pass/fail line, which keeps the polling out of your context window. Drop the `-q` flag if you want to debug.
+
+Before running, make sure you're on the PR's branch:
+
+```bash
+gh pr view <PR_NUMBER> --json headRefName -q .headRefName     # confirm branch
+git checkout <branch> && git pull origin <branch>             # if not already there
+```
+
+The Bash tool's default 2-minute timeout is too short for full CI runs — pass an explicit timeout (e.g. `1800000` ms = 30 min) when invoking `watch-ci.sh`. If the run is expected to take longer than 30 min (system tests, slow runners), use `run_in_background` and monitor the background task.
 
 ### Phase 2: Diagnose
 
-1. Get the failing run ID: `gh run list --branch <branch> --limit 1 --json databaseId,conclusion -q '.[] | select(.conclusion == "failure") | .databaseId'`
-2. Fetch failure logs: `gh run view <run_id> --log-failed 2>&1`
-3. Extract error patterns — look for these common regressions:
+Only reached when `watch-ci.sh` returned exit code `1`.
+
+1. Identify the failing run:
+   ```bash
+   gh run list --branch <branch> --limit 20 \
+     --json databaseId,name,conclusion \
+     -q '.[] | select(.conclusion=="failure" or .conclusion=="cancelled" or .conclusion=="timed_out") | "\(.databaseId) \(.name)"'
+   ```
+2. Fetch the failing logs (use a sandbox so the output doesn't flood context):
+   ```bash
+   gh run view <run_id> --log-failed
+   ```
+3. Match against known regression patterns:
    - `error TS` — TypeScript compilation errors (missing async, null vs undefined, unused vars)
    - `CHECK constraint failed: resource IN` — Permission resource name mismatch
-   - `mockReturnValue` on async functions — Should be `mockResolvedValue`
-   - `is not a function` — Missing method on repository or wrong import
-   - `Cannot read properties of undefined` — Null/undefined propagation from Drizzle repos
-   - `FAIL` lines — Test file names and assertion errors
+   - `mockReturnValue` on async functions → should be `mockResolvedValue`
+   - `is not a function` — missing method on repository or wrong import
+   - `Cannot read properties of undefined` — null/undefined propagation from Drizzle repos
+   - `FAIL` lines — test file names and assertion errors
 
 ### Phase 3: Fix
 
 Apply a **minimal targeted fix** — touch ONLY the files related to the failure:
 
-1. For **TypeScript errors**: Read the file at the error line, understand the type mismatch, fix it
-   - `number | null` vs `number | undefined` → Add `?? undefined`
-   - Missing `async` keyword → Add it to the function
-   - Unused variable → Remove or prefix with `_`
-2. For **CHECK constraint errors**: Verify resource names match the valid list in migration 006
-3. For **Mock mismatches**: Change `mockReturnValue` to `mockResolvedValue` for async functions
-4. For **Missing methods**: Check if the method exists on the repository, add if missing
+1. **TypeScript errors** — read the file at the error line, understand the type mismatch, fix it
+   - `number | null` vs `number | undefined` → add `?? undefined`
+   - Missing `async` keyword → add it to the function
+   - Unused variable → remove or prefix with `_`
+2. **CHECK constraint errors** — verify resource names match the valid list in migration 006
+3. **Mock mismatches** — change `mockReturnValue` to `mockResolvedValue` for async functions
+4. **Missing methods** — verify the method exists on the repository, add if missing
 
 After fixing:
-- Run the failing tests locally: `node_modules/.bin/vitest run <failing_test_file>`
-- If they pass, run the full suite: `npm test 2>&1 | tail -5`
-- Commit: `git add -A && git commit -m "fix: [describe the CI failure]" && git push`
+- Run the failing test file locally first: `node_modules/.bin/vitest run <failing_test_file>`
+- If green, run the relevant suite: `npm test 2>&1 | tail -5`
+- Commit and push: `git add -A && git commit -m "fix: <describe>" && git push`
 
 ### Phase 4: Re-monitor
 
 After pushing the fix:
-1. Wait 30 seconds for CI to pick up the new commit
-2. Return to Phase 1
+1. Wait ~30 seconds for CI to pick up the new commit (otherwise the script may observe the old run)
+2. Run `bash scripts/watch-ci.sh -q <PR_NUMBER>` again — back to Phase 1's exit-code dispatch
 3. **Maximum 3 fix cycles** — if CI is still red after 3 attempts, stop and report what was tried
 
 ### Reporting
@@ -80,4 +108,4 @@ When complete (success or max attempts reached), output a summary:
 - **Never modify files unrelated to the failure** — minimal fixes only
 - **Always run failing tests locally before pushing** — don't push blind fixes
 - **Check that the branch is up to date** before applying fixes
-- The `scripts/watch-ci.sh` script can be used for simple polling if you just need to wait
+- **Don't poll `gh run list` in a loop yourself.** Delegate the wait to `scripts/watch-ci.sh -q <PR>` and dispatch on its exit code. That's the whole point of the script — it keeps polling output out of the model's context.

--- a/.claude/skills/release-monitor.md
+++ b/.claude/skills/release-monitor.md
@@ -1,0 +1,93 @@
+# Release Monitor & Auto-Diagnose
+
+Monitor a release's pipeline workflows (release.yml, docker-publish.yml, desktop-release.yml), diagnose failures, and either auto-rerun on infrastructure flakes or surface root-cause analysis.
+
+## Usage
+
+Invoke with: `/release-monitor [TAG]`
+
+Tag is optional (used for log lines and notifications). Filtering is by `--event release` so the script picks up whichever release was most recently published.
+
+## Instructions
+
+### Phase 1: Wait for release workflows (delegated to script — saves tokens)
+
+**Do not poll the GitHub API yourself.** Run `scripts/watch-release.sh` and read its exit code:
+
+```bash
+bash scripts/watch-release.sh -q [TAG]
+echo "EXIT=$?"
+```
+
+The script polls every 60s, blocks until every release-event workflow is decided, and emits exactly **one** terminal line plus an exit code:
+
+| Exit | Meaning | What you do |
+| ---- | ------- | ----------- |
+| `0`  | All release workflows ended in `success` or `skipped` | Report success and stop |
+| `1`  | At least one release workflow ended in `failure` / `cancelled` / `timed_out` | Proceed to Phase 2 |
+| `2`  | Usage / GitHub API error | Stop, report the error to the user |
+
+The `-q` flag suppresses per-cycle status; you only see the final pass/fail line. Drop the `-q` flag if you want to debug the polling loop itself.
+
+Release workflows can take 30+ minutes (Docker multi-arch builds, Tauri Windows/macOS/Linux builds), so always pass an explicit Bash timeout — `3600000` ms (1 hour) is a safe default — or use `run_in_background` and check the task on completion.
+
+### Phase 2: Diagnose
+
+Only reached when `watch-release.sh` returned exit code `1`.
+
+1. Identify the failing workflow run(s):
+   ```bash
+   gh run list --limit 10 --event release \
+     --json databaseId,name,conclusion \
+     -q '.[] | select(.conclusion=="failure" or .conclusion=="cancelled" or .conclusion=="timed_out") | "\(.databaseId) \(.name)"'
+   ```
+2. Fetch the failing logs:
+   ```bash
+   gh run view <run_id> --log-failed
+   ```
+3. Categorize the failure:
+   - **Infrastructure / network / runner-loss / timeout** — flaky CI, not the code.
+     Examples: "The runner has received a shutdown signal", "Error: connect ETIMEDOUT", "EOF on push of layer", any 5xx from ghcr.io/dockerhub.
+     **Action:** auto-retry with `gh run rerun <run_id>` and return to Phase 1.
+   - **Image not found for platform / linux/arm64 not available** — Dockerfile base image regression.
+     **Action:** prepare a fix on a branch (do not auto-rerun), prompt user.
+   - **Test failure / build failure** — real regression.
+     **Action:** diagnose root cause from the log, prepare a fix, prompt user before pushing.
+   - **Auth / permission denied / 401 from ghcr.io** — token / secret issue, cannot auto-fix.
+     **Action:** stop and report to user with the exact log line.
+
+### Phase 3: Auto-retry (only for transient infra failures)
+
+```bash
+gh run rerun <run_id>
+sleep 30                                  # let GitHub spawn the new run
+bash scripts/watch-release.sh -q [TAG]    # back to Phase 1
+echo "EXIT=$?"
+```
+
+**Maximum 2 retries per workflow.** If a workflow fails twice, treat it as a real failure and stop.
+
+### Phase 4: Reporting
+
+```
+## Release Monitor Report for TAG
+
+**Release:** <tag or "latest">
+**Result:** ✓ ALL GREEN / ✗ FAILED — <workflow name> (<conclusion>)
+
+### Workflows
+- ✓ Release Pipeline
+- ✓ Docker Build and Publish
+- ✗ Desktop Release — failure (rerun #1 also failed)
+
+### Failure analysis
+<log excerpt + categorization + recommended next step>
+```
+
+## Important Rules
+
+- **Never push tags or recreate releases manually.** GitHub creates the tag when you publish a release; the project policy says let it.
+- **Auto-rerun only for infrastructure flakes** — don't blindly retry test/build failures.
+- **Cap retries at 2 per workflow.** Three failures = real problem, escalate.
+- **Don't poll `gh run list` in a loop yourself.** Delegate the wait to `scripts/watch-release.sh -q [TAG]` and dispatch on its exit code. That's the whole point of the script — it keeps polling output out of the model's context.
+- **Pair with `/ci-monitor` semantics.** This skill is the release-pipeline counterpart; `/ci-monitor` watches per-PR CI runs.

--- a/scripts/watch-ci.sh
+++ b/scripts/watch-ci.sh
@@ -1,73 +1,133 @@
 #!/bin/bash
-# watch-ci.sh — Poll CI pipeline status for a PR or branch
-# Usage: ./scripts/watch-ci.sh [PR_NUMBER|BRANCH_NAME]
+# watch-ci.sh — Poll CI pipeline status for a PR or branch.
+#
+# Blocks until every workflow completes, exits early on the first failure
+# (so an automated runner can stop waiting), and exits 0 only when every
+# workflow ended in `success` or `skipped`.
+#
+# Usage: ./scripts/watch-ci.sh [-q] <PR_NUMBER|BRANCH_NAME>
+#
+# Exit codes:
+#   0 — all workflows completed and none failed
+#   1 — at least one workflow concluded with failure / cancelled / timed_out
+#       (the script returns as soon as the failing workflow is observed —
+#        it does NOT wait for the rest to finish)
+#   2 — usage / GitHub API error
+#
+# Flags:
+#   -q   quiet — suppress per-cycle status output. Only the final summary
+#        line is printed. Use this when you intend to consume the exit
+#        code programmatically (e.g. an LLM-driven CI monitor) so the
+#        polling output doesn't flood the consumer's context.
+#
+# Tunables (env vars):
+#   WATCH_CI_INTERVAL   poll interval in seconds (default 60)
+#   WATCH_CI_LIMIT      number of recent runs to inspect (default 20)
 
 set -euo pipefail
 
-TARGET="${1:?Usage: watch-ci.sh <PR_NUMBER|BRANCH_NAME>}"
-INTERVAL=60
-
-if [[ "$TARGET" =~ ^[0-9]+$ ]]; then
-  BRANCH=$(gh pr view "$TARGET" --json headRefName -q .headRefName)
-  echo "Watching CI for PR #$TARGET (branch: $BRANCH)"
-else
-  BRANCH="$TARGET"
-  echo "Watching CI for branch: $BRANCH"
+QUIET=false
+if [[ "${1:-}" == "-q" || "${1:-}" == "--quiet" ]]; then
+  QUIET=true
+  shift
 fi
 
-echo "Polling every ${INTERVAL}s..."
-echo ""
+TARGET="${1:?Usage: watch-ci.sh [-q] <PR_NUMBER|BRANCH_NAME>}"
+INTERVAL="${WATCH_CI_INTERVAL:-60}"
+LIMIT="${WATCH_CI_LIMIT:-20}"
+
+log() { $QUIET || echo "$@"; }
+
+if [[ "$TARGET" =~ ^[0-9]+$ ]]; then
+  if ! BRANCH=$(gh pr view "$TARGET" --json headRefName -q .headRefName 2>/dev/null); then
+    echo "✗ Could not resolve PR #$TARGET" >&2
+    exit 2
+  fi
+  log "Watching CI for PR #$TARGET (branch: $BRANCH)"
+else
+  BRANCH="$TARGET"
+  log "Watching CI for branch: $BRANCH"
+fi
+
+log "Polling every ${INTERVAL}s (limit ${LIMIT})..."
+log ""
+
+# Treat anything other than `success` or `skipped` as a failure once a workflow
+# is in `completed` state. `cancelled` / `timed_out` / `action_required` /
+# `neutral` should all stop the wait — they need human attention.
+is_terminal_failure() {
+  case "$1" in
+    success|skipped) return 1 ;;
+    *)               return 0 ;;
+  esac
+}
+
+last_summary=""
 
 while true; do
   TIMESTAMP=$(date '+%H:%M:%S')
-  RESULTS=$(gh run list --branch "$BRANCH" --limit 4 --json name,conclusion,status \
-    -q '.[] | "\(.name)|\(.status)|\(.conclusion)"' 2>/dev/null)
+
+  if ! RESULTS=$(gh run list --branch "$BRANCH" --limit "$LIMIT" \
+                   --json name,conclusion,status \
+                   -q '.[] | "\(.name)|\(.status)|\(.conclusion)"' 2>&1); then
+    echo "✗ gh run list failed: $RESULTS" >&2
+    exit 2
+  fi
 
   if [ -z "$RESULTS" ]; then
-    echo "[$TIMESTAMP] No CI runs found for branch $BRANCH"
+    log "[$TIMESTAMP] No CI runs found for branch $BRANCH yet — waiting..."
     sleep "$INTERVAL"
     continue
   fi
 
   ALL_COMPLETE=true
-  ANY_FAILED=false
+  FAILED_NAME=""
+  FAILED_CONCLUSION=""
+  summary=""
 
-  echo "[$TIMESTAMP] CI Status:"
   while IFS='|' read -r NAME STATUS CONCLUSION; do
+    [ -z "$NAME" ] && continue
     if [ "$STATUS" = "completed" ]; then
       if [ "$CONCLUSION" = "success" ]; then
-        echo "  ✓ $NAME"
+        summary+=$'\n'"  ✓ $NAME"
       elif [ "$CONCLUSION" = "skipped" ]; then
-        echo "  ⊘ $NAME (skipped)"
+        summary+=$'\n'"  ⊘ $NAME (skipped)"
       else
-        echo "  ✗ $NAME ($CONCLUSION)"
-        ANY_FAILED=true
+        summary+=$'\n'"  ✗ $NAME ($CONCLUSION)"
+        if [ -z "$FAILED_NAME" ] && is_terminal_failure "$CONCLUSION"; then
+          FAILED_NAME="$NAME"
+          FAILED_CONCLUSION="$CONCLUSION"
+        fi
       fi
     else
-      echo "  ⏳ $NAME ($STATUS)"
+      summary+=$'\n'"  ⏳ $NAME ($STATUS)"
       ALL_COMPLETE=false
     fi
   done <<< "$RESULTS"
-  echo ""
+
+  # Only emit per-cycle output when the picture changes — keeps -q paths
+  # silent and reduces noise for verbose paths too.
+  if [ "$summary" != "$last_summary" ]; then
+    log "[$TIMESTAMP] CI Status:$summary"
+    log ""
+    last_summary="$summary"
+  fi
+
+  # Fail fast — don't wait for the remaining workflows once one has failed.
+  if [ -n "$FAILED_NAME" ]; then
+    echo "✗ CI FAILED — $FAILED_NAME ($FAILED_CONCLUSION). Inspect with: gh run view --log-failed --branch $BRANCH"
+    if command -v notify-send &>/dev/null; then
+      notify-send "CI Failed" "$FAILED_NAME on $BRANCH" --urgency=critical 2>/dev/null || true
+    fi
+    exit 1
+  fi
 
   if $ALL_COMPLETE; then
-    echo "═══════════════════════════════════"
-    if $ANY_FAILED; then
-      echo "✗ CI FAILED — check logs with: gh run list --branch $BRANCH"
-    else
-      echo "✓ CI PASSED — all checks green"
-    fi
-    echo "═══════════════════════════════════"
-
+    echo "✓ CI PASSED — all checks green on $BRANCH"
     if command -v notify-send &>/dev/null; then
-      if $ANY_FAILED; then
-        notify-send "CI Failed" "Branch: $BRANCH" --urgency=critical
-      else
-        notify-send "CI Passed" "Branch: $BRANCH" --urgency=normal
-      fi
+      notify-send "CI Passed" "Branch: $BRANCH" --urgency=normal 2>/dev/null || true
     fi
-
-    exit $($ANY_FAILED && echo 1 || echo 0)
+    exit 0
   fi
 
   sleep "$INTERVAL"

--- a/scripts/watch-release.sh
+++ b/scripts/watch-release.sh
@@ -1,84 +1,139 @@
 #!/bin/bash
-# watch-release.sh — Poll release workflow status
-# Usage: ./scripts/watch-release.sh [TAG]
+# watch-release.sh — Poll release workflow status.
+#
+# Blocks until every release-triggered workflow completes, exits early on
+# the first failure, and exits 0 only when every workflow ended in
+# `success` or `skipped`. Filters to runs triggered by `release` events
+# (release.yml, docker-publish.yml, desktop-release.yml — not the docs
+# deploy, which fires on `push`).
+#
+# Usage: ./scripts/watch-release.sh [-q] [TAG]
 #
 # Examples:
-#   ./scripts/watch-release.sh v3.10.0-RC1
-#   ./scripts/watch-release.sh              # watches latest release workflows
+#   ./scripts/watch-release.sh -q v4.1.1
+#   ./scripts/watch-release.sh                  # watches latest release
+#
+# The TAG argument is informational only — it appears in log lines and
+# notifications. Workflow filtering is by `--event release`, so any release
+# you publish will be monitored regardless of which tag you pass.
+#
+# Exit codes:
+#   0 — all release workflows completed and none failed
+#   1 — at least one release workflow failed / cancelled / timed_out
+#       (returns as soon as that's observed — does not wait for the rest)
+#   2 — usage / GitHub API error
+#
+# Flags:
+#   -q   quiet — suppress per-cycle status output. Only the final summary
+#        line is printed. Use this for programmatic exit-code consumption
+#        (e.g. an LLM-driven release monitor) so the polling output
+#        doesn't flood the consumer's context.
+#
+# Tunables (env vars):
+#   WATCH_RELEASE_INTERVAL   poll interval in seconds (default 60)
+#   WATCH_RELEASE_LIMIT      number of recent release-event runs to inspect
+#                            (default 10)
 
 set -euo pipefail
 
-TAG="${1:-}"
-INTERVAL=60
-
-if [ -n "$TAG" ]; then
-  echo "Watching release workflows for tag: $TAG"
-else
-  echo "Watching latest release workflows"
+QUIET=false
+if [[ "${1:-}" == "-q" || "${1:-}" == "--quiet" ]]; then
+  QUIET=true
+  shift
 fi
 
-echo "Polling every ${INTERVAL}s..."
-echo ""
+TAG="${1:-}"
+INTERVAL="${WATCH_RELEASE_INTERVAL:-60}"
+LIMIT="${WATCH_RELEASE_LIMIT:-10}"
+
+log() { $QUIET || echo "$@"; }
+
+if [ -n "$TAG" ]; then
+  log "Watching release workflows for tag: $TAG"
+else
+  log "Watching latest release workflows"
+fi
+
+log "Polling every ${INTERVAL}s (limit ${LIMIT})..."
+log ""
+
+# Treat anything other than `success` or `skipped` as a failure once a workflow
+# is in `completed` state.
+is_terminal_failure() {
+  case "$1" in
+    success|skipped) return 1 ;;
+    *)               return 0 ;;
+  esac
+}
+
+last_summary=""
 
 while true; do
   TIMESTAMP=$(date '+%H:%M:%S')
 
-  RESULTS=$(gh run list --limit 6 --event release --json name,conclusion,status,databaseId,createdAt \
-    -q '.[:3] | .[] | "\(.databaseId)|\(.name)|\(.status)|\(.conclusion)"' 2>/dev/null)
+  if ! RESULTS=$(gh run list --limit "$LIMIT" --event release \
+                   --json databaseId,name,conclusion,status,createdAt \
+                   -q '.[] | "\(.databaseId)|\(.name)|\(.status)|\(.conclusion)"' 2>&1); then
+    echo "✗ gh run list failed: $RESULTS" >&2
+    exit 2
+  fi
 
   if [ -z "$RESULTS" ]; then
-    echo "[$TIMESTAMP] No release workflows found"
+    log "[$TIMESTAMP] No release workflows found yet — waiting..."
     sleep "$INTERVAL"
     continue
   fi
 
   ALL_COMPLETE=true
-  ANY_FAILED=false
-  SUMMARY=""
+  FAILED_NAME=""
+  FAILED_CONCLUSION=""
+  FAILED_ID=""
+  summary=""
 
-  echo "[$TIMESTAMP] Release Workflows:"
   while IFS='|' read -r ID NAME STATUS CONCLUSION; do
+    [ -z "$NAME" ] && continue
     if [ "$STATUS" = "completed" ]; then
       if [ "$CONCLUSION" = "success" ]; then
-        echo "  ✓ $NAME"
-        SUMMARY="$SUMMARY ✓"
+        summary+=$'\n'"  ✓ $NAME"
       elif [ "$CONCLUSION" = "skipped" ]; then
-        echo "  ⊘ $NAME (skipped)"
+        summary+=$'\n'"  ⊘ $NAME (skipped)"
       else
-        echo "  ✗ $NAME ($CONCLUSION) — gh run view $ID --log-failed"
-        ANY_FAILED=true
-        SUMMARY="$SUMMARY ✗"
+        summary+=$'\n'"  ✗ $NAME ($CONCLUSION) — gh run view $ID --log-failed"
+        if [ -z "$FAILED_NAME" ] && is_terminal_failure "$CONCLUSION"; then
+          FAILED_NAME="$NAME"
+          FAILED_CONCLUSION="$CONCLUSION"
+          FAILED_ID="$ID"
+        fi
       fi
     else
-      echo "  ⏳ $NAME ($STATUS)"
+      summary+=$'\n'"  ⏳ $NAME ($STATUS)"
       ALL_COMPLETE=false
-      SUMMARY="$SUMMARY ⏳"
     fi
   done <<< "$RESULTS"
-  echo ""
+
+  # Only print when the picture changes — keeps -q paths silent and
+  # reduces noise for verbose paths too.
+  if [ "$summary" != "$last_summary" ]; then
+    log "[$TIMESTAMP] Release Workflows:$summary"
+    log ""
+    last_summary="$summary"
+  fi
+
+  # Fail fast — don't wait for the remaining workflows once one has failed.
+  if [ -n "$FAILED_NAME" ]; then
+    echo "✗ RELEASE FAILED — $FAILED_NAME ($FAILED_CONCLUSION). Inspect: gh run view $FAILED_ID --log-failed"
+    if command -v notify-send &>/dev/null; then
+      notify-send "Release Failed" "${TAG:-latest} — $FAILED_NAME" --urgency=critical 2>/dev/null || true
+    fi
+    exit 1
+  fi
 
   if $ALL_COMPLETE; then
-    echo "═══════════════════════════════════"
-    if $ANY_FAILED; then
-      echo "✗ RELEASE WORKFLOWS FAILED"
-      echo ""
-      echo "Check failures with:"
-      gh run list --limit 3 --event release --json name,conclusion,databaseId \
-        -q '.[] | select(.conclusion == "failure") | "  gh run view \(.databaseId) --log-failed  # \(.name)"' 2>/dev/null
-    else
-      echo "✓ ALL RELEASE WORKFLOWS PASSED"
-    fi
-    echo "═══════════════════════════════════"
-
+    echo "✓ RELEASE PASSED — all release workflows green${TAG:+ for $TAG}"
     if command -v notify-send &>/dev/null; then
-      if $ANY_FAILED; then
-        notify-send "Release Failed" "${TAG:-latest}" --urgency=critical 2>/dev/null || true
-      else
-        notify-send "Release Passed" "${TAG:-latest}" --urgency=normal 2>/dev/null || true
-      fi
+      notify-send "Release Passed" "${TAG:-latest}" --urgency=normal 2>/dev/null || true
     fi
-
-    exit $($ANY_FAILED && echo 1 || echo 0)
+    exit 0
   fi
 
   sleep "$INTERVAL"


### PR DESCRIPTION
## Summary

The previous `/ci-monitor` workflow had the LLM polling `gh run list` every 60s itself — fine for fast suites, but a 15–30 minute system-tests run flooded the conversation context with hundreds of lines of status. Same problem was about to repeat for release monitoring.

This PR pushes the polling work entirely down into `scripts/watch-ci.sh` and the existing `scripts/watch-release.sh`, exposes both as a `-q`/`--quiet` mode, and adds a matching `/release-monitor` skill.

## What changed

### `scripts/watch-ci.sh` and `scripts/watch-release.sh`
- `-q` / `--quiet` flag — suppresses per-cycle status. Only the final pass/fail line and the exit code make it out.
- **Fail-fast** — return as soon as any workflow concludes with `failure` / `cancelled` / `timed_out`, rather than waiting for the remaining workflows to also finish.
- **Single canonical exit code:** `0` = all green (success/skipped), `1` = first failure observed, `2` = usage / `gh` API error.
- Verbose mode now only prints when the picture changes — less noise even in interactive use.
- `notify-send` stderr is redirected (missing dbus daemons no longer leak `GDBus.Error` lines).
- New env tunables: `WATCH_CI_INTERVAL`, `WATCH_CI_LIMIT`, `WATCH_RELEASE_INTERVAL`, `WATCH_RELEASE_LIMIT`.
- Bumped default `--limit` to cover the full set of release workflows (old `--limit 6 | .[:3]` capped at 3 results).

### `.claude/skills/ci-monitor.md` + `.claude/commands/ci-monitor.md`
Phase 1 now delegates entirely to `bash scripts/watch-ci.sh -q <PR>` and dispatches on the exit code. The skill explicitly tells the model **not** to poll `gh run list` itself.

### `.claude/skills/release-monitor.md` + `.claude/commands/release-monitor.md` (new)
Same exit-code-driven pattern for the release pipeline. Categorizes failures into infra/flake (auto-rerun), platform-image regression (escalate), test/build failure (escalate), and auth (escalate). Caps auto-reruns at 2 per workflow.

## Verification

- Smoke-tested `bash scripts/watch-ci.sh -q 2869` to green during the 4.1.1 release PR — exited `0` with a single line of output.
- All four notify-send call sites now redirect stderr; ran on the dev box where dbus is absent and confirmed no `GDBus.Error` leak.

## Test plan
- [x] Run `bash scripts/watch-ci.sh -q <pr>` against a green PR and confirm exit 0
- [ ] Run against a red PR and confirm exit 1
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)