### PR TITLE
fix(mqtt-source): preserve saved password on edit when field is blank

### DIFF
--- a/src/server/routes/sourceRoutes.credentialPreserve.test.ts
+++ b/src/server/routes/sourceRoutes.credentialPreserve.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Source Routes — credential preservation on PUT (regression test).
+ *
+ * The source-edit UI intentionally clears the password input on load and
+ * omits the field from the save payload when the user does not type a new
+ * one. The PUT handler must re-merge the stored password so unrelated
+ * edits (e.g. toggling the geofence bounding box on an mqtt_bridge) do
+ * not wipe the credential.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import sourceRoutes from './sourceRoutes.js';
+import databaseService from '../../services/database.js';
+import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    sources: {
+      getSource: vi.fn(),
+      getAllSources: vi.fn().mockResolvedValue([]),
+      createSource: vi.fn(),
+      updateSource: vi.fn(),
+    },
+    nodes: {
+      getAllNodes: vi.fn().mockResolvedValue([]),
+      getNodesByNums: vi.fn().mockResolvedValue(new Map()),
+    },
+    messages: { getMessages: vi.fn().mockResolvedValue([]) },
+    traceroutes: { getAllTraceroutes: vi.fn().mockResolvedValue([]) },
+    neighbors: { getAllNeighborInfo: vi.fn().mockResolvedValue([]) },
+    channels: { getAllChannels: vi.fn().mockResolvedValue([]) },
+    settings: { getSetting: vi.fn().mockResolvedValue(null) },
+    checkPermissionAsync: vi.fn().mockResolvedValue(true),
+    findUserByIdAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn().mockResolvedValue(null),
+    getUserPermissionSetAsync: vi.fn().mockResolvedValue({ resources: {}, isAdmin: true }),
+    getChannelDatabasePermissionsForUserAsSetAsync: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    getManager: vi.fn().mockReturnValue(null),
+    addManager: vi.fn().mockResolvedValue(undefined),
+    removeManager: vi.fn().mockResolvedValue(undefined),
+    reconfigureVirtualNode: vi.fn().mockResolvedValue(false),
+  },
+}));
+
+vi.mock('../mqttBridgeManager.js', () => {
+  class MqttBridgeManager {
+    constructor(public id: string, public name: string, public config: any) {}
+    async start() {}
+    async stop() {}
+    getStatus() { return { sourceId: this.id, sourceName: this.name, sourceType: 'mqtt_bridge' as const, connected: false }; }
+  }
+  return { MqttBridgeManager };
+});
+
+vi.mock('../mqttBrokerManager.js', () => {
+  class MqttBrokerManager {
+    constructor(public id: string, public name: string, public config: any) {}
+    async start() {}
+    async stop() {}
+    getStatus() { return { sourceId: this.id, sourceName: this.name, sourceType: 'mqtt_broker' as const, connected: false }; }
+  }
+  return { MqttBrokerManager };
+});
+
+const mockDb = databaseService as any;
+const mockRegistry = sourceManagerRegistry as any;
+const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
+
+const createApp = (): Express => {
+  const app = express();
+  app.use(express.json());
+  app.use(session({ secret: 'test-secret', resave: false, saveUninitialized: false, cookie: { secure: false } }));
+  app.use((req: any, _res, next) => {
+    req.session.userId = adminUser.id;
+    next();
+  });
+  app.use('/', sourceRoutes);
+  return app;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+  mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+  mockDb.checkPermissionAsync.mockResolvedValue(true);
+  mockRegistry.getManager.mockReturnValue({ sourceId: 'src-1' });
+  mockDb.sources.updateSource.mockImplementation((_id: string, updates: any) =>
+    Promise.resolve({
+      id: 'src-1',
+      name: 'bridge',
+      type: 'mqtt_bridge',
+      enabled: true,
+      config: updates.config,
+      createdAt: 0,
+      updatedAt: 0,
+      createdBy: 1,
+    })
+  );
+});
+
+describe('sourceRoutes PUT — mqtt_bridge credential preservation', () => {
+  it('restores the stored upstream password when the save payload omits it (geofence-only edit)', async () => {
+    mockDb.sources.getSource.mockResolvedValue({
+      id: 'src-1',
+      name: 'bridge',
+      type: 'mqtt_bridge',
+      enabled: true,
+      config: {
+        brokerSourceId: 'broker-1',
+        upstream: { url: 'mqtt://upstream.example.com', username: 'bridgeuser', password: 'stored-bridge-secret' },
+        subscriptions: ['msh/#'],
+      },
+      createdAt: 0,
+      updatedAt: 0,
+      createdBy: 1,
+    });
+
+    const res = await request(createApp())
+      .put('/src-1')
+      .send({
+        config: {
+          brokerSourceId: 'broker-1',
+          upstream: { url: 'mqtt://upstream.example.com', username: 'bridgeuser' },
+          subscriptions: ['msh/#'],
+          downlinkFilters: { geo: { minLat: 30, maxLat: 31, minLng: -90, maxLng: -89 } },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const savedConfig = mockDb.sources.updateSource.mock.calls[0][1].config;
+    expect(savedConfig.upstream.password).toBe('stored-bridge-secret');
+    expect(savedConfig.upstream.username).toBe('bridgeuser');
+    expect(savedConfig.downlinkFilters.geo.minLat).toBe(30);
+  });
+
+  it('restores the stored password when upstream.password is explicitly undefined', async () => {
+    mockDb.sources.getSource.mockResolvedValue({
+      id: 'src-1',
+      name: 'bridge',
+      type: 'mqtt_bridge',
+      enabled: true,
+      config: {
+        brokerSourceId: 'broker-1',
+        upstream: { url: 'mqtt://u.example.com', username: 'u', password: 'kept-secret' },
+        subscriptions: ['msh/#'],
+      },
+      createdAt: 0, updatedAt: 0, createdBy: 1,
+    });
+
+    const res = await request(createApp())
+      .put('/src-1')
+      .send({
+        config: {
+          brokerSourceId: 'broker-1',
+          upstream: { url: 'mqtt://u.example.com', username: 'u', password: undefined },
+          subscriptions: ['msh/#'],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const savedConfig = mockDb.sources.updateSource.mock.calls[0][1].config;
+    expect(savedConfig.upstream.password).toBe('kept-secret');
+  });
+
+  it('allows admins to actually change the upstream password when they supply a new one', async () => {
+    mockDb.sources.getSource.mockResolvedValue({
+      id: 'src-1',
+      name: 'bridge',
+      type: 'mqtt_bridge',
+      enabled: true,
+      config: {
+        brokerSourceId: 'broker-1',
+        upstream: { url: 'mqtt://u.example.com', username: 'u', password: 'old-secret' },
+        subscriptions: ['msh/#'],
+      },
+      createdAt: 0, updatedAt: 0, createdBy: 1,
+    });
+
+    const res = await request(createApp())
+      .put('/src-1')
+      .send({
+        config: {
+          brokerSourceId: 'broker-1',
+          upstream: { url: 'mqtt://u.example.com', username: 'u', password: 'new-rotated-secret' },
+          subscriptions: ['msh/#'],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const savedConfig = mockDb.sources.updateSource.mock.calls[0][1].config;
+    expect(savedConfig.upstream.password).toBe('new-rotated-secret');
+  });
+});
+
+describe('sourceRoutes PUT — mqtt_broker credential preservation', () => {
+  beforeEach(() => {
+    mockDb.sources.updateSource.mockImplementation((_id: string, updates: any) =>
+      Promise.resolve({
+        id: 'src-1',
+        name: 'broker',
+        type: 'mqtt_broker',
+        enabled: true,
+        config: updates.config,
+        createdAt: 0,
+        updatedAt: 0,
+        createdBy: 1,
+      })
+    );
+  });
+
+  it('restores the stored auth.password when the save payload omits it', async () => {
+    mockDb.sources.getSource.mockResolvedValue({
+      id: 'src-1',
+      name: 'broker',
+      type: 'mqtt_broker',
+      enabled: true,
+      config: {
+        listener: { port: 1883, host: '0.0.0.0' },
+        auth: { username: 'mqttuser', password: 'stored-broker-secret' },
+        gateway: { nodeNum: 0x80000001, nodeId: '!80000001', longName: 'broker', shortName: 'br' },
+        rootTopic: 'msh',
+      },
+      createdAt: 0, updatedAt: 0, createdBy: 1,
+    });
+
+    const res = await request(createApp())
+      .put('/src-1')
+      .send({
+        config: {
+          listener: { port: 1884, host: '0.0.0.0' },
+          auth: { username: 'mqttuser' },
+          gateway: { nodeNum: 0x80000001, nodeId: '!80000001', longName: 'broker', shortName: 'br' },
+          rootTopic: 'msh',
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const savedConfig = mockDb.sources.updateSource.mock.calls[0][1].config;
+    expect(savedConfig.auth.password).toBe('stored-broker-secret');
+    expect(savedConfig.listener.port).toBe(1884);
+  });
+
+  it('writes a new password through when the admin supplies one', async () => {
+    mockDb.sources.getSource.mockResolvedValue({
+      id: 'src-1',
+      name: 'broker',
+      type: 'mqtt_broker',
+      enabled: true,
+      config: {
+        listener: { port: 1883, host: '0.0.0.0' },
+        auth: { username: 'mqttuser', password: 'old-broker-secret' },
+        gateway: { nodeNum: 0x80000001, nodeId: '!80000001', longName: 'broker', shortName: 'br' },
+        rootTopic: 'msh',
+      },
+      createdAt: 0, updatedAt: 0, createdBy: 1,
+    });
+
+    const res = await request(createApp())
+      .put('/src-1')
+      .send({
+        config: {
+          listener: { port: 1883, host: '0.0.0.0' },
+          auth: { username: 'mqttuser', password: 'new-broker-secret' },
+          gateway: { nodeNum: 0x80000001, nodeId: '!80000001', longName: 'broker', shortName: 'br' },
+          rootTopic: 'msh',
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const savedConfig = mockDb.sources.updateSource.mock.calls[0][1].config;
+    expect(savedConfig.auth.password).toBe('new-broker-secret');
+  });
+});

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -62,6 +62,43 @@ export function buildMqttManagerForSource(
   return new MqttBridgeManager(id, name, config as unknown as MqttBridgeSourceConfig);
 }
 
+// Restore credentials the edit UI intentionally omitted from the save
+// payload. The source-edit form clears the password field on load (the GET
+// endpoint strips it for non-admins) and drops the field from the PUT body
+// when the user did not type a new one, expecting the server to round-trip
+// the stored value. Without this merge, editing an unrelated field (e.g.
+// the geofence bounding box) writes back a config with no password and
+// wipes the saved credential.
+function preserveSourceCredentials(
+  type: string,
+  existingConfig: Record<string, unknown> | undefined,
+  incomingConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...incomingConfig };
+  if (type === 'mqtt_broker') {
+    const existingAuth = (existingConfig as any)?.auth;
+    const incomingAuth = (incomingConfig as any)?.auth;
+    if (
+      existingAuth?.password &&
+      incomingAuth && typeof incomingAuth === 'object' &&
+      (incomingAuth.password === undefined || incomingAuth.password === '')
+    ) {
+      merged.auth = { ...incomingAuth, password: existingAuth.password };
+    }
+  } else if (type === 'mqtt_bridge') {
+    const existingUpstream = (existingConfig as any)?.upstream;
+    const incomingUpstream = (incomingConfig as any)?.upstream;
+    if (
+      existingUpstream?.password &&
+      incomingUpstream && typeof incomingUpstream === 'object' &&
+      (incomingUpstream.password === undefined || incomingUpstream.password === '')
+    ) {
+      merged.upstream = { ...incomingUpstream, password: existingUpstream.password };
+    }
+  }
+  return merged;
+}
+
 // MM-SEC-8: shared credential strip applied to source records leaving the
 // HTTP boundary. The `mqtt` and `meshcore` source types carry connection
 // credentials in their `config` blob; both the list and singular GET
@@ -252,7 +289,13 @@ router.put('/:id', requirePermission('sources', 'write'), async (req: Request, r
 
     const updates: any = {};
     if (name !== undefined) updates.name = name.trim();
-    if (config !== undefined) updates.config = config;
+    if (config !== undefined) {
+      updates.config = preserveSourceCredentials(
+        existing.type,
+        existing.config as Record<string, unknown> | undefined,
+        config,
+      );
+    }
     if (enabled !== undefined) updates.enabled = enabled;
 
     // Validate VN config if config is being updated


### PR DESCRIPTION
## Summary
- Editing an MQTT source via the admin UI and changing an unrelated field (e.g. the geofence bounding box on an `mqtt_bridge`, or the listener port on an `mqtt_broker`) was silently wiping the saved upstream/auth password.
- The frontend deliberately clears the password input on load (admin GET round-trips it; non-admin GETs strip it) and drops the field from the PUT payload when the user has not typed a new one, expecting the server to re-merge the stored value. The PUT handler was instead doing a full `JSON.stringify` replace of `config`.
- Fix: new `preserveSourceCredentials()` helper in `src/server/routes/sourceRoutes.ts` re-injects `upstream.password` (bridge) or `auth.password` (broker) from the existing row when the incoming config omits it. Admins can still rotate the password by supplying a new value.

## Test plan
- [x] `npx vitest run src/server/routes/sourceRoutes.credentialPreserve.test.ts` — 5 new regression tests covering missing password, explicit `undefined`, and successful rotation for both source types.
- [x] `npx vitest run src/server/routes/sourceRoutes` — all 99 source-route tests pass (no regressions).
- [ ] Manual UI smoke test: edit an `mqtt_bridge`, change only the geofence bounds, save, reopen — password remains set.
- [ ] Manual UI smoke test: edit an `mqtt_bridge`, type a new password, save, reopen — new password takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)