### PR TITLE
fix: map tileset selection not applying on dashboard

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -105,6 +105,7 @@ export default function DashboardMap({
         zoomControl
       >
         <TileLayer
+          key={tilesetId}
           url={tileset.url}
           attribution={tileset.attribution}
           maxZoom={tileset.maxZoom}

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -157,7 +157,27 @@ interface SettingsProviderProps {
   baseUrl?: string;
 }
 
-export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, baseUrl = '' }) => {
+// Detect BASE_URL from window.location when caller doesn't supply one.
+// Mirrors detectBaseUrl() in App.tsx / DashboardPage so providers mounted by
+// pages that don't thread baseUrl through (GlobalSettingsPage, ReportsPage,
+// MapAnalysisPage, PacketMonitorPage, DashboardPage) still POST to the
+// correct /<base>/api/... path.
+const detectBaseUrlFromLocation = (): string => {
+  if (typeof window === 'undefined') return '';
+  const pathname = window.location.pathname;
+  const pathParts = pathname.split('/').filter(Boolean);
+  if (pathParts.length === 0) return '';
+  const appRoutes = ['nodes', 'channels', 'messages', 'settings', 'info', 'dashboard', 'source', 'unified', 'analysis', 'reports', 'users', 'packet-monitor'];
+  const baseSegments: string[] = [];
+  for (const segment of pathParts) {
+    if (appRoutes.includes(segment.toLowerCase())) break;
+    baseSegments.push(segment);
+  }
+  return baseSegments.length > 0 ? '/' + baseSegments.join('/') : '';
+};
+
+export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, baseUrl: baseUrlProp }) => {
+  const baseUrl = baseUrlProp ?? detectBaseUrlFromLocation();
   const { getToken: getCsrfToken } = useCsrf();
   const [isLoading, setIsLoading] = useState(true);
 


### PR DESCRIPTION
## Summary
- **DashboardMap TileLayer missing key**: react-leaflet kept the same Leaflet instance when the tile URL prop changed, so picking a new tileset in Settings never refreshed the dashboard map. Added `key={tilesetId}` to force a remount.
- **SettingsProvider baseUrl default '' broke save under BASE_URL deployments**: `GlobalSettingsPage`, `ReportsPage`, `MapAnalysisPage`, `PacketMonitorPage`, and `DashboardPage` instantiate `<SettingsProvider>` without passing `baseUrl`, so `POST /api/user/map-preferences` hit the unprefixed path and 404'd. `SettingsProvider` now auto-detects the base from `window.location` when no prop is supplied; explicit prop callers (`AppWithToast`) are unaffected.

## Test plan
- [x] Verified locally on dev container behind `/meshmonitor` BASE_URL — switching Map Tileset in Settings now succeeds (200) and the dashboard map updates immediately on next load.
- [ ] CI build + tests
- [ ] Smoke-test other pages mounted via `<SettingsProvider>` (Reports, MapAnalysis, PacketMonitor) for any regression in baseUrl detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)