### PR TITLE
feat(helm): publish a Helm chart repository at meshmonitor.org/charts (#3431)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,6 +10,9 @@ on:
       - '.github/workflows/deploy-docs.yml'
       - 'package.json'
       - 'package-lock.json'
+      # Republish the Helm chart repository (served at /charts) when the chart changes.
+      - 'helm/**'
+      - 'scripts/build-helm-repo.sh'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -47,6 +50,14 @@ jobs:
 
       - name: Install dependencies
         run: npm install --legacy-peer-deps
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Build Helm chart repository (served at /charts)
+        run: bash scripts/build-helm-repo.sh
 
       - name: Build with VitePress
         run: npm run docs:build

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ scratch/
 # Generated news feed — rebuilt from docs/blog/ by scripts/blog-to-news.mjs
 # via the VitePress newsJsonPlugin (buildStart) on every docs:build/docs:dev.
 docs/public/news.json
+
+# Generated Helm chart repository — packaged from helm/meshmonitor by
+# scripts/build-helm-repo.sh during the docs deploy (served at /charts). See #3431.
+docs/public/charts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Features
+
+- **Helm chart repository (#3431)**: MeshMonitor now publishes a proper Helm repository at `https://meshmonitor.org/charts`, so you can install without cloning the repo — `helm repo add meshmonitor https://meshmonitor.org/charts && helm install meshmonitor meshmonitor/meshmonitor`. The chart is packaged and indexed by `scripts/build-helm-repo.sh` during the docs deploy and served from the existing docs site (no separate `gh-pages` branch). The repository tracks the latest released chart; older versions remain installable from a checkout at the matching tag.
+
 ## [4.10.1] - 2026-06-11
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -56,9 +56,12 @@ For detailed installation instructions, configuration options, and deployment sc
 
 ### Kubernetes / Helm
 
-Running on Kubernetes? MeshMonitor ships a Helm chart under [`helm/meshmonitor/`](helm/meshmonitor/):
+Running on Kubernetes? Add the MeshMonitor Helm repository and install — no checkout required:
 
 ```bash
+helm repo add meshmonitor https://meshmonitor.org/charts
+helm repo update
+
 # Minimal custom-values.yaml
 cat > custom-values.yaml << 'EOF'
 env:
@@ -66,8 +69,10 @@ env:
   meshtasticUseTls: "false"
 EOF
 
-helm install meshmonitor ./helm/meshmonitor -f custom-values.yaml
+helm install meshmonitor meshmonitor/meshmonitor -f custom-values.yaml
 ```
+
+> Prefer to install from a local checkout instead? `helm install meshmonitor ./helm/meshmonitor -f custom-values.yaml` still works against [`helm/meshmonitor/`](helm/meshmonitor/).
 
 See the [Helm Chart README](helm/README.md) for ingress, TLS, persistence, and the full values reference, or the [Helm Deployment Guide](https://meshmonitor.org/deployment/HELM_GUIDE.html) on the docs site.
 

--- a/docs/deployment/HELM_GUIDE.md
+++ b/docs/deployment/HELM_GUIDE.md
@@ -11,12 +11,14 @@ MeshMonitor ships a Helm chart for deploying to any Kubernetes 1.19+ cluster. Th
 
 ## Quick Start
 
-1. **Clone the repository** to get the chart sources:
+1. **Add the Helm repository:**
 
    ```bash
-   git clone --recurse-submodules https://github.com/Yeraze/meshmonitor.git
-   cd meshmonitor
+   helm repo add meshmonitor https://meshmonitor.org/charts
+   helm repo update
    ```
+
+   `helm search repo meshmonitor` lists the available chart versions. (Prefer to work from a checkout? `git clone --recurse-submodules https://github.com/Yeraze/meshmonitor.git` and use `./helm/meshmonitor` as the chart path in step 3.)
 
 2. **Create `custom-values.yaml`** with the required node settings:
 
@@ -29,7 +31,7 @@ MeshMonitor ships a Helm chart for deploying to any Kubernetes 1.19+ cluster. Th
 3. **Install the chart**:
 
    ```bash
-   helm install meshmonitor ./helm/meshmonitor -f custom-values.yaml
+   helm install meshmonitor meshmonitor/meshmonitor -f custom-values.yaml
    ```
 
 4. **Access the UI**. The default install creates a `ClusterIP` service; port-forward to reach it locally:
@@ -110,9 +112,11 @@ resources:
 ## Upgrading
 
 ```bash
-git pull
-helm upgrade meshmonitor ./helm/meshmonitor -f custom-values.yaml
+helm repo update
+helm upgrade meshmonitor meshmonitor/meshmonitor -f custom-values.yaml
 ```
+
+(From a checkout: `git pull && helm upgrade meshmonitor ./helm/meshmonitor -f custom-values.yaml`.)
 
 The chart `appVersion` is bumped on every MeshMonitor release; pin a specific image tag via `image.tag` if you need a stable target.
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -11,6 +11,23 @@ This Helm chart deploys MeshMonitor, a web application for monitoring Meshtastic
 
 ## Installation
 
+### From the Helm repository (recommended)
+
+MeshMonitor publishes a Helm repository at `https://meshmonitor.org/charts`, so you can install without cloning this repo:
+
+```bash
+helm repo add meshmonitor https://meshmonitor.org/charts
+helm repo update
+
+# See available chart versions
+helm search repo meshmonitor
+
+# Install (create custom-values.yaml first — see Quick Start below)
+helm install meshmonitor meshmonitor/meshmonitor -f custom-values.yaml
+```
+
+Pin a specific version with `--version <x.y.z>`. The repository tracks the latest released chart; for older versions, install from a checkout (below) at the matching tag.
+
 ### Quick Start
 
 1. **Update the required configuration values**
@@ -24,6 +41,14 @@ This Helm chart deploys MeshMonitor, a web application for monitoring Meshtastic
    ```
 
 2. **Install the chart**
+
+   From the Helm repository:
+
+   ```bash
+   helm install meshmonitor meshmonitor/meshmonitor -f custom-values.yaml
+   ```
+
+   Or from a local checkout of this repository:
 
    ```bash
    helm install meshmonitor ./helm/meshmonitor -f custom-values.yaml

--- a/scripts/build-helm-repo.sh
+++ b/scripts/build-helm-repo.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Package the MeshMonitor Helm chart and build a classic chart-repository
+# index under docs/public/charts/. VitePress serves docs/public/ at the site
+# root, so the result is published to https://meshmonitor.org/charts and users
+# can `helm repo add meshmonitor https://meshmonitor.org/charts`.
+#
+# Run by the Deploy Documentation workflow (.github/workflows/deploy-docs.yml)
+# before the VitePress build. Requires `helm` on PATH.
+#
+# See issue #3431.
+set -euo pipefail
+
+REPO_URL="${HELM_REPO_URL:-https://meshmonitor.org/charts}"
+CHART_DIR="helm/meshmonitor"
+OUT_DIR="docs/public/charts"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "error: helm is not installed (needed to build the chart repository)" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+echo "==> Linting chart"
+helm lint "$CHART_DIR"
+
+echo "==> Packaging chart into $OUT_DIR"
+helm package "$CHART_DIR" --destination "$OUT_DIR"
+
+echo "==> Generating repository index (url: $REPO_URL)"
+helm repo index "$OUT_DIR" --url "$REPO_URL"
+
+echo "==> Helm repository contents:"
+ls -la "$OUT_DIR"


### PR DESCRIPTION
## Summary

Closes #3431 — adds a proper Helm chart repository so users can `helm repo add` and install/upgrade MeshMonitor without cloning the repo.

```bash
helm repo add meshmonitor https://meshmonitor.org/charts
helm repo update
helm install meshmonitor meshmonitor/meshmonitor -f custom-values.yaml
```

## Approach

GitHub Pages already serves the VitePress docs site at `meshmonitor.org` (via `actions/deploy-pages` from `main`, not a `gh-pages` branch). Rather than fight that, the Helm repo is **served from the same site under `/charts/`**:

- `scripts/build-helm-repo.sh` runs `helm package` + `helm repo index --url https://meshmonitor.org/charts` into `docs/public/charts/`. VitePress serves `docs/public/` at the site root, so the index and chart tarball publish to `https://meshmonitor.org/charts/`.
- The **Deploy Documentation** workflow installs Helm (`azure/setup-helm`) and runs the script before the VitePress build, and now also triggers on `helm/**` changes so the repo republishes whenever the chart changes.
- `docs/public/charts/` is gitignored (generated at deploy time, like `news.json`) — no `gh-pages` branch, no binaries in git, no Pages-source conflict.

## Docs

- **README**, **helm/README.md**, and the docs-site **Helm Deployment Guide** now lead with `helm repo add`, keeping the local-checkout install as the alternative.
- CHANGELOG `[Unreleased]` entry.

## Validation

Ran the packaging script with Helm v3.16.4 against the real chart:
- `helm lint` passes; packages `meshmonitor-4.10.1.tgz`.
- Generated `index.yaml` references `https://meshmonitor.org/charts/meshmonitor-4.10.1.tgz` (matches the Pages serving path).

> Note: the deploy workflow only runs post-merge, so the live `/charts` endpoint appears once this lands on `main` and the docs deploy runs.

### Known scope
The repository tracks the **latest** released chart version. Pinning older versions via the repo isn't supported yet (install from a checkout at the matching tag); multi-version history can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)