### PR TITLE
feat(messages): add source_ip + source_path columns for per-message attribution

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 64 migrations registered', () => {
-    expect(registry.count()).toBe(64);
+  it('has all 65 migrations registered', () => {
+    expect(registry.count()).toBe(65);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_channel_database_permission', () => {
+  it('last migration is add_message_source_attribution', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(64);
-    expect(last.name).toContain('add_channel_database_permission');
+    expect(last.number).toBe(65);
+    expect(last.name).toContain('add_message_source_attribution');
   });
 
-  it('migrations are sequentially numbered from 1 to 64', () => {
+  it('migrations are sequentially numbered from 1 to 65', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -79,6 +79,7 @@ import { migration as meshcoreNodesCompositePkMigration, runMigration061Postgres
 import { migration as meshcoreMessagesFromnameMigration, runMigration062Postgres, runMigration062Mysql } from '../server/migrations/062_meshcore_messages_fromname.js';
 import { migration as dropSourceIdFromChannelDatabaseMigration, runMigration063Postgres, runMigration063Mysql } from '../server/migrations/063_drop_source_id_from_channel_database.js';
 import { migration as addChannelDatabasePermissionMigration, runMigration064Postgres, runMigration064Mysql } from '../server/migrations/064_add_channel_database_permission.js';
+import { migration as addMessageSourceAttributionMigration, runMigration065Postgres, runMigration065Mysql } from '../server/migrations/065_add_message_source_attribution.js';
 
 // ============================================================================
 // Registry
@@ -1010,4 +1011,19 @@ registry.register({
   sqlite: (db) => addChannelDatabasePermissionMigration.up(db),
   postgres: (client) => runMigration064Postgres(client),
   mysql: (pool) => runMigration064Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 065: Add source_ip + source_path columns to messages table.
+// Two nullable text columns so operators can trace WHICH client/API caller
+// injected a given message. Existing rows get NULL; backward compatible.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 65,
+  name: 'add_message_source_attribution',
+  settingsKey: 'migration_065_add_message_source_attribution',
+  sqlite: (db) => addMessageSourceAttributionMigration.up(db),
+  postgres: (client) => runMigration065Postgres(client),
+  mysql: (pool) => runMigration065Mysql(pool),
 });

--- a/src/db/repositories/messages.bigint.test.ts
+++ b/src/db/repositories/messages.bigint.test.ts
@@ -122,6 +122,8 @@ describe('Messages BIGINT round-trip (SQLite)', () => {
         createdAt INTEGER NOT NULL,
         decrypted_by TEXT,
         sourceId TEXT,
+        source_ip TEXT,
+        source_path TEXT,
         FOREIGN KEY (fromNodeNum) REFERENCES nodes(nodeNum) ON DELETE CASCADE,
         FOREIGN KEY (toNodeNum) REFERENCES nodes(nodeNum) ON DELETE CASCADE
       )

--- a/src/db/repositories/messages.exclude-portnums.test.ts
+++ b/src/db/repositories/messages.exclude-portnums.test.ts
@@ -68,7 +68,9 @@ describe('MessagesRepository.getMessages excludePortnums', () => {
         ackFromNode INTEGER,
         createdAt INTEGER NOT NULL,
         decrypted_by TEXT,
-        sourceId TEXT
+        sourceId TEXT,
+        source_ip TEXT,
+        source_path TEXT
       )
     `);
 

--- a/src/db/repositories/messages.insert.test.ts
+++ b/src/db/repositories/messages.insert.test.ts
@@ -68,7 +68,9 @@ describe('MessagesRepository.insertMessage duplicate detection', () => {
         ackFromNode INTEGER,
         createdAt INTEGER NOT NULL,
         decrypted_by TEXT,
-        sourceId TEXT
+        sourceId TEXT,
+        source_ip TEXT,
+        source_path TEXT
       )
     `);
 

--- a/src/db/repositories/messages.migration.test.ts
+++ b/src/db/repositories/messages.migration.test.ts
@@ -68,7 +68,9 @@ describe('MessagesRepository.migrateMessagesForChannelMoves', () => {
         wantAck INTEGER,
         ackFromNode INTEGER,
         createdAt INTEGER NOT NULL,
-        decrypted_by TEXT
+        decrypted_by TEXT,
+        source_ip TEXT,
+        source_path TEXT
       )
     `);
 

--- a/src/db/repositories/messages.purge.test.ts
+++ b/src/db/repositories/messages.purge.test.ts
@@ -71,7 +71,9 @@ describe('MessagesRepository sync purge helpers', () => {
         ackFromNode INTEGER,
         createdAt INTEGER NOT NULL,
         decrypted_by TEXT,
-        sourceId TEXT
+        sourceId TEXT,
+        source_ip TEXT,
+        source_path TEXT
       )
     `);
 

--- a/src/db/repositories/messages.timestamp.test.ts
+++ b/src/db/repositories/messages.timestamp.test.ts
@@ -67,7 +67,9 @@ describe('MessagesRepository.updateMessageTimestamps', () => {
         wantAck INTEGER,
         ackFromNode INTEGER,
         createdAt INTEGER NOT NULL,
-        decrypted_by TEXT
+        decrypted_by TEXT,
+        source_ip TEXT,
+        source_path TEXT
       )
     `);
 

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -51,6 +51,8 @@ export class MessagesRepository extends BaseRepository {
       ackFromNode: messageData.ackFromNode ?? null,
       createdAt: messageData.createdAt,
       decryptedBy: messageData.decryptedBy ?? null,
+      sourceIp: messageData.sourceIp ?? null,
+      sourcePath: messageData.sourcePath ?? null,
     };
     if (sourceId) {
       values.sourceId = sourceId;
@@ -313,6 +315,8 @@ export class MessagesRepository extends BaseRepository {
       ackFromNode: (messageData as any).ackFromNode ?? null,
       createdAt: messageData.createdAt,
       decryptedBy: (messageData as any).decryptedBy ?? null,
+      sourceIp: (messageData as any).sourceIp ?? null,
+      sourcePath: (messageData as any).sourcePath ?? null,
     };
     if (sourceId) {
       values.sourceId = sourceId;

--- a/src/db/repositories/schemaIntegrity.test.ts
+++ b/src/db/repositories/schemaIntegrity.test.ts
@@ -150,6 +150,8 @@ describe('Schema integrity after all migrations', () => {
         ackFromNode INTEGER,
         createdAt INTEGER NOT NULL,
         decrypted_by TEXT,
+        source_ip TEXT,
+        source_path TEXT,
         FOREIGN KEY (fromNodeNum) REFERENCES nodes(nodeNum) ON DELETE CASCADE,
         FOREIGN KEY (toNodeNum) REFERENCES nodes(nodeNum) ON DELETE CASCADE
       )

--- a/src/db/schema/messages.ts
+++ b/src/db/schema/messages.ts
@@ -40,6 +40,9 @@ export const messagesSqlite = sqliteTable('messages', {
   decryptedBy: text('decrypted_by'),
   // Source association (nullable — NULL = legacy default source)
   sourceId: text('sourceId'),
+  // Per-message ingress attribution (nullable — NULL for pre-migration rows)
+  sourceIp: text('source_ip'),
+  sourcePath: text('source_path'),
 });
 
 // PostgreSQL schema
@@ -75,6 +78,9 @@ export const messagesPostgres = pgTable('messages', {
   decryptedBy: pgText('decrypted_by'),
   // Source association (nullable — NULL = legacy default source)
   sourceId: pgText('sourceId'),
+  // Per-message ingress attribution (nullable — NULL for pre-migration rows)
+  sourceIp: pgText('source_ip'),
+  sourcePath: pgText('source_path'),
 });
 
 // MySQL schema
@@ -110,6 +116,9 @@ export const messagesMysql = mysqlTable('messages', {
   decryptedBy: myVarchar('decrypted_by', { length: 16 }),
   // Source association (nullable — NULL = legacy default source)
   sourceId: myVarchar('sourceId', { length: 36 }),
+  // Per-message ingress attribution (nullable — NULL for pre-migration rows)
+  sourceIp: myVarchar('source_ip', { length: 64 }),
+  sourcePath: myVarchar('source_path', { length: 16 }),
 });
 
 // Type inference

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -125,6 +125,10 @@ export interface DbMessage {
   ackFromNode?: number | null;
   createdAt: number;
   decryptedBy?: 'node' | 'server' | null;
+  /** Client IP for HTTP-injected sends (honors X-Forwarded-For when trust proxy is configured). NULL for non-HTTP sources. */
+  sourceIp?: string | null;
+  /** Categorical message ingress path. NULL for pre-migration rows. */
+  sourcePath?: 'http_api' | 'tcp_radio' | 'mqtt_bridge' | 'system' | null;
 }
 
 /**

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -238,6 +238,8 @@ type TextMessage = {
   createdAt: number;
   decryptedBy?: 'node' | 'server' | null; // Decryption source - 'server' means read-only
   viaStoreForward?: boolean; // Message received via Store & Forward replay
+  sourceIp?: string | null; // Per-message ingress attribution (client IP for HTTP injects)
+  sourcePath?: 'http_api' | 'tcp_radio' | 'mqtt_bridge' | 'system' | null;
 };
 
 /**
@@ -4808,6 +4810,13 @@ class MeshtasticManager implements ISourceManager {
           createdAt: Date.now(),
           decryptedBy: context?.decryptedBy ?? null, // Track decryption source - 'server' means read-only
           viaStoreForward: context?.viaStoreForward === true ? true : undefined, // Message received via Store & Forward replay
+          // Inbound radio path — message arrived from a meshtastic node over TCP.
+          // MQTT-bridged inbound packets are flagged via viaMqtt above; we still
+          // attribute the row's ingress to 'tcp_radio' because it arrived via
+          // this manager's TCP transport (the MQTT bridge path is handled in
+          // mqttIngestion.ts and uses 'mqtt_bridge').
+          sourceIp: null,
+          sourcePath: 'tcp_radio',
         };
         const wasInserted = await databaseService.messages.insertMessage(message, this.sourceId);
 
@@ -6118,7 +6127,10 @@ class MeshtasticManager implements ISourceManager {
         portnum: PortNum.TRACEROUTE_APP,
         timestamp: timestamp,
         rxTime: timestamp,
-        createdAt: Date.now()
+        createdAt: Date.now(),
+        // Inbound traceroute response from a meshtastic node over TCP.
+        sourceIp: null,
+        sourcePath: 'tcp_radio' as const,
       };
 
       const wasInserted = await databaseService.messages.insertMessage(message, this.sourceId);
@@ -7458,7 +7470,7 @@ class MeshtasticManager implements ISourceManager {
     };
   }
 
-  async sendTextMessage(text: string, channel: number = 0, destination?: number, replyId?: number, emoji?: number, userId?: number): Promise<number> {
+  async sendTextMessage(text: string, channel: number = 0, destination?: number, replyId?: number, emoji?: number, userId?: number, attribution?: { sourceIp?: string | null; sourcePath?: 'http_api' | 'tcp_radio' | 'mqtt_bridge' | 'system' | null }): Promise<number> {
     if (!this.isConnected || !this.transport) {
       throw new Error('Not connected to Meshtastic node');
     }
@@ -7550,7 +7562,11 @@ class MeshtasticManager implements ISourceManager {
           requestId: messageId, // Save requestId for routing error matching
           wantAck: true, // Request acknowledgment for this message
           deliveryState: 'pending', // Initial delivery state
-          createdAt: Date.now()
+          createdAt: Date.now(),
+          // Default attribution to 'system' when not provided (e.g. internal
+          // ping/welcome/etc. callers); HTTP route passes 'http_api' + req.ip.
+          sourceIp: attribution?.sourceIp ?? null,
+          sourcePath: attribution?.sourcePath ?? 'system'
         };
 
         await databaseService.messages.insertMessage(message, this.sourceId);

--- a/src/server/migrations/065_add_message_source_attribution.test.ts
+++ b/src/server/migrations/065_add_message_source_attribution.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Migration 065 — Add source_ip + source_path columns to messages table.
+ * SQLite-only unit test; Postgres / MySQL paths share the same shape and are
+ * exercised by the integration suite.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './065_add_message_source_attribution.js';
+
+function createMessagesTable(db: Database.Database) {
+  // Minimal pre-migration messages table — only the columns required to
+  // exercise the ALTER TABLE.
+  db.exec(`
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      fromNodeNum INTEGER NOT NULL,
+      toNodeNum INTEGER NOT NULL,
+      fromNodeId TEXT NOT NULL,
+      toNodeId TEXT NOT NULL,
+      text TEXT NOT NULL,
+      channel INTEGER NOT NULL DEFAULT 0,
+      timestamp INTEGER NOT NULL,
+      createdAt INTEGER NOT NULL
+    );
+  `);
+}
+
+function columnNames(db: Database.Database, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as any[]).map((r) => r.name);
+}
+
+describe('migration 065: add source_ip + source_path columns', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createMessagesTable(db);
+  });
+
+  it('adds source_ip and source_path columns to messages', () => {
+    expect(columnNames(db, 'messages')).not.toContain('source_ip');
+    expect(columnNames(db, 'messages')).not.toContain('source_path');
+
+    migration.up(db);
+
+    const cols = columnNames(db, 'messages');
+    expect(cols).toContain('source_ip');
+    expect(cols).toContain('source_path');
+  });
+
+  it('is idempotent — running twice is a no-op', () => {
+    migration.up(db);
+    migration.up(db); // should not throw on duplicate column
+    const cols = columnNames(db, 'messages');
+    expect(cols.filter((c) => c === 'source_ip')).toHaveLength(1);
+    expect(cols.filter((c) => c === 'source_path')).toHaveLength(1);
+  });
+
+  it('leaves existing rows with NULL for both columns (backward compatible)', () => {
+    const ts = Date.now();
+    db.prepare(
+      `INSERT INTO messages (id, fromNodeNum, toNodeNum, fromNodeId, toNodeId, text, timestamp, createdAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('msg-1', 1, 2, '!00000001', '!00000002', 'hello', ts, ts);
+
+    migration.up(db);
+
+    const row = db.prepare(`SELECT source_ip, source_path FROM messages WHERE id = ?`).get('msg-1') as any;
+    expect(row.source_ip).toBeNull();
+    expect(row.source_path).toBeNull();
+  });
+
+  it('accepts new rows with populated source_ip and source_path', () => {
+    migration.up(db);
+
+    const ts = Date.now();
+    db.prepare(
+      `INSERT INTO messages (id, fromNodeNum, toNodeNum, fromNodeId, toNodeId, text, timestamp, createdAt, source_ip, source_path)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('msg-2', 1, 2, '!00000001', '!00000002', 'world', ts, ts, '192.0.2.42', 'http_api');
+
+    const row = db.prepare(`SELECT source_ip, source_path FROM messages WHERE id = ?`).get('msg-2') as any;
+    expect(row.source_ip).toBe('192.0.2.42');
+    expect(row.source_path).toBe('http_api');
+  });
+});

--- a/src/server/migrations/065_add_message_source_attribution.ts
+++ b/src/server/migrations/065_add_message_source_attribution.ts
@@ -1,0 +1,58 @@
+/**
+ * Migration 065: Add source_ip and source_path columns to messages table.
+ *
+ * Adds two nullable text columns so operators can trace WHICH client/API caller
+ * injected a given message via MeshMonitor's send endpoint:
+ *
+ *   - source_ip   TEXT NULL   — client IP for HTTP-injected sends (honors
+ *                               X-Forwarded-For when trust proxy is configured);
+ *                               NULL for radio-received, MQTT-bridged, and
+ *                               internally-generated messages.
+ *   - source_path TEXT NULL   — categorical source: 'http_api' | 'tcp_radio'
+ *                               | 'mqtt_bridge' | 'system'.
+ *
+ * Backward compatible: existing rows get NULL for both columns (no breaking
+ * change for existing deployments / API consumers).
+ */
+import type { Database } from 'better-sqlite3';
+
+// SQLite migration
+export const migration = {
+  up(db: Database) {
+    try {
+      db.exec(`ALTER TABLE messages ADD COLUMN source_ip TEXT`);
+    } catch (e: any) {
+      if (!e.message?.includes('duplicate column')) throw e;
+    }
+    try {
+      db.exec(`ALTER TABLE messages ADD COLUMN source_path TEXT`);
+    } catch (e: any) {
+      if (!e.message?.includes('duplicate column')) throw e;
+    }
+  },
+};
+
+// PostgreSQL migration
+export async function runMigration065Postgres(client: any): Promise<void> {
+  await client.query(`ALTER TABLE messages ADD COLUMN IF NOT EXISTS source_ip TEXT`);
+  await client.query(`ALTER TABLE messages ADD COLUMN IF NOT EXISTS source_path TEXT`);
+}
+
+// MySQL migration
+export async function runMigration065Mysql(pool: any): Promise<void> {
+  const [ipRows] = await pool.query(`
+    SELECT COLUMN_NAME FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'messages' AND COLUMN_NAME = 'source_ip'
+  `);
+  if ((ipRows as any[]).length === 0) {
+    await pool.query(`ALTER TABLE messages ADD COLUMN source_ip VARCHAR(64)`);
+  }
+
+  const [pathRows] = await pool.query(`
+    SELECT COLUMN_NAME FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'messages' AND COLUMN_NAME = 'source_path'
+  `);
+  if ((pathRows as any[]).length === 0) {
+    await pool.query(`ALTER TABLE messages ADD COLUMN source_path VARCHAR(16)`);
+  }
+}

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -306,6 +306,7 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         emoji,
         replyId,
         createdAt: nowMs,
+        sourcePath: 'mqtt_bridge',
       } as DbMessage;
       (msg as any).sourceId = sourceId;
       // Use the repo's per-source insert — the `databaseService.insertMessage`
@@ -777,6 +778,7 @@ async function ingestStoreForward(
       rxRssi: typeof packet.rxRssi === 'number' ? packet.rxRssi : undefined,
       viaMqtt: true,
       createdAt: nowMs,
+      sourcePath: 'mqtt_bridge',
     } as DbMessage;
     (msg as any).sourceId = sourceId;
     (msg as any).viaStoreForward = true;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2315,6 +2315,8 @@ function transformDbMessageToMeshMessage(msg: DbMessage): MeshMessage {
         ? true
         : undefined,
     decryptedBy: msg.decryptedBy ?? (msg as any).decrypted_by ?? null,
+    sourceIp: (msg as any).sourceIp ?? (msg as any).source_ip ?? null,
+    sourcePath: (msg as any).sourcePath ?? (msg as any).source_path ?? null,
   };
 }
 
@@ -3771,8 +3773,12 @@ apiRouter.post('/messages/send', optionalAuth(), async (req, res) => {
 
     // Send the message to the mesh network (with optional destination for DMs, replyId, and emoji flag)
     // Note: sendTextMessage() now handles saving the message to the database
-    // Pass userId so sent messages are automatically marked as read for the sender
-    await activeManager.sendTextMessage(text, meshChannel, destinationNum, replyId, emoji, req.user?.id);
+    // Pass userId so sent messages are automatically marked as read for the sender.
+    // Attribution: req.ip honors X-Forwarded-For when 'trust proxy' is configured.
+    await activeManager.sendTextMessage(text, meshChannel, destinationNum, replyId, emoji, req.user?.id, {
+      sourceIp: req.ip ?? null,
+      sourcePath: 'http_api',
+    });
 
     res.json({ success: true });
   } catch (error) {
@@ -3863,6 +3869,8 @@ apiRouter.post('/position/request', requirePermission('messages', 'write'), asyn
         timestamp: timestamp,
         rxTime: timestamp,
         createdAt: timestamp,
+        sourceIp: req.ip ?? null,
+        sourcePath: 'http_api',
       });
       logger.info(`📍 Position request system message inserted successfully`);
     } else {
@@ -3928,6 +3936,8 @@ apiRouter.post('/nodeinfo/request', requirePermission('messages', 'write'), asyn
         timestamp: timestamp,
         rxTime: timestamp,
         createdAt: timestamp,
+        sourceIp: req.ip ?? null,
+        sourcePath: 'http_api',
       });
       logger.info(`📇 NodeInfo request system message inserted successfully`);
     } else {

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -34,4 +34,9 @@ export interface MeshMessage {
   requestId?: number; // Packet request ID for tracking
   // Decryption source - 'server' means read-only (cannot reply)
   decryptedBy?: 'node' | 'server' | null;
+  // Per-message ingress attribution. NULL for pre-migration rows.
+  /** Client IP for HTTP-injected sends (honors X-Forwarded-For when trust proxy is configured). */
+  sourceIp?: string | null;
+  /** Categorical message ingress path. */
+  sourcePath?: 'http_api' | 'tcp_radio' | 'mqtt_bridge' | 'system' | null;
 }


### PR DESCRIPTION
## Motivation

Operators investigating duplicate or unexpected mesh broadcasts currently have no way to determine **which client / API caller** injected a specific message via MeshMonitor's send endpoint. The `messages` table already has solid mesh-side attribution (`fromNodeId`, `fromNodeNum`, `viaMqtt`, `hopStart`, `hopLimit`, `viaStoreForward`, `rxSnr`, `rxRssi`, etc.) but no record of the HTTP source for messages injected via `POST /api/messages/send`.

Today operators have to cross-reference packet captures against reverse-proxy access logs to figure out which downstream client sent the duplicate — a problem that a small two-column addition to the `messages` table eliminates.

## What this changes

Adds two **nullable** text columns to the `messages` table:

| Column | Type | Populated for |
|---|---|---|
| `source_ip` | `TEXT` (nullable) | HTTP-injected sends only (honors `X-Forwarded-For` when `trust proxy` is configured) |
| `source_path` | `TEXT` (nullable) | All new rows — enum: `'http_api'` \| `'tcp_radio'` \| `'mqtt_bridge'` \| `'system'` |

### `source_path` mapping

| Value | Set by |
|---|---|
| `http_api` | `POST /api/messages/send`, `POST /api/position/request`, `POST /api/nodeinfo/request` |
| `tcp_radio` | Inbound `TEXT_MESSAGE_APP` / `TRACEROUTE_APP` packets received from a meshtastic node over TCP (`meshtasticManager`) |
| `mqtt_bridge` | Packets ingested via the MQTT bridge (`mqttIngestion`), including Store & Forward replays |
| `system` | Server-internal sends (ping/welcome/etc.) routed through `sendTextMessage` without an HTTP attribution argument |

### Migration

- **Migration 065** (SQLite + PostgreSQL + MySQL) is purely additive: `ALTER TABLE ... ADD COLUMN` with `IF NOT EXISTS` / duplicate-column guards.
- Drizzle schema (`src/db/schema/messages.ts`) gains `sourceIp` + `sourcePath` for all three dialects.
- `DbMessage` unified type gains the two optional fields.
- `MessagesRepository.insertMessage` + `insertMessageSqlite` pass them through.
- HTTP route handlers in `server.ts` populate `sourceIp: req.ip` + `sourcePath: 'http_api'` on the relevant `POST` paths.
- `MeshtasticManager.sendTextMessage` accepts an optional `attribution` argument (defaults to `'system'` when not provided, so internal callers like the auto-ping handler are correctly attributed).
- Inbound radio + MQTT insert sites set `'tcp_radio'` and `'mqtt_bridge'` respectively.
- API response (`transformDbMessageToMeshMessage` in `server.ts` + `MeshMessage` interface in `src/types/message.ts`) surfaces the new fields alongside the existing `decryptedBy` field.

## Backward compatibility

- **Existing rows**: get `NULL` for both columns — no backfill required.
- **Existing API consumers**: ignore the two new optional fields in the response payload.
- **Schema**: both columns are nullable, so any code path that inserts without attribution metadata continues to succeed.
- **Migrations**: idempotent — `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for PG, duplicate-column guard for SQLite, `information_schema` precheck for MySQL.

No breaking change for existing deployments.

## Tests

- New: `src/server/migrations/065_add_message_source_attribution.test.ts` — covers idempotency, NULL backfill of pre-migration rows, and accepting populated values on new inserts.
- Updated: `src/db/migrations.test.ts` (count 64 → 65), `schemaIntegrity.test.ts`, and the messages-repository hand-rolled CREATE TABLE statements in `messages.{insert,purge,bigint,exclude-portnums,migration,timestamp}.test.ts` to include the two new columns.
- `npm run typecheck` — clean.
- `npx vitest run src/db/ src/server/migrations/` — all 32 db test files + all 21 migration test files pass.

## Example API response delta

```diff
 {
   "id": "default_3735928559_1234567890",
   "from": "!deadbeef",
   "to": "!ffffffff",
   "text": "test broadcast",
   "channel": 0,
   "viaMqtt": false,
   "decryptedBy": "node",
+  "sourceIp": "192.0.2.42",
+  "sourcePath": "http_api"
 }
```

For radio-received messages both fields will be `null` and `"tcp_radio"`; for MQTT-bridged messages `null` and `"mqtt_bridge"`; for pre-migration rows both will be `null`.

## Out of scope / future work

- No UI surface for the new fields in this PR — purely operator-facing via DB queries / API. A future PR could add a tooltip on outbound messages showing the originating client IP for admin users.
- No retention or hashing policy for `source_ip` — left as a deployment concern (`source_ip` is only populated when an HTTP client uses the send endpoint, so it's already opt-in via authenticated `POST`).