### PR TITLE
fix(meshcore): decode packed out_path_len to fix 2-byte hash hop count (#3421)

### DIFF
--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -861,6 +861,40 @@ describe('MeshCoreNativeBackend', () => {
     expect(resp.data[2]).toEqual(expect.objectContaining({ out_path: '', path_len: 0 }));
   });
 
+  it('get_contacts decodes 2-byte hash paths correctly (issue #3421)', async () => {
+    // Firmware with PATH_HASH_SIZE=2 stores outPathLen as a packed byte:
+    // top 2 bits = hash_size-1 (0x01 for 2 bytes), bottom 6 bits = hop count.
+    // 4 hops with 2-byte hashes: (1 << 6) | 4 = 0x44 = 68.
+    // Before the fix, this was treated as 68 byte-count with 1-byte hashes,
+    // reading all 64 bytes and producing 8 non-zero hops instead of 4.
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    const pubKey = new Uint8Array(32);
+    pubKey[0] = 0xcc;
+    const outPath = new Uint8Array(64);
+    // 4 hops × 2 bytes: 8542 8960 8940 8920
+    outPath[0] = 0x85; outPath[1] = 0x42;
+    outPath[2] = 0x89; outPath[3] = 0x60;
+    outPath[4] = 0x89; outPath[5] = 0x40;
+    outPath[6] = 0x89; outPath[7] = 0x20;
+    conn.contactsResponse = [{
+      publicKey: pubKey, type: AdvType.Chat, advName: 'Carol',
+      outPath, outPathLen: 68, // packed: (1 << 6) | 4 = 68
+      advLat: 0, advLon: 0, lastAdvert: 1700000000,
+    }];
+
+    const resp = await backend.sendCommand('get_contacts', {});
+    expect(resp.success).toBe(true);
+    expect(resp.data[0]).toEqual(expect.objectContaining({
+      out_path: '8542,8960,8940,8920',
+      path_len: 4,
+    }));
+  });
+
   it('reset_path forwards the resolved pubkey to the connection', async () => {
     const backend = new MeshCoreNativeBackend('src-1', {
       connectionType: 'serial',

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -115,10 +115,11 @@ function bytesToHex(bytes: Uint8Array | number[]): string {
  * an inflated `outPathLen` (e.g. the full 64) with trailing 0x00 padding;
  * all-zero hop chunks are skipped and `pathLen` reflects only real hops.
  *
- * Note: MeshCore OTA packets pack hop hash width into the top 2 bits of the
- * single `path_len` byte (`@liamcottle/meshcore.js/src/packet.js`), but
- * contact records read `outPathLen` as a plain Int8 byte count, so we accept
- * the width as an explicit parameter rather than decoding it from outPathLen.
+ * Note: Both MeshCore OTA packets and companion contact records use the same
+ * packed `path_len` byte format: top 2 bits = hash_size−1, bottom 6 bits =
+ * hop_count. Callers that read this packed byte (e.g. `get_contacts`) must
+ * decode it into a byte count + hash size before calling this function; the
+ * function itself treats `outPathLen` as a plain byte count.
  */
 export function formatOutPath(
   outPath: Uint8Array | number[] | null | undefined,
@@ -758,7 +759,19 @@ export class MeshCoreNativeBackend extends EventEmitter {
       case 'get_contacts': {
         const contacts: any[] = await c.getContacts();
         return contacts.map((ct) => {
-          const { outPathHex, pathLen } = formatOutPath(ct.outPath, ct.outPathLen);
+          // ct.outPathLen is the packed wire byte (same format as OTA path_len):
+          // top 2 bits = hash_size−1, bottom 6 bits = hop_count. Decode it so
+          // formatOutPath receives a plain byte count + the correct hop width.
+          // Negative values and 0 fall through to formatOutPath unchanged
+          // (it handles 0 as "direct" and negatives as OUT_PATH_UNKNOWN).
+          const rawLen = ct.outPathLen as number;
+          let hopHashBytes: 1 | 2 | 3 = 1;
+          let outPathByteCount: number | null | undefined = rawLen;
+          if (rawLen != null && rawLen > 0) {
+            hopHashBytes = (((rawLen >> 6) & 0x03) + 1) as 1 | 2 | 3;
+            outPathByteCount = (rawLen & 0x3F) * hopHashBytes;
+          }
+          const { outPathHex, pathLen } = formatOutPath(ct.outPath, outPathByteCount, hopHashBytes);
           return {
             public_key: bytesToHex(ct.publicKey),
             adv_name: ct.advName,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #3421 — contact paths on devices with `PATH_HASH_SIZE=2` (or 3) were showing double the actual hop count (e.g. 8 hops when there were really 4).

**Root cause:** The MeshCore firmware stores `out_path_len` in contact records as the same packed byte used in OTA `path_len` frames: top 2 bits = `hash_size − 1`, bottom 6 bits = `hop_count`. The `get_contacts` handler in `meshcoreNativeBackend.ts` was passing this raw byte directly to `formatOutPath()` without decoding it, defaulting to `hopHashBytes = 1`.

For a device with 2-byte hashes and 4 hops, the packed byte is `(1 << 6) | 4 = 68`. With `hopHashBytes = 1`, the code read up to 64 bytes from the path buffer and found 8 non-zero bytes → displayed as 8 hops instead of 4.

**Fix:** Decode the packed byte in the `get_contacts` case before calling `formatOutPath`, extracting the true hash width and hop count. 1-byte-hash deployments are unaffected (for hash_size=1, the packed value coincidentally equals the byte count).

## Changes

- `src/server/meshcoreNativeBackend.ts` — decode `ct.outPathLen` as a packed byte in `get_contacts`; update `formatOutPath` docblock to accurately describe the packed format
- `src/server/meshcoreNativeBackend.test.ts` — add regression test with the exact path bytes from the issue report (`outPathLen: 68` → `8542,8960,8940,8920`, 4 hops)

## Test plan

- [ ] All existing `meshcoreNativeBackend` tests pass (48 tests)
- [ ] New test: `get_contacts decodes 2-byte hash paths correctly (issue #3421)` passes
- [ ] Full Vitest suite: no new failures (3 pre-existing failures in `mqttBrokerManager.test.ts` are unrelated)
- [ ] Manually verify with a device configured for `PATH_HASH_SIZE=2` that Contact Details shows the correct hop count

https://claude.ai/code/session_01AN8K4UPtKq3DGty84KURXB
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AN8K4UPtKq3DGty84KURXB)_