### PR TITLE
fix(automation): timed events firing across all sources

### DIFF
--- a/src/server/meshtasticManager.timerTriggerScope.perSource.test.ts
+++ b/src/server/meshtasticManager.timerTriggerScope.perSource.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MeshtasticManager } from './meshtasticManager.js';
+import databaseService from '../services/database.js';
+
+// Regression: "Timed Events are happening across all sources and not just the
+// one intended." updateTimerTriggerResult READ the per-source key
+// (getSettingForSource(this.sourceId, 'timerTriggers')) but WROTE the
+// un-namespaced GLOBAL key (setSetting('timerTriggers', ...)). On every fire it
+// copied that source's trigger list into the global key, which then bled into
+// other sources via the settings GET-merge — so a timer configured for one
+// source ran on all of them. Read and write must both be source-scoped (the
+// per-source helpers deliberately do NOT fall back to global; see #2839).
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+      getSettingForSource: vi.fn().mockResolvedValue(null),
+      setSourceSetting: vi.fn().mockResolvedValue(undefined),
+    },
+  },
+}));
+
+vi.mock('./messageQueueService.js', () => {
+  const mockInstance = {
+    enqueue: vi.fn(),
+    setSendCallback: vi.fn(),
+    clear: vi.fn(),
+    getStatus: vi.fn(() => ({ queueLength: 0, pendingAcks: 0, processing: false })),
+  };
+  function MessageQueueService() { return mockInstance as any; }
+  return { messageQueueService: mockInstance, MessageQueueService };
+});
+
+describe('MeshtasticManager - timer trigger result persistence is source-scoped', () => {
+  const TRIGGER = {
+    id: 'trig-1',
+    name: 'Daily ping',
+    cronExpression: '0 9 * * *',
+    responseType: 'text',
+    response: 'hi',
+    channel: 0,
+    enabled: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes the updated trigger list to the per-source key, not the global key', async () => {
+    const manager = new MeshtasticManager('source-b');
+
+    // The source has its own trigger list under source:source-b:timerTriggers.
+    vi.mocked(databaseService.settings.getSettingForSource).mockResolvedValue(
+      JSON.stringify([TRIGGER]),
+    );
+
+    await (manager as any).updateTimerTriggerResult('trig-1', 'success');
+
+    // Read was source-scoped...
+    expect(databaseService.settings.getSettingForSource).toHaveBeenCalledWith('source-b', 'timerTriggers');
+
+    // ...and the write MUST be source-scoped too (this is the fix).
+    expect(databaseService.settings.setSourceSetting).toHaveBeenCalledTimes(1);
+    const [sourceId, key, value] = vi.mocked(databaseService.settings.setSourceSetting).mock.calls[0];
+    expect(sourceId).toBe('source-b');
+    expect(key).toBe('timerTriggers');
+    const persisted = JSON.parse(value);
+    expect(persisted[0].lastResult).toBe('success');
+    expect(persisted[0].lastRun).toBeGreaterThan(0);
+
+    // It must NOT poison the un-namespaced global key (the original bug).
+    expect(databaseService.settings.setSetting).not.toHaveBeenCalledWith(
+      'timerTriggers',
+      expect.anything(),
+    );
+  });
+
+  it('records an error result against the per-source key', async () => {
+    const manager = new MeshtasticManager('source-a');
+    vi.mocked(databaseService.settings.getSettingForSource).mockResolvedValue(
+      JSON.stringify([TRIGGER]),
+    );
+
+    await (manager as any).updateTimerTriggerResult('trig-1', 'error', 'send failed');
+
+    expect(databaseService.settings.setSourceSetting).toHaveBeenCalledTimes(1);
+    const [sourceId, key, value] = vi.mocked(databaseService.settings.setSourceSetting).mock.calls[0];
+    expect(sourceId).toBe('source-a');
+    expect(key).toBe('timerTriggers');
+    const persisted = JSON.parse(value);
+    expect(persisted[0].lastResult).toBe('error');
+    expect(persisted[0].lastError).toBe('send failed');
+    expect(databaseService.settings.setSetting).not.toHaveBeenCalledWith(
+      'timerTriggers',
+      expect.anything(),
+    );
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -3784,7 +3784,14 @@ class MeshtasticManager implements ISourceManager {
           delete trigger.lastError;
         }
 
-        await databaseService.settings.setSetting('timerTriggers', JSON.stringify(timerTriggers));
+        // Write back to the SAME per-source key we read from above. Using the
+        // un-namespaced global setter here (the original bug) copied this
+        // source's trigger list into the global `timerTriggers` key on every
+        // fire; that global value then bled into other sources via the settings
+        // GET-merge, so a timer configured for one source ran on all of them.
+        // getSettingForSource / setSourceSetting deliberately do NOT fall back
+        // to global (see #2839), so read and write must both be source-scoped.
+        await databaseService.settings.setSourceSetting(this.sourceId, 'timerTriggers', JSON.stringify(timerTriggers));
         logger.debug(`⏱️ Updated timer trigger ${triggerId} result: ${result}`);
       }
     } catch (e) {


### PR DESCRIPTION
## Problem

Users reported that **Timed Events** (Timer Triggers) configured for one source fire on **all** sources.

## Root cause

`updateTimerTriggerResult` (`src/server/meshtasticManager.ts`) had an **asymmetric read/write**:

```ts
// reads the PER-SOURCE key
const json = await databaseService.settings.getSettingForSource(this.sourceId, 'timerTriggers');
...
// writes the GLOBAL un-namespaced key  ← bug
await databaseService.settings.setSetting('timerTriggers', JSON.stringify(timerTriggers));
```

Every time a timer fired, it copied that source's full trigger list into the **global** `timerTriggers` setting. The settings GET-merge (`settingsRoutes.ts` `{ ...global, ...sourceSettings }`) then surfaces that global value to any source that has no per-source override — so the trigger gets read, scheduled, and fired on those sources too. The scheduler and the fire action themselves are correctly per-source; the leak was purely this persistence write.

This is the same class of bug as #2839 (multi-source automation spam), which is exactly why `getSettingForSource` / `setSourceSetting` deliberately do **not** fall back to global.

## Fix

Make the write source-scoped and symmetric with the read:

```ts
await databaseService.settings.setSourceSetting(this.sourceId, 'timerTriggers', JSON.stringify(timerTriggers));
```

Adds `meshtasticManager.timerTriggerScope.perSource.test.ts` asserting the result write targets `source:<id>:timerTriggers` and never the global key (success and error paths).

## Scope notes
- **Secondary hardening (not changed here):** the settings GET-merge still lets a source inherit a *global* `timerTriggers` value, and a `null`-sourceId save fans `restartTimerScheduler` out to every manager. Those are pre-existing behaviors that are only dangerous because this write poisoned the global key — with this fix the global key is no longer written by firing. Happy to follow up on excluding automation keys from the global merge if you want belt-and-suspenders.
- **Existing data:** installs already contaminated may have a stale global `timerTriggers` and/or triggers copied into a source's namespace. This fix stops further contamination but does not retroactively clean those rows — let me know if you want a cleanup migration.

## Validation
- New test: 2/2 pass
- `tsc --noEmit`: clean
- Full Vitest suite: 6448 pass, 0 fail, 0 suite failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)