### PR TITLE
feat(mqtt): per-source detail dashboard for broker and bridge

### DIFF
--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -104,6 +104,7 @@ function getStatusInfo(
 
 interface KebabMenuProps {
   sourceId: string;
+  sourceType: string;
   sourceEnabled: boolean;
   /** When true, render a "Disconnect" item (manager running + autoConnect=false). */
   canDisconnect?: boolean;
@@ -111,6 +112,8 @@ interface KebabMenuProps {
   canPruneOutsideRoi?: boolean;
   /** When true, render a "Resync" item (meshtastic_tcp source currently connected). */
   canResync?: boolean;
+  /** Required for MQTT sources — Open/Edit navigate to the per-source detail page. */
+  onOpen?: (id: string) => void;
   onEdit: (id: string) => void;
   onToggle: (id: string, enabled: boolean) => void;
   onDelete: (id: string) => void;
@@ -121,10 +124,12 @@ interface KebabMenuProps {
 
 const KebabMenu: React.FC<KebabMenuProps> = ({
   sourceId,
+  sourceType,
   sourceEnabled,
   canDisconnect,
   canPruneOutsideRoi,
   canResync,
+  onOpen,
   onEdit,
   onToggle,
   onDelete,
@@ -132,6 +137,11 @@ const KebabMenu: React.FC<KebabMenuProps> = ({
   onPruneOutsideRoi,
   onResync,
 }) => {
+  // MQTT sources get a per-source detail page (Map + Settings tabs) rather
+  // than an inline modal. For those, "Open" replaces "Edit" in the kebab and
+  // the row body click navigates to the same place. Other source types keep
+  // the legacy modal-based edit flow until they grow their own detail pages.
+  const isMqttSource = sourceType === 'mqtt_broker' || sourceType === 'mqtt_bridge';
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -161,16 +171,29 @@ const KebabMenu: React.FC<KebabMenuProps> = ({
       </button>
       {open && (
         <div className="dashboard-kebab-menu">
-          <button
-            className="dashboard-kebab-item"
-            onClick={(e) => {
-              e.stopPropagation();
-              setOpen(false);
-              onEdit(sourceId);
-            }}
-          >
-            {t('source.kebab.edit')}
-          </button>
+          {isMqttSource && onOpen ? (
+            <button
+              className="dashboard-kebab-item"
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpen(false);
+                onOpen(sourceId);
+              }}
+            >
+              {t('source.kebab.open', 'Open')}
+            </button>
+          ) : (
+            <button
+              className="dashboard-kebab-item"
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpen(false);
+                onEdit(sourceId);
+              }}
+            >
+              {t('source.kebab.edit')}
+            </button>
+          )}
           <button
             className="dashboard-kebab-item"
             onClick={(e) => {
@@ -265,8 +288,23 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
   const { hasPermission } = useAuth();
 
   // On mobile, wrap source selection so the drawer auto-closes after tap.
+  // MQTT sources (broker, bridge) navigate to their per-source detail page
+  // instead of the legacy "select then render in-pane" flow.
   const handleSelectSource = (id: string) => {
+    const source = sources.find((s) => s.id === id);
+    if (source && (source.type === 'mqtt_broker' || source.type === 'mqtt_bridge')) {
+      navigate(`/source/${id}/`);
+      onMobileClose?.();
+      return;
+    }
     onSelectSource(id);
+    onMobileClose?.();
+  };
+
+  // Dedicated handler for the kebab "Open" action — always navigates,
+  // bypasses the type check (only MQTT sources surface this action anyway).
+  const handleOpenSource = (id: string) => {
+    navigate(`/source/${id}/`);
     onMobileClose?.();
   };
 
@@ -382,6 +420,7 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
                 return (
                   <KebabMenu
                     sourceId={source.id}
+                    sourceType={source.type}
                     sourceEnabled={source.enabled}
                     canDisconnect={
                       (source.config as any)?.autoConnect === false &&
@@ -392,6 +431,7 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
                       source.type === 'meshtastic_tcp' &&
                       status?.connected === true
                     }
+                    onOpen={handleOpenSource}
                     onEdit={onEditSource}
                     onToggle={onToggleSource}
                     onDelete={onDeleteSource}

--- a/src/components/MqttSourcePageShell/MqttBridgeSettingsTab.tsx
+++ b/src/components/MqttSourcePageShell/MqttBridgeSettingsTab.tsx
@@ -1,0 +1,459 @@
+/**
+ * MqttBridgeSettingsTab — editable settings for an `mqtt_bridge` source.
+ *
+ * Fields mirror the legacy DashboardPage edit modal: name, parent broker
+ * (or standalone), upstream URL/credentials, subscriptions, downlink
+ * topic-block filter, downlink geo bbox filter. Topic-rewriting fields
+ * are added by PR B (#3166) into the placeholder section near the
+ * bottom.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { appBasename } from '../../init';
+import { useCsrf } from '../../contexts/CsrfContext';
+import { useAuth } from '../../contexts/AuthContext';
+import { useToast } from '../ToastContainer';
+import './MqttSettingsTab.css';
+
+export interface MqttBridgeSettingsTabProps {
+  sourceId: string;
+}
+
+interface BridgeSourceResponse {
+  id: string;
+  name: string;
+  type: string;
+  config: {
+    brokerSourceId?: string;
+    upstream?: { url?: string; username?: string; password?: string };
+    subscriptions?: string[];
+    downlinkFilters?: {
+      topics?: { block?: string[] };
+      geo?: { minLat?: number; maxLat?: number; minLng?: number; maxLng?: number };
+    };
+  };
+}
+
+interface SourceListEntry {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export function MqttBridgeSettingsTab({ sourceId }: MqttBridgeSettingsTabProps) {
+  const { t } = useTranslation();
+  const { getToken } = useCsrf();
+  const { hasPermission } = useAuth();
+  const { showToast } = useToast();
+
+  const canEdit = hasPermission('configuration', 'write');
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [availableBrokers, setAvailableBrokers] = useState<SourceListEntry[]>([]);
+
+  const [name, setName] = useState('');
+  const [brokerSourceId, setBrokerSourceId] = useState('');
+  const [upstreamUrl, setUpstreamUrl] = useState('');
+  const [upstreamUsername, setUpstreamUsername] = useState('');
+  const [upstreamPassword, setUpstreamPassword] = useState('');
+  const [subscriptions, setSubscriptions] = useState('msh/#');
+  const [useTopicBlock, setUseTopicBlock] = useState(false);
+  const [topicBlock, setTopicBlock] = useState('');
+  const [useGeo, setUseGeo] = useState(false);
+  const [geoMinLat, setGeoMinLat] = useState('');
+  const [geoMaxLat, setGeoMaxLat] = useState('');
+  const [geoMinLng, setGeoMinLng] = useState('');
+  const [geoMaxLng, setGeoMaxLng] = useState('');
+
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+    (async () => {
+      try {
+        const [sourceRes, listRes] = await Promise.all([
+          fetch(`${appBasename}/api/sources/${sourceId}`, { credentials: 'include' }),
+          fetch(`${appBasename}/api/sources`, { credentials: 'include' }),
+        ]);
+        if (!sourceRes.ok) throw new Error(`HTTP ${sourceRes.status}`);
+        const data = (await sourceRes.json()) as BridgeSourceResponse;
+        const listData = listRes.ok ? ((await listRes.json()) as SourceListEntry[]) : [];
+        if (cancelled) return;
+
+        setName(data.name);
+        setBrokerSourceId(data.config?.brokerSourceId ?? '');
+        setUpstreamUrl(data.config?.upstream?.url ?? '');
+        setUpstreamUsername(data.config?.upstream?.username ?? '');
+        setUpstreamPassword('');
+        setSubscriptions((data.config?.subscriptions ?? ['msh/#']).join('\n'));
+
+        const block = data.config?.downlinkFilters?.topics?.block ?? [];
+        setUseTopicBlock(block.length > 0);
+        setTopicBlock(block.join('\n'));
+
+        const geo = data.config?.downlinkFilters?.geo ?? {};
+        const hasGeo =
+          geo.minLat != null || geo.maxLat != null || geo.minLng != null || geo.maxLng != null;
+        setUseGeo(hasGeo);
+        setGeoMinLat(geo.minLat != null ? String(geo.minLat) : '');
+        setGeoMaxLat(geo.maxLat != null ? String(geo.maxLat) : '');
+        setGeoMinLng(geo.minLng != null ? String(geo.minLng) : '');
+        setGeoMaxLng(geo.maxLng != null ? String(geo.maxLng) : '');
+
+        setAvailableBrokers(listData.filter((s) => s.type === 'mqtt_broker'));
+      } catch (err) {
+        if (!cancelled) {
+          setLoadError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sourceId]);
+
+  const onSave = async () => {
+    if (!name.trim()) {
+      setSaveError(t('source.form.error_name_required', 'Name is required'));
+      return;
+    }
+    if (!upstreamUrl.trim()) {
+      setSaveError(t('source.form.error_mqtt_url_required', 'Upstream URL is required'));
+      return;
+    }
+
+    const subs = subscriptions
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const block = useTopicBlock
+      ? topicBlock.split('\n').map((s) => s.trim()).filter(Boolean)
+      : [];
+
+    const geo: Record<string, number> = {};
+    if (useGeo) {
+      const fields: Array<[string, string]> = [
+        ['minLat', geoMinLat],
+        ['maxLat', geoMaxLat],
+        ['minLng', geoMinLng],
+        ['maxLng', geoMaxLng],
+      ];
+      for (const [key, val] of fields) {
+        if (val.trim()) {
+          const n = Number(val);
+          if (Number.isNaN(n)) {
+            setSaveError(t('source.form.error_geo_invalid', 'Geo bounds must be numbers'));
+            return;
+          }
+          geo[key] = n;
+        }
+      }
+    }
+
+    const downlinkFilters: Record<string, unknown> = {};
+    if (block.length > 0) downlinkFilters.topics = { block };
+    if (Object.keys(geo).length > 0) downlinkFilters.geo = geo;
+
+    const cfg: Record<string, unknown> = {
+      ...(brokerSourceId ? { brokerSourceId } : {}),
+      upstream: {
+        url: upstreamUrl.trim(),
+        username: upstreamUsername.trim() || undefined,
+        ...(upstreamPassword ? { password: upstreamPassword } : {}),
+      },
+      subscriptions: subs.length > 0 ? subs : ['msh/#'],
+      ...(Object.keys(downlinkFilters).length > 0 ? { downlinkFilters } : {}),
+    };
+
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const csrfToken = getToken();
+      const res = await fetch(`${appBasename}/api/sources/${sourceId}`, {
+        method: 'PUT',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-csrf-token': csrfToken || '',
+        },
+        body: JSON.stringify({
+          name: name.trim(),
+          type: 'mqtt_bridge',
+          config: cfg,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        setSaveError((err as { error?: string }).error ?? t('source.form.error_save_failed', 'Failed to save'));
+        return;
+      }
+      setUpstreamPassword('');
+      showToast(t('source.form.saved', 'Settings saved'), 'success');
+    } catch {
+      setSaveError(t('source.form.error_network', 'Network error'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="mqtt-settings-tab">
+        <p>{t('source.mqtt.settings.loading', 'Loading settings…')}</p>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="mqtt-settings-tab">
+        <p className="mqtt-settings-error">
+          {t('source.mqtt.settings.load_error', 'Could not load source: {{err}}', { err: loadError })}
+        </p>
+      </div>
+    );
+  }
+
+  const disabled = !canEdit || saving;
+  const standalone = !brokerSourceId;
+
+  return (
+    <div className="mqtt-settings-tab">
+      <h2>{t('source.mqtt_bridge.settings_title', 'Bridge Settings')}</h2>
+      {!canEdit && (
+        <p className="mqtt-settings-readonly">
+          {t('source.mqtt.settings.readonly', 'Read-only — you do not have permission to edit this source.')}
+        </p>
+      )}
+
+      <div className="mqtt-settings-field">
+        <label htmlFor="bridge-name">{t('source.form.name', 'Name')}</label>
+        <input
+          id="bridge-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+
+      <div className="mqtt-settings-field">
+        <label htmlFor="bridge-parent">{t('source.form.parent_broker', 'Parent broker')}</label>
+        <select
+          id="bridge-parent"
+          value={brokerSourceId}
+          onChange={(e) => setBrokerSourceId(e.target.value)}
+          disabled={disabled}
+        >
+          <option value="">
+            {t('source.form.parent_broker_standalone', 'None — standalone client proxy')}
+          </option>
+          {availableBrokers.map((b) => (
+            <option key={b.id} value={b.id}>
+              {b.name}
+            </option>
+          ))}
+        </select>
+        <p className="mqtt-settings-hint">
+          {standalone
+            ? t(
+                'source.form.parent_broker_hint_standalone',
+                'Standalone — bridge runs as a pure upstream MQTT client. Use as a mqttLink client-proxy target for a Meshtastic source.',
+              )
+            : t(
+                'source.form.parent_broker_hint_attached',
+                'Attached — downlink traffic is republished to this broker so locally-connected devices see it; uplink traffic from the broker is forwarded upstream.',
+              )}
+        </p>
+      </div>
+
+      <h3>{t('source.form.upstream_section', 'Upstream connection')}</h3>
+
+      <div className="mqtt-settings-field">
+        <label htmlFor="bridge-url">{t('source.form.upstream_url', 'Upstream URL')}</label>
+        <input
+          id="bridge-url"
+          type="url"
+          value={upstreamUrl}
+          onChange={(e) => setUpstreamUrl(e.target.value)}
+          disabled={disabled}
+          placeholder="mqtt://mqtt.meshtastic.org"
+        />
+        <p className="mqtt-settings-hint">
+          {t(
+            'source.form.upstream_url_hint',
+            'mqtt:// for plain TCP, mqtts:// for TLS (e.g. mqtts://broker:8883).',
+          )}
+        </p>
+      </div>
+
+      <div className="mqtt-settings-field">
+        <label htmlFor="bridge-username">{t('source.form.username', 'Username')}</label>
+        <input
+          id="bridge-username"
+          type="text"
+          value={upstreamUsername}
+          onChange={(e) => setUpstreamUsername(e.target.value)}
+          disabled={disabled}
+          autoComplete="username"
+        />
+      </div>
+
+      <div className="mqtt-settings-field">
+        <label htmlFor="bridge-password">{t('source.form.password', 'Password')}</label>
+        <input
+          id="bridge-password"
+          type="password"
+          value={upstreamPassword}
+          onChange={(e) => setUpstreamPassword(e.target.value)}
+          disabled={disabled}
+          placeholder={t('source.form.password_unchanged', '(unchanged)')}
+          autoComplete="new-password"
+        />
+        <p className="mqtt-settings-hint">
+          {t('source.form.password_hint', 'Leave blank to keep the current password.')}
+        </p>
+      </div>
+
+      <h3>{t('source.form.subscriptions_section', 'Subscriptions')}</h3>
+
+      <div className="mqtt-settings-field">
+        <label htmlFor="bridge-subscriptions">{t('source.form.subscriptions', 'Upstream topics')}</label>
+        <textarea
+          id="bridge-subscriptions"
+          value={subscriptions}
+          onChange={(e) => setSubscriptions(e.target.value)}
+          disabled={disabled}
+          rows={5}
+        />
+        <p className="mqtt-settings-hint">
+          {t(
+            'source.form.subscriptions_hint',
+            'One per line. MQTT wildcards allowed (+ single segment, # multi-segment tail). e.g. "msh/US/FL/#".',
+          )}
+        </p>
+      </div>
+
+      <h3>{t('source.form.downlink_filters_section', 'Downlink filters')}</h3>
+
+      <div className="mqtt-settings-field mqtt-settings-checkbox">
+        <label htmlFor="bridge-use-topic-block">
+          <input
+            id="bridge-use-topic-block"
+            type="checkbox"
+            checked={useTopicBlock}
+            onChange={(e) => setUseTopicBlock(e.target.checked)}
+            disabled={disabled}
+          />
+          <span>{t('source.form.topic_block', 'Block topics matching these patterns')}</span>
+        </label>
+      </div>
+
+      {useTopicBlock && (
+        <div className="mqtt-settings-field">
+          <label htmlFor="bridge-topic-block">{t('source.form.topic_block_label', 'Block patterns')}</label>
+          <textarea
+            id="bridge-topic-block"
+            value={topicBlock}
+            onChange={(e) => setTopicBlock(e.target.value)}
+            disabled={disabled}
+            rows={4}
+            placeholder="msh/CA/QC/#"
+          />
+          <p className="mqtt-settings-hint">
+            {t('source.form.topic_block_hint', 'One per line. MQTT wildcards allowed.')}
+          </p>
+        </div>
+      )}
+
+      <div className="mqtt-settings-field mqtt-settings-checkbox">
+        <label htmlFor="bridge-use-geo">
+          <input
+            id="bridge-use-geo"
+            type="checkbox"
+            checked={useGeo}
+            onChange={(e) => setUseGeo(e.target.checked)}
+            disabled={disabled}
+          />
+          <span>{t('source.form.geo_bbox', 'Drop position packets outside a bounding box')}</span>
+        </label>
+      </div>
+
+      {useGeo && (
+        <div className="mqtt-settings-field">
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem' }}>
+            <div>
+              <label htmlFor="bridge-geo-minlat">{t('source.form.geo_min_lat', 'Min latitude')}</label>
+              <input
+                id="bridge-geo-minlat"
+                type="number"
+                step="0.001"
+                value={geoMinLat}
+                onChange={(e) => setGeoMinLat(e.target.value)}
+                disabled={disabled}
+              />
+            </div>
+            <div>
+              <label htmlFor="bridge-geo-maxlat">{t('source.form.geo_max_lat', 'Max latitude')}</label>
+              <input
+                id="bridge-geo-maxlat"
+                type="number"
+                step="0.001"
+                value={geoMaxLat}
+                onChange={(e) => setGeoMaxLat(e.target.value)}
+                disabled={disabled}
+              />
+            </div>
+            <div>
+              <label htmlFor="bridge-geo-minlng">{t('source.form.geo_min_lng', 'Min longitude')}</label>
+              <input
+                id="bridge-geo-minlng"
+                type="number"
+                step="0.001"
+                value={geoMinLng}
+                onChange={(e) => setGeoMinLng(e.target.value)}
+                disabled={disabled}
+              />
+            </div>
+            <div>
+              <label htmlFor="bridge-geo-maxlng">{t('source.form.geo_max_lng', 'Max longitude')}</label>
+              <input
+                id="bridge-geo-maxlng"
+                type="number"
+                step="0.001"
+                value={geoMaxLng}
+                onChange={(e) => setGeoMaxLng(e.target.value)}
+                disabled={disabled}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      <h3>{t('source.form.topic_rewrite_section', 'Topic rewriting')}</h3>
+      <p className="mqtt-settings-placeholder">
+        {t(
+          'source.form.topic_rewrite_placeholder',
+          'Coming soon — bridge between meshes that use different MQTT root topics (e.g. msh/US/LA ↔ msh/US/TX). See issue #3166.',
+        )}
+      </p>
+
+      {saveError && <p className="mqtt-settings-error">{saveError}</p>}
+
+      {canEdit && (
+        <div className="mqtt-settings-actions">
+          <button type="button" onClick={onSave} disabled={saving}>
+            {saving ? t('source.form.saving', 'Saving…') : t('source.form.save', 'Save')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MqttSourcePageShell/MqttBrokerSettingsTab.tsx
+++ b/src/components/MqttSourcePageShell/MqttBrokerSettingsTab.tsx
@@ -1,0 +1,286 @@
+/**
+ * MqttBrokerSettingsTab — editable settings for an `mqtt_broker` source.
+ *
+ * Fetches the current config from /api/sources/:id, renders editable
+ * fields (name, listener port, credentials, root topic, zero-hop
+ * injection), and PUTs the merged result back. Matches the field shape
+ * used by the legacy Edit modal in DashboardPage so existing API
+ * validators don't need to change.
+ *
+ * Password field: empty on initial load (non-admin GET strips the
+ * password; admin GET returns it but we deliberately don't pre-fill on
+ * edit — leaving the field empty signals "keep existing"). Submit drops
+ * an empty password field so server-side credential preservation kicks
+ * in.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { appBasename } from '../../init';
+import { useCsrf } from '../../contexts/CsrfContext';
+import { useAuth } from '../../contexts/AuthContext';
+import { useToast } from '../ToastContainer';
+import './MqttSettingsTab.css';
+
+export interface MqttBrokerSettingsTabProps {
+  sourceId: string;
+}
+
+interface BrokerSourceResponse {
+  id: string;
+  name: string;
+  type: string;
+  config: {
+    listener?: { port?: number; host?: string };
+    auth?: { username?: string; password?: string };
+    rootTopic?: string;
+    zeroHopInjection?: boolean;
+  };
+}
+
+export function MqttBrokerSettingsTab({ sourceId }: MqttBrokerSettingsTabProps) {
+  const { t } = useTranslation();
+  const { getToken } = useCsrf();
+  const { hasPermission } = useAuth();
+  const { showToast } = useToast();
+
+  const canEdit = hasPermission('configuration', 'write');
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [name, setName] = useState('');
+  const [listenPort, setListenPort] = useState('1883');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [rootTopic, setRootTopic] = useState('msh');
+  const [zeroHopInjection, setZeroHopInjection] = useState(false);
+
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+    (async () => {
+      try {
+        const res = await fetch(`${appBasename}/api/sources/${sourceId}`, {
+          credentials: 'include',
+        });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const data = (await res.json()) as BrokerSourceResponse;
+        if (cancelled) return;
+        setName(data.name);
+        setListenPort(String(data.config?.listener?.port ?? 1883));
+        setUsername(data.config?.auth?.username ?? '');
+        setPassword('');
+        setRootTopic(data.config?.rootTopic ?? 'msh');
+        setZeroHopInjection(Boolean(data.config?.zeroHopInjection));
+      } catch (err) {
+        if (!cancelled) {
+          setLoadError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sourceId]);
+
+  const onSave = async () => {
+    if (!name.trim()) {
+      setSaveError(t('source.form.error_name_required', 'Name is required'));
+      return;
+    }
+    const port = parseInt(listenPort, 10);
+    if (isNaN(port) || port < 1 || port > 65535) {
+      setSaveError(t('source.form.error_port_range', 'Port must be 1–65535'));
+      return;
+    }
+    if (!username.trim()) {
+      setSaveError(t('source.form.error_mqtt_username_required', 'Broker username is required'));
+      return;
+    }
+
+    const cfg: Record<string, unknown> = {
+      listener: { port, host: '0.0.0.0' },
+      auth: password
+        ? { username: username.trim(), password }
+        : { username: username.trim() }, // server preserves existing password
+      rootTopic: rootTopic.trim() || 'msh',
+      zeroHopInjection,
+    };
+
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const csrfToken = getToken();
+      const res = await fetch(`${appBasename}/api/sources/${sourceId}`, {
+        method: 'PUT',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-csrf-token': csrfToken || '',
+        },
+        body: JSON.stringify({
+          name: name.trim(),
+          type: 'mqtt_broker',
+          config: cfg,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        setSaveError((err as { error?: string }).error ?? t('source.form.error_save_failed', 'Failed to save'));
+        return;
+      }
+      // Empty the password field after a successful save so the next save
+      // doesn't accidentally re-send a stale value the user thought was applied.
+      setPassword('');
+      showToast(t('source.form.saved', 'Settings saved'), 'success');
+    } catch {
+      setSaveError(t('source.form.error_network', 'Network error'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="mqtt-settings-tab">
+        <p>{t('source.mqtt.settings.loading', 'Loading settings…')}</p>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="mqtt-settings-tab">
+        <p className="mqtt-settings-error">
+          {t('source.mqtt.settings.load_error', 'Could not load source: {{err}}', { err: loadError })}
+        </p>
+      </div>
+    );
+  }
+
+  const disabled = !canEdit || saving;
+
+  return (
+    <div className="mqtt-settings-tab">
+      <h2>{t('source.mqtt_broker.settings_title', 'Broker Settings')}</h2>
+      {!canEdit && (
+        <p className="mqtt-settings-readonly">
+          {t('source.mqtt.settings.readonly', 'Read-only — you do not have permission to edit this source.')}
+        </p>
+      )}
+
+      <div className="mqtt-settings-field">
+        <label htmlFor="broker-name">{t('source.form.name', 'Name')}</label>
+        <input
+          id="broker-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+
+      <div className="mqtt-settings-field">
+        <label htmlFor="broker-port">{t('source.form.listener_port', 'Listener port')}</label>
+        <input
+          id="broker-port"
+          type="number"
+          min={1}
+          max={65535}
+          value={listenPort}
+          onChange={(e) => setListenPort(e.target.value)}
+          disabled={disabled}
+        />
+        <p className="mqtt-settings-hint">
+          {t('source.form.listener_port_hint', 'Default 1883. Devices and other MQTT clients connect on this port.')}
+        </p>
+      </div>
+
+      <div className="mqtt-settings-field">
+        <label htmlFor="broker-username">{t('source.form.username', 'Username')}</label>
+        <input
+          id="broker-username"
+          type="text"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          disabled={disabled}
+          autoComplete="username"
+        />
+      </div>
+
+      <div className="mqtt-settings-field">
+        <label htmlFor="broker-password">{t('source.form.password', 'Password')}</label>
+        <input
+          id="broker-password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          disabled={disabled}
+          placeholder={t('source.form.password_unchanged', '(unchanged)')}
+          autoComplete="new-password"
+        />
+        <p className="mqtt-settings-hint">
+          {t(
+            'source.form.password_hint',
+            'Leave blank to keep the current password.',
+          )}
+        </p>
+      </div>
+
+      <div className="mqtt-settings-field">
+        <label htmlFor="broker-root-topic">{t('source.form.root_topic', 'Root topic')}</label>
+        <input
+          id="broker-root-topic"
+          type="text"
+          value={rootTopic}
+          onChange={(e) => setRootTopic(e.target.value)}
+          disabled={disabled}
+        />
+        <p className="mqtt-settings-hint">
+          {t(
+            'source.form.root_topic_hint',
+            'Default "msh". Only packets under this prefix are ingested as Meshtastic ServiceEnvelopes.',
+          )}
+        </p>
+      </div>
+
+      <div className="mqtt-settings-field mqtt-settings-checkbox">
+        <label htmlFor="broker-zero-hop">
+          <input
+            id="broker-zero-hop"
+            type="checkbox"
+            checked={zeroHopInjection}
+            onChange={(e) => setZeroHopInjection(e.target.checked)}
+            disabled={disabled}
+          />
+          <span>{t('source.form.zero_hop', 'Zero-hop injection')}</span>
+        </label>
+        <p className="mqtt-settings-hint">
+          {t(
+            'source.form.zero_hop_hint',
+            'Clamp hop_limit to 0 on every packet delivered to MQTT clients. Mirrors mqtt.meshtastic.org behavior — prevents MQTT-bridged packets from triggering extra RF re-broadcasts.',
+          )}
+        </p>
+      </div>
+
+      {saveError && <p className="mqtt-settings-error">{saveError}</p>}
+
+      {canEdit && (
+        <div className="mqtt-settings-actions">
+          <button type="button" onClick={onSave} disabled={saving}>
+            {saving ? t('source.form.saving', 'Saving…') : t('source.form.save', 'Save')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MqttSourcePageShell/MqttSettingsTab.css
+++ b/src/components/MqttSourcePageShell/MqttSettingsTab.css
@@ -1,0 +1,143 @@
+.mqtt-settings-tab {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 4rem;
+  color: var(--ctp-text, #cdd6f4);
+}
+
+.mqtt-settings-tab h2 {
+  margin: 0 0 1.25rem;
+  color: var(--ctp-mauve, #cba6f7);
+  font-size: 1.25rem;
+}
+
+.mqtt-settings-tab h3 {
+  margin: 1.5rem 0 0.75rem;
+  color: var(--ctp-lavender, #b4befe);
+  font-size: 1rem;
+  border-bottom: 1px solid var(--ctp-surface1, #45475a);
+  padding-bottom: 0.35rem;
+}
+
+.mqtt-settings-readonly {
+  background: var(--ctp-surface0, #313244);
+  border-left: 3px solid var(--ctp-peach, #fab387);
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.mqtt-settings-field {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.mqtt-settings-field > label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--ctp-subtext0, #a6adc8);
+}
+
+.mqtt-settings-field input[type='text'],
+.mqtt-settings-field input[type='number'],
+.mqtt-settings-field input[type='password'],
+.mqtt-settings-field input[type='url'],
+.mqtt-settings-field select,
+.mqtt-settings-field textarea {
+  background: var(--ctp-surface0, #313244);
+  border: 1px solid var(--ctp-surface1, #45475a);
+  border-radius: 4px;
+  color: var(--ctp-text, #cdd6f4);
+  padding: 0.5rem 0.6rem;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.mqtt-settings-field input:focus,
+.mqtt-settings-field select:focus,
+.mqtt-settings-field textarea:focus {
+  outline: none;
+  border-color: var(--ctp-mauve, #cba6f7);
+}
+
+.mqtt-settings-field input:disabled,
+.mqtt-settings-field textarea:disabled,
+.mqtt-settings-field select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.mqtt-settings-field textarea {
+  min-height: 5rem;
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.mqtt-settings-hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--ctp-subtext0, #a6adc8);
+  line-height: 1.4;
+}
+
+.mqtt-settings-checkbox > label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--ctp-text, #cdd6f4);
+}
+
+.mqtt-settings-checkbox input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+}
+
+.mqtt-settings-error {
+  background: var(--ctp-surface0, #313244);
+  border-left: 3px solid var(--ctp-red, #f38ba8);
+  padding: 0.5rem 0.75rem;
+  color: var(--ctp-red, #f38ba8);
+  font-size: 0.9rem;
+}
+
+.mqtt-settings-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--ctp-surface1, #45475a);
+}
+
+.mqtt-settings-actions button {
+  background: var(--ctp-mauve, #cba6f7);
+  color: var(--ctp-base, #1e1e2e);
+  border: 0;
+  border-radius: 4px;
+  padding: 0.5rem 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.mqtt-settings-actions button:hover:not(:disabled) {
+  background: var(--ctp-pink, #f5c2e7);
+}
+
+.mqtt-settings-actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.mqtt-settings-placeholder {
+  background: var(--ctp-surface0, #313244);
+  border-left: 3px solid var(--ctp-blue, #89b4fa);
+  padding: 0.5rem 0.75rem;
+  color: var(--ctp-subtext1, #bac2de);
+  font-size: 0.9rem;
+}

--- a/src/components/MqttSourcePageShell/MqttSourceMapTab.tsx
+++ b/src/components/MqttSourcePageShell/MqttSourceMapTab.tsx
@@ -1,0 +1,60 @@
+/**
+ * MqttSourceMapTab — the Map tab for MQTT source detail pages.
+ *
+ * Fetches per-source nodes / traceroutes / neighbor-info / channels via
+ * useDashboardSourceData and hands them to the existing DashboardMap
+ * component (which already accepts a sourceId for per-source filtering).
+ * Tileset and default-center come from SettingsContext.
+ */
+
+import { useTranslation } from 'react-i18next';
+import DashboardMap from '../Dashboard/DashboardMap';
+import { useDashboardSourceData } from '../../hooks/useDashboardData';
+import { useSettings } from '../../contexts/SettingsContext';
+
+export interface MqttSourceMapTabProps {
+  sourceId: string;
+}
+
+export function MqttSourceMapTab({ sourceId }: MqttSourceMapTabProps) {
+  const { t } = useTranslation();
+  const { mapTileset, customTilesets, defaultMapCenterLat, defaultMapCenterLon, maxNodeAgeHours } = useSettings();
+  const { nodes, neighborInfo, traceroutes, channels, isLoading, isError } = useDashboardSourceData(sourceId);
+
+  if (isLoading && nodes.length === 0) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <p>{t('source.mqtt.map.loading', 'Loading map data…')}</p>
+      </div>
+    );
+  }
+
+  if (isError && nodes.length === 0) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <p>{t('source.mqtt.map.error', 'Could not load map data for this source.')}</p>
+      </div>
+    );
+  }
+
+  const defaultCenter = {
+    lat: defaultMapCenterLat ?? 30.0,
+    lng: defaultMapCenterLon ?? -90.0,
+  };
+
+  return (
+    <div style={{ height: '100%', width: '100%', position: 'relative' }}>
+      <DashboardMap
+        nodes={nodes}
+        neighborInfo={neighborInfo}
+        traceroutes={traceroutes}
+        channels={channels}
+        tilesetId={mapTileset}
+        customTilesets={customTilesets}
+        defaultCenter={defaultCenter}
+        sourceId={sourceId}
+        maxNodeAgeHours={maxNodeAgeHours}
+      />
+    </div>
+  );
+}

--- a/src/components/MqttSourcePageShell/MqttSourcePageShell.css
+++ b/src/components/MqttSourcePageShell/MqttSourcePageShell.css
@@ -1,0 +1,42 @@
+.mqtt-source-page {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+.mqtt-source-tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 1rem;
+  border-bottom: 1px solid var(--ctp-surface1, #45475a);
+  background: var(--ctp-surface0, #313244);
+  flex: 0 0 auto;
+}
+
+.mqtt-source-tab {
+  background: transparent;
+  border: 0;
+  color: var(--ctp-subtext1, #bac2de);
+  padding: 0.75rem 1.25rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.mqtt-source-tab:hover {
+  color: var(--ctp-text, #cdd6f4);
+  background: var(--ctp-surface1, #45475a);
+}
+
+.mqtt-source-tab.active {
+  color: var(--ctp-mauve, #cba6f7);
+  border-bottom-color: var(--ctp-mauve, #cba6f7);
+}
+
+.mqtt-source-tab-content {
+  flex: 1 1 auto;
+  overflow: auto;
+  background: var(--ctp-base, #1e1e2e);
+}

--- a/src/components/MqttSourcePageShell/MqttSourcePageShell.tsx
+++ b/src/components/MqttSourcePageShell/MqttSourcePageShell.tsx
@@ -1,0 +1,141 @@
+/**
+ * MqttSourcePageShell — chrome for per-source MQTT detail dashboards.
+ *
+ * Provides the topbar + tab strip that wraps the Map and Settings panes
+ * for both `mqtt_broker` and `mqtt_bridge` source detail pages. The two
+ * source types differ only in (a) the title text and (b) the contents of
+ * each tab — everything else (back-to-sources button, login/user menu,
+ * connection-status pill, tab navigation, deep-link `?tab=` handling)
+ * lives here so the two pages can't drift apart.
+ */
+
+import { useMemo, useState, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import LoginModal from '../LoginModal';
+import UserMenu from '../UserMenu';
+import { appBasename } from '../../init';
+import '../AppHeader/AppHeader.css';
+import './MqttSourcePageShell.css';
+
+export interface MqttSourcePageTab {
+  id: string;
+  label: string;
+  content: ReactNode;
+}
+
+export interface MqttSourcePageShellProps {
+  /** Title shown in the topbar, e.g. "MeshMonitor — MQTT Broker". */
+  title: string;
+  /** Source name from useSource(); shown next to the title. */
+  sourceName: string | null;
+  /** Whether the source is currently connected/listening. */
+  connected: boolean;
+  /** Tabs to render. The first tab is the default when no `?tab=` is set. */
+  tabs: MqttSourcePageTab[];
+}
+
+export function MqttSourcePageShell({
+  title,
+  sourceName,
+  connected,
+  tabs,
+}: MqttSourcePageShellProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { authStatus } = useAuth();
+  const isAuthenticated = authStatus?.authenticated ?? false;
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [showLogin, setShowLogin] = useState(false);
+
+  const defaultTabId = tabs[0]?.id ?? '';
+  const activeTabId = useMemo(() => {
+    const requested = searchParams.get('tab');
+    if (requested && tabs.some((tab) => tab.id === requested)) {
+      return requested;
+    }
+    return defaultTabId;
+  }, [searchParams, tabs, defaultTabId]);
+  const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? tabs[0];
+
+  const onSelectTab = (tabId: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (tabId === defaultTabId) {
+      next.delete('tab');
+    } else {
+      next.set('tab', tabId);
+    }
+    setSearchParams(next, { replace: true });
+  };
+
+  return (
+    <div className="dashboard-page mqtt-source-page">
+      <header className="dashboard-topbar">
+        <button
+          className="back-to-sources-btn"
+          onClick={() => navigate('/', { state: { showList: true } })}
+          title={t('source.sidebar.open_sources', 'Sources')}
+        >
+          {t('unified.back_to_sources', '← Sources')}
+        </button>
+        <div className="dashboard-topbar-logo">
+          <img
+            src={`${appBasename}/logo.png`}
+            alt="MeshMonitor"
+            className="dashboard-topbar-logo-img"
+          />
+          <span className="dashboard-topbar-title">{title}</span>
+        </div>
+        {sourceName && (
+          <div className="node-info">
+            <span className="node-address">{sourceName}</span>
+          </div>
+        )}
+        <div className="dashboard-topbar-actions">
+          <div className="connection-status-container">
+            <div className="connection-status">
+              <span
+                className={`status-indicator ${connected ? 'connected' : 'disconnected'}`}
+              />
+              <span>
+                {connected
+                  ? t('header.status.connected', 'Connected')
+                  : t('header.status.disconnected', 'Disconnected')}
+              </span>
+            </div>
+          </div>
+          {isAuthenticated ? (
+            <UserMenu />
+          ) : (
+            <button className="dashboard-signin-btn" onClick={() => setShowLogin(true)}>
+              {t('source.topbar.sign_in')}
+            </button>
+          )}
+        </div>
+      </header>
+
+      <nav className="mqtt-source-tabs" role="tablist" aria-label={title}>
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={tab.id === activeTabId}
+            className={`mqtt-source-tab${tab.id === activeTabId ? ' active' : ''}`}
+            onClick={() => onSelectTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+
+      <div className="mqtt-source-tab-content" role="tabpanel">
+        {activeTab?.content}
+      </div>
+
+      <LoginModal isOpen={showLogin} onClose={() => setShowLogin(false)} />
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,6 +19,8 @@ import UnifiedTelemetryPage from './pages/UnifiedTelemetryPage.tsx';
 import GlobalSettingsPage from './pages/GlobalSettingsPage.tsx';
 import UsersPage from './pages/UsersPage.tsx';
 import MeshCoreSourcePage from './pages/MeshCoreSourcePage.tsx';
+import MqttBrokerSourcePage from './pages/MqttBrokerSourcePage.tsx';
+import MqttBridgeSourcePage from './pages/MqttBridgeSourcePage.tsx';
 import { useDashboardSources } from './hooks/useDashboardData';
 import './index.css';
 import { AuthProvider } from './contexts/AuthContext';
@@ -67,6 +69,26 @@ function SourceApp() {
       <SourceProvider sourceId={sourceId} sourceName={source.name} sourceType={source.type}>
         <WebSocketProvider>
           <MeshCoreSourcePage key={sourceId} />
+        </WebSocketProvider>
+      </SourceProvider>
+    );
+  }
+
+  if (source?.type === 'mqtt_broker') {
+    return (
+      <SourceProvider sourceId={sourceId} sourceName={source.name} sourceType={source.type}>
+        <WebSocketProvider>
+          <MqttBrokerSourcePage key={sourceId} />
+        </WebSocketProvider>
+      </SourceProvider>
+    );
+  }
+
+  if (source?.type === 'mqtt_bridge') {
+    return (
+      <SourceProvider sourceId={sourceId} sourceName={source.name} sourceType={source.type}>
+        <WebSocketProvider>
+          <MqttBridgeSourcePage key={sourceId} />
         </WebSocketProvider>
       </SourceProvider>
     );

--- a/src/pages/MqttBridgeSourcePage.test.tsx
+++ b/src/pages/MqttBridgeSourcePage.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Smoke tests for the per-source MQTT Bridge detail page. Verifies tab
+ * navigation, settings loading (upstream, subscriptions, filters), and
+ * the topic-rewrite placeholder rendered ahead of PR B (#3166).
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) => {
+      if (typeof fallback === 'string') return fallback;
+      return key;
+    },
+  }),
+}));
+
+const originalFetch = globalThis.fetch;
+const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    fetchCalls.push({ url, init });
+    if (url.endsWith('/api/sources/bridge-1')) {
+      return new Response(
+        JSON.stringify({
+          id: 'bridge-1',
+          name: 'TX Bridge',
+          type: 'mqtt_bridge',
+          config: {
+            brokerSourceId: 'broker-1',
+            upstream: { url: 'mqtt://mqtt.meshtastic.org', username: 'meshdev' },
+            subscriptions: ['msh/US/TX/#'],
+            downlinkFilters: {
+              topics: { block: ['msh/CA/#'] },
+              geo: { minLat: 29.5, maxLat: 30.2, minLng: -95.8, maxLng: -95.0 },
+            },
+          },
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.endsWith('/api/sources')) {
+      // List used for populating the parent-broker dropdown
+      return new Response(
+        JSON.stringify([
+          { id: 'broker-1', name: 'Local Broker', type: 'mqtt_broker' },
+          { id: 'bridge-1', name: 'TX Bridge', type: 'mqtt_bridge' },
+        ]),
+        { status: 200 },
+      );
+    }
+    if (url.includes('/api/sources/bridge-1/status')) {
+      return new Response(JSON.stringify({ connected: true, upstreamConnected: true }), { status: 200 });
+    }
+    if (url.includes('/api/sources/bridge-1/')) {
+      return new Response(JSON.stringify([]), { status: 200 });
+    }
+    return new Response(JSON.stringify({ success: true, data: [] }), { status: 200 });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+vi.mock('../contexts/SettingsContext', () => ({
+  SettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSettings: () => ({
+    mapTileset: 'osm',
+    customTilesets: [],
+    defaultMapCenterLat: 30,
+    defaultMapCenterLon: -90,
+    maxNodeAgeHours: 24,
+  }),
+}));
+
+vi.mock('../contexts/MapContext', () => ({
+  MapProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useMapContext: () => ({}),
+}));
+
+vi.mock('../components/ToastContainer', () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useToast: () => ({ showToast: vi.fn(), toasts: [] }),
+}));
+
+vi.mock('../components/LoginModal', () => ({ default: () => null }));
+vi.mock('../components/UserMenu', () => ({ default: () => null }));
+
+vi.mock('../components/Dashboard/DashboardMap', () => ({
+  default: (props: { sourceId?: string | null }) => (
+    <div data-testid="dashboard-map">map for {props.sourceId ?? 'no-source'}</div>
+  ),
+}));
+
+const sourceContext = { sourceId: 'bridge-1' as string | null, sourceName: 'TX Bridge' as string | null };
+vi.mock('../contexts/SourceContext', () => ({
+  useSource: () => sourceContext,
+}));
+
+const authValue: { authStatus: any; hasPermission: (r: string, a: string) => boolean } = {
+  authStatus: { authenticated: true, user: { isAdmin: true } },
+  hasPermission: () => true,
+};
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => authValue,
+}));
+
+vi.mock('../contexts/CsrfContext', () => ({
+  useCsrf: () => ({ getToken: () => 'csrf-token' }),
+}));
+
+import MqttBridgeSourcePage from './MqttBridgeSourcePage';
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/source/bridge-1/']}>
+        <MqttBridgeSourcePage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('MqttBridgeSourcePage', () => {
+  it('renders Map and Settings tabs', async () => {
+    authValue.hasPermission = () => true;
+    renderPage();
+    expect(await screen.findByRole('tab', { name: 'Map' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Settings' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-map')).toBeInTheDocument();
+    });
+  });
+
+  it('loads bridge config into Settings fields', async () => {
+    authValue.hasPermission = () => true;
+    renderPage();
+    fireEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+    await waitFor(() => {
+      expect(screen.getByLabelText('Upstream URL')).toHaveValue('mqtt://mqtt.meshtastic.org');
+    });
+    expect(screen.getByLabelText('Username')).toHaveValue('meshdev');
+    expect(screen.getByLabelText('Upstream topics')).toHaveValue('msh/US/TX/#');
+  });
+
+  it('shows the topic-rewrite placeholder ahead of PR B', async () => {
+    authValue.hasPermission = () => true;
+    renderPage();
+    fireEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+    expect(
+      await screen.findByText(/Coming soon — bridge between meshes/),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the surface when connection:read is denied', async () => {
+    authValue.hasPermission = () => false;
+    renderPage();
+    expect(
+      await screen.findByText('You do not have permission to view this source.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/MqttBridgeSourcePage.tsx
+++ b/src/pages/MqttBridgeSourcePage.tsx
@@ -1,0 +1,111 @@
+/**
+ * MqttBridgeSourcePage — per-source detail dashboard for an `mqtt_bridge`.
+ *
+ * Tabbed layout (Map + Settings) inside the shared MqttSourcePageShell
+ * chrome. Bridge-specific settings include upstream URL/creds,
+ * subscriptions, downlink/uplink filters, and (in PR B / #3166) topic
+ * rewriting fields.
+ *
+ * Phase 2 (scaffold): tabs render placeholder content. Map tab is wired
+ * in Phase 3 (#14) and Settings tab in Phase 5 (#16).
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SettingsProvider } from '../contexts/SettingsContext';
+import { ToastProvider } from '../components/ToastContainer';
+import { MapProvider } from '../contexts/MapContext';
+import { useAuth } from '../contexts/AuthContext';
+import { useSource } from '../contexts/SourceContext';
+import { MqttSourcePageShell } from '../components/MqttSourcePageShell/MqttSourcePageShell';
+import { MqttSourceMapTab } from '../components/MqttSourcePageShell/MqttSourceMapTab';
+import { MqttBridgeSettingsTab } from '../components/MqttSourcePageShell/MqttBridgeSettingsTab';
+
+interface SourceStatusResponse {
+  connected?: boolean;
+  upstreamConnected?: boolean;
+}
+
+function MqttBridgeSourceInner() {
+  const { t } = useTranslation();
+  const { sourceId, sourceName } = useSource();
+  const { hasPermission } = useAuth();
+  const canReadConnection = hasPermission('connection', 'read');
+
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    if (!sourceId || !canReadConnection) return;
+    let cancelled = false;
+    const fetchStatus = async () => {
+      try {
+        const res = await fetch(`/api/sources/${sourceId}/status`, { credentials: 'include' });
+        if (!res.ok) return;
+        const data = (await res.json()) as SourceStatusResponse;
+        if (!cancelled) setConnected(Boolean(data.connected ?? data.upstreamConnected));
+      } catch {
+        // Best-effort.
+      }
+    };
+    fetchStatus();
+    const interval = setInterval(fetchStatus, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [sourceId, canReadConnection]);
+
+  if (!sourceId) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <p>{t('source.no_source', 'No source selected.')}</p>
+      </div>
+    );
+  }
+
+  if (!canReadConnection) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h2>{t('source.mqtt_bridge.title', 'MQTT Bridge')}</h2>
+        <p>
+          {t(
+            'source.no_permission',
+            'You do not have permission to view this source.',
+          )}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <MqttSourcePageShell
+      title={t('source.mqtt_bridge.shell_title', 'MeshMonitor — MQTT Bridge')}
+      sourceName={sourceName}
+      connected={connected}
+      tabs={[
+        {
+          id: 'map',
+          label: t('source.mqtt.tab.map', 'Map'),
+          content: <MqttSourceMapTab sourceId={sourceId} />,
+        },
+        {
+          id: 'settings',
+          label: t('source.mqtt.tab.settings', 'Settings'),
+          content: <MqttBridgeSettingsTab sourceId={sourceId} />,
+        },
+      ]}
+    />
+  );
+}
+
+export default function MqttBridgeSourcePage() {
+  return (
+    <SettingsProvider>
+      <ToastProvider>
+        <MapProvider>
+          <MqttBridgeSourceInner />
+        </MapProvider>
+      </ToastProvider>
+    </SettingsProvider>
+  );
+}

--- a/src/pages/MqttBrokerSourcePage.test.tsx
+++ b/src/pages/MqttBrokerSourcePage.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Smoke tests for the per-source MQTT Broker detail page. Verifies tab
+ * navigation (Map default, Settings on click), permission gating, and
+ * that the Settings tab loads + submits the source PUT correctly.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) => {
+      if (typeof fallback === 'string') return fallback;
+      return key;
+    },
+  }),
+}));
+
+const originalFetch = globalThis.fetch;
+const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    fetchCalls.push({ url, init });
+    if (url.endsWith('/api/sources/broker-1')) {
+      // GET single source — return broker config
+      return new Response(
+        JSON.stringify({
+          id: 'broker-1',
+          name: 'Test Broker',
+          type: 'mqtt_broker',
+          config: {
+            listener: { port: 1883 },
+            auth: { username: 'mm' },
+            rootTopic: 'msh',
+            zeroHopInjection: false,
+          },
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes('/api/sources/broker-1/status')) {
+      return new Response(
+        JSON.stringify({ connected: true, listening: true }),
+        { status: 200 },
+      );
+    }
+    if (url.includes('/api/sources/broker-1/nodes')) {
+      return new Response(JSON.stringify([]), { status: 200 });
+    }
+    if (url.includes('/api/sources/broker-1/')) {
+      // /traceroutes, /neighbor-info, /channels — all return empty
+      return new Response(JSON.stringify([]), { status: 200 });
+    }
+    return new Response(JSON.stringify({ success: true, data: [] }), { status: 200 });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+vi.mock('../contexts/SettingsContext', () => ({
+  SettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSettings: () => ({
+    mapTileset: 'osm',
+    customTilesets: [],
+    defaultMapCenterLat: 30,
+    defaultMapCenterLon: -90,
+    maxNodeAgeHours: 24,
+  }),
+}));
+
+vi.mock('../contexts/MapContext', () => ({
+  MapProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useMapContext: () => ({}),
+}));
+
+vi.mock('../components/ToastContainer', () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useToast: () => ({ showToast: vi.fn(), toasts: [] }),
+}));
+
+vi.mock('../components/LoginModal', () => ({ default: () => null }));
+vi.mock('../components/UserMenu', () => ({ default: () => null }));
+
+// DashboardMap is a heavy leaflet component — replace with a marker we can find.
+vi.mock('../components/Dashboard/DashboardMap', () => ({
+  default: (props: { sourceId?: string | null }) => (
+    <div data-testid="dashboard-map">map for {props.sourceId ?? 'no-source'}</div>
+  ),
+}));
+
+const sourceContext = { sourceId: 'broker-1' as string | null, sourceName: 'Test Broker' as string | null };
+vi.mock('../contexts/SourceContext', () => ({
+  useSource: () => sourceContext,
+}));
+
+const authValue: { authStatus: any; hasPermission: (r: string, a: string) => boolean } = {
+  authStatus: { authenticated: true, user: { isAdmin: true } },
+  hasPermission: () => true,
+};
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => authValue,
+}));
+
+vi.mock('../contexts/CsrfContext', () => ({
+  useCsrf: () => ({ getToken: () => 'csrf-token' }),
+}));
+
+import MqttBrokerSourcePage from './MqttBrokerSourcePage';
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/source/broker-1/']}>
+        <MqttBrokerSourcePage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('MqttBrokerSourcePage', () => {
+  it('renders Map and Settings tabs with Map as default', async () => {
+    authValue.hasPermission = () => true;
+    renderPage();
+    expect(await screen.findByRole('tab', { name: 'Map' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Settings' })).toBeInTheDocument();
+    // Map content rendered by default
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-map')).toBeInTheDocument();
+    });
+  });
+
+  it('switches to the Settings tab on click and loads broker config', async () => {
+    authValue.hasPermission = () => true;
+    renderPage();
+    fireEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+    await waitFor(() => {
+      expect(screen.getByLabelText('Listener port')).toHaveValue(1883);
+    });
+    expect(screen.getByLabelText('Username')).toHaveValue('mm');
+    expect(screen.getByLabelText('Root topic')).toHaveValue('msh');
+  });
+
+  it('hides the surface when connection:read is denied', async () => {
+    authValue.hasPermission = () => false;
+    renderPage();
+    expect(
+      await screen.findByText('You do not have permission to view this source.'),
+    ).toBeInTheDocument();
+    // No status poll should have fired.
+    expect(fetchCalls.some((c) => c.url.includes('/status'))).toBe(false);
+  });
+
+  it('PUTs the broker config on save', async () => {
+    authValue.hasPermission = () => true;
+    renderPage();
+    fireEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+    await waitFor(() => {
+      expect(screen.getByLabelText('Listener port')).toHaveValue(1883);
+    });
+    fireEvent.change(screen.getByLabelText('Root topic'), { target: { value: 'msh/US/LA' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      const putCall = fetchCalls.find(
+        (c) => c.init?.method === 'PUT' && c.url.endsWith('/api/sources/broker-1'),
+      );
+      expect(putCall).toBeDefined();
+      const body = JSON.parse(putCall!.init!.body as string);
+      expect(body.type).toBe('mqtt_broker');
+      expect(body.config.rootTopic).toBe('msh/US/LA');
+      // Password was left empty — omit from the auth object so server preserves it.
+      expect(body.config.auth.password).toBeUndefined();
+    });
+  });
+});

--- a/src/pages/MqttBrokerSourcePage.tsx
+++ b/src/pages/MqttBrokerSourcePage.tsx
@@ -1,0 +1,113 @@
+/**
+ * MqttBrokerSourcePage — per-source detail dashboard for an `mqtt_broker`.
+ *
+ * Hosts a tabbed layout (Map + Settings) inside the shared
+ * MqttSourcePageShell chrome. Both tabs read the sourceId from
+ * SourceContext via `useSource()`.
+ *
+ * Phase 1 (scaffold): tabs render placeholder content. Map tab is wired
+ * in Phase 3 (#14) and Settings tab in Phase 4 (#15).
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SettingsProvider } from '../contexts/SettingsContext';
+import { ToastProvider } from '../components/ToastContainer';
+import { MapProvider } from '../contexts/MapContext';
+import { useAuth } from '../contexts/AuthContext';
+import { useSource } from '../contexts/SourceContext';
+import { MqttSourcePageShell } from '../components/MqttSourcePageShell/MqttSourcePageShell';
+import { MqttSourceMapTab } from '../components/MqttSourcePageShell/MqttSourceMapTab';
+import { MqttBrokerSettingsTab } from '../components/MqttSourcePageShell/MqttBrokerSettingsTab';
+
+interface SourceStatusResponse {
+  connected?: boolean;
+  listening?: boolean;
+}
+
+function MqttBrokerSourceInner() {
+  const { t } = useTranslation();
+  const { sourceId, sourceName } = useSource();
+  const { hasPermission } = useAuth();
+  const canReadConnection = hasPermission('connection', 'read');
+
+  const [connected, setConnected] = useState(false);
+
+  // Poll status so the topbar pill reflects reality. The broker's
+  // /api/sources/:id/status returns `listening` for the listener socket
+  // plus a synthetic `connected` boolean — fall back to either signal.
+  useEffect(() => {
+    if (!sourceId || !canReadConnection) return;
+    let cancelled = false;
+    const fetchStatus = async () => {
+      try {
+        const res = await fetch(`/api/sources/${sourceId}/status`, { credentials: 'include' });
+        if (!res.ok) return;
+        const data = (await res.json()) as SourceStatusResponse;
+        if (!cancelled) setConnected(Boolean(data.connected ?? data.listening));
+      } catch {
+        // Best-effort — topbar just shows "disconnected" if we can't reach the API.
+      }
+    };
+    fetchStatus();
+    const interval = setInterval(fetchStatus, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [sourceId, canReadConnection]);
+
+  if (!sourceId) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <p>{t('source.no_source', 'No source selected.')}</p>
+      </div>
+    );
+  }
+
+  if (!canReadConnection) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h2>{t('source.mqtt_broker.title', 'MQTT Broker')}</h2>
+        <p>
+          {t(
+            'source.no_permission',
+            'You do not have permission to view this source.',
+          )}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <MqttSourcePageShell
+      title={t('source.mqtt_broker.shell_title', 'MeshMonitor — MQTT Broker')}
+      sourceName={sourceName}
+      connected={connected}
+      tabs={[
+        {
+          id: 'map',
+          label: t('source.mqtt.tab.map', 'Map'),
+          content: <MqttSourceMapTab sourceId={sourceId} />,
+        },
+        {
+          id: 'settings',
+          label: t('source.mqtt.tab.settings', 'Settings'),
+          content: <MqttBrokerSettingsTab sourceId={sourceId} />,
+        },
+      ]}
+    />
+  );
+}
+
+export default function MqttBrokerSourcePage() {
+  return (
+    <SettingsProvider>
+      <ToastProvider>
+        <MapProvider>
+          <MqttBrokerSourceInner />
+        </MapProvider>
+      </ToastProvider>
+    </SettingsProvider>
+  );
+}


### PR DESCRIPTION
## Summary

Adds dedicated per-source detail pages for `mqtt_broker` and `mqtt_bridge` sources with two tabs:

- **Map** — reuses `DashboardMap` scoped to the source via `useSource()` and the existing per-source `/api/sources/:id/{nodes,traceroutes,neighbor-info,channels}` endpoints.
- **Settings** — editable form migrated from the legacy `DashboardPage` edit modal. Broker fields: listener port, credentials, root topic, zero-hop injection. Bridge fields: parent broker dropdown (None = standalone), upstream URL/credentials, subscriptions, downlink topic-block, downlink geo bbox. Empty password preserves the existing value server-side.

Source rows in `DashboardSidebar` now route through the per-source page for MQTT types:
- Kebab "Edit" is replaced with "Open" for MQTT sources (other types keep the legacy modal flow until they grow their own detail pages).
- Row body click navigates to `/source/:id/` for MQTT sources.

The bridge Settings tab includes a "Topic rewriting" placeholder section ahead of the upcoming feature implementation in #3166 (PR B). This PR is the infrastructure refactor — no new feature behavior.

## Architecture

`MqttSourcePageShell` (shared) provides the topbar + tab strip; each page composes the shell with its own tab content. Mirrors the existing `MeshCoreSourcePage` pattern and reuses its provider stack (`SettingsProvider` → `ToastProvider` → `MapProvider`).

`SourceApp` in `src/main.tsx` now dispatches:
- `meshcore` → `MeshCoreSourcePage` (unchanged)
- `mqtt_broker` → `MqttBrokerSourcePage` (new)
- `mqtt_bridge` → `MqttBridgeSourcePage` (new)
- everything else → legacy `<App>` (unchanged)

## Out of scope

Meshtastic sources (`meshtastic_tcp`, `meshtastic_serial`, `meshtastic_ble`) keep their current behavior — they fall through to the legacy `<App>` dashboard. A follow-up can give them their own detail pages.

## Test plan

- [x] All 626 vitest files pass (10,480 tests green, 0 failures) — including 42 existing sidebar tests after the `KebabMenu` interface change
- [x] 8 new tests across `MqttBrokerSourcePage.test.tsx` and `MqttBridgeSourcePage.test.tsx` cover tab navigation, settings loading, permission gating, PUT submission, and the topic-rewrite placeholder
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm run lint` — net-zero new errors vs. baseline (3308 problems before and after)
- [x] Dev container deployed, `MqttBridge` string confirmed in minified bundle
- [x] `GET /api/sources/:id` and `GET /api/sources/:id/status` return the field shapes both Settings tabs expect (verified against a real broker + bridge on the dev container)
- [ ] Reviewer: navigate to a broker / bridge source row, click "Open" or the row body, verify the new detail page loads with both tabs
- [ ] Reviewer: edit a setting in the new Settings tab, save, confirm the change persists across reload

Relates to #3166 (the upcoming topic-rewrite feature lands in the Bridge Settings tab built here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)