### PR TITLE
fix(auto-welcome): configurable pre-send delay to fix DM failures after nodeDB reset (#3439)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 
+- **Auto Welcome DMs failed on first contact after a nodeDB reset (#3439)**: When many nodes came online at once (e.g. after a nodeDB reset), Auto Welcome DMs failed with a red ✗ — the welcome was transmitted while the target's radio was still finishing its own startup TX burst and not yet receive-ready, and with no retry (`maxAttempts=1`) that was a permanent failure. Auto Welcome now waits a configurable **pre-send delay** (new per-source setting `autoWelcomeDelay`, default 30s, range 0–120, in the Auto Welcome settings) after first hearing a node before sending its welcome, letting the node settle into receive mode. The send is scheduled non-blocking (it no longer stalls packet processing), the de-dup lock is held across the wait, and the welcome is skipped if the node is welcomed during the delay.
 - **Telemetry graphs reshuffled on every update (#3436)**: The Local Node Telemetry graphs on a node's Info screen rendered in the telemetry-grouping order, which changed on almost every update — so a graph you were watching kept jumping around. They now use a stable, deterministic order: favorited metrics first, then alphabetical by label. New metrics (once data becomes available) slot into their alphabetical position instead of appearing at random.
 
 ## [4.10.1] - 2026-06-11

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2317,6 +2317,8 @@
   "automation.auto_welcome.wait_for_name_description": "Wait until the node has a Long Name or Short Name before sending the welcome message. If disabled, welcome messages will be sent immediately when a new node is discovered.",
   "automation.auto_welcome.max_hops": "Maximum Hops",
   "automation.auto_welcome.max_hops_description": "Only welcome nodes within this many hops (1-10). Nodes further away will not receive a welcome message.",
+  "automation.auto_welcome.delay": "Pre-send delay (seconds)",
+  "automation.auto_welcome.delay_description": "Wait this long after first hearing a node before sending its welcome. Gives the node time to finish its startup transmit burst and become ready to receive — important after a nodeDB reset when many nodes come online at once. 0–120 seconds; default 30.",
   "automation.auto_welcome.broadcast_target": "Broadcast Target",
   "automation.auto_welcome.broadcast_target_description": "Select where to send the welcome message",
   "automation.auto_welcome.dm_to_new_node": "Direct Message to New Node",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -597,6 +597,7 @@ function App() {
     autoWelcomeTarget, setAutoWelcomeTarget,
     autoWelcomeWaitForName, setAutoWelcomeWaitForName,
     autoWelcomeMaxHops, setAutoWelcomeMaxHops,
+    autoWelcomeDelay, setAutoWelcomeDelay,
     autoResponderEnabled, setAutoResponderEnabled,
     autoResponderTriggers, setAutoResponderTriggers,
     autoResponderSkipIncompleteNodes, setAutoResponderSkipIncompleteNodes,
@@ -1126,6 +1127,10 @@ function App() {
 
           if (settings.autoWelcomeMaxHops) {
             setAutoWelcomeMaxHops(parseInt(settings.autoWelcomeMaxHops));
+          }
+
+          if (settings.autoWelcomeDelay !== undefined && settings.autoWelcomeDelay !== null) {
+            setAutoWelcomeDelay(parseInt(settings.autoWelcomeDelay));
           }
 
           if (settings.autoResponderEnabled !== undefined) {
@@ -5001,6 +5006,7 @@ function App() {
                   target={autoWelcomeTarget}
                   waitForName={autoWelcomeWaitForName}
                   maxHops={autoWelcomeMaxHops}
+                  delay={autoWelcomeDelay}
                   channels={channels}
                   baseUrl={baseUrl}
                   onEnabledChange={setAutoWelcomeEnabled}
@@ -5008,6 +5014,7 @@ function App() {
                   onTargetChange={setAutoWelcomeTarget}
                   onWaitForNameChange={setAutoWelcomeWaitForName}
                   onMaxHopsChange={setAutoWelcomeMaxHops}
+                  onDelayChange={setAutoWelcomeDelay}
                 />
               </div>
               <div id="auto-favorite">

--- a/src/components/AutoWelcomeSection.tsx
+++ b/src/components/AutoWelcomeSection.tsx
@@ -13,6 +13,7 @@ interface AutoWelcomeSectionProps {
   target: string;
   waitForName: boolean;
   maxHops: number;
+  delay: number;
   channels: Channel[];
   baseUrl: string;
   onEnabledChange: (enabled: boolean) => void;
@@ -20,6 +21,7 @@ interface AutoWelcomeSectionProps {
   onTargetChange: (target: string) => void;
   onWaitForNameChange: (waitForName: boolean) => void;
   onMaxHopsChange: (maxHops: number) => void;
+  onDelayChange: (delay: number) => void;
 }
 
 const DEFAULT_MESSAGE = 'Welcome {LONG_NAME} ({SHORT_NAME}) to the mesh!';
@@ -30,6 +32,7 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
   target,
   waitForName,
   maxHops,
+  delay,
   channels,
   baseUrl,
   onEnabledChange,
@@ -37,6 +40,7 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
   onTargetChange,
   onWaitForNameChange,
   onMaxHopsChange,
+  onDelayChange,
 }) => {
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
@@ -47,6 +51,7 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
   const [localTarget, setLocalTarget] = useState(target || '0');
   const [localWaitForName, setLocalWaitForName] = useState(waitForName);
   const [localMaxHops, setLocalMaxHops] = useState(maxHops || 5);
+  const [localDelay, setLocalDelay] = useState(delay ?? 30);
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isMarkingWelcomed, setIsMarkingWelcomed] = useState(false);
@@ -59,7 +64,8 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
     setLocalTarget(target || '0');
     setLocalWaitForName(waitForName);
     setLocalMaxHops(maxHops || 5);
-  }, [enabled, message, target, waitForName, maxHops]);
+    setLocalDelay(delay ?? 30);
+  }, [enabled, message, target, waitForName, maxHops, delay]);
 
   // Check if any settings have changed
   useEffect(() => {
@@ -68,9 +74,10 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
       localMessage !== message ||
       localTarget !== target ||
       localWaitForName !== waitForName ||
-      localMaxHops !== maxHops;
+      localMaxHops !== maxHops ||
+      localDelay !== (delay ?? 30);
     setHasChanges(changed);
-  }, [localEnabled, localMessage, localTarget, localWaitForName, localMaxHops, enabled, message, target, waitForName, maxHops]);
+  }, [localEnabled, localMessage, localTarget, localWaitForName, localMaxHops, localDelay, enabled, message, target, waitForName, maxHops, delay]);
 
   // Reset local state to props (used by SaveBar dismiss)
   const resetChanges = useCallback(() => {
@@ -79,7 +86,8 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
     setLocalTarget(target || '0');
     setLocalWaitForName(waitForName);
     setLocalMaxHops(maxHops || 5);
-  }, [enabled, message, target, waitForName, maxHops]);
+    setLocalDelay(delay ?? 30);
+  }, [enabled, message, target, waitForName, maxHops, delay]);
 
   const handleMarkAllWelcomed = async () => {
     setIsMarkingWelcomed(true);
@@ -119,7 +127,8 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
           autoWelcomeMessage: localMessage,
           autoWelcomeTarget: localTarget,
           autoWelcomeWaitForName: String(localWaitForName),
-          autoWelcomeMaxHops: String(localMaxHops)
+          autoWelcomeMaxHops: String(localMaxHops),
+          autoWelcomeDelay: String(localDelay)
         })
       });
 
@@ -137,6 +146,7 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
       onTargetChange(localTarget);
       onWaitForNameChange(localWaitForName);
       onMaxHopsChange(localMaxHops);
+      onDelayChange(localDelay);
 
       setHasChanges(false);
       showToast(t('automation.settings_saved'), 'success');
@@ -289,6 +299,31 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
               const value = parseInt(e.target.value);
               if (value >= 1 && value <= 10) {
                 setLocalMaxHops(value);
+              }
+            }}
+            disabled={!localEnabled}
+            className="setting-input"
+            style={{ width: '100px' }}
+          />
+        </div>
+
+        <div className="setting-item" style={{ marginTop: '1rem' }}>
+          <label htmlFor="welcomeDelay">
+            {t('automation.auto_welcome.delay', 'Pre-send delay (seconds)')}
+            <span className="setting-description">
+              {t('automation.auto_welcome.delay_description', 'Wait this long after first hearing a node before sending its welcome. Gives the node time to finish its startup transmit burst and become ready to receive — important after a nodeDB reset when many nodes come online at once. 0–120 seconds; default 30.')}
+            </span>
+          </label>
+          <input
+            id="welcomeDelay"
+            type="number"
+            min="0"
+            max="120"
+            value={localDelay}
+            onChange={(e) => {
+              const value = parseInt(e.target.value);
+              if (Number.isFinite(value) && value >= 0 && value <= 120) {
+                setLocalDelay(value);
               }
             }}
             disabled={!localEnabled}

--- a/src/contexts/AutomationContext.tsx
+++ b/src/contexts/AutomationContext.tsx
@@ -72,6 +72,8 @@ interface AutomationContextType {
   setAutoWelcomeWaitForName: React.Dispatch<React.SetStateAction<boolean>>;
   autoWelcomeMaxHops: number;
   setAutoWelcomeMaxHops: React.Dispatch<React.SetStateAction<number>>;
+  autoWelcomeDelay: number;
+  setAutoWelcomeDelay: React.Dispatch<React.SetStateAction<number>>;
   autoResponderEnabled: boolean;
   setAutoResponderEnabled: React.Dispatch<React.SetStateAction<boolean>>;
   autoResponderTriggers: AutoResponderTrigger[];
@@ -151,6 +153,7 @@ export const AutomationProvider: React.FC<AutomationProviderProps> = ({ children
   const [autoWelcomeTarget, setAutoWelcomeTarget] = useState<string>('0');
   const [autoWelcomeWaitForName, setAutoWelcomeWaitForName] = useState<boolean>(true);
   const [autoWelcomeMaxHops, setAutoWelcomeMaxHops] = useState<number>(5);
+  const [autoWelcomeDelay, setAutoWelcomeDelay] = useState<number>(30);
   const [autoResponderEnabled, setAutoResponderEnabled] = useState<boolean>(false);
   const [autoResponderTriggers, setAutoResponderTriggers] = useState<AutoResponderTrigger[]>([]);
   const [autoResponderSkipIncompleteNodes, setAutoResponderSkipIncompleteNodes] = useState<boolean>(false);
@@ -244,6 +247,7 @@ export const AutomationProvider: React.FC<AutomationProviderProps> = ({ children
         if (s.autoWelcomeTarget !== undefined) setAutoWelcomeTarget(s.autoWelcomeTarget);
         if (s.autoWelcomeWaitForName !== undefined) setAutoWelcomeWaitForName(bool('autoWelcomeWaitForName'));
         if (s.autoWelcomeMaxHops !== undefined) setAutoWelcomeMaxHops(num('autoWelcomeMaxHops', 5));
+        if (s.autoWelcomeDelay !== undefined) setAutoWelcomeDelay(num('autoWelcomeDelay', 30));
 
         if (s.autoResponderEnabled !== undefined) setAutoResponderEnabled(bool('autoResponderEnabled'));
         if (s.autoResponderTriggers !== undefined) setAutoResponderTriggers(jsonArr<AutoResponderTrigger>('autoResponderTriggers', []));
@@ -309,6 +313,7 @@ export const AutomationProvider: React.FC<AutomationProviderProps> = ({ children
         autoWelcomeTarget, setAutoWelcomeTarget,
         autoWelcomeWaitForName, setAutoWelcomeWaitForName,
         autoWelcomeMaxHops, setAutoWelcomeMaxHops,
+        autoWelcomeDelay, setAutoWelcomeDelay,
         autoResponderEnabled, setAutoResponderEnabled,
         autoResponderTriggers, setAutoResponderTriggers,
         autoResponderSkipIncompleteNodes, setAutoResponderSkipIncompleteNodes,

--- a/src/server/autoWelcomeDelay.test.ts
+++ b/src/server/autoWelcomeDelay.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAutoWelcomeDelaySeconds,
+  AUTO_WELCOME_DELAY_DEFAULT_SECONDS,
+  AUTO_WELCOME_DELAY_MAX_SECONDS,
+} from './autoWelcomeDelay';
+
+describe('resolveAutoWelcomeDelaySeconds', () => {
+  it('defaults to 30s when unset (so the fix applies without re-saving)', () => {
+    expect(resolveAutoWelcomeDelaySeconds(null)).toBe(AUTO_WELCOME_DELAY_DEFAULT_SECONDS);
+    expect(resolveAutoWelcomeDelaySeconds(undefined)).toBe(30);
+    expect(resolveAutoWelcomeDelaySeconds('')).toBe(30);
+  });
+
+  it('honors a valid configured value', () => {
+    expect(resolveAutoWelcomeDelaySeconds('0')).toBe(0);
+    expect(resolveAutoWelcomeDelaySeconds('15')).toBe(15);
+    expect(resolveAutoWelcomeDelaySeconds('120')).toBe(120);
+  });
+
+  it('clamps above the 120s maximum', () => {
+    expect(resolveAutoWelcomeDelaySeconds('300')).toBe(AUTO_WELCOME_DELAY_MAX_SECONDS);
+  });
+
+  it('falls back to the default on invalid / negative input', () => {
+    expect(resolveAutoWelcomeDelaySeconds('-5')).toBe(30);
+    expect(resolveAutoWelcomeDelaySeconds('abc')).toBe(30);
+  });
+});

--- a/src/server/autoWelcomeDelay.ts
+++ b/src/server/autoWelcomeDelay.ts
@@ -1,0 +1,24 @@
+/**
+ * Auto-welcome pre-send delay (#3439).
+ *
+ * After a nodeDB reset, many nodes broadcast NodeInfo at once. A DM welcome
+ * sent the instant that packet arrives can land while the target's radio is
+ * still finishing its own startup TX burst (not receive-ready), so it fails at
+ * zero hops with no retry. Deferring the send by a few seconds lets the node
+ * settle into receive mode. Configurable per source via `autoWelcomeDelay`.
+ */
+export const AUTO_WELCOME_DELAY_DEFAULT_SECONDS = 30;
+export const AUTO_WELCOME_DELAY_MAX_SECONDS = 120;
+
+/**
+ * Resolve the stored `autoWelcomeDelay` setting to a clamped number of seconds.
+ * Absent / invalid / negative values fall back to the default (30s) so the fix
+ * applies to existing installs without re-saving settings. Values are capped at
+ * 120s.
+ */
+export function resolveAutoWelcomeDelaySeconds(raw: string | null | undefined): number {
+  if (raw == null || raw === '') return AUTO_WELCOME_DELAY_DEFAULT_SECONDS;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return AUTO_WELCOME_DELAY_DEFAULT_SECONDS;
+  return Math.min(n, AUTO_WELCOME_DELAY_MAX_SECONDS);
+}

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -55,6 +55,7 @@ export const VALID_SETTINGS_KEYS = [
   'autoWelcomeTarget',
   'autoWelcomeWaitForName',
   'autoWelcomeMaxHops',
+  'autoWelcomeDelay',
   'autoResponderEnabled',
   'autoResponderTriggers',
   'autoResponderSkipIncompleteNodes',
@@ -308,6 +309,7 @@ export const PER_SOURCE_SETTINGS_KEYS = [
   'autoWelcomeMessage',
   'autoWelcomeTarget',
   'autoWelcomeWaitForName',
+  'autoWelcomeDelay',
   // MeshCore auto-pathfinding
   'meshcoreAutoPathfindingEnabled',
   'meshcoreAutoPathfindingPathDiscoveryEnabled',

--- a/src/server/meshtasticManager.autowelcome.test.ts
+++ b/src/server/meshtasticManager.autowelcome.test.ts
@@ -161,6 +161,7 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
     it('should skip welcoming local node', async () => {
       vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
         if (key === 'autoWelcomeEnabled') return 'true';
+        if (key === 'autoWelcomeDelay') return '0'; // immediate send in tests (delay covered separately)
         if (key === 'localNodeNum') return '123456';
         return null;
       });
@@ -173,6 +174,7 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
     it('should skip node if not found in database', async () => {
       vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
         if (key === 'autoWelcomeEnabled') return 'true';
+        if (key === 'autoWelcomeDelay') return '0'; // immediate send in tests (delay covered separately)
         if (key === 'localNodeNum') return '123456';
         return null;
       });
@@ -188,6 +190,7 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
 
       vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
         if (key === 'autoWelcomeEnabled') return 'true';
+        if (key === 'autoWelcomeDelay') return '0'; // immediate send in tests (delay covered separately)
         if (key === 'localNodeNum') return '123456';
         return null;
       });
@@ -212,6 +215,7 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
     it('should skip node with default name when waitForName is enabled', async () => {
       vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
         if (key === 'autoWelcomeEnabled') return 'true';
+        if (key === 'autoWelcomeDelay') return '0'; // immediate send in tests (delay covered separately)
         if (key === 'localNodeNum') return '123456';
         if (key === 'autoWelcomeWaitForName') return 'true';
         return null;
@@ -235,6 +239,7 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
     it('should skip node with default short name when waitForName is enabled', async () => {
       vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
         if (key === 'autoWelcomeEnabled') return 'true';
+        if (key === 'autoWelcomeDelay') return '0'; // immediate send in tests (delay covered separately)
         if (key === 'localNodeNum') return '123456';
         if (key === 'autoWelcomeWaitForName') return 'true';
         return null;
@@ -258,6 +263,7 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
     it('should send welcome message to new node with proper name', async () => {
       vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
         if (key === 'autoWelcomeEnabled') return 'true';
+        if (key === 'autoWelcomeDelay') return '0'; // immediate send in tests (delay covered separately)
         if (key === 'localNodeNum') return '123456';
         if (key === 'autoWelcomeMessage') return 'Welcome {LONG_NAME} ({SHORT_NAME})!';
         if (key === 'autoWelcomeTarget') return 'dm';
@@ -288,6 +294,7 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
     it('should send welcome as DM when target is dm', async () => {
       vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
         if (key === 'autoWelcomeEnabled') return 'true';
+        if (key === 'autoWelcomeDelay') return '0'; // immediate send in tests (delay covered separately)
         if (key === 'localNodeNum') return '123456';
         if (key === 'autoWelcomeMessage') return 'Welcome!';
         if (key === 'autoWelcomeTarget') return 'dm';
@@ -321,6 +328,7 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
     it('should send welcome to channel when target is channel number', async () => {
       vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
         if (key === 'autoWelcomeEnabled') return 'true';
+        if (key === 'autoWelcomeDelay') return '0'; // immediate send in tests (delay covered separately)
         if (key === 'localNodeNum') return '123456';
         if (key === 'autoWelcomeMessage') return 'Welcome!';
         if (key === 'autoWelcomeTarget') return '2';
@@ -351,9 +359,75 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
       );
     });
 
+    it('defers the send by the configured delay, then enqueues after it elapses (#3439)', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
+          if (key === 'autoWelcomeEnabled') return 'true';
+          if (key === 'localNodeNum') return '123456';
+          if (key === 'autoWelcomeTarget') return 'dm';
+          if (key === 'autoWelcomeDelay') return '30';
+          return null;
+        });
+        vi.mocked(databaseService.nodes.getNode).mockResolvedValue({
+          nodeNum: 999999,
+          nodeId: '!000f423f',
+          longName: 'Test Node',
+          shortName: 'TEST',
+          hwModel: 0,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        } as any);
+
+        await (manager as any).checkAutoWelcome(999999, '!000f423f');
+        // Deferred — nothing enqueued yet.
+        expect(messageQueueService.enqueue).not.toHaveBeenCalled();
+
+        // After the 30s delay the deferred send fires.
+        await vi.advanceTimersByTimeAsync(30000);
+        expect(messageQueueService.enqueue).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('skips the deferred send if the node was welcomed during the delay (#3439)', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
+          if (key === 'autoWelcomeEnabled') return 'true';
+          if (key === 'localNodeNum') return '123456';
+          if (key === 'autoWelcomeTarget') return 'dm';
+          if (key === 'autoWelcomeDelay') return '30';
+          return null;
+        });
+        const base = {
+          nodeNum: 999999,
+          nodeId: '!000f423f',
+          longName: 'Test Node',
+          shortName: 'TEST',
+          hwModel: 0,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        };
+        // Validation sees an un-welcomed node; the post-delay re-check sees it
+        // welcomed (e.g. a manual DM or another path marked it during the wait).
+        vi.mocked(databaseService.nodes.getNode)
+          .mockResolvedValueOnce(base as any)
+          .mockResolvedValue({ ...base, welcomedAt: Date.now() } as any);
+
+        await (manager as any).checkAutoWelcome(999999, '!000f423f');
+        await vi.advanceTimersByTimeAsync(30000);
+        expect(messageQueueService.enqueue).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('should use default welcome message when not configured', async () => {
       vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
         if (key === 'autoWelcomeEnabled') return 'true';
+        if (key === 'autoWelcomeDelay') return '0'; // immediate send in tests (delay covered separately)
         if (key === 'localNodeNum') return '123456';
         if (key === 'autoWelcomeTarget') return 'dm';
         return null;
@@ -386,6 +460,7 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
     it('should handle errors gracefully without crashing', async () => {
       vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
         if (key === 'autoWelcomeEnabled') return 'true';
+        if (key === 'autoWelcomeDelay') return '0'; // immediate send in tests (delay covered separately)
         if (key === 'localNodeNum') return '123456';
         throw new Error('Database error');
       });
@@ -397,6 +472,7 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
     it('should prevent duplicate welcomes when called in parallel (race condition protection)', async () => {
       vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
         if (key === 'autoWelcomeEnabled') return 'true';
+        if (key === 'autoWelcomeDelay') return '0'; // immediate send in tests (delay covered separately)
         if (key === 'localNodeNum') return '123456';
         if (key === 'autoWelcomeMessage') return 'Welcome!';
         if (key === 'autoWelcomeTarget') return 'dm';
@@ -428,6 +504,7 @@ describe('MeshtasticManager - Auto Welcome Integration', () => {
     it('should handle atomic database operation correctly when node already marked by another process', async () => {
       vi.mocked(databaseService.settings.getSetting).mockImplementation((key: string) => {
         if (key === 'autoWelcomeEnabled') return 'true';
+        if (key === 'autoWelcomeDelay') return '0'; // immediate send in tests (delay covered separately)
         if (key === 'localNodeNum') return '123456';
         if (key === 'autoWelcomeMessage') return 'Welcome!';
         if (key === 'autoWelcomeTarget') return 'dm';

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -21,6 +21,7 @@ import { dataEventEmitter } from './services/dataEventEmitter.js';
 import { waypointService } from './services/waypointService.js';
 import { autoDeleteByDistanceService } from './services/autoDeleteByDistanceService.js';
 import { MessageQueueService } from './messageQueueService.js';
+import { resolveAutoWelcomeDelaySeconds } from './autoWelcomeDelay.js';
 import { normalizeTriggerPatterns, normalizeTriggerChannels } from '../utils/autoResponderUtils.js';
 import { isWithinTimeWindow } from './utils/timeWindow.js';
 import { shouldGateAutomations, averageStrongestNeighborUtilization, DEFAULT_AIRTIME_CUTOFF_THRESHOLD, DEFAULT_AIRTIME_CUTOFF_SOURCE, NEIGHBOR_UTIL_SAMPLE_COUNT, type AirtimeCutoffSource, type NeighborUtilContributor } from './utils/airtimeCutoff.js';
@@ -10428,6 +10429,11 @@ class MeshtasticManager implements ISourceManager {
     }
     this.welcomingNodes.add(nodeNum);
 
+    // When true, a scheduled (deferred) send owns the welcomingNodes lock, so
+    // the finally below must NOT release it — the deferred send releases it
+    // when it fires (#3439).
+    let deferred = false;
+
     try {
       // All auto-welcome settings are per-source (written by AutoWelcomeSection
       // via /api/settings?sourceId=).
@@ -10495,75 +10501,122 @@ class MeshtasticManager implements ISourceManager {
         return;
       }
 
-      // Lock was already acquired at method entry; proceed to send welcome
-      try {
-
-        // Get welcome message template (per-source)
-        const autoWelcomeMessage = await settings.getSettingForSource(sourceId, 'autoWelcomeMessage') || 'Welcome {LONG_NAME} ({SHORT_NAME}) to the mesh!';
-
-        // Replace tokens in the message template
-        const welcomeText = await this.replaceWelcomeTokens(autoWelcomeMessage, nodeNum, nodeId);
-
-        // Get target (DM or channel, per-source)
-        const autoWelcomeTarget = await settings.getSettingForSource(sourceId, 'autoWelcomeTarget') || '0';
-
-        let destination: number | undefined;
-        let channel: number;
-
-        if (autoWelcomeTarget === 'dm') {
-          // Send as direct message
-          destination = nodeNum;
-          channel = 0;
-        } else {
-          // Send to channel
-          destination = undefined;
-          channel = parseInt(autoWelcomeTarget);
-        }
-
-        logger.info(`👋 Sending auto-welcome to ${nodeId} (${node.longName}): "${welcomeText}" ${autoWelcomeTarget === 'dm' ? '(via DM)' : `(channel ${channel})`}`);
-
-        // Route through message queue for rate limiting
-        // For DMs, send only once (maxAttempts=1) — the local radio ACK confirms
-        // transmission to the mesh; remote ACKs from the destination node are unreliable
-        // and waiting for them causes the queue to retry, sending the message multiple times.
-        this.messageQueue.enqueue(
-          welcomeText,
-          destination ?? 0, // destination: node number for DM, 0 for channel
-          undefined, // replyId
-          () => {
-            this.welcomingNodes.delete(nodeNum);
-            logger.debug(`🔓 Unlocked auto-welcome tracking for ${nodeId}`);
-          },
-          (reason: string) => {
-            logger.warn(`❌ Auto-welcome send failed for ${nodeId}: ${reason}`);
-            this.welcomingNodes.delete(nodeNum);
-            logger.debug(`🔓 Unlocked auto-welcome tracking for ${nodeId} (failure case)`);
-          },
-          destination ? undefined : channel, // channel: undefined for DM, channel number for channel
-          1 // maxAttemptsOverride: send once, don't retry on missing remote ACK
-        );
-
-        // Mark node as welcomed immediately after enqueue — the local radio ACK is
-        // sufficient confirmation that the message was transmitted to the mesh.
-        // Previously this was inside the onSuccess callback which only fires on remote
-        // ACK, causing welcomedAt to never be set and the node to be re-welcomed repeatedly.
-        const wasMarked = await databaseService.nodes.markNodeAsWelcomedIfNotAlready(nodeNum, nodeId, this.sourceId);
-        if (wasMarked) {
-          logger.info(`✅ Node ${nodeId} welcomed and marked in database`);
-        } else {
-          logger.warn(`⚠️  Node ${nodeId} was already marked as welcomed by another process`);
-        }
-      } catch (error) {
-        // Release lock on error as well
-        this.welcomingNodes.delete(nodeNum);
-        logger.debug(`🔓 Unlocked auto-welcome tracking for ${nodeId} (error case)`);
-        throw error;
+      // Pre-send delay (#3439): after a nodeDB reset, many nodes broadcast
+      // NodeInfo at once and a DM sent immediately can land while the target's
+      // radio is still finishing its own startup TX burst (not receive-ready),
+      // failing at zero hops with no retry (maxAttempts=1). Defer the send so
+      // the node can settle into receive mode. The welcomingNodes lock acquired
+      // at method entry is held across the wait (deferred=true keeps the finally
+      // from releasing it), so duplicate NodeInfo packets during the window are
+      // skipped at method entry. setTimeout returns immediately, so this never
+      // blocks the packet-processing pipeline.
+      const delaySeconds = resolveAutoWelcomeDelaySeconds(
+        await settings.getSettingForSource(sourceId, 'autoWelcomeDelay'),
+      );
+      if (delaySeconds > 0) {
+        deferred = true;
+        logger.info(`👋 Deferring auto-welcome for ${nodeId} by ${delaySeconds}s to let the node settle into receive mode`);
+        setTimeout(() => { void this.deferredAutoWelcome(nodeNum, nodeId); }, delaySeconds * 1000);
+        return;
       }
+
+      // No delay configured: send immediately.
+      await this.sendAutoWelcome(nodeNum, nodeId);
     } catch (error) {
       logger.error('❌ Error in auto-welcome:', error);
     } finally {
-      // Ensure lock is always released, even on early returns or unexpected errors
+      // Release the lock unless a deferred send now owns it (it will release on fire).
+      if (!deferred) {
+        this.welcomingNodes.delete(nodeNum);
+      }
+    }
+  }
+
+  /**
+   * Fire a deferred auto-welcome after the pre-send delay (#3439). Re-checks
+   * that the node still exists and hasn't been welcomed during the wait, then
+   * sends. Always releases the welcomingNodes lock the deferral was holding.
+   */
+  private async deferredAutoWelcome(nodeNum: number, nodeId: string): Promise<void> {
+    try {
+      const node = await databaseService.nodes.getNode(nodeNum, this.sourceId);
+      if (!node) {
+        logger.debug(`⏭️  Auto-welcome for ${nodeId} skipped — node no longer in database after delay`);
+        return;
+      }
+      if (node.welcomedAt !== null && node.welcomedAt !== undefined) {
+        logger.debug(`⏭️  Auto-welcome for ${nodeId} skipped — welcomed during the pre-send delay`);
+        return;
+      }
+      await this.sendAutoWelcome(nodeNum, nodeId);
+    } catch (error) {
+      logger.error('❌ Error in deferred auto-welcome:', error);
+    } finally {
       this.welcomingNodes.delete(nodeNum);
+    }
+  }
+
+  /**
+   * Build and enqueue the auto-welcome message for a node and mark it welcomed.
+   * The caller (checkAutoWelcome / deferredAutoWelcome) owns the welcomingNodes
+   * lock and releases it; this method does not manage the lock.
+   */
+  private async sendAutoWelcome(nodeNum: number, nodeId: string): Promise<void> {
+    const settings = databaseService.settings;
+    const sourceId = this.sourceId;
+    const node = await databaseService.nodes.getNode(nodeNum, sourceId);
+
+    // Get welcome message template (per-source)
+    const autoWelcomeMessage = await settings.getSettingForSource(sourceId, 'autoWelcomeMessage') || 'Welcome {LONG_NAME} ({SHORT_NAME}) to the mesh!';
+
+    // Replace tokens in the message template
+    const welcomeText = await this.replaceWelcomeTokens(autoWelcomeMessage, nodeNum, nodeId);
+
+    // Get target (DM or channel, per-source)
+    const autoWelcomeTarget = await settings.getSettingForSource(sourceId, 'autoWelcomeTarget') || '0';
+
+    let destination: number | undefined;
+    let channel: number;
+
+    if (autoWelcomeTarget === 'dm') {
+      // Send as direct message
+      destination = nodeNum;
+      channel = 0;
+    } else {
+      // Send to channel
+      destination = undefined;
+      channel = parseInt(autoWelcomeTarget);
+    }
+
+    logger.info(`👋 Sending auto-welcome to ${nodeId} (${node?.longName}): "${welcomeText}" ${autoWelcomeTarget === 'dm' ? '(via DM)' : `(channel ${channel})`}`);
+
+    // Route through message queue for rate limiting
+    // For DMs, send only once (maxAttempts=1) — the local radio ACK confirms
+    // transmission to the mesh; remote ACKs from the destination node are unreliable
+    // and waiting for them causes the queue to retry, sending the message multiple times.
+    this.messageQueue.enqueue(
+      welcomeText,
+      destination ?? 0, // destination: node number for DM, 0 for channel
+      undefined, // replyId
+      () => {
+        logger.debug(`✅ Auto-welcome transmitted for ${nodeId}`);
+      },
+      (reason: string) => {
+        logger.warn(`❌ Auto-welcome send failed for ${nodeId}: ${reason}`);
+      },
+      destination ? undefined : channel, // channel: undefined for DM, channel number for channel
+      1 // maxAttemptsOverride: send once, don't retry on missing remote ACK
+    );
+
+    // Mark node as welcomed immediately after enqueue — the local radio ACK is
+    // sufficient confirmation that the message was transmitted to the mesh.
+    // Previously this was inside the onSuccess callback which only fires on remote
+    // ACK, causing welcomedAt to never be set and the node to be re-welcomed repeatedly.
+    const wasMarked = await databaseService.nodes.markNodeAsWelcomedIfNotAlready(nodeNum, nodeId, this.sourceId);
+    if (wasMarked) {
+      logger.info(`✅ Node ${nodeId} welcomed and marked in database`);
+    } else {
+      logger.warn(`⚠️  Node ${nodeId} was already marked as welcomed by another process`);
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #3439. Auto Welcome DMs failed (red ✗, <20% success) on first contact after a nodeDB reset: the welcome was transmitted while the target's radio was still finishing its own **startup TX burst** (not receive-ready), and with `maxAttempts=1` there was no retry — a permanent failure. Manual DMs to the same node succeed because they're sent after the node has settled.

**Fix:** defer the welcome send by a configurable per-source delay so the node can enter receive mode first.

## Changes

**Backend** (`meshtasticManager.ts`)
- `checkAutoWelcome` schedules the send via `setTimeout` and returns immediately — it **no longer blocks the packet-processing pipeline** (the trigger is `await`ed inline in `processUserMessageProtobuf`).
- The `welcomingNodes` de-dup lock is **held across the wait** (a `deferred` flag keeps the `finally` from releasing it early), so duplicate NodeInfo packets in the window are skipped.
- New `deferredAutoWelcome` re-checks `welcomedAt` after the delay and skips if the node was welcomed meanwhile (e.g. a manual DM), then releases the lock.
- Send logic extracted into `sendAutoWelcome`, shared by the immediate (`delay=0`) and deferred paths.
- `resolveAutoWelcomeDelaySeconds` util: absent/invalid → **30s** (so the fix applies to existing installs without re-saving), clamped to 0–120.

**Settings + UI**
- New per-source setting `autoWelcomeDelay` (added to `VALID_SETTINGS_KEYS` + `PER_SOURCE_SETTINGS_KEYS`).
- A **"Pre-send delay (seconds)"** number input in the Auto Welcome settings, next to "Maximum Hops" (0–120, default 30), wired through `AutomationContext` → `App` → `AutoWelcomeSection`.

## Testing
- Unit tests for `resolveAutoWelcomeDelaySeconds` (default/clamp/invalid).
- Fake-timer tests: the welcome is **not** enqueued immediately but **is** after the delay elapses; and the deferred send is **skipped** if the node is welcomed during the delay.
- Existing auto-welcome tests pass (set `autoWelcomeDelay=0` for the immediate path).
- Full Vitest suite: **6340 passing**.

## Screenshot

The new **Pre-send delay (seconds)** field in the Auto Welcome settings:

![Auto Welcome pre-send delay setting](https://raw.githubusercontent.com/Yeraze/meshmonitor/assets/auto-welcome-delay-3440/auto-welcome-delay-3440.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
