### PR TITLE
fix(api): handle empty body on scan-remote-admin endpoint

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1886,7 +1886,11 @@ apiRouter.post('/nodes/:nodeNum/scan-remote-admin', requirePermission('settings'
       return;
     }
 
-    const { sourceId: scanSourceId } = req.body;
+    const { sourceId: bodySourceId } = (req.body || {}) as { sourceId?: string };
+    const querySourceId = typeof req.query.sourceId === 'string' && req.query.sourceId
+      ? (req.query.sourceId as string)
+      : undefined;
+    const scanSourceId = querySourceId ?? bodySourceId;
     const scanManager = (scanSourceId
       ? (sourceManagerRegistry.getManager(scanSourceId) as typeof meshtasticManager ?? meshtasticManager)
       : meshtasticManager);


### PR DESCRIPTION
## Summary
- `POST /api/nodes/:nodeNum/scan-remote-admin` destructured `sourceId` directly from `req.body`, which is `undefined` when the frontend posts with no body — clicking **Scan for Admin** on the node details page produced `TypeError: Cannot destructure property 'sourceId' of 'req.body' as it is undefined`.
- Frontend (`MessagesTab.tsx:520`) sends `sourceId` in the query string with no body; the route was reading from `req.body` only. Both were introduced together in #2611 (4.0 multi-source) and have been mismatched since 4.0 alpha.
- Fix: read `sourceId` from `req.query` first (matches frontend and the existing pattern at `/api/nodes`), fall back to `req.body` for body callers, and guard the body destructure with `|| {}` to mirror the sibling `/send-key-warning` route.

## Bug report
```
[ERROR] Error scanning node for remote admin: TypeError: Cannot destructure property 'sourceId' of 'req.body' as it is undefined.
    at file:///app/dist/server/server.js:1659:27
```

## Test plan
- [x] Build & deploy dev container — verified compiled `dist/server/server.js` contains new query-first parse
- [x] Click **Scan for Admin** on node details page — no TypeError, scan proceeds (`Manual remote admin scan requested for node …` → `Requested session passkey from remote node …`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)