### PR TITLE
feat(meshcore): date separators between messages from different days (#3316)

### DIFF
--- a/src/components/MeshCore/MeshCoreMessageStream.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for date-separator rendering in the shared MeshCore chat stream
+ * (issue #3316). A non-interactive separator must appear before the first
+ * message and whenever consecutive messages cross a calendar-day boundary,
+ * but not between messages sent on the same day.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) => {
+      if (typeof fallback === 'string') return fallback;
+      return key;
+    },
+  }),
+}));
+
+import { MeshCoreMessageStream } from './MeshCoreMessageStream';
+import type { MeshCoreMessage } from './hooks/useMeshCore';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function msg(id: string, timestamp: number, text: string): MeshCoreMessage {
+  return { id, fromPublicKey: 'abcdef0123456789', text, timestamp };
+}
+
+function renderStream(messages: MeshCoreMessage[]) {
+  return render(
+    <MeshCoreMessageStream messages={messages} onSend={async () => true} />,
+  );
+}
+
+describe('MeshCoreMessageStream date separators', () => {
+  it('renders a single separator for messages all sent on the same day', () => {
+    const now = Date.now();
+    const { container } = renderStream([
+      msg('a', now - 3000, 'first'),
+      msg('b', now - 2000, 'second'),
+      msg('c', now - 1000, 'third'),
+    ]);
+
+    expect(container.querySelectorAll('.mc-date-separator')).toHaveLength(1);
+    // Same-day, recent messages collapse under "Today".
+    expect(screen.getByText('Today')).toBeTruthy();
+  });
+
+  it('inserts a separator at each day boundary', () => {
+    const now = Date.now();
+    const { container } = renderStream([
+      msg('a', now - 2 * DAY_MS, 'two days ago'),
+      msg('b', now - 1 * DAY_MS, 'yesterday'),
+      msg('c', now, 'today'),
+    ]);
+
+    // One separator per distinct day (first message always gets one).
+    expect(container.querySelectorAll('.mc-date-separator')).toHaveLength(3);
+    expect(screen.getByText('Today')).toBeTruthy();
+    expect(screen.getByText('Yesterday')).toBeTruthy();
+  });
+
+  it('renders no separators when there are no messages', () => {
+    const { container } = renderStream([]);
+    expect(container.querySelectorAll('.mc-date-separator')).toHaveLength(0);
+  });
+});

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState, KeyboardEvent
 import { useTranslation } from 'react-i18next';
 import { MeshCoreMessage } from './hooks/useMeshCore';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
+import { getMessageDateSeparator, shouldShowDateSeparator } from '../../utils/datetime';
 
 interface MeshCoreMessageStreamProps {
   messages: MeshCoreMessage[];
@@ -207,7 +208,10 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
           <div className="meshcore-empty-state">
             {emptyText ?? t('meshcore.no_messages', 'No messages')}
           </div>
-        ) : messages.map(m => {
+        ) : messages.map((m, idx) => {
+          const currentDate = new Date(m.timestamp);
+          const prevDate = idx > 0 ? new Date(messages[idx - 1].timestamp) : null;
+          const showSeparator = shouldShowDateSeparator(prevDate, currentDate);
           const outgoing = !!selfPublicKey && m.fromPublicKey === selfPublicKey;
           const friendlyName = outgoing ? null : nameForKey(m.fromPublicKey);
           const fromLabel = outgoing
@@ -219,7 +223,15 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
             : fullKeyFor(m.fromPublicKey);
           const canClick = !outgoing && onNodeNameClick && clickTarget;
           return (
-            <div key={m.id} className={`mc-message-row ${outgoing ? 'outgoing' : ''}`}>
+            <React.Fragment key={m.id}>
+              {showSeparator && (
+                <div className="mc-date-separator">
+                  <span className="mc-date-separator-text">
+                    {getMessageDateSeparator(currentDate)}
+                  </span>
+                </div>
+              )}
+              <div className={`mc-message-row ${outgoing ? 'outgoing' : ''}`}>
               <div className="mc-message-header">
                 {canClick ? (
                   <button
@@ -258,7 +270,8 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                 </span>
               </div>
               <div className="mc-message-text">{renderMessageText(m.text)}</div>
-            </div>
+              </div>
+            </React.Fragment>
           );
         })}
       </div>

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -471,6 +471,30 @@
   gap: 0.5rem;
 }
 
+.mc-date-separator {
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+  text-align: center;
+  margin: 0.5rem 0;
+}
+
+.mc-date-separator::before,
+.mc-date-separator::after {
+  content: '';
+  flex: 1;
+  border-bottom: 1px solid var(--ctp-surface2);
+}
+
+.mc-date-separator-text {
+  padding: 0 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ctp-subtext0);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
 .mc-message-row {
   background: var(--ctp-surface0);
   border-radius: var(--radius-lg);


### PR DESCRIPTION
## Summary

Closes #3316. Adds a centered date separator in the MeshCore chat windows so users can orient when scrolling through multi-day chat history — like Signal/WhatsApp/Telegram/Discord.

The separator is rendered in the **shared** `MeshCoreMessageStream` component, so it appears across all consumers at once:
- Direct Messages
- Rooms
- Channels

## Behavior

- A separator is shown before the first message and whenever two consecutive messages cross a calendar-day boundary.
- Labels reuse the existing Meshtastic helpers in `src/utils/datetime.ts` (`shouldShowDateSeparator` / `getMessageDateSeparator`) for consistency: `Today`, `Yesterday`, `June 3` (this year), or `June 3, 2025` (older).
- Separator is non-interactive and full-width (`align-self: stretch`) within the flex message list.

## Changes

- `MeshCoreMessageStream.tsx` — compute per-message day boundary and render `.mc-date-separator`.
- `MeshCorePage.css` — `.mc-date-separator` / `.mc-date-separator-text` styling matching the Catppuccin separator used in Meshtastic chat.
- `MeshCoreMessageStream.test.tsx` (new) — same-day collapses to one separator, one separator per day boundary, none when empty.

## Testing

- New tests: 3 passed
- `tsc --noEmit`: clean
- ESLint on changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)