### PR TITLE
fix(channels): expose PSK to authorized writers so config UI works (#2951)

### DIFF
--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -38,7 +38,8 @@ const CHANNEL_DB_OFFSET = 100;
 // Encryption status types
 type EncryptionStatus = 'none' | 'default' | 'secure';
 
-// Helper to determine encryption status
+// Helper to determine encryption status from a raw PSK (used for virtual /
+// channel-database entries where we have the key locally).
 const getEncryptionStatus = (psk: string | undefined | null): EncryptionStatus => {
   if (!psk || psk === '') {
     return 'none'; // No encryption
@@ -47,6 +48,16 @@ const getEncryptionStatus = (psk: string | undefined | null): EncryptionStatus =
     return 'default'; // Default/public key - not secure
   }
   return 'secure'; // Custom key - encrypted
+};
+
+// Resolve encryption status for a Channel: prefer the server-derived
+// `encryptionStatus` field (always present and safe to expose) and fall
+// back to deriving from `psk` when only that is available (e.g. legacy
+// payloads or virtual channel objects). Issue #2951.
+const channelEncryptionStatus = (channel: Pick<Channel, 'encryptionStatus' | 'psk'> | null | undefined): EncryptionStatus => {
+  if (!channel) return 'none';
+  if (channel.encryptionStatus) return channel.encryptionStatus;
+  return getEncryptionStatus(channel.psk);
 };
 
 export interface ChannelsTabProps {
@@ -462,7 +473,7 @@ export default function ChannelsTab({
                   const channelConfig = channels.find(ch => ch.id === channelId);
                   const displayName = channelConfig?.name || getChannelName(channelId);
                   const unread = unreadCounts[channelId] || 0;
-                  const encryptionStatus = getEncryptionStatus(channelConfig?.psk);
+                  const encryptionStatus = channelEncryptionStatus(channelConfig);
                   const uplink = channelConfig?.uplinkEnabled ? '↑' : '';
                   const downlink = channelConfig?.downlinkEnabled ? '↓' : '';
                   const encryptionIcon = encryptionStatus === 'secure' ? '🔒' : encryptionStatus === 'default' ? '🔐' : '🔓';
@@ -510,7 +521,7 @@ export default function ChannelsTab({
                         </div>
                         <div className="channel-button-indicators">
                           {(() => {
-                            const status = getEncryptionStatus(channelConfig?.psk);
+                            const status = channelEncryptionStatus(channelConfig);
                             if (status === 'secure') {
                               return (
                                 <span className="encryption-icon secure" title={t('channels.encrypted_secure')}>
@@ -1072,7 +1083,7 @@ export default function ChannelsTab({
                       <span className="info-label">{t('channels.encryption')}</span>
                       <span className="info-value">
                         {(() => {
-                          const status = getEncryptionStatus(selectedChannelConfig.psk);
+                          const status = channelEncryptionStatus(selectedChannelConfig);
                           if (status === 'secure') {
                             return <span className="status-secure">{t('channels.status_secure')}</span>;
                           } else if (status === 'default') {
@@ -1230,7 +1241,7 @@ export default function ChannelsTab({
                   <span className="info-label">{t('channels.encryption')}</span>
                   <span className="info-value">
                     {(() => {
-                      const status = getEncryptionStatus(virtualChannelInfoModal.psk);
+                      const status = channelEncryptionStatus(virtualChannelInfoModal as any);
                       if (status === 'secure') {
                         return <span className="status-secure">{t('channels.status_secure')}</span>;
                       } else if (status === 'default') {

--- a/src/components/NodeFilterPopup.tsx
+++ b/src/components/NodeFilterPopup.tsx
@@ -30,12 +30,16 @@ export const NodeFilterPopup: React.FC<NodeFilterPopupProps> = ({ isOpen, onClos
   // Get unique channel numbers from available channels
   const availableChannels = (channels || []).map(ch => ch.id).sort((a, b) => a - b);
 
-  // Check if the selected channel has a custom PSK (is secure/encrypted)
+  // Check if the selected channel has a custom PSK (is secure/encrypted).
+  // Prefer the server-derived `encryptionStatus` field — non-admin viewers
+  // do not receive `psk` from the API (issue #2951), so the legacy `psk`
+  // check would mis-classify their channels as insecure.
   const isSecureChannel = (channelId: number | 'all'): boolean => {
     if (channelId === 'all') return false;
     const channel = channels.find(ch => ch.id === channelId);
-    // A channel is secure if it has a PSK that's not the default unencrypted one
-    return !!(channel?.psk && channel.psk !== DEFAULT_UNENCRYPTED_PSK);
+    if (!channel) return false;
+    if (channel.encryptionStatus) return channel.encryptionStatus === 'secure';
+    return !!(channel.psk && channel.psk !== DEFAULT_UNENCRYPTED_PSK);
   };
 
   // Auto-hide incomplete nodes when switching to a secure channel

--- a/src/components/configuration/ChannelsConfigSection.tsx
+++ b/src/components/configuration/ChannelsConfigSection.tsx
@@ -32,7 +32,8 @@ const DEFAULT_PUBLIC_PSK = 'AQ==';
 
 type EncryptionStatus = 'none' | 'default' | 'secure';
 
-// Helper to determine encryption status
+// Helper to determine encryption status from a raw PSK (fallback for cases
+// where only the key is available locally).
 const getEncryptionStatus = (psk: string | undefined | null): EncryptionStatus => {
   if (!psk || psk === '') {
     return 'none'; // No encryption
@@ -41,6 +42,17 @@ const getEncryptionStatus = (psk: string | undefined | null): EncryptionStatus =
     return 'default'; // Default/public key - not secure
   }
   return 'secure'; // Custom key - encrypted
+}
+
+// Resolve encryption status for a Channel: prefer the server-derived
+// `encryptionStatus` field (always present on API responses) and fall back
+// to deriving from `psk`. The API only sends `psk` to authorized writers
+// (issue #2951), so unauthorized callers MUST rely on `encryptionStatus`
+// to render the correct icon.
+const channelEncryptionStatus = (channel: Pick<Channel, 'encryptionStatus' | 'psk'> | null | undefined): EncryptionStatus => {
+  if (!channel) return 'none';
+  if (channel.encryptionStatus) return channel.encryptionStatus;
+  return getEncryptionStatus(channel.psk);
 };
 
 interface ChannelsConfigSectionProps {
@@ -505,7 +517,7 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                   {channel && (
                     <div style={{ marginTop: '0.5rem', fontSize: '0.9rem', color: 'var(--ctp-subtext1)' }}>
                       {(() => {
-                        const status = getEncryptionStatus(channel.psk);
+                        const status = channelEncryptionStatus(channel);
                         if (status === 'secure') {
                           return <div title={t('channels.encrypted_secure')}>🔒 {t('channels_config.encrypted_secure')}</div>;
                         } else if (status === 'default') {

--- a/src/server/routes/sourceRoutes.security.test.ts
+++ b/src/server/routes/sourceRoutes.security.test.ts
@@ -6,8 +6,13 @@
  *           channels rows (including the `psk` column) to any caller with
  *           `messages:read` on the source. The fix moves the route to
  *           `optionalAuth()` plus a per-row `channel_${id}:read` gate, then
- *           projects through `transformChannel` so the PSK never reaches
- *           the response.
+ *           projects through `transformChannel`.
+ *
+ *           Issue #2951 follow-up: the actual `psk` is now intentionally
+ *           included for admins and callers with `channel_${id}:write`
+ *           permission so the channel-configuration UI can show the
+ *           existing key to the operator who is allowed to change it.
+ *           Read-only callers must still never see the key.
  *
  * MM-SEC-8: `GET /api/sources/:id` previously returned the raw source row,
  *           skipping the `password` / `apiKey` strip applied to the list
@@ -122,37 +127,71 @@ describe('MM-SEC-7 — /api/sources/:id/channels does not leak PSKs', () => {
     expect(JSON.stringify(res.body)).not.toContain('WklET0VOX0NIQU5fMl9TRUNSRVRfUFNLX0NIQU5fMjI=');
   });
 
-  it('authenticated viewer with channel_0:read sees only channel 0, no psk field', async () => {
+  it('authenticated viewer with channel_0:read (no write) sees channel 0 but no psk field', async () => {
     mockDb.findUserByIdAsync.mockResolvedValue(regularUser);
     mockDb.findUserByUsernameAsync.mockResolvedValue(null);
     mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: false });
-    // Per-channel: grant channel_0 only.
+    // Per-channel: grant channel_0:read only — NOT write.
     mockDb.checkPermissionAsync.mockImplementation(
-      (_uid: number, resource: string) => Promise.resolve(resource === 'channel_0')
+      (_uid: number, resource: string, action: string) =>
+        Promise.resolve(resource === 'channel_0' && action === 'read')
     );
 
     const res = await request(createApp(regularUser.id)).get('/src-1/channels');
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
     expect(res.body[0].id).toBe(0);
+    // Read-only viewer must not receive the actual key.
     expect(res.body[0]).not.toHaveProperty('psk');
     expect(res.body[0].pskSet).toBe(true);
+    // But the derived encryption status is safe to expose.
+    expect(res.body[0].encryptionStatus).toBe('secure');
     // The hidden channel must not appear at all — neither its name nor PSK.
     expect(JSON.stringify(res.body)).not.toContain('hidden');
+    expect(JSON.stringify(res.body)).not.toContain('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=');
     expect(JSON.stringify(res.body)).not.toContain('WklET0VOX0NIQU5fMl9TRUNSRVRfUFNLX0NIQU5fMjI=');
   });
 
-  it('admin sees all channels, no raw psk in response (transformChannel still strips it)', async () => {
+  it('authenticated writer with channel_0:write sees channel 0 PSK in the response (issue #2951)', async () => {
+    mockDb.findUserByIdAsync.mockResolvedValue(regularUser);
+    mockDb.findUserByUsernameAsync.mockResolvedValue(null);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: false });
+    // Grant channel_0 read + write; channel_2 read only.
+    mockDb.checkPermissionAsync.mockImplementation(
+      (_uid: number, resource: string, action: string) => {
+        if (resource === 'channel_0') return Promise.resolve(true); // read + write
+        if (resource === 'channel_2' && action === 'read') return Promise.resolve(true);
+        return Promise.resolve(false);
+      }
+    );
+
+    const res = await request(createApp(regularUser.id)).get('/src-1/channels');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    const ch0 = res.body.find((c: any) => c.id === 0);
+    const ch2 = res.body.find((c: any) => c.id === 2);
+    // Channel 0: writer sees the PSK so the edit dialog can prefill it.
+    expect(ch0.psk).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=');
+    expect(ch0.pskSet).toBe(true);
+    expect(ch0.encryptionStatus).toBe('secure');
+    // Channel 2: read-only — no PSK exposed.
+    expect(ch2).not.toHaveProperty('psk');
+    expect(ch2.pskSet).toBe(true);
+  });
+
+  it('admin sees all channels including PSK (issue #2951 — needed for channel config UI)', async () => {
     mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
     mockDb.getUserPermissionSetAsync.mockResolvedValue({});
 
     const res = await request(createApp(adminUser.id)).get('/src-1/channels');
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(2);
-    expect(res.body.every((c: any) => !('psk' in c))).toBe(true);
+    // Admin can see PSKs to configure channels.
+    expect(res.body.every((c: any) => 'psk' in c)).toBe(true);
+    expect(res.body.find((c: any) => c.id === 0).psk).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=');
+    expect(res.body.find((c: any) => c.id === 2).psk).toBe('WklET0VOX0NIQU5fMl9TRUNSRVRfUFNLX0NIQU5fMjI=');
     expect(res.body.every((c: any) => typeof c.pskSet === 'boolean')).toBe(true);
-    // Sanity: even for admins, the actual PSK string never appears.
-    expect(JSON.stringify(res.body)).not.toContain('WklET0VOX0NIQU5fMl9TRUNSRVRfUFNLX0NIQU5fMjI=');
+    expect(res.body.every((c: any) => typeof c.encryptionStatus === 'string')).toBe(true);
   });
 });
 

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -479,7 +479,19 @@ router.get('/:id/channels', optionalAuth(), async (req: Request, res: Response) 
       }
     }
 
-    res.json(accessible.map(transformChannel));
+    // Issue #2951: include the raw `psk` only for admins or callers with
+    // write permission on the specific channel — otherwise the channel
+    // configuration UI cannot display the existing key for the operator
+    // who is allowed to change it.
+    const projected = await Promise.all(accessible.map(async (channel) => {
+      const channelResource = `channel_${channel.id}` as ResourceType;
+      const includePsk = isAdmin || (req.user
+        ? await hasPermission(req.user, channelResource, 'write', source.id)
+        : false);
+      return transformChannel(channel, { includePsk });
+    }));
+
+    res.json(projected);
   } catch (error) {
     logger.error('Error fetching channels for source:', error);
     res.status(500).json({ error: 'Failed to fetch channels' });

--- a/src/server/routes/v1/channels.ts
+++ b/src/server/routes/v1/channels.ts
@@ -36,16 +36,19 @@ router.get('/', async (req: Request, res: Response) => {
     // Get all channels (scoped to source if provided)
     const allChannels = await databaseService.channels.getAllChannels(sourceIdQ);
 
-    // If admin, return all channels
+    // If admin, return all channels with PSKs included (admin can configure them)
     if (isAdmin) {
       return res.json({
         success: true,
         count: allChannels.length,
-        data: allChannels.map(transformChannel)
+        data: allChannels.map((c) => transformChannel(c, { includePsk: true }))
       });
     }
 
-    // Filter channels by read permission (scoped to source)
+    // Filter channels by read permission (scoped to source). The actual `psk`
+    // is included only when the caller has write permission for that specific
+    // channel — see issue #2951 (the channel-config UI needs to show the
+    // existing key to operators who are allowed to change it).
     const accessibleChannels: any[] = [];
     for (const channel of allChannels) {
       const channelResource = `channel_${channel.id}` as ResourceType;
@@ -55,10 +58,18 @@ router.get('/', async (req: Request, res: Response) => {
       if (allowed) accessibleChannels.push(channel);
     }
 
+    const projected = await Promise.all(accessibleChannels.map(async (channel) => {
+      const channelResource = `channel_${channel.id}` as ResourceType;
+      const includePsk = userId !== null
+        ? await databaseService.checkPermissionAsync(userId, channelResource, 'write', sourceIdQ)
+        : false;
+      return transformChannel(channel, { includePsk });
+    }));
+
     res.json({
       success: true,
-      count: accessibleChannels.length,
-      data: accessibleChannels.map(transformChannel)
+      count: projected.length,
+      data: projected
     });
   } catch (error) {
     logger.error('Error getting channels:', error);
@@ -119,9 +130,16 @@ router.get('/:channelId', async (req: Request, res: Response) => {
       });
     }
 
+    // Include the raw `psk` only for admins or callers with write permission
+    // to this channel (issue #2951).
+    const channelResource = `channel_${channelId}` as ResourceType;
+    const includePsk = isAdmin || (userId !== null
+      ? await databaseService.checkPermissionAsync(userId, channelResource, 'write', sourceIdQ)
+      : false);
+
     res.json({
       success: true,
-      data: transformChannel(channel)
+      data: transformChannel(channel, { includePsk })
     });
   } catch (error) {
     logger.error('Error getting channel:', error);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2498,8 +2498,20 @@ apiRouter.get('/channels/all', optionalAuth(), async (req, res) => {
       }
     }
 
+    // MM-SEC-2 follow-up: include the raw `psk` only for callers with write
+    // permission to the specific channel (or admins). Without this, the
+    // channel-config edit dialog and Info popup can't display the existing
+    // key for the operator who is allowed to change it. See issue #2951.
+    const projected = await Promise.all(accessible.map(async (channel) => {
+      const channelResource = `channel_${channel.id}` as import('../types/permission.js').ResourceType;
+      const includePsk = isAdmin || (req.user
+        ? await hasPermission(req.user, channelResource, 'write', allChannelsSourceId)
+        : false);
+      return transformChannel(channel, { includePsk });
+    }));
+
     logger.debug(`📡 Serving ${accessible.length} channels (per-row filtered, of ${allChannels.length} total)`);
-    res.json(accessible.map(transformChannel));
+    res.json(projected);
   } catch (error) {
     logger.error('Error fetching all channels:', error);
     res.status(500).json({ error: 'Failed to fetch channels' });
@@ -2561,8 +2573,20 @@ apiRouter.get('/channels', optionalAuth(), async (req, res) => {
       filteredChannels.unshift(primary);
     }
 
+    // MM-SEC-2 follow-up: include the raw `psk` only for callers with write
+    // permission to the specific channel (or admins). Without this, the
+    // channel-config edit dialog can't display the existing key for the
+    // operator who is allowed to change it. See issue #2951.
+    const projected = await Promise.all(filteredChannels.map(async (channel) => {
+      const channelResource = `channel_${channel.id}` as import('../types/permission.js').ResourceType;
+      const includePsk = isAdmin || (req.user
+        ? await hasPermission(req.user, channelResource, 'write', channelsSourceId)
+        : false);
+      return transformChannel(channel, { includePsk });
+    }));
+
     logger.debug(`📡 Serving ${filteredChannels.length} filtered channels (from ${allChannels.length} total)`);
-    res.json(filteredChannels.map(transformChannel));
+    res.json(projected);
   } catch (error) {
     logger.error('Error fetching channels:', error);
     res.status(500).json({ error: 'Failed to fetch channels' });
@@ -4689,9 +4713,15 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
       }
 
       // MM-SEC-2: project through transformChannel so the raw `psk` column
-      // never reaches the response, even though the per-channel permission
-      // gate above already filters out hidden channels.
-      result.channels = filteredChannels.map(transformChannel);
+      // is gated. The per-channel permission gate above already filters out
+      // hidden channels; here we additionally include the actual key only
+      // for callers with write permission to that specific channel (admins
+      // automatically). See issue #2951 — the channel-config UI needs the
+      // existing PSK to display in the edit dialog for authorized operators.
+      result.channels = filteredChannels.map((channel) => {
+        const includePsk = checkPerm(`channel_${channel.id}`, 'write');
+        return transformChannel(channel, { includePsk });
+      });
     } catch (error) {
       logger.error('Error fetching channels in poll:', error);
     }

--- a/src/server/utils/channelView.test.ts
+++ b/src/server/utils/channelView.test.ts
@@ -1,9 +1,14 @@
 /**
- * Unit tests for the shared channel-view projection (MM-SEC-2).
+ * Unit tests for the shared channel-view projection (MM-SEC-2 + #2951).
  */
 
 import { describe, it, expect } from 'vitest';
-import { transformChannel, getRoleName } from './channelView.js';
+import {
+  transformChannel,
+  getRoleName,
+  getEncryptionStatus,
+  DEFAULT_PUBLIC_PSK,
+} from './channelView.js';
 
 describe('channelView', () => {
   describe('getRoleName', () => {
@@ -15,6 +20,22 @@ describe('channelView', () => {
     it('falls back to Unknown for unmapped roles', () => {
       expect(getRoleName(undefined)).toBe('Unknown');
       expect(getRoleName(99)).toBe('Unknown');
+    });
+  });
+
+  describe('getEncryptionStatus', () => {
+    it('returns "none" for missing/empty psk', () => {
+      expect(getEncryptionStatus(undefined)).toBe('none');
+      expect(getEncryptionStatus(null)).toBe('none');
+      expect(getEncryptionStatus('')).toBe('none');
+    });
+    it('returns "default" for the publicly known default key', () => {
+      expect(getEncryptionStatus(DEFAULT_PUBLIC_PSK)).toBe('default');
+      expect(getEncryptionStatus('AQ==')).toBe('default');
+    });
+    it('returns "secure" for any other key', () => {
+      expect(getEncryptionStatus('AdxUQpUaswPOlEvZIWNryuMxW8KmsooSIB0LsDYWQ4Y=')).toBe('secure');
+      expect(getEncryptionStatus('shorthand')).toBe('secure');
     });
   });
 
@@ -33,7 +54,7 @@ describe('channelView', () => {
       sourceId: 'src-uuid',
     };
 
-    it('omits psk', () => {
+    it('omits psk by default', () => {
       const out = transformChannel(dbRow);
       expect(out).not.toHaveProperty('psk');
     });
@@ -45,14 +66,31 @@ describe('channelView', () => {
       expect(out).not.toHaveProperty('sourceId');
     });
 
-    it('whitelists exactly the expected fields', () => {
+    it('whitelists exactly the expected fields when psk is omitted', () => {
       const out = transformChannel(dbRow);
       expect(Object.keys(out).sort()).toEqual(
         [
           'id', 'name', 'role', 'roleName',
-          'uplinkEnabled', 'downlinkEnabled', 'positionPrecision', 'pskSet',
+          'uplinkEnabled', 'downlinkEnabled', 'positionPrecision',
+          'pskSet', 'encryptionStatus',
         ].sort()
       );
+    });
+
+    it('includes psk only when includePsk: true is passed', () => {
+      const omitted = transformChannel(dbRow);
+      expect(omitted).not.toHaveProperty('psk');
+
+      const included = transformChannel(dbRow, { includePsk: true });
+      expect(included).toHaveProperty('psk');
+      expect((included as any).psk).toBe(dbRow.psk);
+    });
+
+    it('returns null psk when includePsk: true and the row has no psk', () => {
+      const included = transformChannel({ ...dbRow, psk: null }, { includePsk: true });
+      expect((included as any).psk).toBeNull();
+      const includedUndef = transformChannel({ ...dbRow, psk: undefined }, { includePsk: true });
+      expect((includedUndef as any).psk).toBeNull();
     });
 
     it('exposes pskSet as a boolean derived from the underlying psk', () => {
@@ -60,6 +98,23 @@ describe('channelView', () => {
       expect(transformChannel({ ...dbRow, psk: '' }).pskSet).toBe(false);
       expect(transformChannel({ ...dbRow, psk: null }).pskSet).toBe(false);
       expect(transformChannel({ ...dbRow, psk: undefined }).pskSet).toBe(false);
+    });
+
+    it('exposes encryptionStatus derived from the underlying psk', () => {
+      expect(transformChannel({ ...dbRow, psk: '' }).encryptionStatus).toBe('none');
+      expect(transformChannel({ ...dbRow, psk: null }).encryptionStatus).toBe('none');
+      expect(transformChannel({ ...dbRow, psk: undefined }).encryptionStatus).toBe('none');
+      expect(transformChannel({ ...dbRow, psk: 'AQ==' }).encryptionStatus).toBe('default');
+      expect(transformChannel({ ...dbRow, psk: 'custom-key' }).encryptionStatus).toBe('secure');
+    });
+
+    it('encryptionStatus is present even when the actual psk is omitted', () => {
+      // Issue #2951: read-only viewers must still get an accurate encryption
+      // badge without ever receiving the key itself.
+      const out = transformChannel({ ...dbRow, psk: 'CustomKey123=' });
+      expect(out).not.toHaveProperty('psk');
+      expect(out.encryptionStatus).toBe('secure');
+      expect(out.pskSet).toBe(true);
     });
 
     it('annotates roleName from role', () => {

--- a/src/server/utils/channelView.ts
+++ b/src/server/utils/channelView.ts
@@ -2,16 +2,32 @@
  * Shared channel response shaping.
  *
  * `transformChannel` is the single canonical whitelist used to project a
- * raw `channels` table row into a public-facing API response. It does NOT
- * include the `psk` column — channel PSKs are sensitive (32-byte symmetric
- * keys that authenticate AND encrypt mesh traffic) and must never reach
- * an HTTP response.
+ * raw `channels` table row into a public-facing API response. The raw
+ * `psk` column (32-byte symmetric key that authenticates AND encrypts mesh
+ * traffic) is sensitive and is only included when the caller can prove
+ * write access to that channel — see `includePsk` below.
  *
  * Used by:
- *   - `routes/v1/channels.ts` (already)
+ *   - `routes/v1/channels.ts`
  *   - `server.ts` /api/channels, /api/channels/all, and the poll handler
- *     (added for MM-SEC-2)
  */
+
+/** Default public PSK (base64 of single byte 0x01) — known publicly, not secure. */
+export const DEFAULT_PUBLIC_PSK = 'AQ==';
+
+export type ChannelEncryptionStatus = 'none' | 'default' | 'secure';
+
+/**
+ * Classify a channel's PSK without exposing the key itself.
+ *   - 'none'    no PSK configured (unencrypted)
+ *   - 'default' the publicly known default key (`AQ==`)
+ *   - 'secure'  any other (custom) key
+ */
+export function getEncryptionStatus(psk: string | null | undefined): ChannelEncryptionStatus {
+  if (!psk || psk === '') return 'none';
+  if (psk === DEFAULT_PUBLIC_PSK) return 'default';
+  return 'secure';
+}
 
 export function getRoleName(role: number | undefined): string {
   switch (role) {
@@ -22,11 +38,29 @@ export function getRoleName(role: number | undefined): string {
   }
 }
 
-export function transformChannel(channel: any) {
-  // `pskSet` is a derived boolean so callers (UI badges, system tests,
-  // configuration export flows) can answer "is a PSK configured on this
-  // channel?" without exposing the actual key material.
-  return {
+export interface TransformChannelOptions {
+  /**
+   * Include the raw `psk` field in the response. ONLY pass `true` when the
+   * caller has been authenticated AND has write permission to the specific
+   * channel (or is an admin). MM-SEC-2 forbids leaking PSKs to unprivileged
+   * callers; see `transformChannelForUser` for the gated helper.
+   */
+  includePsk?: boolean;
+}
+
+/**
+ * Project a raw `channels` row into the public response shape.
+ *
+ * Always returns: `id`, `name`, `role`, `roleName`, `uplinkEnabled`,
+ * `downlinkEnabled`, `positionPrecision`, `pskSet` (boolean), and
+ * `encryptionStatus` ('none' | 'default' | 'secure').
+ *
+ * When `options.includePsk === true`, the actual `psk` string is included
+ * so an authorized admin can see/edit the existing key. The default is to
+ * OMIT the key.
+ */
+export function transformChannel(channel: any, options: TransformChannelOptions = {}) {
+  const base = {
     id: channel.id,
     name: channel.name,
     role: channel.role,
@@ -35,5 +69,10 @@ export function transformChannel(channel: any) {
     downlinkEnabled: channel.downlinkEnabled,
     positionPrecision: channel.positionPrecision,
     pskSet: !!channel.psk,
+    encryptionStatus: getEncryptionStatus(channel.psk),
   };
+  if (options.includePsk) {
+    return { ...base, psk: channel.psk ?? null };
+  }
+  return base;
 }

--- a/src/types/device.ts
+++ b/src/types/device.ts
@@ -57,13 +57,23 @@ export interface DeviceInfo {
 export interface Channel {
   id: number;
   name: string;
-  psk?: string;
+  /**
+   * Raw base64 PSK. Only populated by the API for admins or callers with
+   * `channel_${id}:write` permission for this channel (MM-SEC-2 / #2951).
+   * Read-only consumers should rely on `encryptionStatus` / `pskSet` instead.
+   */
+  psk?: string | null;
+  /** Server-derived: whether a PSK is configured (safe for all viewers). */
+  pskSet?: boolean;
+  /** Server-derived encryption status (safe for all viewers). */
+  encryptionStatus?: 'none' | 'default' | 'secure';
   role?: number; // 0=Disabled, 1=Primary, 2=Secondary
+  roleName?: string;
   uplinkEnabled: boolean;
   downlinkEnabled: boolean;
   positionPrecision?: number; // Location precision bits (0-32)
-  createdAt: number;
-  updatedAt: number;
+  createdAt?: number;
+  updatedAt?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- MM-SEC-2 (commit `189cc8ea`) stripped `psk` from every channel API response to stop leaking keys to anonymous viewers. Side effect: admins editing a channel saw an **empty PSK field** and every encryption icon read "**unencrypted**" because the frontend computed status from an always-undefined `psk`.
- This PR keeps the original security guarantee (read-only/anonymous callers never receive PSK material) **and** restores the config UI by sending the actual `psk` only to admins or callers with `channel_${id}:write` permission for that source. A server-derived `encryptionStatus` (`'none' | 'default' | 'secure'`) is now always present so icons render correctly even without the key.

## What changed

- **`src/server/utils/channelView.ts`** — `transformChannel(channel, { includePsk })`. Always emits `encryptionStatus` and `pskSet`; conditionally emits the raw `psk` when `includePsk: true`. New `getEncryptionStatus()` / `DEFAULT_PUBLIC_PSK` exports.
- **API endpoints** (`server.ts` `/api/channels`, `/api/channels/all`, `/api/poll` channels block; `routes/v1/channels.ts`; `routes/sourceRoutes.ts`) — pass `includePsk` per channel based on `channel_${id}:write` (admin gets it automatically).
- **Frontend** (`ChannelsTab.tsx`, `ChannelsConfigSection.tsx`, `NodeFilterPopup.tsx`) — prefer server-derived `encryptionStatus`, fall back to local PSK derivation only for virtual / channel-database entries that carry the key locally.
- **`Channel` type** (`types/device.ts`) — adds optional `encryptionStatus`, `pskSet`, `roleName`.
- **Tests** — `channelView.test.ts` covers the new `encryptionStatus` field and the `includePsk` gating. `sourceRoutes.security.test.ts` updated: read-only viewers still get no `psk`, writers/admins do.

Verified against the dev container: anonymous `GET /api/channels` returns `pskSet` + `encryptionStatus` but no `psk`; admin response includes the actual `psk` so the channel-config edit dialog can prefill it.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 4745 pass / 0 fail
- [x] Manual: anonymous `/api/channels` has `encryptionStatus` but no `psk`
- [x] Manual: admin `/api/channels` includes the actual `psk`
- [ ] CI green
- [ ] Manual sanity in container: channel info popup shows encryption status correctly for read-only users
- [ ] Manual sanity in container: channel-edit dialog prefills the existing PSK for admin

Fixes #2951.

🤖 Generated with [Claude Code](https://claude.com/claude-code)