### PR TITLE
fix(config): scope security key fetch by sourceId

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.7.2",
+  "version": "4.7.3",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.7.2
-appVersion: "4.7.2"
+version: 4.7.3
+appVersion: "4.7.3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.7.2",
+      "version": "4.7.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -730,7 +730,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
 
         // Fetch security keys (public/private) separately
         try {
-          const securityKeys = await apiService.getSecurityKeys();
+          const securityKeys = await apiService.getSecurityKeys(sourceId);
           if (securityKeys.publicKey) {
             setSecurityPublicKey(securityKeys.publicKey);
           }


### PR DESCRIPTION
## Summary
- Fixed `ConfigurationTab.tsx` calling `apiService.getSecurityKeys()` without `sourceId`, causing it to fall back to the primary source's keys instead of the currently selected source
- The Info page already passed `activeSourceId` correctly, and the save path already passed `sourceId` — only this one fetch call was missing it
- Resolves user reports of mismatched public keys between the Info and Configuration pages in multi-source setups

## Test plan
- [ ] Connect two or more Meshtastic sources
- [ ] Select a non-primary source
- [ ] Verify the public key on the Info page matches the public key on the Device Configuration → Security section
- [ ] Verify saving security config still works correctly for the selected source

🤖 Generated with [Claude Code](https://claude.com/claude-code)