### PR TITLE
fix(favorites): version-key supportsFavorites cache so it can't stick on unsupported

### DIFF
--- a/src/server/meshtasticManager.favoritesSupport.test.ts
+++ b/src/server/meshtasticManager.favoritesSupport.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Stub the TCP transport so constructing a manager never touches a real socket
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+// Prevent the constructor's async position-recalc path from touching the DB
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    sources: { getSource: vi.fn().mockResolvedValue(null) },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+import { MeshtasticManager } from './meshtasticManager.js';
+
+function makeManager(firmwareVersion: string | null | undefined) {
+  const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+  (mgr as any).localNodeInfo = { nodeNum: 123, nodeId: '!0000007b', firmwareVersion };
+  return mgr;
+}
+
+describe('MeshtasticManager.supportsFavorites — version-keyed cache', () => {
+  it('returns true for 2.7.24', () => {
+    expect(makeManager('2.7.24').supportsFavorites()).toBe(true);
+  });
+
+  it('returns true with a git-suffixed version (2.7.24.abc1234)', () => {
+    expect(makeManager('2.7.24.abc1234').supportsFavorites()).toBe(true);
+  });
+
+  it('returns false for pre-2.7.0 firmware', () => {
+    expect(makeManager('2.6.9').supportsFavorites()).toBe(false);
+  });
+
+  it('returns false when firmware is unknown WITHOUT caching it', () => {
+    const mgr = makeManager(null);
+    expect(mgr.supportsFavorites()).toBe(false);
+    // The unknown-firmware false must not be cached, or it would stick.
+    expect((mgr as any).favoritesSupportCache).toBeNull();
+  });
+
+  it('REGRESSION: recovers after firmware is populated via a non-metadata path', () => {
+    // 1. Connect with unknown firmware; an early caller polls support → false.
+    const mgr = makeManager(null);
+    expect(mgr.supportsFavorites()).toBe(false);
+
+    // 2. Firmware version arrives through a NodeInfo/node-rebuild path that does
+    //    NOT clear favoritesSupportCache (the actual bug — issue: Auto Favorites
+    //    warning on 2.7.24).
+    (mgr as any).localNodeInfo.firmwareVersion = '2.7.24';
+
+    // 3. Support must now reflect the real version, not a stale false.
+    expect(mgr.supportsFavorites()).toBe(true);
+  });
+
+  it('recomputes when the firmware version changes across the 2.7.0 boundary', () => {
+    const mgr = makeManager('2.6.5');
+    expect(mgr.supportsFavorites()).toBe(false);
+
+    // Upgrade in place without clearing the cache — version-keyed cache must notice.
+    (mgr as any).localNodeInfo.firmwareVersion = '2.7.0';
+    expect(mgr.supportsFavorites()).toBe(true);
+  });
+
+  it('caches by version (no recompute for the same version)', () => {
+    const mgr = makeManager('2.7.24');
+    const spy = vi.spyOn(mgr as any, 'parseFirmwareVersion');
+    expect(mgr.supportsFavorites()).toBe(true);
+    expect(mgr.supportsFavorites()).toBe(true);
+    // Parsed once, then served from cache.
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -633,7 +633,12 @@ class MeshtasticManager implements ISourceManager {
   // want_response Routing ACK (error_reason) — or on a routing error / timeout.
   // (issue #2608 follow-up: confirm remote favorite assignment.)
   private pendingAdminAcks: Map<number, { dest: number; resolve: (errorReason: number | null) => void; timer: ReturnType<typeof setTimeout> }> = new Map();
-  private favoritesSupportCache: boolean | null = null;  // Cache firmware support check result
+  // Cache the favorites-support check, keyed by the firmware version it was
+  // computed from. Keying by version means the cache self-invalidates when the
+  // firmware version changes or is populated late (e.g. via a NodeInfo rebuild
+  // that doesn't go through processDeviceMetadata), so a `false` computed while
+  // the version was unknown can never get stuck. See supportsFavorites().
+  private favoritesSupportCache: { version: string; result: boolean } | null = null;
   private cachedAutoAckRegex: { pattern: string; regex: RegExp } | null = null;  // Cached compiled regex
 
   private autoAckCooldowns: Map<number, number> = new Map(); // nodeNum -> lastResponseTimestamp
@@ -12083,21 +12088,25 @@ class MeshtasticManager implements ISourceManager {
    * Result is cached to avoid redundant parsing and version comparisons
    */
   supportsFavorites(): boolean {
-    // Return cached result if available
-    if (this.favoritesSupportCache !== null) {
-      return this.favoritesSupportCache;
-    }
+    const firmwareVersion = this.localNodeInfo?.firmwareVersion;
 
-    if (!this.localNodeInfo?.firmwareVersion) {
+    // Firmware version not known yet (e.g. DeviceMetadata not received). Return
+    // false but DO NOT cache it — otherwise the `false` sticks even after the
+    // version is populated through a path that doesn't clear the cache.
+    if (!firmwareVersion) {
       logger.debug('⚠️ Firmware version unknown, cannot determine favorites support');
-      this.favoritesSupportCache = false;
       return false;
     }
 
-    const version = this.parseFirmwareVersion(this.localNodeInfo.firmwareVersion);
+    // Cache hit only when it was computed from the current firmware version.
+    if (this.favoritesSupportCache?.version === firmwareVersion) {
+      return this.favoritesSupportCache.result;
+    }
+
+    const version = this.parseFirmwareVersion(firmwareVersion);
     if (!version) {
-      logger.debug(`⚠️ Could not parse firmware version: ${this.localNodeInfo.firmwareVersion}`);
-      this.favoritesSupportCache = false;
+      logger.debug(`⚠️ Could not parse firmware version: ${firmwareVersion}`);
+      this.favoritesSupportCache = { version: firmwareVersion, result: false };
       return false;
     }
 
@@ -12105,13 +12114,12 @@ class MeshtasticManager implements ISourceManager {
     const supportsFavorites = version.major > 2 || (version.major === 2 && version.minor >= 7);
 
     if (!supportsFavorites) {
-      logger.debug(`ℹ️ Firmware ${this.localNodeInfo.firmwareVersion} does not support favorites (requires >= 2.7.0)`);
+      logger.debug(`ℹ️ Firmware ${firmwareVersion} does not support favorites (requires >= 2.7.0)`);
     } else {
-      logger.debug(`✅ Firmware ${this.localNodeInfo.firmwareVersion} supports favorites (cached)`);
+      logger.debug(`✅ Firmware ${firmwareVersion} supports favorites`);
     }
 
-    // Cache the result
-    this.favoritesSupportCache = supportsFavorites;
+    this.favoritesSupportCache = { version: firmwareVersion, result: supportsFavorites };
     return supportsFavorites;
   }
 


### PR DESCRIPTION
## Summary
Users on firmware 2.7.24 saw Auto Favorites warn *"Firmware 2.7.24 does not support favorites (requires >= 2.7.0)"* — a contradiction. The version math is correct (`2.7.24` → minor ≥ 7 → supported); the bug is a **stale cache**. `supportsFavorites()` cached its result in a bare boolean and cached `false` whenever it ran before the firmware version was known (`localNodeInfo.firmwareVersion` starts `null` until DeviceMetadata arrives). The version then reaches `localNodeInfo` through NodeInfo/node-rebuild paths (`:4307`, `:4342`, `:4417`) that do **not** clear `favoritesSupportCache` — only `processDeviceMetadata` does. So on reconnect, where the DB already holds the version, the cached `false` stuck even though `firmwareVersion` read `"2.7.24"`.

This is the same family as the Traffic Management gate bug (#3457) but a different mechanism — favorites is the one check with a sticky cache; `firmwareVersionAtLeast()` (Traffic Management / StatusMessage) reads the version fresh each call and is immune.

## Changes
- `favoritesSupportCache` is now **version-keyed** (`{ version, result }`) instead of a bare boolean.
- `supportsFavorites()` returns `false` for unknown firmware **without caching it**, and serves a cache hit only when it matches the *current* firmware version — recomputing otherwise. Robust to event ordering and to which path populates the version, without sprinkling cache-clears across the rebuild sites.
- The disconnect/reset clears (`:1616/:1629/:4920`) remain valid and unchanged.

## Issues Resolved
Resolves the user report: Auto Favorites showing "firmware not new enough" on 2.7.24.

## Documentation Updates
No documentation changes needed — internal caching logic.

## Testing
- [x] Full Vitest suite: 7042 tests, 0 failures
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] New `meshtasticManager.favoritesSupport.test.ts` (7): 2.7.24 (incl. git suffix), pre-2.7.0, unknown-firmware-not-cached, the **poison-then-repopulate regression**, version-boundary recompute, and cache-by-version
- [x] Existing `passiveMode` and `autoFavorite` suites still green with the new cache shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)