### PR TITLE
fix(messages): keep delivered-icon visible on own replies (Firefox Android) (#3477)

### DIFF
--- a/src/styles/messages.css
+++ b/src/styles/messages.css
@@ -410,6 +410,9 @@
   align-items: center;
   margin-bottom: 2px;
   padding-left: 0.25rem;
+  /* Issue #3477: never let the delivered/sent status icon be squeezed out of
+     the flex row on narrow screens (Firefox Android was stricter about this). */
+  flex-shrink: 0;
 }
 
 .status-pending {

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1482,7 +1482,12 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
-  width: 100%;
+  /* Issue #3477: in the row-reverse container used for own messages, width:100%
+     consumed the whole row and squeezed .message-status (the delivered icon) to
+     zero width — Firefox Android dropped the icon entirely. flex:1 1 auto with
+     min-width:0 lets this column shrink so the status icon always has room. */
+  flex: 1 1 auto;
+  min-width: 0;
   position: relative;
 }
 


### PR DESCRIPTION
## Summary

Fixes #3477 — on Firefox Android, the delivered/sent status icon was invisible on your own replies to public messages.

**Root cause:** own messages render in a `flex-direction: row-reverse` row. `.message-content` had `width: 100%`, which consumed the entire row on narrow screens and squeezed the adjacent `.message-status` element to zero width. Firefox on Android enforces this more strictly than desktop browsers, so the icon disappeared.

**Fix (pure CSS):**
- `.message-content` (`nodes.css`): `width: 100%` → `flex: 1 1 auto; min-width: 0` so the column shrinks within the flex row instead of claiming all the space.
- `.message-status` (`messages.css`): add `flex-shrink: 0` so the status icon can never be collapsed.

No behavior change on desktop.

## Provenance note

A prior AI-generated branch (`claude/great-dijkstra-8o9zpr`) proposed this same CSS but was cut from a stale main and also bundled an obsolete `server.ts` change — adding `statusmessage`/`trafficmanagement` to a `validModuleTypes` array that **main already handles and has since refactored away** (via #3465). This PR is the clean CSS-only fix rebased on current `main`, dropping that dead hunk.

## Testing
- `tsc --noEmit` clean.
- Pure CSS change — verified no conflicting `.message-content` / `.message-status` overrides elsewhere (the only other rule is an unrelated highlight animation). Visual confirmation on Firefox Android recommended at review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)