### PR TITLE
fix(test): update migrations registry assertions for migration 057

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 56 migrations registered', () => {
-    expect(registry.count()).toBe(56);
+  it('has all 57 migrations registered', () => {
+    expect(registry.count()).toBe(57);
   });
 
   it('first migration is v37 baseline', () => {
@@ -12,14 +12,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_source_id_to_meshcore_tables', () => {
+  it('last migration is collapse_meshcore_resource', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(56);
-    expect(last.name).toContain('add_source_id_to_meshcore_tables');
+    expect(last.number).toBe(57);
+    expect(last.name).toContain('collapse_meshcore_resource');
   });
 
-  it('migrations are sequentially numbered from 1 to 56', () => {
+  it('migrations are sequentially numbered from 1 to 57', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);


### PR DESCRIPTION
## Summary
- Bumps the registry-count assertion from 56 → 57 (migration 057, `collapse_meshcore_resource`, was added in slice 3)
- Updates the \"last migration is …\" test to expect 057 instead of the slice-1 sourceId migration
- Bumps the sequential-numbering range to 1..57

This was the test failure that took down `Test Suite (20.x/22.x/24.x/25.x)` on the old slice-3/4 PRs and the v4.4.0-alpha1 Release Pipeline / Desktop Release runs.

## Test plan
- [x] `npx vitest run src/db/migrations.test.ts` — 9/9 pass locally
- [ ] CI on `feature/meshcore` after merge