### PR TITLE
chore(release): bump version to 4.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 _No changes yet._
 
 
+## [4.6.3] - 2026-05-20
+
+# MeshMonitor v4.6.3
+
+Patch release focused on **MQTT-source permissions and map visibility**. The MQTT ingest path now stamps `node.channel` with the channel-database-encoded virtual channel id so the map filter can honor Virtual Channel Permissions, MeshCore contacts are persisted to the DB so the remote-telemetry scheduler can correctly classify repeater targets, unified messages keep tapback metadata across multi-source merges, the Users tab admin UI for MQTT sources is readable in both themes, and traceroute / neighbor-info endpoints are now channel-gated so non-admins can no longer see line segments rendered between coordinates of nodes they have no permission to view.
+
+## Features
+- #3108 feat(mqtt): route MQTT channel permissions through `channel_database` — bootstraps a passive `channel_database` row for every observed MQTT channel name, encodes `message.channel` and `traceroute.channel` as `CHANNEL_DB_OFFSET + dbId`, and routes the Users-tab admin UI to manage MQTT-source access via Virtual Channel Permissions instead of the slot-indexed `channel_0..7` grants (which collide across senders on a shared broker).
+
+## Fixes
+- #3105 fix(unified): preserve tapback metadata across MQTT ingest + cross-source merge — captures `emoji` and `replyId` on MQTT TEXT_MESSAGE_APP ingest, surfaces them from `channelDecryptionService`, and upgrades the unified-merge to prefer non-null values from any source so reactions stop flickering between rendering as emoji pills and as inline messages.
+- #3107 fix(meshcore): persist contact advType to `meshcore_nodes` — the in-memory contact map was correct but never mirrored to SQL, so the remote-telemetry scheduler always read `advType=NULL` and routed every target through the legacy LPP-only path. Fixes #3092 for users with repeaters that don't anonymously answer LPP requests.
+- #3109 fix(users): use Catppuccin variables for the MQTT permissions hint banner so it's readable in both light and dark themes.
+- #3110 fix(mqtt): stamp `node.channel` on ingest, and channel-gate the traceroute and neighbor-info endpoints. Without the first half, the map filter fell back to `permissions[channel_0]` — a slot the #3108 UI hides for MQTT scopes — so non-admins couldn't see MQTT nodes regardless of what was granted. Without the second half, traceroute `routePositions` and neighbor-info enriched positions leaked enough coordinates for the frontend to render "floating lines" between hidden nodes.
+
+## Docs
+- #3106 docs(claude): drop the worktree restriction from CLAUDE.md.
+
+
 ## [4.6.2-1] - 2026-05-19
 
 # MeshMonitor v4.6.2-1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # MeshMonitor — Claude Agent Brief
 
-**Version:** 4.6.1 (multi-source architecture)
+**Version:** 4.6.3 (multi-source architecture)
 **Stack:** React 19 + TS + Vite frontend / Node.js 20+ (Docker image ships Node 24; CI matrix covers 20/22/24/25) + Express 5 + TS backend / SQLite (default), PostgreSQL, MySQL via Drizzle ORM / Meshtastic protobuf-over-TCP and MeshCore (native `meshcore.js` for companion, serial CLI for repeater) through a per-source manager registry.
 
 ## Read order for new agents

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor-desktop",
-  "version": "4.6.1",
+  "version": "4.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor-desktop",
-      "version": "4.6.1",
+      "version": "4.6.3",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.6.2-1",
+  "version": "4.6.3",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.6.2-1",
+  "version": "4.6.3",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/blog/2026-05-20-v4.6.3-permissions.md
+++ b/docs/blog/2026-05-20-v4.6.3-permissions.md
@@ -1,0 +1,61 @@
+---
+id: news-2026-05-20-v4.6.3-permissions
+title: MeshMonitor v4.6.3 — MQTT permissions, map visibility, and tapback fixes
+date: '2026-05-20T18:00:00Z'
+category: release
+priority: important
+minVersion: 4.6.0
+---
+## What this release is really about
+
+**v4.6.3** is a follow-up patch focused on how permissions and map visibility work for **MQTT sources**. v4.6.2 reworked the MQTT ingest pipeline so cross-source dedup and channel decryption finally work; this release fixes the permission and rendering gaps that release exposed.
+
+If you run MeshMonitor with **anonymous users** or **non-admin accounts** viewing the map, this release affects you directly.
+
+## The big change: MQTT channel permissions live under Virtual Channel Permissions
+
+In the old slot-indexed permission model, channel access was granted per-source on slots `channel_0..channel_7`. That works fine for a TCP source where slot 0 always means the same channel — but for an MQTT broker, **slot 0 from different senders is a different channel each time**. The same `channel_0` permission row was effectively a wildcard for whatever channels happened to land there most recently.
+
+Starting in v4.6.3 (with the underlying mechanics from #3108):
+
+- MQTT ingest registers each observed channel **by name** in the global `channel_database` table.
+- Messages, traceroutes, and now node positions are tagged with the channel-database id (encoded as `CHANNEL_DB_OFFSET + id`), not the raw slot.
+- The map filter, the messages filter, and the traceroute / neighbor-info endpoints all read from `channel_database_permissions` for those rows.
+
+**What this means in the UI**: when you scope the Users-tab permissions dropdown to an MQTT source, the `channel_0..7` grid is now hidden, and you'll see a banner pointing you to the **Virtual Channel Permissions** section further down the page. Grant `View on Map` and `Read` on the relevant `channel_database` entries (e.g. `LongFast`, `MediumFast`) for each user — and crucially for the **Anonymous user** if you want unauthenticated viewers to see anything.
+
+## Why your map went empty after upgrading
+
+Several users who upgraded to v4.6.2 saw **zero nodes** on the map for their MQTT sources as the anonymous user (or any non-admin), regardless of what they granted. The cause: MQTT NODEINFO / POSITION ingest wasn't stamping the channel-database id onto the node row. The map filter fell back to checking `channel_0:viewOnMap` — which the new UI hides — so there was no way to grant access.
+
+**v4.6.3 fixes this** by stamping `node.channel = CHANNEL_DB_OFFSET + dbId` at ingest time (#3110). Existing rows with `channel=NULL` recover as each MQTT node re-broadcasts NODEINFO (typically every few hours under default firmware config). If you don't want to wait, restarting the MQTT broker / bridge container is enough to trigger a fresh round of advertisements on most public brokers.
+
+## "Floating lines" — the other half of the fix
+
+Even with nodes correctly filtered, two endpoints were still leaking enough position data for the frontend to draw line segments between coordinates of nodes the user couldn't see:
+
+- `/api/sources/:id/traceroutes` returned rows unfiltered, and each row carries a `routePositions` JSON snapshot of every hop's lat/lng at traceroute time. The map drew traceroute segments using that snapshot, even after the matching node markers had been filtered out.
+- `/api/sources/:id/neighbor-info` enriched each record with positions pulled from the node table without a channel check.
+
+**v4.6.3 channel-gates both endpoints** (#3110) using the same `viewOnMap` permission set the nodes endpoint already used. If you have no `viewOnMap` grant on the channel, you don't see the lines either.
+
+## Tapback rendering finally stays put
+
+If you noticed tapback reactions on the Unified Messages feed flickering — appearing briefly as an emoji pill under the parent message, then turning into a full inline message on the next poll, then back again — this release fixes that (#3105).
+
+Cause: MQTT ingest dropped `emoji` and `replyId` from the decoded protobuf, so MQTT-sourced reaction rows hit the DB with both fields null. The unified-merge then picked first-source-wins for these fields under a non-deterministic `Promise.all` race — sometimes the TCP row (with the correct emoji marker) won, sometimes the MQTT row (with nulls) won. v4.6.3 captures the fields on MQTT ingest, propagates them through server-side decryption, and upgrades the unified-merge to prefer populated values from any source.
+
+## MeshCore repeater telemetry, take three
+
+v4.6.1 added MQTT-side fallbacks for MeshCore repeater telemetry; v4.6.2 added a `SendStatusReq` + guest-login path for the repeater protocol; and now v4.6.3 fixes the **last remaining gap** uncovered while debugging #3092: MeshCore contacts learned from the advert stream were never actually written to the `meshcore_nodes` table (#3107). The remote-telemetry scheduler always read `target.advType=NULL`, decided every target looked like a Companion, and silently skipped the new repeater paths.
+
+With v4.6.3, advert events mirror to the SQL table immediately, `refreshContacts()` bulk-backfills on startup, and the per-node telemetry-config route backfills the contact's `advType` before seeding the retrieval row. The new paths shipped in v4.6.2 finally run for everyone.
+
+## Action items after upgrade
+
+- **Open Users → Permissions → scope to each MQTT source** and confirm the new banner appears.
+- **Scroll down to Virtual Channel Permissions** and make sure each user (including Anonymous if applicable) has `View on Map` and `Read` granted on the channel-database rows for the MQTT channels you want them to see.
+- **Reload the map** — node markers and traceroute/neighbor lines should match each other (no more floating segments). Allow a few hours for `node.channel=NULL` rows from v4.6.2 to backfill on their own, or restart the MQTT container to force fresh adverts.
+- **If you use MeshCore repeaters**, re-enable Telemetry Retrieval on a repeater node and check the scheduler logs — the line should say `Requesting telemetry from … (repeater: status + LPP)`, not `(companion: LPP)`.
+
+Full release notes: [CHANGELOG.md](https://github.com/Yeraze/meshmonitor/blob/main/CHANGELOG.md#463---2026-05-20).

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.6.2-1
-appVersion: "4.6.2-1"
+version: 4.6.3
+appVersion: "4.6.3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.2-1",
+  "version": "4.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.6.2-1",
+      "version": "4.6.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.2-1",
+  "version": "4.6.3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Cuts the **v4.6.3** patch release. Five files bumped per the CLAUDE.md recipe (`package.json`, `package-lock.json` regenerated, `helm/meshmonitor/Chart.yaml`, `desktop/src-tauri/tauri.conf.json`, `desktop/package.json`), CLAUDE.md banner line updated, CHANGELOG entry added, and a release blog post written for `docs/blog/`.

## Scope of 4.6.3

Six PRs merged since 4.6.2-1:

- **#3105** `fix(unified)` — preserve tapback metadata across MQTT ingest + cross-source merge.
- **#3106** `docs(claude)` — drop worktree restriction from CLAUDE.md.
- **#3107** `fix(meshcore)` — persist contact `advType` to `meshcore_nodes` (closes #3092 for users with repeaters that don't anonymously answer LPP).
- **#3108** `feat(mqtt)` — route MQTT channel permissions through `channel_database` (Virtual Channel Permissions).
- **#3109** `fix(users)` — Catppuccin variables for the MQTT permissions hint banner.
- **#3110** `fix(mqtt)` — stamp `node.channel` on ingest + channel-gate traceroutes and neighbor-info (the \"No nodes visible\" + floating-lines fix).

## Blog post focus

Per the request, the blog post focuses on the **permissions story** — what changed in the Users tab for MQTT scopes, why maps may have gone empty after upgrading, the floating-lines fix, and the action items operators should take after upgrading (chiefly: grant Anonymous + non-admin users `View on Map` and `Read` on Virtual Channel Permissions for the relevant channel-database rows).

## Test plan

- [ ] Verify the five version files all show `4.6.3`.
- [ ] Confirm CHANGELOG renders the new section above 4.6.2-1.
- [ ] Confirm the blog post appears on `meshmonitor.org/blog/` after deploy.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)