### PR TITLE
fix(messages): sort by server-side receipt time, not sender clock (#3187)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1635,6 +1635,7 @@ function App() {
         const processedMessages = result.messages.map(msg => ({
           ...msg,
           timestamp: new Date(msg.timestamp),
+          receivedAt: new Date(msg.receivedAt ?? msg.timestamp),
         }));
 
         // Prepend older messages to the existing list, deduplicating by id
@@ -1705,6 +1706,7 @@ function App() {
         const processedMessages = result.messages.map(msg => ({
           ...msg,
           timestamp: new Date(msg.timestamp),
+          receivedAt: new Date(msg.receivedAt ?? msg.timestamp),
         }));
 
         // Prepend older messages to the existing list
@@ -2458,6 +2460,7 @@ function App() {
         const processedMessages = messagesData.map((msg: any) => ({
           ...msg,
           timestamp: new Date(msg.timestamp),
+          receivedAt: new Date(msg.receivedAt ?? msg.timestamp),
         }));
 
         // Play notification sound if new messages arrived from OTHER users

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -15,6 +15,7 @@ import { TimeFormat, DateFormat, useSettings, useNotificationMuteSettings } from
 import { formatPrecisionAccuracy } from '../utils/distance';
 import apiService, { type ChannelDatabaseEntry } from '../services/api';
 import { formatMessageTime, getMessageDateSeparator, shouldShowDateSeparator } from '../utils/datetime';
+import { getMessageSortTime } from '../utils/messageSort';
 import { getUtf8ByteLength, formatByteCount, isEmoji } from '../utils/text';
 import { scrollInputIntoView } from '../utils/scrollInputIntoView';
 import { applyHomoglyphOptimization } from '../utils/homoglyph';
@@ -841,9 +842,11 @@ export default function ChannelsTab({
                         messagesForChannel = messagesForChannel.filter(msg => msg.portnum !== 70);
                       }
 
-                      // Sort messages by timestamp (oldest first)
+                      // Sort messages by server-side receipt time (#3187)
+                      // so messages from nodes with bad clocks don't jump.
+                      // Oldest first.
                       messagesForChannel = messagesForChannel.sort(
-                        (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+                        (a, b) => getMessageSortTime(a) - getMessageSortTime(b)
                       );
 
                       return messagesForChannel && messagesForChannel.length > 0 ? (

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -22,6 +22,7 @@ import {
   shouldShowDateSeparator,
 } from '../utils/datetime';
 import { formatTracerouteRoute } from '../utils/traceroute';
+import { getMessageSortTime } from '../utils/messageSort';
 import { getUtf8ByteLength, formatByteCount, isEmoji } from '../utils/text';
 import { applyHomoglyphOptimization } from '../utils/homoglyph';
 import { calculateDistance, formatDistance, getDistanceToNode } from '../utils/distance';
@@ -624,7 +625,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
 
       const lastMessage =
         dmMessages.length > 0
-          ? dmMessages.reduce((latest, msg) => (msg.timestamp.getTime() > latest.timestamp.getTime() ? msg : latest))
+          ? dmMessages.reduce((latest, msg) => (getMessageSortTime(msg) > getMessageSortTime(latest) ? msg : latest))
           : null;
 
       const lastMessageText = lastMessage
@@ -635,7 +636,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
         ...node,
         messageCount: dmMessages.length,
         unreadCount,
-        lastMessageTime: dmMessages.length > 0 ? Math.max(...dmMessages.map(m => m.timestamp.getTime())) : 0,
+        lastMessageTime: dmMessages.length > 0 ? Math.max(...dmMessages.map(getMessageSortTime)) : 0,
         lastMessageText,
       };
     });
@@ -723,7 +724,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
 
   // Get DM messages for selected node
   const selectedDMMessages = selectedDMNode
-    ? getDMMessages(selectedDMNode).sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
+    ? getDMMessages(selectedDMNode).sort((a, b) => getMessageSortTime(a) - getMessageSortTime(b))
     : [];
 
   const selectedNode = selectedDMNode ? nodes.find(n => n.user?.id === selectedDMNode) : null;

--- a/src/hooks/usePoll.ts
+++ b/src/hooks/usePoll.ts
@@ -130,6 +130,13 @@ export interface RawMessage {
   channel: number;
   portnum?: number;
   timestamp: string | number;
+  /**
+   * Server-side ingest time. JSON-serialized as an ISO string by `new Date(...)`
+   * on the server (see transformDbMessageToMeshMessage). Optional only for
+   * back-compat with older server builds; clients should fall back to
+   * `timestamp` when missing.
+   */
+  receivedAt?: string | number;
   acknowledged?: boolean;
   ackFailed?: boolean;
   isLocalMessage?: boolean;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2294,6 +2294,10 @@ function transformDbMessageToMeshMessage(msg: DbMessage): MeshMessage {
     channel: msg.channel,
     portnum: msg.portnum ?? undefined,
     timestamp: new Date(msg.rxTime ?? msg.timestamp),
+    // Server-side ingest time — robust against sender-clock drift, used by
+    // the client for sort order (issue #3187). Falls back to `timestamp` for
+    // pre-migration rows where `createdAt` was never written.
+    receivedAt: new Date(msg.createdAt ?? msg.rxTime ?? msg.timestamp),
     hopStart: msg.hopStart ?? undefined,
     hopLimit: msg.hopLimit ?? undefined,
     relayNode: msg.relayNode ?? undefined,

--- a/src/server/services/webSocketService.ts
+++ b/src/server/services/webSocketService.ts
@@ -33,6 +33,8 @@ function transformMessageForClient(msg: DbMessage): unknown {
     channel: msg.channel,
     portnum: msg.portnum,
     timestamp: new Date(msg.rxTime ?? msg.timestamp),  // Convert to Date (serializes as ISO string)
+    // Server-side ingest time used by the client for sort order (issue #3187).
+    receivedAt: new Date(msg.createdAt ?? msg.rxTime ?? msg.timestamp),
     hopStart: msg.hopStart,
     hopLimit: msg.hopLimit,
     relayNode: msg.relayNode,

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -15,6 +15,18 @@ export interface MeshMessage {
   channel: number;
   portnum?: number;
   timestamp: Date;
+  /**
+   * Server-side ingest time (`messages.createdAt`). Always reflects when
+   * MeshMonitor actually received the message, independent of the sender
+   * node's clock. Prefer this over `timestamp` for sorting / "last
+   * message" comparisons — `timestamp` may be wildly wrong when the
+   * sending node has bad/uninitialized RTC (issue #3187).
+   *
+   * Optional only to preserve compat with pre-migration rows that may not
+   * have a stored `createdAt`; treat missing values as falling back to
+   * `timestamp`.
+   */
+  receivedAt?: Date;
   acknowledged?: boolean;
   ackFailed?: boolean;
   isLocalMessage?: boolean;

--- a/src/utils/messageSort.test.ts
+++ b/src/utils/messageSort.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for `getMessageSortTime` — the helper that makes message lists
+ * sort by server-side receipt time instead of sender-reported timestamp.
+ * Issue #3187 regression: a node with bad/uninitialized RTC sends a
+ * message claiming `timestamp` = year 2065; previously the message
+ * floated to the top of the channel. Now it sorts by `receivedAt` (server
+ * ingest time) and lands in the correct chronological slot.
+ */
+import { describe, it, expect } from 'vitest';
+import { getMessageSortTime } from './messageSort';
+import { MeshMessage } from '../types/message';
+
+function makeMessage(opts: { timestamp: Date; receivedAt?: Date }): MeshMessage {
+  return {
+    id: 'm',
+    from: 'a',
+    to: 'b',
+    fromNodeId: '!a',
+    toNodeId: '!b',
+    text: 't',
+    channel: 0,
+    timestamp: opts.timestamp,
+    receivedAt: opts.receivedAt,
+  };
+}
+
+describe('getMessageSortTime', () => {
+  it('prefers receivedAt when present', () => {
+    const msg = makeMessage({
+      timestamp: new Date('2065-01-01T00:00:00Z'), // bogus future from bad clock
+      receivedAt: new Date('2026-05-25T12:00:00Z'), // real ingest time
+    });
+    expect(getMessageSortTime(msg)).toBe(new Date('2026-05-25T12:00:00Z').getTime());
+  });
+
+  it('falls back to timestamp when receivedAt is missing', () => {
+    const msg = makeMessage({
+      timestamp: new Date('2026-05-25T12:00:00Z'),
+    });
+    expect(getMessageSortTime(msg)).toBe(new Date('2026-05-25T12:00:00Z').getTime());
+  });
+
+  it('sorts a mix of bad-clock and good-clock messages chronologically by receipt', () => {
+    const goodEarly = makeMessage({
+      timestamp: new Date('2026-05-25T10:00:00Z'),
+      receivedAt: new Date('2026-05-25T10:00:00Z'),
+    });
+    const badClockMid = makeMessage({
+      // Node reports year 2065 but we received it between the good messages.
+      timestamp: new Date('2065-01-01T00:00:00Z'),
+      receivedAt: new Date('2026-05-25T10:30:00Z'),
+    });
+    const goodLate = makeMessage({
+      timestamp: new Date('2026-05-25T11:00:00Z'),
+      receivedAt: new Date('2026-05-25T11:00:00Z'),
+    });
+
+    const list = [goodLate, badClockMid, goodEarly];
+    const sorted = [...list].sort((a, b) => getMessageSortTime(a) - getMessageSortTime(b));
+
+    expect(sorted.map((m) => m.timestamp.toISOString())).toEqual([
+      '2026-05-25T10:00:00.000Z',
+      '2065-01-01T00:00:00.000Z', // bad-clock message in its real receipt slot
+      '2026-05-25T11:00:00.000Z',
+    ]);
+  });
+
+  it('keeps last-message-time computations stable under bad timestamps', () => {
+    // Reduce-based "latest message" — the previous implementation picked the
+    // bad-clock 2065 message even when the most recent real message was newer.
+    const realLatest = makeMessage({
+      timestamp: new Date('2026-05-25T11:30:00Z'),
+      receivedAt: new Date('2026-05-25T11:30:00Z'),
+    });
+    const badClockOld = makeMessage({
+      timestamp: new Date('2065-01-01T00:00:00Z'),
+      receivedAt: new Date('2026-05-25T09:00:00Z'),
+    });
+
+    const messages = [realLatest, badClockOld];
+    const latest = messages.reduce((winner, m) =>
+      getMessageSortTime(m) > getMessageSortTime(winner) ? m : winner,
+    );
+
+    expect(latest).toBe(realLatest);
+  });
+
+  it('handles a flood of bad timestamps without throwing', () => {
+    const messages: MeshMessage[] = Array.from({ length: 50 }, (_, i) =>
+      makeMessage({
+        timestamp: new Date(0), // 1970 — looks like an uninitialized RTC
+        receivedAt: new Date(2_000_000_000_000 + i * 1000),
+      }),
+    );
+
+    const sorted = [...messages].sort((a, b) => getMessageSortTime(a) - getMessageSortTime(b));
+    // Sorted in receipt order: receivedAt strictly increasing.
+    for (let i = 1; i < sorted.length; i++) {
+      expect(getMessageSortTime(sorted[i])).toBeGreaterThan(getMessageSortTime(sorted[i - 1]));
+    }
+  });
+});

--- a/src/utils/messageSort.ts
+++ b/src/utils/messageSort.ts
@@ -1,0 +1,24 @@
+/**
+ * Sort helpers for `MeshMessage` lists.
+ *
+ * Issue #3187: messages from nodes with bad/uninitialized RTC carry a wildly
+ * wrong `timestamp`, which used to sort them to the top or bottom of channel
+ * and DM lists even when MeshMonitor had received them at a normal time.
+ * The server now exposes its ingest time as `receivedAt`; UI sort sites
+ * should use this helper so the fallback to `timestamp` is consistent
+ * (pre-migration rows from older server builds may not carry `receivedAt`).
+ *
+ * Display sites (per-message timestamp labels, date separators) deliberately
+ * keep using `msg.timestamp` so users still see the radio's claimed time and
+ * can spot misconfigured nodes.
+ */
+import { MeshMessage } from '../types/message';
+
+/**
+ * Returns the millisecond timestamp to use for sorting/comparison of a
+ * message. Prefers server-side ingest time; falls back to the radio's
+ * reported timestamp when `receivedAt` is missing.
+ */
+export function getMessageSortTime(msg: MeshMessage): number {
+  return (msg.receivedAt ?? msg.timestamp).getTime();
+}


### PR DESCRIPTION
## Summary

Messages and the per-node "last message" sidebar now sort by **server-side ingest time** (`messages.createdAt`) instead of the radio's reported `timestamp`. Bad-clock nodes (RTC stuck in 1970 or 2065) no longer float/sink to the wrong slot.

Display unchanged — each bubble still shows `msg.timestamp` so misconfigured clocks remain visible.

Fixes #3187.

## How it works

1. **Server** (`server.ts:transformDbMessageToMeshMessage`, `webSocketService.ts:transformMessageForClient`): adds `receivedAt: Date` to the outgoing payload, populated from `msg.createdAt`. Falls back to `rxTime ?? timestamp` only for pre-migration rows.
2. **Types** (`MeshMessage`, `RawMessage`): pick up the new optional field.
3. **Client deserialization** (`App.tsx` x3 sites): converts the ISO string to a `Date` next to the existing `timestamp` conversion.
4. **Sort sites** now use a shared helper `getMessageSortTime(msg)` (`src/utils/messageSort.ts`) that returns `(receivedAt ?? timestamp).getTime()`:
   - `MessagesTab.tsx`: DM message sort, "latest message" reduce, per-node `lastMessageTime` aggregation
   - `ChannelsTab.tsx`: per-channel message sort
5. **Display sites** (date separators, per-message labels) deliberately keep using `msg.timestamp` so operators can still see and diagnose bad clocks.

## Trade-off: no toggle

I deliberately skipped a "sort mode" settings toggle. Receipt time is the right default for everyone, and a toggle would add settings UI + persistence + dual-sort code paths for what's effectively a one-line preference. Easy follow-up if someone asks for sender-time mode.

## Test plan

- [x] `npx vitest run src/utils/messageSort.test.ts` — **5/5 pass** (prefers receivedAt, falls back to timestamp, mixed bad/good clocks land chronologically, "latest message" reduce stays stable under bad clocks, flood of zero-timestamps sorts cleanly).
- [x] `npx vitest run src/utils/messageSort.test.ts src/contexts/MessagingContext.test.tsx src/contexts/DataContext.test.tsx src/services/api.test.ts` — **76/76 pass**.
- [x] `npx vitest run src/server/routes/messageRoutes.test.ts src/server/routes/unifiedRoutes.test.ts` — **101/101 pass**.
- [x] `npx tsc --noEmit` — clean.
- [x] `eslint` on changed files — 0 new errors/warnings (the 23 pre-existing errors in App.tsx and server.ts are at lines unrelated to this change).
- [ ] System tests run by CI on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)