### PR TITLE
fix(meshcore): persist channel/DM messages to DB; fix TCP port default

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 61 migrations registered', () => {
-    expect(registry.count()).toBe(61);
+  it('has all 62 migrations registered', () => {
+    expect(registry.count()).toBe(62);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is meshcore_nodes_composite_pk', () => {
+  it('last migration is meshcore_messages_fromname', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(61);
-    expect(last.name).toContain('meshcore_nodes_composite_pk');
+    expect(last.number).toBe(62);
+    expect(last.name).toContain('meshcore_messages_fromname');
   });
 
-  it('migrations are sequentially numbered from 1 to 61', () => {
+  it('migrations are sequentially numbered from 1 to 62', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -73,6 +73,7 @@ import { migration as collapseMeshcoreResourceMigration, runMigration058Postgres
 import { migration as telemetrySourceNodeTypeTsIndexMigration, runMigration059Postgres, runMigration059Mysql } from '../server/migrations/059_telemetry_source_node_type_ts_index.js';
 import { migration as meshcoreNodeTelemetryConfigMigration, runMigration060Postgres, runMigration060Mysql } from '../server/migrations/060_meshcore_node_telemetry_config.js';
 import { migration as meshcoreNodesCompositePkMigration, runMigration061Postgres, runMigration061Mysql } from '../server/migrations/061_meshcore_nodes_composite_pk.js';
+import { migration as meshcoreMessagesFromnameMigration, runMigration062Postgres, runMigration062Mysql } from '../server/migrations/062_meshcore_messages_fromname.js';
 
 // ============================================================================
 // Registry
@@ -953,4 +954,21 @@ registry.register({
   sqlite: (db) => meshcoreNodesCompositePkMigration.up(db),
   postgres: (client) => runMigration061Postgres(client),
   mysql: (pool) => runMigration061Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 062: Add `fromName` to `meshcore_messages`.
+// MeshCore channel messages carry no per-sender identity on the wire — the
+// sender prefixes their name onto the text body. MeshCoreManager parses it
+// into `fromName` on the in-memory message. This column persists it so
+// channel messages retain sender attribution after restart.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 62,
+  name: 'meshcore_messages_fromname',
+  settingsKey: 'migration_062_meshcore_messages_fromname',
+  sqlite: (db) => meshcoreMessagesFromnameMigration.up(db),
+  postgres: (client) => runMigration062Postgres(client),
+  mysql: (pool) => runMigration062Mysql(pool),
 });

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -51,6 +51,7 @@ describe('MeshCoreRepository — sourceId stamping', () => {
       CREATE TABLE meshcore_messages (
         id TEXT PRIMARY KEY,
         fromPublicKey TEXT NOT NULL,
+        fromName TEXT,
         toPublicKey TEXT,
         text TEXT NOT NULL,
         timestamp INTEGER NOT NULL,

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -4,7 +4,7 @@
  * Handles MeshCore node and message database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, desc, sql, isNull, and, lt } from 'drizzle-orm';
+import { eq, desc, sql, isNull, and, lt, type SQL } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType } from '../types.js';
 
@@ -52,6 +52,8 @@ export interface DbMeshCoreNode {
 export interface DbMeshCoreMessage {
   id: string;
   fromPublicKey: string;
+  /** Display name parsed from channel message body ("Name: text"); null for DMs. */
+  fromName?: string | null;
   toPublicKey?: string | null;
   text: string;
   timestamp: number;
@@ -286,13 +288,17 @@ export class MeshCoreRepository extends BaseRepository {
   // ============ Message Operations ============
 
   /**
-   * Get recent messages
+   * Get recent messages, optionally scoped to a source.
    */
-  async getRecentMessages(limit: number = 50): Promise<DbMeshCoreMessage[]> {
+  async getRecentMessages(limit: number = 50, sourceId?: string): Promise<DbMeshCoreMessage[]> {
     const { meshcoreMessages } = this.tables;
+    const whereClause: SQL | undefined = sourceId
+      ? eq(meshcoreMessages.sourceId, sourceId)
+      : undefined;
     const result = await this.db
       .select()
       .from(meshcoreMessages)
+      .where(whereClause)
       .orderBy(desc(meshcoreMessages.timestamp))
       .limit(limit);
     return this.normalizeBigInts(result) as unknown as DbMeshCoreMessage[];

--- a/src/db/schema/meshcoreMessages.ts
+++ b/src/db/schema/meshcoreMessages.ts
@@ -15,6 +15,9 @@ export const meshcoreMessagesSqlite = sqliteTable('meshcore_messages', {
   // Sender public key
   fromPublicKey: text('fromPublicKey').notNull(),
 
+  // Display name of the sender (channel messages only; parsed from the "Name: body" prefix)
+  fromName: text('fromName'),
+
   // Recipient public key (null for broadcast)
   toPublicKey: text('toPublicKey'),
 
@@ -47,6 +50,7 @@ export const meshcoreMessagesSqlite = sqliteTable('meshcore_messages', {
 export const meshcoreMessagesPostgres = pgTable('meshcore_messages', {
   id: pgText('id').primaryKey(),
   fromPublicKey: pgText('fromPublicKey').notNull(),
+  fromName: pgText('fromName'),
   toPublicKey: pgText('toPublicKey'),
   text: pgText('text').notNull(),
   timestamp: pgBigint('timestamp', { mode: 'number' }).notNull(),
@@ -64,6 +68,7 @@ export const meshcoreMessagesPostgres = pgTable('meshcore_messages', {
 export const meshcoreMessagesMysql = mysqlTable('meshcore_messages', {
   id: myVarchar('id', { length: 64 }).primaryKey(),
   fromPublicKey: myVarchar('fromPublicKey', { length: 64 }).notNull(),
+  fromName: myVarchar('fromName', { length: 64 }),
   toPublicKey: myVarchar('toPublicKey', { length: 64 }),
   text: myText('text').notNull(),
   timestamp: myBigint('timestamp', { mode: 'number' }).notNull(),

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -332,6 +332,32 @@ class MeshCoreManager extends EventEmitter {
 
     this.config = config;
 
+    // Pre-seed in-memory message cache from DB so history survives restarts.
+    // Reset the array first to avoid duplicates on reconnect within the same
+    // process (the previous session's messages are already in DB).
+    this.messages = [];
+    try {
+      const stored = await databaseService.meshcore.getRecentMessages(
+        MeshCoreManager.MAX_MESSAGES,
+        this.sourceId,
+      );
+      // DB returns newest-first; reverse to oldest-first for the in-memory array.
+      this.messages = stored.reverse().map(dbMsg => ({
+        id: dbMsg.id,
+        fromPublicKey: dbMsg.fromPublicKey,
+        fromName: dbMsg.fromName ?? undefined,
+        toPublicKey: dbMsg.toPublicKey ?? undefined,
+        text: dbMsg.text,
+        timestamp: dbMsg.timestamp,
+        rssi: dbMsg.rssi ?? undefined,
+        snr: dbMsg.snr ?? undefined,
+        sourceId: dbMsg.sourceId ?? undefined,
+      }));
+    } catch (loadErr) {
+      logger.warn(`[MeshCore:${this.sourceId}] Failed to load messages from DB: ${(loadErr as Error).message}`);
+      this.messages = [];
+    }
+
     logger.info(`[MeshCore] Connecting via ${this.config.connectionType}...`);
     this.connectionState = 'connecting';
 
@@ -807,6 +833,24 @@ class MeshCoreManager extends EventEmitter {
     if (this.messages.length > MeshCoreManager.MAX_MESSAGES) {
       this.messages = this.messages.slice(-MeshCoreManager.MAX_MESSAGES);
     }
+    databaseService.meshcore.insertMessage(
+      {
+        id: message.id,
+        fromPublicKey: message.fromPublicKey,
+        fromName: message.fromName ?? null,
+        toPublicKey: message.toPublicKey ?? null,
+        text: message.text,
+        timestamp: message.timestamp,
+        rssi: message.rssi ?? null,
+        snr: message.snr ?? null,
+        messageType: 'text',
+        sourceId: this.sourceId,
+        createdAt: Date.now(),
+      },
+      this.sourceId,
+    ).catch(err => {
+      logger.warn(`[MeshCore:${this.sourceId}] Failed to persist message ${message.id}: ${(err as Error).message}`);
+    });
   }
 
   /**

--- a/src/server/migrations/062_meshcore_messages_fromname.ts
+++ b/src/server/migrations/062_meshcore_messages_fromname.ts
@@ -1,0 +1,71 @@
+/**
+ * Migration 062: Add `fromName` column to `meshcore_messages`.
+ *
+ * MeshCore channel packets carry no per-sender identity on the wire — the
+ * sender prefixes their display name onto the text body ("Alice: hello").
+ * MeshCoreManager parses this prefix out and stores it as `fromName` on the
+ * in-memory MeshCoreMessage so the UI can render sender and body separately.
+ * Before this migration that field was never persisted, so channel messages
+ * loaded from the database on restart would show without sender attribution.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 062';
+const TABLE = 'meshcore_messages';
+const COLUMN = 'fromName';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding ${TABLE}.${COLUMN}...`);
+    try {
+      db.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${COLUMN} TEXT`);
+      logger.debug(`${LABEL} (SQLite): added ${TABLE}.${COLUMN}`);
+    } catch (e: any) {
+      if (e.message?.includes('duplicate column')) {
+        logger.debug(`${LABEL} (SQLite): ${TABLE}.${COLUMN} already exists, skipping`);
+      } else {
+        logger.error(`${LABEL} (SQLite): could not add ${TABLE}.${COLUMN}:`, e.message);
+        throw e;
+      }
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration062Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding ${TABLE}.${COLUMN}...`);
+  await client.query(`ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS "${COLUMN}" TEXT`);
+  logger.debug(`${LABEL} (PostgreSQL): ensured ${TABLE}.${COLUMN}`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration062Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding ${TABLE}.${COLUMN}...`);
+  const conn = await pool.getConnection();
+  try {
+    const [rows] = await conn.query(
+      `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+      [TABLE, COLUMN],
+    );
+    if (!Array.isArray(rows) || rows.length === 0) {
+      await conn.query(`ALTER TABLE ${TABLE} ADD COLUMN ${COLUMN} VARCHAR(64)`);
+      logger.debug(`${LABEL} (MySQL): added ${TABLE}.${COLUMN}`);
+    } else {
+      logger.debug(`${LABEL} (MySQL): ${TABLE}.${COLUMN} already exists, skipping`);
+    }
+  } finally {
+    conn.release();
+  }
+}

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -207,7 +207,7 @@ router.post('/connect', meshcoreDeviceLimiter, requireAuth(), requirePermission(
       connectionType: connectionType as ConnectionType || ConnectionType.SERIAL,
       serialPort,
       tcpHost,
-      tcpPort: parsedTcpPort ?? 4403,
+      tcpPort: parsedTcpPort ?? 5000,
       baudRate: parsedBaudRate ?? 115200,
       firmwareType,
     };


### PR DESCRIPTION
## Summary

Fixes #3057 — MeshCore conversations were lost on every restart because `MeshCoreManager` never wrote to the database. The `meshcore_messages` table and all repository methods existed but were never wired up.

- **Message persistence**: `addMessage()` now fire-and-forget inserts each message to the database; on connect the in-memory cache is pre-seeded from the database, so history is immediately available after a restart without changing any route or API shape
- **`fromName` migration (062)**: channel messages carry no per-sender field on the wire — the sender prefixes their display name onto the body (`"Alice: hello"`). A new column persists the parsed name so channel messages retain sender attribution after reload
- **`sourceId` scoping**: `getRecentMessages` now accepts an optional `sourceId` so per-source loads don't bleed across sources
- **Default TCP port**: changed from `4403` to `5000` to match the MeshCore meshcore-proxy and Wi-Fi firmware defaults

## Changes

| File | What changed |
|------|-------------|
| `src/server/migrations/062_meshcore_messages_fromname.ts` | New migration — adds `fromName TEXT` to `meshcore_messages` (SQLite/PG/MySQL, idempotent) |
| `src/db/schema/meshcoreMessages.ts` | `fromName` column added to all three backend schemas |
| `src/db/repositories/meshcore.ts` | `fromName` on `DbMeshCoreMessage`; optional `sourceId` param on `getRecentMessages` |
| `src/server/meshcoreManager.ts` | DB load at connect time; DB persist in `addMessage()` |
| `src/server/routes/meshcoreRoutes.ts` | Default TCP port `4403` → `5000` |
| `src/db/migrations.ts` | Register migration 062 |
| `src/db/migrations.test.ts` | Count 61 → 62, last-migration assertion updated |

## Test plan

- [ ] Restart MeshMonitor while connected to a MeshCore source — verify existing DMs and channel conversations are restored in the UI
- [ ] Send a new message, restart, confirm the new message persists
- [ ] Verify channel messages show the correct sender name after restart
- [ ] Add a new MeshCore TCP source without specifying a port — confirm it defaults to `5000`
- [ ] CI passes (migrations test, full Vitest suite)

https://claude.ai/code/session_016hkudBarWed7ukheFqfBsz

---
_Generated by [Claude Code](https://claude.ai/code/session_016hkudBarWed7ukheFqfBsz)_