### PR TITLE
fix(auth): bootstrap first OIDC user as admin (#2749)

### DIFF
--- a/src/server/auth/oidcAuth.ts
+++ b/src/server/auth/oidcAuth.ts
@@ -244,14 +244,19 @@ export async function handleOIDCCallback(
 
         logger.debug(`✅ User migrated to OIDC: ${user!.username}`);
       } else {
-        // Create new user
+        // First-OIDC-login bootstrap: if no OIDC user has been created yet,
+        // promote this one to admin so the deployment isn't locked out when
+        // local auth is disabled (issue #2749).
+        const allUsersForBootstrap = await databaseService.auth.getAllUsers();
+        const isFirstOidcUser = !allUsersForBootstrap.some(u => u.authMethod === 'oidc');
+
         const userId = await databaseService.auth.createUser({
           username,
           email: email || null,
           displayName: name || null,
           authMethod: 'oidc',
           oidcSubject: sub,
-          isAdmin: false,
+          isAdmin: isFirstOidcUser,
           isActive: true,
           passwordHash: null,
           passwordLocked: false,
@@ -260,27 +265,51 @@ export async function handleOIDCCallback(
         });
         user = await databaseService.findUserByIdAsync(userId) as User;
 
-        // Grant default permissions
-        const defaultResources = ['dashboard', 'nodes', 'messages', 'settings', 'info', 'traceroute'];
-        for (const resource of defaultResources) {
-          await databaseService.auth.createPermission({
-            userId,
-            resource,
-            canRead: true,
-            canWrite: false,
-            grantedBy: null,
-            grantedAt: Date.now()
-          });
+        if (isFirstOidcUser) {
+          // Grant full permissions to the bootstrap admin (mirrors the
+          // resource list used by createAdminIfNeeded).
+          const allResources = [
+            'dashboard', 'nodes', 'messages', 'settings', 'configuration', 'info',
+            'automation', 'connection', 'traceroute', 'audit', 'security', 'themes',
+            'channel_0', 'channel_1', 'channel_2', 'channel_3',
+            'channel_4', 'channel_5', 'channel_6', 'channel_7',
+            'nodes_private', 'meshcore', 'packetmonitor'
+          ];
+          for (const resource of allResources) {
+            await databaseService.auth.createPermission({
+              userId,
+              resource,
+              canRead: true,
+              canWrite: true,
+              canDelete: true,
+              grantedBy: null,
+              grantedAt: Date.now()
+            });
+          }
+          logger.warn(`🔐 First OIDC login bootstrap: '${user!.username}' granted admin rights`);
+        } else {
+          // Grant default permissions
+          const defaultResources = ['dashboard', 'nodes', 'messages', 'settings', 'info', 'traceroute'];
+          for (const resource of defaultResources) {
+            await databaseService.auth.createPermission({
+              userId,
+              resource,
+              canRead: true,
+              canWrite: false,
+              grantedBy: null,
+              grantedAt: Date.now()
+            });
+          }
         }
 
-        logger.debug(`✅ OIDC user auto-created: ${user!.username}`);
+        logger.debug(`✅ OIDC user auto-created: ${user!.username}${isFirstOidcUser ? ' (admin)' : ''}`);
 
         // Audit log
         databaseService.auditLogAsync(
           user!.id,
-          'oidc_user_created',
+          isFirstOidcUser ? 'oidc_user_created_admin' : 'oidc_user_created',
           'users',
-          JSON.stringify({ userId: user!.id, username, oidcSubject: sub }),
+          JSON.stringify({ userId: user!.id, username, oidcSubject: sub, isAdmin: isFirstOidcUser }),
           null
         );
       }


### PR DESCRIPTION
## Summary
- When local auth is disabled and OIDC is the only login path, the first user to log in via OIDC was created as a non-admin with read-only defaults — leaving no one able to manage the deployment.
- Detect the "no OIDC user exists yet" case and promote that first user to admin, granting the full resource permission set used by `createAdminIfNeeded`.
- Subsequent OIDC logins continue to get the existing read-only defaults.

Closes #2749

## Test plan
- [ ] Fresh deploy with local auth disabled: first OIDC login becomes admin with full permissions; warning logged.
- [ ] Second OIDC login still gets the read-only default resource set.
- [ ] Existing deployments with at least one OIDC user are unaffected (new OIDC users remain non-admin).
- [ ] Audit log records `oidc_user_created_admin` for the bootstrap user and `oidc_user_created` for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)