### PR TITLE
fix(ui): auto-favorite checkboxes beside labels, not stacked

### DIFF
--- a/src/components/admin-commands/AutoFavoriteManagementSection.tsx
+++ b/src/components/admin-commands/AutoFavoriteManagementSection.tsx
@@ -165,15 +165,17 @@ const AutoFavoriteManagementSection: React.FC<AutoFavoriteManagementSectionProps
 
   const checkboxRow = (label: string, description: string, checked: boolean, onChange: (v: boolean) => void) => (
     <div className="setting-item">
-      <label style={{ display: 'flex', alignItems: 'flex-start', gap: '0.6rem', cursor: 'pointer' }}>
+      {/* flexDirection:'row' overrides the global `.setting-item label`
+          column layout so the checkbox sits beside the label, not above it. */}
+      <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '0.6rem', cursor: 'pointer', marginBottom: 0 }}>
         <input
           type="checkbox"
           checked={checked}
           onChange={(e) => onChange(e.target.checked)}
-          style={{ marginTop: '0.25rem' }}
+          style={{ marginTop: '0.2rem', flexShrink: 0 }}
         />
-        <span>
-          {label}
+        <span style={{ display: 'flex', flexDirection: 'column', gap: '0.2rem' }}>
+          <span>{label}</span>
           <span className="setting-description">{description}</span>
         </span>
       </label>


### PR DESCRIPTION
## Summary

Fixes the layout of the **Automatic Favorites Management** section on the Remote Admin tab. The checkboxes ("Enable automatic favorites management", "Use NeighborInfo", "Use Traceroutes") rendered **stacked above** their labels, and each label's text ran straight into its description with no separation.

| | |
|---|---|
| **Before** | ☐ on its own line, then `Use NeighborInfoPeriodically request…` jammed below |
| **After** | `☑  Use NeighborInfo` with the description on its own line beneath the label |

## Cause

The global rule `.setting-item label { display: flex; flex-direction: column }` (`src/styles/settings.css:102`) forces a label's children to stack. The component's `checkboxRow` set `display: flex` inline but **not** `flex-direction`, so it inherited `column` from the stylesheet and stacked the checkbox above the text.

## Fix

In `checkboxRow` (`src/components/admin-commands/AutoFavoriteManagementSection.tsx`):
- Set `flexDirection: 'row'` so the checkbox sits beside the text.
- Wrap label + description in a stacked column span with a small gap.
- `flexShrink: 0` on the checkbox so it isn't squished by long descriptions.

Number inputs and the role checkboxes were already laying out correctly and are untouched.

## Verification

- `npm run typecheck` ✅
- Pure inline-style/layout change (no logic). Verified visually in the dev container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
