### PR TITLE
fix(security): strip secret keys from /api/settings (MM-SEC-1)

### DIFF
--- a/docs/security/2026-05-05-mm-sec-1-2-3-review.md
+++ b/docs/security/2026-05-05-mm-sec-1-2-3-review.md
@@ -1,0 +1,140 @@
+# Security Review: MM-SEC-1 / MM-SEC-2 / MM-SEC-3
+
+**Date:** 2026-05-05
+**Branch:** `review/security-audit-meshmonitor-details`
+**Source:** External researcher findings (`meshmonitor-details.md`)
+
+## Validation Summary
+
+| ID | Severity | Status | Notes |
+|----|----------|--------|-------|
+| MM-SEC-1 | High | **Valid** | `GET /api/settings` returns full settings table to anonymous callers; `vapid_private_key` is auto-generated into that table on first start. |
+| MM-SEC-2 | High | **Valid** | `/api/channels`, `/api/channels/all`, and `/api/poll` all return raw DB rows including `psk`; `/api/v1/channels` already has the correct `transformChannel` whitelist that omits `psk`. |
+| MM-SEC-3 | High | **Valid** | `/api/poll` messages section filters only on `msg.channel !== -1` (DM exclusion). No per-channel `read` check, while the sibling channels/unread-counts sections in the same handler already apply per-channel filtering — inconsistency is real. |
+
+All three reproductions match what the researcher described. Code references in the report are accurate against current `main`.
+
+---
+
+## MM-SEC-1 — VAPID/secret leakage via `/api/settings`
+
+### Confirmed code path
+
+- `src/server/routes/settingsRoutes.ts` — root `GET /` uses `optionalAuth()`, calls `databaseService.settings.getAllSettings()`, returns every key not prefixed `source:`. No permission gate.
+- `src/server/services/pushNotificationService.ts:51-71` — on first start, calls `webpush.generateVAPIDKeys()` and persists `vapid_public_key`, `vapid_private_key`, `vapid_subject` into the `settings` table.
+- Other secret-bearing keys present in `VALID_SETTINGS_KEYS` (so they can be set via the same table): `securityDigestAppriseUrl`, `analyticsConfig`.
+
+### Remediation plan
+
+Two-layer fix (defense in depth):
+
+1. **Gate the endpoint** (`settingsRoutes.ts`):
+   - Replace `optionalAuth()` with `requireAuth()` for the global view (`?sourceId` absent).
+   - Per-source view (`?sourceId=...`) keeps `optionalAuth()` but the response is still passed through the strip step below.
+   - Anonymous callers get `401`. Admin/UI flows already authenticate.
+
+2. **Strip secrets from the response** (independent of gate):
+   - Add a `SECRET_SETTINGS_KEYS` constant in `src/server/constants/settings.ts` listing exact keys: `vapid_private_key`, `securityDigestAppriseUrl`, `analyticsConfig`, plus a regex tail pattern `/_private_key$|_secret$|_token$/i` for future-proofing.
+   - In the GET handler, after `getAllSettings()`, drop any key matching this list **unless** `req.user?.isAdmin === true`.
+
+3. **Structural fix (follow-up PR, not blocking)**:
+   - Move secrets out of the `settings` k/v table into a separate `secrets` table that has no list endpoint at all. `pushNotificationService` reads `vapid_private_key` directly from `databaseService.secrets.get(...)`.
+   - Migration to copy existing `vapid_private_key` / `vapid_public_key` / `vapid_subject` into `secrets`, then delete from `settings`.
+
+### Test additions
+
+- `settingsRoutes.test.ts`: anonymous GET returns 401; logged-in non-admin GET excludes the secret keys; admin GET includes them.
+- Add test fixture that pre-populates `vapid_private_key` and asserts it never appears in the non-admin response.
+
+---
+
+## MM-SEC-2 — Channel PSK disclosure via legacy `/api/channels` and `/api/poll`
+
+### Confirmed code path
+
+- `src/server/server.ts:2447` — `/api/channels/all` gates on `channel_0:read` and returns `getAllChannels(sourceId)` verbatim.
+- `src/server/server.ts:2459` — `/api/channels` gates on `channel_0:read` and applies a "is this channel configured?" filter but still returns the raw row (psk included).
+- `src/server/server.ts:4516+` — `/api/poll` channels section: applies the per-channel `read` permission filter (good — fixes visibility), but pushes the raw `getAllChannels()` row into `result.channels` with `psk` intact.
+- `src/server/routes/v1/channels.ts:42-52` — `transformChannel` already does the right thing (whitelists `id`, `name`, `role`, `roleName`, `uplinkEnabled`, `downlinkEnabled`, `positionPrecision`).
+
+### Remediation plan
+
+1. **Hoist `transformChannel` to a shared module**: move it to `src/server/utils/transformChannel.ts` (or `src/shared/channelView.ts`). Export from there. Both v1 and legacy/poll import the same helper to guarantee field set parity.
+
+2. **Patch `/api/channels` and `/api/channels/all`**:
+   - Replace static `channel_0:read` gate with the v1 per-row check (loop allChannels, `checkPermissionAsync(userId, 'channel_${id}', 'read', sourceId)`, push if allowed).
+   - Pipe the filtered list through `transformChannel` before `res.json(...)`.
+
+3. **Patch `/api/poll` channels section** (`server.ts:4516+`):
+   - The per-channel filter is already there. Just pipe `filteredChannels` through `transformChannel` before assigning to `result.channels`.
+
+4. **Audit (separate task, captured below)**: the peer endpoints `GET /api/channels/:id/export`, `PUT /api/channels/:id`, `DELETE /api/channels/:id`, `POST /api/channels/:slotId/import`, `POST /api/channels/reorder` all gate on a static `channel_0` permission while operating on `:id`. That's a privilege-escalation path (authenticated user with channel_0 access can mutate channels they should not see). File a separate finding `MM-SEC-4` and remediate in a follow-up PR — outside this advisory's anonymous-exploit scope.
+
+### Test additions
+
+- New `channels.legacy.test.ts`: anonymous user with `channel_0:read` requests `/api/channels`, response array does NOT contain `psk` field on any row.
+- Same suite: user has `channel_0:read` but not `channel_2:read` — channel 2 must be absent from the array.
+- `poll.test.ts`: same shape against `/api/poll` `result.channels`.
+
+---
+
+## MM-SEC-3 — Hidden-channel messages leaked via `/api/poll`
+
+### Confirmed code path
+
+- `src/server/server.ts` poll section 3 (~lines 4419-4450 per report): computes `hasChannelsRead` from `channel_0:read` once, then if true returns `getRecentMessages(100, sourceId)` with the only filter being `msg.channel !== -1` (DMs).
+- Sibling sections in the SAME handler (channels at ~4516+, unread-counts at ~4470+) correctly iterate channels and call `checkPerm('channel_${id}', 'read')` per row.
+- The legacy `/api/messages` (`server.ts:2105-2140`) and `/api/messages/unread-counts` (`server.ts:2316-2393`) exhibit the same pattern: gate on `channel_0:read || messages:read`, return all-channel data without per-row filtering.
+
+### Remediation plan
+
+1. **Pre-compute authorized channel set once per request** (cheaper than per-message permission lookups):
+   ```ts
+   const authorizedChannelIds = new Set<number>();
+   for (let id = 0; id <= 7; id++) {
+     if (checkPerm(`channel_${id}` as ResourceType, 'read')) authorizedChannelIds.add(id);
+   }
+   ```
+   Place this near the existing `hasChannelsRead`/`hasMessagesRead` computation.
+
+2. **Filter messages**:
+   - In poll section 3, after `messages = dbMessagesRaw.map(...)` and after the existing `msg.channel !== -1` filter, add:
+     ```ts
+     if (hasChannelsRead && !hasMessagesRead) {
+       messages = messages.filter(msg => authorizedChannelIds.has(msg.channel));
+     }
+     // (the !hasChannelsRead && hasMessagesRead branch is already DM-only — keep)
+     ```
+   - The case where the user has both `messages:read` and `channels:read` should also be filtered to `authorizedChannelIds.has(msg.channel) || msg.channel === -1` so `messages:read` doesn't bypass per-channel hiding.
+
+3. **Fix the legacy `/api/messages` and `/api/messages/unread-counts` the same way**. Same `authorizedChannelIds` pattern — add a small helper `getAuthorizedChannelIds(checkPerm)` in a shared utility to avoid duplication across the three sites.
+
+### Test additions
+
+- `poll.test.ts`: configure user with only `channel_0:read`, plant messages in channels 0 and 2, confirm response messages array contains only channel 0 entries.
+- `messages.legacy.test.ts`: same shape against `/api/messages`.
+- `unreadCounts.test.ts`: confirm hidden-channel counts are excluded (already partly tested per `getUnreadCountsByChannelAsync` filter loop, but add explicit coverage).
+
+---
+
+## Implementation order (suggested)
+
+| Order | PR | Scope | Risk |
+|-------|-----|-------|------|
+| 1 | `fix(security): MM-SEC-1 strip secret keys from /api/settings response` | Add denylist + admin-gate; add migration that ensures VAPID keys still load when accessed via the same path. Tests. | Low. UI consumes a known list of keys; secret keys are not used by UI today. |
+| 2 | `fix(security): MM-SEC-2 stop returning channel.psk from legacy and poll endpoints` | Hoist `transformChannel`; patch 3 sites; per-row permission check on legacy `/api/channels[/all]`. Tests. | Low for response-shape; medium for the per-row gate change because some clients may be relying on getting all rows back. Mitigation: keep the legacy "is configured?" filter; change is purely additive (more filtering). |
+| 3 | `fix(security): MM-SEC-3 filter messages by per-channel read in poll/messages` | Pre-compute authorized channel set, apply to 3 sites. Tests. | Low. Already the intended behavior in sibling sections. |
+| 4 | `chore(security): MM-SEC-4 (follow-up) per-row permission gate on channel mutators` | Privilege-escalation cleanup on `PUT/DELETE /api/channels/:id`, etc. Out of this report's scope but file as separate issue. | Medium — affects authenticated mutation flows. |
+| 5 | `refactor(security): move VAPID + apprise + analytics secrets to dedicated table` | Structural fix for MM-SEC-1. Migration + service refactor. | Medium. Migration must be idempotent across all three DB backends; existing keys must be moved without losing the working push deployment. |
+
+Steps 1-3 are individually small and can land independently. Step 4 is independent. Step 5 should follow steps 1 to ensure the response strip is in place before changing storage.
+
+## Notes on operator mitigations
+
+The researcher's pre-patch mitigations (set VAPID via env, revoke `channel_0:read` from anonymous) are accurate. Worth surfacing in a `SECURITY_ADVISORY.md` once the patches land, with the CVE/disclosure timeline if applicable.
+
+## Out of scope but worth flagging
+
+- The `analyticsConfig` setting being on the same exposure path is real — content depends on provider but should be treated as secret regardless. Same denylist treatment.
+- `pushNotificationService` does not currently rotate keys. After step 1 ships, document key rotation procedure (delete the three settings rows, restart, re-subscribe).
+- Footnote 1 confirms `push_subscriptions` is not exposed on current `main`. Recommend adding a regression test that asserts no HTTP route returns rows from the `push_subscriptions` table — would catch a future bug there immediately.

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -270,3 +270,44 @@ export const PER_SOURCE_SETTINGS_KEYS = [
 ] as const;
 
 export type PerSourceSettingKey = typeof PER_SOURCE_SETTINGS_KEYS[number];
+
+/**
+ * Settings keys whose values are secret and must never be returned to
+ * non-admin callers from `GET /api/settings`. The plain VAPID public key
+ * is intentionally NOT included — browsers need it to subscribe.
+ *
+ * Auto-generated VAPID material lives under `vapid_*` keys (see
+ * `pushNotificationService`). Other historical keys live alongside the
+ * regular allowlist (e.g. `securityDigestAppriseUrl`, `analyticsConfig`).
+ */
+export const SECRET_SETTINGS_KEYS = new Set<string>([
+  'vapid_private_key',
+  'securityDigestAppriseUrl',
+  'analyticsConfig',
+]);
+
+/**
+ * Tail-pattern denylist used in addition to the explicit set above so that
+ * future secret-bearing keys are stripped by default. Anything matching
+ * `*_private_key`, `*_secret`, or `*_token` (case-insensitive) is dropped.
+ */
+export const SECRET_SETTINGS_KEY_PATTERN = /(_private_key|_secret|_token)$/i;
+
+/**
+ * Strip secret-bearing keys from a settings map. Admins receive the
+ * unmodified map; everyone else (including unauthenticated callers) gets
+ * the secret keys removed.
+ */
+export function stripSecretSettings<T extends Record<string, unknown>>(
+  settings: T,
+  isAdmin: boolean
+): Partial<T> {
+  if (isAdmin) return settings;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(settings)) {
+    if (SECRET_SETTINGS_KEYS.has(k)) continue;
+    if (SECRET_SETTINGS_KEY_PATTERN.test(k)) continue;
+    out[k] = v;
+  }
+  return out as Partial<T>;
+}

--- a/src/server/routes/settingsRoutes.test.ts
+++ b/src/server/routes/settingsRoutes.test.ts
@@ -121,6 +121,68 @@ describe('settingsRoutes', () => {
 
       expect(res.body).toHaveProperty('error');
     });
+
+    // MM-SEC-1: secret-bearing keys must be stripped from non-admin responses.
+    describe('secret stripping (MM-SEC-1)', () => {
+      const populateSecrets = () => {
+        (databaseService as any).settings.getAllSettings.mockResolvedValue({
+          meshName: 'TestMesh',
+          vapid_public_key: 'BPUBLIC',
+          vapid_private_key: 'PRIVATE-must-not-leak',
+          vapid_subject: 'mailto:admin@x',
+          securityDigestAppriseUrl: 'mailto://user:pass@smtp/',
+          analyticsConfig: '{"token":"sekret"}',
+          custom_api_token: 'tok-fffff',
+          some_secret: 'shh',
+          some_private_key: 'pk',
+        });
+      };
+
+      it('strips secrets for unauthenticated callers', async () => {
+        populateSecrets();
+        const app = createApp(null);
+        (databaseService as any).findUserByIdAsync.mockResolvedValue(null);
+
+        const res = await request(app).get('/api/settings').expect(200);
+
+        expect(res.body.meshName).toBe('TestMesh');
+        expect(res.body.vapid_public_key).toBe('BPUBLIC');
+        expect(res.body).not.toHaveProperty('vapid_private_key');
+        expect(res.body).not.toHaveProperty('securityDigestAppriseUrl');
+        expect(res.body).not.toHaveProperty('analyticsConfig');
+        // Tail-pattern denylist
+        expect(res.body).not.toHaveProperty('custom_api_token');
+        expect(res.body).not.toHaveProperty('some_secret');
+        expect(res.body).not.toHaveProperty('some_private_key');
+      });
+
+      it('strips secrets for authenticated non-admin callers', async () => {
+        populateSecrets();
+        const nonAdmin = { id: 2, username: 'viewer', isActive: true, isAdmin: false };
+        // optionalAuth re-resolves the user from the session via findUserByIdAsync;
+        // mock that lookup so the middleware sees the non-admin identity.
+        (databaseService as any).findUserByIdAsync.mockResolvedValue(nonAdmin);
+        const app = createApp(nonAdmin);
+
+        const res = await request(app).get('/api/settings').expect(200);
+
+        expect(res.body).not.toHaveProperty('vapid_private_key');
+        expect(res.body).not.toHaveProperty('securityDigestAppriseUrl');
+        expect(res.body).not.toHaveProperty('analyticsConfig');
+      });
+
+      it('returns secrets for admin callers', async () => {
+        populateSecrets();
+        const app = createApp(adminUser);
+
+        const res = await request(app).get('/api/settings').expect(200);
+
+        expect(res.body.vapid_private_key).toBe('PRIVATE-must-not-leak');
+        expect(res.body.securityDigestAppriseUrl).toBe('mailto://user:pass@smtp/');
+        expect(res.body.analyticsConfig).toBe('{"token":"sekret"}');
+        expect(res.body.custom_api_token).toBe('tok-fffff');
+      });
+    });
   });
 
   describe('POST /api/settings', () => {

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -14,7 +14,7 @@ import { optionalAuth, requirePermission } from '../auth/authMiddleware.js';
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { securityDigestService } from '../services/securityDigestService.js';
-import { VALID_SETTINGS_KEYS } from '../constants/settings.js';
+import { VALID_SETTINGS_KEYS, stripSecretSettings } from '../constants/settings.js';
 
 // ─── Tile URL validation ─────────────────────────────────────────────────
 
@@ -141,9 +141,14 @@ const router = Router();
 
 // GET /settings — read settings (public)
 // ?sourceId=<id>  → global settings merged with per-source overrides (source wins)
+//
+// Secret-bearing keys (VAPID private key, apprise URLs, analytics tokens, etc.)
+// are stripped from the response for non-admin callers (MM-SEC-1) — see
+// `stripSecretSettings` and `SECRET_SETTINGS_KEYS` in `constants/settings.ts`.
 router.get('/', optionalAuth(), async (req: Request, res: Response) => {
   try {
     const sourceId = typeof req.query.sourceId === 'string' ? req.query.sourceId : null;
+    const isAdmin = (req as any).user?.isAdmin === true;
 
     const globalSettings = await databaseService.settings.getAllSettings();
 
@@ -154,14 +159,15 @@ router.get('/', optionalAuth(), async (req: Request, res: Response) => {
         if (!k.startsWith('source:')) cleaned[k] = v;
       }
       const sourceSettings = await databaseService.settings.getSourceSettings(sourceId);
-      res.json({ ...cleaned, ...sourceSettings });
+      const merged = { ...cleaned, ...sourceSettings };
+      res.json(stripSecretSettings(merged, isAdmin));
     } else {
       // Return only non-namespaced keys for global view
       const cleaned: Record<string, string> = {};
       for (const [k, v] of Object.entries(globalSettings)) {
         if (!k.startsWith('source:')) cleaned[k] = v;
       }
-      res.json(cleaned);
+      res.json(stripSecretSettings(cleaned, isAdmin));
     }
   } catch (error) {
     logger.error('Error fetching settings:', error);


### PR DESCRIPTION
## Summary

- `GET /api/settings` returned every row from the `settings` table to anonymous callers. The auto-generated VAPID private key, `securityDigestAppriseUrl`, and `analyticsConfig` all live in that table — every default deployment was leaking them.
- Adds `SECRET_SETTINGS_KEYS` + tail-pattern denylist + `stripSecretSettings(map, isAdmin)` helper. Applied in the GET handler.
- VAPID **public** key is still returned (browsers need it to subscribe). Private key, apprise URLs, analytics tokens, and any future `*_private_key` / `*_secret` / `*_token` keys are stripped for non-admin callers.

## Background

Reported as MM-SEC-1 (High) by an external researcher. With the VAPID private key plus a subscriber's `endpoint`/`p256dh`/`auth`, an attacker can deliver phishing notifications under the legitimate site's name and icon. The subscription material is not currently exposed via HTTP, so this is primarily a defense-in-depth fix and an immediate plug for the secret leak (see `docs/security/2026-05-05-mm-sec-1-2-3-review.md` for the full validation write-up of MM-SEC-1/2/3).

## Files

- `src/server/constants/settings.ts` — `SECRET_SETTINGS_KEYS`, `SECRET_SETTINGS_KEY_PATTERN`, `stripSecretSettings()`
- `src/server/routes/settingsRoutes.ts` — apply strip in both source-scoped and global response paths
- `src/server/routes/settingsRoutes.test.ts` — 3 new cases: anonymous strip, non-admin strip, admin pass-through
- `docs/security/2026-05-05-mm-sec-1-2-3-review.md` — full review including remediation plan for MM-SEC-2 and MM-SEC-3 (separate PRs to follow)

## Test plan

- [x] `npx vitest run src/server/routes/settingsRoutes.test.ts` — 37/37 pass
- [ ] CI suite green
- [ ] Manual: `curl http://localhost:8081/meshmonitor/api/settings` (no auth) — verify `vapid_private_key` absent
- [ ] Manual: log in as admin, fetch same — verify `vapid_private_key` present
- [ ] Manual: subscribe to push notifications — verify subscription still works (uses public key)

## Operator mitigation pre-merge

Pre-patch deployments should:
1. Set `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` via environment.
2. Rotate any auto-generated key by deleting the three rows from `settings` and restarting (invalidates existing browser subscriptions; clients re-subscribe transparently).
3. Block `/api/settings` at the reverse proxy for unauthenticated GETs.

## Follow-ups

- MM-SEC-2 (channel PSK leak via `/api/channels` + `/api/poll`) — separate PR
- MM-SEC-3 (hidden-channel messages via `/api/poll`) — separate PR
- Structural: move secrets out of the `settings` k/v table into a dedicated `secrets` table (separate refactor PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)