### PR TITLE
fix(docker): install tzdata in Alpine runtime image (#2875)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ WORKDIR /app
 # Create python symlink for user scripts that use #!/usr/bin/env python
 RUN apk add --no-cache \
     curl \
+    tzdata \
     unzip \
     python3 \
     py3-pip \


### PR DESCRIPTION
## Summary

- Add `tzdata` to the Alpine runtime stage in `Dockerfile`
- Without it, musl libc cannot resolve the `TZ` env var and silently falls back to UTC, ignoring user-configured timezones in `docker-compose.yml`
- Closes #2875

## Root cause

Alpine images do not ship the IANA timezone database (`/usr/share/zoneinfo/`). When users set `TZ=Europe/Belgrade` (or any zone), musl returns UTC because the zone files are missing. The `date` shell command sometimes still works due to kernel-level fallbacks, masking the issue, but Node.js's `Date` / `Intl` APIs that rely on libc tz resolution return UTC.

The reporter tried `apk add tzdata` inside the running container, but that does not persist across image rebuilds. The fix needs to land at image-build time.

## Verification

Built and deployed locally:

- `/usr/share/zoneinfo/Europe/Belgrade` now exists in the image
- `TZ=Europe/Belgrade node -e "console.log(new Date().toString())"` → `GMT+0200 (Central European Summer Time)` (was `GMT+0000` before)
- Container health check passes, all migrations run cleanly

## Test plan

- [x] Verify `tzdata` files present in image (`ls /usr/share/zoneinfo/Europe/Belgrade`)
- [x] Verify Node.js resolves non-UTC zones with `TZ` env var
- [x] Verify container starts cleanly and HTTP endpoint responds
- [ ] CI: image build succeeds across all platforms
- [ ] CI: existing test suite passes (no test changes required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)