### PR TITLE
fix(sources): allow MQTT Bridge creation without existing Broker

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1114,12 +1114,7 @@ function DashboardInner() {
                   <option value="meshtastic_tcp">{t('source.form.type_meshtastic', 'Meshtastic (TCP)')}</option>
                   <option value="meshcore">{t('source.form.type_meshcore', 'MeshCore')}</option>
                   <option value="mqtt_broker">{t('source.form.type_mqtt_broker', 'Embedded MQTT Broker (devices connect here)')}</option>
-                  {/* Bridge requires a parent broker — only offer it once an
-                      embedded broker exists, otherwise the user lands on a
-                      form with an empty parent-broker dropdown. */}
-                  {sources.some((s) => s.type === 'mqtt_broker') && (
-                    <option value="mqtt_bridge">{t('source.form.type_mqtt_bridge', 'MQTT Bridge (forward to/from an upstream broker)')}</option>
-                  )}
+                  <option value="mqtt_bridge">{t('source.form.type_mqtt_bridge', 'MQTT Bridge (forward to/from an upstream broker)')}</option>
                 </select>
               </label>
             )}


### PR DESCRIPTION
## Summary
The source-type dropdown previously hid the "MQTT Bridge" option unless at least one `mqtt_broker` source already existed. This was a UX-only gate — the bridge already fully supports standalone mode via the "None — standalone client proxy" parent-broker option, the backend validates correctly with no `brokerSourceId`, and `mqttBridgeManager.attachParentBroker()` gracefully returns early when no broker is configured. Removing the gate lets users create standalone MQTT bridges for pure upstream monitoring without needing to set up an embedded broker first.

## Changes
- Removed the `sources.some(s => s.type === 'mqtt_broker')` conditional that gated the `mqtt_bridge` option in the source-type dropdown (`DashboardPage.tsx`)

## Issues Resolved
None

## Documentation Updates
No documentation changes needed — the standalone bridge mode was already supported and documented in the form's help text.

## Testing
- [ ] Unit tests pass (5627 tests, 3 pre-existing flaky failures in unrelated `mqttBrokerManager` zero-hop protobuf encode tests)
- [ ] TypeScript compiles cleanly
- [ ] Verify MQTT Bridge appears in source-type dropdown without any broker sources present
- [ ] Verify creating a standalone bridge (no parent broker) works end-to-end
- [ ] Verify creating a bridge with a parent broker still works when broker sources exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)