### PR TITLE
fix(reset-admin): also disable MFA when resetting admin password (#1658)

### DIFF
--- a/reset-admin.mjs
+++ b/reset-admin.mjs
@@ -10,13 +10,18 @@ function generatePassword() {
   return password;
 }
 
-function printSuccess(newPassword) {
+function printSuccess(newPassword, mfaDisabled) {
   console.log('');
   console.log('═══════════════════════════════════════════════════════════');
   console.log('🔐 Admin password has been reset');
   console.log('═══════════════════════════════════════════════════════════');
   console.log(`   Username: admin`);
   console.log(`   Password: ${newPassword}`);
+  if (mfaDisabled) {
+    console.log('');
+    console.log('   ℹ️  MFA was enabled and has been disabled.');
+    console.log('      Re-enable it after logging in if needed.');
+  }
   console.log('');
   console.log('   ⚠️  IMPORTANT: Save this password now!');
   console.log('═══════════════════════════════════════════════════════════');
@@ -46,11 +51,13 @@ async function resetSqlite(hashedPassword) {
   const dbPath = process.env.DATABASE_PATH || '/data/meshmonitor.db';
   const db = new Database(dbPath);
   try {
+    const before = db.prepare('SELECT mfa_enabled FROM users WHERE username = ?').get('admin');
     const stmt = db.prepare(
-      'UPDATE users SET password_hash = ?, is_active = 1, password_locked = 0 WHERE username = ?'
+      'UPDATE users SET password_hash = ?, is_active = 1, password_locked = 0, mfa_enabled = 0, mfa_secret = NULL, mfa_backup_codes = NULL WHERE username = ?'
     );
     const result = stmt.run(hashedPassword, 'admin');
-    return result.changes > 0;
+    const mfaDisabled = result.changes > 0 && before?.mfa_enabled === 1;
+    return { changed: result.changes > 0, mfaDisabled };
   } finally {
     db.close();
   }
@@ -60,11 +67,13 @@ async function resetPostgres(hashedPassword) {
   const pg = await import('pg');
   const pool = new pg.default.Pool({ connectionString: process.env.DATABASE_URL });
   try {
+    const before = await pool.query('SELECT "mfaEnabled" FROM users WHERE username = $1', ['admin']);
     const result = await pool.query(
-      'UPDATE users SET "passwordHash" = $1, "isActive" = true, "passwordLocked" = false WHERE username = $2',
+      'UPDATE users SET "passwordHash" = $1, "isActive" = true, "passwordLocked" = false, "mfaEnabled" = false, "mfaSecret" = null, "mfaBackupCodes" = null WHERE username = $2',
       [hashedPassword, 'admin']
     );
-    return result.rowCount > 0;
+    const mfaDisabled = result.rowCount > 0 && before.rows[0]?.mfaEnabled === true;
+    return { changed: result.rowCount > 0, mfaDisabled };
   } finally {
     await pool.end();
   }
@@ -74,11 +83,13 @@ async function resetMysql(hashedPassword) {
   const mysql = await import('mysql2/promise');
   const pool = mysql.createPool(process.env.DATABASE_URL);
   try {
+    const [beforeRows] = await pool.query('SELECT mfaEnabled FROM users WHERE username = ?', ['admin']);
     const [result] = await pool.query(
-      'UPDATE users SET passwordHash = ?, isActive = true, passwordLocked = false WHERE username = ?',
+      'UPDATE users SET passwordHash = ?, isActive = true, passwordLocked = false, mfaEnabled = false, mfaSecret = NULL, mfaBackupCodes = NULL WHERE username = ?',
       [hashedPassword, 'admin']
     );
-    return result.affectedRows > 0;
+    const mfaDisabled = result.affectedRows > 0 && beforeRows[0]?.mfaEnabled;
+    return { changed: result.affectedRows > 0, mfaDisabled };
   } finally {
     await pool.end();
   }
@@ -90,21 +101,21 @@ console.log(`Detected database: ${dbType}`);
 const newPassword = generatePassword();
 const hashedPassword = await bcrypt.hash(newPassword, 10);
 
-let success = false;
+let result = { changed: false, mfaDisabled: false };
 switch (dbType) {
   case 'sqlite':
-    success = await resetSqlite(hashedPassword);
+    result = await resetSqlite(hashedPassword);
     break;
   case 'postgres':
-    success = await resetPostgres(hashedPassword);
+    result = await resetPostgres(hashedPassword);
     break;
   case 'mysql':
-    success = await resetMysql(hashedPassword);
+    result = await resetMysql(hashedPassword);
     break;
 }
 
-if (success) {
-  printSuccess(newPassword);
+if (result.changed) {
+  printSuccess(newPassword, result.mfaDisabled);
 } else {
   printNotFound();
 }


### PR DESCRIPTION
## Summary

- `reset-admin.mjs` only reset the password, but left MFA fields untouched
- If an admin had MFA enabled they would still be blocked from logging in after the reset — the login flow correctly prompts for a TOTP code, which the locked-out user no longer has
- The `@Mebradhen` comment on issue #1658 ("not working after v4.0") is consistent with this: MFA adoption grew alongside the project's maturity
- Added `mfa_enabled = 0 / mfa_secret = NULL / mfa_backup_codes = NULL` to the `UPDATE` statement for all three database backends (SQLite, PostgreSQL, MySQL)
- Added a pre-read of the `mfa_enabled` flag so the success banner can inform the user when MFA was active and has been disabled (so they know to re-enable it after logging back in)

## Test plan

- [x] Manual end-to-end test: insert admin user with `mfa_enabled = 1` + `mfa_secret = 'TOTP_SECRET'`, run reset, verify hash validates via `bcrypt.compare`, verify `mfa_enabled = 0` and `mfa_secret = NULL` after reset
- [x] `vitest run src/db/repositories/auth.test.ts` — 42 passed
- [x] `vitest run src/server/routes/authRoutes.test.ts` — 49 passed
- [ ] Cannot test against a live v4.0+ Docker install with MFA active, but the SQL path is the same as what the existing fix (commit `0fdcb88b`) established for `is_active`/`password_locked`

Closes #1658
cc @Mebradhen — the "can't log in after v4.0" issue was MFA blocking the login step even after a successful password reset.

Authored by Merlin 🪄