### PR TITLE
feat(meshcore): local-device CLI console in configuration view

### DIFF
--- a/src/components/MeshCore/CliConsoleBody.tsx
+++ b/src/components/MeshCore/CliConsoleBody.tsx
@@ -1,0 +1,311 @@
+/**
+ * CliConsoleBody — shared MeshCore CLI surface.
+ *
+ * Owns the transcript, command input, quick-action button row, and the
+ * danger-confirm modal. Used by both `MeshCoreRemoteConsole` (where the
+ * parent layers login + credential capability on top) and
+ * `MeshCoreLocalConsole` (where the parent layers nothing — the local
+ * node has no admin password).
+ *
+ * The parent passes:
+ *  - `runCommand(text, { confirm? })` — actually sends to the wire.
+ *  - `actionCatalog` — quick-action buttons. Danger items route through
+ *    the typed-name confirmation modal.
+ *  - `targetName` — the literal string the user types to unlock danger
+ *    commands. Remote console uses the contact name; local console uses
+ *    the device name (or "this device" when none is set).
+ *  - `disabled` — disables the input and action buttons (e.g. remote
+ *    console passes `!loggedIn`).
+ *
+ * The parent can also push info lines into the transcript via the
+ * imperative ref handle (used by remote console to log
+ * "Logged in with saved password" after auto-login).
+ */
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import './MeshCoreRemoteConsole.css';
+
+export interface ActionCommand {
+  key: string;
+  labelKey: string;
+  defaultLabel: string;
+  command: string;
+  danger?: boolean;
+}
+
+/** Server-enforced regex for danger commands. Mirrored from
+ *  meshcoreRoutes.ts:DANGER_COMMAND_PATTERN; keep in sync. */
+export const DANGER_COMMAND_PATTERN = /(reboot|erase|clkreboot|factory)/i;
+
+export type CliRunResult =
+  | { ok: true; reply: string; elapsedMs?: number }
+  | { ok: false; error: string; code?: string };
+
+export interface CliConsoleBodyHandle {
+  /** Append an info-style line to the transcript (e.g. "Logged in"). */
+  appendInfo: (text: string) => void;
+  /** Clear the transcript. */
+  clear: () => void;
+}
+
+interface TranscriptEntry {
+  id: string;
+  kind: 'sent' | 'reply' | 'error' | 'info';
+  text: string;
+  ts: number;
+}
+
+interface CliConsoleBodyProps {
+  /** Stable identifier for the target — when this changes, transcript
+   *  resets. Remote uses publicKey; local uses sourceId. */
+  targetId: string;
+  /** Literal string the user must type into the danger-confirm modal
+   *  to unlock the action. */
+  targetName: string;
+  /** Send the command. The console handles transcript bookkeeping. */
+  runCommand: (command: string, opts?: { confirm?: boolean }) => Promise<CliRunResult>;
+  /** Quick-action buttons. Empty array → no row. */
+  actionCatalog: ActionCommand[];
+  /** When true, the input row and action buttons are disabled. */
+  disabled?: boolean;
+  /** Placeholder for the input row when disabled. */
+  disabledPlaceholder?: string;
+  /** Placeholder for the input row when enabled. */
+  placeholder?: string;
+  /** Empty-transcript text when disabled. */
+  emptyTextDisabled?: string;
+  /** Empty-transcript text when enabled. */
+  emptyTextEnabled?: string;
+}
+
+const nextId = (() => {
+  let counter = 0;
+  return () => `${Date.now()}-${counter++}`;
+})();
+
+export const CliConsoleBody = forwardRef<CliConsoleBodyHandle, CliConsoleBodyProps>(function CliConsoleBody(
+  {
+    targetId,
+    targetName,
+    runCommand,
+    actionCatalog,
+    disabled = false,
+    disabledPlaceholder,
+    placeholder,
+    emptyTextDisabled,
+    emptyTextEnabled,
+  },
+  ref,
+) {
+  const { t } = useTranslation();
+  const [transcript, setTranscript] = useState<TranscriptEntry[]>([]);
+  const [command, setCommand] = useState('');
+  const [sending, setSending] = useState(false);
+  const [dangerConfirm, setDangerConfirm] = useState<null | { command: string; typedName: string }>(null);
+  const transcriptEndRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    transcriptEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  }, [transcript]);
+
+  // Reset transcript whenever the target changes — a stale transcript
+  // labelled with a different target would be confusing.
+  useEffect(() => {
+    setTranscript([]);
+    setCommand('');
+    setDangerConfirm(null);
+  }, [targetId]);
+
+  const appendTranscript = useCallback((entry: Omit<TranscriptEntry, 'id' | 'ts'>) => {
+    setTranscript((prev) => [...prev, { id: nextId(), ts: Date.now(), ...entry }]);
+  }, []);
+
+  useImperativeHandle(ref, () => ({
+    appendInfo: (text: string) => appendTranscript({ kind: 'info', text }),
+    clear: () => setTranscript([]),
+  }), [appendTranscript]);
+
+  const runAndLog = useCallback(async (cmd: string, opts?: { confirm?: boolean }) => {
+    if (sending) return;
+    setSending(true);
+    appendTranscript({ kind: 'sent', text: cmd });
+    setCommand('');
+    const result = await runCommand(cmd, opts);
+    setSending(false);
+    if (result.ok) {
+      appendTranscript({ kind: 'reply', text: result.reply || '(empty reply)' });
+    } else {
+      const hint =
+        result.code === 'CLI_TIMEOUT'
+          ? t(
+              'meshcore.remoteConsole.timeout_hint',
+              ' — the remote did not reply. Path may be stale, or the admin session may have expired.',
+            )
+          : '';
+      appendTranscript({ kind: 'error', text: `${result.error}${hint}` });
+    }
+  }, [appendTranscript, runCommand, sending, t]);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = command.trim();
+    if (!trimmed || sending) return;
+    if (DANGER_COMMAND_PATTERN.test(trimmed)) {
+      setDangerConfirm({ command: trimmed, typedName: '' });
+      return;
+    }
+    await runAndLog(trimmed);
+  }, [command, runAndLog, sending]);
+
+  const handleActionClick = useCallback((action: ActionCommand) => {
+    if (action.danger) {
+      setDangerConfirm({ command: action.command, typedName: '' });
+      return;
+    }
+    setCommand(action.command);
+  }, []);
+
+  const handleDangerConfirm = useCallback(async () => {
+    if (!dangerConfirm) return;
+    const cmd = dangerConfirm.command;
+    setDangerConfirm(null);
+    await runAndLog(cmd, { confirm: true });
+  }, [dangerConfirm, runAndLog]);
+
+  return (
+    <>
+      {actionCatalog.length > 0 && (
+        <div className="mrc-quick-actions" role="group" aria-label={t('meshcore.remoteConsole.quick_actions', 'Quick actions')}>
+          {actionCatalog.map((action) => (
+            <button
+              key={action.key}
+              type="button"
+              className={action.danger ? 'mrc-btn-danger' : 'mrc-btn-quick'}
+              onClick={() => handleActionClick(action)}
+              disabled={disabled || sending}
+              title={action.command}
+            >
+              {t(action.labelKey, action.defaultLabel)}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="mrc-transcript" role="log" aria-live="polite">
+        {transcript.length === 0 ? (
+          <p className="mrc-transcript-empty">
+            {disabled
+              ? emptyTextDisabled ?? t('meshcore.remoteConsole.empty_logged_out', 'Log in to begin sending commands.')
+              : emptyTextEnabled ?? t('meshcore.remoteConsole.empty_logged_in', 'Type a command below and press Send.')}
+          </p>
+        ) : (
+          transcript.map((entry) => (
+            <div key={entry.id} className={`mrc-line mrc-line-${entry.kind}`}>
+              <span className="mrc-line-prefix">{prefixFor(entry.kind)}</span>
+              <pre className="mrc-line-text">{entry.text}</pre>
+            </div>
+          ))
+        )}
+        <div ref={transcriptEndRef} />
+      </div>
+
+      <form
+        className="mrc-input-row"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void handleSend();
+        }}
+      >
+        <input
+          type="text"
+          value={command}
+          onChange={(e) => setCommand(e.target.value)}
+          placeholder={
+            disabled
+              ? disabledPlaceholder ?? t('meshcore.remoteConsole.command_placeholder_logged_out', 'Log in first')
+              : placeholder ?? t('meshcore.remoteConsole.command_placeholder', 'Type a command (e.g. ver, stats, neighbors)')
+          }
+          disabled={disabled || sending}
+          className="mrc-input"
+          spellCheck={false}
+          autoComplete="off"
+        />
+        <button
+          type="submit"
+          disabled={disabled || sending || command.trim().length === 0}
+          className="mrc-btn-primary"
+        >
+          {sending
+            ? t('meshcore.remoteConsole.sending', 'Sending…')
+            : t('meshcore.remoteConsole.send', 'Send')}
+        </button>
+      </form>
+
+      {dangerConfirm && (
+        <div
+          className="mrc-modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="mrc-danger-title"
+          onClick={() => setDangerConfirm(null)}
+        >
+          <div className="mrc-modal mrc-modal-danger" onClick={(e) => e.stopPropagation()}>
+            <h4 id="mrc-danger-title">
+              {t('meshcore.remoteConsole.danger_modal_title', 'Confirm destructive command')}
+            </h4>
+            <p className="mrc-modal-body">
+              {t(
+                'meshcore.remoteConsole.danger_modal_body',
+                'You are about to send "{{command}}" to {{name}}. This action may interrupt the remote node. Type the contact name to confirm:',
+                { command: dangerConfirm.command, name: targetName },
+              )}
+            </p>
+            <input
+              type="text"
+              value={dangerConfirm.typedName}
+              onChange={(e) => setDangerConfirm({ ...dangerConfirm, typedName: e.target.value })}
+              className="mrc-input"
+              autoFocus
+              spellCheck={false}
+              autoComplete="off"
+              placeholder={targetName}
+            />
+            <div className="mrc-modal-actions">
+              <button
+                type="button"
+                className="mrc-btn-secondary"
+                onClick={() => setDangerConfirm(null)}
+              >
+                {t('meshcore.remoteConsole.cancel', 'Cancel')}
+              </button>
+              <button
+                type="button"
+                className="mrc-btn-danger"
+                onClick={() => void handleDangerConfirm()}
+                disabled={dangerConfirm.typedName !== targetName}
+              >
+                {t('meshcore.remoteConsole.danger_confirm', 'Send {{command}}', { command: dangerConfirm.command })}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+});
+
+function prefixFor(kind: TranscriptEntry['kind']): string {
+  switch (kind) {
+    case 'sent': return '>';
+    case 'reply': return '<';
+    case 'error': return '!';
+    case 'info': return '*';
+  }
+}

--- a/src/components/MeshCore/MeshCoreConfigurationView.tsx
+++ b/src/components/MeshCore/MeshCoreConfigurationView.tsx
@@ -4,6 +4,7 @@ import { ConnectionStatus, MeshCoreActions, TelemetryMode } from './hooks/useMes
 import { RADIO_PRESETS, findPresetId } from './radioPresets';
 import { useAuth } from '../../contexts/AuthContext';
 import { MeshCoreChannelsConfigSection } from './MeshCoreChannelsConfigSection';
+import { MeshCoreLocalConsole } from './MeshCoreLocalConsole';
 
 const TELEMETRY_MODE_OPTIONS: TelemetryMode[] = ['always', 'device', 'never'];
 // MeshCore device types: COMPANION=1, REPEATER=2, ROOM_SERVER=3.
@@ -456,6 +457,19 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
           baseUrl={baseUrl}
           sourceId={sourceId}
           canWrite={connected && canWriteConfig}
+        />
+      )}
+
+      {/* Local CLI console — gated on configuration:write (matches the
+          form fields above) and per-source via the route. Available for
+          all firmware types; the catalog adapts. */}
+      {sourceId && canWriteConfig && (
+        <MeshCoreLocalConsole
+          sourceId={sourceId}
+          deviceName={local?.name}
+          deviceType={local?.advType}
+          connected={connected}
+          actions={{ sendLocalCliCommand: actions.sendLocalCliCommand }}
         />
       )}
     </div>

--- a/src/components/MeshCore/MeshCoreLocalConsole.tsx
+++ b/src/components/MeshCore/MeshCoreLocalConsole.tsx
@@ -1,0 +1,137 @@
+/**
+ * MeshCoreLocalConsole
+ *
+ * Console for the LOCALLY connected MeshCore node. Mounted from the
+ * MeshCore configuration view so a user can poke at the device they're
+ * directly attached to (the same way they'd use the remote console for
+ * a distant repeater).
+ *
+ * No auth / credential layer — the connection is physical (USB serial or
+ * direct TCP), so there is no admin password concept. The HTTP route
+ * separately gates this on `configuration:write`.
+ *
+ * Behavior is driven by the connected firmware (server-side dispatch in
+ * MeshCoreManager.sendLocalCliCommand):
+ *   - Repeater / Room Server → device's native text CLI.
+ *   - Companion → small synthetic CLI (ver, stats, clock, advert, help).
+ *
+ * The command catalog adapts to the device type so users see buttons for
+ * commands that actually work on their hardware.
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { MeshCoreActions } from './hooks/useMeshCore';
+import { CliConsoleBody, type ActionCommand } from './CliConsoleBody';
+import './MeshCoreRemoteConsole.css';
+
+/** Verbs that the synthetic Companion CLI implements. Keep in sync with
+ *  MeshCoreManager.runSyntheticLocalCli. */
+const COMPANION_ACTION_CATALOG: ActionCommand[] = [
+  { key: 'ver',    labelKey: 'meshcore.localConsole.action.ver',    defaultLabel: 'Version', command: 'ver' },
+  { key: 'stats',  labelKey: 'meshcore.localConsole.action.stats',  defaultLabel: 'Stats',   command: 'stats' },
+  { key: 'clock',  labelKey: 'meshcore.localConsole.action.clock',  defaultLabel: 'Clock',   command: 'clock' },
+  { key: 'advert', labelKey: 'meshcore.localConsole.action.advert', defaultLabel: 'Send advert', command: 'advert' },
+  { key: 'help',   labelKey: 'meshcore.localConsole.action.help',   defaultLabel: 'Help',    command: 'help' },
+];
+
+/** Repeater / Room Server firmware: the native serial CLI handles a
+ *  much larger command set. We surface the same safe verbs as the
+ *  remote-Repeater console for consistency, plus a danger Reboot. */
+const REPEATER_ACTION_CATALOG: ActionCommand[] = [
+  { key: 'ver',       labelKey: 'meshcore.remoteConsole.action.ver',       defaultLabel: 'Version',  command: 'ver' },
+  { key: 'stats',     labelKey: 'meshcore.remoteConsole.action.stats',     defaultLabel: 'Stats',    command: 'stats' },
+  { key: 'neighbors', labelKey: 'meshcore.remoteConsole.action.neighbors', defaultLabel: 'Neighbors', command: 'neighbors' },
+  { key: 'clock',     labelKey: 'meshcore.remoteConsole.action.clock',     defaultLabel: 'Clock',    command: 'clock' },
+  { key: 'advert',    labelKey: 'meshcore.remoteConsole.action.advert',    defaultLabel: 'Send advert', command: 'advert' },
+  { key: 'reboot',    labelKey: 'meshcore.remoteConsole.action.reboot',    defaultLabel: 'Reboot',   command: 'reboot', danger: true },
+];
+
+interface MeshCoreLocalConsoleProps {
+  /** Display name of the local device — shown in the danger-confirm
+   *  modal. Falls back to "this device" when no name is set. */
+  deviceName?: string;
+  /** Owning source id — used as the targetId so the transcript resets
+   *  when the user switches sources. */
+  sourceId: string;
+  /** MeshCore device type from status.deviceType (0=Unknown, 1=Companion,
+   *  2=Repeater, 3=RoomServer). Drives the command catalog. */
+  deviceType?: number;
+  /** Whether the source is currently connected. Disables the console
+   *  when false — sending to a disconnected source would just timeout. */
+  connected: boolean;
+  actions: Pick<MeshCoreActions, 'sendLocalCliCommand'>;
+}
+
+export const MeshCoreLocalConsole: React.FC<MeshCoreLocalConsoleProps> = ({
+  deviceName,
+  sourceId,
+  deviceType,
+  connected,
+  actions,
+}) => {
+  const { t } = useTranslation();
+
+  const targetName = deviceName || t('meshcore.localConsole.default_target', 'this device');
+
+  // Repeater (2) and RoomServer (3) share the same catalog. Companion (1)
+  // gets the synthetic catalog. Unknown (0) shows no quick actions —
+  // the user can still type free-form commands.
+  const actionCatalog = useMemo<ActionCommand[]>(() => {
+    if (deviceType === 2 || deviceType === 3) return REPEATER_ACTION_CATALOG;
+    if (deviceType === 1) return COMPANION_ACTION_CATALOG;
+    return [];
+  }, [deviceType]);
+
+  const runCommand = useCallback(
+    (text: string, opts?: { confirm?: boolean }) => actions.sendLocalCliCommand(text, opts),
+    [actions],
+  );
+
+  return (
+    <section className="meshcore-remote-console" aria-label={t('meshcore.localConsole.title', 'Device console')}>
+      <header className="mrc-header">
+        <h3 className="mrc-title">{t('meshcore.localConsole.title', 'Device console')}</h3>
+        <div className="mrc-status">
+          {connected ? (
+            <span className="mrc-status-chip mrc-status-ok">
+              {t('meshcore.localConsole.connected', 'Connected')}
+            </span>
+          ) : (
+            <span className="mrc-status-chip mrc-status-idle">
+              {t('meshcore.localConsole.disconnected', 'Not connected')}
+            </span>
+          )}
+        </div>
+      </header>
+
+      <CliConsoleBody
+        targetId={sourceId}
+        targetName={targetName}
+        runCommand={runCommand}
+        actionCatalog={connected ? actionCatalog : []}
+        disabled={!connected}
+        disabledPlaceholder={t('meshcore.localConsole.disconnected_placeholder', 'Connect the source to send commands')}
+        placeholder={
+          deviceType === 1
+            ? t(
+                'meshcore.localConsole.companion_placeholder',
+                'Type a command (ver, stats, clock, advert, help)',
+              )
+            : t(
+                'meshcore.localConsole.repeater_placeholder',
+                'Type a CLI command (ver, stats, neighbors, advert…)',
+              )
+        }
+        emptyTextDisabled={t(
+          'meshcore.localConsole.empty_disconnected',
+          'Connect the source to begin sending commands.',
+        )}
+        emptyTextEnabled={t(
+          'meshcore.localConsole.empty_connected',
+          'Type a command below and press Send.',
+        )}
+      />
+    </section>
+  );
+};

--- a/src/components/MeshCore/MeshCoreRemoteConsole.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.tsx
@@ -2,46 +2,36 @@
  * MeshCoreRemoteConsole
  *
  * Interactive remote-administration console for a single MeshCore contact
- * (Repeater or Room Server). Renders inside MeshCoreContactDetailPanel
- * when the selected contact's advType warrants it.
+ * (Repeater or Room Server). Mounted by MeshCoreContactDetailPanel when
+ * the user has `remote_admin:write` on the source.
  *
- * Wire model — see docs/internal/dev-notes/ARCHITECTURE_LESSONS.md and the
- * meshcoreCredentialStore service for the full design. In short:
- *   - "Login" sends CMD_SEND_LOGIN with the user-supplied password. The
- *     server may also persist that password (AES-256-GCM, see
- *     MeshCoreCredentialStore) when `rememberPassword=true` and
- *     SESSION_SECRET is explicitly configured.
- *   - "Send" issues a CLI command as an encrypted DM with txtType=CliData
- *     and shows the single-packet reply in the transcript.
- *   - A KEY_ROTATED banner appears when this contact has a stored
- *     credential that no longer decrypts under the current SESSION_SECRET.
+ * Responsibilities owned here (vs. CliConsoleBody, the shared primitive):
+ *  - Login modal (manual login + "remember password" checkbox).
+ *  - Capability fetch — disables remember when SESSION_SECRET is auto-
+ *    generated.
+ *  - Auto-login on mount when a non-rotated stored credential exists.
+ *  - KEY_ROTATED banner + "Forget stored password" action.
+ *  - Stats panel mounting (only once logged in).
+ *
+ * Wire model: see meshcoreCredentialStore + POST /admin/login-with-saved
+ * for the security invariant that the saved plaintext password never
+ * leaves the server process.
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { MeshCoreActions } from './hooks/useMeshCore';
 import { MeshCoreRemoteStatsPanel } from './MeshCoreRemoteStatsPanel';
+import { CliConsoleBody, type ActionCommand, type CliConsoleBodyHandle } from './CliConsoleBody';
 import './MeshCoreRemoteConsole.css';
 
 /**
- * Catalog of one-click CLI commands surfaced as buttons in the console.
+ * Quick-action catalog for remote Repeater / Room Server contacts.
  * Clicking a button pre-fills the command input — it does NOT auto-send,
- * so the user can edit before pressing Send and so danger commands route
- * through the confirmation modal naturally.
- *
- * `danger: true` triggers the typed-name confirmation modal and also gets
- * server-side enforcement via the DANGER_CONFIRM_REQUIRED guard in the
- * /admin/cli route.
+ * so the user can edit before pressing Send and danger commands route
+ * through the typed-name confirmation modal naturally.
  */
-interface ActionCommand {
-  key: string;
-  labelKey: string;
-  defaultLabel: string;
-  command: string;
-  danger?: boolean;
-}
-
-const ACTION_CATALOG: ActionCommand[] = [
+const REMOTE_ACTION_CATALOG: ActionCommand[] = [
   { key: 'ver',       labelKey: 'meshcore.remoteConsole.action.ver',       defaultLabel: 'Version',  command: 'ver' },
   { key: 'stats',     labelKey: 'meshcore.remoteConsole.action.stats',     defaultLabel: 'Stats',    command: 'stats' },
   { key: 'neighbors', labelKey: 'meshcore.remoteConsole.action.neighbors', defaultLabel: 'Neighbors', command: 'neighbors' },
@@ -50,18 +40,6 @@ const ACTION_CATALOG: ActionCommand[] = [
   { key: 'advert',    labelKey: 'meshcore.remoteConsole.action.advert',    defaultLabel: 'Send advert', command: 'advert' },
   { key: 'reboot',    labelKey: 'meshcore.remoteConsole.action.reboot',    defaultLabel: 'Reboot',   command: 'reboot', danger: true },
 ];
-
-/** Server-enforced regex for danger commands. Keep this in sync with the
- *  identically-named pattern in meshcoreRoutes.ts so the client can decide
- *  to open the confirmation modal even for free-typed commands. */
-const DANGER_COMMAND_PATTERN = /(reboot|erase|clkreboot|factory)/i;
-
-interface TranscriptEntry {
-  id: string;
-  kind: 'sent' | 'reply' | 'error' | 'info';
-  text: string;
-  ts: number;
-}
 
 interface CapabilitySnapshot {
   canRemember: boolean;
@@ -74,10 +52,8 @@ interface CapabilitySnapshot {
 interface MeshCoreRemoteConsoleProps {
   /** Full 64-char hex public key of the target contact. */
   publicKey: string;
-  /** Display name (for log lines). */
+  /** Display name (for log lines and the danger-confirm modal). */
   contactName: string;
-  /** Action callbacks from useMeshCore. We pull only the four we need so
-   *  this component is easy to host in tests without a full hook. */
   actions: Pick<
     MeshCoreActions,
     | 'loginRemote'
@@ -89,11 +65,6 @@ interface MeshCoreRemoteConsoleProps {
   >;
 }
 
-const nextId = (() => {
-  let counter = 0;
-  return () => `${Date.now()}-${counter++}`;
-})();
-
 export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
   publicKey,
   contactName,
@@ -102,38 +73,24 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
   const { t } = useTranslation();
   const [capability, setCapability] = useState<CapabilitySnapshot | null>(null);
   const [loggedIn, setLoggedIn] = useState(false);
-  const [transcript, setTranscript] = useState<TranscriptEntry[]>([]);
-  const [command, setCommand] = useState('');
-  const [sending, setSending] = useState(false);
   const [showLogin, setShowLogin] = useState(false);
   const [loginPassword, setLoginPassword] = useState('');
   const [rememberPassword, setRememberPassword] = useState(false);
   const [loginBusy, setLoginBusy] = useState(false);
   const [loginError, setLoginError] = useState<string | null>(null);
 
-  // Danger-command confirmation state. Set when the user clicks a danger
-  // button OR presses Send while the typed command matches the danger
-  // regex. Stays null until the user explicitly opens the flow.
-  const [dangerConfirm, setDangerConfirm] = useState<null | { command: string; typedName: string }>(null);
+  // Imperative handle into the body — used to push "Logged in" info
+  // lines into the transcript without lifting transcript state.
+  const bodyRef = useRef<CliConsoleBodyHandle | null>(null);
 
-  const transcriptEndRef = useRef<HTMLDivElement | null>(null);
-
-  // Auto-scroll the transcript when new entries arrive.
-  useEffect(() => {
-    transcriptEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
-  }, [transcript]);
-
-  // Reset state whenever the targeted contact changes — a stale "logged
+  // Reset auth state when the targeted contact changes — a stale "logged
   // in" badge against the wrong contact would be actively misleading.
   useEffect(() => {
     setLoggedIn(false);
-    setTranscript([]);
-    setCommand('');
     setShowLogin(false);
     setLoginPassword('');
     setRememberPassword(false);
     setLoginError(null);
-    setDangerConfirm(null);
   }, [publicKey]);
 
   const refreshCapability = useCallback(async () => {
@@ -144,8 +101,7 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
 
   // On mount (and on contact change): fetch capability, and if this
   // contact has a non-rotated stored credential, silently attempt
-  // auto-login. The plaintext password stays server-side throughout —
-  // see POST /admin/login-with-saved for the no-frontend-exposure flow.
+  // auto-login. The plaintext password stays server-side throughout.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -155,25 +111,14 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
       const isStored = cap.stored?.some((s) => s.publicKey.toLowerCase() === target);
       const isRotated = cap.rotated?.some((r) => r.publicKey.toLowerCase() === target);
       if (!isStored || isRotated) return;
-      // Try silent auto-login. Don't block the UI or open the modal.
       const result = await actions.loginRemoteWithSaved(publicKey);
       if (cancelled) return;
       if (result.success) {
         setLoggedIn(true);
-        setTranscript((prev) => [
-          ...prev,
-          {
-            id: nextId(),
-            ts: Date.now(),
-            kind: 'info',
-            text: t(
-              'meshcore.remoteConsole.auto_login_success',
-              'Logged in with saved password',
-            ),
-          },
-        ]);
+        bodyRef.current?.appendInfo(
+          t('meshcore.remoteConsole.auto_login_success', 'Logged in with saved password'),
+        );
       } else if (result.code === 'CREDENTIAL_KEY_ROTATED') {
-        // Pull capability again so the rotated banner shows for this contact.
         void refreshCapability();
       }
       // NO_STORED_CREDENTIAL / STORED_CREDENTIAL_REJECTED → silently fall
@@ -183,16 +128,6 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
       cancelled = true;
     };
   }, [publicKey, actions, refreshCapability, t]);
-
-  const appendTranscript = useCallback((entry: Omit<TranscriptEntry, 'id' | 'ts'>) => {
-    setTranscript((prev) => [
-      ...prev,
-      { id: nextId(), ts: Date.now(), ...entry },
-    ]);
-  }, []);
-
-  const isRotatedForThisContact =
-    capability?.rotated.some((r) => r.publicKey.toLowerCase() === publicKey.toLowerCase()) ?? false;
 
   const handleLogin = useCallback(async () => {
     setLoginBusy(true);
@@ -210,77 +145,31 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
     setLoggedIn(true);
     setShowLogin(false);
     setLoginPassword('');
-    appendTranscript({
-      kind: 'info',
-      text: result.persisted
+    bodyRef.current?.appendInfo(
+      result.persisted
         ? t('meshcore.remoteConsole.login_success_persisted', 'Logged in — password saved on this server')
         : t('meshcore.remoteConsole.login_success', 'Logged in'),
-    });
-    // Re-pull capability so the rotated list reflects any new persistence.
+    );
     void refreshCapability();
-  }, [actions, appendTranscript, loginPassword, publicKey, refreshCapability, rememberPassword, t]);
-
-  const runCommand = useCallback(async (cmd: string, opts?: { confirm?: boolean }) => {
-    if (sending) return;
-    setSending(true);
-    appendTranscript({ kind: 'sent', text: cmd });
-    setCommand('');
-    const result = await actions.sendCliCommand(publicKey, cmd, opts);
-    setSending(false);
-    if (result.ok) {
-      appendTranscript({ kind: 'reply', text: result.reply || '(empty reply)' });
-    } else {
-      // 401-shaped responses can indicate session eviction on the remote
-      // (the ACL slot was reused or the device rebooted). Hint that.
-      const hint =
-        result.code === 'CLI_TIMEOUT'
-          ? t(
-              'meshcore.remoteConsole.timeout_hint',
-              ' — the remote did not reply. Path may be stale, or the admin session may have expired.',
-            )
-          : '';
-      appendTranscript({ kind: 'error', text: `${result.error}${hint}` });
-    }
-  }, [actions, appendTranscript, publicKey, sending, t]);
-
-  const handleSend = useCallback(async () => {
-    const trimmed = command.trim();
-    if (!trimmed || sending) return;
-    // Free-typed danger command — route through the confirm modal even
-    // when the user typed it manually instead of clicking the button.
-    if (DANGER_COMMAND_PATTERN.test(trimmed)) {
-      setDangerConfirm({ command: trimmed, typedName: '' });
-      return;
-    }
-    await runCommand(trimmed);
-  }, [command, runCommand, sending]);
-
-  const handleActionClick = useCallback((action: ActionCommand) => {
-    if (action.danger) {
-      setDangerConfirm({ command: action.command, typedName: '' });
-      return;
-    }
-    // Pre-fill the input so the user can review/edit before pressing Send.
-    setCommand(action.command);
-  }, []);
-
-  const handleDangerConfirm = useCallback(async () => {
-    if (!dangerConfirm) return;
-    const cmd = dangerConfirm.command;
-    setDangerConfirm(null);
-    await runCommand(cmd, { confirm: true });
-  }, [dangerConfirm, runCommand]);
+  }, [actions, loginPassword, publicKey, refreshCapability, rememberPassword, t]);
 
   const handleForgetCredential = useCallback(async () => {
     const ok = await actions.forgetRemoteCredential(publicKey);
-    appendTranscript({
-      kind: 'info',
-      text: ok
+    bodyRef.current?.appendInfo(
+      ok
         ? t('meshcore.remoteConsole.credential_forgotten', 'Stored password forgotten')
         : t('meshcore.remoteConsole.credential_forget_failed', 'Failed to forget stored password'),
-    });
+    );
     void refreshCapability();
-  }, [actions, appendTranscript, publicKey, refreshCapability, t]);
+  }, [actions, publicKey, refreshCapability, t]);
+
+  const isRotatedForThisContact =
+    capability?.rotated.some((r) => r.publicKey.toLowerCase() === publicKey.toLowerCase()) ?? false;
+
+  const runCommand = useCallback(
+    (text: string, opts?: { confirm?: boolean }) => actions.sendCliCommand(publicKey, text, opts),
+    [actions, publicKey],
+  );
 
   return (
     <section className="meshcore-remote-console" aria-label={t('meshcore.remoteConsole.title', 'Remote administration')}>
@@ -318,10 +207,7 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
 
       {capability && !capability.canRemember && (
         <div className="mrc-banner mrc-banner-info" role="status">
-          {t(
-            'meshcore.remoteConsole.persistence_disabled_hint',
-            'Saving passwords is disabled. ',
-          )}
+          {t('meshcore.remoteConsole.persistence_disabled_hint', 'Saving passwords is disabled. ')}
           <span className="mrc-muted">{capability.reason}</span>
         </div>
       )}
@@ -345,72 +231,14 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
         />
       )}
 
-      {loggedIn && (
-        <div className="mrc-quick-actions" role="group" aria-label={t('meshcore.remoteConsole.quick_actions', 'Quick actions')}>
-          {ACTION_CATALOG.map((action) => (
-            <button
-              key={action.key}
-              type="button"
-              className={action.danger ? 'mrc-btn-danger' : 'mrc-btn-quick'}
-              onClick={() => handleActionClick(action)}
-              disabled={sending}
-              title={action.command}
-            >
-              {t(action.labelKey, action.defaultLabel)}
-            </button>
-          ))}
-        </div>
-      )}
-
-      <div className="mrc-transcript" role="log" aria-live="polite">
-        {transcript.length === 0 ? (
-          <p className="mrc-transcript-empty">
-            {loggedIn
-              ? t('meshcore.remoteConsole.empty_logged_in', 'Type a command below and press Send.')
-              : t('meshcore.remoteConsole.empty_logged_out', 'Log in to begin sending commands.')}
-          </p>
-        ) : (
-          transcript.map((entry) => (
-            <div key={entry.id} className={`mrc-line mrc-line-${entry.kind}`}>
-              <span className="mrc-line-prefix">{prefixFor(entry.kind)}</span>
-              <pre className="mrc-line-text">{entry.text}</pre>
-            </div>
-          ))
-        )}
-        <div ref={transcriptEndRef} />
-      </div>
-
-      <form
-        className="mrc-input-row"
-        onSubmit={(e) => {
-          e.preventDefault();
-          void handleSend();
-        }}
-      >
-        <input
-          type="text"
-          value={command}
-          onChange={(e) => setCommand(e.target.value)}
-          placeholder={
-            loggedIn
-              ? t('meshcore.remoteConsole.command_placeholder', 'Type a command (e.g. ver, stats, neighbors)')
-              : t('meshcore.remoteConsole.command_placeholder_logged_out', 'Log in first')
-          }
-          disabled={!loggedIn || sending}
-          className="mrc-input"
-          spellCheck={false}
-          autoComplete="off"
-        />
-        <button
-          type="submit"
-          disabled={!loggedIn || sending || command.trim().length === 0}
-          className="mrc-btn-primary"
-        >
-          {sending
-            ? t('meshcore.remoteConsole.sending', 'Sending…')
-            : t('meshcore.remoteConsole.send', 'Send')}
-        </button>
-      </form>
+      <CliConsoleBody
+        ref={bodyRef}
+        targetId={publicKey}
+        targetName={contactName}
+        runCommand={runCommand}
+        actionCatalog={loggedIn ? REMOTE_ACTION_CATALOG : []}
+        disabled={!loggedIn}
+      />
 
       {showLogin && (
         <div
@@ -477,65 +305,6 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
           </div>
         </div>
       )}
-
-      {dangerConfirm && (
-        <div
-          className="mrc-modal-backdrop"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="mrc-danger-title"
-          onClick={() => setDangerConfirm(null)}
-        >
-          <div className="mrc-modal mrc-modal-danger" onClick={(e) => e.stopPropagation()}>
-            <h4 id="mrc-danger-title">
-              {t('meshcore.remoteConsole.danger_modal_title', 'Confirm destructive command')}
-            </h4>
-            <p className="mrc-modal-body">
-              {t(
-                'meshcore.remoteConsole.danger_modal_body',
-                'You are about to send "{{command}}" to {{name}}. This action may interrupt the remote node. Type the contact name to confirm:',
-                { command: dangerConfirm.command, name: contactName },
-              )}
-            </p>
-            <input
-              type="text"
-              value={dangerConfirm.typedName}
-              onChange={(e) => setDangerConfirm({ ...dangerConfirm, typedName: e.target.value })}
-              className="mrc-input"
-              autoFocus
-              spellCheck={false}
-              autoComplete="off"
-              placeholder={contactName}
-            />
-            <div className="mrc-modal-actions">
-              <button
-                type="button"
-                className="mrc-btn-secondary"
-                onClick={() => setDangerConfirm(null)}
-              >
-                {t('meshcore.remoteConsole.cancel', 'Cancel')}
-              </button>
-              <button
-                type="button"
-                className="mrc-btn-danger"
-                onClick={() => void handleDangerConfirm()}
-                disabled={dangerConfirm.typedName !== contactName}
-              >
-                {t('meshcore.remoteConsole.danger_confirm', 'Send {{command}}', { command: dangerConfirm.command })}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </section>
   );
 };
-
-function prefixFor(kind: TranscriptEntry['kind']): string {
-  switch (kind) {
-    case 'sent': return '>';
-    case 'reply': return '<';
-    case 'error': return '!';
-    case 'info': return '*';
-  }
-}

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -153,6 +153,15 @@ export interface MeshCoreActions {
   loginRemoteWithSaved: (
     publicKey: string,
   ) => Promise<{ success: boolean; usedStored?: boolean; error?: string; code?: string }>;
+  /** Send a CLI command to the LOCALLY connected MeshCore node (the one
+   *  this source is bound to). For Repeater / Room Server firmware this
+   *  drives the device's native text CLI; for Companion firmware a small
+   *  synthetic CLI interpreter on the server handles ver / stats / clock
+   *  / advert. Reuses the same danger-confirm flow as `sendCliCommand`. */
+  sendLocalCliCommand: (
+    command: string,
+    opts?: { timeoutMs?: number; confirm?: boolean },
+  ) => Promise<{ ok: true; reply: string; elapsedMs: number } | { ok: false; error: string; code?: string; status?: number }>;
   /** Forget the saved admin password for a remote node. No-op when none is
    *  saved; resolves `true` on success. */
   forgetRemoteCredential: (publicKey: string) => Promise<boolean>;
@@ -589,6 +598,30 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch]);
 
+  const sendLocalCliCommand = useCallback(async (
+    command: string,
+    opts?: { timeoutMs?: number; confirm?: boolean },
+  ) => {
+    try {
+      const response = await csrfFetch(`${mcPrefix}/cli`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          command,
+          ...(opts?.timeoutMs ? { timeoutMs: opts.timeoutMs } : {}),
+          ...(opts?.confirm ? { confirm: true } : {}),
+        }),
+      });
+      const data = await response.json();
+      if (data.success && data.data) {
+        return { ok: true as const, reply: data.data.reply, elapsedMs: data.data.elapsedMs };
+      }
+      return { ok: false as const, error: data.error || 'Unknown error', code: data.code, status: response.status };
+    } catch (err) {
+      return { ok: false as const, error: err instanceof Error ? err.message : 'Network error' };
+    }
+  }, [mcPrefix, csrfFetch]);
+
   const loginRemoteWithSaved = useCallback(async (publicKey: string) => {
     try {
       const response = await csrfFetch(`${mcPrefix}/admin/login-with-saved`, {
@@ -876,6 +909,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       forgetRemoteCredential,
       getRemoteStatus,
       loginRemoteWithSaved,
+      sendLocalCliCommand,
     },
   };
 }

--- a/src/server/meshcoreManager.localCli.test.ts
+++ b/src/server/meshcoreManager.localCli.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for MeshCoreManager.sendLocalCliCommand — the local-CLI dispatcher
+ * that routes commands to either the Repeater's native serial CLI or
+ * Companion's synthetic CLI interpreter based on `deviceType`.
+ *
+ * Pattern follows meshcoreManager.channels.test.ts: construct a manager,
+ * stub deviceType + the relevant private transport, then exercise the
+ * public method.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+interface BridgeCall {
+  cmd: string;
+  params: Record<string, unknown>;
+}
+
+function makeCompanionManager(bridgeResponses: Record<string, { success: boolean; data?: any; error?: string }>) {
+  const m = new MeshCoreManager('test-source');
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  (m as any).connected = true;
+
+  const bridgeCalls: BridgeCall[] = [];
+  (m as any).sendBridgeCommand = async (cmd: string, params: Record<string, unknown>) => {
+    bridgeCalls.push({ cmd, params });
+    const resp = bridgeResponses[cmd];
+    if (!resp) return { id: '1', success: false, error: `no stub for ${cmd}` };
+    return { id: '1', ...resp };
+  };
+
+  return { manager: m, bridgeCalls };
+}
+
+function makeRepeaterManager(repeaterReplies: Record<string, string>) {
+  const m = new MeshCoreManager('test-source');
+  (m as any).deviceType = MeshCoreDeviceType.REPEATER;
+  (m as any).connected = true;
+
+  const repeaterCalls: string[] = [];
+  (m as any).sendRepeaterCommand = async (cmd: string) => {
+    repeaterCalls.push(cmd);
+    return repeaterReplies[cmd] ?? `(no stub for ${cmd})`;
+  };
+
+  return { manager: m, repeaterCalls };
+}
+
+describe('sendLocalCliCommand', () => {
+  describe('common validation', () => {
+    it('rejects an empty command', async () => {
+      const { manager } = makeCompanionManager({});
+      await expect(manager.sendLocalCliCommand('  ')).rejects.toThrow(/non-empty/i);
+    });
+
+    it('rejects when not connected', async () => {
+      const m = new MeshCoreManager('test-source');
+      (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+      (m as any).connected = false;
+      await expect(m.sendLocalCliCommand('ver')).rejects.toThrow(/not connected/i);
+    });
+
+    it('rejects when the device type is Unknown', async () => {
+      const m = new MeshCoreManager('test-source');
+      (m as any).deviceType = MeshCoreDeviceType.UNKNOWN;
+      (m as any).connected = true;
+      await expect(m.sendLocalCliCommand('ver')).rejects.toThrow(/not available/i);
+    });
+  });
+
+  describe('Repeater dispatch', () => {
+    it('forwards the command to sendRepeaterCommand verbatim', async () => {
+      const { manager, repeaterCalls } = makeRepeaterManager({
+        'stats': '  -> packets_sent: 42\n  -> packets_recv: 91',
+      });
+      const result = await manager.sendLocalCliCommand('stats');
+      expect(repeaterCalls).toEqual(['stats']);
+      expect(result.reply).toContain('packets_sent: 42');
+      expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('also forwards for Room Server (same firmware family)', async () => {
+      const m = new MeshCoreManager('test-source');
+      (m as any).deviceType = MeshCoreDeviceType.ROOM_SERVER;
+      (m as any).connected = true;
+      const calls: string[] = [];
+      (m as any).sendRepeaterCommand = async (cmd: string) => { calls.push(cmd); return 'ok'; };
+      await m.sendLocalCliCommand('neighbors');
+      expect(calls).toEqual(['neighbors']);
+    });
+  });
+
+  describe('Companion synthetic CLI', () => {
+    it('renders `ver` from device_query response', async () => {
+      const { manager, bridgeCalls } = makeCompanionManager({
+        device_query: { success: true, data: { 'fw ver': 7, ver: 'v1.7.0', fw_build: '2026-01-15', model: 'Heltec Tracker' } },
+      });
+      const result = await manager.sendLocalCliCommand('ver');
+      expect(bridgeCalls).toEqual([{ cmd: 'device_query', params: {} }]);
+      expect(result.reply).toContain('Firmware: 7');
+      expect(result.reply).toContain('Version: v1.7.0');
+      expect(result.reply).toContain('Model: Heltec Tracker');
+    });
+
+    it('renders `stats` (default core)', async () => {
+      const { manager, bridgeCalls } = makeCompanionManager({
+        get_stats: { success: true, data: { battery_mv: 4123, uptime_secs: 9876 } },
+      });
+      const result = await manager.sendLocalCliCommand('stats');
+      expect(bridgeCalls[0].cmd).toBe('get_stats');
+      expect(bridgeCalls[0].params).toEqual({ type: 'core' });
+      expect(result.reply).toContain('[core]');
+      expect(result.reply).toContain('battery_mv: 4123');
+    });
+
+    it('passes the stats sub-type through', async () => {
+      const { manager, bridgeCalls } = makeCompanionManager({
+        get_stats: { success: true, data: { last_rssi: -94, last_snr: 7.5 } },
+      });
+      await manager.sendLocalCliCommand('stats radio');
+      expect(bridgeCalls[0].params).toEqual({ type: 'radio' });
+    });
+
+    it('returns the device clock as epoch + ISO when available', async () => {
+      const { manager } = makeCompanionManager({
+        get_device_time: { success: true, data: { time: 1700000000 } },
+      });
+      const result = await manager.sendLocalCliCommand('clock');
+      expect(result.reply).toMatch(/^1700000000\n/);
+      expect(result.reply).toContain('T'); // ISO format includes the T separator
+    });
+
+    it('reports "unavailable" when the device returns no clock', async () => {
+      const { manager } = makeCompanionManager({
+        get_device_time: { success: true, data: {} },
+      });
+      const result = await manager.sendLocalCliCommand('clock');
+      expect(result.reply).toContain('unavailable');
+    });
+
+    it('triggers a flood advert on `advert`', async () => {
+      const { manager, bridgeCalls } = makeCompanionManager({
+        send_advert: { success: true, data: { sent: true } },
+      });
+      const result = await manager.sendLocalCliCommand('advert');
+      expect(bridgeCalls[0].cmd).toBe('send_advert');
+      expect(result.reply).toMatch(/sent/i);
+    });
+
+    it('returns a help string on `help`', async () => {
+      const { manager } = makeCompanionManager({});
+      const result = await manager.sendLocalCliCommand('help');
+      expect(result.reply).toContain('ver');
+      expect(result.reply).toContain('stats');
+      expect(result.reply).toContain('clock');
+      expect(result.reply).toContain('advert');
+    });
+
+    it('returns an "Unknown command" hint for unrecognized verbs', async () => {
+      const { manager } = makeCompanionManager({});
+      const result = await manager.sendLocalCliCommand('flux capacitor');
+      expect(result.reply).toContain('Unknown command');
+      expect(result.reply).toContain('help');
+    });
+
+    it('propagates a bridge-command failure as a thrown error', async () => {
+      const { manager } = makeCompanionManager({
+        device_query: { success: false, error: 'transport closed' },
+      });
+      await expect(manager.sendLocalCliCommand('ver')).rejects.toThrow(/transport closed/);
+    });
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1715,6 +1715,115 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
+   * Send a CLI command to the LOCALLY connected MeshCore node.
+   *
+   * Dispatch depends on the connected firmware:
+   *  - Repeater / Room Server: forwards to `sendRepeaterCommand`, which
+   *    drives the device's native serial text CLI. Whatever the device
+   *    prints comes back as `reply`.
+   *  - Companion: there is no native text CLI on the companion-protocol
+   *    wire, so we run a small synthetic-CLI interpreter that maps a
+   *    handful of read-only verbs (ver, stats, clock, advert) to existing
+   *    bridge commands and formats the structured response as text.
+   *
+   * No password / login flow — the local node is physically connected,
+   * so there is no admin ACL to authenticate against. The HTTP route
+   * separately gates this on the `configuration:write` permission.
+   */
+  async sendLocalCliCommand(
+    command: string,
+    opts: { timeoutMs?: number } = {},
+  ): Promise<{ reply: string; elapsedMs: number }> {
+    if (!this.connected) {
+      throw new Error('MeshCore source not connected');
+    }
+    const trimmed = command.trim();
+    if (trimmed.length === 0) {
+      throw new Error('Command must be non-empty');
+    }
+    const sentAt = Date.now();
+    const timeoutMs = opts.timeoutMs ?? 10_000;
+
+    if (this.deviceType === MeshCoreDeviceType.REPEATER || this.deviceType === MeshCoreDeviceType.ROOM_SERVER) {
+      const reply = await this.sendRepeaterCommand(trimmed, timeoutMs);
+      return { reply, elapsedMs: Date.now() - sentAt };
+    }
+
+    if (this.deviceType === MeshCoreDeviceType.COMPANION) {
+      const reply = await this.runSyntheticLocalCli(trimmed);
+      return { reply, elapsedMs: Date.now() - sentAt };
+    }
+
+    throw new Error('Local CLI not available for this device type');
+  }
+
+  /**
+   * Synthetic CLI for Companion firmware. Companion devices speak only
+   * the binary companion protocol on the wire; this method gives the
+   * UI the same "type a command, see structured output" shape as the
+   * Repeater path by mapping a small command vocabulary to existing
+   * bridge commands and formatting the result as readable text.
+   *
+   * Unrecognized commands return a usage hint instead of throwing —
+   * matches the Repeater path's behavior for the same input.
+   */
+  private async runSyntheticLocalCli(command: string): Promise<string> {
+    const parts = command.split(/\s+/);
+    const verb = parts[0]?.toLowerCase() ?? '';
+    const arg = parts[1]?.toLowerCase() ?? '';
+
+    if (verb === 'ver' || verb === 'version') {
+      const response = await this.sendBridgeCommand('device_query', {});
+      if (!response.success) throw new Error(response.error || 'device_query failed');
+      const d = response.data || {};
+      const lines: string[] = [];
+      if (d['fw ver'] !== undefined) lines.push(`Firmware: ${d['fw ver']}`);
+      if (d.ver) lines.push(`Version: ${d.ver}`);
+      if (d.fw_build) lines.push(`Build: ${d.fw_build}`);
+      if (d.model) lines.push(`Model: ${d.model}`);
+      return lines.length > 0 ? lines.join('\n') : 'No device info reported';
+    }
+
+    if (verb === 'stats') {
+      const type = arg === 'radio' || arg === 'packets' ? arg : 'core';
+      const response = await this.sendBridgeCommand('get_stats', { type });
+      if (!response.success) throw new Error(response.error || 'get_stats failed');
+      const d = response.data || {};
+      const lines = Object.entries(d)
+        .filter(([, v]) => v !== undefined && v !== null)
+        .map(([k, v]) => `${k}: ${v}`);
+      return lines.length > 0 ? `[${type}]\n${lines.join('\n')}` : `[${type}] (no data)`;
+    }
+
+    if (verb === 'clock' || verb === 'time') {
+      const response = await this.sendBridgeCommand('get_device_time', {});
+      if (!response.success) throw new Error(response.error || 'get_device_time failed');
+      const epoch = response.data?.time;
+      if (typeof epoch !== 'number') return 'Device clock unavailable';
+      return `${epoch}\n${new Date(epoch * 1000).toISOString()}`;
+    }
+
+    if (verb === 'advert') {
+      const response = await this.sendBridgeCommand('send_advert', {});
+      if (!response.success) throw new Error(response.error || 'send_advert failed');
+      return 'Advert sent (flood)';
+    }
+
+    if (verb === 'help' || verb === '?') {
+      return [
+        'Available local commands (Companion):',
+        '  ver           — firmware version + model',
+        '  stats [core|radio|packets] — local device stats',
+        '  clock         — device time',
+        '  advert        — broadcast a flood advert',
+        '  help          — this list',
+      ].join('\n');
+    }
+
+    return `Unknown command: ${command}\nType "help" for the list of available commands.`;
+  }
+
+  /**
    * Set device name
    */
   async setName(name: string): Promise<boolean> {

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -54,6 +54,7 @@ const meshcoreManager = {
   loginToNode: vi.fn().mockResolvedValue(true),
   requestNodeStatus: vi.fn().mockResolvedValue({ batteryMv: 4200, uptimeSecs: 3600 }),
   sendCliCommand: vi.fn().mockResolvedValue({ reply: 'ok', elapsedMs: 42 }),
+  sendLocalCliCommand: vi.fn().mockResolvedValue({ reply: 'v1.7.0', elapsedMs: 12 }),
   setName: vi.fn().mockResolvedValue(true),
   setRadio: vi.fn().mockResolvedValue(true),
   isConnected: vi.fn().mockReturnValue(false),
@@ -572,6 +573,95 @@ describe('MeshCore Routes', () => {
       expect(response.status).toBe(200);
       expect(response.body.data.rotatedCount).toBe(1);
       expect(response.body.data.rotated).toEqual([{ publicKey: pk1, name: 'Hill repeater' }]);
+    });
+  });
+
+  describe('POST /api/sources/test-source/meshcore/cli (local)', () => {
+    beforeEach(() => {
+      meshcoreManager.sendLocalCliCommand.mockReset();
+      meshcoreManager.sendLocalCliCommand.mockResolvedValue({ reply: 'v1.7.0', elapsedMs: 12 });
+    });
+
+    it('requires authentication', async () => {
+      const response = await request(app)
+        .post('/api/sources/test-source/meshcore/cli')
+        .send({ command: 'ver' });
+      expect(response.status).toBe(401);
+    });
+
+    it('rejects an empty command', async () => {
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/cli')
+        .send({ command: '   ' });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('non-empty');
+    });
+
+    it('rejects a command longer than the LoRa MTU', async () => {
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/cli')
+        .send({ command: 'x'.repeat(231) });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('too long');
+    });
+
+    it('returns the reply on the happy path', async () => {
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/cli')
+        .send({ command: 'ver' });
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data).toEqual({ reply: 'v1.7.0', elapsedMs: 12 });
+      expect(meshcoreManager.sendLocalCliCommand).toHaveBeenCalledWith('ver', {
+        timeoutMs: undefined,
+      });
+    });
+
+    it.each([
+      ['reboot'],
+      ['Reboot'],
+      ['erase'],
+      ['clkreboot'],
+      ['factory reset'],
+    ])('rejects danger command %s without confirm', async (cmd) => {
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/cli')
+        .send({ command: cmd });
+      expect(response.status).toBe(400);
+      expect(response.body.code).toBe('DANGER_CONFIRM_REQUIRED');
+      expect(meshcoreManager.sendLocalCliCommand).not.toHaveBeenCalled();
+    });
+
+    it('accepts a danger command when confirm=true', async () => {
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/cli')
+        .send({ command: 'reboot', confirm: true });
+      expect(response.status).toBe(200);
+      expect(meshcoreManager.sendLocalCliCommand).toHaveBeenCalledWith('reboot', {
+        timeoutMs: undefined,
+      });
+    });
+
+    it('maps a timeout to 504', async () => {
+      meshcoreManager.sendLocalCliCommand.mockRejectedValueOnce(
+        new Error('CLI command timed out after 10000ms'),
+      );
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/cli')
+        .send({ command: 'stats' });
+      expect(response.status).toBe(504);
+      expect(response.body.code).toBe('CLI_TIMEOUT');
+    });
+
+    it('maps a "not available for this device type" failure to 400', async () => {
+      meshcoreManager.sendLocalCliCommand.mockRejectedValueOnce(
+        new Error('Local CLI not available for this device type'),
+      );
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/cli')
+        .send({ command: 'ver' });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('not available');
     });
   });
 

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -838,6 +838,77 @@ router.post('/admin/cli', meshcoreDeviceLimiter, requireAuth(), requirePermissio
 });
 
 /**
+ * POST /api/meshcore/cli
+ *
+ * Send a CLI command to the LOCALLY connected MeshCore node. Returns the
+ * device's response text.
+ *
+ * Body: { command: string, confirm?: boolean, timeoutMs?: number }
+ *
+ * Dispatch depends on the local firmware (see
+ * `MeshCoreManager.sendLocalCliCommand`):
+ *   - Repeater / Room Server: forwarded to the device's native text CLI
+ *     over serial.
+ *   - Companion: handled by a small synthetic-CLI interpreter that
+ *     covers ver / stats / clock / advert / help. Unknown commands
+ *     return a usage hint.
+ *
+ * Reuses the same `DANGER_COMMAND_PATTERN` guard as the remote /admin/cli
+ * route — destructive verbs (reboot / erase / clkreboot / factory)
+ * require `confirm: true`.
+ *
+ * Gated on `configuration:write` per-source — matches the existing
+ * local-device config routes (`/config/name`, `/config/radio`, etc.).
+ */
+router.post('/cli', meshcoreDeviceLimiter, requireAuth(), requirePermission('configuration', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+  try {
+    const { command, confirm, timeoutMs } = req.body as {
+      command?: string;
+      confirm?: boolean;
+      timeoutMs?: number;
+    };
+
+    if (typeof command !== 'string' || command.trim().length === 0) {
+      return res.status(400).json({ success: false, error: 'command must be a non-empty string' });
+    }
+    if (command.length > 230) {
+      return res.status(400).json({ success: false, error: 'command too long (max 230 bytes)' });
+    }
+    if (DANGER_COMMAND_PATTERN.test(command) && confirm !== true) {
+      return res.status(400).json({
+        success: false,
+        error: 'Destructive command requires confirm:true in the request body',
+        code: 'DANGER_CONFIRM_REQUIRED',
+      });
+    }
+    const effectiveTimeout =
+      typeof timeoutMs === 'number' && Number.isFinite(timeoutMs) && timeoutMs > 0 && timeoutMs <= 60_000
+        ? timeoutMs
+        : undefined;
+
+    try {
+      const result = await managerFor(req).sendLocalCliCommand(command, {
+        timeoutMs: effectiveTimeout,
+      });
+      res.json({ success: true, data: result });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/timed out/i.test(msg)) {
+        return res.status(504).json({ success: false, error: msg, code: 'CLI_TIMEOUT' });
+      }
+      if (/not connected|not available for this device type|Serial port not open/i.test(msg)) {
+        return res.status(400).json({ success: false, error: msg });
+      }
+      logger.error('[API] Local CLI command failed:', err);
+      res.status(502).json({ success: false, error: msg });
+    }
+  } catch (error) {
+    logger.error('[API] Unexpected error in /cli:', error);
+    res.status(500).json({ success: false, error: 'CLI error' });
+  }
+});
+
+/**
  * GET /api/meshcore/admin/credentials-capability
  *
  * Reports whether the server can persist MeshCore admin passwords. The


### PR DESCRIPTION
## Summary

Adds a CLI-style console for the **locally connected** MeshCore node, parallel to the remote-administration console from #3160/#3161 but without the auth layer (you're physically connected — there's no admin password).

- New `CliConsoleBody` extracts the shared bits (transcript, input, quick-action row, danger-confirm modal) so both consoles use the same primitive. The remote console becomes a thin wrapper that layers login + capability + auto-login + stats panel on top.
- `MeshCoreLocalConsole` mounts at the bottom of `MeshCoreConfigurationView`, gated on `configuration:write`.

## Dispatch on local firmware

| Local firmware | What you get |
|---|---|
| **Repeater / Room Server** | The device's real serial text CLI. The full command set is whatever the firmware version supports (`ver`, `stats`, `neighbors`, `clock`, `advert`, `reboot`, `setperm`, etc.). |
| **Companion** | A synthetic CLI on the server side that maps `ver` / `stats [core\|radio\|packets]` / `clock` / `advert` / `help` to existing companion-protocol bridge commands and formats the structured response as text. Unknown verbs return a usage hint. |
| **Unknown** | Quick-action row is empty; user can still type free-form commands. They will route to whichever path matches once the device identifies itself. |

The Companion synthetic CLI is intentionally small in this first cut. It covers the "peek at local state" use case (firmware version, battery, packet counts, clock). Mutating verbs (`set name`, `set radio`, etc.) are already handled by the existing form UI on the same page, so duplicating them in the console adds little.

## Danger guard

Reuses the same `DANGER_COMMAND_PATTERN` (`/(reboot|erase|clkreboot|factory)/i`) as the remote console — client-side typed-name confirmation modal AND server-side `DANGER_CONFIRM_REQUIRED` enforcement. Either path triggers the same dialog: click the danger button or type `reboot` free-form into the input.

## Files

- `src/components/MeshCore/CliConsoleBody.tsx` (new) — shared primitive.
- `src/components/MeshCore/MeshCoreLocalConsole.tsx` (new) — local wrapper.
- `src/components/MeshCore/MeshCoreRemoteConsole.tsx` — refactored to use the primitive (no behavior change for existing remote-console users).
- `src/components/MeshCore/MeshCoreConfigurationView.tsx` — mounts the local console.
- `src/components/MeshCore/hooks/useMeshCore.ts` — adds `sendLocalCliCommand`.
- `src/server/meshcoreManager.ts` — `sendLocalCliCommand` + `runSyntheticLocalCli`.
- `src/server/routes/meshcoreRoutes.ts` — new `POST /api/sources/:id/meshcore/cli` route.

## Test plan

- [x] `npx vitest run` — 10461 tests, 0 failures (14 new manager tests + 12 new route tests).
- [x] `npx tsc --noEmit` clean.
- [x] ESLint clean on changed files.
- [x] Refactor preserves remote-console behavior (existing 138 remote-route tests still pass).
- [ ] **Manual dev-container smoke test — deferred.** The Companion synthetic CLI is exercised by the new unit tests with mocked bridge responses; the Repeater path is a one-line forward to `sendRepeaterCommand`, which is already exercised by existing code paths (`set name`, `set radio` go through it today).
- [ ] CI green (will monitor via `/ci-monitor`).

## What's NOT in this PR (deliberately deferred)

- **Reboot for local Companion** — would need a new `reboot` bridge command in `meshcoreNativeBackend.ts`. Trivial follow-up if wanted.
- **`set <key> <value>` in the Companion synthetic CLI** — the existing config form already does name/radio/coords/advert-policy, so duplicating those would just confuse the UX. If we add commands the form doesn't cover (e.g. set TX power), we can expand the interpreter then.
- **Command autocomplete / history** — would land in `CliConsoleBody` and benefit both consoles automatically. Worth a separate PR with focused UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)