### PR TITLE
fix(meshcore): filter empty channel slots + reconcile stale DB rows on sync

### DIFF
--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -75,10 +75,20 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     return a.startsWith(b) || b.startsWith(a);
   };
 
+  // Phase 2 of the MeshCore channels feature tags every locally-sent channel
+  // message with `toPublicKey = 'channel-${idx}'` so the per-channel filter in
+  // MeshCoreChannelsView can group sent messages back into the right tab.
+  // Those synthetic keys are NOT real DM peers and must not surface in the
+  // DM sidebar / conversation list — filter them out everywhere the DM view
+  // looks at toPublicKey / fromPublicKey.
+  const isChannelPseudoKey = (k: string | null | undefined): boolean =>
+    typeof k === 'string' && k.startsWith('channel-');
+
   const dmPeers = useMemo(() => {
     const peers = new Set<string>();
     for (const m of messages) {
       if (!m.toPublicKey) continue;
+      if (isChannelPseudoKey(m.toPublicKey) || isChannelPseudoKey(m.fromPublicKey)) continue;
       if (selfKey && keysMatch(m.fromPublicKey, selfKey)) peers.add(canonicalize(m.toPublicKey));
       else if (selfKey && keysMatch(m.toPublicKey, selfKey)) peers.add(canonicalize(m.fromPublicKey));
       else {
@@ -88,7 +98,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     }
     // Always include all contacts so the user can start a new DM.
     for (const c of contacts) {
-      if (c.publicKey) peers.add(c.publicKey);
+      if (c.publicKey && !isChannelPseudoKey(c.publicKey)) peers.add(c.publicKey);
     }
     return Array.from(peers);
   }, [messages, contacts, selfKey, canonicalize]);
@@ -97,6 +107,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     if (!selected) return [];
     return messages.filter(m => {
       if (!m.toPublicKey) return false;
+      if (isChannelPseudoKey(m.toPublicKey) || isChannelPseudoKey(m.fromPublicKey)) return false;
       if (selfKey && keysMatch(m.fromPublicKey, selfKey) && keysMatch(m.toPublicKey, selected)) return true;
       if (selfKey && keysMatch(m.toPublicKey, selfKey) && keysMatch(m.fromPublicKey, selected)) return true;
       // No selfKey known — fall back to either direction matching the selected peer.

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -100,6 +100,13 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     for (const c of contacts) {
       if (c.publicKey && !isChannelPseudoKey(c.publicKey)) peers.add(c.publicKey);
     }
+    // Drop the local node — DMing yourself is meaningless and the local node
+    // sometimes appears in the contacts list as a side-effect of seeding.
+    if (selfKey) {
+      for (const key of Array.from(peers)) {
+        if (keysMatch(key, selfKey)) peers.delete(key);
+      }
+    }
     return Array.from(peers);
   }, [messages, contacts, selfKey, canonicalize]);
 

--- a/src/server/meshcoreManager.channels.test.ts
+++ b/src/server/meshcoreManager.channels.test.ts
@@ -25,7 +25,14 @@ function makeManager(opts: {
   deviceType?: MeshCoreDeviceType;
   getChannelsResponse?: { success: boolean; data?: unknown; error?: string };
   failOnSet?: boolean;
-}): { manager: MeshCoreManager; bridgeCalls: BridgeCall[]; upsertCalls: Array<{ data: any; sourceId: string | undefined; opts: any }> } {
+  /** Pre-existing DB rows for this source — what `getAllChannels(sourceId)` returns. */
+  preExistingRows?: Array<{ id: number; name?: string; psk?: string | null }>;
+}): {
+  manager: MeshCoreManager;
+  bridgeCalls: BridgeCall[];
+  upsertCalls: Array<{ data: any; sourceId: string | undefined; opts: any }>;
+  deleteCalls: Array<{ id: number; sourceId: string | undefined }>;
+} {
   const deviceType = opts.deviceType ?? MeshCoreDeviceType.COMPANION;
   const m = new MeshCoreManager('test-source');
   // Force the device type so the manager doesn't short-circuit on the
@@ -34,6 +41,14 @@ function makeManager(opts: {
 
   const bridgeCalls: BridgeCall[] = [];
   const upsertCalls: Array<{ data: any; sourceId: string | undefined; opts: any }> = [];
+  const deleteCalls: Array<{ id: number; sourceId: string | undefined }> = [];
+  // syncChannelsFromDevice tracks pre-existing DB rows so it can reconcile
+  // (delete rows for slots the device no longer reports as configured).
+  // Each upsert mutates this view so subsequent calls in the same test see
+  // the post-upsert state.
+  const dbRows: Map<number, { id: number; name: string; psk: string | null }> = new Map(
+    (opts.preExistingRows ?? []).map(r => [r.id, { id: r.id, name: r.name ?? '', psk: r.psk ?? null }]),
+  );
 
   const defaultGetChannels = {
     success: true,
@@ -66,10 +81,18 @@ function makeManager(opts: {
   vi.spyOn(databaseService, 'channels', 'get').mockReturnValue({
     upsertChannel: vi.fn(async (data: any, sourceId?: string, opts?: any) => {
       upsertCalls.push({ data, sourceId, opts });
+      dbRows.set(data.id, { id: data.id, name: data.name ?? '', psk: data.psk ?? null });
+    }),
+    getAllChannels: vi.fn(async (_sourceId?: string) => {
+      return Array.from(dbRows.values());
+    }),
+    deleteChannel: vi.fn(async (id: number, sourceId?: string) => {
+      deleteCalls.push({ id, sourceId });
+      dbRows.delete(id);
     }),
   } as any);
 
-  return { manager: m, bridgeCalls, upsertCalls };
+  return { manager: m, bridgeCalls, upsertCalls, deleteCalls };
 }
 
 describe('MeshCoreManager — listChannels', () => {
@@ -153,6 +176,67 @@ describe('MeshCoreManager — syncChannelsFromDevice', () => {
     await manager.syncChannelsFromDevice();
     expect(upsertCalls).toHaveLength(1);
     expect(upsertCalls[0].data.psk).toBeNull();
+  });
+
+  it('filters out empty/unconfigured slots (the MAX_CHANNELS leak)', async () => {
+    // MeshCore Companion firmware returns success for every slot up to
+    // MAX_CHANNELS (typically 40) with an empty name and all-zero secret
+    // for unused slots. The sync must skip those.
+    const zero = '00'.repeat(16);
+    const { manager, upsertCalls } = makeManager({
+      getChannelsResponse: {
+        success: true,
+        data: [
+          { channel_idx: 0, name: 'Public', secret_hex: 'aa'.repeat(16) },
+          { channel_idx: 1, name: '', secret_hex: zero }, // empty slot — skip
+          { channel_idx: 2, name: '', secret_hex: zero }, // empty slot — skip
+          { channel_idx: 5, name: 'Town', secret_hex: 'bb'.repeat(16) },
+          { channel_idx: 6, name: '', secret_hex: zero }, // empty slot — skip
+        ],
+      },
+    });
+    await manager.syncChannelsFromDevice();
+    expect(upsertCalls.map(c => c.data.id)).toEqual([0, 5]);
+  });
+
+  it('keeps a slot configured when the user blanks the name but keeps a real secret', async () => {
+    const { manager, upsertCalls } = makeManager({
+      getChannelsResponse: {
+        success: true,
+        data: [{ channel_idx: 3, name: '', secret_hex: 'cc'.repeat(16) }],
+      },
+    });
+    await manager.syncChannelsFromDevice();
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0].data.id).toBe(3);
+  });
+
+  it('reconciles: deletes DB rows for slots the device no longer treats as configured', async () => {
+    // Pre-existing DB has channels at idx 0, 1, 5 (left over from before the
+    // empty-slot filter, OR from an out-of-band delete via meshcore-cli).
+    // The device now only reports 0 + 5 as configured; 1 should be deleted.
+    const zero = '00'.repeat(16);
+    const { manager, deleteCalls, upsertCalls } = makeManager({
+      preExistingRows: [
+        { id: 0, name: 'Public', psk: 'old' },
+        { id: 1, name: '', psk: '' },
+        { id: 5, name: 'Town', psk: 'oldtoo' },
+      ],
+      getChannelsResponse: {
+        success: true,
+        data: [
+          { channel_idx: 0, name: 'Public', secret_hex: 'aa'.repeat(16) },
+          { channel_idx: 1, name: '', secret_hex: zero }, // empty — filtered out
+          { channel_idx: 5, name: 'Town', secret_hex: 'bb'.repeat(16) },
+        ],
+      },
+    });
+    await manager.syncChannelsFromDevice();
+
+    // Upserted only the two configured slots.
+    expect(upsertCalls.map(c => c.data.id)).toEqual([0, 5]);
+    // Deleted the stale empty-slot row at idx 1.
+    expect(deleteCalls).toEqual([{ id: 1, sourceId: 'test-source' }]);
   });
 });
 

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -42,6 +42,22 @@ function parseTelemetryMode(value: unknown): TelemetryMode | undefined {
   return undefined;
 }
 
+/**
+ * Decide whether a channel slot reported by the firmware is actually in use.
+ * MeshCore Companion firmware doesn't error on unconfigured slots — it
+ * returns success with an empty name and a 16-byte all-zero secret. We
+ * treat that exact shape as "empty slot" and skip it during DB sync. A slot
+ * with EITHER a non-empty name OR a non-zero secret is considered
+ * configured (so a user who chose to leave the name blank but generated a
+ * real key is preserved).
+ */
+function isConfiguredMeshCoreChannel(ch: { name: string; secretHex: string }): boolean {
+  const nameTrim = (ch.name || '').trim();
+  const hasName = nameTrim.length > 0;
+  const hasSecret = !!ch.secretHex && /[1-9a-f]/i.test(ch.secretHex);
+  return hasName || hasSecret;
+}
+
 // MeshCore device types
 export enum MeshCoreDeviceType {
   UNKNOWN = 0,
@@ -622,18 +638,32 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
-   * Read the device's channel list and mirror it into the shared `channels`
-   * table, scoped by this manager's sourceId. The 16-byte AES secret is
-   * stored base64-encoded in the existing `psk` column. Meshtastic-only
-   * columns (role, uplinkEnabled, downlinkEnabled, positionPrecision) are
-   * left null for MeshCore rows.
+   * Read the device's channel list and mirror CONFIGURED slots into the
+   * shared `channels` table, scoped by this manager's sourceId. The 16-byte
+   * AES secret is stored base64-encoded in the existing `psk` column.
+   * Meshtastic-only columns (role, uplinkEnabled, downlinkEnabled,
+   * positionPrecision) are left null for MeshCore rows.
+   *
+   * Empty/unconfigured slots are filtered out. MeshCore Companion firmware
+   * does NOT error when `GetChannel(idx)` is called on an unused slot — it
+   * returns a success response with an empty name and an all-zero 16-byte
+   * secret. meshcore.js's `getChannels()` enumerates until the firmware
+   * errors, so without this filter the whole slot table (MAX_CHANNELS,
+   * typically 40 on Companion builds) leaks into the UI.
+   *
+   * After syncing the configured slots we also delete any stale DB rows for
+   * this source whose idx is no longer reported as configured by the
+   * device — so an out-of-band delete via meshcore-cli is reflected on the
+   * next sync, and a previous "leaked empty slots" install gets cleaned up.
    *
    * MeshCore has no push event for channel changes, so callers should invoke
    * this on connect and after every local write.
    */
   async syncChannelsFromDevice(): Promise<void> {
     const channels = await this.listChannels();
-    for (const ch of channels) {
+    const configured = channels.filter(ch => isConfiguredMeshCoreChannel(ch));
+
+    for (const ch of configured) {
       const pskBase64 = ch.secretHex ? Buffer.from(ch.secretHex, 'hex').toString('base64') : null;
       await databaseService.channels.upsertChannel(
         {
@@ -650,7 +680,26 @@ class MeshCoreManager extends EventEmitter {
         { allowBlankName: true },
       );
     }
-    logger.debug(`[MeshCore:${this.sourceId}] Synced ${channels.length} channel(s) from device`);
+
+    // Reconcile: remove DB rows for slots the device no longer treats as
+    // configured. This covers (a) out-of-band deletes via meshcore-cli and
+    // (b) cleanup of legacy installs that had unconfigured-slot rows from
+    // before the filter landed.
+    const configuredIdxSet = new Set(configured.map(ch => ch.channelIdx));
+    const existing = await databaseService.channels.getAllChannels(this.sourceId);
+    let removed = 0;
+    for (const row of existing) {
+      if (!configuredIdxSet.has(row.id)) {
+        await databaseService.channels.deleteChannel(row.id, this.sourceId);
+        removed++;
+      }
+    }
+
+    logger.debug(
+      `[MeshCore:${this.sourceId}] Synced ${configured.length} configured channel(s) from device ` +
+      `(filtered out ${channels.length - configured.length} empty slot(s)` +
+      (removed > 0 ? `, removed ${removed} stale DB row(s))` : ')'),
+    );
   }
 
   // ============ Direct Serial Methods (for Repeater) ============

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2891,9 +2891,20 @@ apiRouter.put('/channels/:id', requireAuth(), async (req, res) => {
       // MeshCore write path: push the channel to the device first, then
       // re-sync the DB from the device (the manager's setChannel handles
       // both — including base64↔hex secret conversion).
-      const mcManager = resolveSourceManager(chanSourceId) as unknown as {
-        setChannel: (idx: number, name: string, secretHex: string) => Promise<void>;
-      };
+      //
+      // MeshCore managers live in their own registry (meshcoreManagerRegistry),
+      // separate from the Meshtastic one. resolveSourceManager only knows
+      // about the Meshtastic registry and silently falls back to the global
+      // meshtasticManager singleton on a miss, which has no setChannel and
+      // surfaces as a runtime TypeError.
+      const mcManager = meshcoreManagerRegistry.get(chanSourceId);
+      if (!mcManager || typeof mcManager.setChannel !== 'function') {
+        return res.status(503).json({
+          error: 'MeshCore source not connected or not registered',
+          message: `No active MeshCore manager for source ${chanSourceId}. Connect the source and retry.`,
+        });
+      }
+
       // Convert the base64 PSK to hex for the meshcore.js wire format.
       // Reject anything that doesn't decode to exactly 16 bytes (AES-128).
       const incomingPskBase64 = updatedChannelData.psk;
@@ -3002,10 +3013,14 @@ apiRouter.delete('/channels/:id', requireAuth(), async (req, res) => {
 
     if (sourceType === 'meshcore') {
       // MeshCore: push delete to the device first, then re-sync the DB.
-      // (The manager.deleteChannel does both.) Also purge stored messages.
-      const mcManager = resolveSourceManager(deleteChannelSourceId) as unknown as {
-        deleteChannel: (idx: number) => Promise<void>;
-      };
+      // MeshCore managers are in their own registry — see PUT route comment.
+      const mcManager = meshcoreManagerRegistry.get(deleteChannelSourceId);
+      if (!mcManager || typeof mcManager.deleteChannel !== 'function') {
+        return res.status(503).json({
+          error: 'MeshCore source not connected or not registered',
+          message: `No active MeshCore manager for source ${deleteChannelSourceId}. Connect the source and retry.`,
+        });
+      }
       try {
         await mcManager.deleteChannel(channelId);
       } catch (deviceError) {


### PR DESCRIPTION
Fixes the 40-channel issue reported after deploying the MeshCore channels feature: every freshly-connected Companion source was showing 38 empty placeholder rows alongside the real channels.

## Root cause

MeshCore Companion firmware's \`cmd_get_channel\` does **not** error on an unused slot — it returns success with an empty name and a 16-byte all-zero secret. meshcore.js's \`getChannels()\` enumerates until the firmware errors, so it walks the **whole** slot table — MAX_CHANNELS, typically 40 on Companion builds. \`syncChannelsFromDevice\` was mirroring every slot it received into the \`channels\` DB table, including the 38 empty placeholders.

## Fix

- New helper \`isConfiguredMeshCoreChannel(ch)\` — a slot is configured iff it has a non-empty name OR a non-zero secret. The "OR" preserves the legit edge case where a user generated a real key but left the display name blank.
- \`syncChannelsFromDevice\`:
  - Filters with that predicate before upserting → empty slots never reach the DB.
  - **Reconciles** after upserting: enumerates the existing DB rows for this source and deletes any whose idx isn't in the configured set. This covers both (a) one-time cleanup of legacy installs that already have the leaked rows and (b) reflecting an out-of-band delete via \`meshcore-cli\` on the next sync.

## "Add channel" still works

Phase 3's \`nextFreeIdx\` walks 0..255 looking for the lowest unused index in the *filtered* channel list. After this fix, slot 1 (and 2, 3, … 39) are correctly recognised as free even though the firmware still reports them as empty in its 40-slot table. The PUT /api/channels/<idx> route already accepts any idx 0..255 for MeshCore sources (phase 3).

## Test plan

- [x] \`npx vitest run\` — **4959 PASS / 0 FAIL** (+3 new cases over main)
- [x] \`npm run build\` — clean
- [x] \`tsc --noEmit\` — clean
- [x] Lint count unchanged from main (650)
- [ ] Manual: redeploy, reconnect MeshCore source — DB should now show only configured channels; "Add channel" should suggest the lowest free slot.

## New tests

\`meshcoreManager.channels.test.ts\` (+3):
- \`filters out empty/unconfigured slots (the MAX_CHANNELS leak)\` — mixed configured + empty input → only the configured idx values get upserted.
- \`keeps a slot configured when the user blanks the name but keeps a real secret\` — empty name with non-zero secret is preserved.
- \`reconciles: deletes DB rows for slots the device no longer treats as configured\` — pre-existing stale rows get cleaned up on next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)