### PR TITLE
fix(config): gate Traffic Management/Status Message on correct firmware (#3491)

### DIFF
--- a/src/components/configuration/StatusMessageConfigSection.tsx
+++ b/src/components/configuration/StatusMessageConfigSection.tsx
@@ -80,7 +80,7 @@ const StatusMessageConfigSection: React.FC<StatusMessageConfigSectionProps> = ({
           fontStyle: 'italic',
           marginBottom: '1rem'
         }}>
-          {t('statusmessage_config.unsupported', 'Unsupported by device firmware — Requires firmware 2.7.19 or greater')}
+          {t('statusmessage_config.unsupported', 'Unsupported by device firmware — Requires firmware 2.7.20 or greater')}
         </div>
       )}
 

--- a/src/components/configuration/TrafficManagementConfigSection.tsx
+++ b/src/components/configuration/TrafficManagementConfigSection.tsx
@@ -179,7 +179,7 @@ const TrafficManagementConfigSection: React.FC<TrafficManagementConfigSectionPro
           fontStyle: 'italic',
           marginBottom: '1rem'
         }}>
-          {t('trafficmanagement_config.unsupported', 'Unsupported by this device — requires Meshtastic firmware v2.7.22 or newer with the Traffic Management module.')}
+          {t('trafficmanagement_config.unsupported', 'Unsupported by this device — the Traffic Management module is not in any released Meshtastic firmware yet (it is only on the development branch). Saving here would not persist on the device. It requires a firmware build newer than 2.7.25 (a develop/preview build, or a future release).')}
         </div>
       )}
 

--- a/src/server/meshtasticManager.moduleSupport.test.ts
+++ b/src/server/meshtasticManager.moduleSupport.test.ts
@@ -51,21 +51,28 @@ function makeManager(firmwareVersion: string | undefined) {
 }
 
 describe('MeshtasticManager — module support gating (firmware version, not config presence)', () => {
-  describe('supportsTrafficManagement (>= 2.7.22)', () => {
-    it('returns true for 2.7.24', () => {
-      expect((makeManager('2.7.24') as any).supportsTrafficManagement()).toBe(true);
+  describe('supportsTrafficManagement (>= 2.7.26)', () => {
+    // The firmware set-config handler is develop-only (meshtastic/firmware
+    // PR #9358) and is NOT in any release through the latest pre-release 2.7.25,
+    // so the gate must sit above the latest release. See issue #3491.
+    it('returns false for 2.7.25 (latest pre-release — no firmware handler)', () => {
+      expect((makeManager('2.7.25') as any).supportsTrafficManagement()).toBe(false);
     });
 
-    it('returns true for the exact threshold 2.7.22', () => {
-      expect((makeManager('2.7.22') as any).supportsTrafficManagement()).toBe(true);
+    it('returns false for 2.7.22 (the previous, incorrect threshold)', () => {
+      expect((makeManager('2.7.22') as any).supportsTrafficManagement()).toBe(false);
     });
 
-    it('returns true with a git suffix (2.7.22.abc1234)', () => {
-      expect((makeManager('2.7.22.abc1234') as any).supportsTrafficManagement()).toBe(true);
+    it('returns true for the exact threshold 2.7.26', () => {
+      expect((makeManager('2.7.26') as any).supportsTrafficManagement()).toBe(true);
     });
 
-    it('returns false for 2.7.21', () => {
-      expect((makeManager('2.7.21') as any).supportsTrafficManagement()).toBe(false);
+    it('returns true with a git suffix (2.7.26.abc1234)', () => {
+      expect((makeManager('2.7.26.abc1234') as any).supportsTrafficManagement()).toBe(true);
+    });
+
+    it('returns true for a newer release (2.8.0)', () => {
+      expect((makeManager('2.8.0') as any).supportsTrafficManagement()).toBe(true);
     });
 
     it('returns false when firmware version is unknown', () => {
@@ -73,13 +80,17 @@ describe('MeshtasticManager — module support gating (firmware version, not con
     });
   });
 
-  describe('supportsStatusMessage (>= 2.7.19)', () => {
+  describe('supportsStatusMessage (>= 2.7.20)', () => {
     it('returns true for 2.7.24', () => {
       expect((makeManager('2.7.24') as any).supportsStatusMessage()).toBe(true);
     });
 
-    it('returns true for the exact threshold 2.7.19', () => {
-      expect((makeManager('2.7.19') as any).supportsStatusMessage()).toBe(true);
+    it('returns true for the exact threshold 2.7.20', () => {
+      expect((makeManager('2.7.20') as any).supportsStatusMessage()).toBe(true);
+    });
+
+    it('returns false for 2.7.19 (handler first shipped in 2.7.20)', () => {
+      expect((makeManager('2.7.19') as any).supportsStatusMessage()).toBe(false);
     });
 
     it('returns false for 2.7.18', () => {
@@ -92,14 +103,26 @@ describe('MeshtasticManager — module support gating (firmware version, not con
     // StatusMessage configured sends an all-default config. Proto3 omits an
     // all-default sub-message, so actualModuleConfig has no trafficManagement /
     // statusmessage key. Support MUST still be reported based on firmware version.
-    it('reports trafficManagement and statusmessage supported on 2.7.24 with empty module config', () => {
-      const mgr = makeManager('2.7.24');
+    it('reports trafficManagement and statusmessage supported on 2.7.26 with empty module config', () => {
+      const mgr = makeManager('2.7.26');
       (mgr as any).actualModuleConfig = {}; // no trafficManagement / statusmessage keys (Proto3 omitted)
 
       const { supportedModules } = mgr.getCurrentConfig();
 
       expect(supportedModules.trafficManagement).toBe(true);
       expect(supportedModules.statusmessage).toBe(true);
+    });
+
+    it('reports trafficManagement unsupported on 2.7.25 — the issue #3491 case', () => {
+      // 2.7.25 decodes the admin message but has no firmware handler, so a save
+      // would silently not persist. MeshMonitor must NOT advertise it as editable.
+      const mgr = makeManager('2.7.25');
+      (mgr as any).actualModuleConfig = {};
+
+      const { supportedModules } = mgr.getCurrentConfig();
+
+      expect(supportedModules.trafficManagement).toBe(false);
+      expect(supportedModules.statusmessage).toBe(true); // >= 2.7.20
     });
 
     it('reports neither supported on older firmware (2.7.10) even if a config object is present', () => {
@@ -119,8 +142,8 @@ describe('MeshtasticManager — module support gating (firmware version, not con
 
       const { supportedModules } = mgr.getCurrentConfig();
 
-      expect(supportedModules.trafficManagement).toBe(false); // needs 2.7.22
-      expect(supportedModules.statusmessage).toBe(true); // needs 2.7.19
+      expect(supportedModules.trafficManagement).toBe(false); // needs >= 2.7.26
+      expect(supportedModules.statusmessage).toBe(true); // needs >= 2.7.20
     });
   });
 });

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -12078,17 +12078,36 @@ class MeshtasticManager implements ISourceManager {
   }
 
   /**
-   * Check if the local device firmware supports the StatusMessage module (>= 2.7.19)
+   * Check if the local device firmware supports the StatusMessage module.
+   *
+   * The AdminModule set-config handler for `statusmessage` first shipped in
+   * firmware 2.7.20 (verified against the meshtastic/firmware tags — it is
+   * absent in 2.7.19 and earlier). Gating at 2.7.19 was off by one: a 2.7.19
+   * node would accept the admin message but silently not persist it.
    */
   supportsStatusMessage(): boolean {
-    return this.firmwareVersionAtLeast(2, 7, 19);
+    return this.firmwareVersionAtLeast(2, 7, 20);
   }
 
   /**
-   * Check if the local device firmware supports the Traffic Management module (>= 2.7.22)
+   * Check if the local device firmware supports the Traffic Management module.
+   *
+   * The module and its AdminModule set-config handler landed only on the
+   * meshtastic/firmware `develop` branch via PR #9358 (merged 2026-03-11) and
+   * are NOT in any release through the latest pre-release, 2.7.25 — verified:
+   * `TrafficManagementModule.cpp` doesn't exist at the v2.7.25 tag and
+   * `AdminModule.cpp` has no `traffic_management` case there. On such firmware
+   * the admin message decodes but is silently dropped (it never persists),
+   * which is what made saves appear to "succeed" but not stick (issue #3491).
+   *
+   * Gating at 2.7.22 (the previous value) wrongly advertised it as editable on
+   * 2.7.22–2.7.25. Since no release ships it yet, gate above the latest release:
+   * develop/preview builds (which already contain PR #9358) report a version
+   * newer than 2.7.25, and the first stable release to include it will be
+   * >= 2.7.26. Re-pin to the exact release once it is tagged.
    */
   supportsTrafficManagement(): boolean {
-    return this.firmwareVersionAtLeast(2, 7, 22);
+    return this.firmwareVersionAtLeast(2, 7, 26);
   }
 
   /**

--- a/src/server/protobufService.moduleConfig.test.ts
+++ b/src/server/protobufService.moduleConfig.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    upsertNode: vi.fn(),
+    insertMessage: vi.fn().mockReturnValue(true),
+    insertTelemetry: vi.fn(),
+  },
+}));
+
+import protobufService from './protobufService.js';
+import { loadProtobufDefinitions, getProtobufRoot } from './protobufLoader.js';
+
+/**
+ * Round-trip tests for the generic module-config encoder
+ * (createSetModuleConfigMessageGeneric). protobufjs silently DROPS keys that
+ * aren't fields of the looked-up type, so a field-name drift between the UI
+ * payload and the proto would encode an empty/partial sub-message that the
+ * firmware can't act on. These tests lock the field names by encoding an
+ * AdminMessage and decoding it back to assert the values survive.
+ *
+ * Context: issue #3491 — Traffic Management saves were investigated for exactly
+ * this failure mode. The encoding turned out correct (the real gap is firmware
+ * support), and these tests prevent a future regression where it silently isn't.
+ */
+describe('createSetModuleConfigMessageGeneric round-trip', () => {
+  beforeAll(async () => {
+    await loadProtobufDefinitions();
+  });
+
+  const decode = (encoded: Uint8Array) => {
+    const AdminMessage = getProtobufRoot()!.lookupType('meshtastic.AdminMessage');
+    return AdminMessage.toObject(AdminMessage.decode(encoded), {
+      defaults: true,
+      oneofs: true,
+    }) as any;
+  };
+
+  it('encodes trafficmanagement with the correct payload variant and field names', () => {
+    const encoded = protobufService.createSetModuleConfigMessageGeneric('trafficmanagement', {
+      enabled: true,
+      rateLimitEnabled: true,
+      rateLimitMaxPackets: 5,
+      routerPreserveHops: true,
+    });
+    const msg = decode(encoded);
+
+    // ModuleConfig.payload_variant must be the trafficManagement oneof case,
+    // not empty — an empty/omitted variant is the silent-failure we guard against.
+    expect(msg.setModuleConfig.payloadVariant).toBe('trafficManagement');
+    expect(msg.setModuleConfig.trafficManagement.enabled).toBe(true);
+    expect(msg.setModuleConfig.trafficManagement.rateLimitEnabled).toBe(true);
+    expect(msg.setModuleConfig.trafficManagement.rateLimitMaxPackets).toBe(5);
+    expect(msg.setModuleConfig.trafficManagement.routerPreserveHops).toBe(true);
+  });
+
+  it('encodes statusmessage with the correct payload variant and field name', () => {
+    const encoded = protobufService.createSetModuleConfigMessageGeneric('statusmessage', {
+      nodeStatus: 'on duty',
+    });
+    const msg = decode(encoded);
+
+    expect(msg.setModuleConfig.payloadVariant).toBe('statusmessage');
+    expect(msg.setModuleConfig.statusmessage.nodeStatus).toBe('on duty');
+  });
+
+  it('encodes telemetry (a working module) for comparison', () => {
+    const encoded = protobufService.createSetModuleConfigMessageGeneric('telemetry', {
+      deviceUpdateInterval: 900,
+    });
+    const msg = decode(encoded);
+
+    expect(msg.setModuleConfig.payloadVariant).toBe('telemetry');
+    expect(msg.setModuleConfig.telemetry.deviceUpdateInterval).toBe(900);
+  });
+
+  it('throws on an unknown module type rather than encoding an empty message', () => {
+    expect(() =>
+      protobufService.createSetModuleConfigMessageGeneric('bogus', { enabled: true }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
Fixes #3491.

## Problem

Since 4.10.4, enabling **Traffic Management** appears to save in MeshMonitor but the node never persists it (and on stock firmware doesn't reboot). Other module configs save fine. Reporter is on firmware **2.7.25**.

## Root cause — firmware-side, not encoding

MeshMonitor encodes the `traffic_management` set-config correctly (verified end-to-end; added round-trip tests). The gap is firmware: the Traffic Management module + its `AdminModule::handleSetModuleConfig` case landed **only on meshtastic/firmware `develop`** via [PR #9358](https://github.com/meshtastic/firmware/pull/9358) and are **not in any release**, including the latest pre-release `v2.7.25.104df5f`. Verified directly against that tag:

```
gh api repos/meshtastic/firmware/compare/016e68ec…(PR#9358)…v2.7.25.104df5f -q .status  → diverged
contents/src/modules/AdminModule.cpp?ref=v2.7.25.104df5f | grep -c traffic_management   → 0
contents/src/modules/TrafficManagementModule.cpp?ref=v2.7.25.104df5f                    → 404 Not Found
```

So a 2.7.25 node decodes the admin message but has no handler → silently doesn't persist. Before 4.10.4 the save errored (`400 Invalid module type`); #3464 fixed that, so the (correct) packet now actually sends — which exposed the firmware gap and made it look like a regression.

## Fix

The MeshMonitor bug is the UI version gate advertising the module as editable on firmware that can't honour it:

- **`supportsTrafficManagement()` `>= 2.7.22` → `>= 2.7.26`.** No released firmware (≤ 2.7.25) supports it; gate above the latest release so it enables only on develop/preview builds (which report a newer version) and the first release shipping PR #9358. Comment notes to re-pin the exact release once tagged.
- **`supportsStatusMessage()` `>= 2.7.19` → `>= 2.7.20`** — off-by-one found while verifying; the `statusmessage` handler first shipped in firmware **2.7.20** (absent in 2.7.19). (Status Message set intentionally does not reboot, so for it a no-reboot is normal.)
- Corrected the "unsupported" notices in both config sections.

## Tests
- `meshtasticManager.moduleSupport.test.ts`: updated thresholds; added the **2.7.25 (issue #3491)** case asserting Traffic Management is reported unsupported while Status Message is supported.
- `protobufService.moduleConfig.test.ts` (new): round-trip encode→decode tests locking the module-config field names for `trafficmanagement`, `statusmessage`, and `telemetry`, so a future field-name drift (which would silently encode an empty sub-message) is caught. These also document that MeshMonitor's encoding for Traffic Management is correct.

## Validation
- New + updated tests: 18 pass
- `tsc --noEmit`: clean
- Full Vitest suite: **6503 pass, 0 fail, 0 suite failures**

Note: a `v2.7.26` placeholder is used for the Traffic Management gate since no release ships it yet — re-pin to the exact version once Meshtastic cuts a release containing PR #9358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)