### PR TITLE
fix(meshcore): preserve LPP channel byte in remote telemetry rows

### DIFF
--- a/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
@@ -102,7 +102,7 @@ describe('recordToTelemetryRows', () => {
   it('produces one row for a scalar value with the right type+unit', () => {
     const rows = recordToTelemetryRows(baseRec, 'pk', 1, 1_000);
     expect(rows).toHaveLength(1);
-    expect(rows[0].telemetryType).toBe('mc_temperature');
+    expect(rows[0].telemetryType).toBe('mc_temperature_ch1');
     expect(rows[0].value).toBe(21.5);
     expect(rows[0].unit).toBe('°C');
     expect(rows[0].nodeId).toBe('pk');
@@ -124,9 +124,9 @@ describe('recordToTelemetryRows', () => {
     const rows = recordToTelemetryRows(rec, 'pk', 1, 0);
     const types = rows.map((r) => r.telemetryType).sort();
     expect(types).toEqual([
-      'mc_lpp_136_altitude',
-      'mc_lpp_136_latitude',
-      'mc_lpp_136_longitude',
+      'mc_lpp_136_ch1_altitude',
+      'mc_lpp_136_ch1_latitude',
+      'mc_lpp_136_ch1_longitude',
     ]);
   });
 
@@ -134,9 +134,9 @@ describe('recordToTelemetryRows', () => {
     const rec: MeshCoreTelemetryRecord = { channel: 1, type: 113, value: [1, 2, 3] };
     const rows = recordToTelemetryRows(rec, 'pk', 1, 0);
     expect(rows.map((r) => r.telemetryType)).toEqual([
-      'mc_lpp_113_0',
-      'mc_lpp_113_1',
-      'mc_lpp_113_2',
+      'mc_lpp_113_ch1_0',
+      'mc_lpp_113_ch1_1',
+      'mc_lpp_113_ch1_2',
     ]);
   });
 
@@ -144,7 +144,38 @@ describe('recordToTelemetryRows', () => {
     const rec: MeshCoreTelemetryRecord = { channel: 1, type: 9999, value: 42 };
     const rows = recordToTelemetryRows(rec, 'pk', 1, 0);
     expect(rows).toHaveLength(1);
-    expect(rows[0].telemetryType).toBe('mc_lpp_9999');
+    expect(rows[0].telemetryType).toBe('mc_lpp_9999_ch1');
+  });
+
+  // Regression for #3139: multiple LPP records of the same `type` on
+  // different `channel` bytes must produce distinct telemetryType strings.
+  // Before the fix, all four below collapsed onto `mc_battery_volts` and
+  // were indistinguishable on the chart-per-type frontend.
+  it('preserves the LPP channel byte in the telemetry type', () => {
+    const recs: MeshCoreTelemetryRecord[] = [
+      { channel: 1, type: 116, value: 4.10 }, // 116 = voltage → battery_volts in LPP_TYPE_NAMES
+      { channel: 2, type: 116, value: 12.50 },
+      { channel: 3, type: 116, value: 5.05 },
+      { channel: 4, type: 116, value: 3.30 },
+    ];
+    const rows = recs.flatMap((r) => recordToTelemetryRows(r, 'pk', 1, 1_000));
+    const types = rows.map((r) => r.telemetryType);
+    expect(types).toEqual([
+      'mc_battery_volts_ch1',
+      'mc_battery_volts_ch2',
+      'mc_battery_volts_ch3',
+      'mc_battery_volts_ch4',
+    ]);
+    expect(rows.map((r) => r.value)).toEqual([4.10, 12.50, 5.05, 3.30]);
+  });
+
+  it('does not write the LPP channel into the row\'s mesh-channel column', () => {
+    // The `channel` column on telemetry rows tracks the *mesh* channel slot
+    // (used by maskTelemetryByChannel for per-channel permissions). LPP's
+    // `channel` is a different concept — must not leak into that column.
+    const rec: MeshCoreTelemetryRecord = { channel: 3, type: 103, value: 21.5 };
+    const rows = recordToTelemetryRows(rec, 'pk', 1, 0);
+    expect(rows[0].channel).toBeUndefined();
   });
 });
 

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.ts
@@ -163,9 +163,21 @@ export function recordToTelemetryRows(
 ): DbTelemetry[] {
   if (record.type === null || record.type === undefined) return [];
   const naming = LPP_TYPE_NAMES[record.type] ?? { type: `lpp_${record.type}` };
-  const baseType = `${MC_TELEMETRY_PREFIX}${naming.type}`;
+  // Cayenne-LPP responses can carry several records of the same `type` under
+  // different `channel` bytes (e.g. battery on ch1=main, ch2=solar). Encode
+  // the channel into the telemetry-type string so each lands as a distinct
+  // chart instead of clobbering its peers. See issue #3139.
+  const channelSuffix = `_ch${record.channel}`;
+  const baseType = `${MC_TELEMETRY_PREFIX}${naming.type}${channelSuffix}`;
   const out: DbTelemetry[] = [];
 
+  // NOTE: we deliberately do NOT write `record.channel` into the row's
+  // `channel` column — that column is for the *mesh* channel the packet
+  // rode on (used by `maskTelemetryByChannel` for per-channel permission
+  // filtering, see src/server/utils/nodeEnhancer.ts). LPP's `channel` is a
+  // within-packet sensor-instance discriminator, an entirely different
+  // concept. Mixing the two would cause permission filtering to deny
+  // access to LPP channel 2/3/4 readings on private mesh channels.
   const pushScalar = (typeName: string, raw: unknown, unit?: string) => {
     const num = typeof raw === 'number' ? raw : Number(raw);
     if (!Number.isFinite(num)) return;


### PR DESCRIPTION
## Summary

Fixes part 1 of #3139 — MeshCore telemetry channels 2/3/4 not appearing.

Cayenne-LPP responses can carry several records of the same `type` under different `channel` bytes (e.g. battery on ch1 = main, ch2 = solar, ch3 = aux). `recordToTelemetryRows` in `src/server/services/meshcoreRemoteTelemetryScheduler.ts` was reading only `record.type` and dropping `record.channel`, so all four readings collapsed onto the same `telemetryType` (e.g. `mc_battery_volts`). The frontend renders one chart per telemetryType, so only the channel-1 reading surfaced.

### Fix

Embed `_ch<channel>` into the telemetry type string:
- ch1/battery → `mc_battery_volts_ch1`
- ch2/battery → `mc_battery_volts_ch2`
- ch3/battery → `mc_battery_volts_ch3`
- ch4/battery → `mc_battery_volts_ch4`

Each LPP channel now produces its own chart and time series.

### Subtle bit

We deliberately do **not** write `record.channel` into the row's `channel` column. That column is for the *mesh* channel the packet rode on (read by `maskTelemetryByChannel` in `src/server/utils/nodeEnhancer.ts` for per-channel permission filtering). LPP's `channel` is a within-packet sensor-instance discriminator — an entirely different concept. Mixing the two would cause per-channel permission filters to deny access to LPP channel-2/3/4 readings on private mesh channels.

This is called out as an inline comment in the function and asserted by a regression test.

## Test plan

- [x] `npm run test` — full Vitest suite (5390 tests) passes
- [x] Targeted `meshcoreRemoteTelemetryScheduler.test.ts` — all `recordToTelemetryRows` tests pass with new assertions
- [x] New regression test: feeds four ch1..ch4 records of type=116 (voltage) and asserts four distinct telemetry types are produced
- [x] New negative test: asserts that the row's `channel` column is **not** populated from the LPP byte
- [ ] Manual verification on a MeshCore companion with sensors on multiple LPP channels — should see distinct `mc_*_ch1`, `mc_*_ch2`, ... type names in the telemetry table

## Note on display labels

PR follow-up (separate) will add `TELEMETRY_LABELS` entries for the `mc_*_ch<N>` types so the Telemetry tab and the (still-to-be-built) MeshCore Telemetry Dashboard render friendly names. With this PR alone the raw machine names will show — but at least all four channels' data is *captured* and queryable, which was the regression.

Fixes part 1 of #3139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)