### PR TITLE
Fix: don't record 0-hop telemetry when hop_start is unset

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -4175,10 +4175,14 @@ class MeshtasticManager implements ISourceManager {
         }
       }
 
-      // Track message hops (hopStart - hopLimit) for "All messages" hop calculation mode
+      // Track message hops (hopStart - hopLimit) for "All messages" hop calculation mode.
+      // hop_start is a proto3 uint32 scalar (not optional), so an unset field decodes as 0
+      // — indistinguishable from "really started at 0". Require hopStart > 0 so we don't
+      // record bogus 0-hop telemetry for packets where the sender never populated hop_start
+      // (older firmware, some MQTT-bridged paths, transports that strip the LoRa header bits).
       const hopStart = meshPacket.hopStart ?? meshPacket.hop_start;
       const hopLimit = meshPacket.hopLimit ?? meshPacket.hop_limit;
-      if (hopStart !== undefined && hopStart !== null &&
+      if (hopStart !== undefined && hopStart !== null && hopStart > 0 &&
           hopLimit !== undefined && hopLimit !== null &&
           hopStart >= hopLimit) {
         const messageHops = hopStart - hopLimit;


### PR DESCRIPTION
## Summary
- `MeshPacket.hop_start` is a proto3 `uint32` scalar (not `optional`), so an unset field decodes as `0` — indistinguishable from a packet that genuinely started with `hop_start=0`.
- The existing guard only checked for `undefined`/`null`, so packets with unset `hop_start` were treated as real 0 and recorded `messageHops=0` telemetry. Users on topologies where the upstream firmware/MQTT path doesn't populate `hop_start` saw every node flatlined at 0 hops.
- Add `hopStart > 0` to the guard. A real populated `hop_start` is the original TTL (typically 3/5/7), never 0 in practice, so this cleanly distinguishes "field set" from "field defaulted".

Reported in `#bug-0-hops` — user reporting every node showing `messageHops=0`.

## Test plan
- [ ] Type-check passes (verified locally: `tsc --noEmit -p tsconfig.server.json`)
- [ ] Existing meshtasticManager tests still pass
- [ ] Confirm with affected user that telemetry stops flatlining at 0 once their nodes receive a packet whose sender does populate `hop_start`