### PR TITLE
feat(meshcore): per-node remote telemetry retrieval

### DIFF
--- a/scripts/meshcore-bridge.py
+++ b/scripts/meshcore-bridge.py
@@ -30,6 +30,7 @@ Commands:
 - get_stats: {"id": "17", "cmd": "get_stats", "type": "core" | "radio" | "packets"}
 - get_device_time: {"id": "18", "cmd": "get_device_time"}
 - device_query: {"id": "19", "cmd": "device_query"}
+- request_telemetry: {"id": "20", "cmd": "request_telemetry", "public_key": "...", "timeout": 0}
 - shutdown: {"id": "11", "cmd": "shutdown"}
 
 The get_stats / get_device_time / device_query commands hit only the locally-
@@ -116,6 +117,8 @@ class MeshCoreBridge:
                 return await self.cmd_get_device_time(cmd_id)
             elif cmd == 'device_query':
                 return await self.cmd_device_query(cmd_id)
+            elif cmd == 'request_telemetry':
+                return await self.cmd_request_telemetry(cmd_id, cmd_data)
             elif cmd == 'shutdown':
                 return await self.cmd_shutdown(cmd_id)
             elif cmd == 'ping':
@@ -567,6 +570,76 @@ class MeshCoreBridge:
         payload = getattr(event, 'payload', None) or {}
         # Forward verbatim: fw ver, fw_build (date string), model, ver, etc.
         return {'id': cmd_id, 'success': True, 'data': dict(payload)}
+
+    async def cmd_request_telemetry(self, cmd_id: str, cmd_data: dict) -> dict:
+        """Request telemetry from a remote node over RF.
+
+        Calls `meshcore.commands.binary.req_telemetry_sync(contact)`. This
+        DOES transmit on the air — collision avoidance is the caller's
+        responsibility (the Node-side scheduler enforces a 60s global
+        minimum between requests). Returns the LPP frame as a list of
+        `{channel, type, value}` records.
+        """
+        if not self.connected or not self.meshcore:
+            return {'id': cmd_id, 'success': False, 'error': 'Not connected'}
+
+        public_key = cmd_data.get('public_key', '')
+        if not public_key:
+            return {'id': cmd_id, 'success': False, 'error': 'public_key required'}
+
+        contact = self.meshcore.contacts.get(public_key)
+        if not contact:
+            # Refresh once in case the cache hasn't seen this contact yet.
+            try:
+                await self.meshcore.commands.get_contacts()
+                contact = self.meshcore.contacts.get(public_key)
+            except Exception as e:
+                return {'id': cmd_id, 'success': False, 'error': f'get_contacts threw: {e}'}
+        if not contact:
+            return {'id': cmd_id, 'success': False, 'error': f'no contact for {public_key[:16]}…'}
+
+        try:
+            timeout = float(cmd_data.get('timeout') or 0)
+        except (TypeError, ValueError):
+            timeout = 0.0
+
+        try:
+            lpp = await self.meshcore.commands.req_telemetry_sync(contact, timeout=timeout)
+        except Exception as e:
+            return {'id': cmd_id, 'success': False, 'error': f'req_telemetry_sync threw: {e}'}
+
+        if lpp is None:
+            return {'id': cmd_id, 'success': False, 'error': 'no telemetry response (timeout?)'}
+
+        # `lpp` is a cayennelpp.LppFrame. `.data` is a list of LppData entries,
+        # each with .channel, .type (an LppType enum-ish wrapper), .value
+        # (tuple of floats). Serialize to plain dicts so we can ship over JSON.
+        try:
+            records = []
+            for item in getattr(lpp, 'data', []) or []:
+                # `type` is an LppType-ish object that compares to int — we
+                # forward the raw numeric LPP type id so the Node side can
+                # decide on a string name without depending on the python lib.
+                type_id = getattr(item.type, 'type', None)
+                if type_id is None:
+                    # Fall back: some versions stash type id directly.
+                    type_id = getattr(item, 'type_id', None)
+                value = item.value
+                if isinstance(value, (list, tuple)):
+                    serialized_value = [float(v) if isinstance(v, (int, float)) else v for v in value]
+                    if len(serialized_value) == 1:
+                        serialized_value = serialized_value[0]
+                else:
+                    serialized_value = value
+                records.append({
+                    'channel': int(getattr(item, 'channel', 0)),
+                    'type': int(type_id) if type_id is not None else None,
+                    'value': serialized_value,
+                })
+        except Exception as e:
+            return {'id': cmd_id, 'success': False, 'error': f'failed to serialize lpp: {e}'}
+
+        return {'id': cmd_id, 'success': True, 'data': {'records': records}}
 
     async def cmd_shutdown(self, cmd_id: str) -> dict:
         """Shutdown the bridge"""

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the MeshCore DM/Node-Detail view's hosting of the per-node
+ * telemetry-retrieval config panel. The panel was moved here from
+ * `MeshCoreNodesView` and should only mount when:
+ *   - the selected DM peer has a real 64-hex MeshCore pubkey, AND
+ *   - the view is in per-source mode (sourceId + baseUrl are passed).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) => {
+      if (typeof fallback === 'string') return fallback;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: () => true }),
+}));
+
+vi.mock('../../contexts/SettingsContext', () => ({
+  useSettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
+}));
+
+const csrfFetchMock = vi.fn();
+vi.mock('../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => csrfFetchMock,
+}));
+
+import { MeshCoreDirectMessagesView } from './MeshCoreDirectMessagesView';
+import type { MeshCoreActions, ConnectionStatus, MeshCoreMessage } from './hooks/useMeshCore';
+import type { MeshCoreContact } from '../../utils/meshcoreHelpers';
+
+function makeActions(overrides: Partial<MeshCoreActions> = {}): MeshCoreActions {
+  return {
+    connect: vi.fn().mockResolvedValue(true),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    refreshContacts: vi.fn().mockResolvedValue(undefined),
+    sendAdvert: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue(true),
+    setDeviceName: vi.fn().mockResolvedValue(true),
+    setRadioParams: vi.fn().mockResolvedValue(true),
+    setCoords: vi.fn().mockResolvedValue(true),
+    setAdvertLocPolicy: vi.fn().mockResolvedValue(true),
+    setTelemetryModeBase: vi.fn().mockResolvedValue(true),
+    setTelemetryModeLoc: vi.fn().mockResolvedValue(true),
+    setTelemetryModeEnv: vi.fn().mockResolvedValue(true),
+    refreshAll: vi.fn().mockResolvedValue(undefined),
+    clearError: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeStatus(): ConnectionStatus {
+  return {
+    connected: true,
+    deviceType: 1,
+    deviceTypeName: 'companion',
+    config: null,
+    localNode: { publicKey: 'self'.padEnd(64, '0'), name: 'self', advType: 1 },
+    envConfig: null,
+  };
+}
+
+const REAL_PK = 'a'.repeat(64);
+const REAL_PK_2 = 'b'.repeat(64);
+
+const realContact: MeshCoreContact = {
+  publicKey: REAL_PK,
+  advName: 'Remote Bob',
+  advType: 1,
+  rssi: -72,
+  snr: 8.5,
+  pathLen: 2,
+  lastSeen: Date.now(),
+};
+
+const messages: MeshCoreMessage[] = [];
+
+beforeEach(() => {
+  csrfFetchMock.mockReset();
+  csrfFetchMock.mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        success: true,
+        data: { enabled: false, intervalMinutes: 60, lastRequestAt: null },
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ),
+  );
+});
+
+describe('MeshCoreDirectMessagesView — per-node telemetry-config panel', () => {
+  it('renders the telemetry-retrieval panel when the selected peer has a real 64-hex pubkey and sourceId is set', async () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[realContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    // Pick the peer in the DM sidebar.
+    fireEvent.click(screen.getByText('Remote Bob'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Telemetry Retrieval')).toBeTruthy();
+    });
+
+    // Panel made its GET against the per-node telemetry-config endpoint.
+    expect(csrfFetchMock).toHaveBeenCalled();
+    const calledUrl = csrfFetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('/api/sources/src-a/meshcore/nodes/');
+    expect(calledUrl).toContain(REAL_PK);
+    expect(calledUrl).toContain('/telemetry-config');
+  });
+
+  it('does NOT render the telemetry-retrieval panel when sourceId is not provided (singleton mode)', () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[realContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Remote Bob'));
+
+    expect(screen.queryByText('Telemetry Retrieval')).toBeNull();
+    expect(csrfFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT render the panel for a non-64-hex peer key (e.g. inbound prefix-only)', () => {
+    const prefixOnly: MeshCoreContact = {
+      publicKey: 'cafebabe1234', // 12 hex chars — fails the real-key gate
+      advName: 'Prefix Pete',
+      advType: 1,
+    };
+
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[prefixOnly]}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Prefix Pete'));
+
+    expect(screen.queryByText('Telemetry Retrieval')).toBeNull();
+    expect(csrfFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('refetches telemetry config when switching from one real-pubkey peer to another', async () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[
+          realContact,
+          { ...realContact, publicKey: REAL_PK_2, advName: 'Remote Carol' },
+        ]}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Remote Bob'));
+    await waitFor(() => {
+      const urls = csrfFetchMock.mock.calls.map(c => c[0] as string);
+      expect(urls.some(u => u.includes(REAL_PK))).toBe(true);
+    });
+
+    fireEvent.click(screen.getByText('Remote Carol'));
+    await waitFor(() => {
+      const urls = csrfFetchMock.mock.calls.map(c => c[0] as string);
+      expect(urls.some(u => u.includes(REAL_PK_2))).toBe(true);
+    });
+  });
+});

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -6,6 +6,7 @@ import {
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
 import { MeshCoreContactDetailPanel } from './MeshCoreContactDetailPanel';
+import { MeshCoreNodeTelemetryConfig } from './MeshCoreNodeTelemetryConfig';
 import { useAuth } from '../../contexts/AuthContext';
 
 interface MeshCoreDirectMessagesViewProps {
@@ -13,6 +14,19 @@ interface MeshCoreDirectMessagesViewProps {
   contacts: MeshCoreContact[];
   status: ConnectionStatus | null;
   actions: MeshCoreActions;
+  /** Frontend basename — required for the per-node telemetry-config panel. */
+  baseUrl?: string;
+  /**
+   * Owning source id. When set together with a 64-hex contact pubkey, the
+   * per-node telemetry-retrieval config panel is rendered next to the
+   * contact-detail panel.
+   */
+  sourceId?: string;
+}
+
+/** True when the publicKey is a real 64-char hex (i.e. not a synthetic / prefix key). */
+function isRealNodeKey(key: string): boolean {
+  return /^[0-9a-fA-F]{64}$/.test(key);
 }
 
 export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProps> = ({
@@ -20,6 +34,8 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
   contacts,
   status,
   actions,
+  baseUrl,
+  sourceId,
 }) => {
   const { t } = useTranslation();
   const { hasPermission } = useAuth();
@@ -134,6 +150,13 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                 contact={contactsByKey.get(selected) ?? null}
                 publicKey={selected}
               />
+              {!!sourceId && typeof baseUrl === 'string' && isRealNodeKey(selected) && (
+                <MeshCoreNodeTelemetryConfig
+                  baseUrl={baseUrl}
+                  sourceId={sourceId}
+                  publicKey={selected}
+                />
+              )}
             </div>
           </>
         ) : (

--- a/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
+++ b/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
@@ -1,0 +1,237 @@
+/**
+ * Per-node telemetry-retrieval config panel for the MeshCore Nodes view.
+ *
+ * Mounts inside `MeshCoreNodesView` when a node is selected. Fetches the
+ * current `(enabled, intervalMinutes)` for the (sourceId, publicKey)
+ * pair from `/api/sources/:id/meshcore/nodes/:publicKey/telemetry-config`
+ * and PATCHes back to the same endpoint on save. Gated by
+ * `configuration:write` per the PR #3019 pattern — read-only users see
+ * the current values but the controls are disabled and an explanation
+ * banner is shown.
+ */
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../contexts/AuthContext';
+import { useCsrfFetch } from '../../hooks/useCsrfFetch';
+
+interface MeshCoreNodeTelemetryConfigProps {
+  /** Frontend basename (e.g. '' or '/meshmonitor'). */
+  baseUrl: string;
+  /** Owning source id (UUID). */
+  sourceId: string;
+  /** 64-char hex pubkey of the remote MeshCore node. */
+  publicKey: string;
+}
+
+interface TelemetryConfigState {
+  enabled: boolean;
+  intervalMinutes: number;
+  lastRequestAt: number | null;
+}
+
+const DEFAULT_CFG: TelemetryConfigState = {
+  enabled: false,
+  intervalMinutes: 60,
+  lastRequestAt: null,
+};
+
+const MIN_INTERVAL = 1;
+const MAX_INTERVAL = 24 * 60;
+
+export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigProps> = ({
+  baseUrl,
+  sourceId,
+  publicKey,
+}) => {
+  const { t } = useTranslation();
+  const csrfFetch = useCsrfFetch();
+  const { hasPermission } = useAuth();
+  const canWriteConfig = hasPermission('configuration', 'write');
+
+  const [cfg, setCfg] = useState<TelemetryConfigState>(DEFAULT_CFG);
+  const [intervalDraft, setIntervalDraft] = useState<string>('60');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const endpoint = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/nodes/${encodeURIComponent(publicKey)}/telemetry-config`;
+
+  // Refetch whenever the selected node or source changes.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setSaved(false);
+    (async () => {
+      try {
+        const response = await csrfFetch(endpoint);
+        const data = await response.json();
+        if (cancelled) return;
+        if (data.success && data.data) {
+          const next: TelemetryConfigState = {
+            enabled: Boolean(data.data.enabled),
+            intervalMinutes: typeof data.data.intervalMinutes === 'number' ? data.data.intervalMinutes : 60,
+            lastRequestAt: data.data.lastRequestAt ?? null,
+          };
+          setCfg(next);
+          setIntervalDraft(String(next.intervalMinutes));
+        } else {
+          setError(data.error || t('meshcore.telemetry_config.load_error', 'Failed to load config'));
+        }
+      } catch (_err) {
+        if (!cancelled) {
+          setError(t('meshcore.telemetry_config.load_error', 'Failed to load config'));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [endpoint, csrfFetch, t]);
+
+  const save = async (patch: { enabled?: boolean; intervalMinutes?: number }) => {
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    try {
+      const response = await csrfFetch(endpoint, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+      const data = await response.json();
+      if (data.success && data.data) {
+        setCfg({
+          enabled: Boolean(data.data.enabled),
+          intervalMinutes: typeof data.data.intervalMinutes === 'number' ? data.data.intervalMinutes : 60,
+          lastRequestAt: data.data.lastRequestAt ?? null,
+        });
+        setSaved(true);
+        window.setTimeout(() => setSaved(false), 1800);
+      } else {
+        setError(data.error || t('meshcore.telemetry_config.save_error', 'Failed to save'));
+      }
+    } catch (_err) {
+      setError(t('meshcore.telemetry_config.save_error', 'Failed to save'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggle = (next: boolean) => {
+    setCfg((prev) => ({ ...prev, enabled: next }));
+    void save({ enabled: next });
+  };
+
+  const handleIntervalCommit = () => {
+    const n = parseInt(intervalDraft, 10);
+    if (!Number.isFinite(n) || n < MIN_INTERVAL || n > MAX_INTERVAL) {
+      setIntervalDraft(String(cfg.intervalMinutes));
+      setError(t('meshcore.telemetry_config.interval_range', `Interval must be between ${MIN_INTERVAL} and ${MAX_INTERVAL} minutes`));
+      return;
+    }
+    if (n === cfg.intervalMinutes) return;
+    void save({ intervalMinutes: n });
+  };
+
+  return (
+    <div className="node-details-block">
+      <div className="node-details-header">
+        <h3 className="node-details-title">
+          {t('meshcore.telemetry_config.title', 'Telemetry Retrieval')}
+        </h3>
+      </div>
+
+      <p className="hint" style={{ marginBottom: '0.75rem' }}>
+        {t(
+          'meshcore.telemetry_config.hint',
+          'Periodically request telemetry from this node over RF. A 60-second minimum spacing is enforced across all scheduled mesh ops on this source.',
+        )}
+      </p>
+
+      {!canWriteConfig && (
+        <div
+          className="meshcore-empty-state"
+          style={{ marginBottom: '0.75rem', color: 'var(--ctp-yellow)' }}
+          role="status"
+        >
+          {t(
+            'meshcore.config.permission_denied',
+            "You don't have permission to change configuration for this source.",
+          )}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="meshcore-empty-state">{t('meshcore.telemetry_config.loading', 'Loading…')}</div>
+      ) : (
+        <div className="node-details-grid">
+          <div className="node-detail-card">
+            <div className="node-detail-label">
+              {t('meshcore.telemetry_config.enabled_label', 'Retrieval')}
+            </div>
+            <div className="node-detail-value">
+              <label style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem' }}>
+                <input
+                  type="checkbox"
+                  checked={cfg.enabled}
+                  onChange={(e) => handleToggle(e.target.checked)}
+                  disabled={!canWriteConfig || saving}
+                  aria-label={t('meshcore.telemetry_config.enabled_label', 'Retrieval')}
+                />
+                <span>
+                  {cfg.enabled
+                    ? t('meshcore.telemetry_config.on', 'On')
+                    : t('meshcore.telemetry_config.off', 'Off')}
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <div className="node-detail-card">
+            <div className="node-detail-label">
+              {t('meshcore.telemetry_config.interval_label', 'Interval (minutes)')}
+            </div>
+            <div className="node-detail-value">
+              <input
+                type="number"
+                min={MIN_INTERVAL}
+                max={MAX_INTERVAL}
+                value={intervalDraft}
+                onChange={(e) => setIntervalDraft(e.target.value)}
+                onBlur={handleIntervalCommit}
+                disabled={!canWriteConfig || saving}
+                style={{ width: '6rem' }}
+              />
+            </div>
+          </div>
+
+          {cfg.lastRequestAt && (
+            <div className="node-detail-card node-detail-card-2col">
+              <div className="node-detail-label">
+                {t('meshcore.telemetry_config.last_request', 'Last request')}
+              </div>
+              <div className="node-detail-value">
+                {new Date(cfg.lastRequestAt).toLocaleString()}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div className="meshcore-empty-state" style={{ marginTop: '0.5rem', color: 'var(--ctp-red)' }} role="alert">
+          {error}
+        </div>
+      )}
+      {saved && (
+        <div className="meshcore-empty-state" style={{ marginTop: '0.5rem', color: 'var(--ctp-green)' }} role="status">
+          {t('meshcore.telemetry_config.saved', 'Saved.')}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
+++ b/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
@@ -1,13 +1,14 @@
 /**
- * Per-node telemetry-retrieval config panel for the MeshCore Nodes view.
+ * Per-node telemetry-retrieval config panel for the MeshCore per-node
+ * detail view.
  *
- * Mounts inside `MeshCoreNodesView` when a node is selected. Fetches the
- * current `(enabled, intervalMinutes)` for the (sourceId, publicKey)
- * pair from `/api/sources/:id/meshcore/nodes/:publicKey/telemetry-config`
- * and PATCHes back to the same endpoint on save. Gated by
- * `configuration:write` per the PR #3019 pattern — read-only users see
- * the current values but the controls are disabled and an explanation
- * banner is shown.
+ * Mounts inside the DM/contact detail pane of `MeshCoreDirectMessagesView`
+ * when a peer with a real 64-hex pubkey is selected. Fetches the current
+ * `(enabled, intervalMinutes)` for the (sourceId, publicKey) pair from
+ * `/api/sources/:id/meshcore/nodes/:publicKey/telemetry-config` and
+ * PATCHes back to the same endpoint on save. Gated by `configuration:write`
+ * per the PR #3019 pattern — read-only users see the current values but
+ * the controls are disabled and an explanation banner is shown.
  */
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { MeshCoreNode } from './hooks/useMeshCore';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMap } from './MeshCoreMap';
-import { MeshCoreNodeTelemetryConfig } from './MeshCoreNodeTelemetryConfig';
 
 const DEVICE_TYPE_KEYS: Record<number, string> = {
   0: 'meshcore.device_type.unknown',
@@ -15,19 +14,6 @@ const DEVICE_TYPE_KEYS: Record<number, string> = {
 interface MeshCoreNodesViewProps {
   nodes: MeshCoreNode[];
   contacts: MeshCoreContact[];
-  /** Frontend basename — required for the per-node detail panel's API calls. */
-  baseUrl?: string;
-  /**
-   * Owning source id. When set, selecting a node renders the per-node
-   * telemetry-retrieval config panel; without it the right pane is
-   * map-only (legacy / un-nested mount).
-   */
-  sourceId?: string;
-}
-
-/** True when the publicKey is a real 64-char hex (i.e. not a synthetic channel key). */
-function isRealNodeKey(key: string): boolean {
-  return /^[0-9a-fA-F]{64}$/.test(key);
 }
 
 interface MergedRow {
@@ -92,14 +78,11 @@ function mergeNodesAndContacts(
 export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
   nodes,
   contacts,
-  baseUrl,
-  sourceId,
 }) => {
   const { t } = useTranslation();
   const [selected, setSelected] = useState<string | null>(null);
 
   const rows = useMemo(() => mergeNodesAndContacts(nodes, contacts), [nodes, contacts]);
-  const canShowDetail = !!sourceId && !!baseUrl && !!selected && isRealNodeKey(selected);
 
   return (
     <div className="meshcore-two-pane">
@@ -144,13 +127,6 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
       </div>
       <div className="meshcore-main-pane">
         <MeshCoreMap contacts={contacts} selectedPublicKey={selected} />
-        {canShowDetail && (
-          <MeshCoreNodeTelemetryConfig
-            baseUrl={baseUrl!}
-            sourceId={sourceId!}
-            publicKey={selected!}
-          />
-        )}
       </div>
     </div>
   );

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { MeshCoreNode } from './hooks/useMeshCore';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMap } from './MeshCoreMap';
+import { MeshCoreNodeTelemetryConfig } from './MeshCoreNodeTelemetryConfig';
 
 const DEVICE_TYPE_KEYS: Record<number, string> = {
   0: 'meshcore.device_type.unknown',
@@ -14,6 +15,19 @@ const DEVICE_TYPE_KEYS: Record<number, string> = {
 interface MeshCoreNodesViewProps {
   nodes: MeshCoreNode[];
   contacts: MeshCoreContact[];
+  /** Frontend basename — required for the per-node detail panel's API calls. */
+  baseUrl?: string;
+  /**
+   * Owning source id. When set, selecting a node renders the per-node
+   * telemetry-retrieval config panel; without it the right pane is
+   * map-only (legacy / un-nested mount).
+   */
+  sourceId?: string;
+}
+
+/** True when the publicKey is a real 64-char hex (i.e. not a synthetic channel key). */
+function isRealNodeKey(key: string): boolean {
+  return /^[0-9a-fA-F]{64}$/.test(key);
 }
 
 interface MergedRow {
@@ -75,11 +89,17 @@ function mergeNodesAndContacts(
   });
 }
 
-export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({ nodes, contacts }) => {
+export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
+  nodes,
+  contacts,
+  baseUrl,
+  sourceId,
+}) => {
   const { t } = useTranslation();
   const [selected, setSelected] = useState<string | null>(null);
 
   const rows = useMemo(() => mergeNodesAndContacts(nodes, contacts), [nodes, contacts]);
+  const canShowDetail = !!sourceId && !!baseUrl && !!selected && isRealNodeKey(selected);
 
   return (
     <div className="meshcore-two-pane">
@@ -124,6 +144,13 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({ nodes, con
       </div>
       <div className="meshcore-main-pane">
         <MeshCoreMap contacts={contacts} selectedPublicKey={selected} />
+        {canShowDetail && (
+          <MeshCoreNodeTelemetryConfig
+            baseUrl={baseUrl!}
+            sourceId={sourceId!}
+            publicKey={selected!}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -80,7 +80,12 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
         />
         <div className="meshcore-content">
           {view === 'nodes' && (
-            <MeshCoreNodesView nodes={nodes} contacts={contacts} />
+            <MeshCoreNodesView
+              nodes={nodes}
+              contacts={contacts}
+              baseUrl={baseUrl}
+              sourceId={sourceId}
+            />
           )}
           {view === 'channels' && (
             <MeshCoreChannelsView messages={messages} contacts={contacts} status={status} actions={actions} />

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -83,8 +83,6 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
             <MeshCoreNodesView
               nodes={nodes}
               contacts={contacts}
-              baseUrl={baseUrl}
-              sourceId={sourceId}
             />
           )}
           {view === 'channels' && (
@@ -96,6 +94,8 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
               contacts={contacts}
               status={status}
               actions={actions}
+              baseUrl={baseUrl}
+              sourceId={sourceId}
             />
           )}
           {view === 'info' && sourceId && (

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 59 migrations registered', () => {
-    expect(registry.count()).toBe(59);
+  it('has all 60 migrations registered', () => {
+    expect(registry.count()).toBe(60);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is telemetry_source_node_type_ts_index', () => {
+  it('last migration is meshcore_node_telemetry_config', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(59);
-    expect(last.name).toContain('telemetry_source_node_type_ts_index');
+    expect(last.number).toBe(60);
+    expect(last.name).toContain('meshcore_node_telemetry_config');
   });
 
-  it('migrations are sequentially numbered from 1 to 59', () => {
+  it('migrations are sequentially numbered from 1 to 60', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -71,6 +71,7 @@ import { migration as addShowTraceroutesToEmbedProfilesMigration, runMigration05
 import { migration as addSourceIdToMeshcoreTablesMigration, runMigration057Postgres, runMigration057Mysql } from '../server/migrations/057_add_source_id_to_meshcore_tables.js';
 import { migration as collapseMeshcoreResourceMigration, runMigration058Postgres, runMigration058Mysql } from '../server/migrations/058_collapse_meshcore_resource.js';
 import { migration as telemetrySourceNodeTypeTsIndexMigration, runMigration059Postgres, runMigration059Mysql } from '../server/migrations/059_telemetry_source_node_type_ts_index.js';
+import { migration as meshcoreNodeTelemetryConfigMigration, runMigration060Postgres, runMigration060Mysql } from '../server/migrations/060_meshcore_node_telemetry_config.js';
 
 // ============================================================================
 // Registry
@@ -918,4 +919,20 @@ registry.register({
   sqlite: (db) => telemetrySourceNodeTypeTsIndexMigration.up(db),
   postgres: (client) => runMigration059Postgres(client),
   mysql: (pool) => runMigration059Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 060: Per-node remote-telemetry config columns on meshcore_nodes
+// (telemetryEnabled, telemetryIntervalMinutes, lastTelemetryRequestAt).
+// Read by the MeshCoreRemoteTelemetryScheduler each tick. Idempotent across
+// SQLite / PostgreSQL / MySQL.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 60,
+  name: 'meshcore_node_telemetry_config',
+  settingsKey: 'migration_060_meshcore_node_telemetry_config',
+  sqlite: (db) => meshcoreNodeTelemetryConfigMigration.up(db),
+  postgres: (client) => runMigration060Postgres(client),
+  mysql: (pool) => runMigration060Mysql(pool),
 });

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -42,6 +42,9 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         lastAdminCheck INTEGER,
         isLocalNode INTEGER DEFAULT 0,
         sourceId TEXT,
+        telemetryEnabled INTEGER DEFAULT 0,
+        telemetryIntervalMinutes INTEGER DEFAULT 60,
+        lastTelemetryRequestAt INTEGER,
         createdAt INTEGER NOT NULL,
         updatedAt INTEGER NOT NULL
       );
@@ -122,6 +125,9 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         lastAdminCheck INTEGER,
         isLocalNode INTEGER DEFAULT 0,
         sourceId TEXT NOT NULL,
+        telemetryEnabled INTEGER DEFAULT 0,
+        telemetryIntervalMinutes INTEGER DEFAULT 60,
+        lastTelemetryRequestAt INTEGER,
         createdAt INTEGER NOT NULL,
         updatedAt INTEGER NOT NULL,
         PRIMARY KEY (publicKey, sourceId)
@@ -205,6 +211,129 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         },
         '',
       ),
+    ).rejects.toThrow(/requires a sourceId/);
+  });
+
+  // ============ Per-node telemetry retrieval config (migration 060) ============
+
+  it('setNodeTelemetryConfig inserts a stub row when none exists', async () => {
+    await repo.setNodeTelemetryConfig('src-a', 'pk-new', {
+      enabled: true,
+      intervalMinutes: 15,
+    });
+
+    const row = db
+      .prepare(
+        `SELECT sourceId, telemetryEnabled, telemetryIntervalMinutes
+         FROM meshcore_nodes WHERE publicKey = 'pk-new'`,
+      )
+      .get() as { sourceId: string; telemetryEnabled: number; telemetryIntervalMinutes: number };
+    expect(row.sourceId).toBe('src-a');
+    expect(row.telemetryEnabled).toBe(1);
+    expect(row.telemetryIntervalMinutes).toBe(15);
+  });
+
+  it('setNodeTelemetryConfig updates an existing row in place', async () => {
+    await repo.upsertNode({ publicKey: 'pk-1', name: 'a' }, 'src-a');
+    await repo.setNodeTelemetryConfig('src-a', 'pk-1', { enabled: true });
+    await repo.setNodeTelemetryConfig('src-a', 'pk-1', { intervalMinutes: 30 });
+
+    const row = db
+      .prepare(
+        `SELECT telemetryEnabled, telemetryIntervalMinutes
+         FROM meshcore_nodes WHERE publicKey = 'pk-1'`,
+      )
+      .get() as { telemetryEnabled: number; telemetryIntervalMinutes: number };
+    expect(row.telemetryEnabled).toBe(1);
+    expect(row.telemetryIntervalMinutes).toBe(30);
+  });
+
+  it('setNodeTelemetryConfig is scoped by sourceId — same publicKey on two sources is independent', async () => {
+    // Composite-PK schema mirrors the prior cross-source guard test: lets
+    // one publicKey exist twice, scoped by sourceId. Must include every
+    // column Drizzle's MeshCoreNode schema declares, since drizzle SELECT
+    // pulls all of them by name.
+    db.exec(`
+      DROP TABLE meshcore_nodes;
+      CREATE TABLE meshcore_nodes (
+        publicKey TEXT NOT NULL,
+        name TEXT,
+        advType INTEGER,
+        txPower INTEGER,
+        maxTxPower INTEGER,
+        radioFreq REAL,
+        radioBw REAL,
+        radioSf INTEGER,
+        radioCr INTEGER,
+        latitude REAL,
+        longitude REAL,
+        altitude REAL,
+        batteryMv INTEGER,
+        uptimeSecs INTEGER,
+        rssi INTEGER,
+        snr REAL,
+        lastHeard INTEGER,
+        hasAdminAccess INTEGER DEFAULT 0,
+        lastAdminCheck INTEGER,
+        isLocalNode INTEGER DEFAULT 0,
+        sourceId TEXT NOT NULL,
+        telemetryEnabled INTEGER DEFAULT 0,
+        telemetryIntervalMinutes INTEGER DEFAULT 60,
+        lastTelemetryRequestAt INTEGER,
+        createdAt INTEGER NOT NULL,
+        updatedAt INTEGER NOT NULL,
+        PRIMARY KEY (publicKey, sourceId)
+      );
+    `);
+    await repo.upsertNode({ publicKey: 'pk-1', name: 'a' }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk-1', name: 'b' }, 'src-b');
+    await repo.setNodeTelemetryConfig('src-a', 'pk-1', { enabled: true, intervalMinutes: 10 });
+    await repo.setNodeTelemetryConfig('src-b', 'pk-1', { enabled: false, intervalMinutes: 90 });
+
+    const rows = db
+      .prepare(
+        `SELECT sourceId, telemetryEnabled, telemetryIntervalMinutes
+         FROM meshcore_nodes WHERE publicKey = 'pk-1' ORDER BY sourceId`,
+      )
+      .all() as Array<{ sourceId: string; telemetryEnabled: number; telemetryIntervalMinutes: number }>;
+    expect(rows).toHaveLength(2);
+    const a = rows.find((r) => r.sourceId === 'src-a')!;
+    const b = rows.find((r) => r.sourceId === 'src-b')!;
+    expect(a.telemetryEnabled).toBe(1);
+    expect(a.telemetryIntervalMinutes).toBe(10);
+    expect(b.telemetryEnabled).toBe(0);
+    expect(b.telemetryIntervalMinutes).toBe(90);
+  });
+
+  it('getTelemetryEnabledNodes only returns rows with telemetryEnabled=true and matching sourceId', async () => {
+    await repo.upsertNode({ publicKey: 'pk-1' }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk-2' }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk-3' }, 'src-b');
+    await repo.setNodeTelemetryConfig('src-a', 'pk-1', { enabled: true });
+    await repo.setNodeTelemetryConfig('src-a', 'pk-2', { enabled: false });
+    await repo.setNodeTelemetryConfig('src-b', 'pk-3', { enabled: true });
+
+    const aResult = await repo.getTelemetryEnabledNodes('src-a');
+    expect(aResult.map((n) => n.publicKey)).toEqual(['pk-1']);
+
+    const bResult = await repo.getTelemetryEnabledNodes('src-b');
+    expect(bResult.map((n) => n.publicKey)).toEqual(['pk-3']);
+  });
+
+  it('markTelemetryRequested stamps lastTelemetryRequestAt', async () => {
+    await repo.upsertNode({ publicKey: 'pk-1' }, 'src-a');
+    await repo.setNodeTelemetryConfig('src-a', 'pk-1', { enabled: true });
+    await repo.markTelemetryRequested('src-a', 'pk-1', 999_999);
+
+    const row = db
+      .prepare(`SELECT lastTelemetryRequestAt FROM meshcore_nodes WHERE publicKey = 'pk-1'`)
+      .get() as { lastTelemetryRequestAt: number };
+    expect(row.lastTelemetryRequestAt).toBe(999_999);
+  });
+
+  it('setNodeTelemetryConfig throws without a sourceId', async () => {
+    await expect(
+      repo.setNodeTelemetryConfig('', 'pk-1', { enabled: true }),
     ).rejects.toThrow(/requires a sourceId/);
   });
 });

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -34,6 +34,14 @@ export interface DbMeshCoreNode {
   isLocalNode?: boolean | null;
   /** Owning source id; required on writes since slice 1 (migration 056). */
   sourceId?: string | null;
+  /**
+   * Per-node remote-telemetry retrieval config (migration 060). Controls
+   * whether the MeshCoreRemoteTelemetryScheduler periodically issues
+   * `req_telemetry_sync` against this node and at what cadence.
+   */
+  telemetryEnabled?: boolean | null;
+  telemetryIntervalMinutes?: number | null;
+  lastTelemetryRequestAt?: number | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -158,6 +166,86 @@ export class MeshCoreRepository extends BaseRepository {
           updatedAt: now,
         });
     }
+  }
+
+  /**
+   * Set the per-node remote-telemetry retrieval config for a
+   * (sourceId, publicKey) row. Inserts a stub row if one doesn't yet
+   * exist — MeshCoreManager doesn't currently persist every observed
+   * contact, so the user may toggle telemetry on a node that has only
+   * been seen in-memory. Idempotent on the (publicKey, sourceId) pair.
+   *
+   * Caller is responsible for validating `intervalMinutes` (>0, sane
+   * ceiling). Passing `undefined` for either field leaves the existing
+   * value intact (on update) or applies the column default (on insert).
+   */
+  async setNodeTelemetryConfig(
+    sourceId: string,
+    publicKey: string,
+    cfg: { enabled?: boolean; intervalMinutes?: number },
+  ): Promise<void> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.setNodeTelemetryConfig requires a sourceId');
+    }
+    const now = this.now();
+    const { meshcoreNodes } = this.tables;
+    const existing = await this.getNodeByPublicKeyAndSource(publicKey, sourceId);
+
+    if (existing) {
+      const patch: Record<string, unknown> = { updatedAt: now };
+      if (cfg.enabled !== undefined) patch.telemetryEnabled = cfg.enabled;
+      if (cfg.intervalMinutes !== undefined) patch.telemetryIntervalMinutes = cfg.intervalMinutes;
+      await this.db
+        .update(meshcoreNodes)
+        .set(patch)
+        .where(and(eq(meshcoreNodes.publicKey, publicKey), eq(meshcoreNodes.sourceId, sourceId)));
+      return;
+    }
+
+    const seed: Record<string, unknown> = {
+      publicKey,
+      sourceId,
+      createdAt: now,
+      updatedAt: now,
+    };
+    if (cfg.enabled !== undefined) seed.telemetryEnabled = cfg.enabled;
+    if (cfg.intervalMinutes !== undefined) seed.telemetryIntervalMinutes = cfg.intervalMinutes;
+    await this.db.insert(meshcoreNodes).values(seed);
+  }
+
+  /**
+   * Mark a node as having just had a telemetry request sent. Stamps
+   * `lastTelemetryRequestAt` to `now` so the scheduler will wait at
+   * least `telemetryIntervalMinutes` before picking it again.
+   */
+  async markTelemetryRequested(
+    sourceId: string,
+    publicKey: string,
+    when: number = this.now(),
+  ): Promise<void> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.markTelemetryRequested requires a sourceId');
+    }
+    const { meshcoreNodes } = this.tables;
+    await this.db
+      .update(meshcoreNodes)
+      .set({ lastTelemetryRequestAt: when, updatedAt: when })
+      .where(and(eq(meshcoreNodes.publicKey, publicKey), eq(meshcoreNodes.sourceId, sourceId)));
+  }
+
+  /**
+   * Return every node in a source that currently has telemetry retrieval
+   * enabled. The scheduler decides per-node eligibility (interval vs
+   * `lastTelemetryRequestAt`) in memory so it can stay engine-portable
+   * without needing per-backend time math in the query.
+   */
+  async getTelemetryEnabledNodes(sourceId: string): Promise<DbMeshCoreNode[]> {
+    const { meshcoreNodes } = this.tables;
+    const result = await this.db
+      .select()
+      .from(meshcoreNodes)
+      .where(and(eq(meshcoreNodes.sourceId, sourceId), eq(meshcoreNodes.telemetryEnabled, true)));
+    return this.normalizeBigInts(result) as unknown as DbMeshCoreNode[];
   }
 
   /**

--- a/src/db/schema/meshcoreNodes.ts
+++ b/src/db/schema/meshcoreNodes.ts
@@ -61,6 +61,13 @@ export const meshcoreNodesSqlite = sqliteTable('meshcore_nodes', {
   // Owning source (nullable for legacy single-source rows; backfilled by migration 056)
   sourceId: text('sourceId'),
 
+  // Per-node remote-telemetry retrieval config (migration 060). The
+  // MeshCoreRemoteTelemetryScheduler reads these to decide whether to
+  // send `req_telemetry_sync` to this node on each tick.
+  telemetryEnabled: integer('telemetryEnabled', { mode: 'boolean' }).default(false),
+  telemetryIntervalMinutes: integer('telemetryIntervalMinutes').default(60),
+  lastTelemetryRequestAt: integer('lastTelemetryRequestAt'),
+
   // Timestamps
   createdAt: integer('createdAt').notNull(),
   updatedAt: integer('updatedAt').notNull(),
@@ -100,6 +107,10 @@ export const meshcoreNodesPostgres = pgTable('meshcore_nodes', {
 
   sourceId: pgText('sourceId'),
 
+  telemetryEnabled: pgBoolean('telemetryEnabled').default(false),
+  telemetryIntervalMinutes: pgInteger('telemetryIntervalMinutes').default(60),
+  lastTelemetryRequestAt: pgBigint('lastTelemetryRequestAt', { mode: 'number' }),
+
   createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
   updatedAt: pgBigint('updatedAt', { mode: 'number' }).notNull(),
 });
@@ -137,6 +148,10 @@ export const meshcoreNodesMysql = mysqlTable('meshcore_nodes', {
   isLocalNode: myBoolean('isLocalNode').default(false),
 
   sourceId: myVarchar('sourceId', { length: 64 }),
+
+  telemetryEnabled: myBoolean('telemetryEnabled').default(false),
+  telemetryIntervalMinutes: myInt('telemetryIntervalMinutes').default(60),
+  lastTelemetryRequestAt: myBigint('lastTelemetryRequestAt', { mode: 'number' }),
 
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
   updatedAt: myBigint('updatedAt', { mode: 'number' }).notNull(),

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -177,6 +177,19 @@ export interface MeshCoreStatsPackets {
   recvErrors?: number | null;
 }
 
+/**
+ * One LPP telemetry record decoded from a remote `req_telemetry_sync`
+ * response. `type` is the raw Cayenne-LPP type id (e.g. 116=voltage,
+ * 103=temperature, 104=humidity, 115=barometer, 121=altitude, 136=gps).
+ * `value` is whatever the encoder produced — a scalar for single-value
+ * types, a dict for multi-axis types like gps.
+ */
+export interface MeshCoreTelemetryRecord {
+  channel: number;
+  type: number | null;
+  value: number | string | Record<string, number> | number[] | null;
+}
+
 export interface MeshCoreDeviceInfo {
   firmwareVer?: number;
   firmwareBuild?: string;
@@ -241,6 +254,17 @@ class MeshCoreManager extends EventEmitter {
 
   // Message limit to prevent unbounded growth
   private static readonly MAX_MESSAGES = 1000;
+
+  /**
+   * Wall-clock timestamp (ms) of the most recent outbound RF operation
+   * for this source. Today only the remote-telemetry scheduler stamps
+   * it (after `requestRemoteTelemetry`), but it's intended as the
+   * shared throttling primitive for any future scheduled mesh-op on
+   * this manager (auto-traceroute, periodic adverts, status sweeps,
+   * …). Cross-source: only this manager's value — different sources
+   * are different radios.
+   */
+  private lastMeshTxAt: number = 0;
 
   constructor(sourceId: string) {
     super();
@@ -1237,6 +1261,79 @@ class MeshCoreManager extends EventEmitter {
    */
   async setTelemetryModeEnv(mode: TelemetryMode): Promise<boolean> {
     return this.setTelemetryMode('env', mode);
+  }
+
+  // ============ Mesh-op throttle primitive ============
+
+  /**
+   * Timestamp (ms) of the last outbound RF op the manager is aware of.
+   * Returns 0 if nothing has been recorded yet. Read by the
+   * remote-telemetry scheduler before issuing a new request so two
+   * scheduled-ops on the same source can't stomp each other.
+   */
+  getLastMeshTxAt(): number {
+    return this.lastMeshTxAt;
+  }
+
+  /**
+   * Stamp the manager as having just emitted an RF op. Callers that
+   * transmit on the air via this manager (today: only the
+   * remote-telemetry scheduler) MUST invoke this so the next scheduled
+   * op honours the global minimum interval.
+   */
+  recordMeshTx(when: number = Date.now()): void {
+    this.lastMeshTxAt = when;
+  }
+
+  // ============ Remote-node telemetry (companion only, RF) ============
+  //
+  // `requestRemoteTelemetry` puts a binary req-telemetry packet on the
+  // air via the locally-connected companion node. The python-meshcore
+  // helper `req_telemetry_sync` serialises against `_mesh_request_lock`
+  // on the bridge side, but the Node-side scheduler is also expected
+  // to enforce the cross-call 60s minimum.
+
+  /**
+   * Send a binary telemetry request to a remote node and wait for the
+   * LPP-decoded response. Returns null on timeout / error / repeater.
+   * The caller is responsible for honouring the global 60s throttle —
+   * this method does NOT consult `lastMeshTxAt`. It bumps the field on
+   * success so subsequent scheduled ops see it.
+   */
+  async requestRemoteTelemetry(
+    publicKey: string,
+    timeoutSecs?: number,
+  ): Promise<MeshCoreTelemetryRecord[] | null> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) return null;
+    if (!this.connected) return null;
+    if (!publicKey) return null;
+
+    try {
+      const params: Record<string, unknown> = { public_key: publicKey };
+      if (typeof timeoutSecs === 'number' && Number.isFinite(timeoutSecs) && timeoutSecs > 0) {
+        params.timeout = timeoutSecs;
+      }
+      // req_telemetry_sync can wait several seconds on the air; widen the
+      // bridge timeout so a slow node doesn't trip the default 30s ceiling
+      // on a back-to-back retry.
+      const response = await this.sendBridgeCommand('request_telemetry', params, 45_000);
+      if (!response.success) {
+        logger.warn(
+          `[MeshCore:${this.sourceId}] requestRemoteTelemetry(${publicKey.substring(0, 16)}…) failed: ${response.error}`,
+        );
+        return null;
+      }
+      this.recordMeshTx();
+      const data = response.data;
+      const records = Array.isArray(data?.records) ? (data.records as MeshCoreTelemetryRecord[]) : [];
+      return records;
+    } catch (error) {
+      logger.warn(
+        `[MeshCore:${this.sourceId}] requestRemoteTelemetry(${publicKey.substring(0, 16)}…) threw:`,
+        error,
+      );
+      return null;
+    }
   }
 
   // ============ Local-node stats (companion only, no RF) ============

--- a/src/server/migrations/060_meshcore_node_telemetry_config.test.ts
+++ b/src/server/migrations/060_meshcore_node_telemetry_config.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Migration 060 — Per-node remote-telemetry-retrieval columns on
+ * `meshcore_nodes`. SQLite-only test; the PostgreSQL / MySQL paths
+ * share the same shape and are exercised by the integration suite.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './060_meshcore_node_telemetry_config.js';
+
+function createSchema(db: Database.Database) {
+  // Post-migration-057 shape: meshcore_nodes already has sourceId.
+  db.exec(`
+    CREATE TABLE meshcore_nodes (
+      publicKey TEXT PRIMARY KEY,
+      name TEXT,
+      sourceId TEXT,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL
+    );
+  `);
+}
+
+describe('Migration 060 — meshcore_nodes telemetry-retrieval columns', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createSchema(db);
+  });
+
+  it('adds telemetryEnabled, telemetryIntervalMinutes, lastTelemetryRequestAt', () => {
+    migration.up(db);
+    const cols = db.prepare(`PRAGMA table_info(meshcore_nodes)`).all() as Array<{
+      name: string;
+      type: string;
+      dflt_value: unknown;
+    }>;
+    const colNames = cols.map((c) => c.name);
+    expect(colNames).toContain('telemetryEnabled');
+    expect(colNames).toContain('telemetryIntervalMinutes');
+    expect(colNames).toContain('lastTelemetryRequestAt');
+  });
+
+  it('applies safe defaults — disabled, 60-minute interval, null lastRequest', () => {
+    migration.up(db);
+    const ts = Date.now();
+    db.prepare(
+      `INSERT INTO meshcore_nodes (publicKey, name, sourceId, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)`,
+    ).run('pk-1', 'node-1', 'src-a', ts, ts);
+
+    const row = db
+      .prepare(
+        `SELECT telemetryEnabled, telemetryIntervalMinutes, lastTelemetryRequestAt
+         FROM meshcore_nodes WHERE publicKey = 'pk-1'`,
+      )
+      .get() as {
+      telemetryEnabled: number;
+      telemetryIntervalMinutes: number;
+      lastTelemetryRequestAt: number | null;
+    };
+    expect(row.telemetryEnabled).toBe(0);
+    expect(row.telemetryIntervalMinutes).toBe(60);
+    expect(row.lastTelemetryRequestAt).toBeNull();
+  });
+
+  it('is idempotent — running twice does not fail or duplicate columns', () => {
+    migration.up(db);
+    expect(() => migration.up(db)).not.toThrow();
+    const cols = db.prepare(`PRAGMA table_info(meshcore_nodes)`).all() as Array<{ name: string }>;
+    const telemetryCols = cols.filter((c) => c.name.startsWith('telemetry') || c.name.startsWith('lastTelemetry'));
+    expect(telemetryCols).toHaveLength(3);
+  });
+});

--- a/src/server/migrations/060_meshcore_node_telemetry_config.ts
+++ b/src/server/migrations/060_meshcore_node_telemetry_config.ts
@@ -1,0 +1,112 @@
+/**
+ * Migration 060: Per-node telemetry-retrieval config on `meshcore_nodes`.
+ *
+ * Adds three nullable columns the new MeshCore remote-telemetry
+ * scheduler reads on each tick:
+ *
+ *   telemetryEnabled         BOOLEAN  (false by default)
+ *   telemetryIntervalMinutes INTEGER  (60 default; 0 disables this row)
+ *   lastTelemetryRequestAt   BIGINT   (ms; null until first attempt)
+ *
+ * Backfill is unnecessary — the absence of `telemetryEnabled=true`
+ * means the scheduler will never pick the row. Existing rows therefore
+ * keep their current behaviour without explicit migration work.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 060';
+
+interface ColumnSpec {
+  name: string;
+  sqliteType: string;
+  postgresType: string;
+  mysqlType: string;
+}
+
+const COLUMNS: ColumnSpec[] = [
+  {
+    name: 'telemetryEnabled',
+    sqliteType: 'INTEGER DEFAULT 0',
+    postgresType: 'BOOLEAN DEFAULT FALSE',
+    mysqlType: 'TINYINT(1) DEFAULT 0',
+  },
+  {
+    name: 'telemetryIntervalMinutes',
+    sqliteType: 'INTEGER DEFAULT 60',
+    postgresType: 'INTEGER DEFAULT 60',
+    mysqlType: 'INT DEFAULT 60',
+  },
+  {
+    name: 'lastTelemetryRequestAt',
+    sqliteType: 'INTEGER',
+    postgresType: 'BIGINT',
+    mysqlType: 'BIGINT',
+  },
+];
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding per-node telemetry-retrieval columns to meshcore_nodes...`);
+
+    for (const col of COLUMNS) {
+      try {
+        db.exec(`ALTER TABLE meshcore_nodes ADD COLUMN ${col.name} ${col.sqliteType}`);
+        logger.debug(`${LABEL} (SQLite): added meshcore_nodes.${col.name}`);
+      } catch (e: any) {
+        if (e.message?.includes('duplicate column')) {
+          logger.debug(`${LABEL} (SQLite): meshcore_nodes.${col.name} already exists, skipping`);
+        } else {
+          logger.error(`${LABEL} (SQLite): could not add meshcore_nodes.${col.name}:`, e.message);
+          throw e;
+        }
+      }
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration060Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding per-node telemetry-retrieval columns...`);
+
+  for (const col of COLUMNS) {
+    await client.query(
+      `ALTER TABLE meshcore_nodes ADD COLUMN IF NOT EXISTS "${col.name}" ${col.postgresType}`,
+    );
+    logger.debug(`${LABEL} (PostgreSQL): ensured meshcore_nodes.${col.name}`);
+  }
+}
+
+// ============ MySQL ============
+
+export async function runMigration060Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding per-node telemetry-retrieval columns...`);
+
+  const conn = await pool.getConnection();
+  try {
+    for (const col of COLUMNS) {
+      const [rows] = await conn.query(
+        `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'meshcore_nodes' AND COLUMN_NAME = ?`,
+        [col.name],
+      );
+      if (!Array.isArray(rows) || rows.length === 0) {
+        await conn.query(`ALTER TABLE meshcore_nodes ADD COLUMN ${col.name} ${col.mysqlType}`);
+        logger.debug(`${LABEL} (MySQL): added meshcore_nodes.${col.name}`);
+      } else {
+        logger.debug(`${LABEL} (MySQL): meshcore_nodes.${col.name} already exists, skipping`);
+      }
+    }
+  } finally {
+    conn.release();
+  }
+}

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -12,6 +12,8 @@ import { Router, Request, Response } from 'express';
 import { ConnectionType, MeshCoreDeviceType, MeshCoreManager } from '../meshcoreManager.js';
 import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
 import { getMeshCoreTelemetryPoller, nodeNumFromPubkey } from '../services/meshcoreTelemetryPoller.js';
+import { MAX_INTERVAL_MINUTES } from '../services/meshcoreRemoteTelemetryScheduler.js';
+import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
 import { meshcoreDeviceLimiter, messageLimiter } from '../middleware/rateLimiters.js';
@@ -789,5 +791,106 @@ router.post('/config/telemetry-mode-env', meshcoreDeviceLimiter, requireAuth(), 
     res.status(500).json({ success: false, error: 'Config error' });
   }
 });
+
+/**
+ * GET /api/sources/:id/meshcore/nodes/:publicKey/telemetry-config
+ *
+ * Read the per-node remote-telemetry-retrieval config for a specific
+ * mesh node. Returns the persisted (telemetryEnabled,
+ * telemetryIntervalMinutes, lastTelemetryRequestAt) triple, or
+ * defaults (`enabled: false, intervalMinutes: 60, lastRequestAt: null`)
+ * if the node has never been written.
+ */
+router.get(
+  '/nodes/:publicKey/telemetry-config',
+  optionalAuth(),
+  requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id: string }).id;
+      const { publicKey } = req.params;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
+      }
+      const node = await databaseService.meshcore.getNodeByPublicKeyAndSource(publicKey, sourceId);
+      res.json({
+        success: true,
+        data: {
+          publicKey,
+          sourceId,
+          enabled: Boolean(node?.telemetryEnabled),
+          intervalMinutes: node?.telemetryIntervalMinutes ?? 60,
+          lastRequestAt: node?.lastTelemetryRequestAt ?? null,
+        },
+      });
+    } catch (error) {
+      logger.error('[API] Error getting per-node telemetry-config:', error);
+      res.status(500).json({ success: false, error: 'Failed to read telemetry-config' });
+    }
+  },
+);
+
+/**
+ * PATCH /api/sources/:id/meshcore/nodes/:publicKey/telemetry-config
+ *
+ * Update the per-node remote-telemetry-retrieval config. Body:
+ *   { enabled?: boolean, intervalMinutes?: number }
+ *
+ * Gated by `configuration:write` per the PR #3019 pattern for any
+ * MeshCore control that mutates source-bound state.
+ */
+router.patch(
+  '/nodes/:publicKey/telemetry-config',
+  requireAuth(),
+  requirePermission('configuration', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id: string }).id;
+      const { publicKey } = req.params;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
+      }
+
+      const { enabled, intervalMinutes } = req.body ?? {};
+
+      const patch: { enabled?: boolean; intervalMinutes?: number } = {};
+      if (enabled !== undefined) {
+        if (typeof enabled !== 'boolean') {
+          return res.status(400).json({ success: false, error: 'enabled must be a boolean' });
+        }
+        patch.enabled = enabled;
+      }
+      if (intervalMinutes !== undefined) {
+        const n = Number(intervalMinutes);
+        if (!Number.isInteger(n) || n < 1 || n > MAX_INTERVAL_MINUTES) {
+          return res.status(400).json({
+            success: false,
+            error: `intervalMinutes must be an integer between 1 and ${MAX_INTERVAL_MINUTES}`,
+          });
+        }
+        patch.intervalMinutes = n;
+      }
+      if (patch.enabled === undefined && patch.intervalMinutes === undefined) {
+        return res.status(400).json({ success: false, error: 'No fields to update' });
+      }
+
+      await databaseService.meshcore.setNodeTelemetryConfig(sourceId, publicKey, patch);
+      const node = await databaseService.meshcore.getNodeByPublicKeyAndSource(publicKey, sourceId);
+      res.json({
+        success: true,
+        data: {
+          publicKey,
+          sourceId,
+          enabled: Boolean(node?.telemetryEnabled),
+          intervalMinutes: node?.telemetryIntervalMinutes ?? 60,
+          lastRequestAt: node?.lastTelemetryRequestAt ?? null,
+        },
+      });
+    } catch (error) {
+      logger.error('[API] Error setting per-node telemetry-config:', error);
+      res.status(500).json({ success: false, error: 'Failed to update telemetry-config' });
+    }
+  },
+);
 
 export default router;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -699,6 +699,28 @@ setTimeout(async () => {
 }, 7000); // Slightly after the initial telemetry purge so the DB is settled.
 
 // ==========================================
+// MeshCore remote-telemetry scheduler
+// ==========================================
+// Periodically issues `req_telemetry_sync` against each opt-in remote
+// node. Unlike the local-node poller above, this DOES transmit on the
+// air, so it honours a per-source 60s minimum via the shared
+// `MeshCoreManager.lastMeshTxAt` primitive and only fires when a node's
+// own `telemetryIntervalMinutes` cadence has elapsed.
+export const meshcoreRemoteTelemetryScheduler = new MeshCoreRemoteTelemetryScheduler({
+  registry: meshcoreManagerRegistry,
+  database: databaseService,
+});
+setMeshCoreRemoteTelemetryScheduler(meshcoreRemoteTelemetryScheduler);
+setTimeout(async () => {
+  try {
+    await databaseService.waitForReady();
+    meshcoreRemoteTelemetryScheduler.start();
+  } catch (error) {
+    logger.error('Failed to start MeshCore remote-telemetry scheduler:', error);
+  }
+}, 8000); // After local poller so we never race the first per-manager TX.
+
+// ==========================================
 // Scheduled Auto-Upgrade Check
 // ==========================================
 // Check for updates every 4 hours server-side to enable unattended upgrades
@@ -830,6 +852,10 @@ import v1Router from './routes/v1/index.js';
 import meshcoreRoutes from './routes/meshcoreRoutes.js';
 import { meshcoreManagerRegistry, meshcoreConfigFromSource } from './meshcoreRegistry.js';
 import { MeshCoreTelemetryPoller, setMeshCoreTelemetryPoller } from './services/meshcoreTelemetryPoller.js';
+import {
+  MeshCoreRemoteTelemetryScheduler,
+  setMeshCoreRemoteTelemetryScheduler,
+} from './services/meshcoreRemoteTelemetryScheduler.js';
 import embedProfileRoutes from './routes/embedProfileRoutes.js';
 import { createEmbedCspMiddleware } from './middleware/embedMiddleware.js';
 import embedPublicRoutes from './routes/embedPublicRoutes.js';

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
@@ -1,0 +1,323 @@
+/**
+ * MeshCoreRemoteTelemetryScheduler tests.
+ *
+ * Covers the three rules that have to hold for the scheduler to be
+ * safe to run unattended:
+ *
+ *   1. Per-node eligibility honours `telemetryEnabled` AND the
+ *      `(now - lastTelemetryRequestAt) >= intervalMinutes*60_000`
+ *      window.
+ *   2. Per-source minimum spacing: even with two eligible nodes, the
+ *      scheduler issues at most one request per manager per tick, and
+ *      a manager that emitted any mesh-op less than 60s ago is
+ *      skipped entirely.
+ *   3. LPP record → telemetry-row decoding produces finite values
+ *      and explodes multi-component values into one row per axis.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  MeshCoreRemoteTelemetryScheduler,
+  isNodeEligible,
+  pickMostOverdue,
+  recordToTelemetryRows,
+  MIN_INTERVAL_BETWEEN_REQUESTS_MS,
+} from './meshcoreRemoteTelemetryScheduler.js';
+import type { DbMeshCoreNode } from '../../db/repositories/meshcore.js';
+import type { MeshCoreManager, MeshCoreTelemetryRecord } from '../meshcoreManager.js';
+import type { MeshCoreManagerRegistry } from '../meshcoreRegistry.js';
+
+function makeNode(over: Partial<DbMeshCoreNode>): DbMeshCoreNode {
+  return {
+    publicKey: 'pk-x',
+    sourceId: 'src-a',
+    createdAt: 0,
+    updatedAt: 0,
+    telemetryEnabled: true,
+    telemetryIntervalMinutes: 10,
+    lastTelemetryRequestAt: null,
+    ...over,
+  };
+}
+
+describe('isNodeEligible', () => {
+  it('rejects disabled nodes', () => {
+    expect(isNodeEligible(makeNode({ telemetryEnabled: false }), 0)).toBe(false);
+  });
+
+  it('rejects nodes with zero / null interval', () => {
+    expect(isNodeEligible(makeNode({ telemetryIntervalMinutes: 0 }), 1_000_000)).toBe(false);
+    expect(isNodeEligible(makeNode({ telemetryIntervalMinutes: null }), 1_000_000)).toBe(false);
+  });
+
+  it('accepts nodes that have never been requested', () => {
+    expect(isNodeEligible(makeNode({ lastTelemetryRequestAt: null }), 1_000_000)).toBe(true);
+  });
+
+  it('rejects nodes still inside their interval', () => {
+    const now = 10_000_000;
+    const fiveMinAgo = now - 5 * 60_000;
+    const node = makeNode({ telemetryIntervalMinutes: 10, lastTelemetryRequestAt: fiveMinAgo });
+    expect(isNodeEligible(node, now)).toBe(false);
+  });
+
+  it('accepts nodes past their interval', () => {
+    const now = 10_000_000;
+    const elevenMinAgo = now - 11 * 60_000;
+    const node = makeNode({ telemetryIntervalMinutes: 10, lastTelemetryRequestAt: elevenMinAgo });
+    expect(isNodeEligible(node, now)).toBe(true);
+  });
+});
+
+describe('pickMostOverdue', () => {
+  it('returns undefined when no eligible nodes', () => {
+    const nodes = [makeNode({ publicKey: 'a', telemetryEnabled: false })];
+    expect(pickMostOverdue(nodes, 1_000_000)).toBeUndefined();
+  });
+
+  it('picks the most overdue eligible node', () => {
+    const now = 100_000_000;
+    const a = makeNode({ publicKey: 'a', telemetryIntervalMinutes: 5, lastTelemetryRequestAt: now - 6 * 60_000 });
+    const b = makeNode({ publicKey: 'b', telemetryIntervalMinutes: 5, lastTelemetryRequestAt: now - 60 * 60_000 });
+    const c = makeNode({ publicKey: 'c', telemetryEnabled: false });
+    const picked = pickMostOverdue([a, b, c], now);
+    expect(picked?.publicKey).toBe('b');
+  });
+
+  it('uses publicKey as tiebreaker when overdue-by is equal', () => {
+    const now = 100_000_000;
+    const a = makeNode({ publicKey: 'aaa', lastTelemetryRequestAt: null });
+    const b = makeNode({ publicKey: 'bbb', lastTelemetryRequestAt: null });
+    expect(pickMostOverdue([b, a], now)?.publicKey).toBe('aaa');
+  });
+});
+
+describe('recordToTelemetryRows', () => {
+  const baseRec: MeshCoreTelemetryRecord = { channel: 1, type: 103, value: 21.5 };
+
+  it('produces one row for a scalar value with the right type+unit', () => {
+    const rows = recordToTelemetryRows(baseRec, 'pk', 1, 1_000);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].telemetryType).toBe('mc_temperature');
+    expect(rows[0].value).toBe(21.5);
+    expect(rows[0].unit).toBe('°C');
+    expect(rows[0].nodeId).toBe('pk');
+    expect(rows[0].nodeNum).toBe(1);
+    expect(rows[0].timestamp).toBe(1_000);
+  });
+
+  it('drops non-finite scalars instead of inserting NaN', () => {
+    const rec: MeshCoreTelemetryRecord = { channel: 1, type: 103, value: 'not-a-number' };
+    expect(recordToTelemetryRows(rec, 'pk', 1, 0)).toHaveLength(0);
+  });
+
+  it('explodes object values into one row per axis with _<key> suffix', () => {
+    const rec: MeshCoreTelemetryRecord = {
+      channel: 1,
+      type: 136,
+      value: { latitude: 30.1, longitude: -90.1, altitude: 10 },
+    };
+    const rows = recordToTelemetryRows(rec, 'pk', 1, 0);
+    const types = rows.map((r) => r.telemetryType).sort();
+    expect(types).toEqual([
+      'mc_lpp_136_altitude',
+      'mc_lpp_136_latitude',
+      'mc_lpp_136_longitude',
+    ]);
+  });
+
+  it('explodes array values into one row per index', () => {
+    const rec: MeshCoreTelemetryRecord = { channel: 1, type: 113, value: [1, 2, 3] };
+    const rows = recordToTelemetryRows(rec, 'pk', 1, 0);
+    expect(rows.map((r) => r.telemetryType)).toEqual([
+      'mc_lpp_113_0',
+      'mc_lpp_113_1',
+      'mc_lpp_113_2',
+    ]);
+  });
+
+  it('falls back to mc_lpp_<type> when the LPP type is unknown', () => {
+    const rec: MeshCoreTelemetryRecord = { channel: 1, type: 9999, value: 42 };
+    const rows = recordToTelemetryRows(rec, 'pk', 1, 0);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].telemetryType).toBe('mc_lpp_9999');
+  });
+});
+
+// ============ Scheduler integration-ish tests ============
+
+interface FakeManagerState {
+  sourceId: string;
+  connected: boolean;
+  lastMeshTxAt: number;
+  lastRequestedKey: string | null;
+  recordsToReturn: MeshCoreTelemetryRecord[] | null;
+}
+
+function makeFakeManager(init: Partial<FakeManagerState>): MeshCoreManager & { _state: FakeManagerState } {
+  const state: FakeManagerState = {
+    sourceId: 'src-a',
+    connected: true,
+    lastMeshTxAt: 0,
+    lastRequestedKey: null,
+    recordsToReturn: [{ channel: 1, type: 116, value: 3.7 }],
+    ...init,
+  };
+  const m: any = {
+    sourceId: state.sourceId,
+    isConnected: () => state.connected,
+    getLastMeshTxAt: () => state.lastMeshTxAt,
+    recordMeshTx: (when: number = Date.now()) => {
+      state.lastMeshTxAt = when;
+    },
+    requestRemoteTelemetry: async (publicKey: string) => {
+      state.lastRequestedKey = publicKey;
+      return state.recordsToReturn;
+    },
+    _state: state,
+  };
+  return m as MeshCoreManager & { _state: FakeManagerState };
+}
+
+function makeRegistry(managers: MeshCoreManager[]): MeshCoreManagerRegistry {
+  return { list: () => managers } as unknown as MeshCoreManagerRegistry;
+}
+
+describe('MeshCoreRemoteTelemetryScheduler.tickOneManager', () => {
+  it('skips disconnected managers', async () => {
+    const manager = makeFakeManager({ connected: false });
+    const insertSpy = vi.fn().mockResolvedValue(0);
+    const getNodes = vi.fn();
+    const markRequested = vi.fn();
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: {
+          getTelemetryEnabledNodes: getNodes,
+          markTelemetryRequested: markRequested,
+        },
+        telemetry: { insertTelemetryBatch: insertSpy },
+      },
+      now: () => 10_000_000,
+    });
+    await scheduler.tickOneManager(manager);
+    expect(getNodes).not.toHaveBeenCalled();
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips managers whose lastMeshTxAt is within the global minimum', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({ lastMeshTxAt: now - 30_000 }); // 30s ago, < 60s minimum
+    const getNodes = vi.fn().mockResolvedValue([
+      makeNode({ publicKey: 'a', telemetryEnabled: true, lastTelemetryRequestAt: null }),
+    ]);
+    const markRequested = vi.fn();
+    const insertSpy = vi.fn().mockResolvedValue(0);
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: { getTelemetryEnabledNodes: getNodes, markTelemetryRequested: markRequested },
+        telemetry: { insertTelemetryBatch: insertSpy },
+      },
+      minIntervalMs: MIN_INTERVAL_BETWEEN_REQUESTS_MS,
+      now: () => now,
+    });
+    await scheduler.tickOneManager(manager);
+    expect(getNodes).not.toHaveBeenCalled();
+    expect((manager as any)._state.lastRequestedKey).toBeNull();
+  });
+
+  it('does not skip on first-ever tick (lastMeshTxAt=0)', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({ lastMeshTxAt: 0 });
+    const getNodes = vi.fn().mockResolvedValue([
+      makeNode({ publicKey: 'a', telemetryEnabled: true, lastTelemetryRequestAt: null }),
+    ]);
+    const markRequested = vi.fn();
+    const insertSpy = vi.fn().mockResolvedValue(1);
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: { getTelemetryEnabledNodes: getNodes, markTelemetryRequested: markRequested },
+        telemetry: { insertTelemetryBatch: insertSpy },
+      },
+      now: () => now,
+    });
+    await scheduler.tickOneManager(manager);
+    expect((manager as any)._state.lastRequestedKey).toBe('a');
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('issues at most one request per tick even with multiple eligible nodes', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({});
+    const getNodes = vi.fn().mockResolvedValue([
+      makeNode({ publicKey: 'a', telemetryEnabled: true, lastTelemetryRequestAt: null }),
+      makeNode({ publicKey: 'b', telemetryEnabled: true, lastTelemetryRequestAt: null }),
+      makeNode({ publicKey: 'c', telemetryEnabled: true, lastTelemetryRequestAt: null }),
+    ]);
+    const markRequested = vi.fn();
+    const insertSpy = vi.fn().mockResolvedValue(1);
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: { getTelemetryEnabledNodes: getNodes, markTelemetryRequested: markRequested },
+        telemetry: { insertTelemetryBatch: insertSpy },
+      },
+      now: () => now,
+    });
+    await scheduler.tickOneManager(manager);
+    expect(markRequested).toHaveBeenCalledTimes(1);
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('stamps the per-node lastTelemetryRequestAt before issuing the RF call', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({});
+    const callOrder: string[] = [];
+    const markRequested = vi.fn(async () => {
+      callOrder.push('mark');
+    });
+    const originalRequest = manager.requestRemoteTelemetry;
+    manager.requestRemoteTelemetry = vi.fn(async (pk: string) => {
+      callOrder.push('request');
+      return originalRequest.call(manager, pk);
+    }) as typeof manager.requestRemoteTelemetry;
+
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: {
+          getTelemetryEnabledNodes: vi.fn().mockResolvedValue([
+            makeNode({ publicKey: 'a', telemetryEnabled: true, lastTelemetryRequestAt: null }),
+          ]),
+          markTelemetryRequested: markRequested,
+        },
+        telemetry: { insertTelemetryBatch: vi.fn().mockResolvedValue(1) },
+      },
+      now: () => now,
+    });
+    await scheduler.tickOneManager(manager);
+    expect(callOrder).toEqual(['mark', 'request']);
+  });
+
+  it('does NOT write telemetry rows when the RF response is empty', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({ recordsToReturn: [] });
+    const insertSpy = vi.fn().mockResolvedValue(0);
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: {
+          getTelemetryEnabledNodes: vi.fn().mockResolvedValue([
+            makeNode({ publicKey: 'a', telemetryEnabled: true, lastTelemetryRequestAt: null }),
+          ]),
+          markTelemetryRequested: vi.fn(),
+        },
+        telemetry: { insertTelemetryBatch: insertSpy },
+      },
+      now: () => now,
+    });
+    await scheduler.tickOneManager(manager);
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.ts
@@ -1,0 +1,326 @@
+/**
+ * MeshCore Remote-Telemetry Scheduler — periodic `req_telemetry_sync` for
+ * each opt-in node across every connected source.
+ *
+ * Unlike `MeshCoreTelemetryPoller` (which only touches the locally-attached
+ * companion), this scheduler PUTS PACKETS ON THE AIR. Throttling is
+ * non-negotiable:
+ *
+ *   - Per-node cadence: `telemetryIntervalMinutes` from `meshcore_nodes`.
+ *   - Per-source minimum: `MIN_INTERVAL_BETWEEN_REQUESTS_MS` (60s) between
+ *     any two scheduled telemetry requests on the same manager — enforced
+ *     via the shared `MeshCoreManager.lastMeshTxAt` primitive so future
+ *     scheduled mesh-ops on the same source (auto-traceroute, etc.)
+ *     coordinate against the same field without each owning their own
+ *     bookkeeping.
+ *   - Per-tick budget: at most one request per manager per tick.
+ *
+ * Tick cadence defaults to 30s (the scheduler can't physically do better
+ * than the global minimum, but a shorter tick lets a newly-eligible node
+ * get serviced sooner than waiting a full minute). Configurable via
+ * `MESHCORE_REMOTE_TELEMETRY_TICK_MS`.
+ */
+import { logger } from '../../utils/logger.js';
+import type { DbTelemetry } from '../../services/database.js';
+import type { DbMeshCoreNode } from '../../db/repositories/meshcore.js';
+import type { MeshCoreManager, MeshCoreTelemetryRecord } from '../meshcoreManager.js';
+import type { MeshCoreManagerRegistry } from '../meshcoreRegistry.js';
+import { MC_TELEMETRY_PREFIX, nodeNumFromPubkey } from './meshcoreTelemetryPoller.js';
+
+/** Database surface the scheduler depends on (kept thin for testability). */
+export interface RemoteTelemetrySchedulerDatabase {
+  meshcore: {
+    getTelemetryEnabledNodes: (sourceId: string) => Promise<DbMeshCoreNode[]>;
+    markTelemetryRequested: (sourceId: string, publicKey: string, when?: number) => Promise<void>;
+  };
+  telemetry: {
+    insertTelemetryBatch: (rows: DbTelemetry[], sourceId?: string) => Promise<number>;
+  };
+}
+
+/** Minimum spacing between scheduled telemetry requests on the same source (ms). */
+export const MIN_INTERVAL_BETWEEN_REQUESTS_MS = 60_000;
+
+/** Default scheduler tick (ms); always >= 1s, clamped on parse. */
+export const DEFAULT_TICK_MS = 30_000;
+const MIN_TICK_MS = 1_000;
+
+/** Sanity ceiling on the per-node interval the UI can set, in minutes. */
+export const MAX_INTERVAL_MINUTES = 24 * 60;
+
+export interface MeshCoreRemoteTelemetrySchedulerOptions {
+  registry: MeshCoreManagerRegistry;
+  database: RemoteTelemetrySchedulerDatabase;
+  /** Override the env-derived tick (tests). */
+  tickMs?: number;
+  /** Override the inter-request minimum (tests). */
+  minIntervalMs?: number;
+  /** Inject a clock for tests. */
+  now?: () => number;
+}
+
+export function resolveTickMs(envValue: string | undefined): number {
+  if (!envValue) return DEFAULT_TICK_MS;
+  const parsed = parseInt(envValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TICK_MS;
+  return Math.max(parsed, MIN_TICK_MS);
+}
+
+/**
+ * Map Cayenne-LPP type ids → `telemetry.telemetryType` strings the rest
+ * of MeshMonitor already knows how to graph. Anything missing falls
+ * back to `mc_lpp_<type>` so the row still lands in the DB rather than
+ * being silently dropped.
+ *
+ * Keeping this map small + explicit beats decoding the python lib's
+ * naming on the fly: each entry is something the UI's telemetry
+ * formatter already labels.
+ */
+const LPP_TYPE_NAMES: Record<number, { type: string; unit?: string }> = {
+  2: { type: 'analog_input' },
+  3: { type: 'analog_output' },
+  101: { type: 'illuminance', unit: 'lux' },
+  102: { type: 'presence' },
+  103: { type: 'temperature', unit: '°C' },
+  104: { type: 'humidity', unit: '%' },
+  115: { type: 'barometer', unit: 'hPa' },
+  116: { type: 'battery_volts', unit: 'V' },
+  117: { type: 'current', unit: 'A' },
+  118: { type: 'frequency', unit: 'Hz' },
+  120: { type: 'percentage', unit: '%' },
+  121: { type: 'altitude', unit: 'm' },
+  122: { type: 'load', unit: 'kg' },
+  125: { type: 'concentration', unit: 'ppm' },
+  128: { type: 'power', unit: 'W' },
+  130: { type: 'distance', unit: 'm' },
+  131: { type: 'energy', unit: 'Wh' },
+  133: { type: 'time', unit: 's' },
+};
+
+/**
+ * Decide whether a node is currently eligible for a fresh telemetry
+ * request. Pure function, exported for the unit test.
+ */
+export function isNodeEligible(
+  node: DbMeshCoreNode,
+  now: number,
+): boolean {
+  if (!node.telemetryEnabled) return false;
+  const interval = node.telemetryIntervalMinutes;
+  if (interval === null || interval === undefined || interval <= 0) return false;
+  const last = node.lastTelemetryRequestAt ?? 0;
+  const overdueBy = now - last;
+  return overdueBy >= interval * 60_000;
+}
+
+/**
+ * Pick the most overdue eligible node from a list, or undefined if none.
+ * Stable tiebreaker on publicKey so two nodes that came due in the same
+ * tick don't ping-pong on every cycle.
+ */
+export function pickMostOverdue(
+  nodes: DbMeshCoreNode[],
+  now: number,
+): DbMeshCoreNode | undefined {
+  const eligible = nodes.filter((n) => isNodeEligible(n, now));
+  if (eligible.length === 0) return undefined;
+  eligible.sort((a, b) => {
+    const aOver = now - (a.lastTelemetryRequestAt ?? 0);
+    const bOver = now - (b.lastTelemetryRequestAt ?? 0);
+    if (aOver !== bOver) return bOver - aOver;
+    return a.publicKey.localeCompare(b.publicKey);
+  });
+  return eligible[0];
+}
+
+/**
+ * Convert a Cayenne-LPP record from the bridge into a DbTelemetry row.
+ * Multi-component values (gps, accelerometer, colour) explode into one
+ * row per axis with a `_<axis>` suffix. Anything we can't reduce to a
+ * finite number is dropped — the alternative is poisoning the
+ * telemetry table with NaN.
+ */
+export function recordToTelemetryRows(
+  record: MeshCoreTelemetryRecord,
+  nodeId: string,
+  nodeNum: number,
+  timestamp: number,
+): DbTelemetry[] {
+  if (record.type === null || record.type === undefined) return [];
+  const naming = LPP_TYPE_NAMES[record.type] ?? { type: `lpp_${record.type}` };
+  const baseType = `${MC_TELEMETRY_PREFIX}${naming.type}`;
+  const out: DbTelemetry[] = [];
+
+  const pushScalar = (typeName: string, raw: unknown, unit?: string) => {
+    const num = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isFinite(num)) return;
+    out.push({
+      nodeId,
+      nodeNum,
+      telemetryType: typeName,
+      value: num,
+      unit,
+      timestamp,
+      createdAt: timestamp,
+    });
+  };
+
+  const value = record.value;
+  if (value === null || value === undefined) return [];
+  if (typeof value === 'number') {
+    pushScalar(baseType, value, naming.unit);
+  } else if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      pushScalar(`${baseType}_${i}`, value[i], naming.unit);
+    }
+  } else if (typeof value === 'object') {
+    for (const [k, v] of Object.entries(value)) {
+      pushScalar(`${baseType}_${k}`, v, naming.unit);
+    }
+  } else if (typeof value === 'string') {
+    pushScalar(baseType, value, naming.unit);
+  }
+  return out;
+}
+
+export class MeshCoreRemoteTelemetryScheduler {
+  private readonly registry: MeshCoreManagerRegistry;
+  private readonly database: RemoteTelemetrySchedulerDatabase;
+  private readonly tickMs: number;
+  private readonly minIntervalMs: number;
+  private readonly nowFn: () => number;
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+
+  constructor(opts: MeshCoreRemoteTelemetrySchedulerOptions) {
+    this.registry = opts.registry;
+    this.database = opts.database;
+    this.tickMs = opts.tickMs ?? resolveTickMs(process.env.MESHCORE_REMOTE_TELEMETRY_TICK_MS);
+    this.minIntervalMs = opts.minIntervalMs ?? MIN_INTERVAL_BETWEEN_REQUESTS_MS;
+    this.nowFn = opts.now ?? Date.now;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    logger.info(
+      `[MeshCoreRemoteTelem] Scheduler starting (tick=${Math.round(this.tickMs / 1000)}s, ` +
+        `min-interval=${Math.round(this.minIntervalMs / 1000)}s)`,
+    );
+    this.timer = setInterval(() => {
+      this.tick().catch((err) => logger.error('[MeshCoreRemoteTelem] Unhandled tick error:', err));
+    }, this.tickMs);
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * One tick. Visible for tests. Walks every registered manager and
+   * issues at most one telemetry request per source, gated by both
+   * the in-DB per-node cadence and the per-manager 60s minimum.
+   */
+  async tick(): Promise<void> {
+    if (this.running) {
+      logger.debug('[MeshCoreRemoteTelem] Previous tick still running, skipping');
+      return;
+    }
+    this.running = true;
+    try {
+      const managers = this.registry.list();
+      for (const manager of managers) {
+        try {
+          await this.tickOneManager(manager);
+        } catch (err) {
+          logger.warn(`[MeshCoreRemoteTelem:${manager.sourceId}] Tick failed:`, err);
+        }
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /** Process a single manager. Visible for tests. */
+  async tickOneManager(manager: MeshCoreManager): Promise<void> {
+    if (!manager.isConnected()) return;
+
+    const now = this.nowFn();
+    const sinceLastTx = now - manager.getLastMeshTxAt();
+    if (manager.getLastMeshTxAt() > 0 && sinceLastTx < this.minIntervalMs) {
+      logger.debug(
+        `[MeshCoreRemoteTelem:${manager.sourceId}] Throttled — last mesh tx was ${Math.round(sinceLastTx / 1000)}s ago`,
+      );
+      return;
+    }
+
+    const nodes = await this.database.meshcore.getTelemetryEnabledNodes(manager.sourceId);
+    if (nodes.length === 0) return;
+
+    const target = pickMostOverdue(nodes, now);
+    if (!target) return;
+
+    logger.info(
+      `[MeshCoreRemoteTelem:${manager.sourceId}] Requesting telemetry from ${target.publicKey.substring(0, 16)}…`,
+    );
+
+    // Stamp the request time BEFORE issuing — keeps a slow / failing node
+    // from being re-selected on every tick while we wait. The manager
+    // also bumps its own `lastMeshTxAt` inside `requestRemoteTelemetry`.
+    await this.database.meshcore.markTelemetryRequested(manager.sourceId, target.publicKey, now);
+    manager.recordMeshTx(now);
+
+    const records = await manager.requestRemoteTelemetry(target.publicKey);
+    if (!records || records.length === 0) {
+      logger.debug(
+        `[MeshCoreRemoteTelem:${manager.sourceId}] No telemetry from ${target.publicKey.substring(0, 16)}… (timeout or empty)`,
+      );
+      return;
+    }
+
+    const nodeNum = nodeNumFromPubkey(target.publicKey);
+    const ts = this.nowFn();
+    const rows: DbTelemetry[] = [];
+    for (const rec of records) {
+      rows.push(...recordToTelemetryRows(rec, target.publicKey, nodeNum, ts));
+    }
+
+    if (rows.length === 0) {
+      logger.debug(
+        `[MeshCoreRemoteTelem:${manager.sourceId}] LPP frame decoded to 0 rows for ${target.publicKey.substring(0, 16)}…`,
+      );
+      return;
+    }
+
+    try {
+      await this.database.telemetry.insertTelemetryBatch(rows, manager.sourceId);
+      logger.debug(
+        `[MeshCoreRemoteTelem:${manager.sourceId}] Wrote ${rows.length} telemetry rows for ${target.publicKey.substring(0, 16)}…`,
+      );
+    } catch (err) {
+      logger.warn(`[MeshCoreRemoteTelem:${manager.sourceId}] insertTelemetryBatch failed:`, err);
+    }
+  }
+}
+
+/**
+ * Module-level singleton handle, mirroring the local-node poller. server.ts
+ * constructs the scheduler once at startup and route handlers don't need
+ * to reach into it directly — but exposing it via setter/getter keeps the
+ * pattern consistent with the local poller and leaves room for routes
+ * that want to peek at scheduler state.
+ */
+let _scheduler: MeshCoreRemoteTelemetryScheduler | null = null;
+
+export function setMeshCoreRemoteTelemetryScheduler(
+  scheduler: MeshCoreRemoteTelemetryScheduler | null,
+): void {
+  _scheduler = scheduler;
+}
+
+export function getMeshCoreRemoteTelemetryScheduler(): MeshCoreRemoteTelemetryScheduler | null {
+  return _scheduler;
+}

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -34,6 +34,7 @@ import {
   SourcesRepository,
   AnalysisRepository,
   WaypointsRepository,
+  MeshCoreRepository,
 } from '../db/repositories/index.js';
 import type { DatabaseType, DbPacketLog as DbTypesPacketLog, DbPacketCountByNode, DbPacketCountByPortnum, DbDistinctRelayNode } from '../db/types.js';
 
@@ -475,6 +476,7 @@ class DatabaseService {
   public sourcesRepo: SourcesRepository | null = null;
   public analysisRepo: AnalysisRepository | null = null;
   public waypointsRepo: WaypointsRepository | null = null;
+  public meshcoreRepo: MeshCoreRepository | null = null;
 
   /**
    * Typed repository accessors — throw if database not initialized.
@@ -558,6 +560,11 @@ class DatabaseService {
   get waypoints(): WaypointsRepository {
     if (!this.waypointsRepo) throw new Error('Database not initialized');
     return this.waypointsRepo;
+  }
+
+  get meshcore(): MeshCoreRepository {
+    if (!this.meshcoreRepo) throw new Error('Database not initialized');
+    return this.meshcoreRepo;
   }
 
   constructor() {
@@ -831,6 +838,7 @@ class DatabaseService {
       this.sourcesRepo = new SourcesRepository(drizzleDb, this.drizzleDbType);
       this.analysisRepo = new AnalysisRepository(drizzleDb as any, this.drizzleDbType);
       this.waypointsRepo = new WaypointsRepository(drizzleDb, this.drizzleDbType);
+      this.meshcoreRepo = new MeshCoreRepository(drizzleDb, this.drizzleDbType);
 
       logger.info('[DatabaseService] Drizzle repositories initialized successfully');
 


### PR DESCRIPTION
## Summary
- Adds a scheduled per-node remote telemetry collector for MeshCore. Each node in `meshcore_nodes` can opt in to periodic `req_telemetry_sync` over RF with a per-node interval (minutes).
- Per-source 60-second minimum between any two scheduled telemetry requests, enforced via a new shared `MeshCoreManager.lastMeshTxAt` primitive. Future scheduled mesh-ops on the same manager (auto-traceroute, periodic adverts, etc.) can coordinate against the same field without each owning a private throttle.
- Per-tick budget of one request per manager — no "everyone overdue at once" radio bursts.
- LPP response decoded to existing `telemetry` rows with `mc_<type>` names so the standard graph paths pick them up. No new tables.

## Schema / data
- Migration **060** adds three nullable columns to `meshcore_nodes`:
  - `telemetryEnabled BOOLEAN DEFAULT false`
  - `telemetryIntervalMinutes INTEGER DEFAULT 60`
  - `lastTelemetryRequestAt BIGINT NULL`
- Idempotent across SQLite / PostgreSQL / MySQL.
- No backfill required — absence of `telemetryEnabled=true` keeps existing rows out of the scheduler's pick list.

## Throttle behaviour
- **Per-node cadence** (in DB): `lastTelemetryRequestAt` stamped before the RF call, so a slow node can't be re-selected on every tick while we wait.
- **Per-source minimum** (in-memory): `MeshCoreManager.lastMeshTxAt`, bumped on every successful `requestRemoteTelemetry`. Default 60 s, overridable in tests via the scheduler's `minIntervalMs` option.
- **Per-tick budget**: scheduler picks the single most-overdue eligible node per manager per tick; everyone else waits.

## API
- `GET  /api/sources/:id/meshcore/nodes/:publicKey/telemetry-config` — gated `nodes:read`.
- `PATCH /api/sources/:id/meshcore/nodes/:publicKey/telemetry-config` — gated `configuration:write` per the PR #3019 pattern. Body: `{ enabled?: boolean, intervalMinutes?: number }` (1 ≤ `intervalMinutes` ≤ 1440).

## UI
- New `MeshCoreNodeTelemetryConfig` panel rendered below the map in the Nodes view (per-source mount only). Visible only when the selected key is a real 64-hex public key — channel keys are filtered out.
- Toggle + interval input. Both `disabled` for users without `configuration:write`, with the same yellow-banner explanation used elsewhere in the MeshCore config UI.

## Test plan
- [x] `vitest run` — full suite green (4900 tests).
- [x] New unit tests:
  - `migrations/060_meshcore_node_telemetry_config.test.ts` — adds the three columns with the documented defaults, idempotent on a second run.
  - `repositories/meshcore.test.ts` — set / mark / scoped-by-sourceId, including independent state for the same publicKey on two different sources.
  - `services/meshcoreRemoteTelemetryScheduler.test.ts` — eligibility math, 1-per-tick budget, 60s global throttle skip, LPP→telemetry-row decoder (incl. multi-axis explode).
  - Bumped `migrations.test.ts` to 60.
- [x] `tsc --noEmit` clean.
- [x] `eslint` — no new categories of warning/error beyond the pre-existing `NodeJS.Timeout` pattern already used in `meshcoreTelemetryPoller.ts`.
- [ ] **Visual inspection deferred** — the new UI panel only renders when a per-source MeshCore mount has a connected companion node selected, which requires real MeshCore hardware I don't have access to in this sandbox. Manual screenshot of the Nodes view with a selected node would be the right verification step before merging.
- [ ] Smoke test against a real MeshCore companion device: enable a node, confirm a telemetry row lands within the configured interval, confirm a second request doesn't fire inside 60 s.

Authored by Merlin 🪄