### PR TITLE
feat(meshcore): add Tier 1 protocol gap features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Features
 
+- feat(meshcore): add Tier 1 protocol gap features — contact remove/export/import, repeater neighbour list, device time sync, enhanced stats endpoints, and send-confirmed RTT event. Export produces `meshcore://` URLs; import accepts both raw hex and `meshcore://` URLs via a paste dialog in the Nodes view. Neighbour query uses the binary request protocol for structured data (pubkey prefix, SNR, last-heard). Sync Time button appears next to the RTC drift display in the Info view.
 - #3189 feat(mqtt-bridge): direction mode dropdown (`bidirectional` / `publish_only` / `subscribe_only`) — public/curated upstream brokers like `mqtt.meshtastic.org` accept gateway `PUBLISH` but ACL-reject `SUBSCRIBE`, and the bridge used to spam `permission-denied` warnings on every `SUBACK`. The new per-bridge **Mode** dropdown lets operators skip the upstream `subscribe()` call entirely (`publish_only`) or refuse outbound publishes (`subscribe_only`). Stored in the bridge `config` JSON blob — no schema migration; missing values are treated as `bidirectional` so existing rows keep working. Status now exposes the resolved mode and stops claiming "0 subscriptions denied" when none were ever attempted.
 
 

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -19,6 +19,9 @@ When a MeshCore source is connected, you get:
 - **Per-node remote telemetry** — Scheduled cross-mesh telemetry pulls from other MeshCore nodes, written into the same telemetry store as Meshtastic
 - **Radio preset selector** — Pick from the official MeshCore preset list instead of hand-tuning freq/bw/sf/cr
 - **Contact-detail panel** — Hops, RSSI/SNR, last heard, position, and the full public key shown next to DM threads
+- **Contact management** — Remove contacts from the device, export as `meshcore://` URLs for sharing, import from pasted URLs or hex blobs
+- **Repeater neighbour list** — Query a repeater's neighbour table with SNR and last-heard timestamps
+- **Device time sync** — One-click RTC sync from the Node Info page
 - **Telemetry-mode configuration** — Toggle base / location / environment telemetry on the device itself
 - **UI permission gating** — Write controls are disabled (not just rejected) for users without the right permission
 

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -324,7 +324,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
       const bytes = await onExportContact(publicKey);
       if (bytes) {
         const hex = bytes.map(b => b.toString(16).padStart(2, '0')).join('');
-        await navigator.clipboard.writeText(hex);
+        await navigator.clipboard.writeText(`meshcore://${hex}`);
         setExportSuccess(true);
         window.setTimeout(() => setExportSuccess(false), 2200);
       }

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -45,6 +45,16 @@ interface MeshCoreContactDetailPanelProps {
    *  When false the Edit Path… button is hidden even if onSetOutPath is
    *  supplied. The server route also enforces this for defense in depth. */
   advancedPathEditEnabled?: boolean;
+  /** Remove a contact from the device. Unset hides the Remove button. */
+  onRemoveContact?: (publicKey: string) => Promise<boolean>;
+  /** Export a contact as a signed advert blob. Unset hides the Export button. */
+  onExportContact?: (publicKey: string) => Promise<number[] | null>;
+  /** Query the neighbour list from a remote repeater. Unset hides the
+   *  Neighbours button. */
+  onGetNeighbours?: (publicKey: string, opts?: { count?: number }) => Promise<{
+    total: number;
+    neighbours: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }[];
+  } | null>;
   /** When provided AND the contact is a Repeater (advType=2) or Room
    *  Server (advType=3), the remote-administration console is mounted
    *  below the details block. Pass the four hook actions it needs; leave
@@ -73,6 +83,9 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   onShareContact,
   onSetOutPath,
   onTracePath,
+  onRemoveContact,
+  onExportContact,
+  onGetNeighbours,
   canWriteNodes = false,
   isCompanion = true,
   advancedPathEditEnabled = false,
@@ -94,6 +107,21 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   const [tracing, setTracing] = useState(false);
   const [traceResult, setTraceResult] = useState<TracePathResult | null>(null);
   const [traceError, setTraceError] = useState<string | null>(null);
+
+  // Remove contact state
+  const [removing, setRemoving] = useState(false);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+
+  // Export contact state
+  const [exporting, setExporting] = useState(false);
+  const [exportSuccess, setExportSuccess] = useState(false);
+
+  // Neighbours state
+  const [neighboursLoading, setNeighboursLoading] = useState(false);
+  const [neighboursData, setNeighboursData] = useState<{
+    total: number;
+    neighbours: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }[];
+  } | null>(null);
 
   // Path-editor modal state. Only mounted when advancedPathEditEnabled.
   const [editorOpen, setEditorOpen] = useState(false);
@@ -119,6 +147,12 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     setTracing(false);
     setTraceResult(null);
     setTraceError(null);
+    setRemoving(false);
+    setRemoveError(null);
+    setExporting(false);
+    setExportSuccess(false);
+    setNeighboursLoading(false);
+    setNeighboursData(null);
   }, [publicKey]);
 
   const name = contact?.advName || contact?.name || `${publicKey.substring(0, 8)}…`;
@@ -141,6 +175,12 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     !!onSetOutPath && canWriteNodes && isCompanion && advancedPathEditEnabled;
   const canShowTraceButton =
     !!onTracePath && canWriteNodes && isCompanion && pathKnown && pathLen! > 0;
+  const canShowRemoveButton =
+    !!onRemoveContact && canWriteNodes && isCompanion;
+  const canShowExportButton =
+    !!onExportContact && isCompanion;
+  const canShowNeighboursButton =
+    !!onGetNeighbours && isCompanion && advType === 2;
 
   const handleTracePath = async () => {
     if (!onTracePath || tracing) return;
@@ -257,6 +297,54 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     }
   };
 
+  const handleRemoveContact = async () => {
+    if (!onRemoveContact || removing) return;
+    const confirmMessage = t(
+      'meshcore.contact_details.remove_contact_confirm',
+      `Remove ${name} from the device's contact list? This cannot be undone.`,
+    );
+    if (typeof window !== 'undefined' && !window.confirm(confirmMessage)) return;
+    setRemoving(true);
+    setRemoveError(null);
+    try {
+      const ok = await onRemoveContact(publicKey);
+      if (!ok) {
+        setRemoveError(t('meshcore.contact_details.remove_contact_error', 'Remove contact failed.'));
+      }
+    } finally {
+      setRemoving(false);
+    }
+  };
+
+  const handleExportContact = async () => {
+    if (!onExportContact || exporting) return;
+    setExporting(true);
+    setExportSuccess(false);
+    try {
+      const bytes = await onExportContact(publicKey);
+      if (bytes) {
+        const hex = bytes.map(b => b.toString(16).padStart(2, '0')).join('');
+        await navigator.clipboard.writeText(hex);
+        setExportSuccess(true);
+        window.setTimeout(() => setExportSuccess(false), 2200);
+      }
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleGetNeighbours = async () => {
+    if (!onGetNeighbours || neighboursLoading) return;
+    setNeighboursLoading(true);
+    setNeighboursData(null);
+    try {
+      const result = await onGetNeighbours(publicKey, { count: 20 });
+      setNeighboursData(result);
+    } finally {
+      setNeighboursLoading(false);
+    }
+  };
+
   const getSignalClass = (value: number | undefined): string => {
     if (value === undefined || value === null) return '';
     if (value > 10) return 'signal-good';
@@ -344,8 +432,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
               available because the device retransmits the stored advert
               regardless of route state. Rendered in one card so the
               actions stay grouped at the bottom of the grid. */}
-          {(canShowResetButton || canShowShareButton || canShowEditButton || canShowTraceButton) &&
-            (canShowShareButton || canShowEditButton || canShowTraceButton || pathKnown) && (
+          {(canShowResetButton || canShowShareButton || canShowEditButton || canShowTraceButton || canShowRemoveButton || canShowExportButton || canShowNeighboursButton) &&
+            (canShowShareButton || canShowEditButton || canShowTraceButton || canShowRemoveButton || canShowExportButton || canShowNeighboursButton || pathKnown) && (
             <div className="node-detail-card node-detail-card-2col">
               <div className="node-detail-label">
                 {t('meshcore.contact_details.actions_label', 'Actions')}
@@ -400,15 +488,63 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                       : t('meshcore.contact_details.trace_path_button', 'Trace Path')}
                   </button>
                 )}
+                {canShowExportButton && (
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    onClick={handleExportContact}
+                    disabled={exporting}
+                    aria-label={t('meshcore.contact_details.export_contact_button', 'Export')}
+                  >
+                    {exporting
+                      ? t('meshcore.contact_details.export_contact_running', 'Exporting…')
+                      : t('meshcore.contact_details.export_contact_button', 'Export')}
+                  </button>
+                )}
+                {canShowNeighboursButton && (
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    onClick={handleGetNeighbours}
+                    disabled={neighboursLoading}
+                    aria-label={t('meshcore.contact_details.neighbours_button', 'Neighbours')}
+                  >
+                    {neighboursLoading
+                      ? t('meshcore.contact_details.neighbours_loading', 'Loading…')
+                      : t('meshcore.contact_details.neighbours_button', 'Neighbours')}
+                  </button>
+                )}
+                {canShowRemoveButton && (
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    onClick={handleRemoveContact}
+                    disabled={removing}
+                    style={{ color: 'var(--ctp-red)' }}
+                    aria-label={t('meshcore.contact_details.remove_contact_button', 'Remove')}
+                  >
+                    {removing
+                      ? t('meshcore.contact_details.remove_contact_running', 'Removing…')
+                      : t('meshcore.contact_details.remove_contact_button', 'Remove')}
+                  </button>
+                )}
                 {resetError && (
                   <span style={{ color: 'var(--ctp-red)' }} role="alert">{resetError}</span>
                 )}
                 {shareError && (
                   <span style={{ color: 'var(--ctp-red)' }} role="alert">{shareError}</span>
                 )}
+                {removeError && (
+                  <span style={{ color: 'var(--ctp-red)' }} role="alert">{removeError}</span>
+                )}
                 {shareSuccess && (
                   <span style={{ color: 'var(--ctp-green)' }} role="status">
                     {t('meshcore.contact_details.share_contact_success', 'Advert broadcast.')}
+                  </span>
+                )}
+                {exportSuccess && (
+                  <span style={{ color: 'var(--ctp-green)' }} role="status">
+                    {t('meshcore.contact_details.export_contact_success', 'Copied to clipboard.')}
                   </span>
                 )}
                 {traceError && (
@@ -464,6 +600,57 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     </tr>
                   </tbody>
                 </table>
+              </div>
+            </div>
+          )}
+
+          {/* Neighbours results */}
+          {neighboursData && (
+            <div className="node-detail-card node-detail-card-2col">
+              <div className="node-detail-label">
+                {t('meshcore.contact_details.neighbours_results', 'Neighbours')}
+                {' '}({neighboursData.total} {t('meshcore.contact_details.neighbours_total', 'total')})
+              </div>
+              <div className="node-detail-value">
+                {neighboursData.neighbours.length === 0 ? (
+                  <span style={{ opacity: 0.7 }}>
+                    {t('meshcore.contact_details.neighbours_none', 'No neighbours reported.')}
+                  </span>
+                ) : (
+                  <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: 'var(--font-mono, monospace)', fontSize: '0.9em' }}>
+                    <thead>
+                      <tr style={{ borderBottom: '1px solid var(--ctp-surface1, #45475a)' }}>
+                        <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem' }}>
+                          {t('meshcore.contact_details.neighbours_prefix', 'Key Prefix')}
+                        </th>
+                        <th style={{ textAlign: 'right', padding: '0.25rem 0.5rem' }}>
+                          {t('meshcore.contact_details.neighbours_snr', 'SNR')}
+                        </th>
+                        <th style={{ textAlign: 'right', padding: '0.25rem 0.5rem' }}>
+                          {t('meshcore.contact_details.neighbours_heard', 'Last Heard')}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {neighboursData.neighbours.map((n, i) => (
+                        <tr key={i}>
+                          <td style={{ padding: '0.25rem 0.5rem' }}>{n.publicKeyPrefix}</td>
+                          <td style={{ padding: '0.25rem 0.5rem', textAlign: 'right' }}
+                              className={getSignalClass(n.snr)}>
+                            {n.snr.toFixed(2)} dB
+                          </td>
+                          <td style={{ padding: '0.25rem 0.5rem', textAlign: 'right' }}>
+                            {n.heardSecondsAgo < 60
+                              ? `${n.heardSecondsAgo}s ago`
+                              : n.heardSecondsAgo < 3600
+                                ? `${Math.floor(n.heardSecondsAgo / 60)}m ago`
+                                : `${Math.floor(n.heardSecondsAgo / 3600)}h ago`}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
               </div>
             </div>
           )}

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -287,6 +287,9 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                 onShareContact={actions.shareContact}
                 onSetOutPath={actions.setContactOutPath}
                 onTracePath={actions.traceContactPath}
+                onRemoveContact={actions.removeContact}
+                onExportContact={actions.exportContact}
+                onGetNeighbours={actions.getNeighbours}
                 canWriteNodes={canWriteNodes && connected}
                 isCompanion={isCompanion}
                 advancedPathEditEnabled={advancedPathEditEnabled}

--- a/src/components/MeshCore/MeshCoreInfoView.tsx
+++ b/src/components/MeshCore/MeshCoreInfoView.tsx
@@ -118,6 +118,7 @@ interface MeshCoreInfoViewProps {
   baseUrl: string;
   sourceId: string;
   status: ConnectionStatus | null;
+  onSyncTime?: () => Promise<boolean>;
 }
 
 function fmtUptime(secs?: number): string {
@@ -159,7 +160,7 @@ function fmtFreq(mhz?: number): string {
   return `${mhz.toFixed(3)} MHz`;
 }
 
-export const MeshCoreInfoView: React.FC<MeshCoreInfoViewProps> = ({ baseUrl, sourceId, status }) => {
+export const MeshCoreInfoView: React.FC<MeshCoreInfoViewProps> = ({ baseUrl, sourceId, status, onSyncTime }) => {
   const { t } = useTranslation();
   const [hours, setHours] = useState<HoursOption>(24);
 
@@ -309,7 +310,19 @@ export const MeshCoreInfoView: React.FC<MeshCoreInfoViewProps> = ({ baseUrl, sou
               <dt>{t('meshcore.info.last_snr', 'Last SNR')}</dt>
               <dd>{fmtNumber(latest.lastSnr, ' dB')}</dd>
               <dt>{t('meshcore.info.rtc_drift', 'RTC drift vs server')}</dt>
-              <dd>{fmtDrift(latest.rtcDriftSecs)}</dd>
+              <dd style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                {fmtDrift(latest.rtcDriftSecs)}
+                {onSyncTime && (
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    style={{ fontSize: '0.8em', padding: '0.15rem 0.5rem' }}
+                    onClick={() => void onSyncTime()}
+                  >
+                    {t('meshcore.info.sync_time_button', 'Sync')}
+                  </button>
+                )}
+              </dd>
               <dt>{t('meshcore.info.last_poll', 'Last poll')}</dt>
               <dd>{new Date(latest.timestamp).toLocaleString()}</dd>
             </dl>

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MeshCoreNode } from './hooks/useMeshCore';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
@@ -14,6 +14,7 @@ const DEVICE_TYPE_KEYS: Record<number, string> = {
 interface MeshCoreNodesViewProps {
   nodes: MeshCoreNode[];
   contacts: MeshCoreContact[];
+  onImportContact?: (advertBytes: number[]) => Promise<boolean>;
 }
 
 interface MergedRow {
@@ -89,11 +90,42 @@ function sortRows(rows: MergedRow[], field: SortField, direction: SortDirection)
 export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
   nodes,
   contacts,
+  onImportContact,
 }) => {
   const { t } = useTranslation();
   const [selected, setSelected] = useState<string | null>(null);
   const [sortField, setSortField] = useState<SortField>('lastHeard');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [importHex, setImportHex] = useState('');
+  const [importing, setImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+
+  const handleImport = useCallback(async () => {
+    if (!onImportContact || importing) return;
+    const hex = importHex.trim().replace(/\s+/g, '');
+    if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length < 2 || hex.length % 2 !== 0) {
+      setImportError(t('meshcore.import_contact.invalid_hex', 'Invalid hex — paste the full exported contact blob.'));
+      return;
+    }
+    const bytes: number[] = [];
+    for (let i = 0; i < hex.length; i += 2) {
+      bytes.push(parseInt(hex.substring(i, i + 2), 16));
+    }
+    setImporting(true);
+    setImportError(null);
+    try {
+      const ok = await onImportContact(bytes);
+      if (ok) {
+        setImportDialogOpen(false);
+        setImportHex('');
+      } else {
+        setImportError(t('meshcore.import_contact.failed', 'Import failed — invalid advert data or device not connected.'));
+      }
+    } finally {
+      setImporting(false);
+    }
+  }, [onImportContact, importing, importHex, t]);
 
   const merged = useMemo(() => mergeNodesAndContacts(nodes, contacts), [nodes, contacts]);
   const rows = useMemo(
@@ -107,6 +139,16 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
         <div className="meshcore-list-pane-header">
           <span>{t('meshcore.nav.nodes', 'Nodes')}</span>
           <span className="pane-count">{rows.length}</span>
+          {onImportContact && (
+            <button
+              type="button"
+              className="btn-secondary"
+              style={{ fontSize: '0.8em', padding: '0.15rem 0.5rem', marginLeft: '0.5rem' }}
+              onClick={() => { setImportHex(''); setImportError(null); setImportDialogOpen(true); }}
+            >
+              {t('meshcore.import_contact.button', 'Import')}
+            </button>
+          )}
           <div className="sort-controls meshcore-sort-controls">
             <select
               aria-label={t('meshcore.sort_by', 'Sort by')}
@@ -170,6 +212,87 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
       <div className="meshcore-main-pane">
         <MeshCoreMap contacts={contacts} selectedPublicKey={selected} />
       </div>
+      {importDialogOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={t('meshcore.import_contact.dialog_title', 'Import Contact')}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.55)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1000,
+          }}
+          onClick={(e) => { if (e.target === e.currentTarget && !importing) setImportDialogOpen(false); }}
+        >
+          <div
+            style={{
+              background: 'var(--ctp-base, #1e1e2e)',
+              color: 'var(--ctp-text, #cdd6f4)',
+              padding: '1.25rem 1.5rem',
+              borderRadius: '8px',
+              maxWidth: '32rem',
+              width: '90%',
+              boxShadow: '0 4px 20px rgba(0,0,0,0.5)',
+            }}
+          >
+            <h3 style={{ marginTop: 0 }}>
+              {t('meshcore.import_contact.dialog_title', 'Import Contact')}
+            </h3>
+            <p style={{ marginBottom: '0.75rem' }}>
+              {t(
+                'meshcore.import_contact.dialog_hint',
+                'Paste the hex-encoded signed advert blob exported from another node.',
+              )}
+            </p>
+            <textarea
+              value={importHex}
+              onChange={(e) => setImportHex(e.target.value)}
+              disabled={importing}
+              placeholder="e.g. 04a3b7c2d1..."
+              rows={4}
+              style={{
+                width: '100%',
+                padding: '0.5rem',
+                marginBottom: '0.5rem',
+                fontFamily: 'var(--font-mono, monospace)',
+                fontSize: '0.85em',
+                boxSizing: 'border-box',
+                resize: 'vertical',
+              }}
+              autoFocus
+            />
+            {importError && (
+              <div style={{ color: 'var(--ctp-red)', marginBottom: '0.75rem' }} role="alert">
+                {importError}
+              </div>
+            )}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+              <button
+                type="button"
+                className="btn-secondary"
+                onClick={() => setImportDialogOpen(false)}
+                disabled={importing}
+              >
+                {t('meshcore.import_contact.cancel', 'Cancel')}
+              </button>
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={handleImport}
+                disabled={importing || importHex.trim().length === 0}
+              >
+                {importing
+                  ? t('meshcore.import_contact.importing', 'Importing…')
+                  : t('meshcore.import_contact.import', 'Import')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -103,7 +103,7 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
 
   const handleImport = useCallback(async () => {
     if (!onImportContact || importing) return;
-    const hex = importHex.trim().replace(/\s+/g, '');
+    const hex = importHex.trim().replace(/^meshcore:\/\//i, '').replace(/\s+/g, '');
     if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length < 2 || hex.length % 2 !== 0) {
       setImportError(t('meshcore.import_contact.invalid_hex', 'Invalid hex — paste the full exported contact blob.'));
       return;
@@ -245,7 +245,7 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
             <p style={{ marginBottom: '0.75rem' }}>
               {t(
                 'meshcore.import_contact.dialog_hint',
-                'Paste the hex-encoded signed advert blob exported from another node.',
+                'Paste the hex-encoded signed advert blob or a meshcore:// URL exported from another node.',
               )}
             </p>
             <textarea

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -83,6 +83,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
             <MeshCoreNodesView
               nodes={nodes}
               contacts={contacts}
+              onImportContact={actions.importContact}
             />
           )}
           {view === 'channels' && (

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -119,7 +119,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
             <MeshCoreTelemetryView baseUrl={baseUrl} />
           )}
           {view === 'info' && (
-            <MeshCoreInfoView baseUrl={baseUrl} sourceId={sourceId} status={status} />
+            <MeshCoreInfoView baseUrl={baseUrl} sourceId={sourceId} status={status} onSyncTime={actions.syncDeviceTime} />
           )}
           {view === 'configuration' && (
             <MeshCoreConfigurationView

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -109,6 +109,22 @@ export interface MeshCoreActions {
   /** Send a trace-path diagnostic along the contact's cached forwarding
    *  route and return per-hop SNR data. Resolves `null` on failure. */
   traceContactPath: (publicKey: string) => Promise<TracePathResult | null>;
+  /** Remove a contact from the device's contact list. Resolves `true` when
+   *  the device ACKed the removal; `false` for any error. */
+  removeContact: (publicKey: string) => Promise<boolean>;
+  /** Export a contact as a signed advert blob for sharing. Pass 'self' to
+   *  export the local node's identity. Returns the raw bytes or null. */
+  exportContact: (publicKey: string) => Promise<number[] | null>;
+  /** Import a contact from a signed advert blob. Refreshes contacts on
+   *  success. */
+  importContact: (advertBytes: number[]) => Promise<boolean>;
+  /** Sync the device's RTC to the server's current time. */
+  syncDeviceTime: () => Promise<boolean>;
+  /** Query the neighbour list from a remote repeater. */
+  getNeighbours: (publicKey: string, opts?: { count?: number; offset?: number; orderBy?: number }) => Promise<{
+    total: number;
+    neighbours: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }[];
+  } | null>;
   sendAdvert: () => Promise<void>;
   sendMessage: (text: string, toPublicKey?: string, channelIdx?: number) => Promise<boolean>;
   setDeviceName: (name: string) => Promise<boolean>;
@@ -761,6 +777,100 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch]);
 
+  const removeContact = useCallback(async (publicKey: string): Promise<boolean> => {
+    try {
+      const response = await csrfFetch(
+        `${mcPrefix}/contacts/${encodeURIComponent(publicKey)}`,
+        { method: 'DELETE' },
+      );
+      const data = await response.json();
+      if (!data.success) {
+        setError(data.error || 'Failed to remove contact');
+        return false;
+      }
+      setContacts(prev => prev.filter(c => c.publicKey !== publicKey));
+      contactsRef.current.delete(publicKey);
+      recomputeNodes();
+      return true;
+    } catch (_err) {
+      setError('Failed to remove contact');
+      return false;
+    }
+  }, [mcPrefix, csrfFetch, recomputeNodes]);
+
+  const exportContact = useCallback(async (publicKey: string): Promise<number[] | null> => {
+    try {
+      const response = await csrfFetch(
+        `${mcPrefix}/contacts/${encodeURIComponent(publicKey)}/export`,
+      );
+      const data = await response.json();
+      if (!data.success) {
+        setError(data.error || 'Failed to export contact');
+        return null;
+      }
+      return data.data?.advertBytes ?? null;
+    } catch (_err) {
+      setError('Failed to export contact');
+      return null;
+    }
+  }, [mcPrefix, csrfFetch]);
+
+  const importContact = useCallback(async (advertBytes: number[]): Promise<boolean> => {
+    try {
+      const response = await csrfFetch(`${mcPrefix}/contacts/import`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ advertBytes }),
+      });
+      const data = await response.json();
+      if (!data.success) {
+        setError(data.error || 'Failed to import contact');
+        return false;
+      }
+      await refreshContacts();
+      return true;
+    } catch (_err) {
+      setError('Failed to import contact');
+      return false;
+    }
+  }, [mcPrefix, csrfFetch, refreshContacts]);
+
+  const syncDeviceTime = useCallback(async (): Promise<boolean> => {
+    try {
+      const response = await csrfFetch(`${mcPrefix}/config/sync-time`, { method: 'POST' });
+      const data = await response.json();
+      if (!data.success) {
+        setError(data.error || 'Failed to sync device time');
+        return false;
+      }
+      return true;
+    } catch (_err) {
+      setError('Failed to sync device time');
+      return false;
+    }
+  }, [mcPrefix, csrfFetch]);
+
+  const getNeighbours = useCallback(async (
+    publicKey: string,
+    opts?: { count?: number; offset?: number; orderBy?: number },
+  ) => {
+    try {
+      const params = new URLSearchParams();
+      if (opts?.count) params.set('count', String(opts.count));
+      if (opts?.offset) params.set('offset', String(opts.offset));
+      if (opts?.orderBy !== undefined) params.set('orderBy', String(opts.orderBy));
+      const qs = params.toString();
+      const response = await csrfFetch(
+        `${mcPrefix}/contacts/${encodeURIComponent(publicKey)}/neighbours${qs ? '?' + qs : ''}`,
+      );
+      const data = await response.json();
+      if (!data.success) return null;
+      return data.data as { total: number; neighbours: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }[] };
+    } catch (_err) {
+      return null;
+    }
+  }, [mcPrefix, csrfFetch]);
+
   const sendAdvert = useCallback(async () => {
     try {
       const response = await csrfFetch(`${mcPrefix}/advert`, { method: 'POST' });
@@ -1028,6 +1138,11 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       shareContact,
       setContactOutPath,
       traceContactPath,
+      removeContact,
+      exportContact,
+      importContact,
+      syncDeviceTime,
+      getNeighbours,
       sendAdvert,
       sendMessage,
       setDeviceName,

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -704,6 +704,19 @@ class MeshCoreManager extends EventEmitter {
           `[MeshCore:${this.sourceId}] Unmatched CLI reply from ${prefix}: ${replyText.substring(0, 80)}`,
         );
       }
+    } else if (event_type === 'send_confirmed') {
+      this.emit('send_confirmed', {
+        sourceId: this.sourceId,
+        ackCode: data.ack_code,
+        roundTripMs: data.round_trip_ms,
+      });
+      dataEventEmitter.emitMeshCoreSendConfirmed(
+        { ackCode: data.ack_code, roundTripMs: data.round_trip_ms },
+        this.sourceId,
+      );
+      logger.debug(
+        `[MeshCore:${this.sourceId}] Send confirmed: RTT=${data.round_trip_ms}ms`,
+      );
     } else if (event_type === 'contact_path_updated') {
       const publicKey: string = data.public_key;
       if (publicKey) {
@@ -1558,6 +1571,152 @@ class MeshCoreManager extends EventEmitter {
     } catch (error) {
       logger.error('[MeshCore] setContactOutPath threw:', error);
       return false;
+    }
+  }
+
+  /**
+   * Remove a contact from the device's contact list. On success, the
+   * in-memory contact map and meshcore_nodes row are cleared. Companion only.
+   */
+  async removeContact(publicKey: string): Promise<boolean> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
+      logger.warn('[MeshCore] Remove-contact requires Companion firmware');
+      return false;
+    }
+    if (!this.connected) return false;
+    try {
+      const response = await this.sendBridgeCommand('remove_contact', { public_key: publicKey });
+      if (!response.success) {
+        logger.warn(`[MeshCore] remove_contact failed for ${publicKey}: ${response.error}`);
+        return false;
+      }
+      this.contacts.delete(publicKey);
+      try {
+        await databaseService.meshcore.deleteNode(publicKey, this.sourceId);
+      } catch (err) {
+        logger.warn(`[MeshCore:${this.sourceId}] deleteNode after remove_contact failed: ${(err as Error).message}`);
+      }
+      this.emit('contact_removed', { sourceId: this.sourceId, publicKey });
+      dataEventEmitter.emitMeshCoreContactUpdated({ publicKey, removed: true } as any, this.sourceId);
+      logger.info(`[MeshCore] Removed contact ${publicKey.substring(0, 16)}…`);
+      return true;
+    } catch (error) {
+      logger.error('[MeshCore] removeContact threw:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Export a contact as a signed advert blob (for QR/URL/NFC sharing).
+   * Pass null publicKey to export the local node's own identity.
+   * Returns the raw advert bytes as a number array, or null on failure.
+   */
+  async exportContact(publicKey: string | null): Promise<number[] | null> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
+      logger.warn('[MeshCore] Export-contact requires Companion firmware');
+      return null;
+    }
+    if (!this.connected) return null;
+    try {
+      const params: Record<string, unknown> = {};
+      if (publicKey) params.public_key = publicKey;
+      const response = await this.sendBridgeCommand('export_contact', params);
+      if (!response.success) {
+        logger.warn(`[MeshCore] export_contact failed: ${response.error}`);
+        return null;
+      }
+      const bytes = response.data?.advert_bytes;
+      if (!Array.isArray(bytes)) return null;
+      logger.info(`[MeshCore] Exported contact ${publicKey ? publicKey.substring(0, 16) + '…' : '(self)'} (${bytes.length}B)`);
+      return bytes;
+    } catch (error) {
+      logger.error('[MeshCore] exportContact threw:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Import a contact from a signed advert blob. On success, refreshes
+   * the contact list so the new contact appears in the UI.
+   */
+  async importContact(advertBytes: number[]): Promise<boolean> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
+      logger.warn('[MeshCore] Import-contact requires Companion firmware');
+      return false;
+    }
+    if (!this.connected) return false;
+    try {
+      const response = await this.sendBridgeCommand('import_contact', { advert_bytes: advertBytes });
+      if (!response.success) {
+        logger.warn(`[MeshCore] import_contact failed: ${response.error}`);
+        return false;
+      }
+      await this.refreshContacts();
+      logger.info(`[MeshCore] Imported contact (${advertBytes.length}B advert)`);
+      return true;
+    } catch (error) {
+      logger.error('[MeshCore] importContact threw:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Sync the device's RTC to the server's clock. Companion only.
+   */
+  async syncDeviceTime(): Promise<boolean> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
+      logger.warn('[MeshCore] Sync-device-time requires Companion firmware');
+      return false;
+    }
+    if (!this.connected) return false;
+    try {
+      const response = await this.sendBridgeCommand('set_device_time', {});
+      if (!response.success) {
+        logger.warn(`[MeshCore] set_device_time failed: ${response.error}`);
+        return false;
+      }
+      logger.info(`[MeshCore:${this.sourceId}] Device time synced to server clock`);
+      return true;
+    } catch (error) {
+      logger.error('[MeshCore] syncDeviceTime threw:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Query the neighbour list from a remote repeater node. Returns an array
+   * of neighbour entries with pubkey prefix, last-heard age, and SNR.
+   * Requires firmware v1.9.0+ on the target repeater.
+   */
+  async getNeighbours(publicKey: string, opts?: { count?: number; offset?: number; orderBy?: number }): Promise<{
+    total: number;
+    neighbours: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }[];
+  } | null> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) return null;
+    if (!this.connected) return null;
+    try {
+      const response = await this.sendBridgeCommand('get_neighbours', {
+        public_key: publicKey,
+        count: opts?.count ?? 10,
+        offset: opts?.offset ?? 0,
+        order_by: opts?.orderBy ?? 0,
+      }, 30000);
+      if (!response.success) {
+        logger.warn(`[MeshCore] get_neighbours failed for ${publicKey}: ${response.error}`);
+        return null;
+      }
+      const d = response.data ?? {};
+      return {
+        total: d.total ?? 0,
+        neighbours: (d.neighbours ?? []).map((n: any) => ({
+          publicKeyPrefix: n.public_key_prefix,
+          heardSecondsAgo: n.heard_seconds_ago,
+          snr: n.snr,
+        })),
+      };
+    } catch (error) {
+      logger.error('[MeshCore] getNeighbours threw:', error);
+      return null;
     }
   }
 

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -340,6 +340,14 @@ export class MeshCoreNativeBackend extends EventEmitter {
       });
     });
 
+    // SendConfirmed → send_confirmed (message ACK with round-trip time)
+    this.connection.on(PushCodes.SendConfirmed, (push: any) => {
+      this.emitBridgeEvent('send_confirmed', {
+        ack_code: push.ackCode,
+        round_trip_ms: push.roundTrip,
+      });
+    });
+
     // MsgWaiting → drain via syncNextMessage; meshcore.js does NOT auto-drain
     // the way python-meshcore did. Pulling the messages causes ContactMsgRecv
     // / ChannelMsgRecv to fire normally.
@@ -748,6 +756,60 @@ export class MeshCoreNativeBackend extends EventEmitter {
         }
         await c.deleteChannel(idx);
         return { ok: true };
+      }
+
+      case 'remove_contact': {
+        const publicKey = await this.resolvePublicKey(params.public_key as string);
+        if (!publicKey) throw new Error('Remove-contact target not found');
+        await c.removeContact(publicKey);
+        return { ok: true };
+      }
+
+      case 'export_contact': {
+        const publicKey = params.public_key
+          ? await this.resolvePublicKey(params.public_key as string)
+          : null;
+        const response = await c.exportContact(publicKey ?? undefined);
+        return {
+          advert_bytes: response?.advertPacketBytes
+            ? Array.from(response.advertPacketBytes as Uint8Array)
+            : null,
+        };
+      }
+
+      case 'import_contact': {
+        const bytes = params.advert_bytes as number[] | Uint8Array;
+        if (!bytes) throw new Error('import_contact requires advert_bytes');
+        const arr = bytes instanceof Uint8Array ? bytes : Uint8Array.from(bytes);
+        await c.importContact(arr);
+        return { ok: true };
+      }
+
+      case 'set_device_time': {
+        const epoch = params.epoch as number | undefined;
+        if (epoch !== undefined) {
+          await c.setDeviceTime(epoch);
+        } else {
+          await c.syncDeviceTime();
+        }
+        return { ok: true };
+      }
+
+      case 'get_neighbours': {
+        const publicKey = await this.resolvePublicKey(params.public_key as string);
+        if (!publicKey) throw new Error('Neighbours target not found');
+        const count = typeof params.count === 'number' ? params.count : 10;
+        const offset = typeof params.offset === 'number' ? params.offset : 0;
+        const orderBy = typeof params.order_by === 'number' ? params.order_by : 0;
+        const result = await c.getNeighbours(publicKey, count, offset, orderBy, 8);
+        return {
+          total: result.totalNeighboursCount,
+          neighbours: (result.neighbours ?? []).map((n: any) => ({
+            public_key_prefix: bytesToHex(n.publicKeyPrefix),
+            heard_seconds_ago: n.heardSecondsAgo,
+            snr: n.snr,
+          })),
+        };
       }
 
       case 'shutdown':

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -567,6 +567,221 @@ router.post(
 );
 
 /**
+ * DELETE /api/sources/:id/meshcore/contacts/:publicKey
+ *
+ * Remove a contact from the device's contact list. Deletes the in-memory
+ * entry, the meshcore_nodes DB row, and fires a contact-updated push so
+ * the UI removes the row without a full refresh.
+ */
+router.delete(
+  '/contacts/:publicKey',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const publicKey = req.params.publicKey;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({
+          success: false,
+          error: 'Invalid public key — must be 64-char hex',
+        });
+      }
+      const ok = await managerFor(req).removeContact(publicKey);
+      if (!ok) {
+        return res.status(409).json({
+          success: false,
+          error: 'Remove contact failed — contact may be unknown, source disconnected, or not a Companion device',
+        });
+      }
+      res.json({ success: true });
+    } catch (error) {
+      logger.error('[API] Error removing contact:', error);
+      res.status(500).json({ success: false, error: 'Failed to remove contact' });
+    }
+  },
+);
+
+/**
+ * GET /api/sources/:id/meshcore/contacts/:publicKey/export
+ *
+ * Export a contact as a signed advert blob suitable for sharing via
+ * QR code, NFC, or meshcore:// URL. Returns the raw bytes as a JSON
+ * number array. Omit :publicKey (use 'self') to export the local node.
+ */
+router.get(
+  '/contacts/:publicKey/export',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const publicKey = req.params.publicKey;
+      const isSelf = publicKey === 'self';
+      if (!isSelf && !isValidPublicKey(publicKey)) {
+        return res.status(400).json({
+          success: false,
+          error: 'Invalid public key — must be 64-char hex or "self"',
+        });
+      }
+      const bytes = await managerFor(req).exportContact(isSelf ? null : publicKey);
+      if (!bytes) {
+        return res.status(409).json({
+          success: false,
+          error: 'Export contact failed — contact may be unknown, source disconnected, or not a Companion device',
+        });
+      }
+      res.json({ success: true, data: { advertBytes: bytes } });
+    } catch (error) {
+      logger.error('[API] Error exporting contact:', error);
+      res.status(500).json({ success: false, error: 'Failed to export contact' });
+    }
+  },
+);
+
+/**
+ * POST /api/sources/:id/meshcore/contacts/import
+ *
+ * Import a contact from a signed advert blob. Refreshes contacts on
+ * success. Body: { advertBytes: number[] }
+ */
+router.post(
+  '/contacts/import',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const advertBytes = (req.body ?? {}).advertBytes;
+      if (!Array.isArray(advertBytes) || advertBytes.length === 0) {
+        return res.status(400).json({
+          success: false,
+          error: 'Body must include advertBytes as a non-empty number array',
+        });
+      }
+      if (advertBytes.some((b: unknown) => typeof b !== 'number' || b < 0 || b > 255)) {
+        return res.status(400).json({
+          success: false,
+          error: 'advertBytes must contain only integers 0-255',
+        });
+      }
+      const ok = await managerFor(req).importContact(advertBytes);
+      if (!ok) {
+        return res.status(409).json({
+          success: false,
+          error: 'Import contact failed — may be invalid advert data, source disconnected, or not a Companion device',
+        });
+      }
+      res.json({ success: true });
+    } catch (error) {
+      logger.error('[API] Error importing contact:', error);
+      res.status(500).json({ success: false, error: 'Failed to import contact' });
+    }
+  },
+);
+
+/**
+ * GET /api/sources/:id/meshcore/contacts/:publicKey/neighbours
+ *
+ * Query the neighbour list from a remote repeater node. Returns an array
+ * of { publicKeyPrefix, heardSecondsAgo, snr } entries. Requires the
+ * target to be a repeater running firmware v1.9.0+.
+ *
+ * Query params: count (default 10), offset (default 0),
+ *   orderBy (0=newest, 1=oldest, 2=strongest, 3=weakest)
+ */
+router.get(
+  '/contacts/:publicKey/neighbours',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const publicKey = req.params.publicKey;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({
+          success: false,
+          error: 'Invalid public key — must be 64-char hex',
+        });
+      }
+      const count = Math.min(Math.max(parseInt(req.query.count as string || '10', 10) || 10, 1), 50);
+      const offset = Math.max(parseInt(req.query.offset as string || '0', 10) || 0, 0);
+      const orderBy = Math.min(Math.max(parseInt(req.query.orderBy as string || '0', 10) || 0, 0), 3);
+      const result = await managerFor(req).getNeighbours(publicKey, { count, offset, orderBy });
+      if (!result) {
+        return res.status(409).json({
+          success: false,
+          error: 'Get neighbours failed — source disconnected, not a Companion, or firmware too old',
+        });
+      }
+      res.json({ success: true, data: result });
+    } catch (error) {
+      logger.error('[API] Error getting neighbours:', error);
+      res.status(500).json({ success: false, error: 'Failed to get neighbours' });
+    }
+  },
+);
+
+/**
+ * POST /api/sources/:id/meshcore/config/sync-time
+ *
+ * Sync the device's RTC to the server's current time. Companion only.
+ */
+router.post(
+  '/config/sync-time',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('configuration', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const ok = await managerFor(req).syncDeviceTime();
+      if (!ok) {
+        return res.status(409).json({
+          success: false,
+          error: 'Sync time failed — source disconnected or not a Companion device',
+        });
+      }
+      res.json({ success: true, message: 'Device time synced' });
+    } catch (error) {
+      logger.error('[API] Error syncing device time:', error);
+      res.status(500).json({ success: false, error: 'Failed to sync time' });
+    }
+  },
+);
+
+/**
+ * GET /api/sources/:id/meshcore/stats/:type
+ *
+ * Read local-node stats (core, radio, or packets). These hit the directly-
+ * connected companion node over the local link — no RF transmission.
+ */
+router.get(
+  '/stats/:type',
+  optionalAuth(),
+  requirePermission('connection', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const manager = managerFor(req);
+      const type = req.params.type;
+      let data: any = null;
+      if (type === 'core') data = await manager.getStatsCore();
+      else if (type === 'radio') data = await manager.getStatsRadio();
+      else if (type === 'packets') data = await manager.getStatsPackets();
+      else {
+        return res.status(400).json({ success: false, error: 'type must be core, radio, or packets' });
+      }
+      if (!data) {
+        return res.status(409).json({ success: false, error: 'Stats unavailable — source disconnected or not a Companion' });
+      }
+      res.json({ success: true, data });
+    } catch (error) {
+      logger.error('[API] Error getting stats:', error);
+      res.status(500).json({ success: false, error: 'Failed to get stats' });
+    }
+  },
+);
+
+/**
  * GET /api/meshcore/messages
  * Get recent messages. Optional ?since=<ms-timestamp> returns only messages newer than that time.
  */

--- a/src/server/services/dataEventEmitter.ts
+++ b/src/server/services/dataEventEmitter.ts
@@ -26,7 +26,8 @@ export type DataEventType =
   | 'meshcore:message'
   | 'meshcore:contact:updated'
   | 'meshcore:status:updated'
-  | 'meshcore:local-node:updated';
+  | 'meshcore:local-node:updated'
+  | 'meshcore:send-confirmed';
 
 export interface DataEvent {
   type: DataEventType;
@@ -334,6 +335,20 @@ class DataEventEmitter extends EventEmitter {
     };
     this.emit('data', event);
     logger.debug(`[DataEventEmitter] MeshCore status: ${data.connected ? 'connected' : 'disconnected'} (source: ${sourceId})`);
+  }
+
+  /**
+   * Emit a MeshCore send-confirmed event (message ACK with round-trip time)
+   */
+  emitMeshCoreSendConfirmed(data: { ackCode: number; roundTripMs: number }, sourceId: string): void {
+    const event: DataEvent = {
+      type: 'meshcore:send-confirmed',
+      data: { sourceId, ...data },
+      timestamp: Date.now(),
+      sourceId,
+    };
+    this.emit('data', event);
+    logger.debug(`[DataEventEmitter] MeshCore send confirmed: RTT=${data.roundTripMs}ms (source: ${sourceId})`);
   }
 
   /**


### PR DESCRIPTION
## Summary

Evaluates MeshMonitor's MeshCore implementation against the full MeshCore protocol surface and fills the highest-impact gaps. These are features that the MeshCore companion protocol supports but MeshMonitor previously had no UI or API for — leaving users unable to manage contacts, share node identities, inspect repeater topology, or sync device clocks without resorting to external tools.

## Changes

### Contact Management
- **Remove Contact** — `DELETE /api/sources/:id/meshcore/contacts/:publicKey` with red "Remove" button + confirmation dialog in contact detail panel
- **Export Contact** — `GET /api/sources/:id/meshcore/contacts/:publicKey/export` copies a `meshcore://` URL to clipboard (compatible with the official sharing scheme)
- **Import Contact** — `POST /api/sources/:id/meshcore/contacts/import` with paste dialog in Nodes view accepting both raw hex and `meshcore://` URLs

### Network Diagnostics
- **Repeater Neighbour List** — `GET /api/sources/:id/meshcore/contacts/:publicKey/neighbours` queries a repeater's neighbour table via the binary request protocol. "Neighbours" button appears on repeater contacts, renders a table with key prefix, SNR, and last-heard age
- **Enhanced Stats API** — `GET /api/sources/:id/meshcore/stats/:type` (core/radio/packets) exposes the existing manager stats methods as REST endpoints

### Device Management
- **Device Time Sync** — `POST /api/sources/:id/meshcore/config/sync-time` syncs the device RTC to the server clock. "Sync" button appears next to the RTC drift display in the Info view

### Event Infrastructure
- **Send Confirmed RTT** — Wires `PUSH_CODE_SEND_CONFIRMED` (0x82) through the native backend → manager → data event emitter as `meshcore:send-confirmed`, carrying round-trip time in milliseconds for real-time delivery tracking

### Full Stack Per Feature
Each feature is implemented across all layers: meshcore.js dispatch (native backend) → manager method → Express route → React hook action → UI component.

## Issues Resolved

None — this is a feature gap analysis and implementation, not a bug fix.

## Documentation Updates

- `docs/features/meshcore.md` — Added contact management, neighbour list, and device time sync to the feature overview
- `CHANGELOG.md` — Added entry under `[Unreleased] > Features`

## Testing

- [x] Unit tests pass (5653 tests, 0 failures)
- [x] TypeScript compiles cleanly
- [ ] Connect a MeshCore Companion and verify Remove/Export/Import contact workflow
- [ ] Connect a MeshCore Companion with a Repeater contact and verify Neighbours button returns data
- [ ] Verify Sync Time button appears next to RTC drift in Info view and updates the device clock
- [ ] Verify Export produces `meshcore://` URL and Import accepts it back

🤖 Generated with [Claude Code](https://claude.com/claude-code)