### PR TITLE
feat(meshcore): UI permission gating for write controls

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4175,6 +4175,7 @@
   "meshcore.config.frequency": "Frequency (MHz)",
   "meshcore.config.name_label": "Name",
   "meshcore.config.not_connected": "Connect to a device to change its configuration.",
+  "meshcore.config.permission_denied": "You don't have permission to change configuration for this source.",
   "meshcore.config.radio_hint": "Frequency (137–1020 MHz), Bandwidth (kHz), Spreading Factor (5–12), Coding Rate (5–8 → 4/5 – 4/8).",
   "meshcore.config.radio_params": "Radio parameters",
   "meshcore.config.save_name": "Save name",

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { MeshCoreMessage, MeshCoreActions, ConnectionStatus } from './hooks/useMeshCore';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
+import { useAuth } from '../../contexts/AuthContext';
 
 interface MeshCoreChannelsViewProps {
   messages: MeshCoreMessage[];
@@ -33,6 +34,8 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   actions,
 }) => {
   const { t } = useTranslation();
+  const { hasPermission } = useAuth();
+  const canSend = hasPermission('messages', 'write');
   const [selected, setSelected] = useState<string>('public');
   const channels: ChannelDef[] = [PUBLIC_CHANNEL];
 
@@ -74,7 +77,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
           messages={filtered}
           contacts={contacts}
           selfPublicKey={selfKey}
-          disabled={!connected}
+          disabled={!connected || !canSend}
           emptyText={t('meshcore.no_messages', 'No messages on this channel yet')}
           onSend={text => actions.sendMessage(text, active.toPublicKey)}
         />

--- a/src/components/MeshCore/MeshCoreConfigurationView.test.tsx
+++ b/src/components/MeshCore/MeshCoreConfigurationView.test.tsx
@@ -7,6 +7,14 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Auth: default to write-permitted; individual tests can override before
+// rendering by reassigning `authPermission`.
+let authPermission: (resource: string, action: string) => boolean = () => true;
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: (r: string, a: string) => authPermission(r, a) }),
+}));
+
 import { MeshCoreConfigurationView } from './MeshCoreConfigurationView';
 import type { ConnectionStatus, MeshCoreActions } from './hooks/useMeshCore';
 
@@ -126,5 +134,25 @@ describe('MeshCoreConfigurationView telemetry section', () => {
       />,
     );
     expect(screen.getByLabelText('meshcore.config.telemetry_base')).toBeDisabled();
+  });
+});
+
+describe('MeshCoreConfigurationView permission gating', () => {
+  it('disables every save control and surfaces a hint when configuration:write is denied', () => {
+    authPermission = (_resource, action) => action !== 'write';
+    try {
+      render(<MeshCoreConfigurationView status={makeStatus()} actions={makeActions()} />);
+
+      // Permission-denied hint is visible. (i18n mocked to return the key.)
+      expect(screen.getByText('meshcore.config.permission_denied')).toBeDefined();
+
+      // All four save buttons disabled.
+      expect(screen.getByText('meshcore.config.save_name')).toBeDisabled();
+      expect(screen.getByText('meshcore.config.save_location')).toBeDisabled();
+      expect(screen.getByText('meshcore.config.save_radio')).toBeDisabled();
+      expect(screen.getByText('meshcore.config.save_telemetry')).toBeDisabled();
+    } finally {
+      authPermission = () => true;
+    }
   });
 });

--- a/src/components/MeshCore/MeshCoreConfigurationView.tsx
+++ b/src/components/MeshCore/MeshCoreConfigurationView.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ConnectionStatus, MeshCoreActions, TelemetryMode } from './hooks/useMeshCore';
 import { RADIO_PRESETS, findPresetId } from './radioPresets';
+import { useAuth } from '../../contexts/AuthContext';
 
 const TELEMETRY_MODE_OPTIONS: TelemetryMode[] = ['always', 'device', 'never'];
 // MeshCore device types: COMPANION=1, REPEATER=2, ROOM_SERVER=3.
@@ -17,6 +18,8 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
   actions,
 }) => {
   const { t } = useTranslation();
+  const { hasPermission } = useAuth();
+  const canWriteConfig = hasPermission('configuration', 'write');
   const connected = status?.connected ?? false;
   const local = status?.localNode;
 
@@ -128,7 +131,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
 
   const advType = local?.advType;
   const isCompanionOnly = typeof advType === 'number' && COMPANION_ONLY_DEVICES.has(advType);
-  const telemetryDisabled = !connected || isCompanionOnly;
+  const telemetryDisabled = !connected || isCompanionOnly || !canWriteConfig;
 
   const handleSaveTelemetry = async () => {
     setSavingTelemetry(true);
@@ -157,6 +160,19 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
         </div>
       )}
 
+      {!canWriteConfig && (
+        <div
+          className="meshcore-empty-state"
+          style={{ marginBottom: '1rem', color: 'var(--ctp-yellow)' }}
+          role="status"
+        >
+          {t(
+            'meshcore.config.permission_denied',
+            "You don't have permission to change configuration for this source.",
+          )}
+        </div>
+      )}
+
       <div className="form-section">
         <h3>{t('meshcore.config.device_name', 'Device name')}</h3>
         <p className="hint">
@@ -172,7 +188,10 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
           disabled={!connected || savingName}
         />
         <div>
-          <button onClick={() => void handleSaveName()} disabled={!connected || savingName || !name.trim()}>
+          <button
+            onClick={() => void handleSaveName()}
+            disabled={!connected || savingName || !name.trim() || !canWriteConfig}
+          >
             {savingName
               ? t('meshcore.config.saving', 'Saving…')
               : t('meshcore.config.save_name', 'Save name')}
@@ -222,7 +241,9 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
         <div>
           <button
             onClick={() => void handleSaveLocation()}
-            disabled={!connected || savingLocation || !Number.isFinite(lat) || !Number.isFinite(lon)}
+            disabled={
+              !connected || savingLocation || !Number.isFinite(lat) || !Number.isFinite(lon) || !canWriteConfig
+            }
           >
             {savingLocation
               ? t('meshcore.config.saving', 'Saving…')
@@ -240,7 +261,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
               type="checkbox"
               checked={advLoc}
               onChange={e => void handleToggleAdvLoc(e.target.checked)}
-              disabled={!connected || savingAdvLoc}
+              disabled={!connected || savingAdvLoc || !canWriteConfig}
             />
             {t('meshcore.config.advert_loc_policy', 'Include location in adverts')}
           </label>
@@ -319,7 +340,10 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
           </div>
         </div>
         <div>
-          <button onClick={() => void handleSaveRadio()} disabled={!connected || savingRadio}>
+          <button
+            onClick={() => void handleSaveRadio()}
+            disabled={!connected || savingRadio || !canWriteConfig}
+          >
             {savingRadio
               ? t('meshcore.config.saving', 'Saving…')
               : t('meshcore.config.save_radio', 'Save radio settings')}

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -6,6 +6,7 @@ import {
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
 import { MeshCoreContactDetailPanel } from './MeshCoreContactDetailPanel';
+import { useAuth } from '../../contexts/AuthContext';
 
 interface MeshCoreDirectMessagesViewProps {
   messages: MeshCoreMessage[];
@@ -21,6 +22,8 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
   actions,
 }) => {
   const { t } = useTranslation();
+  const { hasPermission } = useAuth();
+  const canSend = hasPermission('messages', 'write');
   const [selected, setSelected] = useState<string | null>(null);
 
   const selfKey = status?.localNode?.publicKey;
@@ -122,7 +125,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
               messages={filtered}
               contacts={contacts}
               selfPublicKey={selfKey}
-              disabled={!connected}
+              disabled={!connected || !canSend}
               emptyText={t('meshcore.no_messages', 'No messages with this contact yet')}
               onSend={text => actions.sendMessage(text, selected)}
             />

--- a/src/components/MeshCore/MeshCoreSubToolbar.test.tsx
+++ b/src/components/MeshCore/MeshCoreSubToolbar.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+let authPermission: (resource: string, action: string) => boolean = () => true;
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: (r: string, a: string) => authPermission(r, a) }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => (typeof fallback === 'string' ? fallback : key),
+  }),
+}));
+
+import { MeshCoreSubToolbar } from './MeshCoreSubToolbar';
+
+describe('MeshCoreSubToolbar', () => {
+  it('renders the Configuration tab when configuration:read is granted', () => {
+    authPermission = () => true;
+    render(
+      <MeshCoreSubToolbar view="nodes" onSelect={() => {}} expanded onToggleExpanded={() => {}} />,
+    );
+    expect(screen.getByText('Configuration')).toBeDefined();
+  });
+
+  it('hides the Configuration tab when configuration:read is denied', () => {
+    authPermission = (resource, action) =>
+      !(resource === 'configuration' && action === 'read');
+    render(
+      <MeshCoreSubToolbar view="nodes" onSelect={() => {}} expanded onToggleExpanded={() => {}} />,
+    );
+    expect(screen.queryByText('Configuration')).toBeNull();
+    // Other tabs still visible.
+    expect(screen.getByText('Nodes')).toBeDefined();
+    expect(screen.getByText('Channels')).toBeDefined();
+    expect(screen.getByText('Direct Messages')).toBeDefined();
+    expect(screen.getByText('Settings')).toBeDefined();
+  });
+});

--- a/src/components/MeshCore/MeshCoreSubToolbar.tsx
+++ b/src/components/MeshCore/MeshCoreSubToolbar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../contexts/AuthContext';
 
 export type MeshCoreView = 'nodes' | 'channels' | 'dms' | 'configuration' | 'settings';
 
@@ -32,10 +33,13 @@ export const MeshCoreSubToolbar: React.FC<MeshCoreSubToolbarProps> = ({
   onToggleExpanded,
 }) => {
   const { t } = useTranslation();
+  const { hasPermission } = useAuth();
+  const canReadConfig = hasPermission('configuration', 'read');
 
   return (
     <aside className={`meshcore-sub-toolbar ${expanded ? 'expanded' : 'collapsed'}`}>
       {ITEMS.map(item => {
+        if (item.id === 'configuration' && !canReadConfig) return null;
         const label = t(item.labelKey, item.fallback);
         return (
           <button


### PR DESCRIPTION
## Summary

Closes the UI half of the MeshCore permissions audit. Server-side gating (migration 058, `requirePermission(...)` on every `/api/sources/:id/meshcore/*` route) is already complete; the React views, however, only gated at the **page** level. Write controls inside `MeshCoreConfigurationView`, `MeshCoreMessageStream`, and the Configuration tab in `MeshCoreSubToolbar` rendered enabled regardless of permission, so users with `connection:read` but no `configuration:write` / `messages:write` saw enabled buttons and silently 403'd on click.

This PR threads `useAuth().hasPermission(resource, action)` (auto-scoped to SourceContext) through the three remaining components:

- **`MeshCoreConfigurationView`** — `configuration:write` gates every save button (name, location, radio, telemetry) plus the advert-loc-policy checkbox. A yellow `permission_denied` banner renders at the top of the form when denied.
- **`MeshCoreDirectMessagesView`** + **`MeshCoreChannelsView`** — pass `disabled={!connected || !canSend}` to `MeshCoreMessageStream`, where `canSend = hasPermission('messages', 'write')`.
- **`MeshCoreSubToolbar`** — hides the Configuration tab when the user lacks `configuration:read`.

## Notes

- The audit also flagged "DM send error handling: no on-error display for 403 Forbidden." On closer reading, the `useMeshCore.sendMessage` path already calls `setError(data.error)` on `success: false`, which `MeshCorePage` renders in its inline error bar (line 63–70). So 403s are not silent today — no toast plumbing added here. If the page-level gates and the inline bar both fall through for some reason, that's its own story.
- New i18n key: `meshcore.config.permission_denied` (English only this PR; Hosted Weblate will pick up the rest).

## Files touched

- `src/components/MeshCore/MeshCoreConfigurationView.tsx` — gate writes, render banner
- `src/components/MeshCore/MeshCoreConfigurationView.test.tsx` — mock `useAuth`, add denied-state test
- `src/components/MeshCore/MeshCoreDirectMessagesView.tsx` — gate send via `canSend`
- `src/components/MeshCore/MeshCoreChannelsView.tsx` — gate send via `canSend`
- `src/components/MeshCore/MeshCoreSubToolbar.tsx` — hide Configuration tab on missing `configuration:read`
- `src/components/MeshCore/MeshCoreSubToolbar.test.tsx` (new) — tab visibility tests
- `public/locales/en.json` — `meshcore.config.permission_denied`

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run src/components/MeshCore src/pages/MeshCoreSourcePage.test.tsx` — **13/13 passing** (existing tests untouched, 3 new tests added)
- [x] Dev container torn down before opening this PR
- [ ] **Human eyeball needed** — please verify visually with a non-admin user: Configuration tab hides, save buttons disabled with the yellow banner visible, DM/channel send button disabled. Puppeteer not available in the sandbox.

Authored by Merlin 🪄