### PR TITLE
ci: pin Claude Action model (default model 404s on every PR)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,8 +43,10 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}  # Required to avoid OIDC token errors
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin the model explicitly. The action's old default (claude-sonnet-4-20250514)
+          # has been removed and now 404s ("not_found_error"), which failed this check on
+          # every PR. Bump to a current Opus if you want deeper reviews.
+          model: "claude-sonnet-4-6"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,9 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin the model explicitly. The action's old default (claude-sonnet-4-20250514)
+          # has been removed and now 404s ("not_found_error"). Bump to a current Opus if desired.
+          model: "claude-sonnet-4-6"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.CLAUDE_GITHUB_TOKEN }}
-          model: "claude-sonnet-4-20250514"
+          model: "claude-sonnet-4-6"
 
           direct_prompt: |
             🤖 **Automated Issue Triage**
@@ -268,7 +268,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.CLAUDE_GITHUB_TOKEN }}
-          model: "claude-sonnet-4-20250514"
+          model: "claude-sonnet-4-6"
 
           direct_prompt: |
             🤖 **Automated Issue Triage** (Manual Trigger)
@@ -484,7 +484,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.CLAUDE_GITHUB_TOKEN }}
-          model: "claude-sonnet-4-20250514"
+          model: "claude-sonnet-4-6"
 
           direct_prompt: |
             🤖 **Automated Follow-up Analysis**


### PR DESCRIPTION
## Problem

The **Claude Code Review** check has been failing on every PR with:

```
API Error: 404 {"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}
```

`claude-code-review.yml` and `claude.yml` don't set `model:` (the line was commented out), so they fall back to the **action's default model** — which has been removed upstream and now 404s. `issue-triage.yml` hardcoded the same dead model id in three places.

This is why claude-review showed `failure` on recent PRs (e.g. #3487) despite the code being fine; it's an infra issue, not a review finding. Confirmed via the failed log: `CLAUDE_SUCCESS: false` + the 404 above. (A secret refresh does **not** fix it — it's the model id, not auth.)

## Fix

Pin a current model (`claude-sonnet-4-6`) in all three workflows:
- `claude-code-review.yml` (uncommented + set)
- `claude.yml` (uncommented + set)
- `issue-triage.yml` (3 occurrences replaced)

Sonnet 4.6 matches the action's previous Sonnet-tier default; bump to a current Opus if deeper reviews are wanted.

## Validation
- No `claude-sonnet-4-20250514` references remain in active config (only in explanatory comments).
- All three workflow YAMLs parse cleanly.

This PR will itself exercise the fixed `claude-code-review.yml`, so a green claude-review check here confirms it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)