### PR TITLE
fix(unified): include MeshCore nodes in unified source node count

### DIFF
--- a/src/server/routes/unifiedRoutes.test.ts
+++ b/src/server/routes/unifiedRoutes.test.ts
@@ -53,6 +53,15 @@ vi.mock('../sourceManagerRegistry.js', () => ({
   }
 }));
 
+vi.mock('../meshcoreRegistry.js', () => ({
+  meshcoreManagerRegistry: {
+    get: vi.fn().mockReturnValue(null),
+  },
+}));
+
+import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
+const mockMeshcoreRegistry = meshcoreManagerRegistry as any;
+
 const mockDb = databaseService as any;
 
 const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
@@ -1063,6 +1072,43 @@ describe('Unified Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ nodeCount: 0, activeNodeCount: 0, connected: false });
       expect(mockDb.nodes.getDistinctNodeCount).toHaveBeenCalledWith([]);
+    });
+
+    it('includes MeshCore nodes from in-memory managers in the unified count (issue #3321)', async () => {
+      const SOURCE_MC = { id: 'src-mc', name: 'MeshCore', type: 'meshcore', enabled: true };
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_MC]);
+      // Meshtastic source has 10 distinct nodes in DB
+      mockDb.nodes.getDistinctNodeCount.mockResolvedValue(10);
+      mockDb.nodes.getDistinctActiveNodeCount.mockResolvedValue(5);
+
+      const now = Date.now();
+      const recentMs = now - 60_000; // 1 min ago — active
+      const staleMs = now - 8_000_000; // ~2.2h ago — inactive
+      const mcNodes = [
+        // Local node with no lastHeard (should count as active while connected)
+        { name: 'Local', publicKey: 'pk0', latitude: 1, longitude: 1, lastHeard: undefined },
+        { name: 'Node1', publicKey: 'pk1', latitude: 1, longitude: 1, lastHeard: recentMs },
+        { name: 'Node2', publicKey: 'pk2', latitude: 1, longitude: 1, lastHeard: staleMs },
+      ];
+      const mcManagerMock = {
+        getAllNodes: vi.fn().mockReturnValue(mcNodes),
+        getLocalNode: vi.fn().mockReturnValue(mcNodes[0]),
+        sourceId: 'src-mc',
+      };
+      mockMeshcoreRegistry.get.mockImplementation((id: string) =>
+        id === 'src-mc' ? mcManagerMock : null,
+      );
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/status');
+
+      expect(res.status).toBe(200);
+      // 10 meshtastic + 3 meshcore = 13 total
+      expect(res.body.nodeCount).toBe(13);
+      // 5 meshtastic active + 2 meshcore active (local node + Node1) = 7
+      expect(res.body.activeNodeCount).toBe(7);
+      // Only non-MeshCore IDs go to getDistinctNodeCount
+      expect(mockDb.nodes.getDistinctNodeCount).toHaveBeenCalledWith(['src-a']);
     });
   });
 

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -13,6 +13,7 @@ import { optionalAuth } from '../auth/authMiddleware.js';
 import { logger } from '../../utils/logger.js';
 import { PortNum, CHANNEL_DB_OFFSET, modemPresetChannelName } from '../constants/meshtastic.js';
 import { filterPacketsByPermissions, getAllowedChannels } from './packetPermissions.js';
+import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
 import type { DbChannelDatabase, DbPacketLog } from '../../db/types.js';
 import type { DbMeshCorePacket } from '../../db/repositories/meshcore.js';
 
@@ -1116,13 +1117,43 @@ router.get('/status', async (req: Request, res: Response) => {
         : false);
       if (canRead) allowedIds.push(source.id);
     }
-    // Distinct counts across permitted sources. `activeNodeCount` mirrors the
-    // per-source endpoint (issue #2883) using the same 2h window so the
+
+    // MeshCore nodes live in per-source in-memory managers (meshcoreManagerRegistry),
+    // not the shared `nodes` table — count them separately using the same 2h
+    // active window as the per-source /status endpoint (issue #3321).
+    const meshcoreAllowedIds = allowedIds.filter(
+      (id) => sources.find((s) => s.id === id)?.type === 'meshcore',
+    );
+    const meshtasticAllowedIds = allowedIds.filter(
+      (id) => sources.find((s) => s.id === id)?.type !== 'meshcore',
+    );
+
+    const activeCutoffMs = Date.now() - 7_200_000;
+    let mcNodeCount = 0;
+    let mcActiveNodeCount = 0;
+    for (const id of meshcoreAllowedIds) {
+      const mcManager = meshcoreManagerRegistry.get(id);
+      if (mcManager) {
+        const all = mcManager.getAllNodes();
+        mcNodeCount += all.length;
+        const localHasLastHeard = mcManager.getLocalNode()?.lastHeard != null;
+        mcActiveNodeCount += all.filter((n: any, i: number) => {
+          if (i === 0 && mcManager.getLocalNode() && !localHasLastHeard) return true;
+          return typeof n.lastHeard === 'number' && n.lastHeard >= activeCutoffMs;
+        }).length;
+      }
+    }
+
+    // Distinct counts across permitted non-MeshCore sources. `activeNodeCount` mirrors
+    // the per-source endpoint (issue #2883) using the same 2h window so the
     // Unified card and individual source cards line up.
-    const [nodeCount, activeNodeCount] = await Promise.all([
-      databaseService.nodes.getDistinctNodeCount(allowedIds),
-      databaseService.nodes.getDistinctActiveNodeCount(allowedIds),
+    const [meshtasticNodeCount, meshtasticActiveNodeCount] = await Promise.all([
+      databaseService.nodes.getDistinctNodeCount(meshtasticAllowedIds),
+      databaseService.nodes.getDistinctActiveNodeCount(meshtasticAllowedIds),
     ]);
+
+    const nodeCount = meshtasticNodeCount + mcNodeCount;
+    const activeNodeCount = meshtasticActiveNodeCount + mcActiveNodeCount;
 
     res.json({ nodeCount, activeNodeCount, connected: anyConnected });
   } catch (error) {


### PR DESCRIPTION
## Summary

Fixes #3321 — the Unified source card showed node counts from only the first (Meshtastic/MQTT) source, ignoring any MeshCore sources entirely.

- **Root cause**: `/api/unified/status` only queried the shared `nodes` DB table for distinct node counts. MeshCore nodes are never written to the `nodes` table — they live in per-source in-memory managers (`meshcoreManagerRegistry`). The per-source `/status` endpoint already handles this correctly; the unified endpoint did not.
- **Fix**: Import `meshcoreManagerRegistry` in `unifiedRoutes.ts`. In the `/status` handler, split `allowedIds` into MeshCore and non-MeshCore sources. Count MeshCore nodes via `getAllNodes()` (mirroring the per-source endpoint's logic, including the 2-hour active-node window), then sum with the Meshtastic/MQTT distinct count.
- **Test**: Added a test case covering a mixed Meshtastic + MeshCore setup, verifying the totals add up correctly and only non-MeshCore IDs are passed to `getDistinctNodeCount`.

## Test plan

- [ ] Configure MeshMonitor with at least one Meshtastic source and one MeshCore source
- [ ] Go to the start page (Source Overview)
- [ ] Confirm the Unified card's node count now reflects the sum of nodes from all sources
- [ ] Confirm the active node count ("X/Y active") also reflects both sources
- [ ] Confirm existing Meshtastic-only multi-source deployments are unaffected
- [ ] All Vitest tests pass (48 tests in `unifiedRoutes.test.ts`, 3 test files checked)

https://claude.ai/code/session_01FMwtSamiVnDeY3XLjsncKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMwtSamiVnDeY3XLjsncKE)_