### PR TITLE
feat(map): add persisted Show Waypoints visibility toggle (#3253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- **Show Waypoints map toggle** (#3253): The Map Features panel on the dashboard and Nodes maps now has a **Show Waypoints** checkbox that controls waypoint marker visibility. Defaults to on and is persisted per-user via map preferences, alongside the existing Show RF / UDP / MQTT / Traceroute toggles.
+
 ## [4.8.1] - 2026-05-28
 
 # MeshMonitor v4.8.1

--- a/docs/features/maps.md
+++ b/docs/features/maps.md
@@ -86,7 +86,7 @@ When viewing traceroute data:
 
 ### Waypoints
 
-Waypoints — Meshtastic's `WAYPOINT_APP` pins — render directly on the per-source dashboard map and the Map Analysis canvas, using each waypoint's emoji as its icon. Users with `waypoints:write` can create, edit, and delete waypoints in place from the **Map Features** panel. See the dedicated [Waypoints](/features/waypoints) page for the full workflow, permissions, and REST API.
+Waypoints — Meshtastic's `WAYPOINT_APP` pins — render directly on the per-source dashboard map and the Map Analysis canvas, using each waypoint's emoji as its icon. Users with `waypoints:write` can create, edit, and delete waypoints in place from the **Map Features** panel. The same panel has a **Show Waypoints** checkbox (default on) that toggles waypoint marker visibility per-user — persisted alongside the other map feature toggles. See the dedicated [Waypoints](/features/waypoints) page for the full workflow, permissions, and REST API.
 
 ## Map Tilesets
 

--- a/docs/features/waypoints.md
+++ b/docs/features/waypoints.md
@@ -40,6 +40,10 @@ The unified "all sources" dashboard renders waypoints from every source you can 
 
 The Map Analysis canvas exposes a **Waypoints** layer in the toolbar. Toggle it to overlay every visible waypoint on top of the existing analysis layers (heatmap, traceroutes, etc.).
 
+### Showing and hiding waypoints
+
+The **Map Features** panel on both the per-source dashboard map and the Nodes map includes a **Show Waypoints** checkbox. Unchecking it hides all waypoint markers from that map without deleting any waypoints. The setting defaults to on, is saved per-user alongside the other Map Features toggles (Show RF / UDP / MQTT, Show Traceroute, etc.) via your map preferences, and persists across reloads and devices.
+
 ## Creating, editing, and deleting waypoints
 
 Authoring is available on the per-source dashboard map for users with `waypoints:write`.

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4327,6 +4327,7 @@
     "showUdp": "Show UDP",
     "showRf": "Show RF",
     "showMeshCore": "Show MeshCore",
+    "showWaypoints": "Show Waypoints",
     "showPositionHistory": "Show Position History",
     "showAnimations": "Show Animations",
     "showEstimatedPositions": "Show Estimated Positions",

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -140,6 +140,8 @@ export default function DashboardMap({
     setShowUdpNodes,
     showMqttNodes,
     setShowMqttNodes,
+    showWaypoints,
+    setShowWaypoints,
   } = useMapContext();
 
   // Build array of nodes that have valid positions, with their resolved lat/lng.
@@ -232,7 +234,7 @@ export default function DashboardMap({
 
         <MapBoundsUpdater positions={nodePositions} sourceId={sourceId} />
 
-        <DashboardWaypoints sourceId={sourceId} />
+        {showWaypoints && <DashboardWaypoints sourceId={sourceId} />}
 
         {nodesWithPosition.map(({ node, pos }) => {
           const hops = node.hopsAway ?? 999;
@@ -423,6 +425,14 @@ export default function DashboardMap({
               onChange={(e) => setShowMqttNodes(e.target.checked)}
             />
             <span>Show MQTT</span>
+          </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showWaypoints}
+              onChange={(e) => setShowWaypoints(e.target.checked)}
+            />
+            <span>Show Waypoints</span>
           </label>
         </div>
       </div>

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -311,6 +311,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     setShowUdpNodes,
     showRfNodes,
     setShowRfNodes,
+    showWaypoints,
+    setShowWaypoints,
     showAnimations,
     setShowAnimations,
     showEstimatedPositions,
@@ -1804,6 +1806,14 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                   <label className="map-control-item">
                     <input
                       type="checkbox"
+                      checked={showWaypoints}
+                      onChange={(e) => setShowWaypoints(e.target.checked)}
+                    />
+                    <span>{t('map.showWaypoints', 'Show Waypoints')}</span>
+                  </label>
+                  <label className="map-control-item">
+                    <input
+                      type="checkbox"
                       checked={showMotion}
                       onChange={(e) => setShowMotion(e.target.checked)}
                     />
@@ -2029,7 +2039,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 canCreate={canWriteWaypoints}
                 onPick={(lat, lon) => startCreateAtCoords(lat, lon)}
               />
-              <DashboardWaypoints sourceId={currentSourceId ?? null} actions={waypointActions} />
+              {showWaypoints && <DashboardWaypoints sourceId={currentSourceId ?? null} actions={waypointActions} />}
               <DefaultCenterController
                 lat={defaultMapCenterLat}
                 lon={defaultMapCenterLon}

--- a/src/contexts/MapContext.tsx
+++ b/src/contexts/MapContext.tsx
@@ -54,6 +54,8 @@ interface MapContextType {
   setShowRfNodes: (show: boolean) => void;
   showMeshCoreNodes: boolean;
   setShowMeshCoreNodes: (show: boolean) => void;
+  showWaypoints: boolean;
+  setShowWaypoints: (show: boolean) => void;
   showAnimations: boolean;
   setShowAnimations: (show: boolean) => void;
   showEstimatedPositions: boolean;
@@ -105,6 +107,8 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
   const [showUdpNodes, setShowUdpNodesState] = useState<boolean>(false);
   const [showRfNodes, setShowRfNodesState] = useState<boolean>(true);
   const [showMeshCoreNodes, setShowMeshCoreNodesState] = useState<boolean>(true);
+  // Waypoint markers default on (#3253) — opt-out toggle in the Map Features panel.
+  const [showWaypoints, setShowWaypointsState] = useState<boolean>(true);
   const [showAnimations, setShowAnimationsState] = useState<boolean>(false);
   const [meshCoreNodes, setMeshCoreNodes] = useState<MeshCoreMapNode[]>([]);
   const [showEstimatedPositions, setShowEstimatedPositionsState] = useState<boolean>(() => {
@@ -181,6 +185,11 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
   const setShowMeshCoreNodes = React.useCallback((value: boolean) => {
     setShowMeshCoreNodesState(value);
     savePreferenceToServer({ showMeshCoreNodes: value });
+  }, []);
+
+  const setShowWaypoints = React.useCallback((value: boolean) => {
+    setShowWaypointsState(value);
+    savePreferenceToServer({ showWaypoints: value });
   }, []);
 
   const setShowAnimations = React.useCallback((value: boolean) => {
@@ -293,6 +302,9 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
             if (preferences.showMeshCoreNodes !== undefined) {
               setShowMeshCoreNodesState(preferences.showMeshCoreNodes);
             }
+            if (preferences.showWaypoints !== undefined) {
+              setShowWaypointsState(preferences.showWaypoints);
+            }
             if (preferences.showAnimations !== undefined) {
               setShowAnimationsState(preferences.showAnimations);
             }
@@ -370,6 +382,8 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
         setShowRfNodes,
         showMeshCoreNodes,
         setShowMeshCoreNodes,
+        showWaypoints,
+        setShowWaypoints,
         meshCoreNodes,
         setMeshCoreNodes,
         showAnimations,

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 73 migrations registered', () => {
-    expect(registry.count()).toBe(73);
+  it('has all 74 migrations registered', () => {
+    expect(registry.count()).toBe(74);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is meshcore_neighbor_info', () => {
+  it('last migration is add_show_waypoints_to_map_prefs', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(73);
-    expect(last.name).toContain('meshcore_neighbor_info');
+    expect(last.number).toBe(74);
+    expect(last.name).toContain('add_show_waypoints_to_map_prefs');
   });
 
-  it('migrations are sequentially numbered from 1 to 73', () => {
+  it('migrations are sequentially numbered from 1 to 74', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -88,6 +88,7 @@ import { migration as meshcoreAdminCredentialMigration, runMigration070Postgres,
 import { migration as dropLegacyPskLengthCheckMigration, runMigration071Postgres, runMigration071Mysql } from '../server/migrations/071_drop_legacy_psk_length_check.js';
 import { migration as meshcoreRoomSyncMigration, runMigration072Postgres, runMigration072Mysql } from '../server/migrations/072_meshcore_room_sync.js';
 import { migration as meshcoreNeighborInfoMigration, runMigration073Postgres, runMigration073Mysql } from '../server/migrations/073_meshcore_neighbor_info.js';
+import { migration as addShowWaypointsToMapPrefsMigration, runMigration074Postgres, runMigration074Mysql } from '../server/migrations/074_add_show_waypoints_to_map_prefs.js';
 
 // ============================================================================
 // Registry
@@ -1164,4 +1165,19 @@ registry.register({
   sqlite: (db) => meshcoreNeighborInfoMigration.up(db),
   postgres: (client) => runMigration073Postgres(client),
   mysql: (pool) => runMigration073Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 074: Add `show_waypoints` column to user_map_preferences. Persists
+// the waypoint marker visibility toggle alongside the other Map Features
+// toggles. Default TRUE (opt-out) so existing installs keep showing waypoints.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 74,
+  name: 'add_show_waypoints_to_map_prefs',
+  settingsKey: 'migration_074_add_show_waypoints_to_map_prefs',
+  sqlite: (db) => addShowWaypointsToMapPrefsMigration.up(db),
+  postgres: (client) => runMigration074Postgres(client),
+  mysql: (pool) => runMigration074Mysql(pool),
 });

--- a/src/db/repositories/misc.mapprefs.test.ts
+++ b/src/db/repositories/misc.mapprefs.test.ts
@@ -22,3 +22,20 @@ describe('userMapPreferencesSqlite — SQL column alignment (#2713)', () => {
     expect(col.name).toBe('user_id');
   });
 });
+
+describe('userMapPreferences — showWaypoints toggle (#3253)', () => {
+  it('maps JS `showWaypoints` → SQL column `show_waypoints` on all three backends', () => {
+    const sqlite = (schema.userMapPreferencesSqlite as unknown as {
+      showWaypoints: { name: string };
+    }).showWaypoints;
+    const pg = (schema.userMapPreferencesPostgres as unknown as {
+      showWaypoints: { name: string };
+    }).showWaypoints;
+    const mysql = (schema.userMapPreferencesMysql as unknown as {
+      showWaypoints: { name: string };
+    }).showWaypoints;
+    expect(sqlite.name).toBe('show_waypoints');
+    expect(pg.name).toBe('show_waypoints');
+    expect(mysql.name).toBe('show_waypoints');
+  });
+});

--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -1831,7 +1831,10 @@ export class MiscRepository extends BaseRepository {
         showRoute: row.showRoute ?? true,
         showMotion: row.showMotion ?? true,
         showMqttNodes: row.showMqttNodes ?? true,
+        showUdpNodes: row.showUdpNodes ?? false,
+        showRfNodes: row.showRfNodes ?? true,
         showMeshCoreNodes: row.showMeshcoreNodes ?? true,
+        showWaypoints: row.showWaypoints ?? true,
         showAnimations: row.showAnimations ?? false,
         showAccuracyRegions: row.showAccuracyRegions ?? false,
         showEstimatedPositions: row.showEstimatedPositions ?? false,
@@ -1856,6 +1859,7 @@ export class MiscRepository extends BaseRepository {
     showUdpNodes?: boolean;
     showRfNodes?: boolean;
     showMeshCoreNodes?: boolean;
+    showWaypoints?: boolean;
     showAnimations?: boolean;
     showAccuracyRegions?: boolean;
     showEstimatedPositions?: boolean;
@@ -1880,6 +1884,7 @@ export class MiscRepository extends BaseRepository {
         if (preferences.showUdpNodes !== undefined) set.showUdpNodes = preferences.showUdpNodes;
         if (preferences.showRfNodes !== undefined) set.showRfNodes = preferences.showRfNodes;
         if (preferences.showMeshCoreNodes !== undefined) set.showMeshcoreNodes = preferences.showMeshCoreNodes;
+        if (preferences.showWaypoints !== undefined) set.showWaypoints = preferences.showWaypoints;
         if (preferences.showAnimations !== undefined) set.showAnimations = preferences.showAnimations;
         if (preferences.showAccuracyRegions !== undefined) set.showAccuracyRegions = preferences.showAccuracyRegions;
         if (preferences.showEstimatedPositions !== undefined) set.showEstimatedPositions = preferences.showEstimatedPositions;
@@ -1901,6 +1906,7 @@ export class MiscRepository extends BaseRepository {
           showUdpNodes: preferences.showUdpNodes ?? false,
           showRfNodes: preferences.showRfNodes ?? true,
           showMeshcoreNodes: preferences.showMeshCoreNodes ?? true,
+          showWaypoints: preferences.showWaypoints ?? true,
           showAnimations: preferences.showAnimations ?? false,
           showAccuracyRegions: preferences.showAccuracyRegions ?? false,
           showEstimatedPositions: preferences.showEstimatedPositions ?? true,

--- a/src/db/schema/misc.ts
+++ b/src/db/schema/misc.ts
@@ -106,6 +106,9 @@ export const userMapPreferencesSqlite = sqliteTable('user_map_preferences', {
   showUdpNodes: integer('show_udp_nodes', { mode: 'boolean' }).default(false),
   showRfNodes: integer('show_rf_nodes', { mode: 'boolean' }).default(true),
   showMeshcoreNodes: integer('show_meshcore_nodes', { mode: 'boolean' }).default(true),
+  // Waypoint marker visibility (#3253). Default true so existing users keep
+  // seeing waypoints they've placed; opt-out via the Map Features panel.
+  showWaypoints: integer('show_waypoints', { mode: 'boolean' }).default(true),
   showAnimations: integer('show_animations', { mode: 'boolean' }).default(false),
   showAccuracyRegions: integer('show_accuracy_regions', { mode: 'boolean' }).default(false),
   showEstimatedPositions: integer('show_estimated_positions', { mode: 'boolean' }).default(false),
@@ -130,6 +133,7 @@ export const userMapPreferencesPostgres = pgTable('user_map_preferences', {
   showUdpNodes: pgBoolean('show_udp_nodes').default(false),
   showRfNodes: pgBoolean('show_rf_nodes').default(true),
   showMeshcoreNodes: pgBoolean('show_meshcore_nodes').default(true),
+  showWaypoints: pgBoolean('show_waypoints').default(true),
   showAnimations: pgBoolean('show_animations').default(false),
   showAccuracyRegions: pgBoolean('show_accuracy_regions').default(false),
   showEstimatedPositions: pgBoolean('show_estimated_positions').default(false),
@@ -387,6 +391,7 @@ export const userMapPreferencesMysql = mysqlTable('user_map_preferences', {
   showUdpNodes: myBoolean('show_udp_nodes').default(false),
   showRfNodes: myBoolean('show_rf_nodes').default(true),
   showMeshcoreNodes: myBoolean('show_meshcore_nodes').default(true),
+  showWaypoints: myBoolean('show_waypoints').default(true),
   showAnimations: myBoolean('show_animations').default(false),
   showAccuracyRegions: myBoolean('show_accuracy_regions').default(false),
   showEstimatedPositions: myBoolean('show_estimated_positions').default(false),

--- a/src/server/migrations/074_add_show_waypoints_to_map_prefs.ts
+++ b/src/server/migrations/074_add_show_waypoints_to_map_prefs.ts
@@ -1,0 +1,72 @@
+/**
+ * Migration 074: Add `show_waypoints` column to `user_map_preferences`.
+ *
+ * Persists the user's waypoint marker visibility toggle in the same way the
+ * other Map Features toggles (`show_route`, `show_mqtt_nodes`, etc.) already
+ * are. Default TRUE so existing installs keep showing waypoints — the toggle
+ * is opt-out, matching the in-memory MapContext default so a fresh row read
+ * is consistent with what the UI shows for an unconfigured user (#3253).
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 074';
+const TABLE = 'user_map_preferences';
+const COLUMN = 'show_waypoints';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding ${TABLE}.${COLUMN}...`);
+    try {
+      // eslint-disable-next-line no-restricted-syntax -- migrations require raw DDL
+      db.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${COLUMN} INTEGER DEFAULT 1`);
+      logger.debug(`${LABEL} (SQLite): added ${TABLE}.${COLUMN}`);
+    } catch (e: any) {
+      if (e.message?.includes('duplicate column')) {
+        logger.debug(`${LABEL} (SQLite): ${TABLE}.${COLUMN} already present, skipping`);
+      } else {
+        logger.error(`${LABEL} (SQLite): could not add ${TABLE}.${COLUMN}:`, e.message);
+        throw e;
+      }
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration074Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding ${TABLE}.${COLUMN}...`);
+  await client.query(
+    `ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS "${COLUMN}" BOOLEAN DEFAULT TRUE`,
+  );
+}
+
+// ============ MySQL ============
+
+export async function runMigration074Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding ${TABLE}.${COLUMN}...`);
+  const conn = await pool.getConnection();
+  try {
+    const [rows] = await conn.query(
+      `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+      [TABLE, COLUMN],
+    );
+    if (Array.isArray(rows) && rows.length === 0) {
+      await conn.query(`ALTER TABLE ${TABLE} ADD COLUMN ${COLUMN} BOOLEAN DEFAULT TRUE`);
+      logger.debug(`${LABEL} (MySQL): added ${TABLE}.${COLUMN}`);
+    } else {
+      logger.debug(`${LABEL} (MySQL): ${TABLE}.${COLUMN} already present, skipping`);
+    }
+  } finally {
+    conn.release();
+  }
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6494,10 +6494,10 @@ apiRouter.post('/user/map-preferences', requireAuth(), async (req, res) => {
       return res.status(403).json({ error: 'Cannot save preferences for anonymous user' });
     }
 
-    const { mapTileset, showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showUdpNodes, showRfNodes, showMeshCoreNodes, showAnimations, showAccuracyRegions, showEstimatedPositions, positionHistoryHours } = req.body;
+    const { mapTileset, showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showUdpNodes, showRfNodes, showMeshCoreNodes, showWaypoints, showAnimations, showAccuracyRegions, showEstimatedPositions, positionHistoryHours } = req.body;
 
     // Validate boolean values
-    const booleanFields = { showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showUdpNodes, showRfNodes, showMeshCoreNodes, showAnimations, showAccuracyRegions, showEstimatedPositions };
+    const booleanFields = { showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showUdpNodes, showRfNodes, showMeshCoreNodes, showWaypoints, showAnimations, showAccuracyRegions, showEstimatedPositions };
     for (const [key, value] of Object.entries(booleanFields)) {
       if (value !== undefined && typeof value !== 'boolean') {
         return res.status(400).json({ error: `${key} must be a boolean` });
@@ -6525,6 +6525,7 @@ apiRouter.post('/user/map-preferences', requireAuth(), async (req, res) => {
       showUdpNodes,
       showRfNodes,
       showMeshCoreNodes,
+      showWaypoints,
       showAnimations,
       showAccuracyRegions,
       showEstimatedPositions,

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -8869,6 +8869,7 @@ class DatabaseService {
     showUdpNodes?: boolean;
     showRfNodes?: boolean;
     showMeshCoreNodes?: boolean;
+    showWaypoints?: boolean;
     showAnimations?: boolean;
     showAccuracyRegions?: boolean;
     showEstimatedPositions?: boolean;


### PR DESCRIPTION
## Summary
Issue #3253 asked for a way to stop waypoints from cluttering the map. Rather than a destructive "delete all waypoints" action, this adds a non-destructive **Show Waypoints** toggle to the Map Features panel — users who don't want to see waypoints can simply hide them, while authoring and the underlying data are untouched. The toggle is persisted per-user exactly like the sibling Map Features toggles (Show RF / UDP / MQTT, Show Traceroute, etc.), so it survives reloads and follows the user across devices.

## Changes
- **DB:** new `show_waypoints` column on `user_map_preferences` for all three backends (SQLite/PostgreSQL/MySQL) via migration `074_add_show_waypoints_to_map_prefs`, registered in `migrations.ts`. Schema (`db/schema/misc.ts`), repository (`getMapPreferences`/`saveMapPreferences`), `DatabaseService.saveMapPreferencesAsync`, and the `POST /api/user/map-preferences` route all carry the field. Default `true`.
- **Frontend:** `MapContext` gains `showWaypoints` state + `setShowWaypoints` setter (saves to server) + server-load wiring + provider value.
- **UI:** `DashboardMap` and `NodesTab` gate the `<DashboardWaypoints>` render on `showWaypoints` and add a **Show Waypoints** checkbox to their Features panels. New i18n key `map.showWaypoints`.
- **Incidental fix:** `getMapPreferences` now also returns `showUdpNodes`/`showRfNodes` — they were being saved but never read back, so those toggles didn't persist across reload.
- **Docs:** `docs/features/waypoints.md`, `docs/features/maps.md`, and `CHANGELOG.md` updated.

## Issues Resolved
Fixes #3253

## Documentation Updates
- `docs/features/waypoints.md` — new "Showing and hiding waypoints" subsection.
- `docs/features/maps.md` — noted the Show Waypoints checkbox in the Waypoints section.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Testing
- [x] Unit tests pass (5723 tests, 0 failures)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] New 3-backend schema-column regression test in `misc.mapprefs.test.ts`; migration registry test bumped to 74
- [ ] Manual: toggle **Show Waypoints** off in the Map Features panel → waypoint markers disappear on both the dashboard and Nodes maps; reload → preference persists
- [ ] Manual: verify default-on behavior for a user with no saved preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)