### PR TITLE
fix(unified): merge nodes across sources so labels show in unified view (#3135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-_No changes yet._
+## Fixes
+- #3135 fix(unified): merge nodes across sources so labels show in the unified Nodes view — since the composite-keyed `nodes` table holds one row per `(nodeNum, sourceId)`, a node heard on both an RF source (with NodeInfo) and an MQTT-bridged source (with only a transit packet, so `longName/shortName = null`) appeared in the unified view twice — once labeled, once as `Node <nodeNum>`. `getAllNodesAsync` now collapses per-source rows into one entry per `nodeNum` when no `sourceId` is supplied: the newest row by `lastHeard` wins, empty fields are back-filled from older rows, and `isFavorite`/`isIgnored`/`favoriteLocked` are OR'd across sources.
 
 
 ## [4.6.3] - 2026-05-20

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -27,6 +27,7 @@ import { isNodeComplete } from '../utils/nodeHelpers.js';
 import { getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
 import { migrateAutomationChannels } from './utils/automationChannelMigration.js';
 import { detectChannelMoves } from './utils/channelMoveDetection.js';
+import { mergeNodesAcrossSources } from './utils/mergeNodesAcrossSources.js';
 import { applyHomoglyphOptimization } from '../utils/homoglyph.js';
 import { PortNum, RoutingError, isPkiError, getRoutingErrorName, CHANNEL_DB_OFFSET, TransportMechanism, isViaMqtt, MIN_TRACEROUTE_INTERVAL_MS, StoreForwardRequestResponse, getStoreForwardRequestResponseName } from './constants/meshtastic.js';
 import { normalizeChannelRole } from './constants/channelRole.js';
@@ -12795,7 +12796,10 @@ class MeshtasticManager implements ISourceManager {
       sourceId,
     );
     const dbNodes = await databaseService.nodes.getAllNodes(sourceId);
-    return dbNodes.map(node => this.mapDbNodeToDeviceInfo(node, uptimeMap.get(node.nodeId)));
+    // Without a sourceId the caller wants the unified view, so collapse the
+    // per-source rows into one entry per nodeNum. Issue #3135.
+    const effective = sourceId ? dbNodes : mergeNodesAcrossSources(dbNodes);
+    return effective.map(node => this.mapDbNodeToDeviceInfo(node, uptimeMap.get(node.nodeId)));
   }
 
 

--- a/src/server/utils/mergeNodesAcrossSources.test.ts
+++ b/src/server/utils/mergeNodesAcrossSources.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Regression tests for mergeNodesAcrossSources (issue #3135).
+ *
+ * Without the merge step the unified Nodes view showed nodes once per source,
+ * so a node heard on both an RF source (with NodeInfo) and an MQTT-bridged
+ * source (without) appeared twice — once labeled, once as `Node <nodeNum>`.
+ */
+import { describe, it, expect } from 'vitest';
+import type { DbNode } from '../../db/types.js';
+import { mergeNodesAcrossSources } from './mergeNodesAcrossSources.js';
+
+function makeNode(nodeNum: number, overrides: Partial<DbNode> = {}): DbNode {
+  return {
+    nodeNum,
+    nodeId: `!${nodeNum.toString(16).padStart(8, '0')}`,
+    longName: null,
+    shortName: null,
+    hwModel: null,
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  } as DbNode;
+}
+
+describe('mergeNodesAcrossSources (issue #3135)', () => {
+  it('returns the input unchanged when there are no duplicates', () => {
+    const rows = [
+      makeNode(100, { longName: 'Alpha', updatedAt: 3000 }),
+      makeNode(101, { longName: 'Bravo', updatedAt: 2000 }),
+    ];
+    const merged = mergeNodesAcrossSources(rows);
+    expect(merged.length).toBe(2);
+    expect(merged.map((n) => n.nodeNum).sort()).toEqual([100, 101]);
+  });
+
+  it('backfills labels from the older source when the newer one has none', () => {
+    const rows: DbNode[] = [
+      // Older source heard a full NodeInfo, then the newer source only saw a
+      // bare transit packet and never learned the labels.
+      makeNode(200, {
+        longName: 'Real Name',
+        shortName: 'RN',
+        hwModel: 9,
+        lastHeard: 1000,
+        updatedAt: 1000,
+      }),
+      makeNode(200, {
+        longName: null,
+        shortName: null,
+        hwModel: null,
+        lastHeard: 2000,
+        updatedAt: 2000,
+      }),
+    ];
+
+    const merged = mergeNodesAcrossSources(rows);
+    expect(merged.length).toBe(1);
+    expect(merged[0].longName).toBe('Real Name');
+    expect(merged[0].shortName).toBe('RN');
+    expect(merged[0].hwModel).toBe(9);
+    expect(merged[0].lastHeard).toBe(2000);
+  });
+
+  it('treats empty strings as missing and back-fills them', () => {
+    const rows: DbNode[] = [
+      makeNode(201, { longName: 'Real Name', lastHeard: 1000, updatedAt: 1000 }),
+      makeNode(201, { longName: '   ', lastHeard: 2000, updatedAt: 2000 }),
+    ];
+    const [merged] = mergeNodesAcrossSources(rows);
+    expect(merged.longName).toBe('Real Name');
+  });
+
+  it('keeps the newer source\'s values when both have a label', () => {
+    const rows: DbNode[] = [
+      makeNode(300, {
+        longName: 'Old Name',
+        shortName: 'OLD',
+        lastHeard: 1000,
+        updatedAt: 1000,
+      }),
+      makeNode(300, {
+        longName: 'New Name',
+        shortName: 'NEW',
+        lastHeard: 2000,
+        updatedAt: 2000,
+      }),
+    ];
+
+    const [merged] = mergeNodesAcrossSources(rows);
+    expect(merged.longName).toBe('New Name');
+    expect(merged.shortName).toBe('NEW');
+  });
+
+  it('OR\'s isFavorite and isIgnored across sources', () => {
+    const rows: DbNode[] = [
+      makeNode(400, { isFavorite: true, isIgnored: false, lastHeard: 1000 }),
+      makeNode(400, { isFavorite: false, isIgnored: true, lastHeard: 2000 }),
+    ];
+    const [merged] = mergeNodesAcrossSources(rows);
+    expect(merged.isFavorite).toBe(true);
+    expect(merged.isIgnored).toBe(true);
+  });
+
+  it('exposes the max lastHeard / updatedAt across the group', () => {
+    const rows: DbNode[] = [
+      makeNode(500, { lastHeard: 5000, updatedAt: 5500 }),
+      makeNode(500, { lastHeard: 9000, updatedAt: 4000 }),
+      makeNode(500, { lastHeard: 7000, updatedAt: 9500 }),
+    ];
+    const [merged] = mergeNodesAcrossSources(rows);
+    expect(merged.lastHeard).toBe(9000);
+    expect(merged.updatedAt).toBe(9500);
+  });
+
+  it('back-fills position from a source that knows it', () => {
+    const rows: DbNode[] = [
+      makeNode(600, {
+        latitude: 35.123,
+        longitude: -90.456,
+        altitude: 150,
+        lastHeard: 1000,
+      }),
+      makeNode(600, {
+        latitude: null,
+        longitude: null,
+        altitude: null,
+        lastHeard: 2000,
+      }),
+    ];
+    const [merged] = mergeNodesAcrossSources(rows);
+    expect(merged.latitude).toBeCloseTo(35.123);
+    expect(merged.longitude).toBeCloseTo(-90.456);
+    expect(merged.altitude).toBe(150);
+  });
+
+  it('preserves the newer position when both sources have one', () => {
+    const rows: DbNode[] = [
+      makeNode(601, {
+        latitude: 35.0,
+        longitude: -90.0,
+        lastHeard: 1000,
+        updatedAt: 1000,
+      }),
+      makeNode(601, {
+        latitude: 36.0,
+        longitude: -91.0,
+        lastHeard: 2000,
+        updatedAt: 2000,
+      }),
+    ];
+    const [merged] = mergeNodesAcrossSources(rows);
+    expect(merged.latitude).toBeCloseTo(36.0);
+    expect(merged.longitude).toBeCloseTo(-91.0);
+  });
+
+  it('handles three sources with mixed coverage', () => {
+    const rows: DbNode[] = [
+      makeNode(700, { longName: 'Full Name', shortName: 'FN', lastHeard: 500 }),
+      makeNode(700, { latitude: 10, longitude: 20, lastHeard: 1500 }),
+      makeNode(700, { hwModel: 31, lastHeard: 1000 }),
+    ];
+    const merged = mergeNodesAcrossSources(rows);
+    expect(merged.length).toBe(1);
+    expect(merged[0].longName).toBe('Full Name');
+    expect(merged[0].shortName).toBe('FN');
+    expect(merged[0].latitude).toBe(10);
+    expect(merged[0].longitude).toBe(20);
+    expect(merged[0].hwModel).toBe(31);
+    expect(merged[0].lastHeard).toBe(1500);
+  });
+
+  it('returns empty array unchanged', () => {
+    expect(mergeNodesAcrossSources([])).toEqual([]);
+  });
+
+  it('orders the result by updatedAt descending', () => {
+    const rows: DbNode[] = [
+      makeNode(800, { updatedAt: 1000 }),
+      makeNode(801, { updatedAt: 3000 }),
+      makeNode(802, { updatedAt: 2000 }),
+    ];
+    const merged = mergeNodesAcrossSources(rows);
+    expect(merged.map((n) => n.nodeNum)).toEqual([801, 802, 800]);
+  });
+});

--- a/src/server/utils/mergeNodesAcrossSources.ts
+++ b/src/server/utils/mergeNodesAcrossSources.ts
@@ -1,0 +1,78 @@
+/**
+ * Merge per-source `nodes` rows into one representative row per `nodeNum`
+ * for the unified Nodes view (issue #3135).
+ *
+ * Background: since migration 029 the `nodes` table has a composite PK
+ * `(nodeNum, sourceId)`, so a node heard on multiple sources lives as one
+ * row per source. The unified consumers (`/api/poll` and `/api/nodes` with
+ * no `sourceId`) query the table unscoped, which returns every row. Without
+ * a merge step the UI shows the node once per source — and any source that
+ * only saw a transit packet has `longName/shortName = null`, so the user
+ * sees "Node <nodeNum>" duplicates next to the labeled row.
+ *
+ * The merge picks the newest row by `lastHeard` (then `updatedAt` as a
+ * tiebreaker) and back-fills any empty fields from older rows. The two
+ * user-intent booleans (`isFavorite`, `isIgnored`) are OR'd across sources
+ * so a flag set in any source is honored in the unified view.
+ */
+import type { DbNode } from '../../db/types.js';
+
+const isEmpty = (v: unknown): boolean =>
+  v === null || v === undefined || (typeof v === 'string' && v.trim() === '');
+
+export function mergeNodesAcrossSources(rows: DbNode[]): DbNode[] {
+  if (rows.length <= 1) return rows;
+
+  const groups = new Map<number, DbNode[]>();
+  for (const row of rows) {
+    const list = groups.get(row.nodeNum);
+    if (list) list.push(row);
+    else groups.set(row.nodeNum, [row]);
+  }
+
+  const merged: DbNode[] = [];
+  for (const group of groups.values()) {
+    if (group.length === 1) {
+      merged.push(group[0]);
+      continue;
+    }
+
+    group.sort((a, b) => {
+      const lh = (b.lastHeard ?? 0) - (a.lastHeard ?? 0);
+      if (lh !== 0) return lh;
+      return (b.updatedAt ?? 0) - (a.updatedAt ?? 0);
+    });
+
+    const winner: Record<string, any> = { ...group[0] };
+
+    for (let i = 1; i < group.length; i++) {
+      const older = group[i] as unknown as Record<string, any>;
+      for (const key of Object.keys(older)) {
+        if (isEmpty(winner[key]) && !isEmpty(older[key])) {
+          winner[key] = older[key];
+        }
+      }
+    }
+
+    winner.isFavorite = group.some((n) => n.isFavorite === true);
+    winner.isIgnored = group.some((n) => n.isIgnored === true);
+    winner.favoriteLocked = group.some((n) => n.favoriteLocked === true);
+
+    const maxLastHeard = group.reduce(
+      (max, n) => Math.max(max, n.lastHeard ?? 0),
+      0,
+    );
+    if (maxLastHeard > 0) winner.lastHeard = maxLastHeard;
+
+    const maxUpdatedAt = group.reduce(
+      (max, n) => Math.max(max, n.updatedAt ?? 0),
+      0,
+    );
+    if (maxUpdatedAt > 0) winner.updatedAt = maxUpdatedAt;
+
+    merged.push(winner as DbNode);
+  }
+
+  merged.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+  return merged;
+}


### PR DESCRIPTION
## Summary
The unified Nodes view (`/api/poll` and `/api/nodes` with no `sourceId`) was returning every per-source row from the composite-keyed `nodes` table. A node heard on both an RF source (with NodeInfo) and an MQTT-bridged source (with only a transit packet, so `longName/shortName = null`) appeared twice — once labeled, once as `Node <nodeNum>`. This PR collapses the duplicates into one merged row per node when no source is selected.

## Changes
- `src/server/utils/mergeNodesAcrossSources.ts` — new helper. Newest row by `lastHeard` wins (tiebreaker: `updatedAt`); empty fields are back-filled from older rows; `isFavorite` / `isIgnored` / `favoriteLocked` are OR'd across sources; result is sorted by `updatedAt desc`.
- `src/server/meshtasticManager.ts` — `getAllNodesAsync` calls the merger when `sourceId` is undefined. Per-source queries (`getAllNodesAsync(sourceId)`) are untouched.
- `src/server/utils/mergeNodesAcrossSources.test.ts` — 11 regression tests covering back-fill, newer-row-wins, boolean OR, position merging, three-source coverage, ordering.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Issues Resolved
Fixes #3135.

## Documentation Updates
- `CHANGELOG.md` — Unreleased fix entry. No other documentation changes needed; the dedup is an internal contract change in one helper and the behavior is what users intuitively expected from the unified view.

## Testing
- [x] Unit tests pass (10,345 tests, including the 11 new merge tests)
- [x] TypeScript compiles cleanly
- [x] No raw SQL added (merge happens in JS after the repository returns rows)
- [ ] Reviewer can manually verify by connecting two sources where one hears a node via MQTT bridge without a NodeInfo and the other has the NodeInfo, then checking the unified Nodes tab — the node should appear once, with the label from the source that has it

## Design notes
- The alternative was an SQL `GROUP BY` / window function. Rejected because the merge rule isn't expressible as simple aggregates (it's "newest row wins but back-fill empties, then OR booleans"), so it would have required three dialect-specific implementations for marginal gain at our scale (a few thousand rows max).
- A similar cross-source merge already exists for unified messages (#3105). This brings the unified Nodes view in line with that pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)