### PR TITLE
fix(mqtt): implement poll-path manager methods for broker sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **Airtime cutoff — neighbour-averaged source**: The airtime-utilization cutoff (Automation page) can now measure Channel Utilization from *nearby infrastructure* instead of the local node. In "Nearby infrastructure" mode it averages the Channel Utilization of the 3 strongest-RSSI directly-heard (0-hop) router/repeater nodes — useful when a well-placed node under-reports the wider mesh. Default remains the local node's own Channel Utilization; the live banner shows which source is in use and how many neighbours were sampled.
 
+### Fixes
+
+- **MQTT broker source dashboard/map showed no nodes**: `MqttBrokerManager` was missing the `getAllNodesAsync` / `getConnectionStatus` / `getDeviceConfig` methods that the consolidated `/api/poll` (and `/api/device/tx-status`, `/api/messages/unread-counts`) endpoints call, so those endpoints threw `TypeError: ... is not a function` and returned HTTP 500 for `mqtt_broker` sources. The dashboard and map therefore received no node data and showed no positions/pins, even though node positions were being ingested and stored correctly. The broker manager now implements the same DB-backed read methods as `MqttBridgeManager`.
+
 ## [4.9.0] - 2026-06-05
 
 # MeshMonitor v4.9.0

--- a/src/server/mqttBrokerManager.pollMethods.test.ts
+++ b/src/server/mqttBrokerManager.pollMethods.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression test for the broker /api/poll 500.
+ *
+ * The consolidated /api/poll (and /api/device/tx-status, /api/messages/
+ * unread-counts) call getAllNodesAsync() / getConnectionStatus() /
+ * getDeviceConfig() on the resolved source manager. MqttBrokerManager was
+ * missing these, so an mqtt_broker source threw
+ * `TypeError: activeManager.getAllNodesAsync is not a function` → 500 →
+ * the dashboard/map received no nodes and showed no pins, even though node
+ * positions were stored fine. This test pins the method surface that
+ * MqttBridgeManager and MeshtasticManager also provide.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const loadAllNodesAsDeviceInfo = vi.fn();
+
+vi.mock('./utils/dbNodeMapper.js', () => ({
+  loadAllNodesAsDeviceInfo: (...args: unknown[]) => loadAllNodesAsDeviceInfo(...args),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { MqttBrokerManager } from './mqttBrokerManager.js';
+
+function makeManager() {
+  return new MqttBrokerManager('broker-src-1', 'Test Broker', {
+    listener: { port: 0 },
+    auth: { username: 'u', password: 'p' },
+    gateway: { nodeNum: 0x11223344, nodeId: '!11223344', longName: 'GW', shortName: 'GW' },
+  });
+}
+
+describe('MqttBrokerManager — /api/poll method surface', () => {
+  let mgr: MqttBrokerManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mgr = makeManager();
+  });
+
+  it('exposes the methods the consolidated poll endpoint calls', () => {
+    // These were the exact methods that threw "is not a function" for broker sources.
+    expect(typeof (mgr as any).getAllNodesAsync).toBe('function');
+    expect(typeof (mgr as any).getConnectionStatus).toBe('function');
+    expect(typeof (mgr as any).getDeviceConfig).toBe('function');
+    expect(typeof (mgr as any).getLocalNodeInfo).toBe('function');
+  });
+
+  it('getAllNodesAsync returns the DB-backed nodes for this source', async () => {
+    const nodes = [{ nodeNum: 1 }, { nodeNum: 2 }] as any;
+    loadAllNodesAsDeviceInfo.mockResolvedValue(nodes);
+    const result = await mgr.getAllNodesAsync('broker-src-1');
+    expect(loadAllNodesAsDeviceInfo).toHaveBeenCalledWith('broker-src-1');
+    expect(result).toBe(nodes);
+  });
+
+  it('getConnectionStatus reports a Meshtastic-shaped status (not started → disconnected)', async () => {
+    const status = await mgr.getConnectionStatus();
+    expect(status).toMatchObject({
+      connected: false,
+      nodeResponsive: false,
+      configuring: false,
+    });
+  });
+
+  it('getDeviceConfig / getDeviceNodeNums / getSecurityKeys return safe defaults', async () => {
+    expect(await mgr.getDeviceConfig()).toBeNull();
+    expect((mgr as any).getDeviceNodeNums()).toEqual([]);
+    expect((mgr as any).getSecurityKeys()).toEqual({ publicKey: null, privateKey: null });
+  });
+});

--- a/src/server/mqttBrokerManager.ts
+++ b/src/server/mqttBrokerManager.ts
@@ -17,6 +17,8 @@ import { ingestServiceEnvelope, bootstrapMqttChannelDatabase } from './mqttInges
 import meshtasticProtobufService from './meshtasticProtobufService.js';
 import type { ISourceManager, SourceStatus } from './sourceManagerRegistry.js';
 import type { Source } from '../db/repositories/sources.js';
+import { loadAllNodesAsDeviceInfo } from './utils/dbNodeMapper.js';
+import type { DeviceInfo } from './meshtasticManager.js';
 import { logger } from '../utils/logger.js';
 
 export interface MqttBrokerSourceConfig {
@@ -142,6 +144,64 @@ export class MqttBrokerManager extends EventEmitter implements ISourceManager {
       longName: this.config.gateway.longName,
       shortName: this.config.gateway.shortName,
     };
+  }
+
+  /**
+   * Meshtastic-shaped connection status, used by /api/poll and /api/connection
+   * when scoped to this source. The embedded broker is the "device" here, so
+   * `connected` tracks the listener and `nodeResponsive` follows it (the
+   * dashboard shouldn't fall into the "node-offline" UX while the broker is up).
+   * Mirrors MqttBridgeManager.getConnectionStatus.
+   */
+  async getConnectionStatus(): Promise<{
+    connected: boolean;
+    nodeResponsive: boolean;
+    configuring: boolean;
+    nodeIp: string;
+    userDisconnected?: boolean;
+  }> {
+    const connected = this.broker?.getStatus()?.listening ?? false;
+    return {
+      connected,
+      nodeResponsive: connected,
+      configuring: false,
+      nodeIp: '',
+      userDisconnected: false,
+    };
+  }
+
+  /**
+   * DB-backed node list, scoped to this broker's source. Mirrors
+   * MeshtasticManager/MqttBridgeManager.getAllNodesAsync so the consolidated
+   * /api/poll endpoint doesn't have to special-case the manager type.
+   * (Without this, /api/poll threw `getAllNodesAsync is not a function` and
+   * 500'd for broker sources, so the dashboard/map showed no nodes — #issue.)
+   */
+  async getAllNodesAsync(sourceId?: string): Promise<DeviceInfo[]> {
+    return loadAllNodesAsDeviceInfo(sourceId);
+  }
+
+  /**
+   * The embedded broker has no local LoRa device, so there is no device config
+   * to query. Used by /api/device/tx-status — return null like the bridge so
+   * the UI doesn't gate features on a config that will never arrive.
+   */
+  async getDeviceConfig(): Promise<any> {
+    return null;
+  }
+
+  /**
+   * No device-resident NodeDB for a broker source.
+   */
+  getDeviceNodeNums(): number[] {
+    return [];
+  }
+
+  /**
+   * Broker sources have no PKI keypair of their own.
+   */
+  getSecurityKeys(): { publicKey: string | null; privateKey: string | null } {
+    return { publicKey: null, privateKey: null };
   }
 
   /** Publish a raw payload to a topic on this broker. */


### PR DESCRIPTION
## Summary

Fixes MQTT **broker** sources showing **no node positions on the dashboard/map** ("zooms around but no pins"), reported for a user's MQTT sources. Diagnosed live against a running instance.

## Root cause
The consolidated **`/api/poll`** endpoint — which feeds the dashboard/map's live node state — calls `getAllNodesAsync()`, `getConnectionStatus()`, and `getLocalNodeInfo()` on the resolved source manager (and `/api/device/tx-status` calls `getDeviceConfig()`, `/api/messages/unread-counts` calls `getAllNodesAsync()`).

`MeshtasticManager` and `MqttBridgeManager` implement these, but **`MqttBrokerManager` did not**. So for an `mqtt_broker` source the endpoints threw:

```
TypeError: activeManager.getAllNodesAsync is not a function   → HTTP 500
```

Because the map only gets nodes via `/api/poll`, broker sources rendered **0 markers** — even though positions were ingested and stored correctly (`/api/nodes`, which reads the DB directly, returned them fine). Bridge and TCP/serial sources were unaffected (their managers have the methods).

**Position ingestion was never the problem** — verified 695 stored positions on the broker source. (An earlier "missing precisionBits" hypothesis was investigated and disproven.)

## Evidence (live container)
- Broker source Nodes-map: **0 markers**; `/api/poll?sourceId=<broker>` → **500** repeatedly; logs: `Error in consolidated poll endpoint: TypeError: activeManager.getAllNodesAsync is not a function`.
- Bridge source: 172 markers (works). Unified dashboard: 265.

## Fix
Implement the same DB-backed read methods on `MqttBrokerManager` that `MqttBridgeManager` already provides:
- `getAllNodesAsync(sourceId?)` → `loadAllNodesAsDeviceInfo(sourceId)`
- `getConnectionStatus()` → broker-listener-backed Meshtastic-shaped status
- `getDeviceConfig()` → `null` (no local LoRa device)
- `getDeviceNodeNums()` → `[]`, `getSecurityKeys()` → `{ publicKey: null, privateKey: null }`

## Testing
- New `mqttBrokerManager.pollMethods.test.ts` pins the exact method surface `/api/poll` requires (the methods exist + behave), so this `TypeError` regression can't recur.
- Existing broker/bridge manager tests still pass.
- **Full Vitest suite: 6028 / 0 failures.** `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)