### PR TITLE
feat(mqtt-bridge): honor ok_to_mqtt bit on uplink (default on) (#3197)

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -171,6 +171,9 @@ function DashboardInner() {
   const [formMqttBridgeForwardingMode, setFormMqttBridgeForwardingMode] = useState<
     'per_gateway' | 'single'
   >('per_gateway');
+  // When true, bypass the firmware ok_to_mqtt opt-out and uplink every
+  // packet. Default false (honor the bit) — operator override only.
+  const [formMqttBridgeIgnoreOkToMqtt, setFormMqttBridgeIgnoreOkToMqtt] = useState(false);
   // Each filter is opt-in via a checkbox so the form stays short for the
   // common case where the user just wants a topic-pattern subscription.
   const [formMqttBridgeUseTopicBlock, setFormMqttBridgeUseTopicBlock] = useState(false);
@@ -333,6 +336,7 @@ function DashboardInner() {
     setFormMqttBridgeSubscriptions('msh/#');
     setFormMqttBridgeMode('bidirectional');
     setFormMqttBridgeForwardingMode('per_gateway');
+    setFormMqttBridgeIgnoreOkToMqtt(false);
     setFormMqttBridgeUseTopicBlock(false);
     setFormMqttBridgeTopicBlock('');
     setFormMqttBridgeUseGeo(false);
@@ -400,6 +404,7 @@ function DashboardInner() {
       );
       const savedForwarding = cfg?.forwardingMode;
       setFormMqttBridgeForwardingMode(savedForwarding === 'single' ? 'single' : 'per_gateway');
+      setFormMqttBridgeIgnoreOkToMqtt(cfg?.ignoreOkToMqtt === true);
       const topicBlock: string[] = cfg?.downlinkFilters?.topics?.block ?? [];
       setFormMqttBridgeUseTopicBlock(topicBlock.length > 0);
       setFormMqttBridgeTopicBlock(topicBlock.join('\n'));
@@ -540,6 +545,9 @@ function DashboardInner() {
         ...(formMqttBridgeForwardingMode !== 'per_gateway'
           ? { forwardingMode: formMqttBridgeForwardingMode }
           : {}),
+        // Operator override — only serialize when set. Defaults to honoring
+        // the originator's ok_to_mqtt preference.
+        ...(formMqttBridgeIgnoreOkToMqtt ? { ignoreOkToMqtt: true } : {}),
         ...(Object.keys(downlinkFilters).length > 0 ? { downlinkFilters } : {}),
       };
       if (editingSourceId && !formMqttBridgePassword) {
@@ -1379,6 +1387,25 @@ function DashboardInner() {
                       'source.form.mqtt_bridge_forwarding_help',
                       'Per-gateway lets each local node publish upstream under its own !<hex> Client ID — required for community brokers that filter CONNECT on Client ID (mqtt.areyoumeshingwith.us, etc.). Switch to Single only if the upstream broker has tight per-username connection caps.',
                     )}
+                  </span>
+                </label>
+                <label className="dashboard-form-field" style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 8 }}>
+                  <input
+                    type="checkbox"
+                    checked={formMqttBridgeIgnoreOkToMqtt}
+                    onChange={(e) => setFormMqttBridgeIgnoreOkToMqtt(e.target.checked)}
+                    style={{ marginTop: 3 }}
+                  />
+                  <span>
+                    <span className="dashboard-form-label" style={{ display: 'block' }}>
+                      {t('source.form.mqtt_bridge_ignore_ok_to_mqtt', 'Uplink all packets (ignore ok_to_mqtt bit)')}
+                    </span>
+                    <span style={{ fontSize: 11, color: 'var(--ctp-yellow)' }}>
+                      {t(
+                        'source.form.mqtt_bridge_ignore_ok_to_mqtt_help',
+                        '⚠ Overrides the originating node\'s "ok_to_mqtt" preference. By default, MeshMonitor drops uplink packets whose firmware-set ok_to_mqtt bit is unset (matching Meshtastic firmware on public brokers). Enabling this republishes every packet regardless — including from nodes that explicitly opted out of MQTT relay. Only enable for private bridges where every gateway has consented.',
+                      )}
+                    </span>
                   </span>
                 </label>
                 <label className="dashboard-form-field">

--- a/src/server/mqttBridgeManager.test.ts
+++ b/src/server/mqttBridgeManager.test.ts
@@ -64,6 +64,12 @@ function buildPositionEnvelope(opts: {
   channelId: string;
   gatewayId: string;
   packetId?: number;
+  /**
+   * `Data.bitfield` value. Defaults to 1 (ok_to_mqtt bit set) so existing
+   * tests pass the bridge's ok_to_mqtt gate without explicit opt-in. The
+   * gate test below uses bitfield=0 to verify the drop path.
+   */
+  bitfield?: number;
 }): Buffer {
   const r = getProtobufRoot();
   if (!r) throw new Error('protobuf root not loaded');
@@ -77,7 +83,11 @@ function buildPositionEnvelope(opts: {
       to: 0xffffffff,
       channel: 0,
       id: opts.packetId ?? 0xabcdef01,
-      decoded: { portnum: PortNum.POSITION_APP, payload: positionPayload },
+      decoded: {
+        portnum: PortNum.POSITION_APP,
+        payload: positionPayload,
+        bitfield: opts.bitfield ?? 1,
+      },
     },
     channelId: opts.channelId,
     gatewayId: opts.gatewayId,
@@ -749,6 +759,123 @@ describe('MqttBridgeManager', () => {
     const status = bridge.getStatus();
     expect(status.forwardingMode).toBe('single');
     expect(status.publishers).toEqual({});
+
+    await new Promise<void>((r) => localClient.end(true, {}, () => r()));
+  });
+
+  it('honors ok_to_mqtt: drops uplink packets whose Data.bitfield bit 0 is unset', async () => {
+    const publishesByClient: Array<{ clientId: string | null; topic: string }> = [];
+    upstream.aedes.on('publish', (packet, client) => {
+      if (!client) return;
+      publishesByClient.push({ clientId: client.id, topic: packet.topic });
+    });
+
+    bridge = new MqttBridgeManager('ok-bit-bridge', 'OkBit', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: [],
+      mode: 'publish_only',
+    });
+    await sourceManagerRegistry.addManager(bridge);
+
+    const localClient = connect(`mqtt://127.0.0.1:${localPort}`, {
+      username: 'u',
+      password: 'p',
+      reconnectPeriod: 0,
+      clientId: '!11111111',
+    });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('local connect timeout')), 3000);
+      localClient.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+
+    // bit 0 unset → originator opted out of MQTT relay → bridge must drop.
+    const optOutEnvelope = buildPositionEnvelope({
+      from: 0x11111111,
+      latI: 440_000_000,
+      lngI: -780_000_000,
+      channelId: 'LongFast',
+      gatewayId: '!11111111',
+      packetId: 0x40000001,
+      bitfield: 0,
+    });
+    // bit 0 set → opt-in → bridge must republish.
+    const optInEnvelope = buildPositionEnvelope({
+      from: 0x11111111,
+      latI: 440_000_000,
+      lngI: -780_000_000,
+      channelId: 'LongFast',
+      gatewayId: '!11111111',
+      packetId: 0x40000002,
+      bitfield: 1,
+    });
+
+    localClient.publish('msh/CA/ON/PTBO', optOutEnvelope);
+    localClient.publish('msh/CA/ON/PTBO', optInEnvelope);
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Only the opt-in packet should have reached the upstream broker.
+    const upstreamPublishes = publishesByClient.filter((p) => p.topic === 'msh/CA/ON/PTBO');
+    expect(upstreamPublishes.length).toBe(1);
+
+    // Drop counter recorded the opt-out packet.
+    expect(bridge.getStatus().uplinkOkToMqttDrops).toBeGreaterThanOrEqual(1);
+
+    await new Promise<void>((r) => localClient.end(true, {}, () => r()));
+  });
+
+  it('ignoreOkToMqtt: true uplinks packets regardless of the bit', async () => {
+    const publishesByClient: Array<{ clientId: string | null; topic: string }> = [];
+    upstream.aedes.on('publish', (packet, client) => {
+      if (!client) return;
+      publishesByClient.push({ clientId: client.id, topic: packet.topic });
+    });
+
+    bridge = new MqttBridgeManager('ignore-ok-bridge', 'IgnoreOk', {
+      brokerSourceId: 'local-broker',
+      upstream: { url: `mqtt://127.0.0.1:${upstreamPort}` },
+      subscriptions: [],
+      mode: 'publish_only',
+      ignoreOkToMqtt: true,
+    });
+    await sourceManagerRegistry.addManager(bridge);
+
+    const localClient = connect(`mqtt://127.0.0.1:${localPort}`, {
+      username: 'u',
+      password: 'p',
+      reconnectPeriod: 0,
+      clientId: '!22222222',
+    });
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('local connect timeout')), 3000);
+      localClient.once('connect', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+
+    // bit 0 unset — but the override bypasses the gate.
+    const optOutEnvelope = buildPositionEnvelope({
+      from: 0x22222222,
+      latI: 440_000_000,
+      lngI: -780_000_000,
+      channelId: 'LongFast',
+      gatewayId: '!22222222',
+      packetId: 0x40000003,
+      bitfield: 0,
+    });
+    localClient.publish('msh/CA/ON/PTBO', optOutEnvelope);
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Despite bit 0 being unset, the packet was forwarded upstream.
+    expect(publishesByClient.some((p) => p.topic === 'msh/CA/ON/PTBO')).toBe(true);
+    // And the drop counter stayed at zero.
+    expect(bridge.getStatus().uplinkOkToMqttDrops).toBe(0);
 
     await new Promise<void>((r) => localClient.end(true, {}, () => r()));
   });

--- a/src/server/mqttBridgeManager.ts
+++ b/src/server/mqttBridgeManager.ts
@@ -47,6 +47,7 @@ import {
   formatGatewayClientId,
   type PublisherStatus,
 } from './mqttBridgePublisherPool.js';
+import { channelDecryptionService } from './services/channelDecryptionService.js';
 
 /**
  * Direction the bridge is permitted to operate in against the upstream
@@ -123,6 +124,19 @@ export interface MqttBridgeSourceConfig {
    * (standalone bridges have no `local-packet` stream to dispatch over).
    */
   forwardingMode?: MqttBridgeForwardingMode;
+  /**
+   * When true, uplink every packet regardless of the originator's
+   * `ok_to_mqtt` preference (bit 0 of `Data.bitfield`, set firmware-side
+   * via `Config.LoRaConfig.config_ok_to_mqtt`). Default false — the bridge
+   * mirrors firmware MQTT::onSend behavior and drops packets whose
+   * originator opted out of MQTT relay.
+   *
+   * Setting this to true is a knowledgeable-operator override. It violates
+   * the originating node's stated preference and can republish private
+   * mesh traffic to a public broker. Only use on private/known-restricted
+   * upstreams where the operator has explicit consent from every gateway.
+   */
+  ignoreOkToMqtt?: boolean;
 }
 
 /** Literal prefix replacement rule applied to a Meshtastic MQTT topic. */
@@ -168,6 +182,14 @@ export interface MqttBridgeStatus extends SourceStatus {
   uplinkOut: number;
   downlinkDrops: ReturnType<MqttPacketFilter['getDropCounters']>;
   uplinkDrops: ReturnType<MqttPacketFilter['getDropCounters']>;
+  /**
+   * Count of uplink packets dropped because the originator's `ok_to_mqtt`
+   * preference forbade republish (or the packet was encrypted and we
+   * couldn't decrypt it to read the bit). Sits outside `uplinkDrops`
+   * because the gate isn't part of MqttPacketFilter — it's a bridge-level
+   * policy mirroring firmware MQTT::onSend.
+   */
+  uplinkOkToMqttDrops: number;
   lastError: string | null;
   /**
    * Inferred broker ACL state. `permissionMessage` is non-null when the
@@ -225,6 +247,7 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
   private downlinkIngested = 0;
   private downlinkRepublished = 0;
   private uplinkOut = 0;
+  private uplinkOkToMqttDrops = 0;
   private lastError: string | null = null;
   private readonly downlinkEchoes: EchoEntry[] = [];
   private readonly uplinkEchoes: EchoEntry[] = [];
@@ -426,7 +449,42 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
       mode,
       forwardingMode: this.getForwardingMode(),
       publishers: this.publisherPool?.getStatus() ?? {},
+      uplinkOkToMqttDrops: this.uplinkOkToMqttDrops,
     };
+  }
+
+  /**
+   * Determine whether the originator's `ok_to_mqtt` preference allows
+   * this packet to be republished upstream. Mirrors firmware
+   * `MQTT::onSend` (MQTT.cpp:767-788) — checks bit 0 of `Data.bitfield`.
+   *
+   * - Decoded packet with bit set → allow.
+   * - Decoded packet with bit unset or `bitfield` absent → drop.
+   * - Encrypted packet → try server-side decryption via the channel DB,
+   *   then re-check. If decryption fails (no matching key), drop. This
+   *   matches firmware's fail-closed behavior on public brokers.
+   *
+   * Note: we deliberately do NOT special-case "private" upstream brokers
+   * (per design — operator picks the override per-bridge via
+   * `ignoreOkToMqtt` instead of relying on hostname heuristics).
+   */
+  private async evaluateOkToMqtt(envelope: ServiceEnvelopeShape): Promise<boolean> {
+    const decoded = envelope.packet?.decoded;
+    if (decoded && typeof decoded.bitfield === 'number') {
+      return (decoded.bitfield & 0x1) === 1;
+    }
+    // Encrypted path — try decryption against the channel DB so we can
+    // read the originator's bitfield. If we can't decrypt, fail closed.
+    const enc = envelope.packet?.encrypted;
+    const id = envelope.packet?.id;
+    const from = envelope.packet?.from;
+    if (!enc || typeof id !== 'number' || typeof from !== 'number') return false;
+    const channelHash = typeof envelope.packet?.channel === 'number'
+      ? envelope.packet.channel
+      : undefined;
+    const result = await channelDecryptionService.tryDecrypt(enc, id, from, channelHash);
+    if (!result.success || typeof result.bitfield !== 'number') return false;
+    return (result.bitfield & 0x1) === 1;
   }
 
   getLocalNodeInfo() {
@@ -653,7 +711,7 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     }
   }
 
-  private handleUplink(p: MqttBrokerLocalPacket): void {
+  private async handleUplink(p: MqttBrokerLocalPacket): Promise<void> {
     if (!this.client) return;
 
     const packetId = p.envelope.packet?.id !== undefined ? (p.envelope.packet.id >>> 0) : null;
@@ -662,6 +720,17 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     }
 
     if (!this.uplinkFilter.preFilter(p.topic, p.envelope)) return;
+
+    // Honor the originator's `ok_to_mqtt` preference unless the operator
+    // has explicitly opted out for this bridge. See evaluateOkToMqtt for
+    // the policy details — bridge-level gate, not part of the filter chain.
+    if (!this.config.ignoreOkToMqtt) {
+      const allow = await this.evaluateOkToMqtt(p.envelope);
+      if (!allow) {
+        this.uplinkOkToMqttDrops++;
+        return;
+      }
+    }
 
     // Apply uplink topic rewrite (#3166) — uplinkFilter ran on the original
     // topic; only the wire-level publish gets the rewrite. Echo recorded

--- a/src/server/mqttPacketFilter.ts
+++ b/src/server/mqttPacketFilter.ts
@@ -35,7 +35,7 @@ export interface MeshPacketShape {
   rxRssi?: number;
   hopLimit?: number;
   hopStart?: number;
-  decoded?: { portnum?: number; payload?: Uint8Array };
+  decoded?: { portnum?: number; payload?: Uint8Array; bitfield?: number };
   encrypted?: Uint8Array;
 }
 

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -111,6 +111,19 @@ function validateMqttBridgeForwardingMode(config: Record<string, any>): string |
   return null;
 }
 
+/**
+ * Validate the optional `ignoreOkToMqtt` override on an mqtt_bridge
+ * config. Absent (undefined) defaults to false (honor the bit).
+ */
+function validateMqttBridgeIgnoreOkToMqtt(config: Record<string, any>): string | null {
+  const value = config?.ignoreOkToMqtt;
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'boolean') {
+    return 'mqtt_bridge ignoreOkToMqtt must be a boolean';
+  }
+  return null;
+}
+
 function validateMqttBridgeRewrites(config: Record<string, any>): string | null {
   const isAttached =
     typeof config.brokerSourceId === 'string' && config.brokerSourceId.trim() !== '';
@@ -298,6 +311,10 @@ router.post('/', requirePermission('sources', 'write'), async (req: Request, res
       if (forwardingModeError) {
         return res.status(400).json({ error: forwardingModeError });
       }
+      const ignoreOkErr = validateMqttBridgeIgnoreOkToMqtt(config ?? {});
+      if (ignoreOkErr) {
+        return res.status(400).json({ error: ignoreOkErr });
+      }
     }
     if (!config || typeof config !== 'object') {
       return res.status(400).json({ error: 'config is required and must be an object' });
@@ -426,6 +443,10 @@ router.put('/:id', requirePermission('sources', 'write'), async (req: Request, r
         const forwardingModeError = validateMqttBridgeForwardingMode(config);
         if (forwardingModeError) {
           return res.status(400).json({ error: forwardingModeError });
+        }
+        const ignoreOkErr = validateMqttBridgeIgnoreOkToMqtt(config);
+        if (ignoreOkErr) {
+          return res.status(400).json({ error: ignoreOkErr });
         }
       }
 

--- a/src/server/services/channelDecryptionService.ts
+++ b/src/server/services/channelDecryptionService.ts
@@ -30,6 +30,13 @@ export interface DecryptionResult {
    */
   emoji?: number;
   replyId?: number;
+  /**
+   * Raw `Data.bitfield` (protobuf field 9). Bit 0 carries the originator's
+   * `ok_to_mqtt` preference — see Router.h:177 in the firmware. Undefined
+   * when the proto field wasn't set, which firmware treats as "do not
+   * uplink". MqttBridgeManager reads this to gate uplink republishing.
+   */
+  bitfield?: number;
   error?: string;
 }
 
@@ -258,6 +265,7 @@ class ChannelDecryptionService {
     payload?: Uint8Array;
     emoji?: number;
     replyId?: number;
+    bitfield?: number;
   } {
     try {
       // Get the Data type from loaded protobuf definitions
@@ -284,12 +292,20 @@ class ChannelDecryptionService {
       const replyId =
         typeof rawReplyId === 'number' && rawReplyId > 0 ? rawReplyId >>> 0 : undefined;
 
+      // Bit 0 of Data.bitfield carries the originator's `ok_to_mqtt`
+      // preference. MqttBridgeManager reads this to gate uplink
+      // republishing. Undefined when the proto field wasn't set —
+      // firmware treats absent as "do not uplink" on public brokers.
+      const rawBitfield = decoded.bitfield;
+      const bitfield = typeof rawBitfield === 'number' ? rawBitfield >>> 0 : undefined;
+
       return {
         valid: true,
         portnum: portnum,
         payload: decoded.payload ? new Uint8Array(decoded.payload) : undefined,
         emoji,
         replyId,
+        bitfield,
       };
     } catch {
       // Parse failure means invalid protobuf
@@ -324,6 +340,7 @@ class ChannelDecryptionService {
       payload: validation.payload,
       emoji: validation.emoji,
       replyId: validation.replyId,
+      bitfield: validation.bitfield,
     };
   }
 


### PR DESCRIPTION
## Summary

Brings MeshMonitor's MQTT bridge into compliance with the Meshtastic ok_to_mqtt opt-out. Mirrors firmware \`MQTT::onSend\` (firmware src/mqtt/MQTT.cpp:767-788): drops uplink packets whose originator set their \`Config.LoRaConfig.config_ok_to_mqtt\` to false, by checking bit 0 of \`Data.bitfield\` on every uplink.

Until now MeshMonitor uplinked every packet that survived topic/geo filters, regardless of the originator's preference. The firmware was implicitly carrying the load: nodes with the opt-out set never published to our embedded broker because their own MQTT module enforced the gate, so MeshMonitor never saw them. That breaks the moment a passive listener / custom firmware / future MeshCore-style integration publishes everything it hears — we'd happily re-relay to a public upstream in violation of the originator's preference.

### Enforcement logic

| Packet | Bit set | Action |
|---|---|---|
| Decoded | ✓ | uplink |
| Decoded | ✗ or absent | **drop** |
| Encrypted, key known | ✓ | uplink |
| Encrypted, key known | ✗ or absent | **drop** |
| Encrypted, key unknown | (can't check) | **drop** (fail-closed) |

Bridge-level policy, not part of \`MqttPacketFilter\` — counted separately in \`MqttBridgeStatus.uplinkOkToMqttDrops\`.

No private-broker carve-out (per design — operator picks the override per-bridge instead of relying on hostname heuristics).

### Per-bridge override: \`ignoreOkToMqtt\`

New boolean config flag, default false. When true, the gate is bypassed entirely. Documented in the bridge form UI as a knowledgeable-operator override with an inline warning in yellow:

> ⚠ Overrides the originating node's "ok_to_mqtt" preference. By default, MeshMonitor drops uplink packets whose firmware-set ok_to_mqtt bit is unset (matching Meshtastic firmware on public brokers). Enabling this republishes every packet regardless — including from nodes that explicitly opted out of MQTT relay. Only enable for private bridges where every gateway has consented.

### Internal: \`DecryptionResult.bitfield\`

\`channelDecryptionService\` now surfaces the decoded \`Data.bitfield\` (bit 0 = ok_to_mqtt) so the bridge can read the encrypted-path gate without re-parsing the decrypted Data buffer. Existing consumers (mqttIngestion) ignore the new field.

## Test plan

- [x] 2 new integration tests against real Aedes upstream — drop when \`bitfield = 0\`; uplink when \`bitfield = 0\` AND \`ignoreOkToMqtt = true\`; \`uplinkOkToMqttDrops\` counter increments.
- [x] Updated \`buildPositionEnvelope\` helper to default \`bitfield = 1\` so pre-existing tests pass the new gate without explicit opt-in.
- [x] All 13 \`mqttBridgeManager.test.ts\` tests pass; 41/41 across the bridge suites; 166/166 across bridge + channelDecryption + sourceRoutes.
- [x] Typecheck clean.
- [x] No new lint warnings in changed files.
- [ ] Manual: bridge to private upstream with no override → packets from \`config_ok_to_mqtt=true\` nodes uplink, packets from \`config_ok_to_mqtt=false\` nodes get dropped; \`uplinkOkToMqttDrops\` increments.
- [ ] Manual: same bridge with override enabled → both classes uplink.

Tracking: #3197

🤖 Generated with [Claude Code](https://claude.com/claude-code)