### PR TITLE
chore(release): bump version to 4.3.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.2.3",
+  "version": "4.3.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -25,7 +25,8 @@ export default defineConfig({
       {
         text: 'Docs',
         items: [
-          { text: '🆕 4.2 Highlights', link: '/features/analysis-reports' },
+          { text: '🆕 4.3 Highlights', link: '/features/waypoints' },
+          { text: '4.2 Highlights', link: '/features/analysis-reports' },
           { text: '4.1 Highlights', link: '/features/map-analysis' },
           { text: '4.0 Highlights', link: '/features/multi-source' },
           { text: 'Features', link: '/features/settings' },
@@ -40,7 +41,13 @@ export default defineConfig({
     sidebar: {
       '/features/': [
         {
-          text: '🆕 4.2 Highlights',
+          text: '🆕 4.3 Highlights',
+          items: [
+            { text: 'Waypoints', link: '/features/waypoints' }
+          ]
+        },
+        {
+          text: '4.2 Highlights',
           items: [
             { text: 'Analysis & Reports', link: '/features/analysis-reports' }
           ]

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -25,9 +25,6 @@ export default defineConfig({
       {
         text: 'Docs',
         items: [
-          { text: '🆕 4.2 Highlights', link: '/features/analysis-reports' },
-          { text: '4.1 Highlights', link: '/features/map-analysis' },
-          { text: '4.0 Highlights', link: '/features/multi-source' },
           { text: 'Features', link: '/features/settings' },
           { text: 'Configuration', link: '/configuration/' },
           { text: 'Add-ons', link: '/add-ons/' },
@@ -40,32 +37,14 @@ export default defineConfig({
     sidebar: {
       '/features/': [
         {
-          text: '🆕 4.2 Highlights',
-          items: [
-            { text: 'Analysis & Reports', link: '/features/analysis-reports' }
-          ]
-        },
-        {
-          text: '4.1 Highlights',
-          items: [
-            { text: 'Map Analysis', link: '/features/map-analysis' }
-          ]
-        },
-        {
-          text: '4.0 Highlights',
-          items: [
-            { text: 'Multi-Source', link: '/features/multi-source' },
-            { text: 'Per-Source Permissions', link: '/features/per-source-permissions' },
-            { text: 'Global Settings', link: '/features/global-settings' },
-            { text: 'Store & Forward', link: '/features/store-forward' },
-            { text: 'Geofence Triggers', link: '/features/geofence-triggers' }
-          ]
-        },
-        {
           text: 'Features',
           items: [
             { text: 'Settings', link: '/features/settings' },
+            { text: 'Global Settings', link: '/features/global-settings' },
+            { text: 'Multi-Source', link: '/features/multi-source' },
+            { text: 'Per-Source Permissions', link: '/features/per-source-permissions' },
             { text: 'Automation', link: '/features/automation' },
+            { text: 'Geofence Triggers', link: '/features/geofence-triggers' },
             { text: 'Auto Heap Management', link: '/features/auto-heap-management' },
             { text: 'Device Configuration', link: '/features/device' },
             { text: 'Admin Commands', link: '/features/admin-commands' },
@@ -74,10 +53,13 @@ export default defineConfig({
             { text: 'Channel Database', link: '/features/channel-database' },
             { text: 'Security', link: '/features/security' },
             { text: 'Message Search', link: '/features/message-search' },
+            { text: 'Store & Forward', link: '/features/store-forward' },
             { text: 'Embed Maps', link: '/features/embed-maps' },
+            { text: 'Map Analysis', link: '/features/map-analysis' },
             { text: 'Waypoints', link: '/features/waypoints' },
             { text: 'Link Quality & Smart Hops', link: '/features/link-quality' },
             { text: 'Analytics', link: '/features/analytics' },
+            { text: 'Analysis & Reports', link: '/features/analysis-reports' },
             { text: 'Telemetry Widgets', link: '/features/telemetry-widgets' },
             { text: 'MeshCore (Experimental)', link: '/features/meshcore' },
             { text: '🌍 Translations', link: '/features/translations' },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -25,8 +25,7 @@ export default defineConfig({
       {
         text: 'Docs',
         items: [
-          { text: '🆕 4.3 Highlights', link: '/features/waypoints' },
-          { text: '4.2 Highlights', link: '/features/analysis-reports' },
+          { text: '🆕 4.2 Highlights', link: '/features/analysis-reports' },
           { text: '4.1 Highlights', link: '/features/map-analysis' },
           { text: '4.0 Highlights', link: '/features/multi-source' },
           { text: 'Features', link: '/features/settings' },
@@ -41,13 +40,7 @@ export default defineConfig({
     sidebar: {
       '/features/': [
         {
-          text: '🆕 4.3 Highlights',
-          items: [
-            { text: 'Waypoints', link: '/features/waypoints' }
-          ]
-        },
-        {
-          text: '4.2 Highlights',
+          text: '🆕 4.2 Highlights',
           items: [
             { text: 'Analysis & Reports', link: '/features/analysis-reports' }
           ]
@@ -82,6 +75,7 @@ export default defineConfig({
             { text: 'Security', link: '/features/security' },
             { text: 'Message Search', link: '/features/message-search' },
             { text: 'Embed Maps', link: '/features/embed-maps' },
+            { text: 'Waypoints', link: '/features/waypoints' },
             { text: 'Link Quality & Smart Hops', link: '/features/link-quality' },
             { text: 'Analytics', link: '/features/analytics' },
             { text: 'Telemetry Widgets', link: '/features/telemetry-widgets' },

--- a/docs/features/maps.md
+++ b/docs/features/maps.md
@@ -84,6 +84,10 @@ When viewing traceroute data:
    - SNR indicators at each hop
    - Failed routes shown in red
 
+### Waypoints
+
+Waypoints — Meshtastic's `WAYPOINT_APP` pins — render directly on the per-source dashboard map and the Map Analysis canvas, using each waypoint's emoji as its icon. Users with `waypoints:write` can create, edit, and delete waypoints in place from the **Map Features** panel. See the dedicated [Waypoints](/features/waypoints) page for the full workflow, permissions, and REST API.
+
 ## Map Tilesets
 
 ### Built-in Tilesets

--- a/docs/features/waypoints.md
+++ b/docs/features/waypoints.md
@@ -1,0 +1,93 @@
+# Waypoints
+
+MeshMonitor renders, stores, and authors **Meshtastic waypoints** — the per-source pins on the mesh's `WAYPOINT_APP` channel. Use them to mark net check-ins, repeaters, supply caches, hazards, or any geographic point of interest you want everyone on the mesh to see.
+
+Waypoints are first-class data alongside nodes, messages, and telemetry: they live in the per-source database, route through the same WebSocket fan-out, and are gated by a dedicated `waypoints:read` / `waypoints:write` permission pair.
+
+## What you get
+
+- **Per-source storage** of every WAYPOINT_APP packet received, with the owner node, expiry, lock-to-node, and emoji icon preserved
+- **Map rendering** on both the per-source dashboard map and Map Analysis, using the waypoint's emoji as the marker icon
+- **In-place authoring** — create, edit, and delete waypoints from the per-source map and broadcast them to the mesh
+- **Expiry handling**: `expire_at = 0` is treated as "no expiration"; expired waypoints are swept out by the daily maintenance task with a grace window
+- **Real-time updates**: `waypoint:upserted`, `waypoint:deleted`, and `waypoint:expired` events fan out over the existing source-scoped WebSocket rooms
+
+## Permissions
+
+Waypoints are gated by a new permission pair, granted per source the same way other source permissions work:
+
+| Permission | What it lets a user do |
+| --- | --- |
+| `waypoints:read` | See waypoints on the map and in the API |
+| `waypoints:write` | Create, edit, and delete waypoints (subject to `locked_to`) |
+
+On upgrade, every user with `messages:read` / `messages:write` for a given source automatically receives the matching `waypoints:*` grant — admins bypass the row check anyway. You can adjust per-user grants from the Users page like any other source permission.
+
+## Viewing waypoints
+
+### Per-source dashboard map
+
+Open the Dashboard, select a source from the sidebar, and waypoints appear as emoji markers alongside the source's nodes. Click a waypoint to see:
+
+- Name and description
+- Owner node (and source)
+- Expiry timestamp, or "never" when `expire_at` is unset
+- 🔒 indicator when the waypoint is locked to a specific node
+
+The unified "all sources" dashboard renders waypoints from every source you can read, but suppresses authoring actions — those are scoped to a specific source.
+
+### Map Analysis
+
+The Map Analysis canvas exposes a **Waypoints** layer in the toolbar. Toggle it to overlay every visible waypoint on top of the existing analysis layers (heatmap, traceroutes, etc.).
+
+## Creating, editing, and deleting waypoints
+
+Authoring is available on the per-source dashboard map for users with `waypoints:write`.
+
+### Create
+
+1. Open a source's dashboard map.
+2. Open the **Map Features** dropdown and click **➕ Waypoint** (or right-click the map for the same shortcut).
+3. The cursor switches to a crosshair — click the map at the desired location, or press **Esc** to cancel.
+4. Fill in the waypoint editor:
+   - **Name** and **Description**
+   - **Icon** — pick an emoji from the picker (rendered with VS-16 forcing so it shows as an emoji on every platform)
+   - **Lock to me** — only your node can edit this waypoint after broadcast
+   - **Expires** — toggle on to set an expiry timestamp; off means "never expires"
+5. Click **Save**. MeshMonitor allocates a waypoint id (Python-style id allocation), persists the row, and broadcasts a WAYPOINT_APP packet to the mesh.
+
+### Edit
+
+Click the waypoint marker, then **Edit** in the popup. Editing is suppressed when the waypoint is locked to another node.
+
+### Delete
+
+Click **Delete** in the waypoint popup. MeshMonitor removes the row locally and broadcasts an `expire = 0` tombstone so peers also drop it. (The on-wire delete signal is the tombstone; locally we treat `expire_at = 0` as "no expiration", so the deletion is intentional and not a side effect of the column value.)
+
+## REST API
+
+Waypoints are exposed on the v1 source-scoped routes, gated by `waypoints:read|write`:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET`    | `/api/sources/:id/waypoints` | List waypoints (supports `?bbox=` and `?include_expired=`) |
+| `POST`   | `/api/sources/:id/waypoints` | Create a local waypoint and broadcast it |
+| `PATCH`  | `/api/sources/:id/waypoints/:waypointId` | Update name/description/icon/expiry/lock |
+| `DELETE` | `/api/sources/:id/waypoints/:waypointId` | Delete locally and broadcast a tombstone |
+
+All mutations require the standard `X-CSRF-Token` header. Mutations on a waypoint with `locked_to` set to another node return `403`.
+
+## Database
+
+Waypoints live in a per-source `waypoints` table introduced in migration **053**, with composite primary key `(sourceId, waypointId)`, a foreign key to `sources` with `ON DELETE CASCADE`, and indexes on `(sourceId, expireAt)` and `(sourceId, ownerNodeNum)`.
+
+Migrations **054** / **055** seed the new `waypoints:read` / `waypoints:write` permissions for existing users by cloning their `messages` grants per source.
+
+The daily database maintenance tick sweeps expired waypoints (with a grace window) and emits `waypoint:expired` events for each removed row.
+
+## Limitations and follow-ups
+
+- **Rebroadcast scheduler is not yet wired**. The `rebroadcast_interval_s` column is persisted and accepted by the API, but no timer fires it. Waypoints you create are broadcast once on save; resends rely on the stock Meshtastic firmware behaviour at this time.
+- **Automation hooks** for the waypoint message type are not yet available — Auto-Responders and Geofence Triggers do not currently match on waypoint events.
+
+Both are tracked as follow-ups; see [#2936](https://github.com/Yeraze/meshmonitor/issues/2936) for the umbrella issue.

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.2.3
-appVersion: "4.2.3"
+version: 4.3.0
+appVersion: "4.3.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.2.3",
+      "version": "4.3.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Release 4.3.0. Headline feature: **Waypoints** — per-source storage, map rendering, and in-place authoring UI for Meshtastic `WAYPOINT_APP` pins.

Includes since 4.2.3:
- #2936/#2938 feat(waypoints): basic waypoint support
- #2942 feat(waypoints): authoring UI for create/edit/delete
- #2937 fix(auth): bootstrap first OIDC user as admin
- #2935 fix(traceroute): stop cascading IP-style across radio segments
- #2945 feat: Tile Selection / Legend visibility toggles in Map Features
- #2944 fix: correct channel encryption label for unencrypted/shorthand PSKs
- #2946 fix(mobile): mobile browser interface fixes
- #2948 fix: map tileset selection not applying on dashboard
- docs: new Waypoints feature page; 4.3 Highlights nav entry

## Test plan

- [ ] CI build passes
- [ ] `helm lint helm/meshmonitor` succeeds
- [ ] `desktop/src-tauri/tauri.conf.json` reads version `4.3.0`
- [ ] Top-level `package.json` and `package-lock.json` both at `4.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)