### PR TITLE
fix(config): store local-node module config responses (handler was remote-only)

### DIFF
--- a/src/server/meshtasticManager.localModuleConfig.test.ts
+++ b/src/server/meshtasticManager.localModuleConfig.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Stub the TCP transport so constructing a manager never touches a real socket
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+// Prevent the constructor's async position-recalc path from touching the DB
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    sources: { getSource: vi.fn().mockResolvedValue(null) },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+// Mock protobufService — auto-stub any method via a Proxy so the constructor
+// never crashes on an unmocked call; override decodeAdminMessage per test.
+const { decodeAdminMessageMock } = vi.hoisted(() => ({
+  decodeAdminMessageMock: vi.fn(),
+}));
+vi.mock('./protobufService.js', () => {
+  const base: any = {
+    decodeAdminMessage: decodeAdminMessageMock,
+    createGetModuleConfigRequest: vi.fn(() => new Uint8Array()),
+    createAdminPacket: vi.fn(() => new Uint8Array()),
+  };
+  const proxy = new Proxy(base, {
+    get(target, prop: string) {
+      if (!(prop in target)) target[prop] = vi.fn();
+      return target[prop];
+    },
+  });
+  return { default: proxy, convertIpv4ConfigToStrings: vi.fn((x: any) => x) };
+});
+
+import { MeshtasticManager } from './meshtasticManager.js';
+
+const LOCAL_NODE_NUM = 123;
+
+function makeManager() {
+  const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+  (mgr as any).localNodeInfo = {
+    nodeNum: LOCAL_NODE_NUM,
+    nodeId: '!0000007b',
+    firmwareVersion: '2.7.24',
+  };
+  return mgr;
+}
+
+describe('MeshtasticManager — local module config response handling', () => {
+  beforeEach(() => {
+    decodeAdminMessageMock.mockReset();
+  });
+
+  it('merges a non-empty local getModuleConfigResponse into actualModuleConfig', async () => {
+    const mgr = makeManager();
+    (mgr as any).actualModuleConfig = { mqtt: { enabled: true } };
+
+    decodeAdminMessageMock.mockReturnValue({
+      getModuleConfigResponse: { telemetry: { deviceUpdateInterval: 900 } },
+    });
+
+    await (mgr as any).processAdminMessage(new Uint8Array([1]), { from: LOCAL_NODE_NUM });
+
+    expect((mgr as any).actualModuleConfig.telemetry).toEqual({ deviceUpdateInterval: 900 });
+    // Existing keys preserved (merge, not replace)
+    expect((mgr as any).actualModuleConfig.mqtt).toEqual({ enabled: true });
+  });
+
+  it('records an all-default (empty) local response under the pending key', async () => {
+    const mgr = makeManager();
+    (mgr as any).actualModuleConfig = {};
+    // requestModuleConfig(14) would set this; simulate it directly
+    (mgr as any).pendingModuleConfigRequests.set(LOCAL_NODE_NUM, 'trafficManagement');
+
+    decodeAdminMessageMock.mockReturnValue({ getModuleConfigResponse: {} });
+
+    await (mgr as any).processAdminMessage(new Uint8Array([1]), { from: LOCAL_NODE_NUM });
+
+    expect((mgr as any).actualModuleConfig.trafficManagement).toEqual({});
+    // Pending entry consumed
+    expect((mgr as any).pendingModuleConfigRequests.has(LOCAL_NODE_NUM)).toBe(false);
+  });
+
+  it('handles an empty local response when packet `from` is 0 (local origin)', async () => {
+    const mgr = makeManager();
+    (mgr as any).actualModuleConfig = {};
+    (mgr as any).pendingModuleConfigRequests.set(LOCAL_NODE_NUM, 'statusmessage');
+
+    decodeAdminMessageMock.mockReturnValue({ getModuleConfigResponse: {} });
+
+    await (mgr as any).processAdminMessage(new Uint8Array([1]), { from: 0 });
+
+    expect((mgr as any).actualModuleConfig.statusmessage).toEqual({});
+  });
+
+  it('does not overwrite an existing populated config with empty defaults', async () => {
+    const mgr = makeManager();
+    (mgr as any).actualModuleConfig = { trafficManagement: { enabled: true } };
+    (mgr as any).pendingModuleConfigRequests.set(LOCAL_NODE_NUM, 'trafficManagement');
+
+    decodeAdminMessageMock.mockReturnValue({ getModuleConfigResponse: {} });
+
+    await (mgr as any).processAdminMessage(new Uint8Array([1]), { from: LOCAL_NODE_NUM });
+
+    expect((mgr as any).actualModuleConfig.trafficManagement).toEqual({ enabled: true });
+  });
+
+  it('does not store a remote response into the local actualModuleConfig', async () => {
+    const mgr = makeManager();
+    (mgr as any).actualModuleConfig = {};
+
+    decodeAdminMessageMock.mockReturnValue({
+      getModuleConfigResponse: { trafficManagement: { enabled: true } },
+    });
+
+    // from a different node => remote path
+    await (mgr as any).processAdminMessage(new Uint8Array([1]), { from: 999 });
+
+    expect((mgr as any).actualModuleConfig.trafficManagement).toBeUndefined();
+    expect((mgr as any).remoteNodeConfigs.get(999)?.moduleConfig.trafficManagement).toEqual({ enabled: true });
+  });
+
+  it('requestModuleConfig tracks the pending key for the local node', async () => {
+    const mgr = makeManager();
+    (mgr as any).isConnected = true;
+    (mgr as any).transport = { send: vi.fn().mockResolvedValue(undefined) };
+
+    await (mgr as any).requestModuleConfig(14); // TRAFFICMANAGEMENT_CONFIG
+
+    expect((mgr as any).pendingModuleConfigRequests.get(LOCAL_NODE_NUM)).toBe('trafficManagement');
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -70,6 +70,18 @@ const IGNORE_REAPPLY_COOLDOWN_MS = 60_000;
 const ACTIVE_NODE_TOKEN_WINDOW_SECONDS = 7200;
 const ACTIVE_NODE_TOKEN_WINDOW_DAYS = ACTIVE_NODE_TOKEN_WINDOW_SECONDS / 86_400;
 
+// Maps AdminMessage.ModuleConfigType enum values to the ModuleConfig oneof key
+// used in decoded responses. Covers the module types MeshMonitor surfaces a
+// config UI for; used to map empty (all-default, Proto3-omitted) responses back
+// to the correct key via pendingModuleConfigRequests.
+const LOCAL_MODULE_CONFIG_TYPE_KEYS: { [key: number]: string } = {
+  0: 'mqtt',
+  5: 'telemetry',
+  9: 'neighborInfo',
+  13: 'statusmessage',
+  14: 'trafficManagement'
+};
+
 /** Parsed auto-responder payload: list of messages to send, plus the
  * raw decoded JSON object (or `{}` if the payload was plain text) so
  * callers can read optional fields like `private`. */
@@ -11736,6 +11748,39 @@ class MeshtasticManager implements ISourceManager {
           }
           nodeConfig.lastUpdated = Date.now();
           logger.info(`📊 Stored module config response from remote node ${fromNum}, keys:`, Object.keys(nodeConfig.moduleConfig));
+        } else {
+          // Local node: merge the explicit module-config response into
+          // actualModuleConfig. Without this, an explicit refresh
+          // (requestModuleConfig / refreshModuleConfigs) is dropped — only the
+          // initial wantConfig stream ever populated the local config.
+          if (!this.actualModuleConfig) {
+            this.actualModuleConfig = {};
+          }
+          const moduleConfigResponse = adminMsg.getModuleConfigResponse;
+          if (moduleConfigResponse) {
+            const responseKeys = Object.keys(moduleConfigResponse).filter(k => k !== 'payloadVariant' && moduleConfigResponse[k] !== undefined);
+            responseKeys.forEach((key) => {
+              this.actualModuleConfig[key] = moduleConfigResponse[key];
+            });
+
+            // Proto3 omits all-default fields, so an empty response means the
+            // module exists but every value is default. Record it under the
+            // pending request's key so support detection and the config UI see it.
+            if (responseKeys.length === 0) {
+              const localNodeKey = this.localNodeInfo?.nodeNum ?? fromNum;
+              const pendingKey = this.pendingModuleConfigRequests.get(localNodeKey)
+                ?? this.pendingModuleConfigRequests.get(fromNum);
+              if (pendingKey) {
+                logger.info(`📊 Empty local module config response, storing defaults for '${pendingKey}'`);
+                if (this.actualModuleConfig[pendingKey] === undefined) {
+                  this.actualModuleConfig[pendingKey] = {};
+                }
+                this.pendingModuleConfigRequests.delete(localNodeKey);
+                this.pendingModuleConfigRequests.delete(fromNum);
+              }
+            }
+          }
+          logger.info(`📊 Merged local module config response, actualModuleConfig keys:`, Object.keys(this.actualModuleConfig));
         }
       }
 
@@ -12266,6 +12311,14 @@ class MeshtasticManager implements ISourceManager {
       logger.debug(`⚙️ Requesting module config type ${configType} from device`);
       const getModuleConfigMsg = protobufService.createGetModuleConfigRequest(configType);
       const adminPacket = protobufService.createAdminPacket(getModuleConfigMsg, this.localNodeInfo?.nodeNum || 0, this.localNodeInfo?.nodeNum);
+
+      // Track the pending request so an empty (all-default) Proto3 response can be
+      // mapped back to the right key in processAdminMessage. Keyed by the local
+      // node number, matching how the response's `from` field is interpreted.
+      const pendingKey = LOCAL_MODULE_CONFIG_TYPE_KEYS[configType];
+      if (pendingKey && this.localNodeInfo?.nodeNum) {
+        this.pendingModuleConfigRequests.set(this.localNodeInfo.nodeNum, pendingKey);
+      }
 
       await this.transport.send(adminPacket);
       logger.debug(`⚙️ Sent get_module_config_request for config type ${configType}`);


### PR DESCRIPTION
## Summary
The `getModuleConfigResponse` handler in `processAdminMessage` (`src/server/meshtasticManager.ts`) was entirely wrapped in `if (isRemoteNode)`. For the local node, the response was logged and then discarded — it never merged into `this.actualModuleConfig`. Only the initial `wantConfig` download stream ever populated the local node's module config, so explicit refreshes (`requestModuleConfig` / `requestAllModuleConfigs` / `refreshModuleConfigs`) of the local node were effectively no-ops. The Proto3-empty fallback that records an all-default module under its key was also remote-only.

This is the contributing bug found while fixing #3457 (Traffic Management shown unsupported on firmware v2.7.24). That PR resolved the *support-detection* symptom via firmware-version gating; this PR makes explicit local module-config refreshes actually persist.

## Changes
- Added a **local-node branch** to the `getModuleConfigResponse` handler that merges the response into `actualModuleConfig` (preserving existing keys).
- For an empty (all-default, Proto3-omitted) local response, records the module under the pending request's key — without clobbering an already-populated config.
- `requestModuleConfig()` now tracks the pending key (keyed by the local node number) so the empty-response fallback can resolve it.
- Added `LOCAL_MODULE_CONFIG_TYPE_KEYS` map (ModuleConfigType enum → decoded ModuleConfig oneof key).

## Issues Resolved
Relates to #3457 (contributing bug; not user-visible for support detection after #3457).

## Documentation Updates
No documentation changes needed — internal config-sync logic.

## Testing
- [x] Unit tests pass (full suite: 7001 tests, 0 failures)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] New `meshtasticManager.localModuleConfig.test.ts` (6 cases): non-empty merge preserves existing keys; empty response records pending key; `from: 0` local-origin case; no-clobber of a populated config; remote responses don't leak into local config; `requestModuleConfig` pending-key tracking
- [ ] Manual: on a local v2.7.22+ device, trigger a config refresh and confirm an all-default Traffic Management / StatusMessage module persists in `actualModuleConfig`

> Note: the parallel `getConfigResponse` (device config) handler is also remote-only; left out of scope here to keep this focused on module config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)