### PR TITLE
chore(release): 4.6.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.5.2",
+  "version": "4.6.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.5.2",
+  "version": "4.6.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.5.2
-appVersion: "4.5.2"
+version: 4.6.0
+appVersion: "4.6.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.5.2",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.5.2",
+      "version": "4.6.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.5.2",
+  "version": "4.6.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Version bump to **4.6.0** across all five required locations:

- `package.json`
- `package-lock.json` (regenerated via `npm install --package-lock-only --legacy-peer-deps`)
- `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`)
- `desktop/package.json`
- `desktop/src-tauri/tauri.conf.json`

## What's in 4.6.0 since 4.5.2

### Features

- **#3003** — feat(mqtt): embedded MQTT broker + bidirectional bridges (landed across `b848aad1` + `e19d1eb6` + `cec744ff`). New MQTT broker source type, packet filter, and bridge manager. The big-ticket addition of the 4.6 line.

### Fixes

- **#3049** — fix(#3025): scope frontend neighbor-info fetch to current source + defensive lastHeard refresh
- **#3050** — fix(#3048): scale MeshCore radio params between UI MHz/kHz and wire kHz/Hz
- **#3058** — fix(meshcore): persist channel/DM messages to DB; fix TCP port default
- **#3062** — fix: respect `MESHTASTIC_NODE_PORT` env var on fresh install
- **#3065** — fix(desktop): stop creating a phantom Meshtastic source on MeshCore-only installs *(includes a backend behavior change — fresh installs that don't set `MESHTASTIC_NODE_IP` now seed the auto-default Meshtastic source as `enabled=0`. Justifies the minor-version bump per SemVer.)*

### CI / docs

- **#3060** — ci(system-tests): fail-fast on first failing test, drop retry attempt
- **#3061** — docs: embedded MQTT broker — configurator option, feature docs, blog post

## Test plan

- [x] All five version files match (`4.6.0`)
- [x] `package-lock.json` regenerated cleanly against the latest origin/main dependency tree
- [x] No other files modified — diff is 7 lines added, 7 deleted
- [ ] CI to verify build + tests + system tests
- [ ] Helm chart rendering + Tauri desktop build to confirm the version stamp threads through both bundles

## Note on the branch name

This PR was originally cut as 4.5.3; the head ref still reads `chore/release-4.5.3` after the force-push that rebased onto latest main and rewrote the commit as `chore(release): 4.6.0`. If you'd rather have the branch name match the title, I can close + reopen on `chore/release-4.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
