### PR TITLE
release: v4.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.10.2] - 2026-06-14
+
 ### Features
 
 - **User-script dependencies (Python/Node packages)**: Auto Responder / trigger scripts can now use third-party packages. Drop a `requirements.txt` (Python) and/or `package.json` (Node) into the scripts directory (`$DATA_DIR/scripts`) and click **Install / Update dependencies** in the script-management panel (admin / `settings:write`). Packages install into `python_packages/` (pip `--target`) and `node_modules/` next to the scripts on the persisted volume — so they survive restarts — and are exposed to running scripts via `PYTHONPATH` / `NODE_PATH` across every script path (Auto Responder, geofence/timer triggers, the script test endpoint, and MeshCore). Python installs are wheel-only by default so the slim Alpine/musl image needs no compiler; set `SCRIPT_DEPS_ALLOW_SOURCE_BUILD=true` to permit source builds. The installer reuses the same interpreters that run the scripts (ABI-matched) and is isolated from the bundled Apprise venv. Installing third-party packages runs external code and needs network access, so it's admin-gated.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.10.1",
+  "version": "4.10.2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/blog/2026-06-14-v4.10.2.md
+++ b/docs/blog/2026-06-14-v4.10.2.md
@@ -1,0 +1,42 @@
+---
+id: news-2026-06-14-v4-10-2
+title: MeshMonitor v4.10.2 - Cross-Source DMs, MeshCore in Unified Messages & Script Dependencies
+date: '2026-06-14T18:00:00Z'
+category: release
+priority: normal
+minVersion: 4.10.2
+tags: [release, meshcore, messaging, pki, scripts, telemetry]
+---
+MeshMonitor **v4.10.2** is a feature-packed point release focused on **cross-source messaging** and **extensibility**.
+
+## Cross-source PKI direct messages (#3441)
+
+MeshMonitor can now decrypt **PKI-encrypted direct messages server-side** and surface them in the unified Messages view — the cross-source DM-aggregation case. A DM relayed still-encrypted through an MQTT bridge/broker, addressed to one of your connected nodes, is decrypted using that **destination** node's key (regardless of which source received it) and shown like any other message. It's **off by default** behind a global master switch (Settings → Security) and an explicit per-source opt-in; keys are stored **encrypted at rest** and the decryption is byte-exact to the firmware scheme. See [PKI Direct Message Decryption](/features/pki-dm-decryption).
+
+## MeshCore joins the Unified Messages feed (#3442)
+
+MeshCore channel and direct messages now appear in the cross-source **Unified Messages** view alongside Meshtastic traffic, badged so the protocol is obvious. The same change fixed a long-standing limit where MeshCore channels were effectively capped at ~50 messages **total** — each channel now loads its **own** backlog.
+
+## Python & Node packages for your scripts
+
+Auto Responder / trigger scripts can finally use third-party dependencies. Drop a `requirements.txt` or `package.json` in your scripts directory and click **Install / Update dependencies** — packages persist on the volume and are available to every script. See [Installing Dependencies](/user-scripts#installing-dependencies).
+
+## Also in 4.10.2
+
+- **Traffic Management telemetry** (firmware v2.7.22+) now renders as labelled graphs.
+- **Auto Welcome** gained a configurable pre-send delay so first-contact welcomes survive a nodeDB reset (#3439).
+- You can now **remove MeshCore contacts with malformed/short public keys** (#3443).
+- A Map Features **"maximum age" slider** to hide stale markers/traceroutes (#3322).
+- Helm: a published **chart repository** and optional **Gateway API HTTPRoute**.
+
+## Upgrade
+
+```bash
+docker pull ghcr.io/yeraze/meshmonitor:4.10.2
+```
+
+```bash
+helm upgrade meshmonitor meshmonitor/meshmonitor --version 4.10.2
+```
+
+Desktop builds are on the [Releases page](https://github.com/Yeraze/meshmonitor/releases/tag/v4.10.2). Full details in the [changelog](https://github.com/Yeraze/meshmonitor/blob/main/CHANGELOG.md).

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.10.1
-appVersion: "4.10.1"
+version: 4.10.2
+appVersion: "4.10.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.10.1",
+      "version": "4.10.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump to **4.10.2** and changelog/docs finalization.

## Version files (all → 4.10.2)
- `package.json`, `package-lock.json` (regenerated)
- `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`)
- `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`

## Docs & changelog
- Cut the **[4.10.2] – 2026-06-14** section in `CHANGELOG.md` from `[Unreleased]` (kept an empty `[Unreleased]` on top).
- Added a **v4.10.2 release blog post** (`docs/blog/2026-06-14-v4.10.2.md`) — feeds the in-app News feed via `blog-to-news.mjs` at deploy.
- Feature docs (PKI DM decryption, script dependencies) were added in their respective PRs and are current.

## Release highlights
Cross-source PKI DM decryption (#3441) · MeshCore in Unified Messages + per-channel backlog (#3442) · user-script Python/Node dependencies · Traffic Management telemetry graphs · Auto Welcome pre-send delay (#3439) · malformed-key MeshCore contact removal (#3443) · map max-age slider (#3322) · Helm chart repository + Gateway API HTTPRoute.

## CI
**System tests enabled** — the `system-test` label is applied so the hardware system-test suite runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)