### PR TITLE
chore: bump version to 4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.8.0] - 2026-05-27
+
+# MeshMonitor v4.8.0
+
+Minor release focused on **MeshCore path intelligence and UX refinements**. Adds route visualization on the map, automatic path discovery and neighbor collection from repeaters, @mention highlighting with delivery status indicators, and a fully mobile-responsive MeshCore layout. Also improves MQTT reconnection behavior and fixes room server auto-sync persistence.
+
+## Features
+
+### MeshCore Path Intelligence
+
+- #3231 feat(meshcore): Show Paths map feature with hop-count colored lines — visualize MeshCore contact routes on the map. Lines are colored by hop count (green for direct, orange for 2-3 hops, red for 4+ hops). Toggle paths on/off from the map toolbar.
+- #3232 feat(meshcore): add Discover Path button using firmware CMD 52 — manually trigger path discovery to any companion contact. The button appears in the contact-detail panel and sends the MeshCore binary request for route establishment.
+- #3234 feat(meshcore): handle path discovery response push (0x8D) — process firmware push responses that return discovered paths. Routes are stored and used for map rendering and the contact-detail panel.
+- #3238 feat(meshcore): neighbors support for repeaters with CLI parsing, name resolution, and map rendering — query repeater neighbor tables via the binary protocol, parse structured responses (pubkey prefix, SNR, last-heard), resolve prefixes to full contact names, persist to `meshcore_neighbor_info`, and render neighbor links on the map and in the Map Analysis inspector panel.
+
+### MeshCore Auto-Pathfinding
+
+- #3237 feat(meshcore): add Auto-Pathfinding automation tab — new Automation view for MeshCore sources with configurable periodic path discovery and neighbor collection. Discovers paths to all companion contacts and queries neighbor lists from all repeaters on a configurable schedule (default: every 5 minutes between requests, repeat every 24 hours). Supports independent toggles for path discovery and neighbor collection, with configurable inter-request delay to avoid RF flooding.
+
+### MeshCore UX Improvements
+
+- #3236 feat(meshcore): @mention highlighting and delivery status indicators — messages containing `@YourName` are visually highlighted. Sent DMs now show delivery status (pending / confirmed / failed) with timestamp tooltips.
+- #3235 feat(meshcore): add node navigation, clickable names, and search filtering — contact names in messages are clickable and navigate to that contact's DM thread. Added search/filter bar to the Nodes view for quick lookup by name or public key.
+- #3230 feat(meshcore): add mobile-responsive layout and collapsible sections — the MeshCore page adapts to mobile viewports with a list/detail toggle pattern, collapsible sections, and touch-friendly controls.
+
+### General
+
+- #3233 feat: add Delete/Purge buttons to map node popup — quickly remove stale nodes directly from the map without navigating to the nodes list.
+- #3224 feat: pre-populate radio NodeDB via add_contact before PKI DMs — when sending a PKI-encrypted DM to a node not yet in the radio's NodeDB, MeshMonitor first inserts it via `add_contact` so the radio can encrypt and route correctly.
+
+## Fixes
+
+- #3239 fix(meshcore): load saved room Auto-Sync config and retry room login — room auto-sync checkbox and interval were never loaded from the database. Added GET endpoint and frontend loading. Also added 3-attempt retry with 2s delay to room login for reliability over lossy RF links.
+- #3241 fix(mqtt): shared reconnect coordinator to prevent aggregate retry storms — multiple MQTT clients per bridge (subscriber + publisher pool entries) each ran independent backoff timers, producing once-per-second aggregate retries. Added `MqttReconnectCoordinator` that manages a single shared exponential backoff timer (1s to 60s) for all clients targeting the same broker.
+- #3223 fix: prevent false circuit-breaker trips when watchdog upgrade succeeds — watchdog upgrade success was incorrectly counted as a failure, triggering the circuit breaker.
+- fix: classify neighbor links by transport type and filter by RF/UDP/unknown — neighbor link lines on the map analysis layer now distinguish transport types with appropriate styling.
+
 ## [4.7.4] - 2026-05-26
 
 # MeshMonitor v4.7.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # MeshMonitor — Claude Agent Brief
 
-**Version:** 4.6.5 (multi-source architecture)
+**Version:** 4.8.0 (multi-source architecture)
 **Stack:** React 19 + TS + Vite frontend / Node.js 20+ (Docker image ships Node 24; CI matrix covers 20/22/24/25) + Express 5 + TS backend / SQLite (default), PostgreSQL, MySQL via Drizzle ORM / Meshtastic protobuf-over-TCP and MeshCore (native `meshcore.js` for companion, serial CLI for repeater) through a per-source manager registry.
 
 ## Read order for new agents

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.7.4",
+  "version": "4.8.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.7.4",
+  "version": "4.8.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -20,7 +20,14 @@ When a MeshCore source is connected, you get:
 - **Radio preset selector** — Pick from the official MeshCore preset list instead of hand-tuning freq/bw/sf/cr
 - **Contact-detail panel** — Hops, RSSI/SNR, last heard, position, and the full public key shown next to DM threads
 - **Contact management** — Remove contacts from the device, export as `meshcore://` URLs for sharing, import from pasted URLs or hex blobs
-- **Repeater neighbour list** — Query a repeater's neighbour table with SNR and last-heard timestamps
+- **Repeater neighbour list** — Query a repeater's neighbour table with SNR and last-heard timestamps, with results rendered on the map
+- **Path visualization** — Show route lines on the map colored by hop count, with Discover Path buttons for manual route establishment
+- **Auto-pathfinding** — Scheduled path discovery and neighbor collection across your entire mesh
+- **Room server support** — Login, post, and auto-sync with MeshCore room servers (BBS-style message boards)
+- **@mention highlighting** — Messages mentioning your name are visually highlighted
+- **Delivery status** — Sent DMs show pending/confirmed/failed indicators
+- **Clickable contact names** — Names in messages navigate to that contact's DM thread
+- **Mobile-responsive layout** — Full MeshCore page works on mobile with list/detail toggle
 - **Device time sync** — One-click RTC sync from the Node Info page
 - **Device management** — Reboot device, backup/restore Ed25519 private key (danger-gated with confirmation)
 - **Telemetry-mode configuration** — Toggle base / location / environment telemetry on the device itself
@@ -108,7 +115,7 @@ Each MeshCore source has its own multi-pane page accessible by clicking the sour
 
 ### Nodes
 
-A map of every contact with valid coordinates, plus a styled row list aligned to the same visual vocabulary as the Meshtastic nodes view. The map honours zoom-based label visibility and falls through to the dashboard map when the source is selected at the dashboard level.
+A map of every contact with valid coordinates, plus a styled row list aligned to the same visual vocabulary as the Meshtastic nodes view. The map honours zoom-based label visibility and falls through to the dashboard map when the source is selected at the dashboard level. A search/filter bar lets you quickly find contacts by name or public key prefix.
 
 ### Channels
 
@@ -124,6 +131,10 @@ Per-contact DM view with a **contact-detail panel** that mirrors the Meshtastic 
 - Last heard and last advert
 - Position (if known)
 - Full public key
+- **Discover Path** button — triggers firmware CMD 52 to establish/refresh the route to a companion contact
+- **Delivery status** — sent DMs show pending / confirmed / failed indicators with timestamp tooltips
+
+Contact names in messages are **clickable** — clicking a name navigates directly to that contact's DM thread. Messages containing **@YourName** are visually highlighted.
 
 The panel is collapsible with state persisted to localStorage.
 
@@ -241,6 +252,48 @@ Every CLI command, login outcome, and credential mutation writes an `audit_log` 
 
 The `details` JSON captures `sourceId`, `publicKey` (where relevant), command text, reply length, and elapsed milliseconds. **The plaintext password never appears in audit details**, verified by the canary test referenced above.
 
+## Path Visualization
+
+The MeshCore map can render **route lines** between your local node and each contact, colored by hop count:
+
+- **Green** — direct (1 hop)
+- **Orange** — 2-3 hops
+- **Red** — 4+ hops
+
+Toggle path visibility from the map toolbar. Paths are populated by the **Discover Path** button in the contact-detail panel (sends firmware CMD 52) or automatically by the [Auto-Pathfinding](#auto-pathfinding) scheduler. When the firmware responds with path discovery results (push code 0x8D), the route is stored and rendered immediately.
+
+## Neighbor Discovery
+
+Repeaters maintain a neighbor table of other repeaters heard via zero-hop adverts. MeshMonitor can query this table and display the results:
+
+- **Contact-detail panel** — a "Get Neighbours" button appears for repeater contacts. Results show each neighbor's name (resolved from pubkey prefix), SNR, and last-heard time.
+- **Map rendering** — neighbor links appear on the map as dashed lines between repeaters.
+- **Map Analysis** — the inspector panel in Map Analysis mode includes a MeshCore neighbor links layer with transport-type filtering (RF / UDP / unknown).
+- **Database persistence** — neighbor data is stored in `meshcore_neighbor_info` and survives page refreshes.
+
+Neighbor queries require authentication to the repeater (guest or admin login). See [the MeshCore protocol details](/features/meshcore#remote-administration) for auth requirements.
+
+## Auto-Pathfinding
+
+The **Automation** view (accessible from the MeshCore page sub-toolbar) provides scheduled path discovery and neighbor collection:
+
+- **Path Discovery** — periodically sends Discover Path requests to all companion contacts to keep route information fresh.
+- **Neighbors for Repeaters** — periodically queries the neighbor list from all repeater contacts and persists results to the database for map rendering.
+- **Configurable schedule** — set the delay between individual requests (default: 5 minutes) and how often the full cycle repeats (default: every 24 hours).
+- **Independent toggles** — enable/disable path discovery and neighbor collection independently.
+- **RF-aware throttling** — requests are spaced by the configured interval to avoid flooding the mesh. A global 60-second minimum spacing between any two scheduled mesh operations on the same source is also enforced.
+
+Retrieved neighbor data is automatically resolved (pubkey prefixes mapped to full contact records) and persisted to `meshcore_neighbor_info` for map rendering and the Map Analysis inspector panel.
+
+## Room Servers
+
+Room servers (advType=3) are BBS-style MeshCore nodes that store posts and push-sync them to connected clients. The **Rooms** view in the MeshCore page lists discovered room servers and provides:
+
+- **Login / auto-login** — enter a password to join a room, or save credentials for automatic login on future visits. Login retries up to 3 times automatically to handle RF packet loss.
+- **Post stream** — read and send posts in the room's message board.
+- **Auto-sync** — configure periodic re-login to fetch new posts on a schedule (1h to 24h intervals). The auto-sync setting is persisted per-room and loaded when the room is selected.
+- **Credential persistence** — saved room passwords are AES-256-GCM encrypted via the same credential store used for remote admin passwords.
+
 ## Multi-Source Dashboard
 
 MeshCore sources appear as styled cards in the dashboard sidebar — same visual language as Meshtastic sources, with a MeshCore logo and per-source status.
@@ -283,18 +336,15 @@ Saved radio params are now persisted authoritatively: the backend propagates dev
 
 ## Still Early
 
-This is the part that's worth being honest about. MeshCore support is **basic** today — the core "see your network, send messages, watch telemetry" loop works, but plenty is missing.
+MeshCore support has come a long way since 4.5 — remote administration, path visualization, neighbor discovery, auto-pathfinding, room servers, and a mobile-responsive layout are all shipping. But there are still gaps:
 
 Known gaps and limitations:
 
-- **Repeater / Room Server per-source parity** is behind Companion. Repeater is selectable as a USB device type, but most new 4.5 features (local telemetry poller, remote-telemetry scheduler, telemetry-mode toggles) require a Companion connection on the source side.
-- **No remote-admin equivalent** for MeshCore yet — the Meshtastic-side admin scanner, password rotation, OTA flow, etc. don't have MeshCore counterparts.
-- **No auto-responder / auto-announce / auto-traceroute** schedulers for MeshCore. The per-source scheduler primitives are wired up, but the user-facing features haven't been built yet.
+- **Repeater / Room Server per-source parity** is behind Companion. Repeater is selectable as a USB device type, but features like local telemetry polling and telemetry-mode toggles require a Companion connection on the source side.
 - **Notifications** for MeshCore events are minimal — apprise/push surfaces aren't yet first-class.
-- **Map rendering** uses the dashboard map's existing primitives, so MeshCore-specific link visualization (direct radio links, route quality) is not yet there.
 - **Companion-only telemetry mode toggles** — Repeaters report what they report; the base/loc/env toggle is meaningful on Companions.
 
-The roadmap is incremental: keep landing one or two MeshCore features per release, keep aligning the UI vocabulary with Meshtastic, and gradually close the parity gap.
+The roadmap is incremental: keep landing MeshCore features each release, keep aligning the UI vocabulary with Meshtastic, and gradually close the remaining parity gap.
 
 ## Troubleshooting
 

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.7.4
-appVersion: "4.7.4"
+version: 4.8.0
+appVersion: "4.8.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.7.4",
+  "version": "4.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.7.4",
+      "version": "4.8.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.7.4",
+  "version": "4.8.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Version bump from 4.7.4 → 4.8.0 across all 5 version files
- CHANGELOG.md updated with full 4.8.0 release notes
- docs/features/meshcore.md updated with new sections:
  - Path Visualization (route lines colored by hop count)
  - Neighbor Discovery (repeater neighbor tables on map)
  - Auto-Pathfinding (scheduled path discovery + neighbor collection)
  - Room Servers (login, post, auto-sync)
  - Updated DM section (delivery status, @mentions, clickable names)
  - Updated overview feature list
  - Updated "Still Early" section (closed gaps removed)
- CLAUDE.md version updated

### New features in this release
- MeshCore path visualization with hop-count colored lines
- Discover Path button (firmware CMD 52)
- Path discovery response handling (push 0x8D)
- Repeater neighbor support with map rendering
- Auto-Pathfinding automation tab
- @mention highlighting and delivery status
- Node navigation, clickable names, search filtering
- Mobile-responsive MeshCore layout
- Room server auto-sync persistence fix
- MQTT shared reconnect backoff
- Delete/Purge buttons in map popup
- Pre-populate NodeDB for PKI DMs

## Test plan
- [ ] Version displays correctly in UI
- [ ] Docs site builds without errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)