### PR TITLE
feat(dashboard-map): add Show RF/UDP/MQTT + traceroute + accuracy toggles

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -15,7 +15,29 @@ vi.mock('react-leaflet', () => ({
   Marker: ({ children }: any) => <div data-testid="map-marker">{children}</div>,
   Popup: ({ children }: any) => <div data-testid="map-popup">{children}</div>,
   Polyline: () => <div data-testid="map-polyline" />,
+  Rectangle: () => <div data-testid="map-rectangle" />,
   useMap: () => ({ fitBounds: vi.fn(), setView: vi.fn() }),
+}));
+
+// MapContext is normally provided by DashboardPage; in tests we mock the hook
+// directly so the toggles default to a known state and don't fire any server
+// preference fetches. Defaults below: RF/UDP/MQTT all visible (so transport
+// filtering doesn't drop existing fixture nodes), traceroute/accuracy off.
+vi.mock('../../contexts/MapContext', () => ({
+  useMapContext: () => ({
+    showPaths: false,
+    setShowPaths: vi.fn(),
+    showRoute: false,
+    setShowRoute: vi.fn(),
+    showAccuracyRegions: false,
+    setShowAccuracyRegions: vi.fn(),
+    showRfNodes: true,
+    setShowRfNodes: vi.fn(),
+    showUdpNodes: true,
+    setShowUdpNodes: vi.fn(),
+    showMqttNodes: true,
+    setShowMqttNodes: vi.fn(),
+  }),
 }));
 
 vi.mock('leaflet', () => ({

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -1,19 +1,26 @@
 /**
  * DashboardMap — self-contained map component for the Dashboard page.
  *
- * Renders node markers, marker popups, and neighbor link polylines on a
- * react-leaflet MapContainer. Automatically fits the map bounds to nodes
- * that have valid GPS positions.
+ * Renders node markers, marker popups, neighbor link polylines, traceroute
+ * paths, and position-accuracy regions on a react-leaflet MapContainer.
+ * Automatically fits the map bounds to nodes that have valid GPS positions.
+ *
+ * Map feature toggles (Show RF / UDP / MQTT, Show Traceroute, Show Route
+ * Segments, Show Accuracy Regions) are read from MapContext so they
+ * round-trip through `/api/user/map-preferences` alongside the per-source
+ * NodesTab toggles. DashboardPage wraps this component in a MapProvider.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import 'leaflet/dist/leaflet.css';
-import { MapContainer, TileLayer, Marker, Popup, Polyline, useMap } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Popup, Polyline, Rectangle, useMap } from 'react-leaflet';
 import L from 'leaflet';
 import { createNodeIcon } from '../../utils/mapIcons';
 import { getTilesetById } from '../../config/tilesets';
 import type { CustomTileset } from '../../config/tilesets';
 import DashboardWaypoints from './DashboardWaypoints';
+import { useMapContext } from '../../contexts/MapContext';
+import { nodePassesTransportFilter } from '../../utils/nodeTransport';
 
 export interface DashboardMapProps {
   nodes: any[];
@@ -37,6 +44,44 @@ function getNodeLatLng(node: any): { lat: number; lng: number } | null {
     return { lat, lng };
   }
   return null;
+}
+
+/** SNR → color, matching the per-hop coloring used in MapAnalysis/TraceroutePathsLayer. */
+function snrToColor(snr: number): string {
+  if (snr >= 5) return '#22c55e';
+  if (snr >= 0) return '#eab308';
+  if (snr >= -5) return '#f97316';
+  return '#ef4444';
+}
+
+/** Safe JSON.parse that yields [] on bad/empty input. */
+function parseJsonArray(value: unknown): number[] {
+  if (typeof value !== 'string' || value.length === 0) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Parse the `routePositions` JSON snapshot stored on a traceroute row.
+ * Shape: `{ [nodeNum]: { lat, lng, alt? } }`. Backend emits this so the
+ * frontend can draw the route even if a hop's node has gone stale and
+ * been filtered out of the live nodes list.
+ */
+function parseRoutePositions(value: unknown): Record<number, { lat: number; lng: number }> {
+  if (typeof value !== 'string' || value.length === 0) return {};
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<number, { lat: number; lng: number }>;
+    }
+  } catch {
+    /* ignore */
+  }
+  return {};
 }
 
 // ---------------------------------------------------------------------------
@@ -73,6 +118,7 @@ function MapBoundsUpdater({ positions, sourceId }: MapBoundsUpdaterProps) {
 export default function DashboardMap({
   nodes,
   neighborInfo,
+  traceroutes,
   tilesetId,
   customTilesets,
   defaultCenter,
@@ -81,18 +127,91 @@ export default function DashboardMap({
 }: DashboardMapProps) {
   const tileset = getTilesetById(tilesetId, customTilesets);
 
+  const {
+    showPaths,
+    setShowPaths,
+    showRoute,
+    setShowRoute,
+    showAccuracyRegions,
+    setShowAccuracyRegions,
+    showRfNodes,
+    setShowRfNodes,
+    showUdpNodes,
+    setShowUdpNodes,
+    showMqttNodes,
+    setShowMqttNodes,
+  } = useMapContext();
+
   // Build array of nodes that have valid positions, with their resolved lat/lng.
   // Mirrors NodesTab's processedNodes pipeline (App.tsx): ignored hidden, age cutoff
-  // bypassed by favorites. Dashboard has no "show ignored" / "show stale" toggle,
-  // so both filters apply unconditionally.
+  // bypassed by favorites, transport-class filter from the Map Features panel.
   const cutoffTime = Date.now() / 1000 - maxNodeAgeHours * 60 * 60;
   const nodesWithPosition = nodes
     .filter((n) => !n.isIgnored)
     .filter((n) => n.isFavorite || (n.lastHeard != null && n.lastHeard >= cutoffTime))
+    .filter((n) => nodePassesTransportFilter(n, { showRfNodes, showUdpNodes, showMqttNodes }))
     .map((n) => ({ node: n, pos: getNodeLatLng(n) }))
     .filter((entry): entry is { node: any; pos: { lat: number; lng: number } } => entry.pos !== null);
 
   const nodePositions: [number, number][] = nodesWithPosition.map((e) => [e.pos.lat, e.pos.lng]);
+
+  // nodeNum → [lat, lng] map used to resolve traceroute hop positions. The
+  // unified view merges per-source node rows by nodeNum (see mergeUnifiedSourceData
+  // in useDashboardData.ts), so a single lookup table works across sources.
+  const positionByNodeNum = useMemo(() => {
+    const map = new Map<number, [number, number]>();
+    for (const { node, pos } of nodesWithPosition) {
+      if (typeof node.nodeNum === 'number') {
+        map.set(node.nodeNum, [pos.lat, pos.lng]);
+      }
+    }
+    return map;
+  }, [nodesWithPosition]);
+
+  // Traceroute segments: one Polyline per hop, colored by snrTowards. Empty
+  // unless the user has enabled "Show Route Segments" or "Show Traceroute".
+  //
+  // Position resolution order for each hop:
+  //   1. `tr.routePositions` — JSON snapshot of positions at traceroute time.
+  //      Backend stamps this so the line still draws even when a hop's node
+  //      has aged out of the live nodes list.
+  //   2. live `positionByNodeNum` — current node positions.
+  const tracerouteSegments = useMemo(() => {
+    if (!showPaths && !showRoute) return [];
+    const segs: Array<{
+      key: string;
+      positions: [number, number][];
+      color: string;
+    }> = [];
+    for (const tr of (traceroutes ?? [])) {
+      const route = parseJsonArray(tr?.route);
+      const snrTowards = parseJsonArray(tr?.snrTowards);
+      const fromNum = Number(tr?.fromNodeNum);
+      const toNum = Number(tr?.toNodeNum);
+      if (!Number.isFinite(fromNum) || !Number.isFinite(toNum)) continue;
+      const snapshot = parseRoutePositions(tr?.routePositions);
+      const lookup = (nodeNum: number): [number, number] | undefined => {
+        const snap = snapshot[nodeNum];
+        if (snap && typeof snap.lat === 'number' && typeof snap.lng === 'number') {
+          return [snap.lat, snap.lng];
+        }
+        return positionByNodeNum.get(nodeNum);
+      };
+      const path = [fromNum, ...route.map((n) => Number(n)), toNum];
+      for (let i = 0; i < path.length - 1; i++) {
+        const a = lookup(path[i]);
+        const b = lookup(path[i + 1]);
+        if (!a || !b) continue;
+        const snr = typeof snrTowards[i] === 'number' ? snrTowards[i] : 0;
+        segs.push({
+          key: `tr-${tr.sourceId ?? 'x'}-${tr.id}-${i}`,
+          positions: [a, b],
+          color: snrToColor(snr),
+        });
+      }
+    }
+    return segs;
+  }, [traceroutes, positionByNodeNum, showPaths, showRoute]);
 
   const hasNodes = nodesWithPosition.length > 0;
 
@@ -155,6 +274,63 @@ export default function DashboardMap({
           );
         })}
 
+        {/* Position accuracy regions — drawn from precision_bits, mirroring NodesTab. */}
+        {showAccuracyRegions && nodesWithPosition
+          .filter(({ node }) => {
+            const bits = node.positionPrecisionBits;
+            if (bits === undefined || bits === null) return false;
+            if (bits <= 0 || bits >= 32) return false;
+            // Don't show accuracy region for nodes with user-overridden positions
+            if (node.positionIsOverride) return false;
+            return true;
+          })
+          .map(({ node, pos }) => {
+            // Meshtastic encodes lat/lon as int32 (1 unit = 1e-7 degrees).
+            // With N precision bits, the grid cell side = 2^(32-N) * 1e-7 * 111111 m.
+            // Accuracy (max deviation) is half the grid cell.
+            const metersPerDegree = 111_111;
+            const sizeMeters = Math.pow(2, 32 - node.positionPrecisionBits) * 1e-7 * metersPerDegree;
+            const halfSizeMeters = sizeMeters / 2;
+            const latOffset = halfSizeMeters / metersPerDegree;
+            const metersPerDegreeLng = metersPerDegree * Math.cos(pos.lat * Math.PI / 180);
+            const lngOffset = halfSizeMeters / metersPerDegreeLng;
+            const bounds: [[number, number], [number, number]] = [
+              [pos.lat - latOffset, pos.lng - lngOffset],
+              [pos.lat + latOffset, pos.lng + lngOffset],
+            ];
+            return (
+              <Rectangle
+                key={`accuracy-${node.nodeNum ?? node.nodeId ?? node.user?.id}`}
+                bounds={bounds}
+                pathOptions={{
+                  color: '#888',
+                  fillColor: '#888',
+                  fillOpacity: 0.08,
+                  opacity: 0.5,
+                  weight: 1,
+                }}
+              />
+            );
+          })}
+
+        {/* Route segments — thin SNR-colored hop polylines. */}
+        {showPaths && tracerouteSegments.map((s) => (
+          <Polyline
+            key={`seg-${s.key}`}
+            positions={s.positions}
+            pathOptions={{ color: s.color, weight: 2, opacity: 0.85 }}
+          />
+        ))}
+
+        {/* Traceroute overlay — thicker highlight on top of segments. */}
+        {showRoute && tracerouteSegments.map((s) => (
+          <Polyline
+            key={`route-${s.key}`}
+            positions={s.positions}
+            pathOptions={{ color: '#facc15', weight: 4, opacity: 0.6 }}
+          />
+        ))}
+
         {neighborInfo.map((link, idx) => {
           const { nodeLatitude, nodeLongitude, neighborLatitude, neighborLongitude, bidirectional } = link;
           if (
@@ -184,6 +360,62 @@ export default function DashboardMap({
           );
         })}
       </MapContainer>
+
+      {/* Map Features control panel — mirrors NodesTab's "Features" panel but
+          trimmed to the toggles meaningful on a cross-source map. */}
+      <div className="map-controls dashboard-map-controls">
+        <div className="map-controls-body">
+          <div className="map-controls-title">Features</div>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showPaths}
+              onChange={(e) => setShowPaths(e.target.checked)}
+            />
+            <span>Show Route Segments</span>
+          </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showRoute}
+              onChange={(e) => setShowRoute(e.target.checked)}
+            />
+            <span>Show Traceroute</span>
+          </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showAccuracyRegions}
+              onChange={(e) => setShowAccuracyRegions(e.target.checked)}
+            />
+            <span>Show Accuracy Regions</span>
+          </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showRfNodes}
+              onChange={(e) => setShowRfNodes(e.target.checked)}
+            />
+            <span>Show RF</span>
+          </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showUdpNodes}
+              onChange={(e) => setShowUdpNodes(e.target.checked)}
+            />
+            <span>Show UDP</span>
+          </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showMqttNodes}
+              onChange={(e) => setShowMqttNodes(e.target.checked)}
+            />
+            <span>Show MQTT</span>
+          </label>
+        </div>
+      </div>
 
       {!hasNodes && (
         <div className="dashboard-map-empty">

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { SettingsProvider, useSettings } from '../contexts/SettingsContext';
 import { useAuth } from '../contexts/AuthContext';
 import { useCsrf } from '../contexts/CsrfContext';
+import { MapProvider } from '../contexts/MapContext';
 import {
   useDashboardSources,
   useSourceStatuses,
@@ -1322,7 +1323,9 @@ export default function DashboardPage() {
   return (
     <SettingsProvider>
       <ToastProvider>
-        <DashboardInner />
+        <MapProvider>
+          <DashboardInner />
+        </MapProvider>
       </ToastProvider>
     </SettingsProvider>
   );

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -79,6 +79,7 @@ import {
   TransportMechanism,
 } from './constants/meshtastic.js';
 import { calculateDistance } from '../utils/distance.js';
+import { getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
 import { logger } from '../utils/logger.js';
 import {
   nodeNumToId,
@@ -518,6 +519,26 @@ async function ingestTraceroute(
     );
   }
 
+  // Position snapshot for every hop in the route (mirrors TCP path in
+  // meshtasticManager.ts). The dashboard map and TracerouteWidget rely on
+  // this to draw lines that survive a hop node going stale / un-positioned
+  // after the traceroute was recorded. Uses the effective (override-aware)
+  // position so user-pinned coordinates render correctly.
+  const routePositions: Record<number, { lat: number; lng: number; alt?: number }> = {};
+  const pathNodes = new Set<number>([fromNum, ...route, ...routeBack]);
+  if (toNum !== null && toNum !== BROADCAST_ADDR) pathNodes.add(toNum);
+  for (const nodeNum of pathNodes) {
+    const node = await databaseService.nodes.getNode(nodeNum, sourceId);
+    const eff = getEffectiveDbNodePosition(node);
+    if (eff.latitude != null && eff.longitude != null) {
+      routePositions[nodeNum] = {
+        lat: eff.latitude,
+        lng: eff.longitude,
+        ...(eff.altitude != null ? { alt: eff.altitude } : {}),
+      };
+    }
+  }
+
   const record: DbTraceroute = {
     fromNodeNum: fromNum,
     toNodeNum: toNum ?? 0,
@@ -527,6 +548,7 @@ async function ingestTraceroute(
     routeBack: JSON.stringify(routeBack),
     snrTowards: JSON.stringify(snrTowards),
     snrBack: JSON.stringify(snrBack),
+    routePositions: JSON.stringify(routePositions),
     timestamp: nowMs,
     createdAt: nowMs,
   };

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -171,6 +171,8 @@ export interface DbTraceroute {
   routeBack: string;
   snrTowards: string;
   snrBack: string;
+  /** JSON: `{ [nodeNum]: { lat, lng, alt? } }` — position snapshot at traceroute time. */
+  routePositions?: string;
   timestamp: number;
   createdAt: number;
 }


### PR DESCRIPTION
## Summary

Bring the per-source NodesTab "Map Features" toggles to the unified Dashboard map, plus fix MQTT-sourced traceroutes not drawing.

### Frontend (DashboardMap)
- New "Features" panel (top-right) with six checkboxes, all wired through the existing `MapContext` so state round-trips with the per-source NodesTab toggles via `/api/user/map-preferences`:
  - **Show Route Segments** — per-hop polylines colored by `snrTowards`
  - **Show Traceroute** — yellow highlight overlay on top of segments
  - **Show Accuracy Regions** — `Rectangle` per node from `positionPrecisionBits`
  - **Show RF / UDP / MQTT** — applies `nodePassesTransportFilter` to node markers (and their accuracy regions)
- Hop position resolution prefers each traceroute row's `routePositions` snapshot, falling back to a live `nodeNum → [lat,lng]` map from the merged unified nodes — mirrors `useTraceroutePaths.tsx` and `TracerouteWidget`.
- `DashboardPage` now wraps `DashboardInner` in a `MapProvider` so `useMapContext` is in scope on the dashboard route (it isn't part of `sharedProviders`).

### Backend (MQTT ingestion)
- MQTT-sourced traceroutes were inserting with no `routePositions`, so any hop whose node was a stub (intermediate hops have no live position) or had aged out failed to draw on the dashboard map. `mqttIngestion.ts` now builds the snapshot from `getEffectiveDbNodePosition` for every hop in `from`, `route`, `routeBack`, and `to` — same logic the TCP path in `meshtasticManager.ts` already uses.
- `DbTraceroute` gets the optional `routePositions?: string` field that the schema column has required all along.

### Tests
- `DashboardMap.test.tsx` mocks `useMapContext` and adds `Rectangle` to the `react-leaflet` mock. All 20 existing render-shape tests still pass.
- Full server suite + repo traceroute tests run clean (981 tests).

### Caveat
Existing MQTT traceroute rows in the DB still have empty `routePositions` — they are not backfilled. New MQTT traceroutes ingested after this change carry the snapshot, and the frontend's live-position fallback catches any hop with a known current node position even on legacy rows.

## Test plan
- [x] Vitest: `DashboardMap.test.tsx` (20 passed) and full server tests (981 passed)
- [x] `tsc --noEmit` clean
- [x] Local Docker dev container: toggles render, persist across reload, transport filter visibly drops/restores nodes
- [x] MQTT traceroutes ingested after deploy carry `routePositions` (verified in `dist/server/mqttIngestion.js`)
- [ ] CI must pass (system tests, lint, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)