### PR TITLE
refactor(server): Phase 1 — extract /health, /cleanup, /maintenance, /themes, /purge into route modules (#3502)

### DIFF
--- a/src/server/routes/cleanupRoutes.test.ts
+++ b/src/server/routes/cleanupRoutes.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import cleanupRoutes from './cleanupRoutes.js';
+import databaseService from '../../services/database.js';
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    drizzleDbType: 'sqlite',
+    findUserByIdAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn(),
+    checkPermissionAsync: vi.fn(),
+    getUserPermissionSetAsync: vi.fn(),
+    cleanupOldMessagesAsync: vi.fn(),
+    cleanupInactiveNodesAsync: vi.fn(),
+    cleanupInvalidChannelsAsync: vi.fn(),
+  },
+}));
+
+const mockDb = databaseService as unknown as {
+  findUserByIdAsync: ReturnType<typeof vi.fn>;
+  findUserByUsernameAsync: ReturnType<typeof vi.fn>;
+  checkPermissionAsync: ReturnType<typeof vi.fn>;
+  getUserPermissionSetAsync: ReturnType<typeof vi.fn>;
+  cleanupOldMessagesAsync: ReturnType<typeof vi.fn>;
+  cleanupInactiveNodesAsync: ReturnType<typeof vi.fn>;
+  cleanupInvalidChannelsAsync: ReturnType<typeof vi.fn>;
+};
+
+const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
+const regularUser = { id: 2, username: 'user', isActive: true, isAdmin: false };
+
+const createApp = (userId?: number, isAdmin = false): Express => {
+  const app = express();
+  app.use(express.json());
+  app.use(session({ secret: 'test', resave: false, saveUninitialized: false, cookie: { secure: false } }));
+  if (userId !== undefined) {
+    app.use((req, _res, next) => {
+      req.session.userId = userId;
+      next();
+    });
+  }
+  app.use('/cleanup', cleanupRoutes);
+  return app;
+};
+
+describe('Cleanup Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.findUserByUsernameAsync.mockResolvedValue(null);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: false });
+  });
+
+  describe('authentication', () => {
+    it('POST /cleanup/messages returns 401 when unauthenticated', async () => {
+      const app = createApp();
+      const res = await request(app).post('/cleanup/messages');
+      expect(res.status).toBe(401);
+    });
+
+    it('POST /cleanup/nodes returns 401 when unauthenticated', async () => {
+      const app = createApp();
+      const res = await request(app).post('/cleanup/nodes');
+      expect(res.status).toBe(401);
+    });
+
+    it('POST /cleanup/channels returns 401 when unauthenticated', async () => {
+      const app = createApp();
+      const res = await request(app).post('/cleanup/channels');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('authorization', () => {
+    it('POST /cleanup/messages returns 403 for non-admin', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(regularUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: false });
+      const app = createApp(regularUser.id);
+      const res = await request(app).post('/cleanup/messages').send({ days: 30 });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('POST /cleanup/messages', () => {
+    it('deletes old messages and returns count', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      mockDb.cleanupOldMessagesAsync.mockResolvedValue(42);
+      const app = createApp(adminUser.id, true);
+      const res = await request(app).post('/cleanup/messages').send({ days: 7 });
+      expect(res.status).toBe(200);
+      expect(res.body.deletedCount).toBe(42);
+      expect(mockDb.cleanupOldMessagesAsync).toHaveBeenCalledWith(7, undefined);
+    });
+
+    it('defaults to 30 days when days not specified', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      mockDb.cleanupOldMessagesAsync.mockResolvedValue(0);
+      const app = createApp(adminUser.id, true);
+      await request(app).post('/cleanup/messages').send({});
+      expect(mockDb.cleanupOldMessagesAsync).toHaveBeenCalledWith(30, undefined);
+    });
+  });
+
+  describe('POST /cleanup/nodes', () => {
+    it('deletes inactive nodes and returns count', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      mockDb.cleanupInactiveNodesAsync.mockResolvedValue(10);
+      const app = createApp(adminUser.id, true);
+      const res = await request(app).post('/cleanup/nodes').send({ days: 14, sourceId: 'src1' });
+      expect(res.status).toBe(200);
+      expect(res.body.deletedCount).toBe(10);
+      expect(mockDb.cleanupInactiveNodesAsync).toHaveBeenCalledWith(14, 'src1');
+    });
+  });
+
+  describe('POST /cleanup/channels', () => {
+    it('deletes invalid channels and returns count', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      mockDb.cleanupInvalidChannelsAsync.mockResolvedValue(3);
+      const app = createApp(adminUser.id, true);
+      const res = await request(app).post('/cleanup/channels').send({ sourceId: 'src1' });
+      expect(res.status).toBe(200);
+      expect(res.body.deletedCount).toBe(3);
+      expect(mockDb.cleanupInvalidChannelsAsync).toHaveBeenCalledWith('src1');
+    });
+  });
+});

--- a/src/server/routes/cleanupRoutes.ts
+++ b/src/server/routes/cleanupRoutes.ts
@@ -1,0 +1,45 @@
+import { Router, Request, Response } from 'express';
+import { requireAdmin } from '../auth/authMiddleware.js';
+import databaseService from '../../services/database.js';
+import { logger } from '../../utils/logger.js';
+
+const router = Router();
+
+router.use(requireAdmin());
+
+router.post('/messages', async (req: Request, res: Response) => {
+  try {
+    const days = parseInt(req.body.days) || 30;
+    const cleanupSourceId = req.body.sourceId as string | undefined;
+    const deletedCount = await databaseService.cleanupOldMessagesAsync(days, cleanupSourceId);
+    res.json({ deletedCount });
+  } catch (error) {
+    logger.error('Error cleaning up messages:', error);
+    res.status(500).json({ error: 'Failed to cleanup messages' });
+  }
+});
+
+router.post('/nodes', async (req: Request, res: Response) => {
+  try {
+    const days = parseInt(req.body.days) || 30;
+    const cleanupSourceId = req.body.sourceId as string | undefined;
+    const deletedCount = await databaseService.cleanupInactiveNodesAsync(days, cleanupSourceId);
+    res.json({ deletedCount });
+  } catch (error) {
+    logger.error('Error cleaning up nodes:', error);
+    res.status(500).json({ error: 'Failed to cleanup nodes' });
+  }
+});
+
+router.post('/channels', async (req: Request, res: Response) => {
+  try {
+    const cleanupSourceId = req.body?.sourceId as string | undefined;
+    const deletedCount = await databaseService.cleanupInvalidChannelsAsync(cleanupSourceId);
+    res.json({ deletedCount });
+  } catch (error) {
+    logger.error('Error cleaning up channels:', error);
+    res.status(500).json({ error: 'Failed to cleanup channels' });
+  }
+});
+
+export default router;

--- a/src/server/routes/healthRoutes.test.ts
+++ b/src/server/routes/healthRoutes.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import healthRoutes from './healthRoutes.js';
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    drizzleDbType: 'sqlite',
+    findUserByIdAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn(),
+    checkPermissionAsync: vi.fn(),
+    getUserPermissionSetAsync: vi.fn(),
+  },
+}));
+
+const createApp = () => {
+  const app = express();
+  app.use('/health', healthRoutes);
+  return app;
+};
+
+describe('Health Routes', () => {
+  it('GET /health returns status ok with version and uptime', async () => {
+    const app = createApp();
+    const response = await request(app).get('/health');
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('ok');
+    expect(typeof response.body.version).toBe('string');
+    expect(typeof response.body.uptime).toBe('number');
+    expect(response.body.databaseType).toBe('sqlite');
+    expect(typeof response.body.firmwareOtaEnabled).toBe('boolean');
+  });
+
+  it('GET /health does not require authentication', async () => {
+    const app = createApp();
+    const response = await request(app).get('/health');
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/server/routes/healthRoutes.ts
+++ b/src/server/routes/healthRoutes.ts
@@ -1,0 +1,36 @@
+import { createRequire } from 'module';
+import { Router, Request, Response } from 'express';
+import { optionalAuth } from '../auth/authMiddleware.js';
+import { getEnvironmentConfig } from '../config/environment.js';
+import databaseService from '../../services/database.js';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../../../package.json');
+
+// Captured at module load time (modules load during server startup)
+const moduleStartTime = Date.now();
+
+const router = Router();
+
+// Primary health check used by upgrade watchdog and external monitoring
+router.get('/', (_req: Request, res: Response) => {
+  res.json({
+    status: 'ok',
+    version: packageJson.version,
+    uptime: Date.now() - moduleStartTime,
+    databaseType: databaseService.drizzleDbType,
+    firmwareOtaEnabled: process.env.IS_DESKTOP !== 'true',
+  });
+});
+
+// Secondary health check endpoint (returns environment info)
+router.get('/', optionalAuth(), (_req: Request, res: Response) => {
+  const env = getEnvironmentConfig();
+  res.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    nodeEnv: env.nodeEnv,
+  });
+});
+
+export default router;

--- a/src/server/routes/maintenanceRoutes.test.ts
+++ b/src/server/routes/maintenanceRoutes.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import maintenanceRoutes from './maintenanceRoutes.js';
+import databaseService from '../../services/database.js';
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    drizzleDbType: 'sqlite',
+    findUserByIdAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn(),
+    checkPermissionAsync: vi.fn(),
+    getUserPermissionSetAsync: vi.fn(),
+  },
+}));
+
+vi.mock('../services/databaseMaintenanceService.js', () => ({
+  databaseMaintenanceService: {
+    getStatus: vi.fn(),
+    getDatabaseSizeAsync: vi.fn(),
+    formatBytes: vi.fn((n: number) => `${n} B`),
+    runMaintenance: vi.fn(),
+  },
+}));
+
+import { databaseMaintenanceService } from '../services/databaseMaintenanceService.js';
+
+const mockDb = databaseService as unknown as {
+  findUserByIdAsync: ReturnType<typeof vi.fn>;
+  findUserByUsernameAsync: ReturnType<typeof vi.fn>;
+  checkPermissionAsync: ReturnType<typeof vi.fn>;
+  getUserPermissionSetAsync: ReturnType<typeof vi.fn>;
+};
+
+const mockMaintenance = databaseMaintenanceService as unknown as {
+  getStatus: ReturnType<typeof vi.fn>;
+  getDatabaseSizeAsync: ReturnType<typeof vi.fn>;
+  formatBytes: ReturnType<typeof vi.fn>;
+  runMaintenance: ReturnType<typeof vi.fn>;
+};
+
+const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
+const regularUser = { id: 2, username: 'user', isActive: true, isAdmin: false };
+
+const createApp = (userId?: number, isAdmin = false): Express => {
+  const app = express();
+  app.use(express.json());
+  app.use(session({ secret: 'test', resave: false, saveUninitialized: false, cookie: { secure: false } }));
+  if (userId !== undefined) {
+    app.use((req, _res, next) => {
+      req.session.userId = userId;
+      next();
+    });
+  }
+  app.use('/maintenance', maintenanceRoutes);
+  return app;
+};
+
+describe('Maintenance Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.findUserByUsernameAsync.mockResolvedValue(null);
+  });
+
+  describe('GET /maintenance/status', () => {
+    it('returns 401 when unauthenticated', async () => {
+      const app = createApp();
+      const res = await request(app).get('/maintenance/status');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 403 when user lacks configuration:read', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(regularUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: false });
+      const app = createApp(regularUser.id);
+      const res = await request(app).get('/maintenance/status');
+      expect(res.status).toBe(403);
+    });
+
+    it('returns maintenance status for permitted user', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      const mockStatus = { running: false, enabled: true, lastRunTime: null };
+      mockMaintenance.getStatus.mockResolvedValue(mockStatus);
+      const app = createApp(adminUser.id);
+      const res = await request(app).get('/maintenance/status');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockStatus);
+    });
+  });
+
+  describe('GET /maintenance/size', () => {
+    it('returns database size for permitted user', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      mockMaintenance.getDatabaseSizeAsync.mockResolvedValue(1024);
+      mockMaintenance.formatBytes.mockReturnValue('1.00 KB');
+      const app = createApp(adminUser.id);
+      const res = await request(app).get('/maintenance/size');
+      expect(res.status).toBe(200);
+      expect(res.body.size).toBe(1024);
+      expect(res.body.formatted).toBe('1.00 KB');
+    });
+  });
+
+  describe('POST /maintenance/run', () => {
+    it('runs maintenance and returns stats', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      const stats = {
+        messagesDeleted: 10,
+        traceroutesDeleted: 5,
+        routeSegmentsDeleted: 3,
+        neighborInfoDeleted: 2,
+        sizeBefore: 2048,
+        sizeAfter: 1024,
+        duration: 100,
+        timestamp: '2024-01-01',
+      };
+      mockMaintenance.runMaintenance.mockResolvedValue(stats);
+      mockMaintenance.formatBytes.mockReturnValue('1.00 KB');
+      const app = createApp(adminUser.id);
+      const res = await request(app).post('/maintenance/run');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.stats).toEqual(stats);
+    });
+  });
+});

--- a/src/server/routes/maintenanceRoutes.ts
+++ b/src/server/routes/maintenanceRoutes.ts
@@ -1,0 +1,55 @@
+import { Router, Request, Response } from 'express';
+import { requirePermission } from '../auth/authMiddleware.js';
+import { databaseMaintenanceService } from '../services/databaseMaintenanceService.js';
+import { logger } from '../../utils/logger.js';
+
+const router = Router();
+
+router.get('/status', requirePermission('configuration', 'read'), async (_req: Request, res: Response) => {
+  try {
+    const status = await databaseMaintenanceService.getStatus();
+    res.json(status);
+  } catch (error) {
+    logger.error('❌ Error getting maintenance status:', error);
+    res.status(500).json({
+      error: 'Failed to get maintenance status',
+      details: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+router.get('/size', requirePermission('configuration', 'read'), async (_req: Request, res: Response) => {
+  try {
+    const size = await databaseMaintenanceService.getDatabaseSizeAsync();
+    res.json({
+      size,
+      formatted: databaseMaintenanceService.formatBytes(size),
+    });
+  } catch (error) {
+    logger.error('❌ Error getting database size:', error);
+    res.status(500).json({
+      error: 'Failed to get database size',
+      details: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+router.post('/run', requirePermission('configuration', 'write'), async (_req: Request, res: Response) => {
+  try {
+    logger.info('🔧 Manual database maintenance requested...');
+    const stats = await databaseMaintenanceService.runMaintenance();
+    res.json({
+      success: true,
+      stats,
+      message: `Maintenance complete: deleted ${stats.messagesDeleted + stats.traceroutesDeleted + stats.routeSegmentsDeleted + stats.neighborInfoDeleted} records, saved ${databaseMaintenanceService.formatBytes(stats.sizeBefore - stats.sizeAfter)}`,
+    });
+  } catch (error) {
+    logger.error('❌ Error running maintenance:', error);
+    res.status(500).json({
+      error: 'Failed to run maintenance',
+      details: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+export default router;

--- a/src/server/routes/purgeRoutes.test.ts
+++ b/src/server/routes/purgeRoutes.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import purgeRoutes from './purgeRoutes.js';
+import databaseService from '../../services/database.js';
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    drizzleDbType: 'sqlite',
+    findUserByIdAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn(),
+    checkPermissionAsync: vi.fn(),
+    getUserPermissionSetAsync: vi.fn(),
+    auditLogAsync: vi.fn(),
+    nodes: { getNodeCount: vi.fn() },
+    purgeAllNodesAsync: vi.fn(),
+    purgeAllTelemetryAsync: vi.fn(),
+    messages: { getMessageCount: vi.fn(), deleteAllMessages: vi.fn() },
+    traceroutes: { deleteAllTraceroutes: vi.fn(), deleteAllRouteSegments: vi.fn() },
+  },
+}));
+
+const mockManager = { refreshNodeDatabase: vi.fn() };
+vi.mock('../utils/resolveSourceManager.js', () => ({
+  resolveSourceManager: vi.fn(() => mockManager),
+}));
+
+const mockDb = databaseService as unknown as {
+  findUserByIdAsync: ReturnType<typeof vi.fn>;
+  findUserByUsernameAsync: ReturnType<typeof vi.fn>;
+  checkPermissionAsync: ReturnType<typeof vi.fn>;
+  getUserPermissionSetAsync: ReturnType<typeof vi.fn>;
+  auditLogAsync: ReturnType<typeof vi.fn>;
+  nodes: { getNodeCount: ReturnType<typeof vi.fn> };
+  purgeAllNodesAsync: ReturnType<typeof vi.fn>;
+  purgeAllTelemetryAsync: ReturnType<typeof vi.fn>;
+  messages: { getMessageCount: ReturnType<typeof vi.fn>; deleteAllMessages: ReturnType<typeof vi.fn> };
+  traceroutes: { deleteAllTraceroutes: ReturnType<typeof vi.fn>; deleteAllRouteSegments: ReturnType<typeof vi.fn> };
+};
+
+const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
+const regularUser = { id: 2, username: 'user', isActive: true, isAdmin: false };
+
+const createApp = (userId?: number): Express => {
+  const app = express();
+  app.use(express.json());
+  app.use(session({ secret: 'test', resave: false, saveUninitialized: false, cookie: { secure: false } }));
+  if (userId !== undefined) {
+    app.use((req, _res, next) => {
+      req.session.userId = userId;
+      next();
+    });
+  }
+  app.use('/purge', purgeRoutes);
+  return app;
+};
+
+describe('Purge Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.findUserByUsernameAsync.mockResolvedValue(null);
+    mockDb.auditLogAsync.mockResolvedValue(undefined);
+    mockDb.nodes.getNodeCount.mockResolvedValue(0);
+    mockDb.purgeAllNodesAsync.mockResolvedValue(undefined);
+    mockManager.refreshNodeDatabase.mockResolvedValue(undefined);
+    mockDb.purgeAllTelemetryAsync.mockResolvedValue(undefined);
+    mockDb.messages.getMessageCount.mockResolvedValue(0);
+    mockDb.messages.deleteAllMessages.mockResolvedValue(undefined);
+    mockDb.traceroutes.deleteAllTraceroutes.mockResolvedValue(undefined);
+    mockDb.traceroutes.deleteAllRouteSegments.mockResolvedValue(undefined);
+  });
+
+  describe('authentication and authorization', () => {
+    it('returns 401 for unauthenticated requests', async () => {
+      const app = createApp();
+      const res = await request(app).post('/purge/nodes');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 403 for non-admin users', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(regularUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: false });
+      const app = createApp(regularUser.id);
+      const res = await request(app).post('/purge/nodes');
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('POST /purge/nodes', () => {
+    it('purges nodes and triggers refresh', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      const app = createApp(adminUser.id);
+      const res = await request(app).post('/purge/nodes').send({});
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(mockDb.purgeAllNodesAsync).toHaveBeenCalled();
+      expect(mockManager.refreshNodeDatabase).toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /purge/telemetry', () => {
+    it('purges all telemetry', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      const app = createApp(adminUser.id);
+      const res = await request(app).post('/purge/telemetry').send({});
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(mockDb.purgeAllTelemetryAsync).toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /purge/messages', () => {
+    it('purges all messages', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      mockDb.messages.getMessageCount.mockResolvedValue(100);
+      const app = createApp(adminUser.id);
+      const res = await request(app).post('/purge/messages').send({});
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(mockDb.messages.deleteAllMessages).toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /purge/traceroutes', () => {
+    it('purges all traceroutes and route segments', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      const app = createApp(adminUser.id);
+      const res = await request(app).post('/purge/traceroutes').send({});
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(mockDb.traceroutes.deleteAllTraceroutes).toHaveBeenCalled();
+      expect(mockDb.traceroutes.deleteAllRouteSegments).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/routes/purgeRoutes.ts
+++ b/src/server/routes/purgeRoutes.ts
@@ -1,0 +1,104 @@
+import { Router, Request, Response } from 'express';
+import { requireAdmin } from '../auth/authMiddleware.js';
+import databaseService from '../../services/database.js';
+import { logger } from '../../utils/logger.js';
+import { resolveSourceManager } from '../utils/resolveSourceManager.js';
+
+const router = Router();
+
+router.use(requireAdmin());
+
+router.post('/nodes', async (req: Request, res: Response) => {
+  try {
+    const { sourceId: purgeNodesSourceId } = req.body || {};
+    const nodeCount = await databaseService.nodes.getNodeCount();
+    await databaseService.purgeAllNodesAsync(purgeNodesSourceId);
+    const purgeNodesManager = resolveSourceManager(purgeNodesSourceId);
+    await purgeNodesManager.refreshNodeDatabase();
+
+    databaseService.auditLogAsync(
+      req.user!.id,
+      'nodes_purged',
+      'nodes',
+      JSON.stringify({ count: nodeCount, sourceId: purgeNodesSourceId ?? null }),
+      req.ip || null
+    );
+
+    res.json({
+      success: true,
+      message: purgeNodesSourceId
+        ? `Nodes and traceroutes purged for source ${purgeNodesSourceId}, refresh triggered`
+        : 'All nodes and traceroutes purged, refresh triggered',
+    });
+  } catch (error) {
+    logger.error('Error purging nodes:', error);
+    res.status(500).json({ error: 'Failed to purge nodes' });
+  }
+});
+
+router.post('/telemetry', async (req: Request, res: Response) => {
+  try {
+    const { sourceId: purgeTelemetrySourceId } = req.body || {};
+    await databaseService.purgeAllTelemetryAsync(purgeTelemetrySourceId);
+
+    databaseService.auditLogAsync(
+      req.user!.id,
+      'telemetry_purged',
+      'telemetry',
+      JSON.stringify({ sourceId: purgeTelemetrySourceId ?? null }),
+      req.ip || null
+    );
+
+    res.json({
+      success: true,
+      message: purgeTelemetrySourceId
+        ? `Telemetry purged for source ${purgeTelemetrySourceId}`
+        : 'All telemetry data purged',
+    });
+  } catch (error) {
+    logger.error('Error purging telemetry:', error);
+    res.status(500).json({ error: 'Failed to purge telemetry' });
+  }
+});
+
+router.post('/messages', async (req: Request, res: Response) => {
+  try {
+    const messageCount = await databaseService.messages.getMessageCount();
+    await databaseService.messages.deleteAllMessages();
+
+    databaseService.auditLogAsync(
+      req.user!.id,
+      'messages_purged',
+      'messages',
+      JSON.stringify({ count: messageCount }),
+      req.ip || null
+    );
+
+    res.json({ success: true, message: 'All messages purged' });
+  } catch (error) {
+    logger.error('Error purging messages:', error);
+    res.status(500).json({ error: 'Failed to purge messages' });
+  }
+});
+
+router.post('/traceroutes', async (req: Request, res: Response) => {
+  try {
+    await databaseService.traceroutes.deleteAllTraceroutes();
+    await databaseService.traceroutes.deleteAllRouteSegments();
+
+    databaseService.auditLogAsync(
+      req.user!.id,
+      'traceroutes_purged',
+      'traceroute',
+      'All traceroutes and route segments purged',
+      req.ip || null
+    );
+
+    res.json({ success: true, message: 'All traceroutes and route segments purged' });
+  } catch (error) {
+    logger.error('Error purging traceroutes:', error);
+    res.status(500).json({ error: 'Failed to purge traceroutes' });
+  }
+});
+
+export default router;

--- a/src/server/routes/themeRoutes.test.ts
+++ b/src/server/routes/themeRoutes.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import themeRoutes from './themeRoutes.js';
+import databaseService from '../../services/database.js';
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    drizzleDbType: 'sqlite',
+    findUserByIdAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn(),
+    checkPermissionAsync: vi.fn(),
+    getUserPermissionSetAsync: vi.fn(),
+    auditLogAsync: vi.fn(),
+    validateThemeDefinition: vi.fn(),
+    misc: {
+      getAllCustomThemes: vi.fn(),
+      getCustomThemeBySlug: vi.fn(),
+      createCustomTheme: vi.fn(),
+      updateCustomTheme: vi.fn(),
+      deleteCustomTheme: vi.fn(),
+    },
+  },
+}));
+
+const mockDb = databaseService as unknown as {
+  findUserByIdAsync: ReturnType<typeof vi.fn>;
+  findUserByUsernameAsync: ReturnType<typeof vi.fn>;
+  checkPermissionAsync: ReturnType<typeof vi.fn>;
+  getUserPermissionSetAsync: ReturnType<typeof vi.fn>;
+  auditLogAsync: ReturnType<typeof vi.fn>;
+  validateThemeDefinition: ReturnType<typeof vi.fn>;
+  misc: {
+    getAllCustomThemes: ReturnType<typeof vi.fn>;
+    getCustomThemeBySlug: ReturnType<typeof vi.fn>;
+    createCustomTheme: ReturnType<typeof vi.fn>;
+    updateCustomTheme: ReturnType<typeof vi.fn>;
+    deleteCustomTheme: ReturnType<typeof vi.fn>;
+  };
+};
+
+const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
+const regularUser = { id: 2, username: 'user', isActive: true, isAdmin: false };
+
+const createApp = (userId?: number, isAdmin = false): Express => {
+  const app = express();
+  app.use(express.json());
+  app.use(session({ secret: 'test', resave: false, saveUninitialized: false, cookie: { secure: false } }));
+  if (userId !== undefined) {
+    app.use((req, _res, next) => {
+      req.session.userId = userId;
+      next();
+    });
+  }
+  app.use('/themes', themeRoutes);
+  return app;
+};
+
+const sampleTheme = { id: 1, name: 'Dark Mode', slug: 'custom-dark', definition: '{}', is_builtin: false };
+
+describe('Theme Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.findUserByUsernameAsync.mockResolvedValue(null);
+    mockDb.auditLogAsync.mockResolvedValue(undefined);
+    mockDb.validateThemeDefinition.mockReturnValue(true);
+  });
+
+  describe('GET /themes', () => {
+    it('returns all themes without authentication', async () => {
+      mockDb.misc.getAllCustomThemes.mockResolvedValue([sampleTheme]);
+      const app = createApp();
+      const res = await request(app).get('/themes');
+      expect(res.status).toBe(200);
+      expect(res.body.themes).toHaveLength(1);
+    });
+
+    it('returns all themes for authenticated users', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(regularUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: false });
+      mockDb.misc.getAllCustomThemes.mockResolvedValue([sampleTheme]);
+      const app = createApp(regularUser.id);
+      const res = await request(app).get('/themes');
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('GET /themes/:slug', () => {
+    it('returns a specific theme by slug', async () => {
+      mockDb.misc.getCustomThemeBySlug.mockResolvedValue(sampleTheme);
+      const app = createApp();
+      const res = await request(app).get('/themes/custom-dark');
+      expect(res.status).toBe(200);
+      expect(res.body.theme.slug).toBe('custom-dark');
+    });
+
+    it('returns 404 for unknown slug', async () => {
+      mockDb.misc.getCustomThemeBySlug.mockResolvedValue(null);
+      const app = createApp();
+      const res = await request(app).get('/themes/custom-nonexistent');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /themes', () => {
+    it('returns 401 for unauthenticated users', async () => {
+      const app = createApp();
+      const res = await request(app).post('/themes').send({ name: 'Test', slug: 'custom-test', definition: {} });
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 403 for users without themes:write permission', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(regularUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: false });
+      const app = createApp(regularUser.id);
+      const res = await request(app).post('/themes').send({ name: 'Test', slug: 'custom-test', definition: {} });
+      expect(res.status).toBe(403);
+    });
+
+    it('creates a theme for admin', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      mockDb.misc.getCustomThemeBySlug.mockResolvedValue(null);
+      mockDb.misc.createCustomTheme.mockResolvedValue(sampleTheme);
+      const app = createApp(adminUser.id);
+      const res = await request(app)
+        .post('/themes')
+        .send({ name: 'Dark Mode', slug: 'custom-dark', definition: { '--primary': '#000' } });
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+    });
+
+    it('returns 400 for invalid slug format', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      const app = createApp(adminUser.id);
+      const res = await request(app)
+        .post('/themes')
+        .send({ name: 'Test', slug: 'invalid-slug', definition: {} });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 409 when slug already exists', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      mockDb.misc.getCustomThemeBySlug.mockResolvedValue(sampleTheme);
+      const app = createApp(adminUser.id);
+      const res = await request(app)
+        .post('/themes')
+        .send({ name: 'Dark Mode', slug: 'custom-dark', definition: {} });
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe('PUT /themes/:slug', () => {
+    it('updates an existing theme', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      mockDb.misc.getCustomThemeBySlug.mockResolvedValue(sampleTheme);
+      mockDb.misc.updateCustomTheme.mockResolvedValue(undefined);
+      const app = createApp(adminUser.id);
+      const res = await request(app).put('/themes/custom-dark').send({ name: 'Dark Mode Updated' });
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+
+    it('returns 403 when trying to modify a built-in theme', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      mockDb.misc.getCustomThemeBySlug.mockResolvedValue({ ...sampleTheme, is_builtin: true });
+      const app = createApp(adminUser.id);
+      const res = await request(app).put('/themes/custom-dark').send({ name: 'Updated' });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('DELETE /themes/:slug', () => {
+    it('deletes a custom theme', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      mockDb.misc.getCustomThemeBySlug.mockResolvedValue(sampleTheme);
+      mockDb.misc.deleteCustomTheme.mockResolvedValue(undefined);
+      const app = createApp(adminUser.id);
+      const res = await request(app).delete('/themes/custom-dark');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+
+    it('returns 403 when trying to delete a built-in theme', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      mockDb.misc.getCustomThemeBySlug.mockResolvedValue({ ...sampleTheme, is_builtin: true });
+      const app = createApp(adminUser.id);
+      const res = await request(app).delete('/themes/custom-dark');
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 404 for unknown theme', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      mockDb.misc.getCustomThemeBySlug.mockResolvedValue(null);
+      const app = createApp(adminUser.id);
+      const res = await request(app).delete('/themes/custom-nonexistent');
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/src/server/routes/themeRoutes.ts
+++ b/src/server/routes/themeRoutes.ts
@@ -1,0 +1,168 @@
+import { Router, Request, Response } from 'express';
+import { requirePermission, optionalAuth } from '../auth/authMiddleware.js';
+import databaseService from '../../services/database.js';
+import { logger } from '../../utils/logger.js';
+
+const router = Router();
+
+router.get('/', optionalAuth(), async (_req: Request, res: Response) => {
+  try {
+    const themes = await databaseService.misc.getAllCustomThemes();
+    res.json({ themes });
+  } catch (error) {
+    logger.error('Error fetching custom themes:', error);
+    res.status(500).json({ error: 'Failed to fetch custom themes' });
+  }
+});
+
+router.get('/:slug', optionalAuth(), async (req: Request, res: Response) => {
+  try {
+    const { slug } = req.params;
+    const theme = await databaseService.misc.getCustomThemeBySlug(slug);
+
+    if (!theme) {
+      return res.status(404).json({ error: 'Theme not found' });
+    }
+
+    res.json({ theme });
+  } catch (error) {
+    logger.error(`Error fetching theme ${req.params.slug}:`, error);
+    res.status(500).json({ error: 'Failed to fetch theme' });
+  }
+});
+
+router.post('/', requirePermission('themes', 'write'), async (req: Request, res: Response) => {
+  try {
+    const { name, slug, definition } = req.body;
+
+    if (!name || typeof name !== 'string' || name.length < 1 || name.length > 50) {
+      return res.status(400).json({ error: 'Theme name must be 1-50 characters' });
+    }
+
+    if (!slug || typeof slug !== 'string' || !slug.match(/^custom-[a-z0-9-]+$/)) {
+      return res
+        .status(400)
+        .json({ error: 'Slug must start with "custom-" and contain only lowercase letters, numbers, and hyphens' });
+    }
+
+    const existingTheme = await databaseService.misc.getCustomThemeBySlug(slug);
+    if (existingTheme) {
+      return res.status(409).json({ error: 'Theme with this slug already exists' });
+    }
+
+    if (!databaseService.validateThemeDefinition(definition)) {
+      return res
+        .status(400)
+        .json({ error: 'Invalid theme definition. All required color variables must be valid hex codes' });
+    }
+
+    const theme = await databaseService.misc.createCustomTheme(name, slug, JSON.stringify(definition), req.user!.id);
+
+    databaseService.auditLogAsync(
+      req.user!.id,
+      'theme_created',
+      'themes',
+      `Created custom theme: ${name} (${slug})`,
+      req.ip || null,
+      null,
+      JSON.stringify({ id: theme.id, name, slug })
+    );
+
+    res.status(201).json({ success: true, theme });
+  } catch (error) {
+    logger.error('Error creating custom theme:', error);
+    res.status(500).json({ error: 'Failed to create custom theme' });
+  }
+});
+
+router.put('/:slug', requirePermission('themes', 'write'), async (req: Request, res: Response) => {
+  try {
+    const { slug } = req.params;
+    const { name, definition } = req.body;
+
+    const existingTheme = await databaseService.misc.getCustomThemeBySlug(slug);
+    if (!existingTheme) {
+      return res.status(404).json({ error: 'Theme not found' });
+    }
+
+    if (existingTheme.is_builtin) {
+      return res.status(403).json({ error: 'Cannot modify built-in themes' });
+    }
+
+    const updates: Record<string, unknown> = {};
+
+    if (name !== undefined) {
+      if (typeof name !== 'string' || name.length < 1 || name.length > 50) {
+        return res.status(400).json({ error: 'Theme name must be 1-50 characters' });
+      }
+      updates.name = name;
+    }
+
+    if (definition !== undefined) {
+      if (!databaseService.validateThemeDefinition(definition)) {
+        return res
+          .status(400)
+          .json({ error: 'Invalid theme definition. All required color variables must be valid hex codes' });
+      }
+      updates.definition = definition;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({ error: 'No updates provided' });
+    }
+
+    const repoUpdates: Record<string, string> = {};
+    if (updates.name) repoUpdates.name = updates.name as string;
+    if (updates.definition) repoUpdates.definition = JSON.stringify(updates.definition);
+    await databaseService.misc.updateCustomTheme(slug, repoUpdates);
+
+    databaseService.auditLogAsync(
+      req.user!.id,
+      'theme_updated',
+      'themes',
+      `Updated custom theme: ${existingTheme.name} (${slug})`,
+      req.ip || null,
+      JSON.stringify({ name: existingTheme.name }),
+      JSON.stringify(updates)
+    );
+
+    res.json({ success: true });
+  } catch (error) {
+    logger.error(`Error updating theme ${req.params.slug}:`, error);
+    res.status(500).json({ error: 'Failed to update theme' });
+  }
+});
+
+router.delete('/:slug', requirePermission('themes', 'write'), async (req: Request, res: Response) => {
+  try {
+    const { slug } = req.params;
+
+    const theme = await databaseService.misc.getCustomThemeBySlug(slug);
+    if (!theme) {
+      return res.status(404).json({ error: 'Theme not found' });
+    }
+
+    if (theme.is_builtin) {
+      return res.status(403).json({ error: 'Cannot delete built-in themes' });
+    }
+
+    await databaseService.misc.deleteCustomTheme(slug);
+
+    databaseService.auditLogAsync(
+      req.user!.id,
+      'theme_deleted',
+      'themes',
+      `Deleted custom theme: ${theme.name} (${slug})`,
+      req.ip || null,
+      JSON.stringify({ id: theme.id, name: theme.name, slug }),
+      null
+    );
+
+    res.json({ success: true, message: 'Theme deleted successfully' });
+  } catch (error) {
+    logger.error(`Error deleting theme ${req.params.slug}:`, error);
+    res.status(500).json({ error: 'Failed to delete theme' });
+  }
+});
+
+export default router;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -972,20 +972,17 @@ import { createGeoJsonRouter } from './routes/geojsonRoutes.js';
 import { GeoJsonService } from './services/geojsonService.js';
 import { MapStyleService } from './services/mapStyleService.js';
 import { createMapStyleRouter } from './routes/mapStyleRoutes.js';
+import healthRoutes from './routes/healthRoutes.js';
+import cleanupRoutes from './routes/cleanupRoutes.js';
+import maintenanceRoutes from './routes/maintenanceRoutes.js';
+import themeRoutes from './routes/themeRoutes.js';
+import purgeRoutes from './routes/purgeRoutes.js';
 
 // CSRF token endpoint (must be before CSRF protection middleware)
 apiRouter.get('/csrf-token', csrfTokenEndpoint);
 
-// Health check endpoint (for upgrade watchdog and monitoring)
-apiRouter.get('/health', (_req, res) => {
-  res.json({
-    status: 'ok',
-    version: packageJson.version,
-    uptime: Date.now() - serverStartTime,
-    databaseType: databaseService.drizzleDbType,
-    firmwareOtaEnabled: process.env.IS_DESKTOP !== 'true',
-  });
-});
+// Health check endpoints (for upgrade watchdog and monitoring)
+apiRouter.use('/health', healthRoutes);
 
 // Server info endpoint (returns timezone and other server configuration)
 apiRouter.get('/server-info', (_req, res) => {
@@ -1095,6 +1092,10 @@ const mapStyleDataDir = path.join(process.env.DATA_DIR || '/data', 'styles');
 const mapStyleService = new MapStyleService(mapStyleDataDir);
 const mapStyleRouter = createMapStyleRouter(mapStyleService);
 apiRouter.use('/map-styles', mapStyleRouter);
+apiRouter.use('/cleanup', cleanupRoutes);
+apiRouter.use('/maintenance', maintenanceRoutes);
+apiRouter.use('/themes', themeRoutes);
+apiRouter.use('/purge', purgeRoutes);
 
 // Wire up side-effect callbacks for settingsRoutes
 setSettingsCallbacks({
@@ -3851,41 +3852,6 @@ apiRouter.post('/import', requireAdmin(), async (req, res) => {
   }
 });
 
-apiRouter.post('/cleanup/messages', requireAdmin(), async (req, res) => {
-  try {
-    const days = parseInt(req.body.days) || 30;
-    const cleanupSourceId = req.body.sourceId as string | undefined;
-    const deletedCount = await databaseService.cleanupOldMessagesAsync(days, cleanupSourceId);
-    res.json({ deletedCount });
-  } catch (error) {
-    logger.error('Error cleaning up messages:', error);
-    res.status(500).json({ error: 'Failed to cleanup messages' });
-  }
-});
-
-apiRouter.post('/cleanup/nodes', requireAdmin(), async (req, res) => {
-  try {
-    const days = parseInt(req.body.days) || 30;
-    const cleanupSourceId = req.body.sourceId as string | undefined;
-    const deletedCount = await databaseService.cleanupInactiveNodesAsync(days, cleanupSourceId);
-    res.json({ deletedCount });
-  } catch (error) {
-    logger.error('Error cleaning up nodes:', error);
-    res.status(500).json({ error: 'Failed to cleanup nodes' });
-  }
-});
-
-apiRouter.post('/cleanup/channels', requireAdmin(), async (req, res) => {
-  try {
-    const cleanupSourceId = req.body?.sourceId as string | undefined;
-    const deletedCount = await databaseService.cleanupInvalidChannelsAsync(cleanupSourceId);
-    res.json({ deletedCount });
-  } catch (error) {
-    logger.error('Error cleaning up channels:', error);
-    res.status(500).json({ error: 'Failed to cleanup channels' });
-  }
-});
-
 // Send message endpoint
 apiRouter.post('/messages/send', optionalAuth(), async (req, res) => {
   try {
@@ -5987,59 +5953,6 @@ apiRouter.post('/system/backup/settings', requirePermission('configuration', 'wr
 });
 
 // ==========================================
-// Database Maintenance Endpoints
-// ==========================================
-
-// Get database maintenance status
-apiRouter.get('/maintenance/status', requirePermission('configuration', 'read'), async (_req, res) => {
-  try {
-    const status = await databaseMaintenanceService.getStatus();
-    res.json(status);
-  } catch (error) {
-    logger.error('❌ Error getting maintenance status:', error);
-    res.status(500).json({
-      error: 'Failed to get maintenance status',
-      details: error instanceof Error ? error.message : 'Unknown error',
-    });
-  }
-});
-
-// Get current database size
-apiRouter.get('/maintenance/size', requirePermission('configuration', 'read'), async (_req, res) => {
-  try {
-    const size = await databaseMaintenanceService.getDatabaseSizeAsync();
-    res.json({
-      size,
-      formatted: databaseMaintenanceService.formatBytes(size),
-    });
-  } catch (error) {
-    logger.error('❌ Error getting database size:', error);
-    res.status(500).json({
-      error: 'Failed to get database size',
-      details: error instanceof Error ? error.message : 'Unknown error',
-    });
-  }
-});
-
-// Manually trigger database maintenance
-apiRouter.post('/maintenance/run', requirePermission('configuration', 'write'), async (_req, res) => {
-  try {
-    logger.info('🔧 Manual database maintenance requested...');
-    const stats = await databaseMaintenanceService.runMaintenance();
-    res.json({
-      success: true,
-      stats,
-      message: `Maintenance complete: deleted ${stats.messagesDeleted + stats.traceroutesDeleted + stats.routeSegmentsDeleted + stats.neighborInfoDeleted} records, saved ${databaseMaintenanceService.formatBytes(stats.sizeBefore - stats.sizeAfter)}`,
-    });
-  } catch (error) {
-    logger.error('❌ Error running maintenance:', error);
-    res.status(500).json({
-      error: 'Failed to run maintenance',
-      details: error instanceof Error ? error.message : 'Unknown error',
-    });
-  }
-});
-
 // Refresh nodes from device endpoint
 apiRouter.post('/nodes/refresh', requirePermission('nodes', 'write'), async (req, res) => {
   try {
@@ -7014,186 +6927,6 @@ apiRouter.post('/user/map-preferences', requireAuth(), async (req, res) => {
   }
 });
 
-// Custom Themes endpoints
-
-// Get all custom themes (available to all users for reading)
-apiRouter.get('/themes', optionalAuth(), async (_req, res) => {
-  try {
-    const themes = await databaseService.misc.getAllCustomThemes();
-    res.json({ themes });
-  } catch (error) {
-    logger.error('Error fetching custom themes:', error);
-    res.status(500).json({ error: 'Failed to fetch custom themes' });
-  }
-});
-
-// Get a specific theme by slug
-apiRouter.get('/themes/:slug', optionalAuth(), async (req, res) => {
-  try {
-    const { slug } = req.params;
-    const theme = await databaseService.misc.getCustomThemeBySlug(slug);
-
-    if (!theme) {
-      return res.status(404).json({ error: 'Theme not found' });
-    }
-
-    res.json({ theme });
-  } catch (error) {
-    logger.error(`Error fetching theme ${req.params.slug}:`, error);
-    res.status(500).json({ error: 'Failed to fetch theme' });
-  }
-});
-
-// Create a new custom theme
-apiRouter.post('/themes', requirePermission('themes', 'write'), async (req, res) => {
-  try {
-    const { name, slug, definition } = req.body;
-
-    // Validation
-    if (!name || typeof name !== 'string' || name.length < 1 || name.length > 50) {
-      return res.status(400).json({ error: 'Theme name must be 1-50 characters' });
-    }
-
-    if (!slug || typeof slug !== 'string' || !slug.match(/^custom-[a-z0-9-]+$/)) {
-      return res
-        .status(400)
-        .json({ error: 'Slug must start with "custom-" and contain only lowercase letters, numbers, and hyphens' });
-    }
-
-    // Check if theme already exists
-    const existingTheme = await databaseService.misc.getCustomThemeBySlug(slug);
-    if (existingTheme) {
-      return res.status(409).json({ error: 'Theme with this slug already exists' });
-    }
-
-    // Validate theme definition
-    if (!databaseService.validateThemeDefinition(definition)) {
-      return res
-        .status(400)
-        .json({ error: 'Invalid theme definition. All required color variables must be valid hex codes' });
-    }
-
-    // Create the theme
-    const theme = await databaseService.misc.createCustomTheme(name, slug, JSON.stringify(definition), req.user!.id);
-
-    // Audit log
-    databaseService.auditLogAsync(
-      req.user!.id,
-      'theme_created',
-      'themes',
-      `Created custom theme: ${name} (${slug})`,
-      req.ip || null,
-      null,
-      JSON.stringify({ id: theme.id, name, slug })
-    );
-
-    res.status(201).json({ success: true, theme });
-  } catch (error) {
-    logger.error('Error creating custom theme:', error);
-    res.status(500).json({ error: 'Failed to create custom theme' });
-  }
-});
-
-// Update an existing custom theme
-apiRouter.put('/themes/:slug', requirePermission('themes', 'write'), async (req, res) => {
-  try {
-    const { slug } = req.params;
-    const { name, definition } = req.body;
-
-    // Get existing theme for audit log
-    const existingTheme = await databaseService.misc.getCustomThemeBySlug(slug);
-    if (!existingTheme) {
-      return res.status(404).json({ error: 'Theme not found' });
-    }
-
-    if (existingTheme.is_builtin) {
-      return res.status(403).json({ error: 'Cannot modify built-in themes' });
-    }
-
-    const updates: any = {};
-
-    // Validate name if provided
-    if (name !== undefined) {
-      if (typeof name !== 'string' || name.length < 1 || name.length > 50) {
-        return res.status(400).json({ error: 'Theme name must be 1-50 characters' });
-      }
-      updates.name = name;
-    }
-
-    // Validate definition if provided
-    if (definition !== undefined) {
-      if (!databaseService.validateThemeDefinition(definition)) {
-        return res
-          .status(400)
-          .json({ error: 'Invalid theme definition. All required color variables must be valid hex codes' });
-      }
-      updates.definition = definition;
-    }
-
-    if (Object.keys(updates).length === 0) {
-      return res.status(400).json({ error: 'No updates provided' });
-    }
-
-    // Update the theme
-    const repoUpdates: Record<string, string> = {};
-    if (updates.name) repoUpdates.name = updates.name;
-    if (updates.definition) repoUpdates.definition = JSON.stringify(updates.definition);
-    await databaseService.misc.updateCustomTheme(slug, repoUpdates);
-
-    // Audit log
-    databaseService.auditLogAsync(
-      req.user!.id,
-      'theme_updated',
-      'themes',
-      `Updated custom theme: ${existingTheme.name} (${slug})`,
-      req.ip || null,
-      JSON.stringify({ name: existingTheme.name }),
-      JSON.stringify(updates)
-    );
-
-    res.json({ success: true });
-  } catch (error) {
-    logger.error(`Error updating theme ${req.params.slug}:`, error);
-    res.status(500).json({ error: 'Failed to update theme' });
-  }
-});
-
-// Delete a custom theme
-apiRouter.delete('/themes/:slug', requirePermission('themes', 'write'), async (req, res) => {
-  try {
-    const { slug } = req.params;
-
-    // Get theme for audit log before deletion
-    const theme = await databaseService.misc.getCustomThemeBySlug(slug);
-    if (!theme) {
-      return res.status(404).json({ error: 'Theme not found' });
-    }
-
-    if (theme.is_builtin) {
-      return res.status(403).json({ error: 'Cannot delete built-in themes' });
-    }
-
-    // Delete the theme
-    await databaseService.misc.deleteCustomTheme(slug);
-
-    // Audit log
-    databaseService.auditLogAsync(
-      req.user!.id,
-      'theme_deleted',
-      'themes',
-      `Deleted custom theme: ${theme.name} (${slug})`,
-      req.ip || null,
-      JSON.stringify({ id: theme.id, name: theme.name, slug }),
-      null
-    );
-
-    res.json({ success: true, message: 'Theme deleted successfully' });
-  } catch (error) {
-    logger.error(`Error deleting theme ${req.params.slug}:`, error);
-    res.status(500).json({ error: 'Failed to delete theme' });
-  }
-});
-
 // Auto-announce endpoints
 apiRouter.post('/announce/send', requirePermission('automation', 'write'), async (req, res) => {
   try {
@@ -7253,105 +6986,6 @@ apiRouter.get('/announce/preview', requirePermission('automation', 'read'), asyn
   } catch (error) {
     logger.error('Error generating announcement preview:', error);
     res.status(500).json({ error: 'Failed to generate preview' });
-  }
-});
-
-// Danger zone endpoints
-apiRouter.post('/purge/nodes', requireAdmin(), async (req, res) => {
-  try {
-    const { sourceId: purgeNodesSourceId } = req.body || {};
-    const nodeCount = await databaseService.nodes.getNodeCount();
-    await databaseService.purgeAllNodesAsync(purgeNodesSourceId);
-    // Trigger a node refresh after purging (only on the affected source)
-    const purgeNodesManager = resolveSourceManager(purgeNodesSourceId);
-    await purgeNodesManager.refreshNodeDatabase();
-
-    // Audit log
-    databaseService.auditLogAsync(
-      req.user!.id,
-      'nodes_purged',
-      'nodes',
-      JSON.stringify({ count: nodeCount, sourceId: purgeNodesSourceId ?? null }),
-      req.ip || null
-    );
-
-    res.json({
-      success: true,
-      message: purgeNodesSourceId
-        ? `Nodes and traceroutes purged for source ${purgeNodesSourceId}, refresh triggered`
-        : 'All nodes and traceroutes purged, refresh triggered',
-    });
-  } catch (error) {
-    logger.error('Error purging nodes:', error);
-    res.status(500).json({ error: 'Failed to purge nodes' });
-  }
-});
-
-apiRouter.post('/purge/telemetry', requireAdmin(), async (req, res) => {
-  try {
-    const { sourceId: purgeTelemetrySourceId } = req.body || {};
-    await databaseService.purgeAllTelemetryAsync(purgeTelemetrySourceId);
-
-    // Audit log
-    databaseService.auditLogAsync(
-      req.user!.id,
-      'telemetry_purged',
-      'telemetry',
-      JSON.stringify({ sourceId: purgeTelemetrySourceId ?? null }),
-      req.ip || null
-    );
-
-    res.json({
-      success: true,
-      message: purgeTelemetrySourceId
-        ? `Telemetry purged for source ${purgeTelemetrySourceId}`
-        : 'All telemetry data purged',
-    });
-  } catch (error) {
-    logger.error('Error purging telemetry:', error);
-    res.status(500).json({ error: 'Failed to purge telemetry' });
-  }
-});
-
-apiRouter.post('/purge/messages', requireAdmin(), async (req, res) => {
-  try {
-    const messageCount = await databaseService.messages.getMessageCount();
-    await databaseService.messages.deleteAllMessages();
-
-    // Audit log
-    databaseService.auditLogAsync(
-      req.user!.id,
-      'messages_purged',
-      'messages',
-      JSON.stringify({ count: messageCount }),
-      req.ip || null
-    );
-
-    res.json({ success: true, message: 'All messages purged' });
-  } catch (error) {
-    logger.error('Error purging messages:', error);
-    res.status(500).json({ error: 'Failed to purge messages' });
-  }
-});
-
-apiRouter.post('/purge/traceroutes', requireAdmin(), async (req, res) => {
-  try {
-    await databaseService.traceroutes.deleteAllTraceroutes();
-    await databaseService.traceroutes.deleteAllRouteSegments();
-
-    // Audit log
-    databaseService.auditLogAsync(
-      req.user!.id,
-      'traceroutes_purged',
-      'traceroute',
-      'All traceroutes and route segments purged',
-      req.ip || null
-    );
-
-    res.json({ success: true, message: 'All traceroutes and route segments purged' });
-  } catch (error) {
-    logger.error('Error purging traceroutes:', error);
-    res.status(500).json({ error: 'Failed to purge traceroutes' });
   }
 });
 
@@ -9095,15 +8729,6 @@ apiRouter.get('/system/status', requirePermission('dashboard', 'read'), async (_
       type: databaseType.charAt(0).toUpperCase() + databaseType.slice(1), // Capitalize
       version: databaseVersion,
     },
-  });
-});
-
-// Health check endpoint
-apiRouter.get('/health', optionalAuth(), (_req, res) => {
-  res.json({
-    status: 'ok',
-    timestamp: new Date().toISOString(),
-    nodeEnv: env.nodeEnv,
   });
 });
 


### PR DESCRIPTION
## Summary

Phase 1 of #3502: moves 17 inline `apiRouter` handlers out of the 11,322-line `server.ts` monolith into five dedicated `src/server/routes/` modules, leaving `server.ts` responsible only for wiring them up. This is the low-coupling group from the issue's extraction recipe — each handler touches only `databaseService`, `databaseMaintenanceService`, or `resolveSourceManager` with no shared inline helpers, making them safe proof-of-pattern extractions.

## Changes

- **`healthRoutes.ts`** — GET `/health` (both registered handlers, behaviour-preserving)
- **`cleanupRoutes.ts`** — POST `/cleanup/{messages,nodes,channels}` (3 handlers, all `requireAdmin()`)
- **`maintenanceRoutes.ts`** — GET `/maintenance/{status,size}`, POST `/maintenance/run` (3 handlers, `requirePermission('configuration', …)`)
- **`themeRoutes.ts`** — GET/POST/PUT/DELETE `/themes` and `/themes/:slug` (5 handlers, mixed `optionalAuth` / `requirePermission('themes', 'write')`)
- **`purgeRoutes.ts`** — POST `/purge/{nodes,telemetry,messages,traceroutes}` (4 handlers, all `requireAdmin()`)
- **`server.ts`** — removed 386 lines of inline handlers; imports and mounts the five new modules

## Issues Resolved

Relates to #3502

## Documentation Updates

No documentation changes needed — this is a pure internal refactor with no behavior changes.

## Testing

- [x] Unit tests pass (6549 tests, 0 failures — 35 new tests added for the new modules)
- [x] TypeScript compiles cleanly (pre-existing 57 errors on main are unchanged)
- [x] All 5 new route modules have dedicated test files covering happy paths, auth (401/403), and edge cases
- [ ] Reviewer: verify `/api/health`, `/api/cleanup/*`, `/api/maintenance/*`, `/api/themes*`, `/api/purge/*` endpoints respond identically to pre-PR behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)