### PR TITLE
fix(security): gate /api/traceroutes/history with traceroute:read

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3891,7 +3891,7 @@ apiRouter.get('/traceroutes/recent', async (req, res) => {
 });
 
 // Get traceroute history for a specific source-destination pair
-apiRouter.get('/traceroutes/history/:fromNodeNum/:toNodeNum', async (req, res) => {
+apiRouter.get('/traceroutes/history/:fromNodeNum/:toNodeNum', requirePermission('traceroute', 'read', { sourceIdFrom: 'query' }), async (req, res) => {
   try {
     const fromNodeNum = parseInt(req.params.fromNodeNum);
     const toNodeNum = parseInt(req.params.toNodeNum);


### PR DESCRIPTION
## Summary

`GET /api/traceroutes/history/:fromNodeNum/:toNodeNum` had no auth middleware. Anyone could enumerate full traceroute history between any two nodes — route hop sequences, SNR, timestamps, relay metadata. `traceroute` is a `SOURCEY_RESOURCES` member and is supposed to require `traceroute:read`.

This PR gates the route with `requirePermission('traceroute', 'read', { sourceIdFrom: 'query' })`.

**Severity:** HIGH
**Audit:** FINDING-3 in `audit-permissions.md`
**Phase:** 0.1 of unified remediation plan

## Test plan
- [ ] Unauthenticated request returns 401/403
- [ ] Authenticated user without traceroute:read returns 403
- [ ] Authenticated user with traceroute:read on relevant source returns 200
- [ ] CI lint + typecheck + tests pass