### PR TITLE
release: v4.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.10.4] - 2026-06-15
+
 ### Bug Fixes
 
 - **Air-quality particle counts never collected or graphed**: Telemetry from an air-quality sensor reported particle counts (`particles_03um` … `particles_100um`) but they never appeared in the telemetry graphs. protobuf.js only camelCases an underscore followed by a *letter*, so these underscore-before-digit fields stayed snake_case on the decoded message; the serial/direct ingestion path read them as `particles03um` (camelCase) → `undefined` → the values were silently dropped before they reached the database. The PM (`pm10Standard`) and CO₂ (`co2Temperature`) fields were unaffected because their underscores precede letters. Ingestion now reads the snake_case form the decoder actually produces (with the camelCase as a fallback), so all six particle bins are stored under their canonical types and graphed. The same quirk affected `EnvironmentMetrics` `rainfall_1h` / `rainfall_24h`, which are fixed alongside.
+- **Timed Events fired across all sources (#3479)**: A Timer Trigger configured for one source was being scheduled and fired on every source. The per-fire result write saved that source's trigger list to the un-namespaced global settings key, which then bled into other sources via the settings GET-merge. Timer-trigger result writes are now source-scoped, so a timed event only runs on the source it was configured for.
+- **Saving Traffic Management / Status Message config failed (#3464)**: After these modules became editable in 4.10.3, saving either returned HTTP 400 `Invalid module type: trafficmanagement` / `statusmessage`. The generic module-config save route validated against a hardcoded allow-list that was never updated to include the two new module types (the protobuf encoder already supported them). Both are now accepted.
+- **Auto Favorites wrongly reported firmware as unsupported (#3482)**: Auto Favorites could warn "Firmware 2.7.24 does not support favorites (requires >= 2.7.0)" on firmware that clearly qualifies. A support check that ran before the firmware version was known cached `false` and stuck across reconnects. The cache is now keyed by the firmware version it was computed from and never caches the unknown-firmware case.
+- **MeshCore Share Contact failed silently (#3481)**: Share Contact on a MeshCore TCP Companion source could do nothing with no actionable error (or hang ~30s). The real failure reason now reaches the user (e.g. firmware that doesn't support the share command) via a structured result, with a faster 10s timeout instead of a silent 30s hang.
+- **Delivered icon missing on own replies in Firefox on Android (#3477)**: On narrow screens the sent/delivered status icon next to your own messages could disappear in Firefox for Android, because the message content claimed the full row width and collapsed the status column. A CSS flex-sizing fix keeps the icon visible; desktop was unaffected.
 
 ## [4.10.3] - 2026-06-14
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.10.3",
+  "version": "4.10.4",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.10.3",
+  "version": "4.10.4",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.10.3
-appVersion: "4.10.3"
+version: 4.10.4
+appVersion: "4.10.4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.10.3",
+  "version": "4.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.10.3",
+      "version": "4.10.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.10.3",
+  "version": "4.10.4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## v4.10.4 — patch release

Version bumped to **4.10.4** across all five version files (`package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`).

### Bug Fixes (since 4.10.3)
- **Timed Events fired across all sources (#3479)** — timer-trigger result writes are now source-scoped, so a timed event only runs on the source it was configured for.
- **Saving Traffic Management / Status Message config failed (#3464)** — the generic module-config save route now accepts both module types (was rejecting them with "Invalid module type").
- **Auto Favorites wrongly reported firmware as unsupported (#3482)** — the firmware-support cache is keyed by version and no longer sticks on `false` when the version was briefly unknown.
- **MeshCore Share Contact failed silently (#3481)** — the real failure reason now reaches the user, with a faster 10s timeout instead of a silent hang.
- **Delivered icon missing on own replies in Firefox on Android (#3477)** — CSS flex-sizing fix; desktop unaffected.
- **Air-quality particle counts never collected or graphed (#3483)** — underscore-before-digit protobuf fields are now read in their snake_case form, so all six particle bins are stored and graphed.

### Changes
- `CHANGELOG.md`: promoted `[Unreleased]` → `[4.10.4] - 2026-06-15` and added the user-facing PRs merged after the section was last written.

### Validation
- `tsc --noEmit`: clean
- Full Vitest suite: 6470 pass, 0 fail, 0 suite failures
- **System tests enabled** via the `system-test` label on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)