### PR TITLE
fix(security): block message search when user has zero channel permissions

### DIFF
--- a/src/server/routes/messageRoutes.ts
+++ b/src/server/routes/messageRoutes.ts
@@ -177,6 +177,14 @@ router.get('/search', async (req: Request, res: Response) => {
         }
       }
 
+      // Security: if a non-admin user has no accessible channels, the empty
+      // filter array would be ignored by the repository layer and ALL messages
+      // would be returned. Short-circuit to an empty result set instead.
+      // See FINDING-2 (Phase 0.2 remediation).
+      if (!isAdmin && effectiveChannelFilter !== undefined && effectiveChannelFilter.length === 0) {
+        return res.json({ success: true, count: 0, total: 0, data: [] });
+      }
+
       const searchResult = await databaseService.searchMessagesAsync({
         query: searchQuery,
         caseSensitive: isCaseSensitive,
@@ -200,7 +208,7 @@ router.get('/search', async (req: Request, res: Response) => {
 
     // Search MeshCore messages (in-memory filter)
     if ((searchScope === 'all' || searchScope === 'meshcore') && meshcoreManager.isConnected()) {
-      const hasMeshcoreAccess = isAdmin || (accessibleChannels === null);
+      const hasMeshcoreAccess = isAdmin || (accessibleChannels !== null && accessibleChannels.has(-1));
 
       if (hasMeshcoreAccess) {
         const allMeshcoreMessages = meshcoreManager.getRecentMessages(1000);


### PR DESCRIPTION
## Summary

In `GET /api/messages/search`, a non-admin user with no accessible channels produced an empty `effectiveChannelFilter` array. The repository layer (messages.ts:828) skips the `inArray` filter when `channels.length === 0`, so the DB returned messages from **all** channels — a full bypass of channel permission gating.

Fix:
1. Short-circuit to an empty result when `effectiveChannelFilter === []` for a non-admin caller.
2. Correct `hasMeshcoreAccess` from `(accessibleChannels === null)` to `isAdmin || (accessibleChannels !== null && accessibleChannels.has(-1))` so it reflects "has DM access" rather than "no permission set."

**Severity:** HIGH
**Audit:** FINDING-2 in `audit-permissions.md`
**Phase:** 0.2 of unified remediation plan

## Test plan
- [ ] Anonymous user with no grants → search returns empty
- [ ] User with channel_2 grant only → search returns channel 2 only
- [ ] Admin → unaffected
- [ ] DM-only user → MeshCore branch executes
- [ ] CI green