### PR TITLE
fix(sourcey): scope telemetry types and localNodeNum by sourceId in /telemetry/available/nodes

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4367,7 +4367,7 @@ apiRouter.get('/telemetry/available/nodes', requirePermission('info', 'read'), a
     const estimatedPositionTypes = new Set(['estimated_latitude', 'estimated_longitude']);
 
     // Efficient bulk query: get all telemetry types for all nodes at once
-    const nodeTelemetryTypes = await databaseService.getAllNodesTelemetryTypesAsync();
+    const nodeTelemetryTypes = await databaseService.getAllNodesTelemetryTypesAsync(telAvailSourceId);
 
     nodes.forEach(node => {
       const telemetryTypes = nodeTelemetryTypes.get(node.nodeId);
@@ -4395,8 +4395,13 @@ apiRouter.get('/telemetry/available/nodes', requirePermission('info', 'read'), a
     // Check for PKC-enabled nodes
     const nodesWithPKC: string[] = [];
 
-    // Get the local node ID to ensure it's always marked as secure
-    const localNodeNumStr = await databaseService.settings.getSetting('localNodeNum');
+    // Get the local node ID to ensure it's always marked as secure.
+    // Read per-source so multi-source deployments don't always show the first
+    // source's local node as "secure local node" for every source view.
+    const localNodeNumStr = await databaseService.settings.getSettingForSource(
+      telAvailSourceId ?? null,
+      'localNodeNum'
+    );
     let localNodeId: string | null = null;
     if (localNodeNumStr) {
       const localNodeNum = parseInt(localNodeNumStr, 10);

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -263,9 +263,13 @@ class DatabaseService {
 
 
   // Cache for telemetry types per node (expensive GROUP BY query)
-  private telemetryTypesCache: Map<string, string[]> | null = null;
-  private telemetryTypesCacheTime: number = 0;
+  // Keyed by sourceId (or '__global__' when called without a source filter)
+  private telemetryTypesCacheBySource: Map<
+    string,
+    { map: Map<string, string[]>; time: number }
+  > = new Map();
   private static readonly TELEMETRY_TYPES_CACHE_TTL_MS = 60000; // 60 seconds
+  private static readonly TELEMETRY_TYPES_CACHE_GLOBAL_KEY = '__global__';
 
   // Drizzle ORM database and repositories (for async operations and PostgreSQL/MySQL support)
   private drizzleDatabase: Database | null = null;
@@ -6055,71 +6059,61 @@ class DatabaseService {
 
   // Get all nodes with their telemetry types (cached for performance)
   // This query can be slow with large telemetry tables, so results are cached
-  getAllNodesTelemetryTypes(): Map<string, string[]> {
+  getAllNodesTelemetryTypes(sourceId?: string): Map<string, string[]> {
     const now = Date.now();
+    const cacheKey = sourceId ?? DatabaseService.TELEMETRY_TYPES_CACHE_GLOBAL_KEY;
+    const cached = this.telemetryTypesCacheBySource.get(cacheKey);
 
     // Return cached result if still valid
-    if (
-      this.telemetryTypesCache !== null &&
-      now - this.telemetryTypesCacheTime < DatabaseService.TELEMETRY_TYPES_CACHE_TTL_MS
-    ) {
-      return this.telemetryTypesCache;
+    if (cached && now - cached.time < DatabaseService.TELEMETRY_TYPES_CACHE_TTL_MS) {
+      return cached.map;
     }
 
     // For PostgreSQL/MySQL, use async query and cache
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (this.telemetryRepo) {
         // Fire async query and update cache in background
-        this.telemetryRepo.getAllNodesTelemetryTypes().then(map => {
-          this.telemetryTypesCache = map;
-          this.telemetryTypesCacheTime = Date.now();
+        this.telemetryRepo.getAllNodesTelemetryTypes(sourceId).then(map => {
+          this.telemetryTypesCacheBySource.set(cacheKey, { map, time: Date.now() });
         }).catch(err => logger.debug('Failed to fetch telemetry types:', err));
       }
       // Return existing cache or empty map
-      return this.telemetryTypesCache || new Map();
+      return cached?.map ?? new Map();
     }
 
     // SQLite: query the database and update cache
     const map = this.telemetry.getAllNodesTelemetryTypesSync();
-
-    this.telemetryTypesCache = map;
-    this.telemetryTypesCacheTime = now;
-
+    this.telemetryTypesCacheBySource.set(cacheKey, { map, time: now });
     return map;
   }
 
   // Get all nodes with their telemetry types (async version)
-  async getAllNodesTelemetryTypesAsync(): Promise<Map<string, string[]>> {
+  async getAllNodesTelemetryTypesAsync(sourceId?: string): Promise<Map<string, string[]>> {
     const now = Date.now();
+    const cacheKey = sourceId ?? DatabaseService.TELEMETRY_TYPES_CACHE_GLOBAL_KEY;
+    const cached = this.telemetryTypesCacheBySource.get(cacheKey);
 
     // Return cached result if still valid
-    if (
-      this.telemetryTypesCache !== null &&
-      now - this.telemetryTypesCacheTime < DatabaseService.TELEMETRY_TYPES_CACHE_TTL_MS
-    ) {
-      return this.telemetryTypesCache;
+    if (cached && now - cached.time < DatabaseService.TELEMETRY_TYPES_CACHE_TTL_MS) {
+      return cached.map;
     }
 
     // For PostgreSQL/MySQL, use async repository
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      const map = await this.telemetry.getAllNodesTelemetryTypes();
-      this.telemetryTypesCache = map;
-      this.telemetryTypesCacheTime = Date.now();
+      const map = await this.telemetry.getAllNodesTelemetryTypes(sourceId);
+      this.telemetryTypesCacheBySource.set(cacheKey, { map, time: Date.now() });
       return map;
     }
 
     // SQLite: query the database and update cache
     const map = this.telemetry.getAllNodesTelemetryTypesSync();
-
-    this.telemetryTypesCache = map;
-    this.telemetryTypesCacheTime = now;
-
+    this.telemetryTypesCacheBySource.set(cacheKey, { map, time: now });
     return map;
   }
 
   // Invalidate the telemetry types cache (call when new telemetry is inserted)
   invalidateTelemetryTypesCache(): void {
-    this.telemetryTypesCacheTime = 0;
+    this.telemetryTypesCacheBySource.clear();
   }
 
   // Danger zone operations


### PR DESCRIPTION
## Summary

`/api/telemetry/available/nodes` correctly scoped its node list by `?sourceId=`, but two downstream lookups silently ignored that source:

1. **`getAllNodesTelemetryTypesAsync()`** was called without `sourceId`, so it returned the global telemetry-type map. A node from source A with telemetry would appear to have telemetry while viewing source B.
2. **`settings.getSetting('localNodeNum')`** read the global key. The settings layer supports per-source keys via `getSettingForSource()`, but this call used the global accessor — so the first source's local node was always tagged "secure local node" regardless of which source was being inspected.

Changes:
- Thread `sourceId` through `DatabaseService.getAllNodesTelemetryTypes` / `getAllNodesTelemetryTypesAsync`. The cache is reworked from a single global slot into a `Map` keyed by sourceId (or `'__global__'` when none). `invalidateTelemetryTypesCache()` now clears all source entries on bulk-purge.
- Endpoint now passes `telAvailSourceId` to both `getAllNodesTelemetryTypesAsync()` and the `localNodeNum` read (`getSettingForSource()`).

**Severity:** MEDIUM (×2)
**Audit:** Sourcey GAP-M2, GAP-M3
**Phase:** 5.1 + 5.2 of unified remediation plan

## Out of scope (deferred to its own PR)

Phase 5.3 / GAP-M4 (`purgeAllNodes` / `purgeAllTelemetry` source scoping) was originally bundled here but is bigger than the plan estimated — it requires threading `sourceId` through ~12 `deleteAll*` repo methods plus their SQLite sync variants. It will land as its own follow-up.

## Test plan
- [ ] Multi-source: view source A → telemetry badges reflect only source A's nodes
- [ ] Multi-source: view source B → telemetry badges reflect only source B's nodes
- [ ] Multi-source: PKC "secure local node" badge matches the source being viewed
- [ ] Single-source (`?sourceId=` omitted): behavior unchanged
- [ ] Cache TTL still honored per source
- [ ] CI green