### PR TITLE
fix: Show UDP/RF filters now hide neighbor-info lines (closes #3147)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,7 @@ import { getPacketStats } from './services/packetApi';
 import { logger } from './utils/logger';
 // generateArrowMarkers moved to useTraceroutePaths hook
 import { isNodeComplete, getEffectivePosition } from './utils/nodeHelpers';
+import { nodePassesTransportFilter } from './utils/nodeTransport';
 import { applyHomoglyphOptimization } from './utils/homoglyph';
 import Sidebar from './components/Sidebar';
 import { SearchModal } from './components/SearchModal/SearchModal.js';
@@ -344,6 +345,8 @@ function App() {
     showPaths,
     showRoute,
     showMqttNodes,
+    showUdpNodes,
+    showRfNodes,
     showEstimatedPositions,
     setMapCenterTarget,
     traceroutes,
@@ -4454,24 +4457,19 @@ function App() {
     [setSelectedNodeId, setMapCenterTarget]
   );
 
-  // Compute visible node numbers for traceroute path filtering
-  // This ensures route segments are hidden when their connected nodes are filtered out (Issue #1102)
+  // Compute visible node numbers for neighbor-info line and traceroute path filtering.
+  // Must mirror the per-marker filter in NodesTab so that lines are hidden whenever
+  // their endpoint nodes are hidden (Issues #1102, #3147).
   const visibleNodeNums = useMemo(() => {
-    // Start with processedNodes which already has age, text, and advanced filters applied
-    // Then apply the same map-specific filters used in NodesTab for rendering markers
     const visibleNodes = processedNodes.filter(node => {
-      // Must have position to be visible on map
       if (!node.position?.latitude || !node.position?.longitude) return false;
-      // Apply MQTT filter
-      if (!showMqttNodes && node.viaMqtt) return false;
-      // Apply incomplete nodes filter
+      if (!nodePassesTransportFilter(node, { showRfNodes, showUdpNodes, showMqttNodes })) return false;
       if (!showIncompleteNodes && !isNodeComplete(node)) return false;
-      // Apply estimated positions filter
       if (!showEstimatedPositions && node.user?.id && nodesWithEstimatedPosition.has(node.user.id)) return false;
       return true;
     });
     return new Set(visibleNodes.map(n => n.nodeNum));
-  }, [processedNodes, showMqttNodes, showIncompleteNodes, showEstimatedPositions, nodesWithEstimatedPosition]);
+  }, [processedNodes, showRfNodes, showUdpNodes, showMqttNodes, showIncompleteNodes, showEstimatedPositions, nodesWithEstimatedPosition]);
 
   const { traceroutePathsElements, selectedNodeTraceroute, tracerouteNodeNums, tracerouteBounds } = useTraceroutePaths({
     showPaths,


### PR DESCRIPTION
## Summary

- **Root cause:** `visibleNodeNums` in `App.tsx` — the set used to suppress neighbor-info connection lines when a node is hidden — only applied the MQTT filter (via the legacy `node.viaMqtt` boolean). The RF and UDP filters were absent, so unchecking "Show UDP" hid node markers correctly but left their connection lines visible.
- **Fix:** Replace the partial MQTT-only check with `nodePassesTransportFilter` (the same helper already used by the marker renderer in `NodesTab`), add `showRfNodes` / `showUdpNodes` to the `useMapContext()` destructuring in `App.tsx`, and add both to the `useMemo` dependency array so the set updates reactively.

**Changed file:** `src/App.tsx` — 8 insertions, 10 deletions.

## Test plan

- [ ] Start MeshMonitor with a source that has a mix of RF, UDP-bridged, and MQTT-bridged nodes visible on the map with neighbor-info lines enabled.
- [ ] Uncheck **Show UDP** → UDP node markers AND their neighbor-info connection lines should disappear.
- [ ] Re-check **Show UDP** → nodes and lines return.
- [ ] Repeat for **Show MQTT** and **Show RF** to confirm no regression.
- [ ] Confirm traceroute path segments also respect the filter (they share the same `visibleNodeNums` set).

https://claude.ai/code/session_01DyRSp5mPeD4qyG2gNoiS3o

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyRSp5mPeD4qyG2gNoiS3o)_