### PR TITLE
chore(release): 4.9.3 — Estimated Positions docs + blog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.9.3] - 2026-06-07
+
+### Features
+
+- **Position Estimation moved to Global Settings**: Position estimation is a single global, cross-source batch job (one set of `position_estimation_*` keys, one scheduler pooling traceroute + NeighborInfo observations across all Meshtastic sources). It previously rendered in the per-source Automation tab, which implied per-source configuration, was hidden for `mqtt_bridge` sources, and mismatched the backend (its status/run-now/save endpoints are gated by `settings:read`/`settings:write`, not `automation`). It now lives in **Global Settings → Position Estimation**, gated on `settings:write`. Resolves #3360.
+- **Maximum acceptable accuracy cutoff for position estimates**: New global setting `position_estimation_max_uncertainty_km` (0 = no limit). When set, any solved estimate whose uncertainty radius exceeds the ceiling is discarded instead of stored, and that node's now-too-uncertain estimate is cleared — so low-confidence guesses (dominated by the ~5 km single-anchor default) stop drawing huge circles on the map. The last-run summary reports how many estimates were discarded.
+- **"Show Accuracy" governs estimated-position circles**: The estimated-position uncertainty circles on the map are now controlled by the existing **Show Accuracy** map toggle (previously tied to "Show Estimated Positions"), so one control governs every accuracy overlay. The estimated markers stay under "Show Estimated Positions"; a circle is drawn only when both are on.
+- **Sources sidebar — Edit mode for reordering**: Drag-to-reorder handles are now hidden by default and revealed via an **Edit** toggle next to **+ Add** (gated on `sources:write`), keeping the sidebar uncluttered when reordering isn't needed. Resolves #3355.
+- **Sources sidebar — resizable width**: The dashboard Sources sidebar can be resized by dragging its right edge; the chosen width persists per browser (200–480px) and is keyboard-accessible. Resolves #3356.
+
+### Bug Fixes
+
+- **MQTT broker source node count flickered on selection (#3354)**: The MQTT broker card's node count alternated (e.g. 11 ↔ 12) depending on which source was selected. The `/:id/nodes` endpoint injects the broker's synthetic gateway node when it isn't persisted, but `/:id/status`'s `getNodeCount` (a plain `COUNT(*)`) did not, so the badge disagreed with the node list and with the selected-source live count. `/status` now mirrors the injection, so the count matches the list and stays stable regardless of selection.
+- **Settings section-nav buttons did not scroll**: On the standalone Global Settings page, none of the section-nav ("jump to section") buttons scrolled. `<body>` computes to `overflow-y: auto` but isn't the actual scroller (the window is), and `SectionNav` picked it and called `body.scrollBy()` — a no-op. The nearest-scrollable-ancestor search now requires the element to be genuinely scrollable (`scrollHeight > clientHeight`) and skips `<body>`/`<html>`, falling through to window scrolling.
+
 ## [4.9.2] - 2026-06-06
 
 ### Features

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.9.2",
+  "version": "4.9.3",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.9.2",
+  "version": "4.9.3",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -90,6 +90,7 @@ export default defineConfig({
           collapsed: false,
           items: [
             { text: 'Interactive Maps', link: '/features/maps' },
+            { text: 'Position Estimation', link: '/features/position-estimation' },
             { text: 'Embed Maps', link: '/features/embed-maps' },
             { text: 'Map Analysis', link: '/features/map-analysis' },
             { text: 'Waypoints', link: '/features/waypoints' }

--- a/docs/blog/2026-06-07-v4.9.3-estimated-positions.md
+++ b/docs/blog/2026-06-07-v4.9.3-estimated-positions.md
@@ -1,0 +1,29 @@
+---
+id: news-2026-06-07-v4-9-3-estimated-positions
+title: MeshMonitor v4.9.3 - Estimated Positions, Front and Center
+date: '2026-06-07T18:00:00Z'
+category: feature
+priority: normal
+minVersion: 4.9.3
+---
+MeshMonitor v4.9.3 gives **Position Estimation** the home and the controls it deserved. The feature that plots a best-guess location for nodes that never report GPS — by pooling traceroute and NeighborInfo geometry across **all** your Meshtastic sources — is now where you'd expect to find it, with a new knob to keep the map tidy.
+
+## It lives in Global Settings now
+
+Position Estimation is a single, global, cross-source batch job: one schedule, one set of estimates shared by every source. So it no longer hides inside a per-source Automation tab — it now sits in **Global Settings → Position Estimation** (the ⚙️ gear in the dashboard sidebar), gated by `settings:write` to match how the backend has always treated it. Enable it, pick a calculation frequency and lookback window, and hit **Recalculate now** whenever you want a fresh pass.
+
+## Tame the circles: Maximum acceptable accuracy
+
+Estimates come with an honest **uncertainty radius**. A node seen from a single anchor can only be placed "somewhere within radio range" — a ~5 km circle — while a node triangulated from several directions lands in a tight one. On a dense map those big single-anchor circles can take over.
+
+The new **Maximum acceptable accuracy (km)** setting fixes that: any estimate whose radius exceeds your cutoff is **discarded instead of stored**, and stale estimates that no longer qualify are cleared automatically. Set it to ~2–3 km to drop the loosest guesses and keep only the confident ones. Leave it at `0` for no limit. The last-run summary tells you how many were discarded.
+
+## One toggle for accuracy
+
+The estimated-position **uncertainty circles** are now controlled by the existing **Show Accuracy** toggle in the Map Features panel — the same switch that governs the precision regions for GPS nodes. So one control governs every accuracy overlay: turn it off to declutter, on to inspect. The estimated **markers** themselves stay under **Show Estimated Positions**.
+
+[Read more about Position Estimation](https://meshmonitor.org/features/position-estimation)
+
+## Also in 4.9.3
+
+A few Sources sidebar refinements landed alongside: an **Edit mode** that hides the drag-to-reorder handles until you want them, a **resizable** sidebar (great for long MQTT source names), and a fix so each source's **node count** stays consistent no matter which source is selected. The settings page section-nav buttons now reliably scroll to their sections too.

--- a/docs/features/global-settings.md
+++ b/docs/features/global-settings.md
@@ -51,6 +51,14 @@ Individual Apprise URLs (per user, per source) are not here — users configure 
 - Auto heap management (periodic memory reclamation on Postgres/MySQL)
 - Maintenance windows (message purge, telemetry retention, auto-delete-by-distance)
 
+### Position Estimation
+
+::: tip New in 4.9.3
+Position Estimation moved here from the per-source Automation tab — it's a single global, cross-source batch job, so it belongs in Global Settings.
+:::
+
+Estimate locations for GPS-less nodes by pooling traceroute and NeighborInfo geometry across **all** Meshtastic sources. Controls: enable, calculation frequency, lookback window, a **Maximum acceptable accuracy** cutoff (discards low-confidence estimates), and **Recalculate now**. Gated by `settings:write`. See [Position Estimation](/features/position-estimation).
+
 ## Per-source settings (for comparison)
 
 Anything that depends on *which* node you're connected to lives on the source, not here. Open **Dashboard → Edit Source** for:

--- a/docs/features/maps.md
+++ b/docs/features/maps.md
@@ -88,6 +88,22 @@ When viewing traceroute data:
 
 Waypoints — Meshtastic's `WAYPOINT_APP` pins — render directly on the per-source dashboard map and the Map Analysis canvas, using each waypoint's emoji as its icon. Users with `waypoints:write` can create, edit, and delete waypoints in place from the **Map Features** panel. The same panel has a **Show Waypoints** checkbox (default on) that toggles waypoint marker visibility per-user — persisted alongside the other map feature toggles. See the dedicated [Waypoints](/features/waypoints) page for the full workflow, permissions, and REST API.
 
+### Estimated Positions & Accuracy
+
+For nodes that never report GPS, MeshMonitor can plot an **estimated position**
+derived from traceroute and NeighborInfo geometry. Two **Map Features** toggles
+control the display:
+
+- **Show Estimated Positions** — shows the estimated node markers.
+- **Show Accuracy** — shows the dashed **uncertainty circle** around each
+  estimated node (and the precision-bits accuracy regions for GPS nodes). The
+  circle radius reflects how confidently the node could be placed.
+
+Estimation itself is configured in **Global Settings → Position Estimation**,
+including a **Maximum acceptable accuracy** cutoff that discards low-confidence
+guesses. See the dedicated [Position Estimation](/features/position-estimation)
+page.
+
 ## Map Tilesets
 
 ### Built-in Tilesets

--- a/docs/features/multi-source.md
+++ b/docs/features/multi-source.md
@@ -44,6 +44,15 @@ Open the **Sources sidebar** on the dashboard (admin only) to:
 
 Changes that alter the upstream target (host, port, heartbeat) automatically restart the connection — no separate restart action is needed. The Sources sidebar is where *all* post-bootstrap connection changes happen.
 
+### Arranging the sidebar
+
+::: tip New in 4.9.3
+:::
+
+- **Reorder (Edit mode)** — click **Edit** next to **+ Add** (requires `sources:write`) to reveal drag handles, then drag source cards into the order you want. Click **Done** to hide the handles again. The order is saved server-side and shared across users.
+- **Resize** — drag the sidebar's right edge to widen or narrow it; the chosen width is remembered per browser (200–480px). Useful for long MQTT source names.
+- The per-source **node count** badge reflects each source's own nodes consistently, regardless of which source is currently selected.
+
 ## Source picker
 
 Nearly every top-level view has a **source picker** in the header. It controls which source's data you're looking at:

--- a/docs/features/position-estimation.md
+++ b/docs/features/position-estimation.md
@@ -1,0 +1,85 @@
+# Position Estimation
+
+::: tip New in 4.9.3
+Position Estimation now lives in **Global Settings** (it was previously tucked into a per-source Automation tab), and gained a **Maximum acceptable accuracy** cutoff. On the map, the uncertainty circles are now controlled by the **Show Accuracy** toggle.
+:::
+
+MeshMonitor can estimate a location for nodes that never report GPS, by pooling
+the geometry already present in your mesh data — traceroutes and NeighborInfo —
+into a single best-guess position per node.
+
+## How it works
+
+Estimation is a **global, cross-source batch job**. It runs on a schedule (not
+in realtime) and pools observations from **every Meshtastic source**, including
+the embedded MQTT broker and MQTT bridges. MeshCore sources are excluded.
+
+Two kinds of geometric constraint feed the solver:
+
+- **Traceroutes** — each `A → X → B` segment anchors the intermediate node `X`
+  toward its positioned path-neighbors, biased by per-hop SNR.
+- **NeighborInfo** — each direct-RF-range pair anchors the unpositioned side to
+  the positioned side.
+
+The solver computes an SNR- and time-weighted centroid of the anchor
+observations, plus an **uncertainty radius** (in km):
+
+- A node seen from a **single anchor** can only be placed "within radio range",
+  so it gets a conservative default radius (~5 km).
+- A node seen from **multiple converging anchors** gets a much smaller radius
+  (weighted RMS distance ÷ √effective-sample-size).
+
+Estimates are written to a global table — one row per physical node — so every
+source shows the same estimate. A node that later reports a real position is
+dropped from the estimate set automatically.
+
+## Configuring estimation
+
+Open **Global Settings** (the ⚙️ gear in the dashboard sidebar) → **Position
+Estimation**. The controls are global and require `settings:write`.
+
+| Control | What it does |
+| --- | --- |
+| **Enable** | Turns the scheduled estimator on/off. On by default. |
+| **Calculation frequency** | How often the batch job runs (3 / 6 / 12 / 24 hours). Default 6h. |
+| **Lookback window** | How far back observations are pooled (1 / 3 / 7 / 14 / 30 days). Default 7 days. |
+| **Maximum acceptable accuracy (km)** | Estimates whose uncertainty radius is **larger** than this are discarded instead of stored — so low-confidence guesses don't litter the map with huge circles. **`0` = no limit.** |
+| **Recalculate now** | Runs the job immediately. The last-run summary shows how many nodes were estimated, how many observations were pooled, and how many were **discarded** by the accuracy cutoff. |
+
+### Choosing a maximum accuracy
+
+The single biggest source of oversized circles is the ~5 km single-anchor
+default. If your map is cluttered with large dashed circles, set **Maximum
+acceptable accuracy** to roughly **2–3 km**: nodes that can only be placed
+"somewhere within radio range" are dropped, while well-triangulated nodes
+(seen from several directions) are kept. Already-stored estimates that no
+longer qualify are cleared on the next run.
+
+## Viewing estimates on the map
+
+Two independent per-user map toggles live in the **Map Features** panel
+(Nodes map / dashboard map):
+
+- **Show Estimated Positions** — shows the estimated node **markers**.
+- **Show Accuracy** — shows the **uncertainty circle** around each estimated
+  node (and the precision-bits accuracy regions for GPS nodes). Turning it off
+  declutters the map while keeping the markers.
+
+An estimated node's uncertainty circle is drawn only when **both** toggles are
+on, so a circle never appears without its marker. The circle radius is the
+node's computed `uncertaintyKm` — a small circle means a confident,
+multi-anchor estimate; a large one means the node could only be placed loosely.
+
+## Permissions & API
+
+The estimator's status and controls map to the global `settings` resource:
+
+- `GET /api/settings/position-estimation/status` — `settings:read`
+- `POST /api/settings/position-estimation/run-now` — `settings:write`
+- Settings are saved through `POST /api/settings` — `settings:write`
+
+## Related
+
+- [Global Settings](/features/global-settings)
+- [Interactive Maps](/features/maps)
+- [Multi-Source](/features/multi-source)

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.9.2
-appVersion: "4.9.2"
+version: 4.9.3
+appVersion: "4.9.3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.9.2",
+  "version": "4.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.9.2",
+      "version": "4.9.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.9.2",
+  "version": "4.9.3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump to **4.9.3** plus documentation and a blog post covering this cycle's work.

## Version
Bumped to 4.9.3 across all five files: `package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`.

## Documentation
- **New** `docs/features/position-estimation.md` — dedicated feature page (how estimation works, the Global Settings controls incl. the new **Maximum acceptable accuracy** cutoff, and the **Show Accuracy** / **Show Estimated Positions** map toggles). Registered in the VitePress *Maps & Geography* nav.
- `docs/features/global-settings.md` — added a **Position Estimation** subsection (moved here from the Automation tab).
- `docs/features/maps.md` — added an **Estimated Positions & Accuracy** subsection.
- `docs/features/multi-source.md` — documented the Sources sidebar **Edit mode**, **resizable width**, and consistent per-source node count.
- `CHANGELOG.md` — 4.9.3 entry covering #3360 (PE move + max-accuracy + Show-Accuracy gating), #3355 (Edit mode), #3356 (resizable sidebar), #3354 (MQTT node-count fix), and the settings section-nav scroll fix.

## Blog
- **New** `docs/blog/2026-06-07-v4.9.3-estimated-positions.md` — announces the Estimated Positions UI. Validated against `scripts/blog-to-news.mjs` (frontmatter parses; feeds the in-app news popup). The generated `docs/public/news.json` is build-time output and intentionally not committed.

## Notes
- Docs-only + version bump; no source/runtime changes. Full Vitest suite: **6141 passed, 0 failed**; `tsc --noEmit` clean.
- All referenced internal doc links resolve to existing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)