### PR TITLE
fix(channel-url): preserve empty channel names during URL decode

### DIFF
--- a/src/server/services/channelUrlService.ts
+++ b/src/server/services/channelUrlService.ts
@@ -115,7 +115,7 @@ class ChannelUrlService {
             }
           }
 
-          if (ch.name) channel.name = ch.name;
+          if (ch.name !== undefined) channel.name = ch.name;
           if (ch.id !== undefined) channel.id = ch.id;
           if (ch.role !== undefined) channel.role = ch.role;
           if (ch.uplinkEnabled !== undefined) channel.uplinkEnabled = ch.uplinkEnabled;


### PR DESCRIPTION
## Summary

- `channelUrlService.decodeUrl()` used a truthy check (`if (ch.name)`) when copying the decoded channel name into the result, silently dropping legitimately empty names. Decoded channels ended up with `name: undefined` instead of `name: ''`.
- Downstream config-import path at `server.ts:3140` compensates with `channel.name || ''`, so the SetChannel admin write was unaffected. But other consumers (export, UI display, backups via `deviceBackupService`) lose the distinction between "channel explicitly named empty" and "name field absent".
- One-line change to `if (ch.name !== undefined)`.

## Background

Surfaced while debugging why a channel-set URL with channel 0 unnamed (Meshtastic-standard "default" PRIMARY) failed to round-trip cleanly through MeshMonitor. The decoded result was missing `name` entirely — protobuf wire-format had the explicit empty string but our truthy gate in the conversion step swallowed it.

The investigation also captured wire bytes for SetChannel admin messages (independent of this PR) and confirmed MeshMonitor's outbound encoding is correct — the empty-name persistence issue observed during system-tests is on a separate code path (firmware admin transaction sequencing) and is not addressed here.

## Test plan

- [ ] CI unit/integration suite passes (channelUrlService coverage + downstream import code)
- [ ] Manual: import a channel-set URL whose channel 0 has empty name → verify exported URL round-trips with the same empty name
- [ ] Manual: device-backup export with an unnamed channel preserves the `name: ''` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)