### PR TITLE
fix(csp): apply custom analytics CSP Allowed Domains to the CSP header (#3409)

### DIFF
--- a/src/server/middleware/dynamicCsp.test.ts
+++ b/src/server/middleware/dynamicCsp.test.ts
@@ -15,6 +15,11 @@ vi.mock('../../services/database.js', () => ({
 }));
 
 import { buildCspHeader } from './dynamicCsp.js';
+import databaseService from '../../services/database.js';
+
+const mockGetSetting = (databaseService as unknown as {
+  settings: { getSetting: ReturnType<typeof vi.fn> };
+}).settings.getSetting;
 
 function directivesFromHeader(header: string): Record<string, string> {
   const map: Record<string, string> = {};
@@ -82,5 +87,59 @@ describe('buildCspHeader - frame-ancestors', () => {
     const directives = directivesFromHeader(header);
 
     expect(directives['frame-src']).toBe("'none'");
+  });
+});
+
+describe('buildCspHeader - custom analytics CSP domains (#3409)', () => {
+  beforeEach(() => {
+    mockGetSetting.mockReset();
+    mockGetSetting.mockResolvedValue(null);
+  });
+
+  function withSettings(settings: Record<string, string>) {
+    mockGetSetting.mockImplementation(async (key: string) => settings[key] ?? null);
+  }
+
+  it('includes configured custom domains in script-src and connect-src', async () => {
+    withSettings({
+      analyticsProvider: 'custom',
+      analyticsConfig: JSON.stringify({
+        cspDomains: 'https://analytics.example.com https://cdn.example.com',
+      }),
+    });
+
+    const header = await buildCspHeader(true, true, []);
+    const directives = directivesFromHeader(header);
+
+    // Regression: before #3409 the 'custom' provider was short-circuited and
+    // these origins never reached the header.
+    expect(directives['script-src']).toContain('https://analytics.example.com');
+    expect(directives['script-src']).toContain('https://cdn.example.com');
+    expect(directives['connect-src']).toContain('https://analytics.example.com');
+    expect(directives['connect-src']).toContain('https://cdn.example.com');
+    // Inline analytics snippets need 'unsafe-inline' on script-src.
+    expect(directives['script-src']).toContain("'unsafe-inline'");
+  });
+
+  it('reduces bare hostnames / non-URL entries to nothing (requires a scheme)', async () => {
+    withSettings({
+      analyticsProvider: 'custom',
+      analyticsConfig: JSON.stringify({ cspDomains: 'analytics.example.com' }),
+    });
+
+    const header = await buildCspHeader(true, true, []);
+    const directives = directivesFromHeader(header);
+
+    // No scheme → not added (the parser requires http(s)://).
+    expect(directives['script-src']).not.toContain('analytics.example.com');
+  });
+
+  it('adds nothing for provider "none"', async () => {
+    withSettings({ analyticsProvider: 'none' });
+
+    const header = await buildCspHeader(true, true, []);
+    const directives = directivesFromHeader(header);
+
+    expect(directives['script-src']).toBe("'self'");
   });
 });

--- a/src/server/middleware/dynamicCsp.ts
+++ b/src/server/middleware/dynamicCsp.ts
@@ -122,9 +122,12 @@ export async function buildConnectSrcDirective(isProduction: boolean, cookieSecu
 async function getAnalyticsCspFromSettings(): Promise<{ scriptSrc: string[]; connectSrc: string[] }> {
   try {
     const provider = (await databaseService.settings.getSetting('analyticsProvider') || 'none') as AnalyticsProvider;
-    if (provider === 'none' || provider === 'custom') {
+    if (provider === 'none') {
       return { scriptSrc: [], connectSrc: [] };
     }
+    // 'custom' is handled by getAnalyticsCspDomains (reads config.cspDomains);
+    // it must NOT be short-circuited here or the configured domains never reach
+    // the CSP header (issue #3409).
     const configJson = await databaseService.settings.getSetting('analyticsConfig') || '{}';
     const config = JSON.parse(configJson);
     return getAnalyticsCspDomains(provider, config);


### PR DESCRIPTION
Closes #3409.

## Bug
With Analytics Provider = **Custom Script** and a value in **CSP Allowed Domains**, the configured domains were not added to the `Content-Security-Policy` header — `script-src`/`connect-src` stayed at the default policy, so the browser blocked the custom analytics script and its beacons.

## Root cause
`getAnalyticsCspFromSettings()` in `src/server/middleware/dynamicCsp.ts` short-circuited for **both** `'none'` and `'custom'`:

```ts
if (provider === 'none' || provider === 'custom') {
  return { scriptSrc: [], connectSrc: [] };
}
```

So for the custom provider it returned empty arrays and never read `analyticsConfig.cspDomains`. The custom-provider branch in `getAnalyticsCspDomains()` (`analyticsScriptGenerator.ts`) already parses `cspDomains` into origins for both `script-src` and `connect-src` correctly — it just was never reached. (The analytics `<script>` itself *was* being injected into the HTML, which is why the script was present but CSP-blocked.)

## Fix
Drop `'custom'` from the guard so configured origins flow through to the header:

```ts
if (provider === 'none') {
  return { scriptSrc: [], connectSrc: [] };
}
```

## Notes
- The parser requires a scheme (`http(s)://`), matching the field's placeholder (`https://analytics.example.com …`). A bare host like `analytics.domain.tld` is intentionally ignored — enter the full URL.
- The CSP is built per-request, so the change takes effect on the next response after saving settings (no restart needed).

## Testing
- New regression tests in `dynamicCsp.test.ts`: custom provider + `cspDomains` → origins appear in `script-src` **and** `connect-src` (and inline analytics gets `'unsafe-inline'`); bare hostnames are dropped; `none` adds nothing.
- Full Vitest suite: **6246 pass, 0 fail**. `tsc` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)