### PR TITLE
fix: correct channel encryption label for unencrypted and shorthand PSKs (#2939)

### DIFF
--- a/src/components/configuration/ChannelDatabaseSection.encryptionLabel.test.tsx
+++ b/src/components/configuration/ChannelDatabaseSection.encryptionLabel.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+/**
+ * Regression coverage for the channel encryption label fix (#2939, PR #2944).
+ *
+ * The ChannelDatabaseSection card renders a "PSK: <preview> (<label>)" line
+ * whose label depends on `pskLength`:
+ *   0  -> renders "PSK: (none) (None)" (no preview, no AES label)
+ *   1  -> "Shorthand (AES-128)"
+ *   16 -> "AES-128"
+ *   32 -> "AES-256"
+ *   anything else -> "Unknown"
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ChannelDatabaseEntry } from '../../services/api';
+
+const showToastMock = vi.fn();
+vi.mock('../ToastContainer', () => ({
+  useToast: () => ({ showToast: showToastMock, toasts: [] }),
+}));
+
+const getChannelDatabaseEntriesMock = vi.fn();
+const getRetroactiveDecryptionProgressMock = vi.fn();
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual<typeof import('../../services/api')>('../../services/api');
+  return {
+    ...actual,
+    default: {
+      getChannelDatabaseEntries: getChannelDatabaseEntriesMock,
+      getRetroactiveDecryptionProgress: getRetroactiveDecryptionProgressMock,
+      reorderChannelDatabaseEntries: vi.fn(),
+      createChannelDatabaseEntry: vi.fn(),
+      updateChannelDatabaseEntry: vi.fn(),
+      deleteChannelDatabaseEntry: vi.fn(),
+      triggerRetroactiveDecryption: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../../utils/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const baseChannel: ChannelDatabaseEntry = {
+  id: 1,
+  name: 'TestChannel',
+  pskLength: 16,
+  pskPreview: 'AAAAAAAA...',
+  description: null,
+  isEnabled: true,
+  enforceNameValidation: false,
+  sortOrder: 0,
+  decryptedPacketCount: 0,
+  lastDecryptedAt: null,
+  createdBy: null,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+const renderSection = async () => {
+  const { default: ChannelDatabaseSection } = await import('./ChannelDatabaseSection');
+  return render(<ChannelDatabaseSection isAdmin={true} />);
+};
+
+describe('ChannelDatabaseSection encryption label', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getRetroactiveDecryptionProgressMock.mockResolvedValue({ isRunning: false, progress: null });
+  });
+
+  it('renders "None" for pskLength 0 with literal "(none)" preview', async () => {
+    getChannelDatabaseEntriesMock.mockResolvedValue({
+      data: [{ ...baseChannel, pskLength: 0, pskPreview: '(none)' }],
+    });
+
+    await renderSection();
+
+    await waitFor(() => {
+      expect(screen.getByText('PSK: (none) (None)')).toBeTruthy();
+    });
+    // Must not show any preview-style content for pskLength 0
+    expect(screen.queryByText(/AAAAAAAA/)).toBeNull();
+  });
+
+  it('renders "Shorthand (AES-128)" for pskLength 1', async () => {
+    getChannelDatabaseEntriesMock.mockResolvedValue({
+      data: [{ ...baseChannel, pskLength: 1, pskPreview: 'AQ==...' }],
+    });
+
+    await renderSection();
+
+    await waitFor(() => {
+      expect(screen.getByText('PSK: AQ==... (Shorthand (AES-128))')).toBeTruthy();
+    });
+  });
+
+  it('renders "AES-128" for pskLength 16', async () => {
+    getChannelDatabaseEntriesMock.mockResolvedValue({
+      data: [{ ...baseChannel, pskLength: 16, pskPreview: 'BBBBBBBB...' }],
+    });
+
+    await renderSection();
+
+    await waitFor(() => {
+      expect(screen.getByText('PSK: BBBBBBBB... (AES-128)')).toBeTruthy();
+    });
+  });
+
+  it('renders "AES-256" for pskLength 32', async () => {
+    getChannelDatabaseEntriesMock.mockResolvedValue({
+      data: [{ ...baseChannel, pskLength: 32, pskPreview: 'CCCCCCCC...' }],
+    });
+
+    await renderSection();
+
+    await waitFor(() => {
+      expect(screen.getByText('PSK: CCCCCCCC... (AES-256)')).toBeTruthy();
+    });
+  });
+
+  it('renders "Unknown" for an unexpected pskLength (e.g. 7)', async () => {
+    getChannelDatabaseEntriesMock.mockResolvedValue({
+      data: [{ ...baseChannel, pskLength: 7, pskPreview: 'DDDDDDDD...' }],
+    });
+
+    await renderSection();
+
+    await waitFor(() => {
+      expect(screen.getByText('PSK: DDDDDDDD... (Unknown)')).toBeTruthy();
+    });
+  });
+});

--- a/src/components/configuration/ChannelDatabaseSection.tsx
+++ b/src/components/configuration/ChannelDatabaseSection.tsx
@@ -167,7 +167,19 @@ const SortableChannelCard: React.FC<SortableChannelCardProps> = ({
             </p>
           )}
           <div style={{ marginTop: '0.5rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
-            <div>PSK: {channel.pskPreview} ({channel.pskLength === 16 ? 'AES-128' : 'AES-256'})</div>
+            <div>
+              {channel.pskLength === 0
+                ? 'PSK: (none) (None)'
+                : `PSK: ${channel.pskPreview} (${
+                    channel.pskLength === 1
+                      ? 'Shorthand (AES-128)'
+                      : channel.pskLength === 16
+                        ? 'AES-128'
+                        : channel.pskLength === 32
+                          ? 'AES-256'
+                          : 'Unknown'
+                  })`}
+            </div>
             <div>{t('channel_database.decrypted_count')}: {channel.decryptedPacketCount}</div>
             <div>{t('channel_database.last_decrypted')}: {formatTimestamp(channel.lastDecryptedAt)}</div>
           </div>

--- a/src/server/routes/v1/channelDatabase.ts
+++ b/src/server/routes/v1/channelDatabase.ts
@@ -27,7 +27,7 @@ function transformChannelForResponse(channel: any, includeFullPsk: boolean = fal
     id: channel.id,
     name: channel.name,
     pskLength: channel.pskLength,
-    pskPreview: includeFullPsk ? channel.psk : `${channel.psk.substring(0, 8)}...`,
+    pskPreview: includeFullPsk ? channel.psk : (channel.psk ? `${channel.psk.substring(0, 8)}...` : '(none)'),
     psk: includeFullPsk ? channel.psk : undefined,
     description: channel.description,
     isEnabled: channel.isEnabled,

--- a/tests/unit/channelDatabaseTransform.test.ts
+++ b/tests/unit/channelDatabaseTransform.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Regression spec for the channel-database response transform (#2939, PR #2944).
+ *
+ * src/server/routes/v1/channelDatabase.ts:30 (transformChannelForResponse)
+ * sets pskPreview as:
+ *
+ *   includeFullPsk
+ *     ? channel.psk
+ *     : (channel.psk ? `${channel.psk.substring(0, 8)}...` : '(none)')
+ *
+ * The fix is the trailing `'(none)'` branch. Before the fix, an empty/missing
+ * PSK on the masked (non-includeFullPsk) path would crash on `.substring`. The
+ * helper is not exported and the masked branch is gated behind admin-only
+ * routes, so we mirror the expression here in the same logic-spec style as
+ * channelDatabasePermissions.test.ts to lock in the expected behavior and
+ * document the contract.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Mirror of transformChannelForResponse's pskPreview expression.
+// Keep this identical to src/server/routes/v1/channelDatabase.ts:30.
+const pskPreviewFor = (channel: { psk?: string | null }, includeFullPsk: boolean) =>
+  includeFullPsk
+    ? channel.psk
+    : (channel.psk ? `${channel.psk.substring(0, 8)}...` : '(none)');
+
+describe('channel-database response transform — pskPreview (masked branch)', () => {
+  it('returns "(none)" when psk is an empty string', () => {
+    expect(pskPreviewFor({ psk: '' }, false)).toBe('(none)');
+  });
+
+  it('returns "(none)" when psk is null', () => {
+    expect(pskPreviewFor({ psk: null }, false)).toBe('(none)');
+  });
+
+  it('returns "(none)" when psk is undefined / missing', () => {
+    expect(pskPreviewFor({}, false)).toBe('(none)');
+  });
+
+  it('returns the truncated 8-char preview when psk is present', () => {
+    const psk = 'AAAAAAAA1234567890BBBBBBBB';
+    expect(pskPreviewFor({ psk }, false)).toBe('AAAAAAAA...');
+  });
+
+  it('returns truncated preview even for short non-empty PSKs (length <= 8)', () => {
+    // String.prototype.substring(0, 8) on a short string returns the full
+    // string, so the preview is "<psk>...". Still non-empty, still safe.
+    expect(pskPreviewFor({ psk: 'short' }, false)).toBe('short...');
+  });
+});
+
+describe('channel-database response transform — pskPreview (admin branch)', () => {
+  it('returns the raw psk when includeFullPsk=true (preserved by the fix)', () => {
+    expect(pskPreviewFor({ psk: 'full-secret' }, true)).toBe('full-secret');
+  });
+
+  it('does not substitute "(none)" on the admin branch when psk is empty', () => {
+    // The fix is scoped to the masked branch; admin still gets channel.psk
+    // verbatim (here: empty string).
+    expect(pskPreviewFor({ psk: '' }, true)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2939. The Channel Database UI was mislabeling encryption types based on `pskLength`, and showed a misleading `...` preview for empty PSKs.

## Changes

- `src/components/configuration/ChannelDatabaseSection.tsx` — replaced the `pskLength === 16 ? 'AES-128' : 'AES-256'` ternary with logic covering all four documented cases plus an `Unknown` fallback. When `pskLength === 0`, the line now renders `PSK: (none) (None)` instead of pretending a key exists.
  - `0` → `None`
  - `1` → `Shorthand (AES-128)`
  - `16` → `AES-128`
  - `32` → `AES-256`
  - other → `Unknown`
- `src/server/routes/v1/channelDatabase.ts` — when `channel.psk` is empty, `pskPreview` is now `"(none)"` instead of `"..."`. The `includeFullPsk` (admin) branch is unchanged.

## Test plan

- [x] `npx tsc --noEmit` — no errors
- [x] `npx vitest run tests/unit/channelDatabasePermissions.test.ts` — 26/26 pass
- [x] `npm run lint` for the two changed files surfaces only pre-existing warnings (no new issues)
- [ ] Manual check: open Channel Database with channels at pskLength 0, 1, 16, 32 and confirm each label