### PR TITLE
fix(admin): Router role no longer reverts when selected in Remote Admin

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3637,6 +3637,8 @@
   "admin_commands.please_select_node_to_ignore": "Please select a node to ignore",
   "admin_commands.please_select_node_to_unignore": "Please select a node to un-ignore",
   "admin_commands.router_mode_confirmation": "Setting device to ROUTER mode will make it always rebroadcast packets. This is typically used for infrastructure nodes. Continue?",
+  "admin_commands.router_mode_warning_title": "Router mode",
+  "admin_commands.router_mode_warning": "This device will always rebroadcast packets. Reserve Router for infrastructure nodes with stable power and good antenna placement; setting this on a typical client adds noise to the mesh.",
   "admin_commands.channel_name_max_length": "Channel name must be 11 characters or less",
   "admin_commands.channel_name": "Channel Name",
   "admin_commands.channel_name_description": "Up to 11 characters",

--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -1896,13 +1896,6 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
   };
 
   const handleRoleChange = (newRole: number) => {
-    if (newRole === 2) {
-      const confirmed = window.confirm(t('admin_commands.router_mode_confirmation'));
-      if (!confirmed) {
-        setIsRoleDropdownOpen(false);
-        return;
-      }
-    }
     setDeviceConfig({ role: newRole });
     setIsRoleDropdownOpen(false);
   };

--- a/src/components/admin-commands/DeviceConfigurationSection.tsx
+++ b/src/components/admin-commands/DeviceConfigurationSection.tsx
@@ -359,6 +359,37 @@ export const DeviceConfigurationSection: React.FC<DeviceConfigurationSectionProp
               </div>
             )}
           </div>
+          {deviceRole === 2 && (
+            <div
+              role="alert"
+              className="router-role-warning"
+              style={{
+                marginTop: '0.75rem',
+                padding: '0.75rem 1rem',
+                background: 'var(--ctp-yellow-soft, rgba(249, 226, 175, 0.15))',
+                border: '1px solid var(--ctp-yellow, #f9e2af)',
+                borderLeft: '4px solid var(--ctp-yellow, #f9e2af)',
+                borderRadius: '6px',
+                color: 'var(--ctp-text)',
+                fontSize: '0.9em',
+                lineHeight: '1.5',
+                display: 'flex',
+                gap: '0.6rem',
+                alignItems: 'flex-start',
+                maxWidth: '800px',
+              }}
+            >
+              <span aria-hidden="true" style={{ fontSize: '1.1em', flexShrink: 0 }}>⚠️</span>
+              <span>
+                <strong>{t('admin_commands.router_mode_warning_title', 'Router mode')}</strong>
+                {' — '}
+                {t(
+                  'admin_commands.router_mode_warning',
+                  'This device will always rebroadcast packets. Reserve Router for infrastructure nodes with stable power and good antenna placement; setting this on a typical client adds noise to the mesh.'
+                )}
+              </span>
+            </div>
+          )}
         </div>
         <div className="setting-item">
           <label>


### PR DESCRIPTION
## Summary

User report: in the Remote Admin → Device Configuration role dropdown, every attempt to pick **Router** would immediately revert to the previous selection. Other roles (Sensor, Tracker, etc.) saved fine.

## Root cause

`src/components/AdminCommandsTab.tsx` `handleRoleChange` had a special branch for `newRole === 2` (ROUTER) that popped a native `window.confirm()` before applying the change:

```ts
if (newRole === 2) {
  const confirmed = window.confirm(t('admin_commands.router_mode_confirmation'));
  if (!confirmed) {
    setIsRoleDropdownOpen(false);
    return;   // <-- role never committed
  }
}
setDeviceConfig({ role: newRole });
```

If the user dismissed the dialog (Cancel, Escape, or accidental click — easy to do because the native modal feels disconnected from the custom in-page dropdown UX) the role state was never updated and the dropdown snapped back to the previous value. ROUTER is the only role with this gate, which is why Sensor/Tracker/etc. appeared to "work fine."

## Fix

Replace the modal gate with a persistent inline warning banner:

- **`AdminCommandsTab.tsx`** — drop the `window.confirm()` branch. `handleRoleChange` now always commits immediately, like every other role.
- **`DeviceConfigurationSection.tsx`** — render a yellow warning banner directly under the role display whenever `deviceRole === 2`. It includes a ⚠️ icon and explains the routing implications. The banner stays visible until the user picks a different role, so the warning is reviewable before pressing "Save Device Config" (which is when the change actually goes to the node).
- **`public/locales/en.json`** — new keys `admin_commands.router_mode_warning_title` and `admin_commands.router_mode_warning`. The old `router_mode_confirmation` key is left in place (unused) so non-English locale files aren't broken until translators update.

## Why this UX is better

- Selection ≠ commit: the rest of the form treats dropdown selection as staging local state; the actual write happens on Save. The old confirm violated that pattern.
- Persistent warning is more discoverable than a one-shot dialog — a user re-opening the page can still see why Router is unusual.
- Removes the dependency on a native dialog that some users were dismissing without realizing the role would silently drop.

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Manually verify in dev container: pick Router → dropdown shows Router → warning banner appears below → press Save → device config sent to node
- [ ] Pick Sensor (or any non-Router role) → no banner appears, behaves as before
- [ ] Toggle back from Router to Client → banner disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)