### PR TITLE
fix(upgrade): circuit breaker halts auto-upgrade fail-loop (#2871)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,6 +140,8 @@ function App() {
   const [upgradeStatus, setUpgradeStatus] = useState('');
   const [upgradeProgress, setUpgradeProgress] = useState(0);
   const [_upgradeId, setUpgradeId] = useState<string | null>(null);
+  const [autoUpgradeBlocked, setAutoUpgradeBlocked] = useState(false);
+  const [autoUpgradeBlockedReason, setAutoUpgradeBlockedReason] = useState<string | null>(null);
   const [channelInfoModal, setChannelInfoModal] = useState<number | null>(null);
   const [showPsk, setShowPsk] = useState(false);
   const [showRebootModal, setShowRebootModal] = useState(false);
@@ -1308,6 +1310,10 @@ function App() {
         if (response.ok) {
           const data = await response.json();
           setUpgradeEnabled(data.enabled && data.deploymentMethod === 'docker');
+          if (data.autoUpgradeBlock) {
+            setAutoUpgradeBlocked(Boolean(data.autoUpgradeBlock.blocked));
+            setAutoUpgradeBlockedReason(data.autoUpgradeBlock.reason ?? null);
+          }
 
           // If an upgrade is already in progress (e.g., auto-upgrade was triggered),
           // set the upgrade state and start polling for status
@@ -1380,6 +1386,25 @@ function App() {
       showToast?.('Failed to trigger upgrade', 'error');
       setUpgradeInProgress(false);
       setUpgradeStatus('');
+    }
+  };
+
+  // Acknowledge and clear the auto-upgrade circuit breaker
+  const handleClearAutoUpgradeBlock = async () => {
+    try {
+      const response = await authFetch(`${baseUrl}/api/upgrade/clear-block`, {
+        method: 'POST',
+      });
+      if (response.ok) {
+        setAutoUpgradeBlocked(false);
+        setAutoUpgradeBlockedReason(null);
+        showToast?.('Auto-upgrade unblocked. Scheduled upgrades will resume.', 'success');
+      } else {
+        showToast?.('Failed to clear auto-upgrade block', 'error');
+      }
+    } catch (error) {
+      logger.error('Error clearing auto-upgrade block:', error);
+      showToast?.('Failed to clear auto-upgrade block', 'error');
     }
   };
 
@@ -4532,6 +4557,9 @@ function App() {
         upgradeProgress={upgradeProgress}
         onUpgrade={handleUpgrade}
         onDismissUpdate={() => setUpdateAvailable(false)}
+        autoUpgradeBlocked={autoUpgradeBlocked}
+        autoUpgradeBlockedReason={autoUpgradeBlockedReason}
+        onClearAutoUpgradeBlock={handleClearAutoUpgradeBlock}
       />
 
       <LoginModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />

--- a/src/components/AppBanners/AppBanners.tsx
+++ b/src/components/AppBanners/AppBanners.tsx
@@ -15,6 +15,9 @@ interface AppBannersProps {
   upgradeProgress: number;
   onUpgrade: () => void;
   onDismissUpdate: () => void;
+  autoUpgradeBlocked?: boolean;
+  autoUpgradeBlockedReason?: string | null;
+  onClearAutoUpgradeBlock?: () => void;
 }
 
 export const AppBanners: React.FC<AppBannersProps> = ({
@@ -29,6 +32,9 @@ export const AppBanners: React.FC<AppBannersProps> = ({
   upgradeProgress,
   onUpgrade,
   onDismissUpdate,
+  autoUpgradeBlocked = false,
+  autoUpgradeBlockedReason = null,
+  onClearAutoUpgradeBlock,
 }) => {
   const { t } = useTranslation();
 
@@ -83,6 +89,45 @@ export const AppBanners: React.FC<AppBannersProps> = ({
           </div>
         );
       })}
+
+      {/* Auto-Upgrade Blocked Banner (circuit breaker tripped) */}
+      {autoUpgradeBlocked && (() => {
+        const bannersAbove = [isTxDisabled].filter(Boolean).length + configIssues.length;
+        const topOffset =
+          bannersAbove === 0
+            ? 'var(--header-height)'
+            : `calc(var(--header-height) + (var(--banner-height) * ${bannersAbove}))`;
+        return (
+          <div
+            className="warning-banner"
+            style={{ top: topOffset, gap: '1rem' }}
+          >
+            <span>
+              ⚠️ {t('banners.auto_upgrade_blocked', {
+                defaultValue: 'Auto-upgrade halted after repeated failures.',
+              })}
+              {autoUpgradeBlockedReason ? ` ${autoUpgradeBlockedReason}` : ''}
+            </span>
+            {onClearAutoUpgradeBlock && (
+              <button
+                onClick={onClearAutoUpgradeBlock}
+                style={{
+                  marginLeft: '1rem',
+                  padding: '0.25rem 0.75rem',
+                  background: 'rgba(255,255,255,0.2)',
+                  color: 'inherit',
+                  border: '1px solid rgba(255,255,255,0.5)',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  fontWeight: 600,
+                }}
+              >
+                {t('banners.acknowledge', { defaultValue: 'Acknowledge' })}
+              </button>
+            )}
+          </div>
+        );
+      })()}
 
       {/* Update Available Banner */}
       {updateAvailable &&

--- a/src/db/repositories/misc.test.ts
+++ b/src/db/repositories/misc.test.ts
@@ -462,6 +462,54 @@ function runMiscTests(getBackend: () => TestBackend) {
     expect(count).toBe(1); // only 'pending' is an in-progress status
   });
 
+  it('countConsecutiveFailedUpgrades - returns 0 with no history', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    const count = await repo.countConsecutiveFailedUpgrades();
+    expect(count).toBe(0);
+  });
+
+  it('countConsecutiveFailedUpgrades - counts run of failures from most recent', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    const base = Date.now();
+    await repo.createUpgradeHistory({ id: 'u1', fromVersion: '1.0', toVersion: '1.1', deploymentMethod: 'docker', status: 'failed', startedAt: base });
+    await repo.createUpgradeHistory({ id: 'u2', fromVersion: '1.0', toVersion: '1.1', deploymentMethod: 'docker', status: 'failed', startedAt: base + 1000 });
+    await repo.createUpgradeHistory({ id: 'u3', fromVersion: '1.0', toVersion: '1.1', deploymentMethod: 'docker', status: 'failed', startedAt: base + 2000 });
+
+    const count = await repo.countConsecutiveFailedUpgrades();
+    expect(count).toBe(3);
+  });
+
+  it('countConsecutiveFailedUpgrades - stops at first non-failed row', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    const base = Date.now();
+    // Older completed run, then 2 recent failures
+    await repo.createUpgradeHistory({ id: 'u1', fromVersion: '1.0', toVersion: '1.1', deploymentMethod: 'docker', status: 'failed', startedAt: base });
+    await repo.createUpgradeHistory({ id: 'u2', fromVersion: '1.0', toVersion: '1.1', deploymentMethod: 'docker', status: 'complete', startedAt: base + 1000 });
+    await repo.createUpgradeHistory({ id: 'u3', fromVersion: '1.0', toVersion: '1.1', deploymentMethod: 'docker', status: 'failed', startedAt: base + 2000 });
+    await repo.createUpgradeHistory({ id: 'u4', fromVersion: '1.0', toVersion: '1.1', deploymentMethod: 'docker', status: 'failed', startedAt: base + 3000 });
+
+    const count = await repo.countConsecutiveFailedUpgrades();
+    expect(count).toBe(2);
+  });
+
+  it('countConsecutiveFailedUpgrades - returns 0 when most recent succeeded', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    const base = Date.now();
+    await repo.createUpgradeHistory({ id: 'u1', fromVersion: '1.0', toVersion: '1.1', deploymentMethod: 'docker', status: 'failed', startedAt: base });
+    await repo.createUpgradeHistory({ id: 'u2', fromVersion: '1.0', toVersion: '1.1', deploymentMethod: 'docker', status: 'complete', startedAt: base + 1000 });
+
+    const count = await repo.countConsecutiveFailedUpgrades();
+    expect(count).toBe(0);
+  });
+
   // ============ NEWS CACHE ============
 
   it('saveNewsCache and getNewsCache - save and retrieve', async () => {

--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -374,6 +374,30 @@ export class MiscRepository extends BaseRepository {
       .where(eq(upgradeHistory.id, id));
   }
 
+  /**
+   * Count consecutive failed upgrades from most recent backwards.
+   * Stops counting at the first non-failed (e.g. 'complete') row.
+   * Used by the auto-upgrade circuit breaker to halt repeated retries
+   * when something is structurally wrong (e.g. pinned image tag).
+   */
+  async countConsecutiveFailedUpgrades(): Promise<number> {
+    const { upgradeHistory } = this.tables;
+    const rows = await this.db
+      .select({ status: upgradeHistory.status })
+      .from(upgradeHistory)
+      .orderBy(desc(upgradeHistory.startedAt))
+      .limit(50);
+    let count = 0;
+    for (const row of rows) {
+      if (row.status === 'failed') {
+        count++;
+      } else {
+        break;
+      }
+    }
+    return count;
+  }
+
   // ============ NEWS CACHE ============
 
   /**

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -81,6 +81,8 @@ export const VALID_SETTINGS_KEYS = [
   'inactiveNodeCheckIntervalMinutes',
   'inactiveNodeCooldownHours',
   'autoUpgradeImmediate',
+  'autoUpgradeBlocked',
+  'autoUpgradeBlockedReason',
   'maintenanceEnabled',
   'maintenanceTime',
   'messageRetentionDays',

--- a/src/server/routes/upgradeRoutes.ts
+++ b/src/server/routes/upgradeRoutes.ts
@@ -26,16 +26,43 @@ router.use(requireAuth());
 router.get('/status', async (_req: Request, res: Response) => {
   try {
     const activeUpgrade = await upgradeService.getActiveUpgrade();
+    const block = await upgradeService.getAutoUpgradeBlock();
 
     return res.json({
       enabled: upgradeService.isEnabled(),
       deploymentMethod: upgradeService.getDeploymentMethod(),
       currentVersion: packageJson.version,
-      activeUpgrade: activeUpgrade || null
+      activeUpgrade: activeUpgrade || null,
+      autoUpgradeBlock: block,
     });
   } catch (error) {
     logger.error('Error checking upgrade status:', error);
     return res.status(500).json({ error: 'Failed to check upgrade status' });
+  }
+});
+
+/**
+ * POST /api/upgrade/clear-block
+ * Acknowledge and clear the auto-upgrade circuit breaker so scheduled
+ * upgrades resume. Use after the operator has remediated the underlying
+ * cause of the failures (e.g. unpinned image tag, fixed registry access).
+ */
+router.post('/clear-block', async (req: Request, res: Response) => {
+  try {
+    const userId = req.user?.id || null;
+    await upgradeService.clearAutoUpgradeBlock(`Acknowledged by user ${userId ?? 'unknown'}`);
+    databaseService.auditLogAsync(
+      typeof userId === 'number' ? userId : null,
+      'auto_upgrade_block_cleared',
+      'system',
+      'Auto-upgrade circuit breaker cleared',
+      req.ip || null
+    );
+    const block = await upgradeService.getAutoUpgradeBlock();
+    return res.json({ success: true, autoUpgradeBlock: block });
+  } catch (error) {
+    logger.error('Error clearing auto-upgrade block:', error);
+    return res.status(500).json({ success: false, error: 'Failed to clear block' });
   }
 });
 

--- a/src/server/services/upgradeService.test.ts
+++ b/src/server/services/upgradeService.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the upgradeService auto-upgrade circuit breaker.
+ *
+ * Issue #2871: when AUTO_UPGRADE_ENABLED=true on a deployment whose image is
+ * pinned in docker-compose.yml, scheduled upgrades fail forever in a silent
+ * loop. The circuit breaker trips after N consecutive failures so retries
+ * stop until the operator acknowledges.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const settingsStore = vi.hoisted(() => new Map<string, string>());
+
+const mockDb = vi.hoisted(() => ({
+  miscRepo: {
+    countConsecutiveFailedUpgrades: vi.fn().mockResolvedValue(0),
+    markUpgradeFailed: vi.fn().mockResolvedValue(undefined),
+    markUpgradeComplete: vi.fn().mockResolvedValue(undefined),
+    createUpgradeHistory: vi.fn().mockResolvedValue(undefined),
+    findStaleUpgrades: vi.fn().mockResolvedValue([]),
+    countInProgressUpgrades: vi.fn().mockResolvedValue(0),
+    getLastUpgrade: vi.fn().mockResolvedValue(null),
+  },
+  settings: {
+    getSetting: vi.fn(async (key: string) => settingsStore.get(key) ?? null),
+    setSetting: vi.fn(async (key: string, value: string) => {
+      settingsStore.set(key, value);
+    }),
+  },
+  auditLogAsync: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../services/database.js', () => ({
+  default: mockDb,
+}));
+
+// fs is touched on import; provide enough to avoid touching the real disk.
+vi.mock('fs', () => {
+  const noop = () => {};
+  return {
+    default: {
+      existsSync: vi.fn().mockReturnValue(false),
+      readFileSync: vi.fn().mockReturnValue(''),
+      writeFileSync: noop,
+      renameSync: noop,
+      unlinkSync: noop,
+      statfsSync: vi.fn().mockReturnValue({ bavail: 1_000_000, bsize: 4096 }),
+      mkdirSync: noop,
+      accessSync: noop,
+      constants: { W_OK: 2 },
+    },
+    existsSync: vi.fn().mockReturnValue(false),
+    readFileSync: vi.fn().mockReturnValue(''),
+    writeFileSync: noop,
+    renameSync: noop,
+    unlinkSync: noop,
+    statfsSync: vi.fn().mockReturnValue({ bavail: 1_000_000, bsize: 4096 }),
+    mkdirSync: noop,
+    accessSync: noop,
+    constants: { W_OK: 2 },
+  };
+});
+
+const { upgradeService, AUTO_UPGRADE_FAILURE_THRESHOLD } = await import('./upgradeService.js');
+
+describe('upgradeService circuit breaker', () => {
+  beforeEach(() => {
+    settingsStore.clear();
+    vi.clearAllMocks();
+    mockDb.miscRepo.countConsecutiveFailedUpgrades.mockResolvedValue(0);
+    mockDb.miscRepo.findStaleUpgrades.mockResolvedValue([]);
+    mockDb.miscRepo.countInProgressUpgrades.mockResolvedValue(0);
+  });
+
+  it('exposes the configured threshold (default 3)', () => {
+    expect(AUTO_UPGRADE_FAILURE_THRESHOLD).toBeGreaterThanOrEqual(1);
+  });
+
+  it('getAutoUpgradeBlock returns not-blocked by default', async () => {
+    const state = await upgradeService.getAutoUpgradeBlock();
+    expect(state.blocked).toBe(false);
+    expect(state.consecutiveFailures).toBe(0);
+    expect(state.threshold).toBe(AUTO_UPGRADE_FAILURE_THRESHOLD);
+  });
+
+  it('getAutoUpgradeBlock reflects persisted blocked state', async () => {
+    settingsStore.set('autoUpgradeBlocked', 'true');
+    settingsStore.set('autoUpgradeBlockedReason', 'pinned image');
+
+    const state = await upgradeService.getAutoUpgradeBlock();
+    expect(state.blocked).toBe(true);
+    expect(state.reason).toBe('pinned image');
+  });
+
+  it('clearAutoUpgradeBlock unsets persisted block', async () => {
+    settingsStore.set('autoUpgradeBlocked', 'true');
+    settingsStore.set('autoUpgradeBlockedReason', 'something');
+
+    await upgradeService.clearAutoUpgradeBlock();
+
+    const state = await upgradeService.getAutoUpgradeBlock();
+    expect(state.blocked).toBe(false);
+  });
+
+  it('triggerUpgrade refuses scheduled attempts when blocked', async () => {
+    settingsStore.set('autoUpgradeBlocked', 'true');
+    settingsStore.set('autoUpgradeBlockedReason', 'pinned image tag');
+
+    // Need AUTO_UPGRADE_ENABLED + docker for triggerUpgrade to reach the breaker.
+    // The constructor read env at import time; bypass by faking deployment via property:
+    Object.assign(upgradeService, { UPGRADE_ENABLED: true, DEPLOYMENT_METHOD: 'docker' });
+
+    const result = await upgradeService.triggerUpgrade(
+      { targetVersion: 'latest' },
+      '1.0.0',
+      'system-scheduled-auto-upgrade'
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/blocked/i);
+    expect(mockDb.miscRepo.createUpgradeHistory).not.toHaveBeenCalled();
+  });
+
+  it('triggerUpgrade allows manual user attempt even when blocked', async () => {
+    settingsStore.set('autoUpgradeBlocked', 'true');
+
+    Object.assign(upgradeService, { UPGRADE_ENABLED: true, DEPLOYMENT_METHOD: 'docker' });
+
+    const result = await upgradeService.triggerUpgrade(
+      { targetVersion: 'latest', force: true },
+      '1.0.0',
+      '42' // numeric user id, not 'system-*'
+    );
+
+    // Either the manual attempt succeeded or it failed for an unrelated reason
+    // (e.g. mocked filesystem), but it must NOT be the breaker rejection.
+    expect(result.message ?? '').not.toMatch(/blocked after .* consecutive/i);
+  });
+});

--- a/src/server/services/upgradeService.ts
+++ b/src/server/services/upgradeService.ts
@@ -14,6 +14,13 @@ const UPGRADE_TRIGGER_FILE = path.join(DATA_DIR, '.upgrade-trigger');
 const UPGRADE_STATUS_FILE = path.join(DATA_DIR, '.upgrade-status');
 const BACKUP_DIR = path.join(DATA_DIR, 'backups');
 
+// Circuit-breaker threshold: trip after this many consecutive failed upgrades
+// to halt unattended retries when something is structurally wrong (e.g. a
+// pinned image tag in docker-compose.yml — see issue #2871).
+const PARSED_THRESHOLD = parseInt(process.env.AUTO_UPGRADE_FAILURE_THRESHOLD || '', 10);
+export const AUTO_UPGRADE_FAILURE_THRESHOLD =
+  Number.isFinite(PARSED_THRESHOLD) && PARSED_THRESHOLD > 0 ? PARSED_THRESHOLD : 3;
+
 export interface UpgradeStatus {
   upgradeId: string;
   status: 'pending' | 'backing_up' | 'downloading' | 'restarting' | 'health_check' | 'complete' | 'failed' | 'rolled_back';
@@ -153,6 +160,20 @@ class UpgradeService {
         };
       }
 
+      // Circuit breaker: refuse system-initiated upgrades when blocked.
+      // Manual user-initiated upgrades (initiatedBy not starting with 'system-')
+      // and force=true bypass the block so the user can investigate / retry.
+      if (this.isSystemInitiated(initiatedBy) && !request.force) {
+        const blocked = await this.getAutoUpgradeBlock();
+        if (blocked.blocked) {
+          logger.warn(`🛑 Auto-upgrade blocked by circuit breaker — refusing scheduled trigger. Reason: ${blocked.reason}`);
+          return {
+            success: false,
+            message: `Auto-upgrade is blocked after ${AUTO_UPGRADE_FAILURE_THRESHOLD} consecutive failed attempts. ${blocked.reason || ''} Acknowledge from the UI to resume.`.trim()
+          };
+        }
+      }
+
       // Check if upgrade already in progress
       const inProgress = await this.isUpgradeInProgress();
       if (inProgress && !request.force) {
@@ -250,12 +271,12 @@ class UpgradeService {
             const fileStatus = fs.readFileSync(UPGRADE_STATUS_FILE, 'utf-8').trim().toLowerCase();
             if (fileStatus === 'complete' || fileStatus === 'ready') {
               logger.info(`🔄 Syncing upgrade ${upgradeId} status from file: ${row.status} -> complete`);
-              await databaseService.miscRepo.markUpgradeComplete(row.id);
+              await this.markCompleteAndClear(row.id);
               const updated = await databaseService.miscRepo.getUpgradeById(upgradeId);
               if (updated) row = updated;
             } else if (fileStatus === 'failed') {
               logger.info(`🔄 Syncing upgrade ${upgradeId} status from file: ${row.status} -> failed`);
-              await databaseService.miscRepo.markUpgradeFailed(row.id, 'Upgrade failed (detected from watchdog status)');
+              await this.markFailedAndEvaluate(row.id, 'Upgrade failed (detected from watchdog status)');
               const updated = await databaseService.miscRepo.getUpgradeById(upgradeId);
               if (updated) row = updated;
             }
@@ -380,7 +401,7 @@ class UpgradeService {
           const minutesStuck = Math.round((Date.now() - (staleUpgrade.startedAt || 0)) / 60000);
           logger.warn(`⚠️ Upgrade ${staleUpgrade.id} stuck at "${staleUpgrade.currentStep}" for ${minutesStuck} minutes`);
 
-          await databaseService.miscRepo.markUpgradeFailed(
+          await this.markFailedAndEvaluate(
             staleUpgrade.id,
             `Upgrade timed out after ${minutesStuck} minutes (stuck at: ${staleUpgrade.currentStep})`
           );
@@ -443,7 +464,7 @@ class UpgradeService {
           // If the watchdog has marked the upgrade complete or ready, sync to database
           if (fileStatus === 'complete' || fileStatus === 'ready') {
             logger.info(`🔄 Syncing upgrade status from file: ${row.status} -> complete`);
-            await databaseService.miscRepo.markUpgradeComplete(row.id);
+            await this.markCompleteAndClear(row.id);
 
             // No active upgrade anymore
             return null;
@@ -452,7 +473,7 @@ class UpgradeService {
           // If the watchdog has marked it failed, sync to database
           if (fileStatus === 'failed') {
             logger.info(`🔄 Syncing upgrade status from file: ${row.status} -> failed`);
-            await databaseService.miscRepo.markUpgradeFailed(
+            await this.markFailedAndEvaluate(
               row.id,
               'Upgrade failed (detected from watchdog status)'
             );
@@ -540,6 +561,89 @@ class UpgradeService {
       safe: issues.length === 0,
       issues
     };
+  }
+
+  /**
+   * Identify scheduled/immediate auto-upgrades vs manual user-initiated ones.
+   * Used to scope circuit-breaker effects to unattended attempts only.
+   */
+  private isSystemInitiated(initiatedBy: string): boolean {
+    return typeof initiatedBy === 'string' && initiatedBy.startsWith('system-');
+  }
+
+  /**
+   * Read circuit-breaker state. Blocked when a previous run tripped the
+   * threshold and no successful upgrade has cleared it since.
+   */
+  async getAutoUpgradeBlock(): Promise<{
+    blocked: boolean;
+    reason: string | null;
+    consecutiveFailures: number;
+    threshold: number;
+  }> {
+    let consecutiveFailures = 0;
+    if (databaseService.miscRepo) {
+      try {
+        consecutiveFailures = await databaseService.miscRepo.countConsecutiveFailedUpgrades();
+      } catch (error) {
+        logger.warn('Failed to count consecutive upgrade failures:', error);
+      }
+    }
+    let blocked = false;
+    let reason: string | null = null;
+    try {
+      blocked = (await databaseService.settings.getSetting('autoUpgradeBlocked')) === 'true';
+      reason = (await databaseService.settings.getSetting('autoUpgradeBlockedReason')) ?? null;
+    } catch (error) {
+      logger.warn('Failed to read auto-upgrade block state:', error);
+    }
+    return { blocked, reason, consecutiveFailures, threshold: AUTO_UPGRADE_FAILURE_THRESHOLD };
+  }
+
+  /**
+   * Mark an upgrade failed and evaluate the circuit breaker.
+   * Trips the breaker when consecutive failures reach the threshold.
+   */
+  private async markFailedAndEvaluate(id: string, errorMessage: string): Promise<void> {
+    if (!databaseService.miscRepo) return;
+    await databaseService.miscRepo.markUpgradeFailed(id, errorMessage);
+
+    try {
+      const consecutiveFailures = await databaseService.miscRepo.countConsecutiveFailedUpgrades();
+      if (consecutiveFailures >= AUTO_UPGRADE_FAILURE_THRESHOLD) {
+        const reason = `${consecutiveFailures} consecutive upgrade attempts failed. Last error: ${errorMessage}`;
+        await databaseService.settings.setSetting('autoUpgradeBlocked', 'true');
+        await databaseService.settings.setSetting('autoUpgradeBlockedReason', reason);
+        logger.warn(`🛑 Auto-upgrade circuit breaker tripped after ${consecutiveFailures} failures: ${errorMessage}`);
+      }
+    } catch (error) {
+      logger.warn('Failed to evaluate auto-upgrade circuit breaker:', error);
+    }
+  }
+
+  /**
+   * Mark an upgrade complete and clear any tripped circuit breaker.
+   * Called instead of miscRepo.markUpgradeComplete from internal sync paths.
+   */
+  private async markCompleteAndClear(id: string): Promise<void> {
+    if (!databaseService.miscRepo) return;
+    await databaseService.miscRepo.markUpgradeComplete(id);
+    await this.clearAutoUpgradeBlock('Cleared by successful upgrade');
+  }
+
+  /**
+   * Clear the circuit breaker (user acknowledgement or successful upgrade).
+   */
+  async clearAutoUpgradeBlock(reason?: string): Promise<void> {
+    try {
+      await databaseService.settings.setSetting('autoUpgradeBlocked', 'false');
+      await databaseService.settings.setSetting('autoUpgradeBlockedReason', '');
+      if (reason) {
+        logger.info(`✅ Auto-upgrade circuit breaker cleared: ${reason}`);
+      }
+    } catch (error) {
+      logger.warn('Failed to clear auto-upgrade block:', error);
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #2871

## Summary
- Trip a circuit breaker after **3 consecutive failed upgrades** (override via `AUTO_UPGRADE_FAILURE_THRESHOLD` env). While tripped, scheduled / immediate auto-upgrades are refused so the silent retry loop stops.
- Manual user-initiated upgrades and `force=true` bypass the breaker so the operator can still investigate or retry.
- A successful upgrade auto-clears the breaker; the user can also acknowledge it from the UI.

## Why this approach
Per the issue's own suggestion ("bound the retry…surface the failure in the UI and stop retrying until the user acknowledges"). Single-digit-LOC core change, generic enough to catch any failure mode (pinned image, registry down, watchdog can't reach Docker socket), no Docker-socket plumbing required. A future PR can layer pinned-image *detection* on top — this is the safety net.

## Changes
- `src/db/repositories/misc.ts` — new `countConsecutiveFailedUpgrades()` repo method.
- `src/server/services/upgradeService.ts`:
  - `AUTO_UPGRADE_FAILURE_THRESHOLD` constant (env-overridable).
  - `getAutoUpgradeBlock()` / `clearAutoUpgradeBlock()` exposed.
  - `markFailedAndEvaluate()` / `markCompleteAndClear()` private wrappers; sync paths (stale-cleanup, watchdog status-file sync) now go through them. `cancelUpgrade` is unchanged (user-driven cancel must not trip the breaker).
  - `triggerUpgrade()` rejects `system-*` initiators when blocked; manual + force bypass.
- `src/server/routes/upgradeRoutes.ts`:
  - `GET /api/upgrade/status` now returns `autoUpgradeBlock: { blocked, reason, consecutiveFailures, threshold }`.
  - New `POST /api/upgrade/clear-block` (audit-logged via `auto_upgrade_block_cleared`).
- `src/server/constants/settings.ts` — `autoUpgradeBlocked`, `autoUpgradeBlockedReason` added to allowlist.
- `src/App.tsx` + `src/components/AppBanners/AppBanners.tsx` — warning banner with Acknowledge button.

## Tests
- `src/db/repositories/misc.test.ts` — 4 new cases for `countConsecutiveFailedUpgrades` (empty, run-of-failures, stops at first non-failed, recent success returns 0). Runs against SQLite, PostgreSQL, MySQL.
- `src/server/services/upgradeService.test.ts` — new file, 6 cases covering threshold default, block read/clear, scheduled-attempt rejection while blocked, and manual-attempt bypass.

## Test plan
- [x] `npx vitest run src/db/repositories/misc.test.ts` — 30/30 pass
- [x] `npx vitest run src/server/services/upgradeService.test.ts` — 6/6 pass
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] Dev container build + deploy verified
- [ ] CI green
- [ ] Manual: seed 3 'failed' rows in `upgrade_history`, hit `GET /api/upgrade/status`, confirm `autoUpgradeBlock.blocked=true` and banner shows; click Acknowledge → banner clears, scheduled upgrade resumes on next tick.

## Workaround for users on the affected version
Until this ships, the issue body lists a clean manual recovery path (set `AUTO_UPGRADE_ENABLED=false`, recreate container, mark pending row failed, drop `.upgrade-trigger`, set `autoUpgradeEnabled=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)