### PR TITLE
feat(meshcore): add trace path diagnostic

### DIFF
--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -4,7 +4,7 @@ import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { formatRelativeTime } from '../../utils/datetime';
 import { useSettings } from '../../contexts/SettingsContext';
 import { MeshCoreRemoteConsole } from './MeshCoreRemoteConsole';
-import type { MeshCoreActions } from './hooks/useMeshCore';
+import type { MeshCoreActions, TracePathResult } from './hooks/useMeshCore';
 import '../NodeDetailsBlock.css';
 
 const DEVICE_TYPE_KEYS: Record<number, string> = {
@@ -29,6 +29,9 @@ interface MeshCoreContactDetailPanelProps {
    *  ("a3,7f,02"). Unset OR `advancedPathEditEnabled=false` hides the
    *  Edit Path… button. */
   onSetOutPath?: (publicKey: string, outPath: string) => Promise<boolean>;
+  /** Send a trace-path diagnostic along the contact's cached path and
+   *  return per-hop SNR data. Unset hides the Trace Path button. */
+  onTracePath?: (publicKey: string) => Promise<TracePathResult | null>;
   /** Whether the current user may invoke write actions on this source's
    *  `nodes` resource. Required to gate the Reset Path / Share / Edit
    *  buttons. */
@@ -69,6 +72,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   onResetPath,
   onShareContact,
   onSetOutPath,
+  onTracePath,
   canWriteNodes = false,
   isCompanion = true,
   advancedPathEditEnabled = false,
@@ -85,6 +89,11 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   const [sharing, setSharing] = useState(false);
   const [shareError, setShareError] = useState<string | null>(null);
   const [shareSuccess, setShareSuccess] = useState(false);
+
+  // Trace-path state
+  const [tracing, setTracing] = useState(false);
+  const [traceResult, setTraceResult] = useState<TracePathResult | null>(null);
+  const [traceError, setTraceError] = useState<string | null>(null);
 
   // Path-editor modal state. Only mounted when advancedPathEditEnabled.
   const [editorOpen, setEditorOpen] = useState(false);
@@ -107,6 +116,9 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     setEditorOpen(false);
     setEditorError(null);
     setEditorSaving(false);
+    setTracing(false);
+    setTraceResult(null);
+    setTraceError(null);
   }, [publicKey]);
 
   const name = contact?.advName || contact?.name || `${publicKey.substring(0, 8)}…`;
@@ -127,6 +139,27 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     !!onShareContact && canWriteNodes && isCompanion;
   const canShowEditButton =
     !!onSetOutPath && canWriteNodes && isCompanion && advancedPathEditEnabled;
+  const canShowTraceButton =
+    !!onTracePath && canWriteNodes && isCompanion && pathKnown && pathLen! > 0;
+
+  const handleTracePath = async () => {
+    if (!onTracePath || tracing) return;
+    setTracing(true);
+    setTraceError(null);
+    setTraceResult(null);
+    try {
+      const result = await onTracePath(publicKey);
+      if (result) {
+        setTraceResult(result);
+      } else {
+        setTraceError(
+          t('meshcore.contact_details.trace_path_error', 'Trace path failed or timed out.'),
+        );
+      }
+    } finally {
+      setTracing(false);
+    }
+  };
 
   const handleResetPath = async () => {
     if (!onResetPath || resetting) return;
@@ -311,8 +344,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
               available because the device retransmits the stored advert
               regardless of route state. Rendered in one card so the
               actions stay grouped at the bottom of the grid. */}
-          {(canShowResetButton || canShowShareButton || canShowEditButton) &&
-            (canShowShareButton || canShowEditButton || pathKnown) && (
+          {(canShowResetButton || canShowShareButton || canShowEditButton || canShowTraceButton) &&
+            (canShowShareButton || canShowEditButton || canShowTraceButton || pathKnown) && (
             <div className="node-detail-card node-detail-card-2col">
               <div className="node-detail-label">
                 {t('meshcore.contact_details.actions_label', 'Actions')}
@@ -354,6 +387,19 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     {t('meshcore.contact_details.edit_path_button', 'Edit Path…')}
                   </button>
                 )}
+                {canShowTraceButton && (
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    onClick={handleTracePath}
+                    disabled={tracing}
+                    aria-label={t('meshcore.contact_details.trace_path_button', 'Trace Path')}
+                  >
+                    {tracing
+                      ? t('meshcore.contact_details.trace_path_running', 'Tracing…')
+                      : t('meshcore.contact_details.trace_path_button', 'Trace Path')}
+                  </button>
+                )}
                 {resetError && (
                   <span style={{ color: 'var(--ctp-red)' }} role="alert">{resetError}</span>
                 )}
@@ -365,6 +411,59 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     {t('meshcore.contact_details.share_contact_success', 'Advert broadcast.')}
                   </span>
                 )}
+                {traceError && (
+                  <span style={{ color: 'var(--ctp-red)' }} role="alert">{traceError}</span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Trace Path results */}
+          {traceResult && (
+            <div className="node-detail-card node-detail-card-2col">
+              <div className="node-detail-label">
+                {t('meshcore.contact_details.trace_path_results', 'Trace Path Results')}
+              </div>
+              <div className="node-detail-value">
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: 'var(--font-mono, monospace)', fontSize: '0.9em' }}>
+                  <thead>
+                    <tr style={{ borderBottom: '1px solid var(--ctp-surface1, #45475a)' }}>
+                      <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem' }}>
+                        {t('meshcore.contact_details.trace_hop', 'Hop')}
+                      </th>
+                      <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem' }}>
+                        {t('meshcore.contact_details.trace_hash', 'Hash')}
+                      </th>
+                      <th style={{ textAlign: 'right', padding: '0.25rem 0.5rem' }}>
+                        {t('meshcore.contact_details.trace_snr', 'SNR')}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {traceResult.hops.map((hop) => {
+                      const pathHashes = outPath?.split(',') ?? [];
+                      return (
+                        <tr key={hop.index}>
+                          <td style={{ padding: '0.25rem 0.5rem' }}>{hop.index + 1}</td>
+                          <td style={{ padding: '0.25rem 0.5rem' }}>{pathHashes[hop.index] ?? '??'}</td>
+                          <td style={{ padding: '0.25rem 0.5rem', textAlign: 'right' }}
+                              className={getSignalClass(hop.snr)}>
+                            {hop.snr.toFixed(2)} dB
+                          </td>
+                        </tr>
+                      );
+                    })}
+                    <tr style={{ borderTop: '1px solid var(--ctp-surface1, #45475a)' }}>
+                      <td style={{ padding: '0.25rem 0.5rem' }} colSpan={2}>
+                        {t('meshcore.contact_details.trace_destination', 'Destination')}
+                      </td>
+                      <td style={{ padding: '0.25rem 0.5rem', textAlign: 'right' }}
+                          className={getSignalClass(traceResult.lastSnr)}>
+                        {traceResult.lastSnr.toFixed(2)} dB
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           )}

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -283,6 +283,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                 onResetPath={actions.resetContactPath}
                 onShareContact={actions.shareContact}
                 onSetOutPath={actions.setContactOutPath}
+                onTracePath={actions.traceContactPath}
                 canWriteNodes={canWriteNodes && connected}
                 isCompanion={isCompanion}
                 advancedPathEditEnabled={advancedPathEditEnabled}

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -30,6 +30,11 @@ import { MeshCoreContact, mapContactsToNodes } from '../../../utils/meshcoreHelp
 
 export type TelemetryMode = 'always' | 'device' | 'never';
 
+export interface TracePathResult {
+  hops: { index: number; snr: number }[];
+  lastSnr: number;
+}
+
 export interface MeshCoreNode {
   publicKey: string;
   name: string;
@@ -99,6 +104,9 @@ export interface MeshCoreActions {
    *  `meshcoreAdvancedPathEdit` toggle, so a 403 is expected when the
    *  setting is off. */
   setContactOutPath: (publicKey: string, outPath: string) => Promise<boolean>;
+  /** Send a trace-path diagnostic along the contact's cached forwarding
+   *  route and return per-hop SNR data. Resolves `null` on failure. */
+  traceContactPath: (publicKey: string) => Promise<TracePathResult | null>;
   sendAdvert: () => Promise<void>;
   sendMessage: (text: string, toPublicKey?: string, channelIdx?: number) => Promise<boolean>;
   setDeviceName: (name: string) => Promise<boolean>;
@@ -720,6 +728,24 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch]);
 
+  const traceContactPath = useCallback(async (publicKey: string): Promise<TracePathResult | null> => {
+    try {
+      const response = await csrfFetch(
+        `${mcPrefix}/contacts/${encodeURIComponent(publicKey)}/trace-path`,
+        { method: 'POST' },
+      );
+      const data = await response.json();
+      if (!data.success) {
+        setError(data.error || 'Trace path failed');
+        return null;
+      }
+      return { hops: data.hops, lastSnr: data.lastSnr };
+    } catch (_err) {
+      setError('Trace path failed');
+      return null;
+    }
+  }, [mcPrefix, csrfFetch]);
+
   const sendAdvert = useCallback(async () => {
     try {
       const response = await csrfFetch(`${mcPrefix}/advert`, { method: 'POST' });
@@ -892,6 +918,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       resetContactPath,
       shareContact,
       setContactOutPath,
+      traceContactPath,
       sendAdvert,
       sendMessage,
       setDeviceName,

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1385,6 +1385,55 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
+   * Trace the cached forwarding path to a contact, collecting per-hop SNR.
+   * The contact must have a known `outPath`; trace path sends a diagnostic
+   * packet along that exact route and each repeater appends its received
+   * SNR. Returns the per-hop SNR array plus the final-hop SNR, or `null`
+   * on failure (no path, timeout, not Companion).
+   */
+  async traceContactPath(publicKey: string): Promise<{
+    hops: { index: number; snr: number }[];
+    lastSnr: number;
+  } | null> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
+      logger.warn('[MeshCore] Trace-path requires Companion firmware');
+      return null;
+    }
+    if (!this.connected) {
+      return null;
+    }
+    const contact = this.contacts.get(publicKey);
+    if (!contact?.outPath || contact.pathLen == null || contact.pathLen <= 0) {
+      logger.warn(`[MeshCore] Trace-path: no known path for ${publicKey.substring(0, 16)}…`);
+      return null;
+    }
+    const pathBytes = Uint8Array.from(
+      contact.outPath.split(',').map((h) => parseInt(h, 16)),
+    );
+    try {
+      const response = await this.sendBridgeCommand('trace_path', {
+        path: pathBytes,
+      }, 60000);
+      if (!response.success) {
+        logger.warn(`[MeshCore] trace_path failed for ${publicKey}: ${response.error}`);
+        return null;
+      }
+      const d = response.data ?? {};
+      const snrs: number[] = d.pathSnrs ?? [];
+      const hops = snrs.map((raw: number, i: number) => ({
+        index: i,
+        snr: raw / 4,
+      }));
+      const lastSnr: number = d.lastSnr ?? 0;
+      logger.info(`[MeshCore] Trace path to ${publicKey.substring(0, 16)}…: ${hops.length} hops, lastSnr=${lastSnr}`);
+      return { hops, lastSnr };
+    } catch (error) {
+      logger.error('[MeshCore] traceContactPath threw:', error);
+      return null;
+    }
+  }
+
+  /**
    * Broadcast the device's saved advert for a contact as a zero-hop frame
    * so nearby nodes can add this contact themselves. Wraps the firmware's
    * CMD_SHARE_CONTACT; the device only retransmits — no local state is

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -425,6 +425,22 @@ export class MeshCoreNativeBackend extends EventEmitter {
         return { ok: true };
       }
 
+      case 'trace_path': {
+        const pathBytes = params.path as Uint8Array | number[] | undefined;
+        if (!pathBytes || (Array.isArray(pathBytes) ? pathBytes.length : pathBytes.byteLength) === 0) {
+          throw new Error('trace_path requires a non-empty path');
+        }
+        const path = pathBytes instanceof Uint8Array ? pathBytes : Uint8Array.from(pathBytes);
+        const result = await c.tracePath(path, params.extra_timeout as number | undefined);
+        return {
+          ok: true,
+          pathLen: result.pathLen,
+          flags: result.flags,
+          pathSnrs: Array.from(result.pathSnrs as Uint8Array),
+          lastSnr: result.lastSnr,
+        };
+      }
+
       case 'share_contact': {
         // Broadcasts the contact's saved advert as a zero-hop frame so
         // nearby nodes can pick it up. Wraps the firmware's

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -420,6 +420,42 @@ router.post(
 );
 
 /**
+ * POST /api/sources/:id/meshcore/contacts/:publicKey/trace-path
+ *
+ * Send a diagnostic trace along the contact's cached forwarding path,
+ * collecting per-hop SNR. Requires a known out_path (pathLen > 0).
+ * Returns { success, hops: [{ index, snr }], lastSnr }.
+ */
+router.post(
+  '/contacts/:publicKey/trace-path',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const publicKey = req.params.publicKey;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({
+          success: false,
+          error: 'Invalid public key — must be 64-char hex',
+        });
+      }
+      const result = await managerFor(req).traceContactPath(publicKey);
+      if (!result) {
+        return res.status(409).json({
+          success: false,
+          error: 'Trace path failed — contact may have no known path, source disconnected, timed out, or not a Companion device',
+        });
+      }
+      res.json({ success: true, hops: result.hops, lastSnr: result.lastSnr });
+    } catch (error) {
+      logger.error('[API] Error tracing contact path:', error);
+      res.status(500).json({ success: false, error: 'Failed to trace path' });
+    }
+  },
+);
+
+/**
  * PUT /api/sources/:id/meshcore/contacts/:publicKey/out-path
  *
  * Manually set the cached forwarding route ("out_path") for a contact.


### PR DESCRIPTION
## Summary
- Wire up meshcore.js `tracePath()` API to send a diagnostic packet along a contact's cached forwarding route and collect per-hop SNR
- Add `trace_path` bridge command in nativeBackend, `traceContactPath()` method in meshcoreManager, and `POST /contacts/:publicKey/trace-path` REST endpoint
- Add "Trace Path" button to the contact detail panel (visible when path is known with >0 hops) with an inline results table showing hop hash + SNR per repeater and destination SNR

## Test plan
- [ ] Verify typecheck passes (`npx tsc --noEmit`)
- [ ] Verify all tests pass (`npx vitest run`)
- [ ] With a Companion device connected, select a multi-hop contact and click "Trace Path"
- [ ] Confirm per-hop SNR table renders with correct signal color coding
- [ ] Confirm button shows "Tracing…" during the request and reverts on completion
- [ ] Confirm error message appears when trace times out or contact has no known path
- [ ] Confirm button is hidden for direct (0-hop) contacts and contacts with unknown paths
- [ ] Confirm button is hidden when user lacks `nodes:write` permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)