### PR TITLE
feat(meshcore): Show Paths map feature with hop-count colored lines

### DIFF
--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from 'react';
-import { MapContainer, TileLayer, Marker, Popup, Tooltip } from 'react-leaflet';
+import React, { useMemo, useState } from 'react';
+import { MapContainer, TileLayer, Marker, Popup, Tooltip, Polyline } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { useSettings } from '../../contexts/SettingsContext';
@@ -10,9 +10,30 @@ const MESHCORE_COLOR = '#cba6f7';
 const DEFAULT_CENTER: [number, number] = [0, 0];
 const DEFAULT_ZOOM = 2;
 
+const PATH_COLORS: Record<string, string> = {
+  direct: '#a6e3a1',
+  short: '#89b4fa',
+  long: '#fab387',
+  unknown: '#6c7086',
+};
+
+function hopCountColor(hops: number | null | undefined): string {
+  if (hops === null || hops === undefined) return PATH_COLORS.unknown;
+  if (hops === 0) return PATH_COLORS.direct;
+  if (hops <= 2) return PATH_COLORS.short;
+  return PATH_COLORS.long;
+}
+
+function hopCountLabel(hops: number | null | undefined): string {
+  if (hops === null || hops === undefined) return 'Unknown';
+  if (hops === 0) return 'Direct';
+  return `${hops} hop${hops > 1 ? 's' : ''}`;
+}
+
 interface MeshCoreMapProps {
   contacts: MeshCoreContact[];
   selectedPublicKey: string | null;
+  localNodePosition?: { lat: number; lng: number } | null;
 }
 
 function makeIcon(name: string): L.DivIcon {
@@ -51,9 +72,10 @@ function makeIcon(name: string): L.DivIcon {
   });
 }
 
-export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPublicKey }) => {
+export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPublicKey, localNodePosition }) => {
   const { mapTileset, customTilesets } = useSettings();
   const tileset = getTilesetById(mapTileset, customTilesets);
+  const [showPaths, setShowPaths] = useState(true);
 
   const positioned = useMemo(
     () => contacts.filter(c =>
@@ -61,6 +83,29 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
       && typeof c.longitude === 'number' && isFinite(c.longitude)),
     [contacts],
   );
+
+  const localPos = useMemo((): [number, number] | null => {
+    if (localNodePosition?.lat != null && localNodePosition?.lng != null) {
+      return [localNodePosition.lat, localNodePosition.lng];
+    }
+    const local = positioned.find(c => c.advName?.includes('(local)'));
+    if (local) return [local.latitude!, local.longitude!];
+    return null;
+  }, [localNodePosition, positioned]);
+
+  const pathSegments = useMemo(() => {
+    if (!showPaths || !localPos) return [];
+    return positioned
+      .filter(c => !c.advName?.includes('(local)') && typeof c.pathLen === 'number')
+      .map(c => ({
+        key: c.publicKey,
+        from: localPos,
+        to: [c.latitude!, c.longitude!] as [number, number],
+        color: hopCountColor(c.pathLen),
+        label: `${c.advName || c.name || c.publicKey.substring(0, 8)}: ${hopCountLabel(c.pathLen)}`,
+        hops: c.pathLen ?? -1,
+      }));
+  }, [showPaths, localPos, positioned]);
 
   const { center, zoom } = useMemo(() => {
     if (selectedPublicKey) {
@@ -75,7 +120,7 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
   }, [positioned, selectedPublicKey]);
 
   return (
-    <div className="meshcore-map-pane">
+    <div className="meshcore-map-pane" style={{ position: 'relative' }}>
       <MapContainer
         key={`${center[0]}-${center[1]}-${zoom}`}
         center={center}
@@ -99,6 +144,7 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
                 <strong>{name}</strong>
                 {typeof c.rssi === 'number' && <><br />RSSI: {c.rssi} dBm</>}
                 {typeof c.snr === 'number' && <><br />SNR: {c.snr} dB</>}
+                {typeof c.pathLen === 'number' && <><br />Path: {hopCountLabel(c.pathLen)}</>}
               </Tooltip>
               <Popup>
                 <div style={{ minWidth: 200 }}>
@@ -109,13 +155,44 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
                   Key: {c.publicKey.substring(0, 16)}…
                   {typeof c.rssi === 'number' && <><br />RSSI: {c.rssi} dBm</>}
                   {typeof c.snr === 'number' && <><br />SNR: {c.snr} dB</>}
+                  {typeof c.pathLen === 'number' && <><br />Path: {hopCountLabel(c.pathLen)}</>}
+                  {c.outPath && <><br />Route: {c.outPath}</>}
                   {c.lastSeen && <><br />Last seen: {new Date(c.lastSeen).toLocaleString()}</>}
                 </div>
               </Popup>
             </Marker>
           );
         })}
+
+        {pathSegments.map(s => (
+          <Polyline
+            key={`path-${s.key}`}
+            positions={[s.from, s.to]}
+            pathOptions={{
+              color: s.color,
+              weight: 3,
+              opacity: 0.8,
+              dashArray: s.hops === 0 ? undefined : '8 4',
+            }}
+          >
+            <Tooltip sticky>{s.label}</Tooltip>
+          </Polyline>
+        ))}
       </MapContainer>
+
+      <div className="map-controls dashboard-map-controls">
+        <div className="map-controls-body">
+          <div className="map-controls-title">Features</div>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showPaths}
+              onChange={(e) => setShowPaths(e.target.checked)}
+            />
+            <span>Show Paths</span>
+          </label>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -1011,6 +1011,55 @@
 }
 
 /* ============================================================
+ * MeshCore map controls (Features panel overlay)
+ * ============================================================ */
+
+.meshcore-map-pane .map-controls {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 1000;
+  background: var(--ctp-surface0);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  user-select: none;
+}
+
+.meshcore-map-pane .map-controls-body {
+  padding: 0.75rem;
+}
+
+.meshcore-map-pane .map-controls-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ctp-mauve);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.4rem;
+}
+
+.meshcore-map-pane .map-control-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.meshcore-map-pane .map-control-item input[type='checkbox'] {
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+  accent-color: var(--ctp-mauve);
+}
+
+.meshcore-map-pane .map-control-item span {
+  color: var(--ctp-text);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+/* ============================================================
  * Mobile back button (shown in content pane header on mobile)
  * ============================================================ */
 


### PR DESCRIPTION
## Summary
- **Path visualization**: Draws Polylines from local node to each contact with a known forwarding path (`pathLen` set)
- **Hop-count coloring**: Green solid = direct (0 hops), blue dashed = 1-2 hops, orange dashed = 3+
- **Features panel**: Map overlay with "Show Paths" checkbox toggle (on by default), matching the Meshtastic DashboardMap pattern
- **Enhanced tooltips**: Node markers now show path info (hop count + raw outPath hex chain) in tooltips and popups

Only contacts with an established path are drawn — contacts discovered via adverts but without a forwarding route (pathLen=null) are not visualized.

## Test plan
- [ ] Open a MeshCore source → Nodes view → map
- [ ] Verify "Features" panel appears top-right of map with "Show Paths" checkbox
- [ ] Verify path lines drawn from local node to contacts with known paths
- [ ] Verify color coding: green=direct, blue=short, orange=long, dashed for multi-hop
- [ ] Hover path line → tooltip shows contact name and hop count
- [ ] Uncheck "Show Paths" → lines disappear
- [ ] Click a node marker → popup shows path info and outPath hex
- [ ] Desktop and mobile layouts work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)