### PR TITLE
feat(telemetry): auto-scale current/power units and humanize uptime (#3261)

### DIFF
--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -28,6 +28,7 @@ import { useWidgetMode } from '../hooks/useWidgetMode';
 import { useWidgetRange } from '../hooks/useWidgetRange';
 import { useSource } from '../contexts/SourceContext';
 import { getLatestValue } from '../utils/telemetry';
+import { unitScale } from '../utils/telemetryFormat';
 import TelemetryGauge from './TelemetryGauge';
 import TelemetryNumericLabel from './TelemetryNumericLabel';
 
@@ -532,7 +533,17 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
 
     // Prepare chart data
     const chartData = prepareChartData(telemetryData, isTemperature, temperatureUnit, solarEstimates, globalMinTime, timeFormat);
-    const unit = isTemperature ? getTemperatureUnit(temperatureUnit) : telemetryData[0]?.unit || '';
+    // Auto-scale current/power so a sub-1 A/W series reads as mA/mW (#3261).
+    // One factor for the whole series (chosen from its largest magnitude)
+    // keeps every point, the axis, the gauge range and the numeric readout on
+    // the same prefix. Temperature keeps its own C/F handling below.
+    const baseUnit = telemetryData[0]?.unit || '';
+    const seriesMaxAbs = telemetryData.reduce(
+      (m, d) => (typeof d.value === 'number' ? Math.max(m, Math.abs(d.value)) : m),
+      0
+    );
+    const valueScale = isTemperature ? null : unitScale(baseUnit, seriesMaxAbs);
+    const unit = isTemperature ? getTemperatureUnit(temperatureUnit) : (valueScale ? valueScale.unit : baseUnit);
 
     // For combined paxcounter chart, merge BLE data
     if (isPaxcounterCombined) {
@@ -561,15 +572,26 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
 
     const latest = getLatestValue(telemetryData);
 
+    // Apply the chart's display scale to the plotted series. The solar overlay
+    // lives on its own axis (watt-hours) and is left untouched.
+    const scaledChartData = valueScale && valueScale.factor !== 1
+      ? chartData.map((d) => ({ ...d, value: d.value == null ? d.value : d.value * valueScale.factor }))
+      : chartData;
+
     // Gauge/numeric modes display a single raw value, so convert it (and the
-    // gauge range) to the selected unit. Ranges persist in Celsius, so edits
-    // made while displaying Fahrenheit are converted back before saving.
-    const toDisplayTemp = (v: number) =>
-      isTemperature ? formatTemperature(v, 'C', temperatureUnit) : v;
-    const toStoredTemp = (v: number) =>
-      isTemperature ? formatTemperature(v, temperatureUnit, 'C') : v;
+    // gauge range) to the display unit. Ranges persist in base units (Celsius
+    // for temperature, the stored A/W for current/power), so edits made in the
+    // displayed unit are converted back before saving.
+    const toDisplay = (v: number) =>
+      isTemperature
+        ? formatTemperature(v, 'C', temperatureUnit)
+        : v * (valueScale ? valueScale.factor : 1);
+    const toStored = (v: number) =>
+      isTemperature
+        ? formatTemperature(v, temperatureUnit, 'C')
+        : v / (valueScale ? valueScale.factor : 1);
     const handleRangeChange = (r: { min: number; max: number }) =>
-      setRange({ min: toStoredTemp(r.min), max: toStoredTemp(r.max) });
+      setRange({ min: toStored(r.min), max: toStored(r.max) });
 
     return (
       <div ref={setNodeRef} style={style} className="dashboard-chart-container">
@@ -630,9 +652,9 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
         {mode === 'gauge' ? (
           latest ? (
             <TelemetryGauge
-              value={toDisplayTemp(latest.value)}
-              min={toDisplayTemp(range.min)}
-              max={toDisplayTemp(range.max)}
+              value={toDisplay(latest.value)}
+              min={toDisplay(range.min)}
+              max={toDisplay(range.max)}
               unit={unit}
               color={color}
               timestamp={latest.timestamp}
@@ -645,7 +667,7 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
         ) : mode === 'numeric' ? (
           latest ? (
             <TelemetryNumericLabel
-              value={toDisplayTemp(latest.value)}
+              value={toDisplay(latest.value)}
               unit={unit}
               color={color}
               timestamp={latest.timestamp}
@@ -655,7 +677,7 @@ const TelemetryChart: React.FC<TelemetryChartProps> = React.memo(
           )
         ) : (
           <ResponsiveContainer width="100%" height={200}>
-            <ComposedChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+            <ComposedChart data={scaledChartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#ccc" />
               <XAxis
                 dataKey="timestamp"

--- a/src/pages/UnifiedTelemetryPage.tsx
+++ b/src/pages/UnifiedTelemetryPage.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { appBasename } from '../init';
 import { type TemperatureUnit, formatTemperature, getTemperatureUnit, isTemperatureType } from '../utils/temperature';
+import { unitScale, formatDuration, isUptimeType } from '../utils/telemetryFormat';
 import '../styles/unified.css';
 
 type TFn = (key: string, options?: Record<string, unknown>) => string;
@@ -202,19 +203,9 @@ function formatBytes(v: number): string {
   return String(Math.round(v));
 }
 
-/** Human-readable duration from seconds. */
-function formatDuration(seconds: number): string {
-  const d = Math.floor(seconds / 86400);
-  const h = Math.floor((seconds % 86400) / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  if (d > 0) return `${d}d ${h}h`;
-  if (h > 0) return `${h}h ${m}m`;
-  return `${m}m`;
-}
-
 function formatValue(type: string, value: number): string {
   // Durations (seconds) → human-readable
-  if (type === 'uptimeSeconds' || type === 'hostUptimeSeconds' || type === 'paxcounterUptime') {
+  if (isUptimeType(type)) {
     return formatDuration(value);
   }
   // Bytes → KB / MB
@@ -497,10 +488,19 @@ export default function UnifiedTelemetryPage() {
                           const label = TYPE_LABELS[r.telemetryType] ?? r.telemetryType;
                           // Device temperatures arrive in Celsius — honor the unit preference.
                           const isTemp = isTemperatureType(r.telemetryType);
-                          const value = isTemp ? formatTemperature(r.value, 'C', temperatureUnit) : r.value;
+                          const rawUnit = r.unit ?? inferUnit(r.telemetryType);
+                          // Auto-scale current/power (A↔mA, W↔mW/kW) so sub-1
+                          // readings read naturally; uptime renders as a
+                          // duration with no unit suffix (#3261).
+                          const scaled = isTemp ? null : unitScale(rawUnit, Math.abs(r.value));
+                          const value = isTemp
+                            ? formatTemperature(r.value, 'C', temperatureUnit)
+                            : r.value * (scaled ? scaled.factor : 1);
                           const unit = isTemp
                             ? getTemperatureUnit(temperatureUnit)
-                            : (r.unit ?? inferUnit(r.telemetryType));
+                            : isUptimeType(r.telemetryType)
+                              ? ''
+                              : (scaled ? scaled.unit : rawUnit);
                           return (
                             <div key={r.telemetryType} className="unified-reading">
                               <div className="unified-reading__label" title={r.telemetryType}>

--- a/src/utils/telemetryFormat.test.ts
+++ b/src/utils/telemetryFormat.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { unitScale, scaleMeasurement, isUptimeType, formatDuration } from './telemetryFormat';
+
+describe('unitScale', () => {
+  it('keeps amps above 1 A in A', () => {
+    expect(unitScale('A', 2.5)).toEqual({ factor: 1, unit: 'A' });
+  });
+
+  it('drops sub-1 A readings to mA', () => {
+    expect(unitScale('A', 0.45)).toEqual({ factor: 1000, unit: 'mA' });
+  });
+
+  it('keeps small milliamp readings in mA', () => {
+    expect(unitScale('mA', 50)).toEqual({ factor: 1, unit: 'mA' });
+  });
+
+  it('promotes large milliamp readings to A', () => {
+    expect(unitScale('mA', 1500)).toEqual({ factor: 1e-3, unit: 'A' });
+  });
+
+  it('drops sub-1 W readings to mW', () => {
+    expect(unitScale('W', 0.012)).toEqual({ factor: 1000, unit: 'mW' });
+  });
+
+  it('keeps watts between 1 and 1000 in W', () => {
+    expect(unitScale('W', 42)).toEqual({ factor: 1, unit: 'W' });
+  });
+
+  it('promotes kilowatt-scale power to kW', () => {
+    expect(unitScale('W', 2500)).toEqual({ factor: 1e-3, unit: 'kW' });
+  });
+
+  it('uses the magnitude, not the sign, to choose the prefix', () => {
+    expect(unitScale('A', -0.3)).toEqual({ factor: 1000, unit: 'mA' });
+  });
+
+  it('leaves non-scalable units untouched', () => {
+    expect(unitScale('V', 3.7)).toEqual({ factor: 1, unit: 'V' });
+    expect(unitScale('°C', 21)).toEqual({ factor: 1, unit: '°C' });
+    expect(unitScale('', 5)).toEqual({ factor: 1, unit: '' });
+  });
+
+  it('falls back to the smallest prefix for a zero magnitude', () => {
+    expect(unitScale('A', 0)).toEqual({ factor: 1000, unit: 'mA' });
+  });
+
+  it('does not scale on a non-finite representative magnitude', () => {
+    expect(unitScale('A', NaN)).toEqual({ factor: 1, unit: 'A' });
+  });
+});
+
+describe('scaleMeasurement', () => {
+  it('converts 0.45 A to 450 mA', () => {
+    const { value, unit } = scaleMeasurement(0.45, 'A');
+    expect(value).toBeCloseTo(450, 6);
+    expect(unit).toBe('mA');
+  });
+
+  it('converts 0.012 W to 12 mW', () => {
+    const { value, unit } = scaleMeasurement(0.012, 'W');
+    expect(value).toBeCloseTo(12, 6);
+    expect(unit).toBe('mW');
+  });
+
+  it('converts 1500 mA to 1.5 A', () => {
+    const { value, unit } = scaleMeasurement(1500, 'mA');
+    expect(value).toBeCloseTo(1.5, 6);
+    expect(unit).toBe('A');
+  });
+
+  it('leaves voltage untouched', () => {
+    expect(scaleMeasurement(3.72, 'V')).toEqual({ value: 3.72, unit: 'V' });
+  });
+});
+
+describe('isUptimeType', () => {
+  it.each([
+    'uptimeSeconds',
+    'hostUptimeSeconds',
+    'paxcounterUptime',
+    'mc_uptime_secs',
+    'mc_status_uptime_secs',
+  ])('treats %s as an uptime', (type) => {
+    expect(isUptimeType(type)).toBe(true);
+  });
+
+  it.each([
+    'voltage',
+    'current',
+    'mc_air_time_secs',
+    'mc_rtc_drift_secs',
+    'mc_tx_air_secs',
+  ])('does not treat %s as an uptime', (type) => {
+    expect(isUptimeType(type)).toBe(false);
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats days and hours for large uptimes', () => {
+    expect(formatDuration(3 * 86400 + 4 * 3600 + 30 * 60)).toBe('3d 4h');
+  });
+
+  it('formats hours and minutes below a day', () => {
+    expect(formatDuration(5 * 3600 + 12 * 60)).toBe('5h 12m');
+  });
+
+  it('formats minutes below an hour', () => {
+    expect(formatDuration(45 * 60 + 30)).toBe('45m');
+  });
+
+  it('clamps negatives to zero', () => {
+    expect(formatDuration(-100)).toBe('0m');
+  });
+});

--- a/src/utils/telemetryFormat.ts
+++ b/src/utils/telemetryFormat.ts
@@ -1,0 +1,106 @@
+/**
+ * Telemetry value/unit display helpers shared across the telemetry table,
+ * charts, gauges and numeric widgets.
+ *
+ * Two concerns live here:
+ *   1. Auto-scaling SI-prefixed measurements (current, power) so small
+ *      values read naturally — e.g. 0.45 A → 450 mA, 0.012 W → 12 mW,
+ *      2500 W → 2.5 kW. See issue #3261: MeshCore stores current in A and
+ *      power in W, but real-world mesh values sit well below 1, making the
+ *      raw "0.01 A" readout useless.
+ *   2. Human-readable durations (uptime in seconds → "3d 4h").
+ *
+ * The scaling is magnitude-driven and family-based: a value's unit decides
+ * which prefix ladder it belongs to, and a representative magnitude picks
+ * the largest prefix that keeps the displayed number >= 1.
+ */
+
+export interface UnitScale {
+  /** Multiply a value (in the input unit) by this to get the display value. */
+  factor: number;
+  /** The display unit string (may differ from the input unit). */
+  unit: string;
+}
+
+// Each scalable unit maps to a base unit and its size expressed in that base.
+const UNIT_FAMILIES: Record<string, { base: string; toBase: number }> = {
+  mA: { base: 'A', toBase: 1e-3 },
+  A: { base: 'A', toBase: 1 },
+  mW: { base: 'W', toBase: 1e-3 },
+  W: { base: 'W', toBase: 1 },
+  kW: { base: 'W', toBase: 1e3 },
+};
+
+// Prefix ladders per base unit, smallest → largest. `mult` is the value of
+// one display unit expressed in the base unit (display = baseValue / mult).
+const PREFIX_LADDERS: Record<string, Array<{ unit: string; mult: number }>> = {
+  A: [
+    { unit: 'mA', mult: 1e-3 },
+    { unit: 'A', mult: 1 },
+  ],
+  W: [
+    { unit: 'mW', mult: 1e-3 },
+    { unit: 'W', mult: 1 },
+    { unit: 'kW', mult: 1e3 },
+  ],
+};
+
+/**
+ * Pick the most readable prefix for a measurement.
+ *
+ * @param unit              the unit the stored value is expressed in
+ * @param representativeAbs a magnitude (in the *input* unit) used to choose
+ *                          the prefix — typically `Math.abs(value)` for a
+ *                          single reading, or the series max for a chart so
+ *                          every point shares one scale.
+ * @returns a factor + display unit. Non-scalable units return `{factor: 1}`
+ *          with the unit unchanged.
+ */
+export function unitScale(unit: string, representativeAbs: number): UnitScale {
+  const family = UNIT_FAMILIES[unit];
+  if (!family || !Number.isFinite(representativeAbs)) {
+    return { factor: 1, unit };
+  }
+  const ladder = PREFIX_LADDERS[family.base];
+  if (!ladder) return { factor: 1, unit };
+
+  // Representative magnitude expressed in the base unit.
+  const baseAbs = Math.abs(representativeAbs) * family.toBase;
+
+  // Largest prefix whose unit-size still keeps the display number >= 1.
+  let chosen = ladder[0];
+  for (const step of ladder) {
+    if (baseAbs >= step.mult) chosen = step;
+  }
+
+  // display = baseValue / chosen.mult = (inputValue * toBase) / chosen.mult
+  return { factor: family.toBase / chosen.mult, unit: chosen.unit };
+}
+
+/** Scale a single measurement to its most readable prefix. */
+export function scaleMeasurement(value: number, unit: string): { value: number; unit: string } {
+  const s = unitScale(unit, Math.abs(value));
+  return { value: value * s.factor, unit: s.unit };
+}
+
+// Telemetry types whose value is an uptime/duration expressed in seconds.
+// MeshCore poller/remote-status rows use the `*_uptime_secs` suffix; the
+// Meshtastic/host/paxcounter rows use the explicit names below.
+const UPTIME_TYPES = new Set(['uptimeSeconds', 'hostUptimeSeconds', 'paxcounterUptime']);
+
+/** True when a telemetry type's value is an uptime expressed in seconds. */
+export function isUptimeType(type: string): boolean {
+  return UPTIME_TYPES.has(type) || /uptime_secs$/i.test(type);
+}
+
+/** Human-readable duration from a number of seconds (e.g. "3d 4h", "12m"). */
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds)) return String(seconds);
+  const s = Math.max(0, Math.floor(seconds));
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}


### PR DESCRIPTION
## Summary

Closes #3261.

MeshCore (and Meshtastic) telemetry rendered small current/power readings as unreadable `0.01 A` / `0.00 W`, and uptime as a large raw seconds count. This adds a shared display helper that auto-scales current and power to the most readable SI prefix and renders uptime as a human-readable duration — applied consistently across the telemetry table, charts, gauges, and numeric widgets.

### Behavior
- **Current:** `0.45 A → 450 mA`, `1500 mA → 1.5 A`
- **Power:** `0.012 W → 12 mW`, `2500 W → 2.5 kW`
- **Uptime:** `350000 s → 4d 1h` (no unit suffix)
- Non-scalable units (V, °C, %, dBm, …) are untouched.

Fixes both Meshtastic (`mA` / `envCurrent`) and MeshCore LPP telemetry (`current`=A, `power`=W, `mc_*_uptime_secs`).

## Changes
- **`src/utils/telemetryFormat.ts`** (new): `unitScale` / `scaleMeasurement` (magnitude-driven prefix selection), `isUptimeType`, `formatDuration`.
- **`src/utils/telemetryFormat.test.ts`** (new): 29 unit tests covering prefix boundaries, sign handling, non-scalable units, and durations.
- **`src/pages/UnifiedTelemetryPage.tsx`**: per-row auto-scaling of current/power; uptime rendered as a duration with no unit suffix; reuses the shared `formatDuration`.
- **`src/components/TelemetryChart.tsx`**: one series-wide scale factor applied consistently to the plotted line, Y-axis unit, gauge range (round-tripped to base units on edit), and numeric readout.

## Testing
- `tsc --noEmit`: 0 errors
- ESLint: 0 errors
- Vitest (full suite): 5767 passed. Pre-existing MQTT/protobuf suite failures on `main` are unrelated and unaffected (verified by reproducing them on a clean base with these changes stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)