### PR TITLE
feat(meshcore): add Telemetry dashboard tab via source-agnostic Dashboard

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4175,6 +4175,7 @@
   "meshcore.nav.expand": "Expand",
   "meshcore.nav.nodes": "Nodes",
   "meshcore.nav.settings": "Settings",
+  "meshcore.nav.telemetry": "Telemetry",
   "meshcore.config.bandwidth": "Bandwidth (kHz)",
   "meshcore.config.cr": "Coding Rate",
   "meshcore.config.device_name": "Device name",

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -11,17 +11,9 @@ import AddWidgetModal from '../AddWidgetModal';
 import { DashboardHeader, DashboardFilters, DashboardGrid } from './components';
 import { useDashboardData, useDashboardFilters, useCustomWidgets } from './hooks';
 import { type DashboardProps } from './types';
+import { meshtasticDashboardSource } from './dataSources';
 import { useSettings } from '../../contexts/SettingsContext';
 import { useSource } from '../../contexts/SourceContext';
-
-// Telemetry types that should show solar by default (power/environmental)
-const SOLAR_DEFAULT_ON_TYPES = new Set([
-  'batteryLevel', 'voltage', 'ch1Voltage', 'ch1Current',
-  'ch2Voltage', 'ch2Current', 'ch3Voltage', 'ch3Current',
-  'ch4Voltage', 'ch4Current', 'ch5Voltage', 'ch5Current',
-  'ch6Voltage', 'ch6Current', 'ch7Voltage', 'ch7Current',
-  'ch8Voltage', 'ch8Current', 'temperature', 'humidity', 'pressure',
-]);
 
 const Dashboard: React.FC<DashboardProps> = React.memo(
   ({
@@ -32,6 +24,7 @@ const Dashboard: React.FC<DashboardProps> = React.memo(
     currentNodeId = null,
     canEdit = true,
     onOpenNodeDetails,
+    dataSource = meshtasticDashboardSource,
   }) => {
     const { t } = useTranslation();
     const csrfFetch = useCsrfFetch();
@@ -58,7 +51,7 @@ const Dashboard: React.FC<DashboardProps> = React.memo(
       setSolarVisibility,
       loading,
       error,
-    } = useDashboardData();
+    } = useDashboardData({ dataSource });
 
     // Get solar visibility for a specific chart (uses type-based default if not set)
     const getSolarVisibility = useCallback((nodeId: string, telemetryType: string): boolean => {
@@ -66,9 +59,10 @@ const Dashboard: React.FC<DashboardProps> = React.memo(
       if (key in solarVisibility) {
         return solarVisibility[key];
       }
-      // Default based on telemetry type
-      return SOLAR_DEFAULT_ON_TYPES.has(telemetryType);
-    }, [solarVisibility]);
+      // Default based on telemetry type (per-source — Meshtastic and MeshCore
+      // each carry their own default-on type lists).
+      return dataSource.solarDefaultTypes.has(telemetryType);
+    }, [solarVisibility, dataSource]);
 
     // Toggle solar visibility for a specific chart and save to server
     const handleToggleSolar = useCallback(async (nodeId: string, telemetryType: string, show: boolean) => {
@@ -120,6 +114,7 @@ const Dashboard: React.FC<DashboardProps> = React.memo(
       customOrder,
       favoriteTelemetryStorageDays,
       defaultSortOption: preferredDashboardSortOption,
+      dataSource,
     });
 
     // Widgets hook
@@ -252,13 +247,16 @@ const Dashboard: React.FC<DashboardProps> = React.memo(
           favoritesCount={favorites.length}
           daysToView={daysToView}
           onAddWidgetClick={() => setShowAddWidgetModal(true)}
+          showAddWidget={dataSource.showCustomWidgets}
         />
 
-        <AddWidgetModal
-          isOpen={showAddWidgetModal}
-          onClose={() => setShowAddWidgetModal(false)}
-          onAddWidget={addWidget}
-        />
+        {dataSource.showCustomWidgets && (
+          <AddWidgetModal
+            isOpen={showAddWidgetModal}
+            onClose={() => setShowAddWidgetModal(false)}
+            onAddWidget={addWidget}
+          />
+        )}
 
         <DashboardFilters
           daysToView={daysToView}

--- a/src/components/Dashboard/components/DashboardHeader.tsx
+++ b/src/components/Dashboard/components/DashboardHeader.tsx
@@ -5,12 +5,16 @@ interface DashboardHeaderProps {
   favoritesCount: number;
   daysToView: number;
   onAddWidgetClick: () => void;
+  /** When false, the "Add Widget" button is suppressed — used for source
+   *  types (e.g. MeshCore) that don't yet have any custom-widget kinds. */
+  showAddWidget?: boolean;
 }
 
 const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   favoritesCount,
   daysToView,
   onAddWidgetClick,
+  showAddWidget = true,
 }) => {
   const { t } = useTranslation();
 
@@ -24,13 +28,15 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
             : t('dashboard.subtitle_empty')}
         </p>
       </div>
-      <button
-        className="dashboard-add-widget-btn"
-        onClick={onAddWidgetClick}
-        title={t('dashboard.add_widget_title')}
-      >
-        {t('dashboard.add_widget_button')}
-      </button>
+      {showAddWidget && (
+        <button
+          className="dashboard-add-widget-btn"
+          onClick={onAddWidgetClick}
+          title={t('dashboard.add_widget_title')}
+        >
+          {t('dashboard.add_widget_button')}
+        </button>
+      )}
     </div>
   );
 };

--- a/src/components/Dashboard/dataSources.test.ts
+++ b/src/components/Dashboard/dataSources.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for the Dashboard data-source adapters (meshtastic + meshcore).
+ * Regression coverage for #3139 — verifies the MeshCore adapter maps
+ * its native node shape into the NodeInfo shape the Dashboard consumes.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/api', () => ({
+  default: { get: vi.fn() },
+}));
+vi.mock('../../utils/deviceRole', () => ({
+  // Stand-in that returns a recognisable label per Meshtastic role int
+  getDeviceRoleName: (r: number | string) => `role-${r}`,
+}));
+
+import api from '../../services/api';
+import { meshcoreDashboardSource, meshtasticDashboardSource } from './dataSources';
+
+const mockedApiGet = api.get as unknown as ReturnType<typeof vi.fn>;
+
+describe('meshcoreDashboardSource', () => {
+  beforeEach(() => {
+    mockedApiGet.mockReset();
+  });
+
+  it('fetches per-source MeshCore nodes and adapts them into NodeInfo', async () => {
+    mockedApiGet.mockResolvedValueOnce({
+      data: [
+        {
+          publicKey: 'abcd1234',
+          name: 'Repeater A',
+          advType: 2,
+          lastHeard: 1_700_000_000,
+          rssi: -90,
+          snr: 5.5,
+          latitude: 30.1,
+          longitude: -90.1,
+        },
+        {
+          publicKey: 'ef567890',
+          name: 'Companion B',
+          advType: 1,
+          // no location — should not synthesize a position
+        },
+      ],
+    });
+
+    const nodes = await meshcoreDashboardSource.fetchNodes('src-1');
+
+    expect(mockedApiGet).toHaveBeenCalledWith('/api/sources/src-1/meshcore/nodes');
+    expect(nodes).toHaveLength(2);
+
+    expect(nodes[0]).toMatchObject({
+      nodeNum: 0,
+      user: {
+        id: 'abcd1234',
+        longName: 'Repeater A',
+        role: 2,
+      },
+      lastHeard: 1_700_000_000,
+      rssi: -90,
+      snr: 5.5,
+      position: { latitude: 30.1, longitude: -90.1 },
+    });
+
+    expect(nodes[1].position).toBeUndefined();
+  });
+
+  it('returns an empty array when no sourceId is provided', async () => {
+    const nodes = await meshcoreDashboardSource.fetchNodes(null);
+    expect(nodes).toEqual([]);
+    expect(mockedApiGet).not.toHaveBeenCalled();
+  });
+
+  it('tolerates an unwrapped array response (no { data } envelope)', async () => {
+    mockedApiGet.mockResolvedValueOnce([
+      { publicKey: 'pk1', name: 'N1', advType: 1 },
+    ]);
+    const nodes = await meshcoreDashboardSource.fetchNodes('src-1');
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].user?.id).toBe('pk1');
+  });
+
+  it('keys nodes by publicKey (via user.id)', () => {
+    const node = { nodeNum: 0, user: { id: 'pk-xyz' } };
+    expect(meshcoreDashboardSource.nodeKey(node)).toBe('pk-xyz');
+  });
+
+  it('uses longName for display, falling back to shortName then the fallback id', () => {
+    expect(meshcoreDashboardSource.getDisplayName(
+      { nodeNum: 0, user: { id: 'pk', longName: 'Full Name', shortName: 'FN' } },
+      'pk',
+    )).toBe('Full Name');
+
+    expect(meshcoreDashboardSource.getDisplayName(
+      { nodeNum: 0, user: { id: 'pk', shortName: 'FN' } },
+      'pk',
+    )).toBe('FN');
+
+    expect(meshcoreDashboardSource.getDisplayName(undefined, 'fallback-id')).toBe('fallback-id');
+  });
+
+  it('labels MeshCore advType correctly (companion/repeater/room)', () => {
+    expect(meshcoreDashboardSource.getRoleName({ nodeNum: 0, user: { id: 'a', role: 1 } })).toBe('Companion');
+    expect(meshcoreDashboardSource.getRoleName({ nodeNum: 0, user: { id: 'a', role: 2 } })).toBe('Repeater');
+    expect(meshcoreDashboardSource.getRoleName({ nodeNum: 0, user: { id: 'a', role: 3 } })).toBe('Room Server');
+    expect(meshcoreDashboardSource.getRoleName({ nodeNum: 0, user: { id: 'a', role: 0 } })).toBe('Unknown');
+    expect(meshcoreDashboardSource.getRoleName(undefined)).toBeNull();
+    expect(meshcoreDashboardSource.getRoleName({ nodeNum: 0, user: { id: 'a' } })).toBeNull();
+  });
+
+  it('hides custom widgets (no nodeStatus/traceroute for MeshCore yet)', () => {
+    expect(meshcoreDashboardSource.showCustomWidgets).toBe(false);
+  });
+
+  it('marks ch1..ch4 LPP env sensors as solar-default-on', () => {
+    expect(meshcoreDashboardSource.solarDefaultTypes.has('mc_battery_volts_ch1')).toBe(true);
+    expect(meshcoreDashboardSource.solarDefaultTypes.has('mc_battery_volts_ch4')).toBe(true);
+    expect(meshcoreDashboardSource.solarDefaultTypes.has('mc_temperature_ch1')).toBe(true);
+    expect(meshcoreDashboardSource.solarDefaultTypes.has('mc_humidity_ch2')).toBe(true);
+    expect(meshcoreDashboardSource.solarDefaultTypes.has('mc_status_uptime_secs')).toBe(false);
+  });
+});
+
+describe('meshtasticDashboardSource (regression — default unchanged)', () => {
+  beforeEach(() => {
+    mockedApiGet.mockReset();
+  });
+
+  it('still hits /api/nodes with the source-query suffix', async () => {
+    mockedApiGet.mockResolvedValueOnce([
+      { nodeNum: 1, user: { id: '!aabb' } },
+    ]);
+    const nodes = await meshtasticDashboardSource.fetchNodes('src-2');
+    expect(mockedApiGet).toHaveBeenCalledWith('/api/nodes?sourceId=src-2');
+    expect(nodes).toHaveLength(1);
+  });
+
+  it('shows custom widgets (Meshtastic preserves the prior behaviour)', () => {
+    expect(meshtasticDashboardSource.showCustomWidgets).toBe(true);
+  });
+
+  it('keys nodes by user.id', () => {
+    expect(meshtasticDashboardSource.nodeKey({ nodeNum: 1, user: { id: '!abcd' } })).toBe('!abcd');
+  });
+});

--- a/src/components/Dashboard/dataSources.ts
+++ b/src/components/Dashboard/dataSources.ts
@@ -1,0 +1,176 @@
+/**
+ * Dashboard data sources — abstraction layer that lets the per-source
+ * Dashboard component render for either a Meshtastic or a MeshCore source.
+ *
+ * The Dashboard was originally built against Meshtastic-only assumptions
+ * (`/api/nodes` endpoint, `user.id`-keyed node map, `getDeviceRoleName`
+ * for role labels, custom widgets that depend on Meshtastic protocol
+ * concepts). This module abstracts those bits so the same component can
+ * back both source types — see issue #3139.
+ *
+ * The Meshtastic source preserves prior behaviour byte-for-byte and is
+ * the default when no explicit data source is passed.
+ */
+
+import api from '../../services/api';
+import { getDeviceRoleName } from '../../utils/deviceRole';
+import type { NodeInfo } from './types';
+
+/**
+ * Shape of the data the per-source Dashboard needs from its source. Each
+ * implementation knows how to fetch and adapt its native node shape into
+ * the common `NodeInfo` type the Dashboard renders against.
+ */
+export interface DashboardDataSource {
+  /** Identifier for testing / debug logs. */
+  readonly kind: 'meshtastic' | 'meshcore';
+
+  /** Fetch the source's nodes and return them as `NodeInfo`s. */
+  fetchNodes: (sourceId: string | null) => Promise<NodeInfo[]>;
+
+  /** Extract the dedup / lookup key (matches `FavoriteChart.nodeId`). */
+  nodeKey: (node: NodeInfo) => string | undefined;
+
+  /** Human-readable display name; falls back to `fallbackId` when node is unknown. */
+  getDisplayName: (node: NodeInfo | undefined, fallbackId: string) => string;
+
+  /** Device-role label for the filter dropdown, or null if the node has no role. */
+  getRoleName: (node: NodeInfo | undefined) => string | null;
+
+  /** Telemetry types that should show the solar overlay on by default. */
+  readonly solarDefaultTypes: ReadonlySet<string>;
+
+  /** Whether the "Add Widget" button is exposed. Custom widgets are Meshtastic-only today. */
+  readonly showCustomWidgets: boolean;
+
+  /** Whether the device-role filter dropdown is shown. */
+  readonly showRoleFilter: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Meshtastic data source (default)
+// ---------------------------------------------------------------------------
+
+const MESHTASTIC_SOLAR_DEFAULT_ON_TYPES = new Set<string>([
+  'batteryLevel', 'voltage',
+  'ch1Voltage', 'ch1Current',
+  'ch2Voltage', 'ch2Current',
+  'ch3Voltage', 'ch3Current',
+  'ch4Voltage', 'ch4Current',
+  'ch5Voltage', 'ch5Current',
+  'ch6Voltage', 'ch6Current',
+  'ch7Voltage', 'ch7Current',
+  'ch8Voltage', 'ch8Current',
+  'temperature', 'humidity', 'pressure',
+]);
+
+export const meshtasticDashboardSource: DashboardDataSource = {
+  kind: 'meshtastic',
+  fetchNodes: async (sourceId) => {
+    const sourceQuery = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
+    return api.get<NodeInfo[]>(`/api/nodes${sourceQuery}`);
+  },
+  nodeKey: (node) => node.user?.id,
+  getDisplayName: (node, fallbackId) =>
+    node?.user?.longName || node?.user?.shortName || fallbackId,
+  getRoleName: (node) => {
+    const role = node?.user?.role;
+    if (role === undefined || role === null) return null;
+    return getDeviceRoleName(role);
+  },
+  solarDefaultTypes: MESHTASTIC_SOLAR_DEFAULT_ON_TYPES,
+  showCustomWidgets: true,
+  showRoleFilter: true,
+};
+
+// ---------------------------------------------------------------------------
+// MeshCore data source
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw shape returned by `GET /api/sources/:id/meshcore/nodes` (the
+ * registered serverside `MeshCoreNode`). Kept as a local type — we
+ * deliberately don't import the server's interface so this module stays
+ * frontend-only.
+ */
+interface RawMeshCoreNode {
+  publicKey: string;
+  name: string;
+  advType: number; // 0=unknown, 1=companion, 2=repeater, 3=room server
+  lastHeard?: number;
+  rssi?: number;
+  snr?: number;
+  latitude?: number;
+  longitude?: number;
+}
+
+const MESHCORE_ADV_TYPE_LABELS: Record<number, string> = {
+  0: 'Unknown',
+  1: 'Companion',
+  2: 'Repeater',
+  3: 'Room Server',
+};
+
+// LPP env-sensor types that warrant the solar overlay. Status counters
+// (uptime, packets, rssi/snr) don't benefit from a solar curve.
+const MESHCORE_SOLAR_DEFAULT_ON_TYPES = new Set<string>([
+  // Multi-channel battery / voltage / current
+  ...['ch1', 'ch2', 'ch3', 'ch4', 'ch5', 'ch6', 'ch7', 'ch8'].flatMap((ch) => [
+    `mc_battery_volts_${ch}`,
+    `mc_voltage_${ch}`,
+    `mc_current_${ch}`,
+  ]),
+  // Environmental sensors (single-channel typical, but support up to 4)
+  ...['ch1', 'ch2', 'ch3', 'ch4'].flatMap((ch) => [
+    `mc_temperature_${ch}`,
+    `mc_humidity_${ch}`,
+    `mc_pressure_${ch}`,
+  ]),
+]);
+
+export const meshcoreDashboardSource: DashboardDataSource = {
+  kind: 'meshcore',
+  fetchNodes: async (sourceId) => {
+    if (!sourceId) return [];
+    // MeshCore nodes are served per-source, not globally.
+    const response = await api.get<{ data?: RawMeshCoreNode[] } | RawMeshCoreNode[]>(
+      `/api/sources/${encodeURIComponent(sourceId)}/meshcore/nodes`,
+    );
+    const raw: RawMeshCoreNode[] = Array.isArray(response)
+      ? response
+      : (response?.data ?? []);
+    return raw.map((mc): NodeInfo => ({
+      // MeshCore has no integer nodeNum — leave 0; the Dashboard's
+      // chart-rendering path doesn't use nodeNum directly, only for
+      // custom-widget machinery we hide for MeshCore.
+      nodeNum: 0,
+      user: {
+        id: mc.publicKey,
+        longName: mc.name,
+        shortName: mc.name?.slice(0, 4),
+        role: mc.advType,
+      },
+      lastHeard: mc.lastHeard,
+      snr: mc.snr,
+      rssi: mc.rssi,
+      position:
+        mc.latitude != null && mc.longitude != null
+          ? { latitude: mc.latitude, longitude: mc.longitude }
+          : undefined,
+    }));
+  },
+  nodeKey: (node) => node.user?.id,
+  getDisplayName: (node, fallbackId) =>
+    node?.user?.longName || node?.user?.shortName || fallbackId,
+  getRoleName: (node) => {
+    const advType = node?.user?.role;
+    if (advType === undefined || advType === null) return null;
+    const key = typeof advType === 'number' ? advType : Number(advType);
+    return MESHCORE_ADV_TYPE_LABELS[key] ?? null;
+  },
+  solarDefaultTypes: MESHCORE_SOLAR_DEFAULT_ON_TYPES,
+  // MeshCore has no equivalent for Meshtastic's nodeStatus / traceroute /
+  // hopDistribution / distanceDistribution custom widgets.
+  showCustomWidgets: false,
+  showRoleFilter: true,
+};

--- a/src/components/Dashboard/hooks/useDashboardData.ts
+++ b/src/components/Dashboard/hooks/useDashboardData.ts
@@ -4,12 +4,19 @@ import api from '../../../services/api';
 import { logger } from '../../../utils/logger';
 import { useSource } from '../../../contexts/SourceContext';
 import { type FavoriteChart, type NodeInfo, type CustomWidget } from '../types';
+import { type DashboardDataSource, meshtasticDashboardSource } from '../dataSources';
 
 interface UseDashboardDataOptions {
   /** Polling interval in milliseconds (default: 30000) */
   refetchInterval?: number;
   /** Whether queries are enabled (default: true) */
   enabled?: boolean;
+  /**
+   * Source adapter — controls which API the nodes come from and how to
+   * extract the lookup key. Defaults to the Meshtastic adapter so any
+   * legacy caller keeps prior behaviour byte-for-byte.
+   */
+  dataSource?: DashboardDataSource;
 }
 
 interface SettingsResponse {
@@ -46,7 +53,11 @@ export const dashboardQueryKeys = {
  * Uses TanStack Query for caching, automatic refetching, and background updates
  */
 export function useDashboardData(options?: UseDashboardDataOptions): UseDashboardDataResult {
-  const { refetchInterval = 30000, enabled = true } = options ?? {};
+  const {
+    refetchInterval = 30000,
+    enabled = true,
+    dataSource = meshtasticDashboardSource,
+  } = options ?? {};
   const queryClient = useQueryClient();
   const { sourceId } = useSource();
   const sourceQuery = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
@@ -98,15 +109,18 @@ export function useDashboardData(options?: UseDashboardDataOptions): UseDashboar
     refetchIntervalInBackground: false, // Don't poll when tab is not visible
   });
 
-  // Fetch nodes
+  // Fetch nodes — endpoint, response shape, and lookup-key extraction all
+  // come from the active dataSource so the Dashboard can back either a
+  // Meshtastic or MeshCore source without forking.
   const nodesQuery = useQuery({
-    queryKey: dashboardQueryKeys.nodes(sourceId),
+    queryKey: [...dashboardQueryKeys.nodes(sourceId), dataSource.kind] as const,
     queryFn: async (): Promise<Map<string, NodeInfo>> => {
-      const nodesData = await api.get<NodeInfo[]>(`/api/nodes${sourceQuery}`);
+      const nodesData = await dataSource.fetchNodes(sourceId);
       const nodesMap = new Map<string, NodeInfo>();
-      nodesData.forEach((node: NodeInfo) => {
-        if (node.user?.id) {
-          nodesMap.set(node.user.id, node);
+      nodesData.forEach((node) => {
+        const key = dataSource.nodeKey(node);
+        if (key) {
+          nodesMap.set(key, node);
         }
       });
       return nodesMap;

--- a/src/components/Dashboard/hooks/useDashboardFilters.ts
+++ b/src/components/Dashboard/hooks/useDashboardFilters.ts
@@ -1,8 +1,8 @@
 import { useState, useMemo, useCallback } from 'react';
 import { getTelemetryLabel } from '../../TelemetryChart';
-import { getDeviceRoleName } from '../../../utils/deviceRole';
 import { logger } from '../../../utils/logger';
 import { type SortOption, type FavoriteChart, type NodeInfo } from '../types';
+import { type DashboardDataSource, meshtasticDashboardSource } from '../dataSources';
 
 interface UseDashboardFiltersOptions {
   favorites: FavoriteChart[];
@@ -10,6 +10,13 @@ interface UseDashboardFiltersOptions {
   customOrder: string[];
   favoriteTelemetryStorageDays: number;
   defaultSortOption?: SortOption;
+  /**
+   * Source adapter — provides display-name and role-label resolution so
+   * the filter/sort logic works equally for Meshtastic and MeshCore nodes.
+   * Defaults to the Meshtastic adapter so any legacy caller keeps prior
+   * behaviour.
+   */
+  dataSource?: DashboardDataSource;
 }
 
 interface UseDashboardFiltersResult {
@@ -48,6 +55,7 @@ export function useDashboardFilters({
   customOrder,
   favoriteTelemetryStorageDays,
   defaultSortOption = 'custom',
+  dataSource = meshtasticDashboardSource,
 }: UseDashboardFiltersOptions): UseDashboardFiltersResult {
   // Days to view control
   const [daysToView, setDaysToViewState] = useState<number>(() => {
@@ -108,11 +116,10 @@ export function useDashboardFilters({
     const nodesMap = new Map<string, string>();
     favorites.forEach(fav => {
       const node = nodes.get(fav.nodeId);
-      const nodeName = node?.user?.longName || node?.user?.shortName || fav.nodeId;
-      nodesMap.set(fav.nodeId, nodeName);
+      nodesMap.set(fav.nodeId, dataSource.getDisplayName(node, fav.nodeId));
     });
     return Array.from(nodesMap.entries()).sort((a, b) => a[1].localeCompare(b[1]));
-  }, [favorites, nodes]);
+  }, [favorites, nodes, dataSource]);
 
   // Get unique telemetry types for filter dropdown
   const uniqueTelemetryTypes = useMemo(() => {
@@ -126,13 +133,13 @@ export function useDashboardFilters({
     const roles = new Map<string, string>();
     favorites.forEach(fav => {
       const node = nodes.get(fav.nodeId);
-      if (node?.user?.role !== undefined) {
-        const roleName = getDeviceRoleName(node.user.role);
+      const roleName = dataSource.getRoleName(node);
+      if (roleName) {
         roles.set(roleName, roleName);
       }
     });
     return Array.from(roles.values()).sort();
-  }, [favorites, nodes]);
+  }, [favorites, nodes, dataSource]);
 
   // Filter and sort favorites
   const filteredAndSortedFavorites = useMemo(() => {
@@ -143,7 +150,7 @@ export function useDashboardFilters({
       const query = searchQuery.toLowerCase();
       result = result.filter(fav => {
         const node = nodes.get(fav.nodeId);
-        const nodeName = (node?.user?.longName || node?.user?.shortName || fav.nodeId).toLowerCase();
+        const nodeName = dataSource.getDisplayName(node, fav.nodeId).toLowerCase();
         const typeName = getTelemetryLabel(fav.telemetryType).toLowerCase();
         return nodeName.includes(query) || typeName.includes(query);
       });
@@ -160,8 +167,8 @@ export function useDashboardFilters({
     if (selectedRoles.size > 0) {
       result = result.filter(fav => {
         const node = nodes.get(fav.nodeId);
-        if (!node?.user?.role) return false;
-        const roleName = getDeviceRoleName(node.user.role);
+        const roleName = dataSource.getRoleName(node);
+        if (!roleName) return false;
         return selectedRoles.has(roleName);
       });
     }
@@ -180,18 +187,14 @@ export function useDashboardFilters({
       });
     } else if (sortOption === 'node-asc') {
       result.sort((a, b) => {
-        const nodeA = nodes.get(a.nodeId);
-        const nodeB = nodes.get(b.nodeId);
-        const nameA = (nodeA?.user?.longName || nodeA?.user?.shortName || a.nodeId).toLowerCase();
-        const nameB = (nodeB?.user?.longName || nodeB?.user?.shortName || b.nodeId).toLowerCase();
+        const nameA = dataSource.getDisplayName(nodes.get(a.nodeId), a.nodeId).toLowerCase();
+        const nameB = dataSource.getDisplayName(nodes.get(b.nodeId), b.nodeId).toLowerCase();
         return nameA.localeCompare(nameB);
       });
     } else if (sortOption === 'node-desc') {
       result.sort((a, b) => {
-        const nodeA = nodes.get(a.nodeId);
-        const nodeB = nodes.get(b.nodeId);
-        const nameA = (nodeA?.user?.longName || nodeA?.user?.shortName || a.nodeId).toLowerCase();
-        const nameB = (nodeB?.user?.longName || nodeB?.user?.shortName || b.nodeId).toLowerCase();
+        const nameA = dataSource.getDisplayName(nodes.get(a.nodeId), a.nodeId).toLowerCase();
+        const nameB = dataSource.getDisplayName(nodes.get(b.nodeId), b.nodeId).toLowerCase();
         return nameB.localeCompare(nameA);
       });
     } else if (sortOption === 'type-asc') {
@@ -201,7 +204,7 @@ export function useDashboardFilters({
     }
 
     return result;
-  }, [favorites, nodes, searchQuery, selectedNode, selectedType, selectedRoles, sortOption, customOrder]);
+  }, [favorites, nodes, searchQuery, selectedNode, selectedType, selectedRoles, sortOption, customOrder, dataSource]);
 
   return {
     searchQuery,

--- a/src/components/Dashboard/types.ts
+++ b/src/components/Dashboard/types.ts
@@ -1,6 +1,7 @@
 import { type TemperatureUnit } from '../../utils/temperature';
 import { type TelemetryData } from '../../hooks/useTelemetry';
 import { type FavoriteChart, type NodeInfo } from '../TelemetryChart';
+import { type DashboardDataSource } from './dataSources';
 
 // Custom widget types for node status and traceroute
 export interface NodeStatusWidgetConfig {
@@ -44,6 +45,12 @@ export interface DashboardProps {
   currentNodeId?: string | null;
   canEdit?: boolean;
   onOpenNodeDetails?: (nodeId: string) => void;
+  /**
+   * Source-shape adapter. Defaults to the Meshtastic adapter so the
+   * App.tsx call site stays unchanged. MeshCore mounts this with
+   * `meshcoreDashboardSource` from `./dataSources`.
+   */
+  dataSource?: DashboardDataSource;
 }
 
 export interface DashboardFiltersState {

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -21,6 +21,7 @@ import { MeshCoreNodesView } from './MeshCoreNodesView';
 import { MeshCoreChannelsView } from './MeshCoreChannelsView';
 import { MeshCoreDirectMessagesView } from './MeshCoreDirectMessagesView';
 import { MeshCoreInfoView } from './MeshCoreInfoView';
+import { MeshCoreTelemetryView } from './MeshCoreTelemetryView';
 import { MeshCoreConfigurationView } from './MeshCoreConfigurationView';
 import { MeshCoreSettingsView } from './MeshCoreSettingsView';
 import './MeshCoreTab.css';
@@ -102,6 +103,9 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
               baseUrl={baseUrl}
               sourceId={sourceId}
             />
+          )}
+          {view === 'telemetry' && (
+            <MeshCoreTelemetryView baseUrl={baseUrl} />
           )}
           {view === 'info' && (
             <MeshCoreInfoView baseUrl={baseUrl} sourceId={sourceId} status={status} />

--- a/src/components/MeshCore/MeshCoreSubToolbar.tsx
+++ b/src/components/MeshCore/MeshCoreSubToolbar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../contexts/AuthContext';
 
-export type MeshCoreView = 'nodes' | 'channels' | 'dms' | 'info' | 'configuration' | 'settings';
+export type MeshCoreView = 'nodes' | 'channels' | 'dms' | 'telemetry' | 'info' | 'configuration' | 'settings';
 
 interface MeshCoreSubToolbarProps {
   view: MeshCoreView;
@@ -24,6 +24,7 @@ const ITEMS: Item[] = [
   { id: 'nodes', icon: '🛰', labelKey: 'meshcore.nav.nodes', fallback: 'Nodes' },
   { id: 'channels', icon: '💬', labelKey: 'meshcore.nav.channels', fallback: 'Channels' },
   { id: 'dms', icon: '📧', labelKey: 'meshcore.nav.dms', fallback: 'Direct Messages' },
+  { id: 'telemetry', icon: '📊', labelKey: 'meshcore.nav.telemetry', fallback: 'Telemetry' },
   { id: 'info', icon: 'ℹ', labelKey: 'meshcore.nav.info', fallback: 'Node Info' },
   { id: 'configuration', icon: '📡', labelKey: 'meshcore.nav.configuration', fallback: 'Configuration' },
   { id: 'settings', icon: '⚙', labelKey: 'meshcore.nav.settings', fallback: 'Settings' },

--- a/src/components/MeshCore/MeshCoreTelemetryView.tsx
+++ b/src/components/MeshCore/MeshCoreTelemetryView.tsx
@@ -1,0 +1,36 @@
+/**
+ * MeshCoreTelemetryView — Dashboard-style favorite-telemetry view for a
+ * MeshCore source. Mounts the shared per-source `Dashboard` component
+ * with the MeshCore data-source adapter so a user's starred MeshCore
+ * charts (from any DM or node view) land in one place.
+ *
+ * Closes the "I can favorit graphs also in meshcore, but where does it
+ * show up" gap from #3139.
+ */
+import React from 'react';
+import Dashboard from '../Dashboard/Dashboard';
+import { meshcoreDashboardSource } from '../Dashboard/dataSources';
+import { useSettings } from '../../contexts/SettingsContext';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface MeshCoreTelemetryViewProps {
+  baseUrl: string;
+}
+
+export const MeshCoreTelemetryView: React.FC<MeshCoreTelemetryViewProps> = ({ baseUrl }) => {
+  const { temperatureUnit, telemetryVisualizationHours, favoriteTelemetryStorageDays } = useSettings();
+  const { hasPermission } = useAuth();
+
+  return (
+    <Dashboard
+      baseUrl={baseUrl}
+      dataSource={meshcoreDashboardSource}
+      temperatureUnit={temperatureUnit}
+      telemetryHours={telemetryVisualizationHours}
+      favoriteTelemetryStorageDays={favoriteTelemetryStorageDays}
+      canEdit={hasPermission('dashboard', 'write')}
+    />
+  );
+};
+
+export default MeshCoreTelemetryView;

--- a/src/components/TelemetryChart.test.ts
+++ b/src/components/TelemetryChart.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the label-resolution helper exported by TelemetryChart.
+ * Covers the MeshCore `_ch<N>` suffix handling added for #3139.
+ */
+import { describe, it, expect } from 'vitest';
+import { getTelemetryLabel } from './TelemetryChart';
+
+describe('getTelemetryLabel', () => {
+  it('returns the explicit label for known Meshtastic types', () => {
+    expect(getTelemetryLabel('batteryLevel')).toBe('Battery Level');
+    expect(getTelemetryLabel('temperature')).toBe('Temperature');
+  });
+
+  it('returns the explicit label for known MeshCore status types', () => {
+    expect(getTelemetryLabel('mc_status_uptime_secs')).toBe('Uptime');
+    expect(getTelemetryLabel('mc_status_noise_floor')).toBe('Noise Floor');
+  });
+
+  it('formats MeshCore LPP-channel-suffixed types as "<base> (chN)"', () => {
+    expect(getTelemetryLabel('mc_battery_volts_ch1')).toBe('Battery (ch1)');
+    expect(getTelemetryLabel('mc_battery_volts_ch4')).toBe('Battery (ch4)');
+    expect(getTelemetryLabel('mc_temperature_ch2')).toBe('Temperature (ch2)');
+    expect(getTelemetryLabel('mc_humidity_ch3')).toBe('Humidity (ch3)');
+  });
+
+  it('appends the axis key for multi-axis LPP types (gps etc.)', () => {
+    // baseType `mc_lpp_136` isn't in TELEMETRY_LABELS, so this falls
+    // through to the raw type — guards against false label collisions.
+    expect(getTelemetryLabel('mc_lpp_136_ch1_latitude')).toBe('mc_lpp_136_ch1_latitude');
+  });
+
+  it('falls back to the raw type when no label is known', () => {
+    expect(getTelemetryLabel('totally_unknown_metric')).toBe('totally_unknown_metric');
+    expect(getTelemetryLabel('mc_lpp_9999_ch1')).toBe('mc_lpp_9999_ch1');
+  });
+});

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -99,10 +99,76 @@ const TELEMETRY_LABELS: Record<string, string> = {
   // MeshMonitor system metrics (calculated by MeshMonitor)
   systemNodeCount: 'Active Nodes (MeshMonitor)',
   systemDirectNodeCount: 'Direct Nodes (MeshMonitor)',
+  // ---------------------------------------------------------------------
+  // MeshCore — base names (without `_ch<N>` suffix). The label lookup
+  // below strips that suffix and re-appends the channel as "(ch<N>)" so
+  // we don't have to enumerate every type×channel combination here.
+  // ---------------------------------------------------------------------
+  // LPP types from meshcoreRemoteTelemetryScheduler.LPP_TYPE_NAMES
+  mc_analog_input: 'Analog Input',
+  mc_analog_output: 'Analog Output',
+  mc_illuminance: 'Illuminance',
+  mc_presence: 'Presence',
+  mc_temperature: 'Temperature',
+  mc_humidity: 'Humidity',
+  mc_barometer: 'Pressure',
+  mc_battery_volts: 'Battery',
+  mc_current: 'Current',
+  mc_frequency: 'Frequency',
+  mc_percentage: 'Battery %',
+  mc_altitude: 'Altitude',
+  mc_load: 'Load',
+  mc_concentration: 'Concentration',
+  mc_power: 'Power',
+  mc_distance: 'Distance',
+  mc_energy: 'Energy',
+  mc_time: 'Time',
+  // Status fields from meshcoreRemoteTelemetryScheduler.STATUS_FIELD_MAP
+  mc_status_battery_volts: 'Battery (status)',
+  mc_status_uptime_secs: 'Uptime',
+  mc_status_queue_len: 'Queue Length',
+  mc_status_noise_floor: 'Noise Floor',
+  mc_status_last_rssi: 'Last RSSI',
+  mc_status_last_snr: 'Last SNR',
+  mc_status_packets_recv: 'Packets Received',
+  mc_status_packets_sent: 'Packets Sent',
+  mc_status_air_time_secs: 'Air Time',
+  mc_status_sent_flood: 'Sent (Flood)',
+  mc_status_sent_direct: 'Sent (Direct)',
+  mc_status_recv_flood: 'Received (Flood)',
+  mc_status_recv_direct: 'Received (Direct)',
+  mc_status_errors: 'Errors',
+  mc_status_direct_dups: 'Duplicates (Direct)',
+  mc_status_flood_dups: 'Duplicates (Flood)',
 };
 
+// MeshCore LPP records embed the Cayenne channel byte in the telemetry
+// type as `_ch<N>` (see #3139). We label them by stripping the suffix,
+// looking up the base name, and re-appending "(ch<N>)". Multi-axis
+// LPP types (gps, accelerometer) have a further `_<axisKey>` suffix
+// that lands AFTER the channel byte; we strip and re-append that too.
+const MC_CHANNEL_SUFFIX_RE = /^(mc_[a-z_]+?)_ch(\d+)(_[a-z]+)?$/i;
+
 // Export for external use (returns English labels for sorting/filtering compatibility)
-const getTelemetryLabel = (type: string): string => TELEMETRY_LABELS[type] || type;
+const getTelemetryLabel = (type: string): string => {
+  // Fast path — exact match
+  if (TELEMETRY_LABELS[type]) return TELEMETRY_LABELS[type];
+
+  // MeshCore channel-suffixed types: e.g. mc_battery_volts_ch2 → "Battery (ch2)"
+  const m = type.match(MC_CHANNEL_SUFFIX_RE);
+  if (m) {
+    const base = TELEMETRY_LABELS[m[1]];
+    if (base) {
+      const channel = `ch${m[2]}`;
+      const axisSuffix = m[3]; // e.g. "_latitude" for gps
+      return axisSuffix
+        ? `${base} ${axisSuffix.slice(1)} (${channel})`
+        : `${base} (${channel})`;
+    }
+  }
+
+  return type;
+};
 
 const TELEMETRY_COLORS: Record<string, string> = {
   batteryLevel: '#82ca9d',


### PR DESCRIPTION
## Summary

Closes part 2 of #3139. Adds a destination for MeshCore favorited-telemetry charts. Until this PR, the favorite-star toggle was present in MeshCore views (DM contact panels) but no MeshCore-side surface read \`telemetryFavorites\` back — the user could star a chart but couldn't see it anywhere afterward.

## What changed

### 1. Dashboard becomes source-agnostic

New \`DashboardDataSource\` abstraction (\`src/components/Dashboard/dataSources.ts\`). Every Meshtastic-specific assumption inside the per-source \`Dashboard\` now goes through the adapter:

| Concern | Meshtastic adapter | MeshCore adapter |
|---|---|---|
| Nodes endpoint | \`/api/nodes\` | \`/api/sources/:id/meshcore/nodes\` |
| Node-key extraction | \`user.id\` | \`publicKey\` (via \`user.id\` after shape adaption) |
| Display name | \`user.longName \|\| user.shortName\` | same (adapter populates these from \`node.name\`) |
| Role label | \`getDeviceRoleName(role)\` | \`advType\` → "Companion" / "Repeater" / "Room Server" |
| Solar default-on types | Meshtastic-flavoured names | \`mc_battery_volts_ch1..ch4\`, env sensors |
| Custom widgets | shown | hidden — \`nodeStatus\` / \`traceroute\` / \`hopDistribution\` widgets all assume Meshtastic shapes |

Two adapters ship: \`meshtasticDashboardSource\` (default, exactly preserves prior behaviour) and \`meshcoreDashboardSource\`. The Dashboard component accepts the adapter as an optional prop with the Meshtastic default, so the existing \`App.tsx\` mount point at \`activeTab === 'dashboard'\` is **unchanged**.

### 2. New MeshCore Telemetry view

- New \`MeshCoreTelemetryView\` wrapper mounts \`<Dashboard dataSource={meshcoreDashboardSource} />\`.
- New \`'telemetry'\` entry on \`MeshCoreView\` and a 📊 Telemetry button on \`MeshCoreSubToolbar\` (between DMs and Node Info).
- \`MeshCorePage\` renders the new view when \`view === 'telemetry'\`.

### 3. \`mc_*\` labels in \`TELEMETRY_LABELS\`

Adds entries for every LPP type in \`LPP_TYPE_NAMES\` and every \`mc_status_*\` field in \`STATUS_FIELD_MAP\`. The label resolver also recognises the \`_ch<N>\` suffix from #3141 and renders e.g. \`mc_battery_volts_ch2\` as \`Battery (ch2)\` — so we don't need to enumerate every type×channel combination in the label table.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Full Vitest suite: **5411 / 5411 passing** (5395 before + 16 new tests in this PR)
- [x] New \`dataSources.test.ts\` covers MeshCore adapter shape mapping, role labels, key extraction, per-source defaults
- [x] New \`TelemetryChart.test.ts\` covers channel-suffix label resolution
- [ ] Manual: navigate into a MeshCore source → click 📊 Telemetry → verify favorited charts render and "Add Widget" button is hidden

## Notable design decisions

- **No data-shape forking inside Dashboard internals.** The MeshCore adapter normalises into the existing \`NodeInfo\` shape at fetch time, so hooks and grid don't have to know which source they're rendering for. Keeps the diff small (≈550 lines, mostly new files).
- **Custom widgets are gated, not duplicated.** Rather than build a separate \`MeshCoreDashboard\` component, the four Meshtastic-only widget kinds are hidden via \`showCustomWidgets: false\`. If/when MeshCore grows equivalent widgets, they add to the same flag-gated \`AddWidgetModal\` flow.
- **Favorites storage is global.** \`telemetryFavorites\` is shared across sources, keyed on \`(nodeId, telemetryType)\`. A user who'd already starred MeshCore charts (in DM contact panels) before this PR ships will see those favorites appear on the new tab automatically.

Builds on #3141 (LPP channel byte preservation), merged earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)