### PR TITLE
fix(meshcore): add min-height:0 so notifications view actually scrolls

### DIFF
--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -626,15 +626,21 @@
 /* Form view (Configuration / Settings) */
 .meshcore-form-view {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 1.5rem;
 }
 
 /* Notifications view: NotificationsTab supplies its own .tab-content with no
    scroll container, so wrap it here to scroll within the overflow:hidden
-   .meshcore-content the same way the form views do. */
+   .meshcore-content the same way the form views do.
+   min-height: 0 is required: without it a column-flex child's implicit
+   min-height equals its content height, so the browser never sees an overflow
+   and the scrollbar never appears (content is clipped by the parent's
+   overflow:hidden but not scrollable). */
 .meshcore-notifications-view {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 1.5rem;
 }

--- a/src/components/SectionNav.tsx
+++ b/src/components/SectionNav.tsx
@@ -12,14 +12,33 @@ interface SectionNavProps {
 const SectionNav: React.FC<SectionNavProps> = ({ items }) => {
   const scrollToSection = (id: string) => {
     const element = document.getElementById(id);
-    if (element) {
-      // Account for fixed header (60px) + sticky nav (~50px) + padding (16px)
+    if (!element) return;
+
+    // Find the nearest scrollable ancestor so this works both when the window
+    // is the scroll container (standalone settings pages) and when an inner
+    // flex pane is the scroll container (MeshCore notifications view).
+    let scrollContainer: Element | null = element.parentElement;
+    while (scrollContainer && scrollContainer !== document.documentElement) {
+      const { overflowY } = window.getComputedStyle(scrollContainer);
+      if (overflowY === 'auto' || overflowY === 'scroll') break;
+      scrollContainer = scrollContainer.parentElement;
+    }
+
+    if (scrollContainer && scrollContainer !== document.documentElement) {
+      // Inner pane scrolling — offset only for the sticky nav (~50px).
+      const offset = 50;
+      const containerRect = scrollContainer.getBoundingClientRect();
+      const elementRect = element.getBoundingClientRect();
+      scrollContainer.scrollBy({
+        top: elementRect.top - containerRect.top - offset,
+        behavior: 'smooth',
+      });
+    } else {
+      // Window scrolling (standalone settings page).
+      // Account for fixed header (60px) + sticky nav (~50px) + padding (16px).
       const offset = 130;
       const elementPosition = element.getBoundingClientRect().top + window.scrollY;
-      window.scrollTo({
-        top: elementPosition - offset,
-        behavior: 'smooth'
-      });
+      window.scrollTo({ top: elementPosition - offset, behavior: 'smooth' });
     }
   };
 


### PR DESCRIPTION
## Summary

- Adds `min-height: 0` to `.meshcore-notifications-view` (and defensively to `.meshcore-form-view`) to fix the CSS flexbox scrolling issue reported in #3346
- Fixes `SectionNav` to scroll the nearest `overflow: auto/scroll` ancestor instead of always calling `window.scrollTo()` (a no-op inside the MeshCore layout)

## Root cause

PR #3345 (merged this morning) wrapped `NotificationsTab` in a `.meshcore-notifications-view` container with `flex: 1; overflow-y: auto`. The fix was close but omitted `min-height: 0`.

Without `min-height: 0`, a column-flex item's implicit `min-height: auto` causes the browser to treat the item's *logical* height as equal to its *content* height. Since logical height = content height, the browser sees no overflow → no scrollbar. The parent's `overflow: hidden` clips the content visually, so items below the viewport (like the Apprise URL field) are invisible with no way to reach them.

Adding `min-height: 0` forces the flex item to respect its allocated height, at which point `overflow-y: auto` works as intended and a scrollbar appears.

## Test plan

- [ ] Open a MeshCore source → Notifications tab
- [ ] Confirm the page scrolls and the Apprise URL field is reachable
- [ ] Click "Apprise" in the section nav — confirm it jumps to that section within the panel (not a no-op)
- [ ] Open the MeshCore Configuration and Settings views — confirm they still scroll when content is long

Fixes #3346

https://claude.ai/code/session_01BiqAkwqeYz1cJ9vxTtrj6i

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiqAkwqeYz1cJ9vxTtrj6i)_