### PR TITLE
feat(meshcore): auto-acknowledge automation with channels, DM, and macros

### DIFF
--- a/src/components/MeshCore/MeshCoreAutoAckSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAckSection.tsx
@@ -26,7 +26,7 @@ interface MeshCoreChannelRow {
   name: string;
 }
 
-const DEFAULT_MESSAGE = '🤖 Copy, {NODE_NAME}! @ {TIME}';
+const DEFAULT_MESSAGE = '🤖 Copy, {NODE_NAME}! {HOPS} hops @ {TIME}';
 const DEFAULT_REGEX = '^(test|ping)';
 const DEFAULT_TEST_MESSAGES = 'test\nTest message\nping\nPING\nHello world\nTESTING 123';
 
@@ -64,6 +64,9 @@ const generateSample = (template: string): string => {
     .replace(/\{DATE\}/g, now.toLocaleDateString('en-US'))
     .replace(/\{TIME\}/g, now.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false }))
     .replace(/\{SNR\}/g, '7.5')
+    .replace(/\{HOPS\}/g, '3')
+    .replace(/\{NUMBER_HOPS\}/g, '3')
+    .replace(/\{ROUTE\}/g, 'a3 → 7f → 02')
     .replace(/\{VERSION\}/g, '4.8.0');
 };
 
@@ -400,7 +403,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
             {t('meshcore.automation.autoack.message_label', 'Acknowledgement Message')}
             <span className="setting-description" style={{ display: 'block', marginTop: '0.25rem' }}>
               {t('meshcore.automation.autoack.available_tokens', 'Available tokens:')}{' '}
-              {'{NODE_ID}'}, {'{NODE_NAME}'}, {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{DATE}'}, {'{TIME}'}, {'{SNR}'}, {'{VERSION}'}
+              {'{NODE_ID}'}, {'{NODE_NAME}'}, {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{DATE}'}, {'{TIME}'}, {'{SNR}'}, {'{HOPS}'}, {'{ROUTE}'}, {'{VERSION}'}
             </span>
           </label>
           <textarea

--- a/src/components/MeshCore/MeshCoreAutoAckSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAckSection.tsx
@@ -1,0 +1,514 @@
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useCsrfFetch } from '../../hooks/useCsrfFetch';
+import { useToast } from '../ToastContainer';
+import { useAuth } from '../../contexts/AuthContext';
+import { useSaveBar } from '../../hooks/useSaveBar';
+
+interface MeshCoreAutoAckSectionProps {
+  baseUrl: string;
+  sourceId: string;
+}
+
+interface AutoAckSettings {
+  enabled: boolean;
+  regex: string;
+  message: string;
+  channels: number[];
+  directMessages: boolean;
+  useDM: boolean;
+  cooldownSeconds: number;
+  testMessages: string;
+}
+
+interface MeshCoreChannelRow {
+  id: number;
+  name: string;
+}
+
+const DEFAULT_MESSAGE = '🤖 Copy, {NODE_NAME}! @ {TIME}';
+const DEFAULT_REGEX = '^(test|ping)';
+const DEFAULT_TEST_MESSAGES = 'test\nTest message\nping\nPING\nHello world\nTESTING 123';
+
+const DEFAULTS: AutoAckSettings = {
+  enabled: false,
+  regex: DEFAULT_REGEX,
+  message: DEFAULT_MESSAGE,
+  channels: [],
+  directMessages: true,
+  useDM: false,
+  cooldownSeconds: 0,
+  testMessages: DEFAULT_TEST_MESSAGES,
+};
+
+const validateRegex = (pattern: string): { valid: boolean; error?: string } => {
+  if (pattern.length > 100) return { valid: false, error: 'Pattern too long (max 100 chars)' };
+  if (/(\.\*){2,}|(\+.*\+)|(\*.*\*)|(\{[0-9]{3,}\})|(\{[0-9]+,\})/.test(pattern)) {
+    return { valid: false, error: 'Pattern too complex (possible ReDoS)' };
+  }
+  try {
+    new RegExp(pattern, 'i');
+    return { valid: true };
+  } catch {
+    return { valid: false, error: 'Invalid regex syntax' };
+  }
+};
+
+const generateSample = (template: string): string => {
+  const now = new Date();
+  return template
+    .replace(/\{NODE_ID\}/g, '!a1b2c3d4')
+    .replace(/\{NODE_NAME\}/g, 'Alice MeshCore')
+    .replace(/\{LONG_NAME\}/g, 'Alice MeshCore')
+    .replace(/\{SHORT_NAME\}/g, 'Alic')
+    .replace(/\{DATE\}/g, now.toLocaleDateString('en-US'))
+    .replace(/\{TIME\}/g, now.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false }))
+    .replace(/\{SNR\}/g, '7.5')
+    .replace(/\{VERSION\}/g, '4.8.0');
+};
+
+export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ baseUrl, sourceId }) => {
+  const { t } = useTranslation();
+  const csrfFetch = useCsrfFetch();
+  const { showToast } = useToast();
+  const { hasPermission } = useAuth();
+  const canWrite = hasPermission('automation', 'write');
+
+  const [settings, setSettings] = useState<AutoAckSettings>(DEFAULTS);
+  const [initial, setInitial] = useState<AutoAckSettings>(DEFAULTS);
+  const [channels, setChannels] = useState<MeshCoreChannelRow[]>([]);
+  const [hasChanges, setHasChanges] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Load auto-ack settings
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await csrfFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/automation/autoack`);
+        if (!res.ok) return;
+        const json = await res.json();
+        if (cancelled || !json.success || !json.data) return;
+        const s: AutoAckSettings = {
+          enabled: !!json.data.enabled,
+          regex: json.data.regex || DEFAULT_REGEX,
+          message: json.data.message || DEFAULT_MESSAGE,
+          channels: Array.isArray(json.data.channels) ? json.data.channels : [],
+          directMessages: !!json.data.directMessages,
+          useDM: !!json.data.useDM,
+          cooldownSeconds: typeof json.data.cooldownSeconds === 'number' ? json.data.cooldownSeconds : 0,
+          testMessages: json.data.testMessages || DEFAULT_TEST_MESSAGES,
+        };
+        setSettings(s);
+        setInitial(s);
+        setLoaded(true);
+      } catch {
+        // ignore — keep defaults
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [baseUrl, sourceId, csrfFetch]);
+
+  // Load channels for the per-channel allowlist
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await csrfFetch(
+          `${baseUrl}/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`,
+        );
+        if (!res.ok) return;
+        const raw = await res.json();
+        if (cancelled) return;
+        const rows: MeshCoreChannelRow[] = Array.isArray(raw)
+          ? raw
+              .filter((c: any) => typeof c?.id === 'number')
+              .map((c: any) => ({ id: c.id as number, name: String(c.name ?? '') }))
+              .sort((a, b) => a.id - b.id)
+          : [];
+        setChannels(rows);
+      } catch {
+        // ignore
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [baseUrl, sourceId, csrfFetch]);
+
+  // Detect changes
+  useEffect(() => {
+    if (!loaded) return;
+    const channelsChanged = JSON.stringify([...settings.channels].sort()) !== JSON.stringify([...initial.channels].sort());
+    setHasChanges(
+      settings.enabled !== initial.enabled ||
+      settings.regex !== initial.regex ||
+      settings.message !== initial.message ||
+      settings.directMessages !== initial.directMessages ||
+      settings.useDM !== initial.useDM ||
+      settings.cooldownSeconds !== initial.cooldownSeconds ||
+      settings.testMessages !== initial.testMessages ||
+      channelsChanged,
+    );
+  }, [settings, initial, loaded]);
+
+  const handleSave = useCallback(async () => {
+    const validation = validateRegex(settings.regex);
+    if (!validation.valid) {
+      showToast(`Invalid regex pattern: ${validation.error}`, 'error');
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const res = await csrfFetch(
+        `${baseUrl}/api/sources/${sourceId}/meshcore/automation/autoack`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            enabled: settings.enabled,
+            regex: settings.regex,
+            message: settings.message,
+            channels: settings.channels,
+            directMessages: settings.directMessages,
+            useDM: settings.useDM,
+            cooldownSeconds: settings.cooldownSeconds,
+            testMessages: settings.testMessages,
+          }),
+        },
+      );
+      if (!res.ok) {
+        if (res.status === 403) {
+          showToast(t('automation.insufficient_permissions', 'Insufficient permissions'), 'error');
+          return;
+        }
+        throw new Error(`Server returned ${res.status}`);
+      }
+      setInitial(settings);
+      setHasChanges(false);
+      showToast(t('automation.settings_saved', 'Settings saved'), 'success');
+    } catch (err) {
+      console.error('Failed to save MeshCore auto-ack settings:', err);
+      showToast(t('automation.settings_save_failed', 'Failed to save settings'), 'error');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [settings, baseUrl, sourceId, csrfFetch, showToast, t]);
+
+  const handleDismiss = useCallback(() => {
+    setSettings(initial);
+    setHasChanges(false);
+  }, [initial]);
+
+  useSaveBar({
+    id: 'meshcore-auto-ack',
+    sectionName: t('meshcore.automation.autoack.title', 'Auto-Acknowledge'),
+    hasChanges,
+    isSaving,
+    onSave: handleSave,
+    onDismiss: handleDismiss,
+  });
+
+  const update = <K extends keyof AutoAckSettings>(key: K, value: AutoAckSettings[K]) => {
+    setSettings(prev => ({ ...prev, [key]: value }));
+  };
+
+  const sample = useMemo(() => generateSample(settings.message), [settings.message]);
+
+  const testRegex = useMemo(() => {
+    const v = validateRegex(settings.regex);
+    return v.valid ? new RegExp(settings.regex, 'i') : null;
+  }, [settings.regex]);
+
+  const disabled = !settings.enabled;
+
+  return (
+    <>
+      <div className="automation-section-header" style={{
+        display: 'flex',
+        alignItems: 'center',
+        marginBottom: '1.5rem',
+        marginTop: '2rem',
+        padding: '1rem 1.25rem',
+        background: 'var(--ctp-surface1)',
+        border: '1px solid var(--ctp-surface2)',
+        borderRadius: '8px',
+      }}>
+        <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <input
+            type="checkbox"
+            checked={settings.enabled}
+            onChange={(e) => update('enabled', e.target.checked)}
+            disabled={!canWrite}
+            style={{ width: 'auto', margin: 0, cursor: canWrite ? 'pointer' : 'not-allowed' }}
+          />
+          {t('meshcore.automation.autoack.title', 'Auto-Acknowledge')}
+        </h2>
+      </div>
+
+      <div className="settings-section" style={{ opacity: settings.enabled ? 1 : 0.5, transition: 'opacity 0.2s' }}>
+        <p style={{ marginBottom: '1rem', color: '#666', lineHeight: 1.5, marginLeft: '1.75rem' }}>
+          {t(
+            'meshcore.automation.autoack.description',
+            'Automatically reply to incoming MeshCore messages that match a regex pattern. Supports per-channel allowlist, DM trigger, and template macros.',
+          )}
+        </p>
+
+        {/* Regex */}
+        <div className="setting-item" style={{ marginTop: '1rem' }}>
+          <label htmlFor="meshcoreAutoAckRegex">
+            {t('meshcore.automation.autoack.regex_label', 'Trigger Pattern (regex)')}
+            <span className="setting-description">
+              {t(
+                'meshcore.automation.autoack.regex_description',
+                'Incoming messages that match this case-insensitive regex trigger an acknowledgement.',
+              )}{' '}
+              {t('meshcore.automation.autoack.regex_default', 'Default: ^(test|ping)')}
+            </span>
+          </label>
+          <input
+            id="meshcoreAutoAckRegex"
+            type="text"
+            value={settings.regex}
+            onChange={(e) => update('regex', e.target.value)}
+            placeholder={DEFAULT_REGEX}
+            disabled={disabled || !canWrite}
+            className="setting-input"
+            style={{ fontFamily: 'monospace' }}
+          />
+        </div>
+
+        {/* Channel selection */}
+        <div className="setting-item" style={{ marginTop: '1.5rem' }}>
+          <label>
+            {t('meshcore.automation.autoack.active_channels', 'Active Channels')}
+            <span className="setting-description">
+              {t(
+                'meshcore.automation.autoack.active_channels_description',
+                'Acknowledge messages received on these channels. Direct Messages can be toggled separately below.',
+              )}
+            </span>
+          </label>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginTop: '0.5rem' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              <input
+                type="checkbox"
+                id="meshcoreAutoAckDM"
+                checked={settings.directMessages}
+                onChange={(e) => update('directMessages', e.target.checked)}
+                disabled={disabled || !canWrite}
+                style={{ width: 'auto', margin: 0 }}
+              />
+              <label htmlFor="meshcoreAutoAckDM" style={{ margin: 0, fontWeight: 'bold' }}>
+                {t('meshcore.automation.autoack.direct_messages', 'Direct Messages')}
+              </label>
+            </div>
+            {channels.length === 0 && (
+              <div style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)', marginLeft: '1.5rem' }}>
+                {t('meshcore.automation.autoack.no_channels', 'No channels loaded yet.')}
+              </div>
+            )}
+            {channels.map((channel) => (
+              <div key={channel.id} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <input
+                  type="checkbox"
+                  id={`meshcoreAutoAckChannel${channel.id}`}
+                  checked={settings.channels.includes(channel.id)}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      update('channels', [...settings.channels, channel.id]);
+                    } else {
+                      update('channels', settings.channels.filter((c) => c !== channel.id));
+                    }
+                  }}
+                  disabled={disabled || !canWrite}
+                  style={{ width: 'auto', margin: 0 }}
+                />
+                <label
+                  htmlFor={`meshcoreAutoAckChannel${channel.id}`}
+                  style={{ margin: 0 }}
+                >
+                  {channel.name || `Channel ${channel.id}`}
+                </label>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Always respond via DM */}
+        <div className="setting-item" style={{ marginTop: '1.5rem' }}>
+          <label>
+            {t('meshcore.automation.autoack.response_delivery', 'Response Delivery')}
+            <span className="setting-description">
+              {t(
+                'meshcore.automation.autoack.response_delivery_description',
+                'Control whether the acknowledgement is sent on the originating channel or always as a DM.',
+              )}
+            </span>
+          </label>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.5rem' }}>
+            <input
+              type="checkbox"
+              id="meshcoreAutoAckUseDM"
+              checked={settings.useDM}
+              onChange={(e) => update('useDM', e.target.checked)}
+              disabled={disabled || !canWrite}
+              style={{ width: 'auto', margin: 0 }}
+            />
+            <label htmlFor="meshcoreAutoAckUseDM" style={{ margin: 0, fontWeight: 'bold' }}>
+              {t('meshcore.automation.autoack.always_respond_dm', 'Always respond via DM')}
+            </label>
+          </div>
+          <div style={{ marginTop: '0.5rem', marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+            {t(
+              'meshcore.automation.autoack.always_respond_dm_description',
+              'When enabled, replies are always sent as a DM to the sender, even when the trigger came from a channel. Requires the sender to be in your contact list.',
+            )}
+          </div>
+        </div>
+
+        {/* Cooldown */}
+        <div className="setting-item" style={{ marginTop: '1.5rem' }}>
+          <label>
+            {t('meshcore.automation.autoack.cooldown_label', 'Per-Sender Cooldown')}
+            <span className="setting-description">
+              {t(
+                'meshcore.automation.autoack.cooldown_description',
+                'Minimum seconds between acknowledgements for the same sender. 0 disables the cooldown.',
+              )}
+            </span>
+          </label>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.5rem' }}>
+            <input
+              type="number"
+              value={settings.cooldownSeconds}
+              onChange={(e) => update('cooldownSeconds', Math.max(0, parseInt(e.target.value, 10) || 0))}
+              min={0}
+              max={3600}
+              disabled={disabled || !canWrite}
+              style={{ width: '100px', padding: '2px 4px' }}
+            />
+            <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+              {t('meshcore.automation.autoack.cooldown_help', 'seconds (0 = no cooldown)')}
+            </span>
+          </div>
+        </div>
+
+        {/* Message template */}
+        <div className="setting-item" style={{ marginTop: '1.5rem' }}>
+          <label htmlFor="meshcoreAutoAckMessage">
+            {t('meshcore.automation.autoack.message_label', 'Acknowledgement Message')}
+            <span className="setting-description" style={{ display: 'block', marginTop: '0.25rem' }}>
+              {t('meshcore.automation.autoack.available_tokens', 'Available tokens:')}{' '}
+              {'{NODE_ID}'}, {'{NODE_NAME}'}, {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{DATE}'}, {'{TIME}'}, {'{SNR}'}, {'{VERSION}'}
+            </span>
+          </label>
+          <textarea
+            id="meshcoreAutoAckMessage"
+            ref={textareaRef}
+            value={settings.message}
+            onChange={(e) => update('message', e.target.value)}
+            disabled={disabled || !canWrite}
+            className="setting-input"
+            rows={3}
+            style={{ fontFamily: 'monospace', resize: 'vertical', minHeight: '60px' }}
+          />
+          <div style={{ marginTop: '0.5rem' }}>
+            <label style={{ fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+              {t('meshcore.automation.autoack.sample_preview', 'Sample preview')}:
+            </label>
+            <div style={{
+              marginTop: '0.25rem',
+              padding: '0.5rem',
+              background: 'var(--ctp-base)',
+              border: '1px solid var(--ctp-blue)',
+              borderRadius: '4px',
+              fontFamily: 'monospace',
+              fontSize: '0.9rem',
+              color: 'var(--ctp-text)',
+            }}>
+              {sample}
+            </div>
+          </div>
+        </div>
+
+        {/* Regex test */}
+        <div className="setting-item" style={{ marginTop: '1.5rem' }}>
+          <label htmlFor="meshcoreAutoAckTestMessages">
+            {t('meshcore.automation.autoack.pattern_testing', 'Pattern Testing')}
+            <span className="setting-description">
+              {t(
+                'meshcore.automation.autoack.pattern_testing_description',
+                'One message per line. Green means the pattern would match (acknowledge); red means it would not.',
+              )}
+            </span>
+          </label>
+          <div className="auto-ack-test-container">
+            <div>
+              <textarea
+                id="meshcoreAutoAckTestMessages"
+                value={settings.testMessages}
+                onChange={(e) => update('testMessages', e.target.value)}
+                placeholder={t(
+                  'meshcore.automation.autoack.test_placeholder',
+                  'Enter test messages, one per line',
+                )}
+                disabled={disabled || !canWrite}
+                className="setting-input"
+                rows={6}
+                style={{
+                  fontFamily: 'monospace',
+                  resize: 'vertical',
+                  minHeight: '120px',
+                  width: '100%',
+                }}
+              />
+            </div>
+            <div>
+              {settings.testMessages
+                .split('\n')
+                .filter((line) => line.trim())
+                .map((message, index) => {
+                  const matches = testRegex ? testRegex.test(message) : false;
+                  return (
+                    <div
+                      key={index}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        padding: '0.25rem 0.5rem',
+                        marginBottom: '0.15rem',
+                        backgroundColor: matches ? 'rgba(166, 227, 161, 0.1)' : 'rgba(243, 139, 168, 0.1)',
+                        border: `1px solid ${matches ? 'var(--ctp-green)' : 'var(--ctp-red)'}`,
+                        borderRadius: '4px',
+                        fontFamily: 'monospace',
+                        fontSize: '0.9rem',
+                        lineHeight: '1.3',
+                      }}
+                    >
+                      <span
+                        style={{
+                          display: 'inline-block',
+                          width: '16px',
+                          height: '16px',
+                          borderRadius: '50%',
+                          backgroundColor: matches ? 'var(--ctp-green)' : 'var(--ctp-red)',
+                          marginRight: '0.5rem',
+                          flexShrink: 0,
+                        }}
+                      />
+                      <span style={{ color: 'var(--ctp-text)', wordBreak: 'break-word' }}>
+                        {message}
+                      </span>
+                    </div>
+                  );
+                })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default MeshCoreAutoAckSection;

--- a/src/components/MeshCore/MeshCoreAutomationsView.tsx
+++ b/src/components/MeshCore/MeshCoreAutomationsView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { useSaveBar } from '../../hooks/useSaveBar';
 import { useAuth } from '../../contexts/AuthContext';
+import { MeshCoreAutoAckSection } from './MeshCoreAutoAckSection';
 
 interface MeshCoreAutomationsViewProps {
   baseUrl: string;
@@ -286,6 +287,9 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
           </p>
         ) : null}
       </div>
+
+      {/* Auto-Acknowledge Section */}
+      <MeshCoreAutoAckSection baseUrl={baseUrl} sourceId={sourceId} />
     </div>
   );
 };

--- a/src/components/MeshCore/MeshCoreAutomationsView.tsx
+++ b/src/components/MeshCore/MeshCoreAutomationsView.tsx
@@ -135,7 +135,7 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
   };
 
   return (
-    <div className="meshcore-automations-view" style={{ padding: '1rem' }}>
+    <div className="meshcore-automations-view" style={{ padding: '1rem', overflowY: 'auto', height: '100%', minHeight: 0 }}>
       <h1 style={{ marginBottom: '1.5rem' }}>
         {t('meshcore.automation.title', 'Automations')}
       </h1>

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -157,6 +157,15 @@ export const VALID_SETTINGS_KEYS = [
   'meshcoreAutoPathfindingNeighborsEnabled',
   'meshcoreAutoPathfindingIntervalMinutes',
   'meshcoreAutoPathfindingRepeatHours',
+  // MeshCore auto-acknowledge
+  'meshcoreAutoAckEnabled',
+  'meshcoreAutoAckRegex',
+  'meshcoreAutoAckMessage',
+  'meshcoreAutoAckChannels',
+  'meshcoreAutoAckDirectMessages',
+  'meshcoreAutoAckUseDM',
+  'meshcoreAutoAckCooldownSeconds',
+  'meshcoreAutoAckTestMessages',
 ] as const;
 
 export type ValidSettingKey = typeof VALID_SETTINGS_KEYS[number];
@@ -248,6 +257,15 @@ export const PER_SOURCE_SETTINGS_KEYS = [
   'meshcoreAutoPathfindingNeighborsEnabled',
   'meshcoreAutoPathfindingIntervalMinutes',
   'meshcoreAutoPathfindingRepeatHours',
+  // MeshCore auto-acknowledge
+  'meshcoreAutoAckEnabled',
+  'meshcoreAutoAckRegex',
+  'meshcoreAutoAckMessage',
+  'meshcoreAutoAckChannels',
+  'meshcoreAutoAckDirectMessages',
+  'meshcoreAutoAckUseDM',
+  'meshcoreAutoAckCooldownSeconds',
+  'meshcoreAutoAckTestMessages',
   // Misc per-source
   'externalUrl',
   'geofenceTriggers',

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -43,6 +43,18 @@ function parseTelemetryMode(value: unknown): TelemetryMode | undefined {
 }
 
 /**
+ * Decode the hop count from the packed MeshCore `pathLen` byte. The wire
+ * format packs the hash-size in the top 2 bits and the hop count in the
+ * bottom 6 bits. The sentinel value 0xFF means "sent direct" (no flood),
+ * which we report as 0 hops. Returns null when no value is available.
+ */
+function decodePathLenHopCount(pathLen: number | undefined | null): number | null {
+  if (pathLen === undefined || pathLen === null) return null;
+  if (pathLen === 0xff) return 0;
+  return pathLen & 0x3f;
+}
+
+/**
  * Decide whether a channel slot reported by the firmware is actually in use.
  * MeshCore Companion firmware doesn't error on unconfigured slots — it
  * returns success with an empty name and a 16-byte all-zero secret. We
@@ -629,7 +641,13 @@ class MeshCoreManager extends EventEmitter {
       this.emit('message', message);
       dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
       logger.info(`[MeshCore:${this.sourceId}] Contact message from ${data.pubkey_prefix}: ${data.text}`);
-      void this.checkAutoAcknowledge(message, true, undefined);
+      // For DMs we have the sender's pubkey, so {ROUTE} falls back to the
+      // contact record's cached outPath (firmware updates it from inbound
+      // flood-packet paths, so it reflects the route this packet took).
+      const hopCount = decodePathLenHopCount(data.path_len);
+      const senderContact = this.resolveContactByPrefix(data.pubkey_prefix);
+      const route = senderContact?.outPath || null;
+      void this.checkAutoAcknowledge(message, true, undefined, hopCount, route);
     } else if (event_type === 'channel_message') {
       // MeshCore channel packets have no sender field on the wire — the sender's
       // device prefixes "Name: " onto the text body. Split it out so the UI can
@@ -651,7 +669,10 @@ class MeshCoreManager extends EventEmitter {
       this.emit('message', message);
       dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
       logger.info(`[MeshCore] Channel ${data.channel_idx} message: ${data.text}`);
-      void this.checkAutoAcknowledge(message, false, data.channel_idx);
+      // Channel messages carry no sender pubkey on the wire, so we can't
+      // look up an outPath for {ROUTE}. Hop count is still available.
+      const hopCount = decodePathLenHopCount(data.path_len);
+      void this.checkAutoAcknowledge(message, false, data.channel_idx, hopCount, null);
     } else if (event_type === 'room_message') {
       // Room server post (TXT_TYPE_SIGNED_PLAIN). The room's pubkey prefix
       // identifies which room, and the author prefix identifies the poster.
@@ -3164,7 +3185,7 @@ class MeshCoreManager extends EventEmitter {
   // same {NODE_ID}/{NODE_NAME}/{DATE}/{TIME}/{SNR}/{VERSION} macros so a
   // single template behaves consistently across both stacks.
 
-  private static readonly AUTO_ACK_DEFAULT_MESSAGE = '🤖 Copy, {NODE_NAME}! @ {TIME}';
+  private static readonly AUTO_ACK_DEFAULT_MESSAGE = '🤖 Copy, {NODE_NAME}! {HOPS} hops @ {TIME}';
   private static readonly AUTO_ACK_DEFAULT_REGEX = '^(test|ping)';
 
   private validateAutoAckRegex(pattern: string): RegExp | null {
@@ -3186,6 +3207,8 @@ class MeshCoreManager extends EventEmitter {
     senderName: string | undefined,
     snr: number | undefined,
     timestamp: number,
+    hops: number | null,
+    route: string | null,
   ): string {
     const date = new Date(timestamp);
     const longName = senderName || `${senderPubKey.substring(0, 8)}…`;
@@ -3194,6 +3217,22 @@ class MeshCoreManager extends EventEmitter {
     const snrStr = snr !== undefined && snr !== null ? snr.toFixed(1) : '—';
     const dateStr = date.toLocaleDateString('en-US');
     const timeStr = date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
+    const hopsStr = hops !== null ? String(hops) : '—';
+    // {ROUTE} expands the cached hop-hash chain into a readable
+    // arrow-separated list (e.g. "a3 → 7f → 02"). Empty / unknown
+    // route falls back to "direct" when hop count is 0 or "—" otherwise.
+    let routeStr: string;
+    if (route && route.length > 0) {
+      routeStr = route
+        .split(',')
+        .map(h => h.trim())
+        .filter(Boolean)
+        .join(' → ');
+    } else if (hops === 0) {
+      routeStr = 'direct';
+    } else {
+      routeStr = '—';
+    }
 
     return template
       .replace(/\{NODE_ID\}/g, nodeId)
@@ -3203,6 +3242,9 @@ class MeshCoreManager extends EventEmitter {
       .replace(/\{DATE\}/g, dateStr)
       .replace(/\{TIME\}/g, timeStr)
       .replace(/\{SNR\}/g, snrStr)
+      .replace(/\{HOPS\}/g, hopsStr)
+      .replace(/\{NUMBER_HOPS\}/g, hopsStr)
+      .replace(/\{ROUTE\}/g, routeStr)
       .replace(/\{VERSION\}/g, '4.8.0');
   }
 
@@ -3218,6 +3260,8 @@ class MeshCoreManager extends EventEmitter {
     message: MeshCoreMessage,
     isDirectMessage: boolean,
     channelIdx: number | undefined,
+    hops: number | null,
+    route: string | null,
   ): Promise<void> {
     try {
       const settings = databaseService.settings;
@@ -3287,6 +3331,8 @@ class MeshCoreManager extends EventEmitter {
         senderName,
         message.snr,
         message.timestamp,
+        hops,
+        route,
       );
 
       // Decide destination:

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -12,6 +12,7 @@ import { EventEmitter } from 'events';
 import { logger } from '../utils/logger.js';
 import databaseService from '../services/database.js';
 import { dataEventEmitter } from './services/dataEventEmitter.js';
+import { compileAutoAckRegex } from './utils/autoAckRegex.js';
 import { MeshCoreNativeBackend, type BridgeShapedEvent } from './meshcoreNativeBackend.js';
 
 // Dynamic imports for optional serialport dependency
@@ -3204,16 +3205,7 @@ class MeshCoreManager extends EventEmitter {
   private static readonly AUTO_ACK_DEFAULT_REGEX = '^(test|ping)';
 
   private validateAutoAckRegex(pattern: string): RegExp | null {
-    if (!pattern || pattern.length > 100) return null;
-    // Reject patterns with obvious catastrophic-backtracking shapes
-    if (/(\.\*){2,}|(\+.*\+)|(\*.*\*)|(\{[0-9]{3,}\})|(\{[0-9]+,\})/.test(pattern)) {
-      return null;
-    }
-    try {
-      return new RegExp(pattern, 'i');
-    } catch {
-      return null;
-    }
+    return compileAutoAckRegex(pattern).regex;
   }
 
   private replaceAutoAckTokens(

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -371,6 +371,11 @@ class MeshCoreManager extends EventEmitter {
   private autoPathfindingJitterTimeout: NodeJS.Timeout | null = null;
   private autoPathfindingLastRunAt: number = 0;
 
+  // Auto-acknowledge per-sender cooldown (keyed by sender pubkey prefix).
+  // Records the last time we acknowledged a sender so a chatty contact
+  // doesn't burn airtime if they spam the trigger phrase.
+  private autoAckCooldowns: Map<string, number> = new Map();
+
   constructor(sourceId: string) {
     super();
     if (!sourceId) {
@@ -624,6 +629,7 @@ class MeshCoreManager extends EventEmitter {
       this.emit('message', message);
       dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
       logger.info(`[MeshCore:${this.sourceId}] Contact message from ${data.pubkey_prefix}: ${data.text}`);
+      void this.checkAutoAcknowledge(message, true, undefined);
     } else if (event_type === 'channel_message') {
       // MeshCore channel packets have no sender field on the wire — the sender's
       // device prefixes "Name: " onto the text body. Split it out so the UI can
@@ -645,6 +651,7 @@ class MeshCoreManager extends EventEmitter {
       this.emit('message', message);
       dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
       logger.info(`[MeshCore] Channel ${data.channel_idx} message: ${data.text}`);
+      void this.checkAutoAcknowledge(message, false, data.channel_idx);
     } else if (event_type === 'room_message') {
       // Room server post (TXT_TYPE_SIGNED_PLAIN). The room's pubkey prefix
       // identifies which room, and the author prefix identifies the poster.
@@ -3145,6 +3152,165 @@ class MeshCoreManager extends EventEmitter {
       enabled: this.autoPathfindingTimer !== null || this.autoPathfindingJitterTimeout !== null,
       lastRunAt: this.autoPathfindingLastRunAt,
     };
+  }
+
+  // ============ Auto-Acknowledge ============
+  //
+  // Mirrors the Meshtastic auto-acknowledge feature: when an incoming
+  // contact_message (DM) or channel_message matches the configured regex,
+  // we send a reply. The reply destination is either the same channel,
+  // a DM back to the sender, or — if `autoAckUseDM` is set — always a DM
+  // regardless of how the message arrived. The reply text supports the
+  // same {NODE_ID}/{NODE_NAME}/{DATE}/{TIME}/{SNR}/{VERSION} macros so a
+  // single template behaves consistently across both stacks.
+
+  private static readonly AUTO_ACK_DEFAULT_MESSAGE = '🤖 Copy, {NODE_NAME}! @ {TIME}';
+  private static readonly AUTO_ACK_DEFAULT_REGEX = '^(test|ping)';
+
+  private validateAutoAckRegex(pattern: string): RegExp | null {
+    if (!pattern || pattern.length > 100) return null;
+    // Reject patterns with obvious catastrophic-backtracking shapes
+    if (/(\.\*){2,}|(\+.*\+)|(\*.*\*)|(\{[0-9]{3,}\})|(\{[0-9]+,\})/.test(pattern)) {
+      return null;
+    }
+    try {
+      return new RegExp(pattern, 'i');
+    } catch {
+      return null;
+    }
+  }
+
+  private replaceAutoAckTokens(
+    template: string,
+    senderPubKey: string,
+    senderName: string | undefined,
+    snr: number | undefined,
+    timestamp: number,
+  ): string {
+    const date = new Date(timestamp);
+    const longName = senderName || `${senderPubKey.substring(0, 8)}…`;
+    const shortName = senderName ? senderName.substring(0, 4) : senderPubKey.substring(0, 4);
+    const nodeId = `!${senderPubKey.substring(0, 8)}`;
+    const snrStr = snr !== undefined && snr !== null ? snr.toFixed(1) : '—';
+    const dateStr = date.toLocaleDateString('en-US');
+    const timeStr = date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
+
+    return template
+      .replace(/\{NODE_ID\}/g, nodeId)
+      .replace(/\{NODE_NAME\}/g, longName)
+      .replace(/\{LONG_NAME\}/g, longName)
+      .replace(/\{SHORT_NAME\}/g, shortName)
+      .replace(/\{DATE\}/g, dateStr)
+      .replace(/\{TIME\}/g, timeStr)
+      .replace(/\{SNR\}/g, snrStr)
+      .replace(/\{VERSION\}/g, '4.8.0');
+  }
+
+  /**
+   * Check an incoming message against the auto-ack configuration and send
+   * a reply if it matches.
+   *
+   * @param message - the just-received message (DM or channel)
+   * @param isDirectMessage - true if this arrived as a contact_message (DM)
+   * @param channelIdx - channel index when not a DM; undefined for DMs
+   */
+  private async checkAutoAcknowledge(
+    message: MeshCoreMessage,
+    isDirectMessage: boolean,
+    channelIdx: number | undefined,
+  ): Promise<void> {
+    try {
+      const settings = databaseService.settings;
+      const sourceId = this.sourceId;
+
+      const enabled = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckEnabled');
+      if (enabled !== 'true') return;
+
+      const regexStr = (await settings.getSettingForSource(sourceId, 'meshcoreAutoAckRegex')) || MeshCoreManager.AUTO_ACK_DEFAULT_REGEX;
+      const regex = this.validateAutoAckRegex(regexStr);
+      if (!regex) {
+        logger.warn(`[MeshCore:${sourceId}] Auto-ack: invalid regex "${regexStr}", skipping`);
+        return;
+      }
+
+      const text = message.text || '';
+      if (!regex.test(text)) return;
+
+      // Channel allowlist / DM gate
+      if (isDirectMessage) {
+        const dmEnabled = (await settings.getSettingForSource(sourceId, 'meshcoreAutoAckDirectMessages')) === 'true';
+        if (!dmEnabled) {
+          logger.debug(`[MeshCore:${sourceId}] Auto-ack: DM trigger ignored (DM auto-ack disabled)`);
+          return;
+        }
+      } else {
+        const channelsRaw = (await settings.getSettingForSource(sourceId, 'meshcoreAutoAckChannels')) || '';
+        const enabledChannels = new Set(
+          channelsRaw.split(',').map(s => s.trim()).filter(Boolean).map(s => parseInt(s, 10)).filter(n => Number.isFinite(n)),
+        );
+        if (channelIdx === undefined || !enabledChannels.has(channelIdx)) {
+          logger.debug(`[MeshCore:${sourceId}] Auto-ack: channel ${channelIdx} not in allowlist`);
+          return;
+        }
+      }
+
+      // Per-sender cooldown
+      const cooldownRaw = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckCooldownSeconds');
+      const cooldownSeconds = Math.max(0, parseInt(cooldownRaw || '0', 10) || 0);
+      if (cooldownSeconds > 0) {
+        const cooldownKey = isDirectMessage
+          ? `dm:${message.fromPublicKey}`
+          : `ch${channelIdx}:${message.fromPublicKey}`;
+        const last = this.autoAckCooldowns.get(cooldownKey) || 0;
+        if (Date.now() - last < cooldownSeconds * 1000) {
+          logger.debug(`[MeshCore:${sourceId}] Auto-ack: cooldown active for ${cooldownKey}`);
+          return;
+        }
+        this.autoAckCooldowns.set(cooldownKey, Date.now());
+      }
+
+      const useDM = (await settings.getSettingForSource(sourceId, 'meshcoreAutoAckUseDM')) === 'true';
+      const template = (await settings.getSettingForSource(sourceId, 'meshcoreAutoAckMessage')) || MeshCoreManager.AUTO_ACK_DEFAULT_MESSAGE;
+
+      // Resolve sender's display name from contacts when available
+      let senderName = message.fromName;
+      if (!senderName && !isDirectMessage) {
+        // Channel sender is in the prefix-split fromName; nothing to do
+      } else if (!senderName && isDirectMessage) {
+        const contact = this.resolveContactByPrefix(message.fromPublicKey);
+        senderName = contact?.advName ?? contact?.name ?? undefined;
+      }
+
+      const replyText = this.replaceAutoAckTokens(
+        template,
+        message.fromPublicKey,
+        senderName,
+        message.snr,
+        message.timestamp,
+      );
+
+      // Decide destination:
+      //  - DM trigger or "always DM" → send as DM (need contact pubkey)
+      //  - otherwise → reply on the channel it came in on
+      const sendAsDM = isDirectMessage || useDM;
+
+      if (sendAsDM) {
+        // Need the full contact pubkey to address a DM. The DM event
+        // gives us a prefix; resolve via the contact map.
+        const contact = this.resolveContactByPrefix(message.fromPublicKey);
+        if (!contact) {
+          logger.warn(`[MeshCore:${sourceId}] Auto-ack: cannot DM unknown contact ${message.fromPublicKey}`);
+          return;
+        }
+        logger.info(`[MeshCore:${sourceId}] Auto-ack DM → ${contact.advName ?? contact.publicKey.substring(0, 8)}: "${replyText}"`);
+        await this.sendMessage(replyText, contact.publicKey);
+      } else {
+        logger.info(`[MeshCore:${sourceId}] Auto-ack channel ${channelIdx} → "${replyText}"`);
+        await this.sendMessage(replyText, undefined, channelIdx);
+      }
+    } catch (err) {
+      logger.error(`[MeshCore:${this.sourceId}] Auto-ack handler threw: ${(err as Error).message}`);
+    }
   }
 
   private async attemptReconnect(): Promise<void> {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -55,6 +55,17 @@ function decodePathLenHopCount(pathLen: number | undefined | null): number | nul
 }
 
 /**
+ * Render a relay-hash hop list (already-hex strings from LogRxData parsing)
+ * into the comma-separated form `replaceAutoAckTokens` expects for
+ * {ROUTE}. Returns null when no hops are present.
+ */
+function formatPathHops(hops: unknown): string | null {
+  if (!Array.isArray(hops) || hops.length === 0) return null;
+  const filtered = hops.filter((h): h is string => typeof h === 'string' && h.length > 0);
+  return filtered.length > 0 ? filtered.join(',') : null;
+}
+
+/**
  * Decide whether a channel slot reported by the firmware is actually in use.
  * MeshCore Companion firmware doesn't error on unconfigured slots — it
  * returns success with an empty name and a 16-byte all-zero secret. We
@@ -641,12 +652,14 @@ class MeshCoreManager extends EventEmitter {
       this.emit('message', message);
       dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
       logger.info(`[MeshCore:${this.sourceId}] Contact message from ${data.pubkey_prefix}: ${data.text}`);
-      // For DMs we have the sender's pubkey, so {ROUTE} falls back to the
-      // contact record's cached outPath (firmware updates it from inbound
-      // flood-packet paths, so it reflects the route this packet took).
+      // Prefer the per-packet relay-hash chain recovered from LogRxData
+      // (the actual hops THIS packet traversed). Fall back to the
+      // sender contact's cached outPath if the native backend didn't
+      // surface a LogRxData event for this packet (e.g. mid-buffer race
+      // or a backend that doesn't subscribe to raw logging).
       const hopCount = decodePathLenHopCount(data.path_len);
       const senderContact = this.resolveContactByPrefix(data.pubkey_prefix);
-      const route = senderContact?.outPath || null;
+      const route = formatPathHops(data.path_hops) || senderContact?.outPath || null;
       void this.checkAutoAcknowledge(message, true, undefined, hopCount, route);
     } else if (event_type === 'channel_message') {
       // MeshCore channel packets have no sender field on the wire — the sender's
@@ -669,10 +682,12 @@ class MeshCoreManager extends EventEmitter {
       this.emit('message', message);
       dataEventEmitter.emitMeshCoreMessage(message, this.sourceId);
       logger.info(`[MeshCore] Channel ${data.channel_idx} message: ${data.text}`);
-      // Channel messages carry no sender pubkey on the wire, so we can't
-      // look up an outPath for {ROUTE}. Hop count is still available.
+      // Channel messages carry no sender pubkey on the wire, so there
+      // is no contact outPath fallback for {ROUTE}. The LogRxData
+      // path_hops (when present) is the only source of relay identities.
       const hopCount = decodePathLenHopCount(data.path_len);
-      void this.checkAutoAcknowledge(message, false, data.channel_idx, hopCount, null);
+      const route = formatPathHops(data.path_hops);
+      void this.checkAutoAcknowledge(message, false, data.channel_idx, hopCount, route);
     } else if (event_type === 'room_message') {
       // Room server post (TXT_TYPE_SIGNED_PLAIN). The room's pubkey prefix
       // identifies which room, and the author prefix identifies the poster.

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -303,6 +303,10 @@ export class MeshCoreNativeBackend extends EventEmitter {
         text: msg.text,
         sender_timestamp: msg.senderTimestamp,
         txt_type: typeof msg.txtType === 'number' ? msg.txtType : undefined,
+        // ContactMsgRecv pathLen is the packed wire byte (top 2 bits =
+        // hash size - 1, bottom 6 bits = hop count). 0xFF marks "sent
+        // direct"; otherwise the hop count is `pathLen & 0x3F`.
+        path_len: typeof msg.pathLen === 'number' ? msg.pathLen : undefined,
         snr: undefined,
       };
       this.emitBridgeEvent(isCliReply ? 'cli_reply' : 'contact_message', payload);
@@ -314,6 +318,8 @@ export class MeshCoreNativeBackend extends EventEmitter {
         channel_idx: msg.channelIdx,
         text: msg.text,
         sender_timestamp: msg.senderTimestamp,
+        // Same packed-byte semantics as contact_message above.
+        path_len: typeof msg.pathLen === 'number' ? msg.pathLen : undefined,
         snr: undefined,
       });
     });

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -32,6 +32,17 @@ interface MeshCoreJsModule {
     TxtTypes: { Plain: number; CliData: number; SignedPlain: number };
   };
   CayenneLpp: { parse: (bytes: Uint8Array | number[]) => Array<{ channel: number; type: number; value: any }> };
+  /** OTA packet parser used to recover relay-hash chains from LogRxData. */
+  Packet: {
+    PAYLOAD_TYPE_TXT_MSG: number;
+    fromBytes(bytes: Uint8Array | number[]): {
+      payload_type: number;
+      pathLen: number;
+      path: Uint8Array;
+    };
+    extractPathHashSize(pathLen: number): number;
+    extractPathHashCount(pathLen: number): number;
+  };
 }
 
 let meshcoreJsModulePromise: Promise<MeshCoreJsModule> | null = null;
@@ -192,6 +203,17 @@ export class MeshCoreNativeBackend extends EventEmitter {
   private connected: boolean = false;
   private commandSeq: number = 0;
   private drainInFlight: boolean = false;
+  /**
+   * Most recent LogRxData-derived TXT_MSG packet metadata. The firmware
+   * emits LogRxData immediately before dispatching the txt-msg-specific
+   * recv event (ContactMsgRecv / ChannelMsgRecv) for the same packet, so
+   * we buffer the parsed path here and consume it on the next message
+   * recv to give the bridge event the real relay-hash chain rather than
+   * just the packed pathLen byte.
+   */
+  private pendingTxtMsgPath: { hops: string[]; rawPathLen: number } | null = null;
+  /** Constructor reference for the meshcore.js Packet parser, populated when the module loads. */
+  private PacketCtor: MeshCoreJsModule['Packet'] | null = null;
 
   constructor(sourceId: string, config: NativeBackendConfig) {
     super();
@@ -206,6 +228,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
   async connect(): Promise<void> {
     const mod = await loadMeshCoreJs();
     this.constants = mod.Constants;
+    this.PacketCtor = mod.Packet ?? null;
 
     if (this.config.connectionType === 'tcp') {
       if (!this.config.tcpHost || !this.config.tcpPort) {
@@ -260,9 +283,57 @@ export class MeshCoreNativeBackend extends EventEmitter {
 
   // ---------------- push event wiring ----------------
 
+  /**
+   * Pretty-print the relay-hash chain extracted from an OTA `path` field.
+   * `pathLen` is the packed wire byte (top 2 bits = hash size index, bottom
+   * 6 bits = hop count). Returns an array of lowercase hex strings per
+   * hop, or [] if no path is present.
+   */
+  private decodePathHops(path: Uint8Array, pathLen: number): string[] {
+    if (!this.PacketCtor) return [];
+    if (pathLen === 0xff) return []; // direct route — no relay hashes
+    const hashSize = this.PacketCtor.extractPathHashSize(pathLen);
+    const hopCount = this.PacketCtor.extractPathHashCount(pathLen);
+    if (hopCount <= 0 || hashSize <= 0) return [];
+    const hops: string[] = [];
+    for (let i = 0; i < hopCount; i++) {
+      const offset = i * hashSize;
+      const slice = path.subarray(offset, offset + hashSize);
+      if (slice.length === 0) break;
+      const hex = Array.from(slice).map(b => b.toString(16).padStart(2, '0')).join('');
+      hops.push(hex);
+    }
+    return hops;
+  }
+
   private wirePushEvents(): void {
     if (!this.connection || !this.constants) return;
     const { PushCodes, ResponseCodes } = this.constants;
+
+    // LogRxData: emitted for every received OTA packet (when a serial
+    // client is attached). The companion-level txt-msg recv events
+    // (ContactMsgRecv / ChannelMsgRecv) strip the relay-hash chain, so
+    // we parse the raw bytes here, buffer the path for TXT_MSG packets
+    // only, and let the next message-recv handler consume it. The
+    // single-buffer design is intentional — under the wire-level
+    // serialization the firmware uses, LogRxData is emitted right
+    // before the corresponding txt-msg event for the same packet.
+    if (typeof PushCodes?.LogRxData === 'number' && this.PacketCtor) {
+      const PacketCtor = this.PacketCtor;
+      const TXT_MSG = PacketCtor.PAYLOAD_TYPE_TXT_MSG;
+      this.connection.on(PushCodes.LogRxData, (rx: any) => {
+        try {
+          const raw: Uint8Array | undefined = rx?.raw;
+          if (!raw || raw.length === 0) return;
+          const pkt = PacketCtor.fromBytes(raw);
+          if (pkt.payload_type !== TXT_MSG) return;
+          const hops = this.decodePathHops(pkt.path, pkt.pathLen);
+          this.pendingTxtMsgPath = { hops, rawPathLen: pkt.pathLen };
+        } catch {
+          // Best-effort: a malformed log line shouldn't break the message stream.
+        }
+      });
+    }
 
     // ContactMsgRecv → contact_message (plain DM), cli_reply (txtType=CliData),
     // or room_message (txtType=SignedPlain, pushed by a room server).
@@ -298,6 +369,11 @@ export class MeshCoreNativeBackend extends EventEmitter {
         return;
       }
 
+      // Consume the path buffered by the preceding LogRxData event (if any).
+      // Same-tick consumption: clear the buffer so a subsequent recv that
+      // didn't get a matching LogRxData (rare) doesn't reuse stale hops.
+      const consumedPath = this.pendingTxtMsgPath;
+      this.pendingTxtMsgPath = null;
       const payload = {
         pubkey_prefix: bytesToHex(msg.pubKeyPrefix),
         text: msg.text,
@@ -307,6 +383,10 @@ export class MeshCoreNativeBackend extends EventEmitter {
         // hash size - 1, bottom 6 bits = hop count). 0xFF marks "sent
         // direct"; otherwise the hop count is `pathLen & 0x3F`.
         path_len: typeof msg.pathLen === 'number' ? msg.pathLen : undefined,
+        // Per-packet relay-hash chain recovered from the preceding
+        // LogRxData event (raw OTA bytes). undefined when LogRxData is
+        // not available (e.g. backend started without raw logging).
+        path_hops: consumedPath?.hops,
         snr: undefined,
       };
       this.emitBridgeEvent(isCliReply ? 'cli_reply' : 'contact_message', payload);
@@ -314,12 +394,15 @@ export class MeshCoreNativeBackend extends EventEmitter {
 
     // ChannelMsgRecv → channel_message
     this.connection.on(ResponseCodes.ChannelMsgRecv, (msg: any) => {
+      const consumedPath = this.pendingTxtMsgPath;
+      this.pendingTxtMsgPath = null;
       this.emitBridgeEvent('channel_message', {
         channel_idx: msg.channelIdx,
         text: msg.text,
         sender_timestamp: msg.senderTimestamp,
         // Same packed-byte semantics as contact_message above.
         path_len: typeof msg.pathLen === 'number' ? msg.pathLen : undefined,
+        path_hops: consumedPath?.hops,
         snr: undefined,
       });
     });

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -2316,6 +2316,128 @@ router.post(
   },
 );
 
+// ============ Auto-Acknowledge Automation ============
+//
+// Per-source settings store for MeshCore auto-acknowledge. The trigger
+// fires from the manager's incoming-message handler (handleBridgeEvent),
+// so this endpoint is just a CRUD wrapper — no scheduler.
+
+router.get(
+  '/automation/autoack',
+  optionalAuth(),
+  requirePermission('automation', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id?: string }).id!;
+      const settings = databaseService.settings;
+
+      const enabled = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckEnabled');
+      const regex = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckRegex');
+      const message = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckMessage');
+      const channels = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckChannels');
+      const directMessages = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckDirectMessages');
+      const useDM = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckUseDM');
+      const cooldownSeconds = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckCooldownSeconds');
+      const testMessages = await settings.getSettingForSource(sourceId, 'meshcoreAutoAckTestMessages');
+
+      res.json({
+        success: true,
+        data: {
+          enabled: enabled === 'true',
+          regex: regex || '^(test|ping)',
+          message: message || '🤖 Copy, {NODE_NAME}! @ {TIME}',
+          channels: (channels || '')
+            .split(',')
+            .map(s => s.trim())
+            .filter(Boolean)
+            .map(s => parseInt(s, 10))
+            .filter(n => Number.isFinite(n)),
+          directMessages: directMessages === 'true',
+          useDM: useDM === 'true',
+          cooldownSeconds: parseInt(cooldownSeconds || '0', 10) || 0,
+          testMessages: testMessages || 'test\nTest message\nping\nPING\nHello world\nTESTING 123',
+        },
+      });
+    } catch (error) {
+      logger.error('[API] Error reading meshcore auto-ack settings:', error);
+      res.status(500).json({ success: false, error: 'Failed to read auto-ack settings' });
+    }
+  },
+);
+
+router.post(
+  '/automation/autoack',
+  requireAuth(),
+  requirePermission('automation', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id?: string }).id!;
+      const settings = databaseService.settings;
+      const {
+        enabled,
+        regex,
+        message,
+        channels,
+        directMessages,
+        useDM,
+        cooldownSeconds,
+        testMessages,
+      } = req.body as {
+        enabled?: boolean;
+        regex?: string;
+        message?: string;
+        channels?: number[];
+        directMessages?: boolean;
+        useDM?: boolean;
+        cooldownSeconds?: number;
+        testMessages?: string;
+      };
+
+      if (enabled !== undefined) {
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAckEnabled', String(enabled));
+      }
+      if (regex !== undefined) {
+        if (regex.length > 100) {
+          return res.status(400).json({ success: false, error: 'Regex pattern too long (max 100 chars)' });
+        }
+        try {
+          new RegExp(regex, 'i');
+        } catch {
+          return res.status(400).json({ success: false, error: 'Invalid regex pattern' });
+        }
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAckRegex', regex);
+      }
+      if (message !== undefined) {
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAckMessage', message);
+      }
+      if (channels !== undefined) {
+        const csv = Array.isArray(channels)
+          ? channels.filter(n => Number.isFinite(n)).join(',')
+          : '';
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAckChannels', csv);
+      }
+      if (directMessages !== undefined) {
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAckDirectMessages', String(directMessages));
+      }
+      if (useDM !== undefined) {
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAckUseDM', String(useDM));
+      }
+      if (cooldownSeconds !== undefined) {
+        const clamped = Math.max(0, Math.min(3600, cooldownSeconds));
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAckCooldownSeconds', String(clamped));
+      }
+      if (testMessages !== undefined) {
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAckTestMessages', testMessages);
+      }
+
+      res.json({ success: true });
+    } catch (error) {
+      logger.error('[API] Error saving meshcore auto-ack settings:', error);
+      res.status(500).json({ success: false, error: 'Failed to save auto-ack settings' });
+    }
+  },
+);
+
 // ---------------------------------------------------------------------------
 // POST /api/sources/:id/meshcore/neighbors/request
 // Request neighbor data from a MeshCore repeater (remote or local).

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -16,6 +16,7 @@ import { MAX_INTERVAL_MINUTES } from '../services/meshcoreRemoteTelemetrySchedul
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
+import { validateAutoAckRegex } from '../utils/autoAckRegex.js';
 import { meshcoreDeviceLimiter, messageLimiter } from '../middleware/rateLimiters.js';
 import { getMeshCoreCredentialStore } from '../services/meshcoreCredentialStore.js';
 
@@ -2397,13 +2398,14 @@ router.post(
         await settings.setSourceSetting(sourceId, 'meshcoreAutoAckEnabled', String(enabled));
       }
       if (regex !== undefined) {
-        if (regex.length > 100) {
-          return res.status(400).json({ success: false, error: 'Regex pattern too long (max 100 chars)' });
-        }
-        try {
-          new RegExp(regex, 'i');
-        } catch {
-          return res.status(400).json({ success: false, error: 'Invalid regex pattern' });
+        // Store-time safety gate. The shared validator rejects unsafe
+        // shapes (catastrophic backtracking, oversized patterns) and
+        // confirms the value is a syntactically valid RegExp. Centralised
+        // with the manager's execution-time check so the two stay in
+        // sync; this also satisfies CodeQL's js/regex-injection check.
+        const validation = validateAutoAckRegex(regex);
+        if (!validation.ok) {
+          return res.status(400).json({ success: false, error: `Invalid regex pattern: ${validation.error}` });
         }
         await settings.setSourceSetting(sourceId, 'meshcoreAutoAckRegex', regex);
       }

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -2345,7 +2345,7 @@ router.get(
         data: {
           enabled: enabled === 'true',
           regex: regex || '^(test|ping)',
-          message: message || '🤖 Copy, {NODE_NAME}! @ {TIME}',
+          message: message || '🤖 Copy, {NODE_NAME}! {HOPS} hops @ {TIME}',
           channels: (channels || '')
             .split(',')
             .map(s => s.trim())

--- a/src/server/utils/autoAckRegex.ts
+++ b/src/server/utils/autoAckRegex.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared regex-safety check for the MeshCore auto-acknowledge feature.
+ *
+ * The auto-ack trigger pattern is user-supplied and stored per-source. It is
+ * later compiled and run against every inbound message in the manager hot
+ * path. We reject patterns that are obvious ReDoS shapes (nested quantifiers,
+ * unbounded repetitions, very large explicit counts) to keep the compile +
+ * execution costs bounded — both in the store-time route handler and at
+ * execution time in the manager.
+ *
+ * This is intentionally a structural pre-check, not a parser. It catches the
+ * common catastrophic-backtracking patterns flagged by `js/regex-injection`
+ * (CodeQL) without trying to fully validate arbitrary regex grammar; the
+ * subsequent `new RegExp(pattern, 'i')` call still throws on syntactically
+ * invalid input.
+ */
+
+const MAX_PATTERN_LENGTH = 100;
+
+// Catastrophic-backtracking shapes:
+//  - `(\.\*){2,}`  — repeated `.*` groups
+//  - `(\+.*\+)`    — text-between-two-pluses (nested unbounded reps)
+//  - `(\*.*\*)`    — same with stars
+//  - `(\{[0-9]{3,}\})` — explicit count ≥ 1000
+//  - `(\{[0-9]+,\})`   — unbounded `{n,}` repetition
+const DANGEROUS_SHAPE_RE = /(\.\*){2,}|(\+.*\+)|(\*.*\*)|(\{[0-9]{3,}\})|(\{[0-9]+,\})/;
+
+export interface AutoAckRegexValidation {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * Validate the pattern and return a compiled RegExp on success, or null
+ * with the reason on failure. Centralised so the route store-time check
+ * and the manager execution-time check stay in sync.
+ */
+export function compileAutoAckRegex(pattern: string): { regex: RegExp | null; error?: string } {
+  if (!pattern) return { regex: null, error: 'empty pattern' };
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    return { regex: null, error: `pattern too long (max ${MAX_PATTERN_LENGTH} chars)` };
+  }
+  if (DANGEROUS_SHAPE_RE.test(pattern)) {
+    return { regex: null, error: 'pattern matches a catastrophic-backtracking shape' };
+  }
+  try {
+    return { regex: new RegExp(pattern, 'i') };
+  } catch (err) {
+    return { regex: null, error: (err as Error).message };
+  }
+}
+
+/**
+ * Boolean form used at the route layer — store-time gate that simply
+ * rejects unsafe patterns before they reach the database.
+ */
+export function validateAutoAckRegex(pattern: string): AutoAckRegexValidation {
+  const result = compileAutoAckRegex(pattern);
+  return result.regex ? { ok: true } : { ok: false, error: result.error };
+}

--- a/src/server/utils/autoAckRegex.ts
+++ b/src/server/utils/autoAckRegex.ts
@@ -17,6 +17,19 @@
 
 const MAX_PATTERN_LENGTH = 100;
 
+/**
+ * Charset allowlist. The pattern may contain only ASCII letters, digits,
+ * whitespace, and the regex meta-characters we actually want to support
+ * (alternation, anchors, character classes, simple quantifiers,
+ * groups, common literal punctuation). Notably excluded:
+ *  - Unicode property escapes (`\p{…}`) — can be slow / DoS-prone
+ *  - Unicode code-point escapes (`\u{…}`) — same
+ *  - Any non-ASCII character — narrows the attack surface to a
+ *    well-understood charset and acts as a CodeQL data-flow barrier
+ *    for the `js/regex-injection` query.
+ */
+const ALLOWED_CHARSET_RE = /^[A-Za-z0-9\s.^$*+?()|[\]{},\\!@#%&'"<>=~`:;/_\-]+$/;
+
 // Catastrophic-backtracking shapes:
 //  - `(\.\*){2,}`  — repeated `.*` groups
 //  - `(\+.*\+)`    — text-between-two-pluses (nested unbounded reps)
@@ -34,11 +47,20 @@ export interface AutoAckRegexValidation {
  * Validate the pattern and return a compiled RegExp on success, or null
  * with the reason on failure. Centralised so the route store-time check
  * and the manager execution-time check stay in sync.
+ *
+ * Validation order matters: we run a charset allowlist first (which
+ * acts as a sanitising barrier — only patterns built from this fixed
+ * set of ASCII characters reach the compiler), then check for known
+ * catastrophic-backtracking shapes, and finally let `RegExp` reject
+ * any remaining syntactic invalidity.
  */
 export function compileAutoAckRegex(pattern: string): { regex: RegExp | null; error?: string } {
   if (!pattern) return { regex: null, error: 'empty pattern' };
   if (pattern.length > MAX_PATTERN_LENGTH) {
     return { regex: null, error: `pattern too long (max ${MAX_PATTERN_LENGTH} chars)` };
+  }
+  if (!ALLOWED_CHARSET_RE.test(pattern)) {
+    return { regex: null, error: 'pattern contains disallowed characters' };
   }
   if (DANGEROUS_SHAPE_RE.test(pattern)) {
     return { regex: null, error: 'pattern matches a catastrophic-backtracking shape' };


### PR DESCRIPTION
## Summary

- Recreates the Meshtastic Auto-Acknowledge feature in the MeshCore Automations tab with an identical UI: per-channel allowlist + separate DM checkbox, **Always respond via DM** override, regex trigger with live test panel, per-sender cooldown, and a templated reply with token macros + sample preview.
- Backend wires a new `checkAutoAcknowledge` handler into `meshcoreManager.handleBridgeEvent` for both `contact_message` (DM) and `channel_message` paths, with regex validation, ReDoS protection, and contact-prefix resolution for DM addressing.
- Per-source settings persist under `meshcoreAutoAck*` keys; CRUD lives at `GET`/`POST /api/sources/:id/meshcore/automation/autoack` (mirrors the auto-pathfinding route shape).

### Supported macros
`{NODE_ID}`, `{NODE_NAME}`, `{LONG_NAME}`, `{SHORT_NAME}`, `{DATE}`, `{TIME}`, `{SNR}`, `{VERSION}`

## Test plan

- [ ] Open the MeshCore source → Automations tab and confirm the new **Auto-Acknowledge** card renders below Auto-Pathfinding.
- [ ] Toggle the master switch, set regex to `^ping`, enable a single channel, save — confirm the SaveBar fires and the values reload on refresh.
- [ ] Send `ping` on the enabled channel from another node → reply is published on the same channel.
- [ ] Enable **Always respond via DM** → confirm the reply switches to a DM to the sender.
- [ ] Send `ping` on a non-allowlisted channel → confirm no reply.
- [ ] Disable the **Direct Messages** checkbox → confirm DM triggers are ignored.
- [ ] Set cooldown to 30s and send two pings within the window → second is suppressed.
- [ ] Test all tokens render correctly in the live preview and in the actual reply.
- [ ] Invalid regex (e.g. `(`) blocks save with an error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)