### PR TITLE
fix(install): skip puppeteer chrome download via .npmrc (#3097)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,18 @@
 @jsr:registry=https://npm.jsr.io
+
+# Skip puppeteer's Chrome download during `npm install`.
+#
+# Puppeteer is a devDependency used only by two ad-hoc screenshot helpers
+# (scripts/capture-doc-screenshots.js, scripts/capture-theme-screenshots.js).
+# Runtime, the Docker production image, and CI system tests never need the
+# browser binary — system-tests.yml already sets PUPPETEER_SKIP_DOWNLOAD=true.
+#
+# Skipping the download here makes `npm install` succeed on:
+#   - Linux LXC containers without `unzip`/`tar` in PATH (issue #3097)
+#   - armv7 hosts where Chrome has no build (issue #3096)
+#   - air-gapped / restricted-egress environments
+#
+# To regenerate documentation screenshots locally, run:
+#   npx puppeteer browsers install chrome
+# or override per-invocation: PUPPETEER_SKIP_DOWNLOAD=false npm install
+puppeteer_skip_download=true


### PR DESCRIPTION
## Summary
- Pin `puppeteer_skip_download=true` in the project-root `.npmrc` so every `npm install` skips the Chrome download — Docker (all arches), LXC, baremetal, desktop, and dev.
- Fixes install failure on Linux LXC containers reported in #3097: Puppeteer's postinstall aborts when `unzip`/`tar` aren't in PATH (`Required native binary ('tar.exe' or 'unzip') was not found`).
- Generalizes the per-Dockerfile workaround from #3096 to all install paths.

## Why this is safe
- Puppeteer is a `devDependency` used only by two ad-hoc screenshot helpers (`scripts/capture-doc-screenshots.js`, `scripts/capture-theme-screenshots.js`).
- Runtime never imports puppeteer.
- The Docker production stage doesn't copy `~/.cache/puppeteer` out of the builder — Chrome was downloaded and discarded.
- CI's `system-tests.yml` already sets `PUPPETEER_SKIP_DOWNLOAD=true`.
- Users who want to regenerate screenshots can run `npx puppeteer browsers install chrome` or override with `PUPPETEER_SKIP_DOWNLOAD=false npm install`.

## Test plan
- [ ] CI green
- [ ] `npm install` on a fresh checkout completes without invoking the Chrome downloader (no `Resolving dependencies ... downloading Chrome` line)
- [ ] Docker build (`docker compose -f docker-compose.dev.yml -f docker-compose.dev.local.yml build`) succeeds with the new `.npmrc` copied in
- [ ] Container starts and serves the UI as expected

Closes #3097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)