### PR TITLE
fix(neighbor-info): keep links when neighbor lastHeard is NULL but NI report is fresh

### DIFF
--- a/src/server/routes/sourceRoutes.neighbor-info.test.ts
+++ b/src/server/routes/sourceRoutes.neighbor-info.test.ts
@@ -86,7 +86,8 @@ const makeNeighborRecord = (overrides: any = {}) => ({
   neighborNodeNum: 222,
   snr: -5.5,
   lastRxTime: null,
-  timestamp: nowSec(),
+  // Stored as ms in the DB write path (meshtasticManager uses Date.now())
+  timestamp: Date.now(),
   sourceId: 'src-abc',
   ...overrides,
 });
@@ -180,15 +181,16 @@ describe('GET /:id/neighbor-info', () => {
     expect(res.body[0].bidirectional).toBe(false);
   });
 
-  it('filters out records where a node lastHeard is older than maxNodeAge', async () => {
+  it('filters out records where the reporter lastHeard is older than maxNodeAge', async () => {
     const staleTime = nowSec() - 30 * 60 * 60; // 30 hours ago — beyond default 24h
     const ni = makeNeighborRecord({ nodeNum: 111, neighborNodeNum: 222 });
 
     mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
     mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([ni]);
-    // node 111 is fresh, node 222 is stale
+    // reporter (111) is stale — we haven't heard from them recently, so we can't
+    // trust the link even if the NeighborInfo row in the DB is otherwise recent.
     mockDb.nodes.getNodesByNums.mockImplementation(async (nums: number[]) =>
-      new Map(nums.map(n => [n, n === 222 ? makeNode(n, { lastHeard: staleTime }) : makeNode(n)]))
+      new Map(nums.map(n => [n, n === 111 ? makeNode(n, { lastHeard: staleTime }) : makeNode(n)]))
     );
 
     const res = await request(createApp()).get('/src-abc/neighbor-info');
@@ -197,7 +199,26 @@ describe('GET /:id/neighbor-info', () => {
     expect(res.body).toEqual([]);
   });
 
-  it('filters out records where a node has no lastHeard', async () => {
+  it('filters out records where the reporter node has no lastHeard', async () => {
+    const ni = makeNeighborRecord({ nodeNum: 111, neighborNodeNum: 222 });
+
+    mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
+    mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([ni]);
+    // reporter (111) has null lastHeard — we never heard from them directly
+    mockDb.nodes.getNodesByNums.mockImplementation(async (nums: number[]) =>
+      new Map(nums.map(n => [n, n === 111 ? makeNode(n, { lastHeard: null }) : makeNode(n)]))
+    );
+
+    const res = await request(createApp()).get('/src-abc/neighbor-info');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('keeps records where the neighbor has null lastHeard but the NeighborInfo report is fresh', async () => {
+    // Regression for #3025: PR #2615 intentionally leaves lastHeard=NULL on placeholder
+    // nodes we've only heard *about* via NeighborInfo. Those links must not be dropped
+    // when the NeighborInfo report itself is recent.
     const ni = makeNeighborRecord({ nodeNum: 111, neighborNodeNum: 222 });
 
     mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
@@ -209,7 +230,53 @@ describe('GET /:id/neighbor-info', () => {
     const res = await request(createApp()).get('/src-abc/neighbor-info');
 
     expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].nodeNum).toBe(111);
+    expect(res.body[0].neighborNodeNum).toBe(222);
+  });
+
+  it('filters out records when neighbor lastHeard is null AND the NeighborInfo report is stale', async () => {
+    // 48 hours ago, in ms — beyond the default 24h window
+    const staleMs = Date.now() - 48 * 60 * 60 * 1000;
+    const ni = makeNeighborRecord({
+      nodeNum: 111,
+      neighborNodeNum: 222,
+      timestamp: staleMs,
+      lastRxTime: null,
+    });
+
+    mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
+    mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([ni]);
+    mockDb.nodes.getNodesByNums.mockImplementation(async (nums: number[]) =>
+      new Map(nums.map(n => [n, n === 222 ? makeNode(n, { lastHeard: null }) : makeNode(n)]))
+    );
+
+    const res = await request(createApp()).get('/src-abc/neighbor-info');
+
+    expect(res.status).toBe(200);
     expect(res.body).toEqual([]);
+  });
+
+  it('keeps records when neighbor lastHeard is null but lastRxTime (seconds) is fresh', async () => {
+    // Stale NI report row timestamp but recent firmware-supplied lastRxTime
+    const staleMs = Date.now() - 48 * 60 * 60 * 1000;
+    const ni = makeNeighborRecord({
+      nodeNum: 111,
+      neighborNodeNum: 222,
+      timestamp: staleMs,
+      lastRxTime: nowSec(), // firmware time, seconds
+    });
+
+    mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
+    mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([ni]);
+    mockDb.nodes.getNodesByNums.mockImplementation(async (nums: number[]) =>
+      new Map(nums.map(n => [n, n === 222 ? makeNode(n, { lastHeard: null }) : makeNode(n)]))
+    );
+
+    const res = await request(createApp()).get('/src-abc/neighbor-info');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
   });
 
   it('uses positionOverride when positionOverrideEnabled is true', async () => {
@@ -234,15 +301,16 @@ describe('GET /:id/neighbor-info', () => {
   });
 
   it('uses custom maxNodeAge from settings', async () => {
-    // maxNodeAge = 1 hour; stale node is 2 hours old
+    // maxNodeAge = 1 hour; stale reporter is 2 hours old
     const staleTime = nowSec() - 2 * 60 * 60;
     const ni = makeNeighborRecord({ nodeNum: 111, neighborNodeNum: 222 });
 
     mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
     mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([ni]);
     mockDb.settings.getSetting.mockResolvedValue('1'); // 1-hour window
+    // Reporter (111) is stale relative to the custom 1-hour window
     mockDb.nodes.getNodesByNums.mockImplementation(async (nums: number[]) =>
-      new Map(nums.map(n => [n, n === 222 ? makeNode(n, { lastHeard: staleTime }) : makeNode(n)]))
+      new Map(nums.map(n => [n, n === 111 ? makeNode(n, { lastHeard: staleTime }) : makeNode(n)]))
     );
 
     const res = await request(createApp()).get('/src-abc/neighbor-info');

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -703,11 +703,17 @@ router.get('/:id/neighbor-info', requirePermission('nodes', 'read', { sourceIdFr
       };
     })
       .filter(ni => {
-        // Filter out connections where either node is too old or missing lastHeard
-        if (!ni.node?.lastHeard || !ni.neighbor?.lastHeard) {
-          return false;
-        }
-        return ni.node.lastHeard >= cutoffTime && ni.neighbor.lastHeard >= cutoffTime;
+        // The reporter (`node`) is a node we've directly heard from — we require a fresh
+        // `lastHeard` on them. The neighbor side may be a node we've only learned about
+        // second-hand through this NeighborInfo report (see #2615 zombie-node guard,
+        // which intentionally NULLs `lastHeard` on placeholder rows). For those, fall
+        // back to the freshness of the NeighborInfo record itself so we don't drop
+        // every indirect-neighbor link (#3025).
+        if (!ni.node?.lastHeard || ni.node.lastHeard < cutoffTime) return false;
+        if (ni.neighbor?.lastHeard && ni.neighbor.lastHeard >= cutoffTime) return true;
+        const reportSec = Math.floor((ni.timestamp ?? 0) / 1000);
+        const rxSec = ni.lastRxTime ?? 0;
+        return Math.max(reportSec, rxSec) >= cutoffTime;
       })
       .map(({ node, neighbor, ...rest }) => rest);
 

--- a/src/server/server.neighbor-info-position.test.ts
+++ b/src/server/server.neighbor-info-position.test.ts
@@ -147,10 +147,13 @@ describe('Neighbor Info API with Position Overrides', () => {
             };
           })
           .filter(ni => {
-            if (!ni.node?.lastHeard || !ni.neighbor?.lastHeard) {
-              return false;
-            }
-            return ni.node.lastHeard >= cutoffTime && ni.neighbor.lastHeard >= cutoffTime;
+            // Mirror server.ts filter — reporter must be fresh, but neighbor can
+            // fall back to NeighborInfo report freshness when lastHeard is null (#3025)
+            if (!ni.node?.lastHeard || ni.node.lastHeard < cutoffTime) return false;
+            if (ni.neighbor?.lastHeard && ni.neighbor.lastHeard >= cutoffTime) return true;
+            const reportSec = Math.floor(((ni as any).timestamp ?? 0) / 1000);
+            const rxSec = (ni as any).lastRxTime ?? 0;
+            return Math.max(reportSec, rxSec) >= cutoffTime;
           })
           .map(({ node, neighbor, ...rest }) => rest);
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4150,11 +4150,17 @@ apiRouter.get('/neighbor-info', requirePermission('info', 'read'), async (req, r
         };
       })))
       .filter(ni => {
-        // Filter out connections where either node is too old or missing lastHeard
-        if (!ni.node?.lastHeard || !ni.neighbor?.lastHeard) {
-          return false;
-        }
-        return ni.node.lastHeard >= cutoffTime && ni.neighbor.lastHeard >= cutoffTime;
+        // The reporter (`node`) is a node we've directly heard from — we require a fresh
+        // `lastHeard` on them. The neighbor side may be a node we've only learned about
+        // second-hand through this NeighborInfo report (see #2615 zombie-node guard,
+        // which intentionally NULLs `lastHeard` on placeholder rows). For those, fall
+        // back to the freshness of the NeighborInfo record itself so we don't drop
+        // every indirect-neighbor link (#3025).
+        if (!ni.node?.lastHeard || ni.node.lastHeard < cutoffTime) return false;
+        if (ni.neighbor?.lastHeard && ni.neighbor.lastHeard >= cutoffTime) return true;
+        const reportSec = Math.floor((ni.timestamp ?? 0) / 1000);
+        const rxSec = ni.lastRxTime ?? 0;
+        return Math.max(reportSec, rxSec) >= cutoffTime;
       })
       .map(({ node, neighbor, ...rest }) => rest); // Remove the temporary node/neighbor fields
 


### PR DESCRIPTION
## Summary

Addresses one cause of #3025 — the NULL-`lastHeard` filter regression introduced in v4.0.0 by #2615 (zombie-node fix). NeighborInfo packets are still being parsed and saved correctly (`🔗 Saved neighbor:` log lines confirm this), but the read-side filter on both `/api/neighbor-info` and `/api/sources/:id/neighbor-info` was rejecting every indirect-neighbor link because PR #2615 intentionally leaves `lastHeard=NULL` on placeholder rows for nodes we've only heard *about* via NeighborInfo.

This PR keeps the reporter-side freshness requirement but falls back to the NeighborInfo record's own freshness signals (`timestamp` / `lastRxTime`) when the neighbor's `lastHeard` is missing or stale.

## Root cause

The filter (introduced when the zombie guard landed) reads:

```ts
if (!ni.node?.lastHeard || !ni.neighbor?.lastHeard) return false;
return ni.node.lastHeard >= cutoffTime && ni.neighbor.lastHeard >= cutoffTime;
```

Combined with the zombie guard's behavior in `meshtasticManager.ts` (placeholder neighbors written with `lastHeard=NULL`), this drops every NeighborInfo row whose neighbor side is a node we haven't directly heard from — which is most of them.

## The fix

Both filters now:
1. **Require** the reporter (`ni.node`) to have a fresh `lastHeard` — we must have directly heard from the node making the claim.
2. If the neighbor has a fresh `lastHeard`, keep the row (as before).
3. Otherwise fall back to the freshness of the NeighborInfo record itself — `Math.max(timestamp/1000, lastRxTime)` against `cutoffTime`. `timestamp` is stored in ms (`Date.now()` in `meshtasticManager.ts:6710`), `lastRxTime` is firmware seconds.

## Files changed

- `src/server/server.ts:4152` — `GET /api/neighbor-info` filter.
- `src/server/routes/sourceRoutes.ts:705` — `GET /api/sources/:id/neighbor-info` filter (the one the Messages tab actually uses).
- `src/server/routes/sourceRoutes.neighbor-info.test.ts` — fixture `timestamp` corrected from seconds to ms (matches the real write path); existing staleness/NULL-lastHeard tests retargeted at the reporter side; new cases covering NULL-neighbor + fresh NI report (kept), NULL-neighbor + stale NI report (dropped), and NULL-neighbor + fresh `lastRxTime` (kept).
- `src/server/server.neighbor-info-position.test.ts` — inline shadow filter synced with the real handler so the test mirror doesn't drift.

## Honesty caveat

The reporter (`@SyselMitY`) followed up on #3025 indicating their case **also** involves neighbors that **do** have a fresh `lastHeard`, so this PR likely doesn't fully close out #3025. Use of `Refs #3025` (not `Fixes`) is intentional — further DB inspection has been requested from the reporter, and there may be a second cause (sourceId scoping in `getNodesByNums`, possibly elsewhere) still to nail down.

## Out of scope (deliberately)

- `GET /api/neighbor-info/:nodeNum` — no node-age filter there, left alone.
- The zombie-node write path in `meshtasticManager.ts` — the NULLing of `lastHeard` on placeholder rows is intentional and stays.
- The MQTT early-return.

## Follow-ups

- `databaseService.nodes.getNodesByNums` (used by `sourceRoutes.ts:681`) does not appear to scope to `sourceId`. If a node number is shared across sources, the per-source neighbor-info endpoint could pick up `lastHeard` from the wrong source's row. Worth a separate look as part of #3025 investigation.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — green
- [x] `npx vitest run` — full suite 4916/4916 pass (21/21 on targeted neighbor-info files)
- [ ] Manual: confirm with bug reporter (`@SyselMitY`) on a live build that NeighborInfo links now show in the UI for their mesh

Authored by Merlin 🪄