### PR TITLE
fix(sourcey): scope purgeAllNodes / purgeAllTelemetry by sourceId

### DIFF
--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -474,16 +474,18 @@ export class MessagesRepository extends BaseRepository {
   }
 
   /**
-   * SQLite-only synchronous wipe of ALL messages.
+   * SQLite-only synchronous wipe of all messages, optionally scoped to a source.
    * Mirrors `deleteAllMessages()` for the sync DatabaseService facade.
    */
-  deleteAllMessagesSqlite(): number {
+  deleteAllMessagesSqlite(sourceId?: string): number {
     if (!this.sqliteDb) {
       throw new Error('deleteAllMessagesSqlite is SQLite-only');
     }
     const db = this.sqliteDb;
     const messages = this.tables.messages;
-    const result = db.delete(messages).run();
+    const result = sourceId
+      ? db.delete(messages).where(eq(messages.sourceId, sourceId)).run()
+      : db.delete(messages).run();
     return Number(result.changes);
   }
 
@@ -744,13 +746,20 @@ export class MessagesRepository extends BaseRepository {
   }
 
   /**
-   * Delete all messages
+   * Delete all messages, optionally scoped to a single source.
    */
-  async deleteAllMessages(): Promise<number> {
+  async deleteAllMessages(sourceId?: string): Promise<number> {
     const { messages } = this.tables;
-    const result = await this.db.select({ count: count() }).from(messages);
+    const countQuery = this.db.select({ count: count() }).from(messages);
+    const result = await (sourceId
+      ? countQuery.where(eq(messages.sourceId, sourceId))
+      : countQuery);
     const total = Number(result[0].count);
-    await this.db.delete(messages);
+    if (sourceId) {
+      await this.db.delete(messages).where(eq(messages.sourceId, sourceId));
+    } else {
+      await this.db.delete(messages);
+    }
     return total;
   }
 

--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -1094,11 +1094,13 @@ export class MiscRepository extends BaseRepository {
   }
 
   /**
-   * Clear all packet logs
+   * Clear all packet logs, optionally scoped to a single source.
    */
-  async clearPacketLogs(): Promise<number> {
+  async clearPacketLogs(sourceId?: string): Promise<number> {
     try {
-      const results = await this.executeRun(sql`DELETE FROM packet_log`);
+      const results = sourceId
+        ? await this.executeRun(sql`DELETE FROM packet_log WHERE sourceId = ${sourceId}`)
+        : await this.executeRun(sql`DELETE FROM packet_log`);
       const deletedCount = this.getAffectedRows(results);
       logger.debug(`[MiscRepository] Cleared ${deletedCount} packet log entries`);
       return deletedCount;
@@ -1260,9 +1262,11 @@ export class MiscRepository extends BaseRepository {
    * Synchronously clear all packet log rows (SQLite only).
    * Returns number of rows deleted.
    */
-  clearPacketLogsSync(): number {
+  clearPacketLogsSync(sourceId?: string): number {
     const db = this.getSqliteDb();
-    const result = db.run(sql`DELETE FROM packet_log`) as any;
+    const result = (sourceId
+      ? db.run(sql`DELETE FROM packet_log WHERE sourceId = ${sourceId}`)
+      : db.run(sql`DELETE FROM packet_log`)) as any;
     const changes = Number(result?.changes ?? 0);
     logger.debug(`[MiscRepository] Cleared ${changes} packet log entries (sync)`);
     return changes;

--- a/src/db/repositories/neighbors.ts
+++ b/src/db/repositories/neighbors.ts
@@ -144,11 +144,15 @@ export class NeighborsRepository extends BaseRepository {
   }
 
   /**
-   * Delete all neighbor info
+   * Delete all neighbor info, optionally scoped to a single source.
    */
-  async deleteAllNeighborInfo(): Promise<void> {
+  async deleteAllNeighborInfo(sourceId?: string): Promise<void> {
     const { neighborInfo } = this.tables;
-    await this.db.delete(neighborInfo);
+    if (sourceId) {
+      await this.db.delete(neighborInfo).where(eq(neighborInfo.sourceId, sourceId));
+    } else {
+      await this.db.delete(neighborInfo);
+    }
   }
 
   /**

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -825,14 +825,19 @@ export class NodesRepository extends BaseRepository {
   }
 
   /**
-   * Delete all nodes
+   * Delete all nodes, optionally scoped to a single source.
    */
-  async deleteAllNodes(): Promise<number> {
+  async deleteAllNodes(sourceId?: string): Promise<number> {
     const { nodes } = this.tables;
-    const result = await this.db
-      .select({ nodeNum: nodes.nodeNum })
-      .from(nodes);
-    await this.db.delete(nodes);
+    const baseSelect = this.db.select({ nodeNum: nodes.nodeNum }).from(nodes);
+    const result = await (sourceId
+      ? baseSelect.where(eq(nodes.sourceId, sourceId))
+      : baseSelect);
+    if (sourceId) {
+      await this.db.delete(nodes).where(eq(nodes.sourceId, sourceId));
+    } else {
+      await this.db.delete(nodes);
+    }
     this.clearCacheAll();
     return result.length;
   }
@@ -1540,13 +1545,18 @@ export class NodesRepository extends BaseRepository {
   }
 
   /**
-   * SQLite-only sync delete all nodes (used by importData / purgeAllNodes).
+   * SQLite-only sync delete all nodes (used by importData / purgeAllNodes),
+   * optionally scoped to a single source.
    */
-  truncateNodesSqlite(): void {
+  truncateNodesSqlite(sourceId?: string): void {
     if (!this.sqliteDb) throw new Error('truncateNodesSqlite is SQLite-only');
     const db = this.sqliteDb;
     const { nodes } = this.tables;
-    db.delete(nodes).run();
+    if (sourceId) {
+      db.delete(nodes).where(eq(nodes.sourceId, sourceId)).run();
+    } else {
+      db.delete(nodes).run();
+    }
   }
 
   /**

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -623,13 +623,20 @@ export class TelemetryRepository extends BaseRepository {
   }
 
   /**
-   * Delete all telemetry
+   * Delete all telemetry, optionally scoped to a single source.
    */
-  async deleteAllTelemetry(): Promise<number> {
+  async deleteAllTelemetry(sourceId?: string): Promise<number> {
     const { telemetry } = this.tables;
-    const result = await this.db.select({ count: count() }).from(telemetry);
+    const countQuery = this.db.select({ count: count() }).from(telemetry);
+    const result = await (sourceId
+      ? countQuery.where(eq(telemetry.sourceId, sourceId))
+      : countQuery);
     const deleteCount = Number(result[0].count);
-    await this.db.delete(telemetry);
+    if (sourceId) {
+      await this.db.delete(telemetry).where(eq(telemetry.sourceId, sourceId));
+    } else {
+      await this.db.delete(telemetry);
+    }
     return deleteCount;
   }
 
@@ -1111,13 +1118,16 @@ export class TelemetryRepository extends BaseRepository {
   }
 
   /**
-   * Synchronously delete all telemetry rows (SQLite only).
+   * Synchronously delete all telemetry rows (SQLite only),
+   * optionally scoped to a single source.
    * Returns the number of rows deleted.
    */
-  deleteAllTelemetrySync(): number {
+  deleteAllTelemetrySync(sourceId?: string): number {
     const db = this.getSqliteDb();
     const { telemetry } = this.tables;
-    const result = db.delete(telemetry).run();
+    const result = sourceId
+      ? db.delete(telemetry).where(eq(telemetry.sourceId, sourceId)).run()
+      : db.delete(telemetry).run();
     return Number((result as any).changes ?? 0);
   }
 

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -365,13 +365,20 @@ export class TraceroutesRepository extends BaseRepository {
   }
 
   /**
-   * Delete all traceroutes
+   * Delete all traceroutes, optionally scoped to a single source.
    */
-  async deleteAllTraceroutes(): Promise<number> {
+  async deleteAllTraceroutes(sourceId?: string): Promise<number> {
     const { traceroutes } = this.tables;
-    const result = await this.db.select({ count: count() }).from(traceroutes);
+    const countQuery = this.db.select({ count: count() }).from(traceroutes);
+    const result = await (sourceId
+      ? countQuery.where(eq(traceroutes.sourceId, sourceId))
+      : countQuery);
     const total = Number(result[0].count);
-    await this.db.delete(traceroutes);
+    if (sourceId) {
+      await this.db.delete(traceroutes).where(eq(traceroutes.sourceId, sourceId));
+    } else {
+      await this.db.delete(traceroutes);
+    }
     return total;
   }
 
@@ -423,10 +430,12 @@ export class TraceroutesRepository extends BaseRepository {
    * Synchronously delete all traceroutes (SQLite only).
    * Returns the number of rows deleted.
    */
-  deleteAllTraceroutesSync(): number {
+  deleteAllTraceroutesSync(sourceId?: string): number {
     const db = this.getSqliteDb();
     const { traceroutes } = this.tables;
-    const result = db.delete(traceroutes).run();
+    const result = sourceId
+      ? db.delete(traceroutes).where(eq(traceroutes.sourceId, sourceId)).run()
+      : db.delete(traceroutes).run();
     return Number((result as any).changes ?? 0);
   }
 
@@ -434,10 +443,12 @@ export class TraceroutesRepository extends BaseRepository {
    * Synchronously delete all route segments (SQLite only).
    * Returns the number of rows deleted.
    */
-  deleteAllRouteSegmentsSync(): number {
+  deleteAllRouteSegmentsSync(sourceId?: string): number {
     const db = this.getSqliteDb();
     const { routeSegments } = this.tables;
-    const result = db.delete(routeSegments).run();
+    const result = sourceId
+      ? db.delete(routeSegments).where(eq(routeSegments.sourceId, sourceId)).run()
+      : db.delete(routeSegments).run();
     return Number((result as any).changes ?? 0);
   }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6398,10 +6398,10 @@ apiRouter.get('/announce/preview', requirePermission('automation', 'read'), asyn
 // Danger zone endpoints
 apiRouter.post('/purge/nodes', requireAdmin(), async (req, res) => {
   try {
-    const nodeCount = await databaseService.nodes.getNodeCount();
-    await databaseService.purgeAllNodesAsync();
-    // Trigger a node refresh after purging
     const { sourceId: purgeNodesSourceId } = req.body || {};
+    const nodeCount = await databaseService.nodes.getNodeCount();
+    await databaseService.purgeAllNodesAsync(purgeNodesSourceId);
+    // Trigger a node refresh after purging (only on the affected source)
     const purgeNodesManager = resolveSourceManager(purgeNodesSourceId);
     await purgeNodesManager.refreshNodeDatabase();
 
@@ -6410,11 +6410,16 @@ apiRouter.post('/purge/nodes', requireAdmin(), async (req, res) => {
       req.user!.id,
       'nodes_purged',
       'nodes',
-      JSON.stringify({ count: nodeCount }),
+      JSON.stringify({ count: nodeCount, sourceId: purgeNodesSourceId ?? null }),
       req.ip || null
     );
 
-    res.json({ success: true, message: 'All nodes and traceroutes purged, refresh triggered' });
+    res.json({
+      success: true,
+      message: purgeNodesSourceId
+        ? `Nodes and traceroutes purged for source ${purgeNodesSourceId}, refresh triggered`
+        : 'All nodes and traceroutes purged, refresh triggered',
+    });
   } catch (error) {
     logger.error('Error purging nodes:', error);
     res.status(500).json({ error: 'Failed to purge nodes' });
@@ -6423,18 +6428,24 @@ apiRouter.post('/purge/nodes', requireAdmin(), async (req, res) => {
 
 apiRouter.post('/purge/telemetry', requireAdmin(), async (req, res) => {
   try {
-    await databaseService.purgeAllTelemetryAsync();
+    const { sourceId: purgeTelemetrySourceId } = req.body || {};
+    await databaseService.purgeAllTelemetryAsync(purgeTelemetrySourceId);
 
     // Audit log
     databaseService.auditLogAsync(
       req.user!.id,
       'telemetry_purged',
       'telemetry',
-      'All telemetry data purged',
+      JSON.stringify({ sourceId: purgeTelemetrySourceId ?? null }),
       req.ip || null
     );
 
-    res.json({ success: true, message: 'All telemetry data purged' });
+    res.json({
+      success: true,
+      message: purgeTelemetrySourceId
+        ? `Telemetry purged for source ${purgeTelemetrySourceId}`
+        : 'All telemetry data purged',
+    });
   } catch (error) {
     logger.error('Error purging telemetry:', error);
     res.status(500).json({ error: 'Failed to purge telemetry' });
@@ -8138,9 +8149,11 @@ apiRouter.post('/device/purge-nodedb', requirePermission('configuration', 'write
     // Purge the device's node database
     await purgeManager.purgeNodeDb(seconds);
 
-    // Also purge the local database
+    // Also purge the local database (scoped to the source we just told the
+    // device to wipe — purging globally on a per-source admin command would
+    // wipe siblings)
     logger.info('🗑️ Purging local node database');
-    await databaseService.purgeAllNodesAsync();
+    await databaseService.purgeAllNodesAsync(purgeSourceId);
     logger.info('✅ Local node database purged successfully');
 
     res.json({

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -6111,23 +6111,44 @@ class DatabaseService {
     return map;
   }
 
-  // Invalidate the telemetry types cache (call when new telemetry is inserted)
-  invalidateTelemetryTypesCache(): void {
-    this.telemetryTypesCacheBySource.clear();
+  // Invalidate the telemetry types cache (call when new telemetry is inserted
+  // or rows are bulk-purged). When sourceId is provided, only that source's
+  // cache slot is cleared (plus the global '__global__' slot, since its
+  // contents are derived from the union of all sources). When omitted, the
+  // whole map is cleared.
+  invalidateTelemetryTypesCache(sourceId?: string): void {
+    if (!sourceId) {
+      this.telemetryTypesCacheBySource.clear();
+      return;
+    }
+    this.telemetryTypesCacheBySource.delete(sourceId);
+    this.telemetryTypesCacheBySource.delete(DatabaseService.TELEMETRY_TYPES_CACHE_GLOBAL_KEY);
   }
 
   // Danger zone operations
-  purgeAllNodes(): void {
-    logger.debug('⚠️ PURGING all nodes and related data from database');
+  // When sourceId is provided, the purge is scoped to that source only; all
+  // child tables receive a WHERE sourceId = ? filter. When omitted, all rows
+  // are deleted (legacy behavior preserved for unscoped callers).
+  purgeAllNodes(sourceId?: string): void {
+    logger.debug(`⚠️ PURGING ${sourceId ? `source ${sourceId}'s ` : 'all '}nodes and related data from database`);
 
     // For PostgreSQL/MySQL, clear cache and fire-and-forget async purge
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      // Clear the nodes cache immediately
-      this.nodesCache.clear();
+      // Clear the nodes cache immediately (scoped clear when sourceId is provided)
+      if (sourceId) {
+        for (const key of Array.from(this.nodesCache.keys())) {
+          const cached = this.nodesCache.get(key);
+          if (cached && (cached as any).sourceId === sourceId) {
+            this.nodesCache.delete(key);
+          }
+        }
+      } else {
+        this.nodesCache.clear();
+      }
 
       // Fire-and-forget async purge
-      this.purgeAllNodesAsync().catch(err => {
-        logger.error('Failed to purge all nodes from database:', err);
+      this.purgeAllNodesAsync(sourceId).catch(err => {
+        logger.error('Failed to purge nodes from database:', err);
       });
 
       logger.debug('✅ Cache cleared, async purge started');
@@ -6138,43 +6159,43 @@ class DatabaseService {
     // Delete in order to respect foreign key constraints
     // First delete all child records that reference nodes
     if (this.messagesRepo) {
-      this.messagesRepo.deleteAllMessagesSqlite();
+      this.messagesRepo.deleteAllMessagesSqlite(sourceId);
     }
-    this.telemetry.deleteAllTelemetrySync();
-    this.traceroutes.deleteAllTraceroutesSync();
-    this.traceroutes.deleteAllRouteSegmentsSync();
+    this.telemetry.deleteAllTelemetrySync(sourceId);
+    this.traceroutes.deleteAllTraceroutesSync(sourceId);
+    this.traceroutes.deleteAllRouteSegmentsSync(sourceId);
     if (this.neighborsRepo) {
       // Use Drizzle repo for all backends (including SQLite)
-      this.neighborsRepo.deleteAllNeighborInfo().catch(err =>
-        logger.debug('Failed to delete all neighbor info:', err)
+      this.neighborsRepo.deleteAllNeighborInfo(sourceId).catch(err =>
+        logger.debug('Failed to delete neighbor info:', err)
       );
     }
     // Clear packet log so Packet Monitor doesn't show ghost entries from purged nodes (issue #2637)
     if (this.miscRepo) {
       try {
-        this.miscRepo.clearPacketLogsSync();
+        this.miscRepo.clearPacketLogsSync(sourceId);
       } catch (err) {
         logger.error('Failed to clear packet logs during purge:', err);
       }
     }
     // Finally delete the nodes themselves
-    this.nodesRepo!.truncateNodesSqlite();
+    this.nodesRepo!.truncateNodesSqlite(sourceId);
     // Telemetry cache invalidation after bulk purge
-    this.invalidateTelemetryTypesCache();
-    logger.debug('✅ Successfully purged all nodes and related data');
+    this.invalidateTelemetryTypesCache(sourceId);
+    logger.debug('✅ Successfully purged nodes and related data');
   }
 
-  purgeAllTelemetry(): void {
-    logger.debug('⚠️ PURGING all telemetry from database');
+  purgeAllTelemetry(sourceId?: string): void {
+    logger.debug(`⚠️ PURGING ${sourceId ? `source ${sourceId}'s ` : 'all '}telemetry from database`);
 
     // For PostgreSQL/MySQL, use async repository
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
       if (this.telemetryRepo) {
-        this.telemetryRepo.deleteAllTelemetry().then(() => {
-          logger.debug('✅ Successfully purged all telemetry');
-          this.invalidateTelemetryTypesCache();
+        this.telemetryRepo.deleteAllTelemetry(sourceId).then(() => {
+          logger.debug('✅ Successfully purged telemetry');
+          this.invalidateTelemetryTypesCache(sourceId);
         }).catch(err => {
-          logger.error('Failed to purge all telemetry:', err);
+          logger.error('Failed to purge telemetry:', err);
         });
       } else {
         logger.warn('Cannot purge telemetry: telemetry repository not initialized');
@@ -6182,8 +6203,8 @@ class DatabaseService {
       return;
     }
 
-    this.telemetry.deleteAllTelemetrySync();
-    this.invalidateTelemetryTypesCache();
+    this.telemetry.deleteAllTelemetrySync(sourceId);
+    this.invalidateTelemetryTypesCache(sourceId);
   }
 
   purgeOldTelemetry(hoursToKeep: number, favoriteDaysToKeep?: number): number {
@@ -6280,21 +6301,21 @@ class DatabaseService {
   }
 
   /**
-   * Purge all telemetry data (async version)
+   * Purge all telemetry data (async version), optionally scoped to one source.
    */
-  async purgeAllTelemetryAsync(): Promise<void> {
-    logger.debug('⚠️ PURGING all telemetry from database');
+  async purgeAllTelemetryAsync(sourceId?: string): Promise<void> {
+    logger.debug(`⚠️ PURGING ${sourceId ? `source ${sourceId}'s ` : 'all '}telemetry from database`);
 
     if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      await this.telemetry.deleteAllTelemetry();
-      this.invalidateTelemetryTypesCache();
-      logger.debug('✅ Successfully purged all telemetry');
+      await this.telemetry.deleteAllTelemetry(sourceId);
+      this.invalidateTelemetryTypesCache(sourceId);
+      logger.debug('✅ Successfully purged telemetry');
       return;
     }
 
-    this.telemetry.deleteAllTelemetrySync();
-    this.invalidateTelemetryTypesCache();
-    logger.debug('✅ Successfully purged all telemetry');
+    this.telemetry.deleteAllTelemetrySync(sourceId);
+    this.invalidateTelemetryTypesCache(sourceId);
+    logger.debug('✅ Successfully purged telemetry');
   }
 
   /**
@@ -6551,46 +6572,56 @@ class DatabaseService {
   }
 
   /**
-   * Purge all nodes and related data (async version for PostgreSQL)
+   * Purge all nodes and related data (async version).
+   * When sourceId is provided, scope to that source only.
    */
-  async purgeAllNodesAsync(): Promise<void> {
-    logger.debug('⚠️ PURGING all nodes and related data from database (async)');
+  async purgeAllNodesAsync(sourceId?: string): Promise<void> {
+    logger.debug(`⚠️ PURGING ${sourceId ? `source ${sourceId}'s ` : 'all '}nodes and related data from database (async)`);
 
     try {
       // Delete in order to respect foreign key constraints
       // First delete all child records that reference nodes
       if (this.messagesRepo) {
-        await this.messagesRepo.deleteAllMessages();
+        await this.messagesRepo.deleteAllMessages(sourceId);
       }
       if (this.telemetryRepo) {
-        await this.telemetryRepo.deleteAllTelemetry();
+        await this.telemetryRepo.deleteAllTelemetry(sourceId);
       }
       if (this.traceroutesRepo) {
-        await this.traceroutesRepo.deleteAllTraceroutes();
-        await this.traceroutesRepo.deleteAllRouteSegments();
+        await this.traceroutesRepo.deleteAllTraceroutes(sourceId);
+        await this.traceroutesRepo.deleteAllRouteSegments(sourceId);
       }
       if (this.neighborsRepo) {
-        await this.neighborsRepo.deleteAllNeighborInfo();
+        await this.neighborsRepo.deleteAllNeighborInfo(sourceId);
       }
       // Clear packet log so Packet Monitor doesn't show ghost entries from purged nodes (issue #2637)
       if (this.miscRepo) {
         try {
-          await this.miscRepo.clearPacketLogs();
+          await this.miscRepo.clearPacketLogs(sourceId);
         } catch (err) {
           logger.error('Failed to clear packet logs during purge:', err);
         }
       }
       // Finally delete the nodes themselves
       if (this.nodesRepo) {
-        await this.nodesRepo.deleteAllNodes();
+        await this.nodesRepo.deleteAllNodes(sourceId);
       }
 
-      // Clear the cache
-      this.nodesCache.clear();
+      // Clear the cache (scoped if a sourceId was provided)
+      if (sourceId) {
+        for (const key of Array.from(this.nodesCache.keys())) {
+          const cached = this.nodesCache.get(key);
+          if (cached && (cached as any).sourceId === sourceId) {
+            this.nodesCache.delete(key);
+          }
+        }
+      } else {
+        this.nodesCache.clear();
+      }
 
-      logger.debug('✅ Successfully purged all nodes and related data (async)');
+      logger.debug('✅ Successfully purged nodes and related data (async)');
     } catch (error) {
-      logger.error('Error purging all nodes:', error);
+      logger.error('Error purging nodes:', error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary

The `/api/purge/nodes` and `/api/purge/telemetry` endpoints already captured `sourceId` from the request body, but only used it for the post-purge node-refresh — the underlying `DatabaseService.purgeAllNodes*` / `purgeAllTelemetry*` calls ignored it and wiped every source. Audit: Sourcey **GAP-M4 (MEDIUM)**.

This PR threads `sourceId` all the way down to the repo `deleteAll*` methods so a per-source purge only touches that source's rows.

### Repo-layer changes

| Repo | Method(s) now `(sourceId?: string)` |
|---|---|
| `messages.ts` | `deleteAllMessages`, `deleteAllMessagesSqlite` |
| `telemetry.ts` | `deleteAllTelemetry`, `deleteAllTelemetrySync` |
| `traceroutes.ts` | `deleteAllTraceroutes`, `deleteAllTraceroutesSync`, `deleteAllRouteSegmentsSync` (the async `deleteAllRouteSegments` already took sourceId — now passed through consistently) |
| `neighbors.ts` | `deleteAllNeighborInfo` |
| `nodes.ts` | `deleteAllNodes`, `truncateNodesSqlite` |
| `misc.ts` | `clearPacketLogs`, `clearPacketLogsSync` |

When `sourceId` is omitted, behavior is unchanged (full-table delete).

### Service-layer changes

- `DatabaseService.purgeAllNodes(sourceId?)` + `purgeAllNodesAsync(sourceId?)` thread through to every repo above.
- `DatabaseService.purgeAllTelemetry(sourceId?)` + `purgeAllTelemetryAsync(sourceId?)` likewise.
- `nodesCache` is scope-cleared (only entries with matching `sourceId`) when a source-scoped purge runs; full-cleared otherwise.
- `invalidateTelemetryTypesCache(sourceId?)` drops only that source's slot (plus the `__global__` derived slot) when scoped, full-clear otherwise.

### Endpoint changes

- `POST /api/purge/nodes` and `POST /api/purge/telemetry` thread `req.body.sourceId` to the service. Audit log captures the scope. Response messages distinguish per-source vs full-wipe.
- `POST /api/device/purge-nodedb` was wiping the entire local DB when an admin's "purge node DB on source X" command succeeded against the device; now scopes the local purge to that source too.

### MeshCore tables — intentionally untouched

`meshcore_nodes` and `meshcore_messages` have no `sourceId` column today (the `feature/meshcore` branch owns the migrations that add it — Phase 2 of the unified plan). They aren't part of the existing purge sequence, so this PR doesn't add new MeshCore plumbing.

**Severity:** MEDIUM
**Audit:** Sourcey GAP-M4
**Phase:** 5.3 of unified remediation plan

## Test plan
- [ ] Single-source deployment: `/api/purge/nodes` with no `sourceId` body still wipes everything (unchanged)
- [ ] Multi-source deployment: `/api/purge/nodes` with `{sourceId: "src-a"}` removes only src-a's nodes/messages/telemetry/traceroutes/neighbors/packet-log/route-segments, leaves src-b untouched
- [ ] Same for `/api/purge/telemetry`
- [ ] Telemetry types cache: viewing `/api/telemetry/available/nodes?sourceId=src-b` after a src-a-scoped purge does NOT show stale src-a telemetry (cache-key cleared)
- [ ] `nodesCache` after scoped purge: src-b nodes still present in cache; src-a removed
- [ ] `/api/device/purge-nodedb` body `{sourceId: "src-a", seconds: 0}` wipes only src-a's local DB
- [ ] CI matrix (SQLite/Postgres/MySQL) green