### PR TITLE
feat(settings): allow unified pages as default landing destinations

### DIFF
--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -1255,6 +1255,18 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
                 <option value="unified">
                   {t('settings.default_landing_page_unified', 'Unified View (default)')}
                 </option>
+                <option value="unified-messages">
+                  {t('settings.default_landing_page_unified_messages', 'Unified Messages')}
+                </option>
+                <option value="unified-telemetry">
+                  {t('settings.default_landing_page_unified_telemetry', 'Unified Telemetry')}
+                </option>
+                <option value="map-analysis">
+                  {t('settings.default_landing_page_map_analysis', 'Map Analysis')}
+                </option>
+                <option value="reports">
+                  {t('settings.default_landing_page_reports', 'Reports')}
+                </option>
                 {availableSources.map((src) => (
                   <option key={src.id} value={src.id}>
                     {src.name}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -34,6 +34,7 @@ import { ToastProvider } from '../components/ToastContainer';
 import api from '../services/api';
 import { logger } from '../utils/logger';
 import { appBasename } from '../init';
+import { getReservedLandingPath, isReservedLandingValue } from '../utils/defaultLandingPage';
 import '../styles/dashboard.css';
 
 // Helper: parse the four bbox text fields into a BBoxValue, or null if any
@@ -184,16 +185,31 @@ function DashboardInner() {
   const { data: sources = [], isSuccess } = useDashboardSources();
   const sourceIds = sources.map((s) => s.id);
 
-  // Apply admin-configured default landing page (issue #2917). When the
-  // user lands on `/`, redirect to /source/:sourceId/ if the setting points
-  // at a real source. The "Sources" button always passes
-  // location.state.showList=true so users can return to the unified view
-  // even if a default has been configured.
+  // Apply admin-configured default landing page (issue #2917, expanded
+  // for issue #3183 to allow cross-source unified pages). When the user
+  // lands on `/`:
+  //   - `'unified'` (or unset / unknown): stay here.
+  //   - Other reserved values: redirect to the matching unified route
+  //     (e.g. `unified-messages` → `/unified/messages`).
+  //   - Source UUID: redirect to `/source/<id>/`.
+  // The "Sources" button always passes `location.state.showList=true` so
+  // users can return to the unified dashboard even with a default
+  // configured.
   const skipDefaultLanding = (location.state as { showList?: boolean } | null)?.showList === true;
   useEffect(() => {
     if (skipDefaultLanding) return;
     if (!isSuccess) return;
     if (!defaultLandingPage || defaultLandingPage === 'unified') return;
+
+    // Reserved values (built-in unified routes) take precedence over the
+    // source-id lookup so a legitimate keyword can't be shadowed by a
+    // hypothetical source whose UUID happens to collide.
+    if (isReservedLandingValue(defaultLandingPage)) {
+      const reservedPath = getReservedLandingPath(defaultLandingPage);
+      if (reservedPath) navigate(reservedPath, { replace: true });
+      return;
+    }
+
     const target = sources.find((s) => s.id === defaultLandingPage);
     if (!target) return;
     navigate(`/source/${target.id}/`, { replace: true });

--- a/src/utils/defaultLandingPage.test.ts
+++ b/src/utils/defaultLandingPage.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the default-landing-page redirect map. Issue #3183 adds the
+ * cross-source unified pages to the set of values an admin can pick;
+ * regression-guards here ensure the mapping stays accurate and that
+ * unknown / source-UUID values keep returning `null` (so the DashboardPage
+ * effect falls through to its sourceId lookup path).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  RESERVED_LANDING_VALUES,
+  isReservedLandingValue,
+  getReservedLandingPath,
+} from './defaultLandingPage';
+
+describe('isReservedLandingValue', () => {
+  it('accepts every value listed in RESERVED_LANDING_VALUES', () => {
+    for (const v of RESERVED_LANDING_VALUES) {
+      expect(isReservedLandingValue(v)).toBe(true);
+    }
+  });
+
+  it('rejects source-id UUIDs', () => {
+    expect(isReservedLandingValue('11111111-2222-3333-4444-555555555555')).toBe(false);
+  });
+
+  it('rejects unrelated strings and non-strings', () => {
+    expect(isReservedLandingValue('dashboard')).toBe(false);
+    expect(isReservedLandingValue('')).toBe(false);
+    expect(isReservedLandingValue(null)).toBe(false);
+    expect(isReservedLandingValue(undefined)).toBe(false);
+    expect(isReservedLandingValue(123)).toBe(false);
+  });
+});
+
+describe('getReservedLandingPath', () => {
+  it("returns null for 'unified' (no redirect — already at /)", () => {
+    expect(getReservedLandingPath('unified')).toBeNull();
+  });
+
+  it('maps unified-messages to /unified/messages', () => {
+    expect(getReservedLandingPath('unified-messages')).toBe('/unified/messages');
+  });
+
+  it('maps unified-telemetry to /unified/telemetry', () => {
+    expect(getReservedLandingPath('unified-telemetry')).toBe('/unified/telemetry');
+  });
+
+  it('maps map-analysis to /analysis', () => {
+    expect(getReservedLandingPath('map-analysis')).toBe('/analysis');
+  });
+
+  it('maps reports to /reports', () => {
+    expect(getReservedLandingPath('reports')).toBe('/reports');
+  });
+
+  it('returns null for source-id UUIDs (caller falls through to source-lookup path)', () => {
+    expect(getReservedLandingPath('11111111-2222-3333-4444-555555555555')).toBeNull();
+  });
+
+  it('returns null for empty / null / undefined / unknown strings', () => {
+    expect(getReservedLandingPath(null)).toBeNull();
+    expect(getReservedLandingPath(undefined)).toBeNull();
+    expect(getReservedLandingPath('')).toBeNull();
+    expect(getReservedLandingPath('not-a-real-value')).toBeNull();
+  });
+});

--- a/src/utils/defaultLandingPage.ts
+++ b/src/utils/defaultLandingPage.ts
@@ -1,0 +1,51 @@
+/**
+ * Helpers for the admin-configured "default landing page" setting.
+ *
+ * The setting accepts one of two shapes:
+ *   - A reserved string keyword from {@link RESERVED_LANDING_VALUES}
+ *     identifying a built-in cross-source view.
+ *   - A source UUID — the per-source dashboard at `/source/<id>/`.
+ *
+ * Reserved values map to fixed routes via {@link getReservedLandingPath}.
+ * `'unified'` is the legacy keyword that means "stay on the unified
+ * dashboard at `/`" (no redirect). Issue #3183 adds the cross-source
+ * unified pages so they can be picked as the default landing.
+ */
+
+export const RESERVED_LANDING_VALUES = [
+  'unified',
+  'unified-messages',
+  'unified-telemetry',
+  'map-analysis',
+  'reports',
+] as const;
+
+export type ReservedLandingValue = (typeof RESERVED_LANDING_VALUES)[number];
+
+/**
+ * Routes for each reserved landing value. `'unified'` returns `null`
+ * because no redirect is needed — the unified dashboard already lives at
+ * `/`. Source-id UUIDs (everything else) are handled separately by the
+ * dashboard redirect effect.
+ */
+const RESERVED_LANDING_PATHS: Record<ReservedLandingValue, string | null> = {
+  'unified': null,
+  'unified-messages': '/unified/messages',
+  'unified-telemetry': '/unified/telemetry',
+  'map-analysis': '/analysis',
+  'reports': '/reports',
+};
+
+export function isReservedLandingValue(value: unknown): value is ReservedLandingValue {
+  return typeof value === 'string' && (RESERVED_LANDING_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Returns the redirect target for a reserved landing value, or `null` if
+ * the value is `'unified'` (no redirect) or not a reserved value (caller
+ * should treat it as a sourceId UUID and redirect to `/source/<id>/`).
+ */
+export function getReservedLandingPath(value: string | null | undefined): string | null {
+  if (!isReservedLandingValue(value)) return null;
+  return RESERVED_LANDING_PATHS[value];
+}


### PR DESCRIPTION
## Summary

Adds the cross-source unified pages as selectable destinations for the admin-configured **Default Landing Page** setting in Global Settings → Appearance. The setting previously accepted only `'unified'` (stay on `/`) or a source UUID (redirect to `/source/<id>/`). Issue #3183 specifically asked for **Unified Messages** to be selectable; this PR adds it plus the obvious siblings — Unified Telemetry, Map Analysis, Reports.

Fixes #3183.

## Note on duplicate commit

This PR contains a fresh cherry-pick (`c3905401`) of the same default-landing work that appears as commit `37c8dede` on PR #3193 — that commit was accidentally bundled onto the `feat/meshcore-collapsible-dm-nodelist-3192` branch during a branch-switch race. The two SHAs are distinct objects, so they won't conflict in GitHub's merge graph; when one PR squash-merges, the other's commit becomes redundant. Suggested: drop `37c8dede` from PR #3193 (force-push, or rebase to remove it) so each PR matches its title.

## What changed

- **New** `src/utils/defaultLandingPage.ts`: `RESERVED_LANDING_VALUES` list + `getReservedLandingPath(value)` that maps each reserved keyword to its redirect target.
  - `'unified'` → `null` (no redirect — already at `/`)
  - `'unified-messages'` → `/unified/messages`
  - `'unified-telemetry'` → `/unified/telemetry`
  - `'map-analysis'` → `/analysis`
  - `'reports'` → `/reports`
- **DashboardPage redirect effect** now checks reserved values before the sourceId lookup. Reserved keywords take precedence so a future source whose UUID happens to match one of them can't shadow it.
- **SettingsTab dropdown** gets four new options between the existing "Unified View (default)" entry and the per-source list.

Back-compat: `'unified'` and source-UUID values still behave exactly as before.

## Test plan

- [x] `npx vitest run src/utils/defaultLandingPage.test.ts` — **10/10 pass** (every reserved value maps correctly, source-UUID and unknown / nullish inputs return `null`, no false-positives on `isReservedLandingValue`).
- [x] `npx vitest run src/utils/ src/pages/DashboardPage.test.tsx` — **572/572 pass** (no regression in adjacent utilities or the existing DashboardPage suite).
- [x] `npx tsc --noEmit` — clean.
- [x] `eslint` on changed files — 0 new errors/warnings.
- [ ] System tests run by CI on the PR.
- [ ] Manual smoke test: set Default Landing Page to "Unified Messages" in Global Settings, reload `/`, confirm the redirect lands at `/unified/messages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)