### PR TITLE
feat: Analysis & Reports workspace with Solar Monitoring

### DIFF
--- a/src/components/Analysis/AnalysisTab.tsx
+++ b/src/components/Analysis/AnalysisTab.tsx
@@ -1,0 +1,81 @@
+/**
+ * AnalysisTab — landing page for analytical reports.
+ *
+ * Mirrors the MeshManager AnalysisPage card grid: each report is selectable
+ * from the grid and rendered full-screen when active.
+ */
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import SolarMonitoringReport from './SolarMonitoringReport';
+
+type AnalysisType = 'solar-monitoring' | null;
+
+interface AnalysisCard {
+  id: Exclude<AnalysisType, null>;
+  title: string;
+  description: string;
+  icon: string;
+}
+
+interface AnalysisTabProps {
+  baseUrl: string;
+}
+
+const AnalysisTab: React.FC<AnalysisTabProps> = ({ baseUrl }) => {
+  const { t } = useTranslation();
+  const [selected, setSelected] = useState<AnalysisType>(null);
+
+  const reports: AnalysisCard[] = [
+    {
+      id: 'solar-monitoring',
+      title: t('analysis.solar_monitoring.title', 'Solar Monitoring Analysis'),
+      description: t(
+        'analysis.solar_monitoring.description',
+        'Identify solar-powered nodes by analyzing battery and voltage patterns that show daytime charging and nighttime discharge.',
+      ),
+      icon: '☀️',
+    },
+  ];
+
+  if (selected === 'solar-monitoring') {
+    return (
+      <div className="reports-section">
+        <button
+          type="button"
+          className="reports-section__back"
+          onClick={() => setSelected(null)}
+        >
+          {t('analysis.back_to_reports', '← Back to reports')}
+        </button>
+        <SolarMonitoringReport baseUrl={baseUrl} />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <p className="reports-grid__intro">
+        {t(
+          'analysis.subtitle',
+          'Cross-network analytical reports built from collected telemetry and routing data. Choose a report to run.',
+        )}
+      </p>
+      <div className="reports-grid">
+        {reports.map((r) => (
+          <button
+            key={r.id}
+            type="button"
+            className="reports-card"
+            onClick={() => setSelected(r.id)}
+          >
+            <div className="reports-card__icon">{r.icon}</div>
+            <h3 className="reports-card__title">{r.title}</h3>
+            <p className="reports-card__desc">{r.description}</p>
+          </button>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default AnalysisTab;

--- a/src/components/Analysis/SolarMonitoringReport.tsx
+++ b/src/components/Analysis/SolarMonitoringReport.tsx
@@ -1,0 +1,729 @@
+/**
+ * SolarMonitoringReport — analyzes battery / voltage telemetry to identify
+ * likely solar-powered nodes. Port of MeshManager's SolarMonitoring view.
+ *
+ * Renders per-node battery/voltage line + solar-production bar overlay,
+ * reference lines for healthy levels, and an optional forecast simulation
+ * extending the chart into the future.
+ */
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+interface SolarPattern {
+  date: string;
+  sunrise: { time: string; value: number };
+  peak: { time: string; value: number };
+  sunset: { time: string; value: number };
+  rise: number | null;
+  fall: number | null;
+  charge_rate_per_hour: number | null;
+  discharge_rate_per_hour: number | null;
+}
+
+interface SolarChartPoint {
+  timestamp: number;
+  value: number;
+}
+
+interface SolarProductionPoint {
+  timestamp: number;
+  wattHours: number;
+}
+
+interface SolarNode {
+  node_num: number;
+  node_name: string;
+  solar_score: number;
+  days_analyzed: number;
+  days_with_pattern: number;
+  recent_patterns: SolarPattern[];
+  metric_type: string;
+  metrics_detected: string[];
+  chart_data: SolarChartPoint[];
+  avg_charge_rate_per_hour: number | null;
+  avg_discharge_rate_per_hour: number | null;
+  insufficient_solar: boolean | null;
+}
+
+interface SolarNodesAnalysis {
+  lookback_days: number;
+  total_nodes_analyzed: number;
+  solar_nodes_count: number;
+  solar_nodes: SolarNode[];
+  solar_production: SolarProductionPoint[];
+  avg_charging_hours_per_day: number | null;
+  avg_discharge_hours_per_day: number | null;
+}
+
+interface ForecastDay {
+  date: string;
+  forecast_wh: number;
+  avg_historical_wh: number;
+  pct_of_average: number;
+  is_low: boolean;
+}
+
+interface ForecastSimulationPoint {
+  timestamp: string;
+  simulated_battery: number;
+  phase: 'sunrise' | 'peak' | 'sunset';
+  forecast_factor: number;
+}
+
+interface NodeSimulation {
+  node_num: number;
+  node_name: string;
+  metric_type: string;
+  current_battery: number | null;
+  min_simulated_battery: number;
+  simulation: ForecastSimulationPoint[];
+}
+
+interface SolarForecastAnalysis {
+  lookback_days: number;
+  historical_days_analyzed: number;
+  avg_historical_daily_wh: number;
+  low_output_warning: boolean;
+  forecast_days: ForecastDay[];
+  nodes_at_risk_count: number;
+  nodes_at_risk: NodeSimulation[];
+  solar_simulations: NodeSimulation[];
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, { credentials: 'include' });
+  if (!response.ok) {
+    throw new Error(`Request failed (HTTP ${response.status})`);
+  }
+  return response.json();
+}
+
+const SolarMonitoringReport: React.FC<{ baseUrl: string }> = ({ baseUrl }) => {
+  const { t } = useTranslation();
+  const [lookbackDays, setLookbackDays] = useState(7);
+  const [run, setRun] = useState(false);
+  const [runForecast, setRunForecast] = useState(false);
+
+  const { data, isLoading, error, refetch } = useQuery<SolarNodesAnalysis>({
+    queryKey: ['solar-nodes-analysis', lookbackDays],
+    queryFn: () =>
+      fetchJson<SolarNodesAnalysis>(
+        `${baseUrl}/api/analysis/solar-nodes?lookback_days=${lookbackDays}`,
+      ),
+    enabled: run,
+  });
+
+  const {
+    data: forecast,
+    isLoading: forecastLoading,
+    error: forecastError,
+    refetch: refetchForecast,
+  } = useQuery<SolarForecastAnalysis>({
+    queryKey: ['solar-forecast-analysis', lookbackDays],
+    queryFn: () =>
+      fetchJson<SolarForecastAnalysis>(
+        `${baseUrl}/api/analysis/solar-forecast?lookback_days=${lookbackDays}`,
+      ),
+    enabled: runForecast,
+  });
+
+  return (
+    <>
+      <div>
+        <h2 className="reports-section__title">
+          <span aria-hidden>☀️</span>
+          {t('analysis.solar_monitoring.title', 'Solar Monitoring Analysis')}
+        </h2>
+        <p className="reports-section__subtitle">
+          {t(
+            'analysis.solar_monitoring.description',
+            'Identify solar-powered nodes by analyzing battery and voltage patterns that show daytime charging and nighttime discharge.',
+          )}
+        </p>
+      </div>
+
+      <div className="reports-panel">
+        <div className="reports-controls">
+          <label className="reports-controls__field">
+            <span>{t('analysis.solar_monitoring.lookback', 'Lookback (days):')}</span>
+            <input
+              type="number"
+              min={1}
+              max={90}
+              value={lookbackDays}
+              onChange={(e) => {
+                const n = parseInt(e.target.value, 10);
+                if (Number.isFinite(n)) setLookbackDays(Math.min(90, Math.max(1, n)));
+              }}
+            />
+          </label>
+          <button
+            type="button"
+            className="reports-btn"
+            onClick={() => {
+              if (run) {
+                refetch();
+              } else {
+                setRun(true);
+              }
+            }}
+            disabled={isLoading}
+          >
+            {isLoading
+              ? t('analysis.solar_monitoring.analyzing', 'Analyzing…')
+              : run
+                ? t('analysis.solar_monitoring.refresh', 'Re-run analysis')
+                : t('analysis.solar_monitoring.run', 'Run analysis')}
+          </button>
+          <button
+            type="button"
+            className="reports-btn reports-btn--ghost"
+            onClick={() => {
+              if (runForecast) {
+                refetchForecast();
+              } else {
+                setRunForecast(true);
+              }
+            }}
+            disabled={forecastLoading}
+            title={t(
+              'analysis.solar_monitoring.forecast_help',
+              'Project battery state across the next several days using forecast.solar production estimates.',
+            )}
+          >
+            {forecastLoading
+              ? t('analysis.solar_monitoring.forecast_loading', 'Forecasting…')
+              : runForecast
+                ? t('analysis.solar_monitoring.forecast_refresh', 'Re-run forecast')
+                : t('analysis.solar_monitoring.forecast_run', 'Run forecast')}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="reports-banner reports-banner--error">
+          {t('analysis.solar_monitoring.error', 'Error analyzing data:')}{' '}
+          {(error as Error).message}
+        </div>
+      )}
+
+      {forecastError && (
+        <div className="reports-banner reports-banner--error">
+          {t('analysis.solar_monitoring.forecast_error', 'Error computing forecast:')}{' '}
+          {(forecastError as Error).message}
+        </div>
+      )}
+
+      {data && (
+        <SolarSummary
+          totalAnalyzed={data.total_nodes_analyzed}
+          solarCount={data.solar_nodes_count}
+          avgCharging={data.avg_charging_hours_per_day}
+          avgDischarge={data.avg_discharge_hours_per_day}
+          lookbackDays={data.lookback_days}
+          solarPointCount={data.solar_production.length}
+        />
+      )}
+
+      {forecast && <ForecastResults forecast={forecast} />}
+
+      {data && data.solar_nodes.length === 0 && !isLoading && (
+        <div className="reports-banner reports-banner--empty">
+          {t(
+            'analysis.solar_monitoring.empty',
+            'No solar-powered nodes identified. Try increasing the lookback period or ensure nodes have sufficient telemetry data.',
+          )}
+        </div>
+      )}
+
+      {data && data.solar_nodes.length > 0 && (
+        <div className="reports-node-list">
+          {data.solar_nodes.map((node) => (
+            <SolarNodeCard
+              key={node.node_num}
+              node={node}
+              solarProduction={data.solar_production}
+              forecast={forecast}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+};
+
+const SolarSummary: React.FC<{
+  totalAnalyzed: number;
+  solarCount: number;
+  avgCharging: number | null;
+  avgDischarge: number | null;
+  lookbackDays: number;
+  solarPointCount: number;
+}> = ({ totalAnalyzed, solarCount, avgCharging, avgDischarge, lookbackDays, solarPointCount }) => (
+  <div className="reports-stats">
+    <Stat label="Lookback" value={`${lookbackDays} d`} />
+    <Stat label="Nodes analyzed" value={String(totalAnalyzed)} />
+    <Stat label="Solar nodes detected" value={String(solarCount)} />
+    <Stat
+      label="Avg charging hrs/day"
+      value={avgCharging !== null ? `${avgCharging.toFixed(1)} h` : '—'}
+    />
+    <Stat
+      label="Avg discharge hrs/day"
+      value={avgDischarge !== null ? `${avgDischarge.toFixed(1)} h` : '—'}
+    />
+    <Stat label="Solar production points" value={String(solarPointCount)} />
+  </div>
+);
+
+const Stat: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="reports-stat">
+    <div className="reports-stat__label">{label}</div>
+    <div className="reports-stat__value">{value}</div>
+  </div>
+);
+
+const ForecastResults: React.FC<{ forecast: SolarForecastAnalysis }> = ({ forecast }) => {
+  return (
+    <div className="reports-panel reports-forecast">
+      <div className="reports-forecast__header">
+        <h3 className="reports-forecast__title">
+          🔮 Solar Forecast
+        </h3>
+        <div className="reports-forecast__sub">
+          Based on {forecast.historical_days_analyzed} historical day(s) avg{' '}
+          <strong>{forecast.avg_historical_daily_wh.toFixed(0)} Wh/day</strong>.{' '}
+          {forecast.nodes_at_risk_count} of {forecast.solar_simulations.length} solar nodes
+          predicted at risk.
+        </div>
+      </div>
+
+      {forecast.low_output_warning && (
+        <div className="reports-banner reports-banner--warning">
+          ⚠ Forecast output is significantly below historical average — battery levels may
+          drop on at-risk nodes.
+        </div>
+      )}
+
+      {forecast.forecast_days.length > 0 && (
+        <div className="reports-table-wrap">
+          <table className="reports-table">
+            <thead>
+              <tr>
+                <th>Day</th>
+                <th>Forecast Wh</th>
+                <th>Historical Wh</th>
+                <th>% of avg</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {forecast.forecast_days.map((d) => (
+                <tr key={d.date}>
+                  <td>{d.date}</td>
+                  <td>{d.forecast_wh.toFixed(0)}</td>
+                  <td>{d.avg_historical_wh.toFixed(0)}</td>
+                  <td>{d.pct_of_average.toFixed(0)}%</td>
+                  <td>
+                    {d.is_low ? (
+                      <span className="reports-pill reports-pill--warn">Low</span>
+                    ) : (
+                      <span className="reports-pill reports-pill--ok">OK</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {forecast.nodes_at_risk.length > 0 && (
+        <div>
+          <p className="reports-node__patterns-title">Nodes predicted at risk</p>
+          <ul className="reports-at-risk">
+            {forecast.nodes_at_risk.map((n) => (
+              <li key={n.node_num}>
+                <strong>{n.node_name}</strong> — min battery{' '}
+                <span className="reports-pill reports-pill--warn">
+                  {n.min_simulated_battery.toFixed(1)}
+                  {n.metric_type === 'batteryLevel' ? '%' : ' V'}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface ChartPoint {
+  timestamp: number;
+  value?: number | null;
+  forecastBattery?: number | null;
+  solarWh?: number | null;
+}
+
+const SolarNodeCard: React.FC<{
+  node: SolarNode;
+  solarProduction: SolarProductionPoint[];
+  forecast?: SolarForecastAnalysis;
+}> = ({ node, solarProduction, forecast }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const isPercent = node.metric_type === 'batteryLevel';
+  const metricLabel = isPercent
+    ? 'Battery %'
+    : node.metric_type === 'voltage'
+      ? 'Voltage V'
+      : node.metric_type;
+
+  const nodeForecast = forecast?.solar_simulations.find(
+    (s) => s.node_num === node.node_num,
+  );
+
+  const chartData = useMemo<ChartPoint[]>(() => {
+    if (node.chart_data.length === 0) return [];
+    const HOUR = 3_600_000;
+    const solarByHour = new Map<number, number>();
+    for (const sp of solarProduction) {
+      const hour = Math.floor(sp.timestamp / HOUR) * HOUR;
+      solarByHour.set(hour, sp.wattHours);
+    }
+    const points: ChartPoint[] = node.chart_data.map((p) => ({
+      timestamp: p.timestamp,
+      value: p.value,
+      solarWh: solarByHour.get(Math.floor(p.timestamp / HOUR) * HOUR) ?? null,
+    }));
+    const telemetryHours = new Set(
+      points.map((p) => Math.floor(p.timestamp / HOUR) * HOUR),
+    );
+    const lastTs = points[points.length - 1]?.timestamp ?? 0;
+
+    // Add solar-only hourly points the telemetry didn't cover
+    for (const [hour, wh] of solarByHour.entries()) {
+      if (!telemetryHours.has(hour) && hour <= lastTs) {
+        points.push({ timestamp: hour, value: null, solarWh: wh });
+      }
+    }
+
+    // Append forecast simulation points (if loaded) — connects last value
+    if (nodeForecast?.simulation && nodeForecast.simulation.length > 0) {
+      const lastValue = points[points.length - 1]?.value ?? null;
+      // Bridge point: same x as last actual, forecastBattery = last actual value
+      points.push({
+        timestamp: lastTs + 1,
+        value: null,
+        forecastBattery: typeof lastValue === 'number' ? lastValue : null,
+        solarWh: null,
+      });
+      for (const s of nodeForecast.simulation) {
+        const ts = new Date(s.timestamp).getTime();
+        if (ts <= lastTs) continue;
+        const hour = Math.floor(ts / HOUR) * HOUR;
+        points.push({
+          timestamp: ts,
+          value: null,
+          forecastBattery: s.simulated_battery,
+          solarWh: solarByHour.get(hour) ?? null,
+        });
+      }
+    } else {
+      // Even without forecast, append future solar-only points
+      for (const [hour, wh] of solarByHour.entries()) {
+        if (hour > lastTs) {
+          points.push({ timestamp: hour, value: null, solarWh: wh });
+        }
+      }
+    }
+
+    points.sort((a, b) => a.timestamp - b.timestamp);
+    return points;
+  }, [node.chart_data, solarProduction, nodeForecast]);
+
+  // Reference levels — battery uses %, voltage uses LiPo-style thresholds
+  const refLines = isPercent
+    ? [
+        { y: 100, label: '100%', tone: 'good' as const },
+        { y: 50, label: '50%', tone: 'mid' as const },
+        { y: 20, label: '20%', tone: 'low' as const },
+      ]
+    : [
+        { y: 4.2, label: '4.2 V (full)', tone: 'good' as const },
+        { y: 3.7, label: '3.7 V (nominal)', tone: 'mid' as const },
+        { y: 3.3, label: '3.3 V (low)', tone: 'low' as const },
+      ];
+
+  const yMin = isPercent ? 0 : 3.0;
+  const yMax = isPercent ? 105 : 4.3;
+  const hasSolar = chartData.some((p) => typeof p.solarWh === 'number');
+  const hasForecast = chartData.some((p) => typeof p.forecastBattery === 'number');
+
+  return (
+    <div
+      className={`reports-node${node.insufficient_solar ? ' reports-node--insufficient' : ''}`}
+    >
+      <button
+        type="button"
+        className="reports-node__header"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <div>
+          <div className="reports-node__name">
+            {node.node_name}
+            {node.insufficient_solar && (
+              <span className="reports-node__warning">⚠ Insufficient solar</span>
+            )}
+          </div>
+          <div className="reports-node__meta">
+            Score {node.solar_score.toFixed(1)}% • {node.days_with_pattern}/
+            {node.days_analyzed} days • Metric: {metricLabel}
+          </div>
+        </div>
+        <div className="reports-node__chevron">{expanded ? '▼' : '▶'}</div>
+      </button>
+
+      {expanded && (
+        <div className="reports-node__body">
+          <div className="reports-node__fields">
+            <Field
+              label="Avg charge rate"
+              value={
+                node.avg_charge_rate_per_hour !== null
+                  ? `${node.avg_charge_rate_per_hour.toFixed(2)} /h`
+                  : '—'
+              }
+            />
+            <Field
+              label="Avg discharge rate"
+              value={
+                node.avg_discharge_rate_per_hour !== null
+                  ? `${node.avg_discharge_rate_per_hour.toFixed(2)} /h`
+                  : '—'
+              }
+            />
+            <Field
+              label="Metrics detected"
+              value={node.metrics_detected.length > 0 ? node.metrics_detected.join(', ') : '—'}
+            />
+            {nodeForecast && (
+              <Field
+                label="Forecast min battery"
+                value={`${nodeForecast.min_simulated_battery.toFixed(1)}${isPercent ? '%' : ' V'}`}
+              />
+            )}
+          </div>
+
+          {chartData.length > 0 && (
+            <div className="reports-node__chart">
+              <ResponsiveContainer>
+                <ComposedChart
+                  data={chartData}
+                  margin={{ top: 8, right: 16, bottom: 4, left: 8 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--ctp-surface0)" />
+                  <XAxis
+                    dataKey="timestamp"
+                    type="number"
+                    domain={['dataMin', 'dataMax']}
+                    tickFormatter={(ts: number) =>
+                      new Date(ts).toLocaleDateString(undefined, {
+                        month: 'short',
+                        day: 'numeric',
+                      })
+                    }
+                    stroke="var(--ctp-subtext0)"
+                    fontSize={11}
+                  />
+                  <YAxis
+                    yAxisId="left"
+                    domain={[yMin, yMax]}
+                    stroke="var(--ctp-subtext0)"
+                    fontSize={11}
+                    tickFormatter={(v: number) => (isPercent ? `${v}%` : `${v.toFixed(1)}V`)}
+                  />
+                  <YAxis
+                    yAxisId="right"
+                    orientation="right"
+                    stroke="var(--ctp-yellow)"
+                    fontSize={11}
+                    tickFormatter={(v: number) => `${Math.round(v)} Wh`}
+                    hide={!hasSolar}
+                  />
+                  <Tooltip
+                    labelFormatter={(ts) => new Date(Number(ts)).toLocaleString()}
+                    contentStyle={{
+                      background: 'var(--ctp-mantle)',
+                      border: '1px solid var(--ctp-surface1)',
+                      borderRadius: 6,
+                      color: 'var(--ctp-text)',
+                    }}
+                    labelStyle={{ color: 'var(--ctp-subtext0)' }}
+                    formatter={(value, name) => {
+                      if (name === 'solarWh') return [`${Number(value).toFixed(0)} Wh`, 'Solar'];
+                      if (name === 'forecastBattery')
+                        return [
+                          isPercent ? `${value}%` : `${Number(value).toFixed(2)} V`,
+                          'Forecast',
+                        ];
+                      return [
+                        isPercent ? `${value}%` : `${Number(value).toFixed(2)} V`,
+                        metricLabel,
+                      ];
+                    }}
+                  />
+                  <Legend
+                    wrapperStyle={{ fontSize: 11, color: 'var(--ctp-subtext0)' }}
+                  />
+
+                  {/* Reference levels — drawn behind the data lines */}
+                  {refLines.map((rl) => (
+                    <ReferenceLine
+                      key={rl.label}
+                      yAxisId="left"
+                      y={rl.y}
+                      stroke={
+                        rl.tone === 'good'
+                          ? 'var(--ctp-green)'
+                          : rl.tone === 'mid'
+                            ? 'var(--ctp-yellow)'
+                            : 'var(--ctp-red)'
+                      }
+                      strokeDasharray="4 4"
+                      strokeOpacity={0.5}
+                      label={{
+                        value: rl.label,
+                        position: 'insideRight',
+                        fill: 'var(--ctp-subtext0)',
+                        fontSize: 10,
+                      }}
+                    />
+                  ))}
+
+                  {/* Solar production area — sits behind battery line */}
+                  {hasSolar && (
+                    <Area
+                      yAxisId="right"
+                      type="monotone"
+                      dataKey="solarWh"
+                      fill="var(--ctp-yellow)"
+                      fillOpacity={0.18}
+                      stroke="var(--ctp-yellow)"
+                      strokeOpacity={0.4}
+                      strokeWidth={1}
+                      isAnimationActive={false}
+                      connectNulls={false}
+                      name="Solar Wh"
+                    />
+                  )}
+
+                  {/* Actual battery / voltage */}
+                  <Line
+                    yAxisId="left"
+                    type="monotone"
+                    dataKey="value"
+                    stroke="var(--ctp-blue)"
+                    dot={false}
+                    strokeWidth={2}
+                    isAnimationActive={false}
+                    connectNulls
+                    name={metricLabel}
+                  />
+
+                  {/* Forecast simulation — dashed extension */}
+                  {hasForecast && (
+                    <Line
+                      yAxisId="left"
+                      type="monotone"
+                      dataKey="forecastBattery"
+                      stroke="var(--ctp-mauve)"
+                      strokeDasharray="6 4"
+                      strokeWidth={2}
+                      dot={{ r: 3 }}
+                      isAnimationActive={false}
+                      connectNulls
+                      name="Forecast"
+                    />
+                  )}
+                </ComposedChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          {node.recent_patterns.length > 0 && (
+            <div>
+              <p className="reports-node__patterns-title">Recent daily patterns</p>
+              <div className="reports-table-wrap">
+                <table className="reports-table">
+                  <thead>
+                    <tr>
+                      <th>Date</th>
+                      <th>Sunrise</th>
+                      <th>Peak</th>
+                      <th>Sunset</th>
+                      <th>Rise</th>
+                      <th>Fall</th>
+                      <th>Charge /h</th>
+                      <th>Discharge /h</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {node.recent_patterns.map((p) => (
+                      <tr key={p.date}>
+                        <td>{p.date}</td>
+                        <td>
+                          {p.sunrise.time} ({p.sunrise.value})
+                        </td>
+                        <td>
+                          {p.peak.time} ({p.peak.value})
+                        </td>
+                        <td>
+                          {p.sunset.time} ({p.sunset.value})
+                        </td>
+                        <td>{p.rise !== null ? p.rise.toFixed(1) : '—'}</td>
+                        <td>{p.fall !== null ? p.fall.toFixed(1) : '—'}</td>
+                        <td>
+                          {p.charge_rate_per_hour !== null
+                            ? p.charge_rate_per_hour.toFixed(2)
+                            : '—'}
+                        </td>
+                        <td>
+                          {p.discharge_rate_per_hour !== null
+                            ? p.discharge_rate_per_hour.toFixed(2)
+                            : '—'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const Field: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div>
+    <div className="reports-node__field-label">{label}</div>
+    <div className="reports-node__field-value">{value}</div>
+  </div>
+);
+
+export default SolarMonitoringReport;

--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -402,6 +402,12 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
         >
           {t('source.sidebar.map_analysis')}
         </button>
+        <button
+          className="dashboard-sidebar-link dashboard-sidebar-link--active"
+          onClick={() => navigate('/reports')}
+        >
+          {t('source.sidebar.reports', 'Analysis & Reports')}
+        </button>
       </div>
 
       <div className="dashboard-sidebar-footer">

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -261,6 +261,34 @@ export class TelemetryRepository extends BaseRepository {
   }
 
   /**
+   * Get all telemetry rows of any of the given types since a timestamp,
+   * optionally restricted to a set of sourceIds. Used by cross-node analytics
+   * (e.g. solar pattern detection) where we need to scan multiple metrics
+   * across many nodes within a lookback window.
+   */
+  async getTelemetryByTypesSince(
+    telemetryTypes: string[],
+    sinceTimestamp: number,
+    sourceIds?: string[],
+  ): Promise<DbTelemetry[]> {
+    if (telemetryTypes.length === 0) return [];
+    const { telemetry } = this.tables;
+    const conditions: SQL[] = [
+      inArray(telemetry.telemetryType, telemetryTypes),
+      gte(telemetry.timestamp, sinceTimestamp),
+    ];
+    if (sourceIds && sourceIds.length > 0) {
+      conditions.push(inArray(telemetry.sourceId, sourceIds));
+    }
+    const result = await this.db
+      .select()
+      .from(telemetry)
+      .where(and(...conditions))
+      .orderBy(telemetry.timestamp);
+    return this.normalizeBigInts(result) as DbTelemetry[];
+  }
+
+  /**
    * Get latest telemetry for each type for a node
    */
   async getLatestTelemetryByNode(nodeId: string): Promise<DbTelemetry[]> {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import App from './App.tsx';
 import PacketMonitorPage from './pages/PacketMonitorPage.tsx';
 import DashboardPage from './pages/DashboardPage.tsx';
 import MapAnalysisPage from './pages/MapAnalysisPage.tsx';
+import ReportsPage from './pages/ReportsPage.tsx';
 import UnifiedMessagesPage from './pages/UnifiedMessagesPage.tsx';
 import UnifiedTelemetryPage from './pages/UnifiedTelemetryPage.tsx';
 import GlobalSettingsPage from './pages/GlobalSettingsPage.tsx';
@@ -90,6 +91,12 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
             <Route
               path="analysis"
               element={sharedProviders(<MapAnalysisPage />)}
+            />
+
+            {/* Reports workspace (cross-source analytical reports) */}
+            <Route
+              path="reports"
+              element={sharedProviders(<ReportsPage />)}
             />
 
             {/* Global settings */}

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -1,0 +1,41 @@
+/**
+ * ReportsPage — global cross-source analysis & reports workspace.
+ *
+ * Lists report cards (solar monitoring, etc.) and renders the selected report
+ * full-screen. Public route; underlying API endpoints remain gated by per-source
+ * permissions.
+ */
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { SettingsProvider } from '../contexts/SettingsContext';
+import { ToastProvider } from '../components/ToastContainer';
+import AnalysisTab from '../components/Analysis/AnalysisTab';
+import { appBasename } from '../init';
+import '../styles/analysis-reports.css';
+
+export default function ReportsPage() {
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  return (
+    <ToastProvider>
+      <SettingsProvider>
+        <div className="reports-page">
+          <header className="reports-header">
+            <button
+              type="button"
+              className="reports-header__back"
+              onClick={() => navigate('/')}
+            >
+              {t('common.back', '← Dashboard')}
+            </button>
+            <h1>{t('analysis.title', 'Analysis & Reports')}</h1>
+          </header>
+          <main className="reports-body">
+            <AnalysisTab baseUrl={appBasename} />
+          </main>
+        </div>
+      </SettingsProvider>
+    </ToastProvider>
+  );
+}

--- a/src/server/routes/analysisRoutes.ts
+++ b/src/server/routes/analysisRoutes.ts
@@ -15,6 +15,13 @@ import { Router, Request, Response } from 'express';
 import databaseService from '../../services/database.js';
 import { optionalAuth } from '../auth/authMiddleware.js';
 import { logger } from '../../utils/logger.js';
+import {
+  identifySolarNodes,
+  summarizeSolarProduction,
+  computeSolarForecast,
+  type SolarTelemetryRow,
+  type NodeNameLookup,
+} from '../services/solarAnalysis.js';
 
 const router = Router();
 router.use(optionalAuth());
@@ -148,6 +155,156 @@ router.get('/coverage-grid', async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Error in GET /api/analysis/coverage-grid:', error);
     res.status(500).json({ error: 'Failed to fetch coverage grid' });
+  }
+});
+
+/**
+ * GET /api/analysis/solar-nodes
+ *
+ * Identifies likely solar-powered nodes by analyzing battery and voltage
+ * telemetry over a lookback window. Filters telemetry by the requesting
+ * user's permitted source IDs (admin = all enabled sources).
+ */
+router.get('/solar-nodes', async (req: Request, res: Response) => {
+  try {
+    const lookbackDays = (() => {
+      const n = parseInt(String(req.query.lookback_days ?? '7'), 10);
+      if (!Number.isFinite(n)) return 7;
+      return Math.min(Math.max(n, 1), 90);
+    })();
+
+    const permitted = await resolvePermittedSourceIds(req);
+    const requested = parseSourcesParam(req.query.sources);
+    const sourceIds = requested
+      ? permitted.filter((id) => requested.includes(id))
+      : permitted;
+
+    const sinceMs = Date.now() - lookbackDays * 24 * 3600_000;
+
+    // INA voltage channels — covers ch1Voltage, ch2Voltage, ch3Voltage variants
+    // recorded by the firmware.
+    const telemetryTypes = [
+      'batteryLevel',
+      'voltage',
+      'ch1Voltage',
+      'ch2Voltage',
+      'ch3Voltage',
+    ];
+
+    const telemetryRows = await databaseService.telemetry.getTelemetryByTypesSince(
+      telemetryTypes,
+      sinceMs,
+      sourceIds.length > 0 ? sourceIds : undefined,
+    );
+
+    const rows: SolarTelemetryRow[] = telemetryRows
+      .filter((r: any) => typeof r.value === 'number' && r.value !== null)
+      .map((r: any) => ({
+        nodeNum: Number(r.nodeNum),
+        telemetryType: String(r.telemetryType),
+        timestamp: Number(r.timestamp),
+        value: Number(r.value),
+      }));
+
+    const allNodes = await databaseService.nodes.getAllNodes();
+    const nodeLookup: NodeNameLookup[] = allNodes.map((n: any) => ({
+      nodeNum: Number(n.nodeNum),
+      longName: n.longName,
+      shortName: n.shortName,
+    }));
+
+    const result = identifySolarNodes(rows, nodeLookup, lookbackDays);
+
+    // Overlay: hourly solar-production estimates from the forecast.solar
+    // cache for the same lookback window. Returned alongside per-node chart
+    // data so the UI can render an output curve under the battery line.
+    try {
+      const startSec = Math.floor(sinceMs / 1000);
+      const endSec = Math.floor(Date.now() / 1000) + 5 * 24 * 3600; // include forecast window
+      const estimates = await databaseService.getSolarEstimatesInRangeAsync(
+        startSec,
+        endSec,
+      );
+      result.solar_production = summarizeSolarProduction(estimates);
+    } catch (e) {
+      logger.warn('Failed to load solar estimates for analysis overlay:', e);
+    }
+
+    res.json(result);
+  } catch (error) {
+    logger.error('Error in GET /api/analysis/solar-nodes:', error);
+    res.status(500).json({ error: 'Failed to analyze solar nodes' });
+  }
+});
+
+/**
+ * GET /api/analysis/solar-forecast
+ *
+ * Compares forecast.solar projections to historical production averages and
+ * simulates each detected solar node's battery state across the forecast
+ * horizon. Returns nodes predicted to drop below the at-risk threshold so
+ * operators can intervene before they go offline.
+ */
+router.get('/solar-forecast', async (req: Request, res: Response) => {
+  try {
+    const lookbackDays = (() => {
+      const n = parseInt(String(req.query.lookback_days ?? '7'), 10);
+      if (!Number.isFinite(n)) return 7;
+      return Math.min(Math.max(n, 1), 90);
+    })();
+
+    const permitted = await resolvePermittedSourceIds(req);
+    const requested = parseSourcesParam(req.query.sources);
+    const sourceIds = requested
+      ? permitted.filter((id) => requested.includes(id))
+      : permitted;
+
+    const sinceMs = Date.now() - lookbackDays * 24 * 3600_000;
+    const telemetryTypes = [
+      'batteryLevel',
+      'voltage',
+      'ch1Voltage',
+      'ch2Voltage',
+      'ch3Voltage',
+    ];
+
+    const telemetryRows = await databaseService.telemetry.getTelemetryByTypesSince(
+      telemetryTypes,
+      sinceMs,
+      sourceIds.length > 0 ? sourceIds : undefined,
+    );
+
+    const rows: SolarTelemetryRow[] = telemetryRows
+      .filter((r: any) => typeof r.value === 'number' && r.value !== null)
+      .map((r: any) => ({
+        nodeNum: Number(r.nodeNum),
+        telemetryType: String(r.telemetryType),
+        timestamp: Number(r.timestamp),
+        value: Number(r.value),
+      }));
+
+    const allNodes = await databaseService.nodes.getAllNodes();
+    const nodeLookup: NodeNameLookup[] = allNodes.map((n: any) => ({
+      nodeNum: Number(n.nodeNum),
+      longName: n.longName,
+      shortName: n.shortName,
+    }));
+
+    const analysis = identifySolarNodes(rows, nodeLookup, lookbackDays);
+
+    // Need both historical (lookback window) and forecast (today + future) Wh
+    const startSec = Math.floor(sinceMs / 1000);
+    const endSec = Math.floor(Date.now() / 1000) + 5 * 24 * 3600;
+    const estimates = await databaseService.getSolarEstimatesInRangeAsync(
+      startSec,
+      endSec,
+    );
+
+    const forecast = computeSolarForecast(analysis, estimates);
+    res.json(forecast);
+  } catch (error) {
+    logger.error('Error in GET /api/analysis/solar-forecast:', error);
+    res.status(500).json({ error: 'Failed to compute solar forecast' });
   }
 });
 

--- a/src/server/services/solarAnalysis.ts
+++ b/src/server/services/solarAnalysis.ts
@@ -1,0 +1,795 @@
+/**
+ * Solar Analysis Service
+ *
+ * Identifies solar-powered nodes by analyzing battery and voltage telemetry
+ * patterns over a lookback window. A "solar pattern" is detected when a
+ * metric shows a morning low followed by a midday/afternoon peak (charging
+ * during daylight hours), and overnight discharge.
+ *
+ * Algorithm port of MeshManager's `_analyze_metric_for_solar_patterns` and
+ * `identify_solar_nodes` (backend/app/routers/ui.py).
+ */
+
+export interface SolarPattern {
+  date: string;
+  sunrise: { time: string; value: number };
+  peak: { time: string; value: number };
+  sunset: { time: string; value: number };
+  rise: number | null;
+  fall: number | null;
+  charge_rate_per_hour: number | null;
+  discharge_rate_per_hour: number | null;
+}
+
+export interface SolarChartPoint {
+  timestamp: number;
+  value: number;
+}
+
+export interface SolarNode {
+  node_num: number;
+  node_name: string;
+  solar_score: number;
+  days_analyzed: number;
+  days_with_pattern: number;
+  recent_patterns: SolarPattern[];
+  metric_type: string;
+  metrics_detected: string[];
+  chart_data: SolarChartPoint[];
+  avg_charge_rate_per_hour: number | null;
+  avg_discharge_rate_per_hour: number | null;
+  insufficient_solar: boolean | null;
+}
+
+export interface SolarProductionPoint {
+  timestamp: number; // ms epoch
+  wattHours: number;
+}
+
+export interface SolarNodesAnalysis {
+  lookback_days: number;
+  total_nodes_analyzed: number;
+  solar_nodes_count: number;
+  solar_nodes: SolarNode[];
+  solar_production: SolarProductionPoint[];
+  avg_charging_hours_per_day: number | null;
+  avg_discharge_hours_per_day: number | null;
+}
+
+export interface ForecastDay {
+  date: string;
+  forecast_wh: number;
+  avg_historical_wh: number;
+  pct_of_average: number;
+  is_low: boolean;
+}
+
+export type ForecastPhase = 'sunrise' | 'peak' | 'sunset';
+
+export interface ForecastSimulationPoint {
+  timestamp: string; // ISO 8601
+  simulated_battery: number;
+  phase: ForecastPhase;
+  forecast_factor: number;
+}
+
+export interface NodeSimulation {
+  node_num: number;
+  node_name: string;
+  metric_type: string;
+  current_battery: number | null;
+  min_simulated_battery: number;
+  simulation: ForecastSimulationPoint[];
+}
+
+export interface SolarForecastAnalysis {
+  lookback_days: number;
+  historical_days_analyzed: number;
+  avg_historical_daily_wh: number;
+  low_output_warning: boolean;
+  forecast_days: ForecastDay[];
+  nodes_at_risk_count: number;
+  nodes_at_risk: NodeSimulation[];
+  solar_simulations: NodeSimulation[];
+}
+
+interface MetricReading {
+  time: number; // ms epoch
+  value: number;
+}
+
+interface MetricResult {
+  has_pattern: true;
+  is_high_efficiency: boolean;
+  sunrise: { time: number; value: number };
+  peak: { time: number; value: number };
+  sunset: { time: number; value: number };
+  rise: number;
+  fall: number;
+  charge_rate: number | null;
+  discharge_rate: number | null;
+  daylight_hours: number | null;
+  discharge_hours: number | null;
+  daily_range: number;
+}
+
+interface MetricStats {
+  days_with_pattern: number;
+  total_days: number;
+  high_efficiency_days: number;
+  daily_patterns: SolarPattern[];
+  charge_rates: number[];
+  discharge_rates: number[];
+  previous_day_sunset: { time: number; value: number } | null;
+  total_variance: number;
+}
+
+const HOUR_MS = 3600_000;
+const DAY_MS = 24 * HOUR_MS;
+const MIN_HOURS_FOR_RATE = 0.5;
+
+function newStats(): MetricStats {
+  return {
+    days_with_pattern: 0,
+    total_days: 0,
+    high_efficiency_days: 0,
+    daily_patterns: [],
+    charge_rates: [],
+    discharge_rates: [],
+    previous_day_sunset: null,
+    total_variance: 0,
+  };
+}
+
+function hourOf(ts: number): number {
+  return new Date(ts).getUTCHours();
+}
+
+function dateKey(ts: number): string {
+  const d = new Date(ts);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}`;
+}
+
+function formatHM(ts: number): string {
+  const d = new Date(ts);
+  const h = String(d.getUTCHours()).padStart(2, '0');
+  const m = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${h}:${m}`;
+}
+
+function round(value: number, digits: number = 2): number {
+  const f = Math.pow(10, digits);
+  return Math.round(value * f) / f;
+}
+
+function analyzeMetricForSolarPatterns(
+  values: MetricReading[],
+  isBattery: boolean,
+  previousDaySunset: { time: number; value: number } | null,
+): MetricResult | null {
+  if (values.length < 3) return null;
+
+  const allValues = values.map((v) => v.value);
+  const minValue = Math.min(...allValues);
+  const maxValue = Math.max(...allValues);
+  const dailyRange = maxValue - minValue;
+
+  const minVariance = isBattery ? 10 : 0.3;
+
+  let isHighEfficiencyCandidate = false;
+  if (isBattery) {
+    isHighEfficiencyCandidate =
+      minValue >= 90 && dailyRange >= 2 && dailyRange < minVariance;
+  } else {
+    isHighEfficiencyCandidate =
+      minValue >= 4.1 && dailyRange >= 0.05 && dailyRange < minVariance;
+  }
+
+  if (dailyRange < minVariance && !isHighEfficiencyCandidate) {
+    return null;
+  }
+
+  const morning = values.filter((v) => {
+    const h = hourOf(v.time);
+    return h >= 6 && h <= 10;
+  });
+  const afternoon = values.filter((v) => {
+    const h = hourOf(v.time);
+    return h >= 12 && h <= 18;
+  });
+
+  let sunrise: MetricReading;
+  let peak: MetricReading;
+  let sunset: MetricReading;
+  let rise: number;
+  let fall: number;
+
+  if (morning.length > 0 && afternoon.length > 0) {
+    sunrise = morning.reduce((a, b) => (a.value <= b.value ? a : b));
+    peak = afternoon.reduce((a, b) => (a.value >= b.value ? a : b));
+    rise = peak.value - sunrise.value;
+    sunset = values[values.length - 1];
+    fall = peak.value - sunset.value;
+  } else {
+    // Fallback: overall min/max
+    sunrise = values.reduce((a, b) => (a.value <= b.value ? a : b));
+    peak = values.reduce((a, b) => (a.value >= b.value ? a : b));
+    rise = peak.value - sunrise.value;
+    sunset = values[values.length - 1];
+    fall = peak.value - sunset.value;
+  }
+
+  const peakHour = hourOf(peak.time);
+  const sunriseHour = hourOf(sunrise.time);
+
+  let minRiseThreshold: number;
+  let minRatio: number;
+  if (isHighEfficiencyCandidate) {
+    minRiseThreshold = isBattery ? 1 : 0.02;
+    minRatio = 0.98;
+  } else {
+    minRiseThreshold = Math.max(minVariance, dailyRange * 0.3);
+    minRatio = 0.95;
+  }
+
+  const hasSolarPattern =
+    rise >= minRiseThreshold &&
+    peakHour >= 10 &&
+    peakHour <= 18 &&
+    sunriseHour <= 12 &&
+    sunrise.value <= peak.value * minRatio;
+
+  if (!hasSolarPattern) return null;
+
+  // For batteries, use first reading where value hits 100% as effective peak
+  let effectivePeakTime = peak.time;
+  let effectivePeakValue = peak.value;
+  if (isBattery) {
+    for (const v of values) {
+      if (v.time > sunrise.time && v.time <= sunset.time && v.value >= 100) {
+        effectivePeakTime = v.time;
+        effectivePeakValue = v.value;
+        break;
+      }
+    }
+  }
+
+  const chargingHours = (effectivePeakTime - sunrise.time) / HOUR_MS;
+  const chargeRate =
+    chargingHours >= MIN_HOURS_FOR_RATE
+      ? (effectivePeakValue - sunrise.value) / chargingHours
+      : null;
+
+  const daylightHours = (sunset.time - sunrise.time) / HOUR_MS;
+
+  let dischargeRate: number | null = null;
+  let dischargeHours: number | null = null;
+  if (previousDaySunset !== null) {
+    dischargeHours = (sunrise.time - previousDaySunset.time) / HOUR_MS;
+    if (dischargeHours >= MIN_HOURS_FOR_RATE) {
+      dischargeRate = (previousDaySunset.value - sunrise.value) / dischargeHours;
+    }
+  }
+
+  return {
+    has_pattern: true,
+    is_high_efficiency: isHighEfficiencyCandidate,
+    sunrise: { time: sunrise.time, value: sunrise.value },
+    peak: { time: peak.time, value: peak.value },
+    sunset: { time: sunset.time, value: sunset.value },
+    rise,
+    fall,
+    charge_rate: chargeRate,
+    discharge_rate: dischargeRate,
+    daylight_hours: daylightHours > 0 ? daylightHours : null,
+    discharge_hours: dischargeHours,
+    daily_range: dailyRange,
+  };
+}
+
+function applyMetricResult(
+  stats: MetricStats,
+  result: MetricResult | null,
+  values: MetricReading[],
+  date: string,
+  isBattery: boolean,
+  allChargingHours: number[],
+  allDischargeHours: number[],
+): void {
+  if (result) {
+    stats.days_with_pattern += 1;
+    if (result.charge_rate !== null) stats.charge_rates.push(result.charge_rate);
+    if (result.discharge_rate !== null) stats.discharge_rates.push(result.discharge_rate);
+    if (result.daylight_hours !== null) allChargingHours.push(result.daylight_hours);
+    if (result.discharge_hours !== null) allDischargeHours.push(result.discharge_hours);
+    stats.total_variance += result.daily_range;
+    if (result.is_high_efficiency) stats.high_efficiency_days += 1;
+    stats.daily_patterns.push({
+      date,
+      sunrise: { time: formatHM(result.sunrise.time), value: round(result.sunrise.value, 1) },
+      peak: { time: formatHM(result.peak.time), value: round(result.peak.value, 1) },
+      sunset: { time: formatHM(result.sunset.time), value: round(result.sunset.value, 1) },
+      rise: result.rise !== null ? round(result.rise, 1) : null,
+      fall: result.fall !== null ? round(result.fall, 1) : null,
+      charge_rate_per_hour: result.charge_rate !== null ? round(result.charge_rate, 2) : null,
+      discharge_rate_per_hour:
+        result.discharge_rate !== null ? round(result.discharge_rate, 2) : null,
+    });
+    stats.previous_day_sunset = { time: result.sunset.time, value: result.sunset.value };
+    stats.total_days += 1;
+  } else if (values.length > 0) {
+    const allVals = values.map((v) => v.value);
+    const dailyRange = Math.max(...allVals) - Math.min(...allVals);
+    const minVarConsider = isBattery ? 2 : 0.05;
+    if (dailyRange >= minVarConsider) {
+      stats.total_days += 1;
+    }
+  }
+}
+
+export interface SolarTelemetryRow {
+  nodeNum: number;
+  telemetryType: string;
+  timestamp: number;
+  value: number;
+}
+
+export interface NodeNameLookup {
+  nodeNum: number;
+  longName?: string | null;
+  shortName?: string | null;
+}
+
+/**
+ * Run the solar pattern detection across all telemetry rows for the lookback
+ * window. Telemetry rows must include batteryLevel, voltage, and any INA
+ * voltage channels (e.g. ch1Voltage). Caller is responsible for fetching
+ * rows from the database.
+ */
+export function identifySolarNodes(
+  telemetryRows: SolarTelemetryRow[],
+  nodes: NodeNameLookup[],
+  lookbackDays: number,
+): SolarNodesAnalysis {
+  // Build node name lookup
+  const nodeNames = new Map<number, string>();
+  for (const node of nodes) {
+    if (node.longName) nodeNames.set(node.nodeNum, node.longName);
+    else if (node.shortName) nodeNames.set(node.nodeNum, node.shortName);
+    else nodeNames.set(node.nodeNum, `!${(node.nodeNum >>> 0).toString(16).padStart(8, '0')}`);
+  }
+
+  // Group telemetry by node, then date, then metric
+  // Structure: Map<nodeNum, Map<dateKey, Map<metricName, MetricReading[]>>>
+  const nodeData = new Map<number, Map<string, Map<string, MetricReading[]>>>();
+  const inaChannelsByNode = new Map<number, Set<string>>();
+
+  for (const row of telemetryRows) {
+    const nodeNum = Number(row.nodeNum);
+    if (!Number.isFinite(nodeNum)) continue;
+    const date = dateKey(row.timestamp);
+    let byDate = nodeData.get(nodeNum);
+    if (!byDate) {
+      byDate = new Map();
+      nodeData.set(nodeNum, byDate);
+    }
+    let byMetric = byDate.get(date);
+    if (!byMetric) {
+      byMetric = new Map();
+      byDate.set(date, byMetric);
+    }
+    let arr = byMetric.get(row.telemetryType);
+    if (!arr) {
+      arr = [];
+      byMetric.set(row.telemetryType, arr);
+    }
+    arr.push({ time: row.timestamp, value: row.value });
+
+    if (
+      row.telemetryType !== 'voltage' &&
+      row.telemetryType.endsWith('Voltage')
+    ) {
+      let set = inaChannelsByNode.get(nodeNum);
+      if (!set) {
+        set = new Set();
+        inaChannelsByNode.set(nodeNum, set);
+      }
+      set.add(row.telemetryType);
+    }
+  }
+
+  const allChargingHours: number[] = [];
+  const allDischargeHours: number[] = [];
+  const solarCandidates: SolarNode[] = [];
+
+  for (const [nodeNum, byDate] of nodeData.entries()) {
+    const batteryStats = newStats();
+    const voltageStats = newStats();
+    const inaChannels = inaChannelsByNode.get(nodeNum) ?? new Set<string>();
+    const inaStats = new Map<string, MetricStats>();
+    for (const ch of inaChannels) inaStats.set(ch, newStats());
+
+    const sortedDates = Array.from(byDate.keys()).sort();
+    for (const date of sortedDates) {
+      const byMetric = byDate.get(date)!;
+      const batteryReadings = (byMetric.get('batteryLevel') ?? [])
+        .slice()
+        .sort((a, b) => a.time - b.time);
+      const voltageReadings = (byMetric.get('voltage') ?? [])
+        .slice()
+        .sort((a, b) => a.time - b.time);
+
+      // Need at least 3 readings of any metric to consider this day
+      const totalReadings =
+        batteryReadings.length + voltageReadings.length +
+        Array.from(inaChannels).reduce(
+          (sum, ch) => sum + (byMetric.get(ch)?.length ?? 0),
+          0,
+        );
+      if (totalReadings < 3) continue;
+
+      if (batteryReadings.length >= 3) {
+        const result = analyzeMetricForSolarPatterns(
+          batteryReadings,
+          true,
+          batteryStats.previous_day_sunset,
+        );
+        applyMetricResult(
+          batteryStats,
+          result,
+          batteryReadings,
+          date,
+          true,
+          allChargingHours,
+          allDischargeHours,
+        );
+      }
+
+      if (voltageReadings.length >= 3) {
+        const result = analyzeMetricForSolarPatterns(
+          voltageReadings,
+          false,
+          voltageStats.previous_day_sunset,
+        );
+        applyMetricResult(
+          voltageStats,
+          result,
+          voltageReadings,
+          date,
+          false,
+          allChargingHours,
+          allDischargeHours,
+        );
+      }
+
+      for (const ch of inaChannels) {
+        const readings = (byMetric.get(ch) ?? []).slice().sort((a, b) => a.time - b.time);
+        if (readings.length < 3) continue;
+        const stats = inaStats.get(ch)!;
+        const result = analyzeMetricForSolarPatterns(
+          readings,
+          false,
+          stats.previous_day_sunset,
+        );
+        applyMetricResult(
+          stats,
+          result,
+          readings,
+          date,
+          false,
+          allChargingHours,
+          allDischargeHours,
+        );
+      }
+    }
+
+    // Pick best metric: prefer the one with most days_with_pattern, break ties by total_variance
+    const candidates: Array<{
+      metric: string;
+      stats: MetricStats;
+    }> = [];
+    if (batteryStats.days_with_pattern > 0) {
+      candidates.push({ metric: 'batteryLevel', stats: batteryStats });
+    }
+    if (voltageStats.days_with_pattern > 0) {
+      candidates.push({ metric: 'voltage', stats: voltageStats });
+    }
+    for (const [ch, stats] of inaStats.entries()) {
+      if (stats.days_with_pattern > 0) {
+        candidates.push({ metric: ch, stats });
+      }
+    }
+
+    if (candidates.length === 0) continue;
+
+    candidates.sort((a, b) => {
+      if (b.stats.days_with_pattern !== a.stats.days_with_pattern) {
+        return b.stats.days_with_pattern - a.stats.days_with_pattern;
+      }
+      return b.stats.total_variance - a.stats.total_variance;
+    });
+
+    const chosen = candidates[0];
+    const stats = chosen.stats;
+    const totalDays = Math.max(stats.total_days, stats.days_with_pattern);
+    const daysWithPattern = stats.days_with_pattern;
+
+    // Apply pattern threshold (33% if high-efficiency majority, else 50%)
+    const isMostlyHighEff =
+      stats.total_days > 0 && stats.high_efficiency_days >= stats.total_days / 2;
+    const minPatternRatio = isMostlyHighEff ? 0.33 : 0.5;
+    const patternRatio = totalDays > 0 ? daysWithPattern / totalDays : 0;
+    if (patternRatio < minPatternRatio) continue;
+
+    const solarScore = round((daysWithPattern / Math.max(totalDays, 1)) * 100, 1);
+    const avgChargeRate =
+      stats.charge_rates.length > 0
+        ? round(stats.charge_rates.reduce((a, b) => a + b, 0) / stats.charge_rates.length, 2)
+        : null;
+    const avgDischargeRate =
+      stats.discharge_rates.length > 0
+        ? round(
+            stats.discharge_rates.reduce((a, b) => a + b, 0) / stats.discharge_rates.length,
+            2,
+          )
+        : null;
+
+    // Build chart data for the chosen metric across the lookback window
+    const chart: SolarChartPoint[] = [];
+    for (const [, byMetric] of byDate.entries()) {
+      const readings = byMetric.get(chosen.metric) ?? [];
+      for (const r of readings) {
+        chart.push({ timestamp: r.time, value: round(r.value, 3) });
+      }
+    }
+    chart.sort((a, b) => a.timestamp - b.timestamp);
+
+    const metricsDetected: string[] = [];
+    if (batteryStats.days_with_pattern > 0) metricsDetected.push('battery');
+    if (voltageStats.days_with_pattern > 0) metricsDetected.push('voltage');
+    for (const [ch, s] of inaStats.entries()) {
+      if (s.days_with_pattern > 0) metricsDetected.push(ch);
+    }
+
+    solarCandidates.push({
+      node_num: nodeNum,
+      node_name: nodeNames.get(nodeNum) ?? `!${(nodeNum >>> 0).toString(16).padStart(8, '0')}`,
+      solar_score: solarScore,
+      days_analyzed: totalDays,
+      days_with_pattern: daysWithPattern,
+      recent_patterns: stats.daily_patterns.slice(-3),
+      metric_type: chosen.metric,
+      metrics_detected: metricsDetected,
+      chart_data: chart,
+      avg_charge_rate_per_hour: avgChargeRate,
+      avg_discharge_rate_per_hour: avgDischargeRate,
+      insufficient_solar: null,
+    });
+  }
+
+  solarCandidates.sort((a, b) => b.solar_score - a.solar_score);
+
+  const avgChargingHoursPerDay =
+    allChargingHours.length > 0
+      ? round(allChargingHours.reduce((a, b) => a + b, 0) / allChargingHours.length, 1)
+      : null;
+  const avgDischargeHoursPerDay =
+    allDischargeHours.length > 0
+      ? round(allDischargeHours.reduce((a, b) => a + b, 0) / allDischargeHours.length, 1)
+      : null;
+
+  // Mark insufficient_solar
+  for (const node of solarCandidates) {
+    const chargeRate = node.avg_charge_rate_per_hour;
+    const dischargeRate = node.avg_discharge_rate_per_hour;
+    const recent = node.recent_patterns;
+
+    let nearFullSolved = false;
+    if (recent.length > 0) {
+      const peakValues = recent.map((p) => p.peak.value ?? 0);
+      const daysAtFull = peakValues.filter((pv) => pv >= 98).length;
+      if (daysAtFull >= peakValues.length / 2) {
+        node.insufficient_solar = false;
+        nearFullSolved = true;
+      }
+    }
+    if (nearFullSolved) continue;
+
+    if (
+      chargeRate !== null &&
+      dischargeRate !== null &&
+      avgChargingHoursPerDay !== null &&
+      avgDischargeHoursPerDay !== null
+    ) {
+      const totalCharge = chargeRate * avgChargingHoursPerDay;
+      const totalDischarge = dischargeRate * avgDischargeHoursPerDay;
+      node.insufficient_solar = totalCharge <= totalDischarge * 1.1;
+    } else {
+      node.insufficient_solar = null;
+    }
+  }
+
+  void DAY_MS; // reserved for future per-day windowing
+
+  return {
+    lookback_days: lookbackDays,
+    total_nodes_analyzed: nodeData.size,
+    solar_nodes_count: solarCandidates.length,
+    solar_nodes: solarCandidates,
+    solar_production: [],
+    avg_charging_hours_per_day: avgChargingHoursPerDay,
+    avg_discharge_hours_per_day: avgDischargeHoursPerDay,
+  };
+}
+
+/**
+ * Group raw solar estimate points (unix seconds + watt_hours) into hourly
+ * points keyed by ms-epoch — used as a chart-ready overlay alongside the
+ * battery telemetry.
+ */
+export function summarizeSolarProduction(
+  estimates: Array<{ timestamp: number; watt_hours: number }>,
+): SolarProductionPoint[] {
+  // Group by hour, average across estimates that fall in the same bucket
+  // (the upsert is keyed on (timestamp, fetched_at) so multiple fetches can
+  // land in the same hour).
+  const byHour = new Map<number, { sum: number; count: number }>();
+  for (const e of estimates) {
+    const ms = e.timestamp * 1000;
+    const hour = Math.floor(ms / HOUR_MS) * HOUR_MS;
+    const cell = byHour.get(hour) ?? { sum: 0, count: 0 };
+    cell.sum += e.watt_hours;
+    cell.count += 1;
+    byHour.set(hour, cell);
+  }
+  return Array.from(byHour.entries())
+    .map(([hour, cell]) => ({
+      timestamp: hour,
+      wattHours: round(cell.sum / cell.count, 2),
+    }))
+    .sort((a, b) => a.timestamp - b.timestamp);
+}
+
+/**
+ * Build the solar forecast analysis from the per-node solar analysis and the
+ * raw solar estimate dataset (unix-seconds rows from the forecast.solar
+ * cache). Compares historical (pre-today) average daily output to forecast
+ * (today + future) and simulates each solar node's battery state over the
+ * forecast window using its measured charge/discharge rates.
+ */
+export function computeSolarForecast(
+  analysis: SolarNodesAnalysis,
+  estimates: Array<{ timestamp: number; watt_hours: number }>,
+): SolarForecastAnalysis {
+  const now = Date.now();
+  const todayStartMs = (() => {
+    const d = new Date(now);
+    d.setUTCHours(0, 0, 0, 0);
+    return d.getTime();
+  })();
+
+  // Aggregate Wh per UTC day
+  const dailyWh = new Map<string, number>();
+  for (const e of estimates) {
+    const ms = e.timestamp * 1000;
+    const date = dateKey(ms);
+    dailyWh.set(date, (dailyWh.get(date) ?? 0) + e.watt_hours);
+  }
+
+  // Historical = days strictly before today
+  const todayKey = dateKey(todayStartMs);
+  const historicalDailyWh: number[] = [];
+  for (const [date, wh] of dailyWh.entries()) {
+    if (date < todayKey) historicalDailyWh.push(wh);
+  }
+  const avgHistoricalDailyWh =
+    historicalDailyWh.length > 0
+      ? historicalDailyWh.reduce((a, b) => a + b, 0) / historicalDailyWh.length
+      : 0;
+
+  // Forecast days = today + future where data is available
+  const forecastDays: ForecastDay[] = [];
+  for (let dayOffset = 0; dayOffset < 5; dayOffset++) {
+    const ms = todayStartMs + dayOffset * DAY_MS;
+    const date = dateKey(ms);
+    const forecastWh = dailyWh.get(date);
+    if (forecastWh === undefined) continue;
+    const pct = avgHistoricalDailyWh > 0 ? (forecastWh / avgHistoricalDailyWh) * 100 : 100;
+    forecastDays.push({
+      date,
+      forecast_wh: round(forecastWh, 1),
+      avg_historical_wh: round(avgHistoricalDailyWh, 1),
+      pct_of_average: round(pct, 1),
+      is_low: pct < 75,
+    });
+  }
+
+  const lowOutputWarning = forecastDays.some((d) => d.is_low);
+
+  // Simulate per-node battery state across forecast horizon
+  const simulations: NodeSimulation[] = [];
+  const atRisk: NodeSimulation[] = [];
+  const avgChargingHours = analysis.avg_charging_hours_per_day ?? 6;
+  const avgDischargeHours = analysis.avg_discharge_hours_per_day ?? 14;
+
+  for (const node of analysis.solar_nodes) {
+    if (
+      node.avg_charge_rate_per_hour === null ||
+      node.avg_discharge_rate_per_hour === null
+    ) {
+      continue;
+    }
+    const lastPoint = node.chart_data[node.chart_data.length - 1];
+    if (!lastPoint) continue;
+
+    const points: ForecastSimulationPoint[] = [];
+    let battery = lastPoint.value;
+    let minBattery = battery;
+    const isPercent = node.metric_type === 'batteryLevel';
+    const clamp = (v: number) => (isPercent ? Math.max(0, Math.min(100, v)) : Math.max(0, v));
+
+    for (const fd of forecastDays) {
+      const factor =
+        avgHistoricalDailyWh > 0
+          ? Math.min(1.5, Math.max(0, fd.forecast_wh / avgHistoricalDailyWh))
+          : 1;
+      const effectiveCharge = node.avg_charge_rate_per_hour * factor;
+
+      // Sunrise — drained overnight
+      battery = clamp(battery - node.avg_discharge_rate_per_hour * avgDischargeHours);
+      if (battery < minBattery) minBattery = battery;
+      points.push({
+        timestamp: `${fd.date}T12:00:00Z`,
+        simulated_battery: round(battery, 1),
+        phase: 'sunrise',
+        forecast_factor: round(factor, 2),
+      });
+
+      // Peak — charged through daylight
+      battery = clamp(battery + effectiveCharge * avgChargingHours);
+      points.push({
+        timestamp: `${fd.date}T19:00:00Z`,
+        simulated_battery: round(battery, 1),
+        phase: 'peak',
+        forecast_factor: round(factor, 2),
+      });
+
+      // Sunset — small afternoon drain (~4h)
+      battery = clamp(battery - node.avg_discharge_rate_per_hour * 4);
+      points.push({
+        timestamp: `${fd.date}T23:00:00Z`,
+        simulated_battery: round(battery, 1),
+        phase: 'sunset',
+        forecast_factor: round(factor, 2),
+      });
+    }
+
+    const sim: NodeSimulation = {
+      node_num: node.node_num,
+      node_name: node.node_name,
+      metric_type: node.metric_type,
+      current_battery: lastPoint.value,
+      min_simulated_battery: round(minBattery, 1),
+      simulation: points,
+    };
+    simulations.push(sim);
+
+    // At-risk: percentage metric drops below 50%, voltage drops below 3.5V
+    const riskThreshold = isPercent ? 50 : 3.5;
+    if (minBattery < riskThreshold) atRisk.push(sim);
+  }
+
+  return {
+    lookback_days: analysis.lookback_days,
+    historical_days_analyzed: historicalDailyWh.length,
+    avg_historical_daily_wh: round(avgHistoricalDailyWh, 1),
+    low_output_warning: lowOutputWarning,
+    forecast_days: forecastDays,
+    nodes_at_risk_count: atRisk.length,
+    nodes_at_risk: atRisk,
+    solar_simulations: simulations,
+  };
+}

--- a/src/styles/analysis-reports.css
+++ b/src/styles/analysis-reports.css
@@ -1,0 +1,524 @@
+/**
+ * Styles for the Analysis & Reports workspace.
+ * Uses --ctp-* CSS custom properties so the page respects the active theme.
+ */
+
+/* ── Page shell ──────────────────────────────────────────────────────────── */
+
+.reports-page {
+  min-height: 100vh;
+  background: var(--ctp-base);
+  color: var(--ctp-text);
+  font-family: var(--font-family, sans-serif);
+  display: flex;
+  flex-direction: column;
+}
+
+.reports-header {
+  background: var(--ctp-mantle);
+  border-bottom: 1px solid var(--ctp-surface0);
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+}
+
+.reports-header__back {
+  background: var(--ctp-surface1);
+  color: var(--ctp-subtext0);
+  border: none;
+  border-radius: 8px;
+  padding: 7px 14px;
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.reports-header__back:hover {
+  background: var(--ctp-surface2);
+  color: var(--ctp-text);
+}
+
+.reports-header h1 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--ctp-text);
+}
+
+.reports-body {
+  flex: 1 1 auto;
+  padding: 24px;
+  max-width: 1400px;
+  width: 100%;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+/* ── Card grid (landing page) ────────────────────────────────────────────── */
+
+.reports-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.reports-grid__intro {
+  margin: 0 0 8px;
+  color: var(--ctp-subtext1, var(--ctp-subtext0));
+  font-size: 14px;
+  line-height: 1.5;
+  max-width: 720px;
+}
+
+.reports-card {
+  background: var(--ctp-mantle);
+  border: 1px solid var(--ctp-surface0);
+  border-radius: 12px;
+  padding: 22px;
+  cursor: pointer;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  color: var(--ctp-text);
+  transition:
+    border-color 0.15s,
+    transform 0.15s,
+    box-shadow 0.15s,
+    background 0.15s;
+  min-height: 160px;
+  font: inherit;
+}
+
+.reports-card:hover {
+  border-color: var(--ctp-blue);
+  background: var(--ctp-surface0);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+}
+
+.reports-card__icon {
+  font-size: 2.25rem;
+  line-height: 1;
+}
+
+.reports-card__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--ctp-text);
+}
+
+.reports-card__desc {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ctp-subtext0);
+}
+
+/* ── Report shell (when a report is selected) ──────────────────────────── */
+
+.reports-section {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.reports-section__back {
+  align-self: flex-start;
+  background: var(--ctp-surface0);
+  color: var(--ctp-subtext0);
+  border: 1px solid var(--ctp-surface1);
+  padding: 7px 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.reports-section__back:hover {
+  background: var(--ctp-surface1);
+  color: var(--ctp-text);
+}
+
+.reports-section__title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--ctp-text);
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+}
+
+.reports-section__subtitle {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ctp-subtext0);
+  max-width: 760px;
+}
+
+.reports-panel {
+  background: var(--ctp-mantle);
+  border: 1px solid var(--ctp-surface0);
+  border-radius: 12px;
+  padding: 18px;
+}
+
+/* ── Controls bar ───────────────────────────────────────────────────────── */
+
+.reports-controls {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.reports-controls__field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--ctp-subtext0);
+}
+
+.reports-controls__field input[type='number'] {
+  width: 5.5rem;
+  padding: 6px 8px;
+  background: var(--ctp-base);
+  border: 1px solid var(--ctp-surface1);
+  color: var(--ctp-text);
+  border-radius: 6px;
+  font: inherit;
+}
+
+.reports-controls__field input[type='number']:focus {
+  outline: none;
+  border-color: var(--ctp-blue);
+}
+
+.reports-btn {
+  padding: 7px 16px;
+  background: var(--ctp-blue);
+  color: var(--ctp-base);
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  font-size: 13px;
+  transition: filter 0.15s;
+}
+
+.reports-btn:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.reports-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.reports-btn--ghost {
+  background: var(--ctp-surface0);
+  color: var(--ctp-text);
+  border: 1px solid var(--ctp-surface1);
+}
+
+.reports-btn--ghost:hover:not(:disabled) {
+  background: var(--ctp-surface1);
+  filter: none;
+}
+
+/* ── Status banners (error / empty) ─────────────────────────────────────── */
+
+.reports-banner {
+  padding: 14px 16px;
+  border-radius: 10px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.reports-banner--error {
+  background: color-mix(in srgb, var(--ctp-red) 18%, var(--ctp-mantle));
+  border: 1px solid var(--ctp-red);
+  color: var(--ctp-red);
+}
+
+.reports-banner--empty {
+  background: var(--ctp-mantle);
+  border: 1px dashed var(--ctp-surface1);
+  color: var(--ctp-subtext0);
+  text-align: center;
+  padding: 36px 16px;
+}
+
+/* ── Stat tiles (summary row) ───────────────────────────────────────────── */
+
+.reports-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 10px;
+}
+
+.reports-stat {
+  background: var(--ctp-mantle);
+  border: 1px solid var(--ctp-surface0);
+  border-radius: 10px;
+  padding: 12px 14px;
+}
+
+.reports-stat__label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ctp-subtext0);
+  margin-bottom: 4px;
+}
+
+.reports-stat__value {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--ctp-text);
+}
+
+/* ── Node cards (per detected solar node) ──────────────────────────────── */
+
+.reports-node-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.reports-node {
+  background: var(--ctp-mantle);
+  border: 1px solid var(--ctp-surface0);
+  border-radius: 12px;
+  overflow: hidden;
+  transition: border-color 0.15s;
+}
+
+.reports-node--insufficient {
+  border-color: var(--ctp-yellow);
+}
+
+.reports-node__header {
+  width: 100%;
+  padding: 14px 18px;
+  background: transparent;
+  border: none;
+  color: var(--ctp-text);
+  cursor: pointer;
+  text-align: left;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 14px;
+  font: inherit;
+}
+
+.reports-node__header:hover {
+  background: var(--ctp-surface0);
+}
+
+.reports-node__name {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--ctp-text);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.reports-node__warning {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  padding: 2px 9px;
+  background: var(--ctp-yellow);
+  color: var(--ctp-base);
+  border-radius: 999px;
+}
+
+.reports-node__meta {
+  font-size: 12px;
+  color: var(--ctp-subtext0);
+  margin-top: 3px;
+}
+
+.reports-node__chevron {
+  font-size: 12px;
+  color: var(--ctp-subtext0);
+  flex-shrink: 0;
+}
+
+.reports-node__body {
+  padding: 16px 18px 18px;
+  border-top: 1px solid var(--ctp-surface0);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: var(--ctp-base);
+}
+
+.reports-node__fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  font-size: 12px;
+}
+
+.reports-node__field-label {
+  color: var(--ctp-subtext0);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  font-size: 10px;
+  margin-bottom: 3px;
+}
+
+.reports-node__field-value {
+  color: var(--ctp-text);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.reports-node__chart {
+  width: 100%;
+  height: 220px;
+  background: var(--ctp-mantle);
+  border: 1px solid var(--ctp-surface0);
+  border-radius: 8px;
+  padding: 8px 8px 8px 0;
+}
+
+.reports-node__patterns-title {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ctp-subtext0);
+  margin: 0 0 6px;
+}
+
+/* ── Patterns table ─────────────────────────────────────────────────────── */
+
+.reports-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--ctp-surface0);
+  border-radius: 8px;
+}
+
+.reports-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  color: var(--ctp-text);
+}
+
+.reports-table th {
+  background: var(--ctp-mantle);
+  padding: 8px 12px;
+  text-align: left;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ctp-subtext0);
+  border-bottom: 1px solid var(--ctp-surface0);
+}
+
+.reports-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--ctp-surface0);
+  white-space: nowrap;
+}
+
+.reports-table tr:last-child td {
+  border-bottom: none;
+}
+
+.reports-table tbody tr:hover {
+  background: var(--ctp-surface0);
+}
+
+/* ── Forecast section ───────────────────────────────────────────────────── */
+
+.reports-forecast {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.reports-forecast__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.reports-forecast__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.reports-forecast__sub {
+  font-size: 12px;
+  color: var(--ctp-subtext0);
+  line-height: 1.5;
+}
+
+.reports-banner--warning {
+  background: color-mix(in srgb, var(--ctp-yellow) 15%, var(--ctp-mantle));
+  border: 1px solid var(--ctp-yellow);
+  color: var(--ctp-yellow);
+}
+
+.reports-pill {
+  display: inline-block;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.reports-pill--ok {
+  background: color-mix(in srgb, var(--ctp-green) 18%, transparent);
+  color: var(--ctp-green);
+}
+
+.reports-pill--warn {
+  background: color-mix(in srgb, var(--ctp-yellow) 22%, transparent);
+  color: var(--ctp-yellow);
+}
+
+.reports-at-risk {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--ctp-text);
+}
+
+.reports-at-risk li {
+  padding: 8px 12px;
+  background: var(--ctp-base);
+  border: 1px solid var(--ctp-surface0);
+  border-radius: 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}


### PR DESCRIPTION
## Summary
- Adds a global **Analysis & Reports** workspace at `/reports`, linked from the dashboard sidebar (under "Map Analysis")
- First report: **Solar Monitoring Analysis** — ports the MeshManager algorithm to identify solar-powered nodes by analyzing battery / voltage / INA-channel telemetry for daytime charging and overnight discharge patterns
- Adds two new cross-source endpoints under the existing `/api/analysis/*` namespace, both gated by the same per-source `nodes:read` permission filter as the rest of the analysis workspace

## What's new

### Backend
- `src/server/services/solarAnalysis.ts` — TypeScript port of MeshManager's `_analyze_metric_for_solar_patterns` + `identify_solar_nodes` (battery + voltage + INA voltage channels, high-efficiency relaxed thresholds, charge/discharge rate, daylight hours, insufficient-solar flag), plus a forecast simulator
- `GET /api/analysis/solar-nodes?lookback_days=N&sources=…` — solar candidates with recent daily patterns, chart data, and a `solar_production` array (hourly Wh from the existing `forecast.solar` cache) for overlay
- `GET /api/analysis/solar-forecast?lookback_days=N&sources=…` — forecast vs historical Wh per day, per-node battery simulation across sunrise/peak/sunset for the next ~5 days, low-output warning, and nodes-at-risk list (nodes whose simulated min battery drops below 50% / 3.5V)
- `TelemetryRepository.getTelemetryByTypesSince(types, sinceMs, sourceIds?)` — efficient cross-node, multi-type telemetry scan for the lookback window
- All queries use Drizzle ORM (no raw SQL); SQLite/PostgreSQL/MySQL compatible

### Frontend
- `src/pages/ReportsPage.tsx` — global page wrapping the report grid, mounted at `/reports`
- `src/components/Analysis/AnalysisTab.tsx` — report card grid (designed for future reports beyond Solar Monitoring)
- `src/components/Analysis/SolarMonitoringReport.tsx` — Recharts-based per-node chart with:
  - Battery/voltage line on left axis
  - Solar production area overlay (yellow) on right axis
  - Reference lines for healthy levels (100/50/20% for battery; 4.2/3.7/3.3 V for voltage)
  - Forecast simulation as a mauve dashed extension line, sunrise/peak/sunset waypoints
  - Recent-patterns table per node (sunrise/peak/sunset times, rise/fall, charge/discharge rates)
  - Forecast results panel (daily forecast vs historical Wh, low-output banner, at-risk node list)
- `src/components/Dashboard/DashboardSidebar.tsx` — new "Analysis & Reports" link
- `src/styles/analysis-reports.css` — uses Catppuccin `--ctp-*` theme variables, matching the unified.css conventions (page shell, cards, controls, stat tiles, panels, pills)

### Permissions
Both endpoints use the existing `resolvePermittedSourceIds` helper in `analysisRoutes.ts`:
- Admins: all enabled sources
- Non-admins: sources where they have `nodes:read`
- Optional `?sources=id1,id2` query param to scope further

## Test plan
- [ ] `/reports` route loads without auth (page itself is public; data filtered by per-source permission)
- [ ] "Run analysis" with default 7-day lookback returns solar candidates and renders charts
- [ ] Charts show: actual battery line + reference lines + solar production overlay (when forecast.solar cache populated)
- [ ] "Run forecast" produces forecast-vs-historical table, low-output banner when applicable, and a mauve dashed simulation line on each node's chart
- [ ] Per-source filtering: passing `?sources=…` to either endpoint scopes the analysis correctly
- [ ] Voltage-only nodes (no batteryLevel telemetry) still detected via voltage metric
- [ ] INA voltage channels (chNVoltage) detected when present
- [ ] Empty state renders when no solar nodes detected
- [ ] Multi-database compatibility (SQLite tested; Postgres/MySQL via Drizzle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)