### PR TITLE
fix(packets): include MeshCore OTA packets in Unified Packet Monitor

### DIFF
--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -4,7 +4,7 @@
  * Handles MeshCore node and message database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, desc, sql, isNull, and, lt, gte, inArray, type SQL } from 'drizzle-orm';
+import { eq, desc, sql, isNull, and, or, lt, gte, inArray, type SQL } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType } from '../types.js';
 
@@ -118,6 +118,14 @@ export interface MeshCorePacketQuery {
   routeType?: number;
   /** Only return packets with `timestamp >= since` (ms). */
   since?: number;
+  /**
+   * Keyset cursor (paired with `untilId`): return only rows strictly "older"
+   * than `(untilTs, untilId)` in the table's `timestamp DESC, id DESC` order —
+   * `timestamp < untilTs OR (timestamp = untilTs AND id < untilId)`. Mirrors the
+   * Meshtastic packet-log cursor so both logs can share one unified keyset page.
+   */
+  untilTs?: number;
+  untilId?: number;
 }
 
 /**
@@ -766,6 +774,13 @@ export class MeshCoreRepository extends BaseRepository {
     }
     if (typeof query.since === 'number') {
       conditions.push(gte(meshcorePacketLog.timestamp, query.since));
+    }
+    if (typeof query.untilTs === 'number' && typeof query.untilId === 'number') {
+      const keyset = or(
+        lt(meshcorePacketLog.timestamp, query.untilTs),
+        and(eq(meshcorePacketLog.timestamp, query.untilTs), lt(meshcorePacketLog.id, query.untilId))
+      );
+      if (keyset) conditions.push(keyset);
     }
     return conditions;
   }

--- a/src/db/repositories/meshcorePacketLog.perSource.test.ts
+++ b/src/db/repositories/meshcorePacketLog.perSource.test.ts
@@ -104,6 +104,22 @@ describe('MeshCoreRepository — packet-log per-source isolation', () => {
     expect(advert[0].routeType).toBe(0x02);
   });
 
+  it('honours the keyset cursor (untilTs/untilId) used by the unified stream', async () => {
+    // Three rows at the same timestamp plus an older one; ids ascend with insert.
+    await repo.insertPacket(makePacket('src-a', { timestamp: 200 })); // id 1
+    await repo.insertPacket(makePacket('src-a', { timestamp: 200 })); // id 2
+    await repo.insertPacket(makePacket('src-a', { timestamp: 200 })); // id 3
+    await repo.insertPacket(makePacket('src-a', { timestamp: 100 })); // id 4
+
+    const all = await repo.getPackets({ sourceId: 'src-a' });
+    // Newest-first by (timestamp desc, id desc): ids 3, 2, 1, then 4.
+    expect(all.map(p => p.id)).toEqual([3, 2, 1, 4]);
+
+    // Cursor at (200, id 2) returns only rows strictly older: id 1 (same ts) and id 4.
+    const page = await repo.getPackets({ sourceId: 'src-a', untilTs: 200, untilId: 2 });
+    expect(page.map(p => p.id)).toEqual([1, 4]);
+  });
+
   it('filters by since timestamp', async () => {
     await repo.insertPacket(makePacket('src-a', { timestamp: 100 }));
     await repo.insertPacket(makePacket('src-a', { timestamp: 500 }));

--- a/src/pages/UnifiedPacketMonitorPage.tsx
+++ b/src/pages/UnifiedPacketMonitorPage.tsx
@@ -405,7 +405,7 @@ export default function UnifiedPacketMonitorPage() {
                         <td className="date">{formatPacketDateColumn(packet.timestamp, dateFormat, t('packet_monitor.today', 'Today'))}</td>
                         <td className="timestamp">{formatPacketTimestamp(packet.timestamp, timeFormat)}</td>
                         <td className="from-node" title={packet.from_node_longName || packet.from_node_id || ''}>
-                          {packet.from_node_longName || packet.from_node_id || packet.from_node}
+                          {packet.from_node_longName || packet.from_node_id || packet.from_node || t('common.na')}
                         </td>
                         <td className="to-node" title={packet.to_node_longName || packet.to_node_id || ''}>
                           {packet.to_node_id === '!ffffffff'

--- a/src/server/routes/unifiedPackets.test.ts
+++ b/src/server/routes/unifiedPackets.test.ts
@@ -15,6 +15,7 @@ import request from 'supertest';
 import unifiedRoutes from './unifiedRoutes.js';
 import databaseService from '../../services/database.js';
 import packetLogService from '../services/packetLogService.js';
+import meshcorePacketLogService from '../services/meshcorePacketLogService.js';
 
 vi.mock('../../services/database.js', () => ({
   default: {
@@ -37,18 +38,44 @@ vi.mock('../services/packetLogService.js', () => ({
   },
 }));
 
+vi.mock('../services/meshcorePacketLogService.js', () => ({
+  default: {
+    getPackets: vi.fn().mockResolvedValue([]),
+    getPacketCount: vi.fn().mockResolvedValue(0),
+    isEnabled: vi.fn().mockResolvedValue(true),
+  },
+}));
+
 vi.mock('../sourceManagerRegistry.js', () => ({
   sourceManagerRegistry: { getManager: vi.fn().mockReturnValue(null) },
 }));
 
 const mockDb = databaseService as any;
 const mockPackets = packetLogService as any;
+const mockMeshcore = meshcorePacketLogService as any;
 
 const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
 const regularUser = { id: 2, username: 'user', isActive: true, isAdmin: false };
 
 const SOURCE_A = { id: 'src-a', name: 'Source A', type: 'meshtastic_tcp', enabled: true };
 const SOURCE_B = { id: 'src-b', name: 'Source B', type: 'meshtastic_tcp', enabled: true };
+const SOURCE_MC = { id: 'src-mc', name: 'MeshCore', type: 'meshcore', enabled: true };
+
+/** Minimal MeshCore OTA packet row shaped like the repo layer (post-normalize). */
+function mkMeshcorePkt(overrides: Record<string, any> = {}) {
+  return {
+    id: 1,
+    sourceId: 'src-mc',
+    timestamp: 1_700_000_000_000,
+    payloadType: 4,
+    payloadTypeName: 'TXT_MSG',
+    snr: 7.25,
+    rssi: -88,
+    payloadSize: 42,
+    createdAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
 
 const createApp = (user: any = null): Express => {
   const app = express();
@@ -83,6 +110,9 @@ function mkPkt(overrides: Record<string, any> = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockPackets.isEnabled.mockResolvedValue(true);
+  mockMeshcore.isEnabled.mockResolvedValue(true);
+  mockMeshcore.getPackets.mockResolvedValue([]);
+  mockMeshcore.getPacketCount.mockResolvedValue(0);
   mockDb.channelDatabase.getPermissionsForUserAsync.mockResolvedValue([]);
 });
 
@@ -154,6 +184,65 @@ describe('GET /api/unified/packets', () => {
     expect(res.body.hasMore).toBe(true);
     expect(res.body.nextCursor).toMatch(/^\d+_\d+$/);
   });
+
+  it('includes MeshCore OTA packets, mapped onto the packet-log shape', async () => {
+    mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_MC]);
+    mockDb.checkPermissionAsync.mockResolvedValue(true);
+    mockPackets.getPacketsAsync.mockResolvedValue([
+      mkPkt({ id: 10, timestamp: 1_700_000_000_500 }),
+    ]);
+    mockMeshcore.getPackets.mockResolvedValue([
+      mkMeshcorePkt({ id: 7, timestamp: 1_700_000_000_900 }),
+    ]);
+
+    const res = await request(createApp(adminUser)).get('/packets');
+    expect(res.status).toBe(200);
+    // Both Meshtastic and MeshCore sources were queried via their own services.
+    expect(mockMeshcore.getPackets).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: 'src-mc' })
+    );
+    // MeshCore row sorts first (newer timestamp) and is mapped onto DbPacketLog.
+    const mc = res.body.packets.find((p: any) => p.sourceId === 'src-mc');
+    expect(mc).toBeDefined();
+    expect(mc).toMatchObject({
+      portnum: 4,
+      portnum_name: 'TXT_MSG',
+      snr: 7.25,
+      rssi: -88,
+      payload_size: 42,
+      direction: 'rx',
+      encrypted: false,
+      from_node: 0,
+      channel: null,
+    });
+    // The dropdown lists the MeshCore source too.
+    expect(res.body.sources).toContainEqual({ id: 'src-mc', name: 'MeshCore' });
+  });
+
+  it('forwards the keyset cursor to the MeshCore query', async () => {
+    mockDb.sources.getAllSources.mockResolvedValue([SOURCE_MC]);
+    mockDb.checkPermissionAsync.mockResolvedValue(true);
+    mockMeshcore.getPackets.mockResolvedValue([mkMeshcorePkt()]);
+
+    await request(createApp(adminUser)).get('/packets?limit=5&cursor=1700000000050_77');
+    const opts = mockMeshcore.getPackets.mock.calls[0][0];
+    expect(opts.limit).toBe(10); // fetchLimit = 2 * limit
+    expect(opts.untilTs).toBe(1700000000050);
+    expect(opts.untilId).toBe(77);
+  });
+
+  it('excludes MeshCore sources when a Meshtastic-namespace filter is active', async () => {
+    mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_MC]);
+    mockDb.checkPermissionAsync.mockResolvedValue(true);
+    mockPackets.getPacketsAsync.mockResolvedValue([mkPkt({ id: 10, portnum: 3 })]);
+    mockMeshcore.getPackets.mockResolvedValue([mkMeshcorePkt({ id: 7 })]);
+
+    const res = await request(createApp(adminUser)).get('/packets?portnum=3');
+    expect(res.status).toBe(200);
+    // A portnum filter can't be satisfied by MeshCore's payloadType namespace.
+    expect(mockMeshcore.getPackets).not.toHaveBeenCalled();
+    expect(res.body.packets.every((p: any) => p.sourceId === 'src-a')).toBe(true);
+  });
 });
 
 describe('GET /api/unified/packets/distribution', () => {
@@ -196,5 +285,25 @@ describe('GET /api/unified/packets/distribution', () => {
     expect(res.status).toBe(200);
     expect(res.body.bySource).toEqual([{ sourceId: 'src-a', sourceName: 'Source A', count: 7 }]);
     expect(mockPackets.getPacketCountsByPortnumAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts MeshCore sources in bySource without polluting byDevice/byType', async () => {
+    mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_MC]);
+    mockDb.checkPermissionAsync.mockResolvedValue(true);
+    mockPackets.getPacketCountsByNodeAsync.mockResolvedValue([]);
+    mockPackets.getPacketCountsByPortnumAsync.mockResolvedValue([
+      { portnum: 3, portnum_name: 'POSITION_APP', count: 4 },
+    ]);
+    mockMeshcore.getPacketCount.mockResolvedValue(9);
+
+    const res = await request(createApp(adminUser)).get('/packets/distribution');
+    expect(res.status).toBe(200);
+    // MeshCore contributes a source total but no device/type rows.
+    expect(mockMeshcore.getPacketCount).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: 'src-mc' })
+    );
+    expect(res.body.bySource).toContainEqual({ sourceId: 'src-mc', sourceName: 'MeshCore', count: 9 });
+    expect(res.body.byType).toEqual([{ portnum: 3, portnum_name: 'POSITION_APP', count: 4 }]);
+    expect(res.body.total).toBe(13); // 4 (Meshtastic) + 9 (MeshCore)
   });
 });

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -8,13 +8,64 @@
 import { Router, Request, Response } from 'express';
 import databaseService from '../../services/database.js';
 import packetLogService from '../services/packetLogService.js';
+import meshcorePacketLogService from '../services/meshcorePacketLogService.js';
 import { optionalAuth } from '../auth/authMiddleware.js';
 import { logger } from '../../utils/logger.js';
 import { PortNum, CHANNEL_DB_OFFSET, modemPresetChannelName } from '../constants/meshtastic.js';
 import { filterPacketsByPermissions, getAllowedChannels } from './packetPermissions.js';
 import type { DbChannelDatabase, DbPacketLog } from '../../db/types.js';
+import type { DbMeshCorePacket } from '../../db/repositories/meshcore.js';
 
 const router = Router();
+
+/**
+ * Project a MeshCore OTA packet-log row onto the Meshtastic `DbPacketLog` shape
+ * so it can ride in the unified packet stream alongside Meshtastic rows.
+ *
+ * MeshCore OTA captures are far sparser than Meshtastic: there is no sender,
+ * recipient, channel, direction-other-than-RX, or decoded payload. Those fields
+ * are left null so the frontend renders them as N/A. `payloadType`/Name map onto
+ * `portnum`/`portnum_name`, and SNR/RSSI/size carry across directly.
+ */
+function mapMeshCorePacketToTagged(
+  p: DbMeshCorePacket,
+  sourceId: string,
+  sourceName: string
+): DbPacketLog & { sourceId: string; sourceName: string } {
+  return {
+    id: p.id,
+    packet_id: null,
+    timestamp: p.timestamp,
+    // OTA logs have no sender identity; 0 + null name → frontend shows N/A.
+    from_node: 0,
+    from_node_id: null,
+    from_node_longName: null,
+    to_node: null,
+    to_node_id: null,
+    to_node_longName: null,
+    channel: null,
+    portnum: p.payloadType,
+    portnum_name: p.payloadTypeName ?? null,
+    encrypted: false,
+    snr: p.snr ?? null,
+    rssi: p.rssi ?? null,
+    hop_limit: null,
+    hop_start: null,
+    relay_node: null,
+    payload_size: p.payloadSize ?? null,
+    want_ack: null,
+    priority: null,
+    payload_preview: null,
+    metadata: null,
+    direction: 'rx',
+    created_at: p.createdAt,
+    decrypted_by: null,
+    decrypted_channel_id: null,
+    transport_mechanism: null,
+    sourceId,
+    sourceName,
+  };
+}
 
 // All unified routes allow optional auth (some data may be public)
 router.use(optionalAuth());
@@ -846,8 +897,32 @@ router.get('/packets', async (req: Request, res: Response) => {
 
     type TaggedPacket = DbPacketLog & { sourceId: string; sourceName: string };
 
+    // MeshCore OTA rows carry no node/channel/transport/decoded-message info, so
+    // they can't satisfy these Meshtastic-namespace filters. When one is active,
+    // exclude MeshCore sources entirely rather than returning rows that wrongly
+    // match (e.g. a MeshCore payloadType colliding with a Meshtastic PortNum).
+    const meshcoreEligible =
+      portnum === undefined &&
+      from_node === undefined &&
+      transport_mechanism === undefined &&
+      encrypted !== true;
+
     const perSource = await Promise.allSettled(
       fetchSources.map(async (source): Promise<{ rows: TaggedPacket[]; saturated: boolean }> => {
+        if (source.type === 'meshcore') {
+          if (!meshcoreEligible) return { rows: [], saturated: false };
+          const raw = await meshcorePacketLogService.getPackets({
+            sourceId: source.id,
+            limit: fetchLimit,
+            untilTs,
+            untilId,
+          });
+          // No channel/message content to redact — viewing is already authorized
+          // by the source-level packetmonitor:read check above.
+          const tagged = raw.map((p) => mapMeshCorePacketToTagged(p, source.id, source.name));
+          return { rows: tagged, saturated: raw.length >= fetchLimit };
+        }
+
         const raw = await packetLogService.getPacketsAsync({
           sourceId: source.id,
           limit: fetchLimit,
@@ -941,11 +1016,17 @@ router.get('/packets/distribution', async (req: Request, res: Response) => {
 
     const perSource = await Promise.all(
       readableSources.map(async (source) => {
+        // MeshCore OTA rows have no per-node/per-PortNum breakdown that aligns
+        // with the Meshtastic namespace, so they only contribute a source total.
+        if (source.type === 'meshcore') {
+          const count = await meshcorePacketLogService.getPacketCount({ sourceId: source.id, since });
+          return { source, byDevice: [], byType: [], meshcoreCount: count };
+        }
         const [byDevice, byType] = await Promise.all([
           packetLogService.getPacketCountsByNodeAsync({ since, limit: 10, sourceId: source.id }),
           packetLogService.getPacketCountsByPortnumAsync({ since, sourceId: source.id }),
         ]);
-        return { source, byDevice, byType };
+        return { source, byDevice, byType, meshcoreCount: 0 };
       })
     );
 
@@ -954,8 +1035,8 @@ router.get('/packets/distribution', async (req: Request, res: Response) => {
     const typeMap = new Map<number, { portnum: number; portnum_name: string; count: number }>();
     const bySource: Array<{ sourceId: string; sourceName: string; count: number }> = [];
 
-    for (const { source, byDevice, byType } of perSource) {
-      let sourceTotal = 0;
+    for (const { source, byDevice, byType, meshcoreCount } of perSource) {
+      let sourceTotal = meshcoreCount;
       for (const d of byDevice as any[]) {
         const key = Number(d.from_node);
         const existing = deviceMap.get(key);
@@ -987,7 +1068,11 @@ router.get('/packets/distribution', async (req: Request, res: Response) => {
     bySource.sort((a, b) => b.count - a.count);
     const total = bySource.reduce((sum, s) => sum + s.count, 0);
 
-    res.json({ byDevice, byType, bySource, total, enabled: await packetLogService.isEnabled() });
+    const [meshtasticEnabled, meshcoreEnabled] = await Promise.all([
+      packetLogService.isEnabled(),
+      meshcorePacketLogService.isEnabled(),
+    ]);
+    res.json({ byDevice, byType, bySource, total, enabled: meshtasticEnabled || meshcoreEnabled });
   } catch (error) {
     logger.error('Error fetching unified packet distribution:', error);
     res.status(500).json({ error: 'Failed to fetch unified packet distribution' });


### PR DESCRIPTION
## Summary
MeshCore packets never showed up in the Unified Packet Monitor. The unified endpoints iterated every readable source but queried only `packetLogService` (the Meshtastic `packet_log` table); for a `meshcore`-type source that table is empty because its OTA packets live in `meshcore_packet_log` via `meshcorePacketLogService`. This PR teaches the unified packet stream and distribution endpoints to also read the MeshCore log, mapping its sparse OTA rows onto the existing packet-log shape so they merge into the same keyset-paginated stream.

## Changes
- **`src/db/repositories/meshcore.ts`**: add `untilTs`/`untilId` keyset-cursor support to `MeshCorePacketQuery` / `buildPacketConditions`, mirroring the Meshtastic predicate (`timestamp < untilTs OR (timestamp = untilTs AND id < untilId)`) so MeshCore rows ride the unified stream's shared `timestamp/id` keyset page.
- **`src/server/routes/unifiedRoutes.ts`**:
  - New `mapMeshCorePacketToTagged()` projects an OTA row onto `DbPacketLog` (`payloadType`→`portnum`, `payloadTypeName`→`portnum_name`, SNR/RSSI/size carried, `direction:'rx'`; node/channel/transport left null → rendered as N/A).
  - Per-source fetch loop branches on `source.type === 'meshcore'` and queries `meshcorePacketLogService` with the keyset cursor.
  - MeshCore sources are excluded when a Meshtastic-namespace filter (`portnum`/`from_node`/`transport_mechanism`/`encrypted=true`) is active, preventing a PortNum filter from matching a colliding MeshCore `payloadType`.
  - Distribution: MeshCore sources contribute a `bySource` total (and the grand `total`) without polluting `byDevice`/`byType`; `enabled` is now true if *either* monitor is on.
- **`src/pages/UnifiedPacketMonitorPage.tsx`**: the "From" column falls back to N/A so sender-less MeshCore rows don't render a bare `0`.

## Issues Resolved
None (reported via internal investigation).

## Documentation Updates
No documentation changes needed — the Unified Packet Monitor is not yet referenced under `docs/`.

## Known Limitation
The Meshtastic and MeshCore tables have independent auto-increment id spaces. The unified keyset cursor is `timestamp`-dominant; the `id` tiebreak only matters for packets sharing the exact same millisecond *across both tables*, where a row could rarely be skipped/duplicated at a page boundary. Acceptable for an RF-level monitor and consistent with the existing best-effort-within-a-millisecond behavior (documented in code comments).

## Testing
- [x] Unit tests pass (full suite: 5830 passed, 0 failures)
- [x] TypeScript compiles cleanly
- [x] ESLint clean on changed files (no new errors)
- New tests: MeshCore rows appear & map correctly, keyset cursor forwarded, namespace-filter exclusion, distribution totals (`unifiedPackets.test.ts`); keyset-cursor predicate (`meshcorePacketLog.perSource.test.ts`)
- [ ] Manual: with `meshcore_packet_log_enabled` on and a MeshCore source connected, open the Unified Packet Monitor and confirm MeshCore rows appear (badged to the MeshCore source, node/channel columns show N/A, SNR/RSSI/size/type populated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)