### PR TITLE
fix(security): filter messages by per-channel read in poll/messages (MM-SEC-3)

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2120,17 +2120,29 @@ apiRouter.get('/messages', optionalAuth(), async (req, res) => {
     const messagesSourceId = req.query.sourceId as string | undefined;
     let messages = await meshtasticManager.getRecentMessages(limit, messagesSourceId);
 
-    // Filter messages based on permissions
-    // If user only has channels permission, exclude direct messages (channel -1)
-    // If user only has messages permission, only include direct messages (channel -1)
-    if (hasChannelsRead && !hasMessagesRead) {
-      // Only channel messages
-      messages = messages.filter(msg => msg.channel !== -1);
-    } else if (hasMessagesRead && !hasChannelsRead) {
-      // Only direct messages
-      messages = messages.filter(msg => msg.channel === -1);
+    // MM-SEC-3: pre-compute the channels this caller may read so we can
+    // strip messages from hidden channels even when the caller has the
+    // generic `channel_0:read` permission.
+    const isAdmin = req.user?.isAdmin === true;
+    const authorizedChannelIds = new Set<number>();
+    if (isAdmin) {
+      for (let id = 0; id <= 7; id++) authorizedChannelIds.add(id);
+    } else if (req.user) {
+      for (let id = 0; id <= 7; id++) {
+        const channelResource = `channel_${id}` as import('../types/permission.js').ResourceType;
+        if (await hasPermission(req.user, channelResource, 'read')) authorizedChannelIds.add(id);
+      }
     }
-    // If both permissions, return all messages
+
+    // Filter messages based on permissions.
+    // - DMs (channel -1) require `messages:read`.
+    // - Channel messages require BOTH the legacy `channel_0:read` gate
+    //   above AND a per-channel `channel_${id}:read` for the message's
+    //   actual channel.
+    messages = messages.filter(msg => {
+      if (msg.channel === -1) return hasMessagesRead;
+      return hasChannelsRead && (isAdmin || authorizedChannelIds.has(msg.channel));
+    });
 
     res.json(messages);
   } catch (error) {
@@ -2360,12 +2372,22 @@ apiRouter.get('/messages/unread-counts', optionalAuth(), async (req, res) => {
     // Only count incoming messages (exclude messages sent by our node)
     if (hasChannelsRead) {
       const rawCounts = await databaseService.getUnreadCountsByChannelAsync(userId, localNodeInfo?.nodeId);
-      // Filter out muted channels
+
+      // MM-SEC-3: filter by per-channel read permission as well as mute prefs.
+      // The bare `channel_0:read` gate above lets a viewer reach this handler
+      // but they must not learn unread counts for channels they cannot read.
+      const isAdmin = req.user?.isAdmin === true;
       const channels: { [channelId: number]: number } = {};
-      for (const [channelId, count] of Object.entries(rawCounts)) {
-        if (!mutedChannelIds.has(Number(channelId))) {
-          channels[Number(channelId)] = count as number;
+      for (const [channelIdStr, count] of Object.entries(rawCounts)) {
+        const channelId = Number(channelIdStr);
+        if (mutedChannelIds.has(channelId)) continue;
+        if (!isAdmin && req.user) {
+          const channelResource = `channel_${channelId}` as import('../types/permission.js').ResourceType;
+          if (!(await hasPermission(req.user, channelResource, 'read'))) continue;
+        } else if (!req.user && !isAdmin) {
+          continue;
         }
+        channels[channelId] = count as number;
       }
       result.channels = channels;
     }
@@ -4442,12 +4464,28 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
           msg => transformDbMessageToMeshMessage(msg as any as DbMessage)
         );
 
-        // Filter messages based on permissions
-        if (hasChannelsRead && !hasMessagesRead) {
-          messages = messages.filter(msg => msg.channel !== -1);
-        } else if (hasMessagesRead && !hasChannelsRead) {
-          messages = messages.filter(msg => msg.channel === -1);
+        // MM-SEC-3: pre-compute the per-channel authorized set so a caller
+        // with `channel_0:read` no longer sees messages from hidden channels.
+        // Sibling sections (channels, unread-counts) already do this — bring
+        // messages in line.
+        const isAdminCaller = user?.isAdmin === true;
+        const authorizedChannelIds = new Set<number>();
+        if (isAdminCaller) {
+          for (let id = 0; id <= 7; id++) authorizedChannelIds.add(id);
+        } else if (user) {
+          for (let id = 0; id <= 7; id++) {
+            if (checkPerm(`channel_${id}`, 'read')) authorizedChannelIds.add(id);
+          }
         }
+
+        // Filter:
+        // - DMs (channel -1) require `messages:read`.
+        // - Channel messages require BOTH `hasChannelsRead` AND
+        //   per-channel `channel_${id}:read` for the message's actual channel.
+        messages = messages.filter(msg => {
+          if (msg.channel === -1) return hasMessagesRead;
+          return hasChannelsRead && (isAdminCaller || authorizedChannelIds.has(msg.channel));
+        });
 
         result.messages = messages;
       }


### PR DESCRIPTION
## Summary

- `/api/poll` messages section, `/api/messages`, and `/api/messages/unread-counts` all gated on `channel_0:read || messages:read` then returned message content/counts spanning every channel.
- A user with `channel_0:read` (default public-viewer config) received the full text of hidden-channel messages — researcher confirmed empirically: 1 visible channel, 84 messages spanning 3 channels including the hidden one.
- Sibling sections of the same poll handler (channels, unread-counts) already correctly per-channel filter; this PR brings the messages section and the standalone legacy /api/messages and /api/messages/unread-counts endpoints in line.

## Background

Reported as MM-SEC-3 (High). Same root cause across three sites — pre-compute `authorizedChannelIds: Set<number>` of channels the caller may read, then filter both messages and unread counts.

## Files

- `src/server/server.ts` — patches three sites:
  1. `/api/messages` (line 2105) — adds the per-channel filter
  2. `/api/messages/unread-counts` (line 2316) — adds the per-channel filter on rawCounts (in addition to existing mute filter)
  3. `/api/poll` messages section (line 4419) — adds the per-channel filter

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] CI suite green
- [ ] Manual: anonymous user with only `channel_0:read`, plant messages on channel 0 + a hidden channel 2 — `/api/poll` messages array contains only channel 0
- [ ] Manual: same shape against `/api/messages` and `/api/messages/unread-counts`

## Coverage gap

These three sites live in the `server.ts` monolith. No dedicated test file was added in this PR. The fix is parallel to the per-channel filter the poll handler's `channels` and `unread-counts` sections already apply — those sections have lived in production with this pattern. A follow-up could extract the messages handler into `messageRoutes.ts` (which already exists) and add focused unit tests there.

## Follow-ups

- MM-SEC-4 (channel-mutator privilege escalation) — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)