### PR TITLE
fix(multi-source): route Exchange Node Info/Position/Neighbor Info via selected source (#2911)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2829,7 +2829,7 @@ function App() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ destination: nodeNum, ...(channel !== undefined && { channel }) }),
+        body: JSON.stringify({ destination: nodeNum, sourceId: sourceId || undefined, ...(channel !== undefined && { channel }) }),
       });
 
       logger.debug(`📍 Position request sent to ${nodeId}`);
@@ -2875,7 +2875,7 @@ function App() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ destination: nodeNum }),
+        body: JSON.stringify({ destination: nodeNum, sourceId: sourceId || undefined }),
       });
 
       logger.debug(`🔑 NodeInfo request sent to ${nodeId}`);
@@ -2915,7 +2915,7 @@ function App() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ destination: nodeNum }),
+        body: JSON.stringify({ destination: nodeNum, sourceId: sourceId || undefined }),
       });
 
       logger.debug(`🏠 NeighborInfo request sent to ${nodeId}`);


### PR DESCRIPTION
## Summary

Closes #2911.

The frontend handlers for **Exchange Node Info**, **Exchange Position**, and **Request Neighbor Info** were posting to their respective backend endpoints without the active `sourceId` in the body. The backend route handlers (`/api/nodeinfo/request`, `/api/position/request`, `/api/neighborinfo/request`) fall back to the default `meshtasticManager` when `sourceId` is missing, so in multi-source deployments these requests were always emitted from the *primary* node, even when the user had selected a secondary source in the UI.

Other handlers in `App.tsx` (traceroute, send message, set favorite, ignored, locked, etc.) already include `sourceId` in the request body. This change brings the three exchange/request handlers in line with that pattern so they route to the manager for the currently-selected source.

## Changes

- `src/App.tsx`:
  - `handleExchangePosition` — add `sourceId` to POST body
  - `handleExchangeNodeInfo` — add `sourceId` to POST body
  - `handleRequestNeighborInfo` — add `sourceId` to POST body

The backend route handlers (`server.ts`) already correctly read `sourceId` from the body and route to the appropriate manager via `sourceManagerRegistry.getManager(...)`. No backend changes needed.

## Test plan

- [ ] Configure two sources (e.g., MediumFast + LongFast) in MeshMonitor
- [ ] Select the **second** source (LongFast)
- [ ] Open a node detail view and click **Exchange Node Info** — verify the packet is emitted from LongFast (check device log / mesh activity)
- [ ] Click **Exchange Position** — verify the packet is emitted from LongFast
- [ ] Click **Request Neighbor Info** (where eligible) — verify the packet is emitted from LongFast
- [ ] Repeat with the first source selected to confirm no regression
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)