### PR TITLE
fix(scripts): honor DATA_DIR so desktop builds can store scripts

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -51,6 +51,7 @@ pub fn start_backend<R: Runtime>(app: &AppHandle<R>) -> Result<Child, String> {
     let config = Config::load()?;
 
     // Get paths
+    let data_path = config::get_data_path()?;
     let db_path = config::get_database_path()?;
     let logs_path = config::get_logs_path()?;
 
@@ -84,6 +85,7 @@ pub fn start_backend<R: Runtime>(app: &AppHandle<R>) -> Result<Child, String> {
     log_to_file(&logs_path, &format!("Server path: {:?}", server_path));
     log_to_file(&logs_path, &format!("Server dir: {:?}", server_dir));
     log_to_file(&logs_path, &format!("Database: {:?}", db_path));
+    log_to_file(&logs_path, &format!("Data dir: {:?}", data_path));
     log_to_file(&logs_path, &format!("Logs: {:?}", logs_path));
 
     // Check if required files exist
@@ -158,6 +160,7 @@ pub fn start_backend<R: Runtime>(app: &AppHandle<R>) -> Result<Child, String> {
         .env("MESHTASTIC_NODE_IP", &config.meshtastic_ip)
         .env("MESHTASTIC_TCP_PORT", config.meshtastic_port.to_string())
         .env("DATABASE_PATH", db_path.to_string_lossy().to_string())
+        .env("DATA_DIR", data_path.to_string_lossy().to_string())
         .env("SESSION_SECRET", &config.session_secret)
         .env("ALLOWED_ORIGINS", {
             // Always include localhost

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -8026,7 +8026,7 @@ class MeshtasticManager implements ISourceManager {
    */
   /**
    * Resolves a script path from the stored format (/data/scripts/...) to the actual file system path.
-   * Handles both development (relative path) and production (absolute path) environments.
+   * In production, honors DATA_DIR env var (set by desktop sidecar) and falls back to /data.
    */
   private resolveScriptPath(scriptPath: string): string | null {
     // Validate script path (security check)
@@ -8034,26 +8034,23 @@ class MeshtasticManager implements ISourceManager {
       logger.error(`🚫 Invalid script path: ${scriptPath}`);
       return null;
     }
-    
+
     const env = getEnvironmentConfig();
-    
+
     let scriptsDir: string;
-    
+
     if (env.isDevelopment) {
-      // In development, use relative path from project root
       const projectRoot = path.resolve(process.cwd());
       scriptsDir = path.join(projectRoot, 'data', 'scripts');
-      
-      // Ensure directory exists
-      if (!fs.existsSync(scriptsDir)) {
-        fs.mkdirSync(scriptsDir, { recursive: true });
-        logger.debug(`📁 Created scripts directory: ${scriptsDir}`);
-      }
     } else {
-      // In production, use absolute path
-      scriptsDir = '/data/scripts';
+      scriptsDir = path.join(process.env.DATA_DIR || '/data', 'scripts');
     }
-    
+
+    if (!fs.existsSync(scriptsDir)) {
+      fs.mkdirSync(scriptsDir, { recursive: true });
+      logger.debug(`📁 Created scripts directory: ${scriptsDir}`);
+    }
+
     const filename = path.basename(scriptPath);
     const resolvedPath = path.join(scriptsDir, filename);
     

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -76,25 +76,24 @@ const env = getEnvironmentConfig();
 /**
  * Gets the scripts directory path.
  * In development, uses relative path from project root (data/scripts).
- * In production, uses absolute path (/data/scripts).
+ * In production, uses DATA_DIR env var (set by desktop sidecar) or defaults to /data.
  */
 const getScriptsDirectory = (): string => {
+  let scriptsDir: string;
+
   if (env.isDevelopment) {
-    // In development, use relative path from project root
     const projectRoot = path.resolve(__dirname, '../../');
-    const devScriptsDir = path.join(projectRoot, 'data', 'scripts');
-
-    // Ensure directory exists
-    if (!fs.existsSync(devScriptsDir)) {
-      fs.mkdirSync(devScriptsDir, { recursive: true });
-      logger.info(`📁 Created scripts directory: ${devScriptsDir}`);
-    }
-
-    return devScriptsDir;
+    scriptsDir = path.join(projectRoot, 'data', 'scripts');
+  } else {
+    scriptsDir = path.join(process.env.DATA_DIR || '/data', 'scripts');
   }
 
-  // In production, use absolute path
-  return '/data/scripts';
+  if (!fs.existsSync(scriptsDir)) {
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    logger.info(`📁 Created scripts directory: ${scriptsDir}`);
+  }
+
+  return scriptsDir;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Mac/Windows desktop users couldn't upload scripts from Script Management — the upload endpoint failed with `ENOENT/EACCES: mkdir /data/scripts`. Production code paths hardcoded `/data/scripts`, but the desktop sidecar runs unsandboxed under the user account and has no `/data` filesystem path.
- `getScriptsDirectory()` (`src/server/server.ts`) and `resolveScriptPath()` (`src/server/meshtasticManager.ts`) now use `process.env.DATA_DIR || '/data'` for the scripts root, matching the existing `geojsonDataDir` / `mapStyleDataDir` pattern. Both also `mkdir -p` the directory in production.
- Desktop sidecar (`desktop/src-tauri/src/lib.rs`) now passes `DATA_DIR` to the Node server, pointing at the same `MeshMonitor` app-data folder where the SQLite DB lives (e.g. `~/Library/Application Support/MeshMonitor` on macOS).

## Compatibility

Trigger configs already stored as `/data/scripts/foo.py` keep working — the resolver only uses `path.basename()` and rejoins with the runtime scripts dir, so the stored prefix is just a tag. No DB migration needed. Docker / Helm deployments are unaffected: when `DATA_DIR` isn't set, both call sites still default to `/data`.

## Test plan

- [ ] Rebuild macOS DMG, install, upload `.py` script via Script Management UI
- [ ] Confirm script lands in `~/Library/Application Support/MeshMonitor/scripts/`
- [ ] Configure an auto-responder trigger pointing at the uploaded script and verify it executes
- [ ] Verify Docker container still writes to `/data/scripts/` (default unchanged)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)