### PR TITLE
fix(config-import): bump admin-packet pacing to avoid firmware drops

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2895,7 +2895,9 @@ apiRouter.post('/channels/reorder', requirePermission('channel_0', 'write'), asy
       : meshtasticManager);
     logger.info(`🔄 Beginning channel reorder: ${newOrder.join(',')}`);
     await reorderManager.beginEditSettings();
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    // Pacing: device firmware silently drops admin packets that arrive too soon
+    // after BeginEditSettings on TCP PhoneAPI. See /channels/import-config for details.
+    await new Promise((resolve) => setTimeout(resolve, 2000));
 
     for (let newSlot = 0; newSlot < 8; newSlot++) {
       const oldSlot = newOrder[newSlot];
@@ -2940,9 +2942,11 @@ apiRouter.post('/channels/reorder', requirePermission('channel_0', 'write'), asy
         });
       }
 
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
     }
 
+    // Pacing: leave time for the last SetChannel to be processed before commit.
+    await new Promise((resolve) => setTimeout(resolve, 1500));
     // Commit to device
     await reorderManager.commitEditSettings();
     logger.info(`✅ Channel reorder committed`);
@@ -7495,6 +7499,9 @@ apiRouter.post('/admin/import-config', requireAdmin(), async (req, res) => {
       // Use existing local import logic
       try {
         await aicManager.beginEditSettings();
+        // Pacing: device firmware silently drops admin packets that arrive too soon
+        // after BeginEditSettings on TCP PhoneAPI. See /channels/import-config for details.
+        await new Promise((resolve) => setTimeout(resolve, 2000));
       } catch (error) {
         logger.error(`❌ Failed to begin edit settings transaction:`, error);
         throw new Error('Failed to start configuration transaction');
@@ -7517,6 +7524,8 @@ apiRouter.post('/admin/import-config', requireAdmin(), async (req, res) => {
               downlinkEnabled: channel.downlinkEnabled,
               positionPrecision: channel.positionPrecision,
             });
+            // Pacing between admin packets — same firmware drop pattern.
+            await new Promise((resolve) => setTimeout(resolve, 1000));
             importedChannels.push({ index: i, name: channel.name || '(unnamed)' });
           } catch (error) {
             logger.error(`❌ Failed to import channel ${i}:`, error);
@@ -7532,6 +7541,9 @@ apiRouter.post('/admin/import-config', requireAdmin(), async (req, res) => {
             txEnabled: true,
           };
           await aicManager.setLoRaConfig(loraConfigToImport);
+          // Pacing: LoRa config triggers heavier device processing; allow extra time
+          // before commit so the device has finished applying it.
+          await new Promise((resolve) => setTimeout(resolve, 1500));
           loraImported = true;
           requiresReboot = true;
         } catch (error) {
@@ -7570,8 +7582,10 @@ apiRouter.post('/admin/import-config', requireAdmin(), async (req, res) => {
             }, sessionPasskey);
             await aicManager.sendAdminCommand(adminMessage, destinationNodeNum);
             importedChannels.push({ index: i, name: channel.name || '(unnamed)' });
-            // Small delay between channel updates for remote nodes
-            await new Promise(resolve => setTimeout(resolve, 500));
+            // Pacing between admin commands — remote node travels via radio so
+            // gaps are mostly airtime-bound, but the device-side admin handler
+            // exhibits the same drop pattern as local TCP under burst.
+            await new Promise(resolve => setTimeout(resolve, 1000));
           } catch (error) {
             logger.error(`❌ Failed to import channel ${i}:`, error);
           }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3109,8 +3109,10 @@ apiRouter.post('/channels/import-config', requirePermission('configuration', 'wr
     try {
       logger.info(`🔄 Beginning edit settings transaction for import`);
       await configImportManager.beginEditSettings();
-      // Allow device time to enter edit mode before sending config messages
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      // Allow device time to enter edit mode and ack back before sending config messages.
+      // Empirically: 500ms is too short — device firmware silently drops the first
+      // SetChannel that follows BeginEditSettings on TCP PhoneAPI under contention.
+      await new Promise((resolve) => setTimeout(resolve, 2000));
       logger.info(`✅ Edit settings transaction started`);
     } catch (error) {
       logger.error(`❌ Failed to begin edit settings transaction:`, error);
@@ -3146,7 +3148,7 @@ apiRouter.post('/channels/import-config', requirePermission('configuration', 'wr
           });
 
           // Allow device time to process channel config before sending the next message
-          await new Promise((resolve) => setTimeout(resolve, 300));
+          await new Promise((resolve) => setTimeout(resolve, 1000));
           importedChannels.push({ index: i, name: channel.name || '(unnamed)' });
           logger.info(`✅ Imported channel ${i}`);
         } catch (error) {
@@ -3175,7 +3177,7 @@ apiRouter.post('/channels/import-config', requirePermission('configuration', 'wr
         await configImportManager.setLoRaConfig(loraConfigToImport);
         // LoRa config triggers heavier processing (frequency calculations, radio reconfiguration)
         // so allow extra time before committing
-        await new Promise((resolve) => setTimeout(resolve, 500));
+        await new Promise((resolve) => setTimeout(resolve, 1500));
         loraImported = true;
         requiresReboot = true; // LoRa config requires reboot when committed
         logger.info(`✅ Imported LoRa config`);


### PR DESCRIPTION
## Summary

- Bumps inter-admin-packet pacing in `/channels/import-config` from `500/300/500ms` to `2000/1000/1500ms`.
- Restores test reliability for `tests/test-config-import.sh` and downstream system tests on the dev mesh node (firmware v2.7.22.96dd647).
- Documented in code comments why the gaps are needed.

## Background

System Tests have been failing intermittently in CI since May 4 with various manifestations (channel 0 left as previous URL's name, modem preset not applying, "configuration did not change between imports") — all rooted in the same race.

### Root cause

On the dev node firmware (Meshtastic 2.7.22.96dd647) over TCP PhoneAPI, when MeshMonitor sends admin packets back-to-back during a config-import transaction, the device silently drops one of them. Captured device syslog shows the dropped packet has no "PACKET FROM PHONE" log entry at all — the drop is upstream of `PhoneAPI::handleToRadioPacket()`, in the firmware's StreamAPI frame parser, likely caused by RX/TX contention while the device is sending the previous admin packet's ACK back.

### Verified MeshMonitor side is correct

Instrumented `tcpTransport.send()` with per-frame logging:
- `data.length === declaredLen` for every frame
- Header is internally consistent (`94c3 LL LL` followed by exactly the right byte count)
- `socket.write()` callback fires confirming kernel flush
- Zero "waiting for drain" events

The bug is on the firmware side; this PR is a pacing workaround.

### Pattern (reproduced twice locally)

| Run | Dropped packet |
|-----|----------------|
| Run A | URL2 SetChannel(0), 21-byte payload |
| Run B | URL1 SetChannel(0), 96-byte payload |
| Run C (after first wait bump only) | URL1 SetLoRaConfig |
| Run D + E (this PR's full bumps) | All packets delivered |

The drop rotates to whichever admin packet lands while the device is busy ACKing the previous one.

## Verified

Two consecutive `tests/test-config-import.sh` runs locally with the bumped waits:
- URL1: BeginEdit → SetChannel(0) → SetChannel(1) → SetChannel(2) → SetConfig → CommitEdit ✓ all 6
- URL2: BeginEdit → SetChannel(0) → SetChannel(1) → SetConfig → CommitEdit ✓ all 5
- Test EXIT=0, all PASS

Cost: ~7-8 seconds slower per import cycle. Acceptable for a config import.

## Test plan

- [ ] CI System Tests pass on the dev hardware
- [ ] Manual: `tests/test-config-import.sh` passes consistently
- [ ] Manual: importing a channel-set URL via the UI still works without any user-visible regression beyond a slightly longer apply time

## Future work

A proper fix is ACK-based admin-message retry (track admin reply IDs, retransmit on timeout). That's a bigger change. Filing an upstream firmware issue with the captured wire bytes + syslog evidence is also warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)