### PR TITLE
fix(config): gate Traffic Management/StatusMessage support on firmware version

### DIFF
--- a/src/server/meshtasticManager.moduleSupport.test.ts
+++ b/src/server/meshtasticManager.moduleSupport.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Stub the TCP transport so constructing a manager never touches a real socket
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+// Prevent the constructor's async position-recalc path from touching the DB
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    sources: {
+      getSource: vi.fn().mockResolvedValue(null),
+    },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+import { MeshtasticManager } from './meshtasticManager.js';
+
+function makeManager(firmwareVersion: string | undefined) {
+  const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+  (mgr as any).localNodeInfo = {
+    nodeNum: 123,
+    nodeId: '!0000007b',
+    firmwareVersion,
+  };
+  return mgr;
+}
+
+describe('MeshtasticManager — module support gating (firmware version, not config presence)', () => {
+  describe('supportsTrafficManagement (>= 2.7.22)', () => {
+    it('returns true for 2.7.24', () => {
+      expect((makeManager('2.7.24') as any).supportsTrafficManagement()).toBe(true);
+    });
+
+    it('returns true for the exact threshold 2.7.22', () => {
+      expect((makeManager('2.7.22') as any).supportsTrafficManagement()).toBe(true);
+    });
+
+    it('returns true with a git suffix (2.7.22.abc1234)', () => {
+      expect((makeManager('2.7.22.abc1234') as any).supportsTrafficManagement()).toBe(true);
+    });
+
+    it('returns false for 2.7.21', () => {
+      expect((makeManager('2.7.21') as any).supportsTrafficManagement()).toBe(false);
+    });
+
+    it('returns false when firmware version is unknown', () => {
+      expect((makeManager(undefined) as any).supportsTrafficManagement()).toBe(false);
+    });
+  });
+
+  describe('supportsStatusMessage (>= 2.7.19)', () => {
+    it('returns true for 2.7.24', () => {
+      expect((makeManager('2.7.24') as any).supportsStatusMessage()).toBe(true);
+    });
+
+    it('returns true for the exact threshold 2.7.19', () => {
+      expect((makeManager('2.7.19') as any).supportsStatusMessage()).toBe(true);
+    });
+
+    it('returns false for 2.7.18', () => {
+      expect((makeManager('2.7.18') as any).supportsStatusMessage()).toBe(false);
+    });
+  });
+
+  describe('getCurrentConfig().supportedModules', () => {
+    // Regression: a 2.7.24 device that has never had Traffic Management or
+    // StatusMessage configured sends an all-default config. Proto3 omits an
+    // all-default sub-message, so actualModuleConfig has no trafficManagement /
+    // statusmessage key. Support MUST still be reported based on firmware version.
+    it('reports trafficManagement and statusmessage supported on 2.7.24 with empty module config', () => {
+      const mgr = makeManager('2.7.24');
+      (mgr as any).actualModuleConfig = {}; // no trafficManagement / statusmessage keys (Proto3 omitted)
+
+      const { supportedModules } = mgr.getCurrentConfig();
+
+      expect(supportedModules.trafficManagement).toBe(true);
+      expect(supportedModules.statusmessage).toBe(true);
+    });
+
+    it('reports neither supported on older firmware (2.7.10) even if a config object is present', () => {
+      const mgr = makeManager('2.7.10');
+      // Even if a stale/spurious config object were present, old firmware is unsupported.
+      (mgr as any).actualModuleConfig = { trafficManagement: { enabled: true }, statusmessage: {} };
+
+      const { supportedModules } = mgr.getCurrentConfig();
+
+      expect(supportedModules.trafficManagement).toBe(false);
+      expect(supportedModules.statusmessage).toBe(false);
+    });
+
+    it('reports trafficManagement unsupported but statusmessage supported on 2.7.20', () => {
+      const mgr = makeManager('2.7.20');
+      (mgr as any).actualModuleConfig = {};
+
+      const { supportedModules } = mgr.getCurrentConfig();
+
+      expect(supportedModules.trafficManagement).toBe(false); // needs 2.7.22
+      expect(supportedModules.statusmessage).toBe(true); // needs 2.7.19
+    });
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -4846,8 +4846,12 @@ class MeshtasticManager implements ISourceManager {
       moduleConfig,
       localNodeInfo: this.localNodeInfo,
       supportedModules: {
-        statusmessage: !!moduleConfig.statusmessage,
-        trafficManagement: !!moduleConfig.trafficManagement
+        // Gate on firmware version, NOT on presence of the decoded config
+        // sub-message. Proto3 omits an all-default sub-message, so a fully
+        // supported module whose config is untouched (the common case) would
+        // otherwise report as unsupported. See firmwareVersionAtLeast().
+        statusmessage: this.supportsStatusMessage(),
+        trafficManagement: this.supportsTrafficManagement()
       }
     };
   }
@@ -11946,6 +11950,43 @@ class MeshtasticManager implements ISourceManager {
       minor: parseInt(match[2], 10),
       patch: parseInt(match[3], 10)
     };
+  }
+
+  /**
+   * Check whether the local device firmware version is at least the given
+   * major.minor.patch. Returns false if the firmware version is unknown or
+   * unparseable.
+   *
+   * Used to gate module-config feature support (e.g. Traffic Management,
+   * StatusMessage). Module support MUST NOT be inferred from the presence of a
+   * decoded config sub-message: Proto3 omits a sub-message whose every field is
+   * default, so an all-default (but fully supported) module reports as missing.
+   */
+  private firmwareVersionAtLeast(major: number, minor: number, patch: number): boolean {
+    if (!this.localNodeInfo?.firmwareVersion) {
+      return false;
+    }
+    const version = this.parseFirmwareVersion(this.localNodeInfo.firmwareVersion);
+    if (!version) {
+      return false;
+    }
+    if (version.major !== major) return version.major > major;
+    if (version.minor !== minor) return version.minor > minor;
+    return version.patch >= patch;
+  }
+
+  /**
+   * Check if the local device firmware supports the StatusMessage module (>= 2.7.19)
+   */
+  supportsStatusMessage(): boolean {
+    return this.firmwareVersionAtLeast(2, 7, 19);
+  }
+
+  /**
+   * Check if the local device firmware supports the Traffic Management module (>= 2.7.22)
+   */
+  supportsTrafficManagement(): boolean {
+    return this.firmwareVersionAtLeast(2, 7, 22);
   }
 
   /**


### PR DESCRIPTION
## Summary
On firmware that fully supports Traffic Management (e.g. v2.7.24), the Device Configuration tab still showed it as "Unsupported by this device — requires Meshtastic firmware v2.7.22 or newer." The `supportedModules` flags were derived from the *presence* of the decoded `ModuleConfig` sub-message, but Proto3 omits a sub-message whose every field is default. A device that has never configured the module (the common case) sends no sub-message, so it was reported as unsupported regardless of firmware. This switches the gate to a firmware-version check — exactly what the UI message already promises.

## Changes
- Added private `firmwareVersionAtLeast(major, minor, patch)` helper (reuses existing `parseFirmwareVersion`).
- Added `supportsStatusMessage()` (≥ 2.7.19) and `supportsTrafficManagement()` (≥ 2.7.22), mirroring the existing `supportsFavorites()` pattern.
- `getCurrentConfig().supportedModules` now gates on these helpers instead of `!!moduleConfig.statusmessage` / `!!moduleConfig.trafficManagement`.
- Thresholds taken from the existing UI "unsupported" strings (StatusMessage 2.7.19, Traffic Management 2.7.22) — gated independently.
- New `meshtasticManager.moduleSupport.test.ts` regression suite.

## Issues Resolved
None (reported directly: Traffic Management shown unsupported on firmware v2.7.24).

## Documentation Updates
No documentation changes needed — this is backend support-detection logic; no feature docs describe the gating, and CHANGELOG is generated at release time.

## Testing
- [x] Unit tests pass (full suite: 6984 tests, 0 failures)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] New regression suite (11 cases): version-threshold boundaries for both helpers; a 2.7.24 device with an empty `actualModuleConfig` reports both modules supported; old firmware reports them unsupported even with a stale config object present
- [ ] Manual: on a v2.7.22+ device that has never configured Traffic Management, the Device Configuration tab shows the module as enabled/configurable (no "Unsupported" banner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)