### PR TITLE
fix(firmware): keep uploadPhase on error so half-flash detection works

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -3658,6 +3658,7 @@
     "automation.geofence_triggers.section_title": "",
     "meshcore.type": "",
     "source.status_connected": "",
+    "source.status_disconnected": "",
     "source.form.host_placeholder": "",
     "telemetry_config.health_interval": "",
     "automation.time_sync.select_nodes": "",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4217,6 +4217,7 @@
   "source.open": "Open →",
   "source.node_count": "{{count}} nodes",
   "source.status_connected": "Connected",
+  "source.status_disconnected": "Disconnected",
   "source.status_connecting": "Connecting",
   "source.status_disabled": "Disabled",
   "source.status_idle": "Idle (manual)",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -3690,6 +3690,7 @@
     "automation.geofence_triggers.section_title": "",
     "meshcore.type": "",
     "source.status_connected": "",
+    "source.status_disconnected": "",
     "source.form.host_placeholder": "",
     "telemetry_config.health_interval": "",
     "automation.time_sync.select_nodes": "",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -3658,6 +3658,7 @@
     "automation.geofence_triggers.section_title": "",
     "meshcore.type": "",
     "source.status_connected": "",
+    "source.status_disconnected": "",
     "source.form.host_placeholder": "",
     "telemetry_config.health_interval": "",
     "automation.time_sync.select_nodes": "",

--- a/public/locales/nb_NO.json
+++ b/public/locales/nb_NO.json
@@ -3651,6 +3651,7 @@
     "automation.geofence_triggers.section_title": "",
     "meshcore.type": "",
     "source.status_connected": "",
+    "source.status_disconnected": "",
     "source.form.host_placeholder": "",
     "telemetry_config.health_interval": "",
     "automation.time_sync.select_nodes": "",

--- a/public/locales/pt_BR.json
+++ b/public/locales/pt_BR.json
@@ -1386,6 +1386,7 @@
     "device_config.timezone_not_set": "",
     "automation.auto_traceroute.schedule_description": "",
     "source.status_connected": "",
+    "source.status_disconnected": "",
     "purgeModal.purgeTraceroutes": "",
     "channels_config.title": "",
     "node_details.node_id": "",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -3912,6 +3912,7 @@
     "meshcore.device_type.companion": "",
     "meshcore.type": "",
     "source.status_connected": "",
+    "source.status_disconnected": "",
     "source.form.host_placeholder": "",
     "meshcore.rssi": "",
     "meshcore.no_messages": "",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -1369,6 +1369,7 @@
     "device_config.timezone_not_set": "",
     "automation.auto_traceroute.schedule_description": "",
     "source.status_connected": "",
+    "source.status_disconnected": "",
     "purgeModal.purgeTraceroutes": "",
     "channels_config.title": "",
     "node_details.node_id": "",

--- a/public/locales/zh_Hans.json
+++ b/public/locales/zh_Hans.json
@@ -4045,6 +4045,7 @@
     "automation.auto_heap.heap_status": "",
     "unified.telemetry.network_error": "",
     "source.status_connected": "",
+    "source.status_disconnected": "",
     "source.form.host_placeholder": "",
     "unified.messages.history_start": "",
     "automation.auto_ping.successful": "",

--- a/src/server/services/firmwareUpdateService.ts
+++ b/src/server/services/firmwareUpdateService.ts
@@ -1552,7 +1552,11 @@ export class FirmwareUpdateService {
       const finish = (err?: Error) => {
         if (finished) return;
         finished = true;
-        setPhase('done');
+        // Only mark 'done' on success. On error, leave uploadPhase pointing at
+        // the phase that was active when the failure happened so executeFlash's
+        // safety rail can distinguish a handshake-phase failure (retryable, no
+        // bytes streamed) from a streaming/commit failure (real half-flash).
+        if (!err) setPhase('done');
         clearTimeout(overallTimer);
         socket.removeAllListeners();
         socket.destroy();


### PR DESCRIPTION
## Summary
- `finish()` in `uploadOtaFirmware` was unconditionally setting `phase='done'` before rejecting, which clobbered the phase tracker the executeFlash safety rail uses to distinguish handshake-phase failures (retryable, no bytes streamed) from streaming/commit failures (real half-flash). Net effect: a transient ECONNRESET right after the loader's commit-`OK` was being mis-classified as a half-flash and writing a recovery marker that blocked the next OTA.
- Fix: only mark `'done'` on success; on error leave `uploadPhase` pointing at the phase that was active when the failure happened.
- Drive-by i18n: add `source.status_disconnected` key across all 9 locales (it was missing).

## Test plan
- [x] Re-flash node `_43594c70` after rebuild — no longer trips the false-positive marker
- [ ] Confirm a real streaming/commit-phase failure still writes the marker and surfaces the USB-recovery error

🤖 Generated with [Claude Code](https://claude.com/claude-code)