### PR TITLE
feat(notifications): configurable Apprise API server URL via Global Settings (#3012)

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -4170,5 +4170,9 @@
     "settings.apprise_server_section": "Apprise API Server",
     "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
     "settings.apprise_server_url_label": "Apprise API Server URL",
-    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs).",
+    "settings.apprise_server_test": "Test Connection",
+    "settings.apprise_server_testing": "Testing…",
+    "settings.apprise_server_test_success": "Connected successfully ({{latency}}ms)",
+    "settings.apprise_server_test_failure": "Connection failed: {{error}}"
 }

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -4166,5 +4166,9 @@
     "map.legend.bidirectional": "",
     "info.packets_by_type": "",
     "auto_responder.cooldown_badge": "",
-    "node_info.warning_immediate": ""
+    "node_info.warning_immediate": "",
+    "settings.apprise_server_section": "Apprise API Server",
+    "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
+    "settings.apprise_server_url_label": "Apprise API Server URL",
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
 }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1528,6 +1528,11 @@
   "settings.shutdown_action": "shut down",
   "settings.restart_failed": "Failed to {{action}}. Please try again.",
 
+  "settings.apprise_server_section": "Apprise API Server",
+  "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
+  "settings.apprise_server_url_label": "Apprise API Server URL",
+  "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs).",
+
   "settings.analytics": "Analytics",
   "settings.analytics_provider_label": "Analytics Provider",
   "settings.analytics_provider_description": "Select an analytics service to track visitor traffic on your instance.",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1532,6 +1532,10 @@
   "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
   "settings.apprise_server_url_label": "Apprise API Server URL",
   "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs).",
+  "settings.apprise_server_test": "Test Connection",
+  "settings.apprise_server_testing": "Testing…",
+  "settings.apprise_server_test_success": "Connected successfully ({{latency}}ms)",
+  "settings.apprise_server_test_failure": "Connection failed: {{error}}",
 
   "settings.analytics": "Analytics",
   "settings.analytics_provider_label": "Analytics Provider",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -4170,5 +4170,9 @@
     "settings.apprise_server_section": "Apprise API Server",
     "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
     "settings.apprise_server_url_label": "Apprise API Server URL",
-    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs).",
+    "settings.apprise_server_test": "Test Connection",
+    "settings.apprise_server_testing": "Testing…",
+    "settings.apprise_server_test_success": "Connected successfully ({{latency}}ms)",
+    "settings.apprise_server_test_failure": "Connection failed: {{error}}"
 }

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -4166,5 +4166,9 @@
     "map.legend.bidirectional": "",
     "info.packets_by_type": "",
     "auto_responder.cooldown_badge": "",
-    "node_info.warning_immediate": ""
+    "node_info.warning_immediate": "",
+    "settings.apprise_server_section": "Apprise API Server",
+    "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
+    "settings.apprise_server_url_label": "Apprise API Server URL",
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
 }

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -4170,5 +4170,9 @@
     "settings.apprise_server_section": "Apprise API Server",
     "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
     "settings.apprise_server_url_label": "Apprise API Server URL",
-    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs).",
+    "settings.apprise_server_test": "Test Connection",
+    "settings.apprise_server_testing": "Testing…",
+    "settings.apprise_server_test_success": "Connected successfully ({{latency}}ms)",
+    "settings.apprise_server_test_failure": "Connection failed: {{error}}"
 }

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -4166,5 +4166,9 @@
     "map.legend.bidirectional": "",
     "info.packets_by_type": "",
     "auto_responder.cooldown_badge": "",
-    "node_info.warning_immediate": ""
+    "node_info.warning_immediate": "",
+    "settings.apprise_server_section": "Apprise API Server",
+    "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
+    "settings.apprise_server_url_label": "Apprise API Server URL",
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
 }

--- a/public/locales/nb_NO.json
+++ b/public/locales/nb_NO.json
@@ -4159,5 +4159,9 @@
     "map.legend.bidirectional": "",
     "info.packets_by_type": "",
     "auto_responder.cooldown_badge": "",
-    "node_info.warning_immediate": ""
+    "node_info.warning_immediate": "",
+    "settings.apprise_server_section": "Apprise API Server",
+    "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
+    "settings.apprise_server_url_label": "Apprise API Server URL",
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
 }

--- a/public/locales/nb_NO.json
+++ b/public/locales/nb_NO.json
@@ -4163,5 +4163,9 @@
     "settings.apprise_server_section": "Apprise API Server",
     "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
     "settings.apprise_server_url_label": "Apprise API Server URL",
-    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs).",
+    "settings.apprise_server_test": "Test Connection",
+    "settings.apprise_server_testing": "Testing…",
+    "settings.apprise_server_test_success": "Connected successfully ({{latency}}ms)",
+    "settings.apprise_server_test_failure": "Connection failed: {{error}}"
 }

--- a/public/locales/pt_BR.json
+++ b/public/locales/pt_BR.json
@@ -4161,5 +4161,9 @@
     "settings.apprise_server_section": "Apprise API Server",
     "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
     "settings.apprise_server_url_label": "Apprise API Server URL",
-    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs).",
+    "settings.apprise_server_test": "Test Connection",
+    "settings.apprise_server_testing": "Testing…",
+    "settings.apprise_server_test_success": "Connected successfully ({{latency}}ms)",
+    "settings.apprise_server_test_failure": "Connection failed: {{error}}"
 }

--- a/public/locales/pt_BR.json
+++ b/public/locales/pt_BR.json
@@ -4157,5 +4157,9 @@
     "api_token.prefix": "",
     "settings.node_dimming_start_hours": "",
     "node_info.warning_immediate": "",
-    "channels_config.downlink": ""
+    "channels_config.downlink": "",
+    "settings.apprise_server_section": "Apprise API Server",
+    "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
+    "settings.apprise_server_url_label": "Apprise API Server URL",
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
 }

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -4159,5 +4159,9 @@
     "unified.messages.heard_by_count": "",
     "settings.analytics_custom_script_label": "",
     "meshcore.port": "",
-    "auto_responder.cooldown_badge": ""
+    "auto_responder.cooldown_badge": "",
+    "settings.apprise_server_section": "Apprise API Server",
+    "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
+    "settings.apprise_server_url_label": "Apprise API Server URL",
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
 }

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -4163,5 +4163,9 @@
     "settings.apprise_server_section": "Apprise API Server",
     "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
     "settings.apprise_server_url_label": "Apprise API Server URL",
-    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs).",
+    "settings.apprise_server_test": "Test Connection",
+    "settings.apprise_server_testing": "Testing…",
+    "settings.apprise_server_test_success": "Connected successfully ({{latency}}ms)",
+    "settings.apprise_server_test_failure": "Connection failed: {{error}}"
 }

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -4161,5 +4161,9 @@
     "settings.apprise_server_section": "Apprise API Server",
     "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
     "settings.apprise_server_url_label": "Apprise API Server URL",
-    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs).",
+    "settings.apprise_server_test": "Test Connection",
+    "settings.apprise_server_testing": "Testing…",
+    "settings.apprise_server_test_success": "Connected successfully ({{latency}}ms)",
+    "settings.apprise_server_test_failure": "Connection failed: {{error}}"
 }

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -4157,5 +4157,9 @@
     "api_token.prefix": "",
     "settings.node_dimming_start_hours": "",
     "node_info.warning_immediate": "",
-    "channels_config.downlink": ""
+    "channels_config.downlink": "",
+    "settings.apprise_server_section": "Apprise API Server",
+    "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
+    "settings.apprise_server_url_label": "Apprise API Server URL",
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
 }

--- a/public/locales/zh_Hans.json
+++ b/public/locales/zh_Hans.json
@@ -4159,5 +4159,9 @@
     "source.form.error_save_failed": "",
     "unified.messages.empty_channel": "",
     "unified.messages.source_filter_aria": "",
-    "unified.messages.heard_by_count": ""
+    "unified.messages.heard_by_count": "",
+    "settings.apprise_server_section": "Apprise API Server",
+    "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
+    "settings.apprise_server_url_label": "Apprise API Server URL",
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
 }

--- a/public/locales/zh_Hans.json
+++ b/public/locales/zh_Hans.json
@@ -4163,5 +4163,9 @@
     "settings.apprise_server_section": "Apprise API Server",
     "settings.apprise_server_description": "MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.",
     "settings.apprise_server_url_label": "Apprise API Server URL",
-    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."
+    "settings.apprise_server_url_description": "Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs).",
+    "settings.apprise_server_test": "Test Connection",
+    "settings.apprise_server_testing": "Testing…",
+    "settings.apprise_server_test_success": "Connected successfully ({{latency}}ms)",
+    "settings.apprise_server_test_failure": "Connection failed: {{error}}"
 }

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -92,7 +92,7 @@ interface SettingsTabProps {
 
 const GLOBAL_SECTIONS = new Set([
   'settings-language', 'settings-units', 'settings-appearance', 'settings-map',
-  'settings-backup', 'settings-maintenance', 'settings-auto-upgrade', 'settings-analytics',
+  'settings-apprise-server', 'settings-backup', 'settings-maintenance', 'settings-auto-upgrade', 'settings-analytics',
 ]);
 
 const SOURCE_SECTIONS = new Set([
@@ -240,6 +240,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   const [localAnalyticsConfig, setLocalAnalyticsConfig] = useState<Record<string, string>>({});
   const [initialAnalyticsProvider, setInitialAnalyticsProvider] = useState<string>('none');
   const [initialAnalyticsConfig, setInitialAnalyticsConfig] = useState<string>('{}');
+  const [localAppriseApiServerUrl, setLocalAppriseApiServerUrl] = useState<string>('');
+  const [initialAppriseApiServerUrl, setInitialAppriseApiServerUrl] = useState<string>('');
   const { showToast } = useToast();
 
   // Fetch system status to determine if running in Docker
@@ -333,6 +335,13 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               setInitialAnalyticsConfig(settings.analyticsConfig);
             } catch { /* ignore parse errors */ }
           }
+
+          // Load Apprise API server URL (#3012)
+          const appriseApiServerUrl = typeof settings.appriseApiServerUrl === 'string'
+            ? settings.appriseApiServerUrl
+            : '';
+          setLocalAppriseApiServerUrl(appriseApiServerUrl);
+          setInitialAppriseApiServerUrl(appriseApiServerUrl);
         }
       } catch (error) {
         logger.error('Failed to fetch server settings:', error);
@@ -439,7 +448,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       nodeDimmingStartHours !== initialNodeDimmingSettings.startHours ||
       nodeDimmingMinOpacity !== initialNodeDimmingSettings.minOpacity ||
       localAnalyticsProvider !== initialAnalyticsProvider ||
-      JSON.stringify(localAnalyticsConfig) !== initialAnalyticsConfig;
+      JSON.stringify(localAnalyticsConfig) !== initialAnalyticsConfig ||
+      localAppriseApiServerUrl !== initialAppriseApiServerUrl;
     setHasChanges(changed);
   }, [localMaxNodeAge, localInactiveNodeThresholdHours, localInactiveNodeCheckIntervalMinutes, localInactiveNodeCooldownHours, localTemperatureUnit, localDistanceUnit, localPositionHistoryLineStyle, localTelemetryHours, localFavoriteTelemetryStorageDays, localPreferredSortField, localPreferredSortDirection, localTimeFormat, localDateFormat, localMapTileset, localMapPinStyle, localIconStyle, localNeighborInfoMinZoom, localDefaultMapCenterLat, localDefaultMapCenterLon, localDefaultMapCenterZoom, localDefaultLandingPage, localTheme, localNodeHopsCalculation, localDashboardSortOption,
       maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes, inactiveNodeCooldownHours, temperatureUnit, distanceUnit, positionHistoryLineStyle, telemetryVisualizationHours, favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat, dateFormat, mapTileset, mapPinStyle, iconStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, defaultLandingPage, theme, nodeHopsCalculation, preferredDashboardSortOption,
@@ -449,7 +459,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localHideIncompleteNodes, showIncompleteNodes, localHomoglyphEnabled, initialHomoglyphEnabled,
       localLocalStatsIntervalMinutes, initialLocalStatsIntervalMinutes,
       nodeDimmingEnabled, nodeDimmingStartHours, nodeDimmingMinOpacity, initialNodeDimmingSettings,
-      localAnalyticsProvider, localAnalyticsConfig, initialAnalyticsProvider, initialAnalyticsConfig]);
+      localAnalyticsProvider, localAnalyticsConfig, initialAnalyticsProvider, initialAnalyticsConfig,
+      localAppriseApiServerUrl, initialAppriseApiServerUrl]);
 
   // Reset local state to current saved values (for SaveBar dismiss)
   const resetChanges = useCallback(() => {
@@ -492,6 +503,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setNodeDimmingMinOpacity(initialNodeDimmingSettings.minOpacity);
     setLocalAnalyticsProvider(initialAnalyticsProvider);
     try { setLocalAnalyticsConfig(JSON.parse(initialAnalyticsConfig)); } catch { setLocalAnalyticsConfig({}); }
+    setLocalAppriseApiServerUrl(initialAppriseApiServerUrl);
   }, [maxNodeAgeHours, inactiveNodeThresholdHours, inactiveNodeCheckIntervalMinutes,
       inactiveNodeCooldownHours, temperatureUnit, distanceUnit, telemetryVisualizationHours,
       favoriteTelemetryStorageDays, preferredSortField, preferredSortDirection, timeFormat,
@@ -500,7 +512,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes,
       initialHomoglyphEnabled, initialLocalStatsIntervalMinutes, initialNodeDimmingSettings,
       setNodeDimmingEnabled, setNodeDimmingStartHours, setNodeDimmingMinOpacity,
-      initialAnalyticsProvider, initialAnalyticsConfig]);
+      initialAnalyticsProvider, initialAnalyticsConfig, initialAppriseApiServerUrl]);
 
   const handleSave = useCallback(async () => {
     setIsSaving(true);
@@ -545,6 +557,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         nodeDimmingMinOpacity: nodeDimmingMinOpacity.toString(),
         analyticsProvider: localAnalyticsProvider,
         analyticsConfig: JSON.stringify(localAnalyticsConfig),
+        appriseApiServerUrl: localAppriseApiServerUrl.trim(),
       };
 
       // Save to server
@@ -597,6 +610,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       });
       setInitialAnalyticsProvider(localAnalyticsProvider);
       setInitialAnalyticsConfig(JSON.stringify(localAnalyticsConfig));
+      setInitialAppriseApiServerUrl(localAppriseApiServerUrl.trim());
 
       showToast(t('settings.saved_success'), 'success');
       setHasChanges(false);
@@ -622,7 +636,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       onSolarMonitoringLatitudeChange, onSolarMonitoringLongitudeChange, onSolarMonitoringAzimuthChange,
       onSolarMonitoringDeclinationChange, setShowIncompleteNodes, showToast, t,
       nodeDimmingEnabled, nodeDimmingStartHours, nodeDimmingMinOpacity,
-      localAnalyticsProvider, localAnalyticsConfig]);
+      localAnalyticsProvider, localAnalyticsConfig, localAppriseApiServerUrl]);
 
   // Register with SaveBar
   useSaveBar({
@@ -925,6 +939,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         { id: 'settings-notifications', label: t('settings.notifications_and_security') },
         { id: 'settings-packet-monitor', label: t('settings.packet_monitor') },
         { id: 'settings-solar', label: t('settings.solar_monitoring') },
+        ...(isAdmin ? [{ id: 'settings-apprise-server', label: t('settings.apprise_server_section', 'Apprise API Server') }] : []),
         { id: 'settings-backup', label: t('settings.system_backup', 'System Backup') },
         // Only show Database Maintenance for SQLite - it uses SQLite-specific features like VACUUM
         ...(databaseType === 'sqlite' ? [{ id: 'settings-maintenance', label: t('maintenance.title', 'Database Maintenance') }] : []),
@@ -1631,6 +1646,31 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               </div>
             </>
           )}
+        </div>}
+
+        {show('settings-apprise-server') && isAdmin && <div id="settings-apprise-server" className="settings-section">
+          <h3>{t('settings.apprise_server_section', 'Apprise API Server')}</h3>
+          <p className="setting-description">
+            {t('settings.apprise_server_description', 'MeshMonitor delivers Apprise notifications through an Apprise API server, which fans out to the per-user notification service URLs (Discord, email, etc.) configured elsewhere. Override the server location below if you are running it outside the bundled container.')}
+          </p>
+          <div className="setting-item">
+            <label htmlFor="appriseApiServerUrl">
+              {t('settings.apprise_server_url_label', 'Apprise API Server URL')}
+              <span className="setting-description">
+                {t('settings.apprise_server_url_description', 'Leave empty if MeshMonitor\'s bundled Apprise API server is running (default for Docker installs).')}
+              </span>
+            </label>
+            <input
+              id="appriseApiServerUrl"
+              type="url"
+              value={localAppriseApiServerUrl}
+              onChange={(e) => setLocalAppriseApiServerUrl(e.target.value)}
+              placeholder="http://localhost:8000"
+              className="setting-input"
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
         </div>}
 
         {show('settings-backup') && <div id="settings-backup">

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -242,6 +242,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   const [initialAnalyticsConfig, setInitialAnalyticsConfig] = useState<string>('{}');
   const [localAppriseApiServerUrl, setLocalAppriseApiServerUrl] = useState<string>('');
   const [initialAppriseApiServerUrl, setInitialAppriseApiServerUrl] = useState<string>('');
+  const [isTestingApprise, setIsTestingApprise] = useState<boolean>(false);
+  const [appriseTestResult, setAppriseTestResult] = useState<{ ok: boolean; message: string } | null>(null);
   const { showToast } = useToast();
 
   // Fetch system status to determine if running in Docker
@@ -647,6 +649,49 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     onSave: handleSave,
     onDismiss: resetChanges
   });
+
+  const handleTestAppriseConnection = useCallback(async () => {
+    setIsTestingApprise(true);
+    setAppriseTestResult(null);
+    try {
+      const response = await csrfFetch(`${baseUrl}/api/settings/test-apprise`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ url: localAppriseApiServerUrl.trim() || undefined }),
+      });
+
+      if (!response.ok) {
+        const errBody = await response.json().catch(() => ({}));
+        setAppriseTestResult({
+          ok: false,
+          message: errBody.error || `HTTP ${response.status}`,
+        });
+        return;
+      }
+
+      const data: { ok: boolean; status?: number; error?: string; latencyMs?: number } = await response.json();
+      if (data.ok) {
+        setAppriseTestResult({
+          ok: true,
+          message: t('settings.apprise_server_test_success', 'Connected successfully ({{latency}}ms)', { latency: data.latencyMs ?? 0 }),
+        });
+      } else {
+        setAppriseTestResult({
+          ok: false,
+          message: t('settings.apprise_server_test_failure', 'Connection failed: {{error}}', { error: data.error || 'Unknown error' }),
+        });
+      }
+    } catch (error) {
+      logger.error('Failed to test Apprise connection:', error);
+      setAppriseTestResult({
+        ok: false,
+        message: t('settings.apprise_server_test_failure', 'Connection failed: {{error}}', { error: error instanceof Error ? error.message : String(error) }),
+      });
+    } finally {
+      setIsTestingApprise(false);
+    }
+  }, [csrfFetch, baseUrl, localAppriseApiServerUrl, t]);
 
   const handleFetchSolarEstimates = async () => {
     setIsFetchingSolarEstimates(true);
@@ -1670,6 +1715,30 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               autoComplete="off"
               spellCheck={false}
             />
+            <div style={{ marginTop: '0.75rem' }}>
+              <button
+                type="button"
+                onClick={handleTestAppriseConnection}
+                disabled={isTestingApprise}
+                className="save-button"
+                style={{ width: 'auto', padding: '0.5rem 1rem' }}
+              >
+                {isTestingApprise
+                  ? t('settings.apprise_server_testing', 'Testing…')
+                  : t('settings.apprise_server_test', 'Test Connection')}
+              </button>
+              {appriseTestResult && (
+                <p
+                  className="setting-description"
+                  style={{
+                    marginTop: '0.5rem',
+                    color: appriseTestResult.ok ? 'var(--color-success, #10b981)' : 'var(--color-error, #ef4444)',
+                  }}
+                >
+                  {appriseTestResult.message}
+                </p>
+              )}
+            </div>
           </div>
         </div>}
 

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -144,6 +144,7 @@ export const VALID_SETTINGS_KEYS = [
   'tracerouteFilterHopsMin',
   'tracerouteFilterHopsMax',
   'defaultLandingPage',
+  'appriseApiServerUrl',
 ] as const;
 
 export type ValidSettingKey = typeof VALID_SETTINGS_KEYS[number];

--- a/src/server/routes/settingsRoutes.test.ts
+++ b/src/server/routes/settingsRoutes.test.ts
@@ -2,7 +2,7 @@
  * Settings Routes Unit Tests
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import express, { Express } from 'express';
 import session from 'express-session';
 import request from 'supertest';
@@ -377,6 +377,148 @@ describe('settingsRoutes', () => {
           .send({ appriseApiServerUrl: 'http://apprise.example.com:8000' })
           .expect(403);
       });
+    });
+  });
+
+  describe('POST /api/settings/test-apprise (#3012)', () => {
+    const fetchMock = vi.fn();
+    const originalFetch = globalThis.fetch;
+
+    beforeEach(() => {
+      fetchMock.mockReset();
+      globalThis.fetch = fetchMock as any;
+    });
+
+    afterAll(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('returns ok:true when the Apprise server responds 200', async () => {
+      fetchMock.mockResolvedValue(new Response(JSON.stringify({ status: 'ok' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+
+      const app = createApp(adminUser);
+      const res = await request(app)
+        .post('/api/settings/test-apprise')
+        .send({ url: 'http://apprise.example.com:8000' })
+        .expect(200);
+
+      expect(res.body.ok).toBe(true);
+      expect(res.body.status).toBe(200);
+      expect(typeof res.body.latencyMs).toBe('number');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe('http://apprise.example.com:8000/health');
+    });
+
+    it('strips trailing slashes from the supplied URL before probing', async () => {
+      fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const app = createApp(adminUser);
+      await request(app)
+        .post('/api/settings/test-apprise')
+        .send({ url: 'http://apprise.example.com:8000///' })
+        .expect(200);
+
+      expect(fetchMock.mock.calls[0][0]).toBe('http://apprise.example.com:8000/health');
+    });
+
+    it('returns ok:false with status when the Apprise server returns a non-2xx', async () => {
+      fetchMock.mockResolvedValue(new Response('boom', { status: 503 }));
+
+      const app = createApp(adminUser);
+      const res = await request(app)
+        .post('/api/settings/test-apprise')
+        .send({ url: 'http://apprise.example.com:8000' })
+        .expect(200);
+
+      expect(res.body.ok).toBe(false);
+      expect(res.body.status).toBe(503);
+      expect(res.body.error).toContain('503');
+    });
+
+    it('returns ok:false when fetch throws (network failure)', async () => {
+      fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const app = createApp(adminUser);
+      const res = await request(app)
+        .post('/api/settings/test-apprise')
+        .send({ url: 'http://apprise.example.com:8000' })
+        .expect(200);
+
+      expect(res.body.ok).toBe(false);
+      expect(res.body.error).toContain('ECONNREFUSED');
+    });
+
+    it('falls back to the saved global setting when no URL is supplied', async () => {
+      fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+      (databaseService as any).settings.getSetting.mockResolvedValue('http://saved.example.com:8000');
+
+      const app = createApp(adminUser);
+      const res = await request(app)
+        .post('/api/settings/test-apprise')
+        .send({})
+        .expect(200);
+
+      expect(res.body.ok).toBe(true);
+      expect(fetchMock.mock.calls[0][0]).toBe('http://saved.example.com:8000/health');
+    });
+
+    it('falls back to http://localhost:8000 when no URL and no saved setting', async () => {
+      fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+      (databaseService as any).settings.getSetting.mockResolvedValue(null);
+
+      const app = createApp(adminUser);
+      await request(app)
+        .post('/api/settings/test-apprise')
+        .send({})
+        .expect(200);
+
+      expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8000/health');
+    });
+
+    it('rejects a non-http(s) scheme with 400', async () => {
+      const app = createApp(adminUser);
+      const res = await request(app)
+        .post('/api/settings/test-apprise')
+        .send({ url: 'file:///etc/passwd' })
+        .expect(400);
+
+      expect(res.body.ok).toBe(false);
+      expect(res.body.error).toContain('http://');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects garbage that is not a URL with 400', async () => {
+      const app = createApp(adminUser);
+      const res = await request(app)
+        .post('/api/settings/test-apprise')
+        .send({ url: 'not a url' })
+        .expect(400);
+
+      expect(res.body.ok).toBe(false);
+      expect(res.body.error).toContain('Invalid URL');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when lacking settings:write permission', async () => {
+      const app = createApp({ id: 2, username: 'user', isActive: true, isAdmin: false });
+      (databaseService as any).findUserByIdAsync.mockResolvedValue({
+        id: 2, username: 'user', isActive: true, isAdmin: false,
+      });
+      (databaseService as any).checkPermissionAsync.mockResolvedValue(false);
+      (databaseService as any).getUserPermissionSetAsync.mockResolvedValue({
+        settings: { read: true, write: false },
+        isAdmin: false,
+      });
+
+      await request(app)
+        .post('/api/settings/test-apprise')
+        .send({ url: 'http://apprise.example.com:8000' })
+        .expect(403);
+
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/server/routes/settingsRoutes.test.ts
+++ b/src/server/routes/settingsRoutes.test.ts
@@ -311,6 +311,73 @@ describe('settingsRoutes', () => {
         .send({ meshName: 'NewMesh' })
         .expect(500);
     });
+
+    describe('appriseApiServerUrl (#3012)', () => {
+      it('should accept a valid http URL', async () => {
+        const app = createApp(adminUser);
+        await request(app)
+          .post('/api/settings')
+          .send({ appriseApiServerUrl: 'http://apprise.example.com:8000' })
+          .expect(200);
+        expect(databaseService.settings.setSettings).toHaveBeenCalledWith(
+          expect.objectContaining({ appriseApiServerUrl: 'http://apprise.example.com:8000' })
+        );
+      });
+
+      it('should accept a valid https URL', async () => {
+        const app = createApp(adminUser);
+        await request(app)
+          .post('/api/settings')
+          .send({ appriseApiServerUrl: 'https://apprise.example.com' })
+          .expect(200);
+      });
+
+      it('should accept an empty / whitespace value (clears the override)', async () => {
+        const app = createApp(adminUser);
+        await request(app)
+          .post('/api/settings')
+          .send({ appriseApiServerUrl: '   ' })
+          .expect(200);
+        expect(databaseService.settings.setSettings).toHaveBeenCalledWith(
+          expect.objectContaining({ appriseApiServerUrl: '' })
+        );
+      });
+
+      it('should reject a non-http(s) scheme', async () => {
+        const app = createApp(adminUser);
+        const res = await request(app)
+          .post('/api/settings')
+          .send({ appriseApiServerUrl: 'file:///etc/passwd' })
+          .expect(400);
+        expect(res.body.error).toContain('http://');
+      });
+
+      it('should reject garbage that is not a URL', async () => {
+        const app = createApp(adminUser);
+        const res = await request(app)
+          .post('/api/settings')
+          .send({ appriseApiServerUrl: 'not a url' })
+          .expect(400);
+        expect(res.body.error).toContain('valid http(s) URL');
+      });
+
+      it('should return 403 when lacking settings:write permission', async () => {
+        const app = createApp({ id: 2, username: 'user', isActive: true, isAdmin: false });
+        (databaseService as any).findUserByIdAsync.mockResolvedValue({
+          id: 2, username: 'user', isActive: true, isAdmin: false
+        });
+        (databaseService as any).checkPermissionAsync.mockResolvedValue(false);
+        (databaseService as any).getUserPermissionSetAsync.mockResolvedValue({
+          settings: { read: true, write: false },
+          isAdmin: false,
+        });
+
+        await request(app)
+          .post('/api/settings')
+          .send({ appriseApiServerUrl: 'http://apprise.example.com:8000' })
+          .expect(403);
+      });
+    });
   });
 
   describe('DELETE /api/settings', () => {

--- a/src/server/routes/settingsRoutes.test.ts
+++ b/src/server/routes/settingsRoutes.test.ts
@@ -6,7 +6,12 @@ import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import express, { Express } from 'express';
 import session from 'express-session';
 import request from 'supertest';
-import settingsRoutes, { validateTileUrl, validateCustomTilesets } from './settingsRoutes.js';
+import settingsRoutes, {
+  validateTileUrl,
+  validateCustomTilesets,
+  validateAppriseProbeUrl,
+  MAX_APPRISE_PROBE_URL_LENGTH,
+} from './settingsRoutes.js';
 import databaseService from '../../services/database.js';
 
 vi.mock('../../services/database.js', () => ({
@@ -646,5 +651,79 @@ describe('validateCustomTilesets', () => {
   it('should reject tileset missing required fields', () => {
     const { name, ...incomplete } = validTileset;
     expect(validateCustomTilesets([incomplete as any])).toBe(false);
+  });
+});
+
+describe('validateAppriseProbeUrl', () => {
+  it('accepts a bare http URL and builds /health', () => {
+    const r = validateAppriseProbeUrl('http://localhost:8000');
+    expect(r.ok).toBe(true);
+    expect(r.probeUrl).toBe('http://localhost:8000/health');
+  });
+
+  it('accepts an https URL with a path prefix and preserves it', () => {
+    const r = validateAppriseProbeUrl('https://apprise.example.com/api');
+    expect(r.ok).toBe(true);
+    expect(r.probeUrl).toBe('https://apprise.example.com/api/health');
+  });
+
+  it('strips multiple trailing slashes without regex backtracking', () => {
+    const r = validateAppriseProbeUrl('http://localhost:8000/apprise-api/////');
+    expect(r.ok).toBe(true);
+    expect(r.probeUrl).toBe('http://localhost:8000/apprise-api/health');
+  });
+
+  it('accepts RFC1918 hosts (Docker compose / LAN deployments)', () => {
+    const r = validateAppriseProbeUrl('http://192.168.1.50:8000');
+    expect(r.ok).toBe(true);
+    expect(r.probeUrl).toBe('http://192.168.1.50:8000/health');
+  });
+
+  it('rejects empty input', () => {
+    expect(validateAppriseProbeUrl('')).toEqual({ ok: false, error: 'URL is required' });
+  });
+
+  it('rejects inputs longer than the cap', () => {
+    const oversized = 'http://example.com/' + 'a'.repeat(MAX_APPRISE_PROBE_URL_LENGTH);
+    const r = validateAppriseProbeUrl(oversized);
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('URL is too long');
+  });
+
+  it('rejects non-http(s) protocols', () => {
+    expect(validateAppriseProbeUrl('file:///etc/passwd').ok).toBe(false);
+    expect(validateAppriseProbeUrl('ftp://example.com').ok).toBe(false);
+    expect(validateAppriseProbeUrl('javascript:alert(1)').ok).toBe(false);
+  });
+
+  it('rejects unparsable input', () => {
+    expect(validateAppriseProbeUrl('not a url').ok).toBe(false);
+    expect(validateAppriseProbeUrl('http://').ok).toBe(false);
+  });
+
+  it('blocks AWS/Azure IPv4 IMDS (169.254.169.254)', () => {
+    const r = validateAppriseProbeUrl('http://169.254.169.254/latest/meta-data/');
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('Host is not permitted');
+  });
+
+  it('blocks the rest of the 169.254.0.0/16 link-local range', () => {
+    expect(validateAppriseProbeUrl('http://169.254.0.1').ok).toBe(false);
+    expect(validateAppriseProbeUrl('http://169.254.255.254').ok).toBe(false);
+  });
+
+  it('blocks GCP IMDS hostname (case-insensitive)', () => {
+    expect(validateAppriseProbeUrl('http://metadata.google.internal/').ok).toBe(false);
+    expect(validateAppriseProbeUrl('http://Metadata.Google.Internal/').ok).toBe(false);
+  });
+
+  it('blocks Azure IMDS hostname', () => {
+    expect(validateAppriseProbeUrl('http://metadata.azure.com/').ok).toBe(false);
+  });
+
+  it('does not over-block similar-looking hosts', () => {
+    expect(validateAppriseProbeUrl('http://metadata.google.internal.evil.com/').ok).toBe(true);
+    expect(validateAppriseProbeUrl('http://169.254.169.254.nip.io/').ok).toBe(true);
+    expect(validateAppriseProbeUrl('http://169.253.169.254/').ok).toBe(true);
   });
 });

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -806,20 +806,60 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
 // validate a value before saving it). Otherwise the currently-saved global
 // setting is used, falling back to the same precedence as the resolver
 // (APPRISE_URL env / bundled http://localhost:8000).
+export const MAX_APPRISE_PROBE_URL_LENGTH = 2048;
+
+// Hostnames/IPs that resolve to cloud Instance Metadata Service endpoints.
+// Even though this route is admin-only and never returns the upstream body,
+// allowing `fetch()` at these hosts gives a stolen settings:write token a
+// reliable SSRF primitive against AWS/GCP/Azure IMDS. Block them by name and
+// by the 169.254.0.0/16 link-local range that backs the IPv4 IMDS.
+const BLOCKED_APPRISE_PROBE_HOSTNAMES = new Set([
+  'metadata.google.internal',
+  'metadata.azure.com',
+]);
+
+function isBlockedAppriseProbeHost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  if (BLOCKED_APPRISE_PROBE_HOSTNAMES.has(h)) return true;
+  if (/^169\.254\.\d{1,3}\.\d{1,3}$/.test(h)) return true;
+  return false;
+}
+
+export interface AppriseProbeUrlValidation {
+  ok: boolean;
+  error?: string;
+  probeUrl?: string;
+}
+
+export function validateAppriseProbeUrl(raw: string): AppriseProbeUrlValidation {
+  if (raw.length === 0) return { ok: false, error: 'URL is required' };
+  if (raw.length > MAX_APPRISE_PROBE_URL_LENGTH) return { ok: false, error: 'URL is too long' };
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return { ok: false, error: 'Invalid URL format' };
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, error: 'URL must use http:// or https://' };
+  }
+  if (isBlockedAppriseProbeHost(parsed.hostname)) {
+    return { ok: false, error: 'Host is not permitted' };
+  }
+  let pathEnd = parsed.pathname.length;
+  while (pathEnd > 0 && parsed.pathname.charCodeAt(pathEnd - 1) === 47 /* '/' */) {
+    pathEnd--;
+  }
+  const probeUrl = `${parsed.origin}${parsed.pathname.slice(0, pathEnd)}/health`;
+  return { ok: true, probeUrl };
+}
+
 router.post('/test-apprise', requirePermission('settings', 'write'), async (req: Request, res: Response) => {
   try {
     const requestUrl = typeof req.body?.url === 'string' ? req.body.url.trim() : '';
 
     let target: string;
     if (requestUrl.length > 0) {
-      try {
-        const parsed = new URL(requestUrl);
-        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-          return res.status(400).json({ ok: false, error: 'URL must use http:// or https://' });
-        }
-      } catch {
-        return res.status(400).json({ ok: false, error: 'Invalid URL format' });
-      }
       target = requestUrl;
     } else {
       const saved = await databaseService.settings.getSetting('appriseApiServerUrl');
@@ -828,7 +868,11 @@ router.post('/test-apprise', requirePermission('settings', 'write'), async (req:
         : (process.env.APPRISE_URL || 'http://localhost:8000');
     }
 
-    const probeUrl = `${target.replace(/\/+$/, '')}/health`;
+    const validation = validateAppriseProbeUrl(target);
+    if (!validation.ok || !validation.probeUrl) {
+      return res.status(400).json({ ok: false, error: validation.error || 'Invalid URL', url: target });
+    }
+    const probeUrl = validation.probeUrl;
     const start = Date.now();
     try {
       const response = await fetch(probeUrl, {

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -541,6 +541,23 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
       }
     }
 
+    // Apprise API server URL (global; #3012). Empty string clears the override
+    // so the resolver falls back to APPRISE_URL env / bundled localhost default.
+    if ('appriseApiServerUrl' in filteredSettings) {
+      const raw = filteredSettings.appriseApiServerUrl.trim();
+      if (raw.length > 0) {
+        try {
+          const parsed = new URL(raw);
+          if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            return res.status(400).json({ error: 'appriseApiServerUrl must use http:// or https://' });
+          }
+        } catch {
+          return res.status(400).json({ error: 'appriseApiServerUrl must be a valid http(s) URL' });
+        }
+      }
+      filteredSettings.appriseApiServerUrl = raw;
+    }
+
     // Save to database
     if (sourceId) {
       // Per-source: store with source: prefix

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -801,6 +801,77 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
   }
 });
 
+// POST /settings/test-apprise — probe an Apprise API server URL (#3012).
+// If `url` is supplied in the body, that URL is tested directly (so admins can
+// validate a value before saving it). Otherwise the currently-saved global
+// setting is used, falling back to the same precedence as the resolver
+// (APPRISE_URL env / bundled http://localhost:8000).
+router.post('/test-apprise', requirePermission('settings', 'write'), async (req: Request, res: Response) => {
+  try {
+    const requestUrl = typeof req.body?.url === 'string' ? req.body.url.trim() : '';
+
+    let target: string;
+    if (requestUrl.length > 0) {
+      try {
+        const parsed = new URL(requestUrl);
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+          return res.status(400).json({ ok: false, error: 'URL must use http:// or https://' });
+        }
+      } catch {
+        return res.status(400).json({ ok: false, error: 'Invalid URL format' });
+      }
+      target = requestUrl;
+    } else {
+      const saved = await databaseService.settings.getSetting('appriseApiServerUrl');
+      target = (saved && saved.trim().length > 0)
+        ? saved.trim()
+        : (process.env.APPRISE_URL || 'http://localhost:8000');
+    }
+
+    const probeUrl = `${target.replace(/\/+$/, '')}/health`;
+    const start = Date.now();
+    try {
+      const response = await fetch(probeUrl, {
+        method: 'GET',
+        signal: AbortSignal.timeout(5000),
+      });
+      const latencyMs = Date.now() - start;
+
+      if (!response.ok) {
+        return res.json({
+          ok: false,
+          status: response.status,
+          latencyMs,
+          error: `Apprise server returned HTTP ${response.status}`,
+          url: target,
+        });
+      }
+
+      return res.json({
+        ok: true,
+        status: response.status,
+        latencyMs,
+        url: target,
+      });
+    } catch (error: any) {
+      const latencyMs = Date.now() - start;
+      const isTimeout = error?.name === 'TimeoutError' || error?.name === 'AbortError';
+      const message = isTimeout
+        ? 'Connection timed out after 5000ms'
+        : (error?.message || String(error));
+      return res.json({
+        ok: false,
+        latencyMs,
+        error: message,
+        url: target,
+      });
+    }
+  } catch (error) {
+    logger.error('Error testing Apprise connection:', error);
+    res.status(500).json({ ok: false, error: 'Failed to test Apprise connection' });
+  }
+});
+
 // DELETE /settings — reset to defaults
 router.delete('/', requirePermission('settings', 'write'), async (req: Request, res: Response) => {
   try {

--- a/src/server/server.settings-persistence.test.ts
+++ b/src/server/server.settings-persistence.test.ts
@@ -165,6 +165,7 @@ function validTestValue(key: string, suffix = ''): string {
     autoDeleteByDistanceThresholdKm: '100',
     autoDeleteByDistanceLat: '40.7128',
     autoDeleteByDistanceLon: '-74.006',
+    appriseApiServerUrl: 'http://apprise.example.com:8000',
   };
 
   if (key in VALID_VALUES) {
@@ -408,6 +409,9 @@ describe('Settings Persistence', () => {
         'localStatsIntervalMinutes',
         // Analytics — backend injects into HTML, frontend doesn't need them
         'analyticsProvider', 'analyticsConfig',
+        // Apprise API server URL (#3012) — loaded directly by SettingsTab,
+        // not surfaced via SettingsContext (admin-only field, no global hook).
+        'appriseApiServerUrl',
       ];
 
       const keysNotLoaded = SETTINGS_TAB_SENDS.filter(

--- a/src/server/services/appriseNotificationService.resolver.test.ts
+++ b/src/server/services/appriseNotificationService.resolver.test.ts
@@ -1,0 +1,138 @@
+/**
+ * appriseNotificationService — Apprise API URL resolver tests (#3012).
+ *
+ * Exercises the precedence chain in `resolveAppriseConfig`:
+ *   1. Per-source `apprise_url` setting (DB)
+ *   2. Global `appriseApiServerUrl` setting (DB) — added in #3012
+ *   3. `APPRISE_URL` env var
+ *   4. `http://localhost:8000` (bundled default)
+ *
+ * We hit the resolver via the public `testConnection(sourceId)` path and
+ * inspect which base URL `fetch` was called with.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  getSettingMock: vi.fn(),
+  getSettingForSourceMock: vi.fn(),
+  waitForReadyMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    waitForReady: h.waitForReadyMock,
+    settings: {
+      getSetting: h.getSettingMock,
+      getSettingForSource: h.getSettingForSourceMock,
+    },
+  },
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../meshtasticManager.js', () => ({
+  default: {
+    getLocalNodeInfo: vi.fn(() => ({ longName: 'TestNode' })),
+  },
+}));
+
+vi.mock('../utils/notificationFiltering.js', () => ({
+  getUserNotificationPreferencesAsync: vi.fn().mockResolvedValue(null),
+  getUsersWithServiceEnabledAsync: vi.fn().mockResolvedValue([]),
+  shouldFilterNotificationAsync: vi.fn().mockResolvedValue(false),
+  applyNodeNamePrefixAsync: vi.fn(async (_uid: number, body: string) => body),
+}));
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+import { appriseNotificationService } from './appriseNotificationService.js';
+
+describe('appriseNotificationService — resolver precedence (#3012)', () => {
+  const SOURCE = 'src-A';
+
+  beforeEach(async () => {
+    h.getSettingMock.mockReset();
+    h.getSettingForSourceMock.mockReset();
+    fetchMock.mockReset();
+    delete process.env.APPRISE_URL;
+
+    // Default healthy response from the Apprise API.
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    // Ensure the singleton finished its async init before each case so the
+    // resolver path runs with our mocks attached.
+    await appriseNotificationService.waitForInit();
+  });
+
+  afterEach(() => {
+    delete process.env.APPRISE_URL;
+  });
+
+  it('uses the per-source apprise_url setting when present', async () => {
+    h.getSettingForSourceMock.mockImplementation(async (_src: string, key: string) => {
+      if (key === 'apprise_url') return 'http://per-source.example.com:9000';
+      return null;
+    });
+    h.getSettingMock.mockResolvedValue('http://global.example.com:8000');
+    process.env.APPRISE_URL = 'http://env.example.com:8000';
+
+    await appriseNotificationService.testConnection(SOURCE);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('http://per-source.example.com:9000/health');
+  });
+
+  it('falls back to the global appriseApiServerUrl setting when no per-source value', async () => {
+    h.getSettingForSourceMock.mockResolvedValue(null);
+    h.getSettingMock.mockImplementation(async (key: string) => {
+      if (key === 'appriseApiServerUrl') return 'http://global.example.com:8000';
+      return null;
+    });
+    process.env.APPRISE_URL = 'http://env.example.com:8000';
+
+    await appriseNotificationService.testConnection(SOURCE);
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://global.example.com:8000/health');
+  });
+
+  it('falls back to APPRISE_URL env var when no per-source and no global setting', async () => {
+    h.getSettingForSourceMock.mockResolvedValue(null);
+    h.getSettingMock.mockResolvedValue(null);
+    process.env.APPRISE_URL = 'http://env.example.com:8000';
+
+    await appriseNotificationService.testConnection(SOURCE);
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://env.example.com:8000/health');
+  });
+
+  it('falls back to http://localhost:8000 when nothing else is configured', async () => {
+    h.getSettingForSourceMock.mockResolvedValue(null);
+    h.getSettingMock.mockResolvedValue(null);
+
+    await appriseNotificationService.testConnection(SOURCE);
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8000/health');
+  });
+
+  it('treats an empty-string global setting as "not set" and falls through to env/default', async () => {
+    h.getSettingForSourceMock.mockResolvedValue(null);
+    h.getSettingMock.mockImplementation(async (key: string) => {
+      if (key === 'appriseApiServerUrl') return '';
+      return null;
+    });
+    process.env.APPRISE_URL = 'http://env.example.com:8000';
+
+    await appriseNotificationService.testConnection(SOURCE);
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://env.example.com:8000/health');
+  });
+});

--- a/src/server/services/appriseNotificationService.ts
+++ b/src/server/services/appriseNotificationService.ts
@@ -59,18 +59,26 @@ class AppriseNotificationService {
   }
 
   /**
-   * Resolve Apprise URL for a given source (no global fallback per Phase B policy).
+   * Resolve Apprise URL for a given source.
+   *
+   * Precedence (highest → lowest):
+   *   1. Per-source `apprise_url` setting (DB)
+   *   2. Global `appriseApiServerUrl` setting (DB) — set via Global Settings UI;
+   *      added in #3012 so desktop builds can target an externally-hosted
+   *      Apprise API server without env vars.
+   *   3. `APPRISE_URL` environment variable
+   *   4. `http://localhost:8000` (bundled in the Docker image via supervisord)
    */
   private async resolveAppriseConfig(sourceId: string): Promise<AppriseConfig | null> {
     try {
       const perSourceUrl = await databaseService.settings.getSettingForSource(sourceId, 'apprise_url');
       const enabledSetting = await databaseService.settings.getSettingForSource(sourceId, 'apprise_enabled');
-      // Fall back to APPRISE_URL env var if no per-source setting exists.
-      // This preserves zero-config quick-start deployments while still allowing
-      // per-source overrides via the settings UI.
-      // Bundled Apprise server runs on localhost:8000 by default in the
-      // meshmonitor container; preserves zero-config quick-start behavior.
-      const url = perSourceUrl || process.env.APPRISE_URL || 'http://localhost:8000';
+      const globalUrl = await databaseService.settings.getSetting('appriseApiServerUrl');
+      const url =
+        perSourceUrl ||
+        globalUrl ||
+        process.env.APPRISE_URL ||
+        'http://localhost:8000';
       if (!url) {
         logger.debug(`ℹ️ No apprise_url configured for source ${sourceId} (and no APPRISE_URL env)`);
         return null;


### PR DESCRIPTION
## Summary

- Adds an admin-only **Apprise API Server URL** field to the Global Settings page so desktop (macOS/Windows) builds can point MeshMonitor at an externally-hosted Apprise API server. Docker installs keep the zero-config bundled server at `http://localhost:8000`.
- Resolver precedence in `appriseNotificationService.resolveAppriseConfig` is now: per-source `apprise_url` → new global `appriseApiServerUrl` setting → `APPRISE_URL` env var → `http://localhost:8000`. Documented inline near the resolver.
- Backend uses the existing `POST /api/settings` allowlist (`settings:write` permission) with an http(s)-only URL validator; the new key (`appriseApiServerUrl`) is added to `VALID_SETTINGS_KEYS`. Empty/whitespace value clears the global override.
- Frontend adds a new global section (`settings-apprise-server`), gated on `isAdmin`, with help text:
  *"Leave empty if MeshMonitor's bundled Apprise API server is running (default for Docker installs)."*
- i18n: 4 new keys added to `en.json` and mirrored into every other locale (`de`, `es`, `fr`, `nb_NO`, `pt_BR`, `ru`, `sv`, `zh_Hans`) as English placeholders for Weblate to translate.

Closes #3012. Related: #3009.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 277 test files, 4798 tests pass (3 previously-red persistence/alignment cases updated to acknowledge the new key; new resolver tests added).
- [x] New `appriseNotificationService.resolver.test.ts` covers all four precedence rungs (per-source → global → env → default) plus the "empty global value falls through" case.
- [x] New cases in `settingsRoutes.test.ts` cover URL validation: valid http, valid https, empty/whitespace clears, non-http(s) scheme rejected, garbage rejected, 403 when lacking `settings:write`.
- [x] `npm run build` succeeds.
- [ ] Manual smoke test: open Settings → Apprise API Server (admin), enter `http://example:8000`, save, confirm `POST /api/settings` round-trips and the resolver picks it up on next Apprise dispatch.

Authored by Merlin 🪄