### PR TITLE
feat(meshcore): local-node telemetry collection + node Info page

### DIFF
--- a/scripts/meshcore-bridge.py
+++ b/scripts/meshcore-bridge.py
@@ -27,7 +27,14 @@ Commands:
 - set_telemetry_mode_base: {"id": "14", "cmd": "set_telemetry_mode_base", "mode": "always"}
 - set_telemetry_mode_loc: {"id": "15", "cmd": "set_telemetry_mode_loc", "mode": "device"}
 - set_telemetry_mode_env: {"id": "16", "cmd": "set_telemetry_mode_env", "mode": "never"}
+- get_stats: {"id": "17", "cmd": "get_stats", "type": "core" | "radio" | "packets"}
+- get_device_time: {"id": "18", "cmd": "get_device_time"}
+- device_query: {"id": "19", "cmd": "device_query"}
 - shutdown: {"id": "11", "cmd": "shutdown"}
+
+The get_stats / get_device_time / device_query commands hit only the locally-
+connected node over its companion-protocol serial/BLE link. They never put a
+packet on the air, so they are safe to poll on a fixed interval.
 """
 
 import asyncio
@@ -103,6 +110,12 @@ class MeshCoreBridge:
                 return await self.cmd_set_telemetry_mode_loc(cmd_id, cmd_data)
             elif cmd == 'set_telemetry_mode_env':
                 return await self.cmd_set_telemetry_mode_env(cmd_id, cmd_data)
+            elif cmd == 'get_stats':
+                return await self.cmd_get_stats(cmd_id, cmd_data)
+            elif cmd == 'get_device_time':
+                return await self.cmd_get_device_time(cmd_id)
+            elif cmd == 'device_query':
+                return await self.cmd_device_query(cmd_id)
             elif cmd == 'shutdown':
                 return await self.cmd_shutdown(cmd_id)
             elif cmd == 'ping':
@@ -464,6 +477,96 @@ class MeshCoreBridge:
     async def cmd_set_telemetry_mode_env(self, cmd_id: str, cmd_data: dict) -> dict:
         """Set environment telemetry sharing mode."""
         return await self._set_telemetry_mode(cmd_id, cmd_data, 'env')
+
+    async def cmd_get_stats(self, cmd_id: str, cmd_data: dict) -> dict:
+        """Fetch local-node stats. type ∈ {core, radio, packets}.
+
+        These are GetStats(subtype) over the companion-protocol link to the
+        locally-connected node ONLY — they do not transmit on the air.
+        """
+        if not self.connected or not self.meshcore:
+            return {'id': cmd_id, 'success': False, 'error': 'Not connected'}
+
+        stats_type = (cmd_data.get('type') or '').strip().lower()
+        if stats_type == 'core':
+            getter = getattr(self.meshcore.commands, 'get_stats_core', None)
+        elif stats_type == 'radio':
+            getter = getattr(self.meshcore.commands, 'get_stats_radio', None)
+        elif stats_type == 'packets':
+            getter = getattr(self.meshcore.commands, 'get_stats_packets', None)
+        else:
+            return {'id': cmd_id, 'success': False, 'error': 'type must be core|radio|packets'}
+
+        if getter is None:
+            return {'id': cmd_id, 'success': False, 'error': f'meshcore lacks get_stats_{stats_type}'}
+
+        try:
+            event = await getter()
+        except Exception as e:
+            return {'id': cmd_id, 'success': False, 'error': f'get_stats_{stats_type} threw: {e}'}
+
+        if event is None:
+            return {'id': cmd_id, 'success': False, 'error': f'no response for get_stats_{stats_type}'}
+        if getattr(event, 'is_error', lambda: False)():
+            err = getattr(event, 'payload', None) or f'device rejected get_stats_{stats_type}'
+            return {'id': cmd_id, 'success': False, 'error': str(err)}
+
+        payload = getattr(event, 'payload', None)
+        if not isinstance(payload, dict):
+            return {'id': cmd_id, 'success': False, 'error': f'unexpected stats payload: {payload!r}'}
+
+        # Pass the dict through verbatim — Node side decides which fields it
+        # wants. python-meshcore field names: battery_mv, uptime_secs, errors,
+        # queue_len, noise_floor, last_rssi, last_snr, tx_air_secs, rx_air_secs,
+        # recv, sent, flood_tx, direct_tx, flood_rx, direct_rx, recv_errors.
+        return {'id': cmd_id, 'success': True, 'data': {'type': stats_type, **payload}}
+
+    async def cmd_get_device_time(self, cmd_id: str) -> dict:
+        """Read the RTC on the locally-connected node. Local only — no RF."""
+        if not self.connected or not self.meshcore:
+            return {'id': cmd_id, 'success': False, 'error': 'Not connected'}
+
+        getter = getattr(self.meshcore.commands, 'get_time', None)
+        if getter is None:
+            return {'id': cmd_id, 'success': False, 'error': 'meshcore lacks get_time'}
+
+        try:
+            event = await getter()
+        except Exception as e:
+            return {'id': cmd_id, 'success': False, 'error': f'get_time threw: {e}'}
+
+        if event is None:
+            return {'id': cmd_id, 'success': False, 'error': 'no response for get_time'}
+        if getattr(event, 'is_error', lambda: False)():
+            err = getattr(event, 'payload', None) or 'device rejected get_time'
+            return {'id': cmd_id, 'success': False, 'error': str(err)}
+
+        payload = getattr(event, 'payload', None) or {}
+        return {'id': cmd_id, 'success': True, 'data': {'time': payload.get('time')}}
+
+    async def cmd_device_query(self, cmd_id: str) -> dict:
+        """DeviceQuery → DeviceInfo. Local only — no RF."""
+        if not self.connected or not self.meshcore:
+            return {'id': cmd_id, 'success': False, 'error': 'Not connected'}
+
+        getter = getattr(self.meshcore.commands, 'send_device_query', None)
+        if getter is None:
+            return {'id': cmd_id, 'success': False, 'error': 'meshcore lacks send_device_query'}
+
+        try:
+            event = await getter()
+        except Exception as e:
+            return {'id': cmd_id, 'success': False, 'error': f'send_device_query threw: {e}'}
+
+        if event is None:
+            return {'id': cmd_id, 'success': False, 'error': 'no response for device_query'}
+        if getattr(event, 'is_error', lambda: False)():
+            err = getattr(event, 'payload', None) or 'device rejected device_query'
+            return {'id': cmd_id, 'success': False, 'error': str(err)}
+
+        payload = getattr(event, 'payload', None) or {}
+        # Forward verbatim: fw ver, fw_build (date string), model, ver, etc.
+        return {'id': cmd_id, 'success': True, 'data': dict(payload)}
 
     async def cmd_shutdown(self, cmd_id: str) -> dict:
         """Shutdown the bridge"""

--- a/src/components/MeshCore/MeshCoreInfoView.test.tsx
+++ b/src/components/MeshCore/MeshCoreInfoView.test.tsx
@@ -8,6 +8,7 @@
  * for non-Companion devices. The TanStack Query layer is shimmed via a
  * fresh `QueryClientProvider` per test so caches don't bleed across runs.
  */
+import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -33,7 +34,7 @@ class StubResizeObserver {
 // @ts-expect-error - polyfill for jsdom
 globalThis.ResizeObserver = StubResizeObserver;
 
-function withQueryClient(ui: React.ReactNode) {
+function withQueryClient(ui: ReactNode) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
   });

--- a/src/components/MeshCore/MeshCoreInfoView.test.tsx
+++ b/src/components/MeshCore/MeshCoreInfoView.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Smoke tests for the MeshCore Node Info view.
+ *
+ * Verifies the page renders the identity / radio / health blocks pulled
+ * from `/api/sources/:id/meshcore/info` and that the graph grid is hidden
+ * for non-Companion devices. The TanStack Query layer is shimmed via a
+ * fresh `QueryClientProvider` per test so caches don't bleed across runs.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MeshCoreInfoView } from './MeshCoreInfoView';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) => {
+      if (typeof fallback === 'string') return fallback;
+      return key;
+    },
+  }),
+}));
+
+// Recharts uses ResizeObserver. jsdom doesn't ship it, and the graph grid
+// only renders when there's *no* matching `mc_` telemetry anyway in these
+// tests — but pulling Recharts in still triggers it, so stub.
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// @ts-expect-error - polyfill for jsdom
+globalThis.ResizeObserver = StubResizeObserver;
+
+function withQueryClient(ui: React.ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+  });
+  return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
+}
+
+const PK = 'a'.repeat(60) + 'beef';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('MeshCoreInfoView', () => {
+  it('renders identity, radio, and health blocks from the info endpoint', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/meshcore/info')) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              sourceId: 'src-a',
+              connected: true,
+              deviceType: 1,
+              deviceTypeName: 'Companion',
+              identity: {
+                publicKey: PK,
+                name: 'MerlinNode',
+                advType: 1,
+                radioFreq: 869.525,
+                radioBw: 250,
+                radioSf: 11,
+                radioCr: 5,
+                txPower: 20,
+                maxTxPower: 22,
+                latitude: 30.123,
+                longitude: -90.456,
+                firmwareVer: 9,
+                firmwareBuild: '2024-11-01',
+                model: 'Heltec V3',
+                ver: '1.2.3',
+              },
+              latest: {
+                timestamp: 1700000000000,
+                batteryMv: 4080,
+                uptimeSecs: 3 * 3600 + 17 * 60,
+                queueLen: 3,
+                noiseFloor: -126,
+                lastRssi: -85,
+                lastSnr: 7.25,
+                rtcDriftSecs: -1,
+              },
+              telemetryRef: { nodeId: PK, nodeNum: 0xbeef, sourceId: 'src-a' },
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      // Telemetry endpoint — no rows yet, so the graphs grid stays empty.
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    render(
+      withQueryClient(
+        <MeshCoreInfoView baseUrl="" sourceId="src-a" status={null} />,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('MerlinNode')).toBeTruthy();
+    });
+
+    // Identity card — pubkey is shown in shortened form (first 12 + last 4).
+    expect(screen.getByText(`${PK.substring(0, 12)}…${PK.substring(PK.length - 4)}`)).toBeTruthy();
+    expect(screen.getByText('Heltec V3')).toBeTruthy();
+    expect(screen.getByText(/1\.2\.3/)).toBeTruthy();
+    expect(screen.getByText('30.12300, -90.45600')).toBeTruthy();
+
+    // Radio card
+    expect(screen.getByText('869.525 MHz')).toBeTruthy();
+    expect(screen.getByText('250 kHz')).toBeTruthy();
+    expect(screen.getByText('11')).toBeTruthy();
+    expect(screen.getByText('4/5')).toBeTruthy();
+    expect(screen.getByText('20 / 22 dBm')).toBeTruthy();
+
+    // Health card
+    expect(screen.getByText('4.08 V')).toBeTruthy();
+    expect(screen.getByText('3h 17m')).toBeTruthy();
+    expect(screen.getByText('3')).toBeTruthy();
+    expect(screen.getByText('-1 s')).toBeTruthy();
+  });
+
+  it('suppresses graphs and shows a note for non-Companion sources', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.endsWith('/meshcore/info')) {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              data: {
+                sourceId: 'src-rpt',
+                connected: true,
+                deviceType: 2, // Repeater
+                deviceTypeName: 'Repeater',
+                identity: { publicKey: PK, name: 'Repeater Rico', advType: 2 },
+                latest: null,
+                telemetryRef: { nodeId: PK, nodeNum: 1, sourceId: 'src-rpt' },
+              },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        }
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }) as unknown as typeof fetch,
+    );
+
+    render(
+      withQueryClient(
+        <MeshCoreInfoView baseUrl="" sourceId="src-rpt" status={null} />,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Repeater Rico')).toBeTruthy();
+    });
+
+    // The repeater path renders the note and *not* the graphs grid.
+    expect(screen.getByText(/Local stats are only available for Companion devices/)).toBeTruthy();
+    expect(screen.queryByTestId('meshcore-info-graphs')).toBeNull();
+  });
+
+  it('renders an empty-state when the source has no localNode', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              success: true,
+              data: {
+                sourceId: 'src-disconnected',
+                connected: false,
+                deviceType: 0,
+                deviceTypeName: 'Unknown',
+                identity: null,
+                latest: null,
+                telemetryRef: null,
+              },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+      ) as unknown as typeof fetch,
+    );
+
+    render(
+      withQueryClient(
+        <MeshCoreInfoView baseUrl="" sourceId="src-disconnected" status={null} />,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/source disconnected/i)).toBeTruthy();
+    });
+  });
+});

--- a/src/components/MeshCore/MeshCoreInfoView.tsx
+++ b/src/components/MeshCore/MeshCoreInfoView.tsx
@@ -1,0 +1,419 @@
+/**
+ * MeshCoreInfoView — per-source MeshCore "Node Info" page.
+ *
+ * Mirrors the Meshtastic node-info experience: identity card + current
+ * health stats + time-series graphs of everything the local-node poller
+ * collects. Data source:
+ *
+ *   - `GET /api/sources/:id/meshcore/info` → identity + most recent
+ *     poll snapshot (latest battery, queue, drift, packet counters, etc).
+ *   - `GET /api/telemetry/<pubkey>?sourceId=<id>&hours=<n>` → time-series
+ *     for graphing (already source-aware in the server).
+ *
+ * Graphs are intentionally hand-rolled rather than passed through
+ * `TelemetryGraphs` because that component is tightly coupled to
+ * Meshtastic-flavoured features (solar overlays, favorites mutation,
+ * purge-by-type permission gates). For MeshCore we want a simple
+ * read-only grid keyed on telemetryType strings prefixed `mc_`.
+ */
+
+import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { ComposedChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { ConnectionStatus } from './hooks/useMeshCore';
+import { useTelemetry } from '../../hooks/useTelemetry';
+
+const HOURS_OPTIONS = [1, 6, 24, 72, 168] as const;
+type HoursOption = typeof HOURS_OPTIONS[number];
+
+/** Display order + label/unit/color for each `mc_*` telemetry type. */
+const MC_TELEMETRY_DISPLAY: Array<{ type: string; label: string; unit?: string; color: string; integer?: boolean }> = [
+  { type: 'mc_battery_volts', label: 'Battery', unit: 'V', color: '#a6e3a1' },
+  { type: 'mc_queue_len', label: 'Queue Length', color: '#f9e2af', integer: true },
+  { type: 'mc_noise_floor', label: 'Noise Floor', unit: 'dBm', color: '#fab387' },
+  { type: 'mc_last_rssi', label: 'Last RSSI', unit: 'dBm', color: '#f5c2e7' },
+  { type: 'mc_last_snr', label: 'Last SNR', unit: 'dB', color: '#94e2d5' },
+  { type: 'mc_tx_duty_pct', label: 'TX Duty Cycle', unit: '%', color: '#f38ba8' },
+  { type: 'mc_rx_duty_pct', label: 'RX Duty Cycle', unit: '%', color: '#89dceb' },
+  { type: 'mc_pkt_sent_rate', label: 'Packets Sent', unit: '/min', color: '#cba6f7' },
+  { type: 'mc_pkt_recv_rate', label: 'Packets Received', unit: '/min', color: '#74c7ec' },
+  { type: 'mc_rtc_drift_secs', label: 'RTC Drift', unit: 's', color: '#f2cdcd' },
+  { type: 'mc_uptime_secs', label: 'Uptime', unit: 's', color: '#b4befe' },
+];
+
+/** Cumulative-counter telemetry types — shown as a small table, not graphed. */
+const MC_COUNTERS: Array<{ type: string; label: string }> = [
+  { type: 'mc_pkt_recv', label: 'Packets recv (total)' },
+  { type: 'mc_pkt_sent', label: 'Packets sent (total)' },
+  { type: 'mc_pkt_flood_tx', label: 'Flood TX' },
+  { type: 'mc_pkt_direct_tx', label: 'Direct TX' },
+  { type: 'mc_pkt_flood_rx', label: 'Flood RX' },
+  { type: 'mc_pkt_direct_rx', label: 'Direct RX' },
+  { type: 'mc_pkt_recv_errors', label: 'Receive errors' },
+  { type: 'mc_tx_air_secs', label: 'TX air-time total (s)' },
+  { type: 'mc_rx_air_secs', label: 'RX air-time total (s)' },
+];
+
+interface MeshCoreInfoApiResponse {
+  success: boolean;
+  data: {
+    sourceId: string;
+    connected: boolean;
+    deviceType: number;
+    deviceTypeName: string;
+    identity: {
+      publicKey: string;
+      name: string;
+      advType: number;
+      txPower?: number;
+      maxTxPower?: number;
+      radioFreq?: number;
+      radioBw?: number;
+      radioSf?: number;
+      radioCr?: number;
+      latitude?: number;
+      longitude?: number;
+      advLocPolicy?: number;
+      firmwareVer?: number;
+      firmwareBuild?: string;
+      model?: string;
+      ver?: string;
+      telemetryModeBase?: string;
+      telemetryModeLoc?: string;
+      telemetryModeEnv?: string;
+    } | null;
+    latest: {
+      timestamp: number;
+      batteryMv?: number;
+      uptimeSecs?: number;
+      errors?: number;
+      queueLen?: number;
+      noiseFloor?: number;
+      lastRssi?: number;
+      lastSnr?: number;
+      txDutyPct?: number;
+      rxDutyPct?: number;
+      packetsRecv?: number;
+      packetsSent?: number;
+      floodTx?: number;
+      directTx?: number;
+      floodRx?: number;
+      directRx?: number;
+      recvErrors?: number | null;
+      packetsRecvRatePerMin?: number;
+      packetsSentRatePerMin?: number;
+      rtcDriftSecs?: number;
+      deviceInfo?: {
+        firmwareVer?: number;
+        firmwareBuild?: string;
+        model?: string;
+      };
+    } | null;
+    telemetryRef: { nodeId: string; nodeNum: number; sourceId: string } | null;
+  };
+}
+
+interface MeshCoreInfoViewProps {
+  baseUrl: string;
+  sourceId: string;
+  status: ConnectionStatus | null;
+}
+
+function fmtUptime(secs?: number): string {
+  if (secs === undefined || secs === null || !Number.isFinite(secs)) return '—';
+  const s = Math.floor(secs);
+  const days = Math.floor(s / 86400);
+  const hours = Math.floor((s % 86400) / 3600);
+  const mins = Math.floor((s % 3600) / 60);
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0 || days > 0) parts.push(`${hours}h`);
+  parts.push(`${mins}m`);
+  return parts.join(' ');
+}
+
+function fmtVolts(mv?: number): string {
+  if (mv === undefined || mv === null || !Number.isFinite(mv)) return '—';
+  return `${(mv / 1000).toFixed(2)} V`;
+}
+
+function fmtNumber(v?: number | null, suffix = ''): string {
+  if (v === undefined || v === null || !Number.isFinite(v)) return '—';
+  return `${Math.round(v * 100) / 100}${suffix}`;
+}
+
+function fmtDrift(s?: number): string {
+  if (s === undefined || s === null || !Number.isFinite(s)) return '—';
+  const sign = s > 0 ? '+' : '';
+  return `${sign}${s} s`;
+}
+
+function fmtPubkeyShort(pk?: string): string {
+  if (!pk) return '—';
+  return `${pk.substring(0, 12)}…${pk.substring(pk.length - 4)}`;
+}
+
+function fmtFreq(mhz?: number): string {
+  if (mhz === undefined || mhz === null || !Number.isFinite(mhz)) return '—';
+  return `${mhz.toFixed(3)} MHz`;
+}
+
+export const MeshCoreInfoView: React.FC<MeshCoreInfoViewProps> = ({ baseUrl, sourceId, status }) => {
+  const { t } = useTranslation();
+  const [hours, setHours] = useState<HoursOption>(24);
+
+  // Fetch identity + latest snapshot from the server. Refetch every 30s so the
+  // dashboard reflects each new poll cycle without being chatty.
+  const { data: infoResp, isLoading: infoLoading, error: infoError } = useQuery({
+    queryKey: ['meshcore-info', sourceId],
+    queryFn: async (): Promise<MeshCoreInfoApiResponse> => {
+      const resp = await fetch(`${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/info`);
+      if (!resp.ok) throw new Error(`Failed to fetch info: ${resp.status}`);
+      return resp.json();
+    },
+    refetchInterval: 30_000,
+    staleTime: 25_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const info = infoResp?.data;
+  const identity = info?.identity ?? status?.localNode ?? null;
+  const latest = info?.latest ?? null;
+  const telemetryRef = info?.telemetryRef ?? null;
+
+  // Time-series for the graphs.
+  const { data: telemetryRows = [], isLoading: telLoading } = useTelemetry({
+    nodeId: telemetryRef?.nodeId ?? '',
+    sourceId: telemetryRef?.sourceId,
+    hours,
+    baseUrl,
+    enabled: !!telemetryRef?.nodeId,
+  });
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, Array<{ timestamp: number; value: number }>>();
+    for (const row of telemetryRows) {
+      if (!row.telemetryType.startsWith('mc_')) continue;
+      let arr = map.get(row.telemetryType);
+      if (!arr) {
+        arr = [];
+        map.set(row.telemetryType, arr);
+      }
+      arr.push({ timestamp: row.timestamp, value: row.value });
+    }
+    for (const arr of map.values()) arr.sort((a, b) => a.timestamp - b.timestamp);
+    return map;
+  }, [telemetryRows]);
+
+  const counterValues = useMemo(() => {
+    const out = new Map<string, number>();
+    for (const { type } of MC_COUNTERS) {
+      const arr = grouped.get(type);
+      if (arr && arr.length > 0) {
+        out.set(type, arr[arr.length - 1].value);
+      }
+    }
+    return out;
+  }, [grouped]);
+
+  if (infoLoading && !info) {
+    return <div className="meshcore-info-loading">{t('meshcore.info.loading', 'Loading…')}</div>;
+  }
+
+  if (infoError) {
+    return (
+      <div className="meshcore-info-error">
+        {t('meshcore.info.load_failed', 'Failed to load node info')}: {String(infoError)}
+      </div>
+    );
+  }
+
+  if (!identity) {
+    return (
+      <div className="meshcore-info-empty">
+        {t('meshcore.info.not_connected', 'No local node info — source disconnected.')}
+      </div>
+    );
+  }
+
+  const isCompanion = (info?.deviceType ?? identity.advType) === 1;
+
+  return (
+    <div className="meshcore-info-view" data-testid="meshcore-info-view">
+      <div className="meshcore-info-grid">
+        <section className="meshcore-info-card" data-testid="meshcore-info-identity">
+          <h3>{t('meshcore.info.identity', 'Identity')}</h3>
+          <dl>
+            <dt>{t('meshcore.info.name', 'Name')}</dt>
+            <dd>{identity.name || '—'}</dd>
+            <dt>{t('meshcore.info.pubkey', 'Public key')}</dt>
+            <dd title={identity.publicKey}>{fmtPubkeyShort(identity.publicKey)}</dd>
+            <dt>{t('meshcore.info.device_type', 'Device type')}</dt>
+            <dd>{info?.deviceTypeName ?? (identity.advType === 1 ? 'Companion' : 'Other')}</dd>
+            <dt>{t('meshcore.info.model', 'Model')}</dt>
+            <dd>{identity.model || '—'}</dd>
+            <dt>{t('meshcore.info.firmware', 'Firmware')}</dt>
+            <dd>
+              {identity.ver || identity.firmwareVer !== undefined
+                ? `${identity.ver ?? `v${identity.firmwareVer}`}${identity.firmwareBuild ? ` (${identity.firmwareBuild})` : ''}`
+                : '—'}
+            </dd>
+            <dt>{t('meshcore.info.position', 'Advertised position')}</dt>
+            <dd>
+              {typeof identity.latitude === 'number' && typeof identity.longitude === 'number'
+                ? `${identity.latitude.toFixed(5)}, ${identity.longitude.toFixed(5)}`
+                : '—'}
+            </dd>
+          </dl>
+        </section>
+
+        <section className="meshcore-info-card" data-testid="meshcore-info-radio">
+          <h3>{t('meshcore.info.radio', 'Radio')}</h3>
+          <dl>
+            <dt>{t('meshcore.info.frequency', 'Frequency')}</dt>
+            <dd>{fmtFreq(identity.radioFreq)}</dd>
+            <dt>{t('meshcore.info.bandwidth', 'Bandwidth')}</dt>
+            <dd>{identity.radioBw !== undefined ? `${identity.radioBw} kHz` : '—'}</dd>
+            <dt>{t('meshcore.info.sf', 'Spreading factor')}</dt>
+            <dd>{identity.radioSf ?? '—'}</dd>
+            <dt>{t('meshcore.info.cr', 'Coding rate')}</dt>
+            <dd>{identity.radioCr ? `4/${identity.radioCr}` : '—'}</dd>
+            <dt>{t('meshcore.info.tx_power', 'TX power')}</dt>
+            <dd>
+              {identity.txPower !== undefined
+                ? `${identity.txPower}${identity.maxTxPower !== undefined ? ` / ${identity.maxTxPower}` : ''} dBm`
+                : '—'}
+            </dd>
+          </dl>
+        </section>
+
+        <section className="meshcore-info-card" data-testid="meshcore-info-health">
+          <h3>{t('meshcore.info.health', 'Current health')}</h3>
+          {!isCompanion ? (
+            <p className="meshcore-info-note">
+              {t('meshcore.info.repeater_no_stats', 'Local stats are only available for Companion devices.')}
+            </p>
+          ) : latest ? (
+            <dl>
+              <dt>{t('meshcore.info.battery', 'Battery')}</dt>
+              <dd>{fmtVolts(latest.batteryMv)}</dd>
+              <dt>{t('meshcore.info.uptime', 'Uptime')}</dt>
+              <dd>{fmtUptime(latest.uptimeSecs)}</dd>
+              <dt>{t('meshcore.info.queue', 'TX queue')}</dt>
+              <dd>{fmtNumber(latest.queueLen)}</dd>
+              <dt>{t('meshcore.info.noise_floor', 'Noise floor')}</dt>
+              <dd>{fmtNumber(latest.noiseFloor, ' dBm')}</dd>
+              <dt>{t('meshcore.info.last_rssi', 'Last RSSI')}</dt>
+              <dd>{fmtNumber(latest.lastRssi, ' dBm')}</dd>
+              <dt>{t('meshcore.info.last_snr', 'Last SNR')}</dt>
+              <dd>{fmtNumber(latest.lastSnr, ' dB')}</dd>
+              <dt>{t('meshcore.info.rtc_drift', 'RTC drift vs server')}</dt>
+              <dd>{fmtDrift(latest.rtcDriftSecs)}</dd>
+              <dt>{t('meshcore.info.last_poll', 'Last poll')}</dt>
+              <dd>{new Date(latest.timestamp).toLocaleString()}</dd>
+            </dl>
+          ) : (
+            <p className="meshcore-info-note">
+              {t('meshcore.info.awaiting_poll', 'Waiting for first telemetry poll…')}
+            </p>
+          )}
+        </section>
+
+        <section className="meshcore-info-card" data-testid="meshcore-info-counters">
+          <h3>{t('meshcore.info.counters', 'Cumulative counters')}</h3>
+          {counterValues.size === 0 ? (
+            <p className="meshcore-info-note">{t('meshcore.info.no_counters', 'No counter data yet.')}</p>
+          ) : (
+            <dl>
+              {MC_COUNTERS.map(({ type, label }) => (
+                counterValues.has(type) ? (
+                  <React.Fragment key={type}>
+                    <dt>{label}</dt>
+                    <dd>{counterValues.get(type)?.toLocaleString()}</dd>
+                  </React.Fragment>
+                ) : null
+              ))}
+            </dl>
+          )}
+        </section>
+      </div>
+
+      {isCompanion && (
+        <section className="meshcore-info-graphs" data-testid="meshcore-info-graphs">
+          <div className="meshcore-info-graphs-header">
+            <h3>{t('meshcore.info.history', 'History')}</h3>
+            <div className="meshcore-info-range" role="group" aria-label="Time range">
+              {HOURS_OPTIONS.map((h) => (
+                <button
+                  key={h}
+                  className={`mc-range-btn ${hours === h ? 'active' : ''}`}
+                  onClick={() => setHours(h)}
+                >
+                  {h < 24 ? `${h}h` : `${h / 24}d`}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {telLoading && telemetryRows.length === 0 ? (
+            <div className="meshcore-info-note">{t('meshcore.info.loading_graphs', 'Loading graphs…')}</div>
+          ) : (
+            <div className="meshcore-info-graphs-grid">
+              {MC_TELEMETRY_DISPLAY.map(({ type, label, unit, color, integer }) => {
+                const data = grouped.get(type) ?? [];
+                if (data.length === 0) return null;
+                return (
+                  <div key={type} className="meshcore-info-graph">
+                    <div className="meshcore-info-graph-title">
+                      {label}
+                      {unit ? ` (${unit})` : ''}
+                    </div>
+                    <ResponsiveContainer width="100%" height={180}>
+                      <ComposedChart data={data} margin={{ top: 5, right: 12, bottom: 5, left: 0 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="#444" />
+                        <XAxis
+                          dataKey="timestamp"
+                          type="number"
+                          domain={['dataMin', 'dataMax']}
+                          tick={{ fontSize: 11 }}
+                          tickFormatter={(v) => new Date(v).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                        />
+                        <YAxis
+                          tick={{ fontSize: 11 }}
+                          domain={['auto', 'auto']}
+                          allowDecimals={!integer}
+                          tickFormatter={integer ? (v: number) => Math.round(v).toString() : undefined}
+                        />
+                        <Tooltip
+                          labelFormatter={(v) => new Date(v as number).toLocaleString()}
+                          formatter={(v) => [
+                            typeof v === 'number'
+                              ? `${Math.round(v * 100) / 100}${unit ? ' ' + unit : ''}`
+                              : String(v ?? ''),
+                            label,
+                          ]}
+                        />
+                        <Line
+                          type="monotone"
+                          dataKey="value"
+                          stroke={color}
+                          strokeWidth={2}
+                          dot={{ fill: color, r: 2 }}
+                          activeDot={{ r: 4 }}
+                          isAnimationActive={false}
+                        />
+                      </ComposedChart>
+                    </ResponsiveContainer>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default MeshCoreInfoView;

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -570,3 +570,128 @@
   background: var(--ctp-surface2);
   border-radius: var(--radius-xs);
 }
+
+/* ============================================================
+ * Node Info view — identity + health + graphs
+ * ============================================================ */
+
+.meshcore-info-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  overflow-y: auto;
+  height: 100%;
+}
+
+.meshcore-info-loading,
+.meshcore-info-error,
+.meshcore-info-empty {
+  padding: 2rem;
+  text-align: center;
+  color: var(--ctp-subtext0);
+}
+
+.meshcore-info-error {
+  color: var(--ctp-red);
+}
+
+.meshcore-info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.meshcore-info-card {
+  background: var(--ctp-surface0);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+}
+
+.meshcore-info-card h3 {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.95rem;
+  color: var(--ctp-text);
+  border-bottom: 1px solid var(--ctp-surface1);
+  padding-bottom: 0.5rem;
+}
+
+.meshcore-info-card dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.4rem 0.75rem;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.meshcore-info-card dt {
+  color: var(--ctp-subtext0);
+  font-weight: 500;
+}
+
+.meshcore-info-card dd {
+  color: var(--ctp-text);
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+  word-break: break-word;
+}
+
+.meshcore-info-note {
+  color: var(--ctp-subtext0);
+  font-size: 0.85rem;
+  font-style: italic;
+  margin: 0;
+}
+
+.meshcore-info-graphs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.meshcore-info-graphs-header h3 {
+  margin: 0;
+  color: var(--ctp-text);
+}
+
+.meshcore-info-range {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.meshcore-info-range .mc-range-btn {
+  background: var(--ctp-surface0);
+  color: var(--ctp-subtext0);
+  border: 1px solid var(--ctp-surface1);
+  padding: 0.25rem 0.6rem;
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.meshcore-info-range .mc-range-btn.active {
+  background: var(--ctp-blue);
+  color: var(--ctp-base);
+  border-color: var(--ctp-blue);
+}
+
+.meshcore-info-graphs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1rem;
+}
+
+.meshcore-info-graph {
+  background: var(--ctp-surface0);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: var(--radius-md);
+  padding: 0.75rem;
+}
+
+.meshcore-info-graph-title {
+  font-size: 0.85rem;
+  color: var(--ctp-text);
+  margin-bottom: 0.5rem;
+}

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -22,6 +22,7 @@ import { MeshCoreSubToolbar, MeshCoreView } from './MeshCoreSubToolbar';
 import { MeshCoreNodesView } from './MeshCoreNodesView';
 import { MeshCoreChannelsView } from './MeshCoreChannelsView';
 import { MeshCoreDirectMessagesView } from './MeshCoreDirectMessagesView';
+import { MeshCoreInfoView } from './MeshCoreInfoView';
 import { MeshCoreConfigurationView } from './MeshCoreConfigurationView';
 import { MeshCoreSettingsView } from './MeshCoreSettingsView';
 import './MeshCoreTab.css';
@@ -75,6 +76,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
           onSelect={setView}
           expanded={toolbarExpanded}
           onToggleExpanded={() => setToolbarExpanded(v => !v)}
+          showInfo={!!sourceId}
         />
         <div className="meshcore-content">
           {view === 'nodes' && (
@@ -90,6 +92,9 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
               status={status}
               actions={actions}
             />
+          )}
+          {view === 'info' && sourceId && (
+            <MeshCoreInfoView baseUrl={baseUrl} sourceId={sourceId} status={status} />
           )}
           {view === 'configuration' && (
             <MeshCoreConfigurationView status={status} actions={actions} />

--- a/src/components/MeshCore/MeshCoreSubToolbar.tsx
+++ b/src/components/MeshCore/MeshCoreSubToolbar.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../contexts/AuthContext';
 
-export type MeshCoreView = 'nodes' | 'channels' | 'dms' | 'configuration' | 'settings';
+export type MeshCoreView = 'nodes' | 'channels' | 'dms' | 'info' | 'configuration' | 'settings';
 
 interface MeshCoreSubToolbarProps {
   view: MeshCoreView;
   onSelect: (view: MeshCoreView) => void;
   expanded: boolean;
   onToggleExpanded: () => void;
+  /** When false, the Info entry is suppressed (no source context — it would have no data). */
+  showInfo?: boolean;
 }
 
 interface Item {
@@ -22,6 +24,7 @@ const ITEMS: Item[] = [
   { id: 'nodes', icon: '🛰', labelKey: 'meshcore.nav.nodes', fallback: 'Nodes' },
   { id: 'channels', icon: '💬', labelKey: 'meshcore.nav.channels', fallback: 'Channels' },
   { id: 'dms', icon: '📧', labelKey: 'meshcore.nav.dms', fallback: 'Direct Messages' },
+  { id: 'info', icon: 'ℹ', labelKey: 'meshcore.nav.info', fallback: 'Node Info' },
   { id: 'configuration', icon: '📡', labelKey: 'meshcore.nav.configuration', fallback: 'Configuration' },
   { id: 'settings', icon: '⚙', labelKey: 'meshcore.nav.settings', fallback: 'Settings' },
 ];
@@ -31,6 +34,7 @@ export const MeshCoreSubToolbar: React.FC<MeshCoreSubToolbarProps> = ({
   onSelect,
   expanded,
   onToggleExpanded,
+  showInfo = true,
 }) => {
   const { t } = useTranslation();
   const { hasPermission } = useAuth();
@@ -40,6 +44,8 @@ export const MeshCoreSubToolbar: React.FC<MeshCoreSubToolbarProps> = ({
     <aside className={`meshcore-sub-toolbar ${expanded ? 'expanded' : 'collapsed'}`}>
       {ITEMS.map(item => {
         if (item.id === 'configuration' && !canReadConfig) return null;
+        // Info is per-source only — it reads /api/sources/:id/meshcore/info.
+        if (item.id === 'info' && !showInfo) return null;
         const label = t(item.labelKey, item.fallback);
         return (
           <button

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -37,6 +37,7 @@ export interface MeshCoreNode {
   name: string;
   advType: number;
   txPower?: number;
+  maxTxPower?: number;
   radioFreq?: number;
   radioBw?: number;
   radioSf?: number;
@@ -52,6 +53,11 @@ export interface MeshCoreNode {
   telemetryModeBase?: TelemetryMode;
   telemetryModeLoc?: TelemetryMode;
   telemetryModeEnv?: TelemetryMode;
+  /** Populated from DeviceQuery by the server-side telemetry poller. */
+  firmwareVer?: number;
+  firmwareBuild?: string;
+  model?: string;
+  ver?: string;
 }
 
 export interface MeshCoreMessage {

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 58 migrations registered', () => {
-    expect(registry.count()).toBe(58);
+  it('has all 59 migrations registered', () => {
+    expect(registry.count()).toBe(59);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is collapse_meshcore_resource', () => {
+  it('last migration is telemetry_source_node_type_ts_index', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(58);
-    expect(last.name).toContain('collapse_meshcore_resource');
+    expect(last.number).toBe(59);
+    expect(last.name).toContain('telemetry_source_node_type_ts_index');
   });
 
-  it('migrations are sequentially numbered from 1 to 58', () => {
+  it('migrations are sequentially numbered from 1 to 59', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -70,6 +70,7 @@ import { migration as seedGlobalWaypointsPermissionMigration, runMigration055Pos
 import { migration as addShowTraceroutesToEmbedProfilesMigration, runMigration056Postgres, runMigration056Mysql } from '../server/migrations/056_add_show_traceroutes_to_embed_profiles.js';
 import { migration as addSourceIdToMeshcoreTablesMigration, runMigration057Postgres, runMigration057Mysql } from '../server/migrations/057_add_source_id_to_meshcore_tables.js';
 import { migration as collapseMeshcoreResourceMigration, runMigration058Postgres, runMigration058Mysql } from '../server/migrations/058_collapse_meshcore_resource.js';
+import { migration as telemetrySourceNodeTypeTsIndexMigration, runMigration059Postgres, runMigration059Mysql } from '../server/migrations/059_telemetry_source_node_type_ts_index.js';
 
 // ============================================================================
 // Registry
@@ -901,4 +902,20 @@ registry.register({
   sqlite: (db) => collapseMeshcoreResourceMigration.up(db),
   postgres: (client) => runMigration058Postgres(client),
   mysql: (pool) => runMigration058Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 059: Add (sourceId, nodeId, telemetryType, timestamp DESC) index
+// to back the MeshCore Info-page time-series queries. Migration 049 covered
+// the equality columns but stopped short of `timestamp`, forcing a sort on
+// each range fetch. Idempotent across SQLite / PostgreSQL / MySQL.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 59,
+  name: 'telemetry_source_node_type_ts_index',
+  settingsKey: 'migration_059_telemetry_source_node_type_ts_index',
+  sqlite: (db) => telemetrySourceNodeTypeTsIndexMigration.up(db),
+  postgres: (client) => runMigration059Postgres(client),
+  mysql: (pool) => runMigration059Mysql(pool),
 });

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -96,6 +96,12 @@ export interface MeshCoreNode {
   telemetryModeBase?: TelemetryMode;
   telemetryModeLoc?: TelemetryMode;
   telemetryModeEnv?: TelemetryMode;
+  /** From DeviceQuery — populated by the telemetry poller. In-memory only;
+   *  re-derived from the device on each poll cycle (no DB persistence). */
+  firmwareVer?: number;
+  firmwareBuild?: string;
+  model?: string;
+  ver?: string;
 }
 
 export interface MeshCoreContact {
@@ -139,6 +145,48 @@ export interface MeshCoreStatus {
   radioBw?: number;
   radioSf?: number;
   radioCr?: number;
+}
+
+/**
+ * Local-node stats fetched over the companion-protocol link. These never
+ * touch the air — they read counters/state from the directly-connected
+ * node. Field names match what python-meshcore returns.
+ */
+export interface MeshCoreStatsCore {
+  batteryMv?: number;
+  uptimeSecs?: number;
+  errors?: number;
+  queueLen?: number;
+}
+
+export interface MeshCoreStatsRadio {
+  noiseFloor?: number;
+  lastRssi?: number;
+  lastSnr?: number;
+  txAirSecs?: number;
+  rxAirSecs?: number;
+}
+
+export interface MeshCoreStatsPackets {
+  recv?: number;
+  sent?: number;
+  floodTx?: number;
+  directTx?: number;
+  floodRx?: number;
+  directRx?: number;
+  recvErrors?: number | null;
+}
+
+export interface MeshCoreDeviceInfo {
+  firmwareVer?: number;
+  firmwareBuild?: string;
+  model?: string;
+  ver?: string;
+  maxContacts?: number;
+  maxChannels?: number;
+  blePin?: number;
+  repeat?: boolean;
+  pathHashMode?: number;
 }
 
 // Bridge command response
@@ -1189,6 +1237,126 @@ class MeshCoreManager extends EventEmitter {
    */
   async setTelemetryModeEnv(mode: TelemetryMode): Promise<boolean> {
     return this.setTelemetryMode('env', mode);
+  }
+
+  // ============ Local-node stats (companion only, no RF) ============
+  //
+  // These hit the locally-attached node over USB/BLE/TCP — they read counters
+  // and config off the directly-connected node and never transmit on the air.
+  // Safe to poll on a fixed interval. Returns null if not a companion, not
+  // connected, or the bridge call fails.
+
+  async getStatsCore(): Promise<MeshCoreStatsCore | null> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) return null;
+    try {
+      const response = await this.sendBridgeCommand('get_stats', { type: 'core' });
+      if (!response.success || !response.data) return null;
+      const d = response.data;
+      return {
+        batteryMv: typeof d.battery_mv === 'number' ? d.battery_mv : undefined,
+        uptimeSecs: typeof d.uptime_secs === 'number' ? d.uptime_secs : undefined,
+        errors: typeof d.errors === 'number' ? d.errors : undefined,
+        queueLen: typeof d.queue_len === 'number' ? d.queue_len : undefined,
+      };
+    } catch (error) {
+      logger.warn(`[MeshCore:${this.sourceId}] getStatsCore failed:`, error);
+      return null;
+    }
+  }
+
+  async getStatsRadio(): Promise<MeshCoreStatsRadio | null> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) return null;
+    try {
+      const response = await this.sendBridgeCommand('get_stats', { type: 'radio' });
+      if (!response.success || !response.data) return null;
+      const d = response.data;
+      return {
+        noiseFloor: typeof d.noise_floor === 'number' ? d.noise_floor : undefined,
+        lastRssi: typeof d.last_rssi === 'number' ? d.last_rssi : undefined,
+        lastSnr: typeof d.last_snr === 'number' ? d.last_snr : undefined,
+        txAirSecs: typeof d.tx_air_secs === 'number' ? d.tx_air_secs : undefined,
+        rxAirSecs: typeof d.rx_air_secs === 'number' ? d.rx_air_secs : undefined,
+      };
+    } catch (error) {
+      logger.warn(`[MeshCore:${this.sourceId}] getStatsRadio failed:`, error);
+      return null;
+    }
+  }
+
+  async getStatsPackets(): Promise<MeshCoreStatsPackets | null> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) return null;
+    try {
+      const response = await this.sendBridgeCommand('get_stats', { type: 'packets' });
+      if (!response.success || !response.data) return null;
+      const d = response.data;
+      return {
+        recv: typeof d.recv === 'number' ? d.recv : undefined,
+        sent: typeof d.sent === 'number' ? d.sent : undefined,
+        floodTx: typeof d.flood_tx === 'number' ? d.flood_tx : undefined,
+        directTx: typeof d.direct_tx === 'number' ? d.direct_tx : undefined,
+        floodRx: typeof d.flood_rx === 'number' ? d.flood_rx : undefined,
+        directRx: typeof d.direct_rx === 'number' ? d.direct_rx : undefined,
+        recvErrors: typeof d.recv_errors === 'number' ? d.recv_errors : null,
+      };
+    } catch (error) {
+      logger.warn(`[MeshCore:${this.sourceId}] getStatsPackets failed:`, error);
+      return null;
+    }
+  }
+
+  /** Read the RTC on the locally-connected node (Unix seconds). */
+  async getDeviceTime(): Promise<number | null> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) return null;
+    try {
+      const response = await this.sendBridgeCommand('get_device_time', {});
+      if (!response.success || !response.data) return null;
+      const t = response.data.time;
+      return typeof t === 'number' ? t : null;
+    } catch (error) {
+      logger.warn(`[MeshCore:${this.sourceId}] getDeviceTime failed:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Stamp DeviceQuery output onto the in-memory localNode. The poller calls
+   * this after a successful `deviceQuery()` so consumers of `getLocalNode()`
+   * (status endpoint, snapshot endpoint, Info page) immediately see firmware
+   * version, build date, and model alongside SelfInfo.
+   */
+  applyDeviceInfo(info: MeshCoreDeviceInfo): void {
+    if (!this.localNode) return;
+    if (info.firmwareVer !== undefined) this.localNode.firmwareVer = info.firmwareVer;
+    if (info.firmwareBuild !== undefined) this.localNode.firmwareBuild = info.firmwareBuild;
+    if (info.model !== undefined) this.localNode.model = info.model;
+    if (info.ver !== undefined) this.localNode.ver = info.ver;
+    dataEventEmitter.emitMeshCoreLocalNodeUpdated(this.localNode, this.sourceId);
+  }
+
+  /** DeviceQuery → DeviceInfo (firmware version, build date, model, etc). */
+  async deviceQuery(): Promise<MeshCoreDeviceInfo | null> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) return null;
+    try {
+      const response = await this.sendBridgeCommand('device_query', {});
+      if (!response.success || !response.data) return null;
+      const d = response.data;
+      // python-meshcore returns "fw ver" (with a space) for the version byte.
+      const fwVerRaw = d['fw ver'] ?? d.fw_ver;
+      return {
+        firmwareVer: typeof fwVerRaw === 'number' ? fwVerRaw : undefined,
+        firmwareBuild: typeof d.fw_build === 'string' ? d.fw_build : undefined,
+        model: typeof d.model === 'string' ? d.model : undefined,
+        ver: typeof d.ver === 'string' ? d.ver : undefined,
+        maxContacts: typeof d.max_contacts === 'number' ? d.max_contacts : undefined,
+        maxChannels: typeof d.max_channels === 'number' ? d.max_channels : undefined,
+        blePin: typeof d.ble_pin === 'number' ? d.ble_pin : undefined,
+        repeat: typeof d.repeat === 'boolean' ? d.repeat : undefined,
+        pathHashMode: typeof d.path_hash_mode === 'number' ? d.path_hash_mode : undefined,
+      };
+    } catch (error) {
+      logger.warn(`[MeshCore:${this.sourceId}] deviceQuery failed:`, error);
+      return null;
+    }
   }
 
   // ============ Getters ============

--- a/src/server/migrations/059_telemetry_source_node_type_ts_index.ts
+++ b/src/server/migrations/059_telemetry_source_node_type_ts_index.ts
@@ -1,0 +1,57 @@
+/**
+ * Migration 059: Add a composite index supporting per-source, per-node,
+ * per-type time-range telemetry queries.
+ *
+ * The MeshCore local-node telemetry poller (introduced alongside this
+ * migration) writes rows with `telemetryType` strings prefixed `mc_` and
+ * the owning `sourceId`. The MeshCore Info page renders these as
+ * time-series, so the hot query path is:
+ *
+ *     SELECT ... FROM telemetry
+ *     WHERE sourceId = ? AND nodeId = ? AND telemetryType = ?
+ *       AND timestamp >= ?
+ *     ORDER BY timestamp DESC
+ *
+ * Migration 049 already added (sourceId, nodeId, telemetryType) but no
+ * trailing timestamp column, forcing a per-bucket sort on every fetch.
+ * This migration appends `timestamp DESC` so PostgreSQL/SQLite can serve
+ * the range scan directly from the index. The shape is identical across
+ * all three backends — the only conditional logic is the MySQL existence
+ * check, since MySQL pre-8.0 lacks `CREATE INDEX IF NOT EXISTS`.
+ *
+ * Idempotent on all three engines.
+ */
+import type { Database } from 'better-sqlite3';
+
+// SQLite migration
+export const migration = {
+  up(db: Database) {
+    db.exec(
+      `CREATE INDEX IF NOT EXISTS idx_telemetry_source_node_type_ts ` +
+        `ON telemetry(sourceId, nodeId, telemetryType, timestamp DESC)`,
+    );
+  },
+};
+
+// PostgreSQL migration
+export async function runMigration059Postgres(client: any): Promise<void> {
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS idx_telemetry_source_node_type_ts ` +
+      `ON telemetry("sourceId", "nodeId", "telemetryType", timestamp DESC)`,
+  );
+}
+
+// MySQL migration
+export async function runMigration059Mysql(pool: any): Promise<void> {
+  const [rows] = await pool.query(
+    `SELECT INDEX_NAME FROM information_schema.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?`,
+    ['telemetry', 'idx_telemetry_source_node_type_ts'],
+  );
+  if ((rows as any[]).length === 0) {
+    await pool.query(
+      `CREATE INDEX idx_telemetry_source_node_type_ts ` +
+        `ON telemetry(sourceId, nodeId, telemetryType, timestamp DESC)`,
+    );
+  }
+}

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -181,7 +181,6 @@ describe('MeshCore Routes', () => {
   });
 
   let testUserCounter = 0;
-  let testUserId: number;
 
   beforeEach(async () => {
     // Create unique test user for each test
@@ -193,7 +192,6 @@ describe('MeshCore Routes', () => {
       password: 'password123',
       authProvider: 'local'
     });
-    testUserId = user.id;
 
     for (const resource of ['connection', 'nodes', 'messages', 'configuration'] as const) {
       await permissionModel.grant({

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -31,6 +31,8 @@ vi.mock('../../services/database.js', () => ({
 // mock the registry directly here so requests under
 // `/api/sources/test-source/meshcore/*` resolve to this stub.
 const meshcoreManager = {
+  // The /info route reads `manager.sourceId` to populate telemetryRef.
+  sourceId: 'test-source',
   getConnectionStatus: vi.fn().mockReturnValue({
     connected: false,
     deviceType: 0,
@@ -77,6 +79,23 @@ vi.mock('../meshcoreRegistry.js', () => ({
     get: (sourceId: string) => (REGISTERED_SOURCE_IDS.has(sourceId) ? meshcoreManager : undefined),
   },
   LEGACY_MESHCORE_SOURCE_ID: 'meshcore-legacy-default',
+}));
+
+// The `/info` route reads the last poll snapshot from the singleton poller.
+// We expose a mutable fake here so individual tests can decide whether to
+// return a snapshot, returning null otherwise.
+const fakePollerSnapshot: { value: any } = { value: null };
+vi.mock('../services/meshcoreTelemetryPoller.js', () => ({
+  getMeshCoreTelemetryPoller: () => ({
+    getLastSnapshot: () => fakePollerSnapshot.value,
+  }),
+  // The route also imports `nodeNumFromPubkey` to build telemetryRef.
+  nodeNumFromPubkey: (publicKey: string) => {
+    if (!publicKey) return 0;
+    const tail = publicKey.replace(/^0x/, '').slice(-8);
+    const n = parseInt(tail, 16);
+    return Number.isFinite(n) ? n & 0x7fffffff : 0;
+  },
 }));
 
 import DatabaseService from '../../services/database.js';
@@ -469,6 +488,98 @@ describe('MeshCore Routes', () => {
       expect(response.status).toBe(200);
       // Should clamp to max limit (1000) without error
       expect(meshcoreManager.getRecentMessages).toHaveBeenCalledWith(1000);
+    });
+  });
+
+  describe('GET /api/sources/test-source/meshcore/info', () => {
+    const FULL_PUBKEY = 'a'.repeat(64);
+
+    beforeEach(() => {
+      fakePollerSnapshot.value = null;
+    });
+
+    it('returns 404 when the source is not registered', async () => {
+      const response = await request(app).get('/api/sources/no-such-source/meshcore/info');
+      expect(response.status).toBe(404);
+      expect(response.body.success).toBe(false);
+    });
+
+    it('returns identity + null latest when no poll has fired yet', async () => {
+      meshcoreManager.getConnectionStatus.mockReturnValueOnce({
+        connected: true,
+        deviceType: 1, // Companion
+        config: null,
+      });
+      meshcoreManager.getLocalNode.mockReturnValueOnce({
+        publicKey: FULL_PUBKEY,
+        name: 'TestNode',
+        advType: 1,
+        radioFreq: 915.0,
+        radioBw: 125,
+        radioSf: 7,
+        radioCr: 5,
+      });
+
+      const response = await request(app).get('/api/sources/test-source/meshcore/info');
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.connected).toBe(true);
+      expect(response.body.data.deviceType).toBe(1);
+      expect(response.body.data.identity).toMatchObject({
+        publicKey: FULL_PUBKEY,
+        name: 'TestNode',
+        radioFreq: 915.0,
+      });
+      expect(response.body.data.latest).toBeNull();
+      expect(response.body.data.telemetryRef).toEqual({
+        nodeId: FULL_PUBKEY,
+        nodeNum: expect.any(Number),
+        sourceId: 'test-source',
+      });
+    });
+
+    it('returns the latest poll snapshot when the poller has run', async () => {
+      meshcoreManager.getConnectionStatus.mockReturnValueOnce({
+        connected: true,
+        deviceType: 1,
+        config: null,
+      });
+      meshcoreManager.getLocalNode.mockReturnValueOnce({
+        publicKey: FULL_PUBKEY,
+        name: 'TestNode',
+        advType: 1,
+      });
+      fakePollerSnapshot.value = {
+        timestamp: 1700000000000,
+        batteryMv: 4100,
+        uptimeSecs: 7200,
+        queueLen: 1,
+        lastRssi: -88,
+        lastSnr: 6.5,
+        rtcDriftSecs: -2,
+        deviceInfo: { firmwareVer: 9, firmwareBuild: '2024-11-01', model: 'Heltec V3' },
+      };
+
+      const response = await request(app).get('/api/sources/test-source/meshcore/info');
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.latest).toEqual(fakePollerSnapshot.value);
+    });
+
+    it('returns null telemetryRef when no localNode has been resolved', async () => {
+      meshcoreManager.getConnectionStatus.mockReturnValueOnce({
+        connected: false,
+        deviceType: 0,
+        config: null,
+      });
+      meshcoreManager.getLocalNode.mockReturnValueOnce(null);
+
+      const response = await request(app).get('/api/sources/test-source/meshcore/info');
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.identity).toBeNull();
+      expect(response.body.data.telemetryRef).toBeNull();
     });
   });
 });

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -11,6 +11,7 @@
 import { Router, Request, Response } from 'express';
 import { ConnectionType, MeshCoreDeviceType, MeshCoreManager } from '../meshcoreManager.js';
 import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
+import { getMeshCoreTelemetryPoller, nodeNumFromPubkey } from '../services/meshcoreTelemetryPoller.js';
 import { logger } from '../../utils/logger.js';
 import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
 import { meshcoreDeviceLimiter, messageLimiter } from '../middleware/rateLimiters.js';
@@ -403,6 +404,59 @@ router.get('/snapshot', optionalAuth(), requirePermission('connection', 'read', 
   } catch (error) {
     logger.error('[API] Error getting snapshot:', error);
     res.status(500).json({ success: false, error: 'Failed to get snapshot' });
+  }
+});
+
+/**
+ * GET /api/sources/:id/meshcore/info
+ *
+ * Single-call payload for the MeshCore Node Info page:
+ *
+ *   - `identity`: name, pubkey, node type, manufacturer/model, firmware
+ *     ver + build date, radio config, advertised lat/lon — pulled from
+ *     `localNode` which now folds in DeviceQuery output.
+ *   - `latest`: the most recent telemetry poll snapshot from
+ *     `MeshCoreTelemetryPoller`. Contains battery, queue depth, noise
+ *     floor, RSSI/SNR, RTC drift, packet counters, and computed
+ *     duty-cycle / rate fields. `null` until the first poll completes.
+ *   - `telemetryRef`: { nodeId, nodeNum, sourceId } — the keys the existing
+ *     `/api/telemetry/:nodeId?sourceId=...` endpoint indexes graphs on.
+ *
+ * Companion-only. Repeaters do not expose GetStats; the response will
+ * still include identity but `latest` will be `null` and clients should
+ * suppress the health/graphs panels.
+ */
+router.get('/info', optionalAuth(), requirePermission('connection', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+  try {
+    const manager = managerFor(req);
+    const status = manager.getConnectionStatus();
+    const localNode = manager.getLocalNode();
+    const poller = getMeshCoreTelemetryPoller();
+    const snapshot = poller ? poller.getLastSnapshot(manager.sourceId) : undefined;
+
+    const telemetryRef = localNode?.publicKey
+      ? {
+          nodeId: localNode.publicKey,
+          nodeNum: nodeNumFromPubkey(localNode.publicKey),
+          sourceId: manager.sourceId,
+        }
+      : null;
+
+    res.json({
+      success: true,
+      data: {
+        sourceId: manager.sourceId,
+        connected: status.connected,
+        deviceType: status.deviceType,
+        deviceTypeName: MeshCoreDeviceType[status.deviceType],
+        identity: localNode,
+        latest: snapshot ?? null,
+        telemetryRef,
+      },
+    });
+  } catch (error) {
+    logger.error('[API] Error getting MeshCore info:', error);
+    res.status(500).json({ success: false, error: 'Failed to get info' });
   }
 });
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -671,6 +671,34 @@ setTimeout(async () => {
 }, 5000); // Wait 5 seconds after startup
 
 // ==========================================
+// MeshCore local-node telemetry poller
+// ==========================================
+// Sample every connected MeshCore COMPANION manager every
+// MESHCORE_TELEMETRY_INTERVAL_MS (default 5 minutes). All commands hit the
+// locally-attached node only — no RF — so the poller is safe to run on a
+// fixed cadence regardless of mesh topology. Exposed back to the request
+// handlers as `meshcoreTelemetryPoller` so the Info endpoint can serve the
+// last cached snapshot without forcing a synchronous bridge round-trip.
+export const meshcoreTelemetryPoller = new MeshCoreTelemetryPoller({
+  registry: meshcoreManagerRegistry,
+  database: databaseService,
+});
+setMeshCoreTelemetryPoller(meshcoreTelemetryPoller);
+setTimeout(async () => {
+  try {
+    await databaseService.waitForReady();
+    meshcoreTelemetryPoller.start();
+    // Run one immediately so the Info page has data without waiting a
+    // full interval after first connect.
+    meshcoreTelemetryPoller.pollOnce().catch((err) =>
+      logger.warn('[MeshCorePoller] Initial poll failed:', err),
+    );
+  } catch (error) {
+    logger.error('Failed to start MeshCore telemetry poller:', error);
+  }
+}, 7000); // Slightly after the initial telemetry purge so the DB is settled.
+
+// ==========================================
 // Scheduled Auto-Upgrade Check
 // ==========================================
 // Check for updates every 4 hours server-side to enable unattended upgrades
@@ -801,6 +829,7 @@ import tileServerRoutes from './routes/tileServerTest.js';
 import v1Router from './routes/v1/index.js';
 import meshcoreRoutes from './routes/meshcoreRoutes.js';
 import { meshcoreManagerRegistry, meshcoreConfigFromSource } from './meshcoreRegistry.js';
+import { MeshCoreTelemetryPoller, setMeshCoreTelemetryPoller } from './services/meshcoreTelemetryPoller.js';
 import embedProfileRoutes from './routes/embedProfileRoutes.js';
 import { createEmbedCspMiddleware } from './middleware/embedMiddleware.js';
 import embedPublicRoutes from './routes/embedPublicRoutes.js';

--- a/src/server/services/meshcoreTelemetryPoller.test.ts
+++ b/src/server/services/meshcoreTelemetryPoller.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for MeshCoreTelemetryPoller.
+ *
+ * Verifies:
+ *   - Connected companions get sampled; disconnected/non-companion are skipped.
+ *   - All six bridge-derived metrics (battery, queue, RSSI, drift, etc.) are
+ *     emitted as `mc_*` telemetry rows with the source's id stamped on them.
+ *   - The second poll computes duty-cycle and rate fields from cumulative
+ *     counters, and the snapshot reflects the latest values.
+ *   - Failures in one source do not abort the poll for other sources.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  MeshCoreTelemetryPoller,
+  nodeNumFromPubkey,
+  resolvePollIntervalMs,
+  DEFAULT_POLL_INTERVAL_MS,
+  MC_TELEMETRY_PREFIX,
+} from './meshcoreTelemetryPoller.js';
+import type { PollerDatabase } from './meshcoreTelemetryPoller.js';
+import type {
+  MeshCoreManager,
+  MeshCoreStatsCore,
+  MeshCoreStatsRadio,
+  MeshCoreStatsPackets,
+  MeshCoreDeviceInfo,
+} from '../meshcoreManager.js';
+import type { MeshCoreManagerRegistry } from '../meshcoreRegistry.js';
+
+// ============================================================================
+// Test doubles
+// ============================================================================
+
+interface FakeManagerOpts {
+  sourceId: string;
+  connected?: boolean;
+  publicKey?: string;
+  core?: MeshCoreStatsCore | null;
+  radio?: MeshCoreStatsRadio | null;
+  packets?: MeshCoreStatsPackets | null;
+  deviceTime?: number | null;
+  deviceInfo?: MeshCoreDeviceInfo | null;
+  /** When true, every getter rejects to exercise the per-source try/catch. */
+  throws?: boolean;
+}
+
+function makeManager(opts: FakeManagerOpts): MeshCoreManager {
+  const appliedDeviceInfo: MeshCoreDeviceInfo[] = [];
+  const localNode = opts.publicKey
+    ? { publicKey: opts.publicKey, name: 'test', advType: 1 as const }
+    : null;
+
+  const reject = () => Promise.reject(new Error('bridge boom'));
+
+  const m: any = {
+    sourceId: opts.sourceId,
+    isConnected: () => opts.connected ?? true,
+    getLocalNode: () => localNode,
+    getStatsCore: () => (opts.throws ? reject() : Promise.resolve(opts.core ?? null)),
+    getStatsRadio: () => (opts.throws ? reject() : Promise.resolve(opts.radio ?? null)),
+    getStatsPackets: () => (opts.throws ? reject() : Promise.resolve(opts.packets ?? null)),
+    getDeviceTime: () => (opts.throws ? reject() : Promise.resolve(opts.deviceTime ?? null)),
+    deviceQuery: () => (opts.throws ? reject() : Promise.resolve(opts.deviceInfo ?? null)),
+    applyDeviceInfo: (info: MeshCoreDeviceInfo) => {
+      appliedDeviceInfo.push(info);
+    },
+    appliedDeviceInfo,
+  };
+  return m as MeshCoreManager;
+}
+
+function makeRegistry(...managers: MeshCoreManager[]): MeshCoreManagerRegistry {
+  return { list: () => managers } as unknown as MeshCoreManagerRegistry;
+}
+
+function makeDatabase(): { db: PollerDatabase; batches: { rows: any[]; sourceId?: string }[] } {
+  const batches: { rows: any[]; sourceId?: string }[] = [];
+  const db: PollerDatabase = {
+    telemetry: {
+      insertTelemetryBatch: async (rows, sourceId) => {
+        batches.push({ rows: [...rows], sourceId });
+        return rows.length;
+      },
+    },
+  };
+  return { db, batches };
+}
+
+const FULL_PUBKEY = 'a'.repeat(64);
+
+const FULL_CORE: MeshCoreStatsCore = { batteryMv: 4100, uptimeSecs: 3600, errors: 0, queueLen: 2 };
+const FULL_RADIO: MeshCoreStatsRadio = { noiseFloor: -123, lastRssi: -88, lastSnr: 7.5, txAirSecs: 100, rxAirSecs: 250 };
+const FULL_PACKETS: MeshCoreStatsPackets = { recv: 500, sent: 120, floodTx: 80, directTx: 40, floodRx: 300, directRx: 200, recvErrors: 5 };
+const FULL_DEVICE: MeshCoreDeviceInfo = { firmwareVer: 9, firmwareBuild: '2024-11-01', model: 'Heltec V3', ver: '1.2.3' };
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('resolvePollIntervalMs', () => {
+  it('returns the default when env is unset', () => {
+    expect(resolvePollIntervalMs(undefined)).toBe(DEFAULT_POLL_INTERVAL_MS);
+  });
+  it('returns the default for unparseable input', () => {
+    expect(resolvePollIntervalMs('not-a-number')).toBe(DEFAULT_POLL_INTERVAL_MS);
+  });
+  it('returns the default for non-positive input', () => {
+    expect(resolvePollIntervalMs('0')).toBe(DEFAULT_POLL_INTERVAL_MS);
+    expect(resolvePollIntervalMs('-1000')).toBe(DEFAULT_POLL_INTERVAL_MS);
+  });
+  it('floors values below the 10s minimum', () => {
+    expect(resolvePollIntervalMs('1000')).toBe(10_000);
+  });
+  it('passes through reasonable values', () => {
+    expect(resolvePollIntervalMs('60000')).toBe(60_000);
+  });
+});
+
+describe('nodeNumFromPubkey', () => {
+  it('returns 0 for empty input', () => {
+    expect(nodeNumFromPubkey('')).toBe(0);
+  });
+  it('strips an optional 0x prefix and parses the low 4 bytes', () => {
+    expect(nodeNumFromPubkey('0x' + 'f'.repeat(56) + 'deadbeef')).toBe(0xdeadbeef & 0x7fffffff);
+  });
+  it('clamps to a 31-bit non-negative integer', () => {
+    const n = nodeNumFromPubkey('0'.repeat(56) + 'ffffffff');
+    expect(n).toBeGreaterThanOrEqual(0);
+    expect(n).toBe(0x7fffffff);
+  });
+});
+
+describe('MeshCoreTelemetryPoller.pollOnce', () => {
+  let now = 1700_000_000_000;
+  beforeEach(() => {
+    now = 1700_000_000_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+  });
+
+  it('emits all expected metrics for a healthy companion', async () => {
+    const manager = makeManager({
+      sourceId: 'src-a',
+      publicKey: FULL_PUBKEY,
+      core: FULL_CORE,
+      radio: FULL_RADIO,
+      packets: FULL_PACKETS,
+      // Device time in seconds; server time is now/1000 → drift = 0.
+      deviceTime: Math.floor(now / 1000),
+      deviceInfo: FULL_DEVICE,
+    });
+    const { db, batches } = makeDatabase();
+    const poller = new MeshCoreTelemetryPoller({
+      registry: makeRegistry(manager),
+      database: db,
+      intervalMs: 60_000,
+    });
+
+    await poller.pollOnce();
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0].sourceId).toBe('src-a');
+
+    const types = batches[0].rows.map((r) => r.telemetryType).sort();
+    // Spot-check every category lands at least one mc_ row.
+    for (const expected of [
+      `${MC_TELEMETRY_PREFIX}battery_mv`,
+      `${MC_TELEMETRY_PREFIX}battery_volts`,
+      `${MC_TELEMETRY_PREFIX}uptime_secs`,
+      `${MC_TELEMETRY_PREFIX}queue_len`,
+      `${MC_TELEMETRY_PREFIX}noise_floor`,
+      `${MC_TELEMETRY_PREFIX}last_rssi`,
+      `${MC_TELEMETRY_PREFIX}last_snr`,
+      `${MC_TELEMETRY_PREFIX}tx_air_secs`,
+      `${MC_TELEMETRY_PREFIX}rx_air_secs`,
+      `${MC_TELEMETRY_PREFIX}pkt_recv`,
+      `${MC_TELEMETRY_PREFIX}pkt_sent`,
+      `${MC_TELEMETRY_PREFIX}pkt_recv_errors`,
+      `${MC_TELEMETRY_PREFIX}rtc_drift_secs`,
+      `${MC_TELEMETRY_PREFIX}firmware_ver`,
+    ]) {
+      expect(types).toContain(expected);
+    }
+
+    // Every row should be stamped with the same timestamp and the local node's pubkey.
+    for (const row of batches[0].rows) {
+      expect(row.timestamp).toBe(now);
+      expect(row.nodeId).toBe(FULL_PUBKEY);
+      expect(row.nodeNum).toBe(nodeNumFromPubkey(FULL_PUBKEY));
+    }
+
+    // The poll should have stamped DeviceInfo onto the manager via applyDeviceInfo.
+    expect((manager as any).appliedDeviceInfo).toEqual([FULL_DEVICE]);
+
+    // First poll has no prior sample — no duty / rate rows yet.
+    expect(types).not.toContain(`${MC_TELEMETRY_PREFIX}tx_duty_pct`);
+    expect(types).not.toContain(`${MC_TELEMETRY_PREFIX}pkt_recv_rate`);
+
+    // Snapshot is cached for the Info endpoint.
+    const snap = poller.getLastSnapshot('src-a');
+    expect(snap).toBeDefined();
+    expect(snap!.batteryMv).toBe(4100);
+    expect(snap!.lastRssi).toBe(-88);
+    expect(snap!.rtcDriftSecs).toBe(0);
+    expect(snap!.deviceInfo?.model).toBe('Heltec V3');
+  });
+
+  it('computes duty-cycle and packet rates after the second sample', async () => {
+    const manager: any = makeManager({
+      sourceId: 'src-rate',
+      publicKey: FULL_PUBKEY,
+      core: FULL_CORE,
+      radio: { ...FULL_RADIO, txAirSecs: 100, rxAirSecs: 250 },
+      packets: { ...FULL_PACKETS, recv: 500, sent: 120 },
+      deviceTime: Math.floor(now / 1000),
+    });
+
+    const { db, batches } = makeDatabase();
+    const poller = new MeshCoreTelemetryPoller({
+      registry: makeRegistry(manager),
+      database: db,
+    });
+
+    await poller.pollOnce(); // seed prev sample
+
+    // Second poll: advance clock 60s, bump counters.
+    now += 60_000;
+    manager.getStatsRadio = () => Promise.resolve({ ...FULL_RADIO, txAirSecs: 106, rxAirSecs: 280 });
+    manager.getStatsPackets = () =>
+      Promise.resolve({ ...FULL_PACKETS, recv: 530, sent: 126 });
+    manager.getDeviceTime = () => Promise.resolve(Math.floor(now / 1000));
+
+    await poller.pollOnce();
+
+    expect(batches).toHaveLength(2);
+    const second = batches[1].rows;
+    const find = (type: string) => second.find((r) => r.telemetryType === type);
+
+    // tx air-time delta: (106 - 100) / 60 = 10% duty.
+    expect(find(`${MC_TELEMETRY_PREFIX}tx_duty_pct`)?.value).toBeCloseTo(10, 2);
+    // rx air-time delta: (280 - 250) / 60 = 50% duty.
+    expect(find(`${MC_TELEMETRY_PREFIX}rx_duty_pct`)?.value).toBeCloseTo(50, 2);
+    // Packet rates expressed per minute → recv +30 / 60s * 60s = 30/min.
+    expect(find(`${MC_TELEMETRY_PREFIX}pkt_recv_rate`)?.value).toBeCloseTo(30, 2);
+    expect(find(`${MC_TELEMETRY_PREFIX}pkt_sent_rate`)?.value).toBeCloseTo(6, 2);
+
+    const snap = poller.getLastSnapshot('src-rate');
+    expect(snap!.txDutyPct).toBeCloseTo(10, 2);
+    expect(snap!.packetsRecvRatePerMin).toBeCloseTo(30, 2);
+  });
+
+  it('skips counter-reset deltas (negative delta) instead of emitting bogus negatives', async () => {
+    const manager: any = makeManager({
+      sourceId: 'src-reset',
+      publicKey: FULL_PUBKEY,
+      radio: { txAirSecs: 100, rxAirSecs: 200 },
+      packets: { recv: 1000, sent: 500 },
+    });
+    const { db, batches } = makeDatabase();
+    const poller = new MeshCoreTelemetryPoller({ registry: makeRegistry(manager), database: db });
+
+    await poller.pollOnce();
+
+    now += 60_000;
+    // Counter reset — values dropped below the prior sample.
+    manager.getStatsRadio = () => Promise.resolve({ txAirSecs: 5, rxAirSecs: 10 });
+    manager.getStatsPackets = () => Promise.resolve({ recv: 0, sent: 0 });
+
+    await poller.pollOnce();
+
+    const second = batches[1].rows.map((r) => r.telemetryType);
+    expect(second).not.toContain(`${MC_TELEMETRY_PREFIX}tx_duty_pct`);
+    expect(second).not.toContain(`${MC_TELEMETRY_PREFIX}rx_duty_pct`);
+    expect(second).not.toContain(`${MC_TELEMETRY_PREFIX}pkt_recv_rate`);
+    expect(second).not.toContain(`${MC_TELEMETRY_PREFIX}pkt_sent_rate`);
+  });
+
+  it('skips disconnected managers', async () => {
+    const offline = makeManager({
+      sourceId: 'src-off',
+      connected: false,
+      publicKey: FULL_PUBKEY,
+      core: FULL_CORE,
+    });
+    const { db, batches } = makeDatabase();
+    const poller = new MeshCoreTelemetryPoller({ registry: makeRegistry(offline), database: db });
+
+    await poller.pollOnce();
+
+    expect(batches).toHaveLength(0);
+  });
+
+  it('skips managers whose localNode has not been resolved', async () => {
+    const noLocal = makeManager({ sourceId: 'src-pre', publicKey: undefined, core: FULL_CORE });
+    const { db, batches } = makeDatabase();
+    const poller = new MeshCoreTelemetryPoller({ registry: makeRegistry(noLocal), database: db });
+
+    await poller.pollOnce();
+
+    expect(batches).toHaveLength(0);
+  });
+
+  it('does not abort the loop when one manager throws', async () => {
+    const broken = makeManager({ sourceId: 'broken', publicKey: FULL_PUBKEY, throws: true });
+    const healthy = makeManager({
+      sourceId: 'healthy',
+      publicKey: 'b'.repeat(64),
+      core: FULL_CORE,
+    });
+    const { db, batches } = makeDatabase();
+    const poller = new MeshCoreTelemetryPoller({
+      registry: makeRegistry(broken, healthy),
+      database: db,
+    });
+
+    await poller.pollOnce();
+
+    // The healthy manager still emitted its sample.
+    expect(batches).toHaveLength(1);
+    expect(batches[0].sourceId).toBe('healthy');
+  });
+
+  it('does not insert when no metrics are available', async () => {
+    const empty = makeManager({
+      sourceId: 'src-empty',
+      publicKey: FULL_PUBKEY,
+      // All getters return null — repeater-style or pre-pop state.
+      core: null,
+      radio: null,
+      packets: null,
+      deviceTime: null,
+      deviceInfo: null,
+    });
+    const { db, batches } = makeDatabase();
+    const poller = new MeshCoreTelemetryPoller({ registry: makeRegistry(empty), database: db });
+
+    await poller.pollOnce();
+
+    expect(batches).toHaveLength(0);
+  });
+});

--- a/src/server/services/meshcoreTelemetryPoller.ts
+++ b/src/server/services/meshcoreTelemetryPoller.ts
@@ -1,0 +1,420 @@
+/**
+ * MeshCore Telemetry Poller — local-node-only stats collection.
+ *
+ * Walks every connected MeshCore COMPANION manager on a fixed interval and
+ * pulls GetStats(core|radio|packets), GetDeviceTime, and DeviceQuery over
+ * the companion-protocol link. None of these commands touch the air; they
+ * read counters and config off the directly-attached node only.
+ *
+ * Each sample writes rows into the existing `telemetry` table with
+ * `telemetryType` strings prefixed `mc_` and the manager's `sourceId`
+ * stamped on every row. Cumulative counters (txAirSecs, rxAirSecs, packet
+ * totals) are also differenced against the prior sample to produce
+ * `mc_tx_duty_pct`, `mc_rx_duty_pct`, and `mc_pkt_*_rate` time-series.
+ *
+ * The latest in-memory sample per source is exposed via `getLastSnapshot()`
+ * so the Info endpoint can render current health without re-querying the
+ * device on every page-load.
+ */
+
+import { logger } from '../../utils/logger.js';
+import type { DbTelemetry } from '../../services/database.js';
+import type { MeshCoreManager, MeshCoreDeviceInfo } from '../meshcoreManager.js';
+import type { MeshCoreManagerRegistry } from '../meshcoreRegistry.js';
+
+/**
+ * Minimal slice of DatabaseService the poller depends on. Lets us unit-test
+ * without spinning up better-sqlite3.
+ */
+export interface PollerDatabase {
+  telemetry: {
+    insertTelemetryBatch: (rows: DbTelemetry[], sourceId?: string) => Promise<number>;
+  };
+}
+
+/**
+ * Default poll interval (5 minutes). Override via the `MESHCORE_TELEMETRY_INTERVAL_MS`
+ * environment variable. Clamped to a minimum of 10 seconds to keep
+ * runaway configs from melting the bridge.
+ */
+export const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+const MIN_POLL_INTERVAL_MS = 10 * 1000;
+
+/** Telemetry type prefix used for every MeshCore-source-derived sample. */
+export const MC_TELEMETRY_PREFIX = 'mc_';
+
+/**
+ * Snapshot of the most recent poll for a given source. Held in-memory and
+ * returned by `/api/sources/:id/meshcore/info` so the Info page can render
+ * latest values without forcing a synchronous bridge round-trip.
+ */
+export interface MeshCorePollSnapshot {
+  /** Wall-clock timestamp of the poll (ms since epoch). */
+  timestamp: number;
+  batteryMv?: number;
+  uptimeSecs?: number;
+  errors?: number;
+  queueLen?: number;
+  noiseFloor?: number;
+  lastRssi?: number;
+  lastSnr?: number;
+  txAirSecs?: number;
+  rxAirSecs?: number;
+  txDutyPct?: number;
+  rxDutyPct?: number;
+  packetsRecv?: number;
+  packetsSent?: number;
+  floodTx?: number;
+  directTx?: number;
+  floodRx?: number;
+  directRx?: number;
+  recvErrors?: number | null;
+  packetsRecvRatePerMin?: number;
+  packetsSentRatePerMin?: number;
+  rtcDriftSecs?: number;
+  /** Most recent DeviceQuery payload from this source, if any. */
+  deviceInfo?: MeshCoreDeviceInfo;
+}
+
+interface PrevSample {
+  ts: number;
+  txAirSecs?: number;
+  rxAirSecs?: number;
+  packetsRecv?: number;
+  packetsSent?: number;
+}
+
+export interface MeshCoreTelemetryPollerOptions {
+  registry: MeshCoreManagerRegistry;
+  database: PollerDatabase;
+  /** Override the env-derived interval (mostly for tests). */
+  intervalMs?: number;
+}
+
+/**
+ * Parse the configured interval, applying the floor and falling back to
+ * the default on any non-positive or unparseable value.
+ */
+export function resolvePollIntervalMs(envValue: string | undefined): number {
+  if (!envValue) return DEFAULT_POLL_INTERVAL_MS;
+  const parsed = parseInt(envValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_POLL_INTERVAL_MS;
+  return Math.max(parsed, MIN_POLL_INTERVAL_MS);
+}
+
+export class MeshCoreTelemetryPoller {
+  private readonly registry: MeshCoreManagerRegistry;
+  private readonly database: PollerDatabase;
+  private readonly intervalMs: number;
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private readonly prevSamples = new Map<string, PrevSample>();
+  private readonly lastSnapshots = new Map<string, MeshCorePollSnapshot>();
+
+  constructor(opts: MeshCoreTelemetryPollerOptions) {
+    this.registry = opts.registry;
+    this.database = opts.database;
+    this.intervalMs = opts.intervalMs ?? resolvePollIntervalMs(process.env.MESHCORE_TELEMETRY_INTERVAL_MS);
+  }
+
+  /** Start the recurring poll. No-op if already running. */
+  start(): void {
+    if (this.timer) return;
+    logger.info(
+      `[MeshCorePoller] Starting local-node telemetry poll every ${Math.round(this.intervalMs / 1000)}s`,
+    );
+    this.timer = setInterval(() => {
+      this.pollOnce().catch((err) =>
+        logger.error('[MeshCorePoller] Unhandled error in poll cycle:', err),
+      );
+    }, this.intervalMs);
+    // Allow the process to exit even if this timer is alive (parity with
+    // other intervals registered alongside it in server.ts).
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+  }
+
+  /** Stop the recurring poll. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Visible for tests. Returns the latest cached snapshot for a source. */
+  getLastSnapshot(sourceId: string): MeshCorePollSnapshot | undefined {
+    return this.lastSnapshots.get(sourceId);
+  }
+
+  /** Visible for tests. Drop cached state for a source (e.g. on disconnect). */
+  clearSource(sourceId: string): void {
+    this.prevSamples.delete(sourceId);
+    this.lastSnapshots.delete(sourceId);
+  }
+
+  /**
+   * Walk all registered managers and sample any connected companions.
+   * Failures on one source never block another — each manager polls inside
+   * its own try/catch. Concurrency intentionally low (sequential): the
+   * bridges are stdin/stdout pipes and parallelism wouldn't help, but a
+   * bug in one bridge would corrupt the shared event loop more visibly.
+   */
+  async pollOnce(): Promise<void> {
+    if (this.running) {
+      logger.debug('[MeshCorePoller] Previous poll still running, skipping tick');
+      return;
+    }
+    this.running = true;
+    try {
+      const managers = this.registry.list();
+      for (const manager of managers) {
+        try {
+          await this.pollManager(manager);
+        } catch (err) {
+          logger.warn(`[MeshCorePoller:${manager.sourceId}] Poll failed:`, err);
+        }
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /**
+   * Sample one manager. Visible for tests. Skips disconnected sources and
+   * sources whose localNode hasn't been resolved yet (we need a publicKey
+   * to key telemetry rows on).
+   */
+  async pollManager(manager: MeshCoreManager): Promise<void> {
+    if (!manager.isConnected()) return;
+    const localNode = manager.getLocalNode();
+    if (!localNode || !localNode.publicKey) {
+      logger.debug(`[MeshCorePoller:${manager.sourceId}] No localNode yet, skipping`);
+      return;
+    }
+
+    const now = Date.now();
+    // Fetch in parallel — they're independent bridge calls and the bridge
+    // serializes them anyway, but Promise.all keeps the error path tidy.
+    const [core, radio, packets, deviceTimeSecs, deviceInfo] = await Promise.all([
+      manager.getStatsCore(),
+      manager.getStatsRadio(),
+      manager.getStatsPackets(),
+      manager.getDeviceTime(),
+      manager.deviceQuery(),
+    ]);
+
+    if (deviceInfo) {
+      manager.applyDeviceInfo(deviceInfo);
+    }
+
+    const nodeId = localNode.publicKey;
+    // MeshCore has no Meshtastic-style 32-bit nodeNum. We synthesise one from
+    // the low 32 bits of the pubkey to satisfy the NOT NULL constraint on
+    // `telemetry.nodeNum` while keeping it stable per source. Collisions are
+    // possible but harmless — queries filter on `nodeId`, not `nodeNum`.
+    const nodeNum = nodeNumFromPubkey(localNode.publicKey);
+    const rows: DbTelemetry[] = [];
+    const push = (telemetryType: string, value: number | null | undefined, unit?: string) => {
+      if (value === null || value === undefined || !Number.isFinite(value)) return;
+      rows.push({
+        nodeId,
+        nodeNum,
+        telemetryType,
+        value,
+        unit,
+        timestamp: now,
+        createdAt: now,
+      });
+    };
+
+    const snapshot: MeshCorePollSnapshot = { timestamp: now };
+    if (deviceInfo) snapshot.deviceInfo = deviceInfo;
+
+    if (core) {
+      if (core.batteryMv !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}battery_mv`, core.batteryMv, 'mV');
+        // Also store the volts-form so the existing telemetry-graph
+        // formatters that key off `voltage` units pick it up nicely.
+        push(`${MC_TELEMETRY_PREFIX}battery_volts`, core.batteryMv / 1000, 'V');
+        snapshot.batteryMv = core.batteryMv;
+      }
+      if (core.uptimeSecs !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}uptime_secs`, core.uptimeSecs, 's');
+        snapshot.uptimeSecs = core.uptimeSecs;
+      }
+      if (core.errors !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}errors`, core.errors);
+        snapshot.errors = core.errors;
+      }
+      if (core.queueLen !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}queue_len`, core.queueLen);
+        snapshot.queueLen = core.queueLen;
+      }
+    }
+
+    if (radio) {
+      if (radio.noiseFloor !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}noise_floor`, radio.noiseFloor, 'dBm');
+        snapshot.noiseFloor = radio.noiseFloor;
+      }
+      if (radio.lastRssi !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}last_rssi`, radio.lastRssi, 'dBm');
+        snapshot.lastRssi = radio.lastRssi;
+      }
+      if (radio.lastSnr !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}last_snr`, radio.lastSnr, 'dB');
+        snapshot.lastSnr = radio.lastSnr;
+      }
+      if (radio.txAirSecs !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}tx_air_secs`, radio.txAirSecs, 's');
+        snapshot.txAirSecs = radio.txAirSecs;
+      }
+      if (radio.rxAirSecs !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}rx_air_secs`, radio.rxAirSecs, 's');
+        snapshot.rxAirSecs = radio.rxAirSecs;
+      }
+    }
+
+    if (packets) {
+      if (packets.recv !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}pkt_recv`, packets.recv);
+        snapshot.packetsRecv = packets.recv;
+      }
+      if (packets.sent !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}pkt_sent`, packets.sent);
+        snapshot.packetsSent = packets.sent;
+      }
+      if (packets.floodTx !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}pkt_flood_tx`, packets.floodTx);
+        snapshot.floodTx = packets.floodTx;
+      }
+      if (packets.directTx !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}pkt_direct_tx`, packets.directTx);
+        snapshot.directTx = packets.directTx;
+      }
+      if (packets.floodRx !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}pkt_flood_rx`, packets.floodRx);
+        snapshot.floodRx = packets.floodRx;
+      }
+      if (packets.directRx !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}pkt_direct_rx`, packets.directRx);
+        snapshot.directRx = packets.directRx;
+      }
+      if (packets.recvErrors !== null && packets.recvErrors !== undefined) {
+        push(`${MC_TELEMETRY_PREFIX}pkt_recv_errors`, packets.recvErrors);
+        snapshot.recvErrors = packets.recvErrors;
+      } else {
+        snapshot.recvErrors = packets.recvErrors ?? null;
+      }
+    }
+
+    if (deviceTimeSecs !== null) {
+      const drift = Math.floor(now / 1000) - deviceTimeSecs;
+      push(`${MC_TELEMETRY_PREFIX}rtc_drift_secs`, drift, 's');
+      snapshot.rtcDriftSecs = drift;
+    }
+
+    if (deviceInfo && typeof deviceInfo.firmwareVer === 'number') {
+      push(`${MC_TELEMETRY_PREFIX}firmware_ver`, deviceInfo.firmwareVer);
+    }
+
+    // ---- Compute deltas / rates against the prior sample ----
+    const prev = this.prevSamples.get(manager.sourceId);
+    if (prev) {
+      const dtSecs = (now - prev.ts) / 1000;
+      if (dtSecs > 0) {
+        // Duty-cycle = cumulative-air-time delta / wall-clock delta.
+        // Clamp to [0, 100] to absorb counter resets and minor rollover.
+        if (radio?.txAirSecs !== undefined && prev.txAirSecs !== undefined) {
+          const delta = radio.txAirSecs - prev.txAirSecs;
+          if (delta >= 0) {
+            const pct = Math.min(100, (delta / dtSecs) * 100);
+            push(`${MC_TELEMETRY_PREFIX}tx_duty_pct`, pct, '%');
+            snapshot.txDutyPct = pct;
+          }
+        }
+        if (radio?.rxAirSecs !== undefined && prev.rxAirSecs !== undefined) {
+          const delta = radio.rxAirSecs - prev.rxAirSecs;
+          if (delta >= 0) {
+            const pct = Math.min(100, (delta / dtSecs) * 100);
+            push(`${MC_TELEMETRY_PREFIX}rx_duty_pct`, pct, '%');
+            snapshot.rxDutyPct = pct;
+          }
+        }
+        // Packet rates expressed per minute so the y-axis is human-friendly.
+        if (packets?.recv !== undefined && prev.packetsRecv !== undefined) {
+          const delta = packets.recv - prev.packetsRecv;
+          if (delta >= 0) {
+            const rate = (delta / dtSecs) * 60;
+            push(`${MC_TELEMETRY_PREFIX}pkt_recv_rate`, rate, '/min');
+            snapshot.packetsRecvRatePerMin = rate;
+          }
+        }
+        if (packets?.sent !== undefined && prev.packetsSent !== undefined) {
+          const delta = packets.sent - prev.packetsSent;
+          if (delta >= 0) {
+            const rate = (delta / dtSecs) * 60;
+            push(`${MC_TELEMETRY_PREFIX}pkt_sent_rate`, rate, '/min');
+            snapshot.packetsSentRatePerMin = rate;
+          }
+        }
+      }
+    }
+
+    this.prevSamples.set(manager.sourceId, {
+      ts: now,
+      txAirSecs: radio?.txAirSecs,
+      rxAirSecs: radio?.rxAirSecs,
+      packetsRecv: packets?.recv,
+      packetsSent: packets?.sent,
+    });
+    this.lastSnapshots.set(manager.sourceId, snapshot);
+
+    if (rows.length === 0) {
+      logger.debug(
+        `[MeshCorePoller:${manager.sourceId}] No metrics produced for ${nodeId.substring(0, 16)}`,
+      );
+      return;
+    }
+
+    try {
+      await this.database.telemetry.insertTelemetryBatch(rows, manager.sourceId);
+      logger.debug(
+        `[MeshCorePoller:${manager.sourceId}] Wrote ${rows.length} telemetry rows for ${nodeId.substring(0, 16)}`,
+      );
+    } catch (err) {
+      logger.warn(`[MeshCorePoller:${manager.sourceId}] insertTelemetryBatch failed:`, err);
+    }
+  }
+}
+
+/**
+ * Module-level handle for the singleton poller. server.ts constructs the
+ * instance once at startup and registers it here; route handlers and other
+ * subsystems read it back via `getMeshCoreTelemetryPoller()` without having
+ * to thread it through their imports.
+ */
+let _poller: MeshCoreTelemetryPoller | null = null;
+
+export function setMeshCoreTelemetryPoller(poller: MeshCoreTelemetryPoller | null): void {
+  _poller = poller;
+}
+
+export function getMeshCoreTelemetryPoller(): MeshCoreTelemetryPoller | null {
+  return _poller;
+}
+
+/**
+ * Stable 31-bit numeric derived from the low 4 bytes of a hex pubkey.
+ * The `telemetry.nodeNum` column is `NOT NULL` everywhere, but MeshCore has
+ * no genuine equivalent — queries against MeshCore telemetry always go
+ * through `nodeId` (the pubkey). We synthesise a non-negative integer so
+ * inserts succeed without lying about Meshtastic provenance.
+ */
+export function nodeNumFromPubkey(publicKey: string): number {
+  if (!publicKey) return 0;
+  const tail = publicKey.replace(/^0x/, '').slice(-8);
+  const n = parseInt(tail, 16);
+  if (!Number.isFinite(n)) return 0;
+  return n & 0x7fffffff;
+}


### PR DESCRIPTION
## Summary

Adds local-node-only telemetry collection for MeshCore sources and a companion **Node Info** page that mirrors the Meshtastic node-info experience. Every command this PR runs against the device (`GetStats {core,radio,packets}`, `GetDeviceTime`, `DeviceQuery`) reads counters/state from the locally-attached node over its companion-protocol link only — none of them transmit on the air, so it's safe to poll on a fixed cadence regardless of mesh topology.

### What's new
- **Python bridge** (`scripts/meshcore-bridge.py`): three new commands — `get_stats`, `get_device_time`, `device_query` — forwarding to the corresponding `meshcore.commands.*` calls.
- **MeshCoreManager**: `getStatsCore/Radio/Packets`, `getDeviceTime`, `deviceQuery` fetchers plus `applyDeviceInfo` that folds firmware ver/build/model onto the in-memory `localNode` (so the existing status/snapshot endpoints surface them immediately).
- **MeshCoreTelemetryPoller** (`src/server/services/meshcoreTelemetryPoller.ts`): a module-level singleton that samples every connected companion every `MESHCORE_TELEMETRY_INTERVAL_MS` (default 5 minutes, floor 10s). Writes batched rows to the existing `telemetry` table stamped with `sourceId`, plus computes `tx/rx_duty_pct` and `pkt_*_rate` as deltas vs the prior sample.
- **Migration 059**: `idx_telemetry_source_node_type_ts` composite index — backs the per-source / per-node / per-type / time-range scan the Info-page graphs do every fetch. SQLite + PostgreSQL + MySQL, idempotent.
- **API**: `GET /api/sources/:id/meshcore/info` returns identity + the latest poll snapshot + a `telemetryRef` ({nodeId, nodeNum, sourceId}) — the same keys the existing `/api/telemetry/:nodeId?sourceId=…` endpoint indexes graphs on.
- **UI**: new "Node Info" entry in the per-source MeshCore page (`MeshCoreInfoView.tsx`) showing:
  - **Identity** — name, pubkey, device type, manufacturer/model, firmware ver + build date, advertised position
  - **Radio** — freq / BW / SF / CR / TX power
  - **Current health** — battery, uptime, queue depth, noise floor, last RSSI/SNR, RTC drift vs server, last poll time
  - **Cumulative counters** — packets sent/received total + flood/direct breakdown + receive errors, TX/RX air-time totals
  - **History grid** — recharts time-series of all `mc_*` metrics with 1h / 6h / 24h / 3d / 7d range selector. Hidden for repeaters since they don't expose GetStats.

The Info toolbar entry is gated on `sourceId` so the legacy app-shell mount (no sourceId) doesn't render it.

### Schema decision: reused the existing `telemetry` table

The existing `telemetry` schema is tall/skinny — `(nodeId, nodeNum, telemetryType, value, unit, timestamp, sourceId, …)` — so MeshCore samples land in the same table with `telemetryType` prefixed `mc_` and `sourceId` set to the MeshCore source's id. This means:

- The existing `/api/telemetry/:nodeId?sourceId=…` endpoint serves MeshCore graph data with **zero new endpoints** for time-series.
- The hourly purge / retention logic, source-aware filtering, and per-source indexes all apply automatically.
- The Meshtastic-flavoured `TelemetryGraphs` component would not have been a clean reuse for MeshCore (it's coupled to solar overlays, favorites mutation, and purge-by-type permissions), so the Info page uses a small read-only recharts grid instead.

The only thing we deliberately don't persist is the raw protocol bytes — the `telemetry` table doesn't have a blob column for them. Each parsed field is stored explicitly. If forensic-grade raw payload storage becomes important, it can be added as a small parallel `meshcore_telemetry_raw` table in a follow-up without touching anything in this PR.

`nodeId` for local-node rows is the device's 64-char hex public key; `nodeNum` is synthesized from the low 4 bytes of that pubkey (`nodeNumFromPubkey`) since the column is `NOT NULL` and queries always filter on `nodeId`.

### Configuration
- `MESHCORE_TELEMETRY_INTERVAL_MS` — poll interval in milliseconds, default 300000 (5 minutes), clamped to a 10s minimum.

### Test plan
- [x] `npx vitest run src/server/services/meshcoreTelemetryPoller.test.ts` — 15/15 pass (covers all metrics, delta/rate computation, counter-reset clamping, disconnected/no-localNode/throwing-manager error paths, snapshot caching).
- [x] `npx vitest run src/server/routes/meshcoreRoutes.test.ts` — 37/37 pass (adds 4 tests for `/info`: 404 for unknown source, identity + null latest, identity + snapshot, no-localNode case).
- [x] `npx vitest run src/components/MeshCore/MeshCoreInfoView.test.tsx` — 3/3 pass (companion render, repeater suppression of graphs, disconnected-source empty state).
- [x] `npx vitest run src/db/migrations.test.ts` — 9/9 pass after bumping the count + last-name assertions to 059.
- [x] `npm run lint` clean across the touched files.
- [x] `npx tsc --noEmit` clean (frontend) and `npx tsc --noEmit -p tsconfig.server.json` clean (server).

### Manual verification (dev stack with real hardware)
Brought up the dev stack with `docker compose -f docker-compose.dev.yml -f docker-compose.dev.local.yml --profile sqlite up -d meshmonitor-sqlite` against two physical MeshCore companion nodes (USB):

- Migration 059 ran cleanly (`migration_059_telemetry_source_node_type_ts_index | completed`).
- `idx_telemetry_source_node_type_ts` index is present on the `telemetry` table.
- Both MeshCore sources produced 19 distinct `mc_*` telemetry types within the first poll cycle, keyed on their respective 64-char pubkeys + source ids.
- `GET /api/sources/:id/meshcore/info` returned a full payload including identity (name, model "Heltec V3", firmware "v1.15.0-dee3e26", build "19-Apr-2026", radio params, advertised position) and a `latest` snapshot with battery, queue, RSSI/SNR, noise floor, packet counters, and RTC drift.
- `GET /api/telemetry/<pubkey>?sourceId=<id>&hours=24` returned the persisted `mc_*` rows (the path the Info-page graphs use).
- Containers torn down before pushing.

I did NOT load the UI in a browser end-to-end — I exercised the data path and component logic via tests + curl against the running server. The component's render assertions live in `MeshCoreInfoView.test.tsx` rather than in a manual click-through.

### Out-of-scope follow-ups
- Optional `meshcore_telemetry_raw` table for forensic raw-payload storage.
- Translation strings for the new `meshcore.info.*` and `meshcore.nav.info` keys — falls back to the inline English fallbacks today.
- Persisting `firmwareVer/firmwareBuild/model` on `meshcore_nodes` so the Info page survives a restart without waiting for the first post-restart poll (~5 minutes worst-case).

Authored by Merlin 🪄