### PR TITLE
fix(notifications): reconcile stale monitored-node IDs; per-source select/deselect (#3486)

### DIFF
--- a/src/components/NotificationsTab.tsx
+++ b/src/components/NotificationsTab.tsx
@@ -6,6 +6,11 @@ import { Channel } from '../types/device';
 import { useToast } from './ToastContainer';
 import SectionNav from './SectionNav';
 import { useSource } from '../contexts/SourceContext';
+import {
+  reconcileMonitoredNodes,
+  selectAllMonitoredNodes,
+  deselectAllMonitoredNodes,
+} from './monitoredNodes';
 
 interface VapidStatus {
   configured: boolean;
@@ -153,6 +158,32 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
              nodeId.includes(lowerSearch);
     });
   }, [availableNodes, nodeSearchTerm]);
+
+  // The set of node IDs actually present under the active source (already
+  // source- and permission-scoped by /api/nodes).
+  const availableNodeIds = useMemo(
+    () => new Set(
+      availableNodes
+        .map(n => n.user?.id || n.nodeId)
+        .filter((id): id is string => Boolean(id)),
+    ),
+    [availableNodes],
+  );
+
+  // Reconcile the loaded per-source selection against the nodes that actually
+  // resolve under the active source: drop stale IDs (saved under another source
+  // or for nodes that no longer exist), which the visible-only "Deselect all"
+  // could never clear (issue #3486). Guard on a populated list so a failed or
+  // not-yet-returned fetch can't wipe a valid selection. Runs on either
+  // ordering of the nodes/prefs loads; the length guard prevents a re-render
+  // loop and is a no-op once reconciled.
+  useEffect(() => {
+    if (availableNodeIds.size === 0) return;
+    const pruned = reconcileMonitoredNodes(selectedMonitoredNodes, availableNodeIds);
+    if (pruned.length !== selectedMonitoredNodes.length) {
+      setSelectedMonitoredNodes(pruned);
+    }
+  }, [availableNodeIds, selectedMonitoredNodes]);
 
   const checkNotificationStatus = async () => {
     if (!('Notification' in window) || !('serviceWorker' in navigator) || !('PushManager' in window)) {
@@ -864,8 +895,16 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
                     <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem' }}>
                       <button
                         onClick={() => {
-                          const filtered = filteredNodes.map(n => n.user?.id || n.nodeId);
-                          setSelectedMonitoredNodes([...new Set([...selectedMonitoredNodes, ...filtered])]);
+                          const searchActive = nodeSearchTerm.trim().length > 0;
+                          const availableIds = availableNodes
+                            .map(n => n.user?.id || n.nodeId)
+                            .filter((id): id is string => Boolean(id));
+                          const filteredIds = filteredNodes
+                            .map(n => n.user?.id || n.nodeId)
+                            .filter((id): id is string => Boolean(id));
+                          setSelectedMonitoredNodes(
+                            selectAllMonitoredNodes(selectedMonitoredNodes, availableIds, filteredIds, searchActive),
+                          );
                         }}
                         className="btn-secondary"
                         style={{ padding: '0.4rem 0.8rem', fontSize: '12px' }}
@@ -874,8 +913,13 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
                       </button>
                       <button
                         onClick={() => {
-                          const filtered = filteredNodes.map(n => n.user?.id || n.nodeId);
-                          setSelectedMonitoredNodes(selectedMonitoredNodes.filter(id => !filtered.includes(id)));
+                          const searchActive = nodeSearchTerm.trim().length > 0;
+                          const filteredIds = filteredNodes
+                            .map(n => n.user?.id || n.nodeId)
+                            .filter((id): id is string => Boolean(id));
+                          setSelectedMonitoredNodes(
+                            deselectAllMonitoredNodes(selectedMonitoredNodes, filteredIds, searchActive),
+                          );
                         }}
                         className="btn-secondary"
                         style={{ padding: '0.4rem 0.8rem', fontSize: '12px' }}

--- a/src/components/monitoredNodes.test.ts
+++ b/src/components/monitoredNodes.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  reconcileMonitoredNodes,
+  selectAllMonitoredNodes,
+  deselectAllMonitoredNodes,
+} from './monitoredNodes';
+
+// Regression tests for issue #3486: stale per-source node IDs (saved under
+// another source / for deleted nodes) lingered in the monitored-nodes selection
+// because the picker only ever operates on the current source's visible list.
+
+describe('reconcileMonitoredNodes', () => {
+  it('drops IDs that do not resolve under the active source', () => {
+    const selected = ['!aaaa1111', '!bbbb2222', '!cccc3333'];
+    const available = ['!aaaa1111', '!cccc3333']; // bbbb is stale
+    expect(reconcileMonitoredNodes(selected, available)).toEqual(['!aaaa1111', '!cccc3333']);
+  });
+
+  it('removes ALL stale IDs when none resolve (the "11 stuck" case)', () => {
+    const selected = Array.from({ length: 11 }, (_, i) => `!stale${i}`);
+    expect(reconcileMonitoredNodes(selected, ['!real1', '!real2'])).toEqual([]);
+  });
+
+  it('keeps everything when all IDs resolve', () => {
+    const selected = ['!a', '!b'];
+    expect(reconcileMonitoredNodes(selected, new Set(['!a', '!b', '!c']))).toEqual(['!a', '!b']);
+  });
+
+  it('accepts a Set or any iterable for availableIds', () => {
+    expect(reconcileMonitoredNodes(['!a', '!x'], new Set(['!a']))).toEqual(['!a']);
+  });
+});
+
+describe('selectAllMonitoredNodes', () => {
+  const available = ['!a', '!b', '!c'];
+
+  it('no search: selects the entire current source (replace), ignoring stale prior selection', () => {
+    const result = selectAllMonitoredNodes(['!stale'], available, available, false);
+    expect(result.sort()).toEqual(['!a', '!b', '!c']);
+    expect(result).not.toContain('!stale');
+  });
+
+  it('search active: adds only the filtered subset to the existing selection', () => {
+    const result = selectAllMonitoredNodes(['!a'], available, ['!b'], true);
+    expect(result.sort()).toEqual(['!a', '!b']);
+  });
+
+  it('search active: does not duplicate already-selected IDs', () => {
+    const result = selectAllMonitoredNodes(['!a', '!b'], available, ['!b', '!c'], true);
+    expect(result.sort()).toEqual(['!a', '!b', '!c']);
+  });
+});
+
+describe('deselectAllMonitoredNodes', () => {
+  it('no search: clears the entire selection including stale IDs (#3486 fix)', () => {
+    expect(deselectAllMonitoredNodes(['!a', '!b', '!stale'], ['!a', '!b'], false)).toEqual([]);
+  });
+
+  it('search active: removes only the filtered subset, leaving the rest', () => {
+    const result = deselectAllMonitoredNodes(['!a', '!b', '!c'], ['!b'], true);
+    expect(result.sort()).toEqual(['!a', '!c']);
+  });
+
+  it('search active: leaves stale (non-visible) IDs untouched', () => {
+    // While filtering, deselect-all must not silently wipe IDs outside the filter.
+    const result = deselectAllMonitoredNodes(['!a', '!stale'], ['!a'], true);
+    expect(result).toEqual(['!stale']);
+  });
+});

--- a/src/components/monitoredNodes.ts
+++ b/src/components/monitoredNodes.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure helpers for the Notifications → Battery Alerts "monitored nodes" picker
+ * (issue #3486).
+ *
+ * `selectedMonitoredNodes` is a per-source list of node IDs (bare `nodeId`
+ * strings, e.g. `!abcd1234`). The picker only ever shows the *current source's*
+ * nodes — `/api/nodes?sourceId=…` is source- and channel-permission-scoped — so
+ * IDs that were saved under a different source, or for nodes that no longer
+ * exist under the active source, are invisible in the list. The old
+ * "Deselect all" only touched the visible/filtered rows, so those stale IDs
+ * could never be cleared and the selection count stayed wrong (the user saw
+ * "11 node(s) selected" with nothing visibly checked, and low-battery alerts
+ * silently matched nothing).
+ *
+ * These helpers operate on a per-source basis: with no search filter active the
+ * buttons act on the whole current source, and the reconcile step drops IDs
+ * that don't resolve under it.
+ */
+
+/**
+ * Drop selected IDs that don't resolve to a node visible under the active
+ * source. Used to reconcile a loaded per-source selection against the nodes
+ * actually present, so stale cross-source / deleted IDs don't linger.
+ */
+export function reconcileMonitoredNodes(
+  selected: string[],
+  availableIds: Iterable<string>,
+): string[] {
+  const available = availableIds instanceof Set ? availableIds : new Set(availableIds);
+  return selected.filter((id) => available.has(id));
+}
+
+/**
+ * "Select all" semantics.
+ * - No search term active → select the entire current source's node set
+ *   (per-source replace), so the result is exactly what's shown.
+ * - Search active → add just the filtered subset to the existing selection,
+ *   preserving targeted multi-add while filtering.
+ */
+export function selectAllMonitoredNodes(
+  selected: string[],
+  availableIds: string[],
+  filteredIds: string[],
+  searchActive: boolean,
+): string[] {
+  if (searchActive) {
+    return [...new Set([...selected, ...filteredIds])];
+  }
+  return [...new Set(availableIds)];
+}
+
+/**
+ * "Deselect all" semantics.
+ * - No search term active → clear the entire per-source selection, including
+ *   any stale IDs not shown in the list (this is the #3486 fix).
+ * - Search active → remove only the filtered subset.
+ */
+export function deselectAllMonitoredNodes(
+  selected: string[],
+  filteredIds: string[],
+  searchActive: boolean,
+): string[] {
+  if (searchActive) {
+    const remove = new Set(filteredIds);
+    return selected.filter((id) => !remove.has(id));
+  }
+  return [];
+}


### PR DESCRIPTION
Fixes #3486.

## Problem

In **Notifications → Battery Alerts**, the "Select which nodes to monitor" picker showed a stuck selection count (e.g. "11 node(s) selected") with nothing visibly checked, and "Deselect all" couldn't clear it. Low-battery alerts also silently matched nothing.

## Root cause

The picker is **source-scoped**: it only lists the current source's nodes (`/api/nodes?sourceId=…`, also channel-permission filtered). The saved selection is per-source too, but node IDs saved under a *different* source — or for nodes that no longer exist under the active source — stayed in `selectedMonitoredNodes` while being invisible in the list. "Deselect all" mapped over only the **visible/filtered** rows (`filteredNodes`), so those stale IDs were unreachable and the count never went to 0. `getLowBatteryMonitoredNodes` then found no matching nodes to alert on.

(There is no key-format mismatch — selection and list both compare bare `nodeId` strings. The IDs are simply filtered out of the source-scoped response.)

## Fix

- **Reconcile / prune (on load):** prune the per-source selection down to IDs that actually resolve under the active source. Guarded on a populated node list so a failed or not-yet-returned fetch can't wipe a valid selection, and works regardless of whether the nodes or the prefs load first (length-guarded, no re-render loop).
- **Per-source Select all / Deselect all:**
  - No search term → **Select all** selects the entire current source; **Deselect all** clears the entire selection (stale IDs included).
  - Search active → previous subset add/remove behaviour preserved, so you can still do targeted multi-select while filtering (and stale IDs outside the filter are left untouched).

Set logic is extracted into pure helpers (`src/components/monitoredNodes.ts`) with unit tests.

## Notes
- For **non-admin** users, the active-source list is also channel-permission filtered, so reconcile prunes against what the user can actually see/manage in the picker. Admins see the full source list.
- Reconcile updates local state only; the cleaned selection persists when the user saves preferences (consistent with the rest of the form).

## Validation
- New unit tests: 10/10 pass (reconcile + both button modes)
- `tsc --noEmit`: clean
- Full Vitest suite: 6480 pass, 0 fail, 0 suite failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)