### PR TITLE
feat(automation): add {LAST_HOP} template variable (#3318)

### DIFF
--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -39,6 +39,7 @@ When enabled, MeshMonitor monitors all incoming messages for patterns matching t
 - **`{NODE_ID}`**: Sender's node ID (e.g., "!a1b2c3d4")
 - **`{SNR}`**: Signal-to-Noise Ratio in dB (e.g., "7.5")
 - **`{RSSI}`**: Received Signal Strength Indicator in dBm (e.g., "-95")
+- **`{LAST_HOP}`**: Short name of the last relay node (e.g., "RLY1"); falls back to the hex byte (e.g., "0x4F") when the relay isn't in the node database, or "unknown" when there's no relay info
 - **`{VERSION}`**: MeshMonitor version
 - **`{DURATION}`**: System uptime
 - **`{FEATURES}`**: Enabled automation features
@@ -754,6 +755,7 @@ When using Script responses, you can pass command-line arguments to scripts via 
 | `{HOPS}` | Message hop count | `2` |
 | `{SNR}` | Signal-to-noise ratio | `7.5` |
 | `{RSSI}` | Signal strength | `-95` |
+| `{LAST_HOP}` | Last relay node (short name → hex byte → `unknown`) | `RLY1` |
 
 **Example Configuration:**
 ```

--- a/src/components/AutoAcknowledgeSection.tsx
+++ b/src/components/AutoAcknowledgeSection.tsx
@@ -260,6 +260,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
     sample = sample.replace(/{SNR}/g, '7.5');
     sample = sample.replace(/{RSSI}/g, '-95');
     sample = sample.replace(/{TRANSPORT}/g, 'LoRa'); // Sample transport type
+    sample = sample.replace(/{LAST_HOP}/g, isDirect ? 'unknown' : 'RLY1'); // Relay short name (no relay on direct)
 
     return sample;
   };
@@ -718,7 +719,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
                 <label htmlFor="autoAckMessage" style={{ display: 'block', marginBottom: '0.5rem' }}>
                   {t('automation.auto_ack.message_multihop')}
                   <span className="setting-description" style={{ display: 'block', marginTop: '0.25rem' }}>
-                    {t('automation.auto_ack.available_tokens')} {'{NODE_ID}'}, {'{NUMBER_HOPS}'}, {'{HOPS}'}, {'{RABBIT_HOPS}'}, {'{DATE}'}, {'{TIME}'}, {'{VERSION}'}, {'{DURATION}'}, {'{FEATURES}'}, {'{NODECOUNT}'}, {'{DIRECTCOUNT}'}, {'{TOTALNODES}'}, {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{SNR}'}, {'{RSSI}'}, {'{TRANSPORT}'}
+                    {t('automation.auto_ack.available_tokens')} {'{NODE_ID}'}, {'{NUMBER_HOPS}'}, {'{HOPS}'}, {'{RABBIT_HOPS}'}, {'{DATE}'}, {'{TIME}'}, {'{VERSION}'}, {'{DURATION}'}, {'{FEATURES}'}, {'{NODECOUNT}'}, {'{DIRECTCOUNT}'}, {'{TOTALNODES}'}, {'{LONG_NAME}'}, {'{SHORT_NAME}'}, {'{SNR}'}, {'{RSSI}'}, {'{TRANSPORT}'}, {'{LAST_HOP}'}
                   </span>
                 </label>
                 <textarea

--- a/src/server/meshtasticManager.lasthop.test.ts
+++ b/src/server/meshtasticManager.lasthop.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the {LAST_HOP} relay-name resolution wiring on MeshtasticManager
+ * (issue #3318). The pure resolution logic is covered by utils/lastHop.test.ts;
+ * here we verify the manager helper short-circuits on no-relay and otherwise
+ * resolves against recently-active nodes.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetSetting = vi.fn();
+const mockGetActiveNodes = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    getSetting: mockGetSetting,
+    setSetting: vi.fn(),
+    settings: {
+      getSetting: mockGetSetting,
+      getSettingForSource: vi.fn((_s: string, key: string) => mockGetSetting(key)),
+    },
+    nodes: {
+      getActiveNodes: mockGetActiveNodes,
+      getNode: vi.fn().mockResolvedValue(null),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    telemetry: { insertTelemetry: vi.fn().mockResolvedValue(undefined) },
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('MeshtasticManager - {LAST_HOP} resolution', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module = await import('./meshtasticManager.js');
+    manager = module.default;
+  });
+
+  it("returns 'unknown' without touching the DB when there is no relay info", async () => {
+    expect(await manager.getLastHopName(undefined)).toBe('unknown');
+    expect(await manager.getLastHopName(null)).toBe('unknown');
+    expect(await manager.getLastHopName(0)).toBe('unknown');
+    expect(mockGetActiveNodes).not.toHaveBeenCalled();
+  });
+
+  it('resolves the relay byte to a matching active node short name', async () => {
+    mockGetActiveNodes.mockResolvedValue([
+      { nodeNum: 0xaabbcc4f, shortName: 'RLY1', role: 2, hopsAway: 0, lastHeard: 123 },
+    ]);
+    expect(await manager.getLastHopName(0x4f)).toBe('RLY1');
+    expect(mockGetActiveNodes).toHaveBeenCalled();
+  });
+
+  it('falls back to the hex byte when no active node matches the relay byte', async () => {
+    mockGetActiveNodes.mockResolvedValue([
+      { nodeNum: 0x11111111, shortName: 'OTHER', role: 2, hopsAway: 0, lastHeard: 123 },
+    ]);
+    expect(await manager.getLastHopName(0x4f)).toBe('0x4F');
+  });
+
+  it('falls back to the hex byte when the node query fails', async () => {
+    mockGetActiveNodes.mockRejectedValue(new Error('db down'));
+    expect(await manager.getLastHopName(0x4f)).toBe('0x4F');
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -24,6 +24,7 @@ import { MessageQueueService } from './messageQueueService.js';
 import { normalizeTriggerPatterns, normalizeTriggerChannels } from '../utils/autoResponderUtils.js';
 import { isWithinTimeWindow } from './utils/timeWindow.js';
 import { shouldGateAutomations, DEFAULT_AIRTIME_CUTOFF_THRESHOLD } from './utils/airtimeCutoff.js';
+import { resolveLastHopName } from './utils/lastHop.js';
 import { canonicalMessageTime } from './utils/messageTime.js';
 import { isNodeComplete } from '../utils/nodeHelpers.js';
 import { getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
@@ -8931,7 +8932,7 @@ class MeshtasticManager implements ISourceManager {
         const receivedTime = formatTime(timestamp, timeFormat as '12' | '24');
 
         // Replace tokens in the message template
-        const ackText = await this.replaceAcknowledgementTokens(autoAckMessage, message.fromNodeId, fromNum, hopsTraveled, receivedDate, receivedTime, channelIndex, isDirectMessage, rxSnr, rxRssi, message.viaMqtt);
+        const ackText = await this.replaceAcknowledgementTokens(autoAckMessage, message.fromNodeId, fromNum, hopsTraveled, receivedDate, receivedTime, channelIndex, isDirectMessage, rxSnr, rxRssi, message.viaMqtt, false, message.relayNode);
 
         // Don't make it a reply if we're changing channels (DM when triggered by channel message)
         const replyId = (alwaysUseDM && !isDirectMessage) ? undefined : packetId;
@@ -9654,7 +9655,7 @@ class MeshtasticManager implements ISourceManager {
             url = await this.replaceAcknowledgementTokens(
               url, nodeId, message.fromNodeNum, hopsTraveled,
               receivedDate, receivedTime, message.channel, isDirectMessage,
-              message.rxSnr, message.rxRssi, message.viaMqtt, true
+              message.rxSnr, message.rxRssi, message.viaMqtt, true, message.relayNode
             );
 
             logger.debug(`🌐 Fetching HTTP response from: ${url}`);
@@ -9685,7 +9686,7 @@ class MeshtasticManager implements ISourceManager {
               logger.debug(`📥 HTTP response received: ${responseText.substring(0, 50)}...`);
 
               // Replace Auto Acknowledge tokens in HTTP response (Issue #1159)
-              responseText = await this.replaceAcknowledgementTokens(responseText, nodeId, message.fromNodeNum, hopsTraveled, receivedDate, receivedTime, message.channel, isDirectMessage, message.rxSnr, message.rxRssi, message.viaMqtt);
+              responseText = await this.replaceAcknowledgementTokens(responseText, nodeId, message.fromNodeNum, hopsTraveled, receivedDate, receivedTime, message.channel, isDirectMessage, message.rxSnr, message.rxRssi, message.viaMqtt, false, message.relayNode);
             } catch (error: any) {
               if (error.name === 'AbortError') {
                 logger.debug('⏭️  HTTP request timed out after 5 seconds');
@@ -9763,7 +9764,7 @@ class MeshtasticManager implements ISourceManager {
                 const expandedArgs = await this.replaceAcknowledgementTokens(
                   trigger.scriptArgs, nodeId, message.fromNodeNum, hopsTraveled,
                   receivedDate, receivedTime, message.channel, isDirectMessage,
-                  message.rxSnr, message.rxRssi, message.viaMqtt
+                  message.rxSnr, message.rxRssi, message.viaMqtt, false, message.relayNode
                 );
                 scriptArgsList = this.parseScriptArgs(expandedArgs);
                 logger.debug(`🤖 Script args expanded: ${trigger.scriptArgs} -> ${JSON.stringify(scriptArgsList)}`);
@@ -9993,7 +9994,7 @@ class MeshtasticManager implements ISourceManager {
             });
 
             // Replace Auto Acknowledge tokens in text response (Issue #1159)
-            responseText = await this.replaceAcknowledgementTokens(responseText, nodeId, message.fromNodeNum, hopsTraveled, receivedDate, receivedTime, message.channel, isDirectMessage, message.rxSnr, message.rxRssi, message.viaMqtt);
+            responseText = await this.replaceAcknowledgementTokens(responseText, nodeId, message.fromNodeNum, hopsTraveled, receivedDate, receivedTime, message.channel, isDirectMessage, message.rxSnr, message.rxRssi, message.viaMqtt, false, message.relayNode);
           }
 
           const multilineEnabled = trigger.multiline || false;
@@ -11166,7 +11167,29 @@ class MeshtasticManager implements ISourceManager {
     return this.replaceAnnouncementTokens(message);
   }
 
-  private async replaceAcknowledgementTokens(message: string, nodeId: string, fromNum: number, numberHops: number, date: string, time: string, channelIndex: number, isDirectMessage: boolean, rxSnr?: number, rxRssi?: number, viaMqtt?: boolean, urlEncode: boolean = false): Promise<string> {
+  /**
+   * Resolve the {LAST_HOP} relay node value to a display name (short name →
+   * hex byte → 'unknown'), matching the Packet Monitor. Issue #3318.
+   */
+  private async getLastHopName(relayNode?: number | null): Promise<string> {
+    if (relayNode == null || relayNode === 0) return 'unknown';
+    try {
+      const nodes = await databaseService.nodes.getActiveNodes(7, this.sourceId);
+      return resolveLastHopName(relayNode, nodes.map((n: any) => ({
+        nodeNum: Number(n.nodeNum),
+        shortName: n.shortName,
+        role: n.role,
+        hopsAway: n.hopsAway,
+        lastHeard: n.lastHeard,
+      })));
+    } catch (error) {
+      logger.error('Failed to resolve {LAST_HOP} relay name:', error);
+      // Fall back to the hex byte rather than leaking the raw token.
+      return resolveLastHopName(relayNode, []);
+    }
+  }
+
+  private async replaceAcknowledgementTokens(message: string, nodeId: string, fromNum: number, numberHops: number, date: string, time: string, channelIndex: number, isDirectMessage: boolean, rxSnr?: number, rxRssi?: number, viaMqtt?: boolean, urlEncode: boolean = false, relayNode?: number | null): Promise<string> {
     // Start with base announcement tokens (includes {IP}, {PORT}, {VERSION}, {DURATION}, {FEATURES}, {NODECOUNT}, {DIRECTCOUNT})
     let result = await this.replaceAnnouncementTokens(message, urlEncode);
     const encode = (v: string) => urlEncode ? encodeURIComponent(v) : v;
@@ -11252,6 +11275,12 @@ class MeshtasticManager implements ISourceManager {
     if (result.includes('{TRANSPORT}')) {
       const transport = viaMqtt === true ? 'MQTT' : 'LoRa';
       result = result.replace(/{TRANSPORT}/g, encode(transport));
+    }
+
+    // {LAST_HOP} - Short name of the last relay node (hex byte / 'unknown' fallback)
+    if (result.includes('{LAST_HOP}')) {
+      const lastHop = await this.getLastHopName(relayNode);
+      result = result.replace(/{LAST_HOP}/g, encode(lastHop));
     }
 
     return result;

--- a/src/server/utils/lastHop.test.ts
+++ b/src/server/utils/lastHop.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLastHopName, type LastHopCandidate } from './lastHop.js';
+
+const node = (over: Partial<LastHopCandidate> & { nodeNum: number }): LastHopCandidate => ({
+  shortName: null,
+  role: null,
+  hopsAway: null,
+  lastHeard: null,
+  ...over,
+});
+
+describe('resolveLastHopName', () => {
+  it("returns 'unknown' when there is no relay info", () => {
+    expect(resolveLastHopName(undefined, [])).toBe('unknown');
+    expect(resolveLastHopName(null, [])).toBe('unknown');
+    expect(resolveLastHopName(0, [node({ nodeNum: 0x1234ab00 })])).toBe('unknown');
+  });
+
+  it('returns the short name of a node matching the relay low byte', () => {
+    // relay byte 0x4f matches nodeNum ...4f
+    const nodes = [node({ nodeNum: 0xaabbcc4f, shortName: 'RLY1', hopsAway: 0 })];
+    expect(resolveLastHopName(0x4f, nodes)).toBe('RLY1');
+  });
+
+  it('matches an exact full nodeNum when given one (defensive)', () => {
+    const nodes = [node({ nodeNum: 0xaabbcc4f, shortName: 'FULL' })];
+    expect(resolveLastHopName(0xaabbcc4f, nodes)).toBe('FULL');
+  });
+
+  it('falls back to the hex byte when the byte is known but no named node matches', () => {
+    expect(resolveLastHopName(0x4f, [])).toBe('0x4F');
+    // matching node exists but has no short name → still hex byte
+    expect(resolveLastHopName(0x4f, [node({ nodeNum: 0x0000004f, shortName: '' })])).toBe('0x4F');
+  });
+
+  it('zero-pads and upper-cases the hex byte', () => {
+    expect(resolveLastHopName(0x0a, [])).toBe('0x0A');
+    expect(resolveLastHopName(0xff, [])).toBe('0xFF');
+  });
+
+  it('excludes CLIENT_MUTE nodes (role 4) from relay matching', () => {
+    const nodes = [node({ nodeNum: 0x1111114f, shortName: 'MUTE', role: 4 })];
+    // The only byte match is CLIENT_MUTE → no named match → hex byte
+    expect(resolveLastHopName(0x4f, nodes)).toBe('0x4F');
+  });
+
+  it('prefers a plausible (≤1 hop) candidate over a distant one on byte collision', () => {
+    const nodes = [
+      node({ nodeNum: 0xaaaaaa4f, shortName: 'FAR', hopsAway: 5, lastHeard: 9999 }),
+      node({ nodeNum: 0xbbbbbb4f, shortName: 'NEAR', hopsAway: 1, lastHeard: 1 }),
+    ];
+    expect(resolveLastHopName(0x4f, nodes)).toBe('NEAR');
+  });
+
+  it('breaks ties among plausible candidates by most-recently-heard', () => {
+    const nodes = [
+      node({ nodeNum: 0xaaaaaa4f, shortName: 'OLD', hopsAway: 0, lastHeard: 100 }),
+      node({ nodeNum: 0xbbbbbb4f, shortName: 'RECENT', hopsAway: 0, lastHeard: 200 }),
+    ];
+    expect(resolveLastHopName(0x4f, nodes)).toBe('RECENT');
+  });
+});

--- a/src/server/utils/lastHop.ts
+++ b/src/server/utils/lastHop.ts
@@ -1,0 +1,73 @@
+/**
+ * Last-hop (relay node) name resolution for automation templates.
+ *
+ * Meshtastic stores only the *low byte* of the relaying node's number on each
+ * received packet (`MeshPacket.relay_node`). The `{LAST_HOP}` template variable
+ * resolves that byte to a human-friendly name, mirroring the Packet Monitor's
+ * display behaviour:
+ *   - short name when a matching node is known,
+ *   - the hex byte (e.g. `0x4F`) when the relay byte is set but no named node
+ *     in the mesh matches,
+ *   - `unknown` when there is no relay information at all.
+ *
+ * The Packet Monitor additionally disambiguates byte collisions client-side via
+ * RSSI proximity to direct-neighbour stats; that data isn't available server
+ * side, so we instead prefer plausible (≤1 hop) and most-recently-heard
+ * candidates.
+ *
+ * Implements: https://github.com/Yeraze/meshmonitor/issues/3318
+ */
+
+/** A node considered as a possible relay. */
+export interface LastHopCandidate {
+  nodeNum: number;
+  shortName?: string | null;
+  role?: number | null;
+  hopsAway?: number | null;
+  lastHeard?: number | null;
+}
+
+/** Meshtastic Config.DeviceConfig.Role.CLIENT_MUTE — never relays. */
+const CLIENT_MUTE_ROLE = 4;
+
+function hexByte(byte: number): string {
+  return `0x${(byte & 0xff).toString(16).padStart(2, '0').toUpperCase()}`;
+}
+
+/**
+ * Resolve a relay-node value to its display name.
+ *
+ * @param relayNode the stored relay value (low byte 0-255, or a full nodeNum
+ *   defensively); 0/null/undefined means "no relay info"
+ * @param candidates nodes to match against (typically recently-active nodes)
+ */
+export function resolveLastHopName(
+  relayNode: number | null | undefined,
+  candidates: LastHopCandidate[]
+): string {
+  if (relayNode == null || relayNode === 0) return 'unknown';
+
+  const byte = relayNode & 0xff;
+  const relayCapable = candidates.filter((n) => n.role !== CLIENT_MUTE_ROLE);
+
+  // Match an exact full nodeNum (defensive) or the stored low byte.
+  const matches = relayCapable.filter(
+    (n) => n.nodeNum === relayNode || (n.nodeNum & 0xff) === byte
+  );
+
+  // Prefer named candidates; among them favour plausible (≤1 hop) relays and the
+  // most recently heard, which is the best server-side guess at the real relay.
+  const named = matches
+    .filter((n) => typeof n.shortName === 'string' && n.shortName.trim().length > 0)
+    .sort((a, b) => {
+      const aPlausible = a.hopsAway == null || a.hopsAway <= 1 ? 0 : 1;
+      const bPlausible = b.hopsAway == null || b.hopsAway <= 1 ? 0 : 1;
+      if (aPlausible !== bPlausible) return aPlausible - bPlausible;
+      return (b.lastHeard ?? 0) - (a.lastHeard ?? 0);
+    });
+
+  if (named.length > 0) return named[0].shortName!.trim();
+
+  // Relay byte is known but no named node matches → hex byte fallback.
+  return hexByte(byte);
+}


### PR DESCRIPTION
## Summary

Closes #3318. Adds a `{LAST_HOP}` template variable that exposes the **last relay node's identity** in automation message templates — the same automations that already support `{HOPS}`/`{SNR}`/`{RSSI}` (autoresponder + auto-ack).

It resolves exactly like the Packet Monitor displays the relay:
- **short name** when a matching node is known,
- **hex byte** (e.g. `0x4F`) when the relay byte is set but no named node in the mesh matches,
- **`unknown`** when there is no relay info (direct message / relay byte 0).

## Implementation
- **New pure `src/server/utils/lastHop.ts`** — `resolveLastHopName(relayNode, candidates)`:
  - Meshtastic stores only the **low byte** of the relaying node (`MeshPacket.relay_node`), so it matches candidates on that byte (and on a full nodeNum defensively).
  - Excludes `CLIENT_MUTE` nodes (they don't relay).
  - The Packet Monitor disambiguates byte collisions client-side via RSSI proximity to direct-neighbour stats, which isn't available server-side — so this prefers **plausible (≤1 hop)** and **most-recently-heard** named candidates instead.
- **`meshtasticManager.ts`** — `replaceAcknowledgementTokens` gains a `relayNode` argument and a `{LAST_HOP}` token (resolved against `getActiveNodes`, 7-day window). All five call sites (auto-ack, auto-responder text/url/script-args) pass `message.relayNode`. Auto-announce is intentionally unaffected — it has no incoming relay, same as `{HOPS}`.
- **UI** — `{LAST_HOP}` added to the multi-hop token help list and the live sample preview in `AutoAcknowledgeSection`; documented in `docs/features/automation.md`.

## Testing
- `lastHop.test.ts` — unknown (0/null/undefined), low-byte match → short name, exact nodeNum match, hex-byte fallback (zero-padded, upper-cased), `CLIENT_MUTE` exclusion, hop-plausibility and recency tiebreaks.
- `meshtasticManager.lasthop.test.ts` — no-relay short-circuit (no DB call), `getActiveNodes` resolve, hex fallback when no node matches, and hex fallback when the node query throws.
- **Full Vitest suite: 6001 / 0 failures.** `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)