### PR TITLE
feat(mqtt): allow standalone mqtt_bridge as client-proxy target (#3134)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -83,7 +83,7 @@ export default defineConfig({
             { text: 'Security', link: '/features/security' },
             { text: 'Message Search', link: '/features/message-search' },
             { text: 'Store & Forward', link: '/features/store-forward' },
-            { text: 'Embedded MQTT Broker', link: '/features/mqtt-broker' },
+            { text: 'Embedded MQTT Broker & Bridge', link: '/features/mqtt-broker' },
             { text: 'Embed Maps', link: '/features/embed-maps' },
             { text: 'Map Analysis', link: '/features/map-analysis' },
             { text: 'Waypoints', link: '/features/waypoints' },

--- a/docs/features/mqtt-broker.md
+++ b/docs/features/mqtt-broker.md
@@ -1,7 +1,7 @@
-# Embedded MQTT Broker
+# Embedded MQTT Broker & Bridge
 
 ::: tip Added in 4.6
-The embedded MQTT broker and bidirectional bridges shipped in MeshMonitor 4.6 (PR [#3053](https://github.com/Yeraze/meshmonitor/pull/3053), follow-up client-proxy bridge in PR [#3054](https://github.com/Yeraze/meshmonitor/pull/3054), resolving [issue #3003](https://github.com/Yeraze/meshmonitor/issues/3003)).
+The embedded MQTT broker and bidirectional bridges shipped in MeshMonitor 4.6 (PR [#3053](https://github.com/Yeraze/meshmonitor/pull/3053), follow-up client-proxy bridge in PR [#3054](https://github.com/Yeraze/meshmonitor/pull/3054), resolving [issue #3003](https://github.com/Yeraze/meshmonitor/issues/3003)). **Standalone bridges** (no parent broker required) were added in a later release ([issue #3134](https://github.com/Yeraze/meshmonitor/issues/3134)).
 :::
 
 MeshMonitor can run its own MQTT broker inside the same container, so your Meshtastic devices (and any other MQTT clients on your network) can publish directly to MeshMonitor — and MeshMonitor can relay that traffic, with **filtering rules**, to public upstream brokers like `mqtt.meshtastic.org`.
@@ -14,32 +14,99 @@ The embedded broker shifts this fight to the server, where MeshMonitor already h
 
 ## Two source types
 
-The feature adds two new source types in **Dashboard → Sources → Add Source**:
+The feature adds two new source types in **Dashboard → Sources → Add Source**: an `mqtt_broker` that **accepts** MQTT connections (a server), and an `mqtt_bridge` that **opens** an MQTT connection (a client). They can run together, separately, or in any combination — picking the right one (or both) is the most common configuration question, so the rest of this section walks through each in detail and ends with a side-by-side feature matrix.
 
-### `mqtt_broker` — the listener
+### `mqtt_broker` — accept connections from devices and other MQTT clients
 
-A self-contained MQTT broker, backed by [Aedes](https://github.com/moscajs/aedes) (a pure-Node, MQTT 3.1.1 broker, MIT-licensed). Listens on a configurable TCP port (default `1883`) with shared username/password authentication. Decodes [`ServiceEnvelope`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mqtt.proto) packets from any client that publishes, and ingests decodable payloads (NodeInfo, Position, TextMessage, Telemetry) into the database under this source's `sourceId`.
+A self-contained MQTT broker, backed by [Aedes](https://github.com/moscajs/aedes) (a pure-Node, MQTT 3.1.1 broker, MIT-licensed). MeshMonitor opens a TCP port (default `1883`), advertises shared username/password authentication, and accepts MQTT 3.1.1 clients that connect to it.
 
-### `mqtt_bridge` — the upstream connection
+**What it does**
 
-References a parent `mqtt_broker` by ID and connects to one upstream MQTT server via [MQTT.js](https://github.com/mqttjs/MQTT.js). Each bridge has independent **downlink** (upstream → local) and **uplink** (local → upstream) filter pipelines:
+- Listens on `0.0.0.0:<port>` (configurable; defaults to the IANA-registered MQTT port `1883`).
+- Authenticates every CONNECT with a single shared username/password pair (default-deny: connections without configured credentials are rejected).
+- Decodes [`ServiceEnvelope`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mqtt.proto) packets from any client that publishes under its `rootTopic` (default `msh`), and ingests decodable payloads (NodeInfo, Position, TextMessage, Telemetry) into the database under this source's `sourceId`. Other clients subscribed to the broker still see the raw byte-for-byte publish, so devices can fan out to each other over MQTT just like they would on a public broker.
+- Optionally clamps `hop_limit` to `0` on every Meshtastic packet it delivers to a connected client ("Zero-hop injection" — see below), matching `mqtt.meshtastic.org`'s behavior so MQTT-bridged packets don't trigger RF re-broadcasts.
+- Generates a synthetic gateway identity (`nodeNum`, `!nodeId`, longName, shortName) at create time so its publishes look like they're coming from a real node to upstream brokers.
 
-- **Topic patterns** (MQTT wildcards: `+` single-segment, `#` multi-segment tail)
-- **Channel name** allow / block lists
-- **Node ID** allow / block lists (`!xxxxxxxx`)
-- **PortNum** allow / block lists ([Meshtastic PortNum enum](https://github.com/meshtastic/protobufs/blob/master/meshtastic/portnums.proto))
-- **Geographic bounding box** — drop position packets whose `latitude_i / 1e7, longitude_i / 1e7` falls outside `{ minLat, maxLat, minLng, maxLng }`. Applied before republish so out-of-area positions never reach devices on the local broker.
+**When to use a broker**
 
-60-second `(topic, packetId)` echo suppression on both directions prevents bridge feedback loops.
+- You want **multiple devices** to share a single set of MQTT credentials and converge on MeshMonitor instead of each holding its own upstream credentials.
+- You want **other LAN clients** (Home Assistant, Grafana, custom scripts) to subscribe to the same Meshtastic traffic without setting up a separate broker.
+- You need **server-side ingestion** of locally-published traffic — every NodeInfo / Position / Telemetry your devices publish via MQTT lands in the database under this source's `sourceId`, with no extra wiring.
 
-## Two ways a device can reach the broker
+### `mqtt_bridge` — open a connection to an upstream broker
+
+A long-lived MQTT client, backed by [MQTT.js](https://github.com/mqttjs/MQTT.js). MeshMonitor opens a connection out to one upstream MQTT server (`mqtt.meshtastic.org`, a regional community broker, your own private one), subscribes to a list of topics, and decodes whatever comes back.
+
+**What it does**
+
+- Connects to one upstream URL (`mqtt://…` for plain TCP, `mqtts://…:8883` for TLS) with optional username/password.
+- Subscribes to a configured list of upstream topics (MQTT wildcards: `+` single-segment, `#` multi-segment tail).
+- Decodes inbound `ServiceEnvelope` packets and ingests them into the database under this bridge's `sourceId` — so traffic the bridge receives from upstream shows up as its own MeshMonitor source.
+- Applies an **independent downlink filter pipeline** before ingestion and republish:
+  - **Topic patterns** — allow / block lists
+  - **Channel name** — allow / block lists
+  - **Node ID** — allow / block lists (`!xxxxxxxx`)
+  - **PortNum** — allow / block lists ([Meshtastic PortNum enum](https://github.com/meshtastic/protobufs/blob/master/meshtastic/portnums.proto))
+  - **Geographic bounding box** — drop position packets whose `latitude_i / 1e7, longitude_i / 1e7` falls outside `{ minLat, maxLat, minLng, maxLng }`. Applied before republish so out-of-area positions never reach the local broker (when attached) or are injected into a device (when used as a client-proxy target).
+- Surfaces broker ACL state — if the upstream rejects authentication or denies your subscriptions, the bridge status shows `permissionMessage` so you know why traffic isn't flowing.
+- 60-second `(topic, packetId)` echo suppression on both directions prevents bridge feedback loops.
+
+**Two modes — with or without a parent broker**
+
+A bridge can run in either of two configurations, picked when you create it ("Parent broker (optional)" dropdown):
+
+1. **Attached to a parent `mqtt_broker`** (the default before the standalone option was added). In this mode the bridge is bidirectional:
+   - **Downlink** (upstream → local broker): ingests, applies the downlink filter pipeline, and republishes raw bytes onto the parent broker so locally-connected devices see the same wire format.
+   - **Uplink** (local broker → upstream): listens to the parent broker's `local-packet` event, applies an independent **uplink filter pipeline** (same filter shapes as downlink), and publishes raw bytes to the upstream broker.
+2. **Standalone** — no parent broker. The bridge runs as a pure MQTT client. Downlink still ingests; there's no local republish (no local broker to republish to) and no uplink event source. The bridge can still **act as a client-proxy target** for a `meshtastic_tcp` source's `mqttLink`: device traffic flows `device → MeshMonitor → bridge.publish() → upstream`, with no embedded broker in between.
+
+**When to use a bridge**
+
+- **Attached**: you have an embedded broker hosting one or more local devices and you want their traffic to fan out upstream — and/or you want upstream traffic from a curated topic set to reach those devices.
+- **Standalone, monitoring**: you want to watch what flows on an upstream broker (e.g. `mqtt.meshtastic.org` for a regional area) without hosting any local MQTT clients. The bridge subscribes, ingests, and persists; that data shows up as its own source in the sidebar.
+- **Standalone, client-proxy target**: you have a Meshtastic device in `proxy_to_client` mode and you want its MQTT traffic forwarded straight upstream without an intermediate embedded broker. The Meshtastic source's `mqttLink` points at the bridge directly. This is the **MQTT-client-proxy** use case ([issue #3134](https://github.com/Yeraze/meshmonitor/issues/3134)).
+
+### Broker vs Bridge — feature matrix
+
+| Capability | `mqtt_broker` | `mqtt_bridge` (attached) | `mqtt_bridge` (standalone) |
+|---|---|---|---|
+| **Role** | MQTT server — accepts connections | MQTT client — opens one connection | MQTT client — opens one connection |
+| **Opens a TCP listener port?** | Yes (configurable, default `1883`) | No | No |
+| **Connects to an upstream broker?** | No (it _is_ the broker) | Yes (one per bridge) | Yes (one per bridge) |
+| **Locally-connected MQTT clients (devices, LAN apps)?** | Yes, many | Via the parent broker | No |
+| **Multiple upstream brokers?** | n/a | Yes — N bridges, each independent | Yes — N bridges, each independent |
+| **Per-source filter pipeline (topic / channel / node / portnum / geo)?** | No (broker is dumb relay) | **Yes** — downlink _and_ uplink | **Yes** — downlink only |
+| **Server-side ingestion of decoded packets?** | Yes — under broker `sourceId` | Yes — under bridge `sourceId` (downlink) | Yes — under bridge `sourceId` (downlink) |
+| **Echo suppression (no feedback loops)?** | n/a | Yes (60s `topic+packetId` cache) | Yes |
+| **Zero-hop injection toggle?** | Yes ([details](#zero-hop-injection)) | n/a | n/a |
+| **Synthetic gateway identity for outbound publishes?** | Yes (auto-generated at create) | Inherited from parent broker | n/a (no outbound until used as proxy target) |
+| **Default-deny authentication on the listener?** | Yes | n/a | n/a |
+| **Can serve as a `mqttLink` client-proxy target?** | Yes | Yes | **Yes** — primary use case |
+| **TLS / WSS?** | Plain TCP only in v1 | `mqtts://` upstream supported | `mqtts://` upstream supported |
+| **Survives a sibling source restart?** | Independent — broker keeps listening if a bridge restarts | Detaches if parent broker stops; reattaches when it comes back | Independent — runs without any sibling |
+| **Status fields on `/api/sources/:id/status`** | `listening`, `clientCount`, `packetsIn`, `packetsIngested`, `packetsDropped`, `lastError` | `upstreamConnected`, `parentBrokerAttached`, `downlinkIn`, `downlinkIngested`, `downlinkRepublished`, `uplinkOut`, downlink/uplink drop counters, `permissionMessage` | Same as attached, but `parentBrokerAttached: false` and `uplinkOut` stays at 0 |
+| **Required pair?** | Standalone — no bridge required | Requires a sibling `mqtt_broker` | None |
+
+### Use-case recipes
+
+- **"Filtered window onto the public Meshtastic broker."** Create one **standalone bridge** to `mqtt://mqtt.meshtastic.org` with a topic pattern and geo bbox that matches your region. No broker needed. You get a sidebar source whose nodes / messages / positions are sourced from upstream, filtered before ingestion.
+- **"My devices on the LAN should fan out to each other, plus selectively reach a public broker."** Create one **broker** + one **attached bridge**. Devices connect to the broker (direct TCP or client-proxy). The bridge applies a filter pipeline in both directions and forwards the selected slice upstream.
+- **"My BLE-only node should publish MQTT through MeshMonitor straight to a public broker, no embedded broker required."** Create one **standalone bridge** pointed at the public broker. On the Meshtastic source, set `mqttLink → <bridge>` (Sources → Edit → "Bridge MQTT proxy to", or use the Quick Configure dropdown on Device → MQTT). Enable `proxy_to_client_enabled` on the firmware. Device → MeshMonitor (over BLE/serial) → bridge → upstream.
+- **"Same as above, plus I want a Home Assistant box on the LAN to subscribe to my devices."** Create one **broker** + one **attached bridge**. Devices use client-proxy mode pointing at the broker; Home Assistant subscribes to the broker on port 1883. Bridge handles the upstream fan-out.
+- **"Two upstream brokers, one regional and one global, with different filters per upstream."** Create one **broker** + **two attached bridges**, each with its own topic/geo/portnum rules. Devices publish once; each bridge independently decides what to forward.
+
+## Three ways a device can reach MQTT through MeshMonitor
 
 | Path | Firmware setup | MeshMonitor setup | When to use |
 |---|---|---|---|
-| **Direct TCP** | `mqtt.enabled = true`, `address = <host>:1883`, `proxy_to_client_enabled = false`, credentials match | Expose port 1883 in `docker-compose.yml` | Devices with reliable WiFi/Ethernet that can reach the MeshMonitor host on the LAN |
-| **Client-proxy** | `mqtt.enabled = true`, `proxy_to_client_enabled = true`, credentials/address still set on firmware (mostly decorative in proxy mode) | Set the Meshtastic source's `mqttLink` to the embedded broker (Sources → Edit → "Bridge MQTT proxy to") | Devices without WiFi (Serial/BLE-attached), behind NAT, or on networks where port 1883 isn't reachable |
+| **Direct TCP to broker** | `mqtt.enabled = true`, `address = <host>:1883`, `proxy_to_client_enabled = false`, credentials match | Create an `mqtt_broker` source; expose port 1883 in `docker-compose.yml` | Devices with reliable WiFi/Ethernet that can reach the MeshMonitor host on the LAN |
+| **Client-proxy → broker** | `mqtt.enabled = true`, `proxy_to_client_enabled = true`, credentials/address still set on firmware (mostly decorative in proxy mode) | Create an `mqtt_broker` source; set the Meshtastic source's `mqttLink` to the broker (Sources → Edit → "Bridge MQTT proxy to") | Devices without WiFi (Serial/BLE-attached), behind NAT, or on networks where port 1883 isn't reachable — and you also want **other LAN clients** to subscribe to the embedded broker |
+| **Client-proxy → standalone bridge** | Same firmware setup as above (`proxy_to_client_enabled = true`) | Create a **standalone** `mqtt_bridge` (no parent broker); set the Meshtastic source's `mqttLink` to the **bridge** | Same connectivity scenarios as client-proxy → broker, but you don't need a local broker — device traffic goes straight upstream through the bridge ([issue #3134](https://github.com/Yeraze/meshmonitor/issues/3134)) |
 
-In proxy mode, the firmware uses Meshtastic's [`MqttClientProxyMessage`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto) protocol: the device hands every outbound publish off as a `FromRadio.mqttClientProxyMessage` over its existing TCP/serial connection to MeshMonitor, and MeshMonitor publishes on its behalf. Inbound messages from the broker are wrapped as `ToRadio.MqttClientProxyMessage` and injected back to the device. This is the same mechanism the Meshtastic mobile apps use when proxying.
+In proxy mode, the firmware uses Meshtastic's [`MqttClientProxyMessage`](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto) protocol: the device hands every outbound publish off as a `FromRadio.mqttClientProxyMessage` over its existing TCP/serial connection to MeshMonitor, and MeshMonitor publishes on its behalf. Inbound messages from the linked target (broker or bridge) are wrapped as `ToRadio.MqttClientProxyMessage` and injected back to the device. This is the same mechanism the Meshtastic mobile apps use when proxying.
+
+The Device → MQTT **Quick Configure** dropdown lists both brokers and bridges with type tags so you can pick either in one click; for bridges it parses the upstream URL into the firmware's MQTT address field so the device's local config reflects where its traffic is actually going.
 
 ## Quick setup
 
@@ -75,12 +142,14 @@ For each upstream broker (e.g. `mqtt.meshtastic.org`, regional community brokers
 
 | Field | Notes |
 |---|---|
-| Parent broker | Pick the `mqtt_broker` source created in step 1 |
+| Parent broker (optional) | Pick the `mqtt_broker` source from step 1 to make this an **attached** bridge, or leave as **"None — standalone client proxy"** for a pure upstream client. See [Two source types](#two-source-types) for which to pick. |
 | Upstream URL | `mqtt://mqtt.meshtastic.org` (or `mqtts://...:8883` for TLS) |
 | Username / Password | Whatever the upstream needs (e.g. `meshdev / large4cats` for `mqtt.meshtastic.org`) |
 | Upstream topics | One per line, MQTT wildcards allowed (e.g. `msh/US/FL/#`) |
 | Block topics | Optional — drop publishes matching these patterns (e.g. `msh/CA/QC/#`) |
 | Geographic bounding box | Optional — drop position packets outside the box |
+
+A standalone bridge is the right starting point when you have **no embedded broker** (pure upstream monitoring) or when you plan to wire a Meshtastic source's `mqttLink` directly at the bridge for client-proxy traffic — both are also covered in [Use-case recipes](#use-case-recipes) above.
 
 ### 3. Configure your Meshtastic devices
 
@@ -99,11 +168,16 @@ For each upstream broker (e.g. `mqtt.meshtastic.org`, regional community brokers
 | Field | Value |
 |---|---|
 | Enabled | true |
-| Address | Decorative in proxy mode, but conventionally set to the broker's hostname |
+| Address | Decorative in proxy mode, but conventionally set to the broker (or bridge upstream) hostname |
 | Username / Password | Decorative in proxy mode |
 | `proxy_to_client_enabled` | **true** (firmware hands every publish off via the TCP API) |
 
-Then on the Meshtastic source in MeshMonitor (**Dashboard → Sources → Edit → Bridge MQTT proxy to**), pick the embedded broker. MeshMonitor will forward `FromRadio.mqttClientProxyMessage` payloads to the broker, and inject broker messages back as `ToRadio.MqttClientProxyMessage`. The **Quick Configure** dropdown on the Device → MQTT page does all three of these things (firmware flag, firmware fields, source link) in one click.
+Then on the Meshtastic source in MeshMonitor (**Dashboard → Sources → Edit → Bridge MQTT proxy to**), pick either an embedded broker or a bridge as the target. The **Quick Configure** dropdown on the Device → MQTT page does all three of these things (firmware flag, firmware fields, source link) in one click and shows the target type next to the name.
+
+- Picking a **broker** routes the device's MQTT traffic into the embedded broker (and from there, optionally onward via any attached bridge). Other LAN clients connected to the broker also see this traffic.
+- Picking a **bridge** (typically a standalone one) routes the device's MQTT traffic straight to that bridge's upstream connection with no embedded broker in between. Useful when you have no other local MQTT clients.
+
+In both cases MeshMonitor forwards `FromRadio.mqttClientProxyMessage` payloads to the target's MQTT layer, and injects the target's inbound MQTT traffic back to the device as `ToRadio.MqttClientProxyMessage`.
 
 If `proxy_to_client_enabled` is on but no `mqttLink` is set, a yellow warning banner appears on the Device → MQTT page — without it, proxy traffic from the firmware would be silently dropped.
 
@@ -151,6 +225,7 @@ If you're seeing your private broker flood the mesh after attaching a bridge to 
 - **Node built-in MQTT** is fine if you have one node, one upstream broker, reliable WiFi, and no filtering needs.
 - **MQTT Proxy Sidecar** is the right answer if you mostly want a Serial/BLE node to still reach MQTT, without writing any new MeshMonitor source config — the sidecar is essentially a "mobile app, but always on".
 - **Embedded MQTT Broker** is the right answer when you want **selective bridging** (e.g. only forward msh/US/FL/PALM-BEACH traffic from `mqtt.meshtastic.org`, and only re-broadcast your own self-originated traffic), **multiple upstreams** from one local mesh, **server-side ingestion** (the bridged traffic shows up as MeshMonitor source data, not just relay-through), or you need **devices without WiFi** to publish to a broker that other LAN clients can also subscribe to. Both paths (direct TCP + client-proxy) work simultaneously — you can mix them on a per-device basis.
+- **Standalone MQTT Bridge** (no parent broker) is the right answer when you _don't_ need a local broker at all: either because you just want to **monitor** an upstream broker like `mqtt.meshtastic.org` without hosting anything, or because you have a single BLE/serial Meshtastic device in `proxy_to_client` mode whose MQTT traffic should go **straight upstream** with no intermediate broker. It's a smaller surface area than a broker + attached bridge — one source, one outbound TCP connection, no listener port to expose.
 
 ## Troubleshooting
 
@@ -177,7 +252,13 @@ The credentials configured on the bridge don't match what the upstream accepts f
 
 ### Deleting the broker source
 
-If any `mqtt_bridge` source still references the broker, the delete is refused with a 409 — delete or repoint dependent bridges first.
+Deleting an `mqtt_broker` that has dependent `mqtt_bridge` sources pointing at it **auto-detaches** the bridges instead of refusing the delete ([issue #3134](https://github.com/Yeraze/meshmonitor/issues/3134)). Each dependent bridge has its `brokerSourceId` cleared (it becomes a **standalone** bridge), and any enabled bridge is restarted with the new config; then the broker is removed. Standalone bridges are valid — they keep ingesting upstream and can still act as `mqttLink` client-proxy targets.
+
+If you also want the dependent bridges gone, delete them after the broker, or before — bridges don't require a parent.
+
+::: warning Pre-4.7 behavior
+Releases that shipped before the standalone-bridge feature refused this delete with a `409 Conflict` listing the dependent bridges. Repoint or delete those bridges first when running an older version.
+:::
 
 ## Limitations (v1)
 

--- a/docs/features/multi-source.md
+++ b/docs/features/multi-source.md
@@ -10,7 +10,7 @@ Multi-Source lets a single MeshMonitor deployment talk to **multiple meshes at o
 
 A **source** is one upstream connection MeshMonitor speaks to. Each source has:
 
-- A **type** — `meshtastic_tcp`, `meshcore`, `mqtt_broker` (external MQTT broker as a source), or `mqtt_bridge` (the embedded broker bridging to an upstream). Serial and BLE Meshtastic nodes connect through the Serial Bridge / BLE Bridge sidecars and appear as `meshtastic_tcp` sources pointing at the bridge container. MeshCore connects directly — USB through the UI, TCP via the legacy env-var bootstrap path. No sidecar either way.
+- A **type** — `meshtastic_tcp`, `meshcore`, `mqtt_broker` (embedded MQTT broker hosting locally-connected clients), or `mqtt_bridge` (MQTT client to one upstream broker, optionally attached to a sibling `mqtt_broker` for fan-out — see [Embedded MQTT Broker & Bridge](/features/mqtt-broker)). Serial and BLE Meshtastic nodes connect through the Serial Bridge / BLE Bridge sidecars and appear as `meshtastic_tcp` sources pointing at the bridge container. MeshCore connects directly — USB through the UI, TCP via the legacy env-var bootstrap path. No sidecar either way.
 - Its own **connection settings** (host, port, device path, credentials)
 - Its own **scheduler** (auto-responder, auto-announce, auto-traceroute, auto-ack)
 - Its own **Virtual Node** endpoint (TCP sources only)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,8 +25,8 @@ features:
     details: First-class MeshCore companions and repeaters living alongside your Meshtastic nodes. Per-source permissions, a multi-pane page with channels, DMs, and telemetry, and contacts plotted on the unified map.
 
   - icon: 🌉
-    title: Embedded MQTT Broker
-    details: Run an MQTT broker inside MeshMonitor with bidirectional bridges to public upstreams. Filter what crosses the boundary by topic, channel, portnum, or geographic bounding box — your local mesh stays clean without firmware changes.
+    title: Embedded MQTT Broker & Bridge
+    details: Host an MQTT broker inside MeshMonitor, run standalone client bridges to upstreams, or combine the two. Filter what crosses the boundary by topic, channel, portnum, or geographic bounding box — your local mesh stays clean without firmware changes.
 
   - icon: 🔐
     title: Per-Source Permissions

--- a/src/components/configuration/MQTTConfigSection.tsx
+++ b/src/components/configuration/MQTTConfigSection.tsx
@@ -75,12 +75,18 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
   const { hasPermission } = useAuth();
   const canEditMqtt = hasPermission('sources', 'write', { sourceId: currentSourceId });
 
-  // Quick-configure: list of locally-configured mqtt_broker sources the user
-  // can point this device at with one click. Bridges are not offered here —
-  // devices publish to the embedded broker, the bridge fans out to upstream.
+  // Quick-configure: list of valid client-proxy targets the user can point
+  // this device at with one click. Two shapes (issue #3134):
+  //   - mqtt_broker: device's MQTT traffic flows into the embedded broker
+  //     (and from there, optionally upstream via an attached bridge).
+  //   - mqtt_bridge (standalone or not): device's MQTT traffic flows
+  //     directly upstream through the bridge's MQTT client connection.
   const { data: allSources = [] } = useDashboardSources();
-  const brokerSources = useMemo(
-    () => allSources.filter((s) => s.type === 'mqtt_broker' && s.enabled),
+  const proxyTargets = useMemo(
+    () =>
+      allSources.filter(
+        (s) => (s.type === 'mqtt_broker' || s.type === 'mqtt_bridge') && s.enabled,
+      ),
     [allSources],
   );
   const [quickConfigSelection, setQuickConfigSelection] = useState('');
@@ -88,37 +94,67 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
     (sourceId: string) => {
       setQuickConfigSelection(sourceId);
       if (!sourceId) return;
-      const src = brokerSources.find((s) => s.id === sourceId);
-      const cfg = src?.config as
-        | {
-            listener?: { port?: number };
-            auth?: { username?: string; password?: string };
-            rootTopic?: string;
-          }
-        | undefined;
-      if (!cfg) return;
-      // Address: use the hostname the operator is using to reach MeshMonitor
-      // as a best-guess LAN address for the broker. Operator can edit if it's
-      // wrong (e.g. when running behind a reverse proxy).
-      const host = window.location.hostname || 'localhost';
-      const port = cfg.listener?.port ?? 1883;
+      const src = proxyTargets.find((s) => s.id === sourceId);
+      if (!src) return;
+
       setMqttEnabled(true);
-      setMqttAddress(port === 1883 ? host : `${host}:${port}`);
-      if (cfg.auth?.username) setMqttUsername(cfg.auth.username);
-      if (cfg.auth?.password) setMqttPassword(cfg.auth.password);
-      if (cfg.rootTopic) setMqttRoot(cfg.rootTopic);
-      // Embedded broker v1 is plain TCP; firmware MQTT encryption is the
-      // device-payload encryption flag and is a sane default for any broker.
-      setTlsEnabled(false);
-      setMqttEncryptionEnabled(true);
       // Flip on the firmware's MQTT proxy mode so traffic flows through
       // MeshMonitor's TCP API rather than directly to the broker. The
-      // mqttLink stamp below is what actually relays the proxy traffic —
-      // see MeshtasticManager.setupMqttLink (issue #3003 follow-up).
+      // mqttLink stamp below is what actually relays the proxy traffic.
       setProxyToClientEnabled(true);
+      // Device-payload encryption is sane on either target.
+      setMqttEncryptionEnabled(true);
+
+      if (src.type === 'mqtt_broker') {
+        const cfg = src.config as
+          | {
+              listener?: { port?: number };
+              auth?: { username?: string; password?: string };
+              rootTopic?: string;
+            }
+          | undefined;
+        // Address: use the hostname the operator is using to reach MeshMonitor
+        // as a best-guess LAN address for the broker. Operator can edit if it's
+        // wrong (e.g. when running behind a reverse proxy).
+        const host = window.location.hostname || 'localhost';
+        const port = cfg?.listener?.port ?? 1883;
+        setMqttAddress(port === 1883 ? host : `${host}:${port}`);
+        if (cfg?.auth?.username) setMqttUsername(cfg.auth.username);
+        if (cfg?.auth?.password) setMqttPassword(cfg.auth.password);
+        if (cfg?.rootTopic) setMqttRoot(cfg.rootTopic);
+        // Embedded broker v1 is plain TCP.
+        setTlsEnabled(false);
+      } else {
+        // mqtt_bridge target — the device never opens its own connection
+        // (proxy mode), so the address/credentials are mostly metadata.
+        // Fill from the bridge's upstream URL so they match what the
+        // firmware would have used in a non-proxied setup.
+        const cfg = src.config as
+          | {
+              upstream?: { url?: string; username?: string };
+              subscriptions?: string[];
+            }
+          | undefined;
+        const url = cfg?.upstream?.url ?? '';
+        // Parse host:port out of mqtt[s]://host:port — leave alone if empty.
+        const match = url.match(/^mqtts?:\/\/([^/]+)/i);
+        if (match) {
+          setMqttAddress(match[1]);
+          setTlsEnabled(url.toLowerCase().startsWith('mqtts://'));
+        }
+        if (cfg?.upstream?.username) setMqttUsername(cfg.upstream.username);
+        // Password is admin-only and not round-tripped; leave field alone.
+        // Derive a sensible root topic from the first non-wildcard segment
+        // of the first subscription (e.g. `msh/US/CA/#` → `msh/US/CA`).
+        const firstSub = cfg?.subscriptions?.[0];
+        if (firstSub) {
+          const trimmed = firstSub.replace(/\/[+#].*$/, '').replace(/\/+$/, '');
+          if (trimmed) setMqttRoot(trimmed);
+        }
+      }
 
       // Stamp the parent Meshtastic source's mqttLink so MeshMonitor
-      // bridges this device's proxy traffic to the embedded broker. The
+      // relays this device's proxy traffic to the selected target. The
       // PUT triggers reconfigureMqttLink server-side without restarting
       // the transport. Best-effort — failure is logged, not surfaced.
       if (currentSourceId) {
@@ -138,7 +174,7 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
       }
     },
     [
-      brokerSources,
+      proxyTargets,
       allSources,
       currentSourceId,
       getToken,
@@ -195,9 +231,11 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
     if (!parent || parent.type !== 'meshtastic_tcp') return false;
     const link = (parent.config as { mqttLink?: { enabled?: boolean; mqttBrokerSourceId?: string } } | undefined)?.mqttLink;
     if (!link?.enabled || !link.mqttBrokerSourceId) return true;
-    // Link references a sourceId that's no longer present (broker was deleted).
-    const linkedBroker = allSources.find((s) => s.id === link.mqttBrokerSourceId);
-    if (!linkedBroker || linkedBroker.type !== 'mqtt_broker') return true;
+    // Link references a sourceId that's no longer present, or a type
+    // that can't serve as a proxy target. Both mqtt_broker and
+    // mqtt_bridge are valid targets (issue #3134).
+    const linkedTarget = allSources.find((s) => s.id === link.mqttBrokerSourceId);
+    if (!linkedTarget || (linkedTarget.type !== 'mqtt_broker' && linkedTarget.type !== 'mqtt_bridge')) return true;
     return false;
   }, [proxyToClientEnabled, currentSourceId, allSources]);
 
@@ -313,14 +351,14 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
           </div>
           <ul style={{ margin: '6px 0 0 18px', padding: 0 }}>
             <li>
-              {brokerSources.length > 0
+              {proxyTargets.length > 0
                 ? t(
                     'mqtt_config.proxy_warning_link_option',
-                    'Pick an embedded broker from the dropdown below — that will both fill these fields and link this source to the broker.',
+                    'Pick an MQTT source from the dropdown below — either an embedded broker, or an MQTT bridge that will forward this device’s traffic straight upstream.',
                   )
                 : t(
                     'mqtt_config.proxy_warning_no_broker_option',
-                    'Create an embedded MQTT broker source first, then return here and pick it from the dropdown that will appear.',
+                    'Create an embedded MQTT broker or an MQTT bridge source first, then return here and pick it from the dropdown that will appear.',
                   )}
             </li>
             <li>
@@ -332,14 +370,14 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
           </ul>
         </div>
       )}
-      {brokerSources.length > 0 && (
+      {proxyTargets.length > 0 && (
         <div className="setting-item">
           <label htmlFor="mqttQuickConfig">
-            {t('mqtt_config.quick_configure', 'Quick configure from MeshMonitor broker')}
+            {t('mqtt_config.quick_configure', 'Quick configure from a MeshMonitor MQTT source')}
             <span className="setting-description">
               {t(
                 'mqtt_config.quick_configure_description',
-                'Auto-fill these fields to point the device at an embedded MQTT broker configured in MeshMonitor.',
+                'Auto-fill these fields to point the device at an MQTT source configured in MeshMonitor. Brokers receive device traffic locally; bridges forward it straight upstream.',
               )}
             </span>
           </label>
@@ -350,9 +388,11 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
             onChange={(e) => applyQuickConfig(e.target.value)}
           >
             <option value="">{t('common.select', 'Select…')}</option>
-            {brokerSources.map((s) => (
+            {proxyTargets.map((s) => (
               <option key={s.id} value={s.id}>
-                {s.name}
+                {s.type === 'mqtt_bridge'
+                  ? t('mqtt_config.quick_configure_bridge_option', '{{name}} (bridge → upstream)', { name: s.name })
+                  : t('mqtt_config.quick_configure_broker_option', '{{name}} (embedded broker)', { name: s.name })}
               </option>
             ))}
           </select>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -412,10 +412,9 @@ function DashboardInner() {
         delete (cfg.auth as { password?: string }).password;
       }
     } else if (formType === 'mqtt_bridge') {
-      if (!formMqttBridgeBrokerId) {
-        setFormError(t('source.form.error_mqtt_broker_required', 'Select a parent broker'));
-        return;
-      }
+      // Parent broker is optional — empty selection means standalone
+      // client-proxy bridge (issue #3134). No validation needed; the
+      // backend treats an unset/empty `brokerSourceId` as standalone.
       if (!formMqttBridgeUrl.trim()) {
         setFormError(t('source.form.error_mqtt_url_required', 'Upstream URL is required'));
         return;
@@ -448,7 +447,9 @@ function DashboardInner() {
       if (topicBlock.length > 0) downlinkFilters.topics = { block: topicBlock };
       if (Object.keys(geo).length > 0) downlinkFilters.geo = geo;
       cfg = {
-        brokerSourceId: formMqttBridgeBrokerId,
+        // Omit `brokerSourceId` entirely when standalone — the backend
+        // treats an absent field as "no parent" (issue #3134).
+        ...(formMqttBridgeBrokerId ? { brokerSourceId: formMqttBridgeBrokerId } : {}),
         upstream: {
           url: formMqttBridgeUrl.trim(),
           username: formMqttBridgeUsername.trim() || undefined,
@@ -1010,13 +1011,13 @@ function DashboardInner() {
             ) : formType === 'mqtt_bridge' ? (
               <>
                 <label className="dashboard-form-field">
-                  <span className="dashboard-form-label">{t('source.form.mqtt_bridge_broker', 'Parent broker')}</span>
+                  <span className="dashboard-form-label">{t('source.form.mqtt_bridge_broker', 'Parent broker (optional)')}</span>
                   <select
                     className="dashboard-form-input"
                     value={formMqttBridgeBrokerId}
                     onChange={(e) => setFormMqttBridgeBrokerId(e.target.value)}
                   >
-                    <option value="">{t('common.select', 'Select…')}</option>
+                    <option value="">{t('source.form.mqtt_bridge_broker_none', 'None — standalone client proxy')}</option>
                     {sources
                       .filter((s) => s.type === 'mqtt_broker')
                       .map((s) => (
@@ -1025,6 +1026,12 @@ function DashboardInner() {
                         </option>
                       ))}
                   </select>
+                  <span style={{ fontSize: 11, color: 'var(--ctp-subtext0)', marginTop: 4 }}>
+                    {t(
+                      'source.form.mqtt_bridge_broker_help',
+                      'With a parent broker, the bridge also republishes upstream traffic to local devices and forwards their packets upstream. Without one, it runs as a pure MQTT client — useful for monitoring or as a client-proxy target for a Meshtastic source.',
+                    )}
+                  </span>
                 </label>
                 <label className="dashboard-form-field">
                   <span className="dashboard-form-label">{t('source.form.mqtt_upstream_url', 'Upstream URL')}</span>

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -452,8 +452,16 @@ class MeshtasticManager implements ISourceManager {
   // auto re-sync the new connection would otherwise trigger.
   private suppressNextAutoSync = false;
   // mqttLink runtime state — set up in start()/reconfigureMqttLink().
+  // The link target can be either an mqtt_broker (devices connect to the
+  // embedded broker that we then bridge) or an mqtt_bridge (we forward
+  // straight upstream through the bridge's MQTT client). Both expose
+  // `publish()` and emit `local-packet`, so they share this code path
+  // (issue #3134).
   private mqttLink: MeshtasticMqttLink | null = null;
-  private mqttLinkBroker: import('./mqttBrokerManager.js').MqttBrokerManager | null = null;
+  private mqttLinkBroker:
+    | import('./mqttBrokerManager.js').MqttBrokerManager
+    | import('./mqttBridgeManager.js').MqttBridgeManager
+    | null = null;
   private mqttLinkBrokerListener: ((p: import('./mqttBrokerManager.js').MqttBrokerLocalPacket) => void) | null = null;
   private mqttLinkRegistryStartedListener: ((m: ISourceManager) => void) | null = null;
   private mqttLinkRegistryStoppedListener: ((m: ISourceManager) => void) | null = null;
@@ -673,34 +681,39 @@ class MeshtasticManager implements ISourceManager {
   }
 
   private setupMqttLink(): void {
-    const brokerId = this.mqttLink?.mqttBrokerSourceId;
-    if (!brokerId) return;
+    const targetId = this.mqttLink?.mqttBrokerSourceId;
+    if (!targetId) return;
 
     const attach = (mgr: ISourceManager) => {
-      if (mgr.sourceType !== 'mqtt_broker') return;
-      this.mqttLinkBroker = mgr as import('./mqttBrokerManager.js').MqttBrokerManager;
+      // Either an embedded broker (devices publish to it locally) or a
+      // standalone bridge (we go straight to the upstream broker). Both
+      // expose `on('local-packet')` and `publish()`.
+      if (mgr.sourceType !== 'mqtt_broker' && mgr.sourceType !== 'mqtt_bridge') return;
+      this.mqttLinkBroker = mgr as
+        | import('./mqttBrokerManager.js').MqttBrokerManager
+        | import('./mqttBridgeManager.js').MqttBridgeManager;
       const listener = (p: import('./mqttBrokerManager.js').MqttBrokerLocalPacket) => {
         this.handleLinkedBrokerLocalPacket(p);
       };
       this.mqttLinkBrokerListener = listener;
       this.mqttLinkBroker.on('local-packet', listener);
-      logger.info(`MQTT link attached: source ${this.sourceId} ↔ broker ${brokerId}`);
+      logger.info(`MQTT link attached: source ${this.sourceId} ↔ ${mgr.sourceType} ${targetId}`);
     };
 
-    const existing = sourceManagerRegistry.getManager(brokerId);
+    const existing = sourceManagerRegistry.getManager(targetId);
     if (existing) {
       attach(existing);
       return;
     }
-    // Defer until the broker starts.
+    // Defer until the target source starts.
     this.mqttLinkRegistryStartedListener = (m: ISourceManager) => {
-      if (m.sourceId === brokerId) attach(m);
+      if (m.sourceId === targetId) attach(m);
     };
     sourceManagerRegistry.on('manager-started', this.mqttLinkRegistryStartedListener);
 
     this.mqttLinkRegistryStoppedListener = (m: ISourceManager) => {
-      if (m.sourceId === brokerId) {
-        logger.warn(`MQTT link parent broker ${brokerId} stopped — detaching from source ${this.sourceId}`);
+      if (m.sourceId === targetId) {
+        logger.warn(`MQTT link target ${targetId} stopped — detaching from source ${this.sourceId}`);
         this.detachMqttLinkBroker();
       }
     };

--- a/src/server/mqttBridgeManager.test.ts
+++ b/src/server/mqttBridgeManager.test.ts
@@ -238,4 +238,93 @@ describe('MqttBridgeManager', () => {
     await new Promise((r) => setTimeout(r, 50));
     expect(bridge.getStatus().parentBrokerAttached).toBe(true);
   });
+
+  it('runs standalone without a parent broker: emits local-packet on downlink and publish() forwards upstream (#3134)', async () => {
+    // Standalone bridge — no brokerSourceId. Doesn't need (or use) the
+    // local broker fixture.
+    bridge = new MqttBridgeManager('standalone-bridge', 'Standalone', {
+      // brokerSourceId intentionally omitted
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/#'],
+    });
+    await sourceManagerRegistry.addManager(bridge);
+
+    expect(bridge.getStatus().parentBrokerAttached).toBe(false);
+
+    // Capture local-packet emissions so we can prove the client-proxy
+    // event path works without a parent broker.
+    const localPackets: Array<{ topic: string; clientId: string | null }> = [];
+    bridge.on('local-packet', (p: { topic: string; clientId: string | null }) => {
+      localPackets.push({ topic: p.topic, clientId: p.clientId });
+    });
+
+    // A separate client subscribing to upstream lets us assert that
+    // bridge.publish() actually reaches the upstream broker.
+    upstreamClient = connect(`mqtt://127.0.0.1:${upstreamPort}`, { reconnectPeriod: 0 });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('upstream connect timeout')), 3000);
+      upstreamClient!.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+    const upstreamSeen: Array<{ topic: string; payload: Buffer }> = [];
+    await new Promise<void>((resolve, reject) => {
+      upstreamClient!.subscribe('msh/#', { qos: 0 }, (err) => (err ? reject(err) : resolve()));
+    });
+    upstreamClient.on('message', (topic, payload) => {
+      upstreamSeen.push({ topic, payload });
+    });
+
+    // Drive downlink: a *different* upstream publisher emits a packet
+    // the bridge has subscribed to.
+    const pub = connect(`mqtt://127.0.0.1:${upstreamPort}`, { reconnectPeriod: 0 });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('pub connect timeout')), 3000);
+      pub.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+
+    const envelope = buildPositionEnvelope({
+      from: 0xaabbccdd,
+      latI: 440_000_000,
+      lngI: -780_000_000,
+      channelId: 'LongFast',
+      gatewayId: '!aabbccdd',
+      packetId: 0x20000001,
+    });
+    pub.publish('msh/CA/ON/PTBO', envelope);
+    await new Promise((r) => setTimeout(r, 300));
+
+    expect(localPackets.length).toBeGreaterThanOrEqual(1);
+    expect(localPackets[0].topic).toBe('msh/CA/ON/PTBO');
+    expect(localPackets[0].clientId).toBeNull();
+
+    // And the explicit publish() path forwards straight upstream.
+    const outboundEnvelope = buildPositionEnvelope({
+      from: 0x11223344,
+      latI: 440_000_000,
+      lngI: -780_000_000,
+      channelId: 'LongFast',
+      gatewayId: '!11223344',
+      packetId: 0x20000002,
+    });
+    await bridge.publish('msh/proxy/out', outboundEnvelope);
+    await new Promise((r) => setTimeout(r, 300));
+
+    expect(upstreamSeen.some((m) => m.topic === 'msh/proxy/out')).toBe(true);
+
+    await new Promise<void>((r) => pub.end(true, {}, () => r()));
+  });
+
+  it('publish() throws when bridge is not connected to upstream (#3134)', async () => {
+    bridge = new MqttBridgeManager('disconnected-bridge', 'Disconnected', {
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/#'],
+    });
+    // Don't start the bridge — client is null.
+    await expect(bridge.publish('msh/x', Buffer.from([1, 2, 3]))).rejects.toThrow(/not connected to upstream/);
+  });
 });

--- a/src/server/mqttBridgeManager.ts
+++ b/src/server/mqttBridgeManager.ts
@@ -15,6 +15,12 @@
  * Echo suppression: each direction records (topic, packetId) of recently
  * forwarded messages; matching inbound packets are dropped to prevent
  * round-trip loops.
+ *
+ * Standalone mode (issue #3134): when `brokerSourceId` is omitted, the
+ * bridge runs without a parent broker — downlink still ingests upstream
+ * traffic (no local republish), and the bridge can act as a client-proxy
+ * target for a meshtastic_tcp source via `publish()` + `local-packet`
+ * events, the same shape exposed by MqttBrokerManager.
  */
 
 import { EventEmitter } from 'events';
@@ -36,7 +42,15 @@ import databaseService from '../services/database.js';
 import { logger } from '../utils/logger.js';
 
 export interface MqttBridgeSourceConfig {
-  brokerSourceId: string;
+  /**
+   * Optional parent mqtt_broker source. When set, downlink packets are
+   * republished to that broker (so locally-connected devices see them)
+   * and `local-packet` events from the broker drive uplink forwarding.
+   * When unset, the bridge runs as a pure upstream MQTT client — useful
+   * for monitoring a remote broker, or for acting as a `mqttLink`
+   * client-proxy target for a meshtastic_tcp source (issue #3134).
+   */
+  brokerSourceId?: string;
   upstream: {
     url: string;
     username?: string;
@@ -224,8 +238,26 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     return null;
   }
 
+  /**
+   * Publish a raw payload to the upstream broker through this bridge's
+   * client connection. Used by the client-proxy mqttLink path so a
+   * meshtastic_tcp source can route its device's MQTT traffic through a
+   * standalone bridge (issue #3134). Mirrors MqttBrokerManager.publish so
+   * a `mqttLink` target can be either type.
+   */
+  async publish(topic: string, payload: Buffer, retained = false): Promise<void> {
+    if (!this.client || !this.client.isConnected()) {
+      throw new Error(`MQTT bridge ${this.sourceId} not connected to upstream`);
+    }
+    await this.client.publish(topic, payload, retained);
+  }
+
   private attachParentBroker(): void {
-    const existing = sourceManagerRegistry.getManager(this.config.brokerSourceId);
+    // Standalone mode (no parent broker configured) — nothing to attach.
+    const brokerId = this.config.brokerSourceId;
+    if (!brokerId) return;
+
+    const existing = sourceManagerRegistry.getManager(brokerId);
     if (existing && existing.sourceType === 'mqtt_broker') {
       this.parentBroker = existing as MqttBrokerManager;
       this.bindParentListener();
@@ -234,7 +266,7 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
 
     // Defer until the broker is registered. Listen for manager-started.
     this.registryAddedListener = (m: ISourceManager) => {
-      if (m.sourceId === this.config.brokerSourceId && m.sourceType === 'mqtt_broker') {
+      if (m.sourceId === brokerId && m.sourceType === 'mqtt_broker') {
         this.parentBroker = m as MqttBrokerManager;
         this.bindParentListener();
         logger.info(
@@ -245,7 +277,7 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     sourceManagerRegistry.on('manager-started', this.registryAddedListener);
 
     this.registryRemovedListener = (m: ISourceManager) => {
-      if (m.sourceId === this.config.brokerSourceId) {
+      if (m.sourceId === brokerId) {
         this.unbindParentListener();
         this.parentBroker = null;
         logger.warn(
@@ -332,6 +364,18 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
         const msg = err instanceof Error ? err.message : String(err);
         logger.warn(`MQTT bridge ${this.sourceId} ingest failed: ${msg}`);
       });
+
+    // Emit local-packet so consumers (e.g. a meshtastic_tcp source using
+    // this bridge as its `mqttLink` client-proxy target — issue #3134) can
+    // relay the upstream packet to their device. Shape matches
+    // MqttBrokerLocalPacket so listeners can target either source type.
+    this.emit('local-packet', {
+      topic,
+      payload,
+      retained,
+      envelope,
+      clientId: null,
+    });
 
     // Republish to local broker so devices see it. Skip if no parent attached.
     if (this.parentBroker) {

--- a/src/server/routes/sourceRoutes.standaloneBridge.test.ts
+++ b/src/server/routes/sourceRoutes.standaloneBridge.test.ts
@@ -1,0 +1,329 @@
+/**
+ * sourceRoutes — standalone mqtt_bridge regressions (issue #3134).
+ *
+ * Covers:
+ *   - POST creates an mqtt_bridge without `brokerSourceId` (standalone).
+ *   - POST still rejects an mqtt_bridge whose `brokerSourceId` references
+ *     a missing source or a non-broker source.
+ *   - DELETE on an mqtt_broker with bridge dependents no longer returns
+ *     409 — it detaches the dependents (clears their `brokerSourceId`)
+ *     and proceeds with deletion.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import sourceRoutes from './sourceRoutes.js';
+import databaseService from '../../services/database.js';
+import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    sources: {
+      getSource: vi.fn(),
+      getAllSources: vi.fn().mockResolvedValue([]),
+      createSource: vi.fn(),
+      updateSource: vi.fn(),
+      deleteSource: vi.fn().mockResolvedValue(true),
+    },
+    nodes: { getAllNodes: vi.fn().mockResolvedValue([]) },
+    messages: { getMessages: vi.fn().mockResolvedValue([]) },
+    traceroutes: { getAllTraceroutes: vi.fn().mockResolvedValue([]) },
+    neighbors: { getAllNeighborInfo: vi.fn().mockResolvedValue([]) },
+    channels: { getAllChannels: vi.fn().mockResolvedValue([]) },
+    settings: { getSetting: vi.fn().mockResolvedValue(null) },
+    checkPermissionAsync: vi.fn().mockResolvedValue(true),
+    findUserByIdAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn().mockResolvedValue(null),
+    getUserPermissionSetAsync: vi.fn().mockResolvedValue({ resources: {}, isAdmin: true }),
+    getChannelDatabasePermissionsForUserAsSetAsync: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    getManager: vi.fn().mockReturnValue(null),
+    addManager: vi.fn().mockResolvedValue(undefined),
+    removeManager: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Stub MQTT manager constructors so create/delete don't try to bind sockets.
+vi.mock('../mqttBrokerManager.js', () => {
+  class MqttBrokerManager {
+    sourceId: string;
+    sourceType = 'mqtt_broker' as const;
+    constructor(id: string) {
+      this.sourceId = id;
+    }
+    async start() {}
+    async stop() {}
+    on() {
+      return this;
+    }
+    off() {
+      return this;
+    }
+    getStatus() {
+      return { sourceId: this.sourceId, sourceName: '', sourceType: 'mqtt_broker' as const, connected: false };
+    }
+    getLocalNodeInfo() {
+      return null;
+    }
+  }
+  return { MqttBrokerManager };
+});
+
+vi.mock('../mqttBridgeManager.js', () => {
+  class MqttBridgeManager {
+    sourceId: string;
+    sourceType = 'mqtt_bridge' as const;
+    constructor(id: string) {
+      this.sourceId = id;
+    }
+    async start() {}
+    async stop() {}
+    on() {
+      return this;
+    }
+    off() {
+      return this;
+    }
+    getStatus() {
+      return { sourceId: this.sourceId, sourceName: '', sourceType: 'mqtt_bridge' as const, connected: false };
+    }
+    getLocalNodeInfo() {
+      return null;
+    }
+  }
+  return { MqttBridgeManager };
+});
+
+vi.mock('../meshcoreRegistry.js', () => ({
+  meshcoreManagerRegistry: {
+    get: vi.fn().mockReturnValue(null),
+    getOrCreate: vi.fn(),
+    remove: vi.fn().mockResolvedValue(undefined),
+  },
+  meshcoreConfigFromSource: vi.fn().mockReturnValue(null),
+}));
+
+const mockDb = databaseService as any;
+const mockRegistry = sourceManagerRegistry as any;
+
+const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
+
+const createApp = (): Express => {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: 'test-secret',
+      resave: false,
+      saveUninitialized: false,
+      cookie: { secure: false },
+    }),
+  );
+  app.use((req: any, _res, next) => {
+    req.session.userId = adminUser.id;
+    next();
+  });
+  app.use('/', sourceRoutes);
+  return app;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+  mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+  mockDb.checkPermissionAsync.mockResolvedValue(true);
+  mockRegistry.getManager.mockReturnValue(null);
+});
+
+describe('sourceRoutes — POST creates standalone mqtt_bridge (#3134)', () => {
+  it('accepts mqtt_bridge config with no brokerSourceId', async () => {
+    const app = createApp();
+    mockDb.sources.getAllSources.mockResolvedValue([]);
+    mockDb.sources.createSource.mockImplementation(async (s: any) => ({
+      ...s,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(app)
+      .post('/')
+      .send({
+        name: 'Standalone',
+        type: 'mqtt_bridge',
+        config: {
+          // brokerSourceId intentionally omitted
+          upstream: { url: 'mqtt://mqtt.meshtastic.org:1883' },
+          subscriptions: ['msh/#'],
+        },
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockDb.sources.createSource).toHaveBeenCalledTimes(1);
+    const created = mockDb.sources.createSource.mock.calls[0][0];
+    expect(created.type).toBe('mqtt_bridge');
+    expect(created.config.brokerSourceId).toBeUndefined();
+  });
+
+  it('accepts mqtt_bridge config with brokerSourceId explicitly empty', async () => {
+    const app = createApp();
+    mockDb.sources.getAllSources.mockResolvedValue([]);
+    mockDb.sources.createSource.mockImplementation(async (s: any) => ({
+      ...s,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(app)
+      .post('/')
+      .send({
+        name: 'Standalone',
+        type: 'mqtt_bridge',
+        config: {
+          brokerSourceId: '',
+          upstream: { url: 'mqtt://mqtt.meshtastic.org:1883' },
+          subscriptions: ['msh/#'],
+        },
+      });
+
+    expect(res.status).toBe(201);
+  });
+
+  it('still rejects mqtt_bridge whose brokerSourceId points at a missing source', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/')
+      .send({
+        name: 'Broken',
+        type: 'mqtt_bridge',
+        config: {
+          brokerSourceId: 'missing-broker',
+          upstream: { url: 'mqtt://example.com' },
+          subscriptions: ['msh/#'],
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/does not reference an mqtt_broker/);
+  });
+
+  it('still rejects mqtt_bridge whose brokerSourceId points at a non-broker', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue({
+      id: 'tcp-source',
+      type: 'meshtastic_tcp',
+      name: 'TCP',
+      config: {},
+      enabled: true,
+    });
+
+    const res = await request(app)
+      .post('/')
+      .send({
+        name: 'Broken',
+        type: 'mqtt_bridge',
+        config: {
+          brokerSourceId: 'tcp-source',
+          upstream: { url: 'mqtt://example.com' },
+          subscriptions: ['msh/#'],
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/does not reference an mqtt_broker/);
+  });
+});
+
+describe('sourceRoutes — DELETE broker with bridge dependents (#3134)', () => {
+  it('detaches dependent bridges instead of returning 409', async () => {
+    const app = createApp();
+
+    const broker = {
+      id: 'broker-1',
+      type: 'mqtt_broker',
+      name: 'Embedded',
+      enabled: true,
+      config: { listener: { port: 1883 }, auth: { username: 'u', password: 'p' }, gateway: {} },
+    };
+    const bridgeA = {
+      id: 'bridge-a',
+      type: 'mqtt_bridge',
+      name: 'Bridge A',
+      enabled: true,
+      config: {
+        brokerSourceId: 'broker-1',
+        upstream: { url: 'mqtt://example.com' },
+        subscriptions: ['msh/#'],
+      },
+    };
+    const bridgeB = {
+      id: 'bridge-b',
+      type: 'mqtt_bridge',
+      name: 'Bridge B',
+      enabled: false, // disabled — should not be restarted
+      config: {
+        brokerSourceId: 'broker-1',
+        upstream: { url: 'mqtt://example.com' },
+        subscriptions: ['msh/#'],
+      },
+    };
+
+    mockDb.sources.getSource.mockResolvedValue(broker);
+    mockDb.sources.getAllSources.mockResolvedValue([broker, bridgeA, bridgeB]);
+
+    const updatedConfigs: Record<string, any> = {};
+    mockDb.sources.updateSource.mockImplementation(async (id: string, updates: any) => {
+      updatedConfigs[id] = updates.config;
+      return { id, ...updates };
+    });
+
+    const res = await request(app).delete('/broker-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+
+    // Both dependent bridges had brokerSourceId removed from their config.
+    expect(updatedConfigs['bridge-a']).toBeDefined();
+    expect(updatedConfigs['bridge-a'].brokerSourceId).toBeUndefined();
+    expect(updatedConfigs['bridge-a'].upstream).toEqual({ url: 'mqtt://example.com' });
+
+    expect(updatedConfigs['bridge-b']).toBeDefined();
+    expect(updatedConfigs['bridge-b'].brokerSourceId).toBeUndefined();
+
+    // The enabled bridge was restarted; the disabled one was not.
+    expect(mockRegistry.removeManager).toHaveBeenCalledWith('bridge-a');
+    expect(mockRegistry.addManager).toHaveBeenCalledTimes(1);
+    expect(mockRegistry.removeManager).not.toHaveBeenCalledWith('bridge-b');
+
+    // And the broker itself got deleted.
+    expect(mockDb.sources.deleteSource).toHaveBeenCalledWith('broker-1');
+  });
+
+  it('still deletes a broker with no dependents', async () => {
+    const app = createApp();
+
+    const broker = {
+      id: 'broker-1',
+      type: 'mqtt_broker',
+      name: 'Embedded',
+      enabled: true,
+      config: { listener: { port: 1883 }, auth: { username: 'u', password: 'p' }, gateway: {} },
+    };
+
+    mockDb.sources.getSource.mockResolvedValue(broker);
+    mockDb.sources.getAllSources.mockResolvedValue([broker]);
+
+    const res = await request(app).delete('/broker-1');
+
+    expect(res.status).toBe(200);
+    expect(mockDb.sources.deleteSource).toHaveBeenCalledWith('broker-1');
+    expect(mockDb.sources.updateSource).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -185,15 +185,23 @@ router.post('/', requirePermission('sources', 'write'), async (req: Request, res
       return res.status(400).json({ error: 'type must be meshtastic_tcp, mqtt_broker, mqtt_bridge, or meshcore' });
     }
 
-    // mqtt_bridge requires an existing mqtt_broker to attach to.
+    // mqtt_bridge may optionally attach to a parent mqtt_broker. When
+    // brokerSourceId is omitted (or empty), the bridge runs standalone:
+    // an upstream-only MQTT client suitable for monitoring a remote
+    // broker or for serving as a client-proxy target via a
+    // meshtastic_tcp source's `mqttLink` (issue #3134). When provided,
+    // it must reference a real mqtt_broker so downlink republish and
+    // uplink listening can wire up.
     if (type === 'mqtt_bridge') {
       const parentId = config?.brokerSourceId;
-      if (typeof parentId !== 'string' || !parentId) {
-        return res.status(400).json({ error: 'mqtt_bridge config.brokerSourceId is required' });
-      }
-      const parent = await databaseService.sources.getSource(parentId);
-      if (!parent || parent.type !== 'mqtt_broker') {
-        return res.status(400).json({ error: `mqtt_bridge brokerSourceId ${parentId} does not reference an mqtt_broker source` });
+      if (parentId !== undefined && parentId !== null && parentId !== '') {
+        if (typeof parentId !== 'string') {
+          return res.status(400).json({ error: 'mqtt_bridge config.brokerSourceId must be a string when provided' });
+        }
+        const parent = await databaseService.sources.getSource(parentId);
+        if (!parent || parent.type !== 'mqtt_broker') {
+          return res.status(400).json({ error: `mqtt_bridge brokerSourceId ${parentId} does not reference an mqtt_broker source` });
+        }
       }
     }
     if (!config || typeof config !== 'object') {
@@ -528,17 +536,27 @@ router.delete('/:id', requirePermission('sources', 'write'), async (req: Request
   try {
     const target = await databaseService.sources.getSource(req.params.id);
     if (target?.type === 'mqtt_broker') {
-      // Refuse to delete a broker that has bridges pointing at it — cascade
-      // would silently break the bridges' upstream-to-local routing.
+      // Detach dependent mqtt_bridge sources rather than blocking deletion
+      // (issue #3134). Standalone bridges are valid: they ingest upstream
+      // traffic and can still serve as proxy targets for a meshtastic_tcp
+      // source's `mqttLink`.
       const all = await databaseService.sources.getAllSources();
       const dependents = all.filter(
         (s) => s.type === 'mqtt_bridge' && (s.config as any)?.brokerSourceId === req.params.id,
       );
-      if (dependents.length > 0) {
-        return res.status(409).json({
-          error: `Cannot delete: ${dependents.length} mqtt_bridge source(s) reference this broker`,
-          dependents: dependents.map((s) => ({ id: s.id, name: s.name })),
-        });
+      for (const dep of dependents) {
+        const newCfg = { ...(dep.config as Record<string, unknown>) };
+        delete newCfg.brokerSourceId;
+        await databaseService.sources.updateSource(dep.id, { config: newCfg });
+        if (dep.enabled) {
+          try {
+            await sourceManagerRegistry.removeManager(dep.id);
+            const manager = buildMqttManagerForSource(dep.id, dep.name, dep.type as 'mqtt_bridge', newCfg);
+            await sourceManagerRegistry.addManager(manager);
+          } catch (err) {
+            logger.warn(`Could not restart bridge ${dep.id} after detaching from deleted broker ${req.params.id}:`, err);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- `mqtt_bridge` sources can now run **without a parent `mqtt_broker`** (issue #3134). When `config.brokerSourceId` is omitted, the bridge runs as a pure upstream MQTT client — useful for monitoring a remote broker, or for serving as a target for a `meshtastic_tcp` source's MQTT client-proxy `mqttLink`.
- Deleting an `mqtt_broker` no longer returns `409 Conflict` when bridges depend on it (the original bug in #3134). Instead, dependent bridges are **automatically detached** (`brokerSourceId` cleared, manager restarted) and the broker is deleted.
- `MeshtasticManager.setupMqttLink` now accepts either an `mqtt_broker` or an `mqtt_bridge` as the link target. Both source types expose `publish()` and emit `local-packet`, so the existing proxy-message paths work unchanged for either.
- UI: the device MQTT **Quick configure** dropdown lists brokers *and* bridges (tagged by type) so a user can wire a device's MQTT proxy straight to an upstream-only bridge in one click. The source-add modal makes "Parent broker" optional with an explicit "None — standalone client proxy" choice and an explanatory help line.

## Why
`mqtt_bridge` originally required an `mqtt_broker` parent so it could republish upstream traffic locally and forward device traffic upstream. That coupling was the right model for a true broker-to-broker bridge, but it blocked two valid setups:

1. **Pure monitoring** of an upstream Meshtastic MQTT broker (e.g. `mqtt.meshtastic.org`) when you have no locally-connected devices.
2. **MQTT client-proxy** — a Meshtastic device with `mqtt.proxy_to_client_enabled = true` whose MQTT traffic should be relayed straight upstream by MeshMonitor with no embedded broker in between.

Both now work natively.

## Files changed
| File | Change |
|------|--------|
| `src/server/routes/sourceRoutes.ts` | POST validator: `brokerSourceId` is optional. DELETE on a broker auto-detaches dependent bridges. |
| `src/server/mqttBridgeManager.ts` | `brokerSourceId` typed optional; `attachParentBroker()` is a no-op when unset; new `publish()` method; emits `local-packet` on downlink. |
| `src/server/meshtasticManager.ts` | `setupMqttLink` accepts `mqtt_broker` **or** `mqtt_bridge` as link target. |
| `src/pages/DashboardPage.tsx` | Bridge form: optional broker dropdown, save config omits `brokerSourceId` when blank. |
| `src/components/configuration/MQTTConfigSection.tsx` | Quick-configure dropdown lists brokers + bridges with type tags; `proxyLinkMisconfigured` accepts bridges. |
| `src/server/routes/sourceRoutes.standaloneBridge.test.ts` *(new)* | 6 cases: standalone create paths, rejection of bad parent refs, broker delete with/without dependents. |
| `src/server/mqttBridgeManager.test.ts` | 2 new cases: standalone bridge emits `local-packet` + `publish()` reaches upstream; `publish()` throws when disconnected. |

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `vitest run src/server` — 162 files / 2796 tests pass
- [x] `vitest run src/components src/pages` — 470 tests pass
- [x] `npm run build` — clean
- [x] New unit tests for the standalone-bridge create path + broker-delete cascade — 6 pass
- [x] New integration tests for `publish()` + `local-packet` emission on a real Aedes upstream broker — 2 pass
- [ ] Manual: create a bridge with no parent broker via the UI, verify it connects upstream and ingests
- [ ] Manual: point a `meshtastic_tcp` source's `mqttLink` at a standalone bridge, enable `proxy_to_client` on the device firmware, verify device MQTT traffic flows upstream
- [ ] Manual: delete an `mqtt_broker` that has dependent bridges, verify bridges keep running standalone and the broker is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)