### PR TITLE
feat(meshcore): add TX power configuration

### DIFF
--- a/src/components/MeshCore/MeshCoreConfigurationView.tsx
+++ b/src/components/MeshCore/MeshCoreConfigurationView.tsx
@@ -56,19 +56,28 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
     setCr(preset.cr);
   };
 
+  const [txPower, setTxPower] = useState<number>(local?.txPower ?? 0);
+  const maxTxPower = local?.maxTxPower ?? 22;
+
   const [savingName, setSavingName] = useState(false);
   const [savingRadio, setSavingRadio] = useState(false);
+  const [savingTxPower, setSavingTxPower] = useState(false);
   const [savingLocation, setSavingLocation] = useState(false);
   const [savingAdvLoc, setSavingAdvLoc] = useState(false);
   const [savingTelemetry, setSavingTelemetry] = useState(false);
   const [nameSaved, setNameSaved] = useState(false);
   const [radioSaved, setRadioSaved] = useState(false);
+  const [txPowerSaved, setTxPowerSaved] = useState(false);
   const [locationSaved, setLocationSaved] = useState(false);
   const [telemetrySaved, setTelemetrySaved] = useState(false);
 
   useEffect(() => {
     if (local?.name) setName(local.name);
   }, [local?.name]);
+
+  useEffect(() => {
+    if (typeof local?.txPower === 'number') setTxPower(local.txPower);
+  }, [local?.txPower]);
 
   useEffect(() => {
     if (!local) return;
@@ -112,6 +121,17 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
     if (ok) {
       setRadioSaved(true);
       setTimeout(() => setRadioSaved(false), 2500);
+    }
+  };
+
+  const handleSaveTxPower = async () => {
+    setSavingTxPower(true);
+    setTxPowerSaved(false);
+    const ok = await actions.setTxPower(txPower);
+    setSavingTxPower(false);
+    if (ok) {
+      setTxPowerSaved(true);
+      setTimeout(() => setTxPowerSaved(false), 2500);
     }
   };
 
@@ -358,6 +378,47 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
               : t('meshcore.config.save_radio', 'Save radio settings')}
           </button>
           {radioSaved && (
+            <span style={{ marginLeft: '0.75rem', color: 'var(--ctp-green)' }}>
+              ✓ {t('meshcore.config.saved', 'Saved')}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="form-section">
+        <h3>{t('meshcore.config.tx_power', 'TX Power')}</h3>
+        <p className="hint">
+          {t('meshcore.config.tx_power_hint',
+            `Transmit power in dBm (1–${maxTxPower}). This controls the LoRa chip output only; boards with an external PA may amplify further.`)}
+        </p>
+        <div className="form-row" style={{ alignItems: 'center' }}>
+          <div style={{ flex: 1 }}>
+            <label htmlFor="mc-cfg-txpower">{t('meshcore.config.tx_power_label', 'Power (dBm)')}</label>
+            <input
+              id="mc-cfg-txpower"
+              type="range"
+              min={1}
+              max={maxTxPower}
+              step={1}
+              value={txPower}
+              onChange={e => setTxPower(parseInt(e.target.value, 10))}
+              disabled={!connected || savingTxPower || !canWriteConfig}
+            />
+          </div>
+          <div style={{ minWidth: '4rem', textAlign: 'center', fontWeight: 600, fontSize: '1.1rem' }}>
+            {txPower} dBm
+          </div>
+        </div>
+        <div>
+          <button
+            onClick={() => void handleSaveTxPower()}
+            disabled={!connected || savingTxPower || !canWriteConfig || txPower < 1 || txPower > maxTxPower}
+          >
+            {savingTxPower
+              ? t('meshcore.config.saving', 'Saving…')
+              : t('meshcore.config.save_tx_power', 'Save TX power')}
+          </button>
+          {txPowerSaved && (
             <span style={{ marginLeft: '0.75rem', color: 'var(--ctp-green)' }}>
               ✓ {t('meshcore.config.saved', 'Saved')}
             </span>

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -103,6 +103,7 @@ export interface MeshCoreActions {
   sendMessage: (text: string, toPublicKey?: string, channelIdx?: number) => Promise<boolean>;
   setDeviceName: (name: string) => Promise<boolean>;
   setRadioParams: (params: { freq: number; bw: number; sf: number; cr: number }) => Promise<boolean>;
+  setTxPower: (power: number) => Promise<boolean>;
   setCoords: (lat: number, lon: number) => Promise<boolean>;
   setAdvertLocPolicy: (policy: number) => Promise<boolean>;
   setTelemetryModeBase: (mode: TelemetryMode) => Promise<boolean>;
@@ -795,6 +796,26 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch, fetchStatus]);
 
+  const setTxPower = useCallback(async (power: number): Promise<boolean> => {
+    try {
+      const response = await csrfFetch(`${mcPrefix}/config/tx-power`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ power }),
+      });
+      const data = await response.json();
+      if (data.success) {
+        await fetchStatus();
+        return true;
+      }
+      setError(data.error || 'Failed to update TX power');
+      return false;
+    } catch (_err) {
+      setError('Failed to update TX power');
+      return false;
+    }
+  }, [mcPrefix, csrfFetch, fetchStatus]);
+
   const setCoords = useCallback(async (lat: number, lon: number): Promise<boolean> => {
     try {
       const response = await csrfFetch(`${mcPrefix}/config/coords`, {
@@ -896,6 +917,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       sendMessage,
       setDeviceName,
       setRadioParams,
+      setTxPower,
       setCoords,
       setAdvertLocPolicy,
       setTelemetryModeBase,

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1893,6 +1893,43 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
+   * Set TX power (dBm). Range: 1–22.
+   */
+  async setTxPower(power: number): Promise<boolean> {
+    if (!Number.isFinite(power) || power < 1 || power > 22) {
+      throw new Error('Invalid TX power: must be between 1 and 22 dBm');
+    }
+
+    if (this.deviceType === MeshCoreDeviceType.REPEATER) {
+      try {
+        await this.sendRepeaterCommand(`set tx ${power}`);
+        return true;
+      } catch (error) {
+        logger.error('[MeshCore] Failed to set TX power:', error);
+        return false;
+      }
+    } else {
+      try {
+        const response = await this.sendBridgeCommand('set_tx_power', { power });
+        if (response.success) {
+          if (this.localNode) {
+            this.localNode.txPower = power;
+          }
+          try {
+            await this.refreshLocalNode();
+          } catch (refreshErr) {
+            logger.warn('[MeshCore] refreshLocalNode after set_tx_power failed:', refreshErr);
+          }
+        }
+        return response.success;
+      } catch (error) {
+        logger.error('[MeshCore] Failed to set TX power:', error);
+        return false;
+      }
+    }
+  }
+
+  /**
    * Set device coordinates (companion only)
    */
   async setCoords(lat: number, lon: number): Promise<boolean> {

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -565,6 +565,15 @@ export class MeshCoreNativeBackend extends EventEmitter {
         if (this.cachedSelfInfo) this.cachedSelfInfo.name = String(params.name ?? '');
         return { ok: true };
 
+      case 'set_tx_power': {
+        const power = Number(params.power);
+        await c.setTxPower(power);
+        if (this.cachedSelfInfo) {
+          this.cachedSelfInfo.txPower = power;
+        }
+        return { ok: true };
+      }
+
       case 'set_radio': {
         const freqMhz = Number(params.freq);
         const bwKhz = Number(params.bw);

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -1181,6 +1181,38 @@ router.post('/config/name', meshcoreDeviceLimiter, requireAuth(), requirePermiss
 });
 
 /**
+ * POST /api/meshcore/config/tx-power
+ * Set TX power (dBm)
+ * Requires authentication - modifies device radio configuration
+ */
+router.post('/config/tx-power', meshcoreDeviceLimiter, requireAuth(), requirePermission('configuration', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+  try {
+    const { power } = req.body;
+
+    if (power === undefined) {
+      return res.status(400).json({ success: false, error: 'power is required' });
+    }
+
+    const parsedPower = parseInt(power, 10);
+
+    if (isNaN(parsedPower) || parsedPower < 1 || parsedPower > 22) {
+      return res.status(400).json({ success: false, error: 'TX power must be between 1 and 22 dBm' });
+    }
+
+    const success = await managerFor(req).setTxPower(parsedPower);
+
+    if (success) {
+      res.json({ success: true, message: 'TX power updated' });
+    } else {
+      res.status(400).json({ success: false, error: 'Failed to update TX power' });
+    }
+  } catch (error) {
+    logger.error('[API] Error setting TX power:', error);
+    res.status(500).json({ success: false, error: 'Config error' });
+  }
+});
+
+/**
  * POST /api/meshcore/config/radio
  * Set radio parameters
  * Requires authentication - modifies device radio configuration


### PR DESCRIPTION
## Summary
- Adds TX power setting (1–22 dBm) for MeshCore companion and repeater devices
- Full stack: bridge command (`set_tx_power`) → manager method → API route (`POST /config/tx-power`) → frontend hook → Configuration page UI
- UI uses a range slider with dynamic max from the device's reported `maxTxPower`, with live dBm readout
- Companion nodes use the binary protocol (`connection.setTxPower()`); repeaters use the CLI (`set tx <dBm>`)

## Test plan
- [ ] Connect to a MeshCore companion — verify TX Power slider appears in Configuration tab between Radio Parameters and Telemetry
- [ ] Slider max should match device's reported `maxTxPower`
- [ ] Set a new value and click Save — verify "Saved" confirmation appears
- [ ] Refresh the page — verify the value persists (read back from SelfInfo)
- [ ] Verify permission gate: non-admin without `configuration:write` cannot change TX power
- [ ] CI passes (5625 tests, 0 failures locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)