### PR TITLE
feat(meshcore): mobile-responsive layout and collapsible sections

### DIFF
--- a/src/components/MeshCore/CollapsibleSection.tsx
+++ b/src/components/MeshCore/CollapsibleSection.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+
+interface CollapsibleSectionProps {
+  title: string;
+  defaultExpanded?: boolean;
+  className?: string;
+  headerClassName?: string;
+  children: React.ReactNode;
+}
+
+export const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
+  title,
+  defaultExpanded = true,
+  className = '',
+  headerClassName = '',
+  children,
+}) => {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  return (
+    <div className={className}>
+      <div
+        className={`meshcore-collapsible-header ${headerClassName}`}
+        onClick={() => setExpanded(v => !v)}
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setExpanded(v => !v);
+          }
+        }}
+      >
+        <h3>{title}</h3>
+        <span className={`meshcore-collapsible-chevron ${expanded ? 'expanded' : ''}`}>
+          ▶
+        </span>
+      </div>
+      <div className={`meshcore-collapsible-body ${expanded ? 'expanded' : 'collapsed'}`}>
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -14,13 +14,17 @@
  * send (meshcoreManager.ts:sendMessage, phase 2 addition). The per-channel
  * filter therefore matches either direction.
  */
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { MeshCoreMessage, MeshCoreActions, ConnectionStatus } from './hooks/useMeshCore';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
 import { useAuth } from '../../contexts/AuthContext';
+
+const MOBILE_BREAKPOINT = 768;
+const isMobileViewport = (): boolean =>
+  typeof window !== 'undefined' && window.innerWidth <= MOBILE_BREAKPOINT;
 
 interface MeshCoreChannelsViewProps {
   messages: MeshCoreMessage[];
@@ -78,6 +82,20 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   const [channels, setChannels] = useState<ChannelRow[]>([]);
   const [selectedIdx, setSelectedIdx] = useState<number>(0);
   const [loadingChannels, setLoadingChannels] = useState(false);
+  const [mobileShowContent, setMobileShowContent] = useState(false);
+
+  useEffect(() => {
+    const onResize = () => {
+      if (!isMobileViewport()) setMobileShowContent(false);
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const handleSelectChannel = useCallback((idx: number) => {
+    setSelectedIdx(idx);
+    if (isMobileViewport()) setMobileShowContent(true);
+  }, []);
 
   // Fetch the synced channel list for this source. We use /api/channels/all
   // (rather than /api/channels) so MeshCore rows with idx > 7 aren't dropped
@@ -141,8 +159,10 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   const selfKey = status?.localNode?.publicKey;
   const connected = status?.connected ?? false;
 
+  const mobileClass = mobileShowContent ? 'mobile-show-content' : 'mobile-show-list';
+
   return (
-    <div className="meshcore-two-pane">
+    <div className={`meshcore-two-pane ${mobileClass}`}>
       <div className="meshcore-list-pane">
         <div className="meshcore-list-pane-header">
           <span>{t('meshcore.nav.channels', 'Channels')}</span>
@@ -163,7 +183,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
               <button
                 key={c.id}
                 className={`mc-channel-row ${active.id === c.id ? 'selected' : ''}`}
-                onClick={() => setSelectedIdx(c.id)}
+                onClick={() => handleSelectChannel(c.id)}
               >
                 <div className="mc-channel-row-name">
                   # {c.name || t('meshcore.channels.unnamed', 'Channel {{idx}}', { idx: c.id })}
@@ -177,6 +197,20 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
         </div>
       </div>
       <div className="meshcore-main-pane">
+        {mobileShowContent && (
+          <div className="meshcore-mobile-back-header">
+            <button
+              type="button"
+              className="meshcore-mobile-back-btn"
+              onClick={() => setMobileShowContent(false)}
+            >
+              ◀ {t('common.back', 'Back')}
+            </button>
+            <span className="meshcore-mobile-back-title">
+              # {active.name || t('meshcore.channels.unnamed', 'Channel {{idx}}', { idx: active.id })}
+            </span>
+          </div>
+        )}
         <MeshCoreMessageStream
           messages={filtered}
           contacts={contacts}

--- a/src/components/MeshCore/MeshCoreConfigurationView.tsx
+++ b/src/components/MeshCore/MeshCoreConfigurationView.tsx
@@ -5,6 +5,7 @@ import { RADIO_PRESETS, findPresetId } from './radioPresets';
 import { useAuth } from '../../contexts/AuthContext';
 import { MeshCoreChannelsConfigSection } from './MeshCoreChannelsConfigSection';
 import { MeshCoreLocalConsole } from './MeshCoreLocalConsole';
+import { CollapsibleSection } from './CollapsibleSection';
 
 const TELEMETRY_MODE_OPTIONS: TelemetryMode[] = ['always', 'device', 'never'];
 // MeshCore device types: COMPANION=1, REPEATER=2, ROOM_SERVER=3.
@@ -202,8 +203,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
         </div>
       )}
 
-      <div className="form-section">
-        <h3>{t('meshcore.config.device_name', 'Device name')}</h3>
+      <CollapsibleSection title={t('meshcore.config.device_name', 'Device name')} className="form-section">
         <p className="hint">
           {t('meshcore.config.device_name_hint', 'Friendly name advertised to other nodes (max 32 chars).')}
         </p>
@@ -231,10 +231,9 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
             </span>
           )}
         </div>
-      </div>
+      </CollapsibleSection>
 
-      <div className="form-section">
-        <h3>{t('meshcore.config.location', 'Location')}</h3>
+      <CollapsibleSection title={t('meshcore.config.location', 'Location')} className="form-section">
         <p className="hint">
           {t('meshcore.config.location_hint',
             'GPS coordinates reported by the device. Latitude (-90 to 90), Longitude (-180 to 180).')}
@@ -295,10 +294,9 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
             {t('meshcore.config.advert_loc_policy', 'Include location in adverts')}
           </label>
         </div>
-      </div>
+      </CollapsibleSection>
 
-      <div className="form-section">
-        <h3>{t('meshcore.config.radio_params', 'Radio parameters')}</h3>
+      <CollapsibleSection title={t('meshcore.config.radio_params', 'Radio parameters')} className="form-section">
         <p className="hint">
           {t('meshcore.config.radio_hint',
             'Frequency (137–1020 MHz), Bandwidth (kHz), Spreading Factor (5–12), Coding Rate (5–8 → 4/5 – 4/8).')}
@@ -383,10 +381,9 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
             </span>
           )}
         </div>
-      </div>
+      </CollapsibleSection>
 
-      <div className="form-section">
-        <h3>{t('meshcore.config.tx_power', 'TX Power')}</h3>
+      <CollapsibleSection title={t('meshcore.config.tx_power', 'TX Power')} className="form-section">
         <p className="hint">
           {t('meshcore.config.tx_power_hint',
             `Transmit power in dBm (1–${maxTxPower}). This controls the LoRa chip output only; boards with an external PA may amplify further.`)}
@@ -424,10 +421,9 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
             </span>
           )}
         </div>
-      </div>
+      </CollapsibleSection>
 
-      <div className="form-section">
-        <h3>{t('meshcore.config.telemetry', 'Telemetry')}</h3>
+      <CollapsibleSection title={t('meshcore.config.telemetry', 'Telemetry')} className="form-section">
         <p className="hint">
           {t('meshcore.config.telemetry_hint',
             'Control what telemetry this node shares. Always = broadcast on advert; Device only = only respond to direct requests from your contacts; Never = disable.')}
@@ -509,7 +505,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
             </span>
           )}
         </div>
-      </div>
+      </CollapsibleSection>
 
       {/* Channels — Companion-only and only when the per-source addressing
           props are available (sourceId/baseUrl come from the MeshCorePage). */}

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -33,10 +33,9 @@ function isRealNodeKey(key: string): boolean {
 type DmSortField = 'name' | 'lastMessage';
 type DmSortDirection = 'asc' | 'desc';
 
-// Mobile viewport defaults the node list to collapsed so the conversation
-// pane takes the full width (matches Meshtastic MessagesTab behavior).
+const MOBILE_BREAKPOINT = 768;
 const isMobileViewport = (): boolean =>
-  typeof window !== 'undefined' && window.innerWidth <= 768;
+  typeof window !== 'undefined' && window.innerWidth <= MOBILE_BREAKPOINT;
 
 export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProps> = ({
   messages,
@@ -54,7 +53,16 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
   const [selected, setSelected] = useState<string | null>(null);
   const [sortField, setSortField] = useState<DmSortField>('lastMessage');
   const [sortDirection, setSortDirection] = useState<DmSortDirection>('desc');
-  const [isCollapsed, setIsCollapsed] = useState<boolean>(isMobileViewport);
+  const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
+  const [mobileShowContent, setMobileShowContent] = useState(false);
+
+  useEffect(() => {
+    const onResize = () => {
+      if (!isMobileViewport()) setMobileShowContent(false);
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
 
   const selfKey = status?.localNode?.publicKey;
   const connected = status?.connected ?? false;
@@ -193,8 +201,19 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     });
   }, [messages, selected, selfKey]);
 
+  const handleSelectContact = (key: string) => {
+    setSelected(key);
+    if (isMobileViewport()) setMobileShowContent(true);
+  };
+
+  const selectedContactName = selected
+    ? (contactsByKey.get(selected)?.advName || contactsByKey.get(selected)?.name || `${selected.substring(0, 8)}…`)
+    : '';
+
+  const mobileClass = mobileShowContent ? 'mobile-show-content' : 'mobile-show-list';
+
   return (
-    <div className="meshcore-two-pane">
+    <div className={`meshcore-two-pane ${mobileClass}`}>
       <div className={`meshcore-list-pane ${isCollapsed ? 'collapsed' : ''}`}>
         <div className="meshcore-list-pane-header">
           <button
@@ -256,7 +275,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                 <button
                   key={key}
                   className={`mc-node-row ${selected === key ? 'selected' : ''}`}
-                  onClick={() => setSelected(key)}
+                  onClick={() => handleSelectContact(key)}
                 >
                   <div className="mc-node-row-name">
                     <span>{name}</span>
@@ -269,6 +288,20 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
         )}
       </div>
       <div className="meshcore-main-pane meshcore-main-pane--dm">
+        {mobileShowContent && (
+          <div className="meshcore-mobile-back-header">
+            <button
+              type="button"
+              className="meshcore-mobile-back-btn"
+              onClick={() => setMobileShowContent(false)}
+            >
+              ◀ {t('common.back', 'Back')}
+            </button>
+            {selected && (
+              <span className="meshcore-mobile-back-title">{selectedContactName}</span>
+            )}
+          </div>
+        )}
         {selected ? (
           <>
             <MeshCoreMessageStream

--- a/src/components/MeshCore/MeshCoreInfoView.tsx
+++ b/src/components/MeshCore/MeshCoreInfoView.tsx
@@ -23,6 +23,7 @@ import { useQuery } from '@tanstack/react-query';
 import { ComposedChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { ConnectionStatus } from './hooks/useMeshCore';
 import { useTelemetry } from '../../hooks/useTelemetry';
+import { CollapsibleSection } from './CollapsibleSection';
 
 const HOURS_OPTIONS = [1, 6, 24, 72, 168] as const;
 type HoursOption = typeof HOURS_OPTIONS[number];
@@ -244,7 +245,7 @@ export const MeshCoreInfoView: React.FC<MeshCoreInfoViewProps> = ({ baseUrl, sou
     <div className="meshcore-info-view" data-testid="meshcore-info-view">
       <div className="meshcore-info-grid">
         <section className="meshcore-info-card" data-testid="meshcore-info-identity">
-          <h3>{t('meshcore.info.identity', 'Identity')}</h3>
+          <CollapsibleSection title={t('meshcore.info.identity', 'Identity')}>
           <dl>
             <dt>{t('meshcore.info.name', 'Name')}</dt>
             <dd>{identity.name || '—'}</dd>
@@ -267,10 +268,11 @@ export const MeshCoreInfoView: React.FC<MeshCoreInfoViewProps> = ({ baseUrl, sou
                 : '—'}
             </dd>
           </dl>
+          </CollapsibleSection>
         </section>
 
         <section className="meshcore-info-card" data-testid="meshcore-info-radio">
-          <h3>{t('meshcore.info.radio', 'Radio')}</h3>
+          <CollapsibleSection title={t('meshcore.info.radio', 'Radio')}>
           <dl>
             <dt>{t('meshcore.info.frequency', 'Frequency')}</dt>
             <dd>{fmtFreq(identity.radioFreq)}</dd>
@@ -287,10 +289,11 @@ export const MeshCoreInfoView: React.FC<MeshCoreInfoViewProps> = ({ baseUrl, sou
                 : '—'}
             </dd>
           </dl>
+          </CollapsibleSection>
         </section>
 
         <section className="meshcore-info-card" data-testid="meshcore-info-health">
-          <h3>{t('meshcore.info.health', 'Current health')}</h3>
+          <CollapsibleSection title={t('meshcore.info.health', 'Current health')}>
           {!isCompanion ? (
             <p className="meshcore-info-note">
               {t('meshcore.info.repeater_no_stats', 'Local stats are only available for Companion devices.')}
@@ -331,10 +334,11 @@ export const MeshCoreInfoView: React.FC<MeshCoreInfoViewProps> = ({ baseUrl, sou
               {t('meshcore.info.awaiting_poll', 'Waiting for first telemetry poll…')}
             </p>
           )}
+          </CollapsibleSection>
         </section>
 
         <section className="meshcore-info-card" data-testid="meshcore-info-counters">
-          <h3>{t('meshcore.info.counters', 'Cumulative counters')}</h3>
+          <CollapsibleSection title={t('meshcore.info.counters', 'Cumulative counters')}>
           {counterValues.size === 0 ? (
             <p className="meshcore-info-note">{t('meshcore.info.no_counters', 'No counter data yet.')}</p>
           ) : (
@@ -349,24 +353,23 @@ export const MeshCoreInfoView: React.FC<MeshCoreInfoViewProps> = ({ baseUrl, sou
               ))}
             </dl>
           )}
+          </CollapsibleSection>
         </section>
       </div>
 
       {isCompanion && (
         <section className="meshcore-info-graphs" data-testid="meshcore-info-graphs">
-          <div className="meshcore-info-graphs-header">
-            <h3>{t('meshcore.info.history', 'History')}</h3>
-            <div className="meshcore-info-range" role="group" aria-label="Time range">
-              {HOURS_OPTIONS.map((h) => (
-                <button
-                  key={h}
-                  className={`mc-range-btn ${hours === h ? 'active' : ''}`}
-                  onClick={() => setHours(h)}
-                >
-                  {h < 24 ? `${h}h` : `${h / 24}d`}
-                </button>
-              ))}
-            </div>
+          <CollapsibleSection title={t('meshcore.info.history', 'History')}>
+          <div className="meshcore-info-range" role="group" aria-label="Time range" style={{ marginBottom: '1rem' }}>
+            {HOURS_OPTIONS.map((h) => (
+              <button
+                key={h}
+                className={`mc-range-btn ${hours === h ? 'active' : ''}`}
+                onClick={() => setHours(h)}
+              >
+                {h < 24 ? `${h}h` : `${h / 24}d`}
+              </button>
+            ))}
           </div>
 
           {telLoading && telemetryRows.length === 0 ? (
@@ -423,6 +426,7 @@ export const MeshCoreInfoView: React.FC<MeshCoreInfoViewProps> = ({ baseUrl, sou
               })}
             </div>
           )}
+          </CollapsibleSection>
         </section>
       )}
     </div>

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -1,8 +1,12 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MeshCoreNode } from './hooks/useMeshCore';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMap } from './MeshCoreMap';
+
+const MOBILE_BREAKPOINT = 768;
+const isMobileViewport = (): boolean =>
+  typeof window !== 'undefined' && window.innerWidth <= MOBILE_BREAKPOINT;
 
 const DEVICE_TYPE_KEYS: Record<number, string> = {
   0: 'meshcore.device_type.unknown',
@@ -96,6 +100,7 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
   const [selected, setSelected] = useState<string | null>(null);
   const [sortField, setSortField] = useState<SortField>('lastHeard');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [mobileShowContent, setMobileShowContent] = useState(false);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [importHex, setImportHex] = useState('');
   const [importing, setImporting] = useState(false);
@@ -127,14 +132,30 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
     }
   }, [onImportContact, importing, importHex, t]);
 
+  useEffect(() => {
+    const onResize = () => {
+      if (!isMobileViewport()) setMobileShowContent(false);
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const handleSelectNode = useCallback((key: string) => {
+    setSelected(key);
+    if (isMobileViewport()) setMobileShowContent(true);
+  }, []);
+
   const merged = useMemo(() => mergeNodesAndContacts(nodes, contacts), [nodes, contacts]);
   const rows = useMemo(
     () => sortRows(merged, sortField, sortDirection),
     [merged, sortField, sortDirection],
   );
 
+  const mobileClass = mobileShowContent ? 'mobile-show-content' : 'mobile-show-list';
+  const selectedRow = rows.find(r => r.publicKey === selected);
+
   return (
-    <div className="meshcore-two-pane">
+    <div className={`meshcore-two-pane ${mobileClass}`}>
       <div className="meshcore-list-pane">
         <div className="meshcore-list-pane-header">
           <span>{t('meshcore.nav.nodes', 'Nodes')}</span>
@@ -184,7 +205,7 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
             <button
               key={row.publicKey}
               className={`mc-node-row ${selected === row.publicKey ? 'selected' : ''}`}
-              onClick={() => setSelected(row.publicKey)}
+              onClick={() => handleSelectNode(row.publicKey)}
             >
               <div className="mc-node-row-name">
                 <span>{row.name}</span>
@@ -210,6 +231,20 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
         </div>
       </div>
       <div className="meshcore-main-pane">
+        {mobileShowContent && (
+          <div className="meshcore-mobile-back-header">
+            <button
+              type="button"
+              className="meshcore-mobile-back-btn"
+              onClick={() => setMobileShowContent(false)}
+            >
+              ◀ {t('common.back', 'Back')}
+            </button>
+            {selectedRow && (
+              <span className="meshcore-mobile-back-title">{selectedRow.name}</span>
+            )}
+          </div>
+        )}
         <MeshCoreMap contacts={contacts} selectedPublicKey={selected} />
       </div>
       {importDialogOpen && (

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -1009,3 +1009,293 @@
   color: var(--ctp-subtext0);
   font-size: 0.95rem;
 }
+
+/* ============================================================
+ * Mobile back button (shown in content pane header on mobile)
+ * ============================================================ */
+
+.meshcore-mobile-back-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--ctp-mantle);
+  border-bottom: 1px solid var(--ctp-surface1);
+  flex-shrink: 0;
+}
+
+.meshcore-mobile-back-btn {
+  background: transparent;
+  border: 1px solid var(--ctp-surface2);
+  color: var(--ctp-text);
+  padding: 0.3rem 0.6rem;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.meshcore-mobile-back-btn:hover {
+  background: var(--ctp-surface1);
+}
+
+.meshcore-mobile-back-title {
+  font-weight: 500;
+  color: var(--ctp-text);
+  font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ============================================================
+ * Collapsible section
+ * ============================================================ */
+
+.meshcore-collapsible-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.meshcore-collapsible-header h3 {
+  margin-bottom: 0;
+}
+
+.meshcore-collapsible-chevron {
+  font-size: 0.75rem;
+  color: var(--ctp-subtext0);
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+}
+
+.meshcore-collapsible-chevron.expanded {
+  transform: rotate(90deg);
+}
+
+.meshcore-collapsible-body {
+  overflow: hidden;
+  transition: max-height 0.25s ease, opacity 0.2s ease;
+}
+
+.meshcore-collapsible-body.collapsed {
+  max-height: 0 !important;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.meshcore-collapsible-body.expanded {
+  max-height: none;
+  opacity: 1;
+  margin-top: 0.75rem;
+}
+
+/* ============================================================
+ * Mobile responsive — 768px breakpoint
+ * ============================================================ */
+
+@media (max-width: 768px) {
+
+  /* --- Page body: toolbar moves to bottom --- */
+  .meshcore-page-body {
+    flex-direction: column-reverse;
+  }
+
+  /* --- Sub-toolbar: horizontal bottom bar --- */
+  .meshcore-sub-toolbar {
+    width: 100%;
+    flex-direction: row;
+    border-right: none;
+    border-top: 1px solid var(--ctp-surface1);
+    padding: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    flex-shrink: 0;
+  }
+
+  .meshcore-sub-toolbar.expanded {
+    width: 100%;
+  }
+
+  .meshcore-sub-toolbar-item {
+    flex-direction: column;
+    gap: 0.2rem;
+    padding: 0.5rem 0.4rem;
+    margin: 0;
+    border-radius: 0;
+    width: auto;
+    min-width: 56px;
+    flex-shrink: 0;
+    text-align: center;
+    justify-content: center;
+    font-size: 0.7rem;
+  }
+
+  .meshcore-sub-toolbar-item .icon {
+    font-size: 1.2rem;
+  }
+
+  .meshcore-sub-toolbar-item .label {
+    display: block !important;
+    font-size: 0.65rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 64px;
+  }
+
+  .meshcore-sub-toolbar-spacer {
+    display: none;
+  }
+
+  .meshcore-sub-toolbar-toggle {
+    display: none;
+  }
+
+  /* --- Status bar: compact --- */
+  .meshcore-status-bar {
+    padding: 0.4rem 0.75rem;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .meshcore-status-bar .status-text {
+    font-size: 0.85rem;
+  }
+
+  .meshcore-status-bar .status-meta {
+    display: none;
+  }
+
+  .meshcore-status-bar button {
+    padding: 0.35rem 0.6rem;
+    font-size: 0.8rem;
+  }
+
+  /* --- Two-pane: full-width stacking --- */
+  .meshcore-two-pane {
+    flex-direction: column;
+  }
+
+  .meshcore-list-pane {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--ctp-surface1);
+  }
+
+  .meshcore-main-pane {
+    flex: 1;
+  }
+
+  /* Mobile pane toggle: show list OR content */
+  .meshcore-two-pane.mobile-show-content .meshcore-list-pane {
+    display: none;
+  }
+
+  .meshcore-two-pane.mobile-show-list .meshcore-main-pane {
+    display: none;
+  }
+
+  .meshcore-two-pane.mobile-show-list .meshcore-list-pane {
+    flex: 1;
+    max-height: none;
+  }
+
+  /* Collapsed list pane — force back to visible on mobile-show-list */
+  .meshcore-list-pane.collapsed {
+    width: 100%;
+  }
+
+  /* --- Form views: tighter padding --- */
+  .meshcore-form-view {
+    padding: 0.75rem;
+  }
+
+  .meshcore-form-view .form-section {
+    padding: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .meshcore-form-view .form-section h3 {
+    font-size: 1.1rem;
+  }
+
+  .meshcore-form-view input,
+  .meshcore-form-view select {
+    max-width: none;
+  }
+
+  /* --- Info view: single column cards --- */
+  .meshcore-info-view {
+    padding: 0.75rem;
+    gap: 0.75rem;
+  }
+
+  .meshcore-info-grid {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  .meshcore-info-card {
+    padding: 1rem;
+  }
+
+  .meshcore-info-card h3 {
+    font-size: 1.1rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .meshcore-info-graphs {
+    padding: 1rem;
+  }
+
+  .meshcore-info-graphs-header {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .meshcore-info-graphs-grid {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  /* --- DM variant: taller stream on mobile --- */
+  .meshcore-main-pane--dm .meshcore-message-stream {
+    height: 50vh;
+    min-height: 16rem;
+  }
+
+  /* --- Message bubbles: wider on mobile --- */
+  .mc-message-row {
+    max-width: 90%;
+  }
+
+  /* --- Channel rows: tighter on mobile --- */
+  .mc-channel-row {
+    padding: 0.75rem 1rem;
+    margin: 0 0.25rem 0.4rem;
+  }
+
+  /* --- Room stats header: wrap --- */
+  .meshcore-room-stats-header {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .meshcore-room-sync-config {
+    margin-left: 0;
+    width: 100%;
+  }
+
+  /* --- Disconnected hero: smaller --- */
+  .meshcore-disconnected-hero-inner {
+    padding: 1.25rem;
+  }
+}

--- a/src/components/MeshCore/MeshCoreRoomsView.tsx
+++ b/src/components/MeshCore/MeshCoreRoomsView.tsx
@@ -19,6 +19,10 @@ import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
 import { useAuth } from '../../contexts/AuthContext';
 
+const MOBILE_BREAKPOINT = 768;
+const isMobileViewport = (): boolean =>
+  typeof window !== 'undefined' && window.innerWidth <= MOBILE_BREAKPOINT;
+
 interface MeshCoreRoomsViewProps {
   messages: MeshCoreMessage[];
   contacts: MeshCoreContact[];
@@ -60,6 +64,15 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
   const [loginError, setLoginError] = useState<string | null>(null);
   const [loginLoading, setLoginLoading] = useState(false);
   const [rememberPassword, setRememberPassword] = useState(false);
+  const [mobileShowContent, setMobileShowContent] = useState(false);
+
+  useEffect(() => {
+    const onResize = () => {
+      if (!isMobileViewport()) setMobileShowContent(false);
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
 
   // Credential persistence state
   const [canRemember, setCanRemember] = useState(false);
@@ -136,6 +149,7 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
     setLoginPassword('');
     setRememberPassword(false);
     setSyncConfigDirty(false);
+    if (isMobileViewport()) setMobileShowContent(true);
   }, []);
 
   const handleLogin = useCallback(async () => {
@@ -176,8 +190,10 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
 
   const showLoginOverlay = selectedRoom && !isLoggedIn(selectedRoom) && !loginLoading;
 
+  const mobileClass = mobileShowContent ? 'mobile-show-content' : 'mobile-show-list';
+
   return (
-    <div className="meshcore-two-pane">
+    <div className={`meshcore-two-pane ${mobileClass}`}>
       <div className="meshcore-list-pane">
         <div className="meshcore-list-pane-header">
           <span>{t('meshcore.nav.rooms', 'Rooms')}</span>
@@ -218,6 +234,22 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
         </div>
       </div>
       <div className="meshcore-main-pane">
+        {mobileShowContent && (
+          <div className="meshcore-mobile-back-header">
+            <button
+              type="button"
+              className="meshcore-mobile-back-btn"
+              onClick={() => setMobileShowContent(false)}
+            >
+              ◀ {t('common.back', 'Back')}
+            </button>
+            {activeRoom && (
+              <span className="meshcore-mobile-back-title">
+                {activeRoom.advName || activeRoom.name || selectedRoom?.substring(0, 12) + '…'}
+              </span>
+            )}
+          </div>
+        )}
         {!selectedRoom && (
           <div className="meshcore-empty-state">
             {t('meshcore.rooms.select_room', 'Select a room server to view posts')}

--- a/src/pages/MeshCoreSourcePage.tsx
+++ b/src/pages/MeshCoreSourcePage.tsx
@@ -30,7 +30,7 @@ import '../components/AppHeader/AppHeader.css';
 function MeshCoreSourceInner() {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { sourceId } = useSource();
+  const { sourceId, sourceName } = useSource();
   const { authStatus, hasPermission } = useAuth();
   const isAuthenticated = authStatus?.authenticated ?? false;
 
@@ -81,7 +81,10 @@ function MeshCoreSourceInner() {
             alt="MeshMonitor"
             className="dashboard-topbar-logo-img"
           />
-          <span className="dashboard-topbar-title">MeshMonitor — MeshCore</span>
+          <span className="dashboard-topbar-title dashboard-topbar-title-full">MeshMonitor — MeshCore</span>
+          {sourceName && (
+            <span className="dashboard-topbar-title dashboard-topbar-title-short">{sourceName}</span>
+          )}
         </div>
         {localNodeLabel && (
           <div className="node-info">

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -47,6 +47,10 @@
   letter-spacing: -0.01em;
 }
 
+.dashboard-topbar-title-short {
+  display: none;
+}
+
 .dashboard-topbar-actions {
   margin-left: auto;
   display: flex;
@@ -729,14 +733,49 @@
     justify-content: center;
   }
 
-  /* Tighten up the topbar on mobile so the logo/title still fit */
+  /* Tighten up the topbar on mobile */
   .dashboard-topbar {
-    padding: 0 12px;
-    gap: 8px;
+    padding: 0 8px;
+    gap: 6px;
   }
 
-  .dashboard-topbar-title {
-    font-size: 1.2rem;
+  .dashboard-topbar-logo-img {
+    display: none;
+  }
+
+  .dashboard-topbar-title-full {
+    display: none;
+  }
+
+  .dashboard-topbar-title-short {
+    display: inline;
+    font-size: 1rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 140px;
+  }
+
+  .dashboard-topbar .node-info {
+    display: none;
+  }
+
+  .dashboard-topbar .back-to-sources-btn {
+    padding: 0.2rem 0.5rem;
+    font-size: 0.8rem;
+  }
+
+  .dashboard-topbar-actions {
+    gap: 6px;
+  }
+
+  .dashboard-topbar .connection-status span:not(.status-indicator) {
+    display: none;
+  }
+
+  .dashboard-signin-btn {
+    padding: 5px 10px;
+    font-size: 0.8rem;
   }
 
   /* Sidebar becomes a slide-in overlay drawer */


### PR DESCRIPTION
## Summary
- **Mobile bottom nav**: Sub-toolbar converts from a left sidebar to a horizontal bottom tab bar on viewports ≤768px
- **Full-width list/content toggle**: Two-pane views (Nodes, Channels, Rooms, DMs) show either the list or the content full-width on mobile, with a back button to navigate between them
- **Collapsible sections**: Configuration form sections and Info view cards can be collapsed/expanded via chevron toggle (new `CollapsibleSection` component)
- **Responsive dashboard topbar**: Hides logo and node info on mobile; replaces "MeshMonitor — MeshCore" with the source name

## Test plan
- [ ] Open MeshCore source on iPhone or Chrome DevTools device emulation (375px width)
- [ ] Verify bottom tab bar navigation works across all views
- [ ] Tap a node/channel/contact/room → content goes full-width with back button
- [ ] Tap back → returns to list
- [ ] Collapse/expand sections in Configuration and Info views
- [ ] Verify topbar shows source name on mobile, full title on desktop
- [ ] Verify desktop layout is unchanged (no regressions above 768px)
- [ ] All 5663 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)