### PR TITLE
docs(blog): full-width index + post header (breadcrumbs, title, date, tags)

### DIFF
--- a/docs/.vitepress/theme/BlogPostHeader.vue
+++ b/docs/.vitepress/theme/BlogPostHeader.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useData } from 'vitepress'
+
+const { frontmatter, page, site } = useData()
+
+const isBlogPost = computed(() => {
+  const rel = page.value.relativePath || ''
+  if (!rel.startsWith('blog/')) return false
+  if (rel === 'blog/index.md' || rel === 'blog/') return false
+  return true
+})
+
+const title = computed(() => frontmatter.value.title || '')
+
+const formattedDate = computed(() => {
+  const raw = frontmatter.value.date
+  if (!raw) return ''
+  const d = new Date(raw)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+})
+
+const isoDate = computed(() => {
+  const raw = frontmatter.value.date
+  if (!raw) return ''
+  const d = new Date(raw)
+  return Number.isNaN(d.getTime()) ? '' : d.toISOString()
+})
+
+const category = computed(() => frontmatter.value.category as string | undefined)
+const priority = computed(() => {
+  const p = frontmatter.value.priority as string | undefined
+  return p && p !== 'normal' ? p : undefined
+})
+
+const tags = computed<string[]>(() => {
+  const t = frontmatter.value.tags
+  if (Array.isArray(t)) return t.filter(Boolean).map(String)
+  if (typeof t === 'string' && t.trim()) {
+    return t.split(',').map((s) => s.trim()).filter(Boolean)
+  }
+  return []
+})
+
+const base = computed(() => site.value.base || '/')
+
+const blogHref = computed(() => `${base.value}blog/`.replace(/\/+/g, '/'))
+const homeHref = computed(() => base.value)
+</script>
+
+<template>
+  <div v-if="isBlogPost" class="blog-post-header">
+    <nav class="blog-breadcrumbs" aria-label="Breadcrumb">
+      <a :href="homeHref">Home</a>
+      <span class="sep" aria-hidden="true">›</span>
+      <a :href="blogHref">Blog</a>
+      <span class="sep" aria-hidden="true">›</span>
+      <span class="current" :title="title">{{ title }}</span>
+    </nav>
+
+    <h1 v-if="title" class="blog-post-title">{{ title }}</h1>
+
+    <div class="blog-post-meta">
+      <time v-if="formattedDate" :datetime="isoDate">{{ formattedDate }}</time>
+
+      <span v-if="category" :class="['badge', 'badge-' + category]">{{ category }}</span>
+      <span
+        v-if="priority"
+        :class="['badge', 'badge-priority-' + priority]"
+      >{{ priority }}</span>
+
+      <span
+        v-for="tag in tags"
+        :key="tag"
+        class="badge badge-tag"
+      >{{ tag }}</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.blog-post-header {
+  margin: 0 0 1.75rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.blog-breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--vp-c-text-2);
+  margin-bottom: 0.85rem;
+}
+.blog-breadcrumbs a {
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+.blog-breadcrumbs a:hover {
+  color: var(--vp-c-brand-1);
+  text-decoration: underline;
+}
+.blog-breadcrumbs .sep {
+  color: var(--vp-c-text-3);
+}
+.blog-breadcrumbs .current {
+  color: var(--vp-c-text-1);
+  font-weight: 500;
+  max-width: 32ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.blog-post-title {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.6rem, 2.4vw, 2.25rem);
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--vp-c-text-1);
+  border-bottom: none;
+  padding: 0;
+}
+
+.blog-post-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.85rem;
+  color: var(--vp-c-text-2);
+}
+
+.blog-post-meta time {
+  font-variant-numeric: tabular-nums;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.1rem 0.55rem;
+  border-radius: 0.3rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  background: var(--vp-c-default-soft);
+  color: var(--vp-c-text-1);
+  line-height: 1.4;
+}
+.badge-security { background: var(--vp-c-danger-soft); color: var(--vp-c-danger-1); }
+.badge-release { background: var(--vp-c-brand-soft); color: var(--vp-c-brand-1); }
+.badge-feature { background: var(--vp-c-tip-soft); color: var(--vp-c-tip-1); }
+.badge-maintenance,
+.badge-bugfix { background: var(--vp-c-warning-soft); color: var(--vp-c-warning-1); }
+.badge-guide { background: var(--vp-c-purple-soft); color: var(--vp-c-purple-1); }
+.badge-priority-critical { background: var(--vp-c-danger-soft); color: var(--vp-c-danger-1); }
+.badge-priority-important { background: var(--vp-c-warning-soft); color: var(--vp-c-warning-1); }
+.badge-tag {
+  text-transform: none;
+  letter-spacing: 0;
+  background: var(--vp-c-default-soft);
+  color: var(--vp-c-text-2);
+  font-weight: 500;
+}
+</style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,24 @@
+/* Blog index: full-width 3-tile layout.
+   VitePress default doc styles use scoped attribute selectors ([data-v-…]) on
+   .VPDoc/.content/.content-container which outrank plain class selectors, so
+   !important is required for these overrides. */
+.blog-index-page .VPDoc .container {
+  max-width: var(--vp-layout-max-width, 1440px) !important;
+}
+
+.blog-index-page .VPDoc .content {
+  max-width: none !important;
+  padding-left: 32px !important;
+  padding-right: 32px !important;
+}
+
+.blog-index-page .VPDoc .content-container {
+  max-width: none !important;
+}
+
+@media (max-width: 768px) {
+  .blog-index-page .VPDoc .content {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -4,6 +4,8 @@ import StarUs from './StarUs.vue'
 import DockerComposeConfigurator from './DockerComposeConfigurator.vue'
 import UserScriptsGallery from './UserScriptsGallery.vue'
 import HeroCarousel from './HeroCarousel.vue'
+import BlogPostHeader from './BlogPostHeader.vue'
+import './custom.css'
 
 export default {
   extends: DefaultTheme,
@@ -11,6 +13,7 @@ export default {
     return h(DefaultTheme.Layout, null, {
       'nav-bar-content-after': () => h(StarUs),
       'home-hero-image': () => h(HeroCarousel),
+      'doc-before': () => h(BlogPostHeader),
     })
   },
   enhanceApp({ app }) {

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,6 +1,7 @@
 ---
 title: Blog
 aside: false
+pageClass: blog-index-page
 ---
 
 # Blog

--- a/docs/blog/posts.data.ts
+++ b/docs/blog/posts.data.ts
@@ -8,6 +8,18 @@ export interface BlogPost {
   priority?: string;
   minVersion?: string;
   excerpt?: string;
+  tags?: string[];
+}
+
+function normalizeTags(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    const out = value.filter(Boolean).map((v) => String(v));
+    return out.length ? out : undefined;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return value.split(',').map((s) => s.trim()).filter(Boolean);
+  }
+  return undefined;
 }
 
 declare const data: BlogPost[];
@@ -59,6 +71,7 @@ export default createContentLoader('blog/*.md', {
         priority: page.frontmatter.priority,
         minVersion: page.frontmatter.minVersion,
         excerpt: makeExcerpt(page.src ?? ''),
+        tags: normalizeTags(page.frontmatter.tags),
       }))
       .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
   },


### PR DESCRIPTION
## Summary

- **Blog index full-width** — adds `pageClass: blog-index-page` to `docs/blog/index.md` and a theme-level CSS override so the 3-tile featured grid spans up to `--vp-layout-max-width` (~1440px) with 32px side padding, instead of being squeezed into the 688px doc-content default.
- **Individual post header** — new `BlogPostHeader.vue` is injected via VitePress's `doc-before` slot. On blog posts it renders:
  - breadcrumb nav: **Home › Blog › Title**
  - frontmatter title as an `h1`
  - formatted publish date (`<time datetime="…">`)
  - badges for `category`, non-normal `priority`, and an optional `tags` array
  - The component self-gates: `useData().page.relativePath` must start with `blog/` and not be the index — so non-blog doc pages and the blog index are unaffected.
- **Optional tags field** — `posts.data.ts` now surfaces an optional `tags: string[]` from frontmatter (accepts an array or a comma-separated string), available to both the post header and the card grid for future use. No existing posts have tags, so behavior is unchanged for them.

## Files

| File | Change |
|---|---|
| `docs/.vitepress/theme/BlogPostHeader.vue` | new — header component |
| `docs/.vitepress/theme/custom.css` | new — full-width override for `.blog-index-page` |
| `docs/.vitepress/theme/index.ts` | wires `doc-before` slot, imports `custom.css` |
| `docs/blog/index.md` | adds `pageClass: blog-index-page` to frontmatter |
| `docs/blog/posts.data.ts` | exposes optional `tags` field |

The CSS overrides use `!important` because VitePress's default doc styles use scoped `[data-v-…]` attribute selectors that outrank plain class selectors — the inline comment in `custom.css` documents this.

## Test plan

- [x] `npm run docs:build` succeeds
- [x] Rendered `dist/blog/index.html` has `class="Layout blog-index-page"` on the layout root
- [x] Rendered `dist/blog/2026-01-27-v3-3-0.html` contains `blog-post-header`, breadcrumb nav, title, and meta block
- [x] Rendered `dist/blog/index.html` does **not** contain `blog-post-header`
- [x] Rendered `dist/getting-started.html` (non-blog doc page) does **not** contain `blog-post-header`
- [x] Verified visually in `vitepress dev` that the 3-tile grid spans the full layout width
- [ ] Visual review on Netlify/CI preview if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)