### PR TITLE
fix(ui): drop "(USB)" from MeshCore source-type label

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -579,7 +579,7 @@ function DashboardInner() {
                   onChange={(e) => setFormType(e.target.value as 'meshtastic_tcp' | 'meshcore')}
                 >
                   <option value="meshtastic_tcp">{t('source.form.type_meshtastic', 'Meshtastic (TCP)')}</option>
-                  <option value="meshcore">{t('source.form.type_meshcore', 'MeshCore (USB)')}</option>
+                  <option value="meshcore">{t('source.form.type_meshcore', 'MeshCore')}</option>
                 </select>
               </label>
             )}


### PR DESCRIPTION
## Summary
- The Add Source form's type dropdown showed "MeshCore (USB)", but the form offers a separate transport selector (USB or TCP), so the parenthetical was misleading.
- Renames the option to just "MeshCore" (`src/pages/DashboardPage.tsx:582`).

## Test plan
- [ ] Open the Add Source dialog and confirm the type dropdown reads "MeshCore" with transport options still available below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)