### PR TITLE
feat(waypoints): authoring UI for create/edit/delete on per-source map

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -116,7 +116,7 @@ services:
       - SESSION_SECRET=qlskjerhqlwkjehrlqkwejh
       - BASE_URL=/meshmonitor
       - TZ=America/New_York
-      - ALLOWED_ORIGINS=http://localhost:8081,http://localhost:8080,http://sentry.yeraze.online:8081,https://meshdev.yeraze.online
+      - ALLOWED_ORIGINS=http://localhost:8081,http://localhost:8080,http://sentry.yeraze.online:8081,http://spire.yeraze.online:8081,https://meshdev.yeraze.online
       - TRUST_PROXY=1
       - COOKIE_SECURE=false
       - DISABLE_ANONYMOUS=${DISABLE_ANONYMOUS:-false}

--- a/src/components/Dashboard/DashboardWaypoints.tsx
+++ b/src/components/Dashboard/DashboardWaypoints.tsx
@@ -10,6 +10,7 @@ import { useDashboardSources } from '../../hooks/useDashboardData';
 import {
   PerSourceWaypoints,
   type SourceInfo,
+  type WaypointPopupActions,
 } from '../MapAnalysis/layers/WaypointsLayer';
 
 interface DashboardWaypointsProps {
@@ -17,20 +18,26 @@ interface DashboardWaypointsProps {
    *  value (null, undefined, or the unified-view sentinel `"__unified__"`)
    *  renders waypoints across all known sources. */
   sourceId: string | null;
+  /** Optional edit/delete actions; only meaningful on the per-source dashboard
+   *  surface where the caller knows which source is active. */
+  actions?: WaypointPopupActions;
 }
 
-export default function DashboardWaypoints({ sourceId }: DashboardWaypointsProps) {
+export default function DashboardWaypoints({ sourceId, actions }: DashboardWaypointsProps) {
   const { data: sources = [] } = useDashboardSources();
   const sourceList = sources as SourceInfo[];
 
   // Filter only when sourceId matches a real source; otherwise treat as "all".
   const matched = sourceId ? sourceList.find((s) => s.id === sourceId) : null;
   const visible = matched ? [matched] : sourceList;
+  // Authoring actions only apply when we're scoped to a single real source —
+  // on the unified ("all sources") view, edit/delete is ambiguous.
+  const passedActions = matched ? actions : undefined;
 
   return (
     <>
       {visible.map((s) => (
-        <PerSourceWaypoints key={s.id} source={s} />
+        <PerSourceWaypoints key={s.id} source={s} actions={passedActions} />
       ))}
     </>
   );

--- a/src/components/MapAnalysis/layers/WaypointsLayer.test.tsx
+++ b/src/components/MapAnalysis/layers/WaypointsLayer.test.tsx
@@ -99,4 +99,55 @@ describe('WaypointsLayer', () => {
     expect(markers).toHaveLength(1);
     expect(markers[0].getAttribute('data-pos')).toBe('[30,-90]');
   });
+
+  it('does not render Edit/Delete buttons when no actions are provided', async () => {
+    const qc = new QueryClient();
+    const { queryByText } = render(
+      <QueryClientProvider client={qc}>
+        <MapAnalysisProvider>
+          <WaypointsLayer />
+        </MapAnalysisProvider>
+      </QueryClientProvider>,
+    );
+    expect(queryByText(/Edit$/)).toBeNull();
+    expect(queryByText(/Delete$/)).toBeNull();
+  });
+});
+
+describe('PerSourceWaypoints — popup actions', () => {
+  it('renders Edit and Delete buttons when canEdit/canDelete are true and wires them to callbacks', async () => {
+    const { PerSourceWaypoints } = await import('./WaypointsLayer');
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    const qc = new QueryClient();
+    const { getByText } = render(
+      <QueryClientProvider client={qc}>
+        <PerSourceWaypoints
+          source={{ id: 'src-1', name: 'Source One' }}
+          actions={{ canEdit: true, canDelete: true, onEdit, onDelete }}
+        />
+      </QueryClientProvider>,
+    );
+    const editBtn = getByText(/Edit/);
+    const deleteBtn = getByText(/Delete/);
+    editBtn.click();
+    expect(onEdit).toHaveBeenCalledWith(sample[0]);
+    deleteBtn.click();
+    expect(onDelete).toHaveBeenCalledWith(sample[0]);
+  });
+
+  it('hides Edit when canEdit is false but keeps Delete when canDelete is true', async () => {
+    const { PerSourceWaypoints } = await import('./WaypointsLayer');
+    const qc = new QueryClient();
+    const { queryByText, getByText } = render(
+      <QueryClientProvider client={qc}>
+        <PerSourceWaypoints
+          source={{ id: 'src-1', name: 'Source One' }}
+          actions={{ canEdit: false, canDelete: true, onEdit: vi.fn(), onDelete: vi.fn() }}
+        />
+      </QueryClientProvider>,
+    );
+    expect(queryByText(/Edit/)).toBeNull();
+    expect(getByText(/Delete/)).toBeTruthy();
+  });
 });

--- a/src/components/MapAnalysis/layers/WaypointsLayer.tsx
+++ b/src/components/MapAnalysis/layers/WaypointsLayer.tsx
@@ -81,7 +81,24 @@ export interface SourceInfo {
   name?: string;
 }
 
-export function PerSourceWaypoints({ source }: { source: SourceInfo }) {
+export interface WaypointPopupActions {
+  /** Allowed to edit (write perm + not locked-to-other). Edit button hidden when false. */
+  canEdit?: boolean;
+  /** Allowed to delete (write perm + not locked-to-other). Delete button hidden when false. */
+  canDelete?: boolean;
+  /** Caller invokes edit flow with the chosen waypoint. */
+  onEdit?: (wp: Waypoint) => void;
+  /** Caller invokes delete flow with the chosen waypoint. */
+  onDelete?: (wp: Waypoint) => void;
+}
+
+export function PerSourceWaypoints({
+  source,
+  actions,
+}: {
+  source: SourceInfo;
+  actions?: WaypointPopupActions;
+}) {
   const { waypoints } = useWaypoints(source.id);
 
   if (!waypoints || waypoints.length === 0) return null;
@@ -155,6 +172,28 @@ export function PerSourceWaypoints({ source }: { source: SourceInfo }) {
                       </div>
                     )}
                   </div>
+
+                  {(actions?.canEdit || actions?.canDelete) && (
+                    <div className="waypoint-popup-actions">
+                      {actions.canEdit && (
+                        <button
+                          type="button"
+                          onClick={() => actions.onEdit?.(wp)}
+                        >
+                          ✏️ Edit
+                        </button>
+                      )}
+                      {actions.canDelete && (
+                        <button
+                          type="button"
+                          className="danger"
+                          onClick={() => actions.onDelete?.(wp)}
+                        >
+                          🗑 Delete
+                        </button>
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
             </Popup>

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -2057,6 +2057,17 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                       <span>Show Packet Monitor</span>
                     </label>
                   )}
+                  {canWriteWaypoints && (shouldShowData() || meshCoreNodes.length > 0) && (
+                    <button
+                      type="button"
+                      className="waypoint-create-button"
+                      onClick={startCreateBlank}
+                      disabled={placingWaypoint}
+                      title="Place a new waypoint by clicking on the map"
+                    >
+                      ➕ Waypoint
+                    </button>
+                  )}
                 </>
               )}
               </div>
@@ -2534,17 +2545,6 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
             selectedTilesetId={activeTileset}
             onTilesetChange={setMapTileset}
           />
-          )}
-          {canWriteWaypoints && (shouldShowData() || meshCoreNodes.length > 0) && (
-            <button
-              type="button"
-              className="waypoint-create-button"
-              onClick={startCreateBlank}
-              disabled={placingWaypoint}
-              title="Place a new waypoint by clicking on the map"
-            >
-              ➕ Waypoint
-            </button>
           )}
           {(shouldShowData() || meshCoreNodes.length > 0) && nodesWithPosition.length === 0 && meshCoreNodes.filter(n => n.latitude && n.longitude).length === 0 && (
             <div className="map-overlay">

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -22,6 +22,9 @@ import { useSettings } from '../contexts/SettingsContext';
 import { useAuth } from '../contexts/AuthContext';
 import { useSource } from '../contexts/SourceContext';
 import DashboardWaypoints from './Dashboard/DashboardWaypoints';
+import WaypointEditorModal from './WaypointEditorModal';
+import { useWaypoints } from '../hooks/useWaypoints';
+import type { Waypoint, WaypointInput } from '../types/waypoint';
 import { useResizable } from '../hooks/useResizable';
 import ZoomHandler from './ZoomHandler';
 import MapResizeHandler from './MapResizeHandler';
@@ -226,6 +229,53 @@ const TracerouteBoundsController: React.FC<{
   return null;
 };
 
+/**
+ * WaypointMapEventBridge — captures map clicks for waypoint authoring.
+ *
+ * - When `placing` is true, the next left-click drops a pin at the click
+ *   location and exits placement mode.
+ * - Right-click anywhere (when `canCreate`) opens the editor with that
+ *   location seeded as the new waypoint's coordinates.
+ *
+ * Toggles the `waypoint-placing` class on the leaflet container so CSS can
+ * change the cursor to a crosshair during placement.
+ */
+const WaypointMapEventBridge: React.FC<{
+  placing: boolean;
+  canCreate: boolean;
+  onPick: (lat: number, lon: number) => void;
+}> = ({ placing, canCreate, onPick }) => {
+  const map = useMap();
+
+  useEffect(() => {
+    const container = map.getContainer();
+    if (placing) container.classList.add('waypoint-placing');
+    else container.classList.remove('waypoint-placing');
+    return () => container.classList.remove('waypoint-placing');
+  }, [placing, map]);
+
+  useEffect(() => {
+    if (!canCreate) return;
+    const handleClick = (e: any) => {
+      if (!placing) return;
+      const { lat, lng } = e.latlng;
+      onPick(lat, lng);
+    };
+    const handleContextMenu = (e: any) => {
+      const { lat, lng } = e.latlng;
+      onPick(lat, lng);
+    };
+    map.on('click', handleClick);
+    map.on('contextmenu', handleContextMenu);
+    return () => {
+      map.off('click', handleClick);
+      map.off('contextmenu', handleContextMenu);
+    };
+  }, [map, placing, canCreate, onPick]);
+
+  return null;
+};
+
 const NodesTabComponent: React.FC<NodesTabProps> = ({
   processedNodes,
   shouldShowData,
@@ -353,6 +403,93 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
   const { hasPermission, authStatus } = useAuth();
   const csrfFetch = useCsrfFetch();
+
+  // ----- Waypoint authoring state -----
+  const canWriteWaypoints = hasPermission('waypoints', 'write');
+  const waypointMutations = useWaypoints(currentSourceId);
+  const [waypointEditorOpen, setWaypointEditorOpen] = useState(false);
+  const [waypointEditorInitial, setWaypointEditorInitial] = useState<Waypoint | null>(null);
+  const [waypointDefaultCoords, setWaypointDefaultCoords] = useState<
+    { lat: number; lon: number } | null
+  >(null);
+  const [placingWaypoint, setPlacingWaypoint] = useState(false);
+
+  const startCreateAtCoords = useCallback((lat: number, lon: number) => {
+    setWaypointEditorInitial(null);
+    setWaypointDefaultCoords({ lat, lon });
+    setWaypointEditorOpen(true);
+    setPlacingWaypoint(false);
+  }, []);
+
+  const startCreateBlank = useCallback(() => {
+    setPlacingWaypoint(true);
+  }, []);
+
+  const handleEditWaypoint = useCallback((wp: Waypoint) => {
+    setWaypointEditorInitial(wp);
+    setWaypointDefaultCoords(null);
+    setWaypointEditorOpen(true);
+    setPlacingWaypoint(false);
+  }, []);
+
+  const handleDeleteWaypoint = useCallback(
+    async (wp: Waypoint) => {
+      const label = wp.name || `Waypoint ${wp.waypointId}`;
+      if (!window.confirm(`Delete "${label}"? This will be broadcast to the mesh.`)) return;
+      try {
+        await waypointMutations.remove.mutateAsync(wp.waypointId);
+      } catch (err: any) {
+        window.alert(`Failed to delete waypoint: ${err?.message ?? 'unknown error'}`);
+      }
+    },
+    [waypointMutations.remove],
+  );
+
+  const handleSaveWaypoint = useCallback(
+    async (input: WaypointInput) => {
+      if (waypointEditorInitial) {
+        await waypointMutations.update.mutateAsync({
+          waypointId: waypointEditorInitial.waypointId,
+          input,
+        });
+      } else {
+        await waypointMutations.create.mutateAsync(input);
+      }
+    },
+    [waypointEditorInitial, waypointMutations.create, waypointMutations.update],
+  );
+
+  // Esc cancels waypoint placement mode (modal Esc handled by Modal component).
+  useEffect(() => {
+    if (!placingWaypoint) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setPlacingWaypoint(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [placingWaypoint]);
+
+  const localNodeNum = currentNodeId ? parseNodeId(currentNodeId) : null;
+  const lockedToOther = useCallback(
+    (wp: Waypoint) =>
+      Boolean(wp.lockedTo && localNodeNum != null && wp.lockedTo !== localNodeNum),
+    [localNodeNum],
+  );
+  const waypointActions = useMemo(
+    () => ({
+      canEdit: canWriteWaypoints,
+      canDelete: canWriteWaypoints,
+      onEdit: (wp: Waypoint) => {
+        if (lockedToOther(wp)) return;
+        handleEditWaypoint(wp);
+      },
+      onDelete: (wp: Waypoint) => {
+        if (lockedToOther(wp)) return;
+        handleDeleteWaypoint(wp);
+      },
+    }),
+    [canWriteWaypoints, lockedToOther, handleEditWaypoint, handleDeleteWaypoint],
+  );
 
   // Parse current node ID to get node number for effective hops calculation
   const currentNodeNum = currentNodeId ? parseNodeId(currentNodeId) : null;
@@ -1951,7 +2088,12 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               )}
               <ZoomHandler onZoomChange={setMapZoom} />
               <MapPositionHandler />
-              <DashboardWaypoints sourceId={currentSourceId ?? null} />
+              <WaypointMapEventBridge
+                placing={placingWaypoint}
+                canCreate={canWriteWaypoints}
+                onPick={(lat, lon) => startCreateAtCoords(lat, lon)}
+              />
+              <DashboardWaypoints sourceId={currentSourceId ?? null} actions={waypointActions} />
               <DefaultCenterController
                 lat={defaultMapCenterLat}
                 lon={defaultMapCenterLon}
@@ -2393,6 +2535,17 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
             onTilesetChange={setMapTileset}
           />
           )}
+          {canWriteWaypoints && (shouldShowData() || meshCoreNodes.length > 0) && (
+            <button
+              type="button"
+              className="waypoint-create-button"
+              onClick={startCreateBlank}
+              disabled={placingWaypoint}
+              title="Place a new waypoint by clicking on the map"
+            >
+              ➕ Waypoint
+            </button>
+          )}
           {(shouldShowData() || meshCoreNodes.length > 0) && nodesWithPosition.length === 0 && meshCoreNodes.filter(n => n.latitude && n.longitude).length === 0 && (
             <div className="map-overlay">
               <div className="overlay-content">
@@ -2432,6 +2585,23 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
       )}
       </div>
 
+      {placingWaypoint && (
+        <div className="waypoint-placement-hint" role="status">
+          <span>Click the map to place the waypoint</span>
+          <button type="button" onClick={() => setPlacingWaypoint(false)}>
+            Cancel
+          </button>
+        </div>
+      )}
+
+      <WaypointEditorModal
+        isOpen={waypointEditorOpen}
+        initial={waypointEditorInitial}
+        defaultCoords={waypointDefaultCoords}
+        selfNodeNum={localNodeNum ?? null}
+        onClose={() => setWaypointEditorOpen(false)}
+        onSave={handleSaveWaypoint}
+      />
     </div>
   );
 };

--- a/src/components/WaypointEditorModal.css
+++ b/src/components/WaypointEditorModal.css
@@ -187,12 +187,11 @@
   color: var(--ctp-red);
 }
 
-/* Floating button to start waypoint placement, on the per-source map */
+/* "Create waypoint" button shown inside the Features panel on the per-source map */
 .waypoint-create-button {
-  position: absolute;
-  top: 12px;
-  left: 12px;
-  z-index: 1000;
+  display: block;
+  width: 100%;
+  margin-top: 0.4rem;
   background: var(--ctp-base);
   color: var(--ctp-text);
   border: 1px solid var(--ctp-surface1);
@@ -201,7 +200,7 @@
   font-size: 0.85rem;
   font-weight: 500;
   cursor: pointer;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+  text-align: center;
 }
 
 .waypoint-create-button:hover:not(:disabled) {

--- a/src/components/WaypointEditorModal.css
+++ b/src/components/WaypointEditorModal.css
@@ -1,0 +1,251 @@
+/* WaypointEditorModal — form styling layered on top of common/Modal.css */
+
+.waypoint-editor-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: var(--ctp-text);
+  font-size: 0.9rem;
+}
+
+.waypoint-editor-form .form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.waypoint-editor-form .form-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: var(--ctp-subtext0);
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.waypoint-editor-form .form-input {
+  background: var(--ctp-surface0);
+  color: var(--ctp-text);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.55rem;
+  font-size: 0.9rem;
+  font-family: inherit;
+}
+
+.waypoint-editor-form textarea.form-input {
+  resize: vertical;
+  min-height: 2.5rem;
+}
+
+.waypoint-editor-form .form-input:focus {
+  outline: none;
+  border-color: var(--ctp-blue);
+}
+
+.waypoint-editor-form .form-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--ctp-text);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.waypoint-editor-form .form-checkbox input {
+  margin: 0;
+}
+
+.waypoint-editor-form .form-button {
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.waypoint-editor-form .form-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.waypoint-editor-form .form-button-primary {
+  background: var(--ctp-blue);
+  color: var(--ctp-base);
+}
+
+.waypoint-editor-form .form-button-primary:hover:not(:disabled) {
+  background: var(--ctp-sapphire);
+}
+
+.waypoint-editor-form .form-button-secondary {
+  background: var(--ctp-surface0);
+  color: var(--ctp-text);
+  border-color: var(--ctp-surface1);
+}
+
+.waypoint-editor-form .form-button-secondary:hover:not(:disabled) {
+  background: var(--ctp-surface1);
+}
+
+.waypoint-editor-form .form-error {
+  background: var(--ctp-surface0);
+  color: var(--ctp-red);
+  border: 1px solid var(--ctp-red);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.65rem;
+  font-size: 0.85rem;
+}
+
+.waypoint-editor-icon-group {
+  border: 1px solid var(--ctp-surface1);
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.6rem 0.6rem;
+  margin: 0;
+}
+
+.waypoint-editor-icon-group legend {
+  color: var(--ctp-subtext0);
+  font-size: 0.8rem;
+  padding: 0 0.3rem;
+}
+
+.waypoint-editor-icon-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-items: center;
+}
+
+.waypoint-editor-icon-pick {
+  background: transparent;
+  border: 1px solid var(--ctp-surface1);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.4rem;
+  font-size: 1.05rem;
+  cursor: pointer;
+  font-family:
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', 'Twemoji Mozilla', emoji,
+    sans-serif;
+}
+
+.waypoint-editor-icon-pick:hover {
+  background: var(--ctp-surface0);
+}
+
+.waypoint-editor-icon-pick.selected {
+  background: var(--ctp-surface0);
+  border-color: var(--ctp-blue);
+}
+
+.waypoint-editor-icon-custom {
+  width: 4rem;
+  text-align: center;
+  font-family:
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', 'Twemoji Mozilla', emoji,
+    sans-serif;
+}
+
+.waypoint-editor-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+/* Popup actions on the marker (Edit / Delete buttons) */
+.waypoint-popup-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--ctp-surface0);
+}
+
+.waypoint-popup-actions button {
+  background: var(--ctp-surface0);
+  color: var(--ctp-text);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: var(--radius-sm);
+  padding: 0.3rem 0.55rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.waypoint-popup-actions button:hover:not(:disabled) {
+  background: var(--ctp-surface1);
+}
+
+.waypoint-popup-actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.waypoint-popup-actions button.danger {
+  color: var(--ctp-red);
+}
+
+/* Floating button to start waypoint placement, on the per-source map */
+.waypoint-create-button {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 1000;
+  background: var(--ctp-base);
+  color: var(--ctp-text);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: var(--radius-md);
+  padding: 0.45rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+}
+
+.waypoint-create-button:hover:not(:disabled) {
+  background: var(--ctp-surface0);
+  border-color: var(--ctp-blue);
+}
+
+.waypoint-create-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* "Click the map" hint shown during waypoint placement mode */
+.waypoint-placement-hint {
+  position: absolute;
+  top: 0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  background: var(--ctp-base);
+  color: var(--ctp-text);
+  border: 1px solid var(--ctp-blue);
+  border-radius: var(--radius-md);
+  padding: 0.5rem 0.85rem;
+  font-size: 0.85rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  pointer-events: auto;
+}
+
+.waypoint-placement-hint button {
+  background: transparent;
+  color: var(--ctp-subtext0);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: var(--radius-sm);
+  padding: 0.2rem 0.45rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+/* Crosshair cursor on the map during placement */
+.leaflet-container.waypoint-placing,
+.leaflet-container.waypoint-placing .leaflet-interactive {
+  cursor: crosshair !important;
+}

--- a/src/components/WaypointEditorModal.test.tsx
+++ b/src/components/WaypointEditorModal.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import WaypointEditorModal from './WaypointEditorModal';
+
+function renderModal(overrides: Partial<React.ComponentProps<typeof WaypointEditorModal>> = {}) {
+  const onClose = vi.fn();
+  const onSave = vi.fn().mockResolvedValue(undefined);
+  const utils = render(
+    <WaypointEditorModal
+      isOpen
+      initial={null}
+      onClose={onClose}
+      onSave={onSave}
+      selfNodeNum={1234567}
+      {...overrides}
+    />,
+  );
+  return { ...utils, onClose, onSave };
+}
+
+describe('WaypointEditorModal — create mode', () => {
+  it('seeds lat/lon from defaultCoords and dispatches onSave with normalized input', async () => {
+    const { onSave, getByText, getByLabelText, container } = renderModal({
+      defaultCoords: { lat: 26.5, lon: -80.1 },
+    });
+
+    const latInput = container.querySelector(
+      'input[type="number"][step="0.000001"]',
+    ) as HTMLInputElement;
+    expect(latInput.value).toBe('26.5');
+
+    fireEvent.change(getByLabelText(/Name/), { target: { value: 'Trailhead' } });
+    fireEvent.click(getByText(/Create/));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave.mock.calls[0][0]).toMatchObject({
+      lat: 26.5,
+      lon: -80.1,
+      name: 'Trailhead',
+      icon: '📍',
+      expire: null,
+      locked_to: null,
+      virtual: false,
+      rebroadcast_interval_s: null,
+    });
+  });
+
+  it('rejects out-of-range latitude', async () => {
+    const { onSave, getByText, container } = renderModal();
+    const inputs = container.querySelectorAll('input[type="number"][step="0.000001"]');
+    fireEvent.change(inputs[0]!, { target: { value: '200' } });
+    fireEvent.change(inputs[1]!, { target: { value: '0' } });
+    fireEvent.click(getByText(/Create/));
+
+    await waitFor(() => {
+      expect(container.querySelector('[role="alert"]')?.textContent).toMatch(/Latitude/);
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('sets locked_to when "Lock to this node" is checked', async () => {
+    const { onSave, getByText, getByLabelText, container } = renderModal({
+      defaultCoords: { lat: 1, lon: 2 },
+      selfNodeNum: 999,
+    });
+    fireEvent.change(getByLabelText(/Name/), { target: { value: 'Mine' } });
+    fireEvent.click(getByText(/Lock to this node/));
+    fireEvent.click(getByText(/Create/));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][0].locked_to).toBe(999);
+    // sanity: we sent the expected coords through
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+});
+
+describe('WaypointEditorModal — edit mode', () => {
+  it('pre-fills fields from `initial` and shows Save (not Create)', async () => {
+    const { getByText, container } = renderModal({
+      initial: {
+        sourceId: 's1',
+        waypointId: 7,
+        ownerNodeNum: 1,
+        latitude: 10,
+        longitude: 20,
+        expireAt: null,
+        lockedTo: null,
+        name: 'Existing',
+        description: 'desc',
+        iconCodepoint: 0x1f3d5,
+        iconEmoji: '🏕️',
+        isVirtual: false,
+        rebroadcastIntervalS: null,
+        lastBroadcastAt: null,
+        firstSeenAt: 0,
+        lastUpdatedAt: 0,
+      },
+      defaultCoords: null,
+    });
+    expect(getByText(/Save/)).toBeTruthy();
+    const inputs = container.querySelectorAll('input[type="number"][step="0.000001"]');
+    expect((inputs[0] as HTMLInputElement).value).toBe('10');
+    expect((inputs[1] as HTMLInputElement).value).toBe('20');
+  });
+});

--- a/src/components/WaypointEditorModal.tsx
+++ b/src/components/WaypointEditorModal.tsx
@@ -1,13 +1,14 @@
 /**
  * WaypointEditorModal — create/edit dialog for waypoints.
  *
- * Fields: lat/lon (text inputs, with optional map-pick callback), name (≤30),
- * description (≤100), emoji (a small quick-pick + free text), expire
- * (datetime-local or "never"), locked_to (self / open), virtual toggle,
- * rebroadcast interval (numeric, optional).
+ * Wraps the shared `<Modal />` component for consistent overlay/escape/focus
+ * behavior. In create mode pass `initial={null}` (or omit it); in edit mode
+ * pass the existing waypoint and the dialog pre-fills.
  */
 import { useEffect, useState } from 'react';
+import Modal from './common/Modal';
 import type { Waypoint, WaypointInput } from '../types/waypoint';
+import './WaypointEditorModal.css';
 
 const DEFAULT_EMOJIS = ['📍', '🏠', '🏕️', '⛺', '🚗', '🛟', '⚠️', '⭐', '🚩', '🛠️'];
 
@@ -20,6 +21,8 @@ export interface WaypointEditorModalProps {
   onSave: (input: WaypointInput) => Promise<void> | void;
   /** Local node's nodeNum, used when the user toggles "lock to me". */
   selfNodeNum?: number | null;
+  /** Coordinates to seed when opening in create mode (e.g. from a map click). */
+  defaultCoords?: { lat: number; lon: number } | null;
 }
 
 function expireSecondsToLocal(expire: number | null | undefined): string {
@@ -37,7 +40,7 @@ function localToExpireSeconds(local: string): number | null {
 }
 
 export default function WaypointEditorModal(props: WaypointEditorModalProps) {
-  const { isOpen, initial, onPickLocation, onClose, onSave, selfNodeNum } = props;
+  const { isOpen, initial, onPickLocation, onClose, onSave, selfNodeNum, defaultCoords } = props;
 
   const [lat, setLat] = useState('');
   const [lon, setLon] = useState('');
@@ -69,8 +72,8 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
       setVirtual(Boolean(initial.isVirtual));
       setRebroadcast(initial.rebroadcastIntervalS ? String(initial.rebroadcastIntervalS) : '');
     } else {
-      setLat('');
-      setLon('');
+      setLat(defaultCoords ? String(defaultCoords.lat) : '');
+      setLon(defaultCoords ? String(defaultCoords.lon) : '');
       setName('');
       setDescription('');
       setEmoji('📍');
@@ -81,9 +84,7 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
       setRebroadcast('');
     }
     setError(null);
-  }, [isOpen, initial, selfNodeNum]);
-
-  if (!isOpen) return null;
+  }, [isOpen, initial, selfNodeNum, defaultCoords]);
 
   function validate(): WaypointInput | null {
     const latN = Number(lat);
@@ -145,94 +146,113 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
       onClose();
     } catch (err: any) {
       setError(err?.message ?? 'Save failed');
-    } finally {
       setSaving(false);
+      return;
     }
+    setSaving(false);
   }
 
   return (
-    <div className="modal-backdrop" role="dialog" aria-modal="true">
-      <div className="modal waypoint-editor" style={{ maxWidth: 480 }}>
-        <h3>{initial ? 'Edit Waypoint' : 'New Waypoint'}</h3>
-
-        <label>Latitude
-          <input
-            type="number"
-            step="0.000001"
-            value={lat}
-            onChange={(e) => setLat(e.target.value)}
-          />
-        </label>
-        <label>Longitude
-          <input
-            type="number"
-            step="0.000001"
-            value={lon}
-            onChange={(e) => setLon(e.target.value)}
-          />
-        </label>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={initial ? 'Edit Waypoint' : 'New Waypoint'}
+      maxWidth="500px"
+      className="waypoint-editor-modal"
+    >
+      <div className="waypoint-editor-form">
+        <div className="form-row">
+          <label className="form-label">
+            Latitude
+            <input
+              className="form-input"
+              type="number"
+              step="0.000001"
+              value={lat}
+              onChange={(e) => setLat(e.target.value)}
+            />
+          </label>
+          <label className="form-label">
+            Longitude
+            <input
+              className="form-input"
+              type="number"
+              step="0.000001"
+              value={lon}
+              onChange={(e) => setLon(e.target.value)}
+            />
+          </label>
+        </div>
         {onPickLocation && (
-          <button type="button" onClick={onPickLocation}>
-            Pick on map…
+          <button
+            type="button"
+            className="form-button form-button-secondary"
+            onClick={onPickLocation}
+          >
+            📍 Pick on map…
           </button>
         )}
 
-        <label>Name (≤30)
+        <label className="form-label">
+          Name (≤30)
           <input
+            className="form-input"
             type="text"
             maxLength={30}
             value={name}
             onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Trailhead"
           />
         </label>
-        <label>Description (≤100)
+
+        <label className="form-label">
+          Description (≤100)
           <textarea
+            className="form-input"
+            rows={2}
             maxLength={100}
             value={description}
             onChange={(e) => setDescription(e.target.value)}
           />
         </label>
 
-        <fieldset>
+        <fieldset className="waypoint-editor-icon-group">
           <legend>Icon</legend>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+          <div className="waypoint-editor-icon-row">
             {DEFAULT_EMOJIS.map((e) => (
               <button
                 key={e}
                 type="button"
                 onClick={() => setEmoji(e)}
                 aria-pressed={emoji === e}
-                style={{
-                  padding: 6,
-                  background: emoji === e ? '#dde' : 'transparent',
-                  border: '1px solid #ccc',
-                  borderRadius: 4,
-                  cursor: 'pointer',
-                }}
+                className={`waypoint-editor-icon-pick${emoji === e ? ' selected' : ''}`}
               >
                 {e}
               </button>
             ))}
             <input
+              className="form-input waypoint-editor-icon-custom"
               type="text"
               value={emoji}
               onChange={(e) => setEmoji(e.target.value.slice(0, 4))}
-              style={{ width: 60 }}
               aria-label="Custom emoji"
             />
           </div>
         </fieldset>
 
-        <label>
+        <label className="form-checkbox">
           <input
             type="checkbox"
             checked={hasExpiry}
             onChange={(e) => setHasExpiry(e.target.checked)}
-          /> Expires
+          />
+          <span>Expires</span>
         </label>
         {hasExpiry && (
-          <label>Expire at
+          <label className="form-label">
+            Expire at
             <input
+              className="form-input"
               type="datetime-local"
               value={expireLocal}
               onChange={(e) => setExpireLocal(e.target.value)}
@@ -240,25 +260,32 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
           </label>
         )}
 
-        <label>
+        <label className="form-checkbox">
           <input
             type="checkbox"
             checked={lockToSelf}
             onChange={(e) => setLockToSelf(e.target.checked)}
             disabled={selfNodeNum == null}
-          /> Lock to this node ({selfNodeNum != null ? `!${selfNodeNum.toString(16).padStart(8, '0')}` : 'unknown'})
+          />
+          <span>
+            Lock to this node (
+            {selfNodeNum != null ? `!${selfNodeNum.toString(16).padStart(8, '0')}` : 'unknown'})
+          </span>
         </label>
 
-        <label>
+        <label className="form-checkbox">
           <input
             type="checkbox"
             checked={virtual}
             onChange={(e) => setVirtual(e.target.checked)}
-          /> Virtual (do not broadcast)
+          />
+          <span>Virtual (do not broadcast)</span>
         </label>
 
-        <label>Rebroadcast interval (seconds, optional)
+        <label className="form-label">
+          Rebroadcast interval (seconds, optional)
           <input
+            className="form-input"
             type="number"
             min={60}
             value={rebroadcast}
@@ -266,15 +293,31 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
           />
         </label>
 
-        {error && <div role="alert" style={{ color: '#c0392b' }}>{error}</div>}
+        {error && (
+          <div role="alert" className="form-error">
+            {error}
+          </div>
+        )}
 
-        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 12 }}>
-          <button type="button" onClick={onClose} disabled={saving}>Cancel</button>
-          <button type="button" onClick={handleSave} disabled={saving}>
-            {saving ? 'Saving…' : 'Save'}
+        <div className="waypoint-editor-actions">
+          <button
+            type="button"
+            className="form-button form-button-secondary"
+            onClick={onClose}
+            disabled={saving}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="form-button form-button-primary"
+            onClick={handleSave}
+            disabled={saving}
+          >
+            {saving ? 'Saving…' : initial ? 'Save' : 'Create'}
           </button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/hooks/useWaypoints.ts
+++ b/src/hooks/useWaypoints.ts
@@ -23,10 +23,13 @@ async function fetchWaypoints(sourceId: string): Promise<Waypoint[]> {
 }
 
 async function postJson<T>(url: string, method: string, body?: unknown): Promise<T> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const csrfToken = sessionStorage.getItem('csrfToken');
+  if (csrfToken) headers['X-CSRF-Token'] = csrfToken;
   const res = await fetch(url, {
     method,
     credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: body === undefined ? undefined : JSON.stringify(body),
   });
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- Adds create/edit/delete waypoint authoring UI on the per-source map (NodesTab) with a Create Waypoint button surfaced in the Features panel.
- Wires CSRF tokens into waypoint mutations and refreshes the WaypointEditorModal flow with tests for the editor modal and waypoints layer.
- Touches DashboardWaypoints, WaypointsLayer, useWaypoints, and supporting styles to support the new authoring flow.

Follows up on #2936 / #2938.

## Test plan
- [ ] CI: lint, typecheck, unit tests (incl. new WaypointEditorModal + WaypointsLayer tests)
- [ ] Manual: create / edit / delete a waypoint from the per-source map
- [ ] Manual: confirm CSRF token is sent on mutations and request succeeds
- [ ] Manual: verify Create Waypoint button appears in the Features panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)