### PR TITLE
chore: bump version to 4.8.1 with changelog and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### Added
-- **MeshCore automation suite** — three new per-source automations in the MeshCore Automation view:
+## [4.8.1] - 2026-05-28
+
+# MeshMonitor v4.8.1
+
+Patch release combining a **MeshCore automation suite**, an auto-acknowledge automation tier, a connection-stability fix for TCP Meshtastic sources, and a round of security and input-validation hardening from CodeQL.
+
+## Features
+
+### MeshCore Automations
+
+- #3249 feat(meshcore): auto-announce, auto-responder, and timer triggers — three new per-source automations in the MeshCore Automation view:
   - **Auto-Announce** — periodically broadcast a templated status message to selected channels on an interval or cron schedule, with an optional advert burst, live preview, and Send Now.
   - **Auto-Responder** — reply to incoming messages matching an operator-defined regex with a text response or a script, with per-channel/DM filtering and per-sender cooldown.
   - **Timer Triggers** — schedule recurring text/advert/script actions, each on its own cron or interval.
   - Shared token expansion (`{VERSION}`, `{DURATION}`, `{CONTACTCOUNT}`, `{COMPANIONCOUNT}`, `{REPEATERCOUNT}`, `{ROOMCOUNT}`, `{NODE_NAME}`, `{NODE_ID}`) across all three, surfaced in the UI via an inline token legend.
+- #3245 feat(meshcore): auto-acknowledge automation with channels, DM, and macros — operator-configurable auto-ACK rules per source with per-channel/DM scope and templated macro responses.
+
+## Fixes
+
+- #3248 fix(stability): guard handleConnected against transport-swap race (#3247) — on TCP Meshtastic sources, `handleConnected` could observe `this.transport` get nulled during its own async setup chain (notifyNodeConnected, channel snapshot), causing `sendWantConfigId` to throw `Transport not initialized`. The catch block then treated that as a transient post-connect reset and tore down the (still-healthy) session, reproducing the same race on the next reconnect — producing a deterministic 3×/min reconnect loop on otherwise-fine TCP sockets. The handler now captures the transport reference at entry and the catch block distinguishes "transport went away mid-handshake" (silent bail) from a genuine transport-layer send failure (existing teardown path).
+- #3240 fix: add input validation for MeshCore neighbor publicKey parameters — validate-and-extract pubkey for neighbor endpoints to address CodeQL `js/user-controlled-bypass`.
+
+## Security
+
+- #3246 fix(security): remediate polynomial-ReDoS, log-injection, and regex-DoS CodeQL findings — hardens several user-input code paths against denial-of-service via crafted regular expressions and log-injection patterns surfaced by CodeQL static analysis.
+
+## Other
+
+- #3208 chore(i18n): translations update from Hosted Weblate.
 
 ## [4.8.0] - 2026-05-27
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # MeshMonitor — Claude Agent Brief
 
-**Version:** 4.8.0 (multi-source architecture)
+**Version:** 4.8.1 (multi-source architecture)
 **Stack:** React 19 + TS + Vite frontend / Node.js 20+ (Docker image ships Node 24; CI matrix covers 20/22/24/25) + Express 5 + TS backend / SQLite (default), PostgreSQL, MySQL via Drizzle ORM / Meshtastic protobuf-over-TCP and MeshCore (native `meshcore.js` for companion, serial CLI for repeater) through a per-source manager registry.
 
 ## Read order for new agents

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.8.0",
+  "version": "4.8.1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.8.0
-appVersion: "4.8.0"
+version: 4.8.1
+appVersion: "4.8.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.8.0",
+      "version": "4.8.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Patch release combining the MeshCore automation suite, an auto-acknowledge automation tier, the `handleConnected` transport-swap race fix that was producing deterministic 3×/min reconnect loops on TCP Meshtastic sources, MeshCore neighbor publicKey input validation, and CodeQL-driven security remediations.

### Included since 4.8.0

| # | Type | What |
|---|---|---|
| #3249 | feat(meshcore) | Auto-announce, auto-responder, and timer triggers — three per-source automations sharing a token-expansion engine |
| #3245 | feat(meshcore) | Auto-acknowledge automation with channels, DM, and macros |
| #3248 (#3247) | fix(stability) | Guard `handleConnected` against transport-swap race — eliminates 3×/min reconnect loops on healthy TCP sessions |
| #3240 | fix | MeshCore neighbor publicKey input validation (CodeQL `js/user-controlled-bypass`) |
| #3246 | security | Remediate polynomial-ReDoS, log-injection, and regex-DoS CodeQL findings |
| #3208 | i18n | Translations update from Hosted Weblate |

### Files touched

- `package.json`, `package-lock.json` — `4.8.0` → `4.8.1`
- `desktop/package.json`, `desktop/src-tauri/tauri.conf.json` — `4.8.0` → `4.8.1`
- `helm/meshmonitor/Chart.yaml` — `version` and `appVersion` → `4.8.1`
- `CLAUDE.md` — version header → `4.8.1`
- `CHANGELOG.md` — converted `[Unreleased]` (which already held the MeshCore-automation entry) into a full `[4.8.1] - 2026-05-28` release section covering all six post-4.8.0 commits, then reset `[Unreleased]` to empty.

## Test plan

- [x] All 5 version files updated and consistent
- [x] `npm install --package-lock-only --legacy-peer-deps` clean
- [ ] CI: full Vitest suite + system tests (labeled `system-test`)
- [ ] Helm chart lint
- [ ] Docker image builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)