### PR TITLE
fix(upgrade): clear stale .upgrade-status before triggering new upgrade

### DIFF
--- a/src/server/services/upgradeService.test.ts
+++ b/src/server/services/upgradeService.test.ts
@@ -34,29 +34,25 @@ vi.mock('../../services/database.js', () => ({
 }));
 
 // fs is touched on import; provide enough to avoid touching the real disk.
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue(''),
+  writeFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  statfsSync: vi.fn().mockReturnValue({ bavail: 1_000_000, bsize: 4096 }),
+  mkdirSync: vi.fn(),
+  accessSync: vi.fn(),
+}));
+
 vi.mock('fs', () => {
-  const noop = () => {};
-  return {
-    default: {
-      existsSync: vi.fn().mockReturnValue(false),
-      readFileSync: vi.fn().mockReturnValue(''),
-      writeFileSync: noop,
-      renameSync: noop,
-      unlinkSync: noop,
-      statfsSync: vi.fn().mockReturnValue({ bavail: 1_000_000, bsize: 4096 }),
-      mkdirSync: noop,
-      accessSync: noop,
-      constants: { W_OK: 2 },
-    },
-    existsSync: vi.fn().mockReturnValue(false),
-    readFileSync: vi.fn().mockReturnValue(''),
-    writeFileSync: noop,
-    renameSync: noop,
-    unlinkSync: noop,
-    statfsSync: vi.fn().mockReturnValue({ bavail: 1_000_000, bsize: 4096 }),
-    mkdirSync: noop,
-    accessSync: noop,
+  const api = {
+    ...fsMocks,
     constants: { W_OK: 2 },
+  };
+  return {
+    default: api,
+    ...api,
   };
 });
 
@@ -69,6 +65,8 @@ describe('upgradeService circuit breaker', () => {
     mockDb.miscRepo.countConsecutiveFailedUpgrades.mockResolvedValue(0);
     mockDb.miscRepo.findStaleUpgrades.mockResolvedValue([]);
     mockDb.miscRepo.countInProgressUpgrades.mockResolvedValue(0);
+    fsMocks.existsSync.mockReturnValue(false);
+    fsMocks.readFileSync.mockReturnValue('');
   });
 
   it('exposes the configured threshold (default 3)', () => {
@@ -118,6 +116,52 @@ describe('upgradeService circuit breaker', () => {
     expect(result.success).toBe(false);
     expect(result.message).toMatch(/blocked/i);
     expect(mockDb.miscRepo.createUpgradeHistory).not.toHaveBeenCalled();
+  });
+
+  it('triggerUpgrade clears stale .upgrade-status before writing trigger', async () => {
+    // Regression: a previous failed run left "failed" in the watchdog status
+    // file. Without clearing it, getUpgradeStatus() / getActiveUpgrade() sync
+    // the new in-progress row to "failed" before the watchdog touches it,
+    // producing a spurious "Upgrade failed" toast and leaving the circuit
+    // breaker tripped after the watchdog quietly succeeds in the background.
+    Object.assign(upgradeService, { UPGRADE_ENABLED: true, DEPLOYMENT_METHOD: 'docker' });
+
+    const STATUS_FILE = '/data/.upgrade-status';
+    fsMocks.existsSync.mockImplementation((p: string) => p === STATUS_FILE);
+    fsMocks.readFileSync.mockReturnValue('failed');
+
+    const result = await upgradeService.triggerUpgrade(
+      { targetVersion: 'latest', force: true },
+      '1.0.0',
+      '42'
+    );
+
+    expect(result.success).toBe(true);
+    expect(fsMocks.unlinkSync).toHaveBeenCalledWith(STATUS_FILE);
+
+    // The clear must happen before the trigger file is written, otherwise the
+    // watchdog can race ahead of us.
+    const unlinkOrder = fsMocks.unlinkSync.mock.invocationCallOrder[0];
+    const renameOrder = fsMocks.renameSync.mock.invocationCallOrder[0];
+    expect(unlinkOrder).toBeDefined();
+    expect(renameOrder).toBeDefined();
+    expect(unlinkOrder).toBeLessThan(renameOrder);
+  });
+
+  it('triggerUpgrade tolerates missing .upgrade-status (no-op clear)', async () => {
+    // No prior run; status file does not exist. Clear must be a silent no-op.
+    Object.assign(upgradeService, { UPGRADE_ENABLED: true, DEPLOYMENT_METHOD: 'docker' });
+
+    fsMocks.existsSync.mockReturnValue(false);
+
+    const result = await upgradeService.triggerUpgrade(
+      { targetVersion: 'latest', force: true },
+      '1.0.0',
+      '42'
+    );
+
+    expect(result.success).toBe(true);
+    expect(fsMocks.unlinkSync).not.toHaveBeenCalled();
   });
 
   it('triggerUpgrade allows manual user attempt even when blocked', async () => {

--- a/src/server/services/upgradeService.ts
+++ b/src/server/services/upgradeService.ts
@@ -222,6 +222,21 @@ class UpgradeService {
         rollbackAvailable: true,
       });
 
+      // Clear stale watchdog status from any prior run before kicking off this
+      // upgrade. Without this, the file-based sync paths in getUpgradeStatus()
+      // and getActiveUpgrade() would observe a leftover "failed" string and
+      // mark this brand-new row failed before the watchdog has even picked up
+      // the trigger — which both surfaces a spurious "Upgrade failed" toast
+      // and prevents markCompleteAndClear() from clearing the circuit
+      // breaker on success.
+      try {
+        if (fs.existsSync(UPGRADE_STATUS_FILE)) {
+          fs.unlinkSync(UPGRADE_STATUS_FILE);
+        }
+      } catch (clearError) {
+        logger.warn('Could not clear stale upgrade status file before trigger:', clearError);
+      }
+
       // Write trigger file for watchdog (using atomic write to prevent race conditions)
       const triggerData = {
         upgradeId,


### PR DESCRIPTION
## Summary

- Manual "Upgrade Now" reports immediate failure while the watchdog quietly processes the upgrade in the background.
- After the silent success, the circuit breaker added in #2871 stays tripped — the "N consecutive failures, Acknowledge" banner persists.
- Both symptoms share one cause: a stale `failed` value left in `/data/.upgrade-status` from a prior run gets synced into the new in-progress row before the watchdog ever touches it. The new row is marked failed, so `markCompleteAndClear()` never fires.

Fix: in `upgradeService.triggerUpgrade()`, unlink `UPGRADE_STATUS_FILE` immediately before writing the trigger file. The sync paths in `getUpgradeStatus()` / `getActiveUpgrade()` short-circuit when the file is absent, so the first state the app observes is one the watchdog actually wrote for this upgrade.

## Why now

Pre-#2871 the same file leak only produced a one-shot toast. With the circuit breaker live, every leaked false-fail also bumps the consecutive-failure counter and traps the user behind a persistent banner.

## Test plan

- [x] `npx vitest run src/server/services/upgradeService.test.ts` — 8/8 pass, including two new regression cases:
  - Stale `failed` in status file → unlink runs before trigger rename (ordering asserted).
  - Missing status file → no spurious unlink.
- [x] `npx tsc --noEmit` clean.
- [ ] Manual: on a deployment with the breaker tripped, trigger an upgrade; verify (a) no spurious failure toast, (b) breaker auto-clears on success, (c) `Acknowledge` still works for the existing tripped state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)