### PR TITLE
refactor(test): migrate messages repo tests to createTestDb (section B2, part 2)

### DIFF
--- a/src/db/repositories/messages.createdAt-ordering.test.ts
+++ b/src/db/repositories/messages.createdAt-ordering.test.ts
@@ -8,9 +8,10 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
-import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { MessagesRepository } from './messages.js';
 import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
 
 describe('MessagesRepository — createdAt ordering (#3122)', () => {
   let db: Database.Database;
@@ -27,55 +28,19 @@ describe('MessagesRepository — createdAt ordering (#3122)', () => {
   const FAR_FUTURE = 4_000_000_000_000; // ~2096
 
   beforeEach(() => {
-    db = new Database(':memory:');
-    db.exec(`
-      CREATE TABLE nodes (
-        nodeNum INTEGER PRIMARY KEY,
-        nodeId TEXT NOT NULL UNIQUE,
-        longName TEXT,
-        shortName TEXT
-      )
-    `);
-    db.exec(`
-      INSERT INTO nodes (nodeNum, nodeId) VALUES (${LOCAL}, '${LOCAL_ID}');
-      INSERT INTO nodes (nodeNum, nodeId) VALUES (${PEER}, '${PEER_ID}');
-    `);
-    db.exec(`
-      CREATE TABLE messages (
-        id TEXT PRIMARY KEY,
-        fromNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
-        toNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
-        fromNodeId TEXT NOT NULL,
-        toNodeId TEXT NOT NULL,
-        text TEXT NOT NULL,
-        channel INTEGER NOT NULL DEFAULT 0,
-        portnum INTEGER,
-        requestId INTEGER,
-        timestamp INTEGER NOT NULL,
-        rxTime INTEGER,
-        hopStart INTEGER,
-        hopLimit INTEGER,
-        relayNode INTEGER,
-        replyId INTEGER,
-        emoji INTEGER,
-        viaMqtt INTEGER,
-        viaStoreForward INTEGER DEFAULT 0,
-        rxSnr REAL,
-        rxRssi REAL,
-        ackFailed INTEGER,
-        routingErrorReceived INTEGER,
-        deliveryState TEXT,
-        wantAck INTEGER,
-        ackFromNode INTEGER,
-        createdAt INTEGER NOT NULL,
-        decrypted_by TEXT,
-        sourceId TEXT,
-        source_ip TEXT,
-        source_path TEXT,
-        spoofSuspected INTEGER
-      )
-    `);
-    drizzleDb = drizzle(db, { schema });
+    // Full production schema from the migration registry — see testDb.ts.
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+
+    // Seed referenced nodes (full schema NOT NULL/PK columns: sourceId, timestamps).
+    const now = Date.now();
+    const insertNode = db.prepare(
+      "INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, 'default', ?, ?)",
+    );
+    insertNode.run(LOCAL, LOCAL_ID, now, now);
+    insertNode.run(PEER, PEER_ID, now, now);
+
     repo = new MessagesRepository(drizzleDb, 'sqlite');
   });
 

--- a/src/db/repositories/messages.exclude-portnums.test.ts
+++ b/src/db/repositories/messages.exclude-portnums.test.ts
@@ -9,9 +9,10 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
-import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { MessagesRepository } from './messages.js';
 import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
 
 describe('MessagesRepository.getMessages excludePortnums', () => {
   let db: Database.Database;
@@ -24,58 +25,19 @@ describe('MessagesRepository.getMessages excludePortnums', () => {
   const PEER_ID = '!87654321';
 
   beforeEach(() => {
-    db = new Database(':memory:');
+    // Full production schema from the migration registry — see testDb.ts.
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
 
-    db.exec(`
-      CREATE TABLE nodes (
-        nodeNum INTEGER PRIMARY KEY,
-        nodeId TEXT NOT NULL UNIQUE,
-        longName TEXT,
-        shortName TEXT
-      )
-    `);
-    db.exec(`
-      INSERT INTO nodes (nodeNum, nodeId) VALUES (${LOCAL_NUM}, '${LOCAL_ID}');
-      INSERT INTO nodes (nodeNum, nodeId) VALUES (${PEER_NUM}, '${PEER_ID}');
-    `);
+    // Seed referenced nodes (full schema NOT NULL/PK columns: sourceId, timestamps).
+    const now = Date.now();
+    const insertNode = db.prepare(
+      "INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, 'default', ?, ?)",
+    );
+    insertNode.run(LOCAL_NUM, LOCAL_ID, now, now);
+    insertNode.run(PEER_NUM, PEER_ID, now, now);
 
-    db.exec(`
-      CREATE TABLE messages (
-        id TEXT PRIMARY KEY,
-        fromNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
-        toNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
-        fromNodeId TEXT NOT NULL,
-        toNodeId TEXT NOT NULL,
-        text TEXT NOT NULL,
-        channel INTEGER NOT NULL DEFAULT 0,
-        portnum INTEGER,
-        requestId INTEGER,
-        timestamp INTEGER NOT NULL,
-        rxTime INTEGER,
-        hopStart INTEGER,
-        hopLimit INTEGER,
-        relayNode INTEGER,
-        replyId INTEGER,
-        emoji INTEGER,
-        viaMqtt INTEGER,
-        viaStoreForward INTEGER DEFAULT 0,
-        rxSnr REAL,
-        rxRssi REAL,
-        ackFailed INTEGER,
-        routingErrorReceived INTEGER,
-        deliveryState TEXT,
-        wantAck INTEGER,
-        ackFromNode INTEGER,
-        createdAt INTEGER NOT NULL,
-        decrypted_by TEXT,
-        sourceId TEXT,
-        source_ip TEXT,
-        source_path TEXT,
-        spoofSuspected INTEGER
-      )
-    `);
-
-    drizzleDb = drizzle(db, { schema });
     repo = new MessagesRepository(drizzleDb, 'sqlite');
   });
 

--- a/src/db/repositories/messages.insert.test.ts
+++ b/src/db/repositories/messages.insert.test.ts
@@ -5,9 +5,10 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
-import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { MessagesRepository } from './messages.js';
 import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
 
 describe('MessagesRepository.insertMessage duplicate detection', () => {
   let db: Database.Database;
@@ -20,62 +21,20 @@ describe('MessagesRepository.insertMessage duplicate detection', () => {
   const NODE2_ID = '!11223344';
 
   beforeEach(() => {
-    db = new Database(':memory:');
+    // Full production schema from the migration registry — see testDb.ts.
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
 
-    // Create nodes table (referenced by messages foreign keys)
-    db.exec(`
-      CREATE TABLE nodes (
-        nodeNum INTEGER PRIMARY KEY,
-        nodeId TEXT NOT NULL UNIQUE,
-        longName TEXT,
-        shortName TEXT
-      )
-    `);
+    // Seed referenced nodes (messages enrich with node data). Include the
+    // full schema's NOT NULL columns.
+    const now = Date.now();
+    const insertNode = db.prepare(
+      "INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, 'default', ?, ?)",
+    );
+    insertNode.run(NODE1_NUM, NODE1_ID, now, now);
+    insertNode.run(NODE2_NUM, NODE2_ID, now, now);
 
-    // Insert referenced nodes
-    db.exec(`
-      INSERT INTO nodes (nodeNum, nodeId) VALUES (${NODE1_NUM}, '${NODE1_ID}');
-      INSERT INTO nodes (nodeNum, nodeId) VALUES (${NODE2_NUM}, '${NODE2_ID}');
-    `);
-
-    // Create messages table matching the SQLite schema
-    db.exec(`
-      CREATE TABLE messages (
-        id TEXT PRIMARY KEY,
-        fromNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
-        toNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
-        fromNodeId TEXT NOT NULL,
-        toNodeId TEXT NOT NULL,
-        text TEXT NOT NULL,
-        channel INTEGER NOT NULL DEFAULT 0,
-        portnum INTEGER,
-        requestId INTEGER,
-        timestamp INTEGER NOT NULL,
-        rxTime INTEGER,
-        hopStart INTEGER,
-        hopLimit INTEGER,
-        relayNode INTEGER,
-        replyId INTEGER,
-        emoji INTEGER,
-        viaMqtt INTEGER,
-        viaStoreForward INTEGER DEFAULT 0,
-        rxSnr REAL,
-        rxRssi REAL,
-        ackFailed INTEGER,
-        routingErrorReceived INTEGER,
-        deliveryState TEXT,
-        wantAck INTEGER,
-        ackFromNode INTEGER,
-        createdAt INTEGER NOT NULL,
-        decrypted_by TEXT,
-        sourceId TEXT,
-        source_ip TEXT,
-        source_path TEXT,
-        spoofSuspected INTEGER
-      )
-    `);
-
-    drizzleDb = drizzle(db, { schema });
     repo = new MessagesRepository(drizzleDb, 'sqlite');
   });
 

--- a/src/db/repositories/messages.purge.test.ts
+++ b/src/db/repositories/messages.purge.test.ts
@@ -8,9 +8,10 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
-import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { MessagesRepository } from './messages.js';
 import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
 
 describe('MessagesRepository sync purge helpers', () => {
   let db: Database.Database;
@@ -25,60 +26,20 @@ describe('MessagesRepository sync purge helpers', () => {
   const NODE3_ID = '!55667788';
 
   beforeEach(() => {
-    db = new Database(':memory:');
+    // Full production schema from the migration registry — see testDb.ts.
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
 
-    db.exec(`
-      CREATE TABLE nodes (
-        nodeNum INTEGER PRIMARY KEY,
-        nodeId TEXT NOT NULL UNIQUE,
-        longName TEXT,
-        shortName TEXT
-      )
-    `);
+    // Seed referenced nodes (full schema NOT NULL/PK columns: sourceId, timestamps).
+    const now = Date.now();
+    const insertNode = db.prepare(
+      "INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, 'default', ?, ?)",
+    );
+    insertNode.run(NODE1_NUM, NODE1_ID, now, now);
+    insertNode.run(NODE2_NUM, NODE2_ID, now, now);
+    insertNode.run(NODE3_NUM, NODE3_ID, now, now);
 
-    db.exec(`
-      INSERT INTO nodes (nodeNum, nodeId) VALUES (${NODE1_NUM}, '${NODE1_ID}');
-      INSERT INTO nodes (nodeNum, nodeId) VALUES (${NODE2_NUM}, '${NODE2_ID}');
-      INSERT INTO nodes (nodeNum, nodeId) VALUES (${NODE3_NUM}, '${NODE3_ID}');
-    `);
-
-    db.exec(`
-      CREATE TABLE messages (
-        id TEXT PRIMARY KEY,
-        fromNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
-        toNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
-        fromNodeId TEXT NOT NULL,
-        toNodeId TEXT NOT NULL,
-        text TEXT NOT NULL,
-        channel INTEGER NOT NULL DEFAULT 0,
-        portnum INTEGER,
-        requestId INTEGER,
-        timestamp INTEGER NOT NULL,
-        rxTime INTEGER,
-        hopStart INTEGER,
-        hopLimit INTEGER,
-        relayNode INTEGER,
-        replyId INTEGER,
-        emoji INTEGER,
-        viaMqtt INTEGER,
-        viaStoreForward INTEGER DEFAULT 0,
-        rxSnr REAL,
-        rxRssi REAL,
-        ackFailed INTEGER,
-        routingErrorReceived INTEGER,
-        deliveryState TEXT,
-        wantAck INTEGER,
-        ackFromNode INTEGER,
-        createdAt INTEGER NOT NULL,
-        decrypted_by TEXT,
-        sourceId TEXT,
-        source_ip TEXT,
-        source_path TEXT,
-        spoofSuspected INTEGER
-      )
-    `);
-
-    drizzleDb = drizzle(db, { schema });
     repo = new MessagesRepository(drizzleDb, 'sqlite');
   });
 

--- a/src/db/repositories/messages.purge.test.ts
+++ b/src/db/repositories/messages.purge.test.ts
@@ -127,8 +127,13 @@ describe('MessagesRepository sync purge helpers', () => {
     });
 
     it('excludes broadcast messages (!ffffffff)', async () => {
-      // Add the broadcast target node so the foreign key holds
-      db.exec(`INSERT OR IGNORE INTO nodes (nodeNum, nodeId) VALUES (${0xffffffff}, '!ffffffff')`);
+      // Add the broadcast target node so the foreign key holds. Must supply the
+      // full schema's NOT NULL/PK columns — OR IGNORE would otherwise silently
+      // swallow the constraint violation and never insert the row.
+      const now = Date.now();
+      db.prepare(
+        "INSERT OR IGNORE INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, 'default', ?, ?)",
+      ).run(0xffffffff, '!ffffffff', now, now);
 
       // Broadcast looks like a DM by fromNode, but toNodeId is !ffffffff
       await insertMsg('bcast', NODE1_NUM, NODE1_ID, 0xffffffff, '!ffffffff', 0, 'src-a');

--- a/src/db/repositories/messages.timestamp.test.ts
+++ b/src/db/repositories/messages.timestamp.test.ts
@@ -5,9 +5,10 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
-import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { MessagesRepository } from './messages.js';
 import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
 
 describe('MessagesRepository.updateMessageTimestamps', () => {
   let db: Database.Database;
@@ -20,61 +21,19 @@ describe('MessagesRepository.updateMessageTimestamps', () => {
   const NODE2_ID = '!11223344';
 
   beforeEach(() => {
-    db = new Database(':memory:');
+    // Full production schema from the migration registry — see testDb.ts.
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
 
-    // Create nodes table (referenced by messages foreign keys)
-    db.exec(`
-      CREATE TABLE nodes (
-        nodeNum INTEGER PRIMARY KEY,
-        nodeId TEXT NOT NULL UNIQUE,
-        longName TEXT,
-        shortName TEXT
-      )
-    `);
+    // Seed referenced nodes (full schema NOT NULL/PK columns: sourceId, timestamps).
+    const now = Date.now();
+    const insertNode = db.prepare(
+      "INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, 'default', ?, ?)",
+    );
+    insertNode.run(NODE1_NUM, NODE1_ID, now, now);
+    insertNode.run(NODE2_NUM, NODE2_ID, now, now);
 
-    // Insert referenced nodes
-    db.exec(`
-      INSERT INTO nodes (nodeNum, nodeId) VALUES (${NODE1_NUM}, '${NODE1_ID}');
-      INSERT INTO nodes (nodeNum, nodeId) VALUES (${NODE2_NUM}, '${NODE2_ID}');
-    `);
-
-    // Create messages table matching the SQLite schema
-    db.exec(`
-      CREATE TABLE messages (
-        id TEXT PRIMARY KEY,
-        fromNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
-        toNodeNum INTEGER NOT NULL REFERENCES nodes(nodeNum) ON DELETE CASCADE,
-        fromNodeId TEXT NOT NULL,
-        toNodeId TEXT NOT NULL,
-        text TEXT NOT NULL,
-        channel INTEGER NOT NULL DEFAULT 0,
-        portnum INTEGER,
-        requestId INTEGER,
-        timestamp INTEGER NOT NULL,
-        rxTime INTEGER,
-        hopStart INTEGER,
-        hopLimit INTEGER,
-        relayNode INTEGER,
-        replyId INTEGER,
-        emoji INTEGER,
-        viaMqtt INTEGER,
-        viaStoreForward INTEGER DEFAULT 0,
-        rxSnr REAL,
-        rxRssi REAL,
-        ackFailed INTEGER,
-        routingErrorReceived INTEGER,
-        deliveryState TEXT,
-        wantAck INTEGER,
-        ackFromNode INTEGER,
-        createdAt INTEGER NOT NULL,
-        decrypted_by TEXT,
-        source_ip TEXT,
-        source_path TEXT,
-        spoofSuspected INTEGER
-      )
-    `);
-
-    drizzleDb = drizzle(db, { schema });
     repo = new MessagesRepository(drizzleDb, 'sqlite');
   });
 


### PR DESCRIPTION
Continues the section-B2 bulk migration: convert hand-rolled test DDL to the shared `createTestDb()` helper (landed in #3498).

## Change
The five messages repository tests previously hand-rolled `CREATE TABLE nodes` + `CREATE TABLE messages` (duplicating `src/db/schema/`). They now use `createTestDb()` — the full production schema from the migration registry:
- `messages.insert`, `messages.timestamp`, `messages.purge`, `messages.createdAt-ordering`, `messages.exclude-portnums`

## Note on the node seeding
Each test seeded its referenced nodes with a minimal `(nodeNum, nodeId)` insert. The real `nodes` schema requires `sourceId` (composite PK `(nodeNum, sourceId)` from migration 029) and `createdAt`/`updatedAt` NOT NULL — so the node seeds now include those. This is the per-file friction of the migration: the full schema has stricter constraints than the simplified hand-rolled tables.

## Validation
- `tsc --noEmit`: clean
- Full Vitest suite: **6527 pass, 0 fail, 0 suite failures** (same count — no tests lost)

## Remaining B2 scope
~32 hand-rolled-DDL test files remain (nodes, auth, channels, meshcore, services, database facade, etc.). They have heterogeneous setups (different reference-data seeding, some multi-backend) so each batch needs individual verification — these will follow as further small, verified PRs. Intentionally left: `telemetry.multidb.test.ts` (multi-backend by design) and `schemaIntegrity.test.ts` (asserts DDL alignment on purpose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)