### PR TITLE
fix(map-analysis): SNR overlay dedupe, click, scoping, SNR coloring (#2884)

### DIFF
--- a/src/components/MapAnalysis/LayerToggleButton.tsx
+++ b/src/components/MapAnalysis/LayerToggleButton.tsx
@@ -5,7 +5,7 @@ export interface LayerToggleButtonProps {
   enabled: boolean;
   onToggle: (next: boolean) => void;
   lookbackHours?: number | null;
-  lookbackOptions?: number[];
+  lookbackOptions?: Array<number | null>;
   onLookbackChange?: (h: number | null) => void;
   loading?: boolean;
   errored?: boolean;
@@ -56,12 +56,12 @@ export default function LayerToggleButton({
           <div className="map-analysis-popover-label">Lookback</div>
           {lookbackOptions.map((h) => (
             <button
-              key={h}
+              key={h ?? 'last'}
               type="button"
               className={lookbackHours === h ? 'selected' : ''}
               onClick={() => { onLookbackChange(h); setPopOpen(false); }}
             >
-              {h}h
+              {h === null ? 'Last' : `${h}h`}
             </button>
           ))}
         </div>

--- a/src/components/MapAnalysis/MapAnalysisToolbar.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.tsx
@@ -11,14 +11,15 @@ import {
   useAggregateProgress,
 } from '../../hooks/useMapAnalysisData';
 
-const LOOKBACK_OPTIONS = [1, 6, 24, 72, 168, 720];
+const LOOKBACK_OPTIONS: Array<number | null> = [1, 6, 24, 72, 168, 720];
+const SNR_LOOKBACK_OPTIONS: Array<number | null> = [null, 1, 6, 24, 72, 168, 720];
 
-const TIMED_LAYERS: { key: LayerKey; label: string }[] = [
-  { key: 'traceroutes', label: 'Traceroutes' },
-  { key: 'neighbors',   label: 'Neighbors' },
-  { key: 'heatmap',     label: 'Heatmap' },
-  { key: 'trails',      label: 'Trails' },
-  { key: 'snrOverlay',  label: 'SNR Overlay' },
+const TIMED_LAYERS: { key: LayerKey; label: string; options: Array<number | null> }[] = [
+  { key: 'traceroutes', label: 'Traceroutes', options: LOOKBACK_OPTIONS },
+  { key: 'neighbors',   label: 'Neighbors',   options: LOOKBACK_OPTIONS },
+  { key: 'heatmap',     label: 'Heatmap',     options: LOOKBACK_OPTIONS },
+  { key: 'trails',      label: 'Trails',      options: LOOKBACK_OPTIONS },
+  { key: 'snrOverlay',  label: 'SNR Overlay', options: SNR_LOOKBACK_OPTIONS },
 ];
 const UNTIMED_LAYERS: { key: LayerKey; label: string }[] = [
   { key: 'markers',     label: 'Markers' },
@@ -38,11 +39,15 @@ export default function MapAnalysisToolbar() {
   // the toolbar's shared positions hook with the longest enabled lookback so
   // the global progress bar reflects whichever fetch will take longest. Layer
   // components fire their own usePositions calls with per-layer lookbacks;
-  // identical-args calls share React Query cache.
+  // identical-args calls share React Query cache. SNR overlay in "Last" mode
+  // (lookbackHours === null) skips the positions API entirely — it reads from
+  // the unified node table — so don't include it here.
+  const snrUsesPositions =
+    config.layers.snrOverlay.enabled && config.layers.snrOverlay.lookbackHours !== null;
   const positionsLookback = Math.max(
     config.layers.trails.enabled ? (config.layers.trails.lookbackHours ?? 24) : 0,
     config.layers.heatmap.enabled ? (config.layers.heatmap.lookbackHours ?? 24) : 0,
-    config.layers.snrOverlay.enabled ? (config.layers.snrOverlay.lookbackHours ?? 24) : 0,
+    snrUsesPositions ? (config.layers.snrOverlay.lookbackHours ?? 24) : 0,
   );
 
   const positions = usePositions({
@@ -67,12 +72,16 @@ export default function MapAnalysisToolbar() {
     { isLoading: neighbors.isLoading },
   ]);
 
+  // Spinner shows on a button only when that specific layer is enabled and
+  // its data fetch is in flight. Without the .enabled guard the shared
+  // positions.isLoading would flash on heatmap/trails/SNR buttons even when
+  // only one of them is the actual driver of the fetch (issue #2884 bug 3).
   const layerLoading: Partial<Record<LayerKey, boolean>> = {
-    traceroutes: traceroutes.isLoading,
-    neighbors: neighbors.isLoading,
-    trails: positions.isLoading,
-    heatmap: positions.isLoading,
-    snrOverlay: positions.isLoading,
+    traceroutes: config.layers.traceroutes.enabled && traceroutes.isLoading,
+    neighbors:   config.layers.neighbors.enabled   && neighbors.isLoading,
+    trails:      config.layers.trails.enabled      && positions.isLoading,
+    heatmap:     config.layers.heatmap.enabled     && positions.isLoading,
+    snrOverlay:  config.layers.snrOverlay.enabled  && snrUsesPositions && positions.isLoading,
   };
 
   return (
@@ -105,14 +114,14 @@ export default function MapAnalysisToolbar() {
           onToggle={(next) => setLayerEnabled(key, next)}
         />
       ))}
-      {TIMED_LAYERS.map(({ key, label }) => (
+      {TIMED_LAYERS.map(({ key, label, options }) => (
         <LayerToggleButton
           key={key}
           label={label}
           enabled={config.layers[key].enabled}
           onToggle={(next) => setLayerEnabled(key, next)}
           lookbackHours={config.layers[key].lookbackHours}
-          lookbackOptions={LOOKBACK_OPTIONS}
+          lookbackOptions={options}
           onLookbackChange={(h) => setLayerLookback(key, h)}
           loading={layerLoading[key] ?? false}
         />

--- a/src/components/MapAnalysis/layers/SnrOverlayLayer.test.tsx
+++ b/src/components/MapAnalysis/layers/SnrOverlayLayer.test.tsx
@@ -2,71 +2,166 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MapAnalysisProvider } from '../MapAnalysisContext';
+import { MapAnalysisProvider, useMapAnalysisCtx } from '../MapAnalysisContext';
 import SnrOverlayLayer from './SnrOverlayLayer';
 
+interface MockCircleProps {
+  center: [number, number];
+  eventHandlers?: { click?: () => void };
+  pathOptions?: { color?: string; fillColor?: string };
+}
+
 vi.mock('react-leaflet', () => ({
-  CircleMarker: () => <div data-testid="snr-dot" />,
+  CircleMarker: ({ center, eventHandlers, pathOptions }: MockCircleProps) => (
+    <div
+      data-testid="snr-dot"
+      data-lat={center[0]}
+      data-lng={center[1]}
+      data-color={pathOptions?.color}
+      onClick={() => eventHandlers?.click?.()}
+    />
+  ),
 }));
 vi.mock('../../../hooks/useMapAnalysisData', () => ({
   usePositions: () => ({
     items: [
-      { nodeNum: 1, sourceId: 'a', latitude: 30, longitude: -90, timestamp: 0 },
-      { nodeNum: 2, sourceId: 'a', latitude: 31, longitude: -91, timestamp: 0 },
+      // Two recordings for node 1 — older then newer. Layer must dedupe to newer.
+      { nodeNum: 1, sourceId: 'a', latitude: 30, longitude: -90, timestamp: 100 },
+      { nodeNum: 1, sourceId: 'a', latitude: 35, longitude: -95, timestamp: 200 },
+      // Same node 1 also seen on a different source — should still collapse
+      // into the single newest fix across all sources.
+      { nodeNum: 1, sourceId: 'b', latitude: 33, longitude: -93, timestamp: 150 },
+      { nodeNum: 2, sourceId: 'a', latitude: 31, longitude: -91, timestamp: 50 },
     ],
     isLoading: false,
-    progress: { percent: 100, loaded: 2, estimatedTotal: 2 },
+    progress: { percent: 100, loaded: 4, estimatedTotal: 4 },
   }),
 }));
 vi.mock('../../../hooks/useDashboardData', () => ({
   useDashboardSources: () => ({ data: [{ id: 'a', name: 'A' }] }),
+  useDashboardUnifiedData: () => ({
+    nodes: [
+      // SNR coverage: excellent (≥5), good (0..5), fair (-5..0), poor (<-5), missing.
+      { nodeNum: 10, sourceId: 'a', latitude: 40, longitude: -100, snr: 8 },
+      { nodeNum: 11, sourceId: 'a', latitude: 41, longitude: -101, snr: 2 },
+      // Same nodeNum from a different source — must collapse to one dot.
+      { nodeNum: 11, sourceId: 'b', latitude: 41.5, longitude: -101.5, snr: 2 },
+      // Node without a position should be skipped.
+      { nodeNum: 12, sourceId: 'a', snr: -3 },
+      { nodeNum: 1, sourceId: 'a', latitude: 35, longitude: -95, snr: -10 },
+      { nodeNum: 2, sourceId: 'a', latitude: 31, longitude: -91 /* no snr */ },
+    ],
+    traceroutes: [],
+    neighborInfo: [],
+    channels: [],
+    status: null,
+    isLoading: false,
+    isError: false,
+  }),
 }));
+
+function setConfig(snrCfg: { enabled: boolean; lookbackHours: number | null }, extras: Record<string, unknown> = {}) {
+  localStorage.setItem(
+    'mapAnalysis.config.v1',
+    JSON.stringify({
+      version: 1,
+      layers: {
+        markers: { enabled: false, lookbackHours: null },
+        traceroutes: { enabled: false, lookbackHours: 24 },
+        neighbors: { enabled: false, lookbackHours: 24 },
+        heatmap: { enabled: false, lookbackHours: 24 },
+        trails: { enabled: false, lookbackHours: 24 },
+        hopShading: { enabled: false, lookbackHours: null },
+        snrOverlay: snrCfg,
+      },
+      sources: [],
+      timeSlider: { enabled: false },
+      inspectorOpen: true,
+      ...extras,
+    }),
+  );
+}
+
+function renderWith(node: React.ReactElement) {
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <MapAnalysisProvider>{node}</MapAnalysisProvider>
+    </QueryClientProvider>,
+  );
+}
 
 describe('SnrOverlayLayer', () => {
   beforeEach(() => localStorage.clear());
 
-  it('renders one CircleMarker per position', () => {
-    const qc = new QueryClient();
-    render(
-      <QueryClientProvider client={qc}>
-        <MapAnalysisProvider>
-          <SnrOverlayLayer />
-        </MapAnalysisProvider>
-      </QueryClientProvider>,
-    );
-    expect(screen.getAllByTestId('snr-dot')).toHaveLength(2);
+  it('"Last" mode renders one dot per nodeNum even when the node appears under multiple sources', () => {
+    setConfig({ enabled: true, lookbackHours: null });
+    renderWith(<SnrOverlayLayer />);
+    const dots = screen.getAllByTestId('snr-dot');
+    // Unified positioned nodes: 10, 11 (twice across sources collapses), 1, 2.
+    // Node 12 has no position. Total = 4.
+    expect(dots).toHaveLength(4);
   });
 
-  it('excludes positions outside the time slider window when slider is enabled', () => {
-    localStorage.setItem(
-      'mapAnalysis.config.v1',
-      JSON.stringify({
-        version: 1,
-        layers: {
-          markers: { enabled: false, lookbackHours: null },
-          traceroutes: { enabled: false, lookbackHours: 24 },
-          neighbors: { enabled: false, lookbackHours: 24 },
-          heatmap: { enabled: false, lookbackHours: 24 },
-          trails: { enabled: false, lookbackHours: 24 },
-          hopShading: { enabled: false, lookbackHours: null },
-          snrOverlay: { enabled: true, lookbackHours: 24 },
-        },
-        sources: [],
-        // Window [10, 20] excludes the mock positions at timestamp 0
-        timeSlider: { enabled: true, windowStartMs: 10, windowEndMs: 20 },
-        inspectorOpen: true,
-      }),
+  it('colors each dot by the node\'s most recent SNR (matches MapLegend thresholds)', () => {
+    setConfig({ enabled: true, lookbackHours: null });
+    renderWith(<SnrOverlayLayer />);
+    const byNum = (lat: string) => screen.getAllByTestId('snr-dot').find(
+      (d) => d.getAttribute('data-lat') === lat,
     );
-    const qc = new QueryClient();
-    render(
-      <QueryClientProvider client={qc}>
-        <MapAnalysisProvider>
-          <SnrOverlayLayer />
-        </MapAnalysisProvider>
-      </QueryClientProvider>,
+    // node 10 snr=8  -> excellent (#22c55e)
+    expect(byNum('40')!.getAttribute('data-color')).toBe('#22c55e');
+    // node 11 snr=2  -> good (#eab308)
+    expect(byNum('41')!.getAttribute('data-color')).toBe('#eab308');
+    // node 1  snr=-10 -> poor (#ef4444)
+    expect(byNum('35')!.getAttribute('data-color')).toBe('#ef4444');
+    // node 2  snr=undefined -> noData (#888)
+    expect(byNum('31')!.getAttribute('data-color')).toBe('#888');
+  });
+
+  it('windowed mode dedupes to the latest position per nodeNum across all sources', () => {
+    setConfig({ enabled: true, lookbackHours: 24 });
+    renderWith(<SnrOverlayLayer />);
+    const dots = screen.getAllByTestId('snr-dot');
+    // node 1 (3 fixes across sources) collapses to 1 dot, node 2 to 1 dot.
+    expect(dots).toHaveLength(2);
+    // Node 1's newest fix is timestamp=200 (lat=35, lng=-95). Multi-source
+    // older fixes must not win.
+    const node1 = dots.find((d) => d.getAttribute('data-lat') === '35');
+    expect(node1).toBeDefined();
+    expect(node1!.getAttribute('data-lng')).toBe('-95');
+  });
+
+  it('windowed mode excludes positions outside the time slider window', () => {
+    setConfig(
+      { enabled: true, lookbackHours: 24 },
+      { timeSlider: { enabled: true, windowStartMs: 1_000, windowEndMs: 2_000 } },
     );
+    renderWith(<SnrOverlayLayer />);
     expect(screen.queryAllByTestId('snr-dot')).toHaveLength(0);
+  });
+
+  it('clicking a dot selects the node by nodeNum (no sourceId, so the inspector matches across sources)', () => {
+    setConfig({ enabled: true, lookbackHours: null });
+    let capturedSelected: { type?: string; nodeNum?: number; sourceId?: string } | null = null;
+    function Probe() {
+      const { selected } = useMapAnalysisCtx();
+      capturedSelected = selected as typeof capturedSelected;
+      return null;
+    }
+    renderWith(
+      <>
+        <SnrOverlayLayer />
+        <Probe />
+      </>,
+    );
+    const [first] = screen.getAllByTestId('snr-dot');
+    fireEvent.click(first);
+    expect(capturedSelected).toMatchObject({ type: 'node' });
+    expect(typeof capturedSelected!.nodeNum).toBe('number');
+    // sourceId intentionally absent — inspector findNode falls back to nodeNum-only.
+    expect(capturedSelected!.sourceId).toBeUndefined();
   });
 });

--- a/src/components/MapAnalysis/layers/SnrOverlayLayer.tsx
+++ b/src/components/MapAnalysis/layers/SnrOverlayLayer.tsx
@@ -1,7 +1,12 @@
 import { CircleMarker } from 'react-leaflet';
-import { useDashboardSources } from '../../../hooks/useDashboardData';
+import { useMemo } from 'react';
+import {
+  useDashboardSources,
+  useDashboardUnifiedData,
+} from '../../../hooks/useDashboardData';
 import { usePositions } from '../../../hooks/useMapAnalysisData';
 import { useMapAnalysisCtx } from '../MapAnalysisContext';
+import { resolveNodeLatLng, type MaybePositionedNode } from '../nodePositionUtil';
 
 interface PositionRecord {
   nodeNum: number;
@@ -11,44 +16,156 @@ interface PositionRecord {
   timestamp: number;
 }
 
+interface NodeRecord extends MaybePositionedNode {
+  nodeNum: number;
+  sourceId?: string;
+  snr?: number | null;
+}
+
+interface SnrDot {
+  nodeNum: number;
+  latitude: number;
+  longitude: number;
+  timestamp: number;
+}
+
 /**
- * v1 limitation: position rows from /api/analysis/positions don't carry SNR
- * (positions are pivoted from telemetry, which doesn't store per-fix SNR).
- * The layer renders dots at each fix in gray as a coverage overlay. Per-fix
- * SNR coloring is deferred to a future task that joins from packet_log.
+ * SNR Overlay: one dot per node colored by the node's most recent SNR
+ * (sourced from the unified node table; the analysis positions endpoint
+ * doesn't carry per-fix SNR yet).
+ *
+ * Lookback semantics:
+ *   - null  -> "Last": one dot per node from the unified node table
+ *              (latest known position regardless of when it was recorded).
+ *   - >0    -> Latest position per node within the rolling window.
+ *
+ * Color thresholds match the MapLegend's "SNR (dB)" section:
+ *   ≥5 excellent, 0..5 good, -5..0 fair, <-5 poor, missing → noData.
+ *
+ * The dot is clickable and selects the node in MapAnalysisContext. The click
+ * payload omits sourceId because the unified merge collapses cross-source
+ * duplicates and AnalysisInspectorPanel falls back to nodeNum-only matching
+ * when sourceId is undefined.
  */
+const SNR_COLORS = {
+  excellent: '#22c55e',
+  good:      '#eab308',
+  fair:      '#f97316',
+  poor:      '#ef4444',
+  noData:    '#888',
+} as const;
+
+function colorForSnr(snr: number | null | undefined): string {
+  if (typeof snr !== 'number' || Number.isNaN(snr)) return SNR_COLORS.noData;
+  if (snr >= 5) return SNR_COLORS.excellent;
+  if (snr >= 0) return SNR_COLORS.good;
+  if (snr >= -5) return SNR_COLORS.fair;
+  return SNR_COLORS.poor;
+}
+
 export default function SnrOverlayLayer() {
-  const { config } = useMapAnalysisCtx();
+  const { config, setSelected } = useMapAnalysisCtx();
   const layer = config.layers.snrOverlay;
   const { data: sources = [] } = useDashboardSources();
   const sourceIds =
     config.sources.length === 0
       ? (sources as { id: string }[]).map((s) => s.id)
       : config.sources;
-  const { items } = usePositions({
-    enabled: layer.enabled,
+
+  const isLastMode = layer.lookbackHours === null;
+
+  // Windowed mode: pull positions from analysis API and dedupe to latest per node.
+  const { items: positionItems } = usePositions({
+    enabled: layer.enabled && !isLastMode,
     sources: sourceIds,
     lookbackHours: layer.lookbackHours ?? 24,
   });
 
+  // Unified node table is the source of truth for the latest SNR per node
+  // (and also provides positions for "Last" mode). React Query caches across
+  // layers so this is shared with NodeMarkersLayer / inspector.
+  const unified = useDashboardUnifiedData(
+    sourceIds,
+    layer.enabled && sourceIds.length > 0,
+  );
+
+  const snrByNode = useMemo(() => {
+    const m = new Map<number, number | null | undefined>();
+    for (const n of (unified.nodes ?? []) as NodeRecord[]) {
+      const num = Number(n.nodeNum);
+      if (!m.has(num)) m.set(num, n.snr ?? undefined);
+    }
+    return m;
+  }, [unified.nodes]);
+
   const ts = config.timeSlider;
-  const inWindow = (t: number): boolean =>
-    !ts.enabled ||
-    ts.windowStartMs === undefined ||
-    ts.windowEndMs === undefined ||
-    (t >= ts.windowStartMs && t <= ts.windowEndMs);
-  const filtered = (items as PositionRecord[]).filter((p) => inWindow(p.timestamp));
+  const dots: SnrDot[] = useMemo(() => {
+    if (isLastMode) {
+      const seen = new Set<number>();
+      const out: SnrDot[] = [];
+      for (const n of (unified.nodes ?? []) as NodeRecord[]) {
+        const num = Number(n.nodeNum);
+        if (seen.has(num)) continue;
+        const ll = resolveNodeLatLng(n);
+        if (!ll) continue;
+        seen.add(num);
+        out.push({ nodeNum: num, latitude: ll[0], longitude: ll[1], timestamp: 0 });
+      }
+      return out;
+    }
+    // Windowed: dedupe to one dot per nodeNum (across sources) keeping the
+    // newest fix's coordinates. The same node can appear under multiple
+    // sources; per issue #2884 the overlay shows one marker per node.
+    // Time-slider filter is applied against the kept timestamp.
+    const latest = new Map<number, SnrDot>();
+    for (const p of positionItems as PositionRecord[]) {
+      const num = Number(p.nodeNum);
+      const prev = latest.get(num);
+      if (!prev || p.timestamp > prev.timestamp) {
+        latest.set(num, {
+          nodeNum: num,
+          latitude: p.latitude,
+          longitude: p.longitude,
+          timestamp: p.timestamp,
+        });
+      }
+    }
+    const all = Array.from(latest.values());
+    if (
+      !ts.enabled ||
+      ts.windowStartMs === undefined ||
+      ts.windowEndMs === undefined
+    ) {
+      return all;
+    }
+    return all.filter(
+      (d) => d.timestamp >= ts.windowStartMs! && d.timestamp <= ts.windowEndMs!,
+    );
+  }, [
+    isLastMode,
+    positionItems,
+    unified.nodes,
+    ts.enabled,
+    ts.windowStartMs,
+    ts.windowEndMs,
+  ]);
 
   return (
     <>
-      {filtered.map((p, i) => (
-        <CircleMarker
-          key={`${p.sourceId}:${p.nodeNum}:${p.timestamp}:${i}`}
-          center={[p.latitude, p.longitude]}
-          radius={4}
-          pathOptions={{ color: '#888', fillOpacity: 0.7, weight: 1 }}
-        />
-      ))}
+      {dots.map((d) => {
+        const color = colorForSnr(snrByNode.get(d.nodeNum));
+        return (
+          <CircleMarker
+            key={d.nodeNum}
+            center={[d.latitude, d.longitude]}
+            radius={6}
+            pathOptions={{ color, fillColor: color, fillOpacity: 0.85, weight: 1 }}
+            eventHandlers={{
+              click: () => setSelected({ type: 'node', nodeNum: d.nodeNum }),
+            }}
+          />
+        );
+      })}
     </>
   );
 }

--- a/src/hooks/useMapAnalysisConfig.ts
+++ b/src/hooks/useMapAnalysisConfig.ts
@@ -36,7 +36,7 @@ export const DEFAULT_CONFIG: MapAnalysisConfig = {
     heatmap:    { enabled: false, lookbackHours: 24 },
     trails:     { enabled: false, lookbackHours: 24 },
     hopShading: { enabled: false, lookbackHours: null },
-    snrOverlay: { enabled: false, lookbackHours: 24 },
+    snrOverlay: { enabled: false, lookbackHours: null },
   },
   sources: [],
   timeSlider: { enabled: false },


### PR DESCRIPTION
## Summary
Fixes the three SNR Overlay bugs reported in #2884 plus adds the SNR-based dot coloring the layer's name implied:

- **Dedupe to one dot per node.** Both lookback modes collapse multi-source / multi-fix duplicates. A new **"Last"** lookback (default) pulls the most recent position per node from the unified node table; numeric lookbacks (1h/6h/24h/72h/168h/720h) keep the latest fix per node within the window.
- **Clickable dots.** `CircleMarker` now wires `eventHandlers.click → setSelected({ type: 'node', nodeNum })`. The payload intentionally omits `sourceId` because the unified merge collapses cross-source duplicates and `AnalysisInspectorPanel.findNode` falls back to nodeNum-only matching when sourceId is undefined — without that, dots whose source-specific id differed from the merged node's id rendered "Node not found" in the inspector.
- **Scoped loading spinner.** The toolbar's per-button `loading` state is now AND'd with each layer's `enabled` flag and (for SNR) with whether it actually drives the positions fetch, so enabling SNR Overlay no longer flashes the spinner on Heatmap/Trails simultaneously.
- **SNR-based dot coloring.** Each dot is colored by the node's most recent SNR, using the same thresholds the `MapLegend` already documents: ≥5 dB green (excellent), 0..5 yellow (good), −5..0 orange (fair), <−5 red (poor), missing → gray.

## Changes
- `src/components/MapAnalysis/layers/SnrOverlayLayer.tsx` — dedup, "Last" mode via unified data, color by SNR, click → setSelected.
- `src/components/MapAnalysis/MapAnalysisToolbar.tsx` — SNR-specific lookback options including `null`, scoped per-layer loading flags, skip SNR from positions fetch when in Last mode.
- `src/components/MapAnalysis/LayerToggleButton.tsx` — render `null` lookback option as "Last".
- `src/hooks/useMapAnalysisConfig.ts` — default `snrOverlay.lookbackHours` flipped from `24` → `null`.
- `src/components/MapAnalysis/layers/SnrOverlayLayer.test.tsx` — covers Last/windowed dedupe across sources, time-slider window, click-selection without sourceId, color thresholds.

## Test plan
- [x] `npx vitest run` — 4649 / 4649 passing
- [x] `npx tsc --noEmit` — clean
- [x] Local docker dev deploy verified manually:
  - SNR Overlay shows one colored dot per node (no duplicate clusters).
  - Clicking a dot opens the node inspector.
  - "Last" appears as default in the lookback pop-over.
  - Loading spinner stays scoped to the SNR Overlay button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)