### PR TITLE
feat(stability): manual Resync action for Passive Mode sources (#3122)

### DIFF
--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -34,6 +34,8 @@ interface DashboardSidebarProps {
   onDisconnectSource?: (id: string) => void;
   /** Called when user clicks Prune Outside ROI (kebab) on an mqtt_bridge with a geo bbox. */
   onPruneOutsideRoi?: (id: string) => void;
+  /** Called when user clicks Resync (kebab) on a connected meshtastic_tcp source (#3122). */
+  onResyncSource?: (id: string) => void;
   /** Source IDs currently awaiting a /connect POST — used to show "Connecting..." feedback. */
   connectingIds?: Set<string>;
   /** Mobile drawer state — on desktop the sidebar is always visible. */
@@ -107,11 +109,14 @@ interface KebabMenuProps {
   canDisconnect?: boolean;
   /** When true, render a "Prune Outside ROI" item (mqtt_bridge with a geo bbox). */
   canPruneOutsideRoi?: boolean;
+  /** When true, render a "Resync" item (meshtastic_tcp source currently connected). */
+  canResync?: boolean;
   onEdit: (id: string) => void;
   onToggle: (id: string, enabled: boolean) => void;
   onDelete: (id: string) => void;
   onDisconnect?: (id: string) => void;
   onPruneOutsideRoi?: (id: string) => void;
+  onResync?: (id: string) => void;
 }
 
 const KebabMenu: React.FC<KebabMenuProps> = ({
@@ -119,11 +124,13 @@ const KebabMenu: React.FC<KebabMenuProps> = ({
   sourceEnabled,
   canDisconnect,
   canPruneOutsideRoi,
+  canResync,
   onEdit,
   onToggle,
   onDelete,
   onDisconnect,
   onPruneOutsideRoi,
+  onResync,
 }) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -198,6 +205,19 @@ const KebabMenu: React.FC<KebabMenuProps> = ({
               {t('source.kebab.prune_outside_roi')}
             </button>
           )}
+          {canResync && onResync && (
+            <button
+              className="dashboard-kebab-item"
+              title={t('source.kebab.resync_help', 'Force a fresh config/NodeDB sync from the device. Respects a 30s cooldown.')}
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpen(false);
+                onResync(sourceId);
+              }}
+            >
+              {t('source.kebab.resync', 'Resync')}
+            </button>
+          )}
           <button
             className="dashboard-kebab-item danger"
             onClick={(e) => {
@@ -230,6 +250,7 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
   onConnectSource,
   onDisconnectSource,
   onPruneOutsideRoi,
+  onResyncSource,
   connectingIds,
   mobileOpen = false,
   onMobileClose,
@@ -367,11 +388,16 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
                       status?.connected === true
                     }
                     canPruneOutsideRoi={hasGeoBounds}
+                    canResync={
+                      source.type === 'meshtastic_tcp' &&
+                      status?.connected === true
+                    }
                     onEdit={onEditSource}
                     onToggle={onToggleSource}
                     onDelete={onDeleteSource}
                     onDisconnect={onDisconnectSource}
                     onPruneOutsideRoi={onPruneOutsideRoi}
+                    onResync={onResyncSource}
                   />
                 );
               })()}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -677,6 +677,34 @@ function DashboardInner() {
     setPruneConfirm(id);
   };
 
+  // Manual Resync (#3122 follow-up). Operator-initiated full config refresh
+  // for Meshtastic TCP sources — useful for Passive Mode sources where the
+  // automatic reconnect skips want_config_id while the cache is fresh.
+  // Cooldown / single-flight / watchdog all live on the server; the click
+  // either succeeds (200) or is rejected (409) with state describing why.
+  const onResyncSource = async (id: string) => {
+    const csrfToken = getToken();
+    try {
+      const res = await fetch(`${appBasename}/api/sources/${id}/resync`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-csrf-token': csrfToken || '',
+        },
+      });
+      // Refresh source status either way — a successful resync changes the
+      // connection state once configComplete arrives, and a rejected click
+      // doesn't hurt to re-poll.
+      queryClient.refetchQueries({ queryKey: ['dashboard', 'status', id], type: 'active' });
+      if (!res.ok && res.status !== 409) {
+        logger.warn('Manual resync request failed', { status: res.status });
+      }
+    } catch (err) {
+      logger.error('Manual resync request errored', err);
+    }
+  };
+
   const confirmPrune = async () => {
     if (!pruneConfirm || prunePending) return;
     setPrunePending(true);
@@ -758,6 +786,7 @@ function DashboardInner() {
           onConnectSource={onConnectSource}
           onDisconnectSource={onDisconnectSource}
           onPruneOutsideRoi={onPruneOutsideRoi}
+          onResyncSource={onResyncSource}
           connectingIds={connectingIds}
           mobileOpen={mobileSidebarOpen}
           onMobileClose={() => setMobileSidebarOpen(false)}

--- a/src/server/meshtasticManager.manualResync.test.ts
+++ b/src/server/meshtasticManager.manualResync.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the VirtualNodeServer so tests never bind a real TCP port
+const { VNConstructor } = vi.hoisted(() => ({
+  VNConstructor: vi.fn(function (this: any, _opts: any) {
+    this.start = vi.fn().mockResolvedValue(undefined);
+    this.stop = vi.fn().mockResolvedValue(undefined);
+    this.broadcastToClients = vi.fn().mockResolvedValue(undefined);
+    this.isRunning = () => true;
+    this.getClientCount = () => 0;
+  }),
+}));
+vi.mock('./virtualNodeServer.js', () => ({
+  VirtualNodeServer: VNConstructor,
+}));
+
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    sources: { getSource: vi.fn().mockResolvedValue(null) },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+vi.mock('./meshtasticProtobufService.js', () => {
+  const svc = {
+    createNodeInfo: vi.fn().mockResolvedValue(new Uint8Array()),
+    createFromRadioWithPacket: vi.fn().mockResolvedValue(new Uint8Array()),
+    getPortNumName: (n: number) => `PORT_${n}`,
+    normalizePortNum: (n: any) => (typeof n === 'number' ? n : 0),
+    processPayload: vi.fn(),
+  };
+  return { default: svc, meshtasticProtobufService: svc };
+});
+vi.mock('./services/packetLogService.js', () => ({
+  default: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+  packetLogService: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+}));
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: { isEnabled: () => false, tryDecrypt: vi.fn() },
+}));
+vi.mock('./services/serverEventNotificationService.js', () => ({
+  serverEventNotificationService: {
+    notifyNodeDisconnected: vi.fn().mockResolvedValue(undefined),
+    notifyNodeConnected: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { MeshtasticManager } from './meshtasticManager.js';
+
+/**
+ * Manual Resync (#3122 follow-up) — operator-initiated full config refresh.
+ *
+ * The reporter asked for a way to force a fresh sync even when Passive Mode
+ * would otherwise skip it. The implementation must guard against the failure
+ * mode of "single click turns into a sync loop" via single-flight + cooldown
+ * + watchdog + post-recovery suppress.
+ */
+describe('MeshtasticManager — manual resync (#3122 follow-up)', () => {
+  const seedConnectedManager = (passiveMode = true) => {
+    const mgr = new MeshtasticManager('src-1', {
+      host: '127.0.0.1',
+      port: 4403,
+      passiveMode,
+    } as any) as any;
+    mgr.isConnected = true;
+    // Stub the private sendWantConfigId so we don't try to encode protobufs
+    mgr.sendWantConfigId = vi.fn().mockResolvedValue(undefined);
+    // Seed a cache so passive-mode recovery has something to reuse
+    mgr.localNodeInfo = { nodeNum: 0xaabb, nodeId: '!0000aabb' };
+    mgr.actualDeviceConfig = { device: { role: 0 } };
+    mgr.actualModuleConfig = {};
+    mgr.lastDisconnectAt = Date.now() - 1000;
+    return mgr;
+  };
+
+  beforeEach(() => {
+    VNConstructor.mockClear();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('happy path', () => {
+    it('sends want_config_id and reports inFlight=true', async () => {
+      const mgr = seedConnectedManager();
+
+      const result = await mgr.requestManualResync();
+
+      expect(mgr.sendWantConfigId).toHaveBeenCalledOnce();
+      expect(result.started).toBe(true);
+      expect(result.inFlight).toBe(true);
+      expect(result.cooldownExpiresAt).toBeGreaterThan(Date.now());
+    });
+
+    it('latches suppressNextAutoSync so a post-sync disconnect does not trigger another full sync', async () => {
+      const mgr = seedConnectedManager();
+      await mgr.requestManualResync();
+      expect(mgr.suppressNextAutoSync).toBe(true);
+    });
+
+    it('marks configCaptureComplete=false / isCapturingInitConfig=true so streamed config refreshes the cache', async () => {
+      const mgr = seedConnectedManager();
+      mgr.configCaptureComplete = true;
+      mgr.isCapturingInitConfig = false;
+
+      await mgr.requestManualResync();
+
+      expect(mgr.configCaptureComplete).toBe(false);
+      expect(mgr.isCapturingInitConfig).toBe(true);
+    });
+
+    it('clears in-flight via clearManualResyncInFlight when the watchdog fires', async () => {
+      const mgr = seedConnectedManager();
+      await mgr.requestManualResync();
+      expect(mgr.manualResyncInFlight).toBe(true);
+
+      // Fast-forward past the watchdog timeout (120s).
+      await vi.advanceTimersByTimeAsync(125_000);
+
+      expect(mgr.manualResyncInFlight).toBe(false);
+    });
+  });
+
+  describe('guards', () => {
+    it('rejects a second request while one is in flight', async () => {
+      const mgr = seedConnectedManager();
+      await mgr.requestManualResync();
+
+      const second = await mgr.requestManualResync();
+
+      expect(second.started).toBe(false);
+      expect(second.reason).toBe('in-flight');
+      // First call sent it; second call must not have.
+      expect(mgr.sendWantConfigId).toHaveBeenCalledOnce();
+    });
+
+    it('rejects a follow-up request within the 30s cooldown window', async () => {
+      const mgr = seedConnectedManager();
+      await mgr.requestManualResync();
+      // Simulate that the first resync's configCaptureComplete fired so the
+      // in-flight latch cleared — but we're still inside the cooldown.
+      mgr.clearManualResyncInFlight('configComplete');
+
+      const second = await mgr.requestManualResync();
+      expect(second.started).toBe(false);
+      expect(second.reason).toBe('cooldown');
+      expect(mgr.sendWantConfigId).toHaveBeenCalledOnce();
+    });
+
+    it('allows a new request after the cooldown expires', async () => {
+      const mgr = seedConnectedManager();
+      await mgr.requestManualResync();
+      mgr.clearManualResyncInFlight('configComplete');
+
+      // Fast-forward past the 30s cooldown.
+      await vi.advanceTimersByTimeAsync(31_000);
+
+      const second = await mgr.requestManualResync();
+      expect(second.started).toBe(true);
+      expect(mgr.sendWantConfigId).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects when the source is not connected', async () => {
+      const mgr = seedConnectedManager();
+      mgr.isConnected = false;
+
+      const result = await mgr.requestManualResync();
+      expect(result.started).toBe(false);
+      expect(result.reason).toBe('not-connected');
+      expect(mgr.sendWantConfigId).not.toHaveBeenCalled();
+    });
+
+    it('clears in-flight and suppress flag if sendWantConfigId throws', async () => {
+      const mgr = seedConnectedManager();
+      mgr.sendWantConfigId = vi.fn().mockRejectedValue(new Error('transport gone'));
+
+      const result = await mgr.requestManualResync();
+
+      expect(result.started).toBe(false);
+      expect(result.reason).toBe('send-failed');
+      expect(mgr.manualResyncInFlight).toBe(false);
+      expect(mgr.suppressNextAutoSync).toBe(false);
+    });
+  });
+
+  describe('getManualResyncState()', () => {
+    it('returns inFlight=false, cooldownExpiresAt=0 before any resync', () => {
+      const mgr = seedConnectedManager();
+      expect(mgr.getManualResyncState()).toEqual({ inFlight: false, cooldownExpiresAt: 0 });
+    });
+
+    it('reflects in-flight + cooldownExpiresAt after a successful start', async () => {
+      const mgr = seedConnectedManager();
+      const before = Date.now();
+      await mgr.requestManualResync();
+      const state = mgr.getManualResyncState();
+
+      expect(state.inFlight).toBe(true);
+      expect(state.cooldownExpiresAt).toBeGreaterThanOrEqual(before + 30_000);
+    });
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -413,6 +413,25 @@ class MeshtasticManager implements ISourceManager {
   // transient closes on a large infrastructure node, short enough that genuine
   // config drift self-corrects without a manual refresh.
   private static readonly PASSIVE_RESYNC_STALE_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+  // Manual resync (#3122 follow-up) — operator-initiated full config refresh:
+  //   * forces ONE want_config_id regardless of staleness window
+  //   * single-flight: only one resync at a time per source
+  //   * cooldown (30s) between resyncs to prevent rapid-fire button mashing
+  //     from overwhelming a fragile node
+  //   * watchdog (120s) clears the in-flight flag if config never arrives,
+  //     so a stuck sync can't disable the button forever
+  //   * post-resync reconnect: if the node closes the socket during/after
+  //     the forced sync, recovery reuses the cached config and does NOT
+  //     auto-retry the sync (would just recreate the failure loop)
+  private static readonly MANUAL_RESYNC_COOLDOWN_MS = 30_000;
+  private static readonly MANUAL_RESYNC_WATCHDOG_MS = 120_000;
+  private manualResyncInFlight = false;
+  private manualResyncLastAt: number | null = null;
+  private manualResyncWatchdog: NodeJS.Timeout | null = null;
+  // Latches across the next disconnect/reconnect so recovery skips the
+  // auto re-sync the new connection would otherwise trigger.
+  private suppressNextAutoSync = false;
   // mqttLink runtime state — set up in start()/reconfigureMqttLink().
   private mqttLink: MeshtasticMqttLink | null = null;
   private mqttLinkBroker: import('./mqttBrokerManager.js').MqttBrokerManager | null = null;
@@ -1168,9 +1187,21 @@ class MeshtasticManager implements ISourceManager {
       this.lastDisconnectAt !== null &&
       Date.now() - this.lastDisconnectAt < MeshtasticManager.PASSIVE_RESYNC_STALE_MS;
 
-    // In passive mode with fresh cache: keep localNodeInfo so dependent code
-    // doesn't briefly mark the node un-responsive between connect events.
-    if (!passiveResyncFresh) {
+    // suppressNextAutoSync latches a one-shot skip across a disconnect/reconnect
+    // cycle, used by manual-resync recovery: if the operator's forced sync caused
+    // the node to close the socket, we don't want the reconnect to immediately
+    // retry the same sync and reproduce the failure loop (#3122 follow-up).
+    const consumeSuppressFlag = this.suppressNextAutoSync;
+    if (consumeSuppressFlag) {
+      this.suppressNextAutoSync = false;
+      logger.warn('🟡 [manual-resync recovery] Skipping want_config_id on this reconnect — the previous manual resync did not complete cleanly; cached config will be reused');
+    }
+
+    const skipFullSync = passiveResyncFresh || consumeSuppressFlag;
+
+    // Keep cached localNodeInfo when we're skipping the sync — dependent code
+    // would otherwise briefly mark the node un-responsive between connect events.
+    if (!skipFullSync) {
       // Clear localNodeInfo so node will be marked as not responsive until it sends MyNodeInfo
       this.localNodeInfo = null;
     }
@@ -1179,16 +1210,26 @@ class MeshtasticManager implements ISourceManager {
     await serverEventNotificationService.notifyNodeConnected(this.sourceId, await this.getSourceName());
 
     try {
-      if (passiveResyncFresh) {
+      if (skipFullSync) {
         // Skip the want_config_id handshake. Mesh traffic (received packets)
         // continues to flow without it, and we already have a recent config
         // snapshot. This is the core stability fix for large TCP nodes that
         // close the socket under sync pressure (#3122). Mark capture complete
         // so the post-config scheduler logic still runs (with passive-mode
         // skips applied below).
-        logger.info('🟢 [passive] Skipping want_config_id on reconnect — using cached config from last session');
+        const reason = consumeSuppressFlag
+          ? '🟡 [manual-resync recovery] Skipping want_config_id — using cached config'
+          : '🟢 [passive] Skipping want_config_id on reconnect — using cached config from last session';
+        logger.info(reason);
         this.configCaptureComplete = true;
         this.isCapturingInitConfig = false;
+        // A manual-resync recovery should also clear the in-flight latch so the
+        // operator's button re-enables (the original sync never reached
+        // configComplete, so the normal onConfigCaptureComplete handler
+        // wouldn't have fired). Use 'recovery' so the watchdog cancels cleanly.
+        if (consumeSuppressFlag) {
+          this.clearManualResyncInFlight('recovery');
+        }
         // Run the scheduler callback as if config had just completed. The
         // callback itself honors passiveMode and will skip the outbound burst.
         if (this.onConfigCaptureComplete) {
@@ -1252,6 +1293,10 @@ class MeshtasticManager implements ISourceManager {
       // Chaining would accumulate scheduler starts across reconnects, causing
       // duplicate cron jobs (e.g., 4 reconnects = 4x auto-welcome messages).
       this.onConfigCaptureComplete = () => {
+        // Manual resync completed successfully — clear the in-flight latch and
+        // cancel the watchdog so the operator's button re-enables (after cooldown).
+        this.clearManualResyncInFlight('configComplete');
+
         // Call external callback (e.g., virtual node server init) — registered once, safe to call on every reconnect
         if (this.externalConfigCaptureCallback) {
           try { this.externalConfigCaptureCallback(); } catch (e) { logger.error('❌ Error in external config capture callback:', e); }
@@ -12882,6 +12927,119 @@ class MeshtasticManager implements ISourceManager {
         ? ((msg as any).deliveryState === 'confirmed' ? true : undefined)
         : ((msg as any).deliveryState === 'delivered' || (msg as any).deliveryState === 'confirmed' ? true : undefined)
     }));
+  }
+
+  /**
+   * Operator-initiated manual resync (#3122 follow-up).
+   *
+   * Sends a single want_config_id regardless of passive-mode staleness. Mostly
+   * useful for passive-mode sources where the automatic reconnect path skips
+   * resync while the cached config is "fresh" — the operator may know the node
+   * config actually changed (e.g. a remote channel rekey) and want to refresh.
+   *
+   * Guards:
+   *   * **single-flight** — only one resync in flight per source
+   *   * **cooldown** — MANUAL_RESYNC_COOLDOWN_MS (30s) since last attempt
+   *   * **watchdog** — MANUAL_RESYNC_WATCHDOG_MS (120s) max in-flight; if
+   *     the stream never reaches configComplete, the flag self-clears so the
+   *     button doesn't get stuck disabled
+   *   * **recovery latch** — sets suppressNextAutoSync so a node-side close
+   *     during/after the forced sync doesn't immediately re-trigger another
+   *     full sync on reconnect (which would just reproduce the failure loop)
+   *
+   * Returns the post-call state — caller (HTTP route) can surface inFlight +
+   * cooldownExpiresAt to the UI so the button renders the right state.
+   */
+  async requestManualResync(): Promise<{
+    started: boolean;
+    inFlight: boolean;
+    cooldownExpiresAt: number;
+    reason?: 'cooldown' | 'in-flight' | 'not-connected' | 'send-failed';
+  }> {
+    const now = Date.now();
+    const cooldownExpiresAt =
+      this.manualResyncLastAt !== null
+        ? this.manualResyncLastAt + MeshtasticManager.MANUAL_RESYNC_COOLDOWN_MS
+        : 0;
+
+    if (this.manualResyncInFlight) {
+      logger.debug('🟡 [manual-resync] Rejected — already in flight');
+      return { started: false, inFlight: true, cooldownExpiresAt, reason: 'in-flight' };
+    }
+    if (now < cooldownExpiresAt) {
+      logger.debug(`🟡 [manual-resync] Rejected — cooldown until ${new Date(cooldownExpiresAt).toISOString()}`);
+      return { started: false, inFlight: false, cooldownExpiresAt, reason: 'cooldown' };
+    }
+    if (!this.isConnected) {
+      logger.debug('🟡 [manual-resync] Rejected — not connected');
+      return { started: false, inFlight: false, cooldownExpiresAt, reason: 'not-connected' };
+    }
+
+    logger.info('🟡 [manual-resync] Operator-initiated resync — sending want_config_id');
+    this.manualResyncInFlight = true;
+    this.manualResyncLastAt = now;
+    // Latch the suppress flag BEFORE sending so a same-tick disconnect (which
+    // can happen on a fragile node) is observed by handleDisconnected → reconnect
+    // before this method returns.
+    this.suppressNextAutoSync = true;
+    // Mark config capture as resuming so streamed FromRadio entries refresh
+    // the cached snapshot rather than being dropped as "already complete".
+    this.configCaptureComplete = false;
+    this.isCapturingInitConfig = true;
+
+    // Watchdog: clear in-flight if the stream never lands.
+    if (this.manualResyncWatchdog) clearTimeout(this.manualResyncWatchdog);
+    this.manualResyncWatchdog = setTimeout(() => {
+      if (this.manualResyncInFlight) {
+        logger.warn(`⚠️ [manual-resync] Watchdog fired after ${MeshtasticManager.MANUAL_RESYNC_WATCHDOG_MS / 1000}s — clearing in-flight latch`);
+        this.clearManualResyncInFlight('watchdog');
+      }
+    }, MeshtasticManager.MANUAL_RESYNC_WATCHDOG_MS);
+
+    try {
+      await this.sendWantConfigId();
+    } catch (sendErr) {
+      const msg = sendErr instanceof Error ? sendErr.message : String(sendErr);
+      logger.warn(`⚠️ [manual-resync] sendWantConfigId failed: ${msg}`);
+      // Send-time failure means the request never reached the node, so the
+      // suppress latch and in-flight aren't useful — clear them so the
+      // operator can retry (subject to cooldown).
+      this.clearManualResyncInFlight('send-failed');
+      this.suppressNextAutoSync = false;
+      return { started: false, inFlight: false, cooldownExpiresAt: now + MeshtasticManager.MANUAL_RESYNC_COOLDOWN_MS, reason: 'send-failed' };
+    }
+
+    return {
+      started: true,
+      inFlight: true,
+      cooldownExpiresAt: now + MeshtasticManager.MANUAL_RESYNC_COOLDOWN_MS,
+    };
+  }
+
+  /**
+   * Returns a serializable snapshot of manual-resync state for the HTTP layer.
+   * Surfaced to the UI so the Resync button can render disabled/enabled state
+   * and a countdown until the cooldown expires.
+   */
+  getManualResyncState(): { inFlight: boolean; cooldownExpiresAt: number } {
+    const cooldownExpiresAt =
+      this.manualResyncLastAt !== null
+        ? this.manualResyncLastAt + MeshtasticManager.MANUAL_RESYNC_COOLDOWN_MS
+        : 0;
+    return { inFlight: this.manualResyncInFlight, cooldownExpiresAt };
+  }
+
+  /**
+   * Idempotent helper used by configComplete + recovery + watchdog + send-failed
+   * paths. Always cancels the outstanding watchdog so a stale timer can't fire
+   * later and flip the latch back off after a new resync started.
+   */
+  private clearManualResyncInFlight(_reason: 'configComplete' | 'recovery' | 'watchdog' | 'send-failed'): void {
+    this.manualResyncInFlight = false;
+    if (this.manualResyncWatchdog) {
+      clearTimeout(this.manualResyncWatchdog);
+      this.manualResyncWatchdog = null;
+    }
   }
 
   // Public method to trigger manual refresh of node database

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -992,6 +992,61 @@ router.post('/:id/disconnect', requirePermission('sources', 'write'), async (req
   }
 });
 
+// POST /api/sources/:id/resync — operator-initiated full config refresh
+// (#3122 follow-up). Forces a single want_config_id even when Passive Mode
+// would otherwise skip it for cache-freshness. Returns the manual-resync
+// state (inFlight + cooldownExpiresAt) so the UI button renders correctly.
+//
+// Status codes:
+//   200 — resync started, inFlight=true, cooldownExpiresAt populated
+//   404 — source not found
+//   400 — source type doesn't support resync (only meshtastic_tcp)
+//   409 — another resync is in flight OR cooldown still active OR not connected
+//
+// Errors carry the same JSON shape as a success so the UI can keep its
+// disabled/cooldown timer state in sync with the server's reality without
+// special-casing the response shape.
+router.post('/:id/resync', requirePermission('sources', 'write'), async (req: Request, res: Response) => {
+  try {
+    const source = await databaseService.sources.getSource(req.params.id);
+    if (!source) return res.status(404).json({ error: 'Source not found' });
+    if (source.type !== 'meshtastic_tcp') {
+      return res.status(400).json({ error: 'Manual resync is only supported on meshtastic_tcp sources' });
+    }
+    const mgr = sourceManagerRegistry.getManager(source.id) as MeshtasticManager | undefined;
+    if (!mgr || typeof mgr.requestManualResync !== 'function') {
+      return res.status(409).json({ error: 'Source manager is not running', reason: 'not-connected' });
+    }
+    const result = await mgr.requestManualResync();
+    const status = result.started ? 200 : 409;
+    return res.status(status).json(result);
+  } catch (err) {
+    logger.error('Error triggering manual resync:', err);
+    res.status(500).json({ error: 'Failed to trigger manual resync' });
+  }
+});
+
+// GET /api/sources/:id/resync — query the current manual-resync state
+// (inFlight + cooldownExpiresAt). Used by the UI to poll while a resync
+// is running so the button enables/disables in real time.
+router.get('/:id/resync', requirePermission('sources', 'read'), async (req: Request, res: Response) => {
+  try {
+    const source = await databaseService.sources.getSource(req.params.id);
+    if (!source) return res.status(404).json({ error: 'Source not found' });
+    if (source.type !== 'meshtastic_tcp') {
+      return res.json({ inFlight: false, cooldownExpiresAt: 0 });
+    }
+    const mgr = sourceManagerRegistry.getManager(source.id) as MeshtasticManager | undefined;
+    if (!mgr || typeof mgr.getManualResyncState !== 'function') {
+      return res.json({ inFlight: false, cooldownExpiresAt: 0 });
+    }
+    res.json(mgr.getManualResyncState());
+  } catch (err) {
+    logger.error('Error fetching manual resync state:', err);
+    res.status(500).json({ error: 'Failed to fetch manual resync state' });
+  }
+});
+
 // POST /api/sources/:id/prune-outside-roi — surgical cleanup of node rows
 // whose last-known position is outside the bridge's geo bbox. Only valid for
 // mqtt_bridge sources that have downlinkFilters.geo configured. Forward-only


### PR DESCRIPTION
Follow-up to #3125. Implements the Manual Resync action the reporter called out as item 1 in their feedback on the issue.

## Why

With Passive Mode enabled, automatic reconnects skip \`want_config_id\` while the cached config is "fresh" (< 4 h). That's the right default for stability, but it leaves the operator without a way to force a refresh when they *know* the device config changed (remote channel rekey, hwModel swap, role change). This adds a per-source action that forces exactly one full sync, with guards so the forced sync can't accidentally become a new failure loop.

## What

- **\`MeshtasticManager.requestManualResync()\`** — public method that sends a single \`want_config_id\` regardless of staleness.
  - Single-flight: only one resync in flight per source.
  - Cooldown: 30 s between attempts (\`MANUAL_RESYNC_COOLDOWN_MS\`).
  - Watchdog: 120 s max in-flight (\`MANUAL_RESYNC_WATCHDOG_MS\`). If the device never reaches \`configComplete\`, the watchdog clears the latch so the button isn't stuck disabled.
  - Recovery latch (\`suppressNextAutoSync\`): if the forced sync causes the node to close the socket, the next connect re-uses the cached config and does **not** auto-retry the sync. This is the reporter's "do not let a forced sync turn into a new failure loop" requirement.
- **HTTP routes** in \`sourceRoutes.ts\`:
  - \`POST /api/sources/:id/resync\` → starts a resync. 200 with \`{started, inFlight, cooldownExpiresAt}\`; 409 with a \`reason\` when rejected (in-flight / cooldown / not-connected / send-failed); 400 for non-Meshtastic sources.
  - \`GET /api/sources/:id/resync\` → reads current \`{inFlight, cooldownExpiresAt}\` for the UI.
- **UI**: \"Resync\" kebab item on connected meshtastic_tcp source cards. Click POSTs and re-fetches source status so the dot updates.

## What's *not* in this PR

- A live cooldown countdown / disabled-button state polled from \`GET /resync\`. v1 surfaces cooldown via the server's 409 response; if the operator clicks during cooldown the request is rejected server-side without ill effect. Worth a follow-up if the silent rejection feels unfriendly.
- Toast / popover feedback for success vs cooldown. The kebab close + status refetch is the current UX. Easy to layer on later.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`src/server/meshtasticManager.manualResync.test.ts\` (11 tests): happy path, suppress latch set, capture state reset, single-flight rejection, cooldown rejection, post-cooldown allow, not-connected rejection, send-failed cleanup, watchdog timeout, state-query getter
- [x] Full suite: 5275 pass / 3 pre-existing fails (\`mqttBrokerManager\` zero-hop encode failures; reproduce on clean main, unrelated)
- [ ] Manual smoke against a real meshtastic_tcp source

Fixes the manual-Resync follow-up from #3122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)