### PR TITLE
feat(meshcore): add Share Contact action

### DIFF
--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -19,12 +19,16 @@ interface MeshCoreContactDetailPanelProps {
    *  MeshCoreActions; unset means the button is hidden (e.g. read-only
    *  embeds that don't have the actions wired up). */
   onResetPath?: (publicKey: string) => Promise<boolean>;
+  /** Trigger CMD_SHARE_CONTACT for this contact, broadcasting their saved
+   *  advert to nearby nodes. Unset hides the Share button. */
+  onShareContact?: (publicKey: string) => Promise<boolean>;
   /** Whether the current user may invoke write actions on this source's
-   *  `nodes` resource. Required to gate the Reset Path button. */
+   *  `nodes` resource. Required to gate the Reset Path / Share buttons. */
   canWriteNodes?: boolean;
-  /** Is the source's device a Companion? CMD_RESET_PATH is companion-only.
-   *  Defaults to `true` so callers that don't pass this still see the button
-   *  when the action handler is supplied. */
+  /** Is the source's device a Companion? Both Reset Path and Share Contact
+   *  are companion-only (CMD_RESET_PATH / CMD_SHARE_CONTACT aren't supported
+   *  by Repeater firmware). Defaults to `true` so callers that don't pass
+   *  this still see the buttons when the action handlers are supplied. */
   isCompanion?: boolean;
 }
 
@@ -34,6 +38,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   contact,
   publicKey,
   onResetPath,
+  onShareContact,
   canWriteNodes = false,
   isCompanion = true,
 }) => {
@@ -44,16 +49,22 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   });
   const [resetting, setResetting] = useState(false);
   const [resetError, setResetError] = useState<string | null>(null);
+  const [sharing, setSharing] = useState(false);
+  const [shareError, setShareError] = useState<string | null>(null);
+  const [shareSuccess, setShareSuccess] = useState(false);
 
   useEffect(() => {
     localStorage.setItem(COLLAPSED_KEY, isCollapsed.toString());
   }, [isCollapsed]);
 
-  // Clear the action's transient error/loading state when the selected
-  // contact changes so a previous failure doesn't bleed into a new node.
+  // Clear transient action state when the selected contact changes so a
+  // previous failure / success doesn't bleed into a new node.
   useEffect(() => {
     setResetError(null);
     setResetting(false);
+    setShareError(null);
+    setSharing(false);
+    setShareSuccess(false);
   }, [publicKey]);
 
   const name = contact?.advName || contact?.name || `${publicKey.substring(0, 8)}…`;
@@ -70,6 +81,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   const pathKnown = typeof pathLen === 'number' && pathLen !== null && pathLen >= 0;
   const canShowResetButton =
     !!onResetPath && canWriteNodes && isCompanion;
+  const canShowShareButton =
+    !!onShareContact && canWriteNodes && isCompanion;
 
   const handleResetPath = async () => {
     if (!onResetPath || resetting) return;
@@ -91,6 +104,33 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
       }
     } finally {
       setResetting(false);
+    }
+  };
+
+  const handleShareContact = async () => {
+    if (!onShareContact || sharing) return;
+    const confirmMessage = t(
+      'meshcore.contact_details.share_contact_confirm',
+      `Broadcast ${name}'s contact info to nearby nodes? This sends a zero-hop advert with their identity, name and position.`,
+    );
+    if (typeof window !== 'undefined' && !window.confirm(confirmMessage)) {
+      return;
+    }
+    setSharing(true);
+    setShareError(null);
+    setShareSuccess(false);
+    try {
+      const ok = await onShareContact(publicKey);
+      if (ok) {
+        setShareSuccess(true);
+        window.setTimeout(() => setShareSuccess(false), 2200);
+      } else {
+        setShareError(
+          t('meshcore.contact_details.share_contact_error', 'Share contact failed.'),
+        );
+      }
+    } finally {
+      setSharing(false);
     }
   };
 
@@ -175,27 +215,52 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
             </div>
           )}
 
-          {/* Reset Path action — companion-only, write-permission-gated.
-              Hidden entirely when the path is already unknown so users
-              don't fire a no-op CMD_RESET_PATH against the device. */}
-          {canShowResetButton && pathKnown && (
+          {/* Contact actions — companion-only, write-permission-gated.
+              Reset Path is hidden when the route is already unknown so
+              users don't fire a no-op CMD_RESET_PATH; Share is always
+              available because the device retransmits the stored advert
+              regardless of route state. Rendered in one card so the
+              actions stay grouped at the bottom of the grid. */}
+          {(canShowResetButton || canShowShareButton) && (canShowShareButton || pathKnown) && (
             <div className="node-detail-card node-detail-card-2col">
               <div className="node-detail-label">
-                {t('meshcore.contact_details.reset_path_label', 'Route')}
+                {t('meshcore.contact_details.actions_label', 'Actions')}
               </div>
               <div className="node-detail-value" style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', flexWrap: 'wrap' }}>
-                <button
-                  type="button"
-                  onClick={handleResetPath}
-                  disabled={resetting}
-                  aria-label={t('meshcore.contact_details.reset_path_button', 'Reset Path')}
-                >
-                  {resetting
-                    ? t('meshcore.contact_details.reset_path_running', 'Resetting…')
-                    : t('meshcore.contact_details.reset_path_button', 'Reset Path')}
-                </button>
+                {canShowResetButton && pathKnown && (
+                  <button
+                    type="button"
+                    onClick={handleResetPath}
+                    disabled={resetting}
+                    aria-label={t('meshcore.contact_details.reset_path_button', 'Reset Path')}
+                  >
+                    {resetting
+                      ? t('meshcore.contact_details.reset_path_running', 'Resetting…')
+                      : t('meshcore.contact_details.reset_path_button', 'Reset Path')}
+                  </button>
+                )}
+                {canShowShareButton && (
+                  <button
+                    type="button"
+                    onClick={handleShareContact}
+                    disabled={sharing}
+                    aria-label={t('meshcore.contact_details.share_contact_button', 'Share Contact')}
+                  >
+                    {sharing
+                      ? t('meshcore.contact_details.share_contact_running', 'Sharing…')
+                      : t('meshcore.contact_details.share_contact_button', 'Share Contact')}
+                  </button>
+                )}
                 {resetError && (
                   <span style={{ color: 'var(--ctp-red)' }} role="alert">{resetError}</span>
+                )}
+                {shareError && (
+                  <span style={{ color: 'var(--ctp-red)' }} role="alert">{shareError}</span>
+                )}
+                {shareSuccess && (
+                  <span style={{ color: 'var(--ctp-green)' }} role="status">
+                    {t('meshcore.contact_details.share_contact_success', 'Advert broadcast.')}
+                  </span>
                 )}
               </div>
             </div>

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -172,6 +172,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                 contact={contactsByKey.get(selected) ?? null}
                 publicKey={selected}
                 onResetPath={actions.resetContactPath}
+                onShareContact={actions.shareContact}
                 canWriteNodes={canWriteNodes && connected}
                 isCompanion={isCompanion}
               />

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -89,6 +89,10 @@ export interface MeshCoreActions {
    *  ACKed the reset; `false` for any error (permission, unknown contact,
    *  source not Companion, network). */
   resetContactPath: (publicKey: string) => Promise<boolean>;
+  /** Broadcast the device's saved advert for a contact as a zero-hop frame so
+   *  nearby nodes can add this contact themselves. Wraps CMD_SHARE_CONTACT.
+   *  Resolves `true` when the device ACKed; `false` for any error. */
+  shareContact: (publicKey: string) => Promise<boolean>;
   sendAdvert: () => Promise<void>;
   sendMessage: (text: string, toPublicKey?: string, channelIdx?: number) => Promise<boolean>;
   setDeviceName: (name: string) => Promise<boolean>;
@@ -437,6 +441,24 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch]);
 
+  const shareContact = useCallback(async (publicKey: string): Promise<boolean> => {
+    try {
+      const response = await csrfFetch(
+        `${mcPrefix}/contacts/${encodeURIComponent(publicKey)}/share`,
+        { method: 'POST' },
+      );
+      const data = await response.json();
+      if (!data.success) {
+        setError(data.error || 'Failed to share contact');
+        return false;
+      }
+      return true;
+    } catch (_err) {
+      setError('Failed to share contact');
+      return false;
+    }
+  }, [mcPrefix, csrfFetch]);
+
   const sendAdvert = useCallback(async () => {
     try {
       const response = await csrfFetch(`${mcPrefix}/advert`, { method: 'POST' });
@@ -607,6 +629,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       disconnect,
       refreshContacts,
       resetContactPath,
+      shareContact,
       sendAdvert,
       sendMessage,
       setDeviceName,

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1289,6 +1289,37 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
+   * Broadcast the device's saved advert for a contact as a zero-hop frame
+   * so nearby nodes can add this contact themselves. Wraps the firmware's
+   * CMD_SHARE_CONTACT; the device only retransmits — no local state is
+   * mutated, so this method does not touch contacts or meshcore_nodes.
+   *
+   * Returns `true` on success, `false` if the device rejected the request
+   * (unknown contact, transient backend error) or this isn't a Companion.
+   */
+  async shareContact(publicKey: string): Promise<boolean> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
+      logger.warn('[MeshCore] Share-contact requires Companion firmware');
+      return false;
+    }
+    if (!this.connected) {
+      return false;
+    }
+    try {
+      const response = await this.sendBridgeCommand('share_contact', { public_key: publicKey });
+      if (!response.success) {
+        logger.warn(`[MeshCore] share_contact failed for ${publicKey}: ${response.error}`);
+        return false;
+      }
+      logger.info(`[MeshCore] Shared contact ${publicKey.substring(0, 16)}…`);
+      return true;
+    } catch (error) {
+      logger.error('[MeshCore] shareContact threw:', error);
+      return false;
+    }
+  }
+
+  /**
    * Login to a remote node for admin access
    */
   async loginToNode(publicKey: string, password: string): Promise<boolean> {

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -202,6 +202,11 @@ class MockConnection extends EventEmitter {
   async resetPath(pubKey: Uint8Array) {
     this.resetPathCalls.push(pubKey);
   }
+
+  public shareContactCalls: Uint8Array[] = [];
+  async shareContact(pubKey: Uint8Array) {
+    this.shareContactCalls.push(pubKey);
+  }
 }
 
 function installMockModule(MockConn: typeof MockConnection): MockConnection {
@@ -801,6 +806,35 @@ describe('MeshCoreNativeBackend', () => {
     const resp = await backend.sendCommand('reset_path', { public_key: 'cafebabe' });
     expect(resp.success).toBe(false);
     expect(resp.error).toMatch(/Reset-path target not found/);
+  });
+
+  it('share_contact forwards the resolved pubkey to the connection', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    const targetBytes = new Uint8Array(32);
+    targetBytes[0] = 0xfe; targetBytes[1] = 0xed; targetBytes[2] = 0xfa; targetBytes[3] = 0xce;
+    conn.contactsResponse = [{ publicKey: targetBytes, type: AdvType.Chat, advName: 'Carol' }];
+
+    const resp = await backend.sendCommand('share_contact', { public_key: 'feedface' });
+    expect(resp.success).toBe(true);
+    expect(conn.shareContactCalls).toHaveLength(1);
+    expect(Array.from(conn.shareContactCalls[0]).slice(0, 4)).toEqual([0xfe, 0xed, 0xfa, 0xce]);
+  });
+
+  it('share_contact returns an error when the contact cannot be resolved', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+
+    const resp = await backend.sendCommand('share_contact', { public_key: 'cafebabe' });
+    expect(resp.success).toBe(false);
+    expect(resp.error).toMatch(/Share-contact target not found/);
   });
 });
 

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -397,6 +397,17 @@ export class MeshCoreNativeBackend extends EventEmitter {
         return { ok: true };
       }
 
+      case 'share_contact': {
+        // Broadcasts the contact's saved advert as a zero-hop frame so
+        // nearby nodes can pick it up. Wraps the firmware's
+        // CMD_SHARE_CONTACT (companion protocol opcode 16); device does
+        // not mutate the contact, it just retransmits the advert.
+        const publicKey = await this.resolvePublicKey(params.public_key as string);
+        if (!publicKey) throw new Error('Share-contact target not found');
+        await c.shareContact(publicKey);
+        return { ok: true };
+      }
+
       case 'send_message': {
         const to = params.to as string | null | undefined;
         const text = String(params.text ?? '');

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -49,6 +49,7 @@ const meshcoreManager = {
   sendAdvert: vi.fn().mockResolvedValue(true),
   refreshContacts: vi.fn().mockResolvedValue(new Map()),
   resetContactPath: vi.fn().mockResolvedValue(true),
+  shareContact: vi.fn().mockResolvedValue(true),
   loginToNode: vi.fn().mockResolvedValue(true),
   requestNodeStatus: vi.fn().mockResolvedValue({ batteryMv: 4200, uptimeSecs: 3600 }),
   setName: vi.fn().mockResolvedValue(true),
@@ -707,6 +708,52 @@ describe('MeshCore Routes', () => {
     it('returns 404 when the source has no registered manager', async () => {
       const response = await authenticatedAgent
         .post(`/api/sources/no-such-source/meshcore/contacts/${VALID_PUBKEY}/reset-path`);
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('POST /api/sources/test-source/meshcore/contacts/:publicKey/share', () => {
+    const VALID_PUBKEY = 'b'.repeat(64);
+
+    beforeEach(() => {
+      meshcoreManager.shareContact.mockReset();
+      meshcoreManager.shareContact.mockResolvedValue(true);
+    });
+
+    it('requires authentication', async () => {
+      const response = await request(app)
+        .post(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/share`);
+      expect(response.status).toBe(401);
+    });
+
+    it('rejects an invalid public key', async () => {
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/contacts/not-hex/share');
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatch(/64-char hex/);
+      expect(meshcoreManager.shareContact).not.toHaveBeenCalled();
+    });
+
+    it('forwards a valid public key to the manager and returns 200', async () => {
+      const response = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/share`);
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.broadcast).toBe(true);
+      expect(meshcoreManager.shareContact).toHaveBeenCalledWith(VALID_PUBKEY);
+    });
+
+    it('returns 409 when the manager rejects (unknown contact / non-companion)', async () => {
+      meshcoreManager.shareContact.mockResolvedValueOnce(false);
+      const response = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/share`);
+      expect(response.status).toBe(409);
+      expect(response.body.success).toBe(false);
+    });
+
+    it('returns 404 when the source has no registered manager', async () => {
+      const response = await authenticatedAgent
+        .post(`/api/sources/no-such-source/meshcore/contacts/${VALID_PUBKEY}/share`);
       expect(response.status).toBe(404);
     });
   });

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -362,6 +362,43 @@ router.post(
 );
 
 /**
+ * POST /api/sources/:id/meshcore/contacts/:publicKey/share
+ *
+ * Broadcast the contact's saved advert as a zero-hop frame so nearby nodes
+ * can pick it up and add it themselves. Wraps the firmware's
+ * CMD_SHARE_CONTACT (companion protocol opcode 16). The device only
+ * retransmits the stored advert; no local state mutates.
+ */
+router.post(
+  '/contacts/:publicKey/share',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const publicKey = req.params.publicKey;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({
+          success: false,
+          error: 'Invalid public key — must be 64-char hex',
+        });
+      }
+      const ok = await managerFor(req).shareContact(publicKey);
+      if (!ok) {
+        return res.status(409).json({
+          success: false,
+          error: 'Share contact failed — contact may be unknown, source disconnected, or not a Companion device',
+        });
+      }
+      res.json({ success: true, broadcast: true });
+    } catch (error) {
+      logger.error('[API] Error sharing contact:', error);
+      res.status(500).json({ success: false, error: 'Failed to share contact' });
+    }
+  },
+);
+
+/**
  * GET /api/meshcore/messages
  * Get recent messages. Optional ?since=<ms-timestamp> returns only messages newer than that time.
  */


### PR DESCRIPTION
## Summary

Slice 3 of the MeshCore path-management series (#3123 was slice 1+2). Adds a Share Contact action that broadcasts a contact's saved advert as a zero-hop frame so nearby nodes can pick it up and add the contact themselves. Wraps the firmware's `CMD_SHARE_CONTACT` (companion protocol opcode 16).

Unlike Reset Path, the device only retransmits the stored advert — no local state mutates. The button is therefore always available regardless of whether a route is known.

- **Native backend** — new `share_contact` bridge command wrapping `connection.shareContact()`. Resolves a hex pubkey via the existing prefix-tolerant `resolvePublicKey` helper, then hands the 32 bytes to meshcore.js.
- **Manager** — `MeshCoreManager.shareContact()` returns boolean, companion-only.
- **Route** — `POST /api/sources/:id/meshcore/contacts/:publicKey/share`, gated by `nodes:write`, 64-char hex validation, 409 on manager rejection, 404 on unknown source. Success body is `{ success: true, broadcast: true }`.
- **Frontend** — `useMeshCore.shareContact()` action; `MeshCoreContactDetailPanel` grows a Share Contact button alongside Reset Path under a unified "Actions" card with a confirm dialog and brief "Advert broadcast." status chip on success.

Still queued: live PathUpdated push handling (slice 4) and the feature-flagged manual path editor (slice 5).

## Test plan
- [x] `npm test` — 10,227 vitest tests pass
- [x] TS clean for my files (3 pre-existing errors in `meshtasticManager.ts` come from unrelated in-progress work in my local tree, confirmed clean via `git stash`)
- [x] New coverage: `share_contact` dispatch happy + unknown-target; route auth, hex validation, manager-rejection (409), unknown source (404), happy path returns broadcast flag
- [ ] Manual smoke against a real Companion device — observe a "Share Contact" click producing an advert that another Companion picks up via `PUSH_CODE_NEW_ADVERT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)