### PR TITLE
docs: embedded MQTT broker — configurator option, feature docs, blog post

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -83,6 +83,7 @@ export default defineConfig({
             { text: 'Security', link: '/features/security' },
             { text: 'Message Search', link: '/features/message-search' },
             { text: 'Store & Forward', link: '/features/store-forward' },
+            { text: 'Embedded MQTT Broker', link: '/features/mqtt-broker' },
             { text: 'Embed Maps', link: '/features/embed-maps' },
             { text: 'Map Analysis', link: '/features/map-analysis' },
             { text: 'Waypoints', link: '/features/waypoints' },

--- a/docs/.vitepress/theme/DockerComposeConfigurator.vue
+++ b/docs/.vitepress/theme/DockerComposeConfigurator.vue
@@ -488,6 +488,35 @@
 
       <div class="form-group">
         <label class="checkbox-label">
+          <input type="checkbox" v-model="config.enableEmbeddedMqttBroker" />
+          Expose embedded MQTT broker (port 1883)
+        </label>
+        <p class="field-help">
+          Publishes host port <code>1883</code> so Meshtastic devices can connect <strong>directly</strong>
+          to MeshMonitor's built-in MQTT broker. The broker itself is still configured per-source in
+          <strong>Dashboard → Sources → Add Source → Embedded MQTT Broker</strong> after the container starts;
+          this checkbox only opens the host firewall path. Leave off if you'll only use the
+          <em>client-proxy</em> path (devices proxy through their TCP API connection — no extra port needed).
+          <a href="/features/mqtt-broker" target="_blank">Learn more</a>
+        </p>
+      </div>
+
+      <div v-if="config.enableEmbeddedMqttBroker" class="info-box">
+        <strong>📡 Embedded MQTT Broker Setup:</strong>
+        <ol>
+          <li>After container start, go to <strong>Dashboard → Sources → Add Source</strong> and pick <strong>Embedded MQTT Broker</strong>.</li>
+          <li>Set a listen port (default <code>1883</code>) and a shared username/password. Devices must use these credentials to publish.</li>
+          <li>On each Meshtastic device, set <strong>Device → MQTT</strong> → address to <code>&lt;your-host-ip&gt;:1883</code>, fill in the same credentials, and save. The device opens a TCP socket directly to the broker on the standard MQTT port (<a href="https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=mqtt" target="_blank">IANA 1883</a>).</li>
+          <li>Optional: add one or more <strong>MQTT Bridge</strong> sources for upstream public brokers (e.g. <code>mqtt.meshtastic.org</code>) with filter rules (topic / channel / portnum / geographic bounding box).</li>
+        </ol>
+        <p style="margin-top: 1rem; font-size: 0.9rem;">
+          💡 The broker uses <a href="https://github.com/moscajs/aedes" target="_blank">Aedes</a> (pure-Node MQTT 3.1.1 broker) under the hood.
+          TLS (port 8883) and WebSocket listeners are not in v1.
+        </p>
+      </div>
+
+      <div class="form-group">
+        <label class="checkbox-label">
           <input type="checkbox" v-model="config.enableMqttProxy" />
           Enable MQTT Client Proxy Sidecar
         </label>
@@ -495,6 +524,10 @@
           Adds an MQTT proxy container that routes MQTT traffic through MeshMonitor instead of directly from your node.
           Useful when your node has unreliable WiFi or when you want MQTT without running mobile apps.
           <a href="/add-ons/mqtt-proxy" target="_blank">Learn more</a>
+        </p>
+        <p v-if="config.enableEmbeddedMqttBroker" class="field-help" style="color: var(--vp-c-warning-1, #d97706); margin-top: 0.5rem;">
+          ℹ️ The embedded broker (above) already covers this use case natively — no sidecar required.
+          Both can coexist (they listen on different ports), but most deployments only need one.
         </p>
       </div>
 
@@ -622,7 +655,8 @@ const config = ref({
   enableOfflineMaps: false,
   tileServerPort: 8081,
   enableAutoResponderScripts: false,
-  enableMqttProxy: false
+  enableMqttProxy: false,
+  enableEmbeddedMqttBroker: false
 })
 
 const copiedDockerCompose = ref(false)
@@ -738,6 +772,11 @@ const dockerComposeYaml = computed(() => {
     // Publishes the host port for Virtual Node. The in-container port
     // must match — configure it per-source in Dashboard → Edit Source → Virtual Node.
     lines.push(`      - "${config.value.virtualNodePort}:${config.value.virtualNodePort}"`)
+  }
+  if (config.value.enableEmbeddedMqttBroker) {
+    // Publishes the embedded MQTT broker's standard port. The broker itself
+    // is configured per-source in Dashboard → Sources → Add Source.
+    lines.push('      - "1883:1883"  # Embedded MQTT broker — devices connect here for direct-TCP MQTT')
   }
   lines.push('    restart: unless-stopped')
   lines.push('    volumes:')

--- a/docs/add-ons/mqtt-proxy.md
+++ b/docs/add-ons/mqtt-proxy.md
@@ -6,6 +6,10 @@ The MQTT Client Proxy is an optional sidecar container that enables reliable MQT
 The MQTT Proxy was created by [LN4CY](https://github.com/LN4CY/mqtt-proxy). MeshMonitor integrates it as an optional Docker sidecar. See also: [AI Responder](/add-ons/ai-responder), another add-on by the same author.
 :::
 
+::: info Built-in alternative since 4.6
+MeshMonitor now ships its own [**Embedded MQTT Broker**](/features/mqtt-broker) source type that covers most of the use cases this sidecar addresses, with added support for **multiple upstream bridges** and **server-side filtering** (geographic bounding boxes, topic / channel / node / portnum allow-block lists). The sidecar remains a valid option — particularly for pure-relay setups with no MeshMonitor-side ingestion of bridged data. See [the comparison table](/features/mqtt-broker#comparison-embedded-broker-vs-mqtt-proxy-sidecar-vs-node-s-built-in-mqtt) for a per-feature breakdown.
+:::
+
 ## Overview
 
 The MQTT Client Proxy behaves like the official Meshtastic mobile apps - it uses the `mqttClientProxyMessage` protocol to route MQTT traffic through a client device instead of directly from the node. This provides several advantages over the node's built-in MQTT gateway.

--- a/docs/blog/2026-05-17-embedded-mqtt-broker.md
+++ b/docs/blog/2026-05-17-embedded-mqtt-broker.md
@@ -1,0 +1,62 @@
+---
+id: news-2026-05-17-embedded-mqtt-broker
+title: MeshMonitor 4.6 — Embedded MQTT Broker + Bidirectional Bridges
+date: '2026-05-17T22:00:00Z'
+category: feature
+priority: important
+minVersion: 4.6.0
+---
+MeshMonitor 4.6 ships its own MQTT broker. Devices can connect to MeshMonitor directly (or via the existing client-proxy path), MeshMonitor can fan that traffic out to one or more upstream public brokers, and you can attach **filter rules** to each bridge — including a geographic bounding box that drops out-of-area position packets before they ever reach your local mesh.
+
+This is the answer to [issue #3003](https://github.com/Yeraze/meshmonitor/issues/3003): "public Meshtastic MQTT brokers aggregate nodes across an entire country, and downlink pollutes my nodeDB and my RF mesh." It landed in two PRs — [#3053](https://github.com/Yeraze/meshmonitor/pull/3053) (the broker + bridges) and [#3054](https://github.com/Yeraze/meshmonitor/pull/3054) (the `FromRadio.mqttClientProxyMessage` follow-up so devices without WiFi can also reach it).
+
+## Two new source types
+
+Both register the same way as your existing Meshtastic and MeshCore sources — **Dashboard → Sources → Add Source**.
+
+**`mqtt_broker`** — an [Aedes](https://github.com/moscajs/aedes)-backed MQTT 3.1.1 listener on a port you choose (default `1883`), with shared username/password auth. Whatever publishes against it (devices, bridges, other LAN clients) gets decoded as a [`ServiceEnvelope`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mqtt.proto), and decodable payloads (NodeInfo / Position / TextMessage / Telemetry) are persisted to the database under the broker's own `sourceId`. Encrypted channel payloads pass through to other clients but aren't ingested into MeshMonitor's tables (we don't have the PSKs at the broker level).
+
+**`mqtt_bridge`** — references one parent `mqtt_broker` and one upstream MQTT server. Each bridge has independent **downlink** and **uplink** filter pipelines:
+
+- topic patterns (MQTT wildcards)
+- channel name allow/block
+- node ID allow/block
+- portnum allow/block ([Meshtastic PortNum enum](https://github.com/meshtastic/protobufs/blob/master/meshtastic/portnums.proto))
+- **geographic bounding box** — drop position packets whose lat/lon falls outside `{ minLat, maxLat, minLng, maxLng }`. Applied before republish, so out-of-area positions never reach devices on the local broker.
+
+60-second `(topic, packetId)` echo suppression on both sides keeps the broker → bridge → upstream → bridge → broker path from becoming a feedback loop.
+
+## Two ways for a device to reach the broker
+
+**Direct TCP** — Expose port `1883` from the container (the [Docker Configurator](https://meshmonitor.org/configurator) now has a one-click checkbox under section 8), point the device's MQTT module at `<host>:1883`, plug in the shared credentials. The firmware opens the TCP socket itself, exactly the same code path it uses against any other broker — IANA-registered MQTT port, RFC-standard protocol.
+
+**Client-proxy** — Set `proxy_to_client_enabled = true` on the firmware (defined in [`module_config.proto`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/module_config.proto): _"If true, we can use the connected phone / client to proxy messages to MQTT instead of a direct connection"_), and set a Meshtastic source's `mqttLink` to the embedded broker in the UI. The firmware now hands every outbound publish to MeshMonitor as a [`FromRadio.mqttClientProxyMessage`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto) over its existing TCP/serial connection, MeshMonitor relays to the broker, and broker messages destined for the device come back as `ToRadio.MqttClientProxyMessage`. Same protocol the Meshtastic mobile apps use when proxying.
+
+The **Quick Configure** dropdown on the firmware MQTT page does the firmware flag, firmware-side address/creds/root, AND the source's `mqttLink` stamp in one click. A yellow warning banner appears on the Device → MQTT page if `proxy_to_client_enabled` is on but no `mqttLink` is set — the failure mode used to be silent (firmware proxies into the void), now it's visible.
+
+## Why pick this over the existing MQTT proxy sidecar?
+
+The [LN4CY MQTT Proxy sidecar](/add-ons/mqtt-proxy) is still a perfectly good answer if you want a pure relay — no source row, no ingestion, the proxy is essentially "an always-on mobile app" against a single upstream. The embedded broker is the right answer when you want:
+
+- **Multiple upstream brokers from one local mesh** — N bridges, each independent. Stream to `mqtt.meshtastic.org` for the wider mesh community, to a regional community broker (`mqtt.areyoumeshingwith.us`, etc.), and to a private one, all from the same device's publishes.
+- **Selective bridging** — only forward `msh/US/FL/PALM-BEACH/#` from one upstream, only forward your own positions to another, drop everything outside a 50-mile radius of your home. Filters are per-bridge, server-side, and survive firmware updates.
+- **Server-side ingestion** — bridged upstream traffic shows up as MeshMonitor source data, not just relay-through. You can search messages, see node counts, run telemetry analytics on packets that came from upstream brokers, all attributed to the bridge's `sourceId`.
+- **Mixed device fleet** — some devices on WiFi using direct TCP, others on Serial/BLE using client-proxy, all hitting the same broker. Both paths coexist.
+
+The [feature documentation](https://meshmonitor.org/features/mqtt-broker) has the full comparison table and a step-by-step setup walk-through.
+
+## What's missing in 4.6
+
+- **TLS / WSS listener** — the broker is plain TCP MQTT 3.1.1 only. Put a TLS-terminating reverse proxy in front if you need it. (Aedes supports TLS but wiring it up cleanly in MeshMonitor's source-config model is deferred.)
+- **Per-device credentials** — single shared username/password per broker. Per-device creds + ACLs would be the natural next step but aren't in v1.
+- **MQTT 5.0** — Aedes is 3.1.1 only. Meshtastic firmware speaks 3.1.1 anyway, so this only matters for non-Meshtastic clients on the broker.
+- **Retained-message persistence** — broker is in-memory, retained-messages don't survive a MeshMonitor restart.
+
+## Other changes in 4.6
+
+- **Quick Configure dropdown** on the firmware MQTT page autopopulates address, creds, and root from any configured `mqtt_broker` source — and now also flips `proxy_to_client_enabled` and stamps `mqttLink` in one click ([#3054](https://github.com/Yeraze/meshmonitor/pull/3054)).
+- **Source-card watermarks** for the two new types — hub-and-spoke for the broker, two-nodes-with-bidirectional-arrow for the bridge — keep the sidebar visually consistent with the existing Meshtastic and MeshCore styling.
+- **`lastError` tooltip** on sidebar status pills — a disconnected source now surfaces the actual reason on hover (`Connection refused: Bad username or password`, etc.) instead of just showing a red dot.
+- **System tests fail-fast** — the test harness no longer runs all 11 sub-tests on broken state when one fails ([#3060](https://github.com/Yeraze/meshmonitor/pull/3060)). Debugging CI failures is dramatically faster.
+
+[Read the full Embedded MQTT Broker docs](https://meshmonitor.org/features/mqtt-broker) for setup details, the side-by-side comparison against the proxy sidecar and node's built-in MQTT, troubleshooting, and current limitations.

--- a/docs/features/mqtt-broker.md
+++ b/docs/features/mqtt-broker.md
@@ -1,0 +1,173 @@
+# Embedded MQTT Broker
+
+::: tip Added in 4.6
+The embedded MQTT broker and bidirectional bridges shipped in MeshMonitor 4.6 (PR [#3053](https://github.com/Yeraze/meshmonitor/pull/3053), follow-up client-proxy bridge in PR [#3054](https://github.com/Yeraze/meshmonitor/pull/3054), resolving [issue #3003](https://github.com/Yeraze/meshmonitor/issues/3003)).
+:::
+
+MeshMonitor can run its own MQTT broker inside the same container, so your Meshtastic devices (and any other MQTT clients on your network) can publish directly to MeshMonitor — and MeshMonitor can relay that traffic, with **filtering rules**, to public upstream brokers like `mqtt.meshtastic.org`.
+
+## What problem does this solve?
+
+Public Meshtastic brokers aggregate nodes across an entire country or continent. When a device subscribes to a broad topic (`msh/CA`, `msh/US`) with downlink enabled, its nodeDB and the RF mesh get polluted with packets from nodes hundreds of kilometres away. Per-device workarounds (narrow topics, `ignoreMqtt`) are incomplete and require firmware-version-specific config on every node.
+
+The embedded broker shifts this fight to the server, where MeshMonitor already has full nodeDB context. You point your devices at MeshMonitor's local broker, let MeshMonitor bridge to whatever public upstreams you want, and apply filters (topic patterns, channel/node/portnum allow-block lists, **geographic bounding boxes**) at the bridge instead of on the device. The local mesh stays clean regardless of firmware version.
+
+## Two source types
+
+The feature adds two new source types in **Dashboard → Sources → Add Source**:
+
+### `mqtt_broker` — the listener
+
+A self-contained MQTT broker, backed by [Aedes](https://github.com/moscajs/aedes) (a pure-Node, MQTT 3.1.1 broker, MIT-licensed). Listens on a configurable TCP port (default `1883`) with shared username/password authentication. Decodes [`ServiceEnvelope`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mqtt.proto) packets from any client that publishes, and ingests decodable payloads (NodeInfo, Position, TextMessage, Telemetry) into the database under this source's `sourceId`.
+
+### `mqtt_bridge` — the upstream connection
+
+References a parent `mqtt_broker` by ID and connects to one upstream MQTT server via [MQTT.js](https://github.com/mqttjs/MQTT.js). Each bridge has independent **downlink** (upstream → local) and **uplink** (local → upstream) filter pipelines:
+
+- **Topic patterns** (MQTT wildcards: `+` single-segment, `#` multi-segment tail)
+- **Channel name** allow / block lists
+- **Node ID** allow / block lists (`!xxxxxxxx`)
+- **PortNum** allow / block lists ([Meshtastic PortNum enum](https://github.com/meshtastic/protobufs/blob/master/meshtastic/portnums.proto))
+- **Geographic bounding box** — drop position packets whose `latitude_i / 1e7, longitude_i / 1e7` falls outside `{ minLat, maxLat, minLng, maxLng }`. Applied before republish so out-of-area positions never reach devices on the local broker.
+
+60-second `(topic, packetId)` echo suppression on both directions prevents bridge feedback loops.
+
+## Two ways a device can reach the broker
+
+| Path | Firmware setup | MeshMonitor setup | When to use |
+|---|---|---|---|
+| **Direct TCP** | `mqtt.enabled = true`, `address = <host>:1883`, `proxy_to_client_enabled = false`, credentials match | Expose port 1883 in `docker-compose.yml` | Devices with reliable WiFi/Ethernet that can reach the MeshMonitor host on the LAN |
+| **Client-proxy** | `mqtt.enabled = true`, `proxy_to_client_enabled = true`, credentials/address still set on firmware (mostly decorative in proxy mode) | Set the Meshtastic source's `mqttLink` to the embedded broker (Sources → Edit → "Bridge MQTT proxy to") | Devices without WiFi (Serial/BLE-attached), behind NAT, or on networks where port 1883 isn't reachable |
+
+In proxy mode, the firmware uses Meshtastic's [`MqttClientProxyMessage`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto) protocol: the device hands every outbound publish off as a `FromRadio.mqttClientProxyMessage` over its existing TCP/serial connection to MeshMonitor, and MeshMonitor publishes on its behalf. Inbound messages from the broker are wrapped as `ToRadio.MqttClientProxyMessage` and injected back to the device. This is the same mechanism the Meshtastic mobile apps use when proxying.
+
+## Quick setup
+
+### 1. Create the broker source
+
+In **Dashboard → Sources → Add Source**, pick **Embedded MQTT Broker (devices connect here)** and fill in:
+
+| Field | Notes |
+|---|---|
+| Name | Anything — shows in the sidebar |
+| Listener port | Default `1883` ([IANA-registered MQTT port](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=mqtt)) |
+| Username / Password | Shared credential for all clients |
+| Root topic | Default `msh` — must match what your devices publish under |
+
+Save. MeshMonitor will start the broker; you'll see `MQTT broker listening on 0.0.0.0:1883` in the container logs and a new source card in the sidebar.
+
+If you plan to use the **direct-TCP path**, make sure your `docker-compose.yml` exposes port 1883:
+
+```yaml
+services:
+  meshmonitor:
+    ports:
+      - "8080:3001"
+      - "1883:1883"  # Embedded MQTT broker
+```
+
+The [Docker Configurator](/configurator) has a one-click checkbox for this under section 8.
+
+### 2. (Optional) Add bridges to public upstreams
+
+For each upstream broker (e.g. `mqtt.meshtastic.org`, regional community brokers), pick **MQTT Bridge (forward to/from an upstream broker)** in Add Source:
+
+| Field | Notes |
+|---|---|
+| Parent broker | Pick the `mqtt_broker` source created in step 1 |
+| Upstream URL | `mqtt://mqtt.meshtastic.org` (or `mqtts://...:8883` for TLS) |
+| Username / Password | Whatever the upstream needs (e.g. `meshdev / large4cats` for `mqtt.meshtastic.org`) |
+| Upstream topics | One per line, MQTT wildcards allowed (e.g. `msh/US/FL/#`) |
+| Block topics | Optional — drop publishes matching these patterns (e.g. `msh/CA/QC/#`) |
+| Geographic bounding box | Optional — drop position packets outside the box |
+
+### 3. Configure your Meshtastic devices
+
+**Direct TCP path** — On the device (via MeshMonitor's Device → MQTT tab, the Meshtastic mobile app, or the CLI):
+
+| Field | Value |
+|---|---|
+| Enabled | true |
+| Address | `<MeshMonitor host LAN IP>:1883` |
+| Username / Password | Same as set on the broker source |
+| Root | Same as set on the broker source (default `msh`) |
+| `proxy_to_client_enabled` | **false** (firmware opens the TCP socket itself) |
+
+**Client-proxy path** — On the device:
+
+| Field | Value |
+|---|---|
+| Enabled | true |
+| Address | Decorative in proxy mode, but conventionally set to the broker's hostname |
+| Username / Password | Decorative in proxy mode |
+| `proxy_to_client_enabled` | **true** (firmware hands every publish off via the TCP API) |
+
+Then on the Meshtastic source in MeshMonitor (**Dashboard → Sources → Edit → Bridge MQTT proxy to**), pick the embedded broker. MeshMonitor will forward `FromRadio.mqttClientProxyMessage` payloads to the broker, and inject broker messages back as `ToRadio.MqttClientProxyMessage`. The **Quick Configure** dropdown on the Device → MQTT page does all three of these things (firmware flag, firmware fields, source link) in one click.
+
+If `proxy_to_client_enabled` is on but no `mqttLink` is set, a yellow warning banner appears on the Device → MQTT page — without it, proxy traffic from the firmware would be silently dropped.
+
+## Comparison: embedded broker vs MQTT proxy sidecar vs node's built-in MQTT
+
+| Concern | Node's built-in MQTT | MQTT Proxy Sidecar ([LN4CY](https://github.com/LN4CY/mqtt-proxy)) | **Embedded MQTT Broker** (this feature) |
+|---|---|---|---|
+| **Extra container** | No | Yes (one per node group) | No — runs inside MeshMonitor |
+| **Where credentials live** | On every device | On the device (proxy reads them) | Once on the broker source; devices share creds |
+| **WiFi required on device?** | Yes | No — works over Serial/BLE | Both paths supported (direct = WiFi, proxy = any) |
+| **Filtering** | Limited (topic prefix, `ignoreMqtt`) | None — passthrough | **Per-bridge** allow/block lists + geo bbox, applied server-side |
+| **Server-side ingestion** | None (mesh only sees the message after it lands locally) | None (sidecar is pure relay) | **Yes** — decoded NodeInfo/Position/Text/Telemetry persist under the broker's `sourceId` |
+| **Multiple upstream brokers from one mesh?** | No (single config field) | No (single sidecar instance ≈ single upstream) | **Yes** — N bridges, each with independent filter rules |
+| **Reliability** | Depends on node WiFi | Auto-restart via Docker | Auto-restart via Docker; broker survives bridge failures |
+| **Recovery on broker outage** | Manual node restart | Manual sidecar restart | mqtt.js auto-reconnect with backoff |
+| **Default-deny auth** | Per-device | Per-device | Broker refuses connections without configured username/password |
+| **TLS** | Yes (on device) | Yes (on device + proxy) | **Plain TCP only in v1** (TLS / WSS deferred — track in [#3003](https://github.com/Yeraze/meshmonitor/issues/3003)) |
+| **Operational visibility** | Limited firmware logs | Docker logs | Per-source `packetsIn / packetsIngested / packetsDropped / lastError` in `/api/sources/:id/status` |
+
+### Plain-English summary
+
+- **Node built-in MQTT** is fine if you have one node, one upstream broker, reliable WiFi, and no filtering needs.
+- **MQTT Proxy Sidecar** is the right answer if you mostly want a Serial/BLE node to still reach MQTT, without writing any new MeshMonitor source config — the sidecar is essentially a "mobile app, but always on".
+- **Embedded MQTT Broker** is the right answer when you want **selective bridging** (e.g. only forward msh/US/FL/PALM-BEACH traffic from `mqtt.meshtastic.org`, and only re-broadcast your own self-originated traffic), **multiple upstreams** from one local mesh, **server-side ingestion** (the bridged traffic shows up as MeshMonitor source data, not just relay-through), or you need **devices without WiFi** to publish to a broker that other LAN clients can also subscribe to. Both paths (direct TCP + client-proxy) work simultaneously — you can mix them on a per-device basis.
+
+## Troubleshooting
+
+### "Client proxy is enabled but no broker is linked" (yellow banner on Device → MQTT)
+
+`proxy_to_client_enabled` is set on the firmware, but the Meshtastic source has no `mqttLink`. MeshMonitor will silently drop the proxy publishes unless:
+1. You pick an embedded broker from the **Quick Configure** dropdown on Device → MQTT (one click — also stamps the link via PUT); **or**
+2. You have the [MQTT Proxy Sidecar](/add-ons/mqtt-proxy) attached to this source's Virtual Node Server, which publishes to its own configured upstream.
+
+### Broker has `clientCount: 0` but I configured a device
+
+- Confirm port 1883 is exposed on the container (`docker port meshmonitor | grep 1883`).
+- Confirm the device's `mqtt.address` resolves to the MeshMonitor host's LAN IP (not `localhost` from the device's perspective).
+- Confirm the device's MQTT credentials match the broker source's `auth.username` / `auth.password`.
+- The broker enforces default-deny auth: connections without configured credentials are rejected. Check the device's MQTT log for "Connection refused: Bad username or password" — if firmware logs aren't visible, watch the broker's `lastError` field on `/api/sources/:id/status`.
+
+### `packetsIn` climbing, `packetsIngested` stays low
+
+Most upstream traffic and most device-publish traffic is encrypted at the channel-payload level (e.g. `LongFast` PSK). MeshMonitor doesn't have those PSKs at the broker level, so the packets get **republished** (they reach other devices and bridges) but **not ingested into the DB**. `packetsDropped` counts these. This is normal — only decodable packets (NodeInfo, unencrypted Position/Telemetry, etc.) end up in `nodes` / `messages` tables under the broker's sourceId.
+
+### Bridge reports `lastError: "Bad username or password"`
+
+The credentials configured on the bridge don't match what the upstream accepts for an MQTT subscriber. For `mqtt.meshtastic.org`, the public subscriber credentials are `meshdev / large4cats` ([Meshtastic public MQTT docs](https://meshtastic.org/docs/configuration/module/mqtt/#default-public-server)). Other community brokers may use uplink-only credentials that don't work for raw MQTT subscribers; check with the operator.
+
+### Deleting the broker source
+
+If any `mqtt_bridge` source still references the broker, the delete is refused with a 409 — delete or repoint dependent bridges first.
+
+## Limitations (v1)
+
+- **TLS / WSS not supported** — listener is plain TCP MQTT 3.1.1 only. Deploy behind a TLS-terminating reverse proxy if you need encrypted device → broker.
+- **Single shared credential per broker** — no per-device usernames in v1.
+- **No persistence layer for retained messages** — the broker is ephemeral in-memory (Aedes default).
+- **No MQTT 5.0** — the firmware speaks 3.1.1 anyway, so this only matters if you have non-Meshtastic MQTT clients that require v5.
+
+## Related
+
+- [Multi-Source Architecture](/features/multi-source) — the source-row model the broker plugs into
+- [Device Configuration → MQTT](/features/device#mqtt-configuration) — the firmware-side fields and the **Quick Configure** dropdown
+- [MQTT Client Proxy (sidecar)](/add-ons/mqtt-proxy) — the LN4CY-maintained alternative for Serial/BLE-only deployments
+- [Docker Configurator](/configurator) — generate a `docker-compose.yml` with the right port already exposed
+- [Meshtastic MQTT Module documentation](https://meshtastic.org/docs/configuration/module/mqtt/) — upstream documentation for `proxy_to_client_enabled` and the firmware-side knobs
+- [`MqttClientProxyMessage` protobuf definition](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto) — wire format for the proxy path
+- [`ServiceEnvelope` protobuf definition](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mqtt.proto) — wire format for MQTT-published Meshtastic packets

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,67 +18,75 @@ hero:
 features:
   - icon: 🛰️
     title: Multi-Source Networks
-    details: Connect to multiple Meshtastic nodes at once over TCP — including Serial or BLE nodes fronted by the Serial Bridge or BLE Bridge sidecars — plus USB-attached MeshCore companions and repeaters managed from the Sources sidebar (TCP MeshCore via env-var bootstrap; MQTT source type coming soon). Unified map, messages, telemetry, and traceroute views stay scoped per-source with a single click. Ideal for multi-site deployments, backup gateways, and combining a home node with a repeater.
+    details: Connect to many Meshtastic nodes at once — TCP, Serial, or BLE. One dashboard, per-source maps, messages, telemetry, and traceroutes. No restart to add or remove a source.
+
+  - icon: 📡
+    title: MeshCore Support
+    details: First-class MeshCore companions and repeaters living alongside your Meshtastic nodes. Per-source permissions, a multi-pane page with channels, DMs, and telemetry, and contacts plotted on the unified map.
+
+  - icon: 🌉
+    title: Embedded MQTT Broker
+    details: Run an MQTT broker inside MeshMonitor with bidirectional bridges to public upstreams. Filter what crosses the boundary by topic, channel, portnum, or geographic bounding box — your local mesh stays clean without firmware changes.
 
   - icon: 🔐
     title: Per-Source Permissions
-    details: Grant users access to specific sources, not the whole deployment. Shared dashboards, separate operators, and read-only guests all coexist. Admin-managed Users page, SSO support, and MFA round out the access model.
+    details: Grant users access to specific sources, not the whole deployment. Local accounts, SSO (OIDC), MFA, and a full admin audit log.
 
   - icon: 🌐
     title: Per-Source Virtual Node
-    details: Each TCP source can expose its own Virtual Node endpoint on its own port. Multiple Meshtastic mobile apps connect simultaneously through MeshMonitor, with message queuing, config caching, and stability for 3-5+ concurrent clients.
+    details: Each TCP source exposes its own Virtual Node endpoint. Run multiple Meshtastic mobile apps through MeshMonitor with message queuing and config caching.
 
   - icon: 🗺️
-    title: Interactive Map View
-    details: Visualize your mesh network on an interactive map with real-time node positions, signal strength indicators, and network topology. Import GeoJSON, KML, and KMZ overlays to layer zone maps or emergency boundaries. Enable a polar grid overlay for RF coverage visualization.
+    title: Interactive Map
+    details: Real-time node positions, signal-strength indicators, and topology overlays. GeoJSON / KML / KMZ imports for zones, plus an optional polar grid for RF coverage.
 
   - icon: 📊
     title: Analytics & Telemetry
-    details: Track message statistics, node health, signal quality (SNR), and network performance over time with detailed charts and graphs. Switch between chart, gauge, and numeric display modes for telemetry widgets. Unified telemetry view with search, sort, and source filtering.
+    details: Charts, gauges, and numeric widgets across every source. Unified telemetry views with search, sort, and per-source filtering.
 
   - icon: 💬
-    title: Message Management
-    details: View, send, and manage messages across your mesh network. Unified cross-source messages view with per-source isolation. Multi-channel support, drag and drop channel reordering, tapbacks, replies, and full message search.
+    title: Messages
+    details: Unified cross-source view with per-source filters. Multi-channel, drag-and-drop reorder, tapbacks, replies, full-text search.
 
   - icon: ⚡
     title: Automation & Triggers
-    details: Create powerful automations with Auto-Responders, Scheduled Messages, Auto-Traceroute, and Geofence Triggers. Define geographic zones and trigger responses when nodes enter, exit, or remain inside — perfect for arrival notifications, asset tracking, and proximity alerts. Extend further with custom Python or Bash scripts.
+    details: Auto-Responders, Scheduled Messages, Auto-Traceroute, and Geofence Triggers. Extend with custom Python or Bash scripts.
 
   - icon: 📬
     title: Store & Forward
-    details: Work with Store & Forward servers on your mesh — retrieve history from S&F peers, flag S&F server nodes on the map, and keep messages flowing across offline gaps.
+    details: Retrieve history from S&F peers, flag S&F servers on the map, and keep messages flowing across offline gaps.
 
   - icon: 🔒
     title: Security Monitoring
-    details: Automatic detection of weak encryption keys and duplicate key issues. Built-in authentication with local accounts, MFA/TOTP, SSO (OIDC), and a full audit log of admin actions.
+    details: Automatic detection of weak or duplicate encryption keys across your nodes. Full admin audit log of every privileged action.
 
   - icon: 🔔
     title: Push Notifications
-    details: Receive real-time alerts for new messages and per-source events on iOS, Android, and desktop — even when the app is closed. Apprise integration for email, Slack, Discord, Telegram, and more. Zero configuration, works with HTTPS.
+    details: Real-time alerts on iOS, Android, and desktop — even when the app is closed. Apprise for email, Slack, Discord, Telegram, and more.
 
   - icon: 🖥️
     title: Remote Administration
-    details: Change node connections on-the-fly without container restarts. Configure device settings, manage channels, run the Quick Node Configurator, and push OTA firmware updates through a connected gateway — all from the web interface.
+    details: Configure devices, manage channels, and push OTA firmware updates through a connected gateway — all from the web UI, no SSH or CLI.
 
   - icon: 🧩
-    title: Custom Map Tile Servers
-    details: Configure custom map tile servers with support for both vector (.pbf) and raster (.png) tiles. Enable offline operation, custom styling, and privacy-focused mapping. Works with TileServer GL, nginx caching proxy, and standard XYZ tile servers. Upload custom MapLibre style JSON for fully branded or offline-first map appearances.
+    title: Custom Map Tiles
+    details: Bring your own vector or raster tiles (TileServer GL, nginx, XYZ). Upload custom MapLibre styles for branded or offline-first maps.
 
   - icon: 🎨
     title: Customizable Themes
-    details: Choose from 15 built-in themes or create your own with the visual theme editor. Includes color-blind friendly options, WCAG AAA compliant high-contrast themes, and full import/export support for sharing custom themes.
+    details: 15 built-in themes plus a visual editor. Color-blind friendly and WCAG AAA high-contrast variants. Import / export to share.
 
   - icon: ☀️
     title: Solar Monitoring
-    details: Integrate with forecast.solar to visualize expected solar production alongside telemetry data. Run the cross-source Solar Monitoring Analysis report to auto-detect solar-powered nodes, project battery state across the forecast horizon, and surface nodes predicted at risk. Perfect for optimizing off-grid deployments.
+    details: forecast.solar projections alongside telemetry. Auto-detect solar nodes and surface ones predicted at risk for off-grid deployments.
 
   - icon: 💻
     title: Desktop & Mobile
-    details: Native desktop app for Windows and macOS — no server, no Docker. Progressive Web App (PWA) for iOS and Android with a collapsible sidebar on small screens. System tray integration keeps your network awareness one click away.
+    details: Native desktop app for Windows and macOS. Progressive Web App for iOS and Android with a collapsible sidebar and system-tray integration.
 
   - icon: 🐳
     title: Flexible Deployment
-    details: Deploy with Docker Compose, Kubernetes (Helm charts included), Proxmox LXC, or bare metal. SQLite, PostgreSQL, or MySQL backends. System backup, one-click auto-upgrade, and reverse-proxy-friendly configuration out of the box.
+    details: Docker Compose, Kubernetes (Helm), Proxmox LXC, or bare metal. SQLite, PostgreSQL, or MySQL. Reverse-proxy-friendly with one-click auto-upgrade.
 ---
 
 ## Quick Start
@@ -149,7 +157,7 @@ MeshMonitor supports multiple deployment scenarios:
 ## Screenshots
 
 ### Multi-Source Dashboard
-Every source your deployment touches shows up in the sidebar with its own health, map pin colour, and unified or source-scoped views. Meshtastic TCP (with Serial/BLE via the bridge sidecars) and USB-attached MeshCore are first-class today; TCP MeshCore is supported via the legacy env-var bootstrap path, and MQTT is coming soon.
+Every source your deployment touches shows up in the sidebar with its own health, map pin colour, and unified or source-scoped views. Meshtastic TCP (with Serial/BLE via the bridge sidecars), USB-attached MeshCore, and the embedded MQTT broker are first-class today; TCP MeshCore is supported via the legacy env-var bootstrap path.
 
 ![Multi-Source Dashboard](/images/features/dashboard-multi-source.png)
 


### PR DESCRIPTION
## Summary

Documentation pass for the embedded MQTT broker feature that landed in [#3053](https://github.com/Yeraze/meshmonitor/pull/3053) + [#3054](https://github.com/Yeraze/meshmonitor/pull/3054) (resolving [#3003](https://github.com/Yeraze/meshmonitor/issues/3003)).

- **Docker Configurator** — new "Expose embedded MQTT broker (port 1883)" toggle under section 8, with an info-box and a coexistence note for users who also have the MQTT Proxy sidecar checked. Emits `- "1883:1883"` on the meshmonitor service when on.
- **`docs/features/mqtt-broker.md`** — full feature page: the two source types, the two device paths (direct TCP and `mqttClientProxyMessage` client-proxy), filter semantics, quick-setup walk-through, comparison table against the MQTT Proxy Sidecar and node's built-in MQTT, troubleshooting, limitations. Linked from the Features sidebar.
- **`docs/add-ons/mqtt-proxy.md`** — info callout at the top pointing readers at the new built-in alternative, with a deep-link to the comparison table.
- **`docs/blog/2026-05-17-embedded-mqtt-broker.md`** — release announcement following the established blog-post format (frontmatter with id/title/date/category/priority/minVersion).

## Fact-check notes

Every external claim was cross-referenced before drafting:

- **Aedes 1.0.2 / MQTT.js 5.15.1** — confirmed against `package.json` in main (`grep '"aedes\|mqtt"' package.json`).
- **`MqttClientProxyMessage` protobuf** — confirmed against `protobufs/meshtastic/mesh.proto` (vendored submodule). Has `topic` + `payload_variant` oneof (`data` bytes or `text` string). Linked the upstream URL on github.com/meshtastic/protobufs.
- **`proxy_to_client_enabled`** — confirmed against `protobufs/meshtastic/module_config.proto` field 9 on the MQTT module config. Quoted the upstream comment verbatim.
- **`ServiceEnvelope`** — confirmed in `protobufs/meshtastic/mqtt.proto`.
- **Port 1883** — referenced the IANA service-names port-number registry directly.
- **PR / issue numbers** (#3003, #3053, #3054, #3060) — confirmed via `gh pr view` / `gh issue view`.
- **`mqtt.meshtastic.org` default public broker + `meshdev / large4cats` subscriber credentials** — referenced upstream docs at meshtastic.org/docs/configuration/module/mqtt/.

## Version placeholder

The blog post and the feature-doc admonition use `4.6.0` as the minimum version. The active release PR is [#3059](https://github.com/Yeraze/meshmonitor/pull/3059) (4.5.3, doesn't include the MQTT broker). Adjust the version label before publishing if the feature ships under a different number — the placeholder is in three places:

- `docs/blog/2026-05-17-embedded-mqtt-broker.md` frontmatter `minVersion: 4.6.0`
- `docs/blog/2026-05-17-embedded-mqtt-broker.md` title "MeshMonitor 4.6 — …"
- `docs/features/mqtt-broker.md` admonition "Added in 4.6"
- `docs/add-ons/mqtt-proxy.md` admonition "Built-in alternative since 4.6"

## Test plan

- [x] All five files lint-clean (markdown + Vue + TypeScript).
- [x] No new broken internal links — all `/features/mqtt-broker`, `/configurator`, `/add-ons/mqtt-proxy`, `/features/multi-source`, `/features/device` paths already exist.
- [ ] Visual review of the configurator section in a dev VitePress server (reviewer to confirm the new checkbox + info-box render cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)