### PR TITLE
feat(sidebar): stable MQTT node count, edit-mode reorder, resizable sidebar

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4402,6 +4402,10 @@
 
   "source.header": "Sources",
   "source.add_short": "+ Add",
+  "source.edit_mode": "Edit",
+  "source.edit_mode_done": "Done",
+  "source.edit_mode_help": "Reorder sources by dragging. Click Done when finished.",
+  "source.resize_sidebar": "Drag to resize the sidebar",
   "source.add": "Add Source",
   "source.edit": "Edit Source",
   "source.delete": "Delete Source",

--- a/src/components/Dashboard/DashboardSidebar.test.tsx
+++ b/src/components/Dashboard/DashboardSidebar.test.tsx
@@ -380,4 +380,122 @@ describe('DashboardSidebar', () => {
       expect(document.querySelector('.dashboard-publisher-badge')).toBeNull();
     });
   });
+
+  // Issue #3355 — drag handles are hidden until the admin enters Edit mode.
+  describe('Edit mode (drag-reorder gating)', () => {
+    const queryDragHandles = () =>
+      document.querySelectorAll('[title="Drag to reorder"]');
+
+    it('does NOT render the Edit button when reordering is not wired up', () => {
+      // No onReorderSources prop → canReorder is false regardless of perms.
+      renderSidebar();
+      expect(
+        screen.queryByRole('button', { name: 'source.edit_mode' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does NOT render the Edit button without sources:write permission', () => {
+      hasPermissionMock.mockImplementation(() => false);
+      renderSidebar({ onReorderSources: vi.fn() });
+      expect(
+        screen.queryByRole('button', { name: 'source.edit_mode' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the Edit button for a permitted viewer with reorder wired up', () => {
+      renderSidebar({ onReorderSources: vi.fn() });
+      expect(
+        screen.getByRole('button', { name: 'source.edit_mode' }),
+      ).toBeInTheDocument();
+    });
+
+    it('hides drag handles until Edit mode is toggled on', () => {
+      renderSidebar({ onReorderSources: vi.fn() });
+      // Default: no handles.
+      expect(queryDragHandles().length).toBe(0);
+
+      fireEvent.click(screen.getByRole('button', { name: 'source.edit_mode' }));
+
+      // Edit mode on: one handle per real (non-unified) source.
+      expect(queryDragHandles().length).toBe(3);
+      // Button label flips to "Done".
+      expect(
+        screen.getByRole('button', { name: 'source.edit_mode_done' }),
+      ).toBeInTheDocument();
+    });
+
+    it('hides drag handles again when Edit mode is toggled off', () => {
+      renderSidebar({ onReorderSources: vi.fn() });
+      const toggle = screen.getByRole('button', { name: 'source.edit_mode' });
+      fireEvent.click(toggle);
+      expect(queryDragHandles().length).toBe(3);
+      fireEvent.click(screen.getByRole('button', { name: 'source.edit_mode_done' }));
+      expect(queryDragHandles().length).toBe(0);
+    });
+  });
+
+  // Issue #3356 — resizable sidebar with persisted width.
+  describe('Resizable sidebar', () => {
+    const WIDTH_KEY = 'dashboard-sidebar-width';
+
+    beforeEach(() => {
+      window.localStorage.clear();
+    });
+
+    const getAside = () => document.querySelector('aside.dashboard-sidebar') as HTMLElement;
+
+    it('renders a resize handle', () => {
+      renderSidebar();
+      expect(
+        screen.getByRole('separator', { name: 'source.resize_sidebar' }),
+      ).toBeInTheDocument();
+    });
+
+    it('applies the default width as a CSS variable when none is persisted', () => {
+      renderSidebar();
+      expect(getAside().style.getPropertyValue('--dashboard-sidebar-width')).toBe('240px');
+    });
+
+    it('loads a persisted width from localStorage', () => {
+      window.localStorage.setItem(WIDTH_KEY, '320');
+      renderSidebar();
+      expect(getAside().style.getPropertyValue('--dashboard-sidebar-width')).toBe('320px');
+    });
+
+    it('clamps an out-of-range persisted width to the max bound', () => {
+      window.localStorage.setItem(WIDTH_KEY, '9999');
+      renderSidebar();
+      expect(getAside().style.getPropertyValue('--dashboard-sidebar-width')).toBe('480px');
+    });
+
+    it('resizes via arrow keys and persists the new width', () => {
+      renderSidebar();
+      const handle = screen.getByRole('separator', { name: 'source.resize_sidebar' });
+      fireEvent.keyDown(handle, { key: 'ArrowRight' });
+      expect(getAside().style.getPropertyValue('--dashboard-sidebar-width')).toBe('256px');
+      expect(window.localStorage.getItem(WIDTH_KEY)).toBe('256');
+      fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+      expect(getAside().style.getPropertyValue('--dashboard-sidebar-width')).toBe('240px');
+      expect(window.localStorage.getItem(WIDTH_KEY)).toBe('240');
+    });
+
+    it('does not shrink below the minimum width via keyboard', () => {
+      window.localStorage.setItem(WIDTH_KEY, '208'); // 8px above the 200 min
+      renderSidebar();
+      const handle = screen.getByRole('separator', { name: 'source.resize_sidebar' });
+      fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+      // 208 - 16 would be 192, clamped to the 200 minimum.
+      expect(getAside().style.getPropertyValue('--dashboard-sidebar-width')).toBe('200px');
+    });
+
+    it('resizes via pointer drag and persists on pointer up', () => {
+      renderSidebar();
+      const handle = screen.getByRole('separator', { name: 'source.resize_sidebar' });
+      fireEvent.pointerDown(handle, { clientX: 240 });
+      fireEvent.pointerMove(window, { clientX: 300 });
+      expect(getAside().style.getPropertyValue('--dashboard-sidebar-width')).toBe('300px');
+      fireEvent.pointerUp(window, { clientX: 300 });
+      expect(window.localStorage.getItem(WIDTH_KEY)).toBe('300');
+    });
+  });
 });

--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -2,7 +2,7 @@
  * DashboardSidebar — lists source cards with status, node counts, and admin kebab menu.
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -26,6 +26,29 @@ import { version } from '../../../package.json';
 import type { DashboardSource, SourceStatus, UnifiedStatus } from '../../hooks/useDashboardData';
 import { UNIFIED_SOURCE_ID } from '../../hooks/useDashboardData';
 import { useAuth } from '../../contexts/AuthContext';
+
+// Persisted, user-resizable sidebar width (issue #3356). The width is stored
+// in localStorage so it survives reloads; min/max bounds keep the layout from
+// breaking (too narrow to read names, or wide enough to crowd out the map).
+const SIDEBAR_WIDTH_KEY = 'dashboard-sidebar-width';
+const SIDEBAR_MIN_WIDTH = 200;
+const SIDEBAR_MAX_WIDTH = 480;
+const SIDEBAR_DEFAULT_WIDTH = 240;
+
+const clampSidebarWidth = (w: number): number =>
+  Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, w));
+
+function loadSidebarWidth(): number {
+  if (typeof window === 'undefined') return SIDEBAR_DEFAULT_WIDTH;
+  try {
+    const raw = window.localStorage.getItem(SIDEBAR_WIDTH_KEY);
+    const parsed = raw != null ? Number(raw) : NaN;
+    return Number.isFinite(parsed) ? clampSidebarWidth(parsed) : SIDEBAR_DEFAULT_WIDTH;
+  } catch {
+    // localStorage can throw in private-mode / sandboxed contexts.
+    return SIDEBAR_DEFAULT_WIDTH;
+  }
+}
 
 interface DashboardSidebarProps {
   sources: DashboardSource[];
@@ -360,6 +383,85 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
   const canReorder =
     typeof onReorderSources === 'function' && hasPermission('sources', 'write');
 
+  // Edit mode (issue #3355): drag handles are hidden by default and only
+  // appear once the admin explicitly enters edit mode, so the sidebar stays
+  // uncluttered for the common case of never reordering. Dragging is live only
+  // while BOTH the viewer can reorder AND edit mode is on.
+  const [editMode, setEditMode] = useState(false);
+  const isReordering = canReorder && editMode;
+
+  // Resizable sidebar (issue #3356). Width lives in component state, is applied
+  // to the <aside> via a CSS custom property, and is persisted to localStorage.
+  const [sidebarWidth, setSidebarWidth] = useState<number>(loadSidebarWidth);
+  // Latest width during a drag, read by the pointerup persist step without
+  // re-binding the window listeners on every move.
+  const widthRef = useRef(sidebarWidth);
+  widthRef.current = sidebarWidth;
+  const resizeStartRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  const persistSidebarWidth = useCallback((w: number) => {
+    try {
+      window.localStorage.setItem(SIDEBAR_WIDTH_KEY, String(w));
+    } catch {
+      // Ignore localStorage write failures (private mode / quota).
+    }
+  }, []);
+
+  const handleResizeMove = useCallback((e: PointerEvent) => {
+    const start = resizeStartRef.current;
+    if (!start) return;
+    setSidebarWidth(clampSidebarWidth(start.startWidth + (e.clientX - start.startX)));
+  }, []);
+
+  const handleResizeEnd = useCallback(() => {
+    resizeStartRef.current = null;
+    window.removeEventListener('pointermove', handleResizeMove);
+    window.removeEventListener('pointerup', handleResizeEnd);
+    document.body.style.removeProperty('cursor');
+    document.body.style.removeProperty('user-select');
+    persistSidebarWidth(widthRef.current);
+  }, [handleResizeMove, persistSidebarWidth]);
+
+  const handleResizeStart = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      resizeStartRef.current = { startX: e.clientX, startWidth: widthRef.current };
+      window.addEventListener('pointermove', handleResizeMove);
+      window.addEventListener('pointerup', handleResizeEnd);
+      // Lock the cursor + disable text selection globally for the whole drag,
+      // not just over the 5px handle the pointer may slip off.
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+    },
+    [handleResizeMove, handleResizeEnd],
+  );
+
+  // Keyboard resize for accessibility — the handle is focusable and responds
+  // to arrow keys in 16px steps.
+  const handleResizeKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      setSidebarWidth((w) => {
+        const next = clampSidebarWidth(w - 16);
+        persistSidebarWidth(next);
+        return next;
+      });
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      setSidebarWidth((w) => {
+        const next = clampSidebarWidth(w + 16);
+        persistSidebarWidth(next);
+        return next;
+      });
+    }
+  }, [persistSidebarWidth]);
+
+  // Tidy up the window listeners if the sidebar unmounts mid-drag.
+  useEffect(() => () => {
+    window.removeEventListener('pointermove', handleResizeMove);
+    window.removeEventListener('pointerup', handleResizeEnd);
+  }, [handleResizeMove, handleResizeEnd]);
+
   const sensors = useSensors(
     // 5px activation distance so a plain click on the grip still falls through
     // to the card's selection handler (matches the channel-reorder sensor).
@@ -390,7 +492,10 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
         onClick={onMobileClose}
         aria-hidden="true"
       />
-      <aside className={`dashboard-sidebar${mobileOpen ? ' mobile-open' : ''}`}>
+      <aside
+        className={`dashboard-sidebar${mobileOpen ? ' mobile-open' : ''}`}
+        style={{ '--dashboard-sidebar-width': `${sidebarWidth}px` } as React.CSSProperties}
+      >
       <div className="dashboard-sidebar-header">
         {t('source.header')}
         {isAdmin && (
@@ -400,6 +505,17 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
             onClick={onAddSource}
           >
             {t('source.add_short')}
+          </button>
+        )}
+        {canReorder && (
+          <button
+            className="dashboard-add-source-btn"
+            style={{ marginLeft: 6, padding: '2px 8px', fontSize: 11 }}
+            onClick={() => setEditMode((v) => !v)}
+            aria-pressed={editMode}
+            title={t('source.edit_mode_help')}
+          >
+            {editMode ? t('source.edit_mode_done') : t('source.edit_mode')}
           </button>
         )}
       </div>
@@ -639,9 +755,10 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
           </div>
         );
 
-        // Only real (non-unified) sources are draggable, and only when the
-        // viewer can reorder. Unified stays pinned at the top.
-        return canReorder && !isUnified ? (
+        // Only real (non-unified) sources are draggable, and only while edit
+        // mode is active for a viewer who can reorder. Unified stays pinned at
+        // the top.
+        return isReordering && !isUnified ? (
           <SortableSourceCard key={source.id} id={source.id}>
             {card}
           </SortableSourceCard>
@@ -651,7 +768,7 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
         // Wrap the whole list in a drag context only when reordering is
         // enabled. The Unified card sits inside the context but is absent from
         // `items`, so it never participates in the sort.
-        return canReorder ? (
+        return isReordering ? (
           <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}
@@ -749,6 +866,19 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
         </div>
       </div>
     </aside>
+    {/* Resize handle — a flex sibling between the sidebar and the map so it's
+        unaffected by the sidebar's own vertical scroll. Hidden on mobile (the
+        sidebar is a fixed-width overlay drawer there). Issue #3356. */}
+    <div
+      className="dashboard-sidebar-resize-handle"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={t('source.resize_sidebar')}
+      title={t('source.resize_sidebar')}
+      tabIndex={0}
+      onPointerDown={handleResizeStart}
+      onKeyDown={handleResizeKeyDown}
+    />
     </>
   );
 };

--- a/src/server/routes/sourceRoutes.status.test.ts
+++ b/src/server/routes/sourceRoutes.status.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../services/database.js', () => ({
     nodes: {
       getNodeCount: vi.fn().mockResolvedValue(0),
       getActiveNodeCount: vi.fn().mockResolvedValue(0),
+      getNode: vi.fn().mockResolvedValue(null),
     },
     checkPermissionAsync: vi.fn().mockResolvedValue(true),
     findUserByIdAsync: vi.fn(),
@@ -89,6 +90,7 @@ beforeEach(() => {
   mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
   mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
   mockDb.checkPermissionAsync.mockResolvedValue(true);
+  mockDb.nodes.getNode.mockResolvedValue(null);
   mockSourceRegistry.getManager.mockReturnValue(null);
   mockMeshcoreRegistry.get.mockReturnValue(undefined);
 });
@@ -214,5 +216,118 @@ describe('GET /:id/status — meshcore registry fallback', () => {
     expect(res.status).toBe(200);
     expect(res.body.connected).toBe(true);
     expect(mockMeshcoreRegistry.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /:id/status — injected local node count (issue #3354)', () => {
+  // The /:id/nodes endpoint injects the manager's local node into the list
+  // when it isn't persisted for the source (e.g. the MQTT broker's synthetic
+  // gateway). The /status nodeCount must mirror that so the sidebar badge
+  // matches the node list and doesn't flicker on selection state.
+  it('counts the synthetic gateway node not present in the nodes table', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue({
+      id: 'broker-1',
+      name: 'MQTT_BROKER',
+      type: 'mqtt_broker',
+      enabled: true,
+      config: { gateway: { nodeNum: 0xdeadbeef } },
+      createdAt: 0,
+      updatedAt: 0,
+      createdBy: 1,
+    });
+    mockDb.nodes.getNodeCount.mockResolvedValue(11);
+    mockDb.nodes.getActiveNodeCount.mockResolvedValue(5);
+    // The gateway nodeNum is not stored for this source.
+    mockDb.nodes.getNode.mockResolvedValue(null);
+    mockSourceRegistry.getManager.mockReturnValue({
+      getStatus: () => ({
+        sourceId: 'broker-1',
+        sourceName: 'MQTT_BROKER',
+        sourceType: 'mqtt_broker',
+        connected: true,
+      }),
+      getLocalNodeInfo: () => ({
+        nodeNum: 0xdeadbeef,
+        nodeId: '!deadbeef',
+        longName: 'Broker GW',
+        shortName: 'BGW',
+      }),
+    });
+
+    const res = await request(app).get('/broker-1/status');
+
+    expect(res.status).toBe(200);
+    // 11 stored + 1 injected gateway = 12, matching the /nodes list.
+    expect(res.body.nodeCount).toBe(12);
+    // Connected, so the injected node counts as active too: 5 + 1.
+    expect(res.body.activeNodeCount).toBe(6);
+    expect(mockDb.nodes.getNode).toHaveBeenCalledWith(0xdeadbeef, 'broker-1');
+  });
+
+  it('does not double-count when the local node is already in the table', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue({
+      id: 'mt-2',
+      name: 'Meshtastic',
+      type: 'meshtastic_tcp',
+      enabled: true,
+      config: { host: '1.2.3.4', port: 4403 },
+      createdAt: 0,
+      updatedAt: 0,
+      createdBy: 1,
+    });
+    mockDb.nodes.getNodeCount.mockResolvedValue(893);
+    mockDb.nodes.getActiveNodeCount.mockResolvedValue(40);
+    // Local node IS persisted for this source — getNodeCount already includes it.
+    mockDb.nodes.getNode.mockResolvedValue({ nodeNum: 123, sourceId: 'mt-2' });
+    mockSourceRegistry.getManager.mockReturnValue({
+      getStatus: () => ({
+        sourceId: 'mt-2',
+        sourceName: 'Meshtastic',
+        sourceType: 'meshtastic_tcp',
+        connected: true,
+      }),
+      getLocalNodeInfo: () => ({ nodeNum: 123, nodeId: '!7b', longName: 'Local', shortName: 'LCL' }),
+    });
+
+    const res = await request(app).get('/mt-2/status');
+
+    expect(res.status).toBe(200);
+    expect(res.body.nodeCount).toBe(893);
+    expect(res.body.activeNodeCount).toBe(40);
+  });
+
+  it('does not count the injected node as active when the source is disconnected', async () => {
+    const app = createApp();
+    mockDb.sources.getSource.mockResolvedValue({
+      id: 'broker-2',
+      name: 'MQTT_BROKER',
+      type: 'mqtt_broker',
+      enabled: true,
+      config: { gateway: { nodeNum: 0xfeed } },
+      createdAt: 0,
+      updatedAt: 0,
+      createdBy: 1,
+    });
+    mockDb.nodes.getNodeCount.mockResolvedValue(11);
+    mockDb.nodes.getActiveNodeCount.mockResolvedValue(0);
+    mockDb.nodes.getNode.mockResolvedValue(null);
+    mockSourceRegistry.getManager.mockReturnValue({
+      getStatus: () => ({
+        sourceId: 'broker-2',
+        sourceName: 'MQTT_BROKER',
+        sourceType: 'mqtt_broker',
+        connected: false,
+      }),
+      getLocalNodeInfo: () => ({ nodeNum: 0xfeed, nodeId: '!feed', longName: 'GW', shortName: 'GW' }),
+    });
+
+    const res = await request(app).get('/broker-2/status');
+
+    expect(res.status).toBe(200);
+    expect(res.body.nodeCount).toBe(12);
+    // Disconnected → injected node is not counted as active.
+    expect(res.body.activeNodeCount).toBe(0);
   });
 });

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -834,6 +834,28 @@ router.get('/:id/status', optionalAuth(), async (req: Request, res: Response) =>
         databaseService.nodes.getNodeCount(source.id).catch(() => 0),
         databaseService.nodes.getActiveNodeCount(source.id).catch(() => 0),
       ]);
+      // The /:id/nodes endpoint injects the manager's local node into the
+      // returned list whenever it isn't persisted for this source — most
+      // visibly the MQTT broker's synthetic gateway node, which never lands
+      // in the `nodes` table. getNodeCount() (a plain COUNT(*)) doesn't see
+      // that injected node, so the sidebar badge would read one lower than
+      // the node list the user sees when the source is selected. Worse, the
+      // dashboard uses the live list length for the *selected* source but
+      // this polled count for the rest, so the badge flickered (e.g. 11↔12)
+      // purely on selection state (issue #3354). Mirror the injection here so
+      // the count matches the list and stays stable regardless of selection.
+      const localNodeInfo = manager?.getLocalNodeInfo?.();
+      if (localNodeInfo?.nodeNum) {
+        const inSource = await databaseService.nodes
+          .getNode(localNodeInfo.nodeNum, source.id)
+          .catch(() => null);
+        if (!inSource) {
+          nodeCount += 1;
+          // /nodes synthesizes the injected local node with lastHeard=now, so
+          // it counts as "active" whenever the source link is up.
+          if (status?.connected) activeNodeCount += 1;
+        }
+      }
     }
     res.json({ ...status, nodeCount, activeNodeCount });
   } catch (error) {

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -100,13 +100,33 @@
 /* ── Sidebar ─────────────────────────────────────────────────────────────── */
 
 .dashboard-sidebar {
-  width: 240px;
+  /* Width is user-resizable (issue #3356); the inline CSS var carries the
+     persisted value, falling back to the default when unset. */
+  width: var(--dashboard-sidebar-width, 240px);
   flex-shrink: 0;
   background: var(--ctp-mantle);
   display: flex;
   flex-direction: column;
   overflow-y: auto;
   border-right: 1px solid var(--ctp-surface0);
+}
+
+/* Drag-to-resize handle — sits in the flex row between the sidebar and the
+   map body. Thin hit area that highlights on hover/focus. */
+.dashboard-sidebar-resize-handle {
+  flex: 0 0 5px;
+  align-self: stretch;
+  cursor: col-resize;
+  background: transparent;
+  border: none;
+  padding: 0;
+  transition: background 0.15s;
+}
+
+.dashboard-sidebar-resize-handle:hover,
+.dashboard-sidebar-resize-handle:focus-visible {
+  background: var(--ctp-blue);
+  outline: none;
 }
 
 .dashboard-sidebar-header {
@@ -784,11 +804,17 @@
     top: var(--header-height, 64px);
     left: 0;
     bottom: 0;
+    /* Overlay drawer has a fixed width; ignore the desktop resize var. */
     width: 260px;
     z-index: 999;
     transform: translateX(-100%);
     transition: transform 0.25s ease;
     box-shadow: 2px 0 12px rgba(0, 0, 0, 0.4);
+  }
+
+  /* Resizing is desktop-only — the drawer is a fixed overlay on mobile. */
+  .dashboard-sidebar-resize-handle {
+    display: none;
   }
 
   .dashboard-sidebar.mobile-open {


### PR DESCRIPTION
Closes #3354, closes #3355, closes #3356.

All three issues center on the Sources sidebar (`DashboardSidebar.tsx`), so they're delivered together to avoid mutual merge conflicts.

## #3354 — MQTT broker node count flickered on selection
**Root cause:** `GET /:id/nodes` injects the manager's local node into the returned list when it isn't persisted for the source — most visibly the MQTT broker's *synthetic gateway* (`config.gateway.nodeNum`), which never lands in the `nodes` table. But `GET /:id/status` computed `nodeCount` with a plain `COUNT(*)` that didn't see the injected node. The dashboard uses the **live list length** for the *selected* source and this **polled count** for the rest, so the MQTT card's badge alternated (e.g. 11 ↔ 12) purely on selection state.

**Fix:** `/status` now mirrors the same local-node injection (only when the node isn't already in the source), so the badge matches the node list the user sees and stays stable regardless of which source is selected. The injected node also counts toward `activeNodeCount` only when the source is connected (matching the `lastHeard=now` synthesis in `/nodes`).

## #3355 — Edit-mode toggle for drag-reorder
- New **Edit** button next to **+Add**, gated on `sources:write` (same check that already governs reordering).
- Drag handles are hidden by default; they appear only after entering edit mode. Button flips to **Done**.
- Reordering is live only when the viewer can reorder **and** edit mode is on.

## #3356 — Resizable sidebar with persisted width
- Drag handle on the sidebar's right edge (rendered as a flex sibling so it's unaffected by the sidebar's vertical scroll).
- Width persists to `localStorage` (`dashboard-sidebar-width`), clamped to **200–480px**.
- Keyboard-accessible (`role="separator"`, arrow keys in 16px steps).
- Desktop-only — the mobile overlay drawer keeps its fixed width (handle hidden via CSS).

## Tests
- `sourceRoutes.status.test.ts`: 3 new cases — injected gateway counted (11→12), no double-count when the local node is already persisted, and not counted as active when disconnected.
- `DashboardSidebar.test.tsx`: 11 new cases covering edit-mode permission gating + handle visibility, and resize via default/persisted/clamped width, arrow-key resize + persistence, min-bound clamp, and pointer-drag persistence.
- Full suite green: **6115 passed, 0 failed**. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)