### PR TITLE
fix(sources): real status badge for anonymous + mesh-activity badge (#2883)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4211,6 +4211,8 @@
   "source.status_connecting": "Connecting",
   "source.status_disabled": "Disabled",
   "source.status_idle": "Idle (manual)",
+  "source.node_activity": "{{active}}/{{total}} active",
+  "source.node_activity_title": "{{active}} of {{total}} nodes heard in the last 2 hours",
   "source.connect": "Connect",
   "source.connecting": "Connecting…",
   "source.connect_help": "Manually connect to this source. Auto-connect is disabled, so this source won't reconnect on its own.",

--- a/src/components/Dashboard/DashboardSidebar.test.tsx
+++ b/src/components/Dashboard/DashboardSidebar.test.tsx
@@ -110,6 +110,41 @@ describe('DashboardSidebar', () => {
     expect(screen.queryByRole('button', { name: 'source.options' })).not.toBeInTheDocument();
   });
 
+  it('renders mesh-activity badge with the live tone when most heard nodes are recent', () => {
+    const statusMap = new Map<string, SourceStatus | null>([
+      ['src-1', { sourceId: 'src-1', connected: true, activeNodeCount: 4 }],
+      ['src-2', { sourceId: 'src-2', connected: false }],
+      ['src-3', null],
+    ]);
+    renderSidebar({ statusMap });
+    const live = document.querySelector('.dashboard-activity-live');
+    expect(live).toBeInTheDocument();
+    // The i18n test mock returns keys verbatim — verify the mesh-activity
+    // key wires through (interpolation isn't exercised here).
+    expect(live?.textContent).toMatch(/source\.node_activity/);
+  });
+
+  it('renders mesh-activity badge with idle tone when zero nodes heard recently', () => {
+    const statusMap = new Map<string, SourceStatus | null>([
+      ['src-1', { sourceId: 'src-1', connected: true, activeNodeCount: 0 }],
+      ['src-2', { sourceId: 'src-2', connected: false }],
+      ['src-3', null],
+    ]);
+    renderSidebar({ statusMap });
+    expect(document.querySelector('.dashboard-activity-idle')).toBeInTheDocument();
+  });
+
+  it('omits mesh-activity badge when activeNodeCount is missing from server', () => {
+    // Older server / pre-migration deployment — graceful fallback
+    const statusMap = new Map<string, SourceStatus | null>([
+      ['src-1', { sourceId: 'src-1', connected: true }],
+      ['src-2', { sourceId: 'src-2', connected: false }],
+      ['src-3', null],
+    ]);
+    renderSidebar({ statusMap });
+    expect(document.querySelector('.dashboard-activity-badge')).not.toBeInTheDocument();
+  });
+
   it('shows sidebar navigation links', () => {
     renderSidebar();
     expect(screen.getByRole('button', { name: /source\.sidebar\.unified_messages/ })).toBeInTheDocument();

--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -41,6 +41,38 @@ interface DashboardSidebarProps {
   onNewsClick?: () => void;
 }
 
+/**
+ * Build the per-source mesh-activity badge shown beside the link-state badge.
+ *
+ * The link-state badge ("Connected"/"Connecting"/...) only reflects the
+ * MeshMonitor↔gateway TCP/serial link. Users on issue #2883 found that
+ * misleading because a gateway can be "Connected" while every mesh node it
+ * has heard is now stale. This badge complements link state with mesh
+ * liveness — total nodes vs. nodes heard in the last ~2h — colored by ratio
+ * so a glance tells you how lively the source is right now.
+ *
+ * Returns `null` when there's nothing useful to show (no nodes ever heard,
+ * server didn't include the count, or the source isn't enabled).
+ */
+function getActivityBadge(
+  total: number,
+  active: number | undefined,
+  t: (key: string, opts?: any) => string,
+): { text: string; tone: 'live' | 'partial' | 'idle'; title: string } | null {
+  if (active === undefined || total <= 0) return null;
+  // Live = >50% of heard nodes still active; partial = some but minority;
+  // idle = none heard recently. Picking a ratio rather than absolute count
+  // keeps small (<5 node) sources from constantly flipping to "idle" while
+  // still flagging large fleets where most nodes have gone quiet.
+  const tone: 'live' | 'partial' | 'idle' =
+    active === 0 ? 'idle' : active * 2 >= total ? 'live' : 'partial';
+  return {
+    text: t('source.node_activity', { active, total }),
+    tone,
+    title: t('source.node_activity_title', { active, total }),
+  };
+}
+
 function getStatusInfo(
   source: DashboardSource,
   status: SourceStatus | null | undefined,
@@ -219,11 +251,8 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
         const isConnecting = !isUnified && connectingIds?.has(source.id) === true;
         // Unified is a virtual aggregate — show "connected" dot whenever any
         // backing source is connected. Prefer the server-computed
-        // `unifiedStatus.connected` (reachable to anonymous viewers) and fall
-        // back to scanning the per-source statusMap when the poll hasn't
-        // landed yet. The statusMap fallback alone would always read
-        // disconnected for unauthenticated users since /api/sources/:id/status
-        // requires sources:read.
+        // `unifiedStatus.connected` and fall back to scanning the per-source
+        // statusMap when the poll hasn't landed yet.
         const unifiedConnected = isUnified
           ? unifiedStatus?.connected ??
             Array.from(statusMap.values()).some((s) => s?.connected === true)
@@ -237,6 +266,16 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
             : getStatusInfo(source, status, t);
         const nodeCount = nodeCounts.get(source.id) ?? 0;
         const isSelected = selectedSourceId === source.id;
+        // Mesh-activity badge — shown only for enabled sources with a known
+        // active count. Unified pulls from the aggregate endpoint so anonymous
+        // viewers also see it; per-source uses the gated /status response.
+        const activityBadge = source.enabled
+          ? isUnified
+            ? getActivityBadge(unifiedStatus?.nodeCount ?? nodeCount, unifiedStatus?.activeNodeCount, t)
+            : status
+              ? getActivityBadge(nodeCount, status.activeNodeCount as number | undefined, t)
+              : null
+          : null;
 
         // Show the Meshtastic logo as a faint watermark for any meshtastic-typed
         // source. Other source types render without a watermark.
@@ -292,6 +331,14 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
             <div className="dashboard-source-card-status">
               <span className={`dashboard-status-dot ${dotClass}`} />
               <span>{label}</span>
+              {activityBadge && (
+                <span
+                  className={`dashboard-activity-badge dashboard-activity-${activityBadge.tone}`}
+                  title={activityBadge.title}
+                >
+                  {activityBadge.text}
+                </span>
+              )}
             </div>
 
             <div className="dashboard-source-card-actions">

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -224,6 +224,28 @@ export class NodesRepository extends BaseRepository {
   }
 
   /**
+   * Count nodes whose `lastHeard` falls within the given window (default 2h).
+   *
+   * Powers the per-source "node activity" badge in the dashboard sidebar so
+   * users can tell at a glance whether a source is hearing live mesh traffic
+   * even when the gateway link itself is up (issue #2883). The link-state
+   * badge only reflects MeshMonitor↔gateway TCP/serial; this complements it
+   * with mesh-level liveness.
+   *
+   * `lastHeard` is stored in seconds (Unix epoch). Returns 0 for a source
+   * with no recently-heard nodes.
+   */
+  async getActiveNodeCount(sourceId?: string, sinceSeconds: number = 7200): Promise<number> {
+    const cutoff = Math.floor(Date.now() / 1000) - sinceSeconds;
+    const { nodes } = this.tables;
+    const result = await this.db
+      .select({ count: count() })
+      .from(nodes)
+      .where(and(gt(nodes.lastHeard, cutoff), this.withSourceScope(nodes, sourceId)));
+    return Number(result[0].count);
+  }
+
+  /**
    * Count distinct nodeNums across the given source IDs.
    *
    * Used by the Unified source card so the displayed count reflects the
@@ -242,6 +264,23 @@ export class NodesRepository extends BaseRepository {
       .select({ count: countDistinct(nodes.nodeNum) })
       .from(nodes)
       .where(inArray(nodes.sourceId, sourceIds));
+    return Number(result[0].count);
+  }
+
+  /**
+   * Count distinct nodeNums heard within the window across the given source
+   * IDs. Powers the Unified card's node-activity badge (issue #2883) so a
+   * single deduped active count is shown across the whole fleet, matching
+   * the deduped total. Returns 0 when sourceIds is empty.
+   */
+  async getDistinctActiveNodeCount(sourceIds: string[], sinceSeconds: number = 7200): Promise<number> {
+    if (sourceIds.length === 0) return 0;
+    const cutoff = Math.floor(Date.now() / 1000) - sinceSeconds;
+    const { nodes } = this.tables;
+    const result = await this.db
+      .select({ count: countDistinct(nodes.nodeNum) })
+      .from(nodes)
+      .where(and(inArray(nodes.sourceId, sourceIds), gt(nodes.lastHeard, cutoff)));
     return Number(result[0].count);
   }
 

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -32,6 +32,11 @@ export interface SourceStatus {
   connected: boolean;
   /** Total nodes heard by this source — populated by GET /api/sources/:id/status. */
   nodeCount?: number;
+  /**
+   * Nodes heard by this source within the last ~2h. Powers the sidebar's
+   * mesh-activity badge alongside the link-state badge (issue #2883).
+   */
+  activeNodeCount?: number;
   [key: string]: unknown;
 }
 
@@ -107,6 +112,11 @@ export function useSourceStatuses(sourceIds: string[]): Map<string, SourceStatus
 export interface UnifiedStatus {
   /** Distinct nodeNum count across every source the user can read. */
   nodeCount: number;
+  /**
+   * Distinct count of nodes heard within the last ~2h across every readable
+   * source. Mirrors the per-source `activeNodeCount` (issue #2883).
+   */
+  activeNodeCount?: number;
   /** True when any readable source is currently connected. */
   connected: boolean;
 }

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -309,7 +309,13 @@ router.delete('/:id', requirePermission('sources', 'write'), async (req: Request
 // each source has heard without having to fetch every source's full node list
 // (the sidebar polls /status for every source on a 15s interval, but the
 // expensive /nodes endpoint is only fetched for the *selected* source).
-router.get('/:id/status', requirePermission('sources', 'read'), async (req: Request, res: Response) => {
+// `optionalAuth` (not requirePermission) so anonymous viewers see live
+// connection state — same approach as /api/unified/sources-status. The
+// sidebar badge is operational signal, not user-scoped data, and gating it
+// caused anonymous users to see "Connecting"/"Idle" forever (issue #2883).
+// Node counts remain permission-scoped: only included when the caller has
+// `nodes:read` for this source, mirroring the unified endpoint.
+router.get('/:id/status', optionalAuth(), async (req: Request, res: Response) => {
   try {
     const source = await databaseService.sources.getSource(req.params.id);
     if (!source) {
@@ -322,9 +328,26 @@ router.get('/:id/status', requirePermission('sources', 'read'), async (req: Requ
       sourceType: source.type,
       connected: false,
     };
-    // Cheap COUNT(*) — never throws on empty source.
-    const nodeCount = await databaseService.nodes.getNodeCount(source.id).catch(() => 0);
-    res.json({ ...status, nodeCount });
+
+    const user = (req as any).user;
+    const isAdmin = user?.isAdmin ?? false;
+    const canReadNodes = isAdmin || (user
+      ? await databaseService.checkPermissionAsync(user.id, 'nodes', 'read', source.id)
+      : false);
+
+    if (!canReadNodes) {
+      return res.json(status);
+    }
+
+    // Cheap COUNT(*) queries — never throw on empty source.
+    // `activeNodeCount` is the count of nodes heard in the last 2h, used by
+    // the sidebar's node-activity badge (issue #2883). Kept parallel with
+    // the total count so source status fans out in a single round-trip.
+    const [nodeCount, activeNodeCount] = await Promise.all([
+      databaseService.nodes.getNodeCount(source.id).catch(() => 0),
+      databaseService.nodes.getActiveNodeCount(source.id).catch(() => 0),
+    ]);
+    res.json({ ...status, nodeCount, activeNodeCount });
   } catch (error) {
     logger.error('Error fetching source status:', error);
     res.status(500).json({ error: 'Failed to fetch source status' });

--- a/src/server/routes/unifiedRoutes.test.ts
+++ b/src/server/routes/unifiedRoutes.test.ts
@@ -27,6 +27,7 @@ vi.mock('../../services/database.js', () => ({
     nodes: {
       getAllNodes: vi.fn(),
       getDistinctNodeCount: vi.fn(),
+      getDistinctActiveNodeCount: vi.fn().mockResolvedValue(0),
     },
     telemetry: {
       getLatestTelemetryByNode: vi.fn(),
@@ -887,9 +888,10 @@ describe('Unified Routes', () => {
       const res = await request(app).get('/status');
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ nodeCount: 42, connected: false });
+      expect(res.body).toEqual({ nodeCount: 42, activeNodeCount: 0, connected: false });
       // Admin gets every source's id passed through.
       expect(mockDb.nodes.getDistinctNodeCount).toHaveBeenCalledWith(['src-a', 'src-b']);
+      expect(mockDb.nodes.getDistinctActiveNodeCount).toHaveBeenCalledWith(['src-a', 'src-b']);
     });
 
     it('limits the count to sources the user has read permission on', async () => {
@@ -917,7 +919,7 @@ describe('Unified Routes', () => {
       const res = await request(app).get('/status');
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ nodeCount: 0, connected: false });
+      expect(res.body).toEqual({ nodeCount: 0, activeNodeCount: 0, connected: false });
       expect(mockDb.nodes.getDistinctNodeCount).toHaveBeenCalledWith([]);
     });
   });

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -685,9 +685,15 @@ router.get('/status', async (req: Request, res: Response) => {
         : false);
       if (canRead) allowedIds.push(source.id);
     }
-    const nodeCount = await databaseService.nodes.getDistinctNodeCount(allowedIds);
+    // Distinct counts across permitted sources. `activeNodeCount` mirrors the
+    // per-source endpoint (issue #2883) using the same 2h window so the
+    // Unified card and individual source cards line up.
+    const [nodeCount, activeNodeCount] = await Promise.all([
+      databaseService.nodes.getDistinctNodeCount(allowedIds),
+      databaseService.nodes.getDistinctActiveNodeCount(allowedIds),
+    ]);
 
-    res.json({ nodeCount, connected: anyConnected });
+    res.json({ nodeCount, activeNodeCount, connected: anyConnected });
   } catch (error) {
     logger.error('Error fetching unified status:', error);
     res.status(500).json({ error: 'Failed to fetch unified status' });

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -230,6 +230,33 @@
   background: var(--ctp-surface2);
 }
 
+.dashboard-activity-badge {
+  margin-left: auto;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.4;
+  background: var(--ctp-surface1);
+  color: var(--ctp-subtext0);
+  white-space: nowrap;
+}
+
+.dashboard-activity-badge.dashboard-activity-live {
+  background: color-mix(in srgb, var(--ctp-green) 20%, transparent);
+  color: var(--ctp-green);
+}
+
+.dashboard-activity-badge.dashboard-activity-partial {
+  background: color-mix(in srgb, var(--ctp-yellow) 22%, transparent);
+  color: var(--ctp-yellow);
+}
+
+.dashboard-activity-badge.dashboard-activity-idle {
+  background: color-mix(in srgb, var(--ctp-red) 18%, transparent);
+  color: var(--ctp-red);
+}
+
 .dashboard-source-card-actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #2883

## Summary
- `/api/sources/:id/status` is now `optionalAuth()` instead of `requirePermission('sources','read')`. Anonymous viewers were getting 403 → frontend fell into the `!status` branch of `getStatusInfo` and rendered "Connecting" (or "Idle" for `autoConnect=false` sources) forever, regardless of real gateway state. Counts (`nodeCount`, `activeNodeCount`) remain gated behind `nodes:read`, mirroring `/api/unified/sources-status`.
- Adds a **mesh-activity badge** alongside the existing link-state badge: shows `N/M active` (nodes heard in the last 2 h) color-coded **live** (≥50% active), **partial**, or **idle** (zero). The link badge only reflects MeshMonitor↔gateway TCP/serial — users on #2883 saw "Connected" while every node that source had heard was stale.
- New repo methods `getActiveNodeCount` and `getDistinctActiveNodeCount` (Drizzle, all three backends). Wired through `/api/sources/:id/status` and `/api/unified/status` in parallel with the existing total counts.

## Test plan
- [x] `npx vitest run` — 1132/0 (focused) and 1373/0 (broader sweep) green
- [x] `npx tsc --noEmit` — clean
- [x] Manual: anonymous viewer on dev container correctly shows live "Connected" / "Connecting" / "Idle" matching the manager state (previously stuck on "Connecting"/"Idle")
- [x] Manual: per-source mesh-activity pill renders with correct tone for fleets with mixed active/stale nodes
- [x] Manual: counts hidden from anonymous on this instance — `/api/sources/:id/status` returns `{connected, sourceId, sourceType}` only when caller lacks `nodes:read`
- [ ] Reviewer: confirm Unified card's activity pill shows the deduped `activeNodeCount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)