### PR TITLE
fix(meshcore): filter 0x00 padding bytes from out_path display

### DIFF
--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -939,6 +939,25 @@ describe('formatOutPath', () => {
     buf[0] = 0xa3; buf[1] = 0x7f; buf[2] = 0x02; buf[3] = 0x10;
     expect(formatOutPath(buf, 3)).toEqual({ outPathHex: 'a3,7f,02', pathLen: 3 });
   });
+
+  it('filters out 0x00 padding bytes and reports the real hop count (issue #3149)', () => {
+    // Firmware sometimes reports outPathLen=64 with only a couple of real hops
+    // and the rest of the buffer zero-padded. The displayed path should only
+    // contain the real hops.
+    const buf = new Uint8Array(64);
+    buf[0] = 0xad; buf[1] = 0xb0;
+    expect(formatOutPath(buf, 64)).toEqual({ outPathHex: 'ad,b0', pathLen: 2 });
+  });
+
+  it('strips interior 0x00 bytes from the hex chain', () => {
+    const buf = new Uint8Array(64);
+    buf[0] = 0xa3; buf[1] = 0x00; buf[2] = 0x7f; buf[3] = 0x00; buf[4] = 0x02;
+    expect(formatOutPath(buf, 5)).toEqual({ outPathHex: 'a3,7f,02', pathLen: 3 });
+  });
+
+  it('returns empty string when every reported byte is 0x00 padding', () => {
+    expect(formatOutPath(new Uint8Array(64), 8)).toEqual({ outPathHex: '', pathLen: 0 });
+  });
 });
 
 // ---------------- Heartbeat tests (manager-level, also using the mock) ----------------

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -958,6 +958,38 @@ describe('formatOutPath', () => {
   it('returns empty string when every reported byte is 0x00 padding', () => {
     expect(formatOutPath(new Uint8Array(64), 8)).toEqual({ outPathHex: '', pathLen: 0 });
   });
+
+  it('groups bytes into 2-byte hops when hopHashBytes=2', () => {
+    const buf = new Uint8Array(64);
+    buf[0] = 0xad; buf[1] = 0xb0; buf[2] = 0x12; buf[3] = 0x34;
+    expect(formatOutPath(buf, 4, 2)).toEqual({ outPathHex: 'adb0,1234', pathLen: 2 });
+  });
+
+  it('groups bytes into 3-byte hops when hopHashBytes=3', () => {
+    const buf = new Uint8Array(64);
+    buf[0] = 0xad; buf[1] = 0xb0; buf[2] = 0x12; buf[3] = 0x34; buf[4] = 0x56; buf[5] = 0x78;
+    expect(formatOutPath(buf, 6, 3)).toEqual({ outPathHex: 'adb012,345678', pathLen: 2 });
+  });
+
+  it('skips entirely-zero hop chunks at 2-byte width', () => {
+    const buf = new Uint8Array(64);
+    // Real hop at offset 0; zero-padded slot at offset 2; real hop at offset 4.
+    buf[0] = 0xad; buf[1] = 0xb0; buf[4] = 0x12; buf[5] = 0x34;
+    expect(formatOutPath(buf, 6, 2)).toEqual({ outPathHex: 'adb0,1234', pathLen: 2 });
+  });
+
+  it('preserves interior 0x00 bytes inside a wider hop chunk', () => {
+    // 2-byte hop "ad00" is NOT all-zero — must be kept, not stripped.
+    const buf = new Uint8Array(64);
+    buf[0] = 0xad; buf[1] = 0x00; buf[2] = 0x00; buf[3] = 0xb0;
+    expect(formatOutPath(buf, 4, 2)).toEqual({ outPathHex: 'ad00,00b0', pathLen: 2 });
+  });
+
+  it('discards a trailing partial hop that does not fit hopHashBytes', () => {
+    const buf = new Uint8Array(64);
+    buf[0] = 0xad; buf[1] = 0xb0; buf[2] = 0x12;  // 3 bytes, but hop width is 2
+    expect(formatOutPath(buf, 3, 2)).toEqual({ outPathHex: 'adb0', pathLen: 1 });
+  });
 });
 
 // ---------------- Heartbeat tests (manager-level, also using the mock) ----------------

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -94,7 +94,9 @@ function bytesToHex(bytes: Uint8Array | number[]): string {
  * sentinel (0xFF — or -1 if meshcore.js read it as Int8) is set.
  *
  * The wire-format `out_path` field is always a 64-byte buffer; only the
- * first `outPathLen` bytes are meaningful hop hashes.
+ * first `outPathLen` bytes are meaningful hop hashes. Some firmwares report
+ * an inflated `outPathLen` (e.g. the full 64) with trailing 0x00 padding;
+ * 0x00 bytes are filtered out and `pathLen` reflects only real hops.
  */
 export function formatOutPath(
   outPath: Uint8Array | number[] | null | undefined,
@@ -118,9 +120,10 @@ export function formatOutPath(
   const take = Math.min(outPathLen, arr.length);
   const parts: string[] = [];
   for (let i = 0; i < take; i++) {
+    if (arr[i] === 0) continue;
     parts.push(arr[i].toString(16).padStart(2, '0'));
   }
-  return { outPathHex: parts.join(','), pathLen: take };
+  return { outPathHex: parts.join(','), pathLen: parts.length };
 }
 
 /** Manager passes telemetry mode as 'never' | 'device' | 'always'; firmware

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -90,17 +90,25 @@ function bytesToHex(bytes: Uint8Array | number[]): string {
 
 /**
  * Render a MeshCore contact's `out_path` blob into a comma-separated hex
- * chain like "a3,7f,02". Returns null when the firmware's OUT_PATH_UNKNOWN
- * sentinel (0xFF — or -1 if meshcore.js read it as Int8) is set.
+ * chain like "a3,7f,02" (1-byte hashes) or "a37f,02b0" (2-byte hashes).
+ * Returns null when the firmware's OUT_PATH_UNKNOWN sentinel (0xFF — or -1
+ * if meshcore.js read it as Int8) is set.
  *
  * The wire-format `out_path` field is always a 64-byte buffer; only the
- * first `outPathLen` bytes are meaningful hop hashes. Some firmwares report
+ * first `outPathLen` bytes are meaningful. Each hop occupies `hopHashBytes`
+ * bytes (default 1, MeshCore protocol supports 1/2/3). Some firmwares report
  * an inflated `outPathLen` (e.g. the full 64) with trailing 0x00 padding;
- * 0x00 bytes are filtered out and `pathLen` reflects only real hops.
+ * all-zero hop chunks are skipped and `pathLen` reflects only real hops.
+ *
+ * Note: MeshCore OTA packets pack hop hash width into the top 2 bits of the
+ * single `path_len` byte (`@liamcottle/meshcore.js/src/packet.js`), but
+ * contact records read `outPathLen` as a plain Int8 byte count, so we accept
+ * the width as an explicit parameter rather than decoding it from outPathLen.
  */
 export function formatOutPath(
   outPath: Uint8Array | number[] | null | undefined,
   outPathLen: number | null | undefined,
+  hopHashBytes: 1 | 2 | 3 = 1,
 ): { outPathHex: string | null; pathLen: number | null } {
   if (outPathLen === undefined || outPathLen === null) {
     return { outPathHex: null, pathLen: null };
@@ -118,12 +126,19 @@ export function formatOutPath(
   }
   const arr = outPath instanceof Uint8Array ? outPath : Uint8Array.from(outPath);
   const take = Math.min(outPathLen, arr.length);
-  const parts: string[] = [];
-  for (let i = 0; i < take; i++) {
-    if (arr[i] === 0) continue;
-    parts.push(arr[i].toString(16).padStart(2, '0'));
+  const hops: string[] = [];
+  for (let i = 0; i + hopHashBytes <= take; i += hopHashBytes) {
+    let allZero = true;
+    let hex = '';
+    for (let j = 0; j < hopHashBytes; j++) {
+      const b = arr[i + j];
+      if (b !== 0) allZero = false;
+      hex += b.toString(16).padStart(2, '0');
+    }
+    if (allZero) continue;
+    hops.push(hex);
   }
-  return { outPathHex: parts.join(','), pathLen: parts.length };
+  return { outPathHex: hops.join(','), pathLen: hops.length };
 }
 
 /** Manager passes telemetry mode as 'never' | 'device' | 'always'; firmware


### PR DESCRIPTION
## Summary
- Fixes #3149 — Meshcore contact paths displayed up to 64 hops when most were 0x00 padding from the firmware.
- `formatOutPath` now skips 0x00 bytes within the reported `outPathLen` window and reports `pathLen` as the count of real (non-zero) hops only.
- Reported path like `"ad,b0,00,00,00,…"` (64 hops) now renders as `"ad,b0"` (2 hops).

## Background
Some Meshcore firmwares inflate `out_path_len` (sometimes the full 64) with the trailing buffer zero-padded. The wire-format `out_path` field is always a 64-byte buffer; the reporter was seeing every padding byte rendered.

A hop hash of exactly 0x00 is vanishingly unlikely in practice, and the user-visible "00 hops" called out in the issue are unambiguously padding.

## Test plan
- [x] New unit tests in `meshcoreNativeBackend.test.ts` cover the issue's reported case (`outPathLen=64`, only two real bytes), interior 0x00 stripping, and all-zero padding.
- [x] Existing `formatOutPath` tests still pass (6/6).
- [x] Full `meshcoreNativeBackend.test.ts` suite passes (39/39).
- [x] `npm run typecheck` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)