### PR TITLE
feat(embed): add per-source filter to embed profiles

### DIFF
--- a/src/components/settings/EmbedSettings.tsx
+++ b/src/components/settings/EmbedSettings.tsx
@@ -8,6 +8,7 @@ import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { useToast } from '../ToastContainer';
 import { getAllTilesets } from '../../config/tilesets';
 import { useSettings } from '../../contexts/SettingsContext';
+import { useDashboardSources } from '../../hooks/useDashboardData';
 import './EmbedSettings.css';
 
 // Fix default marker icon for Leaflet in bundled builds
@@ -40,6 +41,7 @@ interface EmbedProfile {
   showMqttNodes: boolean;
   pollIntervalSeconds: number;
   allowedOrigins: string[];
+  sourceId: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -62,6 +64,7 @@ const DEFAULT_FORM: ProfileFormData = {
   showMqttNodes: true,
   pollIntervalSeconds: 30,
   allowedOrigins: [],
+  sourceId: null,
 };
 
 // ---------------------------------------------------------------------------
@@ -110,6 +113,7 @@ const EmbedSettings = () => {
   const csrfFetch = useCsrfFetch();
   const { showToast } = useToast();
   const { customTilesets } = useSettings();
+  const { data: sources = [] } = useDashboardSources();
 
   const [profiles, setProfiles] = useState<EmbedProfile[]>([]);
   const [loading, setLoading] = useState(true);
@@ -200,6 +204,7 @@ const EmbedSettings = () => {
       showMqttNodes: profile.showMqttNodes,
       pollIntervalSeconds: profile.pollIntervalSeconds,
       allowedOrigins: [...profile.allowedOrigins],
+      sourceId: profile.sourceId ?? null,
     });
     setOriginsText(profile.allowedOrigins.join(', '));
     setEditingId(profile.id);
@@ -431,6 +436,33 @@ const EmbedSettings = () => {
                     </label>
                   ))}
                 </div>
+              </div>
+
+              {/* Source filter — null = all sources */}
+              <div className="setting-item">
+                <label htmlFor="embed-source">
+                  {t('settings.embed.source', 'Source')}
+                </label>
+                <select
+                  id="embed-source"
+                  className="setting-input embed-input-wide"
+                  value={form.sourceId ?? ''}
+                  onChange={e =>
+                    setForm(prev => ({
+                      ...prev,
+                      sourceId: e.target.value === '' ? null : e.target.value,
+                    }))
+                  }
+                >
+                  <option value="">
+                    {t('settings.embed.source_all', 'All sources')}
+                  </option>
+                  {sources.map(s => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </select>
               </div>
 
               {/* Tileset */}

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 51 migrations registered', () => {
-    expect(registry.count()).toBe(51);
+  it('has all 52 migrations registered', () => {
+    expect(registry.count()).toBe(52);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,14 +12,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is drop_legacy_notif_prefs_userid_unique', () => {
+  it('last migration is add_source_id_to_embed_profiles', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(51);
-    expect(last.name).toContain('drop_legacy_notif_prefs_userid_unique');
+    expect(last.number).toBe(52);
+    expect(last.name).toContain('add_source_id_to_embed_profiles');
   });
 
-  it('migrations are sequentially numbered from 1 to 51', () => {
+  it('migrations are sequentially numbered from 1 to 52', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -63,6 +63,7 @@ import { migration as rebuildIgnoredNodesPerSourceMigration, runMigration048Post
 import { migration as perfCompositeIndexesMigration, runMigration049Postgres, runMigration049Mysql } from '../server/migrations/049_perf_composite_indexes.js';
 import { migration as promoteGlobalsToDefaultSourceMigration, runMigration050Postgres, runMigration050Mysql } from '../server/migrations/050_promote_globals_to_default_source.js';
 import { migration as dropLegacyNotifPrefsUserIdUniqueMigration, runMigration051Postgres, runMigration051Mysql } from '../server/migrations/051_drop_legacy_notif_prefs_userid_unique.js';
+import { migration as addSourceIdToEmbedProfilesMigration, runMigration052Postgres, runMigration052Mysql } from '../server/migrations/052_add_source_id_to_embed_profiles.js';
 
 // ============================================================================
 // Registry
@@ -797,4 +798,19 @@ registry.register({
   sqlite: (db) => dropLegacyNotifPrefsUserIdUniqueMigration.up(db),
   postgres: (client) => runMigration051Postgres(client),
   mysql: (pool) => runMigration051Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 052: Add nullable sourceId column to embed_profiles. NULL = "all
+// sources" (preserves pre-migration behaviour where embed routes returned
+// data unfiltered across sources).
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 52,
+  name: 'add_source_id_to_embed_profiles',
+  settingsKey: 'migration_052_add_source_id_to_embed_profiles',
+  sqlite: (db) => addSourceIdToEmbedProfilesMigration.up(db),
+  postgres: (client) => runMigration052Postgres(client),
+  mysql: (pool) => runMigration052Mysql(pool),
 });

--- a/src/db/repositories/embedProfiles.test.ts
+++ b/src/db/repositories/embedProfiles.test.ts
@@ -37,6 +37,7 @@ describe('EmbedProfileRepository', () => {
         showMqttNodes INTEGER NOT NULL DEFAULT 1,
         pollIntervalSeconds INTEGER NOT NULL DEFAULT 30,
         allowedOrigins TEXT NOT NULL DEFAULT '[]',
+        sourceId TEXT,
         createdAt INTEGER NOT NULL,
         updatedAt INTEGER NOT NULL
       )
@@ -78,6 +79,7 @@ describe('EmbedProfileRepository', () => {
       showMqttNodes: true,
       pollIntervalSeconds: 30,
       allowedOrigins: ['https://example.com'],
+      sourceId: null,
     };
 
     const created = await repo.createAsync(input);
@@ -119,6 +121,7 @@ describe('EmbedProfileRepository', () => {
       showMqttNodes: true,
       pollIntervalSeconds: 30,
       allowedOrigins: [],
+      sourceId: null,
     };
 
     await repo.createAsync(input);
@@ -161,6 +164,7 @@ describe('EmbedProfileRepository', () => {
       showMqttNodes: true,
       pollIntervalSeconds: 30,
       allowedOrigins: [],
+      sourceId: null,
     };
 
     await repo.createAsync(input);
@@ -174,6 +178,37 @@ describe('EmbedProfileRepository', () => {
   it('should return false when deleting non-existent profile', async () => {
     const result = await repo.deleteAsync('nonexistent');
     expect(result).toBe(false);
+  });
+
+  it('should persist and roundtrip sourceId', async () => {
+    const input: EmbedProfileInput = {
+      id: 'src-test',
+      name: 'Source Scoped',
+      enabled: true,
+      channels: [0],
+      tileset: 'osm',
+      defaultLat: 0,
+      defaultLng: 0,
+      defaultZoom: 10,
+      showTooltips: true,
+      showPopups: true,
+      showLegend: true,
+      showPaths: false,
+      showNeighborInfo: false,
+      showMqttNodes: true,
+      pollIntervalSeconds: 30,
+      allowedOrigins: [],
+      sourceId: 'source-abc',
+    };
+
+    const created = await repo.createAsync(input);
+    expect(created.sourceId).toBe('source-abc');
+
+    const fetched = await repo.getByIdAsync('src-test');
+    expect(fetched!.sourceId).toBe('source-abc');
+
+    const cleared = await repo.updateAsync('src-test', { sourceId: null });
+    expect(cleared!.sourceId).toBeNull();
   });
 
   it('should deserialize boolean fields correctly from SQLite integers', async () => {

--- a/src/db/repositories/embedProfiles.ts
+++ b/src/db/repositories/embedProfiles.ts
@@ -28,6 +28,7 @@ export interface EmbedProfile {
   showMqttNodes: boolean;
   pollIntervalSeconds: number;
   allowedOrigins: string[];
+  sourceId: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -58,6 +59,7 @@ function deserializeRow(row: any): EmbedProfile {
     showMqttNodes: Boolean(row.showMqttNodes),
     pollIntervalSeconds: Number(row.pollIntervalSeconds),
     allowedOrigins: typeof row.allowedOrigins === 'string' ? JSON.parse(row.allowedOrigins) : row.allowedOrigins,
+    sourceId: row.sourceId ?? null,
     createdAt: Number(row.createdAt),
     updatedAt: Number(row.updatedAt),
   };
@@ -116,6 +118,7 @@ export class EmbedProfileRepository extends BaseRepository {
       showMqttNodes: input.showMqttNodes,
       pollIntervalSeconds: input.pollIntervalSeconds,
       allowedOrigins: JSON.stringify(input.allowedOrigins),
+      sourceId: input.sourceId ?? null,
       createdAt: now,
       updatedAt: now,
     };
@@ -148,6 +151,7 @@ export class EmbedProfileRepository extends BaseRepository {
     if (input.showMqttNodes !== undefined) updateValues.showMqttNodes = input.showMqttNodes;
     if (input.pollIntervalSeconds !== undefined) updateValues.pollIntervalSeconds = input.pollIntervalSeconds;
     if (input.allowedOrigins !== undefined) updateValues.allowedOrigins = JSON.stringify(input.allowedOrigins);
+    if (input.sourceId !== undefined) updateValues.sourceId = input.sourceId;
 
     await this.db.update(embedProfiles).set(updateValues).where(eq(embedProfiles.id, id));
 

--- a/src/db/schema/embedProfiles.ts
+++ b/src/db/schema/embedProfiles.ts
@@ -24,6 +24,7 @@ export const embedProfilesSqlite = sqliteTable('embed_profiles', {
   showMqttNodes: integer('showMqttNodes', { mode: 'boolean' }).notNull().default(true),
   pollIntervalSeconds: integer('pollIntervalSeconds').notNull().default(30),
   allowedOrigins: text('allowedOrigins').notNull().default('[]'),
+  sourceId: text('sourceId'),
   createdAt: integer('createdAt').notNull(),
   updatedAt: integer('updatedAt').notNull(),
 });
@@ -46,6 +47,7 @@ export const embedProfilesPostgres = pgTable('embed_profiles', {
   showMqttNodes: pgBoolean('showMqttNodes').notNull().default(true),
   pollIntervalSeconds: pgInteger('pollIntervalSeconds').notNull().default(30),
   allowedOrigins: pgText('allowedOrigins').notNull().default('[]'),
+  sourceId: pgText('sourceId'),
   createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
   updatedAt: pgBigint('updatedAt', { mode: 'number' }).notNull(),
 });
@@ -68,6 +70,7 @@ export const embedProfilesMysql = mysqlTable('embed_profiles', {
   showMqttNodes: myBoolean('showMqttNodes').notNull().default(true),
   pollIntervalSeconds: myInt('pollIntervalSeconds').notNull().default(30),
   allowedOrigins: myText('allowedOrigins').notNull(),
+  sourceId: myVarchar('sourceId', { length: 36 }),
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
   updatedAt: myBigint('updatedAt', { mode: 'number' }).notNull(),
 });

--- a/src/server/migrations/052_add_source_id_to_embed_profiles.ts
+++ b/src/server/migrations/052_add_source_id_to_embed_profiles.ts
@@ -1,0 +1,84 @@
+/**
+ * Migration 052: Add sourceId column to embed_profiles
+ *
+ * Adds a nullable `sourceId` column so each embed profile can be scoped to a
+ * specific source. NULL = "all sources" (preserves the pre-migration
+ * behaviour where embed routes returned data unfiltered across sources).
+ *
+ * Idempotent across SQLite/PostgreSQL/MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 052 (SQLite): Adding sourceId to embed_profiles...');
+
+    try {
+      db.exec(`ALTER TABLE embed_profiles ADD COLUMN sourceId TEXT`);
+      logger.debug('Added sourceId to embed_profiles');
+    } catch (e: any) {
+      if (e.message?.includes('duplicate column')) {
+        logger.debug('embed_profiles.sourceId already exists, skipping');
+      } else {
+        logger.warn('Could not add sourceId to embed_profiles:', e.message);
+      }
+    }
+
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_embed_profiles_source_id ON embed_profiles(sourceId)`);
+    logger.info('Migration 052 complete (SQLite)');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 052 down: Not implemented');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration052Postgres(client: any): Promise<void> {
+  logger.info('Running migration 052 (PostgreSQL): Adding sourceId to embed_profiles...');
+
+  await client.query(
+    `ALTER TABLE embed_profiles ADD COLUMN IF NOT EXISTS "sourceId" TEXT`
+  );
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS idx_embed_profiles_source_id ON embed_profiles("sourceId")`
+  );
+
+  logger.info('Migration 052 complete (PostgreSQL)');
+}
+
+// ============ MySQL ============
+
+export async function runMigration052Mysql(pool: any): Promise<void> {
+  logger.info('Running migration 052 (MySQL): Adding sourceId to embed_profiles...');
+
+  const conn = await pool.getConnection();
+  try {
+    const [rows] = await conn.query(
+      `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'embed_profiles' AND COLUMN_NAME = 'sourceId'`
+    );
+    if (!Array.isArray(rows) || rows.length === 0) {
+      await conn.query(`ALTER TABLE embed_profiles ADD COLUMN sourceId VARCHAR(36)`);
+      logger.debug('Added sourceId to embed_profiles');
+    } else {
+      logger.debug('embed_profiles.sourceId already exists, skipping');
+    }
+
+    const [idxRows] = await conn.query(
+      `SELECT COUNT(*) as cnt FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'embed_profiles' AND INDEX_NAME = 'idx_embed_profiles_source_id'`
+    );
+    if (!(idxRows as any)[0]?.cnt) {
+      await conn.query(`CREATE INDEX idx_embed_profiles_source_id ON embed_profiles(sourceId)`);
+    }
+  } finally {
+    conn.release();
+  }
+
+  logger.info('Migration 052 complete (MySQL)');
+}

--- a/src/server/routes/embedProfileRoutes.test.ts
+++ b/src/server/routes/embedProfileRoutes.test.ts
@@ -85,6 +85,7 @@ const sampleProfile = {
   showMqttNodes: true,
   pollIntervalSeconds: 30,
   allowedOrigins: ['https://example.com'],
+  sourceId: null,
   createdAt: 1700000000000,
   updatedAt: 1700000000000,
 };
@@ -252,6 +253,32 @@ describe('Embed Profile Admin Routes', () => {
         expect.objectContaining({
           allowedOrigins: [],
         })
+      );
+    });
+
+    it('persists sourceId when provided', async () => {
+      mockDb.embedProfiles.createAsync.mockResolvedValue(sampleProfile);
+      const app = createApp();
+
+      await request(app)
+        .post('/api/embed-profiles')
+        .send({ name: 'With Source', sourceId: 'src-abc' });
+
+      expect(mockDb.embedProfiles.createAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceId: 'src-abc' })
+      );
+    });
+
+    it('coerces empty/missing sourceId to null', async () => {
+      mockDb.embedProfiles.createAsync.mockResolvedValue(sampleProfile);
+      const app = createApp();
+
+      await request(app)
+        .post('/api/embed-profiles')
+        .send({ name: 'No Source', sourceId: '' });
+
+      expect(mockDb.embedProfiles.createAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceId: null })
       );
     });
 

--- a/src/server/routes/embedProfileRoutes.ts
+++ b/src/server/routes/embedProfileRoutes.ts
@@ -98,6 +98,10 @@ router.post('/', async (req: Request, res: Response) => {
       ? req.body.allowedOrigins.filter(isValidOrigin)
       : [];
     const enabled = req.body.enabled !== false;
+    const sourceId =
+      typeof req.body.sourceId === 'string' && req.body.sourceId.trim().length > 0
+        ? req.body.sourceId
+        : null;
 
     const profile = await databaseService.embedProfiles.createAsync({
       id,
@@ -116,6 +120,7 @@ router.post('/', async (req: Request, res: Response) => {
       showMqttNodes,
       pollIntervalSeconds,
       allowedOrigins,
+      sourceId,
     });
 
     databaseService.auditLogAsync(
@@ -156,6 +161,12 @@ router.put('/:id', async (req: Request, res: Response) => {
     if (req.body.pollIntervalSeconds !== undefined) updates.pollIntervalSeconds = clampPollInterval(req.body.pollIntervalSeconds);
     if (req.body.allowedOrigins !== undefined) updates.allowedOrigins = Array.isArray(req.body.allowedOrigins)
       ? req.body.allowedOrigins.filter(isValidOrigin) : [];
+    if (req.body.sourceId !== undefined) {
+      updates.sourceId =
+        typeof req.body.sourceId === 'string' && req.body.sourceId.trim().length > 0
+          ? req.body.sourceId
+          : null;
+    }
 
     const profile = await databaseService.embedProfiles.updateAsync(id, updates);
 

--- a/src/server/routes/embedPublicRoutes.ts
+++ b/src/server/routes/embedPublicRoutes.ts
@@ -73,7 +73,7 @@ router.get('/:profileId/nodes', createEmbedCspMiddleware(), async (req: Request,
   }
 
   try {
-    const allNodes = await databaseService.nodes.getActiveNodes(7);
+    const allNodes = await databaseService.nodes.getActiveNodes(7, profile.sourceId ?? undefined);
 
     // Filter by the profile's configured channels
     const profileChannels = new Set(profile.channels as number[]);
@@ -136,7 +136,7 @@ router.get('/:profileId/neighborinfo', createEmbedCspMiddleware(), async (req: R
   }
 
   try {
-    const allNodes = await databaseService.nodes.getActiveNodes(7);
+    const allNodes = await databaseService.nodes.getActiveNodes(7, profile.sourceId ?? undefined);
     const profileChannels = new Set(profile.channels as number[]);
 
     // Build a lookup of nodes that pass the embed's filters. Use effective
@@ -158,7 +158,7 @@ router.get('/:profileId/neighborinfo', createEmbedCspMiddleware(), async (req: R
       });
     }
 
-    const rawNeighbors = await databaseService.neighbors.getAllNeighborInfo();
+    const rawNeighbors = await databaseService.neighbors.getAllNeighborInfo(profile.sourceId ?? undefined);
 
     // Enrich with positions — only include pairs where both nodes are in the filtered set
     const segments = rawNeighbors
@@ -195,7 +195,7 @@ router.get('/:profileId/traceroutes', createEmbedCspMiddleware(), async (req: Re
   }
 
   try {
-    const allNodes = await databaseService.nodes.getActiveNodes(7);
+    const allNodes = await databaseService.nodes.getActiveNodes(7, profile.sourceId ?? undefined);
     const profileChannels = new Set(profile.channels as number[]);
 
     // Build position lookup for visible nodes. Use effective position so a
@@ -218,7 +218,7 @@ router.get('/:profileId/traceroutes', createEmbedCspMiddleware(), async (req: Re
     }
 
     // Get recent traceroutes and decompose into point-to-point segments
-    const traceroutes = await databaseService.traceroutes.getAllTraceroutes(100);
+    const traceroutes = await databaseService.traceroutes.getAllTraceroutes(100, profile.sourceId ?? undefined);
     // Traceroute timestamps can be in ms or seconds — normalize to ms
     const cutoffMs = Date.now() - (24 * 60 * 60 * 1000); // last 24h
 


### PR DESCRIPTION
## Summary
- Adds a nullable \`sourceId\` column to \`embed_profiles\` (migration 052, SQLite/PG/MySQL)
- Admin CRUD route accepts and persists \`sourceId\`; empty string coerces to \`NULL\`
- Public embed routes pass \`profile.sourceId\` to \`getActiveNodes\`, \`getAllNeighborInfo\`, \`getAllTraceroutes\`
- Settings editor adds a "Source" dropdown that defaults to "All sources" (\`NULL\`), so existing profiles keep their current cross-source behaviour

## Why
The Map Embed feature was operational but **not source-aware** — it silently returned nodes/neighbors/traceroutes across every configured source. Repository methods already accepted an optional \`sourceId\`; the embed routes just never passed one. This wires that all the way through and exposes a UI control.

## Test plan
- [ ] Migration 052 runs cleanly on a fresh DB and an existing 4.x DB (idempotent)
- [ ] Existing embed profiles continue to return data across all sources (no regression)
- [ ] Create a new profile, pick a single source, confirm \`/api/embed/:id/nodes|neighborinfo|traceroutes\` only returns that source's records
- [ ] Editing an existing profile to pick a source, then back to "All sources", round-trips correctly
- [ ] Repo + routes test suites pass (\`vitest run src/db/repositories/embedProfiles.test.ts src/server/routes/embedProfileRoutes.test.ts\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)