### PR TITLE
fix(nodes): position override writes to live source row, not 'default'

### DIFF
--- a/src/db/repositories/nodes.test.ts
+++ b/src/db/repositories/nodes.test.ts
@@ -278,6 +278,38 @@ function runNodesTests(getBackend: () => TestBackend) {
     expect(node!.longName).toBe('Updated');
   });
 
+  it('upsertNode - falls back to nodeData.sourceId when sourceId arg omitted (issue #2902)', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    // Simulate the cached-node path used by setNodePositionOverride: the caller passes
+    // a node object whose `sourceId` field is already set, but does NOT pass sourceId
+    // as the second argument. Before the fix this silently fell back to 'default',
+    // creating a stray row instead of updating the live-source row.
+    const liveSource = 'live-src-uuid';
+    const cachedNode = makeNode(250, {
+      sourceId: liveSource,
+      positionOverrideEnabled: true,
+      latitudeOverride: 36.629,
+      longitudeOverride: -87.387,
+    });
+
+    await repo.upsertNode(cachedNode); // intentionally no second arg
+
+    const liveRow = await repo.getNode(250, liveSource);
+    expect(liveRow).not.toBeNull();
+    expect(liveRow!.positionOverrideEnabled).toBe(true);
+    expect(liveRow!.latitudeOverride).toBeCloseTo(36.629);
+    expect(liveRow!.longitudeOverride).toBeCloseTo(-87.387);
+
+    // Crucially, no stray 'default' row should have been created.
+    const defaultRow = await repo.getNode(250, 'default');
+    expect(defaultRow).toBeNull();
+  });
+
   it('upsertNode - ignores missing nodeNum or nodeId', async () => {
     const backend = getBackend();
     if (!backend.available) {

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -297,7 +297,11 @@ export class NodesRepository extends BaseRepository {
     }
     // Fall back to 'default' source for callers that predate multi-source.
     // After migration 029 the primary key is (nodeNum, sourceId) so a value is always needed.
-    const effectiveSourceId = sourceId ?? 'default';
+    // If the caller omits the sourceId arg but the node object itself carries a sourceId
+    // (e.g. cached node objects produced by DatabaseService), prefer that over 'default' —
+    // otherwise we'd silently insert a stray 'default' row and lose the update on the
+    // real source row (see issue #2902).
+    const effectiveSourceId = sourceId ?? (nodeData as { sourceId?: string }).sourceId ?? 'default';
 
     const now = this.now();
     const { nodes } = this.tables;

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -2143,8 +2143,10 @@ class DatabaseService {
         this.nodesCache.set(this.cacheKey(nodeData.nodeNum, upsertSourceId), updatedNode);
 
         // Fire and forget async version - pass the full merged node to avoid race conditions
-        // where a subsequent update (like welcomedAt) could be overwritten
-        this.nodesRepo.upsertNode(updatedNode).catch(err => {
+        // where a subsequent update (like welcomedAt) could be overwritten. Pass sourceId
+        // explicitly so the upsert targets the right row even on the off chance the
+        // node object's sourceId field gets stripped somewhere in the cache update path.
+        this.nodesRepo.upsertNode(updatedNode, upsertSourceId).catch(err => {
           logger.error('Failed to upsert node:', err);
         });
 
@@ -7182,9 +7184,11 @@ class DatabaseService {
       existingNode.positionOverrideIsPrivate = enabled && isPrivate;
       existingNode.updatedAt = now;
 
-      // Fire and forget async update
+      // Fire and forget async update — pass sourceId explicitly so the upsert targets
+      // the live-source row (see issue #2902). Without this the repository fell back to
+      // 'default', creating a stray row that the map never reads from.
       if (this.nodesRepo) {
-        this.nodesRepo.upsertNode(existingNode).catch(err => {
+        this.nodesRepo.upsertNode(existingNode, sourceId).catch(err => {
           logger.error('Failed to update position override:', err);
         });
       }


### PR DESCRIPTION
## Summary
Fixes #2902 — clicking **Override Node Position** in PostgreSQL/MySQL deployments appeared to succeed, but the node never moved on the map. The `nodes` table ended up with two rows per node: the live-source row (untouched) and a stray `sourceId='default'` row containing the override coordinates.

## Root cause
`DatabaseService.setNodePositionOverride()` (Postgres/MySQL path at `src/services/database.ts:7187`):

1. Looks up the cached node with the correct live `sourceId` — OK.
2. Mutates the cached node's override fields in place — OK.
3. Calls `nodesRepo.upsertNode(existingNode)` — **broken**. The second arg (`sourceId`) was omitted, so `NodesRepository.upsertNode` fell back to `sourceId ?? 'default'`, ran `getNode(nodeNum, 'default')` (returned null), and INSERTed a brand-new row with `sourceId='default'`. The live-source row never received the override, so the map (which renders from the live row) never moved.

The SQLite path used a raw `UPDATE ... WHERE sourceId = ?` and was unaffected.

## Changes

1. **`src/db/repositories/nodes.ts`** — `upsertNode` now falls back to `nodeData.sourceId` before defaulting to `'default'`. Cached node objects always carry their `sourceId`; honoring it prevents the silent stray-row bug for any current or future caller.
2. **`src/services/database.ts:7187`** — `setNodePositionOverride` now passes `sourceId` explicitly to `nodesRepo.upsertNode`. Belt & suspenders with #1.
3. **`src/services/database.ts:2147`** — same explicit-`sourceId` pattern applied to the other bare `nodesRepo.upsertNode` call (`DatabaseService.upsertNode`).

## Regression test
`src/db/repositories/nodes.test.ts` — new test `upsertNode - falls back to nodeData.sourceId when sourceId arg omitted (issue #2902)` verifies that calling `upsertNode` with a node object whose `sourceId` field is set writes to that source's row and does **not** create a stray `'default'` row. Runs against all three backend harnesses (SQLite / Postgres / MySQL).

## Test plan
- [ ] CI green on SQLite, Postgres, and MySQL test suites
- [ ] Manual: in a PG deployment with `sourceId != 'default'`, set a position override → live-source row gets the override fields and the marker moves on the map
- [ ] Manual: confirm no new `sourceId='default'` row is created in the `nodes` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)