### PR TITLE
docs(lora): clarify TX power accepts signed/negative values

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3176,7 +3176,7 @@
   "lora_config.hop_limit": "Hop Limit",
   "lora_config.hop_limit_description": "Maximum number of hops for mesh packets. Range: 1-7 (default: 3)",
   "lora_config.tx_power": "Transmit Power (dBm)",
-  "lora_config.tx_power_description": "LoRa transmit power in dBm. Value of 0 uses the default maximum safe power for your hardware. Units are in dBm.",
+  "lora_config.tx_power_description": "LoRa transmit power in dBm. A value of 0 uses the default maximum safe power for your hardware. Negative values are permitted (the field is signed) but only meaningful on radios that support reduced/negative output power, e.g. SX126x; firmware does not clamp the lower bound, so behavior for negatives is radio-dependent.",
   "lora_config.channel_num": "Channel Number",
   "lora_config.channel_num_description": "LoRa channel number for frequency hopping. Range: 0-255 (default: 0)",
   "lora_config.rx_boosted_gain": "RX Boosted Gain (SX126x)",


### PR DESCRIPTION
## Context

Users reported that Meshtastic firmware permits **negative** TX power values. This PR verifies the claim and documents the behavior. **No input constraints were added** — negatives are intentionally left accepted.

## Findings

**Firmware (verified):**
- `Config.LoRaConfig.tx_power` is a signed `int32` (on-device narrowed to `int8_t`). Negative values are representable on the wire.
- `0` is a documented sentinel = "use the default maximum safe power for your hardware."
- Firmware applies **upper-bound clamping only** (region/hardware caps). There is **no lower clamp** — a negative passes straight to RadioLib's `setOutputPower()`, where behavior is chip-defined. Meaningful on radios like SX126x (down to ~-9 dBm); undefined elsewhere.

**MeshMonitor (verified):**
- Already accepts negative TX power end-to-end. The three LoRa TX power inputs (`LoRaConfigSection.tsx:405`, `RadioConfigurationSection.tsx:233`, `AdminCommandsTab.tsx:2716`) are bare `type="number"` with no `min`/`max`.
- **No UI filter clamps negatives to 0.** Confirmed there is no `Math.max(0, …)`/clamp on `txPower` anywhere, and the only `min="0"` attributes in the LoRa forms belong to `channelNum` and other unrelated fields — not `txPower`.
- Backend passes `txPower` through unmodified.

## Change

Updates the `lora_config.tx_power_description` help text (en) to state that 0 = default max and that negative values are permitted but radio-dependent. No code/validation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)