### PR TITLE
chore(release): bump version to 4.3.2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.3.1",
+  "version": "4.3.2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bumps version to 4.3.2 in `package.json`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, and refreshes `package-lock.json`.
- Picks up the half-flash phase-tracking fix from #3001.

## Test plan
- [x] `npm install --package-lock-only` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)