### PR TITLE
feat(waypoints): scheduled rebroadcast with global airtime floor

### DIFF
--- a/src/components/WaypointEditorModal.tsx
+++ b/src/components/WaypointEditorModal.tsx
@@ -70,7 +70,11 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
         initial.lockedTo != null && selfNodeNum != null && initial.lockedTo === selfNodeNum,
       );
       setVirtual(Boolean(initial.isVirtual));
-      setRebroadcast(initial.rebroadcastIntervalS ? String(initial.rebroadcastIntervalS) : '');
+      setRebroadcast(
+        initial.rebroadcastIntervalS
+          ? String(Math.max(10, Math.round(initial.rebroadcastIntervalS / 60)))
+          : '',
+      );
     } else {
       setLat(defaultCoords ? String(defaultCoords.lat) : '');
       setLon(defaultCoords ? String(defaultCoords.lon) : '');
@@ -116,12 +120,12 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
     }
     let rebroadcastIntervalS: number | null = null;
     if (rebroadcast.trim().length > 0) {
-      const r = Number(rebroadcast);
-      if (!Number.isFinite(r) || r < 60) {
-        setError('Rebroadcast interval must be at least 60 seconds');
+      const minutes = Number(rebroadcast);
+      if (!Number.isFinite(minutes) || !Number.isInteger(minutes) || minutes < 10) {
+        setError('Rebroadcast interval must be at least 10 minutes');
         return null;
       }
-      rebroadcastIntervalS = Math.floor(r);
+      rebroadcastIntervalS = minutes * 60;
     }
     return {
       lat: latN,
@@ -283,14 +287,18 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
         </label>
 
         <label className="form-label">
-          Rebroadcast interval (seconds, optional)
+          Rebroadcast every (minutes, optional)
           <input
             className="form-input"
             type="number"
-            min={60}
+            min={10}
+            step={1}
             value={rebroadcast}
             onChange={(e) => setRebroadcast(e.target.value)}
           />
+          <span className="form-hint">
+            Minimum 10 minutes. The scheduler rebroadcasts at most one waypoint per minute across the whole mesh.
+          </span>
         </label>
 
         {error && (

--- a/src/db/repositories/waypoints.ts
+++ b/src/db/repositories/waypoints.ts
@@ -4,7 +4,7 @@
  * Per-source storage for Meshtastic waypoints (PortNum.WAYPOINT_APP).
  * Composite primary key (sourceId, waypointId).
  */
-import { and, eq, gte, lte, lt, isNull, or, sql } from 'drizzle-orm';
+import { and, asc, eq, gte, lte, lt, isNull, or, sql } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType } from '../types.js';
 
@@ -196,6 +196,68 @@ export class WaypointsRepository extends BaseRepository {
       .from(waypoints)
       .where(eq(waypoints.sourceId, sourceId));
     return new Set(rows.map((r: any) => Number(r.id)));
+  }
+
+  /**
+   * Pick the single oldest waypoint that is eligible to be rebroadcast right
+   * now. Eligibility:
+   *   - `rebroadcastIntervalS` is non-null and > 0
+   *   - `isVirtual` is false (virtual waypoints never go out on the mesh)
+   *   - waypoint is not expired (`expireAt` null/0, or in the future)
+   *   - either `lastBroadcastAt` is NULL, or
+   *     `now - lastBroadcastAt >= rebroadcastIntervalS`
+   *
+   * Ordering: NULL `lastBroadcastAt` first (never broadcast = highest priority),
+   * then by ascending `lastBroadcastAt` so rotation is fair. `LIMIT 1` keeps
+   * the airtime floor strict — the scheduler picks at most one per tick.
+   *
+   * Times are in epoch seconds to match `rebroadcastIntervalS` and `expireAt`.
+   */
+  async findOldestEligibleForRebroadcastAsync(nowSec: number): Promise<Waypoint | null> {
+    const { waypoints } = this.tables;
+
+    const rows = await this.db
+      .select()
+      .from(waypoints)
+      .where(
+        and(
+          eq(waypoints.isVirtual, 0),
+          sql`${waypoints.rebroadcastIntervalS} IS NOT NULL`,
+          sql`${waypoints.rebroadcastIntervalS} > 0`,
+          or(
+            isNull(waypoints.expireAt),
+            eq(waypoints.expireAt, 0),
+            gte(waypoints.expireAt, nowSec),
+          )!,
+          or(
+            isNull(waypoints.lastBroadcastAt),
+            sql`${nowSec} - ${waypoints.lastBroadcastAt} >= ${waypoints.rebroadcastIntervalS}`,
+          )!,
+        ),
+      )
+      // NULL lastBroadcastAt sorts first in SQLite/PostgreSQL by default;
+      // MySQL also puts NULLs first under ASC. Then fall back to oldest.
+      .orderBy(asc(waypoints.lastBroadcastAt))
+      .limit(1);
+
+    return rows.length > 0 ? deserializeRow(rows[0]) : null;
+  }
+
+  /**
+   * Stamp `lastBroadcastAt = nowSec` for a single waypoint. Returns true if a
+   * row was updated. Used by the rebroadcast scheduler immediately after a
+   * successful mesh send so the same waypoint is not picked again on the next
+   * tick.
+   */
+  async markRebroadcastedAsync(sourceId: string, waypointId: number, nowSec: number): Promise<boolean> {
+    const { waypoints } = this.tables;
+    const result = await this.executeRun(
+      this.db
+        .update(waypoints)
+        .set({ lastBroadcastAt: nowSec })
+        .where(and(eq(waypoints.sourceId, sourceId), eq(waypoints.waypointId, waypointId))),
+    );
+    return this.getAffectedRows(result) > 0;
   }
 
   /**

--- a/src/server/routes/waypoints.test.ts
+++ b/src/server/routes/waypoints.test.ts
@@ -194,6 +194,34 @@ describe('Waypoint routes', () => {
         .send({ lat: 30, lon: -90 });
       expect(res.status).toBe(403);
     });
+
+    it('rejects a rebroadcast interval below the 600s (10-min) airtime floor', async () => {
+      const app = createApp();
+      const res = await request(app)
+        .post('/api/sources/src-1/waypoints')
+        .send({ lat: 30, lon: -90, rebroadcast_interval_s: 300 });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/at least 600 seconds/);
+    });
+
+    it('rejects a non-integer rebroadcast interval', async () => {
+      const app = createApp();
+      const res = await request(app)
+        .post('/api/sources/src-1/waypoints')
+        .send({ lat: 30, lon: -90, rebroadcast_interval_s: 700.5 });
+      expect(res.status).toBe(400);
+    });
+
+    it('accepts a rebroadcast interval at the 10-min floor', async () => {
+      mockWaypointService.createLocal.mockResolvedValue({
+        sourceId: 'src-1', waypointId: 1, latitude: 30, longitude: -90,
+      });
+      const app = createApp();
+      const res = await request(app)
+        .post('/api/sources/src-1/waypoints')
+        .send({ lat: 30, lon: -90, rebroadcast_interval_s: 600 });
+      expect(res.status).toBe(201);
+    });
   });
 
   describe('PATCH /api/sources/:id/waypoints/:waypointId', () => {

--- a/src/server/routes/waypoints.ts
+++ b/src/server/routes/waypoints.ts
@@ -34,6 +34,35 @@ function badRequest(res: Response, message: string) {
   return res.status(400).json({ error: message, code: 'BAD_REQUEST' });
 }
 
+/**
+ * Minimum allowed rebroadcast interval in seconds. The UI surfaces this in
+ * minutes (10 min); we enforce server-side too so direct API callers cannot
+ * blow past the airtime floor.
+ */
+export const MIN_REBROADCAST_INTERVAL_S = 600;
+
+/**
+ * Parse the rebroadcast_interval_s body field. Returns:
+ *   - `undefined` when the caller omitted the field (no change on PATCH)
+ *   - `null` when the caller explicitly cleared it
+ *   - a positive integer >= MIN_REBROADCAST_INTERVAL_S when valid
+ *   - a string error message when the value is invalid
+ */
+function parseRebroadcastIntervalS(raw: unknown): number | null | undefined | { error: string } {
+  if (raw === undefined) return undefined;
+  if (raw === null) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || Math.floor(n) !== n) {
+    return { error: 'rebroadcast_interval_s must be an integer number of seconds' };
+  }
+  if (n < MIN_REBROADCAST_INTERVAL_S) {
+    return {
+      error: `rebroadcast_interval_s must be at least ${MIN_REBROADCAST_INTERVAL_S} seconds (10 minutes)`,
+    };
+  }
+  return n;
+}
+
 // GET /api/sources/:id/waypoints?includeExpired=&bbox=minLat,minLon,maxLat,maxLon
 router.get(
   '/',
@@ -96,9 +125,14 @@ router.post(
         ? null
         : Number(body.locked_to);
       const virtual = Boolean(body.virtual);
-      const rebroadcastIntervalS = body.rebroadcast_interval_s === undefined || body.rebroadcast_interval_s === null
-        ? null
-        : Number(body.rebroadcast_interval_s);
+      const parsedRebroadcast = parseRebroadcastIntervalS(body.rebroadcast_interval_s);
+      if (parsedRebroadcast && typeof parsedRebroadcast === 'object' && 'error' in parsedRebroadcast) {
+        return badRequest(res, parsedRebroadcast.error);
+      }
+      // POST treats `undefined` (omitted) and `null` (explicit) the same: no
+      // rebroadcast scheduled. PATCH preserves the distinction.
+      const rebroadcastIntervalS =
+        parsedRebroadcast === undefined ? null : (parsedRebroadcast as number | null);
 
       // Best-effort: use the source's local node as the owner. Fallback to 0
       // when the manager isn't reachable (still records, owner_node_num NULL).
@@ -185,8 +219,11 @@ router.patch(
         fields.lockedTo = body.locked_to === null ? null : Number(body.locked_to);
       }
       if (body.rebroadcast_interval_s !== undefined) {
-        fields.rebroadcastIntervalS =
-          body.rebroadcast_interval_s === null ? null : Number(body.rebroadcast_interval_s);
+        const parsed = parseRebroadcastIntervalS(body.rebroadcast_interval_s);
+        if (parsed && typeof parsed === 'object' && 'error' in parsed) {
+          return badRequest(res, parsed.error);
+        }
+        fields.rebroadcastIntervalS = parsed as number | null;
       }
 
       let persisted;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -34,6 +34,7 @@ import { databaseMaintenanceService } from './services/databaseMaintenanceServic
 import { systemBackupService } from './services/systemBackupService.js';
 import { systemRestoreService } from './services/systemRestoreService.js';
 import { duplicateKeySchedulerService } from './services/duplicateKeySchedulerService.js';
+import { waypointRebroadcastSchedulerService } from './services/waypointRebroadcastSchedulerService.js';
 import { securityDigestService } from './services/securityDigestService.js';
 import { solarMonitoringService } from './services/solarMonitoringService.js';
 import { newsService } from './services/newsService.js';
@@ -521,6 +522,8 @@ setTimeout(async () => {
     // Initialize duplicate key scanner
     duplicateKeySchedulerService.start();
     logger.debug('Duplicate key scanner initialized');
+
+    waypointRebroadcastSchedulerService.start();
 
     // Initialize security digest scheduler
     securityDigestService.initialize(databaseService);

--- a/src/server/services/waypointRebroadcastSchedulerService.ts
+++ b/src/server/services/waypointRebroadcastSchedulerService.ts
@@ -1,0 +1,70 @@
+/**
+ * Waypoint Rebroadcast Scheduler
+ *
+ * Runs every 60 seconds and asks `waypointService.rebroadcastTick()` to pick
+ * AT MOST one eligible waypoint and re-broadcast it. The hard 60s floor is
+ * enforced here so the airtime budget cannot be exceeded regardless of how
+ * many waypoints are configured or how short their individual
+ * `rebroadcastIntervalS` values are.
+ *
+ * Mirrors the start/stop pattern used by the other periodic services
+ * (databaseMaintenanceService, duplicateKeySchedulerService, …) so process
+ * shutdown / service lifecycle behaves consistently across the server.
+ */
+import { logger } from '../../utils/logger.js';
+import { waypointService } from './waypointService.js';
+
+/** Hard interval — do NOT weaken. The 60s floor is the airtime guarantee. */
+const TICK_INTERVAL_MS = 60_000;
+
+class WaypointRebroadcastSchedulerService {
+  private intervalId: NodeJS.Timeout | null = null;
+  private inFlight = false;
+
+  start(): void {
+    if (this.intervalId) {
+      logger.warn('[waypointRebroadcastScheduler] already running');
+      return;
+    }
+
+    this.intervalId = setInterval(() => {
+      this.runTick().catch((err) => {
+        logger.error('[waypointRebroadcastScheduler] tick failed:', err);
+      });
+    }, TICK_INTERVAL_MS);
+
+    logger.info('▶️ Waypoint rebroadcast scheduler started (60s tick)');
+  }
+
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+      logger.info('⏹️ Waypoint rebroadcast scheduler stopped');
+    }
+  }
+
+  /**
+   * Single tick. Guarded with an in-flight flag so a slow broadcast cannot
+   * stack ticks if a previous one hasn't returned yet.
+   */
+  async runTick(): Promise<void> {
+    if (this.inFlight) {
+      logger.debug('[waypointRebroadcastScheduler] previous tick still running, skipping');
+      return;
+    }
+    this.inFlight = true;
+    try {
+      await waypointService.rebroadcastTick();
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  isRunning(): boolean {
+    return this.intervalId !== null;
+  }
+}
+
+export const waypointRebroadcastSchedulerService = new WaypointRebroadcastSchedulerService();
+export { WaypointRebroadcastSchedulerService };

--- a/src/server/services/waypointService.test.ts
+++ b/src/server/services/waypointService.test.ts
@@ -7,16 +7,29 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockUpsert, mockGet, mockDelete, mockList, mockGetExistingIds, mockSweep, emit } =
-  vi.hoisted(() => ({
-    mockUpsert: vi.fn(),
-    mockGet: vi.fn(),
-    mockDelete: vi.fn(),
-    mockList: vi.fn(),
-    mockGetExistingIds: vi.fn(),
-    mockSweep: vi.fn(),
-    emit: vi.fn(),
-  }));
+const {
+  mockUpsert,
+  mockGet,
+  mockDelete,
+  mockList,
+  mockGetExistingIds,
+  mockSweep,
+  mockFindOldestEligible,
+  mockMarkRebroadcasted,
+  mockGetManager,
+  emit,
+} = vi.hoisted(() => ({
+  mockUpsert: vi.fn(),
+  mockGet: vi.fn(),
+  mockDelete: vi.fn(),
+  mockList: vi.fn(),
+  mockGetExistingIds: vi.fn(),
+  mockSweep: vi.fn(),
+  mockFindOldestEligible: vi.fn(),
+  mockMarkRebroadcasted: vi.fn(),
+  mockGetManager: vi.fn(),
+  emit: vi.fn(),
+}));
 
 vi.mock('../../services/database.js', () => ({
   default: {
@@ -27,7 +40,15 @@ vi.mock('../../services/database.js', () => ({
       listAsync: mockList,
       getExistingIdsAsync: mockGetExistingIds,
       sweepExpiredAsync: mockSweep,
+      findOldestEligibleForRebroadcastAsync: mockFindOldestEligible,
+      markRebroadcastedAsync: mockMarkRebroadcasted,
     },
+  },
+}));
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    getManager: (...args: unknown[]) => mockGetManager(...args),
   },
 }));
 
@@ -48,8 +69,33 @@ beforeEach(() => {
   mockList.mockReset();
   mockGetExistingIds.mockReset();
   mockSweep.mockReset();
+  mockFindOldestEligible.mockReset();
+  mockMarkRebroadcasted.mockReset();
+  mockGetManager.mockReset();
   emit.mockReset();
 });
+
+function eligibleRow(overrides: Record<string, unknown> = {}) {
+  return {
+    sourceId: 's1',
+    waypointId: 7,
+    latitude: 1.23,
+    longitude: 4.56,
+    name: 'Camp',
+    description: '',
+    iconCodepoint: 0,
+    iconEmoji: null,
+    isVirtual: false,
+    expireAt: null,
+    lockedTo: 0,
+    ownerNodeNum: 0,
+    firstSeenAt: 1,
+    lastUpdatedAt: 1,
+    rebroadcastIntervalS: 600,
+    lastBroadcastAt: null,
+    ...overrides,
+  };
+}
 
 describe('codepointToEmoji / emojiToCodepoint', () => {
   it('round-trips a basic emoji', () => {
@@ -208,6 +254,58 @@ describe('createLocal / update / deleteLocal', () => {
     const ok = await waypointService.deleteLocal('s1', 1, 555);
     expect(ok).toBe(true);
     expect(emit.mock.calls[0]?.[0]).toBe('deleted');
+  });
+});
+
+describe('rebroadcastTick', () => {
+  it('returns null when nothing is eligible', async () => {
+    mockFindOldestEligible.mockResolvedValueOnce(null);
+    const result = await waypointService.rebroadcastTick();
+    expect(result).toBeNull();
+    expect(mockMarkRebroadcasted).not.toHaveBeenCalled();
+  });
+
+  it('does NOT stamp lastBroadcastAt when no source manager is available', async () => {
+    mockFindOldestEligible.mockResolvedValueOnce(eligibleRow());
+    mockGetManager.mockReturnValueOnce(null);
+    const result = await waypointService.rebroadcastTick();
+    expect(result).toBeNull();
+    expect(mockMarkRebroadcasted).not.toHaveBeenCalled();
+  });
+
+  it('does NOT stamp lastBroadcastAt when the manager returns a falsy packetId', async () => {
+    mockFindOldestEligible.mockResolvedValueOnce(eligibleRow());
+    mockGetManager.mockReturnValueOnce({ broadcastWaypoint: vi.fn().mockResolvedValue(0) });
+    const result = await waypointService.rebroadcastTick();
+    expect(result).toBeNull();
+    expect(mockMarkRebroadcasted).not.toHaveBeenCalled();
+  });
+
+  it('does NOT stamp lastBroadcastAt when broadcastWaypoint throws', async () => {
+    mockFindOldestEligible.mockResolvedValueOnce(eligibleRow());
+    mockGetManager.mockReturnValueOnce({
+      broadcastWaypoint: vi.fn().mockRejectedValue(new Error('boom')),
+    });
+    const result = await waypointService.rebroadcastTick();
+    expect(result).toBeNull();
+    expect(mockMarkRebroadcasted).not.toHaveBeenCalled();
+  });
+
+  it('stamps lastBroadcastAt and emits upserted on a successful broadcast', async () => {
+    const row = eligibleRow();
+    mockFindOldestEligible.mockResolvedValueOnce(row);
+    const broadcastWaypoint = vi.fn().mockResolvedValue(42);
+    mockGetManager.mockReturnValueOnce({ broadcastWaypoint });
+    mockMarkRebroadcasted.mockResolvedValueOnce(true);
+    const refreshed = { ...row, lastBroadcastAt: 1234 };
+    mockGet.mockResolvedValueOnce(refreshed);
+
+    const result = await waypointService.rebroadcastTick();
+
+    expect(broadcastWaypoint).toHaveBeenCalledOnce();
+    expect(mockMarkRebroadcasted).toHaveBeenCalledWith('s1', 7, expect.any(Number));
+    expect(result).toEqual(refreshed);
+    expect(emit.mock.calls.find((c) => c[0] === 'upserted')).toBeTruthy();
   });
 });
 

--- a/src/server/services/waypointService.ts
+++ b/src/server/services/waypointService.ts
@@ -18,6 +18,7 @@ import crypto from 'crypto';
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { dataEventEmitter } from './dataEventEmitter.js';
+import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
 import type { Waypoint } from '../../db/repositories/waypoints.js';
 
 /** Default emoji shown when a waypoint arrives without a valid icon codepoint. */
@@ -295,6 +296,86 @@ class WaypointService {
       dataEventEmitter.emitWaypointDeleted({ sourceId, waypointId }, sourceId);
     }
     return removed;
+  }
+
+  /**
+   * Rebroadcast scheduler tick. Picks at most ONE eligible waypoint across all
+   * sources, re-broadcasts it through its source manager, and stamps
+   * `lastBroadcastAt` on success. This enforces a hard global airtime floor:
+   * the caller invokes this every 60 seconds, so at worst one waypoint per
+   * minute goes out regardless of how many waypoints are configured.
+   *
+   * Returns the waypoint that was rebroadcast, or `null` when nothing was
+   * eligible or the send failed.
+   */
+  async rebroadcastTick(): Promise<Waypoint | null> {
+    const nowSec = Math.floor(Date.now() / 1000);
+    let candidate: Waypoint | null;
+    try {
+      candidate = await databaseService.waypoints.findOldestEligibleForRebroadcastAsync(nowSec);
+    } catch (error) {
+      logger.error('[waypointService] rebroadcastTick: eligibility query failed:', error);
+      return null;
+    }
+
+    if (!candidate) return null;
+
+    const manager = sourceManagerRegistry.getManager(candidate.sourceId) as any;
+    if (!manager || typeof manager.broadcastWaypoint !== 'function') {
+      // Source manager isn't reachable (e.g. disconnected). Skip this tick;
+      // we'll retry next minute. Do NOT stamp lastBroadcastAt — the waypoint
+      // should remain eligible so it gets sent as soon as the manager is back.
+      logger.debug(
+        `[waypointService] rebroadcastTick: no manager for source ${candidate.sourceId}, skipping`,
+      );
+      return null;
+    }
+
+    try {
+      const packetId = await manager.broadcastWaypoint({
+        id: candidate.waypointId,
+        latitude: candidate.latitude,
+        longitude: candidate.longitude,
+        expire: candidate.expireAt ?? 0,
+        lockedTo: candidate.lockedTo ?? 0,
+        name: candidate.name,
+        description: candidate.description,
+        icon: candidate.iconCodepoint ?? 0,
+      });
+
+      if (!packetId) {
+        // Manager refused (e.g. not connected). Same rationale as above —
+        // leave lastBroadcastAt alone so we retry next tick.
+        logger.debug(
+          `[waypointService] rebroadcastTick: broadcastWaypoint returned 0 for ${candidate.sourceId}/${candidate.waypointId}`,
+        );
+        return null;
+      }
+
+      await databaseService.waypoints.markRebroadcastedAsync(
+        candidate.sourceId,
+        candidate.waypointId,
+        nowSec,
+      );
+
+      // Surface the updated row to listeners so the UI's lastBroadcastAt
+      // refreshes without a polling round-trip.
+      const refreshed = await databaseService.waypoints.getAsync(
+        candidate.sourceId,
+        candidate.waypointId,
+      );
+      if (refreshed) {
+        dataEventEmitter.emitWaypointUpserted(refreshed, refreshed.sourceId);
+      }
+
+      logger.info(
+        `[waypointService] Rebroadcast waypoint ${candidate.waypointId} on source ${candidate.sourceId} (packetId=${packetId})`,
+      );
+      return refreshed ?? candidate;
+    } catch (error) {
+      logger.error('[waypointService] rebroadcastTick: broadcast failed:', error);
+      return null;
+    }
   }
 
   /** Periodic sweep — removes waypoints whose `expire_at` is older than now-grace. */


### PR DESCRIPTION
## Summary

- Adds periodic rebroadcast of waypoints onto the mesh.
- Hard global airtime floor: scheduler picks **at most one waypoint per 60 seconds** across the entire server.
- Per-waypoint cadence configurable in the UI, in **minutes, minimum 10**.

## Design notes

- **Eligibility query** (`findOldestEligibleForRebroadcastAsync`): Drizzle, `LIMIT 1`, NULL-`lastBroadcastAt` first, then ascending — fair rotation. Skips virtual waypoints and expired ones, requires non-null positive `rebroadcastIntervalS`.
- **Scheduler** (`waypointRebroadcastSchedulerService`): fixed 60s `setInterval`, in-flight guard so a slow broadcast cannot stack ticks. Mirrors the existing `duplicateKeySchedulerService` pattern; wired into `server.ts` startup.
- **`lastBroadcastAt` is only stamped on a successful broadcast** (non-zero packetId, no thrown error, manager present). If the source manager is disconnected or the send fails, the waypoint stays eligible for the next tick — no silent drops.
- **10-minute minimum** enforced in both places: `WaypointEditorModal` (`min={10}` + client-side validation message) and `routes/waypoints.ts` (`MIN_REBROADCAST_INTERVAL_S = 600`, applied in POST and PATCH). Direct API callers can't bypass the floor.
- No schema migration needed — `rebroadcastIntervalS` and `lastBroadcastAt` columns already exist on `waypoints`.

## Test plan

- [ ] Unit tests pass: `npm run test:run` (touched files verified locally, 35/35; please confirm full suite in CI)
- [ ] Typecheck passes: `npm run typecheck`
- [ ] Lint passes: `npm run lint`
- [ ] Manual: create a waypoint with rebroadcast interval = 10 minutes; confirm it goes out on the mesh roughly every 10 minutes.
- [ ] Manual: try to set rebroadcast interval = 5 minutes in the UI — should be rejected client-side.
- [ ] Manual: `curl -X POST .../waypoints -d '{"rebroadcast_interval_s": 300, ...}'` — should 400.
- [ ] Manual: create N>1 eligible waypoints; confirm at most one goes out per minute and rotation is fair (oldest-first).
- [ ] Manual: disconnect the source manager, mark a waypoint eligible — confirm `lastBroadcastAt` is NOT stamped while disconnected, then is stamped once the manager reconnects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)