### PR TITLE
fix(nodes): keep PG/MySQL nodesCache coherent via NodesRepository hook (#2858)

### DIFF
--- a/src/db/repositories/index.ts
+++ b/src/db/repositories/index.ts
@@ -8,7 +8,7 @@ export { BaseRepository } from './base.js';
 export type { DrizzleDatabase, SQLiteDrizzle, PostgresDrizzle } from './base.js';
 export { SettingsRepository } from './settings.js';
 export { ChannelsRepository, type ChannelInput } from './channels.js';
-export { NodesRepository } from './nodes.js';
+export { NodesRepository, type NodesCacheHook } from './nodes.js';
 export { MessagesRepository } from './messages.js';
 export { TelemetryRepository } from './telemetry.js';
 export { AuthRepository } from './auth.js';

--- a/src/db/repositories/nodes.test.ts
+++ b/src/db/repositories/nodes.test.ts
@@ -821,6 +821,120 @@ function runNodesTests(getBackend: () => TestBackend) {
     expect(node).not.toBeNull();
     expect(node!.nodeNum).toBe(largeNum);
   });
+
+  // --- Cache hook (regression for issue #2858) ---
+  // PG/MySQL only — SQLite paths skip the hook by design (no in-memory cache).
+
+  it('cache hook - upsertNode notifies setNode for PG/MySQL', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    const calls: Array<{ method: string; nodeNum: number; sourceId?: string; node: any | null }> = [];
+    repo.setCacheHook({
+      setNode: (nodeNum, sourceId, node) => calls.push({ method: 'setNode', nodeNum, sourceId, node }),
+      setNodeAcrossSources: (nodeNum, nodes) => calls.push({ method: 'setNodeAcrossSources', nodeNum, node: nodes }),
+      setNodeByNodeId: (_nodeId, nodes) => calls.push({ method: 'setNodeByNodeId', nodeNum: -1, node: nodes }),
+      clear: () => calls.push({ method: 'clear', nodeNum: -1, node: null }),
+    });
+
+    await repo.upsertNode(makeNode(2000), 'src-A');
+
+    if (backend.dbType === 'sqlite') {
+      // SQLite skips the hook by design — cache is PG/MySQL-only.
+      expect(calls.length).toBe(0);
+    } else {
+      const setCall = calls.find(c => c.method === 'setNode' && c.nodeNum === 2000);
+      expect(setCall).toBeDefined();
+      expect(setCall!.sourceId).toBe('src-A');
+      expect(setCall!.node).not.toBeNull();
+      expect(setCall!.node.nodeNum).toBe(2000);
+      expect(setCall!.node.longName).toBe('Node 2000');
+    }
+  });
+
+  it('cache hook - deleteNodeRecord notifies setNode with null', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.upsertNode(makeNode(2100), 'src-A');
+
+    const calls: Array<{ nodeNum: number; sourceId: string; node: any | null }> = [];
+    repo.setCacheHook({
+      setNode: (nodeNum, sourceId, node) => calls.push({ nodeNum, sourceId, node }),
+      setNodeAcrossSources: () => {},
+      setNodeByNodeId: () => {},
+      clear: () => {},
+    });
+
+    const removed = await repo.deleteNodeRecord(2100, 'src-A');
+    expect(removed).toBe(true);
+
+    if (backend.dbType === 'sqlite') {
+      expect(calls.length).toBe(0);
+    } else {
+      const removalCall = calls.find(c => c.nodeNum === 2100 && c.node === null);
+      expect(removalCall).toBeDefined();
+      expect(removalCall!.sourceId).toBe('src-A');
+    }
+  });
+
+  it('cache hook - setNodeFavorite notifies setNode with refreshed row (PG/MySQL only)', async () => {
+    const backend = getBackend();
+    if (!backend.available || backend.dbType === 'sqlite') {
+      console.log(`⚠ Skipped: SQLite skips cache hook (PG/MySQL only feature)`);
+      return;
+    }
+
+    await repo.upsertNode(makeNode(2200), 'src-A');
+
+    const calls: any[] = [];
+    repo.setCacheHook({
+      setNode: (nodeNum, sourceId, node) => calls.push({ nodeNum, sourceId, node }),
+      setNodeAcrossSources: () => {},
+      setNodeByNodeId: () => {},
+      clear: () => {},
+    });
+
+    await repo.setNodeFavorite(2200, true, 'src-A');
+
+    expect(calls.length).toBeGreaterThan(0);
+    const fav = calls.find(c => c.nodeNum === 2200);
+    expect(fav).toBeDefined();
+    expect(fav.node).not.toBeNull();
+    expect(fav.node.isFavorite).toBe(true);
+  });
+
+  it('cache hook - deleteAllNodes triggers clear', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    await repo.upsertNode(makeNode(2300), 'src-A');
+
+    let cleared = 0;
+    repo.setCacheHook({
+      setNode: () => {},
+      setNodeAcrossSources: () => {},
+      setNodeByNodeId: () => {},
+      clear: () => { cleared++; },
+    });
+
+    await repo.deleteAllNodes();
+
+    if (backend.dbType === 'sqlite') {
+      expect(cleared).toBe(0);
+    } else {
+      expect(cleared).toBe(1);
+    }
+  });
 }
 
 // --- SQLite Backend ---

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -10,11 +10,102 @@ import { DatabaseType, DbNode } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
 /**
+ * Hook for keeping an external in-memory node cache coherent with PG/MySQL writes.
+ *
+ * Background: DatabaseService maintains a `nodesCache` (PG/MySQL only) for sync-method
+ * compatibility. The cache is loaded once at startup, but production writes flow
+ * through this repository directly — bypassing the DatabaseService facade — so without
+ * this hook the cache goes stale after every new node discovery (issue #2858).
+ *
+ * The repository fetches authoritative rows from the DB before invoking the hook so
+ * the cache always reflects DB state, not the repo's pre-write inputs.
+ *
+ * SQLite paths skip the hook entirely (the SQLite cache is structured differently
+ * and reads from DB directly).
+ */
+export interface NodesCacheHook {
+  /** Replace or remove a single (nodeNum, sourceId) cache entry. node=null removes. */
+  setNode(nodeNum: number, sourceId: string, node: DbNode | null): void;
+  /** Replace all cache entries for nodeNum. Removes entries not present in `nodes`. */
+  setNodeAcrossSources(nodeNum: number, nodes: DbNode[]): void;
+  /** Replace all cache entries matching nodeId. Removes entries not present in `nodes`. */
+  setNodeByNodeId(nodeId: string, nodes: DbNode[]): void;
+  /** Clear the entire cache. */
+  clear(): void;
+}
+
+/**
  * Repository for node operations
  */
 export class NodesRepository extends BaseRepository {
+  private cacheHook: NodesCacheHook | null = null;
+
   constructor(db: DrizzleDatabase, dbType: DatabaseType) {
     super(db, dbType);
+  }
+
+  /**
+   * Register a cache hook to be notified of node writes (PG/MySQL only).
+   * Pass null to detach. See {@link NodesCacheHook} for semantics.
+   */
+  setCacheHook(hook: NodesCacheHook | null): void {
+    this.cacheHook = hook;
+  }
+
+  private cacheEnabled(): boolean {
+    return this.cacheHook !== null && (this.dbType === 'postgres' || this.dbType === 'mysql');
+  }
+
+  private async syncCacheNode(nodeNum: number, sourceId: string): Promise<void> {
+    if (!this.cacheEnabled()) return;
+    try {
+      const fresh = await this.getNode(nodeNum, sourceId);
+      this.cacheHook!.setNode(nodeNum, sourceId, fresh);
+    } catch (err) {
+      logger.error('NodesRepository cache sync (single) failed:', err);
+    }
+  }
+
+  private async syncCacheAcrossSources(nodeNum: number): Promise<void> {
+    if (!this.cacheEnabled()) return;
+    try {
+      const { nodes } = this.tables;
+      const rows = await this.db.select().from(nodes).where(eq(nodes.nodeNum, nodeNum));
+      const fresh = (this.normalizeBigInts(rows) ?? []) as DbNode[];
+      this.cacheHook!.setNodeAcrossSources(nodeNum, fresh);
+    } catch (err) {
+      logger.error('NodesRepository cache sync (cross-source) failed:', err);
+    }
+  }
+
+  private async syncCacheByNodeId(nodeId: string): Promise<void> {
+    if (!this.cacheEnabled()) return;
+    try {
+      const { nodes } = this.tables;
+      const rows = await this.db.select().from(nodes).where(eq(nodes.nodeId, nodeId));
+      const fresh = (this.normalizeBigInts(rows) ?? []) as DbNode[];
+      this.cacheHook!.setNodeByNodeId(nodeId, fresh);
+    } catch (err) {
+      logger.error('NodesRepository cache sync (by-nodeId) failed:', err);
+    }
+  }
+
+  private removeCacheNode(nodeNum: number, sourceId: string): void {
+    if (!this.cacheEnabled()) return;
+    try {
+      this.cacheHook!.setNode(nodeNum, sourceId, null);
+    } catch (err) {
+      logger.error('NodesRepository cache remove failed:', err);
+    }
+  }
+
+  private clearCacheAll(): void {
+    if (!this.cacheEnabled()) return;
+    try {
+      this.cacheHook!.clear();
+    } catch (err) {
+      logger.error('NodesRepository cache clear failed:', err);
+    }
   }
 
   /**
@@ -325,6 +416,8 @@ export class NodesRepository extends BaseRepository {
 
       await this.upsert(nodes, newNode, [nodes.nodeNum, nodes.sourceId], upsertSet);
     }
+
+    await this.syncCacheNode(nodeData.nodeNum, effectiveSourceId);
   }
 
   /**
@@ -336,6 +429,8 @@ export class NodesRepository extends BaseRepository {
       .update(nodes)
       .set(updates as any)
       .where(eq(nodes.nodeNum, nodeNum));
+
+    await this.syncCacheAcrossSources(nodeNum);
   }
 
   /**
@@ -352,6 +447,8 @@ export class NodesRepository extends BaseRepository {
       .update(nodes)
       .set({ lastMessageHops: hops, updatedAt: now })
       .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+
+    await this.syncCacheNode(nodeNum, sourceId);
   }
 
   /**
@@ -377,6 +474,7 @@ export class NodesRepository extends BaseRepository {
         .update(nodes)
         .set({ welcomedAt: now })
         .where(eq(nodes.nodeNum, node.nodeNum));
+      await this.syncCacheAcrossSources(node.nodeNum);
     }
     return toUpdate.length;
   }
@@ -407,6 +505,7 @@ export class NodesRepository extends BaseRepository {
         .update(nodes)
         .set({ welcomedAt: now, updatedAt: now })
         .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+      await this.syncCacheNode(nodeNum, sourceId);
       return true;
     }
     return false;
@@ -476,6 +575,8 @@ export class NodesRepository extends BaseRepository {
         updatedAt: now,
       })
       .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+
+    await this.syncCacheNode(nodeNum, sourceId);
   }
 
   /**
@@ -526,6 +627,8 @@ export class NodesRepository extends BaseRepository {
         updatedAt: now,
       })
       .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+
+    await this.syncCacheNode(nodeNum, sourceId);
   }
 
   /**
@@ -543,6 +646,8 @@ export class NodesRepository extends BaseRepository {
     await this.db
       .delete(nodes)
       .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+
+    this.removeCacheNode(nodeNum, sourceId);
     return true;
   }
 
@@ -554,7 +659,7 @@ export class NodesRepository extends BaseRepository {
     const { nodes } = this.tables;
 
     const toDelete = await this.db
-      .select({ nodeNum: nodes.nodeNum })
+      .select({ nodeNum: nodes.nodeNum, sourceId: nodes.sourceId })
       .from(nodes)
       .where(
         and(
@@ -571,6 +676,7 @@ export class NodesRepository extends BaseRepository {
 
     for (const node of toDelete) {
       await this.db.delete(nodes).where(eq(nodes.nodeNum, node.nodeNum));
+      this.removeCacheNode(node.nodeNum, node.sourceId);
     }
     return toDelete.length;
   }
@@ -591,6 +697,8 @@ export class NodesRepository extends BaseRepository {
       .update(nodes)
       .set(setData)
       .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+
+    await this.syncCacheNode(nodeNum, sourceId);
   }
 
   /**
@@ -604,6 +712,8 @@ export class NodesRepository extends BaseRepository {
       .update(nodes)
       .set({ favoriteLocked, updatedAt: now })
       .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+
+    await this.syncCacheNode(nodeNum, sourceId);
   }
 
   /**
@@ -617,6 +727,8 @@ export class NodesRepository extends BaseRepository {
       .update(nodes)
       .set({ isIgnored, updatedAt: now })
       .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+
+    await this.syncCacheNode(nodeNum, sourceId);
   }
 
   /**
@@ -628,6 +740,8 @@ export class NodesRepository extends BaseRepository {
       .update(nodes)
       .set({ mobile })
       .where(eq(nodes.nodeId, nodeId));
+
+    await this.syncCacheByNodeId(nodeId);
   }
 
   /**
@@ -641,6 +755,8 @@ export class NodesRepository extends BaseRepository {
       .update(nodes)
       .set({ lastTracerouteRequest: timestamp, updatedAt: now })
       .where(eq(nodes.nodeNum, nodeNum));
+
+    await this.syncCacheAcrossSources(nodeNum);
   }
 
   /**
@@ -649,7 +765,7 @@ export class NodesRepository extends BaseRepository {
   async deleteInactiveNodes(cutoffTimestamp: number): Promise<number> {
     const { nodes } = this.tables;
     const toDelete = await this.db
-      .select({ nodeNum: nodes.nodeNum })
+      .select({ nodeNum: nodes.nodeNum, sourceId: nodes.sourceId })
       .from(nodes)
       .where(
         and(
@@ -660,6 +776,7 @@ export class NodesRepository extends BaseRepository {
 
     for (const node of toDelete) {
       await this.db.delete(nodes).where(eq(nodes.nodeNum, node.nodeNum));
+      this.removeCacheNode(node.nodeNum, node.sourceId);
     }
     return toDelete.length;
   }
@@ -673,6 +790,7 @@ export class NodesRepository extends BaseRepository {
       .select({ nodeNum: nodes.nodeNum })
       .from(nodes);
     await this.db.delete(nodes);
+    this.clearCacheAll();
     return result.length;
   }
 
@@ -685,6 +803,8 @@ export class NodesRepository extends BaseRepository {
       .update(nodes)
       .set({ lastTracerouteRequest: timestamp })
       .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+
+    await this.syncCacheNode(nodeNum, sourceId);
   }
 
   /**
@@ -884,6 +1004,8 @@ export class NodesRepository extends BaseRepository {
       .update(nodes)
       .set(updateData as any)
       .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+
+    await this.syncCacheNode(nodeNum, sourceId);
   }
 
   /**
@@ -941,6 +1063,8 @@ export class NodesRepository extends BaseRepository {
       .update(nodes)
       .set({ lastTimeSync: timestamp, updatedAt: now })
       .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+
+    await this.syncCacheNode(nodeNum, sourceId);
   }
 
   /**
@@ -965,6 +1089,8 @@ export class NodesRepository extends BaseRepository {
         updatedAt: now,
       } as any)
       .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+
+    await this.syncCacheNode(nodeNum, sourceId);
   }
 
   /**
@@ -987,6 +1113,8 @@ export class NodesRepository extends BaseRepository {
         updatedAt: now,
       } as any)
       .where(and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId)));
+
+    await this.syncCacheNode(nodeNum, sourceId);
   }
 
   /**
@@ -1010,6 +1138,10 @@ export class NodesRepository extends BaseRepository {
     await this.db
       .delete(nodes)
       .where(and(lt(nodes.lastHeard, cutoff), eq(nodes.sourceId, sourceId)));
+
+    for (const row of matching) {
+      this.removeCacheNode(row.nodeNum, sourceId);
+    }
 
     return matching.length;
   }

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -293,6 +293,70 @@ class DatabaseService {
   }
 
   /**
+   * Convert a repository-shaped node row (with `null` for missing fields and a
+   * `sourceId` column) into the local DatabaseService cache shape (with
+   * `undefined` for optional fields). Mirrors the conversion in
+   * loadCachesFromDatabase so cache writes from the repo cache hook stay
+   * structurally identical to the startup-loaded entries.
+   */
+  private repoNodeToCacheNode(node: any, sourceId: string): DbNode {
+    return {
+      nodeNum: node.nodeNum,
+      nodeId: node.nodeId,
+      longName: node.longName ?? '',
+      shortName: node.shortName ?? '',
+      hwModel: node.hwModel ?? 0,
+      role: node.role ?? undefined,
+      hopsAway: node.hopsAway ?? undefined,
+      lastMessageHops: node.lastMessageHops ?? undefined,
+      viaMqtt: node.viaMqtt ?? undefined,
+      macaddr: node.macaddr ?? undefined,
+      latitude: node.latitude ?? undefined,
+      longitude: node.longitude ?? undefined,
+      altitude: node.altitude ?? undefined,
+      batteryLevel: node.batteryLevel ?? undefined,
+      voltage: node.voltage ?? undefined,
+      channelUtilization: node.channelUtilization ?? undefined,
+      airUtilTx: node.airUtilTx ?? undefined,
+      lastHeard: node.lastHeard ?? undefined,
+      snr: node.snr ?? undefined,
+      rssi: node.rssi ?? undefined,
+      lastTracerouteRequest: node.lastTracerouteRequest ?? undefined,
+      firmwareVersion: node.firmwareVersion ?? undefined,
+      channel: node.channel ?? undefined,
+      isFavorite: node.isFavorite ?? undefined,
+      favoriteLocked: node.favoriteLocked ?? undefined,
+      isIgnored: node.isIgnored ?? undefined,
+      mobile: node.mobile ?? undefined,
+      rebootCount: node.rebootCount ?? undefined,
+      publicKey: node.publicKey ?? undefined,
+      hasPKC: node.hasPKC ?? undefined,
+      lastPKIPacket: node.lastPKIPacket ?? undefined,
+      keyIsLowEntropy: node.keyIsLowEntropy ?? undefined,
+      duplicateKeyDetected: node.duplicateKeyDetected ?? undefined,
+      keyMismatchDetected: node.keyMismatchDetected ?? undefined,
+      keySecurityIssueDetails: node.keySecurityIssueDetails ?? undefined,
+      welcomedAt: node.welcomedAt ?? undefined,
+      positionChannel: node.positionChannel ?? undefined,
+      positionPrecisionBits: node.positionPrecisionBits ?? undefined,
+      positionGpsAccuracy: node.positionGpsAccuracy ?? undefined,
+      positionHdop: node.positionHdop ?? undefined,
+      positionTimestamp: node.positionTimestamp ?? undefined,
+      positionOverrideEnabled: node.positionOverrideEnabled ?? undefined,
+      latitudeOverride: node.latitudeOverride ?? undefined,
+      longitudeOverride: node.longitudeOverride ?? undefined,
+      altitudeOverride: node.altitudeOverride ?? undefined,
+      positionOverrideIsPrivate: node.positionOverrideIsPrivate ?? undefined,
+      hasRemoteAdmin: node.hasRemoteAdmin ?? undefined,
+      lastRemoteAdminCheck: node.lastRemoteAdminCheck ?? undefined,
+      remoteAdminMetadata: node.remoteAdminMetadata ?? undefined,
+      sourceId: node.sourceId ?? sourceId,
+      createdAt: node.createdAt,
+      updatedAt: node.updatedAt,
+    } as DbNode;
+  }
+
+  /**
    * Phase 3B: Iterate cache, optionally filtered by sourceId.
    */
   private *iterateCache(sourceId?: string): IterableIterator<DbNode> {
@@ -694,6 +758,54 @@ class DatabaseService {
       this.settingsRepo = new SettingsRepository(drizzleDb, this.drizzleDbType);
       this.channelsRepo = new ChannelsRepository(drizzleDb, this.drizzleDbType);
       this.nodesRepo = new NodesRepository(drizzleDb, this.drizzleDbType);
+      // Wire the in-memory nodesCache to repository writes so PG/MySQL caches
+      // stay coherent with DB state — fixes #2858 where bypassing the facade
+      // (e.g. via `databaseService.nodes.upsertNode(...)`) left newly-discovered
+      // nodes invisible to sync cache readers like setNodePositionOverride.
+      this.nodesRepo.setCacheHook({
+        setNode: (nodeNum, sourceId, node) => {
+          const key = this.cacheKey(nodeNum, sourceId);
+          if (!node) {
+            this.nodesCache.delete(key);
+            return;
+          }
+          this.nodesCache.set(key, this.repoNodeToCacheNode(node, sourceId));
+        },
+        setNodeAcrossSources: (nodeNum, freshNodes) => {
+          // Remove existing cache entries for this nodeNum that aren't in freshNodes,
+          // then upsert each fresh row.
+          const keepSourceIds = new Set(freshNodes.map(n => (n as any).sourceId ?? 'default'));
+          for (const key of Array.from(this.nodesCache.keys())) {
+            const cached = this.nodesCache.get(key);
+            if (cached && cached.nodeNum === nodeNum && !keepSourceIds.has(cached.sourceId ?? 'default')) {
+              this.nodesCache.delete(key);
+            }
+          }
+          for (const fresh of freshNodes) {
+            const sid = (fresh as any).sourceId ?? 'default';
+            this.nodesCache.set(this.cacheKey(nodeNum, sid), this.repoNodeToCacheNode(fresh, sid));
+          }
+        },
+        setNodeByNodeId: (nodeId, freshNodes) => {
+          // Replace all cache entries for this nodeId with the fresh set.
+          const keepKeys = new Set(
+            freshNodes.map(n => this.cacheKey(n.nodeNum, (n as any).sourceId ?? 'default'))
+          );
+          for (const key of Array.from(this.nodesCache.keys())) {
+            const cached = this.nodesCache.get(key);
+            if (cached && cached.nodeId === nodeId && !keepKeys.has(key)) {
+              this.nodesCache.delete(key);
+            }
+          }
+          for (const fresh of freshNodes) {
+            const sid = (fresh as any).sourceId ?? 'default';
+            this.nodesCache.set(this.cacheKey(fresh.nodeNum, sid), this.repoNodeToCacheNode(fresh, sid));
+          }
+        },
+        clear: () => {
+          this.nodesCache.clear();
+        },
+      });
       this.messagesRepo = new MessagesRepository(drizzleDb, this.drizzleDbType);
       this.telemetryRepo = new TelemetryRepository(drizzleDb, this.drizzleDbType);
       // Auth repo for all backends - Migration 012 aligned SQLite schema with Drizzle definitions


### PR DESCRIPTION
## Summary

Fixes #2858 — fresh PostgreSQL / MySQL installs threw `Node !XXXXXXXX not found` when setting a position override for a node that was visible on the map.

**Root cause:** `meshtasticManager` writes node rows via `databaseService.nodes.upsertNode(...)` (the repository), bypassing the cache-aware `DatabaseService.upsertNode()` facade. The PG/MySQL `nodesCache` was only loaded once at startup, so every node discovered after server start lived in DB but not in cache. Sync cache readers like `setNodePositionOverride` then threw on cache miss.

**Fix:** Introduce a `NodesCacheHook` on `NodesRepository`. After every PG/MySQL write, the repo re-reads authoritative DB state and notifies the hook. `DatabaseService.initializeRepositories()` registers a hook that mirrors changes into `nodesCache`, normalizing repo-`null` fields to local-`undefined` (mirroring the existing `loadCachesFromDatabase` converter). SQLite is unaffected — the hook is a no-op there.

Covers all repo write paths: `upsertNode`, `updateNode*`, `setNodeFavorite`/`Locked`, `setNodeIgnored`, `updateNodeMobility`, mobility/welcome/security/spam/time-offset/time-sync flag updates, and all delete/cleanup paths.

## Test plan

- [x] Repository tests pass on SQLite, PostgreSQL, and MySQL (111/111 in `nodes.test.ts`)
- [x] Full repository suite green (843/843 in `src/db/repositories/`)
- [x] DatabaseService tests green (288/288 in `src/services/`)
- [x] Server route tests green (47/47 in `server.test.ts` + `server.estimatedposition.test.ts`)
- [x] `tsc --noEmit` clean
- [x] No new ESLint errors (4 errors are pre-existing on `main`)
- [x] 4 new regression tests covering hook semantics: upsert notifies, delete clears, field-update refreshes, deleteAll clears
- [ ] Manual verification on fresh PG dev container: position override on a freshly-discovered node should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)