### PR TITLE
feat: capture and graph LocalStats noiseFloor telemetry (#3396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Features
+
+- **Noise Floor in LocalStats telemetry (#3396)**: The `noiseFloor` (dBm) field that Meshtastic firmware 2.7.25 added to `LocalStats` is now captured and graphed alongside the other device LocalStats metrics (uptime, channel utilization, packet counts, heap, etc.) — it appears on the Device Info page and anywhere local-stats telemetry is charted, with integer (dBm) formatting. The protobufs submodule was bumped from v2.7.23 to v2.7.25; that bump is otherwise additive (new sensor enums and LoRa regions), with no field removals affecting MeshMonitor.
+
 ## [4.9.4] - 2026-06-09
 
 ### Features

--- a/src/components/InfoTab.tsx
+++ b/src/components/InfoTab.tsx
@@ -145,7 +145,7 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
         'numPacketsTx', 'numPacketsRx', 'numPacketsRxBad',
         'numOnlineNodes', 'numTotalNodes', 'numRxDupe',
         'numTxRelay', 'numTxRelayCanceled', 'heapTotalBytes',
-        'heapFreeBytes', 'numTxDropped',
+        'heapFreeBytes', 'numTxDropped', 'noiseFloor',
         // HostMetrics metrics (for Linux devices)
         'hostUptimeSeconds', 'hostFreememBytes', 'hostDiskfree1Bytes',
         'hostDiskfree2Bytes', 'hostDiskfree3Bytes', 'hostLoad1',

--- a/src/components/TelemetryChart.test.ts
+++ b/src/components/TelemetryChart.test.ts
@@ -13,6 +13,10 @@ describe('getTelemetryLabel', () => {
     expect(getTelemetryLabel('temperature')).toBe('Temperature');
   });
 
+  it('labels the LocalStats noiseFloor type (#3396)', () => {
+    expect(getTelemetryLabel('noiseFloor')).toBe('Noise Floor (Device)');
+  });
+
   it('returns the explicit label for known MeshCore status types', () => {
     expect(getTelemetryLabel('mc_status_uptime_secs')).toBe('Uptime');
     expect(getTelemetryLabel('mc_status_noise_floor')).toBe('Noise Floor');

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -97,6 +97,7 @@ const TELEMETRY_LABELS: Record<string, string> = {
   numTxDropped: 'Dropped TX (Device)',
   heapTotalBytes: 'Heap Total (Device)',
   heapFreeBytes: 'Heap Free (Device)',
+  noiseFloor: 'Noise Floor (Device)',
   // MeshMonitor system metrics (calculated by MeshMonitor)
   systemNodeCount: 'Active Nodes (MeshMonitor)',
   systemDirectNodeCount: 'Direct Nodes (MeshMonitor)',

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -28,6 +28,7 @@ const INTEGER_TELEMETRY_TYPES = new Set([
   'numOnlineNodes', 'numTotalNodes',
   'numPacketsTx', 'numPacketsRx', 'numPacketsRxBad',
   'numRxDupe', 'numTxRelay', 'numTxRelayCanceled', 'numTxDropped',
+  'noiseFloor',
   'systemNodeCount', 'systemDirectNodeCount',
   'paxcounterWifi', 'paxcounterBle',
   'particles03um', 'particles05um', 'particles10um',

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6236,7 +6236,9 @@ class MeshtasticManager implements ISourceManager {
           { type: 'numTxRelayCanceled', value: localStats.numTxRelayCanceled, unit: 'packets' },
           { type: 'heapTotalBytes', value: localStats.heapTotalBytes, unit: 'bytes' },
           { type: 'heapFreeBytes', value: localStats.heapFreeBytes, unit: 'bytes' },
-          { type: 'numTxDropped', value: localStats.numTxDropped, unit: 'packets' }
+          { type: 'numTxDropped', value: localStats.numTxDropped, unit: 'packets' },
+          // Noise floor (dBm) — added to LocalStats in Meshtastic firmware 2.7.25 (#3396)
+          { type: 'noiseFloor', value: localStats.noiseFloor, unit: 'dBm' }
         ], nodeId, fromNum, timestamp, packetTimestamp, packetId);
         await this.checkAutoHeapManagement(localStats.heapFreeBytes, fromNum);
       } else if (telemetry.hostMetrics) {


### PR DESCRIPTION
## Summary
Meshtastic firmware **2.7.25** added `noise_floor` (dBm) to the `LocalStats` telemetry message (issue #3396). MeshMonitor now captures it and graphs it alongside the other device LocalStats metrics — on the Device Info page and anywhere local-stats telemetry is charted.

## On the protobufs submodule
The issue assumed a submodule update would be required. In fact `noise_floor = 15` **already existed in `LocalStats` in our pinned v2.7.23**, and `protobufLoader.ts` loads the `.proto` files directly from the submodule at runtime via protobufjs — so the field already decoded; we just weren't storing/graphing it. Per request, I still **bumped the submodule v2.7.23 → v2.7.25** for parity with the firmware release.

**Blast-radius review of v2.7.23 → v2.7.25** (502+/17−, 7 protos): purely additive for MeshMonitor — new `TelemetrySensorType` enums, new LoRa regions (EU866/EU_NARROW), new ATAK/serial-HAL messages. The only "removals" are benign: `module_config.json_enabled` is just marked `[deprecated]` (field 6 retained, so MQTT-config decoding is unaffected), and `ITU23_2M` keeps enum value `28` (matching MeshMonitor's hardcoded region map). No field MeshMonitor relies on was removed.

## Changes
- **`meshtasticManager.ts`** — store `{ type: 'noiseFloor', value: localStats.noiseFloor, unit: 'dBm' }` in the LocalStats `saveTelemetryMetrics` list. (The existing guard skips `undefined` for older firmware; negative dBm values pass through.)
- **`TelemetryChart.tsx`** — label map → `Noise Floor (Device)`.
- **`TelemetryGraphs.tsx`** — add `noiseFloor` to `INTEGER_TELEMETRY_TYPES` (it's an `int32` dBm).
- **`InfoTab.tsx`** — add `noiseFloor` to the Device Info LocalStats metrics list. (The telemetry graphs discover types dynamically, so they pick it up via the label map automatically.)
- **`protobufs`** submodule → v2.7.25.
- **`TelemetryChart.test.ts`** — label assertion; **CHANGELOG** entry.

## Issues Resolved
Fixes #3396

## Testing
- [x] Full unit suite passes (**6196**) — includes the protobuf encode/decode tests, validating the v2.7.25 bump
- [x] `tsc --noEmit` clean; production build clean
- [x] Direct proto check: `protobufjs` loads `LocalStats.noiseFloor` (field 15, `int32`) and round-trips `-109`
- [ ] Reviewer: on a node running 2.7.25+, confirm a "Noise Floor (Device)" graph appears under Device Info telemetry

> Prepared in an isolated worktree off `main` (with the submodule initialised + bumped there), so local WIP in the main checkout was untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)