### PR TITLE
fix(telemetry): stop bad-clock nodes from distorting telemetry charts (#3362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Telemetry charts distorted by nodes with bad hardware clocks (#3362)**: A node that reboots without GPS/NTP can broadcast telemetry stamped months or years into the future; those points passed the "last N hours" cutoff and stretched the auto-scaled chart X-axis so every telemetry graph collapsed into a sliver. Telemetry ingest now sanitizes future-dated timestamps at the repository chokepoint — a timestamp more than 1h ahead of server-receipt time (or non-finite) is replaced with the receipt time, and the node's claimed value is preserved in `packetTimestamp` for forensics. The averaged chart query also excludes future-dated rows, so estimates stored before this fix no longer distort the axis. Absurdly-old embedded times are left untouched (indistinguishable from buffered/store-forward telemetry at ingest, and already excluded by the chart's time-window cutoff).
+
 ## [4.9.3] - 2026-06-07
 
 ### Features

--- a/src/db/repositories/telemetry.badTimestamp.test.ts
+++ b/src/db/repositories/telemetry.badTimestamp.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Telemetry bad-timestamp handling (issue #3362).
+ *
+ * A node that reboots without GPS/NTP can broadcast telemetry with a hardware
+ * clock months/years off. Those embedded timestamps used to be stored verbatim
+ * and rendered on the chart X-axis, stretching every telemetry graph. Two
+ * defenses are tested here:
+ *   1. Ingest-time sanitizer — out-of-range timestamps are replaced with the
+ *      server-receipt time and the claimed value is preserved in packetTimestamp.
+ *   2. Query upper-bound — future-dated rows (e.g. stored before the fix) are
+ *      excluded from the averaged chart query so they can't distort the axis.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { telemetrySqlite } from '../schema/telemetry.js';
+import { TelemetryRepository } from './telemetry.js';
+import * as schema from '../schema/index.js';
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+const NODE = '!aabbccdd';
+const NODE_NUM = 0xaabbccdd;
+
+describe('Telemetry bad-timestamp handling (#3362)', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: TelemetryRepository;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS telemetry (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        nodeId TEXT NOT NULL, nodeNum INTEGER NOT NULL, telemetryType TEXT NOT NULL,
+        timestamp INTEGER NOT NULL, value REAL NOT NULL, unit TEXT,
+        createdAt INTEGER NOT NULL, packetTimestamp INTEGER, packetId INTEGER,
+        channel INTEGER, precisionBits INTEGER, gpsAccuracy INTEGER, sourceId TEXT
+      )`);
+    drizzleDb = drizzle(db, { schema });
+    repo = new TelemetryRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => db.close());
+
+  const readRow = (telemetryType: string) =>
+    drizzleDb.select().from(telemetrySqlite).where(eq(telemetrySqlite.telemetryType, telemetryType)).all()[0];
+
+  describe('ingest-time sanitizer', () => {
+    it('keeps a sane timestamp untouched', async () => {
+      const now = Date.now();
+      const ts = now - 5 * 60 * 1000; // 5 min ago — fine
+      await repo.insertTelemetry({ nodeId: NODE, nodeNum: NODE_NUM, telemetryType: 'voltage', timestamp: ts, value: 3.9, unit: 'V', createdAt: now });
+      const row = readRow('voltage');
+      expect(row.timestamp).toBe(ts);
+      expect(row.packetTimestamp).toBeNull();
+    });
+
+    it('replaces a future timestamp with receipt time and preserves the claim', async () => {
+      const now = Date.now();
+      const bad = now + 90 * DAY; // node clock months ahead
+      await repo.insertTelemetry({ nodeId: NODE, nodeNum: NODE_NUM, telemetryType: 'altitude', timestamp: bad, value: 100, unit: 'm', createdAt: now });
+      const row = readRow('altitude');
+      expect(row.timestamp).toBe(now);
+      expect(row.packetTimestamp).toBe(bad); // original claim retained for forensics
+    });
+
+    it('leaves an old timestamp untouched (handled by the chart cutoff, not ingest)', async () => {
+      // Old embedded times are indistinguishable from buffered / store-forward
+      // telemetry at ingest, so we keep them; the windowed query filters them.
+      const now = Date.now();
+      const old = now - 120 * DAY;
+      await repo.insertTelemetry({ nodeId: NODE, nodeNum: NODE_NUM, telemetryType: 'snr', timestamp: old, value: -8, unit: 'dB', createdAt: now });
+      const row = readRow('snr');
+      expect(row.timestamp).toBe(old);
+      expect(row.packetTimestamp).toBeNull();
+    });
+
+    it('does not clobber an existing packetTimestamp', async () => {
+      const now = Date.now();
+      const bad = now + 30 * DAY;
+      await repo.insertTelemetry({ nodeId: NODE, nodeNum: NODE_NUM, telemetryType: 'voltage', timestamp: bad, value: 3.7, unit: 'V', createdAt: now, packetTimestamp: 12345 });
+      const row = readRow('voltage');
+      expect(row.timestamp).toBe(now);
+      expect(row.packetTimestamp).toBe(12345);
+    });
+
+    it('sanitizes batch inserts too', async () => {
+      const now = Date.now();
+      await repo.insertTelemetryBatch([
+        { nodeId: NODE, nodeNum: NODE_NUM, telemetryType: 'channelUtilization', timestamp: now + 365 * DAY, value: 10, unit: '%', createdAt: now },
+        { nodeId: NODE, nodeNum: NODE_NUM, telemetryType: 'airUtilTx', timestamp: now - 60 * 1000, value: 2, unit: '%', createdAt: now },
+      ]);
+      expect(readRow('channelUtilization').timestamp).toBe(now); // clamped
+      expect(readRow('airUtilTx').timestamp).toBe(now - 60 * 1000); // untouched
+    });
+  });
+
+  describe('averaged query excludes future-dated rows', () => {
+    it('drops a future row that slipped into the table before the ingest fix', () => {
+      const now = Date.now();
+      // Insert directly (bypassing the sanitizer) to simulate pre-fix data.
+      const insertRaw = (type: string, ts: number, value: number) =>
+        db.prepare('INSERT INTO telemetry (nodeId, nodeNum, telemetryType, timestamp, value, unit, createdAt) VALUES (?,?,?,?,?,?,?)')
+          .run(NODE, NODE_NUM, type, ts, value, '%', now);
+      insertRaw('channelUtilization', now - 30 * 60 * 1000, 11); // good, 30 min ago
+      insertRaw('channelUtilization', now + 60 * DAY, 99);       // bad future row
+
+      const rows = repo.getTelemetryByNodeAveragedSqlite(NODE, now - 72 * HOUR, 5, 72, undefined);
+      const timestamps = rows.map(r => r.timestamp);
+      // No returned bucket may sit in the future.
+      expect(timestamps.every(t => t <= now + HOUR)).toBe(true);
+      expect(rows.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -7,6 +7,45 @@
 import { eq, lt, gte, and, desc, inArray, or, not, SQL, count, sql } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType, DbTelemetry } from '../types.js';
+import { logger } from '../../utils/logger.js';
+
+// A node that reboots without GPS/NTP can broadcast telemetry with a hardware
+// clock that is months or years off. A clock set into the FUTURE is the case
+// that wrecks telemetry charts (issue #3362): future-dated points pass the
+// chart's "last N hours" cutoff and stretch the auto-scaled X-axis domain so
+// every graph compresses into a sliver. Telemetry is live data, so a legitimate
+// embedded time is always within seconds of server-receipt — anything beyond a
+// small skew is a broken clock, and we store the receipt time instead.
+//
+// Absurdly-OLD embedded times are deliberately left as-is: at ingest they're
+// indistinguishable from legitimately buffered / store-and-forward telemetry,
+// and the windowed chart query already excludes anything older than its cutoff,
+// so they never distort the axis.
+const TELEMETRY_FUTURE_SKEW_MS = 60 * 60 * 1000; // 1 hour ahead of receipt
+
+/**
+ * Replace a future-dated (or non-finite) telemetry `timestamp` with the
+ * server-receipt time (`createdAt`), preserving the node's original claimed
+ * time in `packetTimestamp` for forensics. Mutates and returns the row. No-op
+ * when the timestamp is already sane.
+ */
+function sanitizeTelemetryTimestamp<T extends DbTelemetry>(row: T): T {
+  const receipt = Number.isFinite(row.createdAt) ? row.createdAt : Date.now();
+  const ts = row.timestamp;
+  if (!Number.isFinite(ts) || ts > receipt + TELEMETRY_FUTURE_SKEW_MS) {
+    // Keep what the node claimed (if we don't already have it) so the bad
+    // value is still inspectable, then fall back to receipt time.
+    if (row.packetTimestamp == null && Number.isFinite(ts)) {
+      row.packetTimestamp = ts;
+    }
+    logger.warn(
+      `Telemetry timestamp in the future for ${row.nodeId} (${row.telemetryType}): ` +
+      `claimed=${ts}, using receipt=${receipt}`
+    );
+    row.timestamp = receipt;
+  }
+  return row;
+}
 
 /**
  * Favorite telemetry entry: (nodeId, telemetryType) pair that should be
@@ -54,6 +93,7 @@ export class TelemetryRepository extends BaseRepository {
    */
   async insertTelemetry(telemetryData: DbTelemetry, sourceId?: string): Promise<boolean> {
     const { telemetry } = this.tables;
+    sanitizeTelemetryTimestamp(telemetryData);
     const values: any = {
       nodeId: telemetryData.nodeId,
       nodeNum: telemetryData.nodeNum,
@@ -91,6 +131,7 @@ export class TelemetryRepository extends BaseRepository {
 
     const { telemetry } = this.tables;
     const valuesArray = rows.map((r) => {
+      sanitizeTelemetryTimestamp(r);
       const v: any = {
         nodeId: r.nodeId,
         nodeNum: r.nodeNum,
@@ -888,6 +929,10 @@ export class TelemetryRepository extends BaseRepository {
     if (sinceTimestamp !== undefined) {
       baseConditions.push(gte(telemetry.timestamp, sinceTimestamp));
     }
+    // Exclude future-dated rows so a node with a bad hardware clock can't
+    // stretch the chart X-axis (issue #3362). Belt-and-suspenders with the
+    // ingest-time sanitizer — this also hides rows stored before that fix.
+    baseConditions.push(lt(telemetry.timestamp, Date.now() + TELEMETRY_FUTURE_SKEW_MS));
 
     // Averaged query: exclude raw types, group by time bucket
     const bucketExpr = sql<number>`CAST((${telemetry.timestamp} / ${intervalMs}) * ${intervalMs} AS INTEGER)`;
@@ -1003,6 +1048,10 @@ export class TelemetryRepository extends BaseRepository {
     if (sinceTimestamp !== undefined) {
       baseConditions.push(gte(telemetry.timestamp, sinceTimestamp));
     }
+    // Exclude future-dated rows so a node with a bad hardware clock can't
+    // stretch the chart X-axis (issue #3362). Belt-and-suspenders with the
+    // ingest-time sanitizer — this also hides rows stored before that fix.
+    baseConditions.push(lt(telemetry.timestamp, Date.now() + TELEMETRY_FUTURE_SKEW_MS));
 
     // Bucket start in ms. FLOOR(timestamp / intervalMs) * intervalMs.
     //


### PR DESCRIPTION
Closes #3362.

## Problem
When a node reboots without GPS/NTP, it can broadcast telemetry stamped months or years off. Future-dated points pass the chart's "last N hours" cutoff and become the X-axis `dataMax`, stretching the auto-scaled domain so every telemetry graph (Air Utilization, Altitude, Channel Utilization, Device Uptime, Voltage, SNR) collapses into a sliver — and impossible future dates appear in historical views.

## Root cause
The embedded packet timestamp is stored verbatim in `telemetry.timestamp` and used both to filter (`timestamp >= cutoff`) and to render the X-axis. There was no sanity bound, and the auto-scaled Recharts domain (`['dataMin','dataMax']`) lets a single outlier dominate.

## Fix — defense in depth
1. **Ingest sanitizer** at the repository chokepoint (`insertTelemetry` + `insertTelemetryBatch`, the single path every telemetry row flows through, where `createdAt` = server-receipt time is available). A timestamp more than 1h ahead of receipt (or non-finite) is replaced with the receipt time, and the node's claimed value is preserved in `packetTimestamp` for forensics.
2. **Query upper-bound** on the averaged chart query (SQLite + PG/MySQL paths) so future-dated rows stored *before* this fix can't distort the axis either.

**Why future-only:** a clock set into the future is what breaks the windowed chart (future points pass the cutoff). Absurdly-*old* embedded times are intentionally left untouched — at ingest they're indistinguishable from legitimately buffered / store-and-forward telemetry, and the chart's time-window cutoff already excludes them, so they never distort the axis. This also avoids relabeling legitimately-aged data and keeps retention/purge behavior intact.

## Testing
- New `telemetry.badTimestamp.test.ts` (6 cases): sane timestamp untouched; future timestamp → receipt + claim preserved; old timestamp left as-is; existing `packetTimestamp` not clobbered; batch inserts sanitized; averaged query drops a pre-existing future row.
- Full suite: **6147 passed, 0 failed**. `tsc --noEmit` clean. Existing telemetry retention/purge tests (which insert intentionally-old rows) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)