### PR TITLE
fix(telemetry): convert temperature values, not just unit labels

### DIFF
--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -19,7 +19,7 @@ import { ComposedChart, Line, Area, XAxis, YAxis, CartesianGrid, Tooltip, Respon
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useTelemetry, type TelemetryData } from '../hooks/useTelemetry';
-import { type TemperatureUnit, formatTemperature, getTemperatureUnit } from '../utils/temperature';
+import { type TemperatureUnit, formatTemperature, getTemperatureUnit, isTemperatureType } from '../utils/temperature';
 import { formatChartAxisTimestamp, formatTime } from '../utils/datetime';
 import { useSettings, type TimeFormat } from '../contexts/SettingsContext';
 import type { TelemetryNodeInfo } from '../types/device';
@@ -450,7 +450,7 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
     };
 
     const nodeName = formatNodeName(node, favorite.nodeId);
-    const isTemperature = favorite.telemetryType === 'temperature';
+    const isTemperature = isTemperatureType(favorite.telemetryType);
     const color = getColor(favorite.telemetryType);
     const label = isPaxcounterCombined ? 'Paxcounter' : getTranslatedLabel(favorite.telemetryType);
 
@@ -561,6 +561,16 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
 
     const latest = getLatestValue(telemetryData);
 
+    // Gauge/numeric modes display a single raw value, so convert it (and the
+    // gauge range) to the selected unit. Ranges persist in Celsius, so edits
+    // made while displaying Fahrenheit are converted back before saving.
+    const toDisplayTemp = (v: number) =>
+      isTemperature ? formatTemperature(v, 'C', temperatureUnit) : v;
+    const toStoredTemp = (v: number) =>
+      isTemperature ? formatTemperature(v, temperatureUnit, 'C') : v;
+    const handleRangeChange = (r: { min: number; max: number }) =>
+      setRange({ min: toStoredTemp(r.min), max: toStoredTemp(r.max) });
+
     return (
       <div ref={setNodeRef} style={style} className="dashboard-chart-container">
         <div className="dashboard-chart-header">
@@ -620,14 +630,14 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
         {mode === 'gauge' ? (
           latest ? (
             <TelemetryGauge
-              value={latest.value}
-              min={range.min}
-              max={range.max}
+              value={toDisplayTemp(latest.value)}
+              min={toDisplayTemp(range.min)}
+              max={toDisplayTemp(range.max)}
               unit={unit}
               color={color}
               timestamp={latest.timestamp}
               nodeId={favorite.nodeId}
-              onRangeChange={setRange}
+              onRangeChange={handleRangeChange}
             />
           ) : (
             <div className="dashboard-no-data">{t('dashboard.no_chart_data')}</div>
@@ -635,7 +645,7 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
         ) : mode === 'numeric' ? (
           latest ? (
             <TelemetryNumericLabel
-              value={latest.value}
+              value={toDisplayTemp(latest.value)}
               unit={unit}
               color={color}
               timestamp={latest.timestamp}

--- a/src/components/TelemetryGraphs.test.tsx
+++ b/src/components/TelemetryGraphs.test.tsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import TelemetryGraphs from './TelemetryGraphs';
 import { ToastProvider } from './ToastContainer';
@@ -737,6 +736,92 @@ describe('TelemetryGraphs Component', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Temperature (°F)')).toBeInTheDocument();
+      });
+    });
+
+    it('should convert the gauge value to Fahrenheit, not just the unit label', async () => {
+      // Regression: gauge/numeric modes previously rendered the raw Celsius
+      // value with a °F label (e.g. a 25°C node showed "25 °F").
+      const mockData = [
+        {
+          nodeId: mockNodeId,
+          nodeNum: 1,
+          telemetryType: 'temperature',
+          value: 25, // Celsius from API → should display as 77 °F
+          unit: '°C',
+          timestamp: Date.now(),
+          createdAt: Date.now(),
+        },
+      ];
+
+      (global.fetch as Mock).mockImplementation((url: string) => {
+        if (url.includes('/api/settings')) {
+          return Promise.resolve({
+            ok: true,
+            // Force this widget into gauge mode
+            json: async () => ({
+              telemetryWidgetModes: JSON.stringify({ [`${mockNodeId}_temperature`]: 'gauge' }),
+            }),
+          });
+        }
+        if (url.includes('/api/solar/estimates')) {
+          return Promise.resolve({ ok: true, json: async () => ({ count: 0, estimates: [] }) });
+        }
+        if (url.includes('/api/csrf-token')) {
+          return Promise.resolve({ ok: true, json: async () => ({ token: 'test-csrf-token' }) });
+        }
+        return Promise.resolve({ ok: true, json: async () => mockData });
+      });
+
+      renderWithProviders(<TelemetryGraphs nodeId={mockNodeId} temperatureUnit="F" />);
+
+      await waitFor(() => {
+        // 25°C → 77°F. The TelemetryGauge exposes "Gauge: <value> <unit>" as its aria-label.
+        expect(screen.getByLabelText('Gauge: 77 °F')).toBeInTheDocument();
+      });
+      expect(screen.queryByLabelText('Gauge: 25 °F')).not.toBeInTheDocument();
+    });
+
+    it('should also convert soilTemperature and co2Temperature, not just temperature', async () => {
+      const mockData = [
+        {
+          nodeId: mockNodeId,
+          nodeNum: 1,
+          telemetryType: 'soilTemperature',
+          value: 0, // 0°C → 32°F
+          unit: '°C',
+          timestamp: Date.now(),
+          createdAt: Date.now(),
+        },
+        {
+          nodeId: mockNodeId,
+          nodeNum: 1,
+          telemetryType: 'co2Temperature',
+          value: 100, // 100°C → 212°F
+          unit: '°C',
+          timestamp: Date.now(),
+          createdAt: Date.now(),
+        },
+      ];
+
+      (global.fetch as Mock).mockImplementation((url: string) => {
+        if (url.includes('/api/settings')) {
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+        }
+        if (url.includes('/api/solar/estimates')) {
+          return Promise.resolve({ ok: true, json: async () => ({ count: 0, estimates: [] }) });
+        }
+        if (url.includes('/api/csrf-token')) {
+          return Promise.resolve({ ok: true, json: async () => ({ token: 'test-csrf-token' }) });
+        }
+        return Promise.resolve({ ok: true, json: async () => mockData });
+      });
+
+      renderWithProviders(<TelemetryGraphs nodeId={mockNodeId} temperatureUnit="F" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Soil Temperature (°F)')).toBeInTheDocument();
+        expect(screen.getByText('CO₂ Sensor Temperature (°F)')).toBeInTheDocument();
       });
     });
 

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ComposedChart, Line, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import './TelemetryGraphs.css';
-import { type TemperatureUnit, formatTemperature, getTemperatureUnit } from '../utils/temperature';
+import { type TemperatureUnit, formatTemperature, getTemperatureUnit, isTemperatureType } from '../utils/temperature';
 import { logger } from '../utils/logger';
 import { useToast } from './ToastContainer';
 import { useCsrfFetch } from '../hooks/useCsrfFetch';
@@ -150,7 +150,7 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
   const [mode, setMode] = useWidgetMode(nodeId, type, baseUrl);
   const [range, setRange] = useWidgetRange(nodeId, type, baseUrl);
 
-  const isTemperature = type === 'temperature';
+  const isTemperature = isTemperatureType(type);
   const chartData = prepareChartData(data, isTemperature, globalMinTime);
   const unit = isTemperature ? getTemperatureUnit(temperatureUnit) : data[0]?.unit || '';
   const label = isPaxcounterCombined ? 'Paxcounter' : getTelemetryLabel(type);
@@ -181,6 +181,16 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
   }
 
   const latest = getLatestValue(data);
+
+  // Gauge/numeric modes display a single raw value, so convert it (and the
+  // gauge range) to the selected unit. Ranges persist in Celsius, so edits
+  // made while displaying Fahrenheit are converted back before saving.
+  const toDisplayTemp = (v: number) =>
+    isTemperature ? formatTemperature(v, 'C', temperatureUnit) : v;
+  const toStoredTemp = (v: number) =>
+    isTemperature ? formatTemperature(v, temperatureUnit, 'C') : v;
+  const handleRangeChange = (r: { min: number; max: number }) =>
+    setRange({ min: toStoredTemp(r.min), max: toStoredTemp(r.max) });
 
   return (
     <div key={type} className="graph-container">
@@ -262,14 +272,14 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
       {mode === 'gauge' ? (
         latest ? (
           <TelemetryGauge
-            value={latest.value}
-            min={range.min}
-            max={range.max}
+            value={toDisplayTemp(latest.value)}
+            min={toDisplayTemp(range.min)}
+            max={toDisplayTemp(range.max)}
             unit={unit}
             color={color}
             timestamp={latest.timestamp}
             nodeId={nodeId}
-            onRangeChange={setRange}
+            onRangeChange={handleRangeChange}
             canEditRange={canEditSettings}
           />
         ) : (
@@ -278,7 +288,7 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
       ) : mode === 'numeric' ? (
         latest ? (
           <TelemetryNumericLabel
-            value={latest.value}
+            value={toDisplayTemp(latest.value)}
             unit={unit}
             color={color}
             timestamp={latest.timestamp}

--- a/src/pages/UnifiedTelemetryPage.test.tsx
+++ b/src/pages/UnifiedTelemetryPage.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import UnifiedTelemetryPage from './UnifiedTelemetryPage';
+
+const tempEntry = {
+  nodeId: '!abcd1234',
+  nodeNum: 1,
+  telemetryType: 'temperature',
+  value: 25, // Celsius from the device
+  unit: '°C',
+  timestamp: Date.now(),
+  sourceId: 'src1',
+  sourceName: 'Source One',
+  nodeLongName: 'Test Node',
+  nodeShortName: 'TN',
+};
+
+function mockTelemetryResponse(entries: unknown[]) {
+  global.fetch = vi.fn((url: string) => {
+    if (typeof url === 'string' && url.includes('/api/unified/telemetry')) {
+      return Promise.resolve({ ok: true, json: async () => entries });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  }) as unknown as typeof fetch;
+}
+
+function renderPage() {
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/telemetry']}>
+        <UnifiedTelemetryPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('UnifiedTelemetryPage temperature unit', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('displays Celsius by default', async () => {
+    mockTelemetryResponse([tempEntry]);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('25.0')).toBeInTheDocument();
+    });
+    expect(screen.getByText('°C')).toBeInTheDocument();
+  });
+
+  it('converts the value and label to Fahrenheit when preference is F', async () => {
+    localStorage.setItem('temperatureUnit', 'F');
+    mockTelemetryResponse([tempEntry]);
+    renderPage();
+
+    await waitFor(() => {
+      // 25°C → 77°F, not "25 °F"
+      expect(screen.getByText('77.0')).toBeInTheDocument();
+    });
+    expect(screen.getByText('°F')).toBeInTheDocument();
+    expect(screen.queryByText('25.0')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/UnifiedTelemetryPage.tsx
+++ b/src/pages/UnifiedTelemetryPage.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { appBasename } from '../init';
+import { type TemperatureUnit, formatTemperature, getTemperatureUnit, isTemperatureType } from '../utils/temperature';
 import '../styles/unified.css';
 
 type TFn = (key: string, options?: Record<string, unknown>) => string;
@@ -267,6 +268,9 @@ export default function UnifiedTelemetryPage() {
   const [sourceFilter, setSourceFilter] = useState('');
   const [search, setSearch] = useState('');
   const [sortKey, setSortKey] = useState<SortKey>('newest');
+  // This page renders outside SettingsProvider, so read the persisted
+  // temperature-unit preference directly (same localStorage key SettingsContext uses).
+  const temperatureUnit: TemperatureUnit = localStorage.getItem('temperatureUnit') === 'F' ? 'F' : 'C';
 
   const fetchTelemetry = useCallback(async () => {
     try {
@@ -491,14 +495,19 @@ export default function UnifiedTelemetryPage() {
                       <div className="unified-node-card__readings">
                         {readings.map(r => {
                           const label = TYPE_LABELS[r.telemetryType] ?? r.telemetryType;
-                          const unit = r.unit ?? inferUnit(r.telemetryType);
+                          // Device temperatures arrive in Celsius — honor the unit preference.
+                          const isTemp = isTemperatureType(r.telemetryType);
+                          const value = isTemp ? formatTemperature(r.value, 'C', temperatureUnit) : r.value;
+                          const unit = isTemp
+                            ? getTemperatureUnit(temperatureUnit)
+                            : (r.unit ?? inferUnit(r.telemetryType));
                           return (
                             <div key={r.telemetryType} className="unified-reading">
                               <div className="unified-reading__label" title={r.telemetryType}>
                                 {label}
                               </div>
                               <div className="unified-reading__value">
-                                {formatValue(r.telemetryType, r.value)}
+                                {formatValue(r.telemetryType, value)}
                                 {unit && <span className="unified-reading__unit">{unit}</span>}
                               </div>
                             </div>

--- a/src/utils/temperature.test.ts
+++ b/src/utils/temperature.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatTemperature, getTemperatureUnit } from './temperature';
+import { formatTemperature, getTemperatureUnit, isTemperatureType } from './temperature';
 
 describe('temperature utilities', () => {
   describe('formatTemperature', () => {
@@ -53,6 +53,21 @@ describe('temperature utilities', () => {
 
     it('should return correct unit symbol for Fahrenheit', () => {
       expect(getTemperatureUnit('F')).toBe('°F');
+    });
+  });
+
+  describe('isTemperatureType', () => {
+    it('matches all Celsius-bearing telemetry types', () => {
+      expect(isTemperatureType('temperature')).toBe(true);
+      expect(isTemperatureType('soilTemperature')).toBe(true);
+      expect(isTemperatureType('co2Temperature')).toBe(true);
+    });
+
+    it('does not match non-temperature types', () => {
+      expect(isTemperatureType('humidity')).toBe(false);
+      expect(isTemperatureType('voltage')).toBe(false);
+      expect(isTemperatureType('batteryLevel')).toBe(false);
+      expect(isTemperatureType('')).toBe(false);
     });
   });
 });

--- a/src/utils/temperature.ts
+++ b/src/utils/temperature.ts
@@ -27,3 +27,13 @@ export function formatTemperature(value: number, fromUnit: TemperatureUnit, toUn
 export function getTemperatureUnit(unit: TemperatureUnit): string {
   return unit === 'C' ? '°C' : '°F';
 }
+
+/**
+ * Telemetry types that carry a Celsius temperature value from the device and
+ * should honor the user's temperature-unit preference.
+ */
+const TEMPERATURE_TELEMETRY_TYPES = new Set(['temperature', 'soilTemperature', 'co2Temperature']);
+
+export function isTemperatureType(type: string): boolean {
+  return TEMPERATURE_TELEMETRY_TYPES.has(type);
+}


### PR DESCRIPTION
## Summary

Users reported that selecting **Fahrenheit** didn't actually convert temperatures — a node reporting e.g. 41 °C displayed as **"41 °F"**. The root cause: only the **chart** display mode ran values through `formatTemperature`. The **gauge** and **numeric** modes rendered the raw Celsius value while labeling it with the converted unit.

This PR fixes that and two related gaps found while investigating.

## Changes

- **Gauge & numeric modes** (`TelemetryChart.tsx`, `TelemetryGraphs.tsx`): convert the displayed value and the gauge's min/max scale to the selected unit. Gauge range edits are converted back to Celsius before persisting, so stored ranges stay unit-agnostic across a C↔F toggle.
- **Soil / CO₂ temperatures**: the unit preference now applies to `soilTemperature` and `co2Temperature`, not just `temperature`, via a new shared `isTemperatureType()` helper in `src/utils/temperature.ts`.
- **UnifiedTelemetryPage**: converts temperature readings (value + label). This page renders outside `SettingsProvider`, so it reads the persisted `temperatureUnit` from `localStorage` (the same key `SettingsContext` writes).

## Testing

- New regression tests: gauge value conversion (25 °C → 77 °F, not "25 °F"), soil/CO₂ conversion, `isTemperatureType` matchers, and the unified telemetry table (`UnifiedTelemetryPage.test.tsx`). Each fails against the old code and passes now.
- Full Vitest suite: **5755 passed / 0 failed**.
- Typecheck + eslint clean on changed files.

## Note

`UnifiedTelemetryPage` reads the unit from `localStorage` once at render (no cross-tab live reactivity). If full reactivity is preferred, the alternative is wrapping the route in `SettingsProvider` and using `useSettings()` — a slightly larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)