### PR TITLE
fix(messages): unread-count scoping + stuck mark-as-read on SQLite

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1765,7 +1765,12 @@ function App() {
     }
   }, [isScrolledNearBottom, isScrolledNearTop, loadMoreDirectMessages]);
 
-  // Attach scroll event listeners
+  // Attach scroll event listeners. The handler closures are stable now (they
+  // read state via refs), so we re-run this effect when navigation could have
+  // swapped the underlying DOM node — channel switch, DM switch, or tab
+  // switch — to be sure we attach to the freshly mounted container. Without
+  // this the very first scroll on the initial channel never fires the
+  // load-more handler.
   useEffect(() => {
     const channelContainer = channelMessagesContainerRef.current;
     const dmContainer = dmMessagesContainerRef.current;
@@ -1785,7 +1790,7 @@ function App() {
         dmContainer.removeEventListener('scroll', handleDMScroll);
       }
     };
-  }, [handleChannelScroll, handleDMScroll]);
+  }, [handleChannelScroll, handleDMScroll, activeTab, selectedChannel, selectedDMNode]);
 
   // Force scroll to bottom when channel changes OR when switching to channels tab
   // Note: We track initial scroll per channel to avoid re-scrolling when user manually scrolls

--- a/src/contexts/MessagingContext.tsx
+++ b/src/contexts/MessagingContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useCallback, ReactNode } fr
 import { MeshMessage } from '../types/message';
 import { useUnreadCounts, useMarkAsRead } from '../hooks/useUnreadCounts';
 import { useAuth } from './AuthContext';
+import { useSource } from './SourceContext';
 
 interface UnreadCounts {
   channels: { [channelId: number]: number };
@@ -41,6 +42,9 @@ interface MessagingProviderProps {
 export const MessagingProvider: React.FC<MessagingProviderProps> = ({ children, baseUrl = '' }) => {
   const { authStatus } = useAuth();
   const isAuthenticated = authStatus?.authenticated || false;
+  // Scope unread counts to the current source so per-source tabs don't show
+  // badges for messages other sources received but the current source did not.
+  const { sourceId } = useSource();
 
   const [selectedDMNode, setSelectedDMNode] = useState<string>('');
   const [selectedChannel, setSelectedChannel] = useState<number>(-1);
@@ -55,6 +59,7 @@ export const MessagingProvider: React.FC<MessagingProviderProps> = ({ children, 
   const { data: unreadCountsData, refetch: refetchUnreadCounts } = useUnreadCounts({
     baseUrl,
     enabled: isAuthenticated,
+    sourceId,
   });
   const { mutateAsync: markAsReadMutation } = useMarkAsRead({ baseUrl });
 

--- a/src/db/repositories/notifications.ts
+++ b/src/db/repositories/notifications.ts
@@ -7,7 +7,7 @@
  *
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, desc, sql, and, or, lte, isNull, ne } from 'drizzle-orm';
+import { eq, desc, sql, and, or, lte, isNull, ne, type SQL } from 'drizzle-orm';
 import {
   readMessagesSqlite,
 } from '../schema/notifications.js';
@@ -771,15 +771,17 @@ export class NotificationsRepository extends BaseRepository {
    */
   async getUnreadCountsByChannelAsync(
     userId: number | null,
-    localNodeId?: string
+    localNodeId?: string,
+    sourceId?: string
   ): Promise<{ [channelId: number]: number }> {
     const messages = this.tables.messages;
     const readMessages = this.tables.readMessages;
 
-    const conditions = [
+    const conditions: (SQL | undefined)[] = [
       isNull(readMessages.messageId),
       ne(messages.channel, -1),
       eq(messages.portnum, 1),
+      this.withSourceScope(messages, sourceId),
     ];
     if (localNodeId) {
       conditions.push(ne(messages.fromNodeId, localNodeId));
@@ -813,7 +815,8 @@ export class NotificationsRepository extends BaseRepository {
   async getUnreadDMCountAsync(
     localNodeId: string,
     remoteNodeId: string,
-    userId: number | null
+    userId: number | null,
+    sourceId?: string
   ): Promise<number> {
     const messages = this.tables.messages;
     const readMessages = this.tables.readMessages;
@@ -829,7 +832,8 @@ export class NotificationsRepository extends BaseRepository {
             eq(messages.portnum, 1),
             eq(messages.channel, -1),
             eq(messages.fromNodeId, remoteNodeId),
-            eq(messages.toNodeId, localNodeId)
+            eq(messages.toNodeId, localNodeId),
+            this.withSourceScope(messages, sourceId)
           )
         );
       return Number(rows[0]?.count ?? 0);
@@ -845,7 +849,8 @@ export class NotificationsRepository extends BaseRepository {
    */
   async getBatchUnreadDMCountsAsync(
     localNodeId: string,
-    userId: number | null
+    userId: number | null,
+    sourceId?: string
   ): Promise<{ [fromNodeId: string]: number }> {
     const messages = this.tables.messages;
     const readMessages = this.tables.readMessages;
@@ -863,7 +868,8 @@ export class NotificationsRepository extends BaseRepository {
             isNull(readMessages.messageId),
             eq(messages.portnum, 1),
             eq(messages.channel, -1),
-            eq(messages.toNodeId, localNodeId)
+            eq(messages.toNodeId, localNodeId),
+            this.withSourceScope(messages, sourceId)
           )
         )
         .groupBy(messages.fromNodeId);

--- a/src/hooks/useUnreadCounts.ts
+++ b/src/hooks/useUnreadCounts.ts
@@ -29,6 +29,8 @@ interface UseUnreadCountsOptions {
   enabled?: boolean;
   /** Refetch interval in milliseconds (default: 10000) */
   refetchInterval?: number;
+  /** Optional source scope — when set, counts are filtered to this source */
+  sourceId?: string | null;
 }
 
 /**
@@ -55,11 +57,15 @@ export function useUnreadCounts({
   baseUrl = '',
   enabled = true,
   refetchInterval = 10000,
+  sourceId = null,
 }: UseUnreadCountsOptions = {}) {
   return useQuery({
-    queryKey: ['unreadCounts', baseUrl],
+    queryKey: ['unreadCounts', baseUrl, sourceId],
     queryFn: async (): Promise<UnreadCountsData> => {
-      const response = await fetch(`${baseUrl}/api/messages/unread-counts`, {
+      const url = sourceId
+        ? `${baseUrl}/api/messages/unread-counts?sourceId=${encodeURIComponent(sourceId)}`
+        : `${baseUrl}/api/messages/unread-counts`;
+      const response = await fetch(url, {
         credentials: 'include',
       });
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2344,7 +2344,17 @@ apiRouter.get('/messages/unread-counts', optionalAuth(), async (req, res) => {
     }
 
     const userId = req.user?.id ?? null;
-    const localNodeInfo = meshtasticManager.getLocalNodeInfo();
+    // Optional sourceId scoping — multi-source views must only see unread
+    // counts for messages their own source ingested. Without this an inactive
+    // source can keep a badge lit for messages that aren't visible in the
+    // current source's tab.
+    const unreadSourceId = typeof req.query.sourceId === 'string' && req.query.sourceId.length > 0
+      ? req.query.sourceId
+      : undefined;
+    const unreadManager = unreadSourceId
+      ? (sourceManagerRegistry.getManager(unreadSourceId) as typeof meshtasticManager ?? meshtasticManager)
+      : meshtasticManager;
+    const localNodeInfo = unreadManager.getLocalNodeInfo();
 
     const result: {
       channels?: { [channelId: number]: number };
@@ -2375,7 +2385,7 @@ apiRouter.get('/messages/unread-counts', optionalAuth(), async (req, res) => {
     // Get channel unread counts if user has channels permission
     // Only count incoming messages (exclude messages sent by our node)
     if (hasChannelsRead) {
-      const rawCounts = await databaseService.getUnreadCountsByChannelAsync(userId, localNodeInfo?.nodeId);
+      const rawCounts = await databaseService.getUnreadCountsByChannelAsync(userId, localNodeInfo?.nodeId, unreadSourceId);
 
       // MM-SEC-3: filter by per-channel read permission as well as mute prefs.
       // The bare `channel_0:read` gate above lets a viewer reach this handler
@@ -2398,8 +2408,8 @@ apiRouter.get('/messages/unread-counts', optionalAuth(), async (req, res) => {
 
     // Get DM unread counts if user has messages permission (batch query)
     if (hasMessagesRead && localNodeInfo) {
-      const allUnreadDMs = await databaseService.getBatchUnreadDMCountsAsync(localNodeInfo.nodeId, userId);
-      const allNodes = await meshtasticManager.getAllNodesAsync();
+      const allUnreadDMs = await databaseService.getBatchUnreadDMCountsAsync(localNodeInfo.nodeId, userId, unreadSourceId);
+      const allNodes = await unreadManager.getAllNodesAsync(unreadSourceId);
       const visibleNodes = await filterNodesByChannelPermission(allNodes, req.user);
       const visibleNodeIds = new Set(visibleNodes.map(n => n.user?.id).filter(Boolean));
       const directMessages: { [nodeId: string]: number } = {};
@@ -4596,8 +4606,11 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
       } = {};
 
       // Get unread counts for all channels first
-      // Only count incoming messages (exclude messages sent by our node)
-      const allUnreadChannels = await databaseService.getUnreadCountsByChannelAsync(userId, localNodeInfo?.nodeId);
+      // Only count incoming messages (exclude messages sent by our node).
+      // Scope to the requesting source so per-source tabs only count messages
+      // their own source ingested (issue: badge stays lit for messages that
+      // aren't visible in the current tab).
+      const allUnreadChannels = await databaseService.getUnreadCountsByChannelAsync(userId, localNodeInfo?.nodeId, pollSourceId);
 
       // Filter channels based on per-channel read permission
       const filteredUnreadChannels: { [channelId: number]: number } = {};
@@ -4614,7 +4627,7 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
 
       // Batch DM unread counts (single query instead of N+1)
       if (hasMessagesRead && localNodeInfo) {
-        const allUnreadDMs = await databaseService.getBatchUnreadDMCountsAsync(localNodeInfo.nodeId, userId);
+        const allUnreadDMs = await databaseService.getBatchUnreadDMCountsAsync(localNodeInfo.nodeId, userId, pollSourceId);
         const visibleNodeIds = new Set(filteredMemoryNodes.map(n => n.user?.id).filter(Boolean));
         const directMessages: { [nodeId: string]: number } = {};
         for (const [nodeId, count] of Object.entries(allUnreadDMs)) {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -7519,9 +7519,10 @@ class DatabaseService {
       return;
     }
 
+    // INSERT OR REPLACE — see markChannelMessagesAsRead for rationale.
     // eslint-disable-next-line no-restricted-syntax -- legacy raw SQL, pending future Drizzle migration batch
     const stmt = this.db.prepare(`
-      INSERT OR IGNORE INTO read_messages (message_id, user_id, read_at)
+      INSERT OR REPLACE INTO read_messages (message_id, user_id, read_at)
       VALUES (?, ?, ?)
     `);
     stmt.run(messageId, userId, Date.now());
@@ -7536,9 +7537,10 @@ class DatabaseService {
       return;
     }
 
+    // INSERT OR REPLACE — see markChannelMessagesAsRead for rationale.
     // eslint-disable-next-line no-restricted-syntax -- legacy raw SQL, pending future Drizzle migration batch
     const stmt = this.db.prepare(`
-      INSERT OR IGNORE INTO read_messages (message_id, user_id, read_at)
+      INSERT OR REPLACE INTO read_messages (message_id, user_id, read_at)
       VALUES (?, ?, ?)
     `);
 
@@ -7579,8 +7581,13 @@ class DatabaseService {
       }
       return 0; // Return 0 since we don't wait for the async result
     }
+    // SQLite read_messages PK is message_id only — using INSERT OR IGNORE
+    // strands rows owned by an earlier user/anonymous session because the
+    // join in unread queries filters by user_id. INSERT OR REPLACE rewrites
+    // the row to the current reader so subsequent unread checks for that
+    // user actually find their read marker.
     let query = `
-      INSERT OR IGNORE INTO read_messages (message_id, user_id, read_at)
+      INSERT OR REPLACE INTO read_messages (message_id, user_id, read_at)
       SELECT id, ?, ? FROM messages
       WHERE channel = ?
         AND portnum = 1
@@ -7615,8 +7622,9 @@ class DatabaseService {
       }
       return 0; // Return 0 since we don't wait for the async result
     }
+    // INSERT OR REPLACE — see markChannelMessagesAsRead for rationale.
     let query = `
-      INSERT OR IGNORE INTO read_messages (message_id, user_id, read_at)
+      INSERT OR REPLACE INTO read_messages (message_id, user_id, read_at)
       SELECT id, ?, ? FROM messages
       WHERE ((fromNodeId = ? AND toNodeId = ?) OR (fromNodeId = ? AND toNodeId = ?))
         AND portnum = 1
@@ -7649,8 +7657,9 @@ class DatabaseService {
       }
       return 0; // Return 0 since we don't wait for the async result
     }
+    // INSERT OR REPLACE — see markChannelMessagesAsRead for rationale.
     const query = `
-      INSERT OR IGNORE INTO read_messages (message_id, user_id, read_at)
+      INSERT OR REPLACE INTO read_messages (message_id, user_id, read_at)
       SELECT id, ?, ? FROM messages
       WHERE (fromNodeId = ? OR toNodeId = ?)
         AND portnum = 1
@@ -7768,15 +7777,18 @@ class DatabaseService {
     return rows.map(row => row.id);
   }
 
-  getUnreadCountsByChannel(userId: number | null, localNodeId?: string): {[channelId: number]: number} {
+  getUnreadCountsByChannel(userId: number | null, localNodeId?: string, sourceId?: string): {[channelId: number]: number} {
     // For PostgreSQL/MySQL, use async method via cache or return empty for sync call
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       // Sync method can't do async DB query - return empty and let caller use async version
       return {};
     }
 
-    // Only count incoming messages (exclude messages sent by our node)
-    const excludeOutgoing = localNodeId ? 'AND m.fromNodeId != ?' : '';
+    // Only count incoming messages (exclude messages sent by our node) and
+    // optionally scope to a single source so multi-source views don't bleed
+    // counts from other sources into this tab.
+    const fromClause = localNodeId ? 'AND m.fromNodeId != ?' : '';
+    const sourceClause = sourceId ? 'AND m.sourceId = ?' : '';
     // eslint-disable-next-line no-restricted-syntax -- legacy raw SQL, pending future Drizzle migration batch
     const stmt = this.db.prepare(`
       SELECT m.channel, COUNT(*) as count
@@ -7785,20 +7797,17 @@ class DatabaseService {
       WHERE rm.message_id IS NULL
         AND m.channel != -1
         AND m.portnum = 1
-        ${excludeOutgoing}
+        ${fromClause}
+        ${sourceClause}
       GROUP BY m.channel
     `);
 
-    let rows: Array<{ channel: number; count: number }>;
-    if (userId === null) {
-      rows = localNodeId
-        ? stmt.all(localNodeId) as Array<{ channel: number; count: number }>
-        : stmt.all() as Array<{ channel: number; count: number }>;
-    } else {
-      rows = localNodeId
-        ? stmt.all(userId, localNodeId) as Array<{ channel: number; count: number }>
-        : stmt.all(userId) as Array<{ channel: number; count: number }>;
-    }
+    const params: any[] = [];
+    if (userId !== null) params.push(userId);
+    if (localNodeId) params.push(localNodeId);
+    if (sourceId) params.push(sourceId);
+
+    const rows = stmt.all(...params) as Array<{ channel: number; count: number }>;
 
     const counts: {[channelId: number]: number} = {};
     rows.forEach(row => {
@@ -7807,7 +7816,7 @@ class DatabaseService {
     return counts;
   }
 
-  getUnreadDMCount(localNodeId: string, remoteNodeId: string, userId: number | null): number {
+  getUnreadDMCount(localNodeId: string, remoteNodeId: string, userId: number | null, sourceId?: string): number {
     // For PostgreSQL/MySQL, return 0 (unread tracking is complex and low priority)
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       return 0;
@@ -7815,6 +7824,7 @@ class DatabaseService {
 
     // Only count incoming DMs (messages FROM remote node TO local node)
     // Exclude outgoing messages (messages FROM local node TO remote node)
+    const sourceClause = sourceId ? 'AND m.sourceId = ?' : '';
     // eslint-disable-next-line no-restricted-syntax -- legacy raw SQL, pending future Drizzle migration batch
     const stmt = this.db.prepare(`
       SELECT COUNT(*) as count
@@ -7825,11 +7835,13 @@ class DatabaseService {
         AND m.channel = -1
         AND m.fromNodeId = ?
         AND m.toNodeId = ?
+        ${sourceClause}
     `);
 
-    const params = userId === null
-      ? [remoteNodeId, localNodeId]
-      : [userId, remoteNodeId, localNodeId];
+    const params: any[] = [];
+    if (userId !== null) params.push(userId);
+    params.push(remoteNodeId, localNodeId);
+    if (sourceId) params.push(sourceId);
 
     const result = stmt.get(...params) as { count: number };
     return Number(result.count);
@@ -7839,38 +7851,39 @@ class DatabaseService {
    * Async version of getUnreadCountsByChannel for PostgreSQL/MySQL.
    * Delegates to NotificationsRepository for Drizzle-based execution on all backends.
    */
-  async getUnreadCountsByChannelAsync(userId: number | null, localNodeId?: string): Promise<{[channelId: number]: number}> {
+  async getUnreadCountsByChannelAsync(userId: number | null, localNodeId?: string, sourceId?: string): Promise<{[channelId: number]: number}> {
     // For SQLite, use sync version (legacy compatibility)
     if (this.drizzleDbType !== 'postgres' && this.drizzleDbType !== 'mysql') {
-      return this.getUnreadCountsByChannel(userId, localNodeId);
+      return this.getUnreadCountsByChannel(userId, localNodeId, sourceId);
     }
     if (!this.notificationsRepo) return {};
-    return this.notificationsRepo.getUnreadCountsByChannelAsync(userId, localNodeId);
+    return this.notificationsRepo.getUnreadCountsByChannelAsync(userId, localNodeId, sourceId);
   }
 
   /**
    * Async version of getUnreadDMCount for PostgreSQL/MySQL.
    * Delegates to NotificationsRepository for Drizzle-based execution on all backends.
    */
-  async getUnreadDMCountAsync(localNodeId: string, remoteNodeId: string, userId: number | null): Promise<number> {
+  async getUnreadDMCountAsync(localNodeId: string, remoteNodeId: string, userId: number | null, sourceId?: string): Promise<number> {
     // For SQLite, use sync version
     if (this.drizzleDbType !== 'postgres' && this.drizzleDbType !== 'mysql') {
-      return this.getUnreadDMCount(localNodeId, remoteNodeId, userId);
+      return this.getUnreadDMCount(localNodeId, remoteNodeId, userId, sourceId);
     }
     if (!this.notificationsRepo) return 0;
-    return this.notificationsRepo.getUnreadDMCountAsync(localNodeId, remoteNodeId, userId);
+    return this.notificationsRepo.getUnreadDMCountAsync(localNodeId, remoteNodeId, userId, sourceId);
   }
 
   /**
    * Get all DM unread counts in a single batch query, grouped by remote node.
    * Returns { [fromNodeId: string]: number } for all nodes with unread DMs.
    */
-  getBatchUnreadDMCounts(localNodeId: string, userId: number | null): { [fromNodeId: string]: number } {
+  getBatchUnreadDMCounts(localNodeId: string, userId: number | null, sourceId?: string): { [fromNodeId: string]: number } {
     // For PostgreSQL/MySQL, return empty (handled by async version)
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       return {};
     }
 
+    const sourceClause = sourceId ? 'AND m.sourceId = ?' : '';
     // eslint-disable-next-line no-restricted-syntax -- legacy raw SQL, pending future Drizzle migration batch
     const stmt = this.db.prepare(`
       SELECT m.fromNodeId, COUNT(*) as count
@@ -7880,12 +7893,14 @@ class DatabaseService {
         AND m.portnum = 1
         AND m.channel = -1
         AND m.toNodeId = ?
+        ${sourceClause}
       GROUP BY m.fromNodeId
     `);
 
-    const params = userId === null
-      ? [localNodeId]
-      : [userId, localNodeId];
+    const params: any[] = [];
+    if (userId !== null) params.push(userId);
+    params.push(localNodeId);
+    if (sourceId) params.push(sourceId);
 
     const rows = stmt.all(...params) as { fromNodeId: string; count: number }[];
     const result: { [fromNodeId: string]: number } = {};
@@ -7899,13 +7914,13 @@ class DatabaseService {
    * Async version of getBatchUnreadDMCounts for PostgreSQL/MySQL support.
    * Delegates to NotificationsRepository for Drizzle-based execution on all backends.
    */
-  async getBatchUnreadDMCountsAsync(localNodeId: string, userId: number | null): Promise<{ [fromNodeId: string]: number }> {
+  async getBatchUnreadDMCountsAsync(localNodeId: string, userId: number | null, sourceId?: string): Promise<{ [fromNodeId: string]: number }> {
     // For SQLite, use sync version
     if (this.drizzleDbType !== 'postgres' && this.drizzleDbType !== 'mysql') {
-      return this.getBatchUnreadDMCounts(localNodeId, userId);
+      return this.getBatchUnreadDMCounts(localNodeId, userId, sourceId);
     }
     if (!this.notificationsRepo) return {};
-    return this.notificationsRepo.getBatchUnreadDMCountsAsync(localNodeId, userId);
+    return this.notificationsRepo.getBatchUnreadDMCountsAsync(localNodeId, userId, sourceId);
   }
 
   cleanupOldReadMessages(days: number): number {


### PR DESCRIPTION
## Summary

Three bugs surfaced together while debugging a "Primary shows 14 unread that won't clear" report on a multi-source SQLite deployment.

### 1. Unread counts ignored `sourceId` (multi-source leak)
`/api/messages/unread-counts` and the unread sections of `/api/poll` counted unread messages across every source, but the messages payload they returned was source-scoped. Source A's tab kept a badge lit for unread messages that lived only on Source B — invisible in Source A's view, so the user couldn't clear them.

Threaded `sourceId` end-to-end:
- `useUnreadCounts` hook accepts `sourceId`, includes it in the query key + URL.
- `MessagingContext` reads `useSource().sourceId` and passes it through.
- `/api/messages/unread-counts` reads `req.query.sourceId` and uses the per-source manager's `localNodeInfo` so "exclude our own outgoing messages" is correct for the active source.
- `/api/poll` passes `pollSourceId` through.
- `notifications.ts` (`getUnreadCountsByChannelAsync`, `getUnreadDMCountAsync`, `getBatchUnreadDMCountsAsync`) take optional `sourceId` and apply `withSourceScope`.
- `database.ts` SQLite sync paths take optional `sourceId` and append `AND m.sourceId = ?`.

### 2. SQLite mark-as-read returned `marked: 0`
`read_messages` has `message_id` as the **sole** primary key on SQLite, so once a stale row existed for a message (an earlier anonymous session, or a different user), `INSERT OR IGNORE` silently no-op'd every subsequent insert. The authenticated user's unread query joins on `(message_id, user_id)`, so their read row never appeared and the count stayed stuck forever.

Switched all four SQLite raw-SQL mark-read paths in `database.ts` (`markMessageAsRead`, `markMessagesAsRead`, `markChannelMessagesAsRead`, `markDMMessagesAsRead`, `markAllDMMessagesAsRead`) from `INSERT OR IGNORE` to `INSERT OR REPLACE` so the latest reader's `user_id` overwrites the row. PG/MySQL paths already handle multi-user correctly via `NOT EXISTS`.

### 3. Scroll listener didn't re-bind on first navigation
The earlier stale-closure fix (#2930) narrowed the load-more callback deps, which left the scroll-listener `useEffect` unable to re-run when the user landed on Primary — the listener was attached at mount with a null ref and only re-attached after the user switched channels. Added `activeTab`, `selectedChannel`, `selectedDMNode` to that effect's deps so the listener re-binds whenever the underlying container could have swapped.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Targeted vitest suites green (`src/services/database.unread.test.ts`, `src/server/server.poll.test.ts`, all repos & database tests — 650+ tests)
- [x] User verified in dev container: Primary's stuck unread badge clears, Primary infinite-scroll works on first scroll, multi-source unread counts no longer leak across tabs
- [ ] CI: full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)