### PR TITLE
chore(release): 4.5.2 — MeshCore channel support

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.5.1",
+  "version": "4.5.2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.5.1
-appVersion: "4.5.1"
+version: 4.5.2
+appVersion: "4.5.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump for the 4.5.2 release. Headline feature is MeshCore channel support, landed across PRs #3033 / #3034 / #3038 / #3039 / #3040 during this release window.

## Versions bumped (all five canonical files)

- \`package.json\`
- \`package-lock.json\` (regenerated via \`npm install --package-lock-only --legacy-peer-deps\`)
- \`helm/meshmonitor/Chart.yaml\` — both \`version\` and \`appVersion\`
- \`desktop/src-tauri/tauri.conf.json\`
- \`desktop/package.json\`

## What's in 4.5.2

### MeshCore channel support (new, end-to-end)
- **Backend channel CRUD + connect-time sync** (#3034) — \`MeshCoreManager.listChannels / setChannel / deleteChannel / syncChannelsFromDevice\`. AES-128 secret stored base64 in the existing \`channels.psk\` column; source-type-aware \`cleanupInvalidChannels\` so MeshCore high-idx channels survive cleanup.
- **Display the synced list** (#3038) — \`MeshCoreChannelsView\` renders one tab per device-reported channel; the send path now accepts a \`channelIdx\` so non-channel-0 sends route correctly.
- **Configuration UI** (#3039) — \`MeshCoreChannelsConfigSection\` mounted inside \`MeshCoreConfigurationView\`. Add channel (auto-assigns next free idx, seeds a 16-byte random secret), edit, regenerate-secret, delete. Hex secret display with masked-by-default show/copy toggles. Source-type-aware \`PUT/DELETE /api/channels/:id\` routes.
- **Post-deploy polish** (#3040) — empty-slot filter so the firmware's MAX_CHANNELS (typically 40) doesn't leak placeholder rows into the UI; DB reconcile auto-cleans existing leaked rows on next sync; \`PUT/DELETE\` routes pull from the correct \`meshcoreManagerRegistry\` (the route was previously falling back to the Meshtastic singleton, surfacing as a runtime TypeError); DM view filters out \`channel-N\` pseudo-pubkeys and the local node.

### Map fix
- **Per-node position-precision boxes** (#3033) — accuracy boxes on the map now reflect each sending node's own \`precision_bits\` instead of the local MeshMonitor node's channel setting. Removed the local-channel fallback in both the Position and NodeInfo handlers, plus the smart upgrade/downgrade logic that was holding onto stored higher precision for up to 12 hours.

## Test plan

- [x] \`npx vitest run\` — 4959 PASS / 0 FAIL
- [x] Manual: connected MeshCore Companion source; added, renamed, regenerated-secret, and deleted channels; messages segregate correctly per tab; DM sidebar excludes channels and the local node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)