### PR TITLE
feat(meshcore): per-source frontend (slice 4/N)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -627,10 +627,6 @@ function App() {
       info: () => hasPermission('info', 'read'),
       messages: () => hasPermission('messages', 'read'),
       channels: hasAnyChannelPermission,
-      // Slice 3 dropped the global `meshcore` permission resource; the
-      // standalone MeshCore tab is gated off until slice 4 rebuilds the
-      // surface as per-source dashboards under /api/sources/:id/meshcore.
-      meshcore: () => false,
       settings: () => hasPermission('settings', 'read'),
       automation: () => hasPermission('automation', 'read'),
       configuration: () => hasPermission('configuration', 'read'),

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -252,9 +252,6 @@ const Sidebar: React.FC<SidebarProps> = ({
           {hasPermission('dashboard', 'read') && (
             <NavItem id="dashboard" label={t('nav.dashboard')} icon={icon('dashboard')} />
           )}
-          {/* Slice 3 dropped the global `meshcore` permission; the legacy
-              standalone MeshCore tab is hidden until slice 4 lands the
-              per-source dashboards. */}
           {packetLogEnabled && hasPermission('packetmonitor', 'read') && (
             <NavItem id="packetmonitor" label={t('nav.packet_monitor', 'Packet Monitor')} icon={icon('packetmonitor')} />
           )}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,6 +18,8 @@ import UnifiedMessagesPage from './pages/UnifiedMessagesPage.tsx';
 import UnifiedTelemetryPage from './pages/UnifiedTelemetryPage.tsx';
 import GlobalSettingsPage from './pages/GlobalSettingsPage.tsx';
 import UsersPage from './pages/UsersPage.tsx';
+import MeshCoreSourcePage from './pages/MeshCoreSourcePage.tsx';
+import { useDashboardSources } from './hooks/useDashboardData';
 import './index.css';
 import { AuthProvider } from './contexts/AuthContext';
 import { CsrfProvider } from './contexts/CsrfContext';
@@ -28,10 +30,41 @@ import { SourceProvider } from './contexts/SourceContext';
  * Wraps App with SourceProvider then WebSocketProvider so that useWebSocket()
  * can call useSource() and get the real sourceId for room subscription and
  * cache key targeting. WebSocketProvider must be INSIDE SourceProvider.
+ *
+ * Slice 4 of the MeshCore-as-source refactor: dispatch on `source.type`.
+ * Meshcore sources render the dedicated MeshCoreSourcePage, which talks to
+ * the `/api/sources/:id/meshcore/*` routes; everything else falls through to
+ * the legacy Meshtastic <App>.
  */
 function SourceApp() {
   const { sourceId } = useParams<{ sourceId: string }>();
+  const { data: sources, isLoading } = useDashboardSources();
+
   if (!sourceId) return <Navigate to="/" replace />;
+
+  const source = sources?.find((s) => s.id === sourceId);
+
+  // While the source list is in flight we don't yet know whether to render
+  // App or the meshcore page. Block both so we don't flash the wrong UI and
+  // immediately re-mount on switch — App is heavy and re-mount is costly.
+  if (isLoading && !source) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100dvh' }}>
+        Loading…
+      </div>
+    );
+  }
+
+  if (source?.type === 'meshcore') {
+    return (
+      <SourceProvider sourceId={sourceId} sourceName={source.name}>
+        {/* No WebSocketProvider: the per-source meshcore surface polls REST
+            today; live updates come via slice-N follow-up. */}
+        <MeshCoreSourcePage key={sourceId} />
+      </SourceProvider>
+    );
+  }
+
   return (
     <SourceProvider sourceId={sourceId}>
       <WebSocketProvider>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -81,6 +81,7 @@ function DashboardInner() {
   // Source add/edit modal state
   const [showSourceModal, setShowSourceModal] = useState(false);
   const [editingSourceId, setEditingSourceId] = useState<string | null>(null);
+  const [formType, setFormType] = useState<'meshtastic_tcp' | 'meshcore'>('meshtastic_tcp');
   const [formName, setFormName] = useState('');
   const [formHost, setFormHost] = useState('');
   const [formPort, setFormPort] = useState('4403');
@@ -89,6 +90,9 @@ function DashboardInner() {
   const [formVnAllowAdmin, setFormVnAllowAdmin] = useState(false);
   const [formHeartbeat, setFormHeartbeat] = useState('30'); // seconds, 0 = disabled (issue 2609)
   const [formAutoConnect, setFormAutoConnect] = useState(true); // issue #2773
+  // MeshCore-specific (slice 4): companion-USB v1 — serial path + device type.
+  const [formMcSerialPort, setFormMcSerialPort] = useState('');
+  const [formMcDeviceType, setFormMcDeviceType] = useState<'companion' | 'repeater'>('companion');
   const [formError, setFormError] = useState('');
   const [formSaving, setFormSaving] = useState(false);
 
@@ -194,6 +198,7 @@ function DashboardInner() {
   // ----- admin actions -----
   const onAddSource = () => {
     setEditingSourceId(null);
+    setFormType('meshtastic_tcp');
     setFormName('');
     setFormHost('');
     setFormPort('4403');
@@ -202,6 +207,8 @@ function DashboardInner() {
     setFormVnAllowAdmin(false);
     setFormHeartbeat('30');
     setFormAutoConnect(true);
+    setFormMcSerialPort('');
+    setFormMcDeviceType('companion');
     setFormError('');
     setShowSourceModal(true);
   };
@@ -211,6 +218,7 @@ function DashboardInner() {
     if (!source) return;
     const cfg = source.config as Record<string, any> | undefined;
     setEditingSourceId(id);
+    setFormType(source.type === 'meshcore' ? 'meshcore' : 'meshtastic_tcp');
     setFormName(source.name);
     setFormHost(cfg?.host ?? '');
     setFormPort(String(cfg?.port ?? 4403));
@@ -221,48 +229,70 @@ function DashboardInner() {
     setFormHeartbeat(String(cfg?.heartbeatIntervalSeconds ?? 0));
     // Default to true when unset (legacy sources pre-#2773 auto-connected).
     setFormAutoConnect(cfg?.autoConnect !== false);
+    // MeshCore-specific config (slice 4)
+    setFormMcSerialPort(cfg?.serialPort ?? cfg?.port ?? '');
+    setFormMcDeviceType(cfg?.deviceType === 'repeater' ? 'repeater' : 'companion');
     setFormError('');
     setShowSourceModal(true);
   };
 
   const onSaveSource = async () => {
     if (!formName.trim()) { setFormError(t('source.form.error_name_required')); return; }
-    if (!formHost.trim()) { setFormError(t('source.form.error_host_required')); return; }
-    const port = parseInt(formPort, 10);
-    if (isNaN(port) || port < 1 || port > 65535) { setFormError(t('source.form.error_port_range')); return; }
 
-    // Heartbeat interval (issue 2609): 0 = disabled, otherwise a positive
-    // number of seconds. We clamp to a sane range to prevent pathological
-    // configurations (sub-second floods or 24h naps that defeat the point).
-    const heartbeatSeconds = parseInt(formHeartbeat, 10);
-    if (isNaN(heartbeatSeconds) || heartbeatSeconds < 0 || heartbeatSeconds > 3600) {
-      setFormError(t('source.form.error_heartbeat_range'));
-      return;
-    }
-
-    let vnConfig: { enabled: boolean; port: number; allowAdminCommands: boolean } | undefined;
-    if (formVnEnabled) {
-      const vnPort = parseInt(formVnPort, 10);
-      if (isNaN(vnPort) || vnPort < 1 || vnPort > 65535) {
-        setFormError(t('source.form.error_vn_port_range'));
+    let cfg: Record<string, any>;
+    if (formType === 'meshcore') {
+      // MeshCore companion-USB v1: just serial port + device type. Other
+      // transports (BLE/TCP) are out of scope for slice 4.
+      const port = formMcSerialPort.trim();
+      if (!port) {
+        setFormError(t('meshcore.form.error_port_required', 'Serial port is required'));
         return;
       }
-      vnConfig = { enabled: true, port: vnPort, allowAdminCommands: formVnAllowAdmin };
+      cfg = {
+        transport: 'usb',
+        port,
+        deviceType: formMcDeviceType,
+        autoConnect: formAutoConnect,
+      };
+    } else {
+      if (!formHost.trim()) { setFormError(t('source.form.error_host_required')); return; }
+      const port = parseInt(formPort, 10);
+      if (isNaN(port) || port < 1 || port > 65535) { setFormError(t('source.form.error_port_range')); return; }
+
+      // Heartbeat interval (issue 2609): 0 = disabled, otherwise a positive
+      // number of seconds. We clamp to a sane range to prevent pathological
+      // configurations (sub-second floods or 24h naps that defeat the point).
+      const heartbeatSeconds = parseInt(formHeartbeat, 10);
+      if (isNaN(heartbeatSeconds) || heartbeatSeconds < 0 || heartbeatSeconds > 3600) {
+        setFormError(t('source.form.error_heartbeat_range'));
+        return;
+      }
+
+      let vnConfig: { enabled: boolean; port: number; allowAdminCommands: boolean } | undefined;
+      if (formVnEnabled) {
+        const vnPort = parseInt(formVnPort, 10);
+        if (isNaN(vnPort) || vnPort < 1 || vnPort > 65535) {
+          setFormError(t('source.form.error_vn_port_range'));
+          return;
+        }
+        vnConfig = { enabled: true, port: vnPort, allowAdminCommands: formVnAllowAdmin };
+      }
+
+      cfg = { host: formHost.trim(), port };
+      if (heartbeatSeconds > 0) cfg.heartbeatIntervalSeconds = heartbeatSeconds;
+      if (vnConfig) cfg.virtualNode = vnConfig;
+      // Persist autoConnect explicitly so the server can distinguish legacy
+      // sources (undefined → treat as true) from ones the user opted out of.
+      cfg.autoConnect = formAutoConnect;
     }
 
     setFormSaving(true);
     setFormError('');
     try {
       const csrfToken = getToken();
-      const cfg: Record<string, any> = { host: formHost.trim(), port };
-      if (heartbeatSeconds > 0) cfg.heartbeatIntervalSeconds = heartbeatSeconds;
-      if (vnConfig) cfg.virtualNode = vnConfig;
-      // Persist autoConnect explicitly so the server can distinguish legacy
-      // sources (undefined → treat as true) from ones the user opted out of.
-      cfg.autoConnect = formAutoConnect;
       const body = {
         name: formName.trim(),
-        type: 'meshtastic_tcp',
+        type: formType,
         config: cfg,
         enabled: true,
       };
@@ -503,6 +533,23 @@ function DashboardInner() {
           <div className="dashboard-confirm-dialog" style={{ maxWidth: 400 }} onClick={(e) => e.stopPropagation()}>
             <h3>{editingSourceId ? t('source.edit') : t('source.add')}</h3>
 
+            {/* Type selector (slice 4): only meaningful when adding — type is
+                immutable on edit because backend tables and managers are
+                bound to the type that was chosen at creation time. */}
+            {!editingSourceId && (
+              <label className="dashboard-form-field">
+                <span className="dashboard-form-label">{t('source.form.type', 'Type')}</span>
+                <select
+                  className="dashboard-form-input"
+                  value={formType}
+                  onChange={(e) => setFormType(e.target.value as 'meshtastic_tcp' | 'meshcore')}
+                >
+                  <option value="meshtastic_tcp">{t('source.form.type_meshtastic', 'Meshtastic (TCP)')}</option>
+                  <option value="meshcore">{t('source.form.type_meshcore', 'MeshCore (USB)')}</option>
+                </select>
+              </label>
+            )}
+
             <label className="dashboard-form-field">
               <span className="dashboard-form-label">{t('source.form.name')}</span>
               <input
@@ -515,6 +562,48 @@ function DashboardInner() {
               />
             </label>
 
+            {formType === 'meshcore' ? (
+              <>
+                <label className="dashboard-form-field">
+                  <span className="dashboard-form-label">{t('meshcore.form.serial_port', 'Serial Port')}</span>
+                  <input
+                    className="dashboard-form-input"
+                    type="text"
+                    value={formMcSerialPort}
+                    onChange={(e) => setFormMcSerialPort(e.target.value)}
+                    placeholder="/dev/ttyACM0"
+                  />
+                  <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                    {t('meshcore.form.serial_port_help', 'OS path of the USB-connected MeshCore companion (e.g. /dev/ttyACM0, COM3).')}
+                  </p>
+                </label>
+
+                <label className="dashboard-form-field">
+                  <span className="dashboard-form-label">{t('meshcore.form.device_type', 'Device Type')}</span>
+                  <select
+                    className="dashboard-form-input"
+                    value={formMcDeviceType}
+                    onChange={(e) => setFormMcDeviceType(e.target.value as 'companion' | 'repeater')}
+                  >
+                    <option value="companion">{t('meshcore.device_type.companion', 'Companion')}</option>
+                    <option value="repeater">{t('meshcore.device_type.repeater', 'Repeater')}</option>
+                  </select>
+                </label>
+
+                <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, margin: '8px 0 4px' }}>
+                  <input
+                    type="checkbox"
+                    checked={formAutoConnect}
+                    onChange={(e) => setFormAutoConnect(e.target.checked)}
+                  />
+                  {t('source.form.auto_connect')}
+                </label>
+                <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '0 0 8px 24px' }}>
+                  {t('source.form.auto_connect_help')}
+                </p>
+              </>
+            ) : (
+            <>
             <label className="dashboard-form-field">
               <span className="dashboard-form-label">{t('source.form.host')}</span>
               <input
@@ -601,6 +690,8 @@ function DashboardInner() {
                 </>
               )}
             </fieldset>
+            </>
+            )}
 
             {formError && (
               <p style={{ color: 'var(--ctp-red)', fontSize: 12, margin: '8px 0 0' }}>{formError}</p>

--- a/src/pages/MeshCoreSourcePage.test.tsx
+++ b/src/pages/MeshCoreSourcePage.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Smoke tests for the slice-4 per-source MeshCore page. Verifies the page
+ * targets the nested `/api/sources/:id/meshcore/*` routes and that
+ * connection-read permission gates the entire surface.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// react-i18next: passthrough so we can assert on default fallback text.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) => {
+      if (typeof fallback === 'string') return fallback;
+      // Test-only synthetic fallback so unmatched keys don't render as `undefined`.
+      return key;
+    },
+  }),
+}));
+
+// Initial-load helpers — DashboardPage's heavy SettingsContext needs the
+// settings endpoint to resolve. Stub fetch to default per URL.
+const originalFetch = globalThis.fetch;
+let fetchUrls: string[];
+
+beforeEach(() => {
+  fetchUrls = [];
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    fetchUrls.push(url);
+    if (url.includes('/api/settings')) {
+      return new Response(JSON.stringify({}), { status: 200 });
+    }
+    if (url.includes('/api/auth/csrf-token')) {
+      return new Response(JSON.stringify({ token: 't' }), { status: 200 });
+    }
+    if (url.includes('/meshcore/status')) {
+      return new Response(
+        JSON.stringify({ success: true, data: { connected: false, deviceType: 0, deviceTypeName: 'unknown', config: null, localNode: null } }),
+        { status: 200 },
+      );
+    }
+    return new Response(JSON.stringify({ success: true, data: [] }), { status: 200 });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+vi.mock('../contexts/SettingsContext', () => ({
+  SettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSettings: () => ({}),
+}));
+
+vi.mock('../components/ToastContainer', () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../components/LoginModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('../components/UserMenu', () => ({
+  default: () => null,
+}));
+
+vi.mock('../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => globalThis.fetch,
+}));
+
+const sourceContext = { sourceId: 'mc-src-1' as string | null, sourceName: 'MC Test' as string | null };
+vi.mock('../contexts/SourceContext', () => ({
+  useSource: () => sourceContext,
+}));
+
+const authValue: { authStatus: any; hasPermission: (r: string, a: string) => boolean } = {
+  authStatus: { authenticated: true, user: { isAdmin: false } },
+  hasPermission: () => true,
+};
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => authValue,
+}));
+
+import MeshCoreSourcePage from './MeshCoreSourcePage';
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <MeshCoreSourcePage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('MeshCoreSourcePage', () => {
+  it('hits the nested /api/sources/:id/meshcore/status route on mount', async () => {
+    authValue.hasPermission = () => true;
+    renderPage();
+    await waitFor(() => {
+      expect(fetchUrls.some((u) => u.includes('/api/sources/mc-src-1/meshcore/status'))).toBe(true);
+    });
+  });
+
+  it('shows a permission-denied message when connection:read is missing', async () => {
+    authValue.hasPermission = () => false;
+    renderPage();
+    expect(
+      await screen.findByText('You do not have permission to view this MeshCore source.'),
+    ).toBeInTheDocument();
+    // No status request should have been issued.
+    expect(fetchUrls.some((u) => u.includes('/meshcore/status'))).toBe(false);
+  });
+});

--- a/src/pages/MeshCoreSourcePage.tsx
+++ b/src/pages/MeshCoreSourcePage.tsx
@@ -1,0 +1,581 @@
+/**
+ * MeshCoreSourcePage — per-source MeshCore dashboard.
+ *
+ * Slice 4 of the MeshCore-as-source refactor. Mirrors the per-source
+ * Meshtastic dashboard structurally — connection panel, nodes/contacts,
+ * channels-as-messages, message send — but talks to the nested
+ * `/api/sources/:id/meshcore/*` routes that slice 2 introduced.
+ *
+ * Permission gating uses `hasPermission(resource, action, { sourceId })` with
+ * the per-source sourcey resources slice 3 introduced (`connection`,
+ * `configuration`, `nodes`, `messages`). Channels are lumped under `messages`
+ * for v1 — per-channel `mc_channel_N` resources can land later if needed.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { SettingsProvider } from '../contexts/SettingsContext';
+import { ToastProvider } from '../components/ToastContainer';
+import { useAuth } from '../contexts/AuthContext';
+import { useSource } from '../contexts/SourceContext';
+import { useCsrfFetch } from '../hooks/useCsrfFetch';
+import LoginModal from '../components/LoginModal';
+import UserMenu from '../components/UserMenu';
+import { appBasename } from '../init';
+import '../components/MeshCore/MeshCoreTab.css';
+
+interface MeshCoreNode {
+  publicKey: string;
+  name: string;
+  advType: number;
+  txPower?: number;
+  radioFreq?: number;
+  radioBw?: number;
+  radioSf?: number;
+  radioCr?: number;
+  lastHeard?: number;
+  rssi?: number;
+  snr?: number;
+  batteryMv?: number;
+  uptimeSecs?: number;
+  latitude?: number;
+  longitude?: number;
+}
+
+interface MeshCoreContact {
+  publicKey: string;
+  advName?: string;
+  name?: string;
+  advType?: number;
+  rssi?: number;
+  snr?: number;
+  latitude?: number;
+  longitude?: number;
+  lastSeen?: number;
+}
+
+interface MeshCoreMessage {
+  id: string;
+  fromPublicKey: string;
+  toPublicKey?: string;
+  text: string;
+  timestamp: number;
+}
+
+interface ConnectionStatus {
+  connected: boolean;
+  deviceType: number;
+  deviceTypeName: string;
+  config: Record<string, unknown> | null;
+  localNode: MeshCoreNode | null;
+}
+
+const DEVICE_TYPE_KEYS: Record<number, string> = {
+  0: 'meshcore.device_type.unknown',
+  1: 'meshcore.device_type.companion',
+  2: 'meshcore.device_type.repeater',
+  3: 'meshcore.device_type.room_server',
+};
+
+/** Returns the per-source meshcore base path: /api/sources/:id/meshcore */
+function buildBase(sourceId: string): string {
+  return `${appBasename}/api/sources/${encodeURIComponent(sourceId)}/meshcore`;
+}
+
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleString();
+}
+
+function MeshCoreSourceInner() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { sourceId } = useSource();
+  const { authStatus, hasPermission } = useAuth();
+  const csrfFetch = useCsrfFetch();
+  const isAuthenticated = authStatus?.authenticated ?? false;
+
+  const base = sourceId ? buildBase(sourceId) : '';
+
+  // Per-source permissions — sourceId is auto-bound by useAuth via SourceContext.
+  const canReadConnection = hasPermission('connection', 'read');
+  const canWriteConnection = hasPermission('connection', 'write');
+  const canReadNodes = hasPermission('nodes', 'read');
+  const canWriteNodes = hasPermission('nodes', 'write');
+  const canReadMessages = hasPermission('messages', 'read');
+  const canWriteMessages = hasPermission('messages', 'write');
+
+  const [showLogin, setShowLogin] = useState(false);
+  const [status, setStatus] = useState<ConnectionStatus | null>(null);
+  const [nodes, setNodes] = useState<MeshCoreNode[]>([]);
+  const [contacts, setContacts] = useState<MeshCoreContact[]>([]);
+  const [messages, setMessages] = useState<MeshCoreMessage[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const [messageText, setMessageText] = useState('');
+  const [selectedContact, setSelectedContact] = useState<string>('');
+
+  const connectedRef = useRef(false);
+
+  // -- fetchers --------------------------------------------------------------
+
+  const fetchStatus = useCallback(async (): Promise<boolean> => {
+    if (!base || !canReadConnection) return false;
+    try {
+      const res = await csrfFetch(`${base}/status`);
+      const data = await res.json();
+      if (data.success) {
+        setStatus(data.data);
+        return data.data.connected ?? false;
+      }
+    } catch (err) {
+      // Surface only if the user expects authority — anonymous loads stay quiet
+      if (isAuthenticated) console.error('Failed to fetch meshcore status:', err);
+    }
+    return false;
+  }, [base, canReadConnection, csrfFetch, isAuthenticated]);
+
+  const fetchNodes = useCallback(async () => {
+    if (!base || !canReadNodes) return;
+    try {
+      const res = await csrfFetch(`${base}/nodes`);
+      const data = await res.json();
+      if (data.success) setNodes(data.data ?? []);
+    } catch (err) {
+      if (isAuthenticated) console.error('Failed to fetch meshcore nodes:', err);
+    }
+  }, [base, canReadNodes, csrfFetch, isAuthenticated]);
+
+  const fetchContacts = useCallback(async () => {
+    if (!base || !canReadNodes) return;
+    try {
+      const res = await csrfFetch(`${base}/contacts`);
+      const data = await res.json();
+      if (data.success) setContacts(data.data ?? []);
+    } catch (err) {
+      if (isAuthenticated) console.error('Failed to fetch meshcore contacts:', err);
+    }
+  }, [base, canReadNodes, csrfFetch, isAuthenticated]);
+
+  const fetchMessages = useCallback(async () => {
+    if (!base || !canReadMessages) return;
+    try {
+      const res = await csrfFetch(`${base}/messages?limit=100`);
+      const data = await res.json();
+      if (data.success) setMessages(data.data ?? []);
+    } catch (err) {
+      if (isAuthenticated) console.error('Failed to fetch meshcore messages:', err);
+    }
+  }, [base, canReadMessages, csrfFetch, isAuthenticated]);
+
+  // -- polling ---------------------------------------------------------------
+
+  useEffect(() => {
+    connectedRef.current = status?.connected ?? false;
+  }, [status?.connected]);
+
+  useEffect(() => {
+    if (!base) return;
+    let cancelled = false;
+    const tick = async () => {
+      const isConnected = await fetchStatus();
+      if (cancelled) return;
+      if (isConnected) {
+        await Promise.all([fetchNodes(), fetchContacts(), fetchMessages()]);
+      }
+    };
+    void tick();
+    const interval = setInterval(tick, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [base, fetchStatus, fetchNodes, fetchContacts, fetchMessages]);
+
+  // -- actions ---------------------------------------------------------------
+
+  const handleConnect = async () => {
+    if (!base || !canWriteConnection) return;
+    setLoading(true);
+    setError(null);
+    try {
+      // The nested /connect route already pulls connection params from the
+      // saved source.config, so we don't need to send a body.
+      const res = await csrfFetch(`${base}/connect`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      const data = await res.json();
+      if (!data.success) setError(data.error || t('meshcore.connect_failed', 'Connection failed'));
+      await fetchStatus();
+    } catch (err) {
+      setError(t('meshcore.connect_failed', 'Connection failed'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    if (!base || !canWriteConnection) return;
+    setLoading(true);
+    try {
+      await csrfFetch(`${base}/disconnect`, { method: 'POST' });
+      await fetchStatus();
+      setNodes([]);
+      setContacts([]);
+      setMessages([]);
+    } catch (err) {
+      console.error('Disconnect error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRefreshContacts = async () => {
+    if (!base || !canWriteNodes) return;
+    setLoading(true);
+    try {
+      const res = await csrfFetch(`${base}/contacts/refresh`, { method: 'POST' });
+      const data = await res.json();
+      if (data.success) setContacts(data.data ?? []);
+    } catch (err) {
+      console.error('Refresh contacts error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSendAdvert = async () => {
+    if (!base || !canWriteConnection) return;
+    try {
+      const res = await csrfFetch(`${base}/advert`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.success) setError(data.error || t('meshcore.advert_failed', 'Failed to send advert'));
+    } catch (err) {
+      setError(t('meshcore.advert_failed', 'Failed to send advert'));
+    }
+  };
+
+  const handleSendMessage = async () => {
+    if (!base || !canWriteMessages || !messageText.trim()) return;
+    try {
+      const res = await csrfFetch(`${base}/messages/send`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          text: messageText,
+          toPublicKey: selectedContact || undefined,
+        }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setMessageText('');
+        await fetchMessages();
+      } else {
+        setError(data.error || t('meshcore.send_failed', 'Failed to send message'));
+      }
+    } catch (err) {
+      setError(t('meshcore.send_failed', 'Failed to send message'));
+    }
+  };
+
+  // -- render ----------------------------------------------------------------
+
+  if (!sourceId) {
+    return (
+      <div className="meshcore-tab">
+        <p>{t('meshcore.no_source', 'No source selected.')}</p>
+      </div>
+    );
+  }
+
+  // No connection-read permission means the entire surface is hidden, just
+  // like a Meshtastic source the user can't read.
+  if (!canReadConnection) {
+    return (
+      <div className="meshcore-tab">
+        <h2>{t('meshcore.title')}</h2>
+        <p>{t('meshcore.no_permission', 'You do not have permission to view this MeshCore source.')}</p>
+      </div>
+    );
+  }
+
+  // Map view: contacts with coordinates, rendered as a simple list. Slice 4
+  // intentionally avoids pulling in Leaflet here — the dashboard map already
+  // reads MeshCore contacts via MapContext, and the per-source map can be
+  // added in a follow-up once contact→position plumbing is reused.
+  const placedContacts = contacts.filter((c) => c.latitude != null && c.longitude != null);
+
+  return (
+    <div className="dashboard-page">
+      <header className="dashboard-topbar">
+        <button
+          className="dashboard-topbar-hamburger"
+          onClick={() => navigate('/')}
+          title={t('source.sidebar.open_sources', 'Sources')}
+        >
+          ☰
+        </button>
+        <div className="dashboard-topbar-logo">
+          <img
+            src={`${appBasename}/logo.png`}
+            alt="MeshMonitor"
+            className="dashboard-topbar-logo-img"
+          />
+          <span className="dashboard-topbar-title">MeshMonitor — MeshCore</span>
+        </div>
+        <div className="dashboard-topbar-actions">
+          {isAuthenticated ? (
+            <UserMenu />
+          ) : (
+            <button className="dashboard-signin-btn" onClick={() => setShowLogin(true)}>
+              {t('source.topbar.sign_in')}
+            </button>
+          )}
+        </div>
+      </header>
+
+      <div className="meshcore-tab">
+        <h2>{t('meshcore.title')}</h2>
+
+        {error && (
+          <div className="meshcore-error">
+            {error}
+            <button onClick={() => setError(null)}>{t('common.dismiss')}</button>
+          </div>
+        )}
+
+        {/* Connection */}
+        <section className="meshcore-section">
+          <h3>{t('meshcore.connection')}</h3>
+          {!status?.connected ? (
+            <div className="meshcore-status">
+              <div className="status-disconnected">
+                <span className="status-dot disconnected"></span>
+                {t('meshcore.disconnected', 'Disconnected')}
+              </div>
+              {canWriteConnection && (
+                <div className="status-actions">
+                  <button onClick={handleConnect} disabled={loading}>
+                    {loading ? t('meshcore.connecting') : t('meshcore.connect')}
+                  </button>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="meshcore-status">
+              <div className="status-connected">
+                <span className="status-dot connected"></span>
+                {t('meshcore.connected_to', { name: status.localNode?.name ?? t('meshcore.unknown') })}
+              </div>
+              <div className="status-details">
+                <div>
+                  {t('meshcore.type')}: {status.deviceTypeName}
+                </div>
+                {status.localNode?.radioFreq != null && (
+                  <div>
+                    {t('meshcore.radio')}: {status.localNode.radioFreq} MHz, BW
+                    {status.localNode.radioBw}, SF{status.localNode.radioSf}
+                  </div>
+                )}
+                {status.localNode?.publicKey && (
+                  <div>
+                    {t('meshcore.public_key')}: {status.localNode.publicKey.slice(0, 16)}…
+                  </div>
+                )}
+              </div>
+              {canWriteConnection && (
+                <div className="status-actions">
+                  <button onClick={handleSendAdvert}>{t('meshcore.send_advert')}</button>
+                  <button onClick={handleDisconnect} className="disconnect">
+                    {t('meshcore.disconnect')}
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </section>
+
+        {/* Map (contact positions) */}
+        {canReadNodes && (
+          <section className="meshcore-section">
+            <h3>{t('meshcore.map_title', 'Map')}</h3>
+            {placedContacts.length === 0 ? (
+              <div className="meshcore-empty">
+                {t('meshcore.no_positions', 'No contacts have reported positions yet.')}
+              </div>
+            ) : (
+              <div className="meshcore-contact-list">
+                {placedContacts.map((c) => (
+                  <div key={c.publicKey} className="meshcore-contact-item">
+                    <div className="contact-name">{c.advName || c.name || t('meshcore.unknown')}</div>
+                    <div className="contact-details">
+                      <span>
+                        {t('meshcore.position', 'Position')}: {c.latitude!.toFixed(4)},{' '}
+                        {c.longitude!.toFixed(4)}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* Nodes */}
+        {canReadNodes && status?.connected && (
+          <section className="meshcore-section">
+            <h3>{t('meshcore.nodes_count', { count: nodes.length })}</h3>
+            <div className="meshcore-node-list">
+              {nodes.map((node) => (
+                <div key={node.publicKey} className="meshcore-node-item">
+                  <div className="node-name">
+                    {node.name || t('meshcore.unknown')}
+                    <span className="node-type">
+                      {t(DEVICE_TYPE_KEYS[node.advType] || 'meshcore.device_type.unknown')}
+                    </span>
+                  </div>
+                  <div className="node-details">
+                    <span>
+                      {t('meshcore.key')}: {node.publicKey.slice(0, 12)}…
+                    </span>
+                    {node.rssi != null && (
+                      <span>
+                        {t('meshcore.rssi')}: {node.rssi} dBm
+                      </span>
+                    )}
+                    {node.snr != null && (
+                      <span>
+                        {t('meshcore.snr')}: {node.snr} dB
+                      </span>
+                    )}
+                    {node.batteryMv != null && (
+                      <span>
+                        {t('meshcore.battery')}: {(node.batteryMv / 1000).toFixed(2)}V
+                      </span>
+                    )}
+                    {node.lastHeard != null && (
+                      <span>
+                        {t('meshcore.last_heard')}: {formatTime(node.lastHeard)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+              {nodes.length === 0 && (
+                <div className="meshcore-empty">{t('meshcore.no_nodes')}</div>
+              )}
+            </div>
+          </section>
+        )}
+
+        {/* Contacts (channels are lumped here under messages perm per slice-3 design) */}
+        {canReadNodes && status?.connected && (
+          <section className="meshcore-section">
+            <h3>
+              {t('meshcore.contacts_count', { count: contacts.length })}
+              {canWriteNodes && (
+                <button onClick={handleRefreshContacts} disabled={loading} className="refresh-btn">
+                  {t('meshcore.refresh')}
+                </button>
+              )}
+            </h3>
+            <div className="meshcore-contact-list">
+              {contacts.map((c) => (
+                <div key={c.publicKey} className="meshcore-contact-item">
+                  <div className="contact-name">{c.advName || c.name || t('meshcore.unknown')}</div>
+                  <div className="contact-details">
+                    <span>
+                      {t('meshcore.key')}: {c.publicKey.slice(0, 12)}…
+                    </span>
+                    {c.rssi != null && (
+                      <span>
+                        {t('meshcore.rssi')}: {c.rssi}
+                      </span>
+                    )}
+                    {c.snr != null && (
+                      <span>
+                        {t('meshcore.snr')}: {c.snr}
+                      </span>
+                    )}
+                  </div>
+                  {canWriteMessages && (
+                    <button
+                      className="contact-select"
+                      onClick={() => setSelectedContact(c.publicKey)}
+                    >
+                      {t('meshcore.select')}
+                    </button>
+                  )}
+                </div>
+              ))}
+              {contacts.length === 0 && (
+                <div className="meshcore-empty">{t('meshcore.no_contacts')}</div>
+              )}
+            </div>
+          </section>
+        )}
+
+        {/* Messages */}
+        {canReadMessages && status?.connected && (
+          <section className="meshcore-section">
+            <h3>{t('meshcore.messages')}</h3>
+            <div className="meshcore-messages">
+              {messages.map((msg) => (
+                <div key={msg.id} className="meshcore-message">
+                  <div className="message-header">
+                    <span className="message-from">{msg.fromPublicKey.slice(0, 8)}…</span>
+                    <span className="message-time">{formatTime(msg.timestamp)}</span>
+                  </div>
+                  <div className="message-text">{msg.text}</div>
+                </div>
+              ))}
+              {messages.length === 0 && (
+                <div className="meshcore-empty">{t('meshcore.no_messages')}</div>
+              )}
+            </div>
+            {canWriteMessages && (
+              <div className="meshcore-send-form">
+                <select
+                  value={selectedContact}
+                  onChange={(e) => setSelectedContact(e.target.value)}
+                >
+                  <option value="">{t('meshcore.broadcast')}</option>
+                  {contacts.map((c) => (
+                    <option key={c.publicKey} value={c.publicKey}>
+                      {c.advName || c.name || c.publicKey.slice(0, 12)}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  type="text"
+                  value={messageText}
+                  onChange={(e) => setMessageText(e.target.value)}
+                  placeholder={t('meshcore.type_message')}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') void handleSendMessage();
+                  }}
+                />
+                <button onClick={handleSendMessage}>{t('meshcore.send')}</button>
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+
+      <LoginModal isOpen={showLogin} onClose={() => setShowLogin(false)} />
+    </div>
+  );
+}
+
+export default function MeshCoreSourcePage() {
+  return (
+    <SettingsProvider>
+      <ToastProvider>
+        <MeshCoreSourceInner />
+      </ToastProvider>
+    </SettingsProvider>
+  );
+}


### PR DESCRIPTION
## Summary

Slice 4 of the MeshCore-as-source refactor. Builds the user-facing surface on top of the backend slices already shipped: slice 1 (#2954) per-source manager registry, slice 2 (#2955) nested `/api/sources/:id/meshcore/*` routes, slice 3 (#2957) per-source permission collapse.

- **Add Source dialog** — Meshtastic / MeshCore type selector. The Meshcore branch collects companion-USB v1 fields per the [design memo](../../memory/project_meshmonitor_meshcore_source_model.md): `{ transport: 'usb', port, deviceType, autoConnect }`. Type is fixed on edit because backend tables/managers are bound to it.
- **Per-source MeshCore dashboard** — new `MeshCoreSourcePage` hits the nested routes for status / nodes / contacts / messages, with placed-contact listing as a v1 map. Permission gates use `hasPermission(resource, action)` auto-scoped via `SourceContext` (the slice-3 binding). Channels are lumped under `messages` per the memo.
- **Routing** — `main.tsx`'s `SourceApp` dispatches on `source.type`; meshcore sources render the new page, everything else falls through to the legacy `<App>`. The dashboard sidebar already renders source cards by type, so MeshCore sources appear alongside Meshtastic with no extra wiring.
- **Slice-3 cleanup** — drops the `meshcore: () => false` placeholder in `src/App.tsx` and the commented-out NavItem in `src/components/Sidebar.tsx` left behind by slice 3 once a real per-source surface existed.

## Out of scope (deferred)

- BLE / TCP MeshCore transports
- Per-channel `mc_channel_N` permissions (currently lumped under `messages`)
- Repeater text-CLI path
- WebSocket live updates for the meshcore surface (REST-poll for now)
- Embedded Leaflet map (placed-contact list for v1; reuse dashboard map plumbing in a follow-up)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/pages/DashboardPage.test.tsx src/components/Dashboard/DashboardSidebar.test.tsx src/pages/MeshCoreSourcePage.test.tsx src/server/routes/meshcoreRoutes.test.ts src/server/migrations/057_collapse_meshcore_resource.test.ts src/server/meshcoreRegistry.test.ts src/App.test.tsx` — all green
- [ ] Manual smoke: add a MeshCore source via the new dialog, click Open, verify connection panel + nodes/contacts/messages render and gate by per-source perms

🤖 Generated with [Claude Code](https://claude.com/claude-code)