### PR TITLE
refactor(test): shared createTestDb helper from migration registry (section B2, part 1)

### DIFF
--- a/src/db/repositories/telemetry.badTimestamp.test.ts
+++ b/src/db/repositories/telemetry.badTimestamp.test.ts
@@ -12,11 +12,12 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
-import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { eq } from 'drizzle-orm';
 import { telemetrySqlite } from '../schema/telemetry.js';
 import { TelemetryRepository } from './telemetry.js';
 import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
 
 const HOUR = 60 * 60 * 1000;
 const DAY = 24 * HOUR;
@@ -29,17 +30,10 @@ describe('Telemetry bad-timestamp handling (#3362)', () => {
   let repo: TelemetryRepository;
 
   beforeEach(() => {
-    db = new Database(':memory:');
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS telemetry (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        nodeId TEXT NOT NULL, nodeNum INTEGER NOT NULL, telemetryType TEXT NOT NULL,
-        timestamp INTEGER NOT NULL, value REAL NOT NULL, unit TEXT,
-        createdAt INTEGER NOT NULL, packetTimestamp INTEGER, packetId INTEGER,
-        channel INTEGER, precisionBits INTEGER, gpsAccuracy INTEGER,
-        rxSnr REAL, hopStart INTEGER, hopLimit INTEGER, sourceId TEXT
-      )`);
-    drizzleDb = drizzle(db, { schema });
+    // Full production schema from the migration registry — see testDb.ts.
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
     repo = new TelemetryRepository(drizzleDb, 'sqlite');
   });
 

--- a/src/db/repositories/telemetry.extra.test.ts
+++ b/src/db/repositories/telemetry.extra.test.ts
@@ -12,9 +12,10 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
-import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { TelemetryRepository } from './telemetry.js';
 import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
 
 // ---------------------------------------------------------------------------
 // Shared constants & helpers
@@ -35,39 +36,11 @@ describe('TelemetryRepository (expanded)', () => {
   let repo: TelemetryRepository;
 
   beforeEach(() => {
-    db = new Database(':memory:');
-
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS telemetry (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        nodeId TEXT NOT NULL,
-        nodeNum INTEGER NOT NULL,
-        telemetryType TEXT NOT NULL,
-        timestamp INTEGER NOT NULL,
-        value REAL NOT NULL,
-        unit TEXT,
-        createdAt INTEGER NOT NULL,
-        packetTimestamp INTEGER,
-        packetId INTEGER,
-        channel INTEGER,
-        precisionBits INTEGER,
-        gpsAccuracy INTEGER,
-        rxSnr REAL,
-        hopStart INTEGER,
-        hopLimit INTEGER,
-        sourceId TEXT
-      )
-    `);
-
-    // Mirror the migration 032 partial unique index so repo-level dedupe
-    // behavior matches production. NULL packetId rows bypass the constraint.
-    db.exec(`
-      CREATE UNIQUE INDEX IF NOT EXISTS telemetry_source_packet_type_uniq
-        ON telemetry(sourceId, nodeNum, packetId, telemetryType)
-        WHERE packetId IS NOT NULL
-    `);
-
-    drizzleDb = drizzle(db, { schema });
+    // Full production schema from the migration registry (includes the
+    // migration 032 dedupe index and the telemetry columns) — see testDb.ts.
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
     repo = new TelemetryRepository(drizzleDb, 'sqlite');
   });
 

--- a/src/db/repositories/telemetry.test.ts
+++ b/src/db/repositories/telemetry.test.ts
@@ -416,15 +416,10 @@ describe('TelemetryRepository', () => {
     const NOW = Date.now();
     const SOURCE = 'mqtt-bridge-test';
 
-    beforeEach(() => {
-      // Apply the migration 032 partial unique index so insertIgnore /
-      // onConflictDoNothing actually has something to conflict against.
-      db.exec(`
-        CREATE UNIQUE INDEX IF NOT EXISTS telemetry_source_packet_type_uniq
-          ON telemetry(sourceId, nodeNum, packetId, telemetryType)
-          WHERE packetId IS NOT NULL
-      `);
-    });
+    // The migration 032 partial unique index (telemetry_source_packet_type_uniq)
+    // is already present — createTestDb() runs the full migration registry — so
+    // insertIgnore/onConflictDoNothing has a constraint to conflict against
+    // without any extra DDL here.
 
     it('async insertTelemetry: same packet ingested twice yields one row, no throw', async () => {
       const row = {

--- a/src/db/repositories/telemetry.test.ts
+++ b/src/db/repositories/telemetry.test.ts
@@ -5,10 +5,11 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
-import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { telemetrySqlite } from '../schema/telemetry.js';
 import { TelemetryRepository } from './telemetry.js';
 import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
 
 describe('TelemetryRepository', () => {
   let db: Database.Database;
@@ -16,33 +17,10 @@ describe('TelemetryRepository', () => {
   let repo: TelemetryRepository;
 
   beforeEach(() => {
-    // Create in-memory SQLite database
-    db = new Database(':memory:');
-
-    // Create telemetry table
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS telemetry (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        nodeId TEXT NOT NULL,
-        nodeNum INTEGER NOT NULL,
-        telemetryType TEXT NOT NULL,
-        timestamp INTEGER NOT NULL,
-        value REAL NOT NULL,
-        unit TEXT,
-        createdAt INTEGER NOT NULL,
-        packetTimestamp INTEGER,
-        packetId INTEGER,
-        channel INTEGER,
-        precisionBits INTEGER,
-        gpsAccuracy INTEGER,
-        rxSnr REAL,
-        hopStart INTEGER,
-        hopLimit INTEGER,
-        sourceId TEXT
-      )
-    `);
-
-    drizzleDb = drizzle(db, { schema });
+    // Full production schema from the migration registry — see testDb.ts.
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
     repo = new TelemetryRepository(drizzleDb, 'sqlite');
   });
 

--- a/src/server/test-helpers/testDb.test.ts
+++ b/src/server/test-helpers/testDb.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createTestDb, type TestDb } from './testDb.js';
+import { TelemetryRepository } from '../../db/repositories/telemetry.js';
+
+describe('createTestDb', () => {
+  let t: TestDb | null = null;
+  afterEach(() => { t?.close(); t = null; });
+
+  it('builds the full schema from the migration registry (key tables present)', () => {
+    t = createTestDb();
+    const tables = (t.sqlite
+      .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+      .all() as { name: string }[]).map((r) => r.name);
+    for (const expected of ['settings', 'nodes', 'telemetry', 'messages', 'user_map_preferences']) {
+      expect(tables, `missing table ${expected}`).toContain(expected);
+    }
+  });
+
+  it('includes columns added by recent migrations (e.g. telemetry.rxSnr — migration 089)', () => {
+    t = createTestDb();
+    const cols = (t.sqlite.prepare('PRAGMA table_info(telemetry)').all() as { name: string }[]).map((c) => c.name);
+    expect(cols).toContain('rxSnr');
+    expect(cols).toContain('hopStart');
+    expect(cols).toContain('hopLimit');
+  });
+
+  it('supports a repository insert/read round-trip against the generated schema', async () => {
+    t = createTestDb();
+    // nodes FK: telemetry.nodeNum references nodes.nodeNum — insert the node first.
+    t.sqlite.prepare(
+      "INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)",
+    ).run(0xaabbccdd, '!aabbccdd', 'default', Date.now(), Date.now());
+
+    const repo = new TelemetryRepository(t.db, 'sqlite');
+    await repo.insertTelemetry({
+      nodeId: '!aabbccdd', nodeNum: 0xaabbccdd, telemetryType: 'battery',
+      timestamp: Date.now(), value: 88, createdAt: Date.now(),
+    });
+    const rows = await repo.getTelemetryByNode('!aabbccdd', 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].value).toBe(88);
+  });
+});

--- a/src/server/test-helpers/testDb.ts
+++ b/src/server/test-helpers/testDb.ts
@@ -56,6 +56,9 @@ export function createTestDb(): TestDb {
     if (!migration.sqlite) continue;
     // Both self-idempotent (001-046) and settings-key-guarded migrations take
     // the same (db, getSetting, setSetting) signature in production.
+    // `as any`: migrations type their first arg as better-sqlite3's `Database`,
+    // which is structurally what we pass; the cast just bridges the nominal type
+    // (same pattern as the production migration loop in database.ts).
     migration.sqlite(sqlite as any, getSetting, setSetting);
     if (migration.settingsKey) setSetting(migration.settingsKey, 'completed');
   }

--- a/src/server/test-helpers/testDb.ts
+++ b/src/server/test-helpers/testDb.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared in-memory SQLite test database built from the REAL migration registry.
+ *
+ * Before this helper, ~40 non-migration test files hand-rolled `CREATE TABLE`
+ * statements per backend. That copy-pasted DDL drifted from `src/db/schema/`:
+ * a single schema column add broke N tests, and the PG/MySQL copies (only run
+ * in CI) silently diverged — exactly what bit #3495. `createTestDb()` runs the
+ * actual registered SQLite migrations against a fresh `:memory:` database, so
+ * every test gets the production schema and a schema change is a single edit.
+ *
+ * Use this for repository/service unit tests. Migration-state tests that need
+ * a bespoke historical schema should keep their own DDL.
+ */
+import Database from 'better-sqlite3';
+import { drizzle, type BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { registry } from '../../db/migrations.js';
+import * as schema from '../../db/schema/index.js';
+
+export interface TestDb {
+  /** Raw better-sqlite3 connection (for direct DDL/inserts in a test). */
+  sqlite: Database.Database;
+  /** Drizzle instance bound to the full schema. */
+  db: BetterSQLite3Database<typeof schema>;
+  /** Close the connection (call in afterEach). */
+  close(): void;
+}
+
+/**
+ * Create a fresh in-memory SQLite database with the full current schema applied
+ * via the migration registry (migration 001 baseline + all subsequent ALTERs).
+ */
+export function createTestDb(): TestDb {
+  const sqlite = new Database(':memory:');
+
+  // The baseline migration (001) creates the real `settings` table — do NOT
+  // pre-create it (a minimal stub would block the full CREATE TABLE IF NOT
+  // EXISTS). These helpers are defensive for the brief window before `settings`
+  // exists (the first migration that reads/writes it is the baseline itself).
+  const getSetting = (key: string): string | null => {
+    try {
+      const row = sqlite.prepare('SELECT value FROM settings WHERE key = ?').get(key) as { value?: string } | undefined;
+      return row?.value ?? null;
+    } catch {
+      return null;
+    }
+  };
+  const setSetting = (key: string, value: string): void => {
+    try {
+      sqlite.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)').run(key, value);
+    } catch {
+      /* settings table not created yet — ignore */
+    }
+  };
+
+  for (const migration of registry.getAll()) {
+    if (!migration.sqlite) continue;
+    // Both self-idempotent (001-046) and settings-key-guarded migrations take
+    // the same (db, getSetting, setSetting) signature in production.
+    migration.sqlite(sqlite as any, getSetting, setSetting);
+    if (migration.settingsKey) setSetting(migration.settingsKey, 'completed');
+  }
+
+  const db = drizzle(sqlite, { schema });
+  return {
+    sqlite,
+    db,
+    close: () => sqlite.close(),
+  };
+}


### PR DESCRIPTION
Section-B refactor #2. Addresses the test-infrastructure fragility the review flagged — the class of bug that broke #3495.

## Problem
~40 non-migration test files hand-roll `CREATE TABLE` per backend, duplicating `src/db/schema/`. That DDL drifts from the real schema: a single column-add breaks N tests, and the PG/MySQL copies (only run in CI) diverge silently — which is exactly how the #3495 PostgreSQL test-table gap slipped past local runs.

## Change
New `src/server/test-helpers/testDb.ts`:
- `createTestDb()` runs the **real SQLite migration registry** (baseline 001 + every subsequent ALTER) against a fresh `:memory:` database, returning `{ sqlite, db, close }`.
- Every test gets the **exact production schema**, automatically — a schema change is now a single edit in `src/db/schema/` + its migration, with zero test-DDL to update.
- A smoke test (`testDb.test.ts`) asserts key tables exist, recent columns are present (`telemetry.rxSnr` from migration 089), and a repo insert/read round-trip works.

## Migrated in this PR (part 1)
The three SQLite-only telemetry repo tests whose hand-rolled telemetry DDL had to be patched for #3492/#3495:
- `telemetry.test.ts`, `telemetry.extra.test.ts`, `telemetry.badTimestamp.test.ts`

These were clean drop-ins (the helper provides the full telemetry table *and* the migration-032 dedupe index they were mirroring).

## Scope / follow-ups
This is **part 1** — it lands the proven helper and removes the most-recently-fragile DDL. The remaining ~37 hand-rolled tables (nodes in ~20 files, etc.) will be migrated incrementally in follow-up PRs (now trivial mechanical changes). `telemetry.multidb.test.ts` is intentionally left — it deliberately exercises per-backend DDL.

## Design notes
- The helper applies migrations via the same `registry.getAll()` + `m.sqlite(db, getSetting, setSetting)` path production uses. It does **not** pre-create a `settings` stub (that would block the baseline's full table); the get/set shims are defensive for the brief window before `settings` exists.

## Validation
- `tsc --noEmit`: clean
- Full Vitest suite: **6527 pass, 0 fail, 0 suite failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)