### PR TITLE
fix(meshcore): load saved room Auto-Sync config and retry room login

### DIFF
--- a/src/components/MeshCore/MeshCoreRoomsView.tsx
+++ b/src/components/MeshCore/MeshCoreRoomsView.tsx
@@ -145,14 +145,27 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
     })();
   }, [selectedRoom, loggedInRooms, storedCreds, actions]);
 
+  const loadSyncConfig = useCallback(async (pubkey: string) => {
+    const config = await actions.getRoomSyncConfig(pubkey);
+    if (config) {
+      setSyncEnabled(config.enabled);
+      setSyncInterval(config.intervalMinutes);
+    } else {
+      setSyncEnabled(false);
+      setSyncInterval(60);
+    }
+    setSyncConfigDirty(false);
+  }, [actions]);
+
   const handleSelectRoom = useCallback((pubkey: string) => {
     setSelectedRoom(pubkey);
     setLoginError(null);
     setLoginPassword('');
     setRememberPassword(false);
     setSyncConfigDirty(false);
+    loadSyncConfig(pubkey);
     if (isMobileViewport()) setMobileShowContent(true);
-  }, []);
+  }, [loadSyncConfig]);
 
   const handleLogin = useCallback(async () => {
     if (!selectedRoom) return;

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -228,6 +228,8 @@ export interface MeshCoreActions {
   getRoomCredentials: () => Promise<{ canRemember: boolean; stored: Array<{ publicKey: string }> } | null>;
   /** Configure periodic room sync. */
   setRoomSyncConfig: (publicKey: string, enabled: boolean, intervalMinutes?: number) => Promise<boolean>;
+  /** Get current room sync config. */
+  getRoomSyncConfig: (publicKey: string) => Promise<{ enabled: boolean; intervalMinutes: number } | null>;
 }
 
 /**
@@ -1237,6 +1239,17 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch]);
 
+  const getRoomSyncConfig = useCallback(async (publicKey: string): Promise<{ enabled: boolean; intervalMinutes: number } | null> => {
+    try {
+      const response = await csrfFetch(`${mcPrefix}/rooms/sync-config?publicKey=${encodeURIComponent(publicKey)}`);
+      const data = await response.json();
+      if (data.success) return { enabled: data.enabled, intervalMinutes: data.intervalMinutes };
+      return null;
+    } catch (_err) {
+      return null;
+    }
+  }, [mcPrefix, csrfFetch]);
+
   const setRoomSyncConfig = useCallback(async (publicKey: string, enabled: boolean, intervalMinutes?: number): Promise<boolean> => {
     try {
       const response = await csrfFetch(`${mcPrefix}/rooms/sync-config`, {
@@ -1298,6 +1311,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       loginRoomWithSaved,
       sendRoomPost,
       getRoomCredentials,
+      getRoomSyncConfig,
       setRoomSyncConfig,
     },
   };

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -352,6 +352,30 @@ export class MeshCoreRepository extends BaseRepository {
 
   // ---- Room sync config ----
 
+  async getRoomSyncConfig(
+    sourceId: string,
+    publicKey: string,
+  ): Promise<{ enabled: boolean; intervalMinutes: number } | null> {
+    const { meshcoreNodes } = this.tables;
+    const result = await this.db
+      .select({
+        roomSyncEnabled: meshcoreNodes.roomSyncEnabled,
+        roomSyncIntervalMinutes: meshcoreNodes.roomSyncIntervalMinutes,
+      })
+      .from(meshcoreNodes)
+      .where(and(eq(meshcoreNodes.publicKey, publicKey), eq(meshcoreNodes.sourceId, sourceId)));
+    const rows = this.normalizeBigInts(result) as unknown as Array<{
+      roomSyncEnabled: boolean | number | null;
+      roomSyncIntervalMinutes: number | null;
+    }>;
+    if (rows.length === 0) return null;
+    const row = rows[0];
+    return {
+      enabled: row.roomSyncEnabled === true || row.roomSyncEnabled === 1,
+      intervalMinutes: row.roomSyncIntervalMinutes ?? 60,
+    };
+  }
+
   async setRoomSyncConfig(
     sourceId: string,
     publicKey: string,

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2010,11 +2010,19 @@ class MeshCoreManager extends EventEmitter {
    * tracks state in roomLoggedInNodes so the UI can show login status.
    */
   async loginToRoom(publicKey: string, password: string): Promise<boolean> {
-    const ok = await this.loginToNode(publicKey, password);
-    if (ok) {
-      this.roomLoggedInNodes.set(publicKey, { loggedIn: true, loginTime: Date.now() });
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const ok = await this.loginToNode(publicKey, password);
+      if (ok) {
+        this.roomLoggedInNodes.set(publicKey, { loggedIn: true, loginTime: Date.now() });
+        return true;
+      }
+      if (attempt < maxAttempts) {
+        logger.warn(`[MeshCore] Room login attempt ${attempt}/${maxAttempts} failed for ${publicKey.substring(0, 8)}…, retrying`);
+        await new Promise(r => setTimeout(r, 2000));
+      }
     }
-    return ok;
+    return false;
   }
 
   isRoomLoggedIn(publicKey: string): boolean {

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -1391,6 +1391,28 @@ router.post('/rooms/post', messageLimiter, requireAuth(), requirePermission('mes
 });
 
 /**
+ * GET /api/meshcore/rooms/sync-config?publicKey=...
+ * Retrieve the current room sync configuration for a room server.
+ */
+router.get('/rooms/sync-config', requireAuth(), requirePermission('configuration', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
+  try {
+    const publicKey = req.query.publicKey as string | undefined;
+    if (typeof publicKey !== 'string' || !isValidPublicKey(publicKey)) {
+      return res.status(400).json({ success: false, error: 'Invalid public key format' });
+    }
+    const sourceId = req.params.id!;
+    const config = await databaseService.meshcore.getRoomSyncConfig(sourceId, publicKey);
+    if (!config) {
+      return res.json({ success: true, enabled: false, intervalMinutes: 60 });
+    }
+    res.json({ success: true, enabled: config.enabled, intervalMinutes: config.intervalMinutes });
+  } catch (error) {
+    logger.error('[API] Error getting room sync config:', error);
+    res.status(500).json({ success: false, error: 'Failed to get room sync config' });
+  }
+});
+
+/**
  * PATCH /api/meshcore/rooms/sync-config
  * Configure periodic room sync for a room server.
  * Body: { publicKey: string, enabled: boolean, intervalMinutes?: number }


### PR DESCRIPTION
## Summary
- Room Auto-Sync checkbox/interval were never loaded from the database — always showed defaults after selecting a room
- Added `GET /rooms/sync-config` endpoint and `getRoomSyncConfig()` repository method to retrieve saved config
- Frontend now fetches and applies saved sync config on room selection
- Added 3-attempt retry with 2s gap to `loginToRoom()` to improve reliability over lossy RF links

## Test plan
- [ ] Select a room, enable Auto-Sync with a non-default interval, save, navigate away and back — verify the saved values load correctly
- [ ] Verify room login succeeds more reliably (retries visible in server logs)
- [ ] Verify existing room post sending still works
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)