### PR TITLE
feat(auth): native OIDC group → role mapping + SSO docs fixes (#3485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Features
+
+- **Native OIDC group → role mapping (#3485)**: When using OIDC directly (no reverse proxy), MeshMonitor can now map identity-provider groups to roles via three new env vars: `OIDC_GROUPS_CLAIM` (default `groups`, supports dot notation like `realm_access.roles` for Keycloak), `OIDC_ADMIN_GROUPS` (comma-separated groups granted admin), and `OIDC_ALLOWED_GROUPS` (groups allowed to log in; empty = all). When `OIDC_ADMIN_GROUPS` is set, admin status tracks group membership on every login (promote and demote) and the IdP becomes authoritative; when unset, the existing first-login bootstrap + manual-promotion behaviour is preserved. `OIDC_ALLOWED_GROUPS` gates login (admins always pass). Group changes apply on next login. The dot-notation claim traversal and group normalization are shared with proxy auth (`src/server/auth/claims.ts`). No schema changes.
+
+### Documentation
+
+- **SSO docs corrected and expanded (#3485)**: Documented `DISABLE_LOCAL_AUTH` in the SSO guide (it was missing) and corrected the inaccurate claim that local auth "remains available via API" when disabled — the login endpoint returns `403` unconditionally with no bypass. Added a Group → Role Mapping section with Keycloak/Authentik examples and noted the proxy-auth group vars.
+
 ## [4.10.4] - 2026-06-15
 
 ### Bug Fixes

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -168,6 +168,9 @@ If you're running multiple MeshMonitor instances on the same host (different por
 | `OIDC_REDIRECT_URI` | Callback URL for OIDC | None (required for SSO) |
 | `OIDC_SCOPES` | Space-separated OIDC scopes to request | `openid profile email` |
 | `OIDC_AUTO_CREATE_USERS` | Automatically create users on first SSO login | `true` |
+| `OIDC_GROUPS_CLAIM` | ID-token claim with the user's groups (dot notation for nested, e.g. `realm_access.roles`) | `groups` |
+| `OIDC_ADMIN_GROUPS` | Comma-separated groups that grant admin rights | None |
+| `OIDC_ALLOWED_GROUPS` | Comma-separated groups allowed to log in (empty = all) | None |
 | `OIDC_ALLOW_HTTP` | Allow HTTP for OIDC (development only, not secure) | `false` |
 
 See the [SSO Setup guide](/configuration/sso) for detailed OIDC configuration.

--- a/docs/configuration/sso.md
+++ b/docs/configuration/sso.md
@@ -37,6 +37,17 @@ Configure OIDC using these environment variables:
 | `OIDC_CLIENT_SECRET` | OAuth client secret from your IdP | Yes |
 | `OIDC_REDIRECT_URI` | Callback URL for OIDC authentication | Yes |
 
+Optional variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OIDC_SCOPES` | `openid profile email` | Scopes requested from the IdP. Add `groups` (or your provider's equivalent) if you use group→role mapping. |
+| `OIDC_AUTO_CREATE_USERS` | `true` | Create a MeshMonitor user automatically on first OIDC login. |
+| `OIDC_GROUPS_CLAIM` | `groups` | ID-token claim containing the user's groups. Supports dot notation for nested claims (e.g. `realm_access.roles` for Keycloak). |
+| `OIDC_ADMIN_GROUPS` | _(empty)_ | Comma-separated group names that grant MeshMonitor **admin** rights. See [Group → Role Mapping](#group-role-mapping). |
+| `OIDC_ALLOWED_GROUPS` | _(empty)_ | Comma-separated group names allowed to log in at all. Empty = all OIDC users allowed. |
+| `DISABLE_LOCAL_AUTH` | `false` | Disable username/password login entirely (see [Disabling Local Authentication](#disabling-local-authentication)). |
+
 ### Example Configuration
 
 #### Docker Compose
@@ -64,6 +75,70 @@ OIDC_CLIENT_ID=your_client_id_here
 OIDC_CLIENT_SECRET=your_client_secret_here
 OIDC_REDIRECT_URI=https://meshmonitor.example.com/api/auth/oidc/callback
 ```
+
+## Group → Role Mapping
+
+By default, every OIDC user is created as a regular user, and the **first** OIDC
+login is bootstrapped to admin so the deployment isn't locked out; subsequent
+users must be promoted manually in the admin UI.
+
+To map identity-provider groups to MeshMonitor roles automatically, set
+`OIDC_ADMIN_GROUPS` (and optionally `OIDC_ALLOWED_GROUPS`):
+
+```env
+OIDC_SCOPES=openid profile email groups
+OIDC_GROUPS_CLAIM=groups
+OIDC_ADMIN_GROUPS=meshmonitor-admins
+OIDC_ALLOWED_GROUPS=meshmonitor-users,meshmonitor-admins
+```
+
+Behaviour:
+
+- **Admin status follows the group on every login.** When `OIDC_ADMIN_GROUPS` is
+  set, a user in one of those groups is made admin, and a user **not** in one is
+  demoted (the IdP becomes authoritative — the first-login bootstrap no longer
+  applies). When `OIDC_ADMIN_GROUPS` is empty, admin status is never changed by
+  group membership and the bootstrap / manual-promotion behaviour is preserved.
+- **`OIDC_ALLOWED_GROUPS`** gates who may log in at all. If set, a user in none of
+  the listed groups is denied (admins always pass). Empty = all OIDC users allowed.
+- Group changes take effect on the user's **next login** (OIDC rides a session;
+  unlike proxy auth, it is not re-evaluated on every request).
+
+::: warning
+If you set `OIDC_ADMIN_GROUPS`, make sure your own account is in that group, or
+keep a local admin as a break-glass login — otherwise you can demote yourself
+out of admin. The groups claim must be present in the **ID token** (configure a
+mapper in your IdP), not only at the userinfo endpoint.
+:::
+
+### Keycloak
+
+Add a **Group Membership** or **Realm roles** mapper to the client's dedicated
+scope and include it in the ID token. Realm roles arrive under a nested claim:
+
+```env
+OIDC_GROUPS_CLAIM=realm_access.roles
+OIDC_ADMIN_GROUPS=meshmonitor-admin
+```
+
+### Authentik
+
+Groups are emitted in the `groups` claim by default (ensure the `groups` scope is
+requested). The defaults work as-is:
+
+```env
+OIDC_SCOPES=openid profile email groups
+OIDC_GROUPS_CLAIM=groups
+OIDC_ADMIN_GROUPS=meshmonitor admins
+```
+
+::: tip
+If you front Keycloak/Authentik with a reverse proxy such as **oauth2-proxy**,
+you can instead use proxy auth (`PROXY_AUTH_ENABLED=true` with
+`PROXY_AUTH_ADMIN_GROUPS` / `PROXY_AUTH_NORMAL_USER_GROUPS` /
+`PROXY_AUTH_JWT_GROUPS_CLAIM`), which re-evaluates group membership on **every
+request**. See the reverse-proxy documentation.
+:::
 
 ## Provider-Specific Setup
 
@@ -225,7 +300,23 @@ Keep at least one local admin account available as a break-glass login in case y
 
 ### Disabling Local Authentication
 
-If you want to use OIDC exclusively, you can disable local authentication and registration in the UI. However, local authentication will still be available via API for administrative purposes.
+To use OIDC (or proxy auth) exclusively, set:
+
+```env
+DISABLE_LOCAL_AUTH=true
+```
+
+When enabled, username/password login is blocked entirely — the `/api/auth/login`
+endpoint returns `403` and the login UI hides the username/password form. There is
+**no** local API bypass.
+
+::: danger
+Because there is no local login bypass, make sure a working OIDC (or proxy) login
+exists **before** enabling this, or you can lock yourself out. The only safety net
+is the first-OIDC-login admin bootstrap (which does not apply if you have also set
+`OIDC_ADMIN_GROUPS` — in that case ensure your account is in an admin group). If
+you rely on a break-glass local admin, do **not** set `DISABLE_LOCAL_AUTH=true`.
+:::
 
 ## Troubleshooting
 

--- a/src/server/auth/claims.test.ts
+++ b/src/server/auth/claims.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getNestedValue,
+  normalizeGroups,
+  groupsContainAny,
+  resolveGroupRole,
+} from './claims';
+
+describe('getNestedValue', () => {
+  it('reads a flat key', () => {
+    expect(getNestedValue({ groups: ['a'] }, 'groups')).toEqual(['a']);
+  });
+
+  it('reads a dot-notation nested key (Keycloak realm_access.roles)', () => {
+    expect(getNestedValue({ realm_access: { roles: ['admin'] } }, 'realm_access.roles')).toEqual(['admin']);
+  });
+
+  it('returns undefined for a missing path without throwing', () => {
+    expect(getNestedValue({}, 'realm_access.roles')).toBeUndefined();
+  });
+
+  it('handles URL-style namespaced claims, including the Cloudflare custom fallback', () => {
+    expect(getNestedValue({ 'https://x/roles': ['r'] }, 'https://x/roles')).toEqual(['r']);
+    expect(getNestedValue({ custom: { 'https://x/roles': ['r'] } }, 'https://x/roles')).toEqual(['r']);
+  });
+});
+
+describe('normalizeGroups', () => {
+  it('handles null/undefined/empty', () => {
+    expect(normalizeGroups(null)).toEqual([]);
+    expect(normalizeGroups(undefined)).toEqual([]);
+    expect(normalizeGroups('')).toEqual([]);
+  });
+
+  it('wraps a single string', () => {
+    expect(normalizeGroups('admin')).toEqual(['admin']);
+  });
+
+  it('passes through a string array and trims', () => {
+    expect(normalizeGroups([' admin ', 'users'])).toEqual(['admin', 'users']);
+  });
+
+  it('extracts name from object arrays (mixed)', () => {
+    expect(normalizeGroups([{ name: 'admin-role' }, 'plain'])).toEqual(['admin-role', 'plain']);
+  });
+});
+
+describe('groupsContainAny', () => {
+  it('is case-insensitive', () => {
+    expect(groupsContainAny(['Admins'], ['admins'])).toBe(true);
+    expect(groupsContainAny(['users'], ['admins'])).toBe(false);
+  });
+});
+
+describe('resolveGroupRole', () => {
+  it('no admin groups configured: not admin, adminGroupsConfigured=false (bootstrap fallback applies)', () => {
+    const r = resolveGroupRole(['anything'], { adminGroups: [], allowedGroups: [] });
+    expect(r).toEqual({ allowed: true, isAdmin: false, adminGroupsConfigured: false });
+  });
+
+  it('admin group match → isAdmin', () => {
+    const r = resolveGroupRole(['meshmonitor-admins'], { adminGroups: ['meshmonitor-admins'], allowedGroups: [] });
+    expect(r.isAdmin).toBe(true);
+    expect(r.adminGroupsConfigured).toBe(true);
+    expect(r.allowed).toBe(true);
+  });
+
+  it('admin groups configured but user not in them → not admin (demotion case)', () => {
+    const r = resolveGroupRole(['users'], { adminGroups: ['admins'], allowedGroups: [] });
+    expect(r.isAdmin).toBe(false);
+    expect(r.adminGroupsConfigured).toBe(true);
+  });
+
+  it('allowed-groups gate: rejects a user in none of the allowed groups', () => {
+    const r = resolveGroupRole(['guests'], { adminGroups: [], allowedGroups: ['meshmonitor-users'] });
+    expect(r.allowed).toBe(false);
+  });
+
+  it('allowed-groups gate: accepts a user in an allowed group', () => {
+    const r = resolveGroupRole(['meshmonitor-users'], { adminGroups: [], allowedGroups: ['meshmonitor-users'] });
+    expect(r.allowed).toBe(true);
+  });
+
+  it('admins always pass the allowed-groups gate even if not in an allowed group', () => {
+    const r = resolveGroupRole(['admins'], { adminGroups: ['admins'], allowedGroups: ['meshmonitor-users'] });
+    expect(r.isAdmin).toBe(true);
+    expect(r.allowed).toBe(true);
+  });
+
+  it('empty groups + allowed-groups set → denied (fail closed)', () => {
+    const r = resolveGroupRole([], { adminGroups: ['admins'], allowedGroups: ['users'] });
+    expect(r.allowed).toBe(false);
+    expect(r.isAdmin).toBe(false);
+  });
+});

--- a/src/server/auth/claims.ts
+++ b/src/server/auth/claims.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared helpers for resolving group/role information from identity-provider
+ * claims. Used by both proxy auth (JWT/header groups) and native OIDC
+ * (ID-token groups claim) so the two paths interpret group claims identically.
+ */
+
+/**
+ * Get a nested value from an object by dot-path.
+ * Supports both dot notation and URL-style paths (Auth0 custom namespaces).
+ * Cloudflare Access application JWTs often nest IdP custom claims under `custom`,
+ * e.g. custom["https://tenant/roles"] while the flat top-level key is absent.
+ * Examples:
+ *   - getNestedValue(obj, 'groups') → obj.groups
+ *   - getNestedValue(obj, 'realm_access.roles') → obj.realm_access.roles
+ *   - getNestedValue(obj, 'https://mydomain.com/roles') → obj[path] or obj.custom[path]
+ */
+export function getNestedValue(obj: any, path: string): any {
+  // Handle URL-style paths (Auth0 custom namespaces)
+  if (path.includes('://')) {
+    const top = obj[path];
+    if (top !== undefined && top !== null) {
+      return top;
+    }
+    return obj.custom?.[path];
+  }
+
+  // Handle dot notation
+  return path.split('.').reduce((current, key) => current?.[key], obj);
+}
+
+/**
+ * Normalize a groups/roles claim to a flat string array.
+ * Handles: string, string[], { name: string }[], and mixed arrays.
+ */
+export function normalizeGroups(raw: unknown): string[] {
+  if (raw == null) return [];
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  if (!Array.isArray(raw)) return [];
+
+  const result: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry === 'string') {
+      const trimmed = entry.trim();
+      if (trimmed) result.push(trimmed);
+    } else if (entry && typeof entry === 'object' && 'name' in entry) {
+      const name = String((entry as { name: unknown }).name).trim();
+      if (name) result.push(name);
+    }
+  }
+  return result;
+}
+
+/**
+ * Case-insensitive check: does `groups` contain any value from `allowList`?
+ */
+export function groupsContainAny(groups: string[], allowList: string[]): boolean {
+  const lowerAllow = allowList.map((g) => g.toLowerCase());
+  return groups.some((g) => lowerAllow.includes(g.toLowerCase()));
+}
+
+export interface GroupRoleDecision {
+  /** Whether the user is permitted to log in (allowed-groups gate). */
+  allowed: boolean;
+  /** Whether the user should be granted admin rights. */
+  isAdmin: boolean;
+  /** Whether admin groups are configured at all (governs bootstrap fallback). */
+  adminGroupsConfigured: boolean;
+}
+
+/**
+ * Resolve a login decision from a user's groups and the configured admin /
+ * allowed group lists. Pure and dialect-agnostic so it can be unit-tested
+ * without an IdP.
+ *
+ * - `isAdmin` is true only when admin groups are configured AND the user is in
+ *   one of them. When admin groups are NOT configured, the caller keeps its
+ *   existing behaviour (e.g. the first-OIDC-login bootstrap / manual promotion).
+ * - `allowed` is true unless an allowed-groups list is configured and the user
+ *   is in neither it nor an admin group (admins always pass the gate, mirroring
+ *   proxy auth's `isNormalProxyUserAllowed`).
+ */
+export function resolveGroupRole(
+  groups: string[],
+  opts: { adminGroups: string[]; allowedGroups: string[] },
+): GroupRoleDecision {
+  const adminGroupsConfigured = opts.adminGroups.length > 0;
+  const isAdmin = adminGroupsConfigured && groupsContainAny(groups, opts.adminGroups);
+
+  let allowed = true;
+  if (opts.allowedGroups.length > 0) {
+    allowed = isAdmin || groupsContainAny(groups, opts.allowedGroups);
+  }
+
+  return { allowed, isAdmin, adminGroupsConfigured };
+}

--- a/src/server/auth/oidcAuth.ts
+++ b/src/server/auth/oidcAuth.ts
@@ -9,6 +9,7 @@ import { User } from '../../types/auth.js';
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { getEnvironmentConfig } from '../config/environment.js';
+import { getNestedValue, normalizeGroups, resolveGroupRole } from './claims.js';
 
 let oidcConfig: client.Configuration | null = null;
 let isInitialized = false;
@@ -188,24 +189,48 @@ export async function handleOIDCCallback(
     // Create username from claims
     const username = preferredUsername || email?.split('@')[0] || sub.substring(0, 20);
 
+    // Native OIDC group → role mapping (no proxy required). Resolve the groups
+    // claim (dot-notation supported, e.g. realm_access.roles for Keycloak) and
+    // derive admin/allowed using the same helpers proxy auth uses.
+    const env = getEnvironmentConfig();
+    const groups = normalizeGroups(getNestedValue(idTokenClaims, env.oidcGroupsClaim));
+    const groupRole = resolveGroupRole(groups, {
+      adminGroups: env.oidcAdminGroups,
+      allowedGroups: env.oidcAllowedGroups,
+    });
+
+    // Allowed-groups gate: applies to every user (incl. existing ones) so
+    // revoking a group blocks the next login. Admins always pass (mirrors
+    // proxy auth's isNormalProxyUserAllowed).
+    if (!groupRole.allowed) {
+      logger.warn(`❌ OIDC login denied for '${username}': not in any allowed group (OIDC_ALLOWED_GROUPS)`);
+      throw new Error('OIDC login denied: user is not a member of an allowed group');
+    }
+
     // Check if user exists by OIDC subject
     let user: User | null = null;
     user = await databaseService.auth.getUserByOidcSubject(sub) as User | null;
 
     if (user) {
       // Update existing user
-      await databaseService.auth.updateUser(user.id, {
+      const updateFields: Parameters<typeof databaseService.auth.updateUser>[1] = {
         email: email || user.email || undefined,
         displayName: name || user.displayName || undefined,
         lastLoginAt: Date.now()
-      });
+      };
+      // When admin groups are configured, admin status tracks group membership
+      // on every login (promote AND demote). When not configured, leave isAdmin
+      // untouched so manual promotion / the first-login bootstrap is preserved.
+      if (groupRole.adminGroupsConfigured && groupRole.isAdmin !== user.isAdmin) {
+        updateFields.isAdmin = groupRole.isAdmin;
+        logger.info(`🔐 OIDC group sync: '${user.username}' admin ${user.isAdmin} → ${groupRole.isAdmin}`);
+      }
+      await databaseService.auth.updateUser(user.id, updateFields);
       user = await databaseService.findUserByIdAsync(user.id) as User;
 
       logger.debug(`✅ OIDC user logged in: ${user.username}`);
     } else {
       // Auto-create new user if enabled
-      const env = getEnvironmentConfig();
-
       if (!env.oidcAutoCreateUsers) {
         throw new Error('OIDC user not found and auto-creation is disabled');
       }
@@ -224,13 +249,20 @@ export async function handleOIDCCallback(
         // Migrate existing native-login user to OIDC
         logger.info(`🔄 Migrating existing native-login user '${existingUser.username}' to OIDC`);
 
-        await databaseService.auth.updateUser(existingUser.id, {
+        const migrateFields: Parameters<typeof databaseService.auth.updateUser>[1] = {
           authMethod: 'oidc',
           oidcSubject: sub,
           email: email || existingUser.email,
           displayName: name || existingUser.displayName,
           passwordHash: null // Clear password for OIDC users
-        });
+        };
+        // When admin groups are configured, the migrated user's admin status is
+        // group-driven from the first OIDC login. Otherwise keep their existing
+        // isAdmin (don't silently demote a local admin being migrated).
+        if (groupRole.adminGroupsConfigured) {
+          migrateFields.isAdmin = groupRole.isAdmin;
+        }
+        await databaseService.auth.updateUser(existingUser.id, migrateFields);
         user = await databaseService.findUserByIdAsync(existingUser.id) as User;
 
         // Audit log
@@ -249,6 +281,11 @@ export async function handleOIDCCallback(
         // local auth is disabled (issue #2749).
         const allUsersForBootstrap = await databaseService.auth.getAllUsers();
         const isFirstOidcUser = !allUsersForBootstrap.some(u => u.authMethod === 'oidc');
+        // When admin groups are configured, admin is purely group-driven (the
+        // IdP is authoritative). Otherwise fall back to the first-OIDC-login
+        // bootstrap so the deployment isn't locked out when local auth is
+        // disabled (issue #2749).
+        const grantAdmin = groupRole.adminGroupsConfigured ? groupRole.isAdmin : isFirstOidcUser;
 
         const userId = await databaseService.auth.createUser({
           username,
@@ -256,7 +293,7 @@ export async function handleOIDCCallback(
           displayName: name || null,
           authMethod: 'oidc',
           oidcSubject: sub,
-          isAdmin: isFirstOidcUser,
+          isAdmin: grantAdmin,
           isActive: true,
           passwordHash: null,
           passwordLocked: false,
@@ -265,7 +302,7 @@ export async function handleOIDCCallback(
         });
         user = await databaseService.findUserByIdAsync(userId) as User;
 
-        if (isFirstOidcUser) {
+        if (grantAdmin) {
           // Grant full permissions to the bootstrap admin (mirrors the
           // resource list used by createAdminIfNeeded).
           const allResources = [
@@ -286,7 +323,8 @@ export async function handleOIDCCallback(
               grantedAt: Date.now()
             });
           }
-          logger.warn(`🔐 First OIDC login bootstrap: '${user!.username}' granted admin rights`);
+          const reason = groupRole.adminGroupsConfigured ? 'admin group membership' : 'first-OIDC-login bootstrap';
+          logger.warn(`🔐 OIDC admin granted to '${user!.username}' (${reason})`);
         } else {
           // Grant default permissions
           const defaultResources = ['dashboard', 'nodes', 'messages', 'settings', 'info', 'traceroute'];
@@ -302,14 +340,14 @@ export async function handleOIDCCallback(
           }
         }
 
-        logger.debug(`✅ OIDC user auto-created: ${user!.username}${isFirstOidcUser ? ' (admin)' : ''}`);
+        logger.debug(`✅ OIDC user auto-created: ${user!.username}${grantAdmin ? ' (admin)' : ''}`);
 
         // Audit log
         databaseService.auditLogAsync(
           user!.id,
-          isFirstOidcUser ? 'oidc_user_created_admin' : 'oidc_user_created',
+          grantAdmin ? 'oidc_user_created_admin' : 'oidc_user_created',
           'users',
-          JSON.stringify({ userId: user!.id, username, oidcSubject: sub, isAdmin: isFirstOidcUser }),
+          JSON.stringify({ userId: user!.id, username, oidcSubject: sub, isAdmin: grantAdmin }),
           null
         );
       }

--- a/src/server/auth/proxyAuth.ts
+++ b/src/server/auth/proxyAuth.ts
@@ -14,6 +14,11 @@
 import { Request } from 'express';
 import { getEnvironmentConfig } from '../config/environment.js';
 import { logger } from '../../utils/logger.js';
+import { getNestedValue, normalizeGroups, groupsContainAny } from './claims.js';
+
+// Re-export so existing importers (and tests) that pull `normalizeGroups` from
+// this module keep working now that the implementation lives in ./claims.
+export { normalizeGroups };
 
 /**
  * Proxy user information extracted from headers
@@ -35,30 +40,6 @@ function getHeader(headers: Record<string, string | string[] | undefined>, name:
     }
   }
   return undefined;
-}
-
-/**
- * Get nested value from object by dot-path
- * Supports both dot notation and URL-style paths (Auth0 custom namespaces)
- * Cloudflare Access application JWTs often nest IdP custom claims under `custom`,
- * e.g. custom["https://tenant/roles"] while the flat top-level key is absent.
- * Examples:
- *   - getNestedValue(obj, 'groups') → obj.groups
- *   - getNestedValue(obj, 'realm_access.roles') → obj.realm_access.roles
- *   - getNestedValue(obj, 'https://mydomain.com/roles') → obj[path] or obj.custom[path]
- */
-function getNestedValue(obj: any, path: string): any {
-  // Handle URL-style paths (Auth0 custom namespaces)
-  if (path.includes('://')) {
-    const top = obj[path];
-    if (top !== undefined && top !== null) {
-      return top;
-    }
-    return obj.custom?.[path];
-  }
-
-  // Handle dot notation
-  return path.split('.').reduce((current, key) => current?.[key], obj);
 }
 
 /**
@@ -89,31 +70,6 @@ function decodeJwtPayload(jwtToken: string): any {
     logger.error('Failed to decode JWT payload:', err);
     return null;
   }
-}
-
-/**
- * Normalize JWT groups claim to a flat string array.
- * Handles: string, string[], { name: string }[], and mixed arrays.
- */
-export function normalizeGroups(raw: unknown): string[] {
-  if (raw == null) return [];
-  if (typeof raw === 'string') {
-    const trimmed = raw.trim();
-    return trimmed ? [trimmed] : [];
-  }
-  if (!Array.isArray(raw)) return [];
-
-  const result: string[] = [];
-  for (const entry of raw) {
-    if (typeof entry === 'string') {
-      const trimmed = entry.trim();
-      if (trimmed) result.push(trimmed);
-    } else if (entry && typeof entry === 'object' && 'name' in entry) {
-      const name = String((entry as { name: unknown }).name).trim();
-      if (name) result.push(name);
-    }
-  }
-  return result;
 }
 
 /**
@@ -234,14 +190,6 @@ export function extractProxyUser(req: Request): ProxyUser | null {
   }
 
   return null;
-}
-
-/**
- * Case-insensitive check: does `groups` contain any value from `allowList`?
- */
-function groupsContainAny(groups: string[], allowList: string[]): boolean {
-  const lowerAllow = allowList.map(g => g.toLowerCase());
-  return groups.some(g => lowerAllow.includes(g.toLowerCase()));
 }
 
 /**

--- a/src/server/config/environment.ts
+++ b/src/server/config/environment.ts
@@ -253,6 +253,11 @@ export interface EnvironmentConfig {
   oidcAllowHttp: boolean;
   oidcAllowHttpProvided: boolean;
   oidcEnabled: boolean;
+  // Native OIDC group → role mapping (no proxy required)
+  oidcGroupsClaim: string;
+  oidcGroupsClaimProvided: boolean;
+  oidcAdminGroups: string[];
+  oidcAllowedGroups: string[];
 
   // Authentication
   disableLocalAuth: boolean;
@@ -562,6 +567,21 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
   const oidcAutoCreateUsers = parseBoolean('OIDC_AUTO_CREATE_USERS', process.env.OIDC_AUTO_CREATE_USERS, true);
   const oidcAllowHttp = parseBoolean('OIDC_ALLOW_HTTP', process.env.OIDC_ALLOW_HTTP, false);
 
+  // Native OIDC group → role mapping. Same comma-separated / dot-notation
+  // conventions as the PROXY_AUTH_* group vars so the two paths behave alike.
+  const oidcGroupsClaim = {
+    value: process.env.OIDC_GROUPS_CLAIM || 'groups',
+    wasProvided: process.env.OIDC_GROUPS_CLAIM !== undefined
+  };
+  const oidcAdminGroups = (process.env.OIDC_ADMIN_GROUPS || '')
+    .split(',')
+    .map(g => g.trim())
+    .filter(Boolean);
+  const oidcAllowedGroups = (process.env.OIDC_ALLOWED_GROUPS || '')
+    .split(',')
+    .map(g => g.trim())
+    .filter(Boolean);
+
   const oidcEnabled = !!(oidcIssuer.value && oidcClientId.value && oidcClientSecret.value);
 
   if (oidcIssuer.wasProvided || oidcClientId.wasProvided || oidcClientSecret.wasProvided) {
@@ -713,6 +733,9 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
     logger.info(`   OIDC_ISSUER: ${oidcIssuer.value ? '***provided***' : 'not set'}`);
     logger.info(`   OIDC_CLIENT_ID: ${oidcClientId.value ? '***provided***' : 'not set'}`);
     logger.info(`   OIDC_AUTO_CREATE_USERS: ${oidcAutoCreateUsers.value} (${src(oidcAutoCreateUsers.wasProvided)})`);
+    logger.info(`   OIDC_GROUPS_CLAIM: ${oidcGroupsClaim.value} (${src(oidcGroupsClaim.wasProvided)})`);
+    logger.info(`   OIDC_ADMIN_GROUPS: ${oidcAdminGroups.length > 0 ? oidcAdminGroups.join(', ') : 'not set (group→admin mapping disabled; first-login bootstrap applies)'}`);
+    logger.info(`   OIDC_ALLOWED_GROUPS: ${oidcAllowedGroups.length > 0 ? oidcAllowedGroups.join(', ') : 'not set (all OIDC users allowed)'}`);
   }
   logger.info('   --- Authentication ---');
   logger.info(`   DISABLE_ANONYMOUS: ${disableAnonymous.value} (${src(disableAnonymous.wasProvided)})`);
@@ -825,6 +848,10 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
     oidcAllowHttp: oidcAllowHttp.value,
     oidcAllowHttpProvided: oidcAllowHttp.wasProvided,
     oidcEnabled,
+    oidcGroupsClaim: oidcGroupsClaim.value,
+    oidcGroupsClaimProvided: oidcGroupsClaim.wasProvided,
+    oidcAdminGroups,
+    oidcAllowedGroups,
 
     // Authentication
     disableLocalAuth: disableLocalAuth.value,


### PR DESCRIPTION
Implements the feature requested in #3485 (native OIDC group→role mapping) and fixes the SSO documentation gaps the reporter flagged.

## Background — verification of the existing claims

Before building, I verified the maintainer's reply on #3485 against the code:
- ✅ `DISABLE_LOCAL_AUTH=true` exists and **hard-blocks** `/api/auth/login` (403), frontend hides the form.
- ✅ Proxy-auth group vars (`PROXY_AUTH_ENABLED`, `PROXY_AUTH_ADMIN_GROUPS`, `PROXY_AUTH_NORMAL_USER_GROUPS` with "empty = all", `PROXY_AUTH_JWT_GROUPS_CLAIM`) all exist and re-evaluate on every request.
- ✅ Native OIDC had **no** group mapping — the genuine gap.
- ⚠️ The **docs** were wrong: `sso.md` didn't name `DISABLE_LOCAL_AUTH` and falsely claimed local auth "remains available via API" when disabled (it 403s with no bypass). Both fixed here.

## Feature

Three new env vars (parsed in `environment.ts`, same conventions as `PROXY_AUTH_*`):

| Variable | Default | Purpose |
|---|---|---|
| `OIDC_GROUPS_CLAIM` | `groups` | ID-token claim with the user's groups; dot notation for nested (e.g. `realm_access.roles`). |
| `OIDC_ADMIN_GROUPS` | _(empty)_ | Groups granted admin. |
| `OIDC_ALLOWED_GROUPS` | _(empty)_ | Groups allowed to log in; empty = all. |

`handleOIDCCallback` now resolves the groups claim and:
- **Admin tracks groups on every login** (create / migrate / existing-user update) when `OIDC_ADMIN_GROUPS` is set — promote **and** demote; the IdP becomes authoritative and the first-login bootstrap no longer applies. When unset, the existing bootstrap + manual-promotion behaviour is unchanged.
- **`OIDC_ALLOWED_GROUPS`** gates login for all users (admins always pass), applied before user create/update so revoking a group blocks the next login.
- Changes apply on **next login** (OIDC is session-based; documented vs proxy auth's per-request).

The dot-notation traversal + group normalization are factored into `src/server/auth/claims.ts` and shared by `proxyAuth` and `oidcAuth` (the maintainer's plan called for reuse). `proxyAuth` re-exports `normalizeGroups` for back-compat. **No schema/migration** — `isAdmin` is an existing boolean column already updated per-login by proxy auth.

## Design decisions (flagged in the issue scoping)
- **Demotion / lockout:** when `OIDC_ADMIN_GROUPS` is set, a user not in an admin group is demoted (mirrors proxy auth). Docs warn to keep your account in the admin group or a break-glass local admin.
- **Bootstrap interaction:** group-admin overrides the first-login bootstrap only when admin groups are configured.
- **Migration branch:** a local→OIDC migrated user keeps its existing admin status unless admin groups are configured.

## Docs
- `sso.md`: documented `DISABLE_LOCAL_AUTH`, corrected the false "available via API" line, added a **Group → Role Mapping** section (Keycloak `realm_access.roles`, Authentik `groups`) and a pointer to the proxy-auth group vars.
- `index.md`: added the three new vars to the config reference.

## Tests
`src/server/auth/claims.test.ts` covers `getNestedValue`/`normalizeGroups`/`groupsContainAny` and the pure `resolveGroupRole` (admin match, demotion, allowed-gate, admins-bypass-gate, fail-closed). Existing `proxyAuth.test.ts` passes unchanged after the refactor.

## Validation
- New + proxyAuth tests: 61 pass
- `tsc --noEmit`: clean
- Full Vitest suite: **6496 pass, 0 fail, 0 suite failures**

Closes #3485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)