### PR TITLE
fix(telemetry): normalize MQTT telemetry keys to match serial (#3314)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ For per-source permission tests, mock `getUserPermissionSetAsync(userId, sourceI
 ### Migration Registry
 Migrations use a centralized registry in `src/db/migrations.ts`. Each migration has functions for all three backends.
 
-**Current migration count:** 76 (latest: `076_add_low_battery_columns`).
+**Current migration count:** 77 (latest: `077_normalize_mqtt_telemetry_keys`).
 
 For the full "adding a migration" recipe see [Migration recipe](#migration-recipe) below.
 

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 76 migrations registered', () => {
-    expect(registry.count()).toBe(76);
+  it('has all 77 migrations registered', () => {
+    expect(registry.count()).toBe(77);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_low_battery_columns', () => {
+  it('last migration is normalize_mqtt_telemetry_keys', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(76);
-    expect(last.name).toContain('add_low_battery_columns');
+    expect(last.number).toBe(77);
+    expect(last.name).toContain('normalize_mqtt_telemetry_keys');
   });
 
-  it('migrations are sequentially numbered from 1 to 76', () => {
+  it('migrations are sequentially numbered from 1 to 77', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -91,6 +91,7 @@ import { migration as meshcoreNeighborInfoMigration, runMigration073Postgres, ru
 import { migration as addShowWaypointsToMapPrefsMigration, runMigration074Postgres, runMigration074Mysql } from '../server/migrations/074_add_show_waypoints_to_map_prefs.js';
 import { migration as meshcorePacketLogMigration, runMigration075Postgres, runMigration075Mysql } from '../server/migrations/075_meshcore_packet_log.js';
 import { migration as lowBatteryColumnsMigration, runMigration076Postgres, runMigration076Mysql } from '../server/migrations/076_add_low_battery_columns.js';
+import { migration as normalizeMqttTelemetryKeysMigration, runMigration077Postgres, runMigration077Mysql } from '../server/migrations/077_normalize_mqtt_telemetry_keys.js';
 
 // ============================================================================
 // Registry
@@ -1212,4 +1213,20 @@ registry.register({
   sqlite: (db) => lowBatteryColumnsMigration.up(db),
   postgres: (client) => runMigration076Postgres(client),
   mysql: (pool) => runMigration076Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 077: Rewrite historical MQTT-ingested telemetry rows from dotted
+// group-prefixed keys (e.g. environment.barometricPressure) to the canonical
+// short keys serial ingestion uses (pressure), backfilling units. Implements
+// #3314 so MQTT-sourced environment data becomes visible in the UI.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 77,
+  name: 'normalize_mqtt_telemetry_keys',
+  settingsKey: 'migration_077_normalize_mqtt_telemetry_keys',
+  sqlite: (db) => normalizeMqttTelemetryKeysMigration.up(db),
+  postgres: (client) => runMigration077Postgres(client),
+  mysql: (pool) => runMigration077Mysql(pool),
 });

--- a/src/server/migrations/077_normalize_mqtt_telemetry_keys.test.ts
+++ b/src/server/migrations/077_normalize_mqtt_telemetry_keys.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Migration 077 — Normalize historical MQTT telemetry keys
+ *
+ * Validates that rows stored under dotted group-prefixed keys (the old MQTT
+ * format, e.g. `environment.barometricPressure`) are rewritten to the canonical
+ * short keys serial ingestion uses (`pressure`), with units backfilled, while
+ * serial rows and unmapped groups are left untouched. Implements #3314.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './077_normalize_mqtt_telemetry_keys.js';
+
+function createSchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE telemetry (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      nodeId TEXT NOT NULL,
+      nodeNum INTEGER NOT NULL,
+      telemetryType TEXT NOT NULL,
+      timestamp INTEGER NOT NULL,
+      value REAL NOT NULL,
+      unit TEXT,
+      createdAt INTEGER NOT NULL,
+      packetTimestamp INTEGER,
+      packetId INTEGER,
+      channel INTEGER,
+      precisionBits INTEGER,
+      gpsAccuracy INTEGER,
+      sourceId TEXT
+    );
+  `);
+}
+
+function insert(db: Database.Database, telemetryType: string, value: number, unit: string | null) {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO telemetry (nodeId, nodeNum, telemetryType, timestamp, value, unit, createdAt, sourceId)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run('!deadbeef', 0xdeadbeef, telemetryType, now, value, unit, now, 'src-1');
+}
+
+function types(db: Database.Database): Array<{ telemetryType: string; unit: string | null }> {
+  return db.prepare('SELECT telemetryType, unit FROM telemetry ORDER BY id').all() as any;
+}
+
+describe('Migration 077 — normalize MQTT telemetry keys', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createSchema(db);
+  });
+
+  it('rewrites dotted environment keys to canonical keys with units', () => {
+    insert(db, 'environment.temperature', 21.5, null);
+    insert(db, 'environment.barometricPressure', 1013.2, null);
+    insert(db, 'environment.relativeHumidity', 55, null);
+    insert(db, 'environment.voltage', 4.1, null);
+
+    migration.up(db);
+
+    const rows = types(db);
+    const byType = Object.fromEntries(rows.map((r) => [r.telemetryType, r.unit]));
+    expect(byType['temperature']).toBe('°C');
+    expect(byType['pressure']).toBe('hPa');
+    expect(byType['humidity']).toBe('%');
+    expect(byType['envVoltage']).toBe('V');
+    // No dotted environment keys remain.
+    expect(rows.some((r) => r.telemetryType.startsWith('environment.'))).toBe(false);
+  });
+
+  it('rewrites dotted device / air-quality / power keys', () => {
+    insert(db, 'device.batteryLevel', 90, null);
+    insert(db, 'airQuality.pm25Standard', 12, null);
+    insert(db, 'power.ch1Voltage', 3.7, null);
+
+    migration.up(db);
+
+    const byType = Object.fromEntries(types(db).map((r) => [r.telemetryType, r.unit]));
+    expect(byType['batteryLevel']).toBe('%');
+    expect(byType['pm25Standard']).toBe('µg/m³');
+    expect(byType['ch1Voltage']).toBe('V');
+  });
+
+  it('leaves serial (already-canonical) rows and unmapped groups untouched', () => {
+    insert(db, 'temperature', 20, '°C'); // serial row
+    insert(db, 'health.temperature', 36.8, null); // unmapped group — must stay dotted
+
+    migration.up(db);
+
+    const rows = types(db);
+    expect(rows.find((r) => r.telemetryType === 'temperature')).toMatchObject({ unit: '°C' });
+    expect(rows.find((r) => r.telemetryType === 'health.temperature')).toBeDefined();
+  });
+
+  it('is idempotent — a second run changes nothing', () => {
+    insert(db, 'environment.temperature', 21.5, null);
+    migration.up(db);
+    const after1 = types(db);
+    migration.up(db);
+    const after2 = types(db);
+    expect(after2).toEqual(after1);
+    expect(after1.find((r) => r.telemetryType === 'temperature')).toBeDefined();
+  });
+
+  it('merges MQTT and serial rows under the same canonical key (unifies graphs)', () => {
+    insert(db, 'temperature', 20, '°C'); // serial
+    insert(db, 'environment.temperature', 21, null); // MQTT
+
+    migration.up(db);
+
+    const tempRows = types(db).filter((r) => r.telemetryType === 'temperature');
+    expect(tempRows).toHaveLength(2);
+  });
+});

--- a/src/server/migrations/077_normalize_mqtt_telemetry_keys.ts
+++ b/src/server/migrations/077_normalize_mqtt_telemetry_keys.ts
@@ -1,0 +1,85 @@
+/**
+ * Migration 077: Normalize historical MQTT telemetry keys
+ *
+ * MQTT ingestion previously stored environment/device/air-quality/power metrics
+ * under group-prefixed protobuf keys (e.g. `environment.barometricPressure`)
+ * instead of the canonical short keys serial ingestion uses (`pressure`). That
+ * left MQTT-sourced environment data invisible in the UI. Ingestion is fixed
+ * going forward; this migration rewrites already-stored dotted rows to the
+ * canonical key and backfills the matching unit.
+ *
+ * Idempotent: re-running finds no remaining dotted rows and is a no-op. The
+ * mapping comes from the same source of truth as the ingestion path
+ * (MQTT_KEY_MIGRATIONS), so it can't drift.
+ *
+ * Implements: https://github.com/Yeraze/meshmonitor/issues/3314
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+import { MQTT_KEY_MIGRATIONS } from '../utils/telemetryKeys.js';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 077 (SQLite): Normalizing historical MQTT telemetry keys...');
+
+    const stmt = db.prepare('UPDATE telemetry SET telemetryType = ?, unit = ? WHERE telemetryType = ?');
+    let updated = 0;
+    const tx = db.transaction(() => {
+      for (const m of MQTT_KEY_MIGRATIONS) {
+        const info = stmt.run(m.to, m.unit, m.from);
+        updated += info.changes;
+      }
+    });
+    tx();
+
+    logger.info(`Migration 077 complete (SQLite): rewrote ${updated} MQTT telemetry row(s) to canonical keys`);
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 077 down: Not implemented (data normalization is one-way)');
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration077Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 077 (PostgreSQL): Normalizing historical MQTT telemetry keys...');
+
+  try {
+    let updated = 0;
+    for (const m of MQTT_KEY_MIGRATIONS) {
+      const res = await client.query(
+        'UPDATE telemetry SET "telemetryType" = $1, unit = $2 WHERE "telemetryType" = $3',
+        [m.to, m.unit, m.from]
+      );
+      updated += res.rowCount ?? 0;
+    }
+    logger.info(`Migration 077 complete (PostgreSQL): rewrote ${updated} MQTT telemetry row(s) to canonical keys`);
+  } catch (error: any) {
+    logger.error('Migration 077 (PostgreSQL) failed:', error.message);
+    throw error;
+  }
+}
+
+// ============ MySQL ============
+
+export async function runMigration077Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 077 (MySQL): Normalizing historical MQTT telemetry keys...');
+
+  try {
+    let updated = 0;
+    for (const m of MQTT_KEY_MIGRATIONS) {
+      const [res]: any = await pool.query(
+        'UPDATE telemetry SET telemetryType = ?, unit = ? WHERE telemetryType = ?',
+        [m.to, m.unit, m.from]
+      );
+      updated += res?.affectedRows ?? 0;
+    }
+    logger.info(`Migration 077 complete (MySQL): rewrote ${updated} MQTT telemetry row(s) to canonical keys`);
+  } catch (error: any) {
+    logger.error('Migration 077 (MySQL) failed:', error.message);
+    throw error;
+  }
+}

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -78,6 +78,7 @@ vi.mock('./meshtasticProtobufService.js', () => ({
 import { ingestServiceEnvelope, _resetMqttIngestCachesForTest } from './mqttIngestion.js';
 import { MqttPacketFilter, type ServiceEnvelopeShape } from './mqttPacketFilter.js';
 import databaseService from '../services/database.js';
+import meshtasticProtobufService from './meshtasticProtobufService.js';
 import { CHANNEL_DB_OFFSET } from './constants/meshtastic.js';
 
 const NODE_IN = 0x7ff80a48;
@@ -672,5 +673,72 @@ describe('ingestServiceEnvelope — channel_database resolution', () => {
     expect(result.ingested).toBe(true);
     const [insertedNode] = (databaseService.upsertNode as any).mock.calls[0];
     expect(insertedNode.channel).toBe(0); // raw slot from the envelope
+  });
+});
+
+describe('ingestServiceEnvelope — TELEMETRY_APP key normalization (#3314)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const telemetryRows = () =>
+    (databaseService.insertTelemetry as any).mock.calls.map((c: any[]) => c[0]);
+  const rowByType = (type: string) => telemetryRows().find((r: any) => r.telemetryType === type);
+
+  it('stores device metrics under canonical short keys', async () => {
+    // Default mock returns { deviceMetrics: { batteryLevel: 90 } }
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 67 /* TELEMETRY_APP */),
+    });
+    expect(result.ingested).toBe(true);
+    expect(rowByType('batteryLevel')).toBeDefined();
+    expect(rowByType('batteryLevel').value).toBe(90);
+    expect(rowByType('batteryLevel').unit).toBe('%');
+    // No dotted form should be written.
+    expect(rowByType('device.batteryLevel')).toBeUndefined();
+  });
+
+  it('stores environment metrics under canonical keys with serial-matching renames and units', async () => {
+    (meshtasticProtobufService.processPayload as any).mockReturnValueOnce({
+      environmentMetrics: {
+        temperature: 21.5,
+        relativeHumidity: 55,
+        barometricPressure: 1013.2,
+        voltage: 4.1,
+        current: 0.25,
+      },
+    });
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 67 /* TELEMETRY_APP */),
+    });
+    expect(result.ingested).toBe(true);
+
+    expect(rowByType('temperature')).toMatchObject({ value: 21.5, unit: '°C' });
+    expect(rowByType('humidity')).toMatchObject({ value: 55, unit: '%' });
+    expect(rowByType('pressure')).toMatchObject({ value: 1013.2, unit: 'hPa' });
+    expect(rowByType('envVoltage')).toMatchObject({ value: 4.1, unit: 'V' });
+    expect(rowByType('envCurrent')).toMatchObject({ value: 0.25, unit: 'A' });
+
+    // None of the old dotted forms should appear.
+    const types = telemetryRows().map((r: any) => r.telemetryType);
+    expect(types.some((t: string) => t.includes('.'))).toBe(false);
+  });
+
+  it('leaves unmapped groups (health) dotted to avoid colliding with environment keys', async () => {
+    (meshtasticProtobufService.processPayload as any).mockReturnValueOnce({
+      healthMetrics: { temperature: 36.8 },
+    });
+
+    await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 67 /* TELEMETRY_APP */),
+    });
+
+    // Body temperature must NOT collapse onto ambient `temperature`.
+    expect(rowByType('temperature')).toBeUndefined();
+    expect(rowByType('health.temperature')).toMatchObject({ value: 36.8 });
   });
 });

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -80,6 +80,7 @@ import {
 } from './constants/meshtastic.js';
 import { calculateDistance } from '../utils/distance.js';
 import { getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
+import { canonicalTelemetryType, canonicalTelemetryUnit } from './utils/telemetryKeys.js';
 import { logger } from '../utils/logger.js';
 import {
   nodeNumToId,
@@ -363,12 +364,17 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
         if (!metrics || typeof metrics !== 'object') continue;
         for (const [key, val] of Object.entries(metrics)) {
           if (typeof val !== 'number') continue;
+          // Normalize to the canonical key serial ingestion uses (issue #3314),
+          // so MQTT-sourced environment/device metrics match the UI's expected
+          // keys instead of dotted forms like `environment.barometricPressure`.
+          const telemetryType = canonicalTelemetryType(groupName, key);
           const tel: DbTelemetry = {
             nodeId: fromNodeId,
             nodeNum: fromNum,
-            telemetryType: `${groupName}.${key}`,
+            telemetryType,
             timestamp: ts,
             value: val,
+            unit: canonicalTelemetryUnit(telemetryType),
             createdAt: ts,
             packetId,
             packetTimestamp: typeof t.time === 'number' ? t.time * 1000 : undefined,

--- a/src/server/utils/telemetryKeys.test.ts
+++ b/src/server/utils/telemetryKeys.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+  canonicalTelemetryType,
+  canonicalTelemetryUnit,
+  MQTT_KEY_MIGRATIONS,
+  CANONICAL_TELEMETRY_UNITS,
+} from './telemetryKeys.js';
+
+describe('canonicalTelemetryType', () => {
+  it('strips the group prefix for device metrics', () => {
+    expect(canonicalTelemetryType('device', 'batteryLevel')).toBe('batteryLevel');
+    expect(canonicalTelemetryType('device', 'voltage')).toBe('voltage');
+    expect(canonicalTelemetryType('device', 'channelUtilization')).toBe('channelUtilization');
+    expect(canonicalTelemetryType('device', 'airUtilTx')).toBe('airUtilTx');
+  });
+
+  it('strips the group prefix for plain environment metrics', () => {
+    expect(canonicalTelemetryType('environment', 'temperature')).toBe('temperature');
+    expect(canonicalTelemetryType('environment', 'gasResistance')).toBe('gasResistance');
+    expect(canonicalTelemetryType('environment', 'soilTemperature')).toBe('soilTemperature');
+  });
+
+  it('applies the environment leaf renames serial ingestion uses', () => {
+    expect(canonicalTelemetryType('environment', 'relativeHumidity')).toBe('humidity');
+    expect(canonicalTelemetryType('environment', 'barometricPressure')).toBe('pressure');
+    expect(canonicalTelemetryType('environment', 'voltage')).toBe('envVoltage');
+    expect(canonicalTelemetryType('environment', 'current')).toBe('envCurrent');
+  });
+
+  it('strips the group prefix for air-quality and power metrics', () => {
+    expect(canonicalTelemetryType('airQuality', 'pm25Standard')).toBe('pm25Standard');
+    expect(canonicalTelemetryType('power', 'ch1Voltage')).toBe('ch1Voltage');
+    expect(canonicalTelemetryType('power', 'ch8Current')).toBe('ch8Current');
+  });
+
+  it('handles snake_case leaf keys from alternate decoders', () => {
+    expect(canonicalTelemetryType('environment', 'relative_humidity')).toBe('humidity');
+    expect(canonicalTelemetryType('environment', 'barometric_pressure')).toBe('pressure');
+    expect(canonicalTelemetryType('environment', 'soil_temperature')).toBe('soilTemperature');
+    expect(canonicalTelemetryType('device', 'battery_level')).toBe('batteryLevel');
+  });
+
+  it('leaves unmapped groups dotted to avoid key collisions (e.g. health.temperature)', () => {
+    // HealthMetrics.temperature must NOT collapse onto environment temperature.
+    expect(canonicalTelemetryType('health', 'temperature')).toBe('health.temperature');
+    expect(canonicalTelemetryType('host', 'uptimeSeconds')).toBe('host.uptimeSeconds');
+  });
+});
+
+describe('canonicalTelemetryUnit', () => {
+  it('returns the canonical unit for known types', () => {
+    expect(canonicalTelemetryUnit('temperature')).toBe('°C');
+    expect(canonicalTelemetryUnit('pressure')).toBe('hPa');
+    expect(canonicalTelemetryUnit('humidity')).toBe('%');
+    expect(canonicalTelemetryUnit('envVoltage')).toBe('V');
+    expect(canonicalTelemetryUnit('ch1Voltage')).toBe('V');
+    expect(canonicalTelemetryUnit('ch1Current')).toBe('mA');
+  });
+
+  it('returns undefined for unknown types', () => {
+    expect(canonicalTelemetryUnit('health.temperature')).toBeUndefined();
+    expect(canonicalTelemetryUnit('nope')).toBeUndefined();
+  });
+});
+
+describe('MQTT_KEY_MIGRATIONS', () => {
+  it('maps the key environment cases reported in #3314', () => {
+    const byFrom = Object.fromEntries(MQTT_KEY_MIGRATIONS.map((m) => [m.from, m]));
+    expect(byFrom['environment.temperature']).toMatchObject({ to: 'temperature', unit: '°C' });
+    expect(byFrom['environment.barometricPressure']).toMatchObject({ to: 'pressure', unit: 'hPa' });
+    expect(byFrom['environment.relativeHumidity']).toMatchObject({ to: 'humidity', unit: '%' });
+    expect(byFrom['environment.voltage']).toMatchObject({ to: 'envVoltage', unit: 'V' });
+    expect(byFrom['device.batteryLevel']).toMatchObject({ to: 'batteryLevel', unit: '%' });
+  });
+
+  it('every migration target is a known canonical type with a unit', () => {
+    for (const m of MQTT_KEY_MIGRATIONS) {
+      expect(m.from).toContain('.');
+      expect(m.to).not.toContain('.');
+      expect(CANONICAL_TELEMETRY_UNITS[m.to], `unit for ${m.to}`).toBeDefined();
+      expect(m.unit).toBe(CANONICAL_TELEMETRY_UNITS[m.to]);
+    }
+  });
+
+  it('has no duplicate source keys', () => {
+    const froms = MQTT_KEY_MIGRATIONS.map((m) => m.from);
+    expect(new Set(froms).size).toBe(froms.length);
+  });
+});

--- a/src/server/utils/telemetryKeys.ts
+++ b/src/server/utils/telemetryKeys.ts
@@ -1,0 +1,174 @@
+/**
+ * Canonical telemetry key normalization.
+ *
+ * Serial/direct ingestion (meshtasticManager.ts) stores environment, device,
+ * air-quality and power metrics under short canonical keys (e.g. `temperature`,
+ * `pressure`, `humidity`, `ch1Voltage`). MQTT ingestion historically stored the
+ * same metrics under group-prefixed protobuf keys (e.g. `environment.temperature`,
+ * `environment.barometricPressure`), which don't match the keys the UI graphs and
+ * SOLAR_DEFAULT_ON_TYPES expect — so MQTT-sourced environment data was invisible.
+ *
+ * This module maps the MQTT group/leaf form to the canonical serial key so both
+ * transports write identical `telemetryType` values (and units).
+ *
+ * Implements: https://github.com/Yeraze/meshmonitor/issues/3314
+ */
+
+/** Canonical type → unit, mirroring the serial ingestion path. */
+const DEVICE_UNITS: Record<string, string> = {
+  batteryLevel: '%',
+  voltage: 'V',
+  channelUtilization: '%',
+  airUtilTx: '%',
+  uptimeSeconds: 's',
+};
+
+const ENVIRONMENT_UNITS: Record<string, string> = {
+  temperature: '°C',
+  humidity: '%',
+  pressure: 'hPa',
+  gasResistance: 'MΩ',
+  iaq: 'IAQ',
+  lux: 'lux',
+  whiteLux: 'lux',
+  irLux: 'lux',
+  uvLux: 'lux',
+  windDirection: '°',
+  windSpeed: 'm/s',
+  windGust: 'm/s',
+  windLull: 'm/s',
+  rainfall1h: 'mm',
+  rainfall24h: 'mm',
+  soilMoisture: '%',
+  soilTemperature: '°C',
+  radiation: 'µR/h',
+  distance: 'mm',
+  weight: 'kg',
+  envVoltage: 'V',
+  envCurrent: 'A',
+};
+
+const AIR_QUALITY_UNITS: Record<string, string> = {
+  pm10Standard: 'µg/m³',
+  pm25Standard: 'µg/m³',
+  pm100Standard: 'µg/m³',
+  pm10Environmental: 'µg/m³',
+  pm25Environmental: 'µg/m³',
+  pm100Environmental: 'µg/m³',
+  particles03um: '#/0.1L',
+  particles05um: '#/0.1L',
+  particles10um: '#/0.1L',
+  particles25um: '#/0.1L',
+  particles50um: '#/0.1L',
+  particles100um: '#/0.1L',
+  co2: 'ppm',
+  co2Temperature: '°C',
+  co2Humidity: '%',
+};
+
+const POWER_UNITS: Record<string, string> = (() => {
+  const u: Record<string, string> = {};
+  for (let ch = 1; ch <= 8; ch++) {
+    u[`ch${ch}Voltage`] = 'V';
+    u[`ch${ch}Current`] = 'mA';
+  }
+  return u;
+})();
+
+/** All canonical telemetry types → their unit. */
+export const CANONICAL_TELEMETRY_UNITS: Record<string, string> = {
+  ...DEVICE_UNITS,
+  ...ENVIRONMENT_UNITS,
+  ...AIR_QUALITY_UNITS,
+  ...POWER_UNITS,
+};
+
+/**
+ * MQTT group names whose leaf keys map onto canonical serial keys by stripping
+ * the prefix. Other groups (e.g. `health`) are left dotted because serial never
+ * stores them and some leaves (e.g. HealthMetrics.temperature) would collide
+ * with environment keys.
+ */
+const STRIP_GROUPS = new Set(['device', 'environment', 'airQuality', 'power']);
+
+/**
+ * Environment protobuf leaf names that the serial path renames. Everything else
+ * in the environment group keeps its leaf name.
+ */
+const ENVIRONMENT_LEAF_RENAMES: Record<string, string> = {
+  relativeHumidity: 'humidity',
+  barometricPressure: 'pressure',
+  voltage: 'envVoltage',
+  current: 'envCurrent',
+};
+
+function snakeToCamel(s: string): string {
+  return s.replace(/_([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+}
+
+/**
+ * Map an MQTT telemetry group + leaf key to the canonical `telemetryType` used
+ * by serial ingestion. Leaves of unmapped groups are returned dotted, unchanged.
+ *
+ * @param group MQTT metrics group name (e.g. 'environment', 'device', 'health')
+ * @param leaf protobuf field name within the group (camelCase or snake_case)
+ */
+export function canonicalTelemetryType(group: string, leaf: string): string {
+  const camel = snakeToCamel(leaf);
+  if (!STRIP_GROUPS.has(group)) {
+    return `${group}.${leaf}`;
+  }
+  if (group === 'environment') {
+    return ENVIRONMENT_LEAF_RENAMES[camel] ?? camel;
+  }
+  return camel;
+}
+
+/** Canonical unit for a canonical telemetry type, or undefined if unknown. */
+export function canonicalTelemetryUnit(type: string): string | undefined {
+  return CANONICAL_TELEMETRY_UNITS[type];
+}
+
+/**
+ * Explicit list of historical MQTT dotted keys → canonical key (+ unit), used by
+ * the migration that rewrites already-stored rows. Built from the same canonical
+ * tables so it stays in sync with {@link canonicalTelemetryType}.
+ */
+export interface TelemetryKeyMigration {
+  from: string;
+  to: string;
+  unit: string;
+}
+
+export const MQTT_KEY_MIGRATIONS: TelemetryKeyMigration[] = (() => {
+  const out: TelemetryKeyMigration[] = [];
+
+  for (const leaf of Object.keys(DEVICE_UNITS)) {
+    out.push({ from: `device.${leaf}`, to: leaf, unit: DEVICE_UNITS[leaf] });
+  }
+
+  // Environment uses protobuf leaf names; a few are renamed by the serial path.
+  const environmentProtobufLeaves = [
+    'temperature', 'relativeHumidity', 'barometricPressure', 'gasResistance', 'iaq',
+    'lux', 'whiteLux', 'irLux', 'uvLux',
+    'windDirection', 'windSpeed', 'windGust', 'windLull',
+    'rainfall1h', 'rainfall24h',
+    'soilMoisture', 'soilTemperature',
+    'radiation', 'distance', 'weight',
+    'voltage', 'current',
+  ];
+  for (const leaf of environmentProtobufLeaves) {
+    const to = canonicalTelemetryType('environment', leaf);
+    out.push({ from: `environment.${leaf}`, to, unit: ENVIRONMENT_UNITS[to] ?? '' });
+  }
+
+  for (const leaf of Object.keys(AIR_QUALITY_UNITS)) {
+    out.push({ from: `airQuality.${leaf}`, to: leaf, unit: AIR_QUALITY_UNITS[leaf] });
+  }
+
+  for (const leaf of Object.keys(POWER_UNITS)) {
+    out.push({ from: `power.${leaf}`, to: leaf, unit: POWER_UNITS[leaf] });
+  }
+
+  return out;
+})();


### PR DESCRIPTION
## Summary

Fixes #3314. MQTT ingestion stored environment/device/air-quality/power metrics under **group-prefixed protobuf keys** (e.g. `environment.barometricPressure`, `environment.relativeHumidity`) while serial/direct ingestion uses **canonical short keys** (`pressure`, `humidity`). The mismatch meant **MQTT-sourced environment data was invisible** in the UI graphs (which expect the short keys), and a node seen over both transports showed duplicated, mismatched series at different densities.

## Root cause
`mqttIngestion.ts` did `telemetryType: \`${groupName}.${key}\`` while `meshtasticManager.ts` writes `temperature` / `pressure` / `humidity` / `ch1Voltage` / etc. It's the only writer of dotted keys (the meshcore prefix is a separate intentional namespace).

## Fix
- **New `src/server/utils/telemetryKeys.ts`** — `canonicalTelemetryType(group, leaf)`:
  - strips the group prefix for `device` / `environment` / `airQuality` / `power`
  - applies the four environment renames serial uses: `relativeHumidity→humidity`, `barometricPressure→pressure`, `voltage→envVoltage`, `current→envCurrent`
  - leaves unmapped groups (e.g. `health`) **dotted on purpose** — `HealthMetrics.temperature` would otherwise collapse onto ambient environment `temperature`
  - also exposes canonical units (`canonicalTelemetryUnit`)
  - handles snake_case leaves defensively
- **`mqttIngestion.ts`** writes the canonical `telemetryType` and backfills `unit`, so MQTT and serial now produce identical rows.
- **Migration 077** rewrites existing dotted rows → canonical keys + units (idempotent, all three backends), so historical MQTT data becomes visible and unifies with serial rows under the same key.

No frontend change needed — the UI already expects the canonical short keys; this makes the data match them.

## Why fix at ingestion **and** migrate
Fixing ingestion alone leaves already-stored dotted rows invisible. The migration normalizes history; ingestion keeps new data correct. Health/host/etc. stay dotted (serial never stores them, and the UI doesn't graph them).

## Testing
- `telemetryKeys.test.ts` — prefix stripping, the 4 env renames, snake_case, the health collision guard, unit lookups, and `MQTT_KEY_MIGRATIONS` integrity.
- `mqttIngestion.test.ts` — env metrics stored as `temperature`/`pressure`/`humidity`/`envVoltage`/`envCurrent` with units, no dotted forms, and `health.temperature` stays dotted.
- `077_normalize_mqtt_telemetry_keys.test.ts` — functional SQLite migration: rewrite + units, idempotency, serial rows untouched, MQTT+serial rows unify under one key.
- **Full Vitest suite: 5989 / 0 failures.** `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)