### PR TITLE
fix(notifications): fix UNIQUE constraint error when configuring AppRise for a second source

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 78 migrations registered', () => {
-    expect(registry.count()).toBe(78);
+  it('has all 79 migrations registered', () => {
+    expect(registry.count()).toBe(79);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is meshcore_packet_log_bigint_timestamp', () => {
+  it('last migration is drop_residual_notif_prefs_user_id_unique', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(78);
-    expect(last.name).toContain('meshcore_packet_log_bigint_timestamp');
+    expect(last.number).toBe(79);
+    expect(last.name).toContain('drop_residual_notif_prefs_user_id_unique');
   });
 
-  it('migrations are sequentially numbered from 1 to 78', () => {
+  it('migrations are sequentially numbered from 1 to 79', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -93,6 +93,7 @@ import { migration as meshcorePacketLogMigration, runMigration075Postgres, runMi
 import { migration as lowBatteryColumnsMigration, runMigration076Postgres, runMigration076Mysql } from '../server/migrations/076_add_low_battery_columns.js';
 import { migration as normalizeMqttTelemetryKeysMigration, runMigration077Postgres, runMigration077Mysql } from '../server/migrations/077_normalize_mqtt_telemetry_keys.js';
 import { migration as meshcorePacketLogBigintMigration, runMigration078PacketLogBigintPostgres, runMigration078PacketLogBigintMysql } from '../server/migrations/078_meshcore_packet_log_bigint_timestamp.js';
+import { migration as dropResidualNotifPrefsUserIdUniqueMigration, runMigration079Postgres as runMigration079DropResidualPostgres, runMigration079Mysql as runMigration079DropResidualMysql } from '../server/migrations/079_drop_residual_notif_prefs_user_id_unique.js';
 
 // ============================================================================
 // Registry
@@ -1244,4 +1245,22 @@ registry.register({
   sqlite: (db) => meshcorePacketLogBigintMigration.up(db),
   postgres: (client) => runMigration078PacketLogBigintPostgres(client),
   mysql: (pool) => runMigration078PacketLogBigintMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 079: Drop residual single-column unique indexes on
+// user_notification_preferences.user_id. Migrations 028 and 051 dropped the
+// index by known names; this migration uses PRAGMA introspection on SQLite to
+// catch any naming variant that survived earlier cleanup, fixing:
+//   UNIQUE constraint failed: user_notification_preferences.user_id
+// when saving notification preferences for a second source.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 79,
+  name: 'drop_residual_notif_prefs_user_id_unique',
+  settingsKey: 'migration_079_drop_residual_notif_prefs_user_id_unique',
+  sqlite: (db) => dropResidualNotifPrefsUserIdUniqueMigration.up(db),
+  postgres: (client) => runMigration079DropResidualPostgres(client),
+  mysql: (pool) => runMigration079DropResidualMysql(pool),
 });

--- a/src/db/repositories/notifications.ts
+++ b/src/db/repositories/notifications.ts
@@ -263,19 +263,38 @@ export class NotificationsRepository extends BaseRepository {
 
     try {
       if (this.isSQLite()) {
-        // SQLite doesn't have notifyOnChannelMessage column
-        await (this.db as any)
-          .insert(userNotificationPreferences)
-          .values({
-            userId,
-            sourceId: effectiveSourceId,
-            ...setData,
-            createdAt: now,
-          })
-          .onConflictDoUpdate({
-            target: [userNotificationPreferences.userId, userNotificationPreferences.sourceId],
-            set: setData,
-          });
+        // SQLite doesn't have notifyOnChannelMessage column.
+        // Use SELECT + UPDATE/INSERT instead of onConflictDoUpdate to avoid
+        // failures if a residual single-column unique on user_id is present
+        // (migration 079 cleans it up, but this path is safe regardless).
+        const db = this.getSqliteDb();
+        const existing = await db
+          .select({ id: userNotificationPreferences.id })
+          .from(userNotificationPreferences)
+          .where(and(
+            eq(userNotificationPreferences.userId, userId),
+            eq(userNotificationPreferences.sourceId, effectiveSourceId)
+          ))
+          .limit(1);
+
+        if (existing.length > 0) {
+          await db
+            .update(userNotificationPreferences)
+            .set(setData)
+            .where(and(
+              eq(userNotificationPreferences.userId, userId),
+              eq(userNotificationPreferences.sourceId, effectiveSourceId)
+            ));
+        } else {
+          await db
+            .insert(userNotificationPreferences)
+            .values({
+              userId,
+              sourceId: effectiveSourceId,
+              ...setData,
+              createdAt: now,
+            });
+        }
       } else if (this.isMySQL()) {
         const db = this.getMysqlDb();
         await db

--- a/src/server/migrations/079_drop_residual_notif_prefs_user_id_unique.test.ts
+++ b/src/server/migrations/079_drop_residual_notif_prefs_user_id_unique.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Migration 079 — Drop residual single-column unique indexes on
+ * user_notification_preferences.user_id.
+ *
+ * Tests that the migration uses PRAGMA introspection to find and drop any
+ * single-column unique index on user_id regardless of how it was named,
+ * leaving the correct composite (user_id, source_id) index intact.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './079_drop_residual_notif_prefs_user_id_unique.js';
+
+function createTableWithCompositeUnique(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE user_notification_preferences (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      source_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE UNIQUE INDEX idx_user_notification_preferences_user_source
+      ON user_notification_preferences(user_id, source_id);
+  `);
+}
+
+describe('Migration 079 — drop residual single-column user_id unique', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    createTableWithCompositeUnique(db);
+  });
+
+  it('drops an old single-column unique index by the legacy name from migration 015', () => {
+    db.exec(`CREATE UNIQUE INDEX idx_user_notification_preferences_user_id ON user_notification_preferences(user_id)`);
+
+    migration.up(db);
+
+    const indexes = db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='user_notification_preferences'
+    `).all() as any[];
+    const names = indexes.map(i => i.name);
+
+    expect(names).not.toContain('idx_user_notification_preferences_user_id');
+    expect(names).toContain('idx_user_notification_preferences_user_source');
+  });
+
+  it('drops a single-column unique index with any arbitrary name', () => {
+    db.exec(`CREATE UNIQUE INDEX some_other_unique_name ON user_notification_preferences(user_id)`);
+
+    migration.up(db);
+
+    const indexes = db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='user_notification_preferences'
+    `).all() as any[];
+    const names = indexes.map(i => i.name);
+
+    expect(names).not.toContain('some_other_unique_name');
+    expect(names).toContain('idx_user_notification_preferences_user_source');
+  });
+
+  it('leaves the composite (user_id, source_id) unique index intact', () => {
+    migration.up(db);
+
+    const indexes = db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='user_notification_preferences'
+    `).all() as any[];
+    const names = indexes.map(i => i.name);
+
+    expect(names).toContain('idx_user_notification_preferences_user_source');
+  });
+
+  it('does not drop non-unique single-column indexes on user_id', () => {
+    db.exec(`CREATE INDEX idx_non_unique_user_id ON user_notification_preferences(user_id)`);
+
+    migration.up(db);
+
+    const indexes = db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='user_notification_preferences'
+    `).all() as any[];
+    const names = indexes.map(i => i.name);
+
+    expect(names).toContain('idx_non_unique_user_id');
+  });
+
+  it('is idempotent — running twice does not throw and leaves schema stable', () => {
+    db.exec(`CREATE UNIQUE INDEX idx_user_notification_preferences_user_id ON user_notification_preferences(user_id)`);
+
+    migration.up(db);
+    expect(() => migration.up(db)).not.toThrow();
+
+    const indexes = db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='user_notification_preferences'
+    `).all() as any[];
+    expect(indexes.map((i: any) => i.name)).toContain('idx_user_notification_preferences_user_source');
+  });
+
+  it('allows per-source upserts after migration (simulating the fixed bug scenario)', () => {
+    // Simulate the bug: single-column unique on user_id coexists with composite unique
+    db.exec(`CREATE UNIQUE INDEX idx_user_notification_preferences_user_id ON user_notification_preferences(user_id)`);
+
+    // Migration drops the single-column unique
+    migration.up(db);
+
+    const now = Date.now();
+    // Insert first source row
+    db.prepare(
+      `INSERT INTO user_notification_preferences (user_id, source_id, created_at, updated_at) VALUES (?, ?, ?, ?)`
+    ).run(1, 'source-A', now, now);
+
+    // Insert second source row — would have failed with UNIQUE constraint on user_id before fix
+    expect(() => {
+      db.prepare(
+        `INSERT INTO user_notification_preferences (user_id, source_id, created_at, updated_at) VALUES (?, ?, ?, ?)`
+      ).run(1, 'source-B', now, now);
+    }).not.toThrow();
+
+    const rows = db
+      .prepare(`SELECT source_id FROM user_notification_preferences WHERE user_id = 1 ORDER BY source_id`)
+      .all() as any[];
+    expect(rows.map(r => r.source_id)).toEqual(['source-A', 'source-B']);
+  });
+});

--- a/src/server/migrations/079_drop_residual_notif_prefs_user_id_unique.ts
+++ b/src/server/migrations/079_drop_residual_notif_prefs_user_id_unique.ts
@@ -1,0 +1,124 @@
+/**
+ * Migration 079: Drop residual single-column unique indexes on
+ * user_notification_preferences.user_id.
+ *
+ * Migrations 028 and 051 dropped the old unique index created by migration 015
+ * (`idx_user_notification_preferences_user_id`) by name. However, some databases
+ * have a differently-named single-column unique constraint on user_id (e.g. from
+ * an older Drizzle schema push, or a failed migration). That leftover constraint
+ * causes the per-source upsert in saveUserPreferences to fail with:
+ *
+ *   SqliteError: UNIQUE constraint failed: user_notification_preferences.user_id
+ *
+ * because SQLite fires the old single-column unique BEFORE the
+ * ON CONFLICT (user_id, source_id) handler can resolve the composite-key conflict.
+ *
+ * This migration uses PRAGMA index_info introspection to find and drop every
+ * unique index on user_notification_preferences that covers only the user_id column,
+ * regardless of how it was named, leaving the correct composite
+ * (user_id, source_id) unique intact.
+ *
+ * Idempotent — safe to run repeatedly.
+ */
+import type Database from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+export const migration = {
+  up: (db: Database.Database) => {
+    // Get all named indexes on user_notification_preferences
+    const indexes = db.prepare(`
+      SELECT name FROM sqlite_master
+      WHERE type = 'index'
+        AND tbl_name = 'user_notification_preferences'
+        AND sql IS NOT NULL
+    `).all() as Array<{ name: string }>;
+
+    for (const idx of indexes) {
+      // PRAGMA index_info returns one row per indexed column
+      const cols = db.prepare(`PRAGMA index_info("${idx.name}")`).all() as Array<{ name: string }>;
+
+      if (cols.length !== 1 || cols[0].name !== 'user_id') {
+        continue; // Not a single-column index on user_id — leave it alone
+      }
+
+      // Confirm it is a UNIQUE index before dropping
+      const idxList = db.prepare(`PRAGMA index_list('user_notification_preferences')`).all() as Array<{
+        name: string;
+        unique: number;
+      }>;
+      const meta = idxList.find(i => i.name === idx.name);
+      if (!meta || !meta.unique) {
+        continue; // Non-unique — leave it alone
+      }
+
+      try {
+        db.exec(`DROP INDEX IF EXISTS "${idx.name}"`);
+        logger.info(`Migration 079: dropped residual single-column unique index "${idx.name}" on user_notification_preferences`);
+      } catch (e: any) {
+        logger.warn(`Migration 079: could not drop index "${idx.name}": ${e.message}`);
+      }
+    }
+  },
+};
+
+// PostgreSQL: belt-and-braces cleanup — same logic as migration 051 but also
+// catches any single-column unique constraint that wasn't dropped by name earlier.
+export async function runMigration079Postgres(client: any): Promise<void> {
+  // Drop all known names first
+  await client.query(`
+    ALTER TABLE user_notification_preferences
+    DROP CONSTRAINT IF EXISTS "user_notification_preferences_userId_unique"
+  `);
+  await client.query(`
+    ALTER TABLE user_notification_preferences
+    DROP CONSTRAINT IF EXISTS "user_notification_preferences_userId_key"
+  `);
+
+  // Drop any remaining single-column unique on userId via introspection
+  const { rows } = await client.query(`
+    SELECT con.conname AS name
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+    WHERE ns.nspname = 'public'
+      AND rel.relname = 'user_notification_preferences'
+      AND con.contype = 'u'
+      AND array_length(con.conkey, 1) = 1
+      AND EXISTS (
+        SELECT 1 FROM pg_attribute att
+        WHERE att.attrelid = rel.oid
+          AND att.attnum = con.conkey[1]
+          AND att.attname = 'userId'
+      )
+  `);
+  for (const row of rows as Array<{ name: string }>) {
+    await client.query(
+      `ALTER TABLE user_notification_preferences DROP CONSTRAINT IF EXISTS "${row.name}"`
+    );
+  }
+}
+
+// MySQL: belt-and-braces cleanup — drop any single-column unique on userId.
+export async function runMigration079Mysql(pool: any): Promise<void> {
+  const [rows] = await pool.query(`
+    SELECT INDEX_NAME
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'user_notification_preferences'
+      AND NON_UNIQUE = 0
+      AND SEQ_IN_INDEX = 1
+      AND COLUMN_NAME = 'userId'
+    GROUP BY INDEX_NAME
+    HAVING COUNT(*) = 1
+  `);
+  for (const row of (rows as Array<{ INDEX_NAME: string }>)) {
+    if (row.INDEX_NAME === 'PRIMARY') continue;
+    try {
+      await pool.query(
+        `ALTER TABLE user_notification_preferences DROP INDEX \`${row.INDEX_NAME}\``
+      );
+    } catch {
+      // Ignore if already gone
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #3324 — saving AppRise notification preferences for a second source fails with `UNIQUE constraint failed: user_notification_preferences.user_id`.

**Root cause:** A residual single-column `UNIQUE` constraint on `user_notification_preferences.user_id` survived earlier migrations (028 and 051 dropped it by two known index names, but some databases had a differently-named constraint). When inserting a second source's preferences, SQLite fires that old constraint before the `ON CONFLICT (user_id, source_id)` handler can resolve the composite-key conflict.

**Changes:**

- **`src/server/migrations/079_drop_residual_notif_prefs_user_id_unique.ts`** — New migration that uses `PRAGMA index_info` introspection to find and drop *all* single-column unique indexes on `user_id` in `user_notification_preferences`, regardless of how they were named. Equivalent defensive introspection for PostgreSQL and MySQL.

- **`src/db/repositories/notifications.ts`** — In `saveUserPreferences`, replaced the SQLite `onConflictDoUpdate` (which breaks when a competing unique constraint fires) with a manual `SELECT + UPDATE/INSERT` pattern. Safe regardless of constraint state; the migration is the real fix, this is belt-and-suspenders.

- **`src/db/migrations.ts` / `src/db/migrations.test.ts`** — Register migration 079; update count assertion to 79.

- **`src/server/migrations/079_drop_residual_notif_prefs_user_id_unique.test.ts`** — Tests that the migration drops single-column unique indexes by any name, leaves the composite unique intact, and that the per-source upsert works correctly after the migration runs.

## Test plan

- [ ] Verify `src/db/migrations.test.ts` passes (9/9 — registry count and ordering)
- [ ] Verify migration 079 test passes in Docker dev container (native `better-sqlite3` required)
- [ ] Manual: configure two Meshtastic TCP sources, enable AppRise notifications on source 1, then enable on source 2 — both should save successfully
- [ ] Confirm existing databases that already have the composite unique (no residual constraint) are unaffected by the migration (idempotent no-op)

https://claude.ai/code/session_01X7WjkxnihgsakiVXMjp6YG

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7WjkxnihgsakiVXMjp6YG)_