### PR TITLE
docs: add Canadaverse Mesh to Site Gallery

### DIFF
--- a/docs/site-gallery.md
+++ b/docs/site-gallery.md
@@ -83,6 +83,13 @@ Running a public MeshMonitor instance? We'd love to feature it! **[File an issue
 
 ---
 
+### Canadaverse Mesh
+- **URL**: [meshmon.canadaverse.org](https://meshmon.canadaverse.org/)
+- **Notable**: Includes an [`/analysis`](https://meshmon.canadaverse.org/analysis) page with detailed mesh data analytics.
+- **Description**: Community-maintained MeshMonitor instance with extended analytics views.
+
+---
+
 ## About the Site Gallery
 
 The Site Gallery showcases MeshMonitor instances that are publicly accessible. These sites demonstrate:


### PR DESCRIPTION
## Summary

Adds the `meshmon.canadaverse.org` MeshMonitor instance to the community Site Gallery, as requested in #2941.

## Changes

- `docs/site-gallery.md`: New "Canadaverse Mesh" entry, with a callout for its `/analysis` page (detailed mesh data analytics).

## Testing

- Markdown-only change; reviewed rendering against existing entries for formatting consistency.

Fixes #2941