### PR TITLE
fix(mqtt): store ingested publicKey as base64 (not hex), backfill via migration 069

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 68 migrations registered', () => {
-    expect(registry.count()).toBe(68);
+  it('has all 69 migrations registered', () => {
+    expect(registry.count()).toBe(69);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is meshcore_nodes_out_path', () => {
+  it('last migration is normalize_node_public_keys_to_base64', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(68);
-    expect(last.name).toContain('meshcore_nodes_out_path');
+    expect(last.number).toBe(69);
+    expect(last.name).toContain('normalize_node_public_keys_to_base64');
   });
 
-  it('migrations are sequentially numbered from 1 to 68', () => {
+  it('migrations are sequentially numbered from 1 to 69', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -83,6 +83,7 @@ import { migration as addMessageSourceAttributionMigration, runMigration065Postg
 import { migration as addTransportMechanismToNodesMigration, runMigration066Postgres, runMigration066Mysql } from '../server/migrations/066_add_transport_mechanism_to_nodes.js';
 import { migration as addShowUdpRfNodesToMapPrefsMigration, runMigration067Postgres, runMigration067Mysql } from '../server/migrations/067_add_show_udp_rf_nodes_to_map_prefs.js';
 import { migration as meshcoreNodesOutPathMigration, runMigration068Postgres, runMigration068Mysql } from '../server/migrations/068_meshcore_nodes_out_path.js';
+import { migration as normalizeNodePublicKeysToBase64Migration, runMigration069Postgres, runMigration069Mysql } from '../server/migrations/069_normalize_node_public_keys_to_base64.js';
 
 // ============================================================================
 // Registry
@@ -1077,4 +1078,22 @@ registry.register({
   sqlite: (db) => meshcoreNodesOutPathMigration.up(db),
   postgres: (client) => runMigration068Postgres(client),
   mysql: (pool) => runMigration068Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 069: Normalize nodes.publicKey to base64. Cleanup for the MQTT
+// ingest path that stored publicKey as hex while every other path used
+// base64 — caused false-positive key-mismatch warnings every time a
+// MQTT-seen node later sent NodeInfo over the direct radio. Converts every
+// row matching `^[0-9a-f]{64}$` (lowercase 32-byte hex) to its base64
+// equivalent. Idempotent.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 69,
+  name: 'normalize_node_public_keys_to_base64',
+  settingsKey: 'migration_069_normalize_node_public_keys_to_base64',
+  sqlite: (db) => normalizeNodePublicKeysToBase64Migration.up(db),
+  postgres: (client) => runMigration069Postgres(client),
+  mysql: (pool) => runMigration069Mysql(pool),
 });

--- a/src/server/migrations/069_normalize_node_public_keys_to_base64.test.ts
+++ b/src/server/migrations/069_normalize_node_public_keys_to_base64.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for migration 069 (SQLite path) — convert hex-encoded
+ * nodes.publicKey rows to base64.
+ *
+ * The migration's predicate is `length(publicKey) = 64` + JS-side regex
+ * `^[0-9a-f]{64}$`, so rows that already store base64 (44 chars, mixed
+ * case + `+/=`) are left alone and the migration is idempotent.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './069_normalize_node_public_keys_to_base64.js';
+
+describe('Migration 069 — normalize nodes.publicKey to base64', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    // Minimal table — only the columns the migration touches.
+    db.exec(`
+      CREATE TABLE nodes (
+        nodeNum INTEGER PRIMARY KEY,
+        publicKey TEXT
+      );
+    `);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('converts a hex publicKey to base64', () => {
+    // 32 bytes: 0x1e c4 c0 f2 39 09 ... (rest zero)
+    const hex = '1ec4c0f23909' + '00'.repeat(26);
+    db.prepare(`INSERT INTO nodes (nodeNum, publicKey) VALUES (?, ?)`).run(1, hex);
+
+    migration.up(db);
+
+    const row = db.prepare(`SELECT publicKey FROM nodes WHERE nodeNum = 1`).get() as { publicKey: string };
+    const expected = Buffer.from(hex, 'hex').toString('base64');
+    expect(row.publicKey).toBe(expected);
+    // Sanity: round-trip back to hex must match.
+    expect(Buffer.from(row.publicKey, 'base64').toString('hex')).toBe(hex);
+  });
+
+  it('leaves existing base64 publicKey values alone (idempotent)', () => {
+    const hex = 'deadbeef' + '00'.repeat(28);
+    const base64 = Buffer.from(hex, 'hex').toString('base64');
+    db.prepare(`INSERT INTO nodes (nodeNum, publicKey) VALUES (?, ?)`).run(2, base64);
+
+    migration.up(db);
+
+    const row = db.prepare(`SELECT publicKey FROM nodes WHERE nodeNum = 2`).get() as { publicKey: string };
+    expect(row.publicKey).toBe(base64);
+  });
+
+  it('is idempotent when run twice', () => {
+    const hex = 'aabbccdd' + '00'.repeat(28);
+    db.prepare(`INSERT INTO nodes (nodeNum, publicKey) VALUES (?, ?)`).run(3, hex);
+
+    migration.up(db);
+    const firstPass = (db.prepare(`SELECT publicKey FROM nodes WHERE nodeNum = 3`).get() as { publicKey: string }).publicKey;
+    migration.up(db);
+    const secondPass = (db.prepare(`SELECT publicKey FROM nodes WHERE nodeNum = 3`).get() as { publicKey: string }).publicKey;
+
+    expect(secondPass).toBe(firstPass);
+    expect(secondPass).toBe(Buffer.from(hex, 'hex').toString('base64'));
+  });
+
+  it('skips NULL publicKey rows', () => {
+    db.prepare(`INSERT INTO nodes (nodeNum, publicKey) VALUES (?, ?)`).run(4, null);
+    expect(() => migration.up(db)).not.toThrow();
+    const row = db.prepare(`SELECT publicKey FROM nodes WHERE nodeNum = 4`).get() as { publicKey: string | null };
+    expect(row.publicKey).toBeNull();
+  });
+
+  it('skips strings that are 64 chars but contain non-hex characters', () => {
+    // Length matches the predicate but it's not actually hex — must not be
+    // converted (Buffer.from(garbage, 'hex') silently truncates and would
+    // produce a wrong base64 value).
+    const garbage = 'g'.repeat(64);
+    db.prepare(`INSERT INTO nodes (nodeNum, publicKey) VALUES (?, ?)`).run(5, garbage);
+
+    migration.up(db);
+
+    const row = db.prepare(`SELECT publicKey FROM nodes WHERE nodeNum = 5`).get() as { publicKey: string };
+    expect(row.publicKey).toBe(garbage);
+  });
+
+  it('converts only the matching rows when a mix is present', () => {
+    const hex = 'cafebabe' + '00'.repeat(28);
+    const alreadyB64 = Buffer.from(hex, 'hex').toString('base64');
+
+    db.prepare(`INSERT INTO nodes (nodeNum, publicKey) VALUES (?, ?)`).run(10, hex);
+    db.prepare(`INSERT INTO nodes (nodeNum, publicKey) VALUES (?, ?)`).run(11, alreadyB64);
+    db.prepare(`INSERT INTO nodes (nodeNum, publicKey) VALUES (?, ?)`).run(12, null);
+
+    migration.up(db);
+
+    const r10 = (db.prepare(`SELECT publicKey FROM nodes WHERE nodeNum = 10`).get() as { publicKey: string }).publicKey;
+    const r11 = (db.prepare(`SELECT publicKey FROM nodes WHERE nodeNum = 11`).get() as { publicKey: string }).publicKey;
+    const r12 = (db.prepare(`SELECT publicKey FROM nodes WHERE nodeNum = 12`).get() as { publicKey: string | null }).publicKey;
+
+    expect(r10).toBe(alreadyB64);
+    expect(r11).toBe(alreadyB64);
+    expect(r12).toBeNull();
+  });
+});

--- a/src/server/migrations/069_normalize_node_public_keys_to_base64.ts
+++ b/src/server/migrations/069_normalize_node_public_keys_to_base64.ts
@@ -1,0 +1,105 @@
+/**
+ * Migration 069: Normalize `nodes.publicKey` to base64.
+ *
+ * Cleanup for the MQTT ingest bug at `src/server/mqttIngestion.ts:224`
+ * (fixed in the same PR as this migration): NodeInfo packets received
+ * via MQTT were written as **hex** while the direct serial/TCP path and
+ * the device's own security-config handshake both wrote **base64**.
+ *
+ * The encoding mismatch caused the key-mismatch detector at
+ * `meshtasticManager.ts:5572` (`existingNode.publicKey !== nodeData.publicKey`)
+ * to fire as a false positive every time a node first seen via MQTT
+ * later sent NodeInfo over the radio — the underlying bytes were
+ * identical, only the string encoding differed.
+ *
+ * This migration converts every `nodes.publicKey` value that matches
+ * `^[0-9a-f]{64}$` (lowercase 32-byte hex) into its base64 equivalent.
+ * Idempotent: base64-encoded keys are 44 chars and include uppercase or
+ * `+/=`, so they don't match the predicate on a second run.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 069';
+const HEX_PUBKEY_RE = /^[0-9a-f]{64}$/;
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): normalizing hex-encoded nodes.publicKey to base64...`);
+    // SQLite has no native base64 encode; do the conversion in JS.
+    // eslint-disable-next-line no-restricted-syntax -- migrations require raw DML
+    const rows = db
+      .prepare(`SELECT nodeNum, publicKey FROM nodes WHERE publicKey IS NOT NULL AND length(publicKey) = 64`)
+      .all() as Array<{ nodeNum: number; publicKey: string }>;
+    // eslint-disable-next-line no-restricted-syntax -- migrations require raw DML
+    const update = db.prepare(`UPDATE nodes SET publicKey = ? WHERE nodeNum = ?`);
+    let converted = 0;
+    for (const row of rows) {
+      if (!HEX_PUBKEY_RE.test(row.publicKey)) continue;
+      const base64 = Buffer.from(row.publicKey, 'hex').toString('base64');
+      update.run(base64, row.nodeNum);
+      converted++;
+    }
+    logger.info(`${LABEL} (SQLite): converted ${converted} hex publicKey value(s) to base64`);
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (data conversion is not safely reversible)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration069Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): normalizing hex-encoded nodes."publicKey" to base64...`);
+  // PG's encode(decode(col, 'hex'), 'base64') would work, but it wraps
+  // every 76 chars with newlines. For 32-byte keys (44 base64 chars)
+  // no wrap occurs, but to stay defensive against future longer keys,
+  // do the conversion in JS for parity with the SQLite path.
+  const { rows } = await client.query(
+    `SELECT "nodeNum", "publicKey" FROM nodes
+      WHERE "publicKey" IS NOT NULL
+        AND length("publicKey") = 64
+        AND "publicKey" ~ '^[0-9a-f]+$'`,
+  );
+  let converted = 0;
+  for (const row of rows as Array<{ nodeNum: number | string; publicKey: string }>) {
+    if (!HEX_PUBKEY_RE.test(row.publicKey)) continue;
+    const base64 = Buffer.from(row.publicKey, 'hex').toString('base64');
+    await client.query(
+      `UPDATE nodes SET "publicKey" = $1 WHERE "nodeNum" = $2`,
+      [base64, row.nodeNum],
+    );
+    converted++;
+  }
+  logger.info(`${LABEL} (PostgreSQL): converted ${converted} hex publicKey value(s) to base64`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration069Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): normalizing hex-encoded nodes.publicKey to base64...`);
+  const conn = await pool.getConnection();
+  try {
+    const [rows] = await conn.query(
+      `SELECT nodeNum, publicKey FROM nodes
+        WHERE publicKey IS NOT NULL
+          AND CHAR_LENGTH(publicKey) = 64
+          AND publicKey REGEXP '^[0-9a-f]+$'`,
+    );
+    let converted = 0;
+    for (const row of rows as Array<{ nodeNum: number | string; publicKey: string }>) {
+      if (!HEX_PUBKEY_RE.test(row.publicKey)) continue;
+      const base64 = Buffer.from(row.publicKey, 'hex').toString('base64');
+      await conn.query(`UPDATE nodes SET publicKey = ? WHERE nodeNum = ?`, [base64, row.nodeNum]);
+      converted++;
+    }
+    logger.info(`${LABEL} (MySQL): converted ${converted} hex publicKey value(s) to base64`);
+  } finally {
+    conn.release();
+  }
+}

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -221,7 +221,16 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         // the map regardless of what they grant.
         channel: effectiveChannel,
         macaddr: user.macaddr ? bytesToHex(user.macaddr) : undefined,
-        publicKey: user.publicKey ? bytesToHex(user.publicKey) : (user.public_key ? bytesToHex(user.public_key) : undefined),
+        // publicKey is stored base64 across the rest of the codebase
+        // (see meshtasticManager.ts:5546 and the security-config save
+        // path at 3594). Using bytesToHex here would diverge from those
+        // paths and trip the false-positive "key mismatch" warning every
+        // time a node first ingested via MQTT later sends NodeInfo over
+        // the direct radio link. Cleanup of existing hex rows happens in
+        // migration 069.
+        publicKey: user.publicKey
+          ? Buffer.from(user.publicKey).toString('base64')
+          : (user.public_key ? Buffer.from(user.public_key).toString('base64') : undefined),
         lastHeard: Math.floor(nowMs / 1000),
         sourceId,
         createdAt: nowMs,


### PR DESCRIPTION
## Summary

Fixes a long-standing false-positive in the key-mismatch detector caused by an encoding disagreement between the MQTT ingest path and every other publicKey write site.

### The bug

| Path | File:line | Encoding |
|---|---|---|
| Direct serial/TCP NodeInfo | \`meshtasticManager.ts:5546\` | base64 |
| Device security-config handshake | \`meshtasticManager.ts:3594\` | base64 |
| **MQTT NodeInfo ingest** | \`mqttIngestion.ts:224\` | **hex** ← inconsistent |

When a node arrived via MQTT first, its key was stored hex-encoded. When the same node later sent NodeInfo over the direct radio link, the comparison at \`meshtasticManager.ts:5572\`

\`\`\`ts
if (existingNode && existingNode.publicKey && nodeData.publicKey && existingNode.publicKey !== nodeData.publicKey)
\`\`\`

compared \`"1ec4c0f23909..."\` (hex) against \`"HsTA8jkJ..."\` (base64) — never equal, even though the 32 underlying bytes were identical. The user-visible symptom: repeated \`🔐 Key mismatch detected\` log warnings for nodes whose keys had never actually changed. The upsert path then "self-healed" by overwriting hex with base64, but the next MQTT-side update flipped it back, and the cycle repeated.

Diagnosed by decoding the live log fragments side-by-side:
\`\`\`
stored=1ec4c0f2...  →  hex  →  0x1e 0xc4 0xc0 0xf2 ...
mesh=HsTA8jkJ...    → base64 →  0x1e 0xc4 0xc0 0xf2 0x39 0x09 ...
\`\`\`
Identical bytes.

### Fix
\`src/server/mqttIngestion.ts\` now encodes \`user.publicKey\` (and the snake-case fallback) as base64, matching all other paths.

### Cleanup migration

\`src/server/migrations/069_normalize_node_public_keys_to_base64.ts\` scans \`nodes.publicKey\` for lowercase 32-byte hex (\`^[0-9a-f]{64}$\`) and converts each to its base64 equivalent. Idempotent across SQLite / PostgreSQL / MySQL — base64 output is 44 chars and contains uppercase / \`+\` / \`/\` / \`=\`, so a second run finds nothing to match.

After this lands and the migration runs, any node whose key was stored hex by historical MQTT ingest will be converted in-place. No more spurious mismatch warnings; the key-mismatch detector only fires on **actual** key changes.

## Test plan
- [x] \`npm test\` — 10,287 vitest tests pass
- [x] \`npx tsc --noEmit\` clean
- [x] New \`069_normalize_node_public_keys_to_base64.test.ts\` covers: hex → base64 conversion, base64 left alone, idempotent on second run, NULL-skip, 64-char-but-non-hex-skip, mixed-row scenarios
- [x] Migration test count bumped to 69 with last-migration assertion updated
- [ ] After deploy: tail the dev container for \`🔐 Key mismatch detected\` warnings — expect zero for the previously-flapping nodes (Yeraze StationG2, KE4JQ G2 Base, LANTANA G2, Base 01, Julie Portable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)