### PR TITLE
fix: replace hasPermission non-null assertions with null-safe guards

### DIFF
--- a/src/server/routes/v1/messages.ts
+++ b/src/server/routes/v1/messages.ts
@@ -447,7 +447,7 @@ router.post('/', messageLimiter, async (req: Request, res: Response) => {
     // Permission checks
     if (destinationNum) {
       // Direct message - check messages:write permission
-      if (!req.user?.isAdmin && !await hasPermission(req.user!, 'messages', 'write', msgSourceId)) {
+      if (!req.user?.isAdmin && !(req.user ? await hasPermission(req.user, 'messages', 'write', msgSourceId) : false)) {
         return res.status(403).json({
           success: false,
           error: 'Forbidden',
@@ -459,7 +459,7 @@ router.post('/', messageLimiter, async (req: Request, res: Response) => {
       // Channel message - check per-channel write permission
       const channelNum = parseInt(channel);
       const channelResource = `channel_${channelNum}` as ResourceType;
-      if (!req.user?.isAdmin && !await hasPermission(req.user!, channelResource, 'write', msgSourceId)) {
+      if (!req.user?.isAdmin && !(req.user ? await hasPermission(req.user, channelResource, 'write', msgSourceId) : false)) {
         return res.status(403).json({
           success: false,
           error: 'Forbidden',

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2112,8 +2112,8 @@ apiRouter.post('/nodes/scan-duplicate-keys', requirePermission('nodes', 'write')
 apiRouter.get('/messages', optionalAuth(), async (req, res) => {
   try {
     // Check if user has either any channel permission or messages permission
-    const hasChannelsRead = req.user?.isAdmin || await hasPermission(req.user!, 'channel_0', 'read');
-    const hasMessagesRead = req.user?.isAdmin || await hasPermission(req.user!, 'messages', 'read');
+    const hasChannelsRead = req.user?.isAdmin || (req.user ? await hasPermission(req.user, 'channel_0', 'read') : false);
+    const hasMessagesRead = req.user?.isAdmin || (req.user ? await hasPermission(req.user, 'messages', 'read') : false);
 
     if (!hasChannelsRead && !hasMessagesRead) {
       return res.status(403).json({
@@ -2219,7 +2219,7 @@ apiRouter.get('/messages/channel/:channel', optionalAuth(), async (req, res) => 
 
     // Check per-channel read permission
     const channelResource = `channel_${messageChannel}` as import('../types/permission.js').ResourceType;
-    if (!req.user?.isAdmin && !await hasPermission(req.user!, channelResource, 'read')) {
+    if (!req.user?.isAdmin && !(req.user ? await hasPermission(req.user, channelResource, 'read') : false)) {
       return res.status(403).json({
         error: 'Insufficient permissions',
         code: 'FORBIDDEN',
@@ -2275,7 +2275,7 @@ apiRouter.post('/messages/mark-read', optionalAuth(), async (req, res) => {
     // If marking by channelId, check per-channel read permission
     if (channelId !== undefined && channelId !== null && channelId !== -1) {
       const channelResource = `channel_${channelId}` as import('../types/permission.js').ResourceType;
-      if (!req.user?.isAdmin && !await hasPermission(req.user!, channelResource, 'read')) {
+      if (!req.user?.isAdmin && !(req.user ? await hasPermission(req.user, channelResource, 'read') : false)) {
         return res.status(403).json({
           error: 'Insufficient permissions',
           code: 'FORBIDDEN',
@@ -2286,7 +2286,7 @@ apiRouter.post('/messages/mark-read', optionalAuth(), async (req, res) => {
 
     // If marking by nodeId (DMs) or allDMs, check messages permission
     if ((nodeId && channelId === -1) || allDMs) {
-      const hasMessagesRead = req.user?.isAdmin || await hasPermission(req.user!, 'messages', 'read');
+      const hasMessagesRead = req.user?.isAdmin || (req.user ? await hasPermission(req.user, 'messages', 'read') : false);
       if (!hasMessagesRead) {
         return res.status(403).json({
           error: 'Insufficient permissions',
@@ -2335,8 +2335,8 @@ apiRouter.post('/messages/mark-read', optionalAuth(), async (req, res) => {
 apiRouter.get('/messages/unread-counts', optionalAuth(), async (req, res) => {
   try {
     // Check if user has either any channel permission or messages permission
-    const hasChannelsRead = req.user?.isAdmin || await hasPermission(req.user!, 'channel_0', 'read');
-    const hasMessagesRead = req.user?.isAdmin || await hasPermission(req.user!, 'messages', 'read');
+    const hasChannelsRead = req.user?.isAdmin || (req.user ? await hasPermission(req.user, 'channel_0', 'read') : false);
+    const hasMessagesRead = req.user?.isAdmin || (req.user ? await hasPermission(req.user, 'messages', 'read') : false);
 
     if (!hasChannelsRead && !hasMessagesRead) {
       return res.status(403).json({
@@ -3524,7 +3524,7 @@ apiRouter.post('/messages/send', optionalAuth(), async (req, res) => {
     // Check permissions based on whether this is a DM or channel message
     if (destinationNum) {
       // Direct message - check 'messages' write permission
-      if (!req.user?.isAdmin && !await hasPermission(req.user!, 'messages', 'write')) {
+      if (!req.user?.isAdmin && !(req.user ? await hasPermission(req.user, 'messages', 'write') : false)) {
         return res.status(403).json({
           error: 'Insufficient permissions',
           code: 'FORBIDDEN',
@@ -3534,7 +3534,7 @@ apiRouter.post('/messages/send', optionalAuth(), async (req, res) => {
     } else {
       // Channel message - check per-channel write permission
       const channelResource = `channel_${meshChannel}` as import('../types/permission.js').ResourceType;
-      if (!req.user?.isAdmin && !await hasPermission(req.user!, channelResource, 'write')) {
+      if (!req.user?.isAdmin && !(req.user ? await hasPermission(req.user, channelResource, 'write') : false)) {
         return res.status(403).json({
           error: 'Insufficient permissions',
           code: 'FORBIDDEN',
@@ -4126,8 +4126,8 @@ apiRouter.get('/telemetry/:nodeId', optionalAuth(), async (req, res) => {
     // Allow users with info read OR dashboard read (dashboard needs telemetry data)
     if (
       !req.user?.isAdmin &&
-      !await hasPermission(req.user!, 'info', 'read') &&
-      !await hasPermission(req.user!, 'dashboard', 'read')
+      !(req.user ? await hasPermission(req.user, 'info', 'read') : false) &&
+      !(req.user ? await hasPermission(req.user, 'dashboard', 'read') : false)
     ) {
       return res.status(403).json({ error: 'Insufficient permissions' });
     }
@@ -4185,8 +4185,8 @@ apiRouter.get('/telemetry/:nodeId/rates', optionalAuth(), async (req, res) => {
     // Allow users with info read OR dashboard read
     if (
       !req.user?.isAdmin &&
-      !await hasPermission(req.user!, 'info', 'read') &&
-      !await hasPermission(req.user!, 'dashboard', 'read')
+      !(req.user ? await hasPermission(req.user, 'info', 'read') : false) &&
+      !(req.user ? await hasPermission(req.user, 'dashboard', 'read') : false)
     ) {
       return res.status(403).json({ error: 'Insufficient permissions' });
     }
@@ -4266,8 +4266,8 @@ apiRouter.get('/telemetry/:nodeId/smarthops', optionalAuth(), async (req, res) =
     // Allow users with info read OR dashboard read
     if (
       !req.user?.isAdmin &&
-      !await hasPermission(req.user!, 'info', 'read') &&
-      !await hasPermission(req.user!, 'dashboard', 'read')
+      !(req.user ? await hasPermission(req.user, 'info', 'read') : false) &&
+      !(req.user ? await hasPermission(req.user, 'dashboard', 'read') : false)
     ) {
       return res.status(403).json({ error: 'Insufficient permissions' });
     }
@@ -4302,8 +4302,8 @@ apiRouter.get('/telemetry/:nodeId/linkquality', optionalAuth(), async (req, res)
     // Allow users with info read OR dashboard read
     if (
       !req.user?.isAdmin &&
-      !await hasPermission(req.user!, 'info', 'read') &&
-      !await hasPermission(req.user!, 'dashboard', 'read')
+      !(req.user ? await hasPermission(req.user, 'info', 'read') : false) &&
+      !(req.user ? await hasPermission(req.user, 'dashboard', 'read') : false)
     ) {
       return res.status(403).json({ error: 'Insufficient permissions' });
     }
@@ -4823,7 +4823,7 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
 
     // 8. Device config (requires configuration:read permission)
     try {
-      const hasConfigRead = req.user?.isAdmin || await hasPermission(req.user!, 'configuration', 'read');
+      const hasConfigRead = req.user?.isAdmin || (req.user ? await hasPermission(req.user, 'configuration', 'read') : false);
       if (hasConfigRead) {
         const config = await activeManager.getDeviceConfig();
         if (config) {


### PR DESCRIPTION
## Summary

After `optionalAuth()` runs, `req.user` may legitimately be `undefined` when the anonymous DB user record does not exist. Inline handlers across `server.ts` and `routes/v1/messages.ts` called `hasPermission(req.user!, ...)` with the non-null assertion. The `!` suppressed the TS error but caused a runtime `TypeError` when `hasPermission` accessed `user.isAdmin`. Anonymous users without a DB record received 500s instead of 403s.

Replace every `hasPermission(req.user!, …)` with `req.user ? await hasPermission(req.user, …) : false`. 18 sites in `server.ts` and 2 in `routes/v1/messages.ts` (the latter discovered via grep beyond the lines flagged in the audit).

**Severity:** LOW (no security bypass, but wrong response codes and log noise)
**Audit:** FINDING-8 in `audit-permissions.md`
**Phase:** 0.4 of unified remediation plan

## Test plan
- [ ] CI typecheck/lint pass
- [ ] Existing permission tests still pass
- [ ] Anonymous request to a hasPermission-checked route now returns 403 (not 500) when anonymous DB user is absent