### PR TITLE
feat(meshcore): auto-announce, auto-responder, and timer triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- **MeshCore automation suite** — three new per-source automations in the MeshCore Automation view:
+  - **Auto-Announce** — periodically broadcast a templated status message to selected channels on an interval or cron schedule, with an optional advert burst, live preview, and Send Now.
+  - **Auto-Responder** — reply to incoming messages matching an operator-defined regex with a text response or a script, with per-channel/DM filtering and per-sender cooldown.
+  - **Timer Triggers** — schedule recurring text/advert/script actions, each on its own cron or interval.
+  - Shared token expansion (`{VERSION}`, `{DURATION}`, `{CONTACTCOUNT}`, `{COMPANIONCOUNT}`, `{REPEATERCOUNT}`, `{ROOMCOUNT}`, `{NODE_NAME}`, `{NODE_ID}`) across all three, surfaced in the UI via an inline token legend.
+
 ## [4.8.0] - 2026-05-27
 
 # MeshMonitor v4.8.0

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -285,6 +285,31 @@ The **Automation** view (accessible from the MeshCore page sub-toolbar) provides
 
 Retrieved neighbor data is automatically resolved (pubkey prefixes mapped to full contact records) and persisted to `meshcore_neighbor_info` for map rendering and the Map Analysis inspector panel.
 
+## Auto-Announce
+
+The **Automation** view also hosts a per-source Auto-Announce that periodically broadcasts a status message to one or more MeshCore channels:
+
+- **Scheduling** — choose either a simple interval (every N hours, 1–168) or a standard 5-field cron expression. An optional *announce on connection* fires a single message whenever the source reconnects.
+- **Message template** — the message body supports token expansion. Available tokens: `{VERSION}`, `{DURATION}`, `{CONTACTCOUNT}`, `{COMPANIONCOUNT}`, `{REPEATERCOUNT}`, `{ROOMCOUNT}`, `{NODE_NAME}`, `{NODE_ID}`. A live preview shows the rendered text, and clickable token buttons insert at the cursor.
+- **Target channels** — the announcement is broadcast to every selected channel each run.
+- **Optional advert burst** — fire a MeshCore advert N seconds (0–600) after each announcement so neighbours rediscover the node.
+- **Send Now** — manually fire the configured announcement for testing without waiting for the schedule.
+
+## Auto-Responder
+
+Auto-Responder matches incoming messages against operator-defined patterns and replies automatically:
+
+- **Per-trigger pattern** — match incoming text via a regular expression, with per-channel filtering, DM listening, and a per-sender cooldown to avoid loops.
+- **Two actions** — reply with a **text response** (same token expansion as Auto-Announce) or **run a script** (with token-expanded script args). Script execution reuses the shared script runner, with `MESHCORE_*` environment variables injected so a script can branch on which stack invoked it.
+
+## Timer Triggers
+
+Timer Triggers schedule recurring actions independent of incoming traffic:
+
+- **Per-trigger schedule** — each trigger runs on its own cron or interval.
+- **Three actions** — send a **text** message (token expansion supported) to a channel or contact, fire a MeshCore **advert**, or **run a script** (token-expanded args).
+- **Last-run telemetry** — the UI surfaces the last fire time and outcome per trigger.
+
 ## Room Servers
 
 Room servers (advType=3) are BBS-style MeshCore nodes that store posts and push-sync them to connected clients. The **Rooms** view in the MeshCore page lists discovered room servers and provides:

--- a/src/components/MeshCore/MeshCoreAutoAnnounceSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAnnounceSection.tsx
@@ -1,0 +1,563 @@
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { isValidCron } from 'cron-validator';
+import { useCsrfFetch } from '../../hooks/useCsrfFetch';
+import { useToast } from '../ToastContainer';
+import { useAuth } from '../../contexts/AuthContext';
+import { useSaveBar } from '../../hooks/useSaveBar';
+import { MESHCORE_AUTOMATION_TOKENS } from './meshcoreAutomationTokens';
+
+interface MeshCoreAutoAnnounceSectionProps {
+  baseUrl: string;
+  sourceId: string;
+}
+
+interface AutoAnnounceSettings {
+  enabled: boolean;
+  intervalHours: number;
+  message: string;
+  channelIndexes: number[];
+  announceOnStart: boolean;
+  useSchedule: boolean;
+  schedule: string;
+  advertEnabled: boolean;
+  advertDelaySeconds: number;
+}
+
+interface MeshCoreChannelRow {
+  id: number;
+  name: string;
+}
+
+const DEFAULT_MESSAGE = 'MeshMonitor {VERSION} online for {DURATION} — {CONTACTCOUNT} contacts';
+const DEFAULT_SCHEDULE = '0 */6 * * *';
+
+const DEFAULTS: AutoAnnounceSettings = {
+  enabled: false,
+  intervalHours: 6,
+  message: DEFAULT_MESSAGE,
+  channelIndexes: [0],
+  announceOnStart: false,
+  useSchedule: false,
+  schedule: DEFAULT_SCHEDULE,
+  advertEnabled: false,
+  advertDelaySeconds: 30,
+};
+
+const TOKENS = MESHCORE_AUTOMATION_TOKENS;
+
+const arraysEqual = (a: number[], b: number[]): boolean => {
+  if (a.length !== b.length) return false;
+  const aSorted = [...a].sort((x, y) => x - y);
+  const bSorted = [...b].sort((x, y) => x - y);
+  return aSorted.every((v, i) => v === bSorted[i]);
+};
+
+export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionProps> = ({ baseUrl, sourceId }) => {
+  const { t } = useTranslation();
+  const csrfFetch = useCsrfFetch();
+  const { showToast } = useToast();
+  const { hasPermission } = useAuth();
+  const canWrite = hasPermission('automation', 'write');
+
+  const [settings, setSettings] = useState<AutoAnnounceSettings>(DEFAULTS);
+  const [initial, setInitial] = useState<AutoAnnounceSettings>(DEFAULTS);
+  const [channels, setChannels] = useState<MeshCoreChannelRow[]>([]);
+  const [hasChanges, setHasChanges] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [scheduleError, setScheduleError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<string>('');
+  const [isSendingNow, setIsSendingNow] = useState(false);
+  const [lastRunAt, setLastRunAt] = useState<number | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Load settings
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await csrfFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/automation/announce`);
+        if (!res.ok) return;
+        const json = await res.json();
+        if (cancelled || !json.success || !json.data) return;
+        const s: AutoAnnounceSettings = {
+          enabled: !!json.data.enabled,
+          intervalHours: typeof json.data.intervalHours === 'number' ? json.data.intervalHours : 6,
+          message: json.data.message || DEFAULT_MESSAGE,
+          channelIndexes: Array.isArray(json.data.channelIndexes) ? json.data.channelIndexes : [0],
+          announceOnStart: !!json.data.announceOnStart,
+          useSchedule: !!json.data.useSchedule,
+          schedule: json.data.schedule || DEFAULT_SCHEDULE,
+          advertEnabled: !!json.data.advertEnabled,
+          advertDelaySeconds: typeof json.data.advertDelaySeconds === 'number' ? json.data.advertDelaySeconds : 30,
+        };
+        setSettings(s);
+        setInitial(s);
+        setLastRunAt(typeof json.data.lastRunAt === 'number' ? json.data.lastRunAt : null);
+        setLoaded(true);
+      } catch {
+        // keep defaults
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [baseUrl, sourceId, csrfFetch]);
+
+  // Load channels
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await csrfFetch(
+          `${baseUrl}/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`,
+        );
+        if (!res.ok) return;
+        const raw = await res.json();
+        if (cancelled) return;
+        const rows: MeshCoreChannelRow[] = Array.isArray(raw)
+          ? raw
+              .filter((c: any) => typeof c?.id === 'number')
+              .map((c: any) => ({ id: c.id as number, name: String(c.name ?? '') }))
+              .sort((a, b) => a.id - b.id)
+          : [];
+        setChannels(rows);
+      } catch {
+        // ignore
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [baseUrl, sourceId, csrfFetch]);
+
+  // Live preview (debounced)
+  useEffect(() => {
+    let cancelled = false;
+    const handle = setTimeout(async () => {
+      try {
+        const url = `${baseUrl}/api/sources/${sourceId}/meshcore/automation/announce/preview?message=${encodeURIComponent(settings.message)}`;
+        const res = await csrfFetch(url);
+        if (!res.ok || cancelled) return;
+        const json = await res.json();
+        if (!cancelled && json.success) setPreview(json.preview || '');
+      } catch {
+        // leave previous preview
+      }
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [settings.message, baseUrl, sourceId, csrfFetch]);
+
+  // Detect changes
+  useEffect(() => {
+    if (!loaded) return;
+    setHasChanges(
+      settings.enabled !== initial.enabled ||
+      settings.intervalHours !== initial.intervalHours ||
+      settings.message !== initial.message ||
+      !arraysEqual(settings.channelIndexes, initial.channelIndexes) ||
+      settings.announceOnStart !== initial.announceOnStart ||
+      settings.useSchedule !== initial.useSchedule ||
+      settings.schedule !== initial.schedule ||
+      settings.advertEnabled !== initial.advertEnabled ||
+      settings.advertDelaySeconds !== initial.advertDelaySeconds,
+    );
+  }, [settings, initial, loaded]);
+
+  // Validate cron when in schedule mode
+  useEffect(() => {
+    if (!settings.useSchedule) {
+      setScheduleError(null);
+      return;
+    }
+    const valid = isValidCron(settings.schedule, { seconds: false, alias: true, allowBlankDay: true });
+    setScheduleError(valid ? null : t('meshcore.automation.announce.invalid_cron', 'Invalid cron expression'));
+  }, [settings.useSchedule, settings.schedule, t]);
+
+  const handleSave = useCallback(async () => {
+    if (settings.useSchedule && !isValidCron(settings.schedule, { seconds: false, alias: true, allowBlankDay: true })) {
+      showToast(t('meshcore.automation.announce.invalid_cron', 'Invalid cron expression'), 'error');
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const res = await csrfFetch(
+        `${baseUrl}/api/sources/${sourceId}/meshcore/automation/announce`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            enabled: settings.enabled,
+            intervalHours: settings.intervalHours,
+            message: settings.message,
+            channelIndexes: settings.channelIndexes,
+            announceOnStart: settings.announceOnStart,
+            useSchedule: settings.useSchedule,
+            schedule: settings.schedule,
+            advertEnabled: settings.advertEnabled,
+            advertDelaySeconds: settings.advertDelaySeconds,
+          }),
+        },
+      );
+      if (!res.ok) {
+        if (res.status === 403) {
+          showToast(t('automation.insufficient_permissions', 'Insufficient permissions'), 'error');
+          return;
+        }
+        throw new Error(`Server returned ${res.status}`);
+      }
+      const json = await res.json();
+      setInitial(settings);
+      setHasChanges(false);
+      if (typeof json?.data?.lastRunAt === 'number') setLastRunAt(json.data.lastRunAt);
+      showToast(t('automation.settings_saved', 'Settings saved'), 'success');
+    } catch (err) {
+      console.error('Failed to save MeshCore auto-announce settings:', err);
+      showToast(t('automation.settings_save_failed', 'Failed to save settings'), 'error');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [settings, baseUrl, sourceId, csrfFetch, showToast, t]);
+
+  const handleDismiss = useCallback(() => {
+    setSettings(initial);
+    setHasChanges(false);
+  }, [initial]);
+
+  useSaveBar({
+    id: 'meshcore-auto-announce',
+    sectionName: t('meshcore.automation.announce.title', 'Auto-Announce'),
+    hasChanges,
+    isSaving,
+    onSave: handleSave,
+    onDismiss: handleDismiss,
+  });
+
+  const update = <K extends keyof AutoAnnounceSettings>(key: K, value: AutoAnnounceSettings[K]) => {
+    setSettings(prev => ({ ...prev, [key]: value }));
+  };
+
+  const insertToken = (token: string) => {
+    const ta = textareaRef.current;
+    if (!ta) {
+      update('message', settings.message + token);
+      return;
+    }
+    const start = ta.selectionStart;
+    const end = ta.selectionEnd;
+    const next = settings.message.substring(0, start) + token + settings.message.substring(end);
+    update('message', next);
+    // Restore caret after the inserted token on next paint
+    requestAnimationFrame(() => {
+      ta.focus();
+      const pos = start + token.length;
+      ta.setSelectionRange(pos, pos);
+    });
+  };
+
+  const sendNow = useCallback(async () => {
+    setIsSendingNow(true);
+    try {
+      const res = await csrfFetch(
+        `${baseUrl}/api/sources/${sourceId}/meshcore/automation/announce/send`,
+        { method: 'POST' },
+      );
+      if (!res.ok) {
+        if (res.status === 403) {
+          showToast(t('automation.insufficient_permissions', 'Insufficient permissions'), 'error');
+          return;
+        }
+        throw new Error(`Server returned ${res.status}`);
+      }
+      const json = await res.json();
+      if (typeof json?.data?.lastRunAt === 'number') setLastRunAt(json.data.lastRunAt);
+      showToast(t('meshcore.automation.announce.sent', 'Announcement sent'), 'success');
+    } catch (err) {
+      console.error('Failed to send MeshCore announcement:', err);
+      showToast(t('meshcore.automation.announce.send_failed', 'Failed to send announcement'), 'error');
+    } finally {
+      setIsSendingNow(false);
+    }
+  }, [baseUrl, sourceId, csrfFetch, showToast, t]);
+
+  const disabled = !settings.enabled;
+  const sendNowDisabled = !canWrite || isSendingNow || channels.length === 0 || settings.channelIndexes.length === 0;
+
+  const channelLabel = useMemo(() => {
+    const sel = settings.channelIndexes
+      .map(idx => channels.find(c => c.id === idx)?.name || `#${idx}`)
+      .join(', ');
+    return sel || t('meshcore.automation.announce.no_channels_selected', '(no channels selected)');
+  }, [channels, settings.channelIndexes, t]);
+
+  return (
+    <>
+      <div className="automation-section-header" style={{
+        display: 'flex',
+        alignItems: 'center',
+        marginBottom: '1.5rem',
+        marginTop: '2rem',
+        padding: '1rem 1.25rem',
+        background: 'var(--ctp-surface1)',
+        border: '1px solid var(--ctp-surface2)',
+        borderRadius: '8px',
+      }}>
+        <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <input
+            type="checkbox"
+            checked={settings.enabled}
+            onChange={(e) => update('enabled', e.target.checked)}
+            disabled={!canWrite}
+            style={{ width: 'auto', margin: 0, cursor: canWrite ? 'pointer' : 'not-allowed' }}
+          />
+          {t('meshcore.automation.announce.title', 'Auto-Announce')}
+        </h2>
+        <button
+          onClick={sendNow}
+          disabled={sendNowDisabled}
+          className="meshcore-btn meshcore-btn-primary meshcore-send-now"
+        >
+          {isSendingNow
+            ? t('meshcore.automation.announce.sending', 'Sending…')
+            : t('meshcore.automation.announce.send_now', 'Send Now')}
+        </button>
+      </div>
+
+      <div className="settings-section" style={{ opacity: settings.enabled ? 1 : 0.5, transition: 'opacity 0.2s' }}>
+        <p style={{ marginBottom: '1rem', color: '#666', lineHeight: 1.5, marginLeft: '1.75rem' }}>
+          {t(
+            'meshcore.automation.announce.description',
+            'Periodically send a status message to one or more MeshCore channels. Supports interval-based or cron scheduling and an optional advert burst.',
+          )}
+        </p>
+
+        {/* On-start announcement */}
+        <div className="setting-item" style={{ marginTop: '1rem' }}>
+          <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem' }}>
+            <input
+              type="checkbox"
+              checked={settings.announceOnStart}
+              onChange={(e) => update('announceOnStart', e.target.checked)}
+              disabled={disabled || !canWrite}
+              style={{ width: 'auto', margin: 0 }}
+            />
+            <span style={{ fontWeight: 'bold' }}>
+              {t('meshcore.automation.announce.on_start', 'Announce on connection')}
+            </span>
+          </label>
+          <div style={{ marginTop: '0.25rem', marginLeft: '1.75rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+            {t(
+              'meshcore.automation.announce.on_start_description',
+              'Fire a single announcement immediately whenever this source reconnects.',
+            )}
+          </div>
+        </div>
+
+        {/* Schedule type toggle */}
+        <div className="setting-item" style={{ marginTop: '1.5rem' }}>
+          <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem' }}>
+            <input
+              type="checkbox"
+              checked={settings.useSchedule}
+              onChange={(e) => update('useSchedule', e.target.checked)}
+              disabled={disabled || !canWrite}
+              style={{ width: 'auto', margin: 0 }}
+            />
+            <span style={{ fontWeight: 'bold' }}>
+              {t('meshcore.automation.announce.use_schedule', 'Use cron schedule')}
+            </span>
+          </label>
+          <div style={{ marginTop: '0.25rem', marginLeft: '1.75rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+            {t(
+              'meshcore.automation.announce.use_schedule_description',
+              'When unchecked, the announcement runs every N hours. When checked, it follows a standard 5-field cron expression.',
+            )}
+          </div>
+        </div>
+
+        {/* Interval vs schedule */}
+        {!settings.useSchedule ? (
+          <div className="setting-item" style={{ marginTop: '1rem' }}>
+            <label htmlFor="meshcoreAnnounceInterval">
+              {t('meshcore.automation.announce.interval_label', 'Interval (hours)')}
+            </label>
+            <input
+              id="meshcoreAnnounceInterval"
+              type="number"
+              value={settings.intervalHours}
+              onChange={(e) => update('intervalHours', Math.max(1, parseInt(e.target.value, 10) || 1))}
+              min={1}
+              max={168}
+              disabled={disabled || !canWrite}
+              className="setting-input"
+              style={{ width: '120px' }}
+            />
+          </div>
+        ) : (
+          <div className="setting-item" style={{ marginTop: '1rem' }}>
+            <label htmlFor="meshcoreAnnounceSchedule">
+              {t('meshcore.automation.announce.schedule_label', 'Cron schedule (min hour dom mon dow)')}
+            </label>
+            <input
+              id="meshcoreAnnounceSchedule"
+              type="text"
+              value={settings.schedule}
+              onChange={(e) => update('schedule', e.target.value)}
+              placeholder={DEFAULT_SCHEDULE}
+              disabled={disabled || !canWrite}
+              className="setting-input"
+              style={{ fontFamily: 'monospace', width: '260px' }}
+            />
+            {scheduleError && (
+              <div style={{ marginTop: '0.25rem', fontSize: '0.85rem', color: 'var(--ctp-red)' }}>
+                {scheduleError}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Channel selection */}
+        <div className="setting-item" style={{ marginTop: '1.5rem' }}>
+          <label>
+            {t('meshcore.automation.announce.channels', 'Target channels')}
+            <span className="setting-description">
+              {t(
+                'meshcore.automation.announce.channels_description',
+                'The announcement is broadcast to every selected channel each run.',
+              )}{' '}
+              <em>{channelLabel}</em>
+            </span>
+          </label>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginTop: '0.5rem' }}>
+            {channels.length === 0 && (
+              <div style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+                {t('meshcore.automation.announce.no_channels', 'No channels loaded yet.')}
+              </div>
+            )}
+            {channels.map((channel) => (
+              <div key={channel.id} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <input
+                  type="checkbox"
+                  id={`meshcoreAnnounceChannel${channel.id}`}
+                  checked={settings.channelIndexes.includes(channel.id)}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      update('channelIndexes', [...settings.channelIndexes, channel.id]);
+                    } else {
+                      update('channelIndexes', settings.channelIndexes.filter((c) => c !== channel.id));
+                    }
+                  }}
+                  disabled={disabled || !canWrite}
+                  style={{ width: 'auto', margin: 0 }}
+                />
+                <label htmlFor={`meshcoreAnnounceChannel${channel.id}`} style={{ margin: 0 }}>
+                  {channel.name || `Channel ${channel.id}`}
+                </label>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Message template */}
+        <div className="setting-item" style={{ marginTop: '1.5rem' }}>
+          <label htmlFor="meshcoreAnnounceMessage">
+            {t('meshcore.automation.announce.message_label', 'Message template')}
+            <span className="setting-description" style={{ display: 'block', marginTop: '0.25rem' }}>
+              {t('meshcore.automation.announce.available_tokens', 'Available tokens:')}{' '}
+              {TOKENS.join(', ')}
+            </span>
+          </label>
+          <textarea
+            id="meshcoreAnnounceMessage"
+            ref={textareaRef}
+            value={settings.message}
+            onChange={(e) => update('message', e.target.value)}
+            disabled={disabled || !canWrite}
+            className="setting-input"
+            rows={3}
+            style={{ fontFamily: 'monospace', resize: 'vertical', minHeight: '60px' }}
+          />
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem', marginTop: '0.5rem' }}>
+            {TOKENS.map((tok) => (
+              <button
+                key={tok}
+                type="button"
+                onClick={() => insertToken(tok)}
+                disabled={disabled || !canWrite}
+                className="meshcore-btn meshcore-btn-secondary"
+                style={{ padding: '0.2rem 0.5rem', fontSize: '0.8rem', fontFamily: 'monospace' }}
+              >
+                {tok}
+              </button>
+            ))}
+          </div>
+          <div style={{ marginTop: '0.5rem' }}>
+            <label style={{ fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+              {t('meshcore.automation.announce.preview', 'Live preview')}:
+            </label>
+            <div style={{
+              marginTop: '0.25rem',
+              padding: '0.5rem',
+              background: 'var(--ctp-base)',
+              border: '1px solid var(--ctp-blue)',
+              borderRadius: '4px',
+              fontFamily: 'monospace',
+              fontSize: '0.9rem',
+              color: 'var(--ctp-text)',
+              minHeight: '1.5rem',
+            }}>
+              {preview || settings.message}
+            </div>
+          </div>
+        </div>
+
+        {/* Advert burst */}
+        <div className="setting-item" style={{ marginTop: '1.5rem' }}>
+          <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem' }}>
+            <input
+              type="checkbox"
+              checked={settings.advertEnabled}
+              onChange={(e) => update('advertEnabled', e.target.checked)}
+              disabled={disabled || !canWrite}
+              style={{ width: 'auto', margin: 0 }}
+            />
+            <span style={{ fontWeight: 'bold' }}>
+              {t('meshcore.automation.announce.advert_enabled', 'Send advert after each announcement')}
+            </span>
+          </label>
+          <div style={{ marginTop: '0.25rem', marginLeft: '1.75rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+            {t(
+              'meshcore.automation.announce.advert_description',
+              'Fire a MeshCore advert N seconds after each announcement so neighbours rediscover this node.',
+            )}
+          </div>
+          {settings.advertEnabled && (
+            <div style={{ marginTop: '0.5rem', marginLeft: '1.75rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              <input
+                type="number"
+                value={settings.advertDelaySeconds}
+                onChange={(e) => update('advertDelaySeconds', Math.max(0, Math.min(600, parseInt(e.target.value, 10) || 0)))}
+                min={0}
+                max={600}
+                disabled={disabled || !canWrite}
+                style={{ width: '100px', padding: '2px 4px' }}
+              />
+              <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+                {t('meshcore.automation.announce.advert_delay', 'seconds delay (0–600)')}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {lastRunAt && (
+          <p style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)', marginTop: '1rem' }}>
+            {t('meshcore.automation.announce.last_run', 'Last run')}:{' '}
+            {new Date(lastRunAt).toLocaleString()}
+          </p>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default MeshCoreAutoAnnounceSection;

--- a/src/components/MeshCore/MeshCoreAutoResponderSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoResponderSection.tsx
@@ -1,0 +1,516 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useCsrfFetch } from '../../hooks/useCsrfFetch';
+import { useToast } from '../ToastContainer';
+import { useAuth } from '../../contexts/AuthContext';
+import { useSaveBar } from '../../hooks/useSaveBar';
+import { MeshCoreTokenLegend } from './MeshCoreTokenLegend';
+
+interface MeshCoreAutoResponderSectionProps {
+  baseUrl: string;
+  sourceId: string;
+}
+
+/**
+ * Mirrors the backend `MeshCoreAutoResponderTrigger` shape. Kept inline
+ * for the same reason as the timer trigger: it's a server-only type
+ * that crosses the wire as JSON.
+ */
+interface MeshCoreAutoResponderTrigger {
+  id: string;
+  name: string;
+  enabled: boolean;
+  pattern: string;
+  /**
+   * `text` (default) sends `response`; `script` runs `scriptPath` and
+   * sends each entry of the script's wouldSendMessages output.
+   */
+  responseType?: 'text' | 'script';
+  response: string;
+  scriptPath?: string;
+  scriptArgs?: string;
+  channels: number[];
+  listenDMs: boolean;
+  replyAsDM: boolean;
+  cooldownSeconds: number;
+}
+
+interface ScriptMetadata {
+  path: string;
+  filename: string;
+  name?: string;
+  emoji?: string;
+  language?: string;
+}
+
+interface MeshCoreChannelRow {
+  id: number;
+  name: string;
+}
+
+const validateRegex = (pattern: string): { valid: boolean; error?: string } => {
+  if (!pattern) return { valid: false, error: 'Pattern is required' };
+  if (pattern.length > 100) return { valid: false, error: 'Pattern too long (max 100 chars)' };
+  if (/(\.\*){2,}|(\+.*\+)|(\*.*\*)|(\{[0-9]{3,}\})|(\{[0-9]+,\})/.test(pattern)) {
+    return { valid: false, error: 'Pattern too complex (possible ReDoS)' };
+  }
+  try {
+    new RegExp(pattern, 'i');
+    return { valid: true };
+  } catch {
+    return { valid: false, error: 'Invalid regex syntax' };
+  }
+};
+
+const newTrigger = (): MeshCoreAutoResponderTrigger => ({
+  id: typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `r-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  name: '',
+  enabled: true,
+  pattern: '',
+  responseType: 'text',
+  response: '',
+  channels: [],
+  listenDMs: true,
+  replyAsDM: false,
+  cooldownSeconds: 60,
+});
+
+export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSectionProps> = ({ baseUrl, sourceId }) => {
+  const { t } = useTranslation();
+  const csrfFetch = useCsrfFetch();
+  const { showToast } = useToast();
+  const { hasPermission } = useAuth();
+  const canWrite = hasPermission('automation', 'write');
+
+  const [enabled, setEnabled] = useState(false);
+  const [initialEnabled, setInitialEnabled] = useState(false);
+  const [triggers, setTriggers] = useState<MeshCoreAutoResponderTrigger[]>([]);
+  const [initialTriggers, setInitialTriggers] = useState<MeshCoreAutoResponderTrigger[]>([]);
+  const [channels, setChannels] = useState<MeshCoreChannelRow[]>([]);
+  const [scripts, setScripts] = useState<ScriptMetadata[]>([]);
+  const [hasChanges, setHasChanges] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [draft, setDraft] = useState<MeshCoreAutoResponderTrigger>(newTrigger());
+
+  // Load triggers
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await csrfFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/automation/responder`);
+        if (!res.ok) return;
+        const json = await res.json();
+        if (cancelled || !json.success || !json.data) return;
+        const list: MeshCoreAutoResponderTrigger[] = Array.isArray(json.data.triggers) ? json.data.triggers : [];
+        setEnabled(!!json.data.enabled);
+        setInitialEnabled(!!json.data.enabled);
+        setTriggers(list);
+        setInitialTriggers(list);
+        setLoaded(true);
+      } catch { /* keep defaults */ }
+    })();
+    return () => { cancelled = true; };
+  }, [baseUrl, sourceId, csrfFetch]);
+
+  // Load channels
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await csrfFetch(`${baseUrl}/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`);
+        if (!res.ok) return;
+        const raw = await res.json();
+        if (cancelled) return;
+        const rows: MeshCoreChannelRow[] = Array.isArray(raw)
+          ? raw
+              .filter((c: any) => typeof c?.id === 'number')
+              .map((c: any) => ({ id: c.id as number, name: String(c.name ?? '') }))
+              .sort((a, b) => a.id - b.id)
+          : [];
+        setChannels(rows);
+      } catch { /* ignore */ }
+    })();
+    return () => { cancelled = true; };
+  }, [baseUrl, sourceId, csrfFetch]);
+
+  // Load available scripts (responseType='script' picker).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await csrfFetch(`${baseUrl}/api/scripts`);
+        if (!res.ok) return;
+        const raw = await res.json();
+        if (cancelled) return;
+        const list: ScriptMetadata[] = Array.isArray(raw?.scripts)
+          ? raw.scripts.filter((s: any) => typeof s?.path === 'string')
+          : [];
+        setScripts(list);
+      } catch { /* ignore */ }
+    })();
+    return () => { cancelled = true; };
+  }, [baseUrl, csrfFetch]);
+
+  // Detect changes
+  useEffect(() => {
+    if (!loaded) return;
+    const triggersChanged = JSON.stringify(triggers) !== JSON.stringify(initialTriggers);
+    setHasChanges(enabled !== initialEnabled || triggersChanged);
+  }, [enabled, initialEnabled, triggers, initialTriggers, loaded]);
+
+  const handleSave = useCallback(async () => {
+    // Validate every trigger's regex up front so the operator sees the
+    // bad one before a round-trip.
+    for (const tr of triggers) {
+      const v = validateRegex(tr.pattern);
+      if (!v.valid) {
+        showToast(`Trigger "${tr.name || tr.id}": ${v.error}`, 'error');
+        return;
+      }
+    }
+    setIsSaving(true);
+    try {
+      const res = await csrfFetch(
+        `${baseUrl}/api/sources/${sourceId}/meshcore/automation/responder`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ enabled, triggers }),
+        },
+      );
+      if (!res.ok) {
+        if (res.status === 403) {
+          showToast(t('automation.insufficient_permissions', 'Insufficient permissions'), 'error');
+          return;
+        }
+        const errText = await res.text().catch(() => '');
+        throw new Error(`Server returned ${res.status}: ${errText}`);
+      }
+      setInitialEnabled(enabled);
+      setInitialTriggers(triggers);
+      setHasChanges(false);
+      showToast(t('automation.settings_saved', 'Settings saved'), 'success');
+    } catch (err) {
+      console.error('Failed to save MeshCore auto-responder settings:', err);
+      showToast(t('automation.settings_save_failed', 'Failed to save settings'), 'error');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [enabled, triggers, baseUrl, sourceId, csrfFetch, showToast, t]);
+
+  const handleDismiss = useCallback(() => {
+    setEnabled(initialEnabled);
+    setTriggers(initialTriggers);
+    setHasChanges(false);
+  }, [initialEnabled, initialTriggers]);
+
+  useSaveBar({
+    id: 'meshcore-auto-responder',
+    sectionName: t('meshcore.automation.responder.title', 'Auto-Responder'),
+    hasChanges,
+    isSaving,
+    onSave: handleSave,
+    onDismiss: handleDismiss,
+  });
+
+  const updateTrigger = (id: string, patch: Partial<MeshCoreAutoResponderTrigger>) => {
+    setTriggers(prev => prev.map(t => t.id === id ? { ...t, ...patch } : t));
+  };
+  const removeTrigger = (id: string) => {
+    setTriggers(prev => prev.filter(t => t.id !== id));
+  };
+
+  const addTrigger = () => {
+    const v = validateRegex(draft.pattern);
+    if (!v.valid) {
+      showToast(v.error || 'Invalid pattern', 'error');
+      return;
+    }
+    if (!draft.name.trim()) {
+      showToast(t('meshcore.automation.responder.name_required', 'Name is required'), 'error');
+      return;
+    }
+    setTriggers(prev => [...prev, draft]);
+    setDraft(newTrigger());
+  };
+
+  const channelMap = useMemo(() => {
+    const m = new Map<number, string>();
+    channels.forEach(c => m.set(c.id, c.name || `Channel ${c.id}`));
+    return m;
+  }, [channels]);
+
+  const disabled = !enabled;
+
+  return (
+    <>
+      <div className="automation-section-header" style={{
+        display: 'flex',
+        alignItems: 'center',
+        marginBottom: '1.5rem',
+        marginTop: '2rem',
+        padding: '1rem 1.25rem',
+        background: 'var(--ctp-surface1)',
+        border: '1px solid var(--ctp-surface2)',
+        borderRadius: '8px',
+      }}>
+        <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            disabled={!canWrite}
+            style={{ width: 'auto', margin: 0, cursor: canWrite ? 'pointer' : 'not-allowed' }}
+          />
+          {t('meshcore.automation.responder.title', 'Auto-Responder')}
+        </h2>
+        <span style={{ marginLeft: 'auto', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+          {t('meshcore.automation.responder.count', '{{count}} triggers', { count: triggers.length })}
+        </span>
+      </div>
+
+      <div className="settings-section" style={{ opacity: enabled ? 1 : 0.5, transition: 'opacity 0.2s' }}>
+        <p style={{ marginBottom: '1rem', color: '#666', lineHeight: 1.5, marginLeft: '1.75rem' }}>
+          {t(
+            'meshcore.automation.responder.description',
+            'Match incoming messages against operator-defined patterns and reply with a text response. Each trigger supports per-channel filtering, DM listening, and a per-sender cooldown.',
+          )}
+        </p>
+
+        {triggers.length === 0 && (
+          <p style={{ marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+            {t('meshcore.automation.responder.empty', 'No triggers configured yet.')}
+          </p>
+        )}
+
+        {triggers.map(tr => {
+          const v = validateRegex(tr.pattern);
+          return (
+            <div key={tr.id} className="meshcore-trigger-card">
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
+                <input
+                  type="checkbox"
+                  checked={tr.enabled}
+                  onChange={(e) => updateTrigger(tr.id, { enabled: e.target.checked })}
+                  disabled={disabled || !canWrite}
+                  style={{ width: 'auto', margin: 0 }}
+                  aria-label={`Enable ${tr.name}`}
+                />
+                <input
+                  type="text"
+                  value={tr.name}
+                  onChange={(e) => updateTrigger(tr.id, { name: e.target.value })}
+                  disabled={disabled || !canWrite}
+                  placeholder={t('meshcore.automation.responder.name_placeholder', 'Trigger name')}
+                  className="meshcore-input"
+                  style={{ flex: 1 }}
+                />
+                <button
+                  type="button"
+                  onClick={() => removeTrigger(tr.id)}
+                  disabled={!canWrite}
+                  className="meshcore-btn meshcore-btn-danger"
+                >
+                  {t('meshcore.automation.responder.remove', 'Remove')}
+                </button>
+              </div>
+
+              <label style={{ fontSize: '0.85rem', display: 'block', marginBottom: '0.5rem' }}>
+                {t('meshcore.automation.responder.pattern', 'Pattern (regex, case-insensitive)')}
+                <input
+                  type="text"
+                  value={tr.pattern}
+                  onChange={(e) => updateTrigger(tr.id, { pattern: e.target.value })}
+                  disabled={disabled || !canWrite}
+                  placeholder="^(test|ping)"
+                  className="meshcore-input"
+                  style={{ width: '100%', marginTop: '0.25rem', fontFamily: 'monospace' }}
+                />
+                {!v.valid && tr.pattern && (
+                  <div style={{ fontSize: '0.8rem', color: 'var(--ctp-red)', marginTop: '0.25rem' }}>
+                    {v.error}
+                  </div>
+                )}
+              </label>
+
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 2fr', gap: '0.75rem', marginBottom: '0.5rem' }}>
+                <label style={{ fontSize: '0.85rem' }}>
+                  {t('meshcore.automation.responder.response_type', 'Action')}
+                  <select
+                    value={tr.responseType || 'text'}
+                    onChange={(e) => updateTrigger(tr.id, { responseType: e.target.value as 'text' | 'script' })}
+                    disabled={disabled || !canWrite}
+                    className="meshcore-select"
+                    style={{ width: '100%', marginTop: '0.25rem' }}
+                  >
+                    <option value="text">{t('meshcore.automation.responder.response_text', 'Send text')}</option>
+                    <option value="script">{t('meshcore.automation.responder.response_script', 'Run script')}</option>
+                  </select>
+                </label>
+                {(tr.responseType || 'text') === 'text' ? (
+                  <label style={{ fontSize: '0.85rem' }}>
+                    {t('meshcore.automation.responder.response', 'Response (token expansion supported)')}
+                    <MeshCoreTokenLegend />
+                    <textarea
+                      value={tr.response}
+                      onChange={(e) => updateTrigger(tr.id, { response: e.target.value })}
+                      disabled={disabled || !canWrite}
+                      rows={2}
+                      className="meshcore-input"
+                      style={{ width: '100%', marginTop: '0.25rem', fontFamily: 'monospace' }}
+                    />
+                  </label>
+                ) : (
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.5rem' }}>
+                    <label style={{ fontSize: '0.85rem' }}>
+                      {t('meshcore.automation.responder.script', 'Script')}
+                      <select
+                        value={tr.scriptPath || ''}
+                        onChange={(e) => updateTrigger(tr.id, { scriptPath: e.target.value })}
+                        disabled={disabled || !canWrite}
+                        className="meshcore-select"
+                        style={{ width: '100%', marginTop: '0.25rem' }}
+                      >
+                        <option value="">{scripts.length === 0 ? t('meshcore.automation.responder.no_scripts', '(no scripts available)') : t('meshcore.automation.responder.select_script', '(select script)')}</option>
+                        {scripts.map(s => (
+                          <option key={s.path} value={s.path}>
+                            {s.emoji ? `${s.emoji} ` : ''}{s.name || s.filename} ({s.language || '?'})
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <label style={{ fontSize: '0.85rem' }}>
+                      {t('meshcore.automation.responder.script_args', 'Script args (token expansion)')}
+                      <MeshCoreTokenLegend />
+                      <input
+                        type="text"
+                        value={tr.scriptArgs || ''}
+                        onChange={(e) => updateTrigger(tr.id, { scriptArgs: e.target.value })}
+                        disabled={disabled || !canWrite}
+                        className="meshcore-input"
+                        style={{ width: '100%', marginTop: '0.25rem', fontFamily: 'monospace' }}
+                      />
+                    </label>
+                  </div>
+                )}
+              </div>
+
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem', alignItems: 'center', marginBottom: '0.5rem' }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', fontSize: '0.85rem' }}>
+                  <input
+                    type="checkbox"
+                    checked={tr.listenDMs}
+                    onChange={(e) => updateTrigger(tr.id, { listenDMs: e.target.checked })}
+                    disabled={disabled || !canWrite}
+                    style={{ width: 'auto', margin: 0 }}
+                  />
+                  {t('meshcore.automation.responder.listen_dms', 'Listen on DMs')}
+                </label>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', fontSize: '0.85rem' }}>
+                  <input
+                    type="checkbox"
+                    checked={tr.replyAsDM}
+                    onChange={(e) => updateTrigger(tr.id, { replyAsDM: e.target.checked })}
+                    disabled={disabled || !canWrite}
+                    style={{ width: 'auto', margin: 0 }}
+                  />
+                  {t('meshcore.automation.responder.reply_dm', 'Reply as DM')}
+                </label>
+                <label style={{ fontSize: '0.85rem' }}>
+                  {t('meshcore.automation.responder.cooldown', 'Cooldown (s)')}{' '}
+                  <input
+                    type="number"
+                    min={0}
+                    max={3600}
+                    value={tr.cooldownSeconds}
+                    onChange={(e) => updateTrigger(tr.id, { cooldownSeconds: Math.max(0, Math.min(3600, parseInt(e.target.value, 10) || 0)) })}
+                    disabled={disabled || !canWrite}
+                    className="meshcore-input"
+                    style={{ width: '80px' }}
+                  />
+                </label>
+              </div>
+
+              {/* Channels */}
+              <fieldset style={{ border: '1px solid var(--ctp-surface2)', borderRadius: '4px', padding: '0.5rem' }}>
+                <legend style={{ fontSize: '0.8rem', padding: '0 0.5rem' }}>
+                  {t('meshcore.automation.responder.channels', 'Listen on channels')}
+                </legend>
+                {channels.length === 0 && (
+                  <span style={{ fontSize: '0.8rem', color: 'var(--ctp-subtext0)' }}>
+                    {t('meshcore.automation.responder.no_channels', 'No channels loaded')}
+                  </span>
+                )}
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+                  {channels.map(ch => (
+                    <label key={ch.id} style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', fontSize: '0.8rem' }}>
+                      <input
+                        type="checkbox"
+                        checked={tr.channels.includes(ch.id)}
+                        onChange={(e) => {
+                          if (e.target.checked) updateTrigger(tr.id, { channels: [...tr.channels, ch.id] });
+                          else updateTrigger(tr.id, { channels: tr.channels.filter(c => c !== ch.id) });
+                        }}
+                        disabled={disabled || !canWrite}
+                        style={{ width: 'auto', margin: 0 }}
+                      />
+                      {channelMap.get(ch.id)}
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+            </div>
+          );
+        })}
+
+        {/* Add new trigger */}
+        <div className="meshcore-add-card" style={{ opacity: disabled ? 0.6 : 1 }}>
+          <h3 style={{ marginTop: 0, fontSize: '1rem' }}>
+            {t('meshcore.automation.responder.add', 'Add trigger')}
+          </h3>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem', marginBottom: '0.5rem' }}>
+            <input
+              type="text"
+              value={draft.name}
+              onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+              placeholder={t('meshcore.automation.responder.name_placeholder', 'Trigger name')}
+              disabled={disabled || !canWrite}
+              className="meshcore-input"
+            />
+            <input
+              type="text"
+              value={draft.pattern}
+              onChange={(e) => setDraft({ ...draft, pattern: e.target.value })}
+              placeholder="^(test|ping)"
+              disabled={disabled || !canWrite}
+              className="meshcore-input"
+              style={{ fontFamily: 'monospace' }}
+            />
+          </div>
+          <textarea
+            value={draft.response}
+            onChange={(e) => setDraft({ ...draft, response: e.target.value })}
+            placeholder={t('meshcore.automation.responder.response_placeholder', 'Response text (supports {VERSION}, {DURATION}, …)')}
+            rows={2}
+            disabled={disabled || !canWrite}
+            className="meshcore-input"
+            style={{ width: '100%', marginBottom: '0.5rem', fontFamily: 'monospace' }}
+          />
+          <button
+            type="button"
+            onClick={addTrigger}
+            disabled={disabled || !canWrite}
+            className="meshcore-btn meshcore-btn-primary"
+          >
+            {t('meshcore.automation.responder.add_button', 'Add trigger')}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default MeshCoreAutoResponderSection;

--- a/src/components/MeshCore/MeshCoreAutomation.css
+++ b/src/components/MeshCore/MeshCoreAutomation.css
@@ -1,0 +1,239 @@
+/*
+ * MeshCore Automation polish.
+ *
+ * Loaded by MeshCorePage so the auto-announce, auto-responder, and
+ * timer-trigger sections pick up consistent select / button / card
+ * styling. `settings.css` covers `.setting-item` and `.setting-input`
+ * for inputs+textareas already; this file fills the gaps the shared
+ * sheet doesn't address (selects, buttons, and the trigger-card layout
+ * the new sections introduced).
+ */
+
+/* --- Form controls ------------------------------------------------- */
+
+/* Apply setting-input visual treatment to selects too. */
+.meshcore-automations-view select.setting-input,
+.meshcore-automations-view select.meshcore-select {
+  background: var(--ctp-surface1);
+  border: 2px solid var(--ctp-surface2);
+  color: var(--ctp-text);
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-lg, 8px);
+  font-size: 0.95rem;
+  transition: border-color 0.2s, background-color 0.2s;
+  cursor: pointer;
+}
+.meshcore-automations-view select.setting-input:hover,
+.meshcore-automations-view select.meshcore-select:hover {
+  border-color: var(--ctp-overlay0);
+}
+.meshcore-automations-view select.setting-input:focus,
+.meshcore-automations-view select.meshcore-select:focus {
+  outline: none;
+  border-color: var(--ctp-blue);
+}
+.meshcore-automations-view select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/*
+ * The trigger cards override .setting-input's default 200px width — they
+ * live inside narrow grid columns and need to fill their column.
+ */
+.meshcore-automations-view .meshcore-trigger-card .setting-input,
+.meshcore-automations-view .meshcore-trigger-card input.meshcore-input,
+.meshcore-automations-view .meshcore-trigger-card textarea.meshcore-input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Inline text/number/textarea controls inside the trigger cards. */
+.meshcore-automations-view input.meshcore-input,
+.meshcore-automations-view textarea.meshcore-input {
+  background: var(--ctp-surface1);
+  border: 2px solid var(--ctp-surface2);
+  color: var(--ctp-text);
+  padding: 0.4rem 0.6rem;
+  border-radius: var(--radius-md, 6px);
+  font-size: 0.95rem;
+  transition: border-color 0.2s, background-color 0.2s;
+  font-family: inherit;
+}
+.meshcore-automations-view input.meshcore-input:hover,
+.meshcore-automations-view textarea.meshcore-input:hover {
+  border-color: var(--ctp-overlay0);
+}
+.meshcore-automations-view input.meshcore-input:focus,
+.meshcore-automations-view textarea.meshcore-input:focus {
+  outline: none;
+  border-color: var(--ctp-blue);
+  background: var(--ctp-base);
+}
+.meshcore-automations-view input.meshcore-input:disabled,
+.meshcore-automations-view textarea.meshcore-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* --- Buttons ------------------------------------------------------- */
+
+.meshcore-automations-view .meshcore-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.95rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  border: none;
+  border-radius: var(--radius-md, 6px);
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s, opacity 0.15s;
+  font-family: inherit;
+}
+.meshcore-automations-view .meshcore-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.meshcore-automations-view .meshcore-btn-primary {
+  background: var(--ctp-blue);
+  color: var(--ctp-base);
+}
+.meshcore-automations-view .meshcore-btn-primary:hover:not(:disabled) {
+  background: var(--ctp-sapphire, var(--ctp-blue));
+}
+
+.meshcore-automations-view .meshcore-btn-danger {
+  background: var(--ctp-red);
+  color: var(--ctp-base);
+}
+.meshcore-automations-view .meshcore-btn-danger:hover:not(:disabled) {
+  background: var(--ctp-maroon, var(--ctp-red));
+}
+
+.meshcore-automations-view .meshcore-btn-secondary {
+  background: var(--ctp-surface1);
+  color: var(--ctp-text);
+  border: 1px solid var(--ctp-surface2);
+}
+.meshcore-automations-view .meshcore-btn-secondary:hover:not(:disabled) {
+  background: var(--ctp-surface2);
+}
+
+/* --- Trigger cards ------------------------------------------------- */
+
+.meshcore-automations-view .meshcore-trigger-card {
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+  background: var(--ctp-surface0);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: 8px;
+}
+
+.meshcore-automations-view .meshcore-trigger-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.meshcore-automations-view .meshcore-trigger-card .meshcore-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.meshcore-automations-view .meshcore-trigger-card .meshcore-grid-1-2 {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.meshcore-automations-view .meshcore-trigger-card label {
+  font-size: 0.85rem;
+  color: var(--ctp-subtext1, var(--ctp-text));
+  display: block;
+}
+
+.meshcore-automations-view .meshcore-trigger-card legend {
+  font-size: 0.8rem;
+  padding: 0 0.5rem;
+  color: var(--ctp-subtext0);
+}
+
+.meshcore-automations-view .meshcore-trigger-card fieldset {
+  border: 1px solid var(--ctp-surface2);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  margin-top: 0.5rem;
+}
+
+/* The "Add trigger" dashed card. */
+.meshcore-automations-view .meshcore-add-card {
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+  background: var(--ctp-surface0);
+  border: 1px dashed var(--ctp-surface2);
+  border-radius: 8px;
+}
+.meshcore-automations-view .meshcore-add-card h3 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1rem;
+  color: var(--ctp-text);
+}
+
+/* The "Last run …" banner under each trigger. */
+.meshcore-automations-view .meshcore-trigger-lastrun {
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--ctp-subtext0);
+}
+.meshcore-automations-view .meshcore-trigger-lastrun .ok { color: var(--ctp-green); }
+.meshcore-automations-view .meshcore-trigger-lastrun .err { color: var(--ctp-red); }
+
+/* --- Section header send-now button ------------------------------- */
+
+.meshcore-automations-view .automation-section-header .meshcore-send-now {
+  margin-left: auto;
+}
+
+/* --- Token reference (available substitution tokens) -------------- */
+
+.meshcore-automations-view .meshcore-token-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+
+.meshcore-automations-view .meshcore-token-list-label {
+  font-size: 0.8rem;
+  color: var(--ctp-subtext0);
+  margin-right: 0.25rem;
+}
+
+.meshcore-automations-view .meshcore-token-chip {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.78rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: var(--radius-md, 6px);
+  background: var(--ctp-surface1);
+  color: var(--ctp-blue);
+  border: 1px solid var(--ctp-surface2);
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+.meshcore-automations-view .meshcore-token-chip:hover:not(:disabled) {
+  background: var(--ctp-surface2);
+  border-color: var(--ctp-overlay0);
+}
+.meshcore-automations-view .meshcore-token-chip:disabled {
+  cursor: default;
+  opacity: 0.7;
+}

--- a/src/components/MeshCore/MeshCoreAutomationsView.tsx
+++ b/src/components/MeshCore/MeshCoreAutomationsView.tsx
@@ -4,6 +4,9 @@ import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { useSaveBar } from '../../hooks/useSaveBar';
 import { useAuth } from '../../contexts/AuthContext';
 import { MeshCoreAutoAckSection } from './MeshCoreAutoAckSection';
+import { MeshCoreAutoAnnounceSection } from './MeshCoreAutoAnnounceSection';
+import { MeshCoreAutoResponderSection } from './MeshCoreAutoResponderSection';
+import { MeshCoreTimerTriggersSection } from './MeshCoreTimerTriggersSection';
 
 interface MeshCoreAutomationsViewProps {
   baseUrl: string;
@@ -290,6 +293,15 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
 
       {/* Auto-Acknowledge Section */}
       <MeshCoreAutoAckSection baseUrl={baseUrl} sourceId={sourceId} />
+
+      {/* Auto-Announce Section */}
+      <MeshCoreAutoAnnounceSection baseUrl={baseUrl} sourceId={sourceId} />
+
+      {/* Auto-Responder Section */}
+      <MeshCoreAutoResponderSection baseUrl={baseUrl} sourceId={sourceId} />
+
+      {/* Timer Triggers Section */}
+      <MeshCoreTimerTriggersSection baseUrl={baseUrl} sourceId={sourceId} />
     </div>
   );
 };

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -30,6 +30,12 @@ import { SaveBarProvider } from '../../contexts/SaveBarContext';
 import { SaveBar } from '../SaveBar';
 import './MeshCoreTab.css';
 import './MeshCorePage.css';
+// The automation views (auto-ack, auto-announce, auto-responder, timer
+// triggers) lean on the shared settings stylesheet — .setting-item,
+// .setting-input, .automation-section-header. Without this import the
+// form controls render unstyled.
+import '../../styles/settings.css';
+import './MeshCoreAutomation.css';
 
 interface MeshCorePageProps {
   baseUrl: string;

--- a/src/components/MeshCore/MeshCoreTimerTriggersSection.tsx
+++ b/src/components/MeshCore/MeshCoreTimerTriggersSection.tsx
@@ -1,0 +1,566 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { isValidCron } from 'cron-validator';
+import { useCsrfFetch } from '../../hooks/useCsrfFetch';
+import { useToast } from '../ToastContainer';
+import { useAuth } from '../../contexts/AuthContext';
+import { useSaveBar } from '../../hooks/useSaveBar';
+import { MeshCoreTokenLegend } from './MeshCoreTokenLegend';
+
+interface MeshCoreTimerTriggersSectionProps {
+  baseUrl: string;
+  sourceId: string;
+}
+
+/**
+ * Mirrors the backend `MeshCoreTimerTrigger` shape exactly. Kept inline
+ * because the type isn't exported to the client bundle — it's a server-
+ * only interface that crosses the wire as JSON.
+ */
+interface MeshCoreTimerTrigger {
+  id: string;
+  name: string;
+  enabled: boolean;
+  scheduleType: 'cron' | 'interval';
+  cronExpression?: string;
+  intervalMinutes?: number;
+  responseType: 'text' | 'advert' | 'script';
+  response?: string;
+  scriptPath?: string;
+  scriptArgs?: string;
+  destination?: 'channel' | 'dm';
+  channelIndex?: number;
+  contactPublicKey?: string;
+  lastRun?: number;
+  lastResult?: 'success' | 'error';
+  lastError?: string;
+}
+
+interface ScriptMetadata {
+  path: string;
+  filename: string;
+  name?: string;
+  emoji?: string;
+  language?: string;
+}
+
+interface MeshCoreChannelRow {
+  id: number;
+  name: string;
+}
+
+interface MeshCoreContactRow {
+  publicKey: string;
+  name: string;
+}
+
+const newTrigger = (): MeshCoreTimerTrigger => ({
+  id: typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `t-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  name: '',
+  enabled: true,
+  scheduleType: 'cron',
+  cronExpression: '0 */6 * * *',
+  intervalMinutes: 60,
+  responseType: 'text',
+  response: '',
+  destination: 'channel',
+  channelIndex: 0,
+});
+
+const triggersEqual = (a: MeshCoreTimerTrigger[], b: MeshCoreTimerTrigger[]): boolean => {
+  if (a.length !== b.length) return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+};
+
+export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSectionProps> = ({ baseUrl, sourceId }) => {
+  const { t } = useTranslation();
+  const csrfFetch = useCsrfFetch();
+  const { showToast } = useToast();
+  const { hasPermission } = useAuth();
+  const canWrite = hasPermission('automation', 'write');
+
+  const [triggers, setTriggers] = useState<MeshCoreTimerTrigger[]>([]);
+  const [initial, setInitial] = useState<MeshCoreTimerTrigger[]>([]);
+  const [channels, setChannels] = useState<MeshCoreChannelRow[]>([]);
+  const [contacts, setContacts] = useState<MeshCoreContactRow[]>([]);
+  const [scripts, setScripts] = useState<ScriptMetadata[]>([]);
+  const [hasChanges, setHasChanges] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [draft, setDraft] = useState<MeshCoreTimerTrigger>(newTrigger());
+  const [runningId, setRunningId] = useState<string | null>(null);
+
+  // Load triggers
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await csrfFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/automation/timers`);
+        if (!res.ok) return;
+        const json = await res.json();
+        if (cancelled || !json.success) return;
+        const list: MeshCoreTimerTrigger[] = Array.isArray(json.data?.triggers) ? json.data.triggers : [];
+        setTriggers(list);
+        setInitial(list);
+        setLoaded(true);
+      } catch {
+        // keep defaults
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [baseUrl, sourceId, csrfFetch]);
+
+  // Load channels
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await csrfFetch(`${baseUrl}/api/channels/all?sourceId=${encodeURIComponent(sourceId)}`);
+        if (!res.ok) return;
+        const raw = await res.json();
+        if (cancelled) return;
+        const rows: MeshCoreChannelRow[] = Array.isArray(raw)
+          ? raw
+              .filter((c: any) => typeof c?.id === 'number')
+              .map((c: any) => ({ id: c.id as number, name: String(c.name ?? '') }))
+              .sort((a, b) => a.id - b.id)
+          : [];
+        setChannels(rows);
+      } catch { /* ignore */ }
+    })();
+    return () => { cancelled = true; };
+  }, [baseUrl, sourceId, csrfFetch]);
+
+  // Load available scripts (for responseType='script' picker). Shared
+  // with Meshtastic — /api/scripts is protocol-neutral.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await csrfFetch(`${baseUrl}/api/scripts`);
+        if (!res.ok) return;
+        const raw = await res.json();
+        if (cancelled) return;
+        const list: ScriptMetadata[] = Array.isArray(raw?.scripts)
+          ? raw.scripts.filter((s: any) => typeof s?.path === 'string')
+          : [];
+        setScripts(list);
+      } catch { /* ignore */ }
+    })();
+    return () => { cancelled = true; };
+  }, [baseUrl, csrfFetch]);
+
+  // Load contacts (for DM destination)
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await csrfFetch(`${baseUrl}/api/sources/${sourceId}/meshcore/contacts`);
+        if (!res.ok) return;
+        const raw = await res.json();
+        if (cancelled) return;
+        const rows: MeshCoreContactRow[] = Array.isArray(raw?.data)
+          ? raw.data
+              .filter((c: any) => typeof c?.publicKey === 'string')
+              .map((c: any) => ({
+                publicKey: c.publicKey as string,
+                name: String(c.advName ?? c.name ?? c.publicKey.substring(0, 16)),
+              }))
+          : [];
+        setContacts(rows);
+      } catch { /* ignore */ }
+    })();
+    return () => { cancelled = true; };
+  }, [baseUrl, sourceId, csrfFetch]);
+
+  // Detect changes
+  useEffect(() => {
+    if (!loaded) return;
+    setHasChanges(!triggersEqual(triggers, initial));
+  }, [triggers, initial, loaded]);
+
+  const handleSave = useCallback(async () => {
+    // Validate every cron + interval combo before persisting
+    for (const tr of triggers) {
+      if (tr.scheduleType === 'cron' && !isValidCron(tr.cronExpression || '', { seconds: false, alias: true, allowBlankDay: true })) {
+        showToast(t('meshcore.automation.timers.invalid_cron', `Invalid cron for "${tr.name || tr.id}"`), 'error');
+        return;
+      }
+      if (tr.scheduleType === 'interval' && (!Number.isFinite(tr.intervalMinutes) || (tr.intervalMinutes ?? 0) <= 0)) {
+        showToast(t('meshcore.automation.timers.invalid_interval', `Invalid interval for "${tr.name || tr.id}"`), 'error');
+        return;
+      }
+    }
+    setIsSaving(true);
+    try {
+      const res = await csrfFetch(
+        `${baseUrl}/api/sources/${sourceId}/meshcore/automation/timers`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ triggers }),
+        },
+      );
+      if (!res.ok) {
+        if (res.status === 403) {
+          showToast(t('automation.insufficient_permissions', 'Insufficient permissions'), 'error');
+          return;
+        }
+        throw new Error(`Server returned ${res.status}`);
+      }
+      setInitial(triggers);
+      setHasChanges(false);
+      showToast(t('automation.settings_saved', 'Settings saved'), 'success');
+    } catch (err) {
+      console.error('Failed to save MeshCore timer triggers:', err);
+      showToast(t('automation.settings_save_failed', 'Failed to save settings'), 'error');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [triggers, baseUrl, sourceId, csrfFetch, showToast, t]);
+
+  const handleDismiss = useCallback(() => {
+    setTriggers(initial);
+    setHasChanges(false);
+  }, [initial]);
+
+  useSaveBar({
+    id: 'meshcore-timer-triggers',
+    sectionName: t('meshcore.automation.timers.title', 'Timer Triggers'),
+    hasChanges,
+    isSaving,
+    onSave: handleSave,
+    onDismiss: handleDismiss,
+  });
+
+  const updateTrigger = (id: string, patch: Partial<MeshCoreTimerTrigger>) => {
+    setTriggers(prev => prev.map(t => t.id === id ? { ...t, ...patch } : t));
+  };
+  const removeTrigger = (id: string) => {
+    setTriggers(prev => prev.filter(t => t.id !== id));
+  };
+
+  const addTrigger = () => {
+    if (!draft.name.trim()) {
+      showToast(t('meshcore.automation.timers.name_required', 'Name is required'), 'error');
+      return;
+    }
+    if (draft.scheduleType === 'cron' && !isValidCron(draft.cronExpression || '', { seconds: false, alias: true, allowBlankDay: true })) {
+      showToast(t('meshcore.automation.timers.invalid_cron_draft', 'Invalid cron expression'), 'error');
+      return;
+    }
+    setTriggers(prev => [...prev, draft]);
+    setDraft(newTrigger());
+  };
+
+  const runNow = useCallback(async (id: string) => {
+    setRunningId(id);
+    try {
+      const res = await csrfFetch(
+        `${baseUrl}/api/sources/${sourceId}/meshcore/automation/timers/${encodeURIComponent(id)}/run`,
+        { method: 'POST' },
+      );
+      const json = await res.json();
+      if (res.ok && json.success) {
+        showToast(t('meshcore.automation.timers.ran', 'Trigger fired'), 'success');
+      } else {
+        showToast(json?.data?.reason || json?.error || t('meshcore.automation.timers.run_failed', 'Run failed'), 'error');
+      }
+    } catch (err) {
+      console.error('Failed to run timer trigger:', err);
+      showToast(t('meshcore.automation.timers.run_failed', 'Run failed'), 'error');
+    } finally {
+      setRunningId(null);
+    }
+  }, [baseUrl, sourceId, csrfFetch, showToast, t]);
+
+  const channelOptions = useMemo(() => channels.map(c => ({ value: c.id, label: c.name || `Channel ${c.id}` })), [channels]);
+  const contactOptions = useMemo(() => contacts.map(c => ({ value: c.publicKey, label: c.name })), [contacts]);
+
+  return (
+    <>
+      <div className="automation-section-header" style={{
+        display: 'flex',
+        alignItems: 'center',
+        marginBottom: '1.5rem',
+        marginTop: '2rem',
+        padding: '1rem 1.25rem',
+        background: 'var(--ctp-surface1)',
+        border: '1px solid var(--ctp-surface2)',
+        borderRadius: '8px',
+      }}>
+        <h2 style={{ margin: 0 }}>
+          {t('meshcore.automation.timers.title', 'Timer Triggers')}
+        </h2>
+        <span style={{ marginLeft: 'auto', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+          {t('meshcore.automation.timers.count', '{{count}} triggers', { count: triggers.length })}
+        </span>
+      </div>
+
+      <div className="settings-section">
+        <p style={{ marginBottom: '1rem', color: '#666', lineHeight: 1.5, marginLeft: '1.75rem' }}>
+          {t(
+            'meshcore.automation.timers.description',
+            'Schedule recurring actions — send a message to a channel or contact, or fire a MeshCore advert. Each trigger runs on its own cron or interval.',
+          )}
+        </p>
+
+        {/* List of existing triggers */}
+        {triggers.length === 0 && (
+          <p style={{ marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+            {t('meshcore.automation.timers.empty', 'No timer triggers configured yet.')}
+          </p>
+        )}
+
+        {triggers.map(tr => (
+          <div key={tr.id} className="meshcore-trigger-card">
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
+              <input
+                type="checkbox"
+                checked={tr.enabled}
+                onChange={(e) => updateTrigger(tr.id, { enabled: e.target.checked })}
+                disabled={!canWrite}
+                style={{ width: 'auto', margin: 0 }}
+                aria-label={`Enable ${tr.name}`}
+              />
+              <input
+                type="text"
+                value={tr.name}
+                onChange={(e) => updateTrigger(tr.id, { name: e.target.value })}
+                disabled={!canWrite}
+                placeholder={t('meshcore.automation.timers.name_placeholder', 'Trigger name')}
+                className="meshcore-input"
+                style={{ flex: 1 }}
+              />
+              <button
+                type="button"
+                onClick={() => runNow(tr.id)}
+                disabled={!canWrite || runningId === tr.id || !tr.enabled}
+                className="meshcore-btn meshcore-btn-secondary"
+              >
+                {runningId === tr.id ? t('meshcore.automation.timers.running', 'Running…') : t('meshcore.automation.timers.run_now', 'Run now')}
+              </button>
+              <button
+                type="button"
+                onClick={() => removeTrigger(tr.id)}
+                disabled={!canWrite}
+                className="meshcore-btn meshcore-btn-danger"
+              >
+                {t('meshcore.automation.timers.remove', 'Remove')}
+              </button>
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem', marginBottom: '0.5rem' }}>
+              <label style={{ fontSize: '0.85rem' }}>
+                {t('meshcore.automation.timers.schedule_type', 'Schedule')}
+                <select
+                  value={tr.scheduleType}
+                  onChange={(e) => updateTrigger(tr.id, { scheduleType: e.target.value as 'cron' | 'interval' })}
+                  disabled={!canWrite}
+                  className="meshcore-select"
+                  style={{ width: '100%', marginTop: '0.25rem' }}
+                >
+                  <option value="cron">{t('meshcore.automation.timers.cron', 'Cron')}</option>
+                  <option value="interval">{t('meshcore.automation.timers.interval', 'Interval (minutes)')}</option>
+                </select>
+              </label>
+              {tr.scheduleType === 'cron' ? (
+                <label style={{ fontSize: '0.85rem' }}>
+                  {t('meshcore.automation.timers.cron_expr', 'Cron expression')}
+                  <input
+                    type="text"
+                    value={tr.cronExpression || ''}
+                    onChange={(e) => updateTrigger(tr.id, { cronExpression: e.target.value })}
+                    disabled={!canWrite}
+                    placeholder="0 */6 * * *"
+                    className="meshcore-input"
+                    style={{ width: '100%', marginTop: '0.25rem', fontFamily: 'monospace' }}
+                  />
+                </label>
+              ) : (
+                <label style={{ fontSize: '0.85rem' }}>
+                  {t('meshcore.automation.timers.interval_minutes', 'Interval (minutes)')}
+                  <input
+                    type="number"
+                    min={1}
+                    max={10080}
+                    value={tr.intervalMinutes ?? 60}
+                    onChange={(e) => updateTrigger(tr.id, { intervalMinutes: Math.max(1, parseInt(e.target.value, 10) || 60) })}
+                    disabled={!canWrite}
+                    className="meshcore-input"
+                    style={{ width: '100%', marginTop: '0.25rem' }}
+                  />
+                </label>
+              )}
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 2fr', gap: '0.75rem', marginBottom: '0.5rem' }}>
+              <label style={{ fontSize: '0.85rem' }}>
+                {t('meshcore.automation.timers.response_type', 'Action')}
+                <select
+                  value={tr.responseType}
+                  onChange={(e) => updateTrigger(tr.id, { responseType: e.target.value as 'text' | 'advert' | 'script' })}
+                  disabled={!canWrite}
+                  className="meshcore-select"
+                  style={{ width: '100%', marginTop: '0.25rem' }}
+                >
+                  <option value="text">{t('meshcore.automation.timers.response_text', 'Send text')}</option>
+                  <option value="advert">{t('meshcore.automation.timers.response_advert', 'Send advert')}</option>
+                  <option value="script">{t('meshcore.automation.timers.response_script', 'Run script')}</option>
+                </select>
+              </label>
+              {tr.responseType === 'text' && (
+                <label style={{ fontSize: '0.85rem' }}>
+                  {t('meshcore.automation.timers.response_message', 'Message (token expansion supported)')}
+                  <MeshCoreTokenLegend />
+                  <textarea
+                    value={tr.response || ''}
+                    onChange={(e) => updateTrigger(tr.id, { response: e.target.value })}
+                    disabled={!canWrite}
+                    rows={2}
+                    className="meshcore-input"
+                    style={{ width: '100%', marginTop: '0.25rem', fontFamily: 'monospace' }}
+                  />
+                </label>
+              )}
+              {tr.responseType === 'script' && (
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.5rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>
+                    {t('meshcore.automation.timers.script', 'Script')}
+                    <select
+                      value={tr.scriptPath || ''}
+                      onChange={(e) => updateTrigger(tr.id, { scriptPath: e.target.value })}
+                      disabled={!canWrite}
+                      className="meshcore-select"
+                      style={{ width: '100%', marginTop: '0.25rem' }}
+                    >
+                      <option value="">{scripts.length === 0 ? t('meshcore.automation.timers.no_scripts', '(no scripts available)') : t('meshcore.automation.timers.select_script', '(select script)')}</option>
+                      {scripts.map(s => (
+                        <option key={s.path} value={s.path}>
+                          {s.emoji ? `${s.emoji} ` : ''}{s.name || s.filename} ({s.language || '?'})
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label style={{ fontSize: '0.85rem' }}>
+                    {t('meshcore.automation.timers.script_args', 'Script args (token expansion)')}
+                    <MeshCoreTokenLegend />
+                    <input
+                      type="text"
+                      value={tr.scriptArgs || ''}
+                      onChange={(e) => updateTrigger(tr.id, { scriptArgs: e.target.value })}
+                      disabled={!canWrite}
+                      className="meshcore-input"
+                      style={{ width: '100%', marginTop: '0.25rem', fontFamily: 'monospace' }}
+                    />
+                  </label>
+                </div>
+              )}
+            </div>
+
+            {(tr.responseType === 'text' || tr.responseType === 'script') && (
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 2fr', gap: '0.75rem' }}>
+                <label style={{ fontSize: '0.85rem' }}>
+                  {t('meshcore.automation.timers.destination', 'Destination')}
+                  <select
+                    value={tr.destination || 'channel'}
+                    onChange={(e) => updateTrigger(tr.id, { destination: e.target.value as 'channel' | 'dm' })}
+                    disabled={!canWrite}
+                    className="meshcore-select"
+                    style={{ width: '100%', marginTop: '0.25rem' }}
+                  >
+                    <option value="channel">{t('meshcore.automation.timers.dest_channel', 'Channel')}</option>
+                    <option value="dm">{t('meshcore.automation.timers.dest_dm', 'Direct Message')}</option>
+                  </select>
+                </label>
+                {tr.destination === 'channel' ? (
+                  <label style={{ fontSize: '0.85rem' }}>
+                    {t('meshcore.automation.timers.channel', 'Channel')}
+                    <select
+                      value={tr.channelIndex ?? 0}
+                      onChange={(e) => updateTrigger(tr.id, { channelIndex: parseInt(e.target.value, 10) })}
+                      disabled={!canWrite}
+                      className="meshcore-select"
+                      style={{ width: '100%', marginTop: '0.25rem' }}
+                    >
+                      {channelOptions.length === 0 && <option value={0}>(no channels loaded)</option>}
+                      {channelOptions.map(o => (
+                        <option key={o.value} value={o.value}>{o.label}</option>
+                      ))}
+                    </select>
+                  </label>
+                ) : (
+                  <label style={{ fontSize: '0.85rem' }}>
+                    {t('meshcore.automation.timers.contact', 'Contact')}
+                    <select
+                      value={tr.contactPublicKey || ''}
+                      onChange={(e) => updateTrigger(tr.id, { contactPublicKey: e.target.value })}
+                      disabled={!canWrite}
+                      className="meshcore-select"
+                      style={{ width: '100%', marginTop: '0.25rem' }}
+                    >
+                      <option value="">(select contact)</option>
+                      {contactOptions.map(o => (
+                        <option key={o.value} value={o.value}>{o.label}</option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+              </div>
+            )}
+
+            {tr.lastRun && (
+              <div style={{ marginTop: '0.5rem', fontSize: '0.8rem', color: 'var(--ctp-subtext0)' }}>
+                {t('meshcore.automation.timers.last_run', 'Last run')}: {new Date(tr.lastRun).toLocaleString()}{' '}
+                {tr.lastResult === 'error' && (
+                  <span style={{ color: 'var(--ctp-red)' }}>— {tr.lastError || 'error'}</span>
+                )}
+                {tr.lastResult === 'success' && (
+                  <span style={{ color: 'var(--ctp-green)' }}>— success</span>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+
+        {/* Add a new trigger */}
+        <div className="meshcore-add-card">
+          <h3 style={{ marginTop: 0, fontSize: '1rem' }}>
+            {t('meshcore.automation.timers.add', 'Add trigger')}
+          </h3>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem', marginBottom: '0.5rem' }}>
+            <input
+              type="text"
+              value={draft.name}
+              onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+              placeholder={t('meshcore.automation.timers.name_placeholder', 'Trigger name')}
+              disabled={!canWrite}
+              className="meshcore-input"
+            />
+            <input
+              type="text"
+              value={draft.cronExpression || ''}
+              onChange={(e) => setDraft({ ...draft, cronExpression: e.target.value })}
+              placeholder="0 */6 * * *"
+              disabled={!canWrite}
+              className="meshcore-input"
+              style={{ fontFamily: 'monospace' }}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={addTrigger}
+            disabled={!canWrite}
+            className="meshcore-btn meshcore-btn-primary"
+          >
+            {t('meshcore.automation.timers.add_button', 'Add trigger')}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default MeshCoreTimerTriggersSection;

--- a/src/components/MeshCore/MeshCoreTokenLegend.tsx
+++ b/src/components/MeshCore/MeshCoreTokenLegend.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { MESHCORE_AUTOMATION_TOKENS } from './meshcoreAutomationTokens';
+
+/**
+ * Inline "Available tokens: {VERSION}, …" legend. Rendered under the
+ * label of any token-aware text field so operators can see the full set
+ * without hunting through docs. Matches the styling used by the
+ * auto-announce message field.
+ */
+export const MeshCoreTokenLegend: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <span
+      className="setting-description"
+      style={{ display: 'block', marginTop: '0.25rem', fontSize: '0.8rem' }}
+    >
+      {t('meshcore.automation.available_tokens', 'Available tokens:')}{' '}
+      {MESHCORE_AUTOMATION_TOKENS.join(', ')}
+    </span>
+  );
+};

--- a/src/components/MeshCore/meshcoreAutomationTokens.ts
+++ b/src/components/MeshCore/meshcoreAutomationTokens.ts
@@ -1,0 +1,18 @@
+/**
+ * The token set shared by every MeshCore automation surface that runs
+ * text through the server-side `replaceMeshCoreAnnounceTokens` helper:
+ * auto-announce, auto-responder responses, and timer-trigger
+ * messages/script-args. Keep this in lockstep with
+ * `src/server/utils/meshcoreAnnounceTokens.ts` — the server is the
+ * source of truth for which placeholders actually expand.
+ */
+export const MESHCORE_AUTOMATION_TOKENS = [
+  '{VERSION}',
+  '{DURATION}',
+  '{CONTACTCOUNT}',
+  '{COMPANIONCOUNT}',
+  '{REPEATERCOUNT}',
+  '{ROOMCOUNT}',
+  '{NODE_NAME}',
+  '{NODE_ID}',
+] as const;

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -166,6 +166,22 @@ export const VALID_SETTINGS_KEYS = [
   'meshcoreAutoAckUseDM',
   'meshcoreAutoAckCooldownSeconds',
   'meshcoreAutoAckTestMessages',
+  // MeshCore auto-announce
+  'meshcoreAutoAnnounceEnabled',
+  'meshcoreAutoAnnounceIntervalHours',
+  'meshcoreAutoAnnounceMessage',
+  'meshcoreAutoAnnounceChannelIndexes',
+  'meshcoreAutoAnnounceOnStart',
+  'meshcoreAutoAnnounceUseSchedule',
+  'meshcoreAutoAnnounceSchedule',
+  'meshcoreAutoAnnounceAdvertEnabled',
+  'meshcoreAutoAnnounceAdvertDelaySeconds',
+  'meshcoreAutoAnnounceLastRunAt',
+  // MeshCore auto-responder
+  'meshcoreAutoResponderEnabled',
+  'meshcoreAutoResponderTriggers',
+  // MeshCore timer triggers
+  'meshcoreTimerTriggers',
 ] as const;
 
 export type ValidSettingKey = typeof VALID_SETTINGS_KEYS[number];
@@ -266,6 +282,22 @@ export const PER_SOURCE_SETTINGS_KEYS = [
   'meshcoreAutoAckUseDM',
   'meshcoreAutoAckCooldownSeconds',
   'meshcoreAutoAckTestMessages',
+  // MeshCore auto-announce
+  'meshcoreAutoAnnounceEnabled',
+  'meshcoreAutoAnnounceIntervalHours',
+  'meshcoreAutoAnnounceMessage',
+  'meshcoreAutoAnnounceChannelIndexes',
+  'meshcoreAutoAnnounceOnStart',
+  'meshcoreAutoAnnounceUseSchedule',
+  'meshcoreAutoAnnounceSchedule',
+  'meshcoreAutoAnnounceAdvertEnabled',
+  'meshcoreAutoAnnounceAdvertDelaySeconds',
+  'meshcoreAutoAnnounceLastRunAt',
+  // MeshCore auto-responder
+  'meshcoreAutoResponderEnabled',
+  'meshcoreAutoResponderTriggers',
+  // MeshCore timer triggers
+  'meshcoreTimerTriggers',
   // Misc per-source
   'externalUrl',
   'geofenceTriggers',

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -13,6 +13,9 @@ import { logger } from '../utils/logger.js';
 import databaseService from '../services/database.js';
 import { dataEventEmitter } from './services/dataEventEmitter.js';
 import { compileAutoAckRegex } from './utils/autoAckRegex.js';
+import { scheduleCron, validateCron, type CronJob } from './utils/cronScheduler.js';
+import { replaceMeshCoreAnnounceTokens } from './utils/meshcoreAnnounceTokens.js';
+import { runScript, type RunScriptResult } from './utils/scriptRunner.js';
 import { MeshCoreNativeBackend, type BridgeShapedEvent } from './meshcoreNativeBackend.js';
 
 // Dynamic imports for optional serialport dependency
@@ -117,6 +120,80 @@ export enum MeshCoreDeviceType {
 export enum ConnectionType {
   SERIAL = 'serial',
   TCP = 'tcp',
+}
+
+/**
+ * Operator-defined auto-responder trigger, persisted per source as a
+ * JSON array at the `meshcoreAutoResponderTriggers` setting key. Fires
+ * from the manager's incoming-message handler — one regex per row, one
+ * text response per match. Intentionally narrower than the Meshtastic
+ * AutoResponder (no HTTP/script/traceroute response types) so v1 can
+ * land without dragging the script-runner sandbox into the MeshCore
+ * surface.
+ */
+export interface MeshCoreAutoResponderTrigger {
+  id: string;
+  name: string;
+  enabled: boolean;
+  /** Case-insensitive regex matched against incoming message text. */
+  pattern: string;
+  /**
+   * Action to take on match. `text` sends `response` rendered against
+   * announce tokens; `script` runs `scriptPath` and sends each entry of
+   * the script's `wouldSendMessages` output.
+   */
+  responseType?: 'text' | 'script';
+  /** Response template (only consulted for responseType === 'text'). */
+  response: string;
+  /** Script filename inside /data/scripts (responseType === 'script'). */
+  scriptPath?: string;
+  /** Whitespace-separated argv passed to the script. Token-expanded. */
+  scriptArgs?: string;
+  /** Channel indexes the trigger should listen on. Omit/empty = none. */
+  channels: number[];
+  /** Listen on DMs in addition to channels. */
+  listenDMs: boolean;
+  /** Always answer as a DM, even when the trigger came from a channel. */
+  replyAsDM: boolean;
+  /** Per-sender cooldown in seconds. 0 disables. */
+  cooldownSeconds: number;
+}
+
+/**
+ * Operator-defined timer trigger persisted (per source) as a JSON array
+ * at the `meshcoreTimerTriggers` setting key. One scheduler entry per
+ * row; the runner reads the row by id at fire time so a freshly-saved
+ * template applies on the next tick.
+ */
+export interface MeshCoreTimerTrigger {
+  id: string;
+  name: string;
+  enabled: boolean;
+  /** `cron` uses cronExpression; `interval` uses intervalMinutes. */
+  scheduleType: 'cron' | 'interval';
+  cronExpression?: string;
+  intervalMinutes?: number;
+  /**
+   * `text` sends `response` rendered against announce tokens;
+   * `advert` ignores `response`;
+   * `script` runs `scriptPath` and routes wouldSendMessages to
+   * `destination` (channel or dm).
+   */
+  responseType: 'text' | 'advert' | 'script';
+  response?: string;
+  /** Script filename inside /data/scripts (responseType === 'script'). */
+  scriptPath?: string;
+  /** Whitespace-separated argv passed to the script. Token-expanded. */
+  scriptArgs?: string;
+  /** Where to send a `text` / `script` response. `channel` requires `channelIndex`; `dm` requires `contactPublicKey`. */
+  destination?: 'channel' | 'dm';
+  channelIndex?: number;
+  contactPublicKey?: string;
+  // Last-run telemetry. Written by `runTimerTrigger` so the UI can show
+  // "ran 5m ago" without re-querying the device.
+  lastRun?: number;
+  lastResult?: 'success' | 'error';
+  lastError?: string;
 }
 
 export interface MeshCoreConfig {
@@ -418,6 +495,28 @@ class MeshCoreManager extends EventEmitter {
   private autoPathfindingJitterTimeout: NodeJS.Timeout | null = null;
   private autoPathfindingLastRunAt: number = 0;
 
+  // Auto-announce scheduler state. One of these holds the recurring
+  // trigger: cron job when useSchedule=true, setInterval handle when
+  // running on a plain hour interval. lastRunAt is exposed to the UI so
+  // operators can confirm the scheduler is actually firing.
+  private autoAnnounceTimer: NodeJS.Timeout | null = null;
+  private autoAnnounceCron: CronJob | null = null;
+  private autoAnnounceLastRunAt: number = 0;
+  private autoAnnounceAdvertTimer: NodeJS.Timeout | null = null;
+
+  // Timer-trigger scheduler state. Each configured timer trigger gets
+  // either a CronJob (cron mode) or a setInterval handle (interval
+  // mode); they're parallel because the UI lets the operator switch
+  // modes per-trigger. lastRun is persisted via settings so it survives
+  // a process restart and the UI can show "ran 5m ago" reliably.
+  private timerTriggerCrons: Map<string, CronJob> = new Map();
+  private timerTriggerIntervals: Map<string, NodeJS.Timeout> = new Map();
+
+  // Per-trigger × per-sender cooldown for the auto-responder. Key is
+  // `${triggerId}:${pubkeyPrefix}` so two triggers can each answer the
+  // same chatty sender without stomping each other's cooldown.
+  private autoResponderCooldowns: Map<string, number> = new Map();
+
   // Auto-acknowledge per-sender cooldown (keyed by sender pubkey prefix).
   // Records the last time we acknowledged a sender so a chatty contact
   // doesn't burn airtime if they spam the trigger phrase.
@@ -525,6 +624,26 @@ class MeshCoreManager extends EventEmitter {
         logger.warn(`[MeshCore:${this.sourceId}] Failed to start auto-pathfinding: ${(err as Error).message}`),
       );
 
+      // Start auto-announce scheduler. Fires once now if announceOnStart is set.
+      this.startAutoAnnounce().then(async () => {
+        const onStart = (await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoAnnounceOnStart')) === 'true';
+        const enabled = (await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoAnnounceEnabled')) === 'true';
+        if (onStart && enabled) {
+          // Small delay so the device-side AppStart settles before chat goes out.
+          setTimeout(() => {
+            void this.runAutoAnnounceCycle('on_start').catch((err: Error) =>
+              logger.warn(`[MeshCore:${this.sourceId}] on-start announce failed: ${err.message}`));
+          }, 2500);
+        }
+      }).catch(err =>
+        logger.warn(`[MeshCore:${this.sourceId}] Failed to start auto-announce: ${(err as Error).message}`),
+      );
+
+      // Arm any operator-defined timer triggers.
+      this.startTimerTriggers().catch(err =>
+        logger.warn(`[MeshCore:${this.sourceId}] Failed to start timer triggers: ${(err as Error).message}`),
+      );
+
       return true;
     } catch (error) {
       // meshcore.js rejects some promises with `undefined` (no Error object),
@@ -568,6 +687,10 @@ class MeshCoreManager extends EventEmitter {
 
     // Stop auto-pathfinding scheduler.
     this.stopAutoPathfinding();
+
+    // Stop auto-announce + timer-trigger schedulers.
+    this.stopAutoAnnounce();
+    this.stopTimerTriggers();
 
     // Tear down native backend, if active.
     if (this.nativeBackend) {
@@ -685,6 +808,7 @@ class MeshCoreManager extends EventEmitter {
       const senderContact = this.resolveContactByPrefix(data.pubkey_prefix);
       const route = formatPathHops(data.path_hops) || senderContact?.outPath || null;
       void this.checkAutoAcknowledge(message, true, undefined, hopCount, route);
+      void this.checkAutoResponder(message, true, undefined);
     } else if (event_type === 'channel_message') {
       // MeshCore channel packets have no sender field on the wire — the sender's
       // device prefixes "Name: " onto the text body. Split it out so the UI can
@@ -712,6 +836,7 @@ class MeshCoreManager extends EventEmitter {
       const hopCount = decodePathLenHopCount(data.path_len);
       const route = formatPathHops(data.path_hops);
       void this.checkAutoAcknowledge(message, false, data.channel_idx, hopCount, route);
+      void this.checkAutoResponder(message, false, data.channel_idx);
     } else if (event_type === 'room_message') {
       // Room server post (TXT_TYPE_SIGNED_PLAIN). The room's pubkey prefix
       // identifies which room, and the author prefix identifies the poster.
@@ -3234,6 +3359,566 @@ class MeshCoreManager extends EventEmitter {
       enabled: this.autoPathfindingTimer !== null || this.autoPathfindingJitterTimeout !== null,
       lastRunAt: this.autoPathfindingLastRunAt,
     };
+  }
+
+  // ============ Auto-Announce ============
+  //
+  // Periodic broadcast of an operator-defined status message to one or
+  // more MeshCore channels. Mirrors the Meshtastic auto-announce
+  // feature, but the firing primitive here is a per-source scheduler
+  // (cron OR setInterval) since MeshCore manager instances are 1:N with
+  // sources. Both modes call the same runner; the cron path runs from
+  // croner with missed-execution recovery, the interval path uses
+  // setInterval.
+
+  /**
+   * Render a message template against this source's current state.
+   * Pulled into an instance method so the announce-preview route can
+   * resolve tokens with the right contact list / local node.
+   */
+  async previewAnnouncementMessage(template: string): Promise<string> {
+    return replaceMeshCoreAnnounceTokens(template, this);
+  }
+
+  /**
+   * (Re)start the auto-announce scheduler based on the current settings
+   * for this source. Always stops first so a settings change re-arms
+   * the timer cleanly. Safe to call when not yet connected — the runner
+   * is a no-op until `connected` is true.
+   */
+  async startAutoAnnounce(): Promise<void> {
+    this.stopAutoAnnounce();
+
+    const enabledRaw = await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoAnnounceEnabled');
+    if (enabledRaw !== 'true') {
+      logger.debug(`[MeshCore:${this.sourceId}] Auto-announce disabled`);
+      return;
+    }
+
+    const useScheduleRaw = (await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoAnnounceUseSchedule')) === 'true';
+    const schedule = (await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoAnnounceSchedule')) || '0 */6 * * *';
+    const intervalHoursRaw = await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoAnnounceIntervalHours');
+    const intervalHours = Math.max(1, parseInt(intervalHoursRaw || '6', 10) || 6);
+
+    if (useScheduleRaw) {
+      if (!validateCron(schedule)) {
+        logger.warn(`[MeshCore:${this.sourceId}] Auto-announce: invalid cron expression "${schedule}", not scheduling`);
+        return;
+      }
+      try {
+        this.autoAnnounceCron = scheduleCron(schedule, () => {
+          void this.runAutoAnnounceCycle('cron');
+        });
+        logger.info(`[MeshCore:${this.sourceId}] Auto-announce: cron scheduled (${schedule})`);
+      } catch (err) {
+        logger.warn(`[MeshCore:${this.sourceId}] Auto-announce: failed to schedule cron "${schedule}": ${(err as Error).message}`);
+      }
+    } else {
+      const periodMs = intervalHours * 60 * 60 * 1000;
+      this.autoAnnounceTimer = setInterval(() => {
+        void this.runAutoAnnounceCycle('interval');
+      }, periodMs);
+      logger.info(`[MeshCore:${this.sourceId}] Auto-announce: interval scheduled every ${intervalHours}h`);
+    }
+  }
+
+  /** Cancel any scheduled auto-announce timers. Idempotent. */
+  stopAutoAnnounce(): void {
+    if (this.autoAnnounceCron) {
+      try { this.autoAnnounceCron.stop(); } catch { /* ignore */ }
+      this.autoAnnounceCron = null;
+    }
+    if (this.autoAnnounceTimer) {
+      clearInterval(this.autoAnnounceTimer);
+      this.autoAnnounceTimer = null;
+    }
+    if (this.autoAnnounceAdvertTimer) {
+      clearTimeout(this.autoAnnounceAdvertTimer);
+      this.autoAnnounceAdvertTimer = null;
+    }
+  }
+
+  /**
+   * Fire one announcement cycle immediately — broadcast the rendered
+   * template to every configured channel, optionally followed by an
+   * advert. Returns the number of channels successfully transmitted to
+   * so the route handler can surface partial failures.
+   */
+  async runAutoAnnounceCycle(reason: 'cron' | 'interval' | 'on_start' | 'manual'): Promise<{ sent: number; total: number }> {
+    if (!this.connected) {
+      logger.debug(`[MeshCore:${this.sourceId}] Auto-announce: skipping (${reason}) — not connected`);
+      return { sent: 0, total: 0 };
+    }
+    if (this.deviceType === MeshCoreDeviceType.REPEATER) {
+      logger.debug(`[MeshCore:${this.sourceId}] Auto-announce: skipping (${reason}) — repeater cannot transmit chat`);
+      return { sent: 0, total: 0 };
+    }
+
+    const message = (await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoAnnounceMessage')) || '';
+    if (!message.trim()) {
+      logger.debug(`[MeshCore:${this.sourceId}] Auto-announce: skipping (${reason}) — empty template`);
+      return { sent: 0, total: 0 };
+    }
+
+    const channelsCsv = (await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoAnnounceChannelIndexes')) || '';
+    const channelIndexes = channelsCsv
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean)
+      .map(s => parseInt(s, 10))
+      .filter(n => Number.isFinite(n));
+
+    if (channelIndexes.length === 0) {
+      logger.debug(`[MeshCore:${this.sourceId}] Auto-announce: skipping (${reason}) — no channels configured`);
+      return { sent: 0, total: 0 };
+    }
+
+    const rendered = await replaceMeshCoreAnnounceTokens(message, this);
+    let sent = 0;
+    for (const idx of channelIndexes) {
+      try {
+        const ok = await this.sendMessage(rendered, undefined, idx);
+        if (ok) sent += 1;
+      } catch (err) {
+        logger.warn(`[MeshCore:${this.sourceId}] Auto-announce: send to channel ${idx} threw: ${(err as Error).message}`);
+      }
+    }
+
+    this.autoAnnounceLastRunAt = Date.now();
+    await databaseService.settings.setSourceSetting(this.sourceId, 'meshcoreAutoAnnounceLastRunAt', String(this.autoAnnounceLastRunAt));
+    logger.info(`[MeshCore:${this.sourceId}] Auto-announce (${reason}): ${sent}/${channelIndexes.length} channels`);
+
+    // Optional advert burst N seconds after the announcement.
+    const advertEnabled = (await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoAnnounceAdvertEnabled')) === 'true';
+    if (advertEnabled) {
+      const delayRaw = await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoAnnounceAdvertDelaySeconds');
+      const delaySec = Math.max(0, Math.min(600, parseInt(delayRaw || '30', 10) || 30));
+      if (this.autoAnnounceAdvertTimer) clearTimeout(this.autoAnnounceAdvertTimer);
+      this.autoAnnounceAdvertTimer = setTimeout(() => {
+        this.autoAnnounceAdvertTimer = null;
+        if (!this.connected) return;
+        void this.sendAdvert().catch((err: Error) => {
+          logger.warn(`[MeshCore:${this.sourceId}] Auto-announce: advert burst failed: ${err.message}`);
+        });
+      }, delaySec * 1000);
+    }
+
+    return { sent, total: channelIndexes.length };
+  }
+
+  /** Read-only view for the route handler / UI. */
+  getAutoAnnounceStatus(): { enabled: boolean; lastRunAt: number } {
+    return {
+      enabled: this.autoAnnounceCron !== null || this.autoAnnounceTimer !== null,
+      lastRunAt: this.autoAnnounceLastRunAt,
+    };
+  }
+
+  // ============ Timer Triggers ============
+  //
+  // Operator-defined recurring jobs. Each trigger persists as an entry
+  // in the JSON blob at `meshcoreTimerTriggers` and gets scheduled on
+  // start (or whenever settings are saved). A trigger may either:
+  //   - send a text message to a channel/contact (with token expansion)
+  //   - run an advert
+  // Script execution is intentionally not wired here yet — the
+  // existing /api/scripts surface is shared with Meshtastic and the
+  // sandbox semantics need a follow-up to handle MeshCore context.
+
+  /**
+   * Reload all timer-trigger schedules from settings. Idempotent —
+   * cancels existing schedules first.
+   */
+  async startTimerTriggers(): Promise<void> {
+    this.stopTimerTriggers();
+    const raw = (await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreTimerTriggers')) || '[]';
+    let triggers: MeshCoreTimerTrigger[] = [];
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) triggers = parsed as MeshCoreTimerTrigger[];
+    } catch (err) {
+      logger.warn(`[MeshCore:${this.sourceId}] Timer triggers: failed to parse JSON: ${(err as Error).message}`);
+      return;
+    }
+
+    for (const trigger of triggers) {
+      if (!trigger || !trigger.id || !trigger.enabled) continue;
+      this.armTimerTrigger(trigger);
+    }
+  }
+
+  /** Cancel every armed timer trigger. */
+  stopTimerTriggers(): void {
+    for (const job of this.timerTriggerCrons.values()) {
+      try { job.stop(); } catch { /* ignore */ }
+    }
+    this.timerTriggerCrons.clear();
+    for (const handle of this.timerTriggerIntervals.values()) {
+      clearInterval(handle);
+    }
+    this.timerTriggerIntervals.clear();
+  }
+
+  private armTimerTrigger(trigger: MeshCoreTimerTrigger): void {
+    if (trigger.scheduleType === 'interval') {
+      const minutes = Math.max(1, Math.min(60 * 24 * 7, trigger.intervalMinutes || 0));
+      if (!Number.isFinite(minutes) || minutes <= 0) {
+        logger.warn(`[MeshCore:${this.sourceId}] Timer trigger ${trigger.id}: invalid interval, skipping`);
+        return;
+      }
+      const handle = setInterval(() => {
+        void this.runTimerTrigger(trigger.id).catch((err: Error) => {
+          logger.warn(`[MeshCore:${this.sourceId}] Timer trigger ${trigger.id} run failed: ${err.message}`);
+        });
+      }, minutes * 60 * 1000);
+      this.timerTriggerIntervals.set(trigger.id, handle);
+      logger.info(`[MeshCore:${this.sourceId}] Timer trigger "${trigger.name}" (interval ${minutes}m) armed`);
+    } else {
+      const expr = trigger.cronExpression || '';
+      if (!validateCron(expr)) {
+        logger.warn(`[MeshCore:${this.sourceId}] Timer trigger ${trigger.id}: invalid cron "${expr}", skipping`);
+        return;
+      }
+      try {
+        const job = scheduleCron(expr, () => {
+          void this.runTimerTrigger(trigger.id).catch((err: Error) => {
+            logger.warn(`[MeshCore:${this.sourceId}] Timer trigger ${trigger.id} run failed: ${err.message}`);
+          });
+        });
+        this.timerTriggerCrons.set(trigger.id, job);
+        logger.info(`[MeshCore:${this.sourceId}] Timer trigger "${trigger.name}" (cron ${expr}) armed`);
+      } catch (err) {
+        logger.warn(`[MeshCore:${this.sourceId}] Timer trigger ${trigger.id}: failed to schedule cron: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  /**
+   * Execute a single timer trigger by ID (used both by the scheduler
+   * callback and by the manual "Test trigger" button). Re-reads the
+   * trigger from settings so a freshly-saved template fires on the
+   * next tick without a restart.
+   */
+  async runTimerTrigger(triggerId: string): Promise<{ ok: boolean; reason?: string }> {
+    if (!this.connected) return { ok: false, reason: 'not connected' };
+    if (this.deviceType === MeshCoreDeviceType.REPEATER) return { ok: false, reason: 'repeater cannot transmit chat' };
+
+    const raw = (await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreTimerTriggers')) || '[]';
+    let triggers: MeshCoreTimerTrigger[] = [];
+    try { triggers = JSON.parse(raw); } catch { triggers = []; }
+    const trigger = triggers.find(t => t?.id === triggerId);
+    if (!trigger) return { ok: false, reason: 'trigger not found' };
+
+    // Pre-build the dispatch closure so the script + text paths route
+    // through identical destination logic. Returns false when the
+    // trigger has no destination — the caller surfaces that reason.
+    const dispatch = async (text: string): Promise<boolean> => {
+      if (trigger.destination === 'dm' && trigger.contactPublicKey) {
+        return this.sendMessage(text, trigger.contactPublicKey);
+      }
+      if (typeof trigger.channelIndex === 'number') {
+        return this.sendMessage(text, undefined, trigger.channelIndex);
+      }
+      return false;
+    };
+
+    let ok = true;
+    let reason: string | undefined;
+    try {
+      if (trigger.responseType === 'advert') {
+        ok = await this.sendAdvert();
+        if (!ok) reason = 'advert failed';
+      } else if (trigger.responseType === 'script') {
+        if (!trigger.scriptPath) {
+          ok = false;
+          reason = 'script trigger missing scriptPath';
+        } else if (trigger.destination !== 'dm' && typeof trigger.channelIndex !== 'number') {
+          ok = false;
+          reason = 'no destination configured';
+        } else {
+          const env = this.buildMeshCoreTimerScriptEnv(trigger);
+          const result = await this.runMeshCoreScript(trigger.scriptPath, trigger.scriptArgs, env, dispatch, `Timer ${trigger.id}`);
+          ok = result.success;
+          if (!ok) reason = result.error || 'script execution failed';
+        }
+      } else {
+        const body = await replaceMeshCoreAnnounceTokens(trigger.response || '', this);
+        if (trigger.destination === 'dm' && trigger.contactPublicKey) {
+          ok = await dispatch(body);
+          if (!ok) reason = 'DM send failed';
+        } else if (typeof trigger.channelIndex === 'number') {
+          ok = await dispatch(body);
+          if (!ok) reason = 'channel send failed';
+        } else {
+          ok = false;
+          reason = 'no destination configured';
+        }
+      }
+    } catch (err) {
+      ok = false;
+      reason = (err as Error).message;
+    }
+
+    // Persist last-run state back into the trigger row.
+    const updated = triggers.map(t => t?.id === triggerId
+      ? { ...t, lastRun: Date.now(), lastResult: ok ? 'success' as const : 'error' as const, lastError: ok ? undefined : reason }
+      : t);
+    await databaseService.settings.setSourceSetting(this.sourceId, 'meshcoreTimerTriggers', JSON.stringify(updated));
+
+    return { ok, reason };
+  }
+
+  // ============ Auto-Responder ============
+  //
+  // Multi-pattern incoming-message reactor. Mirrors the high-level
+  // shape of the Meshtastic AutoResponder but intentionally narrower:
+  // text responses only, no script/HTTP/traceroute branches in v1.
+  // Triggers are read live on each message so a settings save takes
+  // effect on the next incoming packet without a restart.
+
+  private autoResponderRegexCache: Map<string, RegExp | null> = new Map();
+
+  /**
+   * Build the env map for a script invocation triggered by an incoming
+   * message. Variable names are intentionally shared with the
+   * Meshtastic side (MESSAGE, FROM_NODE, NODE_ID, CHANNEL, IS_DIRECT,
+   * SNR, FROM_LONG_NAME, FROM_SHORT_NAME) so a script that targets
+   * common fields runs on both stacks. MeshCore-specific values get
+   * MESHCORE_-prefixed names.
+   */
+  private buildMeshCoreResponderScriptEnv(
+    message: MeshCoreMessage,
+    isDM: boolean,
+    channelIdx: number | undefined,
+    trigger: MeshCoreAutoResponderTrigger,
+  ): Record<string, string> {
+    const env: Record<string, string> = {
+      MESSAGE: message.text || '',
+      FROM_NODE: message.fromPublicKey || '',
+      NODE_ID: message.fromPublicKey ? message.fromPublicKey.substring(0, 16) : '',
+      CHANNEL: typeof channelIdx === 'number' ? String(channelIdx) : '',
+      IS_DIRECT: String(isDM),
+      TRIGGER: trigger.pattern || '',
+      MESHCORE_SOURCE_ID: this.sourceId,
+      MESHCORE_DEVICE_TYPE: this.deviceType === MeshCoreDeviceType.COMPANION ? 'companion'
+                          : this.deviceType === MeshCoreDeviceType.REPEATER ? 'repeater'
+                          : this.deviceType === MeshCoreDeviceType.ROOM_SERVER ? 'room_server'
+                          : 'unknown',
+    };
+    if (message.snr !== undefined && message.snr !== null) {
+      env.SNR = String(message.snr);
+    }
+    if (message.fromName) {
+      env.FROM_LONG_NAME = message.fromName;
+      env.LONG_NAME = message.fromName;
+    }
+    // Resolve the sender contact to fill in the names — handleBridgeEvent
+    // only carries `pubkey_prefix`, so the friendly name lives on the
+    // cached contact, not the message itself.
+    const contact = this.resolveContactByPrefix(message.fromPublicKey);
+    if (contact) {
+      if (contact.advName || contact.name) {
+        const long = contact.advName || contact.name || '';
+        env.FROM_LONG_NAME = long;
+        env.LONG_NAME = long;
+        env.FROM_SHORT_NAME = long.substring(0, 4);
+        env.SHORT_NAME = long.substring(0, 4);
+      }
+      env.FROM_PUBLIC_KEY = contact.publicKey;
+    }
+    if (this.localNode?.name) env.NODE_LONG_NAME = this.localNode.name;
+    return env;
+  }
+
+  /**
+   * Build the env map for a script invocation triggered by a timer.
+   * Lighter than the responder env — there's no incoming-message
+   * context — but keeps TIMER_NAME / TIMER_ID so a timer script can
+   * branch on which trigger fired it.
+   */
+  private buildMeshCoreTimerScriptEnv(trigger: MeshCoreTimerTrigger): Record<string, string> {
+    const env: Record<string, string> = {
+      TIMER_NAME: trigger.name || '',
+      TIMER_ID: trigger.id,
+      TIMER_SCRIPT: trigger.scriptPath || '',
+      MESHCORE_SOURCE_ID: this.sourceId,
+      MESHCORE_DEVICE_TYPE: this.deviceType === MeshCoreDeviceType.COMPANION ? 'companion'
+                          : this.deviceType === MeshCoreDeviceType.REPEATER ? 'repeater'
+                          : this.deviceType === MeshCoreDeviceType.ROOM_SERVER ? 'room_server'
+                          : 'unknown',
+    };
+    if (typeof trigger.channelIndex === 'number') env.CHANNEL = String(trigger.channelIndex);
+    if (this.localNode?.name) env.NODE_LONG_NAME = this.localNode.name;
+    return env;
+  }
+
+  /** Whitespace-tokenize an argv string. Quoted segments stay intact. */
+  private parseScriptArgsString(s: string): string[] {
+    if (!s) return [];
+    const out: string[] = [];
+    const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(s)) !== null) {
+      out.push(m[1] ?? m[2] ?? m[3] ?? '');
+    }
+    return out;
+  }
+
+  /**
+   * Common script-execution path used by both auto-responder and timer
+   * trigger code. Runs the script, then sends each `wouldSendMessages`
+   * entry through the supplied dispatch callback. Errors are logged
+   * but never thrown — message-loop callers shouldn't crash on a bad
+   * script.
+   */
+  private async runMeshCoreScript(
+    scriptPath: string,
+    scriptArgsString: string | undefined,
+    env: Record<string, string>,
+    dispatch: (text: string) => Promise<boolean>,
+    triggerLabel: string,
+  ): Promise<RunScriptResult> {
+    const expandedArgs = scriptArgsString
+      ? await replaceMeshCoreAnnounceTokens(scriptArgsString, this)
+      : '';
+    const argv = this.parseScriptArgsString(expandedArgs);
+    const result = await runScript({ scriptPath, scriptArgs: argv, env });
+
+    if (!result.success) {
+      logger.warn(`[MeshCore:${this.sourceId}] ${triggerLabel} script error: ${result.error}${result.stderr ? ` | stderr: ${result.stderr.substring(0, 200)}` : ''}`);
+      return result;
+    }
+
+    for (const msg of result.wouldSendMessages) {
+      const trimmed = (msg || '').trim();
+      if (!trimmed) continue;
+      try {
+        const ok = await dispatch(trimmed);
+        if (!ok) {
+          logger.warn(`[MeshCore:${this.sourceId}] ${triggerLabel} script: send failed for "${trimmed.substring(0, 50)}"`);
+        }
+      } catch (err) {
+        logger.warn(`[MeshCore:${this.sourceId}] ${triggerLabel} script: send threw: ${(err as Error).message}`);
+      }
+    }
+    return result;
+  }
+
+  private getAutoResponderRegex(pattern: string): RegExp | null {
+    if (this.autoResponderRegexCache.has(pattern)) {
+      return this.autoResponderRegexCache.get(pattern)!;
+    }
+    // Reuse the auto-ack validator so ReDoS-shaped patterns are
+    // rejected the same way at both surfaces.
+    const compiled = compileAutoAckRegex(pattern).regex;
+    this.autoResponderRegexCache.set(pattern, compiled);
+    return compiled;
+  }
+
+  /**
+   * On every incoming MeshCore message, run every enabled trigger's
+   * regex; on the first match, render the response template and send
+   * it. Subsequent triggers are still checked — multiple matches mean
+   * multiple replies, which is the documented behavior.
+   */
+  private async checkAutoResponder(
+    message: MeshCoreMessage,
+    isDM: boolean,
+    channelIdx: number | undefined,
+  ): Promise<void> {
+    try {
+      const enabledRaw = await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoResponderEnabled');
+      if (enabledRaw !== 'true') return;
+
+      const raw = (await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreAutoResponderTriggers')) || '[]';
+      let triggers: MeshCoreAutoResponderTrigger[] = [];
+      try {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) triggers = parsed as MeshCoreAutoResponderTrigger[];
+      } catch {
+        return;
+      }
+
+      const text = message.text || '';
+      if (!text) return;
+
+      // Don't self-reply.
+      if (this.localNode && message.fromPublicKey === this.localNode.publicKey) {
+        return;
+      }
+
+      for (const trigger of triggers) {
+        if (!trigger || !trigger.enabled || !trigger.pattern) continue;
+
+        // Channel / DM filter.
+        if (isDM && !trigger.listenDMs) continue;
+        if (!isDM) {
+          if (!Array.isArray(trigger.channels) || trigger.channels.length === 0) continue;
+          if (typeof channelIdx !== 'number' || !trigger.channels.includes(channelIdx)) continue;
+        }
+
+        const regex = this.getAutoResponderRegex(trigger.pattern);
+        if (!regex) {
+          logger.warn(`[MeshCore:${this.sourceId}] Auto-responder ${trigger.id}: invalid regex "${trigger.pattern}"`);
+          continue;
+        }
+        if (!regex.test(text)) continue;
+
+        // Cooldown gate.
+        const cooldownMs = Math.max(0, Math.min(3600, trigger.cooldownSeconds || 0)) * 1000;
+        if (cooldownMs > 0) {
+          const cooldownKey = `${trigger.id}:${message.fromPublicKey || 'unknown'}`;
+          const last = this.autoResponderCooldowns.get(cooldownKey) || 0;
+          if (Date.now() - last < cooldownMs) continue;
+          this.autoResponderCooldowns.set(cooldownKey, Date.now());
+        }
+
+        // Build the dispatch closure once — it captures where the
+        // response should go (DM to sender vs channel) so the script
+        // path and text path can share it.
+        const senderContact = this.resolveContactByPrefix(message.fromPublicKey);
+        const dispatch = async (text: string): Promise<boolean> => {
+          if (trigger.replyAsDM || isDM) {
+            const targetKey = senderContact?.publicKey || message.fromPublicKey;
+            return this.sendMessage(text, targetKey);
+          }
+          if (typeof channelIdx === 'number') {
+            return this.sendMessage(text, undefined, channelIdx);
+          }
+          return false;
+        };
+
+        if (trigger.responseType === 'script') {
+          if (!trigger.scriptPath) {
+            logger.warn(`[MeshCore:${this.sourceId}] Auto-responder ${trigger.id}: script trigger missing scriptPath`);
+            continue;
+          }
+          const env = this.buildMeshCoreResponderScriptEnv(message, isDM, channelIdx, trigger);
+          await this.runMeshCoreScript(trigger.scriptPath, trigger.scriptArgs, env, dispatch, `Auto-responder ${trigger.id}`);
+          continue;
+        }
+
+        const body = await replaceMeshCoreAnnounceTokens(trigger.response || '', this);
+        if (!body.trim()) continue;
+
+        try {
+          await dispatch(body);
+        } catch (err) {
+          logger.warn(`[MeshCore:${this.sourceId}] Auto-responder ${trigger.id} send failed: ${(err as Error).message}`);
+        }
+      }
+    } catch (err) {
+      logger.warn(`[MeshCore:${this.sourceId}] Auto-responder check threw: ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * Drop the cached compiled-regex Map so a freshly-saved pattern
+   * recompiles on the next message. Called by the save route after a
+   * triggers update.
+   */
+  resetAutoResponderRegexCache(): void {
+    this.autoResponderRegexCache.clear();
   }
 
   // ============ Auto-Acknowledge ============

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -2440,6 +2440,328 @@ router.post(
   },
 );
 
+// ============ Auto-Announce Automation ============
+//
+// Per-source settings + actions for MeshCore auto-announce. The
+// scheduler lives on the manager (`startAutoAnnounce`,
+// `runAutoAnnounceCycle`); this surface is the CRUD + manual-fire +
+// preview wrapper the UI calls.
+
+router.get(
+  '/automation/announce',
+  optionalAuth(),
+  requirePermission('automation', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id?: string }).id!;
+      const settings = databaseService.settings;
+
+      const enabled = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceEnabled');
+      const intervalHours = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceIntervalHours');
+      const message = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceMessage');
+      const channelIndexesRaw = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceChannelIndexes');
+      const announceOnStart = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceOnStart');
+      const useSchedule = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceUseSchedule');
+      const schedule = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceSchedule');
+      const advertEnabled = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceAdvertEnabled');
+      const advertDelaySeconds = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceAdvertDelaySeconds');
+      const lastRunAt = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceLastRunAt');
+
+      res.json({
+        success: true,
+        data: {
+          enabled: enabled === 'true',
+          intervalHours: parseInt(intervalHours || '6', 10) || 6,
+          message: message || 'MeshMonitor {VERSION} online for {DURATION} — {CONTACTCOUNT} contacts',
+          channelIndexes: (channelIndexesRaw || '')
+            .split(',')
+            .map(s => s.trim())
+            .filter(Boolean)
+            .map(s => parseInt(s, 10))
+            .filter(n => Number.isFinite(n)),
+          announceOnStart: announceOnStart === 'true',
+          useSchedule: useSchedule === 'true',
+          schedule: schedule || '0 */6 * * *',
+          advertEnabled: advertEnabled === 'true',
+          advertDelaySeconds: parseInt(advertDelaySeconds || '30', 10) || 30,
+          lastRunAt: lastRunAt ? parseInt(lastRunAt, 10) || null : null,
+        },
+      });
+    } catch (error) {
+      logger.error('[API] Error reading meshcore auto-announce settings:', error);
+      res.status(500).json({ success: false, error: 'Failed to read auto-announce settings' });
+    }
+  },
+);
+
+router.post(
+  '/automation/announce',
+  requireAuth(),
+  requirePermission('automation', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id?: string }).id!;
+      const settings = databaseService.settings;
+      const {
+        enabled,
+        intervalHours,
+        message,
+        channelIndexes,
+        announceOnStart,
+        useSchedule,
+        schedule,
+        advertEnabled,
+        advertDelaySeconds,
+      } = req.body as {
+        enabled?: boolean;
+        intervalHours?: number;
+        message?: string;
+        channelIndexes?: number[];
+        announceOnStart?: boolean;
+        useSchedule?: boolean;
+        schedule?: string;
+        advertEnabled?: boolean;
+        advertDelaySeconds?: number;
+      };
+
+      if (enabled !== undefined) {
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAnnounceEnabled', String(enabled));
+      }
+      if (intervalHours !== undefined) {
+        const clamped = Math.max(1, Math.min(168, Math.floor(intervalHours) || 6));
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAnnounceIntervalHours', String(clamped));
+      }
+      if (message !== undefined) {
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAnnounceMessage', String(message));
+      }
+      if (channelIndexes !== undefined) {
+        const csv = Array.isArray(channelIndexes)
+          ? channelIndexes.filter(n => Number.isFinite(n)).join(',')
+          : '';
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAnnounceChannelIndexes', csv);
+      }
+      if (announceOnStart !== undefined) {
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAnnounceOnStart', String(announceOnStart));
+      }
+      if (useSchedule !== undefined) {
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAnnounceUseSchedule', String(useSchedule));
+      }
+      if (schedule !== undefined) {
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAnnounceSchedule', String(schedule));
+      }
+      if (advertEnabled !== undefined) {
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAnnounceAdvertEnabled', String(advertEnabled));
+      }
+      if (advertDelaySeconds !== undefined) {
+        const clamped = Math.max(0, Math.min(600, Math.floor(advertDelaySeconds) || 30));
+        await settings.setSourceSetting(sourceId, 'meshcoreAutoAnnounceAdvertDelaySeconds', String(clamped));
+      }
+
+      // Re-arm the scheduler so the new settings take effect immediately.
+      const mgr = meshcoreManagerRegistry.get(sourceId);
+      if (mgr) {
+        await mgr.startAutoAnnounce().catch((err: Error) =>
+          logger.warn(`[API] auto-announce restart after save failed: ${err.message}`));
+      }
+
+      const lastRunRaw = await settings.getSettingForSource(sourceId, 'meshcoreAutoAnnounceLastRunAt');
+      res.json({
+        success: true,
+        data: {
+          lastRunAt: lastRunRaw ? parseInt(lastRunRaw, 10) || null : null,
+        },
+      });
+    } catch (error) {
+      logger.error('[API] Error saving meshcore auto-announce settings:', error);
+      res.status(500).json({ success: false, error: 'Failed to save auto-announce settings' });
+    }
+  },
+);
+
+router.get(
+  '/automation/announce/preview',
+  optionalAuth(),
+  requirePermission('automation', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const mgr = managerFor(req);
+      const message = String(req.query.message ?? '');
+      if (!message) {
+        return res.status(400).json({ success: false, error: 'Missing message parameter' });
+      }
+      const preview = await mgr.previewAnnouncementMessage(message);
+      res.json({ success: true, preview });
+    } catch (error) {
+      logger.error('[API] Error generating meshcore announce preview:', error);
+      res.status(500).json({ success: false, error: 'Failed to generate preview' });
+    }
+  },
+);
+
+router.post(
+  '/automation/announce/send',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('automation', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const mgr = managerFor(req);
+      const result = await mgr.runAutoAnnounceCycle('manual');
+      const status = mgr.getAutoAnnounceStatus();
+      res.json({ success: true, data: { ...result, lastRunAt: status.lastRunAt || null } });
+    } catch (error) {
+      logger.error('[API] Error sending manual meshcore announce:', error);
+      res.status(500).json({ success: false, error: 'Failed to send announcement' });
+    }
+  },
+);
+
+// ============ Timer Triggers Automation ============
+//
+// Triggers persist as a JSON array; the manager re-reads on schedule
+// fire so a freshly-saved template applies on the next tick. The
+// shared MeshCoreTimerTrigger type lives in src/server/meshcoreManager.ts.
+
+router.get(
+  '/automation/timers',
+  optionalAuth(),
+  requirePermission('automation', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id?: string }).id!;
+      const raw = (await databaseService.settings.getSettingForSource(sourceId, 'meshcoreTimerTriggers')) || '[]';
+      let triggers: unknown = [];
+      try { triggers = JSON.parse(raw); } catch { triggers = []; }
+      res.json({ success: true, data: { triggers: Array.isArray(triggers) ? triggers : [] } });
+    } catch (error) {
+      logger.error('[API] Error reading meshcore timer triggers:', error);
+      res.status(500).json({ success: false, error: 'Failed to read timer triggers' });
+    }
+  },
+);
+
+router.post(
+  '/automation/timers',
+  requireAuth(),
+  requirePermission('automation', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id?: string }).id!;
+      const body = req.body as { triggers?: unknown };
+      if (!Array.isArray(body.triggers)) {
+        return res.status(400).json({ success: false, error: 'triggers must be an array' });
+      }
+      await databaseService.settings.setSourceSetting(sourceId, 'meshcoreTimerTriggers', JSON.stringify(body.triggers));
+
+      const mgr = meshcoreManagerRegistry.get(sourceId);
+      if (mgr) {
+        await mgr.startTimerTriggers().catch((err: Error) =>
+          logger.warn(`[API] timer-trigger restart after save failed: ${err.message}`));
+      }
+
+      res.json({ success: true });
+    } catch (error) {
+      logger.error('[API] Error saving meshcore timer triggers:', error);
+      res.status(500).json({ success: false, error: 'Failed to save timer triggers' });
+    }
+  },
+);
+
+router.post(
+  '/automation/timers/:triggerId/run',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('automation', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const mgr = managerFor(req);
+      const triggerId = String((req.params as { triggerId?: string }).triggerId || '');
+      if (!triggerId) {
+        return res.status(400).json({ success: false, error: 'triggerId required' });
+      }
+      const result = await mgr.runTimerTrigger(triggerId);
+      res.json({ success: result.ok, data: result });
+    } catch (error) {
+      logger.error('[API] Error running meshcore timer trigger:', error);
+      res.status(500).json({ success: false, error: 'Failed to run timer trigger' });
+    }
+  },
+);
+
+// ============ Auto-Responder Automation ============
+//
+// Multi-pattern reactor. Triggers persist as a JSON array and the
+// manager re-reads them on every incoming message so a saved pattern
+// fires on the next packet without a restart.
+
+router.get(
+  '/automation/responder',
+  optionalAuth(),
+  requirePermission('automation', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id?: string }).id!;
+      const enabled = await databaseService.settings.getSettingForSource(sourceId, 'meshcoreAutoResponderEnabled');
+      const raw = (await databaseService.settings.getSettingForSource(sourceId, 'meshcoreAutoResponderTriggers')) || '[]';
+      let triggers: unknown = [];
+      try { triggers = JSON.parse(raw); } catch { triggers = []; }
+      res.json({
+        success: true,
+        data: {
+          enabled: enabled === 'true',
+          triggers: Array.isArray(triggers) ? triggers : [],
+        },
+      });
+    } catch (error) {
+      logger.error('[API] Error reading meshcore auto-responder settings:', error);
+      res.status(500).json({ success: false, error: 'Failed to read auto-responder settings' });
+    }
+  },
+);
+
+router.post(
+  '/automation/responder',
+  requireAuth(),
+  requirePermission('automation', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id?: string }).id!;
+      const body = req.body as { enabled?: boolean; triggers?: unknown };
+
+      if (body.enabled !== undefined) {
+        await databaseService.settings.setSourceSetting(sourceId, 'meshcoreAutoResponderEnabled', String(body.enabled));
+      }
+      if (body.triggers !== undefined) {
+        if (!Array.isArray(body.triggers)) {
+          return res.status(400).json({ success: false, error: 'triggers must be an array' });
+        }
+        // Validate each trigger's regex up front so a broken pattern
+        // never reaches the message loop. Reuses the same validator
+        // the manager applies at execution time.
+        for (const tr of body.triggers as Array<{ id?: string; pattern?: string }>) {
+          if (typeof tr?.pattern !== 'string') continue;
+          const v = validateAutoAckRegex(tr.pattern);
+          if (!v.ok) {
+            return res.status(400).json({
+              success: false,
+              error: `Invalid regex for trigger ${tr.id || '(unnamed)'}: ${v.error}`,
+            });
+          }
+        }
+        await databaseService.settings.setSourceSetting(sourceId, 'meshcoreAutoResponderTriggers', JSON.stringify(body.triggers));
+      }
+
+      const mgr = meshcoreManagerRegistry.get(sourceId);
+      if (mgr) mgr.resetAutoResponderRegexCache();
+
+      res.json({ success: true });
+    } catch (error) {
+      logger.error('[API] Error saving meshcore auto-responder settings:', error);
+      res.status(500).json({ success: false, error: 'Failed to save auto-responder settings' });
+    }
+  },
+);
+
 // ---------------------------------------------------------------------------
 // POST /api/sources/:id/meshcore/neighbors/request
 // Request neighbor data from a MeshCore repeater (remote or local).

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9725,6 +9725,12 @@ apiRouter.post('/scripts/test', requirePermission('settings', 'read'), async (re
       timerId,
       // Mock node info (optional)
       mockNode,
+      // Protocol discriminator. Defaults to 'meshtastic' for backwards
+      // compatibility. When 'meshcore', adds MESHCORE_* env vars so a
+      // MeshCore-targeting script can branch on which stack invoked it.
+      protocol = 'meshtastic',
+      meshcoreSourceId,
+      meshcoreDeviceType,
     } = req.body;
 
     // Validate based on trigger type
@@ -9998,6 +10004,14 @@ apiRouter.post('/scripts/test', requirePermission('settings', 'read'), async (re
     scriptEnv.MESHTASTIC_IP = meshtasticIp;
     scriptEnv.MESHTASTIC_PORT = meshtasticPort;
     scriptEnv.VERSION = process.env.VERSION || 'test';
+
+    // Protocol discriminator. Leaves the MESHTASTIC_* vars in place
+    // (harmless for MeshCore scripts) but adds MESHCORE_* so scripts
+    // can branch on which stack invoked them.
+    if (protocol === 'meshcore') {
+      scriptEnv.MESHCORE_SOURCE_ID = String(meshcoreSourceId || 'test-source');
+      scriptEnv.MESHCORE_DEVICE_TYPE = String(meshcoreDeviceType || 'companion');
+    }
 
     // Build script arguments if provided
     const scriptArgList: string[] = [resolvedPath];

--- a/src/server/utils/meshcoreAnnounceTokens.test.ts
+++ b/src/server/utils/meshcoreAnnounceTokens.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { replaceMeshCoreAnnounceTokens } from './meshcoreAnnounceTokens.js';
+import { MeshCoreDeviceType } from '../meshcoreManager.js';
+
+/**
+ * Token replacement is plain-text substitution with no I/O, so we mock
+ * the manager surface to exercise every branch without booting a
+ * MeshCoreManager instance.
+ */
+function makeManager(opts: {
+  contacts?: Array<{ advType: MeshCoreDeviceType }>;
+  local?: { name?: string; publicKey?: string } | null;
+}) {
+  return {
+    getContacts: vi.fn(() => opts.contacts || []),
+    getLocalNode: vi.fn(() => opts.local ?? null),
+  } as any;
+}
+
+describe('replaceMeshCoreAnnounceTokens', () => {
+  it('replaces version and duration using ctx overrides', async () => {
+    const mgr = makeManager({});
+    const out = await replaceMeshCoreAnnounceTokens(
+      'v{VERSION} up {DURATION}',
+      mgr,
+      { version: '9.9.9', uptimeMs: 65 * 60_000 },
+    );
+    expect(out).toBe('v9.9.9 up 1h 5m');
+  });
+
+  it('counts contacts by advType', async () => {
+    const mgr = makeManager({
+      contacts: [
+        { advType: MeshCoreDeviceType.COMPANION },
+        { advType: MeshCoreDeviceType.COMPANION },
+        { advType: MeshCoreDeviceType.REPEATER },
+        { advType: MeshCoreDeviceType.ROOM_SERVER },
+      ],
+    });
+    const out = await replaceMeshCoreAnnounceTokens(
+      '{CONTACTCOUNT} ({COMPANIONCOUNT}/{REPEATERCOUNT}/{ROOMCOUNT})',
+      mgr,
+      { version: 't', uptimeMs: 0 },
+    );
+    expect(out).toBe('4 (2/1/1)');
+  });
+
+  it('renders {NODE_NAME} and {NODE_ID} from the local node', async () => {
+    const mgr = makeManager({
+      local: { name: 'TestStation', publicKey: 'abcdef0123456789cafe' },
+    });
+    const out = await replaceMeshCoreAnnounceTokens('{NODE_NAME} #{NODE_ID}', mgr, {
+      version: 't',
+      uptimeMs: 0,
+    });
+    expect(out).toBe('TestStation #abcdef0123456789');
+  });
+
+  it('falls back gracefully when no manager is supplied', async () => {
+    const out = await replaceMeshCoreAnnounceTokens(
+      '{NODE_NAME} {CONTACTCOUNT} v{VERSION}',
+      null,
+      { version: '1.2.3', uptimeMs: 0 },
+    );
+    expect(out).toBe('MeshMonitor 0 v1.2.3');
+  });
+
+  it('leaves unknown tokens untouched (visible authoring error)', async () => {
+    const mgr = makeManager({});
+    const out = await replaceMeshCoreAnnounceTokens(
+      'hello {NOT_A_TOKEN} {VERSION}',
+      mgr,
+      { version: 'x', uptimeMs: 0 },
+    );
+    expect(out).toBe('hello {NOT_A_TOKEN} x');
+  });
+});

--- a/src/server/utils/meshcoreAnnounceTokens.ts
+++ b/src/server/utils/meshcoreAnnounceTokens.ts
@@ -1,0 +1,106 @@
+/**
+ * MeshCore announcement token replacement.
+ *
+ * Mirrors the Meshtastic auto-announce token expansion so operators
+ * familiar with the Meshtastic side can reuse muscle memory. Tokens are
+ * resolved against a MeshCoreManager: contact counts come from the
+ * manager's in-memory cache, uptime/version come from process state.
+ *
+ * The set intentionally stays narrow — `{VERSION}`, `{DURATION}`,
+ * `{CONTACTCOUNT}`, `{COMPANIONCOUNT}`, `{REPEATERCOUNT}`,
+ * `{ROOMCOUNT}`, `{NODE_NAME}`, `{NODE_ID}`. Adding more is cheap, but
+ * shapes the contract every consumer (announce, timer-trigger text,
+ * future auto-responder text) inherits.
+ */
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { MeshCoreDeviceType } from '../meshcoreManager.js';
+import type { MeshCoreManager } from '../meshcoreManager.js';
+
+let cachedVersion: string | null = null;
+
+async function readPackageVersion(): Promise<string> {
+  if (cachedVersion) return cachedVersion;
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    // utils/ → server/ → src/ → repo root
+    const pkgPath = path.resolve(here, '..', '..', '..', 'package.json');
+    const raw = await fs.readFile(pkgPath, 'utf8');
+    const pkg = JSON.parse(raw) as { version?: string };
+    cachedVersion = pkg.version || 'unknown';
+  } catch {
+    cachedVersion = 'unknown';
+  }
+  return cachedVersion;
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0 || parts.length === 0) parts.push(`${minutes}m`);
+  return parts.join(' ');
+}
+
+export interface MeshCoreAnnounceTokenContext {
+  /** Process uptime override for deterministic tests. */
+  uptimeMs?: number;
+  /** Version override for deterministic tests. */
+  version?: string;
+}
+
+/**
+ * Replace `{TOKEN}` placeholders in `template` with values from the
+ * supplied manager. Unknown tokens are left untouched (rather than
+ * silently dropped) so authoring mistakes are visible to the operator.
+ */
+export async function replaceMeshCoreAnnounceTokens(
+  template: string,
+  manager: MeshCoreManager | null,
+  ctx: MeshCoreAnnounceTokenContext = {},
+): Promise<string> {
+  const version = ctx.version ?? (await readPackageVersion());
+  const uptimeMs = ctx.uptimeMs ?? process.uptime() * 1000;
+
+  let contactCount = 0;
+  let companionCount = 0;
+  let repeaterCount = 0;
+  let roomCount = 0;
+  let nodeName = 'MeshMonitor';
+  let nodeId = '';
+
+  if (manager) {
+    try {
+      const contacts = manager.getContacts();
+      contactCount = contacts.length;
+      for (const c of contacts) {
+        if (c.advType === MeshCoreDeviceType.COMPANION) companionCount += 1;
+        else if (c.advType === MeshCoreDeviceType.REPEATER) repeaterCount += 1;
+        else if (c.advType === MeshCoreDeviceType.ROOM_SERVER) roomCount += 1;
+      }
+    } catch {
+      // Manager may not be connected yet — leave counts at 0.
+    }
+    const local = manager.getLocalNode?.();
+    if (local) {
+      nodeName = local.name || nodeName;
+      nodeId = local.publicKey ? local.publicKey.substring(0, 16) : '';
+    }
+  }
+
+  return template
+    .replace(/\{VERSION\}/g, version)
+    .replace(/\{DURATION\}/g, formatDuration(uptimeMs))
+    .replace(/\{CONTACTCOUNT\}/g, String(contactCount))
+    .replace(/\{COMPANIONCOUNT\}/g, String(companionCount))
+    .replace(/\{REPEATERCOUNT\}/g, String(repeaterCount))
+    .replace(/\{ROOMCOUNT\}/g, String(roomCount))
+    .replace(/\{NODE_NAME\}/g, nodeName)
+    .replace(/\{NODE_ID\}/g, nodeId);
+}

--- a/src/server/utils/scriptRunner.test.ts
+++ b/src/server/utils/scriptRunner.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { runScript, parseScriptOutput, resolveScriptPath } from './scriptRunner.js';
+
+/**
+ * Hosts a temporary scripts directory and points DATA_DIR at it so
+ * `resolveScriptPath` finds our fixtures. Each test writes the script
+ * it needs into this dir.
+ */
+let scriptsRoot: string;
+let scriptsDir: string;
+let originalDataDir: string | undefined;
+
+beforeAll(() => {
+  scriptsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'meshcore-scriptrunner-'));
+  scriptsDir = path.join(scriptsRoot, 'scripts');
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  originalDataDir = process.env.DATA_DIR;
+  process.env.DATA_DIR = scriptsRoot;
+});
+
+afterAll(() => {
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+  fs.rmSync(scriptsRoot, { recursive: true, force: true });
+});
+
+function writeScript(name: string, body: string): string {
+  const p = path.join(scriptsDir, name);
+  fs.writeFileSync(p, body, { mode: 0o755 });
+  return name;
+}
+
+describe('parseScriptOutput', () => {
+  it('returns empty messages for empty stdout', () => {
+    expect(parseScriptOutput('')).toEqual({ wouldSendMessages: [] });
+    expect(parseScriptOutput('   \n  ')).toEqual({ wouldSendMessages: [] });
+  });
+
+  it('treats raw stdout as one message when not JSON', () => {
+    expect(parseScriptOutput('hello from script\n')).toEqual({
+      wouldSendMessages: ['hello from script'],
+    });
+  });
+
+  it('extracts string `response` from JSON', () => {
+    const r = parseScriptOutput('{"response": "the answer"}');
+    expect(r.wouldSendMessages).toEqual(['the answer']);
+    expect(r.returnValue).toEqual({ response: 'the answer' });
+  });
+
+  it('extracts array `responses` from JSON', () => {
+    const r = parseScriptOutput('{"responses": ["a", "b"]}');
+    expect(r.wouldSendMessages).toEqual(['a', 'b']);
+  });
+
+  it('filters non-string entries from response array', () => {
+    const r = parseScriptOutput('{"response": ["ok", 42, null, "fine"]}');
+    expect(r.wouldSendMessages).toEqual(['ok', 'fine']);
+  });
+
+  it('exposes returnValue when JSON has no response/responses', () => {
+    const r = parseScriptOutput('{"foo": 1, "bar": 2}');
+    expect(r.wouldSendMessages).toEqual([]);
+    expect(r.returnValue).toEqual({ foo: 1, bar: 2 });
+  });
+
+  it('handles a bare JSON string as both response and returnValue', () => {
+    const r = parseScriptOutput('"single string"');
+    expect(r.wouldSendMessages).toEqual(['single string']);
+    expect(r.returnValue).toBe('single string');
+  });
+});
+
+describe('resolveScriptPath', () => {
+  it('rejects paths outside the scripts directory', () => {
+    const r = resolveScriptPath('../etc/passwd');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown extensions', () => {
+    writeScript('weird.exe', '#!/bin/sh\necho nope\n');
+    const r = resolveScriptPath('weird.exe');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/extension/);
+  });
+
+  it('resolves a bare filename to the scripts dir', () => {
+    writeScript('hello.sh', '#!/bin/sh\necho hi\n');
+    const r = resolveScriptPath('hello.sh');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.path).toBe(path.join(scriptsDir, 'hello.sh'));
+      expect(r.ext).toBe('sh');
+    }
+  });
+});
+
+describe('runScript', () => {
+  it('captures stdout and exposes wouldSendMessages from a JSON response', async () => {
+    writeScript('json-response.sh', '#!/bin/sh\necho \'{"response": "hi from script", "extra": 1}\'\n');
+    const r = await runScript({ scriptPath: 'json-response.sh', env: {} });
+    expect(r.success).toBe(true);
+    expect(r.wouldSendMessages).toEqual(['hi from script']);
+    expect(r.returnValue).toEqual({ response: 'hi from script', extra: 1 });
+    expect(r.executionTimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('treats non-JSON stdout as a single message', async () => {
+    writeScript('plain-text.sh', '#!/bin/sh\necho "plain text reply"\n');
+    const r = await runScript({ scriptPath: 'plain-text.sh', env: {} });
+    expect(r.success).toBe(true);
+    expect(r.wouldSendMessages).toEqual(['plain text reply']);
+  });
+
+  it('passes env to the script', async () => {
+    writeScript('echo-env.sh', '#!/bin/sh\necho "$MESHCORE_SOURCE_ID|$NODE_ID"\n');
+    const r = await runScript({
+      scriptPath: 'echo-env.sh',
+      env: { MESHCORE_SOURCE_ID: 'src-1', NODE_ID: 'abc1234567890def' },
+    });
+    expect(r.success).toBe(true);
+    expect(r.wouldSendMessages[0]).toBe('src-1|abc1234567890def');
+  });
+
+  it('passes argv to the script', async () => {
+    writeScript('echo-args.sh', '#!/bin/sh\necho "args:$1:$2"\n');
+    const r = await runScript({
+      scriptPath: 'echo-args.sh',
+      scriptArgs: ['first', 'second'],
+      env: {},
+    });
+    expect(r.success).toBe(true);
+    expect(r.wouldSendMessages[0]).toBe('args:first:second');
+  });
+
+  it('returns success=false with stderr when the script exits non-zero', async () => {
+    writeScript('fail.sh', '#!/bin/sh\necho "broke" 1>&2\nexit 7\n');
+    const r = await runScript({ scriptPath: 'fail.sh', env: {} });
+    expect(r.success).toBe(false);
+    expect(r.stderr).toMatch(/broke/);
+    expect(r.error).toBeTruthy();
+  });
+
+  it('reports a timeout when the script hangs longer than timeoutMs', async () => {
+    writeScript('hang.sh', '#!/bin/sh\nsleep 5\necho done\n');
+    const r = await runScript({ scriptPath: 'hang.sh', env: {}, timeoutMs: 250 });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/timed out/i);
+  });
+
+  it('returns a clear error when the script does not exist', async () => {
+    const r = await runScript({ scriptPath: 'missing-xyz.sh', env: {} });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/not found/i);
+  });
+
+  it('rejects paths outside the scripts directory', async () => {
+    const r = await runScript({ scriptPath: '../../etc/passwd', env: {} });
+    expect(r.success).toBe(false);
+  });
+});

--- a/src/server/utils/scriptRunner.ts
+++ b/src/server/utils/scriptRunner.ts
@@ -1,0 +1,213 @@
+/**
+ * Generic script runner used by both Meshtastic and MeshCore automation
+ * features. Spawns a script under one of three interpreters (node /
+ * python3 / sh) with a caller-supplied environment, captures stdout
+ * + stderr, and parses the stdout into a structured result.
+ *
+ * Stays protocol-neutral on purpose: callers build their own env map
+ * (FROM_NODE, NODE_ID, CHANNEL, MESHCORE_SOURCE_ID, …) and consume
+ * `wouldSendMessages` by sending through their own primitives. That
+ * keeps Meshtastic and MeshCore on a shared spawn/parse contract
+ * without coupling either to the other's data model.
+ *
+ * Path validation mirrors the existing inline runners in
+ * `meshtasticManager.ts` / `server.ts` (whitelist to scripts dir,
+ * extension allowlist, no traversal). Keep these aligned — both
+ * surfaces must agree on what's executable.
+ */
+import path from 'path';
+import fs from 'fs';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export interface RunScriptOptions {
+  /** Filename inside the scripts directory, or an absolute path resolved underneath it. */
+  scriptPath: string;
+  /** Already-parsed argv. Token expansion is the caller's job. */
+  scriptArgs?: string[];
+  /** Process env to expose to the script. Merged on top of process.env. */
+  env: Record<string, string>;
+  /** Hard kill timeout. Default 30s. */
+  timeoutMs?: number;
+}
+
+export interface RunScriptResult {
+  success: boolean;
+  /** Raw stdout captured from the script. */
+  stdout: string;
+  /** Raw stderr captured from the script. */
+  stderr: string;
+  /**
+   * Messages the script wants the caller to transmit on the mesh.
+   * Populated from `response`/`responses` in the script's JSON output,
+   * or a single entry equal to raw stdout if the output isn't JSON.
+   * Empty when the script produced no usable output.
+   */
+  wouldSendMessages: string[];
+  /** Parsed JSON output, if the script printed valid JSON. */
+  returnValue?: unknown;
+  /** Wall-clock execution time in ms. */
+  executionTimeMs: number;
+  /** When `success=false`, a short human-readable reason. */
+  error?: string;
+}
+
+const ALLOWED_EXTENSIONS = new Set(['js', 'mjs', 'py', 'sh']);
+
+/**
+ * Resolve a user-supplied script identifier to an absolute path inside
+ * the scripts directory. Rejects traversal (`..`) and anything outside
+ * the directory. Returns null if the file doesn't exist or isn't
+ * allowed.
+ */
+export function resolveScriptPath(scriptPath: string): { ok: true; path: string; ext: string } | { ok: false; error: string } {
+  // Mirror getScriptsDirectory() in server.ts: prefer DATA_DIR env var,
+  // fall back to /data. Tests can override DATA_DIR.
+  const scriptsDir = path.join(process.env.DATA_DIR || '/data', 'scripts');
+
+  // Allow caller to pass either a bare filename or a full path; either
+  // way the resolved path must live inside the scripts dir.
+  const candidate = path.isAbsolute(scriptPath) ? scriptPath : path.join(scriptsDir, scriptPath);
+  const resolved = path.resolve(candidate);
+  const normalizedDir = path.resolve(scriptsDir);
+  if (!resolved.startsWith(normalizedDir + path.sep) && resolved !== normalizedDir) {
+    return { ok: false, error: 'Script path escapes scripts directory' };
+  }
+  if (resolved.includes('..')) {
+    return { ok: false, error: 'Script path contains traversal' };
+  }
+  if (!fs.existsSync(resolved)) {
+    return { ok: false, error: `Script not found: ${path.basename(resolved)}` };
+  }
+  const ext = path.extname(resolved).slice(1).toLowerCase();
+  if (!ALLOWED_EXTENSIONS.has(ext)) {
+    return { ok: false, error: `Unsupported script extension: .${ext || '(none)'}` };
+  }
+  return { ok: true, path: resolved, ext };
+}
+
+/**
+ * Pick the interpreter binary for `ext`. In production builds inside
+ * the Docker image, system binaries aren't on PATH, so we point at
+ * the bundled-Node and the apprise venv's Python explicitly. In dev /
+ * desktop builds the system binaries are fine.
+ *
+ * Matches the existing inline logic in meshtasticManager / server so
+ * scripts behave identically across the two runners.
+ */
+export function pickInterpreter(ext: string): string {
+  const useSystemBin = process.env.NODE_ENV !== 'production' || process.env.IS_DESKTOP === 'true';
+  switch (ext) {
+    case 'js':
+    case 'mjs':
+      return useSystemBin ? 'node' : '/usr/local/bin/node';
+    case 'py':
+      return useSystemBin ? 'python3' : '/opt/apprise-venv/bin/python3';
+    case 'sh':
+      return useSystemBin ? 'sh' : '/bin/sh';
+    default:
+      throw new Error(`pickInterpreter: unsupported extension "${ext}"`);
+  }
+}
+
+/**
+ * Parse the script's stdout into the structured fields. Format
+ * contract:
+ *   - If stdout parses as JSON with a string `response` or string-array
+ *     `response`/`responses`, that becomes `wouldSendMessages`.
+ *   - If stdout parses as JSON otherwise, returnValue is set and
+ *     wouldSendMessages is empty.
+ *   - If stdout isn't JSON, the trimmed raw stdout is a single
+ *     `wouldSendMessages` entry (empty stdout → empty array).
+ *
+ * This mirrors the existing Meshtastic auto-responder / test-handler
+ * parsing so a script written for one stack works for the other.
+ */
+export function parseScriptOutput(stdout: string): { wouldSendMessages: string[]; returnValue?: unknown } {
+  const trimmed = stdout.trim();
+  if (!trimmed) return { wouldSendMessages: [] };
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed === 'string') {
+      return { wouldSendMessages: [parsed], returnValue: parsed };
+    }
+    if (parsed && typeof parsed === 'object') {
+      const obj = parsed as Record<string, unknown>;
+      let messages: string[] = [];
+      const candidate = obj.response ?? obj.responses;
+      if (typeof candidate === 'string') {
+        messages = [candidate];
+      } else if (Array.isArray(candidate)) {
+        messages = candidate.filter((v): v is string => typeof v === 'string');
+      }
+      return { wouldSendMessages: messages, returnValue: parsed };
+    }
+    return { wouldSendMessages: [String(parsed)], returnValue: parsed };
+  } catch {
+    return { wouldSendMessages: [trimmed] };
+  }
+}
+
+/**
+ * Spawn the script and return a structured result. Never throws —
+ * caller branches on `result.success`. Timeouts surface as
+ * `success=false, error='Script timed out (Ns)'`.
+ */
+export async function runScript(opts: RunScriptOptions): Promise<RunScriptResult> {
+  const start = Date.now();
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+
+  const resolved = resolveScriptPath(opts.scriptPath);
+  if (!resolved.ok) {
+    return {
+      success: false,
+      stdout: '',
+      stderr: '',
+      wouldSendMessages: [],
+      executionTimeMs: 0,
+      error: resolved.error,
+    };
+  }
+  const { path: resolvedPath, ext } = resolved;
+  const interpreter = pickInterpreter(ext);
+  const args = [resolvedPath, ...(opts.scriptArgs || [])];
+
+  try {
+    const { stdout, stderr } = await execFileAsync(interpreter, args, {
+      timeout: timeoutMs,
+      env: { ...process.env, ...opts.env },
+      maxBuffer: 1024 * 1024,
+    });
+    const parsed = parseScriptOutput(stdout);
+    return {
+      success: true,
+      stdout,
+      stderr,
+      wouldSendMessages: parsed.wouldSendMessages,
+      returnValue: parsed.returnValue,
+      executionTimeMs: Date.now() - start,
+    };
+  } catch (err) {
+    const e = err as Error & {
+      code?: string;
+      stdout?: string;
+      stderr?: string;
+      signal?: string;
+      killed?: boolean;
+    };
+    const timedOut = e.killed === true || e.signal === 'SIGTERM' || e.code === 'ETIMEDOUT';
+    return {
+      success: false,
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? '',
+      wouldSendMessages: [],
+      executionTimeMs: Date.now() - start,
+      error: timedOut
+        ? `Script timed out after ${Math.round(timeoutMs / 1000)}s`
+        : (e.message || 'Script execution failed'),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Brings the MeshCore Automation view up to parity with the Meshtastic automation surface by adding three per-source automations: **Auto-Announce**, **Auto-Responder**, and **Timer Triggers**. Operators connected via MeshCore can now broadcast scheduled status messages, auto-reply to incoming traffic, and run recurring text/advert/script actions — without dropping to the CLI or relying on external cron.

## Changes
- **Auto-Announce** — periodic templated status broadcast to selected channels on an interval (1–168h) or 5-field cron schedule; optional advert burst (0–600s after each send), announce-on-connection, live preview, and manual **Send Now**.
- **Auto-Responder** — regex-matched replies to incoming messages, replying with either a **text response** or a **script**, with per-channel/DM filtering and a per-sender cooldown to prevent loops.
- **Timer Triggers** — recurring **text / advert / script** actions, each on its own cron or interval, with last-run telemetry surfaced in the UI.
- **Shared token expansion** — all three use `replaceMeshCoreAnnounceTokens`, so the token set is identical (`{VERSION}`, `{DURATION}`, `{CONTACTCOUNT}`, `{COMPANIONCOUNT}`, `{REPEATERCOUNT}`, `{ROOMCOUNT}`, `{NODE_NAME}`, `{NODE_ID}`). A new shared `MeshCoreTokenLegend` renders the available-tokens list under every token-aware field.
- **Settings registration** — new per-source keys added to both `VALID_SETTINGS_KEYS` and `PER_SOURCE_SETTINGS_KEYS`.
- **`/scripts/test` protocol discriminator** — injects `MESHCORE_*` env vars so MeshCore-targeting scripts can branch on the invoking stack.
- Backend scheduler/state lives on `MeshCoreManager`; CRUD + preview + manual-fire routes added to `meshcoreRoutes.ts`.

## Issues Resolved
None — feature work.

## Documentation Updates
- `docs/features/meshcore.md` — new Auto-Announce / Auto-Responder / Timer Triggers sections under the Automation view.
- `CHANGELOG.md` — `[Unreleased] → Added` entry.

## Testing
- [x] Unit tests pass (full Vitest suite: 6277 tests; new `meshcoreAnnounceTokens` + `scriptRunner` suites green). One pre-existing flaky test in `mqttBridgeManager.test.ts` fails only under full-suite parallelism and passes in isolation (13/13) — unrelated to this change.
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Built and deployed to the dev container; verified the three sections render and the token legend appears under token-aware fields
- [ ] Reviewer: exercise interval vs cron scheduling, Send Now, an advert burst, a regex auto-responder reply, and a timer trigger firing a script

🤖 Generated with [Claude Code](https://claude.com/claude-code)