### PR TITLE
feat(meshcore): ACL setperm form, command history, internal docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,9 @@
 
 1. **This file** — invariants, rules, and gotchas. Skim end-to-end.
 2. **`docs/internal/dev-notes/ARCHITECTURE_LESSONS.md`** — MUST-READ before touching node communication, state management, backup/restore, async operations, multi-database, or multi-source.
-3. **`src/server/sourceManagerRegistry.ts`** + **`src/server/meshtasticManager.ts`** — read these two before any feature touching nodes/messages/telemetry. There is no global `meshtasticManager` singleton; everything is per-source.
-4. **One repository under `src/db/repositories/`** (e.g. `auth.ts`) — read before adding a query. Raw SQL outside this directory is ESLint-banned.
+3. **`docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md`** — MUST-READ before touching MeshCore CLI/admin routes, the credential store, the danger guard, or the shared `CliConsoleBody` primitive.
+4. **`src/server/sourceManagerRegistry.ts`** + **`src/server/meshtasticManager.ts`** — read these two before any feature touching nodes/messages/telemetry. There is no global `meshtasticManager` singleton; everything is per-source.
+5. **One repository under `src/db/repositories/`** (e.g. `auth.ts`) — read before adding a query. Raw SQL outside this directory is ESLint-banned.
 
 ## Where things live
 

--- a/docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md
+++ b/docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md
@@ -1,0 +1,305 @@
+# MeshCore Remote Administration — Architecture Notes
+
+Internal reference for anyone touching the MeshCore CLI/admin code. Covers
+the wire protocol, the credential store, the danger guard, the local-vs-
+remote dispatch, and the shared frontend primitive.
+
+> **Read this first if you're about to:** add a new admin route, change the
+> credential storage, expose a new MeshCore CLI surface, or rename anything
+> in `meshcoreManager.ts` / `meshcoreNativeBackend.ts` / `CliConsoleBody.tsx`.
+
+## TL;DR
+
+- **MeshCore admin is CLI text sent as an encrypted DM with `txt_type = 1`.**
+  No dedicated PortNum, no Meshtastic-style AdminMessage protobuf.
+- **Server-side ACL on the remote node** authorizes the sender by their
+  X25519 public key. `setperm <pubkey> <level>` mutates that ACL.
+- **Saved passwords are AES-256-GCM-encrypted** with an HKDF-derived key
+  from `SESSION_SECRET`. Each envelope carries a `kid` fingerprint so a
+  rotated `SESSION_SECRET` is detected and surfaced cleanly (not as a
+  silent auth-tag failure).
+- **The plaintext password never crosses the wire to the frontend** after
+  it's first saved. The auto-login route reads the envelope, decrypts
+  server-side, and uses the plaintext in-process only.
+- **Destructive commands require `confirm: true`** in both the client
+  modal and the server route. Same regex in both places.
+- **Local and remote consoles share `CliConsoleBody`.** The difference
+  is what wraps it: remote layers login + capability + auto-login + stats
+  on top; local does not.
+
+## The MeshCore protocol surface
+
+### Why there's no separate "admin" packet type
+
+MeshCore's design choice: a CLI command going to a remote repeater is
+just an encrypted DM with one byte flipped. The packet type is the same
+`PAYLOAD_TYPE_TXT_MSG = 0x02` as a normal chat message. The distinguishing
+field is **`txt_type`**:
+
+```
+txt_type byte (first byte of the encrypted body):
+  0  TxtTypes.Plain        — chat DM
+  1  TxtTypes.CliData      — CLI command (or reply)
+  2  TxtTypes.SignedPlain  — chat DM with 4-byte sig prefix (rare)
+```
+
+This means the entire wire-level "admin protocol" is reusing the DM
+plumbing. Encryption is the per-contact X25519 ECDH shared secret. The
+remote node's firmware dispatches the text into `CommonCLI::handleCommand`
+when `txt_type == 1` instead of the chat handler.
+
+**Consequence for MeshMonitor:** routing CLI traffic out of the chat log
+matters. `meshcoreNativeBackend.ts` filters incoming `ContactMsgRecv`
+events by `msg.txtType` — `CliData` emits a `cli_reply` bridge event
+instead of `contact_message`. Without that filter, CLI output would land
+in the user's chat thread.
+
+### Single-packet, no chunking, no request IDs
+
+Replies are **always one packet** (≈130-180 bytes after framing). There
+is no fragmentation. Long output (`get acl` listing 50 entries) is
+truncated at the firmware level — there is no application-level way to
+ask "send me the rest."
+
+There is also **no request ID** in the protocol. Correlation is by sender
+pubkey + the implicit ordering: we serialize one outstanding command per
+remote node (per-prefix lock in `meshcoreManager.ts`) so the next reply
+must belong to the in-flight command. Two callers can't have overlapping
+requests against the same target.
+
+This also means **never expose a "send N commands in parallel" API**.
+That breaks the correlation invariant and will silently misroute replies.
+
+### Authentication model
+
+There is no separate admin keypair. The authenticating identity is the
+sender's normal node X25519 public key. Authorization is a server-side
+ACL on the remote node keyed on that pubkey.
+
+`CMD_SEND_LOGIN` (companion-protocol opcode 26) populates that ACL. After
+a successful login, the remote stores `{pubkey → permission_level}` and
+subsequent CLI commands from that pubkey are dispatched at the granted
+level. The ACL slot can be evicted (LRU when full) or wiped on reboot,
+which is why `loginToNode` is treated as cheap to repeat.
+
+The login replay-protection check is a timestamp in the request, so
+clocks must be roughly aligned. The companion firmware doesn't sync
+clocks automatically — that's what `clock sync` is for.
+
+Permission levels (from `setperm <pubkey-hex> <level>`):
+
+| Level | Name        | What it lets you do                                |
+|-------|-------------|----------------------------------------------------|
+| 0     | (remove)    | Revoke the ACL entry entirely                      |
+| 1     | Guest       | Read-only stats / telemetry / `ver`               |
+| 2     | ReadWrite   | Room servers only — post to the room              |
+| 3     | Admin       | Full config + ACL management                      |
+
+The `MeshCoreAclManager` form maps directly to this command. No level=2
+on Repeaters in practice — the dropdown still exposes it because the
+firmware accepts it.
+
+## Credential store
+
+Lives in `src/server/services/meshcoreCredentialStore.ts`.
+
+### Why AES-GCM + HKDF instead of bcrypt?
+
+The remote-admin password must be **reversible** — we need the plaintext
+to feed to `loginToNode`. One-way hashes (bcrypt/argon2) would defeat
+the purpose. AES-256-GCM gives confidentiality + integrity.
+
+### The key fingerprint (`kid`)
+
+Each envelope is:
+
+```json
+{
+  "v":   1,
+  "kid": "9940d2e5",
+  "iv":  "<24 hex chars>",
+  "ct":  "<hex>",
+  "tag": "<32 hex chars>"
+}
+```
+
+- `v` — KDF version. Bump on info-string changes.
+- `kid` — first 4 bytes of `HKDF(SESSION_SECRET, "meshcore-admin-creds-fingerprint-v1")`. **NOT the encryption key.** Lets us detect "this row was encrypted with a different `SESSION_SECRET`" cheaply, without attempting decrypt.
+- `iv` — 12-byte AES-GCM nonce, random per envelope.
+- `ct` — ciphertext.
+- `tag` — 16-byte AES-GCM auth tag.
+
+The actual encryption key is `HKDF(SESSION_SECRET, "meshcore-admin-creds-aead-v1", 32)` — different info-string so the fingerprint can't be used to attack the key.
+
+The HKDF uses a stable zero salt because we need deterministic derivation
+— we can't persist a random salt without re-introducing the same
+"rotation detection" problem we're trying to avoid.
+
+### Three load outcomes
+
+`store.load(sourceId, publicKey)` returns one of:
+
+- `{ kind: 'none' }` — nothing saved.
+- `{ kind: 'ok', password }` — decryption succeeded; the password is the
+  plaintext, **for in-process use only**. Never echo it in any response.
+- `{ kind: 'key_rotated', storedKid }` — saved envelope doesn't decrypt
+  under the current `SESSION_SECRET`. UI surfaces this as a banner and
+  prompts re-entry. We do NOT return `storedKid` to the frontend — an
+  attacker shouldn't be able to enumerate prior fingerprints.
+
+### Capability gating
+
+When `SESSION_SECRET` is auto-generated (not configured via env), the
+store reports `canRemember=false`. The route refuses to persist with
+`code: CREDENTIAL_PERSISTENCE_DISABLED` and the UI hides the "Remember
+password" checkbox with a tooltip explaining why. Persisting against an
+ephemeral key would lose every saved password on every restart, which
+is worse than just re-prompting.
+
+### Threat model boundary
+
+The credential store defends against **DB-file-only exfil**. Someone
+who grabs `meshmonitor.db` without the host environment can't decrypt.
+
+It does **not** defend against host compromise. Anyone running code on
+the server has both `SESSION_SECRET` and the DB. This is the same
+posture as the existing channel-PSK storage (which is plaintext in the
+DB by design, because the server uses those PSKs to decrypt packets).
+
+## The danger guard
+
+Pattern: `/(reboot|erase|clkreboot|factory)/i`.
+
+**Two independent enforcement points**, intentionally duplicated:
+
+1. **Server-side** in `meshcoreRoutes.ts` for both `/admin/cli` and
+   `/cli`. The regex constant `DANGER_COMMAND_PATTERN` is defined once
+   in the file; the routes share it.
+2. **Client-side** in `CliConsoleBody.tsx`. Same regex literal. Opens a
+   typed-name confirmation modal where the user must type the contact
+   name (or local device name) to enable Confirm.
+
+The client modal is the natural UX; the server check is defense in
+depth so a script or hostile browser extension that strips the modal
+still gets the prompt-as-requirement.
+
+**If you change the regex on one side, change it on the other.** The
+test `it.each([['reboot'],['Reboot'],['erase'],['clkreboot'],['factory reset'],['set factory mode']])`
+in `meshcoreRoutes.test.ts` catches a missed update on the server side;
+no equivalent test exists client-side, so be careful with the React file.
+
+## Local vs remote dispatch
+
+Both go through `CliConsoleBody`, but the wire path is completely
+different.
+
+### Remote (`/admin/cli`)
+
+- Target: arbitrary node on the mesh, by `publicKey`.
+- Path: `MeshCoreManager.sendCliCommand` → `send_cli` bridge command
+  → `connection.sendTextMessage(pubkey, text, TxtTypes.CliData)`.
+- Reply arrives async via `ContactMsgRecv` event with `txtType=CliData`.
+- Auth: server-side ACL on the remote, populated by a prior `loginToNode`.
+- Permission: `remote_admin:write` per-source.
+
+### Local (`/cli`)
+
+- Target: the locally-connected device. No `publicKey` parameter.
+- Permission: `configuration:write` per-source.
+- Dispatch depends on local firmware (`deviceType`):
+
+| Local firmware | What you get |
+|---|---|
+| Repeater / Room Server (2/3) | Forwarded to `sendRepeaterCommand`. The device has a real serial text CLI. Whatever the device prints comes back. |
+| Companion (1) | `runSyntheticLocalCli` — a small interpreter mapping `ver` / `stats [core\|radio\|packets]` / `clock` / `advert` / `help` to existing companion-protocol bridge commands. Unknown verbs return a usage hint, NOT an error. |
+| Unknown (0) | 400 — "not available for this device type". The catalog also hides the quick-action row so the user can't blindly click commands that won't work. |
+
+**The Companion synthetic CLI is intentionally small.** It covers
+read-only state inspection. Mutating verbs (`set name`, `set radio`,
+etc.) are deliberately omitted because the existing form UI in
+`MeshCoreConfigurationView` already handles them with proper validation.
+Adding `set X` to the synthetic CLI would duplicate that logic without
+adding capability.
+
+If you need to extend the synthetic CLI: add the verb to
+`runSyntheticLocalCli`, add the catalog entry to
+`COMPANION_ACTION_CATALOG` in `MeshCoreLocalConsole.tsx`, and add a
+unit test to `meshcoreManager.localCli.test.ts`.
+
+## The CliConsoleBody primitive
+
+`src/components/MeshCore/CliConsoleBody.tsx` owns:
+
+- The transcript (`sent` / `reply` / `error` / `info` line kinds).
+- The command input + Send button.
+- The quick-action button row driven by `actionCatalog` prop.
+- The danger-confirm modal.
+- The ↑/↓ command history (in-memory, component-scoped, cap of 50).
+
+Wrappers layer additional state on top via the imperative handle
+(`CliConsoleBodyHandle`):
+
+```typescript
+interface CliConsoleBodyHandle {
+  appendInfo(text: string): void;         // push an info line
+  clear(): void;                          // wipe transcript
+  runCommand(cmd, opts?): Promise<void>;  // run as if user typed it
+}
+```
+
+`runCommand` is the entry point for sibling forms (e.g.
+`MeshCoreAclManager`) that want their result to land in the same
+transcript as free-typed commands. The form calls
+`bodyRef.current.runCommand('setperm abcd... 3')` and the lifecycle
+(transcript append → wire send → transcript reply) runs exactly as if
+the user had typed and pressed Send.
+
+### Why three transcript line kinds for output?
+
+- `sent` (`>` prefix, blue) — request side.
+- `reply` (`<` prefix, default color) — happy-path response.
+- `error` (`!` prefix, red) — fetch failed, timeout, rejection.
+- `info` (`*` prefix, italic muted) — system-level messages: "Logged
+  in", "Logged in with saved password", "Stored password forgotten".
+
+Keep these distinct so a user scanning the transcript can tell at a
+glance whether something needs attention.
+
+## File map
+
+| Path | Role |
+|---|---|
+| `src/server/services/meshcoreCredentialStore.ts` | AES-GCM + HKDF, capability + key-rotation detection. |
+| `src/server/meshcoreManager.ts` | `sendCliCommand` (remote, serialized), `sendLocalCliCommand` (dispatcher), `runSyntheticLocalCli` (Companion). |
+| `src/server/meshcoreNativeBackend.ts` | `send_cli` bridge command + `cli_reply` event filter. |
+| `src/server/routes/meshcoreRoutes.ts` | `/admin/cli`, `/admin/login`, `/admin/login-with-saved`, `/admin/credentials-capability`, `/admin/credentials/:pk` DELETE, `/cli`. `DANGER_COMMAND_PATTERN` lives here. |
+| `src/server/migrations/070_meshcore_admin_credential.ts` | `meshcore_nodes.adminCredential` column. |
+| `src/components/MeshCore/CliConsoleBody.tsx` | Shared transcript / input / actions / danger modal / history. |
+| `src/components/MeshCore/MeshCoreRemoteConsole.tsx` | Remote wrapper: login + capability + auto-login + rotated banner + stats. |
+| `src/components/MeshCore/MeshCoreLocalConsole.tsx` | Local wrapper: device-type-aware catalog, no auth layer. |
+| `src/components/MeshCore/MeshCoreAclManager.tsx` | Setperm form, mounted alongside the body for Repeater / RoomServer targets. |
+| `src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx` | Structured status panel for the remote console. |
+
+## PR history
+
+| PR | What landed |
+|---|---|
+| #3160 | Phase 1-3: backend primitives, credential store, remote console with login + auto-login. |
+| #3161 | Phase 4a: stats panel, quick-action buttons, danger-command guard. Catppuccin theming pass. |
+| #3162 | Local CLI console in the Configuration view; `CliConsoleBody` extracted as a shared primitive. |
+| (this) | ACL manager form, command history, this doc. |
+
+## Things that look tempting but aren't worth doing
+
+- **Adding `set <key> <value>` to the synthetic Companion CLI.** Already covered by the configuration form with proper validation.
+- **Adding `get acl` UI to the remote console.** The `get acl` command is serial-only on the firmware side — it won't reply over the mesh. Use the binary `REQ_TYPE_GET_ACCESS_LIST` request if you really need a list view (not wrapped in meshcore.js yet; would need a new bridge command).
+- **Removing the per-prefix CLI serialization to "speed up" admin work.** The protocol has no request IDs — serialization is the only way reply routing stays correct. Don't.
+- **Letting the client send a `kid` to identify which envelope to decrypt.** Pointless: there's only one envelope per (sourceId, publicKey) pair, and exposing kid to the client gives a hostile script a way to fingerprint `SESSION_SECRET` rotations.
+
+## Things that ARE worth doing later
+
+- **`reboot` for local Companion** — add `case 'reboot'` to the dispatch in `meshcoreNativeBackend.ts` mapping to `connection.reboot()`. Wire it up in the synthetic CLI catalog. ~15 lines total.
+- **Structured `GetAccessList`** — wrap the binary request in `meshcoreNativeBackend.ts` and add a list view to `MeshCoreAclManager`. Would let users see what's currently in the ACL before changing it.
+- **Persist transcript / history across remounts** — sessionStorage keyed on `targetId`. Useful if users frequently switch contacts mid-session.
+- **Per-command audit log entries** — `requirePermission` already audits the route call, but the command text isn't in the audit row. One-line addition in each CLI handler.
+- **Command autocomplete on Tab** — would benefit both consoles; lives in `CliConsoleBody`.

--- a/src/components/MeshCore/CliConsoleBody.tsx
+++ b/src/components/MeshCore/CliConsoleBody.tsx
@@ -54,6 +54,12 @@ export interface CliConsoleBodyHandle {
   appendInfo: (text: string) => void;
   /** Clear the transcript. */
   clear: () => void;
+  /** Run a command exactly as if the user had typed it into the input
+   *  and pressed Send: the command lands in the transcript as a sent
+   *  line, the reply / error lands as a reply / error line, history is
+   *  updated. Used by sibling forms (e.g. ACL manager) so their output
+   *  shares one transcript with free-typed commands. */
+  runCommand: (command: string, opts?: { confirm?: boolean }) => Promise<void>;
 }
 
 interface TranscriptEntry {
@@ -112,6 +118,18 @@ export const CliConsoleBody = forwardRef<CliConsoleBodyHandle, CliConsoleBodyPro
   const [dangerConfirm, setDangerConfirm] = useState<null | { command: string; typedName: string }>(null);
   const transcriptEndRef = useRef<HTMLDivElement | null>(null);
 
+  // Command history — ↑/↓ in the input row cycle through previously-sent
+  // commands. Cap at 50 to keep the buffer bounded; oldest entries are
+  // dropped when full. History is scoped to the component instance (not
+  // per-target) so a user can repeat the same command across different
+  // contacts without retyping. `draft` preserves an in-progress command
+  // when the user starts navigating history, so ArrowDown past the end
+  // restores what they were typing.
+  const historyRef = useRef<string[]>([]);
+  const historyIndexRef = useRef<number | null>(null);
+  const draftRef = useRef<string>('');
+  const HISTORY_MAX = 50;
+
   useEffect(() => {
     transcriptEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
   }, [transcript]);
@@ -128,16 +146,20 @@ export const CliConsoleBody = forwardRef<CliConsoleBodyHandle, CliConsoleBodyPro
     setTranscript((prev) => [...prev, { id: nextId(), ts: Date.now(), ...entry }]);
   }, []);
 
-  useImperativeHandle(ref, () => ({
-    appendInfo: (text: string) => appendTranscript({ kind: 'info', text }),
-    clear: () => setTranscript([]),
-  }), [appendTranscript]);
-
   const runAndLog = useCallback(async (cmd: string, opts?: { confirm?: boolean }) => {
     if (sending) return;
     setSending(true);
     appendTranscript({ kind: 'sent', text: cmd });
     setCommand('');
+    // Push to history. Skip duplicates of the most recent entry so
+    // hammering Send on the same command doesn't bloat the buffer.
+    const prev = historyRef.current;
+    if (prev[prev.length - 1] !== cmd) {
+      prev.push(cmd);
+      if (prev.length > HISTORY_MAX) prev.shift();
+    }
+    historyIndexRef.current = null;
+    draftRef.current = '';
     const result = await runCommand(cmd, opts);
     setSending(false);
     if (result.ok) {
@@ -153,6 +175,12 @@ export const CliConsoleBody = forwardRef<CliConsoleBodyHandle, CliConsoleBodyPro
       appendTranscript({ kind: 'error', text: `${result.error}${hint}` });
     }
   }, [appendTranscript, runCommand, sending, t]);
+
+  useImperativeHandle(ref, () => ({
+    appendInfo: (text: string) => appendTranscript({ kind: 'info', text }),
+    clear: () => setTranscript([]),
+    runCommand: (cmd: string, opts?: { confirm?: boolean }) => runAndLog(cmd, opts),
+  }), [appendTranscript, runAndLog]);
 
   const handleSend = useCallback(async () => {
     const trimmed = command.trim();
@@ -226,7 +254,44 @@ export const CliConsoleBody = forwardRef<CliConsoleBodyHandle, CliConsoleBodyPro
         <input
           type="text"
           value={command}
-          onChange={(e) => setCommand(e.target.value)}
+          onChange={(e) => {
+            setCommand(e.target.value);
+            // User started typing fresh — drop the history cursor.
+            if (historyIndexRef.current !== null) {
+              historyIndexRef.current = null;
+              draftRef.current = '';
+            }
+          }}
+          onKeyDown={(e) => {
+            // History navigation. Only when not modified by Ctrl/Alt/Meta
+            // so we don't fight the browser's own shortcuts.
+            if (e.ctrlKey || e.altKey || e.metaKey) return;
+            const hist = historyRef.current;
+            if (hist.length === 0) return;
+            if (e.key === 'ArrowUp') {
+              e.preventDefault();
+              if (historyIndexRef.current === null) {
+                // Save what the user was typing before we hijack the input.
+                draftRef.current = command;
+                historyIndexRef.current = hist.length - 1;
+              } else if (historyIndexRef.current > 0) {
+                historyIndexRef.current -= 1;
+              }
+              setCommand(hist[historyIndexRef.current]);
+            } else if (e.key === 'ArrowDown') {
+              if (historyIndexRef.current === null) return;
+              e.preventDefault();
+              if (historyIndexRef.current < hist.length - 1) {
+                historyIndexRef.current += 1;
+                setCommand(hist[historyIndexRef.current]);
+              } else {
+                // Moved past the newest entry — restore the saved draft.
+                historyIndexRef.current = null;
+                setCommand(draftRef.current);
+                draftRef.current = '';
+              }
+            }
+          }}
           placeholder={
             disabled
               ? disabledPlaceholder ?? t('meshcore.remoteConsole.command_placeholder_logged_out', 'Log in first')

--- a/src/components/MeshCore/MeshCoreAclManager.css
+++ b/src/components/MeshCore/MeshCoreAclManager.css
@@ -1,0 +1,77 @@
+.meshcore-acl-manager {
+  border: 1px solid var(--ctp-surface1);
+  border-radius: var(--radius-md, 6px);
+  background: var(--ctp-surface0);
+  padding: 0.6rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.acl-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ctp-text);
+}
+
+.acl-hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--ctp-subtext0);
+  line-height: 1.4;
+}
+
+.acl-form {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 0.5rem;
+  align-items: end;
+}
+
+@media (max-width: 600px) {
+  .acl-form {
+    grid-template-columns: 1fr;
+  }
+}
+
+.acl-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.acl-field-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ctp-subtext0);
+}
+
+.acl-input {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--ctp-surface2);
+  background: var(--ctp-base);
+  color: var(--ctp-text);
+  border-radius: var(--radius-md, 4px);
+  font: inherit;
+  font-size: 0.85rem;
+}
+
+.acl-input:focus {
+  outline: none;
+  border-color: var(--ctp-mauve);
+}
+
+.acl-pubkey-input {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.acl-input-invalid {
+  border-color: var(--ctp-red);
+}
+
+.acl-error-hint {
+  font-size: 0.75rem;
+  color: var(--ctp-red);
+}

--- a/src/components/MeshCore/MeshCoreAclManager.tsx
+++ b/src/components/MeshCore/MeshCoreAclManager.tsx
@@ -1,0 +1,134 @@
+/**
+ * MeshCoreAclManager
+ *
+ * Structured form for the most common MeshCore Repeater / Room Server
+ * admin operation: granting or revoking ACL entries via `setperm`.
+ *
+ * Why a form instead of just letting the user type `setperm` into the
+ * console? Typing 64 hex chars by hand is error-prone, and getting the
+ * permission level number wrong silently grants the wrong access. The
+ * form validates the pubkey shape and surfaces the level names so the
+ * user picks a level rather than memorizing 0/1/2/3.
+ *
+ * Result routing: the form has no transcript of its own — it pushes
+ * the built `setperm <pubkey> <level>` command through the parent's
+ * shared CliConsoleBody handle so the command + reply appear inline
+ * with whatever else the user typed in the console.
+ *
+ * No list view in v1. The firmware's `get acl` command is serial-only
+ * (works on a directly-connected Repeater but not over the mesh), and
+ * the structured `GetAccessList` binary request isn't wrapped in
+ * meshcore.js yet. A user can still type `get acl` manually into the
+ * local console for a Repeater they're physically attached to.
+ */
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { CliConsoleBodyHandle } from './CliConsoleBody';
+import './MeshCoreAclManager.css';
+
+/** Permission levels recognized by MeshCore's `setperm` command.
+ *  Mapping from the firmware (CommonCLI.cpp handleCommand):
+ *    0 — remove the ACL entry (revoke all access)
+ *    1 — guest (read-only stats / telemetry)
+ *    2 — read-write (room servers only — can post)
+ *    3 — admin (full control, including ACL management)
+ */
+const PERMISSION_LEVELS = [
+  { value: 0, key: 'remove',    defaultLabel: 'Remove (revoke access)' },
+  { value: 1, key: 'guest',     defaultLabel: 'Guest (read-only)' },
+  { value: 2, key: 'readwrite', defaultLabel: 'Read/Write (room servers)' },
+  { value: 3, key: 'admin',     defaultLabel: 'Admin (full control)' },
+] as const;
+
+interface MeshCoreAclManagerProps {
+  /** Imperative handle into the sibling CliConsoleBody. The form pushes
+   *  its built command through this so the result lands in the console
+   *  transcript, exactly as if the user had typed it. */
+  bodyRef: React.RefObject<CliConsoleBodyHandle | null>;
+  /** Disables the form (e.g. remote console: !loggedIn). */
+  disabled?: boolean;
+}
+
+export const MeshCoreAclManager: React.FC<MeshCoreAclManagerProps> = ({
+  bodyRef,
+  disabled = false,
+}) => {
+  const { t } = useTranslation();
+  const [pubkey, setPubkey] = useState('');
+  const [level, setLevel] = useState<number>(1);
+  const [busy, setBusy] = useState(false);
+
+  const normalized = pubkey.trim().toLowerCase();
+  const valid = /^[0-9a-f]{64}$/.test(normalized);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!valid || disabled || busy) return;
+    setBusy(true);
+    try {
+      await bodyRef.current?.runCommand(`setperm ${normalized} ${level}`);
+      // Clear the pubkey on success so the user doesn't accidentally
+      // apply a different level to the same key without re-pasting.
+      setPubkey('');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="meshcore-acl-manager" aria-label={t('meshcore.acl.title', 'Manage access list')}>
+      <h4 className="acl-title">{t('meshcore.acl.title', 'Manage access list')}</h4>
+      <p className="acl-hint">
+        {t(
+          'meshcore.acl.hint',
+          'Grant or revoke admin / guest access for a specific public key. Translates to a `setperm` command.',
+        )}
+      </p>
+      <form className="acl-form" onSubmit={handleSubmit}>
+        <label className="acl-field">
+          <span className="acl-field-label">{t('meshcore.acl.pubkey_label', 'Public key (64 hex)')}</span>
+          <input
+            type="text"
+            value={pubkey}
+            onChange={(e) => setPubkey(e.target.value)}
+            placeholder="0123456789abcdef…"
+            spellCheck={false}
+            autoComplete="off"
+            disabled={disabled || busy}
+            className={`acl-input acl-pubkey-input${pubkey.length > 0 && !valid ? ' acl-input-invalid' : ''}`}
+          />
+          {pubkey.length > 0 && !valid && (
+            <span className="acl-error-hint">
+              {t('meshcore.acl.pubkey_invalid', 'Must be exactly 64 hex characters')}
+            </span>
+          )}
+        </label>
+        <label className="acl-field">
+          <span className="acl-field-label">{t('meshcore.acl.level_label', 'Permission level')}</span>
+          <select
+            value={level}
+            onChange={(e) => setLevel(parseInt(e.target.value, 10))}
+            disabled={disabled || busy}
+            className="acl-input"
+          >
+            {PERMISSION_LEVELS.map((l) => (
+              <option key={l.value} value={l.value}>
+                {t(`meshcore.acl.level.${l.key}`, l.defaultLabel)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="submit"
+          className="mrc-btn-primary"
+          disabled={disabled || busy || !valid}
+        >
+          {busy
+            ? t('meshcore.acl.applying', 'Applying…')
+            : t('meshcore.acl.apply', 'Apply')}
+        </button>
+      </form>
+    </section>
+  );
+};

--- a/src/components/MeshCore/MeshCoreLocalConsole.tsx
+++ b/src/components/MeshCore/MeshCoreLocalConsole.tsx
@@ -19,10 +19,11 @@
  * commands that actually work on their hardware.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { MeshCoreActions } from './hooks/useMeshCore';
-import { CliConsoleBody, type ActionCommand } from './CliConsoleBody';
+import { CliConsoleBody, type ActionCommand, type CliConsoleBodyHandle } from './CliConsoleBody';
+import { MeshCoreAclManager } from './MeshCoreAclManager';
 import './MeshCoreRemoteConsole.css';
 
 /** Verbs that the synthetic Companion CLI implements. Keep in sync with
@@ -88,6 +89,11 @@ export const MeshCoreLocalConsole: React.FC<MeshCoreLocalConsoleProps> = ({
     [actions],
   );
 
+  // ACL management is meaningful on Repeater (2) and Room Server (3)
+  // local firmware. Companion has no ACL concept.
+  const showAcl = connected && (deviceType === 2 || deviceType === 3);
+  const bodyRef = useRef<CliConsoleBodyHandle | null>(null);
+
   return (
     <section className="meshcore-remote-console" aria-label={t('meshcore.localConsole.title', 'Device console')}>
       <header className="mrc-header">
@@ -106,6 +112,7 @@ export const MeshCoreLocalConsole: React.FC<MeshCoreLocalConsoleProps> = ({
       </header>
 
       <CliConsoleBody
+        ref={bodyRef}
         targetId={sourceId}
         targetName={targetName}
         runCommand={runCommand}
@@ -132,6 +139,8 @@ export const MeshCoreLocalConsole: React.FC<MeshCoreLocalConsoleProps> = ({
           'Type a command below and press Send.',
         )}
       />
+
+      {showAcl && <MeshCoreAclManager bodyRef={bodyRef} />}
     </section>
   );
 };

--- a/src/components/MeshCore/MeshCoreRemoteConsole.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.tsx
@@ -22,6 +22,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { MeshCoreActions } from './hooks/useMeshCore';
 import { MeshCoreRemoteStatsPanel } from './MeshCoreRemoteStatsPanel';
+import { MeshCoreAclManager } from './MeshCoreAclManager';
 import { CliConsoleBody, type ActionCommand, type CliConsoleBodyHandle } from './CliConsoleBody';
 import './MeshCoreRemoteConsole.css';
 
@@ -239,6 +240,8 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
         actionCatalog={loggedIn ? REMOTE_ACTION_CATALOG : []}
         disabled={!loggedIn}
       />
+
+      {loggedIn && <MeshCoreAclManager bodyRef={bodyRef} />}
 
       {showLogin && (
         <div


### PR DESCRIPTION
## Summary

Three follow-ups on top of the existing MeshCore CLI consoles. Each is small but useful.

- **ACL setperm form** — structured \`setperm <pubkey> <level>\` form mounted alongside the console for Repeater / RoomServer targets. Pubkey input validates 64 hex chars; permission dropdown surfaces Remove / Guest / ReadWrite / Admin instead of memorizing 0/1/2/3. Result lands in the shared transcript.
- **Command history** — ↑/↓ arrow keys in the console input cycle through previously-sent commands. Bounded at 50 entries, de-duped, component-scoped. ArrowDown past the newest restores the in-progress draft.
- **Internal docs** — \`docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md\` documents the architecture so the next agent doesn't have to re-derive it. Read-order in CLAUDE.md updated to point at it.

## Why the ACL form pushes through the shared transcript instead of having its own result area

Two places displaying command results would be confusing — \"did I run that or not?\" Solved by exposing \`runCommand\` on the \`CliConsoleBodyHandle\` so sibling forms get the same transcript lifecycle as free-typed commands.

## Why no \"List ACL\" view

\`get acl\` is **serial-only** in the firmware — it doesn't reply over the mesh. The binary \`REQ_TYPE_GET_ACCESS_LIST\` works but isn't wrapped in meshcore.js yet. Surfaced in the internal doc's \"worth doing later\" section.

## Files

- \`src/components/MeshCore/MeshCoreAclManager.tsx\` + \`.css\` (new) — the form.
- \`src/components/MeshCore/CliConsoleBody.tsx\` — command history + \`runCommand\` exposed via the imperative handle.
- \`src/components/MeshCore/MeshCoreRemoteConsole.tsx\` + \`MeshCoreLocalConsole.tsx\` — mount the ACL form.
- \`docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md\` (new) — architecture doc.
- \`CLAUDE.md\` — read-order updated.

## Test plan

- [x] \`npx vitest run\` — 10461 tests, 0 failures.
- [x] \`npx tsc --noEmit\` clean.
- [x] ESLint clean on changed files.
- [ ] Manual smoke test against a real Repeater — deferred. The ACL form is a thin wrapper over the existing \`setperm\` CLI verb, which is already exercised by typing it free-form. Command history is pure-frontend.
- [ ] CI green (will monitor via \`/ci-monitor\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)