### PR TITLE
fix(#3025): scope frontend neighbor-info fetch to current source + defensive lastHeard refresh

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1521,7 +1521,7 @@ function App() {
         return () => clearInterval(interval);
       }
     }
-  }, [connectionStatus]);
+  }, [connectionStatus, sourceId]);
 
   // Fetch position history when a mobile node is selected
   useEffect(() => {
@@ -2306,8 +2306,10 @@ function App() {
   // fetchTraceroutes removed - traceroutes are now synced via poll mechanism
 
   const fetchNeighborInfo = async () => {
+    if (!sourceId) return;
     try {
-      const response = await authFetch(`${baseUrl}/api/neighbor-info`);
+      const url = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/neighbor-info`;
+      const response = await authFetch(url);
       if (response.ok) {
         const data = await response.json();
         setNeighborInfo(data);

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3243,6 +3243,24 @@ class MeshtasticManager implements ISourceManager {
         case 'configComplete':
           logger.debug('✅ Config complete received, ID:', parsed.data.configCompleteId);
 
+          // configComplete is direct evidence the local device just finished talking to us —
+          // refresh its lastHeard so freshness filters (e.g., neighbor-info) don't treat a
+          // quiet-but-connected local node as stale (#3025). Best-effort: silently swallow
+          // errors so a DB hiccup never blocks config-capture completion.
+          if (this.localNodeInfo?.nodeNum) {
+            const localNodeNum = this.localNodeInfo.nodeNum;
+            const localNodeId = this.localNodeInfo.nodeId;
+            try {
+              await databaseService.nodes.upsertNode({
+                nodeNum: localNodeNum,
+                nodeId: localNodeId,
+                lastHeard: Date.now() / 1000,
+              }, this.sourceId);
+            } catch (err) {
+              logger.debug('⚠️ Could not refresh local node lastHeard on configComplete:', err);
+            }
+          }
+
           // Stop capturing init messages
           if (this.isCapturingInitConfig && !this.configCaptureComplete) {
             this.configCaptureComplete = true;
@@ -3411,6 +3429,11 @@ class MeshtasticManager implements ISourceManager {
             isIgnored: newNode?.isIgnored || oldNode?.isIgnored || false,
             hasRemoteAdmin: true, // Local node always has admin
             rebootCount: myNodeInfo.rebootCount !== undefined ? myNodeInfo.rebootCount : undefined,
+            // Receiving MyNodeInfo over the active link is direct evidence we just heard
+            // from the local device — stamp lastHeard so downstream consumers (e.g.,
+            // neighbor-info filters, activity displays) don't treat the local node as stale
+            // when no broadcast traffic has happened to flow through processMeshPacket yet (#3025).
+            lastHeard: Date.now() / 1000,
           }, this.sourceId);
 
           // Delete old ghost node (cascades messages, traceroutes, neighbors, telemetry)
@@ -3498,6 +3521,7 @@ class MeshtasticManager implements ISourceManager {
         nodeId,
         keyMismatchDetected: false,
         keySecurityIssueDetails: null,
+        lastHeard: Date.now() / 1000, // we just received MyNodeInfo (#3025)
       }, this.sourceId);
       dataEventEmitter.emitNodeUpdate(nodeNum, { keyMismatchDetected: false, keySecurityIssueDetails: undefined }, this.sourceId);
     }
@@ -3515,12 +3539,18 @@ class MeshtasticManager implements ISourceManager {
         isLocked: true  // Lock it to prevent overwrites
       } as any;
 
-      // Update rebootCount and ensure hasRemoteAdmin is set for local node
+      // Update rebootCount and ensure hasRemoteAdmin is set for local node.
+      // Also refresh lastHeard — we just received MyNodeInfo, which is direct evidence
+      // we heard from the local device. Without this, a local node whose stored lastHeard
+      // is stale (no inbound packets via processMeshPacket since startup) would have its
+      // own NeighborInfo links silently dropped by the freshness filter in
+      // sourceRoutes.ts / server.ts (#3025).
       await databaseService.nodes.upsertNode({
         nodeNum: nodeNum,
         nodeId: nodeId,
         rebootCount: myNodeInfo.rebootCount !== undefined ? myNodeInfo.rebootCount : undefined,
-        hasRemoteAdmin: true  // Local node always has remote admin access
+        hasRemoteAdmin: true, // Local node always has remote admin access
+        lastHeard: Date.now() / 1000,
       }, this.sourceId);
       logger.debug(`📱 Updated local device: ${existingNode.longName} (${nodeId}), rebootCount: ${myNodeInfo.rebootCount}, hasRemoteAdmin: true`);
 

--- a/tests/test-api-exercise-all-backends.sh
+++ b/tests/test-api-exercise-all-backends.sh
@@ -30,6 +30,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
+# Pre-flight: auto-remove any orphan test-scoped containers leaked by a previous
+# crashed run of this script. These names belong exclusively to this test, so
+# removal cannot affect the developer's running dev stack.
+for orphan in meshmonitor-api-exercise-sqlite-test meshmonitor-api-exercise-postgres-test meshmonitor-api-exercise-mysql-test; do
+    if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx "$orphan"; then
+        echo -e "${YELLOW}!${NC} Removing orphan test container from previous run: $orphan"
+        docker rm -f "$orphan" >/dev/null 2>&1 || true
+    fi
+done
+
 # Test configuration
 TEST_NODE_IP="${TEST_NODE_IP:-192.168.5.106}"
 TEST_PORT="8085"

--- a/tests/test-database-backing.sh
+++ b/tests/test-database-backing.sh
@@ -23,7 +23,26 @@ PROJECT_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
 
 cd "$PROJECT_ROOT"
 
-# Pre-flight: check for existing meshmonitor containers that may hog the device connection
+# Pre-flight: auto-remove any orphan test-scoped containers leaked by a previous
+# crashed run of this script or its sibling (test-api-exercise-all-backends.sh).
+# These names belong exclusively to test scripts, so removal cannot affect the
+# developer's running dev stack.
+ORPHAN_TEST_NAMES=(
+    meshmonitor-db-backing-sqlite-test
+    meshmonitor-db-backing-postgres-test
+    meshmonitor-db-backing-mysql-test
+    meshmonitor-api-exercise-sqlite-test
+    meshmonitor-api-exercise-postgres-test
+    meshmonitor-api-exercise-mysql-test
+)
+for orphan in "${ORPHAN_TEST_NAMES[@]}"; do
+    if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx "$orphan"; then
+        echo -e "${YELLOW}!${NC} Removing orphan test container from previous run: $orphan"
+        docker rm -f "$orphan" >/dev/null 2>&1 || true
+    fi
+done
+
+# Pre-flight: check for any remaining meshmonitor containers that may hog the device connection
 EXISTING_MM=$(docker ps --format '{{.Names}}' 2>/dev/null | grep -E '^meshmonitor' | grep -v 'db-backing' || true)
 if [ -n "$EXISTING_MM" ]; then
     echo -e "${RED}✗ ERROR${NC}: Existing MeshMonitor containers detected that may conflict:"


### PR DESCRIPTION
## Summary

Fixes #3025 — Meshtastic NeighborInfo packets are received and stored, but the Messages-tab UI shows nothing.

Two distinct bugs combined to produce the reported symptom; this branch addresses both:

1. **Frontend was calling the wrong endpoint** (root cause, surfaced by SyselMitY in the latest issue comment). `App.tsx#fetchNeighborInfo` still pointed at the legacy `/api/neighbor-info` route. In 4.x that handler returns `[]` for non-default sources because `neighbor_info` rows are partitioned by `sourceId`, so the UI silently rendered an empty list (HTTP 200, 0 entries). Switched to `/api/sources/:sourceId/neighbor-info` — matching the pattern already used by `useDashboardData` — and added `sourceId` to the effect's dep array so it refetches on source switch.

2. **Defensive `lastHeard` refresh on the local node** (commit `da1223b1`, already on this branch). Between MeshMonitor start and the first self-originated broadcast that echoes through the packet pipeline, the local node row can have `lastHeard=NULL`. The `sourceRoutes.ts:712` filter treats NULL as "stale reporter" and drops every NeighborInfo row sourced from the local node. We now refresh `lastHeard` whenever we receive `MyNodeInfo` or `configComplete` — both are direct evidence the local device just talked to us.

## Test plan

- [x] `npx eslint src/App.tsx` — no new errors/warnings introduced
- [x] `npx vitest run src/server/routes/sourceRoutes.neighbor-info.test.ts src/hooks/useDashboardData.test.ts` — 29/29 pass
- [ ] CI to verify full suite + system tests
- [ ] Manual verification by reporter (@SyselMitY) once a build is available — confirm neighbor entries appear in Messages-tab Neighbor Info block for both local and remote nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)