### PR TITLE
fix(#3048): scale MeshCore radio params between UI MHz/kHz and wire kHz/Hz

### DIFF
--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -83,8 +83,9 @@ class MockConnection extends EventEmitter {
     advLat: 40_000_000,
     advLon: -75_000_000,
     manualAddContacts: 0,
-    radioFreq: 915000000,
-    radioBw: 250000,
+    // Wire-format units: freq in kHz, bw in Hz. 915525 kHz == 915.525 MHz, 62500 Hz == 62.5 kHz.
+    radioFreq: 915525,
+    radioBw: 62500,
     radioSf: 11,
     radioCr: 5,
     name: 'TestNode',
@@ -261,7 +262,10 @@ describe('MeshCoreNativeBackend', () => {
     expect(resp.success).toBe(true);
     expect(resp.data?.name).toBe('TestNode');
     expect(resp.data?.public_key).toMatch(/^01020304/);
-    expect(resp.data?.radio_freq).toBe(915000000);
+    // Library yields wire-format kHz/Hz; the backend must normalize to MHz/kHz
+    // so the rest of MeshMonitor (UI presets, validation) sees consistent units.
+    expect(resp.data?.radio_freq).toBe(915.525);
+    expect(resp.data?.radio_bw).toBe(62.5);
     expect(resp.data?.latitude).toBeCloseTo(40, 4);
     expect(resp.data?.longitude).toBeCloseTo(-75, 4);
 
@@ -505,6 +509,37 @@ describe('MeshCoreNativeBackend', () => {
     const resp = await backend.sendCommand('get_device_time', {}, 50);
     expect(resp.success).toBe(false);
     expect(resp.error).toMatch(/timeout/i);
+  });
+
+  // ---------- radio commands ----------
+
+  it('set_radio scales MHz/kHz floats to wire-format kHz/Hz integers', async () => {
+    // Regression for issue #3048: the meshcore.js wire protocol writes radioFreq
+    // as a uint32 in kHz and radioBw as a uint32 in Hz. Passing the UI's MHz/kHz
+    // floats raw to writeUInt32LE truncates them and the device rejects the frame,
+    // so the user sees a "Failed to update radio params" toast.
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+
+    const resp = await backend.sendCommand('set_radio', {
+      freq: 910.525,
+      bw: 62.5,
+      sf: 7,
+      cr: 5,
+    });
+    expect(resp.success).toBe(true);
+    expect(conn.setRadioParamsCalls).toEqual([[910525, 62500, 7, 5]]);
+
+    // The bridge-shaped get_self_info readback should keep UI units (MHz/kHz).
+    const after = await backend.sendCommand('get_self_info', {});
+    expect(after.data?.radio_freq).toBe(910.525);
+    expect(after.data?.radio_bw).toBe(62.5);
+    expect(after.data?.radio_sf).toBe(7);
+    expect(after.data?.radio_cr).toBe(5);
   });
 
   // ---------- channel commands ----------

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -106,6 +106,27 @@ function fixedToDegrees(v: number | undefined): number | undefined {
   return v / 1e6;
 }
 
+// MeshCore wire protocol uses integer-scaled radio units, but the rest of
+// MeshMonitor (UI presets, validation, API contract) speaks MHz / kHz floats.
+// Centralize the conversion here so cachedSelfInfo and outbound set_radio
+// frames each side of the boundary use their own native units.
+//
+//   radioFreq : library uses kHz uint32 (e.g. 917375 == 917.375 MHz)
+//   radioBw   : library uses Hz  uint32 (e.g. 250000 == 250 kHz, 62500 == 62.5 kHz)
+//   radioSf, radioCr : raw integers in both worlds.
+function libFreqToMhz(v: number | undefined): number | undefined {
+  return typeof v === 'number' ? v / 1000 : v;
+}
+function libBwToKhz(v: number | undefined): number | undefined {
+  return typeof v === 'number' ? v / 1000 : v;
+}
+function mhzToLibFreq(v: number): number {
+  return Math.round(v * 1000);
+}
+function khzToLibBw(v: number): number {
+  return Math.round(v * 1000);
+}
+
 // ---------------- backend ----------------
 
 export class MeshCoreNativeBackend extends EventEmitter {
@@ -152,7 +173,13 @@ export class MeshCoreNativeBackend extends EventEmitter {
     // meshcore.js onConnected() does NOT send AppStart automatically —
     // we must explicitly request SelfInfo after the transport is open.
     const selfInfo = await this.connection.getSelfInfo(10_000);
-    this.cachedSelfInfo = selfInfo;
+    this.cachedSelfInfo = {
+      ...selfInfo,
+      // Normalize wire kHz/Hz to MeshMonitor MHz/kHz so every downstream
+      // consumer (selfInfoToBridgeShape → manager → UI) sees consistent units.
+      radioFreq: libFreqToMhz(selfInfo?.radioFreq),
+      radioBw: libBwToKhz(selfInfo?.radioBw),
+    };
 
     // Listen for connection-side disconnect so callers can react.
     this.connection.on('disconnected', () => {
@@ -384,20 +411,23 @@ export class MeshCoreNativeBackend extends EventEmitter {
         if (this.cachedSelfInfo) this.cachedSelfInfo.name = String(params.name ?? '');
         return { ok: true };
 
-      case 'set_radio':
-        await c.setRadioParams(
-          Number(params.freq),
-          Number(params.bw),
-          Number(params.sf),
-          Number(params.cr),
-        );
+      case 'set_radio': {
+        const freqMhz = Number(params.freq);
+        const bwKhz = Number(params.bw);
+        const sf = Number(params.sf);
+        const cr = Number(params.cr);
+        // Wire protocol expects integer-scaled units (kHz freq, Hz bw); the
+        // library's BufferWriter.writeUInt32LE truncates floats and would
+        // otherwise ship a wildly wrong frequency that the device rejects.
+        await c.setRadioParams(mhzToLibFreq(freqMhz), khzToLibBw(bwKhz), sf, cr);
         if (this.cachedSelfInfo) {
-          this.cachedSelfInfo.radioFreq = Number(params.freq);
-          this.cachedSelfInfo.radioBw = Number(params.bw);
-          this.cachedSelfInfo.radioSf = Number(params.sf);
-          this.cachedSelfInfo.radioCr = Number(params.cr);
+          this.cachedSelfInfo.radioFreq = freqMhz;
+          this.cachedSelfInfo.radioBw = bwKhz;
+          this.cachedSelfInfo.radioSf = sf;
+          this.cachedSelfInfo.radioCr = cr;
         }
         return { ok: true };
+      }
 
       case 'set_coords':
         await c.setAdvertLatLong(Number(params.lat), Number(params.lon));


### PR DESCRIPTION
## Summary

Fixes #3048 — Meshcore Radio Parameters page shows the wrong values and the **Save Radio Settings** button returns an error.

Both symptoms share one root cause: the meshcore.js wire protocol uses **integer-scaled units** for the radio fields (`radioFreq` in kHz, `radioBw` in Hz — confirmed against the library's `index.html` sample, which sends `917375` for 917.375 MHz and `250000` for 250 kHz), while the rest of MeshMonitor — frontend defaults (`869.525`), the preset table (`910.525`, `62.5`), validation (`VALID_BANDWIDTHS: [..., 62.5, 125, 250, 500]` kHz), and the manager-level types — speaks MHz / kHz floats. The native backend boundary at `src/server/meshcoreNativeBackend.ts` passed values through unscaled in both directions:

| Path | What happens today | Symptom |
|------|---------------------|---------|
| `set_radio` → library | `setRadioParams(910.525, 62.5, …)` → `BufferWriter.writeUInt32LE(910.525)` truncates the float, the device receives a wildly-wrong frequency and rejects the frame | "Failed to update radio params" toast |
| Library SelfInfo → cache | Cached raw (e.g. `radioFreq = 869525`); `MeshCoreConfigurationView.findPresetId` compares against `869.525` → no match → UI falls through to the EU/UK Deprecated defaults | "Wrong parameters showing" |

## Fix

Centralize the conversion in the native-backend boundary, so cached `selfInfo` always speaks MeshMonitor units (MHz / kHz floats) and the library always sees wire units (kHz / Hz integers):

* `connect()` normalizes the freshly-received `selfInfo` before caching.
* `set_radio` scales the inbound MHz/kHz floats with `Math.round(v * 1000)` before calling `c.setRadioParams`. The cache update keeps MHz/kHz units, so `selfInfoToBridgeShape` stays symmetric with the inbound path.

`sf` / `cr` are raw integers in both worlds; no conversion needed.

## Test plan

- [x] `npx vitest run src/server/meshcoreNativeBackend.test.ts src/server/routes/meshcoreRoutes.test.ts src/components/MeshCore/MeshCoreConfigurationView.test.tsx` — 64/64 pass
- [x] `npx vitest run src/server/meshcoreManager.channels.test.ts src/server/meshcoreManager.telemetry.test.ts` — 29/29 pass
- [x] Existing `connects via serial…` test reworked to use realistic wire-format values (`radioFreq: 915525` kHz / `radioBw: 62500` Hz) and to assert the backend hands the rest of MeshMonitor MHz / kHz floats (`radio_freq: 915.525`, `radio_bw: 62.5`)
- [x] New regression test (`set_radio scales MHz/kHz floats to wire-format kHz/Hz integers`) exercises the preset values from the issue and asserts `MockConnection.setRadioParamsCalls === [[910525, 62500, 7, 5]]`
- [ ] CI to verify full suite + system tests
- [ ] Manual verification by reporter (@IJustWantToAsk) once a build is available — confirm the page now shows the correct preset and **Save Radio Settings** succeeds when switching to USA

🤖 Generated with [Claude Code](https://claude.com/claude-code)