### PR TITLE
feat(mqtt-broker): optional zero-hop injection (#3084)

### DIFF
--- a/docs/features/mqtt-broker.md
+++ b/docs/features/mqtt-broker.md
@@ -53,6 +53,7 @@ In **Dashboard → Sources → Add Source**, pick **Embedded MQTT Broker (device
 | Listener port | Default `1883` ([IANA-registered MQTT port](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=mqtt)) |
 | Username / Password | Shared credential for all clients |
 | Root topic | Default `msh` — must match what your devices publish under |
+| Zero-hop injection | Off by default. When on, the broker clamps `hop_limit` to `0` on every Meshtastic packet it delivers to a connected device — matching the behavior of [Meshtastic's public broker](https://meshtastic.org/docs/software/integrations/mqtt/). See [Zero-hop injection](#zero-hop-injection) below for when to use it. |
 
 Save. MeshMonitor will start the broker; you'll see `MQTT broker listening on 0.0.0.0:1883` in the container logs and a new source card in the sidebar.
 
@@ -106,6 +107,28 @@ Then on the Meshtastic source in MeshMonitor (**Dashboard → Sources → Edit �
 
 If `proxy_to_client_enabled` is on but no `mqttLink` is set, a yellow warning banner appears on the Device → MQTT page — without it, proxy traffic from the firmware would be silently dropped.
 
+## Zero-hop injection
+
+::: tip Added in 4.6.3
+The **Zero-hop injection** toggle on the broker source ships in 4.6.3 ([issue #3084](https://github.com/Yeraze/meshmonitor/issues/3084)).
+:::
+
+Meshtastic's public broker at `mqtt.meshtastic.org` overwrites the `hop_limit` field on every packet it re-publishes to its MQTT clients, setting it to `0`. Devices that receive a packet via MQTT therefore see "no hops remaining" and skip the RF re-broadcast — the firmware enforces a max of 7 hops (10 on older firmware), so without this clamp an MQTT-bridged packet can flood several RF rings before dying out.
+
+If you run a private broker and bridge it to public upstreams, you may want the same behavior. **Zero-hop injection** is an opt-in toggle on the `mqtt_broker` source that does exactly this:
+
+- **Disabled (default)** — packets are forwarded byte-for-byte. Use this for fully private setups where you actually want MQTT-bridged packets to take additional RF hops (small isolated mesh, deliberate fan-out).
+- **Enabled** — the broker decodes each Meshtastic `ServiceEnvelope` it delivers to a connected client, clamps `hop_limit` to `0`, and re-encodes. `hop_start` is preserved so receivers can still compute "how far has this travelled". Mirrors Meshtastic's public broker so private deployments behave the same way.
+
+Implementation notes:
+
+- The clamp only applies to packets the broker **delivers to its MQTT subscribers** (devices, sidecars, anything that connected to your `mqtt_broker` listener). The original `hop_limit` is preserved in:
+  - The MeshMonitor database (so hop diagnostics stay accurate)
+  - The payload re-published upstream via any attached `mqtt_bridge` (so the next broker in the chain sees the original value)
+- Topics outside the broker's `rootTopic` (e.g. non-Meshtastic publishes), non-decodable payloads, and packets that already have `hop_limit == 0` are passed through unchanged.
+
+If you're seeing your private broker flood the mesh after attaching a bridge to a public upstream, this toggle is almost certainly what you want.
+
 ## Comparison: embedded broker vs MQTT proxy sidecar vs node's built-in MQTT
 
 | Concern | Node's built-in MQTT | MQTT Proxy Sidecar ([LN4CY](https://github.com/LN4CY/mqtt-proxy)) | **Embedded MQTT Broker** (this feature) |
@@ -120,6 +143,7 @@ If `proxy_to_client_enabled` is on but no `mqttLink` is set, a yellow warning ba
 | **Recovery on broker outage** | Manual node restart | Manual sidecar restart | mqtt.js auto-reconnect with backoff |
 | **Default-deny auth** | Per-device | Per-device | Broker refuses connections without configured username/password |
 | **TLS** | Yes (on device) | Yes (on device + proxy) | **Plain TCP only in v1** (TLS / WSS deferred — track in [#3003](https://github.com/Yeraze/meshmonitor/issues/3003)) |
+| **Zero-hop injection** | n/a (no broker) | n/a (passthrough relay) | **Optional per broker** — clamp `hop_limit` to 0 on delivery to match public-broker behavior ([details](#zero-hop-injection)) |
 | **Operational visibility** | Limited firmware logs | Docker logs | Per-source `packetsIn / packetsIngested / packetsDropped / lastError` in `/api/sources/:id/status` |
 
 ### Plain-English summary

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -131,6 +131,7 @@ function DashboardInner() {
   const [formMqttUsername, setFormMqttUsername] = useState('');
   const [formMqttPassword, setFormMqttPassword] = useState('');
   const [formMqttRootTopic, setFormMqttRootTopic] = useState('msh');
+  const [formMqttZeroHopInjection, setFormMqttZeroHopInjection] = useState(false);
   // MQTT bridge (mqtt_bridge) form state.
   const [formMqttBridgeBrokerId, setFormMqttBridgeBrokerId] = useState('');
   const [formMqttBridgeUrl, setFormMqttBridgeUrl] = useState('');
@@ -274,6 +275,7 @@ function DashboardInner() {
     setFormMqttUsername('');
     setFormMqttPassword('');
     setFormMqttRootTopic('msh');
+    setFormMqttZeroHopInjection(false);
     setFormMqttBridgeBrokerId('');
     setFormMqttBridgeUrl('');
     setFormMqttBridgeUsername('');
@@ -302,6 +304,7 @@ function DashboardInner() {
       // backend round-trips the existing value when the field stays empty.
       setFormMqttPassword('');
       setFormMqttRootTopic(cfg?.rootTopic ?? 'msh');
+      setFormMqttZeroHopInjection(Boolean(cfg?.zeroHopInjection));
       setFormError('');
       setShowSourceModal(true);
       return;
@@ -386,6 +389,7 @@ function DashboardInner() {
         auth: { username: formMqttUsername.trim(), password: formMqttPassword },
         gateway: { nodeNum, nodeId, longName: formName.trim(), shortName },
         rootTopic: formMqttRootTopic.trim() || 'msh',
+        zeroHopInjection: formMqttZeroHopInjection,
       };
       if (editingSourceId && !formMqttPassword) {
         // Empty password on edit → tell server to keep the existing one.
@@ -925,6 +929,25 @@ function DashboardInner() {
                     onChange={(e) => setFormMqttRootTopic(e.target.value)}
                     placeholder="msh"
                   />
+                </label>
+                <label className="dashboard-form-field" style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 8 }}>
+                  <input
+                    type="checkbox"
+                    checked={formMqttZeroHopInjection}
+                    onChange={(e) => setFormMqttZeroHopInjection(e.target.checked)}
+                    style={{ marginTop: 3 }}
+                  />
+                  <span>
+                    <span className="dashboard-form-label" style={{ display: 'block' }}>
+                      {t('source.form.mqtt_zero_hop_injection', 'Zero-hop injection')}
+                    </span>
+                    <span style={{ fontSize: 11, color: 'var(--ctp-subtext0)' }}>
+                      {t(
+                        'source.form.mqtt_zero_hop_injection_help',
+                        'Clamp hop_limit to 0 on packets the broker delivers to connected devices, matching the public Meshtastic broker. Prevents MQTT-bridged packets from being rebroadcast over RF.',
+                      )}
+                    </span>
+                  </span>
                 </label>
               </>
             ) : formType === 'mqtt_bridge' ? (

--- a/src/server/mqttBrokerManager.test.ts
+++ b/src/server/mqttBrokerManager.test.ts
@@ -198,3 +198,170 @@ describe('MqttBrokerManager', () => {
     expect(status.packetsIngested).toBe(0);
   });
 });
+
+describe('MqttBrokerManager zero-hop injection', () => {
+  let port: number;
+  let manager: MqttBrokerManager | null = null;
+  let publisher: MqttClient | null = null;
+  let subscriber: MqttClient | null = null;
+
+  beforeAll(async () => {
+    await loadProtobufDefinitions();
+  });
+
+  afterEach(async () => {
+    for (const c of [publisher, subscriber]) {
+      if (c) await new Promise<void>((r) => c.end(true, {}, () => r()));
+    }
+    publisher = null;
+    subscriber = null;
+    if (manager) {
+      await manager.stop();
+      manager = null;
+    }
+  });
+
+  async function startManager(opts: { zeroHop: boolean }): Promise<void> {
+    port = await ephemeralPort();
+    manager = new MqttBrokerManager('zhi-broker', 'Zero Hop Broker', {
+      listener: { port, host: '127.0.0.1' },
+      auth: { username: 'mm', password: 's3cret' },
+      gateway: { nodeNum: 0xdeadbeef, nodeId: '!deadbeef', longName: 'MM', shortName: 'MM' },
+      rootTopic: 'msh',
+      zeroHopInjection: opts.zeroHop,
+    });
+    await manager.start();
+  }
+
+  function buildEnvelopeWithHopLimit(hopLimit: number): Buffer {
+    const bytes = meshtasticProtobufService.encodeServiceEnvelope({
+      packet: {
+        from: 0x12345678,
+        to: 0xffffffff,
+        channel: 0,
+        id: 0xabcdef01,
+        hopLimit,
+        hopStart: hopLimit,
+        decoded: { portnum: PortNum.TEXT_MESSAGE_APP, payload: new Uint8Array([0x68, 0x69]) },
+      },
+      channelId: 'LongFast',
+      gatewayId: '!12345678',
+    });
+    if (!bytes) throw new Error('encode failed');
+    return Buffer.from(bytes);
+  }
+
+  async function connectClient(clientId: string): Promise<MqttClient> {
+    const c = connect(`mqtt://127.0.0.1:${port}`, {
+      username: 'mm',
+      password: 's3cret',
+      reconnectPeriod: 0,
+      clientId,
+    });
+    await waitForEvent(c, 'connect');
+    return c;
+  }
+
+  it('clamps hop_limit to 0 on the payload delivered to subscribers when enabled', async () => {
+    await startManager({ zeroHop: true });
+
+    subscriber = await connectClient('sub');
+    await new Promise<void>((resolve, reject) => {
+      subscriber!.subscribe('msh/#', { qos: 0 }, (err) => (err ? reject(err) : resolve()));
+    });
+
+    publisher = await connectClient('pub');
+    const original = buildEnvelopeWithHopLimit(3);
+
+    const receivedPromise = new Promise<Buffer>((resolve) => {
+      subscriber!.once('message', (_topic, payload) => resolve(payload));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      publisher!.publish('msh/US/2/e/LongFast/!12345678', original, { qos: 0 }, (err) =>
+        err ? reject(err) : resolve(),
+      );
+    });
+
+    const received = await receivedPromise;
+    const decoded = meshtasticProtobufService.decodeServiceEnvelope(received);
+    expect(decoded).not.toBeNull();
+    // proto3 omits zero values on encode, so the decoded field is either 0 or undefined.
+    expect(decoded!.packet.hopLimit ?? 0).toBe(0);
+    // hop_start should be preserved for downstream diagnostics.
+    expect(decoded!.packet.hopStart).toBe(3);
+  });
+
+  it('forwards the payload byte-for-byte when zeroHopInjection is disabled', async () => {
+    await startManager({ zeroHop: false });
+
+    subscriber = await connectClient('sub');
+    await new Promise<void>((resolve, reject) => {
+      subscriber!.subscribe('msh/#', { qos: 0 }, (err) => (err ? reject(err) : resolve()));
+    });
+
+    publisher = await connectClient('pub');
+    const original = buildEnvelopeWithHopLimit(3);
+
+    const receivedPromise = new Promise<Buffer>((resolve) => {
+      subscriber!.once('message', (_topic, payload) => resolve(payload));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      publisher!.publish('msh/US/2/e/LongFast/!12345678', original, { qos: 0 }, (err) =>
+        err ? reject(err) : resolve(),
+      );
+    });
+
+    const received = await receivedPromise;
+    expect(received.equals(original)).toBe(true);
+  });
+
+  it('local-packet event carries the original (un-zeroed) payload', async () => {
+    await startManager({ zeroHop: true });
+
+    publisher = await connectClient('pub');
+    const original = buildEnvelopeWithHopLimit(5);
+
+    const localPacketPromise = new Promise<Buffer>((resolve) => {
+      manager!.once('local-packet', (p: { payload: Buffer }) => resolve(p.payload));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      publisher!.publish('msh/US/2/e/LongFast/!12345678', original, { qos: 0 }, (err) =>
+        err ? reject(err) : resolve(),
+      );
+    });
+
+    const captured = await localPacketPromise;
+    const decoded = meshtasticProtobufService.decodeServiceEnvelope(captured);
+    expect(decoded).not.toBeNull();
+    expect(decoded!.packet.hopLimit).toBe(5);
+    expect(decoded!.packet.hopStart).toBe(5);
+  });
+
+  it('passes garbage payloads through unchanged when enabled', async () => {
+    await startManager({ zeroHop: true });
+
+    subscriber = await connectClient('sub');
+    await new Promise<void>((resolve, reject) => {
+      subscriber!.subscribe('msh/garbage/#', { qos: 0 }, (err) => (err ? reject(err) : resolve()));
+    });
+
+    publisher = await connectClient('pub');
+    const garbage = Buffer.from([0xff, 0xfe, 0xfd, 0xfc, 0xfb]);
+
+    const receivedPromise = new Promise<Buffer>((resolve) => {
+      subscriber!.once('message', (_topic, payload) => resolve(payload));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      publisher!.publish('msh/garbage/topic', garbage, { qos: 0 }, (err) =>
+        err ? reject(err) : resolve(),
+      );
+    });
+
+    const received = await receivedPromise;
+    expect(received.equals(garbage)).toBe(true);
+  });
+});

--- a/src/server/mqttBrokerManager.ts
+++ b/src/server/mqttBrokerManager.ts
@@ -29,6 +29,17 @@ export interface MqttBrokerSourceConfig {
     shortName: string;
   };
   rootTopic?: string;
+  /**
+   * When true, clamp `hop_limit` to 0 on Meshtastic ServiceEnvelopes the
+   * broker forwards back to its connected MQTT clients (issue #3084).
+   * Mirrors how Meshtastic's public broker behaves — devices receiving an
+   * MQTT-bridged packet won't re-flood it over RF. The transform runs on
+   * delivery to each subscriber; the original payload still drives our
+   * ingestion and uplink-bridge paths, so persisted hop diagnostics and
+   * upstream re-publishes stay accurate. Defaults to false to preserve
+   * the existing pass-through behavior for private-broker setups.
+   */
+  zeroHopInjection?: boolean;
 }
 
 export interface MqttBrokerStatus extends SourceStatus {
@@ -76,11 +87,15 @@ export class MqttBrokerManager extends EventEmitter implements ISourceManager {
   async start(): Promise<void> {
     if (this.broker) return;
     await bootstrapMqttChannelDatabase(this.sourceId);
+    const rootTopicPrefix = (this.config.rootTopic ?? 'msh') + '/';
     this.broker = new MqttBroker({
       port: this.config.listener.port,
       host: this.config.listener.host,
       auth: this.config.auth,
       brokerId: `meshmonitor-${this.sourceId}`,
+      forwardTransform: this.config.zeroHopInjection
+        ? (topic, payload) => this.applyZeroHop(rootTopicPrefix, topic, payload)
+        : undefined,
     });
 
     this.broker.on('publish', (msg) => this.handlePublish(msg));
@@ -133,6 +148,29 @@ export class MqttBrokerManager extends EventEmitter implements ISourceManager {
   async publish(topic: string, payload: Buffer, retained = false): Promise<void> {
     if (!this.broker) throw new Error('Broker not started');
     await this.broker.publish(topic, payload, retained);
+  }
+
+  /**
+   * Zero-hop forward transform. Returns a rewritten payload with
+   * `hop_limit = 0` for Meshtastic ServiceEnvelopes on this broker's
+   * root topic, or null to pass the original through. Anything that
+   * isn't a decodable ServiceEnvelope (off-topic, MQTT control, malformed
+   * payload, packet already at zero) falls through unchanged.
+   */
+  private applyZeroHop(rootTopicPrefix: string, topic: string, payload: Buffer): Buffer | null {
+    if (!topic.startsWith(rootTopicPrefix)) return null;
+    const decoded = meshtasticProtobufService.decodeServiceEnvelope(payload, { quiet: true });
+    if (!decoded || !decoded.packet) return null;
+    const packet = decoded.packet as { hopLimit?: number };
+    if (packet.hopLimit === undefined || packet.hopLimit === 0) return null;
+    packet.hopLimit = 0;
+    const reencoded = meshtasticProtobufService.encodeServiceEnvelope({
+      packet: decoded.packet,
+      channelId: decoded.channelId,
+      gatewayId: decoded.gatewayId,
+    });
+    if (!reencoded) return null;
+    return Buffer.from(reencoded);
   }
 
   private handlePublish(msg: MqttBrokerPublish): void {

--- a/src/server/mqttBrokerManager.ts
+++ b/src/server/mqttBrokerManager.ts
@@ -161,7 +161,7 @@ export class MqttBrokerManager extends EventEmitter implements ISourceManager {
     if (!topic.startsWith(rootTopicPrefix)) return null;
     const decoded = meshtasticProtobufService.decodeServiceEnvelope(payload, { quiet: true });
     if (!decoded || !decoded.packet) return null;
-    const packet = decoded.packet as { hopLimit?: number };
+    const packet = decoded.packet as { hopLimit?: number; hopStart?: number };
     if (packet.hopLimit === undefined || packet.hopLimit === 0) return null;
     packet.hopLimit = 0;
     const reencoded = meshtasticProtobufService.encodeServiceEnvelope({

--- a/src/server/transports/mqttBroker.ts
+++ b/src/server/transports/mqttBroker.ts
@@ -19,6 +19,16 @@ export interface MqttBrokerOptions {
   host?: string;
   auth: { username: string; password: string };
   brokerId?: string;
+  /**
+   * Optional per-subscriber payload transform. Called once per delivery via
+   * Aedes' `authorizeForward` hook — returning a Buffer rewrites the payload
+   * the subscriber sees; returning null delivers the original. The
+   * `publish` event fires with the unmodified payload, so ingestion and
+   * uplink-bridge consumers are unaffected. Used by the broker manager to
+   * implement zero-hop injection without touching the wire envelope on
+   * paths the operator hasn't opted in to mutate.
+   */
+  forwardTransform?: (topic: string, payload: Buffer) => Buffer | null;
 }
 
 export interface MqttBrokerPublish {
@@ -71,6 +81,22 @@ export class MqttBroker extends EventEmitter {
     this.aedes = await Aedes.createBroker({
       id: this.options.brokerId ?? 'meshmonitor-broker',
     });
+
+    if (this.options.forwardTransform) {
+      const transform = this.options.forwardTransform;
+      this.aedes.authorizeForward = (_client, packet) => {
+        if (packet.topic.startsWith('$SYS/')) return packet;
+        try {
+          const out = transform(packet.topic, toBuffer(packet.payload));
+          if (!out) return packet;
+          return { ...packet, payload: out };
+        } catch (err) {
+          const m = err instanceof Error ? err.message : String(err);
+          logger.warn(`MQTT broker forwardTransform error on ${packet.topic}: ${m}`);
+          return packet;
+        }
+      };
+    }
 
     this.aedes.authenticate = (_client, username, password, done) => {
       const u = typeof username === 'string' ? username : '';

--- a/src/server/transports/mqttBroker.ts
+++ b/src/server/transports/mqttBroker.ts
@@ -92,7 +92,8 @@ export class MqttBroker extends EventEmitter {
           return { ...packet, payload: out };
         } catch (err) {
           const m = err instanceof Error ? err.message : String(err);
-          logger.warn(`MQTT broker forwardTransform error on ${packet.topic}: ${m}`);
+          const brokerId = this.options.brokerId ?? 'meshmonitor-broker';
+          logger.warn(`MQTT broker [${brokerId}] forwardTransform error on ${packet.topic}: ${m}`);
           return packet;
         }
       };


### PR DESCRIPTION
## Summary

Adds an opt-in **Zero-hop injection** toggle on `mqtt_broker` source settings that clamps `hop_limit` to `0` on Meshtastic packets the embedded broker delivers to connected MQTT clients, matching Meshtastic's public broker behavior. Without this, packets arriving from an upstream public broker via an attached `mqtt_bridge` can be rebroadcast over RF for up to 7 hops, flooding the mesh — exactly the failure mode the public broker zeroes hop_limit to prevent.

Implementation uses Aedes' `authorizeForward` hook so only the on-the-wire delivery to subscribers is mutated. The `publish` event still fires with the original bytes, so DB ingestion preserves accurate hop diagnostics and any uplink-bridge republish to upstream brokers carries the unmodified `hop_limit` field.

Off by default to preserve current pass-through behavior for fully private deployments.

## Changes

- `src/server/transports/mqttBroker.ts` — new `forwardTransform?: (topic, payload) => Buffer | null` option wired through `aedes.authorizeForward`.
- `src/server/mqttBrokerManager.ts` — new `zeroHopInjection?: boolean` config field; manager installs an `applyZeroHop` transform that decodes the ServiceEnvelope, sets `hopLimit = 0`, and re-encodes. Skips non-`rootTopic` traffic, non-decodable payloads, and packets already at zero. `hop_start` is preserved.
- `src/pages/DashboardPage.tsx` — `formMqttZeroHopInjection` form state with a labelled checkbox below the broker source's Root topic field. Loaded on edit, reset on add, persisted to `cfg.zeroHopInjection` on save.
- `src/server/mqttBrokerManager.test.ts` — four new tests in a `MqttBrokerManager zero-hop injection` describe: zeroed on delivery when enabled, byte-identical when disabled, `local-packet` event preserves original `hop_limit`, garbage payloads pass through.
- `docs/features/mqtt-broker.md` — new `## Zero-hop injection` section, broker-fields-table row, and comparison-table row.

## Issues Resolved

Fixes #3084

## Documentation Updates

- `docs/features/mqtt-broker.md` — added Zero-hop injection row to the broker-source Quick Setup field table, a dedicated `## Zero-hop injection` section (rationale + scope + implementation notes), and a Zero-hop injection row in the embedded-broker vs proxy-sidecar vs node-built-in comparison table.

## Testing

- [x] Full Vitest suite passes (15,180 tests, 0 failures)
- [x] `tsc --noEmit` clean
- [x] Targeted MQTT suite: 34/34 pass (`mqttBrokerManager`, `mqttBridgeManager`, transports)
- [ ] Manual verification:
  - Create an `mqtt_broker` source with `zeroHopInjection: false`, confirm subscribers receive unchanged hop_limit.
  - Toggle it on, confirm subscribers receive `hop_limit = 0` but `hop_start` is preserved.
  - Confirm DB ingestion and uplink-bridge re-publish (with a paired `mqtt_bridge`) carry the original hop_limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)