### PR TITLE
feat(mqtt): route MQTT channel permissions through channel_database

### DIFF
--- a/src/components/UsersTab.test.tsx
+++ b/src/components/UsersTab.test.tsx
@@ -179,6 +179,38 @@ describe('UsersTab — PR-C grid additions', () => {
     ]));
   });
 
+  it('hides per-slot channel rows and shows a hint when an MQTT source is selected', async () => {
+    // For MQTT sources, the slot index in `packet.channel` is the sender's
+    // device slot, not a stable channel identity — so channel_0..7 grants
+    // don't actually protect a specific channel. Permissions are routed
+    // through channel_database_permissions instead. The UI hides the slot
+    // grid here and points admins at the Virtual Channel section.
+    setupApi({
+      sources: [
+        { id: 'tcp-1', name: 'TCP Source', type: 'meshtastic_tcp' },
+        { id: 'mqtt-1', name: 'MQTT Broker', type: 'mqtt_broker' },
+      ],
+    });
+    render(<UsersTab />);
+    const aliceRow = await screen.findByText(/Alice/);
+    fireEvent.click(aliceRow);
+
+    const select = (await screen.findByLabelText(/permission_scope/i)) as HTMLSelectElement;
+
+    // TCP source first — channel rows ARE rendered (control case).
+    fireEvent.change(select, { target: { value: 'tcp-1' } });
+    await waitFor(() => expect(screen.getByText('users.channel_primary')).toBeInTheDocument());
+    expect(screen.queryByText(/Virtual Channel Permissions below/i)).not.toBeInTheDocument();
+
+    // Switch to MQTT — channel rows go away, hint appears.
+    fireEvent.change(select, { target: { value: 'mqtt-1' } });
+    await waitFor(() =>
+      expect(screen.getByText(/Virtual Channel Permissions below/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('users.channel_primary')).not.toBeInTheDocument();
+    expect(screen.queryByText('users.channel_n')).not.toBeInTheDocument();
+  });
+
   it('channel-database section renders a canWrite checkbox column', async () => {
     setupApi({
       channelDbEntries: [

--- a/src/components/UsersTab.tsx
+++ b/src/components/UsersTab.tsx
@@ -883,11 +883,41 @@ const UsersTab: React.FC = () => {
               </div>
             )}
 
+            {/* For MQTT sources the slot-indexed channel_0..7 grid doesn't
+                map to a stable channel identity — different upstream nodes
+                use different channels in their own slot 0, so a grant on
+                channel_0 silently protects whichever name "won" the slot
+                most recently. MQTT-sourced rows are instead permission-keyed
+                through channel_database_permissions (the Virtual Channel
+                Permissions section below). Hide the grid's channel rows
+                here and show a pointer to where admins should actually
+                grant access. */}
+              {(() => {
+                const scopedSource = sources.find(s => s.id === permissionScope);
+                const isMqttScope = scopedSource?.type === 'mqtt_broker' || scopedSource?.type === 'mqtt_bridge';
+                return isMqttScope ? (
+                  <div className="permission-hint" style={{ margin: '8px 0 12px', padding: '8px 12px', background: 'var(--bg-soft, #f5f5f5)', borderLeft: '3px solid var(--accent, #2563eb)', borderRadius: '4px' }}>
+                    {t(
+                      'users.mqtt_channel_permissions_hint',
+                      'Channel permissions for MQTT sources are managed under Virtual Channel Permissions below — MQTT channels are identified by name across all sources, not by per-source slot.',
+                    )}
+                  </div>
+                ) : null;
+              })()}
+
             <div className="permissions-grid">
               {/* PR-C: only render sourcey resources here. Globals are in the
                   Global Resources section above; mixing them led to the
-                  scope dropdown looking like it affected themes/sources. */}
-              {PERMISSION_KEYS.filter(r => SOURCEY_RESOURCES.includes(r as ResourceType)).map(resource => {
+                  scope dropdown looking like it affected themes/sources.
+                  MQTT scopes additionally hide channel_0..7 rows — see the
+                  hint banner just above this grid for the rationale. */}
+              {PERMISSION_KEYS.filter(r => {
+                if (!SOURCEY_RESOURCES.includes(r as ResourceType)) return false;
+                const scopedSource = sources.find(s => s.id === permissionScope);
+                const isMqttScope = scopedSource?.type === 'mqtt_broker' || scopedSource?.type === 'mqtt_bridge';
+                if (isMqttScope && String(r).startsWith('channel_')) return false;
+                return true;
+              }).map(resource => {
                 // Get label from translated map or format it
                 let label = resource.charAt(0).toUpperCase() + resource.slice(1);
 

--- a/src/db/repositories/channelDatabase.ts
+++ b/src/db/repositories/channelDatabase.ts
@@ -93,6 +93,51 @@ export class ChannelDatabaseRepository extends BaseRepository {
   }
 
   /**
+   * Look up a channel_database row by its human-readable name. Case-insensitive
+   * to mirror the bootstrap path in mqttIngestion.ts which dedups by lowercase
+   * name. Returns null if no row matches.
+   */
+  async getByNameAsync(name: string): Promise<DbChannelDatabase | null> {
+    const trimmed = name.trim();
+    if (!trimmed) return null;
+    const all = await this.getAllAsync();
+    const lower = trimmed.toLowerCase();
+    return all.find((c) => (c.name ?? '').toLowerCase() === lower) ?? null;
+  }
+
+  /**
+   * Find-or-create a "passive" channel_database row keyed by name. Passive =
+   * isEnabled=false with an empty PSK, so the row exists only as a target for
+   * channel_database_permissions (admins can grant view/read on it) and never
+   * participates in server-side decryption. Used by MQTT ingest to materialize
+   * a row for every observed channel name so the permission model can key
+   * MQTT-source data through channel_database instead of slot-indexed
+   * channel_0..7 grants.
+   *
+   * If a row already exists for the name (regardless of isEnabled), that row's
+   * id is returned and no changes are made — we never demote a real decryption
+   * entry by reusing its slot here.
+   */
+  async findOrCreatePassiveByNameAsync(name: string): Promise<number | null> {
+    const trimmed = name.trim();
+    if (!trimmed) return null;
+    const existing = await this.getByNameAsync(trimmed);
+    // `DbChannelDatabase.id` is typed optional for insert shapes; a row read
+    // from the DB always has it set, so fall through to create only if it
+    // somehow isn't.
+    if (existing && typeof existing.id === 'number') return existing.id;
+    return this.createAsync({
+      name: trimmed,
+      psk: '',
+      pskLength: 0,
+      isEnabled: false,
+      enforceNameValidation: false,
+      description: 'Auto-registered for MQTT channel permissions (no PSK)',
+      createdBy: null,
+    });
+  }
+
+  /**
    * Get all enabled channel database entries (for decryption, ordered by sortOrder)
    */
   async getEnabledAsync(): Promise<DbChannelDatabase[]> {

--- a/src/server/mqttBrokerManager.test.ts
+++ b/src/server/mqttBrokerManager.test.ts
@@ -169,10 +169,15 @@ describe('MqttBrokerManager', () => {
     expect(arg.shortName).toBe('TST');
     expect(arg.sourceId).toBe('test-broker');
 
-    const status = manager.getStatus();
-    expect(status.packetsIn).toBeGreaterThanOrEqual(1);
-    expect(status.packetsIngested).toBeGreaterThanOrEqual(1);
-    expect(status.clientCount).toBe(1);
+    // local-packet emits before ingestServiceEnvelope's .then runs that
+    // increments packetsIngested. Wait for the counter to settle instead
+    // of asserting on the immediate post-emit tick.
+    await vi.waitFor(() => {
+      const s = manager.getStatus();
+      expect(s.packetsIn).toBeGreaterThanOrEqual(1);
+      expect(s.packetsIngested).toBeGreaterThanOrEqual(1);
+    });
+    expect(manager.getStatus().clientCount).toBe(1);
   });
 
   it('drops publishes on topics outside the root topic', async () => {

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -32,6 +32,13 @@ vi.mock('../services/database.js', () => ({
     channels: {
       upsertChannel: vi.fn(async () => undefined),
     },
+    channelDatabase: {
+      // Returns undefined by default so the resolver falls back to the raw
+      // slot — keeps every pre-existing test seeing the same channel values
+      // it asserted under the old behavior. Tests that want to exercise
+      // the channel_database-keyed path override the mock per-case.
+      findOrCreatePassiveByNameAsync: vi.fn(async () => undefined),
+    },
   },
 }));
 
@@ -68,9 +75,10 @@ vi.mock('./meshtasticProtobufService.js', () => ({
   },
 }));
 
-import { ingestServiceEnvelope } from './mqttIngestion.js';
+import { ingestServiceEnvelope, _resetMqttIngestCachesForTest } from './mqttIngestion.js';
 import { MqttPacketFilter, type ServiceEnvelopeShape } from './mqttPacketFilter.js';
 import databaseService from '../services/database.js';
+import { CHANNEL_DB_OFFSET } from './constants/meshtastic.js';
 
 const NODE_IN = 0x7ff80a48;
 const NODE_OUT = 0x11111111;
@@ -454,5 +462,126 @@ describe('ingestServiceEnvelope — STORE_FORWARD_APP', () => {
     expect(result.reason).toBe('unsupported-portnum');
     expect(databaseService.messages.insertMessage).not.toHaveBeenCalled();
     expect(databaseService.upsertNode).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Channel-permission re-wire: MQTT-sourced rows are permission-keyed via
+ * channel_database_permissions rather than per-source channel_0..7 slots.
+ * The seam is here in the ingest path — `channel` gets rewritten to the
+ * `CHANNEL_DB_OFFSET + channelDatabaseId` encoding nodeEnhancer already
+ * enforces. These tests pin that contract.
+ */
+describe('ingestServiceEnvelope — channel_database resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetMqttIngestCachesForTest();
+  });
+
+  it('stamps `channel` with CHANNEL_DB_OFFSET + id when the channel name resolves', async () => {
+    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValueOnce(7);
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 1 /* TEXT_MESSAGE_APP */),
+    });
+
+    expect(result.ingested).toBe(true);
+    expect(databaseService.channelDatabase!.findOrCreatePassiveByNameAsync).toHaveBeenCalledWith('LongFast');
+    const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
+    expect(inserted.channel).toBe(CHANNEL_DB_OFFSET + 7);
+  });
+
+  it('memoizes lookups per channel name so repeated packets do not hit the DB twice', async () => {
+    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValue(11);
+
+    await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 1 /* TEXT_MESSAGE_APP */),
+    });
+    await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 1 /* TEXT_MESSAGE_APP */),
+    });
+
+    expect(databaseService.channelDatabase!.findOrCreatePassiveByNameAsync).toHaveBeenCalledTimes(1);
+    const inserts = (databaseService.messages.insertMessage as any).mock.calls;
+    expect(inserts[0][0].channel).toBe(CHANNEL_DB_OFFSET + 11);
+    expect(inserts[1][0].channel).toBe(CHANNEL_DB_OFFSET + 11);
+  });
+
+  it('falls back to the raw slot when envelope.channelId is missing', async () => {
+    const envelope: ServiceEnvelopeShape = {
+      // No channelId.
+      gatewayId: '!00000001',
+      packet: {
+        id: 0xfeed0001,
+        from: NODE_IN,
+        to: 0xffffffff,
+        channel: 3,
+        decoded: { portnum: 1 /* TEXT_MESSAGE_APP */, payload: new Uint8Array([0]) },
+      },
+    };
+
+    const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope });
+    expect(result.ingested).toBe(true);
+    expect(databaseService.channelDatabase!.findOrCreatePassiveByNameAsync).not.toHaveBeenCalled();
+    const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
+    expect(inserted.channel).toBe(3);
+  });
+
+  it('prefers a channelDatabaseId already attached by the decrypt path over the name lookup', async () => {
+    // Simulate the server-side-decrypted shape: `packet.decoded.channelDatabaseId`
+    // is set by channelDecryptionService.tryDecrypt() in mqttIngestion.ts.
+    // The name-based find-or-create must not be invoked when we already know
+    // the channel_database row.
+    const envelope: ServiceEnvelopeShape = {
+      channelId: 'LongFast',
+      gatewayId: '!00000001',
+      packet: {
+        id: 0xfeed0002,
+        from: NODE_IN,
+        to: 0xffffffff,
+        channel: 0,
+        decoded: {
+          portnum: 1 /* TEXT_MESSAGE_APP */,
+          payload: new Uint8Array([0]),
+          channelDatabaseId: 42,
+        } as any,
+      },
+    };
+
+    const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope });
+    expect(result.ingested).toBe(true);
+    expect(databaseService.channelDatabase!.findOrCreatePassiveByNameAsync).not.toHaveBeenCalled();
+    const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
+    expect(inserted.channel).toBe(CHANNEL_DB_OFFSET + 42);
+  });
+
+  it('falls back to the raw slot when the find-or-create resolves to null', async () => {
+    // Edge case: an empty/whitespace-only channel name reaches the repo and
+    // returns null — surface should still ingest the row with the slot
+    // value, just not permission-key it through channel_database.
+    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValueOnce(null);
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 1 /* TEXT_MESSAGE_APP */),
+    });
+    expect(result.ingested).toBe(true);
+    const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
+    expect(inserted.channel).toBe(0); // raw slot from the envelope
+  });
+
+  it('encodes the channel on traceroute rows the same way as messages', async () => {
+    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValueOnce(5);
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 70 /* TRACEROUTE_APP */),
+    });
+    expect(result.ingested).toBe(true);
+    const [record] = (databaseService.insertTraceroute as any).mock.calls[0];
+    expect(record.channel).toBe(CHANNEL_DB_OFFSET + 5);
   });
 });

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -75,6 +75,7 @@ import {
   PortNum,
   StoreForwardRequestResponse,
   getStoreForwardRequestResponseName,
+  CHANNEL_DB_OFFSET,
 } from './constants/meshtastic.js';
 import { calculateDistance } from '../utils/distance.js';
 import { logger } from '../utils/logger.js';
@@ -126,13 +127,22 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         // Carry tapback metadata (emoji, replyId) onto the synthesized
         // decoded shape so TEXT_MESSAGE_APP ingest can preserve it —
         // reactions otherwise lose their grouping in the unified view.
+        // `channelDatabaseId` rides along too so the channel-resolution
+        // step below can pick it up without re-running the cache scan.
         (packet as {
-          decoded?: { portnum?: number; payload?: Uint8Array; emoji?: number; replyId?: number };
+          decoded?: {
+            portnum?: number;
+            payload?: Uint8Array;
+            emoji?: number;
+            replyId?: number;
+            channelDatabaseId?: number;
+          };
         }).decoded = {
           portnum: r.portnum,
           payload: r.payload,
           emoji: r.emoji,
           replyId: r.replyId,
+          channelDatabaseId: r.channelDatabaseId,
         };
       }
     } catch (err) {
@@ -166,6 +176,18 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
   // picker won't surface this channel for this source — the packet
   // ingest itself is unaffected.
   recordChannelFromEnvelope(sourceId, envelope, packet);
+
+  // Resolve the channel_database row for this packet so downstream rows are
+  // permission-keyed via channel_database_permissions instead of the raw
+  // sender slot (which collides across senders on a shared MQTT broker).
+  // The encoding is the same `CHANNEL_DB_OFFSET + id` convention nodeEnhancer
+  // already enforces, so no schema migration is required. Falls back to the
+  // raw slot if nothing resolves (e.g. an unencrypted packet on a broker
+  // that strips channelId from its republished topic).
+  const channelDatabaseId = await resolveChannelDatabaseIdForMqtt(envelope, packet);
+  const rawSlot = typeof packet.channel === 'number' ? packet.channel : 0;
+  const effectiveChannel =
+    channelDatabaseId !== null ? CHANNEL_DB_OFFSET + channelDatabaseId : rawSlot;
 
   // Fail-closed geo membership: when a bbox is configured on the filter,
   // only allow packets from senders we've previously decoded a position
@@ -262,7 +284,7 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         fromNodeId,
         toNodeId,
         text,
-        channel: typeof packet.channel === 'number' ? packet.channel : 0,
+        channel: effectiveChannel,
         portnum,
         timestamp: nowMs,
         rxTime: typeof packet.rxTime === 'number' ? packet.rxTime * 1000 : undefined,
@@ -340,7 +362,7 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
     }
 
     case PortNum.TRACEROUTE_APP: {
-      await ingestTraceroute(sourceId, packet, payload as Record<string, any>, fromNum, fromNodeId, toNum, toNodeId, nowMs);
+      await ingestTraceroute(sourceId, packet, payload as Record<string, any>, fromNum, fromNodeId, toNum, toNodeId, nowMs, effectiveChannel);
       return { ingested: true, portnum };
     }
 
@@ -355,7 +377,7 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
     }
 
     case PortNum.STORE_FORWARD_APP: {
-      const ok = await ingestStoreForward(sourceId, packet, payload as Record<string, any>, fromNum, fromNodeId, toNum, toNodeId, nowMs);
+      const ok = await ingestStoreForward(sourceId, packet, payload as Record<string, any>, fromNum, fromNodeId, toNum, toNodeId, nowMs, effectiveChannel);
       return ok ? { ingested: true, portnum } : { ingested: false, reason: 'unsupported-portnum', portnum };
     }
 
@@ -380,6 +402,7 @@ async function ingestTraceroute(
   toNum: number | null,
   toNodeId: string,
   nowMs: number,
+  effectiveChannel: number,
 ): Promise<void> {
   const BROADCAST_ADDR = 4294967295;
   const lastHeard = Math.floor(nowMs / 1000);
@@ -474,7 +497,6 @@ async function ingestTraceroute(
     );
   }
 
-  const channelIndex = typeof packet.channel === 'number' ? packet.channel : -1;
   const record: DbTraceroute = {
     fromNodeNum: fromNum,
     toNodeNum: toNum ?? 0,
@@ -487,7 +509,7 @@ async function ingestTraceroute(
     timestamp: nowMs,
     createdAt: nowMs,
   };
-  if (channelIndex >= 0) (record as any).channel = channelIndex;
+  if (effectiveChannel >= 0) (record as any).channel = effectiveChannel;
   databaseService.insertTraceroute(record, sourceId);
 
   // Hop count → telemetry, matches TCP's Smart Hops feed.
@@ -699,6 +721,7 @@ async function ingestStoreForward(
   toNum: number | null,
   toNodeId: string,
   nowMs: number,
+  effectiveChannel: number,
 ): Promise<boolean> {
   const rr = decoded.rr ?? decoded.requestResponse ?? decoded.request_response ?? 0;
   const rrName = getStoreForwardRequestResponseName(rr);
@@ -734,7 +757,7 @@ async function ingestStoreForward(
       fromNodeId,
       toNodeId,
       text,
-      channel: typeof packet.channel === 'number' ? packet.channel : 0,
+      channel: effectiveChannel,
       portnum: PortNum.TEXT_MESSAGE_APP,
       timestamp: nowMs,
       rxTime: typeof packet.rxTime === 'number' ? packet.rxTime * 1000 : undefined,
@@ -782,6 +805,62 @@ async function ingestStoreForward(
  * a fresh upsert so the picker stays in sync.
  */
 const channelMemo = new Map<string, Map<number, string>>();
+
+/**
+ * Process-lifetime cache mapping lower-cased channel names to channel_database
+ * row IDs. Avoids hitting the DB on every MQTT packet for the same name. The
+ * cache is invalidated for a single name on the rare write that mints a new
+ * row; lookups for unknown names still go through findOrCreatePassiveByName
+ * so admin-curated entries are picked up automatically.
+ */
+const channelNameToDbIdCache = new Map<string, number>();
+
+/**
+ * Resolve a channel_database id for an MQTT-ingested packet, in priority order:
+ *   1. If server-side decryption already identified the row, trust that.
+ *   2. If `envelope.channelId` (the human-readable channel name from the topic /
+ *      ServiceEnvelope) is set, look up by name. Auto-register a passive
+ *      (isEnabled=false, no PSK) row if no entry exists — this is the seam
+ *      that lets channel_database_permissions become the single source of
+ *      truth for MQTT channel access without forcing operators to pre-declare
+ *      every observed channel.
+ *   3. Otherwise return null and the caller falls back to the slot index.
+ *
+ * Errors are swallowed because the ingest pipeline must not fail just because
+ * we couldn't materialize a permission target — the slot-indexed fallback
+ * keeps the row visible to anyone with channel_${slot} grants.
+ */
+async function resolveChannelDatabaseIdForMqtt(
+  envelope: ServiceEnvelopeShape,
+  packet: NonNullable<ServiceEnvelopeShape['packet']>,
+): Promise<number | null> {
+  const decoded = packet.decoded as { channelDatabaseId?: number } | undefined;
+  if (typeof decoded?.channelDatabaseId === 'number') return decoded.channelDatabaseId;
+
+  const name = envelope.channelId?.trim();
+  if (!name) return null;
+  const cacheKey = name.toLowerCase();
+  const cached = channelNameToDbIdCache.get(cacheKey);
+  if (typeof cached === 'number') return cached;
+
+  try {
+    const id = await databaseService.channelDatabase.findOrCreatePassiveByNameAsync(name);
+    if (typeof id === 'number') {
+      channelNameToDbIdCache.set(cacheKey, id);
+      return id;
+    }
+  } catch (err) {
+    const m = err instanceof Error ? err.message : String(err);
+    logger.debug(`MQTT ingest: channel_database resolve failed for name="${name}": ${m}`);
+  }
+  return null;
+}
+
+/** Exposed for tests to reset between cases. */
+export function _resetMqttIngestCachesForTest(): void {
+  channelMemo.clear();
+  channelNameToDbIdCache.clear();
+}
 
 function recordChannelFromEnvelope(
   sourceId: string,


### PR DESCRIPTION
## Summary

The Permissions dialog showed an 8-slot channel grid (`channel_0..channel_7`) for every source type, including MQTT. For MQTT that grid keyed permissions on the **sender's device slot** (`packet.channel`), which is unstable: two upstream nodes that use different channels in their own slot 0 fight over the same `(sourceId, slot)` row, and a grant on `channel_0` silently protects whichever channel name won the slot race most recently.

This PR re-keys MQTT channel permissions on the existing `channel_database` (Virtual Channels) — a global, name-based registry that already has its own per-user permission table (`channel_database_permissions`). No schema migration is needed: `nodeEnhancer.ts` already enforces virtual-channel permissions whenever a row's `channel` value is `>= CHANNEL_DB_OFFSET (100)`, with `channelDatabaseId = channel - 100`.

### Changes

- **`src/server/mqttIngestion.ts`** — on every MQTT ingest, resolve a `channelDatabaseId` (priority: server-decrypt result, then `envelope.channelId` via name lookup with find-or-create), then stamp the persisted `channel` column as `CHANNEL_DB_OFFSET + id`. Falls back to the raw slot when nothing resolves. Passes `effectiveChannel` to traceroute / store-forward writes too. Adds a per-process name→id cache and a `_resetMqttIngestCachesForTest` export.
- **`src/db/repositories/channelDatabase.ts`** — new `findOrCreatePassiveByNameAsync(name)` that creates a disabled (no-PSK) row for the name if none exists, so the permission target is always materialized without affecting decryption.
- **`src/components/UsersTab.tsx`** — when the per-user permission scope is an `mqtt_broker` or `mqtt_bridge`, the slot grid hides `channel_0..7` rows and shows a hint pointing to the existing Virtual Channel Permissions section below.
- **Tests** — 6 new MQTT-ingest cases (encoded channel for known/unknown name, decrypt-path preference, fallback, traceroute encoding, name-lookup memoization), 1 new UsersTab case (slot grid hidden for MQTT scope), and a flakiness fix in `mqttBrokerManager.test.ts` so it waits for the ingestion `.then` chain (my added `await` introduced a microtask race).

### Out of scope

- **Historical rows** with raw 0..7 channel values keep the old `channel_${slot}` enforcement until they age out. The cutover is forward-only.
- The per-source `channels` table is still populated by `recordChannelFromEnvelope` for the channel picker — unchanged.

## Test plan

- [x] `npx vitest run` — 5179/5179 pass
- [x] `npx tsc -p tsconfig.server.json --noEmit` — clean
- [x] `npx tsc -p tsconfig.json --noEmit` — clean (UsersTab)
- [ ] Manual: connect an MQTT broker, observe that messages on `LongFast` show up under `channel_database` permissions, and that an admin can grant/revoke a non-admin user access via the Virtual Channel Permissions section in the user editor.
- [ ] Manual: open the Permissions dialog with an MQTT source selected — confirm the `channel_0..7` rows are gone and the hint banner is shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)