### PR TITLE
feat(meshcore): neighbors support for repeaters

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2935,22 +2935,27 @@ function App() {
       // Set loading state
       setNeighborInfoLoading(nodeId);
 
-      // Convert nodeId to node number for backend
-      const nodeNumStr = nodeId.replace('!', '');
-      const nodeNum = parseInt(nodeNumStr, 16);
+      if (sourceType === 'meshcore' && sourceId) {
+        // MeshCore: nodeId is the 64-char hex public key
+        await authFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/neighbors/request`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ publicKey: nodeId }),
+        });
+        logger.debug(`🏠 MeshCore neighbors request sent for ${nodeId.substring(0, 16)}…`);
+      } else {
+        // Meshtastic: convert hex nodeId to numeric destination
+        const nodeNumStr = nodeId.replace('!', '');
+        const nodeNum = parseInt(nodeNumStr, 16);
+        await authFetch(`${baseUrl}/api/neighborinfo/request`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ destination: nodeNum, sourceId: sourceId || undefined }),
+        });
+        logger.debug(`🏠 NeighborInfo request sent to ${nodeId}`);
+      }
 
-      // Use direct fetch with CSRF token
-      await authFetch(`${baseUrl}/api/neighborinfo/request`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ destination: nodeNum, sourceId: sourceId || undefined }),
-      });
-
-      logger.debug(`🏠 NeighborInfo request sent to ${nodeId}`);
-
-      // Clear loading state after 30 seconds (firmware rate-limits to 3 min anyway)
+      // Clear loading state after 30 seconds
       setTimeout(() => {
         setNeighborInfoLoading(null);
       }, 30000);

--- a/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
+++ b/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
@@ -215,17 +215,21 @@ export default function AnalysisInspectorPanel() {
   }
 
   if (selected.type === 'neighbor') {
-    const fromNode = findNode(selected.nodeNum ?? 0, selected.sourceId);
-    const toNode = findNode(selected.neighborNum ?? 0, selected.sourceId);
-    const fromName = nodeName(fromNode, selected.nodeNum ?? 0);
-    const toName = nodeName(toNode, selected.neighborNum ?? 0);
+    const isMeshCore = !!selected.publicKey;
+    const fromName = isMeshCore
+      ? (selected.nodeName ?? selected.publicKey?.substring(0, 12) ?? '?')
+      : nodeName(findNode(selected.nodeNum ?? 0, selected.sourceId), selected.nodeNum ?? 0);
+    const toName = isMeshCore
+      ? (selected.neighborName ?? selected.neighborPublicKey?.substring(0, 12) ?? '?')
+      : nodeName(findNode(selected.neighborNum ?? 0, selected.sourceId), selected.neighborNum ?? 0);
+    const subtitle = isMeshCore
+      ? `${selected.publicKey?.substring(0, 8) ?? ''} ↔ ${selected.neighborPublicKey?.substring(0, 8) ?? ''}`
+      : `!${(selected.nodeNum ?? 0).toString(16)} ↔ !${(selected.neighborNum ?? 0).toString(16)}`;
     const snr = selected.snr;
     return wrap(
       <>
         <h3>Neighbor Link</h3>
-        <div className="subtitle">
-          !{(selected.nodeNum ?? 0).toString(16)} ↔ !{(selected.neighborNum ?? 0).toString(16)}
-        </div>
+        <div className="subtitle">{subtitle}</div>
         <hr />
         <dl>
           <dt>Node</dt>

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -7,6 +7,7 @@ import { TilesetSelector } from '../TilesetSelector';
 import NodeMarkersLayer from './layers/NodeMarkersLayer';
 import TraceroutePathsLayer from './layers/TraceroutePathsLayer';
 import NeighborLinksLayer from './layers/NeighborLinksLayer';
+import MeshCoreNeighborLinksLayer from './layers/MeshCoreNeighborLinksLayer';
 import PositionTrailsLayer from './layers/PositionTrailsLayer';
 import CoverageHeatmapLayer from './layers/CoverageHeatmapLayer';
 import SnrOverlayLayer from './layers/SnrOverlayLayer';
@@ -55,6 +56,7 @@ export default function MapAnalysisCanvas() {
         </Pane>
         <Pane name="neighbors" style={{ zIndex: 450 }}>
           {config.layers.neighbors.enabled && <NeighborLinksLayer />}
+          {config.layers.neighbors.enabled && <MeshCoreNeighborLinksLayer />}
         </Pane>
         <Pane name="snrOverlay" style={{ zIndex: 420 }}>
           {config.layers.snrOverlay.enabled && <SnrOverlayLayer />}

--- a/src/components/MapAnalysis/MapAnalysisContext.tsx
+++ b/src/components/MapAnalysis/MapAnalysisContext.tsx
@@ -14,6 +14,8 @@ export interface SelectedTarget {
   // MeshCore neighbor-specific
   publicKey?: string;
   neighborPublicKey?: string;
+  nodeName?: string | null;
+  neighborName?: string | null;
   // trail-specific
   pointCount?: number;
   startMs?: number;

--- a/src/components/MapAnalysis/MapAnalysisContext.tsx
+++ b/src/components/MapAnalysis/MapAnalysisContext.tsx
@@ -11,6 +11,9 @@ export interface SelectedTarget {
   neighborNum?: number;
   snr?: number | null;
   timestamp?: number;
+  // MeshCore neighbor-specific
+  publicKey?: string;
+  neighborPublicKey?: string;
   // trail-specific
   pointCount?: number;
   startMs?: number;

--- a/src/components/MapAnalysis/layers/MeshCoreNeighborLinksLayer.tsx
+++ b/src/components/MapAnalysis/layers/MeshCoreNeighborLinksLayer.tsx
@@ -22,6 +22,8 @@ interface MeshCoreNeighborEdge {
   sourceId: string;
   snr: number | null;
   timestamp: number;
+  nodeName: string | null;
+  neighborName: string | null;
 }
 
 interface MCNodeRecord extends MaybePositionedNode {
@@ -70,6 +72,8 @@ export default function MeshCoreNeighborLinksLayer() {
       sourceId: string;
       publicKey: string;
       neighborPublicKey: string;
+      nodeName: string | null;
+      neighborName: string | null;
       snr: number | null;
       timestamp: number;
     }> = [];
@@ -88,6 +92,8 @@ export default function MeshCoreNeighborLinksLayer() {
         sourceId: e.sourceId,
         publicKey: e.publicKey,
         neighborPublicKey: e.neighborPublicKey,
+        nodeName: e.nodeName,
+        neighborName: e.neighborName,
         snr: e.snr,
         timestamp: e.timestamp,
       });
@@ -110,6 +116,8 @@ export default function MeshCoreNeighborLinksLayer() {
                 sourceId: e.sourceId,
                 publicKey: e.publicKey,
                 neighborPublicKey: e.neighborPublicKey,
+                nodeName: e.nodeName,
+                neighborName: e.neighborName,
                 snr: e.snr,
                 timestamp: e.timestamp,
                 nodeNum: 0,

--- a/src/components/MapAnalysis/layers/MeshCoreNeighborLinksLayer.tsx
+++ b/src/components/MapAnalysis/layers/MeshCoreNeighborLinksLayer.tsx
@@ -1,0 +1,123 @@
+import { Polyline } from 'react-leaflet';
+import { useMemo } from 'react';
+import {
+  useDashboardSources,
+  useDashboardUnifiedData,
+} from '../../../hooks/useDashboardData';
+import { useMeshCoreNeighbors } from '../../../hooks/useMapAnalysisData';
+import { useMapAnalysisCtx } from '../MapAnalysisContext';
+import { resolveNodeLatLng, type MaybePositionedNode } from '../nodePositionUtil';
+
+function snrToOpacity(snr: number | null): number {
+  if (snr === null) return 0.4;
+  return Math.max(0.2, Math.min(1, (snr + 10) / 20));
+}
+
+const MC_NEIGHBOR_COLOR = '#06b6d4';
+
+interface MeshCoreNeighborEdge {
+  id: number;
+  publicKey: string;
+  neighborPublicKey: string;
+  sourceId: string;
+  snr: number | null;
+  timestamp: number;
+}
+
+interface MCNodeRecord extends MaybePositionedNode {
+  sourceId?: string;
+  isMeshCore?: boolean;
+  publicKey?: string;
+}
+
+export default function MeshCoreNeighborLinksLayer() {
+  const { config, setSelected } = useMapAnalysisCtx();
+  const layer = config.layers.neighbors;
+  const { data: sources = [] } = useDashboardSources();
+  const sourceIds =
+    config.sources.length === 0
+      ? (sources as { id: string }[]).map((s) => s.id)
+      : config.sources;
+  const { data } = useMeshCoreNeighbors({
+    enabled: layer.enabled,
+    sources: sourceIds,
+    lookbackHours: layer.lookbackHours ?? 24,
+  });
+  const { nodes } = useDashboardUnifiedData(sourceIds, sourceIds.length > 0);
+
+  const positionByKey = useMemo(() => {
+    const map = new Map<string, [number, number]>();
+    for (const n of (nodes ?? []) as MCNodeRecord[]) {
+      if (!n.isMeshCore || !n.publicKey) continue;
+      const ll = resolveNodeLatLng(n);
+      if (ll) map.set(`${n.sourceId ?? ''}:${n.publicKey}`, ll);
+    }
+    return map;
+  }, [nodes]);
+
+  const ts = config.timeSlider;
+  const inWindow = (t: number): boolean =>
+    !ts.enabled ||
+    ts.windowStartMs === undefined ||
+    ts.windowEndMs === undefined ||
+    (t >= ts.windowStartMs && t <= ts.windowEndMs);
+
+  const edges = useMemo(() => {
+    const out: Array<{
+      key: string;
+      positions: [number, number][];
+      opacity: number;
+      sourceId: string;
+      publicKey: string;
+      neighborPublicKey: string;
+      snr: number | null;
+      timestamp: number;
+    }> = [];
+    const items = (data as { items?: MeshCoreNeighborEdge[] } | undefined)?.items ?? [];
+    const filtered = items.filter((e) => inWindow(e.timestamp));
+    for (const e of filtered) {
+      const aKey = `${e.sourceId}:${e.publicKey}`;
+      const bKey = `${e.sourceId}:${e.neighborPublicKey}`;
+      const a = positionByKey.get(aKey);
+      const b = positionByKey.get(bKey);
+      if (!a || !b) continue;
+      out.push({
+        key: String(e.id),
+        positions: [a, b],
+        opacity: snrToOpacity(e.snr),
+        sourceId: e.sourceId,
+        publicKey: e.publicKey,
+        neighborPublicKey: e.neighborPublicKey,
+        snr: e.snr,
+        timestamp: e.timestamp,
+      });
+    }
+    return out;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, positionByKey, ts.enabled, ts.windowStartMs, ts.windowEndMs]);
+
+  return (
+    <>
+      {edges.map((e) => (
+        <Polyline
+          key={e.key}
+          positions={e.positions}
+          pathOptions={{ color: MC_NEIGHBOR_COLOR, weight: 1.5, opacity: e.opacity, dashArray: '6 4' }}
+          eventHandlers={{
+            click: () =>
+              setSelected({
+                type: 'neighbor',
+                sourceId: e.sourceId,
+                publicKey: e.publicKey,
+                neighborPublicKey: e.neighborPublicKey,
+                snr: e.snr,
+                timestamp: e.timestamp,
+                nodeNum: 0,
+                neighborNum: 0,
+              }),
+          }}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { formatRelativeTime } from '../../utils/datetime';
 import { useSettings } from '../../contexts/SettingsContext';
+import { useSource } from '../../contexts/SourceContext';
 import { MeshCoreRemoteConsole } from './MeshCoreRemoteConsole';
 import type { MeshCoreActions, TracePathResult } from './hooks/useMeshCore';
+import api from '../../services/api';
 import '../NodeDetailsBlock.css';
 
 const DEVICE_TYPE_KEYS: Record<number, string> = {
@@ -98,6 +100,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
 }) => {
   const { t } = useTranslation();
   const { timeFormat, dateFormat } = useSettings();
+  const { sourceId } = useSource();
   const [isCollapsed, setIsCollapsed] = useState<boolean>(() => {
     return localStorage.getItem(COLLAPSED_KEY) === 'true';
   });
@@ -125,7 +128,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   const [neighboursLoading, setNeighboursLoading] = useState(false);
   const [neighboursData, setNeighboursData] = useState<{
     total: number;
-    neighbours: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }[];
+    neighbours: { publicKeyPrefix: string; name?: string | null; heardSecondsAgo: number; snr: number }[];
+    fetchedAt?: number;
   } | null>(null);
 
   // Path-editor modal state. Only mounted when advancedPathEditEnabled.
@@ -160,6 +164,37 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     setNeighboursLoading(false);
     setNeighboursData(null);
   }, [publicKey]);
+
+  // Auto-load stored neighbor data from the database for repeaters.
+  const loadStoredNeighbors = useCallback(async () => {
+    if (!sourceId || contact?.advType !== 2) return;
+    try {
+      const resp = await api.get<{
+        success: boolean;
+        data: { items: Array<{ neighborPublicKey: string; neighborName: string | null; snr: number | null; timestamp: number }> };
+      }>(`/api/sources/${sourceId}/meshcore/neighbors?since=0&node=${encodeURIComponent(publicKey)}`);
+      if (resp.success && resp.data.items.length > 0) {
+        const ts = resp.data.items[0].timestamp;
+        setNeighboursData({
+          total: resp.data.items.length,
+          neighbours: resp.data.items.map((n) => ({
+            publicKeyPrefix: n.neighborPublicKey.substring(0, 8),
+            name: n.neighborName,
+            heardSecondsAgo: 0,
+            snr: n.snr ?? 0,
+          })),
+          fetchedAt: ts,
+        });
+      }
+    } catch {
+      // Stored data is a nicety — if the fetch fails, the user can
+      // still click Neighbours to fetch live data.
+    }
+  }, [sourceId, publicKey, contact?.advType]);
+
+  useEffect(() => {
+    void loadStoredNeighbors();
+  }, [loadStoredNeighbors]);
 
   const name = contact?.advName || contact?.name || `${publicKey.substring(0, 8)}…`;
   const advType = contact?.advType;
@@ -364,7 +399,9 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     setNeighboursData(null);
     try {
       const result = await onGetNeighbours(publicKey, { count: 20 });
-      setNeighboursData(result);
+      if (result) {
+        setNeighboursData({ ...result, fetchedAt: Date.now() });
+      }
     } finally {
       setNeighboursLoading(false);
     }
@@ -648,6 +685,11 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
               <div className="node-detail-label">
                 {t('meshcore.contact_details.neighbours_results', 'Neighbours')}
                 {' '}({neighboursData.total} {t('meshcore.contact_details.neighbours_total', 'total')})
+                {neighboursData.fetchedAt && (
+                  <span style={{ fontSize: '0.8em', opacity: 0.6, marginLeft: '0.5rem' }}>
+                    {formatRelativeTime(neighboursData.fetchedAt, timeFormat, dateFormat)}
+                  </span>
+                )}
               </div>
               <div className="node-detail-value">
                 {neighboursData.neighbours.length === 0 ? (
@@ -659,7 +701,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     <thead>
                       <tr style={{ borderBottom: '1px solid var(--ctp-surface1, #45475a)' }}>
                         <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem' }}>
-                          {t('meshcore.contact_details.neighbours_prefix', 'Key Prefix')}
+                          {t('meshcore.contact_details.neighbours_name', 'Node')}
                         </th>
                         <th style={{ textAlign: 'right', padding: '0.25rem 0.5rem' }}>
                           {t('meshcore.contact_details.neighbours_snr', 'SNR')}
@@ -672,7 +714,9 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     <tbody>
                       {neighboursData.neighbours.map((n, i) => (
                         <tr key={i}>
-                          <td style={{ padding: '0.25rem 0.5rem' }}>{n.publicKeyPrefix}</td>
+                          <td style={{ padding: '0.25rem 0.5rem' }} title={n.publicKeyPrefix}>
+                            {n.name || n.publicKeyPrefix}
+                          </td>
                           <td style={{ padding: '0.25rem 0.5rem', textAlign: 'right' }}
                               className={getSignalClass(n.snr)}>
                             {n.snr.toFixed(2)} dB

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -128,13 +128,15 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
     api.get<{ success: boolean; data: { items: NeighborEdge[] } }>(
       `/api/sources/${sourceId}/meshcore/neighbors?since=0`,
     ).then((resp) => {
-      if (!cancelled && resp.success) setNeighborEdges(resp.data.items);
+      if (!cancelled && resp.success && Array.isArray(resp.data?.items)) {
+        setNeighborEdges(resp.data.items);
+      }
     }).catch(() => {});
     return () => { cancelled = true; };
   }, [sourceId]);
 
   const neighborSegments = useMemo(() => {
-    if (!showNeighbors || neighborEdges.length === 0) return [];
+    if (!showNeighbors || !neighborEdges?.length) return [];
     const posByKey = new Map<string, [number, number]>();
     for (const c of positioned) {
       posByKey.set(c.publicKey, [c.latitude!, c.longitude!]);

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -1,12 +1,15 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, Tooltip, Polyline } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { useSettings } from '../../contexts/SettingsContext';
+import { useSource } from '../../contexts/SourceContext';
 import { getTilesetById } from '../../config/tilesets';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
+import api from '../../services/api';
 
 const MESHCORE_COLOR = '#cba6f7';
+const NEIGHBOR_COLOR = '#06b6d4';
 const DEFAULT_CENTER: [number, number] = [0, 0];
 const DEFAULT_ZOOM = 2;
 
@@ -28,6 +31,14 @@ function hopCountLabel(hops: number | null | undefined): string {
   if (hops === null || hops === undefined) return 'Unknown';
   if (hops === 0) return 'Direct';
   return `${hops} hop${hops > 1 ? 's' : ''}`;
+}
+
+interface NeighborEdge {
+  publicKey: string;
+  neighborPublicKey: string;
+  nodeName: string | null;
+  neighborName: string | null;
+  snr: number | null;
 }
 
 interface MeshCoreMapProps {
@@ -75,8 +86,11 @@ function makeIcon(name: string): L.DivIcon {
 
 export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPublicKey, localNodePosition, onNavigateToDm }) => {
   const { mapTileset, customTilesets } = useSettings();
+  const { sourceId } = useSource();
   const tileset = getTilesetById(mapTileset, customTilesets);
   const [showPaths, setShowPaths] = useState(true);
+  const [showNeighbors, setShowNeighbors] = useState(true);
+  const [neighborEdges, setNeighborEdges] = useState<NeighborEdge[]>([]);
 
   const positioned = useMemo(
     () => contacts.filter(c =>
@@ -107,6 +121,34 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
         hops: c.pathLen ?? -1,
       }));
   }, [showPaths, localPos, positioned]);
+
+  useEffect(() => {
+    if (!sourceId) return;
+    let cancelled = false;
+    api.get<{ success: boolean; data: { items: NeighborEdge[] } }>(
+      `/api/sources/${sourceId}/meshcore/neighbors?since=0`,
+    ).then((resp) => {
+      if (!cancelled && resp.success) setNeighborEdges(resp.data.items);
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [sourceId]);
+
+  const neighborSegments = useMemo(() => {
+    if (!showNeighbors || neighborEdges.length === 0) return [];
+    const posByKey = new Map<string, [number, number]>();
+    for (const c of positioned) {
+      posByKey.set(c.publicKey, [c.latitude!, c.longitude!]);
+    }
+    return neighborEdges
+      .map((e) => {
+        const a = posByKey.get(e.publicKey);
+        const b = posByKey.get(e.neighborPublicKey);
+        if (!a || !b) return null;
+        const label = `${e.nodeName || e.publicKey.substring(0, 8)} ↔ ${e.neighborName || e.neighborPublicKey.substring(0, 8)}${e.snr != null ? ` (${e.snr.toFixed(1)} dB)` : ''}`;
+        return { key: `nb-${e.publicKey}-${e.neighborPublicKey}`, from: a, to: b, label };
+      })
+      .filter((s): s is NonNullable<typeof s> => s !== null);
+  }, [showNeighbors, neighborEdges, positioned]);
 
   const { center, zoom } = useMemo(() => {
     if (selectedPublicKey) {
@@ -201,6 +243,21 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
             <Tooltip sticky>{s.label}</Tooltip>
           </Polyline>
         ))}
+
+        {neighborSegments.map(s => (
+          <Polyline
+            key={s.key}
+            positions={[s.from, s.to]}
+            pathOptions={{
+              color: NEIGHBOR_COLOR,
+              weight: 1.5,
+              opacity: 0.7,
+              dashArray: '6 4',
+            }}
+          >
+            <Tooltip sticky>{s.label}</Tooltip>
+          </Polyline>
+        ))}
       </MapContainer>
 
       <div className="map-controls dashboard-map-controls">
@@ -213,6 +270,14 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
               onChange={(e) => setShowPaths(e.target.checked)}
             />
             <span>Show Paths</span>
+          </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showNeighbors}
+              onChange={(e) => setShowNeighbors(e.target.checked)}
+            />
+            <span>Show Neighbors</span>
           </label>
         </div>
       </div>

--- a/src/db/activeSchema.ts
+++ b/src/db/activeSchema.ts
@@ -92,6 +92,9 @@ import {
 import {
   meshcoreMessagesSqlite, meshcoreMessagesPostgres, meshcoreMessagesMysql,
 } from './schema/meshcoreMessages.js';
+import {
+  meshcoreNeighborsSqlite, meshcoreNeighborsPostgres, meshcoreNeighborsMysql,
+} from './schema/meshcoreNeighbors.js';
 
 // Embed Profiles table
 import {
@@ -168,6 +171,7 @@ export interface ActiveSchema {
   // MeshCore tables
   meshcoreNodes: any;
   meshcoreMessages: any;
+  meshcoreNeighbors: any;
 
   // Embed Profiles
   embedProfiles: any;
@@ -224,6 +228,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     ignoredNodes: ignoredNodesSqlite,
     meshcoreNodes: meshcoreNodesSqlite,
     meshcoreMessages: meshcoreMessagesSqlite,
+    meshcoreNeighbors: meshcoreNeighborsSqlite,
     embedProfiles: embedProfilesSqlite,
     waypoints: waypointsSqlite,
     sources: sourcesSqlite,
@@ -266,6 +271,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     ignoredNodes: ignoredNodesPostgres,
     meshcoreNodes: meshcoreNodesPostgres,
     meshcoreMessages: meshcoreMessagesPostgres,
+    meshcoreNeighbors: meshcoreNeighborsPostgres,
     embedProfiles: embedProfilesPostgres,
     waypoints: waypointsPostgres,
     sources: sourcesPostgres,
@@ -308,6 +314,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     ignoredNodes: ignoredNodesMysql,
     meshcoreNodes: meshcoreNodesMysql,
     meshcoreMessages: meshcoreMessagesMysql,
+    meshcoreNeighbors: meshcoreNeighborsMysql,
     embedProfiles: embedProfilesMysql,
     waypoints: waypointsMysql,
     sources: sourcesMysql,

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 72 migrations registered', () => {
-    expect(registry.count()).toBe(72);
+  it('has all 73 migrations registered', () => {
+    expect(registry.count()).toBe(73);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is meshcore_room_sync', () => {
+  it('last migration is meshcore_neighbor_info', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(72);
-    expect(last.name).toContain('meshcore_room_sync');
+    expect(last.number).toBe(73);
+    expect(last.name).toContain('meshcore_neighbor_info');
   });
 
-  it('migrations are sequentially numbered from 1 to 72', () => {
+  it('migrations are sequentially numbered from 1 to 73', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -87,6 +87,7 @@ import { migration as normalizeNodePublicKeysToBase64Migration, runMigration069P
 import { migration as meshcoreAdminCredentialMigration, runMigration070Postgres, runMigration070Mysql } from '../server/migrations/070_meshcore_admin_credential.js';
 import { migration as dropLegacyPskLengthCheckMigration, runMigration071Postgres, runMigration071Mysql } from '../server/migrations/071_drop_legacy_psk_length_check.js';
 import { migration as meshcoreRoomSyncMigration, runMigration072Postgres, runMigration072Mysql } from '../server/migrations/072_meshcore_room_sync.js';
+import { migration as meshcoreNeighborInfoMigration, runMigration073Postgres, runMigration073Mysql } from '../server/migrations/073_meshcore_neighbor_info.js';
 
 // ============================================================================
 // Registry
@@ -1149,4 +1150,18 @@ registry.register({
   sqlite: (db) => meshcoreRoomSyncMigration.up(db),
   postgres: (client) => runMigration072Postgres(client),
   mysql: (pool) => runMigration072Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 073: Create meshcore_neighbor_info table for storing parsed
+// neighbor data from MeshCore repeaters' CLI `neighbors` command.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 73,
+  name: 'meshcore_neighbor_info',
+  settingsKey: 'migration_073_meshcore_neighbor_info',
+  sqlite: (db) => meshcoreNeighborInfoMigration.up(db),
+  postgres: (client) => runMigration073Postgres(client),
+  mysql: (pool) => runMigration073Mysql(pool),
 });

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -4,7 +4,7 @@
  * Handles MeshCore node and message database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, desc, sql, isNull, and, lt, type SQL } from 'drizzle-orm';
+import { eq, desc, sql, isNull, and, lt, gte, inArray, type SQL } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType } from '../types.js';
 
@@ -587,5 +587,78 @@ export class MeshCoreRepository extends BaseRepository {
     const { meshcoreMessages } = this.tables;
     await this.db.delete(meshcoreMessages);
     return count;
+  }
+
+  // ============ Neighbor Methods ============
+
+  async insertNeighborsBatch(
+    sourceId: string,
+    publicKey: string,
+    neighbors: Array<{ neighborPublicKey: string; snr: number | null; lastHeardSecs: number | null }>,
+  ): Promise<void> {
+    const { meshcoreNeighbors } = this.tables;
+    const nowMs = Date.now();
+
+    await this.db
+      .delete(meshcoreNeighbors)
+      .where(and(eq(meshcoreNeighbors.sourceId, sourceId), eq(meshcoreNeighbors.publicKey, publicKey)));
+
+    if (neighbors.length === 0) return;
+
+    await this.db.insert(meshcoreNeighbors).values(
+      neighbors.map((n) => ({
+        sourceId,
+        publicKey,
+        neighborPublicKey: n.neighborPublicKey,
+        snr: n.snr,
+        lastHeardSecs: n.lastHeardSecs,
+        timestamp: nowMs,
+        createdAt: nowMs,
+      })),
+    );
+  }
+
+  async getNeighbors(
+    sourceIds: string[],
+    sinceMs: number = 0,
+  ): Promise<Array<{ id: number; sourceId: string; publicKey: string; neighborPublicKey: string; snr: number | null; timestamp: number }>> {
+    const { meshcoreNeighbors } = this.tables;
+    if (sourceIds.length === 0) return [];
+
+    const conditions: SQL[] = [
+      inArray(meshcoreNeighbors.sourceId, sourceIds),
+    ];
+    if (sinceMs > 0) {
+      conditions.push(gte(meshcoreNeighbors.timestamp, sinceMs));
+    }
+
+    return this.db
+      .select({
+        id: meshcoreNeighbors.id,
+        sourceId: meshcoreNeighbors.sourceId,
+        publicKey: meshcoreNeighbors.publicKey,
+        neighborPublicKey: meshcoreNeighbors.neighborPublicKey,
+        snr: meshcoreNeighbors.snr,
+        timestamp: meshcoreNeighbors.timestamp,
+      })
+      .from(meshcoreNeighbors)
+      .where(and(...conditions))
+      .orderBy(desc(meshcoreNeighbors.timestamp));
+  }
+
+  async deleteNeighborsForNode(sourceId: string, publicKey: string): Promise<void> {
+    const { meshcoreNeighbors } = this.tables;
+    await this.db
+      .delete(meshcoreNeighbors)
+      .where(and(eq(meshcoreNeighbors.sourceId, sourceId), eq(meshcoreNeighbors.publicKey, publicKey)));
+  }
+
+  async deleteAllNeighbors(sourceId?: string): Promise<void> {
+    const { meshcoreNeighbors } = this.tables;
+    if (sourceId) {
+      await this.db.delete(meshcoreNeighbors).where(eq(meshcoreNeighbors.sourceId, sourceId));
+    } else {
+      await this.db.delete(meshcoreNeighbors);
+    }
   }
 }

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -621,8 +621,8 @@ export class MeshCoreRepository extends BaseRepository {
   async getNeighbors(
     sourceIds: string[],
     sinceMs: number = 0,
-  ): Promise<Array<{ id: number; sourceId: string; publicKey: string; neighborPublicKey: string; snr: number | null; timestamp: number }>> {
-    const { meshcoreNeighbors } = this.tables;
+  ): Promise<Array<{ id: number; sourceId: string; publicKey: string; neighborPublicKey: string; snr: number | null; timestamp: number; nodeName: string | null; neighborName: string | null }>> {
+    const { meshcoreNeighbors, meshcoreNodes } = this.tables;
     if (sourceIds.length === 0) return [];
 
     const conditions: SQL[] = [
@@ -632,7 +632,7 @@ export class MeshCoreRepository extends BaseRepository {
       conditions.push(gte(meshcoreNeighbors.timestamp, sinceMs));
     }
 
-    return this.db
+    const rows = await this.db
       .select({
         id: meshcoreNeighbors.id,
         sourceId: meshcoreNeighbors.sourceId,
@@ -644,6 +644,29 @@ export class MeshCoreRepository extends BaseRepository {
       .from(meshcoreNeighbors)
       .where(and(...conditions))
       .orderBy(desc(meshcoreNeighbors.timestamp));
+
+    if (rows.length === 0) return [];
+
+    const allKeys = new Set<string>();
+    for (const r of rows) {
+      allKeys.add(r.publicKey);
+      allKeys.add(r.neighborPublicKey);
+    }
+
+    const nodes = await this.db
+      .select({ publicKey: meshcoreNodes.publicKey, name: meshcoreNodes.name })
+      .from(meshcoreNodes)
+      .where(and(
+        inArray(meshcoreNodes.sourceId, sourceIds),
+        inArray(meshcoreNodes.publicKey, [...allKeys]),
+      ));
+    const nameMap = new Map(nodes.map((n: { publicKey: string; name: string | null }) => [n.publicKey, n.name]));
+
+    return rows.map((r: typeof rows[number]) => ({
+      ...r,
+      nodeName: nameMap.get(r.publicKey) ?? null,
+      neighborName: nameMap.get(r.neighborPublicKey) ?? null,
+    }));
   }
 
   async deleteNeighborsForNode(sourceId: string, publicKey: string): Promise<void> {

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -33,6 +33,7 @@ export * from './ignoredNodes.js';
 // MeshCore tables
 export * from './meshcoreNodes.js';
 export * from './meshcoreMessages.js';
+export * from './meshcoreNeighbors.js';
 
 // Embed Profiles table
 export * from './embedProfiles.js';

--- a/src/db/schema/meshcoreNeighbors.ts
+++ b/src/db/schema/meshcoreNeighbors.ts
@@ -1,0 +1,42 @@
+import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
+import { pgTable, text as pgText, integer as pgInteger, real as pgReal } from 'drizzle-orm/pg-core';
+import { mysqlTable, varchar as myVarchar, int as myInt, double as myDouble, serial as mySerial } from 'drizzle-orm/mysql-core';
+
+// ============ SQLite Schema ============
+
+export const meshcoreNeighborsSqlite = sqliteTable('meshcore_neighbor_info', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  sourceId: text('sourceId').notNull(),
+  publicKey: text('publicKey').notNull(),
+  neighborPublicKey: text('neighborPublicKey').notNull(),
+  snr: real('snr'),
+  lastHeardSecs: integer('lastHeardSecs'),
+  timestamp: integer('timestamp').notNull(),
+  createdAt: integer('createdAt').notNull(),
+});
+
+// ============ PostgreSQL Schema ============
+
+export const meshcoreNeighborsPostgres = pgTable('meshcore_neighbor_info', {
+  id: pgInteger('id').primaryKey().generatedAlwaysAsIdentity(),
+  sourceId: pgText('sourceId').notNull(),
+  publicKey: pgText('publicKey').notNull(),
+  neighborPublicKey: pgText('neighborPublicKey').notNull(),
+  snr: pgReal('snr'),
+  lastHeardSecs: pgInteger('lastHeardSecs'),
+  timestamp: pgInteger('timestamp').notNull(),
+  createdAt: pgInteger('createdAt').notNull(),
+});
+
+// ============ MySQL Schema ============
+
+export const meshcoreNeighborsMysql = mysqlTable('meshcore_neighbor_info', {
+  id: mySerial('id').primaryKey(),
+  sourceId: myVarchar('sourceId', { length: 255 }).notNull(),
+  publicKey: myVarchar('publicKey', { length: 64 }).notNull(),
+  neighborPublicKey: myVarchar('neighborPublicKey', { length: 64 }).notNull(),
+  snr: myDouble('snr'),
+  lastHeardSecs: myInt('lastHeardSecs'),
+  timestamp: myInt('timestamp').notNull(),
+  createdAt: myInt('createdAt').notNull(),
+});

--- a/src/hooks/useMapAnalysisData.ts
+++ b/src/hooks/useMapAnalysisData.ts
@@ -4,6 +4,7 @@ import {
   fetchPositionsPage,
   fetchTraceroutesPage,
   fetchNeighbors,
+  fetchMeshCoreNeighbors,
   fetchCoverageGrid,
   fetchHopCounts,
 } from '../services/analysisApi';
@@ -125,6 +126,19 @@ export function useNeighbors(args: PaginatedHookArgs) {
     enabled: args.enabled && args.sources.length > 0,
     queryFn: ({ signal }: { signal: AbortSignal }) =>
       fetchNeighbors({
+        sources: args.sources,
+        sinceMs: lookbackToSinceMs(args.lookbackHours),
+        signal,
+      }),
+  });
+}
+
+export function useMeshCoreNeighbors(args: PaginatedHookArgs) {
+  return useQuery({
+    queryKey: ['analysis', 'meshcoreNeighbors', args.sources, args.lookbackHours],
+    enabled: args.enabled && args.sources.length > 0,
+    queryFn: ({ signal }: { signal: AbortSignal }) =>
+      fetchMeshCoreNeighbors({
         sources: args.sources,
         sinceMs: lookbackToSinceMs(args.lookbackHours),
         signal,

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2074,7 +2074,7 @@ class MeshCoreManager extends EventEmitter {
   /**
    * Find a contact whose publicKey starts with the given hex prefix.
    */
-  private resolveContactByPrefix(prefix: string): MeshCoreContact | undefined {
+  resolveContactByPrefix(prefix: string): MeshCoreContact | undefined {
     if (!prefix) return undefined;
     const exact = this.contacts.get(prefix);
     if (exact) return exact;
@@ -2082,6 +2082,69 @@ class MeshCoreManager extends EventEmitter {
       if (c.publicKey.startsWith(prefix)) return c;
     }
     return undefined;
+  }
+
+  /**
+   * Request and store neighbor data from a MeshCore repeater.
+   *
+   * @param publicKey — target repeater's 64-char hex key (remote request via
+   *   companion bridge). Omit for local repeater (serial CLI).
+   * @returns Resolved neighbor entries, or null if the device said "not supported".
+   */
+  async requestNeighbors(publicKey?: string): Promise<{
+    neighbors: Array<{ publicKey: string; name: string | null; snr: number; lastHeardSecs: number }>;
+  } | null> {
+    const { parseMeshcoreNeighborsResponse } = await import('./utils/parseMeshcoreNeighbors.js');
+
+    let reply: string;
+    if (publicKey) {
+      await this.ensureGuestLogin(publicKey);
+      const result = await this.sendCliCommand(publicKey, 'neighbors');
+      reply = result.reply;
+    } else {
+      const result = await this.sendLocalCliCommand('neighbors');
+      reply = result.reply;
+    }
+
+    const parsed = parseMeshcoreNeighborsResponse(reply);
+    if (parsed === null) return null;
+
+    const reporterKey = publicKey ?? this.localNode?.publicKey;
+    if (!reporterKey) {
+      logger.warn(`[MeshCore:${this.sourceId}] requestNeighbors: no reporter key available`);
+      return { neighbors: [] };
+    }
+
+    const resolved: Array<{ publicKey: string; name: string | null; snr: number; lastHeardSecs: number }> = [];
+    for (const entry of parsed) {
+      const contact = this.resolveContactByPrefix(entry.pubkeyPrefix);
+      if (!contact) {
+        logger.debug(`[MeshCore:${this.sourceId}] neighbor prefix ${entry.pubkeyPrefix} not in contact list, skipping`);
+        continue;
+      }
+      resolved.push({
+        publicKey: contact.publicKey,
+        name: contact.advName ?? contact.name ?? null,
+        snr: entry.snr,
+        lastHeardSecs: entry.lastHeardSecondsAgo,
+      });
+    }
+
+    try {
+      await databaseService.meshcore.insertNeighborsBatch(
+        this.sourceId,
+        reporterKey,
+        resolved.map((r) => ({
+          neighborPublicKey: r.publicKey,
+          snr: r.snr,
+          lastHeardSecs: r.lastHeardSecs,
+        })),
+      );
+    } catch (err) {
+      logger.warn(`[MeshCore:${this.sourceId}] failed to persist neighbors: ${(err as Error).message}`);
+    }
+
+    return { neighbors: resolved };
   }
 
   /**

--- a/src/server/migrations/073_meshcore_neighbor_info.ts
+++ b/src/server/migrations/073_meshcore_neighbor_info.ts
@@ -1,0 +1,107 @@
+/**
+ * Migration 073: Create meshcore_neighbor_info table.
+ *
+ * Stores parsed neighbor data from MeshCore repeaters' CLI `neighbors`
+ * command. Each row records one neighbor relationship: the reporting
+ * repeater's publicKey → one neighbor's publicKey, with SNR and
+ * last-heard-seconds-ago at query time.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 073';
+const TABLE = 'meshcore_neighbor_info';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): creating ${TABLE}...`);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS ${TABLE} (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        sourceId TEXT NOT NULL,
+        publicKey TEXT NOT NULL,
+        neighborPublicKey TEXT NOT NULL,
+        snr REAL,
+        lastHeardSecs INTEGER,
+        timestamp INTEGER NOT NULL,
+        createdAt INTEGER NOT NULL
+      )
+    `);
+
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_mcni_source_pk ON ${TABLE}(sourceId, publicKey)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_mcni_timestamp ON ${TABLE}(timestamp)`);
+
+    logger.info(`${LABEL} complete (SQLite)`);
+  },
+
+  down: (db: Database): void => {
+    logger.info(`${LABEL} down (SQLite): dropping ${TABLE}`);
+    db.exec(`DROP TABLE IF EXISTS ${TABLE}`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration073Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): creating ${TABLE}...`);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS ${TABLE} (
+      id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      "sourceId" TEXT NOT NULL,
+      "publicKey" TEXT NOT NULL,
+      "neighborPublicKey" TEXT NOT NULL,
+      snr REAL,
+      "lastHeardSecs" INTEGER,
+      "timestamp" INTEGER NOT NULL,
+      "createdAt" INTEGER NOT NULL
+    )
+  `);
+
+  await client.query(`CREATE INDEX IF NOT EXISTS idx_mcni_source_pk ON ${TABLE}("sourceId", "publicKey")`);
+  await client.query(`CREATE INDEX IF NOT EXISTS idx_mcni_timestamp ON ${TABLE}("timestamp")`);
+
+  logger.info(`${LABEL} complete (PostgreSQL)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration073Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): creating ${TABLE}...`);
+
+  const conn = await pool.getConnection();
+  try {
+    const [existRows] = await conn.query(
+      `SELECT TABLE_NAME FROM information_schema.TABLES
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`,
+      [TABLE],
+    );
+    if ((existRows as any[]).length === 0) {
+      await conn.query(`
+        CREATE TABLE ${TABLE} (
+          id SERIAL PRIMARY KEY,
+          sourceId VARCHAR(255) NOT NULL,
+          publicKey VARCHAR(64) NOT NULL,
+          neighborPublicKey VARCHAR(64) NOT NULL,
+          snr DOUBLE,
+          lastHeardSecs INT,
+          timestamp INT NOT NULL,
+          createdAt INT NOT NULL,
+          INDEX idx_mcni_source_pk (sourceId, publicKey),
+          INDEX idx_mcni_timestamp (timestamp)
+        )
+      `);
+    } else {
+      logger.debug(`${TABLE} already exists, skipping create`);
+    }
+  } finally {
+    conn.release();
+  }
+
+  logger.info(`${LABEL} complete (MySQL)`);
+}

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -787,14 +787,26 @@ router.get(
           error: 'Get neighbours failed — source disconnected, not a Companion, or firmware too old',
         });
       }
-      const enhanced = {
-        ...result,
-        neighbours: result.neighbours.map((n: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }) => {
-          const contact = manager.resolveContactByPrefix(n.publicKeyPrefix);
-          return { ...n, name: contact?.advName ?? contact?.name ?? null };
-        }),
-      };
-      res.json({ success: true, data: enhanced });
+      const sourceId = (req.params as { id?: string }).id!;
+      const resolved = result.neighbours.map((n: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }) => {
+        const contact = manager.resolveContactByPrefix(n.publicKeyPrefix);
+        return { ...n, name: contact?.advName ?? contact?.name ?? null, fullPublicKey: contact?.publicKey ?? null };
+      });
+
+      // Persist to meshcore_neighbor_info so the data survives page refreshes.
+      const toStore = resolved
+        .filter((n: { fullPublicKey: string | null }) => n.fullPublicKey != null)
+        .map((n: { fullPublicKey: string | null; snr: number; heardSecondsAgo: number }) => ({
+          neighborPublicKey: n.fullPublicKey!,
+          snr: n.snr,
+          lastHeardSecs: n.heardSecondsAgo,
+        }));
+      if (toStore.length > 0) {
+        databaseService.meshcore.insertNeighborsBatch(sourceId, publicKey, toStore)
+          .catch((err: Error) => logger.warn('[API] Failed to persist neighbours:', err.message));
+      }
+
+      res.json({ success: true, data: { ...result, neighbours: resolved } });
     } catch (error) {
       logger.error('[API] Error getting neighbours:', error);
       res.status(500).json({ success: false, error: 'Failed to get neighbours' });

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -2232,4 +2232,69 @@ router.post(
   },
 );
 
+// ---------------------------------------------------------------------------
+// POST /api/sources/:id/meshcore/neighbors/request
+// Request neighbor data from a MeshCore repeater (remote or local).
+// ---------------------------------------------------------------------------
+
+router.post('/neighbors/request', meshcoreDeviceLimiter, requireAuth(), requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+  const sourceId = (req.params as { id?: string }).id!;
+  const { publicKey } = req.body as { publicKey?: string };
+
+  try {
+    const manager = managerFor(req);
+
+    if (publicKey) {
+      const normalizedKey = publicKey.toLowerCase();
+      if (!/^[0-9a-f]{64}$/.test(normalizedKey)) {
+        return res.status(400).json({ success: false, error: 'publicKey must be a 64-char hex string' });
+      }
+      const contact = manager.resolveContactByPrefix(normalizedKey);
+      if (!contact) {
+        return res.status(404).json({ success: false, error: 'Contact not found' });
+      }
+      if (contact.advType !== 2) {
+        return res.status(400).json({ success: false, error: 'Neighbors request is only supported for Repeaters (advType=2)' });
+      }
+    }
+
+    const result = await manager.requestNeighbors(publicKey);
+    if (result === null) {
+      return res.json({ success: true, data: { neighbors: [], count: 0, notSupported: true } });
+    }
+
+    auditMeshcoreEvent(req, 'meshcore_neighbors_request', 'configuration', {
+      sourceId,
+      publicKey: publicKey ?? '(local)',
+      neighborCount: result.neighbors.length,
+    });
+
+    res.json({ success: true, data: { neighbors: result.neighbors, count: result.neighbors.length } });
+  } catch (err: any) {
+    const msg = err?.message ?? String(err);
+    if (msg.includes('timed out')) {
+      return res.status(504).json({ success: false, error: msg, code: 'CLI_TIMEOUT' });
+    }
+    logger.error('[API] MeshCore neighbors request failed:', err);
+    res.status(500).json({ success: false, error: 'Neighbors request failed' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/sources/:id/meshcore/neighbors
+// Query stored MeshCore neighbor data (for map rendering).
+// ---------------------------------------------------------------------------
+
+router.get('/neighbors', requireAuth(), requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+  const sourceId = (req.params as { id?: string }).id!;
+  const sinceMs = Number(req.query.since) || 0;
+
+  try {
+    const items = await databaseService.meshcore.getNeighbors([sourceId], sinceMs);
+    res.json({ success: true, data: { items } });
+  } catch (error) {
+    logger.error('[API] Error fetching MeshCore neighbors:', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch neighbors' });
+  }
+});
 export default router;

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -133,6 +133,40 @@ function auditMeshcoreEvent(
 }
 
 /**
+ * Enhance a raw `neighbors` CLI reply with resolved node names.
+ * Replaces each `{8-char-prefix}:{secs}:{snr*4}` line with a
+ * human-readable version showing the contact name, SNR in dB,
+ * and last-heard time.
+ */
+function enhanceNeighborsReply(reply: string, manager: ReturnType<typeof managerFor>): string {
+  const trimmed = reply.trim();
+  if (!trimmed || trimmed === '-none-' || /not supported/i.test(trimmed)) return reply;
+
+  const lines = trimmed.split('\n');
+  const enhanced: string[] = [];
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    const parts = line.split(':');
+    if (parts.length < 3) { enhanced.push(line); continue; }
+
+    const prefix = parts[0].toLowerCase();
+    if (!/^[0-9a-f]{8}$/.test(prefix)) { enhanced.push(line); continue; }
+
+    const secs = parseInt(parts[1], 10);
+    const snrRaw = parseInt(parts[2], 10);
+    if (Number.isNaN(secs) || Number.isNaN(snrRaw)) { enhanced.push(line); continue; }
+
+    const contact = manager.resolveContactByPrefix(prefix);
+    const name = contact?.advName ?? contact?.name ?? prefix;
+    const snrDb = (snrRaw / 4).toFixed(1);
+    const ago = secs < 60 ? `${secs}s` : secs < 3600 ? `${Math.floor(secs / 60)}m` : `${Math.floor(secs / 3600)}h${Math.floor((secs % 3600) / 60)}m`;
+    enhanced.push(`${name}  SNR: ${snrDb} dB  heard: ${ago} ago`);
+  }
+  return enhanced.join('\n');
+}
+
+/**
  * Parse a comma-separated hex chain like "a3,7f,02" into a Uint8Array.
  * Empty string parses to a zero-length array (zero-hop direct path).
  * Returns null on any malformed token so the route can return a 400.
@@ -745,14 +779,22 @@ router.get(
       const count = Math.min(Math.max(parseInt(req.query.count as string || '10', 10) || 10, 1), 50);
       const offset = Math.max(parseInt(req.query.offset as string || '0', 10) || 0, 0);
       const orderBy = Math.min(Math.max(parseInt(req.query.orderBy as string || '0', 10) || 0, 0), 3);
-      const result = await managerFor(req).getNeighbours(publicKey, { count, offset, orderBy });
+      const manager = managerFor(req);
+      const result = await manager.getNeighbours(publicKey, { count, offset, orderBy });
       if (!result) {
         return res.status(409).json({
           success: false,
           error: 'Get neighbours failed — source disconnected, not a Companion, or firmware too old',
         });
       }
-      res.json({ success: true, data: result });
+      const enhanced = {
+        ...result,
+        neighbours: result.neighbours.map((n: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }) => {
+          const contact = manager.resolveContactByPrefix(n.publicKeyPrefix);
+          return { ...n, name: contact?.advName ?? contact?.name ?? null };
+        }),
+      };
+      res.json({ success: true, data: enhanced });
     } catch (error) {
       logger.error('[API] Error getting neighbours:', error);
       res.status(500).json({ success: false, error: 'Failed to get neighbours' });
@@ -1479,9 +1521,13 @@ router.post('/admin/cli', meshcoreDeviceLimiter, requireAuth(), requirePermissio
         : undefined;
 
     try {
-      const result = await managerFor(req).sendCliCommand(publicKey, command, {
+      const manager = managerFor(req);
+      const result = await manager.sendCliCommand(publicKey, command, {
         timeoutMs: effectiveTimeout,
       });
+      if (/^neighbors$/i.test(command.trim())) {
+        result.reply = enhanceNeighborsReply(result.reply, manager);
+      }
       auditMeshcoreEvent(req, 'meshcore_remote_cli', 'remote_admin', {
         sourceId: req.params.id,
         publicKey,
@@ -1569,9 +1615,13 @@ router.post('/cli', meshcoreDeviceLimiter, requireAuth(), requirePermission('con
         : undefined;
 
     try {
-      const result = await managerFor(req).sendLocalCliCommand(command, {
+      const manager = managerFor(req);
+      const result = await manager.sendLocalCliCommand(command, {
         timeoutMs: effectiveTimeout,
       });
+      if (/^neighbors$/i.test(command.trim())) {
+        result.reply = enhanceNeighborsReply(result.reply, manager);
+      }
       auditMeshcoreEvent(req, 'meshcore_local_cli', 'configuration', {
         sourceId: req.params.id,
         command,
@@ -2288,9 +2338,13 @@ router.post('/neighbors/request', meshcoreDeviceLimiter, requireAuth(), requireP
 router.get('/neighbors', requireAuth(), requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   const sourceId = (req.params as { id?: string }).id!;
   const sinceMs = Number(req.query.since) || 0;
+  const nodeFilter = typeof req.query.node === 'string' ? req.query.node : undefined;
 
   try {
-    const items = await databaseService.meshcore.getNeighbors([sourceId], sinceMs);
+    let items = await databaseService.meshcore.getNeighbors([sourceId], sinceMs);
+    if (nodeFilter) {
+      items = items.filter((i) => i.publicKey === nodeFilter);
+    }
     res.json({ success: true, data: { items } });
   } catch (error) {
     logger.error('[API] Error fetching MeshCore neighbors:', error);

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -834,6 +834,7 @@ router.get('/:id/nodes', requirePermission('nodes', 'read', { sourceIdFrom: 'par
             nodeNum: 0,
             sourceId: mcManager.sourceId,
             isMeshCore: true,
+            publicKey: pubKey,
             isIgnored: false,
             isFavorite: false,
             user: { id: nodeId, longName: n.name, shortName: (n.name || '').substring(0, 4) },

--- a/src/server/utils/parseMeshcoreNeighbors.test.ts
+++ b/src/server/utils/parseMeshcoreNeighbors.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { parseMeshcoreNeighborsResponse } from './parseMeshcoreNeighbors.js';
+
+describe('parseMeshcoreNeighborsResponse', () => {
+  it('parses a single neighbor line', () => {
+    const result = parseMeshcoreNeighborsResponse('a1b2c3d4:120:40');
+    expect(result).toEqual([
+      { pubkeyPrefix: 'a1b2c3d4', lastHeardSecondsAgo: 120, snr: 10 },
+    ]);
+  });
+
+  it('parses multiple neighbor lines', () => {
+    const result = parseMeshcoreNeighborsResponse(
+      'a1b2c3d4:120:40\ne5f6a7b8:3600:-8',
+    );
+    expect(result).toEqual([
+      { pubkeyPrefix: 'a1b2c3d4', lastHeardSecondsAgo: 120, snr: 10 },
+      { pubkeyPrefix: 'e5f6a7b8', lastHeardSecondsAgo: 3600, snr: -2 },
+    ]);
+  });
+
+  it('returns empty array for -none-', () => {
+    expect(parseMeshcoreNeighborsResponse('-none-')).toEqual([]);
+  });
+
+  it('returns null for not supported', () => {
+    expect(parseMeshcoreNeighborsResponse('not supported')).toBeNull();
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(parseMeshcoreNeighborsResponse('')).toEqual([]);
+  });
+
+  it('returns empty array for whitespace-only', () => {
+    expect(parseMeshcoreNeighborsResponse('  \n  ')).toEqual([]);
+  });
+
+  it('skips malformed lines', () => {
+    const result = parseMeshcoreNeighborsResponse(
+      'a1b2c3d4:120:40\nbadline\ne5f6a7b8:3600:-8',
+    );
+    expect(result).toEqual([
+      { pubkeyPrefix: 'a1b2c3d4', lastHeardSecondsAgo: 120, snr: 10 },
+      { pubkeyPrefix: 'e5f6a7b8', lastHeardSecondsAgo: 3600, snr: -2 },
+    ]);
+  });
+
+  it('skips lines with invalid pubkey prefix', () => {
+    const result = parseMeshcoreNeighborsResponse('ZZZZZZZZ:120:40');
+    expect(result).toEqual([]);
+  });
+
+  it('skips lines with non-numeric fields', () => {
+    const result = parseMeshcoreNeighborsResponse('a1b2c3d4:abc:40');
+    expect(result).toEqual([]);
+  });
+
+  it('handles negative SNR values', () => {
+    const result = parseMeshcoreNeighborsResponse('a1b2c3d4:60:-20');
+    expect(result).toEqual([
+      { pubkeyPrefix: 'a1b2c3d4', lastHeardSecondsAgo: 60, snr: -5 },
+    ]);
+  });
+
+  it('normalizes uppercase pubkey to lowercase', () => {
+    const result = parseMeshcoreNeighborsResponse('A1B2C3D4:120:40');
+    expect(result).toEqual([
+      { pubkeyPrefix: 'a1b2c3d4', lastHeardSecondsAgo: 120, snr: 10 },
+    ]);
+  });
+
+  it('handles Windows-style line endings', () => {
+    const result = parseMeshcoreNeighborsResponse('a1b2c3d4:120:40\r\ne5f6a7b8:60:20');
+    expect(result).toEqual([
+      { pubkeyPrefix: 'a1b2c3d4', lastHeardSecondsAgo: 120, snr: 10 },
+      { pubkeyPrefix: 'e5f6a7b8', lastHeardSecondsAgo: 60, snr: 5 },
+    ]);
+  });
+});

--- a/src/server/utils/parseMeshcoreNeighbors.ts
+++ b/src/server/utils/parseMeshcoreNeighbors.ts
@@ -1,0 +1,43 @@
+export interface MeshCoreNeighborEntry {
+  pubkeyPrefix: string;
+  lastHeardSecondsAgo: number;
+  snr: number;
+}
+
+/**
+ * Parse the text output of the MeshCore CLI `neighbors` command.
+ *
+ * Format per line: `{8-char-hex-pubkey}:{seconds_ago}:{snr*4}`
+ * Returns null when the device reports "not supported" (room servers).
+ */
+export function parseMeshcoreNeighborsResponse(
+  reply: string,
+): MeshCoreNeighborEntry[] | null {
+  const trimmed = reply.trim();
+  if (!trimmed) return [];
+  if (/not supported/i.test(trimmed)) return null;
+  if (trimmed === '-none-') return [];
+
+  const entries: MeshCoreNeighborEntry[] = [];
+  for (const raw of trimmed.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+
+    const parts = line.split(':');
+    if (parts.length < 3) continue;
+
+    const pubkeyPrefix = parts[0].toLowerCase();
+    if (!/^[0-9a-f]{8}$/.test(pubkeyPrefix)) continue;
+
+    const secs = parseInt(parts[1], 10);
+    const snrRaw = parseInt(parts[2], 10);
+    if (Number.isNaN(secs) || Number.isNaN(snrRaw)) continue;
+
+    entries.push({
+      pubkeyPrefix,
+      lastHeardSecondsAgo: secs,
+      snr: snrRaw / 4,
+    });
+  }
+  return entries;
+}

--- a/src/services/analysisApi.ts
+++ b/src/services/analysisApi.ts
@@ -69,6 +69,21 @@ export async function fetchNeighbors(
   );
 }
 
+export async function fetchMeshCoreNeighbors(
+  args: { sources: string[]; sinceMs: number; signal?: AbortSignal },
+): Promise<{ items: any[] }> {
+  const results = await Promise.all(
+    args.sources.map((sourceId) =>
+      authedGet<{ success: boolean; data: { items: any[] } }>(
+        `/api/sources/${sourceId}/meshcore/neighbors?since=${args.sinceMs}`,
+        args.signal,
+      ).catch(() => ({ success: false, data: { items: [] } })),
+    ),
+  );
+  const items = results.flatMap((r) => (r.success ? r.data.items : []));
+  return { items };
+}
+
 export async function fetchCoverageGrid(
   args: Omit<FetchArgs, 'pageSize' | 'cursor'> & { zoom: number },
 ): Promise<{ cells: any[]; binSizeDeg: number }> {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1860,6 +1860,20 @@ class DatabaseService {
       );
     `);
 
+    // eslint-disable-next-line no-restricted-syntax -- bootstrap: runs before migrations
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS meshcore_neighbor_info (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        sourceId TEXT NOT NULL,
+        publicKey TEXT NOT NULL,
+        neighborPublicKey TEXT NOT NULL,
+        snr REAL,
+        lastHeardSecs INTEGER,
+        timestamp INTEGER NOT NULL,
+        createdAt INTEGER NOT NULL
+      );
+    `);
+
     // ============================================================
     // NEWS TABLES
     // ============================================================


### PR DESCRIPTION
## Summary

- Wire the DM page **Neighbors** button for MeshCore sources — detects `sourceType === 'meshcore'` and sends the CLI `neighbors` command to the target repeater instead of a Meshtastic NeighborInfo request
- Parse the MeshCore CLI response format (`{8-char-pubkey}:{seconds_ago}:{snr*4}`) into structured data, resolve pubkey prefixes to full contacts, and store in a new `meshcore_neighbor_info` table (migration 073)
- Add `POST /meshcore/neighbors/request` (trigger fetch + parse + store) and `GET /meshcore/neighbors` (query stored data) API endpoints
- Render MeshCore neighbor links on the map via a new `MeshCoreNeighborLinksLayer` component, sharing the existing Neighbors layer toggle

## Changes

- **Parser**: `parseMeshcoreNeighborsResponse()` with 12 unit tests covering normal, `-none-`, `not supported`, malformed, and edge cases
- **Database**: New `meshcore_neighbor_info` table (SQLite/PostgreSQL/MySQL), Drizzle schema, bootstrap, migration 073
- **Repository**: `insertNeighborsBatch`, `getNeighbors`, `deleteNeighborsForNode` on MeshCoreRepository
- **Manager**: `resolveContactByPrefix` made public; new `requestNeighbors()` method handles guest login, CLI send, parse, resolve, and persist
- **Routes**: Two new endpoints on meshcoreRoutes with auth, permission, rate limiting, and advType=2 validation
- **Frontend**: `handleRequestNeighborInfo` branches on sourceType; new fetch/hook/layer for MeshCore neighbor map rendering
- **Source routes**: Adds `publicKey` to unified MeshCore node response for map position matching

## Test plan

- [ ] 12 parser unit tests pass
- [ ] Migration test updated (count=73, last=meshcore_neighbor_info)
- [ ] Full test suite: 5690 tests pass, 0 failures
- [ ] Deploy dev container, open MeshCore repeater DM, click Neighbors button
- [ ] Verify parsed neighbor data returned in response
- [ ] Enable Neighbors layer on map, verify MeshCore neighbor links render between positioned repeaters

🤖 Generated with [Claude Code](https://claude.com/claude-code)