### PR TITLE
fix(docker): skip puppeteer browser download on armv7 build; bump to 4.6.2-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 _No changes yet._
 
 
+## [4.6.2-1] - 2026-05-19
+
+# MeshMonitor v4.6.2-1
+
+Hotfix re-publishing the v4.6.2 multi-arch Docker manifest. The v4.6.2 build pipeline succeeded for `linux/amd64` and `linux/arm64` but failed on `linux/arm/v7` because `puppeteer@25.0.2` (bumped in #3071) attempts to download a Chrome browser binary during npm postinstall and Chrome has no armv7 build. No application-code changes.
+
+## Fixes
+- **Dockerfile.armv7**: set `PUPPETEER_SKIP_DOWNLOAD=true` before `npm install` so the postinstall doesn't try to fetch a non-existent armv7 Chrome binary. Puppeteer is a devDep used only in CI tests; runtime armv7 images don't need it.
+
+
 ## [4.6.2] - 2026-05-19
 
 # MeshMonitor v4.6.2

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -19,7 +19,14 @@ COPY package*.json ./
 # better-sqlite3 will download pre-built binaries for the target platform
 # Use cache mount to speed up repeated builds
 # --legacy-peer-deps needed for vitest peer dependency conflicts
+#
+# PUPPETEER_SKIP_DOWNLOAD=true: puppeteer's npm postinstall downloads a
+# Chrome binary, and Chrome has no armv7 build — without this the
+# install fails at downloadBrowsers and the whole image build aborts.
+# Puppeteer is a devDependency used only by CI tests, so production
+# armv7 images don't need the browser binary at all.
 RUN --mount=type=cache,target=/root/.npm \
+    PUPPETEER_SKIP_DOWNLOAD=true \
     npm install --legacy-peer-deps
 
 # Verify protobufs are present (fail fast if git submodule wasn't initialized)

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.6.2",
+  "version": "4.6.2-1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.6.2",
+  "version": "4.6.2-1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.6.2
-appVersion: "4.6.2"
+version: 4.6.2-1
+appVersion: "4.6.2-1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.2",
+  "version": "4.6.2-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.6.2",
+      "version": "4.6.2-1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.2",
+  "version": "4.6.2-1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Hotfix re-publishing the v4.6.2 multi-arch Docker manifest. The v4.6.2 release pipeline succeeded for `linux/amd64` and `linux/arm64` but failed on `linux/arm/v7` because `puppeteer@25.0.2` (bumped in #3071) attempts to download a Chrome browser binary during npm postinstall and Chrome has no armv7 build — `npm install` aborts before the Dockerfile gets any further.

## Fix

Set `PUPPETEER_SKIP_DOWNLOAD=true` on the armv7 `npm install` step. Puppeteer is a devDependency used only by CI tests; runtime armv7 images don't need the browser binary at all.

Version bumped to **4.6.2-1** across all five canonical files (`package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`) so the multi-arch manifest gets republished cleanly under a fresh tag.

No application-code changes.

## Test plan

- [x] Confirmed exact failure mode against the 4.6.2 armv7 build log (`gh run view 26129557174 --log-failed`)
- [x] All five version files at `4.6.2-1`
- [ ] CI multi-arch build (this PR will verify armv7 is now green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)