### PR TITLE
fix(mobile): mobile browser interface fixes (#2940)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2768,3 +2768,92 @@ body {
     font-size: 1rem;
   }
 }
+
+/* ==========================================================================
+   Mobile foundations
+   Cross-cutting fixes for phone/tablet browsers (Safari iOS/iPadOS, Chrome).
+   Kept additive so desktop is unaffected.
+   ========================================================================== */
+
+@media (max-width: 768px) {
+  /* iOS Safari auto-zooms text inputs whose font-size < 16px on focus.
+     The viewport meta blocks this today, but enforcing 16px is the
+     accessibility-safe fix in case user-scalable=no is ever removed. */
+  input[type='text'],
+  input[type='email'],
+  input[type='password'],
+  input[type='number'],
+  input[type='search'],
+  input[type='tel'],
+  input[type='url'],
+  textarea,
+  select {
+    font-size: max(16px, 1rem);
+  }
+
+  /* Compact settings header on phones — 4rem logo + 2rem padding eats
+     the whole top of the viewport. */
+  .settings-header-card {
+    padding: 1rem;
+    gap: 0.75rem;
+  }
+
+  .settings-logo {
+    height: 2.5rem;
+  }
+
+  .settings-app-name {
+    font-size: 1.25rem;
+  }
+
+  .settings-version {
+    font-size: 0.85rem;
+  }
+
+  .settings-content {
+    padding: 1rem;
+  }
+
+  /* Section nav (sub-tabs inside settings/configuration) — let the row
+     scroll horizontally instead of wrapping into many lines. */
+  .section-nav {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 0.5rem;
+    gap: 0.375rem;
+  }
+
+  .section-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .section-nav-item {
+    flex-shrink: 0;
+    min-height: 40px;
+    padding: 0.5rem 0.75rem;
+  }
+
+  /* Buttons inside settings forms — comfortable hit area. */
+  .button {
+    min-height: 44px;
+  }
+
+  /* Sticky message composer — keep it pinned above the safe-area inset
+     so the iPhone home indicator never overlaps the input. */
+  .send-message-form,
+  .send-direct-message-form {
+    bottom: 0;
+    bottom: env(safe-area-inset-bottom, 0);
+  }
+}
+
+/* Touch devices generally — independent of width since iPads in landscape
+   are wider than 768px but still need finger-sized close buttons. */
+@media (hover: none) and (pointer: coarse) {
+  .modal-close,
+  .close-button {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1554,8 +1554,9 @@ body {
   }
 
   .send-btn {
-    min-width: 40px;
-    width: 40px;
+    min-width: 44px;
+    min-height: 44px;
+    width: 44px;
     padding: 0.6rem 0.3rem;
     font-size: 1.2rem;
     flex-shrink: 0;

--- a/src/App.css
+++ b/src/App.css
@@ -506,6 +506,7 @@ body {
   margin: 0;
   padding: 0;
   padding-bottom: env(safe-area-inset-bottom); /* Account for iPhone home indicator */
+  overflow-x: hidden;
 }
 
 /* Skip to content link - hidden until focused via keyboard */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5205,7 +5205,7 @@ function App() {
         {activeTab === 'meshcore' && <ErrorBoundary fallbackTitle="MeshCore failed to load"><MeshCoreTab baseUrl={baseUrl} /></ErrorBoundary>}
         {activeTab === 'packetmonitor' && (
           <ErrorBoundary fallbackTitle="Packet Monitor failed to load">
-            <div style={{ height: 'calc(100vh - var(--header-height, 60px) - 4rem)', overflow: 'hidden' }}>
+            <div style={{ height: 'calc(100dvh - var(--header-height, 60px) - 4rem)', overflow: 'hidden' }}>
               <PacketMonitorPanel onClose={() => setActiveTab('nodes')} />
             </div>
           </ErrorBoundary>

--- a/src/components/AdvancedNodeFilterPopup/AdvancedNodeFilterPopup.css
+++ b/src/components/AdvancedNodeFilterPopup/AdvancedNodeFilterPopup.css
@@ -10,6 +10,8 @@
   align-items: center;
   justify-content: center;
   z-index: 10001;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .filter-popup {

--- a/src/components/AppBanners/AppBanners.css
+++ b/src/components/AppBanners/AppBanners.css
@@ -5,6 +5,7 @@
   left: var(--sidebar-width);
   right: 0;
   padding: 8px 16px;
+  padding-top: calc(8px + env(safe-area-inset-top));
   text-align: center;
   font-size: 14px;
   font-weight: 500;
@@ -51,7 +52,7 @@
   .warning-banner,
   .update-banner {
     font-size: 13px;
-    padding-top: 6px;
+    padding-top: calc(6px + env(safe-area-inset-top));
     padding-bottom: 6px;
     padding-left: 12px;
   }

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -435,8 +435,25 @@
   }
 
   .dashboard-drag-handle {
-    font-size: 1rem;
-    padding: 0 2px;
+    /* Hide drag handle on mobile — dragging is awkward on touch and
+       it steals horizontal space from the title. */
+    display: none;
+  }
+}
+
+/* Touch devices: enlarge widget header controls to a usable tap size. */
+@media (hover: none) {
+  .dashboard-remove-btn,
+  .solar-toggle-btn,
+  .distance-settings-btn {
+    width: 36px;
+    height: 36px;
+    font-size: 1.15rem;
+  }
+
+  .node-status-remove-node {
+    padding: 8px 10px;
+    font-size: 1.1rem;
   }
 }
 

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -259,7 +259,7 @@
 
 .dashboard-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 450px), 1fr));
   gap: 20px;
   width: 100%;
 }

--- a/src/components/EmojiPickerModal/EmojiPickerModal.css
+++ b/src/components/EmojiPickerModal/EmojiPickerModal.css
@@ -46,6 +46,13 @@
   color: var(--ctp-text);
 }
 
+@media (hover: none) and (pointer: coarse) {
+  .emoji-picker-close {
+    width: 44px;
+    height: 44px;
+  }
+}
+
 .emoji-picker-grid {
   display: grid;
   grid-template-columns: repeat(8, 1fr);

--- a/src/components/LoginPage.css
+++ b/src/components/LoginPage.css
@@ -7,6 +7,7 @@
 
 .login-page {
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/NewsPopup/NewsPopup.css
+++ b/src/components/NewsPopup/NewsPopup.css
@@ -16,6 +16,8 @@
   align-items: center;
   justify-content: center;
   z-index: 10002;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 /* Modal content container */

--- a/src/components/SaveBar/SaveBar.css
+++ b/src/components/SaveBar/SaveBar.css
@@ -8,6 +8,7 @@
   border-top: 2px solid var(--ctp-green);
   animation: saveBarSlideIn 0.3s ease-out;
   box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.15);
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 /* When sidebar is collapsed */

--- a/src/components/SearchModal/SearchModal.css
+++ b/src/components/SearchModal/SearchModal.css
@@ -281,7 +281,9 @@
     width: 100%;
     max-width: 100%;
     max-height: 100vh;
+    max-height: 100dvh;
     height: 100vh;
+    height: 100dvh;
     border-radius: 0;
   }
 

--- a/src/components/SearchModal/SearchModal.css
+++ b/src/components/SearchModal/SearchModal.css
@@ -285,6 +285,8 @@
     height: 100vh;
     height: 100dvh;
     border-radius: 0;
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
   }
 
   .search-filters {

--- a/src/components/TelemetryGraphs.css
+++ b/src/components/TelemetryGraphs.css
@@ -23,7 +23,7 @@
 
 .graphs-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 400px), 1fr));
   gap: 20px;
 }
 

--- a/src/components/common/Modal.css
+++ b/src/components/common/Modal.css
@@ -54,3 +54,27 @@
 .modal-body {
   padding: 1.5rem;
 }
+
+@media (max-width: 768px) {
+  .modal-overlay .modal-content {
+    width: 100%;
+    max-width: none;
+    height: 100dvh;
+    max-height: none;
+    border-radius: 0;
+  }
+
+  .modal-overlay .modal-body {
+    padding-bottom: calc(1.5rem + env(safe-area-inset-bottom));
+  }
+}
+
+@media (max-width: 768px) and (hover: none) {
+  .modal-overlay .modal-close {
+    min-width: 44px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+}

--- a/src/components/configuration/GpioPinSummary.tsx
+++ b/src/components/configuration/GpioPinSummary.tsx
@@ -116,7 +116,7 @@ const GpioPinSummary: React.FC<GpioPinSummaryProps> = (props) => {
         backgroundColor: 'var(--ctp-surface0)',
         borderRadius: '8px',
         border: '1px solid var(--ctp-surface2)',
-        maxHeight: 'calc(100vh - 2rem)',
+        maxHeight: 'calc(100dvh - 2rem)',
         overflowY: 'auto'
       }}>
         <h4 style={{ margin: '0 0 0.5rem 0', color: 'var(--ctp-text)' }}>
@@ -135,7 +135,7 @@ const GpioPinSummary: React.FC<GpioPinSummaryProps> = (props) => {
       backgroundColor: 'var(--ctp-surface0)',
       borderRadius: '8px',
       border: '1px solid var(--ctp-surface2)',
-      maxHeight: 'calc(100vh - 2rem)',
+      maxHeight: 'calc(100dvh - 2rem)',
       overflowY: 'auto'
     }}>
       <h4 style={{ margin: '0 0 0.5rem 0', color: 'var(--ctp-text)' }}>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -64,7 +64,7 @@ const sourceRouteProviders = (children: React.ReactNode) => (
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <Suspense fallback={<div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>Loading...</div>}>
+    <Suspense fallback={<div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100dvh' }}>Loading...</div>}>
       <QueryClientProvider client={queryClient}>
         <BrowserRouter basename={appBasename}>
           <Routes>

--- a/src/pages/PacketMonitorPage.tsx
+++ b/src/pages/PacketMonitorPage.tsx
@@ -26,7 +26,7 @@ const PacketMonitorContent: React.FC = () => {
   return (
     <div style={{
       width: '100vw',
-      height: '100vh',
+      height: '100dvh',
       display: 'flex',
       flexDirection: 'column',
       overflow: 'hidden',

--- a/src/styles/BackupManagement.css
+++ b/src/styles/BackupManagement.css
@@ -200,6 +200,17 @@
   .backup-modal-content {
     padding: 1rem;
     width: 95%;
+    /* Drop the desktop 600px floor and the sidebar offset so the modal
+       fits inside narrow viewports. */
+    min-width: 0;
+    max-width: 100%;
+    margin-left: 0;
+  }
+
+  .modal-content.backup-modal {
+    min-width: 0;
+    max-width: 100%;
+    width: 100%;
   }
 
   /* Hide table headers on mobile */

--- a/src/styles/SecurityTab.css
+++ b/src/styles/SecurityTab.css
@@ -517,6 +517,13 @@
   transform: scale(1.05);
 }
 
+@media (hover: none) and (pointer: coarse) {
+  .send-notification-btn {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
 .send-notification-btn:active {
   transform: scale(0.95);
 }

--- a/src/styles/analysis-reports.css
+++ b/src/styles/analysis-reports.css
@@ -7,6 +7,7 @@
 
 .reports-page {
   min-height: 100vh;
+  min-height: 100dvh;
   background: var(--ctp-base);
   color: var(--ctp-text);
   font-family: var(--font-family, sans-serif);

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -6,6 +6,7 @@
 
 .dashboard-page {
   height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   background: var(--ctp-base);

--- a/src/styles/map-analysis.css
+++ b/src/styles/map-analysis.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  height: 100dvh;
   background: #111;
   color: #eee;
 }

--- a/src/styles/map-analysis.css
+++ b/src/styles/map-analysis.css
@@ -222,7 +222,7 @@
   border: 1px solid #3a3a3a;
   border-radius: 8px;
   padding: 14px 18px;
-  min-width: 520px;
+  width: min(520px, calc(100vw - 24px));
   z-index: 2000;
   display: flex;
   flex-direction: column;
@@ -230,6 +230,14 @@
   color: #eee;
   font-size: 12px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  box-sizing: border-box;
+}
+
+@media (max-width: 768px) {
+  .map-analysis-time-slider {
+    bottom: max(12px, env(safe-area-inset-bottom));
+    padding: 10px 12px;
+  }
 }
 .map-analysis-time-slider input[type="range"] { width: 100%; }
 .map-analysis-time-slider-label {

--- a/src/styles/messages.css
+++ b/src/styles/messages.css
@@ -285,6 +285,21 @@
   outline-offset: 2px;
 }
 
+/* Touch devices have no hover — keep message actions always visible so
+   reply/emoji/delete buttons stay reachable on phones and tablets. */
+@media (hover: none) {
+  .message-actions {
+    opacity: 1;
+    position: static;
+    margin-top: 0.25rem;
+    justify-content: flex-end;
+  }
+
+  .message-bubble-container.mine .message-actions {
+    justify-content: flex-start;
+  }
+}
+
 .reply-button,
 .resend-button,
 .emoji-button,

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1252,7 +1252,8 @@
 
   .sort-direction-btn {
     padding: 0.35rem 0.6rem;
-    min-width: 36px;
+    min-width: 44px;
+    min-height: 44px;
   }
 
   /* Mobile: expanded sidebar overlays the map */
@@ -1374,7 +1375,8 @@
   .sort-direction-btn {
     padding: 0.3rem 0.5rem;
     font-size: 1rem;
-    min-width: 32px;
+    min-width: 44px;
+    min-height: 44px;
   }
 }
 

--- a/src/styles/unified.css
+++ b/src/styles/unified.css
@@ -7,6 +7,7 @@
 
 .unified-page {
   min-height: 100vh;
+  min-height: 100dvh;
   background: var(--ctp-base);
   color: var(--ctp-text);
   font-family: var(--font-family, sans-serif);
@@ -17,6 +18,7 @@
    page flow so the messages column becomes the only scroll surface. */
 .unified-page--chat {
   height: 100vh;
+  height: 100dvh;
   min-height: 0;
   display: flex;
   flex-direction: column;

--- a/src/styles/users.css
+++ b/src/styles/users.css
@@ -15,6 +15,7 @@
   grid-template-columns: 350px 1fr;
   gap: 24px;
   height: calc(100vh - 200px);
+  height: calc(100dvh - 200px);
   min-height: 600px;
 }
 


### PR DESCRIPTION
## Summary

Fixes #2940 — comprehensive mobile browser pass across the MeshMonitor UI.

**First pass — foundational fixes (5 commits):**
- `messages.css`: keep reply/emoji/delete actions visible on touch (`@media (hover: none)`)
- `BackupManagement.css`: drop `min-width: 600px` on narrow viewports so backup modal fits
- `map-analysis.css`: time slider switches to `width: min(520px, calc(100vw - 24px))` + safe-area bottom anchor
- `Dashboard.css`: 36×36 widget header buttons on touch; hide drag handle ≤768px
- `App.css`: ≥16px on inputs to prevent iOS zoom-on-focus; horizontal-scroll section nav; sticky composer with `safe-area-inset-bottom`; 44×44 close-button targets

**Second pass — audit priorities (5 commits):**
- **P1** `Modal.css`: full-screen sheet on `(max-width: 768px)`, scoped under `.modal-overlay` so per-modal `max-width` overrides don't beat it
- **P2** `100vh → 100dvh` sweep across stylesheets and TSX (dual-property fallback in CSS, direct switch in TS)
- **P3** `env(safe-area-inset-*)` on AppBanners, SaveBar, NewsPopup, AdvancedNodeFilterPopup, SearchModal mobile branch
- **P4** 44×44 tap targets on coarse pointers (App.css, SecurityTab, EmojiPickerModal, nodes sort-direction)
- **P5** `body { overflow-x: hidden }`; `.dashboard-grid` and `.graphs-grid` use `minmax(min(100%, ...px), 1fr)` to collapse instead of overflow on tablet widths

**Build / lint:** typecheck clean, build clean. Lint shows pre-existing baseline only — no new diagnostics from this branch.

**Deliberate skips with rationale:**
- `Sidebar.css:401,476` — landscape-density choice (28/32px); 44px would eat too much vertical space
- `Dashboard.css:798,960` — non-interactive labels (`.hop-bar-count`, `.heatmap-cell`)
- `SaveBar.css:132` — 20px notification badge, not a button
- `nodes.css:1320` — slider readout, not interactive
- `NewsPopup.css:260-261` — native checkbox; label is the click target
- Viewport meta `user-scalable=no` left alone (load-bearing for keyboard); 16px input rule mitigates the zoom side effect

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean (only pre-existing chunk-size / deprecation warnings)
- [x] Container deployed and verified loading on a real mobile browser (`http://spire.yeraze.online:8081/meshmonitor/`)
- [ ] Smoke test on iOS Safari (PWA + browser tab)
- [ ] Smoke test on Android Chrome
- [ ] Verify modals render full-screen on phones, retain bordered card on desktop
- [ ] Verify safe-area padding on notched devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)