### PR TITLE
fix(mqtt): stop lastHeard-refresh upserts from clobbering NodeInfo

### DIFF
--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -742,3 +742,94 @@ describe('ingestServiceEnvelope — TELEMETRY_APP key normalization (#3314)', ()
     expect(rowByType('health.temperature')).toMatchObject({ value: 36.8 });
   });
 });
+
+/**
+ * Regression: lastHeard-refresh upserts must NOT clobber NodeInfo.
+ *
+ * The POSITION / TEXT / TELEMETRY / PAXCOUNTER / S&F-heartbeat handlers each
+ * upsert the sender node to bump `lastHeard`. They previously hardcoded
+ * `longName: ''`, `shortName: ''`, `hwModel: 0`. Because the upsert merge
+ * treats an empty string / 0 as a *provided* value (not "absent"), the very
+ * next position/telemetry packet after a NODEINFO_APP packet wiped the saved
+ * name — making MQTT nodes appear nameless almost all the time. These refresh
+ * upserts must omit the name/hwModel fields so the merge preserves whatever
+ * NodeInfo already exists.
+ */
+describe('ingestServiceEnvelope — lastHeard refresh must not clobber NodeInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const senderUpsert = () =>
+    (databaseService.upsertNode as any).mock.calls
+      .map((c: any[]) => c[0])
+      .find((n: any) => n.nodeNum === NODE_IN);
+
+  const expectNoNameClobber = (node: any) => {
+    expect(node).toBeDefined();
+    // Must be omitted entirely (undefined) — NOT '' / 0 — so the upsert merge
+    // preserves any existing NodeInfo instead of overwriting it.
+    expect(node.longName).toBeUndefined();
+    expect(node.shortName).toBeUndefined();
+    expect(node.hwModel).toBeUndefined();
+    // lastHeard is the whole point of these upserts and must still be set.
+    expect(node.lastHeard).toBeGreaterThan(0);
+  };
+
+  it('POSITION refresh omits longName/shortName/hwModel', async () => {
+    await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 3 /* POSITION_APP */),
+    });
+    expectNoNameClobber(senderUpsert());
+  });
+
+  it('TEXT refresh omits longName/shortName/hwModel', async () => {
+    await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 1 /* TEXT_MESSAGE_APP */),
+    });
+    expectNoNameClobber(senderUpsert());
+  });
+
+  it('TELEMETRY refresh omits longName/shortName/hwModel', async () => {
+    await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 67 /* TELEMETRY_APP */),
+    });
+    expectNoNameClobber(senderUpsert());
+  });
+
+  it('PAXCOUNTER refresh omits longName/shortName/hwModel', async () => {
+    await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 34 /* PAXCOUNTER_APP */),
+    });
+    expectNoNameClobber(senderUpsert());
+  });
+
+  it('S&F ROUTER_HEARTBEAT refresh omits longName/shortName/hwModel but keeps the server flag', async () => {
+    const { default: protobuf } = await import('./meshtasticProtobufService.js');
+    (protobuf.processPayload as any).mockImplementationOnce(() => ({ rr: 2 /* ROUTER_HEARTBEAT */ }));
+    await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 65 /* STORE_FORWARD_APP */),
+    });
+    const node = senderUpsert();
+    expectNoNameClobber(node);
+    expect(node.isStoreForwardServer).toBe(true);
+  });
+
+  it('NODEINFO still SAVES the real name (positive control)', async () => {
+    // The fix must not touch the NODEINFO_APP path — it is the one upsert that
+    // is supposed to carry real name/hwModel values.
+    await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 4 /* NODEINFO_APP */),
+    });
+    const node = senderUpsert();
+    expect(node.longName).toBe('Test');
+    expect(node.shortName).toBe('TST');
+    expect(node.hwModel).toBe(1);
+  });
+});

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -252,9 +252,11 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
       const node: Partial<DbNode> = {
         nodeNum: fromNum,
         nodeId: fromNodeId,
-        longName: '',
-        shortName: '',
-        hwModel: 0,
+        // Intentionally omit longName/shortName/hwModel: this upsert only
+        // refreshes lastHeard. Passing '' / 0 would clobber names previously
+        // saved from a NODEINFO_APP packet, because the upsert merge treats
+        // an empty string / 0 as a provided value and overwrites. This was the
+        // root cause of MQTT nodes appearing nameless after their NodeInfo.
         // See NODEINFO_APP above — `node.channel` must carry the
         // CHANNEL_DB_OFFSET-encoded virtual-channel id for the map
         // filter to honor Virtual Channel Permissions.
@@ -335,9 +337,11 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
       databaseService.upsertNode({
         nodeNum: fromNum,
         nodeId: fromNodeId,
-        longName: '',
-        shortName: '',
-        hwModel: 0,
+        // Intentionally omit longName/shortName/hwModel: this upsert only
+        // refreshes lastHeard. Passing '' / 0 would clobber names previously
+        // saved from a NODEINFO_APP packet, because the upsert merge treats
+        // an empty string / 0 as a provided value and overwrites. This was the
+        // root cause of MQTT nodes appearing nameless after their NodeInfo.
         lastHeard: Math.floor(nowMs / 1000),
         viaMqtt: true,
         transportMechanism: TransportMechanism.MQTT,
@@ -386,9 +390,11 @@ export async function ingestServiceEnvelope(input: MqttIngestionInput): Promise<
       databaseService.upsertNode({
         nodeNum: fromNum,
         nodeId: fromNodeId,
-        longName: '',
-        shortName: '',
-        hwModel: 0,
+        // Intentionally omit longName/shortName/hwModel: this upsert only
+        // refreshes lastHeard. Passing '' / 0 would clobber names previously
+        // saved from a NODEINFO_APP packet, because the upsert merge treats
+        // an empty string / 0 as a provided value and overwrites. This was the
+        // root cause of MQTT nodes appearing nameless after their NodeInfo.
         lastHeard: Math.floor(nowMs / 1000),
         viaMqtt: true,
         transportMechanism: TransportMechanism.MQTT,
@@ -755,9 +761,9 @@ function ingestPaxcounter(
   databaseService.upsertNode({
     nodeNum: fromNum,
     nodeId: fromNodeId,
-    longName: '',
-    shortName: '',
-    hwModel: 0,
+    // Omit longName/shortName/hwModel — lastHeard refresh only. Passing '' / 0
+    // would clobber names saved from a NODEINFO_APP packet (the merge treats an
+    // empty string / 0 as a provided value and overwrites).
     lastHeard: Math.floor(nowMs / 1000),
     viaMqtt: true,
     transportMechanism: TransportMechanism.MQTT,
@@ -846,9 +852,9 @@ async function ingestStoreForward(
     databaseService.upsertNode({
       nodeNum: fromNum,
       nodeId: fromNodeId,
-      longName: '',
-      shortName: '',
-      hwModel: 0,
+      // Omit longName/shortName/hwModel — lastHeard refresh only. Passing '' / 0
+      // would clobber names saved from a NODEINFO_APP packet (the merge treats an
+      // empty string / 0 as a provided value and overwrites).
       lastHeard: Math.floor(nowMs / 1000),
       viaMqtt: true,
       transportMechanism: TransportMechanism.MQTT,


### PR DESCRIPTION
## Problem

Many nodes seen on MQTT had no name (longName/shortName) and `hwModel: 0`, despite their NodeInfo being received. Investigation showed this was **not** a decoding failure and **not** a de-dup failure — node de-dup on `(nodeNum, sourceId)` is correct and produces no duplicate rows. NodeInfo was being decoded and saved fine, then **wiped microseconds later**.

## Root cause

The MQTT POSITION / TEXT / TELEMETRY / PAXCOUNTER / Store-&-Forward-heartbeat handlers each upsert the sender node only to refresh `lastHeard`, but hardcoded:

```ts
longName: '',
shortName: '',
hwModel: 0,
```

The upsert merge treats an empty string / `0` as a *provided* value, not "absent":
- SQLite (`upsertNodeSqlite`): `setIfProvided` guards only on `!== null && !== undefined`, so `''`/`0` get written.
- PG/MySQL: `nodeData.longName ?? existing` — `''` is not nullish, so it passes through.

A node broadcasts NodeInfo only every few hours but sends position/telemetry constantly, so the name was overwritten back to empty almost immediately after every NodeInfo packet. Net effect: MQTT nodes appear nameless nearly all the time.

This is unique to the MQTT ingest path — the TCP path omits the name fields on non-NodeInfo updates, so its `??`/`setIfProvided` merges already preserve them.

## Fix

Omit `longName`/`shortName`/`hwModel` from the five `lastHeard`-refresh upserts so the merge preserves whatever NodeInfo already exists. The `NODEINFO_APP` handler — the one upsert that legitimately carries real values — is untouched.

## Tests

Adds a regression suite (`lastHeard refresh must not clobber NodeInfo`):
- POSITION / TEXT / TELEMETRY / PAXCOUNTER / S&F-heartbeat refresh upserts now have `longName`/`shortName`/`hwModel` **undefined** (not `''`/`0`) while still setting `lastHeard`.
- Positive control: `NODEINFO_APP` still saves the real name/shortName/hwModel.

- `mqttIngestion.test.ts`: 40/40 pass
- Full suite: 6403 pass, 0 fail, 0 suite failures
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)