### PR TITLE
fix(notifications): skip traceroute messages in WS cache to stop spurious chime

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -103,6 +103,16 @@ export function useWebSocket(enabled: boolean = true): WebSocketState {
   // Helper to add a new message to the cache
   // Messages are ordered newest-first, so new messages go at the beginning
   const addMessageToCache = useCallback((message: RawMessage) => {
+    // Skip traceroute messages — the /api/poll endpoint excludes them from
+    // `messages` (they live in `pollData.traceroutes` instead, refreshed on
+    // `traceroute:complete`). Inserting them here causes them to briefly
+    // become messages[0]; the next poll then evicts them, which makes the
+    // newest-message-id tracker in App.tsx think the previously-seen text
+    // message at the new messages[0] is "new" and play the chime. (#2867)
+    if (message.portnum === 70 /* TRACEROUTE_APP */) {
+      return;
+    }
+
     const key = sourcePollQueryKey(sourceId);
     queryClient.setQueryData<PollData>(key, (old) => {
       if (!old) {


### PR DESCRIPTION
## Summary

Closes #2867 (still-open follow-up reports). Even after the previous push-notification fix, users on v4.1.1 / v4.2.0 were still hearing the in-app chime on every traceroute completion.

## Root cause

Race between `addMessageToCache` (WS) and `/api/poll` filtering:

1. Traceroute response arrives → backend stores it (`portnum: 70`) and emits `message:new` over WS.
2. `addMessageToCache` (`src/hooks/useWebSocket.ts:105`) prepends it to `pollData.messages`. Cache now has the traceroute at `messages[0]`.
3. `processPollData` (`App.tsx:2438`) updates `newestMessageId.current` to the traceroute's id. The portnum check correctly skips the chime here.
4. The `traceroute:complete` event invalidates the query → refetch.
5. `/api/poll` filters out `portnum=70` (`server.ts:4555`), so `messages[0]` reverts to the previously-seen text message.
6. `processPollData` sees `currentNewestId !== newestMessageId.current` again, but now `messages[0]` IS a text message (`portnum=1`) — chime fires for a stale message.

## Fix

Skip traceroute messages (`portnum === 70`) in `addMessageToCache`. This matches the server-side filter behavior: `pollData.messages` never contains traceroutes, the `traceroute:complete` event already refreshes `pollData.traceroutes` via query invalidation, so traceroutes never need to enter the messages cache.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full unit suite: 4684 / 4684 pass
- [ ] Manual verification with auto-traceroute enabled — confirm no chime on completion, normal text-message chime still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)