### PR TITLE
chore: bump version to 4.7.0 + changelog and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 
+## [4.7.0] - 2026-05-24
+
+# MeshMonitor v4.7.0
+
+Minor release. Headline features are **MeshCore Remote Administration** — a full CLI-over-encrypted-DM admin surface for distant MeshCore nodes plus an in-app console for the locally connected device — and **MQTT bridge topic rewriting**, restored from the (briefly merged + reverted) #3170 with the configuration UI moved to the **broker** edit modal so a single dialog covers every bridge attached to that broker. Also reverts the #3169 / #3170 per-source MQTT dashboard shell that replaced the full v4.6.6 dashboard for broker and bridge sources; those source types fall through to the full Meshtastic dashboard again with all the Channels / Telemetry / DMs / Map surfaces intact.
+
+## Features
+
+### MeshCore Remote Administration
+
+- #3160 feat(meshcore): add remote-administration console with encrypted credentials — new `MeshCoreRemoteConsole` mounted in the contact-detail panel for Repeater / Room Server contacts. Sends CLI commands as encrypted DMs (txt_type=CliData) via meshcore.js, routes replies through a new `cli_reply` bridge event so admin output never lands in the chat log. `loginToNode` populates the remote's ACL; saved passwords are AES-256-GCM-encrypted with an HKDF-derived key from `SESSION_SECRET` and persisted in `meshcore_nodes.adminCredential` (migration 070). A 4-byte `kid` fingerprint on each envelope makes `SESSION_SECRET` rotation detectable and surfaced as a banner instead of a silent auth-tag failure. New `remote_admin` per-source permission resource gates the entire surface.
+- #3161 feat(meshcore): stats panel, quick-action buttons, danger-command guard — `MeshCoreRemoteStatsPanel` renders `getStatus` output (uptime, battery, queue, RSSI/SNR, packets RX/TX, air time, errors) with 30 s auto-refresh. Quick-action buttons pre-fill the input for `ver` / `stats` / `neighbors` / `clock` / `clock sync` / `advert` / `reboot`. Destructive commands matching `/(reboot|erase|clkreboot|factory)/i` route through a typed-name confirmation modal client-side AND a `DANGER_CONFIRM_REQUIRED` 400 server-side, enforced on every CLI route.
+- #3162 feat(meshcore): local-device CLI console in Configuration view — `MeshCoreLocalConsole` for the physically-connected node. Dispatch is device-type-aware: Repeater / Room Server → forwarded to `sendRepeaterCommand` (native serial CLI); Companion → `runSyntheticLocalCli` interprets `ver` / `stats [core|radio|packets]` / `clock` / `advert` / `help` against existing companion-protocol bridge commands. `CliConsoleBody` extracted as a shared primitive consumed by both consoles.
+- #3165 feat(meshcore): ACL setperm form, command history, internal docs — `MeshCoreAclManager` provides a structured `setperm <pubkey> <level>` form (pubkey input + Remove / Guest / ReadWrite / Admin dropdown) mounted alongside the body for Repeater / Room Server targets. `CliConsoleBody` gains ↑/↓ command history (50 entries, de-duped, draft preserved) and a `runCommand` imperative handle so the ACL form shares one transcript with free-typed commands. New `docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md` documents the protocol, credential store design, danger guard, and the local / remote dispatch table.
+- #3167 feat(meshcore): persistent transcript + per-command audit log — transcript restored from `sessionStorage` on mount and persisted on every change, keyed by `targetId` (cap 200 entries). Every CLI command + login outcome + credential mutation writes a distinct audit row via a new `auditMeshcoreEvent` helper. Canary test asserts the plaintext password never appears in any audit details across every emission path.
+
+### MQTT topic rewriting (broker-managed)
+
+- #3173 feat(mqtt): bridge topic rewrites managed from broker settings — re-introduces the topic-rewriting feature originally from #3170 (which was reverted in #3172 alongside the #3169 dashboard shell), with the configuration UI moved into the broker's legacy edit modal. Operators see one collapsible panel per bridge attached to that broker; each panel exposes Downlink and Uplink columns with literal `from` → `to` prefix rules. Broker save fires first; per-bridge PUTs follow for any changed bridge config. Backend (`applyTopicRewrite`, publish-path integration, validator) is unchanged from #3170 — see [`docs/features/mqtt-broker.md`](docs/features/mqtt-broker.md#topic-rewriting).
+
+## Fixes
+
+- #3172 revert(mqtt): restore v4.6.6 per-source dashboard for broker and bridge — reverts PR #3169 (per-source detail dashboard shell) and #3170 (bridge topic rewriting, which depended on #3169's UI files). The #3169 shell replaced the full v4.6.6 MQTT dashboard (Channels / Telemetry / DMs / Map) with a thin Map + Settings tab pair, regressing significant functionality. MQTT broker and bridge sources fall through to `App` again as they did in v4.6.6. The topic-rewriting feature is re-introduced in #3173 with the config UI hosted on the broker side.
+
+## Docs
+
+- #3165 docs: new `docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md` covering the protocol surface, credential store / HKDF / kid design, danger guard (client + server enforcement), local-vs-remote dispatch table, `CliConsoleBody` primitive, and an explicit "tempting but not worth doing" section. CLAUDE.md read-order updated to point new agents at it before they touch MeshCore admin code.
+- This release: `docs/features/meshcore.md` adds a Remote Administration section covering the remote and local consoles, credential store, and audit log. `docs/features/mqtt-broker.md` updates the topic-rewriting section to reflect the broker-side configuration UI.
+
+
 ## [4.6.5] - 2026-05-22
 
 # MeshMonitor v4.6.5

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.6.6",
+  "version": "4.7.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.6.6",
+  "version": "4.7.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/blog/2026-05-24-v4.7.0-release.md
+++ b/docs/blog/2026-05-24-v4.7.0-release.md
@@ -1,0 +1,56 @@
+---
+id: news-2026-05-24-v4.7.0-release
+title: MeshMonitor v4.7.0 — MeshCore Remote Admin & broker-managed MQTT topic rewrites
+date: '2026-05-24T20:00:00Z'
+category: release
+priority: important
+minVersion: 4.0.0
+tags: [meshcore, mqtt, security]
+---
+
+## What's new
+
+**v4.7.0** is mostly two things: a full **MeshCore remote-administration** surface, and the return of **MQTT bridge topic rewriting** with the configuration UI living on the broker side. It also reverts an earlier per-source MQTT dashboard experiment that replaced the v4.6.6 Channels / Telemetry / DMs / Map dashboard with a thin Map + Settings shell — those source types now fall through to the full Meshtastic dashboard again, exactly as they did in v4.6.6.
+
+### MeshCore Remote Administration
+
+For any Repeater or Room Server contact in your MeshCore source, the contact-detail panel now hosts a **Remote administration** console. Log in with the node's admin password (or blank for guest), and you can:
+
+- **Send arbitrary CLI commands** (`ver`, `stats`, `neighbors`, `set radio …`) with the reply appearing inline in a terminal-style transcript.
+- **Use quick-action buttons** that pre-fill the common verbs and surface a typed-name confirmation modal for destructive commands (`reboot`, `erase`, `clkreboot`, `factory`). Mirrored server-side so a script can't bypass the prompt.
+- **Read live stats** in a structured panel — battery, queue depth, packet counts, air time, last RSSI / SNR — auto-refreshed every 30 seconds.
+- **Manage the ACL** via a `setperm` form: paste a 64-character hex pubkey, pick **Remove / Guest / ReadWrite / Admin**, click Apply.
+
+A separate **Device console** lives in the Configuration tab for the locally connected node. Dispatch is device-type-aware: Repeater / Room Server gets the device's native serial CLI; Companion firmware gets a small synthetic CLI (`ver` / `stats` / `clock` / `advert` / `help`) that maps to existing companion-protocol calls.
+
+Optionally **save the admin password** so subsequent visits auto-log-in silently. The plaintext is encrypted with AES-256-GCM using a key derived from `SESSION_SECRET`; a 4-byte fingerprint on each envelope makes secret rotation detectable and surfaced as a yellow banner instead of a silent auth-tag failure. **The plaintext never crosses the wire back to the frontend** — the auto-login route decrypts in-process, calls `loginToNode`, and never echoes the password.
+
+::: warning Capability gating
+When `SESSION_SECRET` was auto-generated rather than configured, the "Remember password" checkbox is disabled. Persisting against an ephemeral key would lose every saved password on restart. Set `SESSION_SECRET=$(openssl rand -hex 32)` in your environment to enable credential persistence.
+:::
+
+Everything is gated by a new per-source `remote_admin` permission so you can grant CLI access to a subset of operators without unlocking source configuration.
+
+Every CLI command, login outcome, and credential mutation also writes an `audit_log` row with distinct action names per outcome (`meshcore_remote_cli`, `meshcore_remote_login`, `meshcore_credential_forget`, etc.) — a forensic trail if you need to answer "who ran `reboot` against which repeater when?".
+
+Full architecture write-up for the curious: [`docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md`](https://github.com/Yeraze/meshmonitor/blob/main/docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md).
+
+### MQTT topic rewriting (now broker-managed)
+
+Topic rewriting lets a single MQTT bridge swap a literal topic prefix in either direction — typically used to glue together two meshes that publish under different MQTT roots (e.g. relay `msh/US/TX/...` from the public Houston broker as `msh/US/LA/...` so LA-attached devices subscribed to `msh/US/LA/#` actually see the traffic). The feature briefly shipped in v4.6.6 as part of the experimental per-source bridge dashboard and was reverted alongside that dashboard.
+
+In v4.7 it's back, with the configuration UI moved to the **broker's edit modal**. Open the broker source's edit dialog, scroll to **Bridge topic rewrites**, and you'll see one collapsible panel per bridge attached to that broker — each with Downlink and Uplink columns of `from` / `to` prefix inputs. Saving the broker writes per-bridge config updates for whatever changed. The backend (publish-path rewriting + echo-cache integration + standalone-bridge rejection + wildcards-disallowed validator) is unchanged from the original implementation.
+
+Full reference: [MQTT broker docs → Topic rewriting](https://github.com/Yeraze/meshmonitor/blob/main/docs/features/mqtt-broker.md#topic-rewriting).
+
+### MQTT dashboard restored
+
+If you saw the broker / bridge detail pages in v4.6.6 collapse into a Map + Settings shell with no Channels, Telemetry, DMs, or Map: that's been reverted. Broker and bridge sources route to the full Meshtastic dashboard again with every original surface available — same routing as v4.6.6.
+
+## Action items after upgrade
+
+- **Try Remote Administration** on a Repeater or Room Server contact. If you want the saved-password convenience, make sure `SESSION_SECRET` is configured.
+- **If you were using topic rewrites in v4.6.6** (between the original merge and the revert), reopen the broker that owns the bridge and re-enter the rewrite rules under "Bridge topic rewrites" — the field locations changed.
+- **Grant `remote_admin` per-source** to operators who should be able to run CLI commands against your MeshCore Repeaters / Room Servers. Admins already have it implicitly.
+
+Full release notes: [CHANGELOG.md](https://github.com/Yeraze/meshmonitor/blob/main/CHANGELOG.md#470---2026-05-24).

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -181,7 +181,7 @@ The composite primary key on `meshcore_nodes` is `(sourceId, publicKey)`, so the
 ## Remote Administration
 
 ::: tip Added in 4.7
-The MeshCore Remote-Administration console ships in 4.7 — gated on the new per-source `remote_admin` permission. See [`docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md`](../internal/dev-notes/MESHCORE_REMOTE_ADMIN.md) for the protocol-level architecture; this section is the operator-facing summary.
+The MeshCore Remote-Administration console ships in 4.7 — gated on the new per-source `remote_admin` permission. See [the internal architecture doc](https://github.com/Yeraze/meshmonitor/blob/main/docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md) (`docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md` in the repo) for the protocol-level architecture; this section is the operator-facing summary.
 :::
 
 MeshCore's remote-admin protocol is **CLI text sent as an encrypted DM** — the same `PAYLOAD_TYPE_TXT_MSG` packet a chat message uses, distinguished by a single `txt_type` byte (`CliData = 1` vs `Plain = 0`). The remote node dispatches the text into its `CommonCLI::handleCommand` handler and replies with one packet of text. MeshMonitor wraps the wire-level traffic behind two consoles.

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -178,6 +178,65 @@ The config requires `configuration:write` on the source. Read-only users see the
 
 The composite primary key on `meshcore_nodes` is `(sourceId, publicKey)`, so the same device advertising under two different sources is tracked independently.
 
+## Remote Administration
+
+::: tip Added in 4.7
+The MeshCore Remote-Administration console ships in 4.7 — gated on the new per-source `remote_admin` permission. See [`docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md`](../internal/dev-notes/MESHCORE_REMOTE_ADMIN.md) for the protocol-level architecture; this section is the operator-facing summary.
+:::
+
+MeshCore's remote-admin protocol is **CLI text sent as an encrypted DM** — the same `PAYLOAD_TYPE_TXT_MSG` packet a chat message uses, distinguished by a single `txt_type` byte (`CliData = 1` vs `Plain = 0`). The remote node dispatches the text into its `CommonCLI::handleCommand` handler and replies with one packet of text. MeshMonitor wraps the wire-level traffic behind two consoles.
+
+### Remote console (per contact)
+
+For any Repeater (advType=2) or Room Server (advType=3) contact in your MeshCore source, the contact-detail panel surfaces a **Remote administration** section. The user with `remote_admin:write` on that source can:
+
+- **Log in** with the node's admin password (or blank for guest access). Optionally tick "Remember this password" — see *Credential store* below.
+- **Send arbitrary CLI commands** (e.g. `ver`, `stats`, `neighbors`, `set radio …`) and see the reply inline in the transcript.
+- **Click quick-action buttons** that pre-fill the input for the most-common commands. `Reboot` is flagged danger — see *Danger commands* below.
+- **Read live stats** in a structured panel (battery, queue, packet counts, air time, last SNR / RSSI) auto-refreshed every 30 s while logged in.
+- **Manage the ACL** via a `setperm` form: paste a 64-char hex pubkey, pick **Remove / Guest / ReadWrite / Admin**, click Apply. The built command (`setperm <pubkey> <level>`) lands in the same transcript as free-typed commands.
+
+The console only renders for Repeater / Room Server advTypes since Companion firmware doesn't expose a remote-admin surface. Replies are single-packet (≈130 – 180 byte MTU) and there is no chunking — long output is truncated at the firmware level.
+
+### Local console (Configuration view)
+
+The Configuration tab gets a **Device console** for the locally connected node. Dispatch depends on the firmware:
+
+| Local firmware | Console behavior |
+|---|---|
+| Repeater / Room Server | Forwards to the device's native serial CLI via `sendRepeaterCommand`. Same command set as a remote Repeater. |
+| Companion | A small synthetic interpreter on the server side maps `ver` / `stats [core\|radio\|packets]` / `clock` / `advert` / `help` to existing companion-protocol bridge commands and formats the response as text. Mutating verbs (`set name`, `set radio` …) are intentionally NOT in the synthetic CLI — the existing form fields on the same Configuration tab handle those with proper validation. |
+
+No login flow: the connection is physical (USB serial or direct TCP), so there's no admin password concept. Gated on the existing `configuration:write` permission.
+
+### Credential store
+
+When the user ticks "Remember this password" at login, the plaintext is encrypted with **AES-256-GCM** using a key derived from `SESSION_SECRET` via HKDF and stored in `meshcore_nodes.adminCredential` (added by migration 070). Each envelope includes a 4-byte `kid` fingerprint of the current secret; on subsequent visits the console silently logs in using the saved password if `kid` matches. If `SESSION_SECRET` rotates, the mismatched `kid` triggers a yellow banner asking the user to re-enter the password — never a silent auth-tag failure.
+
+::: warning Capability gating
+When `SESSION_SECRET` was auto-generated rather than explicitly configured, the "Remember password" checkbox is disabled with a tooltip explanation. Persisting against an ephemeral key would lose every saved password on every restart, which is worse than re-prompting. Set `SESSION_SECRET=$(openssl rand -hex 32)` in your environment to enable credential persistence.
+:::
+
+**Security boundary**: the credential store defends against a DB-file-only exfil (someone grabs `meshmonitor.db` without the host environment). It does **not** defend against a host compromise — anyone running code on the host has `SESSION_SECRET` and the DB. Same posture as the existing channel-PSK storage. The plaintext password **never** leaves the server process: the auto-login route reads the encrypted envelope, decrypts in-process, and calls `loginToNode(pubkey, plaintext)` without echoing the password to the client. A test canary in `meshcoreRoutes.test.ts` walks every audit-emitting login code path and asserts the plaintext is absent from each response body and audit row.
+
+### Danger commands
+
+Destructive verbs matching `/(reboot|erase|clkreboot|factory)/i` are gated by a typed-name confirmation modal: the user must type the contact name (or local device name) exactly to enable the Confirm button. The same regex is mirrored server-side — `POST /admin/cli` and `POST /cli` both reject without `confirm: true` in the body with `code: DANGER_CONFIRM_REQUIRED`. Mirrored deliberately so a script bypassing the modal still gets the prompt-as-requirement.
+
+### Audit log
+
+Every CLI command, login outcome, and credential mutation writes an `audit_log` row through a new `auditMeshcoreEvent` helper. Distinct `action` values per outcome:
+
+| Action | When |
+|---|---|
+| `meshcore_remote_login` / `_failed` | manual `/admin/login` success / auth failure |
+| `meshcore_remote_login_saved` / `_failed` | auto-login via saved credential (failures carry the specific code) |
+| `meshcore_remote_cli` / `_failed` / `_blocked` | per-CLI command on a remote node |
+| `meshcore_local_cli` / `_failed` / `_blocked` | per-CLI command on the local node |
+| `meshcore_credential_forget` | `DELETE /admin/credentials/:pubkey` |
+
+The `details` JSON captures `sourceId`, `publicKey` (where relevant), command text, reply length, and elapsed milliseconds. **The plaintext password never appears in audit details**, verified by the canary test referenced above.
+
 ## Multi-Source Dashboard
 
 MeshCore sources appear as styled cards in the dashboard sidebar — same visual language as Meshtastic sources, with a MeshCore logo and per-source status.

--- a/docs/features/mqtt-broker.md
+++ b/docs/features/mqtt-broker.md
@@ -199,7 +199,7 @@ By default an `mqtt_bridge` is a byte-for-byte relay — it republishes inbound 
 | `downlinkTopicRewrite` | upstream → parent broker | Republish an inbound topic on the parent broker under a different prefix, so locally-subscribed devices see it. |
 | `uplinkTopicRewrite` | parent broker → upstream | Publish a parent-broker topic upstream under a different prefix, so the foreign mesh sees your local traffic. |
 
-Each rule is `{ from, to }` — literal prefix match (no MQTT `+` / `#` wildcards), trailing slashes normalized away. Set in the bridge's **Settings tab** (Sources → click the bridge → Settings → Topic rewriting), or via the API.
+Each rule is `{ from, to }` — literal prefix match (no MQTT `+` / `#` wildcards), trailing slashes normalized away. Configured from the **broker's edit modal** (Sources → kebab on the broker → Edit → **Bridge topic rewrites**) — one collapsible panel per bridge attached to that broker, so an operator can manage every rewrite for a given broker in one place. Equivalent fields are also accepted via the source API on the bridge itself (`PUT /api/sources/<bridgeId>` with `config.downlinkTopicRewrite` and `config.uplinkTopicRewrite`).
 
 ### Example — LA ↔ TX cross-mesh bridge
 

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.6.6
-appVersion: "4.6.6"
+version: 4.7.0
+appVersion: "4.7.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.6",
+  "version": "4.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.6.6",
+      "version": "4.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.6.6",
+  "version": "4.7.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Minor version bump covering this cycles MeshCore Remote Administration work (#3160, #3161, #3162, #3165, #3167) and the broker-managed MQTT bridge topic-rewriting feature (#3173), plus the revert of the per-source MQTT dashboard shell that regressed the v4.6.6 broker/bridge dashboards (#3172).

## Version updates (all 5 tracked files)

- `package.json` → 4.7.0
- `package-lock.json` → regenerated via `npm install --package-lock-only --legacy-peer-deps`
- `helm/meshmonitor/Chart.yaml` → 4.7.0 (version + appVersion)
- `desktop/src-tauri/tauri.conf.json` → 4.7.0
- `desktop/package.json` → 4.7.0

## Documentation

- **CHANGELOG.md** — new 4.7.0 section grouped under Features / Fixes / Docs, with MeshCore Remote Administration items under a sub-heading so the surface area is easy to scan.
- **docs/features/meshcore.md** — new "Remote Administration" section between Telemetry and Multi-Source Dashboard, covering the remote console, local console, credential store with the HKDF + kid fingerprint design, danger-command typed-name confirmation, and the audit log catalog. Points at the internal architecture doc for protocol-level detail.
- **docs/features/mqtt-broker.md** — updates the topic-rewriting section to reflect that the configuration UI now lives on the brokers edit modal (one panel per attached bridge) rather than the bridges own settings tab that was reverted with #3169.
- **docs/blog/2026-05-24-v4.7.0-release.md** (new) — release blog post covering all three pillars (MeshCore admin, MQTT rewrites, dashboard restoration) with the same operator-focused tone as recent release blog entries.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Migration registry test still passes (9 passing)
- [x] Pure docs + version PR — no source code changes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
