### PR TITLE
feat(mqtt): slim bridge source-edit modal to basics + deep-link to Configuration page

### DIFF
--- a/src/components/MQTT/MqttBridgeConfigurationView.tsx
+++ b/src/components/MQTT/MqttBridgeConfigurationView.tsx
@@ -12,7 +12,7 @@
  * `./mqttBridgeConfig` so the two editors can never drift.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../contexts/AuthContext';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
@@ -76,6 +76,9 @@ export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewPr
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState('');
   const [saved, setSaved] = useState(false);
+  // Raw loaded config — passed as `base` on save so any config sub-keys this
+  // page doesn't render (e.g. node/portnum filters) are preserved, not wiped.
+  const baseConfigRef = useRef<Record<string, any> | null>(null);
 
   // Shallow patch helper for the form state.
   const patch = useCallback(
@@ -104,6 +107,7 @@ export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewPr
         if (!srcRes.ok) throw new Error(`GET source failed: ${srcRes.status}`);
         const src = await srcRes.json();
         if (cancelled) return;
+        baseConfigRef.current = (src?.config as Record<string, any>) ?? {};
         setForm(formFromBridgeConfig(src?.config));
         if (listRes.ok) {
           const list: SourceSummary[] = await listRes.json();
@@ -145,7 +149,7 @@ export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewPr
   const handleSave = useCallback(async () => {
     setSaveError('');
     setSaved(false);
-    const result = buildBridgeConfig(form, { editing: true });
+    const result = buildBridgeConfig(form, { editing: true, base: baseConfigRef.current });
     if (result.error) {
       setSaveError(t(result.error.key, result.error.fallback));
       return;
@@ -164,6 +168,7 @@ export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewPr
       const updated = await res.json();
       // Re-hydrate from the server's stored config (clears the password field
       // and reflects any server-side normalization).
+      baseConfigRef.current = (updated?.config as Record<string, any>) ?? {};
       setForm(formFromBridgeConfig(updated?.config));
       setSaved(true);
     } catch (err) {

--- a/src/components/MQTT/mqttBridgeConfig.test.ts
+++ b/src/components/MQTT/mqttBridgeConfig.test.ts
@@ -130,6 +130,42 @@ describe('mqttBridgeConfig', () => {
       expect(config).not.toHaveProperty('uplinkFilters');
     });
 
+    it('preserves all advanced fields when the modal posts only the basics', () => {
+      // The lightweight modal sends just broker/url/creds/subscriptions.
+      const base = {
+        brokerSourceId: 'broker-1',
+        upstream: { url: 'mqtt://old:1883', username: 'old', password: 'secret' },
+        subscriptions: ['msh/#'],
+        mode: 'subscribe_only',
+        forwardingMode: 'single',
+        ignoreOkToMqtt: true,
+        downlinkFilters: { topics: { block: ['msh/CA/#'] }, geo: { minLat: 1 } },
+        uplinkFilters: { channels: { allow: ['LongFast'] } },
+        downlinkTopicRewrite: { from: 'msh/US', to: 'msh/local' },
+      };
+      const { config } = buildBridgeConfig(
+        {
+          brokerId: 'broker-1',
+          url: 'mqtt://new:1883',
+          username: 'new',
+          password: '',
+          subscriptions: 'msh/US/#',
+        },
+        { editing: true, base },
+      );
+      // Basics updated:
+      expect(config?.upstream.url).toBe('mqtt://new:1883');
+      expect(config?.upstream.username).toBe('new');
+      expect(config?.subscriptions).toEqual(['msh/US/#']);
+      // Everything the modal doesn't render is preserved verbatim:
+      expect(config?.mode).toBe('subscribe_only');
+      expect(config?.forwardingMode).toBe('single');
+      expect(config?.ignoreOkToMqtt).toBe(true);
+      expect(config?.downlinkFilters).toEqual({ topics: { block: ['msh/CA/#'] }, geo: { minLat: 1 } });
+      expect(config?.uplinkFilters).toEqual({ channels: { allow: ['LongFast'] } });
+      expect(config?.downlinkTopicRewrite).toEqual({ from: 'msh/US', to: 'msh/local' });
+    });
+
     it('preserves base.uplinkFilters when the caller does not manage uplink (modal)', () => {
       const base = { uplinkFilters: { topics: { block: ['keep'] } } };
       // Modal-style form: uplinkTopicMode omitted.

--- a/src/components/MQTT/mqttBridgeConfig.ts
+++ b/src/components/MQTT/mqttBridgeConfig.ts
@@ -144,12 +144,20 @@ function applyRewrite(
 /**
  * Serialize a bridge form into the `config` blob posted to /api/sources.
  * Returns `{ config }` on success or `{ error }` with a translatable key.
+ *
+ * Accepts a *partial* form: every field is managed only when the caller
+ * supplies it; anything omitted is preserved from `opts.base`. This lets the
+ * lightweight create/edit modal post just the basics (broker, URL, creds,
+ * subscriptions) while the full Configuration page manages everything — the
+ * advanced settings (mode, forwarding, filters, rewrites) survive a modal
+ * edit untouched.
  */
 export function buildBridgeConfig(
-  form: BridgeConfigForm,
+  form: Partial<BridgeConfigForm>,
   opts: BuildBridgeOptions,
 ): { config?: Record<string, any>; error?: BridgeConfigError } {
-  if (!form.url.trim()) {
+  const url = form.url?.trim();
+  if (!url) {
     return {
       error: { key: 'source.form.error_mqtt_url_required', fallback: 'Upstream URL is required' },
     };
@@ -158,45 +166,62 @@ export function buildBridgeConfig(
   const cfg: Record<string, any> = { ...(opts.base ?? {}) };
 
   // Parent broker — omit entirely when standalone (issue #3134).
-  if (form.brokerId) cfg.brokerSourceId = form.brokerId;
-  else delete cfg.brokerSourceId;
+  if (form.brokerId !== undefined) {
+    if (form.brokerId) cfg.brokerSourceId = form.brokerId;
+    else delete cfg.brokerSourceId;
+  }
 
   // Upstream is rebuilt fresh (never spread from base — avoids leaking the
   // stored password back through). Empty password => undefined => server keeps.
   cfg.upstream = {
-    url: form.url.trim(),
-    username: form.username.trim() || undefined,
+    url,
+    username: form.username?.trim() || undefined,
     password: form.password || undefined,
   };
 
-  const subs = splitLines(form.subscriptions);
-  cfg.subscriptions = subs.length > 0 ? subs : ['msh/#'];
+  if (form.subscriptions !== undefined) {
+    const subs = splitLines(form.subscriptions);
+    cfg.subscriptions = subs.length > 0 ? subs : ['msh/#'];
+  }
 
   // Omit defaults so existing rows stay clean / adopt new defaults on upgrade.
-  if (form.mode !== 'bidirectional') cfg.mode = form.mode;
-  else delete cfg.mode;
-  if (form.forwardingMode !== 'per_gateway') cfg.forwardingMode = form.forwardingMode;
-  else delete cfg.forwardingMode;
-  if (form.ignoreOkToMqtt) cfg.ignoreOkToMqtt = true;
-  else delete cfg.ignoreOkToMqtt;
-
-  // --- Subscribe-side (downlink) filters: manage topics.block + geo,
-  // preserve any other downlink subkeys (channels/nodes/portnums). ---
-  const downlink: Record<string, any> = { ...(opts.base?.downlinkFilters ?? {}) };
-  const topicBlock = form.useTopicBlock ? splitLines(form.topicBlock) : [];
-  if (topicBlock.length > 0) {
-    downlink.topics = { ...clearTopicLists(downlink.topics), block: topicBlock };
-  } else {
-    const rest = clearTopicLists(downlink.topics);
-    if (Object.keys(rest).length > 0) downlink.topics = rest;
-    else delete downlink.topics;
+  if (form.mode !== undefined) {
+    if (form.mode !== 'bidirectional') cfg.mode = form.mode;
+    else delete cfg.mode;
   }
-  const downGeo = parseGeo(form.useGeo, form.geo);
-  if (downGeo.error) return { error: downGeo.error };
-  if (downGeo.geo) downlink.geo = downGeo.geo;
-  else delete downlink.geo;
-  if (Object.keys(downlink).length > 0) cfg.downlinkFilters = downlink;
-  else delete cfg.downlinkFilters;
+  if (form.forwardingMode !== undefined) {
+    if (form.forwardingMode !== 'per_gateway') cfg.forwardingMode = form.forwardingMode;
+    else delete cfg.forwardingMode;
+  }
+  if (form.ignoreOkToMqtt !== undefined) {
+    if (form.ignoreOkToMqtt) cfg.ignoreOkToMqtt = true;
+    else delete cfg.ignoreOkToMqtt;
+  }
+
+  // --- Subscribe-side (downlink) filters: manage topics.block / geo only when
+  // the caller supplies them; preserve other downlink subkeys (channels/nodes/
+  // portnums) and the whole block when neither is managed (modal). ---
+  if (form.useTopicBlock !== undefined || form.useGeo !== undefined) {
+    const downlink: Record<string, any> = { ...(opts.base?.downlinkFilters ?? {}) };
+    if (form.useTopicBlock !== undefined) {
+      const topicBlock = form.useTopicBlock ? splitLines(form.topicBlock ?? '') : [];
+      if (topicBlock.length > 0) {
+        downlink.topics = { ...clearTopicLists(downlink.topics), block: topicBlock };
+      } else {
+        const rest = clearTopicLists(downlink.topics);
+        if (Object.keys(rest).length > 0) downlink.topics = rest;
+        else delete downlink.topics;
+      }
+    }
+    if (form.useGeo !== undefined) {
+      const downGeo = parseGeo(form.useGeo, form.geo ?? { minLat: '', maxLat: '', minLng: '', maxLng: '' });
+      if (downGeo.error) return { error: downGeo.error };
+      if (downGeo.geo) downlink.geo = downGeo.geo;
+      else delete downlink.geo;
+    }
+    if (Object.keys(downlink).length > 0) cfg.downlinkFilters = downlink;
+    else delete cfg.downlinkFilters;
+  }
 
   // --- Publish-side (uplink) filters (#3294): channel allow-list (primary)
   // and raw topic filter (advanced). Each sub-field is only managed when the

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -26,9 +26,7 @@ import { useMeshCoreNeighbors } from '../hooks/useMapAnalysisData';
 import type { DashboardSource } from '../hooks/useDashboardData';
 import DashboardSidebar from '../components/Dashboard/DashboardSidebar';
 import DashboardMap from '../components/Dashboard/DashboardMap';
-import BBoxMapEditor, { type BBoxValue } from '../components/BBoxMapEditor';
 import { buildBridgeConfig, formFromBridgeConfig } from '../components/MQTT/mqttBridgeConfig';
-import { bboxToFormStrings, boundsFromDetectedNodes } from './DashboardPage.bboxSeed';
 import LoginModal from '../components/LoginModal';
 import UserMenu from '../components/UserMenu';
 import { NewsPopup } from '../components/NewsPopup';
@@ -38,25 +36,6 @@ import { logger } from '../utils/logger';
 import { appBasename } from '../init';
 import { getReservedLandingPath, isReservedLandingValue } from '../utils/defaultLandingPage';
 import '../styles/dashboard.css';
-
-// Helper: parse the four bbox text fields into a BBoxValue, or null if any
-// is empty / not a number. The map editor needs a fully-defined bbox; the
-// numeric inputs let the user type values one at a time, so we tolerate
-// partial state and just don't render the rectangle until all four parse.
-function bboxFromForm(geo: {
-  minLat: string;
-  maxLat: string;
-  minLng: string;
-  maxLng: string;
-}): BBoxValue | null {
-  const minLat = Number(geo.minLat);
-  const maxLat = Number(geo.maxLat);
-  const minLng = Number(geo.minLng);
-  const maxLng = Number(geo.maxLng);
-  if ([minLat, maxLat, minLng, maxLng].some((n) => Number.isNaN(n))) return null;
-  if (minLat > maxLat || minLng > maxLng) return null;
-  return { minLat, maxLat, minLng, maxLng };
-}
 
 
 // ---------------------------------------------------------------------------
@@ -160,33 +139,9 @@ function DashboardInner() {
   const [formMqttBridgeUsername, setFormMqttBridgeUsername] = useState('');
   const [formMqttBridgePassword, setFormMqttBridgePassword] = useState('');
   const [formMqttBridgeSubscriptions, setFormMqttBridgeSubscriptions] = useState('msh/#');
-  // Bridge mode: bidirectional (default), publish_only (skip upstream
-  // subscribe — for public servers that reject SUBSCRIBE), or
-  // subscribe_only (skip uplink — read-only monitoring).
-  const [formMqttBridgeMode, setFormMqttBridgeMode] = useState<
-    'bidirectional' | 'publish_only' | 'subscribe_only'
-  >('bidirectional');
-  // Per-gateway upstream identity (default) opens one upstream MQTT
-  // connection per local gateway; single keeps the legacy
-  // `mm-bridge-<sourceId>-…` shared connection for brokers with tight
-  // per-username connection caps.
-  const [formMqttBridgeForwardingMode, setFormMqttBridgeForwardingMode] = useState<
-    'per_gateway' | 'single'
-  >('per_gateway');
-  // When true, bypass the firmware ok_to_mqtt opt-out and uplink every
-  // packet. Default false (honor the bit) — operator override only.
-  const [formMqttBridgeIgnoreOkToMqtt, setFormMqttBridgeIgnoreOkToMqtt] = useState(false);
-  // Each filter is opt-in via a checkbox so the form stays short for the
-  // common case where the user just wants a topic-pattern subscription.
-  const [formMqttBridgeUseTopicBlock, setFormMqttBridgeUseTopicBlock] = useState(false);
-  const [formMqttBridgeTopicBlock, setFormMqttBridgeTopicBlock] = useState('');
-  const [formMqttBridgeUseGeo, setFormMqttBridgeUseGeo] = useState(false);
-  const [formMqttBridgeGeo, setFormMqttBridgeGeo] = useState({
-    minLat: '',
-    maxLat: '',
-    minLng: '',
-    maxLng: '',
-  });
+  // Advanced bridge settings (mode, forwarding, ok_to_mqtt, publish/subscribe
+  // filters, geofence, topic rewrites) are NOT edited here — they live on the
+  // bridge's Configuration page. buildBridgeConfig preserves them on save.
   // Meshtastic source ↔ embedded MQTT broker proxy link (issue #3003
   // follow-up). Empty string = unset / no proxy bridge.
   const [formMtMqttLinkBrokerId, setFormMtMqttLinkBrokerId] = useState('');
@@ -351,13 +306,6 @@ function DashboardInner() {
     setFormMqttBridgeUsername('');
     setFormMqttBridgePassword('');
     setFormMqttBridgeSubscriptions('msh/#');
-    setFormMqttBridgeMode('bidirectional');
-    setFormMqttBridgeForwardingMode('per_gateway');
-    setFormMqttBridgeIgnoreOkToMqtt(false);
-    setFormMqttBridgeUseTopicBlock(false);
-    setFormMqttBridgeTopicBlock('');
-    setFormMqttBridgeUseGeo(false);
-    setFormMqttBridgeGeo({ minLat: '', maxLat: '', minLng: '', maxLng: '' });
     setFormMtMqttLinkBrokerId('');
     setFormBrokerBridgeRewrites({});
     setOriginalBrokerBridgeRewrites({});
@@ -408,6 +356,9 @@ function DashboardInner() {
     if (source.type === 'mqtt_bridge') {
       // Hydrate via the shared serializer so the modal and the dedicated
       // bridge Configuration page never drift on config shape.
+      // Only the basics are edited here; advanced settings are preserved on
+      // save (buildBridgeConfig merges over the existing config) and edited on
+      // the Configuration page.
       const bf = formFromBridgeConfig(cfg);
       setFormType('mqtt_bridge');
       setFormName(source.name);
@@ -416,13 +367,6 @@ function DashboardInner() {
       setFormMqttBridgeUsername(bf.username);
       setFormMqttBridgePassword('');
       setFormMqttBridgeSubscriptions(bf.subscriptions);
-      setFormMqttBridgeMode(bf.mode);
-      setFormMqttBridgeForwardingMode(bf.forwardingMode);
-      setFormMqttBridgeIgnoreOkToMqtt(bf.ignoreOkToMqtt);
-      setFormMqttBridgeUseTopicBlock(bf.useTopicBlock);
-      setFormMqttBridgeTopicBlock(bf.topicBlock);
-      setFormMqttBridgeUseGeo(bf.useGeo);
-      setFormMqttBridgeGeo(bf.geo);
       setFormError('');
       setShowSourceModal(true);
       return;
@@ -505,6 +449,9 @@ function DashboardInner() {
       const base = editingSourceId
         ? (sources.find((s) => s.id === editingSourceId)?.config as Record<string, any> | undefined)
         : undefined;
+      // Only the basics are posted from the modal; every advanced field
+      // (mode, forwarding, ok_to_mqtt, downlink/uplink filters, geofence,
+      // rewrites) is omitted so buildBridgeConfig preserves it from `base`.
       const result = buildBridgeConfig(
         {
           brokerId: formMqttBridgeBrokerId,
@@ -512,14 +459,6 @@ function DashboardInner() {
           username: formMqttBridgeUsername,
           password: formMqttBridgePassword,
           subscriptions: formMqttBridgeSubscriptions,
-          mode: formMqttBridgeMode,
-          forwardingMode: formMqttBridgeForwardingMode,
-          ignoreOkToMqtt: formMqttBridgeIgnoreOkToMqtt,
-          useTopicBlock: formMqttBridgeUseTopicBlock,
-          topicBlock: formMqttBridgeTopicBlock,
-          useGeo: formMqttBridgeUseGeo,
-          geo: formMqttBridgeGeo,
-          // uplink filters / rewrites intentionally omitted — preserved via base.
         },
         { editing: !!editingSourceId, base },
       );
@@ -1302,84 +1241,6 @@ function DashboardInner() {
                   </span>
                 </label>
                 <label className="dashboard-form-field">
-                  <span className="dashboard-form-label">{t('source.form.mqtt_bridge_mode', 'Mode')}</span>
-                  <select
-                    className="dashboard-form-input"
-                    value={formMqttBridgeMode}
-                    onChange={(e) =>
-                      setFormMqttBridgeMode(
-                        e.target.value as 'bidirectional' | 'publish_only' | 'subscribe_only',
-                      )
-                    }
-                  >
-                    <option value="bidirectional">
-                      {t('source.form.mqtt_bridge_mode_bidirectional', 'Bidirectional (subscribe + publish)')}
-                    </option>
-                    <option value="publish_only">
-                      {t('source.form.mqtt_bridge_mode_publish_only', 'Publish only (no subscribe)')}
-                    </option>
-                    <option value="subscribe_only">
-                      {t('source.form.mqtt_bridge_mode_subscribe_only', 'Subscribe only (no publish)')}
-                    </option>
-                  </select>
-                  <span style={{ fontSize: 11, color: 'var(--ctp-subtext0)', marginTop: 4 }}>
-                    {t(
-                      'source.form.mqtt_bridge_mode_help',
-                      'Use "Publish only" for public servers (e.g. mqtt.meshtastic.org) that reject SUBSCRIBE — avoids permission-denied noise. "Subscribe only" disables uplink forwarding for read-only monitoring.',
-                    )}
-                  </span>
-                </label>
-                <label className="dashboard-form-field">
-                  <span className="dashboard-form-label">
-                    {t('source.form.mqtt_bridge_forwarding_mode', 'Upstream identity')}
-                  </span>
-                  <select
-                    className="dashboard-form-input"
-                    value={formMqttBridgeForwardingMode}
-                    onChange={(e) =>
-                      setFormMqttBridgeForwardingMode(e.target.value as 'per_gateway' | 'single')
-                    }
-                  >
-                    <option value="per_gateway">
-                      {t(
-                        'source.form.mqtt_bridge_forwarding_per_gateway',
-                        'Per-gateway (one connection per local node)',
-                      )}
-                    </option>
-                    <option value="single">
-                      {t(
-                        'source.form.mqtt_bridge_forwarding_single',
-                        'Single (one shared bridge connection — legacy)',
-                      )}
-                    </option>
-                  </select>
-                  <span style={{ fontSize: 11, color: 'var(--ctp-subtext0)', marginTop: 4 }}>
-                    {t(
-                      'source.form.mqtt_bridge_forwarding_help',
-                      'Per-gateway lets each local node publish upstream under its own !<hex> Client ID — required for community brokers that filter CONNECT on Client ID (mqtt.areyoumeshingwith.us, etc.). Switch to Single only if the upstream broker has tight per-username connection caps.',
-                    )}
-                  </span>
-                </label>
-                <label className="dashboard-form-field" style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 8 }}>
-                  <input
-                    type="checkbox"
-                    checked={formMqttBridgeIgnoreOkToMqtt}
-                    onChange={(e) => setFormMqttBridgeIgnoreOkToMqtt(e.target.checked)}
-                    style={{ marginTop: 3 }}
-                  />
-                  <span>
-                    <span className="dashboard-form-label" style={{ display: 'block' }}>
-                      {t('source.form.mqtt_bridge_ignore_ok_to_mqtt', 'Uplink all packets (ignore ok_to_mqtt bit)')}
-                    </span>
-                    <span style={{ fontSize: 11, color: 'var(--ctp-yellow)' }}>
-                      {t(
-                        'source.form.mqtt_bridge_ignore_ok_to_mqtt_help',
-                        '⚠ Overrides the originating node\'s "ok_to_mqtt" preference. By default, MeshMonitor drops uplink packets whose firmware-set ok_to_mqtt bit is unset (matching Meshtastic firmware on public brokers). Enabling this republishes every packet regardless — including from nodes that explicitly opted out of MQTT relay. Only enable for private bridges where every gateway has consented.',
-                      )}
-                    </span>
-                  </span>
-                </label>
-                <label className="dashboard-form-field">
                   <span className="dashboard-form-label">{t('source.form.mqtt_upstream_url', 'Upstream URL')}</span>
                   <input
                     className="dashboard-form-input"
@@ -1417,95 +1278,42 @@ function DashboardInner() {
                     onChange={(e) => setFormMqttBridgeSubscriptions(e.target.value)}
                   />
                 </label>
-                <fieldset style={{ border: '1px solid var(--ctp-surface1)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
-                  <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--ctp-subtext0)' }}>
-                    <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
-                      <input
-                        type="checkbox"
-                        checked={formMqttBridgeUseTopicBlock}
-                        onChange={(e) => setFormMqttBridgeUseTopicBlock(e.target.checked)}
-                      />
-                      {t('source.form.mqtt_topic_block_enable', 'Block specific topics')}
-                    </label>
-                  </legend>
-                  {formMqttBridgeUseTopicBlock && (
-                    <label className="dashboard-form-field" style={{ marginTop: 4 }}>
-                      <span className="dashboard-form-label">{t('source.form.mqtt_topic_block_label', 'Topics to drop (one per line, MQTT wildcards allowed)')}</span>
-                      <textarea
-                        className="dashboard-form-input"
-                        rows={3}
-                        value={formMqttBridgeTopicBlock}
-                        onChange={(e) => setFormMqttBridgeTopicBlock(e.target.value)}
-                        placeholder="msh/CA/QC/#"
-                      />
-                    </label>
+                {/* Advanced bridge settings (mode, forwarding, ok_to_mqtt,
+                    publish channel/topic filters, geofence, topic rewrites)
+                    live on the bridge's Configuration page so they're
+                    maintained in one place — not duplicated here. When editing
+                    an existing source we can deep-link straight to it. */}
+                <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginTop: 4 }}>
+                  <span style={{ fontSize: 11, color: 'var(--ctp-subtext0)', flex: 1 }}>
+                    {t(
+                      'source.form.mqtt_bridge_advanced_hint',
+                      'Mode, forwarding, publish/subscribe filters, geofence, and topic rewrites are on the bridge’s Configuration page.',
+                    )}
+                  </span>
+                  {editingSourceId && (
+                    <button
+                      type="button"
+                      style={{
+                        flexShrink: 0,
+                        whiteSpace: 'nowrap',
+                        fontSize: 11,
+                        padding: '4px 8px',
+                        background: 'transparent',
+                        color: 'var(--ctp-blue)',
+                        border: '1px solid var(--ctp-blue)',
+                        borderRadius: 4,
+                        cursor: 'pointer',
+                      }}
+                      title={t('source.form.mqtt_bridge_advanced_open', 'Open Configuration page')}
+                      onClick={() => {
+                        setShowSourceModal(false);
+                        navigate(`/source/${editingSourceId}/#mqtt-config`);
+                      }}
+                    >
+                      {t('source.form.mqtt_bridge_advanced_open', 'Configuration')} →
+                    </button>
                   )}
-                </fieldset>
-                <fieldset style={{ border: '1px solid var(--ctp-surface1)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
-                  <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--ctp-subtext0)' }}>
-                    <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
-                      <input
-                        type="checkbox"
-                        checked={formMqttBridgeUseGeo}
-                        onChange={(e) => {
-                          const enabled = e.target.checked;
-                          setFormMqttBridgeUseGeo(enabled);
-                          // Seed the bbox from currently-detected node positions
-                          // when the user first enables the filter and the form is
-                          // empty. Saves them having to pan/zoom from the middle
-                          // of the ocean on a fresh source.
-                          if (
-                            enabled &&
-                            !formMqttBridgeGeo.minLat &&
-                            !formMqttBridgeGeo.maxLat &&
-                            !formMqttBridgeGeo.minLng &&
-                            !formMqttBridgeGeo.maxLng
-                          ) {
-                            const allNodes = [
-                              ...(unifiedSourceData.nodes as Array<{ latitude?: number | null; longitude?: number | null }>),
-                              ...(sourceData.nodes as Array<{ latitude?: number | null; longitude?: number | null }>),
-                            ];
-                            const seeded = boundsFromDetectedNodes(allNodes);
-                            if (seeded) setFormMqttBridgeGeo(bboxToFormStrings(seeded));
-                          }
-                        }}
-                      />
-                      {t('source.form.mqtt_geo_enable', 'Restrict to geographic bounding box')}
-                    </label>
-                  </legend>
-                  {formMqttBridgeUseGeo && (
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 4 }}>
-                      <BBoxMapEditor
-                        bbox={bboxFromForm(formMqttBridgeGeo)}
-                        onChange={(next) => {
-                          if (next) {
-                            setFormMqttBridgeGeo(bboxToFormStrings(next));
-                          } else {
-                            setFormMqttBridgeGeo({ minLat: '', maxLat: '', minLng: '', maxLng: '' });
-                          }
-                        }}
-                      />
-                      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
-                        <label className="dashboard-form-field">
-                          <span className="dashboard-form-label">minLat</span>
-                          <input className="dashboard-form-input" value={formMqttBridgeGeo.minLat} onChange={(e) => setFormMqttBridgeGeo({ ...formMqttBridgeGeo, minLat: e.target.value })} />
-                        </label>
-                        <label className="dashboard-form-field">
-                          <span className="dashboard-form-label">maxLat</span>
-                          <input className="dashboard-form-input" value={formMqttBridgeGeo.maxLat} onChange={(e) => setFormMqttBridgeGeo({ ...formMqttBridgeGeo, maxLat: e.target.value })} />
-                        </label>
-                        <label className="dashboard-form-field">
-                          <span className="dashboard-form-label">minLng</span>
-                          <input className="dashboard-form-input" value={formMqttBridgeGeo.minLng} onChange={(e) => setFormMqttBridgeGeo({ ...formMqttBridgeGeo, minLng: e.target.value })} />
-                        </label>
-                        <label className="dashboard-form-field">
-                          <span className="dashboard-form-label">maxLng</span>
-                          <input className="dashboard-form-input" value={formMqttBridgeGeo.maxLng} onChange={(e) => setFormMqttBridgeGeo({ ...formMqttBridgeGeo, maxLng: e.target.value })} />
-                        </label>
-                      </div>
-                    </div>
-                  )}
-                </fieldset>
+                </div>
               </>
             ) : formType === 'meshcore' ? (
               <>


### PR DESCRIPTION
## Summary

Follow-up to the MQTT bridge Configuration page (#3295). That page is now the home for all advanced bridge settings, but the create/edit **Source popup** still duplicated them (mode, forwarding, ok_to_mqtt, subscribe topic-block, geofence, publish channel/topic filters, topic rewrites) — two places to maintain.

This trims the popup to just the **basics** needed to create/connect a bridge, and points users to the Configuration page for the rest.

## Changes

- **Slim modal (mqtt_bridge):** keeps Name, Parent broker, Upstream URL, Username, Password, Upstream topics. Removes the advanced fields (and their state / reset / hydration, plus the now-unused `BBoxMapEditor` + bbox-seed imports/helper).
- **Hint + deep-link:** a one-line hint plus a **"Configuration →"** button that, when editing an existing source, closes the modal and navigates to `/source/<id>/#mqtt-config`. Hidden on create (no source exists yet).
- **Shared serializer is now partial-aware:** `buildBridgeConfig` accepts a `Partial<BridgeConfigForm>` and manages only the fields a caller supplies, merging over the stored config (`base`) for the rest. A modal save therefore touches only the basics and **preserves all advanced settings untouched** — single source of truth, no double-maintenance. This also fixes a latent bug where a modal edit could clobber fields it didn't render.
- **Configuration page** now also passes the loaded config as `base`, so it preserves config sub-keys it doesn't surface (e.g. node/portnum filters).

## Files

| File | Change |
|------|--------|
| `src/pages/DashboardPage.tsx` | Slimmed bridge modal; removed advanced state/reset/hydration + bbox imports/helper; added the deep-link button. |
| `src/components/MQTT/mqttBridgeConfig.ts` | `buildBridgeConfig` partial-form + preserve semantics. |
| `src/components/MQTT/MqttBridgeConfigurationView.tsx` | Pass loaded config as `base` on save. |
| `src/components/MQTT/mqttBridgeConfig.test.ts` | +1 test: "modal posts only basics → advanced preserved" (18 total). |

## Testing

- `tsc` clean; lint introduces no new errors.
- **Full Vitest suite: 5880 passed, 0 failures.**
- **Manual, dev container, end-to-end:**
  - Bridge edit popup shows only the basics + hint + "Configuration →" button.
  - Changed a username and saved from the popup → API confirmed `mode`, `forwardingMode`, `ignoreOkToMqtt`, `uplinkFilters.channels`, `downlinkFilters.geo`, and `downlinkTopicRewrite` all preserved (username updated).
  - Clicked "Configuration →" → closed the popup and opened the correct bridge's Configuration page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)