### PR TITLE
chore: bump version to 4.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.8.3] - 2026-06-02
+
+# MeshMonitor v4.8.3
+
+Patch release adding **active MeshCore node discovery** (and reciprocal discoverability), a dedicated **MQTT bridge Configuration page** with per-bridge publish filtering, plus correctness fixes to MeshCore private-key validation, hashtag-channel creation, and reconnect stability.
+
+## Features
+
+### MeshCore
+
+- #3302 feat(meshcore): active node discovery (Discover Nearby Nodes / Repeaters) — proactively discover nearby MeshCore nodes and repeaters on demand.
+- #3303 feat(meshcore): respond to discovery requests (be discoverable) — answer inbound discovery requests so this node is itself discoverable by peers.
+
+### MQTT
+
+- #3294 feat(mqtt): dedicated bridge Configuration page with per-bridge publish filter — manage MQTT bridges from a dedicated Configuration page, including a per-bridge publish filter.
+- #3299 feat(mqtt): slim bridge source-edit modal to basics, deep-link to Configuration page — the per-source bridge edit modal is trimmed to the essentials and deep-links to the full Configuration page.
+
+## Fixes
+
+- #3301 fix: correct MeshCore private key validation to 128 hex chars (64 bytes) — MeshCore private keys are now validated as 128 hex characters (64 bytes).
+- #3298 fix(meshcore): allow adding new hashtag channels (fixes #3297) — adding a brand-new MeshCore hashtag channel now works.
+- #3270 fix(stability): close transport-level orphan-reconnect flap — a transport-level reconnect flap from orphaned connections is now closed out.
+- #3283 fix(build): pin legacy-peer-deps in .npmrc so npm ci stays in sync — pins `legacy-peer-deps=true` in `.npmrc` so `npm ci` and `npm install` resolve dependencies identically.
+
+## Documentation
+
+- #3292 docs: document OIDC first-user auto-admin behavior — documents that the first user to log in via OIDC is automatically granted admin.
+
+## Maintenance
+
+- Dependency bumps via Dependabot: production dependencies group (7 updates), development dependencies group, `react-router-dom` 7.15.1→7.16.0, `puppeteer` 25.0.4→25.1.0, `concurrently` 9.2.1→10.0.1, `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser`, and Rollup linux ARM binaries.
+
 ## [4.8.2] - 2026-05-31
 
 # MeshMonitor v4.8.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # MeshMonitor — Claude Agent Brief
 
-**Version:** 4.8.2 (multi-source architecture)
+**Version:** 4.8.3 (multi-source architecture)
 **Stack:** React 19 + TS + Vite frontend / Node.js 20+ (Docker image ships Node 24; CI matrix covers 20/22/24/25) + Express 5 + TS backend / SQLite (default), PostgreSQL, MySQL via Drizzle ORM / Meshtastic protobuf-over-TCP and MeshCore (native `meshcore.js` for companion, serial CLI for repeater) through a per-source manager registry.
 
 ## Read order for new agents

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.8.2",
+  "version": "4.8.3",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -273,6 +273,15 @@ Repeaters maintain a neighbor table of other repeaters heard via zero-hop advert
 
 Neighbor queries require authentication to the repeater (guest or admin login). See [the MeshCore protocol details](/features/meshcore#remote-administration) for auth requirements.
 
+## Active Node Discovery
+
+Beyond passively reading a repeater's neighbor table, MeshMonitor can actively probe the airwaves for nearby MeshCore devices (added in 4.8.3). The MeshCore **Settings** view exposes two buttons:
+
+- **Discover Nearby Nodes** — sweep for any MeshCore node in zero-hop (direct RF) range, matching the mobile app's discovery behaviour. Responders are added/refreshed as contacts.
+- **Discover Repeaters** — the same sweep scoped to repeater-class devices.
+
+Discovery is direct-range only (zero-hop) — it surfaces devices you can hear without relaying. MeshMonitor is also **discoverable** in the other direction: it answers inbound discovery requests from peers, so your source shows up when another node runs the same sweep.
+
 ## Auto-Pathfinding
 
 The **Automation** view (accessible from the MeshCore page sub-toolbar) provides scheduled path discovery and neighbor collection:

--- a/docs/features/mqtt-broker.md
+++ b/docs/features/mqtt-broker.md
@@ -211,7 +211,7 @@ By default an `mqtt_bridge` is a byte-for-byte relay — it republishes inbound 
 | `downlinkTopicRewrite` | upstream → parent broker | Republish an inbound topic on the parent broker under a different prefix, so locally-subscribed devices see it. |
 | `uplinkTopicRewrite` | parent broker → upstream | Publish a parent-broker topic upstream under a different prefix, so the foreign mesh sees your local traffic. |
 
-Each rule is `{ from, to }` — literal prefix match (no MQTT `+` / `#` wildcards), trailing slashes normalized away. Configured from the **broker's edit modal** (Sources → kebab on the broker → Edit → **Bridge topic rewrites**) — one collapsible panel per bridge attached to that broker, so an operator can manage every rewrite for a given broker in one place. Equivalent fields are also accepted via the source API on the bridge itself (`PUT /api/sources/<bridgeId>` with `config.downlinkTopicRewrite` and `config.uplinkTopicRewrite`).
+Each rule is `{ from, to }` — literal prefix match (no MQTT `+` / `#` wildcards), trailing slashes normalized away. Configured from the bridge's dedicated **Configuration page** (select the `mqtt_bridge` source in the sidebar → **Configuration** → **Topic rewrites** section). As of 4.8.3 the per-source bridge edit modal is slimmed to connection basics and deep-links to this Configuration page, which hosts the full set of bridge controls (Connection, Forwarding, Subscribe, Publish + advanced topic filter, and Topic rewrites). Equivalent fields are also accepted via the source API on the bridge itself (`PUT /api/sources/<bridgeId>` with `config.downlinkTopicRewrite` and `config.uplinkTopicRewrite`).
 
 ### Example — LA ↔ TX cross-mesh bridge
 

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.8.2
-appVersion: "4.8.2"
+version: 4.8.3
+appVersion: "4.8.3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.8.2",
+      "version": "4.8.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Release prep for **v4.8.3**, a patch release rolling up the PRs merged since 4.8.2.

### Version bump
Updated all five version files plus the `CLAUDE.md` header:
- `package.json`, `package-lock.json`
- `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`
- `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`)

### Changelog
Added a `[4.8.3]` entry covering:
- **MeshCore** — active node discovery (#3302), respond to discovery requests / be discoverable (#3303)
- **MQTT** — dedicated bridge Configuration page with per-bridge publish filter (#3294), slimmed source-edit modal that deep-links to it (#3299)
- **Fixes** — MeshCore private-key validation = 128 hex chars (#3301), add new hashtag channels (#3298), transport orphan-reconnect flap (#3270), pin `legacy-peer-deps` in `.npmrc` (#3283)
- **Docs** — OIDC first-user auto-admin (#3292)
- Dependabot bumps

### Documentation accuracy review
Reviewed user-facing docs against the above changes and fixed two stale spots:
- `docs/features/mqtt-broker.md` — topic rewrites + publish filter now live on the new dedicated bridge **Configuration page**, not the broker's edit modal (which 4.8.3 slims to basics).
- `docs/features/meshcore.md` — added an **Active Node Discovery** section documenting the new "Discover Nearby Nodes" / "Discover Repeaters" buttons and reciprocal discoverability.

## Testing
- `npm run typecheck` — clean
- `npx vitest run` — **5908 passed, 0 failed**
- System tests requested via the `system-test` label on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)