### PR TITLE
fix(meshcore): stop upsertNode from clobbering stored node data with nulls (#3504)

### DIFF
--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -131,6 +131,28 @@ describe('MeshCoreRepository — sourceId stamping', () => {
     expect(row.name).toBe('updated');
   });
 
+  it('upsertNode does NOT clobber stored name/position with incoming nulls (#3504)', async () => {
+    // Seed a node with a learned name + position.
+    await repo.upsertNode(
+      { publicKey: 'pk-1', name: 'Repeater North', latitude: 43.65, longitude: -79.38 },
+      'src-a',
+    );
+    // A later observation lacks position/name (e.g. a path-only advert), so the
+    // callers pass `field ?? null`. These nulls must NOT wipe the stored values.
+    await repo.upsertNode(
+      { publicKey: 'pk-1', name: null, latitude: null, longitude: null, advType: 1 },
+      'src-a',
+    );
+
+    const row = db.prepare(
+      `SELECT name, latitude, longitude, advType FROM meshcore_nodes WHERE publicKey = 'pk-1'`,
+    ).get() as { name: string; latitude: number; longitude: number; advType: number };
+    expect(row.name).toBe('Repeater North');
+    expect(row.latitude).toBeCloseTo(43.65);
+    expect(row.longitude).toBeCloseTo(-79.38);
+    expect(row.advType).toBe(1); // a provided value still updates
+  });
+
   it('upsertNode does not let one source clobber another source\'s row', async () => {
     // Drop the SQLite PRIMARY KEY so the underlying schema can hold one
     // row per (publicKey, sourceId) — the eventual shape per the slice-1

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -153,6 +153,19 @@ describe('MeshCoreRepository — sourceId stamping', () => {
     expect(row.advType).toBe(1); // a provided value still updates
   });
 
+  it('upsertNode writes a falsy-but-valid value like batteryMv: 0 (not skipped as "absent")', async () => {
+    // Guards the merge guard's `!== null && !== undefined` test against a
+    // future change to a truthiness check (`!v`), which would wrongly drop 0.
+    await repo.upsertNode({ publicKey: 'pk-1', name: 'n', batteryMv: 4100 }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk-1', batteryMv: 0 }, 'src-a');
+
+    const row = db.prepare(
+      `SELECT batteryMv, name FROM meshcore_nodes WHERE publicKey = 'pk-1'`,
+    ).get() as { batteryMv: number; name: string };
+    expect(row.batteryMv).toBe(0); // 0 is written, not skipped
+    expect(row.name).toBe('n');    // unrelated field preserved
+  });
+
   it('upsertNode does not let one source clobber another source\'s row', async () => {
     // Drop the SQLite PRIMARY KEY so the underlying schema can hold one
     // row per (publicKey, sourceId) — the eventual shape per the slice-1

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -215,9 +215,29 @@ export class MeshCoreRepository extends BaseRepository {
     const existing = await this.getNodeByPublicKeyAndSource(node.publicKey, sourceId);
 
     if (existing) {
+      // Merge, don't clobber (#3504). Callers (persistContact, the telemetry
+      // config route) pass `field: value ?? null` for fields they didn't
+      // observe this time. A bare `.set({ ...node })` would write those nulls
+      // over a previously-stored name/position/etc. Drop null/undefined incoming
+      // fields so drizzle only updates columns the caller actually provided a
+      // value for; the stored value is preserved otherwise. (`false`/`0`/`''`
+      // are kept — only null/undefined means "not observed".)
+      //
+      // Exception: outPath/pathLen are explicitly clearable via null — a null
+      // there means the route was reset (CMD_RESET_PATH), not "unobserved".
+      const CLEARABLE_VIA_NULL = new Set(['outPath', 'pathLen']);
+      const updateSet: Record<string, unknown> = { sourceId, updatedAt: now };
+      for (const [k, v] of Object.entries(node)) {
+        if (v !== null && v !== undefined) {
+          updateSet[k] = v;
+        } else if (v === null && CLEARABLE_VIA_NULL.has(k)) {
+          updateSet[k] = null;
+        }
+        // else: preserve the existing stored value (don't write the field)
+      }
       await this.db
         .update(meshcoreNodes)
-        .set({ ...node, sourceId, updatedAt: now })
+        .set(updateSet)
         .where(and(eq(meshcoreNodes.publicKey, node.publicKey), eq(meshcoreNodes.sourceId, sourceId)));
     } else {
       await this.db

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -9,6 +9,14 @@ import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType } from '../types.js';
 
 /**
+ * meshcore_nodes columns where an incoming `null` in upsertNode means "clear
+ * this column" (e.g. CMD_RESET_PATH) rather than "not observed this update".
+ * Every other column preserves its stored value on a null/undefined incoming —
+ * see upsertNode's merge guard (#3504).
+ */
+const CLEARABLE_VIA_NULL = new Set<string>(['outPath', 'pathLen']);
+
+/**
  * MeshCore node data for database operations
  */
 export interface DbMeshCoreNode {
@@ -224,8 +232,8 @@ export class MeshCoreRepository extends BaseRepository {
       // are kept — only null/undefined means "not observed".)
       //
       // Exception: outPath/pathLen are explicitly clearable via null — a null
-      // there means the route was reset (CMD_RESET_PATH), not "unobserved".
-      const CLEARABLE_VIA_NULL = new Set(['outPath', 'pathLen']);
+      // there means the route was reset (CMD_RESET_PATH), not "unobserved"
+      // (see CLEARABLE_VIA_NULL at module scope).
       const updateSet: Record<string, unknown> = { sourceId, updatedAt: now };
       for (const [k, v] of Object.entries(node)) {
         if (v !== null && v !== undefined) {


### PR DESCRIPTION
Closes #3504.

## Bug (reachability verified — this one is real)
`MeshCoreRepository.upsertNode`'s update branch did `.set({ ...node, sourceId, updatedAt })`, **ignoring the `existing` row it fetches**. Two real callers pass `field: value ?? null` for fields they didn't observe this cycle:
- `meshcoreManager.persistContact` (`meshcoreManager.ts:1154`)
- the telemetry-config route (`meshcoreRoutes.ts:2346`, the #3092 advType-stamping path)

So an incoming `null` (no position / no name this time) silently **overwrote a previously-stored name / position / advType**.

(The telemetry poller at `meshcoreTelemetryPoller.ts:249` is **safe** — it passes a partial `{ publicKey, batteryMv }` object, and drizzle `.set()` only writes keys present, so it never nulls other columns.)

## Fix
Merge instead of clobber: drop `null`/`undefined` incoming fields so only columns the caller actually provided a value for are updated; the stored value is preserved otherwise. `false`/`0`/`''` are still written (only `null`/`undefined` means "not observed").

**Per-column exception:** `outPath`/`pathLen` remain **clearable via null** — there a null means the route was reset (CMD_RESET_PATH), not "unobserved". This preserves the existing, tested behavior (`meshcore.test.ts:99-108`). This is the audit's "per-column opt-in" recommendation in practice.

## Tests
- New: a null-laden re-upsert (`name: null, latitude: null, longitude: null`) must preserve the stored name/position, while a provided `advType` still updates.
- The existing CMD_RESET_PATH "null clears outPath/pathLen" test still passes (24/24 meshcore tests).

## Validation
- `tsc --noEmit`: clean
- Full Vitest suite: **6525 pass, 0 fail**

Note: I led with the reachability check this time (#3503 turned out to be dead code). Here the buggy path is genuinely reachable — confirmed the callers pass explicit nulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)