### PR TITLE
fix(scripts): resolve interpreter from PATH in desktop builds

### DIFF
--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -314,7 +314,8 @@ class MeshCoreManager extends EventEmitter {
 
     logger.info(`[MeshCore] Starting Python bridge: ${bridgeScript}`);
 
-    const pythonPath = process.env.NODE_ENV !== 'production' ? 'python3' : '/opt/apprise-venv/bin/python3';
+    const useSystemBin = process.env.NODE_ENV !== 'production' || process.env.IS_DESKTOP === 'true';
+    const pythonPath = useSystemBin ? 'python3' : '/opt/apprise-venv/bin/python3';
     this.bridgeProcess = spawn(pythonPath, [bridgeScript], {
       stdio: ['pipe', 'pipe', 'pipe'],
     });

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -2370,12 +2370,12 @@ class MeshtasticManager implements ISourceManager {
 
     const ext = scriptPath.split('.').pop()?.toLowerCase();
     let interpreter: string;
-    const isDev = process.env.NODE_ENV !== 'production';
+    const useSystemBin = process.env.NODE_ENV !== 'production' || process.env.IS_DESKTOP === 'true';
 
     switch (ext) {
-      case 'js': case 'mjs': interpreter = isDev ? 'node' : '/usr/local/bin/node'; break;
-      case 'py': interpreter = isDev ? 'python' : '/opt/apprise-venv/bin/python3'; break;
-      case 'sh': interpreter = isDev ? 'sh' : '/bin/sh'; break;
+      case 'js': case 'mjs': interpreter = useSystemBin ? 'node' : '/usr/local/bin/node'; break;
+      case 'py': interpreter = useSystemBin ? 'python3' : '/opt/apprise-venv/bin/python3'; break;
+      case 'sh': interpreter = useSystemBin ? 'sh' : '/bin/sh'; break;
       default:
         await this.updateGeofenceTriggerResult(trigger.id, 'error', `Unsupported script extension: ${ext}`);
         return;
@@ -2629,18 +2629,18 @@ class MeshtasticManager implements ISourceManager {
     // Determine interpreter based on file extension
     const ext = scriptPath.split('.').pop()?.toLowerCase();
     let interpreter: string;
-    const isDev = process.env.NODE_ENV !== 'production';
+    const useSystemBin = process.env.NODE_ENV !== 'production' || process.env.IS_DESKTOP === 'true';
 
     switch (ext) {
       case 'js':
       case 'mjs':
-        interpreter = isDev ? 'node' : '/usr/local/bin/node';
+        interpreter = useSystemBin ? 'node' : '/usr/local/bin/node';
         break;
       case 'py':
-        interpreter = isDev ? 'python' : '/opt/apprise-venv/bin/python3';
+        interpreter = useSystemBin ? 'python3' : '/opt/apprise-venv/bin/python3';
         break;
       case 'sh':
-        interpreter = isDev ? 'sh' : '/bin/sh';
+        interpreter = useSystemBin ? 'sh' : '/bin/sh';
         break;
       default:
         logger.error(`⏱️ Unsupported script extension for timer "${triggerName}": ${ext}`);
@@ -8777,20 +8777,20 @@ class MeshtasticManager implements ISourceManager {
             const ext = scriptPath.split('.').pop()?.toLowerCase();
             let interpreter: string;
 
-            // In development, use system interpreters (node, python, sh)
-            // In production, use absolute paths
-            const isDev = process.env.NODE_ENV !== 'production';
+            // In development or desktop, use system interpreters from PATH
+            // In Docker production, use absolute paths to bundled binaries
+            const useSystemBin = process.env.NODE_ENV !== 'production' || process.env.IS_DESKTOP === 'true';
 
             switch (ext) {
               case 'js':
               case 'mjs':
-                interpreter = isDev ? 'node' : '/usr/local/bin/node';
+                interpreter = useSystemBin ? 'node' : '/usr/local/bin/node';
                 break;
               case 'py':
-                interpreter = isDev ? 'python' : '/opt/apprise-venv/bin/python3';
+                interpreter = useSystemBin ? 'python3' : '/opt/apprise-venv/bin/python3';
                 break;
               case 'sh':
-                interpreter = isDev ? 'sh' : '/bin/sh';
+                interpreter = useSystemBin ? 'sh' : '/bin/sh';
                 break;
               default:
                 logger.error(`🚫 Unsupported script extension: ${ext}`);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9456,18 +9456,18 @@ apiRouter.post('/scripts/test', requirePermission('settings', 'read'), async (re
     const ext = script.split('.').pop()?.toLowerCase();
     let interpreter: string;
 
-    const isDev = process.env.NODE_ENV !== 'production';
+    const useSystemBin = process.env.NODE_ENV !== 'production' || process.env.IS_DESKTOP === 'true';
 
     switch (ext) {
       case 'js':
       case 'mjs':
-        interpreter = isDev ? 'node' : '/usr/local/bin/node';
+        interpreter = useSystemBin ? 'node' : '/usr/local/bin/node';
         break;
       case 'py':
-        interpreter = isDev ? 'python' : '/opt/apprise-venv/bin/python3';
+        interpreter = useSystemBin ? 'python3' : '/opt/apprise-venv/bin/python3';
         break;
       case 'sh':
-        interpreter = isDev ? 'sh' : '/bin/sh';
+        interpreter = useSystemBin ? 'sh' : '/bin/sh';
         break;
       default:
         return res.status(400).json({ error: `Unsupported script extension: ${ext}` });


### PR DESCRIPTION
## Summary

Fixes `spawn /opt/apprise-venv/bin/python3 ENOENT` when running the **Test** action on a Python script in the macOS Desktop build.

Script execution (Test endpoint at `server.ts:9459`, geofence/timer/message-trigger paths in `meshtasticManager.ts`) and the MeshCore Python bridge (`meshcoreManager.ts:317`) hardcoded the Docker venv path `/opt/apprise-venv/bin/python3` and `/usr/local/bin/node` whenever `NODE_ENV=production`. Desktop ships no Docker venv, so spawn failed.

Now: when `IS_DESKTOP=true` (set by the Tauri sidecar at `desktop/src-tauri/src/lib.rs:194`), interpreters resolve from `PATH` (`python3`, `node`, `sh`). Docker container behavior is unchanged — only the desktop branch is added.

## Sites updated
- `src/server/server.ts:9459` — script Test endpoint (the one user hit)
- `src/server/meshtasticManager.ts:2373` — geofence trigger
- `src/server/meshtasticManager.ts:2632` — timer trigger
- `src/server/meshtasticManager.ts:8782` — message-pattern trigger
- `src/server/meshcoreManager.ts:317` — MeshCore Python bridge

## Test plan
- [ ] Mac Desktop: open Scripts settings → Test a `.py` script → verify it runs (no ENOENT)
- [ ] Mac Desktop: Test a `.sh` script → runs
- [ ] Mac Desktop: Test a `.js` script → runs
- [ ] Docker container: smoke-check Test on a `.py` script still uses bundled venv (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)