### PR TITLE
fix(lxc): align LXC template Node version with runtime (fixes #2977)

### DIFF
--- a/.github/workflows/lxc-template-build.yml
+++ b/.github/workflows/lxc-template-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/lxc/build-lxc-template.sh
+++ b/lxc/build-lxc-template.sh
@@ -186,6 +186,9 @@ cp -r "$PROJECT_ROOT/protobufs" "$ROOTFS_DIR/opt/meshmonitor/"
 cp "$PROJECT_ROOT/package.json" "$ROOTFS_DIR/opt/meshmonitor/"
 cp "$PROJECT_ROOT/package-lock.json" "$ROOTFS_DIR/opt/meshmonitor/"
 
+echo "Rebuilding native modules against container Node.js..."
+chroot "$ROOTFS_DIR" bash -c "cd /opt/meshmonitor && npm rebuild better-sqlite3 --build-from-source"
+
 # Copy Docker helper scripts (apprise-api.py and others)
 mkdir -p "$ROOTFS_DIR/opt/meshmonitor/docker"
 cp "$PROJECT_ROOT/docker/apprise-api.py" "$ROOTFS_DIR/opt/meshmonitor/docker/"


### PR DESCRIPTION
## Summary
LXC template was shipping `better-sqlite3` compiled against Node 22 while the container runtime is Node 24, causing `NODE_MODULE_VERSION 127 vs 137` and an immediate crash on `systemctl start meshmonitor`.

## Changes
- `lxc-template-build.yml`: pin CI to Node 24 to match the container runtime.
- `build-lxc-template.sh`: defensively `npm rebuild better-sqlite3 --build-from-source` inside the chroot after copying `node_modules`, so a future Node version skew won't silently ship a broken template.

## Test plan
- [ ] LXC template builds successfully in CI on the PR.
- [ ] Resulting template starts cleanly: `systemctl start meshmonitor` -> `active (running)`, no `NODE_MODULE_VERSION` errors in `journalctl -u meshmonitor`.
- [ ] `/data/meshmonitor.db` is created and writable.

Fixes #2977