### PR TITLE
fix: prevent false circuit-breaker trips when watchdog upgrade succeeds (issue #3228)

### DIFF
--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -343,6 +343,22 @@ export class MiscRepository extends BaseRepository {
   }
 
   /**
+   * Find the most recent in-progress upgrade, regardless of age.
+   * Used for boot-time status sync only — do not use for the stale-timeout
+   * path, which uses findStaleUpgrades / findActiveUpgrade with a threshold.
+   */
+  async findMostRecentPendingUpgrade(): Promise<UpgradeHistoryRecord | null> {
+    const { upgradeHistory } = this.tables;
+    const results = await this.db
+      .select()
+      .from(upgradeHistory)
+      .where(inArray(upgradeHistory.status, this.IN_PROGRESS_STATUSES))
+      .orderBy(desc(upgradeHistory.startedAt))
+      .limit(1);
+    return results.length > 0 ? this.normalizeBigInts(results[0]) : null;
+  }
+
+  /**
    * Mark an upgrade as failed
    */
   async markUpgradeFailed(id: string, errorMessage: string): Promise<void> {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -858,6 +858,22 @@ setInterval(() => {
   });
 }, AUTO_UPGRADE_CHECK_INTERVAL_MS);
 
+// Boot-time upgrade reconciliation: resolve any pending upgrade_history row
+// left behind by the previous container before the 60-second auto-upgrade
+// check timer fires. Without this, the pending row sits until it ages past
+// STALE_TIMEOUT_MS (30 min) and is wrongly marked failed, eventually tripping
+// the circuit breaker even though the watchdog succeeded (issue #3228).
+setTimeout(async () => {
+  try {
+    if (upgradeService.isEnabled()) {
+      await databaseService.waitForReady();
+      await upgradeService.syncPendingUpgradeStatusOnBoot();
+    }
+  } catch (error) {
+    logger.error('Error in boot-time upgrade status sync:', error);
+  }
+}, 10 * 1000); // 10 seconds — well before the 60-second auto-upgrade check
+
 // Run initial auto-upgrade check after a delay to allow system to stabilize
 setTimeout(() => {
   checkForAutoUpgrade().catch(error => {

--- a/src/server/services/upgradeService.test.ts
+++ b/src/server/services/upgradeService.test.ts
@@ -1,10 +1,16 @@
 /**
- * Tests for the upgradeService auto-upgrade circuit breaker.
+ * Tests for the upgradeService auto-upgrade circuit breaker and boot-time
+ * upgrade status reconciliation.
  *
  * Issue #2871: when AUTO_UPGRADE_ENABLED=true on a deployment whose image is
  * pinned in docker-compose.yml, scheduled upgrades fail forever in a silent
  * loop. The circuit breaker trips after N consecutive failures so retries
  * stop until the operator acknowledges.
+ *
+ * Issue #3228: on a successful Docker+watchdog auto-upgrade the
+ * upgrade_history row stays pending after container recreate. After 30 min
+ * the stale-timeout reconciler marks it failed, eventually tripping the
+ * circuit breaker even though the upgrade succeeded.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -19,6 +25,7 @@ const mockDb = vi.hoisted(() => ({
     findStaleUpgrades: vi.fn().mockResolvedValue([]),
     countInProgressUpgrades: vi.fn().mockResolvedValue(0),
     getLastUpgrade: vi.fn().mockResolvedValue(null),
+    findMostRecentPendingUpgrade: vi.fn().mockResolvedValue(null),
   },
   settings: {
     getSetting: vi.fn(async (key: string) => settingsStore.get(key) ?? null),
@@ -230,5 +237,164 @@ describe('upgradeService circuit breaker', () => {
     // Either the manual attempt succeeded or it failed for an unrelated reason
     // (e.g. mocked filesystem), but it must NOT be the breaker rejection.
     expect(result.message ?? '').not.toMatch(/blocked after .* consecutive/i);
+  });
+
+  // ── Issue #3228: isUpgradeInProgress stale-check respects watchdog status ──
+
+  it('isUpgradeInProgress marks stale row complete (not failed) when status file says complete', async () => {
+    // Regression: the stale-timeout path in isUpgradeInProgress() called
+    // markFailedAndEvaluate() unconditionally, even when the watchdog had
+    // already written 'complete' to the status file. This falsely incremented
+    // the consecutive-failure counter and could trip the circuit breaker.
+    const staleRow = {
+      id: 'stale-1',
+      status: 'pending',
+      currentStep: 'Preparing upgrade',
+      startedAt: Date.now() - 35 * 60 * 1000, // 35 min ago
+      fromVersion: '4.6.0',
+      toVersion: '4.6.1',
+    };
+    mockDb.miscRepo.findStaleUpgrades.mockResolvedValue([staleRow]);
+    mockDb.miscRepo.countInProgressUpgrades.mockResolvedValue(0);
+
+    const STATUS_FILE = '/data/.upgrade-status';
+    fsMocks.existsSync.mockImplementation((p: string) =>
+      p === STATUS_FILE
+    );
+    fsMocks.readFileSync.mockImplementation((p: string) =>
+      p === STATUS_FILE ? 'complete' : ''
+    );
+
+    await upgradeService.isUpgradeInProgress();
+
+    // Must have marked complete, not failed
+    expect(mockDb.miscRepo.markUpgradeComplete).toHaveBeenCalledWith('stale-1');
+    expect(mockDb.miscRepo.markUpgradeFailed).not.toHaveBeenCalled();
+    // Circuit breaker must NOT have been tripped
+    expect(settingsStore.get('autoUpgradeBlocked')).not.toBe('true');
+  });
+
+  it('isUpgradeInProgress still marks stale row failed when status file is absent', async () => {
+    const staleRow = {
+      id: 'stale-2',
+      status: 'pending',
+      currentStep: 'Preparing upgrade',
+      startedAt: Date.now() - 35 * 60 * 1000,
+      fromVersion: '4.6.0',
+      toVersion: '4.6.1',
+    };
+    mockDb.miscRepo.findStaleUpgrades.mockResolvedValue([staleRow]);
+    mockDb.miscRepo.countInProgressUpgrades.mockResolvedValue(0);
+    fsMocks.existsSync.mockReturnValue(false);
+
+    await upgradeService.isUpgradeInProgress();
+
+    expect(mockDb.miscRepo.markUpgradeFailed).toHaveBeenCalledWith(
+      'stale-2',
+      expect.stringContaining('timed out')
+    );
+    expect(mockDb.miscRepo.markUpgradeComplete).not.toHaveBeenCalled();
+  });
+
+  // ── Issue #3228: syncPendingUpgradeStatusOnBoot ────────────────────────────
+
+  it('syncPendingUpgradeStatusOnBoot marks pending row complete when status file says complete', async () => {
+    const pendingRow = {
+      id: 'boot-1',
+      status: 'pending',
+      fromVersion: '4.6.3',
+      toVersion: '4.6.4',
+    };
+    mockDb.miscRepo.findMostRecentPendingUpgrade.mockResolvedValue(pendingRow);
+
+    const STATUS_FILE = '/data/.upgrade-status';
+    fsMocks.existsSync.mockImplementation((p: string) => p === STATUS_FILE);
+    fsMocks.readFileSync.mockImplementation((p: string) =>
+      p === STATUS_FILE ? 'complete' : ''
+    );
+
+    await upgradeService.syncPendingUpgradeStatusOnBoot();
+
+    expect(mockDb.miscRepo.markUpgradeComplete).toHaveBeenCalledWith('boot-1');
+    expect(mockDb.miscRepo.markUpgradeFailed).not.toHaveBeenCalled();
+    // Status file must be deleted after sync
+    expect(fsMocks.unlinkSync).toHaveBeenCalledWith(STATUS_FILE);
+    // Circuit breaker must be cleared (markCompleteAndClear)
+    expect(settingsStore.get('autoUpgradeBlocked')).toBe('false');
+  });
+
+  it('syncPendingUpgradeStatusOnBoot marks pending row complete when status file says ready', async () => {
+    const pendingRow = { id: 'boot-2', status: 'pending', fromVersion: '4.6.3', toVersion: '4.6.4' };
+    mockDb.miscRepo.findMostRecentPendingUpgrade.mockResolvedValue(pendingRow);
+
+    const STATUS_FILE = '/data/.upgrade-status';
+    fsMocks.existsSync.mockImplementation((p: string) => p === STATUS_FILE);
+    fsMocks.readFileSync.mockImplementation((p: string) =>
+      p === STATUS_FILE ? 'ready' : ''
+    );
+
+    await upgradeService.syncPendingUpgradeStatusOnBoot();
+
+    expect(mockDb.miscRepo.markUpgradeComplete).toHaveBeenCalledWith('boot-2');
+    expect(mockDb.miscRepo.markUpgradeFailed).not.toHaveBeenCalled();
+  });
+
+  it('syncPendingUpgradeStatusOnBoot marks pending row failed when status file says failed', async () => {
+    const pendingRow = { id: 'boot-3', status: 'pending', fromVersion: '4.6.3', toVersion: '4.6.4' };
+    mockDb.miscRepo.findMostRecentPendingUpgrade.mockResolvedValue(pendingRow);
+
+    const STATUS_FILE = '/data/.upgrade-status';
+    fsMocks.existsSync.mockImplementation((p: string) => p === STATUS_FILE);
+    fsMocks.readFileSync.mockImplementation((p: string) =>
+      p === STATUS_FILE ? 'failed' : ''
+    );
+
+    await upgradeService.syncPendingUpgradeStatusOnBoot();
+
+    expect(mockDb.miscRepo.markUpgradeFailed).toHaveBeenCalledWith(
+      'boot-3',
+      expect.stringContaining('watchdog status on boot')
+    );
+    expect(mockDb.miscRepo.markUpgradeComplete).not.toHaveBeenCalled();
+  });
+
+  it('syncPendingUpgradeStatusOnBoot is a no-op when status file does not exist', async () => {
+    fsMocks.existsSync.mockReturnValue(false);
+
+    await upgradeService.syncPendingUpgradeStatusOnBoot();
+
+    expect(mockDb.miscRepo.findMostRecentPendingUpgrade).not.toHaveBeenCalled();
+    expect(mockDb.miscRepo.markUpgradeComplete).not.toHaveBeenCalled();
+    expect(mockDb.miscRepo.markUpgradeFailed).not.toHaveBeenCalled();
+  });
+
+  it('syncPendingUpgradeStatusOnBoot is a no-op when status file contains non-terminal value', async () => {
+    const STATUS_FILE = '/data/.upgrade-status';
+    fsMocks.existsSync.mockImplementation((p: string) => p === STATUS_FILE);
+    fsMocks.readFileSync.mockImplementation((p: string) =>
+      p === STATUS_FILE ? 'downloading' : ''
+    );
+
+    await upgradeService.syncPendingUpgradeStatusOnBoot();
+
+    expect(mockDb.miscRepo.findMostRecentPendingUpgrade).not.toHaveBeenCalled();
+    expect(mockDb.miscRepo.markUpgradeComplete).not.toHaveBeenCalled();
+  });
+
+  it('syncPendingUpgradeStatusOnBoot deletes orphaned status file when no pending row exists', async () => {
+    mockDb.miscRepo.findMostRecentPendingUpgrade.mockResolvedValue(null);
+
+    const STATUS_FILE = '/data/.upgrade-status';
+    fsMocks.existsSync.mockImplementation((p: string) => p === STATUS_FILE);
+    fsMocks.readFileSync.mockImplementation((p: string) =>
+      p === STATUS_FILE ? 'complete' : ''
+    );
+
+    await upgradeService.syncPendingUpgradeStatusOnBoot();
+
+    // No DB mutation — just file cleanup
+    expect(mockDb.miscRepo.markUpgradeComplete).not.toHaveBeenCalled();
+    expect(mockDb.miscRepo.markUpgradeFailed).not.toHaveBeenCalled();
+    expect(fsMocks.unlinkSync).toHaveBeenCalledWith(STATUS_FILE);
   });
 });

--- a/src/server/services/upgradeService.ts
+++ b/src/server/services/upgradeService.ts
@@ -410,16 +410,41 @@ class UpgradeService {
       const staleUpgrades = await databaseService.miscRepo.findStaleUpgrades(staleThreshold);
 
       if (staleUpgrades.length > 0) {
-        logger.warn(`⚠️ Found ${staleUpgrades.length} stale upgrade(s), marking as failed`);
+        logger.warn(`⚠️ Found ${staleUpgrades.length} stale upgrade(s), reconciling...`);
 
         for (const staleUpgrade of staleUpgrades) {
           const minutesStuck = Math.round((Date.now() - (staleUpgrade.startedAt || 0)) / 60000);
           logger.warn(`⚠️ Upgrade ${staleUpgrade.id} stuck at "${staleUpgrade.currentStep}" for ${minutesStuck} minutes`);
 
-          await this.markFailedAndEvaluate(
-            staleUpgrade.id,
-            `Upgrade timed out after ${minutesStuck} minutes (stuck at: ${staleUpgrade.currentStep})`
-          );
+          // Before declaring failure, check whether the watchdog actually
+          // completed the upgrade. On a post-recreate boot the container may
+          // have been replaced before the old backend could update the row,
+          // leaving the status file at 'complete' while the DB still shows
+          // 'pending'. Marking it failed here would trip the circuit breaker
+          // even though the upgrade succeeded (issue #3228).
+          let resolvedAsComplete = false;
+          try {
+            if (fs.existsSync(UPGRADE_STATUS_FILE)) {
+              const fileStatus = fs.readFileSync(UPGRADE_STATUS_FILE, 'utf-8').trim().toLowerCase();
+              if (fileStatus === 'complete' || fileStatus === 'ready') {
+                logger.info(
+                  `🔄 Stale-upgrade reconcile: upgrade ${staleUpgrade.id} actually succeeded — ` +
+                  `marking complete (watchdog status: ${fileStatus})`
+                );
+                await this.markCompleteAndClear(staleUpgrade.id);
+                resolvedAsComplete = true;
+              }
+            }
+          } catch (fileError) {
+            logger.debug('Could not read upgrade status file during stale check:', fileError);
+          }
+
+          if (!resolvedAsComplete) {
+            await this.markFailedAndEvaluate(
+              staleUpgrade.id,
+              `Upgrade timed out after ${minutesStuck} minutes (stuck at: ${staleUpgrade.currentStep})`
+            );
+          }
 
           // Also remove trigger file if it exists
           if (fs.existsSync(UPGRADE_TRIGGER_FILE)) {
@@ -666,6 +691,79 @@ class UpgradeService {
     if (!databaseService.miscRepo) return;
     await databaseService.miscRepo.markUpgradeComplete(id);
     await this.clearAutoUpgradeBlock('Cleared by successful upgrade');
+  }
+
+  /**
+   * Boot-time reconciliation: if a previous container exited during an
+   * upgrade, the upgrade_history row may still show a pending/in-progress
+   * status even though the watchdog completed the upgrade and wrote the
+   * status file. This is the primary trigger for false circuit-breaker trips
+   * (issue #3228).
+   *
+   * Called once on server startup, BEFORE the 60-second auto-upgrade check
+   * timer fires, so the pending row is resolved before isUpgradeInProgress()
+   * is called for the next scheduled check.
+   *
+   * Unlike the stale-timeout reconciler in isUpgradeInProgress(), this check
+   * is NOT bounded by STALE_TIMEOUT_MS — it catches upgrades that completed
+   * quickly (< 30 min), which is the common case on fast hardware.
+   *
+   * Idempotent: if no pending row exists or the status file has already been
+   * consumed (deleted), this method is a no-op.
+   */
+  async syncPendingUpgradeStatusOnBoot(): Promise<void> {
+    if (!databaseService.miscRepo) return;
+
+    try {
+      if (!fs.existsSync(UPGRADE_STATUS_FILE)) {
+        // No status file → either no upgrade happened since last boot, or a
+        // prior boot already consumed and deleted it. Nothing to do.
+        return;
+      }
+
+      const fileStatus = fs.readFileSync(UPGRADE_STATUS_FILE, 'utf-8').trim().toLowerCase();
+      const isTerminal = fileStatus === 'complete' || fileStatus === 'ready' || fileStatus === 'failed';
+      if (!isTerminal) {
+        // Status file exists but contains a non-terminal value (e.g. 'downloading').
+        // A live upgrade may be in progress; leave it for isUpgradeInProgress().
+        return;
+      }
+
+      // Find the most recent pending/in-progress row, regardless of age.
+      const pendingRow = await databaseService.miscRepo.findMostRecentPendingUpgrade();
+      if (!pendingRow) {
+        // No pending row. The status file is a leftover from a previously-synced
+        // upgrade (e.g. the prior boot already reconciled it). Clean it up so
+        // subsequent boots don't attempt to re-process it.
+        try { fs.unlinkSync(UPGRADE_STATUS_FILE); } catch (_) { /* best-effort */ }
+        return;
+      }
+
+      if (fileStatus === 'complete' || fileStatus === 'ready') {
+        logger.info(
+          `🔄 Boot-time upgrade sync: marking ${pendingRow.id} complete ` +
+          `(${pendingRow.fromVersion} → ${pendingRow.toVersion}, ` +
+          `watchdog status: ${fileStatus})`
+        );
+        await this.markCompleteAndClear(pendingRow.id);
+      } else {
+        // fileStatus === 'failed'
+        logger.info(
+          `🔄 Boot-time upgrade sync: marking ${pendingRow.id} failed ` +
+          `(${pendingRow.fromVersion} → ${pendingRow.toVersion}, watchdog status: failed)`
+        );
+        await this.markFailedAndEvaluate(
+          pendingRow.id,
+          'Upgrade failed (detected from watchdog status on boot)'
+        );
+      }
+
+      // Remove the status file so subsequent reboots of the same container
+      // (e.g. manual restarts) don't re-process it.
+      try { fs.unlinkSync(UPGRADE_STATUS_FILE); } catch (_) { /* best-effort */ }
+    } catch (error) {
+      logger.warn('⚠️ Boot-time upgrade status sync failed (non-fatal):', error);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #3228 — after a successful Docker+watchdog auto-upgrade, the `upgrade_history` row stays `pending` because the container is recreated before the old backend can update it. After 30 minutes, `isUpgradeInProgress()` marks the stale row `failed` without consulting the watchdog status file. 3–5 such false failures trip the circuit breaker and silently halt auto-upgrade.

## Root cause

The stale-timeout reconciler in `isUpgradeInProgress()` called `markFailedAndEvaluate()` unconditionally, even when `/data/.upgrade-status` contained `complete`. The status-file sync in `getActiveUpgrade()` / `getUpgradeStatus()` only runs when the UI polls with a specific upgrade ID — after container recreate there is no active UI session polling, so the sync never fires.

## Fix (three complementary layers)

### 1 — Boot-time sync (primary fix)

New method `upgradeService.syncPendingUpgradeStatusOnBoot()`:
- Runs 10 seconds after server start (well before the 60-second auto-upgrade check)
- Finds the most recent pending row **regardless of age** (no `staleThreshold` bound — fast upgrades that complete in < 30 min need this)
- If `/data/.upgrade-status` is `complete`/`ready` → `markCompleteAndClear()`
- If `failed` → `markFailedAndEvaluate()`
- Deletes the status file after sync so subsequent container restarts are no-ops
- Entirely idempotent: no status file or no pending row → returns immediately

### 2 — Status-file guard in stale-check

`isUpgradeInProgress()` now reads the watchdog status file **before** calling `markFailedAndEvaluate()` on a stale row. If the file says `complete`/`ready`, `markCompleteAndClear()` is called instead. This catches the uncommon case where the boot-time sync misses the window (e.g. an upgrade that finishes between DB init and the 10-second timer — very unlikely, but defense in depth).

### 3 — New repo method `findMostRecentPendingUpgrade()`

Unlike `findActiveUpgrade(staleThreshold)`, this returns the most recent in-progress row without an age filter. Used exclusively by the boot-time sync so it can reconcile rows of any age.

## Files changed

| File | Change |
|------|--------|
| `src/db/repositories/misc.ts` | Add `findMostRecentPendingUpgrade()` |
| `src/server/services/upgradeService.ts` | Add `syncPendingUpgradeStatusOnBoot()`; fix stale-check to consult status file |
| `src/server/server.ts` | Schedule boot-time sync at 10 s |
| `src/server/services/upgradeService.test.ts` | 8 new regression tests |

## Tests

All 19 upgrade service tests pass (11 pre-existing + 8 new):

```
✓ isUpgradeInProgress marks stale row complete (not failed) when status file says complete
✓ isUpgradeInProgress still marks stale row failed when status file is absent
✓ syncPendingUpgradeStatusOnBoot marks pending row complete when status file says complete
✓ syncPendingUpgradeStatusOnBoot marks pending row complete when status file says ready
✓ syncPendingUpgradeStatusOnBoot marks pending row failed when status file says failed
✓ syncPendingUpgradeStatusOnBoot is a no-op when status file does not exist
✓ syncPendingUpgradeStatusOnBoot is a no-op when status file contains non-terminal value
✓ syncPendingUpgradeStatusOnBoot deletes orphaned status file when no pending row exists
```

The 5 failing test files in CI (`mqttBrokerManager.test.ts` and related) are pre-existing failures unrelated to this change (confirmed by running the suite on the unmodified branch).

https://claude.ai/code/session_01YLctxhPhPGeMV9LhsscVHK

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLctxhPhPGeMV9LhsscVHK)_