### PR TITLE
fix(meshcore): make Notifications view scrollable

### DIFF
--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -630,6 +630,15 @@
   padding: 1.5rem;
 }
 
+/* Notifications view: NotificationsTab supplies its own .tab-content with no
+   scroll container, so wrap it here to scroll within the overflow:hidden
+   .meshcore-content the same way the form views do. */
+.meshcore-notifications-view {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+}
+
 .meshcore-form-view .form-section {
   max-width: 640px;
   background: var(--ctp-surface0);

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -171,7 +171,9 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
             </SaveBarProvider>
           )}
           {view === 'notifications' && (
-            <NotificationsTab isAdmin={isAdmin} />
+            <div className="meshcore-notifications-view">
+              <NotificationsTab isAdmin={isAdmin} />
+            </div>
           )}
           {view === 'settings' && (
             <MeshCoreSettingsView


### PR DESCRIPTION
## Summary
The MeshCore Notifications tab (added in #3339) was unusable: any content below the viewport was clipped with no way to scroll to it. `NotificationsTab` only renders a `.tab-content` div with no scroll container, but `MeshCorePage`'s `.meshcore-content` is `overflow: hidden` and delegates scrolling to each child view (the form views do this via `.meshcore-form-view { flex:1; overflow-y:auto }`). The Notifications view had no such wrapper, so it got clipped. This doesn't affect the Meshtastic side because there `NotificationsTab` lives in App.tsx's page-level scroll context.

## Changes
- `MeshCorePage.tsx`: wrap `<NotificationsTab>` in a `.meshcore-notifications-view` container.
- `MeshCorePage.css`: add `.meshcore-notifications-view { flex:1; overflow-y:auto; padding:1.5rem }`, mirroring the existing `.meshcore-form-view` scroll pattern.

## Issues Resolved
None (follow-up to #3339).

## Documentation Updates
No documentation changes needed — pure layout/scroll fix.

## Testing
- [x] Unit tests pass (6071 tests, 0 failures)
- [x] TypeScript compiles cleanly
- [x] Built and deployed dev container; verified the bundled CSS/JSX
- [ ] Reviewer: open a MeshCore source → Notifications tab and confirm the page scrolls when content exceeds the viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)