### PR TITLE
fix(traceroute): hydrate Auto Traceroute checkbox from per-source value (#2914)

### DIFF
--- a/src/components/AutoTracerouteSection.test.tsx
+++ b/src/components/AutoTracerouteSection.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression tests for #2914: per-source `tracerouteIntervalMinutes` was being
+ * shadowed by the global prop, so after a save + reload the checkbox snapped
+ * back to "off" even while the per-source scheduler kept running.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import AutoTracerouteSection from './AutoTracerouteSection';
+import { SourceProvider } from '../contexts/SourceContext';
+
+const mockCsrfFetch = vi.fn();
+vi.mock('../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => mockCsrfFetch,
+}));
+
+const mockShowToast = vi.fn();
+vi.mock('./ToastContainer', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+  ToastContainer: () => null,
+}));
+
+const mockUseSaveBar = vi.fn();
+vi.mock('../hooks/useSaveBar', () => ({
+  useSaveBar: (opts: any) => mockUseSaveBar(opts),
+}));
+
+describe('AutoTracerouteSection — per-source interval reload (#2914)', () => {
+  const defaultFilterResponse = {
+    enabled: false,
+    nodeNums: [],
+    filterChannels: [],
+    filterRoles: [],
+    filterHwModels: [],
+    filterNameRegex: '.*',
+    filterNodesEnabled: true,
+    filterChannelsEnabled: true,
+    filterRolesEnabled: true,
+    filterHwModelsEnabled: true,
+    filterRegexEnabled: true,
+    filterLastHeardEnabled: true,
+    filterLastHeardHours: 168,
+    filterHopsEnabled: false,
+    filterHopsMin: 0,
+    filterHopsMax: 10,
+    expirationHours: 24,
+    sortByHops: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockApi(opts: { tracerouteIntervalMinutes?: string | undefined }) {
+    mockCsrfFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/settings/traceroute-nodes')) {
+        return Promise.resolve({ ok: true, json: async () => defaultFilterResponse });
+      }
+      if (url.includes('/api/settings/traceroute-log')) {
+        return Promise.resolve({ ok: true, json: async () => ({ log: [] }) });
+      }
+      if (url.includes('/api/settings')) {
+        const body: Record<string, unknown> = {
+          tracerouteScheduleEnabled: 'false',
+          tracerouteScheduleStart: '00:00',
+          tracerouteScheduleEnd: '00:00',
+        };
+        if (opts.tracerouteIntervalMinutes !== undefined) {
+          body.tracerouteIntervalMinutes = opts.tracerouteIntervalMinutes;
+        }
+        return Promise.resolve({ ok: true, json: async () => body });
+      }
+      if (url.includes('/api/nodes')) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+    });
+  }
+
+  it('uses per-source tracerouteIntervalMinutes even when the prop is 0', async () => {
+    // Server stored `15` per-source, but the global GET that powers the prop
+    // returns nothing → parent passes 0. UI must still hydrate from per-source.
+    mockApi({ tracerouteIntervalMinutes: '15' });
+
+    const onIntervalChange = vi.fn();
+    render(
+      <SourceProvider sourceId="src-1" sourceName="Source 1">
+        <AutoTracerouteSection
+          intervalMinutes={0}
+          baseUrl=""
+          onIntervalChange={onIntervalChange}
+        />
+      </SourceProvider>
+    );
+
+    const intervalInput = await screen.findByDisplayValue('15');
+    expect((intervalInput as HTMLInputElement).id).toBe('tracerouteInterval');
+
+    // The master "enable" checkbox is the first checkbox in the section header.
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect((checkboxes[0] as HTMLInputElement).checked).toBe(true);
+
+    // No spurious "unsaved changes" — baseline matches the per-source value.
+    await waitFor(() => {
+      expect(mockUseSaveBar).toHaveBeenCalled();
+    });
+    const lastCall = mockUseSaveBar.mock.calls[mockUseSaveBar.mock.calls.length - 1][0];
+    expect(lastCall.hasChanges).toBe(false);
+  });
+
+  it('falls back to the prop when per-source value is missing', async () => {
+    mockApi({ tracerouteIntervalMinutes: undefined });
+
+    render(
+      <SourceProvider sourceId="src-1" sourceName="Source 1">
+        <AutoTracerouteSection
+          intervalMinutes={20}
+          baseUrl=""
+          onIntervalChange={vi.fn()}
+        />
+      </SourceProvider>
+    );
+
+    const intervalInput = await screen.findByDisplayValue('20');
+    expect((intervalInput as HTMLInputElement).id).toBe('tracerouteInterval');
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect((checkboxes[0] as HTMLInputElement).checked).toBe(true);
+  });
+});

--- a/src/components/AutoTracerouteSection.tsx
+++ b/src/components/AutoTracerouteSection.tsx
@@ -120,6 +120,12 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
   // Initial state tracking for change detection
   const [initialSettings, setInitialSettings] = useState<FilterSettings | null>(null);
 
+  // Per-source interval baseline (separate from the global `intervalMinutes` prop).
+  // The interval is stored as a per-source setting, so the global GET that powers
+  // the prop returns 0 even when a per-source value is set — using the prop alone
+  // makes the checkbox revert to "off" after reload (#2914).
+  const [initialInterval, setInitialInterval] = useState<number | null>(null);
+
   // Expanded sections state
   const [expandedSections, setExpandedSections] = useState({
     nodes: false,
@@ -131,11 +137,14 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
     hops: false,
   });
 
-  // Update local state when props change
+  // Update local state when props change.
+  // Skip once the per-source GET has resolved — the per-source value is
+  // authoritative and may differ from the global prop (#2914).
   useEffect(() => {
+    if (initialInterval !== null) return;
     setLocalEnabled(intervalMinutes > 0);
     setLocalInterval(intervalMinutes > 0 ? intervalMinutes : 15);
-  }, [intervalMinutes]);
+  }, [intervalMinutes, initialInterval]);
 
   // Fetch available nodes
   useEffect(() => {
@@ -186,19 +195,33 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
           // Load sort by hops setting (default to false)
           setSortByHops(data.sortByHops || false);
 
-          // Load schedule settings from general settings
+          // Load schedule settings + per-source interval from general settings
           let schedEnabled = false;
           let schedStart = '00:00';
           let schedEnd = '00:00';
+          let persistedInterval: number | null = null;
           if (settingsResponse.ok) {
             const settingsData = await settingsResponse.json();
             schedEnabled = settingsData.tracerouteScheduleEnabled === 'true';
             schedStart = settingsData.tracerouteScheduleStart || '00:00';
             schedEnd = settingsData.tracerouteScheduleEnd || '00:00';
+            if (settingsData.tracerouteIntervalMinutes !== undefined) {
+              const parsed = parseInt(String(settingsData.tracerouteIntervalMinutes), 10);
+              if (!isNaN(parsed) && parsed >= 0) {
+                persistedInterval = parsed;
+              }
+            }
           }
           setScheduleEnabled(schedEnabled);
           setScheduleStart(schedStart);
           setScheduleEnd(schedEnd);
+
+          // Per-source interval is authoritative — apply it before unblocking
+          // the prop-sync effect (#2914).
+          const baselineInterval = persistedInterval ?? intervalMinutes;
+          setInitialInterval(baselineInterval);
+          setLocalEnabled(baselineInterval > 0);
+          setLocalInterval(baselineInterval > 0 ? baselineInterval : 15);
 
           // Set initial settings once with all data
           setInitialSettings({
@@ -219,6 +242,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
   // SaveBar change-detection compares against the new source's baseline.
   useEffect(() => {
     setInitialSettings(null);
+    setInitialInterval(null);
   }, [sourceQuery]);
 
   // Fetch auto-traceroute log
@@ -253,7 +277,8 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
     if (!initialSettings) return;
 
     const currentInterval = localEnabled ? localInterval : 0;
-    const intervalChanged = currentInterval !== intervalMinutes;
+    const baselineInterval = initialInterval ?? intervalMinutes;
+    const intervalChanged = currentInterval !== baselineInterval;
     const filterEnabledChanged = filterEnabled !== initialSettings.enabled;
     const nodesChanged = JSON.stringify([...selectedNodeNums].sort()) !== JSON.stringify([...(initialSettings.nodeNums || [])].sort());
     const channelsChanged = JSON.stringify([...filterChannels].sort()) !== JSON.stringify([...(initialSettings.filterChannels || [])].sort());
@@ -289,7 +314,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
       filterLastHeardEnabledChanged || filterLastHeardHoursChanged || filterHopsEnabledChanged || filterHopsMinChanged || filterHopsMaxChanged ||
       expirationHoursChanged || sortByHopsChanged || scheduleEnabledChanged || scheduleStartChanged || scheduleEndChanged;
     setHasChanges(changed);
-  }, [localEnabled, localInterval, intervalMinutes, filterEnabled, selectedNodeNums, filterChannels, filterRoles, filterHwModels, filterNameRegex, initialSettings,
+  }, [localEnabled, localInterval, intervalMinutes, initialInterval, filterEnabled, selectedNodeNums, filterChannels, filterRoles, filterHwModels, filterNameRegex, initialSettings,
       filterNodesEnabled, filterChannelsEnabled, filterRolesEnabled, filterHwModelsEnabled, filterRegexEnabled,
       filterLastHeardEnabled, filterLastHeardHours, filterHopsEnabled, filterHopsMin, filterHopsMax,
       expirationHours, sortByHops,
@@ -297,8 +322,9 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
 
   // Reset local state to initial settings (used by SaveBar dismiss)
   const resetChanges = useCallback(() => {
-    setLocalEnabled(intervalMinutes > 0);
-    setLocalInterval(intervalMinutes > 0 ? intervalMinutes : 15);
+    const baselineInterval = initialInterval ?? intervalMinutes;
+    setLocalEnabled(baselineInterval > 0);
+    setLocalInterval(baselineInterval > 0 ? baselineInterval : 15);
     if (initialSettings) {
       setFilterEnabled(initialSettings.enabled);
       setSelectedNodeNums(initialSettings.nodeNums || []);
@@ -322,7 +348,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
       setScheduleStart(initialSettings.scheduleStart || '00:00');
       setScheduleEnd(initialSettings.scheduleEnd || '00:00');
     }
-  }, [intervalMinutes, initialSettings]);
+  }, [intervalMinutes, initialInterval, initialSettings]);
 
   // Helper to get role from node (could be at top level or in user object)
   const getNodeRole = (node: Node): number | undefined => {
@@ -521,6 +547,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
 
       // Update parent state and local tracking after successful API calls
       onIntervalChange(intervalToSave);
+      setInitialInterval(intervalToSave);
       setInitialSettings({
         enabled: filterEnabled,
         nodeNums: selectedNodeNums,


### PR DESCRIPTION
## Summary
- Closes #2914 — after enabling Auto Traceroute, saving, and refreshing the page the checkbox would snap back to "off" while the per-source scheduler kept running.
- `tracerouteIntervalMinutes` is stored per-source (via `setSourceSettings`), but `AutoTracerouteSection` was hydrating its checkbox/interval state from the global `intervalMinutes` prop produced by `SettingsContext` — which fetches `/api/settings` without a `sourceId` and therefore can never see the per-source value.
- Read `tracerouteIntervalMinutes` from the existing per-source `/api/settings?sourceId=<id>` response, use it as the authoritative baseline for both initial render and SaveBar change detection, and reset it on source switch so the SaveBar doesn't fire spuriously.

## Test plan
- [x] Added `src/components/AutoTracerouteSection.test.tsx` covering the regression (per-source `15` with global prop `0`) and the prop fallback path.
- [x] `npx vitest run src/components/AutoTracerouteSection.test.tsx` — 2 / 2 pass.
- [ ] CI: full Vitest suite + system tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)