### PR TITLE
feat(firmware): guided half-flash recovery with online check (#3413)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4421,6 +4421,13 @@
   "firmware.ota_bootloader_learn_more": "Learn More",
   "firmware.retry_flash": "Retry Flash",
   "firmware.retry_flash_unavailable": "Cannot retry: firmware files are no longer available. Please start a new update.",
+  "firmware.recovery_title": "Device flagged as half-flashed",
+  "firmware.recovery_explanation": "A previous OTA attempt did not finish, so MeshMonitor flagged this node to prevent another flash on a possibly corrupted device. Recover it via a USB-tethered flash first. Once it is back online, clear the flag below to retry.",
+  "firmware.recovery_online": "Node is online and accepting connections — it appears to have recovered.",
+  "firmware.recovery_offline": "Node is not online and accepting connections yet. Recover it via USB and wait for it to reconnect.",
+  "firmware.recovery_not_online": "Node is not online and accepting connections yet. Recover it via USB and wait for it to reconnect before clearing the flag.",
+  "firmware.recovery_clear_retry": "I've Recovered via USB — Clear Flag & Retry",
+  "firmware.recovery_cleared": "Recovery flag cleared",
 
   "direct_links.neighbor_connection": "Neighbor Connection",
   "direct_links.bidirectional": "Bidirectional",

--- a/src/components/configuration/FirmwareUpdateSection.recovery.test.tsx
+++ b/src/components/configuration/FirmwareUpdateSection.recovery.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #3413: when an OTA flash is blocked by Safety Rail 5 (half-flash
+ * marker), the wizard surfaces an inline recovery panel instead of the raw
+ * "DELETE /api/firmware/recovery-marker/..." toast. The "Clear Flag & Retry"
+ * action is gated on a basic "node is online and accepting connections" check
+ * derived from the live poll connection state.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// --- hoisted mutable mock state -----------------------------------------
+const h = vi.hoisted(() => ({
+  pollData: {
+    connection: { connected: true, nodeResponsive: true },
+    config: {
+      localNodeInfo: { nodeId: '!9ea3e00c', nodeNum: 123 },
+      meshtasticNodeIp: '1.2.3.4',
+      meshtasticSourceType: 'meshtastic_tcp',
+      deviceMetadata: { firmwareVersion: '2.5.0' },
+    },
+    nodes: [] as unknown[],
+  },
+  statusResponse: {
+    success: true,
+    status: {
+      state: 'awaiting-confirm',
+      step: 'preflight',
+      message: 'Ready to begin',
+      logs: [] as string[],
+      preflightInfo: { gatewayIp: '1.2.3.4' },
+    },
+    channel: 'stable',
+    customUrl: '',
+    lastChecked: null,
+  },
+  csrfFetch: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+// --- mocks ---------------------------------------------------------------
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string | Record<string, unknown>) =>
+      typeof fallback === 'string' ? fallback : _key,
+  }),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (opts: { queryKey: unknown[] }) => {
+    const key = JSON.stringify(opts.queryKey);
+    if (key === JSON.stringify(['firmware', 'status'])) return { data: h.statusResponse };
+    if (key === JSON.stringify(['firmware', 'releases']))
+      return { data: { success: true, releases: [], channel: 'stable' } };
+    if (key === JSON.stringify(['firmware', 'backups']))
+      return { data: { success: true, backups: [] } };
+    return { data: undefined };
+  },
+  useQueryClient: () => ({
+    getQueryData: () => undefined,
+    invalidateQueries: vi.fn(),
+    removeQueries: vi.fn(),
+    setQueryData: vi.fn(),
+  }),
+}));
+
+vi.mock('../../hooks/useCsrfFetch', () => ({ useCsrfFetch: () => h.csrfFetch }));
+vi.mock('../ToastContainer', () => ({ useToast: () => ({ showToast: h.showToast }) }));
+vi.mock('../../hooks/usePoll', () => ({ usePoll: () => ({ data: h.pollData }) }));
+vi.mock('../../contexts/DataContext', () => ({
+  useData: () => ({ setConnectionStatus: vi.fn() }),
+}));
+
+import FirmwareUpdateSection from './FirmwareUpdateSection';
+
+const resp = (status: number, body: unknown) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+});
+
+const HALF_FLASH_409 = {
+  success: false,
+  error:
+    'Node "!9ea3e00c" is flagged as half-flashed from a previous OTA attempt. ' +
+    'Recover via USB, then DELETE /api/firmware/recovery-marker/!9ea3e00c to clear the flag.',
+};
+
+beforeEach(() => {
+  h.csrfFetch.mockReset();
+  h.showToast.mockReset();
+  h.pollData.connection = { connected: true, nodeResponsive: true };
+});
+
+describe('FirmwareUpdateSection — half-flash recovery panel (issue #3413)', () => {
+  it('shows the inline recovery panel (not a raw toast) when confirm returns the 409', async () => {
+    h.csrfFetch.mockImplementation((url: string) => {
+      if (url.includes('/update/confirm')) return Promise.resolve(resp(409, HALF_FLASH_409));
+      return Promise.resolve(resp(200, {}));
+    });
+
+    render(<FirmwareUpdateSection baseUrl="" />);
+    fireEvent.click(screen.getByText('Confirm & Proceed'));
+
+    await screen.findByText('Device flagged as half-flashed');
+    // The raw "DELETE /api/..." instruction is NOT surfaced as a toast.
+    expect(h.showToast).not.toHaveBeenCalled();
+  });
+
+  it('online node: the clear-and-retry button is enabled and re-runs confirm after clearing', async () => {
+    let confirmCalls = 0;
+    let deletedUrl = '';
+    h.csrfFetch.mockImplementation((url: string, opts?: { method?: string }) => {
+      if (url.includes('/update/confirm')) {
+        confirmCalls += 1;
+        return Promise.resolve(confirmCalls === 1 ? resp(409, HALF_FLASH_409) : resp(200, { success: true }));
+      }
+      if (opts?.method === 'DELETE' && url.includes('/recovery-marker/')) {
+        deletedUrl = url;
+        return Promise.resolve(resp(200, { success: true, removed: 1 }));
+      }
+      return Promise.resolve(resp(200, {}));
+    });
+
+    render(<FirmwareUpdateSection baseUrl="" />);
+    fireEvent.click(screen.getByText('Confirm & Proceed'));
+
+    const clearBtn = await screen.findByText("I've Recovered via USB — Clear Flag & Retry");
+    expect((clearBtn as HTMLButtonElement).disabled).toBe(false);
+    expect(
+      screen.getByText('Node is online and accepting connections — it appears to have recovered.')
+    ).toBeTruthy();
+
+    fireEvent.click(clearBtn);
+
+    await waitFor(() => expect(confirmCalls).toBe(2));
+    // Marker cleared for the encoded nodeId, then the confirm step re-ran.
+    expect(deletedUrl).toContain('/recovery-marker/');
+    expect(deletedUrl).toContain(encodeURIComponent('!9ea3e00c'));
+  });
+
+  it('offline node: the clear-and-retry button is disabled and the offline hint is shown', async () => {
+    h.pollData.connection = { connected: false, nodeResponsive: false };
+    h.csrfFetch.mockImplementation((url: string) => {
+      if (url.includes('/update/confirm')) return Promise.resolve(resp(409, HALF_FLASH_409));
+      return Promise.resolve(resp(200, {}));
+    });
+
+    render(<FirmwareUpdateSection baseUrl="" />);
+    fireEvent.click(screen.getByText('Confirm & Proceed'));
+
+    const clearBtn = await screen.findByText("I've Recovered via USB — Clear Flag & Retry");
+    expect((clearBtn as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      screen.getByText(
+        'Node is not online and accepting connections yet. Recover it via USB and wait for it to reconnect.'
+      )
+    ).toBeTruthy();
+  });
+});

--- a/src/components/configuration/FirmwareUpdateSection.tsx
+++ b/src/components/configuration/FirmwareUpdateSection.tsx
@@ -130,6 +130,13 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
     (gatewayInfo.sourceType === null || gatewayInfo.sourceType === 'meshtastic_tcp') &&
     !!gatewayInfo.gatewayIp;
 
+  // Issue #3413: a node is considered recovered/reachable only when MeshMonitor
+  // currently has a live connection AND the node is answering. This gates the
+  // half-flash recovery action below — clearing the safety marker should only
+  // happen once the device is actually back online and accepting connections.
+  const connection = pollData?.connection;
+  const isGatewayOnline = !!(connection?.connected && connection?.nodeResponsive);
+
   // Local state
   const [channel, setChannel] = useState<FirmwareChannel>('stable');
   const [customUrl, setCustomUrl] = useState('');
@@ -137,6 +144,11 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
   const [isSavingChannel, setIsSavingChannel] = useState(false);
   const [showRejectedFiles, setShowRejectedFiles] = useState(false);
   const [isConfirming, setIsConfirming] = useState(false);
+  // Issue #3413: when Safety Rail 5 (half-flash marker) blocks an OTA, hold the
+  // affected nodeId so the wizard can show an inline recovery panel instead of
+  // surfacing the raw "DELETE /api/firmware/recovery-marker/..." toast.
+  const [halfFlashedNodeId, setHalfFlashedNodeId] = useState<string | null>(null);
+  const [isClearingMarker, setIsClearingMarker] = useState(false);
 
   // Ref for auto-scrolling logs
   const logRef = useRef<HTMLPreElement>(null);
@@ -290,6 +302,13 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
           queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
           return;
         }
+        // Issue #3413: Safety Rail 5 blocked the flash because the node is
+        // flagged half-flashed. Surface an inline recovery panel instead of the
+        // raw API instructions so non-technical users can recover in one click.
+        if (res.status === 409 && data.error?.includes('half-flashed')) {
+          setHalfFlashedNodeId(gatewayInfo.nodeId);
+          return;
+        }
         throw new Error(data.error || 'Failed to confirm step');
       }
       queryClient.invalidateQueries({ queryKey: ['firmware', 'status'] });
@@ -300,7 +319,46 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
     }
   };
 
+  // Issue #3413: clear the half-flash safety marker after a USB recovery, then
+  // re-trigger the blocked confirm step. Includes a basic "node is online and
+  // accepting connections" guard so the marker can't be cleared while the
+  // device is still unreachable — the marker exists to protect a node that may
+  // still be corrupted, so we require evidence it has actually recovered.
+  const handleClearMarkerAndRetry = async () => {
+    if (!halfFlashedNodeId || isClearingMarker) return;
+    if (!isGatewayOnline) {
+      showToast(
+        t(
+          'firmware.recovery_not_online',
+          'Node is not online and accepting connections yet. Recover it via USB and wait for it to reconnect before clearing the flag.'
+        ),
+        'error'
+      );
+      return;
+    }
+    setIsClearingMarker(true);
+    try {
+      const res = await csrfFetch(
+        `${baseUrl}/api/firmware/recovery-marker/${encodeURIComponent(halfFlashedNodeId)}`,
+        { method: 'DELETE' }
+      );
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Failed to clear recovery flag');
+      }
+      showToast(t('firmware.recovery_cleared', 'Recovery flag cleared'), 'success');
+      setHalfFlashedNodeId(null);
+      // Re-run the preflight confirm now that the marker is gone.
+      await handleConfirm();
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Error clearing recovery flag', 'error');
+    } finally {
+      setIsClearingMarker(false);
+    }
+  };
+
   const handleCancel = async () => {
+    setHalfFlashedNodeId(null);
     try {
       const res = await csrfFetch(`${baseUrl}/api/firmware/update/cancel`, {
         method: 'POST',
@@ -317,6 +375,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
   };
 
   const handleDone = async () => {
+    setHalfFlashedNodeId(null);
     const wasSuccess = effectiveStatus?.state === 'success';
     try {
       if (wasSuccess) {
@@ -759,8 +818,74 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
             </p>
           )}
 
+          {/* Half-flash recovery panel (issue #3413) — replaces the raw
+              "DELETE /api/firmware/recovery-marker/..." toast with a guided,
+              one-click recovery flow that checks the node is back online. */}
+          {halfFlashedNodeId && (
+            <div style={{
+              padding: '0.75rem',
+              borderRadius: '6px',
+              backgroundColor: 'rgba(250, 179, 40, 0.1)',
+              border: '1px solid var(--ctp-peach)',
+              color: 'var(--ctp-text)',
+              fontSize: '0.85rem',
+              marginBottom: '0.75rem',
+              lineHeight: '1.5',
+            }}>
+              <strong>
+                {t('firmware.recovery_title', 'Device flagged as half-flashed')}
+              </strong>
+              <p style={{ margin: '0.5rem 0' }}>
+                {t(
+                  'firmware.recovery_explanation',
+                  'A previous OTA attempt did not finish, so MeshMonitor flagged this node to prevent another flash on a possibly corrupted device. Recover it via a USB-tethered flash first. Once it is back online, clear the flag below to retry.'
+                )}
+              </p>
+              {/* Live "online and accepting connections" indicator */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.45rem', marginTop: '0.5rem' }}>
+                <span style={{
+                  width: '10px',
+                  height: '10px',
+                  borderRadius: '50%',
+                  backgroundColor: isGatewayOnline ? '#10b981' : 'var(--ctp-red)',
+                  flexShrink: 0,
+                }} />
+                <span>
+                  {isGatewayOnline
+                    ? t('firmware.recovery_online', 'Node is online and accepting connections — it appears to have recovered.')
+                    : t('firmware.recovery_offline', 'Node is not online and accepting connections yet. Recover it via USB and wait for it to reconnect.')}
+                </span>
+              </div>
+            </div>
+          )}
+
           {/* Action buttons */}
           <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+            {halfFlashedNodeId ? (
+              <>
+                <button
+                  className="save-button"
+                  onClick={handleClearMarkerAndRetry}
+                  disabled={!isGatewayOnline || isClearingMarker}
+                  title={
+                    !isGatewayOnline
+                      ? t(
+                          'firmware.recovery_not_online',
+                          'Node is not online and accepting connections yet. Recover it via USB and wait for it to reconnect before clearing the flag.'
+                        )
+                      : undefined
+                  }
+                >
+                  {isClearingMarker
+                    ? '⏳ Working...'
+                    : t('firmware.recovery_clear_retry', "I've Recovered via USB — Clear Flag & Retry")}
+                </button>
+                <button className="danger-button" onClick={handleCancel}>
+                  {t('firmware.wizard_cancel', 'Cancel Update')}
+                </button>
+              </>
+            ) : (
+              <>
             {effectiveStatus.state === 'awaiting-confirm' && (
               <button className="save-button" onClick={handleConfirm} disabled={isConfirming}>
                 {isConfirming ? '⏳ Working...' : t('firmware.wizard_confirm', 'Confirm & Proceed')}
@@ -786,6 +911,8 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
                 <button className="save-button" onClick={handleDone}>
                   Dismiss
                 </button>
+              </>
+            )}
               </>
             )}
           </div>


### PR DESCRIPTION
Closes #3413

## Problem

When an OTA firmware flash fails mid-stream, MeshMonitor writes a half-flash marker as a safety rail. On the next flash attempt, **Safety Rail 5** returns an HTTP 409 and the frontend surfaced the raw message as a toast:

> Node "!9ea3e00c" is flagged as half-flashed from a previous OTA attempt. Recover via USB, then DELETE /api/firmware/recovery-marker/!9ea3e00c to clear the flag.

Telling a non-technical user to make an API call is a dead end — exactly the friction the issue reporter hit.

## Solution

A guided inline recovery panel inside the firmware wizard (frontend-only — the `DELETE /api/firmware/recovery-marker/:nodeId` endpoint already existed and is now wired to UI).

- **Detect the 409** in `handleConfirm` and store the affected `nodeId` instead of throwing a toast.
- **Recovery panel** explains the safety rail and shows a live **"node is online and accepting connections"** indicator derived from the poll connection state (`connected && nodeResponsive`).
- **"I've Recovered via USB — Clear Flag & Retry"** button clears the marker and auto-re-runs the confirm step.

### Online check (per request)

The clear button is gated on the online check **two ways**:
- `disabled={!isGatewayOnline || isClearingMarker}` with an explanatory tooltip, and
- a re-check inside `handleClearMarkerAndRetry` before the `DELETE` fires.

This keeps the safety intent of the marker intact — it can't be cleared while the device is still unreachable — while removing all friction for a node that has already recovered (green status + enabled button).

## Files | File | Change |
|------|--------|
| `src/components/configuration/FirmwareUpdateSection.tsx` | Detect 409, recovery panel, online-gated clear handler |
| `public/locales/en.json` | 7 new `firmware.recovery_*` keys (English source; rest via Weblate) |
| `src/components/configuration/FirmwareUpdateSection.recovery.test.tsx` | New test: panel on 409, online→enabled+re-confirm, offline→disabled+hint |

## Testing

- Full Vitest suite: **6249 passed, 0 failed**
- `tsc --noEmit`: clean
- ESLint on changed files: 0 errors (2 pre-existing warnings, untouched lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)