### PR TITLE
feat(mqtt): dedicated bridge Configuration page + per-bridge publish filter (#3294)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -6,6 +6,7 @@
   "nav.dashboard": "Dashboard",
   "nav.settings": "Settings",
   "nav.configuration": "Device",
+  "nav.mqtt_bridge_config": "Configuration",
   "nav.automation": "Automation",
   "nav.notifications": "Notifications",
   "nav.users": "Users",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import './App.css';
 import InfoTab from './components/InfoTab';
 import SettingsTab from './components/SettingsTab';
 import ConfigurationTab from './components/ConfigurationTab';
+import MqttBridgeConfigurationView from './components/MQTT/MqttBridgeConfigurationView';
 import NotificationsTab from './components/NotificationsTab';
 import UsersTab from './components/UsersTab';
 import AuditLogTab from './components/AuditLogTab';
@@ -638,6 +639,7 @@ function App() {
       settings: () => hasPermission('settings', 'read'),
       automation: () => !isMqttBridge && hasPermission('automation', 'read'),
       configuration: () => !isMqttBridge && hasPermission('configuration', 'read'),
+      'mqtt-config': () => isMqttBridge && hasPermission('sources', 'read'),
       notifications: () => isAuthenticated,
       users: () => isAdmin,
       admin: () => !isMqttBridge && isAdmin,
@@ -5201,6 +5203,11 @@ function App() {
             onChannelsUpdated={() => fetchChannels()}
             refreshTrigger={configRefreshTrigger}
           />
+          </ErrorBoundary>
+        )}
+        {activeTab === 'mqtt-config' && isMqttBridge && sourceId && (
+          <ErrorBoundary fallbackTitle="Configuration failed to load">
+            <MqttBridgeConfigurationView key={sourceId} sourceId={sourceId} />
           </ErrorBoundary>
         )}
         {activeTab === 'notifications' && <ErrorBoundary fallbackTitle="Notifications failed to load"><NotificationsTab isAdmin={authStatus?.user?.isAdmin || false} /></ErrorBoundary>}

--- a/src/components/MQTT/MqttBridgeConfigurationView.tsx
+++ b/src/components/MQTT/MqttBridgeConfigurationView.tsx
@@ -1,0 +1,656 @@
+/**
+ * Dedicated Configuration page for an mqtt_bridge source.
+ *
+ * Surfaced as the "Configuration" tab inside the bridge source view (see
+ * App.tsx / Sidebar.tsx). Loads the source config via GET /api/sources/:id,
+ * presents the full set of bridge options in roomy collapsible sections, and
+ * saves the reassembled config via PUT /api/sources/:id.
+ *
+ * Centralizes options that previously only lived in the cramped create/edit
+ * modal, and adds the per-bridge **publish (uplink) topic filter** (#3294).
+ * All config (de)serialization is shared with that modal via
+ * `./mqttBridgeConfig` so the two editors can never drift.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../contexts/AuthContext';
+import { useCsrfFetch } from '../../hooks/useCsrfFetch';
+import { appBasename } from '../../init';
+import { logger } from '../../utils/logger';
+import { CollapsibleSection } from '../MeshCore/CollapsibleSection';
+import BBoxMapEditor, { type BBoxValue } from '../BBoxMapEditor';
+import { bboxToFormStrings } from '../../pages/DashboardPage.bboxSeed';
+import {
+  buildBridgeConfig,
+  formFromBridgeConfig,
+  emptyBridgeForm,
+  BRIDGE_MODES,
+  BRIDGE_FORWARDING_MODES,
+  type BridgeConfigForm,
+  type UplinkTopicMode,
+} from './mqttBridgeConfig';
+
+interface SourceSummary {
+  id: string;
+  name: string;
+  type: string;
+}
+
+interface MqttBridgeConfigurationViewProps {
+  /** Source UUID of the bridge being configured. */
+  sourceId: string;
+}
+
+const GEO_KEYS = ['minLat', 'maxLat', 'minLng', 'maxLng'] as const;
+
+/** Parse the four geo string fields into a BBoxValue, or null if incomplete. */
+function bboxFromForm(g: BridgeConfigForm['geo']): BBoxValue | null {
+  if (GEO_KEYS.some((k) => g[k] === '')) return null;
+  const nums = {
+    minLat: Number(g.minLat),
+    maxLat: Number(g.maxLat),
+    minLng: Number(g.minLng),
+    maxLng: Number(g.maxLng),
+  };
+  if (Object.values(nums).some((n) => Number.isNaN(n))) return null;
+  return nums;
+}
+
+const labelStyle: React.CSSProperties = { fontSize: 11, color: 'var(--ctp-subtext0)', marginTop: 4 };
+
+export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewProps> = ({
+  sourceId,
+}) => {
+  const { t } = useTranslation();
+  const { hasPermission } = useAuth();
+  const csrfFetch = useCsrfFetch();
+  const canWrite = hasPermission('sources', 'write');
+
+  const [form, setForm] = useState<BridgeConfigForm>(emptyBridgeForm());
+  const [brokers, setBrokers] = useState<SourceSummary[]>([]);
+  const [knownChannels, setKnownChannels] = useState<string[]>([]);
+  const [customChannel, setCustomChannel] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  // Shallow patch helper for the form state.
+  const patch = useCallback(
+    <K extends keyof BridgeConfigForm>(key: K, value: BridgeConfigForm[K]) => {
+      setForm((prev) => ({ ...prev, [key]: value }));
+      setSaved(false);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setLoadError('');
+    (async () => {
+      try {
+        const [srcRes, listRes, chDbRes, srcChRes] = await Promise.all([
+          csrfFetch(`${appBasename}/api/sources/${sourceId}`),
+          csrfFetch(`${appBasename}/api/sources`),
+          // Global decryption channels — auto-populated with every channel name
+          // any bridge observes, plus user-added rows. Best source of names.
+          csrfFetch(`${appBasename}/api/channel-database`),
+          // Per-source channels (sparse for bridges; populated from live traffic).
+          csrfFetch(`${appBasename}/api/v1/channels?sourceId=${encodeURIComponent(sourceId)}`),
+        ]);
+        if (!srcRes.ok) throw new Error(`GET source failed: ${srcRes.status}`);
+        const src = await srcRes.json();
+        if (cancelled) return;
+        setForm(formFromBridgeConfig(src?.config));
+        if (listRes.ok) {
+          const list: SourceSummary[] = await listRes.json();
+          if (!cancelled) setBrokers(list.filter((s) => s.type === 'mqtt_broker'));
+        }
+        // Channel-name suggestions (best-effort — failures just yield no list).
+        const names = new Set<string>();
+        const collect = (body: unknown) => {
+          const rows = Array.isArray(body)
+            ? body
+            : ((body as { data?: unknown[]; channels?: unknown[] })?.data ??
+               (body as { channels?: unknown[] })?.channels ??
+               []);
+          for (const r of rows as Array<{ name?: unknown }>) {
+            if (typeof r?.name === 'string' && r.name.trim()) names.add(r.name.trim());
+          }
+        };
+        if (chDbRes.ok) collect(await chDbRes.json().catch(() => null));
+        if (srcChRes.ok) collect(await srcChRes.json().catch(() => null));
+        if (!cancelled) {
+          setKnownChannels(Array.from(names).sort((a, b) => a.localeCompare(b)));
+        }
+      } catch (err) {
+        logger.error('Failed to load bridge config:', err);
+        if (!cancelled) {
+          setLoadError(
+            t('mqtt_bridge_config.load_error', 'Failed to load bridge configuration.'),
+          );
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sourceId, csrfFetch, t]);
+
+  const handleSave = useCallback(async () => {
+    setSaveError('');
+    setSaved(false);
+    const result = buildBridgeConfig(form, { editing: true });
+    if (result.error) {
+      setSaveError(t(result.error.key, result.error.fallback));
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await csrfFetch(`${appBasename}/api/sources/${sourceId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ config: result.config }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error || `PUT failed: ${res.status}`);
+      }
+      const updated = await res.json();
+      // Re-hydrate from the server's stored config (clears the password field
+      // and reflects any server-side normalization).
+      setForm(formFromBridgeConfig(updated?.config));
+      setSaved(true);
+    } catch (err) {
+      logger.error('Failed to save bridge config:', err);
+      setSaveError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [form, sourceId, csrfFetch, t]);
+
+  const selectedChannels = form.uplinkChannels ?? [];
+  const toggleChannel = (name: string, checked: boolean) => {
+    const next = new Set(selectedChannels);
+    if (checked) next.add(name);
+    else next.delete(name);
+    patch('uplinkChannels', Array.from(next));
+  };
+  const addCustomChannel = () => {
+    const name = customChannel.trim();
+    if (name && !selectedChannels.includes(name)) {
+      patch('uplinkChannels', [...selectedChannels, name]);
+    }
+    setCustomChannel('');
+  };
+  // Candidate checkboxes = known channel names ∪ anything already selected
+  // (so a saved channel that's no longer "known" still shows, checked).
+  const channelOptions = Array.from(new Set([...knownChannels, ...selectedChannels])).sort((a, b) =>
+    a.localeCompare(b),
+  );
+
+  if (loading) {
+    return (
+      <div className="mqtt-bridge-config" style={{ padding: 16 }}>
+        {t('common.loading', 'Loading…')}
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="mqtt-bridge-config" style={{ padding: 16, color: 'var(--ctp-red)' }}>
+        {loadError}
+      </div>
+    );
+  }
+
+  const attached = !!form.brokerId;
+
+  return (
+    <div className="mqtt-bridge-config" style={{ maxWidth: 720, margin: '0 auto', padding: 16 }}>
+      <h2 style={{ marginTop: 0 }}>
+        {t('mqtt_bridge_config.title', 'MQTT Bridge Configuration')}
+      </h2>
+
+      {/* --- Connection --- */}
+      <CollapsibleSection title={t('mqtt_bridge_config.section_connection', 'Connection')}>
+        <label className="dashboard-form-field">
+          <span className="dashboard-form-label">
+            {t('source.form.mqtt_bridge_broker', 'Parent broker (optional)')}
+          </span>
+          <select
+            className="dashboard-form-input"
+            value={form.brokerId}
+            disabled={!canWrite}
+            onChange={(e) => patch('brokerId', e.target.value)}
+          >
+            <option value="">
+              {t('source.form.mqtt_bridge_broker_none', 'None — standalone client proxy')}
+            </option>
+            {brokers.map((b) => (
+              <option key={b.id} value={b.id}>
+                {b.name}
+              </option>
+            ))}
+          </select>
+          <span style={labelStyle}>
+            {t(
+              'source.form.mqtt_bridge_broker_help',
+              'With a parent broker, the bridge also republishes upstream traffic to local devices and forwards their packets upstream. Without one, it runs as a pure MQTT client — useful for monitoring or as a client-proxy target for a Meshtastic source.',
+            )}
+          </span>
+        </label>
+        <label className="dashboard-form-field">
+          <span className="dashboard-form-label">{t('source.form.mqtt_upstream_url', 'Upstream URL')}</span>
+          <input
+            className="dashboard-form-input"
+            type="text"
+            value={form.url}
+            disabled={!canWrite}
+            onChange={(e) => patch('url', e.target.value)}
+            placeholder="mqtt://mqtt.meshtastic.org:1883"
+          />
+        </label>
+        <label className="dashboard-form-field">
+          <span className="dashboard-form-label">{t('source.form.mqtt_username', 'Username')}</span>
+          <input
+            className="dashboard-form-input"
+            type="text"
+            value={form.username}
+            disabled={!canWrite}
+            onChange={(e) => patch('username', e.target.value)}
+          />
+        </label>
+        <label className="dashboard-form-field">
+          <span className="dashboard-form-label">{t('source.form.mqtt_password', 'Password')}</span>
+          <input
+            className="dashboard-form-input"
+            type="password"
+            value={form.password}
+            disabled={!canWrite}
+            onChange={(e) => patch('password', e.target.value)}
+            placeholder="••••••••"
+          />
+          <span style={labelStyle}>
+            {t('mqtt_bridge_config.password_help', 'Leave blank to keep the stored password.')}
+          </span>
+        </label>
+      </CollapsibleSection>
+
+      {/* --- Forwarding --- */}
+      <CollapsibleSection title={t('mqtt_bridge_config.section_forwarding', 'Forwarding')}>
+        <label className="dashboard-form-field">
+          <span className="dashboard-form-label">{t('source.form.mqtt_bridge_mode', 'Mode')}</span>
+          <select
+            className="dashboard-form-input"
+            value={form.mode}
+            disabled={!canWrite}
+            onChange={(e) => patch('mode', e.target.value as BridgeConfigForm['mode'])}
+          >
+            {BRIDGE_MODES.map((m) => (
+              <option key={m} value={m}>
+                {t(`source.form.mqtt_bridge_mode_${m}`, m)}
+              </option>
+            ))}
+          </select>
+          <span style={labelStyle}>
+            {t(
+              'source.form.mqtt_bridge_mode_help',
+              'Use "Publish only" for public servers (e.g. mqtt.meshtastic.org) that reject SUBSCRIBE — avoids permission-denied noise. "Subscribe only" disables uplink forwarding for read-only monitoring.',
+            )}
+          </span>
+        </label>
+        <label className="dashboard-form-field">
+          <span className="dashboard-form-label">
+            {t('source.form.mqtt_bridge_forwarding_mode', 'Upstream identity')}
+          </span>
+          <select
+            className="dashboard-form-input"
+            value={form.forwardingMode}
+            disabled={!canWrite}
+            onChange={(e) =>
+              patch('forwardingMode', e.target.value as BridgeConfigForm['forwardingMode'])
+            }
+          >
+            {BRIDGE_FORWARDING_MODES.map((m) => (
+              <option key={m} value={m}>
+                {t(`source.form.mqtt_bridge_forwarding_${m}`, m)}
+              </option>
+            ))}
+          </select>
+          <span style={labelStyle}>
+            {t(
+              'source.form.mqtt_bridge_forwarding_help',
+              'Per-gateway lets each local node publish upstream under its own !<hex> Client ID — required for community brokers that filter CONNECT on Client ID. Switch to Single only if the upstream broker has tight per-username connection caps.',
+            )}
+          </span>
+        </label>
+        <label className="dashboard-form-field" style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={form.ignoreOkToMqtt}
+            disabled={!canWrite}
+            onChange={(e) => patch('ignoreOkToMqtt', e.target.checked)}
+            style={{ marginTop: 3 }}
+          />
+          <span>
+            <span className="dashboard-form-label" style={{ display: 'block' }}>
+              {t('source.form.mqtt_bridge_ignore_ok_to_mqtt', 'Uplink all packets (ignore ok_to_mqtt bit)')}
+            </span>
+            <span style={{ fontSize: 11, color: 'var(--ctp-yellow)' }}>
+              {t(
+                'source.form.mqtt_bridge_ignore_ok_to_mqtt_help',
+                '⚠ Overrides the originating node\'s "ok_to_mqtt" preference. Only enable for private bridges where every gateway has consented.',
+              )}
+            </span>
+          </span>
+        </label>
+      </CollapsibleSection>
+
+      {/* --- Subscribe (downlink) --- */}
+      <CollapsibleSection title={t('mqtt_bridge_config.section_subscribe', 'Subscribe (incoming)')}>
+        <label className="dashboard-form-field">
+          <span className="dashboard-form-label">
+            {t('source.form.mqtt_subscriptions', 'Upstream topics (one per line)')}
+          </span>
+          <textarea
+            className="dashboard-form-input"
+            rows={3}
+            value={form.subscriptions}
+            disabled={!canWrite}
+            onChange={(e) => patch('subscriptions', e.target.value)}
+          />
+        </label>
+        <fieldset style={{ border: '1px solid var(--ctp-surface1)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
+          <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--ctp-subtext0)' }}>
+            <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={form.useTopicBlock}
+                disabled={!canWrite}
+                onChange={(e) => patch('useTopicBlock', e.target.checked)}
+              />
+              {t('source.form.mqtt_topic_block_enable', 'Block specific topics')}
+            </label>
+          </legend>
+          {form.useTopicBlock && (
+            <label className="dashboard-form-field" style={{ marginTop: 4 }}>
+              <span className="dashboard-form-label">
+                {t('source.form.mqtt_topic_block_label', 'Topics to drop (one per line, MQTT wildcards allowed)')}
+              </span>
+              <textarea
+                className="dashboard-form-input"
+                rows={3}
+                value={form.topicBlock}
+                disabled={!canWrite}
+                onChange={(e) => patch('topicBlock', e.target.value)}
+                placeholder="msh/CA/QC/#"
+              />
+            </label>
+          )}
+        </fieldset>
+        <fieldset style={{ border: '1px solid var(--ctp-surface1)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
+          <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--ctp-subtext0)' }}>
+            <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={form.useGeo}
+                disabled={!canWrite}
+                onChange={(e) => patch('useGeo', e.target.checked)}
+              />
+              {t('source.form.mqtt_geo_enable', 'Restrict to geographic bounding box')}
+            </label>
+          </legend>
+          {form.useGeo && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 4 }}>
+              <BBoxMapEditor
+                bbox={bboxFromForm(form.geo)}
+                onChange={(next) =>
+                  patch(
+                    'geo',
+                    next
+                      ? bboxToFormStrings(next)
+                      : { minLat: '', maxLat: '', minLng: '', maxLng: '' },
+                  )
+                }
+              />
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+                {GEO_KEYS.map((k) => (
+                  <label className="dashboard-form-field" key={k}>
+                    <span className="dashboard-form-label">{k}</span>
+                    <input
+                      className="dashboard-form-input"
+                      value={form.geo[k]}
+                      disabled={!canWrite}
+                      onChange={(e) => patch('geo', { ...form.geo, [k]: e.target.value })}
+                    />
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+        </fieldset>
+      </CollapsibleSection>
+
+      {/* --- Publish (uplink) filters — #3294. Channel multiselect is primary;
+              the raw topic filter is tucked into an Advanced subsection. --- */}
+      <CollapsibleSection title={t('mqtt_bridge_config.section_publish', 'Publish (outgoing)')}>
+        <span className="dashboard-form-label" style={{ display: 'block' }}>
+          {t('source.form.mqtt_uplink_channels_label', 'Uplink only these channels')}
+        </span>
+        <span style={{ ...labelStyle, display: 'block', marginBottom: 8 }}>
+          {t(
+            'source.form.mqtt_uplink_channels_help',
+            'Leave all unchecked to uplink every channel. Matched on the decoded channel name, regardless of MQTT topic format — the reliable way to uplink only specific channels (e.g. LongFast) while still receiving everything locally.',
+          )}
+        </span>
+        {channelOptions.length > 0 ? (
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))',
+              gap: 4,
+              maxHeight: 200,
+              overflowY: 'auto',
+              border: '1px solid var(--ctp-surface1)',
+              borderRadius: 6,
+              padding: '8px 12px',
+            }}
+          >
+            {channelOptions.map((name) => (
+              <label
+                key={name}
+                style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedChannels.includes(name)}
+                  disabled={!canWrite}
+                  onChange={(e) => toggleChannel(name, e.target.checked)}
+                />
+                {name}
+              </label>
+            ))}
+          </div>
+        ) : (
+          <span style={{ ...labelStyle, display: 'block' }}>
+            {t(
+              'source.form.mqtt_uplink_channels_empty',
+              'No channels known yet — they appear here as the bridge sees traffic. Add one manually below, or use the Advanced topic filter.',
+            )}
+          </span>
+        )}
+        <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+          <input
+            className="dashboard-form-input"
+            style={{ flex: 1 }}
+            type="text"
+            value={customChannel}
+            disabled={!canWrite}
+            placeholder={t('source.form.mqtt_uplink_channels_add', 'Add channel name…')}
+            onChange={(e) => setCustomChannel(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addCustomChannel();
+              }
+            }}
+          />
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={addCustomChannel}
+            disabled={!canWrite || !customChannel.trim()}
+          >
+            {t('common.add', 'Add')}
+          </button>
+        </div>
+
+        <div style={{ marginTop: 12 }}>
+          <CollapsibleSection
+            title={t('mqtt_bridge_config.section_publish_advanced', 'Advanced: topic filter')}
+            defaultExpanded={false}
+          >
+            <label className="dashboard-form-field">
+              <span className="dashboard-form-label">
+                {t('source.form.mqtt_uplink_topic_mode', 'Publish topic filter')}
+              </span>
+              <select
+                className="dashboard-form-input"
+                value={form.uplinkTopicMode ?? 'off'}
+                disabled={!canWrite}
+                onChange={(e) => patch('uplinkTopicMode', e.target.value as UplinkTopicMode)}
+              >
+                <option value="off">
+                  {t('source.form.mqtt_uplink_topic_mode_off', 'Off — publish all subscribed topics')}
+                </option>
+                <option value="allow">
+                  {t('source.form.mqtt_uplink_topic_mode_allow', 'Allow list — only publish matching topics')}
+                </option>
+                <option value="block">
+                  {t('source.form.mqtt_uplink_topic_mode_block', 'Block list — publish all except matching topics')}
+                </option>
+              </select>
+              <span style={labelStyle}>
+                {t(
+                  'source.form.mqtt_uplink_topic_help',
+                  'Raw topic-pattern filter on the outgoing publish topic (MQTT wildcards). Composes with the channel selection above — both must pass. Only needed for filtering by something other than channel.',
+                )}
+              </span>
+            </label>
+            {form.uplinkTopicMode && form.uplinkTopicMode !== 'off' && (
+              <label className="dashboard-form-field" style={{ marginTop: 4 }}>
+                <span className="dashboard-form-label">
+                  {t('source.form.mqtt_uplink_topics_label', 'Publish topics (one per line, MQTT wildcards allowed)')}
+                </span>
+                <textarea
+                  className="dashboard-form-input"
+                  rows={3}
+                  value={form.uplinkTopics ?? ''}
+                  disabled={!canWrite}
+                  onChange={(e) => patch('uplinkTopics', e.target.value)}
+                  placeholder="msh/US/FL/+/+/LongFast/#"
+                />
+              </label>
+            )}
+          </CollapsibleSection>
+        </div>
+      </CollapsibleSection>
+
+      {/* --- Topic rewrites (only meaningful with a parent broker) --- */}
+      {attached && (
+        <CollapsibleSection
+          title={t('mqtt_bridge_config.section_rewrites', 'Topic rewrites')}
+          defaultExpanded={false}
+        >
+          <span style={{ ...labelStyle, display: 'block', marginBottom: 8 }}>
+            {t(
+              'mqtt_bridge_config.rewrites_help',
+              'Literal prefix replacement applied to topics as they cross the bridge. Leave both fields blank to disable a rewrite. MQTT wildcards (+, #) are not allowed.',
+            )}
+          </span>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+            <label className="dashboard-form-field">
+              <span className="dashboard-form-label">
+                {t('mqtt_bridge_config.downlink_rewrite_from', 'Downlink from')}
+              </span>
+              <input
+                className="dashboard-form-input"
+                value={form.downlinkRewrite?.from ?? ''}
+                disabled={!canWrite}
+                onChange={(e) =>
+                  patch('downlinkRewrite', { from: e.target.value, to: form.downlinkRewrite?.to ?? '' })
+                }
+                placeholder="msh/US"
+              />
+            </label>
+            <label className="dashboard-form-field">
+              <span className="dashboard-form-label">
+                {t('mqtt_bridge_config.downlink_rewrite_to', 'Downlink to')}
+              </span>
+              <input
+                className="dashboard-form-input"
+                value={form.downlinkRewrite?.to ?? ''}
+                disabled={!canWrite}
+                onChange={(e) =>
+                  patch('downlinkRewrite', { from: form.downlinkRewrite?.from ?? '', to: e.target.value })
+                }
+                placeholder="msh/local"
+              />
+            </label>
+            <label className="dashboard-form-field">
+              <span className="dashboard-form-label">
+                {t('mqtt_bridge_config.uplink_rewrite_from', 'Uplink from')}
+              </span>
+              <input
+                className="dashboard-form-input"
+                value={form.uplinkRewrite?.from ?? ''}
+                disabled={!canWrite}
+                onChange={(e) =>
+                  patch('uplinkRewrite', { from: e.target.value, to: form.uplinkRewrite?.to ?? '' })
+                }
+                placeholder="msh/local"
+              />
+            </label>
+            <label className="dashboard-form-field">
+              <span className="dashboard-form-label">
+                {t('mqtt_bridge_config.uplink_rewrite_to', 'Uplink to')}
+              </span>
+              <input
+                className="dashboard-form-input"
+                value={form.uplinkRewrite?.to ?? ''}
+                disabled={!canWrite}
+                onChange={(e) =>
+                  patch('uplinkRewrite', { from: form.uplinkRewrite?.from ?? '', to: e.target.value })
+                }
+                placeholder="msh/US"
+              />
+            </label>
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* --- Save --- */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 16 }}>
+        <button
+          type="button"
+          className="btn-primary"
+          onClick={handleSave}
+          disabled={!canWrite || saving}
+        >
+          {saving ? t('common.saving', 'Saving…') : t('common.save', 'Save')}
+        </button>
+        {saved && <span style={{ color: 'var(--ctp-green)' }}>✓ {t('common.saved', 'Saved')}</span>}
+        {saveError && <span style={{ color: 'var(--ctp-red)' }}>{saveError}</span>}
+      </div>
+    </div>
+  );
+};
+
+export default MqttBridgeConfigurationView;

--- a/src/components/MQTT/mqttBridgeConfig.test.ts
+++ b/src/components/MQTT/mqttBridgeConfig.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildBridgeConfig,
+  formFromBridgeConfig,
+  emptyBridgeForm,
+  type BridgeConfigForm,
+} from './mqttBridgeConfig';
+
+describe('mqttBridgeConfig', () => {
+  describe('buildBridgeConfig', () => {
+    it('requires an upstream URL', () => {
+      const form = { ...emptyBridgeForm(), url: '' };
+      const { error, config } = buildBridgeConfig(form, { editing: false });
+      expect(config).toBeUndefined();
+      expect(error?.key).toBe('source.form.error_mqtt_url_required');
+    });
+
+    it('serializes a minimal standalone bridge with defaults omitted', () => {
+      const form = { ...emptyBridgeForm(), url: 'mqtt://broker:1883' };
+      const { config } = buildBridgeConfig(form, { editing: false });
+      expect(config).toEqual({
+        upstream: { url: 'mqtt://broker:1883', username: undefined, password: undefined },
+        subscriptions: ['msh/#'],
+      });
+      // Non-default keys must be absent.
+      expect(config).not.toHaveProperty('mode');
+      expect(config).not.toHaveProperty('forwardingMode');
+      expect(config).not.toHaveProperty('ignoreOkToMqtt');
+      expect(config).not.toHaveProperty('brokerSourceId');
+    });
+
+    it('serializes non-default mode/forwarding/ignore and splits subscriptions', () => {
+      const form: BridgeConfigForm = {
+        ...emptyBridgeForm(),
+        url: 'mqtt://broker:1883',
+        subscriptions: 'msh/US/#\n  msh/EU/#  \n\n',
+        mode: 'publish_only',
+        forwardingMode: 'single',
+        ignoreOkToMqtt: true,
+      };
+      const { config } = buildBridgeConfig(form, { editing: false });
+      expect(config?.subscriptions).toEqual(['msh/US/#', 'msh/EU/#']);
+      expect(config?.mode).toBe('publish_only');
+      expect(config?.forwardingMode).toBe('single');
+      expect(config?.ignoreOkToMqtt).toBe(true);
+    });
+
+    it('writes uplinkFilters.channels.allow for a channel multiselect (#3294)', () => {
+      const form: BridgeConfigForm = {
+        ...emptyBridgeForm(),
+        url: 'mqtt://broker:1883',
+        uplinkChannels: ['LongFast', 'Telemetry'],
+      };
+      const { config } = buildBridgeConfig(form, { editing: false });
+      expect(config?.uplinkFilters).toEqual({
+        channels: { allow: ['LongFast', 'Telemetry'] },
+      });
+    });
+
+    it('removes uplinkFilters.channels when no channels are selected', () => {
+      const base = { uplinkFilters: { channels: { allow: ['Old'] } } };
+      const form: BridgeConfigForm = {
+        ...emptyBridgeForm(),
+        url: 'mqtt://broker:1883',
+        uplinkChannels: [],
+      };
+      const { config } = buildBridgeConfig(form, { editing: true, base });
+      expect(config).not.toHaveProperty('uplinkFilters');
+    });
+
+    it('keeps channel allow-list and topic filter together in uplinkFilters', () => {
+      const form: BridgeConfigForm = {
+        ...emptyBridgeForm(),
+        url: 'mqtt://broker:1883',
+        uplinkChannels: ['LongFast'],
+        uplinkTopicMode: 'block',
+        uplinkTopics: 'msh/CA/#',
+      };
+      const { config } = buildBridgeConfig(form, { editing: false });
+      expect(config?.uplinkFilters).toEqual({
+        channels: { allow: ['LongFast'] },
+        topics: { block: ['msh/CA/#'] },
+      });
+    });
+
+    it('trims and drops blank channel names', () => {
+      const form: BridgeConfigForm = {
+        ...emptyBridgeForm(),
+        url: 'mqtt://broker:1883',
+        uplinkChannels: ['  LongFast  ', '', '   '],
+      };
+      const { config } = buildBridgeConfig(form, { editing: false });
+      expect(config?.uplinkFilters).toEqual({ channels: { allow: ['LongFast'] } });
+    });
+
+    it('writes uplinkFilters.topics.allow for a publish allow-list (#3294)', () => {
+      const form: BridgeConfigForm = {
+        ...emptyBridgeForm(),
+        url: 'mqtt://broker:1883',
+        uplinkTopicMode: 'allow',
+        uplinkTopics: 'msh/US/FL/+/+/LongFast/#',
+      };
+      const { config } = buildBridgeConfig(form, { editing: false });
+      expect(config?.uplinkFilters).toEqual({
+        topics: { allow: ['msh/US/FL/+/+/LongFast/#'] },
+      });
+    });
+
+    it('writes uplinkFilters.topics.block for a publish block-list and clears allow', () => {
+      const base = { uplinkFilters: { topics: { allow: ['old'] } } };
+      const form: BridgeConfigForm = {
+        ...emptyBridgeForm(),
+        url: 'mqtt://broker:1883',
+        uplinkTopicMode: 'block',
+        uplinkTopics: 'msh/CA/#',
+      };
+      const { config } = buildBridgeConfig(form, { editing: true, base });
+      expect(config?.uplinkFilters).toEqual({ topics: { block: ['msh/CA/#'] } });
+    });
+
+    it('removes uplinkFilters when the publish filter is turned off', () => {
+      const base = { uplinkFilters: { topics: { allow: ['x'] } } };
+      const form: BridgeConfigForm = {
+        ...emptyBridgeForm(),
+        url: 'mqtt://broker:1883',
+        uplinkTopicMode: 'off',
+        uplinkTopics: '',
+      };
+      const { config } = buildBridgeConfig(form, { editing: true, base });
+      expect(config).not.toHaveProperty('uplinkFilters');
+    });
+
+    it('preserves base.uplinkFilters when the caller does not manage uplink (modal)', () => {
+      const base = { uplinkFilters: { topics: { block: ['keep'] } } };
+      // Modal-style form: uplinkTopicMode omitted.
+      const form = { ...emptyBridgeForm(), url: 'mqtt://broker:1883' };
+      delete (form as Partial<BridgeConfigForm>).uplinkChannels;
+      delete (form as Partial<BridgeConfigForm>).uplinkTopicMode;
+      delete (form as Partial<BridgeConfigForm>).uplinkTopics;
+      const { config } = buildBridgeConfig(form, { editing: true, base });
+      expect(config?.uplinkFilters).toEqual({ topics: { block: ['keep'] } });
+    });
+
+    it('preserves unmanaged downlink subkeys while updating topics.block', () => {
+      const base = { downlinkFilters: { nodes: { block: ['!deadbeef'] } } };
+      const form: BridgeConfigForm = {
+        ...emptyBridgeForm(),
+        url: 'mqtt://broker:1883',
+        useTopicBlock: true,
+        topicBlock: 'msh/CA/QC/#',
+      };
+      const { config } = buildBridgeConfig(form, { editing: true, base });
+      expect(config?.downlinkFilters).toEqual({
+        nodes: { block: ['!deadbeef'] },
+        topics: { block: ['msh/CA/QC/#'] },
+      });
+    });
+
+    it('rejects non-numeric geo bounds', () => {
+      const form: BridgeConfigForm = {
+        ...emptyBridgeForm(),
+        url: 'mqtt://broker:1883',
+        useGeo: true,
+        geo: { minLat: 'abc', maxLat: '', minLng: '', maxLng: '' },
+      };
+      const { error } = buildBridgeConfig(form, { editing: false });
+      expect(error?.key).toBe('source.form.error_geo_invalid');
+    });
+
+    it('writes downlink geo bounds', () => {
+      const form: BridgeConfigForm = {
+        ...emptyBridgeForm(),
+        url: 'mqtt://broker:1883',
+        useGeo: true,
+        geo: { minLat: '25', maxLat: '31', minLng: '-87', maxLng: '-80' },
+      };
+      const { config } = buildBridgeConfig(form, { editing: false });
+      expect(config?.downlinkFilters?.geo).toEqual({
+        minLat: 25,
+        maxLat: 31,
+        minLng: -87,
+        maxLng: -80,
+      });
+    });
+
+    it('omits the password on edit so the server preserves the stored one', () => {
+      const form: BridgeConfigForm = {
+        ...emptyBridgeForm(),
+        url: 'mqtt://broker:1883',
+        username: 'me',
+        password: '',
+      };
+      const { config } = buildBridgeConfig(form, {
+        editing: true,
+        base: { upstream: { url: 'mqtt://broker:1883', username: 'me', password: 'secret' } },
+      });
+      expect(config?.upstream.password).toBeUndefined();
+      // Round-trips through JSON without leaking the stored password.
+      expect(JSON.parse(JSON.stringify(config)).upstream).not.toHaveProperty('password');
+    });
+
+    it('emits topic rewrites only when attached to a parent broker', () => {
+      const attached: BridgeConfigForm = {
+        ...emptyBridgeForm(),
+        url: 'mqtt://broker:1883',
+        brokerId: 'broker-1',
+        downlinkRewrite: { from: 'msh/US', to: 'msh/local' },
+        uplinkRewrite: { from: '', to: '' },
+      };
+      const a = buildBridgeConfig(attached, { editing: false });
+      expect(a.config?.downlinkTopicRewrite).toEqual({ from: 'msh/US', to: 'msh/local' });
+      expect(a.config).not.toHaveProperty('uplinkTopicRewrite');
+
+      const standalone: BridgeConfigForm = {
+        ...attached,
+        brokerId: '',
+      };
+      const s = buildBridgeConfig(standalone, { editing: false });
+      expect(s.config).not.toHaveProperty('downlinkTopicRewrite');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('formFromBridgeConfig(buildBridgeConfig(form)) preserves all managed fields', () => {
+      const form: BridgeConfigForm = {
+        brokerId: 'broker-1',
+        url: 'mqtt://broker:1883',
+        username: 'user',
+        password: '', // not persisted in config output
+        subscriptions: 'msh/US/#\nmsh/EU/#',
+        mode: 'subscribe_only',
+        forwardingMode: 'single',
+        ignoreOkToMqtt: true,
+        useTopicBlock: true,
+        topicBlock: 'msh/CA/#',
+        useGeo: true,
+        geo: { minLat: '25', maxLat: '31', minLng: '-87', maxLng: '-80' },
+        uplinkChannels: ['LongFast', 'Telemetry'],
+        uplinkTopicMode: 'allow',
+        uplinkTopics: 'msh/US/FL/+/+/LongFast/#',
+        downlinkRewrite: { from: 'msh/US', to: 'msh/local' },
+        uplinkRewrite: { from: 'msh/local', to: 'msh/US' },
+      };
+      const { config } = buildBridgeConfig(form, { editing: false });
+      const round = formFromBridgeConfig(config);
+      expect(round).toEqual({ ...form, password: '' });
+    });
+  });
+});

--- a/src/components/MQTT/mqttBridgeConfig.ts
+++ b/src/components/MQTT/mqttBridgeConfig.ts
@@ -1,0 +1,324 @@
+/**
+ * Shared (de)serialization for mqtt_bridge source `config` blobs.
+ *
+ * Used by BOTH the source create/edit modal (`DashboardPage.tsx`) and the
+ * dedicated bridge Configuration page (`MqttBridgeConfigurationView.tsx`) so
+ * the two editors can never drift on how a bridge config is shaped.
+ *
+ * `buildBridgeConfig` merges over a `base` config (the existing source blob on
+ * edit) so an editor that doesn't render every field — e.g. the modal, which
+ * has no publish-filter or topic-rewrite inputs — leaves those keys intact
+ * instead of clobbering them. Fields are only authoritatively managed when the
+ * caller supplies the corresponding form value:
+ *  - `uplinkTopicMode` undefined  → preserve `base.uplinkFilters`
+ *  - `downlinkRewrite`/`uplinkRewrite` undefined → preserve the rewrite keys
+ *
+ * Passwords are never echoed back: upstream is rebuilt from the form, and an
+ * empty password serializes to `undefined` (dropped by JSON) so the server's
+ * `preserveSourceCredentials` round-trips the stored value.
+ */
+
+export type BridgeMode = 'bidirectional' | 'publish_only' | 'subscribe_only';
+export type BridgeForwardingMode = 'per_gateway' | 'single';
+
+/** Off = no publish topic filter; block/allow map to uplinkFilters.topics.{block,allow}. */
+export type UplinkTopicMode = 'off' | 'block' | 'allow';
+
+export const BRIDGE_MODES: readonly BridgeMode[] = [
+  'bidirectional',
+  'publish_only',
+  'subscribe_only',
+];
+export const BRIDGE_FORWARDING_MODES: readonly BridgeForwardingMode[] = [
+  'per_gateway',
+  'single',
+];
+
+export interface BridgeGeoStrings {
+  minLat: string;
+  maxLat: string;
+  minLng: string;
+  maxLng: string;
+}
+
+export interface BridgeRewriteStrings {
+  from: string;
+  to: string;
+}
+
+export interface BridgeConfigForm {
+  brokerId: string;
+  url: string;
+  username: string;
+  /** '' on edit means "keep the stored password" (server-side merge). */
+  password: string;
+  /** Upstream topics, one per line. */
+  subscriptions: string;
+  mode: BridgeMode;
+  forwardingMode: BridgeForwardingMode;
+  ignoreOkToMqtt: boolean;
+  // Subscribe-side (downlink) filtering.
+  useTopicBlock: boolean;
+  topicBlock: string;
+  useGeo: boolean;
+  geo: BridgeGeoStrings;
+  // --- Page-only fields. When omitted, `buildBridgeConfig` preserves `base`. ---
+  /**
+   * Publish-side (uplink) channel allow-list — #3294. Channel *names* (e.g.
+   * "LongFast") matched against the decoded ServiceEnvelope channelId. Empty
+   * = uplink every channel. This is the primary, reliable publish filter;
+   * the topic filter below is the advanced/raw escape hatch.
+   */
+  uplinkChannels?: string[];
+  /** Publish-side (uplink) raw topic filter — advanced. */
+  uplinkTopicMode?: UplinkTopicMode;
+  uplinkTopics?: string;
+  downlinkRewrite?: BridgeRewriteStrings;
+  uplinkRewrite?: BridgeRewriteStrings;
+}
+
+export interface BridgeConfigError {
+  key: string;
+  fallback: string;
+}
+
+export interface BuildBridgeOptions {
+  editing: boolean;
+  /** Existing source config to merge over (preserves unmanaged keys). */
+  base?: Record<string, any> | null;
+}
+
+const GEO_KEYS = ['minLat', 'maxLat', 'minLng', 'maxLng'] as const;
+
+function splitLines(value: string): string[] {
+  return value
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function parseGeo(
+  useGeo: boolean,
+  geo: BridgeGeoStrings,
+): { geo?: Record<string, number>; error?: BridgeConfigError } {
+  if (!useGeo) return {};
+  const out: Record<string, number> = {};
+  for (const k of GEO_KEYS) {
+    const v = geo[k];
+    if (v) {
+      const n = Number(v);
+      if (Number.isNaN(n)) {
+        return {
+          error: { key: 'source.form.error_geo_invalid', fallback: 'Geo bounds must be numbers' },
+        };
+      }
+      out[k] = n;
+    }
+  }
+  return { geo: Object.keys(out).length > 0 ? out : undefined };
+}
+
+/** Drop the `block`/`allow` arrays from a topics object, keeping any other keys. */
+function clearTopicLists(topics: Record<string, any> | undefined): Record<string, any> {
+  const { block, allow, ...rest } = topics ?? {};
+  void block;
+  void allow;
+  return rest;
+}
+
+function applyRewrite(
+  cfg: Record<string, any>,
+  key: 'downlinkTopicRewrite' | 'uplinkTopicRewrite',
+  rule: BridgeRewriteStrings | undefined,
+): void {
+  if (rule === undefined) return; // unmanaged by this caller — preserve base.
+  const from = rule.from.trim();
+  const to = rule.to.trim();
+  if (from && to) {
+    cfg[key] = { from, to };
+  } else {
+    delete cfg[key];
+  }
+}
+
+/**
+ * Serialize a bridge form into the `config` blob posted to /api/sources.
+ * Returns `{ config }` on success or `{ error }` with a translatable key.
+ */
+export function buildBridgeConfig(
+  form: BridgeConfigForm,
+  opts: BuildBridgeOptions,
+): { config?: Record<string, any>; error?: BridgeConfigError } {
+  if (!form.url.trim()) {
+    return {
+      error: { key: 'source.form.error_mqtt_url_required', fallback: 'Upstream URL is required' },
+    };
+  }
+
+  const cfg: Record<string, any> = { ...(opts.base ?? {}) };
+
+  // Parent broker — omit entirely when standalone (issue #3134).
+  if (form.brokerId) cfg.brokerSourceId = form.brokerId;
+  else delete cfg.brokerSourceId;
+
+  // Upstream is rebuilt fresh (never spread from base — avoids leaking the
+  // stored password back through). Empty password => undefined => server keeps.
+  cfg.upstream = {
+    url: form.url.trim(),
+    username: form.username.trim() || undefined,
+    password: form.password || undefined,
+  };
+
+  const subs = splitLines(form.subscriptions);
+  cfg.subscriptions = subs.length > 0 ? subs : ['msh/#'];
+
+  // Omit defaults so existing rows stay clean / adopt new defaults on upgrade.
+  if (form.mode !== 'bidirectional') cfg.mode = form.mode;
+  else delete cfg.mode;
+  if (form.forwardingMode !== 'per_gateway') cfg.forwardingMode = form.forwardingMode;
+  else delete cfg.forwardingMode;
+  if (form.ignoreOkToMqtt) cfg.ignoreOkToMqtt = true;
+  else delete cfg.ignoreOkToMqtt;
+
+  // --- Subscribe-side (downlink) filters: manage topics.block + geo,
+  // preserve any other downlink subkeys (channels/nodes/portnums). ---
+  const downlink: Record<string, any> = { ...(opts.base?.downlinkFilters ?? {}) };
+  const topicBlock = form.useTopicBlock ? splitLines(form.topicBlock) : [];
+  if (topicBlock.length > 0) {
+    downlink.topics = { ...clearTopicLists(downlink.topics), block: topicBlock };
+  } else {
+    const rest = clearTopicLists(downlink.topics);
+    if (Object.keys(rest).length > 0) downlink.topics = rest;
+    else delete downlink.topics;
+  }
+  const downGeo = parseGeo(form.useGeo, form.geo);
+  if (downGeo.error) return { error: downGeo.error };
+  if (downGeo.geo) downlink.geo = downGeo.geo;
+  else delete downlink.geo;
+  if (Object.keys(downlink).length > 0) cfg.downlinkFilters = downlink;
+  else delete cfg.downlinkFilters;
+
+  // --- Publish-side (uplink) filters (#3294): channel allow-list (primary)
+  // and raw topic filter (advanced). Each sub-field is only managed when the
+  // caller supplies it; otherwise the corresponding part of base.uplinkFilters
+  // is preserved. The modal supplies neither, so it never touches them. ---
+  if (form.uplinkChannels !== undefined || form.uplinkTopicMode !== undefined) {
+    const uplink: Record<string, any> = { ...(opts.base?.uplinkFilters ?? {}) };
+
+    if (form.uplinkChannels !== undefined) {
+      const channels: Record<string, any> = { ...(uplink.channels ?? {}) };
+      delete channels.allow;
+      const names = form.uplinkChannels.map((c) => c.trim()).filter(Boolean);
+      if (names.length > 0) channels.allow = names;
+      if (Object.keys(channels).length > 0) uplink.channels = channels;
+      else delete uplink.channels;
+    }
+
+    if (form.uplinkTopicMode !== undefined) {
+      const topics = clearTopicLists(uplink.topics);
+      const list = form.uplinkTopicMode !== 'off' ? splitLines(form.uplinkTopics ?? '') : [];
+      if (form.uplinkTopicMode === 'block' && list.length > 0) topics.block = list;
+      else if (form.uplinkTopicMode === 'allow' && list.length > 0) topics.allow = list;
+      if (Object.keys(topics).length > 0) uplink.topics = topics;
+      else delete uplink.topics;
+    }
+
+    if (Object.keys(uplink).length > 0) cfg.uplinkFilters = uplink;
+    else delete cfg.uplinkFilters;
+  }
+
+  // --- Topic rewrites (#3166). Server rejects them on standalone bridges,
+  // so clear when there's no parent broker. ---
+  if (!cfg.brokerSourceId) {
+    if (form.downlinkRewrite !== undefined) delete cfg.downlinkTopicRewrite;
+    if (form.uplinkRewrite !== undefined) delete cfg.uplinkTopicRewrite;
+  } else {
+    applyRewrite(cfg, 'downlinkTopicRewrite', form.downlinkRewrite);
+    applyRewrite(cfg, 'uplinkTopicRewrite', form.uplinkRewrite);
+  }
+
+  return { config: cfg };
+}
+
+/** Hydrate a full bridge form (including page-only fields) from a config blob. */
+export function formFromBridgeConfig(config: Record<string, any> | null | undefined): BridgeConfigForm {
+  const cfg = config ?? {};
+
+  const downTopicBlock: string[] = cfg.downlinkFilters?.topics?.block ?? [];
+  const downGeo = cfg.downlinkFilters?.geo ?? {};
+  const hasGeo = GEO_KEYS.some((k) => downGeo[k] != null);
+
+  const upChannels: string[] = Array.isArray(cfg.uplinkFilters?.channels?.allow)
+    ? cfg.uplinkFilters.channels.allow
+    : [];
+
+  const upTopics = cfg.uplinkFilters?.topics ?? {};
+  let uplinkTopicMode: UplinkTopicMode = 'off';
+  let uplinkTopics = '';
+  if (Array.isArray(upTopics.allow) && upTopics.allow.length > 0) {
+    uplinkTopicMode = 'allow';
+    uplinkTopics = upTopics.allow.join('\n');
+  } else if (Array.isArray(upTopics.block) && upTopics.block.length > 0) {
+    uplinkTopicMode = 'block';
+    uplinkTopics = upTopics.block.join('\n');
+  }
+
+  const savedMode = cfg.mode;
+  const savedForwarding = cfg.forwardingMode;
+
+  return {
+    brokerId: cfg.brokerSourceId ?? '',
+    url: cfg.upstream?.url ?? '',
+    username: cfg.upstream?.username ?? '',
+    password: '',
+    subscriptions: (cfg.subscriptions ?? []).join('\n'),
+    mode:
+      savedMode === 'publish_only' || savedMode === 'subscribe_only'
+        ? savedMode
+        : 'bidirectional',
+    forwardingMode: savedForwarding === 'single' ? 'single' : 'per_gateway',
+    ignoreOkToMqtt: cfg.ignoreOkToMqtt === true,
+    useTopicBlock: downTopicBlock.length > 0,
+    topicBlock: downTopicBlock.join('\n'),
+    useGeo: hasGeo,
+    geo: {
+      minLat: downGeo.minLat != null ? String(downGeo.minLat) : '',
+      maxLat: downGeo.maxLat != null ? String(downGeo.maxLat) : '',
+      minLng: downGeo.minLng != null ? String(downGeo.minLng) : '',
+      maxLng: downGeo.maxLng != null ? String(downGeo.maxLng) : '',
+    },
+    uplinkChannels: upChannels,
+    uplinkTopicMode,
+    uplinkTopics,
+    downlinkRewrite: {
+      from: cfg.downlinkTopicRewrite?.from ?? '',
+      to: cfg.downlinkTopicRewrite?.to ?? '',
+    },
+    uplinkRewrite: {
+      from: cfg.uplinkTopicRewrite?.from ?? '',
+      to: cfg.uplinkTopicRewrite?.to ?? '',
+    },
+  };
+}
+
+export function emptyBridgeForm(): BridgeConfigForm {
+  return {
+    brokerId: '',
+    url: '',
+    username: '',
+    password: '',
+    subscriptions: 'msh/#',
+    mode: 'bidirectional',
+    forwardingMode: 'per_gateway',
+    ignoreOkToMqtt: false,
+    useTopicBlock: false,
+    topicBlock: '',
+    useGeo: false,
+    geo: { minLat: '', maxLat: '', minLng: '', maxLng: '' },
+    uplinkChannels: [],
+    uplinkTopicMode: 'off',
+    uplinkTopics: '',
+    downlinkRewrite: { from: '', to: '' },
+    uplinkRewrite: { from: '', to: '' },
+  };
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -274,6 +274,11 @@ const Sidebar: React.FC<SidebarProps> = ({
           {!mqttReadOnly && hasPermission('configuration', 'read') && (
             <NavItem id="configuration" label={t('nav.device')} icon={icon('configuration')} />
           )}
+          {/* MQTT Bridge sources have no device-config surface; surface a
+              dedicated bridge Configuration page instead. */}
+          {mqttReadOnly && hasPermission('sources', 'read') && (
+            <NavItem id="mqtt-config" label={t('nav.mqtt_bridge_config', 'Configuration')} icon={icon('configuration')} />
+          )}
           {isAuthenticated && (
             <NavItem id="notifications" label={t('nav.notifications')} icon={icon('notifications')} />
           )}

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -51,7 +51,7 @@ interface UIProviderProps {
 }
 
 // Valid tab types for hash validation
-const VALID_TABS: TabType[] = ['nodes', 'channels', 'messages', 'info', 'settings', 'automation', 'dashboard', 'configuration', 'notifications', 'users', 'audit', 'security', 'themes', 'admin', 'packetmonitor'];
+const VALID_TABS: TabType[] = ['nodes', 'channels', 'messages', 'info', 'settings', 'automation', 'dashboard', 'configuration', 'notifications', 'users', 'audit', 'security', 'themes', 'admin', 'packetmonitor', 'mqtt-config'];
 
 // Helper to get tab from URL hash
 const getTabFromHash = (): TabType => {

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -27,6 +27,7 @@ import type { DashboardSource } from '../hooks/useDashboardData';
 import DashboardSidebar from '../components/Dashboard/DashboardSidebar';
 import DashboardMap from '../components/Dashboard/DashboardMap';
 import BBoxMapEditor, { type BBoxValue } from '../components/BBoxMapEditor';
+import { buildBridgeConfig, formFromBridgeConfig } from '../components/MQTT/mqttBridgeConfig';
 import { bboxToFormStrings, boundsFromDetectedNodes } from './DashboardPage.bboxSeed';
 import LoginModal from '../components/LoginModal';
 import UserMenu from '../components/UserMenu';
@@ -405,36 +406,23 @@ function DashboardInner() {
       return;
     }
     if (source.type === 'mqtt_bridge') {
+      // Hydrate via the shared serializer so the modal and the dedicated
+      // bridge Configuration page never drift on config shape.
+      const bf = formFromBridgeConfig(cfg);
       setFormType('mqtt_bridge');
       setFormName(source.name);
-      setFormMqttBridgeBrokerId(cfg?.brokerSourceId ?? '');
-      setFormMqttBridgeUrl(cfg?.upstream?.url ?? '');
-      setFormMqttBridgeUsername(cfg?.upstream?.username ?? '');
+      setFormMqttBridgeBrokerId(bf.brokerId);
+      setFormMqttBridgeUrl(bf.url);
+      setFormMqttBridgeUsername(bf.username);
       setFormMqttBridgePassword('');
-      setFormMqttBridgeSubscriptions((cfg?.subscriptions ?? []).join('\n'));
-      const savedMode = cfg?.mode;
-      setFormMqttBridgeMode(
-        savedMode === 'publish_only' || savedMode === 'subscribe_only'
-          ? savedMode
-          : 'bidirectional',
-      );
-      const savedForwarding = cfg?.forwardingMode;
-      setFormMqttBridgeForwardingMode(savedForwarding === 'single' ? 'single' : 'per_gateway');
-      setFormMqttBridgeIgnoreOkToMqtt(cfg?.ignoreOkToMqtt === true);
-      const topicBlock: string[] = cfg?.downlinkFilters?.topics?.block ?? [];
-      setFormMqttBridgeUseTopicBlock(topicBlock.length > 0);
-      setFormMqttBridgeTopicBlock(topicBlock.join('\n'));
-      const geo = cfg?.downlinkFilters?.geo ?? {};
-      const hasGeo = ['minLat', 'maxLat', 'minLng', 'maxLng'].some(
-        (k) => geo[k] != null,
-      );
-      setFormMqttBridgeUseGeo(hasGeo);
-      setFormMqttBridgeGeo({
-        minLat: geo.minLat != null ? String(geo.minLat) : '',
-        maxLat: geo.maxLat != null ? String(geo.maxLat) : '',
-        minLng: geo.minLng != null ? String(geo.minLng) : '',
-        maxLng: geo.maxLng != null ? String(geo.maxLng) : '',
-      });
+      setFormMqttBridgeSubscriptions(bf.subscriptions);
+      setFormMqttBridgeMode(bf.mode);
+      setFormMqttBridgeForwardingMode(bf.forwardingMode);
+      setFormMqttBridgeIgnoreOkToMqtt(bf.ignoreOkToMqtt);
+      setFormMqttBridgeUseTopicBlock(bf.useTopicBlock);
+      setFormMqttBridgeTopicBlock(bf.topicBlock);
+      setFormMqttBridgeUseGeo(bf.useGeo);
+      setFormMqttBridgeGeo(bf.geo);
       setFormError('');
       setShowSourceModal(true);
       return;
@@ -510,65 +498,36 @@ function DashboardInner() {
         delete (cfg.auth as { password?: string }).password;
       }
     } else if (formType === 'mqtt_bridge') {
-      // Parent broker is optional — empty selection means standalone
-      // client-proxy bridge (issue #3134). No validation needed; the
-      // backend treats an unset/empty `brokerSourceId` as standalone.
-      if (!formMqttBridgeUrl.trim()) {
-        setFormError(t('source.form.error_mqtt_url_required', 'Upstream URL is required'));
+      // Serialize via the shared helper. The modal manages connection /
+      // forwarding / subscribe-side fields; publish (uplink) filters and topic
+      // rewrites are edited on the dedicated Configuration page, so we pass the
+      // existing config as `base` to preserve them instead of clobbering.
+      const base = editingSourceId
+        ? (sources.find((s) => s.id === editingSourceId)?.config as Record<string, any> | undefined)
+        : undefined;
+      const result = buildBridgeConfig(
+        {
+          brokerId: formMqttBridgeBrokerId,
+          url: formMqttBridgeUrl,
+          username: formMqttBridgeUsername,
+          password: formMqttBridgePassword,
+          subscriptions: formMqttBridgeSubscriptions,
+          mode: formMqttBridgeMode,
+          forwardingMode: formMqttBridgeForwardingMode,
+          ignoreOkToMqtt: formMqttBridgeIgnoreOkToMqtt,
+          useTopicBlock: formMqttBridgeUseTopicBlock,
+          topicBlock: formMqttBridgeTopicBlock,
+          useGeo: formMqttBridgeUseGeo,
+          geo: formMqttBridgeGeo,
+          // uplink filters / rewrites intentionally omitted — preserved via base.
+        },
+        { editing: !!editingSourceId, base },
+      );
+      if (result.error) {
+        setFormError(t(result.error.key, result.error.fallback));
         return;
       }
-      const subscriptions = formMqttBridgeSubscriptions
-        .split('\n')
-        .map((s) => s.trim())
-        .filter(Boolean);
-      const topicBlock = formMqttBridgeUseTopicBlock
-        ? formMqttBridgeTopicBlock
-            .split('\n')
-            .map((s) => s.trim())
-            .filter(Boolean)
-        : [];
-      const geo: Record<string, number> = {};
-      if (formMqttBridgeUseGeo) {
-        for (const k of ['minLat', 'maxLat', 'minLng', 'maxLng'] as const) {
-          const v = formMqttBridgeGeo[k];
-          if (v) {
-            const n = Number(v);
-            if (Number.isNaN(n)) {
-              setFormError(t('source.form.error_geo_invalid', 'Geo bounds must be numbers'));
-              return;
-            }
-            geo[k] = n;
-          }
-        }
-      }
-      const downlinkFilters: Record<string, unknown> = {};
-      if (topicBlock.length > 0) downlinkFilters.topics = { block: topicBlock };
-      if (Object.keys(geo).length > 0) downlinkFilters.geo = geo;
-      cfg = {
-        // Omit `brokerSourceId` entirely when standalone — the backend
-        // treats an absent field as "no parent" (issue #3134).
-        ...(formMqttBridgeBrokerId ? { brokerSourceId: formMqttBridgeBrokerId } : {}),
-        upstream: {
-          url: formMqttBridgeUrl.trim(),
-          username: formMqttBridgeUsername.trim() || undefined,
-          password: formMqttBridgePassword || undefined,
-        },
-        subscriptions: subscriptions.length > 0 ? subscriptions : ['msh/#'],
-        // Omit when bidirectional (the default) so existing rows stay clean.
-        ...(formMqttBridgeMode !== 'bidirectional' ? { mode: formMqttBridgeMode } : {}),
-        // Omit when per_gateway (the default) so existing rows on upgrade
-        // adopt the new behavior without an explicit config change.
-        ...(formMqttBridgeForwardingMode !== 'per_gateway'
-          ? { forwardingMode: formMqttBridgeForwardingMode }
-          : {}),
-        // Operator override — only serialize when set. Defaults to honoring
-        // the originator's ok_to_mqtt preference.
-        ...(formMqttBridgeIgnoreOkToMqtt ? { ignoreOkToMqtt: true } : {}),
-        ...(Object.keys(downlinkFilters).length > 0 ? { downlinkFilters } : {}),
-      };
-      if (editingSourceId && !formMqttBridgePassword) {
-        delete (cfg.upstream as { password?: string }).password;
-      }
+      cfg = result.config!;
     } else if (formType === 'meshcore') {
       // MeshCore source: USB/serial or TCP. Both transports flow through the
       // same MeshCoreManager via the Python bridge — only the connect params

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -13,7 +13,8 @@ export type TabType =
   | 'security'
   | 'themes'
   | 'admin'
-  | 'packetmonitor';
+  | 'packetmonitor'
+  | 'mqtt-config';
 
 export type SortField = 'longName' | 'shortName' | 'id' | 'lastHeard' | 'snr' | 'battery' | 'hwModel' | 'hops';
 


### PR DESCRIPTION
## Summary

Adds a dedicated **Configuration** tab for `mqtt_bridge` sources, centralizing the growing set of bridge options into a roomy, sectioned page (Connection / Forwarding / Subscribe / Publish / Topic rewrites) — like the MeshCore and Meshtastic device-config surfaces — instead of the cramped shared dashboard modal.

Implements **#3294** (per-bridge publish topic filtering) in the new **Publish** section.

Closes #3294.

## Key finding: no backend change needed

`MqttBridgeManager` already constructed `this.uplinkFilter = new MqttPacketFilter(config.uplinkFilters)` and applied it on the publish path (`if (!this.uplinkFilter.preFilter(p.topic, p.envelope)) return;`). `POST/PUT /api/sources` persist `config` wholesale. The filtering for both topics **and** channels was already implemented in `MqttPacketFilter` — there was simply no UI to set it. So #3294 is a UI feature.

## Publish filtering (two ways)

- **Primary — channel multiselect** (`uplinkFilters.channels.allow`): matched on the **decoded `ServiceEnvelope.channelId`**, so an operator can uplink only specific channels (e.g. `LongFast`) while still receiving everything locally — reliable regardless of the messy `msh/US/FL/2/e/LongFast/!abc` topic format. Channel names are sourced from the global channel-database (auto-populated from observed traffic) + the per-source channels API, with free-form add for anything not listed.
- **Advanced — raw topic filter** (`uplinkFilters.topics`): allow/block topic patterns for non-channel cases. Composes with the channel selection (both must pass), tucked into a collapsed "Advanced" subsection.

## Shared serializer

Config (de)serialization is extracted into `src/components/MQTT/mqttBridgeConfig.ts`, used by **both** the new page and the existing create/edit modal, so the two editors can't drift. `buildBridgeConfig` merges over a `base` config, which also **fixes a latent bug**: editing a bridge in the modal could previously clobber fields it doesn't render (topic rewrites, uplink filters).

## Files

| File | Change |
|------|--------|
| `src/components/MQTT/mqttBridgeConfig.ts` | **New** — shared `buildBridgeConfig` / `formFromBridgeConfig`. |
| `src/components/MQTT/MqttBridgeConfigurationView.tsx` | **New** — sectioned config page + channel multiselect. |
| `src/components/MQTT/mqttBridgeConfig.test.ts` | **New** — 17 serializer/round-trip tests. |
| `src/pages/DashboardPage.tsx` | Modal now uses the shared serializer. |
| `src/App.tsx`, `src/components/Sidebar.tsx`, `src/types/ui.ts`, `src/contexts/UIContext.tsx` | Wire the `mqtt-config` tab (permission, render, nav, `TabType`, **`VALID_TABS`**). |
| `public/locales/en.json` | `nav.mqtt_bridge_config` (other strings use inline fallbacks, matching the existing MQTT-form convention). |

## Testing

- `tsc` clean; lint introduces no new errors.
- **Full Vitest suite: 5879 passed, 0 failures** (17 new serializer tests).
- **Manual, dev container, end-to-end:**
  - New Configuration tab appears for bridge sources and renders all sections.
  - Loads existing `uplinkFilters` / rewrites from a real bridge.
  - Channel multiselect populated 18 real channels from a connected bridge; checking channels + free-form add saved `uplinkFilters.channels.allow: ["LongFast","FloridaMesh","MyCustomChannel"]`, confirmed via API.
  - Allow→block topic switch correctly clears the other list; fields the page doesn't manage are preserved (no clobber).

## Notes / follow-ups

- The channel picker lists names from the **global** channel-database (the per-source `channels` table is empty for bridges until they ingest live traffic). Most reliable option given the data available; free-form add covers gaps. MeshMonitor does not record observed MQTT *topics* anywhere, so a "pick from seen topics" list would require new logging infra — intentionally not attempted.
- Channel multiselect is currently Publish-only; could be extended to the Subscribe (downlink) side later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)