### PR TITLE
fix(meshcore): make all mobile bottom-bar tabs reachable

### DIFF
--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -1265,12 +1265,15 @@
   .meshcore-sub-toolbar-item {
     flex-direction: column;
     gap: 0.2rem;
-    padding: 0.5rem 0.4rem;
+    padding: 0.5rem 0.2rem;
     margin: 0;
     border-radius: 0;
+    /* Share the row equally so every tab (up to 9: …Configuration,
+       Automations, Settings) stays on-screen without relying on a
+       horizontal scroll the user can't see. */
+    flex: 1 1 0;
+    min-width: 0;
     width: auto;
-    min-width: 56px;
-    flex-shrink: 0;
     text-align: center;
     justify-content: center;
     font-size: 0.7rem;
@@ -1286,7 +1289,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 64px;
+    max-width: 100%;
   }
 
   .meshcore-sub-toolbar-spacer {


### PR DESCRIPTION
## Summary
On MeshCore source pages, the Automation tab is unreachable on mobile. Under the 768px breakpoint the sub-toolbar becomes a horizontal bottom bar, but its 9 items were laid out at a fixed width that overflowed the viewport, pushing the last tabs (Automations, Settings) off the right edge behind a touch scrollbar the user can't see. This makes them effectively inaccessible. This PR makes every tab fit on screen.

## Changes
- `src/components/MeshCore/MeshCorePage.css` (mobile `@media (max-width: 768px)` block):
  - `.meshcore-sub-toolbar-item`: replaced `min-width: 56px; flex-shrink: 0` with `flex: 1 1 0; min-width: 0` so the 9 items share the row equally and all fit the viewport — no hidden horizontal scroll. Trimmed item padding (`.4rem` → `.2rem`).
  - `.meshcore-sub-toolbar-item .label`: `max-width: 64px` → `100%` so labels truncate cleanly with an ellipsis inside the narrower slot.
  - `overflow-x: auto` is left in place as a harmless safety net.

## Issues Resolved
None (reported directly).

## Documentation Updates
No documentation changes needed — purely a responsive CSS layout fix, no behavior or API change.

## Testing
- [x] Verified via isolated render of the exact toolbar markup + these rules at 360×720: before, scrollWidth 586px with Automations/Settings clipped off-screen (~5 of 9 tabs visible); after, scrollWidth == 360px with all 9 tabs visible and tappable (labels ellipsis-truncate).
- [ ] CI unit tests pass
- [ ] TypeScript compiles cleanly (CI)
- [ ] Reviewer manual check: open a MeshCore source page on a narrow phone viewport (≤400px) and confirm the Automations (🤖) and Settings (⚙) tabs are visible and tappable in the bottom bar without horizontal scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)