### PR TITLE
fix(desktop): build x64 macOS DMG with x64 native binaries

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -681,7 +681,16 @@ jobs:
           cp package-lock.json desktop/resources/dist/
           # Install production-only dependencies into the bundle (matches Windows step).
           # Excludes dev deps (vitest, esbuild, drizzle-kit, tsx, etc) — shrinks the DMG by hundreds of MB.
-          (cd desktop/resources/dist && npm ci --omit=dev --legacy-peer-deps --no-audit --no-fund)
+          # IMPORTANT: this runner is macos-14 (arm64) but the bundle ships x64 binaries.
+          # Force prebuild-install (better-sqlite3 et al.) to fetch x64 prebuilds — without
+          # this, native .node files are downloaded for arm64 and the x64 DMG fails to load
+          # them at runtime (see issue #2901).
+          (cd desktop/resources/dist && \
+            npm_config_arch=x64 \
+            npm_config_target_arch=x64 \
+            npm_config_platform=darwin \
+            npm_config_target_platform=darwin \
+            npm ci --omit=dev --legacy-peer-deps --no-audit --no-fund)
 
       # Sign all native binaries in node_modules for notarization
       # Native addons with JIT also need the entitlements


### PR DESCRIPTION
## Summary
Fixes #2901 — `MeshMonitor-Desktop-<version>-x64.dmg` shipped a `better_sqlite3.node` built for arm64, so the x64 app failed to start on Intel Macs with `ERR_DLOPEN_FAILED` ("incompatible architecture").

## Root cause
The `build-macos-x64` job in `.github/workflows/desktop-release.yml` runs on `macos-14` (an arm64 GitHub runner) and cross-compiles the Tauri app for `x86_64-apple-darwin`. The `npm ci` step that installs production deps into `desktop/resources/dist` did **not** set a target arch, so `prebuild-install` (used by `better-sqlite3` et al.) downloaded prebuilt `.node` binaries for the host arch (arm64) and bundled them into the x64 DMG.

## Fix
Force `prebuild-install` to fetch x64 prebuilds by setting `npm_config_arch=x64`, `npm_config_target_arch=x64`, `npm_config_platform=darwin`, and `npm_config_target_platform=darwin` on the bundle's `npm ci` invocation in the x64 job. The arm64 job (also runs on an arm64 runner, builds for arm64 target) is unchanged — host arch already matches target.

## Test plan
- [ ] Workflow run produces `MeshMonitor-Desktop-<version>-x64.dmg` whose `Resources/dist/node_modules/better-sqlite3/build/Release/better_sqlite3.node` reports `Mach-O 64-bit bundle x86_64` via `file`
- [ ] Install on Intel Mac, launch → app starts (no `ERR_DLOPEN_FAILED` in `server-stderr.log`)
- [ ] arm64 DMG remains arm64 and continues to launch on Apple Silicon

🤖 Generated with [Claude Code](https://claude.com/claude-code)