### PR TITLE
feat(mqtt): bridge topic rewriting for cross-mesh routing (#3166)

### DIFF
--- a/docs/features/mqtt-broker.md
+++ b/docs/features/mqtt-broker.md
@@ -49,6 +49,7 @@ A long-lived MQTT client, backed by [MQTT.js](https://github.com/mqttjs/MQTT.js)
   - **Node ID** — allow / block lists (`!xxxxxxxx`)
   - **PortNum** — allow / block lists ([Meshtastic PortNum enum](https://github.com/meshtastic/protobufs/blob/master/meshtastic/portnums.proto))
   - **Geographic bounding box** — drop position packets whose `latitude_i / 1e7, longitude_i / 1e7` falls outside `{ minLat, maxLat, minLng, maxLng }`. Applied before republish so out-of-area positions never reach the local broker (when attached) or are injected into a device (when used as a client-proxy target).
+- Optionally rewrites topics on republish via `downlinkTopicRewrite` / `uplinkTopicRewrite` ([Topic rewriting](#topic-rewriting)) for bridging between meshes that publish under different MQTT roots.
 - Surfaces broker ACL state — if the upstream rejects authentication or denies your subscriptions, the bridge status shows `permissionMessage` so you know why traffic isn't flowing.
 - 60-second `(topic, packetId)` echo suppression on both directions prevents bridge feedback loops.
 
@@ -77,6 +78,7 @@ A bridge can run in either of two configurations, picked when you create it ("Pa
 | **Locally-connected MQTT clients (devices, LAN apps)?** | Yes, many | Via the parent broker | No |
 | **Multiple upstream brokers?** | n/a | Yes — N bridges, each independent | Yes — N bridges, each independent |
 | **Per-source filter pipeline (topic / channel / node / portnum / geo)?** | No (broker is dumb relay) | **Yes** — downlink _and_ uplink | **Yes** — downlink only |
+| **Topic rewriting (cross-root bridging)?** | No | **Yes** — `downlinkTopicRewrite` + `uplinkTopicRewrite` ([details](#topic-rewriting)) | No (requires parent broker) |
 | **Server-side ingestion of decoded packets?** | Yes — under broker `sourceId` | Yes — under bridge `sourceId` (downlink) | Yes — under bridge `sourceId` (downlink) |
 | **Echo suppression (no feedback loops)?** | n/a | Yes (60s `topic+packetId` cache) | Yes |
 | **Zero-hop injection toggle?** | Yes ([details](#zero-hop-injection)) | n/a | n/a |
@@ -95,6 +97,7 @@ A bridge can run in either of two configurations, picked when you create it ("Pa
 - **"My BLE-only node should publish MQTT through MeshMonitor straight to a public broker, no embedded broker required."** Create one **standalone bridge** pointed at the public broker. On the Meshtastic source, set `mqttLink → <bridge>` (Sources → Edit → "Bridge MQTT proxy to", or use the Quick Configure dropdown on Device → MQTT). Enable `proxy_to_client_enabled` on the firmware. Device → MeshMonitor (over BLE/serial) → bridge → upstream.
 - **"Same as above, plus I want a Home Assistant box on the LAN to subscribe to my devices."** Create one **broker** + one **attached bridge**. Devices use client-proxy mode pointing at the broker; Home Assistant subscribes to the broker on port 1883. Bridge handles the upstream fan-out.
 - **"Two upstream brokers, one regional and one global, with different filters per upstream."** Create one **broker** + **two attached bridges**, each with its own topic/geo/portnum rules. Devices publish once; each bridge independently decides what to forward.
+- **"Cross-mesh routing between two MQTT roots (e.g. our LA mesh on `msh/US/LA` and the Houston mesh on `msh/US/TX`)."** Create one **broker** + one **attached bridge** to the foreign upstream. Set the bridge's downlink rewrite `msh/US/TX → msh/US/LA` and uplink rewrite `msh/US/LA → msh/US/TX` so the foreign-root traffic appears under your local root (and vice versa). See [Topic rewriting](#topic-rewriting) below for the details and caveats (PSK match, zero-hop, loop suppression).
 
 ## Three ways a device can reach MQTT through MeshMonitor
 
@@ -180,6 +183,59 @@ Then on the Meshtastic source in MeshMonitor (**Dashboard → Sources → Edit �
 In both cases MeshMonitor forwards `FromRadio.mqttClientProxyMessage` payloads to the target's MQTT layer, and injects the target's inbound MQTT traffic back to the device as `ToRadio.MqttClientProxyMessage`.
 
 If `proxy_to_client_enabled` is on but no `mqttLink` is set, a yellow warning banner appears on the Device → MQTT page — without it, proxy traffic from the firmware would be silently dropped.
+
+## Topic rewriting
+
+::: tip Added in 4.7
+Bridge **topic rewriting** ships in 4.7 ([issue #3166](https://github.com/Yeraze/meshmonitor/issues/3166)), driven by [discussion #3159](https://github.com/Yeraze/meshmonitor/discussions/3159) — operators bridging between meshes that publish under different MQTT root topics.
+:::
+
+By default an `mqtt_bridge` is a byte-for-byte relay — it republishes inbound traffic to the parent broker on the same topic, and forwards outbound traffic upstream on the same topic. That works when both ends use the same root, but breaks when the two ends use different roots (e.g. your LA mesh publishes under `msh/US/LA` while the Houston public mesh uses `msh/US/TX`). Locally-attached LA devices subscribe to `msh/US/LA/#`, so they never see `msh/US/TX/...` republishes — the traffic is ingested into the database fine, but never crosses to RF.
+
+**Topic rewriting** adds a literal prefix-replacement step on each direction of the bridge:
+
+| Field | Direction | Effect |
+|---|---|---|
+| `downlinkTopicRewrite` | upstream → parent broker | Republish an inbound topic on the parent broker under a different prefix, so locally-subscribed devices see it. |
+| `uplinkTopicRewrite` | parent broker → upstream | Publish a parent-broker topic upstream under a different prefix, so the foreign mesh sees your local traffic. |
+
+Each rule is `{ from, to }` — literal prefix match (no MQTT `+` / `#` wildcards), trailing slashes normalized away. Set in the bridge's **Settings tab** (Sources → click the bridge → Settings → Topic rewriting), or via the API.
+
+### Example — LA ↔ TX cross-mesh bridge
+
+Local mesh on `msh/US/LA`, Houston public mesh on `mqtt.meshtastic.org` under `msh/US/TX`. Operator wants the two meshes to see each other's traffic on RF.
+
+1. Run the embedded broker with `rootTopic = msh/US/LA` (or `msh`).
+2. Create an attached `mqtt_bridge` to `mqtt://mqtt.meshtastic.org` subscribed to `msh/US/TX/#`.
+3. Configure the rewrite rules:
+
+```yaml
+downlinkTopicRewrite:
+  from: msh/US/TX        # foreign root
+  to:   msh/US/LA        # local root — what LA devices subscribe to
+uplinkTopicRewrite:
+  from: msh/US/LA        # local root — what LA devices publish under
+  to:   msh/US/TX        # foreign root — what Houston subscribers see
+```
+
+4. Optionally pair with a **geographic bounding box** in the downlink filter to drop TX traffic from outside the area you care about, and **Zero-hop injection** on the broker to keep the bridged packets from triggering extra RF hops.
+
+Filters run on the original (pre-rewrite) topic; the rewrite only changes what gets published. Ingestion records and the bridge's `local-packet` event also use the original topic, so dashboards stay accurate.
+
+### Loop suppression
+
+Echo suppression is keyed on the **post-rewrite** topic — so an inbound TX packet republished to the parent broker as `msh/US/LA/...` is recorded under that rewritten topic. When the parent broker re-emits the same packet through the uplink path, the bridge sees `msh/US/LA/...` + the same packetId in the downlink echo cache and suppresses the uplink. The reverse direction works the same way. The existing 60-second `(topic, packetId)` cache covers it; no new infrastructure was needed.
+
+### Caveats
+
+::: warning Read before deploying
+- **PSKs must match.** Topic rewriting moves bytes, not encryption. If the two meshes use different channel PSKs, the relayed packets arrive at devices on the other side as undecodable noise.
+- **Filter the firehose first.** Without a topic block-list, channel allow-list, portnum allow-list, or **geographic bounding box** in the downlink filter, dropping the entire `msh/US/TX/#` into a local mesh can saturate RF.
+- **Pair with Zero-hop injection** on the broker. Without it, inbound foreign-mesh packets arrive carrying their original `hop_limit` and devices on the receiving side will re-broadcast them over RF — re-flooding the foreign mesh's traffic across your local airwaves.
+- **Standalone bridges cannot rewrite.** A bridge without a parent broker has no parent-broker republish path (downlink) and no `local-packet` event source (uplink), so rewriting would silently do nothing. The validator rejects rewrite fields on standalone bridges.
+- **No wildcards.** `from` / `to` are literal prefixes only. `msh/US/+` is rejected by the validator.
+- **Single rule per direction.** v1 supports one `{from, to}` per direction. Folding multiple foreign roots into one local root (`msh/US/TX/* → msh/US/LA/*` AND `msh/CA/QC/* → msh/US/LA/*`) would need separate bridges today.
+:::
 
 ## Zero-hop injection
 

--- a/src/components/MqttSourcePageShell/MqttBridgeSettingsTab.tsx
+++ b/src/components/MqttSourcePageShell/MqttBridgeSettingsTab.tsx
@@ -32,6 +32,8 @@ interface BridgeSourceResponse {
       topics?: { block?: string[] };
       geo?: { minLat?: number; maxLat?: number; minLng?: number; maxLng?: number };
     };
+    downlinkTopicRewrite?: { from?: string; to?: string };
+    uplinkTopicRewrite?: { from?: string; to?: string };
   };
 }
 
@@ -66,6 +68,14 @@ export function MqttBridgeSettingsTab({ sourceId }: MqttBridgeSettingsTabProps) 
   const [geoMaxLat, setGeoMaxLat] = useState('');
   const [geoMinLng, setGeoMinLng] = useState('');
   const [geoMaxLng, setGeoMaxLng] = useState('');
+
+  // Topic rewriting (#3166) — literal prefix substitution applied at
+  // publish time. Each direction is independent; empty fields disable
+  // that direction.
+  const [downlinkRewriteFrom, setDownlinkRewriteFrom] = useState('');
+  const [downlinkRewriteTo, setDownlinkRewriteTo] = useState('');
+  const [uplinkRewriteFrom, setUplinkRewriteFrom] = useState('');
+  const [uplinkRewriteTo, setUplinkRewriteTo] = useState('');
 
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -104,6 +114,13 @@ export function MqttBridgeSettingsTab({ sourceId }: MqttBridgeSettingsTabProps) 
         setGeoMaxLat(geo.maxLat != null ? String(geo.maxLat) : '');
         setGeoMinLng(geo.minLng != null ? String(geo.minLng) : '');
         setGeoMaxLng(geo.maxLng != null ? String(geo.maxLng) : '');
+
+        const dlRewrite = data.config?.downlinkTopicRewrite ?? {};
+        setDownlinkRewriteFrom(dlRewrite.from ?? '');
+        setDownlinkRewriteTo(dlRewrite.to ?? '');
+        const ulRewrite = data.config?.uplinkTopicRewrite ?? {};
+        setUplinkRewriteFrom(ulRewrite.from ?? '');
+        setUplinkRewriteTo(ulRewrite.to ?? '');
 
         setAvailableBrokers(listData.filter((s) => s.type === 'mqtt_broker'));
       } catch (err) {
@@ -161,6 +178,29 @@ export function MqttBridgeSettingsTab({ sourceId }: MqttBridgeSettingsTabProps) 
     if (block.length > 0) downlinkFilters.topics = { block };
     if (Object.keys(geo).length > 0) downlinkFilters.geo = geo;
 
+    // Topic rewriting (#3166) — server-side validator rejects rewrite
+    // fields on standalone bridges, so omit them entirely when there's
+    // no parent broker selected. Either direction is independent: omit
+    // when both from and to are empty after trim.
+    const dlFrom = downlinkRewriteFrom.trim();
+    const dlTo = downlinkRewriteTo.trim();
+    const ulFrom = uplinkRewriteFrom.trim();
+    const ulTo = uplinkRewriteTo.trim();
+    const wantDownlinkRewrite = brokerSourceId && (dlFrom || dlTo);
+    const wantUplinkRewrite = brokerSourceId && (ulFrom || ulTo);
+    if (wantDownlinkRewrite && (!dlFrom || !dlTo)) {
+      setSaveError(
+        t('source.form.error_rewrite_incomplete', 'Both from and to are required when a topic rewrite is set'),
+      );
+      return;
+    }
+    if (wantUplinkRewrite && (!ulFrom || !ulTo)) {
+      setSaveError(
+        t('source.form.error_rewrite_incomplete', 'Both from and to are required when a topic rewrite is set'),
+      );
+      return;
+    }
+
     const cfg: Record<string, unknown> = {
       ...(brokerSourceId ? { brokerSourceId } : {}),
       upstream: {
@@ -170,6 +210,8 @@ export function MqttBridgeSettingsTab({ sourceId }: MqttBridgeSettingsTabProps) 
       },
       subscriptions: subs.length > 0 ? subs : ['msh/#'],
       ...(Object.keys(downlinkFilters).length > 0 ? { downlinkFilters } : {}),
+      ...(wantDownlinkRewrite ? { downlinkTopicRewrite: { from: dlFrom, to: dlTo } } : {}),
+      ...(wantUplinkRewrite ? { uplinkTopicRewrite: { from: ulFrom, to: ulTo } } : {}),
     };
 
     setSaving(true);
@@ -438,12 +480,109 @@ export function MqttBridgeSettingsTab({ sourceId }: MqttBridgeSettingsTabProps) 
       )}
 
       <h3>{t('source.form.topic_rewrite_section', 'Topic rewriting')}</h3>
-      <p className="mqtt-settings-placeholder">
+      <p className="mqtt-settings-hint">
         {t(
-          'source.form.topic_rewrite_placeholder',
-          'Coming soon — bridge between meshes that use different MQTT root topics (e.g. msh/US/LA ↔ msh/US/TX). See issue #3166.',
+          'source.form.topic_rewrite_intro',
+          'Literal prefix replacement applied at publish time. Use this to bridge between meshes that publish under different MQTT root topics. Leave blank to disable.',
         )}
       </p>
+      {standalone ? (
+        <p className="mqtt-settings-readonly">
+          {t(
+            'source.form.topic_rewrite_standalone_warning',
+            'Topic rewriting requires a parent broker — attach one above to enable these fields.',
+          )}
+        </p>
+      ) : (
+        <>
+          <div className="mqtt-settings-field">
+            <label>
+              {t('source.form.topic_rewrite_downlink', 'Downlink (upstream → local broker)')}
+            </label>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem' }}>
+              <div>
+                <label htmlFor="bridge-rewrite-dl-from">
+                  {t('source.form.topic_rewrite_from', 'From prefix')}
+                </label>
+                <input
+                  id="bridge-rewrite-dl-from"
+                  type="text"
+                  value={downlinkRewriteFrom}
+                  onChange={(e) => setDownlinkRewriteFrom(e.target.value)}
+                  disabled={disabled}
+                  placeholder="msh/US/TX"
+                />
+              </div>
+              <div>
+                <label htmlFor="bridge-rewrite-dl-to">
+                  {t('source.form.topic_rewrite_to', 'To prefix')}
+                </label>
+                <input
+                  id="bridge-rewrite-dl-to"
+                  type="text"
+                  value={downlinkRewriteTo}
+                  onChange={(e) => setDownlinkRewriteTo(e.target.value)}
+                  disabled={disabled}
+                  placeholder="msh/US/LA"
+                />
+              </div>
+            </div>
+            <p className="mqtt-settings-hint">
+              {t(
+                'source.form.topic_rewrite_downlink_hint',
+                'Inbound packets whose topic starts with the From prefix are republished to the parent broker under the To prefix. Ingestion and filters still use the original topic.',
+              )}
+            </p>
+          </div>
+
+          <div className="mqtt-settings-field">
+            <label>
+              {t('source.form.topic_rewrite_uplink', 'Uplink (local broker → upstream)')}
+            </label>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem' }}>
+              <div>
+                <label htmlFor="bridge-rewrite-ul-from">
+                  {t('source.form.topic_rewrite_from', 'From prefix')}
+                </label>
+                <input
+                  id="bridge-rewrite-ul-from"
+                  type="text"
+                  value={uplinkRewriteFrom}
+                  onChange={(e) => setUplinkRewriteFrom(e.target.value)}
+                  disabled={disabled}
+                  placeholder="msh/US/LA"
+                />
+              </div>
+              <div>
+                <label htmlFor="bridge-rewrite-ul-to">
+                  {t('source.form.topic_rewrite_to', 'To prefix')}
+                </label>
+                <input
+                  id="bridge-rewrite-ul-to"
+                  type="text"
+                  value={uplinkRewriteTo}
+                  onChange={(e) => setUplinkRewriteTo(e.target.value)}
+                  disabled={disabled}
+                  placeholder="msh/US/TX"
+                />
+              </div>
+            </div>
+            <p className="mqtt-settings-hint">
+              {t(
+                'source.form.topic_rewrite_uplink_hint',
+                'Outbound packets from the parent broker whose topic starts with the From prefix are published upstream under the To prefix.',
+              )}
+            </p>
+          </div>
+
+          <p className="mqtt-settings-hint">
+            {t(
+              'source.form.topic_rewrite_caveats',
+              'Caveats: rewriting moves bytes, not encryption — the channel PSK must match between meshes for inter-mesh packets to decode. Pair with the broker\'s "Zero-hop injection" setting to keep cross-bridged packets from triggering extra RF hops. Literal prefix only (no MQTT + / # wildcards).',
+            )}
+          </p>
+        </>
+      )}
 
       {saveError && <p className="mqtt-settings-error">{saveError}</p>}
 

--- a/src/pages/MqttBridgeSourcePage.test.tsx
+++ b/src/pages/MqttBridgeSourcePage.test.tsx
@@ -154,13 +154,15 @@ describe('MqttBridgeSourcePage', () => {
     expect(screen.getByLabelText('Upstream topics')).toHaveValue('msh/US/TX/#');
   });
 
-  it('shows the topic-rewrite placeholder ahead of PR B', async () => {
+  it('renders topic-rewrite fields for attached bridges (#3166)', async () => {
     authValue.hasPermission = () => true;
     renderPage();
     fireEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
-    expect(
-      await screen.findByText(/Coming soon — bridge between meshes/),
-    ).toBeInTheDocument();
+    // Two from/to pairs (downlink + uplink) — at least one each.
+    await waitFor(() => {
+      expect(screen.getAllByLabelText('From prefix').length).toBeGreaterThanOrEqual(2);
+    });
+    expect(screen.getAllByLabelText('To prefix').length).toBeGreaterThanOrEqual(2);
   });
 
   it('hides the surface when connection:read is denied', async () => {
@@ -169,5 +171,36 @@ describe('MqttBridgeSourcePage', () => {
     expect(
       await screen.findByText('You do not have permission to view this source.'),
     ).toBeInTheDocument();
+  });
+
+  it('shows the standalone-warning when no parent broker is configured (#3166)', async () => {
+    authValue.hasPermission = () => true;
+    // Override the GET to return a standalone bridge.
+    const originalMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    (globalThis.fetch as ReturnType<typeof vi.fn>) = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/api/sources/bridge-1')) {
+        return new Response(
+          JSON.stringify({
+            id: 'bridge-1',
+            name: 'Standalone',
+            type: 'mqtt_bridge',
+            config: {
+              upstream: { url: 'mqtt://x.example.com' },
+              subscriptions: ['msh/#'],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return originalMock(input, init);
+    });
+    renderPage();
+    fireEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+    expect(
+      await screen.findByText(/Topic rewriting requires a parent broker/),
+    ).toBeInTheDocument();
+    // Rewrite inputs must NOT render in the standalone case.
+    expect(screen.queryByLabelText('From prefix')).toBeNull();
   });
 });

--- a/src/server/mqttBridgeManager.test.ts
+++ b/src/server/mqttBridgeManager.test.ts
@@ -327,4 +327,308 @@ describe('MqttBridgeManager', () => {
     // Don't start the bridge — client is null.
     await expect(bridge.publish('msh/x', Buffer.from([1, 2, 3]))).rejects.toThrow(/not connected to upstream/);
   });
+
+  // ---------------------------------------------------------------------------
+  // Topic rewriting (#3166): bridge between meshes that use different MQTT
+  // roots (e.g. msh/US/TX ↔ msh/US/LA). The pure helper is covered by
+  // mqttBridgeManager.topicRewrite.test.ts — these tests verify the
+  // integration: republish topics, echo cache keying, and no-loop behavior.
+  // ---------------------------------------------------------------------------
+
+  it('downlink rewrite republishes under the rewritten topic on the parent broker', async () => {
+    bridge = new MqttBridgeManager('rewrite-bridge', 'Rewrite', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/US/TX/#'],
+      downlinkTopicRewrite: { from: 'msh/US/TX', to: 'msh/US/LA' },
+    });
+    await sourceManagerRegistry.addManager(bridge);
+
+    // A local broker subscriber sees what the bridge republishes locally.
+    const localClient = connect(`mqtt://127.0.0.1:${localPort}`, {
+      username: 'u',
+      password: 'p',
+      reconnectPeriod: 0,
+    });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('local connect timeout')), 3000);
+      localClient.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+    const localMessages: Array<{ topic: string; payload: Buffer }> = [];
+    await new Promise<void>((resolve, reject) => {
+      localClient.subscribe('msh/#', { qos: 0 }, (err) => (err ? reject(err) : resolve()));
+    });
+    localClient.on('message', (topic, payload) => {
+      localMessages.push({ topic, payload });
+    });
+
+    // Publish to upstream as if from a TX-rooted mesh.
+    const pub = connect(`mqtt://127.0.0.1:${upstreamPort}`, { reconnectPeriod: 0 });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('pub connect timeout')), 3000);
+      pub.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+
+    const envelope = buildPositionEnvelope({
+      from: 0x11111111,
+      latI: 440_000_000,
+      lngI: -780_000_000,
+      channelId: 'LongFast',
+      gatewayId: '!11111111',
+      packetId: 0x30000001,
+    });
+    pub.publish('msh/US/TX/2/e/Foo', envelope);
+    await new Promise((r) => setTimeout(r, 400));
+
+    // Local broker should see the REWRITTEN topic (msh/US/LA), not the
+    // original msh/US/TX.
+    expect(localMessages.some((m) => m.topic === 'msh/US/LA/2/e/Foo')).toBe(true);
+    expect(localMessages.some((m) => m.topic === 'msh/US/TX/2/e/Foo')).toBe(false);
+
+    await new Promise<void>((r) => localClient.end(true, {}, () => r()));
+    await new Promise<void>((r) => pub.end(true, {}, () => r()));
+  });
+
+  it('uplink rewrite publishes upstream under the rewritten topic', async () => {
+    bridge = new MqttBridgeManager('uplink-rewrite-bridge', 'UplinkRewrite', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/US/TX/#'], // subscribe to TX so the upstream→local loop test below works
+      uplinkTopicRewrite: { from: 'msh/US/LA', to: 'msh/US/TX' },
+    });
+    await sourceManagerRegistry.addManager(bridge);
+
+    upstreamClient = connect(`mqtt://127.0.0.1:${upstreamPort}`, { reconnectPeriod: 0 });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('upstream connect timeout')), 3000);
+      upstreamClient!.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+    const upstreamSeen: Array<{ topic: string; payload: Buffer }> = [];
+    await new Promise<void>((resolve, reject) => {
+      upstreamClient!.subscribe('msh/#', { qos: 0 }, (err) => (err ? reject(err) : resolve()));
+    });
+    upstreamClient.on('message', (topic, payload) => {
+      upstreamSeen.push({ topic, payload });
+    });
+
+    // Local device publishes to the local broker on the LA root — bridge
+    // picks it up via the parent broker's local-packet event and uplinks
+    // it with the topic rewritten to TX.
+    const localPublisher = connect(`mqtt://127.0.0.1:${localPort}`, {
+      username: 'u',
+      password: 'p',
+      reconnectPeriod: 0,
+    });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('local connect timeout')), 3000);
+      localPublisher.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+
+    const envelope = buildPositionEnvelope({
+      from: 0x22222222,
+      latI: 440_000_000,
+      lngI: -780_000_000,
+      channelId: 'LongFast',
+      gatewayId: '!22222222',
+      packetId: 0x30000002,
+    });
+    localPublisher.publish('msh/US/LA/2/e/Foo', envelope);
+    await new Promise((r) => setTimeout(r, 400));
+
+    // Upstream should see msh/US/TX/2/e/Foo (rewritten), not msh/US/LA.
+    expect(upstreamSeen.some((m) => m.topic === 'msh/US/TX/2/e/Foo')).toBe(true);
+    expect(upstreamSeen.some((m) => m.topic === 'msh/US/LA/2/e/Foo')).toBe(false);
+
+    await new Promise<void>((r) => localPublisher.end(true, {}, () => r()));
+  });
+
+  it('bidirectional rewrite suppresses the echo loop (no runaway republish)', async () => {
+    bridge = new MqttBridgeManager('loop-bridge', 'Loop', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/US/TX/#'],
+      downlinkTopicRewrite: { from: 'msh/US/TX', to: 'msh/US/LA' },
+      uplinkTopicRewrite: { from: 'msh/US/LA', to: 'msh/US/TX' },
+    });
+    await sourceManagerRegistry.addManager(bridge);
+
+    upstreamClient = connect(`mqtt://127.0.0.1:${upstreamPort}`, { reconnectPeriod: 0 });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('upstream connect timeout')), 3000);
+      upstreamClient!.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+    const upstreamSeen: Array<{ topic: string; payload: Buffer }> = [];
+    await new Promise<void>((resolve, reject) => {
+      upstreamClient!.subscribe('msh/#', { qos: 0 }, (err) => (err ? reject(err) : resolve()));
+    });
+    upstreamClient.on('message', (topic, payload) => {
+      upstreamSeen.push({ topic, payload });
+    });
+
+    // A separate upstream publisher emits a TX packet — the bridge ingests,
+    // rewrites to LA, and republishes locally. The parent broker's
+    // local-packet event then runs through the uplink path which rewrites
+    // back to TX. Without echo suppression this would loop forever; with
+    // it, the upstream broker should only see the original packet a
+    // bounded number of times (1: the original publish; if the loop
+    // suppression were broken, we'd see many more).
+    const pub = connect(`mqtt://127.0.0.1:${upstreamPort}`, { reconnectPeriod: 0 });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('pub connect timeout')), 3000);
+      pub.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+    const envelope = buildPositionEnvelope({
+      from: 0x33333333,
+      latI: 440_000_000,
+      lngI: -780_000_000,
+      channelId: 'LongFast',
+      gatewayId: '!33333333',
+      packetId: 0x30000003,
+    });
+    pub.publish('msh/US/TX/2/e/Foo', envelope);
+
+    // Give the system 1s to settle. A broken loop would emit hundreds of
+    // messages in that window.
+    await new Promise((r) => setTimeout(r, 1000));
+
+    // Count appearances on upstream of THIS packet (any topic). Cap at a
+    // small number — 1 original + at most 1 echo before suppression kicks
+    // in is fine; 10+ would indicate runaway.
+    const matchingPayloads = upstreamSeen.filter((m) => Buffer.compare(m.payload, envelope) === 0);
+    expect(matchingPayloads.length).toBeLessThan(5);
+
+    // Also confirm the bridge's uplinkOut counter is bounded (not 100+).
+    expect(bridge.getStatus().uplinkOut).toBeLessThan(5);
+
+    await new Promise<void>((r) => pub.end(true, {}, () => r()));
+  });
+
+  it('no rewrite configured: republish topic matches the original (regression guard)', async () => {
+    bridge = new MqttBridgeManager('no-rewrite-bridge', 'NoRewrite', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/#'],
+      // No rewrite fields — must behave exactly like the pre-#3166 bridge.
+    });
+    await sourceManagerRegistry.addManager(bridge);
+
+    const localClient = connect(`mqtt://127.0.0.1:${localPort}`, {
+      username: 'u',
+      password: 'p',
+      reconnectPeriod: 0,
+    });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('local connect timeout')), 3000);
+      localClient.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+    const localMessages: Array<{ topic: string }> = [];
+    await new Promise<void>((resolve, reject) => {
+      localClient.subscribe('msh/#', { qos: 0 }, (err) => (err ? reject(err) : resolve()));
+    });
+    localClient.on('message', (topic) => {
+      localMessages.push({ topic });
+    });
+
+    const pub = connect(`mqtt://127.0.0.1:${upstreamPort}`, { reconnectPeriod: 0 });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('pub connect timeout')), 3000);
+      pub.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+    const envelope = buildPositionEnvelope({
+      from: 0x44444444,
+      latI: 440_000_000,
+      lngI: -780_000_000,
+      channelId: 'LongFast',
+      gatewayId: '!44444444',
+      packetId: 0x30000004,
+    });
+    pub.publish('msh/CA/ON/PTBO', envelope);
+    await new Promise((r) => setTimeout(r, 300));
+
+    expect(localMessages.some((m) => m.topic === 'msh/CA/ON/PTBO')).toBe(true);
+
+    await new Promise<void>((r) => localClient.end(true, {}, () => r()));
+    await new Promise<void>((r) => pub.end(true, {}, () => r()));
+  });
+
+  it('rewrite prefix mismatch falls through to original topic (no-op for non-matching prefixes)', async () => {
+    bridge = new MqttBridgeManager('mismatch-bridge', 'Mismatch', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: ['msh/#'],
+      // Rewrite TX→LA, but the inbound packet is on CA — should pass through.
+      downlinkTopicRewrite: { from: 'msh/US/TX', to: 'msh/US/LA' },
+    });
+    await sourceManagerRegistry.addManager(bridge);
+
+    const localClient = connect(`mqtt://127.0.0.1:${localPort}`, {
+      username: 'u',
+      password: 'p',
+      reconnectPeriod: 0,
+    });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('local connect timeout')), 3000);
+      localClient.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+    const localMessages: Array<{ topic: string }> = [];
+    await new Promise<void>((resolve, reject) => {
+      localClient.subscribe('msh/#', { qos: 0 }, (err) => (err ? reject(err) : resolve()));
+    });
+    localClient.on('message', (topic) => {
+      localMessages.push({ topic });
+    });
+
+    const pub = connect(`mqtt://127.0.0.1:${upstreamPort}`, { reconnectPeriod: 0 });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('pub connect timeout')), 3000);
+      pub.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+    const envelope = buildPositionEnvelope({
+      from: 0x55555555,
+      latI: 440_000_000,
+      lngI: -780_000_000,
+      channelId: 'LongFast',
+      gatewayId: '!55555555',
+      packetId: 0x30000005,
+    });
+    pub.publish('msh/CA/ON/PTBO', envelope);
+    await new Promise((r) => setTimeout(r, 300));
+
+    // CA topic doesn't match the TX→LA rule — must pass through unchanged.
+    expect(localMessages.some((m) => m.topic === 'msh/CA/ON/PTBO')).toBe(true);
+    expect(localMessages.some((m) => m.topic.startsWith('msh/US/LA'))).toBe(false);
+
+    await new Promise<void>((r) => localClient.end(true, {}, () => r()));
+    await new Promise<void>((r) => pub.end(true, {}, () => r()));
+  });
 });

--- a/src/server/mqttBridgeManager.topicRewrite.test.ts
+++ b/src/server/mqttBridgeManager.topicRewrite.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the applyTopicRewrite helper used by the mqtt_bridge
+ * topic-rewrite feature (issue #3166). End-to-end bridge tests live in
+ * mqttBridgeManager.test.ts; this file focuses on the pure helper.
+ */
+import { describe, it, expect } from 'vitest';
+import { applyTopicRewrite } from './mqttBridgeManager';
+
+describe('applyTopicRewrite', () => {
+  it('returns the topic unchanged when no rule is provided', () => {
+    expect(applyTopicRewrite('msh/US/TX/2/e/Foo', null)).toBe('msh/US/TX/2/e/Foo');
+    expect(applyTopicRewrite('msh/US/TX/2/e/Foo', undefined)).toBe('msh/US/TX/2/e/Foo');
+  });
+
+  it('replaces a matching prefix', () => {
+    const rule = { from: 'msh/US/TX', to: 'msh/US/LA' };
+    expect(applyTopicRewrite('msh/US/TX/2/e/Foo', rule)).toBe('msh/US/LA/2/e/Foo');
+  });
+
+  it('handles an exact match (no trailing path)', () => {
+    const rule = { from: 'msh/US/TX', to: 'msh/US/LA' };
+    expect(applyTopicRewrite('msh/US/TX', rule)).toBe('msh/US/LA');
+  });
+
+  it('does not partially match (msh/US/TX must not match msh/US/TXSomething)', () => {
+    const rule = { from: 'msh/US/TX', to: 'msh/US/LA' };
+    expect(applyTopicRewrite('msh/US/TXSomething/foo', rule)).toBe(
+      'msh/US/TXSomething/foo',
+    );
+  });
+
+  it('returns unchanged when the topic does not match the prefix', () => {
+    const rule = { from: 'msh/US/TX', to: 'msh/US/LA' };
+    expect(applyTopicRewrite('msh/CA/QC/2/e/Foo', rule)).toBe('msh/CA/QC/2/e/Foo');
+  });
+
+  it('normalizes trailing slashes on from and to', () => {
+    expect(
+      applyTopicRewrite('msh/US/TX/2/e/Foo', { from: 'msh/US/TX/', to: 'msh/US/LA' }),
+    ).toBe('msh/US/LA/2/e/Foo');
+    expect(
+      applyTopicRewrite('msh/US/TX/2/e/Foo', { from: 'msh/US/TX', to: 'msh/US/LA/' }),
+    ).toBe('msh/US/LA/2/e/Foo');
+    expect(
+      applyTopicRewrite('msh/US/TX/2/e/Foo', { from: 'msh/US/TX/', to: 'msh/US/LA/' }),
+    ).toBe('msh/US/LA/2/e/Foo');
+    expect(
+      applyTopicRewrite('msh/US/TX/2/e/Foo', { from: 'msh/US/TX///', to: 'msh/US/LA' }),
+    ).toBe('msh/US/LA/2/e/Foo');
+  });
+
+  it('returns unchanged when from is empty', () => {
+    expect(applyTopicRewrite('msh/US/TX/foo', { from: '', to: 'msh/US/LA' })).toBe(
+      'msh/US/TX/foo',
+    );
+    expect(applyTopicRewrite('msh/US/TX/foo', { from: '///', to: 'msh/US/LA' })).toBe(
+      'msh/US/TX/foo',
+    );
+  });
+
+  it('returns unchanged when to is empty', () => {
+    expect(applyTopicRewrite('msh/US/TX/foo', { from: 'msh/US/TX', to: '' })).toBe(
+      'msh/US/TX/foo',
+    );
+  });
+
+  it('returns unchanged when from equals to (after trim)', () => {
+    expect(
+      applyTopicRewrite('msh/US/TX/foo', { from: 'msh/US/TX', to: 'msh/US/TX' }),
+    ).toBe('msh/US/TX/foo');
+    expect(
+      applyTopicRewrite('msh/US/TX/foo', { from: 'msh/US/TX/', to: 'msh/US/TX' }),
+    ).toBe('msh/US/TX/foo');
+  });
+
+  it('preserves the full tail after the prefix replacement', () => {
+    const rule = { from: 'msh', to: 'sandbox' };
+    expect(applyTopicRewrite('msh/US/TX/2/e/Foo', rule)).toBe('sandbox/US/TX/2/e/Foo');
+  });
+
+  it('handles a single-segment rewrite', () => {
+    const rule = { from: 'a', to: 'b' };
+    expect(applyTopicRewrite('a/foo', rule)).toBe('b/foo');
+    expect(applyTopicRewrite('a', rule)).toBe('b');
+    expect(applyTopicRewrite('ab/foo', rule)).toBe('ab/foo'); // not a/foo
+  });
+
+  it('is symmetric (uplink and downlink directions are independent rule calls)', () => {
+    const downlink = { from: 'msh/US/TX', to: 'msh/US/LA' };
+    const uplink = { from: 'msh/US/LA', to: 'msh/US/TX' };
+    const original = 'msh/US/LA/2/e/Foo';
+    const rewritten = applyTopicRewrite(original, uplink);
+    expect(rewritten).toBe('msh/US/TX/2/e/Foo');
+    // Reversing rewritten through the downlink rule should land back on the original.
+    expect(applyTopicRewrite(rewritten, downlink)).toBe(original);
+  });
+});

--- a/src/server/mqttBridgeManager.ts
+++ b/src/server/mqttBridgeManager.ts
@@ -61,6 +61,56 @@ export interface MqttBridgeSourceConfig {
   subscriptions: string[];
   downlinkFilters?: MqttFilterConfig;
   uplinkFilters?: MqttFilterConfig;
+  /**
+   * Literal prefix replacement applied to the topic immediately before
+   * republish to the parent broker (downlink) or publish upstream
+   * (uplink). Useful for bridging between meshes that use different MQTT
+   * root topics (e.g. msh/US/TX ↔ msh/US/LA — issue #3166).
+   *
+   * Semantics: filters run on the ORIGINAL (received) topic, rewrites
+   * apply only at publish time, and the echo cache is keyed on the
+   * post-rewrite topic so feedback loops are still suppressed.
+   *
+   * MQTT wildcards (+, #) are NOT supported — `from` must be a literal
+   * prefix (the validator on sourceRoutes rejects wildcards). Trailing
+   * slashes on `from`/`to` are normalized away.
+   */
+  downlinkTopicRewrite?: TopicRewriteRule;
+  uplinkTopicRewrite?: TopicRewriteRule;
+}
+
+/** Literal prefix replacement rule applied to a Meshtastic MQTT topic. */
+export interface TopicRewriteRule {
+  from: string;
+  to: string;
+}
+
+/**
+ * Apply a literal prefix-replacement rule to a topic.
+ *
+ * - Returns the topic unchanged when the rule is null/undefined, when
+ *   `from` or `to` are empty after trimming trailing slashes, or when
+ *   `from` doesn't match the topic's prefix.
+ * - Trailing slashes on `from` and `to` are normalized away so
+ *   `{from: "msh/US/TX/", to: "msh/US/LA"}` works the same as
+ *   `{from: "msh/US/TX", to: "msh/US/LA/"}`.
+ * - Replaces the literal prefix `from` (and the segment separator `/`
+ *   that follows it) with `to`, preserving the rest of the topic
+ *   unchanged. An exact match (topic equals `from`) returns `to`.
+ *
+ * Exported for unit testing.
+ */
+export function applyTopicRewrite(
+  topic: string,
+  rule: TopicRewriteRule | null | undefined,
+): string {
+  if (!rule) return topic;
+  const from = rule.from.replace(/\/+$/, '');
+  const to = rule.to.replace(/\/+$/, '');
+  if (!from || !to || from === to) return topic;
+  if (topic === from) return to;
+  if (topic.startsWith(from + '/')) return to + topic.slice(from.length);
+  return topic;
 }
 
 export interface MqttBridgeStatus extends SourceStatus {
@@ -437,11 +487,16 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
 
     // Republish to local broker so devices see it. Skip if no parent attached.
     if (this.parentBroker) {
+      // Apply downlink topic rewrite (#3166) right at the publish boundary —
+      // ingestion, filters, and the local-packet event all stay on the
+      // original topic. Echo recorded under the post-rewrite topic so the
+      // uplink direction sees the same topic the parent broker emits.
+      const publishTopic = applyTopicRewrite(topic, this.config.downlinkTopicRewrite);
       this.parentBroker
-        .publish(topic, payload, retained)
+        .publish(publishTopic, payload, retained)
         .then(() => {
           this.downlinkRepublished++;
-          this.recordEcho(this.downlinkEchoes, topic, packetId);
+          this.recordEcho(this.downlinkEchoes, publishTopic, packetId);
         })
         .catch((err) => {
           this.lastError = `local republish failed: ${err.message}`;
@@ -459,11 +514,16 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
 
     if (!this.uplinkFilter.preFilter(p.topic, p.envelope)) return;
 
+    // Apply uplink topic rewrite (#3166) — uplinkFilter ran on the original
+    // topic; only the wire-level publish gets the rewrite. Echo recorded
+    // under the post-rewrite topic so the downlink direction can suppress
+    // the upstream broker's re-emission of this same packet.
+    const publishTopic = applyTopicRewrite(p.topic, this.config.uplinkTopicRewrite);
     this.client
-      .publish(p.topic, p.payload, p.retained)
+      .publish(publishTopic, p.payload, p.retained)
       .then(() => {
         this.uplinkOut++;
-        this.recordEcho(this.uplinkEchoes, p.topic, packetId);
+        this.recordEcho(this.uplinkEchoes, publishTopic, packetId);
       })
       .catch((err) => {
         this.lastError = `upstream publish failed: ${err.message}`;

--- a/src/server/routes/sourceRoutes.topicRewrite.test.ts
+++ b/src/server/routes/sourceRoutes.topicRewrite.test.ts
@@ -1,0 +1,388 @@
+/**
+ * sourceRoutes — mqtt_bridge topic rewrite validation (#3166).
+ *
+ * Covers POST + PUT validation for the new downlinkTopicRewrite and
+ * uplinkTopicRewrite fields on mqtt_bridge config:
+ *
+ *   - Valid rules accepted (POST + PUT).
+ *   - Both rules accepted together.
+ *   - Missing `from` / `to` rejected.
+ *   - Wildcards (+, #) rejected.
+ *   - `from === to` rejected.
+ *   - Wrong type (string instead of object, array) rejected.
+ *   - Standalone bridge (no brokerSourceId) with rewrite rejected.
+ *   - Trailing slashes accepted (normalized).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import sourceRoutes from './sourceRoutes.js';
+import databaseService from '../../services/database.js';
+import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    sources: {
+      getSource: vi.fn(),
+      getAllSources: vi.fn().mockResolvedValue([]),
+      createSource: vi.fn(),
+      updateSource: vi.fn(),
+      deleteSource: vi.fn().mockResolvedValue(true),
+    },
+    nodes: { getAllNodes: vi.fn().mockResolvedValue([]) },
+    messages: { getMessages: vi.fn().mockResolvedValue([]) },
+    traceroutes: { getAllTraceroutes: vi.fn().mockResolvedValue([]) },
+    neighbors: { getAllNeighborInfo: vi.fn().mockResolvedValue([]) },
+    channels: { getAllChannels: vi.fn().mockResolvedValue([]) },
+    settings: { getSetting: vi.fn().mockResolvedValue(null) },
+    checkPermissionAsync: vi.fn().mockResolvedValue(true),
+    findUserByIdAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn().mockResolvedValue(null),
+    getUserPermissionSetAsync: vi.fn().mockResolvedValue({ resources: {}, isAdmin: true }),
+    getChannelDatabasePermissionsForUserAsSetAsync: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    addManager: vi.fn().mockResolvedValue(undefined),
+    removeManager: vi.fn().mockResolvedValue(undefined),
+    getManager: vi.fn().mockReturnValue(null),
+    stopAll: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../meshtasticManager.js', () => {
+  class MeshtasticManager {
+    sourceId: string;
+    constructor(id: string) {
+      this.sourceId = id;
+    }
+    async start() {}
+    async stop() {}
+    on() {
+      return this;
+    }
+    off() {
+      return this;
+    }
+  }
+  return { MeshtasticManager };
+});
+
+vi.mock('../mqttBrokerManager.js', () => {
+  class MqttBrokerManager {
+    sourceId: string;
+    constructor(id: string) {
+      this.sourceId = id;
+    }
+    async start() {}
+    async stop() {}
+    on() {
+      return this;
+    }
+    off() {
+      return this;
+    }
+    getStatus() {
+      return { sourceId: this.sourceId, sourceName: '', sourceType: 'mqtt_broker' as const, connected: false };
+    }
+  }
+  return { MqttBrokerManager };
+});
+
+vi.mock('../mqttBridgeManager.js', () => {
+  class MqttBridgeManager {
+    sourceId: string;
+    constructor(id: string) {
+      this.sourceId = id;
+    }
+    async start() {}
+    async stop() {}
+    on() {
+      return this;
+    }
+    off() {
+      return this;
+    }
+    getStatus() {
+      return { sourceId: this.sourceId, sourceName: '', sourceType: 'mqtt_bridge' as const, connected: false };
+    }
+  }
+  return { MqttBridgeManager };
+});
+
+vi.mock('../meshcoreRegistry.js', () => ({
+  meshcoreManagerRegistry: {
+    get: vi.fn().mockReturnValue(null),
+    getOrCreate: vi.fn(),
+    remove: vi.fn().mockResolvedValue(undefined),
+  },
+  meshcoreConfigFromSource: vi.fn().mockReturnValue(null),
+}));
+
+const mockDb = databaseService as any;
+const mockRegistry = sourceManagerRegistry as any;
+
+const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
+
+const createApp = (): Express => {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: 'test-secret',
+      resave: false,
+      saveUninitialized: false,
+      cookie: { secure: false },
+    }),
+  );
+  app.use((req: any, _res, next) => {
+    req.session.userId = adminUser.id;
+    next();
+  });
+  app.use('/', sourceRoutes);
+  return app;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+  mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+  mockDb.checkPermissionAsync.mockResolvedValue(true);
+  mockRegistry.getManager.mockReturnValue(null);
+});
+
+const brokerRecord = {
+  id: 'broker-1',
+  type: 'mqtt_broker',
+  name: 'Local',
+  enabled: true,
+  config: { listener: { port: 1883 }, auth: { username: 'u', password: 'p' } },
+};
+
+function attachedBridgeBody(extra: Record<string, unknown> = {}) {
+  return {
+    name: 'TX Bridge',
+    type: 'mqtt_bridge',
+    config: {
+      brokerSourceId: 'broker-1',
+      upstream: { url: 'mqtt://mqtt.meshtastic.org:1883', username: 'meshdev', password: 'large4cats' },
+      subscriptions: ['msh/US/TX/#'],
+      ...extra,
+    },
+  };
+}
+
+describe('sourceRoutes — POST mqtt_bridge topic rewrite validation (#3166)', () => {
+  it('accepts a valid downlink rewrite on an attached bridge', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue(brokerRecord);
+    mockDb.sources.createSource.mockImplementation(async (s: any) => ({ ...s, createdAt: new Date(), updatedAt: new Date() }));
+
+    const res = await request(app)
+      .post('/')
+      .send(attachedBridgeBody({ downlinkTopicRewrite: { from: 'msh/US/TX', to: 'msh/US/LA' } }));
+
+    expect(res.status).toBe(201);
+    expect(mockDb.sources.createSource).toHaveBeenCalledTimes(1);
+    const created = mockDb.sources.createSource.mock.calls[0][0];
+    expect(created.config.downlinkTopicRewrite).toEqual({ from: 'msh/US/TX', to: 'msh/US/LA' });
+  });
+
+  it('accepts both downlink and uplink rewrites together', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue(brokerRecord);
+    mockDb.sources.createSource.mockImplementation(async (s: any) => ({ ...s, createdAt: new Date(), updatedAt: new Date() }));
+
+    const res = await request(app)
+      .post('/')
+      .send(
+        attachedBridgeBody({
+          downlinkTopicRewrite: { from: 'msh/US/TX', to: 'msh/US/LA' },
+          uplinkTopicRewrite: { from: 'msh/US/LA', to: 'msh/US/TX' },
+        }),
+      );
+
+    expect(res.status).toBe(201);
+  });
+
+  it('accepts trailing-slash variants (normalized at runtime)', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue(brokerRecord);
+    mockDb.sources.createSource.mockImplementation(async (s: any) => ({ ...s, createdAt: new Date(), updatedAt: new Date() }));
+
+    const res = await request(app)
+      .post('/')
+      .send(attachedBridgeBody({ downlinkTopicRewrite: { from: 'msh/US/TX/', to: 'msh/US/LA' } }));
+
+    expect(res.status).toBe(201);
+  });
+
+  it('rejects rewrite on a standalone bridge (no brokerSourceId)', async () => {
+    const app = createApp();
+    mockDb.sources.getAllSources.mockResolvedValue([]);
+
+    const res = await request(app)
+      .post('/')
+      .send({
+        name: 'Standalone',
+        type: 'mqtt_bridge',
+        config: {
+          upstream: { url: 'mqtt://example.com' },
+          subscriptions: ['msh/#'],
+          downlinkTopicRewrite: { from: 'msh/US/TX', to: 'msh/US/LA' },
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/standalone bridges cannot rewrite/);
+  });
+
+  it('rejects rewrite missing `from`', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue(brokerRecord);
+
+    const res = await request(app)
+      .post('/')
+      .send(attachedBridgeBody({ downlinkTopicRewrite: { to: 'msh/US/LA' } as any }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/downlinkTopicRewrite\.from.*to.*strings/);
+  });
+
+  it('rejects empty `from` after trim', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue(brokerRecord);
+
+    const res = await request(app)
+      .post('/')
+      .send(attachedBridgeBody({ downlinkTopicRewrite: { from: '   /', to: 'msh/US/LA' } }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/non-empty/);
+  });
+
+  it('rejects MQTT wildcards (+)', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue(brokerRecord);
+
+    const res = await request(app)
+      .post('/')
+      .send(attachedBridgeBody({ downlinkTopicRewrite: { from: 'msh/US/+', to: 'msh/US/LA' } }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/MQTT wildcards/);
+  });
+
+  it('rejects MQTT wildcards (#)', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue(brokerRecord);
+
+    const res = await request(app)
+      .post('/')
+      .send(attachedBridgeBody({ uplinkTopicRewrite: { from: 'msh/US/LA', to: 'msh/#' } }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/MQTT wildcards/);
+  });
+
+  it('rejects from === to', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue(brokerRecord);
+
+    const res = await request(app)
+      .post('/')
+      .send(attachedBridgeBody({ downlinkTopicRewrite: { from: 'msh/US/TX', to: 'msh/US/TX/' } }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/must differ/);
+  });
+
+  it('rejects non-object rule (array)', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue(brokerRecord);
+
+    const res = await request(app)
+      .post('/')
+      .send(attachedBridgeBody({ downlinkTopicRewrite: ['msh/US/TX', 'msh/US/LA'] as any }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/must be an object/);
+  });
+});
+
+describe('sourceRoutes — PUT mqtt_bridge topic rewrite validation (#3166)', () => {
+  const existingBridge = {
+    id: 'bridge-1',
+    type: 'mqtt_bridge',
+    name: 'TX Bridge',
+    enabled: true,
+    config: {
+      brokerSourceId: 'broker-1',
+      upstream: { url: 'mqtt://mqtt.meshtastic.org:1883', username: 'meshdev', password: 'large4cats' },
+      subscriptions: ['msh/US/TX/#'],
+    },
+  };
+
+  it('accepts adding a valid rewrite on PUT', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue(existingBridge);
+    mockDb.sources.updateSource.mockResolvedValue({ ...existingBridge });
+
+    const res = await request(app)
+      .put('/bridge-1')
+      .send({
+        config: {
+          brokerSourceId: 'broker-1',
+          upstream: { url: 'mqtt://mqtt.meshtastic.org:1883', username: 'meshdev' },
+          subscriptions: ['msh/US/TX/#'],
+          downlinkTopicRewrite: { from: 'msh/US/TX', to: 'msh/US/LA' },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const updateArg = mockDb.sources.updateSource.mock.calls[0][1];
+    expect(updateArg.config.downlinkTopicRewrite).toEqual({ from: 'msh/US/TX', to: 'msh/US/LA' });
+  });
+
+  it('rejects rewrite on PUT when the bridge becomes standalone', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue(existingBridge);
+
+    // PUT drops brokerSourceId — bridge becomes standalone. Rewrite must be rejected.
+    const res = await request(app)
+      .put('/bridge-1')
+      .send({
+        config: {
+          upstream: { url: 'mqtt://mqtt.meshtastic.org:1883' },
+          subscriptions: ['msh/US/TX/#'],
+          downlinkTopicRewrite: { from: 'msh/US/TX', to: 'msh/US/LA' },
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/standalone bridges cannot rewrite/);
+  });
+
+  it('rejects malformed rewrite on PUT', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue(existingBridge);
+
+    const res = await request(app)
+      .put('/bridge-1')
+      .send({
+        config: {
+          brokerSourceId: 'broker-1',
+          upstream: { url: 'mqtt://mqtt.meshtastic.org:1883' },
+          subscriptions: ['msh/US/TX/#'],
+          downlinkTopicRewrite: { from: 'msh/US/+/foo', to: 'msh/US/LA' },
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/MQTT wildcards/);
+  });
+});

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -62,6 +62,60 @@ export function buildMqttManagerForSource(
   return new MqttBridgeManager(id, name, config as unknown as MqttBridgeSourceConfig);
 }
 
+/**
+ * Validate the optional downlink/uplink topic-rewrite fields on an
+ * mqtt_bridge config (#3166).
+ *
+ * Rules:
+ * - Each rule (if present) must be an object with non-empty string
+ *   `from` and `to` fields. Trailing whitespace and slashes are
+ *   meaningful here only when both fields end up empty post-trim (the
+ *   runtime helper normalizes trailing slashes itself).
+ * - MQTT wildcards `+` and `#` are rejected — the rule is a literal
+ *   prefix replacement.
+ * - `from === to` is rejected (no-op config).
+ * - Rewrites only apply when the bridge is attached to a parent broker
+ *   (downlink republish has nowhere to go without one, and uplink fires
+ *   off the parent broker's `local-packet` event). When the bridge is
+ *   standalone (no `brokerSourceId`), rewrite fields are rejected so
+ *   the user doesn't ship a setting that will silently do nothing.
+ *
+ * Returns an error message string if invalid, or null if OK.
+ */
+function validateMqttBridgeRewrites(config: Record<string, any>): string | null {
+  const isAttached =
+    typeof config.brokerSourceId === 'string' && config.brokerSourceId.trim() !== '';
+  const checkOne = (label: string, rule: unknown): string | null => {
+    if (rule === undefined || rule === null) return null;
+    if (typeof rule !== 'object' || Array.isArray(rule)) {
+      return `${label} must be an object with from and to string fields`;
+    }
+    if (!isAttached) {
+      return `${label} requires a parent broker — standalone bridges cannot rewrite topics`;
+    }
+    const r = rule as { from?: unknown; to?: unknown };
+    if (typeof r.from !== 'string' || typeof r.to !== 'string') {
+      return `${label}.from and ${label}.to must be strings`;
+    }
+    const from = r.from.trim().replace(/\/+$/, '');
+    const to = r.to.trim().replace(/\/+$/, '');
+    if (!from || !to) {
+      return `${label}.from and ${label}.to must be non-empty`;
+    }
+    if (/[+#]/.test(from) || /[+#]/.test(to)) {
+      return `${label} must not contain MQTT wildcards (+, #) — rewrites are literal prefix replacement`;
+    }
+    if (from === to) {
+      return `${label}.from and ${label}.to must differ`;
+    }
+    return null;
+  };
+  return (
+    checkOne('downlinkTopicRewrite', config.downlinkTopicRewrite) ??
+    checkOne('uplinkTopicRewrite', config.uplinkTopicRewrite)
+  );
+}
+
 // Restore credentials the edit UI intentionally omitted from the save
 // payload. The source-edit form clears the password field on load (the GET
 // endpoint strips it for non-admins) and drops the field from the PUT body
@@ -203,6 +257,10 @@ router.post('/', requirePermission('sources', 'write'), async (req: Request, res
           return res.status(400).json({ error: `mqtt_bridge brokerSourceId ${parentId} does not reference an mqtt_broker source` });
         }
       }
+      const rewriteError = validateMqttBridgeRewrites(config ?? {});
+      if (rewriteError) {
+        return res.status(400).json({ error: rewriteError });
+      }
     }
     if (!config || typeof config !== 'object') {
       return res.status(400).json({ error: 'config is required and must be an object' });
@@ -313,6 +371,17 @@ router.put('/:id', requirePermission('sources', 'write'), async (req: Request, r
       const vnErr = await validateVirtualNodeConfig(existing.type, config, existing.id);
       if (vnErr) {
         return res.status(vnErr.status).json({ error: vnErr.error });
+      }
+
+      // Validate mqtt_bridge topic rewrites (#3166) against the incoming
+      // config — preserveSourceCredentials only round-trips passwords, so
+      // the rewrite fields and the brokerSourceId in `config` reflect the
+      // post-save state.
+      if (existing.type === 'mqtt_bridge') {
+        const rewriteError = validateMqttBridgeRewrites(config);
+        if (rewriteError) {
+          return res.status(400).json({ error: rewriteError });
+        }
       }
 
       // Prevent duplicate host:port combinations (exclude self)


### PR DESCRIPTION
## Summary

Adds optional `downlinkTopicRewrite` and `uplinkTopicRewrite` fields to `mqtt_bridge` config — literal prefix-replacement rules applied at the publish boundary only.

**Example:** Bridge between an LA mesh (`msh/US/LA`) and the Houston public mesh (`msh/US/TX`) by setting downlink TX→LA and uplink LA→TX. Inbound TX traffic is republished to the parent broker as LA-rooted (so local devices subscribed to `msh/US/LA/#` pick it up); outbound LA traffic goes upstream as TX-rooted (so Houston subscribers see it).

Closes #3166. Originated from discussion #3159.

## Architecture

- **Ingestion, filters, and `local-packet` events keep the ORIGINAL (received) topic.** Only the wire-level publish (`parentBroker.publish` for downlink, `client.publish` for uplink) sees the rewrite.
- **Echo cache keyed on the POST-rewrite topic** — feedback loops through the parent broker's `local-packet` event are suppressed by the existing `(topic, packetId)` 60-second cache without new infrastructure. Walked through in the docs section.
- Pure `applyTopicRewrite` helper handles trailing-slash normalization and pass-through for non-matching prefixes. Exported for testing.

## Validation (server-side, POST + PUT)

- Each rule must be an object with non-empty string `from` / `to`.
- MQTT wildcards (`+`, `#`) rejected — rewrites are literal prefix only.
- `from === to` rejected (no-op).
- **Rewrite fields rejected on standalone bridges** (no parent broker republish path and no `local-packet` event source — they'd silently do nothing).
- PUT validation runs against the incoming config since `preserveSourceCredentials` only round-trips passwords.

## UI

The PR-A placeholder section in `MqttBridgeSettingsTab` is replaced with two From/To input pairs (one per direction). When no parent broker is selected, the inputs are hidden and a warning surfaces explaining the standalone limitation. Caveats footer covers PSK match, zero-hop pairing, and the wildcard restriction.

## Docs

- New "Topic rewriting" section in `docs/features/mqtt-broker.md` with the LA↔TX recipe, loop-suppression walkthrough, and a Caveats warning block.
- Feature matrix row added.
- Bridge "What it does" bullet list updated.
- New use-case recipe ("Cross-mesh routing between two MQTT roots") added.

## Test plan

- [x] 12 unit tests for `applyTopicRewrite` (prefix/exact match, trailing slash normalization, pass-through, empty-field safety, no-op detection, symmetry).
- [x] 5 integration tests in `mqttBridgeManager.test.ts` using real Aedes brokers: downlink rewrite, uplink rewrite, bidirectional loop suppression, no-rewrite regression, prefix mismatch fall-through.
- [x] 13 API validation tests covering POST + PUT for valid/invalid rules, standalone rejection, wildcards, `from === to`, missing fields.
- [x] 1 updated frontend test + 1 new test (standalone warning shows, inputs hidden).
- [x] Full vitest suite: 10,511 passed, 0 failed (+31 over PR A baseline).
- [x] `npm run typecheck` + `npm run build` + `npm run docs:build` all clean.
- [x] Dev container deployed and verified live: malformed PUT returns 400 with exact expected error, valid PUT returns 200 and round-trips, restore PUT returns the bridge to a clean state.
- [ ] Reviewer: open a bridge in the Settings tab, set a rewrite, save, restart the container, confirm the rule persists.
- [ ] Reviewer (optional): if you have a second mesh accessible via MQTT, exercise the cross-mesh recipe end-to-end and confirm packets cross over RF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)