### PR TITLE
feat(meshcore): collapse global meshcore permission (slice 3/N)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -609,7 +609,6 @@ function App() {
 
     const isAdmin = authStatus?.user?.isAdmin || false;
     const isAuthenticated = authStatus?.authenticated || false;
-    const meshcoreEnabled = authStatus?.meshcoreEnabled || false;
 
     // Mirrors Sidebar.tsx hasAnyChannelPermission — channels tab is reachable
     // if the user can read at least one channel (channel_0..channel_7).
@@ -628,7 +627,10 @@ function App() {
       info: () => hasPermission('info', 'read'),
       messages: () => hasPermission('messages', 'read'),
       channels: hasAnyChannelPermission,
-      meshcore: () => meshcoreEnabled && hasPermission('meshcore', 'read'),
+      // Slice 3 dropped the global `meshcore` permission resource; the
+      // standalone MeshCore tab is gated off until slice 4 rebuilds the
+      // surface as per-source dashboards under /api/sources/:id/meshcore.
+      meshcore: () => false,
       settings: () => hasPermission('settings', 'read'),
       automation: () => hasPermission('automation', 'read'),
       configuration: () => hasPermission('configuration', 'read'),
@@ -5271,7 +5273,7 @@ function App() {
           shortName: n.user?.shortName || '????',
         }))}
         canSearchDms={hasPermission('messages', 'read')}
-        canSearchMeshcore={hasPermission('meshcore', 'read')}
+        canSearchMeshcore={false}
       />
 
       {/* SaveBar for unified save/dismiss actions */}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -86,7 +86,6 @@ const Sidebar: React.FC<SidebarProps> = ({
   onSearchClick,
   baseUrl,
   connectedNodeName,
-  meshcoreEnabled,
   packetLogEnabled
 }) => {
   const { t } = useTranslation();
@@ -253,9 +252,9 @@ const Sidebar: React.FC<SidebarProps> = ({
           {hasPermission('dashboard', 'read') && (
             <NavItem id="dashboard" label={t('nav.dashboard')} icon={icon('dashboard')} />
           )}
-          {meshcoreEnabled && hasPermission('meshcore', 'read') && (
-            <NavItem id="meshcore" label={t('nav.meshcore', 'MeshCore')} icon={icon('meshcore')} />
-          )}
+          {/* Slice 3 dropped the global `meshcore` permission; the legacy
+              standalone MeshCore tab is hidden until slice 4 lands the
+              per-source dashboards. */}
           {packetLogEnabled && hasPermission('packetmonitor', 'read') && (
             <NavItem id="packetmonitor" label={t('nav.packet_monitor', 'Packet Monitor')} icon={icon('packetmonitor')} />
           )}

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 55 migrations registered', () => {
-    expect(registry.count()).toBe(55);
+  it('has all 56 migrations registered', () => {
+    expect(registry.count()).toBe(56);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,14 +12,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is seed_global_waypoints_permission', () => {
+  it('last migration is add_source_id_to_meshcore_tables', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(55);
-    expect(last.name).toContain('seed_global_waypoints_permission');
+    expect(last.number).toBe(56);
+    expect(last.name).toContain('add_source_id_to_meshcore_tables');
   });
 
-  it('migrations are sequentially numbered from 1 to 55', () => {
+  it('migrations are sequentially numbered from 1 to 56', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -67,6 +67,7 @@ import { migration as addSourceIdToEmbedProfilesMigration, runMigration052Postgr
 import { migration as createWaypointsMigration, runMigration053Postgres, runMigration053Mysql } from '../server/migrations/053_create_waypoints.js';
 import { migration as addWaypointsPermissionMigration, runMigration054Postgres, runMigration054Mysql } from '../server/migrations/054_add_waypoints_permission.js';
 import { migration as seedGlobalWaypointsPermissionMigration, runMigration055Postgres, runMigration055Mysql } from '../server/migrations/055_seed_global_waypoints_permission.js';
+import { migration as addSourceIdToMeshcoreTablesMigration, runMigration056Postgres, runMigration056Mysql } from '../server/migrations/056_add_source_id_to_meshcore_tables.js';
 
 // ============================================================================
 // Registry
@@ -856,4 +857,20 @@ registry.register({
   sqlite: (db) => seedGlobalWaypointsPermissionMigration.up(db),
   postgres: (client) => runMigration055Postgres(client),
   mysql: (pool) => runMigration055Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 056: Add nullable sourceId to meshcore_nodes / meshcore_messages
+// (mirrors migration 021 for Meshtastic) and synthesise a legacy default
+// MeshCore source for any pre-existing rows. First slice of the MeshCore
+// per-source refactor — the manager registry now keys on sourceId.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 56,
+  name: 'add_source_id_to_meshcore_tables',
+  settingsKey: 'migration_056_add_source_id_to_meshcore_tables',
+  sqlite: (db) => addSourceIdToMeshcoreTablesMigration.up(db),
+  postgres: (client) => runMigration056Postgres(client),
+  mysql: (pool) => runMigration056Mysql(pool),
 });

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -68,6 +68,7 @@ import { migration as createWaypointsMigration, runMigration053Postgres, runMigr
 import { migration as addWaypointsPermissionMigration, runMigration054Postgres, runMigration054Mysql } from '../server/migrations/054_add_waypoints_permission.js';
 import { migration as seedGlobalWaypointsPermissionMigration, runMigration055Postgres, runMigration055Mysql } from '../server/migrations/055_seed_global_waypoints_permission.js';
 import { migration as addSourceIdToMeshcoreTablesMigration, runMigration056Postgres, runMigration056Mysql } from '../server/migrations/056_add_source_id_to_meshcore_tables.js';
+import { migration as collapseMeshcoreResourceMigration, runMigration057Postgres, runMigration057Mysql } from '../server/migrations/057_collapse_meshcore_resource.js';
 
 // ============================================================================
 // Registry
@@ -873,4 +874,21 @@ registry.register({
   sqlite: (db) => addSourceIdToMeshcoreTablesMigration.up(db),
   postgres: (client) => runMigration056Postgres(client),
   mysql: (pool) => runMigration056Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 057: Collapse the global `meshcore` permission resource into
+// the per-source sourcey set. Expands each global meshcore grant into
+// (connection, configuration, nodes, messages) rows scoped per
+// meshcore-typed source, then drops the originals. Slice 3 of the
+// MeshCore per-source refactor.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 57,
+  name: 'collapse_meshcore_resource',
+  settingsKey: 'migration_057_collapse_meshcore_resource',
+  sqlite: (db) => collapseMeshcoreResourceMigration.up(db),
+  postgres: (client) => runMigration057Postgres(client),
+  mysql: (pool) => runMigration057Mysql(pool),
 });

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -1,0 +1,134 @@
+/**
+ * MeshCore Repository Tests
+ *
+ * Slice 1 of multi-source MeshCore: every write to `meshcore_nodes` /
+ * `meshcore_messages` must be stamped with its owning sourceId.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { MeshCoreRepository } from './meshcore.js';
+import * as schema from '../schema/index.js';
+
+describe('MeshCoreRepository — sourceId stamping', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: MeshCoreRepository;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+
+    // Match the post-migration-056 schema.
+    db.exec(`
+      CREATE TABLE meshcore_nodes (
+        publicKey TEXT PRIMARY KEY,
+        name TEXT,
+        advType INTEGER,
+        txPower INTEGER,
+        maxTxPower INTEGER,
+        radioFreq REAL,
+        radioBw REAL,
+        radioSf INTEGER,
+        radioCr INTEGER,
+        latitude REAL,
+        longitude REAL,
+        altitude REAL,
+        batteryMv INTEGER,
+        uptimeSecs INTEGER,
+        rssi INTEGER,
+        snr REAL,
+        lastHeard INTEGER,
+        hasAdminAccess INTEGER DEFAULT 0,
+        lastAdminCheck INTEGER,
+        isLocalNode INTEGER DEFAULT 0,
+        sourceId TEXT,
+        createdAt INTEGER NOT NULL,
+        updatedAt INTEGER NOT NULL
+      );
+      CREATE TABLE meshcore_messages (
+        id TEXT PRIMARY KEY,
+        fromPublicKey TEXT NOT NULL,
+        toPublicKey TEXT,
+        text TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        rssi INTEGER,
+        snr INTEGER,
+        messageType TEXT DEFAULT 'text',
+        delivered INTEGER DEFAULT 0,
+        deliveredAt INTEGER,
+        sourceId TEXT,
+        createdAt INTEGER NOT NULL
+      );
+    `);
+
+    drizzleDb = drizzle(db, { schema });
+    repo = new MeshCoreRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('upsertNode stamps sourceId on insert', async () => {
+    await repo.upsertNode({ publicKey: 'pk-1', name: 'first' }, 'src-a');
+
+    const row = db.prepare(`SELECT sourceId, name FROM meshcore_nodes WHERE publicKey = 'pk-1'`).get() as {
+      sourceId: string;
+      name: string;
+    };
+    expect(row.sourceId).toBe('src-a');
+    expect(row.name).toBe('first');
+  });
+
+  it('upsertNode stamps sourceId on update too', async () => {
+    await repo.upsertNode({ publicKey: 'pk-1', name: 'first' }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk-1', name: 'updated' }, 'src-b');
+
+    const row = db.prepare(`SELECT sourceId, name FROM meshcore_nodes WHERE publicKey = 'pk-1'`).get() as {
+      sourceId: string;
+      name: string;
+    };
+    expect(row.sourceId).toBe('src-b');
+    expect(row.name).toBe('updated');
+  });
+
+  it('upsertNode throws when called without a sourceId', async () => {
+    // @ts-expect-error — exercising runtime guard
+    await expect(repo.upsertNode({ publicKey: 'pk-1' }, '')).rejects.toThrow(/requires a sourceId/);
+  });
+
+  it('insertMessage stamps sourceId', async () => {
+    await repo.insertMessage(
+      {
+        id: 'm1',
+        fromPublicKey: 'pk-1',
+        text: 'hello',
+        timestamp: 1000,
+        createdAt: 1000,
+      },
+      'src-a',
+    );
+
+    const row = db.prepare(`SELECT sourceId, text FROM meshcore_messages WHERE id = 'm1'`).get() as {
+      sourceId: string;
+      text: string;
+    };
+    expect(row.sourceId).toBe('src-a');
+    expect(row.text).toBe('hello');
+  });
+
+  it('insertMessage throws when called without a sourceId', async () => {
+    await expect(
+      repo.insertMessage(
+        {
+          id: 'm1',
+          fromPublicKey: 'pk-1',
+          text: 'hello',
+          timestamp: 1000,
+          createdAt: 1000,
+        },
+        '',
+      ),
+    ).rejects.toThrow(/requires a sourceId/);
+  });
+});

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -80,16 +80,92 @@ describe('MeshCoreRepository — sourceId stamping', () => {
     expect(row.name).toBe('first');
   });
 
-  it('upsertNode stamps sourceId on update too', async () => {
+  it('upsertNode updates same-source row in place', async () => {
     await repo.upsertNode({ publicKey: 'pk-1', name: 'first' }, 'src-a');
-    await repo.upsertNode({ publicKey: 'pk-1', name: 'updated' }, 'src-b');
+    await repo.upsertNode({ publicKey: 'pk-1', name: 'updated' }, 'src-a');
 
     const row = db.prepare(`SELECT sourceId, name FROM meshcore_nodes WHERE publicKey = 'pk-1'`).get() as {
       sourceId: string;
       name: string;
     };
-    expect(row.sourceId).toBe('src-b');
+    expect(row.sourceId).toBe('src-a');
     expect(row.name).toBe('updated');
+  });
+
+  it('upsertNode does not let one source clobber another source\'s row', async () => {
+    // Drop the SQLite PRIMARY KEY so the underlying schema can hold one
+    // row per (publicKey, sourceId) — the eventual shape per the slice-1
+    // PR description ("composite PK like Meshtastic"). Once that schema
+    // change lands this guard goes away; the upsert-level scoping is
+    // what we're proving here.
+    db.exec(`
+      DROP TABLE meshcore_nodes;
+      CREATE TABLE meshcore_nodes (
+        publicKey TEXT NOT NULL,
+        name TEXT,
+        advType INTEGER,
+        txPower INTEGER,
+        maxTxPower INTEGER,
+        radioFreq REAL,
+        radioBw REAL,
+        radioSf INTEGER,
+        radioCr INTEGER,
+        latitude REAL,
+        longitude REAL,
+        altitude REAL,
+        batteryMv INTEGER,
+        uptimeSecs INTEGER,
+        rssi INTEGER,
+        snr REAL,
+        lastHeard INTEGER,
+        hasAdminAccess INTEGER DEFAULT 0,
+        lastAdminCheck INTEGER,
+        isLocalNode INTEGER DEFAULT 0,
+        sourceId TEXT NOT NULL,
+        createdAt INTEGER NOT NULL,
+        updatedAt INTEGER NOT NULL,
+        PRIMARY KEY (publicKey, sourceId)
+      );
+    `);
+
+    await repo.upsertNode({ publicKey: 'pk-shared', name: 'A-owned' }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk-shared', name: 'B-owned' }, 'src-b');
+
+    const rows = db
+      .prepare(`SELECT sourceId, name FROM meshcore_nodes WHERE publicKey = 'pk-shared' ORDER BY sourceId`)
+      .all() as Array<{ sourceId: string; name: string }>;
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({ sourceId: 'src-a', name: 'A-owned' });
+    expect(rows[1]).toEqual({ sourceId: 'src-b', name: 'B-owned' });
+  });
+
+  it('upsertNode lookup is sourceId-scoped (no cross-source UPDATE)', async () => {
+    // Even with the singleton-PK schema in place, the repository must not
+    // issue an UPDATE against another source's row. We seed src-a's row,
+    // then have src-b try to upsert the same publicKey: src-a's row must
+    // not be modified. (The INSERT may then collide on PK; that's a
+    // schema-level concern handled by the composite-PK migration —
+    // separately. The repository contract is the focus here.)
+    await repo.upsertNode({ publicKey: 'pk-shared', name: 'A-owned' }, 'src-a');
+
+    let threw = false;
+    try {
+      await repo.upsertNode({ publicKey: 'pk-shared', name: 'B-attempt' }, 'src-b');
+    } catch {
+      threw = true;
+    }
+
+    const aRow = db
+      .prepare(`SELECT sourceId, name FROM meshcore_nodes WHERE publicKey = 'pk-shared' AND sourceId = 'src-a'`)
+      .get() as { sourceId: string; name: string } | undefined;
+    expect(aRow).toBeDefined();
+    expect(aRow!.name).toBe('A-owned');
+    // The row owned by src-a must never carry src-b's name.
+    expect(aRow!.sourceId).toBe('src-a');
+    // Either the INSERT collided (PK constraint) or it succeeded —
+    // both are acceptable; the invariant is "src-a's row is untouched".
+    expect(typeof threw).toBe('boolean');
   });
 
   it('upsertNode throws when called without a sourceId', async () => {

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -32,6 +32,8 @@ export interface DbMeshCoreNode {
   hasAdminAccess?: boolean | null;
   lastAdminCheck?: number | null;
   isLocalNode?: boolean | null;
+  /** Owning source id; required on writes since slice 1 (migration 056). */
+  sourceId?: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -50,6 +52,8 @@ export interface DbMeshCoreMessage {
   messageType?: string | null;
   delivered?: boolean | null;
   deliveredAt?: number | null;
+  /** Owning source id; required on writes since slice 1 (migration 056). */
+  sourceId?: string | null;
   createdAt: number;
 }
 
@@ -102,9 +106,17 @@ export class MeshCoreRepository extends BaseRepository {
   }
 
   /**
-   * Upsert a MeshCore node (insert or update)
+   * Upsert a MeshCore node (insert or update). `sourceId` is required so
+   * every row in `meshcore_nodes` is stamped with its owning source —
+   * non-negotiable since the multi-source MeshCore refactor (slice 1).
    */
-  async upsertNode(node: Partial<DbMeshCoreNode> & { publicKey: string }): Promise<void> {
+  async upsertNode(
+    node: Partial<DbMeshCoreNode> & { publicKey: string },
+    sourceId: string,
+  ): Promise<void> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.upsertNode requires a sourceId');
+    }
     const now = this.now();
     const { meshcoreNodes } = this.tables;
     const existing = await this.getNodeByPublicKey(node.publicKey);
@@ -112,13 +124,14 @@ export class MeshCoreRepository extends BaseRepository {
     if (existing) {
       await this.db
         .update(meshcoreNodes)
-        .set({ ...node, updatedAt: now })
+        .set({ ...node, sourceId, updatedAt: now })
         .where(eq(meshcoreNodes.publicKey, node.publicKey));
     } else {
       await this.db
         .insert(meshcoreNodes)
         .values({
           ...node,
+          sourceId,
           createdAt: now,
           updatedAt: now,
         });
@@ -199,11 +212,15 @@ export class MeshCoreRepository extends BaseRepository {
   }
 
   /**
-   * Insert a message
+   * Insert a message. `sourceId` is required so every row in
+   * `meshcore_messages` is stamped with its owning source.
    */
-  async insertMessage(message: DbMeshCoreMessage): Promise<void> {
+  async insertMessage(message: DbMeshCoreMessage, sourceId: string): Promise<void> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.insertMessage requires a sourceId');
+    }
     const { meshcoreMessages } = this.tables;
-    await this.db.insert(meshcoreMessages).values(message);
+    await this.db.insert(meshcoreMessages).values({ ...message, sourceId });
   }
 
   /**

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -4,7 +4,7 @@
  * Handles MeshCore node and message database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, desc, sql, isNull } from 'drizzle-orm';
+import { eq, desc, sql, isNull, and, lt } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType } from '../types.js';
 
@@ -80,7 +80,10 @@ export class MeshCoreRepository extends BaseRepository {
   }
 
   /**
-   * Get a specific node by public key
+   * Get a specific node by public key, ignoring source ownership.
+   * Prefer `getNodeByPublicKeyAndSource` for write paths — this variant
+   * exists for cross-source read paths that legitimately don't care which
+   * source owns the row.
    */
   async getNodeByPublicKey(publicKey: string): Promise<DbMeshCoreNode | null> {
     const { meshcoreNodes } = this.tables;
@@ -88,6 +91,25 @@ export class MeshCoreRepository extends BaseRepository {
       .select()
       .from(meshcoreNodes)
       .where(eq(meshcoreNodes.publicKey, publicKey))
+      .limit(1);
+    return result[0] ? this.normalizeBigInts(result[0]) as unknown as DbMeshCoreNode : null;
+  }
+
+  /**
+   * Get a node scoped by both publicKey and sourceId. Required for any
+   * write path: looking up by publicKey alone would let one source's
+   * upsert clobber another source's row when both happen to advertise
+   * the same key.
+   */
+  async getNodeByPublicKeyAndSource(
+    publicKey: string,
+    sourceId: string,
+  ): Promise<DbMeshCoreNode | null> {
+    const { meshcoreNodes } = this.tables;
+    const result = await this.db
+      .select()
+      .from(meshcoreNodes)
+      .where(and(eq(meshcoreNodes.publicKey, publicKey), eq(meshcoreNodes.sourceId, sourceId)))
       .limit(1);
     return result[0] ? this.normalizeBigInts(result[0]) as unknown as DbMeshCoreNode : null;
   }
@@ -119,13 +141,13 @@ export class MeshCoreRepository extends BaseRepository {
     }
     const now = this.now();
     const { meshcoreNodes } = this.tables;
-    const existing = await this.getNodeByPublicKey(node.publicKey);
+    const existing = await this.getNodeByPublicKeyAndSource(node.publicKey, sourceId);
 
     if (existing) {
       await this.db
         .update(meshcoreNodes)
         .set({ ...node, sourceId, updatedAt: now })
-        .where(eq(meshcoreNodes.publicKey, node.publicKey));
+        .where(and(eq(meshcoreNodes.publicKey, node.publicKey), eq(meshcoreNodes.sourceId, sourceId)));
     } else {
       await this.db
         .insert(meshcoreNodes)
@@ -252,11 +274,13 @@ export class MeshCoreRepository extends BaseRepository {
     const toDelete = await this.db
       .select({ id: meshcoreMessages.id })
       .from(meshcoreMessages)
-      .where(sql`${meshcoreMessages.timestamp} < ${timestamp}`);
+      .where(lt(meshcoreMessages.timestamp, timestamp));
 
-    for (const msg of toDelete) {
-      await this.db.delete(meshcoreMessages).where(eq(meshcoreMessages.id, msg.id));
-    }
+    if (toDelete.length === 0) return 0;
+
+    await this.db
+      .delete(meshcoreMessages)
+      .where(lt(meshcoreMessages.timestamp, timestamp));
     return toDelete.length;
   }
 

--- a/src/db/schema/meshcoreMessages.ts
+++ b/src/db/schema/meshcoreMessages.ts
@@ -35,6 +35,9 @@ export const meshcoreMessagesSqlite = sqliteTable('meshcore_messages', {
   delivered: integer('delivered', { mode: 'boolean' }).default(false),
   deliveredAt: integer('deliveredAt'),
 
+  // Owning source (nullable for legacy single-source rows; backfilled by migration 056)
+  sourceId: text('sourceId'),
+
   // Timestamps
   createdAt: integer('createdAt').notNull(),
 });
@@ -52,6 +55,7 @@ export const meshcoreMessagesPostgres = pgTable('meshcore_messages', {
   messageType: pgText('messageType').default('text'),
   delivered: pgBoolean('delivered').default(false),
   deliveredAt: pgBigint('deliveredAt', { mode: 'number' }),
+  sourceId: pgText('sourceId'),
   createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
 });
 
@@ -68,6 +72,7 @@ export const meshcoreMessagesMysql = mysqlTable('meshcore_messages', {
   messageType: myVarchar('messageType', { length: 32 }).default('text'),
   delivered: myBoolean('delivered').default(false),
   deliveredAt: myBigint('deliveredAt', { mode: 'number' }),
+  sourceId: myVarchar('sourceId', { length: 64 }),
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
 });
 

--- a/src/db/schema/meshcoreNodes.ts
+++ b/src/db/schema/meshcoreNodes.ts
@@ -58,6 +58,9 @@ export const meshcoreNodesSqlite = sqliteTable('meshcore_nodes', {
   // Local node indicator
   isLocalNode: integer('isLocalNode', { mode: 'boolean' }).default(false),
 
+  // Owning source (nullable for legacy single-source rows; backfilled by migration 056)
+  sourceId: text('sourceId'),
+
   // Timestamps
   createdAt: integer('createdAt').notNull(),
   updatedAt: integer('updatedAt').notNull(),
@@ -95,6 +98,8 @@ export const meshcoreNodesPostgres = pgTable('meshcore_nodes', {
 
   isLocalNode: pgBoolean('isLocalNode').default(false),
 
+  sourceId: pgText('sourceId'),
+
   createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
   updatedAt: pgBigint('updatedAt', { mode: 'number' }).notNull(),
 });
@@ -130,6 +135,8 @@ export const meshcoreNodesMysql = mysqlTable('meshcore_nodes', {
   lastAdminCheck: myBigint('lastAdminCheck', { mode: 'number' }),
 
   isLocalNode: myBoolean('isLocalNode').default(false),
+
+  sourceId: myVarchar('sourceId', { length: 64 }),
 
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
   updatedAt: myBigint('updatedAt', { mode: 'number' }).notNull(),

--- a/src/server/auth/localAuth.ts
+++ b/src/server/auth/localAuth.ts
@@ -94,7 +94,7 @@ export async function createLocalUser(
     }
     // Admin gets additional permissions
     if (isAdmin) {
-      const adminResources = ['configuration', 'automation', 'connection', 'audit', 'security', 'themes', 'nodes_private', 'meshcore', 'packetmonitor'];
+      const adminResources = ['configuration', 'automation', 'connection', 'audit', 'security', 'themes', 'nodes_private', 'packetmonitor'];
       for (const resource of adminResources) {
         await databaseService.auth.createPermission({
           userId,

--- a/src/server/auth/oidcAuth.ts
+++ b/src/server/auth/oidcAuth.ts
@@ -273,7 +273,7 @@ export async function handleOIDCCallback(
             'automation', 'connection', 'traceroute', 'audit', 'security', 'themes',
             'channel_0', 'channel_1', 'channel_2', 'channel_3',
             'channel_4', 'channel_5', 'channel_6', 'channel_7',
-            'nodes_private', 'meshcore', 'packetmonitor'
+            'nodes_private', 'packetmonitor'
           ];
           for (const resource of allResources) {
             await databaseService.auth.createPermission({

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -103,6 +103,12 @@ export interface MeshCoreMessage {
   timestamp: number;
   rssi?: number;
   snr?: number;
+  /**
+   * Owning source. Set by the MeshCoreManager that produced the message;
+   * persisted into meshcore_messages.sourceId so the row can be filtered
+   * per source.
+   */
+  sourceId?: string;
 }
 
 export interface MeshCoreStatus {
@@ -132,6 +138,14 @@ const __dirname = path.dirname(__filename);
  * Handles connection and communication with MeshCore devices
  */
 class MeshCoreManager extends EventEmitter {
+  /**
+   * The owning source this manager belongs to. Every write the manager
+   * performs into `meshcore_nodes` / `meshcore_messages` is stamped with
+   * this id. Required since slice 1 of the multi-source MeshCore refactor
+   * (migration 056).
+   */
+  public readonly sourceId: string;
+
   private config: MeshCoreConfig | null = null;
   private connected: boolean = false;
   private deviceType: MeshCoreDeviceType = MeshCoreDeviceType.UNKNOWN;
@@ -160,9 +174,13 @@ class MeshCoreManager extends EventEmitter {
   // Message limit to prevent unbounded growth
   private static readonly MAX_MESSAGES = 1000;
 
-  constructor() {
+  constructor(sourceId: string) {
     super();
-    logger.info('[MeshCore] Manager initialized');
+    if (!sourceId) {
+      throw new Error('MeshCoreManager requires a sourceId');
+    }
+    this.sourceId = sourceId;
+    logger.info(`[MeshCore:${sourceId}] Manager initialized`);
   }
 
   /**
@@ -462,10 +480,11 @@ class MeshCoreManager extends EventEmitter {
         text: data.text,
         timestamp: data.sender_timestamp ? data.sender_timestamp * 1000 : Date.now(),
         snr: data.snr,
+        sourceId: this.sourceId,
       };
       this.addMessage(message);
       this.emit('message', message);
-      logger.info(`[MeshCore] Contact message from ${data.pubkey_prefix}: ${data.text}`);
+      logger.info(`[MeshCore:${this.sourceId}] Contact message from ${data.pubkey_prefix}: ${data.text}`);
     } else if (event_type === 'channel_message') {
       const message: MeshCoreMessage = {
         id: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
@@ -473,6 +492,7 @@ class MeshCoreManager extends EventEmitter {
         text: data.text,
         timestamp: data.sender_timestamp ? data.sender_timestamp * 1000 : Date.now(),
         snr: data.snr,
+        sourceId: this.sourceId,
       };
       this.addMessage(message);
       this.emit('message', message);
@@ -575,6 +595,7 @@ class MeshCoreManager extends EventEmitter {
         fromPublicKey: match[1],
         text: match[2],
         timestamp: Date.now(),
+        sourceId: this.sourceId,
       };
       this.addMessage(message);
       this.emit('message', message);
@@ -813,6 +834,7 @@ class MeshCoreManager extends EventEmitter {
           toPublicKey: toPublicKey || undefined,
           text: text,
           timestamp: Date.now(),
+          sourceId: this.sourceId,
         };
         this.addMessage(sentMessage);
         this.emit('message', sentMessage);
@@ -1023,7 +1045,4 @@ class MeshCoreManager extends EventEmitter {
   }
 }
 
-// Export singleton instance
-const meshcoreManager = new MeshCoreManager();
-export default meshcoreManager;
 export { MeshCoreManager };

--- a/src/server/meshcoreRegistry.test.ts
+++ b/src/server/meshcoreRegistry.test.ts
@@ -1,0 +1,109 @@
+/**
+ * MeshCoreManagerRegistry — lifecycle tests for the per-source factory.
+ * Mirrors what `sourceManagerRegistry` does for Meshtastic TCP, but for
+ * MeshCore. We exercise pure registry plumbing here; the actual device
+ * connection logic in MeshCoreManager is out of scope for this slice.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MeshCoreManagerRegistry, meshcoreConfigFromSource } from './meshcoreRegistry.js';
+import { ConnectionType } from './meshcoreManager.js';
+import type { Source } from '../db/repositories/sources.js';
+
+function fakeSource(overrides: Partial<Source> = {}): Source {
+  return {
+    id: 'src-a',
+    name: 'A',
+    type: 'meshcore',
+    config: { transport: 'usb', port: '/dev/ttyACM0', deviceType: 'companion' },
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+    createdBy: null,
+    ...overrides,
+  };
+}
+
+describe('MeshCoreManagerRegistry', () => {
+  let registry: MeshCoreManagerRegistry;
+
+  beforeEach(() => {
+    registry = new MeshCoreManagerRegistry();
+  });
+
+  it('getOrCreate returns the same instance for the same source id', () => {
+    const a = registry.getOrCreate(fakeSource({ id: 'a' }));
+    const a2 = registry.getOrCreate(fakeSource({ id: 'a', name: 'A renamed' }));
+    expect(a).toBe(a2);
+    expect(a.sourceId).toBe('a');
+  });
+
+  it('getOrCreate yields independent instances per source id', () => {
+    const a = registry.getOrCreate(fakeSource({ id: 'a' }));
+    const b = registry.getOrCreate(fakeSource({ id: 'b' }));
+    expect(a).not.toBe(b);
+    expect(a.sourceId).toBe('a');
+    expect(b.sourceId).toBe('b');
+  });
+
+  it('list returns every registered manager', () => {
+    registry.getOrCreate(fakeSource({ id: 'a' }));
+    registry.getOrCreate(fakeSource({ id: 'b' }));
+    const ids = registry.list().map(m => m.sourceId).sort();
+    expect(ids).toEqual(['a', 'b']);
+  });
+
+  it('remove disconnects and forgets the manager', async () => {
+    const m = registry.getOrCreate(fakeSource({ id: 'a' }));
+    expect(registry.get('a')).toBe(m);
+    await registry.remove('a');
+    expect(registry.get('a')).toBeUndefined();
+    expect(registry.list()).toHaveLength(0);
+  });
+
+  it('disconnectAll clears the registry', async () => {
+    registry.getOrCreate(fakeSource({ id: 'a' }));
+    registry.getOrCreate(fakeSource({ id: 'b' }));
+    await registry.disconnectAll();
+    expect(registry.list()).toHaveLength(0);
+  });
+
+  it('getOrCreateLegacyManager lazily creates a manager keyed by the legacy id', () => {
+    const m = registry.getOrCreateLegacyManager();
+    expect(m.sourceId).toBe('meshcore-legacy-default');
+    // Subsequent calls reuse the same instance
+    expect(registry.getOrCreateLegacyManager()).toBe(m);
+  });
+});
+
+describe('meshcoreConfigFromSource', () => {
+  it('maps companion-USB source config to a SERIAL MeshCoreConfig', () => {
+    const cfg = meshcoreConfigFromSource(
+      fakeSource({ config: { transport: 'usb', port: '/dev/ttyACM0', deviceType: 'companion' } }),
+    );
+    expect(cfg).toEqual({
+      connectionType: ConnectionType.SERIAL,
+      serialPort: '/dev/ttyACM0',
+      baudRate: 115200,
+      firmwareType: 'companion',
+    });
+  });
+
+  it('maps tcp source config when host is set', () => {
+    const cfg = meshcoreConfigFromSource(
+      fakeSource({ config: { transport: 'tcp', tcpHost: '10.0.0.5', tcpPort: 4404, deviceType: 'companion' } }),
+    );
+    expect(cfg).toEqual({
+      connectionType: ConnectionType.TCP,
+      tcpHost: '10.0.0.5',
+      tcpPort: 4404,
+      firmwareType: 'companion',
+    });
+  });
+
+  it('returns null when companion-USB source has no port set (legacy seed default)', () => {
+    const cfg = meshcoreConfigFromSource(
+      fakeSource({ config: { transport: 'usb', port: '', deviceType: 'companion' } }),
+    );
+    expect(cfg).toBeNull();
+  });
+});

--- a/src/server/meshcoreRegistry.ts
+++ b/src/server/meshcoreRegistry.ts
@@ -1,0 +1,163 @@
+/**
+ * MeshCoreManagerRegistry — per-source registry of MeshCoreManager instances.
+ *
+ * Slice 1 of the multi-source MeshCore refactor (companion-USB only):
+ * lifts MeshCore from a module-level singleton to one manager per
+ * `sources.id`, mirroring how Meshtastic TCP already works via
+ * `sourceManagerRegistry`.
+ *
+ * Route nesting (`/api/sources/:id/meshcore/*`), the per-source UI, and
+ * the `meshcore` permission collapse are deferred to slice 2/3.
+ */
+import { MeshCoreManager, ConnectionType, type MeshCoreConfig } from './meshcoreManager.js';
+import type { Source } from '../db/repositories/sources.js';
+import { logger } from '../utils/logger.js';
+
+/** Source id minted by migration 056 for pre-multi-source MeshCore data. */
+export const LEGACY_MESHCORE_SOURCE_ID = 'meshcore-legacy-default';
+
+interface MeshCoreSourceConfig {
+  transport?: 'usb' | 'serial' | 'tcp';
+  port?: string;
+  serialPort?: string;
+  baudRate?: number;
+  tcpHost?: string;
+  tcpPort?: number;
+  deviceType?: 'companion' | 'repeater';
+  autoConnect?: boolean;
+}
+
+/**
+ * Convert a `sources.config` record into the runtime `MeshCoreConfig`
+ * shape that `MeshCoreManager.connect` expects. Slice 1 only supports
+ * companion-USB; other transports are documented but not yet wired.
+ */
+export function meshcoreConfigFromSource(source: Source): MeshCoreConfig | null {
+  const cfg = (source.config ?? {}) as MeshCoreSourceConfig;
+  const firmwareType = cfg.deviceType === 'repeater' ? 'repeater' : 'companion';
+
+  // Companion-USB / direct serial — the v1 path.
+  const port = cfg.serialPort || cfg.port;
+  if ((cfg.transport === 'usb' || cfg.transport === 'serial' || !cfg.transport) && port) {
+    return {
+      connectionType: ConnectionType.SERIAL,
+      serialPort: port,
+      baudRate: cfg.baudRate ?? 115200,
+      firmwareType,
+    };
+  }
+
+  if (cfg.transport === 'tcp' && cfg.tcpHost) {
+    return {
+      connectionType: ConnectionType.TCP,
+      tcpHost: cfg.tcpHost,
+      tcpPort: cfg.tcpPort ?? 4403,
+      firmwareType,
+    };
+  }
+
+  return null;
+}
+
+export class MeshCoreManagerRegistry {
+  private readonly managers = new Map<string, MeshCoreManager>();
+
+  /** Get the manager for a given source, or undefined if not yet created. */
+  get(sourceId: string): MeshCoreManager | undefined {
+    return this.managers.get(sourceId);
+  }
+
+  /**
+   * Get-or-create the manager for a source. Does NOT call connect();
+   * callers do that explicitly so they can decide whether to honour
+   * `autoConnect` and surface failures.
+   */
+  getOrCreate(source: Source): MeshCoreManager {
+    const existing = this.managers.get(source.id);
+    if (existing) return existing;
+
+    const manager = new MeshCoreManager(source.id);
+    this.managers.set(source.id, manager);
+    logger.info(`[MeshCoreRegistry] Registered manager for source ${source.id} (${source.name})`);
+    return manager;
+  }
+
+  /** List all registered managers. */
+  list(): MeshCoreManager[] {
+    return Array.from(this.managers.values());
+  }
+
+  /**
+   * Disconnect and forget the manager for a source. Used when a source is
+   * deleted or disabled.
+   */
+  async remove(sourceId: string): Promise<void> {
+    const manager = this.managers.get(sourceId);
+    if (!manager) return;
+    try {
+      await manager.disconnect();
+    } catch (err) {
+      logger.warn(`[MeshCoreRegistry] Error disconnecting ${sourceId}:`, err);
+    }
+    this.managers.delete(sourceId);
+    logger.info(`[MeshCoreRegistry] Removed manager for source ${sourceId}`);
+  }
+
+  /** Disconnect every manager. Used on shutdown. */
+  async disconnectAll(): Promise<void> {
+    const ids = Array.from(this.managers.keys());
+    await Promise.all(
+      ids.map(async (id) => {
+        try {
+          await this.managers.get(id)?.disconnect();
+        } catch (err) {
+          logger.warn(`[MeshCoreRegistry] Error disconnecting ${id}:`, err);
+        }
+      }),
+    );
+    this.managers.clear();
+  }
+
+  /**
+   * Returns the "primary" manager for legacy `/api/meshcore/*` routes that
+   * are not yet nested under `/api/sources/:id/meshcore/*` (deferred to
+   * slice 2). The first manager that's currently connected wins; otherwise
+   * any registered manager. Returns undefined if no managers exist — the
+   * caller should treat that as "MeshCore not configured".
+   *
+   * TODO(slice-2): remove once routes are nested and carry sourceId.
+   */
+  getPrimaryForLegacyRoutes(): MeshCoreManager | undefined {
+    for (const m of this.managers.values()) {
+      if (m.isConnected()) return m;
+    }
+    return this.managers.values().next().value;
+  }
+
+  /**
+   * Legacy helper: return an existing manager (preferring the connected
+   * one) or lazily create one against `LEGACY_MESHCORE_SOURCE_ID`. Used
+   * only by the un-nested `/api/meshcore/*` routes; new code paths must
+   * use `getOrCreate(source)` so that the manager is bound to a real
+   * source row.
+   *
+   * TODO(slice-2): remove once routes are nested and carry sourceId.
+   */
+  getOrCreateLegacyManager(): MeshCoreManager {
+    const primary = this.getPrimaryForLegacyRoutes();
+    if (primary) return primary;
+    logger.warn(
+      `[MeshCoreRegistry] No managers registered — lazily creating legacy manager bound to ${LEGACY_MESHCORE_SOURCE_ID}. ` +
+        'Configure a MeshCore source to make this explicit.',
+    );
+    const manager = new MeshCoreManager(LEGACY_MESHCORE_SOURCE_ID);
+    this.managers.set(LEGACY_MESHCORE_SOURCE_ID, manager);
+    return manager;
+  }
+}
+
+/**
+ * Module-level registry instance. Imported by route handlers that haven't
+ * yet been migrated to per-source paths (deferred to slice 2/N).
+ */
+export const meshcoreManagerRegistry = new MeshCoreManagerRegistry();

--- a/src/server/migrations/056_add_source_id_to_meshcore_tables.test.ts
+++ b/src/server/migrations/056_add_source_id_to_meshcore_tables.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Migration 056 — Add sourceId to meshcore tables and seed a legacy default
+ * source for any pre-existing rows. SQLite-only test; the Postgres / MySQL
+ * paths share the same shape and are exercised by the integration suite.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './056_add_source_id_to_meshcore_tables.js';
+
+const LEGACY_SOURCE_ID = 'meshcore-legacy-default';
+
+function createSchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE sources (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL,
+      config TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL,
+      createdBy INTEGER
+    );
+    CREATE TABLE meshcore_nodes (
+      publicKey TEXT PRIMARY KEY,
+      name TEXT,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL
+    );
+    CREATE TABLE meshcore_messages (
+      id TEXT PRIMARY KEY,
+      fromPublicKey TEXT NOT NULL,
+      text TEXT NOT NULL,
+      timestamp INTEGER NOT NULL,
+      createdAt INTEGER NOT NULL
+    );
+  `);
+}
+
+function insertNode(db: Database.Database, pk: string) {
+  const ts = Date.now();
+  db.prepare(`INSERT INTO meshcore_nodes (publicKey, name, createdAt, updatedAt) VALUES (?, ?, ?, ?)`)
+    .run(pk, `node-${pk}`, ts, ts);
+}
+
+function insertMessage(db: Database.Database, id: string) {
+  const ts = Date.now();
+  db.prepare(
+    `INSERT INTO meshcore_messages (id, fromPublicKey, text, timestamp, createdAt) VALUES (?, ?, ?, ?, ?)`,
+  ).run(id, 'pubkey', 'hi', ts, ts);
+}
+
+describe('Migration 056 — add sourceId to meshcore tables', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createSchema(db);
+  });
+
+  it('adds sourceId column + index to both meshcore tables', () => {
+    migration.up(db);
+
+    const nodeCols = db.prepare(`PRAGMA table_info(meshcore_nodes)`).all() as Array<{ name: string }>;
+    const msgCols = db.prepare(`PRAGMA table_info(meshcore_messages)`).all() as Array<{ name: string }>;
+    expect(nodeCols.some((c) => c.name === 'sourceId')).toBe(true);
+    expect(msgCols.some((c) => c.name === 'sourceId')).toBe(true);
+
+    const indexes = db.prepare(`PRAGMA index_list('meshcore_nodes')`).all() as Array<{ name: string }>;
+    expect(indexes.some((i) => i.name === 'idx_meshcore_nodes_source_id')).toBe(true);
+  });
+
+  it('does not seed a legacy source when no rows exist', () => {
+    migration.up(db);
+
+    const sources = db.prepare(`SELECT id FROM sources`).all() as Array<{ id: string }>;
+    expect(sources).toHaveLength(0);
+  });
+
+  it('seeds the legacy default source and backfills NULL-sourceId rows', () => {
+    insertNode(db, 'pk-1');
+    insertNode(db, 'pk-2');
+    insertMessage(db, 'msg-1');
+
+    migration.up(db);
+
+    const legacy = db.prepare(`SELECT * FROM sources WHERE id = ?`).get(LEGACY_SOURCE_ID) as any;
+    expect(legacy).toBeDefined();
+    expect(legacy.type).toBe('meshcore');
+    expect(legacy.name).toBe('MeshCore (legacy)');
+    expect(legacy.enabled).toBe(0);
+    const cfg = JSON.parse(legacy.config);
+    expect(cfg).toEqual({ transport: 'usb', port: '', deviceType: 'companion' });
+
+    const nodes = db.prepare(`SELECT publicKey, sourceId FROM meshcore_nodes`).all() as Array<{
+      publicKey: string;
+      sourceId: string | null;
+    }>;
+    expect(nodes).toHaveLength(2);
+    expect(nodes.every((n) => n.sourceId === LEGACY_SOURCE_ID)).toBe(true);
+
+    const msgs = db.prepare(`SELECT id, sourceId FROM meshcore_messages`).all() as Array<{
+      id: string;
+      sourceId: string | null;
+    }>;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].sourceId).toBe(LEGACY_SOURCE_ID);
+  });
+
+  it('is idempotent — re-running does not duplicate the legacy source or change rows', () => {
+    insertNode(db, 'pk-1');
+    migration.up(db);
+    migration.up(db);
+
+    const sources = db.prepare(`SELECT id FROM sources WHERE id = ?`).all(LEGACY_SOURCE_ID);
+    expect(sources).toHaveLength(1);
+
+    const nodes = db.prepare(`SELECT sourceId FROM meshcore_nodes`).all() as Array<{ sourceId: string }>;
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].sourceId).toBe(LEGACY_SOURCE_ID);
+  });
+
+  it('does not touch rows that already have a sourceId set', () => {
+    insertNode(db, 'pk-1');
+    insertNode(db, 'pk-2');
+    migration.up(db); // first pass — both backfilled to legacy default
+
+    // Manually re-stamp pk-2 to a different source
+    db.prepare(`UPDATE meshcore_nodes SET sourceId = 'some-other-src' WHERE publicKey = 'pk-2'`).run();
+
+    migration.up(db);
+
+    const pk2 = db.prepare(`SELECT sourceId FROM meshcore_nodes WHERE publicKey = 'pk-2'`).get() as { sourceId: string };
+    expect(pk2.sourceId).toBe('some-other-src');
+  });
+});

--- a/src/server/migrations/056_add_source_id_to_meshcore_tables.ts
+++ b/src/server/migrations/056_add_source_id_to_meshcore_tables.ts
@@ -1,0 +1,248 @@
+/**
+ * Migration 056: Lift MeshCore out of singleton-land into the per-source
+ * model that Meshtastic already uses.
+ *
+ * Adds a nullable `sourceId TEXT` column to `meshcore_nodes` and
+ * `meshcore_messages`, indexes it, and — if any rows exist that pre-date
+ * multi-source MeshCore — synthesises a legacy default MeshCore source
+ * (`meshcore-legacy-default`, enabled=0, companion-USB) and backfills
+ * those rows to point at it.
+ *
+ * Mirrors what migration 021 + 050 / `_legacyDefaultSource.ts` did for
+ * Meshtastic, but scoped to the MeshCore tables.
+ *
+ * Idempotent across SQLite/PostgreSQL/MySQL: ALTER guards against
+ * duplicate columns, the synth-source uses a fixed id with INSERT ...
+ * IGNORE / ON CONFLICT DO NOTHING, and backfill UPDATEs run only against
+ * NULL rows so a manual re-run is a no-op.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 056';
+const LEGACY_SOURCE_ID = 'meshcore-legacy-default';
+const LEGACY_SOURCE_NAME = 'MeshCore (legacy)';
+const LEGACY_SOURCE_TYPE = 'meshcore';
+const LEGACY_SOURCE_CONFIG = JSON.stringify({
+  transport: 'usb',
+  port: '',
+  deviceType: 'companion',
+});
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding sourceId to meshcore tables...`);
+
+    for (const table of ['meshcore_nodes', 'meshcore_messages']) {
+      try {
+        db.exec(`ALTER TABLE ${table} ADD COLUMN sourceId TEXT`);
+        logger.debug(`${LABEL} (SQLite): added sourceId to ${table}`);
+      } catch (e: any) {
+        if (e.message?.includes('duplicate column')) {
+          logger.debug(`${LABEL} (SQLite): ${table}.sourceId already exists, skipping`);
+        } else {
+          logger.warn(`${LABEL} (SQLite): could not add sourceId to ${table}:`, e.message);
+        }
+      }
+    }
+
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_meshcore_nodes_source_id ON meshcore_nodes(sourceId)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_meshcore_messages_source_id ON meshcore_messages(sourceId)`);
+
+    // If any rows still have NULL sourceId, mint the legacy default source
+    // and backfill them.
+    const hasOrphans = (() => {
+      try {
+        const nodes = db.prepare(`SELECT 1 FROM meshcore_nodes WHERE sourceId IS NULL LIMIT 1`).get();
+        if (nodes) return true;
+        const msgs = db.prepare(`SELECT 1 FROM meshcore_messages WHERE sourceId IS NULL LIMIT 1`).get();
+        return Boolean(msgs);
+      } catch {
+        return false;
+      }
+    })();
+
+    if (!hasOrphans) {
+      logger.info(`${LABEL} (SQLite): no orphan meshcore rows, skipping legacy source seed`);
+      return;
+    }
+
+    const sourcesExists = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='sources'`)
+      .get();
+    if (!sourcesExists) {
+      logger.debug(`${LABEL} (SQLite): sources table missing — leaving meshcore rows with NULL sourceId`);
+      return;
+    }
+
+    const ts = Date.now();
+    db.prepare(`
+      INSERT OR IGNORE INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+      VALUES (?, ?, ?, ?, 0, ?, ?)
+    `).run(LEGACY_SOURCE_ID, LEGACY_SOURCE_NAME, LEGACY_SOURCE_TYPE, LEGACY_SOURCE_CONFIG, ts, ts);
+
+    const nodeRes = db
+      .prepare(`UPDATE meshcore_nodes SET sourceId = ? WHERE sourceId IS NULL`)
+      .run(LEGACY_SOURCE_ID);
+    const msgRes = db
+      .prepare(`UPDATE meshcore_messages SET sourceId = ? WHERE sourceId IS NULL`)
+      .run(LEGACY_SOURCE_ID);
+
+    logger.info(
+      `${LABEL} (SQLite): backfilled ${nodeRes.changes ?? 0} meshcore_nodes + ${msgRes.changes ?? 0} meshcore_messages -> ${LEGACY_SOURCE_ID}`,
+    );
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration056Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding sourceId to meshcore tables...`);
+
+  for (const table of ['meshcore_nodes', 'meshcore_messages']) {
+    await client.query(
+      `ALTER TABLE ${table} ADD COLUMN IF NOT EXISTS "sourceId" TEXT`,
+    );
+    logger.debug(`${LABEL} (PostgreSQL): ensured sourceId on ${table}`);
+  }
+
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS idx_meshcore_nodes_source_id ON meshcore_nodes("sourceId")`,
+  );
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS idx_meshcore_messages_source_id ON meshcore_messages("sourceId")`,
+  );
+
+  const orphanNodes = await client.query(
+    `SELECT 1 FROM meshcore_nodes WHERE "sourceId" IS NULL LIMIT 1`,
+  );
+  const orphanMsgs = await client.query(
+    `SELECT 1 FROM meshcore_messages WHERE "sourceId" IS NULL LIMIT 1`,
+  );
+  const hasOrphans = (orphanNodes.rowCount ?? 0) > 0 || (orphanMsgs.rowCount ?? 0) > 0;
+
+  if (!hasOrphans) {
+    logger.info(`${LABEL} (PostgreSQL): no orphan meshcore rows, skipping legacy source seed`);
+    return;
+  }
+
+  const sourcesExists = await client.query(`SELECT to_regclass('public.sources') AS reg`);
+  if (!sourcesExists.rows[0]?.reg) {
+    logger.debug(`${LABEL} (PostgreSQL): sources table missing — leaving meshcore rows with NULL sourceId`);
+    return;
+  }
+
+  const ts = Date.now();
+  await client.query(
+    `INSERT INTO sources (id, name, type, config, enabled, "createdAt", "updatedAt")
+     VALUES ($1, $2, $3, $4, false, $5, $6)
+     ON CONFLICT (id) DO NOTHING`,
+    [LEGACY_SOURCE_ID, LEGACY_SOURCE_NAME, LEGACY_SOURCE_TYPE, LEGACY_SOURCE_CONFIG, ts, ts],
+  );
+
+  const nodeRes = await client.query(
+    `UPDATE meshcore_nodes SET "sourceId" = $1 WHERE "sourceId" IS NULL`,
+    [LEGACY_SOURCE_ID],
+  );
+  const msgRes = await client.query(
+    `UPDATE meshcore_messages SET "sourceId" = $1 WHERE "sourceId" IS NULL`,
+    [LEGACY_SOURCE_ID],
+  );
+
+  logger.info(
+    `${LABEL} (PostgreSQL): backfilled ${nodeRes.rowCount ?? 0} meshcore_nodes + ${msgRes.rowCount ?? 0} meshcore_messages -> ${LEGACY_SOURCE_ID}`,
+  );
+}
+
+// ============ MySQL ============
+
+export async function runMigration056Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding sourceId to meshcore tables...`);
+
+  const conn = await pool.getConnection();
+  try {
+    for (const table of ['meshcore_nodes', 'meshcore_messages']) {
+      const [rows] = await conn.query(
+        `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = 'sourceId'`,
+        [table],
+      );
+      if (!Array.isArray(rows) || rows.length === 0) {
+        await conn.query(`ALTER TABLE ${table} ADD COLUMN sourceId VARCHAR(64)`);
+        logger.debug(`${LABEL} (MySQL): added sourceId to ${table}`);
+      } else {
+        logger.debug(`${LABEL} (MySQL): ${table}.sourceId already exists, skipping`);
+      }
+    }
+
+    const indexChecks: Array<[string, string]> = [
+      ['meshcore_nodes', 'idx_meshcore_nodes_source_id'],
+      ['meshcore_messages', 'idx_meshcore_messages_source_id'],
+    ];
+    for (const [table, indexName] of indexChecks) {
+      const [idxRows] = await conn.query(
+        `SELECT COUNT(*) as cnt FROM information_schema.STATISTICS
+         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?`,
+        [table, indexName],
+      );
+      if (!(idxRows as any)[0]?.cnt) {
+        await conn.query(`CREATE INDEX ${indexName} ON ${table}(sourceId)`);
+        logger.debug(`${LABEL} (MySQL): created index ${indexName}`);
+      }
+    }
+
+    const [orphanNodes] = await conn.query(
+      `SELECT 1 FROM meshcore_nodes WHERE sourceId IS NULL LIMIT 1`,
+    );
+    const [orphanMsgs] = await conn.query(
+      `SELECT 1 FROM meshcore_messages WHERE sourceId IS NULL LIMIT 1`,
+    );
+    const hasOrphans =
+      (Array.isArray(orphanNodes) && orphanNodes.length > 0) ||
+      (Array.isArray(orphanMsgs) && orphanMsgs.length > 0);
+
+    if (!hasOrphans) {
+      logger.info(`${LABEL} (MySQL): no orphan meshcore rows, skipping legacy source seed`);
+      return;
+    }
+
+    const [sourcesTable] = await conn.query(
+      `SELECT COUNT(*) AS c FROM information_schema.tables
+       WHERE table_schema = DATABASE() AND table_name = 'sources'`,
+    );
+    if (!Number((sourcesTable as any[])[0]?.c ?? 0)) {
+      logger.debug(`${LABEL} (MySQL): sources table missing — leaving meshcore rows with NULL sourceId`);
+      return;
+    }
+
+    const ts = Date.now();
+    await conn.query(
+      `INSERT IGNORE INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, 0, ?, ?)`,
+      [LEGACY_SOURCE_ID, LEGACY_SOURCE_NAME, LEGACY_SOURCE_TYPE, LEGACY_SOURCE_CONFIG, ts, ts],
+    );
+
+    const [nodeRes] = await conn.query(
+      `UPDATE meshcore_nodes SET sourceId = ? WHERE sourceId IS NULL`,
+      [LEGACY_SOURCE_ID],
+    );
+    const [msgRes] = await conn.query(
+      `UPDATE meshcore_messages SET sourceId = ? WHERE sourceId IS NULL`,
+      [LEGACY_SOURCE_ID],
+    );
+
+    const nodeAffected = (nodeRes as { affectedRows?: number }).affectedRows ?? 0;
+    const msgAffected = (msgRes as { affectedRows?: number }).affectedRows ?? 0;
+    logger.info(
+      `${LABEL} (MySQL): backfilled ${nodeAffected} meshcore_nodes + ${msgAffected} meshcore_messages -> ${LEGACY_SOURCE_ID}`,
+    );
+  } finally {
+    conn.release();
+  }
+}

--- a/src/server/migrations/056_add_source_id_to_meshcore_tables.ts
+++ b/src/server/migrations/056_add_source_id_to_meshcore_tables.ts
@@ -43,7 +43,9 @@ export const migration = {
         if (e.message?.includes('duplicate column')) {
           logger.debug(`${LABEL} (SQLite): ${table}.sourceId already exists, skipping`);
         } else {
-          logger.warn(`${LABEL} (SQLite): could not add sourceId to ${table}:`, e.message);
+          // Don't swallow — silent failure leaves rows without sourceId at runtime.
+          logger.error(`${LABEL} (SQLite): could not add sourceId to ${table}:`, e.message);
+          throw e;
         }
       }
     }

--- a/src/server/migrations/057_collapse_meshcore_resource.test.ts
+++ b/src/server/migrations/057_collapse_meshcore_resource.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Migration 057 — Collapse the global `meshcore` permission resource into
+ * per-source rows on the sourcey set (connection / configuration / nodes /
+ * messages). SQLite-only test; the Postgres / MySQL paths share the same
+ * shape and are exercised by the integration suite.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './057_collapse_meshcore_resource.js';
+
+const TARGET_RESOURCES = ['connection', 'configuration', 'nodes', 'messages'] as const;
+
+function createSchema(db: Database.Database) {
+  // permissions schema matches the post-033 shape (no CHECK constraint, with
+  // sourceId column + the unique index 033 added).
+  db.exec(`
+    CREATE TABLE sources (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL,
+      config TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL,
+      createdBy INTEGER
+    );
+    CREATE TABLE permissions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      resource TEXT NOT NULL,
+      can_view_on_map INTEGER NOT NULL DEFAULT 0,
+      can_read INTEGER NOT NULL DEFAULT 0,
+      can_write INTEGER NOT NULL DEFAULT 0,
+      can_delete INTEGER NOT NULL DEFAULT 0,
+      granted_at INTEGER NOT NULL,
+      granted_by INTEGER,
+      sourceId TEXT
+    );
+    CREATE UNIQUE INDEX permissions_user_resource_source_uniq
+      ON permissions(user_id, resource, sourceId);
+  `);
+}
+
+function insertSource(db: Database.Database, id: string, type: string) {
+  const ts = Date.now();
+  db.prepare(
+    `INSERT INTO sources (id, name, type, config, enabled, createdAt, updatedAt) VALUES (?, ?, ?, '{}', 1, ?, ?)`,
+  ).run(id, `src-${id}`, type, ts, ts);
+}
+
+function insertGlobalMeshcoreGrant(db: Database.Database, userId: number, opts: { read?: boolean; write?: boolean } = {}) {
+  db.prepare(
+    `INSERT INTO permissions (user_id, resource, can_read, can_write, granted_at) VALUES (?, 'meshcore', ?, ?, ?)`,
+  ).run(userId, opts.read ? 1 : 0, opts.write ? 1 : 0, Date.now());
+}
+
+describe('Migration 057 — collapse meshcore resource', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createSchema(db);
+  });
+
+  it('expands a global meshcore grant into per-source rows on every target resource', () => {
+    insertSource(db, 'mc-A', 'meshcore');
+    insertSource(db, 'mc-B', 'meshcore');
+    insertSource(db, 'mt-1', 'meshtastic');
+    insertGlobalMeshcoreGrant(db, 42, { read: true, write: true });
+
+    migration.up(db);
+
+    // Expect 4 resources × 2 meshcore sources = 8 rows for user 42
+    const rows = db
+      .prepare(
+        `SELECT resource, sourceId, can_read, can_write FROM permissions WHERE user_id = 42 ORDER BY resource, sourceId`,
+      )
+      .all() as Array<{ resource: string; sourceId: string; can_read: number; can_write: number }>;
+
+    expect(rows).toHaveLength(TARGET_RESOURCES.length * 2);
+    const sourceIds = new Set(rows.map((r) => r.sourceId));
+    expect(sourceIds).toEqual(new Set(['mc-A', 'mc-B']));
+    const resources = new Set(rows.map((r) => r.resource));
+    expect(resources).toEqual(new Set(TARGET_RESOURCES));
+    expect(rows.every((r) => r.can_read === 1 && r.can_write === 1)).toBe(true);
+  });
+
+  it('drops the original global meshcore rows', () => {
+    insertSource(db, 'mc-A', 'meshcore');
+    insertGlobalMeshcoreGrant(db, 42, { read: true });
+
+    migration.up(db);
+
+    const remaining = db
+      .prepare(`SELECT 1 FROM permissions WHERE resource = 'meshcore'`)
+      .all();
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('skips non-meshcore source types', () => {
+    insertSource(db, 'mt-1', 'meshtastic');
+    insertGlobalMeshcoreGrant(db, 42, { read: true });
+
+    migration.up(db);
+
+    const rows = db
+      .prepare(`SELECT 1 FROM permissions WHERE user_id = 42 AND sourceId = 'mt-1'`)
+      .all();
+    expect(rows).toHaveLength(0);
+  });
+
+  it('still drops global meshcore rows when no meshcore sources exist', () => {
+    insertGlobalMeshcoreGrant(db, 42, { read: true });
+
+    migration.up(db);
+
+    const rows = db.prepare(`SELECT 1 FROM permissions WHERE user_id = 42`).all();
+    expect(rows).toHaveLength(0);
+  });
+
+  it('is idempotent across re-runs', () => {
+    insertSource(db, 'mc-A', 'meshcore');
+    insertGlobalMeshcoreGrant(db, 42, { read: true, write: true });
+
+    migration.up(db);
+    const after1 = db.prepare(`SELECT COUNT(*) as c FROM permissions`).get() as { c: number };
+
+    migration.up(db);
+    const after2 = db.prepare(`SELECT COUNT(*) as c FROM permissions`).get() as { c: number };
+
+    expect(after2.c).toBe(after1.c);
+  });
+
+  it('preserves canRead/canWrite distinct from each other', () => {
+    insertSource(db, 'mc-A', 'meshcore');
+    insertGlobalMeshcoreGrant(db, 42, { read: true, write: false });
+
+    migration.up(db);
+
+    const rows = db
+      .prepare(`SELECT can_read, can_write FROM permissions WHERE user_id = 42`)
+      .all() as Array<{ can_read: number; can_write: number }>;
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((r) => r.can_read === 1 && r.can_write === 0)).toBe(true);
+  });
+});

--- a/src/server/migrations/057_collapse_meshcore_resource.ts
+++ b/src/server/migrations/057_collapse_meshcore_resource.ts
@@ -1,0 +1,187 @@
+/**
+ * Migration 057: Collapse the global `meshcore` permission resource into
+ * the existing per-source sourcey set.
+ *
+ * Context:
+ *   Slices 1–2 made MeshCore a first-class per-source citizen (manager
+ *   registry, sourceId on domain rows, nested routes under
+ *   `/api/sources/:id/meshcore/*`). The permission system still had a
+ *   single global `meshcore` resource, which is incompatible with
+ *   per-source authorisation. This migration mirrors what 033 did for
+ *   Meshtastic globals: expand each global `meshcore` grant into rows on
+ *   the sourcey resources actually used by the MeshCore routes
+ *   (`connection`, `configuration`, `nodes`, `messages`), scoped per
+ *   meshcore-typed source. The original global rows are then deleted so
+ *   the now-removed `meshcore` resource id can no longer shadow checks.
+ *
+ *   Channels are intentionally lumped under `messages` for v1 — per-channel
+ *   `mc_channel_N` grants can be added later if a use case appears.
+ *
+ * Idempotency:
+ *   Inserts use INSERT OR IGNORE / ON CONFLICT DO NOTHING so a second run
+ *   is a no-op. Deleting the global rows is also idempotent.
+ *
+ *   The unique index `permissions_user_resource_source_uniq` (created in
+ *   033) covers (user_id, resource, sourceId), so the per-source rows we
+ *   insert here will not collide with grants the user already has.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 057';
+
+/**
+ * Sourcey resources the MeshCore routes check against. Keep this in sync
+ * with the requirePermission(...) calls in meshcoreRoutes.ts.
+ */
+const TARGET_RESOURCES = ['connection', 'configuration', 'nodes', 'messages'] as const;
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): collapsing global \`meshcore\` grants into per-source rows...`);
+
+    const meshcoreSources = db
+      .prepare(`SELECT id FROM sources WHERE type = 'meshcore'`)
+      .all() as { id: string }[];
+
+    if (meshcoreSources.length === 0) {
+      logger.info(`${LABEL} (SQLite): no meshcore sources — dropping any orphan global meshcore grants`);
+    } else {
+      const globalRows = db
+        .prepare(`SELECT * FROM permissions WHERE sourceId IS NULL AND resource = 'meshcore'`)
+        .all() as any[];
+
+      logger.info(
+        `${LABEL} (SQLite): expanding ${globalRows.length} global meshcore grant(s) ` +
+          `across ${meshcoreSources.length} meshcore source(s) × ${TARGET_RESOURCES.length} target resource(s)`,
+      );
+
+      const insertStmt = db.prepare(`
+        INSERT OR IGNORE INTO permissions
+          (user_id, resource, can_view_on_map, can_read, can_write, can_delete, granted_at, granted_by, sourceId)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+
+      for (const row of globalRows) {
+        for (const src of meshcoreSources) {
+          for (const resource of TARGET_RESOURCES) {
+            insertStmt.run(
+              row.user_id,
+              resource,
+              row.can_view_on_map,
+              row.can_read,
+              row.can_write,
+              row.can_delete ?? 0,
+              row.granted_at,
+              row.granted_by,
+              src.id,
+            );
+          }
+        }
+      }
+    }
+
+    const delResult = db
+      .prepare(`DELETE FROM permissions WHERE sourceId IS NULL AND resource = 'meshcore'`)
+      .run();
+    if (delResult.changes > 0) {
+      logger.info(`${LABEL} (SQLite): deleted ${delResult.changes} global meshcore grant(s)`);
+    }
+
+    logger.info(`${LABEL} complete (SQLite)`);
+  },
+
+  down: (_db: Database): void => {
+    // Forward-only — there is no global `meshcore` resource to restore to,
+    // and 033 already removed the supporting CHECK constraint.
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration057Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): collapsing global \`meshcore\` grants into per-source rows...`);
+
+  const sourcesRes = await client.query(`SELECT id FROM sources WHERE type = 'meshcore'`);
+  const meshcoreSources: string[] = sourcesRes.rows.map((r: any) => r.id);
+
+  if (meshcoreSources.length === 0) {
+    logger.info(`${LABEL} (PostgreSQL): no meshcore sources — dropping any orphan global meshcore grants`);
+  } else {
+    for (const sourceId of meshcoreSources) {
+      for (const resource of TARGET_RESOURCES) {
+        await client.query(
+          `
+          INSERT INTO permissions
+            ("userId", resource, "canViewOnMap", "canRead", "canWrite", "canDelete", "grantedAt", "grantedBy", "sourceId")
+          SELECT "userId", $2, "canViewOnMap", "canRead", "canWrite", COALESCE("canDelete", false), "grantedAt", "grantedBy", $1
+            FROM permissions
+           WHERE "sourceId" IS NULL
+             AND resource = 'meshcore'
+          ON CONFLICT DO NOTHING
+          `,
+          [sourceId, resource],
+        );
+      }
+    }
+    logger.info(
+      `${LABEL} (PostgreSQL): expanded global meshcore grants across ${meshcoreSources.length} source(s)`,
+    );
+  }
+
+  const delRes = await client.query(
+    `DELETE FROM permissions WHERE "sourceId" IS NULL AND resource = 'meshcore'`,
+  );
+  if (delRes.rowCount && delRes.rowCount > 0) {
+    logger.info(`${LABEL} (PostgreSQL): deleted ${delRes.rowCount} global meshcore grant(s)`);
+  }
+
+  logger.info(`${LABEL} complete (PostgreSQL)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration057Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): collapsing global \`meshcore\` grants into per-source rows...`);
+
+  const conn = await pool.getConnection();
+  try {
+    const [sourceRows] = await conn.query(`SELECT id FROM sources WHERE type = 'meshcore'`);
+    const meshcoreSources: string[] = (sourceRows as any[]).map((r) => r.id);
+
+    if (meshcoreSources.length === 0) {
+      logger.info(`${LABEL} (MySQL): no meshcore sources — dropping any orphan global meshcore grants`);
+    } else {
+      for (const sourceId of meshcoreSources) {
+        for (const resource of TARGET_RESOURCES) {
+          await conn.query(
+            `INSERT IGNORE INTO permissions
+               (userId, resource, canViewOnMap, canRead, canWrite, canDelete, grantedAt, grantedBy, sourceId)
+             SELECT userId, ?, canViewOnMap, canRead, canWrite, canDelete, grantedAt, grantedBy, ?
+               FROM permissions
+              WHERE sourceId IS NULL
+                AND resource = 'meshcore'`,
+            [resource, sourceId],
+          );
+        }
+      }
+      logger.info(
+        `${LABEL} (MySQL): expanded global meshcore grants across ${meshcoreSources.length} source(s)`,
+      );
+    }
+
+    const [delResult] = await conn.query(
+      `DELETE FROM permissions WHERE sourceId IS NULL AND resource = 'meshcore'`,
+    );
+    const affected = (delResult as any)?.affectedRows ?? 0;
+    if (affected > 0) {
+      logger.info(`${LABEL} (MySQL): deleted ${affected} global meshcore grant(s)`);
+    }
+  } finally {
+    conn.release();
+  }
+
+  logger.info(`${LABEL} complete (MySQL)`);
+}

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -68,11 +68,14 @@ vi.mock('../meshcoreManager.js', () => ({
   MeshCoreManager: class {},
 }));
 
+// Only `test-source` is registered; unknown ids return undefined so the
+// router-level guard returns 404.
+const REGISTERED_SOURCE_IDS = new Set(['test-source']);
 vi.mock('../meshcoreRegistry.js', () => ({
   meshcoreManagerRegistry: {
     getOrCreateLegacyManager: () => meshcoreManager,
     list: () => [meshcoreManager],
-    get: () => meshcoreManager,
+    get: (sourceId: string) => (REGISTERED_SOURCE_IDS.has(sourceId) ? meshcoreManager : undefined),
   },
   LEGACY_MESHCORE_SOURCE_ID: 'meshcore-legacy-default',
 }));
@@ -205,6 +208,13 @@ describe('MeshCore Routes', () => {
       const response = await request(app).get('/api/sources/test-source/meshcore/status');
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
+    });
+
+    it('returns 404 when :id has no registered manager', async () => {
+      const response = await request(app).get('/api/sources/does-not-exist/meshcore/status');
+      expect(response.status).toBe(404);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toMatch(/does-not-exist/);
     });
   });
 

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -26,11 +26,10 @@ vi.mock('../../services/database.js', () => ({
   default: {}
 }));
 
-// Stub manager — every method the routes call is mocked. Slice 1 of the
-// MeshCore multi-source refactor moved the singleton into a per-source
-// registry, so the legacy `/api/meshcore/*` routes resolve their manager
-// via `meshcoreManagerRegistry.getOrCreateLegacyManager()`. We mock the
-// registry directly here.
+// Stub manager — every method the routes call is mocked. The MeshCore
+// multi-source refactor put the manager behind a per-source registry; we
+// mock the registry directly here so requests under
+// `/api/sources/test-source/meshcore/*` resolve to this stub.
 const meshcoreManager = {
   getConnectionStatus: vi.fn().mockReturnValue({
     connected: false,
@@ -139,24 +138,27 @@ describe('MeshCore Routes', () => {
       return permissionModel.getUserPermissionSet(userId);
     };
 
-    // Create anonymous user with meshcore read permission for unauthenticated access
+    // Create anonymous user with read permissions on the sourcey resources
+    // the MeshCore routes check (slice 3 collapsed the global `meshcore`
+    // resource into per-source connection/nodes/messages/configuration).
     const anonymousUser = await userModel.create({
       username: 'anonymous',
       password: 'anonymous123',
       authProvider: 'local',
     });
-    await permissionModel.grant({
-      userId: anonymousUser.id,
-      resource: 'meshcore',
-      canRead: true,
-      canWrite: false,
-    });
+    for (const resource of ['connection', 'nodes', 'messages', 'configuration'] as const) {
+      await permissionModel.grant({
+        userId: anonymousUser.id,
+        resource,
+        canRead: true,
+        canWrite: false,
+      });
+    }
 
-    // Mount routes — both the legacy un-nested form and the slice-2
-    // nested form share the same router so we can exercise both shapes.
+    // Mount routes. Slice 3 dropped the un-nested `/api/meshcore` mount,
+    // so the tests below all hit `/api/sources/test-source/meshcore/*`.
     app.use('/api/auth', authRoutes);
     app.use('/api/sources/:id/meshcore', meshcoreRoutes);
-    app.use('/api/meshcore', meshcoreRoutes);
   });
 
   let testUserCounter = 0;
@@ -174,12 +176,14 @@ describe('MeshCore Routes', () => {
     });
     testUserId = user.id;
 
-    await permissionModel.grant({
-      userId: user.id,
-      resource: 'meshcore',
-      canRead: true,
-      canWrite: true
-    });
+    for (const resource of ['connection', 'nodes', 'messages', 'configuration'] as const) {
+      await permissionModel.grant({
+        userId: user.id,
+        resource,
+        canRead: true,
+        canWrite: true,
+      });
+    }
 
     // Login
     authenticatedAgent = request.agent(app);
@@ -195,9 +199,9 @@ describe('MeshCore Routes', () => {
     db.close();
   });
 
-  describe('GET /api/meshcore/status', () => {
+  describe('GET /api/sources/test-source/meshcore/status', () => {
     it('should return status without authentication', async () => {
-      const response = await request(app).get('/api/meshcore/status');
+      const response = await request(app).get('/api/sources/test-source/meshcore/status');
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
     });
@@ -218,17 +222,17 @@ describe('MeshCore Routes', () => {
     });
   });
 
-  describe('POST /api/meshcore/connect', () => {
+  describe('POST /api/sources/test-source/meshcore/connect', () => {
     it('should require authentication', async () => {
       const response = await request(app)
-        .post('/api/meshcore/connect')
+        .post('/api/sources/test-source/meshcore/connect')
         .send({ connectionType: 'serial', serialPort: 'COM3' });
       expect(response.status).toBe(401);
     });
 
     it('should connect with valid parameters', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/connect')
+        .post('/api/sources/test-source/meshcore/connect')
         .send({ connectionType: 'serial', serialPort: 'COM3' });
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
@@ -236,7 +240,7 @@ describe('MeshCore Routes', () => {
 
     it('should reject invalid connection type', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/connect')
+        .post('/api/sources/test-source/meshcore/connect')
         .send({ connectionType: 'invalid', serialPort: 'COM3' });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('Connection type');
@@ -244,7 +248,7 @@ describe('MeshCore Routes', () => {
 
     it('should reject invalid baud rate', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/connect')
+        .post('/api/sources/test-source/meshcore/connect')
         .send({ connectionType: 'serial', serialPort: 'COM3', baudRate: 12345 });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('Baud rate');
@@ -252,24 +256,24 @@ describe('MeshCore Routes', () => {
 
     it('should reject invalid TCP port', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/connect')
+        .post('/api/sources/test-source/meshcore/connect')
         .send({ connectionType: 'tcp', tcpHost: '192.168.1.1', tcpPort: 70000 });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('port');
     });
   });
 
-  describe('POST /api/meshcore/messages/send', () => {
+  describe('POST /api/sources/test-source/meshcore/messages/send', () => {
     it('should require authentication', async () => {
       const response = await request(app)
-        .post('/api/meshcore/messages/send')
+        .post('/api/sources/test-source/meshcore/messages/send')
         .send({ text: 'Hello' });
       expect(response.status).toBe(401);
     });
 
     it('should send message with valid text', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/messages/send')
+        .post('/api/sources/test-source/meshcore/messages/send')
         .send({ text: 'Hello world' });
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
@@ -277,7 +281,7 @@ describe('MeshCore Routes', () => {
 
     it('should reject empty message', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/messages/send')
+        .post('/api/sources/test-source/meshcore/messages/send')
         .send({ text: '' });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('Message');
@@ -286,7 +290,7 @@ describe('MeshCore Routes', () => {
     it('should reject message exceeding max length', async () => {
       const longMessage = 'a'.repeat(300);
       const response = await authenticatedAgent
-        .post('/api/meshcore/messages/send')
+        .post('/api/sources/test-source/meshcore/messages/send')
         .send({ text: longMessage });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('maximum length');
@@ -294,7 +298,7 @@ describe('MeshCore Routes', () => {
 
     it('should reject invalid public key format', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/messages/send')
+        .post('/api/sources/test-source/meshcore/messages/send')
         .send({ text: 'Hello', toPublicKey: 'invalid-key' });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('public key');
@@ -303,24 +307,24 @@ describe('MeshCore Routes', () => {
     it('should accept valid public key', async () => {
       const validKey = 'a'.repeat(64);
       const response = await authenticatedAgent
-        .post('/api/meshcore/messages/send')
+        .post('/api/sources/test-source/meshcore/messages/send')
         .send({ text: 'Hello', toPublicKey: validKey });
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
     });
   });
 
-  describe('POST /api/meshcore/admin/login', () => {
+  describe('POST /api/sources/test-source/meshcore/admin/login', () => {
     it('should require authentication', async () => {
       const response = await request(app)
-        .post('/api/meshcore/admin/login')
+        .post('/api/sources/test-source/meshcore/admin/login')
         .send({ publicKey: 'a'.repeat(64), password: 'admin' });
       expect(response.status).toBe(401);
     });
 
     it('should reject invalid public key format', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/admin/login')
+        .post('/api/sources/test-source/meshcore/admin/login')
         .send({ publicKey: 'invalid', password: 'admin' });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('public key');
@@ -329,17 +333,17 @@ describe('MeshCore Routes', () => {
     it('should accept valid login request', async () => {
       const validKey = 'a'.repeat(64);
       const response = await authenticatedAgent
-        .post('/api/meshcore/admin/login')
+        .post('/api/sources/test-source/meshcore/admin/login')
         .send({ publicKey: validKey, password: 'admin123' });
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
     });
   });
 
-  describe('GET /api/meshcore/admin/status/:publicKey', () => {
+  describe('GET /api/sources/test-source/meshcore/admin/status/:publicKey', () => {
     it('should reject invalid public key format', async () => {
       const response = await authenticatedAgent
-        .get('/api/meshcore/admin/status/invalid-key');
+        .get('/api/sources/test-source/meshcore/admin/status/invalid-key');
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('public key');
     });
@@ -347,23 +351,23 @@ describe('MeshCore Routes', () => {
     it('should accept valid public key', async () => {
       const validKey = 'a'.repeat(64);
       const response = await authenticatedAgent
-        .get(`/api/meshcore/admin/status/${validKey}`);
+        .get(`/api/sources/test-source/meshcore/admin/status/${validKey}`);
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
     });
   });
 
-  describe('POST /api/meshcore/config/name', () => {
+  describe('POST /api/sources/test-source/meshcore/config/name', () => {
     it('should require authentication', async () => {
       const response = await request(app)
-        .post('/api/meshcore/config/name')
+        .post('/api/sources/test-source/meshcore/config/name')
         .send({ name: 'TestNode' });
       expect(response.status).toBe(401);
     });
 
     it('should reject empty name', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/config/name')
+        .post('/api/sources/test-source/meshcore/config/name')
         .send({ name: '' });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('Name');
@@ -371,7 +375,7 @@ describe('MeshCore Routes', () => {
 
     it('should reject whitespace-only name', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/config/name')
+        .post('/api/sources/test-source/meshcore/config/name')
         .send({ name: '   ' });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('empty');
@@ -380,7 +384,7 @@ describe('MeshCore Routes', () => {
     it('should reject name exceeding max length', async () => {
       const longName = 'a'.repeat(50);
       const response = await authenticatedAgent
-        .post('/api/meshcore/config/name')
+        .post('/api/sources/test-source/meshcore/config/name')
         .send({ name: longName });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('maximum length');
@@ -388,24 +392,24 @@ describe('MeshCore Routes', () => {
 
     it('should accept valid name', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/config/name')
+        .post('/api/sources/test-source/meshcore/config/name')
         .send({ name: 'MyNode' });
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
     });
   });
 
-  describe('POST /api/meshcore/config/radio', () => {
+  describe('POST /api/sources/test-source/meshcore/config/radio', () => {
     it('should require authentication', async () => {
       const response = await request(app)
-        .post('/api/meshcore/config/radio')
+        .post('/api/sources/test-source/meshcore/config/radio')
         .send({ freq: 915.0, bw: 125, sf: 7, cr: 5 });
       expect(response.status).toBe(401);
     });
 
     it('should reject missing parameters', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/config/radio')
+        .post('/api/sources/test-source/meshcore/config/radio')
         .send({ freq: 915.0 });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('required');
@@ -413,7 +417,7 @@ describe('MeshCore Routes', () => {
 
     it('should reject frequency out of range', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/config/radio')
+        .post('/api/sources/test-source/meshcore/config/radio')
         .send({ freq: 2000.0, bw: 125, sf: 7, cr: 5 });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('Frequency');
@@ -421,7 +425,7 @@ describe('MeshCore Routes', () => {
 
     it('should reject invalid bandwidth', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/config/radio')
+        .post('/api/sources/test-source/meshcore/config/radio')
         .send({ freq: 915.0, bw: 100, sf: 7, cr: 5 });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('Bandwidth');
@@ -429,7 +433,7 @@ describe('MeshCore Routes', () => {
 
     it('should reject spreading factor out of range', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/config/radio')
+        .post('/api/sources/test-source/meshcore/config/radio')
         .send({ freq: 915.0, bw: 125, sf: 15, cr: 5 });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('Spreading factor');
@@ -437,7 +441,7 @@ describe('MeshCore Routes', () => {
 
     it('should reject coding rate out of range', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/config/radio')
+        .post('/api/sources/test-source/meshcore/config/radio')
         .send({ freq: 915.0, bw: 125, sf: 7, cr: 10 });
       expect(response.status).toBe(400);
       expect(response.body.error).toContain('Coding rate');
@@ -445,23 +449,23 @@ describe('MeshCore Routes', () => {
 
     it('should accept valid radio parameters', async () => {
       const response = await authenticatedAgent
-        .post('/api/meshcore/config/radio')
+        .post('/api/sources/test-source/meshcore/config/radio')
         .send({ freq: 915.0, bw: 125, sf: 7, cr: 5 });
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
     });
   });
 
-  describe('GET /api/meshcore/messages', () => {
+  describe('GET /api/sources/test-source/meshcore/messages', () => {
     it('should return messages without authentication', async () => {
-      const response = await request(app).get('/api/meshcore/messages');
+      const response = await request(app).get('/api/sources/test-source/meshcore/messages');
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(Array.isArray(response.body.data)).toBe(true);
     });
 
     it('should limit messages to max allowed', async () => {
-      const response = await request(app).get('/api/meshcore/messages?limit=5000');
+      const response = await request(app).get('/api/sources/test-source/meshcore/messages?limit=5000');
       expect(response.status).toBe(200);
       // Should clamp to max limit (1000) without error
       expect(meshcoreManager.getRecentMessages).toHaveBeenCalledWith(1000);

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -149,8 +149,10 @@ describe('MeshCore Routes', () => {
       canWrite: false,
     });
 
-    // Mount routes
+    // Mount routes — both the legacy un-nested form and the slice-2
+    // nested form share the same router so we can exercise both shapes.
     app.use('/api/auth', authRoutes);
+    app.use('/api/sources/:id/meshcore', meshcoreRoutes);
     app.use('/api/meshcore', meshcoreRoutes);
   });
 
@@ -193,6 +195,14 @@ describe('MeshCore Routes', () => {
   describe('GET /api/meshcore/status', () => {
     it('should return status without authentication', async () => {
       const response = await request(app).get('/api/meshcore/status');
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+    });
+  });
+
+  describe('Nested mount /api/sources/:id/meshcore', () => {
+    it('resolves the manager via :id and serves status', async () => {
+      const response = await request(app).get('/api/sources/test-source/meshcore/status');
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
     });

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -26,28 +26,35 @@ vi.mock('../../services/database.js', () => ({
   default: {}
 }));
 
+// Stub manager — every method the routes call is mocked. Slice 1 of the
+// MeshCore multi-source refactor moved the singleton into a per-source
+// registry, so the legacy `/api/meshcore/*` routes resolve their manager
+// via `meshcoreManagerRegistry.getOrCreateLegacyManager()`. We mock the
+// registry directly here.
+const meshcoreManager = {
+  getConnectionStatus: vi.fn().mockReturnValue({
+    connected: false,
+    deviceType: 0,
+    config: null,
+  }),
+  getLocalNode: vi.fn().mockReturnValue(null),
+  getEnvConfig: vi.fn().mockReturnValue(null),
+  getAllNodes: vi.fn().mockReturnValue([]),
+  getContacts: vi.fn().mockReturnValue([]),
+  getRecentMessages: vi.fn().mockReturnValue([]),
+  connect: vi.fn().mockResolvedValue(true),
+  disconnect: vi.fn().mockResolvedValue(undefined),
+  sendMessage: vi.fn().mockResolvedValue(true),
+  sendAdvert: vi.fn().mockResolvedValue(true),
+  refreshContacts: vi.fn().mockResolvedValue(new Map()),
+  loginToNode: vi.fn().mockResolvedValue(true),
+  requestNodeStatus: vi.fn().mockResolvedValue({ batteryMv: 4200, uptimeSecs: 3600 }),
+  setName: vi.fn().mockResolvedValue(true),
+  setRadio: vi.fn().mockResolvedValue(true),
+  isConnected: vi.fn().mockReturnValue(false),
+};
+
 vi.mock('../meshcoreManager.js', () => ({
-  default: {
-    getConnectionStatus: vi.fn().mockReturnValue({
-      connected: false,
-      deviceType: 0,
-      config: null,
-    }),
-    getLocalNode: vi.fn().mockReturnValue(null),
-    getEnvConfig: vi.fn().mockReturnValue(null),
-    getAllNodes: vi.fn().mockReturnValue([]),
-    getContacts: vi.fn().mockReturnValue([]),
-    getRecentMessages: vi.fn().mockReturnValue([]),
-    connect: vi.fn().mockResolvedValue(true),
-    disconnect: vi.fn().mockResolvedValue(undefined),
-    sendMessage: vi.fn().mockResolvedValue(true),
-    sendAdvert: vi.fn().mockResolvedValue(true),
-    refreshContacts: vi.fn().mockResolvedValue(new Map()),
-    loginToNode: vi.fn().mockResolvedValue(true),
-    requestNodeStatus: vi.fn().mockResolvedValue({ batteryMv: 4200, uptimeSecs: 3600 }),
-    setName: vi.fn().mockResolvedValue(true),
-    setRadio: vi.fn().mockResolvedValue(true),
-  },
   ConnectionType: {
     SERIAL: 'serial',
     TCP: 'tcp',
@@ -58,12 +65,21 @@ vi.mock('../meshcoreManager.js', () => ({
     2: 'Repeater',
     3: 'RoomServer',
   },
+  MeshCoreManager: class {},
+}));
+
+vi.mock('../meshcoreRegistry.js', () => ({
+  meshcoreManagerRegistry: {
+    getOrCreateLegacyManager: () => meshcoreManager,
+    list: () => [meshcoreManager],
+    get: () => meshcoreManager,
+  },
+  LEGACY_MESHCORE_SOURCE_ID: 'meshcore-legacy-default',
 }));
 
 import DatabaseService from '../../services/database.js';
 import meshcoreRoutes from './meshcoreRoutes.js';
 import authRoutes from './authRoutes.js';
-import meshcoreManager from '../meshcoreManager.js';
 
 describe('MeshCore Routes', () => {
   let app: Express;

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -9,10 +9,21 @@
  */
 
 import { Router, Request, Response } from 'express';
-import meshcoreManager, { ConnectionType, MeshCoreDeviceType } from '../meshcoreManager.js';
+import { ConnectionType, MeshCoreDeviceType } from '../meshcoreManager.js';
+import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
 import { logger } from '../../utils/logger.js';
 import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
 import { meshcoreDeviceLimiter, messageLimiter } from '../middleware/rateLimiters.js';
+
+/**
+ * Resolve the manager for the legacy un-nested `/api/meshcore/*` routes.
+ *
+ * TODO(slice-2): these routes will be re-mounted under
+ * `/api/sources/:id/meshcore/*` and the manager will come from the URL.
+ * Until then, every endpoint lazy-creates / reuses one manager keyed by
+ * the legacy default source id so behaviour matches the old singleton.
+ */
+const meshcoreManager = () => meshcoreManagerRegistry.getOrCreateLegacyManager();
 
 const router = Router();
 
@@ -120,9 +131,9 @@ function isValidConnectionParams(params: {
  */
 router.get('/status', optionalAuth(), requirePermission('meshcore', 'read'), async (_req: Request, res: Response) => {
   try {
-    const status = meshcoreManager.getConnectionStatus();
-    const localNode = meshcoreManager.getLocalNode();
-    const envConfig = meshcoreManager.getEnvConfig();
+    const status = meshcoreManager().getConnectionStatus();
+    const localNode = meshcoreManager().getLocalNode();
+    const envConfig = meshcoreManager().getEnvConfig();
 
     res.json({
       success: true,
@@ -175,15 +186,15 @@ router.post('/connect', meshcoreDeviceLimiter, requireAuth(), requirePermission(
       firmwareType,
     };
 
-    const success = await meshcoreManager.connect(config);
+    const success = await meshcoreManager().connect(config);
 
     if (success) {
       res.json({
         success: true,
         message: 'Connected successfully',
         data: {
-          localNode: meshcoreManager.getLocalNode(),
-          deviceType: MeshCoreDeviceType[meshcoreManager.getConnectionStatus().deviceType],
+          localNode: meshcoreManager().getLocalNode(),
+          deviceType: MeshCoreDeviceType[meshcoreManager().getConnectionStatus().deviceType],
         },
       });
     } else {
@@ -202,7 +213,7 @@ router.post('/connect', meshcoreDeviceLimiter, requireAuth(), requirePermission(
  */
 router.post('/disconnect', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (_req: Request, res: Response) => {
   try {
-    await meshcoreManager.disconnect();
+    await meshcoreManager().disconnect();
     res.json({ success: true, message: 'Disconnected' });
   } catch (error) {
     logger.error('[API] Error disconnecting:', error);
@@ -216,7 +227,7 @@ router.post('/disconnect', meshcoreDeviceLimiter, requireAuth(), requirePermissi
  */
 router.get('/nodes', optionalAuth(), requirePermission('meshcore', 'read'), async (_req: Request, res: Response) => {
   try {
-    const nodes = meshcoreManager.getAllNodes();
+    const nodes = meshcoreManager().getAllNodes();
     res.json({
       success: true,
       data: nodes,
@@ -234,8 +245,8 @@ router.get('/nodes', optionalAuth(), requirePermission('meshcore', 'read'), asyn
  */
 router.get('/contacts', optionalAuth(), requirePermission('meshcore', 'read'), async (_req: Request, res: Response) => {
   try {
-    const contacts = meshcoreManager.getContacts();
-    const localNode = meshcoreManager.getLocalNode();
+    const contacts = meshcoreManager().getContacts();
+    const localNode = meshcoreManager().getLocalNode();
 
     // Include local node in contacts list if it has coordinates
     const allContacts = [...contacts];
@@ -271,7 +282,7 @@ router.get('/contacts', optionalAuth(), requirePermission('meshcore', 'read'), a
  */
 router.post('/contacts/refresh', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (_req: Request, res: Response) => {
   try {
-    const contacts = await meshcoreManager.refreshContacts();
+    const contacts = await meshcoreManager().refreshContacts();
     res.json({
       success: true,
       data: Array.from(contacts.values()),
@@ -296,7 +307,7 @@ router.get('/messages', optionalAuth(), requirePermission('meshcore', 'read'), a
     } else if (limit > VALIDATION.MAX_MESSAGE_LIMIT) {
       limit = VALIDATION.MAX_MESSAGE_LIMIT;
     }
-    const messages = meshcoreManager.getRecentMessages(limit);
+    const messages = meshcoreManager().getRecentMessages(limit);
     res.json({
       success: true,
       data: messages,
@@ -330,7 +341,7 @@ router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('
       }
     }
 
-    const success = await meshcoreManager.sendMessage(text, toPublicKey);
+    const success = await meshcoreManager().sendMessage(text, toPublicKey);
 
     if (success) {
       res.json({ success: true, message: 'Message sent' });
@@ -350,7 +361,7 @@ router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('
  */
 router.post('/advert', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (_req: Request, res: Response) => {
   try {
-    const success = await meshcoreManager.sendAdvert();
+    const success = await meshcoreManager().sendAdvert();
 
     if (success) {
       res.json({ success: true, message: 'Advert sent' });
@@ -381,7 +392,7 @@ router.post('/admin/login', meshcoreDeviceLimiter, requireAuth(), requirePermiss
       return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
     }
 
-    const success = await meshcoreManager.loginToNode(publicKey, password);
+    const success = await meshcoreManager().loginToNode(publicKey, password);
 
     if (success) {
       res.json({ success: true, message: 'Login successful' });
@@ -408,7 +419,7 @@ router.get('/admin/status/:publicKey', requireAuth(), requirePermission('meshcor
       return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
     }
 
-    const status = await meshcoreManager.requestNodeStatus(publicKey);
+    const status = await meshcoreManager().requestNodeStatus(publicKey);
 
     if (status) {
       res.json({ success: true, data: status });
@@ -436,7 +447,7 @@ router.post('/config/name', meshcoreDeviceLimiter, requireAuth(), requirePermiss
       return res.status(400).json({ success: false, error: nameValidation.error });
     }
 
-    const success = await meshcoreManager.setName(name.trim());
+    const success = await meshcoreManager().setName(name.trim());
 
     if (success) {
       res.json({ success: true, message: 'Name updated' });
@@ -477,7 +488,7 @@ router.post('/config/radio', meshcoreDeviceLimiter, requireAuth(), requirePermis
       return res.status(400).json({ success: false, error: radioValidation.error });
     }
 
-    const success = await meshcoreManager.setRadio(parsedFreq, parsedBw, parsedSf, parsedCr);
+    const success = await meshcoreManager().setRadio(parsedFreq, parsedBw, parsedSf, parsedCr);
 
     if (success) {
       res.json({ success: true, message: 'Radio config updated' });

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -159,9 +159,10 @@ function isValidConnectionParams(params: {
  */
 router.get('/status', optionalAuth(), requirePermission('meshcore', 'read'), async (req: Request, res: Response) => {
   try {
-    const status = managerFor(req).getConnectionStatus();
-    const localNode = managerFor(req).getLocalNode();
-    const envConfig = managerFor(req).getEnvConfig();
+    const manager = managerFor(req);
+    const status = manager.getConnectionStatus();
+    const localNode = manager.getLocalNode();
+    const envConfig = manager.getEnvConfig();
 
     res.json({
       success: true,
@@ -214,15 +215,16 @@ router.post('/connect', meshcoreDeviceLimiter, requireAuth(), requirePermission(
       firmwareType,
     };
 
-    const success = await managerFor(req).connect(config);
+    const manager = managerFor(req);
+    const success = await manager.connect(config);
 
     if (success) {
       res.json({
         success: true,
         message: 'Connected successfully',
         data: {
-          localNode: managerFor(req).getLocalNode(),
-          deviceType: MeshCoreDeviceType[managerFor(req).getConnectionStatus().deviceType],
+          localNode: manager.getLocalNode(),
+          deviceType: MeshCoreDeviceType[manager.getConnectionStatus().deviceType],
         },
       });
     } else {
@@ -273,8 +275,9 @@ router.get('/nodes', optionalAuth(), requirePermission('meshcore', 'read'), asyn
  */
 router.get('/contacts', optionalAuth(), requirePermission('meshcore', 'read'), async (req: Request, res: Response) => {
   try {
-    const contacts = managerFor(req).getContacts();
-    const localNode = managerFor(req).getLocalNode();
+    const manager = managerFor(req);
+    const contacts = manager.getContacts();
+    const localNode = manager.getLocalNode();
 
     // Include local node in contacts list if it has coordinates
     const allContacts = [...contacts];

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -16,36 +16,34 @@ import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddle
 import { meshcoreDeviceLimiter, messageLimiter } from '../middleware/rateLimiters.js';
 
 /**
- * Resolve the manager for a request. Slice 2 nests these routes under
- * `/api/sources/:id/meshcore/*`, so when `req.params.id` is present we
- * resolve the manager bound to that source. The un-nested
- * `/api/meshcore/*` mount is kept for backward compatibility (UI, scripts)
- * and falls back to the legacy registry helper.
+ * Resolve the manager for a request. Mounted only under
+ * `/api/sources/:id/meshcore/*`, so `req.params.id` is always present —
+ * the legacy un-nested mount and its registry fallback were removed in
+ * slice 3 along with the global `meshcore` permission resource.
  *
- * Returns `null` when the URL carried a sourceId that has no registered
- * manager — the caller should respond 404. Never returns null on the
- * legacy path.
+ * Presence + existence of the manager is enforced by the router-level
+ * guard below, so the assertion here is safe.
  */
 function managerFor(req: Request): MeshCoreManager {
-  const sourceId = (req.params as { id?: string }).id;
-  if (sourceId) {
-    // Presence is enforced by the router-level guard below, so a missing
-    // manager here would be a logic bug; assert rather than re-check.
-    return meshcoreManagerRegistry.get(sourceId)!;
-  }
-  return meshcoreManagerRegistry.getOrCreateLegacyManager();
+  const sourceId = (req.params as { id?: string }).id!;
+  return meshcoreManagerRegistry.get(sourceId)!;
 }
 
 const router = Router({ mergeParams: true });
 
 /**
- * Router-level guard: when the URL carries a `:id`, the source must
- * have a registered manager. This lets every handler call `managerFor`
- * without null-checking at each call-site.
+ * Router-level guard: every request must carry an `:id` and that source
+ * must have a registered manager. This lets every handler call
+ * `managerFor` without null-checking at each call-site.
  */
 router.use((req, res, next) => {
   const sourceId = (req.params as { id?: string }).id;
-  if (!sourceId) return next();
+  if (!sourceId) {
+    return res.status(404).json({
+      success: false,
+      error: 'MeshCore routes must be mounted under /api/sources/:id/meshcore',
+    });
+  }
   if (!meshcoreManagerRegistry.get(sourceId)) {
     return res.status(404).json({
       success: false,
@@ -157,7 +155,7 @@ function isValidConnectionParams(params: {
  * GET /api/meshcore/status
  * Get connection status and local node info
  */
-router.get('/status', optionalAuth(), requirePermission('meshcore', 'read'), async (req: Request, res: Response) => {
+router.get('/status', optionalAuth(), requirePermission('connection', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
     const manager = managerFor(req);
     const status = manager.getConnectionStatus();
@@ -184,7 +182,7 @@ router.get('/status', optionalAuth(), requirePermission('meshcore', 'read'), asy
  * Connect to a MeshCore device
  * Requires authentication - connects to hardware
  */
-router.post('/connect', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (req: Request, res: Response) => {
+router.post('/connect', meshcoreDeviceLimiter, requireAuth(), requirePermission('connection', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
     const { connectionType, serialPort, tcpHost, tcpPort, baudRate } = req.body;
 
@@ -241,7 +239,7 @@ router.post('/connect', meshcoreDeviceLimiter, requireAuth(), requirePermission(
  * Disconnect from the device
  * Requires authentication - disconnects hardware
  */
-router.post('/disconnect', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (req: Request, res: Response) => {
+router.post('/disconnect', meshcoreDeviceLimiter, requireAuth(), requirePermission('connection', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
     await managerFor(req).disconnect();
     res.json({ success: true, message: 'Disconnected' });
@@ -255,7 +253,7 @@ router.post('/disconnect', meshcoreDeviceLimiter, requireAuth(), requirePermissi
  * GET /api/meshcore/nodes
  * Get all known nodes (local + contacts)
  */
-router.get('/nodes', optionalAuth(), requirePermission('meshcore', 'read'), async (req: Request, res: Response) => {
+router.get('/nodes', optionalAuth(), requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
     const nodes = managerFor(req).getAllNodes();
     res.json({
@@ -273,7 +271,7 @@ router.get('/nodes', optionalAuth(), requirePermission('meshcore', 'read'), asyn
  * GET /api/meshcore/contacts
  * Get contacts list
  */
-router.get('/contacts', optionalAuth(), requirePermission('meshcore', 'read'), async (req: Request, res: Response) => {
+router.get('/contacts', optionalAuth(), requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
     const manager = managerFor(req);
     const contacts = manager.getContacts();
@@ -311,7 +309,7 @@ router.get('/contacts', optionalAuth(), requirePermission('meshcore', 'read'), a
  * Refresh contacts from device
  * Requires authentication - triggers device communication
  */
-router.post('/contacts/refresh', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (req: Request, res: Response) => {
+router.post('/contacts/refresh', meshcoreDeviceLimiter, requireAuth(), requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
     const contacts = await managerFor(req).refreshContacts();
     res.json({
@@ -329,7 +327,7 @@ router.post('/contacts/refresh', meshcoreDeviceLimiter, requireAuth(), requirePe
  * GET /api/meshcore/messages
  * Get recent messages
  */
-router.get('/messages', optionalAuth(), requirePermission('meshcore', 'read'), async (req: Request, res: Response) => {
+router.get('/messages', optionalAuth(), requirePermission('messages', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
     let limit = parseInt(req.query.limit as string || '50', 10);
     // Validate and clamp limit to reasonable bounds
@@ -355,7 +353,7 @@ router.get('/messages', optionalAuth(), requirePermission('meshcore', 'read'), a
  * Send a message
  * Requires authentication - sends data over mesh network
  */
-router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (req: Request, res: Response) => {
+router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
     const { text, toPublicKey } = req.body;
 
@@ -390,7 +388,7 @@ router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('
  * Send an advertisement
  * Requires authentication - broadcasts on mesh network
  */
-router.post('/advert', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (req: Request, res: Response) => {
+router.post('/advert', meshcoreDeviceLimiter, requireAuth(), requirePermission('connection', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
     const success = await managerFor(req).sendAdvert();
 
@@ -410,7 +408,7 @@ router.post('/advert', meshcoreDeviceLimiter, requireAuth(), requirePermission('
  * Login to a remote node for admin access
  * Requires authentication - sensitive admin operation
  */
-router.post('/admin/login', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (req: Request, res: Response) => {
+router.post('/admin/login', meshcoreDeviceLimiter, requireAuth(), requirePermission('configuration', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
     const { publicKey, password } = req.body;
 
@@ -441,7 +439,7 @@ router.post('/admin/login', meshcoreDeviceLimiter, requireAuth(), requirePermiss
  * Get status from a remote node (requires prior login)
  * Requires authentication - queries remote node
  */
-router.get('/admin/status/:publicKey', requireAuth(), requirePermission('meshcore', 'read'), async (req: Request, res: Response) => {
+router.get('/admin/status/:publicKey', requireAuth(), requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
     const { publicKey } = req.params;
 
@@ -468,7 +466,7 @@ router.get('/admin/status/:publicKey', requireAuth(), requirePermission('meshcor
  * Set device name
  * Requires authentication - modifies device configuration
  */
-router.post('/config/name', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (req: Request, res: Response) => {
+router.post('/config/name', meshcoreDeviceLimiter, requireAuth(), requirePermission('configuration', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
     const { name } = req.body;
 
@@ -496,7 +494,7 @@ router.post('/config/name', meshcoreDeviceLimiter, requireAuth(), requirePermiss
  * Set radio parameters
  * Requires authentication - modifies device radio configuration
  */
-router.post('/config/radio', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (req: Request, res: Response) => {
+router.post('/config/radio', meshcoreDeviceLimiter, requireAuth(), requirePermission('configuration', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
     const { freq, bw, sf, cr } = req.body;
 

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -9,23 +9,51 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { ConnectionType, MeshCoreDeviceType } from '../meshcoreManager.js';
+import { ConnectionType, MeshCoreDeviceType, MeshCoreManager } from '../meshcoreManager.js';
 import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
 import { logger } from '../../utils/logger.js';
 import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
 import { meshcoreDeviceLimiter, messageLimiter } from '../middleware/rateLimiters.js';
 
 /**
- * Resolve the manager for the legacy un-nested `/api/meshcore/*` routes.
+ * Resolve the manager for a request. Slice 2 nests these routes under
+ * `/api/sources/:id/meshcore/*`, so when `req.params.id` is present we
+ * resolve the manager bound to that source. The un-nested
+ * `/api/meshcore/*` mount is kept for backward compatibility (UI, scripts)
+ * and falls back to the legacy registry helper.
  *
- * TODO(slice-2): these routes will be re-mounted under
- * `/api/sources/:id/meshcore/*` and the manager will come from the URL.
- * Until then, every endpoint lazy-creates / reuses one manager keyed by
- * the legacy default source id so behaviour matches the old singleton.
+ * Returns `null` when the URL carried a sourceId that has no registered
+ * manager — the caller should respond 404. Never returns null on the
+ * legacy path.
  */
-const meshcoreManager = () => meshcoreManagerRegistry.getOrCreateLegacyManager();
+function managerFor(req: Request): MeshCoreManager {
+  const sourceId = (req.params as { id?: string }).id;
+  if (sourceId) {
+    // Presence is enforced by the router-level guard below, so a missing
+    // manager here would be a logic bug; assert rather than re-check.
+    return meshcoreManagerRegistry.get(sourceId)!;
+  }
+  return meshcoreManagerRegistry.getOrCreateLegacyManager();
+}
 
-const router = Router();
+const router = Router({ mergeParams: true });
+
+/**
+ * Router-level guard: when the URL carries a `:id`, the source must
+ * have a registered manager. This lets every handler call `managerFor`
+ * without null-checking at each call-site.
+ */
+router.use((req, res, next) => {
+  const sourceId = (req.params as { id?: string }).id;
+  if (!sourceId) return next();
+  if (!meshcoreManagerRegistry.get(sourceId)) {
+    return res.status(404).json({
+      success: false,
+      error: `No MeshCore manager for source ${sourceId}`,
+    });
+  }
+  next();
+});
 
 /**
  * Input Validation Constants
@@ -129,11 +157,11 @@ function isValidConnectionParams(params: {
  * GET /api/meshcore/status
  * Get connection status and local node info
  */
-router.get('/status', optionalAuth(), requirePermission('meshcore', 'read'), async (_req: Request, res: Response) => {
+router.get('/status', optionalAuth(), requirePermission('meshcore', 'read'), async (req: Request, res: Response) => {
   try {
-    const status = meshcoreManager().getConnectionStatus();
-    const localNode = meshcoreManager().getLocalNode();
-    const envConfig = meshcoreManager().getEnvConfig();
+    const status = managerFor(req).getConnectionStatus();
+    const localNode = managerFor(req).getLocalNode();
+    const envConfig = managerFor(req).getEnvConfig();
 
     res.json({
       success: true,
@@ -186,15 +214,15 @@ router.post('/connect', meshcoreDeviceLimiter, requireAuth(), requirePermission(
       firmwareType,
     };
 
-    const success = await meshcoreManager().connect(config);
+    const success = await managerFor(req).connect(config);
 
     if (success) {
       res.json({
         success: true,
         message: 'Connected successfully',
         data: {
-          localNode: meshcoreManager().getLocalNode(),
-          deviceType: MeshCoreDeviceType[meshcoreManager().getConnectionStatus().deviceType],
+          localNode: managerFor(req).getLocalNode(),
+          deviceType: MeshCoreDeviceType[managerFor(req).getConnectionStatus().deviceType],
         },
       });
     } else {
@@ -211,9 +239,9 @@ router.post('/connect', meshcoreDeviceLimiter, requireAuth(), requirePermission(
  * Disconnect from the device
  * Requires authentication - disconnects hardware
  */
-router.post('/disconnect', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (_req: Request, res: Response) => {
+router.post('/disconnect', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (req: Request, res: Response) => {
   try {
-    await meshcoreManager().disconnect();
+    await managerFor(req).disconnect();
     res.json({ success: true, message: 'Disconnected' });
   } catch (error) {
     logger.error('[API] Error disconnecting:', error);
@@ -225,9 +253,9 @@ router.post('/disconnect', meshcoreDeviceLimiter, requireAuth(), requirePermissi
  * GET /api/meshcore/nodes
  * Get all known nodes (local + contacts)
  */
-router.get('/nodes', optionalAuth(), requirePermission('meshcore', 'read'), async (_req: Request, res: Response) => {
+router.get('/nodes', optionalAuth(), requirePermission('meshcore', 'read'), async (req: Request, res: Response) => {
   try {
-    const nodes = meshcoreManager().getAllNodes();
+    const nodes = managerFor(req).getAllNodes();
     res.json({
       success: true,
       data: nodes,
@@ -243,10 +271,10 @@ router.get('/nodes', optionalAuth(), requirePermission('meshcore', 'read'), asyn
  * GET /api/meshcore/contacts
  * Get contacts list
  */
-router.get('/contacts', optionalAuth(), requirePermission('meshcore', 'read'), async (_req: Request, res: Response) => {
+router.get('/contacts', optionalAuth(), requirePermission('meshcore', 'read'), async (req: Request, res: Response) => {
   try {
-    const contacts = meshcoreManager().getContacts();
-    const localNode = meshcoreManager().getLocalNode();
+    const contacts = managerFor(req).getContacts();
+    const localNode = managerFor(req).getLocalNode();
 
     // Include local node in contacts list if it has coordinates
     const allContacts = [...contacts];
@@ -280,9 +308,9 @@ router.get('/contacts', optionalAuth(), requirePermission('meshcore', 'read'), a
  * Refresh contacts from device
  * Requires authentication - triggers device communication
  */
-router.post('/contacts/refresh', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (_req: Request, res: Response) => {
+router.post('/contacts/refresh', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (req: Request, res: Response) => {
   try {
-    const contacts = await meshcoreManager().refreshContacts();
+    const contacts = await managerFor(req).refreshContacts();
     res.json({
       success: true,
       data: Array.from(contacts.values()),
@@ -307,7 +335,7 @@ router.get('/messages', optionalAuth(), requirePermission('meshcore', 'read'), a
     } else if (limit > VALIDATION.MAX_MESSAGE_LIMIT) {
       limit = VALIDATION.MAX_MESSAGE_LIMIT;
     }
-    const messages = meshcoreManager().getRecentMessages(limit);
+    const messages = managerFor(req).getRecentMessages(limit);
     res.json({
       success: true,
       data: messages,
@@ -341,7 +369,7 @@ router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('
       }
     }
 
-    const success = await meshcoreManager().sendMessage(text, toPublicKey);
+    const success = await managerFor(req).sendMessage(text, toPublicKey);
 
     if (success) {
       res.json({ success: true, message: 'Message sent' });
@@ -359,9 +387,9 @@ router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('
  * Send an advertisement
  * Requires authentication - broadcasts on mesh network
  */
-router.post('/advert', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (_req: Request, res: Response) => {
+router.post('/advert', meshcoreDeviceLimiter, requireAuth(), requirePermission('meshcore', 'write'), async (req: Request, res: Response) => {
   try {
-    const success = await meshcoreManager().sendAdvert();
+    const success = await managerFor(req).sendAdvert();
 
     if (success) {
       res.json({ success: true, message: 'Advert sent' });
@@ -392,7 +420,7 @@ router.post('/admin/login', meshcoreDeviceLimiter, requireAuth(), requirePermiss
       return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
     }
 
-    const success = await meshcoreManager().loginToNode(publicKey, password);
+    const success = await managerFor(req).loginToNode(publicKey, password);
 
     if (success) {
       res.json({ success: true, message: 'Login successful' });
@@ -419,7 +447,7 @@ router.get('/admin/status/:publicKey', requireAuth(), requirePermission('meshcor
       return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
     }
 
-    const status = await meshcoreManager().requestNodeStatus(publicKey);
+    const status = await managerFor(req).requestNodeStatus(publicKey);
 
     if (status) {
       res.json({ success: true, data: status });
@@ -447,7 +475,7 @@ router.post('/config/name', meshcoreDeviceLimiter, requireAuth(), requirePermiss
       return res.status(400).json({ success: false, error: nameValidation.error });
     }
 
-    const success = await meshcoreManager().setName(name.trim());
+    const success = await managerFor(req).setName(name.trim());
 
     if (success) {
       res.json({ success: true, message: 'Name updated' });
@@ -488,7 +516,7 @@ router.post('/config/radio', meshcoreDeviceLimiter, requireAuth(), requirePermis
       return res.status(400).json({ success: false, error: radioValidation.error });
     }
 
-    const success = await meshcoreManager().setRadio(parsedFreq, parsedBw, parsedSf, parsedCr);
+    const success = await managerFor(req).setRadio(parsedFreq, parsedBw, parsedSf, parsedCr);
 
     if (success) {
       res.json({ success: true, message: 'Radio config updated' });

--- a/src/server/routes/messageRoutes.ts
+++ b/src/server/routes/messageRoutes.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from 'express';
 import databaseService from '../../services/database.js';
-import meshcoreManager from '../meshcoreManager.js';
+import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
 import meshtasticManagerDefault from '../meshtasticManager.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { logger } from '../../utils/logger.js';
@@ -198,12 +198,13 @@ router.get('/search', async (req: Request, res: Response) => {
       total += sourceIdStr ? filtered.length : searchResult.total;
     }
 
-    // Search MeshCore messages (in-memory filter)
-    if ((searchScope === 'all' || searchScope === 'meshcore') && meshcoreManager.isConnected()) {
+    // Search MeshCore messages (in-memory filter, across every registered source)
+    const meshcoreManagers = meshcoreManagerRegistry.list().filter(m => m.isConnected());
+    if ((searchScope === 'all' || searchScope === 'meshcore') && meshcoreManagers.length > 0) {
       const hasMeshcoreAccess = isAdmin || (accessibleChannels === null);
 
       if (hasMeshcoreAccess) {
-        const allMeshcoreMessages = meshcoreManager.getRecentMessages(1000);
+        const allMeshcoreMessages = meshcoreManagers.flatMap(m => m.getRecentMessages(1000));
         const filtered = allMeshcoreMessages.filter(m => {
           if (!m.text) return false;
           const textMatch = isCaseSensitive

--- a/src/server/routes/v1/messages.ts
+++ b/src/server/routes/v1/messages.ts
@@ -8,7 +8,7 @@
 import express, { Request, Response } from 'express';
 import databaseService from '../../../services/database.js';
 import meshtasticManager from '../../meshtasticManager.js';
-import meshcoreManager from '../../meshcoreManager.js';
+import { meshcoreManagerRegistry } from '../../meshcoreRegistry.js';
 import { sourceManagerRegistry } from '../../sourceManagerRegistry.js';
 import { hasPermission } from '../../auth/authMiddleware.js';
 import { ResourceType } from '../../../types/permission.js';
@@ -249,12 +249,13 @@ router.get('/search', async (req: Request, res: Response) => {
       total += scopedMessages.length;
     }
 
-    // Search MeshCore messages (in-memory filter)
-    if ((searchScope === 'all' || searchScope === 'meshcore') && meshcoreManager.isConnected()) {
+    // Search MeshCore messages (in-memory filter, across every registered source)
+    const meshcoreManagers = meshcoreManagerRegistry.list().filter(m => m.isConnected());
+    if ((searchScope === 'all' || searchScope === 'meshcore') && meshcoreManagers.length > 0) {
       const hasMeshcoreAccess = isAdmin || (accessibleChannels === null);
 
       if (hasMeshcoreAccess) {
-        const allMeshcoreMessages = meshcoreManager.getRecentMessages(1000);
+        const allMeshcoreMessages = meshcoreManagers.flatMap(m => m.getRecentMessages(1000));
         const filtered = allMeshcoreMessages.filter(m => {
           if (!m.text) return false;
           const textMatch = isCaseSensitive

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -889,7 +889,12 @@ apiRouter.use('/messages', optionalAuth(), messageRoutes);
 
 // MeshCore routes (for MeshCore device monitoring)
 // Authentication handled per-route in meshcoreRoutes.ts
-// Enable with MESHCORE_ENABLED=true in .env
+// Slice 2: routes are nested under `/api/sources/:id/meshcore/*` so each
+// request resolves the manager bound to a specific source. The legacy
+// un-nested `/api/meshcore/*` mount is retained for backward compat with
+// the existing UI/scripts and routes through the legacy registry helper —
+// it goes away once the UI migrates (slice 2 follow-up).
+apiRouter.use('/sources/:id/meshcore', meshcoreRoutes);
 if (process.env.MESHCORE_ENABLED === 'true') {
   apiRouter.use('/meshcore', meshcoreRoutes);
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -445,6 +445,35 @@ setTimeout(async () => {
     let firstTcpSourceConfigured = false;
 
     for (const source of enabledSources) {
+      if (source.type === 'meshcore') {
+        // Slice 1 of multi-source MeshCore: spin up a per-source manager
+        // and connect it. Companion-USB only — other transports will be
+        // wired in slice 2.
+        const cfg = source.config as any;
+        if (cfg?.autoConnect === false) {
+          logger.info(`Skipping auto-connect for MeshCore source ${source.id} (${source.name}) — autoConnect disabled`);
+          continue;
+        }
+
+        try {
+          const mcConfig = meshcoreConfigFromSource(source);
+          if (!mcConfig) {
+            logger.warn(`MeshCore source ${source.id} (${source.name}) has incomplete config; skipping auto-connect`);
+            continue;
+          }
+          const manager = meshcoreManagerRegistry.getOrCreate(source);
+          const connected = await manager.connect(mcConfig);
+          if (connected) {
+            logger.info(`[MeshCore:${source.id}] Auto-connected source ${source.name}`);
+          } else {
+            logger.warn(`[MeshCore:${source.id}] Auto-connect failed for source ${source.name}`);
+          }
+        } catch (err) {
+          logger.error(`Failed to start MeshCore source ${source.id} (${source.name}); continuing with other sources:`, err);
+        }
+        continue;
+      }
+
       if (source.type === 'meshtastic_tcp') {
         const cfg = source.config as any;
 
@@ -498,19 +527,31 @@ setTimeout(async () => {
       logger.debug(`Started ${enabledSources.length} source manager(s)`);
     }
 
-    // Auto-connect MeshCore if enabled via environment variables
+    // Legacy env-var-based MeshCore auto-connect: when MESHCORE_ENABLED=true
+    // and no MeshCore source row exists yet, mint the legacy default source
+    // (same id as migration 056) from environment variables and connect it
+    // through the registry. Once a real source is configured via the UI,
+    // this branch becomes a no-op.
     if (process.env.MESHCORE_ENABLED === 'true') {
-      const meshcoreConfig = meshcoreManager.getEnvConfig();
-      if (meshcoreConfig) {
-        logger.info('[MeshCore] Auto-connecting on startup...');
-        const connected = await meshcoreManager.connect();
-        if (connected) {
-          logger.info('[MeshCore] Auto-connected successfully on startup');
-        } else {
-          logger.warn('[MeshCore] Auto-connect on startup failed — use the MeshCore tab to retry');
+      const existingMeshcoreSources = enabledSources.filter(s => s.type === 'meshcore');
+      if (existingMeshcoreSources.length === 0) {
+        try {
+          const legacyManager = meshcoreManagerRegistry.getOrCreateLegacyManager();
+          const envConfig = legacyManager.getEnvConfig();
+          if (envConfig) {
+            logger.info('[MeshCore] Auto-connecting legacy env-var source on startup...');
+            const connected = await legacyManager.connect(envConfig);
+            if (connected) {
+              logger.info('[MeshCore] Legacy env-var source connected');
+            } else {
+              logger.warn('[MeshCore] Legacy env-var auto-connect failed — use the MeshCore tab to retry');
+            }
+          } else {
+            logger.warn('[MeshCore] MESHCORE_ENABLED=true but no serial port or TCP host configured');
+          }
+        } catch (err) {
+          logger.error('[MeshCore] Legacy env-var auto-connect threw:', err);
         }
-      } else {
-        logger.warn('[MeshCore] MESHCORE_ENABLED=true but no serial port or TCP host configured');
       }
     }
 
@@ -755,7 +796,7 @@ import newsRoutes from './routes/newsRoutes.js';
 import tileServerRoutes from './routes/tileServerTest.js';
 import v1Router from './routes/v1/index.js';
 import meshcoreRoutes from './routes/meshcoreRoutes.js';
-import meshcoreManager from './meshcoreManager.js';
+import { meshcoreManagerRegistry, meshcoreConfigFromSource } from './meshcoreRegistry.js';
 import embedProfileRoutes from './routes/embedProfileRoutes.js';
 import { createEmbedCspMiddleware } from './middleware/embedMiddleware.js';
 import embedPublicRoutes from './routes/embedPublicRoutes.js';

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -887,17 +887,12 @@ apiRouter.use('/upgrade', upgradeRoutes);
 // Message routes (requires appropriate write permissions)
 apiRouter.use('/messages', optionalAuth(), messageRoutes);
 
-// MeshCore routes (for MeshCore device monitoring)
-// Authentication handled per-route in meshcoreRoutes.ts
-// Slice 2: routes are nested under `/api/sources/:id/meshcore/*` so each
+// MeshCore routes — nested under `/api/sources/:id/meshcore/*` so each
 // request resolves the manager bound to a specific source. The legacy
-// un-nested `/api/meshcore/*` mount is retained for backward compat with
-// the existing UI/scripts and routes through the legacy registry helper —
-// it goes away once the UI migrates (slice 2 follow-up).
+// un-nested `/api/meshcore/*` mount was dropped in slice 3 along with
+// the global `meshcore` permission resource; the new frontend talks to
+// the per-source surface only.
 apiRouter.use('/sources/:id/meshcore', meshcoreRoutes);
-if (process.env.MESHCORE_ENABLED === 'true') {
-  apiRouter.use('/meshcore', meshcoreRoutes);
-}
 
 // Link preview routes
 apiRouter.use('/', linkPreviewRoutes);

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -24,7 +24,6 @@ export type ResourceType =
   | 'security'
   | 'themes'
   | 'nodes_private'
-  | 'meshcore'
   | 'packetmonitor'
   | 'sources'
   | 'waypoints';
@@ -115,7 +114,6 @@ export const RESOURCES: readonly ResourceDefinition[] = [
   { id: 'security', name: 'Security', description: 'View security scan results and key management' },
   { id: 'themes', name: 'Custom Themes', description: 'Create and manage custom color themes' },
   { id: 'nodes_private', name: 'Private Positions', description: 'View private node position overrides' },
-  { id: 'meshcore', name: 'MeshCore', description: 'MeshCore protocol device management' },
   { id: 'packetmonitor', name: 'Packet Monitor', description: 'View real-time packet logs and statistics' },
   { id: 'sources', name: 'Sources', description: 'Manage data sources (Meshtastic TCP, MQTT, MeshCore)' },
   { id: 'waypoints', name: 'Waypoints', description: 'View and manage map waypoints (Meshtastic WAYPOINT_APP)' },
@@ -144,7 +142,6 @@ export const ADMIN_PERMISSIONS: PermissionSet = {
   security: { read: true, write: true },
   themes: { read: true, write: true },
   nodes_private: { read: true, write: true },
-  meshcore: { read: true, write: true },
   packetmonitor: { read: true, write: true },
   sources: { read: true, write: true },
   waypoints: { read: true, write: true },
@@ -172,7 +169,6 @@ export const DEFAULT_USER_PERMISSIONS: PermissionSet = {
   security: { read: false, write: false },
   themes: { read: true, write: false },
   nodes_private: { read: false, write: false },
-  meshcore: { read: true, write: false },
   packetmonitor: { read: true, write: false },
   sources: { read: false, write: false },
   waypoints: { read: true, write: false },


### PR DESCRIPTION
## Summary

Slice 3 of the MeshCore-as-source refactor. The global `meshcore` permission resource is removed and replaced with the existing per-source sourcey set (`connection`, `configuration`, `nodes`, `messages`) scoped per meshcore-typed source.

- **Migration 057** expands each global `meshcore` grant into per-source rows across the four target resources for every meshcore-typed source, then drops the originals. SQLite/Postgres/MySQL paths plus a SQLite unit test (idempotency, expansion math, non-meshcore-source skip, canRead/canWrite preservation).
- **Routes** — `requirePermission('meshcore', ...)` calls in `meshcoreRoutes.ts` rewritten to the appropriate sourcey resource with `sourceIdFrom: 'params.id'`. The legacy un-nested `/api/meshcore/*` mount is removed (router-level guard now requires `:id`).
- **Types / seeds** — `'meshcore'` removed from `ResourceType`, `RESOURCES`, `ADMIN_PERMISSIONS`, `DEFAULT_USER_PERMISSIONS`, and the seed lists in `oidcAuth.ts` / `localAuth.ts`. Migration 006's historical CHECK constraint is superseded by 033 (which removed the CHECK entirely), so no edits there.
- **Frontend** — legacy MeshCore tab gated `false` and search-modal MeshCore filter likewise, until slice 4 lands the per-source dashboards. Slice 4 is in flight in a parallel branch.

Channels lump under `messages` for v1 — per-channel `mc_channel_N` resources can be added later if a real use case appears.

Stacked on top of #2955 (slice 2). Frontend rebuild lives in slice 4.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/server/migrations/057_collapse_meshcore_resource.test.ts src/server/routes/meshcoreRoutes.test.ts` — 39 pass
- [ ] System tests pass in CI
- [ ] Existing users with `meshcore:read+write` retain equivalent access on each meshcore source after migration