### PR TITLE
feat(traceroute): draggable Forward/Return path popups (#2887)

### DIFF
--- a/src/components/DraggablePopup.tsx
+++ b/src/components/DraggablePopup.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef } from 'react';
+import { Popup, useMap } from 'react-leaflet';
+import type { PopupProps } from 'react-leaflet';
+import L from 'leaflet';
+
+/**
+ * Popup that can be dragged by its content wrapper. Drag is session-only —
+ * closing/re-opening resets to the click anchor.
+ *
+ * Buttons, links, and form inputs inside the popup body still receive clicks
+ * (drag is suppressed when the mousedown target is one of those elements).
+ */
+export function DraggablePopup({ children, ...rest }: PopupProps) {
+  const popupRef = useRef<L.Popup | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const map = useMap();
+
+  useEffect(() => () => { cleanupRef.current?.(); cleanupRef.current = null; }, []);
+
+  const attach = () => {
+    const popup = popupRef.current;
+    if (!popup) return;
+    const el = popup.getElement();
+    if (!el || !map) return;
+    const wrapper = el.querySelector('.leaflet-popup-content-wrapper') as HTMLElement | null;
+    if (!wrapper) return;
+
+    wrapper.style.cursor = 'grab';
+    wrapper.title = 'Drag to reposition';
+
+    let dragging = false;
+    let startX = 0;
+    let startY = 0;
+    let startLatLng: L.LatLng | null = null;
+
+    const onMouseMove = (e: MouseEvent) => {
+      if (!dragging || !startLatLng) return;
+      const dx = e.clientX - startX;
+      const dy = e.clientY - startY;
+      const startPoint = map.latLngToContainerPoint(startLatLng);
+      const newPoint = startPoint.add(L.point(dx, dy));
+      popup.setLatLng(map.containerPointToLatLng(newPoint));
+    };
+
+    const onMouseUp = () => {
+      if (!dragging) return;
+      dragging = false;
+      wrapper.style.cursor = 'grab';
+      map.dragging.enable();
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('button, a, input, select, textarea, .leaflet-popup-close-button')) return;
+      const ll = popup.getLatLng();
+      if (!ll) return;
+      dragging = true;
+      startX = e.clientX;
+      startY = e.clientY;
+      startLatLng = ll;
+      wrapper.style.cursor = 'grabbing';
+      map.dragging.disable();
+      e.preventDefault();
+      e.stopPropagation();
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+    };
+
+    wrapper.addEventListener('mousedown', onMouseDown);
+
+    cleanupRef.current = () => {
+      wrapper.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      map.dragging.enable();
+    };
+  };
+
+  const detach = () => {
+    cleanupRef.current?.();
+    cleanupRef.current = null;
+  };
+
+  return (
+    <Popup
+      autoPan={false}
+      {...rest}
+      ref={(instance) => {
+        popupRef.current = instance ?? null;
+      }}
+      eventHandlers={{
+        ...(rest.eventHandlers ?? {}),
+        add: (e) => {
+          attach();
+          rest.eventHandlers?.add?.(e);
+        },
+        remove: (e) => {
+          detach();
+          rest.eventHandlers?.remove?.(e);
+        },
+      }}
+    >
+      {children}
+    </Popup>
+  );
+}
+
+export default DraggablePopup;

--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -12,6 +12,7 @@
 
 import React, { useMemo, useState } from 'react';
 import { Popup, Polyline } from 'react-leaflet';
+import { DraggablePopup } from '../components/DraggablePopup';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { calculateDistance, formatDistance } from '../utils/distance';
 import { generateCurvedArrowMarkers, generateCurvedPath, getLineWeight, getSegmentSnrColor, getSegmentSnrOpacity, getTemporalOpacityMultiplier, isUnknownSnr } from '../utils/mapHelpers';
@@ -818,7 +819,7 @@ export function useTraceroutePaths({
                  }}
                  className={`route-segment node-${forwardSequence[i]} node-${forwardSequence[i + 1]}`}
                >
-                 <Popup>
+                 <DraggablePopup>
                    <div className="route-popup">
                      <h4>Forward Path</h4>
                      <div className="route-endpoints">
@@ -845,7 +846,7 @@ export function useTraceroutePaths({
                         </div>
                      )}
                    </div>
-                 </Popup>
+                 </DraggablePopup>
                </Polyline>
              );
           }
@@ -923,7 +924,7 @@ export function useTraceroutePaths({
                  }}
                  className={`route-segment node-${backSequence[i]} node-${backSequence[i + 1]}`}
                >
-                 <Popup>
+                 <DraggablePopup>
                    <div className="route-popup">
                      <h4>Return Path</h4>
                      <div className="route-endpoints">
@@ -950,7 +951,7 @@ export function useTraceroutePaths({
                         </div>
                      )}
                    </div>
-                 </Popup>
+                 </DraggablePopup>
                </Polyline>
              );
           }


### PR DESCRIPTION
## Summary
- Wraps the Forward Path / Return Path popups on the NodesTab source map in a new `DraggablePopup` component (react-leaflet `<Popup>` + mousedown drag on `.leaflet-popup-content-wrapper`, driven by `popup.setLatLng()` via container-point math).
- Map drag is disabled while a popup is being dragged so the map doesn't pan along.
- Buttons / links / close button inside the popup body still receive clicks (drag is suppressed when the mousedown target matches `button, a, input, select, textarea, .leaflet-popup-close-button`).
- Position is session-only — closing or re-clicking the segment resets to the click anchor. No persistence, per the issue.

Closes #2887.

## Files
- `src/components/DraggablePopup.tsx` (new) — drop-in replacement for `<Popup>` with drag.
- `src/hooks/useTraceroutePaths.tsx` — Forward Path popup (~line 821) and Return Path popup (~line 926) now use `DraggablePopup`. Other route-segment popups untouched.

## Test plan
- [ ] On NodesTab, select a node with traceroute history and enable Show Route.
- [ ] Click a Forward Path segment → popup appears at click point.
- [ ] Drag popup body — cursor switches `grab` → `grabbing`, popup follows mouse, map does **not** pan.
- [ ] Repeat for Return Path segment.
- [ ] Click the popup's `×` close button — closes cleanly.
- [ ] Re-click segment — popup reopens at new click point (no stale position).
- [ ] Confirm screenshot of the routes is no longer occluded by the info box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)