### PR TITLE
feat(automation): airtime cutoff to pause automations when mesh is busy

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4538,6 +4538,16 @@
 
   "admin.back_to_dashboard": "← Back to Dashboard",
 
+  "automation.airtime_cutoff.title": "Cutoff Airtime Utilization Threshold",
+  "automation.airtime_cutoff.description": "Pauses all automations (auto-traceroute, auto-announce, timers, etc.) whenever the connected node's Channel Utilization rises above this threshold, so bots stop adding traffic while the mesh is busy with real activity. Automations resume automatically once utilization drops back below the threshold. Set to 0 to disable.",
+  "automation.airtime_cutoff.threshold_label": "Cutoff Airtime Utilization Threshold (%)",
+  "automation.airtime_cutoff.threshold_hint": "Channel Utilization percent above which automations pause. 0 disables; default 30.",
+  "automation.airtime_cutoff.status_disabled": "Airtime cutoff is disabled (threshold 0).",
+  "automation.airtime_cutoff.status_unknown": "Waiting for the connected node to report Channel Utilization…",
+  "automation.airtime_cutoff.status_paused": "⏸ Automations paused — Channel Utilization {{util}}% exceeds {{threshold}}%.",
+  "automation.airtime_cutoff.status_active": "✓ Automations active — Channel Utilization {{util}}% is under {{threshold}}%.",
+  "automation.airtime_cutoff.saved": "Airtime cutoff settings saved",
+  "automation.airtime_cutoff.save_error": "Failed to save settings",
   "automation.auto_heap.title": "Auto Heap Management",
   "automation.auto_heap.saved": "Auto Heap Management settings saved",
   "automation.auto_heap.save_error": "Failed to save settings",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import AutoTimeSyncSection from './components/AutoTimeSyncSection';
 import AutoPingSection from './components/AutoPingSection';
 import AutoFavoriteSection from './components/AutoFavoriteSection';
 import AutoHeapManagementSection from './components/AutoHeapManagementSection';
+import AirtimeCutoffSection from './components/AirtimeCutoffSection';
 import IgnoredNodesSection from './components/IgnoredNodesSection';
 import SectionNav from './components/SectionNav';
 import { ToastProvider, useToast } from './components/ToastContainer';
@@ -4987,6 +4988,7 @@ function App() {
           <div className="settings-tab">
             <SectionNav
               items={[
+                { id: 'airtime-cutoff', label: t('automation.airtime_cutoff.title', 'Cutoff Airtime Utilization Threshold') },
                 { id: 'auto-welcome', label: t('automation.welcome.title', 'Auto Welcome') },
                 { id: 'auto-favorite', label: t('automation.auto_favorite.title', 'Auto Favorite') },
                 { id: 'auto-traceroute', label: t('automation.traceroute.title', 'Auto Traceroute') },
@@ -5005,6 +5007,9 @@ function App() {
               ]}
             />
             <div className="settings-content">
+              <div id="airtime-cutoff">
+                <AirtimeCutoffSection baseUrl={baseUrl} />
+              </div>
               <div id="auto-welcome">
                 <AutoWelcomeSection
                   enabled={autoWelcomeEnabled}

--- a/src/components/AirtimeCutoffSection.tsx
+++ b/src/components/AirtimeCutoffSection.tsx
@@ -1,0 +1,199 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useCsrfFetch } from '../hooks/useCsrfFetch';
+import { useSourceQuery } from '../hooks/useSourceQuery';
+import { useSaveBar } from '../hooks/useSaveBar';
+import { useToast } from './ToastContainer';
+
+interface AirtimeCutoffSectionProps {
+  baseUrl: string;
+}
+
+interface AirtimeStatus {
+  threshold: number;
+  channelUtilization: number | null;
+  gated: boolean;
+}
+
+const DEFAULT_THRESHOLD = 30;
+const STATUS_POLL_MS = 15000;
+
+/**
+ * "Cutoff Airtime Utilization Threshold" — pauses all transmitting automations
+ * (auto-traceroute, auto-announce, timers, etc.) whenever the connected node's
+ * self-reported Channel Utilization exceeds the configured threshold, so bots
+ * back off while real traffic is heavy. 0 disables the feature.
+ */
+const AirtimeCutoffSection: React.FC<AirtimeCutoffSectionProps> = ({ baseUrl }) => {
+  const { t } = useTranslation();
+  const csrfFetch = useCsrfFetch();
+  const sourceQuery = useSourceQuery();
+  const { showToast } = useToast();
+
+  const [localThreshold, setLocalThreshold] = useState(DEFAULT_THRESHOLD);
+  const [initialThreshold, setInitialThreshold] = useState<number | null>(null);
+  const [hasChanges, setHasChanges] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [status, setStatus] = useState<AirtimeStatus | null>(null);
+
+  const fetchSettings = useCallback(async () => {
+    try {
+      const res = await csrfFetch(`${baseUrl}/api/settings${sourceQuery}`);
+      if (res.ok) {
+        const settings = await res.json();
+        const raw = parseInt(settings.automationAirtimeCutoffThreshold ?? String(DEFAULT_THRESHOLD), 10);
+        const threshold = Number.isFinite(raw) && raw >= 0 && raw <= 100 ? raw : DEFAULT_THRESHOLD;
+        setLocalThreshold(threshold);
+        setInitialThreshold(threshold);
+      }
+    } catch (error) {
+      console.error('Failed to fetch airtime cutoff settings:', error);
+    }
+  }, [baseUrl, csrfFetch, sourceQuery]);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await csrfFetch(`${baseUrl}/api/automation/airtime-status${sourceQuery}`);
+      if (res.ok) {
+        setStatus(await res.json());
+      }
+    } catch (error) {
+      console.error('Failed to fetch airtime cutoff status:', error);
+    }
+  }, [baseUrl, csrfFetch, sourceQuery]);
+
+  useEffect(() => {
+    fetchSettings();
+    fetchStatus();
+  }, [fetchSettings, fetchStatus]);
+
+  // Poll the live status so the banner reflects current utilization.
+  useEffect(() => {
+    const id = setInterval(fetchStatus, STATUS_POLL_MS);
+    return () => clearInterval(id);
+  }, [fetchStatus]);
+
+  useEffect(() => {
+    if (initialThreshold === null) return;
+    setHasChanges(localThreshold !== initialThreshold);
+  }, [localThreshold, initialThreshold]);
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true);
+    try {
+      const response = await csrfFetch(`${baseUrl}/api/settings${sourceQuery}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ automationAirtimeCutoffThreshold: String(localThreshold) }),
+      });
+      if (response.ok) {
+        setInitialThreshold(localThreshold);
+        setHasChanges(false);
+        showToast(t('automation.airtime_cutoff.saved', 'Airtime cutoff settings saved'), 'success');
+        fetchStatus();
+      } else {
+        showToast(t('automation.airtime_cutoff.save_error', 'Failed to save settings'), 'error');
+      }
+    } catch {
+      showToast(t('automation.airtime_cutoff.save_error', 'Failed to save settings'), 'error');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [baseUrl, csrfFetch, sourceQuery, localThreshold, showToast, t, fetchStatus]);
+
+  const resetChanges = useCallback(() => {
+    if (initialThreshold !== null) setLocalThreshold(initialThreshold);
+  }, [initialThreshold]);
+
+  useSaveBar({
+    id: 'airtime-cutoff',
+    sectionName: t('automation.airtime_cutoff.title', 'Cutoff Airtime Utilization Threshold'),
+    hasChanges,
+    isSaving,
+    onSave: handleSave,
+    onDismiss: resetChanges,
+  });
+
+  const disabled = localThreshold === 0;
+  const util = status?.channelUtilization;
+  const gated = status?.gated ?? false;
+
+  // Banner colour: red when paused, green when active, neutral when disabled/unknown.
+  const bannerColor = disabled
+    ? 'var(--ctp-overlay0)'
+    : gated
+      ? 'var(--ctp-red)'
+      : 'var(--ctp-green)';
+
+  return (
+    <>
+      <div className="automation-section-header" style={{
+        display: 'flex',
+        alignItems: 'center',
+        marginBottom: '1.5rem',
+        padding: '1rem 1.25rem',
+        background: 'var(--ctp-surface1)',
+        border: '1px solid var(--ctp-surface2)',
+        borderRadius: '8px'
+      }}>
+        <h2 style={{ margin: 0 }}>
+          {t('automation.airtime_cutoff.title', 'Cutoff Airtime Utilization Threshold')}
+        </h2>
+      </div>
+
+      <div className="settings-section">
+        <p style={{ marginLeft: '0.25rem', marginBottom: '1rem', color: 'var(--ctp-subtext1)', fontSize: '13px', lineHeight: '1.5' }}>
+          {t('automation.airtime_cutoff.description',
+            'Pauses all automations (auto-traceroute, auto-announce, timers, etc.) whenever the connected node\'s Channel Utilization rises above this threshold, so bots stop adding traffic while the mesh is busy with real activity. Automations resume automatically once utilization drops back below the threshold. Set to 0 to disable.')}
+        </p>
+
+        {/* Live status banner */}
+        <div style={{
+          marginBottom: '1.25rem',
+          padding: '0.6rem 1rem',
+          background: 'var(--ctp-surface0)',
+          border: `1px solid ${bannerColor}`,
+          borderLeft: `4px solid ${bannerColor}`,
+          borderRadius: '6px',
+          color: bannerColor,
+          fontSize: '13px',
+          fontWeight: 500,
+        }}>
+          {disabled
+            ? t('automation.airtime_cutoff.status_disabled', 'Airtime cutoff is disabled (threshold 0).')
+            : util == null
+              ? t('automation.airtime_cutoff.status_unknown', 'Waiting for the connected node to report Channel Utilization…')
+              : gated
+                ? t('automation.airtime_cutoff.status_paused', '⏸ Automations paused — Channel Utilization {{util}}% exceeds {{threshold}}%.', { util, threshold: status?.threshold ?? localThreshold })
+                : t('automation.airtime_cutoff.status_active', '✓ Automations active — Channel Utilization {{util}}% is under {{threshold}}%.', { util, threshold: status?.threshold ?? localThreshold })}
+        </div>
+
+        {/* Threshold input */}
+        <div className="setting-item">
+          <label htmlFor="airtimeCutoffThreshold">
+            {t('automation.airtime_cutoff.threshold_label', 'Cutoff Airtime Utilization Threshold (%)')}
+            <span className="setting-description">
+              {t('automation.airtime_cutoff.threshold_hint',
+                'Channel Utilization percent above which automations pause. 0 disables; default 30.')}
+            </span>
+          </label>
+          <input
+            id="airtimeCutoffThreshold"
+            type="number"
+            min={0}
+            max={100}
+            value={localThreshold}
+            onChange={(e) => {
+              const raw = parseInt(e.target.value, 10);
+              const clamped = Number.isNaN(raw) ? 0 : Math.max(0, Math.min(100, raw));
+              setLocalThreshold(clamped);
+            }}
+            className="setting-input"
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default AirtimeCutoffSection;

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -37,6 +37,7 @@ export const VALID_SETTINGS_KEYS = [
   'autoAckTestMessages',
   'autoAckCooldownSeconds',
   'customTapbackEmojis',
+  'automationAirtimeCutoffThreshold',
   'autoAnnounceEnabled',
   'autoAnnounceIntervalHours',
   'autoAnnounceMessage',
@@ -229,6 +230,8 @@ export const PER_SOURCE_SETTINGS_KEYS = [
   'autoAckRegex',
   'autoAckSkipIncompleteNodes',
   'autoAckUseDM',
+  // Automation airtime cutoff (pauses all automations above channel-utilization threshold)
+  'automationAirtimeCutoffThreshold',
   // Auto-announce
   'autoAnnounceChannelIndexes',
   'autoAnnounceEnabled',

--- a/src/server/meshtasticManager.airtimeCutoff.test.ts
+++ b/src/server/meshtasticManager.airtimeCutoff.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the airtime-cutoff automation gate on MeshtasticManager:
+ * - setAutomationAirtimeCutoffThreshold range validation
+ * - getAirtimeCutoffStatus / isAutomationAirtimeGated reflect the cached
+ *   local Channel Utilization vs. the configured threshold
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetSetting = vi.fn();
+const mockSetSetting = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    getSetting: mockGetSetting,
+    setSetting: mockSetSetting,
+    settings: {
+      getSetting: mockGetSetting,
+      setSetting: mockSetSetting,
+      getSettingForSource: vi.fn((_sourceId: string, key: string) => mockGetSetting(key)),
+      setSettingForSource: vi.fn((_sourceId: string, key: string, value: string) => mockSetSetting(key, value)),
+    },
+    nodes: {
+      getAllNodes: vi.fn().mockResolvedValue([]),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+    },
+    telemetry: { insertTelemetry: vi.fn().mockResolvedValue(undefined) },
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('MeshtasticManager - airtime cutoff gate', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module = await import('./meshtasticManager.js');
+    manager = module.default;
+    // Reset gate-related state between tests
+    manager.setAutomationAirtimeCutoffThreshold(30);
+    manager.localChannelUtilization = null;
+    manager.lastAirtimeGateLogTime = 0;
+  });
+
+  describe('setAutomationAirtimeCutoffThreshold', () => {
+    it('accepts values within 0-100', () => {
+      manager.setAutomationAirtimeCutoffThreshold(45);
+      expect(manager.getAirtimeCutoffStatus().threshold).toBe(45);
+      manager.setAutomationAirtimeCutoffThreshold(0);
+      expect(manager.getAirtimeCutoffStatus().threshold).toBe(0);
+      manager.setAutomationAirtimeCutoffThreshold(100);
+      expect(manager.getAirtimeCutoffStatus().threshold).toBe(100);
+    });
+
+    it('rejects out-of-range values', () => {
+      expect(() => manager.setAutomationAirtimeCutoffThreshold(-1)).toThrow();
+      expect(() => manager.setAutomationAirtimeCutoffThreshold(101)).toThrow();
+      expect(() => manager.setAutomationAirtimeCutoffThreshold(NaN)).toThrow();
+    });
+  });
+
+  describe('isAutomationAirtimeGated / getAirtimeCutoffStatus', () => {
+    it('does not gate before any telemetry is seen', () => {
+      manager.setAutomationAirtimeCutoffThreshold(30);
+      expect(manager.localChannelUtilization).toBeNull();
+      expect(manager.isAutomationAirtimeGated()).toBe(false);
+      expect(manager.getAirtimeCutoffStatus()).toEqual({ threshold: 30, channelUtilization: null, gated: false });
+    });
+
+    it('gates when cached utilization exceeds the threshold', () => {
+      manager.setAutomationAirtimeCutoffThreshold(30);
+      manager.localChannelUtilization = 42;
+      expect(manager.isAutomationAirtimeGated()).toBe(true);
+      expect(manager.getAirtimeCutoffStatus()).toEqual({ threshold: 30, channelUtilization: 42, gated: true });
+    });
+
+    it('does not gate when utilization is at or below the threshold', () => {
+      manager.setAutomationAirtimeCutoffThreshold(30);
+      manager.localChannelUtilization = 30;
+      expect(manager.isAutomationAirtimeGated()).toBe(false);
+      manager.localChannelUtilization = 12;
+      expect(manager.isAutomationAirtimeGated()).toBe(false);
+    });
+
+    it('never gates when the feature is disabled (threshold 0), even at high utilization', () => {
+      manager.setAutomationAirtimeCutoffThreshold(0);
+      manager.localChannelUtilization = 99;
+      expect(manager.isAutomationAirtimeGated()).toBe(false);
+      expect(manager.getAirtimeCutoffStatus().gated).toBe(false);
+    });
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -23,6 +23,7 @@ import { autoDeleteByDistanceService } from './services/autoDeleteByDistanceServ
 import { MessageQueueService } from './messageQueueService.js';
 import { normalizeTriggerPatterns, normalizeTriggerChannels } from '../utils/autoResponderUtils.js';
 import { isWithinTimeWindow } from './utils/timeWindow.js';
+import { shouldGateAutomations, DEFAULT_AIRTIME_CUTOFF_THRESHOLD } from './utils/airtimeCutoff.js';
 import { canonicalMessageTime } from './utils/messageTime.js';
 import { isNodeComplete } from '../utils/nodeHelpers.js';
 import { getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
@@ -487,6 +488,14 @@ class MeshtasticManager implements ISourceManager {
 
   private tracerouteIntervalMinutes: number = 0;
   private lastTracerouteSentTime: number = 0;
+  // Airtime cutoff: pause all transmitting automations when the local node's
+  // Channel Utilization exceeds this percent. 0 disables the feature.
+  private automationAirtimeCutoffThreshold: number = DEFAULT_AIRTIME_CUTOFF_THRESHOLD;
+  // Most recent Channel Utilization (%) self-reported by the local node, or null
+  // if no device telemetry has been seen yet.
+  private localChannelUtilization: number | null = null;
+  // Throttle the "automations gated" log so a busy mesh doesn't spam.
+  private lastAirtimeGateLogTime: number = 0;
   private localStatsInterval: NodeJS.Timeout | null = null;
   private timeOffsetSamples: number[] = [];
   private timeOffsetInterval: NodeJS.Timeout | null = null;
@@ -1482,6 +1491,10 @@ class MeshtasticManager implements ISourceManager {
         setTimeout(() => this.startTimerScheduler().catch(e =>
           logger.error('❌ Error starting timer scheduler:', e)), S * 7);
 
+        // Load the airtime cutoff threshold (local value, no outbound traffic)
+        this.loadAirtimeCutoffThreshold().catch(e =>
+          logger.error('❌ Error loading airtime cutoff threshold:', e));
+
         // Start geofence engine (no outbound traffic, safe immediately)
         this.initGeofenceEngine().catch(e =>
           logger.error('❌ Error initializing geofence engine:', e));
@@ -1814,6 +1827,11 @@ class MeshtasticManager implements ISourceManager {
         }
       }
 
+      // Airtime cutoff: skip auto-traceroute while the mesh is congested
+      if (this.isAutomationAirtimeGated()) {
+        return;
+      }
+
       if (this.isConnected && this.localNodeInfo) {
         try {
           // Enforce minimum interval between traceroute sends (Meshtastic firmware rate limit)
@@ -1927,6 +1945,77 @@ class MeshtasticManager implements ISourceManager {
   }
 
   /**
+   * Set the airtime cutoff threshold (percent Channel Utilization).
+   * When the local node's ChUtil exceeds this value, all transmitting
+   * automations are paused. 0 disables the feature.
+   * @param threshold Cutoff percent (0-100; 0 = disabled)
+   */
+  setAutomationAirtimeCutoffThreshold(threshold: number): void {
+    if (!Number.isFinite(threshold) || threshold < 0 || threshold > 100) {
+      throw new Error('Airtime cutoff threshold must be between 0 and 100 (0 = disabled)');
+    }
+    this.automationAirtimeCutoffThreshold = threshold;
+    if (threshold === 0) {
+      logger.debug('📡 Airtime cutoff disabled (threshold 0)');
+    } else {
+      logger.debug(`📡 Airtime cutoff threshold set to ${threshold}% Channel Utilization`);
+    }
+  }
+
+  /**
+   * Load the persisted airtime cutoff threshold for this source from settings.
+   * Falls back to the default when unset or invalid.
+   */
+  private async loadAirtimeCutoffThreshold(): Promise<void> {
+    try {
+      const saved = await databaseService.settings.getSettingForSource(this.sourceId, 'automationAirtimeCutoffThreshold');
+      const parsed = saved != null ? parseInt(saved, 10) : NaN;
+      this.automationAirtimeCutoffThreshold =
+        Number.isFinite(parsed) && parsed >= 0 && parsed <= 100 ? parsed : DEFAULT_AIRTIME_CUTOFF_THRESHOLD;
+      logger.debug(
+        `📡 Airtime cutoff threshold for ${this.sourceId}: ${this.automationAirtimeCutoffThreshold}%` +
+          (this.automationAirtimeCutoffThreshold === 0 ? ' (disabled)' : '')
+      );
+    } catch (error) {
+      logger.error(`Failed to load airtime cutoff threshold for ${this.sourceId}:`, error);
+      this.automationAirtimeCutoffThreshold = DEFAULT_AIRTIME_CUTOFF_THRESHOLD;
+    }
+  }
+
+  /**
+   * Whether automations are currently gated (paused) because the local node's
+   * self-reported Channel Utilization exceeds the configured cutoff threshold.
+   * Logs (throttled) the first time gating engages. Fail-open: never gates when
+   * the feature is disabled or no telemetry has been seen yet.
+   */
+  isAutomationAirtimeGated(): boolean {
+    const gated = shouldGateAutomations(this.localChannelUtilization, this.automationAirtimeCutoffThreshold);
+    if (gated) {
+      const now = Date.now();
+      if (now - this.lastAirtimeGateLogTime > 60000) {
+        this.lastAirtimeGateLogTime = now;
+        logger.info(
+          `⏸️  Automations paused on ${this.sourceId}: Channel Utilization ${this.localChannelUtilization}% exceeds cutoff ${this.automationAirtimeCutoffThreshold}%`
+        );
+      }
+    }
+    return gated;
+  }
+
+  /**
+   * Current airtime-cutoff status for this source: the configured threshold,
+   * the local node's most recent Channel Utilization (or null if unknown), and
+   * whether automations are currently gated. Used by the Automation page banner.
+   */
+  getAirtimeCutoffStatus(): { threshold: number; channelUtilization: number | null; gated: boolean } {
+    return {
+      threshold: this.automationAirtimeCutoffThreshold,
+      channelUtilization: this.localChannelUtilization,
+      gated: shouldGateAutomations(this.localChannelUtilization, this.automationAirtimeCutoffThreshold),
+    };
+  }
+
+  /**
    * Set the remote admin scanner interval
    * @param minutes Interval in minutes (0 = disabled, 1-60)
    */
@@ -1984,6 +2073,11 @@ class MeshtasticManager implements ISourceManager {
           logger.debug(`🔑 Remote admin scanner: Skipping - outside schedule window (${start}-${end})`);
           return;
         }
+      }
+
+      // Airtime cutoff: skip remote admin scanning while the mesh is congested
+      if (this.isAutomationAirtimeGated()) {
+        return;
       }
 
       if (this.isConnected && this.localNodeInfo) {
@@ -2072,6 +2166,11 @@ class MeshtasticManager implements ISourceManager {
   private async syncNextNodeTime(): Promise<void> {
     if (!this.localNodeInfo) {
       logger.debug('🕐 Time sync: No local node info');
+      return;
+    }
+
+    // Airtime cutoff: skip time sync while the mesh is congested
+    if (this.isAutomationAirtimeGated()) {
       return;
     }
 
@@ -2199,6 +2298,11 @@ class MeshtasticManager implements ISourceManager {
   private async processKeyRepairs(): Promise<void> {
     if (this.rebootMergeInProgress) {
       logger.debug('🔐 Key repair: skipping - reboot merge in progress');
+      return;
+    }
+
+    // Airtime cutoff: skip key repair (NodeInfo exchanges) while the mesh is congested
+    if (this.isAutomationAirtimeGated()) {
       return;
     }
 
@@ -2539,7 +2643,7 @@ class MeshtasticManager implements ISourceManager {
           logger.debug(`📢 Cron job triggered (connected: ${this.isConnected})`);
           if (this.isConnected) {
             try {
-              await this.sendAutoAnnouncement();
+              await this.sendAutoAnnouncement(true);
             } catch (error) {
               logger.error('❌ Error in cron auto-announce:', error);
             }
@@ -2564,7 +2668,7 @@ class MeshtasticManager implements ISourceManager {
         logger.debug(`📢 Announce interval triggered (connected: ${this.isConnected})`);
         if (this.isConnected) {
           try {
-            await this.sendAutoAnnouncement();
+            await this.sendAutoAnnouncement(true);
           } catch (error) {
             logger.error('❌ Error in auto-announce:', error);
           }
@@ -2595,7 +2699,7 @@ class MeshtasticManager implements ISourceManager {
           setTimeout(async () => {
             if (this.isConnected) {
               try {
-                await this.sendAutoAnnouncement();
+                await this.sendAutoAnnouncement(true);
               } catch (error) {
                 logger.error('❌ Error in startup announcement:', error);
               }
@@ -2609,7 +2713,7 @@ class MeshtasticManager implements ISourceManager {
         setTimeout(async () => {
           if (this.isConnected) {
             try {
-              await this.sendAutoAnnouncement();
+              await this.sendAutoAnnouncement(true);
             } catch (error) {
               logger.error('❌ Error in startup announcement:', error);
             }
@@ -2702,6 +2806,10 @@ class MeshtasticManager implements ISourceManager {
       // Schedule the cron job
       const job = scheduleCron(trigger.cronExpression, async () => {
         logger.info(`⏱️ Timer "${trigger.name}" triggered (cron: ${trigger.cronExpression})`);
+        // Airtime cutoff: skip timer automations while the mesh is congested
+        if (this.isAutomationAirtimeGated()) {
+          return;
+        }
         const responseType = trigger.responseType || 'script'; // Default to script for backward compatibility
         if (responseType === 'text' && trigger.response?.trim()) {
           await this.executeTimerTextMessage(trigger.id, trigger.name, trigger.response, trigger.channel ?? 0);
@@ -2928,6 +3036,11 @@ class MeshtasticManager implements ISourceManager {
     eventType: 'entry' | 'exit' | 'while_inside'
   ): Promise<void> {
     try {
+      // Airtime cutoff: skip geofence automations while the mesh is congested
+      if (this.isAutomationAirtimeGated()) {
+        return;
+      }
+
       if (trigger.responseType === 'text' && trigger.response?.trim()) {
         const expanded = await this.replaceGeofenceTokens(trigger.response, trigger, nodeNum, lat, lng, eventType);
         const truncated = this.truncateMessageForMeshtastic(expanded, 200);
@@ -5877,6 +5990,17 @@ class MeshtasticManager implements ISourceManager {
         nodeData.channelUtilization = deviceMetrics.channelUtilization;
         nodeData.airUtilTx = deviceMetrics.airUtilTx;
 
+        // Airtime cutoff: cache the local node's Channel Utilization so the
+        // automation gate can consult it cheaply (no per-fire DB read).
+        if (
+          fromNum === this.localNodeInfo?.nodeNum &&
+          deviceMetrics.channelUtilization !== undefined &&
+          deviceMetrics.channelUtilization !== null &&
+          !isNaN(deviceMetrics.channelUtilization)
+        ) {
+          this.localChannelUtilization = deviceMetrics.channelUtilization;
+        }
+
         // Save all telemetry values from actual TELEMETRY_APP packets (no deduplication)
         if (deviceMetrics.batteryLevel !== undefined && deviceMetrics.batteryLevel !== null && !isNaN(deviceMetrics.batteryLevel)) {
           await databaseService.telemetry.insertTelemetry({
@@ -8564,6 +8688,11 @@ class MeshtasticManager implements ISourceManager {
         return;
       }
 
+      // Airtime cutoff: skip while the mesh is congested
+      if (this.isAutomationAirtimeGated()) {
+        return;
+      }
+
       // Check channel-specific settings
       const autoAckChannels = await settings.getSettingForSource(sourceId, 'autoAckChannels');
       const autoAckDirectMessages = await settings.getSettingForSource(sourceId, 'autoAckDirectMessages');
@@ -8865,6 +8994,11 @@ class MeshtasticManager implements ISourceManager {
     const autoPingEnabled = await databaseService.settings.getSettingForSource(this.sourceId, 'autoPingEnabled');
     if (autoPingEnabled !== 'true') {
       logger.debug('⏭️  Auto-ping command received but feature is disabled');
+      return false;
+    }
+
+    // Airtime cutoff: skip auto-ping while the mesh is congested
+    if (this.isAutomationAirtimeGated()) {
       return false;
     }
 
@@ -9223,6 +9357,11 @@ class MeshtasticManager implements ISourceManager {
 
       // Skip if auto-responder is disabled
       if (autoResponderEnabled !== 'true') {
+        return;
+      }
+
+      // Airtime cutoff: skip while the mesh is congested
+      if (this.isAutomationAirtimeGated()) {
         return;
       }
 
@@ -10160,6 +10299,11 @@ class MeshtasticManager implements ISourceManager {
         return;
       }
 
+      // Airtime cutoff: skip while the mesh is congested
+      if (this.isAutomationAirtimeGated()) {
+        return;
+      }
+
       // Skip messages from our own locally connected node
       const localNodeNum = await settings.getSetting(this.localNodeSettingKey('localNodeNum'));
       if (localNodeNum && parseInt(localNodeNum) === nodeNum) {
@@ -10691,9 +10835,16 @@ class MeshtasticManager implements ISourceManager {
     return result;
   }
 
-  async sendAutoAnnouncement(): Promise<void> {
+  async sendAutoAnnouncement(triggeredByAutomation = false): Promise<void> {
     if (this.rebootMergeInProgress) {
       logger.debug('📢 Skipping auto-announcement - reboot merge in progress');
+      return;
+    }
+
+    // Airtime cutoff: skip scheduled announcements while the mesh is congested.
+    // Manual "Send Announcement" requests (triggeredByAutomation = false) are
+    // always allowed through.
+    if (triggeredByAutomation && this.isAutomationAirtimeGated()) {
       return;
     }
 

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -125,6 +125,7 @@ export interface SettingsCallbacks {
   restartAnnounceScheduler?: (sourceId?: string | null) => void;
   restartTimerScheduler?: (sourceId?: string | null) => void;
   restartGeofenceEngine?: (sourceId?: string | null) => void;
+  setAutomationAirtimeCutoffThreshold?: (threshold: number, sourceId?: string | null) => void;
   handleAutoWelcomeEnabled?: () => number;
   invalidateHtmlCache?: () => void;
   restartAutoDeleteByDistanceService?: (intervalHours: number, sourceId?: string | null) => void;
@@ -272,6 +273,16 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
       const cooldown = parseInt(filteredSettings.lowBatteryCooldownHours, 10);
       if (isNaN(cooldown) || cooldown < 1 || cooldown > 720) {
         return res.status(400).json({ error: 'lowBatteryCooldownHours must be between 1 and 720 hours' });
+      }
+    }
+
+    // Validate airtime cutoff threshold (0 = disabled, 1-100 = percent Channel Utilization)
+    if ('automationAirtimeCutoffThreshold' in filteredSettings) {
+      const threshold = parseInt(filteredSettings.automationAirtimeCutoffThreshold, 10);
+      if (isNaN(threshold) || threshold < 0 || threshold > 100) {
+        return res
+          .status(400)
+          .json({ error: 'automationAirtimeCutoffThreshold must be between 0 and 100 (0 = disabled)' });
       }
     }
 
@@ -600,6 +611,12 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
       if ('geofenceTriggers' in filteredSettings) {
         callbacks.restartGeofenceEngine?.(sourceId);
       }
+      if ('automationAirtimeCutoffThreshold' in filteredSettings) {
+        const threshold = parseInt(filteredSettings.automationAirtimeCutoffThreshold, 10);
+        if (!isNaN(threshold)) {
+          callbacks.setAutomationAirtimeCutoffThreshold?.(threshold, sourceId);
+        }
+      }
 
       return res.json({ success: true });
     }
@@ -647,6 +664,13 @@ router.post('/', requirePermission('settings', 'write'), async (req: Request, re
       const interval = parseInt(filteredSettings.localStatsIntervalMinutes);
       if (!isNaN(interval) && interval >= 0 && interval <= 60) {
         callbacks.setLocalStatsInterval?.(interval);
+      }
+    }
+
+    if ('automationAirtimeCutoffThreshold' in filteredSettings) {
+      const threshold = parseInt(filteredSettings.automationAirtimeCutoffThreshold, 10);
+      if (!isNaN(threshold) && threshold >= 0 && threshold <= 100) {
+        callbacks.setAutomationAirtimeCutoffThreshold?.(threshold, sourceId);
       }
     }
 

--- a/src/server/server.settings-persistence.test.ts
+++ b/src/server/server.settings-persistence.test.ts
@@ -132,6 +132,7 @@ function validTestValue(key: string, suffix = ''): string {
     inactiveNodeCooldownHours: '24',
     lowBatteryCheckIntervalMinutes: '60',
     lowBatteryCooldownHours: '24',
+    automationAirtimeCutoffThreshold: '30',
     autoResponderTriggers: JSON.stringify([
       { id: '1', trigger: 'test', responseType: 'text', response: 'hi' },
     ]),

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1129,6 +1129,16 @@ setSettingsCallbacks({
       }
     }
   },
+  setAutomationAirtimeCutoffThreshold: (threshold: number, sourceId?: string | null) => {
+    if (sourceId) {
+      const mgr = sourceManagerRegistry.getManager(sourceId) as typeof meshtasticManager | undefined;
+      mgr?.setAutomationAirtimeCutoffThreshold(threshold);
+    } else {
+      for (const mgr of sourceManagerRegistry.getAllManagers() as (typeof meshtasticManager)[]) {
+        mgr.setAutomationAirtimeCutoffThreshold(threshold);
+      }
+    }
+  },
   handleAutoWelcomeEnabled: () => { databaseService.handleAutoWelcomeEnabledAsync().catch(() => {}); return 0; },
   invalidateHtmlCache,
   restartAutoDeleteByDistanceService: (intervalHours: number) =>
@@ -6788,6 +6798,20 @@ apiRouter.get('/announce/last', requirePermission('automation', 'read'), async (
   } catch (error) {
     logger.error('Error fetching last announcement time:', error);
     res.status(500).json({ error: 'Failed to fetch last announcement time' });
+  }
+});
+
+// Airtime cutoff status — drives the live banner on the Automation page.
+// Returns the configured threshold, the local node's current Channel
+// Utilization (null if no telemetry yet), and whether automations are paused.
+apiRouter.get('/automation/airtime-status', requirePermission('automation', 'read'), (req, res) => {
+  try {
+    const airtimeSourceId = (req.query.sourceId as string) || null;
+    const mgr = resolveSourceManager(airtimeSourceId);
+    res.json(mgr.getAirtimeCutoffStatus());
+  } catch (error) {
+    logger.error('Error fetching airtime cutoff status:', error);
+    res.status(500).json({ error: 'Failed to fetch airtime cutoff status' });
   }
 });
 

--- a/src/server/utils/airtimeCutoff.test.ts
+++ b/src/server/utils/airtimeCutoff.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { shouldGateAutomations, DEFAULT_AIRTIME_CUTOFF_THRESHOLD } from './airtimeCutoff.js';
+
+describe('shouldGateAutomations', () => {
+  it('gates when utilization exceeds the threshold', () => {
+    expect(shouldGateAutomations(45, 30)).toBe(true);
+  });
+
+  it('does not gate when utilization is below the threshold', () => {
+    expect(shouldGateAutomations(10, 30)).toBe(false);
+  });
+
+  it('does not gate when utilization exactly equals the threshold', () => {
+    // Strictly greater-than: at the threshold we still run.
+    expect(shouldGateAutomations(30, 30)).toBe(false);
+  });
+
+  it('uses the default threshold value of 30', () => {
+    expect(DEFAULT_AIRTIME_CUTOFF_THRESHOLD).toBe(30);
+    expect(shouldGateAutomations(31, DEFAULT_AIRTIME_CUTOFF_THRESHOLD)).toBe(true);
+    expect(shouldGateAutomations(29, DEFAULT_AIRTIME_CUTOFF_THRESHOLD)).toBe(false);
+  });
+
+  it('never gates when the threshold is 0 (feature disabled)', () => {
+    expect(shouldGateAutomations(99, 0)).toBe(false);
+  });
+
+  it('never gates when the threshold is negative', () => {
+    expect(shouldGateAutomations(99, -5)).toBe(false);
+  });
+
+  it('never gates when utilization is unknown (null/undefined)', () => {
+    expect(shouldGateAutomations(null, 30)).toBe(false);
+    expect(shouldGateAutomations(undefined, 30)).toBe(false);
+  });
+
+  it('does not gate on NaN inputs', () => {
+    expect(shouldGateAutomations(NaN, 30)).toBe(false);
+    expect(shouldGateAutomations(50, NaN)).toBe(false);
+  });
+});

--- a/src/server/utils/airtimeCutoff.ts
+++ b/src/server/utils/airtimeCutoff.ts
@@ -1,0 +1,34 @@
+/**
+ * Airtime-cutoff gating for automations.
+ *
+ * When the locally-connected node's self-reported Channel Utilization (ChUtil)
+ * exceeds a configured threshold, all transmitting automations (auto-traceroute,
+ * auto-announce, timers, etc.) are paused so they don't add to mesh congestion
+ * while real traffic is heavy. Automations resume automatically once utilization
+ * drops back under the threshold.
+ *
+ * Implements: https://github.com/Yeraze/meshmonitor/issues (airtime cutoff)
+ */
+
+/** Default cutoff threshold (percent Channel Utilization) when unset. */
+export const DEFAULT_AIRTIME_CUTOFF_THRESHOLD = 30;
+
+/**
+ * Decide whether automations should be gated (paused) right now.
+ *
+ * Fail-open by design:
+ *  - threshold <= 0 disables the feature entirely (never gate).
+ *  - a null/undefined utilization (no telemetry yet) never gates.
+ *
+ * @param channelUtilization local node's most recent ChUtil percent, or null if unknown
+ * @param threshold cutoff percent; <= 0 disables gating
+ * @returns true when automations should be suppressed
+ */
+export function shouldGateAutomations(
+  channelUtilization: number | null | undefined,
+  threshold: number
+): boolean {
+  if (!Number.isFinite(threshold) || threshold <= 0) return false;
+  if (channelUtilization == null || !Number.isFinite(channelUtilization)) return false;
+  return channelUtilization > threshold;
+}


### PR DESCRIPTION
## Summary

Adds a per-source **Cutoff Airtime Utilization Threshold** (default **30%**) to the top of the Automation page. When the locally-connected node's self-reported **Channel Utilization** rises above the threshold, MeshMonitor **pauses all transmitting automations** so bots (auto-traceroute, auto-announce, etc.) stop adding traffic while real people are using the mesh. Automations resume automatically once utilization drops back below the threshold.

**Motivation:** semi-automatic backoff — people were concerned that things like auto-traceroute drown out legitimate traffic during busy periods.

## Why Channel Utilization (not AirUtilTx)
The goal is to detect when the **mesh** is congested by real traffic. **Channel Utilization (ChUtil)** measures overall channel busy-time including *other* nodes, so it reflects "real people talking." AirUtilTx only measures this node's own transmit airtime and wouldn't move when others are busy — so ChUtil is the right signal.

## How it works
- **Pure gate helper** `shouldGateAutomations(channelUtilization, threshold)` — fail-open: threshold `0` disables the feature, and a null utilization (no telemetry yet) never gates.
- **MeshtasticManager** caches the local node's ChUtil from device telemetry, loads the per-source threshold on `configComplete`, and exposes `isAutomationAirtimeGated()` / `getAirtimeCutoffStatus()` / a setter.
- **Gate inserted at all 11 transmitting automation fire points:** auto-traceroute, remote-admin-scanner, time-sync, key-repair, timer triggers, geofence triggers, auto-ack, auto-ping, auto-responder, auto-welcome, and scheduled auto-announce.
  - **Manual "Send Announcement" bypasses the gate** (user-initiated actions are never blocked).
  - **Not gated:** auto-favorite and auto-delete-by-distance — they're local-only and don't transmit.
- **Setting** `automationAirtimeCutoffThreshold` (per-source, 0–100 validated); a settings-change callback pushes the new value to the matching source manager live.
- **`GET /api/automation/airtime-status`** returns `{ threshold, channelUtilization, gated }`.

## UI
A new section at the top of the Automation tab:
- Threshold number input (0–100, default 30; `0` disables).
- A **live banner** showing the current Channel Utilization and whether automations are currently paused (green = active, red = paused), polled from the status endpoint.

## Testing
- `airtimeCutoff.test.ts` — pure gate logic (under/over/equal/disabled/null/NaN).
- `meshtasticManager.airtimeCutoff.test.ts` — setter range validation + status/gate wiring against cached ChUtil.
- Settings round-trip for the new key.
- **Full Vitest suite: 5948 / 0 failures.** `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)