### PR TITLE
release: v4.10.1 — Automated Remote Favorites Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.10.1] - 2026-06-11
+
 ### Features
 
+- **Automated Remote Favorites Management (#2608)**: A new **Automatic Favorites Management** section on a node's Remote Admin page keeps the favorites list up to date on remote infrastructure nodes — preserving Meshtastic's zero-hop cost between favorited routers as the mesh changes, without site visits or blind CLI spamming. Per target, MeshMonitor discovers the node's direct neighbors from its **NeighborInfo** broadcasts and/or from **traceroutes that pass through it**, filters them to a configurable set of eligible roles (default Router / Router Late / Client Base), and sends `set-favorite` admin commands on a schedule (default every 24h), capped per cycle for newly-discovered (default 1) and re-asserted (default 1) favorites. Favorite commands are **confirmed**: MeshMonitor captures the firmware's routing ACK and surfaces the result per favorite (confirmed / no-ack / rejected) on both the automatic ledger and the manual **Set/Remove Favorite** buttons — and the re-favorite pass prioritizes un-confirmed assignments to recover any whose command was dropped. A **Maximum neighbor age** setting (default 24h) reuses an on-file NeighborInfo record instead of re-requesting one when it's recent enough, saving airtime. (Migrations 084–086.)
+- **Guided firmware half-flash recovery (#3413)**: A guided recovery flow for a device left in a half-flashed state, with an online connectivity check before recovery is attempted.
 - **Disable link previews (privacy)** (#3416): A global **Settings → Link Previews** toggle ("Show link previews") controls whether MeshMonitor fetches and renders OpenGraph preview cards for URLs in messages. When off, no outbound request is ever made to a link target — URLs still render as clickable text. The toggle is enforced at three layers: the `/api/link-preview` endpoint refuses to fetch (403), the `LinkPreview` component renders nothing and skips the request, and operators can hard-disable instance-wide via the `LINK_PREVIEWS_ENABLED=false` environment variable (which overrides the UI). Previews (and the toggle) now apply consistently across **all** message surfaces — Meshtastic and MQTT channels & DMs, the Unified messaging view, and MeshCore channels & DMs. Defaults to enabled, preserving existing behavior.
 - **Per-channel notification sounds**: The in-app "new message" audio notification is now selectable per channel. A new picker under **Settings → Notifications & Security** (shown when "Enable Audio Notifications" is on) lists each channel with a dropdown of bundled sounds — five standard tones (Classic Ding, Soft Chime, Classic Beep, Ping, Marimba Blip) and four fun ones (8-bit Coin, Ascending Arpeggio, Boop, Radio Squelch) — plus a **Silent** option and a **Preview** button. Every sound is synthesized at runtime from Web Audio oscillators (no audio files and no third-party samples, so the whole set is original/public-domain). Selections persist per channel in `localStorage`, the direct-message pseudo-channel has its own row (Meshtastic sources only), selections are scoped per source so the same channel number on two sources stays independent, and the default (Classic Ding) reproduces the previous hard-coded 800 Hz ding so existing behavior is unchanged for anyone who doesn't customize.
+
+### Bug Fixes
+
+- **Per-channel notification sounds: DM row + per-source scoping (#3414)**: Wired up the direct-message sound row and scoped channel-sound selections per source so the same channel number on two sources stays independent.
+- **MeshCore hop-count decode**: The packed `out_path_len` is now decoded correctly, fixing the hop count for 2-byte path hashes on MeshCore contacts.
+- **Auto-favorite checkbox layout (#3423)**: The Automatic Favorites Management checkboxes now sit beside their labels instead of above them.
 
 ## [4.10.0] - 2026-06-10
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.10.0",
+  "version": "4.10.1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/blog/2026-06-11-v4.10.1-remote-favorites.md
+++ b/docs/blog/2026-06-11-v4.10.1-remote-favorites.md
@@ -1,0 +1,68 @@
+---
+id: news-2026-06-11-v4-10-1-remote-favorites
+title: MeshMonitor v4.10.1 - Automated Remote Favorites Management
+date: '2026-06-11T18:00:00Z'
+category: release
+priority: normal
+minVersion: 4.10.1
+tags: [release, automation, remote-admin, favorites]
+---
+MeshMonitor **v4.10.1** lands a feature that's been a recurring pain point for anyone running infrastructure: **keeping the favorites list current on routers you can't physically reach.**
+
+## Why favorites matter (and why they're a chore)
+
+Meshtastic gives you a **zero-hop cost between favorited routers** — a real, measurable routing benefit. But that only holds if each router's favorites list actually reflects its current neighbors. As a mesh grows, keeping that list up to date means either walking to the node and managing it over Bluetooth, or spamming `meshtastic --set-favorite-node` from a terminal with no visual confirmation. Neither scales.
+
+## Automatic Favorites Management
+
+v4.10.1 adds an **Automatic Favorites Management** section to a node's **Remote Admin** page. Point it at a remote router or base station you administer, and MeshMonitor keeps that node's favorites list current for you.
+
+Each cycle (default: once every 24 hours), it:
+
+1. **Discovers the target's direct neighbors** — from the node's own **NeighborInfo** broadcasts, from **traceroutes that pass through it**, or both.
+2. **Filters** to the roles worth favoriting — Router, Router Late, and Client Base by default, fully configurable.
+3. **Favorites the new ones** and **re-asserts a few existing ones**, with per-cycle caps (default 1 each) so it stays a polite citizen of the mesh.
+
+It's a heavy operation — every favorite is several packets plus a session-passkey handshake — so the defaults are deliberately conservative. Set it and let it tick along in the background.
+
+## "Wait, you *do* get an ACK"
+
+The original design assumed favorite commands were fire-and-forget over LoRa — sent blindly, with no confirmation. Then users told us that wasn't true: setting a remote favorite **does** come back acknowledged.
+
+They were right. We went into the Meshtastic firmware to confirm exactly what happens, and it turns out MeshMonitor's admin packets already request a response — so the target node's `AdminModule` returns an explicit **routing ACK** after it processes the command. We were simply throwing that ACK away.
+
+Now we capture it. Every favorite shows its result:
+
+- **✓ confirmed** — the remote received, authorized, and processed the command.
+- **⏱ no ack** — nothing came back in time (it may still have applied).
+- **✕ rejected** — the remote refused it (e.g. a bad/expired session key).
+
+The same confirmation now appears as a toast on the **manual** Set Favorite / Remove Favorite buttons in Node Management, too — so even one-off remote favorites tell you whether they stuck.
+
+One honest caveat we kept visible in the UI: an ACK proves the remote *processed* the request. If the favorited node isn't in the remote's node database yet, the firmware accepts and ACKs the command but the favorite is a no-op there until that node is known. That's exactly why the **re-favorite** pass exists — it re-sends previously assigned favorites, un-confirmed ones first, to recover anything that didn't stick.
+
+## Saving airtime: Maximum neighbor age
+
+NeighborInfo discovery doesn't need to ask the mesh for fresh data every single cycle. A new **Maximum neighbor age** setting (default 24 hours) tells MeshMonitor to **reuse an on-file NeighborInfo record** if it's newer than that window, instead of spending airtime on another request. Set it to `0` to always request fresh.
+
+## Also in 4.10.1
+
+- **Disable link previews (#3416):** a global **Settings → Link Previews** toggle (and a `LINK_PREVIEWS_ENABLED=false` env override) that stops MeshMonitor from making any outbound request to render OpenGraph cards — across every message surface, Meshtastic, MQTT, and MeshCore. Defaults to on, so nothing changes unless you turn it off.
+- **Per-channel notification sounds:** pick a different "new message" tone per channel from a bundled set of nine original, runtime-synthesized sounds (plus Silent and a Preview button), scoped per source.
+- **Guided firmware half-flash recovery (#3413):** a guided flow to recover a device left in a half-flashed state, with an online check before it tries.
+
+Plus fixes to MeshCore hop-count decoding, the direct-message notification-sound row, and the favorites checkbox layout.
+
+## Upgrade
+
+```bash
+# Docker
+docker pull ghcr.io/yeraze/meshmonitor:4.10.1
+docker compose down && docker compose up -d
+
+# Helm
+helm repo update
+helm upgrade meshmonitor meshmonitor/meshmonitor --version 4.10.1
+```
+
+Desktop builds are on the [Releases page](https://github.com/Yeraze/meshmonitor/releases/tag/v4.10.1).

--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -1898,6 +1898,68 @@ Nodes must also:
 
 ---
 
+## Automatic Favorites Management (Remote) {#remote-favorites}
+
+Keeps the favorites list up to date **on a remote infrastructure node you administer** — preserving Meshtastic's zero-hop cost between favorited routers as your mesh grows, without site visits or blind CLI spamming.
+
+This is distinct from [Auto Favorite](#auto-favorite) above: that feature manages favorites on *your own* locally-connected node. Automatic Favorites Management runs over [Remote Admin](#remote-admin-scanner) and manages the favorites list on *another* node — typically a router or base station two hops away that you can't easily reach.
+
+You configure it per target node in the **Automatic Favorites Management** section of the **Remote Admin** tab (select the target node, then scroll to the section).
+
+### How It Works
+
+Each enabled target runs a "cycle" no more often than its configured interval (default 24 hours). A cycle:
+
+1. **Discovers the target's direct neighbors** from one or both sources:
+   - **Use NeighborInfo** — the nodes the target reports in its NeighborInfo broadcasts.
+   - **Use Traceroutes** — the nodes immediately adjacent to the target in any traceroute that passes through it.
+2. **Filters** the candidates to the configured eligible roles (default Router / Router Late / Client Base — the roles that benefit from zero-hop favoriting). The controlling (local) node is eligible too if it shows up as a direct neighbor.
+3. **Favorites** up to *Maximum new neighbors per cycle* newly-discovered nodes by sending `set-favorite` admin commands to the target, and **re-asserts** up to *Maximum re-favorite per cycle* previously-assigned favorites.
+
+### Acknowledged, not blind
+
+Favorite commands sent over Remote Admin request a response, so the target node returns a **routing ACK**. MeshMonitor captures it and shows the result per favorite:
+
+- **✓ confirmed** — the target received, authorized, and processed the command.
+- **⏱ no ack** — no acknowledgement arrived within the timeout (it may still have applied).
+- **✕ &lt;error&gt;** — the target rejected the command (e.g. `ADMIN_BAD_SESSION_KEY`).
+
+The same confirmation is shown as a toast on the manual **Set Favorite** / **Remove Favorite** buttons in Node Management.
+
+> **Caveat:** an ACK confirms the *remote processed the request*. If the favorited node is not yet in the remote node's database, the firmware accepts and ACKs the command but the favorite is a no-op there until that node is known. This is why the **re-favorite** pass exists — it re-sends previously assigned favorites (un-confirmed ones first) to recover any whose command was dropped or didn't stick.
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Enable | Run discovery + favorite cycles for this target on the schedule below | Off |
+| Use NeighborInfo | Discover neighbors from the target's NeighborInfo broadcasts (target must have the NeighborInfo module enabled) | On |
+| Use Traceroutes | Discover neighbors from traceroutes that pass through the target | On |
+| Cycle interval (hours) | How often to run a favorite cycle | 24 |
+| Maximum neighbor age (hours) | Reuse an on-file NeighborInfo record newer than this instead of requesting a fresh one (0 = always request) | 24 |
+| Maximum new neighbors per cycle | Cap on how many newly-discovered neighbors are favorited each cycle | 1 |
+| Maximum re-favorite per cycle | How many previously-assigned favorites are re-asserted each cycle | 1 |
+| Eligible neighbor roles | Which roles are favorited (multi-select) | Router, Router Late, Client Base |
+
+A **Run Cycle Now** button triggers one cycle immediately for the selected target (useful for testing).
+
+### Requirements
+
+- **Remote Admin access** to the target node (a session passkey is negotiated automatically; see [Remote Admin Scanner](#remote-admin-scanner)).
+- Local device firmware **≥ 2.7.0** (favorites support).
+- For NeighborInfo discovery, the **NeighborInfo module must be enabled** on the target node.
+
+### Side Effects
+
+- **Heavy operation**: each favorite is multiple packets per transaction (including a session-passkey handshake) plus a wait for the ACK. Keep the per-cycle limits low and the interval long, and use it sparingly.
+- **Airtime**: discovery requests and favorite commands use admin-channel airtime on the path to the target.
+
+### Permissions
+
+- Configuring Automatic Favorites Management requires **admin** access (the Remote Admin tab).
+
+---
+
 ## Ignored Nodes {#ignored-nodes}
 
 Manages the persistent ignore list for nodes you want to exclude from your mesh monitoring. Ignored nodes are hidden from the node list and stay ignored permanently — whenever a listed node reappears without the ignore flag, MeshMonitor re-applies it automatically. This covers both inactive-node cleanup and the case where the device's own node database fills up and silently clears the ignore (see [#2601](https://github.com/Yeraze/meshmonitor/issues/2601)).

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.10.0
-appVersion: "4.10.0"
+version: 4.10.1
+appVersion: "4.10.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.10.0",
+      "version": "4.10.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Release v4.10.1

Version bump + documentation for the **Automated Remote Favorites Management** feature (and the other changes landed since 4.10.0).

### Version bump (5 files)
`package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml` (version + appVersion), `desktop/package.json`, `desktop/src-tauri/tauri.conf.json` → **4.10.1**.

### Documentation
- **CHANGELOG.md** — cut `[4.10.1]`. Headline: Automated Remote Favorites Management (#2608, migrations 084–086); also guided firmware half-flash recovery (#3413), disable link previews (#3416), per-channel notification sounds, and fixes (MeshCore hop-count decode, DM sound row, favorites checkbox layout).
- **docs/features/automation.md** — new **"Automatic Favorites Management (Remote)"** section: discovery via NeighborInfo/traceroutes, role filtering, the routing-ACK confirmation model (confirmed / no-ack / rejected + the node-unknown caveat), the new Maximum neighbor age reuse, full configuration table, requirements, side effects, and permissions. Renders on the VitePress site (meshmonitor.org).
- **Blog** — `docs/blog/2026-06-11-v4.10.1-remote-favorites.md` walking through the feature, including the "you actually *do* get an ACK" story and the airtime-saving neighbor-age reuse.

### Validation
- All 5 version strings verified consistent at 4.10.1 (lockfile regenerated via `npm install --package-lock-only`).
- `npm run docs:build` (VitePress) completes cleanly with the new content.
- In-app news feed (`docs/public/news.json`, gitignored) regenerates with the new post.

### System tests
This PR carries the **`system-test`** label to run the hardware system-test suite, per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)