### PR TITLE
fix(meshcore): split NUL-separated DeviceInfo remainder for Info panel

### DIFF
--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -463,7 +463,7 @@ describe('MeshCoreNativeBackend', () => {
     conn.deviceQueryResponse = {
       firmwareVer: 4,
       firmware_build_date: '01 Jan 2026',
-      manufacturerModel: 'Heltec V3 v1.7.0 ',
+      manufacturerModel: 'Heltec V3\u0000v1.7.0\u0000',
     };
 
     const resp = await backend.sendCommand('device_query', {});
@@ -497,6 +497,44 @@ describe('MeshCoreNativeBackend', () => {
       model: 'RAK4631',
       ver: undefined,
     });
+  });
+
+  it('device_query: empty manufacturerModel falls back to empty model + undefined ver', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    conn.deviceQueryResponse = {
+      firmwareVer: 2,
+      firmware_build_date: '01 Jan 2024',
+      manufacturerModel: '',
+    };
+
+    const resp = await backend.sendCommand('device_query', {});
+    expect(resp.success).toBe(true);
+    expect(resp.data.model).toBe('');
+    expect(resp.data.ver).toBeUndefined();
+  });
+
+  it('device_query: manufacturerModel that is only NUL padding yields empty model', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    conn.deviceQueryResponse = {
+      firmwareVer: 5,
+      firmware_build_date: '01 May 2026',
+      manufacturerModel: '\u0000\u0000\u0000',
+    };
+
+    const resp = await backend.sendCommand('device_query', {});
+    expect(resp.success).toBe(true);
+    expect(resp.data.model).toBe('');
+    expect(resp.data.ver).toBeUndefined();
   });
 
   it('routes telemetry/advert-loc commands to fork helpers', async () => {

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -448,6 +448,57 @@ describe('MeshCoreNativeBackend', () => {
     expect(resp.data).toEqual({ time: 1700000000 });
   });
 
+  it('device_query: splits NUL-separated remainder into model + version', async () => {
+    // Newer Meshcore firmware packs the model name and a firmware-version
+    // string as NUL-terminated segments into the DeviceInfo frame remainder.
+    // The upstream meshcore.js library decodes the whole remainder as one
+    // UTF-8 string, so we have to split it ourselves — otherwise the Info
+    // panel's Model row shows "<model><NUL><version>" with unprintable boxes.
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    conn.deviceQueryResponse = {
+      firmwareVer: 4,
+      firmware_build_date: '01 Jan 2026',
+      manufacturerModel: 'Heltec V3 v1.7.0 ',
+    };
+
+    const resp = await backend.sendCommand('device_query', {});
+    expect(resp.success).toBe(true);
+    expect(resp.data).toEqual({
+      'fw ver': 4,
+      fw_build: '01 Jan 2026',
+      model: 'Heltec V3',
+      ver: 'v1.7.0',
+    });
+  });
+
+  it('device_query: handles plain model with no trailing version string', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    conn.deviceQueryResponse = {
+      firmwareVer: 3,
+      firmware_build_date: '12 Mar 2025',
+      manufacturerModel: 'RAK4631',
+    };
+
+    const resp = await backend.sendCommand('device_query', {});
+    expect(resp.success).toBe(true);
+    expect(resp.data).toEqual({
+      'fw ver': 3,
+      fw_build: '12 Mar 2025',
+      model: 'RAK4631',
+      ver: undefined,
+    });
+  });
+
   it('routes telemetry/advert-loc commands to fork helpers', async () => {
     const backend = new MeshCoreNativeBackend('src-1', {
       connectionType: 'serial',

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -483,12 +483,21 @@ export class MeshCoreNativeBackend extends EventEmitter {
       case 'device_query': {
         // SupportedCompanionProtocolVersion = 1
         const info = await c.deviceQuery(1);
-        const manuf = (info?.manufacturerModel ?? '') as string;
+        // The upstream meshcore.js library reads the entire remainder of the
+        // DeviceInfo frame as `manufacturerModel`. Newer firmware packs the
+        // hardware model name and a firmware-version string (e.g. "v1.7.0") as
+        // separate NUL-terminated segments into that remainder, so without
+        // splitting we'd show both fields concatenated with stray NUL bytes
+        // (rendered as unprintable squares) in the Info panel's Model row.
+        const rawManuf = (info?.manufacturerModel ?? '') as string;
+        const manufParts = rawManuf.split(' ').filter((s) => s.length > 0);
+        const model = manufParts[0] ?? '';
+        const verString = manufParts[1];
         return {
           'fw ver': info?.firmwareVer,
           fw_build: info?.firmware_build_date,
-          model: manuf,
-          ver: info?.firmware_build_date,
+          model,
+          ver: verString,
         };
       }
 

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -490,7 +490,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
         // splitting we'd show both fields concatenated with stray NUL bytes
         // (rendered as unprintable squares) in the Info panel's Model row.
         const rawManuf = (info?.manufacturerModel ?? '') as string;
-        const manufParts = rawManuf.split(' ').filter((s) => s.length > 0);
+        const manufParts = rawManuf.split('\u0000').filter((s) => s.length > 0);
         const model = manufParts[0] ?? '';
         const verString = manufParts[1];
         return {


### PR DESCRIPTION
## Summary
- The Meshcore Node Info panel was showing the HW Model and firmware version string concatenated together with unprintable boxes (the raw NUL bytes between them), and the Firmware row was displaying the build date instead of the firmware version.
- Root cause was in the `device_query` handler in `meshcoreNativeBackend.ts`:
  1. The upstream `@liamcottle/meshcore.js` library reads the entire remainder of the `DeviceInfo` frame as a single `manufacturerModel` string. Newer firmware packs NUL-separated segments (`"<model>\0<verString>\0"`) into that remainder, so both fields landed in the Model row.
  2. The handler explicitly set `ver: info?.firmware_build_date`, and the UI prefers `ver` over `firmwareVer` — so "Firmware" rendered as `<build_date> (<build_date>)`.
- Fix: split the remainder on `\0`, use the first segment as the model and the second (when present) as the firmware version string. UI now shows `Heltec V3` in the Model row and `v1.7.0 (01 Jan 2026)` in the Firmware row. Older firmware that doesn't pack a version string falls back to `v<firmwareVer> (<build_date>)`.

## Test plan
- [x] Added `device_query: splits NUL-separated remainder into model + version` regression test (`Heltec V3\0v1.7.0\0` → `model: "Heltec V3"`, `ver: "v1.7.0"`)
- [x] Added `device_query: handles plain model with no trailing version string` test (older-firmware fallback path)
- [x] `npx vitest run src/server/meshcoreNativeBackend.test.ts` — 23/23 pass
- [x] `npx vitest run` — full suite 5073/5073 pass
- [x] `npm run typecheck` — clean
- [ ] Verify on real hardware: a Meshcore companion that previously showed boxes in the Model row now renders the model cleanly, and the Firmware row shows the version string + build date

🤖 Generated with [Claude Code](https://claude.com/claude-code)