### PR TITLE
fix(mqtt): shared reconnect backoff to prevent retry storms

### DIFF
--- a/src/server/mqttBridgeManager.ts
+++ b/src/server/mqttBridgeManager.ts
@@ -24,7 +24,7 @@
  */
 
 import { EventEmitter } from 'events';
-import { MqttBrokerClient, type MqttClientCapabilities } from './transports/mqttBrokerClient.js';
+import { MqttBrokerClient, MqttReconnectCoordinator, type MqttClientCapabilities } from './transports/mqttBrokerClient.js';
 import {
   MqttPacketFilter,
   type MqttFilterConfig,
@@ -257,6 +257,7 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
    * Holds one MQTT connection per `gateway_id` seen in `local-packet`.
    */
   private publisherPool: MqttBridgePublisherPool | null = null;
+  private reconnectCoordinator: MqttReconnectCoordinator | null = null;
   /**
    * In `per_gateway` mode, the gatewayNum whose pool entry doubles as
    * the subscriber connection (i.e., the parent broker's own gateway
@@ -294,6 +295,8 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     // node, not as an opaque `mm-bridge-…`. The same connection is also
     // the publisher for traffic whose gateway_id IS the broker's nodeId
     // (avoids the MQTT 3.1.1 §3.1.4 duplicate-clientId disconnect).
+    this.reconnectCoordinator = new MqttReconnectCoordinator();
+
     let subscriberClientId: string | undefined;
     if (forwardingMode === 'per_gateway' && this.parentBroker) {
       const localInfo = this.parentBroker.getLocalNodeInfo();
@@ -304,6 +307,7 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
         username: this.config.upstream.username,
         password: this.config.upstream.password,
         poolLabel: this.sourceId,
+        reconnectCoordinator: this.reconnectCoordinator,
       });
     }
 
@@ -317,6 +321,7 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
       clientId: subscriberClientId,
       clientIdPrefix: subscriberClientId ? undefined : `mm-bridge-${this.sourceId}`,
     });
+    this.client.setCoordinator(this.reconnectCoordinator);
     this.client.on('error', (err) => {
       this.lastError = err.message;
     });
@@ -365,6 +370,10 @@ export class MqttBridgeManager extends EventEmitter implements ISourceManager {
     if (this.client) {
       await this.client.disconnect();
       this.client = null;
+    }
+    if (this.reconnectCoordinator) {
+      this.reconnectCoordinator.dispose();
+      this.reconnectCoordinator = null;
     }
     this.brokerGatewayNum = null;
   }

--- a/src/server/mqttBridgePublisherPool.ts
+++ b/src/server/mqttBridgePublisherPool.ts
@@ -27,7 +27,7 @@
  *   - `gateway_id` provenance check against known local nodes.
  */
 
-import { MqttBrokerClient } from './transports/mqttBrokerClient.js';
+import { MqttBrokerClient, type MqttReconnectCoordinator } from './transports/mqttBrokerClient.js';
 import { logger } from '../utils/logger.js';
 
 export interface PublisherPoolOptions {
@@ -38,6 +38,8 @@ export interface PublisherPoolOptions {
   password?: string;
   /** Pool diagnostic label — usually the owning bridge's sourceId. */
   poolLabel: string;
+  /** Shared reconnect coordinator — all pool entries use the same backoff timer. */
+  reconnectCoordinator?: MqttReconnectCoordinator;
 }
 
 export interface PublisherStatus {
@@ -184,6 +186,9 @@ export class MqttBridgePublisherPool {
       password: this.options.password,
       clientId,
     });
+    if (this.options.reconnectCoordinator) {
+      client.setCoordinator(this.options.reconnectCoordinator);
+    }
     const entry: PoolEntry = {
       client,
       clientId,

--- a/src/server/transports/mqttBrokerClient.ts
+++ b/src/server/transports/mqttBrokerClient.ts
@@ -64,6 +64,53 @@ export interface MqttClientCapabilities {
  * - 'permission-denied' (reason: { kind: 'subscribe' | 'auth'; topics?: string[]; message: string })
  *     fired when the broker denied subscribe or rejected the CONNACK on auth grounds.
  */
+/**
+ * Coordinates reconnection across multiple MqttBrokerClient instances
+ * targeting the same broker. Instead of N independent backoff timers
+ * (which interleave to produce once-per-second aggregate retry storms),
+ * a single shared timer fires and reconnects all registered clients together.
+ */
+export class MqttReconnectCoordinator {
+  private readonly clients = new Set<MqttBrokerClient>();
+  private backoffMs = 1000;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly BACKOFF_MIN_MS = 1000;
+  private static readonly BACKOFF_MAX_MS = 60_000;
+
+  register(client: MqttBrokerClient): void {
+    this.clients.add(client);
+  }
+
+  unregister(client: MqttBrokerClient): void {
+    this.clients.delete(client);
+  }
+
+  requestReconnect(): void {
+    if (this.timer) return;
+    const jitter = this.backoffMs * 0.2 * (Math.random() - 0.5);
+    const delay = Math.round(this.backoffMs + jitter);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      for (const client of this.clients) {
+        client.doReconnect();
+      }
+    }, delay);
+    this.backoffMs = Math.min(this.backoffMs * 2, MqttReconnectCoordinator.BACKOFF_MAX_MS);
+  }
+
+  resetBackoff(): void {
+    this.backoffMs = MqttReconnectCoordinator.BACKOFF_MIN_MS;
+  }
+
+  dispose(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.clients.clear();
+  }
+}
+
 export class MqttBrokerClient extends EventEmitter {
   private readonly options: MqttBrokerClientOptions;
   private client: MqttClient | null = null;
@@ -74,12 +121,18 @@ export class MqttBrokerClient extends EventEmitter {
   private authFailed = false;
   private reconnectBackoffMs = 1000;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private coordinator: MqttReconnectCoordinator | null = null;
   private static readonly BACKOFF_MIN_MS = 1000;
   private static readonly BACKOFF_MAX_MS = 60_000;
 
   constructor(options: MqttBrokerClientOptions) {
     super();
     this.options = options;
+  }
+
+  setCoordinator(coordinator: MqttReconnectCoordinator): void {
+    this.coordinator = coordinator;
+    coordinator.register(this);
   }
 
   connect(): Promise<void> {
@@ -112,6 +165,7 @@ export class MqttBrokerClient extends EventEmitter {
       this.lastError = null;
       this.authFailed = false;
       this.reconnectBackoffMs = MqttBrokerClient.BACKOFF_MIN_MS;
+      if (this.coordinator) this.coordinator.resetBackoff();
       logger.info(`📡 MQTT client connected to ${url}`);
       // Re-subscribe on every connect (covers reconnects with clean=true).
       // Clear previously-tracked denials too — a fresh session may have
@@ -205,9 +259,17 @@ export class MqttBrokerClient extends EventEmitter {
     });
   }
 
+  doReconnect(): void {
+    if (this.client) this.client.reconnect();
+  }
+
   private scheduleReconnect(): void {
-    if (!this.client || this.reconnectTimer) return;
-    // Add ±20% jitter to spread reconnects across pool entries.
+    if (!this.client) return;
+    if (this.coordinator) {
+      this.coordinator.requestReconnect();
+      return;
+    }
+    if (this.reconnectTimer) return;
     const jitter = this.reconnectBackoffMs * 0.2 * (Math.random() - 0.5);
     const delay = Math.round(this.reconnectBackoffMs + jitter);
     this.reconnectTimer = setTimeout(() => {
@@ -223,6 +285,10 @@ export class MqttBrokerClient extends EventEmitter {
   }
 
   async disconnect(): Promise<void> {
+    if (this.coordinator) {
+      this.coordinator.unregister(this);
+      this.coordinator = null;
+    }
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;


### PR DESCRIPTION
## Summary
- Each `MqttBrokerClient` (subscriber + N publisher pool entries) ran independent backoff timers targeting the same broker, interleaving to produce ~1/sec aggregate retries
- Added `MqttReconnectCoordinator` — a single shared timer (1s→60s exponential backoff with ±20% jitter) that reconnects all registered clients together
- `MqttBridgeManager` creates one coordinator and passes it to the subscriber client and publisher pool entries
- Backoff resets on successful connect; coordinator is disposed on stop

## Test plan
- [ ] All 5690 tests pass (verified locally)
- [ ] MQTT bridge tests (19) pass specifically
- [ ] Deploy and verify connack timeout log lines show increasing gaps instead of once-per-second
- [ ] Verify normal MQTT reconnection still works after transient broker outage

🤖 Generated with [Claude Code](https://claude.com/claude-code)