### PR TITLE
chore: bump version to 4.8.2 with changelog and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### Added
-- **Unified Telemetry source jump buttons** (#3262): The source labels at the top of the Unified Telemetry page are now clickable pills that smooth-scroll to their section's card grid. The header bar is sticky so the pills stay reachable while scrolling, and the pill for the section nearest the top is highlighted as the active jump target.
-- **Show Waypoints map toggle** (#3253): The Map Features panel on the dashboard and Nodes maps now has a **Show Waypoints** checkbox that controls waypoint marker visibility. Defaults to on and is persisted per-user via map preferences, alongside the existing Show RF / UDP / MQTT / Traceroute toggles.
+## [4.8.2] - 2026-05-31
+
+# MeshMonitor v4.8.2
+
+Patch release centered on packet observability: a new **Unified Packet Monitor** spanning every source and a dedicated **MeshCore Packet Monitor** with click-to-open packet decoding and hashtag-channel support. Also adds telemetry unit auto-scaling, richer dashboard map popups, and a round of stability and rendering fixes.
+
+## Features
+
+### Packet Monitoring
+
+- #3252 feat(packets): add Unified Packet Monitor across all sources — a cross-source packet monitor that aggregates packet activity from every connected source into one view.
+- #3268 feat(meshcore): MeshCore Packet Monitor via LogRxData — opt-in capture of MeshCore OTA packets through the `LogRxData` stream, persisted to `meshcore_packet_log`, with its own monitor view.
+- #3273 feat(meshcore): decode packet contents in a click-to-open modal — click any captured MeshCore packet to open a modal that decodes its contents.
+
+### MeshCore
+
+- #3277 feat(meshcore): support hashtag channels — recognize and handle MeshCore hashtag (`#`) channels.
+- #3259 feat(meshcore): dashboard neighbor links, saved-password neighbor queries, on-demand remote console — render MeshCore neighbor links on the dashboard, allow neighbor queries using saved passwords, and open the remote console on demand.
+
+### Telemetry
+
+- #3261 feat(telemetry): auto-scale current/power units and humanize uptime — current/power telemetry values auto-scale to appropriate units and uptime is rendered in human-readable form.
+- #3262 feat(telemetry): clickable source jump buttons on Unified Telemetry — the source labels at the top of the Unified Telemetry page are now clickable pills that smooth-scroll to their section's card grid. The header bar is sticky so the pills stay reachable while scrolling, and the pill for the section nearest the top is highlighted as the active jump target.
+- #3258 Make traceroute history limit configurable — the traceroute history retention limit is now operator-configurable.
+
+### Map
+
+- #3256 feat(dashboard-map): rich node popup with per-source/protocol breakdown — the dashboard map node popup now shows a per-source and per-protocol breakdown.
+- #3253 feat(map): add persisted Show Waypoints visibility toggle — the Map Features panel on the dashboard and Nodes maps now has a **Show Waypoints** checkbox that controls waypoint marker visibility. Defaults to on and is persisted per-user via map preferences, alongside the existing Show RF / UDP / MQTT / Traceroute toggles.
+
+## Fixes
+
+- #3270 fix(stability): tear down orphaned transport on reconnect — on reconnect, an orphaned transport left over from a prior session is now torn down rather than leaking.
+- #3274 fix(packets): include MeshCore OTA packets in Unified Packet Monitor — MeshCore OTA packets now appear alongside Meshtastic packets in the Unified Packet Monitor.
+- #3263 fix(mqtt): stop rxTime=0 from rendering messages at Unix epoch (Dec 1969) — messages with `rxTime=0` no longer render with a December 1969 timestamp.
+- #3260 fix(telemetry): convert temperature values, not just unit labels — temperature conversion now converts the underlying value, not only the displayed unit label.
+- #3257 fix(map): make RF/UDP/MQTT visibility toggles additive per node — the RF/UDP/MQTT map visibility toggles now combine additively per node instead of overriding one another.
+- #3254 fix(meshcore): make all mobile bottom-bar tabs reachable — every MeshCore mobile bottom-bar tab is now reachable.
+
+## Documentation
+
+- #3267 docs(meshtasticd): add physical LoRa hardware compose example — adds a Docker Compose example for physical LoRa hardware with meshtasticd.
 
 ## [4.8.1] - 2026-05-28
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # MeshMonitor — Claude Agent Brief
 
-**Version:** 4.8.1 (multi-source architecture)
+**Version:** 4.8.2 (multi-source architecture)
 **Stack:** React 19 + TS + Vite frontend / Node.js 20+ (Docker image ships Node 24; CI matrix covers 20/22/24/25) + Express 5 + TS backend / SQLite (default), PostgreSQL, MySQL via Drizzle ORM / Meshtastic protobuf-over-TCP and MeshCore (native `meshcore.js` for companion, serial CLI for repeater) through a per-source manager registry.
 
 ## Read order for new agents

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.8.1",
+  "version": "4.8.2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.8.1
-appVersion: "4.8.1"
+version: 4.8.2
+appVersion: "4.8.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.8.1",
+      "version": "4.8.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Bumps MeshMonitor to **4.8.2** and brings documentation up to date.

- Version updated across all release-managed files: `package.json`, `package-lock.json`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, `helm/meshmonitor/Chart.yaml`.
- `CLAUDE.md` version header updated to 4.8.2.
- `CHANGELOG.md`: rolled the **17 PRs merged since 4.8.1** into a new `[4.8.2]` entry. The `[Unreleased]` section had only captured 2 of them (#3262, #3253), so the changelog was significantly behind — this reconciles it against `git log bdfa135e..main`.

## Changelog highlights (4.8.2)

**Features**
- Unified Packet Monitor across all sources (#3252)
- MeshCore Packet Monitor via LogRxData (#3268) + click-to-open packet decode modal (#3273)
- MeshCore hashtag channels (#3277); dashboard neighbor links + on-demand remote console (#3259)
- Telemetry unit auto-scaling & humanized uptime (#3261); Unified Telemetry jump buttons (#3262); configurable traceroute history (#3258)
- Rich dashboard map node popups (#3256); persisted Show Waypoints toggle (#3253)

**Fixes**
- Tear down orphaned transport on reconnect (#3270); MeshCore OTA packets in Unified Monitor (#3274); rxTime=0 epoch rendering (#3263); temperature value conversion (#3260); additive map visibility toggles (#3257); reachable MeshCore mobile tabs (#3254)

**Docs**
- Physical LoRa hardware compose example (#3267)

## Test plan

- [x] All five version-managed files confirmed at 4.8.2; JSON validated
- [x] `package-lock.json` regenerated via `npm install --package-lock-only --legacy-peer-deps`
- [x] No source/test files touched — diff is JSON + markdown only
- [ ] CI: full Vitest suite + **system tests** (run automatically on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
