### PR TITLE
feat(mqtt): full source-scoped ingest with channel decryption and unified-view fixes

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -131,33 +131,6 @@ services:
       # News feed URL for testing - use host.docker.internal to access host machine
       - NEWS_FEED_URL=${NEWS_FEED_URL:-}
 
-  # LN4CY MQTT Proxy - sidecar for testing MQTT uplink via Virtual Node
-  # Connects to source 2's VN on port 4504. Bring up alongside sqlite profile.
-  # Credit: https://github.com/LN4CY/mqtt-proxy
-  mqtt-proxy:
-    image: ghcr.io/ln4cy/mqtt-proxy:master
-    container_name: meshmonitor-mqtt-proxy
-    profiles:
-      - sqlite
-    restart: unless-stopped
-    depends_on:
-      - meshmonitor-sqlite
-    environment:
-      - INTERFACE_TYPE=tcp
-      - TCP_NODE_HOST=meshmonitor-sqlite
-      - TCP_NODE_PORT=4503
-      - LOG_LEVEL=INFO
-      - TCP_TIMEOUT=300
-      - CONFIG_WAIT_TIMEOUT=60
-      - HEALTH_CHECK_ACTIVITY_TIMEOUT=300
-      - TZ=America/New_York
-    healthcheck:
-      test: ["CMD-SHELL", "test -f /tmp/healthy && find /tmp/healthy -mmin -1 | grep -q healthy"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
-
   # MySQL service for testing dual-database support
   # Start with: docker compose -f docker-compose.dev.yml --profile mysql up -d
   mysql:

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -289,15 +289,18 @@ export class TelemetryRepository extends BaseRepository {
   }
 
   /**
-   * Get latest telemetry for each type for a node
+   * Get latest telemetry for each type for a node. When `sourceId` is
+   * provided, only rows attributed to that source are considered — required
+   * for multi-source views (e.g. `/api/unified/telemetry`) that otherwise
+   * misattribute cross-source telemetry to whichever source happens to be
+   * iterating in the outer loop.
    */
-  async getLatestTelemetryByNode(nodeId: string): Promise<DbTelemetry[]> {
-    // Get all distinct types for this node, then get latest of each
-    const types = await this.getNodeTelemetryTypes(nodeId);
+  async getLatestTelemetryByNode(nodeId: string, sourceId?: string): Promise<DbTelemetry[]> {
+    const types = await this.getNodeTelemetryTypes(nodeId, sourceId);
     const results: DbTelemetry[] = [];
 
     for (const type of types) {
-      const latest = await this.getLatestTelemetryForType(nodeId, type);
+      const latest = await this.getLatestTelemetryForType(nodeId, type, sourceId);
       if (latest) {
         results.push(latest);
       }
@@ -307,19 +310,24 @@ export class TelemetryRepository extends BaseRepository {
   }
 
   /**
-   * Get latest telemetry for a specific type for a node
+   * Get latest telemetry for a specific type for a node, optionally scoped
+   * to a single source.
    */
-  async getLatestTelemetryForType(nodeId: string, telemetryType: string): Promise<DbTelemetry | null> {
+  async getLatestTelemetryForType(
+    nodeId: string,
+    telemetryType: string,
+    sourceId?: string,
+  ): Promise<DbTelemetry | null> {
     const { telemetry } = this.tables;
+    const conditions = [
+      eq(telemetry.nodeId, nodeId),
+      eq(telemetry.telemetryType, telemetryType),
+    ];
+    if (sourceId) conditions.push(eq(telemetry.sourceId, sourceId));
     const result = await this.db
       .select()
       .from(telemetry)
-      .where(
-        and(
-          eq(telemetry.nodeId, nodeId),
-          eq(telemetry.telemetryType, telemetryType)
-        )
-      )
+      .where(and(...conditions))
       .orderBy(desc(telemetry.timestamp))
       .limit(1);
 
@@ -398,12 +406,14 @@ export class TelemetryRepository extends BaseRepository {
   /**
    * Get all telemetry types for a node
    */
-  async getNodeTelemetryTypes(nodeId: string): Promise<string[]> {
+  async getNodeTelemetryTypes(nodeId: string, sourceId?: string): Promise<string[]> {
     const { telemetry } = this.tables;
+    const conditions = [eq(telemetry.nodeId, nodeId)];
+    if (sourceId) conditions.push(eq(telemetry.sourceId, sourceId));
     const result = await this.db
       .selectDistinct({ type: telemetry.telemetryType })
       .from(telemetry)
-      .where(eq(telemetry.nodeId, nodeId));
+      .where(and(...conditions));
 
     return result.map((r: any) => r.type);
   }

--- a/src/server/constants/meshtastic.ts
+++ b/src/server/constants/meshtastic.ts
@@ -207,6 +207,39 @@ export function getStoreForwardRequestResponseName(rr: number): string {
 }
 
 /**
+ * Modem preset → channel-name map (Meshtastic firmware spec).
+ *
+ * When a device's channel slot has an empty name AND it's running on a
+ * `modem_preset`, the firmware derives the on-wire channel name from the
+ * preset's pascal-case label (no spaces) — `LONG_FAST` → `LongFast` etc.
+ * That derived name is used both for the channel hash AND for the
+ * `ServiceEnvelope.channelId` field when publishing to MQTT.
+ *
+ * Reference: firmware `meshtastic/firmware`, see `Channels.cpp::getName`.
+ *
+ * NOTE: the values here are the firmware-spec names (no spaces) — distinct
+ * from the user-friendly "Long Fast" labels we render elsewhere. Anything
+ * touching channel hashes or MQTT topic naming must use these.
+ */
+export const MODEM_PRESET_CHANNEL_NAMES: Record<number, string> = {
+  0: 'LongFast',
+  1: 'LongSlow',
+  2: 'VeryLongSlow',  // deprecated in firmware, retained for legacy enum values
+  3: 'MediumSlow',
+  4: 'MediumFast',
+  5: 'ShortSlow',
+  6: 'ShortFast',
+  7: 'LongModerate',
+  8: 'ShortTurbo',
+};
+
+/** Returns the firmware-derived channel name for a modem preset, or null. */
+export function modemPresetChannelName(modemPreset: number | undefined | null): string | null {
+  if (typeof modemPreset !== 'number') return null;
+  return MODEM_PRESET_CHANNEL_NAMES[modemPreset] ?? null;
+}
+
+/**
  * Channel Database Constants
  *
  * These constants are used for server-side decryption of encrypted packets

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3235,6 +3235,22 @@ class MeshtasticManager implements ISourceManager {
               parsed.data.lora.channelNum = 0;
               logger.info('📊 Set channelNum to 0 (was undefined - Proto3 default)');
             }
+
+            // Persist the modem preset per-source so the unified channels
+            // endpoint can use it as the display-name fallback for slot 0
+            // (which the firmware leaves blank when running on a preset).
+            // See `unifiedChannelDisplayName` in unifiedRoutes.ts.
+            if (this.sourceId && typeof parsed.data.lora.modemPreset === 'number') {
+              const presetKey = `lora.preset.${this.sourceId}`;
+              try {
+                await databaseService.settings.setSetting(
+                  presetKey,
+                  String(parsed.data.lora.modemPreset),
+                );
+              } catch (err) {
+                logger.debug(`Failed to persist ${presetKey}:`, err);
+              }
+            }
           }
 
           // Apply Proto3 defaults to device config

--- a/src/server/mqttBridgeManager.ts
+++ b/src/server/mqttBridgeManager.ts
@@ -25,13 +25,14 @@ import {
   type ServiceEnvelopeShape,
   type PositionShape,
 } from './mqttPacketFilter.js';
-import { ingestServiceEnvelope } from './mqttIngestion.js';
+import { ingestServiceEnvelope, bootstrapMqttChannelDatabase } from './mqttIngestion.js';
 import { PortNum } from './constants/meshtastic.js';
 import meshtasticProtobufService from './meshtasticProtobufService.js';
 import type { ISourceManager, SourceStatus } from './sourceManagerRegistry.js';
 import { sourceManagerRegistry } from './sourceManagerRegistry.js';
 import type { MqttBrokerManager, MqttBrokerLocalPacket } from './mqttBrokerManager.js';
 import type { Source } from '../db/repositories/sources.js';
+import databaseService from '../services/database.js';
 import { logger } from '../utils/logger.js';
 
 export interface MqttBridgeSourceConfig {
@@ -103,6 +104,8 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
 
   async start(): Promise<void> {
     this.attachParentBroker();
+    await bootstrapMqttChannelDatabase(this.sourceId);
+    await this.seedDownlinkMembership();
 
     this.client = new MqttBrokerClient({
       url: this.config.upstream.url,
@@ -139,6 +142,58 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     if (this.client) {
       await this.client.disconnect();
       this.client = null;
+    }
+  }
+
+  /**
+   * Pre-seed the downlink filter's geo-membership cache with:
+   *   1. Any node our local (non-MQTT) sources have heard directly —
+   *      "trusted" because the operator clearly considers them part of
+   *      their mesh. These pass the bbox filter regardless of whether we
+   *      have a stored position for them. Without this, a node attached
+   *      to a TCP source whose GPS hasn't reported a position yet would
+   *      have its MQTT-relayed text/telemetry silently geo-dropped.
+   *   2. Any node from any source whose stored position is inside the bbox.
+   *
+   * Without this seed the fail-closed filter drops every non-POSITION
+   * packet from a node until that node next broadcasts a position — which
+   * can be hours and is reset on every restart.
+   */
+  private async seedDownlinkMembership(): Promise<void> {
+    try {
+      const allSources = await databaseService.sources.getAllSources();
+      const localSourceIds = allSources
+        .filter((s) => s.type !== 'mqtt_bridge' && s.type !== 'mqtt_broker')
+        .map((s) => s.id);
+
+      // Trusted local-mesh nodes (any source we operate directly).
+      const trustedNums = new Set<number>();
+      for (const sid of localSourceIds) {
+        const localNodes = await databaseService.nodes.getAllNodes(sid);
+        for (const n of localNodes) trustedNums.add(n.nodeNum);
+      }
+      const trustedSeeded = this.downlinkFilter.seedTrustedNodes(trustedNums);
+
+      // In-bbox positions from anywhere.
+      const allNodes = await databaseService.nodes.getAllNodes();
+      const entries = allNodes
+        .filter((n) => typeof n.latitude === 'number' && typeof n.longitude === 'number')
+        .map((n) => ({
+          nodeNum: n.nodeNum,
+          latitudeDeg: n.latitude as number,
+          longitudeDeg: n.longitude as number,
+        }));
+      const positionSeeded = this.downlinkFilter.seedMembership(entries);
+
+      if (trustedSeeded > 0 || positionSeeded > 0) {
+        logger.info(
+          `MQTT bridge ${this.sourceId} seeded ${trustedSeeded} trusted local-mesh node(s) + ` +
+            `${positionSeeded} in-bbox position(s) into downlink membership cache`,
+        );
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(`MQTT bridge ${this.sourceId} membership seed failed: ${message}`);
     }
   }
 
@@ -265,12 +320,18 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
       if (!this.downlinkFilter.passesMembership(fromNum)) return;
     }
 
-    const result = ingestServiceEnvelope({
+    ingestServiceEnvelope({
       sourceId: this.sourceId,
       envelope,
       filter: this.downlinkFilter,
-    });
-    if (result.ingested) this.downlinkIngested++;
+    })
+      .then((result) => {
+        if (result.ingested) this.downlinkIngested++;
+      })
+      .catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.warn(`MQTT bridge ${this.sourceId} ingest failed: ${msg}`);
+      });
 
     // Republish to local broker so devices see it. Skip if no parent attached.
     if (this.parentBroker) {

--- a/src/server/mqttBrokerManager.ts
+++ b/src/server/mqttBrokerManager.ts
@@ -13,7 +13,7 @@
 import { EventEmitter } from 'events';
 import { MqttBroker, type MqttBrokerPublish } from './transports/mqttBroker.js';
 import { MqttPacketFilter, type ServiceEnvelopeShape } from './mqttPacketFilter.js';
-import { ingestServiceEnvelope } from './mqttIngestion.js';
+import { ingestServiceEnvelope, bootstrapMqttChannelDatabase } from './mqttIngestion.js';
 import meshtasticProtobufService from './meshtasticProtobufService.js';
 import type { ISourceManager, SourceStatus } from './sourceManagerRegistry.js';
 import type { Source } from '../db/repositories/sources.js';
@@ -75,6 +75,7 @@ export class MqttBrokerManager extends EventEmitter implements ISourceManager {
 
   async start(): Promise<void> {
     if (this.broker) return;
+    await bootstrapMqttChannelDatabase(this.sourceId);
     this.broker = new MqttBroker({
       port: this.config.listener.port,
       host: this.config.listener.host,
@@ -150,14 +151,20 @@ export class MqttBrokerManager extends EventEmitter implements ISourceManager {
     }
     const envelope: ServiceEnvelopeShape = decoded as ServiceEnvelopeShape;
 
-    const result = ingestServiceEnvelope({
+    ingestServiceEnvelope({
       sourceId: this.sourceId,
       envelope,
       filter: this.filter,
-    });
-
-    if (result.ingested) this.packetsIngested++;
-    else this.packetsDropped++;
+    })
+      .then((result) => {
+        if (result.ingested) this.packetsIngested++;
+        else this.packetsDropped++;
+      })
+      .catch((err) => {
+        this.packetsDropped++;
+        const m = err instanceof Error ? err.message : String(err);
+        logger.warn(`MQTT broker ${this.sourceId} ingest failed: ${m}`);
+      });
 
     // Always emit, even if not ingested — bridges may want encrypted or
     // unsupported-portnum packets for uplink. They apply their own filter.

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -14,6 +14,24 @@ vi.mock('../services/database.js', () => ({
     upsertNode: vi.fn(),
     insertMessage: vi.fn(),
     insertTelemetry: vi.fn(),
+    insertTraceroute: vi.fn(),
+    insertRouteSegment: vi.fn(),
+    nodes: {
+      getNode: vi.fn(async () => null),
+      getNodesByNums: vi.fn(async () => new Map()),
+      upsertNode: vi.fn(async () => undefined),
+    },
+    neighbors: {
+      deleteNeighborInfoForNode: vi.fn(async () => undefined),
+      insertNeighborInfoBatch: vi.fn(async () => undefined),
+    },
+    messages: {
+      getMessage: vi.fn(async () => null),
+      insertMessage: vi.fn((_msg: any, _sourceId?: string) => true),
+    },
+    channels: {
+      upsertChannel: vi.fn(async () => undefined),
+    },
   },
 }));
 
@@ -25,7 +43,6 @@ vi.mock('./meshtasticProtobufService.js', () => ({
         return { longName: 'Test', shortName: 'TST', hwModel: 1 };
       }
       if (portnum === 3 /* POSITION_APP */) {
-        // Toronto-ish — used to learn 'in' membership for NODE_IN.
         return { latitudeI: 437_000_000, longitudeI: -793_000_000, altitude: 100 };
       }
       if (portnum === 1 /* TEXT_MESSAGE_APP */) {
@@ -33,6 +50,18 @@ vi.mock('./meshtasticProtobufService.js', () => ({
       }
       if (portnum === 67 /* TELEMETRY_APP */) {
         return { deviceMetrics: { batteryLevel: 90 } };
+      }
+      if (portnum === 70 /* TRACEROUTE_APP */) {
+        return { route: [], routeBack: [], snrTowards: [40], snrBack: [] };
+      }
+      if (portnum === 71 /* NEIGHBORINFO_APP */) {
+        return { neighbors: [{ nodeId: 0xaaaa1111, snr: 4.5, lastRxTime: 1700000000 }] };
+      }
+      if (portnum === 34 /* PAXCOUNTER_APP */) {
+        return { wifi: 12, ble: 5, uptime: 360 };
+      }
+      if (portnum === 65 /* STORE_FORWARD_APP */) {
+        return { rr: 9 /* ROUTER_TEXT_BROADCAST */, text: new TextEncoder().encode('replayed') };
       }
       return null;
     }),
@@ -67,23 +96,23 @@ describe('ingestServiceEnvelope — fail-closed membership', () => {
     vi.clearAllMocks();
   });
 
-  it('drops a TEXT_MESSAGE from an unknown sender when bbox is enabled', () => {
+  it('drops a TEXT_MESSAGE from an unknown sender when bbox is enabled', async () => {
     const filter = new MqttPacketFilter({ geo: ON_BBOX });
-    const result = ingestServiceEnvelope({
+    const result = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
       envelope: envFor(NODE_UNKNOWN, 1 /* TEXT_MESSAGE_APP */),
       filter,
     });
     expect(result.ingested).toBe(false);
     expect(result.reason).toBe('geo-filtered');
-    expect(databaseService.insertMessage).not.toHaveBeenCalled();
+    expect(databaseService.messages.insertMessage).not.toHaveBeenCalled();
     expect(databaseService.upsertNode).not.toHaveBeenCalled();
     expect(filter.getDropCounters().geo).toBe(1);
   });
 
-  it('drops NODEINFO from an unknown sender when bbox is enabled', () => {
+  it('drops NODEINFO from an unknown sender when bbox is enabled', async () => {
     const filter = new MqttPacketFilter({ geo: ON_BBOX });
-    const result = ingestServiceEnvelope({
+    const result = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
       envelope: envFor(NODE_UNKNOWN, 4 /* NODEINFO_APP */),
       filter,
@@ -93,9 +122,9 @@ describe('ingestServiceEnvelope — fail-closed membership', () => {
     expect(databaseService.upsertNode).not.toHaveBeenCalled();
   });
 
-  it('drops TELEMETRY from an unknown sender when bbox is enabled', () => {
+  it('drops TELEMETRY from an unknown sender when bbox is enabled', async () => {
     const filter = new MqttPacketFilter({ geo: ON_BBOX });
-    const result = ingestServiceEnvelope({
+    const result = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
       envelope: envFor(NODE_UNKNOWN, 67 /* TELEMETRY_APP */),
       filter,
@@ -105,11 +134,11 @@ describe('ingestServiceEnvelope — fail-closed membership', () => {
     expect(databaseService.insertTelemetry).not.toHaveBeenCalled();
   });
 
-  it('allows a TEXT_MESSAGE after the same sender posted an in-bbox POSITION', () => {
+  it('allows a TEXT_MESSAGE after the same sender posted an in-bbox POSITION', async () => {
     const filter = new MqttPacketFilter({ geo: ON_BBOX });
 
     // Step 1: position learns NODE_IN as 'in'.
-    const posResult = ingestServiceEnvelope({
+    const posResult = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
       envelope: envFor(NODE_IN, 3 /* POSITION_APP */),
       filter,
@@ -119,13 +148,13 @@ describe('ingestServiceEnvelope — fail-closed membership', () => {
 
     // Step 2: text message from the same sender now passes the gate.
     vi.clearAllMocks();
-    const txtResult = ingestServiceEnvelope({
+    const txtResult = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
       envelope: envFor(NODE_IN, 1 /* TEXT_MESSAGE_APP */),
       filter,
     });
     expect(txtResult.ingested).toBe(true);
-    expect(databaseService.insertMessage).toHaveBeenCalledTimes(1);
+    expect(databaseService.messages.insertMessage).toHaveBeenCalledTimes(1);
   });
 
   it('blocks TEXT_MESSAGE after the same sender posted an out-of-bbox POSITION', async () => {
@@ -139,7 +168,7 @@ describe('ingestServiceEnvelope — fail-closed membership', () => {
     const filter = new MqttPacketFilter({ geo: ON_BBOX });
 
     // Position is out → bbox rejects, cache marks NODE_OUT as 'out'.
-    const posResult = ingestServiceEnvelope({
+    const posResult = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
       envelope: envFor(NODE_OUT, 3 /* POSITION_APP */),
       filter,
@@ -148,34 +177,199 @@ describe('ingestServiceEnvelope — fail-closed membership', () => {
     expect(posResult.reason).toBe('geo-filtered');
 
     // Subsequent text from the same sender — known-out → drop.
-    const txtResult = ingestServiceEnvelope({
+    const txtResult = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
       envelope: envFor(NODE_OUT, 1 /* TEXT_MESSAGE_APP */),
       filter,
     });
     expect(txtResult.ingested).toBe(false);
     expect(txtResult.reason).toBe('geo-filtered');
-    expect(databaseService.insertMessage).not.toHaveBeenCalled();
+    expect(databaseService.messages.insertMessage).not.toHaveBeenCalled();
   });
 
-  it('passes everything when no filter is supplied (back-compat)', () => {
-    const result = ingestServiceEnvelope({
+  it('passes everything when no filter is supplied (back-compat)', async () => {
+    const result = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
       envelope: envFor(NODE_UNKNOWN, 1 /* TEXT_MESSAGE_APP */),
       // No filter argument → no fail-closed enforcement.
     });
     expect(result.ingested).toBe(true);
-    expect(databaseService.insertMessage).toHaveBeenCalledTimes(1);
+    expect(databaseService.messages.insertMessage).toHaveBeenCalledTimes(1);
   });
 
-  it('passes non-position packets when bbox is configured with empty bounds', () => {
+  it('passes non-position packets when bbox is configured with empty bounds', async () => {
     const filter = new MqttPacketFilter({ geo: {} });
-    const result = ingestServiceEnvelope({
+    const result = await ingestServiceEnvelope({
       sourceId: 'bridge-1',
       envelope: envFor(NODE_UNKNOWN, 1 /* TEXT_MESSAGE_APP */),
       filter,
     });
     expect(result.ingested).toBe(true);
     expect(filter.getDropCounters().geo).toBe(0);
+  });
+});
+
+describe('ingestServiceEnvelope — TRACEROUTE_APP', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists the traceroute record and a messageHops telemetry datum', async () => {
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 70 /* TRACEROUTE_APP */),
+    });
+    expect(result.ingested).toBe(true);
+    expect(databaseService.insertTraceroute).toHaveBeenCalledTimes(1);
+    const [record, sourceId] = (databaseService.insertTraceroute as any).mock.calls[0];
+    expect(record.fromNodeNum).toBe(NODE_IN);
+    expect(record.route).toBe('[]');
+    expect(record.snrTowards).toBe('[40]');
+    expect(sourceId).toBe('bridge-1');
+
+    const telemetryCall = (databaseService.insertTelemetry as any).mock.calls
+      .find((c: any[]) => c[0].telemetryType === 'messageHops');
+    expect(telemetryCall).toBeDefined();
+    expect(telemetryCall[0].value).toBe(1); // route.length + 1
+    expect(telemetryCall[1]).toBe('bridge-1');
+  });
+
+  it('upserts the sender node when it has not been seen before', async () => {
+    await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 70 /* TRACEROUTE_APP */),
+    });
+    expect(databaseService.nodes.upsertNode).toHaveBeenCalled();
+    const senderUpsert = (databaseService.nodes.upsertNode as any).mock.calls
+      .find((c: any[]) => c[0].nodeNum === NODE_IN);
+    expect(senderUpsert).toBeDefined();
+    expect(senderUpsert[1]).toBe('bridge-1');
+  });
+});
+
+describe('ingestServiceEnvelope — NEIGHBORINFO_APP', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('replaces the sender neighbor list scoped to this source', async () => {
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 71 /* NEIGHBORINFO_APP */),
+    });
+    expect(result.ingested).toBe(true);
+    // Old rows are wiped first, then the new batch is inserted.
+    expect(databaseService.neighbors.deleteNeighborInfoForNode).toHaveBeenCalledWith(NODE_IN, 'bridge-1');
+    expect(databaseService.neighbors.insertNeighborInfoBatch).toHaveBeenCalledTimes(1);
+    const [records, sourceId] = (databaseService.neighbors.insertNeighborInfoBatch as any).mock.calls[0];
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      nodeNum: NODE_IN,
+      neighborNodeNum: 0xaaaa1111,
+      snr: 4.5,
+      lastRxTime: 1700000000,
+    });
+    expect(sourceId).toBe('bridge-1');
+  });
+
+  it('drops a packet with an empty neighbors array as decode-error', async () => {
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => ({ neighbors: [] }));
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 71),
+    });
+    expect(result.ingested).toBe(false);
+    expect(result.reason).toBe('decode-error');
+    expect(databaseService.neighbors.insertNeighborInfoBatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('ingestServiceEnvelope — PAXCOUNTER_APP', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes wifi, ble, and uptime telemetry rows with paxcounter type names', async () => {
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 34 /* PAXCOUNTER_APP */),
+    });
+    expect(result.ingested).toBe(true);
+    const types = (databaseService.insertTelemetry as any).mock.calls.map((c: any[]) => c[0].telemetryType);
+    expect(types).toEqual(expect.arrayContaining(['paxcounterWifi', 'paxcounterBle', 'paxcounterUptime']));
+    // All three carry the bridge's sourceId.
+    for (const call of (databaseService.insertTelemetry as any).mock.calls) {
+      expect(call[1]).toBe('bridge-1');
+    }
+  });
+
+  it('returns decode-error when no metrics are decodable', async () => {
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => ({}));
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 34),
+    });
+    expect(result.ingested).toBe(false);
+    expect(result.reason).toBe('decode-error');
+  });
+});
+
+describe('ingestServiceEnvelope — STORE_FORWARD_APP', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('replays a ROUTER_TEXT_BROADCAST as a viaStoreForward text message', async () => {
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 65 /* STORE_FORWARD_APP */),
+    });
+    expect(result.ingested).toBe(true);
+    expect(databaseService.messages.insertMessage).toHaveBeenCalledTimes(1);
+    const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
+    expect(inserted.text).toBe('replayed');
+    expect(inserted.fromNodeNum).toBe(NODE_IN);
+    expect(inserted.viaMqtt).toBe(true);
+    expect(inserted.viaStoreForward).toBe(true);
+    expect(inserted.sourceId).toBe('bridge-1');
+  });
+
+  it('does NOT insert a duplicate when the original message already landed', async () => {
+    (databaseService.messages.getMessage as any).mockResolvedValueOnce({ id: 'exists' });
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 65),
+    });
+    expect(result.ingested).toBe(false);
+    expect(databaseService.messages.insertMessage).not.toHaveBeenCalled();
+  });
+
+  it('marks a node as a Store & Forward server on a ROUTER_HEARTBEAT', async () => {
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => ({ rr: 2 /* ROUTER_HEARTBEAT */ }));
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 65),
+    });
+    expect(result.ingested).toBe(true);
+    expect(databaseService.upsertNode).toHaveBeenCalledTimes(1);
+    const upserted = (databaseService.upsertNode as any).mock.calls[0][0];
+    expect(upserted.nodeNum).toBe(NODE_IN);
+    expect(upserted.isStoreForwardServer).toBe(true);
+  });
+
+  it('returns unsupported-portnum for log-only S&F subtypes (STATS)', async () => {
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => ({ rr: 7 /* ROUTER_STATS */, stats: {} }));
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 65),
+    });
+    expect(result.ingested).toBe(false);
+    expect(result.reason).toBe('unsupported-portnum');
+    expect(databaseService.messages.insertMessage).not.toHaveBeenCalled();
+    expect(databaseService.upsertNode).not.toHaveBeenCalled();
   });
 });

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -12,9 +12,74 @@
  */
 
 import meshtasticProtobufService from './meshtasticProtobufService.js';
+import { channelDecryptionService } from './services/channelDecryptionService.js';
 import databaseService from '../services/database.js';
-import type { DbNode, DbMessage, DbTelemetry } from '../services/database.js';
-import { PortNum } from './constants/meshtastic.js';
+
+/**
+ * Public Meshtastic channels that ship with the default key. Used to
+ * bootstrap the channel_database for newly-created MQTT sources so the
+ * decryption service can decode their traffic out of the box. Users can
+ * still add/remove rows via the UI; this only inserts when no matching
+ * name+psk row exists, so manual edits aren't clobbered.
+ *
+ * Format: `name` + 1-byte shorthand PSK (expanded by `expandShorthandPsk`
+ * at cache load time — see channelDecryptionService.refreshChannelCache).
+ *   0x01 → LongFast (the Meshtastic public default)
+ */
+const DEFAULT_MQTT_CHANNELS: ReadonlyArray<{ name: string; psk: string; pskLength: number }> = [
+  { name: 'LongFast', psk: 'AQ==', pskLength: 1 },
+];
+
+/**
+ * Ensure each well-known default-key channel exists in the channel_database
+ * so the server-side decryption service can decrypt MQTT-relayed traffic
+ * for newly added MQTT sources. Attribution is by sourceId — first MQTT
+ * source to bootstrap a channel owns it. Subsequent calls are no-ops when
+ * a matching row (by name, case-insensitive) already exists in any scope.
+ */
+export async function bootstrapMqttChannelDatabase(sourceId: string): Promise<void> {
+  try {
+    const existing = await databaseService.channelDatabase.getAllAsync();
+    const haveName = new Set(existing.map((c) => (c.name ?? '').toLowerCase()));
+    for (const ch of DEFAULT_MQTT_CHANNELS) {
+      if (haveName.has(ch.name.toLowerCase())) continue;
+      await databaseService.channelDatabase.createAsync(
+        {
+          name: ch.name,
+          psk: ch.psk,
+          pskLength: ch.pskLength,
+          isEnabled: true,
+          enforceNameValidation: false,
+          description: `Auto-seeded for MQTT decryption (default Meshtastic key)`,
+          createdBy: null,
+        },
+        sourceId,
+      );
+      logger.info(
+        `MQTT source ${sourceId} bootstrapped channel_database entry "${ch.name}" with default key`,
+      );
+    }
+    // Pick up the new row(s) on the next decryption attempt.
+    await channelDecryptionService.refreshChannelCache();
+  } catch (err) {
+    const m = err instanceof Error ? err.message : String(err);
+    logger.warn(`MQTT source ${sourceId} channel_database bootstrap failed: ${m}`);
+  }
+}
+import type {
+  DbNode,
+  DbMessage,
+  DbTelemetry,
+  DbTraceroute,
+  DbRouteSegment,
+  DbNeighborInfo,
+} from '../services/database.js';
+import {
+  PortNum,
+  StoreForwardRequestResponse,
+  getStoreForwardRequestResponseName,
+} from './constants/meshtastic.js';
+import { calculateDistance } from '../utils/distance.js';
 import { logger } from '../utils/logger.js';
 import {
   nodeNumToId,
@@ -40,10 +105,36 @@ export interface MqttIngestionResult {
   portnum?: number;
 }
 
-export function ingestServiceEnvelope(input: MqttIngestionInput): MqttIngestionResult {
+export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<MqttIngestionResult> {
   const { sourceId, envelope, filter } = input;
   const packet = envelope.packet;
   if (!packet) return { ingested: false, reason: 'no-packet' };
+
+  // Server-side channel decryption — mirror the TCP path in
+  // `meshtasticManager.processMeshPacket`. Public MQTT brokers republish
+  // packets in their on-wire encrypted form (`packet.encrypted` set, no
+  // `packet.decoded`). If any PSK in the channel_database matches, we
+  // synthesize the `decoded` field and continue with normal ingest.
+  if (!packet.decoded && packet.encrypted && packet.encrypted.length > 0 && channelDecryptionService.isEnabled()) {
+    const fromNum = typeof packet.from === 'number' ? packet.from >>> 0 : 0;
+    const pid = typeof packet.id === 'number' ? packet.id >>> 0 : 0;
+    try {
+      const r = await channelDecryptionService.tryDecrypt(
+        packet.encrypted,
+        pid,
+        fromNum,
+        typeof packet.channel === 'number' ? packet.channel : undefined,
+      );
+      if (r.success) {
+        (packet as { decoded?: { portnum?: number; payload?: Uint8Array } }).decoded = {
+          portnum: r.portnum,
+          payload: r.payload,
+        };
+      }
+    } catch (err) {
+      logger.debug(`MQTT ingest: server decryption error for packet from ${fromNum}: ${err}`);
+    }
+  }
 
   const decoded = packet.decoded;
   if (!decoded) return { ingested: false, reason: 'encrypted' };
@@ -65,6 +156,12 @@ export function ingestServiceEnvelope(input: MqttIngestionInput): MqttIngestionR
     logger.warn(`MQTT ingest: failed to decode portnum ${portnum}: ${err}`);
     return { ingested: false, reason: 'decode-error', portnum };
   }
+
+  // Surface the channel this packet came in on so the unified channel
+  // picker shows it. Fire-and-forget: a failed upsert just means the
+  // picker won't surface this channel for this source — the packet
+  // ingest itself is unaffected.
+  recordChannelFromEnvelope(sourceId, envelope, packet);
 
   // Fail-closed geo membership: when a bbox is configured on the filter,
   // only allow packets from senders we've previously decoded a position
@@ -129,7 +226,14 @@ export function ingestServiceEnvelope(input: MqttIngestionInput): MqttIngestionR
       if (!text) return { ingested: false, reason: 'decode-error', portnum };
       const packetId = typeof packet.id === 'number' ? packet.id >>> 0 : 0;
       const msg: DbMessage = {
-        id: `${sourceId}-${packetId || nowMs}-${fromNum}`,
+        // Row ID uses the TCP convention `${sourceId}_${fromNum}_${packetId}`
+        // — underscores, fromNum middle, packetId last — so the unified
+        // dedup parser (extractPacketIdFromRowId in unifiedRoutes.ts) can
+        // recover the packet ID and collapse TCP/MQTT receptions of the
+        // same mesh packet into one entry with a multi-source receptions
+        // array. Diverging from this format makes the same packet appear
+        // N times in the unified view (one per receiving source).
+        id: `${sourceId}_${fromNum}_${packetId || nowMs}`,
         fromNodeNum: fromNum,
         toNodeNum: toNum ?? 0xffffffff,
         fromNodeId,
@@ -145,7 +249,10 @@ export function ingestServiceEnvelope(input: MqttIngestionInput): MqttIngestionR
         createdAt: nowMs,
       } as DbMessage;
       (msg as any).sourceId = sourceId;
-      databaseService.insertMessage(msg);
+      // Use the repo's per-source insert — the `databaseService.insertMessage`
+      // facade drops the sourceId, leaving rows orphaned (`sourceId=NULL`)
+      // and invisible to source-scoped queries like /api/unified/messages.
+      databaseService.messages.insertMessage(msg, sourceId);
       // Refresh lastHeard for the sender.
       databaseService.upsertNode({
         nodeNum: fromNum,
@@ -207,8 +314,495 @@ export function ingestServiceEnvelope(input: MqttIngestionInput): MqttIngestionR
       return any ? { ingested: true, portnum } : { ingested: false, reason: 'decode-error', portnum };
     }
 
+    case PortNum.TRACEROUTE_APP: {
+      await ingestTraceroute(sourceId, packet, payload as Record<string, any>, fromNum, fromNodeId, toNum, toNodeId, nowMs);
+      return { ingested: true, portnum };
+    }
+
+    case PortNum.NEIGHBORINFO_APP: {
+      const ok = await ingestNeighborInfo(sourceId, payload as Record<string, any>, fromNum, fromNodeId, nowMs);
+      return ok ? { ingested: true, portnum } : { ingested: false, reason: 'decode-error', portnum };
+    }
+
+    case PortNum.PAXCOUNTER_APP: {
+      const ok = ingestPaxcounter(sourceId, packet, payload as Record<string, any>, fromNum, fromNodeId, nowMs);
+      return ok ? { ingested: true, portnum } : { ingested: false, reason: 'decode-error', portnum };
+    }
+
+    case PortNum.STORE_FORWARD_APP: {
+      const ok = await ingestStoreForward(sourceId, packet, payload as Record<string, any>, fromNum, fromNodeId, toNum, toNodeId, nowMs);
+      return ok ? { ingested: true, portnum } : { ingested: false, reason: 'unsupported-portnum', portnum };
+    }
+
     default:
       return { ingested: false, reason: 'unsupported-portnum', portnum };
+  }
+}
+
+/**
+ * TRACEROUTE_APP — persist the traceroute record, a hop-count telemetry
+ * datum, and any route segments we can compute from known node positions.
+ * Mirrors the TCP path's storage side (skipping presentation-only steps
+ * like human-readable route text generation and the autoresponder
+ * delivery hook, which don't apply to MQTT-sourced traceroutes).
+ */
+async function ingestTraceroute(
+  sourceId: string,
+  packet: any,
+  routeDiscovery: Record<string, any>,
+  fromNum: number,
+  fromNodeId: string,
+  toNum: number | null,
+  toNodeId: string,
+  nowMs: number,
+): Promise<void> {
+  const BROADCAST_ADDR = 4294967295;
+  const lastHeard = Math.floor(nowMs / 1000);
+  const isValidRouteNode = (n: number): boolean => n > 3 && n !== 255 && n !== 65535;
+
+  // Refresh sender. Don't clobber an existing name.
+  const existingFrom = await databaseService.nodes.getNode(fromNum, sourceId);
+  await databaseService.nodes.upsertNode(
+    existingFrom
+      ? { nodeNum: fromNum, nodeId: fromNodeId, lastHeard, viaMqtt: true }
+      : {
+          nodeNum: fromNum,
+          nodeId: fromNodeId,
+          longName: `Node ${fromNodeId}`,
+          shortName: fromNodeId.slice(-4),
+          hwModel: 0,
+          viaMqtt: true,
+          lastHeard,
+          createdAt: nowMs,
+          updatedAt: nowMs,
+        },
+    sourceId,
+  );
+
+  if (toNum !== null && toNum !== BROADCAST_ADDR) {
+    const existingTo = await databaseService.nodes.getNode(toNum, sourceId);
+    await databaseService.nodes.upsertNode(
+      existingTo
+        ? { nodeNum: toNum, nodeId: toNodeId, lastHeard, viaMqtt: true }
+        : {
+            nodeNum: toNum,
+            nodeId: toNodeId,
+            longName: `Node ${toNodeId}`,
+            shortName: toNodeId.slice(-4),
+            hwModel: 0,
+            viaMqtt: true,
+            lastHeard,
+            createdAt: nowMs,
+            updatedAt: nowMs,
+          },
+      sourceId,
+    );
+  }
+
+  const rawRoute: number[] = Array.isArray(routeDiscovery.route) ? routeDiscovery.route : [];
+  const rawRouteBack: number[] = Array.isArray(routeDiscovery.routeBack) ? routeDiscovery.routeBack : [];
+  const rawSnrTowards: number[] = Array.isArray(routeDiscovery.snrTowards) ? routeDiscovery.snrTowards : [];
+  const rawSnrBack: number[] = Array.isArray(routeDiscovery.snrBack) ? routeDiscovery.snrBack : [];
+
+  const route: number[] = [];
+  const snrTowards: number[] = [];
+  rawRoute.forEach((n, i) => {
+    if (!isValidRouteNode(n)) return;
+    route.push(n);
+    if (rawSnrTowards[i] !== undefined) snrTowards.push(rawSnrTowards[i]);
+  });
+  const routeBack: number[] = [];
+  const snrBack: number[] = [];
+  rawRouteBack.forEach((n, i) => {
+    if (!isValidRouteNode(n)) return;
+    routeBack.push(n);
+    if (rawSnrBack[i] !== undefined) snrBack.push(rawSnrBack[i]);
+  });
+  if (rawSnrTowards.length > rawRoute.length) snrTowards.push(rawSnrTowards[rawRoute.length]);
+  if (rawSnrBack.length > rawRouteBack.length) snrBack.push(rawSnrBack[rawRouteBack.length]);
+
+  // Stub rows for intermediate hops we haven't seen NodeInfo for. No
+  // lastHeard — we haven't directly heard from them, only learned of them
+  // via the relay. Matches the TCP path's anti-zombie behavior (issue #2602).
+  const intermediates = new Set<number>();
+  for (const n of route) intermediates.add(n);
+  for (const n of routeBack) intermediates.add(n);
+  intermediates.delete(fromNum);
+  if (toNum !== null) intermediates.delete(toNum);
+  intermediates.delete(BROADCAST_ADDR);
+  for (const hop of intermediates) {
+    const hopId = nodeNumToId(hop);
+    const existing = await databaseService.nodes.getNode(hop, sourceId);
+    if (existing) continue;
+    await databaseService.nodes.upsertNode(
+      {
+        nodeNum: hop,
+        nodeId: hopId,
+        longName: `Node ${hopId}`,
+        shortName: hopId.slice(-4),
+        hwModel: 0,
+        viaMqtt: true,
+        createdAt: nowMs,
+        updatedAt: nowMs,
+      },
+      sourceId,
+    );
+  }
+
+  const channelIndex = typeof packet.channel === 'number' ? packet.channel : -1;
+  const record: DbTraceroute = {
+    fromNodeNum: fromNum,
+    toNodeNum: toNum ?? 0,
+    fromNodeId,
+    toNodeId,
+    route: JSON.stringify(route),
+    routeBack: JSON.stringify(routeBack),
+    snrTowards: JSON.stringify(snrTowards),
+    snrBack: JSON.stringify(snrBack),
+    timestamp: nowMs,
+    createdAt: nowMs,
+  };
+  if (channelIndex >= 0) (record as any).channel = channelIndex;
+  databaseService.insertTraceroute(record, sourceId);
+
+  // Hop count → telemetry, matches TCP's Smart Hops feed.
+  const packetId = typeof packet.id === 'number' ? packet.id >>> 0 : undefined;
+  const hops = route.length + 1;
+  const hopTel: DbTelemetry = {
+    nodeId: fromNodeId,
+    nodeNum: fromNum,
+    telemetryType: 'messageHops',
+    timestamp: nowMs,
+    value: hops,
+    createdAt: nowMs,
+    packetId,
+    ...({ unit: 'hops' } as any),
+  };
+  databaseService.insertTelemetry(hopTel, sourceId);
+
+  // Route segments — one row per adjacent pair with known positions.
+  if (toNum !== null) {
+    const fullForward = [toNum, ...route, fromNum];
+    await persistRouteSegments(sourceId, fullForward, nowMs);
+    if (routeBack.length > 0) {
+      const fullReturn = [fromNum, ...routeBack, toNum];
+      await persistRouteSegments(sourceId, fullReturn, nowMs);
+    }
+  }
+}
+
+async function persistRouteSegments(sourceId: string, fullRoute: number[], timestamp: number): Promise<void> {
+  for (let i = 0; i < fullRoute.length - 1; i++) {
+    const a = fullRoute[i];
+    const b = fullRoute[i + 1];
+    if (a === b) continue;
+    if (a === 4294967295 || b === 4294967295) continue; // broadcast placeholder
+    const n1 = await databaseService.nodes.getNode(a, sourceId);
+    const n2 = await databaseService.nodes.getNode(b, sourceId);
+    if (!n1?.latitude || !n1?.longitude || !n2?.latitude || !n2?.longitude) continue;
+    const distKm = calculateDistance(n1.latitude, n1.longitude, n2.latitude, n2.longitude);
+    const seg: DbRouteSegment = {
+      fromNodeNum: a,
+      toNodeNum: b,
+      fromNodeId: nodeNumToId(a),
+      toNodeId: nodeNumToId(b),
+      distanceKm: distKm,
+      isRecordHolder: false,
+      timestamp,
+      createdAt: Date.now(),
+      ...({
+        fromLatitude: n1.latitude,
+        fromLongitude: n1.longitude,
+        toLatitude: n2.latitude,
+        toLongitude: n2.longitude,
+      } as any),
+    };
+    databaseService.insertRouteSegment(seg, sourceId);
+  }
+}
+
+/**
+ * NEIGHBORINFO_APP — replace the sender's neighbor list with whatever this
+ * packet contains, scoped to this source. Mirrors the TCP path's storage.
+ *
+ * Differs from TCP intentionally: TCP's handler skips packets flagged
+ * `viaMqtt` on the wire (an MQTT-gateway-relayed packet picked up over
+ * LoRa). That guard exists to avoid polluting the *local* radio's neighbor
+ * graph with foreign-mesh data. Here the source IS an MQTT bridge and the
+ * neighbor data is exactly what we want to persist — the sourceId scope
+ * keeps it cleanly partitioned from TCP-learned neighbors.
+ */
+async function ingestNeighborInfo(
+  sourceId: string,
+  neighborInfo: Record<string, any>,
+  fromNum: number,
+  fromNodeId: string,
+  nowMs: number,
+): Promise<boolean> {
+  const neighbors = neighborInfo.neighbors;
+  if (!Array.isArray(neighbors)) return false;
+
+  const senderNode = await databaseService.nodes.getNode(fromNum, sourceId);
+  if (!senderNode) {
+    await databaseService.nodes.upsertNode(
+      {
+        nodeNum: fromNum,
+        nodeId: fromNodeId,
+        longName: `Node ${fromNodeId}`,
+        shortName: fromNodeId.slice(-4),
+        hwModel: 0,
+        viaMqtt: true,
+        lastHeard: Math.floor(nowMs / 1000),
+        createdAt: nowMs,
+        updatedAt: nowMs,
+      },
+      sourceId,
+    );
+  }
+  const senderHopsAway = senderNode?.hopsAway ?? 0;
+
+  const valid: Array<{ nodeNum: number; snr: number | null; lastRxTime: number | null }> = [];
+  for (const n of neighbors) {
+    const num = Number(n.nodeId ?? n.node_id);
+    if (!Number.isFinite(num) || num <= 0) continue;
+    valid.push({
+      nodeNum: num >>> 0,
+      snr: n.snr != null ? Number(n.snr) : null,
+      lastRxTime: n.lastRxTime != null ? Number(n.lastRxTime) : (n.last_rx_time != null ? Number(n.last_rx_time) : null),
+    });
+  }
+  if (valid.length === 0) return false;
+
+  // Create stubs for unknown neighbors. No lastHeard — only the reporter
+  // has heard them. Matches the TCP path (issue #2602 zombie-row fix).
+  const existing = await databaseService.nodes.getNodesByNums(valid.map((v) => v.nodeNum));
+  for (const v of valid) {
+    if (existing.has(v.nodeNum)) continue;
+    const id = nodeNumToId(v.nodeNum);
+    await databaseService.nodes.upsertNode(
+      {
+        nodeNum: v.nodeNum,
+        nodeId: id,
+        longName: `Node ${id}`,
+        shortName: id.slice(-4),
+        hwModel: 0,
+        hopsAway: senderHopsAway + 1,
+        viaMqtt: true,
+        createdAt: nowMs,
+        updatedAt: nowMs,
+      },
+      sourceId,
+    );
+  }
+
+  await databaseService.neighbors.deleteNeighborInfoForNode(fromNum, sourceId);
+  const records: DbNeighborInfo[] = valid.map((v) => ({
+    nodeNum: fromNum,
+    neighborNodeNum: v.nodeNum,
+    snr: v.snr,
+    lastRxTime: v.lastRxTime,
+    timestamp: nowMs,
+    createdAt: nowMs,
+  } as DbNeighborInfo));
+  await databaseService.neighbors.insertNeighborInfoBatch(records, sourceId);
+  return true;
+}
+
+/**
+ * PAXCOUNTER_APP — three telemetry rows (wifi, ble, uptime) plus a
+ * lastHeard refresh. Same shape as TCP's processPaxcounterMessageProtobuf.
+ */
+function ingestPaxcounter(
+  sourceId: string,
+  packet: any,
+  paxcount: Record<string, any>,
+  fromNum: number,
+  fromNodeId: string,
+  nowMs: number,
+): boolean {
+  const packetId = typeof packet.id === 'number' ? packet.id >>> 0 : undefined;
+  let any = false;
+  const tryInsert = (telemetryType: string, value: unknown, unit: string): void => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return;
+    const tel: DbTelemetry = {
+      nodeId: fromNodeId,
+      nodeNum: fromNum,
+      telemetryType,
+      timestamp: nowMs,
+      value,
+      createdAt: nowMs,
+      packetId,
+      ...({ unit } as any),
+    };
+    databaseService.insertTelemetry(tel, sourceId);
+    any = true;
+  };
+  tryInsert('paxcounterWifi', paxcount.wifi, 'devices');
+  tryInsert('paxcounterBle', paxcount.ble, 'devices');
+  tryInsert('paxcounterUptime', paxcount.uptime, 's');
+
+  databaseService.upsertNode({
+    nodeNum: fromNum,
+    nodeId: fromNodeId,
+    longName: '',
+    shortName: '',
+    hwModel: 0,
+    lastHeard: Math.floor(nowMs / 1000),
+    viaMqtt: true,
+    sourceId,
+    createdAt: nowMs,
+    updatedAt: nowMs,
+  });
+  return any;
+}
+
+/**
+ * STORE_FORWARD_APP — replicates the storage-affecting branches of the
+ * TCP processStoreForwardMessage handler:
+ *   - ROUTER_HEARTBEAT: mark sender as an S&F server
+ *   - ROUTER_TEXT_DIRECT / ROUTER_TEXT_BROADCAST: insert as a text message
+ *     with viaStoreForward=true, deduping against the original transmission
+ * The STATS / HISTORY / PING branches are log-only on TCP and are skipped
+ * here (returned as unsupported).
+ */
+async function ingestStoreForward(
+  sourceId: string,
+  packet: any,
+  decoded: Record<string, any>,
+  fromNum: number,
+  fromNodeId: string,
+  toNum: number | null,
+  toNodeId: string,
+  nowMs: number,
+): Promise<boolean> {
+  const rr = decoded.rr ?? decoded.requestResponse ?? decoded.request_response ?? 0;
+  const rrName = getStoreForwardRequestResponseName(rr);
+
+  if (
+    rr === StoreForwardRequestResponse.ROUTER_TEXT_DIRECT ||
+    rr === StoreForwardRequestResponse.ROUTER_TEXT_BROADCAST
+  ) {
+    const textBytes = decoded.text;
+    if (!textBytes || (textBytes.length ?? 0) === 0) {
+      logger.debug(`📦 MQTT S&F ${rrName} from ${fromNodeId} — empty text, skipping`);
+      return false;
+    }
+    const text = new TextDecoder('utf-8').decode(
+      textBytes instanceof Uint8Array ? textBytes : new Uint8Array(textBytes),
+    );
+    const packetId = typeof packet.id === 'number' ? packet.id >>> 0 : 0;
+    // Match the TEXT_MESSAGE_APP id format above — see the comment there
+    // for why the TCP convention `${sourceId}_${fromNum}_${packetId}` is
+    // load-bearing for cross-source dedup in the unified view.
+    const id = `${sourceId}_${fromNum}_${packetId || nowMs}`;
+    // Dedup: if the original transmission already landed in `messages`
+    // via the regular TEXT_MESSAGE_APP path, don't double-insert.
+    const existing = await databaseService.messages.getMessage(id);
+    if (existing) {
+      logger.debug(`📦 MQTT S&F replay duplicates existing message ${id}`);
+      return false;
+    }
+    const msg: DbMessage = {
+      id,
+      fromNodeNum: fromNum,
+      toNodeNum: toNum ?? 0xffffffff,
+      fromNodeId,
+      toNodeId,
+      text,
+      channel: typeof packet.channel === 'number' ? packet.channel : 0,
+      portnum: PortNum.TEXT_MESSAGE_APP,
+      timestamp: nowMs,
+      rxTime: typeof packet.rxTime === 'number' ? packet.rxTime * 1000 : undefined,
+      rxSnr: typeof packet.rxSnr === 'number' ? packet.rxSnr : undefined,
+      rxRssi: typeof packet.rxRssi === 'number' ? packet.rxRssi : undefined,
+      viaMqtt: true,
+      createdAt: nowMs,
+    } as DbMessage;
+    (msg as any).sourceId = sourceId;
+    (msg as any).viaStoreForward = true;
+    // Same per-source insert path as the TEXT_MESSAGE_APP case above —
+    // the facade drops sourceId; the repo accepts it.
+    databaseService.messages.insertMessage(msg, sourceId);
+    return true;
+  }
+
+  if (rr === StoreForwardRequestResponse.ROUTER_HEARTBEAT) {
+    databaseService.upsertNode({
+      nodeNum: fromNum,
+      nodeId: fromNodeId,
+      longName: '',
+      shortName: '',
+      hwModel: 0,
+      lastHeard: Math.floor(nowMs / 1000),
+      viaMqtt: true,
+      sourceId,
+      createdAt: nowMs,
+      updatedAt: nowMs,
+      // isStoreForwardServer is in the schema but not on DbNode (Migration 056-ish).
+      ...({ isStoreForwardServer: true } as any),
+    } as Partial<DbNode>);
+    return true;
+  }
+
+  // STATS / HISTORY / PING / PONG / BUSY / etc. — log-only on TCP, mirrored here.
+  logger.debug(`📦 MQTT S&F ${rrName} (rr=${rr}) from ${fromNodeId}`);
+  return false;
+}
+
+/**
+ * Per-source memo of (slot, channelName) pairs we've already upserted into
+ * the channels table this process lifetime. Used to keep `recordChannelFromEnvelope`
+ * cheap: only the first packet on a given (source, slot, name) combination
+ * actually hits the DB. Names that change for an existing slot still trigger
+ * a fresh upsert so the picker stays in sync.
+ */
+const channelMemo = new Map<string, Map<number, string>>();
+
+function recordChannelFromEnvelope(
+  sourceId: string,
+  envelope: ServiceEnvelopeShape,
+  packet: NonNullable<ServiceEnvelopeShape['packet']>,
+): void {
+  const name = envelope.channelId?.trim();
+  if (!name) return;
+  const slot = typeof packet.channel === 'number' ? packet.channel : 0;
+  if (slot < 0 || slot > 255) return;
+
+  let perSource = channelMemo.get(sourceId);
+  if (!perSource) {
+    perSource = new Map();
+    channelMemo.set(sourceId, perSource);
+  }
+  if (perSource.get(slot) === name) return;
+  perSource.set(slot, name);
+
+  try {
+    const result = databaseService.channels?.upsertChannel(
+      {
+        id: slot,
+        name,
+        // Slot 0 is the primary channel on Meshtastic; anything else is
+        // secondary. Matches the role rules in `upsertChannel`.
+        role: slot === 0 ? 1 : 2,
+        uplinkEnabled: true,
+        downlinkEnabled: true,
+      },
+      sourceId,
+    );
+    if (result && typeof (result as any).catch === 'function') {
+      (result as Promise<unknown>).catch((err) => {
+        // Clear the memo entry so a retry can run on the next packet —
+        // losing a single write isn't fatal, but persistently skipping
+        // it would keep the channel invisible in the picker.
+        perSource!.delete(slot);
+        const m = err instanceof Error ? err.message : String(err);
+        logger.debug(`MQTT channel upsert skipped for source ${sourceId} slot ${slot}: ${m}`);
+      });
+    }
+  } catch (err) {
+    perSource.delete(slot);
+    const m = err instanceof Error ? err.message : String(err);
+    logger.debug(`MQTT channel upsert unavailable for source ${sourceId} slot ${slot}: ${m}`);
   }
 }
 

--- a/src/server/mqttPacketFilter.test.ts
+++ b/src/server/mqttPacketFilter.test.ts
@@ -326,6 +326,136 @@ describe('MqttPacketFilter.passesMembership — fail-closed geo membership', () 
   });
 });
 
+describe('MqttPacketFilter.seedMembership — pre-seeded geo membership', () => {
+  // Bbox approximately covering southern Ontario.
+  const ON_BBOX = { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 };
+  const NODE_IN = 0x7ff80a48;
+  const NODE_OUT = 0x11111111;
+  const NODE_OTHER = 0x33333333;
+
+  it('seeds in-region nodes so non-position packets pass without a prior POSITION_APP', () => {
+    const f = new MqttPacketFilter({ geo: ON_BBOX });
+    // Pre-load with Toronto-ish coordinates.
+    const count = f.seedMembership([
+      { nodeNum: NODE_IN, latitudeDeg: 43.7, longitudeDeg: -79.3 },
+    ]);
+    expect(count).toBe(1);
+    // Right out of the gate, before any POSITION_APP packet — node passes.
+    expect(f.passesMembership(NODE_IN)).toBe(true);
+    expect(f.getDropCounters().geo).toBe(0);
+  });
+
+  it('does NOT seed out-of-region nodes (only seeds "in")', () => {
+    const f = new MqttPacketFilter({ geo: ON_BBOX });
+    // Vancouver — clearly outside.
+    const count = f.seedMembership([
+      { nodeNum: NODE_OUT, latitudeDeg: 49.2, longitudeDeg: -123.0 },
+    ]);
+    expect(count).toBe(0);
+    // Node remains unknown — fail-closed drops, but cache stays empty so the
+    // next POSITION_APP can still flip the verdict either way.
+    expect(f.passesMembership(NODE_OUT)).toBe(false);
+    expect(f.getMembershipSize()).toBe(0);
+  });
+
+  it('partitions a mixed batch into in/out and only seeds the in-region ones', () => {
+    const f = new MqttPacketFilter({ geo: ON_BBOX });
+    const count = f.seedMembership([
+      { nodeNum: NODE_IN, latitudeDeg: 43.7, longitudeDeg: -79.3 },
+      { nodeNum: NODE_OUT, latitudeDeg: 49.2, longitudeDeg: -123.0 },
+      { nodeNum: NODE_OTHER, latitudeDeg: 44.0, longitudeDeg: -78.5 },
+    ]);
+    expect(count).toBe(2);
+    expect(f.getMembershipSize()).toBe(2);
+    expect(f.passesMembership(NODE_IN)).toBe(true);
+    expect(f.passesMembership(NODE_OTHER)).toBe(true);
+    expect(f.passesMembership(NODE_OUT)).toBe(false);
+  });
+
+  it('skips entries with non-finite coordinates without throwing', () => {
+    const f = new MqttPacketFilter({ geo: ON_BBOX });
+    const count = f.seedMembership([
+      { nodeNum: NODE_IN, latitudeDeg: NaN, longitudeDeg: -79.3 },
+      { nodeNum: NODE_OTHER, latitudeDeg: 43.7, longitudeDeg: Infinity },
+    ]);
+    expect(count).toBe(0);
+    expect(f.getMembershipSize()).toBe(0);
+  });
+
+  it('treats 0,0 as "no position" sentinel and skips it', () => {
+    const f = new MqttPacketFilter({ geo: { minLat: -1, maxLat: 1, minLng: -1, maxLng: 1 } });
+    // 0,0 is technically inside the bbox here, but it's our codebase-wide
+    // sentinel for "node has no real position yet" — must not be seeded.
+    const count = f.seedMembership([
+      { nodeNum: NODE_IN, latitudeDeg: 0, longitudeDeg: 0 },
+    ]);
+    expect(count).toBe(0);
+    expect(f.passesMembership(NODE_IN)).toBe(false);
+  });
+
+  it('is a no-op when the filter has no bbox configured', () => {
+    const f = new MqttPacketFilter({});
+    const count = f.seedMembership([
+      { nodeNum: NODE_IN, latitudeDeg: 43.7, longitudeDeg: -79.3 },
+    ]);
+    expect(count).toBe(0);
+    expect(f.getMembershipSize()).toBe(0);
+  });
+
+  it('lets a subsequent POSITION_APP outside the bbox override the seed', () => {
+    const f = new MqttPacketFilter({ geo: ON_BBOX });
+    f.seedMembership([{ nodeNum: NODE_IN, latitudeDeg: 43.7, longitudeDeg: -79.3 }]);
+    expect(f.passesMembership(NODE_IN)).toBe(true);
+
+    // Node sends a new position — Vancouver, outside the bbox.
+    f.postFilterPosition({ latitudeI: 492_000_000, longitudeI: -1_230_000_000 }, NODE_IN);
+    expect(f.passesMembership(NODE_IN)).toBe(false);
+    // Still a single entry — refreshed, not duplicated.
+    expect(f.getMembershipSize()).toBe(1);
+  });
+});
+
+describe('MqttPacketFilter.seedTrustedNodes — bypasses bbox check', () => {
+  const ON_BBOX = { minLat: 43, maxLat: 45, minLng: -80, maxLng: -77 };
+  const NODE_A = 0xa2e4ff4c;
+  const NODE_B = 0x11111111;
+
+  it('marks nodes as in-cache without a position check', () => {
+    const f = new MqttPacketFilter({ geo: ON_BBOX });
+    const seeded = f.seedTrustedNodes([NODE_A, NODE_B]);
+    expect(seeded).toBe(2);
+    expect(f.passesMembership(NODE_A)).toBe(true);
+    expect(f.passesMembership(NODE_B)).toBe(true);
+    expect(f.getDropCounters().geo).toBe(0);
+  });
+
+  it('skips non-finite node numbers', () => {
+    const f = new MqttPacketFilter({ geo: ON_BBOX });
+    const seeded = f.seedTrustedNodes([NaN, Infinity, NODE_A] as any);
+    expect(seeded).toBe(1);
+    expect(f.passesMembership(NODE_A)).toBe(true);
+  });
+
+  it('is a no-op when no bbox is configured', () => {
+    const f = new MqttPacketFilter({});
+    const seeded = f.seedTrustedNodes([NODE_A]);
+    expect(seeded).toBe(0);
+    expect(f.getMembershipSize()).toBe(0);
+  });
+
+  it('lets a subsequent out-of-bbox POSITION_APP downgrade a trusted seed', () => {
+    const f = new MqttPacketFilter({ geo: ON_BBOX });
+    f.seedTrustedNodes([NODE_A]);
+    expect(f.passesMembership(NODE_A)).toBe(true);
+
+    // Trusted node sends a position outside the bbox — membership flips.
+    // Same refresh semantics as `seedMembership` lets POSITION_APP override.
+    f.postFilterPosition({ latitudeI: 492_000_000, longitudeI: -1_230_000_000 }, NODE_A);
+    expect(f.passesMembership(NODE_A)).toBe(false);
+    expect(f.getMembershipSize()).toBe(1);
+  });
+});
+
 describe('MqttPacketFilter.resetCounters', () => {
   it('zeroes all drop counters', () => {
     const f = new MqttPacketFilter({ topics: { block: ['x'] } });

--- a/src/server/mqttPacketFilter.ts
+++ b/src/server/mqttPacketFilter.ts
@@ -224,6 +224,63 @@ export class MqttPacketFilter {
     return this.membership.size;
   }
 
+  /**
+   * Pre-seed the membership cache with "trusted" nodes — those we know
+   * belong to the operator's mesh regardless of whether we have a stored
+   * position for them. Used to flow MQTT-relayed packets from nodes that
+   * our TCP/Meshcore sources have heard directly but whose position
+   * hasn't been decoded yet (e.g. a base station with GPS disabled).
+   *
+   * Bypasses the bbox check on purpose: if a node is part of the local
+   * mesh, its MQTT-relayed traffic should land regardless of geometry.
+   * No-op when no bbox is configured (everything already passes).
+   */
+  seedTrustedNodes(nodeNums: Iterable<number>): number {
+    if (!this.hasGeoBounds()) return 0;
+    let seeded = 0;
+    for (const num of nodeNums) {
+      if (!Number.isFinite(num)) continue;
+      this.recordMembership(num >>> 0, 'in');
+      seeded++;
+    }
+    return seeded;
+  }
+
+  /**
+   * Pre-seed the membership cache with nodes whose persisted positions are
+   * inside the bbox. Used by MqttBridgeManager on start so that nodes
+   * already known to be in-region don't have to re-broadcast a POSITION_APP
+   * packet before their TEXT/TELEMETRY/NODEINFO traffic is accepted.
+   *
+   * Only seeds 'in' — never 'out'. An out-of-region node may have moved,
+   * so we leave it unknown and let the next POSITION_APP packet update it.
+   * Returns the number of entries actually marked. No-op when no bbox is
+   * configured or for entries with invalid/zero coords.
+   */
+  seedMembership(
+    entries: Array<{ nodeNum: number; latitudeDeg: number; longitudeDeg: number }>,
+  ): number {
+    if (!this.hasGeoBounds()) return 0;
+    const { minLat, maxLat, minLng, maxLng } = this.geo!;
+    let seeded = 0;
+    for (const e of entries) {
+      const lat = e.latitudeDeg;
+      const lng = e.longitudeDeg;
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+      // 0,0 is the sentinel for "no position" elsewhere in the codebase.
+      if (lat === 0 && lng === 0) continue;
+      const inside =
+        (typeof minLat !== 'number' || lat >= minLat) &&
+        (typeof maxLat !== 'number' || lat <= maxLat) &&
+        (typeof minLng !== 'number' || lng >= minLng) &&
+        (typeof maxLng !== 'number' || lng <= maxLng);
+      if (!inside) continue;
+      this.recordMembership(e.nodeNum >>> 0, 'in');
+      seeded++;
+    }
+    return seeded;
+  }
+
   getDropCounters(): MqttFilterDropCounters {
     return { ...this.drops };
   }

--- a/src/server/routes/unifiedRoutes.test.ts
+++ b/src/server/routes/unifiedRoutes.test.ts
@@ -36,6 +36,9 @@ vi.mock('../../services/database.js', () => ({
       getAllAsync: vi.fn(),
       getPermissionsForUserAsync: vi.fn(),
     },
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+    },
     checkPermissionAsync: vi.fn(),
     findUserByIdAsync: vi.fn(),
     findUserByUsernameAsync: vi.fn(),
@@ -242,6 +245,63 @@ describe('Unified Routes', () => {
       const app = createApp(adminUser);
       const res = await request(app).get('/channels');
       expect(res.status).toBe(500);
+    });
+
+    it('uses the source modem preset as the slot 0 display name when set', async () => {
+      // Empty-named slot 0 on a TCP source with persisted preset 4 (MEDIUM_FAST)
+      // should display as "MediumFast" — matching the firmware-derived label
+      // that public MQTT gateways publish under, so unified picker collapses
+      // TCP + MQTT receptions of the same logical channel.
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
+      mockDb.channels.getAllChannels.mockResolvedValue([{ id: 0, name: '', role: 1 }]);
+      mockDb.settings.getSetting.mockResolvedValueOnce('4'); // MEDIUM_FAST
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/channels');
+
+      expect(res.status).toBe(200);
+      const names = res.body.map((c: any) => c.name);
+      expect(names).toContain('MediumFast');
+      expect(names).not.toContain('Primary');
+    });
+
+    it('falls back to "Primary" when no preset is persisted for the source', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
+      mockDb.channels.getAllChannels.mockResolvedValue([{ id: 0, name: '', role: 1 }]);
+      mockDb.settings.getSetting.mockResolvedValue(null);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/channels');
+
+      expect(res.status).toBe(200);
+      const names = res.body.map((c: any) => c.name);
+      expect(names).toContain('Primary');
+    });
+
+    it('groups TCP empty-slot-0 and MQTT explicit-name as one entry when preset matches', async () => {
+      // TCP source: empty-name slot 0 with preset MEDIUM_FAST → "MediumFast"
+      // MQTT source: explicit "MediumFast" at slot 0
+      // Both should collapse to one picker entry sourced from both.
+      const TCP_SRC = { id: 'tcp', name: 'TCP', type: 'meshtastic_tcp', enabled: true };
+      const MQTT_SRC = { id: 'mqtt', name: 'MQTT', type: 'mqtt_bridge', enabled: true };
+      mockDb.sources.getAllSources.mockResolvedValue([TCP_SRC, MQTT_SRC]);
+      mockDb.channels.getAllChannels.mockImplementation((sourceId: string) => {
+        if (sourceId === 'tcp') return Promise.resolve([{ id: 0, name: '', role: 1 }]);
+        return Promise.resolve([{ id: 0, name: 'MediumFast', role: 1 }]);
+      });
+      // Preset only persisted for the TCP source.
+      mockDb.settings.getSetting.mockImplementation((key: string) =>
+        Promise.resolve(key === 'lora.preset.tcp' ? '4' : null),
+      );
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/channels');
+
+      expect(res.status).toBe(200);
+      const mediumFast = res.body.find((c: any) => c.name === 'MediumFast');
+      expect(mediumFast).toBeDefined();
+      expect(mediumFast.sources).toHaveLength(2);
+      expect(mediumFast.sources.map((s: any) => s.sourceId).sort()).toEqual(['mqtt', 'tcp']);
     });
   });
 

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -9,7 +9,7 @@ import { Router, Request, Response } from 'express';
 import databaseService from '../../services/database.js';
 import { optionalAuth } from '../auth/authMiddleware.js';
 import { logger } from '../../utils/logger.js';
-import { PortNum, CHANNEL_DB_OFFSET } from '../constants/meshtastic.js';
+import { PortNum, CHANNEL_DB_OFFSET, modemPresetChannelName } from '../constants/meshtastic.js';
 import type { DbChannelDatabase } from '../../db/types.js';
 
 const router = Router();
@@ -22,24 +22,59 @@ router.use(optionalAuth());
  *
  * Meshtastic channel conventions:
  *  - Channel 0 is always the PRIMARY channel. Its name is often blank because
- *    the Meshtastic client shows the modem preset instead; we label it
- *    "Primary" so it surfaces in the unified channel picker.
+ *    the firmware derives the on-wire channel name from the modem preset at
+ *    runtime — `MEDIUM_FAST` → "MediumFast" — and uses that derived name for
+ *    both the channel hash and the `ServiceEnvelope.channelId` it publishes
+ *    to MQTT. When we have the source's preset on hand (via
+ *    `lora.preset.<sourceId>` in the settings table), use the preset's
+ *    pascal-case label so the TCP-side empty-name channel groups with
+ *    MQTT-side rows that carry the same label. Falls back to "Primary" only
+ *    when no preset is known.
  *  - Channels with `role === 0` are DISABLED — skip entirely.
  *  - Any other channel with a blank name is a disabled/unused slot — skip.
  *
  * Returns `null` when the channel should be omitted from the unified list.
  */
 const PRIMARY_CHANNEL_NAME = 'Primary';
-function unifiedChannelDisplayName(c: {
-  id: number;
-  name?: string | null;
-  role?: number | null;
-}): string | null {
+function unifiedChannelDisplayName(
+  c: { id: number; name?: string | null; role?: number | null },
+  presetName?: string | null,
+): string | null {
   if (c.role === 0) return null; // DISABLED
   const name = (c.name ?? '').trim();
   if (name) return name;
-  if (c.id === 0) return PRIMARY_CHANNEL_NAME;
+  if (c.id === 0) return presetName ?? PRIMARY_CHANNEL_NAME;
   return null;
+}
+
+/**
+ * Load the modem-preset-derived channel name for each source the caller can
+ * see. Returns a Map<sourceId, presetName | null>. Sources without a stored
+ * `lora.preset.<sourceId>` setting (e.g. MQTT bridges/brokers, MeshCore
+ * sources, or TCP sources we've never received config from) map to null.
+ *
+ * Heavy callers fetch this once up front and pass per-source slices into
+ * `unifiedChannelDisplayName` so we don't hit the settings table on every
+ * channel row.
+ */
+async function loadSourcePresetNames(sourceIds: string[]): Promise<Map<string, string | null>> {
+  const out = new Map<string, string | null>();
+  await Promise.all(
+    sourceIds.map(async (sid) => {
+      try {
+        const raw = await databaseService.settings.getSetting(`lora.preset.${sid}`);
+        if (raw === null || raw === undefined) {
+          out.set(sid, null);
+          return;
+        }
+        const n = Number(raw);
+        out.set(sid, Number.isFinite(n) ? modemPresetChannelName(n) : null);
+      } catch {
+        out.set(sid, null);
+      }
+    }),
+  );
+  return out;
 }
 
 /**
@@ -52,6 +87,16 @@ function unifiedChannelDisplayName(c: {
  * reliable cross-source dedup key for received text messages because the
  * `requestId` column is only populated for Virtual Node ACK tracking, not for
  * ordinary received text.
+ *
+ * **Contract for every code path that inserts into `messages`:** this exact
+ * format (underscores, fromNum middle, packetId last) is load-bearing.
+ * Diverge from it — different separator, different field order, hyphens,
+ * anything — and this parser returns null. The `/messages` dedup then falls
+ * back to a `${fromNum}:${text}:${floor(timestamp/1000)}` heuristic. TCP and
+ * MQTT receptions of the same packet arrive seconds apart, miss the 1s
+ * window, and the user sees the same message N times in the unified view —
+ * once per receiving source. See `src/server/mqttIngestion.ts` for examples
+ * of MQTT-side ingest matching this format.
  *
  * Defensive validation (rowId comes from DB so trusted, but cheap to harden):
  *  - non-string or empty → null
@@ -152,6 +197,10 @@ router.get('/channels', async (req: Request, res: Response) => {
       loadEnabledVirtualChannels(),
       getUserReadableVirtualChannelIds(user, isAdmin),
     ]);
+    // Modem preset per source — used as the fallback display name for
+    // empty-named slot 0 so TCP and MQTT-side rows for the same logical
+    // channel collapse to one picker entry.
+    const sourcePresets = await loadSourcePresetNames(sources.map((s) => s.id));
 
     type ChannelSourceRef = { sourceId: string; sourceName: string; channelNumber: number };
     // Group case-insensitively so cross-device casing drift (e.g. one source
@@ -186,8 +235,9 @@ router.get('/channels', async (req: Request, res: Response) => {
 
         try {
           const chans = await databaseService.channels.getAllChannels(source.id);
+          const presetName = sourcePresets.get(source.id) ?? null;
           for (const c of chans) {
-            const name = unifiedChannelDisplayName(c as any);
+            const name = unifiedChannelDisplayName(c as any, presetName);
             if (!name) continue; // disabled or unused slot
             const channelNum = (c as any).id as number;
             const canReadChannel = canReadMessages || (user
@@ -290,6 +340,10 @@ router.get('/messages', async (req: Request, res: Response) => {
       loadEnabledVirtualChannels(),
       getUserReadableVirtualChannelIds(user, isAdmin),
     ]);
+    // Modem preset per source — pass into the channel-name resolver so a
+    // picker entry like "MediumFast" matches an empty-named slot 0 on a TCP
+    // source whose preset derives that label.
+    const sourcePresets = await loadSourcePresetNames(sources.map((s) => s.id));
 
     type Reception = {
       sourceId: string;
@@ -379,11 +433,16 @@ router.get('/messages', async (req: Request, res: Response) => {
           // messages even though the picker showed a single entry.
           const channelNameLower = channelName.toLowerCase();
 
-          // Physical slot match.
-          const match = chans?.find(
-            (c) => (unifiedChannelDisplayName(c as any) ?? '').toLowerCase() === channelNameLower
+          // Physical slot matches. MQTT bridges/brokers can have multiple
+          // slots on a single source with the same channel name (different
+          // upstream gateways place "LongFast" at different slots) — collect
+          // ALL matches, not just the first. The preset hint lets empty-named
+          // slot 0 on a TCP source match a picker entry like "MediumFast".
+          const presetName = sourcePresets.get(source.id) ?? null;
+          const physMatches = (chans ?? []).filter(
+            (c) => (unifiedChannelDisplayName(c as any, presetName) ?? '').toLowerCase() === channelNameLower
           );
-          if (match) {
+          for (const match of physMatches) {
             const physNum = (match as any).id as number;
             const canReadChannel = canReadMessages || (user
               ? await databaseService.checkPermissionAsync(
@@ -605,7 +664,7 @@ router.get('/telemetry', async (req: Request, res: Response) => {
         const perNodeLatest = await Promise.all(
           nodes.map((node) =>
             databaseService.telemetry
-              .getLatestTelemetryByNode(node.nodeId)
+              .getLatestTelemetryByNode(node.nodeId, source.id)
               .then((latest) => ({ node, latest }))
               .catch((err) => {
                 logger.warn(


### PR DESCRIPTION
## Summary

MQTT bridges were connecting to upstream brokers but contributing almost nothing to the unified views. This PR fixes the entire ingest path so MQTT-relayed traffic lands properly attributed, decrypts via the channel database, and dedups across TCP + MQTT receptions of the same mesh packet.

**Before:** ~99% packet drop rate on Florida MQTT, zero messages in DB from MQTT sources, no MQTT entries in the unified channels picker or source filter.

**After:** ~25–35% ingest rate, full nodes/messages/telemetry/traceroutes/neighbors populated per MQTT source, picker entries from TCP and MQTT collapse to one logical channel, and a single mesh packet heard by TCP + Florida MQTT + Yeraze Broker appears as one unified entry with three receptions.

## What's in here

### Ingest pipeline (`src/server/mqttIngestion.ts`)
- `ingestServiceEnvelope` is async now and dispatches four additional portnums with the same storage semantics as the TCP path: `TRACEROUTE_APP` (incl. route segments + hop telemetry), `NEIGHBORINFO_APP`, `PAXCOUNTER_APP`, and `STORE_FORWARD_APP` (`ROUTER_HEARTBEAT` + `ROUTER_TEXT_*`).
- Server-side channel decryption via `channelDecryptionService`, mirroring `meshtasticManager.processMeshPacket` — encrypted packets get a synthetic `decoded` field populated from any matching `channel_database` PSK.
- `bootstrapMqttChannelDatabase` auto-seeds the well-known LongFast key (`AQ==`, expanded by `expandShorthandPsk`) so MQTT decryption works out of the box for new MQTT sources. Idempotent across multiple sources.
- Auto-records each `(envelope.channelId, packet.channel)` pair seen into the per-source `channels` table so the unified channels picker surfaces MQTT-side labels.
- Message row IDs now use the TCP convention `${sourceId}_${fromNum}_${packetId}`. This is load-bearing — `extractPacketIdFromRowId` in `unifiedRoutes.ts` splits on `_` and reads the trailing segment for the cross-source dedup key. Previously diverged with hyphens, which made the same packet appear N times in the unified view.
- Messages now flow through `databaseService.messages.insertMessage(msg, sourceId)` (repo) instead of `databaseService.insertMessage(msg)` (facade). The facade drops the `sourceId`, leaving rows orphaned with `sourceId=NULL` and invisible to source-scoped queries.

### Geo-membership seed (`src/server/mqttPacketFilter.ts`, `mqttBridgeManager.ts`)
- `seedMembership(positions)` marks nodes whose stored position is inside the bbox as `'in'` on bridge start, so non-POSITION traffic from already-known nodes flows without waiting for a fresh `POSITION_APP` broadcast (which can be hours and is reset on every restart).
- `seedTrustedNodes(nodeNums)` bypasses the bbox check for any node already heard directly by a non-MQTT source — fixes the case where the operator's own station (GPS off, no stored position) was geo-dropped on MQTT-relayed copies of its own packets.

### Unified routes (`src/server/routes/unifiedRoutes.ts`)
- `/telemetry`: `getLatestTelemetryByNode` now takes a `sourceId` so cross-source telemetry no longer misattributes to whichever source happens to be iterating in the outer loop. Telemetry repo signatures widened.
- `/channels` + `/messages`: multi-slot match (`filter`, not `find`) so MQTT sources with multiple slots sharing one channel name all resolve.
- `unifiedChannelDisplayName` accepts a preset hint; slot 0 with empty name resolves to the firmware-derived label (`MediumFast`, `LongFast`, etc.) from the persisted `lora.preset.<sourceId>` setting. Collapses TCP empty-name slot 0 with MQTT-side `"MediumFast"` rows into one picker entry. `meshtasticManager` persists the preset on each LoRa config response.
- New `MODEM_PRESET_CHANNEL_NAMES` constant + `modemPresetChannelName` helper in `src/server/constants/meshtastic.ts` (firmware-spec pascal-case names — distinct from the human-friendly `"Long Fast"` labels).
- Expanded jsdoc on `extractPacketIdFromRowId` documenting the row-ID contract so future ingest paths don't diverge.

### Misc
- `docker-compose.dev.yml`: removed the standalone LN4CY `mqtt-proxy` sidecar service. The feature has been integrated.

## Test plan

- [x] `npx vitest run` — 10064 tests pass (4 new in mqttPacketFilter, 10 new in mqttIngestion, 3 new in unifiedRoutes)
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] Live verification in dev container with 3 MQTT sources (1 broker + 2 bridges):
  - Bridges seed 346 trusted + ~600-700 in-bbox nodes on start
  - LongFast PSK auto-bootstrapped to `channel_database`
  - >4500 packets decrypted via channel decryption in normal operation
  - Telemetry, traceroute, neighbor info rows landing per-source
  - Sent test message confirmed to appear as ONE unified entry with TCP + Florida MQTT + Yeraze Broker receptions stacked
  - `MediumFast` shows in the unified picker (was `Primary`)
- [x] System tests run on every PR via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)