### PR TITLE
feat(helm): add optional Gateway API HTTPRoute (#3432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Features
 
+- **Helm chart: Gateway API HTTPRoute (#3432)**: The Helm chart can now provision a Gateway API `HTTPRoute` as a modern alternative to ingress, gated behind `httpRoute.enabled` (default `false`). Set `parentRefs` (and optionally `hostnames`); the chart routes the matched traffic to the MeshMonitor service automatically, with `matches`, `filters`, and `additionalRules` available for advanced setups and `apiVersion` overridable for older Gateway API CRDs.
 - **Helm chart repository (#3431)**: MeshMonitor now publishes a proper Helm repository at `https://meshmonitor.org/charts`, so you can install without cloning the repo — `helm repo add meshmonitor https://meshmonitor.org/charts && helm install meshmonitor meshmonitor/meshmonitor`. The chart is packaged and indexed by `scripts/build-helm-repo.sh` during the docs deploy and served from the existing docs site (no separate `gh-pages` branch). The repository tracks the latest released chart; older versions remain installable from a checkout at the matching tag.
 
 ## [4.10.1] - 2026-06-11

--- a/helm/README.md
+++ b/helm/README.md
@@ -95,6 +95,28 @@ Then install:
 helm install meshmonitor ./helm/meshmonitor -f custom-values.yaml
 ```
 
+### Installing with a Gateway API HTTPRoute
+
+If your cluster uses the [Gateway API](https://gateway-api.sigs.k8s.io/) instead of Ingress, enable an `HTTPRoute` (disabled by default). This requires the Gateway API CRDs installed and a `Gateway` already provisioned. Use this **or** Ingress, not both.
+
+```yaml
+# custom-values.yaml
+env:
+  meshtasticNodeIp: "192.168.1.100"
+  meshtasticUseTls: "false"
+
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway          # the Gateway to attach to
+      namespace: gateway-system
+      sectionName: https        # optional: a specific listener
+  hostnames:
+    - meshmonitor.example.com
+```
+
+The chart routes the matched traffic to the MeshMonitor service automatically. Customize `matches`, add `filters` (e.g. `URLRewrite` for subfolder hosting), or append fully-specified `additionalRules` as needed — see the values reference below. On clusters with older Gateway API CRDs, set `httpRoute.apiVersion: gateway.networking.k8s.io/v1beta1`.
+
 ### Installing in a Subfolder
 
 To deploy MeshMonitor at a subfolder path (e.g., `https://example.com/meshmonitor/`):
@@ -177,6 +199,25 @@ ingress:
     # - secretName: meshmonitor-tls
     #   hosts:
     #     - meshmonitor.local
+
+# Gateway API HTTPRoute (alternative to ingress; disabled by default)
+httpRoute:
+  enabled: false
+  apiVersion: gateway.networking.k8s.io/v1   # v1beta1 on older Gateway API CRDs
+  annotations: {}
+  labels: {}
+  parentRefs: []                              # required when enabled
+    # - name: my-gateway
+    #   namespace: gateway-system
+    #   sectionName: https
+  hostnames: []
+    # - meshmonitor.example.com
+  matches:                                    # default rule path match(es)
+    - path:
+        type: PathPrefix
+        value: /
+  filters: []                                 # optional HTTPRouteFilters for the default rule
+  additionalRules: []                         # extra fully-specified rules (own matches/backendRefs)
 
 # Persistent storage for SQLite database
 persistence:

--- a/helm/meshmonitor/templates/httproute.yaml
+++ b/helm/meshmonitor/templates/httproute.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: {{ .Values.httpRoute.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: HTTPRoute
+metadata:
+  name: {{ include "meshmonitor.fullname" . }}
+  labels:
+    {{- include "meshmonitor.labels" . | nindent 4 }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.httpRoute.matches | nindent 8 }}
+      {{- with .Values.httpRoute.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "meshmonitor.fullname" . }}
+          port: {{ .Values.service.port }}
+    {{- with .Values.httpRoute.additionalRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/helm/meshmonitor/values.yaml
+++ b/helm/meshmonitor/values.yaml
@@ -32,6 +32,38 @@ ingress:
     #   hosts:
     #     - meshmonitor.local
 
+# Gateway API HTTPRoute — a modern alternative to ingress for north-south
+# routing (https://gateway-api.sigs.k8s.io/). Disabled by default. Requires the
+# Gateway API CRDs installed and a Gateway already provisioned in your cluster.
+# Use this OR ingress above, not both.
+httpRoute:
+  enabled: false
+  # apiVersion of the HTTPRoute resource. Override to
+  # gateway.networking.k8s.io/v1beta1 on clusters running older Gateway API CRDs.
+  apiVersion: gateway.networking.k8s.io/v1
+  annotations: {}
+  labels: {}
+  # The Gateway(s) this route attaches to (spec.parentRefs). Required when enabled.
+  parentRefs: []
+    # - name: my-gateway
+    #   namespace: gateway-system
+    #   sectionName: https
+  # Hostnames this route matches (spec.hostnames). Empty matches the Gateway's.
+  hostnames: []
+    # - meshmonitor.example.com
+  # Path/header/method matches for the default rule. The matched traffic is
+  # routed to the MeshMonitor service automatically.
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+  # Optional HTTPRouteFilters applied to the default rule (e.g. URLRewrite,
+  # RequestHeaderModifier, RequestRedirect).
+  filters: []
+  # Extra fully-specified rules appended after the default rule. Each entry must
+  # include its own matches/backendRefs.
+  additionalRules: []
+
 # Environment variables
 # Seed values for the first Meshtastic source on first boot.
 # MeshMonitor 4.0 manages additional sources via the Dashboard → Sources UI;


### PR DESCRIPTION
## Summary

Closes #3432. Adds a Gateway API `HTTPRoute` to the Helm chart as a modern alternative to Ingress, **disabled by default** (`httpRoute.enabled: false`) — matching the pattern requested (e.g. the authentik chart's `route:` block).

```yaml
httpRoute:
  enabled: true
  parentRefs:
    - name: my-gateway
      namespace: gateway-system
      sectionName: https
  hostnames:
    - meshmonitor.example.com
```

The chart routes the matched traffic to the MeshMonitor service automatically.

## What's included

- **`templates/httproute.yaml`** — renders only when `httpRoute.enabled`. Emits a valid `gateway.networking.k8s.io/v1` HTTPRoute with `parentRefs`, `hostnames`, merged labels/annotations, and a default rule (`PathPrefix /` → the service on `service.port`).
- **`values.yaml`** — new `httpRoute:` block: `enabled`, `apiVersion` (override to `v1beta1` for older CRDs), `annotations`, `labels`, `parentRefs`, `hostnames`, `matches`, `filters` (optional HTTPRouteFilters on the default rule), and `additionalRules` (extra fully-specified rules).
- **Docs** — `helm/README.md` gains an "Installing with a Gateway API HTTPRoute" section and a values-reference entry. CHANGELOG `[Unreleased]`.

## Validation (Helm 3.16.4)

- `helm lint` passes (0 failures).
- Default values → **no** HTTPRoute rendered (off by default).
- `httpRoute.enabled=true` → valid HTTPRoute; verified `parentRefs`/`hostnames`/`sectionName`, label+annotation merge, `filters` (RequestHeaderModifier), and `additionalRules` all render with correct indentation and backend wiring to the service.

## Note

The chart `version`/`appVersion` is intentionally left at `4.10.1` here — per the project convention all version files bump together at release time, so this lands under `[Unreleased]` and ships with the next version bump (which republishes a new chart version to `meshmonitor.org/charts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)