### PR TITLE
chore(release): bump version to 4.3.1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.3.0",
+  "version": "4.3.1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.3.0
-appVersion: "4.3.0"
+version: 4.3.1
+appVersion: "4.3.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Patch release 4.3.1 — version bumps for `package.json`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, and `helm/meshmonitor/Chart.yaml` (chart + appVersion).

15 commits land since v4.3.0:

**Features**
- #2974 feat(waypoints): scheduled rebroadcast with global airtime floor
- #2960 feat(dashboard): "More..." entry in Add Widget menu with telemetry help

**Fixes**
- 073aa8b2 fix(firmware): harden OTA update — timeouts, cancel guard, async orchestration, retry widening, half-flash detection
- #2956 fix: don't record 0-hop telemetry when hop_start is unset
- #2953 fix(channels): expose PSK to authorized writers so config UI works

**Dependencies**
- protobufjs 8.0.3 → 8.2.0 (#2968)
- archiver 7.0.1 → 8.0.0 (#2964)
- react-router-dom 7.14.2 → 7.15.0 (#2967)
- i18next-http-backend 3.0.6 → 4.0.0 (#2970)
- vite-plugin-pwa 1.2.0 → 1.3.0 (#2969)
- puppeteer 24.42.0 → 24.43.0 (#2965)
- @eslint/compat 2.0.5 → 2.1.0 (#2966)
- production-dependencies group, 7 updates (#2963)
- @types/node (#2961)

## Test plan

- [ ] CI green
- [ ] Helm chart renders with new appVersion
- [ ] Desktop build picks up 4.3.1
- [ ] Tag v4.3.1 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)