### PR TITLE
fix(firmware): scope OTA gateway IP to active source (#2981)

### DIFF
--- a/src/components/configuration/FirmwareUpdateSection.tsx
+++ b/src/components/configuration/FirmwareUpdateSection.tsx
@@ -117,8 +117,18 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
       hwModel: gatewayNode?.user?.hwModel ?? 0,
       nodeId,
       nodeNum,
+      // Issue #2981: track the active source's type so we can disable OTA on
+      // sources that can't be reached via the OTA CLI's `--host` (BLE, serial,
+      // virtual, mqtt, meshcore). `null` means single-source legacy mode.
+      sourceType: (config?.meshtasticSourceType ?? null) as string | null,
     };
   }, [pollData]);
+
+  // OTA firmware updates require a reachable TCP host. A null sourceType is
+  // legacy single-source mode and trusts MESHTASTIC_NODE_IP.
+  const isOtaSupported =
+    (gatewayInfo.sourceType === null || gatewayInfo.sourceType === 'meshtastic_tcp') &&
+    !!gatewayInfo.gatewayIp;
 
   // Local state
   const [channel, setChannel] = useState<FirmwareChannel>('stable');
@@ -392,6 +402,33 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
     <div id="settings-firmware" className="settings-section" style={{ marginTop: '2rem' }}>
       <h3>{t('firmware.title', 'Firmware Updates')}</h3>
       <p className="setting-description">{t('firmware.description', 'Manage firmware updates for your gateway node.')}</p>
+
+      {/* Issue #2981: surface a clear notice when the active source can't be
+          flashed over IP, instead of silently defaulting to 192.168.1.100. */}
+      {!isOtaSupported && (
+        <div
+          className="setting-item"
+          style={{
+            marginTop: '0.5rem',
+            padding: '0.5rem 0.75rem',
+            border: '1px solid var(--ctp-yellow, #d4a017)',
+            borderRadius: '4px',
+          }}
+        >
+          <span className="setting-description">
+            {gatewayInfo.sourceType && gatewayInfo.sourceType !== 'meshtastic_tcp'
+              ? t(
+                  'firmware.ota_unavailable_non_tcp',
+                  'OTA firmware update is only available for TCP sources. The active source ({{type}}) cannot be flashed from MeshMonitor.',
+                  { type: gatewayInfo.sourceType }
+                )
+              : t(
+                  'firmware.ota_unavailable_no_host',
+                  'No node IP is configured for this source. Configure the TCP host before starting an OTA update.'
+                )}
+          </span>
+        </div>
+      )}
 
       {/* Gateway Info */}
       {gatewayInfo.firmwareVersion && (
@@ -818,6 +855,15 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
                       <button
                         className="save-button"
                         onClick={() => handleInstall(release)}
+                        disabled={!isOtaSupported}
+                        title={
+                          !isOtaSupported
+                            ? t(
+                                'firmware.ota_unavailable_tooltip',
+                                'OTA firmware update requires a TCP source with a configured host.'
+                              )
+                            : undefined
+                        }
                         style={{ padding: '0.25rem 0.75rem', fontSize: '0.85rem' }}
                       >
                         {t('firmware.install', 'Install')}

--- a/src/hooks/usePoll.ts
+++ b/src/hooks/usePoll.ts
@@ -73,6 +73,7 @@ export interface PollConfig {
   meshtasticNodeIp?: string;
   meshtasticTcpPort?: number;
   meshtasticUseTls?: boolean;
+  meshtasticSourceType?: string | null;
   baseUrl?: string;
   deviceMetadata?: {
     firmwareVersion?: string;

--- a/src/server/routes/firmwareUpdateRoutes.test.ts
+++ b/src/server/routes/firmwareUpdateRoutes.test.ts
@@ -121,6 +121,17 @@ vi.mock('../meshtasticManager.js', () => ({
   },
 }));
 
+// Mock environment config — issue #2981 guard reads meshtasticNodeIpProvided
+// to decide whether the gatewayIp argument was explicitly configured by the
+// operator. Tests pass an explicit IP, so flag it as provided.
+vi.mock('../config/environment.js', () => ({
+  getEnvironmentConfig: () => ({
+    meshtasticNodeIp: '192.168.1.100',
+    meshtasticNodeIpProvided: true,
+    meshtasticTcpPort: 4403,
+  }),
+}));
+
 // Mock logger
 vi.mock('../../utils/logger.js', () => ({
   logger: {

--- a/src/server/routes/firmwareUpdateRoutes.ts
+++ b/src/server/routes/firmwareUpdateRoutes.ts
@@ -8,6 +8,7 @@
 import { Router, Request, Response } from 'express';
 import { requireAdmin } from '../auth/authMiddleware.js';
 import { firmwareUpdateService } from '../services/firmwareUpdateService.js';
+import { getEnvironmentConfig } from '../config/environment.js';
 import { logger } from '../../utils/logger.js';
 import path from 'path';
 
@@ -131,6 +132,20 @@ router.post('/update', async (req: Request, res: Response) => {
       return res.status(400).json({
         success: false,
         error: `Release version "${targetVersion}" not found in cached releases. Try checking for updates first.`,
+      });
+    }
+
+    // Issue #2981: refuse to start the wizard when the resolved gateway is the
+    // env default *and* MESHTASTIC_NODE_IP was not explicitly provided. This
+    // is the fallback that used to silently target 192.168.1.100 for non-TCP
+    // or unconfigured sources. We surface it as an explicit error instead.
+    const env = getEnvironmentConfig();
+    if (!env.meshtasticNodeIpProvided && gatewayIp === env.meshtasticNodeIp) {
+      return res.status(400).json({
+        success: false,
+        error:
+          'No node IP configured for this source. OTA firmware update requires ' +
+          'a TCP source with a host configured, or MESHTASTIC_NODE_IP explicitly set.',
       });
     }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4487,6 +4487,65 @@ apiRouter.get('/device/security-keys', requireAdmin(), async (req, res) => {
   }
 });
 
+/**
+ * Resolve the connection host/port for an `/api/poll` or `/api/config` caller
+ * scoped to a particular sourceId. Returns the active source's `config.host`
+ * and `config.port` when the source is `meshtastic_tcp`, the env default when
+ * no sourceId was supplied (legacy single-source callers), and `null` host
+ * when the source is non-TCP (BLE/serial/virtual/MQTT/meshcore) — those
+ * cannot be reached via the OTA CLI's `--host` argument and the firmware UI
+ * must not present them as a flash target. See issue #2981.
+ */
+async function resolveSourceConnectionConfig(
+  sourceId: string | undefined
+): Promise<{
+  host: string | null;
+  port: number | null;
+  sourceType: string | null;
+  isEnvDefault: boolean;
+}> {
+  if (!sourceId) {
+    return {
+      host: env.meshtasticNodeIp,
+      port: env.meshtasticTcpPort,
+      sourceType: null,
+      isEnvDefault: true,
+    };
+  }
+  try {
+    const source = await databaseService.sources.getSource(sourceId);
+    if (!source) {
+      return {
+        host: env.meshtasticNodeIp,
+        port: env.meshtasticTcpPort,
+        sourceType: null,
+        isEnvDefault: true,
+      };
+    }
+    if (source.type === 'meshtastic_tcp') {
+      const cfg = (source.config ?? {}) as { host?: string; port?: number };
+      return {
+        host: cfg.host || null,
+        port: cfg.port ?? env.meshtasticTcpPort,
+        sourceType: source.type,
+        isEnvDefault: false,
+      };
+    }
+    // Non-TCP sources (mqtt, meshcore, BLE/serial via future managers) can't
+    // be flashed over IP — surface a null host so the UI disables OTA rather
+    // than silently shipping the env default.
+    return { host: null, port: null, sourceType: source.type, isEnvDefault: false };
+  } catch (error) {
+    logger.error(`Failed to resolve source connection config for ${sourceId}:`, error);
+    return {
+      host: env.meshtasticNodeIp,
+      port: env.meshtasticTcpPort,
+      sourceType: null,
+      isEnvDefault: true,
+    };
+  }
+}
+
 // Consolidated polling endpoint - reduces multiple API calls to one
 apiRouter.get('/poll', optionalAuth(), async (req, res) => {
   logger.debug('🔔 [POLL] Endpoint called');
@@ -4803,10 +4862,16 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
         shortName: managerNodeInfo.shortName,
       } : undefined;
 
+      // Source-scoped connection config (issue #2981). When the caller passes
+      // a sourceId, return that source's host/port so OTA firmware updates
+      // flash the right node instead of the env default (192.168.1.100).
+      const conn = await resolveSourceConnectionConfig(pollSourceId);
+
       result.config = {
-        ...(req.session.userId ? { meshtasticNodeIp: env.meshtasticNodeIp } : {}),
-        meshtasticTcpPort: env.meshtasticTcpPort,
+        ...(req.session.userId ? { meshtasticNodeIp: conn.host ?? '' } : {}),
+        meshtasticTcpPort: conn.port ?? env.meshtasticTcpPort,
         meshtasticUseTls: false,
+        meshtasticSourceType: conn.sourceType,
         baseUrl: BASE_URL,
         deviceMetadata: deviceMetadata,
         localNodeInfo: pollLocalNodeInfo,
@@ -5050,10 +5115,14 @@ apiRouter.get('/config', optionalAuth(), async (req, res) => {
       }
     }
 
+    // Source-scoped connection config (issue #2981).
+    const conn = await resolveSourceConnectionConfig(configSourceId);
+
     res.json({
-      ...(req.session.userId ? { meshtasticNodeIp: env.meshtasticNodeIp } : {}),
-      meshtasticTcpPort: env.meshtasticTcpPort,
+      ...(req.session.userId ? { meshtasticNodeIp: conn.host ?? '' } : {}),
+      meshtasticTcpPort: conn.port ?? env.meshtasticTcpPort,
       meshtasticUseTls: false, // We're using TCP, not TLS
+      meshtasticSourceType: conn.sourceType,
       baseUrl: BASE_URL,
       deviceMetadata: deviceMetadata,
       localNodeInfo: localNodeInfo,


### PR DESCRIPTION
## Summary

Closes #2981 — firmware update was always sending `192.168.1.100` as `--host` in multi-source deployments because `/api/poll`'s `config.meshtasticNodeIp` returned `env.meshtasticNodeIp` regardless of the active source.

- **Server**: `/api/poll` and `/api/config` now resolve host/port from the active source's config when the source is `meshtastic_tcp`. Non-TCP sources (BLE, serial, virtual, mqtt, meshcore) return `host: null` so the UI can disable OTA cleanly. Also exposes `meshtasticSourceType` for the frontend.
- **Routes**: `/api/firmware/update` refuses to start the wizard when `gatewayIp` matches the env default and `MESHTASTIC_NODE_IP` was not explicitly provided, replacing the silent "flash toward 192.168.1.100" failure mode with a clear error.
- **Frontend**: `FirmwareUpdateSection` disables the Install button and shows an inline notice when the active source can't be flashed over IP (non-TCP, or TCP with no host configured).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run src/server/routes/firmwareUpdateRoutes.test.ts` — 23/23 pass (added env mock for the new preflight guard)
- [x] `npx vitest run src/server/server` — 82 pass, 21 todo, 1 skipped — no regressions
- [ ] Manual: flash a Station G2 from a multi-source deployment where the TCP source host is *not* the env default — confirm preflight shows the correct IP
- [ ] Manual: select a BLE/serial source on the configuration page and confirm the Install button is disabled with the "OTA only available for TCP sources" notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)