### PR TITLE
fix(nodes): Copy NodeInfo button visibility and API routing

### DIFF
--- a/src/components/CopyNodeInfoModal/CopyNodeInfoModal.tsx
+++ b/src/components/CopyNodeInfoModal/CopyNodeInfoModal.tsx
@@ -106,7 +106,7 @@ export const CopyNodeInfoModal: React.FC<CopyNodeInfoModalProps> = ({
     api.getBaseUrl()
       .then(baseUrl =>
         fetch(
-          `${baseUrl}/api/v1/nodes/${nodeNum}/copy-candidates?sourceId=${encodeURIComponent(sourceId)}`,
+          `${baseUrl}/api/nodes/${nodeNum}/copy-candidates?sourceId=${encodeURIComponent(sourceId)}`,
           { credentials: 'include' },
         ),
       )
@@ -149,7 +149,7 @@ export const CopyNodeInfoModal: React.FC<CopyNodeInfoModalProps> = ({
     try {
       const baseUrl = await api.getBaseUrl();
       const res = await csrfFetch(
-        `${baseUrl}/api/v1/nodes/${nodeNum}/copy-nodeinfo`,
+        `${baseUrl}/api/nodes/${nodeNum}/copy-nodeinfo`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/components/MapNodePopupContent.tsx
+++ b/src/components/MapNodePopupContent.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { DeviceInfo } from '../types/device';
 import type { DbTraceroute } from '../services/database';
 import type { ResourceType } from '../types/permission';
-import { getHardwareModelName, getRoleName, parseNodeId, TRACEROUTE_DISPLAY_HOURS } from '../utils/nodeHelpers';
+import { getHardwareModelName, getRoleName, parseNodeId, isNodeComplete, TRACEROUTE_DISPLAY_HOURS } from '../utils/nodeHelpers';
 import { formatDateTime, formatRelativeTime } from '../utils/datetime';
 import { formatTracerouteRoute } from '../utils/traceroute';
 
@@ -19,6 +19,7 @@ interface MapNodePopupContentProps {
   traceroutes: DbTraceroute[];
   hasPermission: (resource: ResourceType, action: 'read' | 'write') => boolean;
   onDMNode: () => void;
+  onCopyNodeInfo?: () => void;
   onTraceroute?: () => void;
   connectionStatus?: string;
   tracerouteLoading?: string | null;
@@ -35,6 +36,7 @@ export const MapNodePopupContent: React.FC<MapNodePopupContentProps> = ({
   traceroutes,
   hasPermission,
   onDMNode,
+  onCopyNodeInfo,
   onTraceroute,
   connectionStatus,
   tracerouteLoading,
@@ -162,6 +164,11 @@ export const MapNodePopupContent: React.FC<MapNodePopupContentProps> = ({
           {node.user?.id && hasPermission('messages', 'read') && (
             <button className="node-popup-btn" onClick={onDMNode}>
               🔍 More Details
+            </button>
+          )}
+          {!isNodeComplete(node) && onCopyNodeInfo && hasPermission('nodes', 'write') && (
+            <button className="node-popup-btn" onClick={onCopyNodeInfo}>
+              📋 {t('nodes.copy_nodeinfo_title')}
             </button>
           )}
         </div>

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -2138,6 +2138,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                       traceroutes={traceroutes}
                       hasPermission={hasPermission}
                       onDMNode={handlePopupDMClick(node)}
+                      onCopyNodeInfo={() => setCopyNodeInfoTarget(node)}
                       onTraceroute={onTraceroute ? () => onTraceroute(node.user!.id) : undefined}
                       connectionStatus={connectionStatus}
                       tracerouteLoading={tracerouteLoading}

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1583,7 +1583,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                           💬
                         </button>
                       )}
-                      {!node.user?.longName && hasPermission('nodes', 'write') && (
+                      {!isNodeComplete(node) && hasPermission('nodes', 'write') && (
                         <button
                           className="dm-icon"
                           title={t('nodes.copy_nodeinfo')}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1182,6 +1182,46 @@ apiRouter.get('/nodes/active', optionalAuth(), async (req, res) => {
   }
 });
 
+// Copy NodeInfo from another source
+import { findCopyCandidates, copyNodeInfo } from './services/nodeInfoCopyService.js';
+
+apiRouter.get('/nodes/:nodeNum/copy-candidates', requirePermission('nodes', 'read'), async (req, res) => {
+  try {
+    const sourceId = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
+    if (!sourceId) {
+      return res.status(400).json({ error: 'sourceId query parameter is required' });
+    }
+    const nodeNum = Number(req.params.nodeNum);
+    if (isNaN(nodeNum)) {
+      return res.status(400).json({ error: 'nodeNum must be a number' });
+    }
+    const candidates = await findCopyCandidates(nodeNum, sourceId);
+    res.json({ success: true, data: candidates });
+  } catch (error) {
+    logger.error('Error getting copy candidates:', error);
+    res.status(500).json({ error: 'Failed to retrieve copy candidates' });
+  }
+});
+
+apiRouter.post('/nodes/:nodeNum/copy-nodeinfo', requirePermission('nodes', 'write'), async (req, res) => {
+  try {
+    const nodeNum = Number(req.params.nodeNum);
+    if (isNaN(nodeNum)) {
+      return res.status(400).json({ error: 'nodeNum must be a number' });
+    }
+    const { fromSourceId, toSourceId, pushToNodeDb } = req.body ?? {};
+    if (!fromSourceId || !toSourceId) {
+      return res.status(400).json({ error: 'fromSourceId and toSourceId are required' });
+    }
+    const result = await copyNodeInfo(nodeNum, fromSourceId, toSourceId, !!pushToNodeDb);
+    res.json({ success: true, data: result });
+  } catch (error: any) {
+    logger.error('Error copying node info:', error);
+    const status = error.message?.includes('not found') ? 404 : 500;
+    res.status(status).json({ error: error.message || 'Failed to copy node info' });
+  }
+});
+
 // Get position history for a node (for mobile node visualization)
 apiRouter.get('/nodes/:nodeId/position-history', optionalAuth(), async (req, res) => {
   try {

--- a/src/server/services/nodeInfoCopyService.test.ts
+++ b/src/server/services/nodeInfoCopyService.test.ts
@@ -85,15 +85,15 @@ describe('findCopyCandidates', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('sorts candidates by most recent updatedAt first', async () => {
+  it('sorts candidates by most fields filled first, then by updatedAt', async () => {
     h.getNodeMock
-      .mockResolvedValueOnce(makeNode({ longName: 'Older', updatedAt: 1000 })) // src-B
-      .mockResolvedValueOnce(makeNode({ longName: 'Newer', updatedAt: 3000 })); // src-C
+      .mockResolvedValueOnce(makeNode({ longName: 'Fewer', updatedAt: 3000 })) // src-B: 1 field
+      .mockResolvedValueOnce(makeNode({ longName: 'More', shortName: 'MR', hwModel: 42, updatedAt: 1000 })); // src-C: 3 fields
 
     const result = await findCopyCandidates(100, 'src-A');
 
     expect(result).toHaveLength(2);
-    expect(result[0].sourceName).toBe('Source C');
+    expect(result[0].sourceName).toBe('Source C'); // more fields wins despite older
     expect(result[1].sourceName).toBe('Source B');
   });
 });

--- a/src/server/services/nodeInfoCopyService.ts
+++ b/src/server/services/nodeInfoCopyService.ts
@@ -69,7 +69,7 @@ export async function findCopyCandidates(
     });
   }
 
-  candidates.sort((a, b) => b.node.updatedAt - a.node.updatedAt);
+  candidates.sort((a, b) => b.fieldsFilled - a.fieldsFilled || b.node.updatedAt - a.node.updatedAt);
   return candidates;
 }
 


### PR DESCRIPTION
## Summary
- Use `isNodeComplete()` for Copy NodeInfo button visibility instead of raw `longName` check — handles the `"Node !xxx"` firmware placeholder correctly
- Add copy-candidates and copy-nodeinfo endpoints to the internal `/api/nodes` router (session auth) — the v1 API requires Bearer tokens which the frontend doesn't use
- Add "📋 Copy NodeInfo" button to the map marker popup for incomplete nodes
- Sort copy candidates by most fields filled first (tiebreak: most recent `updatedAt`)

Follow-up to #3215

## Test plan
- [x] All 9 nodeInfoCopyService tests pass (updated sort-order test)
- [x] TypeScript compiles clean
- [ ] Manual: switch to an MQTT source, enable "Show Incomplete Nodes", click an incomplete node's map marker, verify "📋 Copy NodeInfo" button appears in popup
- [ ] Manual: click the button, verify the modal shows candidates sorted by most fields filled, confirm copy works

🤖 Generated with [Claude Code](https://claude.com/claude-code)