### PR TITLE
Open changelog links in new tab

### DIFF
--- a/src/components/NewsPopup/NewsPopup.tsx
+++ b/src/components/NewsPopup/NewsPopup.tsx
@@ -266,7 +266,16 @@ export const NewsPopup: React.FC<NewsPopupProps> = ({
             <h3 className="news-item-title">{currentItem.title}</h3>
 
             <div className="news-item-content">
-              <ReactMarkdown>{currentItem.content}</ReactMarkdown>
+              <ReactMarkdown
+                components={{
+                  a(props) {
+                    const { node: _node, ...rest } = props;
+                    return <a {...rest} target="_blank" rel="noopener noreferrer" />;
+                  },
+                }}
+              >
+                {currentItem.content}
+              </ReactMarkdown>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Adds a custom `a` component renderer to `ReactMarkdown` in `NewsPopup.tsx` so all links in news/changelog items (e.g. GitHub PR/issue links like `#3014`) open in a new browser tab instead of navigating away from the app.
- Uses `target="_blank"` with `rel="noopener noreferrer"` for security best-practice.

Closes #3035

## Test plan

- [ ] Open the News popup from the sidebar
- [ ] Click a GitHub PR/issue link — it should open in a new tab
- [ ] Verify the app remains open in the original tab

https://claude.ai/code/session_014hgBmRufMjtP8wWFmgpRUD

---
_Generated by [Claude Code](https://claude.ai/code/session_014hgBmRufMjtP8wWFmgpRUD)_