### PR TITLE
fix(meshcore): show Connecting… instead of Disconnected while status loads

### DIFF
--- a/src/pages/MeshCoreSourcePage.test.tsx
+++ b/src/pages/MeshCoreSourcePage.test.tsx
@@ -156,4 +156,60 @@ describe('MeshCoreSourcePage', () => {
     expect(fetchUrls.some((u) => u.includes('/meshcore/snapshot'))).toBe(false);
     expect(fetchUrls.some((u) => u.includes('/meshcore/status'))).toBe(false);
   });
+
+  it('shows Disconnected after snapshot returns connected=false', async () => {
+    authValue.hasPermission = () => true;
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Disconnected')).toBeInTheDocument();
+    });
+  });
+
+  it('shows Connected after snapshot returns connected=true', async () => {
+    authValue.hasPermission = () => true;
+    // Override snapshot to return connected=true for this test.
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      fetchUrls.push(url);
+      if (url.includes('/api/settings')) {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
+      if (url.includes('/api/auth/csrf-token')) {
+        return new Response(JSON.stringify({ token: 't' }), { status: 200 });
+      }
+      if (url.includes('/meshcore/snapshot')) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              status: {
+                connected: true,
+                deviceType: 1,
+                deviceTypeName: 'Companion',
+                config: null,
+                localNode: { publicKey: 'abc', name: 'MyNode', advType: 1 },
+              },
+              contacts: [],
+              nodes: [],
+              messages: [],
+              seqCursor: 0,
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes('/meshcore/status')) {
+        return new Response(
+          JSON.stringify({ success: true, data: { connected: true, deviceType: 1, deviceTypeName: 'Companion', config: null, localNode: null } }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ success: true, data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Connected')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/MeshCoreSourcePage.tsx
+++ b/src/pages/MeshCoreSourcePage.tsx
@@ -60,6 +60,9 @@ function MeshCoreSourceInner() {
     );
   }
 
+  // mcStatus is null until the snapshot loads — show "Connecting…" instead of
+  // "Disconnected" so the header doesn't mislead the user during the initial fetch.
+  const statusLoading = mcStatus === null;
   const connected = mcStatus?.connected ?? false;
   const localNode = mcStatus?.localNode ?? null;
   const localNodeLabel = localNode?.name || null;
@@ -97,12 +100,14 @@ function MeshCoreSourceInner() {
           <div className="connection-status-container">
             <div className="connection-status">
               <span
-                className={`status-indicator ${connected ? 'connected' : 'disconnected'}`}
+                className={`status-indicator ${statusLoading ? 'connecting' : connected ? 'connected' : 'disconnected'}`}
               />
               <span>
-                {connected
-                  ? t('header.status.connected', 'Connected')
-                  : t('header.status.disconnected', 'Disconnected')}
+                {statusLoading
+                  ? t('source.status_connecting', 'Connecting')
+                  : connected
+                    ? t('header.status.connected', 'Connected')
+                    : t('header.status.disconnected', 'Disconnected')}
               </span>
             </div>
           </div>


### PR DESCRIPTION
## Summary

When a user navigates to the MeshCore source page, the header connection chip was immediately showing "Disconnected" for the entire duration of the initial snapshot fetch — even when the device was fully connected. This created a confusing discrepancy where the dashboard sidebar showed "Connected" (from its polled cache) while the source page showed "Disconnected" (the default `null → false` state before the snapshot resolved).

The root cause is that `mcStatus` starts as `null`, and `mcStatus?.connected ?? false` evaluates to `false`, causing "Disconnected" to render prematurely. The fix treats `mcStatus === null` as a loading state and shows "Connecting…" until the snapshot completes.

## Changes

- `src/pages/MeshCoreSourcePage.tsx`: Derive `statusLoading = mcStatus === null`; render `.status-indicator.connecting` + `source.status_connecting` ("Connecting") while loading, then switch to "Connected" / "Disconnected" once the snapshot resolves
- `src/pages/MeshCoreSourcePage.test.tsx`: Add two new test cases — one verifying "Disconnected" renders after a `connected: false` snapshot, and one verifying "Connected" renders after a `connected: true` snapshot

Reuses the existing `.status-indicator.connecting` CSS class and the `source.status_connecting` i18n key — no new styles or translations needed.

## Issues Resolved

Fixes #3379

## Documentation Updates

No documentation changes needed.

## Testing

- [x] Unit tests pass (4 tests in MeshCoreSourcePage.test.tsx, full suite green)
- [x] TypeScript compiles cleanly
- [ ] Open a MeshCore source page — the header should show "Connecting…" briefly on load, then update to "Connected" (if device is up) or "Disconnected" (if device is down)
- [ ] Verify the chip no longer shows "Disconnected" during the snapshot load window when the device is actually connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ReNykYcCcqLfYRTEqAWYY)_