### PR TITLE
docs: improve Helm chart findability (#3163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ docker compose up -d
 
 For detailed installation instructions, configuration options, and deployment scenarios, see the **[Getting Started Guide](https://meshmonitor.org/getting-started.html)**.
 
+### Kubernetes / Helm
+
+Running on Kubernetes? MeshMonitor ships a Helm chart under [`helm/meshmonitor/`](helm/meshmonitor/):
+
+```bash
+# Minimal custom-values.yaml
+cat > custom-values.yaml << 'EOF'
+env:
+  meshtasticNodeIp: "192.168.1.100"
+  meshtasticUseTls: "false"
+EOF
+
+helm install meshmonitor ./helm/meshmonitor -f custom-values.yaml
+```
+
+See the [Helm Chart README](helm/README.md) for ingress, TLS, persistence, and the full values reference, or the [Helm Deployment Guide](https://meshmonitor.org/deployment/HELM_GUIDE.html) on the docs site.
+
 ## Proxy Authentication
 
 MeshMonitor supports authentication via reverse proxy headers for seamless single sign-on (SSO) integration with Cloudflare Access, oauth2-proxy, Authelia, Traefik ForwardAuth, and similar solutions.
@@ -196,8 +213,9 @@ MeshMonitor supports multiple deployment methods:
   - [Docker Compose Guide](docs/deployment/DEPLOYMENT_GUIDE.md)
   - Platforms: amd64, arm64, armv7
 
-- **☸️ Kubernetes** - Helm charts for production clusters
-  - [Helm Chart](helm/meshmonitor/)
+- **☸️ Kubernetes / Helm** - Helm chart for production clusters
+  - [Helm Chart README](helm/README.md) — full install, values, ingress, and TLS reference
+  - [Helm Deployment Guide](https://meshmonitor.org/deployment/HELM_GUIDE.html) — quick-start on the docs site
   - GitOps-ready with ArgoCD/Flux support
 
 - **📦 Proxmox LXC** - Lightweight containers for Proxmox VE

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -201,6 +201,7 @@ export default defineConfig({
           collapsed: true,
           items: [
             { text: 'Deployment Guide', link: '/deployment/DEPLOYMENT_GUIDE' },
+            { text: '☸️ Kubernetes / Helm', link: '/deployment/HELM_GUIDE' },
             { text: '📦 Proxmox LXC', link: '/deployment/PROXMOX_LXC_GUIDE' }
           ]
         }

--- a/docs/deployment/DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/DEPLOYMENT_GUIDE.md
@@ -9,7 +9,7 @@ This guide covers various deployment scenarios for MeshMonitor, from development
 MeshMonitor supports several deployment options:
 
 - **🐳 Docker Compose** (Recommended) - Easiest setup with auto-upgrade support
-- **☸️ Kubernetes/Helm** - Production-grade orchestration
+- **☸️ Kubernetes/Helm** - Production-grade orchestration ([separate guide](HELM_GUIDE.md))
 - **📦 Proxmox LXC** - Lightweight containers for Proxmox VE ([separate guide](PROXMOX_LXC_GUIDE.md))
 - **🔧 Bare Metal (Node.js)** - Direct deployment without containers
 
@@ -69,6 +69,30 @@ docker compose up -d
 Default login: **admin** / **changeme** — change your password immediately after first login.
 
 For production deployments with HTTPS and reverse proxies, see the [Production Deployment Guide](/configuration/production).
+
+---
+
+## Kubernetes (Helm)
+
+MeshMonitor ships a Helm chart under [`helm/meshmonitor/`](https://github.com/Yeraze/meshmonitor/tree/main/helm/meshmonitor). See the [Kubernetes / Helm Guide](HELM_GUIDE.md) for the full walkthrough — ingress, TLS, persistence, subfolder deployment, and the complete `values.yaml` reference.
+
+Short version:
+
+```bash
+git clone --recurse-submodules https://github.com/Yeraze/meshmonitor.git
+cd meshmonitor
+
+cat > custom-values.yaml << 'EOF'
+env:
+  meshtasticNodeIp: "192.168.1.100"
+  meshtasticUseTls: "false"
+EOF
+
+helm install meshmonitor ./helm/meshmonitor -f custom-values.yaml
+kubectl port-forward svc/meshmonitor 8080:80
+```
+
+The canonical reference for every chart value lives in the [`helm/README.md`](https://github.com/Yeraze/meshmonitor/blob/main/helm/README.md) in the repository.
 
 ---
 

--- a/docs/deployment/HELM_GUIDE.md
+++ b/docs/deployment/HELM_GUIDE.md
@@ -1,0 +1,159 @@
+# Kubernetes Deployment (Helm)
+
+MeshMonitor ships a Helm chart for deploying to any Kubernetes 1.19+ cluster. The chart lives under [`helm/meshmonitor/`](https://github.com/Yeraze/meshmonitor/tree/main/helm/meshmonitor) in the repository and is fully documented in the [chart README](https://github.com/Yeraze/meshmonitor/blob/main/helm/README.md) — this page is the docs-site landing point for Kubernetes installs.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+- A Meshtastic node reachable from the cluster (WiFi/Ethernet, or a Serial/BLE bridge exposing TCP)
+- Optional: an ingress controller (nginx, Traefik, etc.) and cert-manager if you want TLS
+
+## Quick Start
+
+1. **Clone the repository** to get the chart sources:
+
+   ```bash
+   git clone --recurse-submodules https://github.com/Yeraze/meshmonitor.git
+   cd meshmonitor
+   ```
+
+2. **Create `custom-values.yaml`** with the required node settings:
+
+   ```yaml
+   env:
+     meshtasticNodeIp: "192.168.1.100"   # REQUIRED — your Meshtastic node IP
+     meshtasticUseTls: "false"           # REQUIRED — "true" for HTTPS to the node
+   ```
+
+3. **Install the chart**:
+
+   ```bash
+   helm install meshmonitor ./helm/meshmonitor -f custom-values.yaml
+   ```
+
+4. **Access the UI**. The default install creates a `ClusterIP` service; port-forward to reach it locally:
+
+   ```bash
+   kubectl port-forward svc/meshmonitor 8080:80
+   ```
+
+   Open <http://localhost:8080> and sign in with the default credentials (`admin` / `changeme`). Change the password immediately.
+
+## Common Configurations
+
+### Ingress with TLS
+
+```yaml
+env:
+  meshtasticNodeIp: "192.168.1.100"
+  meshtasticUseTls: "false"
+
+ingress:
+  enabled: true
+  className: "nginx"
+  hosts:
+    - host: meshmonitor.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: meshmonitor-tls
+      hosts:
+        - meshmonitor.example.com
+```
+
+### Subfolder Deployment
+
+To serve MeshMonitor at `https://example.com/meshmonitor/`:
+
+```yaml
+env:
+  meshtasticNodeIp: "192.168.1.100"
+  meshtasticUseTls: "false"
+  baseUrl: "/meshmonitor"
+
+ingress:
+  enabled: true
+  className: "nginx"
+  hosts:
+    - host: example.com
+      paths:
+        - path: /meshmonitor
+          pathType: Prefix
+```
+
+### Persistence
+
+The chart provisions a `PersistentVolumeClaim` by default (1Gi). Resize or point at an existing PVC:
+
+```yaml
+persistence:
+  enabled: true
+  size: "5Gi"
+  # storageClass: "fast-ssd"
+  # existingClaim: "my-existing-pvc"
+```
+
+### Resource Limits
+
+```yaml
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+```
+
+## Upgrading
+
+```bash
+git pull
+helm upgrade meshmonitor ./helm/meshmonitor -f custom-values.yaml
+```
+
+The chart `appVersion` is bumped on every MeshMonitor release; pin a specific image tag via `image.tag` if you need a stable target.
+
+## Uninstalling
+
+```bash
+helm uninstall meshmonitor
+# PVC is preserved by default — delete it explicitly if desired:
+kubectl delete pvc meshmonitor
+```
+
+## Troubleshooting
+
+**Can't reach the Meshtastic node from the pod:**
+
+```bash
+kubectl run -it --rm debug --image=busybox --restart=Never -- wget -O- http://YOUR_NODE_IP
+kubectl logs -l app.kubernetes.io/name=meshmonitor
+```
+
+**Database/permission errors:**
+
+```bash
+kubectl get pvc
+kubectl exec -it deployment/meshmonitor -- ls -la /data
+```
+
+**Pod not starting:**
+
+```bash
+kubectl describe pod -l app.kubernetes.io/name=meshmonitor
+kubectl logs -l app.kubernetes.io/name=meshmonitor
+```
+
+## Reference
+
+- [Helm chart README](https://github.com/Yeraze/meshmonitor/blob/main/helm/README.md) — full values tree, architecture diagram, and every supported option (canonical source).
+- [Chart sources](https://github.com/Yeraze/meshmonitor/tree/main/helm/meshmonitor) — templates and default `values.yaml`.
+- [Production Deployment Guide](/configuration/production) — production hardening notes that apply to the Helm install.
+- [Deployment Guide](/deployment/DEPLOYMENT_GUIDE) — other deployment methods (Docker, bare metal, Proxmox LXC).
+
+## GitOps
+
+The chart is GitOps-friendly: commit your `custom-values.yaml` to a config repo and let ArgoCD or Flux apply it. Pin `image.tag` to a specific release rather than `latest` so deployments are reproducible.


### PR DESCRIPTION
## Summary

Closes #3163 — users had trouble finding the Helm chart because it wasn't linked from the root README or the docs site nav.

- Root `README.md`: added a Kubernetes / Helm quick-start subsection with a direct link to `helm/README.md` and the new docs-site guide.
- New `docs/deployment/HELM_GUIDE.md`: docs-site landing page for Kubernetes installs (install, ingress + TLS, subfolder, persistence, resources, upgrade, troubleshooting). The canonical values reference still lives in `helm/README.md`; the new page links to it.
- `docs/.vitepress/config.mts`: added the Helm guide under "Deployment Guides" in the Configuration sidebar.
- `docs/deployment/DEPLOYMENT_GUIDE.md`: the Kubernetes/Helm bullet now links to the new guide, and a short Helm section sits between Docker Compose and Bare Metal.

The `helm/README.md` (canonical chart README) was not modified — it is the single source of truth for the values tree.

## Test plan

- [x] `npm run docs:build` succeeds with no broken-link warnings
- [x] `docs/.vitepress/dist/deployment/HELM_GUIDE.html` is rendered
- [ ] Reviewer: confirm sidebar shows "☸️ Kubernetes / Helm" under Deployment Guides
- [ ] Reviewer: confirm root README "Deployment Options" section and the new quick-start subsection both link to `helm/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)