### PR TITLE
feat(meshcore): TCP transport option on MeshCore sources

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -91,7 +91,12 @@ function DashboardInner() {
   const [formHeartbeat, setFormHeartbeat] = useState('30'); // seconds, 0 = disabled (issue 2609)
   const [formAutoConnect, setFormAutoConnect] = useState(true); // issue #2773
   // MeshCore-specific (slice 4): companion-USB v1 — serial path + device type.
+  // TCP transport added in v2: same Companion firmware reachable over a TCP
+  // socket (e.g. esp-link, ser2net, native TCP-capable MeshCore firmware).
+  const [formMcTransport, setFormMcTransport] = useState<'usb' | 'tcp'>('usb');
   const [formMcSerialPort, setFormMcSerialPort] = useState('');
+  const [formMcTcpHost, setFormMcTcpHost] = useState('');
+  const [formMcTcpPort, setFormMcTcpPort] = useState('4403');
   const [formMcDeviceType, setFormMcDeviceType] = useState<'companion' | 'repeater'>('companion');
   const [formError, setFormError] = useState('');
   const [formSaving, setFormSaving] = useState(false);
@@ -207,7 +212,10 @@ function DashboardInner() {
     setFormVnAllowAdmin(false);
     setFormHeartbeat('30');
     setFormAutoConnect(true);
+    setFormMcTransport('usb');
     setFormMcSerialPort('');
+    setFormMcTcpHost('');
+    setFormMcTcpPort('4403');
     setFormMcDeviceType('companion');
     setFormError('');
     setShowSourceModal(true);
@@ -229,8 +237,13 @@ function DashboardInner() {
     setFormHeartbeat(String(cfg?.heartbeatIntervalSeconds ?? 0));
     // Default to true when unset (legacy sources pre-#2773 auto-connected).
     setFormAutoConnect(cfg?.autoConnect !== false);
-    // MeshCore-specific config (slice 4)
+    // MeshCore-specific config. transport=tcp is a v2 addition; legacy rows
+    // with no transport field are treated as USB (the original v1 default).
+    const mcTransport: 'usb' | 'tcp' = cfg?.transport === 'tcp' ? 'tcp' : 'usb';
+    setFormMcTransport(mcTransport);
     setFormMcSerialPort(cfg?.serialPort ?? cfg?.port ?? '');
+    setFormMcTcpHost(cfg?.tcpHost ?? '');
+    setFormMcTcpPort(cfg?.tcpPort != null ? String(cfg.tcpPort) : '4403');
     setFormMcDeviceType(cfg?.deviceType === 'repeater' ? 'repeater' : 'companion');
     setFormError('');
     setShowSourceModal(true);
@@ -241,19 +254,40 @@ function DashboardInner() {
 
     let cfg: Record<string, any>;
     if (formType === 'meshcore') {
-      // MeshCore companion-USB v1: just serial port + device type. Other
-      // transports (BLE/TCP) are out of scope for slice 4.
-      const port = formMcSerialPort.trim();
-      if (!port) {
-        setFormError(t('meshcore.form.error_port_required', 'Serial port is required'));
-        return;
+      // MeshCore source: USB/serial or TCP. Both transports flow through the
+      // same MeshCoreManager via the Python bridge — only the connect params
+      // differ. BLE remains out of scope.
+      if (formMcTransport === 'tcp') {
+        const host = formMcTcpHost.trim();
+        if (!host) {
+          setFormError(t('meshcore.form.error_tcp_host_required', 'Host is required'));
+          return;
+        }
+        const tcpPort = parseInt(formMcTcpPort, 10);
+        if (isNaN(tcpPort) || tcpPort < 1 || tcpPort > 65535) {
+          setFormError(t('source.form.error_port_range'));
+          return;
+        }
+        cfg = {
+          transport: 'tcp',
+          tcpHost: host,
+          tcpPort,
+          deviceType: formMcDeviceType,
+          autoConnect: formAutoConnect,
+        };
+      } else {
+        const port = formMcSerialPort.trim();
+        if (!port) {
+          setFormError(t('meshcore.form.error_port_required', 'Serial port is required'));
+          return;
+        }
+        cfg = {
+          transport: 'usb',
+          port,
+          deviceType: formMcDeviceType,
+          autoConnect: formAutoConnect,
+        };
       }
-      cfg = {
-        transport: 'usb',
-        port,
-        deviceType: formMcDeviceType,
-        autoConnect: formAutoConnect,
-      };
     } else {
       if (!formHost.trim()) { setFormError(t('source.form.error_host_required')); return; }
       const port = parseInt(formPort, 10);
@@ -565,18 +599,59 @@ function DashboardInner() {
             {formType === 'meshcore' ? (
               <>
                 <label className="dashboard-form-field">
-                  <span className="dashboard-form-label">{t('meshcore.form.serial_port', 'Serial Port')}</span>
-                  <input
+                  <span className="dashboard-form-label">{t('meshcore.form.transport', 'Transport')}</span>
+                  <select
                     className="dashboard-form-input"
-                    type="text"
-                    value={formMcSerialPort}
-                    onChange={(e) => setFormMcSerialPort(e.target.value)}
-                    placeholder="/dev/ttyACM0"
-                  />
-                  <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
-                    {t('meshcore.form.serial_port_help', 'OS path of the USB-connected MeshCore companion (e.g. /dev/ttyACM0, COM3).')}
-                  </p>
+                    value={formMcTransport}
+                    onChange={(e) => setFormMcTransport(e.target.value as 'usb' | 'tcp')}
+                  >
+                    <option value="usb">{t('meshcore.form.transport_usb', 'USB / Serial')}</option>
+                    <option value="tcp">{t('meshcore.form.transport_tcp', 'TCP')}</option>
+                  </select>
                 </label>
+
+                {formMcTransport === 'tcp' ? (
+                  <>
+                    <label className="dashboard-form-field">
+                      <span className="dashboard-form-label">{t('source.form.host')}</span>
+                      <input
+                        className="dashboard-form-input"
+                        type="text"
+                        value={formMcTcpHost}
+                        onChange={(e) => setFormMcTcpHost(e.target.value)}
+                        placeholder={t('source.form.host_placeholder')}
+                      />
+                      <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                        {t('meshcore.form.tcp_host_help', 'Hostname or IP of the MeshCore companion reachable over TCP (e.g. esp-link, ser2net, or native TCP firmware).')}
+                      </p>
+                    </label>
+
+                    <label className="dashboard-form-field">
+                      <span className="dashboard-form-label">{t('source.form.tcp_port')}</span>
+                      <input
+                        className="dashboard-form-input"
+                        type="number"
+                        value={formMcTcpPort}
+                        onChange={(e) => setFormMcTcpPort(e.target.value)}
+                        placeholder="4403"
+                      />
+                    </label>
+                  </>
+                ) : (
+                  <label className="dashboard-form-field">
+                    <span className="dashboard-form-label">{t('meshcore.form.serial_port', 'Serial Port')}</span>
+                    <input
+                      className="dashboard-form-input"
+                      type="text"
+                      value={formMcSerialPort}
+                      onChange={(e) => setFormMcSerialPort(e.target.value)}
+                      placeholder="/dev/ttyACM0"
+                    />
+                    <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                      {t('meshcore.form.serial_port_help', 'OS path of the USB-connected MeshCore companion (e.g. /dev/ttyACM0, COM3).')}
+                    </p>
+                  </label>
+                )}
 
                 <label className="dashboard-form-field">
                   <span className="dashboard-form-label">{t('meshcore.form.device_type', 'Device Type')}</span>

--- a/src/server/meshcoreRegistry.test.ts
+++ b/src/server/meshcoreRegistry.test.ts
@@ -100,6 +100,25 @@ describe('meshcoreConfigFromSource', () => {
     });
   });
 
+  it('defaults tcpPort to 4403 when omitted', () => {
+    const cfg = meshcoreConfigFromSource(
+      fakeSource({ config: { transport: 'tcp', tcpHost: '10.0.0.5', deviceType: 'companion' } }),
+    );
+    expect(cfg).toEqual({
+      connectionType: ConnectionType.TCP,
+      tcpHost: '10.0.0.5',
+      tcpPort: 4403,
+      firmwareType: 'companion',
+    });
+  });
+
+  it('returns null for tcp transport without a host', () => {
+    const cfg = meshcoreConfigFromSource(
+      fakeSource({ config: { transport: 'tcp', tcpPort: 4403, deviceType: 'companion' } }),
+    );
+    expect(cfg).toBeNull();
+  });
+
   it('returns null when companion-USB source has no port set (legacy seed default)', () => {
     const cfg = meshcoreConfigFromSource(
       fakeSource({ config: { transport: 'usb', port: '', deviceType: 'companion' } }),


### PR DESCRIPTION
## Summary

MeshCore sources currently only expose **USB / Serial** in the source modal, even though `MeshCoreManager` + `meshcoreConfigFromSource` already speak TCP via the Python bridge. This PR closes that loop: users can now pick TCP when creating or editing a MeshCore source.

The runtime side was already there — this is mostly a form change.

## Changes

- **`src/pages/DashboardPage.tsx`** — new `Transport` selector (USB / TCP) inside the MeshCore branch of the source modal. When TCP is selected, the form shows host + port (default 4403) and hides the serial path; USB keeps the existing UX. Edit-mode hydration reads `cfg.transport`/`cfg.tcpHost`/`cfg.tcpPort` so existing TCP sources (or any pre-staged via the API) round-trip cleanly. Save handler builds either a `{transport:'usb', port, ...}` or `{transport:'tcp', tcpHost, tcpPort, ...}` config.
- **`src/server/meshcoreRegistry.test.ts`** — adds two cases to `meshcoreConfigFromSource`: default `tcpPort` → 4403 when omitted, and `null` when `transport:'tcp'` is set without a host. The happy-path TCP test already lives there.

## What's intentionally **not** in this PR

- No changes to `MeshCoreManager`, the Python bridge, route handlers, or autoconnect — they already handle `connectionType: ConnectionType.TCP`.
- No migrations — the `transport`/`tcpHost`/`tcpPort` fields ride inside the existing `sources.config` JSON blob.
- No BLE transport. Out of scope.
- No new `meshcore.form.*` i18n entries in `public/locales/en.json` — DashboardPage uses `t(key, defaultValue)` for the MeshCore form, matching the existing inline-default pattern in this file. Locale entries can come in a follow-up if Randall wants them surfaced for translators.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run src/server/meshcoreRegistry.test.ts` — 11 pass (including new TCP cases)
- [x] `npx vitest run src/pages/DashboardPage.test.tsx` — 11 pass
- [x] `npx vitest run src/server/meshcore` (full meshcore server suite) — 26 pass
- [x] `eslint` clean on changed files (0 errors; pre-existing `any` warnings untouched)
- [ ] **Visual inspection of the new Transport selector in the dashboard modal — pending (didn't spin up the full dev stack locally for a screenshot, flagging so Randall can eyeball before merge).**
- [ ] Manual end-to-end against a real TCP-reachable MeshCore companion (e.g. ser2net) — also pending; recommend before lifting draft.

Authored by Merlin 🪄