### PR TITLE
feat(meshcore): radio preset selector + dashboard map + channel sender fixes

### DIFF
--- a/scripts/meshcore-bridge.py
+++ b/scripts/meshcore-bridge.py
@@ -374,8 +374,11 @@ class MeshCoreBridge:
         sf = cmd_data.get('sf')
         cr = cmd_data.get('cr')
 
-        await self.meshcore.commands.set_radio(freq, bw, sf, cr)
-        return {'id': cmd_id, 'success': True, 'data': {'set': True}}
+        result = await self.meshcore.commands.set_radio(freq, bw, sf, cr)
+        if result is not None and getattr(result, 'is_error', lambda: False)():
+            err = getattr(result, 'payload', None) or 'device rejected set_radio'
+            return {'id': cmd_id, 'success': False, 'error': str(err)}
+        return {'id': cmd_id, 'success': True, 'data': {'set': True, 'freq': freq, 'bw': bw, 'sf': sf, 'cr': cr}}
 
     async def cmd_set_coords(self, cmd_id: str, cmd_data: dict) -> dict:
         """Set device GPS coordinates (lat/lon in decimal degrees)"""

--- a/src/components/MeshCore/MeshCoreConfigurationView.tsx
+++ b/src/components/MeshCore/MeshCoreConfigurationView.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ConnectionStatus, MeshCoreActions } from './hooks/useMeshCore';
+import { RADIO_PRESETS, findPresetId } from './radioPresets';
 
 interface MeshCoreConfigurationViewProps {
   status: ConnectionStatus | null;
@@ -23,6 +24,18 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
   const [lat, setLat] = useState<number>(local?.latitude ?? 0);
   const [lon, setLon] = useState<number>(local?.longitude ?? 0);
   const [advLoc, setAdvLoc] = useState<boolean>(local?.advLocPolicy === 1);
+
+  const presetId = useMemo(() => findPresetId(freq, bw, sf, cr), [freq, bw, sf, cr]);
+
+  const handlePresetChange = (id: string) => {
+    if (id === 'custom') return;
+    const preset = RADIO_PRESETS.find(p => p.id === id);
+    if (!preset) return;
+    setFreq(preset.freq);
+    setBw(preset.bw);
+    setSf(preset.sf);
+    setCr(preset.cr);
+  };
 
   const [savingName, setSavingName] = useState(false);
   const [savingRadio, setSavingRadio] = useState(false);
@@ -207,6 +220,20 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
           {t('meshcore.config.radio_hint',
             'Frequency (137–1020 MHz), Bandwidth (kHz), Spreading Factor (5–12), Coding Rate (5–8 → 4/5 – 4/8).')}
         </p>
+        <div>
+          <label htmlFor="mc-cfg-preset">{t('meshcore.config.preset', 'Preset')}</label>
+          <select
+            id="mc-cfg-preset"
+            value={presetId}
+            onChange={e => handlePresetChange(e.target.value)}
+            disabled={!connected || savingRadio}
+          >
+            <option value="custom">{t('meshcore.config.preset.custom', 'Custom')}</option>
+            {RADIO_PRESETS.map(p => (
+              <option key={p.id} value={p.id}>{p.label}</option>
+            ))}
+          </select>
+        </div>
         <div className="form-row">
           <div>
             <label>{t('meshcore.config.frequency', 'Frequency (MHz)')}</label>

--- a/src/components/MeshCore/MeshCoreConfigurationView.tsx
+++ b/src/components/MeshCore/MeshCoreConfigurationView.tsx
@@ -50,21 +50,19 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
   }, [local?.name]);
 
   useEffect(() => {
-    if (local) {
-      if (typeof local.radioFreq === 'number') setFreq(local.radioFreq);
-      if (typeof local.radioBw === 'number') setBw(local.radioBw);
-      if (typeof local.radioSf === 'number') setSf(local.radioSf);
-      if (typeof local.radioCr === 'number') setCr(local.radioCr);
-    }
-  }, [local]);
+    if (!local) return;
+    if (typeof local.radioFreq === 'number') setFreq(local.radioFreq);
+    if (typeof local.radioBw === 'number') setBw(local.radioBw);
+    if (typeof local.radioSf === 'number') setSf(local.radioSf);
+    if (typeof local.radioCr === 'number') setCr(local.radioCr);
+  }, [local?.radioFreq, local?.radioBw, local?.radioSf, local?.radioCr]);
 
   useEffect(() => {
-    if (local) {
-      if (typeof local.latitude === 'number') setLat(local.latitude);
-      if (typeof local.longitude === 'number') setLon(local.longitude);
-      if (typeof local.advLocPolicy === 'number') setAdvLoc(local.advLocPolicy === 1);
-    }
-  }, [local]);
+    if (!local) return;
+    if (typeof local.latitude === 'number') setLat(local.latitude);
+    if (typeof local.longitude === 'number') setLon(local.longitude);
+    if (typeof local.advLocPolicy === 'number') setAdvLoc(local.advLocPolicy === 1);
+  }, [local?.latitude, local?.longitude, local?.advLocPolicy]);
 
   const handleSaveName = async () => {
     if (!name.trim()) return;

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -79,7 +79,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
           const friendlyName = outgoing ? null : nameForKey(m.fromPublicKey);
           const fromLabel = outgoing
             ? t('meshcore.you', 'You')
-            : friendlyName ?? `${m.fromPublicKey.substring(0, 8)}…`;
+            : m.fromName ?? friendlyName ?? `${m.fromPublicKey.substring(0, 8)}…`;
           return (
             <div key={m.id} className={`mc-message-row ${outgoing ? 'outgoing' : ''}`}>
               <div className="mc-message-header">

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -52,6 +52,7 @@ export interface MeshCoreNode {
 export interface MeshCoreMessage {
   id: string;
   fromPublicKey: string;
+  fromName?: string;
   toPublicKey?: string;
   text: string;
   timestamp: number;

--- a/src/components/MeshCore/radioPresets.ts
+++ b/src/components/MeshCore/radioPresets.ts
@@ -1,0 +1,37 @@
+export interface RadioPreset {
+  id: string;
+  label: string;
+  freq: number;
+  bw: number;
+  sf: number;
+  cr: number;
+  region?: string;
+}
+
+export const RADIO_PRESETS: ReadonlyArray<RadioPreset> = [
+  { id: 'au',             label: 'Australia',               freq: 915.800, bw: 250,   sf: 10, cr: 5 },
+  { id: 'au-narrow',     label: 'Australia (Narrow)',       freq: 916.575, bw: 62.5,  sf: 7,  cr: 8 },
+  { id: 'au-mid',        label: 'Australia (Mid)',          freq: 915.075, bw: 125,   sf: 9,  cr: 5 },
+  { id: 'au-sa-wa',      label: 'Australia: SA, WA',        freq: 923.125, bw: 62.5,  sf: 8,  cr: 8 },
+  { id: 'au-qld',        label: 'Australia: QLD',           freq: 923.125, bw: 62.5,  sf: 8,  cr: 5 },
+  { id: 'eu-uk-narrow',  label: 'EU/UK (Narrow)',           freq: 869.618, bw: 62.5,  sf: 8,  cr: 8 },
+  { id: 'eu-uk-depr',    label: 'EU/UK (Deprecated)',       freq: 869.525, bw: 250,   sf: 11, cr: 5 },
+  { id: 'cz-narrow',     label: 'Czech Republic (Narrow)',  freq: 869.432, bw: 62.5,  sf: 7,  cr: 5 },
+  { id: 'eu433-lr',      label: 'EU 433MHz (Long Range)',   freq: 433.650, bw: 250,   sf: 11, cr: 5 },
+  { id: 'eu433-narrow',  label: 'EU 433MHz (Narrow)',       freq: 433.650, bw: 62.5,  sf: 8,  cr: 8 },
+  { id: 'nz',            label: 'New Zealand',              freq: 917.375, bw: 250,   sf: 11, cr: 5 },
+  { id: 'nz-narrow',     label: 'New Zealand (Narrow)',     freq: 917.375, bw: 62.5,  sf: 7,  cr: 5 },
+  { id: 'pt433',         label: 'Portugal 433',             freq: 433.375, bw: 62.5,  sf: 9,  cr: 6 },
+  { id: 'pt868',         label: 'Portugal 868',             freq: 869.618, bw: 62.5,  sf: 7,  cr: 6 },
+  { id: 'ch',            label: 'Switzerland',              freq: 869.618, bw: 62.5,  sf: 8,  cr: 8 },
+  { id: 'us-ca',         label: 'USA/Canada (Recommended)', freq: 910.525, bw: 62.5,  sf: 7,  cr: 5 },
+  { id: 'vn-narrow',     label: 'Vietnam (Narrow)',         freq: 920.250, bw: 62.5,  sf: 8,  cr: 5 },
+  { id: 'vn-depr',       label: 'Vietnam (Deprecated)',     freq: 920.250, bw: 250,   sf: 11, cr: 5 },
+];
+
+export function findPresetId(freq: number, bw: number, sf: number, cr: number): string {
+  const match = RADIO_PRESETS.find(
+    p => p.freq === freq && p.bw === bw && p.sf === sf && p.cr === cr,
+  );
+  return match?.id ?? 'custom';
+}

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -313,17 +313,27 @@ function mergeNodeRecords(records: any[]): any {
 export function mergeUnifiedSourceData(
   perSource: Array<{ nodes: unknown[]; traceroutes: unknown[]; neighborInfo: unknown[]; channels: unknown[] }>,
 ): { nodes: unknown[]; traceroutes: unknown[]; neighborInfo: unknown[]; channels: unknown[] } {
-  const recordsByNum = new Map<number, any[]>();
+  // Keys are stringified so MeshCore contacts (which don't have a meshtastic
+  // nodeNum and instead carry an `mc:<source>:<pubkey>` nodeId) don't all
+  // collapse into the bucket for nodeNum=0.
+  const recordsByKey = new Map<string, any[]>();
   const traceroutes: unknown[] = [];
   const neighborInfo: unknown[] = [];
   let channels: unknown[] = [];
 
   for (const ps of perSource) {
     for (const n of ps.nodes as any[]) {
-      if (n == null || typeof n.nodeNum !== 'number') continue;
-      const bucket = recordsByNum.get(n.nodeNum);
+      if (n == null) continue;
+      let key: string | null = null;
+      if (n.isMeshCore && typeof n.nodeId === 'string' && n.nodeId.length > 0) {
+        key = `mc:${n.nodeId}`;
+      } else if (typeof n.nodeNum === 'number') {
+        key = `mt:${n.nodeNum}`;
+      }
+      if (key == null) continue;
+      const bucket = recordsByKey.get(key);
       if (bucket) bucket.push(n);
-      else recordsByNum.set(n.nodeNum, [n]);
+      else recordsByKey.set(key, [n]);
     }
     traceroutes.push(...ps.traceroutes);
     neighborInfo.push(...ps.neighborInfo);
@@ -332,7 +342,7 @@ export function mergeUnifiedSourceData(
     }
   }
 
-  const nodes = Array.from(recordsByNum.values()).map(mergeNodeRecords);
+  const nodes = Array.from(recordsByKey.values()).map(mergeNodeRecords);
 
   return {
     nodes,

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -102,6 +102,9 @@ export interface MeshCoreContact {
 export interface MeshCoreMessage {
   id: string;
   fromPublicKey: string;
+  /** Display name parsed from the message body (channel messages only — MeshCore
+   *  channel packets carry no per-sender identity; the sender prefixes their name). */
+  fromName?: string;
   toPublicKey?: string; // null for broadcast
   text: string;
   timestamp: number;
@@ -497,10 +500,18 @@ class MeshCoreManager extends EventEmitter {
       dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
       logger.info(`[MeshCore:${this.sourceId}] Contact message from ${data.pubkey_prefix}: ${data.text}`);
     } else if (event_type === 'channel_message') {
+      // MeshCore channel packets have no sender field on the wire — the sender's
+      // device prefixes "Name: " onto the text body. Split it out so the UI can
+      // show the sender and the body separately.
+      const rawText: string = data.text ?? '';
+      const prefixMatch = rawText.match(/^([^:\n]{1,32}):\s*(.*)$/s);
+      const fromName = prefixMatch ? prefixMatch[1].trim() : undefined;
+      const body = prefixMatch ? prefixMatch[2] : rawText;
       const message: MeshCoreMessage = {
         id: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
         fromPublicKey: MeshCoreManager.channelPublicKey(data.channel_idx),
-        text: data.text,
+        fromName,
+        text: body,
         timestamp: data.sender_timestamp ? data.sender_timestamp * 1000 : Date.now(),
         snr: data.snr,
         sourceId: this.sourceId,
@@ -1035,6 +1046,19 @@ class MeshCoreManager extends EventEmitter {
     } else {
       try {
         const response = await this.sendBridgeCommand('set_radio', { freq, bw, sf, cr });
+        if (response.success) {
+          if (this.localNode) {
+            this.localNode.radioFreq = freq;
+            this.localNode.radioBw = bw;
+            this.localNode.radioSf = sf;
+            this.localNode.radioCr = cr;
+          }
+          try {
+            await this.refreshLocalNode();
+          } catch (refreshErr) {
+            logger.warn('[MeshCore] refreshLocalNode after set_radio failed:', refreshErr);
+          }
+        }
         return response.success;
       } catch (error) {
         logger.error('[MeshCore] Failed to set radio:', error);

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -474,6 +474,43 @@ router.get('/:id/nodes', requirePermission('nodes', 'read', { sourceIdFrom: 'par
     const source = await databaseService.sources.getSource(req.params.id);
     if (!source) return res.status(404).json({ error: 'Source not found' });
 
+    // MeshCore sources don't share the meshtastic node table — pull contacts
+    // (and localNode) directly from the per-source MeshCoreManager and map
+    // them into the dashboard's flat node shape.
+    if (source.type === 'meshcore') {
+      const mcManager = meshcoreManagerRegistry.get(source.id);
+      const mcNodes: any[] = [];
+      if (mcManager) {
+        for (const n of mcManager.getAllNodes()) {
+          if (n.latitude == null || n.longitude == null) continue;
+          if (n.latitude === 0 && n.longitude === 0) continue;
+          const lastHeard = typeof n.lastHeard === 'number'
+            ? Math.floor(n.lastHeard / 1000)
+            : Math.floor(Date.now() / 1000);
+          const pubKey = n.publicKey || '';
+          const nodeId = `mc:${mcManager.sourceId}:${pubKey.substring(0, 12)}`;
+          mcNodes.push({
+            nodeId,
+            nodeNum: 0,
+            sourceId: mcManager.sourceId,
+            isMeshCore: true,
+            isIgnored: false,
+            isFavorite: false,
+            user: { id: nodeId, longName: n.name, shortName: (n.name || '').substring(0, 4) },
+            longName: n.name,
+            shortName: (n.name || '').substring(0, 4),
+            latitude: n.latitude,
+            longitude: n.longitude,
+            position: { latitude: n.latitude, longitude: n.longitude },
+            lastHeard,
+            hopsAway: 0,
+            role: 0,
+          });
+        }
+      }
+      return res.json(mcNodes);
+    }
+
     // Nodes are stored per-source (composite PK (nodeNum, sourceId) since
     // migration 029). Filter strictly by this source so two sources viewing
     // overlapping meshes show only what each has actually heard.

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1003,7 +1003,44 @@ apiRouter.get('/nodes', optionalAuth(), async (req, res) => {
     // Filter nodes based on channel read permissions
     const filteredNodes = await filterNodesByChannelPermission(allNodes, (req as any).user);
     const enhancedNodes = await Promise.all(filteredNodes.map(node => enhanceNodeForClient(node, (req as any).user, estimatedPositions)));
-    res.json(enhancedNodes);
+
+    // Append MeshCore contacts/localNodes so the aggregate dashboard map can
+    // render them alongside Meshtastic nodes. MeshCore stores lastSeen in ms;
+    // dashboard age-cutoff expects seconds, so we down-convert here.
+    const meshcoreManagers = nodesSourceId
+      ? (meshcoreManagerRegistry.get(nodesSourceId) ? [meshcoreManagerRegistry.get(nodesSourceId)!] : [])
+      : meshcoreManagerRegistry.list();
+    const meshcoreNodes: any[] = [];
+    for (const mgr of meshcoreManagers) {
+      for (const n of mgr.getAllNodes()) {
+        if (n.latitude == null || n.longitude == null) continue;
+        if (n.latitude === 0 && n.longitude === 0) continue;
+        const lastHeard = typeof n.lastHeard === 'number'
+          ? Math.floor(n.lastHeard / 1000)
+          : Math.floor(Date.now() / 1000);
+        const pubKey = n.publicKey || '';
+        const nodeId = `mc:${mgr.sourceId}:${pubKey.substring(0, 12)}`;
+        meshcoreNodes.push({
+          nodeId,
+          nodeNum: 0,
+          sourceId: mgr.sourceId,
+          isMeshCore: true,
+          isIgnored: false,
+          isFavorite: false,
+          user: { id: nodeId, longName: n.name, shortName: (n.name || '').substring(0, 4) },
+          longName: n.name,
+          shortName: (n.name || '').substring(0, 4),
+          latitude: n.latitude,
+          longitude: n.longitude,
+          position: { latitude: n.latitude, longitude: n.longitude },
+          lastHeard,
+          hopsAway: 0,
+          role: 0,
+        });
+      }
+    }
+
+    res.json([...enhancedNodes, ...meshcoreNodes]);
   } catch (error) {
     logger.error('Error fetching nodes:', error);
     res.status(500).json({ error: 'Failed to fetch nodes' });


### PR DESCRIPTION
## Summary
- Adds a region-preset selector to the MeshCore device config (preset commit 2c4b0005 / 078d1e78 was already on this branch)
- Fixes preset/location Save flow: hydration effects no longer clobber staged edits when push events arrive; bridge propagates device errors; server cache refreshes from device after `set_radio` so refresh doesn't revert
- Channel messages now show the sender above the body (parses MeshCore's `"Name: "` prefix convention) instead of dumping the synthetic `channel-N` key in the sender slot
- MeshCore contacts now appear on the per-source dashboard map, the Unified view, and `/api/nodes` (was meshtastic-only)

## Test plan
- [ ] Pick a preset → click Save → reload page → values stick (and preset re-selects)
- [ ] Receive a channel message → sender label is the parsed name; body is just the body
- [ ] Per-source dashboard for a MeshCore source shows nodes-with-positions on the map
- [ ] Unified dashboard map shows MeshCore nodes alongside Meshtastic nodes
- [ ] No regression on Meshtastic-only dashboards
- [ ] Typecheck clean

Authored by Merlin 🪄