### PR TITLE
feat(meshcore): channel CRUD + connect-time sync (phase 1/3)

### DIFF
--- a/docs/meshcore-channels-plan.md
+++ b/docs/meshcore-channels-plan.md
@@ -1,0 +1,220 @@
+# MeshCore Channels — Plan
+
+**Status:** Draft. No implementation yet.
+**Goal:** Detect, display, and CRUD-manage the channels on a MeshCore-source node, the way we already do for Meshtastic sources.
+
+---
+
+## TL;DR
+
+MeshCore channels are dramatically simpler than Meshtastic channels: just `{ channelIdx, name, secret }`. The meshcore.js library already has `getChannel` / `setChannel` / `deleteChannel` wire commands wired up. The existing `channels` DB table is Meshtastic-biased but its core columns (`id`, `name`, `psk`, `sourceId`) align well enough that we can reuse it, leaving the Meshtastic-only fields (`role`, `uplinkEnabled`, `downlinkEnabled`, `positionPrecision`) null for MeshCore rows.
+
+The work splits naturally into three PR-sized phases:
+
+1. **Backend sync** — read channels from the device on connect, mirror to DB.
+2. **Display** — replace the hardcoded "Public" channel in `MeshCoreChannelsView` with the real per-source list.
+3. **Configuration UI** — add MeshCore-aware create/edit/delete affordances to `ChannelsConfigSection`.
+
+Estimated effort: **~4–6 person-days total** (1 day phase 1, 1 day phase 2, 2–3 days phase 3).
+
+---
+
+## 1. What a MeshCore channel actually is
+
+From `@liamcottle/meshcore.js` v1.13 (`src/connection/connection.js:605-622`):
+
+```
+ChannelInfo (response to GetChannel)
+  channelIdx : uint8
+  name       : C-string, 32 bytes fixed (≤31 chars + NUL)
+  secret     : 16 bytes, AES-128 key
+```
+
+That is the entire model. No role, no uplink/downlink, no position precision, no hash, no salt, no frequency override.
+
+Behavioural notes:
+- **Identity is the index.** `SendChannelTxtMsg`, `ChannelMsgRecv`, `SetChannel`, `DeleteChannel` all key off `channelIdx`. Hashes are an internal-firmware concern (`packet.js:24-25`) and don't surface to the host.
+- **Channel-count is device-dependent.** There is no `maxChannels` field in `AppStart` or `DeviceQuery`. `getChannels()` enumerates by calling `GetChannel(0)`, `GetChannel(1)`, … until the firmware returns an error. The 8-slot cap that `channels.ts::cleanupInvalidChannels` enforces today is a Meshtastic assumption.
+- **No push events.** There is no `ChannelAdded` / `ChannelUpdated`. Channel state is pull-only — we re-read on connect and after every write we issue.
+- **No well-known default PSK** like Meshtastic's `AQ==`. Whatever the device firmware ships with at idx 0 is what we'll discover on first sync.
+- **The host link is unencrypted** — secrets travel in cleartext between MeshMonitor and the locally-attached MeshCore Companion. Mesh-side encryption is firmware-internal.
+
+meshcore.js methods we'll call (all on `Connection`):
+- `getChannel(channelIdx)` — single read, returns `{channelIdx, name, secret}`
+- `getChannels()` — enumerates until error, returns `Channel[]`
+- `setChannel(channelIdx, name, secret)` — write (creates if absent, updates if present)
+- `deleteChannel(channelIdx)` — issues `SetChannel` with an empty-name marker (see library impl)
+- `sendChannelTextMessage(channelIdx, text)` — already used by `meshcoreManager.sendMessage`
+
+---
+
+## 2. What MeshMonitor has today
+
+| Surface | File | State |
+|---|---|---|
+| MeshCore source manager | `src/server/meshcoreManager.ts` | **No channel CRUD methods.** Consumes `channel_message` push events (line 477) with a `channel_idx` field; synthesizes a fake `channel-${idx}` pubkey to scope incoming messages. |
+| meshcore.js wrapper | `src/server/meshcoreNativeBackend.ts` | Wires `ResponseCodes.ChannelMsgRecv` → `channel_message` event (line 197-204). No channel-CRUD method exposure yet. |
+| Channels DB schema | `src/db/schema/channels.ts` | Has `id`, `name`, `psk`, `role`, `uplinkEnabled`, `downlinkEnabled`, `positionPrecision`, `sourceId`. `UNIQUE(sourceId, id)` per migration 023. |
+| Channels repository | `src/db/repositories/channels.ts` | Generic CRUD methods. `cleanupInvalidChannels()` (line 228) hard-rejects `id < 0` or `id > 7`. |
+| Configuration UI | `src/components/configuration/ChannelsConfigSection.tsx` | Renders all Meshtastic-specific fields unconditionally. No "add" button — it edits fixed slots only. No source-type awareness. |
+| MeshCore display | `src/components/MeshCore/MeshCoreChannelsView.tsx` | Hardcoded single `PUBLIC_CHANNEL` (line 23). Filters messages by the synthesized pubkey. No DB read. |
+| Routes | `src/server/routes/v1/channels.ts` | Generic REST CRUD. Backend write path is Meshtastic-only (sends admin messages); no MeshCore branch. |
+
+Concrete gaps:
+1. `meshcoreManager` doesn't expose `getChannels` / `setChannel` / `deleteChannel`.
+2. Nothing syncs MeshCore channels into the DB.
+3. `MeshCoreChannelsView` ignores the DB entirely.
+4. `ChannelsConfigSection` renders Meshtastic-only fields for any source.
+5. The channels route's write path can't talk to MeshCore.
+6. The 8-slot cap in `cleanupInvalidChannels()` is wrong for MeshCore.
+
+---
+
+## 3. Architectural decisions
+
+### D1. Reuse the existing `channels` table
+
+**Decision:** reuse, don't create a new `meshcoreChannels` table.
+
+The shared fields (`id`, `name`, `psk`, `sourceId`) line up perfectly. The Meshtastic-only fields (`role`, `uplinkEnabled`, `downlinkEnabled`, `positionPrecision`) just stay `NULL` for MeshCore rows. The repository's `cleanupInvalidChannels()` needs softening (see D4) but no schema migration is required.
+
+Storage format for `secret`: the column is already typed for base64-encoded PSK. A MeshCore 16-byte secret base64-encodes to a 24-char string — no schema change. We coerce hex ↔ base64 at the API boundary.
+
+### D2. Channel CRUD method placement
+
+Add methods to `MeshCoreManager` (mirroring its existing style of thin TS wrappers around the native backend):
+
+```ts
+class MeshCoreManager {
+  async listChannels(): Promise<MeshCoreChannel[]> { … }
+  async setChannel(idx: number, name: string, secret: Uint8Array): Promise<void> { … }
+  async deleteChannel(idx: number): Promise<void> { … }
+  private async syncChannelsFromDevice(): Promise<void> { … }  // calls listChannels + upserts to DB
+}
+```
+
+`syncChannelsFromDevice()` runs:
+- Once on connect, right after `refreshLocalNode()` / `refreshContacts()` in the existing connect sequence.
+- After every successful `setChannel` / `deleteChannel` (re-read to confirm; the device is authoritative).
+- On demand via a "Refresh from device" button in the configuration UI.
+
+### D3. UI strategy — fork or unify?
+
+**Decision:** unify, with source-type-conditional rendering inside `ChannelsConfigSection`.
+
+The existing component already renders a list-of-channels-with-edit-controls; the same shape works for MeshCore. We add a `sourceType` prop (or read it from `useSource()`), and conditionally:
+- Hide `role`, `uplinkEnabled`, `downlinkEnabled`, `positionPrecision` for MeshCore.
+- Show an "Add channel" button for MeshCore (Meshtastic has fixed slots and doesn't need it).
+- Show a "regenerate secret" button for MeshCore (uses `crypto.getRandomValues(new Uint8Array(16))`).
+- Display the secret in hex (matches the MeshCore CLI convention) with a "copy" button; round-trip through base64 only at the DB layer.
+
+If the field-set divergence grows in future, we can fork to `<MeshCoreChannelsConfigSection>`. For now a single component keeps the configuration page coherent.
+
+### D4. Soften `cleanupInvalidChannels`
+
+Today it deletes any row with `id < 0` or `id > 7`. For MeshCore that's wrong — firmware builds vary. Two options:
+
+- **D4a (minimal):** widen the cap to a generous fixed value (e.g. `id > 31`) and assume no MeshCore firmware exceeds it. Simple, but a guess.
+- **D4b (proper):** scope the cleanup by source type — keep the 8-slot cap for Meshtastic sources, drop it entirely for MeshCore sources (or rely on the device's own rejection when we try to read past the end).
+
+**Recommendation: D4b.** Requires reading `sources.sourceType` in the repo method, but it's the honest fix.
+
+### D5. PSK / secret display format
+
+- **Storage:** base64, same column as Meshtastic. Keeps the schema uniform.
+- **API:** return as hex when source is MeshCore (matches MeshCore CLI / docs conventions), base64 when Meshtastic.
+- **UI:** show hex for MeshCore with copy + regenerate buttons. Mask by default behind a "show" toggle, matching how Meshtastic PSK is shown.
+
+### D6. No "default channel" auto-creation
+
+Meshtastic has a well-known default PSK (`AQ==`) and channel 0 is conventionally "LongFast" with that key. MeshCore has no analog. We do NOT seed a default channel on a fresh MeshCore source — whatever the device firmware ships with at idx 0 is what we discover on first sync. If the device has zero channels configured, the UI shows an empty list with a prominent "Add channel" affordance.
+
+---
+
+## 4. Phased delivery
+
+### Phase 1 — Backend sync (1 PR, ~1 day)
+
+**Scope:**
+- `meshcoreNativeBackend.ts`: expose `getChannels()`, `setChannel(idx, name, secret)`, `deleteChannel(idx)` pass-throughs to the meshcore.js `Connection` instance.
+- `meshcoreManager.ts`: add `listChannels()`, `setChannel()`, `deleteChannel()`, `syncChannelsFromDevice()`.
+- Hook `syncChannelsFromDevice()` into the manager's connect sequence (after contacts refresh).
+- Repository: implement D4b — drop the 8-slot cap for MeshCore-source rows by reading `sources.sourceType` (or pass `sourceType` as an explicit arg to `cleanupInvalidChannels`).
+- Tests:
+  - Unit test for `MeshCoreManager.syncChannelsFromDevice` mocks the native backend's `getChannels()` and asserts the channels table gets the expected rows with the right `sourceId` and base64-encoded secrets.
+  - Repository test asserting `cleanupInvalidChannels` no longer drops MeshCore rows with idx > 7.
+
+**Out of scope:** UI changes, REST route changes.
+
+**Acceptance:** start MeshMonitor with a MeshCore source attached, wait for connect, query `SELECT * FROM channels WHERE sourceId = '<meshcore-source>'` — rows reflect the device's channel list.
+
+### Phase 2 — Display the real channel list (1 PR, ~1 day)
+
+**Scope:**
+- `MeshCoreChannelsView.tsx`: replace the hardcoded `PUBLIC_CHANNEL` constant with a query of the channels table scoped to the current source. Render each channel as a selectable tab/section. Filter messages by `channelIdx` (the manager already tags channel messages with `channel_idx`; ensure that flows into the messages table — check existing storage, may already be there).
+- If channel-index tagging isn't already on messages: small extension to the manager's `channel_message` event handler to store `channelIdx` in `messages.channelIdx` (Meshtastic-side field) or a new column. **Check first**, don't assume.
+- Tests: render component with 2-3 channel rows in DB, assert all tabs render and messages filter correctly.
+
+**Out of scope:** writes.
+
+**Acceptance:** in the MeshCore page, switch between the device's actual channels and see messages segregated by channel.
+
+### Phase 3 — Configuration UI (1 PR, ~2-3 days)
+
+**Scope:**
+- `ChannelsConfigSection.tsx`: add `sourceType`-aware conditional rendering. Hide Meshtastic-only fields for MeshCore. Add "Add channel" and "Regenerate secret" buttons. Show secret as hex with copy/show toggle.
+- `src/server/routes/v1/channels.ts`: route the write path by source type. Meshtastic: existing admin-message flow. MeshCore: call `meshcoreManager.setChannel(idx, name, secret)` then re-sync.
+- DELETE route: similarly route by type.
+- Validation: name ≤ 31 bytes, secret = exactly 16 bytes (32 hex chars).
+- Tests:
+  - Frontend: render with `sourceType='meshcore'`, assert hidden fields are absent, assert "Add channel" button is present.
+  - Backend: integration test for `PUT /api/v1/channels/:id` against a MeshCore source — mocks `meshcoreManager.setChannel`, asserts it's called with right args, asserts DB is re-synced afterwards.
+  - Permissions: assert `requirePermission('channels', 'write')` still gates the route per-source.
+
+**Out of scope:** mass-import/export, bulk operations, channel-link sharing.
+
+**Acceptance:** in the Configuration tab for a MeshCore source, the user can:
+- See the existing channels.
+- Click "Add channel", enter a name, click "Generate secret", save, and see the new channel appear in the list and on the MeshCore page.
+- Edit an existing channel's name or regenerate its secret and save.
+- Delete a channel.
+All operations write to the device first, then mirror to DB.
+
+---
+
+## 5. Open questions for confirmation before phase 1
+
+1. **D4a vs D4b for `cleanupInvalidChannels`.** I recommend D4b (source-type-aware). Acceptable to commit to that, or do you want the minimal D4a fix and we revisit later?
+2. **Secret display in UI.** Hidden-by-default with a "show" toggle, hex format, copy + regenerate buttons — same as Meshtastic PSK except hex instead of base64. OK?
+3. **Channel-message DB column.** Is the channel index already stored on `messages` rows for MeshCore-source messages, or do we need to extend that in phase 2? (Will verify before phase 2 starts.)
+4. **First-sync behaviour for fresh sources.** No default channel auto-creation — let the device drive. If the device has zero channels, UI shows empty + "Add channel" affordance. Agree?
+5. **Permission model.** Reuse the existing `channels` resource per-source permission, no new permission key. Agree?
+
+---
+
+## 6. Risk register
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `getChannels()` enumerate-until-error can be slow on devices with many channels | Low | Has a hard upper bound (firmware will error eventually). One-shot on connect, not on every poll. |
+| User edits a channel from the MeshCore CLI / other client out-of-band; we don't see the change | Medium | "Refresh from device" button in UI; periodic re-sync (every N minutes?) as a follow-up if it matters. Phase 1 covers the connect-time sync. |
+| Editing a channel name silently re-broadcasts the secret (since `setChannel` takes both) | Low | Documented; UI confirms "Save will resend the secret to the device" on edit. |
+| Schema mismatch — Meshtastic-only columns getting non-null values for MeshCore rows | Low | Repository layer enforces nulls for MeshCore-source rows; covered by tests. |
+| Channel index collision when adding a channel mid-edit (two users pressing "Add" at once) | Very low | Single-user product context; on conflict, the second write surfaces the device's rejection. |
+| Backward compat — existing MeshCore-source installs have no channel rows | None | Phase 1 sync creates them on next connect. |
+
+---
+
+## 7. File pointers
+
+| Concern | Path | Notes |
+|---|---|---|
+| MeshCore manager | `src/server/meshcoreManager.ts` | Where listChannels/setChannel/deleteChannel/syncChannelsFromDevice will live |
+| Native backend wrapper | `src/server/meshcoreNativeBackend.ts:22-34` | Expose meshcore.js channel methods |
+| meshcore.js channel impl | `~/.openclaw/workspace/meshcore.js/src/connection/connection.js:2077-2190` | Reference for what we're calling |
+| Channels schema | `src/db/schema/channels.ts` | No migration needed |
+| Channels repo | `src/db/repositories/channels.ts:228` | `cleanupInvalidChannels` needs softening |
+| Channels route | `src/server/routes/v1/channels.ts` | Add source-type branch in write path |
+| Configuration UI | `src/components/configuration/ChannelsConfigSection.tsx` | Add sourceType-conditional rendering, Add/Regenerate buttons |
+| MeshCore display | `src/components/MeshCore/MeshCoreChannelsView.tsx:23` | Replace hardcoded `PUBLIC_CHANNEL` |
+| Source-type lookup | `src/db/schema/sources.ts` | For `cleanupInvalidChannels` source-type check |

--- a/src/db/repositories/channels.test.ts
+++ b/src/db/repositories/channels.test.ts
@@ -21,8 +21,9 @@ import {
   mysqlAvailable,
 } from './test-utils.js';
 
-// SQL for creating the channels table per backend
-// Matches the schema after migration 023: surrogate pk + UNIQUE(sourceId, id)
+// SQL for creating the channels + sources tables per backend.
+// `sources` is required because cleanupInvalidChannels reads source.type to
+// exempt MeshCore-owned channels from the 0-7 slot cap.
 const SQLITE_CREATE = `
   CREATE TABLE IF NOT EXISTS channels (
     pk INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -37,7 +38,17 @@ const SQLITE_CREATE = `
     updatedAt INTEGER NOT NULL DEFAULT 0,
     sourceId TEXT,
     UNIQUE(sourceId, id)
-  )
+  );
+  CREATE TABLE IF NOT EXISTS sources (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    config TEXT NOT NULL DEFAULT '{}',
+    enabled INTEGER NOT NULL DEFAULT 1,
+    createdAt INTEGER NOT NULL DEFAULT 0,
+    updatedAt INTEGER NOT NULL DEFAULT 0,
+    createdBy INTEGER
+  );
 `;
 
 const POSTGRES_CREATE = `
@@ -55,7 +66,18 @@ const POSTGRES_CREATE = `
     "updatedAt" BIGINT NOT NULL DEFAULT 0,
     "sourceId" TEXT,
     UNIQUE ("sourceId", id)
-  )
+  );
+  DROP TABLE IF EXISTS sources CASCADE;
+  CREATE TABLE sources (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    config TEXT NOT NULL DEFAULT '{}',
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" BIGINT NOT NULL DEFAULT 0,
+    "updatedAt" BIGINT NOT NULL DEFAULT 0,
+    "createdBy" INTEGER
+  );
 `;
 
 const MYSQL_CREATE = `
@@ -73,7 +95,18 @@ const MYSQL_CREATE = `
     updatedAt BIGINT NOT NULL DEFAULT 0,
     sourceId VARCHAR(36),
     UNIQUE KEY channels_source_id_uniq (sourceId, id)
-  )
+  );
+  DROP TABLE IF EXISTS sources;
+  CREATE TABLE sources (
+    id VARCHAR(36) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    type VARCHAR(32) NOT NULL,
+    config VARCHAR(4096) NOT NULL DEFAULT '{}',
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    createdAt BIGINT NOT NULL DEFAULT 0,
+    updatedAt BIGINT NOT NULL DEFAULT 0,
+    createdBy INT
+  );
 `;
 
 /**
@@ -292,6 +325,42 @@ function runChannelsTests(getBackend: () => TestBackend) {
     expect(await repo.getChannelCount()).toBe(2);
   });
 
+  it('cleanupInvalidChannels - preserves out-of-range channels owned by a MeshCore source', async () => {
+    // MeshCore devices report a device-dependent number of channels; the 0-7
+    // slot cap is a Meshtastic-only convention. cleanupInvalidChannels must
+    // only apply the cap to Meshtastic-owned (or unscoped) channels.
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    // Set up two sources: one MeshCore, one Meshtastic.
+    await backend.exec(`INSERT INTO sources (id, name, type, config) VALUES ('mc-1', 'My MeshCore', 'meshcore', '{}')`);
+    await backend.exec(`INSERT INTO sources (id, name, type, config) VALUES ('mt-1', 'My Meshtastic', 'meshtastic_tcp', '{}')`);
+
+    // MeshCore source has a channel at idx 8 (legal for its device).
+    await backend.exec(`INSERT INTO channels (id, name, psk, sourceId) VALUES (8, 'MC-Eight', 'aGVsbG8=', 'mc-1')`);
+    // Meshtastic source has an invalid channel at idx 8 (should be removed).
+    await backend.exec(`INSERT INTO channels (id, name, psk, sourceId) VALUES (8, 'MT-Eight', 'aGVsbG8=', 'mt-1')`);
+    // A legacy NULL-sourceId channel at idx 9 (implicitly Meshtastic; should be removed).
+    await backend.exec(`INSERT INTO channels (id, name, psk) VALUES (9, 'Legacy-Nine', 'aGVsbG8=')`);
+
+    expect(await repo.getChannelCount()).toBe(3);
+
+    const deleted = await repo.cleanupInvalidChannels();
+    expect(deleted).toBe(2);
+
+    // MeshCore row survived.
+    const survivor = await repo.getChannelById(8, 'mc-1');
+    expect(survivor).not.toBeNull();
+    expect(survivor!.name).toBe('MC-Eight');
+
+    // Meshtastic row + legacy row gone.
+    expect(await repo.getChannelById(8, 'mt-1')).toBeNull();
+    expect(await repo.getChannelById(9)).toBeNull();
+  });
+
   it('cleanupEmptyChannels - removes channels with id > 1 and no psk/role', async () => {
     const backend = getBackend();
     if (!backend.available) {
@@ -394,6 +463,7 @@ describe.skipIf(!postgresAvailable)('ChannelsRepository - PostgreSQL Backend', (
   beforeEach(async () => {
     if (!backend.available) return;
     await clearTable(backend, 'channels');
+    await clearTable(backend, 'sources');
   });
 
   runChannelsTests(() => backend);
@@ -421,6 +491,7 @@ describe.skipIf(!mysqlAvailable)('ChannelsRepository - MySQL Backend', () => {
   beforeEach(async () => {
     if (!backend.available) return;
     await clearTable(backend, 'channels');
+    await clearTable(backend, 'sources');
   });
 
   runChannelsTests(() => backend);

--- a/src/db/repositories/channels.test.ts
+++ b/src/db/repositories/channels.test.ts
@@ -335,14 +335,20 @@ function runChannelsTests(getBackend: () => TestBackend) {
       return;
     }
 
+    // PostgreSQL preserves camelCase only when the identifier is double-quoted;
+    // MySQL's default sql_mode treats "..." as a string literal, not an
+    // identifier. So `sourceId` needs dialect-specific quoting on the raw SQL
+    // path. SQLite is happy either way.
+    const sourceIdCol = backend.dbType === 'postgres' ? '"sourceId"' : 'sourceId';
+
     // Set up two sources: one MeshCore, one Meshtastic.
     await backend.exec(`INSERT INTO sources (id, name, type, config) VALUES ('mc-1', 'My MeshCore', 'meshcore', '{}')`);
     await backend.exec(`INSERT INTO sources (id, name, type, config) VALUES ('mt-1', 'My Meshtastic', 'meshtastic_tcp', '{}')`);
 
     // MeshCore source has a channel at idx 8 (legal for its device).
-    await backend.exec(`INSERT INTO channels (id, name, psk, sourceId) VALUES (8, 'MC-Eight', 'aGVsbG8=', 'mc-1')`);
+    await backend.exec(`INSERT INTO channels (id, name, psk, ${sourceIdCol}) VALUES (8, 'MC-Eight', 'aGVsbG8=', 'mc-1')`);
     // Meshtastic source has an invalid channel at idx 8 (should be removed).
-    await backend.exec(`INSERT INTO channels (id, name, psk, sourceId) VALUES (8, 'MT-Eight', 'aGVsbG8=', 'mt-1')`);
+    await backend.exec(`INSERT INTO channels (id, name, psk, ${sourceIdCol}) VALUES (8, 'MT-Eight', 'aGVsbG8=', 'mt-1')`);
     // A legacy NULL-sourceId channel at idx 9 (implicitly Meshtastic; should be removed).
     await backend.exec(`INSERT INTO channels (id, name, psk) VALUES (9, 'Legacy-Nine', 'aGVsbG8=')`);
 

--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -4,7 +4,7 @@
  * Handles all channel-related database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, and, gt, isNull, or, lt, count } from 'drizzle-orm';
+import { eq, and, gt, isNull, or, lt, count, notInArray } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbChannel } from '../types.js';
 import { logger } from '../../utils/logger.js';
@@ -222,18 +222,37 @@ export class ChannelsRepository extends BaseRepository {
   }
 
   /**
-   * Clean up invalid channels that shouldn't have been created
-   * Meshtastic supports channels 0-7 (8 total channels)
+   * Clean up invalid channels that shouldn't have been created.
+   *
+   * The 0-7 slot cap is a Meshtastic-only constraint (8 channels per device).
+   * MeshCore devices report a device-dependent number of channels enumerated
+   * by index — we must not delete those rows just because they fall outside
+   * the Meshtastic range. The cap is therefore applied only to channels whose
+   * owning source is a Meshtastic source, or whose source is unset (legacy
+   * pre-multi-source rows are implicitly Meshtastic).
    */
   async cleanupInvalidChannels(): Promise<number> {
-    const { channels } = this.tables;
-    const whereClause = or(lt(channels.id, 0), gt(channels.id, 7));
+    const { channels, sources } = this.tables;
+
+    // Collect source IDs whose source-type is NOT Meshtastic. Channels owned
+    // by these sources are exempt from the 0-7 slot cap.
+    const nonMeshtasticRows = await this.db
+      .select({ id: sources.id })
+      .from(sources)
+      .where(eq(sources.type, 'meshcore'));
+    const exemptSourceIds = nonMeshtasticRows.map((r: { id: string }) => r.id).filter(Boolean);
+
+    const outOfRange = or(lt(channels.id, 0), gt(channels.id, 7));
+    const whereClause = exemptSourceIds.length > 0
+      ? and(outOfRange, or(isNull(channels.sourceId), notInArray(channels.sourceId, exemptSourceIds)))
+      : outOfRange;
+
     const result = await this.db.select({ count: count() }).from(channels).where(whereClause);
     const deleteCount = Number(result[0].count);
     if (deleteCount > 0) {
       await this.db.delete(channels).where(whereClause);
     }
-    logger.debug(`Cleaned up ${deleteCount} invalid channels (outside 0-7 range)`);
+    logger.debug(`Cleaned up ${deleteCount} invalid channels (outside 0-7 range, Meshtastic-owned only)`);
     return deleteCount;
   }
 

--- a/src/server/meshcoreManager.channels.test.ts
+++ b/src/server/meshcoreManager.channels.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for MeshCoreManager channel CRUD + sync.
+ *
+ * The manager exposes:
+ *   - listChannels() — pulls the channel list from the device via `get_channels`.
+ *   - setChannel(idx, name, secretHex) — writes via `set_channel` and re-syncs DB.
+ *   - deleteChannel(idx) — writes via `delete_channel` and re-syncs DB.
+ *   - syncChannelsFromDevice() — mirrors the device's channel list into the
+ *     shared `channels` table (Meshtastic-only columns left null).
+ *
+ * These tests use the same private-method-stubbing pattern as
+ * meshcoreManager.telemetry.test.ts to exercise the logic without spinning up
+ * a real native backend.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+import databaseService from '../services/database.js';
+
+interface BridgeCall {
+  cmd: string;
+  params: Record<string, unknown>;
+}
+
+function makeManager(opts: {
+  deviceType?: MeshCoreDeviceType;
+  getChannelsResponse?: { success: boolean; data?: unknown; error?: string };
+  failOnSet?: boolean;
+}): { manager: MeshCoreManager; bridgeCalls: BridgeCall[]; upsertCalls: Array<{ data: any; sourceId: string | undefined; opts: any }> } {
+  const deviceType = opts.deviceType ?? MeshCoreDeviceType.COMPANION;
+  const m = new MeshCoreManager('test-source');
+  // Force the device type so the manager doesn't short-circuit on the
+  // "not connected" branch — the same trick the existing telemetry tests use.
+  (m as any).deviceType = deviceType;
+
+  const bridgeCalls: BridgeCall[] = [];
+  const upsertCalls: Array<{ data: any; sourceId: string | undefined; opts: any }> = [];
+
+  const defaultGetChannels = {
+    success: true,
+    data: [
+      { channel_idx: 0, name: 'Public', secret_hex: '00112233445566778899aabbccddeeff' },
+      { channel_idx: 1, name: 'Private', secret_hex: 'ffeeddccbbaa99887766554433221100' },
+    ],
+  };
+
+  // Stub the private bridge transport.
+  (m as any).sendBridgeCommand = async (cmd: string, params: Record<string, unknown>) => {
+    bridgeCalls.push({ cmd, params });
+    if (cmd === 'get_channels') {
+      return { id: '1', ...(opts.getChannelsResponse ?? defaultGetChannels) };
+    }
+    if (cmd === 'set_channel') {
+      if (opts.failOnSet) {
+        return { id: '1', success: false, error: 'firmware rejected' };
+      }
+      return { id: '1', success: true, data: { ok: true } };
+    }
+    if (cmd === 'delete_channel') {
+      return { id: '1', success: true, data: { ok: true } };
+    }
+    return { id: '1', success: true, data: {} };
+  };
+
+  // Stub the channels repository on the shared databaseService singleton.
+  // We don't initialise a real DB here — this is a pure unit test.
+  vi.spyOn(databaseService, 'channels', 'get').mockReturnValue({
+    upsertChannel: vi.fn(async (data: any, sourceId?: string, opts?: any) => {
+      upsertCalls.push({ data, sourceId, opts });
+    }),
+  } as any);
+
+  return { manager: m, bridgeCalls, upsertCalls };
+}
+
+describe('MeshCoreManager — listChannels', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns [] when device is not in Companion mode', async () => {
+    const { manager, bridgeCalls } = makeManager({ deviceType: MeshCoreDeviceType.REPEATER });
+    const list = await manager.listChannels();
+    expect(list).toEqual([]);
+    // Repeater short-circuits before issuing any bridge command.
+    expect(bridgeCalls).toHaveLength(0);
+  });
+
+  it('maps wire-shaped rows into MeshCoreChannel objects', async () => {
+    const { manager, bridgeCalls } = makeManager({});
+    const list = await manager.listChannels();
+    expect(bridgeCalls).toEqual([{ cmd: 'get_channels', params: {} }]);
+    expect(list).toEqual([
+      { channelIdx: 0, name: 'Public', secretHex: '00112233445566778899aabbccddeeff' },
+      { channelIdx: 1, name: 'Private', secretHex: 'ffeeddccbbaa99887766554433221100' },
+    ]);
+  });
+
+  it('throws when the bridge response is not successful', async () => {
+    const { manager } = makeManager({
+      getChannelsResponse: { success: false, error: 'transport closed' },
+    });
+    await expect(manager.listChannels()).rejects.toThrow('transport closed');
+  });
+});
+
+describe('MeshCoreManager — syncChannelsFromDevice', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('upserts each channel into the shared channels table with sourceId scoping', async () => {
+    const { manager, upsertCalls } = makeManager({});
+    await manager.syncChannelsFromDevice();
+
+    expect(upsertCalls).toHaveLength(2);
+
+    // Channel 0 — base64 of the 16 hex bytes 00112233445566778899aabbccddeeff
+    expect(upsertCalls[0].data).toMatchObject({
+      id: 0,
+      name: 'Public',
+      psk: Buffer.from('00112233445566778899aabbccddeeff', 'hex').toString('base64'),
+      role: null,
+      uplinkEnabled: null,
+      downlinkEnabled: null,
+      positionPrecision: null,
+    });
+    expect(upsertCalls[0].sourceId).toBe('test-source');
+    expect(upsertCalls[0].opts).toEqual({ allowBlankName: true });
+
+    // Channel 1
+    expect(upsertCalls[1].data).toMatchObject({
+      id: 1,
+      name: 'Private',
+      psk: Buffer.from('ffeeddccbbaa99887766554433221100', 'hex').toString('base64'),
+    });
+  });
+
+  it('handles an empty channel list without throwing', async () => {
+    const { manager, upsertCalls } = makeManager({
+      getChannelsResponse: { success: true, data: [] },
+    });
+    await manager.syncChannelsFromDevice();
+    expect(upsertCalls).toHaveLength(0);
+  });
+
+  it('stores psk as null when the device reports an empty secret', async () => {
+    const { manager, upsertCalls } = makeManager({
+      getChannelsResponse: {
+        success: true,
+        data: [{ channel_idx: 0, name: 'OpenChannel', secret_hex: '' }],
+      },
+    });
+    await manager.syncChannelsFromDevice();
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0].data.psk).toBeNull();
+  });
+});
+
+describe('MeshCoreManager — setChannel / deleteChannel', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('setChannel passes idx + name + secret_hex and then re-syncs', async () => {
+    const { manager, bridgeCalls, upsertCalls } = makeManager({});
+    await manager.setChannel(2, 'New', 'aabbccddeeff00112233445566778899');
+
+    // First the set_channel write, then a get_channels re-sync.
+    expect(bridgeCalls.map((c) => c.cmd)).toEqual(['set_channel', 'get_channels']);
+    expect(bridgeCalls[0].params).toEqual({
+      idx: 2,
+      name: 'New',
+      secret_hex: 'aabbccddeeff00112233445566778899',
+    });
+    // Re-sync upserts the (mocked) channel list (Public + Private from the default fixture).
+    expect(upsertCalls.length).toBeGreaterThan(0);
+  });
+
+  it('setChannel throws when device is not Companion', async () => {
+    const { manager } = makeManager({ deviceType: MeshCoreDeviceType.REPEATER });
+    await expect(manager.setChannel(0, 'x', '00'.repeat(16))).rejects.toThrow(/Companion mode/);
+  });
+
+  it('setChannel surfaces firmware errors instead of swallowing them', async () => {
+    const { manager } = makeManager({ failOnSet: true });
+    await expect(manager.setChannel(0, 'x', '00'.repeat(16))).rejects.toThrow('firmware rejected');
+  });
+
+  it('deleteChannel passes idx and then re-syncs', async () => {
+    const { manager, bridgeCalls } = makeManager({});
+    await manager.deleteChannel(3);
+    expect(bridgeCalls.map((c) => c.cmd)).toEqual(['delete_channel', 'get_channels']);
+    expect(bridgeCalls[0].params).toEqual({ idx: 3 });
+  });
+
+  it('deleteChannel throws when device is not Companion', async () => {
+    const { manager } = makeManager({ deviceType: MeshCoreDeviceType.REPEATER });
+    await expect(manager.deleteChannel(0)).rejects.toThrow(/Companion mode/);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -10,6 +10,7 @@
 
 import { EventEmitter } from 'events';
 import { logger } from '../utils/logger.js';
+import databaseService from '../services/database.js';
 import { dataEventEmitter } from './services/dataEventEmitter.js';
 import { MeshCoreNativeBackend, type BridgeShapedEvent } from './meshcoreNativeBackend.js';
 
@@ -160,6 +161,19 @@ export interface MeshCoreStatus {
   radioBw?: number;
   radioSf?: number;
   radioCr?: number;
+}
+
+/**
+ * A single channel slot on a MeshCore device. The wire model is just
+ * { channelIdx, name, secret(16 bytes) } — see meshcore.js connection.js:605.
+ * The secret travels as a hex string in our API for human readability;
+ * we re-encode to base64 when mirroring into the shared `channels.psk` column.
+ */
+export interface MeshCoreChannel {
+  channelIdx: number;
+  name: string;
+  /** 32-char lowercase hex (16 bytes). Empty string if the firmware reports an empty slot. */
+  secretHex: string;
 }
 
 /**
@@ -324,6 +338,16 @@ class MeshCoreManager extends EventEmitter {
       // Get initial info
       await this.refreshLocalNode();
       await this.refreshContacts();
+      // Pull the device's channel list and mirror it into the DB. MeshCore has
+      // no push event for channel changes, so re-sync is connect-time and
+      // after every local write. Failure here is non-fatal.
+      if (this.deviceType === MeshCoreDeviceType.COMPANION) {
+        try {
+          await this.syncChannelsFromDevice();
+        } catch (err) {
+          logger.warn(`[MeshCore:${this.sourceId}] syncChannelsFromDevice failed: ${(err as Error).message}`);
+        }
+      }
 
       this.connected = true;
       this.connectionState = 'connected';
@@ -536,6 +560,97 @@ class MeshCoreManager extends EventEmitter {
   /** Generate a synthetic public key identifier for channel messages */
   private static channelPublicKey(channelIdx: number): string {
     return `channel-${channelIdx}`;
+  }
+
+  // ============ Channel CRUD ============
+
+  /**
+   * Read the channel list from the device. Channels are returned in the order
+   * the firmware reports them (typically ascending channelIdx). Companion mode
+   * only — Repeater firmware doesn't expose a channel API over the CLI.
+   */
+  async listChannels(): Promise<MeshCoreChannel[]> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
+      return [];
+    }
+    const response = await this.sendBridgeCommand('get_channels', {});
+    if (!response.success) {
+      throw new Error(response.error || 'get_channels failed');
+    }
+    const list: Array<{ channel_idx: number; name: string; secret_hex: string }> =
+      Array.isArray(response.data) ? response.data : [];
+    return list.map((row) => ({
+      channelIdx: row.channel_idx,
+      name: row.name ?? '',
+      secretHex: row.secret_hex ?? '',
+    }));
+  }
+
+  /**
+   * Write a channel slot on the device. `secretHex` must decode to 16 bytes
+   * (AES-128). Re-syncs the DB from the device afterwards so any side-effect
+   * (e.g. the firmware normalising the name) is reflected immediately.
+   */
+  async setChannel(idx: number, name: string, secretHex: string): Promise<void> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
+      throw new Error('setChannel: MeshCore source is not in Companion mode');
+    }
+    const response = await this.sendBridgeCommand('set_channel', {
+      idx,
+      name,
+      secret_hex: secretHex,
+    });
+    if (!response.success) {
+      throw new Error(response.error || 'set_channel failed');
+    }
+    await this.syncChannelsFromDevice();
+  }
+
+  /**
+   * Delete a channel slot on the device. Re-syncs the DB from the device
+   * afterwards so the local mirror reflects the firmware's view.
+   */
+  async deleteChannel(idx: number): Promise<void> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
+      throw new Error('deleteChannel: MeshCore source is not in Companion mode');
+    }
+    const response = await this.sendBridgeCommand('delete_channel', { idx });
+    if (!response.success) {
+      throw new Error(response.error || 'delete_channel failed');
+    }
+    await this.syncChannelsFromDevice();
+  }
+
+  /**
+   * Read the device's channel list and mirror it into the shared `channels`
+   * table, scoped by this manager's sourceId. The 16-byte AES secret is
+   * stored base64-encoded in the existing `psk` column. Meshtastic-only
+   * columns (role, uplinkEnabled, downlinkEnabled, positionPrecision) are
+   * left null for MeshCore rows.
+   *
+   * MeshCore has no push event for channel changes, so callers should invoke
+   * this on connect and after every local write.
+   */
+  async syncChannelsFromDevice(): Promise<void> {
+    const channels = await this.listChannels();
+    for (const ch of channels) {
+      const pskBase64 = ch.secretHex ? Buffer.from(ch.secretHex, 'hex').toString('base64') : null;
+      await databaseService.channels.upsertChannel(
+        {
+          id: ch.channelIdx,
+          name: ch.name,
+          psk: pskBase64,
+          // Meshtastic-only fields explicitly nulled for MeshCore rows
+          role: null,
+          uplinkEnabled: null,
+          downlinkEnabled: null,
+          positionPrecision: null,
+        },
+        this.sourceId,
+        { allowBlankName: true },
+      );
+    }
+    logger.debug(`[MeshCore:${this.sourceId}] Synced ${channels.length} channel(s) from device`);
   }
 
   // ============ Direct Serial Methods (for Repeater) ============

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -180,6 +180,21 @@ class MockConnection extends EventEmitter {
   async syncNextMessage() {
     return this.syncNextMessageQueue.shift() ?? null;
   }
+
+  // Channels — meshcore.js Connection.getChannels iterates until the device
+  // errors. Our mock just returns a programmable array.
+  public channelsResponse: Array<{ channelIdx: number; name: string; secret: Uint8Array }> = [];
+  public setChannelCalls: Array<{ idx: number; name: string; secret: Uint8Array }> = [];
+  public deleteChannelCalls: number[] = [];
+  async getChannels() {
+    return this.channelsResponse;
+  }
+  async setChannel(idx: number, name: string, secret: Uint8Array) {
+    this.setChannelCalls.push({ idx, name, secret });
+  }
+  async deleteChannel(idx: number) {
+    this.deleteChannelCalls.push(idx);
+  }
 }
 
 function installMockModule(MockConn: typeof MockConnection): MockConnection {
@@ -490,6 +505,103 @@ describe('MeshCoreNativeBackend', () => {
     const resp = await backend.sendCommand('get_device_time', {}, 50);
     expect(resp.success).toBe(false);
     expect(resp.error).toMatch(/timeout/i);
+  });
+
+  // ---------- channel commands ----------
+
+  it('get_channels maps meshcore.js rows to snake_case bridge shape with hex secret', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    conn.channelsResponse = [
+      {
+        channelIdx: 0,
+        name: 'Public',
+        secret: Uint8Array.from([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99]),
+      },
+      {
+        channelIdx: 1,
+        name: 'Private',
+        secret: new Uint8Array(16),
+      },
+    ];
+
+    const resp = await backend.sendCommand('get_channels', {});
+    expect(resp.success).toBe(true);
+    expect(resp.data).toEqual([
+      { channel_idx: 0, name: 'Public', secret_hex: 'aabbccddeeff00112233445566778899' },
+      { channel_idx: 1, name: 'Private', secret_hex: '00'.repeat(16) },
+    ]);
+  });
+
+  it('set_channel passes idx + name + decoded 16-byte secret to the connection', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+
+    const resp = await backend.sendCommand('set_channel', {
+      idx: 2,
+      name: 'New',
+      secret_hex: 'aabbccddeeff00112233445566778899',
+    });
+    expect(resp.success).toBe(true);
+    expect(conn.setChannelCalls).toHaveLength(1);
+    expect(conn.setChannelCalls[0].idx).toBe(2);
+    expect(conn.setChannelCalls[0].name).toBe('New');
+    expect(conn.setChannelCalls[0].secret.length).toBe(16);
+    expect(Array.from(conn.setChannelCalls[0].secret).map((b) => b.toString(16).padStart(2, '0')).join(''))
+      .toBe('aabbccddeeff00112233445566778899');
+  });
+
+  it('set_channel rejects a non-16-byte secret', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+
+    const resp = await backend.sendCommand('set_channel', {
+      idx: 0,
+      name: 'TooShort',
+      secret_hex: 'aabb', // 1 byte, not 16
+    });
+    expect(resp.success).toBe(false);
+    expect(resp.error).toMatch(/must be 16 bytes/);
+  });
+
+  it('set_channel rejects an out-of-range index', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+
+    const resp = await backend.sendCommand('set_channel', {
+      idx: 999,
+      name: 'OutOfRange',
+      secret_hex: '00'.repeat(16),
+    });
+    expect(resp.success).toBe(false);
+    expect(resp.error).toMatch(/Invalid channel index/);
+  });
+
+  it('delete_channel passes idx to the connection', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+
+    const resp = await backend.sendCommand('delete_channel', { idx: 4 });
+    expect(resp.success).toBe(true);
+    expect(conn.deleteChannelCalls).toEqual([4]);
   });
 });
 

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -463,6 +463,39 @@ export class MeshCoreNativeBackend extends EventEmitter {
         return { records };
       }
 
+      case 'get_channels': {
+        const list: any[] = await c.getChannels();
+        return list.map((ch) => ({
+          channel_idx: ch.channelIdx,
+          name: typeof ch.name === 'string' ? ch.name : String(ch.name ?? ''),
+          secret_hex: ch.secret ? bytesToHex(ch.secret) : '',
+        }));
+      }
+
+      case 'set_channel': {
+        const idx = Number(params.idx);
+        const name = String(params.name ?? '');
+        const secretHex = String(params.secret_hex ?? '');
+        if (!Number.isInteger(idx) || idx < 0 || idx > 255) {
+          throw new Error(`Invalid channel index: ${idx}`);
+        }
+        const secret = Uint8Array.from(hexToBytes(secretHex));
+        if (secret.length !== 16) {
+          throw new Error(`Channel secret must be 16 bytes, got ${secret.length}`);
+        }
+        await c.setChannel(idx, name, secret);
+        return { ok: true };
+      }
+
+      case 'delete_channel': {
+        const idx = Number(params.idx);
+        if (!Number.isInteger(idx) || idx < 0 || idx > 255) {
+          throw new Error(`Invalid channel index: ${idx}`);
+        }
+        await c.deleteChannel(idx);
+        return { ok: true };
+      }
+
       case 'shutdown':
         await this.disconnect();
         return { ok: true };


### PR DESCRIPTION
Phase 1 of 3 for MeshCore channels support. See [`docs/meshcore-channels-plan.md`](./docs/meshcore-channels-plan.md) for the full plan.

## Summary

Wires meshcore.js's channel API (`getChannels` / `setChannel` / `deleteChannel`) into `MeshCoreManager` and mirrors the device's channel list into the shared `channels` table on connect. Phases 2 and 3 (display + Configuration UI) are separate PRs.

## What changed

- **`meshcoreNativeBackend.ts`** — three new bridge-shaped commands: `get_channels`, `set_channel`, `delete_channel`. `set_channel` validates idx range and that the hex-encoded secret decodes to exactly 16 bytes (AES-128).
- **`meshcoreManager.ts`** — public `listChannels()`, `setChannel(idx, name, secretHex)`, `deleteChannel(idx)`, plus a private `syncChannelsFromDevice()` that runs after `refreshContacts` on the Companion connect path. Failure is non-fatal so a half-configured device still connects.
- **`channels` repository** — `cleanupInvalidChannels` is now source-type aware. The 0–7 slot cap is a Meshtastic-only convention; MeshCore devices report a device-dependent number of channels. Channels owned by a MeshCore source are exempt; Meshtastic-owned and legacy NULL-`sourceId` rows still get the cap applied.

## Why this design

- **Reused the existing `channels` table**, no schema migration. Shared fields (`id`, `name`, `psk`, `sourceId`) map 1:1 to MeshCore's `{channelIdx, name, secret}`. Meshtastic-only fields stay `NULL` for MeshCore rows.
- **AES-128 secret stored as base64** in the existing `psk` column. The wire/API form stays hex (matches the MeshCore CLI convention).
- **No push events** in MeshCore for channel changes, so we sync on connect and after every local write. A "refresh from device" UI affordance can be added later if out-of-band edits become a pain point.

## Test plan

- [x] `npx vitest run` — **4943 PASS / 0 FAIL** (+17 new tests over main)
- [x] `npm run build` — clean
- [x] `tsc --noEmit -p tsconfig.server.json` — clean
- [x] Lint error count unchanged from main (650 pre-existing)
- [ ] Manual: connect a MeshCore Companion device, confirm `SELECT * FROM channels WHERE sourceId = '<mc-source>'` reflects the device's channel list after connect

## New tests

- `meshcoreNativeBackend.test.ts` — get_channels mapping, set_channel validation (idx range, 16-byte secret), delete_channel pass-through
- `meshcoreManager.channels.test.ts` (new file) — listChannels, setChannel/deleteChannel re-sync, syncChannelsFromDevice shape + scoping + empty-secret handling
- `channels.test.ts` (repo) — new "preserves out-of-range channels owned by a MeshCore source" case

## Not in this PR (phases 2 & 3)

- Reading the synced channel list in `MeshCoreChannelsView` (still hardcoded to one "Public" channel)
- Configuration UI for create/edit/delete
- Source-type-aware rendering in `ChannelsConfigSection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)