### PR TITLE
chore: remove legacy /api/nodes/security-issues endpoint

### DIFF
--- a/docs/features/security.md
+++ b/docs/features/security.md
@@ -216,12 +216,17 @@ POST /api/nodes/scan-duplicate-keys
 Retrieve all nodes currently flagged with security issues:
 
 ```bash
-GET /api/nodes/security-issues
+GET /api/security/issues
 ```
 
 **Response**:
 ```json
 {
+  "total": 1,
+  "lowEntropyCount": 1,
+  "duplicateKeyCount": 0,
+  "excessivePacketsCount": 0,
+  "timeOffsetCount": 0,
   "nodes": [
     {
       "nodeNum": 123456789,
@@ -232,7 +237,7 @@ GET /api/nodes/security-issues
       "keySecurityIssueDetails": "Known low-entropy key detected"
     }
   ],
-  "count": 1
+  "topBroadcasters": []
 }
 ```
 
@@ -314,7 +319,7 @@ GET /api/nodes/security-issues
 **Diagnostic Commands**:
 ```bash
 # Get nodes with security issues
-curl http://localhost:8080/api/nodes/security-issues
+curl http://localhost:8080/api/security/issues
 
 # View scanner logs (Docker)
 docker logs meshmonitor 2>&1 | grep "🔐"

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1929,22 +1929,6 @@ apiRouter.post('/nodes/:nodeNum/scan-remote-admin', requirePermission('settings'
   }
 });
 
-// Get nodes with key security issues (low-entropy or duplicate keys)
-apiRouter.get('/nodes/security-issues', requirePermission('security', 'read'), async (_req, res) => {
-  try {
-    const nodes = await databaseService.getNodesWithKeySecurityIssuesAsync();
-    res.json(nodes);
-  } catch (error) {
-    logger.error('Error getting nodes with security issues:', error);
-    const errorResponse: ApiErrorResponse = {
-      error: 'Failed to get nodes with security issues',
-      code: 'INTERNAL_ERROR',
-      details: error instanceof Error ? error.message : 'Unknown error occurred',
-    };
-    res.status(500).json(errorResponse);
-  }
-});
-
 // Send key security warning DM to a specific node
 apiRouter.post('/nodes/:nodeId/send-key-warning', requirePermission('messages', 'write'), async (req, res) => {
   try {

--- a/tests/api-exercise-test.sh
+++ b/tests/api-exercise-test.sh
@@ -271,7 +271,6 @@ check "GET /api/version/check" "$(api GET /api/version/check)" 200
 check_json "GET /api/virtual-node/status" "GET" "/api/virtual-node/status" "'sources' in data"
 check_json "GET /api/nodes" "GET" "/api/nodes" "isinstance(data, list)"
 check_json "GET /api/nodes/active" "GET" "/api/nodes/active" "isinstance(data, list)"
-check_json "GET /api/nodes/security-issues" "GET" "/api/nodes/security-issues" "isinstance(data, list)"
 check_json "GET /api/ignored-nodes" "GET" "/api/ignored-nodes" "isinstance(data, list)"
 check "GET /api/auto-favorite/status" "$(api GET /api/auto-favorite/status)" 200
 check "GET /api/device/tx-status" "$(api GET /api/device/tx-status)" 200


### PR DESCRIPTION
## Summary

Removes the legacy `GET /api/nodes/security-issues` endpoint and its remaining references. The properly-scoped `/api/security/issues` route is unchanged and continues to serve all internal callers (e.g. SecurityTab).

- Audit **FINDING-5** (severity **MEDIUM**)
- PR #2984 was the interim gate (`requirePermission('security', 'read')`) — now superseded by full removal
- Phase **8.2** of the unified remediation plan

## References removed (3)

1. `src/server/server.ts` — route handler block (was lines 1932-1946)
2. `tests/api-exercise-test.sh:274` — assertion deleted; modern `/api/security/issues` already covered at line 384
3. `docs/features/security.md` — two references at lines 219 and 317 updated to `/api/security/issues`, including the structured response shape (`total`, `lowEntropyCount`, `duplicateKeyCount`, `excessivePacketsCount`, `timeOffsetCount`, `nodes`, `topBroadcasters`)

## Callers

Audit confirmed **no** frontend, v1, embed, or service code depends on the legacy path. Final `grep -rn "/api/nodes/security-issues"` on the worktree returned zero matches after edits.

## Test plan

- [ ] CI matrix passes (typecheck, lint, tests)
- [ ] `tests/api-exercise-test.sh` still passes; `/api/security/issues` coverage intact
- [ ] SecurityTab UI continues to render security issues (uses `/api/security/issues`)
- [ ] No 404s or referrer breakage from removed route

**DO NOT MERGE** — awaiting user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)