### PR TITLE
fix(meshcore): use lucide sidebar icons matching MQTT/Meshtastic

### DIFF
--- a/src/components/MeshCore/MeshCoreSubToolbar.test.tsx
+++ b/src/components/MeshCore/MeshCoreSubToolbar.test.tsx
@@ -9,6 +9,11 @@ vi.mock('../../contexts/AuthContext', () => ({
   useAuth: () => ({ hasPermission: (r: string, a: string) => authPermission(r, a) }),
 }));
 
+let iconStyle: 'icon' | 'emoji' = 'icon';
+vi.mock('../../contexts/SettingsContext', () => ({
+  useSettings: () => ({ iconStyle }),
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, fallback?: string) => (typeof fallback === 'string' ? fallback : key),
@@ -18,6 +23,30 @@ vi.mock('react-i18next', () => ({
 import { MeshCoreSubToolbar } from './MeshCoreSubToolbar';
 
 describe('MeshCoreSubToolbar', () => {
+  it('renders lucide SVG icons (not emoji) in the default icon style', () => {
+    authPermission = () => true;
+    iconStyle = 'icon';
+    const { container } = render(
+      <MeshCoreSubToolbar view="nodes" onSelect={() => {}} expanded onToggleExpanded={() => {}} />,
+    );
+    // Each nav item's .icon span should contain an <svg> from lucide-react.
+    const iconSpans = container.querySelectorAll('.meshcore-sub-toolbar-item .icon');
+    expect(iconSpans.length).toBeGreaterThan(0);
+    iconSpans.forEach((span) => expect(span.querySelector('svg')).not.toBeNull());
+  });
+
+  it('renders emoji when the icon style is set to emoji', () => {
+    authPermission = () => true;
+    iconStyle = 'emoji';
+    const { container } = render(
+      <MeshCoreSubToolbar view="nodes" onSelect={() => {}} expanded onToggleExpanded={() => {}} />,
+    );
+    const firstIcon = container.querySelector('.meshcore-sub-toolbar-item .icon');
+    expect(firstIcon?.querySelector('svg')).toBeNull();
+    expect(firstIcon?.textContent).toBe('🗺️');
+    iconStyle = 'icon'; // reset for other tests
+  });
+
   it('renders the Configuration tab when configuration:read is granted', () => {
     authPermission = () => true;
     render(

--- a/src/components/MeshCore/MeshCoreSubToolbar.tsx
+++ b/src/components/MeshCore/MeshCoreSubToolbar.tsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import {
+  Map, MessageSquare, Home, Mail, BarChart3, Activity, Info, Satellite, Bot,
+  Settings, ChevronLeft, ChevronRight,
+} from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
+import { useSettings } from '../../contexts/SettingsContext';
 
 export type MeshCoreView = 'nodes' | 'channels' | 'rooms' | 'dms' | 'telemetry' | 'packets' | 'info' | 'configuration' | 'automations' | 'settings';
 
@@ -15,23 +20,54 @@ interface MeshCoreSubToolbarProps {
 
 interface Item {
   id: MeshCoreView;
-  icon: string;
   labelKey: string;
   fallback: string;
 }
 
 const ITEMS: Item[] = [
-  { id: 'nodes', icon: '🛰', labelKey: 'meshcore.nav.nodes', fallback: 'Nodes' },
-  { id: 'channels', icon: '💬', labelKey: 'meshcore.nav.channels', fallback: 'Channels' },
-  { id: 'rooms', icon: '🏠', labelKey: 'meshcore.nav.rooms', fallback: 'Rooms' },
-  { id: 'dms', icon: '📧', labelKey: 'meshcore.nav.dms', fallback: 'Direct Messages' },
-  { id: 'telemetry', icon: '📊', labelKey: 'meshcore.nav.telemetry', fallback: 'Telemetry' },
-  { id: 'packets', icon: '📡', labelKey: 'meshcore.nav.packets', fallback: 'Packet Monitor' },
-  { id: 'info', icon: 'ℹ', labelKey: 'meshcore.nav.info', fallback: 'Node Info' },
-  { id: 'configuration', icon: '📡', labelKey: 'meshcore.nav.configuration', fallback: 'Configuration' },
-  { id: 'automations', icon: '🤖', labelKey: 'meshcore.nav.automations', fallback: 'Automations' },
-  { id: 'settings', icon: '⚙', labelKey: 'meshcore.nav.settings', fallback: 'Settings' },
+  { id: 'nodes', labelKey: 'meshcore.nav.nodes', fallback: 'Nodes' },
+  { id: 'channels', labelKey: 'meshcore.nav.channels', fallback: 'Channels' },
+  { id: 'rooms', labelKey: 'meshcore.nav.rooms', fallback: 'Rooms' },
+  { id: 'dms', labelKey: 'meshcore.nav.dms', fallback: 'Direct Messages' },
+  { id: 'telemetry', labelKey: 'meshcore.nav.telemetry', fallback: 'Telemetry' },
+  { id: 'packets', labelKey: 'meshcore.nav.packets', fallback: 'Packet Monitor' },
+  { id: 'info', labelKey: 'meshcore.nav.info', fallback: 'Node Info' },
+  { id: 'configuration', labelKey: 'meshcore.nav.configuration', fallback: 'Configuration' },
+  { id: 'automations', labelKey: 'meshcore.nav.automations', fallback: 'Automations' },
+  { id: 'settings', labelKey: 'meshcore.nav.settings', fallback: 'Settings' },
 ];
+
+// Lucide icon components — chosen to match the main sidebar (Sidebar.tsx) for
+// shared concepts: nodes→Map, channels→MessageSquare, dms→Mail (messages),
+// packets→Activity (packetmonitor), info→Info, configuration→Satellite,
+// automations→Bot (automation), settings→Settings.
+const LUCIDE_ICONS: Record<MeshCoreView, React.ReactNode> = {
+  nodes: <Map size={20} />,
+  channels: <MessageSquare size={20} />,
+  rooms: <Home size={20} />,
+  dms: <Mail size={20} />,
+  telemetry: <BarChart3 size={20} />,
+  packets: <Activity size={20} />,
+  info: <Info size={20} />,
+  configuration: <Satellite size={20} />,
+  automations: <Bot size={20} />,
+  settings: <Settings size={20} />,
+};
+
+// Emoji fallbacks for the 'emoji' icon style, aligned with the main sidebar's
+// emoji for shared concepts so both navs look identical in either mode.
+const EMOJI_ICONS: Record<MeshCoreView, string> = {
+  nodes: '🗺️',
+  channels: '💬',
+  rooms: '🏠',
+  dms: '📧',
+  telemetry: '📊',
+  packets: '📈',
+  info: 'ℹ️',
+  configuration: '📡',
+  automations: '🤖',
+  settings: '⚙️',
+};
 
 export const MeshCoreSubToolbar: React.FC<MeshCoreSubToolbarProps> = ({
   view,
@@ -42,9 +78,19 @@ export const MeshCoreSubToolbar: React.FC<MeshCoreSubToolbarProps> = ({
 }) => {
   const { t } = useTranslation();
   const { hasPermission } = useAuth();
+  const { iconStyle } = useSettings();
   const canReadConfig = hasPermission('configuration', 'read');
   const canReadAutomation = hasPermission('automation', 'read');
   const canReadPackets = hasPermission('packetmonitor', 'read');
+
+  // Mirror Sidebar.tsx: honor the global icon-style setting so MeshCore renders
+  // the same lucide icons (default) or emoji fallbacks as the rest of the app.
+  const renderIcon = useMemo(() => {
+    const useEmoji = iconStyle === 'emoji';
+    return (id: MeshCoreView) => useEmoji
+      ? <span style={{ fontSize: '1.1rem' }}>{EMOJI_ICONS[id]}</span>
+      : LUCIDE_ICONS[id];
+  }, [iconStyle]);
 
   return (
     <aside className={`meshcore-sub-toolbar ${expanded ? 'expanded' : 'collapsed'}`}>
@@ -62,7 +108,7 @@ export const MeshCoreSubToolbar: React.FC<MeshCoreSubToolbarProps> = ({
             onClick={() => onSelect(item.id)}
             title={!expanded ? label : undefined}
           >
-            <span className="icon">{item.icon}</span>
+            <span className="icon">{renderIcon(item.id)}</span>
             <span className="label">{label}</span>
           </button>
         );
@@ -75,7 +121,7 @@ export const MeshCoreSubToolbar: React.FC<MeshCoreSubToolbarProps> = ({
           ? t('meshcore.nav.collapse', 'Collapse')
           : t('meshcore.nav.expand', 'Expand')}
       >
-        {expanded ? '◀' : '▶'}
+        {expanded ? <ChevronLeft size={18} /> : <ChevronRight size={18} />}
       </button>
     </aside>
   );


### PR DESCRIPTION
## Summary

The MeshCore sub-toolbar hardcoded **emoji** for its nav icons, while the main sidebar (shared by Meshtastic and MQTT) renders **lucide-react** icons and honors the global icon-vs-emoji `iconStyle` setting. This makes `MeshCoreSubToolbar.tsx` mirror that pattern exactly, so MeshCore looks consistent with the rest of the app.

## Changes

- Renders **lucide-react** icons by default, reusing the **same components as `Sidebar.tsx`** for shared concepts:

  | Nav item | lucide icon | Matches main sidebar |
  |---|---|---|
  | Nodes | `Map` | ✓ (nodes) |
  | Channels | `MessageSquare` | ✓ (channels) |
  | Rooms | `Home` | — |
  | Direct Messages | `Mail` | ✓ (messages) |
  | Telemetry | `BarChart3` | — |
  | Packet Monitor | `Activity` | ✓ (packetmonitor) |
  | Node Info | `Info` | ✓ (info) |
  | Configuration | `Satellite` | ✓ (configuration) |
  | Automations | `Bot` | ✓ (automation) |
  | Settings | `Settings` | ✓ (settings) |

- **Honors the `iconStyle` setting** (`useSettings()`) so emoji mode still shows emoji, aligned with the main sidebar's emoji set.
- Collapse/expand toggle uses `ChevronLeft`/`ChevronRight` instead of `◀`/`▶` glyphs.
- No CSS change — the `.icon` span is already a centered 24px flexbox holding the 20px SVGs.

## Testing

- Full Vitest suite **5910 passing, 0 failing**; typecheck + lint clean.
- `MeshCoreSubToolbar.test.tsx`: added assertions that a lucide `<svg>` renders per nav item in the default icon style and that emoji render when `iconStyle === 'emoji'`; mocked `SettingsContext` (the component now reads `useSettings()`). Existing permission-gating tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
