### PR TITLE
fix(telemetry): collect air-quality particle counts (protobuf.js snake_case quirk)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Air-quality particle counts never collected or graphed**: Telemetry from an air-quality sensor reported particle counts (`particles_03um` … `particles_100um`) but they never appeared in the telemetry graphs. protobuf.js only camelCases an underscore followed by a *letter*, so these underscore-before-digit fields stayed snake_case on the decoded message; the serial/direct ingestion path read them as `particles03um` (camelCase) → `undefined` → the values were silently dropped before they reached the database. The PM (`pm10Standard`) and CO₂ (`co2Temperature`) fields were unaffected because their underscores precede letters. Ingestion now reads the snake_case form the decoder actually produces (with the camelCase as a fallback), so all six particle bins are stored under their canonical types and graphed. The same quirk affected `EnvironmentMetrics` `rainfall_1h` / `rainfall_24h`, which are fixed alongside.
+
 ## [4.10.3] - 2026-06-14
 
 ### Features

--- a/src/server/meshtasticManager.airQualityParticles.test.ts
+++ b/src/server/meshtasticManager.airQualityParticles.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression test for air-quality particle telemetry ingestion.
+ *
+ * protobuf.js only camelCases an underscore followed by a *letter*, so the
+ * AirQualityMetrics fields `particles_03um … particles_100um` (underscore before
+ * a digit) stay snake_case on the decoded message. The serial/direct ingestion
+ * path read them as `particles03um` (camelCase) → undefined → the particle data
+ * was silently dropped and never graphed. Same quirk affects EnvironmentMetrics
+ * `rainfall_1h` / `rainfall_24h`.
+ *
+ * These tests feed the processor a payload shaped exactly as protobuf.js decodes
+ * it (snake_case for the digit fields) and assert the rows are stored under the
+ * canonical camelCase telemetryType the UI graphs.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockInsertTelemetry = vi.fn();
+const mockUpsertNode = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    telemetry: { insertTelemetry: mockInsertTelemetry },
+    nodes: { upsertNode: mockUpsertNode, getAllNodes: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+/** Find the value stored for a given canonical telemetryType, or undefined. */
+function storedValue(type: string): number | undefined {
+  const call = mockInsertTelemetry.mock.calls.find((c) => c[0]?.telemetryType === type);
+  return call?.[0]?.value;
+}
+function storedTypes(): string[] {
+  return mockInsertTelemetry.mock.calls.map((c) => c[0]?.telemetryType);
+}
+
+describe('MeshtasticManager - air-quality particle telemetry (protobuf.js snake_case quirk)', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module = await import('./meshtasticManager.js');
+    manager = module.default;
+    // trackPKIEncryption hits other state/DB; not under test here.
+    vi.spyOn(manager, 'trackPKIEncryption').mockResolvedValue(undefined);
+  });
+
+  const meshPacket = { from: 0x11111111, id: 42 };
+
+  it('stores particle counts decoded under snake_case names as canonical camelCase types', async () => {
+    // Shape matches protobuf.js output: particles_* stay snake_case, letter
+    // fields (pm10Standard, co2Temperature) come through camelCased.
+    await manager.processTelemetryMessageProtobuf(meshPacket, {
+      time: 1781393171,
+      airQualityMetrics: {
+        pm10Standard: 0,
+        particles_03um: 123,
+        particles_05um: 35,
+        particles_10um: 0,
+        particles_25um: 0,
+        particles_50um: 0,
+        particles_100um: 0,
+        co2Temperature: 23.96,
+        co2Humidity: 49.72,
+      },
+    });
+
+    expect(storedValue('particles03um')).toBe(123);
+    expect(storedValue('particles05um')).toBe(35);
+    // Zero is a real reading and must still be stored.
+    expect(storedValue('particles10um')).toBe(0);
+    expect(storedValue('particles25um')).toBe(0);
+    expect(storedValue('particles50um')).toBe(0);
+    expect(storedValue('particles100um')).toBe(0);
+    // Letter fields keep working.
+    expect(storedValue('co2Temperature')).toBeCloseTo(23.96, 2);
+    expect(storedValue('co2Humidity')).toBeCloseTo(49.72, 2);
+  });
+
+  it('still works if a future decoder emits camelCase particle names', async () => {
+    await manager.processTelemetryMessageProtobuf(meshPacket, {
+      airQualityMetrics: { particles03um: 200, particles05um: 50 },
+    });
+    expect(storedValue('particles03um')).toBe(200);
+    expect(storedValue('particles05um')).toBe(50);
+  });
+
+  it('stores rainfall_1h / rainfall_24h decoded under snake_case names', async () => {
+    await manager.processTelemetryMessageProtobuf(meshPacket, {
+      environmentMetrics: {
+        temperature: 20,
+        rainfall_1h: 2.5,
+        rainfall_24h: 11.0,
+      },
+    });
+    expect(storedValue('rainfall1h')).toBeCloseTo(2.5, 3);
+    expect(storedValue('rainfall24h')).toBeCloseTo(11.0, 3);
+  });
+
+  it('does not store a particle type when neither name form is present', async () => {
+    await manager.processTelemetryMessageProtobuf(meshPacket, {
+      airQualityMetrics: { co2: 400 },
+    });
+    expect(storedTypes()).toContain('co2');
+    expect(storedTypes()).not.toContain('particles03um');
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6447,9 +6447,11 @@ class MeshtasticManager implements ISourceManager {
           { type: 'windSpeed', value: envMetrics.windSpeed, unit: 'm/s' },
           { type: 'windGust', value: envMetrics.windGust, unit: 'm/s' },
           { type: 'windLull', value: envMetrics.windLull, unit: 'm/s' },
-          // Precipitation
-          { type: 'rainfall1h', value: envMetrics.rainfall1h, unit: 'mm' },
-          { type: 'rainfall24h', value: envMetrics.rainfall24h, unit: 'mm' },
+          // Precipitation. Same protobuf.js underscore-before-digit quirk as the
+          // particle counts: `rainfall_1h` / `rainfall_24h` stay snake_case on the
+          // decoded message, so read those with the camelCase as a fallback.
+          { type: 'rainfall1h', value: envMetrics.rainfall1h ?? envMetrics.rainfall_1h, unit: 'mm' },
+          { type: 'rainfall24h', value: envMetrics.rainfall24h ?? envMetrics.rainfall_24h, unit: 'mm' },
           // Soil sensors
           { type: 'soilMoisture', value: envMetrics.soilMoisture, unit: '%' },
           { type: 'soilTemperature', value: envMetrics.soilTemperature, unit: '°C' },
@@ -6512,13 +6514,19 @@ class MeshtasticManager implements ISourceManager {
           { type: 'pm10Environmental', value: aqMetrics.pm10Environmental, unit: 'µg/m³' },
           { type: 'pm25Environmental', value: aqMetrics.pm25Environmental, unit: 'µg/m³' },
           { type: 'pm100Environmental', value: aqMetrics.pm100Environmental, unit: 'µg/m³' },
-          // Particle counts (#/0.1L)
-          { type: 'particles03um', value: aqMetrics.particles03um, unit: '#/0.1L' },
-          { type: 'particles05um', value: aqMetrics.particles05um, unit: '#/0.1L' },
-          { type: 'particles10um', value: aqMetrics.particles10um, unit: '#/0.1L' },
-          { type: 'particles25um', value: aqMetrics.particles25um, unit: '#/0.1L' },
-          { type: 'particles50um', value: aqMetrics.particles50um, unit: '#/0.1L' },
-          { type: 'particles100um', value: aqMetrics.particles100um, unit: '#/0.1L' },
+          // Particle counts (#/0.1L).
+          // protobuf.js only camelCases an underscore followed by a *letter*, so
+          // these underscore-before-digit fields (particles_03um …) stay
+          // snake_case on the decoded message — `aqMetrics.particles03um` is
+          // undefined and the data was silently dropped. Read the snake_case form
+          // the decoder actually produces, with the camelCase as a fallback in
+          // case a future protobuf.js / keepCase config changes the shape.
+          { type: 'particles03um', value: aqMetrics.particles03um ?? aqMetrics.particles_03um, unit: '#/0.1L' },
+          { type: 'particles05um', value: aqMetrics.particles05um ?? aqMetrics.particles_05um, unit: '#/0.1L' },
+          { type: 'particles10um', value: aqMetrics.particles10um ?? aqMetrics.particles_10um, unit: '#/0.1L' },
+          { type: 'particles25um', value: aqMetrics.particles25um ?? aqMetrics.particles_25um, unit: '#/0.1L' },
+          { type: 'particles50um', value: aqMetrics.particles50um ?? aqMetrics.particles_50um, unit: '#/0.1L' },
+          { type: 'particles100um', value: aqMetrics.particles100um ?? aqMetrics.particles_100um, unit: '#/0.1L' },
           // CO2 and related
           { type: 'co2', value: aqMetrics.co2, unit: 'ppm' },
           { type: 'co2Temperature', value: aqMetrics.co2Temperature, unit: '°C' },


### PR DESCRIPTION
## Summary

A user hooked up an air-quality sensor; the PM/CO₂ values graphed but the **particle counts never rendered**. Root cause is a protobuf.js field-naming quirk in the serial/direct telemetry ingestion path — the data was dropped before it ever reached the database.

## Root cause (empirically verified)

protobuf.js's camelCase only collapses an underscore followed by a **letter**, not a **digit**. Decoding the bundled `telemetry.proto`:

```
pm10_standard    → pm10Standard     ✓
co2_temperature  → co2Temperature   ✓
particles_03um   → particles_03um   ✗  (stays snake_case!)
```

`processTelemetryMessageProtobuf` read the particle bins as `aqMetrics.particles03um` (camelCase) → `undefined` → `saveTelemetryMetrics` filters out undefined → nothing stored → nothing to graph. The PM and CO₂ fields were unaffected because their underscores precede letters, which is why only the particle data went missing.

The same quirk affects `EnvironmentMetrics.rainfall_1h` / `rainfall_24h`, fixed alongside.

## Fix

Read the snake_case form the decoder actually produces, with the camelCase as a fallback (so a future protobuf.js/keepCase change can't re-break it). The stored `telemetryType` stays the canonical camelCase the UI graphs/colors already key on (`particles03um`, etc.) — so no frontend change is needed; labels, colors and integer-formatting for these types already exist.

Note: the **MQTT ingestion** path was already correct — its own `snakeToCamel` (`telemetryKeys.ts`) includes digits — so only the direct/serial path needed fixing.

## Testing
- New `meshtasticManager.airQualityParticles.test.ts`: feeds payloads shaped exactly as protobuf.js decodes them (snake_case digit fields) and asserts all six particle bins + rainfall_1h/24h are stored under canonical types, including zero-valued readings. Would fail on the unfixed code.
- Full Vitest suite green: **6450 passed, 0 failures**. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)