### PR TITLE
feat(meshcore): live path updates via debounced PathUpdated push

### DIFF
--- a/src/server/meshcoreManager.contactPersistence.test.ts
+++ b/src/server/meshcoreManager.contactPersistence.test.ts
@@ -106,9 +106,14 @@ describe('MeshCoreManager contact persistence (issue #3092)', () => {
     );
   });
 
-  it('preserves the existing advType when contact_path_updated fires later', async () => {
-    // Path updates carry no advert metadata; the manager must not
-    // overwrite the previously-learned advType with null/undefined.
+  it('does not directly upsert on contact_path_updated (refresh is debounced)', async () => {
+    // Slice 4 change: the PUSH_CODE_PATH_UPDATED frame body is just the
+    // pubkey, so the only way to learn the new path bytes is to re-read
+    // the contact record from the device. The push handler now schedules
+    // a debounced refreshContacts() call instead of upserting a stub
+    // immediately. The in-memory advType from the prior advert is
+    // preserved (no synchronous overwrite), and the refresh happens
+    // off-timer — covered by the debounce-specific tests below.
     const manager = new MeshCoreManager('src-a');
     dispatchBridgeEvent(manager, {
       event_type: 'contact_advertised',
@@ -129,14 +134,8 @@ describe('MeshCoreManager contact persistence (issue #3092)', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(upsertNode).toHaveBeenCalledTimes(1);
-    expect(upsertNode).toHaveBeenCalledWith(
-      expect.objectContaining({
-        publicKey: REPEATER_PUBKEY,
-        advType: MeshCoreDeviceType.REPEATER,
-      }),
-      'src-a',
-    );
+    expect(upsertNode).not.toHaveBeenCalled();
+    expect(manager.getContact(REPEATER_PUBKEY)?.advType).toBe(MeshCoreDeviceType.REPEATER);
   });
 
   it('logs but does not throw when the DB upsert fails', async () => {

--- a/src/server/meshcoreManager.pathUpdate.test.ts
+++ b/src/server/meshcoreManager.pathUpdate.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for MeshCoreManager's debounced response to PUSH_CODE_PATH_UPDATED
+ * (slice 4 of MeshCore path management).
+ *
+ * The push frame body is just the affected pubkey — the new path bytes
+ * live on the contact record itself. meshcore.js doesn't expose
+ * CMD_GET_CONTACT_BY_KEY yet, so the manager falls back to
+ * refreshContacts() coalesced over a {@link PATH_REFRESH_DEBOUNCE_MS}
+ * window so a chatty contact churning its route doesn't thunder the
+ * device.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const upsertNode = vi.fn().mockResolvedValue(undefined);
+const emitMeshCoreContactUpdated = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      upsertNode: (...args: unknown[]) => upsertNode(...args),
+    },
+  },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: {
+    emitMeshCoreContactUpdated: (...args: unknown[]) => emitMeshCoreContactUpdated(...args),
+    emitMeshCoreMessage: vi.fn(),
+    emitMeshCoreSelfInfoUpdated: vi.fn(),
+  },
+}));
+
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+interface BridgeEvent {
+  event_type: string;
+  data: Record<string, unknown>;
+}
+
+function dispatchBridgeEvent(m: MeshCoreManager, evt: BridgeEvent): void {
+  // @ts-expect-error - exercising private method
+  m.handleBridgeEvent(evt);
+}
+
+function makeCompanionManager(): {
+  manager: MeshCoreManager;
+  bridgeCalls: Array<{ cmd: string; params: Record<string, unknown> }>;
+  contactsResponse: { value: unknown };
+} {
+  const m = new MeshCoreManager('src-a');
+  // Force device type so refreshContacts() doesn't short-circuit on the
+  // "not Companion" branch.
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  const bridgeCalls: Array<{ cmd: string; params: Record<string, unknown> }> = [];
+  const contactsResponse: { value: unknown } = {
+    value: [
+      {
+        public_key: 'a'.repeat(64),
+        adv_name: 'Bob',
+        name: 'Bob',
+        adv_type: MeshCoreDeviceType.COMPANION,
+        latitude: 0,
+        longitude: 0,
+        last_advert: 0,
+        out_path: 'a3,7f,02',
+        path_len: 3,
+      },
+    ],
+  };
+
+  (m as any).sendBridgeCommand = async (cmd: string, params: Record<string, unknown>) => {
+    bridgeCalls.push({ cmd, params });
+    if (cmd === 'get_contacts') {
+      return { id: '1', success: true, data: contactsResponse.value };
+    }
+    return { id: '1', success: true, data: {} };
+  };
+
+  return { manager: m, bridgeCalls, contactsResponse };
+}
+
+describe('MeshCoreManager — PUSH_CODE_PATH_UPDATED debounce', () => {
+  beforeEach(() => {
+    upsertNode.mockClear();
+    emitMeshCoreContactUpdated.mockClear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('coalesces multiple path-updated pushes into a single refreshContacts() call', async () => {
+    const { manager, bridgeCalls } = makeCompanionManager();
+    const PUBKEY = 'a'.repeat(64);
+
+    // Three pushes inside the debounce window — should collapse to one refresh.
+    dispatchBridgeEvent(manager, { event_type: 'contact_path_updated', data: { public_key: PUBKEY } });
+    dispatchBridgeEvent(manager, { event_type: 'contact_path_updated', data: { public_key: PUBKEY } });
+    dispatchBridgeEvent(manager, { event_type: 'contact_path_updated', data: { public_key: PUBKEY } });
+
+    // Nothing should have hit the wire yet — we're inside the window.
+    expect(bridgeCalls).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(1600);
+
+    const getContactsCalls = bridgeCalls.filter(c => c.cmd === 'get_contacts');
+    expect(getContactsCalls).toHaveLength(1);
+  });
+
+  it('updates in-memory contact with the new path bytes after refresh', async () => {
+    const { manager } = makeCompanionManager();
+    const PUBKEY = 'a'.repeat(64);
+
+    dispatchBridgeEvent(manager, { event_type: 'contact_path_updated', data: { public_key: PUBKEY } });
+    await vi.advanceTimersByTimeAsync(1600);
+    // refreshContacts → persistContact runs via `void`; flush microtasks.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const contact = manager.getContact(PUBKEY);
+    expect(contact?.outPath).toBe('a3,7f,02');
+    expect(contact?.pathLen).toBe(3);
+  });
+
+  it('emits a contact-updated WS event for each affected pubkey post-refresh', async () => {
+    const { manager } = makeCompanionManager();
+    const PUBKEY = 'a'.repeat(64);
+
+    dispatchBridgeEvent(manager, { event_type: 'contact_path_updated', data: { public_key: PUBKEY } });
+    await vi.advanceTimersByTimeAsync(1600);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(emitMeshCoreContactUpdated).toHaveBeenCalledTimes(1);
+    expect(emitMeshCoreContactUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicKey: PUBKEY,
+        outPath: 'a3,7f,02',
+        pathLen: 3,
+      }),
+      'src-a',
+    );
+  });
+
+  it('does not emit for pubkeys that no longer appear in the refreshed list', async () => {
+    // Push arrives for X, but by the time we refresh the device has dropped
+    // X (e.g. contacts-table aging). We shouldn't synthesize a fake row —
+    // the WS event would push stale path bytes back into the UI.
+    const { manager, contactsResponse } = makeCompanionManager();
+    const X = 'b'.repeat(64);
+    contactsResponse.value = []; // empty refresh
+
+    dispatchBridgeEvent(manager, { event_type: 'contact_path_updated', data: { public_key: X } });
+    await vi.advanceTimersByTimeAsync(1600);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(emitMeshCoreContactUpdated).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -317,6 +317,14 @@ class MeshCoreManager extends EventEmitter {
   private heartbeatTimer: NodeJS.Timeout | null = null;
   private reconnectTimer: NodeJS.Timeout | null = null;
   private heartbeatConsecutiveFailures: number = 0;
+
+  /** Coalescing state for `contact_path_updated` pushes. Multiple pushes
+   *  within {@link PATH_REFRESH_DEBOUNCE_MS} collapse to a single
+   *  refreshContacts() call so a chatty contact churning its route doesn't
+   *  thunder the device. The set tracks which pubkeys had pushes during
+   *  the window — purely for logging; the refresh fetches everything. */
+  private pathRefreshTimer: NodeJS.Timeout | null = null;
+  private pathRefreshPendingKeys: Set<string> = new Set();
   private heartbeatLastSuccessAt: number | null = null;
   private heartbeatProbeInFlight: boolean = false;
   private reconnectAttempts: number = 0;
@@ -332,6 +340,12 @@ class MeshCoreManager extends EventEmitter {
 
   // Message limit to prevent unbounded growth
   private static readonly MAX_MESSAGES = 1000;
+
+  /** Window over which we coalesce `contact_path_updated` pushes into a
+   *  single device-side refreshContacts() call. Long enough to absorb a
+   *  flurry from one chatty contact churning its route, short enough that
+   *  the UI feels live. */
+  private static readonly PATH_REFRESH_DEBOUNCE_MS = 1500;
 
   /**
    * Wall-clock timestamp (ms) of the most recent outbound RF operation
@@ -477,6 +491,10 @@ class MeshCoreManager extends EventEmitter {
     // Stop heartbeat before tearing down the transport so a stray probe
     // doesn't fire mid-teardown.
     this.stopHeartbeat();
+
+    // Cancel any pending path-refresh — refreshContacts() against a torn-
+    // down connection would just log an error.
+    this.clearPathRefreshTimer();
 
     // Tear down native backend, if active.
     if (this.nativeBackend) {
@@ -633,17 +651,15 @@ class MeshCoreManager extends EventEmitter {
     } else if (event_type === 'contact_path_updated') {
       const publicKey: string = data.public_key;
       if (publicKey) {
-        const existing = this.contacts.get(publicKey) ?? { publicKey };
-        const updated: MeshCoreContact = {
-          ...existing,
-          publicKey,
-          lastSeen: Date.now(),
-        };
-        this.contacts.set(publicKey, updated);
-        void this.persistContact(updated);
-        this.emit('contacts_updated', { sourceId: this.sourceId, contact: updated });
-        dataEventEmitter.emitMeshCoreContactUpdated(updated, this.sourceId);
-        logger.info(`[MeshCore] contact_path_updated for ${publicKey}`);
+        // The firmware's PUSH_CODE_PATH_UPDATED frame body is just the
+        // pubkey — the new path bytes live on the contact record itself,
+        // so we have to re-read the contact list to actually learn them.
+        // meshcore.js doesn't expose CMD_GET_CONTACT_BY_KEY yet (the only
+        // single-contact fetcher in the firmware), so refreshContacts()
+        // is what's available. Coalesce pushes in a debounce window so a
+        // chatty contact churning its route doesn't thunder the device.
+        this.schedulePathRefresh(publicKey);
+        logger.info(`[MeshCore] contact_path_updated for ${publicKey} (refresh scheduled)`);
       }
     } else {
       logger.debug(`[MeshCore] Unknown push event: ${event_type}`);
@@ -1103,6 +1119,62 @@ class MeshCoreManager extends EventEmitter {
     }
 
     return this.localNode;
+  }
+
+  /**
+   * Schedule a coalesced contact-list refresh in response to a
+   * `contact_path_updated` push (firmware's PUSH_CODE_PATH_UPDATED). The
+   * push body carries only the affected pubkey, so we need to re-read the
+   * contact record to learn the new path bytes. Multiple pushes inside
+   * the {@link PATH_REFRESH_DEBOUNCE_MS} window collapse to a single
+   * refreshContacts() call.
+   *
+   * Cleared on disconnect so a teardown can't fire a refresh against a
+   * dead connection.
+   */
+  private schedulePathRefresh(publicKey: string): void {
+    this.pathRefreshPendingKeys.add(publicKey);
+    if (this.pathRefreshTimer !== null) {
+      return; // already scheduled — the open window will pick this up
+    }
+    this.pathRefreshTimer = setTimeout(() => {
+      this.pathRefreshTimer = null;
+      const pending = Array.from(this.pathRefreshPendingKeys);
+      this.pathRefreshPendingKeys.clear();
+      logger.info(
+        `[MeshCore:${this.sourceId}] Refreshing contacts after ${pending.length} path-update push(es)`,
+      );
+      void this.refreshContacts()
+        .then(() => {
+          // refreshContacts() persists to DB but doesn't emit per-row
+          // WS events. Emit one update per affected pubkey so the UI
+          // flips the Hops/Path cells live without a full snapshot
+          // reload. We only emit for pubkeys we know about post-refresh
+          // — a path-update push for a contact that's since been
+          // removed shouldn't manufacture a fake row.
+          for (const key of pending) {
+            const fresh = this.contacts.get(key);
+            if (fresh) {
+              this.emit('contacts_updated', { sourceId: this.sourceId, contact: fresh });
+              dataEventEmitter.emitMeshCoreContactUpdated(fresh, this.sourceId);
+            }
+          }
+        })
+        .catch((err) => {
+          logger.warn(
+            `[MeshCore:${this.sourceId}] Path-refresh refreshContacts threw: ${(err as Error).message}`,
+          );
+        });
+    }, MeshCoreManager.PATH_REFRESH_DEBOUNCE_MS);
+  }
+
+  /** Test/disconnect hook: cancel any scheduled path-refresh. */
+  private clearPathRefreshTimer(): void {
+    if (this.pathRefreshTimer !== null) {
+      clearTimeout(this.pathRefreshTimer);
+      this.pathRefreshTimer = null;
+    }
+    this.pathRefreshPendingKeys.clear();
   }
 
   /**


### PR DESCRIPTION
## Summary

Slice 4 of the MeshCore path-management series (after #3123 / #3124).

The firmware's `PUSH_CODE_PATH_UPDATED` push announces a route change but the frame body is only the affected pubkey — the new path bytes live on the contact record itself. Before this change the manager stamped `lastSeen` on receipt but never re-read the contact, so `out_path` / `path_len` rendered stale in the UI until the next manual contacts refresh.

meshcore.js doesn't yet expose `CMD_GET_CONTACT_BY_KEY` (the firmware's single-contact fetcher), so the practical fix is to coalesce pushes into one `refreshContacts()` round-trip per **1.5 s** debounce window. A chatty contact churning its route across several pushes costs one device sync instead of N.

## Changes

- `PATH_REFRESH_DEBOUNCE_MS = 1500` class constant + per-manager `pathRefreshTimer` / `pathRefreshPendingKeys` state.
- `contact_path_updated` handler now calls `schedulePathRefresh(pubkey)` instead of upserting a stub row.
- After the window fires:
  - `refreshContacts()` runs once.
  - For each pending pubkey **that still appears in the refreshed list**, the manager emits `contact_updated` (in-process) and `dataEventEmitter.emitMeshCoreContactUpdated` (WS). A contact aged out during the window doesn't synthesize a fake UI row.
- `disconnect()` clears the timer and the pending set so teardown can't fire against a dead connection.

The frontend's existing `meshcore:contact:updated` socket handler picks up the new `outPath` / `pathLen` automatically — no UI changes needed.

## Test plan
- [x] `npm test` — 10,231 vitest tests pass
- [x] `npx tsc --noEmit` clean
- [x] New coverage in `meshcoreManager.pathUpdate.test.ts`: three back-to-back pushes collapse to one `get_contacts` call; in-memory contact picks up new path bytes; one WS emit per pending pubkey; no emit for pubkeys absent from the refresh
- [x] Existing `contactPersistence.test.ts` updated for the new behavior (no synchronous upsert on path_updated; cached advType still preserved because the handler doesn't touch the in-memory contact)
- [ ] Manual smoke against a real Companion that churns routes (e.g. force a flood via Reset Path then a direct send) — confirm the UI flips Hops/Path without a refresh click

## What's queued
Slice 5 (feature-flagged manual path editor) is the last piece. Pick up whenever ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)