### PR TITLE
fix(users): render only configured channels in the permission grid

### DIFF
--- a/src/components/UsersTab.test.tsx
+++ b/src/components/UsersTab.test.tsx
@@ -104,7 +104,12 @@ function setupApi(opts: {
       return { data: opts.channelDbPermissions ?? [] };
     }
     if (url.includes('/api/channels/all')) {
-      return [];
+      // Default fixture: a single primary channel — required for the
+      // per-source permission grid to render the channel_0 row at all
+      // now that the grid is gated on actually-configured channels
+      // (fix/users-perm-source-aware-channels). Specific tests can
+      // override via `opts.channels`.
+      return opts.channels ?? [{ id: 0, name: '' }];
     }
     return {};
   });
@@ -209,6 +214,39 @@ describe('UsersTab — PR-C grid additions', () => {
     );
     expect(screen.queryByText('users.channel_primary')).not.toBeInTheDocument();
     expect(screen.queryByText('users.channel_n')).not.toBeInTheDocument();
+  });
+
+  it('renders channel rows only for channels actually configured on the scoped source', async () => {
+    // Regression for issue: UsersTab used to paint all 8 channel_N rows
+    // unconditionally, so MeshCore sources (which have no per-slot
+    // channels) and Meshtastic sources with fewer than 8 channels showed
+    // empty/non-existent rows — e.g. "Channel 1 (Gauntlet)" lingered even
+    // after the underlying channel was disabled. The grid is now gated on
+    // the source's actual channel list returned by `/api/channels/all`.
+    setupApi({
+      sources: [
+        { id: 'tcp-1', name: 'TCP Source', type: 'meshtastic_tcp' },
+      ],
+      channels: [
+        { id: 0, name: '' }, // Primary, unnamed
+        { id: 2, name: 'Gauntlet' }, // configured secondary
+      ],
+    });
+    render(<UsersTab />);
+    fireEvent.click(await screen.findByText(/Alice/));
+    const select = (await screen.findByLabelText(/permission_scope/i)) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'tcp-1' } });
+
+    // channel_0 (primary, no name) → row appears.
+    await waitFor(() => expect(screen.getByText('users.channel_primary')).toBeInTheDocument());
+    // channel_2 → row appears, labelled with the channel name.
+    expect(screen.getByText(/Gauntlet/)).toBeInTheDocument();
+    // channel_1 / channel_3..7 → NOT configured, so no row should render.
+    // We assert by counting the channel_n label occurrences — should match
+    // exactly one channel (channel_2 here, since channel_0 uses the
+    // separate channel_primary key).
+    const channelNRows = screen.queryAllByText(/^users\.channel_n/);
+    expect(channelNRows).toHaveLength(1);
   });
 
   it('channel-database section renders a canWrite checkbox column', async () => {

--- a/src/components/UsersTab.tsx
+++ b/src/components/UsersTab.tsx
@@ -107,6 +107,12 @@ const UsersTab: React.FC = () => {
   const [sources, setSources] = useState<Source[]>([]);
   const [permissionScope, setPermissionScope] = useState<string | null>(null);
   const [channelNames, setChannelNames] = useState<Map<number, string>>(new Map());
+  // Channel IDs the currently-scoped source actually has configured. Used to
+  // gate which `channel_N` rows appear in the per-source permission grid —
+  // without this, the UI hardcodes 8 slots regardless of source type, which
+  // is wrong for MeshCore (no per-slot channels) and confusing for any
+  // Meshtastic source that has fewer than 8 channels enabled.
+  const [configuredChannelIds, setConfiguredChannelIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
     fetchUsers();
@@ -214,16 +220,30 @@ const UsersTab: React.FC = () => {
   };
 
   const fetchChannelNames = async (sourceId: string | null) => {
-    if (!sourceId) { setChannelNames(new Map()); return; }
+    if (!sourceId) {
+      setChannelNames(new Map());
+      setConfiguredChannelIds(new Set());
+      return;
+    }
     try {
       const channels = await api.get<{ id: number; name: string }[]>(`/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`);
-      const map = new Map<number, string>();
+      const nameMap = new Map<number, string>();
+      const idSet = new Set<number>();
       if (Array.isArray(channels)) {
-        channels.forEach(ch => { if (ch.name) map.set(ch.id, ch.name); });
+        channels.forEach(ch => {
+          // Some channels (notably Primary / channel_0) come back without a
+          // name set — still configured, just unlabeled. Track IDs
+          // independently from names so we can render an unnamed Primary
+          // row but skip slots the source doesn't actually use.
+          if (typeof ch.id === 'number') idSet.add(ch.id);
+          if (ch.name) nameMap.set(ch.id, ch.name);
+        });
       }
-      setChannelNames(map);
+      setChannelNames(nameMap);
+      setConfiguredChannelIds(idSet);
     } catch {
       setChannelNames(new Map());
+      setConfiguredChannelIds(new Set());
     }
   };
 
@@ -927,6 +947,19 @@ const UsersTab: React.FC = () => {
                 const scopedSource = sources.find(s => s.id === permissionScope);
                 const isMqttScope = scopedSource?.type === 'mqtt_broker' || scopedSource?.type === 'mqtt_bridge';
                 if (isMqttScope && String(r).startsWith('channel_')) return false;
+                // Only render channel_N rows for channels actually
+                // configured on the scoped source. MeshCore sources have
+                // no per-slot channels, and Meshtastic sources with fewer
+                // than 8 active channels shouldn't expose empty slots
+                // (which was the source of "channel 1 (Gauntlet) still
+                // shows after disabling all perms" — the row was painted
+                // from hardcoded PERMISSION_KEYS, not from the source's
+                // real channel list).
+                const channelMatch = /^channel_(\d+)$/.exec(String(r));
+                if (channelMatch) {
+                  const id = Number(channelMatch[1]);
+                  if (!configuredChannelIds.has(id)) return false;
+                }
                 return true;
               }).map(resource => {
                 // Get label from translated map or format it


### PR DESCRIPTION
## Summary

The per-source permission grid in `UsersTab.tsx` painted all eight `channel_0..channel_7` rows from a hardcoded `PERMISSION_KEYS` list, regardless of which source was scoped. This produced two visible bugs:

- **MeshCore sources** (no per-slot channel concept) still surfaced 8 channel rows the operator had no business toggling.
- **Meshtastic sources** with fewer than 8 channels still showed empty slots, and disabling all permissions on a real channel (e.g. "Channel 1 (Gauntlet)") did not remove the row — the UI was painting it from the hardcoded list, not from the source's actual channel list.

This is a regression of behavior that "we fixed long ago" per the user report — the grid now derives its channel rows from `/api/channels/all?sourceId=<x>` again.

## What changed

- New state `configuredChannelIds: Set<number>` populated alongside `channelNames` from the existing `/api/channels/all?sourceId=<x>` fetch (the data was already being fetched for label lookup).
- Row filter rejects any `channel_N` whose ID is not in `configuredChannelIds`. Primary (`channel_0`) renders whenever it's present in the source's list, even if unnamed.
- Existing MQTT-scope carveout (hide all channel rows + show the Virtual Channel hint) is preserved.
- No backend change.

## Test plan

- [x] Updated the shared `/api/channels/all` mock in `UsersTab.test.tsx` to return `[{id:0,name:''}]` by default (a primary channel) so the existing "TCP source renders channel_primary" assertion still passes. Tests can override via `opts.channels`.
- [x] New regression test: with the source mocked to have `[channel_0, channel_2='Gauntlet']`, the grid renders the Primary row and the Gauntlet row, but no rows for channel_1/3/4/5/6/7.
- [x] `npx vitest run src/components/UsersTab.test.tsx` — **6/6 pass**.
- [x] `npx tsc --noEmit` — clean.
- [x] `eslint` on changed files — 0 errors, 1 pre-existing warning (useEffect dependency, unrelated).
- [ ] System tests run by CI on the PR.
- [ ] Manual smoke test: open Users → anonymous → per-source scope → switch between a Meshtastic source (with 2 channels) and a MeshCore source. Should see 2 channel rows for the Meshtastic source and 0 for MeshCore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)