### PR TITLE
fix(mqtt): stamp node.channel on ingest so the map honors VC permissions

### DIFF
--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -584,4 +584,52 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
     const [record] = (databaseService.insertTraceroute as any).mock.calls[0];
     expect(record.channel).toBe(CHANNEL_DB_OFFSET + 5);
   });
+
+  it('stamps node.channel on NODEINFO upserts so the map filter can honor Virtual Channel Permissions', async () => {
+    // Regression: prior to the fix, NODEINFO_APP and POSITION_APP node
+    // upserts dropped the resolved channel. The map filter then read
+    // `node.channel ?? 0` → channel 0 → required a per-source channel_0
+    // grant. But #3108 hides the channel_0..7 toggles for MQTT scopes
+    // and directs admins to Virtual Channel Permissions, leaving no
+    // way to grant map access — every non-admin saw "No nodes visible".
+    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValueOnce(9);
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 4 /* NODEINFO_APP */),
+    });
+
+    expect(result.ingested).toBe(true);
+    const [insertedNode] = (databaseService.upsertNode as any).mock.calls[0];
+    expect(insertedNode.channel).toBe(CHANNEL_DB_OFFSET + 9);
+  });
+
+  it('stamps node.channel on POSITION upserts the same way as NODEINFO', async () => {
+    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValueOnce(4);
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 3 /* POSITION_APP */),
+    });
+
+    expect(result.ingested).toBe(true);
+    const [insertedNode] = (databaseService.upsertNode as any).mock.calls[0];
+    expect(insertedNode.channel).toBe(CHANNEL_DB_OFFSET + 4);
+  });
+
+  it('falls back to the raw slot on node.channel when name resolution fails', async () => {
+    // Mirrors the same fallback semantics as the message-side test
+    // above — an empty channelId or null find-or-create should still
+    // ingest the node, just keyed to the raw slot.
+    (databaseService.channelDatabase!.findOrCreatePassiveByNameAsync as any).mockResolvedValueOnce(null);
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 4 /* NODEINFO_APP */),
+    });
+
+    expect(result.ingested).toBe(true);
+    const [insertedNode] = (databaseService.upsertNode as any).mock.calls[0];
+    expect(insertedNode.channel).toBe(0); // raw slot from the envelope
+  });
 });

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -209,6 +209,14 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         hwModel: typeof user.hwModel === 'number' ? user.hwModel : (user.hw_model ?? 0),
         role: typeof user.role === 'number' ? user.role : undefined,
         viaMqtt: true,
+        // Stamp the channel-database-encoded channel so
+        // `filterNodesByChannelPermission` can gate map visibility on
+        // the Virtual Channel Permissions the #3108 UI directs admins
+        // toward. Without this the row's `channel` stays NULL → the
+        // filter falls back to `channel_0` (a slot grant the UI hides
+        // for MQTT scopes), so non-admins can never see MQTT nodes on
+        // the map regardless of what they grant.
+        channel: effectiveChannel,
         macaddr: user.macaddr ? bytesToHex(user.macaddr) : undefined,
         publicKey: user.publicKey ? bytesToHex(user.publicKey) : (user.public_key ? bytesToHex(user.public_key) : undefined),
         lastHeard: Math.floor(nowMs / 1000),
@@ -234,6 +242,10 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         longName: '',
         shortName: '',
         hwModel: 0,
+        // See NODEINFO_APP above — `node.channel` must carry the
+        // CHANNEL_DB_OFFSET-encoded virtual-channel id for the map
+        // filter to honor Virtual Channel Permissions.
+        channel: effectiveChannel,
         latitude: typeof latI === 'number' ? latI / 1e7 : undefined,
         longitude: typeof lngI === 'number' ? lngI / 1e7 : undefined,
         altitude: typeof alt === 'number' ? alt : undefined,

--- a/src/server/routes/sourceRoutes.neighbor-info.test.ts
+++ b/src/server/routes/sourceRoutes.neighbor-info.test.ts
@@ -31,6 +31,7 @@ vi.mock('../../services/database.js', () => ({
     findUserByIdAsync: vi.fn(),
     findUserByUsernameAsync: vi.fn(),
     getUserPermissionSetAsync: vi.fn(),
+    getChannelDatabasePermissionsForUserAsSetAsync: vi.fn(),
   }
 }));
 
@@ -337,6 +338,35 @@ describe('GET /:id/neighbor-info', () => {
     expect(res.body[0].nodeName).toBe('Node !abcdef01');
     expect(res.body[0].neighborNodeId).toBe('!12345678');
     expect(res.body[0].neighborName).toBe('Node !12345678');
+  });
+
+  it('drops records whose endpoint nodes the user lacks viewOnMap permission for', async () => {
+    // Regression for #3092 follow-up: before the fix the neighbor-info
+    // endpoint enriched every record with positions from getNodesByNums
+    // regardless of channel access, leaving the map to draw lines
+    // between coordinates a non-admin viewer should never see.
+    const regularUser = { id: 7, username: 'viewer', isActive: true, isAdmin: false };
+    mockDb.findUserByIdAsync.mockResolvedValue(regularUser);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({}); // no channel grants
+    mockDb.getChannelDatabasePermissionsForUserAsSetAsync.mockResolvedValue({});
+    mockDb.checkPermissionAsync.mockResolvedValue(true); // nodes:read passes
+
+    const ni = makeNeighborRecord({ nodeNum: 111, neighborNodeNum: 222 });
+    mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
+    mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([ni]);
+    // Both nodes have a channel set (e.g. CHANNEL_DB_OFFSET + 5 — MQTT-routed)
+    // that the user has no permission for; filterNodesByChannelPermission
+    // returns empty → enriched neighbor-info must be empty.
+    // CHANNEL_DB_OFFSET = 100, so channel 105 = VC id 5 (which the user
+    // has no permission for in the empty mock above).
+    mockDb.nodes.getNodesByNums.mockImplementation(async (nums: number[]) =>
+      new Map(nums.map(n => [n, makeNode(n, { channel: 105 })])),
+    );
+
+    const res = await request(createApp(regularUser)).get('/src-abc/neighbor-info');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
   });
 
   it('returns 403 for unauthenticated requests', async () => {

--- a/src/server/routes/sourceRoutes.traceroutes.test.ts
+++ b/src/server/routes/sourceRoutes.traceroutes.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Source Routes — traceroutes endpoint tests
+ *
+ * Regression for #3092 follow-up: GET /api/sources/:id/traceroutes must
+ * apply the same per-channel viewOnMap gate the nodes endpoint uses, so
+ * the rows' embedded `routePositions` JSON can't leak hop coordinates
+ * that the frontend would draw as "floating lines" once the matching
+ * nodes have been filtered out of the nodes endpoint.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import sourceRoutes from './sourceRoutes.js';
+import databaseService from '../../services/database.js';
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    sources: {
+      getSource: vi.fn(),
+      getAllSources: vi.fn(),
+    },
+    traceroutes: {
+      getAllTraceroutes: vi.fn(),
+    },
+    settings: {
+      getSetting: vi.fn(),
+    },
+    checkPermissionAsync: vi.fn(),
+    findUserByIdAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn(),
+    getUserPermissionSetAsync: vi.fn(),
+    getChannelDatabasePermissionsForUserAsSetAsync: vi.fn(),
+  },
+}));
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    getManager: vi.fn().mockReturnValue(null),
+    startManager: vi.fn(),
+    stopManager: vi.fn(),
+  },
+}));
+
+vi.mock('../meshtasticManager.js', () => ({
+  MeshtasticManager: vi.fn().mockImplementation(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+const mockDb = databaseService as any;
+
+const MOCK_SOURCE = { id: 'src-mqtt', name: 'Test MQTT', type: 'mqtt_broker', enabled: true };
+const CHANNEL_DB_OFFSET = 100; // mirrored from constants/meshtastic.ts
+
+const createApp = (user: any): Express => {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: 'test-secret',
+      resave: false,
+      saveUninitialized: false,
+      cookie: { secure: false },
+    }),
+  );
+  app.use((req: any, _res: any, next: any) => {
+    if (user) {
+      req.session.userId = user.id;
+      mockDb.findUserByIdAsync.mockResolvedValue(user);
+    }
+    next();
+  });
+  app.use('/', sourceRoutes);
+  return app;
+};
+
+const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
+const regularUser = { id: 7, username: 'viewer', isActive: true, isAdmin: false };
+
+describe('GET /:id/traceroutes — channel masking', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+    mockDb.findUserByUsernameAsync.mockResolvedValue(null);
+    mockDb.checkPermissionAsync.mockResolvedValue(true);
+    mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
+  });
+
+  it('returns all traceroutes for admins (no channel gating)', async () => {
+    const traceroutes = [
+      { id: 1, fromNodeNum: 100, toNodeNum: 200, channel: CHANNEL_DB_OFFSET + 5 },
+      { id: 2, fromNodeNum: 300, toNodeNum: 400, channel: 0 },
+    ];
+    mockDb.traceroutes.getAllTraceroutes.mockResolvedValue(traceroutes);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({});
+    mockDb.getChannelDatabasePermissionsForUserAsSetAsync.mockResolvedValue({});
+
+    const res = await request(createApp(adminUser)).get('/src-mqtt/traceroutes');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+  });
+
+  it('drops traceroutes whose channel the non-admin user has no viewOnMap permission for', async () => {
+    const traceroutes = [
+      // MQTT-routed traceroute on virtual channel 5; user has no VC grants.
+      { id: 1, fromNodeNum: 100, toNodeNum: 200, channel: CHANNEL_DB_OFFSET + 5 },
+      // Slot-0 traceroute; user has no per-source channel_0 grant either.
+      { id: 2, fromNodeNum: 300, toNodeNum: 400, channel: 0 },
+    ];
+    mockDb.traceroutes.getAllTraceroutes.mockResolvedValue(traceroutes);
+    mockDb.findUserByIdAsync.mockResolvedValue(regularUser);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({}); // no channel_0 grant
+    mockDb.getChannelDatabasePermissionsForUserAsSetAsync.mockResolvedValue({}); // no VC grant
+
+    const res = await request(createApp(regularUser)).get('/src-mqtt/traceroutes');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('keeps traceroutes on virtual channels the non-admin user has been granted viewOnMap on', async () => {
+    const traceroutes = [
+      { id: 1, fromNodeNum: 100, toNodeNum: 200, channel: CHANNEL_DB_OFFSET + 5 },
+      { id: 2, fromNodeNum: 300, toNodeNum: 400, channel: CHANNEL_DB_OFFSET + 6 },
+    ];
+    mockDb.traceroutes.getAllTraceroutes.mockResolvedValue(traceroutes);
+    mockDb.findUserByIdAsync.mockResolvedValue(regularUser);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({});
+    // User has viewOnMap on VC id=5 but not 6.
+    mockDb.getChannelDatabasePermissionsForUserAsSetAsync.mockResolvedValue({
+      5: { canViewOnMap: true, viewOnMap: true, canRead: true },
+    });
+
+    const res = await request(createApp(regularUser)).get('/src-mqtt/traceroutes');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].id).toBe(1);
+  });
+});

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -9,7 +9,7 @@ import { meshcoreManagerRegistry, meshcoreConfigFromSource } from '../meshcoreRe
 import { MqttBrokerManager, type MqttBrokerSourceConfig } from '../mqttBrokerManager.js';
 import { MqttBridgeManager, type MqttBridgeSourceConfig } from '../mqttBridgeManager.js';
 import waypointRoutes from './waypoints.js';
-import { filterNodesByChannelPermission, maskNodeLocationByChannel, getEffectiveDbNodePosition } from '../utils/nodeEnhancer.js';
+import { filterNodesByChannelPermission, maskNodeLocationByChannel, maskTraceroutesByChannel, getEffectiveDbNodePosition } from '../utils/nodeEnhancer.js';
 import { PortNum, modemPresetChannelName } from '../constants/meshtastic.js';
 import { transformChannel } from '../utils/channelView.js';
 import type { ResourceType } from '../../types/permission.js';
@@ -812,7 +812,15 @@ router.get('/:id/traceroutes', requirePermission('traceroute', 'read', { sourceI
 
     const limit = Math.min(parseInt(req.query.limit as string) || 50, 200);
     const traceroutes = await databaseService.traceroutes.getAllTraceroutes(limit, source.id);
-    res.json(traceroutes);
+    // Channel-gate traceroutes the same way nodes are gated. Without
+    // this, the rows' embedded `routePositions` JSON (a snapshot of
+    // every hop's lat/lng at traceroute time) lets the frontend draw
+    // line segments for routes the user has no viewOnMap permission
+    // for — appearing as "floating lines" once the nodes endpoint has
+    // stripped the corresponding markers. See #3092 follow-up.
+    const user = (req as any).user ?? null;
+    const masked = await maskTraceroutesByChannel(traceroutes, user, source.id);
+    res.json(masked);
   } catch (error) {
     logger.error('Error fetching traceroutes for source:', error);
     res.status(500).json({ error: 'Failed to fetch traceroutes' });
@@ -842,8 +850,28 @@ router.get('/:id/neighbor-info', requirePermission('nodes', 'read', { sourceIdFr
     ])];
     const nodeMap = await databaseService.nodes.getNodesByNums(allNodeNums);
 
+    // Apply the same channel gate the nodes endpoint uses, so that a
+    // neighbor-info link whose endpoint nodes the user can't see on the
+    // map doesn't leak their positions through the enriched response.
+    // Without this gate the map would draw neighbor lines between
+    // coordinates of nodes the user has no viewOnMap permission for —
+    // same "floating lines" symptom as the traceroute leak above.
+    // See #3092 follow-up.
+    const neighborUser = (req as any).user ?? null;
+    const visibleNodes = await filterNodesByChannelPermission(
+      Array.from(nodeMap.values()),
+      neighborUser,
+      source.id,
+    );
+    const visibleNodeNums = new Set(visibleNodes.map(n => Number((n as any).nodeNum)));
+
     // Enrich each record with node names, positions, and bidirectionality flag
-    const enrichedNeighborInfo = neighborInfo.map(ni => {
+    const enrichedNeighborInfo = neighborInfo
+      .filter(ni =>
+        visibleNodeNums.has(Number(ni.nodeNum)) &&
+        visibleNodeNums.has(Number(ni.neighborNodeNum)),
+      )
+      .map(ni => {
       const node = nodeMap.get(ni.nodeNum) ?? null;
       const neighbor = nodeMap.get(ni.neighborNodeNum) ?? null;
       const nodePos = getEffectivePosition(node);


### PR DESCRIPTION
## Summary

#3108 routed MQTT message ingest through `channel_database` and stamped `message.channel = CHANNEL_DB_OFFSET + dbId`. The matching changes on the node and neighbor-info / traceroute endpoints were missed, so non-admin / anonymous viewers either saw nothing on the map or — worse — saw line segments rendered between coordinates of nodes they had no permission to see ("floating lines").

### What this PR fixes

1. **MQTT NODEINFO/POSITION ingest didn't stamp `node.channel`.** `mqttIngestion.ts` left the column NULL, so the map node filter fell back to `permissions[channel_0]` — a slot grant the #3108 UI hides for MQTT scopes. Result: anonymous and non-admin viewers couldn't see any MQTT nodes regardless of what they granted.
2. **`/api/sources/:id/traceroutes` returned rows unfiltered.** Each row carries a `routePositions` JSON snapshot of hop coordinates. The frontend's `useTraceroutePaths` hook prefers that snapshot over the live nodes list, so it drew lines for traceroutes the user had no channel access to — coordinates leaked, lines floated.
3. **`/api/sources/:id/neighbor-info` enriched records with positions from `getNodesByNums` with no channel check.** Same leak shape: lines drawn between coordinates of nodes the user shouldn't see.

### Fix

- `mqttIngestion.ts`: pass `channel: effectiveChannel` into the NODEINFO_APP and POSITION_APP `upsertNode` calls. Existing rows with `channel=NULL` recover as each node re-broadcasts NODEINFO.
- `sourceRoutes.ts /traceroutes`: apply `maskTraceroutesByChannel` (already existed in `nodeEnhancer.ts`) to the response.
- `sourceRoutes.ts /neighbor-info`: build a visible-node set via `filterNodesByChannelPermission` and drop neighbor records whose endpoints aren't in it.

### Tests

- 3 new tests in `mqttIngestion.test.ts` pinning the node.channel stamping (NODEINFO, POSITION, raw-slot fallback).
- 1 new regression test in `sourceRoutes.neighbor-info.test.ts` for the channel-gate.
- New `sourceRoutes.traceroutes.test.ts` covering admin-pass, no-grant-drop, and partial-grant scenarios.
- Full Vitest suite: 10158 pass / 0 fail.

### Test plan

- [ ] Pull and deploy on a system with an MQTT source.
- [ ] Confirm new NODEINFO arrivals land with `nodes.channel = CHANNEL_DB_OFFSET + dbId` (not NULL or 0).
- [ ] Grant Anonymous `viewOnMap` on the corresponding Virtual Channel Permissions entry.
- [ ] Reload the map as an anonymous viewer → nodes now show.
- [ ] Without VC grants, confirm zero MQTT nodes appear AND no traceroute/neighbor lines float in empty space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)