### PR TITLE
fix: Dashboard map respects Map Pin Style setting (#3364)

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -49,6 +49,7 @@ vi.mock('../../contexts/MapContext', () => ({
 // SettingsProvider.
 vi.mock('../../contexts/SettingsContext', () => ({
   useDisplaySettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
+  useSettings: () => ({ mapPinStyle: 'official' }),
 }));
 
 vi.mock('leaflet', () => ({
@@ -60,8 +61,9 @@ vi.mock('leaflet', () => ({
   latLngBounds: (...args: any[]) => ({ isValid: () => args.length > 0 }),
 }));
 
+const createNodeIconMock = vi.fn(() => ({}));
 vi.mock('../../utils/mapIcons', () => ({
-  createNodeIcon: () => ({}),
+  createNodeIcon: (...args: any[]) => createNodeIconMock(...args),
   getHopColor: () => '#000',
 }));
 
@@ -190,6 +192,18 @@ describe('DashboardMap', () => {
     );
     const markers = screen.getAllByTestId('map-marker');
     expect(markers.length).toBe(1);
+  });
+
+  it('forwards the configured map pin style to createNodeIcon (issue #3364)', () => {
+    render(
+      <DashboardMap
+        {...defaultProps}
+        nodes={[nodeWithPosition]}
+      />,
+    );
+    expect(createNodeIconMock).toHaveBeenCalledWith(
+      expect.objectContaining({ pinStyle: 'official' }),
+    );
   });
 
   it('does not render markers for nodes without positions', () => {

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -21,6 +21,7 @@ import type { CustomTileset } from '../../config/tilesets';
 import DashboardWaypoints from './DashboardWaypoints';
 import DashboardNodePopup from './DashboardNodePopup';
 import { useMapContext } from '../../contexts/MapContext';
+import { useSettings } from '../../contexts/SettingsContext';
 import { nodePassesTransportFilter } from '../../utils/nodeTransport';
 
 export interface DashboardMapProps {
@@ -140,6 +141,7 @@ export default function DashboardMap({
   maxNodeAgeHours,
 }: DashboardMapProps) {
   const tileset = getTilesetById(tilesetId, customTilesets);
+  const { mapPinStyle } = useSettings();
 
   const {
     showPaths,
@@ -301,6 +303,7 @@ export default function DashboardMap({
             isRouter,
             shortName,
             showLabel: true,
+            pinStyle: mapPinStyle,
           });
 
           return (


### PR DESCRIPTION
## Summary
The Dashboard ("Unified") map ignored the **Map Pin Style** setting and always rendered nodes as the default MeshMonitor pins, regardless of what the user selected (e.g. "Official Meshtastic circles"). This was inconsistent with every other live map view. The Dashboard map now reads the configured pin style and forwards it, so node markers honor the setting like `NodesTab` and the Map Analysis workspace already do.

## Changes
- `src/components/Dashboard/DashboardMap.tsx`: import `useSettings`, read `mapPinStyle`, and pass `pinStyle: mapPinStyle` into the `createNodeIcon(...)` marker call (it previously omitted `pinStyle`, defaulting to `'meshmonitor'`).
- `src/components/Dashboard/DashboardMap.test.tsx`: add `useSettings` to the `SettingsContext` mock and add a regression test asserting the configured pin style is forwarded to `createNodeIcon`.

## Issues Resolved
Fixes #3364

## Documentation Updates
No documentation changes needed — this restores already-documented Map Pin Style behavior on the Dashboard map.

## Testing
- [x] Unit tests pass (6154 tests, 0 failures)
- [x] TypeScript compiles cleanly
- [x] Manually verified in the dev container: switching Map Pin Style to "Official Meshtastic circles" now updates the Dashboard map markers
- [ ] Reviewer: set Settings → Map Pin Style to a non-pin style, open the Dashboard, confirm markers match the selected style

🤖 Generated with [Claude Code](https://claude.com/claude-code)