### PR TITLE
Make traceroute history limit configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ MESHTASTIC_TCP_PORT=4403
 # Increase if your node shows queue overflow during config loading
 # MESHTASTIC_MODULE_CONFIG_DELAY_MS=100
 
+# Number of traceroute history rows to keep per node pair (default: 50)
+# Increase for longer-term route trend analysis.
+# TRACEROUTE_HISTORY_LIMIT=50
+
 # MeshCore sources are configured through the UI (Sources sidebar). The legacy
 # 3.x `MESHCORE_*` environment-variable bootstrap was removed in 4.6 — add a
 # MeshCore source from the dashboard's Sources panel instead.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -67,6 +67,7 @@ MeshMonitor can be configured using environment variables. Here are the most imp
 | `SESSION_SECRET` | Secret key for session encryption (REQUIRED in production) | Auto-generated |
 | `NODE_ENV` | Environment mode (`development` or `production`) | `development` |
 | `DATABASE_PATH` | SQLite database file path | `/data/meshmonitor.db` |
+| `TRACEROUTE_HISTORY_LIMIT` | Traceroute history rows to keep per node pair | `50` |
 | `BASE_URL` | Base path if serving from subfolder (e.g., `/meshmonitor`) | `/` (root) |
 | `TZ` | Timezone for log timestamps and scheduled tasks | `America/New_York` |
 

--- a/src/server/config/environment.traceroute.test.ts
+++ b/src/server/config/environment.traceroute.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getEnvironmentConfig, resetEnvironmentConfig } from './environment.js';
+
+describe('Traceroute history environment configuration', () => {
+  const originalLimit = process.env.TRACEROUTE_HISTORY_LIMIT;
+
+  afterEach(() => {
+    if (originalLimit !== undefined) {
+      process.env.TRACEROUTE_HISTORY_LIMIT = originalLimit;
+    } else {
+      delete process.env.TRACEROUTE_HISTORY_LIMIT;
+    }
+    resetEnvironmentConfig();
+  });
+
+  it('defaults to 50 when TRACEROUTE_HISTORY_LIMIT is not set', () => {
+    delete process.env.TRACEROUTE_HISTORY_LIMIT;
+    resetEnvironmentConfig();
+
+    const config = getEnvironmentConfig();
+
+    expect(config.tracerouteHistoryLimit).toBe(50);
+    expect(config.tracerouteHistoryLimitProvided).toBe(false);
+  });
+
+  it('accepts a positive integer override', () => {
+    process.env.TRACEROUTE_HISTORY_LIMIT = '500';
+    resetEnvironmentConfig();
+
+    const config = getEnvironmentConfig();
+
+    expect(config.tracerouteHistoryLimit).toBe(500);
+    expect(config.tracerouteHistoryLimitProvided).toBe(true);
+  });
+
+  it('falls back to 50 for invalid values', () => {
+    process.env.TRACEROUTE_HISTORY_LIMIT = '0';
+    resetEnvironmentConfig();
+
+    const config = getEnvironmentConfig();
+
+    expect(config.tracerouteHistoryLimit).toBe(50);
+    expect(config.tracerouteHistoryLimitProvided).toBe(false);
+  });
+});

--- a/src/server/config/environment.ts
+++ b/src/server/config/environment.ts
@@ -66,6 +66,22 @@ function parseInt32(
 }
 
 /**
+ * Parse a positive integer environment variable.
+ */
+function parsePositiveInt(
+  name: string,
+  envValue: string | undefined,
+  defaultValue: number
+): { value: number; wasProvided: boolean } {
+  const parsed = parseInt32(name, envValue, defaultValue);
+  if (parsed.value < 1) {
+    logger.warn(`⚠️  Invalid ${name} value: "${envValue}". Expected positive integer. Using default: ${defaultValue}`);
+    return { value: defaultValue, wasProvided: false };
+  }
+  return parsed;
+}
+
+/**
  * Parse a rate limit environment variable.
  * Accepts positive integers (normal limit), or special values to disable:
  *   "unlimited" (case-insensitive), "0", "-1" → returns 0 (sentinel for disabled)
@@ -200,6 +216,8 @@ export interface EnvironmentConfig {
   databaseUrl: string | undefined;
   databaseUrlProvided: boolean;
   databaseType: 'sqlite' | 'postgres' | 'mysql';
+  tracerouteHistoryLimit: number;
+  tracerouteHistoryLimitProvided: boolean;
 
   // Meshtastic
   meshtasticNodeIp: string;
@@ -458,6 +476,12 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
     logger.debug('📦 Database: SQLite (default)');
   }
 
+  const tracerouteHistoryLimit = parsePositiveInt(
+    'TRACEROUTE_HISTORY_LIMIT',
+    process.env.TRACEROUTE_HISTORY_LIMIT,
+    50
+  );
+
   const versionCheckDisabled = process.env.VERSION_CHECK_DISABLED == "true";
 
   // Meshtastic
@@ -675,6 +699,7 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
   } else {
     logger.info(`   DATABASE_PATH: ${databasePath.value} (${src(databasePath.wasProvided)})`);
   }
+  logger.info(`   TRACEROUTE_HISTORY_LIMIT: ${tracerouteHistoryLimit.value} (${src(tracerouteHistoryLimit.wasProvided)})`);
   logger.info('   --- Meshtastic ---');
   logger.info(`   MESHTASTIC_NODE_IP: ${meshtasticNodeIp.value} (${src(meshtasticNodeIp.wasProvided)})`);
   logger.info(`   MESHTASTIC_NODE_PORT / MESHTASTIC_TCP_PORT: ${meshtasticTcpPort.value} (${src(meshtasticTcpPort.wasProvided)})`);
@@ -763,6 +788,8 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
     databaseUrl: databaseUrl.value,
     databaseUrlProvided: databaseUrl.wasProvided,
     databaseType,
+    tracerouteHistoryLimit: tracerouteHistoryLimit.value,
+    tracerouteHistoryLimitProvided: tracerouteHistoryLimit.wasProvided,
 
     // Meshtastic
     meshtasticNodeIp: meshtasticNodeIp.value,

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -39,7 +39,7 @@ import {
 import type { DatabaseType, DbPacketLog as DbTypesPacketLog, DbPacketCountByNode, DbPacketCountByPortnum, DbDistinctRelayNode } from '../db/types.js';
 
 // Configuration constants for traceroute history
-const TRACEROUTE_HISTORY_LIMIT = 50;
+const TRACEROUTE_HISTORY_LIMIT = getEnvironmentConfig().tracerouteHistoryLimit;
 const PENDING_TRACEROUTE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 export interface DbNode {


### PR DESCRIPTION
## Summary
- Add TRACEROUTE_HISTORY_LIMIT env var with default 50 and positive-integer validation
- Use the configured limit when pruning per-node-pair traceroute history
- Document the option in .env.example and configuration docs

## Testing
- npm test -- --run src/server/config/environment.traceroute.test.ts src/server/config/environment.ratelimit.test.ts
- npm run typecheck *(fails on existing Express route param typing errors unrelated to this change)*
