### PR TITLE
docs(meshcore): 4.5 release docs + blog post

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.3.2",
+  "version": "4.5.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.3.2",
+  "version": "4.5.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -90,7 +90,7 @@ export default defineConfig({
             { text: 'Analytics', link: '/features/analytics' },
             { text: 'Analysis & Reports', link: '/features/analysis-reports' },
             { text: 'Telemetry Widgets', link: '/features/telemetry-widgets' },
-            { text: 'MeshCore (Experimental)', link: '/features/meshcore' },
+            { text: 'MeshCore', link: '/features/meshcore' },
             { text: '🌍 Translations', link: '/features/translations' },
             { text: '🎨 Theme Gallery', link: '/THEME_GALLERY' },
             { text: '🌐 Site Gallery', link: '/site-gallery' },

--- a/docs/blog/2026-05-14-meshcore-4-5.md
+++ b/docs/blog/2026-05-14-meshcore-4-5.md
@@ -1,0 +1,68 @@
+---
+id: news-2026-05-14-meshcore-4-5
+title: MeshMonitor 4.5.0 — MeshCore Levels Up
+date: '2026-05-14T18:00:00Z'
+category: feature
+priority: important
+minVersion: 4.5.0
+---
+When MeshCore landed back in v3.5.0, it was deliberately small: a single experimental tab, env-var-only setup, basic serial messaging, and a single global permission. Since then it's been quietly growing up, and v4.5.0 is the release where that work crosses the finish line.
+
+MeshCore is now a **first-class source** in MeshMonitor. It sits in the dashboard sidebar next to your Meshtastic nodes, has its own per-source permissions, its own multi-pane page, its own telemetry pipeline, and contributes contacts to the unified dashboard map. You can run multiple MeshCore companions and repeaters alongside multiple Meshtastic nodes and gate each one independently. The 4.5 UI source-add flow is **USB-only** for MeshCore (Companion or Repeater); TCP-connected companions still work but are wired up via the legacy environment-variable bootstrap path.
+
+## What's New Since v3.5.0
+
+**Source-model overhaul**
+
+- **Per-source MeshCore managers** — each MeshCore device is its own source row, manageable from the Sources sidebar with no container restart ([#3005](https://github.com/Yeraze/meshmonitor/pull/3005), [#3014](https://github.com/Yeraze/meshmonitor/pull/3014))
+- **Permissions, expanded** — the legacy global `meshcore` permission is gone; migration 058 expanded every grant into the per-source **sourcey** set (connection, configuration, nodes, messages)
+- **Composite primary key** on `meshcore_nodes` — the same device advertising under two different sources is tracked independently ([#3023](https://github.com/Yeraze/meshmonitor/pull/3023))
+
+**Dashboard + map integration**
+
+- **Styled source cards** matching the Meshtastic visual vocabulary, with a MeshCore logo ([#3016](https://github.com/Yeraze/meshmonitor/pull/3016))
+- **Unified dashboard map** now enumerates every MeshCore source and renders contacts with valid coordinates alongside Meshtastic nodes ([#3015](https://github.com/Yeraze/meshmonitor/pull/3015))
+
+**The MeshCore page itself**
+
+- **Multi-pane redesign** with Nodes, Channels, Direct Messages, Configuration, and a new Node Info view ([#3005](https://github.com/Yeraze/meshmonitor/pull/3005))
+- **Contact-detail panel** under each DM thread — hops, RSSI/SNR, last heard, position, full public key, collapsible with persisted state ([#3017](https://github.com/Yeraze/meshmonitor/pull/3017))
+- **UI permission gating** — write controls dim and explain themselves for read-only users instead of just rejecting submits ([#3019](https://github.com/Yeraze/meshmonitor/pull/3019))
+- **Visual alignment** with the Meshtastic Info / Channels / Nodes rows ([#3021](https://github.com/Yeraze/meshmonitor/pull/3021))
+
+**Telemetry**
+
+- **Local-node telemetry** — a background poller samples `GetStats core/radio/packets`, `GetDeviceTime`, and `DeviceQuery` every 5 minutes (configurable, all on-device, no RF) and writes batched `mc_*` rows into the same `telemetry` table the Meshtastic side uses ([#3020](https://github.com/Yeraze/meshmonitor/pull/3020))
+- **Node Info page** that graphs all of that across 1h / 6h / 24h / 3d / 7d ranges with current health, cumulative counters, and identity
+- **Telemetry-mode configuration** — toggle device-side base / loc / env telemetry classes from the Configuration view ([#3018](https://github.com/Yeraze/meshmonitor/pull/3018))
+- **Per-node remote telemetry retrieval** — opt nodes into scheduled `req_telemetry_sync` pulls with a per-node interval, gated through a shared 60-second cross-mesh throttle, with decoded LPP values written back into the telemetry store ([#3022](https://github.com/Yeraze/meshmonitor/pull/3022))
+
+**Configuration quality-of-life**
+
+- **Radio preset selector** populated from the official MeshCore preset list, with a Custom fallback ([#3015](https://github.com/Yeraze/meshmonitor/pull/3015))
+- **Persistent radio params** — the bridge now propagates device-side errors instead of silently returning success, and the manager refreshes from the device after Save so the next snapshot reflects real state
+- **Staged edits no longer revert** during live push updates (the Phase 3 push events used to overwrite in-flight edits)
+- **Location configuration** + advert-location policy in the Configuration view
+- **Channel-message senders** are now extracted from the `"Name: body"` prefix and shown separately from the message body
+
+## Still Early
+
+It would be tempting to ship this announcement as "MeshCore is done." It's not.
+
+MeshCore support in MeshMonitor is still **new and basic**. The core "see your network, send messages, watch telemetry" loop works, but plenty is missing compared to the Meshtastic side. To be candid about the gaps:
+
+- **Repeater / Room Server parity** trails Companion — Repeater is selectable as a USB device type, but the local-telemetry poller, remote-telemetry scheduler, and telemetry-mode toggles all need a Companion on the source side
+- **TCP MeshCore via the UI** isn't shipped yet — TCP companions are env-var bootstrap only in 4.5
+- **No remote-admin equivalent** — no admin scanner, no password rotation flow, no OTA flow for MeshCore
+- **No scheduler integrations** — auto-responder, auto-announce, auto-traceroute don't have MeshCore counterparts yet (the per-source primitives are wired up; the user-facing features are next)
+- **Notifications** for MeshCore events are minimal — apprise and push surfaces aren't yet first-class
+- **Map-specific affordances** — direct-link visualization, route-quality overlays, MeshCore-specific marker behavior — aren't there yet
+- **MQTT source type** is still planned, not shipped
+
+The plan is incremental: keep landing one or two MeshCore features per release, keep aligning the UI vocabulary with Meshtastic, and gradually close the parity gap. If something doesn't behave the way you'd expect, [open an issue](https://github.com/yeraze/meshmonitor/issues/new).
+
+## Where to Go Next
+
+The MeshCore feature documentation has been updated to cover everything in this release — adding a source, the multi-pane page, the telemetry model, permissions, radio presets, and the current known gaps.
+
+[Read the updated MeshCore docs](https://meshmonitor.org/features/meshcore)

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -1,51 +1,89 @@
 # MeshCore Support
 
-::: warning EXPERIMENTAL
-MeshCore support is an **experimental feature** introduced in MeshMonitor v3.4.13. It is under active development and may have rough edges. If you encounter any issues, please [submit a bug report](https://github.com/yeraze/meshmonitor/issues/new) on GitHub.
+::: warning STILL EARLY
+MeshCore support is still **new and basic**. The core capabilities are stable and shipping incrementally — but expect rough edges, missing pieces compared to the Meshtastic side, and a fast-moving feature surface. If something doesn't behave the way you'd expect, [open an issue](https://github.com/yeraze/meshmonitor/issues/new).
 :::
 
 ## Overview
 
-[MeshCore](https://meshcore.co) is an alternative LoRa mesh networking protocol that runs on many of the same hardware devices as Meshtastic. MeshMonitor can now connect to and monitor MeshCore devices alongside your existing Meshtastic network.
+[MeshCore](https://meshcore.co) is an alternative LoRa mesh networking protocol that runs on much of the same hardware as Meshtastic. In MeshMonitor 4.5+, each MeshCore device is a first-class **source** — it lives in the Sources sidebar next to your Meshtastic nodes, has its own per-source permissions, its own page, its own telemetry, and contributes contacts with valid coordinates to the unified dashboard map.
 
-When enabled, MeshCore adds a dedicated **MeshCore tab** to the MeshMonitor UI, providing:
+A single MeshMonitor deployment can run multiple MeshCore sources alongside multiple Meshtastic sources and gate access to each one independently. The 4.5 UI source-add flow is **USB-only** (Companion or Repeater); TCP-connected companions are still supported but only through the legacy environment-variable bootstrap path.
 
-- **Connection management** - Connect via serial port or TCP
-- **Node list** - View all discovered MeshCore nodes with signal quality, battery, and radio info
-- **Contact management** - Browse and refresh your contact list
-- **Messaging** - Send and receive messages (broadcast or direct)
-- **Admin commands** - Login to remote nodes, query status, configure settings
-- **Map integration** - MeshCore nodes with GPS coordinates appear on the map
+When a MeshCore source is connected, you get:
+
+- **Per-source MeshCore page** — Nodes, Channels, Direct Messages, Configuration, and a Node Info page in a single multi-pane layout
+- **Dashboard integration** — MeshCore sources appear as styled cards in the dashboard sidebar with their own logo, status, and node count
+- **Unified map** — MeshCore contacts with GPS appear on the dashboard map alongside Meshtastic nodes
+- **Local-node telemetry** — Battery, radio stats, packet rates, and duty-cycle graphs from the connected companion
+- **Per-node remote telemetry** — Scheduled cross-mesh telemetry pulls from other MeshCore nodes, written into the same telemetry store as Meshtastic
+- **Radio preset selector** — Pick from the official MeshCore preset list instead of hand-tuning freq/bw/sf/cr
+- **Contact-detail panel** — Hops, RSSI/SNR, last heard, position, and the full public key shown next to DM threads
+- **Telemetry-mode configuration** — Toggle base / location / environment telemetry on the device itself
+- **UI permission gating** — Write controls are disabled (not just rejected) for users without the right permission
+
+## Source Types
+
+MeshCore sources today are **USB-attached** when added through the UI. The Sources sidebar lets you pick a device type of **Companion** (Python bridge) or **Repeater** (direct serial). TCP-connected companions are still wired through the MeshCore Python bridge under the hood, but in 4.5 they're only configured through the env-var bootstrap path described in [Bootstrap via Environment Variables](#bootstrap-via-environment-variables) — UI-driven TCP and BLE transports are out of scope for this slice.
+
+| Source path | Device type | Notes |
+|---|---|---|
+| **UI (USB)** | Companion or Repeater | Add from the Sources sidebar; the entrypoint auto-grants the `node` user access to mapped tty groups |
+| **Env-var bootstrap (USB)** | Companion or Repeater (`MESHCORE_FIRMWARE_TYPE`) | Seeded on first boot; manage afterward through the UI |
+| **Env-var bootstrap (TCP)** | Companion only | Seeded on first boot via `MESHCORE_TCP_HOST` / `MESHCORE_TCP_PORT` |
+
+::: tip Room Server
+**Room Server** devices use the same Python bridge as Companion — when present they're auto-detected on connection. There's no Room Server option in the device-type selector; pick Companion and the bridge will identify the device correctly.
+:::
 
 ## Requirements
 
-MeshCore support requires:
+1. **A MeshCore device** — A LoRa device flashed with MeshCore firmware (Companion, Repeater, or Room Server)
+2. **Python 3** — Must be available in the container/host as `python3` (included in the official MeshMonitor image)
+3. **`meshcore` Python library** — Required for Companion device communication (`pip install meshcore`; preinstalled in the official image)
+4. **Serial port access** — If connecting via USB serial, the device must be mapped into the container with `devices:`
 
-1. **A MeshCore device** - A LoRa device flashed with MeshCore firmware (Companion, Repeater, or Room Server)
-2. **Python 3** - Must be available in the container/host as `python3`
-3. **meshcore Python library** - Required for Companion device communication (`pip install meshcore`)
-4. **Serial port access** - If connecting via USB serial, the device must be mapped into the container
+## Adding a MeshCore Source
 
-## Environment Variables
+The recommended path is to add MeshCore sources from the UI — they hot-connect immediately without a restart.
 
-MeshCore is disabled by default. To enable it, set the following environment variables:
+1. Open the **Sources sidebar** on the dashboard (admin only)
+2. Click the **+** button next to the Sources header
+3. Pick **MeshCore (USB)** as the source type
+4. Enter the **serial port** (e.g. `/dev/ttyACM0`)
+5. Pick the **device type** — **Companion** for full-featured devices, **Repeater** for direct-serial repeaters
+6. Save — the source connects immediately if **Auto-connect** is on
+
+Sources you create from the UI are wired into the per-source MeshCore manager registry the same way Meshtastic TCP sources are, so create / update / delete / connect / disconnect all work without a process restart.
+
+::: tip Need TCP?
+TCP-connected companions still work, but in 4.5 they have to be set up via environment variables — see below. UI support for TCP-attached MeshCore is planned for a later slice.
+:::
+
+### Bootstrap via Environment Variables
+
+For headless setups and legacy 3.x compatibility, MeshCore can still be seeded on first boot from environment variables. After the first boot, **the env vars are informational only** — manage the source through the UI.
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `MESHCORE_ENABLED` | Yes | `false` | Set to `true` to enable MeshCore support |
+| `MESHCORE_ENABLED` | Yes | `false` | Set to `true` to seed a MeshCore source on first boot |
 | `MESHCORE_SERIAL_PORT` | Conditional | - | Serial port path (e.g., `/dev/ttyACM0`). Required for serial connections. |
 | `MESHCORE_BAUD_RATE` | No | `115200` | Baud rate for serial connection |
 | `MESHCORE_TCP_HOST` | Conditional | - | TCP host address. Required for TCP connections. |
 | `MESHCORE_TCP_PORT` | No | `4403` | TCP port for network connection |
 | `MESHCORE_FIRMWARE_TYPE` | No | `companion` | Set to `repeater` for Repeater devices. Companion and Room Server devices use the default. |
+| `MESHCORE_TELEMETRY_INTERVAL_MS` | No | `300000` | How often (ms) to poll the **local** companion for telemetry. Default 5 minutes. |
+| `MESHCORE_REMOTE_TELEMETRY_TICK_MS` | No | `30000` | How often (ms) the remote-telemetry scheduler walks each source and picks an eligible node. |
 
 You must provide **either** `MESHCORE_SERIAL_PORT` (for USB serial) **or** `MESHCORE_TCP_HOST` (for TCP network) when MeshCore is enabled.
 
 ::: tip
-`ENABLE_VIRTUAL_NODE` is a separate feature for proxying the Meshtastic protocol to mobile apps — it has **no relation** to MeshCore connectivity. Do not set it expecting it to affect MeshCore behavior.
+`ENABLE_VIRTUAL_NODE` is a separate Meshtastic feature for proxying the Meshtastic protocol to mobile apps — it has **no relation** to MeshCore connectivity and is ignored by MeshCore sources.
 :::
 
-### Docker Compose Example
+### Docker Compose Examples
+
+USB-connected companion:
 
 ```yaml
 services:
@@ -58,26 +96,27 @@ services:
     devices:
       - /dev/ttyACM0:/dev/ttyACM0
     ports:
-      - "8080:8080"
+      - "8080:3001"
 ```
 
-For TCP connections:
+TCP-connected companion:
 
 ```yaml
 services:
   meshmonitor:
+    image: yeraze/meshmonitor:latest
     environment:
       - MESHTASTIC_NODE_IP=192.168.1.100
       - MESHCORE_ENABLED=true
       - MESHCORE_TCP_HOST=192.168.1.200
       - MESHCORE_TCP_PORT=4403
     ports:
-      - "8080:8080"
+      - "8080:3001"
 ```
 
 ## Device Types
 
-MeshCore firmware comes in several variants. MeshMonitor automatically detects the device type on connection:
+MeshMonitor automatically detects the device type on connection:
 
 | Device Type | Description | Connection Method |
 |---|---|---|
@@ -85,41 +124,114 @@ MeshCore firmware comes in several variants. MeshMonitor automatically detects t
 | **Repeater** | Lightweight relay with text CLI interface | Direct serial |
 | **Room Server** | Chat room server for group messaging | Python bridge |
 
-## Using MeshCore
+## The MeshCore Page
 
-### Connecting
+Each MeshCore source has its own multi-pane page accessible by clicking the source in the dashboard sidebar. The page has a sub-toolbar with these views:
 
-1. Enable MeshCore via environment variables and restart MeshMonitor
-2. Navigate to the **MeshCore** tab in the UI
-3. If environment variables are configured, MeshMonitor will auto-connect on startup
-4. You can also connect manually by entering connection details in the UI
+### Nodes
 
-### Viewing Nodes and Contacts
+A map of every contact with valid coordinates, plus a styled row list aligned to the same visual vocabulary as the Meshtastic nodes view. The map honours zoom-based label visibility and falls through to the dashboard map when the source is selected at the dashboard level.
 
-Once connected, the MeshCore tab displays:
+### Channels
 
-- **Connection status** - Shows the connected device name, type, and radio parameters
-- **Node list** - All discovered nodes with their public key, signal quality (RSSI/SNR), battery voltage, and uptime
-- **Contacts** - Your device's contact list with last-seen timestamps
+The device's channels with the most recent message stream. Channel-message senders are now extracted from the `"Name: body"` prefix that MeshCore embeds in the text body, so the sender column and the message body are no longer collapsed into one string.
 
-### Sending Messages
+### Direct Messages
 
-1. Select a contact from the dropdown (or leave empty for broadcast)
-2. Type your message (maximum 228 characters for LoRa)
-3. Click Send
+Per-contact DM view with a **contact-detail panel** that mirrors the Meshtastic NodeDetailsBlock. It surfaces:
 
-### Admin Commands
+- Contact name and type (companion / repeater / room server)
+- Hops away (`pathLen`)
+- RSSI and SNR
+- Last heard and last advert
+- Position (if known)
+- Full public key
 
-For nodes you have admin access to:
+The panel is collapsible with state persisted to localStorage.
 
-1. Enter the target node's public key (64-character hex string)
-2. Enter the admin password
-3. Click **Login** to authenticate
-4. Once logged in, you can query node status (battery, uptime, radio settings)
+The **per-node remote-telemetry config** panel hangs off the contact-detail panel (see [Per-Node Remote Telemetry](#per-node-remote-telemetry) below).
 
-### Radio Configuration
+### Node Info
 
-With admin access to your local node, you can configure radio parameters:
+A dashboard-style view of the connected local companion. It graphs the data collected by the local-telemetry poller (see [Local-Node Telemetry](#local-node-telemetry) below) across 1h / 6h / 24h / 3d / 7d ranges, plus identity (firmware version, build, model), current radio settings, current health, and cumulative counters.
+
+This view is only available when the page is mounted from a per-source URL — the legacy app-shell mount path does not have a `sourceId` and hides the Node Info entry.
+
+### Configuration
+
+Where you change the device's settings:
+
+- **Identity** — Name and advert
+- **Location** — Position and advert-location policy
+- **Radio** — Frequency, bandwidth, spreading factor, coding rate (now with a preset selector)
+- **Telemetry mode** — Which telemetry classes the device emits (see [Telemetry Modes](#telemetry-modes))
+
+## Telemetry
+
+MeshMonitor collects three kinds of telemetry from MeshCore sources, all written into the same `telemetry` table the Meshtastic side uses (just with `mc_*` type names) so the graphing UI works the same way.
+
+### Local-Node Telemetry
+
+A module-level singleton polls every connected companion every `MESHCORE_TELEMETRY_INTERVAL_MS` (default 5 minutes). It calls `GetStats core / radio / packets`, `GetDeviceTime`, and `DeviceQuery` — **none of which transmit on the air** — and writes batched rows stamped with `sourceId` and prefixed `mc_`. tx/rx duty-cycle and packet rates are computed as deltas vs the prior sample.
+
+This drives the [Node Info](#node-info) view.
+
+### Telemetry Modes
+
+You can toggle which telemetry classes the device itself emits over the air:
+
+- **base** — Battery, voltage, uptime
+- **loc** — Position
+- **env** — Environmental sensors (where supported by the hardware)
+
+Set these from the Configuration view; the device-side flag is persisted on the companion.
+
+### Per-Node Remote Telemetry
+
+Each row in `meshcore_nodes` can opt in to periodic `req_telemetry_sync` requests with a per-node interval. The remote-telemetry scheduler walks every registered manager every `MESHCORE_REMOTE_TELEMETRY_TICK_MS` (default 30s), picks at most one most-overdue eligible node per source, decodes the LPP response, and writes `mc_<lpp-type-name>` rows into the same `telemetry` table.
+
+A global 60-second minimum spacing between any two scheduled mesh ops on the same source is enforced through `MeshCoreManager.lastMeshTxAt`, so future scheduled operations on the same manager (auto-traceroute, periodic adverts, etc.) coordinate against a single field instead of each owning their own throttle.
+
+You configure this from the contact-detail panel in the Direct Messages view:
+
+1. Open the DM with the target contact
+2. Open the contact-detail panel
+3. Toggle **Remote telemetry** on
+4. Set the **interval** (minutes)
+5. Save
+
+The config requires `configuration:write` on the source. Read-only users see the panel with controls disabled and a banner explaining why.
+
+The composite primary key on `meshcore_nodes` is `(sourceId, publicKey)`, so the same device advertising under two different sources is tracked independently.
+
+## Multi-Source Dashboard
+
+MeshCore sources appear as styled cards in the dashboard sidebar — same visual language as Meshtastic sources, with a MeshCore logo and per-source status.
+
+The aggregate dashboard map and `/api/nodes` endpoint enumerate every connected MeshCore manager and include contacts that have valid `(latitude, longitude)` (zeros are rejected). Each contact gets a synthetic `nodeId` of `mc:<sourceId>:<pubkeyPrefix>` so cross-source duplicates don't collide on React keys, and `getNodeLatLng` resolves either the flat `{latitude, longitude}` shape or the nested `position` shape.
+
+## Permissions
+
+In 4.5 the global `meshcore` permission is gone. Migration 058 expanded every legacy `meshcore` grant into the per-source **sourcey** resource set, matching how Meshtastic resources are scoped:
+
+| Resource | Scope | Description |
+|---|---|---|
+| `connection` | Per-source | Connect/disconnect, status |
+| `configuration` | Per-source | Identity, radio, telemetry mode, location, per-node remote-telemetry config |
+| `nodes` | Per-source | Node list, contacts, map data |
+| `messages` | Per-source | Read and send DMs / channel messages |
+
+Anonymous users can view MeshCore data on sources where the anonymous user has the relevant `*:read` permission. Sending messages, changing config, and toggling remote telemetry all require `configuration:write` (or `messages:write` for sends).
+
+### UI Permission Gating
+
+Write controls in the MeshCore UI are now **disabled in place** for users without the right permission — not just rejected on submit. The Configuration view, Channels view, DM compose box, and remote-telemetry toggle all dim themselves and surface an explanatory banner, mirroring how the Meshtastic side handles permission gating.
+
+See [Per-Source Permissions](/features/per-source-permissions) for the full model.
+
+## Radio Configuration
+
+Use the Configuration view's **Preset** dropdown to pick from the official MeshCore preset list, or choose **Custom** to manually set:
 
 - **Frequency** (100-1000 MHz)
 - **Bandwidth** (125, 250, 500 kHz)
@@ -130,45 +242,52 @@ With admin access to your local node, you can configure radio parameters:
 Changing radio parameters will disconnect you from nodes using different settings. Make sure all nodes in your mesh use the same radio configuration.
 :::
 
-## Permissions
+Saved radio params are now persisted authoritatively: the bridge propagates device-side errors back instead of silently returning success, and the manager optimistically updates `localNode.radio*` then refreshes from the device so the next snapshot reflects the real device state.
 
-MeshCore access is controlled through MeshMonitor's permission system:
+## Still Early
 
-| Permission | Scope | Description |
-|---|---|---|
-| `meshcore` read | Unauthenticated | View connection status, nodes, contacts, and messages |
-| `meshcore` write | Authenticated | Connect/disconnect, send messages, admin commands, configuration |
+This is the part that's worth being honest about. MeshCore support is **basic** today — the core "see your network, send messages, watch telemetry" loop works, but plenty is missing.
 
-Anonymous users can view MeshCore data if the `meshcore` read permission is granted to the anonymous user (this is the default). Modifying settings or sending messages requires authentication.
+Known gaps and limitations:
+
+- **Repeater / Room Server per-source parity** is behind Companion. Repeater is selectable as a USB device type, but most new 4.5 features (local telemetry poller, remote-telemetry scheduler, telemetry-mode toggles) require a Companion connection on the source side.
+- **TCP MeshCore via the UI** isn't shipped yet — TCP companions are env-var bootstrap only in 4.5.
+- **No remote-admin equivalent** for MeshCore yet — the Meshtastic-side admin scanner, password rotation, OTA flow, etc. don't have MeshCore counterparts.
+- **No auto-responder / auto-announce / auto-traceroute** schedulers for MeshCore. The per-source scheduler primitives are wired up, but the user-facing features haven't been built yet.
+- **Notifications** for MeshCore events are minimal — apprise/push surfaces aren't yet first-class.
+- **Map rendering** uses the dashboard map's existing primitives, so MeshCore-specific link visualization (direct radio links, route quality) is not yet there.
+- **Companion-only telemetry mode toggles** — Repeaters report what they report; the base/loc/env toggle is meaningful on Companions.
+
+The roadmap is incremental: keep landing one or two MeshCore features per release, keep aligning the UI vocabulary with Meshtastic, and gradually close the parity gap.
 
 ## Troubleshooting
 
-### MeshCore tab not visible
-- Ensure `MESHCORE_ENABLED=true` is set in your environment
-- Restart the MeshMonitor container after changing environment variables
+### MeshCore source can't be added or connection fails
+- Verify the serial port is accessible inside the container (check `devices:` mapping in docker-compose). The entrypoint auto-grants the `node` user access to mapped tty groups; if you mounted a device after the container started, restart it.
+- Ensure `python3` is available and the `meshcore` Python library is installed.
+- Check MeshMonitor logs for `[MeshCore]` entries for detailed error messages.
 
-### Connection fails
-- Verify the serial port is accessible inside the container (check `devices:` mapping in docker-compose)
-- Ensure `python3` is available and the `meshcore` Python library is installed
-- Check MeshMonitor logs for `[MeshCore]` entries for detailed error messages
+### Runtime-added MeshCore source idle until restart
+This is fixed in 4.5 — source create/update/delete/connect/disconnect endpoints all wire MeshCore into the per-source registry. If you're seeing this on an earlier 4.x version, restart the container as a workaround and upgrade.
 
 ### Python bridge errors
-- The MeshCore Python bridge (`scripts/meshcore-bridge.py`) requires the `meshcore` Python package
-- Install it with: `pip install meshcore`
-- For TCP connections, ensure your meshcore library version supports TCP (`TCPConnection`)
+- The MeshCore Python bridge (`scripts/meshcore-bridge.py`) requires the `meshcore` Python package.
+- Install it with: `pip install meshcore`.
+- For TCP connections, ensure your `meshcore` library version supports TCP (`TCPConnection`).
 
 ### No nodes appearing
-- Verify your MeshCore device is properly flashed and operating
-- Check that the radio frequency and parameters match other nodes in your mesh
-- Try sending an advert to announce your presence on the network
+- Verify your MeshCore device is properly flashed and operating.
+- Check that the radio frequency and parameters match other nodes in your mesh.
+- Try sending an advert to announce your presence on the network.
+
+### Radio parameter changes "revert" on save
+Earlier 4.x versions had a hook-dependency bug where Phase 3 push events overwrote staged radio/location edits before Save fired. Fixed in 4.5.
 
 ## Reporting Issues
 
-This is an experimental feature and we appreciate your feedback. If you encounter any problems:
+If you hit a problem, please [open an issue](https://github.com/yeraze/meshmonitor/issues/new) with:
 
-1. Check the [existing issues](https://github.com/yeraze/meshmonitor/issues) to see if your problem has been reported
-2. If not, [open a new issue](https://github.com/yeraze/meshmonitor/issues/new) with:
-   - Your MeshCore device type and firmware version
-   - MeshMonitor version
-   - Relevant log output (look for `[MeshCore]` prefixed messages)
-   - Steps to reproduce the issue
+- Your MeshCore device type and firmware version
+- MeshMonitor version
+- Relevant log output (look for `[MeshCore]` prefixed messages)
+- Steps to reproduce the issue

--- a/docs/features/multi-source.md
+++ b/docs/features/multi-source.md
@@ -5,7 +5,7 @@ Multi-Source lets a single MeshMonitor deployment talk to **multiple Meshtastic 
 :::
 
 ::: info Coming soon
-**MQTT** and **MeshCore** source types are part of the multi-source architecture but are still in active development. They'll land in a future 4.x release.
+**MQTT** source types are part of the multi-source architecture but are still in active development. They'll land in a future 4.x release. **MeshCore** is a first-class source type as of 4.5 — see [MeshCore](/features/meshcore).
 :::
 
 ![Dashboard with multiple sources in the sidebar](/images/features/dashboard-multi-source.png)
@@ -14,7 +14,7 @@ Multi-Source lets a single MeshMonitor deployment talk to **multiple Meshtastic 
 
 A **source** is one upstream connection MeshMonitor speaks to — typically a Meshtastic node. Each source has:
 
-- A **type** — `meshtastic_tcp` today; `mqtt` and `meshcore` are planned. Serial and BLE nodes connect through the Serial Bridge / BLE Bridge sidecars and appear as `meshtastic_tcp` sources pointing at the bridge container.
+- A **type** — `meshtastic_tcp` and `meshcore` today; `mqtt` is planned. Serial and BLE Meshtastic nodes connect through the Serial Bridge / BLE Bridge sidecars and appear as `meshtastic_tcp` sources pointing at the bridge container. MeshCore connects directly — USB through the UI, TCP via the legacy env-var bootstrap path. No sidecar either way.
 - Its own **connection settings** (host, port, device path, credentials)
 - Its own **scheduler** (auto-responder, auto-announce, auto-traceroute, auto-ack)
 - Its own **Virtual Node** endpoint (TCP sources only)
@@ -61,7 +61,7 @@ Your picker choice persists per view and per user.
 
 Virtual Node is a MeshMonitor feature that lets mobile Meshtastic apps connect *through* MeshMonitor instead of directly to the node. In 4.0 it is **per-source**.
 
-- Only `meshtastic_tcp` sources support Virtual Node (planned MQTT and MeshCore source types will ignore VN settings when they ship)
+- Only `meshtastic_tcp` sources support Virtual Node — MeshCore sources ignore VN settings, and the planned MQTT source type will too
 - Each source can expose its own VN endpoint on its own port
 - Ports must be unique across sources — the API rejects collisions with HTTP 409
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ hero:
 features:
   - icon: 🛰️
     title: Multi-Source Networks
-    details: Connect to multiple Meshtastic nodes at once over TCP — including Serial or BLE nodes fronted by the Serial Bridge or BLE Bridge sidecars (MQTT and MeshCore source types coming soon). Unified map, messages, telemetry, and traceroute views stay scoped per-source with a single click. Ideal for multi-site deployments, backup gateways, and combining a home node with a repeater.
+    details: Connect to multiple Meshtastic nodes at once over TCP — including Serial or BLE nodes fronted by the Serial Bridge or BLE Bridge sidecars — plus USB-attached MeshCore companions and repeaters managed from the Sources sidebar (TCP MeshCore via env-var bootstrap; MQTT source type coming soon). Unified map, messages, telemetry, and traceroute views stay scoped per-source with a single click. Ideal for multi-site deployments, backup gateways, and combining a home node with a repeater.
 
   - icon: 🔐
     title: Per-Source Permissions
@@ -149,7 +149,7 @@ MeshMonitor supports multiple deployment scenarios:
 ## Screenshots
 
 ### Multi-Source Dashboard
-Every source your deployment touches shows up in the sidebar with its own health, map pin colour, and unified or source-scoped views. TCP today (with Serial/BLE via the bridge sidecars); MQTT and MeshCore source types coming soon.
+Every source your deployment touches shows up in the sidebar with its own health, map pin colour, and unified or source-scoped views. Meshtastic TCP (with Serial/BLE via the bridge sidecars) and USB-attached MeshCore are first-class today; TCP MeshCore is supported via the legacy env-var bootstrap path, and MQTT is coming soon.
 
 ![Multi-Source Dashboard](/images/features/dashboard-multi-source.png)
 

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.3.1
-appVersion: "4.3.1"
+version: 4.5.0
+appVersion: "4.5.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.4.0-alpha2",
+  "version": "4.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.4.0-alpha2",
+      "version": "4.5.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.4.0-alpha2",
+  "version": "4.5.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Promote MeshCore from "experimental tab" to first-class source across the docs and add the 4.5 release blog post.

- **`docs/features/meshcore.md`** — full rewrite: per-source model, multi-pane page (Nodes / Channels / DMs / Configuration / Node Info), telemetry pipeline (local + per-node remote), telemetry-mode toggles, radio preset selector, UI permission gating, sourcey permission set after migration 058, env-var bootstrap section, troubleshooting refresh.
- **`docs/features/multi-source.md`** — drop the "MeshCore coming soon" callout; mark MeshCore as a shipped source type with the right transport caveats.
- **`docs/index.md`** — landing-page hero + screenshot caption updated to stop deferring MeshCore.
- **`docs/.vitepress/config.mts`** — sidebar entry: `MeshCore (Experimental)` → `MeshCore`.
- **`docs/blog/2026-05-14-meshcore-4-5.md`** (new) — release post for 4.5 walking through every MeshCore PR that landed: #3005, #3014, #3015, #3016, #3017, #3018, #3019, #3020, #3021, #3022, #3023.

The post and the rewritten `meshcore.md` both keep an honest **"Still Early"** section about what's missing (no remote-admin, no auto-* schedulers, minimal notifications, no MeshCore-specific link visualization, MQTT source still planned).

## Verified against `main` source

Every claim that names a constant, env var, or UI affordance was checked against the source on `main`:

- **Local poller**: `src/server/services/meshcoreTelemetryPoller.ts`
  - Env var: `MESHCORE_TELEMETRY_INTERVAL_MS` (matches draft)
  - Default: `5 * 60 * 1000` ms (5 min, matches draft)
  - Floor: 10 s
- **Remote scheduler**: `src/server/services/meshcoreRemoteTelemetryScheduler.ts`
  - Env var: `MESHCORE_REMOTE_TELEMETRY_TICK_MS` (matches draft)
  - Default: `DEFAULT_TICK_MS = 30_000` (30 s, matches draft)
  - Per-source minimum: `MIN_INTERVAL_BETWEEN_REQUESTS_MS = 60_000` ms — exactly the **shared 60 s cross-mesh throttle** the draft references, enforced through `MeshCoreManager.lastMeshTxAt` (matches draft)
- **Source-side gating for `requestRemoteTelemetry`**: `src/server/meshcoreManager.ts:1307` returns `null` immediately unless `deviceType === COMPANION`. So **the source must be a Companion to issue remote-telemetry pulls** — repeater/room-server *as the source* can't drive the scheduler. Targets aren't device-type-gated (just publicKey-addressed), but the user-facing opt-in lives on the contact-detail panel inside DMs, which is Companion-source territory in 4.5.
- **UI source-add flow**: `src/pages/DashboardPage.tsx:243-256` — MeshCore branch sets `transport: 'usb'` only and the inline comment says "MeshCore companion-USB v1: just serial port + device type. Other transports (BLE/TCP) are out of scope for slice 4." Form fields: `formMcSerialPort` + `formMcDeviceType` (`companion` | `repeater`). **No TCP host/port field, no baud field, no Room Server option** in the UI today.
  - This contradicted an earlier draft that claimed "TCP and USB transports per source" via the UI and listed "TCP host/port, or serial path + baud" in the add-source steps. Corrected: UI is USB-only (Companion or Repeater); TCP MeshCore is env-var bootstrap only in 4.5; Room Server is auto-detected by the Python bridge when present (no separate selector). Called out explicitly in the new "Source Types" section, "Adding a MeshCore Source" steps, and the "Still Early" list.
- **Docker compose port form**: `docker-compose.yml` ships `8080:3001` (the canonical 4.x form). Earlier draft kept the pre-4.0 `8080:8080` in two of the example snippets — fixed to `8080:3001` to match the rest of the docs.
- **Telemetry mode names**: `meshcoreManager.ts:1218` — `'base' | 'loc' | 'env'` (matches draft).

## Files in the commit

```
docs/.vitepress/config.mts
docs/blog/2026-05-14-meshcore-4-5.md
docs/features/meshcore.md
docs/features/multi-source.md
docs/index.md
```

(Other untracked files in the working tree — `docker-compose.dev.local.yml` — were intentionally left out.)

## Test plan

- [ ] `npm run docs:build` (or VitePress equivalent) succeeds and the new pages render
- [ ] Sidebar shows `MeshCore` (no "(Experimental)" tag)
- [ ] Blog post renders on the news/blog index with the May 14 date
- [ ] `meshcore.md` table of contents reflects the new section structure (Source Types → Requirements → Adding a MeshCore Source → Bootstrap via Environment Variables → Device Types → The MeshCore Page → Telemetry → Multi-Source Dashboard → Permissions → Radio Configuration → Still Early → Troubleshooting → Reporting Issues)
- [ ] `multi-source.md` no longer carries "MeshCore coming soon" callouts
- [ ] `index.md` hero + screenshot caption read correctly post-edit

---

Authored by Merlin 🪄