### PR TITLE
fix(meshcore): clipboard fallback for non-HTTPS contexts

### DIFF
--- a/src/components/MeshCore/MeshCoreConfigurationView.tsx
+++ b/src/components/MeshCore/MeshCoreConfigurationView.tsx
@@ -588,7 +588,11 @@ const MeshCoreDeviceManagement: React.FC<{
 
   const handleCopyKey = async () => {
     if (!exportedKey) return;
-    await navigator.clipboard.writeText(exportedKey);
+    try {
+      await navigator.clipboard.writeText(exportedKey);
+    } catch {
+      window.prompt('Copy this private key:', exportedKey);
+    }
   };
 
   const handleImportKey = async () => {

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -323,8 +323,15 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     try {
       const bytes = await onExportContact(publicKey);
       if (bytes) {
-        const hex = bytes.map(b => b.toString(16).padStart(2, '0')).join('');
-        await navigator.clipboard.writeText(`meshcore://${hex}`);
+        const url = `meshcore://${bytes.map(b => b.toString(16).padStart(2, '0')).join('')}`;
+        try {
+          await navigator.clipboard.writeText(url);
+        } catch {
+          window.prompt(
+            t('meshcore.contact_details.export_contact_copy_fallback', 'Copy this meshcore:// URL:'),
+            url,
+          );
+        }
         setExportSuccess(true);
         window.setTimeout(() => setExportSuccess(false), 2200);
       }


### PR DESCRIPTION
## Summary

Export Contact and Copy Private Key crash with a TypeError when running over HTTP because `navigator.clipboard.writeText()` requires a secure context. Adds a `window.prompt()` fallback so users can still copy the value.

## Changes

- `MeshCoreContactDetailPanel.tsx` — wrap clipboard call in try/catch, fall back to prompt dialog
- `MeshCoreConfigurationView.tsx` — same fix for the private key copy button

## Issues Resolved

None (found during dev-container testing of #3218/#3219)

## Testing

- [x] TypeScript compiles cleanly
- [ ] Export Contact over HTTP shows prompt dialog with meshcore:// URL
- [ ] Copy Private Key over HTTP shows prompt dialog with hex key

🤖 Generated with [Claude Code](https://claude.com/claude-code)