### PR TITLE
fix(automation): add Position Estimation to the Automation section nav

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5004,6 +5004,7 @@ function App() {
                 { id: 'timer-triggers', label: t('automation.timer_triggers.title', 'Timer Triggers') },
                 { id: 'geofence-triggers', label: t('automation.geofence_triggers.title', 'Geofence Triggers') },
                 { id: 'auto-delete-by-distance', label: t('automation.distance_delete.title', 'Auto Delete by Distance') },
+                { id: 'position-estimation', label: t('automation.position_estimation.title', 'Position Estimation') },
                 { id: 'ignored-nodes', label: t('automation.ignored_nodes.title', 'Ignored Nodes') },
               ]}
             />

--- a/src/components/AutomationSectionNav.test.ts
+++ b/src/components/AutomationSectionNav.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Guards the Automation tab's SectionNav quick-links against drift.
+ *
+ * Regression: the Position Estimation section (issue #3271/#3349) was rendered
+ * in the Automation tab as `<div id="position-estimation">` but was never added
+ * to the `SectionNav` items list, so there was no quick-link to it and users
+ * couldn't find the feature's settings.
+ *
+ * App.tsx is far too large to render in jsdom, so this is a static-source
+ * invariant: every Automation nav item id must have a matching section anchor
+ * (`id="..."`) in the file, and Position Estimation must be listed.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function readAppSource(): string {
+  // Vitest runs from the repo root.
+  return readFileSync(resolve('src/App.tsx'), 'utf8');
+}
+
+/** Extract the `items={[ ... ]}` array that immediately follows the
+ *  `activeTab === 'automation'` block, and return the parsed nav item ids. */
+function automationNavIds(src: string): string[] {
+  const tabStart = src.indexOf("activeTab === 'automation'");
+  expect(tabStart, "Automation tab block not found in App.tsx").toBeGreaterThan(-1);
+  const itemsStart = src.indexOf('items={[', tabStart);
+  expect(itemsStart, "SectionNav items array not found in Automation tab").toBeGreaterThan(-1);
+  const itemsEnd = src.indexOf(']}', itemsStart);
+  expect(itemsEnd, "Unterminated SectionNav items array").toBeGreaterThan(itemsStart);
+  const block = src.slice(itemsStart, itemsEnd);
+  return [...block.matchAll(/id:\s*'([^']+)'/g)].map((m) => m[1]);
+}
+
+describe('Automation tab SectionNav', () => {
+  it('lists the Position Estimation section', () => {
+    const ids = automationNavIds(readAppSource());
+    expect(ids).toContain('position-estimation');
+  });
+
+  it('every nav item has a matching section anchor in the page', () => {
+    const src = readAppSource();
+    const ids = automationNavIds(src);
+    expect(ids.length).toBeGreaterThan(0);
+    for (const id of ids) {
+      // The rendered section wrapper is `<div id="<id>">`.
+      expect(src, `missing <div id="${id}"> anchor for nav item '${id}'`).toContain(`id="${id}"`);
+    }
+  });
+});


### PR DESCRIPTION
## Problem
The **Position Estimation** settings section (from #3271 / #3349) is rendered in the Automation tab as `<div id="position-estimation">` (`App.tsx:5191`), but it was never added to the tab's `SectionNav` quick-links list — which jumped straight from *Auto Delete by Distance* to *Ignored Nodes*. As a result the section had no quick-link and was only discoverable by scrolling, so users couldn't find where to configure the estimator (enable, frequency, lookback, "Recalculate now").

## Fix
- Add the missing `{ id: 'position-estimation', label: t('automation.position_estimation.title', 'Position Estimation') }` entry to the Automation `SectionNav`, in render order (after Auto Delete by Distance, before Ignored Nodes).
- Add `AutomationSectionNav.test.ts` — a static-source invariant guard (App.tsx is too large to render in jsdom) asserting:
  1. the Automation nav lists `position-estimation`, and
  2. every Automation nav item id has a matching `<div id="...">` section anchor (catches drift in either direction).

## Testing
- New test: 2 passed.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)