### PR TITLE
chore: bump version to 4.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.9.2] - 2026-06-06
+
 ### Features
 
 - **Reorderable Sources list on the Unified View**: Admins can now drag-and-drop the source cards in the Dashboard / Unified View sidebar to control their order, mirroring the existing channel-reorder UX. The order is stored server-side (new `sources.displayOrder` column, migration 081) so it is shared across all viewers, and a grab handle only appears for users with `sources:write`. The Unified aggregate card stays pinned at the top and is not draggable; new sources append to the end of the list. Resolves #3338.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # MeshMonitor — Claude Agent Brief
 
-**Version:** 4.9.1 (multi-source architecture)
+**Version:** 4.9.2 (multi-source architecture)
 **Stack:** React 19 + TS + Vite frontend / Node.js 20+ (Docker image ships Node 24; CI matrix covers 20/22/24/25) + Express 5 + TS backend / SQLite (default), PostgreSQL, MySQL via Drizzle ORM / Meshtastic protobuf-over-TCP and MeshCore (native `meshcore.js` for companion, serial CLI for repeater) through a per-source manager registry.
 
 ## Read order for new agents
@@ -98,7 +98,7 @@ For per-source permission tests, mock `getUserPermissionSetAsync(userId, sourceI
 ### Migration Registry
 Migrations use a centralized registry in `src/db/migrations.ts`. Each migration has functions for all three backends.
 
-**Current migration count:** 78 (latest: `078_meshcore_packet_log_bigint_timestamp`).
+**Current migration count:** 81 (latest: `081_add_sources_display_order`).
 
 For the full "adding a migration" recipe see [Migration recipe](#migration-recipe) below.
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.9.1",
+  "version": "4.9.2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/development/database.md
+++ b/docs/development/database.md
@@ -270,7 +270,7 @@ Or with Docker:
 docker run --rm -it \
   -v $(pwd)/meshmonitor.db:/data/meshmonitor.db:ro \
   --network host \
-  ghcr.io/yeraze/meshmonitor:4.9.1 \
+  ghcr.io/yeraze/meshmonitor:4.9.2 \
   npm run migrate-db -- \
     --from sqlite:/data/meshmonitor.db \
     --to postgres://meshmonitor:password@localhost:5432/meshmonitor

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.9.1
-appVersion: "4.9.1"
+version: 4.9.2
+appVersion: "4.9.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.9.1",
+      "version": "4.9.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
Release **4.9.2**. Bumps all version files and promotes the accumulated `[Unreleased]` changelog entries into a dated 4.9.2 section. The `system-test` label is applied so the hardware system-test suite runs against this release.

## Changes
- Version → **4.9.2** across all five required files: `package.json`, `package-lock.json` (regenerated), `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`), `desktop/src-tauri/tauri.conf.json`, `desktop/package.json`.
- `CHANGELOG.md`: moved `[Unreleased]` items under `## [4.9.2] - 2026-06-06`.
- Docs: `CLAUDE.md` version header (4.9.1 → 4.9.2) and corrected stale migration count (78 → 81, latest `081_add_sources_display_order`); `docs/development/database.md` migrate-db image tag (4.9.1 → 4.9.2).

## Release contents (4.9.2)
- feat: reorderable Sources list on the Unified View (#3338)
- feat: MeshCore Notifications space + inactive-node & new-node alerts (#3331)
- fix: migrate-db TABLE_ORDER sync with schema (#3337)
- fix: Channels tab layout on installed iOS PWAs
- fix: scope channel reorder to its source (MeshCore/Meshtastic bleed)

## Issues Resolved
Release rollup — see individual issues above. No new code changes.

## Documentation Updates
- CHANGELOG 4.9.2 section, CLAUDE.md version + migration count, database.md image tag.

## Testing
- [x] TypeScript compiles cleanly
- [x] No source/logic changes (version strings + markdown only; lockfile diff is the self-version fields only)
- [ ] CI test matrix (Node 20/22/24/25, SQLite/PG/MySQL)
- [ ] **System Tests (Hardware)** — enabled via the `system-test` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)