### PR TITLE
feat(meshcore): @mention highlighting and delivery status indicators

### DIFF
--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -16,6 +16,35 @@ function formatTime(ts: number): string {
   return new Date(ts).toLocaleTimeString();
 }
 
+const MENTION_RE = /@\[([^\]]+)\]/g;
+
+function renderMessageText(text: string): React.ReactNode {
+  const parts: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  MENTION_RE.lastIndex = 0;
+  while ((match = MENTION_RE.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.substring(lastIndex, match.index));
+    }
+    const name = match[1];
+    parts.push(
+      <span
+        key={match.index}
+        className="mc-mention"
+        title={name}
+      >
+        @{name}
+      </span>,
+    );
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < text.length) {
+    parts.push(text.substring(lastIndex));
+  }
+  return parts.length > 0 ? parts : text;
+}
+
 export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
   messages,
   contacts,
@@ -150,9 +179,30 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                 <span className="mc-message-from" title={outgoing ? undefined : m.fromPublicKey}>
                   {fromLabel}
                 </span>
-                <span className="mc-message-time">{formatTime(m.timestamp)}</span>
+                <span className="mc-message-time">
+                  {formatTime(m.timestamp)}
+                  {outgoing && m.deliveryStatus && (
+                    <span
+                      className={`mc-delivery-status mc-delivery-${m.deliveryStatus}`}
+                      title={
+                        m.deliveryStatus === 'delivered'
+                          ? `Delivered (${m.roundTripMs}ms)`
+                          : m.deliveryStatus === 'failed'
+                            ? 'Delivery failed'
+                            : m.deliveryStatus === 'sent'
+                              ? 'Sent, awaiting confirmation'
+                              : 'Sending…'
+                      }
+                    >
+                      {m.deliveryStatus === 'delivered' ? ' ✓✓'
+                        : m.deliveryStatus === 'failed' ? ' ✗'
+                        : m.deliveryStatus === 'sent' ? ' ✓'
+                        : ' …'}
+                    </span>
+                  )}
+                </span>
               </div>
-              <div className="mc-message-text">{m.text}</div>
+              <div className="mc-message-text">{renderMessageText(m.text)}</div>
             </div>
           );
         })}

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -500,6 +500,25 @@
 .mc-message-time { color: var(--ctp-overlay0); }
 .mc-message-text { color: var(--ctp-text); font-size: 0.9rem; word-wrap: break-word; }
 
+.mc-mention {
+  color: var(--ctp-blue);
+  font-weight: 600;
+  cursor: default;
+  border-radius: var(--radius-sm);
+  padding: 0 0.15rem;
+  background: color-mix(in srgb, var(--ctp-blue) 12%, transparent);
+}
+
+.mc-delivery-status {
+  font-size: 0.75rem;
+  margin-left: 0.25rem;
+}
+
+.mc-delivery-sent { color: var(--ctp-overlay0); }
+.mc-delivery-delivered { color: var(--ctp-green); }
+.mc-delivery-failed { color: var(--ctp-red); }
+.mc-delivery-sending { color: var(--ctp-overlay0); }
+
 .meshcore-send-bar {
   display: flex;
   gap: 0.5rem;

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -63,6 +63,8 @@ export interface MeshCoreNode {
   ver?: string;
 }
 
+export type MessageDeliveryStatus = 'sending' | 'sent' | 'delivered' | 'failed';
+
 export interface MeshCoreMessage {
   id: string;
   fromPublicKey: string;
@@ -72,6 +74,10 @@ export interface MeshCoreMessage {
   timestamp: number;
   /** 'text' (default, DMs + channel) or 'room_post' (room server posts). */
   messageType?: string;
+  expectedAckCrc?: number;
+  estTimeout?: number;
+  deliveryStatus?: MessageDeliveryStatus;
+  roundTripMs?: number;
 }
 
 export interface ConnectionStatus {
@@ -397,10 +403,31 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     if (socket.connected) joinRoom();
     socket.on('connect', joinRoom);
 
+    const ackTimers = new Map<number, NodeJS.Timeout>();
+
+    const startAckTimeout = (ackCrc: number, timeoutMs: number) => {
+      if (ackTimers.has(ackCrc)) return;
+      const timer = setTimeout(() => {
+        ackTimers.delete(ackCrc);
+        setMessages(prev => prev.map(m =>
+          m.expectedAckCrc === ackCrc && m.deliveryStatus === 'sent'
+            ? { ...m, deliveryStatus: 'failed' as const }
+            : m,
+        ));
+      }, timeoutMs + 5000);
+      ackTimers.set(ackCrc, timer);
+    };
+
     const onMessage = (msg: MeshCoreMessageEvent) => {
       setMessages(prev => {
         if (prev.some(m => m.id === msg.id)) return prev;
-        return [...prev, msg];
+        const enriched: MeshCoreMessage = msg.expectedAckCrc
+          ? { ...msg, deliveryStatus: 'sent' as const }
+          : msg;
+        if (enriched.expectedAckCrc && enriched.estTimeout) {
+          startAckTimeout(enriched.expectedAckCrc, enriched.estTimeout);
+        }
+        return [...prev, enriched];
       });
       if (msg.timestamp > seqCursorRef.current) seqCursorRef.current = msg.timestamp;
     };
@@ -471,18 +498,36 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       })();
     };
 
+    const onSendConfirmed = (evt: { sourceId: string; ackCode: number; roundTripMs: number }) => {
+      if (evt.sourceId !== sourceId) return;
+      const timer = ackTimers.get(evt.ackCode);
+      if (timer) {
+        clearTimeout(timer);
+        ackTimers.delete(evt.ackCode);
+      }
+      setMessages(prev => prev.map(m =>
+        m.expectedAckCrc === evt.ackCode
+          ? { ...m, deliveryStatus: 'delivered' as const, roundTripMs: evt.roundTripMs }
+          : m,
+      ));
+    };
+
     socket.on('meshcore:message', onMessage);
     socket.on('meshcore:contact:updated', onContactUpdated);
     socket.on('meshcore:status:updated', onStatusUpdated);
     socket.on('meshcore:local-node:updated', onLocalNodeUpdated);
+    socket.on('meshcore:send-confirmed', onSendConfirmed);
     socket.io.on('reconnect', onReconnect);
 
     return () => {
+      for (const timer of ackTimers.values()) clearTimeout(timer);
+      ackTimers.clear();
       socket.off('connect', joinRoom);
       socket.off('meshcore:message', onMessage);
       socket.off('meshcore:contact:updated', onContactUpdated);
       socket.off('meshcore:status:updated', onStatusUpdated);
       socket.off('meshcore:local-node:updated', onLocalNodeUpdated);
+      socket.off('meshcore:send-confirmed', onSendConfirmed);
       socket.io.off('reconnect', onReconnect);
     };
   }, [enabled, sourceId, socket, mcPrefix, csrfFetch, setMeshCoreNodes, recomputeNodes]);

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -51,6 +51,8 @@ export interface MeshCoreMessageEvent {
   rssi?: number;
   snr?: number;
   sourceId?: string;
+  expectedAckCrc?: number;
+  estTimeout?: number;
 }
 
 export interface MeshCoreContactPayload {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -179,6 +179,12 @@ export interface MeshCoreMessage {
   sourceId?: string;
   /** 'text' (default, DMs + channel) or 'room_post' (room server posts). */
   messageType?: string;
+  /** 4-byte CRC from RESP_CODE_SENT — correlates with PUSH_CODE_SEND_CONFIRMED
+   *  to confirm delivery. Only set on outgoing DMs (not channels). */
+  expectedAckCrc?: number;
+  /** Estimated timeout in ms before the message should be considered failed.
+   *  Only set on outgoing DMs. */
+  estTimeout?: number;
 }
 
 export interface MeshCoreStatus {
@@ -1364,19 +1370,24 @@ class MeshCoreManager extends EventEmitter {
       });
 
       if (response.success) {
-        logger.info(`[MeshCore] Message sent: ${text.substring(0, 50)}...`);
+        const ackCrc: number | null = response.data?.expectedAckCrc ?? null;
+        const estTimeout: number | null = response.data?.estTimeout ?? null;
+        logger.info(`[MeshCore] Message sent: ${text.substring(0, 50)}... (ackCrc=${ackCrc}, estTimeout=${estTimeout})`);
 
         const sentToPublicKey = isChannelSend
           ? MeshCoreManager.channelPublicKey(channelIdx!)
           : (toPublicKey || undefined);
 
+        const msgId = `sent-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
         const sentMessage: MeshCoreMessage = {
-          id: `sent-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+          id: msgId,
           fromPublicKey: this.localNode?.publicKey || 'local',
           toPublicKey: sentToPublicKey,
           text: text,
           timestamp: Date.now(),
           sourceId: this.sourceId,
+          expectedAckCrc: ackCrc ?? undefined,
+          estTimeout: estTimeout ?? undefined,
         };
         this.addMessage(sentMessage);
         this.emit('message', sentMessage);

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -596,8 +596,12 @@ export class MeshCoreNativeBackend extends EventEmitter {
           if (!fullKey) {
             throw new Error(`Contact not found for public key ${to.substring(0, 12)}…`);
           }
-          await c.sendTextMessage(fullKey, text);
-          return { sent: true };
+          const sentResp = await c.sendTextMessage(fullKey, text);
+          return {
+            sent: true,
+            expectedAckCrc: sentResp?.expectedAckCrc ?? null,
+            estTimeout: sentResp?.estTimeout ?? null,
+          };
         }
         // No recipient → broadcast on a channel. `channel_idx` is optional;
         // historical callers omit it and get channel 0, which the firmware's


### PR DESCRIPTION
## Summary
- **@[NodeName] mention highlighting**: Parses `@[...]` patterns in message text and renders the node name inline with blue highlighted styling + subtle background
- **Message delivery status indicators** on outgoing DMs:
  - `✓` (gray) — sent to device, awaiting ACK
  - `✓✓` (green) — delivered to recipient (hover shows round-trip time)
  - `✗` (red) — delivery failed (ACK timeout expired)

## How delivery tracking works
1. Backend returns `expectedAckCrc` + `estTimeout` from the firmware's RESP_CODE_SENT response
2. Messages arriving via WebSocket with `expectedAckCrc` get `deliveryStatus: 'sent'`
3. A timeout timer starts (estTimeout + 5s buffer)
4. When `meshcore:send-confirmed` WebSocket event arrives with matching `ackCode`, status flips to `delivered` with round-trip time
5. If timeout expires without confirmation, status flips to `failed`
6. Channel messages have no delivery tracking (fire-and-forget per MeshCore protocol)
7. Delivery status is ephemeral (in-memory only, not persisted to DB)

## Test plan
- [ ] Send a DM to a reachable contact → verify ✓ appears, then ✓✓ when delivered
- [ ] Send a DM to an unreachable contact → verify ✓ appears, then ✗ after timeout
- [ ] Send a channel message → verify no delivery indicator shown
- [ ] Receive a message containing `@[SomeName]` → verify mention is highlighted blue
- [ ] Receive a message without mentions → verify plain text unchanged
- [ ] All 44 MeshCore tests pass, TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)