### PR TITLE
feat(meshcore): dashboard neighbor links, saved-password neighbor queries, on-demand remote console

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -37,6 +37,10 @@ vi.mock('../../contexts/MapContext', () => ({
     setShowUdpNodes: vi.fn(),
     showMqttNodes: true,
     setShowMqttNodes: vi.fn(),
+    showNeighborInfo: true,
+    setShowNeighborInfo: vi.fn(),
+    showWaypoints: false,
+    setShowWaypoints: vi.fn(),
   }),
 }));
 
@@ -152,6 +156,7 @@ const neighborLinkMissingPositions = {
 const defaultProps = {
   nodes: [],
   neighborInfo: [],
+  meshcoreNeighbors: [],
   traceroutes: [],
   channels: [],
   tilesetId: 'osm',
@@ -274,5 +279,46 @@ describe('DashboardMap', () => {
     );
     const markers = screen.getAllByTestId('map-marker');
     expect(markers.length).toBe(1);
+  });
+
+  // --- MeshCore neighbor links ------------------------------------------------
+
+  const mcNodeA = {
+    isMeshCore: true, publicKey: 'AAAA', nodeNum: 0,
+    user: { id: 'mc:s:AAAA', shortName: 'A', longName: 'MC A' },
+    position: { latitude: 35.0, longitude: -80.0 },
+    hopsAway: 0, role: 0, lastHeard: recent,
+  };
+  const mcNodeB = {
+    isMeshCore: true, publicKey: 'BBBB', nodeNum: 0,
+    user: { id: 'mc:s:BBBB', shortName: 'B', longName: 'MC B' },
+    position: { latitude: 36.0, longitude: -81.0 },
+    hopsAway: 0, role: 0, lastHeard: recent,
+  };
+  const mcEdge = { id: 1, publicKey: 'AAAA', neighborPublicKey: 'BBBB', sourceId: 's', snr: 5, timestamp: recent * 1000 };
+
+  it('renders a MeshCore neighbor link between two positioned MeshCore nodes', () => {
+    render(
+      <DashboardMap {...defaultProps} nodes={[mcNodeA, mcNodeB]} meshcoreNeighbors={[mcEdge]} />,
+    );
+    expect(screen.getAllByTestId('map-marker')).toHaveLength(2);
+    // One MeshCore neighbor polyline (no traceroute/meshtastic-neighbor lines here).
+    expect(screen.getAllByTestId('map-polyline')).toHaveLength(1);
+  });
+
+  it('does not render a MeshCore neighbor link when one endpoint node is not visible', () => {
+    render(
+      <DashboardMap {...defaultProps} nodes={[mcNodeA]} meshcoreNeighbors={[mcEdge]} />,
+    );
+    expect(screen.getAllByTestId('map-marker')).toHaveLength(1);
+    expect(screen.queryAllByTestId('map-polyline')).toHaveLength(0);
+  });
+
+  it('deduplicates a MeshCore link reported by multiple sources (drawn once)', () => {
+    const reverseEdge = { id: 2, publicKey: 'BBBB', neighborPublicKey: 'AAAA', sourceId: 's2', snr: 4, timestamp: recent * 1000 };
+    render(
+      <DashboardMap {...defaultProps} nodes={[mcNodeA, mcNodeB]} meshcoreNeighbors={[mcEdge, reverseEdge]} />,
+    );
+    expect(screen.getAllByTestId('map-polyline')).toHaveLength(1);
   });
 });

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -26,6 +26,12 @@ import { nodePassesTransportFilter } from '../../utils/nodeTransport';
 export interface DashboardMapProps {
   nodes: any[];
   neighborInfo: any[];
+  /**
+   * MeshCore neighbor edges (from `/api/sources/:id/meshcore/neighbors`), keyed
+   * by publicKey. Rendered as links between MeshCore node markers when the
+   * "Show Neighbors" toggle is on. Empty for non-MeshCore sources.
+   */
+  meshcoreNeighbors?: any[];
   traceroutes: any[];
   channels: any[];
   tilesetId: string;
@@ -53,6 +59,12 @@ function snrToColor(snr: number): string {
   if (snr >= 0) return '#eab308';
   if (snr >= -5) return '#f97316';
   return '#ef4444';
+}
+
+/** SNR → line opacity for MeshCore neighbor links, matching MeshCoreNeighborLinksLayer. */
+function snrToOpacity(snr: number | null | undefined): number {
+  if (snr == null) return 0.4;
+  return Math.max(0.2, Math.min(1, (snr + 10) / 20));
 }
 
 /** Safe JSON.parse that yields [] on bad/empty input. */
@@ -119,6 +131,7 @@ function MapBoundsUpdater({ positions, sourceId }: MapBoundsUpdaterProps) {
 export default function DashboardMap({
   nodes,
   neighborInfo,
+  meshcoreNeighbors = [],
   traceroutes,
   tilesetId,
   customTilesets,
@@ -141,6 +154,8 @@ export default function DashboardMap({
     setShowUdpNodes,
     showMqttNodes,
     setShowMqttNodes,
+    showNeighborInfo,
+    setShowNeighborInfo,
     showWaypoints,
     setShowWaypoints,
   } = useMapContext();
@@ -170,6 +185,44 @@ export default function DashboardMap({
     }
     return map;
   }, [nodesWithPosition]);
+
+  // publicKey → [lat, lng] for resolving MeshCore neighbor-link endpoints.
+  // MeshCore nodes carry no meshtastic nodeNum; their stable identity (and the
+  // key the neighbor edges reference) is the public key.
+  const positionByPublicKey = useMemo(() => {
+    const map = new Map<string, [number, number]>();
+    for (const { node, pos } of nodesWithPosition) {
+      if (node.isMeshCore && typeof node.publicKey === 'string' && node.publicKey.length > 0) {
+        map.set(node.publicKey, [pos.lat, pos.lng]);
+      }
+    }
+    return map;
+  }, [nodesWithPosition]);
+
+  // MeshCore neighbor links: one Polyline per edge whose BOTH endpoints resolve
+  // to a currently-visible MeshCore node. Gated by the "Show Neighbors" toggle.
+  // Endpoints are filtered through the same node pipeline above, so links to a
+  // hidden node (stale / ignored / RF off) naturally drop out. Deduped by the
+  // unordered {publicKey, neighborPublicKey} pair so the same link reported by
+  // multiple sources (Unified view) draws once.
+  const meshcoreSegments = useMemo(() => {
+    if (!showNeighborInfo) return [];
+    const seen = new Set<string>();
+    const segs: Array<{ key: string; positions: [number, number][]; opacity: number }> = [];
+    for (const e of (meshcoreNeighbors ?? [])) {
+      const pk = e?.publicKey;
+      const npk = e?.neighborPublicKey;
+      if (typeof pk !== 'string' || typeof npk !== 'string') continue;
+      const a = positionByPublicKey.get(pk);
+      const b = positionByPublicKey.get(npk);
+      if (!a || !b) continue;
+      const pairKey = pk < npk ? `${pk}~${npk}` : `${npk}~${pk}`;
+      if (seen.has(pairKey)) continue;
+      seen.add(pairKey);
+      segs.push({ key: pairKey, positions: [a, b], opacity: snrToOpacity(e?.snr) });
+    }
+    return segs;
+  }, [meshcoreNeighbors, positionByPublicKey, showNeighborInfo]);
 
   // Traceroute segments: one Polyline per hop, colored by snrTowards. Empty
   // unless the user has enabled "Show Route Segments" or "Show Traceroute".
@@ -320,7 +373,16 @@ export default function DashboardMap({
           />
         ))}
 
-        {neighborInfo
+        {/* MeshCore neighbor links — cyan dashed, resolved by public key. */}
+        {meshcoreSegments.map((s) => (
+          <Polyline
+            key={`mc-neighbor-${s.key}`}
+            positions={s.positions}
+            pathOptions={{ color: '#06b6d4', weight: 1.5, opacity: s.opacity, dashArray: '6 4' }}
+          />
+        ))}
+
+        {showNeighborInfo && neighborInfo
           .filter((link: any) => {
             const tc = link.transportClass ?? 'rf';
             if (tc === 'mqtt' && !showMqttNodes) return false;
@@ -380,6 +442,14 @@ export default function DashboardMap({
               onChange={(e) => setShowRoute(e.target.checked)}
             />
             <span>Show Traceroute</span>
+          </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showNeighborInfo}
+              onChange={(e) => setShowNeighborInfo(e.target.checked)}
+            />
+            <span>Show Neighbors</span>
           </label>
           <label className="map-control-item">
             <input

--- a/src/components/MeshCore/MeshCoreRemoteConsole.css
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.css
@@ -49,6 +49,13 @@
   color: var(--ctp-subtext0);
 }
 
+/* Saved-password-available (not yet logged in): teal, distinct from the
+   green "session active" so it doesn't read as an active session. */
+.mrc-status-saved {
+  background: var(--ctp-teal);
+  color: var(--ctp-crust);
+}
+
 .mrc-banner {
   padding: 0.6rem 0.8rem;
   border-radius: var(--radius-md, 6px);

--- a/src/components/MeshCore/MeshCoreRemoteConsole.test.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.test.tsx
@@ -1,17 +1,15 @@
 /**
  * @vitest-environment jsdom
  *
- * Regression tests for MeshCoreRemoteConsole's auto-login flow.
+ * Tests for MeshCoreRemoteConsole's credential handling.
  *
- * The auto-login `useEffect` depends on `actions`, and `useMeshCore`
- * rebuilds the `actions` object on every poll refresh (every few
- * seconds). Without an attempted-for-key guard, the effect re-fires
- * on every poll and pushes a fresh "Logged in with saved password"
- * line into the transcript each time — visible as continuous log
- * spam in the Remote Administration console.
+ * The console must NEVER auto-login (that spends radio airtime the user
+ * didn't ask for). On mount it only fetches the credential *capability* (a
+ * local server lookup) so it can show a "Saved password" indicator; the saved
+ * password is used only when the user explicitly clicks the login button.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MeshCoreRemoteConsole } from './MeshCoreRemoteConsole';
 
 vi.mock('react-i18next', () => ({
@@ -23,8 +21,7 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-// Stub the heavy children — we're only exercising the auto-login effect
-// and its interaction with the `actions` prop identity.
+// Stub the heavy children — we're only exercising the console's own UI.
 vi.mock('./MeshCoreRemoteStatsPanel', () => ({
   MeshCoreRemoteStatsPanel: () => null,
 }));
@@ -38,10 +35,9 @@ vi.mock('./CliConsoleBody', () => ({
 const PK = 'a'.repeat(64);
 
 function makeActions(overrides?: Partial<Record<string, ReturnType<typeof vi.fn>>>) {
-  const loginRemoteWithSaved = vi.fn().mockResolvedValue({ success: true });
   return {
     loginRemote: vi.fn(),
-    loginRemoteWithSaved,
+    loginRemoteWithSaved: vi.fn().mockResolvedValue({ success: true }),
     sendCliCommand: vi.fn(),
     getRemoteAdminCapability: vi.fn().mockResolvedValue({
       canRemember: true,
@@ -55,70 +51,56 @@ function makeActions(overrides?: Partial<Record<string, ReturnType<typeof vi.fn>
   };
 }
 
-describe('MeshCoreRemoteConsole auto-login', () => {
+describe('MeshCoreRemoteConsole credential handling', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('attempts auto-login exactly once across multiple actions-identity changes for the same contact', async () => {
-    // Shared mock instance so re-renders see the same call counter even
-    // though the wrapping `actions` object identity changes each time.
-    const sharedLoginWithSaved = vi.fn().mockResolvedValue({ success: true });
+  it('does NOT auto-login on mount (no radio airtime), but fetches capability', async () => {
+    const actions = makeActions();
+    render(<MeshCoreRemoteConsole publicKey={PK} contactName="Repeater" actions={actions as any} />);
 
-    const buildActions = () => ({
-      ...makeActions(),
-      loginRemoteWithSaved: sharedLoginWithSaved,
-    });
-
-    const { rerender } = render(
-      <MeshCoreRemoteConsole publicKey={PK} contactName="Repeater" actions={buildActions()} />,
-    );
-
-    // Wait for the first auto-login attempt to resolve.
-    await waitFor(() => expect(sharedLoginWithSaved).toHaveBeenCalledTimes(1));
-
-    // Simulate several poll refreshes — useMeshCore would hand down a new
-    // `actions` object each time. Without the guard the effect re-fires
-    // and `loginRemoteWithSaved` is called once per re-render.
-    for (let i = 0; i < 5; i += 1) {
-      await act(async () => {
-        rerender(
-          <MeshCoreRemoteConsole publicKey={PK} contactName="Repeater" actions={buildActions()} />,
-        );
-      });
-    }
-
-    // Still exactly one auto-login attempt.
-    expect(sharedLoginWithSaved).toHaveBeenCalledTimes(1);
+    // Capability is fetched (local lookup) so the UI can reflect saved state…
+    await waitFor(() => expect(actions.getRemoteAdminCapability).toHaveBeenCalled());
+    // …but the saved password is never used automatically.
+    expect(actions.loginRemoteWithSaved).not.toHaveBeenCalled();
   });
 
-  it('re-attempts auto-login after the targeted contact changes', async () => {
-    const sharedLoginWithSaved = vi.fn().mockResolvedValue({ success: true });
-    const PK2 = 'b'.repeat(64);
+  it('shows a "Saved password" indicator when a credential is stored', async () => {
+    const actions = makeActions();
+    render(<MeshCoreRemoteConsole publicKey={PK} contactName="Repeater" actions={actions as any} />);
 
-    const buildActionsFor = (key: string) => ({
-      ...makeActions({
-        getRemoteAdminCapability: vi.fn().mockResolvedValue({
-          canRemember: true,
-          rotatedCount: 0,
-          rotated: [],
-          stored: [{ publicKey: key, name: 'Stored' }],
-        }),
+    // Chip text is "✓ Saved password" — match the substring.
+    await waitFor(() => expect(screen.getByText(/Saved password/)).toBeInTheDocument());
+    expect(actions.loginRemoteWithSaved).not.toHaveBeenCalled();
+  });
+
+  it('logs in with the saved password only when the user clicks the button', async () => {
+    const actions = makeActions();
+    render(<MeshCoreRemoteConsole publicKey={PK} contactName="Repeater" actions={actions as any} />);
+
+    const btn = await screen.findByText('Log in with saved password');
+    expect(actions.loginRemoteWithSaved).not.toHaveBeenCalled(); // not yet
+
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(actions.loginRemoteWithSaved).toHaveBeenCalledTimes(1));
+    expect(actions.loginRemoteWithSaved).toHaveBeenCalledWith(PK);
+  });
+
+  it('shows the plain "Log in" button (no saved indicator) when nothing is stored', async () => {
+    const actions = makeActions({
+      getRemoteAdminCapability: vi.fn().mockResolvedValue({
+        canRemember: true,
+        rotatedCount: 0,
+        rotated: [],
+        stored: [],
       }),
-      loginRemoteWithSaved: sharedLoginWithSaved,
     });
+    render(<MeshCoreRemoteConsole publicKey={PK} contactName="Repeater" actions={actions as any} />);
 
-    const { rerender } = render(
-      <MeshCoreRemoteConsole publicKey={PK} contactName="Repeater A" actions={buildActionsFor(PK)} />,
-    );
-    await waitFor(() => expect(sharedLoginWithSaved).toHaveBeenCalledWith(PK));
-
-    await act(async () => {
-      rerender(
-        <MeshCoreRemoteConsole publicKey={PK2} contactName="Repeater B" actions={buildActionsFor(PK2)} />,
-      );
-    });
-    await waitFor(() => expect(sharedLoginWithSaved).toHaveBeenCalledWith(PK2));
-    expect(sharedLoginWithSaved).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(actions.getRemoteAdminCapability).toHaveBeenCalled());
+    expect(screen.queryByText('Saved password')).not.toBeInTheDocument();
+    expect(screen.queryByText('Log in with saved password')).not.toBeInTheDocument();
   });
 });

--- a/src/components/MeshCore/MeshCoreRemoteConsole.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.tsx
@@ -84,15 +84,6 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
   // lines into the transcript without lifting transcript state.
   const bodyRef = useRef<CliConsoleBodyHandle | null>(null);
 
-  // Guard: auto-login runs from a useEffect whose deps include the
-  // `actions` object, and `useMeshCore` rebuilds `actions` on every
-  // poll refresh — so without this ref the effect re-fires and pushes
-  // a fresh "Logged in with saved password" line into the transcript
-  // every few seconds. Tracks the publicKey we've already auto-attempted
-  // in this mount cycle; the reset effect below clears it on contact
-  // change so navigating away and back still re-attempts.
-  const autoLoginAttemptedFor = useRef<string | null>(null);
-
   // Reset auth state when the targeted contact changes — a stale "logged
   // in" badge against the wrong contact would be actively misleading.
   useEffect(() => {
@@ -101,7 +92,6 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
     setLoginPassword('');
     setRememberPassword(false);
     setLoginError(null);
-    autoLoginAttemptedFor.current = null;
   }, [publicKey]);
 
   const refreshCapability = useCallback(async () => {
@@ -110,37 +100,14 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
     return cap;
   }, [actions]);
 
-  // On mount (and on contact change): fetch capability, and if this
-  // contact has a non-rotated stored credential, silently attempt
-  // auto-login. The plaintext password stays server-side throughout.
+  // On mount (and on contact change): fetch the credential capability so the
+  // UI can show whether a saved password exists. This is a local server/DB
+  // lookup — NO radio airtime. We intentionally do NOT auto-login: logging in
+  // costs airtime, so it's an explicit user action (the "Log in with saved
+  // password" button below).
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const cap = await refreshCapability();
-      if (cancelled || !cap) return;
-      const target = publicKey.toLowerCase();
-      const isStored = cap.stored?.some((s) => s.publicKey.toLowerCase() === target);
-      const isRotated = cap.rotated?.some((r) => r.publicKey.toLowerCase() === target);
-      if (!isStored || isRotated) return;
-      if (autoLoginAttemptedFor.current === publicKey) return;
-      autoLoginAttemptedFor.current = publicKey;
-      const result = await actions.loginRemoteWithSaved(publicKey);
-      if (cancelled) return;
-      if (result.success) {
-        setLoggedIn(true);
-        bodyRef.current?.appendInfo(
-          t('meshcore.remoteConsole.auto_login_success', 'Logged in with saved password'),
-        );
-      } else if (result.code === 'CREDENTIAL_KEY_ROTATED') {
-        void refreshCapability();
-      }
-      // NO_STORED_CREDENTIAL / STORED_CREDENTIAL_REJECTED → silently fall
-      // through to the manual login modal.
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [publicKey, actions, refreshCapability, t]);
+    void refreshCapability();
+  }, [publicKey, refreshCapability]);
 
   const handleLogin = useCallback(async () => {
     setLoginBusy(true);
@@ -166,6 +133,28 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
     void refreshCapability();
   }, [actions, loginPassword, publicKey, refreshCapability, rememberPassword, t]);
 
+  // On-demand login using the saved password (one click, no re-typing). This
+  // is the only place the saved credential is used from the console, and only
+  // when the user explicitly asks — never automatically.
+  const handleLoginWithSaved = useCallback(async () => {
+    setLoginBusy(true);
+    setLoginError(null);
+    const result = await actions.loginRemoteWithSaved(publicKey);
+    setLoginBusy(false);
+    if (result.success) {
+      setLoggedIn(true);
+      bodyRef.current?.appendInfo(
+        t('meshcore.remoteConsole.login_success_saved', 'Logged in with saved password'),
+      );
+      void refreshCapability();
+      return;
+    }
+    if (result.code === 'CREDENTIAL_KEY_ROTATED') {
+      void refreshCapability();
+    }
+    setLoginError(result.error || t('meshcore.remoteConsole.login_failed', 'Login failed'));
+  }, [actions, publicKey, refreshCapability, t]);
+
   const handleForgetCredential = useCallback(async () => {
     const ok = await actions.forgetRemoteCredential(publicKey);
     bodyRef.current?.appendInfo(
@@ -178,6 +167,13 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
 
   const isRotatedForThisContact =
     capability?.rotated.some((r) => r.publicKey.toLowerCase() === publicKey.toLowerCase()) ?? false;
+
+  // A usable saved password exists for this contact (stored and decryptable —
+  // i.e. not key-rotated). Drives the "✓ Saved password" indicator and the
+  // one-click login button.
+  const hasSavedCredential =
+    (capability?.stored.some((s) => s.publicKey.toLowerCase() === publicKey.toLowerCase()) ?? false) &&
+    !isRotatedForThisContact;
 
   const runCommand = useCallback(
     (text: string, opts?: { confirm?: boolean }) => actions.sendCliCommand(publicKey, text, opts),
@@ -194,6 +190,10 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
           {loggedIn ? (
             <span className="mrc-status-chip mrc-status-ok">
               {t('meshcore.remoteConsole.session_active', 'Session active')}
+            </span>
+          ) : hasSavedCredential ? (
+            <span className="mrc-status-chip mrc-status-saved">
+              ✓ {t('meshcore.remoteConsole.saved_password', 'Saved password')}
             </span>
           ) : (
             <span className="mrc-status-chip mrc-status-idle">
@@ -226,13 +226,34 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
       )}
 
       <div className="mrc-actions">
-        {!loggedIn ? (
-          <button type="button" className="mrc-btn-primary" onClick={() => setShowLogin(true)}>
-            {t('meshcore.remoteConsole.login_button', 'Log in to {{name}}', { name: contactName })}
-          </button>
-        ) : (
+        {loggedIn ? (
           <button type="button" className="mrc-btn-secondary" onClick={handleForgetCredential}>
             {t('meshcore.remoteConsole.forget_credential', 'Forget stored password')}
+          </button>
+        ) : hasSavedCredential ? (
+          <>
+            <button
+              type="button"
+              className="mrc-btn-primary"
+              onClick={() => void handleLoginWithSaved()}
+              disabled={loginBusy}
+            >
+              {loginBusy
+                ? t('meshcore.remoteConsole.logging_in', 'Logging in…')
+                : t('meshcore.remoteConsole.login_with_saved_button', 'Log in with saved password')}
+            </button>
+            <button
+              type="button"
+              className="mrc-btn-secondary"
+              onClick={() => setShowLogin(true)}
+              disabled={loginBusy}
+            >
+              {t('meshcore.remoteConsole.login_different', 'Use a different password')}
+            </button>
+          </>
+        ) : (
+          <button type="button" className="mrc-btn-primary" onClick={() => setShowLogin(true)}>
+            {t('meshcore.remoteConsole.login_button', 'Log in to {{name}}', { name: contactName })}
           </button>
         )}
       </div>

--- a/src/components/MeshCore/MeshCoreRemoteStatsPanel.css
+++ b/src/components/MeshCore/MeshCoreRemoteStatsPanel.css
@@ -76,6 +76,38 @@
   font-style: italic;
 }
 
+/* On-demand empty state: prompt + Fetch button before the first request. */
+.mrs-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+}
+
+.mrs-empty-hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--ctp-subtext0);
+  font-style: italic;
+}
+
+.mrs-fetch-btn {
+  padding: 0.35rem 1rem;
+  border: 1px solid var(--ctp-mauve);
+  background: var(--ctp-surface0);
+  color: var(--ctp-text);
+  border-radius: var(--radius-sm, 3px);
+  cursor: pointer;
+  font-size: 0.82rem;
+  font-weight: 600;
+  transition: background 0.15s;
+}
+
+.mrs-fetch-btn:hover {
+  background: var(--ctp-surface1);
+}
+
 .mrs-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));

--- a/src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx
@@ -5,14 +5,15 @@
  * (wrapped by GET /admin/status/:publicKey → `getRemoteStatus`). Mounted
  * inside MeshCoreRemoteConsole once the user has an active admin session.
  *
- * Auto-refresh: a low-frequency poll (30s by default) so the panel stays
- * fresh without hammering the radio. Manual refresh button bypasses the
- * timer. Failures render a soft "unavailable" state — typical when the
- * remote firmware is a Companion (which doesn't populate the full counter
- * set) or the path has gone stale since login.
+ * On-demand only: status is fetched when the user clicks "Fetch stats" (or
+ * "Refresh"). It does NOT auto-fetch on mount or poll on a timer — querying a
+ * remote repeater costs radio airtime, so it's an explicit user action.
+ * Failures render a soft "unavailable" state — typical when the remote
+ * firmware is a Companion (which doesn't populate the full counter set) or the
+ * path has gone stale since login.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { MeshCoreActions, MeshCoreRemoteStatus } from './hooks/useMeshCore';
 import './MeshCoreRemoteStatsPanel.css';
@@ -21,14 +22,11 @@ interface Props {
   publicKey: string;
   /** Pulled from the same useMeshCore actions bundle the console uses. */
   fetchStatus: MeshCoreActions['getRemoteStatus'];
-  /** Auto-refresh interval in ms. 0 disables auto-refresh. Default 30s. */
-  refreshIntervalMs?: number;
 }
 
 export const MeshCoreRemoteStatsPanel: React.FC<Props> = ({
   publicKey,
   fetchStatus,
-  refreshIntervalMs = 30_000,
 }) => {
   const { t } = useTranslation();
   const [status, setStatus] = useState<MeshCoreRemoteStatus | null>(null);
@@ -60,14 +58,9 @@ export const MeshCoreRemoteStatsPanel: React.FC<Props> = ({
     }
   }, [fetchStatus, publicKey, t]);
 
-  // Initial fetch + interval. Reset whenever the targeted contact changes
-  // so a stale interval tick can't hit the previously-selected node.
-  useEffect(() => {
-    void load();
-    if (refreshIntervalMs <= 0) return;
-    const id = setInterval(() => { void load(); }, refreshIntervalMs);
-    return () => clearInterval(id);
-  }, [load, refreshIntervalMs]);
+  // No auto-fetch and no polling — status is loaded only when the user asks
+  // (the "Fetch stats" / "Refresh" buttons below), to avoid spending radio
+  // airtime on a remote query the user didn't request.
 
   return (
     <section className="meshcore-remote-stats" aria-label={t('meshcore.remoteStats.title', 'Remote node status')}>
@@ -94,7 +87,11 @@ export const MeshCoreRemoteStatsPanel: React.FC<Props> = ({
           onClick={(e) => { e.stopPropagation(); void load(); }}
           disabled={loading}
         >
-          {loading ? t('meshcore.remoteStats.refreshing', 'Refreshing…') : t('meshcore.remoteStats.refresh', 'Refresh')}
+          {loading
+            ? t('meshcore.remoteStats.refreshing', 'Refreshing…')
+            : status
+              ? t('meshcore.remoteStats.refresh', 'Refresh')
+              : t('meshcore.remoteStats.fetch', 'Fetch stats')}
         </button>
       </header>
 
@@ -137,6 +134,16 @@ export const MeshCoreRemoteStatsPanel: React.FC<Props> = ({
           )}
           {loading && !status && (
             <p className="mrs-loading">{t('meshcore.remoteStats.loading', 'Loading status…')}</p>
+          )}
+          {!status && !loading && (
+            <div className="mrs-empty">
+              <p className="mrs-empty-hint">
+                {t('meshcore.remoteStats.empty_hint', 'Status is not fetched automatically.')}
+              </p>
+              <button type="button" className="mrs-fetch-btn" onClick={() => void load()}>
+                {t('meshcore.remoteStats.fetch', 'Fetch stats')}
+              </button>
+            </div>
           )}
         </div>
       )}

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -49,6 +49,10 @@ vi.mock('../hooks/useDashboardData', () => ({
   UNIFIED_SOURCE_ID: '__unified__',
 }));
 
+vi.mock('../hooks/useMapAnalysisData', () => ({
+  useMeshCoreNeighbors: vi.fn(() => ({ data: { items: [] }, isLoading: false, isError: false })),
+}));
+
 vi.mock('../contexts/AuthContext', () => ({
   useAuth: vi.fn(() => ({
     authStatus: { authenticated: false, user: null },

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { SettingsProvider, useSettings } from '../contexts/SettingsContext';
 import { useAuth } from '../contexts/AuthContext';
 import { useCsrf } from '../contexts/CsrfContext';
-import { MapProvider } from '../contexts/MapContext';
+import { MapProvider, useMapContext } from '../contexts/MapContext';
 import {
   useDashboardSources,
   useSourceStatuses,
@@ -22,6 +22,7 @@ import {
   useUnifiedStatus,
   UNIFIED_SOURCE_ID,
 } from '../hooks/useDashboardData';
+import { useMeshCoreNeighbors } from '../hooks/useMapAnalysisData';
 import type { DashboardSource } from '../hooks/useDashboardData';
 import DashboardSidebar from '../components/Dashboard/DashboardSidebar';
 import DashboardMap from '../components/Dashboard/DashboardMap';
@@ -238,6 +239,21 @@ function DashboardInner() {
   const singleSourceData = useDashboardSourceData(isUnifiedSelected ? null : selectedSourceId);
   const unifiedSourceData = useDashboardUnifiedData(sources, isUnifiedSelected);
   const sourceData = isUnifiedSelected ? unifiedSourceData : singleSourceData;
+
+  // MeshCore neighbor links for the map. Fetched only when the "Show Neighbors"
+  // toggle is on (DashboardInner sits inside MapProvider, so we can read it
+  // here to gate the request). Unified pulls every source; single-source pulls
+  // just the selected one. Non-MeshCore sources simply return no edges.
+  const { showNeighborInfo } = useMapContext();
+  const neighborSourceIds = isUnifiedSelected
+    ? sourceIds
+    : (selectedSourceId && selectedSourceId !== UNIFIED_SOURCE_ID ? [selectedSourceId] : []);
+  const meshcoreNeighborsQuery = useMeshCoreNeighbors({
+    enabled: showNeighborInfo && neighborSourceIds.length > 0,
+    sources: neighborSourceIds,
+    lookbackHours: maxNodeAgeHours,
+  });
+  const meshcoreNeighbors = (meshcoreNeighborsQuery.data?.items as unknown[] | undefined) ?? [];
 
   // Synthetic Unified pseudo-source for the sidebar. Recognized by its sentinel ID
   // so DashboardSidebar can hide admin/open controls that don't apply.
@@ -1013,6 +1029,7 @@ function DashboardInner() {
           nodes={sourceData.nodes}
           traceroutes={sourceData.traceroutes}
           neighborInfo={sourceData.neighborInfo}
+          meshcoreNeighbors={meshcoreNeighbors}
           channels={sourceData.channels}
           tilesetId={mapTileset}
           customTilesets={customTilesets}

--- a/src/server/meshcoreManager.neighborLogin.test.ts
+++ b/src/server/meshcoreManager.neighborLogin.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for MeshCoreManager.requestNeighbors login behavior.
+ *
+ * A neighbor request to a remote repeater logs in with the SAVED password for
+ * that node (repeaters gate `neighbors` behind a guest/admin password). It
+ * must NEVER fall back to an empty-password ("anonymous") login — that silently
+ * downgrades below the guest level and the command returns nothing. It retries
+ * the saved password because the login round-trip is easily dropped on a lossy
+ * link. Regression guard for the "neighbor request ignores the saved password /
+ * downgrades to anonymous" bug.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mocked credential store — same specifier the manager imports dynamically.
+const mockLoad = vi.fn();
+vi.mock('./services/meshcoreCredentialStore.js', () => ({
+  getMeshCoreCredentialStore: () => ({ load: mockLoad }),
+}));
+
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+const KEY = 'a'.repeat(64);
+
+interface LoginCall { pk: string; pw: string }
+
+function makeManager(loginImpl?: (pk: string, pw: string, attempt: number) => boolean) {
+  const m = new MeshCoreManager('test-source') as any;
+  m.deviceType = MeshCoreDeviceType.COMPANION;
+  m.connected = true;
+  m.localNode = { publicKey: 'local', name: 'local', advType: MeshCoreDeviceType.COMPANION };
+  const loginCalls: LoginCall[] = [];
+  m.loginToNode = vi.fn(async (pk: string, pw: string) => {
+    loginCalls.push({ pk, pw });
+    return loginImpl ? loginImpl(pk, pw, loginCalls.length) : true;
+  });
+  // Stub the CLI transport: reply "not supported" so requestNeighbors returns
+  // early (null) right after login — we only assert on the login that happened.
+  m.sendCliCommand = vi.fn(async () => ({ reply: 'not supported', elapsedMs: 0 }));
+  return { m, loginCalls };
+}
+
+describe('MeshCoreManager.requestNeighbors — saved-password login (no anonymous fallback)', () => {
+  beforeEach(() => {
+    mockLoad.mockReset();
+  });
+
+  it('logs in with the SAVED password when one exists', async () => {
+    mockLoad.mockResolvedValue({ kind: 'ok', password: 's3cret' });
+    const { m, loginCalls } = makeManager();
+
+    await m.requestNeighbors(KEY);
+
+    expect(mockLoad).toHaveBeenCalledWith('test-source', KEY);
+    expect(loginCalls).toEqual([{ pk: KEY, pw: 's3cret' }]);
+  });
+
+  it('NEVER falls back to an empty-password (anonymous) login when no credential is saved', async () => {
+    mockLoad.mockResolvedValue({ kind: 'none' });
+    const { m, loginCalls } = makeManager();
+
+    await m.requestNeighbors(KEY);
+
+    expect(loginCalls).toEqual([]); // no login attempted at all
+    expect(loginCalls.some((c) => c.pw === '')).toBe(false);
+  });
+
+  it('NEVER anonymous-logs-in when the stored credential key was rotated', async () => {
+    mockLoad.mockResolvedValue({ kind: 'key_rotated', storedKid: 'old' });
+    const { m, loginCalls } = makeManager();
+
+    await m.requestNeighbors(KEY);
+
+    expect(loginCalls).toEqual([]);
+  });
+
+  it('retries the saved password (lossy link) and does NOT downgrade to empty', async () => {
+    mockLoad.mockResolvedValue({ kind: 'ok', password: 's3cret' });
+    // First attempt dropped (no reply → false), second succeeds.
+    const { m, loginCalls } = makeManager((_pk, _pw, attempt) => attempt >= 2);
+
+    await m.requestNeighbors(KEY);
+
+    expect(loginCalls).toEqual([
+      { pk: KEY, pw: 's3cret' },
+      { pk: KEY, pw: 's3cret' },
+    ]);
+    expect(loginCalls.some((c) => c.pw === '')).toBe(false);
+  });
+
+  it('gives up after 3 saved-password attempts without ever sending an empty password', async () => {
+    mockLoad.mockResolvedValue({ kind: 'ok', password: 's3cret' });
+    const { m, loginCalls } = makeManager(() => false); // every attempt dropped
+
+    await m.requestNeighbors(KEY);
+
+    expect(loginCalls).toEqual([
+      { pk: KEY, pw: 's3cret' },
+      { pk: KEY, pw: 's3cret' },
+      { pk: KEY, pw: 's3cret' },
+    ]);
+    expect(loginCalls.some((c) => c.pw === '')).toBe(false);
+  });
+});
+
+describe('MeshCoreManager.getNeighbours — saved-password login (binary path)', () => {
+  beforeEach(() => {
+    mockLoad.mockReset();
+  });
+
+  it('logs in with the saved password before the binary get_neighbours query', async () => {
+    mockLoad.mockResolvedValue({ kind: 'ok', password: 's3cret' });
+    const { m, loginCalls } = makeManager();
+    const bridgeCalls: string[] = [];
+    m.sendBridgeCommand = vi.fn(async (cmd: string) => {
+      bridgeCalls.push(cmd);
+      return { id: '1', success: true, data: { total: 0, neighbours: [] } };
+    });
+
+    await m.getNeighbours(KEY, { count: 20 });
+
+    expect(loginCalls).toEqual([{ pk: KEY, pw: 's3cret' }]);
+    expect(bridgeCalls).toContain('get_neighbours');
+  });
+
+  it('does NOT anonymous-login when no credential is saved (binary path)', async () => {
+    mockLoad.mockResolvedValue({ kind: 'none' });
+    const { m, loginCalls } = makeManager();
+    m.sendBridgeCommand = vi.fn(async () => ({ id: '1', success: true, data: { total: 0, neighbours: [] } }));
+
+    await m.getNeighbours(KEY, { count: 20 });
+
+    expect(loginCalls).toEqual([]); // no empty-password login
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1981,6 +1981,11 @@ class MeshCoreManager extends EventEmitter {
   } | null> {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) return null;
     if (!this.connected) return null;
+    // Establish a session with the saved password first — repeaters gate the
+    // neighbours query behind a guest/admin login, and this binary path (like
+    // the CLI `neighbors` path) otherwise fails with no session. Never
+    // anonymous-logs-in (see ensureSavedLogin).
+    await this.ensureSavedLogin(publicKey);
     try {
       const response = await this.sendBridgeCommand('get_neighbours', {
         public_key: publicKey,
@@ -2195,6 +2200,53 @@ class MeshCoreManager extends EventEmitter {
     return ok;
   }
 
+  /**
+   * Establish a login session for a remote repeater before a read command,
+   * using ONLY the SAVED password for this (source, node). Repeaters gate
+   * `neighbors`/`stats` behind a guest (or admin) password; the saved
+   * credential is that password.
+   *
+   * Deliberately does NOT fall back to an empty-password ("anonymous") login:
+   * on firmware that requires the guest password, an empty login silently
+   * downgrades to anonymous — the command then returns nothing and the only
+   * symptom is a CLI timeout. So if no password is saved, or every attempt is
+   * dropped, this returns false and the caller proceeds without masquerading
+   * as anonymous.
+   *
+   * Retries a few times (like `loginToRoom`) because the login round-trip is
+   * easily dropped on a lossy LoRa link to a distant repeater — a single miss
+   * must not be treated as "no session".
+   *
+   * The decrypted plaintext is used in-process only; it never leaves the
+   * server (same invariant as the login-with-saved route).
+   */
+  async ensureSavedLogin(publicKey: string): Promise<boolean> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) return false;
+    if (!this.connected) return false;
+
+    let cred;
+    try {
+      const { getMeshCoreCredentialStore } = await import('./services/meshcoreCredentialStore.js');
+      cred = await getMeshCoreCredentialStore().load(this.sourceId, publicKey);
+    } catch (err) {
+      logger.warn(`[MeshCore:${this.sourceId}] credential lookup failed for ${publicKey.substring(0, 8)}…: ${(err as Error).message}`);
+      return false;
+    }
+    // No saved password (or unreadable/rotated): do NOT anonymous-login.
+    if (cred.kind !== 'ok') return false;
+
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      if (await this.loginToNode(publicKey, cred.password)) return true;
+      if (attempt < maxAttempts) {
+        logger.debug(`[MeshCore:${this.sourceId}] saved-credential login attempt ${attempt}/${maxAttempts} got no reply for ${publicKey.substring(0, 8)}…, retrying`);
+        await new Promise((r) => setTimeout(r, 1500));
+      }
+    }
+    logger.warn(`[MeshCore:${this.sourceId}] saved-credential login failed after ${maxAttempts} attempts for ${publicKey.substring(0, 8)}…`);
+    return false;
+  }
+
   // ============ Room Server Support ============
 
   /**
@@ -2306,7 +2358,10 @@ class MeshCoreManager extends EventEmitter {
 
     let reply: string;
     if (sanitizedTargetKey !== null) {
-      await this.ensureGuestLogin(sanitizedTargetKey);
+      // Log in with the SAVED password (repeaters gate `neighbors` behind a
+      // guest/admin password). Never anonymous-login: an empty-password login
+      // downgrades to anonymous and the command returns nothing.
+      await this.ensureSavedLogin(sanitizedTargetKey);
       const result = await this.sendCliCommand(sanitizedTargetKey, 'neighbors');
       reply = result.reply;
     } else {


### PR DESCRIPTION
## Summary

Three related MeshCore improvements to the dashboard map and the remote-admin console, developed and tested together.

### 1. MeshCore neighbor links on the Dashboard map
- New **"Show Neighbors"** toggle in the map Features panel (reuses the persisted `showNeighborInfo` preference; **off by default**). It gates both Meshtastic and MeshCore neighbor links.
- `DashboardPage` fetches MeshCore neighbors (`useMeshCoreNeighbors`) **only when the toggle is on**; `DashboardMap` resolves each edge's endpoints by **public key** and draws cyan dashed links, deduped across sources.

### 2. Saved-password login for neighbor queries (both paths)
Neighbor queries to a remote repeater now log in with the **saved password** first — repeaters gate `neighbors`/`get_neighbours` behind a guest/admin login.
- Applied to **both** the CLI path (`requestNeighbors`) **and** the binary path (`getNeighbours` → `GET /contacts/:pk/neighbours`). The binary path previously did **no login at all**, so any node without an existing session returned **409 Conflict** — this was the reported "Neighbors button → 409".
- New `ensureSavedLogin()`: loads the saved credential, **retries the login 3×** (lossy LoRa link), and **never** falls back to an empty-password/anonymous login. An anonymous session silently downgrades below the guest password, so the query returns nothing (surfaces as a CLI timeout / 409).

### 3. On-demand remote console (no automatic airtime)
- **Removed auto-login on mount.** The console now only fetches credential *capability* (a local DB lookup — no radio) and shows a **"✓ Saved password"** indicator.
- Using the saved password is **one explicit click** ("Log in with saved password"); it's never used automatically.
- **Remote stats no longer auto-fetch or poll** (was: fetch on mount + every 30s). A **"Fetch stats"** button loads them on demand.

## Testing
- Full Vitest suite: **5749 passing, 0 failing**; `tsc` clean.
- New/updated tests:
  - `meshcoreManager.neighborLogin.test.ts` — CLI + binary neighbor login use the saved password, retry on a dropped login, and **never** send an empty password.
  - `DashboardMap.test.tsx` — MeshCore neighbor link renders between positioned nodes, hidden when an endpoint isn't visible, deduped across sources.
  - `MeshCoreRemoteConsole.test.tsx` — no auto-login on mount, "Saved password" indicator shows, login fires only on click.
- Verified live in the dev container against real repeaters (BOCA/POMP TRON): saved-password login now used on both neighbor paths; remaining transient failures are mesh reachability right after a restart (paths rebuild), not the code.

## Notes
- The `getNeighbours` 409 message ("source disconnected, not a Companion, or firmware too old") is now slightly misleading when the real cause is a login/reachability timeout — a follow-up could distinguish that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)