### PR TITLE
fix(config): accept statusmessage/trafficmanagement in module config save (#3464)

### DIFF
--- a/src/server/constants/moduleConfig.test.ts
+++ b/src/server/constants/moduleConfig.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+  VALID_MODULE_CONFIG_TYPES,
+  isValidModuleConfigType,
+} from './moduleConfig.js';
+
+describe('module config type allow-list', () => {
+  // Regression for #3464: statusmessage and trafficmanagement were made editable
+  // in #3457 (gated on firmware version) but were missing from the generic
+  // module-config save route's allow-list, so saving them returned
+  // "Invalid module type". They must be accepted.
+  it('accepts statusmessage and trafficmanagement (#3464)', () => {
+    expect(isValidModuleConfigType('statusmessage')).toBe(true);
+    expect(isValidModuleConfigType('trafficmanagement')).toBe(true);
+    expect(VALID_MODULE_CONFIG_TYPES).toContain('statusmessage');
+    expect(VALID_MODULE_CONFIG_TYPES).toContain('trafficmanagement');
+  });
+
+  it('accepts every generic module type the UI can send', () => {
+    // The lowercase, separator-free ids the frontend posts to
+    // POST /api/config/module/:moduleType.
+    const expected = [
+      'extnotif',
+      'storeforward',
+      'rangetest',
+      'cannedmsg',
+      'audio',
+      'remotehardware',
+      'detectionsensor',
+      'paxcounter',
+      'serial',
+      'ambientlighting',
+      'statusmessage',
+      'trafficmanagement',
+    ];
+    for (const t of expected) {
+      expect(isValidModuleConfigType(t)).toBe(true);
+    }
+    // No accidental extras: the set should be exactly the expected list.
+    expect([...VALID_MODULE_CONFIG_TYPES].sort()).toEqual([...expected].sort());
+  });
+
+  it('rejects unknown module types', () => {
+    expect(isValidModuleConfigType('bogus')).toBe(false);
+    expect(isValidModuleConfigType('')).toBe(false);
+  });
+
+  it('excludes types that use dedicated config routes (telemetry, neighborinfo)', () => {
+    // These are valid protobuf module configs but are saved through their own
+    // endpoints, not the generic one — so they are intentionally absent here.
+    expect(isValidModuleConfigType('telemetry')).toBe(false);
+    expect(isValidModuleConfigType('neighborinfo')).toBe(false);
+  });
+});

--- a/src/server/constants/moduleConfig.ts
+++ b/src/server/constants/moduleConfig.ts
@@ -1,0 +1,37 @@
+/**
+ * Module config types accepted by the generic module-config save route
+ * (`POST /api/config/module/:moduleType`).
+ *
+ * These are the lowercase, separator-free identifiers the UI sends. Every entry
+ * here MUST have a matching field in `protobufService.createSetModuleConfigMessageGeneric`'s
+ * `configFieldMap` (which translates the id to the protobuf `ModuleConfig` field),
+ * otherwise the save 400s with "Invalid module type" even though the encoder
+ * supports it.
+ *
+ * `statusmessage` and `trafficmanagement` were made editable in #3457 (gated on
+ * firmware version) but were missing from this allow-list, so saving them failed
+ * with "Invalid module type" — see #3464.
+ *
+ * Note: `telemetry` and `neighborinfo` are intentionally absent — they have their
+ * own dedicated config routes rather than going through the generic endpoint.
+ */
+export const VALID_MODULE_CONFIG_TYPES = [
+  'extnotif',
+  'storeforward',
+  'rangetest',
+  'cannedmsg',
+  'audio',
+  'remotehardware',
+  'detectionsensor',
+  'paxcounter',
+  'serial',
+  'ambientlighting',
+  'statusmessage',
+  'trafficmanagement',
+] as const;
+
+export type ModuleConfigType = (typeof VALID_MODULE_CONFIG_TYPES)[number];
+
+export function isValidModuleConfigType(moduleType: string): moduleType is ModuleConfigType {
+  return (VALID_MODULE_CONFIG_TYPES as readonly string[]).includes(moduleType);
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -59,6 +59,7 @@ import { safeFetch, SsrfBlockedError } from './utils/ssrfGuard.js';
 import { resolveRequestSourceId } from './utils/sourceResolver.js';
 import { parseDestinationNum } from './utils/parseDestination.js';
 import { PortNum, modemPresetChannelName, getRoutingErrorName } from './constants/meshtastic.js';
+import { isValidModuleConfigType } from './constants/moduleConfig.js';
 import settingsRoutes, { setSettingsCallbacks } from './routes/settingsRoutes.js';
 import { applyManagerSettings } from './applyManagerSettings.js';
 
@@ -7490,17 +7491,16 @@ apiRouter.post('/config/module/telemetry', requirePermission('configuration', 'w
 });
 
 // Generic module config endpoint - handles extnotif, storeforward, rangetest, cannedmsg, audio,
-// remotehardware, detectionsensor, paxcounter, serial, ambientlighting
+// remotehardware, detectionsensor, paxcounter, serial, ambientlighting, statusmessage, trafficmanagement
 apiRouter.post('/config/module/:moduleType', requirePermission('configuration', 'write'), async (req, res) => {
   try {
     const { moduleType } = req.params;
     const { sourceId: cfgModSourceId, ...config } = req.body;
     const cfgModManager = resolveSourceManager(cfgModSourceId);
 
-    // Validate moduleType
-    const validModuleTypes = ['extnotif', 'storeforward', 'rangetest', 'cannedmsg', 'audio',
-      'remotehardware', 'detectionsensor', 'paxcounter', 'serial', 'ambientlighting'];
-    if (!validModuleTypes.includes(moduleType)) {
+    // Validate moduleType against the shared allow-list (kept in sync with
+    // protobufService.createSetModuleConfigMessageGeneric's configFieldMap). See #3464.
+    if (!isValidModuleConfigType(moduleType)) {
       res.status(400).json({ error: `Invalid module type: ${moduleType}` });
       return;
     }


### PR DESCRIPTION
Fixes #3464.

## Problem

On v4.10.3, saving **Traffic Management** or **Status Message** module config fails server-side:

```
Failed to save Traffic Management config: Invalid module type: trafficmanagement
Failed to save Status Message config: Invalid module type: statusmessage
```

## Root cause

#3457 made these two module configs **editable** (gated on firmware version), and the protobuf encoder (`createSetModuleConfigMessageGeneric`'s `configFieldMap`) already supports both. But the generic save route `POST /api/config/module/:moduleType` validates the module type against a **separate, hardcoded allow-list** (`validModuleTypes`) that was never updated — so both saves were rejected with HTTP 400 before ever reaching the (working) encoder.

Single missing entry in one allow-list; no protobuf/manager/frontend changes needed.

## Fix

- Extract the allow-list into an import-safe shared constant `VALID_MODULE_CONFIG_TYPES` + `isValidModuleConfigType()` in `src/server/constants/moduleConfig.ts`, now including `statusmessage` and `trafficmanagement`.
- Use it in the route in place of the inline array.
- Add `moduleConfig.test.ts` asserting both new types are accepted, unknown types are rejected, and `telemetry`/`neighborinfo` (which use dedicated routes) stay excluded — guarding against this allow-list/encoder drift recurring.

## Validation
- New test: 4/4 pass
- `tsc --noEmit`: clean
- Full Vitest suite: 6446 pass, 0 fail, 0 suite failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)