### PR TITLE
fix(users): readable MQTT permissions hint banner (Catppuccin vars)

### DIFF
--- a/src/components/UsersTab.tsx
+++ b/src/components/UsersTab.tsx
@@ -896,7 +896,18 @@ const UsersTab: React.FC = () => {
                 const scopedSource = sources.find(s => s.id === permissionScope);
                 const isMqttScope = scopedSource?.type === 'mqtt_broker' || scopedSource?.type === 'mqtt_bridge';
                 return isMqttScope ? (
-                  <div className="permission-hint" style={{ margin: '8px 0 12px', padding: '8px 12px', background: 'var(--bg-soft, #f5f5f5)', borderLeft: '3px solid var(--accent, #2563eb)', borderRadius: '4px' }}>
+                  <div
+                    className="permission-hint"
+                    style={{
+                      margin: '8px 0 12px',
+                      padding: '8px 12px',
+                      background: 'var(--ctp-surface0)',
+                      color: 'var(--ctp-text)',
+                      borderLeft: '3px solid var(--ctp-blue)',
+                      borderRadius: '4px',
+                      fontSize: '0.9em',
+                    }}
+                  >
                     {t(
                       'users.mqtt_channel_permissions_hint',
                       'Channel permissions for MQTT sources are managed under Virtual Channel Permissions below — MQTT channels are identified by name across all sources, not by per-source slot.',


### PR DESCRIPTION
## Summary

The MQTT-scope hint banner under the permissions grid (added in #3108) used `var(--bg-soft)` and `var(--accent)` — variables that aren't defined in MeshMonitor's Catppuccin theme. Both fell back to their hex defaults (`#f5f5f5` bg, `#2563eb` border), and no `color` was set, so the text inherited the surrounding panel's color. Result: light-blue-on-white, unreadable in light mode; wrong contrast in dark mode.

Fix: switch to the project's Catppuccin vars (`--ctp-surface0` bg, `--ctp-text` color, `--ctp-blue` border) and add an explicit `color` so the hint reads correctly in both themes.

## Test plan
- [ ] Users tab → Permissions → scope to an MQTT broker/bridge source → confirm the hint banner is readable in both light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)