### PR TITLE
fix: restore GeoJSON popup padding in embed dark theme

### DIFF
--- a/src/components/EmbedMap.tsx
+++ b/src/components/EmbedMap.tsx
@@ -637,11 +637,11 @@ const embedPopupCss = `
     border: 1px solid #313244 !important;
     border-radius: 8px !important;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4) !important;
-    padding: 0 !important;
+    padding: 1px !important;
   }
 
   .leaflet-popup-content {
-    margin: 0 !important;
+    margin: 13px 19px !important;
     color: #cdd6f4 !important;
   }
 


### PR DESCRIPTION
## Summary

Fixes #3429.

The embed map view (`/embed/:profileId`) injected a dark popup theme that zeroed out all Leaflet popup spacing:

- `.leaflet-popup-content-wrapper { padding: 0 !important }` — removed the 1px wrapper border inset
- `.leaflet-popup-content { margin: 0 !important }` — removed the content spacing so text touched the edges

This caused GeoJSON click-popup content to render flush against the border in the embed view, while the main app's popups looked correctly padded (it never overrides the default `margin: 13px 24px 13px 20px`).

**Fix:** Restore Leaflet's default padding/margin values inside the embed's dark-theme overrides:
- `padding: 1px !important` on `.leaflet-popup-content-wrapper`
- `margin: 13px 19px !important` on `.leaflet-popup-content`

## Test plan

- [ ] Open an embed profile that has a GeoJSON layer with feature properties
- [ ] Click a GeoJSON feature — confirm the popup is dark-themed and has normal inner padding (text not flush against edges)
- [ ] Confirm hover tooltips are unaffected
- [ ] Confirm main app node/message popups are unaffected

https://claude.ai/code/session_01EiMw5KyttysVt1hurN1jxa

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiMw5KyttysVt1hurN1jxa)_