### PR TITLE
feat(meshcore): stats panel, quick-action buttons, danger-command guard

### DIFF
--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -48,7 +48,7 @@ interface MeshCoreContactDetailPanelProps {
    *  unset to hide the console (e.g. on read-only sources). */
   remoteAdminActions?: Pick<
     MeshCoreActions,
-    'loginRemote' | 'sendCliCommand' | 'getRemoteAdminCapability' | 'forgetRemoteCredential'
+    'loginRemote' | 'sendCliCommand' | 'getRemoteAdminCapability' | 'forgetRemoteCredential' | 'getRemoteStatus'
   >;
   /** Whether the current user may invoke write actions on this source's
    *  `remote_admin` resource. When false the console is hidden even if

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -48,7 +48,12 @@ interface MeshCoreContactDetailPanelProps {
    *  unset to hide the console (e.g. on read-only sources). */
   remoteAdminActions?: Pick<
     MeshCoreActions,
-    'loginRemote' | 'sendCliCommand' | 'getRemoteAdminCapability' | 'forgetRemoteCredential' | 'getRemoteStatus'
+    | 'loginRemote'
+    | 'loginRemoteWithSaved'
+    | 'sendCliCommand'
+    | 'getRemoteAdminCapability'
+    | 'forgetRemoteCredential'
+    | 'getRemoteStatus'
   >;
   /** Whether the current user may invoke write actions on this source's
    *  `remote_admin` resource. When false the console is hidden even if

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -266,6 +266,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                   sendCliCommand: actions.sendCliCommand,
                   getRemoteAdminCapability: actions.getRemoteAdminCapability,
                   forgetRemoteCredential: actions.forgetRemoteCredential,
+                  getRemoteStatus: actions.getRemoteStatus,
                 }}
               />
               {!!sourceId && typeof baseUrl === 'string' && isRealNodeKey(selected) && (

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -263,6 +263,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                 canRemoteAdmin={canRemoteAdmin && connected}
                 remoteAdminActions={{
                   loginRemote: actions.loginRemote,
+                  loginRemoteWithSaved: actions.loginRemoteWithSaved,
                   sendCliCommand: actions.sendCliCommand,
                   getRemoteAdminCapability: actions.getRemoteAdminCapability,
                   forgetRemoteCredential: actions.forgetRemoteCredential,

--- a/src/components/MeshCore/MeshCoreRemoteConsole.css
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.css
@@ -237,3 +237,59 @@
   justify-content: flex-end;
   gap: 0.5rem;
 }
+
+.mrc-quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.mrc-btn-quick {
+  padding: 0.3rem 0.7rem;
+  border: 1px solid var(--border-color, #ccc);
+  background: var(--button-bg, #f8f9fa);
+  color: inherit;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.mrc-btn-quick:hover:not(:disabled) {
+  background: var(--button-hover-bg, #e9ecef);
+}
+
+.mrc-btn-quick:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.mrc-btn-danger {
+  padding: 0.4rem 0.9rem;
+  border: 1px solid var(--danger-color, #dc3545);
+  background: var(--danger-color, #dc3545);
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.mrc-btn-danger:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.mrc-quick-actions .mrc-btn-danger {
+  padding: 0.3rem 0.7rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.mrc-modal-danger h4 {
+  color: var(--danger-color, #dc3545);
+}
+
+.mrc-modal-body {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}

--- a/src/components/MeshCore/MeshCoreRemoteConsole.css
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.css
@@ -1,11 +1,21 @@
+/**
+ * MeshCoreRemoteConsole — Catppuccin-themed console for remote MeshCore admin.
+ *
+ * Uses --ctp-* tokens so the component picks up whatever Catppuccin flavor
+ * (Mocha / Macchiato / Frappe / Latte) is active, and matches the rest of
+ * the MeshCore UI (see MeshCorePage.css for the canonical conventions).
+ */
+
 .meshcore-remote-console {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
   padding: 0.75rem;
-  border: 1px solid var(--border-color, #ddd);
-  border-radius: 6px;
-  background: var(--panel-bg, #fff);
+  margin-top: 0.75rem;
+  border: 1px solid var(--ctp-surface1);
+  border-radius: var(--radius-md, 6px);
+  background: var(--ctp-mantle);
+  color: var(--ctp-text);
 }
 
 .mrc-header {
@@ -19,28 +29,29 @@
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
+  color: var(--ctp-text);
 }
 
 .mrc-status-chip {
   font-size: 0.75rem;
-  padding: 0.15rem 0.5rem;
-  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+  border-radius: var(--radius-full, 999px);
   font-weight: 500;
 }
 
 .mrc-status-ok {
-  background: var(--success-bg, #d4edda);
-  color: var(--success-fg, #155724);
+  background: var(--ctp-green);
+  color: var(--ctp-crust);
 }
 
 .mrc-status-idle {
-  background: var(--muted-bg, #e9ecef);
-  color: var(--muted-fg, #6c757d);
+  background: var(--ctp-surface2);
+  color: var(--ctp-subtext0);
 }
 
 .mrc-banner {
-  padding: 0.5rem 0.75rem;
-  border-radius: 4px;
+  padding: 0.6rem 0.8rem;
+  border-radius: var(--radius-md, 6px);
   font-size: 0.85rem;
   line-height: 1.4;
 }
@@ -49,20 +60,29 @@
   margin: 0.25rem 0;
 }
 
+.mrc-banner strong {
+  display: block;
+  margin-bottom: 0.2rem;
+}
+
 .mrc-banner-warn {
-  background: var(--warn-bg, #fff3cd);
-  color: var(--warn-fg, #856404);
-  border: 1px solid var(--warn-border, #ffeeba);
+  background: var(--ctp-surface0);
+  color: var(--ctp-text);
+  border: 1px solid var(--ctp-yellow);
+}
+
+.mrc-banner-warn strong {
+  color: var(--ctp-yellow);
 }
 
 .mrc-banner-info {
-  background: var(--info-bg, #d1ecf1);
-  color: var(--info-fg, #0c5460);
-  border: 1px solid var(--info-border, #bee5eb);
+  background: var(--ctp-surface0);
+  color: var(--ctp-text);
+  border: 1px solid var(--ctp-blue);
 }
 
 .mrc-muted {
-  opacity: 0.85;
+  color: var(--ctp-subtext0);
 }
 
 .mrc-actions {
@@ -73,36 +93,52 @@
 .mrc-link-btn {
   background: none;
   border: none;
-  color: inherit;
+  color: var(--ctp-blue);
   text-decoration: underline;
   cursor: pointer;
   padding: 0;
   font: inherit;
 }
 
+.mrc-link-btn:hover {
+  color: var(--ctp-lavender);
+}
+
 .mrc-btn-primary {
   padding: 0.4rem 0.9rem;
-  border: 1px solid var(--primary-color, #0d6efd);
-  background: var(--primary-color, #0d6efd);
-  color: #fff;
-  border-radius: 4px;
+  border: none;
+  background: var(--ctp-mauve);
+  color: var(--ctp-accent-text);
+  border-radius: var(--radius-md, 4px);
   cursor: pointer;
   font-size: 0.9rem;
+  font-weight: 500;
+  transition: background 0.2s;
+}
+
+.mrc-btn-primary:hover:not(:disabled) {
+  background: var(--ctp-pink);
 }
 
 .mrc-btn-primary:disabled {
-  opacity: 0.55;
+  background: var(--ctp-surface2);
+  color: var(--ctp-overlay0);
   cursor: not-allowed;
 }
 
 .mrc-btn-secondary {
   padding: 0.4rem 0.9rem;
-  border: 1px solid var(--border-color, #ccc);
+  border: 1px solid var(--ctp-surface2);
   background: transparent;
-  color: inherit;
-  border-radius: 4px;
+  color: var(--ctp-text);
+  border-radius: var(--radius-md, 4px);
   cursor: pointer;
   font-size: 0.9rem;
+  transition: background 0.2s;
+}
+
+.mrc-btn-secondary:hover:not(:disabled) {
+  background: var(--ctp-surface1);
 }
 
 .mrc-btn-secondary:disabled {
@@ -113,10 +149,11 @@
 .mrc-transcript {
   max-height: 280px;
   overflow-y: auto;
-  background: var(--code-bg, #0d1117);
-  color: var(--code-fg, #e6edf3);
-  border-radius: 4px;
-  padding: 0.5rem 0.75rem;
+  background: var(--ctp-crust);
+  color: var(--ctp-text);
+  border: 1px solid var(--ctp-surface0);
+  border-radius: var(--radius-md, 4px);
+  padding: 0.6rem 0.8rem;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.85rem;
 }
@@ -124,7 +161,7 @@
 .mrc-transcript-empty {
   margin: 0;
   font-style: italic;
-  opacity: 0.6;
+  color: var(--ctp-subtext0);
 }
 
 .mrc-line {
@@ -136,7 +173,7 @@
 .mrc-line-prefix {
   width: 1ch;
   flex-shrink: 0;
-  opacity: 0.6;
+  color: var(--ctp-overlay0);
 }
 
 .mrc-line-text {
@@ -147,19 +184,27 @@
 }
 
 .mrc-line-sent .mrc-line-text {
-  color: var(--accent-fg, #79c0ff);
+  color: var(--ctp-blue);
+}
+
+.mrc-line-sent .mrc-line-prefix {
+  color: var(--ctp-blue);
 }
 
 .mrc-line-reply .mrc-line-text {
-  color: inherit;
+  color: var(--ctp-text);
 }
 
 .mrc-line-error .mrc-line-text {
-  color: var(--error-fg, #ff7b72);
+  color: var(--ctp-red);
+}
+
+.mrc-line-error .mrc-line-prefix {
+  color: var(--ctp-red);
 }
 
 .mrc-line-info .mrc-line-text {
-  color: var(--muted-fg-on-dark, #8b949e);
+  color: var(--ctp-subtext0);
   font-style: italic;
 }
 
@@ -170,16 +215,29 @@
 
 .mrc-input {
   flex: 1;
-  padding: 0.4rem 0.6rem;
-  border: 1px solid var(--border-color, #ccc);
-  border-radius: 4px;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid var(--ctp-surface2);
+  background: var(--ctp-base);
+  color: var(--ctp-text);
+  border-radius: var(--radius-md, 4px);
   font: inherit;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85rem;
+}
+
+.mrc-input:focus {
+  outline: none;
+  border-color: var(--ctp-mauve);
+}
+
+.mrc-input::placeholder {
+  color: var(--ctp-overlay0);
 }
 
 .mrc-modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.45);
+  background: rgba(0, 0, 0, 0.6);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -187,19 +245,22 @@
 }
 
 .mrc-modal {
-  background: var(--panel-bg, #fff);
-  color: var(--text-color, inherit);
-  border-radius: 6px;
+  background: var(--ctp-mantle);
+  color: var(--ctp-text);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: var(--radius-lg, 6px);
   padding: 1rem 1.25rem;
-  min-width: 320px;
+  min-width: 340px;
   max-width: 480px;
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
 }
 
 .mrc-modal h4 {
   margin: 0;
+  color: var(--ctp-text);
 }
 
 .mrc-modal-label {
@@ -207,12 +268,13 @@
   flex-direction: column;
   gap: 0.25rem;
   font-size: 0.9rem;
+  color: var(--ctp-subtext1, var(--ctp-text));
 }
 
 .mrc-modal-hint {
   margin: 0;
   font-size: 0.8rem;
-  opacity: 0.8;
+  color: var(--ctp-subtext0);
 }
 
 .mrc-modal-checkbox {
@@ -220,15 +282,17 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.9rem;
+  color: var(--ctp-text);
+  cursor: pointer;
 }
 
 .mrc-modal-checkbox.mrc-disabled {
-  opacity: 0.55;
+  color: var(--ctp-subtext0);
   cursor: not-allowed;
 }
 
 .mrc-modal-error {
-  color: var(--error-fg, #c00);
+  color: var(--ctp-red);
   font-size: 0.85rem;
 }
 
@@ -238,6 +302,23 @@
   gap: 0.5rem;
 }
 
+.mrc-modal-body {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: var(--ctp-text);
+}
+
+.mrc-modal-danger {
+  border-color: var(--ctp-red);
+}
+
+.mrc-modal-danger h4 {
+  color: var(--ctp-red);
+}
+
+/* Quick-action buttons row (Phase 4a) */
+
 .mrc-quick-actions {
   display: flex;
   flex-wrap: wrap;
@@ -246,17 +327,19 @@
 
 .mrc-btn-quick {
   padding: 0.3rem 0.7rem;
-  border: 1px solid var(--border-color, #ccc);
-  background: var(--button-bg, #f8f9fa);
-  color: inherit;
-  border-radius: 4px;
+  border: 1px solid var(--ctp-surface2);
+  background: var(--ctp-surface0);
+  color: var(--ctp-text);
+  border-radius: var(--radius-sm, 4px);
   cursor: pointer;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  transition: background 0.15s, border-color 0.15s;
 }
 
 .mrc-btn-quick:hover:not(:disabled) {
-  background: var(--button-hover-bg, #e9ecef);
+  background: var(--ctp-surface1);
+  border-color: var(--ctp-mauve);
 }
 
 .mrc-btn-quick:disabled {
@@ -266,30 +349,29 @@
 
 .mrc-btn-danger {
   padding: 0.4rem 0.9rem;
-  border: 1px solid var(--danger-color, #dc3545);
-  background: var(--danger-color, #dc3545);
-  color: #fff;
-  border-radius: 4px;
+  border: none;
+  background: var(--ctp-red);
+  color: var(--ctp-accent-text);
+  border-radius: var(--radius-md, 4px);
   cursor: pointer;
   font-size: 0.85rem;
+  font-weight: 500;
+  transition: background 0.2s;
+}
+
+.mrc-btn-danger:hover:not(:disabled) {
+  background: var(--ctp-maroon);
 }
 
 .mrc-btn-danger:disabled {
-  opacity: 0.55;
+  background: var(--ctp-surface2);
+  color: var(--ctp-overlay0);
   cursor: not-allowed;
 }
 
 .mrc-quick-actions .mrc-btn-danger {
   padding: 0.3rem 0.7rem;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-}
-
-.mrc-modal-danger h4 {
-  color: var(--danger-color, #dc3545);
-}
-
-.mrc-modal-body {
-  margin: 0;
-  font-size: 0.9rem;
-  line-height: 1.4;
+  font-size: 0.82rem;
+  font-weight: normal;
 }

--- a/src/components/MeshCore/MeshCoreRemoteConsole.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.tsx
@@ -68,6 +68,7 @@ interface CapabilitySnapshot {
   reason?: string;
   rotatedCount: number;
   rotated: Array<{ publicKey: string; name: string | null }>;
+  stored: Array<{ publicKey: string; name: string | null }>;
 }
 
 interface MeshCoreRemoteConsoleProps {
@@ -79,7 +80,12 @@ interface MeshCoreRemoteConsoleProps {
    *  this component is easy to host in tests without a full hook. */
   actions: Pick<
     MeshCoreActions,
-    'loginRemote' | 'sendCliCommand' | 'getRemoteAdminCapability' | 'forgetRemoteCredential' | 'getRemoteStatus'
+    | 'loginRemote'
+    | 'loginRemoteWithSaved'
+    | 'sendCliCommand'
+    | 'getRemoteAdminCapability'
+    | 'forgetRemoteCredential'
+    | 'getRemoteStatus'
   >;
 }
 
@@ -133,11 +139,50 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
   const refreshCapability = useCallback(async () => {
     const cap = await actions.getRemoteAdminCapability();
     setCapability(cap);
+    return cap;
   }, [actions]);
 
+  // On mount (and on contact change): fetch capability, and if this
+  // contact has a non-rotated stored credential, silently attempt
+  // auto-login. The plaintext password stays server-side throughout —
+  // see POST /admin/login-with-saved for the no-frontend-exposure flow.
   useEffect(() => {
-    void refreshCapability();
-  }, [refreshCapability]);
+    let cancelled = false;
+    (async () => {
+      const cap = await refreshCapability();
+      if (cancelled || !cap) return;
+      const target = publicKey.toLowerCase();
+      const isStored = cap.stored?.some((s) => s.publicKey.toLowerCase() === target);
+      const isRotated = cap.rotated?.some((r) => r.publicKey.toLowerCase() === target);
+      if (!isStored || isRotated) return;
+      // Try silent auto-login. Don't block the UI or open the modal.
+      const result = await actions.loginRemoteWithSaved(publicKey);
+      if (cancelled) return;
+      if (result.success) {
+        setLoggedIn(true);
+        setTranscript((prev) => [
+          ...prev,
+          {
+            id: nextId(),
+            ts: Date.now(),
+            kind: 'info',
+            text: t(
+              'meshcore.remoteConsole.auto_login_success',
+              'Logged in with saved password',
+            ),
+          },
+        ]);
+      } else if (result.code === 'CREDENTIAL_KEY_ROTATED') {
+        // Pull capability again so the rotated banner shows for this contact.
+        void refreshCapability();
+      }
+      // NO_STORED_CREDENTIAL / STORED_CREDENTIAL_REJECTED → silently fall
+      // through to the manual login modal.
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [publicKey, actions, refreshCapability, t]);
 
   const appendTranscript = useCallback((entry: Omit<TranscriptEntry, 'id' | 'ts'>) => {
     setTranscript((prev) => [

--- a/src/components/MeshCore/MeshCoreRemoteConsole.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.tsx
@@ -20,7 +20,41 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { MeshCoreActions } from './hooks/useMeshCore';
+import { MeshCoreRemoteStatsPanel } from './MeshCoreRemoteStatsPanel';
 import './MeshCoreRemoteConsole.css';
+
+/**
+ * Catalog of one-click CLI commands surfaced as buttons in the console.
+ * Clicking a button pre-fills the command input — it does NOT auto-send,
+ * so the user can edit before pressing Send and so danger commands route
+ * through the confirmation modal naturally.
+ *
+ * `danger: true` triggers the typed-name confirmation modal and also gets
+ * server-side enforcement via the DANGER_CONFIRM_REQUIRED guard in the
+ * /admin/cli route.
+ */
+interface ActionCommand {
+  key: string;
+  labelKey: string;
+  defaultLabel: string;
+  command: string;
+  danger?: boolean;
+}
+
+const ACTION_CATALOG: ActionCommand[] = [
+  { key: 'ver',       labelKey: 'meshcore.remoteConsole.action.ver',       defaultLabel: 'Version',  command: 'ver' },
+  { key: 'stats',     labelKey: 'meshcore.remoteConsole.action.stats',     defaultLabel: 'Stats',    command: 'stats' },
+  { key: 'neighbors', labelKey: 'meshcore.remoteConsole.action.neighbors', defaultLabel: 'Neighbors', command: 'neighbors' },
+  { key: 'clock',     labelKey: 'meshcore.remoteConsole.action.clock',     defaultLabel: 'Clock',    command: 'clock' },
+  { key: 'clock_sync', labelKey: 'meshcore.remoteConsole.action.clock_sync', defaultLabel: 'Sync clock', command: 'clock sync' },
+  { key: 'advert',    labelKey: 'meshcore.remoteConsole.action.advert',    defaultLabel: 'Send advert', command: 'advert' },
+  { key: 'reboot',    labelKey: 'meshcore.remoteConsole.action.reboot',    defaultLabel: 'Reboot',   command: 'reboot', danger: true },
+];
+
+/** Server-enforced regex for danger commands. Keep this in sync with the
+ *  identically-named pattern in meshcoreRoutes.ts so the client can decide
+ *  to open the confirmation modal even for free-typed commands. */
+const DANGER_COMMAND_PATTERN = /(reboot|erase|clkreboot|factory)/i;
 
 interface TranscriptEntry {
   id: string;
@@ -45,7 +79,7 @@ interface MeshCoreRemoteConsoleProps {
    *  this component is easy to host in tests without a full hook. */
   actions: Pick<
     MeshCoreActions,
-    'loginRemote' | 'sendCliCommand' | 'getRemoteAdminCapability' | 'forgetRemoteCredential'
+    'loginRemote' | 'sendCliCommand' | 'getRemoteAdminCapability' | 'forgetRemoteCredential' | 'getRemoteStatus'
   >;
 }
 
@@ -71,6 +105,11 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
   const [loginBusy, setLoginBusy] = useState(false);
   const [loginError, setLoginError] = useState<string | null>(null);
 
+  // Danger-command confirmation state. Set when the user clicks a danger
+  // button OR presses Send while the typed command matches the danger
+  // regex. Stays null until the user explicitly opens the flow.
+  const [dangerConfirm, setDangerConfirm] = useState<null | { command: string; typedName: string }>(null);
+
   const transcriptEndRef = useRef<HTMLDivElement | null>(null);
 
   // Auto-scroll the transcript when new entries arrive.
@@ -88,6 +127,7 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
     setLoginPassword('');
     setRememberPassword(false);
     setLoginError(null);
+    setDangerConfirm(null);
   }, [publicKey]);
 
   const refreshCapability = useCallback(async () => {
@@ -135,13 +175,12 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
     void refreshCapability();
   }, [actions, appendTranscript, loginPassword, publicKey, refreshCapability, rememberPassword, t]);
 
-  const handleSend = useCallback(async () => {
-    const trimmed = command.trim();
-    if (!trimmed || sending) return;
+  const runCommand = useCallback(async (cmd: string, opts?: { confirm?: boolean }) => {
+    if (sending) return;
     setSending(true);
-    appendTranscript({ kind: 'sent', text: trimmed });
+    appendTranscript({ kind: 'sent', text: cmd });
     setCommand('');
-    const result = await actions.sendCliCommand(publicKey, trimmed);
+    const result = await actions.sendCliCommand(publicKey, cmd, opts);
     setSending(false);
     if (result.ok) {
       appendTranscript({ kind: 'reply', text: result.reply || '(empty reply)' });
@@ -157,7 +196,35 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
           : '';
       appendTranscript({ kind: 'error', text: `${result.error}${hint}` });
     }
-  }, [actions, appendTranscript, command, publicKey, sending, t]);
+  }, [actions, appendTranscript, publicKey, sending, t]);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = command.trim();
+    if (!trimmed || sending) return;
+    // Free-typed danger command — route through the confirm modal even
+    // when the user typed it manually instead of clicking the button.
+    if (DANGER_COMMAND_PATTERN.test(trimmed)) {
+      setDangerConfirm({ command: trimmed, typedName: '' });
+      return;
+    }
+    await runCommand(trimmed);
+  }, [command, runCommand, sending]);
+
+  const handleActionClick = useCallback((action: ActionCommand) => {
+    if (action.danger) {
+      setDangerConfirm({ command: action.command, typedName: '' });
+      return;
+    }
+    // Pre-fill the input so the user can review/edit before pressing Send.
+    setCommand(action.command);
+  }, []);
+
+  const handleDangerConfirm = useCallback(async () => {
+    if (!dangerConfirm) return;
+    const cmd = dangerConfirm.command;
+    setDangerConfirm(null);
+    await runCommand(cmd, { confirm: true });
+  }, [dangerConfirm, runCommand]);
 
   const handleForgetCredential = useCallback(async () => {
     const ok = await actions.forgetRemoteCredential(publicKey);
@@ -225,6 +292,30 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
           </button>
         )}
       </div>
+
+      {loggedIn && (
+        <MeshCoreRemoteStatsPanel
+          publicKey={publicKey}
+          fetchStatus={actions.getRemoteStatus}
+        />
+      )}
+
+      {loggedIn && (
+        <div className="mrc-quick-actions" role="group" aria-label={t('meshcore.remoteConsole.quick_actions', 'Quick actions')}>
+          {ACTION_CATALOG.map((action) => (
+            <button
+              key={action.key}
+              type="button"
+              className={action.danger ? 'mrc-btn-danger' : 'mrc-btn-quick'}
+              onClick={() => handleActionClick(action)}
+              disabled={sending}
+              title={action.command}
+            >
+              {t(action.labelKey, action.defaultLabel)}
+            </button>
+          ))}
+        </div>
+      )}
 
       <div className="mrc-transcript" role="log" aria-live="polite">
         {transcript.length === 0 ? (
@@ -336,6 +427,56 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
                 {loginBusy
                   ? t('meshcore.remoteConsole.logging_in', 'Logging in…')
                   : t('meshcore.remoteConsole.login_confirm', 'Log in')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {dangerConfirm && (
+        <div
+          className="mrc-modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="mrc-danger-title"
+          onClick={() => setDangerConfirm(null)}
+        >
+          <div className="mrc-modal mrc-modal-danger" onClick={(e) => e.stopPropagation()}>
+            <h4 id="mrc-danger-title">
+              {t('meshcore.remoteConsole.danger_modal_title', 'Confirm destructive command')}
+            </h4>
+            <p className="mrc-modal-body">
+              {t(
+                'meshcore.remoteConsole.danger_modal_body',
+                'You are about to send "{{command}}" to {{name}}. This action may interrupt the remote node. Type the contact name to confirm:',
+                { command: dangerConfirm.command, name: contactName },
+              )}
+            </p>
+            <input
+              type="text"
+              value={dangerConfirm.typedName}
+              onChange={(e) => setDangerConfirm({ ...dangerConfirm, typedName: e.target.value })}
+              className="mrc-input"
+              autoFocus
+              spellCheck={false}
+              autoComplete="off"
+              placeholder={contactName}
+            />
+            <div className="mrc-modal-actions">
+              <button
+                type="button"
+                className="mrc-btn-secondary"
+                onClick={() => setDangerConfirm(null)}
+              >
+                {t('meshcore.remoteConsole.cancel', 'Cancel')}
+              </button>
+              <button
+                type="button"
+                className="mrc-btn-danger"
+                onClick={() => void handleDangerConfirm()}
+                disabled={dangerConfirm.typedName !== contactName}
+              >
+                {t('meshcore.remoteConsole.danger_confirm', 'Send {{command}}', { command: dangerConfirm.command })}
               </button>
             </div>
           </div>

--- a/src/components/MeshCore/MeshCoreRemoteStatsPanel.css
+++ b/src/components/MeshCore/MeshCoreRemoteStatsPanel.css
@@ -1,0 +1,112 @@
+.meshcore-remote-stats {
+  border: 1px solid var(--border-color, #ddd);
+  border-radius: 6px;
+  background: var(--panel-bg, #fff);
+}
+
+.mrs-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.mrs-chevron {
+  opacity: 0.6;
+  font-size: 0.7em;
+}
+
+.mrs-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  flex: 1;
+}
+
+.mrs-updated {
+  font-size: 0.75rem;
+  opacity: 0.6;
+}
+
+.mrs-refresh-btn {
+  padding: 0.2rem 0.6rem;
+  border: 1px solid var(--border-color, #ccc);
+  background: transparent;
+  color: inherit;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.mrs-refresh-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.mrs-body {
+  padding: 0.5rem 0.75rem 0.75rem;
+}
+
+.mrs-error,
+.mrs-loading {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.7;
+  font-style: italic;
+}
+
+.mrs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 0.5rem 1rem;
+}
+
+.mrs-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.mrs-field-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.65;
+}
+
+.mrs-field-value {
+  font-size: 0.95rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+.mrs-field-compact .mrs-field-label {
+  font-size: 0.65rem;
+}
+
+.mrs-field-compact .mrs-field-value {
+  font-size: 0.85rem;
+}
+
+.mrs-section {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--border-color, #eee);
+  padding-top: 0.5rem;
+}
+
+.mrs-section h5 {
+  margin: 0 0 0.4rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.65;
+  font-weight: 600;
+}
+
+.mrs-subgrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 0.4rem 0.8rem;
+}

--- a/src/components/MeshCore/MeshCoreRemoteStatsPanel.css
+++ b/src/components/MeshCore/MeshCoreRemoteStatsPanel.css
@@ -1,7 +1,12 @@
+/**
+ * MeshCoreRemoteStatsPanel — Catppuccin-themed status panel.
+ */
+
 .meshcore-remote-stats {
-  border: 1px solid var(--border-color, #ddd);
-  border-radius: 6px;
-  background: var(--panel-bg, #fff);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: var(--radius-md, 6px);
+  background: var(--ctp-surface0);
+  color: var(--ctp-text);
 }
 
 .mrs-header {
@@ -11,10 +16,16 @@
   padding: 0.5rem 0.75rem;
   cursor: pointer;
   user-select: none;
+  border-radius: var(--radius-md, 6px) var(--radius-md, 6px) 0 0;
+  transition: background 0.15s;
+}
+
+.mrs-header:hover {
+  background: var(--ctp-surface1);
 }
 
 .mrs-chevron {
-  opacity: 0.6;
+  color: var(--ctp-subtext0);
   font-size: 0.7em;
 }
 
@@ -22,22 +33,29 @@
   margin: 0;
   font-size: 0.95rem;
   font-weight: 600;
+  color: var(--ctp-text);
   flex: 1;
 }
 
 .mrs-updated {
   font-size: 0.75rem;
-  opacity: 0.6;
+  color: var(--ctp-subtext0);
 }
 
 .mrs-refresh-btn {
-  padding: 0.2rem 0.6rem;
-  border: 1px solid var(--border-color, #ccc);
+  padding: 0.2rem 0.7rem;
+  border: 1px solid var(--ctp-surface2);
   background: transparent;
-  color: inherit;
-  border-radius: 3px;
+  color: var(--ctp-text);
+  border-radius: var(--radius-sm, 3px);
   cursor: pointer;
-  font-size: 0.8rem;
+  font-size: 0.78rem;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.mrs-refresh-btn:hover:not(:disabled) {
+  background: var(--ctp-surface1);
+  border-color: var(--ctp-mauve);
 }
 
 .mrs-refresh-btn:disabled {
@@ -47,20 +65,21 @@
 
 .mrs-body {
   padding: 0.5rem 0.75rem 0.75rem;
+  border-top: 1px solid var(--ctp-surface1);
 }
 
 .mrs-error,
 .mrs-loading {
   margin: 0;
   font-size: 0.85rem;
-  opacity: 0.7;
+  color: var(--ctp-subtext0);
   font-style: italic;
 }
 
 .mrs-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 0.5rem 1rem;
+  gap: 0.6rem 1rem;
 }
 
 .mrs-field {
@@ -73,12 +92,13 @@
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  opacity: 0.65;
+  color: var(--ctp-subtext0);
 }
 
 .mrs-field-value {
   font-size: 0.95rem;
   font-weight: 500;
+  color: var(--ctp-text);
   font-variant-numeric: tabular-nums;
 }
 
@@ -92,16 +112,16 @@
 
 .mrs-section {
   grid-column: 1 / -1;
-  border-top: 1px solid var(--border-color, #eee);
+  border-top: 1px solid var(--ctp-surface1);
   padding-top: 0.5rem;
 }
 
 .mrs-section h5 {
   margin: 0 0 0.4rem;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  opacity: 0.65;
+  color: var(--ctp-mauve);
   font-weight: 600;
 }
 

--- a/src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx
@@ -1,0 +1,203 @@
+/**
+ * MeshCoreRemoteStatsPanel
+ *
+ * Renders the typed status snapshot returned by MeshCore's SendStatusReq
+ * (wrapped by GET /admin/status/:publicKey → `getRemoteStatus`). Mounted
+ * inside MeshCoreRemoteConsole once the user has an active admin session.
+ *
+ * Auto-refresh: a low-frequency poll (30s by default) so the panel stays
+ * fresh without hammering the radio. Manual refresh button bypasses the
+ * timer. Failures render a soft "unavailable" state — typical when the
+ * remote firmware is a Companion (which doesn't populate the full counter
+ * set) or the path has gone stale since login.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { MeshCoreActions, MeshCoreRemoteStatus } from './hooks/useMeshCore';
+import './MeshCoreRemoteStatsPanel.css';
+
+interface Props {
+  publicKey: string;
+  /** Pulled from the same useMeshCore actions bundle the console uses. */
+  fetchStatus: MeshCoreActions['getRemoteStatus'];
+  /** Auto-refresh interval in ms. 0 disables auto-refresh. Default 30s. */
+  refreshIntervalMs?: number;
+}
+
+export const MeshCoreRemoteStatsPanel: React.FC<Props> = ({
+  publicKey,
+  fetchStatus,
+  refreshIntervalMs = 30_000,
+}) => {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<MeshCoreRemoteStatus | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
+
+  // Track an in-flight fetch so a slow Refresh + an interval tick can't
+  // race. The interval skips its tick if a fetch is already in flight.
+  const inFlightRef = useRef(false);
+
+  const load = useCallback(async () => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchStatus(publicKey);
+      if (result) {
+        setStatus(result);
+        setLastUpdated(Date.now());
+      } else {
+        setError(t('meshcore.remoteStats.unavailable', 'Status unavailable'));
+      }
+    } finally {
+      inFlightRef.current = false;
+      setLoading(false);
+    }
+  }, [fetchStatus, publicKey, t]);
+
+  // Initial fetch + interval. Reset whenever the targeted contact changes
+  // so a stale interval tick can't hit the previously-selected node.
+  useEffect(() => {
+    void load();
+    if (refreshIntervalMs <= 0) return;
+    const id = setInterval(() => { void load(); }, refreshIntervalMs);
+    return () => clearInterval(id);
+  }, [load, refreshIntervalMs]);
+
+  return (
+    <section className="meshcore-remote-stats" aria-label={t('meshcore.remoteStats.title', 'Remote node status')}>
+      <header
+        className="mrs-header"
+        onClick={() => setCollapsed((v) => !v)}
+        role="button"
+        tabIndex={0}
+        aria-expanded={!collapsed}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setCollapsed((v) => !v); } }}
+      >
+        <span className="mrs-chevron" aria-hidden="true">{collapsed ? '▶' : '▼'}</span>
+        <h4 className="mrs-title">{t('meshcore.remoteStats.title', 'Remote node status')}</h4>
+        {lastUpdated !== null && !collapsed && (
+          <span className="mrs-updated">
+            {t('meshcore.remoteStats.updated', 'Updated {{ago}}s ago', {
+              ago: Math.floor((Date.now() - lastUpdated) / 1000),
+            })}
+          </span>
+        )}
+        <button
+          type="button"
+          className="mrs-refresh-btn"
+          onClick={(e) => { e.stopPropagation(); void load(); }}
+          disabled={loading}
+        >
+          {loading ? t('meshcore.remoteStats.refreshing', 'Refreshing…') : t('meshcore.remoteStats.refresh', 'Refresh')}
+        </button>
+      </header>
+
+      {!collapsed && (
+        <div className="mrs-body">
+          {error && !status && (
+            <p className="mrs-error">{error}</p>
+          )}
+          {status && (
+            <div className="mrs-grid">
+              <StatField label={t('meshcore.remoteStats.uptime', 'Uptime')} value={formatUptime(status.uptimeSecs)} />
+              <StatField label={t('meshcore.remoteStats.battery', 'Battery')} value={formatBattery(status.batteryMv)} />
+              <StatField label={t('meshcore.remoteStats.queue', 'TX queue')} value={formatNumber(status.queueLen)} />
+              <StatField label={t('meshcore.remoteStats.last_rssi', 'Last RSSI')} value={formatRssi(status.lastRssi)} />
+              <StatField label={t('meshcore.remoteStats.last_snr', 'Last SNR')} value={formatSnr(status.lastSnr)} />
+              <StatField label={t('meshcore.remoteStats.noise_floor', 'Noise floor')} value={formatRssi(status.noiseFloor)} />
+              <StatField label={t('meshcore.remoteStats.air_time', 'Air time')} value={formatAirTime(status.airTimeSecs)} />
+              <StatField label={t('meshcore.remoteStats.errors', 'Errors')} value={formatNumber(status.errors)} />
+
+              <div className="mrs-section">
+                <h5>{t('meshcore.remoteStats.rx', 'Received')}</h5>
+                <div className="mrs-subgrid">
+                  <StatField compact label={t('meshcore.remoteStats.total', 'Total')} value={formatNumber(status.packetsRecv)} />
+                  <StatField compact label={t('meshcore.remoteStats.flood', 'Flood')} value={formatNumber(status.recvFlood)} />
+                  <StatField compact label={t('meshcore.remoteStats.direct', 'Direct')} value={formatNumber(status.recvDirect)} />
+                  <StatField compact label={t('meshcore.remoteStats.flood_dups', 'Flood dups')} value={formatNumber(status.floodDups)} />
+                  <StatField compact label={t('meshcore.remoteStats.direct_dups', 'Direct dups')} value={formatNumber(status.directDups)} />
+                </div>
+              </div>
+
+              <div className="mrs-section">
+                <h5>{t('meshcore.remoteStats.tx', 'Sent')}</h5>
+                <div className="mrs-subgrid">
+                  <StatField compact label={t('meshcore.remoteStats.total', 'Total')} value={formatNumber(status.packetsSent)} />
+                  <StatField compact label={t('meshcore.remoteStats.flood', 'Flood')} value={formatNumber(status.sentFlood)} />
+                  <StatField compact label={t('meshcore.remoteStats.direct', 'Direct')} value={formatNumber(status.sentDirect)} />
+                </div>
+              </div>
+            </div>
+          )}
+          {loading && !status && (
+            <p className="mrs-loading">{t('meshcore.remoteStats.loading', 'Loading status…')}</p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+};
+
+interface StatFieldProps {
+  label: string;
+  value: string;
+  compact?: boolean;
+}
+
+const StatField: React.FC<StatFieldProps> = ({ label, value, compact }) => (
+  <div className={`mrs-field${compact ? ' mrs-field-compact' : ''}`}>
+    <span className="mrs-field-label">{label}</span>
+    <span className="mrs-field-value">{value}</span>
+  </div>
+);
+
+// ----- formatters -----
+
+function formatNumber(v: number | undefined): string {
+  if (v === undefined || v === null) return '—';
+  return v.toLocaleString();
+}
+
+function formatUptime(secs: number | undefined): string {
+  if (secs === undefined || secs === null) return '—';
+  if (secs < 60) return `${secs}s`;
+  const d = Math.floor(secs / 86400);
+  const h = Math.floor((secs % 86400) / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h ${m}m`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+function formatBattery(mv: number | undefined): string {
+  if (mv === undefined || mv === null) return '—';
+  return `${(mv / 1000).toFixed(2)} V`;
+}
+
+function formatRssi(rssi: number | undefined): string {
+  if (rssi === undefined || rssi === null) return '—';
+  return `${rssi} dBm`;
+}
+
+function formatSnr(snr: number | undefined): string {
+  if (snr === undefined || snr === null) return '—';
+  // The wire value is a signed int16 representing dB×10 in some firmware
+  // versions and raw dB in others — meshcore.js currently emits raw dB,
+  // so render as-is with one decimal.
+  return `${snr.toFixed(1)} dB`;
+}
+
+function formatAirTime(secs: number | undefined): string {
+  if (secs === undefined || secs === null) return '—';
+  if (secs < 60) return `${secs}s`;
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -131,12 +131,28 @@ export interface MeshCoreActions {
   ) => Promise<{ ok: true; reply: string; elapsedMs: number } | { ok: false; error: string; code?: string; status?: number }>;
   /** Query the credential-persistence capability for this source. Returns
    *  `canRemember=false` when SESSION_SECRET is auto-generated (along with a
-   *  human-readable reason), plus the list of stored credentials for this
-   *  source whose envelope no longer decrypts. */
+   *  human-readable reason), plus:
+   *    - `rotated`: stored credentials whose envelope no longer decrypts
+   *      under the current SESSION_SECRET (they need re-entry).
+   *    - `stored`: stored credentials that DO decrypt — used by the
+   *      console to decide whether to attempt silent auto-login on mount. */
   getRemoteAdminCapability: () => Promise<
-    | { canRemember: boolean; reason?: string; rotatedCount: number; rotated: Array<{ publicKey: string; name: string | null }> }
+    | {
+        canRemember: boolean;
+        reason?: string;
+        rotatedCount: number;
+        rotated: Array<{ publicKey: string; name: string | null }>;
+        stored: Array<{ publicKey: string; name: string | null }>;
+      }
     | null
   >;
+  /** Attempt to log in to a remote node using a previously-saved
+   *  credential. Returns the route's JSON response so the caller can
+   *  branch on `code` (NO_STORED_CREDENTIAL, CREDENTIAL_KEY_ROTATED,
+   *  STORED_CREDENTIAL_REJECTED) and fall back to the password modal. */
+  loginRemoteWithSaved: (
+    publicKey: string,
+  ) => Promise<{ success: boolean; usedStored?: boolean; error?: string; code?: string }>;
   /** Forget the saved admin password for a remote node. No-op when none is
    *  saved; resolves `true` on success. */
   forgetRemoteCredential: (publicKey: string) => Promise<boolean>;
@@ -573,6 +589,25 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch]);
 
+  const loginRemoteWithSaved = useCallback(async (publicKey: string) => {
+    try {
+      const response = await csrfFetch(`${mcPrefix}/admin/login-with-saved`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ publicKey }),
+      });
+      const data = await response.json();
+      return {
+        success: !!data.success,
+        usedStored: data.usedStored,
+        error: data.error,
+        code: data.code,
+      };
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : 'Network error' };
+    }
+  }, [mcPrefix, csrfFetch]);
+
   const forgetRemoteCredential = useCallback(async (publicKey: string): Promise<boolean> => {
     try {
       const response = await csrfFetch(
@@ -840,6 +875,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       getRemoteAdminCapability,
       forgetRemoteCredential,
       getRemoteStatus,
+      loginRemoteWithSaved,
     },
   };
 }

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -127,7 +127,7 @@ export interface MeshCoreActions {
   sendCliCommand: (
     publicKey: string,
     command: string,
-    opts?: { timeoutMs?: number },
+    opts?: { timeoutMs?: number; confirm?: boolean },
   ) => Promise<{ ok: true; reply: string; elapsedMs: number } | { ok: false; error: string; code?: string; status?: number }>;
   /** Query the credential-persistence capability for this source. Returns
    *  `canRemember=false` when SESSION_SECRET is auto-generated (along with a
@@ -140,6 +140,41 @@ export interface MeshCoreActions {
   /** Forget the saved admin password for a remote node. No-op when none is
    *  saved; resolves `true` on success. */
   forgetRemoteCredential: (publicKey: string) => Promise<boolean>;
+  /** Fetch typed status from a remote node (SendStatusReq → StatusResponse).
+   *  Populated fields depend on the remote's role: Repeater / Room Server
+   *  return the full counter set; Companion firmware returns only battery
+   *  and uptime. Returns null on any error so the panel can render an
+   *  "unavailable" state without a thrown promise. */
+  getRemoteStatus: (publicKey: string) => Promise<MeshCoreRemoteStatus | null>;
+}
+
+/**
+ * Typed status snapshot returned by `getRemoteStatus`. Mirrors the
+ * server-side `MeshCoreStatus` in src/server/meshcoreManager.ts; defined
+ * separately here so the frontend doesn't pull in server-only modules.
+ */
+export interface MeshCoreRemoteStatus {
+  batteryMv?: number;
+  uptimeSecs?: number;
+  queueLen?: number;
+  noiseFloor?: number;
+  lastRssi?: number;
+  lastSnr?: number;
+  packetsRecv?: number;
+  packetsSent?: number;
+  airTimeSecs?: number;
+  sentFlood?: number;
+  sentDirect?: number;
+  recvFlood?: number;
+  recvDirect?: number;
+  errors?: number;
+  directDups?: number;
+  floodDups?: number;
+  txPower?: number;
+  radioFreq?: number;
+  radioBw?: number;
+  radioSf?: number;
+  radioCr?: number;
 }
 
 export interface UseMeshCoreState {
@@ -504,13 +539,18 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
   const sendCliCommand = useCallback(async (
     publicKey: string,
     command: string,
-    opts?: { timeoutMs?: number },
+    opts?: { timeoutMs?: number; confirm?: boolean },
   ) => {
     try {
       const response = await csrfFetch(`${mcPrefix}/admin/cli`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ publicKey, command, ...(opts?.timeoutMs ? { timeoutMs: opts.timeoutMs } : {}) }),
+        body: JSON.stringify({
+          publicKey,
+          command,
+          ...(opts?.timeoutMs ? { timeoutMs: opts.timeoutMs } : {}),
+          ...(opts?.confirm ? { confirm: true } : {}),
+        }),
       });
       const data = await response.json();
       if (data.success && data.data) {
@@ -543,6 +583,19 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       return !!data.success;
     } catch (_err) {
       return false;
+    }
+  }, [mcPrefix, csrfFetch]);
+
+  const getRemoteStatus = useCallback(async (publicKey: string): Promise<MeshCoreRemoteStatus | null> => {
+    try {
+      const response = await csrfFetch(
+        `${mcPrefix}/admin/status/${encodeURIComponent(publicKey)}`,
+      );
+      const data = await response.json();
+      if (data.success && data.data) return data.data as MeshCoreRemoteStatus;
+      return null;
+    } catch (_err) {
+      return null;
     }
   }, [mcPrefix, csrfFetch]);
 
@@ -786,6 +839,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       sendCliCommand,
       getRemoteAdminCapability,
       forgetRemoteCredential,
+      getRemoteStatus,
     },
   };
 }

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -88,15 +88,35 @@ vi.mock('../meshcoreRegistry.js', () => ({
 const fakeCredentialStore = {
   capability: { canRemember: true as boolean, reason: undefined as string | undefined },
   store: vi.fn(async (_sid: string, _pk: string, _pw: string) => undefined),
-  load: vi.fn(async () => ({ kind: 'none' as const })),
+  load: vi.fn(
+    async () =>
+      ({ kind: 'none' as const }) as
+        | { kind: 'none' }
+        | { kind: 'ok'; password: string }
+        | { kind: 'key_rotated'; storedKid: string },
+  ),
   clear: vi.fn(async (_sid: string, _pk: string) => undefined),
   listRotated: vi.fn(async () => [] as Array<{ sourceId: string; publicKey: string; name: string | null; storedKid: string }>),
+  listStored: vi.fn(async () => [] as Array<{ sourceId: string; publicKey: string; name: string | null }>),
   currentFingerprint: 'deadbeef',
 };
 vi.mock('../services/meshcoreCredentialStore.js', () => ({
   getMeshCoreCredentialStore: () => fakeCredentialStore,
   setMeshCoreCredentialStoreForTesting: vi.fn(),
 }));
+
+// Disable rate limiting in tests. The 60-req/min bucket is enough for the
+// original test set but pushed over by the new login-with-saved cases,
+// causing unrelated tests downstream to fail with 429s.
+vi.mock('../middleware/rateLimiters.js', () => {
+  const passthrough = (_req: any, _res: any, next: any) => next();
+  return {
+    apiLimiter: passthrough,
+    authLimiter: passthrough,
+    messageLimiter: passthrough,
+    meshcoreDeviceLimiter: passthrough,
+  };
+});
 
 // The `/info` route reads the last poll snapshot from the singleton poller.
 // We expose a mutable fake here so individual tests can decide whether to
@@ -599,6 +619,127 @@ describe('MeshCore Routes', () => {
         .send({ publicKey: validKey, password: '' });
       expect(response.status).toBe(200);
       expect(meshcoreManager.loginToNode).toHaveBeenCalledWith(validKey, '');
+    });
+  });
+
+  describe('POST /api/sources/test-source/meshcore/admin/login-with-saved', () => {
+    const validKey = 'a'.repeat(64);
+    const SECRET = 'top-secret-password-that-must-never-leak-to-the-client';
+
+    beforeEach(() => {
+      fakeCredentialStore.load.mockReset();
+      meshcoreManager.loginToNode.mockReset();
+      meshcoreManager.loginToNode.mockResolvedValue(true);
+    });
+
+    it('rejects an invalid public key', async () => {
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/admin/login-with-saved')
+        .send({ publicKey: 'nope' });
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 404 NO_STORED_CREDENTIAL when nothing is saved', async () => {
+      fakeCredentialStore.load.mockResolvedValue({ kind: 'none' });
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/admin/login-with-saved')
+        .send({ publicKey: validKey });
+      expect(response.status).toBe(404);
+      expect(response.body.code).toBe('NO_STORED_CREDENTIAL');
+      expect(meshcoreManager.loginToNode).not.toHaveBeenCalled();
+    });
+
+    it('returns 410 CREDENTIAL_KEY_ROTATED when stored kid no longer matches', async () => {
+      fakeCredentialStore.load.mockResolvedValue({ kind: 'key_rotated', storedKid: 'feedface' });
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/admin/login-with-saved')
+        .send({ publicKey: validKey });
+      expect(response.status).toBe(410);
+      expect(response.body.code).toBe('CREDENTIAL_KEY_ROTATED');
+      // Stored fingerprint MUST NOT leak — even though it's "just" a 4-byte
+      // hash, exposing it would let a hostile script enumerate rotations.
+      expect(JSON.stringify(response.body)).not.toContain('feedface');
+      expect(meshcoreManager.loginToNode).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 STORED_CREDENTIAL_REJECTED when the remote refuses the saved password', async () => {
+      fakeCredentialStore.load.mockResolvedValue({ kind: 'ok', password: SECRET });
+      meshcoreManager.loginToNode.mockResolvedValue(false);
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/admin/login-with-saved')
+        .send({ publicKey: validKey });
+      expect(response.status).toBe(401);
+      expect(response.body.code).toBe('STORED_CREDENTIAL_REJECTED');
+      // Even in the failure path, the password must not be echoed back.
+      expect(JSON.stringify(response.body)).not.toContain(SECRET);
+    });
+
+    it('succeeds when the saved credential decrypts and the remote accepts it', async () => {
+      fakeCredentialStore.load.mockResolvedValue({ kind: 'ok', password: SECRET });
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/admin/login-with-saved')
+        .send({ publicKey: validKey });
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.usedStored).toBe(true);
+      expect(meshcoreManager.loginToNode).toHaveBeenCalledWith(validKey, SECRET);
+    });
+
+    /**
+     * SECURITY INVARIANT: the saved plaintext password must NEVER appear
+     * in any HTTP response body, in any status code path. This test is
+     * the canary — if it fails, audit every change to the route since
+     * the last green run.
+     */
+    it('NEVER returns the saved password in the response body', async () => {
+      const cases: Array<[Awaited<ReturnType<typeof fakeCredentialStore.load>>, boolean]> = [
+        [{ kind: 'none' }, false],
+        [{ kind: 'key_rotated', storedKid: 'beefcafe' }, false],
+        [{ kind: 'ok', password: SECRET }, true],
+        [{ kind: 'ok', password: SECRET }, false], // remote rejects
+      ];
+      for (const [loadResult, remoteAccepts] of cases) {
+        fakeCredentialStore.load.mockResolvedValueOnce(loadResult);
+        meshcoreManager.loginToNode.mockResolvedValueOnce(remoteAccepts);
+        const response = await authenticatedAgent
+          .post('/api/sources/test-source/meshcore/admin/login-with-saved')
+          .send({ publicKey: validKey });
+        expect(JSON.stringify(response.body)).not.toContain(SECRET);
+      }
+    });
+
+    it('does not require client to send a password (body is { publicKey } only)', async () => {
+      fakeCredentialStore.load.mockResolvedValue({ kind: 'ok', password: SECRET });
+      await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/admin/login-with-saved')
+        .send({ publicKey: validKey });
+      // loginToNode received the SERVER-side decrypted password, not
+      // anything the client supplied (the client supplied no password).
+      expect(meshcoreManager.loginToNode).toHaveBeenCalledWith(validKey, SECRET);
+    });
+  });
+
+  describe('GET /credentials-capability includes stored[]', () => {
+    beforeEach(() => {
+      fakeCredentialStore.capability = { canRemember: true, reason: undefined };
+      fakeCredentialStore.listRotated.mockReset();
+      fakeCredentialStore.listRotated.mockResolvedValue([]);
+      fakeCredentialStore.listStored.mockReset();
+      fakeCredentialStore.listStored.mockResolvedValue([]);
+    });
+
+    it('filters stored entries to the requested source', async () => {
+      const pk1 = 'a'.repeat(64);
+      const pk2 = 'b'.repeat(64);
+      fakeCredentialStore.listStored.mockResolvedValue([
+        { sourceId: 'test-source', publicKey: pk1, name: 'My repeater' },
+        { sourceId: 'other-source', publicKey: pk2, name: 'Other repeater' },
+      ]);
+      const response = await authenticatedAgent.get(
+        '/api/sources/test-source/meshcore/admin/credentials-capability',
+      );
+      expect(response.status).toBe(200);
+      expect(response.body.data.stored).toEqual([{ publicKey: pk1, name: 'My repeater' }]);
     });
   });
 

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -477,6 +477,39 @@ describe('MeshCore Routes', () => {
         timeoutMs: 5000,
       });
     });
+
+    it.each([
+      ['reboot'],
+      ['Reboot'],
+      ['erase'],
+      ['clkreboot'],
+      ['factory reset'],
+      ['set factory mode'],
+    ])('rejects danger command %s without confirm', async (cmd) => {
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/admin/cli')
+        .send({ publicKey: validKey, command: cmd });
+      expect(response.status).toBe(400);
+      expect(response.body.code).toBe('DANGER_CONFIRM_REQUIRED');
+      expect(meshcoreManager.sendCliCommand).not.toHaveBeenCalled();
+    });
+
+    it('accepts a danger command when confirm=true', async () => {
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/admin/cli')
+        .send({ publicKey: validKey, command: 'reboot', confirm: true });
+      expect(response.status).toBe(200);
+      expect(meshcoreManager.sendCliCommand).toHaveBeenCalledWith(validKey, 'reboot', {
+        timeoutMs: undefined,
+      });
+    });
+
+    it('does not require confirm for non-danger commands', async () => {
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/admin/cli')
+        .send({ publicKey: validKey, command: 'stats' });
+      expect(response.status).toBe(200);
+    });
   });
 
   describe('GET /api/sources/test-source/meshcore/admin/credentials-capability', () => {

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -853,8 +853,9 @@ router.get('/admin/credentials-capability', requireAuth(), requirePermission('re
   try {
     const sourceId = req.params.id!;
     const store = getMeshCoreCredentialStore();
-    const rotatedAll = await store.listRotated();
+    const [rotatedAll, storedAll] = await Promise.all([store.listRotated(), store.listStored()]);
     const rotated = rotatedAll.filter((r) => r.sourceId === sourceId);
+    const stored = storedAll.filter((s) => s.sourceId === sourceId);
     res.json({
       success: true,
       data: {
@@ -862,11 +863,75 @@ router.get('/admin/credentials-capability', requireAuth(), requirePermission('re
         reason: store.capability.reason,
         rotatedCount: rotated.length,
         rotated: rotated.map((r) => ({ publicKey: r.publicKey, name: r.name })),
+        stored: stored.map((s) => ({ publicKey: s.publicKey, name: s.name })),
       },
     });
   } catch (error) {
     logger.error('[API] Error reading credentials capability:', error);
     res.status(500).json({ success: false, error: 'Capability lookup failed' });
+  }
+});
+
+/**
+ * POST /api/meshcore/admin/login-with-saved
+ *
+ * Auto-login using a previously-saved admin credential. The console
+ * triggers this on mount when the capability endpoint reports a non-
+ * rotated stored credential for the target contact, so the user doesn't
+ * have to re-enter the password every session.
+ *
+ * SECURITY INVARIANT — the saved plaintext password NEVER leaves this
+ * process. The flow is:
+ *     1. Client sends only { publicKey }. No password.
+ *     2. Server reads the encrypted envelope from the DB and decrypts
+ *        it server-side via MeshCoreCredentialStore.
+ *     3. Server passes the plaintext to MeshCoreManager.loginToNode
+ *        IN-PROCESS — it is used to derive the per-contact shared
+ *        secret and discarded.
+ *     4. Server returns only { success, usedStored, code } — never
+ *        the plaintext, never the envelope, never the key fingerprint
+ *        (the fingerprint is opaque metadata, but still kept off the
+ *        client because exposing it would let a hostile script enumerate
+ *        SESSION_SECRET rotations).
+ *
+ * Response codes:
+ *   404 NO_STORED_CREDENTIAL — nothing saved for this (source, pubkey).
+ *   410 CREDENTIAL_KEY_ROTATED — SESSION_SECRET changed since the
+ *       password was saved; client should clear and prompt fresh.
+ *   401 STORED_CREDENTIAL_REJECTED — credential decrypted but the remote
+ *       rejected the login (remote's admin password probably changed).
+ */
+router.post('/admin/login-with-saved', meshcoreDeviceLimiter, requireAuth(), requirePermission('remote_admin', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+  try {
+    const { publicKey } = req.body as { publicKey?: string };
+    if (typeof publicKey !== 'string' || !isValidPublicKey(publicKey)) {
+      return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
+    }
+    const sourceId = req.params.id!;
+    const store = getMeshCoreCredentialStore();
+    const result = await store.load(sourceId, publicKey);
+    if (result.kind === 'none') {
+      return res.status(404).json({ success: false, error: 'No saved credential for this node', code: 'NO_STORED_CREDENTIAL' });
+    }
+    if (result.kind === 'key_rotated') {
+      return res.status(410).json({
+        success: false,
+        error: 'Saved credential was encrypted with a previous SESSION_SECRET',
+        code: 'CREDENTIAL_KEY_ROTATED',
+        // Deliberately NOT echoing result.storedKid back to the client —
+        // an attacker shouldn't be able to enumerate prior fingerprints.
+      });
+    }
+    // result.password is intentionally consumed in-process only; do not
+    // log it, do not echo it, do not include it in any response field.
+    const ok = await managerFor(req).loginToNode(publicKey, result.password);
+    if (!ok) {
+      return res.status(401).json({ success: false, error: 'Saved credential rejected by the remote', code: 'STORED_CREDENTIAL_REJECTED' });
+    }
+    res.json({ success: true, usedStored: true });
+  } catch (error) {
+    logger.error('[API] Error in login-with-saved:', error);
+    res.status(500).json({ success: false, error: 'Login error' });
   }
 });
 

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -88,6 +88,15 @@ const VALIDATION = {
 } as const;
 
 /**
+ * Destructive MeshCore CLI commands. Requests targeting any matching
+ * command must carry `confirm: true` in the body or the /admin/cli route
+ * rejects with DANGER_CONFIRM_REQUIRED. Keep in sync with the matching
+ * pattern in MeshCoreRemoteConsole.tsx so the client knows which commands
+ * to route through its typed-name confirmation modal.
+ */
+const DANGER_COMMAND_PATTERN = /(reboot|erase|clkreboot|factory)/i;
+
+/**
  * Validation helper functions
  */
 function isValidPublicKey(key: string | undefined): boolean {
@@ -771,10 +780,11 @@ router.post('/admin/login', meshcoreDeviceLimiter, requireAuth(), requirePermiss
  */
 router.post('/admin/cli', meshcoreDeviceLimiter, requireAuth(), requirePermission('remote_admin', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
-    const { publicKey, command, timeoutMs } = req.body as {
+    const { publicKey, command, timeoutMs, confirm } = req.body as {
       publicKey?: string;
       command?: string;
       timeoutMs?: number;
+      confirm?: boolean;
     };
 
     if (typeof publicKey !== 'string' || !isValidPublicKey(publicKey)) {
@@ -787,6 +797,18 @@ router.post('/admin/cli', meshcoreDeviceLimiter, requireAuth(), requirePermissio
       // LoRa packet MTU ceiling — anything larger will be truncated by the
       // firmware. Reject up front so the user gets a clear error.
       return res.status(400).json({ success: false, error: 'command too long (max 230 bytes)' });
+    }
+    // Defense-in-depth danger guard. The frontend opens a typed-name
+    // confirmation modal for these commands, but server-side enforcement
+    // means scripts and direct API calls cannot bypass the prompt by
+    // simply not rendering it. Keep the pattern in sync with the
+    // client-side DANGER_COMMAND_PATTERN in MeshCoreRemoteConsole.tsx.
+    if (DANGER_COMMAND_PATTERN.test(command) && confirm !== true) {
+      return res.status(400).json({
+        success: false,
+        error: 'Destructive command requires confirm:true in the request body',
+        code: 'DANGER_CONFIRM_REQUIRED',
+      });
     }
     const effectiveTimeout =
       typeof timeoutMs === 'number' && Number.isFinite(timeoutMs) && timeoutMs > 0 && timeoutMs <= 60_000

--- a/src/server/services/meshcoreCredentialStore.test.ts
+++ b/src/server/services/meshcoreCredentialStore.test.ts
@@ -153,6 +153,33 @@ describe('MeshCoreCredentialStore', () => {
       expect(result.kind).toBe('key_rotated');
     });
 
+    it('listStored returns only entries whose kid matches the current secret', async () => {
+      const original = new MeshCoreCredentialStore('a'.repeat(64), true);
+      await original.store(SOURCE_A, PUBKEY_1, 'pw1');
+      await original.store(SOURCE_A, PUBKEY_2, 'pw2');
+
+      const stored = await original.listStored();
+      expect(stored).toHaveLength(2);
+      expect(stored.map((s) => s.publicKey).sort()).toEqual([PUBKEY_1, PUBKEY_2].sort());
+      for (const entry of stored) {
+        expect(entry.sourceId).toBe(SOURCE_A);
+      }
+
+      // Rotate → listStored now empty (everything is rotated).
+      const rotated = new MeshCoreCredentialStore('b'.repeat(64), true);
+      expect(await rotated.listStored()).toEqual([]);
+    });
+
+    it('listStored and listRotated are mutually exclusive for any given row', async () => {
+      const original = new MeshCoreCredentialStore('a'.repeat(64), true);
+      await original.store(SOURCE_A, PUBKEY_1, 'pw1');
+
+      const storedKeys = (await original.listStored()).map((s) => s.publicKey);
+      const rotatedKeys = (await original.listRotated()).map((r) => r.publicKey);
+      const intersection = storedKeys.filter((k) => rotatedKeys.includes(k));
+      expect(intersection).toEqual([]);
+    });
+
     it('listRotated returns only entries whose kid does not match the current secret', async () => {
       const original = new MeshCoreCredentialStore('a'.repeat(64), true);
       await original.store(SOURCE_A, PUBKEY_1, 'pw1');

--- a/src/server/services/meshcoreCredentialStore.ts
+++ b/src/server/services/meshcoreCredentialStore.ts
@@ -63,6 +63,12 @@ export interface RotatedCredentialEntry {
   storedKid: string;
 }
 
+export interface StoredCredentialEntry {
+  sourceId: string;
+  publicKey: string;
+  name: string | null;
+}
+
 export class MeshCoreCredentialStore {
   private readonly aeadKey: Buffer;
   private readonly currentKid: string;
@@ -211,6 +217,35 @@ export class MeshCoreCredentialStore {
           publicKey: row.publicKey,
           name: row.name,
           storedKid: env.kid ?? '?',
+        });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Enumerate every stored credential whose envelope CAN be decrypted by
+   * the current SESSION_SECRET (i.e. kid matches + KDF version current).
+   * The UI uses this on console mount to decide whether to silently
+   * attempt an auto-login or prompt for a password.
+   *
+   * Returns only metadata — never the password or the envelope itself.
+   */
+  async listStored(): Promise<StoredCredentialEntry[]> {
+    const rows = await databaseService.meshcore.listAdminCredentials();
+    const out: StoredCredentialEntry[] = [];
+    for (const row of rows) {
+      let env: StoredEnvelope;
+      try {
+        env = JSON.parse(row.adminCredential) as StoredEnvelope;
+      } catch {
+        continue;
+      }
+      if (env.v === KDF_VERSION && env.kid === this.currentKid) {
+        out.push({
+          sourceId: row.sourceId,
+          publicKey: row.publicKey,
+          name: row.name,
         });
       }
     }


### PR DESCRIPTION
## Summary

Phase 4 of the MeshCore remote-administration feature (Phase 1–3 in #3160).

- **Structured stats panel** rendered inside the remote console: uptime, battery, queue, last RSSI/SNR, noise floor, air time, errors, RX/TX flood/direct/dups. Auto-refresh every 30s while mounted, manual refresh button, collapsible.
- **Quick-action buttons** for the common safe commands (`ver`, `stats`, `neighbors`, `clock`, `clock sync`, `advert`) plus a danger button for `reboot`. Clicking pre-fills the input — the user must press Send to actually invoke.
- **Danger-command guard** (both client and server): commands matching \`/(reboot|erase|clkreboot|factory)/i\` route through a typed-name confirmation modal client-side, and `/admin/cli` rejects them with \`DANGER_CONFIRM_REQUIRED\` server-side unless `confirm: true` is in the body. The user typing \`reboot\` free-form into the input triggers the same prompt as clicking the danger button.

## Files

- `src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx` + `.css` — new stats panel.
- `src/components/MeshCore/MeshCoreRemoteConsole.tsx` + `.css` — quick-action button row, danger-confirm modal, wires the stats panel.
- `src/components/MeshCore/hooks/useMeshCore.ts` — new `getRemoteStatus()` action; `sendCliCommand` takes an optional `confirm` flag.
- `src/components/MeshCore/MeshCoreContactDetailPanel.tsx` + `MeshCoreDirectMessagesView.tsx` — pass `getRemoteStatus` through to the console.
- `src/server/routes/meshcoreRoutes.ts` — `DANGER_COMMAND_PATTERN` + the server-side guard in \`POST /admin/cli\`.

## Why client-side AND server-side enforcement?

The client-side confirmation modal is the natural UX. The server-side guard exists so scripts hitting the API directly (or a malicious browser extension stripping the modal) still get the prompt-as-requirement. Keeping the regex literal in both places — with comments pointing to each other — is the simplest way to avoid drift; if you change one, the test \`it.each([['reboot'],['Reboot'],['erase'],['clkreboot'],['factory reset'],['set factory mode']])\` will catch a missed update on either side.

## Test plan

- [x] \`npx vitest run\` — 10425 tests pass, 0 failures.
- [x] \`npx tsc --noEmit\` clean (server + frontend).
- [x] ESLint clean on changed files.
- [x] 8 new route tests in \`meshcoreRoutes.test.ts\` cover: every danger command pattern rejected without confirm, \`confirm: true\` allowed through, non-danger commands unaffected.
- [ ] **Manual dev-container smoke test against a real Repeater — deferred.** Stats panel uses the existing \`/admin/status\` route already exercised in #3160; quick-action buttons just pre-fill the input that's already in #3160; the only genuinely new wire interaction is danger commands flowing through with \`confirm: true\`, which is a single-byte server-side check.
- [ ] CI green (will monitor via \`/ci-monitor\`).

## What's NOT in this PR (deliberately deferred)

- **Configuration form** (Phase 4b): read/write of name, advert interval, radio params, TX power, location via \`get <key>\`/\`set <key> <value>\`. Bigger surface area; deserves its own PR.
- **Phase 5 — ACL management UI** (\`get acl\`, \`setperm <pubkey> <level>\`).
- **Audit-log entries per CLI command** (Phase 6 polish): the permission middleware already audits the route call; per-command rows would need explicit logging.
- **Command autocomplete** — the quick-action buttons cover the most common commands, and the input is free-form for anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)