### PR TITLE
fix: scope {NODECOUNT}/{DIRECTCOUNT} tokens to 2h active window (#3388)

### DIFF
--- a/src/components/GeofenceTriggersSection.tsx
+++ b/src/components/GeofenceTriggersSection.tsx
@@ -29,7 +29,7 @@ const AVAILABLE_TOKENS = [
   { token: '{DISTANCE_TO_CENTER}', description: 'Distance to geofence center (km)' },
   { token: '{IP}', description: 'Connected Meshtastic node IP address' },
   { token: '{VERSION}', description: 'MeshMonitor version' },
-  { token: '{NODECOUNT}', description: 'Active nodes (filtered by maxNodeAgeHours)' },
+  { token: '{NODECOUNT}', description: 'Active nodes (heard in last 2h, matches Sources panel)' },
   { token: '{TOTALNODES}', description: 'Total nodes ever seen' },
 ];
 

--- a/src/components/TimerTriggersSection.tsx
+++ b/src/components/TimerTriggersSection.tsx
@@ -39,8 +39,8 @@ const AVAILABLE_TOKENS = [
   { token: '{VERSION}', description: 'MeshMonitor version' },
   { token: '{DURATION}', description: 'Server uptime' },
   { token: '{FEATURES}', description: 'Enabled features as emojis' },
-  { token: '{NODECOUNT}', description: 'Active nodes (filtered by maxNodeAgeHours)' },
-  { token: '{DIRECTCOUNT}', description: 'Direct nodes (0 hops)' },
+  { token: '{NODECOUNT}', description: 'Active nodes (heard in last 2h, matches Sources panel)' },
+  { token: '{DIRECTCOUNT}', description: 'Direct nodes (0 hops) heard in last 2h' },
   { token: '{TOTALNODES}', description: 'Total nodes ever seen' },
 ];
 

--- a/src/server/meshtasticManager.autowelcome.test.ts
+++ b/src/server/meshtasticManager.autowelcome.test.ts
@@ -23,6 +23,7 @@ vi.mock('../services/database.js', () => ({
       getNode: vi.fn(),
       getAllNodes: vi.fn().mockResolvedValue([]),
       getActiveNodes: vi.fn().mockResolvedValue([]),
+      getActiveNodeCount: vi.fn().mockResolvedValue(0),
       upsertNode: vi.fn().mockResolvedValue(undefined),
       markNodeAsWelcomedIfNotAlready: vi.fn().mockResolvedValue(false),
       getNodeCount: vi.fn().mockResolvedValue(0),
@@ -472,6 +473,9 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
         if (key === 'maxNodeAgeHours') return '24';
         return null;
       });
+      // {NODECOUNT} uses getActiveNodeCount (2h window, matches Sources panel #3388);
+      // {DIRECTCOUNT} still pulls the node list to count 0-hop nodes.
+      vi.mocked(databaseService.nodes.getActiveNodeCount).mockResolvedValue(3);
       vi.mocked(databaseService.nodes.getActiveNodes).mockResolvedValue([
         mockNode,
         { ...mockNode, nodeNum: 888888, hopsAway: 0 },
@@ -488,6 +492,43 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
       expect(result).toContain('2.3.1');
       expect(result).toContain('3'); // NODECOUNT
       expect(result).toContain('1'); // DIRECTCOUNT (only one node with hopsAway: 0)
+    });
+
+    // Issue #3388: {NODECOUNT} must report the same "active" figure the Sources
+    // panel badge shows (nodes heard in the last 2h via getActiveNodeCount),
+    // NOT the wider maxNodeAgeHours window that previously made the sent message
+    // read e.g. "99" while the UI showed "62 active".
+    it('replaces {NODECOUNT} with the 2h active count (matches Sources panel #3388)', async () => {
+      const mockNode = {
+        nodeNum: 999999,
+        nodeId: '!000f423f',
+        longName: 'Test Node',
+        shortName: 'TEST',
+        hwModel: 0,
+        firmwareVersion: '2.3.1',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      vi.mocked(databaseService.nodes.getNode).mockResolvedValue(mockNode);
+      vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
+        if (key === 'maxNodeAgeHours') return '24';
+        return null;
+      });
+      // Badge-style active count (2h window) = 62; total ever seen = 99.
+      vi.mocked(databaseService.nodes.getActiveNodeCount).mockResolvedValue(62);
+      vi.mocked(databaseService.nodes.getAllNodes).mockResolvedValue(
+        Array.from({ length: 99 }, (_, i) => ({ ...mockNode, nodeNum: 100000 + i }))
+      );
+
+      const result = await (manager as any).replaceWelcomeTokens(
+        '{NODECOUNT} / {TOTALNODES}',
+        999999,
+        '!000f423f'
+      );
+
+      expect(result).toBe('62 / 99'); // NODECOUNT is the 2h active count, not the 99 total
+      // Queried with the 2h window (7200s), matching the Sources panel badge.
+      expect(databaseService.nodes.getActiveNodeCount).toHaveBeenCalledWith('default', 7200);
     });
 
     it('should handle missing node gracefully with fallbacks', async () => {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -57,6 +57,13 @@ const SCRIPT_AUTO_RESPONDER_TIMEOUT_MS = 30_000;
 // Minimum gap between local "re-ignore" admin pushes for the same node (#2601),
 // so a device that can't durably hold the ignore doesn't trigger a command storm.
 const IGNORE_REAPPLY_COOLDOWN_MS = 60_000;
+// Window for the {NODECOUNT}/{DIRECTCOUNT} template tokens, matching the
+// Sources panel's per-source "active" badge (issue #3388). The badge counts
+// nodes heard in the last 2h (getActiveNodeCount default, issue #2883); the
+// tokens previously used the much wider `maxNodeAgeHours` setting, so the
+// sent message disagreed with what the UI showed for the same gateway.
+const ACTIVE_NODE_TOKEN_WINDOW_SECONDS = 7200;
+const ACTIVE_NODE_TOKEN_WINDOW_DAYS = ACTIVE_NODE_TOKEN_WINDOW_SECONDS / 86_400;
 
 /** Parsed auto-responder payload: list of messages to send, plus the
  * raw decoded JSON object (or `{}` if the payload was plain text) so
@@ -9978,12 +9985,11 @@ class MeshtasticManager implements ISourceManager {
       }
     }
 
-    // Add NODECOUNT - active nodes based on maxNodeAgeHours setting (scoped to this source
-    // so auto-responder scripts see the count for their own source, not a cross-source union)
-    const maxNodeAgeHours = parseInt(await databaseService.settings.getSetting('maxNodeAgeHours') || '24');
-    const maxNodeAgeDays = maxNodeAgeHours / 24;
-    const activeNodes = await databaseService.nodes.getActiveNodes(maxNodeAgeDays, this.sourceId);
-    scriptEnv.NODECOUNT = String(activeNodes.length);
+    // Add NODECOUNT - nodes heard in the last 2h (scoped to this source so
+    // auto-responder scripts see the count for their own source, not a
+    // cross-source union). Matches the Sources panel "active" badge (#3388).
+    const activeNodeCount = await databaseService.nodes.getActiveNodeCount(this.sourceId, ACTIVE_NODE_TOKEN_WINDOW_SECONDS);
+    scriptEnv.NODECOUNT = String(activeNodeCount);
 
     // Add location environment variables for the MeshMonitor node (MM_LAT, MM_LON)
     const localNodeInfo = this.getLocalNodeInfo();
@@ -10664,19 +10670,16 @@ class MeshtasticManager implements ISourceManager {
       result = result.replace(/{FEATURES}/g, features.join(' '));
     }
 
-    // {NODECOUNT} - Active nodes based on maxNodeAgeHours setting (scoped to this source)
+    // {NODECOUNT} - Nodes heard in the last 2h, matching the Sources panel
+    // "active" badge (scoped to this source) (#3388)
     if (result.includes('{NODECOUNT}')) {
-      const maxNodeAgeHours = parseInt(await databaseService.settings.getSetting('maxNodeAgeHours') || '24');
-      const maxNodeAgeDays = maxNodeAgeHours / 24;
-      const nodes = await databaseService.nodes.getActiveNodes(maxNodeAgeDays, this.sourceId);
-      result = result.replace(/{NODECOUNT}/g, nodes.length.toString());
+      const activeNodeCount = await databaseService.nodes.getActiveNodeCount(this.sourceId, ACTIVE_NODE_TOKEN_WINDOW_SECONDS);
+      result = result.replace(/{NODECOUNT}/g, activeNodeCount.toString());
     }
 
-    // {DIRECTCOUNT} - Direct nodes (0 hops) from active nodes (scoped to this source)
+    // {DIRECTCOUNT} - Direct nodes (0 hops) among nodes heard in the last 2h (scoped to this source) (#3388)
     if (result.includes('{DIRECTCOUNT}')) {
-      const maxNodeAgeHours = parseInt(await databaseService.settings.getSetting('maxNodeAgeHours') || '24');
-      const maxNodeAgeDays = maxNodeAgeHours / 24;
-      const nodes = await databaseService.nodes.getActiveNodes(maxNodeAgeDays, this.sourceId);
+      const nodes = await databaseService.nodes.getActiveNodes(ACTIVE_NODE_TOKEN_WINDOW_DAYS, this.sourceId);
       const directCount = nodes.filter((n: any) => n.hopsAway === 0).length;
       result = result.replace(/{DIRECTCOUNT}/g, directCount.toString());
     }
@@ -10935,22 +10938,18 @@ class MeshtasticManager implements ISourceManager {
       result = result.replace(/{FEATURES}/g, encode(features.join(' ')));
     }
 
-    // {NODECOUNT} - Active nodes based on maxNodeAgeHours setting
+    // {NODECOUNT} - Nodes heard in the last 2h, matching the Sources panel "active" badge (#3388)
     if (result.includes('{NODECOUNT}')) {
-      const maxNodeAgeHours = parseInt(await databaseService.settings.getSetting('maxNodeAgeHours') || '24');
-      const maxNodeAgeDays = maxNodeAgeHours / 24;
-      const nodes = await databaseService.nodes.getActiveNodes(maxNodeAgeDays, this.sourceId);
-      logger.info(`📢 Token replacement - NODECOUNT: ${nodes.length} active nodes (maxNodeAgeHours: ${maxNodeAgeHours})`);
-      result = result.replace(/{NODECOUNT}/g, encode(nodes.length.toString()));
+      const activeNodeCount = await databaseService.nodes.getActiveNodeCount(this.sourceId, ACTIVE_NODE_TOKEN_WINDOW_SECONDS);
+      logger.info(`📢 Token replacement - NODECOUNT: ${activeNodeCount} active nodes (last 2h)`);
+      result = result.replace(/{NODECOUNT}/g, encode(activeNodeCount.toString()));
     }
 
-    // {DIRECTCOUNT} - Direct nodes (0 hops) from active nodes (scoped to this source)
+    // {DIRECTCOUNT} - Direct nodes (0 hops) among nodes heard in the last 2h (scoped to this source) (#3388)
     if (result.includes('{DIRECTCOUNT}')) {
-      const maxNodeAgeHours = parseInt(await databaseService.settings.getSetting('maxNodeAgeHours') || '24');
-      const maxNodeAgeDays = maxNodeAgeHours / 24;
-      const nodes = await databaseService.nodes.getActiveNodes(maxNodeAgeDays, this.sourceId);
+      const nodes = await databaseService.nodes.getActiveNodes(ACTIVE_NODE_TOKEN_WINDOW_DAYS, this.sourceId);
       const directCount = nodes.filter((n: any) => n.hopsAway === 0).length;
-      logger.info(`📢 Token replacement - DIRECTCOUNT: ${directCount} direct nodes out of ${nodes.length} active nodes`);
+      logger.info(`📢 Token replacement - DIRECTCOUNT: ${directCount} direct nodes out of ${nodes.length} active nodes (last 2h)`);
       result = result.replace(/{DIRECTCOUNT}/g, encode(directCount.toString()));
     }
 


### PR DESCRIPTION
## Summary

Fixes #3388. The Auto Acknowledge / Auto Announce `{NODECOUNT}` and `{DIRECTCOUNT}` template tokens reported values that didn't match the Sources panel's "active" badge for the same gateway (e.g. message said `99 / 91 / 99` while the panel showed `62/99 active`).

### Root cause

Two different definitions of "active node" existed:

| Surface | "Active" window |
|---|---|
| **Sources panel badge** ("62/99 active") | last **2 hours** (`getActiveNodeCount`, fixed 7200s — issue #2883) |
| **`{NODECOUNT}` / `{DIRECTCOUNT}` tokens** | configurable **`maxNodeAgeHours`** (default 24h, via `getActiveNodes`) |

With `maxNodeAgeHours`=24h, every node heard in the last day counted, so `{NODECOUNT}` matched the *total* (99) instead of the badge's 2h *active* figure (62).

### Fix

Repoint the count tokens at the same 2h window the badge uses:
- `{NODECOUNT}` now calls `getActiveNodeCount(sourceId, 7200)` — the exact method the badge uses, guaranteeing the numbers agree.
- `{DIRECTCOUNT}` counts 0-hop nodes within the same 2h window.
- Applied to all three token sites: `replaceWelcomeTokens`, `replaceAnnouncementTokens` (auto-ack/announce/geofence/timer), and the auto-responder `scriptEnv`.
- Updated the in-UI token help text in `TimerTriggersSection` / `GeofenceTriggersSection`.

**Left unchanged:** `systemNodeCount`/`systemDirectNodeCount` telemetry graphs keep the `maxNodeAgeHours` window (changing it would create a discontinuity in existing graphs). `{TOTALNODES}` is unchanged.

## Testing

- `tsc --noEmit` clean, ESLint clean.
- Added a regression test reproducing the exact 62/99 scenario and asserting the 7200s window is queried.
- All token / announce / geofence / welcome tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)