### PR TITLE
chore(eslint): close `const db = …; db.prepare()` escape hatch in no-restricted-syntax

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,6 +72,16 @@ export default [
           message: "Raw SQL forbidden outside src/server/migrations/. Use Drizzle repository in src/db/repositories/. For intentional raw (bootstrap/diagnostic), add eslint-disable-next-line with reason.",
         },
         {
+          // Catches `const db = databaseService.db; db.prepare(...)` — the
+          // local-variable escape hatch around the two selectors above.
+          selector: "CallExpression[callee.object.name='db'][callee.property.name='prepare']",
+          message: "Raw SQL forbidden outside src/server/migrations/. Use Drizzle repository in src/db/repositories/. For intentional raw (bootstrap/diagnostic), add eslint-disable-next-line with reason.",
+        },
+        {
+          selector: "CallExpression[callee.object.name='db'][callee.property.name='exec']",
+          message: "Raw SQL forbidden outside src/server/migrations/. Use Drizzle repository in src/db/repositories/. For intentional raw (bootstrap/diagnostic), add eslint-disable-next-line with reason.",
+        },
+        {
           selector: "CallExpression[callee.object.property.name='postgresPool'][callee.property.name='query']",
           message: "Raw SQL forbidden outside src/server/migrations/. Use Drizzle repository in src/db/repositories/. For intentional raw (bootstrap/diagnostic), add eslint-disable-next-line with reason.",
         },

--- a/src/server/services/backupFileService.ts
+++ b/src/server/services/backupFileService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(remediation 6.2): migrate SQLite path to Drizzle repository, then remove this disable. */
 /**
  * Backup File Service
  * Handles file system operations for device backups

--- a/src/server/services/systemBackupService.ts
+++ b/src/server/services/systemBackupService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(remediation 6.3): retire generic queryRows/queryOne/executeStatement helpers in favor of typed Drizzle selectors per BACKUP_TABLES, then remove this disable. */
 /**
  * System Backup Service
  * Exports complete database to JSON format for disaster recovery and migration

--- a/src/server/services/systemRestoreService.ts
+++ b/src/server/services/systemRestoreService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- TODO(remediation 6.3): retire raw SQL identifier interpolation in favor of typed Drizzle selectors per BACKUP_TABLES, then remove this disable. */
 /**
  * System Restore Service
  * Restores complete database from JSON backup with migration support


### PR DESCRIPTION
## Summary

The existing `no-restricted-syntax` rule caught `databaseService.db.prepare()` and `this.db.prepare()` via the AST selector `callee.object.property.name='db'`. It missed the common idiom:

\`\`\`ts
const db = databaseService.db;
db.prepare('...');
\`\`\`

The local-variable rewrite makes `callee.object` an `Identifier` instead of a `MemberExpression`, so the existing selector doesn't fire. `backupFileService.ts`, `systemBackupService.ts`, and `systemRestoreService.ts` all bypass the rule this way today.

This PR adds two more selectors (`callee.object.name='db'` for `.prepare` and `.exec`) to close the gap.

To keep CI green without doing the larger Drizzle migration in the same PR, file-level `eslint-disable no-restricted-syntax` directives are added to the three affected services. Each one carries a `TODO` pointing to the corresponding remediation (6.2 for `backupFileService`, 6.3 for `systemBackupService` and `systemRestoreService`). When those migrate to Drizzle, the disables come out.

**Severity:** LOW (governance — current bypassers are LOW injection risk)
**Audit:** SQL/Drizzle LOW-3
**Phase:** 6.1 of unified remediation plan

## Test plan
- [ ] `npm run lint` passes locally
- [ ] CI lint job passes
- [ ] Introducing a new `const db = …; db.prepare('SELECT 1')` outside the disabled files produces the expected ESLint error
- [ ] Existing `databaseService.db.prepare()` violations (if any) still flag