### PR TITLE
fix: packet-stats legend count clipping + distribution grand total (#3400, #3401)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1844,6 +1844,7 @@
   "info.secrets_unavailable": "Security keys not available",
 
   "info.packet_distribution": "Packet Distribution",
+  "info.total_packets": "Total: {{count}} packets",
   "info.packets_by_device": "Packets by Device",
   "info.packets_by_type": "Packets by Type",
   "info.last_hour": "Last Hour",

--- a/src/components/InfoTab.tsx
+++ b/src/components/InfoTab.tsx
@@ -727,7 +727,12 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
               {!loadingDistribution && packetDistribution.total > 0 && (
                 <div className="info-section-wide">
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem' }}>
-                    <h3 style={{ margin: 0 }}>{t('info.packet_distribution', 'Packet Distribution')}</h3>
+                    <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.75rem' }}>
+                      <h3 style={{ margin: 0 }}>{t('info.packet_distribution', 'Packet Distribution')}</h3>
+                      <span style={{ fontSize: '0.9em', color: 'var(--ctp-subtext0)', fontWeight: 600 }}>
+                        {t('info.total_packets', { count: packetDistribution.total, defaultValue: 'Total: {{count}} packets' })}
+                      </span>
+                    </div>
                     {timeRangeButtons}
                   </div>
                   <div className="packet-distribution-grid">

--- a/src/components/PacketStatsChart.test.tsx
+++ b/src/components/PacketStatsChart.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PacketStatsChart, { type ChartDataEntry } from './PacketStatsChart';
+
+// Recharts' ResponsiveContainer reports a 0x0 box in jsdom; that's fine — we
+// only assert on the legend markup, which renders regardless of chart size.
+
+const rxData: ChartDataEntry[] = [
+  { name: 'Good', value: 2134, color: '#a6e3a1' },
+  { name: 'Bad', value: 2, color: '#f38ba8' },
+  { name: 'Dupe', value: 50, color: '#fab387' },
+];
+
+describe('PacketStatsChart legend', () => {
+  it('renders the full count for every entry (issue #3401)', () => {
+    render(<PacketStatsChart title="RX" data={rxData} total={2186} chartId="rx" bare />);
+
+    // The raw count must always be fully present — this is the value that was
+    // being clipped mid-string before the fix.
+    expect(screen.getByText(/Good: 97\.6% \(2,134\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Bad: 0\.1% \(2\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Dupe: 2\.3% \(50\)/)).toBeInTheDocument();
+  });
+
+  it('does not apply nowrap/ellipsis clipping in horizontal (non-stacked) mode', () => {
+    render(<PacketStatsChart title="RX" data={rxData} total={2186} chartId="rx" bare />);
+
+    const entry = screen.getByText(/Good: 97\.6% \(2,134\)/);
+    // The legend paragraph must be allowed to wrap so the count is never clipped.
+    expect(entry).not.toHaveStyle({ whiteSpace: 'nowrap' });
+    expect(entry).not.toHaveStyle({ textOverflow: 'ellipsis' });
+  });
+
+  it('keeps nowrap/ellipsis truncation in stacked mode for long node names', () => {
+    const deviceData: ChartDataEntry[] = [
+      { name: 'A-Very-Long-Node-Name-That-Should-Truncate', value: 76, color: '#89b4fa' },
+      { name: 'Other', value: 24, color: '#9399b2' },
+    ];
+    render(
+      <PacketStatsChart title="By Device" data={deviceData} total={100} chartId="dist" bare stacked />,
+    );
+
+    const entry = screen.getByText(/A-Very-Long-Node-Name-That-Should-Truncate: 76\.0% \(76\)/);
+    expect(entry).toHaveStyle({ whiteSpace: 'nowrap' });
+    expect(entry).toHaveStyle({ textOverflow: 'ellipsis' });
+  });
+
+  it('omits zero-value entries from the legend', () => {
+    const data: ChartDataEntry[] = [
+      { name: 'Direct', value: 10, color: '#89b4fa' },
+      { name: 'Relay', value: 0, color: '#a6e3a1' },
+    ];
+    render(<PacketStatsChart title="TX" data={data} total={10} chartId="tx" bare />);
+
+    expect(screen.getByText(/Direct: 100\.0% \(10\)/)).toBeInTheDocument();
+    expect(screen.queryByText(/Relay/)).not.toBeInTheDocument();
+  });
+
+  it('returns null when there is no positive data', () => {
+    const data: ChartDataEntry[] = [{ name: 'Direct', value: 0, color: '#89b4fa' }];
+    const { container } = render(
+      <PacketStatsChart title="TX" data={data} total={0} chartId="tx" bare />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/PacketStatsChart.tsx
+++ b/src/components/PacketStatsChart.tsx
@@ -78,11 +78,21 @@ const PacketStatsChart: React.FC<PacketStatsChartProps> = React.memo(({ title, d
   );
 
   const legend = (
-    <div style={{ fontSize: '0.85em', minWidth: 0, overflow: 'hidden' }}>
+    <div style={{ fontSize: '0.85em', minWidth: 0, overflow: stacked ? 'hidden' : 'visible' }}>
       {filteredData.map((entry, index) => {
         const pct = total > 0 ? ((entry.value / total) * 100).toFixed(1) : '0';
+        // Stacked distribution charts can have long node names, so truncate the
+        // whole line with an ellipsis. Horizontal RX/TX charts use short names and
+        // must never clip the count (issue #3401) — let the name wrap instead.
         return (
-          <p key={`${chartId}-legend-${index}`} style={{ margin: '0.25rem 0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          <p
+            key={`${chartId}-legend-${index}`}
+            style={
+              stacked
+                ? { margin: '0.25rem 0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
+                : { margin: '0.25rem 0' }
+            }
+          >
             <span style={{
               display: 'inline-block',
               width: '10px',


### PR DESCRIPTION
## Summary

Fixes two issues on the Info tab's packet charts.

### #3401 — Radio Statistics legend counts clipped (bug)
The legend lines rendered with `whiteSpace: nowrap` + `textOverflow: ellipsis` inside an `overflow: hidden` container. In the horizontal RX/TX layout the legend column gets squeezed next to the fixed-width donut, so the raw count in parentheses was truncated mid-value (e.g. `Bad: 24.5% (2 ...`).

Fix: apply nowrap/ellipsis truncation **only in stacked mode** (the Packet Distribution charts, whose long node names genuinely need clipping). Horizontal RX/TX legends now wrap instead of clipping, so the full count always renders (e.g. `Good: 21.3% (2,134)`).

### #3400 — Packet Distribution grand total (feature)
Added a prominent **"Total: N packets"** summary in the panel header next to the title, derived from the existing `packetDistribution.total`. Added the `info.total_packets` i18n key (with `{{count}}` interpolation and a `defaultValue` fallback for untranslated locales).

## Files
- `src/components/PacketStatsChart.tsx` — conditional legend truncation
- `src/components/InfoTab.tsx` — grand total in distribution header
- `public/locales/en.json` — `info.total_packets`
- `src/components/PacketStatsChart.test.tsx` — new tests

## Testing
- New `PacketStatsChart.test.tsx`: full count rendering, non-stacked no-clip behavior, stacked truncation retained, zero-value filtering, empty-data null render.
- Full Vitest suite: **6201 passed, 0 failed**.
- `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)