### PR TITLE
fix: scope channel reorder to its source (MeshCore/Meshtastic bleed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Channel reorder could replace a Meshtastic channel with a MeshCore one**: The `POST /api/channels/reorder` handler read the current channels with an unscoped `getAllChannels()` and keyed them into a slot-indexed map. Because MeshCore and Meshtastic channels share the `channels` table and both use slot ids 0-7, a MeshCore channel occupying the same slot could win the lookup and be written back to the Meshtastic device. The reorder read and database writes are now scoped to the source being edited (`reorderManager.sourceId`), keeping each source's channels isolated.
+
 ## [4.9.1] - 2026-06-05
 
 ### Features

--- a/src/db/repositories/channels.test.ts
+++ b/src/db/repositories/channels.test.ts
@@ -240,6 +240,40 @@ function runChannelsTests(getBackend: () => TestBackend) {
     expect(channels[2].id).toBe(3);
   });
 
+  // Regression: the POST /api/channels/reorder handler builds a slot-keyed Map
+  // from getAllChannels() and writes each slot back to the source it is
+  // reordering. MeshCore and Meshtastic channels share the `channels` table
+  // and both use slot ids 0-7, so an UNSCOPED getAllChannels() would let a
+  // MeshCore channel at slot N collide with the Meshtastic channel at slot N in
+  // that Map — silently replacing a Meshtastic channel with a MeshCore one on
+  // reorder. Scoping the read by sourceId is what keeps reorder isolated.
+  it('getAllChannels - scopes by sourceId so reorder cannot bleed channels across sources', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    // Meshtastic source: slot 0 (Primary) and slot 1.
+    await repo.upsertChannel({ id: 0, name: 'MT-Primary', psk: 'p0', role: 1 }, 'mt-1');
+    await repo.upsertChannel({ id: 1, name: 'MT-Secondary', psk: 'p1', role: 2 }, 'mt-1');
+    // MeshCore source: also occupies slots 0 and 1 in the same table.
+    await repo.upsertChannel({ id: 0, name: 'MC-Public', psk: 'mc0', role: 1 }, 'mc-1');
+    await repo.upsertChannel({ id: 1, name: 'MC-Room', psk: 'mc1', role: 2 }, 'mc-1');
+
+    // Mirror the reorder handler: scoped read -> slot-keyed Map.
+    const mtChannels = await repo.getAllChannels('mt-1');
+    const mtBySlot = new Map(mtChannels.map(ch => [ch.id, ch]));
+    expect(mtBySlot.get(0)!.name).toBe('MT-Primary');
+    expect(mtBySlot.get(1)!.name).toBe('MT-Secondary');
+    // No MeshCore channel leaked into the Meshtastic source's view.
+    expect(mtChannels.every(ch => ch.name.startsWith('MT-'))).toBe(true);
+
+    // And the reverse: the MeshCore source sees only its own channels.
+    const mcChannels = await repo.getAllChannels('mc-1');
+    expect(mcChannels.every(ch => ch.name.startsWith('MC-'))).toBe(true);
+  });
+
   it('getChannelCount - returns correct count', async () => {
     const backend = getBackend();
     if (!backend.available) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3429,14 +3429,24 @@ apiRouter.post('/channels/reorder', requireAuth(), async (req, res) => {
       }
     }
 
-    const allChannels = await databaseService.channels.getAllChannels();
+    // Resolve the target source manager first so the channel lookup below can
+    // be scoped to THIS source. MeshCore and Meshtastic channels share the
+    // `channels` table and both use slot ids 0-7, so an unscoped
+    // getAllChannels() returns rows from every source; the slot-keyed Map then
+    // collapses same-id rows and a MeshCore channel can win the slot being
+    // reordered — silently overwriting a Meshtastic channel with a MeshCore
+    // one (and vice-versa). Scoping to reorderManager.sourceId keeps the
+    // reorder confined to the source the user is actually editing.
+    const reorderManager = (resolveSourceManager(reorderSourceId));
+    const reorderSourceScope = reorderManager.sourceId;
+
+    const allChannels = await databaseService.channels.getAllChannels(reorderSourceScope);
 
     // Build the new channel configs based on the reorder mapping
     // newOrder[newSlot] = oldSlot — means "new slot i gets the channel from old slot newOrder[i]"
     const channelsBySlot = new Map(allChannels.map(ch => [ch.id, ch]));
 
     // Begin edit settings transaction
-    const reorderManager = (resolveSourceManager(reorderSourceId));
     logger.info(`🔄 Beginning channel reorder: ${newOrder.join(',')}`);
     await reorderManager.beginEditSettings();
     // Pacing: device firmware silently drops admin packets that arrive too soon
@@ -3461,7 +3471,8 @@ apiRouter.post('/channels/reorder', requireAuth(), async (req, res) => {
           positionPrecision: sourceChannel.positionPrecision ?? undefined,
         });
 
-        // Update database
+        // Update database (scoped to this source; reorder is an authoritative
+        // user write, so allow blank names to overwrite)
         await databaseService.channels.upsertChannel({
           id: newSlot,
           name: sourceChannel.name || '',
@@ -3470,7 +3481,7 @@ apiRouter.post('/channels/reorder', requireAuth(), async (req, res) => {
           uplinkEnabled: sourceChannel.uplinkEnabled,
           downlinkEnabled: sourceChannel.downlinkEnabled,
           positionPrecision: sourceChannel.positionPrecision,
-        });
+        }, reorderSourceScope, { allowBlankName: true });
       } else {
         // Empty/disabled slot
         await reorderManager.setChannelConfig(newSlot, {
@@ -3483,7 +3494,7 @@ apiRouter.post('/channels/reorder', requireAuth(), async (req, res) => {
           name: '',
           psk: null,
           role: 0,
-        });
+        }, reorderSourceScope, { allowBlankName: true });
       }
 
       await new Promise((resolve) => setTimeout(resolve, 1000));


### PR DESCRIPTION
## Summary
A user reordering Meshtastic channels via drag-and-drop had a channel silently replaced with a MeshCore channel. The cause is server-side: the reorder handler read the current channels without scoping to a source, then keyed them into a slot-indexed map. Since MeshCore and Meshtastic channels share the `channels` table and both use slot ids 0-7, a MeshCore channel at the same slot could win the lookup and be written back to the Meshtastic device. This PR scopes the reorder read and writes to the source being edited.

## Changes
- `src/server/server.ts` (`POST /api/channels/reorder`):
  - Resolve the target source manager first and scope `getAllChannels()` to `reorderManager.sourceId` instead of reading channels from every source.
  - Scope both `upsertChannel()` writes to the same source, and pass `{ allowBlankName: true }` so an emptied slot is actually cleared (the default ingest-protection logic would otherwise preserve a stale name on a slot the reorder is blanking).
- `src/db/repositories/channels.test.ts`: regression test seeding a Meshtastic and a MeshCore source both occupying slots 0/1, mirroring the handler's slot-keyed-Map logic and asserting no cross-source bleed (runs across all three DB backends).
- `CHANGELOG.md`: Unreleased bug-fix entry.

## Issues Resolved
None (reported directly by a user).

## Documentation Updates
No documentation changes needed — this is a correctness fix; the reorder feature's documented behavior is unchanged.

## Testing
- [x] Unit tests pass (6042 tests)
- [x] TypeScript compiles cleanly
- [ ] Reviewer: with a Meshtastic + MeshCore source both having channels in slots 0-7, reorder Meshtastic channels and confirm only Meshtastic channels are affected and MeshCore channels are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)