### PR TITLE
fix(map): make RF/UDP/MQTT visibility toggles additive per node

### DIFF
--- a/src/hooks/useDashboardData.test.ts
+++ b/src/hooks/useDashboardData.test.ts
@@ -418,6 +418,27 @@ describe('mergeUnifiedSourceData', () => {
     ]);
   });
 
+  it('attaches a union of transport classes across sources (additive map filter)', () => {
+    // Same node heard via RF (LORA=1) on source 1 and MQTT (5) on source 2.
+    // The whole-record merge keeps the newest transportMechanism (MQTT), but
+    // transportClasses must list BOTH so "Show RF" keeps the node visible.
+    const merged = mergeUnifiedSourceData([
+      {
+        sourceId: 's1', sourceName: 'Direct', protocol: 'Meshtastic',
+        nodes: [{ nodeNum: 700, lastHeard: 100, transportMechanism: 1 }],
+        traceroutes: [], neighborInfo: [], channels: [],
+      },
+      {
+        sourceId: 's2', sourceName: 'MQTT Bridge', protocol: 'Meshtastic',
+        nodes: [{ nodeNum: 700, lastHeard: 200, transportMechanism: 5 }],
+        traceroutes: [], neighborInfo: [], channels: [],
+      },
+    ]);
+    expect(merged.nodes).toHaveLength(1);
+    const classes = (merged.nodes[0] as any).transportClasses;
+    expect([...classes].sort()).toEqual(['mqtt', 'rf']);
+  });
+
   it('keeps distinct MeshCore nodes (different publicKeys) separate', () => {
     const merged = mergeUnifiedSourceData([
       {

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -8,6 +8,7 @@
 import { useQuery, useQueries } from '@tanstack/react-query';
 import { appBasename } from '../init';
 import { useAuth } from '../contexts/AuthContext';
+import { classifyNodeTransport, type NodeTransportClass } from '../utils/nodeTransport';
 
 /**
  * A data source configured in MeshMonitor
@@ -398,6 +399,14 @@ export function mergeUnifiedSourceData(
       if (e.source && !seen.has(e.source.sourceId)) seen.set(e.source.sourceId, e.source);
     }
     if (seen.size > 0) merged.sources = Array.from(seen.values());
+    // Union of transport classes across every per-source record so the map's
+    // RF/UDP/MQTT toggles are additive — a node heard via RF on one source and
+    // MQTT on another stays visible under "Show RF" even with "Show MQTT" off.
+    // The whole-record merge keeps only the newest transportMechanism, which
+    // would otherwise drop the other transports.
+    const classes = new Set<NodeTransportClass>();
+    for (const e of entries) classes.add(classifyNodeTransport(e.node));
+    merged.transportClasses = Array.from(classes);
     return merged;
   });
 

--- a/src/utils/nodeTransport.test.ts
+++ b/src/utils/nodeTransport.test.ts
@@ -115,3 +115,46 @@ describe('nodePassesTransportFilter', () => {
     }
   });
 });
+
+describe('nodePassesTransportFilter — additive transportClasses (Unified)', () => {
+  // A node heard via RF on one source and MQTT on another carries both classes.
+  const rfAndMqtt = { transportClasses: ['rf', 'mqtt'] as const, transportMechanism: TX_MQTT };
+
+  it('stays visible under "Show RF" even when MQTT is off (the reported bug)', () => {
+    expect(
+      nodePassesTransportFilter(rfAndMqtt, { showRfNodes: true, showUdpNodes: false, showMqttNodes: false }),
+    ).toBe(true);
+  });
+
+  it('stays visible under "Show MQTT" even when RF is off', () => {
+    expect(
+      nodePassesTransportFilter(rfAndMqtt, { showRfNodes: false, showUdpNodes: false, showMqttNodes: true }),
+    ).toBe(true);
+  });
+
+  it('is hidden only when ALL of its classes are toggled off', () => {
+    expect(
+      nodePassesTransportFilter(rfAndMqtt, { showRfNodes: false, showUdpNodes: true, showMqttNodes: false }),
+    ).toBe(false);
+  });
+
+  it('ignores the collapsed transportMechanism when a transportClasses union is present', () => {
+    // transportMechanism says MQTT (newest-wins from the merge), but the union
+    // includes rf — RF-only filter must still show it.
+    expect(
+      nodePassesTransportFilter(
+        { transportClasses: ['rf'], transportMechanism: TX_MQTT },
+        { showRfNodes: true, showUdpNodes: false, showMqttNodes: false },
+      ),
+    ).toBe(true);
+  });
+
+  it('falls back to single-class classification when transportClasses is empty/absent', () => {
+    expect(
+      nodePassesTransportFilter(
+        { transportClasses: [], transportMechanism: TX_MQTT },
+        { showRfNodes: true, showUdpNodes: false, showMqttNodes: false },
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/utils/nodeTransport.ts
+++ b/src/utils/nodeTransport.ts
@@ -22,7 +22,22 @@ export const TX_API = 7;
 
 export type NodeTransportClass = 'rf' | 'udp' | 'mqtt';
 
-/** Classify a node's most-recent transport for the map filter. */
+/** A node carrying a precomputed union of transport classes (set by the
+ *  Unified merge — see `mergeUnifiedSourceData`). */
+export interface NodeTransportFields {
+  transportMechanism?: number | null;
+  viaMqtt?: boolean | null;
+  /**
+   * Union of transport classes this node has been observed on, across every
+   * source that reported it. Present on Unified-merged nodes so the map's
+   * RF/UDP/MQTT toggles are *additive* — a node heard via RF on one source and
+   * MQTT on another stays visible while "Show RF" is on even if "Show MQTT" is
+   * off. Absent on single-source rows (which have exactly one class).
+   */
+  transportClasses?: NodeTransportClass[] | null;
+}
+
+/** Classify a single node record's most-recent transport for the map filter. */
 export function classifyNodeTransport(node: {
   transportMechanism?: number | null;
   viaMqtt?: boolean | null;
@@ -41,17 +56,33 @@ export function classifyNodeTransport(node: {
 }
 
 /**
- * Returns true when a node should be visible on the map given the
- * three transport-class toggles. Keep this small/inlined — it's
- * called from inside large `.filter()` chains.
+ * The set of transport classes a node should be filtered against. Prefers the
+ * precomputed `transportClasses` union (Unified view), falling back to the
+ * single classification of this record (single-source view / unmerged rows).
+ */
+export function getNodeTransportClasses(node: NodeTransportFields): NodeTransportClass[] {
+  if (Array.isArray(node.transportClasses) && node.transportClasses.length > 0) {
+    return node.transportClasses;
+  }
+  return [classifyNodeTransport(node)];
+}
+
+/**
+ * Returns true when a node should be visible on the map given the three
+ * transport-class toggles. Additive: a node is shown when ANY transport class
+ * it has been seen on (across sources) has its toggle enabled — so toggling
+ * MQTT off no longer hides a node that is also reachable via RF. Keep this
+ * small — it's called from inside large `.filter()` chains.
  */
 export function nodePassesTransportFilter(
-  node: { transportMechanism?: number | null; viaMqtt?: boolean | null },
+  node: NodeTransportFields,
   flags: { showRfNodes: boolean; showUdpNodes: boolean; showMqttNodes: boolean },
 ): boolean {
-  switch (classifyNodeTransport(node)) {
-    case 'mqtt': return flags.showMqttNodes;
-    case 'udp':  return flags.showUdpNodes;
-    case 'rf':   return flags.showRfNodes;
-  }
+  return getNodeTransportClasses(node).some((c) => {
+    switch (c) {
+      case 'mqtt': return flags.showMqttNodes;
+      case 'udp':  return flags.showUdpNodes;
+      case 'rf':   return flags.showRfNodes;
+    }
+  });
 }


### PR DESCRIPTION
## Summary

The Dashboard map's **Show RF / UDP / MQTT** toggles hid nodes incorrectly: a node reachable via RF that had *also* been heard over MQTT would disappear when "Show MQTT" was turned off, even with "Show RF" on. Most visible with MeshCore/MQTT-bridge setups.

## Root cause

Transport class was a single value per node. In the **Unified** view, the cross-source merge keeps only the newest source's `transportMechanism` (newest-wins), so a node heard via RF on a direct source **and** MQTT on an MQTT bridge collapsed to just `mqtt`. The single-class filter then gated the whole node on "Show MQTT".

## Fix — additive, tracked per node *and* per source

- `mergeUnifiedSourceData` attaches a `transportClasses` array on each merged node: the **union** of every reporting source's transport class.
- `nodePassesTransportFilter` is now additive — a node is shown when **any** of its transport classes has its toggle enabled (`getNodeTransportClasses` prefers the union, falling back to single-class classification for single-source/unmerged rows, so per-source pages are unchanged).

## Testing

- Full Vitest suite: **5737 passed, 0 failed**.
- New tests: additive-filter cases in `nodeTransport.test.ts` (RF+MQTT node stays visible under "Show RF" with MQTT off; hidden only when all its classes are off) and a cross-source union-merge case in `useDashboardData.test.ts`.
- Verified live in the dev container (Unified view): of **195** RF+MQTT nodes, toggling "Show MQTT" off (RF on) kept all of them visible — marker count dropped 289 → 236, removing only the 53 MQTT-only nodes. Example node `8558` (RF+MQTT) stayed on the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)