### PR TITLE
fix(security): allowlist tables and validate column names in SQLite restore

### DIFF
--- a/src/server/services/systemRestoreService.test.ts
+++ b/src/server/services/systemRestoreService.test.ts
@@ -48,9 +48,15 @@ const mockBackupService = vi.hoisted(() => ({
   getBackupMetadata: vi.fn(),
 }));
 
-vi.mock('./systemBackupService.js', () => ({
-  systemBackupService: mockBackupService,
-}));
+vi.mock('./systemBackupService.js', async () => {
+  const actual = await vi.importActual<typeof import('./systemBackupService.js')>(
+    './systemBackupService.js'
+  );
+  return {
+    systemBackupService: mockBackupService,
+    BACKUP_TABLES: actual.BACKUP_TABLES,
+  };
+});
 
 // ─── getDatabaseConfig mock ───────────────────────────────────────────────────
 

--- a/src/server/services/systemRestoreService.ts
+++ b/src/server/services/systemRestoreService.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { logger } from '../../utils/logger.js';
 import databaseService from '../../services/database.js';
-import { systemBackupService } from './systemBackupService.js';
+import { systemBackupService, BACKUP_TABLES } from './systemBackupService.js';
 import { getDatabaseConfig } from '../../db/index.js';
 import { Pool } from 'pg';
 import mysql from 'mysql2/promise';
@@ -350,9 +350,20 @@ class SystemRestoreService {
     let totalRowsRestored = 0;
     let tablesRestored = 0;
 
+    // Allowlist of tables that can be restored. Table names from a backup's
+    // metadata.json are otherwise interpolated directly into SQL, so a crafted
+    // backup could inject arbitrary statements. See SQL/Drizzle audit MEDIUM-3.
+    const allowedTables = new Set<string>(BACKUP_TABLES);
+    const identifierPattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
     const transaction = db.transaction(() => {
       for (const tableName of tables) {
         try {
+          if (!allowedTables.has(tableName)) {
+            logger.warn(`⚠️  Skipping table not in backup allowlist: ${tableName}`);
+            continue;
+          }
+
           const tableFile = path.join(backupPath, `${tableName}.json`);
 
           if (!fs.existsSync(tableFile)) {
@@ -368,6 +379,15 @@ class SystemRestoreService {
           // Insert backup data
           if (data.length > 0) {
             const columns = Object.keys(data[0]);
+            // Column names are interpolated into the INSERT statement, so
+            // reject anything that isn't a plain SQL identifier.
+            for (const col of columns) {
+              if (!identifierPattern.test(col)) {
+                throw new Error(
+                  `Invalid column name in backup for table ${tableName}: ${col}`
+                );
+              }
+            }
             const placeholders = columns.map(() => '?').join(', ');
             const stmt = db.prepare(
               `INSERT INTO ${tableName} (${columns.join(', ')}) VALUES (${placeholders})`


### PR DESCRIPTION
## Summary

The SQLite path of `SystemRestoreService` interpolated both table names and column names directly into raw SQL. \`tableName\` was read from a backup's \`metadata.json\` and \`columns\` was \`Object.keys(data[0])\` on the per-table JSON file — neither was validated. A crafted backup directory could inject arbitrary SQL via either identifier. The Postgres restore path already quoted identifiers.

Guards added:
1. Skip any table not in the `BACKUP_TABLES` allowlist (imported from `systemBackupService`).
2. Reject column names that do not match `/^[a-zA-Z_][a-zA-Z0-9_]*$/`.

**Severity:** MEDIUM
**Audit:** MEDIUM-3 in `audit-sql-drizzle.md`
**Phase:** 0.6 of unified remediation plan

## Test plan
- [ ] Normal restore from a valid backup succeeds
- [ ] Restore with a fabricated unknown table in metadata.json skips it and logs a warning
- [ ] Restore where a column key contains invalid chars throws and aborts
- [ ] CI green