### PR TITLE
refactor(config): centralize config/module-type registry (section B1)

### DIFF
--- a/src/server/constants/configTypes.test.ts
+++ b/src/server/constants/configTypes.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CONFIG_TYPES,
+  CONFIG_TYPE_MAP,
+  MODULE_FIELD_BY_ID,
+  DEVICE_FIELD_BY_ID,
+} from './configTypes.js';
+import { VALID_MODULE_CONFIG_TYPES } from './moduleConfig.js';
+
+describe('config type registry', () => {
+  // Regression snapshot: these numeric enum values and field names are the
+  // Meshtastic admin protocol contract. A wrong value silently breaks config
+  // get/set, so pin the full expected table here. Update deliberately if the
+  // protocol changes.
+  const EXPECTED: Record<string, { type: number; isModule: boolean; field: string }> = {
+    device: { type: 0, isModule: false, field: 'device' },
+    position: { type: 1, isModule: false, field: 'position' },
+    power: { type: 2, isModule: false, field: 'power' },
+    network: { type: 3, isModule: false, field: 'network' },
+    display: { type: 4, isModule: false, field: 'display' },
+    lora: { type: 5, isModule: false, field: 'lora' },
+    bluetooth: { type: 6, isModule: false, field: 'bluetooth' },
+    security: { type: 7, isModule: false, field: 'security' },
+    sessionkey: { type: 8, isModule: false, field: 'sessionkey' },
+    deviceui: { type: 9, isModule: false, field: 'deviceui' },
+    mqtt: { type: 0, isModule: true, field: 'mqtt' },
+    serial: { type: 1, isModule: true, field: 'serial' },
+    extnotif: { type: 2, isModule: true, field: 'externalNotification' },
+    storeforward: { type: 3, isModule: true, field: 'storeForward' },
+    rangetest: { type: 4, isModule: true, field: 'rangeTest' },
+    telemetry: { type: 5, isModule: true, field: 'telemetry' },
+    cannedmsg: { type: 6, isModule: true, field: 'cannedMessage' },
+    audio: { type: 7, isModule: true, field: 'audio' },
+    remotehardware: { type: 8, isModule: true, field: 'remoteHardware' },
+    neighborinfo: { type: 9, isModule: true, field: 'neighborInfo' },
+    ambientlighting: { type: 10, isModule: true, field: 'ambientLighting' },
+    detectionsensor: { type: 11, isModule: true, field: 'detectionSensor' },
+    paxcounter: { type: 12, isModule: true, field: 'paxcounter' },
+    statusmessage: { type: 13, isModule: true, field: 'statusmessage' },
+    trafficmanagement: { type: 14, isModule: true, field: 'trafficManagement' },
+  };
+
+  it('matches the known admin protocol enum/field table exactly', () => {
+    const actual: Record<string, { type: number; isModule: boolean; field: string }> = {};
+    for (const e of CONFIG_TYPES) {
+      actual[e.id] = { type: e.adminType, isModule: e.kind === 'module', field: e.field };
+    }
+    expect(actual).toEqual(EXPECTED);
+  });
+
+  it('derives CONFIG_TYPE_MAP / MODULE_FIELD_BY_ID / DEVICE_FIELD_BY_ID consistently', () => {
+    expect(CONFIG_TYPE_MAP.trafficmanagement).toEqual({ type: 14, isModule: true });
+    expect(CONFIG_TYPE_MAP.lora).toEqual({ type: 5, isModule: false });
+    expect(MODULE_FIELD_BY_ID.extnotif).toBe('externalNotification');
+    expect(MODULE_FIELD_BY_ID.lora).toBeUndefined(); // device, not a module
+    expect(DEVICE_FIELD_BY_ID.lora).toBe('lora');
+    expect(DEVICE_FIELD_BY_ID.serial).toBeUndefined(); // module, not a device
+  });
+
+  it('has unique adminType per kind (device enum / module enum are independent)', () => {
+    for (const kind of ['device', 'module'] as const) {
+      const types = CONFIG_TYPES.filter((e) => e.kind === kind).map((e) => e.adminType);
+      expect(new Set(types).size).toBe(types.length);
+    }
+  });
+
+  it('every generic-route-saveable module (VALID_MODULE_CONFIG_TYPES) is a module in the registry with a field', () => {
+    // Drift guard: the save allow-list (moduleConfig.ts) and the encoder/registry
+    // diverging was the root cause of #3464.
+    for (const id of VALID_MODULE_CONFIG_TYPES) {
+      const entry = CONFIG_TYPES.find((e) => e.id === id);
+      expect(entry, `missing registry entry for module '${id}'`).toBeDefined();
+      expect(entry!.kind).toBe('module');
+      expect(MODULE_FIELD_BY_ID[id]).toBeTruthy();
+    }
+  });
+});

--- a/src/server/constants/configTypes.ts
+++ b/src/server/constants/configTypes.ts
@@ -1,0 +1,76 @@
+/**
+ * Canonical registry of Meshtastic device-config and module-config types.
+ *
+ * Before this existed, the same facts (the numeric AdminMessage config/module
+ * type enum, and the snake_case-id → camelCase-protobuf-field mapping) were
+ * copy-pasted across `server.ts` (multiple times), `protobufService.ts`, and
+ * `services/api.ts`. They drifted — issue #3464 (a module saveable by the
+ * encoder but rejected by a stale route allow-list) was a direct symptom of
+ * that drift. Everything derives from `CONFIG_TYPES` here so adding a new
+ * config/module type is a single edit.
+ *
+ * `adminType` is the numeric enum value the device expects:
+ *   - kind 'device'  → AdminMessage.ConfigType        (device / position / … )
+ *   - kind 'module'  → AdminMessage.ModuleConfigType  (mqtt / serial / … )
+ * The two enums share small integers, so `kind` is what disambiguates them.
+ *
+ * `field` is the camelCase key under the decoded `deviceConfig{}` / `moduleConfig{}`
+ * object, which is also the protobuf field name used when encoding a set message.
+ *
+ * NOTE: which module types are *editable via the generic save route*
+ * (`POST /api/config/module/:type`) is a separate concern owned by
+ * `VALID_MODULE_CONFIG_TYPES` in ./moduleConfig — a `configTypes.test.ts`
+ * asserts those stay consistent with this registry so they can't drift again.
+ */
+
+export interface ConfigTypeEntry {
+  /** Lowercase, separator-free identifier used in routes/UI (e.g. 'trafficmanagement'). */
+  id: string;
+  kind: 'device' | 'module';
+  /** Numeric AdminMessage ConfigType (device) / ModuleConfigType (module) enum value. */
+  adminType: number;
+  /** camelCase key in deviceConfig{}/moduleConfig{} and protobuf encode field. */
+  field: string;
+}
+
+export const CONFIG_TYPES: readonly ConfigTypeEntry[] = [
+  // Device configs — AdminMessage.ConfigType
+  { id: 'device', kind: 'device', adminType: 0, field: 'device' },
+  { id: 'position', kind: 'device', adminType: 1, field: 'position' },
+  { id: 'power', kind: 'device', adminType: 2, field: 'power' },
+  { id: 'network', kind: 'device', adminType: 3, field: 'network' },
+  { id: 'display', kind: 'device', adminType: 4, field: 'display' },
+  { id: 'lora', kind: 'device', adminType: 5, field: 'lora' },
+  { id: 'bluetooth', kind: 'device', adminType: 6, field: 'bluetooth' },
+  { id: 'security', kind: 'device', adminType: 7, field: 'security' },
+  { id: 'sessionkey', kind: 'device', adminType: 8, field: 'sessionkey' },
+  { id: 'deviceui', kind: 'device', adminType: 9, field: 'deviceui' },
+  // Module configs — AdminMessage.ModuleConfigType
+  { id: 'mqtt', kind: 'module', adminType: 0, field: 'mqtt' },
+  { id: 'serial', kind: 'module', adminType: 1, field: 'serial' },
+  { id: 'extnotif', kind: 'module', adminType: 2, field: 'externalNotification' },
+  { id: 'storeforward', kind: 'module', adminType: 3, field: 'storeForward' },
+  { id: 'rangetest', kind: 'module', adminType: 4, field: 'rangeTest' },
+  { id: 'telemetry', kind: 'module', adminType: 5, field: 'telemetry' },
+  { id: 'cannedmsg', kind: 'module', adminType: 6, field: 'cannedMessage' },
+  { id: 'audio', kind: 'module', adminType: 7, field: 'audio' },
+  { id: 'remotehardware', kind: 'module', adminType: 8, field: 'remoteHardware' },
+  { id: 'neighborinfo', kind: 'module', adminType: 9, field: 'neighborInfo' },
+  { id: 'ambientlighting', kind: 'module', adminType: 10, field: 'ambientLighting' },
+  { id: 'detectionsensor', kind: 'module', adminType: 11, field: 'detectionSensor' },
+  { id: 'paxcounter', kind: 'module', adminType: 12, field: 'paxcounter' },
+  { id: 'statusmessage', kind: 'module', adminType: 13, field: 'statusmessage' },
+  { id: 'trafficmanagement', kind: 'module', adminType: 14, field: 'trafficManagement' },
+];
+
+/** id → { type: numeric adminType, isModule }. Covers both device and module types. */
+export const CONFIG_TYPE_MAP: Record<string, { type: number; isModule: boolean }> =
+  Object.fromEntries(CONFIG_TYPES.map((e) => [e.id, { type: e.adminType, isModule: e.kind === 'module' }]));
+
+/** module id → camelCase moduleConfig field (e.g. 'extnotif' → 'externalNotification'). */
+export const MODULE_FIELD_BY_ID: Record<string, string> =
+  Object.fromEntries(CONFIG_TYPES.filter((e) => e.kind === 'module').map((e) => [e.id, e.field]));
+
+/** device id → camelCase deviceConfig field. */
+export const DEVICE_FIELD_BY_ID: Record<string, string> =
+  Object.fromEntries(CONFIG_TYPES.filter((e) => e.kind === 'device').map((e) => [e.id, e.field]));

--- a/src/server/protobufService.ts
+++ b/src/server/protobufService.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { getProtobufRoot } from './protobufLoader.js';
 import { logger } from '../utils/logger.js';
 import { PortNum } from './constants/meshtastic.js';
+import { MODULE_FIELD_BY_ID } from './constants/configTypes.js';
 
 export interface MeshtasticPosition {
   latitude_i: number;
@@ -1617,25 +1618,8 @@ class ProtobufService {
         throw new Error('Required proto types not found');
       }
 
-      // Map config type names to protobuf field names
-      const configFieldMap: { [key: string]: string } = {
-        'serial': 'serial',
-        'extnotif': 'externalNotification',
-        'storeforward': 'storeForward',
-        'rangetest': 'rangeTest',
-        'telemetry': 'telemetry',
-        'cannedmsg': 'cannedMessage',
-        'audio': 'audio',
-        'remotehardware': 'remoteHardware',
-        'neighborinfo': 'neighborInfo',
-        'ambientlighting': 'ambientLighting',
-        'detectionsensor': 'detectionSensor',
-        'paxcounter': 'paxcounter',
-        'statusmessage': 'statusmessage',
-        'trafficmanagement': 'trafficManagement'
-      };
-
-      const fieldName = configFieldMap[configType];
+      // Module id → protobuf field name (canonical registry — see configTypes.ts).
+      const fieldName = MODULE_FIELD_BY_ID[configType];
       if (!fieldName) {
         throw new Error(`Unknown module config type: ${configType}`);
       }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -60,6 +60,7 @@ import { resolveRequestSourceId } from './utils/sourceResolver.js';
 import { parseDestinationNum } from './utils/parseDestination.js';
 import { PortNum, modemPresetChannelName, getRoutingErrorName } from './constants/meshtastic.js';
 import { isValidModuleConfigType } from './constants/moduleConfig.js';
+import { CONFIG_TYPE_MAP, MODULE_FIELD_BY_ID, DEVICE_FIELD_BY_ID } from './constants/configTypes.js';
 import settingsRoutes, { setSettingsCallbacks } from './routes/settingsRoutes.js';
 import { applyManagerSettings } from './applyManagerSettings.js';
 
@@ -7597,22 +7598,11 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
         // Local node - use existing config or request it
         let currentConfig = adminLoadManager.getCurrentConfig();
         
-        // Map config types to their numeric values (same as remote node mapping)
-        const configTypeMap: { [key: string]: { type: number; isModule: boolean } } = {
-          'device': { type: 0, isModule: false },  // DEVICE_CONFIG
-          'position': { type: 1, isModule: false }, // POSITION_CONFIG
-          'network': { type: 3, isModule: false },  // NETWORK_CONFIG
-          'lora': { type: 5, isModule: false },      // LORA_CONFIG
-          'bluetooth': { type: 6, isModule: false }, // BLUETOOTH_CONFIG
-          'security': { type: 7, isModule: false },  // SECURITY_CONFIG
-          'mqtt': { type: 0, isModule: true },        // MQTT_CONFIG (module)
-          'telemetry': { type: 5, isModule: true },  // TELEMETRY_CONFIG (module)
-          'neighborinfo': { type: 9, isModule: true }, // NEIGHBORINFO_CONFIG (module)
-          'statusmessage': { type: 13, isModule: true }, // STATUSMESSAGE_CONFIG (module)
-          'trafficmanagement': { type: 14, isModule: true } // TRAFFICMANAGEMENT_CONFIG (module)
-        };
-
-        const configInfo = configTypeMap[configType];
+        // Canonical config/module type registry (see configTypes.ts). Previously
+        // this local-node branch used an incomplete inline copy that omitted
+        // power/display/serial/etc., so a local GET of those configs 400'd with
+        // "Unknown config type"; using the full registry resolves that.
+        const configInfo = CONFIG_TYPE_MAP[configType];
         if (!configInfo && configType !== 'channel') {
           return res.status(400).json({ error: `Unknown config type: ${configType}` });
         }
@@ -7621,41 +7611,10 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
         let needsRequest = false;
         if (configInfo) {
           if (configInfo.isModule) {
-            // Module configs
-            const moduleConfigMap: { [key: string]: string } = {
-              'mqtt': 'mqtt',
-              'serial': 'serial',
-              'extnotif': 'externalNotification',
-              'storeforward': 'storeForward',
-              'rangetest': 'rangeTest',
-              'telemetry': 'telemetry',
-              'cannedmsg': 'cannedMessage',
-              'audio': 'audio',
-              'remotehardware': 'remoteHardware',
-              'neighborinfo': 'neighborInfo',
-              'ambientlighting': 'ambientLighting',
-              'detectionsensor': 'detectionSensor',
-              'paxcounter': 'paxcounter',
-              'statusmessage': 'statusmessage',
-              'trafficmanagement': 'trafficManagement'
-            };
-            const moduleKey = moduleConfigMap[configType];
+            const moduleKey = MODULE_FIELD_BY_ID[configType];
             if (moduleKey && !currentConfig?.moduleConfig?.[moduleKey]) needsRequest = true;
           } else {
-            // Device configs
-            const deviceConfigMap: { [key: string]: string } = {
-              'device': 'device',
-              'position': 'position',
-              'power': 'power',
-              'network': 'network',
-              'display': 'display',
-              'lora': 'lora',
-              'bluetooth': 'bluetooth',
-              'security': 'security',
-              'sessionkey': 'sessionkey',
-              'deviceui': 'deviceui'
-            };
-            const deviceKey = deviceConfigMap[configType];
+            const deviceKey = DEVICE_FIELD_BY_ID[configType];
             if (deviceKey && !currentConfig?.deviceConfig?.[deviceKey]) needsRequest = true;
           }
         }
@@ -7837,23 +7796,7 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
           case 'paxcounter':
           case 'statusmessage':
           case 'trafficmanagement':
-            const moduleConfigMap: { [key: string]: string } = {
-              'serial': 'serial',
-              'extnotif': 'externalNotification',
-              'storeforward': 'storeForward',
-              'rangetest': 'rangeTest',
-              'telemetry': 'telemetry',
-              'cannedmsg': 'cannedMessage',
-              'audio': 'audio',
-              'remotehardware': 'remoteHardware',
-              'neighborinfo': 'neighborInfo',
-              'ambientlighting': 'ambientLighting',
-              'detectionsensor': 'detectionSensor',
-              'paxcounter': 'paxcounter',
-              'statusmessage': 'statusmessage',
-              'trafficmanagement': 'trafficManagement'
-            };
-            const moduleKey = moduleConfigMap[configType];
+            const moduleKey = MODULE_FIELD_BY_ID[configType];
             if (moduleKey && finalConfig.moduleConfig?.[moduleKey]) {
               config = finalConfig.moduleConfig[moduleKey];
             } else {
@@ -7866,36 +7809,8 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
         // Remote node - request config with session passkey
         logger.info(`Requesting ${configType} config from remote node ${destinationNodeNum}`);
         
-        // Map config types to their numeric values (same as local node mapping)
-        const configTypeMap: { [key: string]: { type: number; isModule: boolean } } = {
-          'device': { type: 0, isModule: false },  // DEVICE_CONFIG
-          'position': { type: 1, isModule: false }, // POSITION_CONFIG
-          'power': { type: 2, isModule: false },    // POWER_CONFIG
-          'network': { type: 3, isModule: false },  // NETWORK_CONFIG
-          'display': { type: 4, isModule: false },  // DISPLAY_CONFIG
-          'lora': { type: 5, isModule: false },     // LORA_CONFIG
-          'bluetooth': { type: 6, isModule: false }, // BLUETOOTH_CONFIG
-          'security': { type: 7, isModule: false }, // SECURITY_CONFIG
-          'sessionkey': { type: 8, isModule: false }, // SESSIONKEY_CONFIG
-          'deviceui': { type: 9, isModule: false }, // DEVICEUI_CONFIG
-          'mqtt': { type: 0, isModule: true },      // MQTT_CONFIG (module)
-          'serial': { type: 1, isModule: true },    // SERIAL_CONFIG (module)
-          'extnotif': { type: 2, isModule: true },  // EXTNOTIF_CONFIG (module)
-          'storeforward': { type: 3, isModule: true }, // STOREFORWARD_CONFIG (module)
-          'rangetest': { type: 4, isModule: true },  // RANGETEST_CONFIG (module)
-          'telemetry': { type: 5, isModule: true }, // TELEMETRY_CONFIG (module)
-          'cannedmsg': { type: 6, isModule: true }, // CANNEDMSG_CONFIG (module)
-          'audio': { type: 7, isModule: true },     // AUDIO_CONFIG (module)
-          'remotehardware': { type: 8, isModule: true }, // REMOTEHARDWARE_CONFIG (module)
-          'neighborinfo': { type: 9, isModule: true }, // NEIGHBORINFO_CONFIG (module)
-          'ambientlighting': { type: 10, isModule: true }, // AMBIENTLIGHTING_CONFIG (module)
-          'detectionsensor': { type: 11, isModule: true }, // DETECTIONSENSOR_CONFIG (module)
-          'paxcounter': { type: 12, isModule: true }, // PAXCOUNTER_CONFIG (module)
-          'statusmessage': { type: 13, isModule: true }, // STATUSMESSAGE_CONFIG (module)
-          'trafficmanagement': { type: 14, isModule: true } // TRAFFICMANAGEMENT_CONFIG (module)
-        };
-
-        const configInfo = configTypeMap[configType];
+        // Canonical config/module type registry (see configTypes.ts).
+        const configInfo = CONFIG_TYPE_MAP[configType];
         if (!configInfo) {
           return res.status(400).json({ error: `Unknown config type: ${configType}` });
         }


### PR DESCRIPTION
First of the **section-B refactors** from the systemic review. Targets the duplicated module/config-type maps — the #1 "very tractable, high impact" candidate, and the exact drift class behind #3464.

## Problem
The numeric AdminMessage config/module enum values and the `id → camelCase protobuf field` maps were copy-pasted across `server.ts` (5 inline maps) and `protobufService.ts`. Adding a config/module type meant editing ~6 sites; they drifted (#3464).

## Change
New canonical registry `src/server/constants/configTypes.ts`:
- `CONFIG_TYPES` (the one source of truth) → derived `CONFIG_TYPE_MAP`, `MODULE_FIELD_BY_ID`, `DEVICE_FIELD_BY_ID`.

Every duplicated site now derives from it:
- `protobufService.ts` module-config encoder field map
- `server.ts`: local + remote config-type maps, and the module/device field lookup maps (**5 inline copies removed**)

## Incidental correctness fix
The local-node branch used an **incomplete copy** of the config-type map (omitted power/display/sessionkey/deviceui/serial/extnotif/storeforward/rangetest/cannedmsg/audio/remotehardware/ambientlighting/detectionsensor/paxcounter). A local-node GET of those configs returned `400 "Unknown config type"`. The full registry resolves it. (The remote branch already had the full map.)

## Deliberately left
`protobufService.createSetDeviceConfigMessageGeneric`'s 5-entry map is a **restricted** "generic device encoder" allow-list (power/display/bluetooth/sessionkey/deviceui), semantically distinct from the device lookup map — unchanged to avoid widening what that encoder accepts.

## Tests
`configTypes.test.ts`:
- Pins the **full enum/field table** as a regression snapshot (the numeric values are the admin-protocol contract — a wrong number silently breaks config get/set).
- Asserts the derived maps.
- **Drift guard**: every `VALID_MODULE_CONFIG_TYPES` entry must exist as a module in the registry — links the save allow-list to the encoder so #3464 can't recur.

## Validation
- `tsc --noEmit`: clean
- Full Vitest suite: **6524 pass, 0 fail, 0 suite failures** (the protobuf encoder round-trip test from #3491 exercises the consolidated module field map)

Next in section B: **B2** (shared `createTestDb` helper to kill the hand-rolled per-backend test DDL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)