### PR TITLE
fix(meshcore): surface real Share Contact errors instead of failing silently

### DIFF
--- a/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
@@ -4,7 +4,7 @@
  * Smoke tests for the MeshCore DM contact-detail panel.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MeshCoreContactDetailPanel } from './MeshCoreContactDetailPanel';
 import type { MeshCoreContact } from '../../utils/meshcoreHelpers';
 
@@ -88,5 +88,53 @@ describe('MeshCoreContactDetailPanel', () => {
       />,
     );
     expect(screen.queryByRole('button', { name: 'Discover Path' })).toBeNull();
+  });
+
+  it('surfaces the real server error from onShareContact (issue #3480)', async () => {
+    const contact: MeshCoreContact = { publicKey: PK, advType: 1 };
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const serverError = 'Device rejected share-contact — the firmware may not support this command.';
+    const onShareContact = vi.fn().mockResolvedValue({ ok: false, error: serverError });
+
+    render(
+      <MeshCoreContactDetailPanel
+        contact={contact}
+        publicKey={PK}
+        onShareContact={onShareContact}
+        canWriteNodes
+        isCompanion
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Share Contact' }));
+
+    // The real reason is shown, NOT the hardcoded generic fallback.
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(serverError);
+    expect(onShareContact).toHaveBeenCalledWith(PK);
+
+    confirmSpy.mockRestore();
+  });
+
+  it('falls back to a generic message when onShareContact returns no error text', async () => {
+    const contact: MeshCoreContact = { publicKey: PK, advType: 1 };
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const onShareContact = vi.fn().mockResolvedValue({ ok: false });
+
+    render(
+      <MeshCoreContactDetailPanel
+        contact={contact}
+        publicKey={PK}
+        onShareContact={onShareContact}
+        canWriteNodes
+        isCompanion
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Share Contact' }));
+
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toBe('Share contact failed.'));
+
+    confirmSpy.mockRestore();
   });
 });

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -25,7 +25,7 @@ interface MeshCoreContactDetailPanelProps {
   onResetPath?: (publicKey: string) => Promise<boolean>;
   /** Trigger CMD_SHARE_CONTACT for this contact, broadcasting their saved
    *  advert to nearby nodes. Unset hides the Share button. */
-  onShareContact?: (publicKey: string) => Promise<boolean>;
+  onShareContact?: (publicKey: string) => Promise<{ ok: boolean; error?: string }>;
   /** Manually push a forwarding route into the device's contact record
    *  via CMD_ADD_UPDATE_CONTACT. `outPath` is a comma-separated hex chain
    *  ("a3,7f,02"). Unset OR `advancedPathEditEnabled=false` hides the
@@ -336,13 +336,14 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     setShareError(null);
     setShareSuccess(false);
     try {
-      const ok = await onShareContact(publicKey);
-      if (ok) {
+      const result = await onShareContact(publicKey);
+      if (result.ok) {
         setShareSuccess(true);
         window.setTimeout(() => setShareSuccess(false), 2200);
       } else {
         setShareError(
-          t('meshcore.contact_details.share_contact_error', 'Share contact failed.'),
+          result.error ||
+            t('meshcore.contact_details.share_contact_error', 'Share contact failed.'),
         );
       }
     } finally {

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -104,8 +104,9 @@ export interface MeshCoreActions {
   resetContactPath: (publicKey: string) => Promise<boolean>;
   /** Broadcast the device's saved advert for a contact as a zero-hop frame so
    *  nearby nodes can add this contact themselves. Wraps CMD_SHARE_CONTACT.
-   *  Resolves `true` when the device ACKed; `false` for any error. */
-  shareContact: (publicKey: string) => Promise<boolean>;
+   *  Resolves `{ ok: true }` on ACK; on failure `ok` is false and `error`
+   *  carries the server's actionable reason. */
+  shareContact: (publicKey: string) => Promise<{ ok: boolean; error?: string }>;
   /** Manually push a forwarding route into the device's contact record.
    *  `outPath` is a comma-separated hex chain ("a3,7f,02"); empty string
    *  sets a zero-hop direct path. Server gates this on the
@@ -844,7 +845,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch]);
 
-  const shareContact = useCallback(async (publicKey: string): Promise<boolean> => {
+  const shareContact = useCallback(async (publicKey: string): Promise<{ ok: boolean; error?: string }> => {
     try {
       const response = await csrfFetch(
         `${mcPrefix}/contacts/${encodeURIComponent(publicKey)}/share`,
@@ -852,13 +853,15 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       );
       const data = await response.json();
       if (!data.success) {
-        setError(data.error || 'Failed to share contact');
-        return false;
+        const error = data.error || 'Failed to share contact';
+        setError(error);
+        return { ok: false, error };
       }
-      return true;
+      return { ok: true };
     } catch (_err) {
-      setError('Failed to share contact');
-      return false;
+      const error = 'Failed to share contact';
+      setError(error);
+      return { ok: false, error };
     }
   }, [mcPrefix, csrfFetch]);
 

--- a/src/server/meshcoreManager.shareContact.test.ts
+++ b/src/server/meshcoreManager.shareContact.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for MeshCoreManager.shareContact().
+ *
+ * Share Contact wraps the firmware's CMD_SHARE_CONTACT (opcode 16). The
+ * underlying meshcore.js call rejects with NO argument on a firmware Err, so
+ * the manager must manufacture an actionable reason rather than returning a
+ * bare boolean / `String(undefined)`. See issue #3480 (silent failure on
+ * MeshCore TCP Companion sources).
+ *
+ * Uses the private-method-stubbing pattern from meshcoreManager.channels.test.ts.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+interface BridgeCall {
+  cmd: string;
+  params: Record<string, unknown>;
+  timeout?: number;
+}
+
+function makeManager(opts: {
+  deviceType?: MeshCoreDeviceType;
+  connected?: boolean;
+  response?: { success: boolean; data?: unknown; error?: string };
+}): { manager: MeshCoreManager; bridgeCalls: BridgeCall[] } {
+  const m = new MeshCoreManager('test-source');
+  (m as any).deviceType = opts.deviceType ?? MeshCoreDeviceType.COMPANION;
+  (m as any).connected = opts.connected ?? true;
+
+  const bridgeCalls: BridgeCall[] = [];
+  (m as any).sendBridgeCommand = async (
+    cmd: string,
+    params: Record<string, unknown>,
+    timeout?: number,
+  ) => {
+    bridgeCalls.push({ cmd, params, timeout });
+    return { id: '1', ...(opts.response ?? { success: true, data: { ok: true } }) };
+  };
+
+  return { manager: m, bridgeCalls };
+}
+
+describe('MeshCoreManager — shareContact', () => {
+  const PK = 'a'.repeat(64);
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns ok:true and issues share_contact with a short timeout', async () => {
+    const { manager, bridgeCalls } = makeManager({});
+    const result = await manager.shareContact(PK);
+
+    expect(result).toEqual({ ok: true });
+    expect(bridgeCalls).toHaveLength(1);
+    expect(bridgeCalls[0].cmd).toBe('share_contact');
+    expect(bridgeCalls[0].params).toEqual({ public_key: PK });
+    // Short dedicated timeout, NOT the 30s default — fails fast on a non-acking device.
+    expect(bridgeCalls[0].timeout).toBe(10_000);
+  });
+
+  it('returns an actionable error when the device is not a Companion', async () => {
+    const { manager, bridgeCalls } = makeManager({ deviceType: MeshCoreDeviceType.REPEATER });
+    const result = await manager.shareContact(PK);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Companion/i);
+    // Short-circuits before issuing any bridge command.
+    expect(bridgeCalls).toHaveLength(0);
+  });
+
+  it('returns an actionable error when disconnected', async () => {
+    const { manager, bridgeCalls } = makeManager({ connected: false });
+    const result = await manager.shareContact(PK);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/disconnected/i);
+    expect(bridgeCalls).toHaveLength(0);
+  });
+
+  it('maps a backend timeout to a firmware-support hint (not a raw timeout string)', async () => {
+    const { manager } = makeManager({
+      response: { success: false, error: 'Native command timeout: share_contact' },
+    });
+    const result = await manager.shareContact(PK);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/did not respond/i);
+    expect(result.error).toMatch(/firmware may not support/i);
+  });
+
+  it('replaces a useless "undefined" backend error with a firmware-support hint', async () => {
+    // meshcore.js reject() with no argument → String(undefined) === "undefined".
+    const { manager } = makeManager({ response: { success: false, error: 'undefined' } });
+    const result = await manager.shareContact(PK);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/firmware may not support/i);
+    expect(result.error).not.toMatch(/undefined/);
+  });
+
+  it('forwards a descriptive backend error verbatim', async () => {
+    const { manager } = makeManager({
+      response: {
+        success: false,
+        error: 'Device rejected share-contact — the firmware may not support CMD_SHARE_CONTACT (opcode 16)',
+      },
+    });
+    const result = await manager.shareContact(PK);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe(
+      'Device rejected share-contact — the firmware may not support CMD_SHARE_CONTACT (opcode 16)',
+    );
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -152,6 +152,12 @@ export const MeshCoreDiscoverFilter = {
 
 export type MeshCoreDiscoverMode = 'nearby' | 'repeaters' | 'sensors';
 
+/** Result of a share-contact request, carrying an actionable reason on failure. */
+export interface ShareContactResult {
+  ok: boolean;
+  error?: string;
+}
+
 // Connection types
 export enum ConnectionType {
   SERIAL = 'serial',
@@ -2061,28 +2067,41 @@ class MeshCoreManager extends EventEmitter {
    * CMD_SHARE_CONTACT; the device only retransmits — no local state is
    * mutated, so this method does not touch contacts or meshcore_nodes.
    *
-   * Returns `true` on success, `false` if the device rejected the request
-   * (unknown contact, transient backend error) or this isn't a Companion.
+   * Returns `{ ok: true }` on success. On failure `ok` is false and `error`
+   * carries an actionable reason (not a Companion, disconnected, device
+   * rejected, or no response) so the route and UI can surface it instead of a
+   * generic string. The underlying meshcore.js call rejects with no argument
+   * on a firmware Err, so the descriptive text is manufactured here / in the
+   * native backend rather than read from the device.
    */
-  async shareContact(publicKey: string): Promise<boolean> {
+  async shareContact(publicKey: string): Promise<ShareContactResult> {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
       logger.warn('[MeshCore] Share-contact requires Companion firmware');
-      return false;
+      return { ok: false, error: 'Share contact requires MeshCore Companion firmware.' };
     }
     if (!this.connected) {
-      return false;
+      return { ok: false, error: 'Source is disconnected.' };
     }
     try {
-      const response = await this.sendBridgeCommand('share_contact', { public_key: publicKey });
+      // Use a short dedicated timeout (not the 30s default) so a firmware that
+      // never acks CMD_SHARE_CONTACT fails fast instead of hanging the request.
+      const response = await this.sendBridgeCommand('share_contact', { public_key: publicKey }, 10_000);
       if (!response.success) {
-        logger.warn(`[MeshCore] share_contact failed for ${publicKey}: ${response.error}`);
-        return false;
+        const raw = response.error ?? '';
+        const friendly = /timeout/i.test(raw)
+          ? 'Device did not respond to share-contact within 10s — the firmware may not support this command.'
+          : raw && raw !== 'undefined'
+            ? raw
+            : 'Device rejected share-contact — the firmware may not support this command.';
+        logger.warn(`[MeshCore] share_contact failed for ${publicKey}: ${friendly}`);
+        return { ok: false, error: friendly };
       }
       logger.info(`[MeshCore] Shared contact ${publicKey.substring(0, 16)}…`);
-      return true;
+      return { ok: true };
     } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
       logger.error('[MeshCore] shareContact threw:', error);
-      return false;
+      return { ok: false, error: `Share contact failed: ${msg}` };
     }
   }
 

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -313,6 +313,37 @@ describe('MeshCoreNativeBackend', () => {
     expect(resp.error).toMatch(/Unknown native command/);
   });
 
+  it('share_contact resolves the key and calls the library', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const pubkey = 'aa'.repeat(32); // full 64-char hex → no contact lookup needed
+    const resp = await backend.sendCommand('share_contact', { public_key: pubkey });
+    expect(resp.success).toBe(true);
+    expect(lastInstanceRef.current!.shareContactCalls).toHaveLength(1);
+    expect(Array.from(lastInstanceRef.current!.shareContactCalls[0])).toEqual(
+      Array.from(Uint8Array.from(Buffer.from(pubkey, 'hex'))),
+    );
+  });
+
+  it('share_contact converts the library bare reject() into an actionable error', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    // meshcore.js rejects with NO argument on a firmware Err response.
+    lastInstanceRef.current!.shareContact = () => Promise.reject(undefined);
+
+    const resp = await backend.sendCommand('share_contact', { public_key: 'aa'.repeat(32) });
+    expect(resp.success).toBe(false);
+    // Not the useless "undefined" — a real, actionable message.
+    expect(resp.error).toMatch(/firmware may not support CMD_SHARE_CONTACT/i);
+    expect(resp.error).not.toBe('undefined');
+  });
+
   it('maps get_contacts to bridge-shaped contact rows', async () => {
     const backend = new MeshCoreNativeBackend('src-1', {
       connectionType: 'serial',

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -891,7 +891,21 @@ export class MeshCoreNativeBackend extends EventEmitter {
         // not mutate the contact, it just retransmits the advert.
         const publicKey = await this.resolvePublicKey(params.public_key as string);
         if (!publicKey) throw new Error('Share-contact target not found');
-        await c.shareContact(publicKey);
+        try {
+          await c.shareContact(publicKey);
+        } catch (err) {
+          // meshcore.js rejects this promise with NO argument when the firmware
+          // returns an Err response (connection.js shareContact onErr → reject()),
+          // so `err` is typically undefined. Surface an actionable message
+          // instead of letting `String(undefined)` propagate up the chain.
+          const detail = err instanceof Error ? err.message : err == null ? '' : String(err);
+          throw new Error(
+            detail
+              ? `Device rejected share-contact: ${detail}`
+              : 'Device rejected share-contact — the firmware may not support CMD_SHARE_CONTACT (opcode 16)',
+            { cause: err },
+          );
+        }
         return { ok: true };
       }
 

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -55,7 +55,7 @@ const meshcoreManager = {
   discoverNodes: vi.fn().mockResolvedValue({ returned: 0, newCount: 0 }),
   getRespondToDiscovery: vi.fn().mockResolvedValue(false),
   setRespondToDiscovery: vi.fn().mockResolvedValue(undefined),
-  shareContact: vi.fn().mockResolvedValue(true),
+  shareContact: vi.fn().mockResolvedValue({ ok: true }),
   setContactOutPath: vi.fn().mockResolvedValue(true),
   loginToNode: vi.fn().mockResolvedValue(true),
   requestNodeStatus: vi.fn().mockResolvedValue({ batteryMv: 4200, uptimeSecs: 3600 }),
@@ -1439,7 +1439,7 @@ describe('MeshCore Routes', () => {
 
     beforeEach(() => {
       meshcoreManager.shareContact.mockReset();
-      meshcoreManager.shareContact.mockResolvedValue(true);
+      meshcoreManager.shareContact.mockResolvedValue({ ok: true });
     });
 
     it('requires authentication', async () => {
@@ -1465,12 +1465,29 @@ describe('MeshCore Routes', () => {
       expect(meshcoreManager.shareContact).toHaveBeenCalledWith(VALID_PUBKEY);
     });
 
-    it('returns 409 when the manager rejects (unknown contact / non-companion)', async () => {
-      meshcoreManager.shareContact.mockResolvedValueOnce(false);
+    it('returns 409 and forwards the manager error when the device rejects', async () => {
+      meshcoreManager.shareContact.mockResolvedValueOnce({
+        ok: false,
+        error: 'Device rejected share-contact — the firmware may not support this command.',
+      });
       const response = await authenticatedAgent
         .post(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/share`);
       expect(response.status).toBe(409);
       expect(response.body.success).toBe(false);
+      // Real reason is surfaced, not a hardcoded generic string.
+      expect(response.body.error).toMatch(/firmware may not support/i);
+    });
+
+    it('returns 504 when the device did not respond (timeout)', async () => {
+      meshcoreManager.shareContact.mockResolvedValueOnce({
+        ok: false,
+        error: 'Device did not respond to share-contact within 10s — the firmware may not support this command.',
+      });
+      const response = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/share`);
+      expect(response.status).toBe(504);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toMatch(/did not respond/i);
     });
 
     it('returns 404 when the source has no registered manager', async () => {

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -713,12 +713,15 @@ router.post(
           error: 'Invalid public key — must be 64-char hex',
         });
       }
-      const ok = await managerFor(req).shareContact(publicKey);
-      if (!ok) {
-        return res.status(409).json({
-          success: false,
-          error: 'Share contact failed — contact may be unknown, source disconnected, or not a Companion device',
-        });
+      const result = await managerFor(req).shareContact(publicKey);
+      if (!result.ok) {
+        const error =
+          result.error ??
+          'Share contact failed — contact may be unknown, source disconnected, or not a Companion device';
+        // A non-responding device is a gateway-timeout condition; everything
+        // else (rejected, disconnected, not a Companion) is a 409 conflict.
+        const status = /did not respond|timeout/i.test(error) ? 504 : 409;
+        return res.status(status).json({ success: false, error });
       }
       res.json({ success: true, broadcast: true });
     } catch (error) {


### PR DESCRIPTION
## Summary
**Share Contact** did nothing on a MeshCore TCP Companion source and gave the user no actionable error (issue #3480). I traced the full chain and the root cause is broader than the issue described: `meshcore.js`'s `shareContact()` rejects **with no argument** on a firmware `Err` and has **no internal timeout** (`connection.js:1287`), so the propagated error was the literal string `"undefined"` — or, if the firmware never replied, a 30s hang followed by a generic timeout. On top of that the manager returned a bare `boolean`, the route replied with a hardcoded 409 string, and the UI showed a hardcoded i18n string, so the real reason never reached the user.

The device-type gate is **not** the cause — a TCP Companion correctly resolves to `COMPANION`, and the on-wire frame (opcode 16 + 32-byte key) is correct. If the broadcast itself fails, that's almost certainly a firmware limitation (pymc / official v1.15 not implementing `CMD_SHARE_CONTACT`); this PR makes that **observable and fast** rather than silent, which is the actual complaint.

## Changes
- **Native backend** (`meshcoreNativeBackend.ts`): wrap `c.shareContact()` and convert the argument-less `reject()` into an actionable error (with `cause`) instead of letting `String(undefined)` propagate.
- **Manager** (`meshcoreManager.ts`): `shareContact()` now returns `{ ok, error }` (`ShareContactResult`), uses a **10s dedicated timeout** instead of the 30s default (fail fast, no hang), and maps timeout / `"undefined"` into firmware-support hints.
- **Route** (`meshcoreRoutes.ts`): forward the real error text — **504** for no-response, **409** otherwise.
- **UI** (`useMeshCore.ts` hook + `MeshCoreContactDetailPanel.tsx`): surface the server's error text instead of the hardcoded generic string.

## Issues Resolved
Fixes #3480.

## Documentation Updates
No documentation changes needed — internal error-handling / diagnostics.

## Testing
- [x] Full Vitest suite: 7035 tests, 0 failures
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] New `meshcoreManager.shareContact.test.ts` (6): return shape + short timeout, non-Companion, disconnected, timeout→hint, `"undefined"`→hint, verbatim forward
- [x] `meshcoreNativeBackend.test.ts` (+2): success path + bare-`reject()`→actionable error
- [x] `meshcoreRoutes.test.ts`: updated mock shape; 409 forwards real error + new 504 timeout case
- [x] `MeshCoreContactDetailPanel.test.tsx` (+2): real error surfaced + generic fallback
- [ ] Manual: on a MeshCore TCP Companion (pymc / v1.15), Share Contact now shows a specific reason within ~10s instead of hanging/failing silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)