### PR TITLE
fix(ui): remove dead space below chat input in installed PWA

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1406,13 +1406,42 @@ body {
     /* Create flexbox layout for mobile to prevent scrolling */
     display: flex;
     flex-direction: column;
-    /* Account for header + top padding + bottom padding + safe area */
-    /* Use dvh (dynamic viewport height) for proper behavior with virtual keyboard */
-    height: calc(100vh - var(--header-height) - 0.5rem - max(0.5rem, env(safe-area-inset-bottom)));
-    height: calc(100dvh - var(--header-height) - 0.5rem - max(0.5rem, env(safe-area-inset-bottom)));
+    /* Fill the parent's content box instead of recomputing from 100dvh.
+       In an installed PWA (display: standalone, viewport-fit=cover) dvh
+       under-resolves versus the real webview height, leaving dead space
+       below the message input. The % height chain + flex parent below give
+       the true viewport height; .app-main's padding already reserves the
+       header and bottom safe-area space. */
+    flex: 1 1 auto;
+    min-height: 0;
     overflow: hidden;
     /* Prevent scroll chaining to body */
     overscroll-behavior: contain;
+  }
+
+  /* The chat view is a fixed-height, internally-scrolling layout. Anchor its
+     height chain to % (reliable in standalone PWAs, unlike dvh) and let the
+     active tab flex to fill .app-main. Scoped to the channels tab via :has()
+     so naturally-scrolling tabs (nodes, map, etc.) are unaffected. */
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+
+  .app:has(.channels-tab-content) {
+    height: 100%;
+  }
+
+  .app-main:has(.channels-tab-content) {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* The page-level bottom spacer (.app-main::after) would add dead space
+     below the message input on the channels tab — suppress it there. */
+  .app-main:has(.channels-tab-content)::after {
+    display: none;
   }
 
   /* Fixed header section */


### PR DESCRIPTION
## Problem

In the **Channels** view, an installed PWA (added to home screen, `display: standalone`) shows a large empty area below the message input. The same view looks fine in a normal mobile browser.

| Mobile browser (ok) | Installed PWA (dead space) |
|---|---|
| input near bottom, spacer below the fold | input mid-screen, large void below |

## Root cause (mobile layout only)

Two issues compound, and both are masked in a browser because the browser chrome shrinks the visible viewport so the slack falls below the fold:

1. **`.channels-tab-content` height was hard-computed from `100dvh`.** In standalone mode (`viewport-fit=cover`), `dvh` under-resolves versus the real webview height, so the fixed-height chat box ends short of the screen.
2. **The page-level bottom spacer** (`.app-main::after`, `8rem + safe-area`) — intended for naturally-scrolling tabs (nodes/map) so the last row clears the home indicator — was being appended below the chat view, adding ~128px+ of dead space.

## Fix

Scoped entirely to the mobile media query and to the channels tab via `:has(.channels-tab-content)`:

- Anchor the height chain to `%` (`html, body, #root` and `.app` when the chat tab is active) — reliable in standalone PWAs, unlike `dvh`.
- Let `.channels-tab-content` **flex to fill** `.app-main`'s content box (`flex: 1 1 auto; min-height: 0`) instead of recomputing from `dvh`. `.app-main`'s padding already reserves the header + bottom safe-area.
- Suppress `.app-main::after` for the chat tab only.

Naturally-scrolling tabs and desktop are untouched.

## Testing

- CSS brace balance verified; rules scoped to `@media (max-width: 768px)`.
- ⚠️ The bug only manifests in iOS-standalone (safe-area/`dvh` behavior), which can't be reproduced off-device. **Needs on-device verification:** rebuild → reinstall/hard-refresh the PWA → open Channels in portrait; input should sit at the bottom with no void below.

`:has()` is supported on iOS Safari 15.4+ (2022), well within PWA target range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)