### PR TITLE
fix: scope auto-ack {LONG_NAME}/{SHORT_NAME} lookup by sourceId (#3384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 
+- **Auto-Acknowledge `{LONG_NAME}`/`{SHORT_NAME}` resolved as `Unknown`/`????` (#3384)**: The auto-ack template resolver looked up the sender node without a `sourceId`. Under the multi-source composite `(nodeNum, sourceId)` primary key, an unscoped lookup returns the first matching row across *any* source — frequently a different source's row (or none), so the name tokens intermittently fell back to `Unknown`/`????` even when the originating source had the node's name on record (the channel-window title, which reads per-source, always showed it correctly). The lookup is now scoped to the manager's own `sourceId`, matching the already-correct auto-welcome path.
+
 - **Telemetry charts distorted by nodes with bad hardware clocks (#3362)**: A node that reboots without GPS/NTP can broadcast telemetry stamped months or years into the future; those points passed the "last N hours" cutoff and stretched the auto-scaled chart X-axis so every telemetry graph collapsed into a sliver. Telemetry ingest now sanitizes future-dated timestamps at the repository chokepoint — a timestamp more than 1h ahead of server-receipt time (or non-finite) is replaced with the receipt time, and the node's claimed value is preserved in `packetTimestamp` for forensics. The averaged chart query also excludes future-dated rows, so estimates stored before this fix no longer distort the axis. Absurdly-old embedded times are left untouched (indistinguishable from buffered/store-forward telemetry at ingest, and already excluded by the chart's time-window cutoff).
 
 ## [4.9.3] - 2026-06-07

--- a/src/server/meshtasticManager.autoAckTokens.perSource.test.ts
+++ b/src/server/meshtasticManager.autoAckTokens.perSource.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MeshtasticManager } from './meshtasticManager.js';
+import databaseService from '../services/database.js';
+
+// Regression test for #3384: {LONG_NAME} / {SHORT_NAME} in Auto-Acknowledge
+// messages resolved to 'Unknown' / '????' intermittently. Root cause: the
+// auto-ack token replacer called databaseService.nodes.getNode(fromNum) WITHOUT
+// a sourceId. Under the composite (nodeNum, sourceId) PK an unscoped lookup
+// returns the first row across ANY source — often a different source's node (or
+// nothing), even though THIS source has the name on record.
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      getSettingForSource: vi.fn().mockResolvedValue(null),
+    },
+    nodes: {
+      getNode: vi.fn(),
+    },
+    channels: {
+      getChannelById: vi.fn().mockResolvedValue(null),
+    },
+  },
+}));
+
+vi.mock('./messageQueueService.js', () => {
+  const mockInstance = {
+    enqueue: vi.fn(),
+    setSendCallback: vi.fn(),
+    clear: vi.fn(),
+    getStatus: vi.fn(() => ({ queueLength: 0, pendingAcks: 0, processing: false })),
+  };
+  function MessageQueueService() { return mockInstance as any; }
+  return { messageQueueService: mockInstance, MessageQueueService };
+});
+
+describe('MeshtasticManager - Auto-Ack {LONG_NAME}/{SHORT_NAME} source scoping (#3384)', () => {
+  const FROM_NUM = 0x11223344;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('looks up the sender node scoped to this manager\'s sourceId', async () => {
+    const manager = new MeshtasticManager('source-b');
+    vi.mocked(databaseService.nodes.getNode).mockResolvedValue({
+      nodeNum: FROM_NUM,
+      longName: 'Base Station One',
+      shortName: 'BS01',
+    } as any);
+
+    const result = await (manager as any).replaceAcknowledgementTokens(
+      '🤖 Copy {LONG_NAME} ({SHORT_NAME})',
+      '!11223344', FROM_NUM, 2, '01/01/2026', '12:00', 0, false,
+    );
+
+    expect(result).toBe('🤖 Copy Base Station One (BS01)');
+    // The fix: getNode MUST be scoped by sourceId.
+    expect(databaseService.nodes.getNode).toHaveBeenCalledWith(FROM_NUM, 'source-b');
+  });
+
+  it('resolves real names when the node exists ONLY under this source (not the first cross-source row)', async () => {
+    const manager = new MeshtasticManager('source-b');
+
+    // Simulate the multi-source PK: the node row only exists for 'source-b'.
+    // An unscoped lookup (old buggy behaviour) would have returned null here,
+    // producing 'Unknown' / '????'.
+    vi.mocked(databaseService.nodes.getNode).mockImplementation(
+      async (_nodeNum: number, sourceId?: string) =>
+        sourceId === 'source-b'
+          ? ({ nodeNum: FROM_NUM, longName: 'Repeater North', shortName: 'RPTN' } as any)
+          : null,
+    );
+
+    const result = await (manager as any).replaceAcknowledgementTokens(
+      '{LONG_NAME}/{SHORT_NAME}',
+      '!11223344', FROM_NUM, 0, '01/01/2026', '12:00', 0, false,
+    );
+
+    expect(result).toBe('Repeater North/RPTN');
+    expect(result).not.toContain('Unknown');
+    expect(result).not.toContain('????');
+  });
+
+  it('still falls back to Unknown/???? when the node is genuinely absent for this source', async () => {
+    const manager = new MeshtasticManager('source-b');
+    vi.mocked(databaseService.nodes.getNode).mockResolvedValue(null);
+
+    const result = await (manager as any).replaceAcknowledgementTokens(
+      '{LONG_NAME}/{SHORT_NAME}',
+      '!11223344', FROM_NUM, 0, '01/01/2026', '12:00', 0, false,
+    );
+
+    expect(result).toBe('Unknown/????');
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -11048,14 +11048,19 @@ class MeshtasticManager implements ISourceManager {
 
     // {LONG_NAME} - Sender node long name
     if (result.includes('{LONG_NAME}')) {
-      const node = await databaseService.nodes.getNode(fromNum);
+      // Scope by sourceId: under the composite (nodeNum, sourceId) PK an
+      // unscoped lookup returns the first row across ANY source, which can be a
+      // different source's node (or nothing), making the token resolve to
+      // 'Unknown' even when this source has the name on record (#3384).
+      const node = await databaseService.nodes.getNode(fromNum, this.sourceId);
       const longName = node?.longName || 'Unknown';
       result = result.replace(/{LONG_NAME}/g, encode(longName));
     }
 
     // {SHORT_NAME} - Sender node short name
     if (result.includes('{SHORT_NAME}')) {
-      const node = await databaseService.nodes.getNode(fromNum);
+      // Scope by sourceId — see {LONG_NAME} above (#3384).
+      const node = await databaseService.nodes.getNode(fromNum, this.sourceId);
       const shortName = node?.shortName || '????';
       result = result.replace(/{SHORT_NAME}/g, encode(shortName));
     }


### PR DESCRIPTION
## Summary
Auto-Acknowledge replies intermittently rendered `{LONG_NAME}`/`{SHORT_NAME}` as `Unknown`/`????` even when MeshMonitor clearly knew the node (its name showed in the channel-window title). The auto-ack token resolver looked up the sender node *without* a `sourceId`. Under the 4.x multi-source composite `(nodeNum, sourceId)` primary key, an unscoped `getNode` returns the first matching row across **any** source — often a different source's row, or none — so the name tokens fell back to placeholders. This scopes the lookup to the manager's own source.

## Changes
- `replaceAcknowledgementTokens` in `src/server/meshtasticManager.ts` now calls `databaseService.nodes.getNode(fromNum, this.sourceId)` for both `{LONG_NAME}` and `{SHORT_NAME}`, matching the already-correct `replaceWelcomeTokens` path.
- Added `src/server/meshtasticManager.autoAckTokens.perSource.test.ts` — a per-source regression test.
- Added a CHANGELOG entry under `[Unreleased] → Bug Fixes`.

## Issues Resolved
Fixes #3384

## Documentation Updates
- `CHANGELOG.md` updated. No feature/config docs needed — the available token set is unchanged; only the per-source lookup was wrong.

## Testing
- [x] Unit tests pass (6173 tests)
- [x] TypeScript compiles cleanly
- [x] New per-source test asserts `getNode` is called with `(fromNum, sourceId)`, resolves real names for a node that exists only under this source (the exact failure mode — would have returned `Unknown/????` before the fix), and still falls back to `Unknown/????` when the node is genuinely absent for the source.
- [ ] Manual: configure an Auto-Acknowledge rule with `{LONG_NAME}`/`{SHORT_NAME}`, receive a matching message from a known node, confirm the reply substitutes the real name on every message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)