### PR TITLE
chore(release): bump version to 4.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 _No changes yet._
 
 
+## [4.6.2] - 2026-05-19
+
+# MeshMonitor v4.6.2
+
+Patch release focused on **MQTT ingest completeness** and channel-name UX. MQTT bridges and brokers now ingest the full set of Meshtastic portnums (text, telemetry, position, nodeinfo, traceroute, neighbor info, paxcounter, store-and-forward) with proper per-source attribution and server-side channel decryption — receptions of the same mesh packet on TCP and MQTT now dedup into a single Unified Messages entry with all sources listed. Empty-named slot 0 on a source now displays as the modem preset's firmware label (`MediumFast`, `LongFast`, etc.) instead of the synthetic `"Primary"`, matching what MQTT gateways publish under and collapsing the TCP and MQTT views of the same channel into one picker entry. The Channel Database is now genuinely global (PSKs apply to decryption across all sources), with the dead `sourceId` column dropped and the management UI moved from the per-source Channels tab to Global Settings. A Meshcore repeater-telemetry regression was fixed via `SendStatusReq` + guest-login fallback. The Desktop first-run flow no longer requires a Meshtastic IP.
+
+## Features
+- #3089 feat(mqtt): full source-scoped ingest with channel decryption and unified-view fixes — auto-bootstraps the LongFast PSK into `channel_database`, decrypts encrypted packets server-side, adds TRACEROUTE_APP / NEIGHBORINFO_APP / PAXCOUNTER_APP / STORE_FORWARD_APP handlers, pre-seeds the geo-membership cache with trusted local-mesh nodes and in-bbox positions, fixes telemetry source attribution in `/api/unified/telemetry`, and aligns MQTT message row IDs with the TCP convention so cross-source dedup collapses TCP + MQTT receptions of the same packet into one Unified Messages entry.
+- #3093 feat(channels): apply modem-preset display name to per-source channels view — `transformChannel` now emits a `displayName` field that uses the source's persisted `lora.preset` for empty-name slot 0 (firmware-spec label `MediumFast` / `LongFast` / etc.), falling back to `"Primary"` only when no preset is known. Channels tab + Source Channels view now show the same label MQTT gateways publish under.
+- #3088 feat(desktop): remove Meshtastic IP requirement from first-run setup
+
+## Fixes
+- #3086 fix: clear recovery message on SQLITE_CORRUPT migration failure
+- #3094 fix(meshcore): repeater telemetry via SendStatusReq + guest-login fallback
+
+## Refactors
+- #3091 refactor(channel-db): drop dead sourceId column (migration 063) and move UI to Global Settings — channel_database PSKs were already global (decryption tries every enabled row regardless of source), so the per-row sourceId was misleading dead weight. Drops the column, removes the Channels-tab UI entry point, and surfaces management under Global Settings.
+
+## Dependencies
+- #3069 chore(deps): bump lucide-react from 1.14.0 to 1.16.0
+- #3070 chore(deps): bump protobufjs from 8.2.0 to 8.3.0
+- #3072 chore(deps): bump better-sqlite3 from 12.9.0 to 12.10.0
+- #3071 chore(deps-dev): bump puppeteer from 24.43.0 to 25.0.2
+
+## Docs
+- #3090 docs: refresh CLAUDE.md, README, CHANGELOG for 4.6.1 accuracy
+
+
 ## [4.6.1] - 2026-05-18
 
 # MeshMonitor v4.6.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@
 | Multi-source registry | `src/server/sourceManagerRegistry.ts`, `src/server/meshtasticManager.ts`, `src/server/meshcoreManager.ts` (parallel Meshcore protocol; not a fallback), `src/contexts/SourceContext.tsx` |
 | Auth + permissions | `src/server/auth/`, `src/db/repositories/auth.ts`, `src/db/repositories/permissions.ts` |
 | Database backends | `src/db/drivers/{sqlite,postgres,mysql}.ts`, `src/db/schema/`, `src/db/repositories/` |
-| Migrations | `src/server/migrations/NNN_*.ts` (62+ total), registry in `src/db/migrations.ts` |
+| Migrations | `src/server/migrations/NNN_*.ts` (63+ total), registry in `src/db/migrations.ts` |
 | Backup/restore | `src/server/services/systemBackupService.ts`, `systemRestoreService.ts` |
 | Routes | `src/server/routes/*` |
 | Frontend pages | `src/pages/*` (`Unified*Page` = multi-source aware) |
@@ -39,7 +39,7 @@ MeshMonitor 4.x supports **N concurrent Meshtastic node connections** ("sources"
 
 ### Critical Rules
 - **No global `meshtasticManager` singleton.** Look up per-source instances via `sourceManagerRegistry.getManager(sourceId)`.
-- **Every packet/node/message/telemetry/traceroute/neighbor/channel/embed-profile/ignored-node/distance-delete/time-sync/meshcore row carries a `sourceId`.** Migrations 020–062 are mostly source-scoping work. Repository queries that don't scope by `sourceId` will leak data across sources.
+- **Every packet/node/message/telemetry/traceroute/neighbor/channel/embed-profile/ignored-node/distance-delete/time-sync/meshcore row carries a `sourceId`.** Migrations 020–062 are mostly source-scoping work. Repository queries that don't scope by `sourceId` will leak data across sources. **Exception:** the `channel_database` (server-side decryption PSKs) is intentionally global — `channelDecryptionService` tries every enabled row regardless of source, and migration 063 dropped its dead `sourceId` column. Adding a new per-source data type should still get a `sourceId` column unless you have a concrete cross-source-by-design reason like decryption.
 - **Permissions are per-source.** `permissions.sourceId` was added in migration 022, refined in 033. `requirePermission(resource, action)` middleware honors source scoping.
 - **Frontend uses `SourceContext`** (`src/contexts/SourceContext.tsx`). `useSource()` returns `{ sourceId, sourceName }`; `sourceId` is `null` outside a `SourceProvider` (legacy/single-source views).
 - **`Unified*Page` components are cross-source consumers** (`UnifiedMessagesPage`, `UnifiedTelemetryPage`, `DashboardPage`).
@@ -97,7 +97,7 @@ For per-source permission tests, mock `getUserPermissionSetAsync(userId, sourceI
 ### Migration Registry
 Migrations use a centralized registry in `src/db/migrations.ts`. Each migration has functions for all three backends.
 
-**Current migration count:** 62 (latest: `062_meshcore_messages_fromname`).
+**Current migration count:** 63 (latest: `063_drop_source_id_from_channel_database`).
 
 For the full "adding a migration" recipe see [Migration recipe](#migration-recipe) below.
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.6.1",
+  "version": "4.6.2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/blog/2026-05-19-v4.6.2-release.md
+++ b/docs/blog/2026-05-19-v4.6.2-release.md
@@ -1,0 +1,49 @@
+---
+id: news-2026-05-19-v4.6.2-release
+title: MeshMonitor v4.6.2 — MQTT in the Unified views & cleaner channel names
+date: '2026-05-19T20:00:00Z'
+category: release
+priority: important
+minVersion: 4.0.0
+---
+## Heads-up: things you'll notice immediately
+
+**v4.6.2** ships several user-visible UX changes alongside a much deeper rework of how MQTT-sourced data flows into MeshMonitor. The three things most likely to surprise you on first launch:
+
+### 1. Your channel may have a new name
+
+The "Primary" label MeshMonitor used to show on slot 0 was a synthetic fallback — your device's firmware actually publishes that channel under its **modem-preset name** (`MediumFast`, `LongFast`, `ShortFast`, etc.), and that's the label MQTT gateways relay it under on the public brokers.
+
+After upgrading, MeshMonitor reads each TCP source's persisted LoRa config and renders slot 0 with the preset-derived label. So your **Channels tab and Unified Messages picker** will switch from "Primary" to whatever your modem preset actually is. The underlying channel is unchanged — only the displayed name. The "Primary" star indicator on the channel that's role-assigned as PRIMARY also still appears, since that's a separate concept (channel **role**, not channel **name**).
+
+Side benefit: TCP and MQTT views of the same logical channel now collapse onto **one** picker entry instead of separate "Primary" and "MediumFast" entries.
+
+### 2. Channel Database moved
+
+The **Channel Database** (server-side decryption PSKs for channels not configured on a connected device) is no longer presented per-source. It was already global under the hood — the decryption service tries every enabled key against every encrypted packet regardless of source — and the per-source UI placement was misleading.
+
+You'll now find Channel Database under **Global Settings**. Existing rows are preserved and the dead `sourceId` column is removed in migration `063`.
+
+### 3. MQTT sources now participate in Unified views
+
+MQTT bridges and the embedded MQTT broker used to be wired up but contribute almost nothing to the cross-source views. This release reworks the MQTT ingest pipeline end-to-end. With **Unified Messages** and **Unified Telemetry** you'll now see:
+
+- **Text messages, telemetry, and traceroutes** from MQTT-relayed nodes (subject to your bbox / channel filters) attributed to the correct MQTT source.
+- **Cross-source dedup**: a single mesh packet heard by TCP **and** one or more MQTT sources now shows as **one** entry with a multi-reception array — same packet ID, multiple `sourceId` rows collapsed in the UI.
+- **Server-side channel decryption** for encrypted MQTT traffic: the default LongFast PSK is auto-seeded into the Channel Database the first time an MQTT source starts. Add additional channel PSKs under Global Settings → Channel Database to decrypt other channels.
+
+If you've been relying on the "no MQTT entries in the Unified Messages source-filter dropdown" behavior as a sign your MQTT source was broken, look again — it was a downstream symptom of the row attribution bug fixed here.
+
+## Other fixes in 4.6.2
+
+- **Meshcore repeater telemetry** — repeater nodes now respond via `SendStatusReq` with a guest-login fallback when the primary path fails ([#3094](https://github.com/Yeraze/meshmonitor/pull/3094)).
+- **SQLITE_CORRUPT migration recovery** — the recovery message clears correctly when migrations succeed after a prior corruption ([#3086](https://github.com/Yeraze/meshmonitor/pull/3086)).
+- **Desktop first-run setup** no longer requires a Meshtastic IP — you can start with no source configured and add one through the UI ([#3088](https://github.com/Yeraze/meshmonitor/pull/3088)).
+
+## Action items after upgrade
+
+- **Glance at your Channels tab** so the rename from "Primary" to your preset's label isn't a surprise.
+- **Open Global Settings → Channel Database** to confirm the auto-seeded LongFast row landed. Add any private-channel PSKs you want MeshMonitor to decrypt.
+- **Re-check Unified Messages and Unified Telemetry** — your map and feed should now include MQTT-sourced data for nodes inside your configured bbox.
+
+Full release notes: [CHANGELOG.md](https://github.com/Yeraze/meshmonitor/blob/main/CHANGELOG.md#462---2026-05-19).

--- a/docs/public/news.json
+++ b/docs/public/news.json
@@ -1,7 +1,16 @@
 {
   "version": "1",
-  "lastUpdated": "2026-05-06T18:00:00Z",
+  "lastUpdated": "2026-05-19T20:00:00Z",
   "items": [
+    {
+      "minVersion": "4.0.0",
+      "id": "news-2026-05-19-v4.6.2-release",
+      "title": "MeshMonitor v4.6.2 — MQTT in the Unified views & cleaner channel names",
+      "content": "## Heads-up: things you'll notice immediately\n\n**v4.6.2** ships several user-visible UX changes alongside a much deeper rework of how MQTT-sourced data flows into MeshMonitor.\n\n### 1. Your channel may have a new name\n\nThe \"Primary\" label MeshMonitor used to show on slot 0 was a synthetic fallback — your device's firmware actually publishes that channel under its **modem-preset name** (`MediumFast`, `LongFast`, `ShortFast`, etc.), which is the label MQTT gateways relay it under. After upgrading, your **Channels tab and Unified Messages picker** will switch from \"Primary\" to whatever your modem preset actually is. The underlying channel is unchanged — only the displayed name. Side benefit: TCP and MQTT views of the same logical channel now collapse onto **one** picker entry.\n\n### 2. Channel Database moved\n\nThe **Channel Database** (server-side decryption PSKs for channels not configured on a connected device) is no longer presented per-source. It was already global under the hood and the per-source UI was misleading. You'll now find it under **Global Settings**. Existing rows are preserved; the dead `sourceId` column is removed in migration `063`.\n\n### 3. MQTT sources now participate in Unified views\n\nMQTT bridges and the embedded MQTT broker used to be wired up but contributed almost nothing to the cross-source views. This release reworks the MQTT ingest pipeline end-to-end. With **Unified Messages** and **Unified Telemetry** you'll now see:\n\n- Text messages, telemetry, and traceroutes from MQTT-relayed nodes (subject to your bbox / channel filters) attributed to the correct MQTT source.\n- **Cross-source dedup** — a single mesh packet heard by TCP **and** one or more MQTT sources now shows as one entry with a multi-reception array.\n- **Server-side channel decryption** for encrypted MQTT traffic — the default LongFast PSK is auto-seeded into the Channel Database the first time an MQTT source starts. Add additional channel PSKs under Global Settings → Channel Database to decrypt other channels.\n\n## Other fixes\n\n- **Meshcore repeater telemetry** via `SendStatusReq` with guest-login fallback ([#3094](https://github.com/Yeraze/meshmonitor/pull/3094)).\n- **SQLITE_CORRUPT migration recovery** message clears correctly after success ([#3086](https://github.com/Yeraze/meshmonitor/pull/3086)).\n- **Desktop first-run setup** no longer requires a Meshtastic IP ([#3088](https://github.com/Yeraze/meshmonitor/pull/3088)).\n\n## Action items after upgrade\n\n- Glance at your **Channels tab** so the rename from \"Primary\" to your preset's label isn't a surprise.\n- Open **Global Settings → Channel Database** to confirm the auto-seeded LongFast row landed. Add any private-channel PSKs you want MeshMonitor to decrypt.\n- Re-check **Unified Messages** and **Unified Telemetry** — your feed should now include MQTT-sourced data for nodes inside your configured bbox.\n\nFull release notes: [CHANGELOG.md](https://github.com/Yeraze/meshmonitor/blob/main/CHANGELOG.md#462---2026-05-19).",
+      "date": "2026-05-19T20:00:00Z",
+      "category": "release",
+      "priority": "important"
+    },
     {
       "minVersion": "4.0.0",
       "id": "news-2026-05-06-v4.2.2-release",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.6.1
-appVersion: "4.6.1"
+version: 4.6.2
+appVersion: "4.6.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.6.1",
+      "version": "4.6.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -4760,7 +4760,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5073,7 +5073,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5106,6 +5106,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7503,6 +7504,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -14571,7 +14573,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -15317,14 +15320,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -16807,7 +16802,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Patch release covering #3089 (MQTT ingest rework + Unified-view source attribution + cross-source dedup), #3093 (channel display-name from modem preset), #3091 (Channel Database moved to Global Settings, dead `sourceId` column dropped via migration 063), #3094 (Meshcore repeater telemetry), #3086 (SQLITE_CORRUPT recovery), #3088 (Desktop first-run), plus the usual dependency bumps.

Version bumps across all five canonical files: `package.json`, `package-lock.json` (regenerated), `helm/meshmonitor/Chart.yaml`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`.

## What's in here

- **CHANGELOG.md** — new `[4.6.2] - 2026-05-19` section organized under Features / Fixes / Refactors / Dependencies / Docs. MQTT and channel-rename items called out as the headline changes.
- **CLAUDE.md** — migration count `62+` → `63+`, latest migration name updated. "Every row carries a `sourceId`" rule gains an exception note for `channel_database` (intentionally global since `channelDecryptionService` tries every enabled row regardless of source).
- **docs/blog/2026-05-19-v4.6.2-release.md** — release blog post structured around three "things you'll notice immediately": slot-0 channel rename from "Primary" to modem-preset label, Channel Database moved to Global Settings, MQTT sources now participate in Unified Messages and Unified Telemetry.
- **docs/public/news.json** — same content as the blog post compressed into a single news entry at the top, `lastUpdated` bumped.

## Test plan

- [x] All five version files at `4.6.2`
- [x] Local container reports `version: "4.6.2"` on `/api/health`
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` green (15167 / 0 in last full run)
- [x] JSON validates: `jq '.items[0]' docs/public/news.json`
- [ ] System tests (tagged with `system-test` label below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)