### PR TITLE
feat: export MeshCore packet monitor log as JSONL (#3391)

### DIFF
--- a/src/components/MeshCore/MeshCorePacketMonitorView.tsx
+++ b/src/components/MeshCore/MeshCorePacketMonitorView.tsx
@@ -15,7 +15,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { Filter, Trash2, Pause, Play, RefreshCw } from 'lucide-react';
+import { Filter, Trash2, Pause, Play, RefreshCw, Download } from 'lucide-react';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { useWebSocketContext } from '../../contexts/WebSocketContext';
 import { useAuth } from '../../contexts/AuthContext';
@@ -171,6 +171,36 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
     }
   }, [csrfFetch, mcPrefix, t]);
 
+  // Download the captured packet log as JSONL (honors the active filters),
+  // mirroring the Meshtastic packet-monitor export.
+  const handleExport = useCallback(async () => {
+    try {
+      const params = new URLSearchParams();
+      if (payloadFilter !== '') params.set('payload_type', String(payloadFilter));
+      if (routeFilter !== '') params.set('route_type', String(routeFilter));
+      const res = await csrfFetch(`${mcPrefix}/packets/export?${params.toString()}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      // Prefer the server-provided filename (timestamped, filter-aware).
+      const contentDisposition = res.headers.get('Content-Disposition');
+      let filename = 'meshcore-packet-monitor.jsonl';
+      const matches = contentDisposition && /filename="(.+)"/.exec(contentDisposition);
+      if (matches && matches[1]) filename = matches[1];
+
+      const blob = await res.blob();
+      const blobUrl = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = blobUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(blobUrl);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to export packets');
+    }
+  }, [csrfFetch, mcPrefix, payloadFilter, routeFilter]);
+
   return (
     <div className="meshcore-packet-monitor">
       <div className="mcpm-header">
@@ -193,6 +223,9 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
           </button>
           <button className="mcpm-btn" onClick={() => void load()} title={t('common.refresh', 'Refresh')}>
             <RefreshCw size={14} />
+          </button>
+          <button className="mcpm-btn" onClick={() => void handleExport()} title={t('common.export', 'Export')}>
+            <Download size={14} />
           </button>
           {canClear && (
             <button className="mcpm-btn mcpm-btn-danger" onClick={() => void handleClear()} title={t('common.clear', 'Clear')}>

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -147,6 +147,18 @@ vi.mock('../services/meshcoreTelemetryPoller.js', () => ({
   },
 }));
 
+// Mock the MeshCore packet-log service so the packet-monitor routes don't hit
+// the (fully-mocked) database. Hoisted so the vi.mock factory can reference it.
+const mockPacketService = vi.hoisted(() => ({
+  getPackets: vi.fn(),
+  getPacketCount: vi.fn(),
+  getMaxCount: vi.fn(),
+  getMaxAgeHours: vi.fn(),
+  isEnabled: vi.fn(),
+  clearPackets: vi.fn(),
+}));
+vi.mock('../services/meshcorePacketLogService.js', () => ({ default: mockPacketService }));
+
 import DatabaseService from '../../services/database.js';
 
 // Mutable holder so individual tests can flip the toggle for the
@@ -234,7 +246,7 @@ describe('MeshCore Routes', () => {
       password: 'anonymous123',
       authProvider: 'local',
     });
-    for (const resource of ['connection', 'nodes', 'messages', 'configuration', 'remote_admin'] as const) {
+    for (const resource of ['connection', 'nodes', 'messages', 'configuration', 'remote_admin', 'packetmonitor'] as const) {
       await permissionModel.grant({
         userId: anonymousUser.id,
         resource,
@@ -262,7 +274,7 @@ describe('MeshCore Routes', () => {
       authProvider: 'local'
     });
 
-    for (const resource of ['connection', 'nodes', 'messages', 'configuration', 'remote_admin'] as const) {
+    for (const resource of ['connection', 'nodes', 'messages', 'configuration', 'remote_admin', 'packetmonitor'] as const) {
       await permissionModel.grant({
         userId: user.id,
         resource,
@@ -1753,6 +1765,53 @@ describe('MeshCore Routes', () => {
         expect(response.status).toBe(409);
         expect(response.body.success).toBe(false);
       });
+    });
+  });
+
+  describe('GET /api/sources/test-source/meshcore/packets/export', () => {
+    const samplePackets = [
+      { id: 2, sourceId: 'test-source', timestamp: 1700000002000, payloadType: 1, routeType: 0, rawHex: 'beef' },
+      { id: 1, sourceId: 'test-source', timestamp: 1700000001000, payloadType: 2, routeType: 1, rawHex: 'cafe' },
+    ];
+
+    beforeEach(() => {
+      mockPacketService.getMaxCount.mockResolvedValue(1000);
+      mockPacketService.getPackets.mockResolvedValue(samplePackets);
+    });
+
+    it('exports packets as JSONL with attachment headers', async () => {
+      const response = await authenticatedAgent.get('/api/sources/test-source/meshcore/packets/export');
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toContain('application/x-ndjson');
+      expect(response.headers['content-disposition']).toMatch(/attachment; filename="meshcore-packet-monitor-.*\.jsonl"/);
+
+      const lines = response.text.trim().split('\n');
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0])).toMatchObject({ id: 2, payloadType: 1 });
+      expect(JSON.parse(lines[1])).toMatchObject({ id: 1, payloadType: 2 });
+
+      // Exports up to the retention cap, scoped to this source, offset 0.
+      expect(mockPacketService.getPackets).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceId: 'test-source', offset: 0, limit: 1000 }),
+      );
+    });
+
+    it('passes filters through and marks the filename as filtered', async () => {
+      const response = await authenticatedAgent.get(
+        '/api/sources/test-source/meshcore/packets/export?payload_type=1&route_type=0',
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-disposition']).toMatch(/meshcore-packet-monitor-filtered-/);
+      expect(mockPacketService.getPackets).toHaveBeenCalledWith(
+        expect.objectContaining({ payloadType: 1, routeType: 0 }),
+      );
+    });
+
+    it('returns 404 for an unregistered source', async () => {
+      const response = await authenticatedAgent.get('/api/sources/does-not-exist/meshcore/packets/export');
+      expect(response.status).toBe(404);
     });
   });
 });

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -2998,6 +2998,60 @@ router.get(
 );
 
 /**
+ * GET /api/sources/:id/meshcore/packets/export
+ *
+ * Export this source's OTA packet log as JSONL (newest first), honoring the
+ * same payload_type / route_type / since filters as the list endpoint. Streams
+ * one JSON object per line as an attachment download — the MeshCore analogue of
+ * the Meshtastic packet-monitor export (issue #3391).
+ */
+router.get(
+  '/packets/export',
+  optionalAuth(),
+  requirePermission('packetmonitor', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id?: string }).id!;
+      const payloadType = req.query.payload_type !== undefined ? parseInt(req.query.payload_type as string, 10) : undefined;
+      const routeType = req.query.route_type !== undefined ? parseInt(req.query.route_type as string, 10) : undefined;
+      let since = req.query.since !== undefined ? parseInt(req.query.since as string, 10) : undefined;
+      // Accept seconds or milliseconds (mirror the list endpoint).
+      if (since !== undefined && since < 1e12) since = since * 1000;
+
+      // Export every retained packet matching the filters (up to the cap).
+      const maxCount = await meshcorePacketLogService.getMaxCount();
+      const packets = await meshcorePacketLogService.getPackets({
+        sourceId,
+        offset: 0,
+        limit: maxCount,
+        payloadType: Number.isFinite(payloadType as number) ? payloadType : undefined,
+        routeType: Number.isFinite(routeType as number) ? routeType : undefined,
+        since: Number.isFinite(since as number) ? since : undefined,
+      });
+
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').substring(0, 19);
+      const hasActiveFilters = req.query.payload_type !== undefined ||
+                               req.query.route_type !== undefined ||
+                               req.query.since !== undefined;
+      const filterInfo = hasActiveFilters ? '-filtered' : '';
+      const filename = `meshcore-packet-monitor${filterInfo}-${timestamp}.jsonl`;
+
+      res.setHeader('Content-Type', 'application/x-ndjson');
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+
+      for (const packet of packets) {
+        res.write(JSON.stringify(packet) + '\n');
+      }
+      res.end();
+      logger.debug(`[API] Exported ${packets.length} MeshCore packets to ${filename}`);
+    } catch (error) {
+      logger.error('[API] Error exporting MeshCore packets:', error);
+      res.status(500).json({ success: false, error: 'Failed to export packets' });
+    }
+  },
+);
+
+/**
  * DELETE /api/sources/:id/meshcore/packets
  *
  * Clear this source's OTA packet log. Requires packetmonitor:write.


### PR DESCRIPTION
## Summary

Closes #3391 — adds a JSON(L) export to the **MeshCore Packet Monitor**, mirroring the existing Meshtastic packet-monitor export.

## Changes

- **`src/server/routes/meshcoreRoutes.ts`** — new `GET /api/sources/:id/meshcore/packets/export` route. Streams the source's OTA packet log as JSONL (one JSON object per line, newest first), honoring the same `payload_type` / `route_type` / `since` filters as the list endpoint. Uses the same `optionalAuth` + `packetmonitor:read` permission, and returns a timestamped attachment filename (`meshcore-packet-monitor-<ts>.jsonl`, or `…-filtered-<ts>.jsonl` when filters are active).
- **`src/components/MeshCore/MeshCorePacketMonitorView.tsx`** — a Download button in the monitor toolbar (next to Refresh/Clear) with a `handleExport` blob-download handler that carries the currently-active payload/route filters. Reuses the existing `common.export` i18n key.
- **`src/server/routes/meshcoreRoutes.test.ts`** — mocks `meshcorePacketLogService` and adds coverage for: JSONL body + attachment headers, filter pass-through + `-filtered-` filename, and the per-source 404 guard.

## Behavior

Matches the Meshtastic export exactly — same JSONL format, same streaming approach, same filter-aware filename — so the two packet monitors behave identically.

## Testing

- `npx tsc --noEmit` — clean
- `vitest run src/server/routes/meshcoreRoutes.test.ts` — 140/140 pass (incl. 3 new export tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)