### PR TITLE
refactor: gate audit cleanup with requireAdmin instead of redundant inner check

### DIFF
--- a/src/server/routes/auditRoutes.ts
+++ b/src/server/routes/auditRoutes.ts
@@ -5,7 +5,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { requirePermission } from '../auth/authMiddleware.js';
+import { requirePermission, requireAdmin } from '../auth/authMiddleware.js';
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 
@@ -121,15 +121,8 @@ router.get('/:id', async (req: Request, res: Response) => {
 });
 
 // Cleanup old audit logs (admin only)
-router.post('/cleanup', requirePermission('audit', 'write'), async (req: Request, res: Response) => {
+router.post('/cleanup', requireAdmin(), async (req: Request, res: Response) => {
   try {
-    // Require admin for cleanup operations
-    if (!req.user?.isAdmin) {
-      return res.status(403).json({
-        error: 'Admin privileges required for audit log cleanup'
-      });
-    }
-
     const { days } = req.body;
 
     if (!days || typeof days !== 'number' || days < 1) {


### PR DESCRIPTION
## Summary

`POST /api/audit/cleanup` was guarded by `requirePermission('audit', 'write')` as route middleware, then re-checked `req.user?.isAdmin` inside the handler and returned 403 if the user wasn't admin. Two problems:

- **Inconsistent**: granting a user `audit:write` looked like it should let them call cleanup, but the inner check silently overrode that and 403'd them anyway.
- **Redundant**: two layers expressing different intents for the same endpoint.

This PR replaces the middleware with `requireAdmin()` and removes the inner `isAdmin` check, so the admin requirement is explicit and enforced in exactly one place at the middleware layer.

## Scope

- **Phase 0.5** of the remediation plan.
- Addresses audit finding **FINDING-6** (severity **LOW**) from `audit-permissions.md`.
- Only the `/cleanup` route is touched; all other audit routes are unchanged.

## Changes

- `src/server/routes/auditRoutes.ts`:
  - Import `requireAdmin` alongside `requirePermission` from `auth/authMiddleware`.
  - `router.post('/cleanup', requirePermission('audit', 'write'), …)` -> `router.post('/cleanup', requireAdmin(), …)`.
  - Delete the inner `if (!req.user?.isAdmin)` 403 block.

Net diff: +2 / -9, single file.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] CI lint + typecheck + tests
- [ ] Manual: non-admin with `audit:write` hits `/api/audit/cleanup` -> 403 (now from `requireAdmin`, was from inner check)
- [ ] Manual: admin hits `/api/audit/cleanup` -> success path unchanged