### PR TITLE
chore: bump version to 4.2.0 and document Analysis & Reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- **Analysis & Reports workspace** ([#2898](https://github.com/Yeraze/meshmonitor/pull/2898)): New global cross-source analytics page at `/reports`, linked from the dashboard sidebar. The first bundled report is **Solar Monitoring Analysis**, a port of MeshManager's algorithm that detects solar-powered nodes by scanning battery / voltage / INA-channel telemetry for the morning-low → afternoon-peak charging pattern and overnight discharge.
+  - **Two new endpoints** under `/api/analysis/*`, both gated by the existing per-source `nodes:read` permission filter:
+    - `GET /api/analysis/solar-nodes?lookback_days=N&sources=…` — solar candidates with daily patterns, chart data, and a hourly solar-production overlay sourced from the existing forecast.solar cache
+    - `GET /api/analysis/solar-forecast?lookback_days=N&sources=…` — forecast vs historical Wh per day, per-node battery simulation across the next ~5 days (sunrise / peak / sunset waypoints), low-output warning, and a "nodes predicted at risk" list (simulated min battery < 50% / 3.5 V)
+  - **Per-node chart** uses Recharts to render the actual battery / voltage line, the solar production area overlay, healthy-level reference lines (100/50/20% for battery; 4.2/3.7/3.3 V for voltage), and the forecast simulation as a mauve dashed extension
+  - **Permission-aware**: admins see all enabled sources, non-admins see only sources they hold `nodes:read` on; an optional `?sources=` query param scopes further
+  - **Telemetry repository**: new `getTelemetryByTypesSince(types, sinceMs, sourceIds?)` for efficient cross-node multi-type scans within a lookback window — works against SQLite, PostgreSQL, and MySQL via Drizzle
+
 - **BREAKING (v1 REST API)**: Per-source data endpoints moved under `/api/v1/sources/{sourceId}/...` to mirror the 4.0 multi-source architecture. The reshape affects nodes, messages, channels, telemetry, traceroutes, packets, network, position history, and status. The literal string `default` is accepted in place of a UUID — it resolves to the first source the token has read permission on (admins get the first enabled source by `createdAt`). New `GET /api/v1/sources` lists the sources a token can read. Deployment-global endpoints (`/api/v1/solar`, `/api/v1/channel-database`) stay unscoped.
   - Legacy root paths (`/api/v1/nodes?sourceId=...`, etc.) still respond but now emit a `Warning: 299` response header and will be removed in a future release.
   - Bumps OpenAPI `info.version` to `2.0.0` while keeping the URL prefix `/api/v1/` so existing `mm_v1_` tokens keep working.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ MeshMonitor supports multiple deployment methods:
 
 ## Key Features
 
+- **Analysis & Reports (4.2)** - Cross-source analytical workspace at `/reports`; first report is Solar Monitoring Analysis with auto-detection of solar-powered nodes, production overlay, healthy-level reference lines, and multi-day battery forecast simulation
 - **Multi-Source (4.0)** - Monitor multiple Meshtastic nodes from a single deployment; per-source permissions, schedulers, and Virtual Nodes
 - **Real-time Mesh Monitoring** - Live node discovery, telemetry, and message tracking
 - **Modern UI** - Catppuccin theme with message reactions and threading

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.1.2",
+  "version": "4.2.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -25,7 +25,8 @@ export default defineConfig({
       {
         text: 'Docs',
         items: [
-          { text: '🆕 4.1 Highlights', link: '/features/map-analysis' },
+          { text: '🆕 4.2 Highlights', link: '/features/analysis-reports' },
+          { text: '4.1 Highlights', link: '/features/map-analysis' },
           { text: '4.0 Highlights', link: '/features/multi-source' },
           { text: 'Features', link: '/features/settings' },
           { text: 'Configuration', link: '/configuration/' },
@@ -39,7 +40,13 @@ export default defineConfig({
     sidebar: {
       '/features/': [
         {
-          text: '🆕 4.1 Highlights',
+          text: '🆕 4.2 Highlights',
+          items: [
+            { text: 'Analysis & Reports', link: '/features/analysis-reports' }
+          ]
+        },
+        {
+          text: '4.1 Highlights',
           items: [
             { text: 'Map Analysis', link: '/features/map-analysis' }
           ]

--- a/docs/api/REST_API.md
+++ b/docs/api/REST_API.md
@@ -985,6 +985,120 @@ Enable or disable Apprise notifications system-wide.
 
 ---
 
+## Analysis & Reports
+
+Cross-source analytical endpoints used by the **Analysis & Reports** workspace at `/reports`. All handlers resolve the requesting user's permitted source IDs (admin = all enabled; otherwise filtered via `nodes:read`) and intersect with the optional `sources` query parameter. Data is publicly routable but always filtered by permission.
+
+### Solar Nodes Analysis
+
+#### GET /api/analysis/solar-nodes
+
+Detects likely solar-powered nodes by analyzing battery and voltage telemetry over a lookback window. Returns the per-node solar score, recent daily charge/discharge patterns, and a chart-ready time series, alongside the hourly solar production overlay from the forecast.solar cache.
+
+**Query Parameters:**
+- `lookback_days` (optional, default `7`, range `1`–`90`) — days of history to analyze
+- `sources` (optional) — comma-separated source IDs to restrict the analysis (intersected with permitted sources)
+
+**Response:**
+```json
+{
+  "lookback_days": 7,
+  "total_nodes_analyzed": 119,
+  "solar_nodes_count": 8,
+  "avg_charging_hours_per_day": 10.2,
+  "avg_discharge_hours_per_day": 13.8,
+  "solar_nodes": [
+    {
+      "node_num": 3575252989,
+      "node_name": "KC4FSU Base",
+      "solar_score": 100,
+      "days_analyzed": 7,
+      "days_with_pattern": 7,
+      "metric_type": "batteryLevel",
+      "metrics_detected": ["battery"],
+      "avg_charge_rate_per_hour": 4.5,
+      "avg_discharge_rate_per_hour": 1.2,
+      "insufficient_solar": false,
+      "chart_data": [
+        { "timestamp": 1777316400000, "value": 87 }
+      ],
+      "recent_patterns": [
+        {
+          "date": "2026-05-03",
+          "sunrise": { "time": "07:12", "value": 72 },
+          "peak":    { "time": "14:48", "value": 99 },
+          "sunset":  { "time": "19:30", "value": 95 },
+          "rise": 27,
+          "fall": 4,
+          "charge_rate_per_hour": 3.5,
+          "discharge_rate_per_hour": 0.9
+        }
+      ]
+    }
+  ],
+  "solar_production": [
+    { "timestamp": 1777316400000, "wattHours": 427 }
+  ]
+}
+```
+
+**Example:**
+```bash
+curl -X GET "http://localhost:8080/api/analysis/solar-nodes?lookback_days=14"
+```
+
+### Solar Forecast Analysis
+
+#### GET /api/analysis/solar-forecast
+
+Compares forecast.solar projections to the lookback's historical average and simulates each detected solar node's battery state across the forecast horizon. Surfaces nodes whose simulated minimum drops below the at-risk threshold (50% for batteries, 3.5 V for voltage metrics).
+
+**Query Parameters:**
+- `lookback_days` (optional, default `7`, range `1`–`90`) — days of history to compute the historical average
+- `sources` (optional) — comma-separated source IDs (intersected with permitted sources)
+
+**Response:**
+```json
+{
+  "lookback_days": 7,
+  "historical_days_analyzed": 7,
+  "avg_historical_daily_wh": 4280.5,
+  "low_output_warning": true,
+  "forecast_days": [
+    { "date": "2026-05-04", "forecast_wh": 3950.0, "avg_historical_wh": 4280.5, "pct_of_average": 92.3, "is_low": false },
+    { "date": "2026-05-05", "forecast_wh": 2475.0, "avg_historical_wh": 4280.5, "pct_of_average": 57.8, "is_low": true }
+  ],
+  "nodes_at_risk_count": 2,
+  "nodes_at_risk": [
+    {
+      "node_num": 1128074052,
+      "node_name": "0day Roof 🤖",
+      "metric_type": "batteryLevel",
+      "current_battery": 78,
+      "min_simulated_battery": 41.5,
+      "simulation": [
+        { "timestamp": "2026-05-04T12:00:00Z", "simulated_battery": 62.4, "phase": "sunrise", "forecast_factor": 0.92 },
+        { "timestamp": "2026-05-04T19:00:00Z", "simulated_battery": 95.2, "phase": "peak",    "forecast_factor": 0.92 },
+        { "timestamp": "2026-05-04T23:00:00Z", "simulated_battery": 90.4, "phase": "sunset",  "forecast_factor": 0.92 }
+      ]
+    }
+  ],
+  "solar_simulations": [/* same shape as nodes_at_risk, but for every solar candidate */]
+}
+```
+
+**Notes:**
+- `forecast_factor` is `forecast_wh / avg_historical_wh`, clamped to `[0, 1.5]`. Each day's effective charge rate for a node is `node.avg_charge_rate_per_hour * forecast_factor`.
+- `low_output_warning` is `true` when any forecast day drops below 75% of the historical average.
+- The forecast horizon is bounded by the data available in the local forecast.solar cache (typically today + 1–2 days).
+
+**Example:**
+```bash
+curl -X GET "http://localhost:8080/api/analysis/solar-forecast?lookback_days=7"
+```
+
+---
+
 ## WebSocket API (Future)
 
 *Note: WebSocket endpoints are planned for future implementation to provide real-time updates.*

--- a/docs/features/analysis-reports.md
+++ b/docs/features/analysis-reports.md
@@ -1,0 +1,86 @@
+# Analysis & Reports
+
+The **Analysis & Reports** workspace is a global, cross-source analytics page that runs analytical reports against the telemetry, position, and routing data MeshMonitor has collected from every source you can read. It lives at `/reports` and is linked from the bottom of the dashboard sidebar (right under *Map Analysis*).
+
+The first report bundled with the workspace is **Solar Monitoring Analysis** — see below. The card-grid landing page is designed to host additional reports over time without changing the routing or navigation surface.
+
+## Solar Monitoring Analysis
+
+Identifies solar-powered nodes by analyzing battery and voltage telemetry over a configurable lookback window and looking for the characteristic morning-low → afternoon-peak charging curve, followed by overnight discharge. Ports the proven detection algorithm from MeshManager.
+
+### What gets analyzed
+
+For every node in your permitted sources, the report scans the following telemetry types over the lookback window:
+
+- `batteryLevel` (preferred when ≥ 3 readings/day are present)
+- `voltage`
+- `ch1Voltage`, `ch2Voltage`, `ch3Voltage` (INA voltage channels)
+
+A daily pattern is recorded when the metric shows:
+
+- A morning low (06:00–10:00 UTC) and an afternoon peak (12:00–18:00 UTC)
+- Sufficient daily variance (≥ 10% for battery, ≥ 0.3 V for voltage) **or** a "high-efficiency" candidate that stays above 90% / 4.1 V with smaller swings
+- A peak hour between 10:00 and 18:00 UTC and a sunrise hour ≤ 12:00 UTC
+
+A node becomes a **solar candidate** when at least 50% of its analyzed days show a pattern (33% for high-efficiency candidates that consistently stay above 98%).
+
+### Running the report
+
+1. Open the dashboard, click **Analysis & Reports** in the sidebar.
+2. Click the **Solar Monitoring Analysis** card.
+3. Set the **Lookback (days)** between `1` and `90` (default `7`) and click **Run analysis**.
+4. *(Optional)* Click **Run forecast** to project battery state across the next several days using the forecast.solar production estimates.
+
+The summary row shows the lookback window, total nodes analyzed, solar nodes detected, average charging hours per day, and average overnight discharge hours per day.
+
+### Per-node card
+
+Each detected node renders an expandable card with:
+
+- **Solar score** (% of analyzed days that showed a clear pattern)
+- **Average charge / discharge rates** (per hour)
+- **Detected metrics** (`battery`, `voltage`, INA channel names)
+- **Insufficient solar warning** when projected daily charging cannot keep up with overnight discharge
+- A **Recharts** time-series chart showing:
+    - Battery / voltage line
+    - Solar production area overlay (Wh, right axis) when forecast.solar data is available
+    - Reference levels: green at 100% / 4.2 V (full), yellow at 50% / 3.7 V (nominal), red at 20% / 3.3 V (low)
+    - **Forecast simulation** as a mauve dashed extension when *Run forecast* has been triggered
+- A **Recent daily patterns** table (date, sunrise / peak / sunset times and values, rise, fall, charge rate /h, discharge rate /h)
+
+### Forecast simulation
+
+The forecast endpoint compares projected daily Wh totals from forecast.solar to the lookback's historical average. Each day is flagged **Low** if it falls below 75% of the historical average. For every solar candidate, the report simulates the next ~5 days of battery state by running the node's measured charge and discharge rates against the forecast factor for each day:
+
+- **Sunrise** point: battery after the overnight discharge
+- **Peak** point: battery after the daylight charge (modulated by `forecast_factor = forecast_wh / avg_historical_wh`, clamped 0–1.5)
+- **Sunset** point: battery after a small afternoon drain
+
+Nodes whose simulated minimum drops below `50%` (battery) or `3.5 V` (voltage) are listed as **Nodes predicted at risk** so operators can intervene before they go offline.
+
+Solar production must already be configured under **Settings → Solar Monitoring** for the forecast to produce useful output. See the [Solar Monitoring guide](./solar-monitoring) for set-up details.
+
+## Permissions
+
+Both endpoints behind the workspace are scoped to the requesting user's permitted source IDs:
+
+- Admins see all enabled sources
+- Non-admin users see sources where they hold `nodes:read`
+- An optional `?sources=id1,id2` query param restricts the analysis further (intersected with permitted IDs)
+
+The page itself is publicly routable; only the data is gated.
+
+## API
+
+The Reports workspace surfaces two endpoints under the existing `/api/analysis/*` namespace:
+
+- `GET /api/analysis/solar-nodes?lookback_days=N&sources=…`
+- `GET /api/analysis/solar-forecast?lookback_days=N&sources=…`
+
+See the [REST API reference](../api/REST_API) for the full request/response shapes.
+
+## Related
+
+- [Solar Monitoring](./solar-monitoring) — configuration of the forecast.solar integration that powers the production curve and forecast factor
+- [Map Analysis](./map-analysis) — cross-source map / coverage workspace at `/analysis`
+- [Analytics](./analytics) — analytics dashboards in the per-source view

--- a/docs/features/analysis-reports.md
+++ b/docs/features/analysis-reports.md
@@ -77,7 +77,7 @@ The Reports workspace surfaces two endpoints under the existing `/api/analysis/*
 - `GET /api/analysis/solar-nodes?lookback_days=N&sources=…`
 - `GET /api/analysis/solar-forecast?lookback_days=N&sources=…`
 
-See the [REST API reference](../api/REST_API) for the full request/response shapes.
+See the [REST API reference](https://github.com/Yeraze/meshmonitor/blob/main/docs/api/REST_API.md) for the full request/response shapes.
 
 ## Related
 

--- a/docs/features/solar-monitoring.md
+++ b/docs/features/solar-monitoring.md
@@ -64,6 +64,7 @@ Solar overlays appear on:
 - **Node Details** page: Telemetry graphs for individual nodes
 - **Telemetry Dashboard**: All favorite telemetry charts
 - **Any time-series telemetry visualization**
+- **Analysis & Reports → Solar Monitoring Analysis**: cross-source report that auto-detects solar-powered nodes and overlays the solar production curve on each candidate's chart, with optional multi-day battery forecast simulation. See [Analysis & Reports](./analysis-reports).
 
 ### Visual Design
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ features:
 
   - icon: ☀️
     title: Solar Monitoring
-    details: Integrate with forecast.solar to visualize expected solar production alongside telemetry data. Perfect for optimizing off-grid deployments and predicting power availability.
+    details: Integrate with forecast.solar to visualize expected solar production alongside telemetry data. Run the cross-source Solar Monitoring Analysis report to auto-detect solar-powered nodes, project battery state across the forecast horizon, and surface nodes predicted at risk. Perfect for optimizing off-grid deployments.
 
   - icon: 💻
     title: Desktop & Mobile

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.1.2
-appVersion: "4.1.2"
+version: 4.2.0
+appVersion: "4.2.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.1.2",
+      "version": "4.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -4941,7 +4941,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5254,7 +5254,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5287,6 +5287,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7659,6 +7660,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -14716,7 +14718,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -15352,14 +15355,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -16863,7 +16858,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Cuts a **4.2.0** minor release wrapping up the Analysis & Reports workspace (shipped in #2898)
- Bumps all five canonical version sources: `package.json`, `package-lock.json` (regenerated via `npm install --package-lock-only --legacy-peer-deps`), `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`)
- Brings documentation in line with the new feature

## Documentation changes
- **New** `docs/features/analysis-reports.md` — feature page covering the workspace, Solar Monitoring report, forecast simulation, permissions, and API pointer
- `docs/features/solar-monitoring.md` — cross-link added to the new report under "Display Locations"
- `docs/.vitepress/config.mts` — "🆕 4.2 Highlights" added (with Analysis & Reports as the lead) in both top nav and `/features/` sidebar; old 4.1 highlights demoted but kept
- `docs/api/REST_API.md` — new "## Analysis & Reports" section documenting `GET /api/analysis/solar-nodes` and `GET /api/analysis/solar-forecast` with full request/response shapes and curl examples
- `docs/index.md` — Solar Monitoring feature card mentions the new analysis report
- `README.md` — Key Features list leads with the 4.2 Analysis & Reports highlight
- `CHANGELOG.md` — `[Unreleased]` opens with the Analysis & Reports entry referencing #2898

## Test plan
- [ ] `tsc --noEmit` clean (verified locally)
- [ ] Vitepress docs build succeeds with the new page and updated nav
- [ ] Helm `helm lint helm/meshmonitor` accepts the bumped Chart
- [ ] Desktop Tauri build picks up the new version string
- [ ] PR Tests, CI, CodeQL, and Claude Code Review all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)