### PR TITLE
fix: respect MESHTASTIC_NODE_PORT env var on fresh install

### DIFF
--- a/src/server/config/environment.ts
+++ b/src/server/config/environment.ts
@@ -465,7 +465,13 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
     value: process.env.MESHTASTIC_NODE_IP || '192.168.1.100',
     wasProvided: process.env.MESHTASTIC_NODE_IP !== undefined
   };
-  const meshtasticTcpPort = parseInt32('MESHTASTIC_TCP_PORT', process.env.MESHTASTIC_TCP_PORT, 4403);
+  // Accept MESHTASTIC_NODE_PORT (used by the online configurator and docker-compose examples)
+  // as a synonym for MESHTASTIC_TCP_PORT, giving it priority.
+  const meshtasticTcpPort = parseInt32(
+    'MESHTASTIC_NODE_PORT / MESHTASTIC_TCP_PORT',
+    process.env.MESHTASTIC_NODE_PORT ?? process.env.MESHTASTIC_TCP_PORT,
+    4403
+  );
   const meshtasticStaleConnectionTimeout = parseInt32(
     'MESHTASTIC_STALE_CONNECTION_TIMEOUT',
     process.env.MESHTASTIC_STALE_CONNECTION_TIMEOUT,
@@ -671,7 +677,7 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
   }
   logger.info('   --- Meshtastic ---');
   logger.info(`   MESHTASTIC_NODE_IP: ${meshtasticNodeIp.value} (${src(meshtasticNodeIp.wasProvided)})`);
-  logger.info(`   MESHTASTIC_TCP_PORT: ${meshtasticTcpPort.value} (${src(meshtasticTcpPort.wasProvided)})`);
+  logger.info(`   MESHTASTIC_NODE_PORT / MESHTASTIC_TCP_PORT: ${meshtasticTcpPort.value} (${src(meshtasticTcpPort.wasProvided)})`);
   logger.info(`   MESHTASTIC_STALE_CONNECTION_TIMEOUT: ${meshtasticStaleConnectionTimeout.value}ms (${src(meshtasticStaleConnectionTimeout.wasProvided)})`);
   logger.info(`   MESHTASTIC_CONNECT_TIMEOUT_MS: ${meshtasticConnectTimeoutMs.value}ms (${src(meshtasticConnectTimeoutMs.wasProvided)})`);
   logger.info(`   MESHTASTIC_RECONNECT_INITIAL_DELAY_MS: ${meshtasticReconnectInitialDelayMs.value}ms (${src(meshtasticReconnectInitialDelayMs.wasProvided)})`);


### PR DESCRIPTION
## Summary

- The online configurator and many docker-compose examples document `MESHTASTIC_NODE_PORT`, but `environment.ts` only read `MESHTASTIC_TCP_PORT`
- On a fresh install, the default source was always created with port `4403` regardless of what `MESHTASTIC_NODE_PORT` was set to
- Fix: accept both names, with `MESHTASTIC_NODE_PORT` taking priority and `MESHTASTIC_TCP_PORT` as a backwards-compatible fallback

## Root cause

`src/server/config/environment.ts:468` read only `process.env.MESHTASTIC_TCP_PORT`. The startup log, `.env.example`, and internal docs consistently used `MESHTASTIC_TCP_PORT`, but the public-facing online configurator and several docker-compose example files (`docker-compose.rpi.yml`, `docker-compose.ble.yml`, meshtasticd configs) all used `MESHTASTIC_NODE_PORT` — so users following the configurator would silently get the default port.

## Test plan

- [ ] Fresh install with `MESHTASTIC_NODE_PORT=5000` in docker-compose → source is created with port 5000
- [ ] Fresh install with `MESHTASTIC_TCP_PORT=5000` (legacy name) → source is created with port 5000 (backwards compat)
- [ ] Both set → `MESHTASTIC_NODE_PORT` wins
- [ ] Neither set → default 4403 applies
- [ ] Startup log shows `MESHTASTIC_NODE_PORT / MESHTASTIC_TCP_PORT: <value>`

Fixes #3061

https://claude.ai/code/session_01VjtwcgbcfgeLaL7mKa4yoz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjtwcgbcfgeLaL7mKa4yoz)_