### PR TITLE
fix(server): migrate archiver to v8 named class API (#3008)

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5381,7 +5381,10 @@ apiRouter.get('/system/backup/download/:dirname', requirePermission('configurati
     }
 
     const backupPath = systemBackupService.getBackupPath(dirname);
-    const archiver = await import('archiver');
+    // archiver v8 exposes only named class exports; @types/archiver still ships v7 types.
+    const { TarArchive } = (await import('archiver')) as unknown as {
+      TarArchive: new (opts: import('archiver').ArchiverOptions) => import('archiver').Archiver;
+    };
     const fs = await import('fs');
 
     // Check if backup exists
@@ -5393,7 +5396,7 @@ apiRouter.get('/system/backup/download/:dirname', requirePermission('configurati
     res.setHeader('Content-Type', 'application/gzip');
     res.setHeader('Content-Disposition', `attachment; filename="${dirname}.tar.gz"`);
 
-    const archive = archiver.default('tar', {
+    const archive = new TarArchive({
       gzip: true,
       gzipOptions: { level: 9 },
     });
@@ -9933,8 +9936,11 @@ apiRouter.post('/scripts/export', requirePermission('settings', 'read'), async (
     }
 
     const scriptsDir = getScriptsDirectory();
-    const archiver = (await import('archiver')).default;
-    const archive = archiver('zip', { zlib: { level: 9 } });
+    // archiver v8 exposes only named class exports; @types/archiver still ships v7 types.
+    const { ZipArchive } = (await import('archiver')) as unknown as {
+      ZipArchive: new (opts: import('archiver').ArchiverOptions) => import('archiver').Archiver;
+    };
+    const archive = new ZipArchive({ zlib: { level: 9 } });
 
     res.attachment('scripts-export.zip');
     archive.pipe(res);


### PR DESCRIPTION
## Summary

Alternative fix for #3008 that **migrates the code to archiver v8** instead of reverting the dependency (see #3010 for the revert approach).

Two server endpoints were still calling the v7 function-form API and broke at runtime after Dependabot bumped `archiver` 7.0.1 → 8.0.0 in #2964:

- `src/server/server.ts:5384` — system backup download (tar.gz)
- `src/server/server.ts:9936` — script export (zip)

Both surfaced the user-visible toast: `archiver is not a function`.

## Root cause

archiver 8.0.0 is pure ESM and dropped the function-form default export. The module now exposes only named class exports: `Archiver`, `ZipArchive`, `TarArchive`, `JsonArchive`. The dynamic-import pattern `(await import('archiver')).default` resolves to `undefined`, hence "archiver is not a function".

## Fix

Switch both call sites to the v8 class API:

```ts
const { ZipArchive } = await import('archiver');
const archive = new ZipArchive({ zlib: { level: 9 } });
```

```ts
const { TarArchive } = await import('archiver');
const archive = new TarArchive({ gzip: true, gzipOptions: { level: 9 } });
```

All instance methods (`.pipe()`, `.append()`, `.directory()`, `.finalize()`, `.on()`) are unchanged.

`@types/archiver` on DefinitelyTyped is still at v7 (no v8 types published yet), so the dynamic imports are cast inline through `as unknown as { ... }` using the existing v7 `ArchiverOptions` / `Archiver` types for the constructor signature and instance type. This keeps full typing on `.directory()`, `.on('error', err => ...)`, etc., and the cast can be deleted once DefinitelyTyped publishes v8 types.

## vs. #3010

| | #3010 (revert) | This PR (migrate) |
|---|---|---|
| package.json | downgrade archiver to ^7.0.1 | unchanged (^8.0.0) |
| code | unchanged | switch to named class API |
| Dependabot | will keep re-opening v8 bumps | done |
| Surface area | dep | 2 endpoints in server.ts |

Pick whichever fits the project's preferred direction.

## Test plan

- [x] `npm run typecheck` clean
- [ ] Manual: trigger script export from Settings → Scripts → Export → confirm zip downloads cleanly
- [ ] Manual: trigger system backup download → confirm tar.gz downloads cleanly
- [ ] CI green

Fixes #3008

— Authored by Merlin 🪄