### PR TITLE
fix: classify neighbor links by transport type and filter by toggles

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -331,8 +331,16 @@ export default function DashboardMap({
           />
         ))}
 
-        {neighborInfo.map((link, idx) => {
-          const { nodeLatitude, nodeLongitude, neighborLatitude, neighborLongitude, bidirectional } = link;
+        {neighborInfo
+          .filter((link: any) => {
+            const tc = link.transportClass ?? 'rf';
+            if (tc === 'mqtt' && !showMqttNodes) return false;
+            if (tc === 'udp' && !showUdpNodes) return false;
+            if (tc === 'rf' && !showRfNodes) return false;
+            return true;
+          })
+          .map((link: any, idx: number) => {
+          const { nodeLatitude, nodeLongitude, neighborLatitude, neighborLongitude, bidirectional, transportClass } = link;
           if (
             nodeLatitude == null ||
             nodeLongitude == null ||
@@ -347,9 +355,11 @@ export default function DashboardMap({
             [neighborLatitude, neighborLongitude],
           ];
 
+          const tc = transportClass ?? 'rf';
+          const colorByTransport = tc === 'mqtt' ? '#22c55e' : tc === 'udp' ? '#f97316' : 'blue';
           const pathOptions = bidirectional
-            ? { color: 'blue', weight: 2, opacity: 0.6 }
-            : { color: 'gray', weight: 1, opacity: 0.6, dashArray: '5, 5' };
+            ? { color: colorByTransport, weight: 2, opacity: 0.6 }
+            : { color: colorByTransport, weight: 1, opacity: 0.6, dashArray: '5, 5' };
 
           return (
             <Polyline

--- a/src/components/MapAnalysis/layers/NeighborLinksLayer.tsx
+++ b/src/components/MapAnalysis/layers/NeighborLinksLayer.tsx
@@ -7,10 +7,17 @@ import {
 import { useNeighbors } from '../../../hooks/useMapAnalysisData';
 import { useMapAnalysisCtx } from '../MapAnalysisContext';
 import { resolveNodeLatLng, type MaybePositionedNode } from '../nodePositionUtil';
+import { classifyNodeTransport, type NodeTransportClass } from '../../../utils/nodeTransport';
 
 function snrToOpacity(snr: number | null): number {
   if (snr === null) return 0.4;
   return Math.max(0.2, Math.min(1, (snr + 10) / 20));
+}
+
+function transportColor(tc: NodeTransportClass): string {
+  if (tc === 'mqtt') return '#22c55e';
+  if (tc === 'udp') return '#f97316';
+  return '#06b6d4';
 }
 
 interface NeighborEdge {
@@ -55,6 +62,14 @@ export default function NeighborLinksLayer() {
     return map;
   }, [nodes]);
 
+  const transportByKey = useMemo(() => {
+    const map = new Map<string, NodeTransportClass>();
+    for (const n of (nodes ?? []) as NodeRecord[]) {
+      map.set(`${n.sourceId ?? ''}:${Number(n.nodeNum)}`, classifyNodeTransport(n as any));
+    }
+    return map;
+  }, [nodes]);
+
   const ts = config.timeSlider;
   const inWindow = (t: number): boolean =>
     !ts.enabled ||
@@ -72,13 +87,19 @@ export default function NeighborLinksLayer() {
       neighborNum: number;
       snr: number | null;
       timestamp?: number;
+      transportClass: NodeTransportClass;
     }> = [];
     const items = (data as { items?: NeighborEdge[] } | undefined)?.items ?? [];
     const filtered = items.filter((e) => inWindow(e.timestamp ?? 0));
     for (const e of filtered) {
-      const a = positionByKey.get(`${e.sourceId}:${Number(e.nodeNum)}`);
-      const b = positionByKey.get(`${e.sourceId}:${Number(e.neighborNum)}`);
+      const aKey = `${e.sourceId}:${Number(e.nodeNum)}`;
+      const bKey = `${e.sourceId}:${Number(e.neighborNum)}`;
+      const a = positionByKey.get(aKey);
+      const b = positionByKey.get(bKey);
       if (!a || !b) continue;
+      const aTx = transportByKey.get(aKey) ?? 'rf';
+      const bTx = transportByKey.get(bKey) ?? 'rf';
+      const tc: NodeTransportClass = aTx === 'mqtt' || bTx === 'mqtt' ? 'mqtt' : aTx === 'udp' || bTx === 'udp' ? 'udp' : 'rf';
       out.push({
         key: String(e.id),
         positions: [a, b],
@@ -88,11 +109,12 @@ export default function NeighborLinksLayer() {
         neighborNum: Number(e.neighborNum),
         snr: e.snr,
         timestamp: e.timestamp,
+        transportClass: tc,
       });
     }
     return out;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, positionByKey, ts.enabled, ts.windowStartMs, ts.windowEndMs]);
+  }, [data, positionByKey, transportByKey, ts.enabled, ts.windowStartMs, ts.windowEndMs]);
 
   return (
     <>
@@ -100,7 +122,7 @@ export default function NeighborLinksLayer() {
         <Polyline
           key={e.key}
           positions={e.positions}
-          pathOptions={{ color: '#06b6d4', weight: 1, opacity: e.opacity, dashArray: '4 4' }}
+          pathOptions={{ color: transportColor(e.transportClass), weight: 1, opacity: e.opacity, dashArray: '4 4' }}
           eventHandlers={{
             click: () =>
               setSelected({

--- a/src/contexts/MapContext.tsx
+++ b/src/contexts/MapContext.tsx
@@ -22,6 +22,7 @@ export interface EnrichedNeighborInfo extends DbNeighborInfo {
   neighborLatitude?: number;
   neighborLongitude?: number;
   bidirectional?: boolean;
+  transportClass?: 'rf' | 'udp' | 'mqtt';
 }
 
 // MeshCore node for map display

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -1046,6 +1046,14 @@ router.get('/:id/neighbor-info', requirePermission('nodes', 'read', { sourceIdFr
       const nodePos = getEffectivePosition(node);
       const neighborPos = getEffectivePosition(neighbor);
 
+      const TX_MQTT = 5;
+      const TX_UDP = 6;
+      const nTx = (node as any)?.transportMechanism;
+      const nbTx = (neighbor as any)?.transportMechanism;
+      const isMqtt = nTx === TX_MQTT || nbTx === TX_MQTT || (node as any)?.viaMqtt || (neighbor as any)?.viaMqtt;
+      const isUdp = nTx === TX_UDP || nbTx === TX_UDP;
+      const transportClass: 'rf' | 'udp' | 'mqtt' = isMqtt ? 'mqtt' : isUdp ? 'udp' : 'rf';
+
       return {
         ...ni,
         nodeId: node?.nodeId || `!${ni.nodeNum.toString(16).padStart(8, '0')}`,
@@ -1053,6 +1061,7 @@ router.get('/:id/neighbor-info', requirePermission('nodes', 'read', { sourceIdFr
         neighborNodeId: neighbor?.nodeId || `!${ni.neighborNodeNum.toString(16).padStart(8, '0')}`,
         neighborName: neighbor?.longName || `Node !${ni.neighborNodeNum.toString(16).padStart(8, '0')}`,
         bidirectional: linkKeys.has(`${ni.neighborNodeNum}-${ni.nodeNum}`),
+        transportClass,
         nodeLatitude: nodePos.latitude,
         nodeLongitude: nodePos.longitude,
         neighborLatitude: neighborPos.latitude,


### PR DESCRIPTION
## Summary

Neighbor link polylines on the Dashboard map were rendered identically (blue/gray) regardless of whether the connection involved RF, MQTT, or UDP nodes. The Show RF/UDP/MQTT toggles in the Features panel only filtered node markers — not neighbor links — leaving "floating lines" visible when MQTT was toggled off. This fix classifies each neighbor link's transport based on its endpoint nodes and applies both filtering and transport-aware coloring.

## Changes

- **Backend** (`sourceRoutes.ts`): The neighbor-info enrichment endpoint now stamps `transportClass` ('rf'/'udp'/'mqtt') on each neighbor link, derived from the endpoint nodes' `transportMechanism`/`viaMqtt` fields — no migration needed
- **Frontend type** (`MapContext.tsx`): Added `transportClass` to `EnrichedNeighborInfo` interface
- **Dashboard map** (`DashboardMap.tsx`): Neighbor links are now filtered by the Show RF/UDP/MQTT toggles and color-coded — blue (RF), green (MQTT), orange (UDP) — with bidirectional/unidirectional styling preserved
- **Analysis map** (`NeighborLinksLayer.tsx`): Neighbor links are color-coded by transport class using a node-data lookup (cyan=RF, green=MQTT, orange=UDP)

## Issues Resolved

Fixes #3223

## Documentation Updates

No documentation changes needed

## Testing

- [x] Unit tests pass (5655 tests)
- [x] TypeScript compiles cleanly
- [ ] Verify Dashboard map neighbor links are colored by transport (RF=blue, MQTT=green, UDP=orange)
- [ ] Verify toggling Show MQTT off hides MQTT neighbor links (not just markers)
- [ ] Verify Analysis map neighbor links show transport-aware colors
- [ ] Verify bidirectional links remain solid, unidirectional remain dashed

🤖 Generated with [Claude Code](https://claude.com/claude-code)