### PR TITLE
feat(meshcore): handle path discovery response (0x8D) for instant path updates

### DIFF
--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -730,6 +730,47 @@ class MeshCoreManager extends EventEmitter {
         this.schedulePathRefresh(publicKey);
         logger.info(`[MeshCore] contact_path_updated for ${publicKey} (refresh scheduled)`);
       }
+    } else if (event_type === 'path_discovery_response') {
+      // 0x8D push from CMD 52 — carries the actual bidirectional path
+      // bytes so we can update the contact directly without a device
+      // round-trip. The pubkey_prefix is 6 bytes; resolve to full key.
+      const prefix: string = data.pubkey_prefix;
+      const outHops: number = data.out_path_len ?? 0;
+      const outPathHex: string = data.out_path_hex ?? '';
+      const outHashSize: number = data.out_hash_size ?? 1;
+      const inHops: number = data.in_path_len ?? 0;
+      const inPathHex: string = data.in_path_hex ?? '';
+
+      const contact = this.resolveContactByPrefix(prefix);
+      if (!contact) {
+        logger.warn(`[MeshCore] path_discovery_response for unknown prefix ${prefix}`);
+        return;
+      }
+
+      const formatPathHex = (hex: string, hashSize: number): string => {
+        if (!hex) return '';
+        const bytes: string[] = [];
+        for (let i = 0; i < hex.length; i += hashSize * 2) {
+          bytes.push(hex.substring(i, i + hashSize * 2));
+        }
+        return bytes.join(',');
+      };
+
+      const outPathFormatted = formatPathHex(outPathHex, outHashSize);
+      const updated: MeshCoreContact = {
+        ...contact,
+        outPath: outPathFormatted || null,
+        pathLen: outHops,
+        lastSeen: Date.now(),
+      };
+      this.contacts.set(contact.publicKey, updated);
+      void this.persistContact(updated);
+      this.emit('contacts_updated', { sourceId: this.sourceId, contact: updated });
+      dataEventEmitter.emitMeshCoreContactUpdated(updated, this.sourceId);
+      logger.info(
+        `[MeshCore] Path discovery response for ${contact.publicKey.substring(0, 16)}…: ` +
+        `out=${outHops} hops [${outPathFormatted}], in=${inHops} hops [${formatPathHex(inPathHex, data.in_hash_size ?? 1)}]`,
+      );
     } else {
       logger.debug(`[MeshCore] Unknown push event: ${event_type}`);
     }

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -340,6 +340,46 @@ export class MeshCoreNativeBackend extends EventEmitter {
       });
     });
 
+    // PathDiscoveryResponse (0x8D) — not in meshcore.js PushCodes, so we
+    // intercept raw frames. Contains the bidirectional paths discovered by
+    // CMD_SEND_PATH_DISCOVERY_REQ (52). Frame format:
+    //   [0x8D] [reserved] [pubkey_prefix 6B] [out_path_len] [out_path...] [in_path_len] [in_path...]
+    // path_len is packed: top 2 bits = hash_size-1, bottom 6 = hop_count.
+    const PUSH_PATH_DISCOVERY_RESPONSE = 0x8D;
+    this.connection.on('rx', (frame: Uint8Array) => {
+      if (!frame || frame.length < 2 || frame[0] !== PUSH_PATH_DISCOVERY_RESPONSE) return;
+      try {
+        let offset = 2; // skip code + reserved
+        const pubkeyPrefix = bytesToHex(frame.slice(offset, offset + 6));
+        offset += 6;
+
+        const outPathLenRaw = frame[offset++];
+        const outHashSize = ((outPathLenRaw >> 6) & 0x03) + 1;
+        const outHopCount = outPathLenRaw & 0x3F;
+        const outPathBytes = outHopCount * outHashSize;
+        const outPath = bytesToHex(frame.slice(offset, offset + outPathBytes));
+        offset += outPathBytes;
+
+        const inPathLenRaw = frame[offset++];
+        const inHashSize = ((inPathLenRaw >> 6) & 0x03) + 1;
+        const inHopCount = inPathLenRaw & 0x3F;
+        const inPathBytes = inHopCount * inHashSize;
+        const inPath = bytesToHex(frame.slice(offset, offset + inPathBytes));
+
+        this.emitBridgeEvent('path_discovery_response', {
+          pubkey_prefix: pubkeyPrefix,
+          out_path_len: outHopCount,
+          out_path_hex: outPath,
+          out_hash_size: outHashSize,
+          in_path_len: inHopCount,
+          in_path_hex: inPath,
+          in_hash_size: inHashSize,
+        });
+      } catch (err) {
+        logger.warn(`[MeshCore:native] Failed to parse 0x8D frame: ${(err as Error).message}`);
+      }
+    });
+
     // SendConfirmed → send_confirmed (message ACK with round-trip time)
     this.connection.on(PushCodes.SendConfirmed, (push: any) => {
       this.emitBridgeEvent('send_confirmed', {


### PR DESCRIPTION
## Summary
- **Closes the loop on CMD 52**: Previously we sent the path discovery flood but ignored the firmware's response push (0x8D), relying on the generic PathUpdated (0x81) which triggers a full device round-trip via refreshContacts()
- **Direct path update**: The 0x8D frame carries both outbound and inbound path data (relay hashes + hop counts), so the manager can update the contact record immediately without querying the device
- **Raw frame interception**: Since meshcore.js doesn't define push code 0x8D, the native backend listens on the connection's `"rx"` event and filters for the 0x8D code byte

## Frame format parsed
```
[0x8D] [reserved] [pubkey_prefix 6B] [out_path_len] [out_path...] [in_path_len] [in_path...]
```
Where `path_len` is packed: top 2 bits = hash_size-1, bottom 6 bits = hop_count.

## What changes
- **meshcoreNativeBackend.ts**: Intercepts raw 0x8D frames, parses packed path fields, emits `path_discovery_response` bridge event with both paths
- **meshcoreManager.ts**: Handles `path_discovery_response` — resolves 6-byte pubkey prefix to full contact, formats outPath, updates contact directly, persists to DB, emits to frontend

## Test plan
- [ ] Click "Discover Path" on a reachable Companion contact
- [ ] Verify server log shows "Path discovery response for ..." with hop count and path hex
- [ ] Verify the contact's Hops field updates in the UI without a manual refresh
- [ ] Verify the path line appears on the map (Show Paths feature)
- [ ] All 161 existing tests pass, TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)