### PR TITLE
release(4.6.4): MeshCore path-management polish (docs + button styles + version bump)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.6.3",
+  "version": "4.6.4",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/ARCHITECTURE_LESSONS.md
+++ b/docs/ARCHITECTURE_LESSONS.md
@@ -14,6 +14,7 @@ This document captures critical insights learned during MeshMonitor development.
 7. [Background Task Management](#background-task-management)
 8. [Multi-Database Architecture](#multi-database-architecture)
 9. [Multi-Source Architecture](#multi-source-architecture)
+10. [MeshCore Routing & Paths](#meshcore-routing--paths)
 
 ---
 
@@ -949,5 +950,68 @@ Auto-key-management, immediate purge, and the manual key-repair button all send 
 
 ---
 
-**Last Updated**: 2026-03-22
-**Related PRs**: #427, #429, #430, #431, #432, #433, #1359 (packet filtering), #1360 (protocol constants), #1404 (PostgreSQL support), #1405 (MySQL support), #1436 (async test fixes), #2243 (key mismatch detection), #2246 (neighbor info zoom setting), #2365 (key mismatch clearing), #2382 (PKI error detection)
+## MeshCore Routing & Paths
+
+MeshCore and Meshtastic both speak "paths," but the semantics are different enough that conflating them silently breaks features. Read this before touching anything in `src/server/meshcoreManager.ts`, the MeshCore detail panel, or the `meshcore_nodes.out_path` column.
+
+### Path is a **forwarding instruction**, not a hop trace
+
+In Meshtastic, a traceroute records the hops a packet visited after the fact. In MeshCore, the `path` field of every packet is **what the sender writes into the header to instruct routers where to send it next** (`src/Packet.h` in `meshtastic/MeshCore`). Two-bit route mode in the header:
+
+| Mode | Meaning |
+|---|---|
+| `ROUTE_TYPE_FLOOD` (1) | Packet floods; each forwarder appends `SNR*4` to `path[]` so the destination can read the SNR trace and reply with a discovered route |
+| `ROUTE_TYPE_DIRECT` (2) | Sender writes hop hashes into `path[]`; each router consumes one hash and forwards |
+| `TRANSPORT_FLOOD` / `TRANSPORT_DIRECT` (0/3) | Same modes + transport-code prefix |
+
+`MAX_PATH_SIZE = 64`. Hash size defaults to 1 byte per hop.
+
+### Per-contact `out_path` cache
+
+`ContactInfo.out_path` is the cached route **the local device uses next time it sends to this contact**. `out_path_len = OUT_PATH_UNKNOWN (0xFF)` means "we don't know — next send floods to discover." meshcore.js reads `out_path_len` as `Int8`, so the sentinel arrives as either `0xFF` or `-1` depending on platform; `formatOutPath()` in `src/server/meshcoreNativeBackend.ts` handles both.
+
+The firmware learns the path passively: send floods, destination replies via `PAYLOAD_TYPE_PATH` containing the reversed hop chain, manager stores it via `onContactPathRecv`. After that, sends to this contact are ROUTE_TYPE_DIRECT — much cheaper than flooding.
+
+### The four user actions, and why they're distinct
+
+This is the load-bearing distinction in the UI:
+
+| Action | Wire opcode | When to use |
+|---|---|---|
+| **Reset Path** | `CMD_RESET_PATH` (13) | "I think the cached route is stale — let auto-discovery flood next time." Sets `out_path_len = 0xFF`. Safe; firmware re-learns. |
+| **Share Contact** | `CMD_SHARE_CONTACT` (16) | "Broadcast this contact's stored advert so nearby nodes can add them." Pure retransmit; no local state changes. |
+| **Set Out-Path** | `CMD_ADD_UPDATE_CONTACT` (9) | Manually push specific hop bytes. Footgun: stale hops silently drop direct sends until the next flood. |
+| **Send Trace Path** | `CMD_SEND_TRACE_PATH` (36) | Explicit hop-by-hop SNR probe — closest analogue to Meshtastic traceroute. Not currently exposed in MeshMonitor. |
+
+**Reset Path is the default user-facing affordance.** Set Out-Path lives behind the `meshcoreAdvancedPathEdit` setting (off by default, server-side enforced) because users forget they pinned a route and then can't reach the contact when one hop disappears.
+
+### Path bytes are **hop hashes**, not node IDs
+
+A 1-byte hash collides — the UI can't always map every hop to a known node. Surface the hex chain (`a3,7f,02`) verbatim and accept that. Don't try to resolve hashes to names; you'll be wrong some of the time.
+
+### `PUSH_CODE_PATH_UPDATED` carries only the pubkey
+
+The push tells the app "this contact's path changed" but the body is just the 32-byte public key. To learn the new hop bytes you have to re-read the contact record. meshcore.js doesn't expose `CMD_GET_CONTACT_BY_KEY` (opcode 30) yet, so MeshMonitor falls back to `refreshContacts()` over a 1.5 s debounce window (`PATH_REFRESH_DEBOUNCE_MS`). A chatty contact churning its route across N back-to-back pushes costs **one** device sync, not N. If meshcore.js ever exposes the single-contact fetcher, swap it in here — same emit semantics, narrower wire traffic.
+
+After the refresh, only pubkeys still present in the contact list emit a `meshcore:contact:updated` WS event. A contact aged out during the window doesn't synthesize a stale UI row.
+
+### Companion-only
+
+`CMD_RESET_PATH`, `CMD_SHARE_CONTACT`, and `CMD_ADD_UPDATE_CONTACT` are only supported on Companion firmware (`deviceType = 1`). Gate every UI action and manager method on `deviceType === COMPANION` — Repeaters speak the serial CLI, not the companion binary protocol, and will silently fail or error.
+
+### Schema scoping
+
+`meshcore_nodes.out_path` (TEXT) and `meshcore_nodes.path_len` (INTEGER) live on the existing `(sourceId, publicKey)` composite-keyed table (migration 061). Path data is inherently per-source — different radios learn different routes to the same contact — so the columns inherit the source scope without extra work. Don't add a global path table.
+
+### Critical Design Principles
+
+- **Path = forwarding instruction, not trace.** Naming and UI copy should reflect that.
+- **Reset Path is the safe default.** Manual edits are advanced + flagged.
+- **Debounce push-driven refreshes.** Direct device queries per push thrash the link.
+- **Treat `0xFF` and `-1` as the same OUT_PATH_UNKNOWN sentinel.** meshcore.js parses path_len as Int8.
+- **Companion-only.** Wrap every path action in a `deviceType === COMPANION` guard.
+
+---
+
+**Last Updated**: 2026-05-21
+**Related PRs**: #427, #429, #430, #431, #432, #433, #1359 (packet filtering), #1360 (protocol constants), #1404 (PostgreSQL support), #1405 (MySQL support), #1436 (async test fixes), #2243 (key mismatch detection), #2246 (neighbor info zoom setting), #2365 (key mismatch clearing), #2382 (PKI error detection), #3123 #3124 #3127 #3130 (MeshCore path management)

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.6.3
-appVersion: "4.6.3"
+version: 4.6.4
+appVersion: "4.6.4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.6.3",
+      "version": "4.6.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -300,6 +300,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                 {canShowResetButton && pathKnown && (
                   <button
                     type="button"
+                    className="btn-secondary"
                     onClick={handleResetPath}
                     disabled={resetting}
                     aria-label={t('meshcore.contact_details.reset_path_button', 'Reset Path')}
@@ -312,6 +313,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                 {canShowShareButton && (
                   <button
                     type="button"
+                    className="btn-secondary"
                     onClick={handleShareContact}
                     disabled={sharing}
                     aria-label={t('meshcore.contact_details.share_contact_button', 'Share Contact')}
@@ -324,6 +326,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                 {canShowEditButton && (
                   <button
                     type="button"
+                    className="btn-secondary"
                     onClick={openEditor}
                     aria-label={t('meshcore.contact_details.edit_path_button', 'Edit Path…')}
                   >
@@ -491,6 +494,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
               <button
                 type="button"
+                className="btn-secondary"
                 onClick={() => setEditorOpen(false)}
                 disabled={editorSaving}
               >
@@ -498,6 +502,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
               </button>
               <button
                 type="button"
+                className="btn-primary"
                 onClick={handleSaveEditor}
                 disabled={editorSaving}
               >


### PR DESCRIPTION
## Summary

Patch release rolling up the post-merge polish for the MeshCore path-management series (#3123 / #3124 / #3127 / #3130):

- **Architecture lessons** — new "MeshCore Routing & Paths" section in `docs/ARCHITECTURE_LESSONS.md` documenting the load-bearing distinction between Meshtastic-style traceroute traces and MeshCore-style sender-supplied forwarding instructions, the four user actions and when to use each, the `0xFF`/`-1` sentinel gotcha, and the push-debounce design. Helps the next agent avoid conflating the two protocols.
- **Button styles** — Reset Path / Share Contact / Edit Path… / Cancel / Save Path were rendering as unstyled native browser buttons. Applied the project's canonical `btn-secondary` (row actions, dialog Cancel) and `btn-primary` (dialog Save) so they pick up Catppuccin colors, padding, rounded corners, and hover/disabled states.
- **Version bump** — 4.6.3 → 4.6.4 across all five files per the release checklist in CLAUDE.md (root `package.json` + lockfile, `helm/meshmonitor/Chart.yaml`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`).

## Commits in this PR
- `59fd6b51` style(meshcore): apply btn-primary/btn-secondary to path-action buttons
- `be9982a7` docs: document MeshCore routing & paths in architecture lessons
- `3dc037e9` chore(release): bump version to 4.6.4

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] All four MeshCore path PRs already verified locally via dev container against a real Companion source (Reset Path, Share Contact, Hops/Path display, manual Edit Path with the flag toggled on/off)
- [x] Button styling visually confirmed in the dev container after redeploying with `style(...)` applied
- [ ] **system-test label applied** — hardware system tests should run as part of CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)