### PR TITLE
fix(auto-responder): prevent triple-send when target ACK arrives late

### DIFF
--- a/src/server/messageQueueService.test.ts
+++ b/src/server/messageQueueService.test.ts
@@ -137,17 +137,39 @@ describe('MessageQueueService', () => {
       await vi.advanceTimersByTimeAsync(0);
       expect(sentMessages).toHaveLength(1);
 
-      // Second attempt (after 30s)
-      await vi.advanceTimersByTimeAsync(30000);
+      // Second attempt (after 90s retry interval)
+      await vi.advanceTimersByTimeAsync(90000);
       expect(sentMessages).toHaveLength(2);
 
-      // Third attempt (after another 30s)
-      await vi.advanceTimersByTimeAsync(30000);
+      // Third attempt (after another 90s)
+      await vi.advanceTimersByTimeAsync(90000);
       expect(sentMessages).toHaveLength(3);
 
       // No fourth attempt - max 3 attempts reached
-      await vi.advanceTimersByTimeAsync(30000);
+      await vi.advanceTimersByTimeAsync(90000);
       expect(sentMessages).toHaveLength(3);
+    });
+
+    it('should clear retries when a late ACK arrives on a prior attempt', async () => {
+      const successCallback = vi.fn();
+      messageQueueService.enqueue('Test message', 12345678, undefined, successCallback);
+
+      // First attempt at T=0 with requestId 1000
+      await vi.advanceTimersByTimeAsync(0);
+      expect(sentMessages).toHaveLength(1);
+
+      // Second attempt at T=90s with requestId 1001 (target ACK on 1000 still hasn't arrived)
+      await vi.advanceTimersByTimeAsync(90000);
+      expect(sentMessages).toHaveLength(2);
+
+      // Late ACK arrives for the FIRST attempt (requestId 1000) — should still
+      // resolve the message and prevent the third attempt.
+      messageQueueService.handleAck(1000);
+      expect(successCallback).toHaveBeenCalledTimes(1);
+
+      // Advance past where the third attempt would have fired — no new send.
+      await vi.advanceTimersByTimeAsync(90000);
+      expect(sentMessages).toHaveLength(2);
     });
 
     it('should call failure callback after max retries without ACK', async () => {
@@ -156,16 +178,16 @@ describe('MessageQueueService', () => {
 
       // Send all 3 attempts without ACK
       await vi.advanceTimersByTimeAsync(0);     // attempt 1 at T
-      await vi.advanceTimersByTimeAsync(30000); // attempt 2 at T+30s
-      await vi.advanceTimersByTimeAsync(30000); // attempt 3 at T+60s
+      await vi.advanceTimersByTimeAsync(90000); // attempt 2 at T+90s
+      await vi.advanceTimersByTimeAsync(90000); // attempt 3 at T+180s
 
       // After final attempt, still waiting for ACK
       expect(failureCallback).not.toHaveBeenCalled();
 
-      // pendingAckSince is T+60s (updated on last attempt). Cleanup runs every 60s.
+      // pendingAckSince is T+180s (updated on last attempt). Cleanup runs every 60s.
       // Need cleanup fire where age > 5 minutes (300000ms).
-      // At T+420s (7 min): age = 420000-60000 = 360000 > 300000 → cleanup fires.
-      // From T+60s, advance 360s to reach T+420s.
+      // At T+540s (9 min): age = 540000-180000 = 360000 > 300000 → cleanup fires.
+      // From T+180s, advance 360s to reach T+540s.
       await vi.advanceTimersByTimeAsync(360000);
 
       expect(failureCallback).toHaveBeenCalledTimes(1);
@@ -206,7 +228,7 @@ describe('MessageQueueService', () => {
       expect(sentMessages).toHaveLength(0);
 
       // Second attempt succeeds (message stays in queue after failed first attempt)
-      await vi.advanceTimersByTimeAsync(30000);
+      await vi.advanceTimersByTimeAsync(90000);
       expect(sentMessages).toHaveLength(1);
     });
 
@@ -219,8 +241,8 @@ describe('MessageQueueService', () => {
 
       // All 3 attempts fail
       await vi.advanceTimersByTimeAsync(0);
-      await vi.advanceTimersByTimeAsync(30000);
-      await vi.advanceTimersByTimeAsync(30000);
+      await vi.advanceTimersByTimeAsync(90000);
+      await vi.advanceTimersByTimeAsync(90000);
 
       expect(failureCallback).toHaveBeenCalledTimes(1);
       expect(failureCallback.mock.calls[0][0]).toContain('Send error after 3 attempts');
@@ -235,8 +257,8 @@ describe('MessageQueueService', () => {
       await vi.advanceTimersByTimeAsync(0);
 
       // Should retry due to error
-      await vi.advanceTimersByTimeAsync(30000);
-      await vi.advanceTimersByTimeAsync(30000);
+      await vi.advanceTimersByTimeAsync(90000);
+      await vi.advanceTimersByTimeAsync(90000);
 
       expect(failureCallback).toHaveBeenCalled();
     });

--- a/src/server/messageQueueService.ts
+++ b/src/server/messageQueueService.ts
@@ -21,6 +21,11 @@ export interface QueuedMessage {
   enqueuedAt: number;
   lastAttemptAt?: number;
   requestId?: number; // The message ID from the last send attempt
+  // Every requestId this message has used (current + all prior retries). Late
+  // ACKs on a prior attempt's requestId still satisfy the message, so we keep
+  // every attempt's id mapped to the same message in pendingAcks until it
+  // resolves (or the orphan-cleanup timeout expires).
+  priorRequestIds?: number[];
   pendingAckSince?: number; // Timestamp when added to pendingAcks (for cleanup)
   onSuccess?: () => void;
   onFailure?: (reason: string) => void;
@@ -31,7 +36,12 @@ export class MessageQueueService {
   private processing = false;
   private lastSendTime = 0;
   private readonly SEND_INTERVAL_MS = 30000; // 30 seconds between sends
-  private readonly RETRY_INTERVAL_MS = 30000; // 30 seconds between retry attempts
+  // Mesh ACK round-trip on LongFast with multi-hop + channel utilization
+  // routinely exceeds 30s. A 30s retry interval caused every verifyResponse=true
+  // DM auto-response to fire all 3 attempts even when the target ACK eventually
+  // arrived. 90s gives the firmware/mesh time to deliver the ACK before we
+  // assume failure and retransmit.
+  private readonly RETRY_INTERVAL_MS = 90000;
   private readonly MAX_ATTEMPTS = 3;
   private readonly PENDING_ACK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes - cleanup orphaned ACKs
 
@@ -154,13 +164,18 @@ export class MessageQueueService {
   private cleanupOrphanedAcks() {
     const now = Date.now();
     let cleanedCount = 0;
+    // Dedupe by message.id since retried messages have multiple requestIds
+    // mapped to the same QueuedMessage in pendingAcks.
+    const seen = new Set<string>();
 
     for (const [requestId, message] of this.pendingAcks.entries()) {
+      if (seen.has(message.id)) continue;
       if (message.pendingAckSince) {
         const age = now - message.pendingAckSince;
         if (age > this.PENDING_ACK_TIMEOUT_MS) {
+          seen.add(message.id);
           logger.warn(`🧹 Cleaning up orphaned ACK for message ${message.id} (requestId: ${requestId}, age: ${Math.round(age / 1000)}s)`);
-          this.pendingAcks.delete(requestId);
+          this.deleteAllRequestIds(message);
 
           // Call failure callback if present with error handling
           if (message.onFailure) {
@@ -242,7 +257,13 @@ export class MessageQueueService {
    * Find a message that needs retry
    */
   private findMessageForRetry(now: number): QueuedMessage | null {
+    // pendingAcks may map several requestIds to the same QueuedMessage when
+    // retries created additional ids; dedupe by message.id so we don't retry
+    // the same message twice on a single tick.
+    const seen = new Set<string>();
     for (const message of this.pendingAcks.values()) {
+      if (seen.has(message.id)) continue;
+      seen.add(message.id);
       if (message.attempts < message.maxAttempts) {
         const timeSinceLastAttempt = now - (message.lastAttemptAt || 0);
         if (timeSinceLastAttempt >= this.RETRY_INTERVAL_MS) {
@@ -251,6 +272,22 @@ export class MessageQueueService {
       }
     }
     return null;
+  }
+
+  /**
+   * Remove every requestId associated with this message from pendingAcks.
+   * Used when an ACK/failure resolves the message — late ACKs on prior
+   * retry attempts must clear the queue entry instead of being ignored.
+   */
+  private deleteAllRequestIds(message: QueuedMessage) {
+    if (message.requestId !== undefined) {
+      this.pendingAcks.delete(message.requestId);
+    }
+    if (message.priorRequestIds) {
+      for (const oldId of message.priorRequestIds) {
+        this.pendingAcks.delete(oldId);
+      }
+    }
   }
 
   /**
@@ -279,9 +316,13 @@ export class MessageQueueService {
         throw new Error(`Invalid requestId returned: ${requestId}`);
       }
 
-      // Clean up old pendingAcks entry from previous attempt (retry case)
-      if (message.requestId) {
-        this.pendingAcks.delete(message.requestId);
+      // Keep the prior attempt's requestId mapped in pendingAcks so a late ACK
+      // on it still resolves the message instead of being dropped.
+      if (message.requestId !== undefined && message.requestId !== requestId) {
+        if (!message.priorRequestIds) message.priorRequestIds = [];
+        if (!message.priorRequestIds.includes(message.requestId)) {
+          message.priorRequestIds.push(message.requestId);
+        }
       }
 
       message.requestId = requestId;
@@ -328,8 +369,9 @@ export class MessageQueueService {
   handleAck(requestId: number) {
     const message = this.pendingAcks.get(requestId);
     if (message) {
-      logger.info(`✅ ACK received for message ${message.id} (requestId: ${requestId})`);
-      this.pendingAcks.delete(requestId);
+      const isLateAck = message.requestId !== requestId;
+      logger.info(`✅ ACK received for message ${message.id} (requestId: ${requestId}${isLateAck ? ', late ACK on prior attempt' : ''})`);
+      this.deleteAllRequestIds(message);
 
       // Call success callback with error handling
       if (message.onSuccess) {
@@ -360,10 +402,8 @@ export class MessageQueueService {
     // Remove from queue if still there
     this.removeFromQueue(message);
 
-    // Remove from pending ACKs if there
-    if (message.requestId) {
-      this.pendingAcks.delete(message.requestId);
-    }
+    // Remove every requestId associated with this message from pendingAcks
+    this.deleteAllRequestIds(message);
 
     // Call failure callback with error handling
     if (message.onFailure) {


### PR DESCRIPTION
## Summary

DM auto-responses (and script responses) with `verifyResponse=true` were always shipping all 3 retries even when the recipient successfully received the message. Two compounding bugs:

1. `RETRY_INTERVAL_MS = 30s` is shorter than typical mesh ACK round-trip on LongFast (multi-hop + channel utilization).
2. Each retry **deleted** the prior attempt's `requestId` from `pendingAcks`, so the eventual target ACK arrived for an orphaned id and was silently dropped.

Result: every verified DM auto-response sent 3 copies even on success.

## Changes

`src/server/messageQueueService.ts`:
- Bumped `RETRY_INTERVAL_MS` 30s → 90s with comment explaining why.
- Added `priorRequestIds?: number[]` on `QueuedMessage`. On retry, the previous attempt's id is appended and **kept** in `pendingAcks` — late ACKs on it still resolve the message.
- New `deleteAllRequestIds(message)` helper used by `handleAck` / `handleFailure` / `failMessage` / `cleanupOrphanedAcks`.
- `findMessageForRetry` and `cleanupOrphanedAcks` dedupe by `message.id` since the same `QueuedMessage` is now mapped under multiple keys.

## Test plan

- [x] Unit tests updated for 90s retry cadence (`messageQueueService.test.ts`)
- [x] New regression test: `should clear retries when a late ACK arrives on a prior attempt`
- [x] Full unit suite: 4684 / 4684 pass
- [x] `tsc --noEmit` clean
- [ ] Verify on dev container with auto-responder + verifyResponse trigger that ACK from target node now stops retries

## Source-aware verification

Confirmed ACK/retry mechanism is per-source: each `MeshtasticManager` instantiates its own `MessageQueueService` (`meshtasticManager.ts:516`); enqueue / handleAck / handleFailure / sendCallback all route through `this.messageQueue` for the correct source. The singleton at `messageQueueService.ts:455` is only used by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)