### PR TITLE
fix: Security tab source-scoping (dead-nodes + key-mismatches) + Auto Remote LocalStats nav

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4993,6 +4993,7 @@ function App() {
                 { id: 'auto-welcome', label: t('automation.welcome.title', 'Auto Welcome') },
                 { id: 'auto-favorite', label: t('automation.auto_favorite.title', 'Auto Favorite') },
                 { id: 'auto-traceroute', label: t('automation.traceroute.title', 'Auto Traceroute') },
+                { id: 'auto-localstats', label: t('automation.auto_localstats.title', 'Auto Remote LocalStats') },
                 { id: 'auto-ping', label: t('automation.auto_ping.title', 'Auto Ping') },
                 { id: 'auto-heap-management', label: t('automation.auto_heap.title', 'Auto Heap Management') },
                 { id: 'remote-admin-scanner', label: t('automation.remote_admin_scanner.title', 'Remote Admin Scanner') },

--- a/src/components/SecurityTab.tsx
+++ b/src/components/SecurityTab.tsx
@@ -111,7 +111,7 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ onTabChange, onSelectD
       const [issuesData, statusData, mismatchData, deadNodesData] = await Promise.all([
         api.get<SecurityIssuesResponse>(`/api/security/issues${srcParam}`),
         api.get<ScannerStatus>(`/api/security/scanner/status${srcParam}`),
-        api.get<{ events: any[] }>('/api/security/key-mismatches'),
+        api.get<{ events: any[] }>(`/api/security/key-mismatches${srcParam}`),
         sourceId
           ? api.get<DeadNodesResponse>(`/api/security/dead-nodes${srcParam}`)
           : Promise.resolve({ nodes: [], count: 0, thresholdDays: 7 } as unknown as DeadNodesResponse),

--- a/src/server/routes/securityRoutes.test.ts
+++ b/src/server/routes/securityRoutes.test.ts
@@ -157,4 +157,35 @@ describe('securityRoutes — per-source scanner', () => {
       expect(getStatusMock).toHaveBeenCalledWith('src-1');
     });
   });
+
+  describe('GET /dead-nodes', () => {
+    beforeEach(() => {
+      getManagerMock.mockImplementation((id: string) =>
+        ['src-1', 'src-2'].includes(id)
+          ? { sourceId: id, isNodeInDeviceDb: () => false }
+          : undefined,
+      );
+      mockDb.settings.getSetting.mockResolvedValue('0');
+    });
+
+    it('scopes the dead-nodes query to the requested source', async () => {
+      const nowSec = Math.floor(Date.now() / 1000);
+      const daysAgo = (d: number) => nowSec - d * 24 * 60 * 60;
+      mockDb.nodes.getAllNodes.mockResolvedValue([
+        { nodeNum: 111, nodeId: '!6f', longName: 'Stale', shortName: 'OLD', hwModel: 1, lastHeard: daysAgo(30), isIgnored: false },
+        { nodeNum: 222, nodeId: '!de', longName: 'Fresh', shortName: 'NEW', hwModel: 1, lastHeard: daysAgo(0), isIgnored: false },
+      ]);
+
+      const app = createApp();
+      const res = await request(app).get('/api/security/dead-nodes?sourceId=src-1');
+
+      expect(res.status).toBe(200);
+      // Regression (2000+ dead nodes bug): the query MUST be scoped by sourceId,
+      // otherwise dead nodes from every source leak into one source's list.
+      expect(mockDb.nodes.getAllNodes).toHaveBeenCalledWith('src-1');
+      // Only the stale node (30d) is dead; the freshly-heard one is excluded.
+      expect(res.body.count).toBe(1);
+      expect(res.body.nodes.map((n: any) => n.nodeNum)).toEqual([111]);
+    });
+  });
 });

--- a/src/server/routes/securityRoutes.test.ts
+++ b/src/server/routes/securityRoutes.test.ts
@@ -188,4 +188,15 @@ describe('securityRoutes — per-source scanner', () => {
       expect(res.body.nodes.map((n: any) => n.nodeNum)).toEqual([111]);
     });
   });
+
+  describe('GET /key-mismatches', () => {
+    it('scopes the key-repair log to the requested source', async () => {
+      const app = createApp();
+      const res = await request(app).get('/api/security/key-mismatches?sourceId=src-1');
+      expect(res.status).toBe(200);
+      // Regression: the repair log MUST be scoped by sourceId, otherwise key
+      // mismatch events from every source leak into one source's view.
+      expect(mockDb.getKeyRepairLogAsync).toHaveBeenCalledWith(100, 'src-1');
+    });
+  });
 });

--- a/src/server/routes/securityRoutes.ts
+++ b/src/server/routes/securityRoutes.ts
@@ -376,7 +376,9 @@ router.get('/dead-nodes', async (req: Request, res: Response) => {
     const DEAD_NODE_DAYS = 7;
     const cutoffSeconds = Math.floor(Date.now() / 1000) - (DEAD_NODE_DAYS * 24 * 60 * 60);
 
-    const allNodes = await databaseService.nodes.getAllNodes();
+    // Scope to the requested source — otherwise the list leaks dead nodes from
+    // every source into one source's view (issue: 2000+ dead nodes).
+    const allNodes = await databaseService.nodes.getAllNodes(deadNodesSourceId);
     const localNodeNum = parseInt(await databaseService.settings.getSetting('localNodeNum') || '0');
 
     const deadNodes = allNodes

--- a/src/server/routes/securityRoutes.ts
+++ b/src/server/routes/securityRoutes.ts
@@ -327,9 +327,12 @@ router.post('/nodes/:nodeNum/clear', requirePermission('security', 'write'), asy
  * GET /api/security/key-mismatches
  * Returns recent key mismatch events from the repair log
  */
-router.get('/key-mismatches', async (_req: Request, res: Response) => {
+router.get('/key-mismatches', async (req: Request, res: Response) => {
   try {
-    const log = await databaseService.getKeyRepairLogAsync(100);
+    // Scope to the requested source so the repair log doesn't leak events from
+    // every source into one source's view (same class as the dead-nodes bug).
+    const sourceId = req.query.sourceId as string | undefined;
+    const log = await databaseService.getKeyRepairLogAsync(100, sourceId);
 
     // Filter to mismatch-related actions
     const mismatchActions = new Set(['mismatch', 'purge', 'fixed', 'exhausted']);


### PR DESCRIPTION
Bugs found while testing `main` in the dev container, plus a follow-up audit of the Security tab for the same scoping bug class.

## 1. Dead Nodes list showed 2000+ nodes for one source
`GET /api/security/dead-nodes` called `getAllNodes()` without a `sourceId`, returning dead nodes across all sources. Fix: `getAllNodes(deadNodesSourceId)`.

## 2. Key Mismatch Events leaked across sources (found via audit)
After fixing #1 I audited the whole Security tab. Every section threads `sourceId` correctly except Key Mismatch Events: the `/api/security/key-mismatches` handler ignored `req.query.sourceId` and `SecurityTab.tsx` fetched it without `srcParam`. `getKeyRepairLogAsync` already supports per-source filtering on all three backends — this wires it through.

## 3. "Auto Remote LocalStats" missing from the Automation navbar
The `AutoLocalStatsSection` (#3398) was rendered/wired but never added to the Automation `SectionNav` items array. Fix: add the nav item between Auto Traceroute and Auto Ping in `App.tsx`.

## Security tab audit
Every other section is correctly source-scoped: Low-Entropy/Duplicate Keys, Excessive Packets, Time-Offset Issues, Top Broadcasters, Scanner status/scan, Dead Nodes (+ bulk-delete), Export. Digest "Send Now" intentionally iterates all sources, scoping each. Only the two above leaked.

## Testing
- `securityRoutes.test.ts`: 8 pass (+ dead-nodes and key-mismatches scoping regressions).
- `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)