### PR TITLE
fix(auth): mount optionalAuth() in front of permission-gated router groups

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -823,16 +823,16 @@ apiRouter.use('/mfa', mfaRoutes);
 apiRouter.use('/v1', v1Router);
 
 // User management routes (admin only)
-apiRouter.use('/users', userRoutes);
+apiRouter.use('/users', optionalAuth(), userRoutes);
 
 // Audit log routes (admin only)
-apiRouter.use('/audit', auditRoutes);
+apiRouter.use('/audit', optionalAuth(), auditRoutes);
 
 // Channel database routes (admin only, session-based)
-apiRouter.use('/channel-database', channelDatabaseRoutes);
+apiRouter.use('/channel-database', optionalAuth(), channelDatabaseRoutes);
 
 // Security routes (requires security:read)
-apiRouter.use('/security', securityRoutes);
+apiRouter.use('/security', optionalAuth(), securityRoutes);
 
 // Packet log routes (requires channels:read AND messages:read)
 apiRouter.use('/packets', optionalAuth(), packetRoutes);


### PR DESCRIPTION
## Summary

The `/users`, `/audit`, `/channel-database`, and `/security` routers all gate their handlers with `requirePermission()` or `requireAdmin()`. Both of those middlewares look up the caller via `req.session.userId` only — they do not read proxy auth headers directly. Proxy auth establishes the session via `optionalAuth()`, but the four router groups above were mounted without an `optionalAuth()` prefix.

Result: a proxy-authenticated user's first request to any of these routes hit the inner gate before the session was established. The middleware saw no `req.session.userId`, fell back to the anonymous user, and either denied access silently or applied the wrong permission set.

Adds `optionalAuth()` in front of each mount — matches the pattern already used for `/packets` and `/solar` immediately below.

**Severity:** MEDIUM
**Audit:** FINDING-4 in `audit-permissions.md`
**Phase:** 1.1 of unified remediation plan (unblocks future source-scoped MeshCore route work, but no MeshCore changes in this PR)

## Test plan
- [ ] Proxy-auth user first request to `/api/users/me` resolves to the proxy identity (not anonymous fallback)
- [ ] Proxy-auth user first request to `/api/security/issues` resolves to proxy identity
- [ ] Anonymous user still denied where they were denied before
- [ ] Session-cookie auth unchanged
- [ ] CI green