### PR TITLE
feat: Map Analysis node search, marker spiderfy & traceroute direction/weak-link analysis (#3399)

### DIFF
--- a/src/components/MapAnalysis/AnalysisInspectorPanel.test.tsx
+++ b/src/components/MapAnalysis/AnalysisInspectorPanel.test.tsx
@@ -36,6 +36,13 @@ vi.mock('../../hooks/useMapAnalysisData', () => ({
   useHopCounts: () => ({
     data: { entries: [{ sourceId: 'a', nodeNum: 1, hops: 2 }] },
   }),
+  useTraceroutes: () => ({
+    items: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    progress: { loaded: 0, estimatedTotal: 0, percent: 100 },
+  }),
 }));
 vi.mock('../../hooks/useLinkQuality', () => ({
   useLinkQuality: () => ({

--- a/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
+++ b/src/components/MapAnalysis/AnalysisInspectorPanel.tsx
@@ -1,10 +1,15 @@
-import type { ReactNode } from 'react';
+import { useMemo, type ReactNode } from 'react';
 import {
   useDashboardSources,
   useDashboardUnifiedData,
 } from '../../hooks/useDashboardData';
-import { useHopCounts } from '../../hooks/useMapAnalysisData';
+import { useHopCounts, useTraceroutes } from '../../hooks/useMapAnalysisData';
 import { useLinkQuality } from '../../hooks/useLinkQuality';
+import {
+  useTracerouteAnalysis,
+  type TracerouteAnalysisInput,
+} from '../../hooks/useTracerouteAnalysis';
+import { getTracerouteOptions } from '../../hooks/useMapAnalysisConfig';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
 import { resolveNodeLatLng, type MaybePositionedNode } from './nodePositionUtil';
 
@@ -76,6 +81,37 @@ export default function AnalysisInspectorPanel() {
     nodeId: selectedNodeId,
     hours: 24,
     enabled: selected?.type === 'node' && !!selectedNodeId,
+  });
+
+  // Per-node traceroute summary (issue #3399). Shares the React Query cache with
+  // the traceroute layer when the same source/lookback args are in use.
+  const tracerouteOptions = useMemo(
+    () => getTracerouteOptions(config),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [config.layers.traceroutes.options],
+  );
+  const isNodeSelected = selected?.type === 'node' && selected.nodeNum !== undefined;
+  const { items: tracerouteItems } = useTraceroutes({
+    enabled: isNodeSelected && sourceIds.length > 0,
+    sources: sourceIds,
+    lookbackHours: config.layers.traceroutes.lookbackHours ?? 24,
+  });
+  const positionByKey = useMemo(() => {
+    const map = new Map<string, [number, number]>();
+    for (const n of (nodes ?? []) as NodeRecord[]) {
+      const ll = resolveNodeLatLng(n);
+      if (ll) map.set(`${n.sourceId ?? ''}:${Number(n.nodeNum)}`, ll);
+    }
+    return map;
+  }, [nodes]);
+  const { summary: tracerouteSummary } = useTracerouteAnalysis({
+    traceroutes: tracerouteItems as TracerouteAnalysisInput[],
+    positionByKey,
+    selectedNodeNum: isNodeSelected ? selected!.nodeNum! : null,
+    selectedSourceId: isNodeSelected ? selected!.sourceId ?? null : null,
+    options: tracerouteOptions,
+    visibleNodeNums: null,
+    timeWindow: null,
   });
 
   if (!config.inspectorOpen) {
@@ -210,6 +246,24 @@ export default function AnalysisInspectorPanel() {
           <dt>SNR</dt>
           <dd>{formatNumber(node.snr, ' dB', 2)}</dd>
         </dl>
+        {tracerouteSummary && tracerouteSummary.distinctLinks > 0 && (
+          <>
+            <hr />
+            <div className="map-analysis-tr-summary-title">Traceroute Links</div>
+            <dl>
+              <dt>Distinct Links</dt>
+              <dd>{tracerouteSummary.distinctLinks}</dd>
+              <dt>Outbound</dt>
+              <dd>{tracerouteSummary.outboundLinks}</dd>
+              <dt>Inbound</dt>
+              <dd>{tracerouteSummary.inboundLinks}</dd>
+              <dt>Observations</dt>
+              <dd>{tracerouteSummary.totalObservations}</dd>
+              <dt>Avg SNR</dt>
+              <dd>{formatNumber(tracerouteSummary.avgSnr, ' dB', 1)}</dd>
+            </dl>
+          </>
+        )}
       </>,
     );
   }
@@ -300,10 +354,28 @@ export default function AnalysisInspectorPanel() {
       </div>
       <hr />
       <dl>
-        <dt>From</dt>
+        <dt>From (TX)</dt>
         <dd>{fromName}</dd>
-        <dt>To</dt>
+        <dt>To (RX)</dt>
         <dd>{toName}</dd>
+        {selected.direction && selected.direction !== 'neutral' && (
+          <>
+            <dt>Direction</dt>
+            <dd>{selected.direction === 'outbound' ? 'Outbound (TX)' : 'Inbound (RX)'}</dd>
+          </>
+        )}
+        {selected.occurrences !== undefined && (
+          <>
+            <dt>Observations</dt>
+            <dd>{selected.occurrences}</dd>
+          </>
+        )}
+        {selected.avgSnr !== undefined && (
+          <>
+            <dt>Avg SNR</dt>
+            <dd>{selected.avgSnr === null ? '— (unknown)' : `${selected.avgSnr.toFixed(1)} dB`}</dd>
+          </>
+        )}
       </dl>
     </>,
   );

--- a/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
@@ -29,6 +29,8 @@ vi.mock('react-leaflet', () => ({
     <div data-testid="popup">{children}</div>
   ),
   Pane: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  // Spiderfier (NodeMarkersLayer) calls useMap(); null makes the hook a no-op.
+  useMap: () => null,
 }));
 
 vi.mock('../../hooks/useMapAnalysisData', () => ({

--- a/src/components/MapAnalysis/MapAnalysisContext.tsx
+++ b/src/components/MapAnalysis/MapAnalysisContext.tsx
@@ -20,11 +20,18 @@ export interface SelectedTarget {
   pointCount?: number;
   startMs?: number;
   endMs?: number;
+  // route-segment extras (issue #3399)
+  direction?: 'inbound' | 'outbound' | 'neutral';
+  occurrences?: number;
+  avgSnr?: number | null;
 }
 
 type CtxShape = ReturnType<typeof useMapAnalysisConfig> & {
   selected: SelectedTarget | null;
   setSelected: (s: SelectedTarget | null) => void;
+  /** Free-text node search term; empty = no filter (issue #3399). */
+  nodeFilter: string;
+  setNodeFilter: (s: string) => void;
 };
 
 const Ctx = createContext<CtxShape | null>(null);
@@ -32,7 +39,12 @@ const Ctx = createContext<CtxShape | null>(null);
 export function MapAnalysisProvider({ children }: { children: ReactNode }) {
   const config = useMapAnalysisConfig();
   const [selected, setSelected] = useState<SelectedTarget | null>(null);
-  return <Ctx.Provider value={{ ...config, selected, setSelected }}>{children}</Ctx.Provider>;
+  const [nodeFilter, setNodeFilter] = useState('');
+  return (
+    <Ctx.Provider value={{ ...config, selected, setSelected, nodeFilter, setNodeFilter }}>
+      {children}
+    </Ctx.Provider>
+  );
 }
 
 export function useMapAnalysisCtx() {

--- a/src/components/MapAnalysis/MapAnalysisToolbar.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.tsx
@@ -2,6 +2,8 @@ import { useNavigate } from 'react-router-dom';
 import { useDashboardSources } from '../../hooks/useDashboardData';
 import LayerToggleButton from './LayerToggleButton';
 import SourceMultiSelect from './SourceMultiSelect';
+import NodeSearchControl from './NodeSearchControl';
+import TracerouteControls from './TracerouteControls';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
 import { LayerKey } from '../../hooks/useMapAnalysisConfig';
 import {
@@ -100,6 +102,7 @@ export default function MapAnalysisToolbar() {
         value={config.sources}
         onChange={setSources}
       />
+      <NodeSearchControl />
       <button
         type="button"
         className={`map-analysis-layer-btn ${config.timeSlider.enabled ? 'active' : ''}`}
@@ -127,6 +130,7 @@ export default function MapAnalysisToolbar() {
           loading={layerLoading[key] ?? false}
         />
       ))}
+      {config.layers.traceroutes.enabled && <TracerouteControls />}
       {aggregate !== null && (
         <div
           className="map-analysis-progress"

--- a/src/components/MapAnalysis/NodeSearchControl.tsx
+++ b/src/components/MapAnalysis/NodeSearchControl.tsx
@@ -1,0 +1,33 @@
+import { useMapAnalysisCtx } from './MapAnalysisContext';
+
+/**
+ * Toolbar text input that filters map markers to nodes matching the term
+ * (issue #3399). Non-matching nodes are hidden; the term also constrains which
+ * traceroute link endpoints render.
+ */
+export default function NodeSearchControl() {
+  const { nodeFilter, setNodeFilter } = useMapAnalysisCtx();
+
+  return (
+    <div className="map-analysis-node-search">
+      <input
+        type="text"
+        className="map-analysis-node-search-input"
+        placeholder="Search nodes…"
+        aria-label="Search nodes"
+        value={nodeFilter}
+        onChange={(e) => setNodeFilter(e.target.value)}
+      />
+      {nodeFilter && (
+        <button
+          type="button"
+          className="map-analysis-node-search-clear"
+          aria-label="Clear node search"
+          onClick={() => setNodeFilter('')}
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/MapAnalysis/TracerouteControls.tsx
+++ b/src/components/MapAnalysis/TracerouteControls.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { useMapAnalysisCtx } from './MapAnalysisContext';
+import { getTracerouteOptions, type TracerouteLayerOptions } from '../../hooks/useMapAnalysisConfig';
+
+const DIRECTIONS: Array<{ key: TracerouteLayerOptions['directionMode']; label: string }> = [
+  { key: 'both', label: 'Both' },
+  { key: 'outbound', label: 'Out' },
+  { key: 'inbound', label: 'In' },
+];
+
+/**
+ * Traceroute analysis controls (issue #3399): inbound/outbound direction filter,
+ * focus-on-selected toggle, and weak-link filters (min occurrences, min SNR).
+ * Rendered in the toolbar only while the traceroutes layer is enabled.
+ */
+export default function TracerouteControls() {
+  const { config, setLayerOptions } = useMapAnalysisCtx();
+  const opts = getTracerouteOptions(config);
+  const [open, setOpen] = useState(false);
+
+  const update = (patch: Partial<TracerouteLayerOptions>) =>
+    setLayerOptions('traceroutes', patch as Record<string, unknown>);
+
+  return (
+    <div className="map-analysis-tr-controls">
+      <button
+        type="button"
+        className="map-analysis-pill"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+      >
+        Traceroute filters ▾
+      </button>
+      {open && (
+        <div className="map-analysis-tr-popover" role="dialog">
+          <div className="map-analysis-popover-label">Direction (selected node)</div>
+          <div className="map-analysis-tr-seg">
+            {DIRECTIONS.map((d) => (
+              <button
+                key={d.key}
+                type="button"
+                className={opts.directionMode === d.key ? 'selected' : ''}
+                onClick={() => update({ directionMode: d.key })}
+              >
+                {d.label}
+              </button>
+            ))}
+          </div>
+
+          <label className="map-analysis-tr-check">
+            <input
+              type="checkbox"
+              checked={opts.scopeToSelectedNode}
+              onChange={(e) => update({ scopeToSelectedNode: e.target.checked })}
+            />
+            Focus on selected node
+          </label>
+
+          <div className="map-analysis-popover-label">Min occurrences</div>
+          <input
+            type="number"
+            min={1}
+            className="map-analysis-tr-num"
+            value={opts.minOccurrences}
+            aria-label="Minimum occurrences"
+            onChange={(e) => {
+              const v = Math.max(1, Math.floor(Number(e.target.value) || 1));
+              update({ minOccurrences: v });
+            }}
+          />
+
+          <div className="map-analysis-popover-label">Min SNR (dB)</div>
+          <input
+            type="number"
+            step={1}
+            className="map-analysis-tr-num"
+            placeholder="off"
+            value={opts.minSnr ?? ''}
+            aria-label="Minimum SNR in dB"
+            onChange={(e) => {
+              const raw = e.target.value;
+              update({ minSnr: raw === '' ? null : Number(raw) });
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
+++ b/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
@@ -1,5 +1,6 @@
 import { Marker, Popup } from 'react-leaflet';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
+import type { Marker as LeafletMarker } from 'leaflet';
 import {
   useDashboardSources,
   useDashboardUnifiedData,
@@ -7,12 +8,15 @@ import {
 import { useHopCounts } from '../../../hooks/useMapAnalysisData';
 import { useSettings } from '../../../contexts/SettingsContext';
 import { useMapAnalysisCtx } from '../MapAnalysisContext';
+import { useMarkerSpiderfier } from '../../../hooks/useMarkerSpiderfier';
 import { resolveNodeLatLng, type MaybePositionedNode } from '../nodePositionUtil';
+import { nodeMatchesSearch } from '../nodeSearch';
 import { createNodeIcon } from '../../../utils/mapIcons';
 
 interface NodeRecord extends MaybePositionedNode {
   nodeNum: number;
   sourceId?: string;
+  nodeId?: string | null;
   longName?: string | null;
   shortName?: string | null;
   user?: { role?: string | number | null } | null;
@@ -36,8 +40,34 @@ interface HopEntry {
  * inspector panel can react.
  */
 export default function NodeMarkersLayer() {
-  const { config, selected, setSelected } = useMapAnalysisCtx();
+  const { config, selected, setSelected, nodeFilter } = useMapAnalysisCtx();
   const { mapPinStyle } = useSettings();
+
+  // Spiderfier fans out markers that share (rounded) coordinates so each node in
+  // a cluster is individually selectable (issue #3399). Same bridge pattern as
+  // NodesTab: stable per-key ref handlers feed the imperative Leaflet markers in.
+  const { addMarker, removeMarker } = useMarkerSpiderfier({ keepSpiderfied: true });
+  const markerByKey = useRef<Map<string, LeafletMarker>>(new Map());
+  const refHandlers = useRef<Map<string, (m: LeafletMarker | null) => void>>(new Map());
+  const getMarkerRef = (key: string) => {
+    let h = refHandlers.current.get(key);
+    if (!h) {
+      h = (m: LeafletMarker | null) => {
+        const prev = markerByKey.current.get(key);
+        if (m) {
+          markerByKey.current.set(key, m);
+          addMarker(m, key);
+        } else {
+          if (prev) removeMarker(prev);
+          markerByKey.current.delete(key);
+          refHandlers.current.delete(key);
+        }
+      };
+      refHandlers.current.set(key, h);
+    }
+    return h;
+  };
+
   const { data: sources = [] } = useDashboardSources();
   const sourceList = sources as Array<{ id: string; name: string }>;
   const sourceIds = sourceList.map((s) => s.id);
@@ -65,6 +95,8 @@ export default function NodeMarkersLayer() {
     .map((n) => ({ node: n, latLng: resolveNodeLatLng(n) }))
     .filter(({ node, latLng }) => {
       if (!latLng) return false;
+      // Node search (issue #3399): hide non-matches.
+      if (!nodeMatchesSearch(node, nodeFilter)) return false;
       if (config.sources.length === 0) return true;
       if (!node.sourceId) return false;
       return config.sources.includes(node.sourceId);
@@ -97,9 +129,11 @@ export default function NodeMarkersLayer() {
           showLabel: true,
           pinStyle: mapPinStyle,
         });
+        const markerKey = `${sourceId}:${n.nodeNum}`;
         return (
           <Marker
-            key={`${sourceId}:${n.nodeNum}`}
+            key={markerKey}
+            ref={getMarkerRef(markerKey)}
             position={[lat, lon]}
             icon={icon}
             eventHandlers={{

--- a/src/components/MapAnalysis/layers/TraceroutePathsLayer.test.tsx
+++ b/src/components/MapAnalysis/layers/TraceroutePathsLayer.test.tsx
@@ -16,8 +16,8 @@ vi.mock('../../../hooks/useMapAnalysisData', () => ({
     items: [
       {
         id: 1,
-        fromNodeNum: 1,
-        toNodeNum: 2,
+        fromNodeNum: 0x1111,
+        toNodeNum: 0x2222,
         sourceId: 'a',
         route: '[]',
         routeBack: '[]',
@@ -37,8 +37,8 @@ vi.mock('../../../hooks/useDashboardData', () => ({
   useDashboardSources: () => ({ data: [{ id: 'a', name: 'A' }] }),
   useDashboardUnifiedData: () => ({
     nodes: [
-      { nodeNum: 1, sourceId: 'a', position: { latitude: 30, longitude: -90 } },
-      { nodeNum: 2, sourceId: 'a', position: { latitude: 31, longitude: -91 } },
+      { nodeNum: 0x1111, sourceId: 'a', position: { latitude: 30, longitude: -90 } },
+      { nodeNum: 0x2222, sourceId: 'a', position: { latitude: 31, longitude: -91 } },
     ],
   }),
   UNIFIED_SOURCE_ID: '__unified__',

--- a/src/components/MapAnalysis/layers/TraceroutePathsLayer.tsx
+++ b/src/components/MapAnalysis/layers/TraceroutePathsLayer.tsx
@@ -6,40 +6,65 @@ import {
 } from '../../../hooks/useDashboardData';
 import { useTraceroutes } from '../../../hooks/useMapAnalysisData';
 import { useMapAnalysisCtx } from '../MapAnalysisContext';
+import { getTracerouteOptions } from '../../../hooks/useMapAnalysisConfig';
+import {
+  useTracerouteAnalysis,
+  type AnalyzedSegment,
+  type TracerouteAnalysisInput,
+} from '../../../hooks/useTracerouteAnalysis';
 import { resolveNodeLatLng, type MaybePositionedNode } from '../nodePositionUtil';
+import { visibleNodeNumSet, type SearchableNode } from '../nodeSearch';
+import {
+  generateCurvedPath,
+  generateCurvedArrowMarkers,
+  getSegmentSnrOpacity,
+  UNKNOWN_SNR_SENTINEL,
+} from '../../../utils/mapHelpers';
 
-function snrToColor(snr: number): string {
-  if (snr >= 5) return '#22c55e';
-  if (snr >= 0) return '#eab308';
-  if (snr >= -5) return '#f97316';
+// Direction colours (issue #3399): outbound = the selected node transmitting,
+// inbound = the selected node receiving.
+const OUTBOUND_COLOR = '#3b82f6'; // blue
+const INBOUND_COLOR = '#f43f5e'; // rose
+
+/** SNR → quality colour for the global (no node selected) view. */
+function snrQualityColor(avgSnr: number | null): string {
+  if (avgSnr === null) return '#94a3b8'; // slate — unknown SNR
+  if (avgSnr >= 5) return '#22c55e';
+  if (avgSnr >= 0) return '#eab308';
+  if (avgSnr >= -5) return '#f97316';
   return '#ef4444';
 }
 
-interface TracerouteRecord {
-  id: number | string;
-  fromNodeNum: number;
-  toNodeNum: number;
-  sourceId: string;
-  route?: string | null;
-  routeBack?: string | null;
-  snrTowards?: string | null;
-  snrBack?: string | null;
-  timestamp?: number;
+function segmentColor(s: AnalyzedSegment): string {
+  if (s.direction === 'outbound') return OUTBOUND_COLOR;
+  if (s.direction === 'inbound') return INBOUND_COLOR;
+  return snrQualityColor(s.avgSnr);
 }
 
 interface NodeRecord extends MaybePositionedNode {
   nodeNum: number;
   sourceId?: string;
+  longName?: string | null;
+  shortName?: string | null;
+  nodeId?: string | null;
 }
 
 /**
- * Renders one Polyline per hop in each traceroute. Each segment is colored by
- * the per-hop SNR toward the destination. Clicking a segment writes the
- * selection into MapAnalysisContext for the inspector panel.
+ * Renders deduplicated traceroute links via {@link useTracerouteAnalysis}. When
+ * a node is selected, links are scoped to that node and coloured by direction
+ * (outbound vs inbound) with arrows; otherwise links are coloured by SNR. Weak
+ * links are removed per the persisted min-occurrences / min-SNR options.
  */
 export default function TraceroutePathsLayer() {
-  const { config, setSelected } = useMapAnalysisCtx();
+  const { config, selected, nodeFilter, setSelected } = useMapAnalysisCtx();
   const layer = config.layers.traceroutes;
+  const options = useMemo(
+    () => getTracerouteOptions(config),
+    // Only the traceroute options object affects the result; re-deriving on every
+    // unrelated config change would needlessly recompute the analysis.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [config.layers.traceroutes.options],
+  );
   const { data: sources = [] } = useDashboardSources();
   const sourceIds =
     config.sources.length === 0
@@ -61,73 +86,85 @@ export default function TraceroutePathsLayer() {
     return map;
   }, [nodes]);
 
-  const ts = config.timeSlider;
-  const inWindow = (t: number): boolean =>
-    !ts.enabled ||
-    ts.windowStartMs === undefined ||
-    ts.windowEndMs === undefined ||
-    (t >= ts.windowStartMs && t <= ts.windowEndMs);
+  const visibleNodeNums = useMemo(
+    () => visibleNodeNumSet((nodes ?? []) as SearchableNode[], nodeFilter),
+    [nodes, nodeFilter],
+  );
 
-  const segments = useMemo(() => {
-    const out: Array<{
-      key: string;
-      positions: [number, number][];
-      color: string;
-      from: number;
-      to: number;
-    }> = [];
-    const filtered = (items as TracerouteRecord[]).filter((tr) =>
-      inWindow(tr.timestamp ?? 0),
-    );
-    for (const tr of filtered) {
-      let route: number[] = [];
-      try {
-        route = JSON.parse(tr.route ?? '[]');
-      } catch {
-        /* ignore */
-      }
-      let snrTowards: number[] = [];
-      try {
-        snrTowards = JSON.parse(tr.snrTowards ?? '[]');
-      } catch {
-        /* ignore */
-      }
-      const path = [Number(tr.fromNodeNum), ...route, Number(tr.toNodeNum)];
-      for (let i = 0; i < path.length - 1; i++) {
-        const a = positionByKey.get(`${tr.sourceId}:${path[i]}`);
-        const b = positionByKey.get(`${tr.sourceId}:${path[i + 1]}`);
-        if (!a || !b) continue;
-        const snr = snrTowards[i] ?? 0;
-        out.push({
-          key: `${tr.id}:${i}`,
-          positions: [a, b],
-          color: snrToColor(snr),
-          from: path[i],
-          to: path[i + 1],
-        });
-      }
-    }
-    return out;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [items, positionByKey, ts.enabled, ts.windowStartMs, ts.windowEndMs]);
+  const ts = config.timeSlider;
+  const timeWindow = useMemo(
+    () =>
+      ts.enabled && ts.windowStartMs !== undefined && ts.windowEndMs !== undefined
+        ? { startMs: ts.windowStartMs, endMs: ts.windowEndMs }
+        : null,
+    [ts.enabled, ts.windowStartMs, ts.windowEndMs],
+  );
+
+  const selectedNodeNum =
+    selected?.type === 'node' && selected.nodeNum !== undefined ? selected.nodeNum : null;
+  const selectedSourceId =
+    selected?.type === 'node' ? selected.sourceId ?? null : null;
+
+  const { segments } = useTracerouteAnalysis({
+    traceroutes: items as TracerouteAnalysisInput[],
+    positionByKey,
+    selectedNodeNum,
+    selectedSourceId,
+    options,
+    visibleNodeNums,
+    timeWindow,
+  });
+
+  // Arrows are only drawn in the directional (node-selected) view to keep the
+  // global view light.
+  const showArrows = selectedNodeNum !== null;
 
   return (
     <>
-      {segments.map((s) => (
-        <Polyline
-          key={s.key}
-          positions={s.positions}
-          pathOptions={{ color: s.color, weight: 2 }}
-          eventHandlers={{
-            click: () =>
-              setSelected({
-                type: 'segment',
-                fromNodeNum: s.from,
-                toNodeNum: s.to,
-              }),
-          }}
-        />
-      ))}
+      {segments.map((s) => {
+        const color = segmentColor(s);
+        const curvature = s.direction === 'neutral' ? 0.12 : 0.2;
+        const path = generateCurvedPath(s.fromPos, s.toPos, curvature, 20, true);
+        const weight = 2 + Math.min(s.occurrences - 1, 5) * 0.8;
+        const opacity = getSegmentSnrOpacity(
+          s.avgSnr === null ? undefined : [{ snr: s.avgSnr }],
+          s.isMqtt,
+        );
+        return (
+          <Polyline
+            key={s.key}
+            positions={path}
+            pathOptions={{
+              color,
+              weight,
+              opacity,
+              dashArray: s.isMqtt ? '4,6' : undefined,
+            }}
+            eventHandlers={{
+              click: () =>
+                setSelected({
+                  type: 'segment',
+                  fromNodeNum: s.from,
+                  toNodeNum: s.to,
+                  direction: s.direction,
+                  occurrences: s.occurrences,
+                  avgSnr: s.avgSnr,
+                }),
+            }}
+          />
+        );
+      })}
+      {showArrows &&
+        segments.flatMap((s) =>
+          generateCurvedArrowMarkers(
+            [s.fromPos, s.toPos],
+            s.key,
+            segmentColor(s),
+            [s.avgSnr === null ? UNKNOWN_SNR_SENTINEL : s.avgSnr],
+            s.direction === 'neutral' ? 0.12 : 0.2,
+            true,
+          ),
+        )}
     </>
   );
 }

--- a/src/components/MapAnalysis/nodeSearch.test.ts
+++ b/src/components/MapAnalysis/nodeSearch.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { nodeMatchesSearch, visibleNodeNumSet } from './nodeSearch';
+
+const nodes = [
+  { nodeNum: 0x1a2b3c4d, longName: 'Mountain Repeater', shortName: 'MTN', nodeId: '!1a2b3c4d' },
+  { nodeNum: 0x09a1, longName: 'Punk Not Dead', shortName: 'PUNK', nodeId: '!000009a1' },
+  { nodeNum: 42, longName: null, shortName: null, nodeId: null },
+];
+
+describe('nodeMatchesSearch', () => {
+  it('matches everything when the term is empty or whitespace', () => {
+    expect(nodeMatchesSearch(nodes[0], '')).toBe(true);
+    expect(nodeMatchesSearch(nodes[0], '   ')).toBe(true);
+  });
+
+  it('matches case-insensitively on long name', () => {
+    expect(nodeMatchesSearch(nodes[0], 'mountain')).toBe(true);
+    expect(nodeMatchesSearch(nodes[0], 'PUNK')).toBe(false);
+  });
+
+  it('matches on short name and node id', () => {
+    expect(nodeMatchesSearch(nodes[1], 'punk')).toBe(true);
+    expect(nodeMatchesSearch(nodes[1], '000009a1')).toBe(true);
+  });
+
+  it('matches on hex and decimal node number even with no names', () => {
+    expect(nodeMatchesSearch(nodes[2], '42')).toBe(true);
+    expect(nodeMatchesSearch(nodes[2], '!2a')).toBe(true);
+  });
+
+  it('returns false on no match', () => {
+    expect(nodeMatchesSearch(nodes[0], 'zzz')).toBe(false);
+  });
+});
+
+describe('visibleNodeNumSet', () => {
+  it('returns null for an empty term', () => {
+    expect(visibleNodeNumSet(nodes, '')).toBeNull();
+  });
+
+  it('returns only matching node numbers', () => {
+    const set = visibleNodeNumSet(nodes, 'punk');
+    expect(set).not.toBeNull();
+    expect(set!.has(0x09a1)).toBe(true);
+    expect(set!.has(0x1a2b3c4d)).toBe(false);
+    expect(set!.size).toBe(1);
+  });
+});

--- a/src/components/MapAnalysis/nodeSearch.ts
+++ b/src/components/MapAnalysis/nodeSearch.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared node-search matching for the Map Analysis view (issue #3399).
+ * Mirrors the filter idiom used by GeofenceNodeSelector: case-insensitive
+ * substring match against long name, short name and the node id (decimal + hex).
+ */
+
+export interface SearchableNode {
+  nodeNum: number;
+  longName?: string | null;
+  shortName?: string | null;
+  nodeId?: string | null;
+}
+
+/** True when `term` is empty (no filter) or matches the node's names/ids. */
+export function nodeMatchesSearch(node: SearchableNode, term: string): boolean {
+  const t = term.trim().toLowerCase();
+  if (!t) return true;
+  const num = Number(node.nodeNum);
+  const hex = `!${(num >>> 0).toString(16)}`;
+  const candidates = [
+    node.longName ?? '',
+    node.shortName ?? '',
+    node.nodeId ?? '',
+    hex,
+    String(num),
+  ];
+  return candidates.some((c) => c.toLowerCase().includes(t));
+}
+
+/**
+ * Build the set of node numbers visible under a search term. Returns null when
+ * the term is empty so callers can treat "no filter" as "show everything"
+ * without allocating a set.
+ */
+export function visibleNodeNumSet(
+  nodes: SearchableNode[],
+  term: string,
+): Set<number> | null {
+  if (!term.trim()) return null;
+  const set = new Set<number>();
+  for (const n of nodes) {
+    if (nodeMatchesSearch(n, term)) set.add(Number(n.nodeNum));
+  }
+  return set;
+}

--- a/src/hooks/useMapAnalysisConfig.ts
+++ b/src/hooks/useMapAnalysisConfig.ts
@@ -16,6 +16,25 @@ export interface LayerConfig {
   options?: Record<string, unknown>;
 }
 
+/** Persisted options for the traceroutes layer (issue #3399). */
+export interface TracerouteLayerOptions {
+  /** When a node is selected, which directions to render. */
+  directionMode: 'both' | 'inbound' | 'outbound';
+  /** When a node is selected, restrict traceroutes to ones involving it. */
+  scopeToSelectedNode: boolean;
+  /** Hide links observed fewer than this many times (weak-link filter). */
+  minOccurrences: number;
+  /** Hide links whose mean SNR (dB) is below this; null = off. */
+  minSnr: number | null;
+}
+
+export const DEFAULT_TRACEROUTE_OPTIONS: TracerouteLayerOptions = {
+  directionMode: 'both',
+  scopeToSelectedNode: true,
+  minOccurrences: 1,
+  minSnr: null,
+};
+
 export interface MapAnalysisConfig {
   version: 1;
   layers: Record<LayerKey, LayerConfig>;
@@ -32,7 +51,7 @@ export const DEFAULT_CONFIG: MapAnalysisConfig = {
   version: 1,
   layers: {
     markers:    { enabled: true,  lookbackHours: null },
-    traceroutes:{ enabled: false, lookbackHours: 24 },
+    traceroutes:{ enabled: false, lookbackHours: 24, options: { ...DEFAULT_TRACEROUTE_OPTIONS } },
     neighbors:  { enabled: false, lookbackHours: 24 },
     heatmap:    { enabled: false, lookbackHours: 24 },
     trails:     { enabled: false, lookbackHours: 24 },
@@ -44,6 +63,14 @@ export const DEFAULT_CONFIG: MapAnalysisConfig = {
   timeSlider: { enabled: false },
   inspectorOpen: true,
 };
+
+/** Read the traceroute options off a config, layering stored values over defaults. */
+export function getTracerouteOptions(config: MapAnalysisConfig): TracerouteLayerOptions {
+  return {
+    ...DEFAULT_TRACEROUTE_OPTIONS,
+    ...(config.layers.traceroutes.options as Partial<TracerouteLayerOptions> | undefined),
+  };
+}
 
 const STORAGE_KEY = 'mapAnalysis.config.v1';
 

--- a/src/hooks/useTracerouteAnalysis.test.ts
+++ b/src/hooks/useTracerouteAnalysis.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest';
+import {
+  analyzeTraceroutes,
+  type TracerouteAnalysisInput,
+  type AnalyzeParams,
+  type TracerouteAnalysisOptions,
+} from './useTracerouteAnalysis';
+
+// Node numbers used across the fixtures.
+const REQ = 100; // requester (local) -> stored as toNodeNum
+const RESP = 200; // responder (remote) -> stored as fromNodeNum
+const MID = 150; // an intermediate hop
+
+// Positions for everyone so segments are renderable.
+function positions(...nums: number[]): Map<string, [number, number]> {
+  const m = new Map<string, [number, number]>();
+  nums.forEach((n, i) => m.set(`s1:${n}`, [10 + i, 20 + i]));
+  return m;
+}
+
+const defaultOptions: TracerouteAnalysisOptions = {
+  directionMode: 'both',
+  scopeToSelectedNode: true,
+  minOccurrences: 1,
+  minSnr: null,
+};
+
+function makeParams(overrides: Partial<AnalyzeParams>): AnalyzeParams {
+  return {
+    traceroutes: [],
+    positionByKey: positions(REQ, RESP, MID),
+    selectedNodeNum: null,
+    selectedSourceId: null,
+    options: defaultOptions,
+    visibleNodeNums: null,
+    timeWindow: null,
+    ...overrides,
+  };
+}
+
+// Direct one-hop traceroute: requester <-> responder, SNR raw (dB x 4).
+function directTrace(
+  id: number,
+  snrTowardsRaw: number[],
+  snrBackRaw: number[],
+  timestamp = 1_000,
+): TracerouteAnalysisInput {
+  return {
+    id,
+    fromNodeNum: RESP,
+    toNodeNum: REQ,
+    sourceId: 's1',
+    route: '[]',
+    routeBack: '[]',
+    snrTowards: JSON.stringify(snrTowardsRaw),
+    snrBack: JSON.stringify(snrBackRaw),
+    timestamp,
+  };
+}
+
+describe('analyzeTraceroutes', () => {
+  it('decomposes a direct traceroute into outbound + inbound hops for the requester', () => {
+    // Forward leg requester->responder: snrTowards[0] measured AT responder (so requester is TX => outbound).
+    // Back leg responder->requester: snrBack[0] measured AT requester (so requester is RX => inbound).
+    const { segments, summary } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [directTrace(1, [20], [12])], // 5 dB towards, 3 dB back
+        selectedNodeNum: REQ,
+        selectedSourceId: 's1',
+      }),
+    );
+
+    const outbound = segments.find((s) => s.direction === 'outbound');
+    const inbound = segments.find((s) => s.direction === 'inbound');
+
+    expect(outbound).toBeDefined();
+    expect(inbound).toBeDefined();
+    // Outbound: requester -> responder, neighbour is the responder.
+    expect(outbound!.from).toBe(REQ);
+    expect(outbound!.to).toBe(RESP);
+    expect(outbound!.neighborNum).toBe(RESP);
+    expect(outbound!.avgSnr).toBe(5);
+    // Inbound: responder -> requester, neighbour is the responder.
+    expect(inbound!.from).toBe(RESP);
+    expect(inbound!.to).toBe(REQ);
+    expect(inbound!.neighborNum).toBe(RESP);
+    expect(inbound!.avgSnr).toBe(3);
+
+    expect(summary).not.toBeNull();
+    expect(summary!.distinctLinks).toBe(1); // one neighbour (the responder)
+    expect(summary!.outboundLinks).toBe(1);
+    expect(summary!.inboundLinks).toBe(1);
+    expect(summary!.totalObservations).toBe(2);
+    expect(summary!.avgSnr).toBe(4); // mean of 5 and 3
+  });
+
+  it('classifies an intermediate selected node from both legs', () => {
+    // route=[MID]: forward path req -> MID -> resp. snrTowards[0]@MID, snrTowards[1]@resp.
+    const tr: TracerouteAnalysisInput = {
+      id: 2,
+      fromNodeNum: RESP,
+      toNodeNum: REQ,
+      sourceId: 's1',
+      route: JSON.stringify([MID]),
+      routeBack: '[]',
+      snrTowards: JSON.stringify([16, 8]), // 4 dB @MID, 2 dB @resp
+      snrBack: JSON.stringify([]),
+      timestamp: 1_000,
+    };
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [tr],
+        selectedNodeNum: MID,
+        selectedSourceId: 's1',
+      }),
+    );
+    // Incident to MID: req->MID (inbound, RX@MID, 4dB) and MID->resp (outbound, TX from MID).
+    const inbound = segments.find((s) => s.direction === 'inbound');
+    const outbound = segments.find((s) => s.direction === 'outbound');
+    expect(inbound!.from).toBe(REQ);
+    expect(inbound!.to).toBe(MID);
+    expect(inbound!.avgSnr).toBe(4);
+    expect(outbound!.from).toBe(MID);
+    expect(outbound!.to).toBe(RESP);
+    expect(outbound!.avgSnr).toBe(2); // snrTowards[1] belongs to the receiver (resp)
+    // No segment should be incident to a non-MID-touching pair.
+    expect(segments.every((s) => s.from === MID || s.to === MID)).toBe(true);
+  });
+
+  it('filters by direction mode', () => {
+    const params = makeParams({
+      traceroutes: [directTrace(1, [20], [12])],
+      selectedNodeNum: REQ,
+      selectedSourceId: 's1',
+    });
+    const outboundOnly = analyzeTraceroutes({
+      ...params,
+      options: { ...defaultOptions, directionMode: 'outbound' },
+    });
+    expect(outboundOnly.segments).toHaveLength(1);
+    expect(outboundOnly.segments[0].direction).toBe('outbound');
+
+    const inboundOnly = analyzeTraceroutes({
+      ...params,
+      options: { ...defaultOptions, directionMode: 'inbound' },
+    });
+    expect(inboundOnly.segments).toHaveLength(1);
+    expect(inboundOnly.segments[0].direction).toBe('inbound');
+  });
+
+  it('drops links seen fewer than minOccurrences times', () => {
+    // Two traceroutes both exercise the same outbound hop requester->responder.
+    const params = makeParams({
+      traceroutes: [directTrace(1, [20], [12]), directTrace(2, [24], [16])],
+      selectedNodeNum: REQ,
+      selectedSourceId: 's1',
+      options: { ...defaultOptions, minOccurrences: 2 },
+    });
+    const { segments } = analyzeTraceroutes(params);
+    // Both outbound (req->resp) and inbound (resp->req) occur twice => survive.
+    expect(segments).toHaveLength(2);
+    expect(segments.every((s) => s.occurrences === 2)).toBe(true);
+
+    // Raise threshold beyond observed -> nothing survives.
+    const none = analyzeTraceroutes({
+      ...params,
+      options: { ...defaultOptions, minOccurrences: 3 },
+    });
+    expect(none.segments).toHaveLength(0);
+  });
+
+  it('drops links below the SNR threshold', () => {
+    // Outbound 5 dB, inbound 3 dB. minSnr=4 keeps only outbound.
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [directTrace(1, [20], [12])],
+        selectedNodeNum: REQ,
+        selectedSourceId: 's1',
+        options: { ...defaultOptions, minSnr: 4 },
+      }),
+    );
+    expect(segments).toHaveLength(1);
+    expect(segments[0].direction).toBe('outbound');
+    expect(segments[0].avgSnr).toBe(5);
+  });
+
+  it('treats the firmware unknown-SNR sentinel (-128 raw) as MQTT/unknown', () => {
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [directTrace(1, [-128], [-128])],
+        selectedNodeNum: REQ,
+        selectedSourceId: 's1',
+      }),
+    );
+    expect(segments.length).toBeGreaterThan(0);
+    for (const s of segments) {
+      expect(s.avgSnr).toBeNull();
+      expect(s.isMqtt).toBe(true);
+    }
+    // minSnr filtering removes unknown-SNR links.
+    const filtered = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [directTrace(1, [-128], [-128])],
+        selectedNodeNum: REQ,
+        selectedSourceId: 's1',
+        options: { ...defaultOptions, minSnr: -20 },
+      }),
+    );
+    expect(filtered.segments).toHaveLength(0);
+  });
+
+  it('hides segments whose endpoints are not in the visible set', () => {
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [directTrace(1, [20], [12])],
+        selectedNodeNum: REQ,
+        selectedSourceId: 's1',
+        visibleNodeNums: new Set([REQ]), // responder hidden
+      }),
+    );
+    expect(segments).toHaveLength(0);
+  });
+
+  it('respects the time window', () => {
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [directTrace(1, [20], [12], 5_000)],
+        selectedNodeNum: REQ,
+        selectedSourceId: 's1',
+        timeWindow: { startMs: 0, endMs: 1_000 },
+      }),
+    );
+    expect(segments).toHaveLength(0);
+  });
+
+  it('ignores the selection (global view) when focus is off', () => {
+    const { segments, summary } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [directTrace(1, [20], [12])],
+        selectedNodeNum: REQ,
+        selectedSourceId: 's1',
+        options: { ...defaultOptions, scopeToSelectedNode: false },
+      }),
+    );
+    expect(summary).toBeNull();
+    expect(segments.length).toBeGreaterThan(0);
+    expect(segments.every((s) => s.direction === 'neutral')).toBe(true);
+  });
+
+  it('returns neutral segments and no summary when nothing is selected', () => {
+    const { segments, summary } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [directTrace(1, [20], [12])],
+        selectedNodeNum: null,
+      }),
+    );
+    expect(summary).toBeNull();
+    expect(segments.length).toBeGreaterThan(0);
+    expect(segments.every((s) => s.direction === 'neutral')).toBe(true);
+  });
+
+  it('skips segments with missing positions', () => {
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [directTrace(1, [20], [12])],
+        selectedNodeNum: REQ,
+        selectedSourceId: 's1',
+        positionByKey: positions(REQ), // responder has no position
+      }),
+    );
+    expect(segments).toHaveLength(0);
+  });
+});

--- a/src/hooks/useTracerouteAnalysis.ts
+++ b/src/hooks/useTracerouteAnalysis.ts
@@ -1,0 +1,373 @@
+import { useMemo } from 'react';
+
+/**
+ * Scaled SNR sentinel for unknown hops (raw firmware INT8_MIN -128 / 4 = -32).
+ * Mirrors `UNKNOWN_SNR_SENTINEL` in utils/mapHelpers.tsx — duplicated here so
+ * the analysis core stays free of the Leaflet import (keeps it node-testable).
+ */
+const UNKNOWN_SNR_SENTINEL = -32;
+const isUnknownSnr = (snr: number | undefined): boolean => snr === UNKNOWN_SNR_SENTINEL;
+
+/**
+ * Traceroute analysis for the Map Analysis view (issue #3399).
+ *
+ * Turns raw traceroute rows into deduplicated, directed link segments with
+ * occurrence counts and SNR statistics, then classifies each segment as
+ * inbound (received at the selected node) or outbound (transmitted from the
+ * selected node) so the operator can evaluate RX sensitivity vs TX power.
+ *
+ * SNR semantics (authoritative, from meshtasticManager storage):
+ *   - fromNodeNum = responder (remote), toNodeNum = requester (local).
+ *   - `route`/`snrTowards` describe the request leg. The physical node order is
+ *     [requester, ...route, responder] and snrTowards[i] is the SNR measured at
+ *     the *receiver* of hop i (fullPath[i+1]).
+ *   - `routeBack`/`snrBack` describe the response leg, node order
+ *     [responder, ...routeBack, requester], snrBack[i] measured at fullPath[i+1].
+ *   - SNR values are raw firmware ints (actual dB x 4). The unknown-hop sentinel
+ *     is raw -128 => -32 after /4 (see UNKNOWN_SNR_SENTINEL / isUnknownSnr).
+ *
+ * Because every hop's SNR belongs to its receiver, for a selected node N a
+ * directed segment A->B means: B==N => inbound to N (N's RX), A==N => outbound
+ * from N (the neighbour's reception of N's TX).
+ */
+
+export type SegmentDirection = 'inbound' | 'outbound' | 'neutral';
+
+export interface TracerouteAnalysisInput {
+  id: number | string;
+  fromNodeNum: number;
+  toNodeNum: number;
+  sourceId: string;
+  route?: string | null;
+  routeBack?: string | null;
+  snrTowards?: string | null;
+  snrBack?: string | null;
+  timestamp?: number;
+}
+
+export interface TracerouteAnalysisOptions {
+  directionMode: 'both' | 'inbound' | 'outbound';
+  scopeToSelectedNode: boolean;
+  minOccurrences: number;
+  minSnr: number | null;
+}
+
+export interface AnalyzeParams {
+  traceroutes: TracerouteAnalysisInput[];
+  /** `${sourceId}:${nodeNum}` -> [lat, lng] */
+  positionByKey: Map<string, [number, number]>;
+  selectedNodeNum: number | null;
+  selectedSourceId: string | null;
+  options: TracerouteAnalysisOptions;
+  /** When set (search active), segments touching a node outside this set are dropped. */
+  visibleNodeNums?: Set<number> | null;
+  timeWindow?: { startMs?: number; endMs?: number } | null;
+}
+
+export interface AnalyzedSegment {
+  key: string;
+  sourceId: string;
+  /** transmitter nodeNum */
+  from: number;
+  /** receiver nodeNum */
+  to: number;
+  fromPos: [number, number];
+  toPos: [number, number];
+  direction: SegmentDirection;
+  /** the endpoint that is not the selected node (== `from` for neutral) */
+  neighborNum: number;
+  /** mean RF SNR in dB across observations, null if every sample was unknown */
+  avgSnr: number | null;
+  /** number of traceroutes that contained this directed hop */
+  occurrences: number;
+  /** true if any observation reported an unknown-SNR (sentinel) sample */
+  isMqtt: boolean;
+}
+
+export interface TracerouteSummary {
+  /** distinct neighbours (unordered) linked to the selected node */
+  distinctLinks: number;
+  /** total directed-hop observations incident to the selected node */
+  totalObservations: number;
+  /** mean SNR (dB) across surviving segments, null if none have RF SNR */
+  avgSnr: number | null;
+  /** distinct outbound directed links (N -> neighbour) */
+  outboundLinks: number;
+  /** distinct inbound directed links (neighbour -> N) */
+  inboundLinks: number;
+}
+
+export interface AnalyzeResult {
+  segments: AnalyzedSegment[];
+  summary: TracerouteSummary | null;
+}
+
+function parseNumArray(json: string | null | undefined): number[] {
+  if (!json || json === 'null' || json === '') return [];
+  try {
+    const v = JSON.parse(json);
+    return Array.isArray(v) ? v.map((n) => Number(n)) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Raw firmware SNR (dB x 4) -> scaled dB. Returns the -32 sentinel for unknown. */
+function scaleSnr(raw: number | undefined): number | undefined {
+  if (raw === undefined || !Number.isFinite(raw)) return undefined;
+  return raw / 4;
+}
+
+interface RawSegment {
+  sourceId: string;
+  from: number;
+  to: number;
+  snr: number | undefined; // scaled dB (may be the unknown sentinel)
+}
+
+/** Decompose one traceroute into directed hops carrying receiver-measured SNR. */
+function segmentsForTraceroute(tr: TracerouteAnalysisInput): RawSegment[] {
+  const out: RawSegment[] = [];
+  const requester = Number(tr.toNodeNum);
+  const responder = Number(tr.fromNodeNum);
+
+  const route = parseNumArray(tr.route);
+  const routeBack = parseNumArray(tr.routeBack);
+  const snrTowards = parseNumArray(tr.snrTowards);
+  const snrBack = parseNumArray(tr.snrBack);
+
+  // Request leg: requester -> ...route -> responder
+  const forwardPath = [requester, ...route, responder];
+  for (let i = 0; i < forwardPath.length - 1; i++) {
+    out.push({
+      sourceId: tr.sourceId,
+      from: forwardPath[i],
+      to: forwardPath[i + 1],
+      snr: scaleSnr(snrTowards[i]),
+    });
+  }
+
+  // Response leg: responder -> ...routeBack -> requester
+  const backPath = [responder, ...routeBack, requester];
+  for (let i = 0; i < backPath.length - 1; i++) {
+    out.push({
+      sourceId: tr.sourceId,
+      from: backPath[i],
+      to: backPath[i + 1],
+      snr: scaleSnr(snrBack[i]),
+    });
+  }
+
+  return out;
+}
+
+const INVALID_NODE_NUMS = new Set([0, 1, 2, 3, 255, 65535, 4294967295]);
+
+function aggregateKey(s: RawSegment): string {
+  return `${s.sourceId}:${s.from}->${s.to}`;
+}
+
+interface Accum {
+  sourceId: string;
+  from: number;
+  to: number;
+  occurrences: number;
+  snrSum: number;
+  snrCount: number;
+  hasUnknown: boolean;
+}
+
+/**
+ * Pure analysis core. Kept free of React so it can be unit-tested directly.
+ */
+export function analyzeTraceroutes(params: AnalyzeParams): AnalyzeResult {
+  const {
+    traceroutes,
+    positionByKey,
+    selectedNodeNum,
+    selectedSourceId,
+    options,
+    visibleNodeNums,
+    timeWindow,
+  } = params;
+
+  // "focus" = a node is selected AND the focus toggle is on. Only then do we
+  // scope to / classify relative to that node; otherwise links render globally.
+  const hasNode = selectedNodeNum !== null && selectedNodeNum !== undefined;
+  const focus = hasNode && options.scopeToSelectedNode;
+
+  const inWindow = (t: number | undefined): boolean => {
+    if (!timeWindow) return true;
+    const { startMs, endMs } = timeWindow;
+    if (startMs === undefined || endMs === undefined) return true;
+    const ts = t ?? 0;
+    return ts >= startMs && ts <= endMs;
+  };
+
+  // 1. Filter rows by time window, source scope and node scope.
+  const rows = traceroutes.filter((tr) => {
+    if (!inWindow(tr.timestamp)) return false;
+    if (focus) {
+      if (selectedSourceId && tr.sourceId !== selectedSourceId) return false;
+      const route = parseNumArray(tr.route);
+      const routeBack = parseNumArray(tr.routeBack);
+      const all = [
+        Number(tr.fromNodeNum),
+        Number(tr.toNodeNum),
+        ...route,
+        ...routeBack,
+      ];
+      if (!all.includes(selectedNodeNum as number)) return false;
+    }
+    return true;
+  });
+
+  // 2. Aggregate directed hops.
+  const acc = new Map<string, Accum>();
+  for (const tr of rows) {
+    for (const seg of segmentsForTraceroute(tr)) {
+      if (INVALID_NODE_NUMS.has(seg.from) || INVALID_NODE_NUMS.has(seg.to)) continue;
+      if (seg.from === seg.to) continue;
+
+      // Node-centric: only keep hops incident to the selected node.
+      if (focus && seg.from !== selectedNodeNum && seg.to !== selectedNodeNum) {
+        continue;
+      }
+      // Search filter: both endpoints must be visible.
+      if (visibleNodeNums) {
+        if (!visibleNodeNums.has(seg.from) || !visibleNodeNums.has(seg.to)) continue;
+      }
+
+      const key = aggregateKey(seg);
+      let a = acc.get(key);
+      if (!a) {
+        a = {
+          sourceId: seg.sourceId,
+          from: seg.from,
+          to: seg.to,
+          occurrences: 0,
+          snrSum: 0,
+          snrCount: 0,
+          hasUnknown: false,
+        };
+        acc.set(key, a);
+      }
+      a.occurrences += 1;
+      if (seg.snr === undefined || isUnknownSnr(seg.snr)) {
+        a.hasUnknown = true;
+      } else {
+        a.snrSum += seg.snr;
+        a.snrCount += 1;
+      }
+    }
+  }
+
+  // 3. Build segments, apply weak-link + direction filters.
+  const segments: AnalyzedSegment[] = [];
+  for (const a of acc.values()) {
+    const avgSnr = a.snrCount > 0 ? a.snrSum / a.snrCount : null;
+
+    // Weak-link filters.
+    if (a.occurrences < options.minOccurrences) continue;
+    if (options.minSnr !== null) {
+      if (avgSnr === null || avgSnr < options.minSnr) continue;
+    }
+
+    let direction: SegmentDirection = 'neutral';
+    let neighborNum = a.from;
+    if (focus) {
+      if (a.to === selectedNodeNum) {
+        direction = 'inbound';
+        neighborNum = a.from;
+      } else {
+        direction = 'outbound';
+        neighborNum = a.to;
+      }
+      if (options.directionMode !== 'both' && options.directionMode !== direction) {
+        continue;
+      }
+    }
+
+    const fromPos = positionByKey.get(`${a.sourceId}:${a.from}`);
+    const toPos = positionByKey.get(`${a.sourceId}:${a.to}`);
+    if (!fromPos || !toPos) continue;
+
+    segments.push({
+      key: `${a.sourceId}:${a.from}->${a.to}`,
+      sourceId: a.sourceId,
+      from: a.from,
+      to: a.to,
+      fromPos,
+      toPos,
+      direction,
+      neighborNum,
+      avgSnr,
+      occurrences: a.occurrences,
+      isMqtt: a.hasUnknown && a.snrCount === 0,
+    });
+  }
+
+  // 4. Summary (only meaningful when focused on a selected node).
+  let summary: TracerouteSummary | null = null;
+  if (focus) {
+    const neighbors = new Set<number>();
+    const outbound = new Set<number>();
+    const inbound = new Set<number>();
+    let totalObservations = 0;
+    let snrSum = 0;
+    let snrCount = 0;
+    for (const s of segments) {
+      neighbors.add(s.neighborNum);
+      totalObservations += s.occurrences;
+      if (s.direction === 'outbound') outbound.add(s.neighborNum);
+      if (s.direction === 'inbound') inbound.add(s.neighborNum);
+      if (s.avgSnr !== null) {
+        snrSum += s.avgSnr;
+        snrCount += 1;
+      }
+    }
+    summary = {
+      distinctLinks: neighbors.size,
+      totalObservations,
+      avgSnr: snrCount > 0 ? snrSum / snrCount : null,
+      outboundLinks: outbound.size,
+      inboundLinks: inbound.size,
+    };
+  }
+
+  return { segments, summary };
+}
+
+/** React wrapper: memoises analyzeTraceroutes over its inputs. */
+export function useTracerouteAnalysis(params: AnalyzeParams): AnalyzeResult {
+  const {
+    traceroutes,
+    positionByKey,
+    selectedNodeNum,
+    selectedSourceId,
+    options,
+    visibleNodeNums,
+    timeWindow,
+  } = params;
+  return useMemo(
+    () =>
+      analyzeTraceroutes({
+        traceroutes,
+        positionByKey,
+        selectedNodeNum,
+        selectedSourceId,
+        options,
+        visibleNodeNums,
+        timeWindow,
+      }),
+    [
+      traceroutes,
+      positionByKey,
+      selectedNodeNum,
+      selectedSourceId,
+      options,
+      visibleNodeNums,
+      timeWindow,
+    ],
+  );
+}

--- a/src/styles/map-analysis.css
+++ b/src/styles/map-analysis.css
@@ -449,6 +449,113 @@
   border: 1px solid #444;
 }
 
+/* ===== Node search (issue #3399) ===== */
+.map-analysis-node-search {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+.map-analysis-node-search-input {
+  background: #1e1e1e;
+  color: #eee;
+  border: 1px solid #3a3a3a;
+  border-radius: 999px;
+  padding: 6px 28px 6px 14px;
+  font-size: 13px;
+  width: 160px;
+  transition: border-color 0.12s, width 0.12s;
+}
+.map-analysis-node-search-input:focus {
+  outline: none;
+  border-color: #2563eb;
+  width: 200px;
+}
+.map-analysis-node-search-input::placeholder { color: #777; }
+.map-analysis-node-search-clear {
+  position: absolute;
+  right: 8px;
+  background: transparent;
+  border: none;
+  color: #888;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+.map-analysis-node-search-clear:hover { color: #fff; }
+
+/* ===== Traceroute controls (issue #3399) ===== */
+.map-analysis-tr-controls {
+  position: relative;
+  display: inline-block;
+}
+.map-analysis-tr-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  background: #1e1e1e;
+  border: 1px solid #3a3a3a;
+  border-radius: 8px;
+  padding: 12px;
+  min-width: 200px;
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+.map-analysis-tr-seg {
+  display: inline-flex;
+  border: 1px solid #3a3a3a;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.map-analysis-tr-seg button {
+  background: transparent;
+  color: #ddd;
+  border: none;
+  border-right: 1px solid #3a3a3a;
+  padding: 5px 12px;
+  cursor: pointer;
+  font-size: 12px;
+  transition: background 0.12s, color 0.12s;
+}
+.map-analysis-tr-seg button:last-child { border-right: none; }
+.map-analysis-tr-seg button:hover { background: #262626; }
+.map-analysis-tr-seg button.selected {
+  background: #2563eb;
+  color: #fff;
+}
+.map-analysis-tr-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #ddd;
+  cursor: pointer;
+  user-select: none;
+}
+.map-analysis-tr-num {
+  background: #161616;
+  color: #eee;
+  border: 1px solid #3a3a3a;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 12px;
+  width: 90px;
+}
+.map-analysis-tr-num:focus { outline: none; border-color: #2563eb; }
+
+/* ===== Inspector: traceroute summary (issue #3399) ===== */
+.map-analysis-tr-summary-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #888;
+  margin-bottom: 8px;
+}
+
 /* ===== Back to Sources ===== */
 .map-analysis-back {
   background: transparent;


### PR DESCRIPTION
Closes #3399.

Implements all four Map Analysis enhancements requested in the issue. **Frontend-only** — no DB migration, no API change; everything runs over the existing `/api/analysis/traceroutes` data.

## What changed

### A · Node search & filter (hide non-matches)
- New `NodeSearchControl` in the toolbar. Case-insensitive match against long name, short name, node id, and hex/decimal `nodeNum` (idiom from `GeofenceNodeSelector`).
- Non-matching markers are hidden; the term lives in `MapAnalysisContext` and also constrains which traceroute link endpoints render.

### B · Overlapping / clustered markers
- `NodeMarkersLayer` now feeds the existing `useMarkerSpiderfier` hook via stable per-key `ref` callbacks (same bridge pattern as `NodesTab`), so clusters that share rounded coordinates fan out and each node is individually selectable. The hook no-ops gracefully when there's no map (keeps it test-friendly). No new dependency.

### C · Inbound/outbound traceroute separation (node-centric)
- New shared hook **`useTracerouteAnalysis`** decomposes traceroutes into directed hops. Using the authoritative storage convention (`fromNodeNum` = responder, `toNodeNum` = requester; `route`/`snrTowards` = request leg, `routeBack`/`snrBack` = response leg), and the fact that **each hop's SNR is measured at its receiver**, a hop *arriving at* the selected node is **inbound (RX sensitivity)** and a hop *leaving* it is **outbound (TX power)**.
- Rendered with direction colours (blue = outbound, rose = inbound), opposite curvature, and SNR-tooltip arrows — reusing the curve/arrow/SNR helpers in `mapHelpers`. MQTT/unknown-SNR hops are dashed.
- Toolbar `TracerouteControls`: direction toggle (Both/Out/In) + "Focus on selected node", persisted in the traceroutes layer options.

### D · Weak-link filtering & summary
- `minOccurrences` (drop links not observed ≥ N times — "leaving only those that occur multiple times") and `minSnr` filters, persisted in layer options. Repeated paths are deduplicated and weighted by occurrence count, which also reduces clutter.
- Inspector shows a per-node **Traceroute Links** summary: distinct links, outbound/inbound counts, total observations, average SNR. Segment popups gained direction / observation / avg-SNR detail.

## Architecture notes
- All traceroute math lives in the pure, node-testable `analyzeTraceroutes` core (`useTracerouteAnalysis` is a thin memoised wrapper), so the rendering layer and the inspector summary share identical results.
- SNR arrays are raw firmware ints (dB×4); the hook scales by ¼ and treats the −128 → −32 sentinel as unknown, matching `mapHelpers`.
- Reserved node numbers (0–3, 255, 65535, broadcast) are filtered.

## Testing
- Full Vitest suite: **6218 passed, 0 failed**. `tsc --noEmit` clean; eslint clean on changed files.
- New unit tests: `useTracerouteAnalysis.test.ts` (direction split, min-occurrences, min-SNR, MQTT sentinel, focus on/off, time window, visibility, missing positions) and `nodeSearch.test.ts` (matcher + visible-set).
- Updated existing MapAnalysis test mocks/fixtures touched by the changes (`useTraceroutes` mock in the inspector/canvas tests; realistic node numbers in the traceroute-layer fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)