### PR TITLE
fix(stability): close transport-level orphan-reconnect flap (#3270)

### DIFF
--- a/src/server/meshtasticManager.orphanTransport.test.ts
+++ b/src/server/meshtasticManager.orphanTransport.test.ts
@@ -197,6 +197,39 @@ describe('MeshtasticManager - issue #3270 orphaned-transport flap', () => {
     expect(manager.transport).toBe(createdTransports[0]);
   });
 
+  it('serializes concurrent connect() calls into a single transport (#3270 follow-up: startup-race orphan)', async () => {
+    manager.transport = null;
+
+    // Fire two connect() calls without awaiting the first. This reproduces the
+    // residual #3270 flap: on the legacy singleton, a startup connect() is
+    // still mid-handshake (awaiting getConfig / protobuf init / transport
+    // connect) while a legacy route's refreshNodeDatabase() — which calls
+    // connect() whenever isConnected is false — fires a second connect().
+    // Without a connect mutex, both calls pass the null-transport teardown
+    // check and each constructs a TcpTransport; the first becomes an
+    // unreferenced orphan that auto-reconnects forever (the transport-level
+    // flap the #3276 teardown can no longer reach).
+    const [r1, r2] = await Promise.all([manager.connect(), manager.connect()]);
+
+    expect(r1).toBe(true);
+    expect(r2).toBe(true);
+
+    // Exactly one transport was constructed — the second call joined the
+    // in-flight attempt instead of building a parallel (orphan) transport.
+    expect(createdTransports.length).toBe(1);
+    expect(manager.transport).toBe(createdTransports[0]);
+  });
+
+  it('allows a fresh connect() after the previous attempt settles (mutex clears)', async () => {
+    await manager.connect();
+    expect(createdTransports.length).toBe(1);
+
+    // Once the in-flight attempt has resolved, a later connect() must proceed
+    // normally (the mutex must not latch permanently).
+    await manager.connect();
+    expect(createdTransports.length).toBe(2);
+  });
+
   it('does not tear down an injected transport that is reused as-is', async () => {
     const injected = makeFakeTransport();
     manager.transport = injected;

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -472,6 +472,10 @@ class MeshtasticManager implements ISourceManager {
   private postResetCooldownUntil: number = 0;
   private virtualNodeServer?: VirtualNodeServer;
   private transport: ITransport | null = null;
+  // Single-flight latch for connect(): holds the in-flight attempt so a
+  // concurrent connect() joins it instead of building a second (orphan)
+  // transport (#3270). Cleared in a finally when the attempt settles.
+  private connectInFlight: Promise<boolean> | null = null;
   private isConnected = false;
   private userDisconnectedState = false;  // Track user-initiated disconnect
   private tracerouteInterval: NodeJS.Timeout | null = null;
@@ -1080,7 +1084,33 @@ class MeshtasticManager implements ISourceManager {
     }
   }
 
+  /**
+   * Connect to the node, serialized so overlapping callers never build two
+   * transports.
+   *
+   * #3270 follow-up: connect() has several `await`s (getConfig, protobuf init,
+   * the up-to-10s transport.connect) before it assigns `this.transport`. The
+   * legacy singleton is hit by routes that call connect() whenever
+   * `isConnected` is false (e.g. refreshNodeDatabase). If a second connect()
+   * lands during the first one's handshake window, both pass the
+   * teardown-existing-transport check (this.transport is still null/stale) and
+   * each constructs a TcpTransport. The first then becomes an unreferenced
+   * orphan that auto-reconnects forever — the residual flap the #3276 teardown
+   * cannot reach because it only tears down the transport currently in
+   * `this.transport`. A single-flight latch makes a concurrent connect() join
+   * the in-flight attempt instead of racing it.
+   */
   async connect(injectedTransport?: ITransport): Promise<boolean> {
+    if (this.connectInFlight) {
+      logger.debug('connect() already in progress — joining the in-flight attempt (prevents orphaned-transport flap #3270)');
+      return this.connectInFlight;
+    }
+    this.connectInFlight = this.doConnectInternal(injectedTransport)
+      .finally(() => { this.connectInFlight = null; });
+    return this.connectInFlight;
+  }
+
+  private async doConnectInternal(injectedTransport?: ITransport): Promise<boolean> {
     try {
       const config = await this.getConfig();
       logger.debug(`Connecting to Meshtastic node at ${config.nodeIp}:${config.tcpPort}...`);

--- a/src/server/tcpTransport.orphanGuard.test.ts
+++ b/src/server/tcpTransport.orphanGuard.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Regression tests for the transport-level half of issue #3270.
+ *
+ * #3276 added a teardown in MeshtasticManager.connect(), but that can only
+ * reach the transport the manager currently references. The residual flap the
+ * reporter measured on PR #3276 was driven entirely by TcpTransport's own
+ * auto-reconnect loop (scheduleReconnect → doConnect on socket 'close'). These
+ * tests harden the transport itself so it cannot become a self-reconnecting
+ * zombie:
+ *
+ *   1. Once disconnect()ed, a transport must never reconnect again — even if a
+ *      late scheduleReconnect() arrives (a queued 'close' handler, a racing
+ *      timer). Before this fix scheduleReconnect() scheduled a doConnect
+ *      unconditionally, with no "I've been torn down" guard.
+ *   2. doConnect() must tear down any pre-existing socket before opening a new
+ *      one, so a single transport can never leak two live sockets at the
+ *      daemon (the 2:1 force-close fingerprint).
+ *
+ * `net` is mocked so doConnect() never opens a real socket.
+ */
+
+const createdSockets: any[] = [];
+
+vi.mock('net', () => {
+  class FakeSocket {
+    setKeepAlive = vi.fn();
+    setNoDelay = vi.fn();
+    on = vi.fn();
+    once = vi.fn();
+    removeAllListeners = vi.fn();
+    destroy = vi.fn();
+    connect = vi.fn();
+    write = vi.fn();
+    constructor() {
+      createdSockets.push(this);
+    }
+  }
+  return { Socket: FakeSocket };
+});
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('TcpTransport — orphan/zombie reconnect guard (#3270)', () => {
+  let TcpTransport: any;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    createdSockets.length = 0;
+    ({ TcpTransport } = await import('./tcpTransport.js'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('does not reconnect after disconnect(), even if scheduleReconnect() fires late', () => {
+    const t = new TcpTransport();
+    (t as any).config = { host: '127.0.0.1', port: 4403 };
+    const doConnectSpy = vi.spyOn(t as any, 'doConnect').mockResolvedValue(undefined);
+
+    // Operator/manager tears the transport down.
+    t.disconnect();
+
+    // A late 'close' handler (or any straggler) tries to reschedule a reconnect.
+    (t as any).scheduleReconnect();
+    vi.advanceTimersByTime(120_000);
+
+    // The torn-down transport must stay dead — no resurrection.
+    expect(doConnectSpy).not.toHaveBeenCalled();
+  });
+
+  it('doConnect() tears down a pre-existing socket before opening a new one', () => {
+    const t = new TcpTransport();
+    (t as any).config = { host: '127.0.0.1', port: 4403 };
+
+    const staleSocket = {
+      removeAllListeners: vi.fn(),
+      destroy: vi.fn(),
+    };
+    (t as any).socket = staleSocket;
+
+    // Kick off a connect. We don't await it (the fake socket never fires
+    // 'connect'); we only care that the stale socket was reclaimed.
+    void (t as any).doConnect();
+
+    expect(staleSocket.removeAllListeners).toHaveBeenCalled();
+    expect(staleSocket.destroy).toHaveBeenCalled();
+    // Exactly one new socket was constructed for this attempt.
+    expect(createdSockets.length).toBe(1);
+  });
+
+  it('public connect() re-arms a previously disconnected transport', async () => {
+    const t = new TcpTransport();
+    const doConnectSpy = vi.spyOn(t as any, 'doConnect').mockResolvedValue(undefined);
+
+    t.disconnect();
+    // A brand-new explicit connect() is a fresh intent and must be honored.
+    await t.connect('127.0.0.1', 4403);
+
+    expect(doConnectSpy).toHaveBeenCalledTimes(1);
+    expect((t as any).shouldReconnect).toBe(true);
+  });
+});

--- a/src/server/tcpTransport.ts
+++ b/src/server/tcpTransport.ts
@@ -16,6 +16,13 @@ export class TcpTransport extends EventEmitter implements ITransport {
   private isConnected = false;
   private isConnecting = false;
   private shouldReconnect = true;
+  // Set once disconnect() has been called. A destroyed transport must never
+  // reconnect again — even if a straggler 'close' handler or racing timer
+  // calls scheduleReconnect() after teardown. This is the transport-level
+  // half of the #3270 orphan-flap fix: once the manager lets go of a
+  // transport it can no longer reach, the transport must not resurrect itself.
+  // Re-armed to false by the public connect() (an explicit fresh intent).
+  private destroyed = false;
   private config: TcpTransportConfig | null = null;
 
   // Stale connection detection
@@ -165,6 +172,8 @@ export class TcpTransport extends EventEmitter implements ITransport {
 
     this.config = { host, port };
     this.shouldReconnect = true;
+    // A fresh explicit connect re-arms a previously torn-down transport.
+    this.destroyed = false;
 
     return this.doConnect();
   }
@@ -174,6 +183,23 @@ export class TcpTransport extends EventEmitter implements ITransport {
       if (!this.config) {
         reject(new Error('No configuration set'));
         return;
+      }
+
+      // A torn-down transport must never open another socket (#3270).
+      if (this.destroyed) {
+        reject(new Error('Transport has been disconnected'));
+        return;
+      }
+
+      // Reclaim any pre-existing socket before opening a new one. Without this
+      // a single transport could leak two live sockets at the daemon — the
+      // 2:1 "Force close previous TCP connection" fingerprint from #3270.
+      if (this.socket) {
+        try {
+          this.socket.removeAllListeners();
+          this.socket.destroy();
+        } catch { /* ignore */ }
+        this.socket = null;
       }
 
       this.isConnecting = true;
@@ -245,8 +271,9 @@ export class TcpTransport extends EventEmitter implements ITransport {
           this.emit('disconnect');
         }
 
-        // Attempt reconnection if enabled (will retry forever with exponential backoff up to 60s)
-        if (this.shouldReconnect) {
+        // Attempt reconnection if enabled (will retry forever with exponential backoff up to 60s).
+        // Never reconnect once the transport has been torn down (#3270).
+        if (this.shouldReconnect && !this.destroyed) {
           this.scheduleReconnect();
         }
       });
@@ -256,6 +283,12 @@ export class TcpTransport extends EventEmitter implements ITransport {
   }
 
   private scheduleReconnect(): void {
+    // Guard against resurrection: a transport torn down via disconnect() must
+    // not schedule another connect, no matter who calls this (#3270).
+    if (this.destroyed) {
+      return;
+    }
+
     if (this.reconnectTimeout) {
       clearTimeout(this.reconnectTimeout);
     }
@@ -281,6 +314,9 @@ export class TcpTransport extends EventEmitter implements ITransport {
 
   disconnect(): void {
     this.shouldReconnect = false;
+    // Mark torn-down so any late scheduleReconnect()/'close' straggler can't
+    // resurrect this transport into a zombie auto-reconnect loop (#3270).
+    this.destroyed = true;
 
     if (this.reconnectTimeout) {
       clearTimeout(this.reconnectTimeout);


### PR DESCRIPTION
## Summary

Follow-up to #3276. The reporter's post-#3276 testing (issue #3270) confirmed the orphan-transport diagnosis was correct but the fix was **incomplete**: the v4.8.1 error noise vanished, yet the 25–60s reconnect flap persisted on the legacy-singleton source, with a ~2:1 daemon force-close ratio and **every reconnect originating from `TcpTransport`'s own auto-reconnect loop** — `manager.connect()` was never entered during the flap window.

### Root cause

`MeshtasticManager.connect()` has **no concurrency guard**. It performs several `await`s (`getConfig`, protobuf init, the up-to-10s `transport.connect`) *before* it assigns `this.transport`. The legacy singleton is driven by routes that call `connect()` whenever `isConnected` is false (e.g. `refreshNodeDatabase`). When a second `connect()` lands during the first one's handshake window, **both pass the "tear down existing transport" check** (`this.transport` is still null/stale) and each constructs a `TcpTransport`. The first becomes an **unreferenced orphan** that auto-reconnects forever via the transport's own `scheduleReconnect()` — and #3276's teardown can't reach it because it only disconnects whatever is currently in `this.transport`.

Two live transports vs meshtasticd's single-API-client policy → permanent ping-pong (2:1 force-close ratio, no `want_config_id` errors, exact 5s cadence). UI-created sources connect exactly once via `start()`, so they never orphan — explaining the per-source asymmetry in the report.

### Fix (two layers)

1. **Manager — single-flight latch.** `connectInFlight` holds the in-flight attempt; a concurrent `connect()` joins it instead of building a second transport. Cleared in a `finally`.
2. **Transport — anti-zombie hardening** (the reporter's suggestion). A `destroyed` flag set by `disconnect()` guards the `'close'` handler and `scheduleReconnect()` so a torn-down transport can never resurrect; `doConnect()` also reclaims any pre-existing socket before opening a new one.

## Test plan

- [x] 5 new regression tests:
  - manager: concurrent `connect()` → exactly one transport; mutex clears for later connects
  - transport: late `scheduleReconnect()` is a no-op after `disconnect()`; `doConnect()` reclaims a stale socket; public `connect()` re-arms a disconnected transport
- [x] Full Vitest suite green — **5862 passed**, 0 failures
- [x] `tsc --noEmit` clean
- [x] No new lint errors (the 3 `NodeJS` `no-undef` are pre-existing baseline on `main`)
- [ ] CI: full suite + system tests (run automatically on this PR)

Closes #3270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
