### PR TITLE
release(4.6.5): MQTT Bridge mirror dashboard + cross-source polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+
+## [4.6.5] - 2026-05-22
+
+# MeshMonitor v4.6.5
+
+Patch release adding a **read-only MQTT Bridge dashboard**, a MeshCore telemetry tab in the source-agnostic dashboard, and a handful of cross-source / unified-view fixes. MQTT Bridge sources now have their own "Open" button on the source list and render the full Meshtastic dashboard with every transmit surface suppressed — bridges ingest but never send, so send composers, DM action buttons, Device Configuration, Remote Administration, and Automation tabs are all hidden. Server-side, `MqttBridgeManager` now implements the Meshtastic-shaped methods the consolidated `/api/poll` and `/api/connection` endpoints call through `resolveSourceManager` — without those, the bridge dashboard 500'd before any data could render. Standalone `mqtt_bridge` sources are also now valid targets for the meshtastic_tcp client-proxy `mqttLink`.
+
+## Features
+- #3143 feat(mqtt-bridge): mirror dashboard for MQTT Bridge sources — adds an Open button to `mqtt_bridge` cards and routes to a read-only mirror of the Meshtastic dashboard. Suppresses every TX surface: send composers (Channels + DM), the four top DM action buttons (Traceroute / Exchange Node Info / Exchange Position / Request Neighbor Info), the matching DM Actions dropdown entries (Traceroute / Exchange / Request Telemetry / Scan for Admin), and the Device Config / Remote Admin / Automation sidebar tabs. The Channels picker also relaxes the per-channel permission filter for bridge mode since bridges routinely see channel slots outside `0-7` from upstream nodes with custom configs, and the "Show MQTT messages" toggle is hidden because every bridge packet has `viaMqtt=true` and the filter would always blank the list.
+- #3142 feat(meshcore): add Telemetry dashboard tab via source-agnostic Dashboard (#3139)
+- #3136 feat(mqtt): allow standalone mqtt_bridge as client-proxy target (#3134) — a `meshtastic_tcp` source's `mqttLink` configuration now accepts either an `mqtt_broker` or a standalone `mqtt_bridge` source as its parent.
+
 ## Fixes
-- #3135 fix(unified): merge nodes across sources so labels show in the unified Nodes view — since the composite-keyed `nodes` table holds one row per `(nodeNum, sourceId)`, a node heard on both an RF source (with NodeInfo) and an MQTT-bridged source (with only a transit packet, so `longName/shortName = null`) appeared in the unified view twice — once labeled, once as `Node <nodeNum>`. `getAllNodesAsync` now collapses per-source rows into one entry per `nodeNum` when no `sourceId` is supplied: the newest row by `lastHeard` wins, empty fields are back-filled from older rows, and `isFavorite`/`isIgnored`/`favoriteLocked` are OR'd across sources.
+- #3143 fix(mqtt-bridge): wire `MqttBridgeManager` into the consolidated poll path — adds `getConnectionStatus`, `getAllNodesAsync`, `getDeviceConfig`, `getDeviceNodeNums`, and `getSecurityKeys` so `/api/poll?sourceId=<bridge>` and `/api/connection?sourceId=<bridge>` stop throwing `TypeError: ... is not a function`. `mapDbNodeToDeviceInfo` and `loadAllNodesAsDeviceInfo` extracted to `src/server/utils/dbNodeMapper.ts` so both managers share the projection.
+- #3143 fix(mqtt-bridge): suppress env-default Meshtastic IP leaking into the AppHeader node-info slot when the bridge has no local device.
+- #3141 fix(meshcore): preserve LPP channel byte in remote telemetry rows (#3139)
+- #3140 fix(dm): skip PKI flag when `keyMismatchDetected` — firmware may lack the key after a purge, so flagging would mark legitimate sessions as compromised.
+- #3137 fix(unified): merge nodes across sources so labels show in the unified Nodes view (#3135) — since the composite-keyed `nodes` table holds one row per `(nodeNum, sourceId)`, a node heard on both an RF source (with NodeInfo) and an MQTT-bridged source (with only a transit packet, so `longName/shortName = null`) appeared in the unified view twice — once labeled, once as `Node <nodeNum>`. `getAllNodesAsync` now collapses per-source rows into one entry per `nodeNum` when no `sourceId` is supplied: the newest row by `lastHeard` wins, empty fields are back-filled from older rows, and `isFavorite`/`isIgnored`/`favoriteLocked` are OR'd across sources.
+
+## Docs
+- #3138 docs: reorganize site for easier discovery; remove dead links
 
 
 ## [4.6.3] - 2026-05-20

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # MeshMonitor — Claude Agent Brief
 
-**Version:** 4.6.3 (multi-source architecture)
+**Version:** 4.6.5 (multi-source architecture)
 **Stack:** React 19 + TS + Vite frontend / Node.js 20+ (Docker image ships Node 24; CI matrix covers 20/22/24/25) + Express 5 + TS backend / SQLite (default), PostgreSQL, MySQL via Drizzle ORM / Meshtastic protobuf-over-TCP and MeshCore (native `meshcore.js` for companion, serial CLI for repeater) through a per-source manager registry.
 
 ## Read order for new agents

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.6.4",
+  "version": "4.6.5",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.6.4",
+  "version": "4.6.5",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.6.4
-appVersion: "4.6.4"
+version: 4.6.5
+appVersion: "4.6.5"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.4",
+  "version": "4.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.6.4",
+      "version": "4.6.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.4",
+  "version": "4.6.5",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Version bump to **4.6.5** and CHANGELOG entry covering the seven PRs merged since `v4.6.4`.

Bumped files: `package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json` (per the CLAUDE.md release recipe). `CLAUDE.md` version line refreshed.

## Included PRs (since v4.6.4)

- #3143 feat(mqtt-bridge): mirror dashboard for MQTT Bridge sources
- #3142 feat(meshcore): add Telemetry dashboard tab via source-agnostic Dashboard
- #3141 fix(meshcore): preserve LPP channel byte in remote telemetry rows
- #3140 fix(dm): skip PKI flag when `keyMismatchDetected`
- #3138 docs: reorganize site for easier discovery; remove dead links
- #3137 fix(unified): merge nodes across sources so labels show in unified view
- #3136 feat(mqtt): allow standalone mqtt_bridge as client-proxy target

## Doc review

- `README.md` — multi-protocol description and MQTT broker/bridge mentions are still accurate; no version-specific copy to update.
- `CLAUDE.md` — version line bumped to 4.6.5; migration count (63) still current.
- `ARCHITECTURE.md` — no version- or MQTT-bridge-specific copy; left untouched.
- `RELEASE_NOTES.md` — historical 3.0.1 file, not maintained per-release; left untouched.
- `docs/features/multi-source.md` — already references `mqtt_bridge` accurately.
- `CHANGELOG.md` — new 4.6.5 entry with full Features / Fixes / Docs breakdown for all seven PRs; old "Unreleased" `#3135` item rolled into 4.6.5; an empty "Unreleased" stays for the next cycle.

## Test plan

- [ ] `system-test` label set on this PR so the hardware system-test workflow runs alongside normal CI.
- [ ] All standard CI checks (lint, Vitest, build, type-check) green.
- [ ] Once green, tag `v4.6.5` and publish a GitHub release using the CHANGELOG section as the release body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)