### PR TITLE
fix(telemetry): stable order for Local Node Telemetry graphs (#3436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Helm chart: Gateway API HTTPRoute (#3432)**: The Helm chart can now provision a Gateway API `HTTPRoute` as a modern alternative to ingress, gated behind `httpRoute.enabled` (default `false`). Set `parentRefs` (and optionally `hostnames`); the chart routes the matched traffic to the MeshMonitor service automatically, with `matches`, `filters`, and `additionalRules` available for advanced setups and `apiVersion` overridable for older Gateway API CRDs.
 - **Helm chart repository (#3431)**: MeshMonitor now publishes a proper Helm repository at `https://meshmonitor.org/charts`, so you can install without cloning the repo — `helm repo add meshmonitor https://meshmonitor.org/charts && helm install meshmonitor meshmonitor/meshmonitor`. The chart is packaged and indexed by `scripts/build-helm-repo.sh` during the docs deploy and served from the existing docs site (no separate `gh-pages` branch). The repository tracks the latest released chart; older versions remain installable from a checkout at the matching tag.
 
+### Bug Fixes
+
+- **Telemetry graphs reshuffled on every update (#3436)**: The Local Node Telemetry graphs on a node's Info screen rendered in the telemetry-grouping order, which changed on almost every update — so a graph you were watching kept jumping around. They now use a stable, deterministic order: favorited metrics first, then alphabetical by label. New metrics (once data becomes available) slot into their alphabetical position instead of appearing at random.
+
 ## [4.10.1] - 2026-06-11
 
 ### Features

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -19,6 +19,7 @@ import { getLatestValue } from '../utils/telemetry';
 import TelemetryGauge from './TelemetryGauge';
 import TelemetryNumericLabel from './TelemetryNumericLabel';
 import { getTelemetryLabel } from './TelemetryChart';
+import { compareTelemetryGraphs } from '../utils/telemetryGraphOrder';
 
 /** Telemetry types that represent discrete integer values where fractional display is meaningless */
 const INTEGER_TELEMETRY_TYPES = new Set([
@@ -904,7 +905,14 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
       }
 
       return true;
-    });
+    })
+      // Stable, deterministic order (#3436): favorited metrics first, then
+      // alphabetical by display label. Previously the order came from the
+      // grouping Map's insertion order, which reshuffled on almost every
+      // telemetry update — making it hard to track a specific graph. New
+      // metrics now slot into their alphabetical position instead of jumping
+      // around.
+      .sort(([typeA], [typeB]) => compareTelemetryGraphs(typeA, typeB, favorites, getTelemetryLabel));
 
     // Sub-hour windows (e.g. the 15-minute preset) read awkwardly as
     // fractional hours, so render those with a minutes-based title instead.

--- a/src/utils/telemetryGraphOrder.test.ts
+++ b/src/utils/telemetryGraphOrder.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { compareTelemetryGraphs } from './telemetryGraphOrder';
+
+// Simple label map standing in for getTelemetryLabel.
+const LABELS: Record<string, string> = {
+  batteryLevel: 'Battery Level',
+  channelUtilization: 'Channel Utilization',
+  temperature: 'Temperature',
+  voltage: 'Voltage',
+  humidity: 'Relative Humidity',
+};
+const getLabel = (t: string) => LABELS[t] ?? t;
+
+function sortTypes(types: string[], favorites: Set<string>): string[] {
+  return [...types].sort((a, b) => compareTelemetryGraphs(a, b, favorites, getLabel));
+}
+
+describe('compareTelemetryGraphs', () => {
+  const all = ['temperature', 'batteryLevel', 'voltage', 'channelUtilization', 'humidity'];
+
+  it('orders alphabetically by display label when there are no favorites', () => {
+    expect(sortTypes(all, new Set())).toEqual([
+      'batteryLevel',        // Battery Level
+      'channelUtilization',  // Channel Utilization
+      'humidity',            // Relative Humidity
+      'temperature',         // Temperature
+      'voltage',             // Voltage
+    ]);
+  });
+
+  it('puts favorites first, each group alphabetical by label', () => {
+    const favorites = new Set(['voltage', 'temperature']);
+    expect(sortTypes(all, favorites)).toEqual([
+      // favorites, alphabetical by label: Temperature, Voltage
+      'temperature',
+      'voltage',
+      // rest, alphabetical by label
+      'batteryLevel',
+      'channelUtilization',
+      'humidity',
+    ]);
+  });
+
+  it('is stable regardless of the input (insertion) order', () => {
+    const favorites = new Set(['batteryLevel']);
+    const orderA = sortTypes(['humidity', 'temperature', 'batteryLevel', 'voltage', 'channelUtilization'], favorites);
+    const orderB = sortTypes(['voltage', 'channelUtilization', 'humidity', 'batteryLevel', 'temperature'], favorites);
+    expect(orderA).toEqual(orderB);
+    expect(orderA[0]).toBe('batteryLevel'); // favorite stays on top
+  });
+
+  it('slots a newly-available metric into its alphabetical position, not the top', () => {
+    const favorites = new Set<string>();
+    const before = sortTypes(['batteryLevel', 'voltage'], favorites);
+    expect(before).toEqual(['batteryLevel', 'voltage']);
+    // "humidity" => "Relative Humidity" sorts between Battery Level and Voltage
+    const after = sortTypes(['batteryLevel', 'voltage', 'humidity'], favorites);
+    expect(after).toEqual(['batteryLevel', 'humidity', 'voltage']);
+  });
+
+  it('falls back to the raw type when no label is known', () => {
+    const favorites = new Set<string>();
+    expect(sortTypes(['zzz_unknown', 'batteryLevel'], favorites)).toEqual(['batteryLevel', 'zzz_unknown']);
+  });
+});

--- a/src/utils/telemetryGraphOrder.ts
+++ b/src/utils/telemetryGraphOrder.ts
@@ -1,0 +1,21 @@
+/**
+ * Stable ordering for the node Info screen's telemetry graphs (#3436).
+ *
+ * The graph list was previously rendered in the telemetry-grouping Map's
+ * insertion order, which reshuffled on almost every update. This comparator
+ * gives a deterministic order — favorited metrics first, then alphabetical by
+ * display label — so a specific graph stays put between updates and newly
+ * available metrics slot into their alphabetical position instead of jumping
+ * to the top/bottom at random.
+ */
+export function compareTelemetryGraphs(
+  typeA: string,
+  typeB: string,
+  favorites: Set<string>,
+  getLabel: (type: string) => string,
+): number {
+  const favA = favorites.has(typeA) ? 0 : 1;
+  const favB = favorites.has(typeB) ? 0 : 1;
+  if (favA !== favB) return favA - favB;
+  return getLabel(typeA).localeCompare(getLabel(typeB));
+}


### PR DESCRIPTION
## Summary

Closes #3436. The **Local Node Telemetry** graphs on a node's Info screen rendered in the telemetry-grouping `Map`'s insertion order, which shifted on almost every update — so a graph you were watching kept jumping around.

They now sort **deterministically**:
1. **Favorited** metrics first (the existing ★ toggle), then
2. **alphabetical by display label**.

This gives a stable order across updates, puts favorites on top (as requested), and makes a newly-available metric slot into its **alphabetical** position instead of appearing at the top/bottom at random.

## Implementation
- Extracted the comparator into `src/utils/telemetryGraphOrder.ts` (`compareTelemetryGraphs`) and applied it as a `.sort()` on the existing `filteredData` in `TelemetryGraphs.tsx`.
- Pure, unit-tested: no-favorites alphabetical order, favorites-on-top, stability regardless of input order, and new-metric insertion position.

## Testing
- New unit tests for the comparator; existing `TelemetryGraphs.test.tsx` still green.
- Full Vitest suite: **6334 passing, 0 failing**.

## Screenshot

Local Node Telemetry graphs in their new stable, alphabetical-by-label order (deployed from this branch). Favorited metrics sort above the rest — favorites-on-top is unit-tested.

![Telemetry graphs in stable alphabetical order](https://raw.githubusercontent.com/Yeraze/meshmonitor/assets/telemetry-order-3437/screenshots/telem-order-alpha.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
