### PR TITLE
fix(meshcore): allow adding new hashtag channels (fixes #3297)

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3011,9 +3011,14 @@ apiRouter.put('/channels/:id', requireAuth(), async (req, res) => {
       return res.status(400).json({ error: 'Invalid position precision. Must be between 0-32' });
     }
 
-    // Get existing channel
-    const existingChannel = await databaseService.channels.getChannelById(channelId);
-    if (!existingChannel) {
+    // MeshCore channels are created on-device (setChannel + syncChannelsFromDevice),
+    // so there is no pre-existing DB row when adding a new slot. Skip the
+    // existence check for MeshCore; enforce 404 only for Meshtastic, which
+    // always pre-creates 8 slots.
+    const existingChannel = sourceType !== 'meshcore'
+      ? await databaseService.channels.getChannelById(channelId)
+      : null;
+    if (sourceType !== 'meshcore' && !existingChannel) {
       return res.status(404).json({ error: 'Channel not found' });
     }
 
@@ -3023,15 +3028,15 @@ apiRouter.put('/channels/:id', requireAuth(), async (req, res) => {
     // Prepare the updated channel data
     const updatedChannelData = {
       id: channelId,
-      name: name !== undefined && name !== null ? name : existingChannel.name,
-      psk: psk !== undefined && psk !== null ? psk : existingChannel.psk,
-      role: role !== undefined && role !== null ? role : existingChannel.role,
-      uplinkEnabled: uplinkEnabled !== undefined ? uplinkEnabled : existingChannel.uplinkEnabled,
-      downlinkEnabled: downlinkEnabled !== undefined ? downlinkEnabled : existingChannel.downlinkEnabled,
+      name: name !== undefined && name !== null ? name : (existingChannel?.name ?? ''),
+      psk: psk !== undefined && psk !== null ? psk : (existingChannel?.psk ?? null),
+      role: role !== undefined && role !== null ? role : (existingChannel?.role ?? null),
+      uplinkEnabled: uplinkEnabled !== undefined ? uplinkEnabled : (existingChannel?.uplinkEnabled ?? null),
+      downlinkEnabled: downlinkEnabled !== undefined ? downlinkEnabled : (existingChannel?.downlinkEnabled ?? null),
       positionPrecision:
         positionPrecision !== undefined && positionPrecision !== null
           ? positionPrecision
-          : existingChannel.positionPrecision,
+          : (existingChannel?.positionPrecision ?? null),
     };
 
     if (sourceType === 'meshcore') {


### PR DESCRIPTION
## Summary

- Fixes `PUT /api/channels/:id` returning `404 Channel not found` when adding a new MeshCore channel (including `#hashtag` channels)
- The existing guard was designed for Meshtastic, which pre-creates 8 channel slots in the DB; MeshCore channels are created on-device first and synced back, so no pre-existing row exists for new slots
- For MeshCore sources, the 404 guard is now skipped entirely — `setChannel()` + `syncChannelsFromDevice()` handles both creation and update

## Root Cause

`server.ts:3015` called `getChannelById(channelId)` **without** a `sourceId` and returned 404 if the row was missing. For new MeshCore channel additions, the slot doesn't exist in the DB until after `mcManager.setChannel()` + `syncChannelsFromDevice()` run. The Meshtastic 404 guard was blocking the MeshCore write path entirely.

## Changes

**`src/server/server.ts`** — one targeted change in `PUT /api/channels/:id`:
- Skip `getChannelById` for MeshCore (set `existingChannel = null`); keep the 404 guard for Meshtastic only
- Use optional chaining (`existingChannel?.name ?? ''`) in the `updatedChannelData` fallbacks so the Meshtastic path is unaffected

## Test plan

- [x] All existing tests pass (104/104 across server + MeshCore components + utils)
- [x] Frontend tests for saving a `#test` channel with derived PSK continue to pass
- [x] `meshcoreManager.channels.test.ts` — setChannel/deleteChannel/sync tests pass

Closes #3297

https://claude.ai/code/session_01TN4dj7q9EFuswudYevuseT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TN4dj7q9EFuswudYevuseT)_