### PR TITLE
fix(unified): preserve tapback metadata across MQTT ingest + cross-source merge

### DIFF
--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -209,6 +209,89 @@ describe('ingestServiceEnvelope — fail-closed membership', () => {
   });
 });
 
+describe('ingestServiceEnvelope — TEXT_MESSAGE_APP tapbacks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves emoji and replyId from the decoded Data protobuf', async () => {
+    // Regression: prior to the fix, the TEXT_MESSAGE_APP branch built a
+    // DbMessage that dropped emoji/replyId, so MQTT-sourced reactions
+    // failed `isReactionMessage` in the unified view and rendered as
+    // full inline messages instead of grouping under the parent packet.
+    const envelope: ServiceEnvelopeShape = {
+      channelId: 'LongFast',
+      gatewayId: '!00000001',
+      packet: {
+        id: 0xdeadbeef,
+        from: NODE_IN,
+        to: 0xffffffff,
+        channel: 0,
+        decoded: {
+          portnum: 1 /* TEXT_MESSAGE_APP */,
+          payload: new Uint8Array([0]),
+          emoji: 1,
+          replyId: 12345,
+        } as any,
+      },
+    };
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope,
+    });
+
+    expect(result.ingested).toBe(true);
+    expect(databaseService.messages.insertMessage).toHaveBeenCalledTimes(1);
+    const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
+    expect(inserted.emoji).toBe(1);
+    expect(inserted.replyId).toBe(12345);
+  });
+
+  it('accepts snake_case reply_id from a gateway that did not camelCase the field', async () => {
+    // Some MQTT bridges publish the raw protobuf field name `reply_id`
+    // rather than the protobufjs camelCase `replyId`. Accept both.
+    const envelope: ServiceEnvelopeShape = {
+      channelId: 'LongFast',
+      gatewayId: '!00000001',
+      packet: {
+        id: 0xdeadbeef,
+        from: NODE_IN,
+        to: 0xffffffff,
+        channel: 0,
+        decoded: {
+          portnum: 1 /* TEXT_MESSAGE_APP */,
+          payload: new Uint8Array([0]),
+          emoji: 1,
+          reply_id: 99,
+        } as any,
+      },
+    };
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope,
+    });
+
+    expect(result.ingested).toBe(true);
+    const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
+    expect(inserted.replyId).toBe(99);
+  });
+
+  it('omits emoji/replyId when the decoded packet has neither', async () => {
+    // Regular text messages must not be marked as reactions.
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 1 /* TEXT_MESSAGE_APP */),
+    });
+
+    expect(result.ingested).toBe(true);
+    const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
+    expect(inserted.emoji).toBeUndefined();
+    expect(inserted.replyId).toBeUndefined();
+  });
+});
+
 describe('ingestServiceEnvelope — TRACEROUTE_APP', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -123,9 +123,16 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         typeof packet.channel === 'number' ? packet.channel : undefined,
       );
       if (r.success) {
-        (packet as { decoded?: { portnum?: number; payload?: Uint8Array } }).decoded = {
+        // Carry tapback metadata (emoji, replyId) onto the synthesized
+        // decoded shape so TEXT_MESSAGE_APP ingest can preserve it —
+        // reactions otherwise lose their grouping in the unified view.
+        (packet as {
+          decoded?: { portnum?: number; payload?: Uint8Array; emoji?: number; replyId?: number };
+        }).decoded = {
           portnum: r.portnum,
           payload: r.payload,
+          emoji: r.emoji,
+          replyId: r.replyId,
         };
       }
     } catch (err) {
@@ -222,6 +229,25 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
       const text = typeof payload === 'string' ? payload : '';
       if (!text) return { ingested: false, reason: 'decode-error', portnum };
       const packetId = typeof packet.id === 'number' ? packet.id >>> 0 : 0;
+      // Tapback metadata. `emoji=1` flags reactions; `reply_id` points at
+      // the parent packet id. Both live as siblings of `payload` on the
+      // decoded Data protobuf. When the bridge published an already-decoded
+      // packet they're on `packet.decoded`; when we server-decrypted via
+      // channel_database, channelDecryptionService now surfaces them on
+      // the synthesized `decoded` object (see `DecryptionResult`).
+      // Without these fields the unified view's `isReactionMessage` test
+      // fails for MQTT-sourced reactions and they render as full inline
+      // messages instead of grouping under the parent — see
+      // https://github.com/Yeraze/meshmonitor/issues/3092 follow-up.
+      const decodedAny = decoded as Record<string, unknown>;
+      const rawEmoji =
+        (decodedAny.emoji as number | undefined) ?? undefined;
+      const emoji = typeof rawEmoji === 'number' && rawEmoji > 0 ? rawEmoji : undefined;
+      const rawReplyId =
+        (decodedAny.replyId as number | undefined) ??
+        (decodedAny.reply_id as number | undefined);
+      const replyId =
+        typeof rawReplyId === 'number' && rawReplyId > 0 ? rawReplyId >>> 0 : undefined;
       const msg: DbMessage = {
         // Row ID uses the TCP convention `${sourceId}_${fromNum}_${packetId}`
         // — underscores, fromNum middle, packetId last — so the unified
@@ -243,6 +269,8 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         rxSnr: typeof packet.rxSnr === 'number' ? packet.rxSnr : undefined,
         rxRssi: typeof packet.rxRssi === 'number' ? packet.rxRssi : undefined,
         viaMqtt: true,
+        emoji,
+        replyId,
         createdAt: nowMs,
       } as DbMessage;
       (msg as any).sourceId = sourceId;

--- a/src/server/routes/unifiedRoutes.test.ts
+++ b/src/server/routes/unifiedRoutes.test.ts
@@ -465,6 +465,52 @@ describe('Unified Routes', () => {
       expect(res.body[0].receptions[1].rxSnr).toBe(-8);
     });
 
+    it('upgrades emoji/replyId from a later source when the first-seen row lacks them', async () => {
+      // Same mesh packet heard by two sources. Source A's row arrives first
+      // in merge order but is missing tapback metadata (e.g. server-decrypted
+      // MQTT row before the channelDecryptionService surfaced emoji/replyId).
+      // Source B's row has the correct emoji=1 + replyId. The merged entry
+      // must adopt B's metadata so the unified view classifies it as a
+      // reaction — otherwise it renders as a full inline message.
+      // Regression for the bug where tapbacks flickered between rendering
+      // as reactions and full messages depending on Promise.all race order.
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
+      // Row IDs share the trailing packetId segment so unifiedRoutes'
+      // extractPacketIdFromRowId collapses them onto the same dedupKey.
+      mockDb.messages.getMessages
+        .mockResolvedValueOnce([
+          mkMsg({
+            id: 'src-a_2864434397_99',
+            fromNodeNum: NODE_ONE.nodeNum,
+            text: '👍',
+            timestamp: 3000,
+            rxTime: 3000,
+            emoji: null,
+            replyId: null,
+          }),
+        ])
+        .mockResolvedValueOnce([
+          mkMsg({
+            id: 'src-b_2864434397_99',
+            fromNodeNum: NODE_ONE.nodeNum,
+            text: '👍',
+            timestamp: 3100,
+            rxTime: 3100,
+            emoji: 1,
+            replyId: 12345,
+          }),
+        ]);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/messages?limit=50');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].receptions).toHaveLength(2);
+      expect(res.body[0].emoji).toBe(1);
+      expect(res.body[0].replyId).toBe(12345);
+    });
+
     it('resolves sender display names from the nodes table', async () => {
       mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
       mockDb.messages.getMessages.mockResolvedValue([

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -586,6 +586,20 @@ router.get('/messages', async (req: Request, res: Response) => {
                 existing.fromNodeShortName = sender.shortName;
               }
             }
+            // Upgrade tapback metadata if a later source has it and the
+            // first-seen entry didn't. The per-source `Promise.all` ingest
+            // order is non-deterministic, so a row from a source that lost
+            // emoji/replyId (e.g. a stale insert) could otherwise win the
+            // race and make a tapback render as a full inline message.
+            // Once set, prefer the populated value: any source with the
+            // metadata is correct because the underlying mesh packet is
+            // identical across receivers.
+            if ((existing.emoji == null || existing.emoji === 0) && m.emoji != null && m.emoji > 0) {
+              existing.emoji = m.emoji;
+            }
+            if (existing.replyId == null && m.replyId != null && m.replyId > 0) {
+              existing.replyId = m.replyId;
+            }
           } else {
             const sender = nodeMap.get(fromNum);
             merged.set(dedupKey, {

--- a/src/server/services/channelDecryptionService.ts
+++ b/src/server/services/channelDecryptionService.ts
@@ -21,6 +21,15 @@ export interface DecryptionResult {
   channelName?: string;
   portnum?: number;
   payload?: Uint8Array;
+  /**
+   * Tapback metadata from the decoded `Data` protobuf. `emoji=1` flags
+   * the packet as a reaction; `replyId` points at the parent packet id.
+   * Callers (mqttIngestion) propagate these so the unified view can group
+   * reactions under their parent message — without them, server-decrypted
+   * reactions render as full inline messages.
+   */
+  emoji?: number;
+  replyId?: number;
   error?: string;
 }
 
@@ -243,7 +252,13 @@ class ChannelDecryptionService {
    * 1. Have a reasonable portnum (field 1, varint) within the Meshtastic range (0-511)
    * 2. Not have obviously wrong values
    */
-  private isValidProtobuf(data: Buffer): { valid: boolean; portnum?: number; payload?: Uint8Array } {
+  private isValidProtobuf(data: Buffer): {
+    valid: boolean;
+    portnum?: number;
+    payload?: Uint8Array;
+    emoji?: number;
+    replyId?: number;
+  } {
     try {
       // Get the Data type from loaded protobuf definitions
       const root = getProtobufRoot();
@@ -261,10 +276,20 @@ class ChannelDecryptionService {
         return { valid: false };
       }
 
+      // Tapback metadata — surface so callers (mqttIngestion) can group
+      // reactions under their parent in the unified view.
+      const rawEmoji = decoded.emoji;
+      const emoji = typeof rawEmoji === 'number' && rawEmoji > 0 ? rawEmoji : undefined;
+      const rawReplyId = decoded.replyId ?? decoded.reply_id;
+      const replyId =
+        typeof rawReplyId === 'number' && rawReplyId > 0 ? rawReplyId >>> 0 : undefined;
+
       return {
         valid: true,
         portnum: portnum,
         payload: decoded.payload ? new Uint8Array(decoded.payload) : undefined,
+        emoji,
+        replyId,
       };
     } catch {
       // Parse failure means invalid protobuf
@@ -297,6 +322,8 @@ class ChannelDecryptionService {
       channelName: channel.name,
       portnum: validation.portnum,
       payload: validation.payload,
+      emoji: validation.emoji,
+      replyId: validation.replyId,
     };
   }
 


### PR DESCRIPTION
## Summary

Tapback reactions on the Unified Messages feed flickered between rendering correctly (grouped under the parent as an emoji pill) and rendering as full inline messages, depending on which source's row won a non-deterministic `Promise.all` race in `/api/unified/messages`.

Three interacting causes, all introduced in #3089 (`feat(mqtt): full source-scoped ingest with channel decryption and unified-view fixes`):

1. **MQTT ingest dropped `emoji` / `reply_id`.** `mqttIngestion.ts` TEXT_MESSAGE_APP branch built `DbMessage` rows without reading the decoded Data's `emoji` / `reply_id` fields, so MQTT-sourced reactions hit the DB with both null.
2. **Server-side decryption stripped tapback metadata.** `channelDecryptionService.isValidProtobuf` decoded the full Data protobuf but only returned `{portnum, payload}`, throwing away emoji/replyId.
3. **Unified merge was first-source-wins.** `unifiedRoutes.ts` merge logic only upgraded sender display names — emoji/replyId stayed whatever the first race-winning source had, even when later sources had correct values.

The result: TCP-source row has `emoji=1, replyId=parentPacketId`; MQTT-source row has `emoji=null, replyId=null`. Each poll races; when MQTT wins, the merged record drops the metadata and the reaction renders as a regular inline message.

## Fix

- `mqttIngestion.ts` — read `emoji` and `replyId` (accepting both camelCase and snake_case) from the decoded Data in TEXT_MESSAGE_APP.
- `channelDecryptionService.ts` — extend `DecryptionResult` with `emoji?` / `replyId?` and surface them from `isValidProtobuf`. Propagate onto the synthesized `decoded` object so MQTT ingest sees them after server-decryption.
- `unifiedRoutes.ts` — in the `if (existing)` merge branch, upgrade `emoji`/`replyId` from any source that has them populated when the first-seen row didn't (mirrors the existing sender-name upgrade pattern).

## Tests

- New regression test in `unifiedRoutes.test.ts` proving the merge upgrades tapback metadata across sources.
- Three new MQTT-ingest tests covering `replyId` / camelCase, `reply_id` / snake_case, and the regular-text case where neither field is set.
- Full Vitest suite: 10137 pass / 0 fail.

## Test plan

- [ ] Send a tapback (👍) from a phone connected to the TCP companion; also have MQTT bridge ingest the same packet.
- [ ] Open Unified Messages on the affected channel.
- [ ] Confirm the tapback stays grouped under the parent across multiple 10s poll cycles — no flicker, no transition to a full inline message.
- [ ] Send a normal text message; confirm it stays an inline message and is NOT misclassified as a reaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)