### PR TITLE
fix(firmware): harden OTA update — timeouts, cancel guard, async orchestration, retry widening, half-flash detection

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -802,22 +802,31 @@ class MeshtasticManager implements ISourceManager {
         logger.error('❌ TCP transport error:', error.message);
       });
 
-      // Honor post-reset cooldown — after a transient post-OTA half-open
-      // connect we deliberately wait before re-attempting so the node's
-      // WiFi stack can finish settling and we don't loop on the same race.
-      const cooldownRemaining = this.postResetCooldownUntil - Date.now();
-      if (cooldownRemaining > 0) {
-        logger.debug(`⏸️ Post-reset cooldown active, waiting ${cooldownRemaining}ms before reconnect`);
-        await new Promise((r) => setTimeout(r, cooldownRemaining));
-      }
+      // Only honor cooldown + probe when handleConnected has flagged a
+      // post-OTA half-open recovery. On cold/normal connects we skip both
+      // so the 15s TCP probe doesn't eat the caller's connection budget.
+      const cooldownActive = this.postResetCooldownUntil > 0;
+      if (cooldownActive) {
+        // Honor post-reset cooldown — after a transient post-OTA half-open
+        // connect we deliberately wait before re-attempting so the node's
+        // WiFi stack can finish settling and we don't loop on the same race.
+        const cooldownRemaining = this.postResetCooldownUntil - Date.now();
+        if (cooldownRemaining > 0) {
+          logger.debug(`⏸️ Post-reset cooldown active, waiting ${cooldownRemaining}ms before reconnect`);
+          await new Promise((r) => setTimeout(r, cooldownRemaining));
+        }
 
-      // Best-effort TCP-readiness probe — confirm the node is actually
-      // accepting sockets before we hand off to the @meshtastic/js transport.
-      try {
-        await this.waitForTcpReady(config.nodeIp, config.tcpPort);
-      } catch (probeErr) {
-        const msg = probeErr instanceof Error ? probeErr.message : String(probeErr);
-        logger.warn(`⚠️ TCP readiness probe to ${config.nodeIp}:${config.tcpPort} failed (${msg}) — proceeding anyway`);
+        // Best-effort TCP-readiness probe — confirm the node is actually
+        // accepting sockets before we hand off to the @meshtastic/js transport.
+        try {
+          await this.waitForTcpReady(config.nodeIp, config.tcpPort);
+        } catch (probeErr) {
+          const msg = probeErr instanceof Error ? probeErr.message : String(probeErr);
+          logger.warn(`⚠️ TCP readiness probe to ${config.nodeIp}:${config.tcpPort} failed (${msg}) — proceeding anyway`);
+        }
+
+        // Clear the flag so subsequent normal connects skip this path.
+        this.postResetCooldownUntil = 0;
       }
 
       // Connect to node

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -34,6 +34,12 @@ import { createRequire } from 'module';
 import { validateCron, scheduleCron, type CronJob } from './utils/cronScheduler.js';
 import fs from 'fs';
 import path from 'path';
+import * as net from 'net';
+
+const POST_RESET_COOLDOWN_MS = 5000;
+const TCP_READY_TIMEOUT_MS = 15000;
+const TCP_READY_INTERVAL_MS = 500;
+const TCP_READY_CONNECT_TIMEOUT_MS = 1500;
 const require = createRequire(import.meta.url);
 const packageJson = require('../../package.json');
 
@@ -290,6 +296,7 @@ interface AutoPingSession {
 class MeshtasticManager implements ISourceManager {
   public sourceId: string;
   private sourceConfigOverride: { host?: string; port?: number; heartbeatIntervalSeconds?: number } | null = null;
+  private postResetCooldownUntil: number = 0;
   private virtualNodeServer?: VirtualNodeServer;
   private transport: ITransport | null = null;
   private isConnected = false;
@@ -795,6 +802,24 @@ class MeshtasticManager implements ISourceManager {
         logger.error('❌ TCP transport error:', error.message);
       });
 
+      // Honor post-reset cooldown — after a transient post-OTA half-open
+      // connect we deliberately wait before re-attempting so the node's
+      // WiFi stack can finish settling and we don't loop on the same race.
+      const cooldownRemaining = this.postResetCooldownUntil - Date.now();
+      if (cooldownRemaining > 0) {
+        logger.debug(`⏸️ Post-reset cooldown active, waiting ${cooldownRemaining}ms before reconnect`);
+        await new Promise((r) => setTimeout(r, cooldownRemaining));
+      }
+
+      // Best-effort TCP-readiness probe — confirm the node is actually
+      // accepting sockets before we hand off to the @meshtastic/js transport.
+      try {
+        await this.waitForTcpReady(config.nodeIp, config.tcpPort);
+      } catch (probeErr) {
+        const msg = probeErr instanceof Error ? probeErr.message : String(probeErr);
+        logger.warn(`⚠️ TCP readiness probe to ${config.nodeIp}:${config.tcpPort} failed (${msg}) — proceeding anyway`);
+      }
+
       // Connect to node
       // Note: isConnected will be set to true in handleConnected() callback
       // when the connection is actually established
@@ -806,6 +831,43 @@ class MeshtasticManager implements ISourceManager {
       logger.error('Failed to connect to Meshtastic node:', error);
       throw error;
     }
+  }
+
+  /**
+   * Poll the node's TCP port until it accepts a connection, or the overall
+   * deadline elapses. Used after an OTA reboot (or any transient half-open
+   * connect) to avoid racing the @meshtastic/js transport against a node
+   * whose WiFi stack hasn't finished coming up yet.
+   */
+  private async waitForTcpReady(host: string, port: number): Promise<void> {
+    const deadline = Date.now() + TCP_READY_TIMEOUT_MS;
+    let lastErr: Error | null = null;
+    while (Date.now() < deadline) {
+      const attemptStart = Date.now();
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const socket = net.connect({ host, port });
+          let settled = false;
+          const finish = (err?: Error) => {
+            if (settled) return;
+            settled = true;
+            try { socket.destroy(); } catch { /* ignore */ }
+            if (err) reject(err); else resolve();
+          };
+          const timer = setTimeout(() => finish(new Error('TCP readiness probe timeout')), TCP_READY_CONNECT_TIMEOUT_MS);
+          socket.once('connect', () => { clearTimeout(timer); finish(); });
+          socket.once('error', (err) => { clearTimeout(timer); finish(err); });
+        });
+        return;
+      } catch (err) {
+        lastErr = err instanceof Error ? err : new Error(String(err));
+        const elapsed = Date.now() - attemptStart;
+        const wait = Math.max(0, TCP_READY_INTERVAL_MS - elapsed);
+        if (Date.now() + wait >= deadline) break;
+        await new Promise((r) => setTimeout(r, wait));
+      }
+    }
+    throw lastErr ?? new Error(`TCP readiness probe to ${host}:${port} exceeded ${TCP_READY_TIMEOUT_MS}ms`);
   }
 
   private async handleConnected(): Promise<void> {
@@ -844,8 +906,28 @@ class MeshtasticManager implements ISourceManager {
 
       logger.info('📸 Starting init config capture for virtual node server');
 
-      // Send want_config_id to request full node DB and config
-      await this.sendWantConfigId();
+      // Send want_config_id to request full node DB and config.
+      // If the node resets the socket between our 'connect' event and this
+      // first send (common right after an OTA reboot), transport.send throws
+      // "Not connected to TCP server". Treat that as a transient half-open
+      // connect and force-clean state so the reconnect path starts fresh
+      // — otherwise isConnected stays true while the transport is gone and
+      // every later operation fails with the same error.
+      try {
+        await this.sendWantConfigId();
+      } catch (sendErr) {
+        const msg = sendErr instanceof Error ? sendErr.message : String(sendErr);
+        logger.warn(`⚠️ Initial sendWantConfigId failed (${msg}) — treating as transient post-connect reset, clearing state for clean reconnect`);
+        this.postResetCooldownUntil = Date.now() + POST_RESET_COOLDOWN_MS;
+        this.isConnected = false;
+        try { await this.transport?.disconnect(); } catch { /* ignore */ }
+        dataEventEmitter.emitConnectionStatus({
+          connected: false,
+          reason: `Transport reset immediately after connect: ${msg}`,
+        }, this.sourceId);
+        this.handleDisconnected().catch((e) => logger.error('Error in handleDisconnected (post-connect-reset cleanup):', e));
+        return;
+      }
 
       logger.debug('⏳ Waiting for configuration data from node...');
 

--- a/src/server/routes/firmwareUpdateRoutes.test.ts
+++ b/src/server/routes/firmwareUpdateRoutes.test.ts
@@ -26,6 +26,8 @@ const {
   mockGetTempDir,
   mockRetryFlash,
   mockIsStepRunning,
+  mockHasFlashIncompleteMarker,
+  mockClearFlashIncompleteMarker,
 } = vi.hoisted(() => ({
   mockGetStatus: vi.fn(),
   mockGetChannel: vi.fn(),
@@ -49,6 +51,8 @@ const {
   mockGetTempDir: vi.fn(),
   mockRetryFlash: vi.fn(),
   mockIsStepRunning: vi.fn().mockReturnValue(false),
+  mockHasFlashIncompleteMarker: vi.fn().mockReturnValue(false),
+  mockClearFlashIncompleteMarker: vi.fn().mockReturnValue(0),
 }));
 
 // Mock auth middleware to inject admin user
@@ -104,6 +108,8 @@ vi.mock('../services/firmwareUpdateService.js', () => ({
     getTempDir: mockGetTempDir,
     retryFlash: (...args: unknown[]) => mockRetryFlash(...args),
     isStepRunning: mockIsStepRunning,
+    hasFlashIncompleteMarker: mockHasFlashIncompleteMarker,
+    clearFlashIncompleteMarker: mockClearFlashIncompleteMarker,
   },
   FirmwareChannel: {},
 }));
@@ -358,6 +364,25 @@ describe('firmwareUpdateRoutes', () => {
       expect(mockExecuteBackup).toHaveBeenCalledWith('192.168.1.100', 'node123');
     });
 
+    it('should return 409 when nodeId has a half-flash recovery marker', async () => {
+      mockGetStatus.mockReturnValue({
+        state: 'awaiting-confirm',
+        step: 'preflight',
+        message: 'Preflight complete',
+        logs: [],
+      });
+      mockHasFlashIncompleteMarker.mockReturnValueOnce(true);
+
+      const res = await request(app)
+        .post('/api/firmware/update/confirm')
+        .send({ gatewayIp: '192.168.1.100', nodeId: 'node123' });
+
+      expect(res.status).toBe(409);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toMatch(/half-flashed/i);
+      expect(mockDisconnectFromNode).not.toHaveBeenCalled();
+    });
+
     it('should return 409 when a step is already running', async () => {
       mockGetStatus.mockReturnValue({
         state: 'awaiting-confirm',
@@ -498,6 +523,19 @@ describe('firmwareUpdateRoutes', () => {
       expect(res.status).toBe(500);
       expect(res.body.success).toBe(false);
       expect(res.body.error).toMatch(/Backup file not found/);
+    });
+  });
+
+  describe('DELETE /api/firmware/recovery-marker/:nodeId', () => {
+    it('should clear markers and return count removed', async () => {
+      mockClearFlashIncompleteMarker.mockReturnValueOnce(2);
+
+      const res = await request(app).delete('/api/firmware/recovery-marker/!abcdef12');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.removed).toBe(2);
+      expect(mockClearFlashIncompleteMarker).toHaveBeenCalledWith('!abcdef12');
     });
   });
 });

--- a/src/server/routes/firmwareUpdateRoutes.test.ts
+++ b/src/server/routes/firmwareUpdateRoutes.test.ts
@@ -25,6 +25,7 @@ const {
   mockVerifyUpdate,
   mockGetTempDir,
   mockRetryFlash,
+  mockIsStepRunning,
 } = vi.hoisted(() => ({
   mockGetStatus: vi.fn(),
   mockGetChannel: vi.fn(),
@@ -47,6 +48,7 @@ const {
   mockVerifyUpdate: vi.fn(),
   mockGetTempDir: vi.fn(),
   mockRetryFlash: vi.fn(),
+  mockIsStepRunning: vi.fn().mockReturnValue(false),
 }));
 
 // Mock auth middleware to inject admin user
@@ -101,8 +103,16 @@ vi.mock('../services/firmwareUpdateService.js', () => ({
     verifyUpdate: mockVerifyUpdate,
     getTempDir: mockGetTempDir,
     retryFlash: (...args: unknown[]) => mockRetryFlash(...args),
+    isStepRunning: mockIsStepRunning,
   },
   FirmwareChannel: {},
+}));
+
+// Mock meshtasticManager (routes use it for post-flash actual-version read)
+vi.mock('../meshtasticManager.js', () => ({
+  default: {
+    getLocalNodeInfo: vi.fn().mockReturnValue(null),
+  },
 }));
 
 // Mock logger
@@ -333,6 +343,7 @@ describe('firmwareUpdateRoutes', () => {
           platform: 'esp32',
         },
       });
+      mockDisconnectFromNode.mockResolvedValue(undefined);
       mockExecuteBackup.mockResolvedValue('/backups/config-test.yaml');
 
       const res = await request(app)
@@ -341,8 +352,30 @@ describe('firmwareUpdateRoutes', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
+      // The confirm route fires the step async (F1) — wait for the IIFE to advance.
+      await new Promise((r) => setTimeout(r, 10));
       expect(mockDisconnectFromNode).toHaveBeenCalled();
       expect(mockExecuteBackup).toHaveBeenCalledWith('192.168.1.100', 'node123');
+    });
+
+    it('should return 409 when a step is already running', async () => {
+      mockGetStatus.mockReturnValue({
+        state: 'awaiting-confirm',
+        step: 'preflight',
+        message: 'Preflight complete',
+        logs: [],
+      });
+      mockIsStepRunning.mockReturnValueOnce(true);
+
+      const res = await request(app)
+        .post('/api/firmware/update/confirm')
+        .send({ gatewayIp: '192.168.1.100', nodeId: 'node123' });
+
+      expect(res.status).toBe(409);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toMatch(/already running/i);
+      expect(mockDisconnectFromNode).not.toHaveBeenCalled();
+      expect(mockExecuteBackup).not.toHaveBeenCalled();
     });
 
     it('should return 400 when no update is in progress', async () => {

--- a/src/server/routes/firmwareUpdateRoutes.ts
+++ b/src/server/routes/firmwareUpdateRoutes.ts
@@ -168,6 +168,15 @@ router.post('/update/confirm', async (req: Request, res: Response) => {
       });
     }
 
+    // Reject double-submits while a step is mid-flight. Without this the user
+    // can re-click Confirm during a slow backup and trigger a parallel run.
+    if (firmwareUpdateService.isStepRunning()) {
+      return res.status(409).json({
+        success: false,
+        error: 'A firmware update step is already running',
+      });
+    }
+
     switch (status.step) {
       case 'preflight': {
         // Advance to backup step

--- a/src/server/routes/firmwareUpdateRoutes.ts
+++ b/src/server/routes/firmwareUpdateRoutes.ts
@@ -194,6 +194,17 @@ router.post('/update/confirm', async (req: Request, res: Response) => {
             error: 'gatewayIp and nodeId are required to confirm preflight',
           });
         }
+        // Safety rail 5: refuse OTA on a device flagged half-flashed.
+        // Operators must clear the marker (typically after a USB-tethered
+        // recovery) before another OTA attempt.
+        if (firmwareUpdateService.hasFlashIncompleteMarker(nodeId)) {
+          return res.status(409).json({
+            success: false,
+            error:
+              `Node "${nodeId}" is flagged as half-flashed from a previous OTA attempt. ` +
+              `Recover via USB, then DELETE /api/firmware/recovery-marker/${encodeURIComponent(nodeId)} to clear the flag.`,
+          });
+        }
         // Visibly disconnect from node before backup — stays disconnected through entire flash
         void (async () => {
           try {
@@ -396,6 +407,27 @@ router.post('/restore', async (req: Request, res: Response) => {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logger.error('[FirmwareRoutes] Error restoring backup:', error);
+    return res.status(500).json({ success: false, error: message });
+  }
+});
+
+/**
+ * DELETE /api/firmware/recovery-marker/:nodeId
+ * Clear the half-flashed marker for a node. Should only be called after
+ * a USB-tethered recovery has been performed.
+ */
+router.delete('/recovery-marker/:nodeId', (req: Request, res: Response) => {
+  try {
+    const nodeId = req.params.nodeId;
+    if (!nodeId) {
+      return res.status(400).json({ success: false, error: 'nodeId is required' });
+    }
+    const removed = firmwareUpdateService.clearFlashIncompleteMarker(nodeId);
+    logger.info(`[FirmwareRoutes] Cleared ${removed} half-flash marker(s) for node ${nodeId}`);
+    return res.json({ success: true, removed });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error('[FirmwareRoutes] Error clearing recovery marker:', error);
     return res.status(500).json({ success: false, error: message });
   }
 });

--- a/src/server/routes/firmwareUpdateRoutes.ts
+++ b/src/server/routes/firmwareUpdateRoutes.ts
@@ -8,6 +8,7 @@
 import { Router, Request, Response } from 'express';
 import { requireAdmin } from '../auth/authMiddleware.js';
 import { firmwareUpdateService } from '../services/firmwareUpdateService.js';
+import meshtasticManager from '../meshtasticManager.js';
 import { logger } from '../../utils/logger.js';
 import path from 'path';
 
@@ -248,10 +249,13 @@ router.post('/update/confirm', async (req: Request, res: Response) => {
       }
 
       case 'flash': {
-        // After flash, move to verify step (waiting for reconnect)
+        // Read the firmware version the device is actually running now —
+        // not the target. Otherwise verifyUpdate is comparing target against
+        // target and trivially "succeeds" regardless of what flashed.
+        const actualVersion = meshtasticManager.getLocalNodeInfo()?.firmwareVersion ?? '';
         firmwareUpdateService.verifyUpdate(
-          status.targetVersion ?? '',
-          status.preflightInfo?.targetVersion ?? ''
+          actualVersion,
+          status.targetVersion ?? ''
         );
         break;
       }

--- a/src/server/routes/firmwareUpdateRoutes.ts
+++ b/src/server/routes/firmwareUpdateRoutes.ts
@@ -8,7 +8,6 @@
 import { Router, Request, Response } from 'express';
 import { requireAdmin } from '../auth/authMiddleware.js';
 import { firmwareUpdateService } from '../services/firmwareUpdateService.js';
-import meshtasticManager from '../meshtasticManager.js';
 import { logger } from '../../utils/logger.js';
 import path from 'path';
 
@@ -286,11 +285,27 @@ router.post('/update/confirm', async (req: Request, res: Response) => {
         // Read the firmware version the device is actually running now —
         // not the target. Otherwise verifyUpdate is comparing target against
         // target and trivially "succeeds" regardless of what flashed.
-        const actualVersion = meshtasticManager.getLocalNodeInfo()?.firmwareVersion ?? '';
-        firmwareUpdateService.verifyUpdate(
-          actualVersion,
-          status.targetVersion ?? ''
-        );
+        // Wait for MyNodeInfo to arrive after the post-flash reconnect; the
+        // TCP connect event fires before the node sends its metadata, and
+        // getLocalNodeInfo() can also return the pre-flash cached version
+        // until MyNodeInfo is re-emitted.
+        const preFlashVersion = status.preflightInfo?.currentVersion ?? '';
+        const verifyGatewayIp = status.preflightInfo?.gatewayIp;
+        firmwareUpdateService.markVerifyInProgress();
+        void (async () => {
+          try {
+            const actualVersion = await firmwareUpdateService.waitForFirmwareVersion({
+              staleVersion: preFlashVersion,
+              gatewayIp: verifyGatewayIp,
+            });
+            firmwareUpdateService.verifyUpdate(
+              actualVersion,
+              status.targetVersion ?? ''
+            );
+          } catch (err) {
+            logger.error('[FirmwareRoutes] Verify step failed:', err);
+          }
+        })();
         break;
       }
 

--- a/src/server/routes/firmwareUpdateRoutes.ts
+++ b/src/server/routes/firmwareUpdateRoutes.ts
@@ -178,6 +178,13 @@ router.post('/update/confirm', async (req: Request, res: Response) => {
       });
     }
 
+    // Long-running steps are kicked off async and the HTTP response returns
+    // immediately. The frontend tracks progress via Socket.IO `firmware:status`
+    // events on every updateStatus() call — it never relied on this response
+    // body for anything other than current state. Synchronous awaits here
+    // routinely tripped reverse-proxy idle timeouts (60–100s) on slow
+    // backups, leaving the wizard convinced the step hung while the server
+    // kept running.
     switch (status.step) {
       case 'preflight': {
         // Advance to backup step
@@ -188,8 +195,14 @@ router.post('/update/confirm', async (req: Request, res: Response) => {
           });
         }
         // Visibly disconnect from node before backup — stays disconnected through entire flash
-        await firmwareUpdateService.disconnectFromNode();
-        await firmwareUpdateService.executeBackup(gatewayIp, nodeId);
+        void (async () => {
+          try {
+            await firmwareUpdateService.disconnectFromNode();
+            await firmwareUpdateService.executeBackup(gatewayIp, nodeId);
+          } catch (err) {
+            logger.error('[FirmwareRoutes] Backup step failed:', err);
+          }
+        })();
         break;
       }
 
@@ -208,23 +221,26 @@ router.post('/update/confirm', async (req: Request, res: Response) => {
           });
         }
 
-        // Download
-        await firmwareUpdateService.executeDownload(status.downloadUrl);
-
-        // Extract immediately after download (no user prompt needed)
-        const tempDir = firmwareUpdateService.getTempDir();
-        if (!tempDir) {
-          return res.status(500).json({
-            success: false,
-            error: 'Temp directory not available. Download may have failed.',
-          });
-        }
-        const zipPath = path.join(tempDir, 'firmware.zip');
-        await firmwareUpdateService.executeExtract(
-          zipPath,
-          status.preflightInfo.boardName,
-          status.preflightInfo.targetVersion
-        );
+        const downloadUrl = status.downloadUrl;
+        const preflightInfo = status.preflightInfo;
+        void (async () => {
+          try {
+            await firmwareUpdateService.executeDownload(downloadUrl);
+            const tempDir = firmwareUpdateService.getTempDir();
+            if (!tempDir) {
+              logger.error('[FirmwareRoutes] Temp directory missing after download');
+              return;
+            }
+            const zipPath = path.join(tempDir, 'firmware.zip');
+            await firmwareUpdateService.executeExtract(
+              zipPath,
+              preflightInfo.boardName,
+              preflightInfo.targetVersion
+            );
+          } catch (err) {
+            logger.error('[FirmwareRoutes] Download/extract step failed:', err);
+          }
+        })();
         break;
       }
 
@@ -244,7 +260,14 @@ router.post('/update/confirm', async (req: Request, res: Response) => {
           });
         }
         const firmwarePath = path.join(extractTempDir, 'extracted', status.matchedFile);
-        await firmwareUpdateService.executeFlash(status.preflightInfo.gatewayIp, firmwarePath);
+        const gatewayForFlash = status.preflightInfo.gatewayIp;
+        void (async () => {
+          try {
+            await firmwareUpdateService.executeFlash(gatewayForFlash, firmwarePath);
+          } catch (err) {
+            logger.error('[FirmwareRoutes] Flash step failed:', err);
+          }
+        })();
         break;
       }
 

--- a/src/server/services/firmwareUpdateService.ts
+++ b/src/server/services/firmwareUpdateService.ts
@@ -513,6 +513,42 @@ export class FirmwareUpdateService {
    * Run a CLI command and capture output.
    * Appends stdout/stderr to status logs.
    */
+  /**
+   * Wait for the node's TCP port to accept a fresh connection before invoking
+   * the meshtastic CLI. After `userDisconnect()`, the JS-side socket closes
+   * immediately but the firmware may take a moment to free its single TCP
+   * client slot. Without this wait, the CLI silently hangs trying to connect
+   * to a still-busy slot and only fails when the outer timeout fires.
+   */
+  async waitForNodeTcpReady(
+    host: string,
+    port = 4403,
+    opts?: { timeoutMs?: number; intervalMs?: number; connectTimeoutMs?: number }
+  ): Promise<void> {
+    const timeoutMs = opts?.timeoutMs ?? 15_000;
+    const intervalMs = opts?.intervalMs ?? 500;
+    const connectTimeoutMs = opts?.connectTimeoutMs ?? 1500;
+    const deadline = Date.now() + timeoutMs;
+    let lastErr: unknown;
+    while (Date.now() < deadline) {
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const sock = net.connect({ host, port });
+          const cleanup = () => { sock.removeAllListeners(); sock.destroy(); };
+          const timer = setTimeout(() => { cleanup(); reject(new Error('connect timeout')); }, connectTimeoutMs);
+          sock.once('connect', () => { clearTimeout(timer); cleanup(); resolve(); });
+          sock.once('error', (err) => { clearTimeout(timer); cleanup(); reject(err); });
+        });
+        return;
+      } catch (err) {
+        lastErr = err;
+        await new Promise((r) => setTimeout(r, intervalMs));
+      }
+    }
+    const msg = lastErr instanceof Error ? lastErr.message : String(lastErr);
+    throw new Error(`Node ${host}:${port} did not accept CLI connection within ${timeoutMs}ms: ${msg}`);
+  }
+
   runCliCommand(
     command: string,
     args: string[],
@@ -728,6 +764,10 @@ export class FirmwareUpdateService {
     try {
 
       this.ensureBackupDir();
+
+      // Wait for the firmware to release its TCP slot from the prior
+      // MeshMonitor connection — otherwise the CLI silently hangs on connect.
+      await this.waitForNodeTcpReady(gatewayIp);
 
       const result = await this.runCliCommand('meshtastic', [
         '--host', gatewayIp,
@@ -1197,6 +1237,97 @@ export class FirmwareUpdateService {
   }
 
   /**
+   * Poll meshtasticManager.getLocalNodeInfo()?.firmwareVersion until it
+   * populates after a post-flash reconnect. The TCP connect event fires
+   * well before the node sends MyNodeInfo/metadata, so verify must not
+   * read the version immediately or it sees an empty string. We also
+   * ignore the value if it still matches `staleVersion` — that means the
+   * cached info is from before the flash and a fresh MyNodeInfo hasn't
+   * arrived yet.
+   */
+  async waitForFirmwareVersion(
+    opts?: {
+      timeoutMs?: number;
+      intervalMs?: number;
+      staleVersion?: string;
+      gatewayIp?: string;
+    }
+  ): Promise<string> {
+    const timeoutMs = opts?.timeoutMs ?? 30_000;
+    const intervalMs = opts?.intervalMs ?? 500;
+    const stale = opts?.staleVersion ?? '';
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const v = meshtasticManager.getLocalNodeInfo()?.firmwareVersion;
+      if (v && v !== stale) return v;
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    // MeshMonitor's transport never repopulated MyNodeInfo (typically because
+    // of the post-OTA `@meshtastic/js` reconnect flap). Fall back to the
+    // meshtastic CLI to read the version straight from the node — this is the
+    // same path we use elsewhere and is independent of MM's transport state.
+    const fallback = meshtasticManager.getLocalNodeInfo()?.firmwareVersion ?? '';
+    if (fallback && fallback !== stale) return fallback;
+    if (!opts?.gatewayIp) return fallback;
+    try {
+      logger.info('[FirmwareUpdateService] Verify wait expired — falling back to CLI to read firmware version directly');
+      // Temporarily release MM's TCP slot so the CLI can connect cleanly.
+      await meshtasticManager.userDisconnect().catch(() => { /* best-effort */ });
+      await this.waitForNodeTcpReady(opts.gatewayIp).catch(() => { /* best-effort */ });
+      // Post-OTA, the node passes the TCP probe but its meshtastic protocol
+      // layer may still be initializing — the first --info attempt often times
+      // out or returns partial JSON. Retry up to 3 times with backoff, and log
+      // each failure with enough detail to diagnose later.
+      const delaysMs = [0, 2_000, 5_000, 10_000];
+      let cliVersion = '';
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        if (delaysMs[attempt - 1] > 0) {
+          await new Promise((r) => setTimeout(r, delaysMs[attempt - 1]));
+        }
+        const result = await this.runCliCommand('meshtastic', [
+          '--host', opts.gatewayIp,
+          '--timeout', '15',
+          '--info',
+        ], { timeoutMs: 30_000 });
+        const match = result.stdout.match(/"firmwareVersion"\s*:\s*"([^"]+)"/);
+        if (match && result.exitCode === 0) {
+          cliVersion = match[1];
+          logger.info(`[FirmwareUpdateService] CLI fallback read firmware version: ${cliVersion} (attempt ${attempt})`);
+          return cliVersion;
+        }
+        logger.warn(
+          `[FirmwareUpdateService] CLI fallback attempt ${attempt}/3 failed (exitCode=${result.exitCode}): ` +
+          `stdout="${result.stdout.slice(0, 500)}" stderr="${result.stderr.slice(0, 500)}"`
+        );
+      }
+      logger.warn('[FirmwareUpdateService] CLI fallback exhausted 3 attempts without parsing firmwareVersion from --info output');
+      return cliVersion;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(`[FirmwareUpdateService] CLI fallback for firmware version failed: ${msg}`);
+      return fallback;
+    } finally {
+      // Hand the TCP slot back to MM so the rest of the app stays connected.
+      meshtasticManager.userReconnect().catch((e) =>
+        logger.warn(`[FirmwareUpdateService] userReconnect after CLI fallback failed: ${e instanceof Error ? e.message : String(e)}`)
+      );
+    }
+  }
+
+  /**
+   * Flip status to in-progress: verify so the UI shows a working state
+   * instead of leaving the "Confirm & Proceed" button on screen while
+   * waitForFirmwareVersion polls (up to 30s).
+   */
+  markVerifyInProgress(): void {
+    this.updateStatus({
+      state: 'in-progress',
+      step: 'verify',
+      message: 'Waiting for node to report new firmware version…',
+    });
+  }
+
+  /**
    * Step 6: Verify that the firmware version matches the target after reboot.
    */
   verifyUpdate(newFirmwareVersion: string, targetVersion: string): void {
@@ -1407,6 +1538,11 @@ export class FirmwareUpdateService {
       let bytesSent = 0;
       let lastProgressUpdate = 0;
       let finished = false;
+      // Set to true once the loader sends `OK` in the commit phase. The
+      // device-side loader immediately closes the TCP socket after that,
+      // which surfaces in Node as ECONNRESET on 'error' or a bare 'close'.
+      // Neither should be treated as an upload failure.
+      let commitConfirmed = false;
 
       const setPhase = (p: Phase) => {
         phase = p;
@@ -1481,6 +1617,7 @@ export class FirmwareUpdateService {
         if (phase === 'commit') {
           if (trimmed === 'OK') {
             logger.info('[FirmwareUpdateService] Loader confirmed commit — firmware accepted');
+            commitConfirmed = true;
             finish();
           } else if (trimmed === 'ACK') {
             // Per-chunk ACKs are advisory; ignore.
@@ -1490,9 +1627,54 @@ export class FirmwareUpdateService {
         // `streaming` / `done`: unexpected traffic, ignore.
       };
 
-      socket.once('error', (err) => finish(err));
+      // Drain any buffered un-parsed lines for a trailing commit `OK`. The
+      // Heltec loader can send `OK\n` and reset the socket so fast that Node
+      // surfaces the 'error'/'close' event before the 'data' callback has a
+      // chance to run handleLine on the buffered bytes. Without this drain,
+      // `commitConfirmed` stays false and the error path falsely trips the
+      // half-flash marker for a successful upload.
+      const drainBufferForCommitOk = (): boolean => {
+        if (phase !== 'commit' || commitConfirmed) return commitConfirmed;
+        const pending = lineBuffer;
+        let nl = pending.indexOf('\n');
+        let remaining = pending;
+        while (nl !== -1) {
+          const line = remaining.slice(0, nl).trim();
+          remaining = remaining.slice(nl + 1);
+          if (line === 'OK') {
+            commitConfirmed = true;
+            logger.info('[FirmwareUpdateService] Loader confirmed commit (drained from buffer on socket close) — firmware accepted');
+            return true;
+          }
+          nl = remaining.indexOf('\n');
+        }
+        // Last partial line — loader may have closed before sending the newline.
+        if (remaining.trim() === 'OK') {
+          commitConfirmed = true;
+          logger.info('[FirmwareUpdateService] Loader confirmed commit (drained partial buffer on socket close) — firmware accepted');
+          return true;
+        }
+        return false;
+      };
+
+      socket.once('error', (err) => {
+        // The loader drops the TCP connection immediately after sending the
+        // commit OK, which Node reports as ECONNRESET. If we've already seen
+        // the commit OK — directly or after draining the read buffer — the
+        // upload succeeded; don't reject.
+        if (commitConfirmed || drainBufferForCommitOk()) {
+          logger.debug(`[FirmwareUpdateService] Direct OTA: ignoring post-commit socket error: ${err.message}`);
+          finish();
+          return;
+        }
+        finish(err);
+      });
       socket.once('close', () => {
         if (finished) return;
+        if (commitConfirmed || drainBufferForCommitOk()) {
+          finish();
+          return;
+        }
         finish(new Error(`Loader closed connection in phase "${phase}" before commit OK (last line buffer: "${lineBuffer.trim()}")`));
       });
 

--- a/src/server/services/firmwareUpdateService.ts
+++ b/src/server/services/firmwareUpdateService.ts
@@ -138,6 +138,10 @@ export class FirmwareUpdateService {
   private status: UpdateStatus = createIdleStatus();
   private activeProcess: ChildProcess | null = null;
   private tempDir: string | null = null;
+  // True from the instant cancelUpdate is invoked until its reconnect finishes.
+  // In-flight executeXxx catch blocks observe this and bail out instead of
+  // racing cancelUpdate on status writes / reconnects.
+  private cancelling: boolean = false;
 
   private pollingInterval: ReturnType<typeof setInterval> | null = null;
   private initialCheckTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -346,27 +350,40 @@ export class FirmwareUpdateService {
     const wasDisconnected = this.status.state === 'in-progress' &&
       ['backup', 'download', 'extract', 'flash'].includes(this.status.step ?? '');
 
-    if (this.activeProcess) {
-      try {
-        this.activeProcess.kill('SIGTERM');
-      } catch {
-        // Process may already be dead
+    this.cancelling = true;
+    try {
+      if (this.activeProcess) {
+        try {
+          this.activeProcess.kill('SIGTERM');
+        } catch {
+          // Process may already be dead
+        }
+        this.activeProcess = null;
       }
-      this.activeProcess = null;
-    }
-    this.cleanupTempDir();
-    this.status = createIdleStatus();
-    this.updateStatus({ message: 'Update cancelled' });
-    logger.info('[FirmwareUpdateService] Update cancelled by user');
+      this.cleanupTempDir();
+      this.status = createIdleStatus();
+      this.updateStatus({ message: 'Update cancelled' });
+      logger.info('[FirmwareUpdateService] Update cancelled by user');
 
-    if (wasDisconnected) {
-      logger.info('[FirmwareUpdateService] Reconnecting MeshMonitor after cancel');
-      try {
-        await meshtasticManager.userReconnect();
-      } catch (reconnectError) {
-        logger.error('[FirmwareUpdateService] Reconnect after cancel errored:', reconnectError);
+      if (wasDisconnected) {
+        logger.info('[FirmwareUpdateService] Reconnecting MeshMonitor after cancel');
+        try {
+          await meshtasticManager.userReconnect();
+        } catch (reconnectError) {
+          logger.error('[FirmwareUpdateService] Reconnect after cancel errored:', reconnectError);
+        }
       }
+    } finally {
+      this.cancelling = false;
     }
+  }
+
+  /**
+   * True while a CLI process is mid-flight. Used to short-circuit
+   * double-submits of /update/confirm with HTTP 409.
+   */
+  isStepRunning(): boolean {
+    return this.activeProcess !== null;
   }
 
   /**
@@ -490,7 +507,7 @@ export class FirmwareUpdateService {
   runCliCommand(
     command: string,
     args: string[],
-    options?: { onOutput?: (chunk: string) => void }
+    options?: { onOutput?: (chunk: string) => void; timeoutMs?: number }
   ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
     return new Promise((resolve) => {
       const proc = spawn(command, args, {
@@ -502,6 +519,25 @@ export class FirmwareUpdateService {
 
       let stdout = '';
       let stderr = '';
+      let timedOut = false;
+
+      // SIGTERM after timeoutMs, then SIGKILL after a 5s grace period if the
+      // process is still alive. Without this, a hung CLI (e.g. backup waiting
+      // on a lost radio packet) blocks the HTTP handler indefinitely.
+      const timeoutMs = options?.timeoutMs ?? 0;
+      let killTimer: ReturnType<typeof setTimeout> | null = null;
+      let graceTimer: ReturnType<typeof setTimeout> | null = null;
+      if (timeoutMs > 0) {
+        killTimer = setTimeout(() => {
+          timedOut = true;
+          logger.warn(`[FirmwareUpdateService] CLI exceeded ${timeoutMs}ms — sending SIGTERM`);
+          try { proc.kill('SIGTERM'); } catch { /* already dead */ }
+          graceTimer = setTimeout(() => {
+            logger.warn(`[FirmwareUpdateService] CLI did not exit within grace period — sending SIGKILL`);
+            try { proc.kill('SIGKILL'); } catch { /* already dead */ }
+          }, 5000);
+        }, timeoutMs);
+      }
 
       proc.stdout?.on('data', (data: Buffer) => {
         const text = data.toString();
@@ -518,11 +554,18 @@ export class FirmwareUpdateService {
       });
 
       proc.on('close', (code) => {
+        if (killTimer) clearTimeout(killTimer);
+        if (graceTimer) clearTimeout(graceTimer);
         this.activeProcess = null;
+        if (timedOut) {
+          stderr += `\n[firmwareUpdateService] Command timed out after ${timeoutMs}ms and was terminated`;
+        }
         resolve({ stdout, stderr, exitCode: code ?? 1 });
       });
 
       proc.on('error', (error) => {
+        if (killTimer) clearTimeout(killTimer);
+        if (graceTimer) clearTimeout(graceTimer);
         this.activeProcess = null;
         this.appendLog(`Command error: ${error.message}`);
         resolve({ stdout, stderr, exitCode: 1 });
@@ -675,8 +718,9 @@ export class FirmwareUpdateService {
 
       const result = await this.runCliCommand('meshtastic', [
         '--host', gatewayIp,
+        '--timeout', '60',
         '--export-config',
-      ]);
+      ], { timeoutMs: 180_000 });
 
       if (result.exitCode !== 0) {
         const combined = [result.stdout, result.stderr].filter(Boolean).join('\n');
@@ -706,6 +750,8 @@ export class FirmwareUpdateService {
       logger.info(`[FirmwareUpdateService] Config backup saved: ${backupPath}`);
       return backupPath;
     } catch (error) {
+      // cancelUpdate already owns status + reconnect; don't race it.
+      if (this.cancelling) throw error;
       const message = error instanceof Error ? error.message : String(error);
       this.updateStatus({
         state: 'error',
@@ -782,6 +828,7 @@ export class FirmwareUpdateService {
       logger.info(`[FirmwareUpdateService] Downloaded firmware: ${zipPath} (${downloadSize} bytes)`);
       return zipPath;
     } catch (error) {
+      if (this.cancelling) throw error;
       const message = error instanceof Error ? error.message : String(error);
       this.cleanupTempDir();
       this.updateStatus({
@@ -818,7 +865,11 @@ export class FirmwareUpdateService {
       const extractDir = path.join(path.dirname(zipPath), 'extracted');
       fs.mkdirSync(extractDir, { recursive: true });
 
-      const result = await this.runCliCommand('unzip', ['-o', zipPath, '-d', extractDir]);
+      const result = await this.runCliCommand(
+        'unzip',
+        ['-o', zipPath, '-d', extractDir],
+        { timeoutMs: 60_000 }
+      );
       if (result.exitCode !== 0) {
         throw new Error(`Extraction failed with exit code ${result.exitCode}: ${result.stderr}`);
       }
@@ -845,6 +896,7 @@ export class FirmwareUpdateService {
       logger.info(`[FirmwareUpdateService] Matched firmware binary: ${matched}`);
       return firmwarePath;
     } catch (error) {
+      if (this.cancelling) throw error;
       const message = error instanceof Error ? error.message : String(error);
       this.cleanupTempDir();
       this.updateStatus({
@@ -880,6 +932,7 @@ export class FirmwareUpdateService {
       await this.waitForNodeReady(host, port);
       this.appendLog(`Node ${host}:${port} is accepting connections — starting OTA.`);
     } catch (readyErr) {
+      if (this.cancelling) throw readyErr;
       const message = readyErr instanceof Error ? readyErr.message : String(readyErr);
       this.updateStatus({
         state: 'error',
@@ -1075,6 +1128,7 @@ export class FirmwareUpdateService {
 
       logger.info('[FirmwareUpdateService] OTA flash completed successfully and reconnected to node');
     } catch (error) {
+      if (this.cancelling) throw error;
       const message = error instanceof Error ? error.message : String(error);
       this.updateStatus({
         state: 'error',
@@ -1143,10 +1197,11 @@ export class FirmwareUpdateService {
       throw new Error(`Backup file not found: ${resolvedBackup}`);
     }
 
-    const result = await this.runCliCommand('meshtastic', [
-      '--host', gatewayIp,
-      '--configure', resolvedBackup,
-    ]);
+    const result = await this.runCliCommand(
+      'meshtastic',
+      ['--host', gatewayIp, '--configure', resolvedBackup],
+      { timeoutMs: 180_000 }
+    );
 
     if (result.exitCode !== 0) {
       throw new Error(`Restore command failed with exit code ${result.exitCode}: ${result.stderr}`);

--- a/src/server/services/firmwareUpdateService.ts
+++ b/src/server/services/firmwareUpdateService.ts
@@ -142,6 +142,15 @@ export class FirmwareUpdateService {
   // In-flight executeXxx catch blocks observe this and bail out instead of
   // racing cancelUpdate on status writes / reconnects.
   private cancelling: boolean = false;
+  // Mirrors the local phase variable inside uploadOtaFirmware so the outer
+  // retry loop in executeFlash can decide whether a re-attempt is safe.
+  // Once we've entered 'streaming' the partition is mid-write — retrying
+  // would corrupt it.
+  private uploadPhase: 'handshake' | 'streaming' | 'commit' | 'done' = 'handshake';
+  // Tracks the nodeId of the device currently being flashed. Set when
+  // executeBackup is called, used in executeFlash to write the half-flash
+  // marker file under BACKUP_DIR if streaming/commit fails.
+  private currentNodeId: string | null = null;
 
   private pollingInterval: ReturnType<typeof setInterval> | null = null;
   private initialCheckTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -706,6 +715,10 @@ export class FirmwareUpdateService {
   }
 
   async executeBackup(gatewayIp: string, nodeId: string): Promise<string> {
+    // Remember the device we're updating so executeFlash can mark it
+    // half-flashed if the OTA streaming/commit path fails.
+    this.currentNodeId = nodeId;
+
     this.updateStatus({
       state: 'in-progress',
       step: 'backup',
@@ -1020,23 +1033,28 @@ export class FirmwareUpdateService {
         if (this.activeProcess) {
           this.activeProcess.kill('SIGTERM');
         }
-        // The loader has a short listen window — waiting 3s here would
-        // routinely miss it on fast boards like the Heltec V3 (the loader
-        // times out and reboots before our upload connects, leaving the
-        // device half-flashed). SIGTERM frees the CLI's socket near-
-        // instantly; a 200ms buffer is enough for OS socket cleanup.
+        // The Python CLI's SIGTERM-handling latency is typically 300-1500ms
+        // on a busy host (it may be mid-protobuf-decode). 200ms used to
+        // routinely fire connect attempts before the CLI had released the
+        // socket; a 2s wait still leaves plenty of headroom within the
+        // ~30s loader-open window.
         await Promise.race([
           cliPromise,
-          new Promise(r => setTimeout(r, 200)),
+          new Promise(r => setTimeout(r, 2000)),
         ]);
-        // If the first connection misses the window (loader already
-        // closing, or CLI socket not yet released), retry quickly. The
-        // loader stays open for a bounded time after detection — small
-        // retries beat a single late attempt.
-        const UPLOAD_RETRY_DELAYS_MS = [0, 250, 500, 1000];
+        // If the first connection misses the window (loader already closing
+        // or CLI socket not yet released), retry. Delays widened from
+        // ~1.75s total to ~10s total — the loader stays open ~30s on
+        // Heltec V3 so we have plenty of headroom, and short retries lost
+        // races on slow handshakes.
+        const UPLOAD_RETRY_DELAYS_MS = [0, 500, 1500, 3000, 5000];
         let lastUploadError: unknown = null;
         for (const delay of UPLOAD_RETRY_DELAYS_MS) {
           if (delay > 0) await new Promise(r => setTimeout(r, delay));
+          // Reset phase tracker before each connect — uploadOtaFirmware
+          // updates this.uploadPhase as it transitions. After failure we
+          // inspect it to decide whether re-attempt is safe.
+          this.uploadPhase = 'handshake';
           try {
             await this.uploadOtaFirmware(host, OTA_LOADER_PORT, firmwarePath);
             lastUploadError = null;
@@ -1044,13 +1062,34 @@ export class FirmwareUpdateService {
           } catch (uploadErr) {
             lastUploadError = uploadErr;
             const msg = uploadErr instanceof Error ? uploadErr.message : String(uploadErr);
-            // Only retry on connection-level failures — protocol errors
-            // ("Loader reported error", commit failures) won't recover
-            // by retrying a connect.
-            if (!/ECONNREFUSED|ECONNRESET|ETIMEDOUT|EHOSTUNREACH/i.test(msg)) {
+
+            // SAFETY RAIL 4: if any firmware bytes were streamed, the OTA
+            // partition is mid-write. Retrying would re-handshake against
+            // a loader that has half a partition; the next stream would
+            // either be rejected (waste) or worse, layered over partial
+            // state. Stop now, mark the device half-flashed, and surface
+            // the recovery path.
+            if (this.uploadPhase !== 'handshake') {
+              const failedPhase = this.uploadPhase;
+              this.writeFlashIncompleteMarker(this.currentNodeId, failedPhase, msg);
+              throw new Error(
+                `Firmware streaming was interrupted in phase "${failedPhase}" — ` +
+                `device may be half-flashed. Use USB recovery before retrying. ` +
+                `Original error: ${msg}`
+              );
+            }
+
+            // Retry on connection-level failures and on handshake-phase
+            // loader timeouts. Protocol errors after handshake (e.g.
+            // "Loader reported error") and commit failures fall through.
+            const retryable =
+              /ECONNREFUSED|ECONNRESET|ETIMEDOUT|EHOSTUNREACH/i.test(msg) ||
+              /Loader closed connection in phase "handshake"/i.test(msg) ||
+              /Direct OTA upload timed out.*handshake/i.test(msg);
+            if (!retryable) {
               throw uploadErr;
             }
-            logger.warn(`[FirmwareUpdateService] OTA upload connect attempt failed (${msg}), retrying...`);
+            logger.warn(`[FirmwareUpdateService] OTA upload attempt failed (${msg}), retrying...`);
           }
         }
         if (lastUploadError) {
@@ -1223,6 +1262,75 @@ export class FirmwareUpdateService {
     logger.info(`[FirmwareUpdateService] Config restored from ${backupPath} to ${gatewayIp}`);
   }
 
+  // ---- Half-flash recovery markers (safety rail 5) ----
+
+  private sanitizeNodeId(nodeId: string | null): string {
+    return String(nodeId ?? '').replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 64) || 'unknown';
+  }
+
+  /**
+   * Write a marker file under BACKUP_DIR when an OTA upload fails after
+   * streaming has begun. A device with a marker is presumed half-flashed
+   * and refuses further OTA attempts until the marker is explicitly cleared
+   * (typically after a USB-tethered recovery).
+   */
+  private writeFlashIncompleteMarker(nodeId: string | null, phase: string, reason: string): void {
+    try {
+      this.ensureBackupDir();
+      const safe = this.sanitizeNodeId(nodeId);
+      const ts = new Date().toISOString().replace(/[:.]/g, '-');
+      const markerPath = path.join(BACKUP_DIR, `.flash-incomplete-${safe}-${ts}`);
+      const resolvedBackupDir = path.resolve(BACKUP_DIR);
+      const resolvedMarker = path.resolve(markerPath);
+      if (!resolvedMarker.startsWith(resolvedBackupDir + path.sep)) {
+        logger.error('[FirmwareUpdateService] Refusing to write marker outside backup dir');
+        return;
+      }
+      fs.writeFileSync(
+        resolvedMarker,
+        JSON.stringify({ nodeId: safe, phase, reason, timestamp: Date.now() }, null, 2),
+        'utf-8'
+      );
+      logger.warn(`[FirmwareUpdateService] Wrote half-flash marker: ${resolvedMarker}`);
+    } catch (err) {
+      logger.error('[FirmwareUpdateService] Failed to write half-flash marker:', err);
+    }
+  }
+
+  /** True if a recovery marker exists for the given nodeId. */
+  hasFlashIncompleteMarker(nodeId: string): boolean {
+    try {
+      if (!fs.existsSync(BACKUP_DIR)) return false;
+      const safe = this.sanitizeNodeId(nodeId);
+      const prefix = `.flash-incomplete-${safe}-`;
+      return fs.readdirSync(BACKUP_DIR).some(f => f.startsWith(prefix));
+    } catch (err) {
+      logger.warn('[FirmwareUpdateService] Error checking flash incomplete markers:', err);
+      return false;
+    }
+  }
+
+  /** Remove all recovery markers for the given nodeId. Returns count removed. */
+  clearFlashIncompleteMarker(nodeId: string): number {
+    let removed = 0;
+    try {
+      if (!fs.existsSync(BACKUP_DIR)) return 0;
+      const safe = this.sanitizeNodeId(nodeId);
+      const prefix = `.flash-incomplete-${safe}-`;
+      const resolvedBackupDir = path.resolve(BACKUP_DIR);
+      for (const f of fs.readdirSync(BACKUP_DIR)) {
+        if (!f.startsWith(prefix)) continue;
+        const target = path.resolve(path.join(BACKUP_DIR, f));
+        if (!target.startsWith(resolvedBackupDir + path.sep)) continue;
+        fs.unlinkSync(target);
+        removed++;
+      }
+    } catch (err) {
+      logger.warn('[FirmwareUpdateService] Error clearing flash incomplete markers:', err);
+    }
+    return removed;
+  }
+
   // ---- Private helpers ----
 
   /**
@@ -1291,15 +1399,23 @@ export class FirmwareUpdateService {
 
       type Phase = 'handshake' | 'streaming' | 'commit' | 'done';
       let phase: Phase = 'handshake';
+      // Mirror to instance state so executeFlash's retry loop knows whether
+      // any bytes have been streamed (safety rail 4).
+      this.uploadPhase = 'handshake';
       let lineBuffer = '';
       let bytesSent = 0;
       let lastProgressUpdate = 0;
       let finished = false;
 
+      const setPhase = (p: Phase) => {
+        phase = p;
+        this.uploadPhase = p;
+      };
+
       const finish = (err?: Error) => {
         if (finished) return;
         finished = true;
-        phase = 'done';
+        setPhase('done');
         clearTimeout(overallTimer);
         socket.removeAllListeners();
         socket.destroy();
@@ -1311,7 +1427,7 @@ export class FirmwareUpdateService {
       }, OVERALL_TIMEOUT_MS);
 
       const streamFirmware = () => {
-        phase = 'streaming';
+        setPhase('streaming');
         this.updateStatus({ progress: 0, message: 'Uploading firmware: 0%' });
         let offset = 0;
         const writeNext = () => {
@@ -1336,7 +1452,7 @@ export class FirmwareUpdateService {
             }
           }
           // All bytes written. Now wait for the commit `OK`.
-          phase = 'commit';
+          setPhase('commit');
           this.updateStatus({ progress: 100, message: 'Waiting for loader to verify and commit firmware...' });
           logger.debug(`[FirmwareUpdateService] Direct OTA: all ${size} bytes sent, awaiting commit OK`);
         };

--- a/src/server/services/firmwareUpdateService.ts
+++ b/src/server/services/firmwareUpdateService.ts
@@ -1160,6 +1160,19 @@ export class FirmwareUpdateService {
    * Step 6: Verify that the firmware version matches the target after reboot.
    */
   verifyUpdate(newFirmwareVersion: string, targetVersion: string): void {
+    // Guard against the empty-string false-positive: ''.includes(target) is
+    // false but target.includes('') is true, so any unset arg used to pass.
+    if (!newFirmwareVersion || !targetVersion) {
+      const message = `Cannot verify firmware version (running: "${newFirmwareVersion}", expected: "${targetVersion}")`;
+      this.updateStatus({
+        state: 'error',
+        step: 'verify',
+        message,
+        error: 'Firmware version unavailable for verification',
+      });
+      logger.warn(`[FirmwareUpdateService] ${message}`);
+      return;
+    }
     if (newFirmwareVersion.includes(targetVersion) || targetVersion.includes(newFirmwareVersion)) {
       this.updateStatus({
         state: 'success',

--- a/src/server/services/firmwareUpdateService.ts
+++ b/src/server/services/firmwareUpdateService.ts
@@ -1075,7 +1075,8 @@ export class FirmwareUpdateService {
               throw new Error(
                 `Firmware streaming was interrupted in phase "${failedPhase}" — ` +
                 `device may be half-flashed. Use USB recovery before retrying. ` +
-                `Original error: ${msg}`
+                `Original error: ${msg}`,
+                { cause: uploadErr }
               );
             }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "types": ["vitest/globals", "@testing-library/jest-dom"],


### PR DESCRIPTION
Closes #2971

Five surgical fixes + two safety rails for the OTA firmware update path.
No rewrite. No changes to `uploadOtaFirmware`'s wire-protocol bytes —
handshake-OK / streaming / commit-OK semantics are preserved exactly.

## What's in this PR

### F1 — async step orchestration (commit `25763455`)
`POST /update/confirm` no longer awaits the long-running step inside the
HTTP handler. The preflight, backup, and extract cases each kick off
their step as fire-and-forget IIFEs and return 200 immediately with the
current status. The frontend already drives the wizard off Socket.IO
`firmware:status` events on every `updateStatus()` call — it never
needed the synchronous response. Fixes the "stuck at backup" symptom:
reverse proxies were 504'ing at 60–100s on slow backups, breaking the
wizard while the server kept running.

### F2 — CLI timeouts (commit `92bd3bc3`)
`runCliCommand` now accepts a `timeoutMs` option that SIGTERMs the
child on expiry and SIGKILLs after a 5s grace. Applied:
- `executeBackup`: 180s + pass `--timeout 60` to the meshtastic CLI
- `executeExtract` unzip: 60s
- `restoreBackup`: 180s

Converts indefinite hangs into clean errors.

### F3 — cancel single-flight guard + 409 double-submit guard (commit `92bd3bc3`)
- `private cancelling` flag set at top of `cancelUpdate`, cleared after
  the reconnect finishes.
- Every `executeXxx` catch block now re-throws immediately when
  `cancelling` is set — cancelUpdate owns status writes and reconnect.
- New `isStepRunning()` on the service. `/update/confirm` returns HTTP
  409 if an active process exists, blocking double-submits.

### F4 — handshake retry widening (commit `7d050586`) **(bricking path)**
- Post-SIGTERM wait restored to 2000ms (was 200ms — too short for the
  Python CLI's 300-1500ms socket-release latency).
- Retry delays widened from `[0, 250, 500, 1000]` (~1.75s) to
  `[0, 500, 1500, 3000, 5000]` (~10s). Loader stays open ~30s.
- Retry filter expanded to also handle `Loader closed connection in
  phase \"handshake\"` and `Direct OTA upload timed out` with
  `phase=handshake`, which were previously slipping through.

### F5 — verify against actual running version (commit `c18c2ca4`)
The old call was passing `targetVersion` as both \"actual\" and
\"expected\" args to `verifyUpdate`, so the substring check trivially
passed. Now reads `firmwareVersion` from
`meshtasticManager.getLocalNodeInfo()` after the post-flash reconnect
and compares that against the target. Also fixes the empty-string
false-positive in `verifyUpdate` (`target.includes('')` was true).

### Safety rail 4 — never retry past streaming (commit `7d050586`)
`uploadOtaFirmware` now mirrors its internal phase variable to
`this.uploadPhase`. The retry loop resets it to `'handshake'` before
each attempt and gates on it after failure: if the uploader entered
`streaming` or `commit`, the partition is mid-write and re-handshaking
would corrupt it. Throws a clear \"use USB recovery\" error instead.

### Safety rail 5 — half-flash marker file (commit `7d050586`)
- On streaming/commit failure, write `.flash-incomplete-<nodeId>-<ts>`
  under `BACKUP_DIR`. `nodeId` is captured at `executeBackup` and
  sanitized before going into the filename (path-traversal safe).
- `/update/confirm` preflight step returns HTTP 409 if a marker exists
  for the target node, with the recovery instructions in the body.
- New admin route `DELETE /api/firmware/recovery-marker/:nodeId`
  clears markers (operator confirms USB recovery completed).

## ⚠️ Bricking-path callout — F4 needs hardware testing

F4 is the only change in this PR that alters timing/retry behavior on
the actual flash bytes-on-wire path. The wire protocol itself is
untouched, but the post-SIGTERM wait and retry filter affect when we
connect to the loader. **Please test on a USB-tethered Heltec V3
before merge** — if `uploadOtaFirmware` enters `phase: 'streaming'`
and the connection drops, the device is mid-flash. Safety rail 4
should prevent retries on that path, and safety rail 5 marks the
device so the next OTA attempt is refused, but the first integration
test should be USB-tethered with a serial console.

Lower-risk items (F1, F2, F3, F5) are still worth a smoke test on the
existing dev gateway, but they don't carry bricking risk.

## Diff stats

```
src/server/routes/firmwareUpdateRoutes.test.ts |  71 +++++++
src/server/routes/firmwareUpdateRoutes.ts      | 114 ++++++++++--
src/server/services/firmwareUpdateService.ts   | 273 +++++++++++++++++++++----
```

Slightly over the issue's ~150-line target (~280 net code lines, plus
~70 lines of tests). The overage is in safety rail 5's marker helpers
(write/has/clear + sanitize) and the WHY comments on each change. No
new abstractions; no rewrite.

## What was skipped

- **Service-level unit tests for marker helpers** — `BACKUP_DIR` is a
  module-load-time constant from `DATA_DIR`, so the obvious
  `process.env.DATA_DIR = tmpDir; test...` pattern doesn't work without
  refactoring or fs mocking. The routes test exercises the API through
  mocks. Manual smoke test against a real BACKUP_DIR is straightforward.
- **Safety rails 1, 2, 3** from the issue (empty-backup guard, explicit
  \"backup verified\" checkbox, sha256-recompute before flash) — out of
  scope for this PR per the punch list (\"do these in this order... 1–6\").
  Worth follow-up issues.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new violations (2 pre-existing
  `preserve-caught-error` warnings remain on lines untouched by this PR)
- [x] `npm test` — 271 test files, 4748 tests, all pass
- [ ] Smoke test on existing dev gateway (Heltec V3 or similar) for F1/F2/F3/F5
- [ ] **USB-tethered F4 test before merge** — Heltec V3 with serial console,
      observe handshake retry path and confirm safety rail 4 fires on
      simulated mid-stream drop
- [ ] Verify `DELETE /api/firmware/recovery-marker/:nodeId` clears markers