### PR TITLE
fix(server): skip auto-upgrade check while migrations are still running

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -747,6 +747,17 @@ async function checkForAutoUpgrade(): Promise<void> {
     return;
   }
 
+  // Skip if the DatabaseService hasn't finished initializing repositories yet.
+  // The initial-check setTimeout fires 60s after process start; on installs
+  // with long-running migrations (e.g. PG migration 030 rebuilding hundreds
+  // of thousands of route_segments rows) that timer can fire mid-migration
+  // and crash on the `settings` getter with `Database not initialized`.
+  // The next 4-hour interval tick will retry once the DB is up.
+  if (!databaseService.isDatabaseReady()) {
+    logger.debug('Skipping auto-upgrade check: database not ready yet (migrations in progress)');
+    return;
+  }
+
   // Skip if autoUpgradeImmediate is not enabled
   const autoUpgradeImmediate = await databaseService.settings.getSetting('autoUpgradeImmediate') === 'true';
   if (!autoUpgradeImmediate) {


### PR DESCRIPTION
## Summary

On production PostgreSQL installs with large traceroute / route_segments tables, the initial auto-upgrade-check timer (`setTimeout`, 60s after process start) can fire **before migrations have finished**. The first call into `databaseService.settings` then throws `Database not initialized`, surfacing as a startup error.

Reproduced from a user's log on a PG install:
```
[INFO] Running migration 030 (PostgreSQL): Adding sourceId to route_segments...
[INFO] Cleared 250314 legacy route_segments rows
[ERROR] Error in initial auto-upgrade check: Error: Database not initialized
    at get settings (file:///app/dist/services/database.js:244:19)
    at checkForAutoUpgrade (...server.js:656:56)
    at Timeout._onTimeout (...server.js:720:5)
[INFO] Rebuilt 250171 route_segments from 111643 traceroutes
[INFO] Migration 030 complete (PostgreSQL)
```

Migration 030 alone clears 250k rows and rebuilds 250k more from 111k traceroutes — easily over a minute of work on PG. The 60-second `setTimeout(checkForAutoUpgrade, ...)` fires mid-migration.

## Fix

Add `databaseService.isDatabaseReady()` as a fourth early-return guard in `checkForAutoUpgrade`, alongside the existing `versionCheckDisabled` / `upgradeService.isEnabled()` / `autoUpgradeImmediate` guards. Logs at debug level so a normal-boot log stays clean. The 4-hour `setInterval` will retry once the DB is up, so there's no harm in skipping the first call.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [ ] System tests run by CI on the PR.

No unit test: `checkForAutoUpgrade` is module-private, and there's no existing fixture for server.ts top-level functions. The 11-line addition is structurally identical to the three early-return guards directly above it and verifiable by code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)