### PR TITLE
feat: support multiple responses for HTTP auto-responder triggers

### DIFF
--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -704,6 +704,7 @@ You can specify custom regex patterns for parameters using `{paramName:regex}` s
 - Supports multiline text (automatically uses textarea for editing)
 - Can include extracted parameters using `{parameter}` syntax
 - **Multiline Support**: Enable to automatically split long responses into multiple messages
+- Can output single or multiple responses (see [Multiple Responses Support](#multiple-responses-support))
 - Example trigger: `hello {name}`
 - Example response: `Hi {name}! Welcome to the mesh.`
 
@@ -713,6 +714,7 @@ You can specify custom regex patterns for parameters using `{paramName:regex}` s
 - URL also supports all acknowledgement/announcement tokens (e.g., `{NODE_ID}`, `{SHORT_NAME}`, `{HOPS}`, `{SNR}`, `{RSSI}`, `{CHANNEL}`, `{VERSION}`, etc.) - token values are automatically URI-encoded for URL safety
 - Extracted parameters from regex capture groups take precedence over built-in tokens of the same name
 - **Multiline Support**: Enable to automatically split long responses into multiple messages
+- Can output single or multiple responses (see [Multiple Responses Support](#multiple-responses-support))
 - Useful for triggering webhooks, APIs, or external automation
 - Example trigger: `alert {message}`
 - Example response: `https://api.example.com/alert?msg={message}&node={NODE_ID}&snr={SNR}`
@@ -722,7 +724,7 @@ You can specify custom regex patterns for parameters using `{paramName:regex}` s
 - Scripts must be placed in `/data/scripts/` directory
 - Supports Node.js (`.js`, `.mjs`), Python (`.py`), and Shell (`.sh`) scripts
 - Scripts receive message data and parameters via environment variables
-- Can output single or multiple responses (see Script Response Details below)
+- Can output single or multiple responses (see [Script Response Details](#script-response-details) below)
 - 10-second execution timeout
 - **Script Arguments**: Optional command-line arguments with token expansion (see below)
 - Example trigger: `weather {location}`
@@ -831,6 +833,35 @@ This would be split into approximately 3 messages, each sent 30 seconds apart.
 - Time-sensitive responses
 - Single-line messages
 
+### Multiple Responses Support
+
+For **Text**, **HTTP** and **Script** response types, you can return single or multiple responses, using JSON.
+
+**JSON Output Format**:
+
+**Single Response:**
+```json
+{
+  "response": "Your response text (max 200 chars)"
+}
+```
+
+**Multiple Responses:**
+```json
+{
+  "responses": [
+    "First message (max 200 chars)",
+    "Second message (max 200 chars)",
+    "Third message (max 200 chars)"
+  ]
+}
+```
+
+When using multiple responses, each message is queued individually and sent with:
+- 30-second rate limiting between messages
+- Up to 3 retry attempts per message
+- Automatic ACK tracking for delivery confirmation
+
 ### Parameter Extraction
 
 Parameters are automatically extracted from the incoming message and can be used in responses:
@@ -881,7 +912,7 @@ Scripts provide the most powerful and flexible response type, allowing you to ex
 Scripts must:
 - Be located in `/data/scripts/` directory
 - Have a supported extension: `.js`, `.mjs`, `.py`, or `.sh`
-- Output valid JSON to stdout with a `response` field
+- Output valid JSON to stdout with a `response` or `responses` field (see details in [Multiple Responses Support](#multiple-responses-support) section)
 - Complete execution within 10 seconds (timeout)
 - Handle errors gracefully
 
@@ -906,33 +937,6 @@ All scripts receive these environment variables:
 - `MSG_*`: All message fields as individual variables
 
 See the [Auto Responder Scripting Guide](/developers/auto-responder-scripting#environment-variables) for the complete list.
-
-**JSON Output Format**:
-
-Scripts can return single or multiple responses:
-
-**Single Response:**
-```json
-{
-  "response": "Your response text (max 200 chars)"
-}
-```
-
-**Multiple Responses:**
-```json
-{
-  "responses": [
-    "First message (max 200 chars)",
-    "Second message (max 200 chars)",
-    "Third message (max 200 chars)"
-  ]
-}
-```
-
-When using multiple responses, each message is queued individually and sent with:
-- 30-second rate limiting between messages
-- Up to 3 retry attempts per message
-- Automatic ACK tracking for delivery confirmation
 
 **Example 1 - Node.js Weather Script**:
 ```javascript

--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -862,6 +862,23 @@ When using multiple responses, each message is queued individually and sent with
 - Up to 3 retry attempts per message
 - Automatic ACK tracking for delivery confirmation
 
+**Optional fields**:
+
+| Field | Type | Applies to | Effect |
+|-------|------|------------|--------|
+| `response` | string | Text, HTTP, Script | Single message body (≤ 200 chars). |
+| `responses` | string[] | Text, HTTP, Script | Multiple message bodies (each ≤ 200 chars). Wins over `response` if both are present. |
+| `private` | boolean | Text, HTTP, Script | Force DM routing (`true`) or channel routing (`false`) regardless of where the trigger fired. Omit to keep the default ("reply on the same channel the trigger arrived on"). |
+
+**Interaction with the `multiline` trigger option**:
+
+- `multiline=true` only splits when the payload is a **single** response (plain text or `{"response": "…"}`). Each item in a `{"responses": [...]}` array is treated as already-chunked: items longer than 200 chars are **truncated**, not split. Pre-chunk your own messages when returning the array form.
+- `multiline=false` (default) truncates every response to 200 chars.
+
+**HTTP responses that aren't MeshMonitor-shaped JSON**:
+
+If an HTTP endpoint returns a body that parses as JSON but doesn't have `response` / `responses` (e.g. `{"status":"ok"}` from a webhook acknowledgment), the entire raw body is used as the single response message — same behaviour as a plain-text body. Only the script path treats this as an error.
+
 ### Parameter Extraction
 
 Parameters are automatically extracted from the incoming message and can be used in responses:

--- a/src/server/meshtasticManager.parseAutoResponderResponse.test.ts
+++ b/src/server/meshtasticManager.parseAutoResponderResponse.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the pure `parseAutoResponderResponse` helper extracted
+ * from MeshtasticManager. The auto-responder calls it for:
+ *
+ *  - HTTP response bodies (`jsonExpected=false`) — must keep treating
+ *    non-MeshMonitor-shaped responses as a single plain message so
+ *    webhooks that return their own JSON shape don't silently drop.
+ *  - Script stdout    (`jsonExpected=true`)  — strict; non-JSON or
+ *    missing-field output is an error.
+ *  - Static text responses (`jsonExpected=false`) — same fallback as
+ *    HTTP so an admin can author `{"responses":[...]}` directly into
+ *    the trigger's Response field.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { parseAutoResponderResponse } from './meshtasticManager.js';
+import { logger } from '../utils/logger.js';
+
+describe('parseAutoResponderResponse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Multi-response array ────────────────────────────────────────
+
+  it('returns all strings from { responses: [...] }', () => {
+    const result = parseAutoResponderResponse('{"responses":["a","b","c"]}', true);
+    expect(result.responses).toEqual(['a', 'b', 'c']);
+    expect(result.json).toEqual({ responses: ['a', 'b', 'c'] });
+  });
+
+  it('filters non-string entries out of `responses` and warns about discards', () => {
+    const result = parseAutoResponderResponse(
+      '{"responses":["a", 123, "b", null, "c", true]}',
+      true,
+    );
+    expect(result.responses).toEqual(['a', 'b', 'c']);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/dropped 3 non-string/));
+  });
+
+  it('treats { responses: [] } as no-responses and logs an error', () => {
+    const result = parseAutoResponderResponse('{"responses":[]}', true);
+    expect(result.responses).toEqual([]);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('treats { responses: [123, null] } as no-responses after filtering', () => {
+    const result = parseAutoResponderResponse('{"responses":[123, null]}', true);
+    expect(result.responses).toEqual([]);
+    expect(logger.error).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('prefers `responses` over `response` when both are present', () => {
+    const result = parseAutoResponderResponse(
+      '{"response":"single","responses":["a","b"]}',
+      true,
+    );
+    expect(result.responses).toEqual(['a', 'b']);
+  });
+
+  // ── Single response ─────────────────────────────────────────────
+
+  it('returns [s] from { response: "s" }', () => {
+    const result = parseAutoResponderResponse('{"response":"hello"}', true);
+    expect(result.responses).toEqual(['hello']);
+    expect(result.json).toEqual({ response: 'hello' });
+  });
+
+  it('falls through when `response` is a non-string', () => {
+    // jsonExpected=true → script path → error + empty.
+    const script = parseAutoResponderResponse('{"response":42}', true);
+    expect(script.responses).toEqual([]);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  // ── Plain text input (jsonExpected=false) ───────────────────────
+
+  it('returns the raw body as a single message when input is plain text and jsonExpected=false', () => {
+    const result = parseAutoResponderResponse('hello world', false);
+    expect(result.responses).toEqual(['hello world']);
+    expect(result.json).toEqual({});
+  });
+
+  it('treats whitespace-only input as a single plain-text message', () => {
+    const result = parseAutoResponderResponse('   ', false);
+    expect(result.responses).toEqual(['   ']);
+  });
+
+  // ── jsonExpected=true: strict mode ──────────────────────────────
+
+  it('errors on non-JSON input when jsonExpected=true', () => {
+    const result = parseAutoResponderResponse('not json', true);
+    expect(result.responses).toEqual([]);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringMatching(/not valid JSON/));
+  });
+
+  it('errors on JSON missing both `response` and `responses` when jsonExpected=true', () => {
+    const result = parseAutoResponderResponse('{"status":"ok"}', true);
+    expect(result.responses).toEqual([]);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringMatching(/missing valid 'response' or 'responses'/));
+  });
+
+  // ── jsonExpected=false: HTTP backwards-compat ──────────────────
+
+  it('returns the raw body when JSON parses but lacks recognised fields and jsonExpected=false', () => {
+    // Regression: webhooks that return e.g. {"status":"ok"} as
+    // acknowledgment used to get truncated-and-sent as the message.
+    // The unified parser must preserve that behaviour for HTTP.
+    const raw = '{"status":"ok"}';
+    const result = parseAutoResponderResponse(raw, false);
+    expect(result.responses).toEqual([raw]);
+    expect(result.json).toEqual({ status: 'ok' });
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('returns the raw body for a top-level JSON array when jsonExpected=false', () => {
+    // Array roots aren't `responses` (that field is *inside* an object).
+    // Fall through to raw-body single message.
+    const result = parseAutoResponderResponse('[1,2,3]', false);
+    expect(result.responses).toEqual(['[1,2,3]']);
+  });
+
+  // ── `private` flag exposure ─────────────────────────────────────
+
+  it('exposes the `private` field on `.json` so callers can force DM routing', () => {
+    const result = parseAutoResponderResponse(
+      '{"response":"msg","private":true}',
+      true,
+    );
+    expect(result.json.private).toBe(true);
+    expect(result.responses).toEqual(['msg']);
+  });
+
+  it('does not surface a `private` field for plain-text input', () => {
+    const result = parseAutoResponderResponse('plain', false);
+    expect(result.json).toEqual({});
+  });
+
+  // ── Hardening ───────────────────────────────────────────────────
+
+  it('handles JSON null without crashing', () => {
+    const result = parseAutoResponderResponse('null', false);
+    // null is valid JSON but has no fields — falls through to raw body.
+    expect(result.responses).toEqual(['null']);
+  });
+
+  it('returns empty messages on empty input with jsonExpected=true', () => {
+    const result = parseAutoResponderResponse('', true);
+    expect(result.responses).toEqual([]);
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -44,6 +44,8 @@ const TCP_READY_CONNECT_TIMEOUT_MS = 1500;
 const require = createRequire(import.meta.url);
 const packageJson = require('../../package.json');
 
+const AUTO_RESPONDER_TIMEOUT = 30_000;
+
 export interface MeshtasticConfig {
   nodeIp: string;
   tcpPort: number;
@@ -9093,9 +9095,9 @@ class MeshtasticManager implements ISourceManager {
             logger.debug(`🌐 Fetching HTTP response from: ${url}`);
 
             try {
-              // Fetch with 5-second timeout
+              // Fetch with standard auto responder timeout
               const controller = new AbortController();
-              const timeout = setTimeout(() => controller.abort(), 5000);
+              const timeout = setTimeout(() => controller.abort(), AUTO_RESPONDER_TIMEOUT);
 
               const response = await fetch(url, {
                 signal: controller.signal,
@@ -9200,10 +9202,10 @@ class MeshtasticManager implements ISourceManager {
                 logger.debug(`🤖 Script args expanded: ${trigger.scriptArgs} -> ${JSON.stringify(scriptArgsList)}`);
               }
 
-              // Execute script with 30-second timeout
+              // Execute script with standard auto responder timeout
               // Use resolvedPath (actual file path) instead of scriptPath (API format)
               const { stdout, stderr } = await execFileAsync(interpreter, [resolvedPath, ...scriptArgsList], {
-                timeout: 30000,
+                timeout: AUTO_RESPONDER_TIMEOUT,
                 env: scriptEnv,
                 maxBuffer: 1024 * 1024, // 1MB max output
               });
@@ -9212,31 +9214,9 @@ class MeshtasticManager implements ISourceManager {
                 logger.warn(`🔧 Auto-responder script for "${triggerPattern}" stderr: ${stderr}`);
               }
 
-              // Parse JSON output
-              let scriptOutput;
-              try {
-                scriptOutput = JSON.parse(stdout.trim());
-              } catch (parseError) {
-                logger.error(`❌ Script output is not valid JSON: ${stdout.substring(0, 100)}`);
-                return;
-              }
-
               // Support both single response and multiple responses
-              let scriptResponses: string[];
-              if (scriptOutput.responses && Array.isArray(scriptOutput.responses)) {
-                // Multiple responses format: { "responses": ["msg1", "msg2", "msg3"] }
-                scriptResponses = scriptOutput.responses.filter((r: any) => typeof r === 'string');
-                if (scriptResponses.length === 0) {
-                  logger.error(`❌ Script 'responses' array contains no valid strings`);
-                  return;
-                }
-                logger.debug(`📥 Script returned ${scriptResponses.length} responses`);
-              } else if (scriptOutput.response && typeof scriptOutput.response === 'string') {
-                // Single response format: { "response": "msg" }
-                scriptResponses = [scriptOutput.response];
-                logger.debug(`📥 Script response: ${scriptOutput.response.substring(0, 50)}...`);
-              } else {
-                logger.error(`❌ Script output missing valid 'response' or 'responses' field`);
+              const scriptResp = this.parseAutoResponderResponse(stdout.trim(), true);
+              if (scriptResp.responses.length === 0) {
                 return;
               }
 
@@ -9262,15 +9242,15 @@ class MeshtasticManager implements ISourceManager {
               //   - "private": true  -> force DM reply to the sender
               //   - "private": false -> force channel reply even if the trigger was a DM
               let isDM = isDirectMessage;
-              if (typeof scriptOutput.private === 'boolean') {
-                isDM = scriptOutput.private;
+              if (typeof scriptResp.json.private === 'boolean') {
+                isDM = scriptResp.json.private;
               }
               // For DMs: use 3 attempts if verifyResponse is enabled, otherwise just 1 attempt
               const maxAttempts = isDM ? (trigger.verifyResponse ? 3 : 1) : 1;
               const target = isDM ? `!${message.fromNodeNum.toString(16).padStart(8, '0')}` : `channel ${message.channel}`;
-              logger.debug(`🤖 Enqueueing ${scriptResponses.length} script response(s) to ${target}${trigger.verifyResponse ? ' (with verification)' : ''}`);
+              logger.debug(`🤖 Enqueueing ${scriptResp.responses.length} script response(s) to ${target}${trigger.verifyResponse ? ' (with verification)' : ''}`);
 
-              scriptResponses.forEach((resp, index) => {
+              scriptResp.responses.forEach((resp, index) => {
                 const truncated = this.truncateMessageForMeshtastic(resp, 200);
                 const isFirstMessage = index === 0;
 
@@ -9279,10 +9259,10 @@ class MeshtasticManager implements ISourceManager {
                   isDM ? message.fromNodeNum : 0, // destination: node number for DM, 0 for channel
                   isFirstMessage ? packetId : undefined, // Reply to original message for first response
                   () => {
-                    logger.info(`✅ Script response ${index + 1}/${scriptResponses.length} delivered to ${target}`);
+                    logger.info(`✅ Script response ${index + 1}/${scriptResp.responses.length} delivered to ${target}`);
                   },
                   (reason: string) => {
-                    logger.warn(`❌ Script response ${index + 1}/${scriptResponses.length} failed to ${target}: ${reason}`);
+                    logger.warn(`❌ Script response ${index + 1}/${scriptResp.responses.length} failed to ${target}: ${reason}`);
                   },
                   isDM ? undefined : message.channel as number, // channel: undefined for DM, channel number for channel
                   maxAttempts
@@ -9291,7 +9271,7 @@ class MeshtasticManager implements ISourceManager {
 
               // Script responses queued
               const scriptDuration = Date.now() - scriptStartTime;
-              logger.info(`🔧 Auto-responder script for "${triggerPattern}" completed in ${scriptDuration}ms, ${scriptResponses.length} response(s) queued to ${target}`);
+              logger.info(`🔧 Auto-responder script for "${triggerPattern}" completed in ${scriptDuration}ms, ${scriptResp.responses.length} response(s) queued to ${target}`);
 
               // Record cooldown timestamp
               const triggerCooldownScript = trigger.cooldownSeconds || 0;
@@ -9449,23 +9429,21 @@ class MeshtasticManager implements ISourceManager {
             responseText = await this.replaceAcknowledgementTokens(responseText, nodeId, message.fromNodeNum, hopsTraveled, receivedDate, receivedTime, message.channel, isDirectMessage, message.rxSnr, message.rxRssi, message.viaMqtt);
           }
 
-          // Handle multiline responses or truncate as needed
           const multilineEnabled = trigger.multiline || false;
-          let messagesToSend: string[];
-
-          if (multilineEnabled) {
+          const responseValue = this.parseAutoResponderResponse(responseText, false);
+          if (multilineEnabled && responseValue.responses.length === 1) {
             // Split into multiple messages if enabled
-            messagesToSend = this.splitMessageForMeshtastic(responseText, 200);
-            if (messagesToSend.length > 1) {
-              logger.debug(`📝 Split response into ${messagesToSend.length} messages`);
+            responseValue.responses = this.splitMessageForMeshtastic(responseValue.responses[0], 200);
+            if (responseValue.responses.length > 1) {
+              logger.debug(`📝 Split response into ${responseValue.responses.length} messages`);
             }
           } else {
-            // Truncate to single message
-            const truncated = this.truncateMessageForMeshtastic(responseText, 200);
-            if (truncated !== responseText) {
-              logger.debug(`✂️  Response truncated from ${responseText.length} to ${truncated.length} characters`);
-            }
-            messagesToSend = [truncated];
+            // Truncate all responses
+            responseValue.responses = responseValue.responses.map((oldVal, i) => {
+              const newVal = this.truncateMessageForMeshtastic(oldVal, 200);
+              logger.debug(`✂️  Response ${i + 1} truncated from ${oldVal.length} to ${newVal.length} characters`);
+              return newVal;
+            });
           }
 
           // Enqueue all messages for delivery with retry logic
@@ -9474,19 +9452,19 @@ class MeshtasticManager implements ISourceManager {
           // For DMs: use 3 attempts if verifyResponse is enabled, otherwise just 1 attempt
           const maxAttempts = isDM ? (trigger.verifyResponse ? 3 : 1) : 1;
           const target = isDM ? `!${message.fromNodeNum.toString(16).padStart(8, '0')}` : `channel ${message.channel}`;
-          logger.debug(`🤖 Enqueueing ${messagesToSend.length} auto-response message(s) to ${target}${trigger.verifyResponse ? ' (with verification)' : ''}`);
+          logger.debug(`🤖 Enqueueing ${responseValue.responses.length} auto-response message(s) to ${target}${trigger.verifyResponse ? ' (with verification)' : ''}`);
 
-          messagesToSend.forEach((msg, index) => {
+          responseValue.responses.forEach((msg, index) => {
             const isFirstMessage = index === 0;
             this.messageQueue.enqueue(
               msg,
               isDM ? message.fromNodeNum : 0, // destination: node number for DM, 0 for channel
               isFirstMessage ? packetId : undefined, // Reply to original message for first response
               () => {
-                logger.info(`✅ Auto-response ${index + 1}/${messagesToSend.length} delivered to ${target}`);
+                logger.info(`✅ Auto-response ${index + 1}/${responseValue.responses.length} delivered to ${target}`);
               },
               (reason: string) => {
-                logger.warn(`❌ Auto-response ${index + 1}/${messagesToSend.length} failed to ${target}: ${reason}`);
+                logger.warn(`❌ Auto-response ${index + 1}/${responseValue.responses.length} failed to ${target}: ${reason}`);
               },
               isDM ? undefined : message.channel as number, // channel: undefined for DM, channel number for channel
               maxAttempts
@@ -9506,6 +9484,41 @@ class MeshtasticManager implements ISourceManager {
 
     } catch (error) {
       logger.error('❌ Error in auto-responder:', error);
+    }
+  }
+
+  private parseAutoResponderResponse(rawResp: string, jsonExpected: boolean): { json: any, responses: string[] } {
+    // try to parse response as JSON...
+    let jsonResp;
+    try {
+      jsonResp = JSON.parse(rawResp);
+    } catch (_) {
+      if (jsonExpected) {
+        logger.error(`❌ Auto responder output is not valid JSON: ${rawResp.substring(0, 100)}`);
+        return { json: {}, responses: [] };
+      }
+
+      return { json: {}, responses: [rawResp] };
+    }
+
+    // Support both single response and multiple responses
+    if (jsonResp.responses && Array.isArray(jsonResp.responses)) {
+      // Multiple responses format: { "responses": ["msg1", "msg2", "msg3"] }
+      const responses = jsonResp.responses.filter((r: any) => typeof r === 'string');
+      if (responses.length === 0) {
+        logger.error(`❌ Auto responder output 'responses' array contains no valid strings`);
+      } else {
+        logger.debug(`📥 Auto responder returned ${responses.length} responses`);
+      }
+
+      return { json: jsonResp, responses: responses };
+    } else if (jsonResp.response && typeof jsonResp.response === 'string') {
+      // Single response format: { "response": "msg" }
+      logger.debug(`📥 Auto responder output: ${jsonResp.response.substring(0, 50)}...`);
+      return { json: jsonResp, responses: [jsonResp.response] };
+    } else {
+      logger.error(`❌ Auto responder output missing valid 'response' or 'responses' field`);
+      return { json: {}, responses: [] };
     }
   }
 

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -44,7 +44,94 @@ const TCP_READY_CONNECT_TIMEOUT_MS = 1500;
 const require = createRequire(import.meta.url);
 const packageJson = require('../../package.json');
 
-const AUTO_RESPONDER_TIMEOUT = 30_000;
+// Auto-responder timeouts are split so the HTTP path can stay snappy
+// (mesh consumers wait synchronously for the trigger to fire) while
+// scripts get a longer budget for legitimate work. Keep both ≤ the
+// 30s rate-limit so a slow backend can't fully consume the budget.
+const HTTP_AUTO_RESPONDER_TIMEOUT_MS = 5_000;
+const SCRIPT_AUTO_RESPONDER_TIMEOUT_MS = 30_000;
+
+/** Parsed auto-responder payload: list of messages to send, plus the
+ * raw decoded JSON object (or `{}` if the payload was plain text) so
+ * callers can read optional fields like `private`. */
+export interface AutoResponderParsed {
+  json: Record<string, unknown>;
+  responses: string[];
+}
+
+/**
+ * Parse an auto-responder response payload (script stdout or HTTP
+ * body) into a normalized `{ json, responses }` shape.
+ *
+ * Accepted formats:
+ *   { "responses": ["…", "…"] }    multi-message JSON
+ *   { "response": "…" }             single-message JSON
+ *   "plain text"                    only when jsonExpected=false
+ *
+ * `jsonExpected=true` (script path) requires JSON output with one of
+ * the two recognised fields; anything else logs an error and returns
+ * no messages. `jsonExpected=false` (HTTP / text path) keeps the raw
+ * body as a single response when the input either fails to parse OR
+ * parses to a JSON object that doesn't carry `response`/`responses`
+ * — preserves pre-PR behaviour for third-party endpoints that happen
+ * to return JSON shaped differently from MeshMonitor's convention.
+ *
+ * Exported so unit tests can exercise the matrix of inputs without
+ * standing up a MeshtasticManager.
+ */
+export function parseAutoResponderResponse(
+  rawResp: string,
+  jsonExpected: boolean,
+): AutoResponderParsed {
+  let jsonResp: unknown;
+  try {
+    jsonResp = JSON.parse(rawResp);
+  } catch (_) {
+    if (jsonExpected) {
+      logger.error(`❌ Auto responder output is not valid JSON: ${rawResp.substring(0, 100)}`);
+      return { json: {}, responses: [] };
+    }
+    return { json: {}, responses: [rawResp] };
+  }
+
+  // Narrow to a record so we can index by field name without `any`.
+  const obj = (jsonResp !== null && typeof jsonResp === 'object')
+    ? (jsonResp as Record<string, unknown>)
+    : ({} as Record<string, unknown>);
+
+  // Multiple responses format: { "responses": ["msg1", "msg2", ...] }
+  if (Array.isArray(obj.responses)) {
+    const arr = obj.responses;
+    const responses = arr.filter((r): r is string => typeof r === 'string');
+    const dropped = arr.length - responses.length;
+    if (dropped > 0) {
+      logger.warn(`⚠️  Auto responder 'responses' array dropped ${dropped} non-string entr${dropped === 1 ? 'y' : 'ies'}`);
+    }
+    if (responses.length === 0) {
+      logger.error(`❌ Auto responder output 'responses' array contains no valid strings`);
+    } else {
+      logger.debug(`📥 Auto responder returned ${responses.length} response(s)`);
+    }
+    return { json: obj, responses };
+  }
+
+  // Single response format: { "response": "msg" }
+  if (typeof obj.response === 'string') {
+    logger.debug(`📥 Auto responder output: ${obj.response.substring(0, 50)}…`);
+    return { json: obj, responses: [obj.response] };
+  }
+
+  // JSON parsed but no recognised field. For the script path this is
+  // a hard error. For HTTP/text we fall back to the raw body so
+  // existing webhooks that return e.g. {"status":"ok"} keep behaving
+  // as they did before this refactor (truncate-and-send).
+  if (jsonExpected) {
+    logger.error(`❌ Auto responder output missing valid 'response' or 'responses' field`);
+    return { json: {}, responses: [] };
+  }
+  logger.debug(`📥 Auto responder JSON body has no 'response'/'responses' field; using raw body as single message`);
+  return { json: obj, responses: [rawResp] };
+}
 
 export interface MeshtasticConfig {
   nodeIp: string;
@@ -9095,9 +9182,11 @@ class MeshtasticManager implements ISourceManager {
             logger.debug(`🌐 Fetching HTTP response from: ${url}`);
 
             try {
-              // Fetch with standard auto responder timeout
+              // Fetch with HTTP auto-responder timeout (5s). Kept shorter
+              // than the script timeout so mesh-trigger latency stays
+              // bounded even if the backend is slow.
               const controller = new AbortController();
-              const timeout = setTimeout(() => controller.abort(), AUTO_RESPONDER_TIMEOUT);
+              const timeout = setTimeout(() => controller.abort(), HTTP_AUTO_RESPONDER_TIMEOUT_MS);
 
               const response = await fetch(url, {
                 signal: controller.signal,
@@ -9202,10 +9291,10 @@ class MeshtasticManager implements ISourceManager {
                 logger.debug(`🤖 Script args expanded: ${trigger.scriptArgs} -> ${JSON.stringify(scriptArgsList)}`);
               }
 
-              // Execute script with standard auto responder timeout
+              // Execute script with the script-side auto-responder timeout (30s)
               // Use resolvedPath (actual file path) instead of scriptPath (API format)
               const { stdout, stderr } = await execFileAsync(interpreter, [resolvedPath, ...scriptArgsList], {
-                timeout: AUTO_RESPONDER_TIMEOUT,
+                timeout: SCRIPT_AUTO_RESPONDER_TIMEOUT_MS,
                 env: scriptEnv,
                 maxBuffer: 1024 * 1024, // 1MB max output
               });
@@ -9431,24 +9520,39 @@ class MeshtasticManager implements ISourceManager {
 
           const multilineEnabled = trigger.multiline || false;
           const responseValue = this.parseAutoResponderResponse(responseText, false);
+          if (responseValue.responses.length === 0) {
+            // parseAutoResponderResponse already logged the reason
+            return;
+          }
           if (multilineEnabled && responseValue.responses.length === 1) {
-            // Split into multiple messages if enabled
+            // Split into multiple messages if enabled — only safe when
+            // the parsed payload was a single response. Multi-response
+            // JSON intentionally bypasses splitting (see Multiple
+            // Responses Support in docs/features/automation.md).
             responseValue.responses = this.splitMessageForMeshtastic(responseValue.responses[0], 200);
             if (responseValue.responses.length > 1) {
               logger.debug(`📝 Split response into ${responseValue.responses.length} messages`);
             }
           } else {
-            // Truncate all responses
+            // Truncate each response and only log when truncation actually changed bytes.
             responseValue.responses = responseValue.responses.map((oldVal, i) => {
               const newVal = this.truncateMessageForMeshtastic(oldVal, 200);
-              logger.debug(`✂️  Response ${i + 1} truncated from ${oldVal.length} to ${newVal.length} characters`);
+              if (newVal.length !== oldVal.length) {
+                logger.debug(`✂️  Response ${i + 1} truncated from ${oldVal.length} to ${newVal.length} characters`);
+              }
               return newVal;
             });
           }
 
           // Enqueue all messages for delivery with retry logic
-          // Respond on the channel the message came from
-          const isDM = isDirectMessage;
+          // Respond on the channel the message came from.
+          // HTTP and text triggers honor an optional `"private": true`
+          // field in their JSON payload to force DM routing (same
+          // behaviour as the script path).
+          let isDM = isDirectMessage;
+          if (typeof responseValue.json.private === 'boolean') {
+            isDM = responseValue.json.private;
+          }
           // For DMs: use 3 attempts if verifyResponse is enabled, otherwise just 1 attempt
           const maxAttempts = isDM ? (trigger.verifyResponse ? 3 : 1) : 1;
           const target = isDM ? `!${message.fromNodeNum.toString(16).padStart(8, '0')}` : `channel ${message.channel}`;
@@ -9487,39 +9591,8 @@ class MeshtasticManager implements ISourceManager {
     }
   }
 
-  private parseAutoResponderResponse(rawResp: string, jsonExpected: boolean): { json: any, responses: string[] } {
-    // try to parse response as JSON...
-    let jsonResp;
-    try {
-      jsonResp = JSON.parse(rawResp);
-    } catch (_) {
-      if (jsonExpected) {
-        logger.error(`❌ Auto responder output is not valid JSON: ${rawResp.substring(0, 100)}`);
-        return { json: {}, responses: [] };
-      }
-
-      return { json: {}, responses: [rawResp] };
-    }
-
-    // Support both single response and multiple responses
-    if (jsonResp.responses && Array.isArray(jsonResp.responses)) {
-      // Multiple responses format: { "responses": ["msg1", "msg2", "msg3"] }
-      const responses = jsonResp.responses.filter((r: any) => typeof r === 'string');
-      if (responses.length === 0) {
-        logger.error(`❌ Auto responder output 'responses' array contains no valid strings`);
-      } else {
-        logger.debug(`📥 Auto responder returned ${responses.length} responses`);
-      }
-
-      return { json: jsonResp, responses: responses };
-    } else if (jsonResp.response && typeof jsonResp.response === 'string') {
-      // Single response format: { "response": "msg" }
-      logger.debug(`📥 Auto responder output: ${jsonResp.response.substring(0, 50)}...`);
-      return { json: jsonResp, responses: [jsonResp.response] };
-    } else {
-      logger.error(`❌ Auto responder output missing valid 'response' or 'responses' field`);
-      return { json: {}, responses: [] };
-    }
+  private parseAutoResponderResponse(rawResp: string, jsonExpected: boolean): AutoResponderParsed {
+    return parseAutoResponderResponse(rawResp, jsonExpected);
   }
 
   /**


### PR DESCRIPTION
# Summary

This PR unifies the Auto Responder functionality by enabling multiple response support for HTTP response type triggers, bringing HTTP triggers to feature parity with Script triggers.

# Problem

Previously, Auto Responder had inconsistent behavior between response types:
- **Script triggers**: Already supported multiple responses via `{ "responses": [...] }` JSON format
- **HTTP triggers**: Only supported a single response (plain text)

This meant that users wanting to send multiple messages via HTTP had to use workarounds like chaining multiple triggers or using scripts as intermediaries.

# Solution

The change refactors the auto-responder response handling to use a common `parseAutoResponderResponse()` method for all response types (HTTP, text, script). This method:

1. Parses JSON responses to extract either `response` (single) or `responses` (multiple) fields
2. Falls back to treating plain text as a single response

This allows HTTP triggers to return multiple responses in the same way as scripts:

**Plain text response (existing behavior):**
```
Plain text single message
```

**Json response (single message, new):**
```json
{
  "response": "Single message"
}
```

**Json response (multiple messages, new):**
```json
{
  "responses": [
    "First message",
    "Second message",
    "Third message"
  ]
}
```

# Changes

## `src/server/meshtasticManager.ts`

1. **Added `AUTO_RESPONDER_TIMEOUT` constant** (30 seconds)
   - Standardizes timeout across HTTP and script triggers
   - HTTP: increased from 5s to 30s

2. **Refactored HTTP response handling**
   - HTTP response text is now parsed using `parseAutoResponderResponse()`
   - Supports both single JSON response and multiple responses array
   - Maintains backward compatibility with plain text responses

3. **Refactored Script response handling**
   - Script output now uses the same `parseAutoResponderResponse()` method to avoid duplicate parsing logic

## `docs/features/automation.md`

1. **Updated documentation**
   - Added section `Multiple Responses Support`
   - Updated response types descriptions (now it have links to new `Multiple Responses Support` section)

# Backward Compatibility

✅ **Fully backward compatible**

- Existing HTTP triggers returning plain text continue to work
- Existing Script triggers using `response` or `responses` continue to work

# Benefits

1. **Feature parity**: HTTP and Script triggers now support the same response formats
2. **Simplified configuration**: No need for script workarounds to send multiple HTTP responses