### PR TITLE
feat(telemetry): clickable source jump buttons on Unified Telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- **Unified Telemetry source jump buttons** (#3262): The source labels at the top of the Unified Telemetry page are now clickable pills that smooth-scroll to their section's card grid. The header bar is sticky so the pills stay reachable while scrolling, and the pill for the section nearest the top is highlighted as the active jump target.
 - **Show Waypoints map toggle** (#3253): The Map Features panel on the dashboard and Nodes maps now has a **Show Waypoints** checkbox that controls waypoint marker visibility. Defaults to on and is persisted per-user via map preferences, alongside the existing Show RF / UDP / MQTT / Traceroute toggles.
 
 ## [4.8.1] - 2026-05-28

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4467,6 +4467,7 @@
   "unified.telemetry.age_minutes": "{{count}}m ago",
   "unified.telemetry.age_hours": "{{count}}h ago",
   "unified.telemetry.age_days": "{{count}}d ago",
+  "unified.telemetry.jump_to_source": "Jump to {{name}}",
 
   "admin.back_to_dashboard": "← Back to Dashboard",
 

--- a/src/pages/UnifiedTelemetryPage.test.tsx
+++ b/src/pages/UnifiedTelemetryPage.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import UnifiedTelemetryPage from './UnifiedTelemetryPage';
@@ -71,5 +71,50 @@ describe('UnifiedTelemetryPage temperature unit', () => {
     });
     expect(screen.getByText('°F')).toBeInTheDocument();
     expect(screen.queryByText('25.0')).not.toBeInTheDocument();
+  });
+});
+
+describe('UnifiedTelemetryPage source navigation', () => {
+  const srcA = { ...tempEntry, nodeId: '!a', nodeNum: 1, sourceId: 'src1', sourceName: 'RAK4631', nodeLongName: 'Node A' };
+  const srcB = { ...tempEntry, nodeId: '!b', nodeNum: 2, sourceId: 'src2', sourceName: 'Heltec_V4', nodeLongName: 'Node B' };
+
+  beforeEach(() => {
+    localStorage.clear();
+    // jsdom implements neither of these — stub so the component can call them.
+    vi.stubGlobal('IntersectionObserver', class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    });
+    window.scrollTo = vi.fn() as unknown as typeof window.scrollTo;
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it('renders source legend entries as jump buttons', async () => {
+    mockTelemetryResponse([srcA, srcB]);
+    renderPage();
+
+    const pillA = await screen.findByRole('button', { name: 'RAK4631' });
+    const pillB = await screen.findByRole('button', { name: 'Heltec_V4' });
+    expect(pillA).toBeEnabled();
+    expect(pillB).toBeEnabled();
+    // i18n isn't loaded in tests, so the title resolves to the raw key — assert
+    // the jump-to-source string was wired up rather than its translated value.
+    expect(pillA).toHaveAttribute('title', 'unified.telemetry.jump_to_source');
+  });
+
+  it('scrolls to the section when a legend pill is clicked', async () => {
+    mockTelemetryResponse([srcA, srcB]);
+    renderPage();
+
+    const pillB = await screen.findByRole('button', { name: 'Heltec_V4' });
+    fireEvent.click(pillB);
+
+    expect(window.scrollTo).toHaveBeenCalled();
+    expect(pillB).toHaveAttribute('aria-current', 'true');
   });
 });

--- a/src/pages/UnifiedTelemetryPage.tsx
+++ b/src/pages/UnifiedTelemetryPage.tsx
@@ -5,7 +5,7 @@
  * Grouped by source, with color-coded source tags. Fleet overview.
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { appBasename } from '../init';
@@ -268,6 +268,11 @@ export default function UnifiedTelemetryPage() {
   const [sourceFilter, setSourceFilter] = useState('');
   const [search, setSearch] = useState('');
   const [sortKey, setSortKey] = useState<SortKey>('newest');
+  // Source the legend pills jump to. `activeSource` highlights the pill for the
+  // section nearest the top of the viewport (tracked via IntersectionObserver).
+  const [activeSource, setActiveSource] = useState<string>('');
+  const headerRef = useRef<HTMLDivElement>(null);
+  const sectionRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   // This page renders outside SettingsProvider, so read the persisted
   // temperature-unit preference directly (same localStorage key SettingsContext uses).
   const temperatureUnit: TemperatureUnit = localStorage.getItem('temperatureUnit') === 'F' ? 'F' : 'C';
@@ -359,9 +364,56 @@ export default function UnifiedTelemetryPage() {
     }
   };
 
+  // Source sections currently rendered (after filters). Drives the legend's
+  // jump targets + active-state tracking. Joined into a string for a stable
+  // effect dependency.
+  const renderedSourceIds = Object.keys(bySource);
+  const renderedKey = renderedSourceIds.join('|');
+
+  const setSectionRef = useCallback(
+    (sid: string) => (el: HTMLDivElement | null) => {
+      if (el) sectionRefs.current.set(sid, el);
+      else sectionRefs.current.delete(sid);
+    },
+    [],
+  );
+
+  // Smooth-scroll a source section to just below the sticky header. We compute
+  // the offset manually (rather than CSS scroll-margin) because the header
+  // height changes as the controls wrap on narrow viewports.
+  const scrollToSource = useCallback((sid: string) => {
+    const el = sectionRefs.current.get(sid);
+    if (!el) return;
+    const headerH = headerRef.current?.offsetHeight ?? 0;
+    const top = el.getBoundingClientRect().top + window.scrollY - headerH - 12;
+    window.scrollTo({ top, behavior: 'smooth' });
+    setActiveSource(sid);
+  }, []);
+
+  // Highlight the legend pill for the section nearest the top of the viewport.
+  // The negative top rootMargin keeps the active section under the sticky header
+  // from counting as "at the top"; the -70% bottom margin biases toward the
+  // section whose header has just scrolled into the upper band.
+  useEffect(() => {
+    if (typeof IntersectionObserver === 'undefined') return;
+    const headerH = headerRef.current?.offsetHeight ?? 0;
+    const observer = new IntersectionObserver(
+      (obsEntries) => {
+        const visible = obsEntries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        const sid = visible[0]?.target.getAttribute('data-source-id');
+        if (sid) setActiveSource(sid);
+      },
+      { rootMargin: `-${headerH + 8}px 0px -70% 0px`, threshold: 0 },
+    );
+    for (const el of sectionRefs.current.values()) observer.observe(el);
+    return () => observer.disconnect();
+  }, [renderedKey]);
+
   return (
     <div className="unified-page">
-      <div className="unified-header">
+      <div className="unified-header unified-header--sticky" ref={headerRef}>
         <button className="unified-header__back" onClick={() => navigate('/', { state: { showList: true } })}>{t('unified.back_to_sources')}</button>
 
         <div className="unified-header__title">
@@ -427,21 +479,32 @@ export default function UnifiedTelemetryPage() {
           </select>
         </div>
 
-        <div className="unified-source-legend">
-          {sourceIds.map(sid => {
-            const name = entries.find(e => e.sourceId === sid)?.sourceName ?? sid;
-            const color = getSourceColor(sid, sourceIds);
-            return (
-              <span
-                key={sid}
-                className="unified-source-pill"
-                style={{ background: `color-mix(in srgb, ${color} 15%, transparent)`, color, border: `1px solid color-mix(in srgb, ${color} 35%, transparent)` }}
-              >
-                {name}
-              </span>
-            );
-          })}
-        </div>
+        {sourceIds.length > 0 && (
+          <div className="unified-source-legend">
+            {sourceIds.map(sid => {
+              const name = entries.find(e => e.sourceId === sid)?.sourceName ?? sid;
+              const color = getSourceColor(sid, sourceIds);
+              // A pill can only jump if its section is currently rendered (it
+              // gets filtered out by the source/type/search controls otherwise).
+              const hasSection = Object.prototype.hasOwnProperty.call(bySource, sid);
+              const isActive = hasSection && sid === activeSource;
+              return (
+                <button
+                  key={sid}
+                  type="button"
+                  className={`unified-source-pill${isActive ? ' is-active' : ''}`}
+                  style={{ background: `color-mix(in srgb, ${color} 15%, transparent)`, color, border: `1px solid color-mix(in srgb, ${color} 35%, transparent)` }}
+                  disabled={!hasSection}
+                  aria-current={isActive ? 'true' : undefined}
+                  title={t('unified.telemetry.jump_to_source', { name })}
+                  onClick={() => scrollToSource(sid)}
+                >
+                  {name}
+                </button>
+              );
+            })}
+          </div>
+        )}
       </div>
 
       <div className="unified-body unified-body--wide">
@@ -462,7 +525,12 @@ export default function UnifiedTelemetryPage() {
           const nodeEntries = sortNodes(nodeMap);
 
           return (
-            <div key={sourceId} className="unified-telem-source">
+            <div
+              key={sourceId}
+              className="unified-telem-source"
+              ref={setSectionRef(sourceId)}
+              data-source-id={sourceId}
+            >
               <div className="unified-telem-source__header">
                 <div className="unified-telem-source__bar" style={{ background: color }} />
                 <span className="unified-telem-source__name" style={{ color }}>{sourceName}</span>

--- a/src/styles/unified.css
+++ b/src/styles/unified.css
@@ -48,6 +48,15 @@
   flex-wrap: wrap;
 }
 
+/* Telemetry page pins the header so the source jump-pills stay reachable while
+   the card grids scroll underneath. Scoped to a modifier so the chat-style
+   messages page (which manages its own scroll surface) is unaffected. */
+.unified-header--sticky {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
 .unified-header__back {
   background: var(--ctp-surface1);
   color: var(--ctp-subtext0);
@@ -94,6 +103,29 @@
   padding: 3px 10px;
   font-size: 12px;
   font-weight: 600;
+}
+
+/* Pills double as in-page jump buttons. Reset the native button chrome and
+   layer interaction states on top of the inline color styling. */
+button.unified-source-pill {
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1.4;
+  transition: filter 0.15s, box-shadow 0.15s;
+}
+
+button.unified-source-pill:hover:not(:disabled) {
+  filter: brightness(1.25);
+}
+
+button.unified-source-pill:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+/* currentColor is the source color (set inline), so the ring matches the pill. */
+button.unified-source-pill.is-active {
+  box-shadow: 0 0 0 2px currentColor inset;
 }
 
 /* Controls: time range / type filter */


### PR DESCRIPTION
## Summary
On large meshes the Unified Telemetry view gets long, making it tedious to jump between source/node groups. This PR turns the source legend pills at the top of the page into in-page navigation buttons and pins the header so they stay reachable while the card grids scroll underneath. The pill for the section nearest the top is highlighted as the active jump target.

## Changes
- Source legend pills are now `<button>`s instead of `<span>`s; clicking one smooth-scrolls to that source's section.
- Scroll offset is computed from the live header height so sections land just below the sticky bar (robust against the controls wrapping on narrow viewports).
- An `IntersectionObserver` tracks the section nearest the top and highlights the matching pill (`is-active` + `aria-current="true"`).
- Pills whose section is filtered out (by source/type/search) are `disabled` so they can't jump to nothing.
- New `.unified-header--sticky` CSS modifier pins the header — scoped so the chat-style Unified Messages page (own scroll surface) is unaffected.
- Added button-pill styles: hover brightness, disabled dimming, and an `is-active` inset ring using `currentColor` (matches each source's color).
- Added i18n key `unified.telemetry.jump_to_source` for the pill tooltip/aria.

## Issues Resolved
Fixes #3262

## Documentation Updates
- Added a CHANGELOG entry under `[Unreleased] > Added`. No feature docs under `docs/` reference the Unified Telemetry legend, so none required updates.

## Testing
- [x] Unit tests pass (5766 tests)
- [x] TypeScript compiles cleanly
- [x] ESLint clean on changed files
- [ ] Manual: open Unified Telemetry with multiple sources, click a source pill, confirm smooth-scroll to its section and active highlight; scroll manually and confirm the active pill updates; apply a source filter and confirm filtered-out pills are disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)