### PR TITLE
chore: release v4.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.9.1] - 2026-06-05
+
 ### Features
 
 - **MeshCore low-battery alerts (voltage-based)**: Low-battery notifications now work for MeshCore sources. MeshCore devices report battery as a voltage (mV) rather than a 0-100 percentage, so a new per-user voltage threshold (default 3300 mV) is compared against each monitored node's `batteryMv`. The Notifications settings expose both thresholds — percentage for Meshtastic, mV for MeshCore — and the monitored-node picker now lists all MeshCore nodes (not just those with a GPS fix) so battery-powered companions can be selected. Resolves #3331.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # MeshMonitor — Claude Agent Brief
 
-**Version:** 4.9.0 (multi-source architecture)
+**Version:** 4.9.1 (multi-source architecture)
 **Stack:** React 19 + TS + Vite frontend / Node.js 20+ (Docker image ships Node 24; CI matrix covers 20/22/24/25) + Express 5 + TS backend / SQLite (default), PostgreSQL, MySQL via Drizzle ORM / Meshtastic protobuf-over-TCP and MeshCore (native `meshcore.js` for companion, serial CLI for repeater) through a per-source manager registry.
 
 ## Read order for new agents

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.9.0",
+  "version": "4.9.1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.9.0
-appVersion: "4.9.0"
+version: 4.9.1
+appVersion: "4.9.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.9.0",
+      "version": "4.9.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Version bump **4.9.0 → 4.9.1**, rolling the changes merged since the 4.9.0 release into a patch release. Labeled `system-test` so the hardware suite runs against it.

### Features
- **MeshCore low-battery alerts (voltage-based)** — voltage-threshold (default 3300 mV) low-battery notifications for MeshCore companions. Resolves #3331.
- **Airtime cutoff — neighbour-averaged source** — Automation cutoff can average Channel Utilization from the 3 strongest-RSSI 0-hop router/repeater neighbours instead of the local node. (#3328)

### Fixes
- **MQTT broker source dashboard/map showed no nodes** — `MqttBrokerManager` now implements the `getAllNodesAsync` / `getConnectionStatus` / `getDeviceConfig` read methods that `/api/poll` requires, so broker sources stop 500'ing and render node positions/pins. (#3333)

### Files bumped
`package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml` (version + appVersion), `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, `CLAUDE.md` version banner, and `CHANGELOG.md` (`[Unreleased]` → `[4.9.1] - 2026-06-05`).

### Verification
- `tsc --noEmit`: clean
- Full Vitest suite: **6033 passed / 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)