### PR TITLE
feat(meshcore): render telemetry graphs in DM contact-detail pane

### DIFF
--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -32,6 +32,16 @@ vi.mock('../../hooks/useCsrfFetch', () => ({
   useCsrfFetch: () => csrfFetchMock,
 }));
 
+// TelemetryGraphs is exercised by its own tests; here we only need to
+// confirm the DM view mounts it with the right props when conditions are
+// met. Stub the heavy graphs component with a sentinel so we don't need
+// ToastProvider / QueryClientProvider / SourceProvider in this test.
+vi.mock('../TelemetryGraphs', () => ({
+  default: (props: { nodeId: string; baseUrl?: string }) => (
+    <div data-testid="telemetry-graphs" data-node-id={props.nodeId} data-base-url={props.baseUrl ?? ''} />
+  ),
+}));
+
 import { MeshCoreDirectMessagesView } from './MeshCoreDirectMessagesView';
 import type { MeshCoreActions, ConnectionStatus, MeshCoreMessage } from './hooks/useMeshCore';
 import type { MeshCoreContact } from '../../utils/meshcoreHelpers';
@@ -160,6 +170,61 @@ describe('MeshCoreDirectMessagesView — per-node telemetry-config panel', () =>
 
     expect(screen.queryByText('Telemetry Retrieval')).toBeNull();
     expect(csrfFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('mounts the TelemetryGraphs component with the selected pubkey when sourceId is set', async () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[realContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl="/meshmonitor"
+        sourceId="src-a"
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Remote Bob'));
+
+    const graphs = await screen.findByTestId('telemetry-graphs');
+    expect(graphs.getAttribute('data-node-id')).toBe(REAL_PK);
+    expect(graphs.getAttribute('data-base-url')).toBe('/meshmonitor');
+  });
+
+  it('does NOT mount TelemetryGraphs for a non-real-pubkey peer', () => {
+    const prefixOnly: MeshCoreContact = {
+      publicKey: 'cafebabe1234',
+      advName: 'Prefix Pete',
+      advType: 1,
+    };
+
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[prefixOnly]}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Prefix Pete'));
+    expect(screen.queryByTestId('telemetry-graphs')).toBeNull();
+  });
+
+  it('does NOT mount TelemetryGraphs when sourceId is not provided', () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[realContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Remote Bob'));
+    expect(screen.queryByTestId('telemetry-graphs')).toBeNull();
   });
 
   it('refetches telemetry config when switching from one real-pubkey peer to another', async () => {

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -7,6 +7,7 @@ import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
 import { MeshCoreContactDetailPanel } from './MeshCoreContactDetailPanel';
 import { MeshCoreNodeTelemetryConfig } from './MeshCoreNodeTelemetryConfig';
+import TelemetryGraphs from '../TelemetryGraphs';
 import { useAuth } from '../../contexts/AuthContext';
 
 interface MeshCoreDirectMessagesViewProps {
@@ -169,11 +170,14 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                 publicKey={selected}
               />
               {!!sourceId && typeof baseUrl === 'string' && isRealNodeKey(selected) && (
-                <MeshCoreNodeTelemetryConfig
-                  baseUrl={baseUrl}
-                  sourceId={sourceId}
-                  publicKey={selected}
-                />
+                <>
+                  <MeshCoreNodeTelemetryConfig
+                    baseUrl={baseUrl}
+                    sourceId={sourceId}
+                    publicKey={selected}
+                  />
+                  <TelemetryGraphs nodeId={selected} baseUrl={baseUrl} />
+                </>
               )}
             </div>
           </>

--- a/src/server/utils/nodeEnhancer.test.ts
+++ b/src/server/utils/nodeEnhancer.test.ts
@@ -266,6 +266,23 @@ describe('nodeEnhancer: checkNodeChannelAccess', () => {
     const noPermUser = { id: 99, isAdmin: false } as any;
     expect(await checkNodeChannelAccess('!00000001', noPermUser)).toBe(false);
   });
+
+  it('should allow access for a MeshCore 64-char-hex pubkey even without per-channel viewOnMap permission', async () => {
+    // MeshCore sources do not use the Meshtastic per-channel permission
+    // model; access is controlled at the source-permission level by the
+    // calling route. A user with no channel permissions should still be
+    // able to look up telemetry for a MeshCore contact in a source they
+    // can read.
+    const noPermUser = { id: 99, isAdmin: false } as any;
+    const meshcorePubkey = 'a'.repeat(64);
+    expect(await checkNodeChannelAccess(meshcorePubkey, noPermUser)).toBe(true);
+  });
+
+  it('should still deny anonymous access for a MeshCore pubkey', async () => {
+    const meshcorePubkey = 'b'.repeat(64);
+    expect(await checkNodeChannelAccess(meshcorePubkey, null)).toBe(false);
+    expect(await checkNodeChannelAccess(meshcorePubkey, undefined)).toBe(false);
+  });
 });
 
 describe('nodeEnhancer: maskNodeLocationByChannel', () => {

--- a/src/server/utils/nodeEnhancer.ts
+++ b/src/server/utils/nodeEnhancer.ts
@@ -355,6 +355,14 @@ export async function checkNodeChannelAccess(
 ): Promise<boolean> {
   if (user?.isAdmin) return true;
 
+  // MeshCore node identifiers are 64-char hex public keys. The Meshtastic
+  // per-channel viewOnMap permission model does not apply to them — MeshCore
+  // sources gate access at the source-permission level (and the calling
+  // route still enforces the top-level info/dashboard read gate). Short-
+  // circuit to allow so non-admin MeshCore users can fetch telemetry for
+  // contacts in their source. Anonymous callers remain blocked.
+  if (/^[0-9a-fA-F]{64}$/.test(nodeId)) return !!user;
+
   // Support both hex nodeId (!abcdef01) and decimal nodeId (2882400001)
   const nodeNum = nodeId.startsWith('!')
     ? parseInt(nodeId.replace('!', ''), 16)


### PR DESCRIPTION
## Summary
- Mounts the existing `<TelemetryGraphs>` component under the per-node telemetry-retrieval config in the MeshCore DM view, so an operator who has just enabled remote telemetry polling for a contact can see the resulting plotted history in the same panel.
- MeshCore's remote-telemetry scheduler already persists rows to the `telemetry` table keyed on the contact's 64-char `publicKey`, and the existing `/api/telemetry/:nodeId?sourceId=...` endpoint already serves them — so this is a frontend wiring change plus one targeted permission fix.
- Fixes `checkNodeChannelAccess` so non-admin MeshCore users are not 403'd: the Meshtastic per-channel `viewOnMap` model does not apply to 64-char hex pubkeys, and the calling route already enforces `info:read`/`dashboard:read` plus source-level access. Anonymous callers remain blocked.

## Implementation notes
- DM view (`src/components/MeshCore/MeshCoreDirectMessagesView.tsx`): gated on the same `sourceId + baseUrl + isRealNodeKey(selected)` predicate that already gates `MeshCoreNodeTelemetryConfig`, so prefix-only contacts and singleton-mode renders don't mount the heavy graphs component.
- Permission helper (`src/server/utils/nodeEnhancer.ts`): early-return when the nodeId matches `/^[0-9a-fA-F]{64}$/` (MeshCore pubkey), returning `!!user` so unauthenticated callers still get `false`.
- Existing DM view test was upgraded to mount a sentinel `<TelemetryGraphs>` stub so we can assert it is rendered (or not) based on props — three new test cases cover the positive path, prefix-only peer, and singleton mode.
- Two new `checkNodeChannelAccess` test cases cover the MeshCore allow path and the anonymous-deny path.

## Test plan
- [x] `npx vitest run src/components/MeshCore src/server/utils src/server/routes/v1/v1-api.test.ts` — 579 tests pass, 0 failures.
- [x] `npx tsc --noEmit` — clean.
- [x] `node_modules/.bin/eslint src/components/MeshCore/MeshCoreDirectMessagesView.tsx src/server/utils/nodeEnhancer.ts` — 0 errors (1 pre-existing `prefer-const` warning, not introduced here).
- [ ] Manual UI smoke: enable remote-telemetry polling on a MeshCore contact, wait for the first poll, confirm graphs appear in the DM contact-detail pane.
- [ ] Manual permission check: log in as a non-admin user with `connection:read` on the MeshCore source and `info:read` globally; confirm graphs render and the telemetry endpoint returns data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)