### PR TITLE
fix: persist companion batteryMv to meshcore_nodes for low-battery alerts (#3462)

### DIFF
--- a/src/server/services/meshcoreTelemetryPoller.test.ts
+++ b/src/server/services/meshcoreTelemetryPoller.test.ts
@@ -73,8 +73,13 @@ function makeRegistry(...managers: MeshCoreManager[]): MeshCoreManagerRegistry {
   return { list: () => managers } as unknown as MeshCoreManagerRegistry;
 }
 
-function makeDatabase(): { db: PollerDatabase; batches: { rows: any[]; sourceId?: string }[] } {
+function makeDatabase(): {
+  db: PollerDatabase;
+  batches: { rows: any[]; sourceId?: string }[];
+  upsertedNodes: { node: any; sourceId: string }[];
+} {
   const batches: { rows: any[]; sourceId?: string }[] = [];
+  const upsertedNodes: { node: any; sourceId: string }[] = [];
   const db: PollerDatabase = {
     telemetry: {
       insertTelemetryBatch: async (rows, sourceId) => {
@@ -82,8 +87,13 @@ function makeDatabase(): { db: PollerDatabase; batches: { rows: any[]; sourceId?
         return rows.length;
       },
     },
+    meshcore: {
+      upsertNode: async (node, sourceId) => {
+        upsertedNodes.push({ node: { ...node }, sourceId });
+      },
+    },
   };
-  return { db, batches };
+  return { db, batches, upsertedNodes };
 }
 
 const FULL_PUBKEY = 'a'.repeat(64);
@@ -336,5 +346,53 @@ describe('MeshCoreTelemetryPoller.pollOnce', () => {
     await poller.pollOnce();
 
     expect(batches).toHaveLength(0);
+  });
+
+  it('persists batteryMv to meshcore_nodes so low-battery notifications can fire (regression #3462)', async () => {
+    const manager = makeManager({
+      sourceId: 'src-batt',
+      publicKey: FULL_PUBKEY,
+      core: { batteryMv: 3800, uptimeSecs: 100, errors: 0, queueLen: 0 },
+      radio: null,
+      packets: null,
+      deviceTime: null,
+      deviceInfo: null,
+    });
+    const { db, upsertedNodes } = makeDatabase();
+    const poller = new MeshCoreTelemetryPoller({ registry: makeRegistry(manager), database: db });
+
+    await poller.pollOnce();
+
+    // Wait for the fire-and-forget upsert to resolve
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(upsertedNodes).toHaveLength(1);
+    expect(upsertedNodes[0].sourceId).toBe('src-batt');
+    expect(upsertedNodes[0].node.publicKey).toBe(FULL_PUBKEY);
+    expect(upsertedNodes[0].node.batteryMv).toBe(3800);
+  });
+
+  it('does not upsert batteryMv when battery is zero or absent', async () => {
+    const zeroBatt = makeManager({
+      sourceId: 'src-zero',
+      publicKey: FULL_PUBKEY,
+      core: { batteryMv: 0, uptimeSecs: 100, errors: 0, queueLen: 0 },
+      radio: null, packets: null, deviceTime: null, deviceInfo: null,
+    });
+    const noBatt = makeManager({
+      sourceId: 'src-none',
+      publicKey: FULL_PUBKEY,
+      core: { uptimeSecs: 100, errors: 0, queueLen: 0 },
+      radio: null, packets: null, deviceTime: null, deviceInfo: null,
+    });
+    const { db: db1, upsertedNodes: u1 } = makeDatabase();
+    const { db: db2, upsertedNodes: u2 } = makeDatabase();
+
+    await new MeshCoreTelemetryPoller({ registry: makeRegistry(zeroBatt), database: db1 }).pollOnce();
+    await new MeshCoreTelemetryPoller({ registry: makeRegistry(noBatt), database: db2 }).pollOnce();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(u1).toHaveLength(0);
+    expect(u2).toHaveLength(0);
   });
 });

--- a/src/server/services/meshcoreTelemetryPoller.ts
+++ b/src/server/services/meshcoreTelemetryPoller.ts
@@ -19,6 +19,7 @@
 
 import { logger } from '../../utils/logger.js';
 import type { DbTelemetry } from '../../services/database.js';
+import type { DbMeshCoreNode } from '../../db/repositories/meshcore.js';
 import type { MeshCoreManager, MeshCoreDeviceInfo } from '../meshcoreManager.js';
 import type { MeshCoreManagerRegistry } from '../meshcoreRegistry.js';
 
@@ -29,6 +30,9 @@ import type { MeshCoreManagerRegistry } from '../meshcoreRegistry.js';
 export interface PollerDatabase {
   telemetry: {
     insertTelemetryBatch: (rows: DbTelemetry[], sourceId?: string) => Promise<number>;
+  };
+  meshcore: {
+    upsertNode: (node: Partial<DbMeshCoreNode> & { publicKey: string }, sourceId: string) => Promise<void>;
   };
 }
 
@@ -237,6 +241,18 @@ export class MeshCoreTelemetryPoller {
         // formatters that key off `voltage` units pick it up nicely.
         push(`${MC_TELEMETRY_PREFIX}battery_volts`, core.batteryMv / 1000, 'V');
         snapshot.batteryMv = core.batteryMv;
+        // Persist to meshcore_nodes so getLowVoltageNodes() can find it for
+        // low-battery notifications. Without this, batteryMv stays NULL in the
+        // table and the notification service never fires for companion nodes.
+        // Mirrors what meshcoreRemoteTelemetryScheduler does for repeaters.
+        if (core.batteryMv > 0) {
+          this.database.meshcore.upsertNode(
+            { publicKey: nodeId, batteryMv: core.batteryMv },
+            manager.sourceId,
+          ).catch((err) => {
+            logger.warn(`[MeshCorePoller:${manager.sourceId}] Failed to persist batteryMv:`, err);
+          });
+        }
       }
       if (core.uptimeSecs !== undefined) {
         push(`${MC_TELEMETRY_PREFIX}uptime_secs`, core.uptimeSecs, 's');


### PR DESCRIPTION
## Summary

Fixes #3462 — MeshCore low battery notifications never firing even when the battery voltage is visibly below the configured threshold in charts.

### Root Cause

`MeshCoreTelemetryPoller` (the companion local-node poller) correctly writes battery voltage into the **telemetry table** on every poll — which is why charts work — but it never updated `meshcore_nodes.batteryMv`.

The low-battery notification service calls `getLowVoltageNodes(sourceId, thresholdMv)`, which queries `meshcore_nodes.batteryMv`. Because that column stayed `NULL` for companion-type MeshCore nodes, no alert ever fired regardless of the actual voltage.

**The path that already worked**: `MeshCoreRemoteTelemetryScheduler` (the over-the-air remote poller for repeater/room-server nodes) already persists `batteryMv` to `meshcore_nodes` via `requestNodeStatus()`. The companion poller had no equivalent step.

### Fix

- Extended `PollerDatabase` interface to include `meshcore.upsertNode`
- After a positive `batteryMv` is received from `getStatsCore()`, call `upsertNode({ publicKey, batteryMv }, sourceId)` to persist it — mirroring the step the remote scheduler already performs for repeaters
- Added two regression tests:
  - Asserts that a healthy companion with battery data triggers an `upsertNode` call with the correct pubkey and voltage
  - Asserts that zero or absent `batteryMv` values are not persisted (no spurious updates)

## Test plan

- [ ] Deploy and connect a MeshCore companion source
- [ ] Set a low-battery voltage threshold above the current battery voltage
- [ ] Wait one poll interval (default 5 min) or trigger a poll
- [ ] Confirm `meshcore_nodes.batteryMv` is now populated
- [ ] Confirm a low-battery Apprise notification fires at the next notification check (default hourly)
- [ ] Verify charts still display battery data normally (telemetry path unchanged)

https://claude.ai/code/session_01S25UopTDdZdn2gJWhiSwHv

---
_Generated by [Claude Code](https://claude.ai/code/session_01S25UopTDdZdn2gJWhiSwHv)_