### PR TITLE
feat: add Tile Selection and Legend visibility toggles to Map Features panel

### DIFF
--- a/docs/site-gallery.md
+++ b/docs/site-gallery.md
@@ -83,6 +83,13 @@ Running a public MeshMonitor instance? We'd love to feature it! **[File an issue
 
 ---
 
+### Canadaverse Mesh
+- **URL**: [meshmon.canadaverse.org](https://meshmon.canadaverse.org/)
+- **Notable**: Includes an [`/analysis`](https://meshmon.canadaverse.org/analysis) page with detailed mesh data analytics.
+- **Description**: Community-maintained MeshMonitor instance with extended analytics views.
+
+---
+
 ## About the Site Gallery
 
 The Site Gallery showcases MeshMonitor instances that are publicly accessible. These sites demonstrate:

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -693,6 +693,16 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     return saved === 'true';
   });
 
+  const [showTileSelector, setShowTileSelector] = useState(() => {
+    const saved = localStorage.getItem('meshmonitor-showTileSelector');
+    return saved === null ? false : saved === 'true';
+  });
+
+  const [showLegend, setShowLegend] = useState(() => {
+    const saved = localStorage.getItem('meshmonitor-showLegend');
+    return saved === null ? false : saved === 'true';
+  });
+
   const sidebarRef = useRef<HTMLDivElement>(null);
 
   // Save packet monitor preference to localStorage
@@ -704,6 +714,14 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   useEffect(() => {
     localStorage.setItem('isMapControlsCollapsed', isMapControlsCollapsed.toString());
   }, [isMapControlsCollapsed]);
+
+  useEffect(() => {
+    localStorage.setItem('meshmonitor-showTileSelector', showTileSelector.toString());
+  }, [showTileSelector]);
+
+  useEffect(() => {
+    localStorage.setItem('meshmonitor-showLegend', showLegend.toString());
+  }, [showLegend]);
 
 
   // Map controls position state with localStorage persistence
@@ -1976,6 +1994,22 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                       {t('map.showPolarGrid')}
                     </span>
                   </label>
+                  <label className="map-control-item">
+                    <input
+                      type="checkbox"
+                      checked={showTileSelector}
+                      onChange={(e) => setShowTileSelector(e.target.checked)}
+                    />
+                    <span>Show Tile Selection</span>
+                  </label>
+                  <label className="map-control-item">
+                    <input
+                      type="checkbox"
+                      checked={showLegend}
+                      onChange={(e) => setShowLegend(e.target.checked)}
+                    />
+                    <span>Show Legend</span>
+                  </label>
                   {geoJsonLayers.map(layer => (
                     <label key={layer.id} className="map-control-item">
                       <input
@@ -2112,9 +2146,11 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               />
               <MapResizeHandler trigger={`${showPacketMonitor}-${isNodeListCollapsed}-${packetMonitorHeight}`} />
               <SpiderfierController ref={spiderfierRef} zoomLevel={mapZoom} />
+              {showLegend && (
               <MapLegend
                 positionHistory={positionHistoryLegendData}
               />
+              )}
               {nodesWithPosition
                 .filter(node => {
                   // Apply standard filters
@@ -2540,7 +2576,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               {positionHistoryElements}
 
           </MapContainer>
-          {(shouldShowData() || meshCoreNodes.length > 0) && (
+          {(shouldShowData() || meshCoreNodes.length > 0) && showTileSelector && (
           <TilesetSelector
             selectedTilesetId={activeTileset}
             onTilesetChange={setMapTileset}


### PR DESCRIPTION
## Summary
- Adds two checkboxes to the Map Features panel: **Tile Selection** and **Legend**, both default OFF (hidden) on first load.
- Visibility state persists via `localStorage` keys `meshmonitor-showTileSelector` and `meshmonitor-showLegend`, matching the existing `isMapControlsCollapsed` pattern.
- Wraps `<MapLegend>` and `<TilesetSelector>` rendering with the new toggles.

## Why localStorage
Used `localStorage` rather than the server map-preferences API to keep this purely UI-only — adding DB columns/migration for two visibility toggles felt out of scope.

## Test plan
- [ ] Fresh load: both Tile Selection and Legend hidden by default.
- [ ] Toggling each checkbox shows/hides the corresponding control.
- [ ] Refresh page — toggle states persist.
- [ ] `npx tsc --noEmit` clean (verified locally).