### PR TITLE
fix(channels): hide global Channel Database entries in per-source view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 
+## [4.7.1] - 2026-05-25
+
+# MeshMonitor v4.7.1
+
+Patch release. Fixes a per-source dashboard regression where the Channels tab inflated its visible channel list with the global Channel Database (server-side MQTT decryption PSK storage). A meshtastic_tcp source like "Sandbox" — with three real channels configured on the device — was showing ~25 entries because every MQTT-bridge-observed channel name across every other source got merged in.
+
+## Fixes
+
+- #3175 fix(channels): hide global Channel Database entries in per-source view — `ChannelsTab` gains a `sourceId` prop; when set (per-source view via `/source/:id/*`), the global `channel_database` entries are NOT merged into `getAvailableChannels`. The unified / cross-source view keeps merging them as before. The `messages` and `channels` arrays were already source-scoped by the poll endpoint on the server, so no client-side filter is needed for those.
+
+
 ## [4.7.0] - 2026-05-24
 
 # MeshMonitor v4.7.0

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.7.0",
+  "version": "4.7.1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.7.0
-appVersion: "4.7.0"
+version: 4.7.1
+appVersion: "4.7.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4749,6 +4749,7 @@ function App() {
             channelMessages={channelMessages}
             messages={messages}
             currentNodeId={currentNodeId}
+            sourceId={sourceId}
             connectionStatus={connectionStatus}
             selectedChannel={selectedChannel}
             setSelectedChannel={setSelectedChannel}

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -68,6 +68,22 @@ export interface ChannelsTabProps {
   channelMessages: Record<number, MeshMessage[]>;
   messages: MeshMessage[];
   currentNodeId: string;
+  /**
+   * Active source id when this tab is rendered inside a per-source view
+   * (`/source/:id/...`). `null` in the legacy/unified view that aggregates
+   * every source.
+   *
+   * When set, the global `channelDatabaseEntries` (server-side MQTT
+   * decryption PSKs that grow as MQTT ingest sees new channel names
+   * across every source) are NOT merged into the visible list. Those
+   * are a cross-source concept and live in Global Settings → Channel
+   * Database; they belong only in the unified / cross-source view.
+   *
+   * The poll endpoint already filters `messages` and `channels` by
+   * `sourceId` on the server, so no per-source filtering of those two
+   * arrays is needed in this component.
+   */
+  sourceId?: string | null;
 
   // Connection state
   connectionStatus: string;
@@ -150,6 +166,7 @@ export default function ChannelsTab({
   channelMessages,
   messages,
   currentNodeId,
+  sourceId = null,
   connectionStatus,
   selectedChannel,
   setSelectedChannel,
@@ -369,15 +386,27 @@ export default function ChannelsTab({
   const getAvailableChannels = (): number[] => {
     const channelSet = new Set<number>();
 
-    // Add channels from channel configurations first (these are authoritative)
+    // Add channels from channel configurations first (these are authoritative).
+    // The poll endpoint already scopes these by sourceId on the server side
+    // when `sourceId` is set, so this is the correctly-scoped baseline.
     channels.forEach(ch => channelSet.add(ch.id));
 
-    // Add virtual channels from Channel Database
-    channelDatabaseEntries.forEach(entry => {
-      channelSet.add(CHANNEL_DB_OFFSET + entry.id);
-    });
+    // Add virtual channels from Channel Database — ONLY in the unified /
+    // legacy cross-source view. In a per-source view these are noise: the
+    // Channel Database is global (auto-seeded from MQTT ingest for
+    // server-side decryption) and not bound to any specific source. The
+    // table lives in Global Settings → Channel Database; surfacing it on a
+    // per-source Channels tab made a Sandbox view look like it had dozens
+    // of foreign channels.
+    if (!sourceId) {
+      channelDatabaseEntries.forEach(entry => {
+        channelSet.add(CHANNEL_DB_OFFSET + entry.id);
+      });
+    }
 
-    // Add channels from messages
+    // Add channels from messages. The messages array is already
+    // source-scoped by the poll endpoint when sourceId is non-null, so
+    // no per-source filter is needed here.
     messages.forEach(msg => {
       channelSet.add(msg.channel);
     });


### PR DESCRIPTION
The Channels tab on a per-source view (e.g. clicking a meshtastic_tcp source like "Sandbox") was inflating its channel list with every row in the global `channel_database` table. The user-visible result was Sandbox showing ~25 channels (mostly TX/SHARC/JAXMesh/etc. names from unrelated MQTT bridges) when its actual channel count is 3.

## Root cause

`getAvailableChannels` in `ChannelsTab.tsx` unions three sources:

1. `channels` — properly scoped to the active source by the `/api/poll?sourceId=...` server route.
2. `channelDatabaseEntries` — **global** server-side MQTT decryption PSK storage. Auto-seeded as MQTT ingest sees new channel names across every source. Lives in Global Settings → Channel Database (moved there in 4.6.5).
3. `messages` — also source-scoped by the poll route.

The Channel Database union was unconditional. In a per-source view those entries are not meaningful — they belong only in the unified / cross-source view.

## Fix

- New `sourceId?: string \| null` prop on `ChannelsTab`. When set (per-source view), `channelDatabaseEntries` are **not** merged. The unified view (`sourceId` null) keeps merging them as before.
- `App.tsx` passes `useSource().sourceId` through to `ChannelsTab`. That hook returns the source id when the view is mounted under `/source/:sourceId/*` via `SourceProvider`, which is exactly the path that exhibited the bug.

No backend changes — the poll route was already scoping `channels` and `messages` correctly server-side.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 5537 passing
- [x] Channel-related tests (16) still passing
- [ ] Manual: open Sandbox → Channels tab should show 3 entries, not 25
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
