### PR TITLE
feat(meshcore): support hashtag channels (#3277)

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsConfigSection.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsConfigSection.test.tsx
@@ -177,6 +177,93 @@ describe('MeshCoreChannelsConfigSection — add channel', () => {
   });
 });
 
+describe('MeshCoreChannelsConfigSection — hashtag channels', () => {
+  it('renders a synced hashtag channel without doubling the # prefix', async () => {
+    csrfFetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        // SHA-256("#general")[0:16] = 4c49f3f24629f5ee4ad5b3965db47985 → base64 below.
+        { id: 0, name: '#general', psk: 'TEnz8kYp9e5K1bOWXbR5hQ==' },
+      ]),
+    );
+
+    render(
+      <MeshCoreChannelsConfigSection baseUrl="" sourceId="src-a" canWrite={true} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('#general')).toBeTruthy();
+      // The decorative-prefixed form must NOT appear.
+      expect(screen.queryByText('# #general')).toBeNull();
+    });
+  });
+
+  it('auto-derives the secret from a #hashtag name and locks the field', async () => {
+    csrfFetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    render(
+      <MeshCoreChannelsConfigSection baseUrl="" sourceId="src-a" canWrite={true} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText('No channels reported by the device yet.')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByText('+ Add channel'));
+    const nameInput = screen.getByLabelText('Name') as HTMLInputElement;
+    const secretInput = screen.getByLabelText('Secret (hex, 32 chars)') as HTMLInputElement;
+
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: '#test' } });
+    });
+
+    // SHA-256("#test")[0:16].
+    await waitFor(() =>
+      expect(secretInput.value).toBe('9cd8fcf22a47333b591d96a2b848b73f'),
+    );
+    // The derived secret is read-only and Regenerate is disabled.
+    expect(secretInput.readOnly).toBe(true);
+    expect((screen.getByText('Regenerate') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('Save sends the # name and the derived PSK to the device', async () => {
+    csrfFetchMock
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse({ success: true }))
+      .mockResolvedValueOnce(jsonResponse([
+        { id: 0, name: '#test', psk: 'nNj88ipHMztZHZaiuEi3Pw==' },
+      ]));
+
+    render(
+      <MeshCoreChannelsConfigSection baseUrl="" sourceId="src-a" canWrite={true} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText('No channels reported by the device yet.')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByText('+ Add channel'));
+    const nameInput = screen.getByLabelText('Name') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: '#test' } });
+    });
+    const secretInput = screen.getByLabelText('Secret (hex, 32 chars)') as HTMLInputElement;
+    await waitFor(() =>
+      expect(secretInput.value).toBe('9cd8fcf22a47333b591d96a2b848b73f'),
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    const putCall = csrfFetchMock.mock.calls.find(
+      c => typeof c[1]?.method === 'string' && c[1].method === 'PUT',
+    );
+    expect(putCall).toBeDefined();
+    const body = JSON.parse(putCall![1].body);
+    expect(body.name).toBe('#test');
+    // base64 of 9cd8fcf22a47333b591d96a2b848b73f.
+    expect(body.psk).toBe('nNj88ipHMztZHZaiuEi3Pw==');
+  });
+});
+
 describe('MeshCoreChannelsConfigSection — delete + secret-visibility', () => {
   it('Delete sends DELETE to /api/channels/<idx>?sourceId=<src> and refetches', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);

--- a/src/components/MeshCore/MeshCoreChannelsConfigSection.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsConfigSection.tsx
@@ -24,6 +24,11 @@ import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { useAuth } from '../../contexts/AuthContext';
 import { useToast } from '../ToastContainer';
 import { logger } from '../../utils/logger';
+import {
+  deriveHashtagSecretHex,
+  formatMeshCoreChannelName,
+  isHashtagChannelName,
+} from '../../utils/meshcoreHelpers';
 
 interface MeshCoreChannelsConfigSectionProps {
   baseUrl: string;
@@ -146,6 +151,30 @@ export const MeshCoreChannelsConfigSection: React.FC<MeshCoreChannelsConfigSecti
     return 255;
   }, [channels]);
 
+  // A channel whose name starts with `#` is a hashtag channel: its secret is
+  // derived from the name (SHA-256("#name")[0:16]) rather than randomized, so
+  // it matches the well-known key everyone else on that public topic shares.
+  const isHashtag = isHashtagChannelName(editName);
+
+  // Live-derive the secret whenever the (trimmed) name is a hashtag, mirroring
+  // the official MeshCore app: typing `#general` deterministically yields the
+  // shared key. Non-hashtag names keep whatever secret is in the field.
+  useEffect(() => {
+    if (editingIdx === null) return;
+    const name = editName.trim();
+    if (!name.startsWith('#')) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const hex = await deriveHashtagSecretHex(name);
+        if (!cancelled) setEditSecretHex(hex);
+      } catch (err) {
+        if (!cancelled) logger.error('Failed to derive hashtag channel secret:', err);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [editName, editingIdx]);
+
   const startEdit = useCallback((row: ChannelRow) => {
     setEditingIdx(row.id);
     setEditName(row.name);
@@ -250,7 +279,7 @@ export const MeshCoreChannelsConfigSection: React.FC<MeshCoreChannelsConfigSecti
       <p className="hint">
         {t(
           'meshcore.channels.hint',
-          'Channels on this MeshCore device. Each channel is a name plus a 16-byte (AES-128) shared secret.',
+          'Channels on this MeshCore device. Each channel is a name plus a 16-byte (AES-128) shared secret. Name a channel with a leading "#" (e.g. #general) to join a public hashtag channel — its secret is derived from the name so it matches everyone else on that topic.',
         )}
       </p>
 
@@ -285,7 +314,10 @@ export const MeshCoreChannelsConfigSection: React.FC<MeshCoreChannelsConfigSecti
                   <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
                     <div style={{ flex: 1 }}>
                       <div style={{ fontWeight: 'bold' }}>
-                        # {row.name || t('meshcore.channels.unnamed', 'Channel {{idx}}', { idx: row.id })}
+                        {formatMeshCoreChannelName(
+                          row.name,
+                          t('meshcore.channels.unnamed', 'Channel {{idx}}', { idx: row.id }),
+                        )}
                       </div>
                       <div className="hint" style={{ fontSize: '0.8rem' }}>
                         {t('meshcore.channels.idx_label', 'Index')}: {row.id}
@@ -323,6 +355,7 @@ export const MeshCoreChannelsConfigSection: React.FC<MeshCoreChannelsConfigSecti
                     onSave={handleSave}
                     onCancel={cancelEdit}
                     saving={saving}
+                    derivedFromHashtag={isHashtag}
                   />
                 )}
               </li>
@@ -358,6 +391,7 @@ export const MeshCoreChannelsConfigSection: React.FC<MeshCoreChannelsConfigSecti
             onSave={handleSave}
             onCancel={cancelEdit}
             saving={saving}
+            derivedFromHashtag={isHashtag}
           />
         </div>
       )}
@@ -390,6 +424,9 @@ interface ChannelEditorProps {
   onSave: () => void;
   onCancel: () => void;
   saving: boolean;
+  /** True when the name is a `#hashtag`: the secret is auto-derived and the
+   *  field is locked read-only (regenerating a random secret makes no sense). */
+  derivedFromHashtag: boolean;
 }
 
 const ChannelEditor: React.FC<ChannelEditorProps> = ({
@@ -405,6 +442,7 @@ const ChannelEditor: React.FC<ChannelEditorProps> = ({
   onSave,
   onCancel,
   saving,
+  derivedFromHashtag,
 }) => {
   const { t } = useTranslation();
   return (
@@ -436,6 +474,7 @@ const ChannelEditor: React.FC<ChannelEditorProps> = ({
           spellCheck={false}
           autoComplete="off"
           disabled={saving}
+          readOnly={derivedFromHashtag}
           style={{ flex: 1, fontFamily: 'monospace' }}
         />
         <button
@@ -459,12 +498,21 @@ const ChannelEditor: React.FC<ChannelEditorProps> = ({
         <button
           type="button"
           onClick={onRegenerate}
-          disabled={saving}
+          disabled={saving || derivedFromHashtag}
           title={t('meshcore.channels.regen_title', 'Generate a new random secret')}
         >
           {t('meshcore.channels.regen', 'Regenerate')}
         </button>
       </div>
+      {derivedFromHashtag && (
+        <p className="hint" style={{ fontSize: '0.8rem', marginTop: '0.25rem' }}>
+          {t(
+            'meshcore.channels.hashtag_derived',
+            'Hashtag channel — secret is derived from the name (SHA-256) and shared by everyone using #{{name}}.',
+            { name: name.trim().replace(/^#+/, '') },
+          )}
+        </p>
+      )}
     </div>
     <div style={{ display: 'flex', gap: '0.5rem' }}>
       <button

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -18,7 +18,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { MeshCoreMessage, MeshCoreActions, ConnectionStatus } from './hooks/useMeshCore';
-import { MeshCoreContact } from '../../utils/meshcoreHelpers';
+import { MeshCoreContact, formatMeshCoreChannelName } from '../../utils/meshcoreHelpers';
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
 import { useAuth } from '../../contexts/AuthContext';
 
@@ -188,7 +188,10 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
                 onClick={() => handleSelectChannel(c.id)}
               >
                 <div className="mc-channel-row-name">
-                  # {c.name || t('meshcore.channels.unnamed', 'Channel {{idx}}', { idx: c.id })}
+                  {formatMeshCoreChannelName(
+                    c.name,
+                    t('meshcore.channels.unnamed', 'Channel {{idx}}', { idx: c.id }),
+                  )}
                 </div>
                 <div className="mc-channel-row-meta">
                   {count} {t('meshcore.messages', 'messages')}
@@ -209,7 +212,10 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
               ◀ {t('common.back', 'Back')}
             </button>
             <span className="meshcore-mobile-back-title">
-              # {active.name || t('meshcore.channels.unnamed', 'Channel {{idx}}', { idx: active.id })}
+              {formatMeshCoreChannelName(
+                active.name,
+                t('meshcore.channels.unnamed', 'Channel {{idx}}', { idx: active.id }),
+              )}
             </span>
           </div>
         )}

--- a/src/utils/meshcoreHelpers.test.ts
+++ b/src/utils/meshcoreHelpers.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveHashtagSecretHex,
+  formatMeshCoreChannelName,
+  isHashtagChannelName,
+} from './meshcoreHelpers';
+
+describe('isHashtagChannelName', () => {
+  it('is true for names starting with #', () => {
+    expect(isHashtagChannelName('#general')).toBe(true);
+    expect(isHashtagChannelName('  #test')).toBe(true); // leading whitespace trimmed
+  });
+
+  it('is false for plain names and empty/nullish input', () => {
+    expect(isHashtagChannelName('Public')).toBe(false);
+    expect(isHashtagChannelName('')).toBe(false);
+    expect(isHashtagChannelName(null)).toBe(false);
+    expect(isHashtagChannelName(undefined)).toBe(false);
+  });
+});
+
+describe('formatMeshCoreChannelName', () => {
+  it('keeps the leading # for hashtag channels (no double #)', () => {
+    expect(formatMeshCoreChannelName('#general', 'Channel 0')).toBe('#general');
+  });
+
+  it('decoratively prepends "# " for plain names', () => {
+    expect(formatMeshCoreChannelName('Public', 'Channel 0')).toBe('# Public');
+  });
+
+  it('falls back to the supplied label for empty names', () => {
+    expect(formatMeshCoreChannelName('', 'Channel 5')).toBe('# Channel 5');
+    expect(formatMeshCoreChannelName(null, 'Channel 5')).toBe('# Channel 5');
+  });
+});
+
+describe('deriveHashtagSecretHex', () => {
+  // Authoritative MeshCore value: SHA-256("#test")[0:16].
+  it('matches the well-known MeshCore #test derivation', async () => {
+    await expect(deriveHashtagSecretHex('#test')).resolves.toBe('9cd8fcf22a47333b591d96a2b848b73f');
+  });
+
+  it('hashes the literal "#" prefix — adds it when missing', async () => {
+    // "test" and "#test" must yield the same key (the # is always hashed).
+    await expect(deriveHashtagSecretHex('test')).resolves.toBe('9cd8fcf22a47333b591d96a2b848b73f');
+  });
+
+  it('is case-sensitive', async () => {
+    const lower = await deriveHashtagSecretHex('#general');
+    const upper = await deriveHashtagSecretHex('#General');
+    expect(lower).not.toBe(upper);
+  });
+
+  it('returns a 32-char (16-byte) lowercase hex string', async () => {
+    const hex = await deriveHashtagSecretHex('#general');
+    expect(hex).toMatch(/^[0-9a-f]{32}$/);
+  });
+});

--- a/src/utils/meshcoreHelpers.ts
+++ b/src/utils/meshcoreHelpers.ts
@@ -46,3 +46,52 @@ export function mapContactsToNodes(contacts: MeshCoreContact[]): MeshCoreMapNode
       };
     });
 }
+
+// --- MeshCore channels -----------------------------------------------------
+
+/** Number of bytes in a MeshCore channel secret (AES-128). */
+export const MESHCORE_SECRET_BYTES = 16;
+
+/**
+ * A MeshCore "hashtag channel" is a public topic channel (`#general`, `#test`)
+ * whose secret is deterministically derived from its name, so anyone using the
+ * same `#name` shares the key with no key exchange. MeshCore classifies a
+ * channel as a hashtag channel precisely when its name starts with `#`.
+ */
+export function isHashtagChannelName(name: string | null | undefined): boolean {
+  return (name ?? '').trim().startsWith('#');
+}
+
+/**
+ * Format a MeshCore channel name for display.
+ *
+ * Names are shown with a leading `# ` as a decorative convention. Hashtag
+ * channels already store the `#` as part of the name (e.g. `#general`), so we
+ * must NOT prepend another one or they render as `# #general`. Empty names fall
+ * back to the supplied label (e.g. "Channel 0").
+ */
+export function formatMeshCoreChannelName(name: string | null | undefined, fallback: string): string {
+  const trimmed = (name ?? '').trim();
+  if (!trimmed) return `# ${fallback}`;
+  if (trimmed.startsWith('#')) return trimmed;
+  return `# ${trimmed}`;
+}
+
+/**
+ * Derive the 16-byte AES-128 secret for a MeshCore hashtag channel.
+ *
+ * Matches the official MeshCore app: `SHA-256("#" + room)[0:16]`, where the
+ * literal name string — INCLUDING the leading `#` — is hashed verbatim (the
+ * derivation is case-sensitive). Pass the channel name exactly as it will be
+ * stored (`#general`); a missing leading `#` is added before hashing.
+ *
+ * Returns the secret as a lowercase hex string (32 chars).
+ */
+export async function deriveHashtagSecretHex(name: string): Promise<string> {
+  const normalized = name.trim().startsWith('#') ? name.trim() : `#${name.trim()}`;
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(normalized));
+  const full = new Uint8Array(digest);
+  let hex = '';
+  for (let i = 0; i < MESHCORE_SECRET_BYTES; i++) hex += full[i].toString(16).padStart(2, '0');
+  return hex;
+}


### PR DESCRIPTION
## Summary

Closes #3277. Adds support for MeshCore **hashtag channels** — public topic channels (`#general`, `#test`) whose 16-byte AES-128 secret is deterministically derived from the name as `SHA-256("#"+name)[0:16]`. Everyone using the same `#name` shares the key with no key exchange, so this lets MeshMonitor join and participate in the wider MeshCore public-channel ecosystem.

Previously the MeshCore channel editor only generated **random** secrets, so there was no way to join these well-known channels.

## What changed (frontend-only)

The backend needs no changes — the existing `PUT /api/channels/:idx` MeshCore path (`server.ts`) already passes the channel name + secret to the device verbatim and only validates a 16-byte secret.

- **`src/utils/meshcoreHelpers.ts`** — new shared helpers:
  - `deriveHashtagSecretHex(name)` — `SHA-256("#"+name)[0:16]`; the `#` is always hashed, case-sensitive (matches the official app).
  - `isHashtagChannelName(name)` — classifies a channel as hashtag iff the name starts with `#`.
  - `formatMeshCoreChannelName(name, fallback)` — display formatter that avoids a double `#`.
- **`MeshCoreChannelsConfigSection.tsx`** — when the channel name starts with `#`, the secret auto-derives live (mirroring the official MeshCore app), the secret field locks read-only, Regenerate is disabled, and a hint explains it's a shared hashtag channel. Non-`#` names keep the existing random-secret behavior.
- **`MeshCoreChannelsView.tsx`** — uses the shared formatter in the channel list + mobile header.

### Bonus: fixed a latent display bug
Names are stored **with** the leading `#` (firmware/app convention), but the UI decoratively prepended `# `, so a real hashtag channel `#general` would have rendered as `# #general`. The shared formatter fixes this while keeping the decorative `# ` for plain (non-hashtag) names.

## Provenance
Authoritative MeshCore behavior (hash includes the `#`; name stored with the `#`; classified as hashtag iff `name.startsWith('#')`) confirmed against the official `zjs81/meshcore-open` Flutter client and `meshcore.js`. Verified `#test → 9cd8fcf22a47333b591d96a2b848b73f`.

## Testing
- New unit tests for all three helpers (incl. the authoritative `#test` derivation, case-sensitivity, no-double-`#`).
- New config-section integration tests: auto-derive + locked field, Save sends the `#` name + derived PSK, synced `#general` renders without double-`#`.
- ✅ Full Vitest suite: **5853 passed, 0 failed**
- ✅ `tsc --noEmit` clean; ESLint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)