### PR TITLE
fix(rate-limit): exempt RFC 1918 / loopback IPs from API rate limiter

### DIFF
--- a/src/server/middleware/rateLimiters.test.ts
+++ b/src/server/middleware/rateLimiters.test.ts
@@ -125,20 +125,37 @@ describe('Rate Limiters Middleware', () => {
   });
 
   describe('When rate limits are set to a small positive value', () => {
-    it('should enforce API rate limit after max requests exceeded', async () => {
+    it('should enforce API rate limit after max requests exceeded from a public IP', async () => {
       const app = await createTestApp({
         rateLimitApi: 2,
         rateLimitApiProvided: true,
       });
+      // Enable trust proxy so X-Forwarded-For is honoured, bypassing the private-IP exemption
+      app.set('trust proxy', 1);
+
+      const makeRequest = () => request(app).get('/api').set('X-Forwarded-For', '1.2.3.4');
 
       // First 2 should succeed
-      expect((await request(app).get('/api')).status).toBe(200);
-      expect((await request(app).get('/api')).status).toBe(200);
+      expect((await makeRequest()).status).toBe(200);
+      expect((await makeRequest()).status).toBe(200);
 
       // Third should be rate-limited
-      const res = await request(app).get('/api');
+      const res = await makeRequest();
       expect(res.status).toBe(429);
       expect(res.body.error).toContain('Too many requests');
+    });
+
+    it('should not throttle private/local network IPs regardless of limit', async () => {
+      const app = await createTestApp({
+        rateLimitApi: 2, // very tight limit
+        rateLimitApiProvided: true,
+      });
+
+      // Supertest connects from 127.0.0.1 (loopback) — should always pass
+      for (let i = 0; i < 5; i++) {
+        const res = await request(app).get('/api');
+        expect(res.status).toBe(200);
+      }
     });
 
     it('should enforce auth rate limit after max requests exceeded', async () => {
@@ -256,11 +273,16 @@ describe('Rate Limiters Middleware', () => {
         expect.stringContaining('unlimited (disabled)')
       );
 
-      // All three should show disabled
+      // API, Auth, and Messages should all show disabled
       const disabledLogs = infoCalls.filter((msg: string) =>
         msg.includes('unlimited (disabled)')
       );
       expect(disabledLogs).toHaveLength(3);
+
+      // Private-IP exemption line should always be logged
+      expect(infoCalls).toContainEqual(
+        expect.stringContaining('private/local network addresses: always exempt')
+      );
     });
 
     it('should log normal values when rate limit is a positive number', async () => {
@@ -299,6 +321,85 @@ describe('Rate Limiters Middleware', () => {
       expect(infoCalls).toContainEqual(
         expect.stringContaining('30 messages per minute')
       );
+    });
+  });
+
+  describe('isPrivateNetworkIp', () => {
+    async function getIsPrivateNetworkIp() {
+      vi.resetModules();
+      vi.doMock('../config/environment.js', () => ({
+        getEnvironmentConfig: () => ({
+          rateLimitApi: 10000,
+          rateLimitApiProvided: false,
+          rateLimitAuth: 100,
+          rateLimitAuthProvided: false,
+          rateLimitMessages: 100,
+          rateLimitMessagesProvided: false,
+          isProduction: false,
+          trustProxyProvided: true,
+        }),
+      }));
+      vi.doMock('../../utils/logger.js', () => ({
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      }));
+      const { isPrivateNetworkIp } = await import('./rateLimiters.js');
+      return isPrivateNetworkIp;
+    }
+
+    it('should return true for IPv4 loopback', async () => {
+      const fn = await getIsPrivateNetworkIp();
+      expect(fn('127.0.0.1')).toBe(true);
+    });
+
+    it('should return true for 10.x.x.x', async () => {
+      const fn = await getIsPrivateNetworkIp();
+      expect(fn('10.0.0.1')).toBe(true);
+      expect(fn('10.255.255.255')).toBe(true);
+    });
+
+    it('should return true for 192.168.x.x', async () => {
+      const fn = await getIsPrivateNetworkIp();
+      expect(fn('192.168.1.100')).toBe(true);
+      expect(fn('192.168.0.1')).toBe(true);
+    });
+
+    it('should return true for 172.16-31.x.x', async () => {
+      const fn = await getIsPrivateNetworkIp();
+      expect(fn('172.16.0.1')).toBe(true);
+      expect(fn('172.31.255.255')).toBe(true);
+      expect(fn('172.20.10.5')).toBe(true);
+    });
+
+    it('should return false for public IPv4 addresses', async () => {
+      const fn = await getIsPrivateNetworkIp();
+      expect(fn('1.2.3.4')).toBe(false);
+      expect(fn('8.8.8.8')).toBe(false);
+      expect(fn('172.15.0.1')).toBe(false);  // just outside 172.16/12
+      expect(fn('172.32.0.1')).toBe(false);  // just outside 172.16/12
+    });
+
+    it('should return true for IPv6 loopback (::1)', async () => {
+      const fn = await getIsPrivateNetworkIp();
+      expect(fn('::1')).toBe(true);
+    });
+
+    it('should return true for IPv6 ULA (fc/fd prefix)', async () => {
+      const fn = await getIsPrivateNetworkIp();
+      expect(fn('fc00::1')).toBe(true);
+      expect(fn('fd12:3456:789a::1')).toBe(true);
+    });
+
+    it('should return true for IPv4-mapped private addresses (::ffff:192.168.x.x)', async () => {
+      const fn = await getIsPrivateNetworkIp();
+      expect(fn('::ffff:192.168.1.1')).toBe(true);
+      expect(fn('::ffff:10.0.0.1')).toBe(true);
+      expect(fn('::ffff:127.0.0.1')).toBe(true);
+    });
+
+    it('should return false for IPv4-mapped public addresses', async () => {
+      const fn = await getIsPrivateNetworkIp();
+      expect(fn('::ffff:1.2.3.4')).toBe(false);
+      expect(fn('::ffff:8.8.8.8')).toBe(false);
     });
   });
 

--- a/src/server/middleware/rateLimiters.ts
+++ b/src/server/middleware/rateLimiters.ts
@@ -31,6 +31,22 @@ export function normalizeRateLimitKey(req: { ip?: string }): string {
   return ipKeyGenerator(normalized);
 }
 
+// RFC 1918 private network ranges and loopback — never routable from the public
+// internet, so rate limiting them provides no security benefit for local deployments.
+const PRIVATE_IP_PATTERNS = [
+  /^127\./,                             // IPv4 loopback (127.0.0.0/8)
+  /^10\./,                              // 10.0.0.0/8
+  /^192\.168\./,                        // 192.168.0.0/16
+  /^172\.(1[6-9]|2[0-9]|3[01])\./,     // 172.16.0.0/12
+  /^::1$/,                              // IPv6 loopback
+  /^f[cd]/i,                            // IPv6 ULA (fc00::/7)
+];
+
+export function isPrivateNetworkIp(ip: string): boolean {
+  const normalized = ip.startsWith(IPV4_MAPPED_PREFIX) ? ip.slice(IPV4_MAPPED_PREFIX.length) : ip;
+  return PRIVATE_IP_PATTERNS.some(pattern => pattern.test(normalized));
+}
+
 // When TRUST_PROXY is set, we need to skip express-rate-limit's validation
 // We're relying on Express's trust proxy configuration which is set at the app level
 const rateLimitConfig = {
@@ -45,6 +61,7 @@ const rateLimitConfig = {
 // Log rate limit configuration at startup
 logger.info('⏱️  Rate limit configuration:');
 logger.info(`   - API: ${env.rateLimitApi === 0 ? 'unlimited (disabled)' : `${env.rateLimitApi} requests per 15 minutes`}${env.rateLimitApiProvided ? ' (custom)' : ' (default)'}`);
+logger.info('   - API private/local network addresses: always exempt (RFC 1918 + loopback)');
 logger.info(`   - Auth: ${env.rateLimitAuth === 0 ? 'unlimited (disabled)' : `${env.rateLimitAuth} attempts per 15 minutes`}${env.rateLimitAuthProvided ? ' (custom)' : ' (default)'}`);
 logger.info(`   - Messages: ${env.rateLimitMessages === 0 ? 'unlimited (disabled)' : `${env.rateLimitMessages} messages per minute`}${env.rateLimitMessagesProvided ? ' (custom)' : ' (default)'}`);
 
@@ -57,10 +74,14 @@ if (!env.trustProxyProvided && env.isProduction) {
 // General API rate limiting
 // Configurable via RATE_LIMIT_API environment variable
 // Default: 1000 requests per 15 minutes (~1 req/sec) in production, 10000 in development
+// Private network IPs (RFC 1918 + loopback) are always exempt — a single active
+// MeshMonitor browser session generates ~900+ API requests per 15 minutes via its
+// polling hooks, and local-network deployments have no security need for rate limiting.
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: env.rateLimitApi,
   message: 'Too many requests from this IP, please try again later',
+  skip: (req) => env.rateLimitApi === 0 || isPrivateNetworkIp(req.ip ?? ''),
   handler: (req, res) => {
     const ip = req.ip || 'unknown';
     logger.warn(`🚫 Rate limit exceeded for API - IP: ${ip}, Path: ${req.path}`);
@@ -70,7 +91,6 @@ export const apiLimiter = rateLimit({
     });
   },
   ...rateLimitConfig,
-  ...(env.rateLimitApi === 0 ? { skip: () => true } : {}),
 });
 
 // Strict rate limiting for authentication endpoints


### PR DESCRIPTION
## Summary

Fixes #3308 — users on local networks were hitting HTTP 429 "Too many requests from this IP" errors during normal use, and the MQTT Bridge proxy was stopping as a side-effect.

**Root cause:** The production default of 1,000 API requests per 15 minutes is far too low for MeshMonitor's own polling behavior. A single active browser session generates approximately:

| Hook | Interval | req/15min |
|------|----------|-----------|
| Dashboard (8 queries) | 15 s | ~480 |
| Status polling | 5 s | 180 |
| Unread counts | 10 s | 90 |
| usePoll (WS connected) | 30 s | 30 |
| Health, telemetry, packets… | 30–60 s | ~150 |
| **Total (one tab)** | | **~930** |

A single tab with WebSocket connected is already near the limit. Any brief WebSocket disconnect (which switches `usePoll` to a 5-second fallback) or opening a second tab pushes users over.

**Fix:** Add `isPrivateNetworkIp()` that matches RFC 1918 ranges (10/8, 172.16/12, 192.168/16), loopback (127.x, ::1), IPv6 ULA (fc00::/7), and their IPv4-mapped equivalents. The `apiLimiter` now skips these addresses entirely via the `skip` option.

These IPs can never originate from the public internet, so rate limiting them provides no security benefit for the typical self-hosted local-network deployment. Public IPs (cloud deployments with `TRUST_PROXY` configured) still have the existing 1,000 req/15min protection, and `RATE_LIMIT_API=0` continues to disable the limiter entirely.

## Test plan

- [x] All 26 `rateLimiters.test.ts` tests pass (including 9 new `isPrivateNetworkIp` unit tests and an updated enforcement test that uses a public IP via `X-Forwarded-For`)
- [x] Enforcement test updated to set `trust proxy` + `X-Forwarded-For: 1.2.3.4` so rate limiting is still verified for public-IP traffic
- [x] New test confirms private-IP requests are never throttled regardless of the configured limit
- [x] Full Vitest suite: 26 new/updated tests pass; the 3 pre-existing unrelated failures (`mqttBrokerManager` protobuf encode issue) are unchanged

https://claude.ai/code/session_01GsCJ4sKCmn5C4LiJqzLYNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsCJ4sKCmn5C4LiJqzLYNQ)_