### PR TITLE
fix(meshcore): convert companion GPS to microdegrees in set_coords (#3352)

### DIFF
--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -630,6 +630,31 @@ describe('MeshCoreNativeBackend', () => {
     expect(conn.setTelemetryModeEnvCalls).toEqual([0]);
   });
 
+  // Regression: issue #3352 — MeshCore's wire protocol expects fixed-point
+  // microdegrees (deg × 1e6). Passing raw decimal degrees to setAdvertLatLong
+  // (which writes via DataView.setInt32) truncated to the integer degree, saving
+  // coordinates ~6 decimal places off.
+  it('set_coords converts decimal degrees to fixed-point microdegrees before sending to device', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+
+    const resp = await backend.sendCommand('set_coords', { lat: 40.712776, lon: -74.005974 });
+    expect(resp.success).toBe(true);
+
+    // Device must receive microdegrees, NOT the truncated integer degree (40, -74).
+    expect(conn.setAdvertLatLongCalls).toHaveLength(1);
+    expect(conn.setAdvertLatLongCalls[0]).toEqual([40712776, -74005974]);
+
+    // Cache mirrors the same fixed-point values so the UI and device agree.
+    const selfResp = await backend.sendCommand('get_self_info', {});
+    expect(selfResp.data?.latitude).toBeCloseTo(40.712776, 5);
+    expect(selfResp.data?.longitude).toBeCloseTo(-74.005974, 5);
+  });
+
   it('decodes request_telemetry response via CayenneLpp.parse', async () => {
     const backend = new MeshCoreNativeBackend('src-1', {
       connectionType: 'serial',

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -1038,13 +1038,16 @@ export class MeshCoreNativeBackend extends EventEmitter {
         return { ok: true };
       }
 
-      case 'set_coords':
-        await c.setAdvertLatLong(Number(params.lat), Number(params.lon));
+      case 'set_coords': {
+        const latFixed = Math.round(Number(params.lat) * 1e6);
+        const lonFixed = Math.round(Number(params.lon) * 1e6);
+        await c.setAdvertLatLong(latFixed, lonFixed);
         if (this.cachedSelfInfo) {
-          this.cachedSelfInfo.advLat = Math.round(Number(params.lat) * 1e6);
-          this.cachedSelfInfo.advLon = Math.round(Number(params.lon) * 1e6);
+          this.cachedSelfInfo.advLat = latFixed;
+          this.cachedSelfInfo.advLon = lonFixed;
         }
         return { ok: true };
+      }
 
       case 'set_advert_loc_policy': {
         const policy = Number(params.policy);


### PR DESCRIPTION
## Summary

Fixes #3352 — MeshCore companion GPS lat/lon saved ~6 decimal places off (microdegree unit mismatch).

MeshCore's wire protocol expects **fixed-point microdegrees** (degrees × 1,000,000), written via `DataView.setInt32`. The `set_coords` handler in `meshcoreNativeBackend.ts` passed **raw decimal degrees** to `setAdvertLatLong`, so `40.712776` was truncated to `40` on the device. The UI appeared correct because it read MeshMonitor's own cache (which was already computing the right fixed-point value), masking the bug.

## Fix

Pre-convert lat/lon to microdegrees before sending to the device, and reuse the computed values for the cache update:

```ts
case 'set_coords': {
  const latFixed = Math.round(Number(params.lat) * 1e6);
  const lonFixed = Math.round(Number(params.lon) * 1e6);
  await c.setAdvertLatLong(latFixed, lonFixed);
  if (this.cachedSelfInfo) {
    this.cachedSelfInfo.advLat = latFixed;
    this.cachedSelfInfo.advLon = lonFixed;
  }
  return { ok: true };
}
```

## Tests

Adds a regression test in `meshcoreNativeBackend.test.ts` asserting the device receives microdegrees `[40712776, -74005974]` (not the truncated `[40, -74]`), and that the cache mirrors the same values back through `get_self_info`. The test fails against the old raw-degrees code. Full backend suite: 47/47 green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
