### PR TITLE
feat(meshcore): display device channels in MeshCoreChannelsView (phase 2/3, relanded)

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for MeshCoreChannelsView phase 2:
+ *   - reads the channel list from /api/channels/all?sourceId=...
+ *   - falls back to a synthetic Channel 0 when the API returns nothing
+ *   - filters messages per channel (received + locally-sent)
+ *   - passes the active channelIdx to actions.sendMessage on broadcast
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>, vars?: Record<string, unknown>) => {
+      // Mimic i18next interpolation for the {{idx}} placeholder used by the
+      // "unnamed channel" fallback so tests can assert on the rendered string.
+      if (typeof fallback === 'string') {
+        if (vars && typeof vars === 'object') {
+          return fallback.replace(/\{\{(\w+)\}\}/g, (_m, k) => String((vars as any)[k] ?? ''));
+        }
+        return fallback;
+      }
+      // when fallback was actually an interpolation `values` object, return key
+      return key;
+    },
+  }),
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: () => true }),
+}));
+
+const csrfFetchMock = vi.fn();
+vi.mock('../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => csrfFetchMock,
+}));
+
+import { MeshCoreChannelsView } from './MeshCoreChannelsView';
+import type { MeshCoreActions, ConnectionStatus, MeshCoreMessage } from './hooks/useMeshCore';
+import type { MeshCoreContact } from '../../utils/meshcoreHelpers';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function makeActions(overrides: Partial<MeshCoreActions> = {}): MeshCoreActions {
+  return {
+    connect: vi.fn().mockResolvedValue(true),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    refreshContacts: vi.fn().mockResolvedValue(undefined),
+    sendAdvert: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue(true),
+    setDeviceName: vi.fn().mockResolvedValue(true),
+    setRadioParams: vi.fn().mockResolvedValue(true),
+    setCoords: vi.fn().mockResolvedValue(true),
+    setAdvertLocPolicy: vi.fn().mockResolvedValue(true),
+    setTelemetryModeBase: vi.fn().mockResolvedValue(true),
+    setTelemetryModeLoc: vi.fn().mockResolvedValue(true),
+    setTelemetryModeEnv: vi.fn().mockResolvedValue(true),
+    refreshAll: vi.fn().mockResolvedValue(undefined),
+    clearError: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeStatus(): ConnectionStatus {
+  return {
+    connected: true,
+    deviceType: 1,
+    deviceTypeName: 'companion',
+    config: null,
+    localNode: { publicKey: 'local-pubkey'.padEnd(64, '0'), name: 'self', advType: 1 },
+  };
+}
+
+const contacts: MeshCoreContact[] = [];
+
+beforeEach(() => {
+  csrfFetchMock.mockReset();
+});
+
+describe('MeshCoreChannelsView — channel list rendering', () => {
+  it('renders a tab for each channel returned by /api/channels/all', async () => {
+    csrfFetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        { id: 0, name: 'Public' },
+        { id: 1, name: 'Town' },
+        { id: 2, name: 'Operators' },
+      ]),
+    );
+
+    render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('# Public')).toBeTruthy();
+      expect(screen.getByText('# Town')).toBeTruthy();
+      expect(screen.getByText('# Operators')).toBeTruthy();
+    });
+
+    // Called the source-scoped /all endpoint.
+    expect(csrfFetchMock).toHaveBeenCalled();
+    const calledUrl = csrfFetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('/api/channels/all?sourceId=src-a');
+  });
+
+  it('falls back to a synthetic Public channel when the API returns nothing', async () => {
+    csrfFetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-empty"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('# Public')).toBeTruthy();
+    });
+  });
+
+  it('substitutes "Channel N" when the device reports a blank channel name', async () => {
+    csrfFetchMock.mockResolvedValueOnce(jsonResponse([
+      { id: 0, name: 'Public' },
+      { id: 5, name: '' }, // blank
+    ]));
+
+    render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('# Channel 5')).toBeTruthy();
+    });
+  });
+});
+
+describe('MeshCoreChannelsView — per-channel message filter', () => {
+  const messages: MeshCoreMessage[] = [
+    // Received on channel 0
+    { id: 'r0', fromPublicKey: 'channel-0', text: 'hi from chan 0', timestamp: 1000 },
+    // Received on channel 1
+    { id: 'r1', fromPublicKey: 'channel-1', text: 'hi from chan 1', timestamp: 1100 },
+    // Received on channel 2
+    { id: 'r2', fromPublicKey: 'channel-2', text: 'hi from chan 2', timestamp: 1200 },
+    // Local outbound to channel 1 (phase-2 tagging via toPublicKey)
+    { id: 's1', fromPublicKey: 'local-pubkey'.padEnd(64, '0'), toPublicKey: 'channel-1', text: 'my reply on 1', timestamp: 1300 },
+    // Pre-phase-2 legacy local outbound (no toPublicKey) — should bucket into channel 0
+    { id: 's0-legacy', fromPublicKey: 'local-pubkey'.padEnd(64, '0'), text: 'legacy local on 0', timestamp: 1400 },
+    // A direct message — has a toPublicKey that is NOT channel-N, must not appear anywhere
+    { id: 'dm', fromPublicKey: 'cafe'.padEnd(64, '0'), toPublicKey: 'beef'.padEnd(64, '0'), text: 'private dm', timestamp: 1500 },
+  ];
+
+  beforeEach(() => {
+    csrfFetchMock.mockResolvedValue(
+      jsonResponse([
+        { id: 0, name: 'Public' },
+        { id: 1, name: 'Town' },
+        { id: 2, name: 'Operators' },
+      ]),
+    );
+  });
+
+  it('shows only channel-0 messages (received + legacy local) on the Public tab', async () => {
+    render(
+      <MeshCoreChannelsView
+        messages={messages}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => screen.getByText('# Public'));
+
+    // Default selected channel is 0.
+    expect(screen.getByText('hi from chan 0')).toBeTruthy();
+    expect(screen.getByText('legacy local on 0')).toBeTruthy();
+    expect(screen.queryByText('hi from chan 1')).toBeNull();
+    expect(screen.queryByText('hi from chan 2')).toBeNull();
+    expect(screen.queryByText('my reply on 1')).toBeNull();
+    expect(screen.queryByText('private dm')).toBeNull();
+  });
+
+  it('shows received + locally-sent messages on the Town (channel 1) tab', async () => {
+    render(
+      <MeshCoreChannelsView
+        messages={messages}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => screen.getByText('# Town'));
+    fireEvent.click(screen.getByText('# Town'));
+
+    expect(screen.getByText('hi from chan 1')).toBeTruthy();
+    expect(screen.getByText('my reply on 1')).toBeTruthy();
+    expect(screen.queryByText('hi from chan 0')).toBeNull();
+    expect(screen.queryByText('hi from chan 2')).toBeNull();
+    expect(screen.queryByText('legacy local on 0')).toBeNull();
+    expect(screen.queryByText('private dm')).toBeNull();
+  });
+});
+
+describe('MeshCoreChannelsView — sending', () => {
+  it('passes the active channel idx to actions.sendMessage', async () => {
+    csrfFetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        { id: 0, name: 'Public' },
+        { id: 2, name: 'Ops' },
+      ]),
+    );
+
+    const actions = makeActions();
+    render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={actions}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    await waitFor(() => screen.getByText('# Ops'));
+    fireEvent.click(screen.getByText('# Ops'));
+
+    const input = screen.getByPlaceholderText('Type a message…') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'channel ops msg' } });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Send'));
+    });
+
+    expect(actions.sendMessage).toHaveBeenCalledWith('channel ops msg', undefined, 2);
+  });
+});

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -1,5 +1,22 @@
-import React, { useMemo, useState } from 'react';
+/**
+ * MeshCoreChannelsView — per-channel message stream for a MeshCore source.
+ *
+ * Reads the channel list from `/api/channels?sourceId=<sourceId>` (mirrored
+ * by `MeshCoreManager.syncChannelsFromDevice` on connect — phase 1 of the
+ * MeshCore channels feature). Falls back to a synthetic "Channel 0" entry
+ * when no rows are available so the panel doesn't look broken before the
+ * first sync completes.
+ *
+ * Channel messaging on the wire is index-keyed (no per-sender pubkey for
+ * channel traffic — the firmware embeds the sender's name in the text body).
+ * MeshMonitor synthesises `fromPublicKey = 'channel-${idx}'` on receive
+ * (meshcoreManager.ts:561) and `toPublicKey = 'channel-${idx}'` on local
+ * send (meshcoreManager.ts:sendMessage, phase 2 addition). The per-channel
+ * filter therefore matches either direction.
+ */
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { MeshCoreMessage, MeshCoreActions, ConnectionStatus } from './hooks/useMeshCore';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
@@ -10,39 +27,115 @@ interface MeshCoreChannelsViewProps {
   contacts: MeshCoreContact[];
   status: ConnectionStatus | null;
   actions: MeshCoreActions;
+  baseUrl: string;
+  sourceId: string;
 }
 
-interface ChannelDef {
-  id: string;
+interface ChannelRow {
+  id: number;
   name: string;
-  filter: (m: MeshCoreMessage) => boolean;
-  /** When sending, the toPublicKey to use (undefined = broadcast). */
-  toPublicKey?: string;
 }
 
-const PUBLIC_CHANNEL: ChannelDef = {
-  id: 'public',
-  name: 'Public',
-  filter: m => !m.toPublicKey,
-  toPublicKey: undefined,
-};
+/** Synthesised pseudo-pubkey used to scope channel messages. Must match the
+ *  format that meshcoreManager generates server-side (`channel-${idx}`). */
+const channelKey = (idx: number) => `channel-${idx}`;
+
+/**
+ * Returns the messages that belong to the given channel index.
+ *
+ *  - Received: `fromPublicKey === channel-${idx}` (synthesised by the manager).
+ *  - Locally-sent: `toPublicKey === channel-${idx}` (phase-2 tagging).
+ *  - Legacy fallback for channel 0 only: pre-phase-2 outbound channel-0
+ *    messages had `toPublicKey === undefined`; treat any message with no
+ *    recipient AND no synthesised `channel-N` sender as channel 0 so old
+ *    rows still appear in the right tab.
+ */
+function buildChannelFilter(channelIdx: number): (m: MeshCoreMessage) => boolean {
+  const key = channelKey(channelIdx);
+  return (m) => {
+    if (m.fromPublicKey === key) return true;
+    if (m.toPublicKey === key) return true;
+    if (channelIdx === 0 && !m.toPublicKey && !m.fromPublicKey.startsWith('channel-')) {
+      return true;
+    }
+    return false;
+  };
+}
 
 export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   messages,
   contacts,
   status,
   actions,
+  baseUrl,
+  sourceId,
 }) => {
   const { t } = useTranslation();
+  const csrfFetch = useCsrfFetch();
   const { hasPermission } = useAuth();
   const canSend = hasPermission('messages', 'write');
-  const [selected, setSelected] = useState<string>('public');
-  const channels: ChannelDef[] = [PUBLIC_CHANNEL];
 
-  const active = channels.find(c => c.id === selected) ?? PUBLIC_CHANNEL;
+  const [channels, setChannels] = useState<ChannelRow[]>([]);
+  const [selectedIdx, setSelectedIdx] = useState<number>(0);
+  const [loadingChannels, setLoadingChannels] = useState(false);
+
+  // Fetch the synced channel list for this source. We use /api/channels/all
+  // (rather than /api/channels) so MeshCore rows with idx > 7 aren't dropped
+  // by the legacy Meshtastic-shaped 0-7 filter on the basic endpoint. The
+  // /all endpoint still goes through the per-row permission gate.
+  useEffect(() => {
+    if (!sourceId) return;
+    let cancelled = false;
+    setLoadingChannels(true);
+    (async () => {
+      try {
+        const url = `${baseUrl}/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`;
+        const response = await csrfFetch(url);
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const raw = await response.json();
+        const rows: ChannelRow[] = Array.isArray(raw)
+          ? raw
+              .filter((c: any) => typeof c?.id === 'number')
+              .map((c: any) => ({ id: c.id as number, name: String(c.name ?? '') }))
+              .sort((a, b) => a.id - b.id)
+          : [];
+        if (!cancelled) setChannels(rows);
+      } catch (err) {
+        if (!cancelled) {
+          console.error('Failed to fetch MeshCore channels:', err);
+          setChannels([]);
+        }
+      } finally {
+        if (!cancelled) setLoadingChannels(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  // Status connected→disconnected→connected transitions trigger a re-fetch so a
+  // freshly-synced channel list shows up without a full page reload.
+  }, [baseUrl, sourceId, csrfFetch, status?.connected]);
+
+  // Always include a synthetic "Channel 0" placeholder when the device hasn't
+  // reported any channels yet — keeps the view usable on first connect, and
+  // gives the user something to chat in if the firmware ships with a default
+  // primary channel that hasn't been read yet.
+  const displayChannels: ChannelRow[] = useMemo(() => {
+    if (channels.length > 0) return channels;
+    return [{ id: 0, name: t('meshcore.channels.public_fallback', 'Public') }];
+  }, [channels, t]);
+
+  // Keep `selectedIdx` valid if channels change underneath us.
+  useEffect(() => {
+    if (displayChannels.length === 0) return;
+    if (!displayChannels.some(c => c.id === selectedIdx)) {
+      setSelectedIdx(displayChannels[0].id);
+    }
+  }, [displayChannels, selectedIdx]);
+
+  const active = displayChannels.find(c => c.id === selectedIdx) ?? displayChannels[0];
+  const activeFilter = useMemo(() => buildChannelFilter(active.id), [active.id]);
   const filtered = useMemo(
-    () => messages.filter(active.filter),
-    [messages, active],
+    () => messages.filter(activeFilter),
+    [messages, activeFilter],
   );
 
   const selfKey = status?.localNode?.publicKey;
@@ -53,23 +146,34 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
       <div className="meshcore-list-pane">
         <div className="meshcore-list-pane-header">
           <span>{t('meshcore.nav.channels', 'Channels')}</span>
-          <span className="pane-count">{channels.length}</span>
+          <span className="pane-count">{displayChannels.length}</span>
         </div>
         <div className="meshcore-list-pane-body">
-          {channels.map(c => (
-            <button
-              key={c.id}
-              className={`mc-channel-row ${active.id === c.id ? 'selected' : ''}`}
-              onClick={() => setSelected(c.id)}
-            >
+          {loadingChannels && channels.length === 0 && (
+            <div className="mc-channel-row" aria-busy="true">
               <div className="mc-channel-row-name">
-                # {c.name}
+                {t('meshcore.channels.loading', 'Loading channels…')}
               </div>
-              <div className="mc-channel-row-meta">
-                {messages.filter(c.filter).length} {t('meshcore.messages', 'messages')}
-              </div>
-            </button>
-          ))}
+            </div>
+          )}
+          {displayChannels.map(c => {
+            const filter = buildChannelFilter(c.id);
+            const count = messages.filter(filter).length;
+            return (
+              <button
+                key={c.id}
+                className={`mc-channel-row ${active.id === c.id ? 'selected' : ''}`}
+                onClick={() => setSelectedIdx(c.id)}
+              >
+                <div className="mc-channel-row-name">
+                  # {c.name || t('meshcore.channels.unnamed', 'Channel {{idx}}', { idx: c.id })}
+                </div>
+                <div className="mc-channel-row-meta">
+                  {count} {t('meshcore.messages', 'messages')}
+                </div>
+              </button>
+            );
+          })}
         </div>
       </div>
       <div className="meshcore-main-pane">
@@ -79,7 +183,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
           selfPublicKey={selfKey}
           disabled={!connected || !canSend}
           emptyText={t('meshcore.no_messages', 'No messages on this channel yet')}
-          onSend={text => actions.sendMessage(text, active.toPublicKey)}
+          onSend={text => actions.sendMessage(text, undefined, active.id)}
         />
       </div>
     </div>

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -84,7 +84,14 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
             />
           )}
           {view === 'channels' && (
-            <MeshCoreChannelsView messages={messages} contacts={contacts} status={status} actions={actions} />
+            <MeshCoreChannelsView
+              messages={messages}
+              contacts={contacts}
+              status={status}
+              actions={actions}
+              baseUrl={baseUrl}
+              sourceId={sourceId}
+            />
           )}
           {view === 'dms' && (
             <MeshCoreDirectMessagesView

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -85,7 +85,7 @@ export interface MeshCoreActions {
   disconnect: () => Promise<void>;
   refreshContacts: () => Promise<void>;
   sendAdvert: () => Promise<void>;
-  sendMessage: (text: string, toPublicKey?: string) => Promise<boolean>;
+  sendMessage: (text: string, toPublicKey?: string, channelIdx?: number) => Promise<boolean>;
   setDeviceName: (name: string) => Promise<boolean>;
   setRadioParams: (params: { freq: number; bw: number; sf: number; cr: number }) => Promise<boolean>;
   setCoords: (lat: number, lon: number) => Promise<boolean>;
@@ -413,13 +413,17 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch]);
 
-  const sendMessage = useCallback(async (text: string, toPublicKey?: string): Promise<boolean> => {
+  const sendMessage = useCallback(async (text: string, toPublicKey?: string, channelIdx?: number): Promise<boolean> => {
     if (!text.trim()) return false;
     try {
       const response = await csrfFetch(`${mcPrefix}/messages/send`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text, toPublicKey: toPublicKey || undefined }),
+        body: JSON.stringify({
+          text,
+          toPublicKey: toPublicKey || undefined,
+          channelIdx,
+        }),
       });
       const data = await response.json();
       if (data.success) {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -957,9 +957,19 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
-   * Send a text message
+   * Send a text message.
+   *
+   * - `toPublicKey` is set → direct message to that contact.
+   * - `toPublicKey` unset and `channelIdx` set → broadcast on that channel.
+   * - Both unset → broadcast on channel 0 (the firmware's primary "Public" slot).
+   *
+   * The locally-stored copy of an outgoing channel message gets its
+   * `toPublicKey` stamped with the synthesized `channel-${idx}` pseudonym so
+   * the per-channel filter in the frontend can distinguish "I sent this to
+   * channel 1" from "I sent this to channel 0" — both used to be indistinguishable
+   * when only channel 0 was supported (issue follow-up to MeshCore channels plan).
    */
-  async sendMessage(text: string, toPublicKey?: string): Promise<boolean> {
+  async sendMessage(text: string, toPublicKey?: string, channelIdx?: number): Promise<boolean> {
     if (!this.connected) {
       logger.error('[MeshCore] Not connected');
       return false;
@@ -971,18 +981,24 @@ class MeshCoreManager extends EventEmitter {
     }
 
     try {
+      const isChannelSend = !toPublicKey && channelIdx !== undefined;
       const response = await this.sendBridgeCommand('send_message', {
         text,
         to: toPublicKey || null,
+        channel_idx: isChannelSend ? channelIdx : undefined,
       });
 
       if (response.success) {
         logger.info(`[MeshCore] Message sent: ${text.substring(0, 50)}...`);
 
+        const sentToPublicKey = isChannelSend
+          ? MeshCoreManager.channelPublicKey(channelIdx!)
+          : (toPublicKey || undefined);
+
         const sentMessage: MeshCoreMessage = {
           id: `sent-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
           fromPublicKey: this.localNode?.publicKey || 'local',
-          toPublicKey: toPublicKey || undefined,
+          toPublicKey: sentToPublicKey,
           text: text,
           timestamp: Date.now(),
           sourceId: this.sourceId,

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -336,8 +336,19 @@ export class MeshCoreNativeBackend extends EventEmitter {
           await c.sendTextMessage(fullKey, text);
           return { sent: true };
         }
-        // Broadcast = channel 0
-        await c.sendChannelTextMessage(0, text);
+        // No recipient → broadcast on a channel. `channel_idx` is optional;
+        // historical callers omit it and get channel 0, which the firmware's
+        // primary "Public" slot is conventionally bound to. Multi-channel
+        // callers (Phase 2 of the channels feature) pass a specific idx.
+        const channelIdxRaw = params.channel_idx;
+        const channelIdx =
+          channelIdxRaw === undefined || channelIdxRaw === null
+            ? 0
+            : Number(channelIdxRaw);
+        if (!Number.isInteger(channelIdx) || channelIdx < 0 || channelIdx > 255) {
+          throw new Error(`Invalid channel index: ${channelIdxRaw}`);
+        }
+        await c.sendChannelTextMessage(channelIdx, text);
         return { sent: true };
       }
 

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -463,7 +463,7 @@ router.get('/info', optionalAuth(), requirePermission('connection', 'read', { so
  */
 router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
-    const { text, toPublicKey } = req.body;
+    const { text, toPublicKey, channelIdx } = req.body;
 
     // Validate message text
     const textValidation = isValidMessage(text);
@@ -478,7 +478,17 @@ router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('
       }
     }
 
-    const success = await managerFor(req).sendMessage(text, toPublicKey);
+    // Validate optional channelIdx (broadcast on a specific channel).
+    let parsedChannelIdx: number | undefined;
+    if (channelIdx !== undefined && channelIdx !== null) {
+      const n = Number(channelIdx);
+      if (!Number.isInteger(n) || n < 0 || n > 255) {
+        return res.status(400).json({ success: false, error: 'channelIdx must be an integer between 0 and 255' });
+      }
+      parsedChannelIdx = n;
+    }
+
+    const success = await managerFor(req).sendMessage(text, toPublicKey, parsedChannelIdx);
 
     if (success) {
       res.json({ success: true, message: 'Message sent' });


### PR DESCRIPTION
Re-land of PR #3036, which was inadvertently merged into the phase-1 branch (now orphaned) instead of main. The retarget-base step before merging didn't take.

This is the same commit, cherry-picked onto a fresh branch off main. Full vitest suite passes locally (4949/0).

## Summary (from #3036)

Reads the channel list synced by phase 1 and renders one tab per channel. Replaces the hardcoded "Public" entry that was the only channel surface in the UI before. Extends the send path so messages sent on a non-channel-0 tab actually go to the right channel.

### Display
- `MeshCoreChannelsView.tsx` fetches `/api/channels/all?sourceId=<src>` and renders one tab per row.
- Per-channel filter handles received (`fromPublicKey === 'channel-${idx}'`) and locally-sent (`toPublicKey === 'channel-${idx}'`) messages, with a back-compat clause for pre-phase-2 channel-0 local messages.

### Send path extension
- `meshcoreNativeBackend.send_message` now accepts `channel_idx`.
- `MeshCoreManager.sendMessage(text, toPublicKey?, channelIdx?)` — third arg passes through and stamps the locally-stored copy with `toPublicKey = 'channel-${idx}'`.
- `/api/meshcore/messages/send` accepts `channelIdx` in the body with range validation (0..255).
- `useMeshCore.sendMessage` and the view pass the active channel idx.

## Test plan

- [x] `npx vitest run` — **4949 PASS / 0 FAIL**
- [x] CI on the original #3036 ran fully green including hardware system tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)