### PR TITLE
fix(stability): tear down orphaned transport on reconnect (#3270)

### DIFF
--- a/src/server/meshtasticManager.orphanTransport.test.ts
+++ b/src/server/meshtasticManager.orphanTransport.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Regression test for issue #3270: per-source TCP flap caused by an orphaned
+ * transport.
+ *
+ * Symptoms in production: one of two configured TCP sources cycles
+ * `Connection status: connected` → `disconnected` every 25–60s while the
+ * other is rock-solid, with the daemon logging ~2 "Force close previous TCP
+ * connection" events per MeshMonitor disconnect and NO want_config_id /
+ * connect-race errors.
+ *
+ * Root cause: `MeshtasticManager.connect()` reassigned `this.transport`
+ * without tearing down the previous TcpTransport. A second connect() call —
+ * `refreshNodeDatabase()` landing in a transient disconnect window, a user
+ * reconnect, or a startup race on the env-bootstrap singleton — orphaned the
+ * old transport. The orphan kept its socket open, kept its 'connect'/
+ * 'disconnect' listeners bound to the manager, and kept its internal
+ * shouldReconnect flag set, so it auto-reconnected forever. Two live
+ * transports against the same meshtasticd (single API-client policy) then
+ * ping-ponged: each new socket force-closed the other, both saw 'close',
+ * both reconnected.
+ *
+ * The fix tears down any existing transport at the top of connect() before
+ * creating the new one, guaranteeing exactly one live transport per manager.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetSetting = vi.fn();
+
+// Track every TcpTransport the manager constructs so we can assert the new
+// transport is distinct from the torn-down one.
+const createdTransports: any[] = [];
+const makeFakeTransport = () => ({
+  setStaleConnectionTimeout: vi.fn(),
+  setConnectTimeout: vi.fn(),
+  setReconnectTiming: vi.fn(),
+  setStartupGraceReconnect: vi.fn(),
+  setHeartbeatInterval: vi.fn(),
+  on: vi.fn(),
+  removeAllListeners: vi.fn(),
+  disconnect: vi.fn(),
+  connect: vi.fn().mockResolvedValue(undefined),
+  send: vi.fn().mockResolvedValue(undefined),
+});
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    getSetting: mockGetSetting,
+    setSetting: vi.fn(),
+    settings: {
+      getSetting: mockGetSetting,
+      setSetting: vi.fn(),
+      getSettingForSource: vi.fn((_sourceId: string, key: string) => mockGetSetting(key)),
+      setSettingForSource: vi.fn(),
+    },
+    nodes: { getAllNodes: vi.fn().mockResolvedValue([]) },
+    channels: { getAllChannels: vi.fn().mockResolvedValue([]) },
+    sources: {
+      getSource: vi.fn().mockResolvedValue({ id: 'default', name: 'test', type: 'meshtastic' }),
+    },
+  },
+}));
+
+vi.mock('./meshtasticProtobufService.js', () => ({
+  default: {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    createWantConfigRequest: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3])),
+  },
+}));
+
+vi.mock('./protobufService.js', () => ({
+  default: { encode: vi.fn(), decode: vi.fn() },
+  convertIpv4ConfigToStrings: vi.fn(),
+}));
+
+vi.mock('./protobufLoader.js', () => ({ getProtobufRoot: vi.fn() }));
+
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: vi.fn(function () {
+    const t = makeFakeTransport();
+    createdTransports.push(t);
+    return t;
+  }),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('./services/serverEventNotificationService.js', () => ({
+  serverEventNotificationService: {
+    notifyNodeConnected: vi.fn().mockResolvedValue(undefined),
+    notifyNodeDisconnected: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: { emit: vi.fn(), emitConnectionStatus: vi.fn(), on: vi.fn() },
+}));
+
+vi.mock('./services/packetLogService.js', () => ({ default: { logPacket: vi.fn() } }));
+vi.mock('./services/channelDecryptionService.js', () => ({ channelDecryptionService: { tryDecrypt: vi.fn() } }));
+vi.mock('./services/notificationService.js', () => ({ notificationService: { checkAndSendNotifications: vi.fn() } }));
+
+vi.mock('./messageQueueService.js', () => {
+  const mockInstance = {
+    enqueue: vi.fn(),
+    setSendCallback: vi.fn(),
+    handleAck: vi.fn(),
+    handleFailure: vi.fn(),
+    recordExternalSend: vi.fn(),
+    clear: vi.fn(),
+    getStatus: vi.fn(() => ({ queueLength: 0, pendingAcks: 0, processing: false })),
+  };
+  function MessageQueueService() { return mockInstance as any; }
+  return { messageQueueService: mockInstance, MessageQueueService };
+});
+
+vi.mock('./utils/cronScheduler.js', () => ({
+  validateCron: vi.fn(() => true),
+  scheduleCron: vi.fn(() => ({ stop: vi.fn() })),
+}));
+
+vi.mock('./config/environment.js', () => ({
+  getEnvironmentConfig: vi.fn(() => ({
+    meshtasticNodeIp: '127.0.0.1',
+    meshtasticTcpPort: 4403,
+    meshtasticStaleConnectionTimeout: 300000,
+    meshtasticConnectTimeoutMs: 10000,
+    meshtasticReconnectInitialDelayMs: 1000,
+    meshtasticReconnectMaxDelayMs: 60000,
+  })),
+}));
+
+vi.mock('../utils/autoResponderUtils.js', () => ({ normalizeTriggerPatterns: vi.fn() }));
+vi.mock('../utils/nodeHelpers.js', () => ({ isNodeComplete: vi.fn() }));
+
+describe('MeshtasticManager - issue #3270 orphaned-transport flap', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    createdTransports.length = 0;
+
+    const module = await import('./meshtasticManager.js');
+    manager = module.default;
+
+    // Use a per-source config override so getConfig() short-circuits without
+    // touching settings.
+    manager.sourceConfigOverride = { host: '127.0.0.1', port: 4403 };
+    manager.isConnected = false;
+    manager.transport = null;
+    manager.passiveMode = false;
+    manager.postResetCooldownUntil = 0;
+    manager.userDisconnectedState = false;
+  });
+
+  it('tears down an existing transport before creating a new one', async () => {
+    const oldTransport = makeFakeTransport();
+    manager.transport = oldTransport;
+
+    await manager.connect();
+
+    // The old transport was fully decommissioned: listeners removed and socket
+    // closed (which clears its shouldReconnect flag), so it can no longer
+    // auto-reconnect and fight the new transport for the daemon's API slot.
+    expect(oldTransport.removeAllListeners).toHaveBeenCalled();
+    expect(oldTransport.disconnect).toHaveBeenCalled();
+
+    // A single fresh transport was created and installed.
+    expect(createdTransports.length).toBe(1);
+    expect(manager.transport).toBe(createdTransports[0]);
+    expect(manager.transport).not.toBe(oldTransport);
+  });
+
+  it('does not orphan a transport across repeated connect() calls', async () => {
+    await manager.connect();
+    const first = manager.transport;
+    await manager.connect();
+    const second = manager.transport;
+
+    // Two connect() calls => exactly two transports constructed, and the first
+    // was torn down rather than left running in parallel.
+    expect(createdTransports.length).toBe(2);
+    expect(second).not.toBe(first);
+    expect(first.disconnect).toHaveBeenCalled();
+    expect(first.removeAllListeners).toHaveBeenCalled();
+    expect(second.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('first connect with no prior transport does not attempt a teardown', async () => {
+    manager.transport = null;
+
+    await expect(manager.connect()).resolves.toBe(true);
+
+    expect(createdTransports.length).toBe(1);
+    expect(manager.transport).toBe(createdTransports[0]);
+  });
+
+  it('does not tear down an injected transport that is reused as-is', async () => {
+    const injected = makeFakeTransport();
+    manager.transport = injected;
+
+    await manager.connect(injected);
+
+    // Re-injecting the same transport must not destroy it — the guard skips
+    // teardown when this.transport === injectedTransport.
+    expect(injected.disconnect).not.toHaveBeenCalled();
+    expect(injected.removeAllListeners).not.toHaveBeenCalled();
+    expect(manager.transport).toBe(injected);
+    // No fresh TcpTransport was constructed.
+    expect(createdTransports.length).toBe(0);
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1085,6 +1085,32 @@ class MeshtasticManager implements ISourceManager {
       const config = await this.getConfig();
       logger.debug(`Connecting to Meshtastic node at ${config.nodeIp}:${config.tcpPort}...`);
 
+      // Tear down any existing transport before creating a new one. Without
+      // this, a second connect() call — refreshNodeDatabase() landing in a
+      // transient disconnect window, a user reconnect, or a startup race —
+      // orphans the previous TcpTransport: its socket stays open, its
+      // 'connect'/'disconnect' listeners stay bound to this manager, and its
+      // internal shouldReconnect flag keeps it auto-reconnecting forever.
+      // Two live transports against the same meshtasticd — whose single
+      // API-client policy force-closes the older socket whenever a new one
+      // arrives — then ping-pong indefinitely, producing the 25–60s
+      // disconnect/reconnect flap with a ~2:1 daemon-force-close ratio and
+      // no want_config_id errors (#3270). Disconnecting the old transport
+      // first (clears shouldReconnect, removes listeners, destroys the socket)
+      // guarantees exactly one live transport per manager. Skip when the
+      // caller re-injects the same transport (test/VN injection path).
+      if (this.transport && this.transport !== injectedTransport) {
+        logger.debug('🔌 Tearing down existing transport before reconnect (prevents orphaned-transport flap #3270)');
+        try {
+          this.transport.removeAllListeners();
+          this.transport.disconnect();
+        } catch (teardownErr) {
+          const msg = teardownErr instanceof Error ? teardownErr.message : String(teardownErr);
+          logger.debug(`Ignoring error tearing down previous transport: ${msg}`);
+        }
+        this.transport = null;
+      }
+
       // Initialize protobuf service first
       await meshtasticProtobufService.initialize();
 


### PR DESCRIPTION
Fixes #3270.

## Root cause

`MeshtasticManager.connect()` reassigned `this.transport` **without tearing down the previous transport** (`src/server/meshtasticManager.ts:1125`). Any *second* `connect()` call orphaned the old `TcpTransport`:

- its socket stayed open,
- its `'connect'`/`'disconnect'` listeners stayed bound to the manager (the closures kept driving `handleConnected`/`handleDisconnected`),
- its internal `shouldReconnect` flag stayed `true`, so it auto-reconnected forever.

That left **two live transports against the same meshtasticd**. meshtasticd allows a single API client, so it force-closes the older socket whenever the newer one (re)connects → both see `close` → both reconnect → permanent ping-pong.

This matches every symptom in the report:

- **~2:1 daemon-force-close-to-disconnect ratio** — two transports overlapping
- **"ghost socket 1–8s after the main one"**
- **exact 5.0s reconnect cadence** — the transport's own reconnect-initial-delay
- **no `want_config_id` / `connect-race` errors** — these are plain socket closes, the transport just auto-reconnects

### Why only one source flaps

Source A is the env-bootstrap **legacy singleton**, which is what the legacy routes resolve to. `refreshNodeDatabase()` (`meshtasticManager.ts:13200`) calls `await this.connect()` whenever `this.isConnected` is false — and the manager's `isConnected` flips false on every transient transport disconnect *while the transport is still alive auto-reconnecting*. `/nodes/refresh` and `/channels/refresh` resolve to the singleton when no `sourceId` is given (`server.ts:5922,5952` → `resolveSourceManager(undefined)`). UI-created Source B is only ever connected once via `addManager→start`, so it never orphans → rock-solid.

This is **distinct from #3247/#3248** (the `handleConnected` handshake race). The reporter's debug-log capture confirmed the `connect-race` instrumentation (v4.8.x-only, introduced in #3248) fires zero times on v4.7.0, and no `sendWantConfigId` failures occur — so the `waitForTcpReady` probe (gated behind `postResetCooldownUntil > 0`) is not the second socket. The second socket is the orphaned transport.

## Fix

Tear down any existing transport at the top of `connect()` before creating a new one — clears `shouldReconnect`, removes listeners, destroys the socket — guaranteeing exactly one live transport per manager. Skips teardown when the same transport is re-injected (test / Virtual Node path).

## Tests

- New `meshtasticManager.orphanTransport.test.ts` (4 regression cases): existing-transport teardown, no orphan across repeated `connect()`, first-connect no-op, injected-transport reuse not destroyed.
- Full Vitest suite green (5845 passed, 0 failed). `tsc` clean; no new lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)