### PR TITLE
fix(users): split Connection permission into separate Read/Write checkboxes

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2116,6 +2116,8 @@
   "users.channel_primary": "Channel 0 (Primary)",
   "users.channel_n": "Channel {{n}}",
   "users.can_control_connection": "Can Control Connection",
+  "users.connection_view_status": "View status",
+  "users.connection_control_device": "Control device",
   "users.can_initiate_traceroutes": "Can Initiate Traceroutes",
   "users.read": "Read",
   "users.write": "Write",

--- a/src/components/UsersTab.tsx
+++ b/src/components/UsersTab.tsx
@@ -959,14 +959,15 @@ const UsersTab: React.FC = () => {
                           />
                           {t('users.read')}
                         </label>
-                      ) : (resource === 'connection' || resource === 'traceroute') ? (
-                        // Connection and traceroute permissions use a single checkbox
+                      ) : resource === 'traceroute' ? (
+                        // Traceroute is a single action — read is implicit for any
+                        // viewer of the source, only the "initiate" capability
+                        // needs gating.
                         <label>
                           <input
                             type="checkbox"
                             checked={permissions[resource]?.write || false}
                             onChange={() => {
-                              // For these permissions, both read and write are set together
                               const newValue = !permissions[resource]?.write;
                               setPermissions({
                                 ...permissions,
@@ -974,8 +975,34 @@ const UsersTab: React.FC = () => {
                               });
                             }}
                           />
-                          {resource === 'connection' ? t('users.can_control_connection') : t('users.can_initiate_traceroutes')}
+                          {t('users.can_initiate_traceroutes')}
                         </label>
+                      ) : resource === 'connection' ? (
+                        // Connection is split: `read` gates viewing source status
+                        // (e.g. MeshCore source pages), `write` gates disconnect/
+                        // reconnect. Previously bundled into a single "Can Control
+                        // Connection" checkbox, which forced admins to grant write
+                        // just to expose read-only views to a user (issue: anonymous
+                        // MeshCore viewer needed `connection:read` without the
+                        // ability to disconnect the radio).
+                        <>
+                          <label>
+                            <input
+                              type="checkbox"
+                              checked={permissions[resource]?.read || false}
+                              onChange={() => togglePermission(resource, 'read')}
+                            />
+                            {t('users.connection_view_status', 'View status')}
+                          </label>
+                          <label>
+                            <input
+                              type="checkbox"
+                              checked={permissions[resource]?.write || false}
+                              onChange={() => togglePermission(resource, 'write')}
+                            />
+                            {t('users.connection_control_device', 'Control device')}
+                          </label>
+                        </>
                       ) : resource.startsWith('channel_') ? (
                         // Channel permissions use three checkboxes: viewOnMap, read, write
                         <>


### PR DESCRIPTION
## Summary

The **Connection** row in the Users permission grid previously rendered as a single "Can Control Connection" checkbox that set both `read` and `write` to the same value. The server side has long supported the split — `requirePermission('connection', 'read')` gates status / info / snapshot (including the MeshCore source page), `requirePermission('connection', 'write')` gates connect / disconnect — but the UI bundling forced admins to grant `write` (the ability to disconnect the radio) any time they wanted to expose a read-only view to a user.

Most visible failure case: granting the `anonymous` account access to the MeshCore source page required `connection:read`, but the only way to set that via the UI also granted `connection:write` — meaning an unauthenticated visitor could click "Disconnect."

## Fix

`UsersTab.tsx` now renders Connection as two independent checkboxes:

| Label | Permission |
|---|---|
| **View status** | `connection:read` — view source status / info / snapshot (MeshCore page, etc.) |
| **Control device** | `connection:write` — disconnect / reconnect the underlying device |

Traceroute keeps its single-checkbox UX (its read and write actions are functionally identical — "can initiate").

## Data compatibility

No migration needed. Existing rows with the previously-bundled `(read=1, write=1)` state remain that way. Admins can untick "Control device" from the new UI to downgrade an existing user to read-only.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run src/components/UsersTab.test.tsx` — **5/5 pass** (existing suite).
- [x] `eslint` on changed files — 0 new errors/warnings (1 pre-existing on a useEffect dependency array, unrelated).
- [ ] System tests run by CI on the PR.
- [ ] Manual smoke test: edit the `anonymous` user → per-source grid → MeshCore source → tick only "View status" on Connection → save → confirm anonymous can browse the MeshCore source page but the disconnect button errors with 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)