### PR TITLE
fix(traceroute): stop cascading IP-style across radio segments (#2931)

### DIFF
--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -492,9 +492,14 @@ export function useTraceroutePaths({
       const node1 = nodesPositionDigest.find(n => n.nodeNum === segment.nodeNums[0]);
       const node2 = nodesPositionDigest.find(n => n.nodeNum === segment.nodeNums[1]);
 
-      // Check if this segment traversed MQTT: either SNR sentinel or either endpoint is an MQTT node
-      const isMqttSegment = (segmentHasMqtt.get(segmentKey) || false) ||
-        (node1?.viaMqtt === true) || (node2?.viaMqtt === true);
+      // A segment is MQTT/IP only when the firmware reported the unknown-SNR
+      // sentinel for that specific hop (issue #2931). Don't infer from
+      // `node.viaMqtt` — that flag tracks how the node's own NodeInfo last
+      // reached us, not how its radio segments work; a single MQTT/UDP
+      // bridge node would otherwise mark every adjacent segment as IP and
+      // cascade the dashed style across an entire route that's actually
+      // mostly radio.
+      const isMqttSegment = segmentHasMqtt.get(segmentKey) === true;
       const node1Name =
         segment.nodeNums[0] === BROADCAST_ADDR
           ? '(unknown)'


### PR DESCRIPTION
## Summary

Fixes #2931. A single UDP/MQTT bridge node in a traceroute was forcing every adjacent segment — and often the entire route — to render as dashed-blue IP, even when the firmware reported real radio SNR for those hops.

## Root cause

`src/hooks/useTraceroutePaths.tsx` decided "is this segment IP/MQTT?" with:

\`\`\`ts
const isMqttSegment = (segmentHasMqtt.get(segmentKey) || false) ||
  (node1?.viaMqtt === true) || (node2?.viaMqtt === true);
\`\`\`

`node.viaMqtt` only tracks how that node's own NodeInfo packet last reached us, not how its radio segments work. A UDP-bridge node B in path A→B→C inherited the IP style onto both A-B and B-C segments. With multiple bridge-flagged nodes anywhere in the route, the dashed style cascaded across the whole path.

## Fix

Drop the endpoint propagation. Use only the per-hop SNR sentinel populated into `segmentHasMqtt` from `isUnknownSnr(snrValue)` — that's the firmware's authoritative signal for an IP/UDP hop. Radio hops on either side of a bridge now stay solid.

\`\`\`ts
// A segment is MQTT/IP only when the firmware reported the unknown-SNR
// sentinel for that specific hop (issue #2931). Don't infer from
// node.viaMqtt — that flag tracks how the node's own NodeInfo last
// reached us, not how its radio segments work.
const isMqttSegment = segmentHasMqtt.get(segmentKey) === true;
\`\`\`

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`useTraceroutePaths\` and \`App.traceroute-display\` test suites green (31 tests)
- [x] Deployed to dev container; user verified bridge segments still render dashed while radio hops stay solid
- [ ] CI: full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)