### PR TITLE
feat(channels): apply modem-preset display name to per-source channels view

### DIFF
--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -330,8 +330,15 @@ export default function ChannelsTab({
     // First check device channels (0-7)
     const channel = channels.find(ch => ch.id === channelNum);
     if (channel) {
-      // Slot 0 with blank name displays as "Primary" — matches unifiedChannelDisplayName
-      // and the Meshtastic client convention of falling back to the modem preset label.
+      // Prefer the server-projected `displayName` — it carries the modem-
+      // preset fallback ("MediumFast"/"LongFast"/etc.) for empty-name slot
+      // 0, matching the unified picker and what MQTT gateways publish under.
+      // Falls back to the raw `name`, and finally to the legacy "Primary"
+      // localization key when neither is present (server returns
+      // displayName="Primary" only when no preset is known for the source).
+      if (channel.displayName && channel.displayName.trim()) {
+        return channel.displayName;
+      }
       if (!channel.name?.trim() && channelNum === 0) {
         return t('channels.primary');
       }

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -10,7 +10,7 @@ import { MqttBrokerManager, type MqttBrokerSourceConfig } from '../mqttBrokerMan
 import { MqttBridgeManager, type MqttBridgeSourceConfig } from '../mqttBridgeManager.js';
 import waypointRoutes from './waypoints.js';
 import { filterNodesByChannelPermission, maskNodeLocationByChannel, getEffectiveDbNodePosition } from '../utils/nodeEnhancer.js';
-import { PortNum } from '../constants/meshtastic.js';
+import { PortNum, modemPresetChannelName } from '../constants/meshtastic.js';
 import { transformChannel } from '../utils/channelView.js';
 import type { ResourceType } from '../../types/permission.js';
 
@@ -759,6 +759,20 @@ router.get('/:id/channels', optionalAuth(), async (req: Request, res: Response) 
     const allChannels = await databaseService.channels.getAllChannels(source.id);
     const isAdmin = req.user?.isAdmin === true;
 
+    // Resolve this source's persisted modem preset (if any) so empty-name
+    // slot 0 can display as "MediumFast"/"LongFast"/etc. instead of the
+    // synthetic "Primary" fallback — matching the unified channels picker
+    // and the on-wire label gateways use. The setting is written by
+    // `meshtasticManager` on each LoRa config response.
+    let presetName: string | null = null;
+    try {
+      const raw = await databaseService.settings.getSetting(`lora.preset.${source.id}`);
+      const n = raw != null ? Number(raw) : NaN;
+      if (Number.isFinite(n)) presetName = modemPresetChannelName(n);
+    } catch (err) {
+      logger.debug(`Failed to load preset for source ${source.id}:`, err);
+    }
+
     const accessible: typeof allChannels = [];
     for (const channel of allChannels) {
       if (isAdmin) {
@@ -780,7 +794,7 @@ router.get('/:id/channels', optionalAuth(), async (req: Request, res: Response) 
       const includePsk = isAdmin || (req.user
         ? await hasPermission(req.user, channelResource, 'write', source.id)
         : false);
-      return transformChannel(channel, { includePsk });
+      return transformChannel(channel, { includePsk, presetName });
     }));
 
     res.json(projected);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -51,7 +51,7 @@ import { rewriteHtml } from './utils/htmlRewriter.js';
 import { migrateAutomationChannels } from './utils/automationChannelMigration.js';
 import { safeFetch, SsrfBlockedError } from './utils/ssrfGuard.js';
 import { resolveRequestSourceId } from './utils/sourceResolver.js';
-import { PortNum } from './constants/meshtastic.js';
+import { PortNum, modemPresetChannelName } from './constants/meshtastic.js';
 import settingsRoutes, { setSettingsCallbacks } from './routes/settingsRoutes.js';
 import { applyManagerSettings } from './applyManagerSettings.js';
 
@@ -2647,6 +2647,21 @@ apiRouter.get('/channels', optionalAuth(), async (req, res) => {
     const allChannels = await databaseService.channels.getAllChannels(channelsSourceId);
     const isAdmin = req.user?.isAdmin === true;
 
+    // Resolve the source's persisted modem preset (if scoped to one source)
+    // so empty-name slot 0 displays as "MediumFast"/"LongFast"/etc. via
+    // transformChannel's `displayName` field. Matches the unified picker
+    // and the firmware-derived label MQTT gateways publish under.
+    let channelsPresetName: string | null = null;
+    if (channelsSourceId) {
+      try {
+        const raw = await databaseService.settings.getSetting(`lora.preset.${channelsSourceId}`);
+        const n = raw != null ? Number(raw) : NaN;
+        if (Number.isFinite(n)) channelsPresetName = modemPresetChannelName(n);
+      } catch (err) {
+        logger.debug(`Failed to load preset for source ${channelsSourceId}:`, err);
+      }
+    }
+
     // Per-row permission gate (MM-SEC-2). Build the authorized set first.
     const accessible: typeof allChannels = [];
     for (const channel of allChannels) {
@@ -2705,7 +2720,7 @@ apiRouter.get('/channels', optionalAuth(), async (req, res) => {
       const includePsk = isAdmin || (req.user
         ? await hasPermission(req.user, channelResource, 'write', channelsSourceId)
         : false);
-      return transformChannel(channel, { includePsk });
+      return transformChannel(channel, { includePsk, presetName: channelsPresetName });
     }));
 
     logger.debug(`📡 Serving ${filteredChannels.length} filtered channels (from ${allChannels.length} total)`);

--- a/src/server/utils/channelView.test.ts
+++ b/src/server/utils/channelView.test.ts
@@ -70,11 +70,33 @@ describe('channelView', () => {
       const out = transformChannel(dbRow);
       expect(Object.keys(out).sort()).toEqual(
         [
-          'id', 'name', 'role', 'roleName',
+          'id', 'name', 'displayName', 'role', 'roleName',
           'uplinkEnabled', 'downlinkEnabled', 'positionPrecision',
           'pskSet', 'encryptionStatus',
         ].sort()
       );
+    });
+
+    it('uses raw name as displayName when set', () => {
+      const out = transformChannel({ ...dbRow, name: 'gauntlet', id: 2 });
+      expect(out.name).toBe('gauntlet');
+      expect(out.displayName).toBe('gauntlet');
+    });
+
+    it('falls back to preset-derived name for empty slot 0 when presetName is provided', () => {
+      const out = transformChannel({ ...dbRow, name: '' }, { presetName: 'MediumFast' });
+      expect(out.name).toBe(''); // raw DB column unchanged
+      expect(out.displayName).toBe('MediumFast');
+    });
+
+    it('falls back to "Primary" for empty slot 0 when no preset is provided', () => {
+      const out = transformChannel({ ...dbRow, name: '' });
+      expect(out.displayName).toBe('Primary');
+    });
+
+    it('does not synthesize a fallback name for non-slot-0 empty channels', () => {
+      const out = transformChannel({ ...dbRow, id: 3, name: '' });
+      expect(out.displayName).toBe('');
     });
 
     it('includes psk only when includePsk: true is passed', () => {

--- a/src/server/utils/channelView.ts
+++ b/src/server/utils/channelView.ts
@@ -46,14 +46,51 @@ export interface TransformChannelOptions {
    * callers; see `transformChannelForUser` for the gated helper.
    */
   includePsk?: boolean;
+  /**
+   * Firmware-derived channel name for the device's modem preset
+   * (e.g. `MediumFast`, `LongFast`). When provided, this is used as the
+   * `displayName` fallback for slot 0 if its `name` column is blank —
+   * matching what the Meshtastic firmware actually publishes on the wire.
+   * Callers compute this from the persisted `lora.preset.<sourceId>`
+   * setting via `modemPresetChannelName`; pass `null` when no preset is
+   * known for the source.
+   */
+  presetName?: string | null;
+}
+
+/** Slot 0 fallback when we can't derive a firmware-preset name. */
+export const PRIMARY_CHANNEL_NAME = 'Primary';
+
+/**
+ * Compute the user-facing display name for a channel row, applying the
+ * same rules as `unifiedChannelDisplayName` in unifiedRoutes.ts:
+ *   1. If `name` is set, use it.
+ *   2. Otherwise for slot 0, fall back to the modem-preset's firmware name
+ *      ("MediumFast", "LongFast", etc.) when available, so per-source
+ *      views collapse onto the same label MQTT gateways publish under.
+ *   3. Otherwise for slot 0 with no preset hint, fall back to "Primary".
+ *   4. Otherwise return whatever `name` is (typically empty/unused slot).
+ */
+export function computeChannelDisplayName(
+  channel: { id: number; name?: string | null },
+  presetName?: string | null,
+): string {
+  const trimmed = (channel.name ?? '').trim();
+  if (trimmed) return trimmed;
+  if (channel.id === 0) return presetName ?? PRIMARY_CHANNEL_NAME;
+  return trimmed;
 }
 
 /**
  * Project a raw `channels` row into the public response shape.
  *
- * Always returns: `id`, `name`, `role`, `roleName`, `uplinkEnabled`,
- * `downlinkEnabled`, `positionPrecision`, `pskSet` (boolean), and
- * `encryptionStatus` ('none' | 'default' | 'secure').
+ * Always returns: `id`, `name`, `displayName`, `role`, `roleName`,
+ * `uplinkEnabled`, `downlinkEnabled`, `positionPrecision`,
+ * `pskSet` (boolean), and `encryptionStatus` ('none' | 'default' | 'secure').
+ *
+ * `name` is the raw DB column (may be empty for slot 0 when the device
+ * runs on a modem preset). `displayName` is the user-facing label with
+ * the preset/Primary fallback applied — frontends should render that.
  *
  * When `options.includePsk === true`, the actual `psk` string is included
  * so an authorized admin can see/edit the existing key. The default is to
@@ -63,6 +100,7 @@ export function transformChannel(channel: any, options: TransformChannelOptions 
   const base = {
     id: channel.id,
     name: channel.name,
+    displayName: computeChannelDisplayName(channel, options.presetName),
     role: channel.role,
     roleName: getRoleName(channel.role),
     uplinkEnabled: channel.uplinkEnabled,

--- a/src/types/device.ts
+++ b/src/types/device.ts
@@ -58,6 +58,17 @@ export interface Channel {
   id: number;
   name: string;
   /**
+   * User-facing channel name with the modem-preset / "Primary" fallback
+   * applied by `transformChannel` on the server. For slot 0 with an empty
+   * `name` column this surfaces the firmware-derived label (e.g.
+   * `"MediumFast"`, `"LongFast"`) so per-source views match the unified
+   * picker and the label MQTT gateways publish under. Always present on
+   * server-projected channel rows; clients should prefer this over `name`
+   * for display purposes. Falls back to `"Primary"` if the source's modem
+   * preset hasn't been received yet.
+   */
+  displayName?: string;
+  /**
    * Raw base64 PSK. Only populated by the API for admins or callers with
    * `channel_${id}:write` permission for this channel (MM-SEC-2 / #2951).
    * Read-only consumers should rely on `encryptionStatus` / `pskSet` instead.


### PR DESCRIPTION
## Summary

Follow-up to #3089. The unified channels picker now renders empty-name slot 0 with the firmware-derived label (`MediumFast`, `LongFast`, etc.) drawn from the device's modem preset, but the per-source **Source Channels** tab was still showing the synthetic `"Primary"` fallback. This PR applies the same logic to the per-source channel responses so the two views agree and match what MQTT gateways actually publish on the wire.

## Changes

- **`transformChannel`** (`src/server/utils/channelView.ts`) now emits a new `displayName` field alongside the raw `name`. Computed by a new `computeChannelDisplayName` helper:
  - trimmed `name` if set
  - else for slot 0: the modem preset's pascal-case label when a `presetName` option is passed, otherwise the legacy `"Primary"` fallback
  - else the raw (empty) name
  The raw `name` column is intentionally unchanged so channel-config edits still round-trip to firmware untouched.
- **`/api/sources/:id/channels`** and **`/api/channels?sourceId=...`** now look up the source's persisted modem preset (`lora.preset.<sourceId>` setting, written by `meshtasticManager` on each LoRa config response) and pass the firmware-derived name into `transformChannel`. Cross-source listings without a `sourceId` query param fall back to `"Primary"` as before.
- **`Channel`** type (`src/types/device.ts`) gains optional `displayName`, documented as the field the frontend should prefer.
- **`ChannelsTab.getChannelName`** prefers `displayName` when present so the Source Channels tab matches the unified picker.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx vitest run` — full suite passes (4 new channelView cases for preset-derived display name, empty-slot-0 fallback, non-slot-0 handling, and the whitelist updated to include `displayName`)
- [x] Live in dev container: `/api/sources/<sandbox-id>/channels` returns `{ id: 0, name: "", displayName: "MediumFast", role: 1, roleName: "Primary" }` (preset persisted from `MEDIUM_FAST` = 4)
- [x] `/api/channels?sourceId=<sandbox-id>` returns the same `displayName`
- [x] Frontend Source Channels tab renders **MediumFast** instead of "Primary" after hard refresh
- [x] System tests run on every PR via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)