### PR TITLE
fix(security): gate legacy /api/nodes/security-issues with security:read

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1933,7 +1933,7 @@ apiRouter.post('/nodes/:nodeNum/scan-remote-admin', requirePermission('settings'
 });
 
 // Get nodes with key security issues (low-entropy or duplicate keys)
-apiRouter.get('/nodes/security-issues', optionalAuth(), async (_req, res) => {
+apiRouter.get('/nodes/security-issues', requirePermission('security', 'read'), async (_req, res) => {
   try {
     const nodes = await databaseService.getNodesWithKeySecurityIssuesAsync();
     res.json(nodes);


### PR DESCRIPTION
## Summary

Legacy `GET /api/nodes/security-issues` was protected by `optionalAuth()` only — no permission check. Any unauthenticated caller could enumerate every node flagged with key security issues, including `keyIsLowEntropy`, `duplicateKeyDetected`, `keySecurityIssueDetails`, partial `publicKey`, `packetRatePerHour`, and `timeOffsetSeconds`. The parallel `/api/security/issues` is properly gated; this older path bypassed it.

Apply `requirePermission('security', 'read')` as an interim fix. Full removal in favor of `/api/security/issues` is tracked separately (FINDING-5).

**Severity:** HIGH
**Audit:** FINDING-1 in `audit-permissions.md`
**Phase:** 0.3 of unified remediation plan

## Test plan
- [ ] Anonymous returns 401/403
- [ ] User without security:read returns 403
- [ ] Admin / user with security:read returns 200 with prior payload
- [ ] CI green