### PR TITLE
docs: reframe top-level pages as multi-protocol (Meshtastic, MeshCore, MQTT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/github/license/Yeraze/meshmonitor)](https://github.com/Yeraze/meshmonitor/blob/main/LICENSE)
 [![Translation Status](https://hosted.weblate.org/widgets/meshmonitor/-/svg-badge.svg)](https://hosted.weblate.org/engage/meshmonitor/)
 
-A comprehensive web application for monitoring Meshtastic mesh networks over IP. Built with React, TypeScript, and Node.js, featuring a beautiful Catppuccin Mocha dark theme and multi-database support (SQLite, PostgreSQL, MySQL).
+A comprehensive web application for monitoring off-grid mesh networks — Meshtastic, MeshCore, and MQTT — from a single dashboard. Built with React, TypeScript, and Node.js, featuring a beautiful Catppuccin Mocha dark theme and multi-database support (SQLite, PostgreSQL, MySQL).
 
 ![MeshMonitor Interface](docs/images/main.png)
 
@@ -217,11 +217,12 @@ MeshMonitor supports multiple deployment methods:
 
 ## Key Features
 
+- **Multi-Protocol, Multi-Source** - Monitor Meshtastic (TCP/Serial/BLE), MeshCore (USB/TCP), and MQTT brokers from a single deployment, with per-source permissions, schedulers, and Virtual Nodes
+- **Embedded MQTT Broker** - Optional built-in broker with bidirectional bridges to public upstreams and topic/channel/portnum/geo filtering
 - **Analysis & Reports (4.2)** - Cross-source analytical workspace at `/reports`; first report is Solar Monitoring Analysis with auto-detection of solar-powered nodes, production overlay, healthy-level reference lines, and multi-day battery forecast simulation
-- **Multi-Source (4.0)** - Monitor multiple Meshtastic nodes from a single deployment; per-source permissions, schedulers, and Virtual Nodes
-- **Real-time Mesh Monitoring** - Live node discovery, telemetry, and message tracking
+- **Real-time Mesh Monitoring** - Live node discovery, telemetry, and message tracking across every connected source
 - **Modern UI** - Catppuccin theme with message reactions and threading
-- **Interactive Maps** - Node positions and network topology visualization
+- **Interactive Maps** - Unified node positions and network topology visualization across all sources
 - **Multi-Database Support** - SQLite (default), PostgreSQL, and MySQL via Drizzle ORM
 - **Notifications** - Web Push and Apprise integration for 100+ services
 - **Authentication** - Local, OIDC/SSO, and reverse proxy authentication with RBAC
@@ -229,7 +230,6 @@ MeshMonitor supports multiple deployment methods:
 - **Device Configuration** - Full node configuration UI
 - **Virtual Node Server** - Remote TCP access for Meshtastic Python clients
 - **REST API** - v1 API with Bearer token authentication for external integrations
-- **MeshCore Support** - Optional monitoring for MeshCore mesh networks
 - **Docker Ready** - Pre-built multi-architecture images
 - **One-click Self-Upgrade** - Automatic upgrades from the UI with backup and rollback
 - **System Backup & Restore** - Complete disaster recovery with automated backups
@@ -242,7 +242,7 @@ For a complete feature list and technical details, visit **[meshmonitor.org](htt
 
 - Node.js 20+
 - Docker (recommended) or local Node.js environment
-- A Meshtastic device with WiFi/Ethernet connectivity
+- At least one mesh source — a Meshtastic device (WiFi/Ethernet, or Serial/BLE via bridge), a MeshCore device, or an MQTT broker
 
 ### Local Development
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -38,7 +38,7 @@ export default defineConfig({
     plugins: [newsJsonPlugin]
   },
   title: "MeshMonitor",
-  description: "Self-hosted web dashboard for Meshtastic networks. Real-time maps, messaging, telemetry, automation, and alerts. Runs on Docker, desktop, or Kubernetes.",
+  description: "Self-hosted, multi-protocol web dashboard for Meshtastic, MeshCore, and MQTT mesh networks. Real-time maps, messaging, telemetry, automation, and alerts. Runs on Docker, desktop, or Kubernetes.",
   base: '/',  // Custom domain: meshmonitor.org
 
   themeConfig: {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -145,54 +145,45 @@ docker compose up -d
 
 ## 📡 Node Management
 
-### Can I monitor multiple Meshtastic nodes with one MeshMonitor instance?
+### Can I monitor multiple nodes (or multiple mesh protocols) with one MeshMonitor instance?
 
-**No.** Each MeshMonitor instance connects to exactly **one** Meshtastic node at a time.
+**Yes.** As of 4.0, a single MeshMonitor instance is **multi-source** — it can connect to many Meshtastic nodes, MeshCore devices, and MQTT brokers at the same time.
 
-**Why:** MeshMonitor maintains a persistent TCP connection to a single node and stores all mesh data from that node's perspective.
+**How:** Each upstream connection is a **source** stored in the database. Sources are added, edited, or removed from **Dashboard → Sources** without restarting the container. Every source has its own Virtual Node, scheduler, auto-responder, permissions, and per-source views (maps, messages, telemetry, traceroutes), and there's a **unified** mode that aggregates across all of them.
 
-**Solution for multiple nodes:**
+See [Multi-Source](/features/multi-source) for the full feature description.
 
-Run multiple MeshMonitor instances, one per node:
+**Why you might still run multiple instances:** strict tenant isolation (separate databases per organization), separate auto-upgrade schedules, or running different MeshMonitor versions side by side. For most users, a single multi-source instance is the right answer — add nodes from the UI rather than spinning up a second container.
+
+**Bootstrap:** The `MESHTASTIC_NODE_IP` / `MESHTASTIC_TCP_PORT` env vars only seed the **first** source on first boot. Add additional sources (and additional protocols) from the dashboard:
 
 ```yaml
 services:
-  meshmonitor-node1:
+  meshmonitor:
     image: ghcr.io/yeraze/meshmonitor:latest
-    container_name: meshmonitor-node1
+    container_name: meshmonitor
     ports:
       - "8080:3001"
     volumes:
-      - meshmonitor-node1-data:/data
+      - meshmonitor-data:/data
     environment:
-      - MESHTASTIC_NODE_IP=192.168.1.100
+      - MESHTASTIC_NODE_IP=192.168.1.100  # Seeds source #1 on first boot
       - ALLOWED_ORIGINS=http://192.168.1.50:8080
     restart: unless-stopped
 
-  meshmonitor-node2:
-    image: ghcr.io/yeraze/meshmonitor:latest
-    container_name: meshmonitor-node2
-    ports:
-      - "8081:3001"  # Different port!
-    volumes:
-      - meshmonitor-node2-data:/data
-    environment:
-      - MESHTASTIC_NODE_IP=192.168.1.101
-      - ALLOWED_ORIGINS=http://192.168.1.50:8081
-    restart: unless-stopped
-
 volumes:
-  meshmonitor-node1-data:
-  meshmonitor-node2-data:
+  meshmonitor-data:
 ```
 
-Access them at:
-- Node 1: `http://192.168.1.50:8080`
-- Node 2: `http://192.168.1.50:8081`
+Then open **Dashboard → Sources → +** to add a second Meshtastic node, a MeshCore device, or an MQTT broker.
 
 ---
 
 ### I get CSRF errors when running multiple MeshMonitor instances on the same host
+
+::: tip First, do you actually need multiple instances?
+Since 4.0, one MeshMonitor instance is multi-source and can talk to many Meshtastic, MeshCore, and MQTT sources at once. The setup below only applies if you deliberately run multiple instances (e.g. tenant isolation, different versions).
+:::
 
 **Problem:** When running multiple MeshMonitor instances on the same host (same IP/domain, different ports), you experience random logouts, CSRF validation failures, or session conflicts.
 
@@ -499,6 +490,10 @@ cp data/meshmonitor.db ~/meshmonitor-backup-$(date +%Y%m%d).db
 ## 🌐 Network & Connectivity
 
 ### MeshMonitor can't connect to my Meshtastic node
+
+::: tip Connecting MeshCore or MQTT instead?
+The steps below apply to a Meshtastic TCP source. For MeshCore see [MeshCore](/features/meshcore); for MQTT see [Embedded MQTT Broker](/features/mqtt-broker) or check broker host, port, and credentials in **Dashboard → Sources → Edit**.
+:::
 
 **Checklist:**
 

--- a/docs/features/multi-source.md
+++ b/docs/features/multi-source.md
@@ -1,20 +1,16 @@
 # Multi-Source
 
-::: tip New in 4.0
-Multi-Source lets a single MeshMonitor deployment talk to **multiple Meshtastic nodes at once** over TCP. Serial- and BLE-attached nodes reach MeshMonitor through the **Serial Bridge** or **BLE Bridge** sidecar (they present as a TCP endpoint). Everything that used to be a global setting (Virtual Node, auto-responder, auto-traceroute, scheduler, permissions) is now configured **per source**.
-:::
-
-::: info Coming soon
-**MQTT** source types are part of the multi-source architecture but are still in active development. They'll land in a future 4.x release. **MeshCore** is a first-class source type as of 4.5 — see [MeshCore](/features/meshcore).
+::: tip New in 4.0 (expanded in 4.5+)
+Multi-Source lets a single MeshMonitor deployment talk to **multiple meshes at once** — Meshtastic, MeshCore, and MQTT — side by side. Serial- and BLE-attached Meshtastic nodes reach MeshMonitor through the **Serial Bridge** or **BLE Bridge** sidecar (they present as a TCP endpoint). Everything that used to be a global setting (Virtual Node, auto-responder, auto-traceroute, scheduler, permissions) is now configured **per source**.
 :::
 
 ![Dashboard with multiple sources in the sidebar](/images/features/dashboard-multi-source.png)
 
 ## What is a Source?
 
-A **source** is one upstream connection MeshMonitor speaks to — typically a Meshtastic node. Each source has:
+A **source** is one upstream connection MeshMonitor speaks to. Each source has:
 
-- A **type** — `meshtastic_tcp` and `meshcore` today; `mqtt` is planned. Serial and BLE Meshtastic nodes connect through the Serial Bridge / BLE Bridge sidecars and appear as `meshtastic_tcp` sources pointing at the bridge container. MeshCore connects directly — USB through the UI, TCP via the legacy env-var bootstrap path. No sidecar either way.
+- A **type** — `meshtastic_tcp`, `meshcore`, `mqtt_broker` (external MQTT broker as a source), or `mqtt_bridge` (the embedded broker bridging to an upstream). Serial and BLE Meshtastic nodes connect through the Serial Bridge / BLE Bridge sidecars and appear as `meshtastic_tcp` sources pointing at the bridge container. MeshCore connects directly — USB through the UI, TCP via the legacy env-var bootstrap path. No sidecar either way.
 - Its own **connection settings** (host, port, device path, credentials)
 - Its own **scheduler** (auto-responder, auto-announce, auto-traceroute, auto-ack)
 - Its own **Virtual Node** endpoint (TCP sources only)
@@ -61,7 +57,7 @@ Your picker choice persists per view and per user.
 
 Virtual Node is a MeshMonitor feature that lets mobile Meshtastic apps connect *through* MeshMonitor instead of directly to the node. In 4.0 it is **per-source**.
 
-- Only `meshtastic_tcp` sources support Virtual Node — MeshCore sources ignore VN settings, and the planned MQTT source type will too
+- Only `meshtastic_tcp` sources support Virtual Node — MeshCore and MQTT sources ignore VN settings
 - Each source can expose its own VN endpoint on its own port
 - Ports must be unique across sources — the API rejects collisions with HTTP 409
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,11 +71,19 @@ The following deployment methods are contributed and supported by the community:
 
 Before you begin, ensure you have:
 
-### Meshtastic Device
+### At least one mesh source
+
+MeshMonitor can monitor Meshtastic, MeshCore, and MQTT all at once — you only need **one** of these to get started. More can be added later from **Dashboard → Sources**.
+
+**Meshtastic** — any of:
 - A Meshtastic device connected to your network via IP (WiFi or Ethernet)
-- **OR** A Serial/USB device with the [Serial Bridge](/configuration/serial-bridge)
-- **OR** A Bluetooth device with the [BLE Bridge](/configuration/ble-bridge)
-- **OR** `meshtasticd` running as a virtual node
+- A Serial/USB device with the [Serial Bridge](/configuration/serial-bridge)
+- A Bluetooth device with the [BLE Bridge](/configuration/ble-bridge)
+- `meshtasticd` running as a virtual node
+
+**MeshCore** — a MeshCore companion or repeater attached over USB or reachable over TCP. See [MeshCore](/features/meshcore).
+
+**MQTT** — an MQTT broker (yours or a public one) carrying mesh traffic, or just use MeshMonitor's [embedded broker](/features/mqtt-broker) — no external broker required.
 
 ### Deployment Platform
 Choose one based on your deployment method:
@@ -249,6 +257,8 @@ ALLOWED_ORIGINS=https://meshmonitor.example.com # REQUIRED!
 - **Rate limiting**: Stricter (1000 requests/15min vs 10,000)
 
 ## Using with Virtual or Physical Devices
+
+These sections cover Meshtastic-specific setups. For MeshCore add a source from **Dashboard → Sources** ([details](/features/meshcore)); for MQTT enable the [embedded broker](/features/mqtt-broker) or point a source at an external broker.
 
 ### Virtual Nodes with meshtasticd
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,10 +4,10 @@ layout: home
 hero:
   name: "MeshMonitor"
   text: "One dashboard. Every mesh."
-  tagline: "Self-hosted Meshtastic monitoring for multi-source networks — real-time maps, alerts, per-source permissions, and full network awareness."
+  tagline: "Self-hosted multi-protocol mesh monitoring for Meshtastic, MeshCore, and MQTT — real-time maps, alerts, per-source permissions, and full network awareness."
   image:
     src: /images/features/dashboard-multi-source.png
-    alt: MeshMonitor dashboard showing multiple Meshtastic sources
+    alt: MeshMonitor dashboard showing Meshtastic, MeshCore, and MQTT sources side by side
   actions:
     - theme: brand
       text: Get Started
@@ -17,8 +17,8 @@ hero:
       link: https://github.com/yeraze/meshmonitor
 features:
   - icon: 🛰️
-    title: Multi-Source Networks
-    details: Connect to many Meshtastic nodes at once — TCP, Serial, or BLE. One dashboard, per-source maps, messages, telemetry, and traceroutes. No restart to add or remove a source.
+    title: Multi-Protocol, Multi-Source
+    details: Connect Meshtastic (TCP, Serial, BLE), MeshCore, and MQTT brokers all at once — mix and match in one dashboard. Per-source maps, messages, telemetry, and traceroutes. No restart to add or remove a source.
 
   - icon: 📡
     title: MeshCore Support
@@ -125,26 +125,32 @@ Access at `http://localhost:8080` and login with username `admin` and password `
 
 For production deployments, Kubernetes, reverse proxies, and advanced configurations, see the [Production Deployment Guide](/configuration/production).
 
-## What is Meshtastic?
+## What can MeshMonitor monitor?
 
-[Meshtastic](https://meshtastic.org/) is an open-source, off-grid, decentralized mesh network built on affordable, low-power devices. MeshMonitor provides a web-based interface to monitor and manage your Meshtastic network.
+MeshMonitor speaks three off-grid mesh ecosystems and treats them as peers in one deployment:
+
+- **[Meshtastic](https://meshtastic.org/)** — an open-source, off-grid, decentralized mesh network built on affordable, low-power devices. Connect over TCP, Serial (via the [Serial Bridge](/configuration/serial-bridge)), or BLE (via the [BLE Bridge](/configuration/ble-bridge)).
+- **[MeshCore](/features/meshcore)** — companions and repeaters connected over USB or TCP, alongside or instead of Meshtastic.
+- **MQTT** — connect to an external MQTT broker as a read-only source, or run the [embedded broker](/features/mqtt-broker) with bidirectional bridges to public upstreams.
+
+Pick one, mix all three — MeshMonitor's unified views, per-source permissions, and the same automation, telemetry, and map features apply to every source you add.
 
 ## Key Features
 
 ### Network Visualization
-View your entire mesh network on an interactive map, with nodes colored by their signal strength and connectivity status. Track node positions, signal quality, and network topology in real-time.
+View every connected mesh — Meshtastic, MeshCore, MQTT — on a single interactive map, with nodes colored by signal strength and connectivity status. Track node positions, signal quality, and network topology in real-time.
 
 ### Message History
-Access complete message history across all channels. Search, filter, and export messages for analysis or record-keeping.
+Access complete message history across every source and channel. Search, filter, and export messages for analysis or record-keeping.
 
 ### Node Management
-Monitor individual node health, battery levels, environmental telemetry, and connection status. View detailed statistics for each node in your network.
+Monitor individual node health, battery levels, environmental telemetry, and connection status. View detailed statistics for each node in your network, regardless of source protocol.
 
 ### Channel Configuration
-Manage multiple channels, view channel settings, and monitor message flow across different communication channels in your mesh.
+Manage multiple channels, view channel settings, and monitor message flow across different communication channels — Meshtastic channels, MeshCore channels, and MQTT topics alike.
 
 ### Security Monitoring
-Automatically detect and flag nodes with security vulnerabilities. MeshMonitor identifies low-entropy (weak) encryption keys and duplicate keys shared across multiple nodes. Visual warnings and filtering options help you maintain a secure mesh network.
+Automatically detect and flag nodes with security vulnerabilities. MeshMonitor identifies low-entropy (weak) encryption keys and duplicate keys shared across multiple Meshtastic nodes. Visual warnings and filtering options help you maintain a secure mesh.
 
 ## Deployment Options
 
@@ -157,7 +163,7 @@ MeshMonitor supports multiple deployment scenarios:
 ## Screenshots
 
 ### Multi-Source Dashboard
-Every source your deployment touches shows up in the sidebar with its own health, map pin colour, and unified or source-scoped views. Meshtastic TCP (with Serial/BLE via the bridge sidecars), USB-attached MeshCore, and the embedded MQTT broker are first-class today; TCP MeshCore is supported via the legacy env-var bootstrap path.
+Every source your deployment touches shows up in the sidebar with its own health, map pin colour, and unified or source-scoped views. Meshtastic (TCP, plus Serial/BLE via the bridge sidecars), MeshCore (USB or TCP), MQTT brokers, and the embedded MQTT bridge are all first-class — mix and match without a restart.
 
 ![Multi-Source Dashboard](/images/features/dashboard-multi-source.png)
 


### PR DESCRIPTION
## Summary
- Refresh user-facing docs so the project is described as multi-protocol (Meshtastic, MeshCore, MQTT) rather than Meshtastic-only.
- Touches landing page (`docs/index.md`), `README.md`, `docs/getting-started.md`, `docs/faq.md`, `docs/features/multi-source.md`, and the VitePress site `description` meta in `docs/.vitepress/config.mts`.
- Flips the FAQ "Can I monitor multiple Meshtastic nodes?" answer to **Yes** and points users at the multi-source UI. Removes "MQTT coming soon / planned" notices from the multi-source feature page now that `mqtt_broker` and `mqtt_bridge` are first-class source types in the schema.
- Broadens the "Meshtastic Device" prerequisite section in Getting Started into "At least one mesh source" with Meshtastic, MeshCore, and MQTT branches. Adds source-type hints to FAQ entries that previously assumed a Meshtastic TCP source.

## What was deliberately left alone
- Protocol-specific docs (`configuration/serial-bridge.md`, `configuration/ble-bridge.md`, `configuration/meshtasticd.md`, `configuration/virtual-node.md`, device-config pages) — these are legitimately Meshtastic-scoped and don't need rewording.
- `MESHTASTIC_NODE_IP` / `MESHTASTIC_TCP_PORT` env var docs — still accurate as the bootstrap path for the first source.

## Test plan
- [ ] Build the docs site (`npm run docs:dev` or `npm run docs:build`) and visually confirm the homepage hero, "What can MeshMonitor monitor?" section, and updated FAQ render correctly
- [ ] Check that internal links (`/features/meshcore`, `/features/mqtt-broker`, `/configuration/serial-bridge`, `/configuration/ble-bridge`) resolve in the built site
- [ ] Confirm the `<meta name="description">` tag in built HTML reflects the new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)