### PR TITLE
feat(meshcore): manual path editor (feature-flagged)

### DIFF
--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -22,14 +22,24 @@ interface MeshCoreContactDetailPanelProps {
   /** Trigger CMD_SHARE_CONTACT for this contact, broadcasting their saved
    *  advert to nearby nodes. Unset hides the Share button. */
   onShareContact?: (publicKey: string) => Promise<boolean>;
+  /** Manually push a forwarding route into the device's contact record
+   *  via CMD_ADD_UPDATE_CONTACT. `outPath` is a comma-separated hex chain
+   *  ("a3,7f,02"). Unset OR `advancedPathEditEnabled=false` hides the
+   *  Edit Path… button. */
+  onSetOutPath?: (publicKey: string, outPath: string) => Promise<boolean>;
   /** Whether the current user may invoke write actions on this source's
-   *  `nodes` resource. Required to gate the Reset Path / Share buttons. */
+   *  `nodes` resource. Required to gate the Reset Path / Share / Edit
+   *  buttons. */
   canWriteNodes?: boolean;
-  /** Is the source's device a Companion? Both Reset Path and Share Contact
-   *  are companion-only (CMD_RESET_PATH / CMD_SHARE_CONTACT aren't supported
-   *  by Repeater firmware). Defaults to `true` so callers that don't pass
-   *  this still see the buttons when the action handlers are supplied. */
+  /** Is the source's device a Companion? Reset Path / Share Contact /
+   *  manual edit are all companion-only. Defaults to `true` so callers
+   *  that don't pass this still see the buttons when handlers are
+   *  supplied. */
   isCompanion?: boolean;
+  /** Server-side gated advanced toggle (settings.meshcoreAdvancedPathEdit).
+   *  When false the Edit Path… button is hidden even if onSetOutPath is
+   *  supplied. The server route also enforces this for defense in depth. */
+  advancedPathEditEnabled?: boolean;
 }
 
 const COLLAPSED_KEY = 'meshcoreContactDetailsCollapsed';
@@ -39,8 +49,10 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   publicKey,
   onResetPath,
   onShareContact,
+  onSetOutPath,
   canWriteNodes = false,
   isCompanion = true,
+  advancedPathEditEnabled = false,
 }) => {
   const { t } = useTranslation();
   const { timeFormat, dateFormat } = useSettings();
@@ -52,6 +64,12 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   const [sharing, setSharing] = useState(false);
   const [shareError, setShareError] = useState<string | null>(null);
   const [shareSuccess, setShareSuccess] = useState(false);
+
+  // Path-editor modal state. Only mounted when advancedPathEditEnabled.
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editorDraft, setEditorDraft] = useState('');
+  const [editorSaving, setEditorSaving] = useState(false);
+  const [editorError, setEditorError] = useState<string | null>(null);
 
   useEffect(() => {
     localStorage.setItem(COLLAPSED_KEY, isCollapsed.toString());
@@ -65,6 +83,9 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     setShareError(null);
     setSharing(false);
     setShareSuccess(false);
+    setEditorOpen(false);
+    setEditorError(null);
+    setEditorSaving(false);
   }, [publicKey]);
 
   const name = contact?.advName || contact?.name || `${publicKey.substring(0, 8)}…`;
@@ -83,6 +104,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     !!onResetPath && canWriteNodes && isCompanion;
   const canShowShareButton =
     !!onShareContact && canWriteNodes && isCompanion;
+  const canShowEditButton =
+    !!onSetOutPath && canWriteNodes && isCompanion && advancedPathEditEnabled;
 
   const handleResetPath = async () => {
     if (!onResetPath || resetting) return;
@@ -104,6 +127,52 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
       }
     } finally {
       setResetting(false);
+    }
+  };
+
+  const openEditor = () => {
+    setEditorDraft(outPath ?? '');
+    setEditorError(null);
+    setEditorOpen(true);
+  };
+
+  const HEX_PATH_REGEX = /^\s*([0-9a-fA-F]{1,2})(\s*,\s*[0-9a-fA-F]{1,2})*\s*$/;
+
+  const handleSaveEditor = async () => {
+    if (!onSetOutPath || editorSaving) return;
+    const draft = editorDraft.trim();
+    if (draft !== '' && !HEX_PATH_REGEX.test(draft)) {
+      setEditorError(
+        t(
+          'meshcore.contact_details.edit_path_invalid',
+          'Path must be comma-separated hex bytes, e.g. "a3,7f,02" (max 64).',
+        ),
+      );
+      return;
+    }
+    const hopCount = draft === '' ? 0 : draft.split(',').length;
+    if (hopCount > 64) {
+      setEditorError(
+        t(
+          'meshcore.contact_details.edit_path_too_long',
+          `Path too long: ${hopCount} hops (max 64).`,
+        ),
+      );
+      return;
+    }
+    setEditorSaving(true);
+    setEditorError(null);
+    try {
+      const ok = await onSetOutPath(publicKey, draft);
+      if (!ok) {
+        setEditorError(
+          t('meshcore.contact_details.edit_path_save_failed', 'Save failed.'),
+        );
+      } else {
+        setEditorOpen(false);
+      }
+    } finally {
+      setEditorSaving(false);
     }
   };
 
@@ -221,7 +290,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
               available because the device retransmits the stored advert
               regardless of route state. Rendered in one card so the
               actions stay grouped at the bottom of the grid. */}
-          {(canShowResetButton || canShowShareButton) && (canShowShareButton || pathKnown) && (
+          {(canShowResetButton || canShowShareButton || canShowEditButton) &&
+            (canShowShareButton || canShowEditButton || pathKnown) && (
             <div className="node-detail-card node-detail-card-2col">
               <div className="node-detail-label">
                 {t('meshcore.contact_details.actions_label', 'Actions')}
@@ -249,6 +319,15 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     {sharing
                       ? t('meshcore.contact_details.share_contact_running', 'Sharing…')
                       : t('meshcore.contact_details.share_contact_button', 'Share Contact')}
+                  </button>
+                )}
+                {canShowEditButton && (
+                  <button
+                    type="button"
+                    onClick={openEditor}
+                    aria-label={t('meshcore.contact_details.edit_path_button', 'Edit Path…')}
+                  >
+                    {t('meshcore.contact_details.edit_path_button', 'Edit Path…')}
                   </button>
                 )}
                 {resetError && (
@@ -324,6 +403,108 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
             <div className="node-detail-label">{t('meshcore.public_key', 'Public Key')}</div>
             <div className="node-detail-value node-detail-public-key" title={publicKey}>
               {publicKey}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {editorOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={t('meshcore.contact_details.edit_path_dialog_title', 'Edit forwarding path')}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.55)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1000,
+          }}
+          onClick={(e) => { if (e.target === e.currentTarget && !editorSaving) setEditorOpen(false); }}
+        >
+          <div
+            style={{
+              background: 'var(--ctp-base, #1e1e2e)',
+              color: 'var(--ctp-text, #cdd6f4)',
+              padding: '1.25rem 1.5rem',
+              borderRadius: '8px',
+              maxWidth: '32rem',
+              width: '90%',
+              boxShadow: '0 4px 20px rgba(0,0,0,0.5)',
+            }}
+          >
+            <h3 style={{ marginTop: 0 }}>
+              {t('meshcore.contact_details.edit_path_dialog_title', 'Edit forwarding path')}
+            </h3>
+            <p style={{ marginBottom: '0.75rem' }}>
+              {t(
+                'meshcore.contact_details.edit_path_dialog_hint',
+                'Enter the new hop chain as comma-separated hex bytes (e.g. "a3,7f,02"). Each byte is one hop hash; 0..64 bytes total. Leave empty to set a zero-hop direct path.',
+              )}
+            </p>
+            <div
+              style={{
+                background: 'var(--ctp-surface0, #313244)',
+                color: 'var(--ctp-yellow, #f9e2af)',
+                padding: '0.6rem 0.8rem',
+                borderRadius: '4px',
+                marginBottom: '0.75rem',
+                fontSize: '0.9em',
+              }}
+              role="alert"
+            >
+              {t(
+                'meshcore.contact_details.edit_path_warning',
+                'Manual paths bypass auto-discovery. Stale hops silently drop direct sends until the next flood. Use "Reset Path" instead if you just want to re-discover.',
+              )}
+            </div>
+            <label style={{ display: 'block', marginBottom: '0.5rem' }}>
+              {t('meshcore.contact_details.edit_path_label', 'New path (hex chain):')}
+            </label>
+            <input
+              type="text"
+              value={editorDraft}
+              onChange={(e) => setEditorDraft(e.target.value)}
+              disabled={editorSaving}
+              placeholder="a3,7f,02"
+              style={{
+                width: '100%',
+                padding: '0.5rem',
+                marginBottom: '0.5rem',
+                fontFamily: 'var(--font-mono, monospace)',
+                boxSizing: 'border-box',
+              }}
+              autoFocus
+            />
+            <div style={{ fontSize: '0.85em', opacity: 0.8, marginBottom: '0.75rem' }}>
+              {editorDraft.trim() === ''
+                ? t('meshcore.contact_details.edit_path_zero_hops', '0 hops (direct path)')
+                : t('meshcore.contact_details.edit_path_hop_count', { count: editorDraft.trim().split(',').length })}
+            </div>
+            {editorError && (
+              <div style={{ color: 'var(--ctp-red)', marginBottom: '0.75rem' }} role="alert">
+                {editorError}
+              </div>
+            )}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+              <button
+                type="button"
+                onClick={() => setEditorOpen(false)}
+                disabled={editorSaving}
+              >
+                {t('meshcore.contact_details.edit_path_cancel', 'Cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={handleSaveEditor}
+                disabled={editorSaving}
+              >
+                {editorSaving
+                  ? t('meshcore.contact_details.edit_path_saving', 'Saving…')
+                  : t('meshcore.contact_details.edit_path_save', 'Save Path')}
+              </button>
             </div>
           </div>
         </div>

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   MeshCoreMessage, MeshCoreActions, ConnectionStatus,
@@ -46,8 +46,32 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
 
   const selfKey = status?.localNode?.publicKey;
   const connected = status?.connected ?? false;
-  // CMD_RESET_PATH is companion-only (firmware deviceType=1).
+  // CMD_RESET_PATH / CMD_SHARE_CONTACT / CMD_ADD_UPDATE_CONTACT are all
+  // companion-only (firmware deviceType=1).
   const isCompanion = (status?.deviceType ?? 0) === 1;
+
+  // Lazy-read the advanced path-edit toggle from /api/settings. Off by
+  // default; flipping it on/off in the Settings tab takes effect on the
+  // next mount. We don't subscribe to settings changes here — the panel
+  // is mounted often enough that polling isn't worth the complexity.
+  const [advancedPathEditEnabled, setAdvancedPathEditEnabled] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    const base = (baseUrl ?? '').replace(/\/$/, '');
+    fetch(`${base}/api/settings`, { credentials: 'include' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (cancelled || !j) return;
+        const value = j?.data?.meshcoreAdvancedPathEdit ?? j?.meshcoreAdvancedPathEdit;
+        setAdvancedPathEditEnabled(value === 'true' || value === '1' || value === true);
+      })
+      .catch(() => {
+        /* leave default false on error */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [baseUrl]);
 
   // Contacts that have at least one DM thread (filtered on top).
   const contactsByKey = useMemo(() => {
@@ -173,8 +197,10 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                 publicKey={selected}
                 onResetPath={actions.resetContactPath}
                 onShareContact={actions.shareContact}
+                onSetOutPath={actions.setContactOutPath}
                 canWriteNodes={canWriteNodes && connected}
                 isCompanion={isCompanion}
+                advancedPathEditEnabled={advancedPathEditEnabled}
               />
               {!!sourceId && typeof baseUrl === 'string' && isRealNodeKey(selected) && (
                 <>

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -93,6 +93,12 @@ export interface MeshCoreActions {
    *  nearby nodes can add this contact themselves. Wraps CMD_SHARE_CONTACT.
    *  Resolves `true` when the device ACKed; `false` for any error. */
   shareContact: (publicKey: string) => Promise<boolean>;
+  /** Manually push a forwarding route into the device's contact record.
+   *  `outPath` is a comma-separated hex chain ("a3,7f,02"); empty string
+   *  sets a zero-hop direct path. Server gates this on the
+   *  `meshcoreAdvancedPathEdit` toggle, so a 403 is expected when the
+   *  setting is off. */
+  setContactOutPath: (publicKey: string, outPath: string) => Promise<boolean>;
   sendAdvert: () => Promise<void>;
   sendMessage: (text: string, toPublicKey?: string, channelIdx?: number) => Promise<boolean>;
   setDeviceName: (name: string) => Promise<boolean>;
@@ -459,6 +465,41 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch]);
 
+  const setContactOutPath = useCallback(async (publicKey: string, outPath: string): Promise<boolean> => {
+    try {
+      const response = await csrfFetch(
+        `${mcPrefix}/contacts/${encodeURIComponent(publicKey)}/out-path`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ outPath }),
+        },
+      );
+      const data = await response.json();
+      if (!data.success) {
+        setError(data.error || 'Failed to set path');
+        return false;
+      }
+      // Optimistic local update so the UI shows the new hops without a
+      // round trip. The server has already mirrored the new bytes to
+      // meshcore_nodes; refreshContacts() will happen on the next
+      // PathUpdated push if the firmware reroutes.
+      const trimmed = outPath.trim();
+      const newPathLen = trimmed === '' ? 0 : trimmed.split(',').length;
+      setContacts(prev => prev.map(c => (
+        c.publicKey === publicKey
+          ? { ...c, outPath: trimmed, pathLen: newPathLen }
+          : c
+      )));
+      const existing = contactsRef.current.get(publicKey) ?? { publicKey };
+      contactsRef.current.set(publicKey, { ...existing, outPath: trimmed, pathLen: newPathLen });
+      return true;
+    } catch (_err) {
+      setError('Failed to set path');
+      return false;
+    }
+  }, [mcPrefix, csrfFetch]);
+
   const sendAdvert = useCallback(async () => {
     try {
       const response = await csrfFetch(`${mcPrefix}/advert`, { method: 'POST' });
@@ -630,6 +671,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       refreshContacts,
       resetContactPath,
       shareContact,
+      setContactOutPath,
       sendAdvert,
       sendMessage,
       setDeviceName,

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -229,6 +229,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   // the UI checkbox says "Hide" while the context uses "show" semantics
   const [localHideIncompleteNodes, setLocalHideIncompleteNodes] = useState(!showIncompleteNodes);
   const [localHomoglyphEnabled, setLocalHomoglyphEnabled] = useState(false);
+  const [localMeshcoreAdvancedPathEdit, setLocalMeshcoreAdvancedPathEdit] = useState(false);
   const [localLocalStatsIntervalMinutes, setLocalLocalStatsIntervalMinutes] = useState(15);
   const [initialLocalStatsIntervalMinutes, setInitialLocalStatsIntervalMinutes] = useState(15);
   const [isFetchingSolarEstimates, setIsFetchingSolarEstimates] = useState(false);
@@ -312,6 +313,13 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           const homoglyphOn = settings.homoglyphEnabled === 'true';
           setLocalHomoglyphEnabled(homoglyphOn);
           setInitialHomoglyphEnabled(homoglyphOn);
+
+          // Load MeshCore advanced path-edit toggle (gates the manual
+          // Edit Path… button on the per-contact detail panel and is
+          // server-side-checked by the matching PUT route).
+          const meshcorePathEditOn = settings.meshcoreAdvancedPathEdit === 'true';
+          setLocalMeshcoreAdvancedPathEdit(meshcorePathEditOn);
+          setInitialMeshcoreAdvancedPathEdit(meshcorePathEditOn);
 
           // Load LocalStats interval setting
           const statsInterval = parseInt(settings.localStatsIntervalMinutes || '15', 10);
@@ -405,6 +413,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   // Instead, we'll track initial packet monitor values separately
   const [initialPacketMonitorSettings, setInitialPacketMonitorSettings] = useState({ enabled: false, maxCount: 1000, maxAgeHours: 24 });
   const [initialHomoglyphEnabled, setInitialHomoglyphEnabled] = useState(false);
+  const [initialMeshcoreAdvancedPathEdit, setInitialMeshcoreAdvancedPathEdit] = useState(false);
   const [initialNodeDimmingSettings, setInitialNodeDimmingSettings] = useState({
     enabled: nodeDimmingEnabled,
     startHours: nodeDimmingStartHours,
@@ -447,6 +456,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localSolarMonitoringDeclination !== solarMonitoringDeclination ||
       localHideIncompleteNodes !== !showIncompleteNodes ||
       localHomoglyphEnabled !== initialHomoglyphEnabled ||
+      localMeshcoreAdvancedPathEdit !== initialMeshcoreAdvancedPathEdit ||
       localLocalStatsIntervalMinutes !== initialLocalStatsIntervalMinutes ||
       nodeDimmingEnabled !== initialNodeDimmingSettings.enabled ||
       nodeDimmingStartHours !== initialNodeDimmingSettings.startHours ||
@@ -461,6 +471,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localSolarMonitoringEnabled, localSolarMonitoringLatitude, localSolarMonitoringLongitude, localSolarMonitoringAzimuth, localSolarMonitoringDeclination,
       solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination,
       localHideIncompleteNodes, showIncompleteNodes, localHomoglyphEnabled, initialHomoglyphEnabled,
+      localMeshcoreAdvancedPathEdit, initialMeshcoreAdvancedPathEdit,
       localLocalStatsIntervalMinutes, initialLocalStatsIntervalMinutes,
       nodeDimmingEnabled, nodeDimmingStartHours, nodeDimmingMinOpacity, initialNodeDimmingSettings,
       localAnalyticsProvider, localAnalyticsConfig, initialAnalyticsProvider, initialAnalyticsConfig,
@@ -501,6 +512,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalSolarMonitoringDeclination(solarMonitoringDeclination);
     setLocalHideIncompleteNodes(!showIncompleteNodes);
     setLocalHomoglyphEnabled(initialHomoglyphEnabled);
+    setLocalMeshcoreAdvancedPathEdit(initialMeshcoreAdvancedPathEdit);
     setLocalLocalStatsIntervalMinutes(initialLocalStatsIntervalMinutes);
     setNodeDimmingEnabled(initialNodeDimmingSettings.enabled);
     setNodeDimmingStartHours(initialNodeDimmingSettings.startHours);
@@ -514,7 +526,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       dateFormat, mapTileset, mapPinStyle, iconStyle, neighborInfoMinZoom, defaultMapCenterLat, defaultMapCenterLon, defaultMapCenterZoom, defaultLandingPage, theme, nodeHopsCalculation, preferredDashboardSortOption,
       initialPacketMonitorSettings, solarMonitoringEnabled, solarMonitoringLatitude,
       solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes,
-      initialHomoglyphEnabled, initialLocalStatsIntervalMinutes, initialNodeDimmingSettings,
+      initialHomoglyphEnabled, initialMeshcoreAdvancedPathEdit, initialLocalStatsIntervalMinutes, initialNodeDimmingSettings,
       setNodeDimmingEnabled, setNodeDimmingStartHours, setNodeDimmingMinOpacity,
       initialAnalyticsProvider, initialAnalyticsConfig, initialAppriseApiServerUrl]);
 
@@ -554,6 +566,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         solarMonitoringDeclination: localSolarMonitoringDeclination.toString(),
         hideIncompleteNodes: localHideIncompleteNodes ? '1' : '0',
         homoglyphEnabled: String(localHomoglyphEnabled),
+        meshcoreAdvancedPathEdit: String(localMeshcoreAdvancedPathEdit),
         localStatsIntervalMinutes: localLocalStatsIntervalMinutes.toString(),
         nodeHopsCalculation: localNodeHopsCalculation,
         nodeDimmingEnabled: nodeDimmingEnabled ? '1' : '0',
@@ -1564,6 +1577,25 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
                 {t('settings.homoglyph_enabled')}
               </span>
               <span className="setting-description">{t('settings.homoglyph_description')}</span>
+            </label>
+          </div>
+          <div className="setting-item">
+            <label>
+              <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  checked={localMeshcoreAdvancedPathEdit}
+                  onChange={(e) => setLocalMeshcoreAdvancedPathEdit(e.target.checked)}
+                  style={{ cursor: 'pointer' }}
+                />
+                {t('settings.meshcore_advanced_path_edit', 'MeshCore: enable manual path editing (advanced)')}
+              </span>
+              <span className="setting-description">
+                {t(
+                  'settings.meshcore_advanced_path_edit_description',
+                  'Exposes an Edit Path… button on each MeshCore contact that lets you push arbitrary hop bytes into the device. Stale hops silently drop direct sends until the next flood, so leave this off unless you know exactly what you\'re doing.',
+                )}
+              </span>
             </label>
           </div>
         </div>}

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -145,6 +145,12 @@ export const VALID_SETTINGS_KEYS = [
   'tracerouteFilterHopsMax',
   'defaultLandingPage',
   'appriseApiServerUrl',
+  // Advanced/unsafe MeshCore actions. When true the per-contact detail
+  // panel exposes a manual "Edit Path…" button that lets the user push
+  // arbitrary hop hashes into the device's contact record. Stale hops
+  // silently drop direct sends, so this is gated behind an explicit
+  // toggle (off by default).
+  'meshcoreAdvancedPathEdit',
 ] as const;
 
 export type ValidSettingKey = typeof VALID_SETTINGS_KEYS[number];

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1392,6 +1392,71 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
+   * Manually push a forwarding route ("out_path") into the device's
+   * contact record. Wraps meshcore.js setContactPath via the
+   * `set_out_path` bridge command, which preserves all other contact
+   * fields and only mutates outPath + outPathLen.
+   *
+   * Stale hops silently drop direct sends — this is gated by the
+   * advanced settings toggle at the route layer.
+   *
+   * `outPathBytes` must be 0..64 bytes; an empty array sets path-len 0
+   * (zero-hop direct), which is distinct from RESET_PATH's
+   * OUT_PATH_UNKNOWN sentinel.
+   *
+   * On success the in-memory contact + meshcore_nodes row are mirrored
+   * so the UI reflects the new state without waiting for a PathUpdated
+   * push.
+   *
+   * Returns `true` on success, `false` if the device rejected the
+   * request or this isn't a connected Companion.
+   */
+  async setContactOutPath(publicKey: string, outPathBytes: Uint8Array): Promise<boolean> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
+      logger.warn('[MeshCore] Set-out-path requires Companion firmware');
+      return false;
+    }
+    if (!this.connected) {
+      return false;
+    }
+    if (outPathBytes.length > 64) {
+      logger.warn(`[MeshCore] Set-out-path rejected: ${outPathBytes.length} > 64 bytes`);
+      return false;
+    }
+    try {
+      const response = await this.sendBridgeCommand('set_out_path', {
+        public_key: publicKey,
+        out_path: outPathBytes,
+      });
+      if (!response.success) {
+        logger.warn(`[MeshCore] set_out_path failed for ${publicKey}: ${response.error}`);
+        return false;
+      }
+      const hex = Array.from(outPathBytes)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join(',');
+      const existing = this.contacts.get(publicKey);
+      if (existing) {
+        const updated: MeshCoreContact = {
+          ...existing,
+          outPath: hex,
+          pathLen: outPathBytes.length,
+          lastSeen: Date.now(),
+        };
+        this.contacts.set(publicKey, updated);
+        void this.persistContact(updated);
+        this.emit('contacts_updated', { sourceId: this.sourceId, contact: updated });
+        dataEventEmitter.emitMeshCoreContactUpdated(updated, this.sourceId);
+      }
+      logger.info(`[MeshCore] Set out_path (${outPathBytes.length} hops) for ${publicKey.substring(0, 16)}…`);
+      return true;
+    } catch (error) {
+      logger.error('[MeshCore] setContactOutPath threw:', error);
+      return false;
+    }
+  }
+
+  /**
    * Login to a remote node for admin access
    */
   async loginToNode(publicKey: string, password: string): Promise<boolean> {

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -207,6 +207,11 @@ class MockConnection extends EventEmitter {
   async shareContact(pubKey: Uint8Array) {
     this.shareContactCalls.push(pubKey);
   }
+
+  public setContactPathCalls: Array<{ contact: any; path: Uint8Array }> = [];
+  async setContactPath(contact: any, path: Uint8Array) {
+    this.setContactPathCalls.push({ contact, path });
+  }
 }
 
 function installMockModule(MockConn: typeof MockConnection): MockConnection {
@@ -835,6 +840,86 @@ describe('MeshCoreNativeBackend', () => {
     const resp = await backend.sendCommand('share_contact', { public_key: 'cafebabe' });
     expect(resp.success).toBe(false);
     expect(resp.error).toMatch(/Share-contact target not found/);
+  });
+
+  it('set_out_path forwards the resolved contact and path bytes to setContactPath', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    const targetBytes = new Uint8Array(32);
+    targetBytes[0] = 0xab; targetBytes[1] = 0xcd; targetBytes[2] = 0xef; targetBytes[3] = 0x01;
+    // setContactPath needs the full contact object so it can preserve
+    // type/flags/name/advert timestamp/lat/lon — verify it's the one
+    // returned by getContacts(), not a synthesised stub.
+    const fullContact = {
+      publicKey: targetBytes,
+      type: AdvType.Chat,
+      flags: 0,
+      outPathLen: 0xff,
+      outPath: new Uint8Array(64),
+      advName: 'Bob',
+      lastAdvert: 1700000000,
+      advLat: 10_000_000,
+      advLon: 20_000_000,
+      lastMod: 1700000000,
+    };
+    conn.contactsResponse = [fullContact];
+
+    const pathBytes = Uint8Array.from([0xa3, 0x7f, 0x02]);
+    const resp = await backend.sendCommand('set_out_path', {
+      public_key: 'abcdef01' + '0'.repeat(56),
+      out_path: pathBytes,
+    });
+
+    expect(resp.success).toBe(true);
+    expect(conn.setContactPathCalls).toHaveLength(1);
+    expect(conn.setContactPathCalls[0].contact).toBe(fullContact);
+    expect(Array.from(conn.setContactPathCalls[0].path)).toEqual([0xa3, 0x7f, 0x02]);
+  });
+
+  it('set_out_path rejects oversize paths (>64 bytes)', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    const targetBytes = new Uint8Array(32);
+    targetBytes[0] = 0xab;
+    conn.contactsResponse = [{ publicKey: targetBytes, type: AdvType.Chat, advName: 'Bob' }];
+
+    const tooLong = new Uint8Array(65);
+    const resp = await backend.sendCommand('set_out_path', {
+      public_key: 'ab' + '0'.repeat(62),
+      out_path: tooLong,
+    });
+    expect(resp.success).toBe(false);
+    expect(resp.error).toMatch(/out_path too long/);
+    expect(conn.setContactPathCalls).toHaveLength(0);
+  });
+
+  it('set_out_path returns an error when the contact is missing from the device list', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    // Backend can resolve the pubkey from the 64-char hex form even
+    // without a contact match — but setContactPath needs the full
+    // contact object, so the second lookup against getContacts() should
+    // produce the "not in device contact list" error.
+    conn.contactsResponse = [];
+
+    const resp = await backend.sendCommand('set_out_path', {
+      public_key: 'a'.repeat(64),
+      out_path: Uint8Array.from([0x01]),
+    });
+    expect(resp.success).toBe(false);
+    expect(resp.error).toMatch(/Set-out-path target not in device contact list/);
   });
 });
 

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -408,6 +408,36 @@ export class MeshCoreNativeBackend extends EventEmitter {
         return { ok: true };
       }
 
+      case 'set_out_path': {
+        // Manually push a forwarding route into the device's contact
+        // record. Wraps meshcore.js's setContactPath(contact, path),
+        // which reads the contact's existing type/flags/name/advert
+        // timestamp/lat/lon and only mutates outPath + outPathLen via
+        // CMD_ADD_UPDATE_CONTACT (opcode 9). Stale hops silently drop
+        // direct sends, so this is gated behind the advanced toggle at
+        // the route layer.
+        //
+        // `out_path` is the parsed Uint8Array of hop hashes (0..64 bytes).
+        // Caller is responsible for validating the byte length; we just
+        // forward.
+        const publicKey = await this.resolvePublicKey(params.public_key as string);
+        if (!publicKey) throw new Error('Set-out-path target not found');
+        const pathBytes = params.out_path as Uint8Array | number[] | undefined;
+        if (!pathBytes) throw new Error('set_out_path requires out_path bytes');
+        const path = pathBytes instanceof Uint8Array ? pathBytes : Uint8Array.from(pathBytes);
+        if (path.length > 64) {
+          throw new Error(`out_path too long: ${path.length} > 64`);
+        }
+        const contacts: any[] = await c.getContacts();
+        const contact = contacts.find((ct) => {
+          const hex = bytesToHex(ct.publicKey);
+          return hex === bytesToHex(publicKey);
+        });
+        if (!contact) throw new Error('Set-out-path target not in device contact list');
+        await c.setContactPath(contact, path);
+        return { ok: true };
+      }
+
       case 'send_message': {
         const to = params.to as string | null | undefined;
         const text = String(params.text ?? '');

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -50,6 +50,7 @@ const meshcoreManager = {
   refreshContacts: vi.fn().mockResolvedValue(new Map()),
   resetContactPath: vi.fn().mockResolvedValue(true),
   shareContact: vi.fn().mockResolvedValue(true),
+  setContactOutPath: vi.fn().mockResolvedValue(true),
   loginToNode: vi.fn().mockResolvedValue(true),
   requestNodeStatus: vi.fn().mockResolvedValue({ batteryMv: 4200, uptimeSecs: 3600 }),
   setName: vi.fn().mockResolvedValue(true),
@@ -99,6 +100,12 @@ vi.mock('../services/meshcoreTelemetryPoller.js', () => ({
 }));
 
 import DatabaseService from '../../services/database.js';
+
+// Mutable holder so individual tests can flip the toggle for the
+// feature-flag-gated out-path route.
+const globalSettingsMock = {
+  meshcoreAdvancedPathEdit: 'false' as string | boolean | null,
+};
 import meshcoreRoutes from './meshcoreRoutes.js';
 import authRoutes from './authRoutes.js';
 
@@ -139,6 +146,16 @@ describe('MeshCore Routes', () => {
     // permissionModel wired via checkPermissionAsync / getUserPermissionSetAsync below
     (DatabaseService as any).auditLog = () => {};
     (DatabaseService as any).drizzleDbType = 'sqlite';
+
+    // The out-path PUT route reads the advanced-path-edit toggle from
+    // global settings. Default the mock to "off" so tests opt-in to the
+    // "feature flag enabled" branch.
+    (DatabaseService as any).settings = {
+      getSetting: vi.fn(async (key: string) => {
+        if (key === 'meshcoreAdvancedPathEdit') return globalSettingsMock.meshcoreAdvancedPathEdit;
+        return null;
+      }),
+    };
 
     // Add async method mocks
     (DatabaseService as any).findUserByIdAsync = async (id: number) => {
@@ -755,6 +772,96 @@ describe('MeshCore Routes', () => {
       const response = await authenticatedAgent
         .post(`/api/sources/no-such-source/meshcore/contacts/${VALID_PUBKEY}/share`);
       expect(response.status).toBe(404);
+    });
+  });
+
+  describe('PUT /api/sources/test-source/meshcore/contacts/:publicKey/out-path', () => {
+    const VALID_PUBKEY = 'c'.repeat(64);
+
+    beforeEach(() => {
+      meshcoreManager.setContactOutPath.mockReset();
+      meshcoreManager.setContactOutPath.mockResolvedValue(true);
+      globalSettingsMock.meshcoreAdvancedPathEdit = 'false';
+    });
+
+    it('requires authentication', async () => {
+      const response = await request(app)
+        .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
+        .send({ outPath: 'a3,7f,02' });
+      expect(response.status).toBe(401);
+    });
+
+    it('returns 403 when the advanced toggle is off', async () => {
+      globalSettingsMock.meshcoreAdvancedPathEdit = 'false';
+      const response = await authenticatedAgent
+        .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
+        .send({ outPath: 'a3,7f,02' });
+      expect(response.status).toBe(403);
+      expect(response.body.error).toMatch(/meshcoreAdvancedPathEdit/);
+      expect(meshcoreManager.setContactOutPath).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid public key (regardless of toggle)', async () => {
+      globalSettingsMock.meshcoreAdvancedPathEdit = 'true';
+      const response = await authenticatedAgent
+        .put('/api/sources/test-source/meshcore/contacts/not-hex/out-path')
+        .send({ outPath: 'a3,7f,02' });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatch(/64-char hex/);
+      expect(meshcoreManager.setContactOutPath).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed hex chain', async () => {
+      globalSettingsMock.meshcoreAdvancedPathEdit = 'true';
+      const response = await authenticatedAgent
+        .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
+        .send({ outPath: 'a3,nothex,02' });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatch(/comma-separated hex/);
+      expect(meshcoreManager.setContactOutPath).not.toHaveBeenCalled();
+    });
+
+    it('rejects an oversize path (>64 hops)', async () => {
+      globalSettingsMock.meshcoreAdvancedPathEdit = 'true';
+      const oversized = Array(65).fill('aa').join(',');
+      const response = await authenticatedAgent
+        .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
+        .send({ outPath: oversized });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatch(/too long/);
+      expect(meshcoreManager.setContactOutPath).not.toHaveBeenCalled();
+    });
+
+    it('forwards valid path bytes to the manager and returns 200', async () => {
+      globalSettingsMock.meshcoreAdvancedPathEdit = 'true';
+      const response = await authenticatedAgent
+        .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
+        .send({ outPath: 'a3,7f,02' });
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(meshcoreManager.setContactOutPath).toHaveBeenCalledTimes(1);
+      const [pk, bytes] = meshcoreManager.setContactOutPath.mock.calls[0];
+      expect(pk).toBe(VALID_PUBKEY);
+      expect(Array.from(bytes)).toEqual([0xa3, 0x7f, 0x02]);
+    });
+
+    it('accepts an empty path as zero-hop direct', async () => {
+      globalSettingsMock.meshcoreAdvancedPathEdit = 'true';
+      const response = await authenticatedAgent
+        .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
+        .send({ outPath: '' });
+      expect(response.status).toBe(200);
+      const bytes = meshcoreManager.setContactOutPath.mock.calls[0][1];
+      expect(Array.from(bytes)).toEqual([]);
+    });
+
+    it('returns 409 when the manager rejects', async () => {
+      globalSettingsMock.meshcoreAdvancedPathEdit = 'true';
+      meshcoreManager.setContactOutPath.mockResolvedValueOnce(false);
+      const response = await authenticatedAgent
+        .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
+        .send({ outPath: 'a3' });
+      expect(response.status).toBe(409);
     });
   });
 });

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -94,6 +94,26 @@ function isValidPublicKey(key: string | undefined): boolean {
   return /^[0-9a-fA-F]{64}$/.test(key);
 }
 
+/**
+ * Parse a comma-separated hex chain like "a3,7f,02" into a Uint8Array.
+ * Empty string parses to a zero-length array (zero-hop direct path).
+ * Returns null on any malformed token so the route can return a 400.
+ */
+function parseHexPathChain(input: string): Uint8Array | null {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return new Uint8Array(0);
+  const parts = trimmed.split(',');
+  const out = new Uint8Array(parts.length);
+  for (let i = 0; i < parts.length; i++) {
+    const tok = parts[i].trim();
+    if (!/^[0-9a-fA-F]{1,2}$/.test(tok)) return null;
+    const n = parseInt(tok, 16);
+    if (!Number.isFinite(n) || n < 0 || n > 0xff) return null;
+    out[i] = n;
+  }
+  return out;
+}
+
 function isValidMessage(text: string | undefined): { valid: boolean; error?: string } {
   if (!text || typeof text !== 'string') {
     return { valid: false, error: 'Message text required' };
@@ -357,6 +377,80 @@ router.post(
     } catch (error) {
       logger.error('[API] Error resetting contact path:', error);
       res.status(500).json({ success: false, error: 'Failed to reset path' });
+    }
+  },
+);
+
+/**
+ * PUT /api/sources/:id/meshcore/contacts/:publicKey/out-path
+ *
+ * Manually set the cached forwarding route ("out_path") for a contact.
+ * Wraps the firmware's CMD_ADD_UPDATE_CONTACT (companion protocol
+ * opcode 9), with the non-path fields preserved verbatim by
+ * meshcore.js's setContactPath helper.
+ *
+ * Gated by the `meshcoreAdvancedPathEdit` setting because stale hops
+ * silently drop direct sends to this contact. When the toggle is off
+ * (default), the route returns 403 even for users with nodes:write.
+ *
+ * Body: { outPath: "a3,7f,02" }  — comma-separated hex chain, 0..64
+ *                                   bytes (empty string = 0 hops).
+ */
+router.put(
+  '/contacts/:publicKey/out-path',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const publicKey = req.params.publicKey;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({
+          success: false,
+          error: 'Invalid public key — must be 64-char hex',
+        });
+      }
+      // Settings are stored as string values; the boolean check is here
+      // only for robustness against future schema changes.
+      const flagRaw: unknown = await databaseService.settings.getSetting('meshcoreAdvancedPathEdit');
+      const flagEnabled = flagRaw === 'true' || flagRaw === '1' || flagRaw === true;
+      if (!flagEnabled) {
+        return res.status(403).json({
+          success: false,
+          error: 'Advanced MeshCore path editing is disabled. Enable meshcoreAdvancedPathEdit in Settings to use this endpoint.',
+        });
+      }
+      const rawPath = (req.body ?? {}).outPath;
+      if (typeof rawPath !== 'string') {
+        return res.status(400).json({
+          success: false,
+          error: 'Body must include `outPath` as a comma-separated hex string',
+        });
+      }
+      const parsed = parseHexPathChain(rawPath);
+      if (!parsed) {
+        return res.status(400).json({
+          success: false,
+          error: 'Invalid outPath — expected comma-separated hex bytes, e.g. "a3,7f,02"',
+        });
+      }
+      if (parsed.length > 64) {
+        return res.status(400).json({
+          success: false,
+          error: `outPath too long: ${parsed.length} bytes (max 64)`,
+        });
+      }
+      const ok = await managerFor(req).setContactOutPath(publicKey, parsed);
+      if (!ok) {
+        return res.status(409).json({
+          success: false,
+          error: 'Set out_path failed — contact may be unknown, source disconnected, or not a Companion device',
+        });
+      }
+      res.json({ success: true });
+    } catch (error) {
+      logger.error('[API] Error setting contact out_path:', error);
+      res.status(500).json({ success: false, error: 'Failed to set out_path' });
     }
   },
 );

--- a/src/server/server.settings-persistence.test.ts
+++ b/src/server/server.settings-persistence.test.ts
@@ -412,6 +412,11 @@ describe('Settings Persistence', () => {
         // Apprise API server URL (#3012) — loaded directly by SettingsTab,
         // not surfaced via SettingsContext (admin-only field, no global hook).
         'appriseApiServerUrl',
+        // MeshCore advanced path-edit toggle — gates the manual Edit Path…
+        // button + the server-side route. Read by the route directly via
+        // databaseService.settings.getSetting and lazy-fetched on the
+        // MeshCore page; not part of SettingsContext.
+        'meshcoreAdvancedPathEdit',
       ];
 
       const keysNotLoaded = SETTINGS_TAB_SENDS.filter(


### PR DESCRIPTION
## Summary

Final slice (5/5) of the MeshCore path-management series, after #3123 / #3124 / #3127. Adds the ability to manually push arbitrary hop bytes into a contact's `out_path` via `CMD_ADD_UPDATE_CONTACT`, gated behind an explicit settings toggle.

**Why it's off by default**: Reset Path (slice 1+2) clears the route cache so auto-discovery re-floods on the next send — that's the correct affordance for "I think this route is stale". Manual editing is the *footgun* version, useful for testing / debugging / forcing a specific repeater, but bad if you forget it's set and the chosen hop drops out. Three layers of gating:

1. Off by default in settings (`meshcoreAdvancedPathEdit`).
2. UI button hidden when toggle is off.
3. Server route returns 403 when toggle is off (defense in depth).

## Backend
- New `meshcoreAdvancedPathEdit` key in `VALID_SETTINGS_KEYS`.
- `set_out_path` bridge command wrapping meshcore.js `setContactPath` (preserves `type/flags/name/lastAdvert/lat/lon` verbatim, only mutates `outPath` + `outPathLen`).
- `MeshCoreManager.setContactOutPath()` — companion-only, ≤64 bytes; mirrors the new hex / pathLen into the in-memory contact + DB row on success so the UI doesn't need to re-fetch.
- `PUT /api/sources/:id/meshcore/contacts/:publicKey/out-path` — reads the feature flag from `databaseService.settings.getSetting`. Hex-chain parser rejects malformed tokens and >64 hops.

## Frontend
- `SettingsTab` checkbox under the optimization section with a clear warning that manual paths bypass auto-discovery.
- `useMeshCore.setContactOutPath()` action with optimistic local update.
- `MeshCoreContactDetailPanel`: **Edit Path…** button in the Actions card (visible only when companion + `nodes:write` + flag enabled). Opens a modal with current path pre-filled, comma-separated hex input with live hop count, a stale-hops warning banner, and Cancel / Save Path actions.
- `MeshCoreDirectMessagesView` lazy-fetches `/api/settings` at mount to learn the current flag value (no SettingsContext plumbing).

## Test plan
- [x] `npm test` — 10,267 vitest tests pass
- [x] `npx tsc --noEmit` clean
- [x] New coverage:
  - Native backend: `set_out_path` forwards the resolved contact + path bytes; rejects oversize; errors when contact missing from device list
  - Route: requires auth; 403 when flag off; 400 on invalid pubkey / malformed hex / oversize; 200 on valid + empty (zero-hop direct); forwards exact bytes to manager; 409 on manager rejection
  - Settings persistence: added `meshcoreAdvancedPathEdit` to `SERVER_ONLY_SETTINGS` allowlist
- [ ] Manual smoke against a real Companion: enable toggle, click Edit Path on a contact, save \`a3,7f,02\`, confirm Hops Away updates and a subsequent direct send uses the new route

## The series, complete

| PR | Slice | Feature |
|---|---|---|
| #3123 | 1+2 | Persist + Reset Path |
| #3124 | 3 | Share Contact |
| #3127 | 4 | Live PathUpdated push handling |
| this | 5 | Manual path editor (feature-flagged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)