### PR TITLE
fix(nodes): reject out-of-range nodeNum + resolve publicKey destinations

### DIFF
--- a/src/db/repositories/nodes.invalidNodeNum.test.ts
+++ b/src/db/repositories/nodes.invalidNodeNum.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression tests for issue #3186: `NodesRepository` must guard against
+ * out-of-range nodeNum inputs instead of forwarding them to the database
+ * (which crashes with `invalid input syntax for type bigint` on PG and
+ * silently mis-stores on SQLite). Repository methods return `null` /
+ * filter out invalid values without ever issuing the broken query.
+ *
+ * Stand-alone SQLite scaffold — keeps the test focused on the guard
+ * behavior rather than the full multi-backend integration matrix already
+ * covered by `nodes.test.ts`.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import * as schema from '../schema/index.js';
+import { NodesRepository } from './nodes.js';
+
+// Mirrors the SQLite schema scaffold used by nodes.test.ts. Includes columns
+// the repository touches even when this test only exercises the guards.
+const SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS nodes (
+    nodeNum INTEGER NOT NULL,
+    nodeId TEXT NOT NULL,
+    longName TEXT,
+    shortName TEXT,
+    hwModel INTEGER,
+    role INTEGER,
+    hopsAway INTEGER,
+    lastMessageHops INTEGER,
+    viaMqtt INTEGER DEFAULT 0,
+    transportMechanism INTEGER,
+    macaddr TEXT,
+    latitude REAL,
+    longitude REAL,
+    altitude REAL,
+    batteryLevel INTEGER,
+    voltage REAL,
+    channelUtilization REAL,
+    airUtilTx REAL,
+    lastHeard INTEGER,
+    snr REAL,
+    rssi INTEGER,
+    lastTracerouteRequest INTEGER,
+    firmwareVersion TEXT,
+    channel INTEGER,
+    isFavorite INTEGER DEFAULT 0,
+    favoriteLocked INTEGER DEFAULT 0,
+    isIgnored INTEGER DEFAULT 0,
+    mobile INTEGER DEFAULT 0,
+    rebootCount INTEGER,
+    publicKey TEXT,
+    lastMeshReceivedKey TEXT,
+    hasPKC INTEGER,
+    lastPKIPacket INTEGER,
+    keyIsLowEntropy INTEGER,
+    duplicateKeyDetected INTEGER,
+    keyMismatchDetected INTEGER,
+    keySecurityIssueDetails TEXT,
+    isExcessivePackets INTEGER DEFAULT 0,
+    packetRatePerHour INTEGER,
+    packetRateLastChecked INTEGER,
+    isTimeOffsetIssue INTEGER DEFAULT 0,
+    timeOffsetSeconds INTEGER,
+    welcomedAt INTEGER,
+    positionChannel INTEGER,
+    positionPrecisionBits INTEGER,
+    positionGpsAccuracy REAL,
+    positionHdop REAL,
+    positionTimestamp INTEGER,
+    positionOverrideEnabled INTEGER DEFAULT 0,
+    latitudeOverride REAL,
+    longitudeOverride REAL,
+    altitudeOverride REAL,
+    positionOverrideIsPrivate INTEGER DEFAULT 0,
+    hasRemoteAdmin INTEGER DEFAULT 0,
+    lastRemoteAdminCheck INTEGER,
+    remoteAdminMetadata TEXT,
+    lastTimeSync INTEGER,
+    isStoreForwardServer INTEGER DEFAULT 0,
+    createdAt INTEGER NOT NULL DEFAULT 0,
+    updatedAt INTEGER NOT NULL DEFAULT 0,
+    sourceId TEXT NOT NULL DEFAULT 'default',
+    PRIMARY KEY (nodeNum, sourceId)
+  )
+`;
+
+describe('NodesRepository — out-of-range nodeNum guards (#3186)', () => {
+  let repo: NodesRepository;
+  let raw: Database.Database;
+
+  beforeEach(() => {
+    raw = new Database(':memory:');
+    raw.exec(SCHEMA_SQL);
+    const db = drizzle(raw, { schema });
+    repo = new NodesRepository(db as never, 'sqlite');
+  });
+
+  const insert = (nodeNum: number, sourceId = 'src-A', publicKey: string | null = null) => {
+    raw
+      .prepare(
+        `INSERT INTO nodes (nodeNum, nodeId, sourceId, publicKey)
+           VALUES (?, ?, ?, ?)`,
+      )
+      .run(nodeNum, `!${nodeNum.toString(16).padStart(8, '0')}`, sourceId, publicKey);
+  };
+
+  it('getNode returns null for an out-of-range float without querying', async () => {
+    insert(123, 'src-A');
+    const result = await repo.getNode(2.7130620829267897e+76, 'src-A');
+    expect(result).toBeNull();
+    // Sanity: known-good lookups still work after a bad call.
+    const good = await repo.getNode(123, 'src-A');
+    expect(good?.nodeNum).toBe(123);
+  });
+
+  it('getNode returns null for negative, fractional, and >uint32 values', async () => {
+    expect(await repo.getNode(-1, 'src-A')).toBeNull();
+    expect(await repo.getNode(1.5, 'src-A')).toBeNull();
+    expect(await repo.getNode(0x100000000, 'src-A')).toBeNull(); // uint32 max + 1
+  });
+
+  it('getNode allows the broadcast address (uint32 max)', async () => {
+    insert(0xFFFFFFFF, 'src-A');
+    const result = await repo.getNode(0xFFFFFFFF, 'src-A');
+    expect(result?.nodeNum).toBe(0xFFFFFFFF);
+  });
+
+  it('getNodesByNums filters out invalid entries and returns matches for the rest', async () => {
+    insert(100, 'src-A');
+    insert(200, 'src-A');
+    const map = await repo.getNodesByNums([100, 2.7e+76, -5, 200]);
+    expect(map.size).toBe(2);
+    expect(map.get(100)?.nodeNum).toBe(100);
+    expect(map.get(200)?.nodeNum).toBe(200);
+  });
+
+  it('getNodesByNums returns an empty map when every nodeNum is invalid', async () => {
+    const map = await repo.getNodesByNums([2.7e+76, -1, NaN as unknown as number]);
+    expect(map.size).toBe(0);
+  });
+
+  it('getNodeByPublicKey returns the matching node', async () => {
+    insert(555, 'src-A', 'base64-pubkey-xxx');
+    const node = await repo.getNodeByPublicKey('base64-pubkey-xxx', 'src-A');
+    expect(node?.nodeNum).toBe(555);
+  });
+
+  it('getNodeByPublicKey returns null for unknown publicKey', async () => {
+    expect(await repo.getNodeByPublicKey('no-such-key', 'src-A')).toBeNull();
+  });
+
+  it('getNodeByPublicKey returns null for empty input', async () => {
+    expect(await repo.getNodeByPublicKey('', 'src-A')).toBeNull();
+  });
+});

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -8,6 +8,7 @@ import { eq, gt, lt, isNull, or, desc, asc, and, isNotNull, ne, sql, inArray, co
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbNode } from '../types.js';
 import { logger } from '../../utils/logger.js';
+import { isValidNodeNum } from '../../server/constants/meshtastic.js';
 
 /**
  * Hook for keeping an external in-memory node cache coherent with PG/MySQL writes.
@@ -127,6 +128,13 @@ export class NodesRepository extends BaseRepository {
    * lookups retained for back-compat with non-threaded callers).
    */
   async getNode(nodeNum: number, sourceId?: string): Promise<DbNode | null> {
+    if (!isValidNodeNum(nodeNum)) {
+      // Defensive guard: PG `bigint` rejects out-of-range JS numbers with
+      // `invalid input syntax for type bigint` (issue #3186). Treat the
+      // value as "no such node" rather than crashing the query.
+      logger.warn(`NodesRepository.getNode: rejecting out-of-range nodeNum ${nodeNum}`);
+      return null;
+    }
     const { nodes } = this.tables;
     const whereClause = sourceId
       ? and(eq(nodes.nodeNum, nodeNum), eq(nodes.sourceId, sourceId))
@@ -146,11 +154,20 @@ export class NodesRepository extends BaseRepository {
    */
   async getNodesByNums(nodeNums: number[]): Promise<Map<number, DbNode>> {
     if (nodeNums.length === 0) return new Map();
+    // Filter out-of-range values up front (issue #3186) — one bad entry would
+    // otherwise fail the whole batch query against a PG `bigint` column.
+    const validNums = nodeNums.filter((n) => {
+      if (isValidNodeNum(n)) return true;
+      logger.warn(`NodesRepository.getNodesByNums: dropping out-of-range nodeNum ${n}`);
+      return false;
+    });
+    if (validNums.length === 0) return new Map();
+
     const { nodes } = this.tables;
     const result = await this.db
       .select()
       .from(nodes)
-      .where(inArray(nodes.nodeNum, nodeNums));
+      .where(inArray(nodes.nodeNum, validNums));
 
     const map = new Map<number, DbNode>();
     for (const row of result) {
@@ -172,6 +189,31 @@ export class NodesRepository extends BaseRepository {
     const whereClause = sourceId
       ? and(eq(nodes.nodeId, nodeId), eq(nodes.sourceId, sourceId))
       : eq(nodes.nodeId, nodeId);
+    const result = await this.db
+      .select()
+      .from(nodes)
+      .where(whereClause)
+      .limit(1);
+
+    if (result.length === 0) return null;
+    return this.normalizeBigInts(result[0]) as DbNode;
+  }
+
+  /**
+   * Get a node by its 32-byte public key (base64-encoded), optionally scoped
+   * to a source. Used by request-routing helpers to resolve a 64-hex-char
+   * public-key destination to the node's `nodeNum` so the protocol-level
+   * 32-bit address can be used for sending. See `parseDestinationNum`.
+   *
+   * The repository stores publicKey as base64. Callers passing a hex string
+   * should convert via `Buffer.from(hex, 'hex').toString('base64')` first.
+   */
+  async getNodeByPublicKey(publicKey: string, sourceId?: string): Promise<DbNode | null> {
+    if (!publicKey) return null;
+    const { nodes } = this.tables;
+    const whereClause = sourceId
+      ? and(eq(nodes.publicKey, publicKey), eq(nodes.sourceId, sourceId))
+      : eq(nodes.publicKey, publicKey);
     const result = await this.db
       .select()
       .from(nodes)

--- a/src/server/constants/meshtastic.test.ts
+++ b/src/server/constants/meshtastic.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isViaMqtt, TransportMechanism, getTransportMechanismName, RoutingError, isPkiError, getPortNumName, StoreForwardRequestResponse, getStoreForwardRequestResponseName } from './meshtastic.js';
+import { isViaMqtt, TransportMechanism, getTransportMechanismName, RoutingError, isPkiError, getPortNumName, StoreForwardRequestResponse, getStoreForwardRequestResponseName, isValidNodeNum, MAX_NODE_NUM } from './meshtastic.js';
 
 describe('isViaMqtt', () => {
   it('should return true for MQTT transport mechanism', () => {
@@ -177,5 +177,33 @@ describe('getStoreForwardRequestResponseName', () => {
   it('returns UNKNOWN for unknown values', () => {
     expect(getStoreForwardRequestResponseName(99)).toBe('UNKNOWN_99');
     expect(getStoreForwardRequestResponseName(255)).toBe('UNKNOWN_255');
+  });
+});
+
+describe('isValidNodeNum', () => {
+  it('accepts the full uint32 range', () => {
+    expect(isValidNodeNum(0)).toBe(true);
+    expect(isValidNodeNum(1)).toBe(true);
+    expect(isValidNodeNum(MAX_NODE_NUM)).toBe(true);
+    expect(MAX_NODE_NUM).toBe(0xFFFFFFFF);
+  });
+
+  it('rejects negative, fractional, and out-of-range numbers', () => {
+    expect(isValidNodeNum(-1)).toBe(false);
+    expect(isValidNodeNum(1.5)).toBe(false);
+    expect(isValidNodeNum(MAX_NODE_NUM + 1)).toBe(false);
+    // The exact magnitude reported in issue #3186 — a 64-hex-char publicKey
+    // parsed via `parseInt(_, 16)` lands here.
+    expect(isValidNodeNum(2.7130620829267897e+76)).toBe(false);
+  });
+
+  it('rejects non-finite numbers and non-number types', () => {
+    expect(isValidNodeNum(NaN)).toBe(false);
+    expect(isValidNodeNum(Infinity)).toBe(false);
+    expect(isValidNodeNum(-Infinity)).toBe(false);
+    expect(isValidNodeNum('123')).toBe(false);
+    expect(isValidNodeNum(null)).toBe(false);
+    expect(isValidNodeNum(undefined)).toBe(false);
+    expect(isValidNodeNum({})).toBe(false);
   });
 });

--- a/src/server/constants/meshtastic.ts
+++ b/src/server/constants/meshtastic.ts
@@ -280,6 +280,30 @@ export const MIN_TRACEROUTE_INTERVAL_MS = 30 * 1000;
 export const MAX_MESSAGE_BYTES = 200;
 
 /**
+ * Maximum valid Meshtastic node number.
+ *
+ * `nodeNum` is a 32-bit unsigned integer in the Meshtastic protocol — values
+ * outside `[0, 0xFFFFFFFF]` cannot represent a real node, and pushing them into
+ * a PostgreSQL `bigint` column triggers a query error (issue #3186). Use
+ * {@link isValidNodeNum} as a guard before any DB op or routing decision.
+ *
+ * `0xFFFFFFFF` itself is the broadcast address.
+ */
+export const MAX_NODE_NUM = 0xFFFFFFFF; // 4,294,967,295
+
+/**
+ * Returns true if `n` is a safe-integer in the 32-bit unsigned `nodeNum` range.
+ *
+ * Rejects NaN, Infinity, negatives, non-integers (the floating-point values
+ * `parseInt(longHexString, 16)` can produce when the input is longer than 8
+ * hex chars — e.g. a 64-char public key — overflow into ~1e+76, which still
+ * passes `Number.isFinite` but cannot fit in any DB column).
+ */
+export function isValidNodeNum(n: unknown): n is number {
+  return typeof n === 'number' && Number.isInteger(n) && n >= 0 && n <= MAX_NODE_NUM;
+}
+
+/**
  * Meshtastic default channel encryption key.
  * This is the well-known key used when PSK is set to shorthand value 1 (AQ== in base64).
  */

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -51,6 +51,7 @@ import { rewriteHtml } from './utils/htmlRewriter.js';
 import { migrateAutomationChannels } from './utils/automationChannelMigration.js';
 import { safeFetch, SsrfBlockedError } from './utils/ssrfGuard.js';
 import { resolveRequestSourceId } from './utils/sourceResolver.js';
+import { parseDestinationNum } from './utils/parseDestination.js';
 import { PortNum, modemPresetChannelName } from './constants/meshtastic.js';
 import settingsRoutes, { setSettingsCallbacks } from './routes/settingsRoutes.js';
 import { applyManagerSettings } from './applyManagerSettings.js';
@@ -3714,11 +3715,16 @@ apiRouter.post('/messages/send', optionalAuth(), async (req, res) => {
       return res.status(400).json({ error: 'Invalid emoji flag: must be 0 or 1' });
     }
 
-    // Convert destination nodeId to nodeNum if provided
+    // Convert destination nodeId to nodeNum if provided. Accepts an 8-hex
+    // nodeId (`!ad8c9eff`) or a 64-hex publicKey; rejects anything else with
+    // 400 so a long-string input can't overflow PG bigint (issue #3186).
     let destinationNum: number | undefined = undefined;
     if (destination) {
-      const nodeIdStr = destination.replace('!', '');
-      destinationNum = parseInt(nodeIdStr, 16);
+      const resolved = await parseDestinationNum(destination, reqSourceId, databaseService);
+      if (resolved === null) {
+        return res.status(400).json({ error: `Invalid destination: ${destination}` });
+      }
+      destinationNum = resolved;
     }
 
     // Map channel to mesh network
@@ -3795,7 +3801,10 @@ apiRouter.post('/traceroute', requirePermission('traceroute', 'write'), async (r
       return res.status(400).json({ error: 'Destination node number is required' });
     }
 
-    const destinationNum = typeof destination === 'string' ? parseInt(destination, 16) : destination;
+    const destinationNum = await parseDestinationNum(destination, traceSourceId, databaseService);
+    if (destinationNum === null) {
+      return res.status(400).json({ error: `Invalid destination: ${destination}` });
+    }
 
     // Look up the node to get its channel — scope to this source so the channel
     // reflects the mesh this traceroute will actually traverse.
@@ -3822,7 +3831,10 @@ apiRouter.post('/position/request', requirePermission('messages', 'write'), asyn
       return res.status(400).json({ error: 'Destination node number is required' });
     }
 
-    const destinationNum = typeof destination === 'string' ? parseInt(destination, 16) : destination;
+    const destinationNum = await parseDestinationNum(destination, posSourceId, databaseService);
+    if (destinationNum === null) {
+      return res.status(400).json({ error: `Invalid destination: ${destination}` });
+    }
 
     // Look up the node to get its channel (scoped to this source)
     const node = await databaseService.nodes.getNode(destinationNum, posSourceId);
@@ -3895,7 +3907,10 @@ apiRouter.post('/nodeinfo/request', requirePermission('messages', 'write'), asyn
       return res.status(400).json({ error: 'Destination node number is required' });
     }
 
-    const destinationNum = typeof destination === 'string' ? parseInt(destination, 16) : destination;
+    const destinationNum = await parseDestinationNum(destination, niSourceId, databaseService);
+    if (destinationNum === null) {
+      return res.status(400).json({ error: `Invalid destination: ${destination}` });
+    }
 
     // Look up the node to get its channel (scoped to this source)
     const node = await databaseService.nodes.getNode(destinationNum, niSourceId);
@@ -3966,10 +3981,13 @@ apiRouter.post('/neighborinfo/request', requirePermission('traceroute', 'write')
       return res.status(400).json({ error: 'Destination node number is required' });
     }
 
-    const destinationNum = typeof destination === 'string' ? parseInt(destination, 16) : destination;
+    const { sourceId: neighborSourceId } = req.body;
+    const destinationNum = await parseDestinationNum(destination, neighborSourceId, databaseService);
+    if (destinationNum === null) {
+      return res.status(400).json({ error: `Invalid destination: ${destination}` });
+    }
 
     // Eligibility check: only allow requests to local node or 0-hop nodes
-    const { sourceId: neighborSourceId } = req.body;
     const neighborManager = (resolveSourceManager(neighborSourceId));
     const localNodeNum = neighborManager.getLocalNodeInfo()?.nodeNum;
     // Scope to the target source so hopsAway/channel reflect this mesh
@@ -4032,7 +4050,10 @@ apiRouter.post('/telemetry/request', requirePermission('messages', 'write'), asy
       return res.status(400).json({ error: `Invalid telemetry type. Must be one of: ${validTypes.join(', ')}` });
     }
 
-    const destinationNum = typeof destination === 'string' ? parseInt(destination, 16) : destination;
+    const destinationNum = await parseDestinationNum(destination, telSourceId, databaseService);
+    if (destinationNum === null) {
+      return res.status(400).json({ error: `Invalid destination: ${destination}` });
+    }
 
     // Look up the node to get its channel (scoped to this source)
     const node = await databaseService.nodes.getNode(destinationNum, telSourceId);

--- a/src/server/utils/parseDestination.test.ts
+++ b/src/server/utils/parseDestination.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for `parseDestinationNum` — the shared destination parser used by
+ * the DM / traceroute / position / nodeInfo / neighborInfo / telemetry
+ * routes. Issue #3186 background: a 64-char publicKey string fed through
+ * the previous `parseInt(_, 16)` parser produced ~2.7e+76 and crashed
+ * downstream PG queries; the helper now routes long hex strings into a
+ * publicKey lookup and rejects malformed input with `null`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parseDestinationNum } from './parseDestination.js';
+import { MAX_NODE_NUM } from '../constants/meshtastic.js';
+
+type DbFacade = Parameters<typeof parseDestinationNum>[2];
+
+function fakeDb(getNodeByPublicKey: ReturnType<typeof vi.fn>): DbFacade {
+  return { nodes: { getNodeByPublicKey } } as unknown as DbFacade;
+}
+
+describe('parseDestinationNum', () => {
+  let lookup: ReturnType<typeof vi.fn>;
+  let db: DbFacade;
+
+  beforeEach(() => {
+    lookup = vi.fn();
+    db = fakeDb(lookup);
+  });
+
+  // ---- numeric inputs ----
+  it('passes through a valid numeric nodeNum unchanged', async () => {
+    const result = await parseDestinationNum(123456, 'src-A', db);
+    expect(result).toBe(123456);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('accepts the broadcast address (uint32 max)', async () => {
+    expect(await parseDestinationNum(MAX_NODE_NUM, 'src-A', db)).toBe(MAX_NODE_NUM);
+  });
+
+  it('rejects out-of-range numeric input', async () => {
+    expect(await parseDestinationNum(MAX_NODE_NUM + 1, 'src-A', db)).toBeNull();
+    expect(await parseDestinationNum(-1, 'src-A', db)).toBeNull();
+    expect(await parseDestinationNum(1.5, 'src-A', db)).toBeNull();
+    expect(await parseDestinationNum(NaN, 'src-A', db)).toBeNull();
+  });
+
+  // ---- 8-char nodeId inputs ----
+  it('parses an 8-char hex nodeId', async () => {
+    expect(await parseDestinationNum('ad8c9eff', 'src-A', db)).toBe(0xad8c9eff);
+  });
+
+  it("strips a leading '!' from an 8-char nodeId", async () => {
+    expect(await parseDestinationNum('!ad8c9eff', 'src-A', db)).toBe(0xad8c9eff);
+  });
+
+  it('is case-insensitive for hex nodeIds', async () => {
+    expect(await parseDestinationNum('!AD8C9EFF', 'src-A', db)).toBe(0xad8c9eff);
+  });
+
+  it('trims surrounding whitespace', async () => {
+    expect(await parseDestinationNum('  !ad8c9eff  ', 'src-A', db)).toBe(0xad8c9eff);
+  });
+
+  // ---- 64-char publicKey inputs ----
+  it('resolves a 64-char publicKey to its stored nodeNum (issue #3186)', async () => {
+    const hex64 = 'a'.repeat(64);
+    const expectedBase64 = Buffer.from(hex64, 'hex').toString('base64');
+    lookup.mockResolvedValueOnce({ nodeNum: 42, publicKey: expectedBase64 });
+
+    const result = await parseDestinationNum(hex64, 'src-A', db);
+
+    expect(result).toBe(42);
+    expect(lookup).toHaveBeenCalledWith(expectedBase64, 'src-A');
+  });
+
+  it("strips a leading '!' on a publicKey input before lookup", async () => {
+    const hex64 = 'b'.repeat(64);
+    const expectedBase64 = Buffer.from(hex64, 'hex').toString('base64');
+    lookup.mockResolvedValueOnce({ nodeNum: 7, publicKey: expectedBase64 });
+
+    const result = await parseDestinationNum(`!${hex64}`, 'src-A', db);
+
+    expect(result).toBe(7);
+    expect(lookup).toHaveBeenCalledWith(expectedBase64, 'src-A');
+  });
+
+  it('returns null when the publicKey is not found', async () => {
+    lookup.mockResolvedValueOnce(null);
+    expect(await parseDestinationNum('c'.repeat(64), 'src-A', db)).toBeNull();
+  });
+
+  it('returns null when the publicKey lookup yields a stored node with an invalid nodeNum', async () => {
+    // Defense-in-depth: a corrupt row in the DB shouldn't leak garbage downstream.
+    lookup.mockResolvedValueOnce({ nodeNum: 2.7130620829267897e+76, publicKey: 'x' });
+    expect(await parseDestinationNum('d'.repeat(64), 'src-A', db)).toBeNull();
+  });
+
+  // ---- malformed inputs ----
+  it('returns null for a 9-char hex string (neither nodeId nor publicKey)', async () => {
+    expect(await parseDestinationNum('ad8c9effe', 'src-A', db)).toBeNull();
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a string with non-hex characters', async () => {
+    expect(await parseDestinationNum('zz8c9eff', 'src-A', db)).toBeNull();
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('returns null for empty string and non-string non-number types', async () => {
+    expect(await parseDestinationNum('', 'src-A', db)).toBeNull();
+    expect(await parseDestinationNum(null, 'src-A', db)).toBeNull();
+    expect(await parseDestinationNum(undefined, 'src-A', db)).toBeNull();
+    expect(await parseDestinationNum({}, 'src-A', db)).toBeNull();
+  });
+
+  // ---- sourceId scoping ----
+  it('forwards an undefined sourceId to the lookup', async () => {
+    lookup.mockResolvedValueOnce({ nodeNum: 99, publicKey: 'x' });
+    await parseDestinationNum('e'.repeat(64), undefined, db);
+    expect(lookup).toHaveBeenCalledWith(expect.any(String), undefined);
+  });
+});

--- a/src/server/utils/parseDestination.ts
+++ b/src/server/utils/parseDestination.ts
@@ -1,0 +1,88 @@
+/**
+ * Destination parsing for routes that accept a Meshtastic node identifier
+ * in their request body (DM, traceroute, position request, NodeInfo request,
+ * NeighborInfo request, telemetry request).
+ *
+ * Accepts:
+ *   - a JS number that's already a valid uint32 `nodeNum`
+ *   - an 8-char hex string with optional `!` prefix (the canonical
+ *     Meshtastic nodeId, e.g. `!ad8c9eff`)
+ *   - a 64-char hex string (a 32-byte public key) — looks up the node by
+ *     its `publicKey` column and returns the resolved `nodeNum`
+ *
+ * Returns `null` for anything else: route handlers should treat null as a
+ * client error and respond with HTTP 400.
+ *
+ * Background (issue #3186): the previous parsing did `parseInt(input, 16)`
+ * with no length check, so a 64-hex-char public key pasted as the
+ * destination would parse into ~2.7e+76, overflow PG's `bigint`, and crash
+ * the request with a `DrizzleQueryError`. This helper rejects malformed
+ * inputs up front and treats long hex strings as public keys instead.
+ */
+import { isValidNodeNum } from '../constants/meshtastic.js';
+import { logger } from '../../utils/logger.js';
+import type databaseService from '../../services/database.js';
+
+const NODE_ID_HEX_RE = /^[0-9a-f]{8}$/i;
+const PUBLIC_KEY_HEX_RE = /^[0-9a-f]{64}$/i;
+
+/**
+ * Resolve a route's `destination` field to a Meshtastic 32-bit nodeNum.
+ *
+ * @param destination Value as received from the request body. String or
+ *   number; anything else is rejected.
+ * @param sourceId Source to scope `publicKey` lookups by. When omitted, the
+ *   lookup falls back to a cross-source first-match (legacy behavior).
+ * @param db Injected database facade so this helper is testable without a
+ *   global singleton import.
+ * @returns The validated `nodeNum`, or `null` if the input is malformed,
+ *   out of range, or names an unknown publicKey.
+ */
+export async function parseDestinationNum(
+  destination: unknown,
+  sourceId: string | undefined,
+  db: typeof databaseService,
+): Promise<number | null> {
+  // Pre-parsed number from the client.
+  if (typeof destination === 'number') {
+    if (isValidNodeNum(destination)) return destination;
+    logger.warn(`parseDestinationNum: rejecting out-of-range numeric destination ${destination}`);
+    return null;
+  }
+
+  if (typeof destination !== 'string') return null;
+
+  // Strip a single leading `!` and any whitespace; lowercase for matching.
+  const raw = destination.trim().replace(/^!/, '').toLowerCase();
+
+  if (NODE_ID_HEX_RE.test(raw)) {
+    const num = parseInt(raw, 16);
+    return isValidNodeNum(num) ? num : null;
+  }
+
+  if (PUBLIC_KEY_HEX_RE.test(raw)) {
+    // Repository stores publicKey as base64 (32-byte key → 44 base64 chars).
+    const base64 = Buffer.from(raw, 'hex').toString('base64');
+    const node = await db.nodes.getNodeByPublicKey(base64, sourceId);
+    if (!node) {
+      logger.warn(
+        `parseDestinationNum: no node matches publicKey ${raw.slice(0, 16)}…${sourceId ? ` (source ${sourceId})` : ''}`,
+      );
+      return null;
+    }
+    if (!isValidNodeNum(node.nodeNum)) {
+      // A stored row whose nodeNum is itself bad — should be unreachable
+      // post-issue-#3186 but guard so we never propagate junk downstream.
+      logger.error(
+        `parseDestinationNum: stored node has invalid nodeNum ${node.nodeNum} for publicKey ${raw.slice(0, 16)}…`,
+      );
+      return null;
+    }
+    return node.nodeNum;
+  }
+
+  logger.warn(
+    `parseDestinationNum: rejecting destination "${destination}" — expected 8-hex nodeId or 64-hex publicKey`,
+  );
+  return null;
+}


### PR DESCRIPTION
## Summary

- **Properly handle long IDs as public keys.** New `parseDestinationNum(destination, sourceId, db)` helper accepts an 8-hex nodeId (`!ad8c9eff`) or a 64-hex publicKey and rejects anything else with `null` → route returns **HTTP 400**. The 64-hex case looks up the node by the stored `publicKey` column and resolves to its `nodeNum`. Wired into 6 routes that all duplicated the same brittle `parseInt(_, 16)` pattern: DM, traceroute, position, nodeInfo, neighborInfo, telemetry.
- **Defense-in-depth at the DB boundary.** New `MAX_NODE_NUM = 0xFFFFFFFF` + `isValidNodeNum()` in `src/server/constants/meshtastic.ts`. `NodesRepository.getNode` warn-logs and returns `null` for out-of-range inputs; `getNodesByNums` filters them out instead of failing the whole batch.
- **New repository method:** `NodesRepository.getNodeByPublicKey(publicKey, sourceId?)` so the parse helper can resolve publicKey destinations without a global singleton.

Fixes #3186.

## Root cause

The reported value `2.7130620829267897e+76` ≈ what `parseInt('<64 hex chars>', 16)` returns when the input is the size of a Meshtastic public key (32 bytes / 64 hex chars / 256 bits ≈ 1.16e+77). The previous parsing did `parseInt(destination, 16)` with no length sanity check and forwarded the resulting float straight to `getNode`, where PG rejected it with `invalid input syntax for type bigint`. Plausible trigger: a client pasted a public key as the destination field thinking it was a nodeId.

## Behavior changes for clients

- Sending a 64-hex publicKey as `destination` now **resolves to the node's nodeNum** (previously crashed the request).
- Sending malformed input (wrong length, non-hex chars, etc.) now returns **HTTP 400** with the offending value echoed (previously crashed with 500).
- Sending a valid 8-hex nodeId works exactly as before.
- Sending an already-numeric `destination` works as before, but values outside `[0, 0xFFFFFFFF]` now return 400 instead of crashing.

## Test plan

- [x] `npx vitest run src/server/constants/meshtastic.test.ts src/server/utils/parseDestination.test.ts src/db/repositories/nodes.invalidNodeNum.test.ts` — **56/56 pass** (uint32 boundary, ~2.7e+76 magnitude regression, 8-hex parse with `!`/case/whitespace handling, 64-hex publicKey resolution, missing-key 404 path, malformed-input rejection, broadcast address allowed, batch-query filtering).
- [x] `npx vitest run src/server/constants/ src/server/utils/ src/db/repositories/nodes.test.ts src/db/repositories/nodes.pruneOutsideBbox.test.ts src/db/repositories/nodes.invalidNodeNum.test.ts` — **313/313 pass** (no regression in NodesRepository integration suite).
- [x] `npx tsc --noEmit` — clean.
- [x] `eslint` on changed files — 0 new errors/warnings (pre-existing server.ts warnings at lines 9029+ are unrelated to this change).
- [ ] System tests run by CI on the PR.

## Out of scope (deliberate)

Write methods on `NodesRepository` (`updateNode`, `deleteNodeRecord`, `setNodeFavorite`, etc.) are not guarded — none are in any current crash path. Easy follow-up if the same magnitude turns up there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)