### PR TITLE
fix(meshcore): persist contact advType to meshcore_nodes (#3092)

### DIFF
--- a/src/server/meshcoreManager.contactPersistence.test.ts
+++ b/src/server/meshcoreManager.contactPersistence.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for MeshCoreManager contact → meshcore_nodes persistence.
+ *
+ * Regression for issue #3092: before the fix, contact_advertised /
+ * contact_added events only updated the in-memory `this.contacts` map.
+ * The `meshcore_nodes` SQL table was only written by
+ * setNodeTelemetryConfig (publicKey + telemetry flags, advType=null),
+ * so the remote-telemetry scheduler always treated every target as a
+ * Companion and skipped the SendStatusReq + guest-login paths added
+ * in #3094.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const upsertNode = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      upsertNode: (...args: unknown[]) => upsertNode(...args),
+    },
+  },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: {
+    emitMeshCoreContactUpdated: vi.fn(),
+    emitMeshCoreMessage: vi.fn(),
+    emitMeshCoreSelfInfoUpdated: vi.fn(),
+  },
+}));
+
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+interface BridgeEvent {
+  event_type: string;
+  data: Record<string, unknown>;
+}
+
+function dispatchBridgeEvent(m: MeshCoreManager, evt: BridgeEvent): void {
+  // handleBridgeEvent is private; invoking it directly is the cleanest
+  // way to exercise the contact-event path without standing up the
+  // native backend.
+  // @ts-expect-error - exercising private method
+  m.handleBridgeEvent(evt);
+}
+
+describe('MeshCoreManager contact persistence (issue #3092)', () => {
+  const REPEATER_PUBKEY = 'a'.repeat(64);
+
+  beforeEach(() => {
+    upsertNode.mockClear();
+  });
+
+  it('persists advType to meshcore_nodes on contact_advertised', async () => {
+    const manager = new MeshCoreManager('src-a');
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_advertised',
+      data: {
+        public_key: REPEATER_PUBKEY,
+        adv_name: 'MyRepeater',
+        adv_type: MeshCoreDeviceType.REPEATER,
+        latitude: 51.5,
+        longitude: -0.1,
+        last_advert: 1_700_000_000,
+      },
+    });
+
+    // persistContact runs via `void`, so flush the microtask queue.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(upsertNode).toHaveBeenCalledTimes(1);
+    expect(upsertNode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicKey: REPEATER_PUBKEY,
+        name: 'MyRepeater',
+        advType: MeshCoreDeviceType.REPEATER,
+        latitude: 51.5,
+        longitude: -0.1,
+      }),
+      'src-a',
+    );
+  });
+
+  it('persists advType to meshcore_nodes on contact_added', async () => {
+    const manager = new MeshCoreManager('src-a');
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_added',
+      data: {
+        public_key: REPEATER_PUBKEY,
+        adv_name: 'Room1',
+        adv_type: MeshCoreDeviceType.ROOM_SERVER,
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(upsertNode).toHaveBeenCalledTimes(1);
+    expect(upsertNode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicKey: REPEATER_PUBKEY,
+        advType: MeshCoreDeviceType.ROOM_SERVER,
+      }),
+      'src-a',
+    );
+  });
+
+  it('preserves the existing advType when contact_path_updated fires later', async () => {
+    // Path updates carry no advert metadata; the manager must not
+    // overwrite the previously-learned advType with null/undefined.
+    const manager = new MeshCoreManager('src-a');
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_advertised',
+      data: {
+        public_key: REPEATER_PUBKEY,
+        adv_name: 'MyRepeater',
+        adv_type: MeshCoreDeviceType.REPEATER,
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    upsertNode.mockClear();
+
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_path_updated',
+      data: { public_key: REPEATER_PUBKEY },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(upsertNode).toHaveBeenCalledTimes(1);
+    expect(upsertNode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicKey: REPEATER_PUBKEY,
+        advType: MeshCoreDeviceType.REPEATER,
+      }),
+      'src-a',
+    );
+  });
+
+  it('logs but does not throw when the DB upsert fails', async () => {
+    upsertNode.mockRejectedValueOnce(new Error('db kaput'));
+    const manager = new MeshCoreManager('src-a');
+
+    expect(() =>
+      dispatchBridgeEvent(manager, {
+        event_type: 'contact_advertised',
+        data: {
+          public_key: REPEATER_PUBKEY,
+          adv_name: 'MyRepeater',
+          adv_type: MeshCoreDeviceType.REPEATER,
+        },
+      }),
+    ).not.toThrow();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    // In-memory contact still updated even though the persist failed.
+    expect(manager.getContact(REPEATER_PUBKEY)?.advType).toBe(MeshCoreDeviceType.REPEATER);
+  });
+
+  it('exposes the in-memory contact via getContact for route-side backfill', () => {
+    const manager = new MeshCoreManager('src-a');
+    expect(manager.getContact(REPEATER_PUBKEY)).toBeUndefined();
+
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_advertised',
+      data: {
+        public_key: REPEATER_PUBKEY,
+        adv_name: 'MyRepeater',
+        adv_type: MeshCoreDeviceType.REPEATER,
+      },
+    });
+
+    expect(manager.getContact(REPEATER_PUBKEY)).toMatchObject({
+      publicKey: REPEATER_PUBKEY,
+      advName: 'MyRepeater',
+      advType: MeshCoreDeviceType.REPEATER,
+    });
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -610,6 +610,12 @@ class MeshCoreManager extends EventEmitter {
           lastSeen: Date.now(),
         };
         this.contacts.set(publicKey, updated);
+        // Mirror to meshcore_nodes so per-source consumers (telemetry
+        // scheduler, REST queries) see the contact's advType. Without
+        // this, the table only gets stub rows from setNodeTelemetryConfig
+        // and the scheduler can never classify a target as a repeater.
+        // See https://github.com/Yeraze/meshmonitor/issues/3092.
+        void this.persistContact(updated);
         this.emit('contacts_updated', { sourceId: this.sourceId, contact: updated });
         dataEventEmitter.emitMeshCoreContactUpdated(updated, this.sourceId);
         logger.info(`[MeshCore] ${event_type} for ${publicKey} (${data.adv_name ?? ''})`);
@@ -624,12 +630,50 @@ class MeshCoreManager extends EventEmitter {
           lastSeen: Date.now(),
         };
         this.contacts.set(publicKey, updated);
+        void this.persistContact(updated);
         this.emit('contacts_updated', { sourceId: this.sourceId, contact: updated });
         dataEventEmitter.emitMeshCoreContactUpdated(updated, this.sourceId);
         logger.info(`[MeshCore] contact_path_updated for ${publicKey}`);
       }
     } else {
       logger.debug(`[MeshCore] Unknown push event: ${event_type}`);
+    }
+  }
+
+  /**
+   * Mirror an in-memory MeshCoreContact to the `meshcore_nodes` SQL table.
+   *
+   * Without this the table only ever sees stub rows from
+   * `setNodeTelemetryConfig` (publicKey + telemetry flags, advType=null),
+   * so the remote-telemetry scheduler can't tell a Repeater from a
+   * Companion and routes every target through the LPP-only path —
+   * skipping the SendStatusReq + guest-login paths added in #3094. The
+   * mirror keeps the table accurate enough for any per-source consumer
+   * (scheduler, REST endpoints, future cross-source views) to read the
+   * contact's actual device type.
+   *
+   * Failures are logged but never thrown — a transient DB error on a
+   * single advert should not break the contact-event pipeline.
+   */
+  private async persistContact(contact: MeshCoreContact): Promise<void> {
+    try {
+      await databaseService.meshcore.upsertNode(
+        {
+          publicKey: contact.publicKey,
+          name: contact.advName ?? contact.name ?? null,
+          advType: contact.advType ?? null,
+          latitude: contact.latitude ?? null,
+          longitude: contact.longitude ?? null,
+          rssi: contact.rssi ?? null,
+          snr: contact.snr ?? null,
+          lastHeard: contact.lastSeen ?? null,
+        },
+        this.sourceId,
+      );
+    } catch (err) {
+      logger.warn(
+        `[MeshCore:${this.sourceId}] persistContact(${contact.publicKey.substring(0, 16)}…) failed: ${(err as Error).message}`,
+      );
     }
   }
 
@@ -1074,6 +1118,14 @@ class MeshCoreManager extends EventEmitter {
             lastSeen: Date.now(),
           });
         }
+        // Mirror every contact to meshcore_nodes so stale stub rows
+        // (publicKey-only seeds from setNodeTelemetryConfig) get their
+        // advType backfilled on the next refresh. This is what backfills
+        // existing deployments without requiring the user to retoggle
+        // telemetry-retrieval — see issue #3092.
+        await Promise.all(
+          Array.from(this.contacts.values()).map((c) => this.persistContact(c)),
+        );
         logger.info(`[MeshCore] Refreshed ${this.contacts.size} contacts`);
       }
     } catch (error) {
@@ -1682,6 +1734,16 @@ class MeshCoreManager extends EventEmitter {
 
   getContacts(): MeshCoreContact[] {
     return Array.from(this.contacts.values());
+  }
+
+  /**
+   * Look up a single in-memory contact by full public key. Returns
+   * `undefined` if the contact hasn't been seen yet on this connection.
+   * Used by routes that need the contact's advType/advName at config
+   * time (e.g. telemetry-config seed) so they can backfill the SQL row.
+   */
+  getContact(publicKey: string): MeshCoreContact | undefined {
+    return this.contacts.get(publicKey);
   }
 
   getAllNodes(): MeshCoreNode[] {

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -41,6 +41,7 @@ const meshcoreManager = {
   getLocalNode: vi.fn().mockReturnValue(null),
   getAllNodes: vi.fn().mockReturnValue([]),
   getContacts: vi.fn().mockReturnValue([]),
+  getContact: vi.fn().mockReturnValue(undefined),
   getRecentMessages: vi.fn().mockReturnValue([]),
   connect: vi.fn().mockResolvedValue(true),
   disconnect: vi.fn().mockResolvedValue(undefined),
@@ -575,6 +576,92 @@ describe('MeshCore Routes', () => {
       expect(response.status).toBe(200);
       expect(response.body.data.identity).toBeNull();
       expect(response.body.data.telemetryRef).toBeNull();
+    });
+  });
+
+  describe('PATCH /api/sources/test-source/meshcore/nodes/:publicKey/telemetry-config', () => {
+    const REPEATER_PUBKEY = 'f'.repeat(64);
+    const upsertNode = vi.fn().mockResolvedValue(undefined);
+    const setNodeTelemetryConfig = vi.fn().mockResolvedValue(undefined);
+    const getNodeByPublicKeyAndSource = vi.fn().mockResolvedValue({
+      publicKey: REPEATER_PUBKEY,
+      telemetryEnabled: true,
+      telemetryIntervalMinutes: 60,
+      lastTelemetryRequestAt: null,
+    });
+
+    beforeEach(() => {
+      // Inject the meshcore repo facade onto the mocked DatabaseService.
+      // Done in beforeEach so the function refs survive the global
+      // `vi.clearAllMocks()` (which clears call history but not impls).
+      (DatabaseService as any).meshcore = {
+        upsertNode,
+        setNodeTelemetryConfig,
+        getNodeByPublicKeyAndSource,
+      };
+      upsertNode.mockClear();
+      setNodeTelemetryConfig.mockClear();
+      getNodeByPublicKeyAndSource.mockClear();
+      meshcoreManager.getContact.mockReset();
+    });
+
+    it('backfills advType + advName from the in-memory contact before seeding the telemetry-config row', async () => {
+      // Regression for issue #3092: the route used to call only
+      // setNodeTelemetryConfig, which inserts a stub row with advType=null.
+      // The remote-telemetry scheduler then treated every target as a
+      // Companion (`isRepeaterLike=false`) and skipped the SendStatusReq +
+      // guest-login paths added in #3094.
+      meshcoreManager.getContact.mockReturnValueOnce({
+        publicKey: REPEATER_PUBKEY,
+        advName: 'MyRepeater',
+        advType: 2, // REPEATER
+        latitude: 51.0,
+        longitude: 0.0,
+        lastSeen: 1_700_000_000_000,
+      });
+
+      const response = await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${REPEATER_PUBKEY}/telemetry-config`)
+        .send({ enabled: true, intervalMinutes: 30 });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      // The contact backfill must run BEFORE the telemetry-config seed
+      // so the seed's getOrInsert path sees the populated row and only
+      // patches its telemetry columns.
+      expect(upsertNode).toHaveBeenCalledTimes(1);
+      expect(upsertNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          publicKey: REPEATER_PUBKEY,
+          name: 'MyRepeater',
+          advType: 2,
+        }),
+        'test-source',
+      );
+      expect(setNodeTelemetryConfig).toHaveBeenCalledWith(
+        'test-source',
+        REPEATER_PUBKEY,
+        { enabled: true, intervalMinutes: 30 },
+      );
+      // Order: backfill upsert → telemetry-config patch.
+      const upsertOrder = upsertNode.mock.invocationCallOrder[0];
+      const setCfgOrder = setNodeTelemetryConfig.mock.invocationCallOrder[0];
+      expect(upsertOrder).toBeLessThan(setCfgOrder);
+    });
+
+    it('skips the backfill upsert when the contact is not yet in memory', async () => {
+      // User enables telemetry-retrieval on a publicKey we haven't
+      // received an advert for yet. The route must still create the
+      // telemetry-config row; backfill happens when the contact arrives.
+      meshcoreManager.getContact.mockReturnValueOnce(undefined);
+
+      const response = await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${REPEATER_PUBKEY}/telemetry-config`)
+        .send({ enabled: true });
+
+      expect(response.status).toBe(200);
+      expect(upsertNode).not.toHaveBeenCalled();
+      expect(setNodeTelemetryConfig).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -878,6 +878,33 @@ router.patch(
         return res.status(400).json({ success: false, error: 'No fields to update' });
       }
 
+      // Backfill advType/advName from the in-memory contact before
+      // seeding the stub row, so the remote-telemetry scheduler can
+      // classify the target correctly on the very next tick. Without
+      // this, setNodeTelemetryConfig writes a publicKey-only row and
+      // the scheduler treats every target as a Companion regardless
+      // of whether it's actually a Repeater — see issue #3092.
+      const manager = managerFor(req);
+      const contact = manager.getContact(publicKey);
+      if (contact) {
+        try {
+          await databaseService.meshcore.upsertNode(
+            {
+              publicKey,
+              name: contact.advName ?? contact.name ?? null,
+              advType: contact.advType ?? null,
+              latitude: contact.latitude ?? null,
+              longitude: contact.longitude ?? null,
+              lastHeard: contact.lastSeen ?? null,
+            },
+            sourceId,
+          );
+        } catch (err) {
+          logger.warn(
+            `[API] telemetry-config: contact backfill for ${publicKey.substring(0, 16)}… failed: ${(err as Error).message}`,
+          );
+        }
+      }
       await databaseService.meshcore.setNodeTelemetryConfig(sourceId, publicKey, patch);
       const node = await databaseService.meshcore.getNodeByPublicKeyAndSource(publicKey, sourceId);
       res.json({


### PR DESCRIPTION
## Summary

Closes the user-visible part of #3092 by making sure the remote-telemetry scheduler can actually classify a target as a Repeater or Room Server.

### Root cause

MeshCore contacts learned via the companion's advert stream were **never persisted** to the `meshcore_nodes` SQL table. The only writer to that table was `setNodeTelemetryConfig`, which seeds a publicKey-only row with `advType=NULL`. Consequently the remote-telemetry scheduler read `target.advType === null`, computed `isRepeaterLike === false` (because `typeof null !== 'number'`), and routed every target through the legacy LPP `GetTelemetryData` path — silently skipping the `SendStatusReq` + guest-login paths added in #3094.

HougeDK's logs in #3092 confirmed this: every telemetry-request line printed `(companion: LPP)` even though the targets were repeaters.

### Fix

Three complementary edits:

1. **`meshcoreManager.handleBridgeEvent`** — call a new `persistContact` helper from the `contact_advertised`, `contact_added`, and `contact_path_updated` handlers so every advert update mirrors to `meshcore_nodes` via `databaseService.meshcore.upsertNode`.
2. **`meshcoreManager.refreshContacts`** — bulk-persist all contacts when a full refresh runs. **This backfills existing deployments** without requiring users to re-toggle telemetry-retrieval on each node.
3. **`meshcoreRoutes` PATCH `.../telemetry-config`** — look up the in-memory contact via the new `MeshCoreManager.getContact` getter and upsert `advType`/`advName` immediately, so a node that gets enabled before its first advert refresh still picks up the right classification on the very next scheduler tick.

Persistence at the event level is fire-and-forget (failures logged, never thrown) so a transient DB error on a single advert can't break the contact-event pipeline. The full-refresh path awaits so the "Refreshed N contacts" log stays accurate.

### Tests

- New `meshcoreManager.contactPersistence.test.ts` covers all three event types, the `contact_path_updated` preserves-advType invariant, the DB-failure swallow path, and the new `getContact` getter (5 tests).
- New `PATCH /api/sources/test-source/meshcore/nodes/:publicKey/telemetry-config` block in `meshcoreRoutes.test.ts` covers both the contact-known backfill path AND the contact-unknown skip path (2 tests).
- Full Vitest suite: 10142 pass / 1 pre-existing flake (`mqttBrokerManager` accept-client test fails identically on clean main).

### Test plan

- [ ] Pull this branch on a MeshCore-only deployment with at least one repeater enabled for telemetry.
- [ ] Confirm scheduler logs `(repeater: status + LPP)` instead of `(companion: LPP)` for repeater targets on the next tick.
- [ ] Confirm `SendStatusReq` status fields (battery, uptime, queue len, RSSI, etc.) start landing as `mc_status_*` telemetry rows.
- [ ] Confirm a `setNodeTelemetryConfig` PATCH for a freshly-seen contact backfills `advType` in the same request (no need to wait for next refresh).
- [ ] Confirm an existing deployment with `advType=NULL` rows gets backfilled automatically on the next `refreshContacts` cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)