### PR TITLE
feat(firmware): detect bridged nodes and disable OTA firmware update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Features
+
+- **Bridged-node detection disables OTA firmware update**: MeshMonitor now detects when a Meshtastic source is a *bridged* node — a serial/BLE-only radio (e.g. an nRF52-class board with no native IP transport) fronted by a TCP proxy such as `meshtasticd` or `mesh-bridge`. The connected node's `DeviceMetadata` capability flags (`hasWifi` / `hasEthernet`) are now captured for the local node and exposed via the poll API as `deviceMetadata.isBridged`. When both are absent, the node physically cannot serve an OTA HTTP endpoint, so the **Firmware Update** UI is disabled with an explanatory notice ("update it directly via USB instead") and the `POST /api/firmware/update` route rejects the attempt server-side as a defence-in-depth guard. Detection is inert until DeviceMetadata arrives (unknown capabilities are never treated as bridged), so native WiFi/Ethernet nodes are unaffected.
+
 ### Bug Fixes
 
 - **MeshCore auto-ack `{SNR}` always blank**: The `{SNR}` macro in MeshCore auto-acknowledge / auto-responder reply templates always rendered as `—`. The RX SNR only arrives on the firmware's `LogRxData` event (not on the contact/channel message-recv event), and while the relay-hash path was buffered across the two events for `{ROUTE}`, the SNR was dropped — the message events hard-coded `snr: undefined`. The SNR is now buffered alongside the path and carried onto `contact_message` / `channel_message` events, so `{SNR}` resolves whenever `{ROUTE}` does.

--- a/src/components/configuration/FirmwareUpdateSection.tsx
+++ b/src/components/configuration/FirmwareUpdateSection.tsx
@@ -121,14 +121,21 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
       // sources that can't be reached via the OTA CLI's `--host` (BLE, serial,
       // virtual, mqtt, meshcore). `null` means single-source legacy mode.
       sourceType: (config?.meshtasticSourceType ?? null) as string | null,
+      // A bridged node (serial/BLE-only radio fronted by a TCP proxy) reports no
+      // native WiFi/Ethernet and cannot be flashed over the air, even though the
+      // source is technically TCP. Detected server-side from DeviceMetadata.
+      isBridged: (config?.deviceMetadata?.isBridged ?? false) as boolean,
     };
   }, [pollData]);
 
-  // OTA firmware updates require a reachable TCP host. A null sourceType is
-  // legacy single-source mode and trusts MESHTASTIC_NODE_IP.
+  // OTA firmware updates require a reachable TCP host AND a node that actually
+  // has a native IP transport. A null sourceType is legacy single-source mode and
+  // trusts MESHTASTIC_NODE_IP. A bridged node is reached over TCP but the radio
+  // itself can't serve an OTA endpoint, so it is excluded.
   const isOtaSupported =
     (gatewayInfo.sourceType === null || gatewayInfo.sourceType === 'meshtastic_tcp') &&
-    !!gatewayInfo.gatewayIp;
+    !!gatewayInfo.gatewayIp &&
+    !gatewayInfo.isBridged;
 
   // Issue #3413: a node is considered recovered/reachable only when MeshMonitor
   // currently has a live connection AND the node is answering. This gates the
@@ -475,7 +482,12 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
           }}
         >
           <span className="setting-description">
-            {gatewayInfo.sourceType && gatewayInfo.sourceType !== 'meshtastic_tcp'
+            {gatewayInfo.isBridged
+              ? t(
+                  'firmware.ota_unavailable_bridged',
+                  'This node is reached through a serial/BLE-to-TCP bridge (it reports no native WiFi or Ethernet), so it cannot be flashed over the air. Update it directly via USB instead.'
+                )
+              : gatewayInfo.sourceType && gatewayInfo.sourceType !== 'meshtastic_tcp'
               ? t(
                   'firmware.ota_unavailable_non_tcp',
                   'OTA firmware update is only available for TCP sources. The active source ({{type}}) cannot be flashed from MeshMonitor.',
@@ -985,10 +997,15 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
                         disabled={!isOtaSupported}
                         title={
                           !isOtaSupported
-                            ? t(
-                                'firmware.ota_unavailable_tooltip',
-                                'OTA firmware update requires a TCP source with a configured host.'
-                              )
+                            ? gatewayInfo.isBridged
+                              ? t(
+                                  'firmware.ota_unavailable_bridged_tooltip',
+                                  'This bridged node cannot be flashed over the air. Update it directly via USB.'
+                                )
+                              : t(
+                                  'firmware.ota_unavailable_tooltip',
+                                  'OTA firmware update requires a TCP source with a configured host.'
+                                )
                             : undefined
                         }
                         style={{ padding: '0.25rem 0.75rem', fontSize: '0.85rem' }}

--- a/src/hooks/usePoll.ts
+++ b/src/hooks/usePoll.ts
@@ -78,6 +78,12 @@ export interface PollConfig {
   deviceMetadata?: {
     firmwareVersion?: string;
     rebootCount?: number;
+    hasWifi?: boolean;
+    hasEthernet?: boolean;
+    hasBluetooth?: boolean;
+    // True when the node is reached via a serial/BLE-to-TCP bridge and cannot
+    // be flashed over the air. Gates the OTA firmware update UI.
+    isBridged?: boolean;
   };
   localNodeInfo?: LocalNodeInfo;
 }

--- a/src/server/meshtasticManager.bridgedNode.test.ts
+++ b/src/server/meshtasticManager.bridgedNode.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for bridged-node detection on MeshtasticManager:
+ * - isLocalNodeBridged() across capability-flag states
+ * - processDeviceMetadata captures hasWifi/hasEthernet/hasBluetooth from
+ *   the connected node's DeviceMetadata so detection works
+ *
+ * A "bridged" node is a serial/BLE-only radio fronted by a TCP proxy
+ * (meshtasticd, mesh-bridge, …): it reports no native WiFi and no Ethernet,
+ * yet MeshMonitor reaches it over TCP. Such a node cannot serve an OTA HTTP
+ * endpoint, so OTA firmware update must be disabled for it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetSetting = vi.fn();
+const mockSetSetting = vi.fn();
+const mockUpsertNode = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    getSetting: mockGetSetting,
+    setSetting: mockSetSetting,
+    settings: {
+      getSetting: mockGetSetting,
+      setSetting: mockSetSetting,
+      getSettingForSource: vi.fn((_sourceId: string, key: string) => mockGetSetting(key)),
+      setSettingForSource: vi.fn((_sourceId: string, key: string, value: string) => mockSetSetting(key, value)),
+    },
+    nodes: {
+      getAllNodes: vi.fn().mockResolvedValue([]),
+      upsertNode: mockUpsertNode,
+    },
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('MeshtasticManager - bridged node detection', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module = await import('./meshtasticManager.js');
+    manager = module.default;
+    manager.localNodeInfo = {
+      nodeNum: 0x11111111,
+      nodeId: '!11111111',
+      longName: 'Test Local Node',
+      shortName: 'TLN',
+    };
+  });
+
+  describe('isLocalNodeBridged', () => {
+    it('returns false when there is no local node info', () => {
+      manager.localNodeInfo = null;
+      expect(manager.isLocalNodeBridged()).toBe(false);
+    });
+
+    it('returns false when capability flags are unknown (no DeviceMetadata yet)', () => {
+      // Flags undefined => we have not received DeviceMetadata; do not block OTA.
+      expect(manager.isLocalNodeBridged()).toBe(false);
+    });
+
+    it('returns true when the node has neither WiFi nor Ethernet', () => {
+      manager.localNodeInfo.hasWifi = false;
+      manager.localNodeInfo.hasEthernet = false;
+      expect(manager.isLocalNodeBridged()).toBe(true);
+    });
+
+    it('returns false when the node has native WiFi', () => {
+      manager.localNodeInfo.hasWifi = true;
+      manager.localNodeInfo.hasEthernet = false;
+      expect(manager.isLocalNodeBridged()).toBe(false);
+    });
+
+    it('returns false when the node has Ethernet', () => {
+      manager.localNodeInfo.hasWifi = false;
+      manager.localNodeInfo.hasEthernet = true;
+      expect(manager.isLocalNodeBridged()).toBe(false);
+    });
+  });
+
+  describe('processDeviceMetadata capability capture', () => {
+    it('captures flags and flags a WiFi/Ethernet-less node as bridged', async () => {
+      await manager.processDeviceMetadata({
+        hasWifi: false,
+        hasBluetooth: true,
+        hasEthernet: false,
+      });
+
+      expect(manager.localNodeInfo.hasWifi).toBe(false);
+      expect(manager.localNodeInfo.hasEthernet).toBe(false);
+      expect(manager.localNodeInfo.hasBluetooth).toBe(true);
+      expect(manager.isLocalNodeBridged()).toBe(true);
+      // No firmwareVersion in the payload => no DB write on this path.
+      expect(mockUpsertNode).not.toHaveBeenCalled();
+    });
+
+    it('does not flag a native WiFi node as bridged', async () => {
+      await manager.processDeviceMetadata({
+        hasWifi: true,
+        hasBluetooth: true,
+        hasEthernet: false,
+      });
+
+      expect(manager.localNodeInfo.hasWifi).toBe(true);
+      expect(manager.isLocalNodeBridged()).toBe(false);
+    });
+
+    it('coerces missing proto bools to false (treats absent WiFi/Ethernet as bridged)', async () => {
+      // protobufjs may omit default-false bools; the manager must coerce them.
+      await manager.processDeviceMetadata({ firmwareVersion: '' });
+
+      expect(manager.localNodeInfo.hasWifi).toBe(false);
+      expect(manager.localNodeInfo.hasEthernet).toBe(false);
+      expect(manager.isLocalNodeBridged()).toBe(true);
+    });
+
+    it('does nothing when localNodeInfo is not yet initialised', async () => {
+      manager.localNodeInfo = null;
+      await expect(
+        manager.processDeviceMetadata({ hasWifi: false, hasEthernet: false })
+      ).resolves.toBeUndefined();
+      expect(manager.isLocalNodeBridged()).toBe(false);
+    });
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -584,6 +584,12 @@ class MeshtasticManager implements ISourceManager {
     firmwareVersion?: string;
     rebootCount?: number;
     isLocked?: boolean;  // Flag to prevent overwrites after initial setup
+    // Capability flags from the connected node's DeviceMetadata. Used to detect
+    // a "bridged" node — a serial/BLE-only device fronted by a TCP proxy — which
+    // cannot serve an OTA endpoint. Undefined until DeviceMetadata is received.
+    hasWifi?: boolean;
+    hasEthernet?: boolean;
+    hasBluetooth?: boolean;
   } | null = null;
   private actualDeviceConfig: any = null;  // Store actual device config (local node)
   private actualModuleConfig: any = null;  // Store actual module config (local node)
@@ -4454,8 +4460,25 @@ class MeshtasticManager implements ISourceManager {
     // Note: Local node's public key is extracted from security config when received
   }
 
-  getLocalNodeInfo(): { nodeNum: number; nodeId: string; longName: string; shortName: string; hwModel?: number; firmwareVersion?: string; rebootCount?: number; isLocked?: boolean } | null {
+  getLocalNodeInfo(): { nodeNum: number; nodeId: string; longName: string; shortName: string; hwModel?: number; firmwareVersion?: string; rebootCount?: number; isLocked?: boolean; hasWifi?: boolean; hasEthernet?: boolean; hasBluetooth?: boolean } | null {
     return this.localNodeInfo;
+  }
+
+  /**
+   * Whether the connected local node is reached through a bridge/proxy rather
+   * than being a native IP node. A serial/BLE-only device (e.g. an nRF52-class
+   * board) fronted by a TCP proxy (meshtasticd, mesh-bridge, …) reports no
+   * native WiFi and no Ethernet in its DeviceMetadata, yet we reach it over a
+   * TCP socket — so it physically cannot serve an OTA HTTP endpoint. Features
+   * that require direct device IP access (OTA firmware update) must be disabled
+   * for such nodes. Returns false until DeviceMetadata has been received
+   * (capability flags undefined => unknown => treated as not bridged).
+   */
+  isLocalNodeBridged(): boolean {
+    const info = this.localNodeInfo;
+    if (!info) return false;
+    if (info.hasWifi === undefined || info.hasEthernet === undefined) return false;
+    return info.hasWifi === false && info.hasEthernet === false;
   }
 
   /** Returns source-scoped settings keys for local node identity persistence.
@@ -4858,6 +4881,20 @@ class MeshtasticManager implements ISourceManager {
   private async processDeviceMetadata(metadata: any): Promise<void> {
     logger.debug('📱 Processing DeviceMetadata:', JSON.stringify(metadata, null, 2));
     logger.debug('📱 Firmware version:', metadata.firmwareVersion);
+
+    // Capture the node's transport-capability flags (proto3 bools decode to a
+    // concrete true/false). These drive isLocalNodeBridged() — a serial/BLE-only
+    // node fronted by a TCP proxy reports both false and cannot do OTA updates.
+    // Captured independently of firmwareVersion so detection works even if the
+    // firmware string is momentarily empty.
+    if (this.localNodeInfo) {
+      this.localNodeInfo.hasWifi = metadata.hasWifi === true;
+      this.localNodeInfo.hasEthernet = metadata.hasEthernet === true;
+      this.localNodeInfo.hasBluetooth = metadata.hasBluetooth === true;
+      if (this.isLocalNodeBridged()) {
+        logger.info('🌉 Connected node reports no native WiFi/Ethernet — treating as a bridged node (OTA firmware update disabled)');
+      }
+    }
 
     // Update local node info with firmware version (always allowed, even if locked)
     if (this.localNodeInfo && metadata.firmwareVersion) {

--- a/src/server/routes/firmwareUpdateRoutes.test.ts
+++ b/src/server/routes/firmwareUpdateRoutes.test.ts
@@ -28,6 +28,7 @@ const {
   mockIsStepRunning,
   mockHasFlashIncompleteMarker,
   mockClearFlashIncompleteMarker,
+  mockIsLocalNodeBridged,
 } = vi.hoisted(() => ({
   mockGetStatus: vi.fn(),
   mockGetChannel: vi.fn(),
@@ -53,6 +54,7 @@ const {
   mockIsStepRunning: vi.fn().mockReturnValue(false),
   mockHasFlashIncompleteMarker: vi.fn().mockReturnValue(false),
   mockClearFlashIncompleteMarker: vi.fn().mockReturnValue(0),
+  mockIsLocalNodeBridged: vi.fn().mockReturnValue(false),
 }));
 
 // Mock auth middleware to inject admin user
@@ -118,6 +120,7 @@ vi.mock('../services/firmwareUpdateService.js', () => ({
 vi.mock('../meshtasticManager.js', () => ({
   default: {
     getLocalNodeInfo: vi.fn().mockReturnValue(null),
+    isLocalNodeBridged: mockIsLocalNodeBridged,
   },
 }));
 
@@ -156,6 +159,9 @@ describe('firmwareUpdateRoutes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks resets call history but not implementations, so restore the
+    // default (not bridged) — the bridged-node test overrides it to true.
+    mockIsLocalNodeBridged.mockReturnValue(false);
     app = createApp();
   });
 
@@ -324,6 +330,35 @@ describe('firmwareUpdateRoutes', () => {
 
       expect(res.status).toBe(400);
       expect(res.body.success).toBe(false);
+    });
+
+    it('should return 400 (without starting preflight) when the node is bridged', async () => {
+      mockIsLocalNodeBridged.mockReturnValue(true);
+      const releases = [
+        {
+          tagName: 'v2.5.0',
+          version: '2.5.0',
+          prerelease: false,
+          publishedAt: '2024-01-01',
+          htmlUrl: '',
+          assets: [],
+        },
+      ];
+      mockGetCachedReleases.mockReturnValue(releases);
+
+      const res = await request(app)
+        .post('/api/firmware/update')
+        .send({
+          targetVersion: '2.5.0',
+          gatewayIp: '192.168.1.100',
+          hwModel: 44,
+          currentVersion: '2.4.0',
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toMatch(/bridged/i);
+      expect(mockStartPreflight).not.toHaveBeenCalled();
     });
 
     it('should return 400 when target release not found', async () => {

--- a/src/server/routes/firmwareUpdateRoutes.ts
+++ b/src/server/routes/firmwareUpdateRoutes.ts
@@ -8,6 +8,7 @@
 import { Router, Request, Response } from 'express';
 import { requireAdmin } from '../auth/authMiddleware.js';
 import { firmwareUpdateService } from '../services/firmwareUpdateService.js';
+import meshtasticManager from '../meshtasticManager.js';
 import { getEnvironmentConfig } from '../config/environment.js';
 import { logger } from '../../utils/logger.js';
 import path from 'path';
@@ -121,6 +122,22 @@ router.post('/update', async (req: Request, res: Response) => {
       return res.status(400).json({
         success: false,
         error: 'Missing required fields: targetVersion, gatewayIp, hwModel, currentVersion',
+      });
+    }
+
+    // Refuse OTA on a bridged node. A serial/BLE-only device fronted by a TCP
+    // proxy (meshtasticd, mesh-bridge, …) reports no native WiFi/Ethernet and
+    // cannot serve an OTA HTTP endpoint, so the flash would target the proxy,
+    // not the radio. The frontend hides the button, but enforce server-side too.
+    // firmwareUpdateService operates on the default-source manager singleton.
+    if (meshtasticManager.isLocalNodeBridged()) {
+      return res.status(400).json({
+        success: false,
+        error:
+          'OTA firmware update is not available for a bridged node. The connected ' +
+          'node reports no native WiFi or Ethernet, meaning it is reached through a ' +
+          'serial/BLE-to-TCP bridge and cannot be flashed over the air. Update it ' +
+          'directly via USB instead.',
       });
     }
 

--- a/src/server/server.poll.test.ts
+++ b/src/server/server.poll.test.ts
@@ -121,6 +121,7 @@ const meshtasticManagerMock = {
   }),
   getConnectionStatus: vi.fn(() => ({ connected: true, userDisconnected: false })),
   getLocalNodeInfo: vi.fn(() => ({ nodeId: '!node1', longName: 'Test Node 1' })),
+  isLocalNodeBridged: vi.fn(() => false),
   getDeviceConfig: vi.fn(async () => ({
     basic: { nodeId: '!node1' },
     lora: { region: 'US', hopLimit: 3 },

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5318,6 +5318,12 @@ apiRouter.get('/poll', optionalAuth(), async (req, res) => {
       const deviceMetadata = managerNodeInfo ? {
         firmwareVersion: managerNodeInfo.firmwareVersion,
         rebootCount: managerNodeInfo.rebootCount,
+        hasWifi: managerNodeInfo.hasWifi,
+        hasEthernet: managerNodeInfo.hasEthernet,
+        hasBluetooth: managerNodeInfo.hasBluetooth,
+        // True when the node is reached via a bridge/proxy (no native IP) and
+        // therefore cannot do OTA firmware updates. See isLocalNodeBridged().
+        isBridged: activeManager.isLocalNodeBridged(),
       } : undefined;
 
       const pollLocalNodeInfo = managerNodeInfo ? {
@@ -8297,9 +8303,12 @@ apiRouter.post('/admin/get-device-metadata', requireAdmin(), async (req, res) =>
             firmwareVersion: localNodeInfo.firmwareVersion || 'Unknown',
             hwModel: nodeData?.hwModel || 0,
             role: nodeData?.role || 0,
-            hasWifi: false,  // Not tracked for local node
-            hasBluetooth: false,
-            hasEthernet: false,
+            // Capability flags captured from the local node's DeviceMetadata
+            // (undefined until metadata arrives — coerce to false for the wire).
+            hasWifi: localNodeInfo.hasWifi ?? false,
+            hasBluetooth: localNodeInfo.hasBluetooth ?? false,
+            hasEthernet: localNodeInfo.hasEthernet ?? false,
+            isBridged: gdmManager.isLocalNodeBridged(),
             canShutdown: false,
             hasRemoteHardware: false,
             deviceStateVersion: 0,


### PR DESCRIPTION
## Summary

Detects when a Meshtastic source is a **bridged node** — a serial/BLE-only radio (e.g. an nRF52-class board with no native IP transport) fronted by a TCP proxy such as `meshtasticd` or `mesh-bridge` — and disables **OTA Firmware Update** for it. Such a node is reachable over TCP but physically cannot serve an OTA HTTP endpoint, so a flash would target the proxy rather than the radio.

This grew out of an investigation into how MeshMonitor could tell a "real" TCP node apart from a bridge. There's no transport-level signal (TCP and serial framing are identical, and the node never reports which interface a session arrived on), but the firmware's `DeviceMetadata` does expose capability flags — and a node reporting **no WiFi and no Ethernet** that we nonetheless reach over TCP must be bridged.

## How it works

- **Capture**: `processDeviceMetadata` now records `hasWifi`/`hasEthernet`/`hasBluetooth` on `localNodeInfo` (previously only `firmwareVersion` was captured). New `MeshtasticManager.isLocalNodeBridged()` returns true only when both WiFi and Ethernet are explicitly absent; capabilities are "unknown" (→ not bridged) until DeviceMetadata arrives, so native nodes are never falsely flagged.
- **Expose**: the `/api/poll` config builder includes `deviceMetadata.isBridged` (+ the raw flags). `/admin/get-device-metadata` now returns the real local-node flags instead of the hardcoded `false` / "not tracked for local node".
- **Disable (UI)**: `FirmwareUpdateSection` folds `isBridged` into `isOtaSupported`; the install buttons disable, with a dedicated notice and tooltip telling the operator to update via USB.
- **Disable (server)**: `POST /api/firmware/update` rejects a bridged node as defence-in-depth, so the block holds even if the UI is bypassed.

## Notes
- No migration / DB schema change — the firmware UI reads the live manager via `/api/poll`, and the OTA service operates on the default-source manager singleton, so detection is purely in-memory from DeviceMetadata.
- No new locale keys: `FirmwareUpdateSection` uses inline `t(key, default)` fallbacks throughout, matching the existing convention in that component.

## Testing
- New `meshtasticManager.bridgedNode.test.ts`: `isLocalNodeBridged()` across all flag states + `processDeviceMetadata` capture/coercion.
- New firmware-route test: `/api/firmware/update` returns 400 (without starting preflight) for a bridged node.
- Updated `server.poll.test.ts` manager mock with `isLocalNodeBridged`.
- Full Vitest suite green: **6407 passed, 0 failures**. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)