### PR TITLE
feat(desktop): bundle Apprise notifications as a frozen sidecar

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -108,6 +108,15 @@ jobs:
           }
         shell: pwsh
 
+      - name: Setup Python for Apprise sidecar
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build Apprise sidecar
+        shell: pwsh
+        run: pwsh desktop/apprise-sidecar/build.ps1
+
       - name: Run Rust linting
         working-directory: desktop/src-tauri
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -216,6 +225,14 @@ jobs:
           tar -xzf node.tar.gz
           cp "node-${NODE_VERSION}-darwin-arm64/bin/node" desktop/resources/binaries/node
 
+      - name: Setup Python for Apprise sidecar
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build Apprise sidecar
+        run: bash desktop/apprise-sidecar/build.sh
+
       - name: Run Rust linting
         working-directory: desktop/src-tauri
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -323,6 +340,13 @@ jobs:
           echo "${EXPECTED_SHA256}  node.tar.gz" | shasum -a 256 -c -
           tar -xzf node.tar.gz
           cp "node-${NODE_VERSION}-darwin-x64/bin/node" desktop/resources/binaries/node
+
+      # NOTE: No Apprise sidecar is bundled for the x86_64 macOS build. This job
+      # cross-compiles the Rust app to x86_64 on an Apple Silicon (arm64) runner,
+      # but PyInstaller cannot cross-compile — it would produce an arm64 binary.
+      # Intel Mac users fall back to a remote Apprise API via the
+      # `appriseApiServerUrl` global setting. The Rust sidecar launcher treats a
+      # missing apprise-api binary as non-fatal. See desktop/apprise-sidecar/README.md.
 
       - name: Run Rust linting
         working-directory: desktop/src-tauri

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -105,6 +105,15 @@ jobs:
         working-directory: desktop
         run: npm install
 
+      - name: Setup Python for Apprise sidecar
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build Apprise sidecar
+        shell: pwsh
+        run: pwsh desktop/apprise-sidecar/build.ps1
+
       - name: Build Tauri app (release)
         working-directory: desktop
         run: npm run tauri:build
@@ -381,6 +390,14 @@ jobs:
         working-directory: desktop
         run: npm install
 
+      - name: Setup Python for Apprise sidecar
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build Apprise sidecar
+        run: bash desktop/apprise-sidecar/build.sh
+
       # Build the Tauri app (app bundle only, we'll create DMG after re-signing)
       - name: Build Tauri app (release)
         working-directory: desktop
@@ -419,6 +436,22 @@ jobs:
 
           echo "Verifying node entitlements..."
           codesign -d --entitlements - "$NODE_PATH"
+
+          # Sign the frozen Apprise sidecar (PyInstaller one-file binary) with the
+          # hardened runtime. Without this, notarization rejects the embedded
+          # executable and Gatekeeper blocks it. Uses library-validation-disabled
+          # entitlements because the one-file bootloader dlopen()s ad-hoc-signed libs.
+          # Not present on the x86_64 build (sidecar not cross-compiled) — guarded.
+          APPRISE_PATH="$APP_PATH/Contents/Resources/binaries/apprise-api"
+          if [ -f "$APPRISE_PATH" ]; then
+            echo "Re-signing Apprise sidecar binary..."
+            codesign --force --options runtime --sign "$APPLE_SIGNING_IDENTITY" \
+              --entitlements desktop/src-tauri/apprise.entitlements \
+              --timestamp "$APPRISE_PATH"
+            codesign -d --entitlements - "$APPRISE_PATH"
+          else
+            echo "No Apprise sidecar binary found at $APPRISE_PATH, skipping"
+          fi
 
           echo "Re-signing app bundle to update signature..."
           codesign --force --options runtime --sign "$APPLE_SIGNING_IDENTITY" \
@@ -616,6 +649,12 @@ jobs:
           mkdir -p dist/server/routes/v1
           cp src/server/routes/v1/openapi.yaml dist/server/routes/v1/
 
+      # NOTE: No Apprise sidecar is bundled for the x86_64 macOS release. This job
+      # cross-compiles to x86_64 on an Apple Silicon (arm64) runner and PyInstaller
+      # cannot cross-compile (it would emit an arm64 binary). Intel Mac users fall
+      # back to a remote Apprise API via the `appriseApiServerUrl` global setting;
+      # the Rust launcher treats a missing apprise-api binary as non-fatal.
+      # See desktop/apprise-sidecar/README.md.
       - name: Download Node.js for bundling (x64)
         run: |
           NODE_VERSION="v24.12.0"
@@ -780,6 +819,22 @@ jobs:
 
           echo "Verifying node entitlements..."
           codesign -d --entitlements - "$NODE_PATH"
+
+          # Sign the frozen Apprise sidecar (PyInstaller one-file binary) with the
+          # hardened runtime. Without this, notarization rejects the embedded
+          # executable and Gatekeeper blocks it. Uses library-validation-disabled
+          # entitlements because the one-file bootloader dlopen()s ad-hoc-signed libs.
+          # Not present on the x86_64 build (sidecar not cross-compiled) — guarded.
+          APPRISE_PATH="$APP_PATH/Contents/Resources/binaries/apprise-api"
+          if [ -f "$APPRISE_PATH" ]; then
+            echo "Re-signing Apprise sidecar binary..."
+            codesign --force --options runtime --sign "$APPLE_SIGNING_IDENTITY" \
+              --entitlements desktop/src-tauri/apprise.entitlements \
+              --timestamp "$APPRISE_PATH"
+            codesign -d --entitlements - "$APPRISE_PATH"
+          else
+            echo "No Apprise sidecar binary found at $APPRISE_PATH, skipping"
+          fi
 
           echo "Re-signing app bundle to update signature..."
           codesign --force --options runtime --sign "$APPLE_SIGNING_IDENTITY" \

--- a/desktop/apprise-sidecar/.gitignore
+++ b/desktop/apprise-sidecar/.gitignore
@@ -1,0 +1,8 @@
+# PyInstaller / venv build artifacts — only the source (spec, scripts,
+# requirements) is tracked. The frozen binary lands in desktop/resources/
+# (itself gitignored) and is produced fresh per-platform in CI.
+.venv/
+build/
+dist/
+__pycache__/
+*.pyc

--- a/desktop/apprise-sidecar/README.md
+++ b/desktop/apprise-sidecar/README.md
@@ -1,0 +1,96 @@
+# Desktop Apprise Sidecar
+
+The desktop (Tauri) bundle ships the Node backend but no system Python, so the
+[Apprise](https://github.com/caronc/apprise) notification engine — which the
+Docker image runs as a Python sidecar — isn't available out of the box. This
+directory builds Apprise into a **single self-contained executable** (via
+PyInstaller) that the desktop app launches alongside the Node backend, giving
+desktop users full Apprise notification support with no Python install.
+
+## How it fits together
+
+```
+┌─────────────────────────── MeshMonitor.app ───────────────────────────┐
+│  Tauri (Rust)                                                          │
+│    ├─ spawns  binaries/node  ── runs ──►  dist/server/server.js        │
+│    │            ▲ env: APPRISE_URL=http://127.0.0.1:<port>             │
+│    └─ spawns  binaries/apprise-api  (frozen Apprise HTTP API)          │
+│                 listening on 127.0.0.1:<random free port>             │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+1. **Build** — `build.sh` / `build.ps1` freeze `../../docker/apprise-api.py`
+   (stdlib `http.server` + `apprise`) into `apprise-api[.exe]` and drop it into
+   `../resources/binaries/`, next to the bundled `node` binary.
+2. **Launch** — `desktop/src-tauri/src/lib.rs::start_apprise()` finds the binary
+   in the Tauri resource dir, picks a free loopback port, and spawns it with
+   `APPRISE_HOST=127.0.0.1` (loopback only — never exposed to the LAN).
+3. **Wire** — the chosen `http://127.0.0.1:<port>` URL is stored in
+   `BackendState` and injected into the Node backend as `APPRISE_URL`, which the
+   server's `appriseNotificationService` already honors. The sidecar is started
+   once and kept alive across Node backend restarts.
+
+The HTTP contract the Node side depends on is tiny: `GET /health`,
+`GET /urls`, `POST /config`, `POST /notify {title, body, type, urls}`. The same
+`docker/apprise-api.py` serves both the Docker container and the frozen desktop
+sidecar, so notification behavior stays identical across deployments.
+
+## Building locally
+
+Requires Python 3.10+ on the target platform (PyInstaller does **not**
+cross-compile — build each OS/arch on its own machine).
+
+```bash
+# Linux / macOS
+./build.sh
+
+# Windows (PowerShell)
+./build.ps1
+```
+
+Output: `desktop/resources/binaries/apprise-api[.exe]`
+(`desktop/resources/` is gitignored — the binary is produced fresh per build).
+
+Approximate frozen size: **~18 MB** (Linux x64, Python 3.14). Windows and macOS
+are in the same ballpark.
+
+## CI integration
+
+Both `desktop-ci.yml` and `desktop-release.yml` run a **Setup Python** +
+**Build Apprise sidecar** step before the Tauri build, on the platforms where
+PyInstaller can produce a native binary:
+
+| Job              | Runner          | Apprise bundled? |
+|------------------|-----------------|------------------|
+| `build-windows`  | windows-latest  | ✅ (win x64)     |
+| `build-macos`    | macos-latest    | ✅ (arm64)       |
+| `build-macos-x64`| macos-14 (arm64, cross-compiles Rust → x64) | ❌ — see below |
+
+### macOS x86_64 gap
+
+The Intel-Mac build cross-compiles Rust to `x86_64-apple-darwin` on an Apple
+Silicon runner. PyInstaller can't cross-compile, so it would emit an arm64
+binary. Rather than ship a mismatched executable, the x64 build omits the
+sidecar. The Rust launcher treats a missing `apprise-api` binary as non-fatal,
+and Intel users can still point at a remote Apprise API via the
+`appriseApiServerUrl` global setting. Closing this gap would require building an
+x86_64 Python under Rosetta 2 — deferred.
+
+### macOS code signing
+
+The frozen binary is a Mach-O executable embedded in
+`Contents/Resources/binaries/`, so the release workflow signs it with the
+hardened runtime (`desktop/src-tauri/apprise.entitlements`) before notarization —
+otherwise notarization rejects the embedded executable and Gatekeeper blocks it.
+The entitlements disable library validation because the PyInstaller one-file
+bootloader `dlopen()`s ad-hoc-signed libraries it unpacks at runtime.
+
+## Files
+
+| File              | Purpose                                                        |
+|-------------------|----------------------------------------------------------------|
+| `apprise-api.spec`| PyInstaller spec; `collect_all('apprise')` pulls every plugin. |
+| `requirements.txt`| Build deps: `apprise` (unpinned, matches Dockerfile) + PyInstaller. |
+| `build.sh`        | POSIX build (Linux/macOS).                                     |
+| `build.ps1`       | Windows build.                                                 |
+| `.gitignore`      | Excludes `.venv/`, `build/`, `dist/` build artifacts.         |

--- a/desktop/apprise-sidecar/apprise-api.spec
+++ b/desktop/apprise-sidecar/apprise-api.spec
@@ -1,0 +1,60 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller spec for the MeshMonitor desktop Apprise sidecar.
+
+Freezes the existing docker/apprise-api.py HTTP wrapper (stdlib http.server +
+apprise) into a single self-contained executable so the desktop bundle can ship
+full Apprise notification support without a system Python.
+
+Apprise discovers its 100+ notification plugins dynamically at runtime, so a
+naive freeze would miss them. `collect_all('apprise')` pulls every submodule,
+data file (i18n .mo catalogs, templates) and any bundled binary so every
+notification schema works in the frozen build.
+
+Build with:  pyinstaller apprise-api.spec   (run from desktop/apprise-sidecar/)
+Output:      dist/apprise-api[.exe]
+"""
+import os
+from PyInstaller.utils.hooks import collect_all
+
+# Spec files don't get __file__; PyInstaller sets SPECPATH to the spec's dir.
+ENTRYPOINT = os.path.join(SPECPATH, '..', '..', 'docker', 'apprise-api.py')
+
+apprise_datas, apprise_binaries, apprise_hiddenimports = collect_all('apprise')
+
+a = Analysis(
+    [ENTRYPOINT],
+    pathex=[],
+    binaries=apprise_binaries,
+    datas=apprise_datas,
+    hiddenimports=apprise_hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    # Optional, heavy transitive deps some apprise plugins pull in but that the
+    # desktop sidecar does not need. Excluding them keeps the binary small.
+    excludes=['tkinter', 'test', 'unittest', 'pydoc', 'PIL', 'numpy'],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='apprise-api',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/desktop/apprise-sidecar/build.ps1
+++ b/desktop/apprise-sidecar/build.ps1
@@ -1,0 +1,42 @@
+<#
+.SYNOPSIS
+    Build the frozen Apprise sidecar binary for the MeshMonitor desktop bundle (Windows).
+
+.DESCRIPTION
+    Produces apprise-api.exe (self-contained, no system Python required) and copies
+    it into desktop/resources/binaries/ where the Tauri bundle picks it up alongside
+    the Node sidecar. PyInstaller does not cross-compile, so this runs on the Windows
+    CI runner to produce the Windows binary.
+
+.EXAMPLE
+    ./build.ps1
+#>
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$VenvDir   = Join-Path $ScriptDir '.venv'
+$DestDir   = Join-Path $ScriptDir '..\resources\binaries'
+
+Write-Host "==> Creating build venv at $VenvDir"
+python -m venv $VenvDir
+$Py = Join-Path $VenvDir 'Scripts\python.exe'
+
+Write-Host "==> Installing build dependencies (apprise + pyinstaller)"
+& $Py -m pip install --upgrade pip | Out-Null
+& $Py -m pip install -r (Join-Path $ScriptDir 'requirements.txt')
+
+Write-Host "==> Freezing apprise-api.py with PyInstaller"
+Push-Location $ScriptDir
+try {
+    Remove-Item -Recurse -Force build, dist -ErrorAction SilentlyContinue
+    & $Py -m PyInstaller --clean --noconfirm apprise-api.spec
+
+    New-Item -ItemType Directory -Force -Path $DestDir | Out-Null
+    Copy-Item 'dist\apprise-api.exe' (Join-Path $DestDir 'apprise-api.exe') -Force
+
+    $Size = [math]::Round((Get-Item (Join-Path $DestDir 'apprise-api.exe')).Length / 1MB, 1)
+    Write-Host "==> Done. apprise-api.exe (${Size} MB) -> $DestDir\apprise-api.exe"
+}
+finally {
+    Pop-Location
+}

--- a/desktop/apprise-sidecar/build.sh
+++ b/desktop/apprise-sidecar/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Build the frozen Apprise sidecar binary for the MeshMonitor desktop bundle.
+#
+# Produces a single self-contained executable (no system Python required) and
+# copies it into desktop/resources/binaries/ where the Tauri bundle picks it up
+# alongside the Node sidecar. Run on the target platform — PyInstaller does not
+# cross-compile, so macOS/Windows/Linux each build their own binary in CI.
+#
+# Usage:  ./build.sh            (from anywhere; paths are resolved relative to this script)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="${SCRIPT_DIR}/.venv"
+DEST_DIR="${SCRIPT_DIR}/../resources/binaries"
+
+echo "==> Creating build venv at ${VENV_DIR}"
+python3 -m venv "${VENV_DIR}"
+# shellcheck disable=SC1091
+source "${VENV_DIR}/bin/activate"
+
+echo "==> Installing build dependencies (apprise + pyinstaller)"
+python3 -m pip install --upgrade pip >/dev/null
+python3 -m pip install -r "${SCRIPT_DIR}/requirements.txt"
+
+echo "==> Freezing apprise-api.py with PyInstaller"
+cd "${SCRIPT_DIR}"
+rm -rf build dist
+pyinstaller --clean --noconfirm apprise-api.spec
+
+mkdir -p "${DEST_DIR}"
+cp "dist/apprise-api" "${DEST_DIR}/apprise-api"
+chmod +x "${DEST_DIR}/apprise-api"
+
+SIZE="$(du -h "${DEST_DIR}/apprise-api" | cut -f1)"
+echo "==> Done. apprise-api (${SIZE}) -> ${DEST_DIR}/apprise-api"

--- a/desktop/apprise-sidecar/requirements.txt
+++ b/desktop/apprise-sidecar/requirements.txt
@@ -1,0 +1,8 @@
+# Build-time dependencies for the frozen Apprise sidecar.
+#
+# `apprise` is intentionally left unpinned to track the same version the Docker
+# image installs (see Dockerfile) so the desktop and container notification
+# behaviour stay in sync. PyInstaller is pinned to a major to keep the freeze
+# reproducible across the CI runners that build per-platform binaries.
+apprise
+pyinstaller>=6.3,<7

--- a/desktop/src-tauri/apprise.entitlements
+++ b/desktop/src-tauri/apprise.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+      Entitlements for the frozen Apprise sidecar (PyInstaller one-file binary).
+      A one-file build extracts its bundled Python runtime and shared libraries to
+      a temp dir at launch and dlopen()s them. Under the hardened runtime those
+      libraries are signed ad-hoc (not by our Team ID), so library validation must
+      be disabled or the process is killed at startup. PyInstaller's bootloader
+      also reads DYLD_* environment variables.
+    -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -31,6 +31,24 @@ pub use config::Config;
 /// Global state for the backend process
 pub struct BackendState {
     pub process: Mutex<Option<Child>>,
+    /// The frozen Apprise sidecar process. Started once at launch and kept
+    /// alive across Node backend restarts. `None` when no apprise-api binary
+    /// is bundled (e.g. dev builds) or the sidecar failed to start.
+    pub apprise: Mutex<Option<Child>>,
+    /// URL the Apprise sidecar is listening on (e.g. `http://127.0.0.1:8123`).
+    /// Injected into the Node backend as APPRISE_URL so the notification
+    /// service targets the bundled sidecar. `None` when no sidecar is running.
+    pub apprise_url: Mutex<Option<String>>,
+}
+
+impl Default for BackendState {
+    fn default() -> Self {
+        Self {
+            process: Mutex::new(None),
+            apprise: Mutex::new(None),
+            apprise_url: Mutex::new(None),
+        }
+    }
 }
 
 /// Write a log message to the MeshMonitor log file
@@ -44,6 +62,114 @@ fn log_to_file(logs_path: &std::path::Path, message: &str) {
         let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
         let _ = writeln!(file, "[{}] {}", timestamp, message);
     }
+}
+
+/// Ask the OS for a free TCP port on loopback by binding to port 0 and reading
+/// back the assigned port. There is an inherent (small) race between releasing
+/// the listener here and the sidecar binding it, but on a single-user desktop
+/// that is acceptable and far safer than a hardcoded port that may collide.
+fn find_free_loopback_port() -> Result<u16, String> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .map_err(|e| format!("Failed to find a free port for Apprise sidecar: {}", e))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| format!("Failed to read Apprise sidecar port: {}", e))?
+        .port();
+    Ok(port)
+}
+
+/// Start the frozen Apprise sidecar, if the binary is bundled.
+///
+/// Returns `Ok(Some(url))` with the loopback URL the sidecar is listening on,
+/// or `Ok(None)` when no apprise-api binary is present (dev builds / platforms
+/// where the sidecar wasn't built). A missing sidecar is NOT an error — the
+/// desktop app simply runs without bundled Apprise (users can still point at a
+/// remote Apprise API via the `appriseApiServerUrl` global setting).
+pub fn start_apprise<R: Runtime>(app: &AppHandle<R>) -> Result<Option<(Child, String)>, String> {
+    let data_path = config::get_data_path()?;
+    let logs_path = config::get_logs_path()?;
+    std::fs::create_dir_all(&logs_path)
+        .map_err(|e| format!("Failed to create logs directory: {}", e))?;
+
+    let resource_path = strip_extended_length_prefix(
+        app.path()
+            .resource_dir()
+            .map_err(|e| format!("Failed to get resource dir: {}", e))?,
+    );
+
+    let apprise_path = resource_path.join("binaries").join(if cfg!(windows) {
+        "apprise-api.exe"
+    } else {
+        "apprise-api"
+    });
+
+    if !apprise_path.exists() {
+        log_to_file(
+            &logs_path,
+            &format!(
+                "Apprise sidecar not bundled at {:?} — notifications via bundled Apprise disabled",
+                apprise_path
+            ),
+        );
+        return Ok(None);
+    }
+
+    let port = find_free_loopback_port()?;
+    let url = format!("http://127.0.0.1:{}", port);
+    let config_dir = data_path.join("apprise-config");
+    std::fs::create_dir_all(&config_dir)
+        .map_err(|e| format!("Failed to create apprise-config directory: {}", e))?;
+
+    // Stdout/stderr to a dedicated log so sidecar issues are diagnosable.
+    let apprise_log_path = logs_path.join("apprise.log");
+    let apprise_log = File::create(&apprise_log_path)
+        .map_err(|e| format!("Failed to create apprise log: {}", e))?;
+    let apprise_log_err = apprise_log
+        .try_clone()
+        .map_err(|e| format!("Failed to clone apprise log handle: {}", e))?;
+
+    log_to_file(&logs_path, &format!("Starting Apprise sidecar: {:?}", apprise_path));
+    log_to_file(&logs_path, &format!("Apprise URL: {}", url));
+
+    let mut cmd = std::process::Command::new(&apprise_path);
+    cmd.stdout(Stdio::from(apprise_log))
+        .stderr(Stdio::from(apprise_log_err))
+        // Loopback only — never expose the notification sender to the LAN.
+        .env("APPRISE_HOST", "127.0.0.1")
+        .env("APPRISE_PORT", port.to_string())
+        .env("APPRISE_CONFIG_DIR", config_dir.to_string_lossy().to_string());
+
+    // On Windows, hide the console window for the sidecar too.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let child = cmd.spawn().map_err(|e| {
+        let msg = format!("Failed to start Apprise sidecar: {}", e);
+        log_to_file(&logs_path, &msg);
+        msg
+    })?;
+
+    log_to_file(
+        &logs_path,
+        &format!("Apprise sidecar started with PID: {}", child.id()),
+    );
+
+    Ok(Some((child, url)))
+}
+
+/// Stop the Apprise sidecar process if running.
+pub fn stop_apprise(state: &BackendState) {
+    let mut process = state.apprise.lock().unwrap();
+    if let Some(mut child) = process.take() {
+        println!("Stopping Apprise sidecar...");
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    *state.apprise_url.lock().unwrap() = None;
 }
 
 /// Start the MeshMonitor backend server
@@ -191,6 +317,21 @@ pub fn start_backend<R: Runtime>(app: &AppHandle<R>) -> Result<Child, String> {
         )
         .env("IS_DESKTOP", "true")
         .env("FIRMWARE_CHECK_ENABLED", "false");
+
+    // Point the backend's notification service at the bundled Apprise sidecar
+    // if one is running. Resolved from BackendState so it survives Node backend
+    // restarts (the sidecar is started once and kept alive). When absent, the
+    // backend falls back to the `appriseApiServerUrl` global setting / no Apprise.
+    if let Some(apprise_url) = app
+        .state::<BackendState>()
+        .apprise_url
+        .lock()
+        .unwrap()
+        .clone()
+    {
+        cmd.env("APPRISE_URL", &apprise_url);
+        log_to_file(&logs_path, &format!("APPRISE_URL: {}", apprise_url));
+    }
 
     // Only pass MESHTASTIC_NODE_IP / TCP_PORT if the user has actually
     // configured a Meshtastic node. Setting either env var triggers the

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ fn strip_extended_length_prefix(path: PathBuf) -> PathBuf {
 pub use config::Config;
 
 /// Global state for the backend process
+#[derive(Default)]
 pub struct BackendState {
     pub process: Mutex<Option<Child>>,
     /// The frozen Apprise sidecar process. Started once at launch and kept
@@ -39,16 +40,6 @@ pub struct BackendState {
     /// Injected into the Node backend as APPRISE_URL so the notification
     /// service targets the bundled sidecar. `None` when no sidecar is running.
     pub apprise_url: Mutex<Option<String>>,
-}
-
-impl Default for BackendState {
-    fn default() -> Self {
-        Self {
-            process: Mutex::new(None),
-            apprise: Mutex::new(None),
-            apprise_url: Mutex::new(None),
-        }
-    }
 }
 
 /// Write a log message to the MeshMonitor log file
@@ -128,7 +119,10 @@ pub fn start_apprise<R: Runtime>(app: &AppHandle<R>) -> Result<Option<(Child, St
         .try_clone()
         .map_err(|e| format!("Failed to clone apprise log handle: {}", e))?;
 
-    log_to_file(&logs_path, &format!("Starting Apprise sidecar: {:?}", apprise_path));
+    log_to_file(
+        &logs_path,
+        &format!("Starting Apprise sidecar: {:?}", apprise_path),
+    );
     log_to_file(&logs_path, &format!("Apprise URL: {}", url));
 
     let mut cmd = std::process::Command::new(&apprise_path);
@@ -137,7 +131,10 @@ pub fn start_apprise<R: Runtime>(app: &AppHandle<R>) -> Result<Option<(Child, St
         // Loopback only — never expose the notification sender to the LAN.
         .env("APPRISE_HOST", "127.0.0.1")
         .env("APPRISE_PORT", port.to_string())
-        .env("APPRISE_CONFIG_DIR", config_dir.to_string_lossy().to_string());
+        .env(
+            "APPRISE_CONFIG_DIR",
+            config_dir.to_string_lossy().to_string(),
+        );
 
     // On Windows, hide the console window for the sidecar too.
     #[cfg(windows)]

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,8 +1,9 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use meshmonitor_desktop_lib::{start_backend, stop_backend, tray, BackendState, Config};
-use std::sync::Mutex;
+use meshmonitor_desktop_lib::{
+    start_apprise, start_backend, stop_apprise, stop_backend, tray, BackendState, Config,
+};
 use tauri::{AppHandle, Manager};
 
 // Tauri commands must be defined in the binary crate to avoid E0255 duplicate symbol errors
@@ -43,11 +44,24 @@ fn main() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_fs::init())
-        .manage(BackendState {
-            process: Mutex::new(None),
-        })
+        .manage(BackendState::default())
         .setup(|app| {
             let handle = app.handle().clone();
+
+            // Start the bundled Apprise notification sidecar (if present) before
+            // the backend, so its loopback URL is available to inject as
+            // APPRISE_URL when the Node backend spawns. A missing sidecar is
+            // non-fatal — the app runs without bundled Apprise.
+            match start_apprise(&handle) {
+                Ok(Some((child, url))) => {
+                    let state: tauri::State<BackendState> = handle.state();
+                    *state.apprise.lock().unwrap() = Some(child);
+                    *state.apprise_url.lock().unwrap() = Some(url);
+                    println!("Apprise sidecar started");
+                }
+                Ok(None) => println!("No Apprise sidecar bundled; skipping"),
+                Err(e) => eprintln!("Failed to start Apprise sidecar: {}", e),
+            }
 
             // Load or create configuration
             let config = Config::load().unwrap_or_default();
@@ -105,9 +119,10 @@ fn main() {
         .expect("error while building tauri application")
         .run(|app, event| {
             if let tauri::RunEvent::Exit = event {
-                // Stop the backend when the app exits
+                // Stop the backend and Apprise sidecar when the app exits
                 let state: tauri::State<BackendState> = app.state();
                 stop_backend(&state);
+                stop_apprise(&state);
             }
         });
 }

--- a/docker/apprise-api.py
+++ b/docker/apprise-api.py
@@ -11,6 +11,11 @@ from urllib.parse import urlparse, parse_qs
 
 CONFIG_DIR = os.getenv('APPRISE_CONFIG_DIR', '/apprise-config')
 PORT = int(os.getenv('APPRISE_PORT', '8000'))
+# Bind address. Defaults to all interfaces to preserve the Docker behaviour
+# (the Node process reaches it over localhost inside the same container).
+# The desktop bundle sets APPRISE_HOST=127.0.0.1 so the frozen sidecar is
+# only reachable from the local machine and never the LAN.
+HOST = os.getenv('APPRISE_HOST', '')
 
 # Global Apprise object
 apobj = apprise.Apprise()
@@ -226,9 +231,9 @@ class AppriseHandler(BaseHTTPRequestHandler):
 def run_server():
     """Start the HTTP server"""
     load_config()
-    server_address = ('', PORT)
+    server_address = (HOST, PORT)
     httpd = HTTPServer(server_address, AppriseHandler)
-    print(f"🚀 Apprise API server starting on http://0.0.0.0:{PORT}")
+    print(f"🚀 Apprise API server starting on http://{HOST or '0.0.0.0'}:{PORT}")
     print(f"📁 Config directory: {CONFIG_DIR}")
     print(f"📊 Loaded {len(apobj)} notification URLs")
     httpd.serve_forever()


### PR DESCRIPTION
## Summary

Brings full **Apprise** notification support to the **desktop (Tauri) bundles**. Today the desktop app ships the Node backend but no Python, so the Apprise engine — which the Docker image runs as a Python sidecar — is unavailable; desktop users can only point at a remote Apprise API. This freezes Apprise into a single self-contained executable bundled next to the Node binary, so desktop gets the same 100+ notification services with no system Python.

**Draft intentionally** — the main goal of opening it is to **verify the per-platform builds (Windows + macOS) compile and bundle correctly in CI**. There is no local Rust toolchain in the dev environment, so CI's `lint-rust`/build jobs are the first real compile of the Rust changes.

## Approach (Option A: freeze the existing wrapper)

- **`desktop/apprise-sidecar/`** — PyInstaller spec (`collect_all('apprise')` pulls every notification plugin) + `build.sh`/`build.ps1` + pinned `requirements.txt`. Freezes the **existing** `docker/apprise-api.py`, so desktop and Docker share one notification code path. Built ~18 MB on Linux/Py3.14 and smoke-tested locally (`/health` + a `json://` dispatch confirm plugins load inside the frozen binary).
- **Rust (`lib.rs`/`main.rs`)** — `start_apprise()` locates the bundled binary, picks a free loopback port, spawns it bound to `127.0.0.1` only, and injects `APPRISE_URL` into the Node backend (which `appriseNotificationService` already honors). Started once, kept alive across backend restarts; a **missing binary is non-fatal**. Stopped on exit; timer/process cleanup wired in.
- **`docker/apprise-api.py`** — bind host is now `APPRISE_HOST` (default `''` preserves Docker behavior; desktop sets `127.0.0.1` so the sidecar never reaches the LAN). Backward-compatible.
- **CI** (`desktop-ci.yml` / `desktop-release.yml`) — per-platform PyInstaller build step on **Windows** and **macOS-arm64**; the release workflow signs the frozen binary with the hardened runtime (`apprise.entitlements`) before notarization.

## Known gap (documented)

**macOS x86_64** is cross-compiled to x64 on an Apple-Silicon (arm64) runner, and PyInstaller can't cross-compile — it would emit an arm64 binary. So the Intel build **omits** the sidecar (Intel users fall back to a remote Apprise API via the `appriseApiServerUrl` global setting). The Rust launcher treats a missing binary as non-fatal. See `desktop/apprise-sidecar/README.md`.

## Testing / verification asks

- ✅ Frozen binary builds + smoke-tests locally on Linux (~18 MB, plugins load, dispatch works).
- ⏳ **CI is the verification target**: Windows build, macOS-arm64 build (+ sidecar bundling), macOS-x64 build (no sidecar), and the Rust compile (`lint-rust`/clippy) — none of which can run in the local dev env.
- The 18 MB frozen binary lands in `desktop/resources/` (gitignored) and is produced fresh per-platform in CI; it is **not** committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)