### PR TITLE
feat(meshcore): collapsible node list on Direct Messages view (#3192)

### DIFF
--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -254,6 +254,33 @@ describe('MeshCoreDirectMessagesView — per-node telemetry-config panel', () =>
     expect(names).toEqual(['alpha', 'Bravo', 'Charlie']);
   });
 
+  it('collapses the node list when the toggle button is clicked, and restores it on re-click', () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={[]}
+        contacts={[realContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+
+    // Starts expanded — peer is visible and the toggle reads "Collapse node list".
+    expect(screen.getByText('Remote Bob')).toBeTruthy();
+    const toggle = screen.getByTitle('Collapse node list');
+    expect(toggle.textContent).toBe('◀');
+
+    // Click collapses — peer row is unmounted, toggle now reads "Expand…".
+    fireEvent.click(toggle);
+    expect(screen.queryByText('Remote Bob')).toBeNull();
+    const expandToggle = screen.getByTitle('Expand node list');
+    expect(expandToggle.textContent).toBe('▶');
+
+    // Click again restores the list.
+    fireEvent.click(expandToggle);
+    expect(screen.getByText('Remote Bob')).toBeTruthy();
+    expect(screen.getByTitle('Collapse node list')).toBeTruthy();
+  });
+
   it('refetches telemetry config when switching from one real-pubkey peer to another', async () => {
     render(
       <MeshCoreDirectMessagesView

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -33,6 +33,11 @@ function isRealNodeKey(key: string): boolean {
 type DmSortField = 'name' | 'lastMessage';
 type DmSortDirection = 'asc' | 'desc';
 
+// Mobile viewport defaults the node list to collapsed so the conversation
+// pane takes the full width (matches Meshtastic MessagesTab behavior).
+const isMobileViewport = (): boolean =>
+  typeof window !== 'undefined' && window.innerWidth <= 768;
+
 export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProps> = ({
   messages,
   contacts,
@@ -49,6 +54,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
   const [selected, setSelected] = useState<string | null>(null);
   const [sortField, setSortField] = useState<DmSortField>('lastMessage');
   const [sortDirection, setSortDirection] = useState<DmSortDirection>('desc');
+  const [isCollapsed, setIsCollapsed] = useState<boolean>(isMobileViewport);
 
   const selfKey = status?.localNode?.publicKey;
   const connected = status?.connected ?? false;
@@ -186,58 +192,78 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
 
   return (
     <div className="meshcore-two-pane">
-      <div className="meshcore-list-pane">
+      <div className={`meshcore-list-pane ${isCollapsed ? 'collapsed' : ''}`}>
         <div className="meshcore-list-pane-header">
-          <span>{t('meshcore.nav.dms', 'Direct Messages')}</span>
-          <span className="pane-count">{dmPeers.length}</span>
-          <div className="sort-controls meshcore-sort-controls">
-            <select
-              aria-label={t('meshcore.sort_by', 'Sort by')}
-              title={t('meshcore.sort_by', 'Sort by')}
-              value={sortField}
-              onChange={(e) => setSortField(e.target.value as DmSortField)}
-              className="sort-dropdown"
-            >
-              <option value="lastMessage">{t('meshcore.sort_last_message', 'Last message')}</option>
-              <option value="name">{t('meshcore.sort_name', 'Name')}</option>
-            </select>
-            <button
-              type="button"
-              className="sort-direction-btn"
-              onClick={() => setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'))}
-              title={sortDirection === 'asc'
-                ? t('meshcore.ascending', 'Ascending')
-                : t('meshcore.descending', 'Descending')}
-              aria-label={sortDirection === 'asc'
-                ? t('meshcore.ascending', 'Ascending')
-                : t('meshcore.descending', 'Descending')}
-            >
-              {sortDirection === 'asc' ? '↑' : '↓'}
-            </button>
+          <button
+            type="button"
+            className="meshcore-collapse-btn"
+            onClick={() => setIsCollapsed((c) => !c)}
+            title={isCollapsed
+              ? t('nodes.expand_node_list', 'Expand node list')
+              : t('nodes.collapse_node_list', 'Collapse node list')}
+            aria-label={isCollapsed
+              ? t('nodes.expand_node_list', 'Expand node list')
+              : t('nodes.collapse_node_list', 'Collapse node list')}
+            aria-expanded={!isCollapsed}
+          >
+            {isCollapsed ? '▶' : '◀'}
+          </button>
+          {!isCollapsed && (
+            <>
+              <span>{t('meshcore.nav.dms', 'Direct Messages')}</span>
+              <span className="pane-count">{dmPeers.length}</span>
+              <div className="sort-controls meshcore-sort-controls">
+                <select
+                  aria-label={t('meshcore.sort_by', 'Sort by')}
+                  title={t('meshcore.sort_by', 'Sort by')}
+                  value={sortField}
+                  onChange={(e) => setSortField(e.target.value as DmSortField)}
+                  className="sort-dropdown"
+                >
+                  <option value="lastMessage">{t('meshcore.sort_last_message', 'Last message')}</option>
+                  <option value="name">{t('meshcore.sort_name', 'Name')}</option>
+                </select>
+                <button
+                  type="button"
+                  className="sort-direction-btn"
+                  onClick={() => setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'))}
+                  title={sortDirection === 'asc'
+                    ? t('meshcore.ascending', 'Ascending')
+                    : t('meshcore.descending', 'Descending')}
+                  aria-label={sortDirection === 'asc'
+                    ? t('meshcore.ascending', 'Ascending')
+                    : t('meshcore.descending', 'Descending')}
+                >
+                  {sortDirection === 'asc' ? '↑' : '↓'}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+        {!isCollapsed && (
+          <div className="meshcore-list-pane-body">
+            {dmPeers.length === 0 ? (
+              <div className="meshcore-empty-state">
+                {t('meshcore.no_contacts', 'No contacts yet')}
+              </div>
+            ) : dmPeers.map(key => {
+              const c = contactsByKey.get(key);
+              const name = c?.advName || c?.name || `${key.substring(0, 8)}…`;
+              return (
+                <button
+                  key={key}
+                  className={`mc-node-row ${selected === key ? 'selected' : ''}`}
+                  onClick={() => setSelected(key)}
+                >
+                  <div className="mc-node-row-name">
+                    <span>{name}</span>
+                  </div>
+                  <div className="mc-node-row-key">{key.substring(0, 20)}…</div>
+                </button>
+              );
+            })}
           </div>
-        </div>
-        <div className="meshcore-list-pane-body">
-          {dmPeers.length === 0 ? (
-            <div className="meshcore-empty-state">
-              {t('meshcore.no_contacts', 'No contacts yet')}
-            </div>
-          ) : dmPeers.map(key => {
-            const c = contactsByKey.get(key);
-            const name = c?.advName || c?.name || `${key.substring(0, 8)}…`;
-            return (
-              <button
-                key={key}
-                className={`mc-node-row ${selected === key ? 'selected' : ''}`}
-                onClick={() => setSelected(key)}
-              >
-                <div className="mc-node-row-name">
-                  <span>{name}</span>
-                </div>
-                <div className="mc-node-row-key">{key.substring(0, 20)}…</div>
-              </button>
-            );
-          })}
-        </div>
+        )}
       </div>
       <div className="meshcore-main-pane">
         {selected ? (

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -264,6 +264,44 @@
   padding: 0.5rem 0;
 }
 
+/* Collapsed sidebar — only the toggle button is visible. */
+.meshcore-list-pane.collapsed {
+  width: auto;
+  border-right: none;
+  background: transparent;
+}
+
+.meshcore-list-pane.collapsed .meshcore-list-pane-header {
+  background: transparent;
+  border-bottom: none;
+  padding: 0.5rem;
+  justify-content: flex-start;
+}
+
+.meshcore-collapse-btn {
+  background: var(--ctp-surface1);
+  border: 2px solid var(--ctp-surface2);
+  color: var(--ctp-text);
+  padding: 0;
+  border-radius: var(--radius-sm);
+  font-size: 0.6rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  margin-right: 0.4rem;
+}
+
+.meshcore-collapse-btn:hover {
+  background: var(--ctp-blue);
+  border-color: var(--ctp-blue);
+  color: var(--ctp-accent-text);
+}
+
 .meshcore-main-pane {
   flex: 1;
   min-width: 0;

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -1255,6 +1255,18 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
                 <option value="unified">
                   {t('settings.default_landing_page_unified', 'Unified View (default)')}
                 </option>
+                <option value="unified-messages">
+                  {t('settings.default_landing_page_unified_messages', 'Unified Messages')}
+                </option>
+                <option value="unified-telemetry">
+                  {t('settings.default_landing_page_unified_telemetry', 'Unified Telemetry')}
+                </option>
+                <option value="map-analysis">
+                  {t('settings.default_landing_page_map_analysis', 'Map Analysis')}
+                </option>
+                <option value="reports">
+                  {t('settings.default_landing_page_reports', 'Reports')}
+                </option>
                 {availableSources.map((src) => (
                   <option key={src.id} value={src.id}>
                     {src.name}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -34,6 +34,7 @@ import { ToastProvider } from '../components/ToastContainer';
 import api from '../services/api';
 import { logger } from '../utils/logger';
 import { appBasename } from '../init';
+import { getReservedLandingPath, isReservedLandingValue } from '../utils/defaultLandingPage';
 import '../styles/dashboard.css';
 
 // Helper: parse the four bbox text fields into a BBoxValue, or null if any
@@ -184,16 +185,31 @@ function DashboardInner() {
   const { data: sources = [], isSuccess } = useDashboardSources();
   const sourceIds = sources.map((s) => s.id);
 
-  // Apply admin-configured default landing page (issue #2917). When the
-  // user lands on `/`, redirect to /source/:sourceId/ if the setting points
-  // at a real source. The "Sources" button always passes
-  // location.state.showList=true so users can return to the unified view
-  // even if a default has been configured.
+  // Apply admin-configured default landing page (issue #2917, expanded
+  // for issue #3183 to allow cross-source unified pages). When the user
+  // lands on `/`:
+  //   - `'unified'` (or unset / unknown): stay here.
+  //   - Other reserved values: redirect to the matching unified route
+  //     (e.g. `unified-messages` → `/unified/messages`).
+  //   - Source UUID: redirect to `/source/<id>/`.
+  // The "Sources" button always passes `location.state.showList=true` so
+  // users can return to the unified dashboard even with a default
+  // configured.
   const skipDefaultLanding = (location.state as { showList?: boolean } | null)?.showList === true;
   useEffect(() => {
     if (skipDefaultLanding) return;
     if (!isSuccess) return;
     if (!defaultLandingPage || defaultLandingPage === 'unified') return;
+
+    // Reserved values (built-in unified routes) take precedence over the
+    // source-id lookup so a legitimate keyword can't be shadowed by a
+    // hypothetical source whose UUID happens to collide.
+    if (isReservedLandingValue(defaultLandingPage)) {
+      const reservedPath = getReservedLandingPath(defaultLandingPage);
+      if (reservedPath) navigate(reservedPath, { replace: true });
+      return;
+    }
+
     const target = sources.find((s) => s.id === defaultLandingPage);
     if (!target) return;
     navigate(`/source/${target.id}/`, { replace: true });

--- a/src/utils/defaultLandingPage.test.ts
+++ b/src/utils/defaultLandingPage.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the default-landing-page redirect map. Issue #3183 adds the
+ * cross-source unified pages to the set of values an admin can pick;
+ * regression-guards here ensure the mapping stays accurate and that
+ * unknown / source-UUID values keep returning `null` (so the DashboardPage
+ * effect falls through to its sourceId lookup path).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  RESERVED_LANDING_VALUES,
+  isReservedLandingValue,
+  getReservedLandingPath,
+} from './defaultLandingPage';
+
+describe('isReservedLandingValue', () => {
+  it('accepts every value listed in RESERVED_LANDING_VALUES', () => {
+    for (const v of RESERVED_LANDING_VALUES) {
+      expect(isReservedLandingValue(v)).toBe(true);
+    }
+  });
+
+  it('rejects source-id UUIDs', () => {
+    expect(isReservedLandingValue('11111111-2222-3333-4444-555555555555')).toBe(false);
+  });
+
+  it('rejects unrelated strings and non-strings', () => {
+    expect(isReservedLandingValue('dashboard')).toBe(false);
+    expect(isReservedLandingValue('')).toBe(false);
+    expect(isReservedLandingValue(null)).toBe(false);
+    expect(isReservedLandingValue(undefined)).toBe(false);
+    expect(isReservedLandingValue(123)).toBe(false);
+  });
+});
+
+describe('getReservedLandingPath', () => {
+  it("returns null for 'unified' (no redirect — already at /)", () => {
+    expect(getReservedLandingPath('unified')).toBeNull();
+  });
+
+  it('maps unified-messages to /unified/messages', () => {
+    expect(getReservedLandingPath('unified-messages')).toBe('/unified/messages');
+  });
+
+  it('maps unified-telemetry to /unified/telemetry', () => {
+    expect(getReservedLandingPath('unified-telemetry')).toBe('/unified/telemetry');
+  });
+
+  it('maps map-analysis to /analysis', () => {
+    expect(getReservedLandingPath('map-analysis')).toBe('/analysis');
+  });
+
+  it('maps reports to /reports', () => {
+    expect(getReservedLandingPath('reports')).toBe('/reports');
+  });
+
+  it('returns null for source-id UUIDs (caller falls through to source-lookup path)', () => {
+    expect(getReservedLandingPath('11111111-2222-3333-4444-555555555555')).toBeNull();
+  });
+
+  it('returns null for empty / null / undefined / unknown strings', () => {
+    expect(getReservedLandingPath(null)).toBeNull();
+    expect(getReservedLandingPath(undefined)).toBeNull();
+    expect(getReservedLandingPath('')).toBeNull();
+    expect(getReservedLandingPath('not-a-real-value')).toBeNull();
+  });
+});

--- a/src/utils/defaultLandingPage.ts
+++ b/src/utils/defaultLandingPage.ts
@@ -1,0 +1,51 @@
+/**
+ * Helpers for the admin-configured "default landing page" setting.
+ *
+ * The setting accepts one of two shapes:
+ *   - A reserved string keyword from {@link RESERVED_LANDING_VALUES}
+ *     identifying a built-in cross-source view.
+ *   - A source UUID — the per-source dashboard at `/source/<id>/`.
+ *
+ * Reserved values map to fixed routes via {@link getReservedLandingPath}.
+ * `'unified'` is the legacy keyword that means "stay on the unified
+ * dashboard at `/`" (no redirect). Issue #3183 adds the cross-source
+ * unified pages so they can be picked as the default landing.
+ */
+
+export const RESERVED_LANDING_VALUES = [
+  'unified',
+  'unified-messages',
+  'unified-telemetry',
+  'map-analysis',
+  'reports',
+] as const;
+
+export type ReservedLandingValue = (typeof RESERVED_LANDING_VALUES)[number];
+
+/**
+ * Routes for each reserved landing value. `'unified'` returns `null`
+ * because no redirect is needed — the unified dashboard already lives at
+ * `/`. Source-id UUIDs (everything else) are handled separately by the
+ * dashboard redirect effect.
+ */
+const RESERVED_LANDING_PATHS: Record<ReservedLandingValue, string | null> = {
+  'unified': null,
+  'unified-messages': '/unified/messages',
+  'unified-telemetry': '/unified/telemetry',
+  'map-analysis': '/analysis',
+  'reports': '/reports',
+};
+
+export function isReservedLandingValue(value: unknown): value is ReservedLandingValue {
+  return typeof value === 'string' && (RESERVED_LANDING_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Returns the redirect target for a reserved landing value, or `null` if
+ * the value is `'unified'` (no redirect) or not a reserved value (caller
+ * should treat it as a sourceId UUID and redirect to `/source/<id>/`).
+ */
+export function getReservedLandingPath(value: string | null | undefined): string | null {
+  if (!isReservedLandingValue(value)) return null;
+  return RESERVED_LANDING_PATHS[value];
+}


### PR DESCRIPTION
## Summary

Closes #3192. Adds parity with the Meshtastic Messages tab — the MeshCore Direct Messages node sidebar can now be collapsed/expanded via a left/right arrow toggle in the sidebar header.

- New ◀/▶ toggle button on `MeshCoreDirectMessagesView`, mirroring the Meshtastic `MessagesTab` pattern
- Sidebar content (title, count, sort controls, peer list) is unmounted when collapsed; only the toggle remains visible
- Defaults to collapsed on mobile viewports (≤768px) so the conversation pane gets the full width on phones — same heuristic `MessagesTab` uses
- Reuses the existing `nodes.expand_node_list` / `nodes.collapse_node_list` i18n keys

## Test plan

- [x] New Vitest test covers collapse → unmount of peer rows → expand → restore
- [x] Existing `MeshCoreDirectMessagesView.test.tsx` suite passes (9/9)
- [x] `tsc --noEmit` clean for the changed files
- [x] ESLint clean for the changed files (pre-existing repo-wide lint failures are unrelated)
- [ ] Manual: dev container — collapse/expand the sidebar, confirm the conversation pane reflows and the telemetry-config / TelemetryGraphs panels still render on the right
- [ ] Manual: resize to ≤768px and reload — sidebar starts collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)