### PR TITLE
fix(upgrade): clear stale auto-upgrade banner after successful upgrade

### DIFF
--- a/src/server/services/upgradeService.test.ts
+++ b/src/server/services/upgradeService.test.ts
@@ -89,6 +89,58 @@ describe('upgradeService circuit breaker', () => {
     expect(state.reason).toBe('pinned image');
   });
 
+  it('auto-heals stale block flag when most recent upgrade is complete', async () => {
+    // Regression: production users reported the "auto-upgrade halted" red
+    // banner persisting after a successful auto-upgrade. The persisted
+    // `autoUpgradeBlocked` setting is supposed to be cleared by
+    // markCompleteAndClear() during the watchdog status sync, but that path
+    // can be skipped (e.g. no frontend session was open to poll
+    // /api/upgrade/status after the container restarted). Treat the persisted
+    // flag as a cache: if the most recent upgrade row is 'complete', the
+    // failure streak is over and the flag must clear on next status read.
+    settingsStore.set('autoUpgradeBlocked', 'true');
+    settingsStore.set('autoUpgradeBlockedReason', 'old failures');
+    mockDb.miscRepo.getLastUpgrade.mockResolvedValue({
+      id: 'abc',
+      status: 'complete',
+    });
+
+    const state = await upgradeService.getAutoUpgradeBlock();
+
+    expect(state.blocked).toBe(false);
+    expect(state.reason).toBeNull();
+    // The flag must be cleared in the store (durable), not just masked in
+    // this response — otherwise the next read would re-trigger the heal.
+    expect(settingsStore.get('autoUpgradeBlocked')).toBe('false');
+    expect(settingsStore.get('autoUpgradeBlockedReason')).toBe('');
+  });
+
+  it('does NOT auto-heal when most recent upgrade is failed', async () => {
+    settingsStore.set('autoUpgradeBlocked', 'true');
+    settingsStore.set('autoUpgradeBlockedReason', 'pinned image');
+    mockDb.miscRepo.getLastUpgrade.mockResolvedValue({
+      id: 'def',
+      status: 'failed',
+    });
+
+    const state = await upgradeService.getAutoUpgradeBlock();
+
+    expect(state.blocked).toBe(true);
+    expect(state.reason).toBe('pinned image');
+    expect(settingsStore.get('autoUpgradeBlocked')).toBe('true');
+  });
+
+  it('does NOT auto-heal when upgrade history is empty', async () => {
+    // Defensive: a manually-set flag with no upgrade history at all must
+    // not be cleared. (getLastUpgrade returns null by default.)
+    settingsStore.set('autoUpgradeBlocked', 'true');
+
+    const state = await upgradeService.getAutoUpgradeBlock();
+
+    expect(state.blocked).toBe(true);
+    expect(settingsStore.get('autoUpgradeBlocked')).toBe('true');
+  });
+
   it('clearAutoUpgradeBlock unsets persisted block', async () => {
     settingsStore.set('autoUpgradeBlocked', 'true');
     settingsStore.set('autoUpgradeBlockedReason', 'something');

--- a/src/server/services/upgradeService.ts
+++ b/src/server/services/upgradeService.ts
@@ -612,6 +612,28 @@ class UpgradeService {
     } catch (error) {
       logger.warn('Failed to read auto-upgrade block state:', error);
     }
+
+    // Auto-heal a stale persisted flag. If the breaker tripped on a previous
+    // run but the most recent upgrade completed successfully, the failure
+    // streak is over — clear the flag so the UI banner doesn't linger after a
+    // successful auto-upgrade where the explicit clear path
+    // (markCompleteAndClear) was missed (e.g. container restarted before the
+    // watchdog status sync had a chance to run).
+    if (blocked && databaseService.miscRepo) {
+      try {
+        const lastUpgrade = await databaseService.miscRepo.getLastUpgrade();
+        if (lastUpgrade?.status === 'complete') {
+          await this.clearAutoUpgradeBlock(
+            'Auto-cleared: most recent upgrade completed successfully'
+          );
+          blocked = false;
+          reason = null;
+        }
+      } catch (error) {
+        logger.warn('Failed to evaluate auto-upgrade block auto-heal:', error);
+      }
+    }
+
     return { blocked, reason, consecutiveFailures, threshold: AUTO_UPGRADE_FAILURE_THRESHOLD };
   }
 


### PR DESCRIPTION
## Symptom

User report: after a successful auto-update, the UI still shows the red "auto-upgrade halted after repeated failures — Acknowledge" banner. Auto-updates themselves are working normally; the banner just lingers indefinitely.

## Root cause

The auto-upgrade circuit breaker uses **two** pieces of state:

- `autoUpgradeBlocked` setting (persisted boolean) — drives the UI banner and the scheduled-trigger refusal in `triggerUpgrade()`.
- `countConsecutiveFailedUpgrades()` (live count from `upgrade_history`) — what actually trips the flag.

On a successful upgrade the flag is supposed to clear via `markCompleteAndClear()`. That function is only called from inside `getUpgradeStatus(id)` / `getActiveUpgrade()` — both of which sync from the watchdog status file. **Neither runs unless someone (the frontend, typically) calls `/api/upgrade/status` while there's still an in-progress DB row to find.**

On an unattended scheduled auto-upgrade, the failure mode is:
1. Old container writes the upgrade row, kicks the watchdog, exits.
2. New container boots. DB row still says `'restarting'`. Watchdog file says `'complete'`.
3. If no frontend session polls `/api/upgrade/status` in the window where `findActiveUpgrade()` would find the row, no sync happens.
4. Eventually a manual reconciliation (or `isUpgradeInProgress()`'s stale-cleanup) marks the row terminal — but neither calls `markCompleteAndClear`.
5. `autoUpgradeBlocked` setting stays `'true'` from whenever the breaker last tripped. Banner persists.

The frontend `useAutoUpgrade` hook only calls `/api/upgrade/status` once on mount, so reopening the page after the restart often misses the window.

## Fix

`src/server/services/upgradeService.ts` `getAutoUpgradeBlock()` now treats the persisted flag as a cache. After reading it, if it's `true` and the most recent upgrade row is `'complete'`, the flag is durably cleared via the existing `clearAutoUpgradeBlock()` path. The next time the frontend polls `/api/upgrade/status` (which it does on mount), the banner disappears.

**Scheduler safety:** when the most recent upgrade is `'failed'` (the case the breaker actually exists for), the flag stays and `triggerUpgrade()` still refuses scheduled retries. Verified by both new and existing tests.

**Empty-history safety:** `getLastUpgrade()` returns `null` when no upgrades have run yet → no auto-heal. A flag set without any history (e.g. by a future migration or manual seed) is preserved.

## Tests

`src/server/services/upgradeService.test.ts` (full suite: 19 tests, all green; project suite: 10,379 / 0 fail):

- ✅ auto-heals stale block flag when most recent upgrade is complete — and verifies the flag is cleared in the persistent store, not just masked in the response
- ✅ does NOT auto-heal when most recent upgrade is failed
- ✅ does NOT auto-heal when upgrade history is empty
- ✅ all previously-existing circuit-breaker tests still pass unchanged

## Test plan

- [x] `npx vitest run src/server/services/upgradeService.test.ts` — 19 PASS / 0 FAIL
- [x] Full `npx vitest run` — 10379 PASS / 0 FAIL
- [x] `npx tsc --noEmit` — clean
- [ ] Verify on user's production instance: after deploy, the red banner should disappear on next page load (assuming a successful upgrade is in history). If the breaker genuinely needs to be tripped (real failure streak), it will re-trip on the next failed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)