### PR TITLE
feat: add {DATE} and {TIME} tokens to Auto Announce (#3382)

### DIFF
--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -584,6 +584,8 @@ When enabled, MeshMonitor sends a scheduled message to the configured channel at
   - 📢 = Auto Announce enabled
 - **`{NODECOUNT}`**: Number of active nodes (e.g., "42 nodes")
 - **`{DIRECTCOUNT}`**: Number of direct nodes at 0 hops
+- **`{DATE}`**: Current date when the announcement is sent, formatted per your Date Format preference (e.g., "1/15/2025")
+- **`{TIME}`**: Current time when the announcement is sent, formatted per your Time Format preference (e.g., "2:30 PM")
 
 **Default Message**:
 ```

--- a/src/components/AutoAnnounceSection.test.tsx
+++ b/src/components/AutoAnnounceSection.test.tsx
@@ -243,6 +243,22 @@ describe.skip('AutoAnnounceSection Component', () => {
       expect(screen.getByText('+ {FEATURES}')).toBeInTheDocument();
       expect(screen.getByText('+ {NODECOUNT}')).toBeInTheDocument();
       expect(screen.getByText('+ {DIRECTCOUNT}')).toBeInTheDocument();
+      expect(screen.getByText('+ {DATE}')).toBeInTheDocument();
+      expect(screen.getByText('+ {TIME}')).toBeInTheDocument();
+    });
+
+    it('should insert DATE and TIME tokens when buttons clicked (issue #3382)', async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<AutoAnnounceSection {...defaultProps} message="" />);
+
+      await user.click(screen.getByText('+ {DATE}'));
+      await user.click(screen.getByText('+ {TIME}'));
+
+      await waitFor(() => {
+        const messageInput = screen.getByLabelText(/Announcement Message/) as HTMLTextAreaElement;
+        expect(messageInput.value).toContain('{DATE}');
+        expect(messageInput.value).toContain('{TIME}');
+      });
     });
 
     it('should insert VERSION token when button clicked', async () => {

--- a/src/components/AutoAnnounceSection.tsx
+++ b/src/components/AutoAnnounceSection.tsx
@@ -660,6 +660,38 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
             >
               + {'{TOTALNODES}'}
             </button>
+            <button
+              type="button"
+              onClick={createInsertTokenHandler('{DATE}')}
+              disabled={!localEnabled}
+              style={{
+                padding: '0.25rem 0.5rem',
+                fontSize: '12px',
+                background: 'var(--ctp-surface2)',
+                border: '1px solid var(--ctp-overlay0)',
+                borderRadius: '4px',
+                cursor: localEnabled ? 'pointer' : 'not-allowed',
+                opacity: localEnabled ? 1 : 0.5
+              }}
+            >
+              + {'{DATE}'}
+            </button>
+            <button
+              type="button"
+              onClick={createInsertTokenHandler('{TIME}')}
+              disabled={!localEnabled}
+              style={{
+                padding: '0.25rem 0.5rem',
+                fontSize: '12px',
+                background: 'var(--ctp-surface2)',
+                border: '1px solid var(--ctp-overlay0)',
+                borderRadius: '4px',
+                cursor: localEnabled ? 'pointer' : 'not-allowed',
+                opacity: localEnabled ? 1 : 0.5
+              }}
+            >
+              + {'{TIME}'}
+            </button>
           </div>
         </div>
 

--- a/src/server/meshtasticManager.announce-datetime.test.ts
+++ b/src/server/meshtasticManager.announce-datetime.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the {DATE} and {TIME} Auto-Announce tokens (issue #3382).
+ *
+ * These tokens expand to the current date/time at send time, formatted per the
+ * global `dateFormat` / `timeFormat` presentation preferences — mirroring how
+ * the acknowledgement path already formats received-message timestamps.
+ *
+ * We drive the real `previewAnnouncementMessage` wrapper (which calls the
+ * private `replaceAnnouncementTokens`) on the manager singleton, and compare
+ * against the shared formatter so the assertions stay timezone-independent.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { formatDate, formatTime } from '../utils/datetime.js';
+
+const mockGetSetting = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    getSetting: mockGetSetting,
+    setSetting: vi.fn(),
+    settings: {
+      getSetting: mockGetSetting,
+      getSettingForSource: vi.fn((_s: string, key: string) => mockGetSetting(key)),
+    },
+    nodes: {
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getNode: vi.fn().mockResolvedValue(null),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    telemetry: { insertTelemetry: vi.fn().mockResolvedValue(undefined) },
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// A fixed instant so "now" is deterministic across runs.
+const FIXED_NOW = new Date('2025-03-09T14:05:00');
+
+describe('MeshtasticManager - {DATE} / {TIME} announcement tokens', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    const module = await import('./meshtasticManager.js');
+    manager = module.default;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('replaces {DATE} using the configured dateFormat', async () => {
+    mockGetSetting.mockImplementation((key: string) =>
+      key === 'dateFormat' ? 'DD/MM/YYYY' : key === 'timeFormat' ? '24' : undefined,
+    );
+
+    const result = await manager.previewAnnouncementMessage('Today is {DATE}');
+
+    expect(result).toBe(`Today is ${formatDate(FIXED_NOW, 'DD/MM/YYYY')}`);
+  });
+
+  it('replaces {TIME} using the configured 12-hour timeFormat', async () => {
+    mockGetSetting.mockImplementation((key: string) =>
+      key === 'timeFormat' ? '12' : key === 'dateFormat' ? 'MM/DD/YYYY' : undefined,
+    );
+
+    const result = await manager.previewAnnouncementMessage('Online at {TIME}');
+
+    expect(result).toBe(`Online at ${formatTime(FIXED_NOW, '12')}`);
+  });
+
+  it('replaces both {DATE} and {TIME} in a single message', async () => {
+    mockGetSetting.mockImplementation((key: string) =>
+      key === 'dateFormat' ? 'MM/DD/YYYY' : key === 'timeFormat' ? '24' : undefined,
+    );
+
+    const result = await manager.previewAnnouncementMessage('{DATE} {TIME}');
+
+    expect(result).toBe(`${formatDate(FIXED_NOW, 'MM/DD/YYYY')} ${formatTime(FIXED_NOW, '24')}`);
+  });
+
+  it('falls back to default formats when the settings are unset', async () => {
+    mockGetSetting.mockResolvedValue(undefined);
+
+    const result = await manager.previewAnnouncementMessage('{DATE} {TIME}');
+
+    expect(result).toBe(`${formatDate(FIXED_NOW, 'MM/DD/YYYY')} ${formatTime(FIXED_NOW, '24')}`);
+  });
+
+  it('leaves a message without the tokens untouched', async () => {
+    mockGetSetting.mockResolvedValue(undefined);
+
+    const result = await manager.previewAnnouncementMessage('No tokens here');
+
+    expect(result).toBe('No tokens here');
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -10990,6 +10990,20 @@ class MeshtasticManager implements ISourceManager {
       result = result.replace(/{PORT}/g, encode(String(config.tcpPort)));
     }
 
+    // {DATE} / {TIME} - Current date/time when the announcement is sent, formatted
+    // per the global dateFormat/timeFormat presentation preferences (issue #3382).
+    if (result.includes('{DATE}') || result.includes('{TIME}')) {
+      const now = new Date();
+      const dateFormat = await databaseService.settings.getSetting('dateFormat') || 'MM/DD/YYYY';
+      const timeFormat = await databaseService.settings.getSetting('timeFormat') || '24';
+      if (result.includes('{DATE}')) {
+        result = result.replace(/{DATE}/g, encode(formatDate(now, dateFormat as 'MM/DD/YYYY' | 'DD/MM/YYYY')));
+      }
+      if (result.includes('{TIME}')) {
+        result = result.replace(/{TIME}/g, encode(formatTime(now, timeFormat as '12' | '24')));
+      }
+    }
+
     return result;
   }
 


### PR DESCRIPTION
## Summary
Adds `{DATE}` and `{TIME}` template tokens to the Auto Announce message editor, as requested in #3382. They expand to the **current** date/time at the moment the announcement is sent, so periodic announcements can carry a timestamp (e.g. "online as of {DATE} {TIME}"). Formatting honors the global Date Format / Time Format preferences, consistent with how the acknowledgement and welcome paths already render timestamps.

## Changes
- **Backend** (`src/server/meshtasticManager.ts`): `replaceAnnouncementTokens()` now resolves `{DATE}` and `{TIME}` using the shared `formatDate`/`formatTime` helpers and the global `dateFormat`/`timeFormat` settings. The live preview endpoint (`previewAnnouncementMessage`) picks them up automatically.
- **Frontend** (`src/components/AutoAnnounceSection.tsx`): added `+ {DATE}` and `+ {TIME}` insert buttons alongside the existing token buttons.
- **Docs** (`docs/features/automation.md`): documented the two new tokens in the Auto-Announce token reference.

## Issues Resolved
Fixes #3382

## Documentation Updates
- `docs/features/automation.md` — added `{DATE}` and `{TIME}` to the Auto-Announce token list.

## Testing
- [x] Unit tests pass (full suite: 6159 passed, 0 failures)
- [x] TypeScript compiles cleanly
- [x] New backend test `meshtasticManager.announce-datetime.test.ts` drives the real `previewAnnouncementMessage`: covers DD/MM date format, 12-hour time, combined tokens, default-format fallback, and no-token passthrough (timezone-safe).
- [ ] Reviewer: in Settings → Auto Announce, insert `{DATE}` / `{TIME}`, confirm the live preview renders the current date/time matching your Date/Time Format preferences.

## Scope note
Scoped to the Meshtastic Auto Announce (the editor referenced in the issue). MeshCore has a separate, intentionally-narrow announce token set; extending it there can be a follow-up if parity is desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)