### PR TITLE
fix(security): enforce channel viewOnMap and private-position gates on analysis positions endpoint

### DIFF
--- a/src/db/repositories/analysis.ts
+++ b/src/db/repositories/analysis.ts
@@ -142,6 +142,7 @@ export interface GetCoverageGridArgs {
   sourceIds: string[];
   sinceMs: number;
   zoom: number;
+  postFilter?: (pos: PositionRow) => boolean;
 }
 
 export interface HopEntry {
@@ -560,6 +561,7 @@ export class AnalysisRepository {
         cursor,
       });
       for (const p of page.items) {
+        if (args.postFilter && !args.postFilter(p)) continue;
         const latBin = Math.floor(p.latitude / binSize);
         const lonBin = Math.floor(p.longitude / binSize);
         const dedupeKey = `${p.sourceId}:${p.nodeNum}:${latBin}:${lonBin}`;

--- a/src/server/routes/analysisRoutes.test.ts
+++ b/src/server/routes/analysisRoutes.test.ts
@@ -13,11 +13,13 @@ import request from 'supertest';
 vi.mock('../../services/database.js', () => ({
   default: {
     sources: { getAllSources: vi.fn() },
-    analysis: { getPositions: vi.fn() },
+    analysis: { getPositions: vi.fn(), getCoverageGrid: vi.fn() },
+    nodes: { getAllNodes: vi.fn() },
     checkPermissionAsync: vi.fn(),
     findUserByIdAsync: vi.fn(),
     findUserByUsernameAsync: vi.fn(),
     getUserPermissionSetAsync: vi.fn(),
+    getChannelDatabasePermissionsForUserAsSetAsync: vi.fn(),
   },
 }));
 
@@ -54,6 +56,10 @@ describe('GET /positions', () => {
     mockDb.analysis.getPositions.mockResolvedValue({
       items: [], pageSize: 500, hasMore: false, nextCursor: null,
     });
+    mockDb.nodes.getAllNodes.mockResolvedValue([]);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({ channel_0: { viewOnMap: true, read: true, write: false } });
+    mockDb.getChannelDatabasePermissionsForUserAsSetAsync.mockResolvedValue({});
+    mockDb.checkPermissionAsync.mockResolvedValue(true);
   });
 
   it('admin: queries all enabled sources', async () => {
@@ -108,6 +114,75 @@ describe('GET /positions', () => {
     expect(mockDb.analysis.getPositions).toHaveBeenCalledWith(
       expect.objectContaining({ cursor: 'abc' }),
     );
+  });
+
+  it('filters out positions on channels the user lacks viewOnMap on', async () => {
+    const posOnCh0 = { nodeNum: 1, sourceId: 'src-a', latitude: 1, longitude: 1, altitude: null, timestamp: 1000 };
+    const posOnCh1 = { nodeNum: 2, sourceId: 'src-a', latitude: 2, longitude: 2, altitude: null, timestamp: 1000 };
+    mockDb.analysis.getPositions.mockResolvedValue({
+      items: [posOnCh0, posOnCh1], pageSize: 500, hasMore: false, nextCursor: null,
+    });
+    // node 1 is on channel 0 (viewOnMap granted), node 2 is on channel 1 (not granted)
+    mockDb.nodes.getAllNodes.mockResolvedValue([
+      { nodeNum: 1, channel: 0 },
+      { nodeNum: 2, channel: 1 },
+    ]);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({
+      channel_0: { viewOnMap: true, read: true, write: false },
+      // channel_1 not granted
+    });
+    // nodes:read = true (allows source access), nodes_private:read = false (irrelevant here)
+    mockDb.checkPermissionAsync.mockImplementation((_uid: number, resource: string) =>
+      Promise.resolve(resource !== 'nodes_private'),
+    );
+
+    const app = createApp(regularUser);
+    const res = await request(app).get('/positions?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].nodeNum).toBe(1);
+  });
+
+  it('filters out positions for nodes with private position override when user lacks nodes_private:read', async () => {
+    const privatePos = { nodeNum: 99, sourceId: 'src-a', latitude: 5, longitude: 5, altitude: null, timestamp: 2000 };
+    mockDb.analysis.getPositions.mockResolvedValue({
+      items: [privatePos], pageSize: 500, hasMore: false, nextCursor: null,
+    });
+    mockDb.nodes.getAllNodes.mockResolvedValue([
+      { nodeNum: 99, channel: 0, positionOverrideIsPrivate: true },
+    ]);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({
+      channel_0: { viewOnMap: true, read: true, write: false },
+    });
+    // nodes_private:read denied
+    mockDb.checkPermissionAsync.mockImplementation((_uid: number, resource: string) =>
+      Promise.resolve(resource !== 'nodes_private'),
+    );
+
+    const app = createApp(regularUser);
+    const res = await request(app).get('/positions?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(0);
+  });
+
+  it('admin sees all positions regardless of channel or private override', async () => {
+    const pos = { nodeNum: 99, sourceId: 'src-a', latitude: 5, longitude: 5, altitude: null, timestamp: 2000 };
+    mockDb.analysis.getPositions.mockResolvedValue({
+      items: [pos], pageSize: 500, hasMore: false, nextCursor: null,
+    });
+    mockDb.nodes.getAllNodes.mockResolvedValue([
+      { nodeNum: 99, channel: 1, positionOverrideIsPrivate: true },
+    ]);
+    // Admin bypasses all node-level filters; these mocks should not be consulted
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({});
+    mockDb.checkPermissionAsync.mockResolvedValue(false);
+
+    const app = createApp(adminUser);
+    const res = await request(app).get('/positions?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    // Admin path: getAllNodes should not be called (filter is skipped)
+    expect(mockDb.nodes.getAllNodes).not.toHaveBeenCalled();
   });
 });
 
@@ -181,9 +256,13 @@ describe('GET /coverage-grid', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A, SOURCE_B]);
-    mockDb.analysis.getCoverageGrid = vi.fn().mockResolvedValue({
+    mockDb.analysis.getCoverageGrid.mockResolvedValue({
       cells: [], binSizeDeg: 0.04,
     });
+    mockDb.nodes.getAllNodes.mockResolvedValue([]);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({ channel_0: { viewOnMap: true, read: true, write: false } });
+    mockDb.getChannelDatabasePermissionsForUserAsSetAsync.mockResolvedValue({});
+    mockDb.checkPermissionAsync.mockResolvedValue(true);
   });
 
   it('admin: queries all enabled sources and forwards zoom', async () => {
@@ -195,14 +274,27 @@ describe('GET /coverage-grid', () => {
     );
   });
 
-  it('serves second request from cache (within TTL)', async () => {
+  it('admin: serves second request from cache (within TTL)', async () => {
     const app = createApp(adminUser);
     // Use a unique cache key (different sinceMs) to avoid cache pollution
     // from any prior test.
-    const url = '/coverage-grid?since=42&zoom=8';
+    const url = '/coverage-grid?since=9999&zoom=8';
     await request(app).get(url);
     await request(app).get(url);
     expect(mockDb.analysis.getCoverageGrid).toHaveBeenCalledTimes(1);
+  });
+
+  it('non-admin: skips cache and passes postFilter to getCoverageGrid', async () => {
+    mockDb.checkPermissionAsync.mockResolvedValue(false);
+    const app = createApp(regularUser);
+    const url = '/coverage-grid?since=8888&zoom=8';
+    await request(app).get(url);
+    await request(app).get(url);
+    // Result is not cached for non-admin, so getCoverageGrid called twice
+    expect(mockDb.analysis.getCoverageGrid).toHaveBeenCalledTimes(2);
+    // postFilter should be provided (non-null function)
+    const firstCall = mockDb.analysis.getCoverageGrid.mock.calls[0][0];
+    expect(typeof firstCall.postFilter).toBe('function');
   });
 });
 

--- a/src/server/routes/analysisRoutes.ts
+++ b/src/server/routes/analysisRoutes.ts
@@ -15,6 +15,8 @@ import { Router, Request, Response } from 'express';
 import databaseService from '../../services/database.js';
 import { optionalAuth } from '../auth/authMiddleware.js';
 import { logger } from '../../utils/logger.js';
+import { CHANNEL_DB_OFFSET } from '../constants/meshtastic.js';
+import type { PositionRow } from '../../db/repositories/analysis.js';
 import {
   identifySolarNodes,
   summarizeSolarProduction,
@@ -64,8 +66,72 @@ function parseSinceMs(raw: unknown): number {
   return Number.isFinite(n) && n >= 0 ? n : 0;
 }
 
+/**
+ * Build a synchronous position-row filter that enforces per-channel viewOnMap
+ * and positionOverrideIsPrivate gating. Returns null for admins (allow all).
+ *
+ * Pre-fetches all permissions and node metadata once so the returned predicate
+ * is pure and cheap to call per item — avoids N async DB round-trips inside
+ * the hot path of coverage-grid page iteration.
+ */
+async function buildPositionFilter(
+  user: any,
+  sourceIds: string[],
+): Promise<((pos: PositionRow) => boolean) | null> {
+  if (user?.isAdmin) return null;
+
+  const userId: number | null = user?.id ?? null;
+
+  // Fetch channel permission sets once per source
+  const permsBySource = new Map<string, Record<string, { viewOnMap?: boolean } | undefined>>();
+  for (const srcId of sourceIds) {
+    const perms = userId !== null
+      ? await databaseService.getUserPermissionSetAsync(userId, srcId)
+      : {};
+    permsBySource.set(srcId, perms);
+  }
+
+  // Fetch virtual-channel (channel DB) permissions and nodes_private:read once
+  const channelDbPerms: Record<number, { viewOnMap: boolean } | undefined> = userId !== null
+    ? await databaseService.getChannelDatabasePermissionsForUserAsSetAsync(userId)
+    : {};
+  const canViewPrivate = userId !== null
+    ? await databaseService.checkPermissionAsync(userId, 'nodes_private', 'read')
+    : false;
+
+  // Batch-load node metadata (channel, positionOverrideIsPrivate) for all nodes
+  // across permitted sources so the filter predicate runs synchronously.
+  const nodeInfoByKey = new Map<string, { channel: number; positionOverrideIsPrivate: boolean }>();
+  for (const srcId of sourceIds) {
+    const nodes = await databaseService.nodes.getAllNodes(srcId);
+    for (const n of nodes) {
+      nodeInfoByKey.set(`${srcId}:${n.nodeNum}`, {
+        channel: n.channel ?? 0,
+        positionOverrideIsPrivate: !!n.positionOverrideIsPrivate,
+      });
+    }
+  }
+
+  return (pos: PositionRow): boolean => {
+    const info = nodeInfoByKey.get(`${pos.sourceId}:${pos.nodeNum}`)
+      ?? { channel: 0, positionOverrideIsPrivate: false };
+
+    // Block private-position nodes unless the user has nodes_private:read
+    if (info.positionOverrideIsPrivate && !canViewPrivate) return false;
+
+    // Block nodes on channels the user lacks viewOnMap permission for
+    const perms = permsBySource.get(pos.sourceId) ?? {};
+    const ch = info.channel;
+    if (ch < CHANNEL_DB_OFFSET) {
+      return perms[`channel_${ch}`]?.viewOnMap === true;
+    }
+    return channelDbPerms[ch - CHANNEL_DB_OFFSET]?.viewOnMap === true;
+  };
+}
+
 router.get('/positions', async (req: Request, res: Response) => {
   try {
+    const user = (req as any).user;
     const permitted = await resolvePermittedSourceIds(req);
     const requested = parseSourcesParam(req.query.sources);
     const sourceIds = requested
@@ -78,6 +144,14 @@ router.get('/positions', async (req: Request, res: Response) => {
       pageSize: clampPageSize(req.query.pageSize),
       cursor: typeof req.query.cursor === 'string' ? req.query.cursor : null,
     });
+
+    // Enforce per-channel viewOnMap and positionOverrideIsPrivate gates,
+    // matching the checks the main map and v1/position-history already apply.
+    const posFilter = await buildPositionFilter(user, sourceIds);
+    if (posFilter) {
+      result.items = result.items.filter(posFilter);
+    }
+
     res.json(result);
   } catch (error) {
     logger.error('Error in GET /api/analysis/positions:', error);
@@ -131,6 +205,8 @@ const COVERAGE_TTL_MS = 5 * 60_000;
 
 router.get('/coverage-grid', async (req: Request, res: Response) => {
   try {
+    const user = (req as any).user;
+    const isAdmin = user?.isAdmin ?? false;
     const permitted = await resolvePermittedSourceIds(req);
     const requested = parseSourcesParam(req.query.sources);
     const sourceIds = requested
@@ -139,18 +215,30 @@ router.get('/coverage-grid', async (req: Request, res: Response) => {
     const sinceMs = parseSinceMs(req.query.since);
     const zoom = parseInt(String(req.query.zoom ?? '12'), 10) || 12;
 
+    // Cache only for admin requests — non-admin results vary by user permissions.
     const key = `${sourceIds.slice().sort().join(',')}|${sinceMs}|${zoom}`;
-    const cached = coverageCache.get(key);
-    if (cached && Date.now() - cached.at < COVERAGE_TTL_MS) {
-      res.json(cached.data);
-      return;
+    if (isAdmin) {
+      const cached = coverageCache.get(key);
+      if (cached && Date.now() - cached.at < COVERAGE_TTL_MS) {
+        res.json(cached.data);
+        return;
+      }
     }
+
+    // Enforce the same per-channel viewOnMap / positionOverrideIsPrivate gates
+    // that /positions applies — pre-built as a synchronous predicate so it can
+    // be applied inside getCoverageGrid's internal pagination loop.
+    const posFilter = await buildPositionFilter(user, sourceIds);
     const result = await databaseService.analysis.getCoverageGrid({
       sourceIds,
       sinceMs,
       zoom,
+      postFilter: posFilter ?? undefined,
     });
-    coverageCache.set(key, { at: Date.now(), data: result });
+
+    if (isAdmin) {
+      coverageCache.set(key, { at: Date.now(), data: result });
+    }
     res.json(result);
   } catch (error) {
     logger.error('Error in GET /api/analysis/coverage-grid:', error);


### PR DESCRIPTION
## Summary

Fixes #3365 — the `/api/analysis/positions` (Trails view) and `/api/analysis/coverage-grid` endpoints were returning GPS position data without enforcing the two finer-grained permission checks that the main map and `v1/position-history` already apply:

- **Per-channel `viewOnMap`** — nodes on channels the user lacks `viewOnMap` permission for were still included in the response.
- **`positionOverrideIsPrivate`** — nodes marked with a private position override were returned without requiring `nodes_private:read`.

## Changes

**`src/server/routes/analysisRoutes.ts`**
- Added `buildPositionFilter(user, sourceIds)` helper: pre-fetches the user's channel permission set (once per source), virtual-channel DB permissions, and node metadata (`channel` + `positionOverrideIsPrivate`) in bulk, then returns a cheap synchronous predicate.
- `/positions` handler: applies the predicate to `result.items` after `getPositions()` returns.
- `/coverage-grid` handler: passes the predicate as `postFilter` into `getCoverageGrid()`; also skips the shared in-memory cache for non-admin users since results are now user-specific.
- Admin requests bypass the filter entirely (no behaviour change).

**`src/db/repositories/analysis.ts`**
- Added optional `postFilter?: (pos: PositionRow) => boolean` to `GetCoverageGridArgs`.
- `getCoverageGrid()` applies the filter inside its internal pagination loop.

**`src/server/routes/analysisRoutes.test.ts`**
- Updated mock setup to include `nodes.getAllNodes`, `getChannelDatabasePermissionsForUserAsSetAsync`.
- 3 new tests: channel-denied positions filtered out; private-position nodes blocked without `nodes_private:read`; admin bypass (filter never invoked).

## Permission check comparison (after fix)

| Check | Main map | v1 `/position-history` | Analysis `/positions` | Analysis `/coverage-grid` |
|---|---|---|---|---|
| Source-level `nodes:read` | ✅ | ✅ | ✅ | ✅ |
| Per-channel `channel_N.viewOnMap` | ✅ | ✅ | ✅ | ✅ |
| `positionOverrideIsPrivate` → `nodes_private:read` | ✅ | ✅ | ✅ | ✅ |

## Test plan

- [ ] Confirm existing analysis route tests still pass (19/19)
- [ ] As a non-admin user with `nodes:read` but `channel_0.viewOnMap = false`: verify `/api/analysis/positions` returns no items for nodes on channel 0
- [ ] As a non-admin user without `nodes_private:read`: verify nodes with `positionOverrideIsPrivate = true` are excluded from `/api/analysis/positions`
- [ ] As admin: verify all positions are still returned (filter bypassed)
- [ ] Verify Trails UI renders correctly for permitted nodes and omits restricted ones

https://claude.ai/code/session_011GB1VoJXTVbFh2wdaUoArj

---
_Generated by [Claude Code](https://claude.ai/code/session_011GB1VoJXTVbFh2wdaUoArj)_