### PR TITLE
feat(stability): startup-grace fast reconnect for Passive Mode (#3122)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -413,6 +413,14 @@ class MeshtasticManager implements ISourceManager {
   // transient closes on a large infrastructure node, short enough that genuine
   // config drift self-corrects without a manual refresh.
   private static readonly PASSIVE_RESYNC_STALE_MS = 4 * 60 * 60 * 1000; // 4 hours
+  // Startup-grace fast reconnect for passive-mode sources (#3122 follow-up).
+  // The reporter observed that a large infrastructure node usually closes
+  // the *first* config-sync session but recovers cleanly on the next attempt;
+  // a brief grace window with a 3s delay shortens the user-visible
+  // "stuck reconnecting" gap during startup without changing the steady-state
+  // backoff once the session stabilizes.
+  private static readonly STARTUP_GRACE_WINDOW_MS = 2 * 60 * 1000; // 2 minutes
+  private static readonly STARTUP_GRACE_FAST_DELAY_MS = 3_000; // 3 seconds
 
   // Manual resync (#3122 follow-up) — operator-initiated full config refresh:
   //   * forces ONE want_config_id regardless of staleness window
@@ -1051,6 +1059,17 @@ class MeshtasticManager implements ISourceManager {
         tcpTransport.setStaleConnectionTimeout(env.meshtasticStaleConnectionTimeout);
         tcpTransport.setConnectTimeout(env.meshtasticConnectTimeoutMs);
         tcpTransport.setReconnectTiming(env.meshtasticReconnectInitialDelayMs, env.meshtasticReconnectMaxDelayMs);
+        // Passive-mode sources get a startup-grace fast-reconnect window
+        // (#3122). On large/fragile TCP nodes the first session often closes
+        // mid-sync but the second works — a 3s delay for the first 2min
+        // shortens the user-visible "stuck reconnecting" gap without
+        // changing steady-state backoff once the session stabilizes.
+        if (this.passiveMode) {
+          tcpTransport.setStartupGraceReconnect(
+            MeshtasticManager.STARTUP_GRACE_WINDOW_MS,
+            MeshtasticManager.STARTUP_GRACE_FAST_DELAY_MS,
+          );
+        }
 
         // Optional per-source keepalive heartbeat (issue 2609). When configured,
         // we periodically send a Meshtastic Heartbeat ToRadio to the device so

--- a/src/server/tcpTransport.test.ts
+++ b/src/server/tcpTransport.test.ts
@@ -176,3 +176,100 @@ describe('TcpTransport — heartbeat (issue 2609)', () => {
     expect(sendSpy).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Unit tests for TcpTransport startup-grace fast reconnect (#3122 follow-up).
+ *
+ * Passive-mode TCP sources opt into a short grace window during which
+ * reconnect attempts use a fixed fast delay instead of exponential backoff.
+ * The reporter observed that a large infrastructure node usually closes the
+ * first config-sync session but recovers cleanly on the next attempt; the
+ * grace shortens the user-visible reconnect gap during that startup window
+ * without affecting steady-state backoff.
+ */
+describe('TcpTransport — startup-grace fast reconnect (#3122)', () => {
+  let transport: TcpTransport;
+  let doConnectSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    transport = new TcpTransport();
+    // scheduleReconnect calls doConnect via setTimeout; stub it so the test
+    // doesn't try to open a real socket.
+    doConnectSpy = vi.spyOn(transport as any, 'doConnect').mockResolvedValue(undefined);
+    (transport as any).shouldReconnect = true;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  /** Pulls the next-scheduled delay off the most recent setTimeout call. */
+  const scheduleAndReadDelay = (): number => {
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+    (transport as any).scheduleReconnect();
+    const call = setTimeoutSpy.mock.calls[setTimeoutSpy.mock.calls.length - 1];
+    setTimeoutSpy.mockRestore();
+    return call?.[1] as number;
+  };
+
+  it('disabled by default — uses exponential backoff (1s for first attempt)', () => {
+    // First attempt: initialDelay * 2^0 = 1000ms
+    const delay = scheduleAndReadDelay();
+    expect(delay).toBe(1_000);
+  });
+
+  it('inside the grace window: uses the fast delay regardless of attempt count', () => {
+    transport.setStartupGraceReconnect(120_000, 3_000);
+
+    // First attempt
+    expect(scheduleAndReadDelay()).toBe(3_000);
+    // Bump attempts to where exponential backoff would otherwise be 8s,
+    // 16s, 32s, etc. — still 3s while in the grace window.
+    (transport as any).reconnectAttempts = 4;
+    expect(scheduleAndReadDelay()).toBe(3_000);
+  });
+
+  it('after the grace window expires: falls back to exponential backoff', () => {
+    transport.setStartupGraceReconnect(120_000, 3_000);
+
+    // Set the reconnect attempts so we can verify backoff math after grace
+    // expires. attempts=3 means scheduleReconnect bumps to 4 → 2^3 = 8000ms.
+    (transport as any).reconnectAttempts = 3;
+
+    // Advance past the 2-minute grace window
+    vi.advanceTimersByTime(121_000);
+
+    const delay = scheduleAndReadDelay();
+    expect(delay).toBe(8_000);
+  });
+
+  it('graceMs=0 disables the grace window (legacy behavior)', () => {
+    transport.setStartupGraceReconnect(120_000, 3_000);
+    transport.setStartupGraceReconnect(0, 0);
+
+    const delay = scheduleAndReadDelay();
+    expect(delay).toBe(1_000); // exponential, attempt #1
+  });
+
+  it('grace fast delay does not exceed the configured max (sanity)', () => {
+    // Edge case: fast delay set absurdly large — the test just verifies the
+    // value is honored as-is (it's not clamped against maxDelayMs because the
+    // grace window is meant to be a tight, deterministic delay).
+    transport.setStartupGraceReconnect(120_000, 100);
+
+    const delay = scheduleAndReadDelay();
+    expect(delay).toBe(100);
+  });
+
+  it('reconnect actually fires after the fast delay', async () => {
+    transport.setStartupGraceReconnect(120_000, 3_000);
+
+    (transport as any).scheduleReconnect();
+    expect(doConnectSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(doConnectSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/src/server/tcpTransport.ts
+++ b/src/server/tcpTransport.ts
@@ -49,6 +49,16 @@ export class TcpTransport extends EventEmitter implements ITransport {
   private reconnectInitialDelayMs: number = 1000; // 1 second default
   private reconnectMaxDelayMs: number = 60000; // 60 second default
 
+  // Startup-grace fast reconnect (#3122 follow-up). During the first
+  // `startupGraceMs` after this transport is created, scheduleReconnect uses
+  // `startupGraceFastDelayMs` instead of the exponential backoff. The reporter
+  // observed that a large/fragile TCP node usually closes the *first* config
+  // sync session but recovers cleanly on the next attempt — a short fast
+  // delay during startup shortens that user-visible "stuck reconnecting" gap
+  // without changing steady-state backoff once the session stabilizes.
+  private startupGraceUntil: number = 0;
+  private startupGraceFastDelayMs: number = 0;
+
   // Protocol constants
   private readonly START1 = 0x94;
   private readonly START2 = 0xc3;
@@ -83,6 +93,30 @@ export class TcpTransport extends EventEmitter implements ITransport {
     this.reconnectInitialDelayMs = initialDelayMs;
     this.reconnectMaxDelayMs = maxDelayMs;
     logger.debug(`⏱️  Reconnect timing: initial=${initialDelayMs}ms, max=${maxDelayMs}ms`);
+  }
+
+  /**
+   * Enable a startup-grace fast-reconnect window (#3122 follow-up).
+   *
+   * For the next `graceMs` from now, reconnect attempts use `fastDelayMs`
+   * instead of the exponential backoff. After the window expires, normal
+   * backoff resumes automatically. Intended for passive-mode TCP sources
+   * where the first session often closes mid-sync but the second session
+   * works — without the grace, the user sees a multi-second backoff gap
+   * before the recovery attempt.
+   *
+   * Pass graceMs=0 to disable (the default).
+   */
+  setStartupGraceReconnect(graceMs: number, fastDelayMs: number): void {
+    if (graceMs <= 0) {
+      this.startupGraceUntil = 0;
+      this.startupGraceFastDelayMs = 0;
+      logger.debug('⏱️  Startup-grace reconnect: disabled');
+      return;
+    }
+    this.startupGraceUntil = Date.now() + graceMs;
+    this.startupGraceFastDelayMs = fastDelayMs;
+    logger.debug(`⏱️  Startup-grace reconnect: ${fastDelayMs}ms delay for next ${graceMs / 1000}s`);
   }
 
   /**
@@ -228,10 +262,15 @@ export class TcpTransport extends EventEmitter implements ITransport {
 
     this.reconnectAttempts++;
 
-    // Exponential backoff: initialDelay * 2^(attempts-1), capped at maxDelay
-    const delay = Math.min(Math.pow(2, this.reconnectAttempts - 1) * this.reconnectInitialDelayMs, this.reconnectMaxDelayMs);
+    // Startup-grace fast reconnect (#3122): if we're still inside the grace
+    // window, use the fast delay regardless of attempt count. Outside the
+    // window, fall back to exponential backoff.
+    const inGrace = this.startupGraceUntil > 0 && Date.now() < this.startupGraceUntil;
+    const delay = inGrace
+      ? this.startupGraceFastDelayMs
+      : Math.min(Math.pow(2, this.reconnectAttempts - 1) * this.reconnectInitialDelayMs, this.reconnectMaxDelayMs);
 
-    logger.debug(`🔄 Reconnecting in ${delay / 1000}s (attempt ${this.reconnectAttempts})...`);
+    logger.debug(`🔄 Reconnecting in ${delay / 1000}s (attempt ${this.reconnectAttempts}${inGrace ? ', startup-grace' : ''})...`);
 
     this.reconnectTimeout = setTimeout(() => {
       this.doConnect().catch((error) => {


### PR DESCRIPTION
Follow-up to #3125 / #3126. Closes item 3 of the reporter's feedback on #3122 (fast initial reconnect during the startup window).

## Why

The reporter observed that a large infrastructure node consistently closes the *first* config-sync session — but recovers cleanly on the very next attempt. Under normal exponential backoff, MeshMonitor would wait 8–16 s before retrying, which translates to a long user-visible "stuck reconnecting" gap right at app start. The grace window collapses that gap on the path the reporter actually walks (passive-mode sources, fresh process start, first reconnect after the initial sync drops).

## What

- **\`TcpTransport.setStartupGraceReconnect(graceMs, fastDelayMs)\`** — for the next \`graceMs\` after the call, \`scheduleReconnect\` uses \`fastDelayMs\` instead of the exponential backoff. After the window expires the legacy backoff resumes automatically. Pass \`graceMs=0\` to explicitly disable.
- **\`MeshtasticManager\` opt-in** — passive-mode sources call \`setStartupGraceReconnect(2 * 60_000, 3_000)\` at transport-construct time. Non-passive sources are unchanged; this is strictly additive for the opt-in path.

Constants live as class statics on \`MeshtasticManager\` (\`STARTUP_GRACE_WINDOW_MS\`, \`STARTUP_GRACE_FAST_DELAY_MS\`) — picked the reporter's exact recommended values: 2 min window, 3 s delay.

## What's *not* in this PR

- A configurable staleness window as an advanced per-source setting (still item 2 from the reporter's feedback). Worth its own follow-up if anyone hits a node where 4 h doesn't fit.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] 6 new \`tcpTransport.test.ts\` tests: default-disabled uses exponential, inside grace uses fast delay regardless of attempt count, post-window falls back to exponential, \`graceMs=0\` disables, sanity check on tiny fast delays, reconnect actually fires after the configured delay
- [x] Full suite: 5281 pass / 3 pre-existing fails (\`mqttBrokerManager\` zero-hop encode failures; reproduce on clean main, unrelated)
- [ ] Manual smoke against a real passive-mode TCP node — verify the recovery reconnect kicks in at ~3 s rather than ~8 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)