### PR TITLE
feat(dashboard-map): rich node popup with per-source/protocol breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- **Show Waypoints map toggle** (#3253): The Map Features panel on the dashboard and Nodes maps now has a **Show Waypoints** checkbox that controls waypoint marker visibility. Defaults to on and is persisted per-user via map preferences, alongside the existing Show RF / UDP / MQTT / Traceroute toggles.
+
 ## [4.8.1] - 2026-05-28
 
 # MeshMonitor v4.8.1

--- a/docs/features/maps.md
+++ b/docs/features/maps.md
@@ -86,7 +86,7 @@ When viewing traceroute data:
 
 ### Waypoints
 
-Waypoints — Meshtastic's `WAYPOINT_APP` pins — render directly on the per-source dashboard map and the Map Analysis canvas, using each waypoint's emoji as its icon. Users with `waypoints:write` can create, edit, and delete waypoints in place from the **Map Features** panel. See the dedicated [Waypoints](/features/waypoints) page for the full workflow, permissions, and REST API.
+Waypoints — Meshtastic's `WAYPOINT_APP` pins — render directly on the per-source dashboard map and the Map Analysis canvas, using each waypoint's emoji as its icon. Users with `waypoints:write` can create, edit, and delete waypoints in place from the **Map Features** panel. The same panel has a **Show Waypoints** checkbox (default on) that toggles waypoint marker visibility per-user — persisted alongside the other map feature toggles. See the dedicated [Waypoints](/features/waypoints) page for the full workflow, permissions, and REST API.
 
 ## Map Tilesets
 

--- a/docs/features/waypoints.md
+++ b/docs/features/waypoints.md
@@ -40,6 +40,10 @@ The unified "all sources" dashboard renders waypoints from every source you can 
 
 The Map Analysis canvas exposes a **Waypoints** layer in the toolbar. Toggle it to overlay every visible waypoint on top of the existing analysis layers (heatmap, traceroutes, etc.).
 
+### Showing and hiding waypoints
+
+The **Map Features** panel on both the per-source dashboard map and the Nodes map includes a **Show Waypoints** checkbox. Unchecking it hides all waypoint markers from that map without deleting any waypoints. The setting defaults to on, is saved per-user alongside the other Map Features toggles (Show RF / UDP / MQTT, Show Traceroute, etc.) via your map preferences, and persists across reloads and devices.
+
 ## Creating, editing, and deleting waypoints
 
 Authoring is available on the per-source dashboard map for users with `waypoints:write`.

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4327,6 +4327,7 @@
     "showUdp": "Show UDP",
     "showRf": "Show RF",
     "showMeshCore": "Show MeshCore",
+    "showWaypoints": "Show Waypoints",
     "showPositionHistory": "Show Position History",
     "showAnimations": "Show Animations",
     "showEstimatedPositions": "Show Estimated Positions",

--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -40,6 +40,13 @@ vi.mock('../../contexts/MapContext', () => ({
   }),
 }));
 
+// The marker popup (DashboardNodePopup) reads time/date format from
+// SettingsContext; mock the display-settings hook so tests don't need a
+// SettingsProvider.
+vi.mock('../../contexts/SettingsContext', () => ({
+  useDisplaySettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
+}));
+
 vi.mock('leaflet', () => ({
   default: {
     divIcon: () => ({}),

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -19,6 +19,7 @@ import { createNodeIcon } from '../../utils/mapIcons';
 import { getTilesetById } from '../../config/tilesets';
 import type { CustomTileset } from '../../config/tilesets';
 import DashboardWaypoints from './DashboardWaypoints';
+import DashboardNodePopup from './DashboardNodePopup';
 import { useMapContext } from '../../contexts/MapContext';
 import { nodePassesTransportFilter } from '../../utils/nodeTransport';
 
@@ -239,7 +240,6 @@ export default function DashboardMap({
         {nodesWithPosition.map(({ node, pos }) => {
           const hops = node.hopsAway ?? 999;
           const shortName = node.shortName ?? node.user?.shortName;
-          const longName = node.longName ?? node.user?.longName ?? 'Unknown';
           const nodeId = node.nodeId ?? node.user?.id;
           const isRouter = node.role === 2;
           const icon = createNodeIcon({
@@ -257,20 +257,7 @@ export default function DashboardMap({
               icon={icon}
             >
               <Popup>
-                <div>
-                  <strong>{longName}</strong>
-                  {shortName && <span> ({shortName})</span>}
-                  <br />
-                  <span>
-                    {pos.lat.toFixed(5)}, {pos.lng.toFixed(5)}
-                  </span>
-                  {hops !== 999 && (
-                    <>
-                      <br />
-                      <span>Hops: {hops}</span>
-                    </>
-                  )}
-                </div>
+                <DashboardNodePopup node={node} pos={pos} />
               </Popup>
             </Marker>
           );

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -140,6 +140,8 @@ export default function DashboardMap({
     setShowUdpNodes,
     showMqttNodes,
     setShowMqttNodes,
+    showWaypoints,
+    setShowWaypoints,
   } = useMapContext();
 
   // Build array of nodes that have valid positions, with their resolved lat/lng.
@@ -232,7 +234,7 @@ export default function DashboardMap({
 
         <MapBoundsUpdater positions={nodePositions} sourceId={sourceId} />
 
-        <DashboardWaypoints sourceId={sourceId} />
+        {showWaypoints && <DashboardWaypoints sourceId={sourceId} />}
 
         {nodesWithPosition.map(({ node, pos }) => {
           const hops = node.hopsAway ?? 999;
@@ -423,6 +425,14 @@ export default function DashboardMap({
               onChange={(e) => setShowMqttNodes(e.target.checked)}
             />
             <span>Show MQTT</span>
+          </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showWaypoints}
+              onChange={(e) => setShowWaypoints(e.target.checked)}
+            />
+            <span>Show Waypoints</span>
           </label>
         </div>
       </div>

--- a/src/components/Dashboard/DashboardNodePopup.test.tsx
+++ b/src/components/Dashboard/DashboardNodePopup.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DashboardNodePopup from './DashboardNodePopup';
+
+vi.mock('../../contexts/SettingsContext', () => ({
+  useDisplaySettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
+}));
+
+const pos = { lat: 35.12345, lng: -80.6789 };
+
+describe('DashboardNodePopup', () => {
+  it('renders name, short name, node ID, role, hardware, and hops from flat fields', () => {
+    render(
+      <DashboardNodePopup
+        pos={pos}
+        node={{
+          nodeNum: 42,
+          nodeId: '!0000002a',
+          longName: 'Tower Node',
+          shortName: 'TWR',
+          role: 2,
+          hwModel: 9,
+          hopsAway: 3,
+          lastHeard: Math.floor(Date.now() / 1000) - 120,
+        }}
+      />,
+    );
+    expect(screen.getByText('Tower Node')).toBeInTheDocument();
+    expect(screen.getByText('TWR')).toBeInTheDocument();
+    expect(screen.getByText('!0000002a')).toBeInTheDocument();
+    expect(screen.getByText('3 hops')).toBeInTheDocument();
+    // Coordinates always shown
+    expect(screen.getByText('35.12345, -80.67890')).toBeInTheDocument();
+  });
+
+  it('falls back to nested user/position fields', () => {
+    render(
+      <DashboardNodePopup
+        pos={pos}
+        node={{
+          nodeNum: 7,
+          user: { id: '!00000007', longName: 'Nested Node', shortName: 'NST' },
+          position: { altitude: 120 },
+          hopsAway: 0,
+        }}
+      />,
+    );
+    expect(screen.getByText('Nested Node')).toBeInTheDocument();
+    expect(screen.getByText('NST')).toBeInTheDocument();
+    expect(screen.getByText('!00000007')).toBeInTheDocument();
+    expect(screen.getByText('0 hops')).toBeInTheDocument();
+    expect(screen.getByText('120m')).toBeInTheDocument();
+  });
+
+  it('renders the per-source list with protocol badges on the unified view', () => {
+    render(
+      <DashboardNodePopup
+        pos={pos}
+        node={{
+          nodeNum: 100,
+          longName: 'Shared Node',
+          sources: [
+            { sourceId: 'a', sourceName: 'Tower Alpha', protocol: 'Meshtastic' },
+            { sourceId: 'b', sourceName: 'Core Bravo', protocol: 'MeshCore' },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText('Seen by 2 sources')).toBeInTheDocument();
+    expect(screen.getByText('Tower Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Core Bravo')).toBeInTheDocument();
+    expect(screen.getByText('Meshtastic')).toBeInTheDocument();
+    expect(screen.getByText('MeshCore')).toBeInTheDocument();
+  });
+
+  it('omits the sources section for single-source nodes', () => {
+    render(
+      <DashboardNodePopup
+        pos={pos}
+        node={{ nodeNum: 1, longName: 'Solo Node' }}
+      />,
+    );
+    expect(screen.queryByText(/Seen by/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Dashboard/DashboardNodePopup.tsx
+++ b/src/components/Dashboard/DashboardNodePopup.tsx
@@ -1,0 +1,167 @@
+/**
+ * DashboardNodePopup — richly formatted marker popup for the Dashboard map.
+ *
+ * Renders the same Meshtastic-style node card used elsewhere in the app
+ * (reusing the `.node-popup-*` classes from styles/nodes.css) directly from
+ * the flat node shape returned by `/api/sources/:id/nodes`. Handles both the
+ * flat API fields (node.longName, node.role, …) and the nested fallbacks
+ * (node.user?.longName, node.position?.altitude, …).
+ *
+ * On the Unified view each merged node carries a `sources` array describing
+ * which configured sources reported it and over which protocol (Meshtastic vs
+ * MeshCore); when present it's rendered as a labelled list at the bottom.
+ */
+
+import { useDisplaySettings } from '../../contexts/SettingsContext';
+import { getHardwareModelName, getRoleName } from '../../utils/nodeHelpers';
+import { formatRelativeTime } from '../../utils/datetime';
+
+/** A single source that reported this node, attached by mergeUnifiedSourceData. */
+export interface NodeSourceRef {
+  sourceId: string;
+  sourceName: string;
+  protocol: 'Meshtastic' | 'MeshCore';
+}
+
+interface DashboardNodePopupProps {
+  node: any;
+  pos: { lat: number; lng: number };
+}
+
+/** Coerce a field that may live on the flat node or its nested `user`. */
+function pick<T>(node: any, flatKey: string, userKey: string): T | undefined {
+  const flat = node?.[flatKey];
+  if (flat !== undefined && flat !== null) return flat as T;
+  const nested = node?.user?.[userKey];
+  return nested === null ? undefined : (nested as T | undefined);
+}
+
+export default function DashboardNodePopup({ node, pos }: DashboardNodePopupProps) {
+  const { timeFormat, dateFormat } = useDisplaySettings();
+
+  const longName = pick<string>(node, 'longName', 'longName')
+    ?? (typeof node?.nodeNum === 'number' ? `Node ${node.nodeNum}` : 'Unknown');
+  const shortName = pick<string>(node, 'shortName', 'shortName');
+  const nodeId = pick<string>(node, 'nodeId', 'id');
+
+  const roleRaw = pick<number | string>(node, 'role', 'role');
+  const roleName = roleRaw !== undefined ? getRoleName(roleRaw) : null;
+
+  const hwModel = pick<number>(node, 'hwModel', 'hwModel');
+  const hwModelName = hwModel !== undefined ? getHardwareModelName(hwModel) : null;
+
+  const hops = typeof node?.hopsAway === 'number' ? node.hopsAway : null;
+  const altitude = node?.altitude ?? node?.position?.altitude;
+  const snr = typeof node?.snr === 'number' ? node.snr : null;
+  const battery = typeof node?.batteryLevel === 'number' ? node.batteryLevel : null;
+  const lastHeard = typeof node?.lastHeard === 'number' ? node.lastHeard : null;
+
+  const sources: NodeSourceRef[] | undefined = Array.isArray(node?.sources) ? node.sources : undefined;
+
+  return (
+    <div className="node-popup">
+      {/* Header */}
+      <div
+        className="node-popup-header"
+        style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}
+      >
+        <div
+          className="node-popup-title"
+          style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+        >
+          {longName}
+        </div>
+        {shortName && (
+          <div className="node-popup-subtitle" style={{ flexShrink: 0 }}>
+            {shortName}
+          </div>
+        )}
+      </div>
+
+      {/* Info grid */}
+      <div className="node-popup-content">
+        <div className="node-popup-grid">
+          {nodeId && (
+            <div className="node-popup-item node-popup-item-full">
+              <span className="node-popup-icon">🆔</span>
+              <span className="node-popup-value">{nodeId}</span>
+            </div>
+          )}
+
+          {roleName && (
+            <div className="node-popup-item">
+              <span className="node-popup-icon">👤</span>
+              <span className="node-popup-value">{roleName}</span>
+            </div>
+          )}
+
+          {hops != null && (
+            <div className="node-popup-item">
+              <span className="node-popup-icon">🔗</span>
+              <span className="node-popup-value">{hops} hop{hops !== 1 ? 's' : ''}</span>
+            </div>
+          )}
+
+          {hwModelName && (
+            <div className="node-popup-item node-popup-item-full">
+              <span className="node-popup-icon">🖥️</span>
+              <span className="node-popup-value">{hwModelName}</span>
+            </div>
+          )}
+
+          {battery != null && (
+            <div className="node-popup-item">
+              <span className="node-popup-icon">🔋</span>
+              <span className="node-popup-value">{battery}%</span>
+            </div>
+          )}
+
+          {snr != null && (
+            <div className="node-popup-item">
+              <span className="node-popup-icon">📶</span>
+              <span className="node-popup-value">{snr} dB</span>
+            </div>
+          )}
+
+          {altitude != null && (
+            <div className="node-popup-item">
+              <span className="node-popup-icon">⛰️</span>
+              <span className="node-popup-value">{altitude}m</span>
+            </div>
+          )}
+
+          <div className="node-popup-item node-popup-item-full">
+            <span className="node-popup-icon">📍</span>
+            <span className="node-popup-value">
+              {pos.lat.toFixed(5)}, {pos.lng.toFixed(5)}
+            </span>
+          </div>
+        </div>
+
+        {lastHeard != null && (
+          <div className="node-popup-footer">
+            <span className="node-popup-icon">🕐</span>
+            {formatRelativeTime(lastHeard * 1000, timeFormat, dateFormat, true)}
+          </div>
+        )}
+
+        {/* Unified view: which sources reported this node + protocol. */}
+        {sources && sources.length > 0 && (
+          <div className="node-popup-sources">
+            <div className="node-popup-sources-title">
+              Seen by {sources.length} source{sources.length !== 1 ? 's' : ''}
+            </div>
+            {sources.map((s) => (
+              <div key={s.sourceId} className="node-popup-source-row">
+                <span className={`node-popup-protocol-badge protocol-${s.protocol.toLowerCase()}`}>
+                  {s.protocol}
+                </span>
+                <span className="node-popup-source-name">{s.sourceName}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -311,6 +311,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     setShowUdpNodes,
     showRfNodes,
     setShowRfNodes,
+    showWaypoints,
+    setShowWaypoints,
     showAnimations,
     setShowAnimations,
     showEstimatedPositions,
@@ -1804,6 +1806,14 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                   <label className="map-control-item">
                     <input
                       type="checkbox"
+                      checked={showWaypoints}
+                      onChange={(e) => setShowWaypoints(e.target.checked)}
+                    />
+                    <span>{t('map.showWaypoints', 'Show Waypoints')}</span>
+                  </label>
+                  <label className="map-control-item">
+                    <input
+                      type="checkbox"
                       checked={showMotion}
                       onChange={(e) => setShowMotion(e.target.checked)}
                     />
@@ -2029,7 +2039,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 canCreate={canWriteWaypoints}
                 onPick={(lat, lon) => startCreateAtCoords(lat, lon)}
               />
-              <DashboardWaypoints sourceId={currentSourceId ?? null} actions={waypointActions} />
+              {showWaypoints && <DashboardWaypoints sourceId={currentSourceId ?? null} actions={waypointActions} />}
               <DefaultCenterController
                 lat={defaultMapCenterLat}
                 lon={defaultMapCenterLon}

--- a/src/contexts/MapContext.tsx
+++ b/src/contexts/MapContext.tsx
@@ -54,6 +54,8 @@ interface MapContextType {
   setShowRfNodes: (show: boolean) => void;
   showMeshCoreNodes: boolean;
   setShowMeshCoreNodes: (show: boolean) => void;
+  showWaypoints: boolean;
+  setShowWaypoints: (show: boolean) => void;
   showAnimations: boolean;
   setShowAnimations: (show: boolean) => void;
   showEstimatedPositions: boolean;
@@ -105,6 +107,8 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
   const [showUdpNodes, setShowUdpNodesState] = useState<boolean>(false);
   const [showRfNodes, setShowRfNodesState] = useState<boolean>(true);
   const [showMeshCoreNodes, setShowMeshCoreNodesState] = useState<boolean>(true);
+  // Waypoint markers default on (#3253) — opt-out toggle in the Map Features panel.
+  const [showWaypoints, setShowWaypointsState] = useState<boolean>(true);
   const [showAnimations, setShowAnimationsState] = useState<boolean>(false);
   const [meshCoreNodes, setMeshCoreNodes] = useState<MeshCoreMapNode[]>([]);
   const [showEstimatedPositions, setShowEstimatedPositionsState] = useState<boolean>(() => {
@@ -181,6 +185,11 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
   const setShowMeshCoreNodes = React.useCallback((value: boolean) => {
     setShowMeshCoreNodesState(value);
     savePreferenceToServer({ showMeshCoreNodes: value });
+  }, []);
+
+  const setShowWaypoints = React.useCallback((value: boolean) => {
+    setShowWaypointsState(value);
+    savePreferenceToServer({ showWaypoints: value });
   }, []);
 
   const setShowAnimations = React.useCallback((value: boolean) => {
@@ -293,6 +302,9 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
             if (preferences.showMeshCoreNodes !== undefined) {
               setShowMeshCoreNodesState(preferences.showMeshCoreNodes);
             }
+            if (preferences.showWaypoints !== undefined) {
+              setShowWaypointsState(preferences.showWaypoints);
+            }
             if (preferences.showAnimations !== undefined) {
               setShowAnimationsState(preferences.showAnimations);
             }
@@ -370,6 +382,8 @@ export const MapProvider: React.FC<MapProviderProps> = ({ children }) => {
         setShowRfNodes,
         showMeshCoreNodes,
         setShowMeshCoreNodes,
+        showWaypoints,
+        setShowWaypoints,
         meshCoreNodes,
         setMeshCoreNodes,
         showAnimations,

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 73 migrations registered', () => {
-    expect(registry.count()).toBe(73);
+  it('has all 74 migrations registered', () => {
+    expect(registry.count()).toBe(74);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is meshcore_neighbor_info', () => {
+  it('last migration is add_show_waypoints_to_map_prefs', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(73);
-    expect(last.name).toContain('meshcore_neighbor_info');
+    expect(last.number).toBe(74);
+    expect(last.name).toContain('add_show_waypoints_to_map_prefs');
   });
 
-  it('migrations are sequentially numbered from 1 to 73', () => {
+  it('migrations are sequentially numbered from 1 to 74', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -88,6 +88,7 @@ import { migration as meshcoreAdminCredentialMigration, runMigration070Postgres,
 import { migration as dropLegacyPskLengthCheckMigration, runMigration071Postgres, runMigration071Mysql } from '../server/migrations/071_drop_legacy_psk_length_check.js';
 import { migration as meshcoreRoomSyncMigration, runMigration072Postgres, runMigration072Mysql } from '../server/migrations/072_meshcore_room_sync.js';
 import { migration as meshcoreNeighborInfoMigration, runMigration073Postgres, runMigration073Mysql } from '../server/migrations/073_meshcore_neighbor_info.js';
+import { migration as addShowWaypointsToMapPrefsMigration, runMigration074Postgres, runMigration074Mysql } from '../server/migrations/074_add_show_waypoints_to_map_prefs.js';
 
 // ============================================================================
 // Registry
@@ -1164,4 +1165,19 @@ registry.register({
   sqlite: (db) => meshcoreNeighborInfoMigration.up(db),
   postgres: (client) => runMigration073Postgres(client),
   mysql: (pool) => runMigration073Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 074: Add `show_waypoints` column to user_map_preferences. Persists
+// the waypoint marker visibility toggle alongside the other Map Features
+// toggles. Default TRUE (opt-out) so existing installs keep showing waypoints.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 74,
+  name: 'add_show_waypoints_to_map_prefs',
+  settingsKey: 'migration_074_add_show_waypoints_to_map_prefs',
+  sqlite: (db) => addShowWaypointsToMapPrefsMigration.up(db),
+  postgres: (client) => runMigration074Postgres(client),
+  mysql: (pool) => runMigration074Mysql(pool),
 });

--- a/src/db/repositories/misc.mapprefs.test.ts
+++ b/src/db/repositories/misc.mapprefs.test.ts
@@ -22,3 +22,20 @@ describe('userMapPreferencesSqlite — SQL column alignment (#2713)', () => {
     expect(col.name).toBe('user_id');
   });
 });
+
+describe('userMapPreferences — showWaypoints toggle (#3253)', () => {
+  it('maps JS `showWaypoints` → SQL column `show_waypoints` on all three backends', () => {
+    const sqlite = (schema.userMapPreferencesSqlite as unknown as {
+      showWaypoints: { name: string };
+    }).showWaypoints;
+    const pg = (schema.userMapPreferencesPostgres as unknown as {
+      showWaypoints: { name: string };
+    }).showWaypoints;
+    const mysql = (schema.userMapPreferencesMysql as unknown as {
+      showWaypoints: { name: string };
+    }).showWaypoints;
+    expect(sqlite.name).toBe('show_waypoints');
+    expect(pg.name).toBe('show_waypoints');
+    expect(mysql.name).toBe('show_waypoints');
+  });
+});

--- a/src/db/repositories/misc.ts
+++ b/src/db/repositories/misc.ts
@@ -1831,7 +1831,10 @@ export class MiscRepository extends BaseRepository {
         showRoute: row.showRoute ?? true,
         showMotion: row.showMotion ?? true,
         showMqttNodes: row.showMqttNodes ?? true,
+        showUdpNodes: row.showUdpNodes ?? false,
+        showRfNodes: row.showRfNodes ?? true,
         showMeshCoreNodes: row.showMeshcoreNodes ?? true,
+        showWaypoints: row.showWaypoints ?? true,
         showAnimations: row.showAnimations ?? false,
         showAccuracyRegions: row.showAccuracyRegions ?? false,
         showEstimatedPositions: row.showEstimatedPositions ?? false,
@@ -1856,6 +1859,7 @@ export class MiscRepository extends BaseRepository {
     showUdpNodes?: boolean;
     showRfNodes?: boolean;
     showMeshCoreNodes?: boolean;
+    showWaypoints?: boolean;
     showAnimations?: boolean;
     showAccuracyRegions?: boolean;
     showEstimatedPositions?: boolean;
@@ -1880,6 +1884,7 @@ export class MiscRepository extends BaseRepository {
         if (preferences.showUdpNodes !== undefined) set.showUdpNodes = preferences.showUdpNodes;
         if (preferences.showRfNodes !== undefined) set.showRfNodes = preferences.showRfNodes;
         if (preferences.showMeshCoreNodes !== undefined) set.showMeshcoreNodes = preferences.showMeshCoreNodes;
+        if (preferences.showWaypoints !== undefined) set.showWaypoints = preferences.showWaypoints;
         if (preferences.showAnimations !== undefined) set.showAnimations = preferences.showAnimations;
         if (preferences.showAccuracyRegions !== undefined) set.showAccuracyRegions = preferences.showAccuracyRegions;
         if (preferences.showEstimatedPositions !== undefined) set.showEstimatedPositions = preferences.showEstimatedPositions;
@@ -1901,6 +1906,7 @@ export class MiscRepository extends BaseRepository {
           showUdpNodes: preferences.showUdpNodes ?? false,
           showRfNodes: preferences.showRfNodes ?? true,
           showMeshcoreNodes: preferences.showMeshCoreNodes ?? true,
+          showWaypoints: preferences.showWaypoints ?? true,
           showAnimations: preferences.showAnimations ?? false,
           showAccuracyRegions: preferences.showAccuracyRegions ?? false,
           showEstimatedPositions: preferences.showEstimatedPositions ?? true,

--- a/src/db/schema/misc.ts
+++ b/src/db/schema/misc.ts
@@ -106,6 +106,9 @@ export const userMapPreferencesSqlite = sqliteTable('user_map_preferences', {
   showUdpNodes: integer('show_udp_nodes', { mode: 'boolean' }).default(false),
   showRfNodes: integer('show_rf_nodes', { mode: 'boolean' }).default(true),
   showMeshcoreNodes: integer('show_meshcore_nodes', { mode: 'boolean' }).default(true),
+  // Waypoint marker visibility (#3253). Default true so existing users keep
+  // seeing waypoints they've placed; opt-out via the Map Features panel.
+  showWaypoints: integer('show_waypoints', { mode: 'boolean' }).default(true),
   showAnimations: integer('show_animations', { mode: 'boolean' }).default(false),
   showAccuracyRegions: integer('show_accuracy_regions', { mode: 'boolean' }).default(false),
   showEstimatedPositions: integer('show_estimated_positions', { mode: 'boolean' }).default(false),
@@ -130,6 +133,7 @@ export const userMapPreferencesPostgres = pgTable('user_map_preferences', {
   showUdpNodes: pgBoolean('show_udp_nodes').default(false),
   showRfNodes: pgBoolean('show_rf_nodes').default(true),
   showMeshcoreNodes: pgBoolean('show_meshcore_nodes').default(true),
+  showWaypoints: pgBoolean('show_waypoints').default(true),
   showAnimations: pgBoolean('show_animations').default(false),
   showAccuracyRegions: pgBoolean('show_accuracy_regions').default(false),
   showEstimatedPositions: pgBoolean('show_estimated_positions').default(false),
@@ -387,6 +391,7 @@ export const userMapPreferencesMysql = mysqlTable('user_map_preferences', {
   showUdpNodes: myBoolean('show_udp_nodes').default(false),
   showRfNodes: myBoolean('show_rf_nodes').default(true),
   showMeshcoreNodes: myBoolean('show_meshcore_nodes').default(true),
+  showWaypoints: myBoolean('show_waypoints').default(true),
   showAnimations: myBoolean('show_animations').default(false),
   showAccuracyRegions: myBoolean('show_accuracy_regions').default(false),
   showEstimatedPositions: myBoolean('show_estimated_positions').default(false),

--- a/src/hooks/useDashboardData.test.ts
+++ b/src/hooks/useDashboardData.test.ts
@@ -335,6 +335,106 @@ describe('mergeUnifiedSourceData', () => {
     ]);
     expect(merged.channels).toEqual([{ id: 0, name: 'LongFast' }]);
   });
+
+  it('attaches a deduped sources list (id/name/protocol) to each merged node', () => {
+    const merged = mergeUnifiedSourceData([
+      {
+        sourceId: 'src-1',
+        sourceName: 'Tower Alpha',
+        protocol: 'Meshtastic',
+        nodes: [{ nodeNum: 500, lastHeard: 100 }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+      {
+        sourceId: 'src-2',
+        sourceName: 'Core Bravo',
+        protocol: 'MeshCore',
+        nodes: [{ nodeNum: 500, lastHeard: 200 }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+    ]);
+    expect(merged.nodes).toHaveLength(1);
+    expect((merged.nodes[0] as any).sources).toEqual([
+      { sourceId: 'src-1', sourceName: 'Tower Alpha', protocol: 'Meshtastic' },
+      { sourceId: 'src-2', sourceName: 'Core Bravo', protocol: 'MeshCore' },
+    ]);
+  });
+
+  it('omits the sources list when source metadata is not supplied', () => {
+    const merged = mergeUnifiedSourceData([
+      { nodes: [{ nodeNum: 600, lastHeard: 100 }], traceroutes: [], neighborInfo: [], channels: [] },
+    ]);
+    expect((merged.nodes[0] as any).sources).toBeUndefined();
+  });
+
+  it('merges a MeshCore node across sources by publicKey (not the source-scoped nodeId)', () => {
+    // Regression: the server builds MeshCore nodeId as `mc:<sourceId>:<pubkey>`,
+    // so the same physical contact heard by two sources had two different
+    // nodeIds and never merged — always showing "seen by 1 source". Keying on
+    // publicKey must collapse them into one node listing both sources.
+    const PUBKEY = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+    const merged = mergeUnifiedSourceData([
+      {
+        sourceId: 'mc-1',
+        sourceName: 'Core One',
+        protocol: 'MeshCore',
+        nodes: [{
+          isMeshCore: true,
+          nodeNum: 0,
+          nodeId: `mc:mc-1:${PUBKEY.substring(0, 12)}`,
+          publicKey: PUBKEY,
+          lastHeard: 100,
+          longName: 'Repeater',
+        }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+      {
+        sourceId: 'mc-2',
+        sourceName: 'Core Two',
+        protocol: 'MeshCore',
+        nodes: [{
+          isMeshCore: true,
+          nodeNum: 0,
+          nodeId: `mc:mc-2:${PUBKEY.substring(0, 12)}`,
+          publicKey: PUBKEY,
+          lastHeard: 200,
+          longName: 'Repeater',
+        }],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+    ]);
+    expect(merged.nodes).toHaveLength(1);
+    expect((merged.nodes[0] as any).sources).toEqual([
+      { sourceId: 'mc-1', sourceName: 'Core One', protocol: 'MeshCore' },
+      { sourceId: 'mc-2', sourceName: 'Core Two', protocol: 'MeshCore' },
+    ]);
+  });
+
+  it('keeps distinct MeshCore nodes (different publicKeys) separate', () => {
+    const merged = mergeUnifiedSourceData([
+      {
+        sourceId: 'mc-1',
+        sourceName: 'Core One',
+        protocol: 'MeshCore',
+        nodes: [
+          { isMeshCore: true, nodeNum: 0, nodeId: 'mc:mc-1:aaaaaaaaaaaa', publicKey: 'aaaa', lastHeard: 100 },
+          { isMeshCore: true, nodeNum: 0, nodeId: 'mc:mc-1:bbbbbbbbbbbb', publicKey: 'bbbb', lastHeard: 100 },
+        ],
+        traceroutes: [],
+        neighborInfo: [],
+        channels: [],
+      },
+    ]);
+    expect(merged.nodes).toHaveLength(2);
+  });
 });
 
 describe('useDashboardUnifiedData', () => {
@@ -347,9 +447,14 @@ describe('useDashboardUnifiedData', () => {
     vi.restoreAllMocks();
   });
 
+  const unifiedSources: DashboardSource[] = [
+    { id: 'src-1', name: 'Source One', type: 'meshtastic_tcp', enabled: true },
+    { id: 'src-2', name: 'Source Two', type: 'meshcore', enabled: true },
+  ];
+
   it('returns empty defaults without fetching when disabled', async () => {
     const { result } = renderHook(
-      () => useDashboardUnifiedData(['src-1', 'src-2'], false),
+      () => useDashboardUnifiedData(unifiedSources, false),
       { wrapper: createWrapper() },
     );
 
@@ -395,7 +500,7 @@ describe('useDashboardUnifiedData', () => {
     });
 
     const { result } = renderHook(
-      () => useDashboardUnifiedData(['src-1', 'src-2'], true),
+      () => useDashboardUnifiedData(unifiedSources, true),
       { wrapper: createWrapper() },
     );
 
@@ -410,5 +515,11 @@ describe('useDashboardUnifiedData', () => {
     expect(result.current.traceroutes).toEqual([{ id: 'tr-1' }, { id: 'tr-2' }]);
     expect(result.current.neighborInfo).toEqual([{ id: 'ni-1' }]);
     expect(result.current.channels).toEqual([{ id: 0, name: 'LongFast' }]);
+    // Node 42 was heard by both sources — both should be listed with the
+    // protocol derived from each source's type.
+    expect((result.current.nodes[0] as any).sources).toEqual([
+      { sourceId: 'src-1', sourceName: 'Source One', protocol: 'Meshtastic' },
+      { sourceId: 'src-2', sourceName: 'Source Two', protocol: 'MeshCore' },
+    ]);
   });
 });

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -300,10 +300,38 @@ function mergeNodeRecords(records: any[]): any {
 }
 
 /**
+ * Describes one source that reported a node, attached to each merged Unified
+ * node so the map popup can list "seen by source X over protocol Y".
+ */
+export interface NodeSourceRef {
+  sourceId: string;
+  sourceName: string;
+  protocol: 'Meshtastic' | 'MeshCore';
+}
+
+/**
+ * One source's data bundle plus its identifying metadata. The metadata is
+ * optional so legacy callers (and tests) that only pass data still work — when
+ * absent, merged nodes simply carry no `sources` array.
+ */
+export interface UnifiedSourceBundle {
+  sourceId?: string;
+  sourceName?: string;
+  protocol?: 'Meshtastic' | 'MeshCore';
+  nodes: unknown[];
+  traceroutes: unknown[];
+  neighborInfo: unknown[];
+  channels: unknown[];
+}
+
+/**
  * Merge the same record type fetched from N sources into a single array.
  *
  * - **Nodes**: grouped by nodeNum, then field-level merged via
- *   `mergeNodeRecords` so position/user/role survive across sources.
+ *   `mergeNodeRecords` so position/user/role survive across sources. Each
+ *   merged node also gets a `sources` array (deduped by sourceId) naming every
+ *   source that reported it and its protocol — consumed by the map popup on
+ *   the Unified view.
  * - **NeighborInfo / Traceroutes**: simply concatenated; each row is a
  *   per-source observation and the map renders one polyline per row.
  * - **Channels**: taken from the first source that returned any. The
@@ -311,29 +339,50 @@ function mergeNodeRecords(records: any[]): any {
  *   array so other consumers don't break.
  */
 export function mergeUnifiedSourceData(
-  perSource: Array<{ nodes: unknown[]; traceroutes: unknown[]; neighborInfo: unknown[]; channels: unknown[] }>,
+  perSource: UnifiedSourceBundle[],
 ): { nodes: unknown[]; traceroutes: unknown[]; neighborInfo: unknown[]; channels: unknown[] } {
-  // Keys are stringified so MeshCore contacts (which don't have a meshtastic
-  // nodeNum and instead carry an `mc:<source>:<pubkey>` nodeId) don't all
-  // collapse into the bucket for nodeNum=0.
-  const recordsByKey = new Map<string, any[]>();
+  // Keys are stringified and namespaced (`mt:`/`mc:`) so MeshCore contacts
+  // (which carry no meshtastic nodeNum) don't collapse into the nodeNum=0
+  // bucket. MeshCore nodes key on publicKey so the same physical node merges
+  // across sources (see keying block below). Each bucket entry pairs the raw
+  // node record with the source it came from so we can rebuild `sources` after
+  // the field-level merge collapses the records.
+  const recordsByKey = new Map<string, Array<{ node: any; source: NodeSourceRef | null }>>();
   const traceroutes: unknown[] = [];
   const neighborInfo: unknown[] = [];
   let channels: unknown[] = [];
 
   for (const ps of perSource) {
+    const source: NodeSourceRef | null = ps.sourceId
+      ? {
+          sourceId: ps.sourceId,
+          sourceName: ps.sourceName ?? ps.sourceId,
+          protocol: ps.protocol ?? 'Meshtastic',
+        }
+      : null;
     for (const n of ps.nodes as any[]) {
       if (n == null) continue;
       let key: string | null = null;
-      if (n.isMeshCore && typeof n.nodeId === 'string' && n.nodeId.length > 0) {
-        key = `mc:${n.nodeId}`;
+      if (n.isMeshCore) {
+        // A MeshCore contact's identity is its public key — stable across
+        // sources. The server-built `nodeId` embeds the reporting source
+        // (`mc:<sourceId>:<pubkeyPrefix>`), so keying on it would put the same
+        // physical node into a separate bucket per source and it would always
+        // show as "seen by 1 source". Key on publicKey so the same node merges
+        // across MeshCore sources; fall back to nodeId only when no key exists.
+        if (typeof n.publicKey === 'string' && n.publicKey.length > 0) {
+          key = `mc:${n.publicKey}`;
+        } else if (typeof n.nodeId === 'string' && n.nodeId.length > 0) {
+          key = `mc:${n.nodeId}`;
+        }
       } else if (typeof n.nodeNum === 'number') {
         key = `mt:${n.nodeNum}`;
       }
       if (key == null) continue;
+      const entry = { node: n, source };
       const bucket = recordsByKey.get(key);
-      if (bucket) bucket.push(n);
-      else recordsByKey.set(key, [n]);
+      if (bucket) bucket.push(entry);
+      else recordsByKey.set(key, [entry]);
     }
     traceroutes.push(...ps.traceroutes);
     neighborInfo.push(...ps.neighborInfo);
@@ -342,7 +391,15 @@ export function mergeUnifiedSourceData(
     }
   }
 
-  const nodes = Array.from(recordsByKey.values()).map(mergeNodeRecords);
+  const nodes = Array.from(recordsByKey.values()).map((entries) => {
+    const merged = mergeNodeRecords(entries.map((e) => e.node));
+    const seen = new Map<string, NodeSourceRef>();
+    for (const e of entries) {
+      if (e.source && !seen.has(e.source.sourceId)) seen.set(e.source.sourceId, e.source);
+    }
+    if (seen.size > 0) merged.sources = Array.from(seen.values());
+    return merged;
+  });
 
   return {
     nodes,
@@ -360,11 +417,16 @@ export function mergeUnifiedSourceData(
  * tab.
  */
 export function useDashboardUnifiedData(
-  sourceIds: string[],
+  sources: Array<string | DashboardSource>,
   enabled: boolean,
 ): DashboardSourceData {
   const { authStatus } = useAuth();
   const isAuthenticated = authStatus?.authenticated ?? false;
+  // Accept either bare source-id strings (MapAnalysis layers, which never use
+  // the per-node `sources` field) or full DashboardSource objects (the Unified
+  // dashboard map, which needs source names + protocol for the popup).
+  const sourceList = sources.map((s) => (typeof s === 'string' ? { id: s } : s));
+  const sourceIds = sourceList.map((s) => s.id);
 
   const queries = useQueries({
     queries: sourceIds.flatMap((id) => [
@@ -416,7 +478,14 @@ export function useDashboardUnifiedData(
 
   // Group every 4 sequential queries back into one source's bundle, mirroring
   // the order we registered them in (nodes, traceroutes, neighborInfo, channels).
-  const perSource = sourceIds.map((_, i) => ({
+  // When given full DashboardSource objects we carry id/name/protocol so the
+  // merge can stamp `sources` onto every node (MeshCore source types map to the
+  // MeshCore protocol; everything else is Meshtastic). Bare-string callers get
+  // no metadata, so merged nodes carry no `sources` field.
+  const perSource: UnifiedSourceBundle[] = sourceList.map((s, i) => ({
+    sourceId: 'name' in s ? s.id : undefined,
+    sourceName: 'name' in s ? s.name : undefined,
+    protocol: 'type' in s ? (s.type === 'meshcore' ? 'MeshCore' : 'Meshtastic') : undefined,
     nodes: (queries[i * 4 + 0]?.data as unknown[] | undefined) ?? [],
     traceroutes: (queries[i * 4 + 1]?.data as unknown[] | undefined) ?? [],
     neighborInfo: (queries[i * 4 + 2]?.data as unknown[] | undefined) ?? [],

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -236,7 +236,7 @@ function DashboardInner() {
   // Run both data hooks but disable whichever is not active so we don't fan
   // out N parallel fetches when the user is on a single-source view.
   const singleSourceData = useDashboardSourceData(isUnifiedSelected ? null : selectedSourceId);
-  const unifiedSourceData = useDashboardUnifiedData(sourceIds, isUnifiedSelected);
+  const unifiedSourceData = useDashboardUnifiedData(sources, isUnifiedSelected);
   const sourceData = isUnifiedSelected ? unifiedSourceData : singleSourceData;
 
   // Synthetic Unified pseudo-source for the sidebar. Recognized by its sentinel ID

--- a/src/server/migrations/074_add_show_waypoints_to_map_prefs.ts
+++ b/src/server/migrations/074_add_show_waypoints_to_map_prefs.ts
@@ -1,0 +1,72 @@
+/**
+ * Migration 074: Add `show_waypoints` column to `user_map_preferences`.
+ *
+ * Persists the user's waypoint marker visibility toggle in the same way the
+ * other Map Features toggles (`show_route`, `show_mqtt_nodes`, etc.) already
+ * are. Default TRUE so existing installs keep showing waypoints — the toggle
+ * is opt-out, matching the in-memory MapContext default so a fresh row read
+ * is consistent with what the UI shows for an unconfigured user (#3253).
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 074';
+const TABLE = 'user_map_preferences';
+const COLUMN = 'show_waypoints';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding ${TABLE}.${COLUMN}...`);
+    try {
+      // eslint-disable-next-line no-restricted-syntax -- migrations require raw DDL
+      db.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${COLUMN} INTEGER DEFAULT 1`);
+      logger.debug(`${LABEL} (SQLite): added ${TABLE}.${COLUMN}`);
+    } catch (e: any) {
+      if (e.message?.includes('duplicate column')) {
+        logger.debug(`${LABEL} (SQLite): ${TABLE}.${COLUMN} already present, skipping`);
+      } else {
+        logger.error(`${LABEL} (SQLite): could not add ${TABLE}.${COLUMN}:`, e.message);
+        throw e;
+      }
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration074Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding ${TABLE}.${COLUMN}...`);
+  await client.query(
+    `ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS "${COLUMN}" BOOLEAN DEFAULT TRUE`,
+  );
+}
+
+// ============ MySQL ============
+
+export async function runMigration074Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding ${TABLE}.${COLUMN}...`);
+  const conn = await pool.getConnection();
+  try {
+    const [rows] = await conn.query(
+      `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+      [TABLE, COLUMN],
+    );
+    if (Array.isArray(rows) && rows.length === 0) {
+      await conn.query(`ALTER TABLE ${TABLE} ADD COLUMN ${COLUMN} BOOLEAN DEFAULT TRUE`);
+      logger.debug(`${LABEL} (MySQL): added ${TABLE}.${COLUMN}`);
+    } else {
+      logger.debug(`${LABEL} (MySQL): ${TABLE}.${COLUMN} already present, skipping`);
+    }
+  } finally {
+    conn.release();
+  }
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6494,10 +6494,10 @@ apiRouter.post('/user/map-preferences', requireAuth(), async (req, res) => {
       return res.status(403).json({ error: 'Cannot save preferences for anonymous user' });
     }
 
-    const { mapTileset, showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showUdpNodes, showRfNodes, showMeshCoreNodes, showAnimations, showAccuracyRegions, showEstimatedPositions, positionHistoryHours } = req.body;
+    const { mapTileset, showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showUdpNodes, showRfNodes, showMeshCoreNodes, showWaypoints, showAnimations, showAccuracyRegions, showEstimatedPositions, positionHistoryHours } = req.body;
 
     // Validate boolean values
-    const booleanFields = { showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showUdpNodes, showRfNodes, showMeshCoreNodes, showAnimations, showAccuracyRegions, showEstimatedPositions };
+    const booleanFields = { showPaths, showNeighborInfo, showRoute, showMotion, showMqttNodes, showUdpNodes, showRfNodes, showMeshCoreNodes, showWaypoints, showAnimations, showAccuracyRegions, showEstimatedPositions };
     for (const [key, value] of Object.entries(booleanFields)) {
       if (value !== undefined && typeof value !== 'boolean') {
         return res.status(400).json({ error: `${key} must be a boolean` });
@@ -6525,6 +6525,7 @@ apiRouter.post('/user/map-preferences', requireAuth(), async (req, res) => {
       showUdpNodes,
       showRfNodes,
       showMeshCoreNodes,
+      showWaypoints,
       showAnimations,
       showAccuracyRegions,
       showEstimatedPositions,

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -8869,6 +8869,7 @@ class DatabaseService {
     showUdpNodes?: boolean;
     showRfNodes?: boolean;
     showMeshCoreNodes?: boolean;
+    showWaypoints?: boolean;
     showAnimations?: boolean;
     showAccuracyRegions?: boolean;
     showEstimatedPositions?: boolean;

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1906,6 +1906,56 @@
   color: var(--ctp-base);
 }
 
+/* Node Popup Sources Section (Unified map only) — which sources reported this
+   node and over which protocol. */
+.node-popup-sources {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--ctp-surface1);
+}
+
+.node-popup-sources-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--ctp-subtext0);
+  margin-bottom: 0.35rem;
+}
+
+.node-popup-source-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0;
+  font-size: 0.82rem;
+}
+
+.node-popup-source-name {
+  color: var(--ctp-text);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.node-popup-protocol-badge {
+  flex-shrink: 0;
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius-sm);
+  color: var(--ctp-base);
+}
+
+.node-popup-protocol-badge.protocol-meshtastic {
+  background: var(--ctp-green);
+}
+
+.node-popup-protocol-badge.protocol-meshcore {
+  background: var(--ctp-peach);
+}
+
 /* Node Popup Traceroute Section */
 .node-popup-traceroute {
   margin: 0.75rem 0;


### PR DESCRIPTION
## Summary

Enhances the Dashboard map marker popup and fixes MeshCore cross-source node merging.

The bare popup (name, coordinates, hops) is replaced with a Meshtastic-style formatted card, and on the **Unified** view each node now lists which sources reported it and over which protocol.

> [!NOTE]
> This branch is based on `main` per request, so the diff also includes the unmerged **Show Waypoints** commit (#3253). The new work in this PR is the single commit `feat(dashboard-map): rich node popup …`.

## What changed

**Rich popup** — new `DashboardNodePopup` component (rendered from the flat `/api/sources/:id/nodes` shape, with nested `user`/`position` fallbacks) showing:
- Long name + short-name badge
- Node ID, Role, Hops, Hardware model, Battery, SNR, Altitude, Coordinates
- Relative last-heard footer (honors the user's time/date format)

**Per-source / protocol on Unified** — each merged node carries a deduped `sources` array (`{ sourceId, sourceName, protocol }`); the popup renders a "Seen by N sources" section with **Meshtastic** (green) / **MeshCore** (peach) badges.

**MeshCore cross-source merge fix** — MeshCore nodes were keyed in `mergeUnifiedSourceData` by the server-built `nodeId` (`mc:<sourceId>:<pubkey>`), which embeds the reporting source. The same physical node heard by multiple MeshCore sources therefore never merged and always showed "1 source". They're now keyed on the stable `publicKey`. Meshtastic continues to key on `nodeNum`.

## Implementation notes
- `useDashboardUnifiedData` now accepts `DashboardSource[]`; bare-string callers (MapAnalysis layers) still work and simply get no `sources` field.
- `nodes.css`: added `.node-popup-sources` / `.node-popup-protocol-badge` styles.

## Testing
- Full Vitest suite: **5731 passed, 0 failed**.
- New unit tests: `DashboardNodePopup` (fields, nested fallbacks, sources list, single-source omission) + regression tests for cross-source MeshCore merge by `publicKey`.
- Verified live in the dev container (Unified view): a Meshtastic node correctly shows "Seen by 5 sources", and after the fix MeshCore nodes (e.g. `KE4JQ Base RAK1W`) correctly show "Seen by 2 sources" (MC-Sandbox + MC-BLESandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)