### PR TITLE
chore: bump version to 4.6.6

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.6.5",
+  "version": "4.6.6",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.6.5",
+  "version": "4.6.6",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.6.5
-appVersion: "4.6.5"
+version: 4.6.6
+appVersion: "4.6.6"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.5",
+  "version": "4.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.6.5",
+      "version": "4.6.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.5",
+  "version": "4.6.6",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Patch bump covering recent fixes since 4.6.5:

- **#3153** — Router role no longer reverts on selection in Remote Admin
- **#3155** — Auto-upgrade banner no longer persists after successful upgrade
- **#3152** — Blog index goes full-width; individual posts get breadcrumbs / title / date / tags header

## Files updated

All five version-tracking files per CLAUDE.md:

- `package.json`
- `package-lock.json` (regenerated via `npm install --package-lock-only --legacy-peer-deps`)
- `helm/meshmonitor/Chart.yaml` (both `version` and `appVersion`)
- `desktop/src-tauri/tauri.conf.json`
- `desktop/package.json`

## Test plan

- [x] All five files show `4.6.6`
- [x] Lockfile root and self-name entry both updated
- [ ] CI passes
- [ ] Run `/create-release` after merge if a tagged release is desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)