### PR TITLE
fix(meshcore): make MeshCorePage fill the dashboard shell height

### DIFF
--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -5,13 +5,15 @@
 .meshcore-page {
   display: flex;
   flex-direction: column;
-  /* .app-main applies header+2rem top padding and 2rem on the other sides.
-     Take what we're given but fill the remaining viewport height. */
-  height: calc(100dvh - var(--header-height, 60px) - 4rem);
+  /* Fill the parent flex slot. The page is rendered inside .dashboard-page
+     (a 100dvh flex column with .dashboard-topbar above) and previously used
+     an absolute `height: calc(100dvh - header - 4rem)` calc that assumed
+     `.app-main`'s 2rem padding existed — leaving a ~4rem dead band at the
+     bottom and a too-short sub-toolbar in the dashboard shell. */
+  flex: 1;
+  min-height: 0;
   overflow: hidden;
   background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface1);
-  border-radius: var(--radius-xl);
 }
 
 /* Status strip under the AppHeader */


### PR DESCRIPTION
## Summary

When viewing a MeshCore source, the page didn't fill the viewport — the left sub-toolbar stopped roughly 4rem short of the bottom and there was a visible dead band below the map / content area. The Meshtastic source pages didn't have this issue.

Root cause: `.meshcore-page` set `height: calc(100dvh - var(--header-height) - 4rem)` on the assumption it was nested inside the legacy `.app-main`, which has `padding: 2rem` all around (4rem combined vertical). After the source-detail page moved to the `.dashboard-page` shell (no padding around its children), the `-4rem` subtracted nonexistent gutter and the page came up short.

Switched to `flex: 1; min-height: 0` so the page fills whatever vertical space its flex parent gives it. The dashboard shell is itself a 100dvh flex column with the topbar above, so the math works out automatically and the layout is now context-independent.

Also dropped the now-redundant border / border-radius — those were "card in 2rem padding" decoration that looked awkward flush against the topbar in the dashboard shell.

## Test plan

- [x] All MeshCore tests pass (69/69)
- [x] Deployed locally and manually verified: sub-toolbar reaches the bottom, no dead band below the content, page is flush with the topbar
- [ ] Sanity-check both views (nodes / channels / dms / configuration) render edge-to-edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)