### PR TITLE
fix(meshcore): widen packet_log timestamp/createdAt to BIGINT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ For per-source permission tests, mock `getUserPermissionSetAsync(userId, sourceI
 ### Migration Registry
 Migrations use a centralized registry in `src/db/migrations.ts`. Each migration has functions for all three backends.
 
-**Current migration count:** 76 (latest: `076_add_low_battery_columns`).
+**Current migration count:** 77 (latest: `077_meshcore_packet_log_bigint_timestamp`).
 
 For the full "adding a migration" recipe see [Migration recipe](#migration-recipe) below.
 

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 76 migrations registered', () => {
-    expect(registry.count()).toBe(76);
+  it('has all 77 migrations registered', () => {
+    expect(registry.count()).toBe(77);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_low_battery_columns', () => {
+  it('last migration is meshcore_packet_log_bigint_timestamp', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(76);
-    expect(last.name).toContain('add_low_battery_columns');
+    expect(last.number).toBe(77);
+    expect(last.name).toContain('meshcore_packet_log_bigint_timestamp');
   });
 
-  it('migrations are sequentially numbered from 1 to 76', () => {
+  it('migrations are sequentially numbered from 1 to 77', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -91,6 +91,7 @@ import { migration as meshcoreNeighborInfoMigration, runMigration073Postgres, ru
 import { migration as addShowWaypointsToMapPrefsMigration, runMigration074Postgres, runMigration074Mysql } from '../server/migrations/074_add_show_waypoints_to_map_prefs.js';
 import { migration as meshcorePacketLogMigration, runMigration075Postgres, runMigration075Mysql } from '../server/migrations/075_meshcore_packet_log.js';
 import { migration as lowBatteryColumnsMigration, runMigration076Postgres, runMigration076Mysql } from '../server/migrations/076_add_low_battery_columns.js';
+import { migration as meshcorePacketLogBigintMigration, runMigration077Postgres, runMigration077Mysql } from '../server/migrations/077_meshcore_packet_log_bigint_timestamp.js';
 
 // ============================================================================
 // Registry
@@ -1212,4 +1213,19 @@ registry.register({
   sqlite: (db) => lowBatteryColumnsMigration.up(db),
   postgres: (client) => runMigration076Postgres(client),
   mysql: (pool) => runMigration076Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 077: Widen meshcore_packet_log.timestamp/createdAt to BIGINT on
+// PostgreSQL/MySQL. They held ms-epoch values that overflow 32-bit INTEGER,
+// breaking the retention cleanup DELETE with SQLSTATE 22003. SQLite no-op.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 77,
+  name: 'meshcore_packet_log_bigint_timestamp',
+  settingsKey: 'migration_077_meshcore_packet_log_bigint_timestamp',
+  sqlite: (db) => meshcorePacketLogBigintMigration.up(db),
+  postgres: (client) => runMigration077Postgres(client),
+  mysql: (pool) => runMigration077Mysql(pool),
 });

--- a/src/db/schema/meshcorePacketLog.ts
+++ b/src/db/schema/meshcorePacketLog.ts
@@ -1,6 +1,6 @@
 import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
-import { pgTable, text as pgText, integer as pgInteger, real as pgReal } from 'drizzle-orm/pg-core';
-import { mysqlTable, varchar as myVarchar, int as myInt, double as myDouble, serial as mySerial, text as myText } from 'drizzle-orm/mysql-core';
+import { pgTable, text as pgText, integer as pgInteger, real as pgReal, bigint as pgBigint } from 'drizzle-orm/pg-core';
+import { mysqlTable, varchar as myVarchar, int as myInt, double as myDouble, serial as mySerial, text as myText, bigint as myBigint } from 'drizzle-orm/mysql-core';
 
 // ============ SQLite Schema ============
 //
@@ -46,7 +46,8 @@ export const meshcorePacketLogSqlite = sqliteTable('meshcore_packet_log', {
 export const meshcorePacketLogPostgres = pgTable('meshcore_packet_log', {
   id: pgInteger('id').primaryKey().generatedAlwaysAsIdentity(),
   sourceId: pgText('sourceId').notNull(),
-  timestamp: pgInteger('timestamp').notNull(),
+  // ms-epoch timestamps overflow 32-bit INTEGER (~2.1e9); JS Date.now() is ~1.8e12.
+  timestamp: pgBigint('timestamp', { mode: 'number' }).notNull(),
   payloadType: pgInteger('payloadType').notNull(),
   payloadTypeName: pgText('payloadTypeName'),
   routeType: pgInteger('routeType'),
@@ -58,7 +59,7 @@ export const meshcorePacketLogPostgres = pgTable('meshcore_packet_log', {
   rssi: pgInteger('rssi'),
   payloadSize: pgInteger('payloadSize'),
   rawHex: pgText('rawHex'),
-  createdAt: pgInteger('createdAt').notNull(),
+  createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
 });
 
 // ============ MySQL Schema ============
@@ -66,7 +67,8 @@ export const meshcorePacketLogPostgres = pgTable('meshcore_packet_log', {
 export const meshcorePacketLogMysql = mysqlTable('meshcore_packet_log', {
   id: mySerial('id').primaryKey(),
   sourceId: myVarchar('sourceId', { length: 255 }).notNull(),
-  timestamp: myInt('timestamp').notNull(),
+  // ms-epoch timestamps overflow 32-bit INT (~2.1e9); JS Date.now() is ~1.8e12.
+  timestamp: myBigint('timestamp', { mode: 'number' }).notNull(),
   payloadType: myInt('payloadType').notNull(),
   payloadTypeName: myVarchar('payloadTypeName', { length: 32 }),
   routeType: myInt('routeType'),
@@ -78,5 +80,5 @@ export const meshcorePacketLogMysql = mysqlTable('meshcore_packet_log', {
   rssi: myInt('rssi'),
   payloadSize: myInt('payloadSize'),
   rawHex: myText('rawHex'),
-  createdAt: myInt('createdAt').notNull(),
+  createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
 });

--- a/src/server/migrations/075_meshcore_packet_log.ts
+++ b/src/server/migrations/075_meshcore_packet_log.ts
@@ -62,7 +62,7 @@ export async function runMigration075Postgres(client: any): Promise<void> {
     CREATE TABLE IF NOT EXISTS ${TABLE} (
       id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
       "sourceId" TEXT NOT NULL,
-      "timestamp" INTEGER NOT NULL,
+      "timestamp" BIGINT NOT NULL,
       "payloadType" INTEGER NOT NULL,
       "payloadTypeName" TEXT,
       "routeType" INTEGER,
@@ -74,7 +74,7 @@ export async function runMigration075Postgres(client: any): Promise<void> {
       rssi INTEGER,
       "payloadSize" INTEGER,
       "rawHex" TEXT,
-      "createdAt" INTEGER NOT NULL
+      "createdAt" BIGINT NOT NULL
     )
   `);
 
@@ -101,7 +101,7 @@ export async function runMigration075Mysql(pool: any): Promise<void> {
         CREATE TABLE ${TABLE} (
           id SERIAL PRIMARY KEY,
           sourceId VARCHAR(255) NOT NULL,
-          timestamp INT NOT NULL,
+          timestamp BIGINT NOT NULL,
           payloadType INT NOT NULL,
           payloadTypeName VARCHAR(32),
           routeType INT,
@@ -113,7 +113,7 @@ export async function runMigration075Mysql(pool: any): Promise<void> {
           rssi INT,
           payloadSize INT,
           rawHex TEXT,
-          createdAt INT NOT NULL,
+          createdAt BIGINT NOT NULL,
           INDEX idx_mcpl_source_ts (sourceId, timestamp),
           INDEX idx_mcpl_payload_type (payloadType)
         )

--- a/src/server/migrations/077_meshcore_packet_log_bigint_timestamp.ts
+++ b/src/server/migrations/077_meshcore_packet_log_bigint_timestamp.ts
@@ -1,0 +1,67 @@
+/**
+ * Migration 077: Widen meshcore_packet_log timestamp/createdAt to BIGINT.
+ *
+ * Migration 075 created these columns as 32-bit INTEGER on PostgreSQL/MySQL,
+ * but they hold JS ms-epoch timestamps (Date.now() ~= 1.8e12), which overflow
+ * the signed 32-bit range (~2.1e9). On PostgreSQL the retention cleanup
+ * (`DELETE ... WHERE timestamp < $1`) failed with `value out of range for type
+ * integer` (SQLSTATE 22003); inserts of post-2038-style values would fail too.
+ *
+ * SQLite is unaffected — its INTEGER storage class is dynamically 64-bit — so
+ * the SQLite branch is a no-op.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL (re-running the ALTER on an
+ * already-BIGINT column is a harmless no-op).
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 077';
+const TABLE = 'meshcore_packet_log';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (_db: Database): void => {
+    // SQLite INTEGER is dynamically sized (up to 64-bit), so ms-epoch values
+    // never overflowed. Nothing to alter.
+    logger.info(`${LABEL} (SQLite): no-op (INTEGER already 64-bit capable)`);
+  },
+
+  down: (_db: Database): void => {
+    logger.info(`${LABEL} down (SQLite): no-op`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration077Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): widening ${TABLE}.timestamp/createdAt to BIGINT...`);
+
+  await client.query(
+    `ALTER TABLE ${TABLE}
+       ALTER COLUMN "timestamp" TYPE BIGINT,
+       ALTER COLUMN "createdAt" TYPE BIGINT`,
+  );
+
+  logger.info(`${LABEL} complete (PostgreSQL)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration077Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): widening ${TABLE}.timestamp/createdAt to BIGINT...`);
+
+  const conn = await pool.getConnection();
+  try {
+    await conn.query(
+      `ALTER TABLE ${TABLE}
+         MODIFY COLUMN timestamp BIGINT NOT NULL,
+         MODIFY COLUMN createdAt BIGINT NOT NULL`,
+    );
+  } finally {
+    conn.release();
+  }
+
+  logger.info(`${LABEL} complete (MySQL)`);
+}


### PR DESCRIPTION
## Problem

A user running PostgreSQL hit a recurring error in the MeshCore packet-log retention cleanup:

```
[ERROR] ❌ Failed to cleanup MeshCore packet logs: DrizzleQueryError:
delete from "meshcore_packet_log" where "meshcore_packet_log"."timestamp" < $1
params: 1780529564236
cause: error: value "1780529564236" is out of range for type integer (22003)
```

## Root cause

`meshcore_packet_log.timestamp` (and `createdAt`) were declared as **32-bit `INTEGER`/`INT`** in the PostgreSQL and MySQL schemas, but they store JS millisecond epoch values. `Date.now()` is ~`1.78e12`, while a signed 32-bit int maxes at `2,147,483,647` (~`2.1e9`). PostgreSQL rejected the cleanup `DELETE ... WHERE timestamp < <ms>` with `22003: value out of range for type integer`. Inserts of those values would fail the same way — the retention cleanup is just where it first surfaced.

SQLite is unaffected — its `INTEGER` storage class is dynamically up to 64-bit. The sibling Meshtastic `packet_log` table already uses `BIGINT` for these columns (`pgBigint('timestamp', { mode: 'number' })`); the MeshCore table simply missed it.

## Fix

- **`src/db/schema/meshcorePacketLog.ts`** — `timestamp`/`createdAt` → `pgBigint`/`myBigint` (`{ mode: 'number' }`), matching `packets.ts`.
- **`src/server/migrations/075_meshcore_packet_log.ts`** — DDL changed to `BIGINT` so fresh PG/MySQL installs are correct from the start.
- **`src/server/migrations/077_meshcore_packet_log_bigint_timestamp.ts`** (new) — widens the columns to `BIGINT` on existing PG/MySQL deployments (`ALTER COLUMN ... TYPE BIGINT` / `MODIFY COLUMN`). SQLite is a no-op. Idempotent.
- Updated `migrations.test.ts` (76 → 77, last-migration name) and the migration count in `CLAUDE.md`.

Affected PG/MySQL instances self-heal on next startup when migration 077 runs.

## Testing

- `tsc --noEmit`: clean
- Full Vitest suite: **5970 passed, 0 failures** (551 skipped, 21 todo)
- `eslint` on changed files: 0 errors (only the pre-existing `any`-param warnings shared by every migration file)

Note: unit tests exercise SQLite; the PG/MySQL `ALTER` paths are covered by CI's multi-DB system tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)