### PR TITLE
feat(mqtt-bridge): seed bbox from detected node positions on first enable

### DIFF
--- a/src/pages/DashboardPage.bboxSeed.test.ts
+++ b/src/pages/DashboardPage.bboxSeed.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Focused tests for the helpers that seed the mqtt_bridge geofence bbox
+ * from currently-detected node positions. Lives in its own file (rather
+ * than DashboardPage.test.tsx) because the helpers are pure and don't
+ * need the JSDOM / React render stack.
+ */
+import { describe, it, expect } from 'vitest';
+import { boundsFromDetectedNodes, bboxToFormStrings } from './DashboardPage.bboxSeed';
+
+describe('boundsFromDetectedNodes', () => {
+  it('returns null when no nodes report a position', () => {
+    expect(boundsFromDetectedNodes([])).toBeNull();
+    expect(
+      boundsFromDetectedNodes([
+        { latitude: undefined, longitude: undefined },
+        { latitude: null, longitude: null },
+      ]),
+    ).toBeNull();
+  });
+
+  it('skips nodes with the (0,0) "no fix" sentinel', () => {
+    // Without skipping (0,0), a single un-positioned node would balloon
+    // the bbox out to the middle of the ocean — defeating the whole point.
+    expect(
+      boundsFromDetectedNodes([{ latitude: 0, longitude: 0 }]),
+    ).toBeNull();
+    expect(
+      boundsFromDetectedNodes([
+        { latitude: 0, longitude: 0 },
+        { latitude: 44.5, longitude: -78.5 },
+      ]),
+    ).toEqual({
+      minLat: 44.5 - 0.05,
+      maxLat: 44.5 + 0.05,
+      minLng: -78.5 - 0.05,
+      maxLng: -78.5 + 0.05,
+    });
+  });
+
+  it('encloses a multi-node cluster with 10% padding', () => {
+    const bbox = boundsFromDetectedNodes([
+      { latitude: 43, longitude: -80 },
+      { latitude: 45, longitude: -77 },
+      { latitude: 44, longitude: -78.5 },
+    ]);
+    // Range: lat 43→45 (2°), lng -80→-77 (3°). 10% padding = 0.2° lat / 0.3° lng.
+    expect(bbox).not.toBeNull();
+    expect(bbox!.minLat).toBeCloseTo(43 - 0.2, 5);
+    expect(bbox!.maxLat).toBeCloseTo(45 + 0.2, 5);
+    expect(bbox!.minLng).toBeCloseTo(-80 - 0.3, 5);
+    expect(bbox!.maxLng).toBeCloseTo(-77 + 0.3, 5);
+  });
+
+  it('applies the minimum 0.05° padding for a single (non-zero) node', () => {
+    const bbox = boundsFromDetectedNodes([{ latitude: 44.0, longitude: -78.0 }]);
+    // Single node → range is 0; padding clamps to 0.05° minimum each side.
+    expect(bbox).toEqual({
+      minLat: 43.95,
+      maxLat: 44.05,
+      minLng: -78.05,
+      maxLng: -77.95,
+    });
+  });
+
+  it('ignores partial position rows (only one of lat/lng present)', () => {
+    expect(
+      boundsFromDetectedNodes([
+        { latitude: 44.5 },
+        { longitude: -78.5 },
+      ] as Array<{ latitude?: number; longitude?: number }>),
+    ).toBeNull();
+  });
+});
+
+describe('bboxToFormStrings', () => {
+  it('rounds each axis to 5 decimal places', () => {
+    expect(
+      bboxToFormStrings({
+        minLat: 43.123456789,
+        maxLat: 44.987654321,
+        minLng: -80.111111111,
+        maxLng: -77.999999999,
+      }),
+    ).toEqual({
+      minLat: '43.12346',
+      maxLat: '44.98765',
+      minLng: '-80.11111',
+      maxLng: '-78.00000',
+    });
+  });
+});

--- a/src/pages/DashboardPage.bboxSeed.ts
+++ b/src/pages/DashboardPage.bboxSeed.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure helpers used by the mqtt_bridge geofence editor inside DashboardPage.
+ *
+ * Extracted here so the unit tests can import them without dragging in the
+ * full React component tree (which depends on JSDOM globals).
+ */
+import type { BBoxValue } from '../components/BBoxMapEditor';
+
+export function bboxToFormStrings(b: BBoxValue): {
+  minLat: string;
+  maxLat: string;
+  minLng: string;
+  maxLng: string;
+} {
+  return {
+    minLat: b.minLat.toFixed(5),
+    maxLat: b.maxLat.toFixed(5),
+    minLng: b.minLng.toFixed(5),
+    maxLng: b.maxLng.toFixed(5),
+  };
+}
+
+/**
+ * Compute a bbox enclosing all nodes that report a real position, with a
+ * 10% padding (clamped to a minimum of 0.05° ≈ 5km) so the rectangle isn't
+ * razor-tight on the outermost nodes. Used to seed the geofence bbox when
+ * the user first enables the geographic filter — sticking them at (0,0)
+ * in the middle of the ocean on a fresh checkbox click is useless.
+ *
+ * Nodes at exactly (0,0) are treated as "no fix" and skipped: this is the
+ * sentinel value firmware reports when GPS hasn't locked yet, and lumping
+ * it in would balloon the bbox out to the Atlantic.
+ */
+export function boundsFromDetectedNodes(
+  nodes: ReadonlyArray<{ latitude?: number | null; longitude?: number | null }>,
+): BBoxValue | null {
+  let minLat = Infinity;
+  let maxLat = -Infinity;
+  let minLng = Infinity;
+  let maxLng = -Infinity;
+  let count = 0;
+  for (const n of nodes) {
+    const lat = n.latitude;
+    const lng = n.longitude;
+    if (typeof lat !== 'number' || typeof lng !== 'number') continue;
+    if (lat === 0 && lng === 0) continue;
+    if (lat < minLat) minLat = lat;
+    if (lat > maxLat) maxLat = lat;
+    if (lng < minLng) minLng = lng;
+    if (lng > maxLng) maxLng = lng;
+    count++;
+  }
+  if (count === 0) return null;
+  const padLat = Math.max(0.05, (maxLat - minLat) * 0.1);
+  const padLng = Math.max(0.05, (maxLng - minLng) * 0.1);
+  return {
+    minLat: minLat - padLat,
+    maxLat: maxLat + padLat,
+    minLng: minLng - padLng,
+    maxLng: maxLng + padLng,
+  };
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -25,6 +25,7 @@ import type { DashboardSource } from '../hooks/useDashboardData';
 import DashboardSidebar from '../components/Dashboard/DashboardSidebar';
 import DashboardMap from '../components/Dashboard/DashboardMap';
 import BBoxMapEditor, { type BBoxValue } from '../components/BBoxMapEditor';
+import { bboxToFormStrings, boundsFromDetectedNodes } from './DashboardPage.bboxSeed';
 import LoginModal from '../components/LoginModal';
 import UserMenu from '../components/UserMenu';
 import { NewsPopup } from '../components/NewsPopup';
@@ -52,6 +53,7 @@ function bboxFromForm(geo: {
   if (minLat > maxLat || minLng > maxLng) return null;
   return { minLat, maxLat, minLng, maxLng };
 }
+
 
 // ---------------------------------------------------------------------------
 // DashboardInner — rendered inside SettingsProvider
@@ -933,7 +935,28 @@ function DashboardInner() {
                       <input
                         type="checkbox"
                         checked={formMqttBridgeUseGeo}
-                        onChange={(e) => setFormMqttBridgeUseGeo(e.target.checked)}
+                        onChange={(e) => {
+                          const enabled = e.target.checked;
+                          setFormMqttBridgeUseGeo(enabled);
+                          // Seed the bbox from currently-detected node positions
+                          // when the user first enables the filter and the form is
+                          // empty. Saves them having to pan/zoom from the middle
+                          // of the ocean on a fresh source.
+                          if (
+                            enabled &&
+                            !formMqttBridgeGeo.minLat &&
+                            !formMqttBridgeGeo.maxLat &&
+                            !formMqttBridgeGeo.minLng &&
+                            !formMqttBridgeGeo.maxLng
+                          ) {
+                            const allNodes = [
+                              ...(unifiedSourceData.nodes as Array<{ latitude?: number | null; longitude?: number | null }>),
+                              ...(sourceData.nodes as Array<{ latitude?: number | null; longitude?: number | null }>),
+                            ];
+                            const seeded = boundsFromDetectedNodes(allNodes);
+                            if (seeded) setFormMqttBridgeGeo(bboxToFormStrings(seeded));
+                          }
+                        }}
                       />
                       {t('source.form.mqtt_geo_enable', 'Restrict to geographic bounding box')}
                     </label>
@@ -944,12 +967,7 @@ function DashboardInner() {
                         bbox={bboxFromForm(formMqttBridgeGeo)}
                         onChange={(next) => {
                           if (next) {
-                            setFormMqttBridgeGeo({
-                              minLat: next.minLat.toFixed(5),
-                              maxLat: next.maxLat.toFixed(5),
-                              minLng: next.minLng.toFixed(5),
-                              maxLng: next.maxLng.toFixed(5),
-                            });
+                            setFormMqttBridgeGeo(bboxToFormStrings(next));
                           } else {
                             setFormMqttBridgeGeo({ minLat: '', maxLat: '', minLng: '', maxLng: '' });
                           }


### PR DESCRIPTION
## Summary

When a user creates an `mqtt_bridge` source and first enables the "Restrict to geographic bounding box" filter, the map editor used to drop them at (0,0) in the middle of the ocean. Now it seeds the bbox from the bounds of currently-detected node positions (with 10% padding, min 0.05° ≈ 5km), so the user starts looking at their actual network and can refine from there.

- Skips (0,0) nodes — the firmware's "no GPS fix yet" sentinel.
- Only seeds when the form is empty; if you clear the bbox or hand-edit the numbers, your values stick.
- Helpers extracted to `DashboardPage.bboxSeed.ts` so they're unit-testable without JSDOM.

## Test plan

- [x] `vitest run src/pages/DashboardPage.bboxSeed.test.ts` — 6 new tests (empty/null nodes, (0,0) sentinel skip, multi-node bounding, single-node minimum padding, partial position rows, `bboxToFormStrings` rounding)
- [x] `vitest run src/pages/DashboardPage.test.tsx` — existing 22 DashboardPage tests still pass
- [x] `npm run typecheck` — clean
- [ ] Manual: open the dev container, add an mqtt_bridge source, check the geofence box, confirm the editor opens with a sensible rectangle around the live nodes instead of empty ocean

🤖 Generated with [Claude Code](https://claude.com/claude-code)