### PR TITLE
docs: add deployment comparison table to Getting Started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,31 @@ Want a custom configuration generated for you? Try our **[Docker Compose Configu
 
 ## Deployment Methods
 
-MeshMonitor supports multiple deployment options to fit your infrastructure:
+MeshMonitor supports multiple deployment options to fit your infrastructure.
+
+### At a Glance
+
+| Method | Platform | Auto-Upgrade | Complexity | Support |
+|--------|----------|--------------|------------|---------|
+| 🐳 [Docker Compose](#quick-start-with-docker-compose) | Any | ✅ Yes (sidecar) | Low | Official |
+| 🖥️ [Desktop App](/configuration/desktop) | Windows / macOS | ❌ Manual | Very Low | Official |
+| ☸️ [Kubernetes / Helm](/deployment/DEPLOYMENT_GUIDE) | Any | ✅ Yes (image pull) | High | Official |
+| 📦 [Proxmox LXC](/deployment/PROXMOX_LXC_GUIDE) | Proxmox VE | ❌ Manual | Low | Community |
+| ❄️ [NixOS Flake](https://github.com/benjajaja/nixos-rk3588/blob/main/configuration.nix#L580) | NixOS | ✅ Declarative rebuild | Medium | Community |
+| 🔧 [Bare Metal](/deployment/DEPLOYMENT_GUIDE) | Linux / macOS | ❌ Manual | Medium | Community |
+
+### Which Should I Choose?
+
+- **You want the smoothest update experience** → **Docker Compose** with the [auto-upgrade overlay](/configuration/auto-upgrade). One click in the UI pulls a new image and restarts the container.
+- **You're on a single Windows or macOS machine and don't want to think about servers** → **Desktop App**. Updates are manual (download a new installer), but setup is the simplest.
+- **You're running on a Kubernetes cluster** → **Helm chart**. Upgrades are an `image:` tag bump and a `helm upgrade`.
+- **You're a Proxmox VE user** → **Proxmox LXC** for a lightweight, native-feeling install. Note: updates are manual.
+- **You're on NixOS** → **NixOS Flake** for fully declarative deployment. Upgrades happen on `nixos-rebuild`.
+- **You want to run directly on the host with Node.js** → **Bare Metal**. Best for development or custom integrations.
+
+::: tip Auto-Upgrade requires Docker
+Auto-upgrade through the MeshMonitor UI is only available with the Docker Compose deployment (using the `docker-compose.upgrade.yml` overlay). Desktop, Proxmox LXC, and Bare Metal installs must be updated manually. Kubernetes and NixOS handle upgrades through their own native mechanisms (Helm / `nixos-rebuild`), not the in-app button.
+:::
 
 ### Officially Supported
 


### PR DESCRIPTION
## Summary

Implements the deployment comparison table @Yeraze proposed in #3113.

The reporter had trouble figuring out that Docker Compose was the right path for auto-upgrade support — they had to read multiple deployment pages to discover that Proxmox LXC and the Desktop app are manual-update only. This PR adds an at-a-glance table near the top of the Getting Started guide so the trade-offs (platform, auto-upgrade story, complexity, support tier) are visible *before* a user picks a deployment method.

## Changes

- `docs/getting-started.md`:
  - New **"At a Glance"** comparison table covering all 6 deployment methods.
  - New **"Which Should I Choose?"** decision guide mapping common user situations to a recommendation.
  - New tip box clarifying that the in-app auto-upgrade button is Docker-Compose-only (Kubernetes/NixOS upgrade via their own mechanisms, others are manual).
  - All links verified against existing docs (`/configuration/desktop`, `/configuration/auto-upgrade`, `/deployment/DEPLOYMENT_GUIDE`, `/deployment/PROXMOX_LXC_GUIDE`).

## Test plan

- [ ] Visual review of the rendered Getting Started page on docs preview
- [ ] Confirm all internal links resolve (verified against `docs/configuration/` and `docs/deployment/` directory listings — all targets exist)
- [ ] Confirm the VitePress `::: tip` admonition renders correctly

Closes #3113

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDCyZ4FvZjEhMYgBeygudG)_