### PR TITLE
fix(channel-detection): prevent phantom swaps when channels share PSK+name (#3452)

### DIFF
--- a/src/server/utils/channelMoveDetection.test.ts
+++ b/src/server/utils/channelMoveDetection.test.ts
@@ -85,4 +85,67 @@ describe('detectChannelMoves', () => {
     expect(moves).toContainEqual({ from: 0, to: 1 });
     expect(moves).toContainEqual({ from: 1, to: 0 });
   });
+
+  it('returns empty when two channels share the same PSK+name (issue #3452 - phantom swap)', () => {
+    // Both slots have identical (psk, name) — ambiguous, must not produce a move
+    const before: ChannelSnapshot[] = [
+      { id: 1, psk: 'defaultPsk', name: 'LongFast' },
+      { id: 3, psk: 'defaultPsk', name: 'LongFast' },
+    ];
+    const after: ChannelSnapshot[] = [
+      { id: 1, psk: 'defaultPsk', name: 'LongFast' },
+      { id: 3, psk: 'defaultPsk', name: 'LongFast' },
+    ];
+    expect(detectChannelMoves(before, after)).toEqual([]);
+  });
+
+  it('does not produce phantom bidirectional swap when duplicate (psk,name) present in both snapshots', () => {
+    // Simulates the exact scenario from issue #3452:
+    // channels 1 and 3 share (psk, name) — detector must decline, not swap them
+    const before: ChannelSnapshot[] = [
+      { id: 0, psk: 'pskA', name: 'Alpha' },
+      { id: 1, psk: 'sharedPsk', name: 'SharedName' },
+      { id: 2, psk: 'pskB', name: 'Beta' },
+      { id: 3, psk: 'sharedPsk', name: 'SharedName' },
+    ];
+    const after: ChannelSnapshot[] = [
+      { id: 0, psk: 'pskA', name: 'Alpha' },
+      { id: 1, psk: 'sharedPsk', name: 'SharedName' },
+      { id: 2, psk: 'pskB', name: 'Beta' },
+      { id: 3, psk: 'sharedPsk', name: 'SharedName' },
+    ];
+    expect(detectChannelMoves(before, after)).toEqual([]);
+  });
+
+  it('detects a real move when the duplicate channel is removed (becomes unique)', () => {
+    // One of the duplicate slots is replaced — remaining unique identity can be tracked
+    const before: ChannelSnapshot[] = [
+      { id: 1, psk: 'pskA', name: 'Alpha' },
+      { id: 2, psk: 'pskB', name: 'Beta' },
+    ];
+    const after: ChannelSnapshot[] = [
+      { id: 1, psk: 'pskB', name: 'Beta' },
+      { id: 2, psk: 'pskA', name: 'Alpha' },
+    ];
+    const moves = detectChannelMoves(before, after);
+    expect(moves).toHaveLength(2);
+    expect(moves).toContainEqual({ from: 1, to: 2 });
+    expect(moves).toContainEqual({ from: 2, to: 1 });
+  });
+
+  it('skips duplicate-identity channels but still detects moves for unique ones', () => {
+    // Channels 1+3 share (psk, name) → skipped; channel 0 (unique) moves to slot 4
+    const before: ChannelSnapshot[] = [
+      { id: 0, psk: 'uniquePsk', name: 'Unique' },
+      { id: 1, psk: 'sharedPsk', name: 'Shared' },
+      { id: 3, psk: 'sharedPsk', name: 'Shared' },
+    ];
+    const after: ChannelSnapshot[] = [
+      { id: 1, psk: 'sharedPsk', name: 'Shared' },
+      { id: 3, psk: 'sharedPsk', name: 'Shared' },
+      { id: 4, psk: 'uniquePsk', name: 'Unique' },
+    ];
+    const moves = detectChannelMoves(before, after);
+    expect(moves).toEqual([{ from: 0, to: 4 }]);
+  });
 });

--- a/src/server/utils/channelMoveDetection.ts
+++ b/src/server/utils/channelMoveDetection.ts
@@ -2,6 +2,9 @@
  * Detects channel moves by comparing before/after snapshots.
  * Matches channels by PSK + name identity across different slot positions.
  * Returns both directions for swaps so downstream migration handles them correctly.
+ *
+ * Only matches when (psk, name) is unique in BOTH snapshots — duplicate identities
+ * are ambiguous and skipped to avoid phantom swaps (see issue #3452).
  */
 
 export interface ChannelSnapshot {
@@ -10,13 +13,33 @@ export interface ChannelSnapshot {
   name?: string | null;
 }
 
+function channelKey(ch: ChannelSnapshot): string {
+  return JSON.stringify([ch.psk, ch.name || '']);
+}
+
+function countByKey(snapshot: ChannelSnapshot[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const ch of snapshot) {
+    if (!ch.psk) continue;
+    const k = channelKey(ch);
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  }
+  return counts;
+}
+
 export function detectChannelMoves(
   beforeSnapshot: ChannelSnapshot[],
   afterSnapshot: ChannelSnapshot[]
 ): { from: number; to: number }[] {
+  const beforeCounts = countByKey(beforeSnapshot);
+  const afterCounts = countByKey(afterSnapshot);
   const moves: { from: number; to: number }[] = [];
+
   for (const oldCh of beforeSnapshot) {
     if (!oldCh.psk || oldCh.psk === '') continue;
+    const k = channelKey(oldCh);
+    // Skip ambiguous identities — (psk, name) must be unique in both snapshots
+    if ((beforeCounts.get(k) ?? 0) !== 1 || (afterCounts.get(k) ?? 0) !== 1) continue;
     const newCh = afterSnapshot.find(ch =>
       ch.id !== oldCh.id &&
       ch.psk === oldCh.psk &&


### PR DESCRIPTION
## Summary

Fixes #3452 — `detectChannelMoves` in `src/server/utils/channelMoveDetection.ts` produced phantom bidirectional swap detections whenever two channels shared the same `(psk, name)` pair. On every config sync this triggered `migrateMessagesForChannelMoves`, progressively scrambling message↔channel attribution.

**Root cause:** the matcher had no uniqueness guard — a duplicate identity in either snapshot caused each side to match the other, generating a bogus `slot X→Y, slot Y→X` swap that recurred forever.

**Fix:** before matching, count occurrences of each `(psk, name)` key in both the before and after snapshots. If the key appears more than once in either snapshot the identity is ambiguous — skip it. Messages stay in place (no corruption), which is strictly safer than mis-migrating them. Unique identities are still matched correctly, so genuine single-moves and genuine swaps continue to work.

## Changes

- `src/server/utils/channelMoveDetection.ts` — added `channelKey` / `countByKey` helpers; `detectChannelMoves` now guards on uniqueness before matching
- `src/server/utils/channelMoveDetection.test.ts` — 4 new regression tests covering the phantom-swap scenario, the mixed unique+duplicate case, and the unchanged genuine-swap path

## Test plan

- [ ] `npm test` — all 10 tests in `channelMoveDetection.test.ts` pass (6 original + 4 new regression tests)
- [ ] CI passes
- [ ] Manually verify: two channels with identical PSK+name no longer produce repeated `channel_migration_on_startup` entries in `audit_log`

https://claude.ai/code/session_01P8be9VE84SBL1LoGefsQ3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8be9VE84SBL1LoGefsQ3c)_