### PR TITLE
fix(meshcore): composite (sourceId, publicKey) primary key on meshcore_nodes

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 60 migrations registered', () => {
-    expect(registry.count()).toBe(60);
+  it('has all 61 migrations registered', () => {
+    expect(registry.count()).toBe(61);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is meshcore_node_telemetry_config', () => {
+  it('last migration is meshcore_nodes_composite_pk', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(60);
-    expect(last.name).toContain('meshcore_node_telemetry_config');
+    expect(last.number).toBe(61);
+    expect(last.name).toContain('meshcore_nodes_composite_pk');
   });
 
-  it('migrations are sequentially numbered from 1 to 60', () => {
+  it('migrations are sequentially numbered from 1 to 61', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -72,6 +72,7 @@ import { migration as addSourceIdToMeshcoreTablesMigration, runMigration057Postg
 import { migration as collapseMeshcoreResourceMigration, runMigration058Postgres, runMigration058Mysql } from '../server/migrations/058_collapse_meshcore_resource.js';
 import { migration as telemetrySourceNodeTypeTsIndexMigration, runMigration059Postgres, runMigration059Mysql } from '../server/migrations/059_telemetry_source_node_type_ts_index.js';
 import { migration as meshcoreNodeTelemetryConfigMigration, runMigration060Postgres, runMigration060Mysql } from '../server/migrations/060_meshcore_node_telemetry_config.js';
+import { migration as meshcoreNodesCompositePkMigration, runMigration061Postgres, runMigration061Mysql } from '../server/migrations/061_meshcore_nodes_composite_pk.js';
 
 // ============================================================================
 // Registry
@@ -935,4 +936,21 @@ registry.register({
   sqlite: (db) => meshcoreNodeTelemetryConfigMigration.up(db),
   postgres: (client) => runMigration060Postgres(client),
   mysql: (pool) => runMigration060Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 061: meshcore_nodes composite PK (sourceId, publicKey). Previously
+// publicKey alone was the PK, which collapsed the same MeshCore node under
+// two sources into one row and raised UNIQUE constraint failures on any
+// second-source write (observed via the per-source telemetry-config endpoint).
+// Mirrors migration 029 for Meshtastic nodes. Idempotent.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 61,
+  name: 'meshcore_nodes_composite_pk',
+  settingsKey: 'migration_061_meshcore_nodes_composite_pk',
+  sqlite: (db) => meshcoreNodesCompositePkMigration.up(db),
+  postgres: (client) => runMigration061Postgres(client),
+  mysql: (pool) => runMigration061Mysql(pool),
 });

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -336,4 +336,122 @@ describe('MeshCoreRepository — sourceId stamping', () => {
       repo.setNodeTelemetryConfig('', 'pk-1', { enabled: true }),
     ).rejects.toThrow(/requires a sourceId/);
   });
+
+  // ============ Composite-PK regression (issue: UNIQUE constraint failed) ============
+
+  it('setNodeTelemetryConfig succeeds for the same publicKey under two sources on the composite-PK schema', async () => {
+    // Post-migration-061 schema: PK is (sourceId, publicKey). This was the
+    // bug repro — POST /api/sources/{sourceId}/meshcore/nodes/{publicKey}
+    // /telemetry-config raised `UNIQUE constraint failed:
+    // meshcore_nodes.publicKey` when the same key already existed under a
+    // different source.
+    db.exec(`
+      DROP TABLE meshcore_nodes;
+      CREATE TABLE meshcore_nodes (
+        publicKey TEXT NOT NULL,
+        name TEXT,
+        advType INTEGER,
+        txPower INTEGER,
+        maxTxPower INTEGER,
+        radioFreq REAL,
+        radioBw REAL,
+        radioSf INTEGER,
+        radioCr INTEGER,
+        latitude REAL,
+        longitude REAL,
+        altitude REAL,
+        batteryMv INTEGER,
+        uptimeSecs INTEGER,
+        rssi INTEGER,
+        snr REAL,
+        lastHeard INTEGER,
+        hasAdminAccess INTEGER DEFAULT 0,
+        lastAdminCheck INTEGER,
+        isLocalNode INTEGER DEFAULT 0,
+        sourceId TEXT NOT NULL,
+        telemetryEnabled INTEGER DEFAULT 0,
+        telemetryIntervalMinutes INTEGER DEFAULT 60,
+        lastTelemetryRequestAt INTEGER,
+        createdAt INTEGER NOT NULL,
+        updatedAt INTEGER NOT NULL,
+        PRIMARY KEY (sourceId, publicKey)
+      );
+    `);
+
+    // src-a owns the key first.
+    await repo.setNodeTelemetryConfig('src-a', 'pk-shared', {
+      enabled: true,
+      intervalMinutes: 15,
+    });
+
+    // src-b setting telemetry-config on the SAME publicKey must NOT
+    // raise UNIQUE constraint failed.
+    await expect(
+      repo.setNodeTelemetryConfig('src-b', 'pk-shared', {
+        enabled: true,
+        intervalMinutes: 45,
+      }),
+    ).resolves.not.toThrow();
+
+    const rows = db
+      .prepare(
+        `SELECT sourceId, telemetryEnabled, telemetryIntervalMinutes
+         FROM meshcore_nodes WHERE publicKey = 'pk-shared' ORDER BY sourceId`,
+      )
+      .all() as Array<{ sourceId: string; telemetryEnabled: number; telemetryIntervalMinutes: number }>;
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({ sourceId: 'src-a', telemetryEnabled: 1, telemetryIntervalMinutes: 15 });
+    expect(rows[1]).toEqual({ sourceId: 'src-b', telemetryEnabled: 1, telemetryIntervalMinutes: 45 });
+  });
+
+  it('deleteNode requires a sourceId and only removes the matching (sourceId, publicKey) row', async () => {
+    db.exec(`
+      DROP TABLE meshcore_nodes;
+      CREATE TABLE meshcore_nodes (
+        publicKey TEXT NOT NULL,
+        name TEXT,
+        advType INTEGER,
+        txPower INTEGER,
+        maxTxPower INTEGER,
+        radioFreq REAL,
+        radioBw REAL,
+        radioSf INTEGER,
+        radioCr INTEGER,
+        latitude REAL,
+        longitude REAL,
+        altitude REAL,
+        batteryMv INTEGER,
+        uptimeSecs INTEGER,
+        rssi INTEGER,
+        snr REAL,
+        lastHeard INTEGER,
+        hasAdminAccess INTEGER DEFAULT 0,
+        lastAdminCheck INTEGER,
+        isLocalNode INTEGER DEFAULT 0,
+        sourceId TEXT NOT NULL,
+        telemetryEnabled INTEGER DEFAULT 0,
+        telemetryIntervalMinutes INTEGER DEFAULT 60,
+        lastTelemetryRequestAt INTEGER,
+        createdAt INTEGER NOT NULL,
+        updatedAt INTEGER NOT NULL,
+        PRIMARY KEY (sourceId, publicKey)
+      );
+    `);
+
+    await repo.upsertNode({ publicKey: 'pk-shared', name: 'A' }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk-shared', name: 'B' }, 'src-b');
+
+    // Guard against missing sourceId
+    await expect(repo.deleteNode('pk-shared', '')).rejects.toThrow(/requires a sourceId/);
+
+    // Source-scoped delete leaves the other source's row alone
+    const ok = await repo.deleteNode('pk-shared', 'src-a');
+    expect(ok).toBe(true);
+
+    const rows = db
+      .prepare(`SELECT sourceId, name FROM meshcore_nodes WHERE publicKey = 'pk-shared'`)
+      .all() as Array<{ sourceId: string; name: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({ sourceId: 'src-b', name: 'B' });
+  });
 });

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -249,11 +249,18 @@ export class MeshCoreRepository extends BaseRepository {
   }
 
   /**
-   * Delete a node by public key
+   * Delete a node row scoped by (sourceId, publicKey). Required since the
+   * composite-PK migration: the same publicKey can exist under multiple
+   * sources, so a publicKey-only delete would wipe rows from every source.
    */
-  async deleteNode(publicKey: string): Promise<boolean> {
+  async deleteNode(publicKey: string, sourceId: string): Promise<boolean> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.deleteNode requires a sourceId');
+    }
     const { meshcoreNodes } = this.tables;
-    await this.db.delete(meshcoreNodes).where(eq(meshcoreNodes.publicKey, publicKey));
+    await this.db
+      .delete(meshcoreNodes)
+      .where(and(eq(meshcoreNodes.publicKey, publicKey), eq(meshcoreNodes.sourceId, sourceId)));
     return true;
   }
 

--- a/src/db/schema/meshcoreNodes.ts
+++ b/src/db/schema/meshcoreNodes.ts
@@ -5,9 +5,9 @@
  * MeshCore uses public keys (64-char hex) as primary identifiers
  * instead of numeric node IDs like Meshtastic.
  */
-import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
-import { pgTable, text as pgText, integer as pgInteger, real as pgReal, doublePrecision as pgDoublePrecision, boolean as pgBoolean, bigint as pgBigint } from 'drizzle-orm/pg-core';
-import { mysqlTable, varchar as myVarchar, int as myInt, double as myDouble, boolean as myBoolean, bigint as myBigint } from 'drizzle-orm/mysql-core';
+import { sqliteTable, text, integer, real, primaryKey as sqlitePrimaryKey } from 'drizzle-orm/sqlite-core';
+import { pgTable, text as pgText, integer as pgInteger, real as pgReal, doublePrecision as pgDoublePrecision, boolean as pgBoolean, bigint as pgBigint, primaryKey as pgPrimaryKey } from 'drizzle-orm/pg-core';
+import { mysqlTable, varchar as myVarchar, int as myInt, double as myDouble, boolean as myBoolean, bigint as myBigint, primaryKey as myPrimaryKey } from 'drizzle-orm/mysql-core';
 
 /**
  * MeshCore device types
@@ -20,8 +20,8 @@ import { mysqlTable, varchar as myVarchar, int as myInt, double as myDouble, boo
 // ============ SQLite Schema ============
 
 export const meshcoreNodesSqlite = sqliteTable('meshcore_nodes', {
-  // Primary identifier - 64 character hex public key
-  publicKey: text('publicKey').primaryKey(),
+  // 64 character hex public key — part of composite PK after migration 061
+  publicKey: text('publicKey').notNull(),
 
   // Node identity
   name: text('name'),
@@ -58,8 +58,8 @@ export const meshcoreNodesSqlite = sqliteTable('meshcore_nodes', {
   // Local node indicator
   isLocalNode: integer('isLocalNode', { mode: 'boolean' }).default(false),
 
-  // Owning source (nullable for legacy single-source rows; backfilled by migration 056)
-  sourceId: text('sourceId'),
+  // Owning source — required as part of composite PK after migration 061.
+  sourceId: text('sourceId').notNull(),
 
   // Per-node remote-telemetry retrieval config (migration 060). The
   // MeshCoreRemoteTelemetryScheduler reads these to decide whether to
@@ -71,12 +71,14 @@ export const meshcoreNodesSqlite = sqliteTable('meshcore_nodes', {
   // Timestamps
   createdAt: integer('createdAt').notNull(),
   updatedAt: integer('updatedAt').notNull(),
-});
+}, (table) => ({
+  pk: sqlitePrimaryKey({ columns: [table.sourceId, table.publicKey] }),
+}));
 
 // ============ PostgreSQL Schema ============
 
 export const meshcoreNodesPostgres = pgTable('meshcore_nodes', {
-  publicKey: pgText('publicKey').primaryKey(),
+  publicKey: pgText('publicKey').notNull(),
 
   name: pgText('name'),
   advType: pgInteger('advType'),
@@ -105,7 +107,7 @@ export const meshcoreNodesPostgres = pgTable('meshcore_nodes', {
 
   isLocalNode: pgBoolean('isLocalNode').default(false),
 
-  sourceId: pgText('sourceId'),
+  sourceId: pgText('sourceId').notNull(),
 
   telemetryEnabled: pgBoolean('telemetryEnabled').default(false),
   telemetryIntervalMinutes: pgInteger('telemetryIntervalMinutes').default(60),
@@ -113,12 +115,14 @@ export const meshcoreNodesPostgres = pgTable('meshcore_nodes', {
 
   createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
   updatedAt: pgBigint('updatedAt', { mode: 'number' }).notNull(),
-});
+}, (table) => ({
+  pk: pgPrimaryKey({ columns: [table.sourceId, table.publicKey] }),
+}));
 
 // ============ MySQL Schema ============
 
 export const meshcoreNodesMysql = mysqlTable('meshcore_nodes', {
-  publicKey: myVarchar('publicKey', { length: 64 }).primaryKey(),
+  publicKey: myVarchar('publicKey', { length: 64 }).notNull(),
 
   name: myVarchar('name', { length: 255 }),
   advType: myInt('advType'),
@@ -147,7 +151,7 @@ export const meshcoreNodesMysql = mysqlTable('meshcore_nodes', {
 
   isLocalNode: myBoolean('isLocalNode').default(false),
 
-  sourceId: myVarchar('sourceId', { length: 64 }),
+  sourceId: myVarchar('sourceId', { length: 64 }).notNull(),
 
   telemetryEnabled: myBoolean('telemetryEnabled').default(false),
   telemetryIntervalMinutes: myInt('telemetryIntervalMinutes').default(60),
@@ -155,7 +159,9 @@ export const meshcoreNodesMysql = mysqlTable('meshcore_nodes', {
 
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
   updatedAt: myBigint('updatedAt', { mode: 'number' }).notNull(),
-});
+}, (table) => ({
+  pk: myPrimaryKey({ columns: [table.sourceId, table.publicKey] }),
+}));
 
 // ============ Type Inference ============
 

--- a/src/server/migrations/061_meshcore_nodes_composite_pk.test.ts
+++ b/src/server/migrations/061_meshcore_nodes_composite_pk.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Migration 061 — meshcore_nodes composite PK (sourceId, publicKey).
+ *
+ * SQLite-only test; PG/MySQL paths share the same shape and are exercised
+ * by the integration suite. We assert:
+ *
+ *   1. The rebuild produces a composite PK on (sourceId, publicKey).
+ *   2. Existing rows survive the rebuild.
+ *   3. NULL-sourceId rows are backfilled to the legacy meshcore source.
+ *   4. After the rebuild, the same publicKey can be inserted under two
+ *      different sourceIds without a UNIQUE constraint failure — the
+ *      observed production bug.
+ *   5. The migration is idempotent.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './061_meshcore_nodes_composite_pk.js';
+
+function createPostM060Schema(db: Database.Database) {
+  // Sources table is required for the legacy-default backfill path.
+  db.exec(`
+    CREATE TABLE sources (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL,
+      config TEXT,
+      enabled INTEGER DEFAULT 1,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL
+    );
+  `);
+
+  // Post-migration-060 shape: publicKey-only PK.
+  db.exec(`
+    CREATE TABLE meshcore_nodes (
+      publicKey TEXT PRIMARY KEY,
+      name TEXT,
+      advType INTEGER,
+      txPower INTEGER,
+      maxTxPower INTEGER,
+      radioFreq REAL,
+      radioBw REAL,
+      radioSf INTEGER,
+      radioCr INTEGER,
+      latitude REAL,
+      longitude REAL,
+      altitude REAL,
+      batteryMv INTEGER,
+      uptimeSecs INTEGER,
+      rssi INTEGER,
+      snr REAL,
+      lastHeard INTEGER,
+      hasAdminAccess INTEGER DEFAULT 0,
+      lastAdminCheck INTEGER,
+      isLocalNode INTEGER DEFAULT 0,
+      sourceId TEXT,
+      telemetryEnabled INTEGER DEFAULT 0,
+      telemetryIntervalMinutes INTEGER DEFAULT 60,
+      lastTelemetryRequestAt INTEGER,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL
+    );
+  `);
+}
+
+function pkColumns(db: Database.Database): string[] {
+  const rows = db
+    .prepare(`SELECT name FROM pragma_table_info('meshcore_nodes') WHERE pk > 0 ORDER BY pk`)
+    .all() as Array<{ name: string }>;
+  return rows.map((r) => r.name);
+}
+
+describe('Migration 061 — meshcore_nodes composite PK (sourceId, publicKey)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createPostM060Schema(db);
+  });
+
+  it('rebuilds with composite (sourceId, publicKey) PK', () => {
+    migration.up(db);
+    const pk = pkColumns(db);
+    expect(pk).toContain('sourceId');
+    expect(pk).toContain('publicKey');
+    expect(pk.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('preserves existing rows through the rebuild', () => {
+    const ts = Date.now();
+    db.prepare(
+      `INSERT INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+       VALUES ('src-a', 'Source A', 'meshcore', '{}', 1, ?, ?)`,
+    ).run(ts, ts);
+    db.prepare(
+      `INSERT INTO meshcore_nodes (publicKey, name, sourceId, createdAt, updatedAt)
+       VALUES ('pk-1', 'kept', 'src-a', ?, ?)`,
+    ).run(ts, ts);
+
+    migration.up(db);
+
+    const row = db
+      .prepare(`SELECT publicKey, name, sourceId FROM meshcore_nodes WHERE publicKey = 'pk-1'`)
+      .get() as { publicKey: string; name: string; sourceId: string };
+    expect(row.publicKey).toBe('pk-1');
+    expect(row.name).toBe('kept');
+    expect(row.sourceId).toBe('src-a');
+  });
+
+  it('backfills NULL-sourceId rows to the legacy meshcore source', () => {
+    const ts = Date.now();
+    // A pre-057-style orphan row with NULL sourceId.
+    db.prepare(
+      `INSERT INTO meshcore_nodes (publicKey, name, sourceId, createdAt, updatedAt)
+       VALUES ('pk-orphan', 'orphan', NULL, ?, ?)`,
+    ).run(ts, ts);
+
+    migration.up(db);
+
+    const row = db
+      .prepare(`SELECT sourceId FROM meshcore_nodes WHERE publicKey = 'pk-orphan'`)
+      .get() as { sourceId: string };
+    expect(row.sourceId).toBe('meshcore-legacy-default');
+
+    // The legacy source row was synthesised.
+    const src = db
+      .prepare(`SELECT id, type FROM sources WHERE id = 'meshcore-legacy-default'`)
+      .get() as { id: string; type: string };
+    expect(src.id).toBe('meshcore-legacy-default');
+    expect(src.type).toBe('meshcore');
+  });
+
+  it('allows the same publicKey under two different sourceIds after the rebuild — the bug fix', () => {
+    const ts = Date.now();
+    db.prepare(
+      `INSERT INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+       VALUES ('src-a', 'Source A', 'meshcore', '{}', 1, ?, ?),
+              ('src-b', 'Source B', 'meshcore', '{}', 1, ?, ?)`,
+    ).run(ts, ts, ts, ts);
+    db.prepare(
+      `INSERT INTO meshcore_nodes (publicKey, name, sourceId, createdAt, updatedAt)
+       VALUES ('pk-shared', 'A-owned', 'src-a', ?, ?)`,
+    ).run(ts, ts);
+
+    migration.up(db);
+
+    // After the rebuild, inserting the same publicKey under src-b must succeed.
+    expect(() => {
+      db.prepare(
+        `INSERT INTO meshcore_nodes (publicKey, name, sourceId, createdAt, updatedAt)
+         VALUES ('pk-shared', 'B-owned', 'src-b', ?, ?)`,
+      ).run(ts, ts);
+    }).not.toThrow();
+
+    const rows = db
+      .prepare(
+        `SELECT sourceId, name FROM meshcore_nodes WHERE publicKey = 'pk-shared' ORDER BY sourceId`,
+      )
+      .all() as Array<{ sourceId: string; name: string }>;
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({ sourceId: 'src-a', name: 'A-owned' });
+    expect(rows[1]).toEqual({ sourceId: 'src-b', name: 'B-owned' });
+  });
+
+  it('still rejects duplicate (sourceId, publicKey) pairs', () => {
+    const ts = Date.now();
+    db.prepare(
+      `INSERT INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+       VALUES ('src-a', 'Source A', 'meshcore', '{}', 1, ?, ?)`,
+    ).run(ts, ts);
+    db.prepare(
+      `INSERT INTO meshcore_nodes (publicKey, name, sourceId, createdAt, updatedAt)
+       VALUES ('pk-1', 'A1', 'src-a', ?, ?)`,
+    ).run(ts, ts);
+
+    migration.up(db);
+
+    expect(() => {
+      db.prepare(
+        `INSERT INTO meshcore_nodes (publicKey, name, sourceId, createdAt, updatedAt)
+         VALUES ('pk-1', 'dup', 'src-a', ?, ?)`,
+      ).run(ts, ts);
+    }).toThrow(/UNIQUE|PRIMARY/);
+  });
+
+  it('is idempotent — running twice does not fail or alter the schema', () => {
+    migration.up(db);
+    const pkBefore = pkColumns(db);
+    expect(() => migration.up(db)).not.toThrow();
+    const pkAfter = pkColumns(db);
+    expect(pkAfter).toEqual(pkBefore);
+  });
+
+  it('preserves the meshcore_nodes source-id index post-rebuild', () => {
+    migration.up(db);
+    const idx = db
+      .prepare(
+        `SELECT name FROM sqlite_master
+         WHERE type = 'index' AND tbl_name = 'meshcore_nodes' AND name = 'idx_meshcore_nodes_source_id'`,
+      )
+      .get();
+    expect(idx).toBeDefined();
+  });
+});

--- a/src/server/migrations/061_meshcore_nodes_composite_pk.ts
+++ b/src/server/migrations/061_meshcore_nodes_composite_pk.ts
@@ -1,0 +1,328 @@
+/**
+ * Migration 061: meshcore_nodes composite PK (sourceId, publicKey).
+ *
+ * Slice of the MeshCore per-source refactor. Before this migration the table
+ * keyed on `publicKey` alone — so the same MeshCore device advertising under
+ * two different sources collapsed into one row, and any second-source write
+ * raised `UNIQUE constraint failed: meshcore_nodes.publicKey` (observed via
+ * `POST /api/sources/{sourceId}/meshcore/nodes/{publicKey}/telemetry-config`
+ * for a publicKey already owned by another source).
+ *
+ * New shape: composite primary key `(sourceId, publicKey)` so each
+ * (source, key) pair is independent. Mirrors what migration 029 did for
+ * Meshtastic `nodes (nodeNum, sourceId)`.
+ *
+ * Backfill: migration 057 already mints a `meshcore-legacy-default` source
+ * for any orphan NULL-sourceId rows, but we still defensively backfill here
+ * in case those rows were re-introduced between 057 and now. If `sources`
+ * is empty we synthesise the same legacy default 057 uses so the upgrade
+ * can complete.
+ *
+ * SQLite path uses the rebuild pattern (CREATE _new + copy + drop + rename)
+ * because SQLite cannot ALTER a primary key in place. PG/MySQL just swap
+ * the PK constraint.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 061';
+const LEGACY_SOURCE_ID = 'meshcore-legacy-default';
+const LEGACY_SOURCE_NAME = 'MeshCore (legacy)';
+const LEGACY_SOURCE_TYPE = 'meshcore';
+const LEGACY_SOURCE_CONFIG = JSON.stringify({
+  transport: 'usb',
+  port: '',
+  deviceType: 'companion',
+});
+
+// Stable column order for the SQLite rebuild. Must match the post-060
+// `meshcore_nodes` shape exactly: bootstrap columns + 057 (sourceId) +
+// 060 (telemetry retrieval columns).
+const MESHCORE_NODE_COLUMNS_SQLITE = `
+  publicKey TEXT NOT NULL,
+  name TEXT,
+  advType INTEGER,
+  txPower INTEGER,
+  maxTxPower INTEGER,
+  radioFreq REAL,
+  radioBw REAL,
+  radioSf INTEGER,
+  radioCr INTEGER,
+  latitude REAL,
+  longitude REAL,
+  altitude REAL,
+  batteryMv INTEGER,
+  uptimeSecs INTEGER,
+  rssi INTEGER,
+  snr REAL,
+  lastHeard INTEGER,
+  hasAdminAccess INTEGER DEFAULT 0,
+  lastAdminCheck INTEGER,
+  isLocalNode INTEGER DEFAULT 0,
+  sourceId TEXT NOT NULL,
+  telemetryEnabled INTEGER DEFAULT 0,
+  telemetryIntervalMinutes INTEGER DEFAULT 60,
+  lastTelemetryRequestAt INTEGER,
+  createdAt INTEGER NOT NULL,
+  updatedAt INTEGER NOT NULL
+`;
+
+const MESHCORE_NODE_COLUMN_LIST = `
+  publicKey, name, advType, txPower, maxTxPower, radioFreq, radioBw,
+  radioSf, radioCr, latitude, longitude, altitude, batteryMv, uptimeSecs,
+  rssi, snr, lastHeard, hasAdminAccess, lastAdminCheck, isLocalNode,
+  sourceId, telemetryEnabled, telemetryIntervalMinutes, lastTelemetryRequestAt,
+  createdAt, updatedAt
+`;
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): rebuilding meshcore_nodes with composite (sourceId, publicKey) PK...`);
+
+    // Idempotency: composite PK already in place?
+    try {
+      const pkCols = db
+        .prepare(`SELECT name FROM pragma_table_info('meshcore_nodes') WHERE pk > 0 ORDER BY pk`)
+        .all() as Array<{ name: string }>;
+      const pkNames = pkCols.map((r) => r.name);
+      if (pkNames.includes('publicKey') && pkNames.includes('sourceId')) {
+        logger.info(`${LABEL} (SQLite): meshcore_nodes already has composite PK, skipping`);
+        return;
+      }
+    } catch (err) {
+      logger.warn(`${LABEL} (SQLite): idempotency check failed, attempting migration anyway:`, err);
+    }
+
+    // Capture non-autoindex indexes so we can recreate them post-rebuild.
+    const existingIndexes = db
+      .prepare(
+        `SELECT name, sql FROM sqlite_master
+         WHERE type = 'index' AND tbl_name = 'meshcore_nodes' AND sql IS NOT NULL`,
+      )
+      .all() as Array<{ name: string; sql: string }>;
+
+    // SQLite's table-rebuild pattern needs foreign_keys=OFF
+    // (https://www.sqlite.org/lang_altertable.html). Pragma must be set
+    // outside any transaction or it becomes a no-op.
+    const prevForeignKeys = db.pragma('foreign_keys', { simple: true }) as number;
+    if (prevForeignKeys) {
+      db.pragma('foreign_keys = OFF');
+    }
+
+    const tx = db.transaction(() => {
+      // Backfill any lingering NULL-sourceId rows so the new NOT NULL +
+      // composite PK don't reject them. Mirrors 057's strategy.
+      const nullNodesRow = db
+        .prepare(`SELECT COUNT(*) as c FROM meshcore_nodes WHERE sourceId IS NULL`)
+        .get() as { c: number };
+      const nullNodes = nullNodesRow?.c ?? 0;
+
+      if (nullNodes > 0) {
+        const sourcesExists = db
+          .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='sources'`)
+          .get();
+
+        if (sourcesExists) {
+          const ts = Date.now();
+          db.prepare(
+            `INSERT OR IGNORE INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+             VALUES (?, ?, ?, ?, 0, ?, ?)`,
+          ).run(LEGACY_SOURCE_ID, LEGACY_SOURCE_NAME, LEGACY_SOURCE_TYPE, LEGACY_SOURCE_CONFIG, ts, ts);
+
+          const res = db
+            .prepare(`UPDATE meshcore_nodes SET sourceId = ? WHERE sourceId IS NULL`)
+            .run(LEGACY_SOURCE_ID);
+          logger.info(
+            `${LABEL} (SQLite): backfilled ${res.changes ?? 0} NULL-sourceId meshcore_nodes -> ${LEGACY_SOURCE_ID}`,
+          );
+        } else {
+          // No sources table — extremely unusual at this point. Drop the
+          // orphans so the composite PK doesn't fail the upgrade.
+          const res = db.prepare(`DELETE FROM meshcore_nodes WHERE sourceId IS NULL`).run();
+          logger.warn(
+            `${LABEL} (SQLite): sources table missing; deleted ${res.changes ?? 0} orphan NULL-sourceId meshcore_nodes`,
+          );
+        }
+      }
+
+      // Rebuild meshcore_nodes with composite PK.
+      db.exec(`
+        CREATE TABLE meshcore_nodes_new (
+          ${MESHCORE_NODE_COLUMNS_SQLITE},
+          PRIMARY KEY (sourceId, publicKey)
+        )
+      `);
+
+      db.exec(`
+        INSERT INTO meshcore_nodes_new (${MESHCORE_NODE_COLUMN_LIST})
+        SELECT ${MESHCORE_NODE_COLUMN_LIST} FROM meshcore_nodes
+      `);
+
+      db.exec(`DROP TABLE meshcore_nodes`);
+      db.exec(`ALTER TABLE meshcore_nodes_new RENAME TO meshcore_nodes`);
+
+      // Recreate any non-PK indexes that existed before. Skip auto unique
+      // indexes (regenerated by the new schema's PK).
+      for (const idx of existingIndexes) {
+        if (idx.name.startsWith('sqlite_autoindex_')) continue;
+        try {
+          db.exec(idx.sql);
+        } catch (err) {
+          logger.warn(`${LABEL} (SQLite): failed to recreate index ${idx.name}:`, err);
+        }
+      }
+
+      // Ensure the source-id index from migration 057 exists.
+      db.exec(
+        `CREATE INDEX IF NOT EXISTS idx_meshcore_nodes_source_id ON meshcore_nodes(sourceId)`,
+      );
+    });
+
+    try {
+      tx();
+    } finally {
+      if (prevForeignKeys) {
+        db.pragma('foreign_keys = ON');
+      }
+    }
+
+    logger.info(`${LABEL} complete (SQLite)`);
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration061Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): meshcore_nodes composite PK (sourceId, publicKey)...`);
+
+  // Idempotency: already composite?
+  const pkCheck = await client.query(`
+    SELECT a.attname
+    FROM pg_index i
+    JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+    WHERE i.indrelid = 'meshcore_nodes'::regclass AND i.indisprimary
+  `);
+  const pkCols = pkCheck.rows.map((r: any) => r.attname);
+  if (pkCols.includes('sourceId') && pkCols.includes('publicKey') && pkCols.length >= 2) {
+    logger.info(`${LABEL} (PostgreSQL): composite PK already present, skipping`);
+    return;
+  }
+
+  await client.query('BEGIN');
+  try {
+    // Backfill NULL sourceIds defensively.
+    const nullRes = await client.query(
+      `SELECT COUNT(*)::int AS c FROM "meshcore_nodes" WHERE "sourceId" IS NULL`,
+    );
+    const nullNodes = nullRes.rows[0]?.c ?? 0;
+
+    if (nullNodes > 0) {
+      const ts = Date.now();
+      await client.query(
+        `INSERT INTO sources (id, name, type, config, enabled, "createdAt", "updatedAt")
+         VALUES ($1, $2, $3, $4, false, $5, $6)
+         ON CONFLICT (id) DO NOTHING`,
+        [LEGACY_SOURCE_ID, LEGACY_SOURCE_NAME, LEGACY_SOURCE_TYPE, LEGACY_SOURCE_CONFIG, ts, ts],
+      );
+
+      const upd = await client.query(
+        `UPDATE "meshcore_nodes" SET "sourceId" = $1 WHERE "sourceId" IS NULL`,
+        [LEGACY_SOURCE_ID],
+      );
+      logger.info(
+        `${LABEL} (PostgreSQL): backfilled ${upd.rowCount ?? 0} NULL-sourceId meshcore_nodes -> ${LEGACY_SOURCE_ID}`,
+      );
+    }
+
+    await client.query(`ALTER TABLE "meshcore_nodes" ALTER COLUMN "sourceId" SET NOT NULL`);
+
+    // Drop existing PK (Postgres-default name: meshcore_nodes_pkey).
+    await client.query(`ALTER TABLE "meshcore_nodes" DROP CONSTRAINT IF EXISTS meshcore_nodes_pkey`);
+
+    await client.query(`
+      ALTER TABLE "meshcore_nodes"
+        ADD CONSTRAINT meshcore_nodes_pkey PRIMARY KEY ("sourceId", "publicKey")
+    `);
+
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  }
+
+  logger.info(`${LABEL} complete (PostgreSQL)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration061Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): meshcore_nodes composite PK (sourceId, publicKey)...`);
+
+  const conn = await pool.getConnection();
+  try {
+    const [pkRows] = await conn.query(
+      `SELECT COLUMN_NAME FROM information_schema.KEY_COLUMN_USAGE
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'meshcore_nodes' AND CONSTRAINT_NAME = 'PRIMARY'`,
+    );
+    const pkCols = (pkRows as any[]).map((r) => r.COLUMN_NAME);
+    if (pkCols.includes('sourceId') && pkCols.includes('publicKey') && pkCols.length >= 2) {
+      logger.info(`${LABEL} (MySQL): composite PK already present, skipping`);
+      return;
+    }
+
+    await conn.beginTransaction();
+
+    try {
+      const [nullRows] = await conn.query(
+        `SELECT COUNT(*) AS c FROM meshcore_nodes WHERE sourceId IS NULL`,
+      );
+      const nullNodes = Number((nullRows as any[])[0]?.c ?? 0);
+
+      if (nullNodes > 0) {
+        const ts = Date.now();
+        await conn.query(
+          `INSERT IGNORE INTO sources (id, name, type, config, enabled, createdAt, updatedAt)
+           VALUES (?, ?, ?, ?, 0, ?, ?)`,
+          [LEGACY_SOURCE_ID, LEGACY_SOURCE_NAME, LEGACY_SOURCE_TYPE, LEGACY_SOURCE_CONFIG, ts, ts],
+        );
+
+        const [res] = await conn.query(
+          `UPDATE meshcore_nodes SET sourceId = ? WHERE sourceId IS NULL`,
+          [LEGACY_SOURCE_ID],
+        );
+        const affected = (res as { affectedRows?: number }).affectedRows ?? 0;
+        logger.info(
+          `${LABEL} (MySQL): backfilled ${affected} NULL-sourceId meshcore_nodes -> ${LEGACY_SOURCE_ID}`,
+        );
+      }
+
+      // sourceId was VARCHAR-ish at create (TEXT in the 057 path). MySQL
+      // primary keys require a length-bounded type, so widen+NOT NULL it.
+      await conn.query(`ALTER TABLE meshcore_nodes MODIFY COLUMN sourceId VARCHAR(64) NOT NULL`);
+
+      // publicKey was VARCHAR(64) in the mysql baseline. Keep length but
+      // make sure it's NOT NULL (it already is via PRIMARY KEY, but defensive).
+      await conn.query(`ALTER TABLE meshcore_nodes MODIFY COLUMN publicKey VARCHAR(64) NOT NULL`);
+
+      // Replace PK in one statement.
+      await conn.query(
+        `ALTER TABLE meshcore_nodes DROP PRIMARY KEY, ADD PRIMARY KEY (sourceId, publicKey)`,
+      );
+
+      await conn.commit();
+    } catch (err) {
+      await conn.rollback();
+      throw err;
+    }
+  } finally {
+    conn.release();
+  }
+
+  logger.info(`${LABEL} complete (MySQL)`);
+}


### PR DESCRIPTION
## Summary

- Convert `meshcore_nodes` from a `publicKey`-only primary key to a composite `(sourceId, publicKey)` primary key (new migration **061**), so the same MeshCore node can be configured under multiple sources.
- Mirrors what migration 029 did for Meshtastic `nodes (nodeNum, sourceId)`.
- Includes a focused regression test plus an updated repository test that proves the bug repro succeeds post-fix.

## Bug repro (before this PR)

`POST /api/sources/{sourceId}/meshcore/nodes/{publicKey}/telemetry-config` for a `publicKey` that already exists under a different `sourceId` raised:

```
[ERROR] [API] Error setting per-node telemetry-config:
  SqliteError: UNIQUE constraint failed: meshcore_nodes.publicKey
  code: 'SQLITE_CONSTRAINT_PRIMARYKEY'
```

Root cause: `meshcore_nodes.publicKey TEXT PRIMARY KEY` collapsed the same MeshCore device under two sources into one row, so any second-source upsert/insert via the per-source repository hit the global PK.

## Migration approach

`061_meshcore_nodes_composite_pk.ts` is the standard rename → CREATE _new → copy → drop → rename pattern (per SQLite's [ALTER TABLE docs](https://www.sqlite.org/lang_altertable.html)) since SQLite cannot ALTER a primary key in place. PostgreSQL and MySQL do an explicit `DROP CONSTRAINT … ADD CONSTRAINT … PRIMARY KEY (sourceId, publicKey)` swap.

Backfill: migration 057 already mints a `meshcore-legacy-default` source for any orphan NULL-sourceId rows, but 061 defensively backfills again in case any slipped in afterwards. If `sources` is empty for some reason, 061 synthesises the same legacy default 057 uses so the upgrade still completes. SQLite path also temporarily disables `foreign_keys` per the documented rebuild pattern.

All three engines are idempotent and recheck the PK shape before doing any work.

## Schema + repository changes

- Drizzle schema (`src/db/schema/meshcoreNodes.ts`): `publicKey` and `sourceId` are now `.notNull()`; composite `primaryKey({ columns: [sourceId, publicKey] })` is declared on all three dialects.
- `MeshCoreRepository.deleteNode(publicKey, sourceId)` now requires a `sourceId` — a publicKey-only delete is unsafe under the composite-PK model since it would touch rows from every source. (No prior in-tree callers — checked with grep.)
- All hot write paths (`upsertNode`, `setNodeTelemetryConfig`, `markTelemetryRequested`) already used `getNodeByPublicKeyAndSource` and remain unchanged. The pre-existing `getNodeByPublicKey` read is explicitly documented as cross-source and left alone.

## Tests

- `src/server/migrations/061_meshcore_nodes_composite_pk.test.ts` — composite-PK shape, row preservation, NULL backfill, idempotence, and the explicit "same publicKey under two sources" insert that reproduced the original 500.
- `src/db/repositories/meshcore.test.ts` — adds two cross-source regression tests on the composite-PK schema:
  - `setNodeTelemetryConfig` succeeds for the same publicKey under two sources (the exact bug repro from the API endpoint).
  - `deleteNode` requires a sourceId and only removes the matching `(sourceId, publicKey)` row.
- `src/db/migrations.test.ts` — count + last-migration assertions bumped to 61.

## Test plan

- [ ] `npx tsc --noEmit` — passes.
- [ ] `npx vitest run` — full suite passes.
- [ ] Migration 061 idempotency test passes.
- [ ] Cross-source upsert + telemetry-config tests pass.
- [ ] PR CI green.

Authored by Merlin 🪄
