### PR TITLE
fix(meshcore): carry RX SNR onto message events so auto-ack {SNR} resolves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 
+- **MeshCore auto-ack `{SNR}` always blank**: The `{SNR}` macro in MeshCore auto-acknowledge / auto-responder reply templates always rendered as `—`. The RX SNR only arrives on the firmware's `LogRxData` event (not on the contact/channel message-recv event), and while the relay-hash path was buffered across the two events for `{ROUTE}`, the SNR was dropped — the message events hard-coded `snr: undefined`. The SNR is now buffered alongside the path and carried onto `contact_message` / `channel_message` events, so `{SNR}` resolves whenever `{ROUTE}` does.
 - **MeshCore device name stripped parentheses and emoji on save (#3450)**: Editing a MeshCore companion's **Device Name** (Source → Configuration) silently deleted parentheses, emoji, and other Unicode the moment you pressed Save, because the name sanitizer used an `[a-zA-Z0-9\s\-_]` allow-list. It now drops only control characters (which would break the line-based repeater serial CLI) and preserves printable Unicode, capping the result to the device's 32-byte name field on a character boundary (so a multi-byte emoji is never split).
 
 ## [4.10.2] - 2026-06-14

--- a/src/server/meshcoreNativeBackend.otaPacket.test.ts
+++ b/src/server/meshcoreNativeBackend.otaPacket.test.ts
@@ -159,6 +159,41 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
     const msg = events.find((e) => e.event_type === 'contact_message');
     expect(msg).toBeDefined();
     expect(msg.data.path_hops).toEqual(['a3', '7f']);
+    // SNR from the LogRxData metadata is carried onto the message event so
+    // {SNR} resolves in auto-ack/auto-responder templates (#3450-followup).
+    expect(msg.data.snr).toBe(5);
+  });
+
+  it('carries the buffered LogRxData SNR onto a channel_message event', async () => {
+    const { conn, events } = await connectedBackend();
+    const raw = Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]);
+    conn.emit(PushCodes.LogRxData, { lastSnr: -3.5, lastRssi: -88, raw });
+    conn.emit(ResponseCodes.ChannelMsgRecv, {
+      channelIdx: 0,
+      text: 'Alice: ping',
+      senderTimestamp: 1800,
+      pathLen: 0x02,
+    });
+
+    const msg = events.find((e) => e.event_type === 'channel_message');
+    expect(msg).toBeDefined();
+    expect(msg.data.snr).toBe(-3.5);
+    expect(msg.data.path_hops).toEqual(['a3', '7f']);
+  });
+
+  it('leaves snr undefined on a message with no preceding LogRxData', async () => {
+    const { conn, events } = await connectedBackend();
+    conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
+      text: 'hello',
+      senderTimestamp: 1700,
+      pathLen: 0x02,
+      txtType: TxtTypes.Plain,
+    });
+    const msg = events.find((e) => e.event_type === 'contact_message');
+    expect(msg).toBeDefined();
+    expect(msg.data.snr).toBeUndefined();
+    expect(msg.data.path_hops).toBeUndefined();
   });
 
   it('does not throw on malformed LogRxData (empty raw)', async () => {

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -213,9 +213,11 @@ export class MeshCoreNativeBackend extends EventEmitter {
    * recv event (ContactMsgRecv / ChannelMsgRecv) for the same packet, so
    * we buffer the parsed path here and consume it on the next message
    * recv to give the bridge event the real relay-hash chain rather than
-   * just the packed pathLen byte.
+   * just the packed pathLen byte. The RX SNR is carried alongside the path
+   * (it only appears on LogRxData, not on the txt-msg recv event) so the
+   * message event — and {SNR} in auto-ack/auto-responder templates — has it.
    */
-  private pendingTxtMsgPath: { hops: string[]; rawPathLen: number } | null = null;
+  private pendingTxtMsgPath: { hops: string[]; rawPathLen: number; snr?: number } | null = null;
   /** Constructor reference for the meshcore.js Packet parser, populated when the module loads. */
   private PacketCtor: MeshCoreJsModule['Packet'] | null = null;
   /**
@@ -359,15 +361,17 @@ export class MeshCoreNativeBackend extends EventEmitter {
           const pkt = PacketCtor.fromBytes(raw);
           const hops = this.decodePathHops(pkt.path, pkt.pathLen);
 
-          // Buffer the relay-hash chain for the next TXT_MSG recv event.
-          if (pkt.payload_type === TXT_MSG) {
-            this.pendingTxtMsgPath = { hops, rawPathLen: pkt.pathLen };
-          }
-
-          // Surface the full packet for the Packet Monitor. `lastSnr`/
-          // `lastRssi` come from the LogRxData metadata (connection.js).
+          // `lastSnr`/`lastRssi` come from the LogRxData metadata (connection.js).
+          // The SNR only appears here, NOT on the subsequent txt-msg recv event,
+          // so it must be buffered with the path for the message event to carry
+          // it (auto-ack/auto-responder {SNR}).
           const snr = typeof rx?.lastSnr === 'number' ? rx.lastSnr : undefined;
           const rssi = typeof rx?.lastRssi === 'number' ? rx.lastRssi : undefined;
+
+          // Buffer the relay-hash chain + SNR for the next TXT_MSG recv event.
+          if (pkt.payload_type === TXT_MSG) {
+            this.pendingTxtMsgPath = { hops, rawPathLen: pkt.pathLen, snr };
+          }
           this.emitBridgeEvent('ota_packet', {
             payload_type: pkt.payload_type,
             payload_type_string: pkt.payload_type_string,
@@ -439,7 +443,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
         // LogRxData event (raw OTA bytes). undefined when LogRxData is
         // not available (e.g. backend started without raw logging).
         path_hops: consumedPath?.hops,
-        snr: undefined,
+        snr: consumedPath?.snr,
       };
       this.emitBridgeEvent(isCliReply ? 'cli_reply' : 'contact_message', payload);
     });
@@ -455,7 +459,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
         // Same packed-byte semantics as contact_message above.
         path_len: typeof msg.pathLen === 'number' ? msg.pathLen : undefined,
         path_hops: consumedPath?.hops,
-        snr: undefined,
+        snr: consumedPath?.snr,
       });
     });
 


### PR DESCRIPTION
## Summary

A user reported that **`{SNR}` (and `{ROUTE}`)** weren't expanding in MeshCore node **auto-ack** replies.

## Root cause
The MeshCore firmware delivers per-packet RX metadata over **two** events: `LogRxData` (raw OTA bytes — carries the relay-hash path **and** the SNR/RSSI) immediately followed by the `ContactMsgRecv` / `ChannelMsgRecv` text event (which has the message body but **not** the SNR or path).

`meshcoreNativeBackend` buffers the path across those two events (`pendingTxtMsgPath`) so `{ROUTE}` works — but it **dropped the SNR**: the buffer only held `{ hops, rawPathLen }`, and the `contact_message` / `channel_message` payloads hard-coded `snr: undefined`. So `{SNR}` always rendered as `—`.

(`{ROUTE}` itself rides this same correlation and was already wired — it resolves whenever `LogRxData` fires; this change doesn't alter the path handling.)

## Fix
- Buffer the SNR (`rx.lastSnr`, already computed for the Packet Monitor) alongside the path in `pendingTxtMsgPath`.
- Set `snr: consumedPath?.snr` on the `contact_message` and `channel_message` bridge events.

Now `{SNR}` resolves whenever `{ROUTE}` does, from the same `LogRxData` correlation.

## Testing
Extended `meshcoreNativeBackend.otaPacket.test.ts`: SNR is carried onto `contact_message` and `channel_message` from the buffered LogRxData metadata, and left `undefined` when no LogRxData precedes the message.

Full Vitest suite: **6397 passing**, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)