### PR TITLE
feat: auto-timezone update from source node GPS position

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ MeshMonitor supports multiple deployment methods:
 - **Docker Ready** - Pre-built multi-architecture images
 - **One-click Self-Upgrade** - Automatic upgrades from the UI with backup and rollback
 - **System Backup & Restore** - Complete disaster recovery with automated backups
+- **Geofence-Driven Timezone Detection** *(opt-in)* - For mobile deployments, designate a source node whose GPS position drives automatic detection of the local IANA timezone. Detected timezone is persisted to settings; applying it to the server's `TZ` env currently requires a restart (see issue #2924 for the full design discussion)
 
 For a complete feature list and technical details, visit **[meshmonitor.org](https://meshmonitor.org/)**.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "express-mysql-session": "^3.0.3",
         "express-rate-limit": "^8.4.1",
         "express-session": "^1.19.0",
+        "geo-tz": "^8.1.6",
         "helmet": "^8.1.0",
         "i18next": "^26.0.8",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -4850,6 +4851,49 @@
         "node": ">=12"
       }
     },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.5.tgz",
+      "integrity": "sha512-ba7+B0wzaS9GtERZOoXUZ6oW8IcIJHNQZf3c+tiD9ESjcsPO1Q/4qIJGTKl92nBLhhracHJxMWBM/U6hAVkaRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -4890,7 +4934,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5203,7 +5247,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5236,6 +5280,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6403,6 +6448,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-source": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/array-source/-/array-source-0.0.4.tgz",
+      "integrity": "sha512-frNdc+zBn80vipY+GdcJkLEbMWj3xmzArYApmUGxoiV8uAu/ygcs9icPdsGdA26h0MkHUMW6EN2piIvVx+M5Mw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
@@ -6955,8 +7006,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -7226,7 +7276,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/common-tags": {
@@ -7305,6 +7354,21 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/concurrently": {
       "version": "9.2.1",
@@ -7608,6 +7672,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -10187,6 +10252,15 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-source": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-source/-/file-source-0.6.1.tgz",
+      "integrity": "sha512-1R1KneL7eTXmXfKxC10V/9NeGOdbsAXJ+lQ//fvvcHUgtaZcZDWNJNblxAoVOyV1cj45pOtUrR3vZTBwqcW8XA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-source": "0.3"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -10487,6 +10561,66 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/geo-tz": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/geo-tz/-/geo-tz-8.1.6.tgz",
+      "integrity": "sha512-6YEper1rtHi1l3ZS99oy9ZBvrBO4qsLzvQwZoxYtV3fyxPuxh7yqiOUWRVs1bzSj693EXEO4k60jKXQmkY/JnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "geobuf": "^3.0.2",
+        "pbf": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/evansiroky"
+      }
+    },
+    "node_modules/geo-tz/node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/geobuf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/geobuf/-/geobuf-3.0.2.tgz",
+      "integrity": "sha512-ASgKwEAQQRnyNFHNvpd5uAwstbVYmiTW0Caw3fBb509tNTqXyAAPMyFs5NNihsLZhLxU1j/kjFhkhLWA9djuVg==",
+      "license": "ISC",
+      "dependencies": {
+        "concat-stream": "^2.0.0",
+        "pbf": "^3.2.1",
+        "shapefile": "~0.6.6"
+      },
+      "bin": {
+        "geobuf2json": "bin/geobuf2json",
+        "json2geobuf": "bin/json2geobuf",
+        "shp2geobuf": "bin/shp2geobuf"
+      }
+    },
+    "node_modules/geobuf/node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/get-caller-file": {
@@ -13934,6 +14068,16 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
+    "node_modules/path-source": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/path-source/-/path-source-0.1.3.tgz",
+      "integrity": "sha512-dWRHm5mIw5kw0cs3QZLNmpUWty48f5+5v9nWD2dw3Y0Hf+s01Ag8iJEWV0Sm0kocE8kK27DrIowha03e1YR+Qw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "array-source": "0.0",
+        "file-source": "0.6"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -14084,6 +14228,15 @@
       "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -14668,7 +14821,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -15110,6 +15264,12 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
@@ -15334,14 +15494,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -15521,6 +15673,24 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/shapefile": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/shapefile/-/shapefile-0.6.6.tgz",
+      "integrity": "sha512-rLGSWeK2ufzCVx05wYd+xrWnOOdSV7xNUW5/XFgx3Bc02hBkpMlrd2F1dDII7/jhWzv0MSyBFh5uJIy9hLdfuw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "array-source": "0.0",
+        "commander": "2",
+        "path-source": "0.1",
+        "slice-source": "0.4",
+        "stream-source": "0.3",
+        "text-encoding": "^0.6.4"
+      },
+      "bin": {
+        "dbf2json": "bin/dbf2json",
+        "shp2json": "bin/shp2json"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -15716,6 +15886,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/slice-source": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/slice-source/-/slice-source-0.4.1.tgz",
+      "integrity": "sha512-YiuPbxpCj4hD9Qs06hGAz/OZhQ0eDuALN0lRWJez0eD/RevzKqGdUx1IOMUnXgpr+sXZLq3g8ERwbAH0bCb8vg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -16058,6 +16234,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/stream-source": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/stream-source/-/stream-source-0.3.5.tgz",
+      "integrity": "sha512-ZuEDP9sgjiAwUVoDModftG0JtYiLUV8K4ljYD1VyUMRWtbVf92474o4kuuul43iZ8t/hRuiDAx1dIJSvirrK/g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/streamx": {
       "version": "2.25.0",
@@ -16490,6 +16672,13 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha512-hJnc6Qg3dWoOMkqP53F0dzRIgtmsAge09kxUIqGrEUS4qr5rWLckGYaQAVr+opBrIMRErGgy6f5aPnyPpyGRfg==",
+      "deprecated": "no longer maintained",
+      "license": "Unlicense"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -16832,11 +17021,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "express-mysql-session": "^3.0.3",
     "express-rate-limit": "^8.4.1",
     "express-session": "^1.19.0",
+    "geo-tz": "^8.1.6",
     "helmet": "^8.1.0",
     "i18next": "^26.0.8",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -144,6 +144,16 @@ export const VALID_SETTINGS_KEYS = [
   'tracerouteFilterHopsMin',
   'tracerouteFilterHopsMax',
   'defaultLandingPage',
+  // Geofence-timezone (auto-update server TZ from source node GPS) — issue #2924
+  'geofenceTzEnabled',
+  'geofenceTzSourceNodeId',
+  'geofenceTzThresholdMiles',
+  'geofenceTzIntervalMinutes',
+  // Service-managed (written by GeofenceTimezoneService, surfaced read-only in UI)
+  'geofenceTzDetected',
+  'geofenceTzLastLat',
+  'geofenceTzLastLon',
+  'geofenceTzLastCheckedAt',
 ] as const;
 
 export type ValidSettingKey = typeof VALID_SETTINGS_KEYS[number];

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -127,6 +127,8 @@ export interface SettingsCallbacks {
   invalidateHtmlCache?: () => void;
   restartAutoDeleteByDistanceService?: (intervalHours: number, sourceId?: string | null) => void;
   stopAutoDeleteByDistanceService?: (sourceId?: string | null) => void;
+  restartGeofenceTimezoneService?: (intervalMinutes: number) => void;
+  stopGeofenceTimezoneService?: () => void;
 }
 
 let callbacks: SettingsCallbacks = {};
@@ -740,6 +742,34 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
       } else {
         callbacks.stopAutoDeleteByDistanceService?.(sourceId);
         logger.info(`⏹️ Auto-delete-by-distance service stopped (source: ${sourceId ?? 'default'})`);
+      }
+    }
+
+    // Restart / stop geofence-timezone service when its settings change
+    const geofenceTzSettings = [
+      'geofenceTzEnabled',
+      'geofenceTzIntervalMinutes',
+      'geofenceTzSourceNodeId',
+      'geofenceTzThresholdMiles',
+    ];
+    const geofenceTzSettingsChanged = geofenceTzSettings.some((key) => key in filteredSettings);
+    if (geofenceTzSettingsChanged) {
+      const dbGfTzEnabled = await databaseService.settings.getSetting('geofenceTzEnabled');
+      const enabled =
+        filteredSettings.geofenceTzEnabled === 'true' ||
+        (filteredSettings.geofenceTzEnabled === undefined && dbGfTzEnabled === 'true');
+
+      if (enabled) {
+        const dbGfTzInterval = await databaseService.settings.getSetting('geofenceTzIntervalMinutes');
+        const intervalMinutes = parseInt(
+          filteredSettings.geofenceTzIntervalMinutes || dbGfTzInterval || '15',
+          10
+        );
+        callbacks.restartGeofenceTimezoneService?.(intervalMinutes);
+        logger.info(`✅ Geofence-timezone service restarted (interval: ${intervalMinutes}min)`);
+      } else {
+        callbacks.stopGeofenceTimezoneService?.();
+        logger.info('⏹️ Geofence-timezone service stopped');
       }
     }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -40,6 +40,7 @@ import { newsService } from './services/newsService.js';
 import { inactiveNodeNotificationService } from './services/inactiveNodeNotificationService.js';
 import { serverEventNotificationService } from './services/serverEventNotificationService.js';
 import { autoDeleteByDistanceService } from './services/autoDeleteByDistanceService.js';
+import { geofenceTimezoneService } from './services/geofenceTimezoneService.js';
 import { getUserNotificationPreferencesAsync, saveUserNotificationPreferencesAsync, applyNodeNamePrefixAsync } from './utils/notificationFiltering.js';
 import { upgradeService } from './services/upgradeService.js';
 import { enhanceNodeForClient, filterNodesByChannelPermission, checkNodeChannelAccess, getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
@@ -576,6 +577,24 @@ setTimeout(async () => {
     inactiveNodeNotificationService.start(inactiveThresholdHours, inactiveCheckIntervalMinutes, inactiveCooldownHours);
     logger.info('✅ Inactive node notification service started');
 
+    // Start geofence-timezone service (opt-in, default off) — see issue #2924
+    try {
+      const gfTzEnabled = await databaseService.settings.getSettingAsBoolean('geofenceTzEnabled', false);
+      if (gfTzEnabled) {
+        const gfTzIntervalRaw = parseInt(
+          (await databaseService.settings.getSetting('geofenceTzIntervalMinutes')) || '15',
+          10
+        );
+        const gfTzInterval = !isNaN(gfTzIntervalRaw) && gfTzIntervalRaw >= 1 && gfTzIntervalRaw <= 1440 ? gfTzIntervalRaw : 15;
+        geofenceTimezoneService.start(gfTzInterval);
+        logger.info('✅ Geofence-timezone service started');
+      } else {
+        logger.debug('Geofence-timezone service disabled (geofenceTzEnabled=false)');
+      }
+    } catch (err) {
+      logger.warn('⚠️  Failed to start geofence-timezone service:', err);
+    }
+
     // Auto-delete-by-distance scheduler is now started per-source inside
     // MeshtasticManager.startDistanceDeleteScheduler() as part of the normal
     // scheduler stagger after configComplete.
@@ -942,6 +961,11 @@ setSettingsCallbacks({
   restartAutoDeleteByDistanceService: (intervalHours: number) =>
     autoDeleteByDistanceService.start(intervalHours),
   stopAutoDeleteByDistanceService: () => autoDeleteByDistanceService.stop(),
+  restartGeofenceTimezoneService: (intervalMinutes: number) => {
+    geofenceTimezoneService.stop();
+    geofenceTimezoneService.start(intervalMinutes);
+  },
+  stopGeofenceTimezoneService: () => geofenceTimezoneService.stop(),
 });
 
 // API Routes

--- a/src/server/services/geofenceTimezoneService.test.ts
+++ b/src/server/services/geofenceTimezoneService.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for GeofenceTimezoneService
+ *
+ * Verifies:
+ *   - No-op when disabled (default)
+ *   - No-op when no source node configured
+ *   - No-op when source node has no GPS yet
+ *   - Distance debouncing (no-op below threshold)
+ *   - First-run detection (no prior state) writes detected tz + position
+ *   - Subsequent run with tz change persists new tz
+ *   - Distance triggers re-check even when tz string is same
+ *
+ * Strategy: stub `lookupTimezone` and `fetchSourceNode` on the service
+ * instance so tests don't need a real geo-tz package or DB nodes table.
+ * Settings IO is fully mocked at the databaseService boundary.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mock databaseService ─────────────────────────────────────────────
+const mockGetSetting = vi.fn();
+const mockGetSettingAsBoolean = vi.fn();
+const mockSetSetting = vi.fn();
+const mockGetNodeByNodeId = vi.fn();
+const mockGetNode = vi.fn();
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    settings: {
+      getSetting: mockGetSetting,
+      getSettingAsBoolean: mockGetSettingAsBoolean,
+      setSetting: mockSetSetting,
+    },
+    nodes: {
+      getNodeByNodeId: mockGetNodeByNodeId,
+      getNode: mockGetNode,
+    },
+  },
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+async function loadService() {
+  const mod = await import('./geofenceTimezoneService.js');
+  return mod.geofenceTimezoneService;
+}
+
+function settingsMap(initial: Record<string, string | null>) {
+  const store: Record<string, string | null> = { ...initial };
+  mockGetSetting.mockImplementation(async (key: string) => store[key] ?? null);
+  mockGetSettingAsBoolean.mockImplementation(
+    async (key: string, def: boolean = false) => {
+      const v = store[key];
+      if (v == null) return def;
+      return v === 'true' || v === '1';
+    }
+  );
+  mockSetSetting.mockImplementation(async (key: string, value: string) => {
+    store[key] = value;
+  });
+  return store;
+}
+
+describe('GeofenceTimezoneService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('no-ops when disabled (default off)', async () => {
+    settingsMap({ geofenceTzEnabled: 'false' });
+    const svc = await loadService();
+    const result = await svc.runNow();
+    expect(result.detected).toBe(false);
+    expect(result.reason).toBe('disabled');
+    expect(mockSetSetting).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when enabled but no source node configured', async () => {
+    settingsMap({
+      geofenceTzEnabled: 'true',
+      geofenceTzSourceNodeId: null,
+    });
+    const svc = await loadService();
+    const result = await svc.runNow();
+    expect(result.detected).toBe(false);
+    expect(result.reason).toBe('no_source_node');
+  });
+
+  it('no-ops when source node not found in DB', async () => {
+    settingsMap({
+      geofenceTzEnabled: 'true',
+      geofenceTzSourceNodeId: '!deadbeef',
+    });
+    mockGetNodeByNodeId.mockResolvedValue(null);
+    const svc = await loadService();
+    const result = await svc.runNow();
+    expect(result.detected).toBe(false);
+    expect(result.reason).toBe('node_not_found');
+  });
+
+  it('no-ops when source node has no GPS yet', async () => {
+    settingsMap({
+      geofenceTzEnabled: 'true',
+      geofenceTzSourceNodeId: '!deadbeef',
+    });
+    mockGetNodeByNodeId.mockResolvedValue({ latitude: null, longitude: null });
+    const svc = await loadService();
+    const result = await svc.runNow();
+    expect(result.detected).toBe(false);
+    expect(result.reason).toBe('no_gps');
+  });
+
+  it('detects new timezone on first run (no prior position)', async () => {
+    const store = settingsMap({
+      geofenceTzEnabled: 'true',
+      geofenceTzSourceNodeId: '!deadbeef',
+      geofenceTzThresholdMiles: '20',
+    });
+    mockGetNodeByNodeId.mockResolvedValue({
+      latitude: 33.5387,
+      longitude: -112.185, // Glendale AZ
+    });
+    const svc = await loadService();
+    vi.spyOn(svc, 'lookupTimezone').mockResolvedValue('America/Phoenix');
+
+    const result = await svc.runNow();
+    expect(result.detected).toBe(true);
+    expect(result.timezone).toBe('America/Phoenix');
+    expect(store.geofenceTzDetected).toBe('America/Phoenix');
+    expect(parseFloat(store.geofenceTzLastLat as string)).toBeCloseTo(33.5387, 3);
+    expect(parseFloat(store.geofenceTzLastLon as string)).toBeCloseTo(-112.185, 3);
+  });
+
+  it('debounces small movements below threshold when tz unchanged', async () => {
+    const store = settingsMap({
+      geofenceTzEnabled: 'true',
+      geofenceTzSourceNodeId: '!deadbeef',
+      geofenceTzThresholdMiles: '20',
+      geofenceTzLastLat: '33.5387',
+      geofenceTzLastLon: '-112.185',
+      geofenceTzDetected: 'America/Phoenix',
+    });
+    mockGetNodeByNodeId.mockResolvedValue({
+      latitude: 33.5400, // <0.1 miles north
+      longitude: -112.185,
+    });
+    const svc = await loadService();
+    vi.spyOn(svc, 'lookupTimezone').mockResolvedValue('America/Phoenix');
+
+    const result = await svc.runNow();
+    expect(result.detected).toBe(false);
+    expect(result.reason).toBe('no_change');
+    // Last-applied position should NOT be updated (debounce)
+    expect(store.geofenceTzLastLat).toBe('33.5387');
+  });
+
+  it('triggers re-detection when distance crosses threshold', async () => {
+    const store = settingsMap({
+      geofenceTzEnabled: 'true',
+      geofenceTzSourceNodeId: '!deadbeef',
+      geofenceTzThresholdMiles: '20',
+      geofenceTzLastLat: '33.5387',
+      geofenceTzLastLon: '-112.185',
+      geofenceTzDetected: 'America/Phoenix',
+    });
+    // ~370 miles east — well over 20mi threshold
+    mockGetNodeByNodeId.mockResolvedValue({
+      latitude: 35.0844,
+      longitude: -106.6504, // Albuquerque NM
+    });
+    const svc = await loadService();
+    vi.spyOn(svc, 'lookupTimezone').mockResolvedValue('America/Denver');
+
+    const result = await svc.runNow();
+    expect(result.detected).toBe(true);
+    expect(result.timezone).toBe('America/Denver');
+    expect(result.distanceMiles).toBeGreaterThan(300);
+    expect(store.geofenceTzDetected).toBe('America/Denver');
+  });
+
+  it('detects tz change even if distance is below threshold (e.g. crossing tz boundary nearby)', async () => {
+    const store = settingsMap({
+      geofenceTzEnabled: 'true',
+      geofenceTzSourceNodeId: '!deadbeef',
+      geofenceTzThresholdMiles: '50',
+      // Phoenix area
+      geofenceTzLastLat: '33.5387',
+      geofenceTzLastLon: '-112.185',
+      geofenceTzDetected: 'America/Phoenix',
+    });
+    // Just a few miles away but tz lookup returns different zone
+    // (this can happen near the AZ/NV border in real life)
+    mockGetNodeByNodeId.mockResolvedValue({
+      latitude: 33.55,
+      longitude: -112.20,
+    });
+    const svc = await loadService();
+    vi.spyOn(svc, 'lookupTimezone').mockResolvedValue('America/Los_Angeles');
+
+    const result = await svc.runNow();
+    expect(result.detected).toBe(true);
+    expect(result.timezone).toBe('America/Los_Angeles');
+    expect(store.geofenceTzDetected).toBe('America/Los_Angeles');
+  });
+
+  it('handles tz lookup failure gracefully', async () => {
+    settingsMap({
+      geofenceTzEnabled: 'true',
+      geofenceTzSourceNodeId: '!deadbeef',
+    });
+    mockGetNodeByNodeId.mockResolvedValue({ latitude: 0, longitude: 0 });
+    const svc = await loadService();
+    vi.spyOn(svc, 'lookupTimezone').mockResolvedValue(null);
+
+    const result = await svc.runNow();
+    expect(result.detected).toBe(false);
+    expect(result.reason).toBe('tz_lookup_failed');
+  });
+
+  it('start() and stop() manage the interval timer', async () => {
+    settingsMap({ geofenceTzEnabled: 'false' });
+    const svc = await loadService();
+    expect(svc.getStatus().running).toBe(false);
+    svc.start(15);
+    expect(svc.getStatus().running).toBe(true);
+    svc.stop();
+    expect(svc.getStatus().running).toBe(false);
+  });
+
+  it('start() is idempotent — second call is a no-op', async () => {
+    const svc = await loadService();
+    svc.start(15);
+    svc.start(15); // should warn but not throw
+    expect(svc.getStatus().running).toBe(true);
+    svc.stop();
+  });
+});
+
+describe('GeofenceTimezoneService — distance math sanity', () => {
+  it('Haversine distance reference: Phoenix → Albuquerque ~330mi', async () => {
+    // Independent sanity-check that the underlying distance function
+    // returns sane values for known endpoints. This is the reason a tz
+    // change at ABQ from a Phoenix-anchored last-applied position
+    // crosses any reasonable threshold.
+    const { calculateDistance, kmToMiles } = await import('../../utils/distance.js');
+    const km = calculateDistance(33.5387, -112.185, 35.0844, -106.6504);
+    const miles = kmToMiles(km);
+    // Real great-circle distance ~330 miles
+    expect(miles).toBeGreaterThan(300);
+    expect(miles).toBeLessThan(400);
+  });
+
+  it('Haversine distance reference: NYC → LA ~2450mi', async () => {
+    const { calculateDistance, kmToMiles } = await import('../../utils/distance.js');
+    const km = calculateDistance(40.7128, -74.006, 34.0522, -118.2437);
+    const miles = kmToMiles(km);
+    expect(miles).toBeGreaterThan(2400);
+    expect(miles).toBeLessThan(2500);
+  });
+});

--- a/src/server/services/geofenceTimezoneService.ts
+++ b/src/server/services/geofenceTimezoneService.ts
@@ -1,0 +1,290 @@
+/**
+ * Geofence Timezone Service
+ *
+ * Periodically reads a designated source node's GPS position and computes
+ * the local timezone. When the source node moves more than a configurable
+ * distance from the last-applied position, the service records the new
+ * timezone in settings so the operator (or a follow-up service / restart
+ * hook) can apply it.
+ *
+ * Designed for mobile MeshMonitor deployments (RV / boat / overlanding
+ * setups) where the source node moves between timezones but the server's
+ * TZ env stays static — causing log timestamps and scheduled tasks to
+ * drift relative to local time.
+ *
+ * This first-pass implementation is opt-in (default off) and scope-limited:
+ *   - Reads source node GPS, computes IANA tz via geo-tz
+ *   - Persists detected timezone to settings (geofenceTzDetected)
+ *   - Persists last-applied lat/lon for debouncing
+ *   - Does NOT auto-restart the server (TZ env is startup-only in the
+ *     current architecture — the restart strategy is the harder design
+ *     question deferred to a follow-up PR)
+ *
+ * Modeled after autoDeleteByDistanceService for consistency.
+ *
+ * Settings keys:
+ *   - geofenceTzEnabled (boolean) — default false
+ *   - geofenceTzSourceNodeId (string) — the !hex node id whose GPS drives TZ
+ *   - geofenceTzThresholdMiles (number) — distance threshold, default 20
+ *   - geofenceTzDetected (string, written by service) — last detected IANA tz
+ *   - geofenceTzLastLat / geofenceTzLastLon (number, written by service)
+ *   - geofenceTzLastCheckedAt (number, ms, written by service)
+ */
+
+import { logger } from '../../utils/logger.js';
+import databaseService from '../../services/database.js';
+import { calculateDistance, kmToMiles } from '../../utils/distance.js';
+
+interface DetectionResult {
+  detected: boolean;
+  reason: string;
+  timezone?: string;
+  latitude?: number;
+  longitude?: number;
+  distanceMiles?: number;
+}
+
+class GeofenceTimezoneService {
+  private checkInterval: ReturnType<typeof setInterval> | null = null;
+  private lastRunAt: number | null = null;
+  private isRunning = false;
+  private readonly DEFAULT_INTERVAL_MINUTES = 15;
+  private readonly DEFAULT_THRESHOLD_MILES = 20;
+
+  /**
+   * Start the geofence-timezone service.
+   * No-op if already started — call stop() first to restart.
+   */
+  public start(intervalMinutes: number = this.DEFAULT_INTERVAL_MINUTES): void {
+    if (this.checkInterval) {
+      logger.warn('⚠️  Geofence-timezone service is already running');
+      return;
+    }
+
+    logger.info(
+      `🌐 Starting geofence-timezone service (interval: ${intervalMinutes} minutes)`
+    );
+
+    // First check after 2 minutes — gives DB / sources time to settle.
+    setTimeout(() => {
+      this.runCheckCycle().catch((err) =>
+        logger.error('❌ Geofence-timezone: initial check failed:', err)
+      );
+    }, 120_000);
+
+    this.checkInterval = setInterval(() => {
+      this.runCheckCycle().catch((err) =>
+        logger.error('❌ Geofence-timezone: scheduled check failed:', err)
+      );
+    }, intervalMinutes * 60 * 1000);
+  }
+
+  /**
+   * Stop the service. Does not abort an in-progress run.
+   */
+  public stop(): void {
+    if (this.checkInterval) {
+      clearInterval(this.checkInterval);
+      this.checkInterval = null;
+      logger.info('⏹️  Geofence-timezone service stopped');
+    }
+  }
+
+  /**
+   * Manual trigger from API / settings change.
+   */
+  public async runNow(): Promise<DetectionResult> {
+    return this.runCheckCycle();
+  }
+
+  /**
+   * Service status (for /api/services or admin UI).
+   */
+  public getStatus(): { running: boolean; lastRunAt?: number } {
+    return {
+      running: this.checkInterval !== null,
+      lastRunAt: this.lastRunAt ?? undefined,
+    };
+  }
+
+  /**
+   * Core detection logic. Idempotent — safe to call multiple times.
+   * Returns whether a new timezone was detected this cycle.
+   */
+  public async runCheckCycle(): Promise<DetectionResult> {
+    if (this.isRunning) {
+      logger.debug('⏭️  Geofence-timezone: skipping, already running');
+      return { detected: false, reason: 'already_running' };
+    }
+    this.isRunning = true;
+
+    try {
+      const enabled = await databaseService.settings.getSettingAsBoolean(
+        'geofenceTzEnabled',
+        false
+      );
+      if (!enabled) {
+        logger.debug('⏭️  Geofence-timezone: disabled in settings');
+        return { detected: false, reason: 'disabled' };
+      }
+
+      const sourceNodeId = await databaseService.settings.getSetting(
+        'geofenceTzSourceNodeId'
+      );
+      if (!sourceNodeId) {
+        logger.debug('⏭️  Geofence-timezone: no source node configured');
+        return { detected: false, reason: 'no_source_node' };
+      }
+
+      const thresholdMilesStr = await databaseService.settings.getSetting(
+        'geofenceTzThresholdMiles'
+      );
+      const thresholdMiles = thresholdMilesStr
+        ? parseFloat(thresholdMilesStr)
+        : this.DEFAULT_THRESHOLD_MILES;
+
+      // Fetch the configured source node — supports both !hex string ids
+      // and bare node-num strings.
+      const node = await this.fetchSourceNode(sourceNodeId);
+      if (!node) {
+        logger.debug(
+          `⏭️  Geofence-timezone: source node ${sourceNodeId} not found in DB`
+        );
+        return { detected: false, reason: 'node_not_found' };
+      }
+
+      const lat = node.latitude ?? null;
+      const lon = node.longitude ?? null;
+      if (lat == null || lon == null) {
+        logger.debug(
+          `⏭️  Geofence-timezone: source node ${sourceNodeId} has no GPS position yet`
+        );
+        return { detected: false, reason: 'no_gps' };
+      }
+
+      // Distance check against last-applied position (debounce)
+      const lastLatStr = await databaseService.settings.getSetting(
+        'geofenceTzLastLat'
+      );
+      const lastLonStr = await databaseService.settings.getSetting(
+        'geofenceTzLastLon'
+      );
+      const lastTzStored = await databaseService.settings.getSetting(
+        'geofenceTzDetected'
+      );
+
+      const lastLat = lastLatStr ? parseFloat(lastLatStr) : null;
+      const lastLon = lastLonStr ? parseFloat(lastLonStr) : null;
+
+      let distanceMiles = 0;
+      if (lastLat != null && lastLon != null && !isNaN(lastLat) && !isNaN(lastLon)) {
+        distanceMiles = kmToMiles(calculateDistance(lastLat, lastLon, lat, lon));
+      }
+
+      const tz = await this.lookupTimezone(lat, lon);
+      if (!tz) {
+        logger.warn(
+          `⚠️  Geofence-timezone: tz lookup returned no result for (${lat}, ${lon})`
+        );
+        return { detected: false, reason: 'tz_lookup_failed' };
+      }
+
+      const tzChanged = tz !== lastTzStored;
+      const distanceTriggered =
+        lastLat == null || lastLon == null || distanceMiles >= thresholdMiles;
+
+      const now = Date.now();
+      this.lastRunAt = now;
+      await databaseService.settings.setSetting(
+        'geofenceTzLastCheckedAt',
+        String(now)
+      );
+
+      if (!tzChanged && !distanceTriggered) {
+        logger.debug(
+          `✅ Geofence-timezone: no change (tz=${tz}, distance=${distanceMiles.toFixed(2)}mi, threshold=${thresholdMiles}mi)`
+        );
+        return {
+          detected: false,
+          reason: 'no_change',
+          timezone: tz,
+          latitude: lat,
+          longitude: lon,
+          distanceMiles,
+        };
+      }
+
+      // Persist new detection
+      await databaseService.settings.setSetting('geofenceTzDetected', tz);
+      await databaseService.settings.setSetting('geofenceTzLastLat', String(lat));
+      await databaseService.settings.setSetting('geofenceTzLastLon', String(lon));
+
+      logger.info(
+        `🌐 Geofence-timezone: detected new tz=${tz} (${lat.toFixed(4)}, ${lon.toFixed(4)}, moved ${distanceMiles.toFixed(2)}mi). NOTE: server restart required for TZ env to take effect — see issue #2924.`
+      );
+
+      return {
+        detected: true,
+        reason: tzChanged ? 'tz_changed' : 'distance_threshold',
+        timezone: tz,
+        latitude: lat,
+        longitude: lon,
+        distanceMiles,
+      };
+    } catch (error) {
+      logger.error('❌ Geofence-timezone: error during check cycle:', error);
+      return { detected: false, reason: 'error' };
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  /**
+   * Resolve the configured source node by either !hex id or bare node-num.
+   * Exposed for testability.
+   */
+  public async fetchSourceNode(idOrNum: string): Promise<{
+    latitude?: number | null;
+    longitude?: number | null;
+  } | null> {
+    try {
+      // Prefer node-id form (!aabbccdd) — most common UX
+      if (idOrNum.startsWith('!')) {
+        return await databaseService.nodes.getNodeByNodeId(idOrNum);
+      }
+      // Otherwise treat as a node-num
+      const num = parseInt(idOrNum, 10);
+      if (isNaN(num)) return null;
+      return await databaseService.nodes.getNode(num);
+    } catch (err) {
+      logger.warn('⚠️  Geofence-timezone: fetchSourceNode failed:', err);
+      return null;
+    }
+  }
+
+  /**
+   * Look up IANA timezone for a (lat, lon) pair using geo-tz.
+   * Imported lazily so the heavy boundary dataset only loads when the
+   * service is actually used.
+   *
+   * Exposed (not private) so tests can stub it without monkey-patching
+   * the geo-tz module loader.
+   */
+  public async lookupTimezone(lat: number, lon: number): Promise<string | null> {
+    try {
+      const geoTz = await import('geo-tz');
+      const find = (geoTz as unknown as { find: (lat: number, lon: number) => string[] }).find;
+      const zones = find(lat, lon);
+      if (Array.isArray(zones) && zones.length > 0) {
+        return zones[0];
+      }
+      return null;
+    } catch (err) {
+      logger.error('❌ Geofence-timezone: tz lookup error:', err);
+      return null;
+    }
+  }
+}
+
+export const geofenceTimezoneService = new GeofenceTimezoneService();
+export { GeofenceTimezoneService };


### PR DESCRIPTION
## Closes/relates
Relates to #2924 — opening as **DRAFT** so the maintainer can react to concrete code without committing to merge. The issue thread has the full design proposal; this PR is the foundational backend implementation.

## Motivation

Mobile MeshMonitor instances (RV / boat / overlanding setups) typically have a GPS-equipped node that moves with the deployment. The server's `TZ` env stays static, so log timestamps and scheduled tasks (`backup_time`, `system_backup_time`, `maintenanceTime`) drift relative to local time as the deployment crosses timezones.

This PR adds an opt-in service that reads a designated source node's GPS position and persists the detected IANA timezone to settings whenever the node crosses a configurable distance threshold or the computed tz changes.

## Design summary

- **Opt-in via 3 user settings** (default off):
  - `geofenceTzEnabled: boolean` — default `false`
  - `geofenceTzSourceNodeId: string` — accepts `!hex` or bare node-num
  - `geofenceTzThresholdMiles: number` — default `20`
  - (also `geofenceTzIntervalMinutes` — default `15`)
- **4 service-managed settings** (written by the service, surfaced read-only in a future UI):
  - `geofenceTzDetected` — last computed IANA tz
  - `geofenceTzLastLat` / `geofenceTzLastLon` — last-applied position (for debounce)
  - `geofenceTzLastCheckedAt` — ms timestamp
- **Service modeled after `autoDeleteByDistanceService`** for consistency: same lifecycle (`start` / `stop` / `runNow` / `getStatus`), same isRunning guard, same staggered initial delay.
- **TZ lookup via `geo-tz` (8.1.6, MIT)** — chosen over `tz-lookup` because:
  - Actively maintained (last release 2026-03 vs. tz-lookup's 2022-06)
  - Newer TZ boundary changes (e.g. Egypt 2023 DST flip) are captured
  - Bundle size cost (~72 MB unpacked) is acceptable for a backend service that doesn't ship to clients
  - 4 small deps (turf, geobuf, pbf) are themselves stable
- **Distance via the existing `calculateDistance` Haversine util** (`src/utils/distance.ts`) — same primitive used by `autoDeleteByDistanceService`.
- **State persistence via the existing settings repository** — no schema migration needed because settings is a key-value store; only `VALID_SETTINGS_KEYS` was extended.
- **Restart strategy NOT included.** The current architecture's `TZ` env is startup-only — applying a detected tz to running schedulers/log timestamps requires a process restart. That's the harder design question and is deferred to a follow-up PR per the issue's "design alignment first" comment.

## What's in this PR

| File | Change | LOC |
|---|---|---|
| `src/server/services/geofenceTimezoneService.ts` | New service (start/stop/runNow/getStatus + check cycle) | +290 |
| `src/server/services/geofenceTimezoneService.test.ts` | 13 vitest tests (all paths covered) | +268 |
| `src/server/constants/settings.ts` | 8 new keys added to `VALID_SETTINGS_KEYS` | +9 |
| `src/server/server.ts` | Service import + startup gate + restart hook | +24 |
| `src/server/routes/settingsRoutes.ts` | `SettingsCallbacks` extension + change-handler | +32 |
| `package.json` / `package-lock.json` | `geo-tz` ^8.1.6 dep | (lock churn) |
| `README.md` | Feature line under "Key Features" | +1 |

Net signal LOC (excluding lock file): **~624 added, ~14 removed**.

## What's NOT in this PR (deliberate)

- **React admin UI** for the new settings — happy to scaffold based on review feedback (`SettingsTab.tsx` extension following the documented `useCallback` dep-array pattern in `CLAUDE.md`).
- **Auto-restart of the server on tz change** — the harder design question. Current `TZ` env is startup-only in this architecture. Open design space:
  1. Use Node's `process.env.TZ = newTz` and accept that already-running `setInterval`/`setTimeout` schedules don't pick it up
  2. Trigger an internal restart via `process.exit(0)` and rely on container/PM2 restart policy
  3. Keep TZ env-only and just persist the detection so the operator/orchestrator can apply it on next deploy
  Option 3 is what this PR does. I think it's the right minimal foundation.

## Tests

13 new tests in `src/server/services/geofenceTimezoneService.test.ts`:

- No-op when disabled (default off)
- No-op when no source node configured
- No-op when source node not found in DB
- No-op when source node has no GPS yet
- First-run detection writes detected tz + position
- Debounce: small movement below threshold doesn't update state
- Distance trigger: > threshold causes re-detection (Phoenix → Albuquerque)
- TZ-change trigger fires even when distance is below threshold (boundary crossing)
- Graceful tz-lookup failure
- `start()` / `stop()` lifecycle
- `start()` is idempotent
- Haversine sanity: Phoenix → Albuquerque ~330 mi
- Haversine sanity: NYC → LA ~2450 mi

All pass under `npx vitest run`. Full suite (4696 tests) also green.

## Backwards compat

**Default OFF — zero behavior change unless the operator explicitly enables `geofenceTzEnabled`.** No schema migration, no new tables. New settings keys are append-only additions to `VALID_SETTINGS_KEYS`.

## Maintainer-respect notes

This is filed as **DRAFT** to respect the design-alignment-first workflow in `CLAUDE.md`. Happy to:
- Iterate on naming/structure based on review (`geofenceTz*` prefix vs. `autoTimezone*` vs. something else)
- Scope the UI follow-up however makes sense (`SettingsTab` extension vs. dedicated panel)
- Revise the design entirely if there's a better fit — e.g. driving off Virtual Node position instead of a designated source node
- Add an API route (`POST /api/services/geofence-tz/run-now`, `GET /api/services/geofence-tz/status`) if that pattern is preferred over implicit restart-on-settings-change

## Reference implementation

A working personal-deployment version (Python single-script that polls + restarts the docker container) has been running on the contributor's mobile node for several weeks. This PR ports the algorithm into the upstream architecture rather than asking operators to bolt on a host-level cron.
