### PR TITLE
fix(mqtt): stop rxTime=0 from rendering messages at Unix epoch (Dec 1969)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -23,6 +23,7 @@ import { autoDeleteByDistanceService } from './services/autoDeleteByDistanceServ
 import { MessageQueueService } from './messageQueueService.js';
 import { normalizeTriggerPatterns, normalizeTriggerChannels } from '../utils/autoResponderUtils.js';
 import { isWithinTimeWindow } from './utils/timeWindow.js';
+import { canonicalMessageTime } from './utils/messageTime.js';
 import { isNodeComplete } from '../utils/nodeHelpers.js';
 import { getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
 import { migrateAutomationChannels } from './utils/automationChannelMigration.js';
@@ -13030,7 +13031,7 @@ class MeshtasticManager implements ISourceManager {
       text: msg.text,
       channel: msg.channel,
       portnum: msg.portnum ?? undefined,
-      timestamp: new Date(msg.rxTime ?? msg.timestamp),
+      timestamp: new Date(canonicalMessageTime(msg)),
       hopStart: msg.hopStart ?? undefined,
       hopLimit: msg.hopLimit ?? undefined,
       relayNode: msg.relayNode ?? undefined,

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -300,6 +300,47 @@ describe('ingestServiceEnvelope — TEXT_MESSAGE_APP tapbacks', () => {
   });
 });
 
+describe('ingestServiceEnvelope — TEXT_MESSAGE_APP rxTime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const textEnvelope = (rxTime?: number): ServiceEnvelopeShape => ({
+    channelId: 'LongFast',
+    gatewayId: '!00000001',
+    packet: {
+      id: 0xdeadbeef,
+      from: NODE_IN,
+      to: 0xffffffff,
+      channel: 0,
+      ...(rxTime !== undefined ? { rxTime } : {}),
+      decoded: {
+        portnum: 1 /* TEXT_MESSAGE_APP */,
+        payload: new Uint8Array([0]),
+      } as any,
+    },
+  });
+
+  it('drops rxTime === 0 (unset gateway time) instead of storing Unix epoch', async () => {
+    // Regression: MQTT gateway packets frequently carry rxTime === 0. Storing
+    // 0 made the unified view canonical (`rxTime ?? timestamp`) resolve to the
+    // Unix epoch and render "December 31, 1969". rxTime must be undefined so
+    // display falls back to the server timestamp.
+    const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope: textEnvelope(0) });
+    expect(result.ingested).toBe(true);
+    const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
+    expect(inserted.rxTime).toBeUndefined();
+    expect(inserted.timestamp).toBeGreaterThan(0);
+  });
+
+  it('preserves a real rxTime, converting seconds to milliseconds', async () => {
+    const result = await ingestServiceEnvelope({ sourceId: 'bridge-1', envelope: textEnvelope(1_700_000_000) });
+    expect(result.ingested).toBe(true);
+    const inserted = (databaseService.messages.insertMessage as any).mock.calls[0][0];
+    expect(inserted.rxTime).toBe(1_700_000_000_000);
+  });
+});
+
 describe('ingestServiceEnvelope — TRACEROUTE_APP', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -312,7 +312,11 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         channel: effectiveChannel,
         portnum,
         timestamp: nowMs,
-        rxTime: typeof packet.rxTime === 'number' ? packet.rxTime * 1000 : undefined,
+        // Guard against rxTime === 0: MQTT gateway packets frequently arrive
+        // with an unset (0) receive time. Storing 0 makes the unified view's
+        // `rxTime ?? timestamp` canonical resolve to Unix epoch (Dec 31 1969).
+        // Treat anything <= 0 as "no rxTime" so display falls back to timestamp.
+        rxTime: typeof packet.rxTime === 'number' && packet.rxTime > 0 ? packet.rxTime * 1000 : undefined,
         rxSnr: typeof packet.rxSnr === 'number' ? packet.rxSnr : undefined,
         rxRssi: typeof packet.rxRssi === 'number' ? packet.rxRssi : undefined,
         viaMqtt: true,
@@ -815,7 +819,9 @@ async function ingestStoreForward(
       channel: effectiveChannel,
       portnum: PortNum.TEXT_MESSAGE_APP,
       timestamp: nowMs,
-      rxTime: typeof packet.rxTime === 'number' ? packet.rxTime * 1000 : undefined,
+      // See TEXT_MESSAGE_APP case: drop rxTime === 0 (unset gateway time) so it
+      // doesn't render as Unix epoch in the unified view's canonical timestamp.
+      rxTime: typeof packet.rxTime === 'number' && packet.rxTime > 0 ? packet.rxTime * 1000 : undefined,
       rxSnr: typeof packet.rxSnr === 'number' ? packet.rxSnr : undefined,
       rxRssi: typeof packet.rxRssi === 'number' ? packet.rxRssi : undefined,
       viaMqtt: true,

--- a/src/server/routes/unifiedRoutes.test.ts
+++ b/src/server/routes/unifiedRoutes.test.ts
@@ -446,6 +446,26 @@ describe('Unified Routes', () => {
       expect(res.body[1].receptions[0].sourceName).toBe('Source B');
     });
 
+    it('falls back to server timestamp when rxTime is 0 (MQTT unset-time epoch bug)', async () => {
+      // Regression: an MQTT row stored rxTime === 0 (gateway never set a
+      // receive time). `rxTime ?? timestamp` would pick 0 — nullish coalescing
+      // only falls through on null/undefined — and render Unix epoch (Dec 1969).
+      // Canonical must fall back to the real server timestamp, and the reception
+      // must report rxTime as null rather than 0.
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
+      mockDb.messages.getMessages.mockResolvedValueOnce([
+        mkMsg({ id: 'z', text: 'Happy Friday Mesh', timestamp: 1_700_000_000_000, rxTime: 0, createdAt: 1_700_000_000_000 }),
+      ]);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/messages?limit=50');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].timestamp).toBe(1_700_000_000_000);
+      expect(res.body[0].receptions[0].rxTime).toBeNull();
+    });
+
     it('de-duplicates the same (fromNodeNum, requestId) across sources into one entry with two receptions', async () => {
       mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
       // Same mesh packet heard by both sources — same fromNodeNum + requestId.

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -550,7 +550,12 @@ router.get('/messages', async (req: Request, res: Response) => {
         }
 
         for (const m of msgs) {
-          const canonical = (m.rxTime ?? m.timestamp) as number;
+          // Treat rxTime <= 0 as missing, not as a real device time. MQTT
+          // gateway packets can carry rxTime === 0 (unset receive time); a
+          // plain `rxTime ?? timestamp` would pick 0 (nullish coalescing only
+          // falls through on null/undefined) and render Unix epoch (Dec 1969).
+          const rxTime = typeof m.rxTime === 'number' && m.rxTime > 0 ? m.rxTime : null;
+          const canonical = (rxTime ?? m.timestamp) as number;
           const reqId = (m.requestId ?? null) as number | null;
           const fromNum = Number(m.fromNodeNum);
           // Dedup key priority:
@@ -572,7 +577,7 @@ router.get('/messages', async (req: Request, res: Response) => {
             hopLimit: m.hopLimit ?? null,
             rxSnr: m.rxSnr ?? null,
             rxRssi: m.rxRssi ?? null,
-            rxTime: m.rxTime ?? null,
+            rxTime,
             timestamp: m.timestamp,
           };
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -11,6 +11,7 @@ import meshtasticManager from './meshtasticManager.js';
 import { MeshtasticManager } from './meshtasticManager.js';
 import { sourceManagerRegistry } from './sourceManagerRegistry.js';
 import { resolveSourceManager } from './utils/resolveSourceManager.js';
+import { canonicalMessageTime, messageReceivedAt } from './utils/messageTime.js';
 import protobufService from './protobufService.js';
 
 // Make meshtasticManager available globally for routes that need it
@@ -2381,11 +2382,11 @@ function transformDbMessageToMeshMessage(msg: DbMessage): MeshMessage {
     text: msg.text,
     channel: msg.channel,
     portnum: msg.portnum ?? undefined,
-    timestamp: new Date(msg.rxTime ?? msg.timestamp),
+    timestamp: new Date(canonicalMessageTime(msg)),
     // Server-side ingest time — robust against sender-clock drift, used by
     // the client for sort order (issue #3187). Falls back to `timestamp` for
     // pre-migration rows where `createdAt` was never written.
-    receivedAt: new Date(msg.createdAt ?? msg.rxTime ?? msg.timestamp),
+    receivedAt: new Date(messageReceivedAt(msg)),
     hopStart: msg.hopStart ?? undefined,
     hopLimit: msg.hopLimit ?? undefined,
     relayNode: msg.relayNode ?? undefined,

--- a/src/server/services/webSocketService.ts
+++ b/src/server/services/webSocketService.ts
@@ -15,6 +15,7 @@ import { logger } from '../../utils/logger.js';
 import { getEnvironmentConfig } from '../config/environment.js';
 import type { DbMessage } from '../../services/database.js';
 import databaseService from '../../services/database.js';
+import { canonicalMessageTime, messageReceivedAt } from '../utils/messageTime.js';
 
 /**
  * Transform a DbMessage to the format expected by the client (MeshMessage)
@@ -32,9 +33,9 @@ function transformMessageForClient(msg: DbMessage): unknown {
     text: msg.text,
     channel: msg.channel,
     portnum: msg.portnum,
-    timestamp: new Date(msg.rxTime ?? msg.timestamp),  // Convert to Date (serializes as ISO string)
+    timestamp: new Date(canonicalMessageTime(msg)),  // Convert to Date (serializes as ISO string)
     // Server-side ingest time used by the client for sort order (issue #3187).
-    receivedAt: new Date(msg.createdAt ?? msg.rxTime ?? msg.timestamp),
+    receivedAt: new Date(messageReceivedAt(msg)),
     hopStart: msg.hopStart,
     hopLimit: msg.hopLimit,
     relayNode: msg.relayNode,

--- a/src/server/utils/messageTime.test.ts
+++ b/src/server/utils/messageTime.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalMessageTime, messageReceivedAt } from './messageTime.js';
+
+describe('canonicalMessageTime', () => {
+  it('prefers a positive rxTime over timestamp', () => {
+    expect(canonicalMessageTime({ rxTime: 1_700_000_000_000, timestamp: 1 })).toBe(1_700_000_000_000);
+  });
+
+  it('falls back to timestamp when rxTime is 0 (MQTT unset gateway time)', () => {
+    // Regression for the "December 31, 1969" MQTT bug: rxTime === 0 must not
+    // win over the real server timestamp.
+    expect(canonicalMessageTime({ rxTime: 0, timestamp: 1_700_000_000_000 })).toBe(1_700_000_000_000);
+  });
+
+  it('falls back to timestamp when rxTime is null or undefined', () => {
+    expect(canonicalMessageTime({ rxTime: null, timestamp: 42 })).toBe(42);
+    expect(canonicalMessageTime({ timestamp: 42 })).toBe(42);
+  });
+
+  it('treats a negative rxTime as missing', () => {
+    expect(canonicalMessageTime({ rxTime: -5, timestamp: 99 })).toBe(99);
+  });
+});
+
+describe('messageReceivedAt', () => {
+  it('prefers a positive createdAt', () => {
+    expect(messageReceivedAt({ createdAt: 500, rxTime: 0, timestamp: 1000 })).toBe(500);
+  });
+
+  it('falls back through the chain without leaking a 0 rxTime', () => {
+    // createdAt missing AND rxTime 0 → must land on timestamp, not epoch.
+    expect(messageReceivedAt({ createdAt: null, rxTime: 0, timestamp: 1000 })).toBe(1000);
+    expect(messageReceivedAt({ rxTime: 0, timestamp: 1000 })).toBe(1000);
+  });
+});

--- a/src/server/utils/messageTime.ts
+++ b/src/server/utils/messageTime.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical display time for a message row.
+ *
+ * Prefers the device receive time (`rxTime`) and falls back to the server
+ * `timestamp`. The guard against `rxTime <= 0` is load-bearing: MQTT gateway
+ * packets frequently arrive with an unset receive time of `0`, and a plain
+ * `rxTime ?? timestamp` would pick that `0` (nullish coalescing only falls
+ * through on null/undefined) and render the Unix epoch — "December 31, 1969".
+ * Treating `<= 0` as missing makes such rows fall back to the server time.
+ *
+ * Mirrors the same guard applied at the unified-view canonical computation in
+ * `routes/unifiedRoutes.ts` and at MQTT ingestion in `mqttIngestion.ts`.
+ */
+export function canonicalMessageTime(msg: {
+  rxTime?: number | null;
+  timestamp: number;
+}): number {
+  return typeof msg.rxTime === 'number' && msg.rxTime > 0 ? msg.rxTime : msg.timestamp;
+}
+
+/**
+ * Server-side ingest time used by clients for sort order (issue #3187), with
+ * the same `rxTime <= 0` guard so a zero receive time can never leak through
+ * the `createdAt ?? rxTime ?? timestamp` fallback chain as a 1969 epoch.
+ */
+export function messageReceivedAt(msg: {
+  createdAt?: number | null;
+  rxTime?: number | null;
+  timestamp: number;
+}): number {
+  if (typeof msg.createdAt === 'number' && msg.createdAt > 0) return msg.createdAt;
+  return canonicalMessageTime(msg);
+}


### PR DESCRIPTION
## Problem

Users reported MQTT messages showing timestamps of **December 31, 1969 / 7:00 PM** — Unix epoch `0` rendered in a UTC‑5 timezone.

![symptom: messages dated 1969-12-31](https://github.com/Yeraze/meshmonitor/assets/placeholder)

## Root cause

MQTT gateway packets frequently arrive with an unset receive time of `0`. Two compounding bugs turned that into a 1969 timestamp:

1. **`mqttIngestion.ts`** stored `rxTime: 0 * 1000 = 0`. Its `typeof packet.rxTime === 'number'` guard let `0` through — unlike the TCP path (`meshtasticManager.ts`) which uses a *truthy* check and so was never affected.
2. **`unifiedRoutes.ts`** (and the non-unified/realtime serializers in `server.ts`, `webSocketService.ts`, `meshtasticManager.ts`) computed the display time as `rxTime ?? timestamp`. Nullish coalescing only falls through on `null`/`undefined`, **not `0`**, so `0 ?? timestamp` returned `0` → Unix epoch.

This is why TCP messages were fine, only MQTT broke, and MQTT messages that happened to carry a real `rxTime` still displayed correctly.

## Fix (two layers)

1. **Root cause** — `mqttIngestion.ts` now stores `rxTime: undefined` when the gateway time is `≤ 0`, so display falls back to the server `timestamp`. Stops all new bad rows across every consumer.
2. **Defensive read** — the four display/serialization sites now go through a shared `canonicalMessageTime()` / `messageReceivedAt()` helper (`src/server/utils/messageTime.ts`) that treats `rxTime ≤ 0` as missing. This also repairs **already-stored** `rxTime=0` rows on display — no migration needed.

## Tests

- New `messageTime.test.ts` — helper units (0, null, undefined, negative, real rxTime).
- `mqttIngestion.test.ts` — ingestion drops `rxTime=0`, preserves and ms-converts a real rxTime.
- `unifiedRoutes.test.ts` — falls back to server timestamp when `rxTime=0`; reception reports `rxTime: null`.
- Full Vitest suite: **5764 passed, 0 failed**. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)