### PR TITLE
feat(mqtt-bridge): per-gateway publisher pool (default on) (#3197)

### DIFF
--- a/src/server/mqttBridgeManager.test.ts
+++ b/src/server/mqttBridgeManager.test.ts
@@ -631,4 +631,125 @@ describe('MqttBridgeManager', () => {
     await new Promise<void>((r) => localClient.end(true, {}, () => r()));
     await new Promise<void>((r) => pub.end(true, {}, () => r()));
   });
+
+  it('in default per_gateway mode, dispatches uplink publishes through a per-gateway upstream connection', async () => {
+    // Record every CONNECT and every publish the upstream broker sees so
+    // we can prove the bridge opened a connection whose clientId matches
+    // the envelope's gateway_id, not the legacy `mm-bridge-…` prefix.
+    const connects: string[] = [];
+    const publishesByClient: Array<{ clientId: string | null; topic: string }> = [];
+    upstream.aedes.on('client', (c) => connects.push(c.id));
+    upstream.aedes.on('publish', (packet, client) => {
+      if (!client) return;
+      publishesByClient.push({ clientId: client.id, topic: packet.topic });
+    });
+
+    bridge = new MqttBridgeManager('per-gw-bridge', 'PerGW', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      // No explicit forwardingMode — should default to per_gateway.
+      subscriptions: [],
+      mode: 'publish_only',
+    });
+    await sourceManagerRegistry.addManager(bridge);
+
+    // A local Meshtastic client publishes through the embedded broker;
+    // gateway_id is intentionally DIFFERENT from the broker's own
+    // !deadbeef so the pool has to create a new entry.
+    const localClient = connect(`mqtt://127.0.0.1:${localPort}`, {
+      username: 'u',
+      password: 'p',
+      reconnectPeriod: 0,
+      clientId: '!11111111', // a local gateway node connecting to our embedded broker
+    });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('local connect timeout')), 3000);
+      localClient.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+
+    const envelope = buildPositionEnvelope({
+      from: 0x11111111,
+      latI: 440_000_000,
+      lngI: -780_000_000,
+      channelId: 'LongFast',
+      gatewayId: '!11111111',
+      packetId: 0x30000001,
+    });
+    localClient.publish('msh/CA/ON/PTBO', envelope);
+
+    // Wait for the uplink chain: local → embedded broker → bridge.handleUplink
+    // → pool.publish → upstream Aedes records the publish.
+    await new Promise((r) => setTimeout(r, 600));
+
+    // The bridge's subscriber connected as the broker's gateway nodeId.
+    expect(connects).toContain('!deadbeef');
+    // The pool opened a separate per-gateway connection for the local node.
+    expect(connects).toContain('!11111111');
+
+    // The uplink publish rode the per-gateway connection, not the subscriber.
+    const fromGateway = publishesByClient.filter((p) => p.clientId === '!11111111');
+    expect(fromGateway.length).toBeGreaterThanOrEqual(1);
+    expect(fromGateway[0].topic).toBe('msh/CA/ON/PTBO');
+
+    // Status surface reports the publisher pool entry.
+    const status = bridge.getStatus();
+    expect(status.forwardingMode).toBe('per_gateway');
+    expect(Object.keys(status.publishers)).toContain('!11111111');
+
+    await new Promise<void>((r) => localClient.end(true, {}, () => r()));
+  });
+
+  it('in single mode, uplink rides the legacy `mm-bridge-…` connection with no publisher pool', async () => {
+    const connects: string[] = [];
+    upstream.aedes.on('client', (c) => connects.push(c.id));
+
+    bridge = new MqttBridgeManager('single-bridge', 'Single', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: [],
+      mode: 'publish_only',
+      forwardingMode: 'single',
+    });
+    await sourceManagerRegistry.addManager(bridge);
+
+    const localClient = connect(`mqtt://127.0.0.1:${localPort}`, {
+      username: 'u',
+      password: 'p',
+      reconnectPeriod: 0,
+      clientId: '!22222222',
+    });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('local connect timeout')), 3000);
+      localClient.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+
+    const envelope = buildPositionEnvelope({
+      from: 0x22222222,
+      latI: 440_000_000,
+      lngI: -780_000_000,
+      channelId: 'LongFast',
+      gatewayId: '!22222222',
+      packetId: 0x30000002,
+    });
+    localClient.publish('msh/CA/ON/PTBO', envelope);
+
+    await new Promise((r) => setTimeout(r, 400));
+
+    // Only the legacy `mm-bridge-…` prefix shows up — no per-gateway
+    // connections were ever created.
+    expect(connects.some((id) => id.startsWith('mm-bridge-single-bridge-'))).toBe(true);
+    expect(connects).not.toContain('!22222222');
+
+    const status = bridge.getStatus();
+    expect(status.forwardingMode).toBe('single');
+    expect(status.publishers).toEqual({});
+
+    await new Promise<void>((r) => localClient.end(true, {}, () => r()));
+  });
 });

--- a/src/server/mqttBridgeManager.ts
+++ b/src/server/mqttBridgeManager.ts
@@ -42,6 +42,11 @@ import databaseService from '../services/database.js';
 import { logger } from '../utils/logger.js';
 import { loadAllNodesAsDeviceInfo } from './utils/dbNodeMapper.js';
 import type { DeviceInfo } from './meshtasticManager.js';
+import {
+  MqttBridgePublisherPool,
+  formatGatewayClientId,
+  type PublisherStatus,
+} from './mqttBridgePublisherPool.js';
 
 /**
  * Direction the bridge is permitted to operate in against the upstream
@@ -59,6 +64,22 @@ import type { DeviceInfo } from './meshtasticManager.js';
  *   Use this for read-only monitoring.
  */
 export type MqttBridgeMode = 'bidirectional' | 'publish_only' | 'subscribe_only';
+
+/**
+ * Per-bridge upstream forwarding identity model.
+ *
+ * - `per_gateway` (default): each `local-packet`'s `gateway_id` is
+ *   dispatched through its own upstream MQTT connection with
+ *   `clientId = '!' + hex8(gatewayNum)`. The parent broker's own
+ *   gateway nodeId doubles as the subscriber connection so MQTT 3.1.1
+ *   §3.1.4's mandatory-disconnect rule for duplicate Client IDs cannot
+ *   trip. Required for upstream brokers that filter CONNECT on Client
+ *   ID (e.g. community brokers that whitelist `!<8-hex>`).
+ * - `single`: legacy behavior — one upstream connection with
+ *   `mm-bridge-<sourceId>-<random>` Client ID handles every uplink.
+ *   Useful for upstream brokers with tight per-username connection caps.
+ */
+export type MqttBridgeForwardingMode = 'per_gateway' | 'single';
 
 export interface MqttBridgeSourceConfig {
   /**
@@ -96,6 +117,12 @@ export interface MqttBridgeSourceConfig {
    */
   downlinkTopicRewrite?: TopicRewriteRule;
   uplinkTopicRewrite?: TopicRewriteRule;
+  /**
+   * See {@link MqttBridgeForwardingMode}. Defaults to `per_gateway` when
+   * unset. Only meaningful when the bridge has a `brokerSourceId`
+   * (standalone bridges have no `local-packet` stream to dispatch over).
+   */
+  forwardingMode?: MqttBridgeForwardingMode;
 }
 
 /** Literal prefix replacement rule applied to a Meshtastic MQTT topic. */
@@ -153,12 +180,34 @@ export interface MqttBridgeStatus extends SourceStatus {
   permissionMessage: string | null;
   /** Resolved bridge mode (defaults to `bidirectional`). */
   mode: MqttBridgeMode;
+  /** Resolved forwarding mode (defaults to `per_gateway`). */
+  forwardingMode: MqttBridgeForwardingMode;
+  /**
+   * Per-gateway publisher status when `forwardingMode === 'per_gateway'`.
+   * Keyed by `!<8-hex>` Client ID. Empty when the bridge is in `single`
+   * mode or when no `local-packet` traffic has been seen yet.
+   */
+  publishers: Record<string, PublisherStatus>;
 }
 
 interface EchoEntry { topic: string; packetId: number; expiresAt: number }
 
 const ECHO_TTL_MS = 60_000;
 const ECHO_MAX = 256;
+
+/**
+ * Parse a Meshtastic ServiceEnvelope `gateway_id` string (`!<8-hex>`) into
+ * the unsigned 32-bit nodeNum. Returns null for unparseable input so the
+ * caller can fall back to the subscriber connection — we never want a
+ * malformed envelope to take down the uplink path.
+ */
+export function extractGatewayNum(gatewayId: string | undefined): number | null {
+  if (typeof gatewayId !== 'string') return null;
+  const hex = gatewayId.startsWith('!') ? gatewayId.slice(1) : gatewayId;
+  if (!/^[0-9a-fA-F]{1,8}$/.test(hex)) return null;
+  const n = parseInt(hex, 16);
+  return Number.isFinite(n) ? n >>> 0 : null;
+}
 
 export class MqttBridgeManager extends EventEmitter implements ISourceManager {
   readonly sourceId: string;
@@ -179,6 +228,20 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
   private lastError: string | null = null;
   private readonly downlinkEchoes: EchoEntry[] = [];
   private readonly uplinkEchoes: EchoEntry[] = [];
+  /**
+   * Per-gateway publisher pool. Non-null only while the bridge is
+   * running in `per_gateway` mode with a parent broker attached.
+   * Holds one MQTT connection per `gateway_id` seen in `local-packet`.
+   */
+  private publisherPool: MqttBridgePublisherPool | null = null;
+  /**
+   * In `per_gateway` mode, the gatewayNum whose pool entry doubles as
+   * the subscriber connection (i.e., the parent broker's own gateway
+   * nodeId). When `gateway_id` of an uplink packet matches this, the
+   * publish rides `this.client` instead of being dispatched into a
+   * separate pool entry — see MQTT 3.1.1 §3.1.4 duplicate-clientId rule.
+   */
+  private brokerGatewayNum: number | null = null;
 
   constructor(sourceId: string, sourceName: string, config: MqttBridgeSourceConfig) {
     super();
@@ -189,17 +252,47 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     this.uplinkFilter = new MqttPacketFilter(config.uplinkFilters);
   }
 
+  /** Resolves the configured forwarding mode, defaulting to `'per_gateway'`. */
+  private getForwardingMode(): MqttBridgeForwardingMode {
+    return this.config.forwardingMode ?? 'per_gateway';
+  }
+
   async start(): Promise<void> {
     this.attachParentBroker();
     await bootstrapMqttChannelDatabase(this.sourceId);
     await this.seedDownlinkMembership();
 
     const mode = this.getMode();
+    const forwardingMode = this.getForwardingMode();
+
+    // In per_gateway mode with a parent broker attached, the bridge's
+    // subscriber connection takes the broker's gateway nodeId as its
+    // Client ID — so the upstream broker sees the bridge as the broker
+    // node, not as an opaque `mm-bridge-…`. The same connection is also
+    // the publisher for traffic whose gateway_id IS the broker's nodeId
+    // (avoids the MQTT 3.1.1 §3.1.4 duplicate-clientId disconnect).
+    let subscriberClientId: string | undefined;
+    if (forwardingMode === 'per_gateway' && this.parentBroker) {
+      const localInfo = this.parentBroker.getLocalNodeInfo();
+      this.brokerGatewayNum = localInfo.nodeNum >>> 0;
+      subscriberClientId = formatGatewayClientId(this.brokerGatewayNum);
+      this.publisherPool = new MqttBridgePublisherPool({
+        url: this.config.upstream.url,
+        username: this.config.upstream.username,
+        password: this.config.upstream.password,
+        poolLabel: this.sourceId,
+      });
+    }
+
     this.client = new MqttBrokerClient({
       url: this.config.upstream.url,
       username: this.config.upstream.username,
       password: this.config.upstream.password,
-      clientIdPrefix: `mm-bridge-${this.sourceId}`,
+      // Explicit clientId in per_gateway mode (broker's gateway nodeId);
+      // fall back to the legacy `mm-bridge-…` prefix in single mode or
+      // when no parent broker is attached (standalone bridge).
+      clientId: subscriberClientId,
+      clientIdPrefix: subscriberClientId ? undefined : `mm-bridge-${this.sourceId}`,
     });
     this.client.on('error', (err) => {
       this.lastError = err.message;
@@ -231,7 +324,7 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
       await this.client.subscribe(this.config.subscriptions);
     }
     logger.info(
-      `MQTT bridge ${this.sourceId} subscribed to ${this.config.subscriptions.length} upstream topic(s) (mode=${mode})`,
+      `MQTT bridge ${this.sourceId} subscribed to ${this.config.subscriptions.length} upstream topic(s) (mode=${mode}, forwarding=${forwardingMode})`,
     );
   }
 
@@ -242,10 +335,15 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
 
   async stop(): Promise<void> {
     this.detachParentBroker();
+    if (this.publisherPool) {
+      await this.publisherPool.close();
+      this.publisherPool = null;
+    }
     if (this.client) {
       await this.client.disconnect();
       this.client = null;
     }
+    this.brokerGatewayNum = null;
   }
 
   /**
@@ -326,6 +424,8 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
       capabilities,
       permissionMessage: buildPermissionMessage(capabilities, requestedSubs),
       mode,
+      forwardingMode: this.getForwardingMode(),
+      publishers: this.publisherPool?.getStatus() ?? {},
     };
   }
 
@@ -554,7 +654,7 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
   }
 
   private handleUplink(p: MqttBrokerLocalPacket): void {
-    if (!this.client || !this.client.isConnected()) return;
+    if (!this.client) return;
 
     const packetId = p.envelope.packet?.id !== undefined ? (p.envelope.packet.id >>> 0) : null;
     if (packetId !== null && this.matchesEcho(this.downlinkEchoes, p.topic, packetId)) {
@@ -568,15 +668,39 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     // under the post-rewrite topic so the downlink direction can suppress
     // the upstream broker's re-emission of this same packet.
     const publishTopic = applyTopicRewrite(p.topic, this.config.uplinkTopicRewrite);
-    this.client
-      .publish(publishTopic, p.payload, p.retained)
-      .then(() => {
-        this.uplinkOut++;
-        this.recordEcho(this.uplinkEchoes, publishTopic, packetId);
-      })
-      .catch((err) => {
-        this.lastError = `upstream publish failed: ${err.message}`;
-      });
+    // Per-gateway dispatch: when the pool is active and the envelope's
+    // gateway_id parses to a nodeNum different from the broker's own
+    // gateway nodeId, publish through the pool entry whose clientId is
+    // `!<gatewayHex>`. Otherwise (single mode, no pool, broker-self-
+    // originated packet, or unparseable gateway_id) ride the subscriber
+    // connection — which in per_gateway mode already uses the broker's
+    // own nodeId as its Client ID.
+    const gatewayNum = this.publisherPool ? extractGatewayNum(p.envelope.gatewayId) : null;
+    const dispatchToPool =
+      this.publisherPool !== null &&
+      gatewayNum !== null &&
+      gatewayNum !== this.brokerGatewayNum;
+
+    const onSuccess = () => {
+      this.uplinkOut++;
+      this.recordEcho(this.uplinkEchoes, publishTopic, packetId);
+    };
+    const onError = (err: Error) => {
+      this.lastError = `upstream publish failed: ${err.message}`;
+    };
+
+    if (dispatchToPool && this.publisherPool && gatewayNum !== null) {
+      this.publisherPool
+        .publish(gatewayNum, publishTopic, p.payload, p.retained)
+        .then(onSuccess)
+        .catch(onError);
+    } else {
+      if (!this.client.isConnected()) return;
+      this.client
+        .publish(publishTopic, p.payload, p.retained)
+        .then(onSuccess)
+        .catch(onError);
+    }
   }
 
   private recordEcho(store: EchoEntry[], topic: string, packetId: number | null): void {

--- a/src/server/mqttBridgePublisherPool.test.ts
+++ b/src/server/mqttBridgePublisherPool.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for MqttBridgePublisherPool.
+ *
+ * Stands up a real Aedes broker that records every CONNECT's clientId and
+ * every publish's clientId, then asserts the pool creates one upstream
+ * connection per gatewayNum and that publishes ride the matching clientId.
+ *
+ * Pairs with the per-gateway integration test in mqttBridgeManager.test.ts;
+ * here we exercise the pool API directly to keep failure modes localized.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Aedes, type Client as AedesClient } from 'aedes';
+import { createServer, type Server } from 'net';
+
+import {
+  MqttBridgePublisherPool,
+  formatGatewayClientId,
+} from './mqttBridgePublisherPool.js';
+
+async function ephemeralPort(): Promise<number> {
+  const net = await import('net');
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      if (!addr || typeof addr === 'string') {
+        srv.close();
+        reject(new Error('no address'));
+        return;
+      }
+      const port = addr.port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+interface UpstreamRecorder {
+  aedes: Aedes;
+  server: Server;
+  port: number;
+  connects: string[];                                            // clientIds in order
+  publishes: Array<{ clientId: string | null; topic: string }>;
+}
+
+async function startUpstream(): Promise<UpstreamRecorder> {
+  const port = await ephemeralPort();
+  const aedes = await Aedes.createBroker({ id: 'pool-upstream' });
+  const rec: UpstreamRecorder = { aedes, server: null as unknown as Server, port, connects: [], publishes: [] };
+  aedes.on('client', (c: AedesClient) => rec.connects.push(c.id));
+  aedes.on('publish', (packet, client) => {
+    // Internal aedes broadcasts (e.g. $SYS, retained reload) come through
+    // with client === null — ignore those, we only care about pool publishes.
+    if (!client) return;
+    rec.publishes.push({ clientId: client.id, topic: packet.topic });
+  });
+  const server = createServer((socket) => aedes.handle(socket));
+  await new Promise<void>((resolve) => server.listen(port, '127.0.0.1', () => resolve()));
+  rec.server = server;
+  return rec;
+}
+
+async function stopUpstream(rec: UpstreamRecorder): Promise<void> {
+  await new Promise<void>((resolve) => rec.server.close(() => resolve()));
+  await new Promise<void>((resolve) => rec.aedes.close(() => resolve()));
+}
+
+// Wait until predicate is true or timeout. Avoids fragile sleep-based asserts.
+async function waitFor(predicate: () => boolean, timeoutMs = 2000, intervalMs = 25): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+}
+
+describe('MqttBridgePublisherPool', () => {
+  let upstream: UpstreamRecorder;
+  let pool: MqttBridgePublisherPool;
+
+  beforeEach(async () => {
+    upstream = await startUpstream();
+    pool = new MqttBridgePublisherPool({
+      url: `mqtt://127.0.0.1:${upstream.port}`,
+      poolLabel: 'unit-test',
+    });
+  });
+
+  afterEach(async () => {
+    await pool.close();
+    await stopUpstream(upstream);
+  });
+
+  it('formats clientIds as `!<8-hex>` matching firmware convention', () => {
+    expect(formatGatewayClientId(0xdeadbeef)).toBe('!deadbeef');
+    expect(formatGatewayClientId(0x1)).toBe('!00000001');
+    // High-bit-set nodeNums (used for synthetic broker gateways) still
+    // produce a valid 8-hex string — confirms the unsigned cast.
+    expect(formatGatewayClientId(0x80000001)).toBe('!80000001');
+  });
+
+  it('creates one upstream connection per distinct gatewayNum and publishes through it', async () => {
+    await pool.publish(0x11111111, 'msh/test/!11111111', Buffer.from('hello-a'));
+    await pool.publish(0x22222222, 'msh/test/!22222222', Buffer.from('hello-b'));
+    // Second publish from same gateway reuses the existing connection.
+    await pool.publish(0x11111111, 'msh/test/!11111111', Buffer.from('hello-a-again'));
+
+    await waitFor(() => upstream.publishes.length >= 3);
+
+    // Two distinct CONNECTs — the third publish reused the first connection.
+    expect(upstream.connects).toContain('!11111111');
+    expect(upstream.connects).toContain('!22222222');
+    const conn1Count = upstream.connects.filter((id) => id === '!11111111').length;
+    expect(conn1Count).toBe(1);
+
+    // Publishes carry the matching clientId on the wire.
+    const fromGw1 = upstream.publishes.filter((p) => p.clientId === '!11111111');
+    const fromGw2 = upstream.publishes.filter((p) => p.clientId === '!22222222');
+    expect(fromGw1.length).toBe(2);
+    expect(fromGw2.length).toBe(1);
+  });
+
+  it('exposes per-entry status via getStatus()', async () => {
+    await pool.publish(0xabcdef01, 'msh/test/!abcdef01', Buffer.from('x'));
+    await waitFor(() => upstream.publishes.length >= 1);
+
+    const status = pool.getStatus();
+    expect(Object.keys(status)).toEqual(['!abcdef01']);
+    const entry = status['!abcdef01'];
+    expect(entry.clientId).toBe('!abcdef01');
+    expect(entry.publishes).toBe(1);
+    expect(entry.lastPublishAt).not.toBeNull();
+    expect(entry.lastError).toBeNull();
+  });
+
+  it('prepare() opens the connection without publishing', async () => {
+    await pool.prepare(0xcafebabe);
+    await waitFor(() => upstream.connects.includes('!cafebabe'));
+    expect(upstream.publishes).toEqual([]);
+    expect(pool.size()).toBe(1);
+  });
+
+  it('close() disconnects every pool entry and rejects further publishes', async () => {
+    await pool.publish(0x11111111, 'msh/test/x', Buffer.from('x'));
+    await waitFor(() => upstream.publishes.length >= 1);
+
+    await pool.close();
+    await expect(
+      pool.publish(0x22222222, 'msh/test/y', Buffer.from('y')),
+    ).rejects.toThrow(/closed/);
+  });
+
+  it('normalizes signed/negative gatewayNum input via unsigned 32-bit cast', async () => {
+    // -1 interpreted as uint32 = 0xffffffff → `!ffffffff`
+    await pool.publish(-1, 'msh/test/all', Buffer.from('z'));
+    await waitFor(() => upstream.publishes.length >= 1);
+    expect(upstream.connects).toContain('!ffffffff');
+  });
+});

--- a/src/server/mqttBridgePublisherPool.ts
+++ b/src/server/mqttBridgePublisherPool.ts
@@ -1,0 +1,206 @@
+/**
+ * Per-gateway upstream MQTT publisher pool.
+ *
+ * In `forwardingMode: 'per_gateway'` mode (the default), `MqttBridgeManager`
+ * dispatches each `local-packet` to a separate upstream MQTT connection
+ * keyed on the packet's `gateway_id`. Each connection authenticates with
+ * `clientId = '!' + hex8(gatewayNum)` so the upstream broker sees the
+ * packet as if it came directly from the gateway node — mirroring the
+ * wire behavior of a Meshtastic device that publishes its own MQTT-out.
+ *
+ * The motivating use case is community brokers (e.g. `mqtt.areyoumeshingwith.us`)
+ * that gate CONNECT on a Client ID regex like `^!\[0-9a-f]{8,}$` and
+ * return CONNACK 4 to MeshMonitor's legacy `mm-bridge-<sourceId>-…`
+ * prefix regardless of credentials. With per-gateway identities the
+ * bridge looks indistinguishable from N firmware MQTT clients.
+ *
+ * Pool entries are created lazily on the first `publish()` for a gateway
+ * and held open for the pool's lifetime — no idle eviction in v1. At
+ * realistic local-node counts (single digits per host) the socket cost
+ * is negligible and the cold-publish CONNACK round-trip on every new
+ * gateway would noticeably hurt latency on bursty traffic.
+ *
+ * NOT included in v1, intentionally:
+ *   - LWT (Last-Will) on per-gateway clients — defer until we have parity
+ *     with firmware's exact disconnect payload shape.
+ *   - Idle eviction policy.
+ *   - `gateway_id` provenance check against known local nodes.
+ */
+
+import { MqttBrokerClient } from './transports/mqttBrokerClient.js';
+import { logger } from '../utils/logger.js';
+
+export interface PublisherPoolOptions {
+  /** Upstream URL passed through to each MqttBrokerClient. */
+  url: string;
+  /** Optional upstream auth, shared across every pool entry. */
+  username?: string;
+  password?: string;
+  /** Pool diagnostic label — usually the owning bridge's sourceId. */
+  poolLabel: string;
+}
+
+export interface PublisherStatus {
+  /** `!<8-hex>` representation of the gateway, matching the entry's clientId. */
+  clientId: string;
+  connected: boolean;
+  publishes: number;
+  lastPublishAt: number | null;
+  lastError: string | null;
+}
+
+interface PoolEntry {
+  client: MqttBrokerClient;
+  clientId: string;
+  publishes: number;
+  lastPublishAt: number | null;
+  lastError: string | null;
+  /** Resolves once the initial CONNACK lands (or the first reconnect, etc.). */
+  ready: Promise<void>;
+}
+
+/**
+ * Format a Meshtastic node number as the canonical `!<8-hex>` Client ID.
+ * Treats `gatewayNum` as unsigned 32-bit; values exceeding that range
+ * are masked, which preserves the firmware convention.
+ */
+export function formatGatewayClientId(gatewayNum: number): string {
+  return '!' + (gatewayNum >>> 0).toString(16).padStart(8, '0');
+}
+
+export class MqttBridgePublisherPool {
+  private readonly options: PublisherPoolOptions;
+  private readonly entries = new Map<number, PoolEntry>();
+  private closed = false;
+
+  constructor(options: PublisherPoolOptions) {
+    this.options = options;
+  }
+
+  /**
+   * Returns the count of pool entries currently held open. Used for
+   * diagnostic surfaces; pool size has no upper bound in v1.
+   */
+  size(): number {
+    return this.entries.size;
+  }
+
+  /**
+   * Snapshot of every pool entry's state, keyed by `!<8-hex>` Client ID.
+   * Safe to read at any time; reflects the most recent publish outcome.
+   */
+  getStatus(): Record<string, PublisherStatus> {
+    const out: Record<string, PublisherStatus> = {};
+    for (const entry of this.entries.values()) {
+      out[entry.clientId] = {
+        clientId: entry.clientId,
+        connected: entry.client.isConnected(),
+        publishes: entry.publishes,
+        lastPublishAt: entry.lastPublishAt,
+        lastError: entry.lastError,
+      };
+    }
+    return out;
+  }
+
+  /**
+   * Publish through the per-gateway connection, creating it on first use.
+   *
+   * Resolves once the publish is queued to mqtt.js. If the underlying
+   * connection isn't yet connected (initial CONNACK pending), the publish
+   * still resolves — mqtt.js queues it client-side and flushes on connect.
+   * That's the same behavior as direct mqtt.connect() use; callers don't
+   * have to wait for `ready`.
+   *
+   * Errors are recorded on the entry's `lastError` and rethrown so the
+   * caller can log them at the bridge level. They don't tear the pool
+   * entry down — mqtt.js handles reconnection.
+   */
+  async publish(
+    gatewayNum: number,
+    topic: string,
+    payload: Buffer,
+    retained = false,
+  ): Promise<void> {
+    if (this.closed) {
+      throw new Error(`Publisher pool ${this.options.poolLabel} is closed`);
+    }
+    const entry = this.ensureEntry(gatewayNum);
+    try {
+      await entry.client.publish(topic, payload, retained);
+      entry.publishes++;
+      entry.lastPublishAt = Date.now();
+      entry.lastError = null;
+    } catch (err) {
+      entry.lastError = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
+  }
+
+  /**
+   * Pre-create a pool entry without publishing — useful when the bridge
+   * wants the broker-identity connection up before any uplink traffic
+   * arrives. Returns the entry's ready-promise so callers can await
+   * the initial CONNACK if they need to.
+   */
+  prepare(gatewayNum: number): Promise<void> {
+    if (this.closed) {
+      return Promise.reject(
+        new Error(`Publisher pool ${this.options.poolLabel} is closed`),
+      );
+    }
+    return this.ensureEntry(gatewayNum).ready;
+  }
+
+  /**
+   * Close every pool entry in parallel. After this resolves the pool
+   * rejects further publishes — call `new MqttBridgePublisherPool(...)`
+   * to rebuild.
+   */
+  async close(): Promise<void> {
+    this.closed = true;
+    const closes = Array.from(this.entries.values()).map((e) =>
+      e.client.disconnect().catch((err) => {
+        logger.warn(
+          `Publisher pool ${this.options.poolLabel}: disconnect failed for ${e.clientId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }),
+    );
+    this.entries.clear();
+    await Promise.all(closes);
+  }
+
+  private ensureEntry(gatewayNum: number): PoolEntry {
+    const key = gatewayNum >>> 0; // normalize to unsigned 32-bit
+    const existing = this.entries.get(key);
+    if (existing) return existing;
+
+    const clientId = formatGatewayClientId(key);
+    const client = new MqttBrokerClient({
+      url: this.options.url,
+      username: this.options.username,
+      password: this.options.password,
+      clientId,
+    });
+    const entry: PoolEntry = {
+      client,
+      clientId,
+      publishes: 0,
+      lastPublishAt: null,
+      lastError: null,
+      // connect() returns a promise that resolves on the first CONNACK;
+      // we keep it so prepare() callers can await it explicitly.
+      ready: client.connect(),
+    };
+    client.on('error', (err) => {
+      entry.lastError = err.message;
+    });
+    this.entries.set(key, entry);
+    logger.info(
+      `Publisher pool ${this.options.poolLabel}: created entry for gateway ${clientId}`,
+    );
+    return entry;
+  }
+}

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -83,6 +83,7 @@ export function buildMqttManagerForSource(
  * Returns an error message string if invalid, or null if OK.
  */
 const MQTT_BRIDGE_MODES = ['bidirectional', 'publish_only', 'subscribe_only'] as const;
+const MQTT_BRIDGE_FORWARDING_MODES = ['per_gateway', 'single'] as const;
 
 /**
  * Validate the optional `mode` field on an mqtt_bridge config. Absent
@@ -93,6 +94,19 @@ function validateMqttBridgeMode(config: Record<string, any>): string | null {
   if (mode === undefined || mode === null) return null;
   if (!MQTT_BRIDGE_MODES.includes(mode)) {
     return `mqtt_bridge mode must be one of ${MQTT_BRIDGE_MODES.join(', ')}`;
+  }
+  return null;
+}
+
+/**
+ * Validate the optional `forwardingMode` field on an mqtt_bridge config.
+ * Absent (undefined) defaults to `per_gateway`.
+ */
+function validateMqttBridgeForwardingMode(config: Record<string, any>): string | null {
+  const value = config?.forwardingMode;
+  if (value === undefined || value === null) return null;
+  if (!MQTT_BRIDGE_FORWARDING_MODES.includes(value)) {
+    return `mqtt_bridge forwardingMode must be one of ${MQTT_BRIDGE_FORWARDING_MODES.join(', ')}`;
   }
   return null;
 }
@@ -280,6 +294,10 @@ router.post('/', requirePermission('sources', 'write'), async (req: Request, res
       if (modeError) {
         return res.status(400).json({ error: modeError });
       }
+      const forwardingModeError = validateMqttBridgeForwardingMode(config ?? {});
+      if (forwardingModeError) {
+        return res.status(400).json({ error: forwardingModeError });
+      }
     }
     if (!config || typeof config !== 'object') {
       return res.status(400).json({ error: 'config is required and must be an object' });
@@ -404,6 +422,10 @@ router.put('/:id', requirePermission('sources', 'write'), async (req: Request, r
         const modeError = validateMqttBridgeMode(config);
         if (modeError) {
           return res.status(400).json({ error: modeError });
+        }
+        const forwardingModeError = validateMqttBridgeForwardingMode(config);
+        if (forwardingModeError) {
+          return res.status(400).json({ error: forwardingModeError });
         }
       }
 

--- a/src/server/transports/mqttBrokerClient.ts
+++ b/src/server/transports/mqttBrokerClient.ts
@@ -14,6 +14,14 @@ export interface MqttBrokerClientOptions {
   url: string;
   username?: string;
   password?: string;
+  /**
+   * Explicit MQTT Client ID. When set, used verbatim on CONNECT (no random
+   * suffix). Takes precedence over `clientIdPrefix`. Use this when the
+   * upstream broker filters CONNECT on Client ID — e.g. community brokers
+   * that whitelist `!<8-hex>` patterns. See `MqttBridgePublisherPool` for
+   * the per-gateway-identity use case.
+   */
+  clientId?: string;
   clientIdPrefix?: string;
   rejectUnauthorized?: boolean;
 }
@@ -75,9 +83,15 @@ export class MqttBrokerClient extends EventEmitter {
 
     const url = normalizeBrokerUrl(this.options.url);
     const clientId =
+      this.options.clientId ??
       (this.options.clientIdPrefix ?? 'meshmonitor') +
-      '-' +
-      Math.random().toString(36).slice(2, 10);
+        '-' +
+        Math.random().toString(36).slice(2, 10);
+
+    // Per-client reconnect jitter: when N publisher-pool entries reconnect
+    // after an upstream broker bounce, a flat 5000ms period would have them
+    // all CONNECT in the same window. Random 4000-6000ms spreads the herd.
+    const reconnectPeriod = 5000 + Math.floor((Math.random() - 0.5) * 2000);
 
     this.client = connect(url, {
       clientId,
@@ -86,7 +100,7 @@ export class MqttBrokerClient extends EventEmitter {
       protocolVersion: 4, // MQTT 3.1.1
       clean: true,
       keepalive: 60,
-      reconnectPeriod: 5000,
+      reconnectPeriod,
       connectTimeout: 30_000,
       rejectUnauthorized: this.options.rejectUnauthorized ?? true,
     });


### PR DESCRIPTION
## Summary

Closes most of #3197. Adds a per-gateway upstream MQTT publisher pool to `MqttBridgeManager`, making the bridge open one upstream connection per local gateway it sees in `local-packet` events — each authenticating with `clientId = '!' + hex8(gatewayNum)`. The bridge's subscriber connection takes over the broker's own gateway nodeId, so the broker-identity entry and the subscriber share one TCP socket (sidesteps MQTT 3.1.1 §3.1.4 duplicate-clientId disconnect).

**Motivated by `mqtt.areyoumeshingwith.us` and similar community brokers** that gate CONNECT on a `!<8-hex>` clientId regex and return CONNACK 4 to MeshMonitor's legacy `mm-bridge-<sourceId>-…` prefix regardless of credentials. With the pool active each gateway looks identical to a Meshtastic firmware node connecting MQTT directly, including the broker that hosts them.

### New config: `forwardingMode`

Per-bridge field, accepts `per_gateway` (default) or `single` (legacy). Operators on brokers with tight per-username connection caps can opt back into the single-connection path without losing the rest of the bridge functionality.

### Identity rules

| Packet's `gateway_id` matches | Publishes through |
|---|---|
| Broker's own gateway nodeId | `this.client` (subscriber connection, already that identity) |
| Any other local gateway | Pool entry with `clientId = !<gatewayHex>` (lazy-created) |
| Missing / unparseable | `this.client` (subscriber connection — fail-safe) |

### Why this is safe to default on

- Two MeshMonitor instances can't share a physical Meshtastic node (TCP port 4403, serial, BLE all exclusive), so they can't produce the same `gateway_id` upstream and can't collide on Client IDs. No HA-flap risk.
- Existing bridges with no parent broker (standalone client-proxy mode, #3134) are unaffected — the pool only activates when there's a `brokerSourceId`.
- Bridges using \`forwardingMode: 'single'\` remain on the legacy path bit-for-bit.

The only realistic surprise is upstream brokers with `max_connections_per_user` < (number of local gateways). Operators hit by that switch the bridge to `single` mode and get the old behavior back. A follow-up PR will add startup CONNACK-rate detection to surface a one-line hint for this case.

### Other changes

- `MqttBrokerClient` accepts an explicit `clientId` option (used verbatim when set, falls back to `clientIdPrefix + random`).
- Per-client reconnect jitter (±1s on the base 5s) so N publisher pool entries don't reconnect simultaneously after an upstream bounce.
- `MqttBridgeStatus` grows a `publishers: Record<'!<hex>', { connected, publishes, lastPublishAt, lastError }>` map and a resolved `forwardingMode` field.
- API validation for `forwardingMode` on POST /api/sources and PUT /api/sources/:id.

## Test plan

- [x] New `MqttBridgePublisherPool` unit tests (6) — clientId formatting, per-gateway connection creation, reuse on second publish, status surface, prepare() vs publish(), close() idempotency, unsigned-cast normalization.
- [x] New `MqttBridgeManager` integration tests (2) against real Aedes upstream — per_gateway default dispatches uplink through `!<gatewayHex>` connection; explicit `single` stays on legacy `mm-bridge-…` connection.
- [x] All 5,612 tests in the full vitest suite pass.
- [x] Typecheck clean (`tsc --noEmit`).
- [x] No new lint warnings in the changed files.
- [ ] Manual: dev container — point a bridge at `mqtt.areyoumeshingwith.us` with `uplink/uplink`, confirm uplink works in `per_gateway` and fails-as-before in `single`.
- [ ] Manual: confirm a standalone bridge (no parent broker) still behaves like legacy.

## Out of scope (parked for follow-up)

- Bridge-edit form UI control for `forwardingMode` (API field works today; UI control can ride a separate small PR).
- Startup CONNACK-rate detection emitting "switch to single?" hint when many pool entries fail auth.
- LWT (Last-Will) per pool entry for wire-faithful disconnect signaling.
- Per-publisher stats in the broker status panel.

Tracking: #3197

🤖 Generated with [Claude Code](https://claude.com/claude-code)