### PR TITLE
fix(telemetry): suppress duplicate-packet WARN spam in MQTT ingest (#3119)

### DIFF
--- a/src/db/repositories/telemetry.test.ts
+++ b/src/db/repositories/telemetry.test.ts
@@ -427,4 +427,121 @@ describe('TelemetryRepository', () => {
       expect(result!.packetId).toBe(200);
     });
   });
+
+  // Regression: issue #3119 — MQTT bridge/broker re-broadcasts produce
+  // duplicate telemetry inserts. The migration 032 unique index must
+  // suppress them silently (no throw, no [WARN] in caller logs).
+  describe('duplicate packet dedupe (issue #3119)', () => {
+    const NOW = Date.now();
+    const SOURCE = 'mqtt-bridge-test';
+
+    beforeEach(() => {
+      // Apply the migration 032 partial unique index so insertIgnore /
+      // onConflictDoNothing actually has something to conflict against.
+      db.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS telemetry_source_packet_type_uniq
+          ON telemetry(sourceId, nodeNum, packetId, telemetryType)
+          WHERE packetId IS NOT NULL
+      `);
+    });
+
+    it('async insertTelemetry: same packet ingested twice yields one row, no throw', async () => {
+      const row = {
+        nodeId: NODE1,
+        nodeNum: NODE1_NUM,
+        telemetryType: 'batteryLevel',
+        timestamp: NOW,
+        value: 85,
+        unit: '%',
+        createdAt: NOW,
+        packetId: 4242,
+      };
+
+      const first = await repo.insertTelemetry(row, SOURCE);
+      const second = await repo.insertTelemetry(row, SOURCE);
+
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+
+      const results = await repo.getTelemetryByNode(NODE1, 10);
+      expect(results).toHaveLength(1);
+    });
+
+    it('sync insertTelemetrySync: same packet ingested twice yields one row, no throw', () => {
+      const row = {
+        nodeId: NODE1,
+        nodeNum: NODE1_NUM,
+        telemetryType: 'voltage',
+        timestamp: NOW,
+        value: 3.7,
+        unit: 'V',
+        createdAt: NOW,
+        packetId: 9999,
+      };
+
+      // Both calls must complete without throwing.
+      expect(() => repo.insertTelemetrySync(row, SOURCE)).not.toThrow();
+      expect(() => repo.insertTelemetrySync(row, SOURCE)).not.toThrow();
+
+      const rows = db
+        .prepare('SELECT COUNT(*) AS n FROM telemetry WHERE packetId = ?')
+        .get(9999) as { n: number };
+      expect(rows.n).toBe(1);
+    });
+
+    it('different telemetryType from same packet still inserts (constraint includes telemetryType)', async () => {
+      const packetId = 7777;
+      await repo.insertTelemetry({
+        nodeId: NODE1, nodeNum: NODE1_NUM, telemetryType: 'batteryLevel',
+        timestamp: NOW, value: 85, unit: '%', createdAt: NOW, packetId,
+      }, SOURCE);
+      await repo.insertTelemetry({
+        nodeId: NODE1, nodeNum: NODE1_NUM, telemetryType: 'voltage',
+        timestamp: NOW, value: 3.7, unit: 'V', createdAt: NOW, packetId,
+      }, SOURCE);
+
+      const results = await repo.getTelemetryByNode(NODE1, 10);
+      expect(results).toHaveLength(2);
+    });
+
+    it('different sourceId is not deduped (cross-source telemetry preserved)', async () => {
+      const row = {
+        nodeId: NODE1,
+        nodeNum: NODE1_NUM,
+        telemetryType: 'batteryLevel',
+        timestamp: NOW,
+        value: 85,
+        unit: '%',
+        createdAt: NOW,
+        packetId: 5555,
+      };
+
+      const a = await repo.insertTelemetry(row, 'source-a');
+      const b = await repo.insertTelemetry(row, 'source-b');
+
+      expect(a).toBe(true);
+      expect(b).toBe(true);
+
+      const results = await repo.getTelemetryByNode(NODE1, 10);
+      expect(results).toHaveLength(2);
+    });
+
+    it('NULL packetId rows bypass the constraint (synthesized telemetry)', async () => {
+      const row = {
+        nodeId: NODE1,
+        nodeNum: NODE1_NUM,
+        telemetryType: 'derivedMetric',
+        timestamp: NOW,
+        value: 1,
+        unit: '',
+        createdAt: NOW,
+      };
+
+      await repo.insertTelemetry(row, SOURCE);
+      await repo.insertTelemetry(row, SOURCE);
+
+      const results = await repo.getTelemetryByNode(NODE1, 10);
+      expect(results).toHaveLength(2);
+    });
+  });
 });

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -1157,8 +1157,13 @@ export class TelemetryRepository extends BaseRepository {
 
   /**
    * Synchronously insert a telemetry row via Drizzle query builder (SQLite only).
-   * Does NOT apply the unique-on-packetId suppression from insertTelemetry; this
-   * matches the legacy facade sync behavior which always inserts.
+   *
+   * Uses onConflictDoNothing so duplicates colliding on the migration 032
+   * unique index (sourceId, nodeNum, packetId, telemetryType) WHERE packetId
+   * IS NOT NULL are silently dropped — matching the async insertTelemetry.
+   * Without this, MQTT bridge/broker re-broadcasts of the same packet would
+   * raise SQLITE_CONSTRAINT and the caller would log a [WARN] for every
+   * duplicate, drowning out real warnings.
    */
   insertTelemetrySync(telemetryData: DbTelemetry, sourceId?: string): void {
     const db = this.getSqliteDb();
@@ -1180,7 +1185,7 @@ export class TelemetryRepository extends BaseRepository {
     if (sourceId) {
       values.sourceId = sourceId;
     }
-    db.insert(telemetry).values(values).run();
+    db.insert(telemetry).values(values).onConflictDoNothing().run();
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add `onConflictDoNothing()` to `insertTelemetrySync` so duplicate MQTT bridge/broker re-broadcasts are silently swallowed by the migration 032 unique index instead of throwing `SQLITE_CONSTRAINT` and triggering `[WARN] MQTT bridge ... ingest failed: UNIQUE constraint failed: telemetry.sourceId, ...` for every duplicate
- The async `insertTelemetry` and `insertTelemetryBatch` already use `insertIgnore`/`onConflictDoNothing`; the sync sibling was the outlier
- PostgreSQL/MySQL paths route through the async repo and were unaffected

Fixes #3119

## Test plan
- [x] New regression suite `duplicate packet dedupe (issue #3119)` in `telemetry.test.ts`:
  - async insert: 2× same packet → 1 row, returns `true` then `false`, no throw
  - sync insert: 2× same packet → 1 row, neither call throws
  - same packet, different `telemetryType` → both insert (constraint is per-type)
  - same packet, different `sourceId` → both insert (cross-source preserved)
  - NULL `packetId` rows bypass the constraint (synthesized telemetry still allowed)
- [x] All 84 tests in `telemetry.test.ts` + `032_telemetry_packet_dedupe.test.ts` + `mqttIngestion.test.ts` pass
- [ ] Verify in dev container: steady-state logs no longer carry the `UNIQUE constraint failed: telemetry.sourceId...` WARN under normal MQTT bridge+broker traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)