### PR TITLE
fix(telemetry): unify serial ingest onto shared digit-aware normalizer (#3506)

### DIFF
--- a/src/server/meshtasticManager.telemetryCanonical.test.ts
+++ b/src/server/meshtasticManager.telemetryCanonical.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression tests for #3506 — serial telemetry ingest unified onto the shared
+ * canonical-key normalizer (buildCanonicalMetrics).
+ *
+ * The device / environment / airQuality / power branches no longer read a
+ * hand-maintained list of camelCase property names; they iterate the decoded
+ * fields and resolve each through canonicalTelemetryType/Unit. These tests pin:
+ *   - the environment leaf renames (relativeHumidity→humidity, etc.),
+ *   - device + power channels coming through the same path,
+ *   - genuine 0 readings still stored,
+ *   - protobuf.js repeated fields (exposed as own `[]`) and unknown leaves skipped.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockInsertTelemetry = vi.fn();
+const mockUpsertNode = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    telemetry: { insertTelemetry: mockInsertTelemetry },
+    nodes: { upsertNode: mockUpsertNode, getAllNodes: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+function storedValue(type: string): number | undefined {
+  const call = mockInsertTelemetry.mock.calls.find((c) => c[0]?.telemetryType === type);
+  return call?.[0]?.value;
+}
+function storedUnit(type: string): string | undefined {
+  const call = mockInsertTelemetry.mock.calls.find((c) => c[0]?.telemetryType === type);
+  return call?.[0]?.unit;
+}
+function storedTypes(): string[] {
+  return mockInsertTelemetry.mock.calls.map((c) => c[0]?.telemetryType);
+}
+
+describe('MeshtasticManager - canonical telemetry normalization (#3506)', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module = await import('./meshtasticManager.js');
+    manager = module.default;
+    vi.spyOn(manager, 'trackPKIEncryption').mockResolvedValue(undefined);
+  });
+
+  const meshPacket = { from: 0x22222222, id: 7 };
+
+  it('normalizes environment leaf renames and units', async () => {
+    await manager.processTelemetryMessageProtobuf(meshPacket, {
+      environmentMetrics: {
+        temperature: 21.5,
+        relativeHumidity: 48,
+        barometricPressure: 1013.2,
+        voltage: 3.7,
+        current: 0.12,
+      },
+    });
+
+    expect(storedValue('temperature')).toBeCloseTo(21.5, 2);
+    expect(storedValue('humidity')).toBe(48);
+    expect(storedUnit('humidity')).toBe('%');
+    expect(storedValue('pressure')).toBeCloseTo(1013.2, 1);
+    expect(storedUnit('pressure')).toBe('hPa');
+    // Deprecated env voltage/current are renamed so they don't collide with PowerMetrics.
+    expect(storedValue('envVoltage')).toBeCloseTo(3.7, 2);
+    expect(storedUnit('envVoltage')).toBe('V');
+    expect(storedValue('envCurrent')).toBeCloseTo(0.12, 2);
+    expect(storedUnit('envCurrent')).toBe('A');
+  });
+
+  it('stores device metrics through the shared path', async () => {
+    await manager.processTelemetryMessageProtobuf(meshPacket, {
+      deviceMetrics: {
+        batteryLevel: 0, // genuine 0 must persist
+        voltage: 4.1,
+        channelUtilization: 12.5,
+        airUtilTx: 3.2,
+        uptimeSeconds: 86400,
+      },
+    });
+
+    expect(storedValue('batteryLevel')).toBe(0);
+    expect(storedUnit('batteryLevel')).toBe('%');
+    expect(storedValue('voltage')).toBeCloseTo(4.1, 2);
+    expect(storedValue('channelUtilization')).toBeCloseTo(12.5, 2);
+    expect(storedValue('airUtilTx')).toBeCloseTo(3.2, 2);
+    expect(storedValue('uptimeSeconds')).toBe(86400);
+  });
+
+  it('stores power channels through the shared path', async () => {
+    await manager.processTelemetryMessageProtobuf(meshPacket, {
+      powerMetrics: { ch1Voltage: 3.8, ch1Current: 150, ch3Voltage: 5.0 },
+    });
+
+    expect(storedValue('ch1Voltage')).toBeCloseTo(3.8, 2);
+    expect(storedUnit('ch1Voltage')).toBe('V');
+    expect(storedValue('ch1Current')).toBe(150);
+    expect(storedUnit('ch1Current')).toBe('mA');
+    expect(storedValue('ch3Voltage')).toBe(5.0);
+  });
+
+  it('skips repeated/array fields and unknown leaves', async () => {
+    await manager.processTelemetryMessageProtobuf(meshPacket, {
+      environmentMetrics: {
+        temperature: 19,
+        // protobuf.js exposes repeated EnvironmentMetrics.oneWireTemperature as an own [].
+        oneWireTemperature: [],
+        // A leaf with no canonical unit must not be persisted.
+        someFutureUntrackedField: 999,
+      },
+    });
+
+    expect(storedValue('temperature')).toBe(19);
+    expect(storedTypes()).not.toContain('oneWireTemperature');
+    expect(storedTypes()).not.toContain('someFutureUntrackedField');
+  });
+});

--- a/src/server/meshtasticManager.telemetryCanonical.test.ts
+++ b/src/server/meshtasticManager.telemetryCanonical.test.ts
@@ -105,6 +105,21 @@ describe('MeshtasticManager - canonical telemetry normalization (#3506)', () => 
     expect(storedValue('ch3Voltage')).toBe(5.0);
   });
 
+  it('excludes NaN / Infinity values (Number.isFinite guard)', async () => {
+    await manager.processTelemetryMessageProtobuf(meshPacket, {
+      environmentMetrics: {
+        temperature: NaN,
+        barometricPressure: Infinity,
+        humidity: -Infinity, // relativeHumidity canonical is 'humidity'; this is an unknown leaf anyway
+        gasResistance: 12.3, // a finite value still gets through
+      },
+    });
+
+    expect(storedTypes()).not.toContain('temperature');
+    expect(storedTypes()).not.toContain('pressure');
+    expect(storedValue('gasResistance')).toBeCloseTo(12.3, 2);
+  });
+
   it('skips repeated/array fields and unknown leaves', async () => {
     await manager.processTelemetryMessageProtobuf(meshPacket, {
       environmentMetrics: {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6434,6 +6434,10 @@ class MeshtasticManager implements ISourceManager {
         const deviceMetrics = telemetry.deviceMetrics;
         logger.debug(`📊 Device telemetry: battery=${deviceMetrics.batteryLevel}%, voltage=${deviceMetrics.voltage}V`);
 
+        // These four are copied onto nodeData (the node-row "latest value" snapshot
+        // persisted via upsertNode below), which is a separate concern from the
+        // per-reading telemetry history rows that buildCanonicalMetrics extracts —
+        // hence the apparent duplication.
         nodeData.batteryLevel = deviceMetrics.batteryLevel;
         nodeData.voltage = deviceMetrics.voltage;
         nodeData.channelUtilization = deviceMetrics.channelUtilization;

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -30,6 +30,7 @@ import { shouldGateAutomations, averageStrongestNeighborUtilization, DEFAULT_AIR
 import { resolveLastHopName } from './utils/lastHop.js';
 import { scriptDependencyEnv } from './utils/scriptRunner.js';
 import { canonicalMessageTime } from './utils/messageTime.js';
+import { canonicalTelemetryType, canonicalTelemetryUnit } from './utils/telemetryKeys.js';
 import { isNodeComplete } from '../utils/nodeHelpers.js';
 import { getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
 import { migrateAutomationChannels } from './utils/automationChannelMigration.js';
@@ -1102,6 +1103,40 @@ class MeshtasticManager implements ISourceManager {
         }, this.sourceId);
       }
     }
+  }
+
+  /**
+   * Normalize a decoded protobuf metrics sub-message (device / environment /
+   * airQuality / power) into the canonical `{ type, value, unit }` rows that
+   * {@link saveTelemetryMetrics} persists.
+   *
+   * This iterates the *actual* fields the decoder produced rather than reading a
+   * hand-maintained list of camelCase property names. That matters because of
+   * the protobuf.js underscore-before-digit quirk (#3483): fields like
+   * `particles_03um` / `rainfall_1h` stay snake_case on the decoded message, so
+   * a fixed `metrics.particles03um` read returns undefined and silently drops
+   * the data. {@link canonicalTelemetryType} runs each decoded leaf through the
+   * same digit-aware `snakeToCamel` the MQTT path uses, so a new
+   * underscore-before-digit field is picked up automatically once its unit is
+   * added to `CANONICAL_TELEMETRY_UNITS` — no per-field fallback to maintain.
+   *
+   * Only numeric leaves with a known canonical unit are stored: this skips
+   * repeated/message fields (protobuf.js exposes e.g. `oneWireTemperature` as an
+   * own `[]`), Long/object values, and leaves we don't track (unit === undefined).
+   */
+  private buildCanonicalMetrics(
+    group: 'device' | 'environment' | 'airQuality' | 'power',
+    metrics: Record<string, unknown>
+  ): Array<{ type: string; value: number; unit: string }> {
+    const rows: Array<{ type: string; value: number; unit: string }> = [];
+    for (const [leaf, raw] of Object.entries(metrics)) {
+      if (typeof raw !== 'number' || !Number.isFinite(raw)) continue;
+      const type = canonicalTelemetryType(group, leaf);
+      const unit = canonicalTelemetryUnit(type);
+      if (unit === undefined) continue;
+      rows.push({ type, value: raw, unit });
+    }
+    return rows;
   }
 
   /**
@@ -6415,76 +6450,27 @@ class MeshtasticManager implements ISourceManager {
           this.localChannelUtilization = deviceMetrics.channelUtilization;
         }
 
-        // Save all telemetry values from actual TELEMETRY_APP packets (no deduplication)
-        if (deviceMetrics.batteryLevel !== undefined && deviceMetrics.batteryLevel !== null && !isNaN(deviceMetrics.batteryLevel)) {
-          await databaseService.telemetry.insertTelemetry({
-            nodeId, nodeNum: fromNum, telemetryType: 'batteryLevel',
-            timestamp, value: deviceMetrics.batteryLevel, unit: '%', createdAt: now, packetTimestamp, packetId
-          }, this.sourceId);
-        }
-        if (deviceMetrics.voltage !== undefined && deviceMetrics.voltage !== null && !isNaN(deviceMetrics.voltage)) {
-          await databaseService.telemetry.insertTelemetry({
-            nodeId, nodeNum: fromNum, telemetryType: 'voltage',
-            timestamp, value: deviceMetrics.voltage, unit: 'V', createdAt: now, packetTimestamp, packetId
-          }, this.sourceId);
-        }
-        if (deviceMetrics.channelUtilization !== undefined && deviceMetrics.channelUtilization !== null && !isNaN(deviceMetrics.channelUtilization)) {
-          await databaseService.telemetry.insertTelemetry({
-            nodeId, nodeNum: fromNum, telemetryType: 'channelUtilization',
-            timestamp, value: deviceMetrics.channelUtilization, unit: '%', createdAt: now, packetTimestamp, packetId
-          }, this.sourceId);
-        }
-        if (deviceMetrics.airUtilTx !== undefined && deviceMetrics.airUtilTx !== null && !isNaN(deviceMetrics.airUtilTx)) {
-          await databaseService.telemetry.insertTelemetry({
-            nodeId, nodeNum: fromNum, telemetryType: 'airUtilTx',
-            timestamp, value: deviceMetrics.airUtilTx, unit: '%', createdAt: now, packetTimestamp, packetId
-          }, this.sourceId);
-        }
-        if (deviceMetrics.uptimeSeconds !== undefined && deviceMetrics.uptimeSeconds !== null && !isNaN(deviceMetrics.uptimeSeconds)) {
-          await databaseService.telemetry.insertTelemetry({
-            nodeId, nodeNum: fromNum, telemetryType: 'uptimeSeconds',
-            timestamp, value: deviceMetrics.uptimeSeconds, unit: 's', createdAt: now, packetTimestamp, packetId
-          }, this.sourceId);
-        }
+        // Save all telemetry values from actual TELEMETRY_APP packets (no
+        // deduplication). Normalized through the shared canonical-key path so
+        // both serial and MQTT ingest write identical telemetryType/unit values.
+        await this.saveTelemetryMetrics(
+          this.buildCanonicalMetrics('device', deviceMetrics),
+          nodeId, fromNum, timestamp, packetTimestamp, packetId
+        );
       } else if (telemetry.environmentMetrics) {
         const envMetrics = telemetry.environmentMetrics;
         logger.debug(`🌡️ Environment telemetry: temp=${envMetrics.temperature}°C, humidity=${envMetrics.relativeHumidity}%`);
 
-        // Save all Environment metrics to telemetry table
-        await this.saveTelemetryMetrics([
-          // Core weather metrics
-          { type: 'temperature', value: envMetrics.temperature, unit: '°C' },
-          { type: 'humidity', value: envMetrics.relativeHumidity, unit: '%' },
-          { type: 'pressure', value: envMetrics.barometricPressure, unit: 'hPa' },
-          // Air quality related
-          { type: 'gasResistance', value: envMetrics.gasResistance, unit: 'MΩ' },
-          { type: 'iaq', value: envMetrics.iaq, unit: 'IAQ' },
-          // Light sensors
-          { type: 'lux', value: envMetrics.lux, unit: 'lux' },
-          { type: 'whiteLux', value: envMetrics.whiteLux, unit: 'lux' },
-          { type: 'irLux', value: envMetrics.irLux, unit: 'lux' },
-          { type: 'uvLux', value: envMetrics.uvLux, unit: 'lux' },
-          // Wind metrics
-          { type: 'windDirection', value: envMetrics.windDirection, unit: '°' },
-          { type: 'windSpeed', value: envMetrics.windSpeed, unit: 'm/s' },
-          { type: 'windGust', value: envMetrics.windGust, unit: 'm/s' },
-          { type: 'windLull', value: envMetrics.windLull, unit: 'm/s' },
-          // Precipitation. Same protobuf.js underscore-before-digit quirk as the
-          // particle counts: `rainfall_1h` / `rainfall_24h` stay snake_case on the
-          // decoded message, so read those with the camelCase as a fallback.
-          { type: 'rainfall1h', value: envMetrics.rainfall1h ?? envMetrics.rainfall_1h, unit: 'mm' },
-          { type: 'rainfall24h', value: envMetrics.rainfall24h ?? envMetrics.rainfall_24h, unit: 'mm' },
-          // Soil sensors
-          { type: 'soilMoisture', value: envMetrics.soilMoisture, unit: '%' },
-          { type: 'soilTemperature', value: envMetrics.soilTemperature, unit: '°C' },
-          // Other sensors
-          { type: 'radiation', value: envMetrics.radiation, unit: 'µR/h' },
-          { type: 'distance', value: envMetrics.distance, unit: 'mm' },
-          { type: 'weight', value: envMetrics.weight, unit: 'kg' },
-          // Deprecated but still supported (use PowerMetrics for new implementations)
-          { type: 'envVoltage', value: envMetrics.voltage, unit: 'V' },
-          { type: 'envCurrent', value: envMetrics.current, unit: 'A' }
-        ], nodeId, fromNum, timestamp, packetTimestamp, packetId);
+        // Save all Environment metrics to telemetry table. buildCanonicalMetrics
+        // iterates the decoded fields and normalizes each through the shared
+        // canonical-key map, so the underscore-before-digit quirk (rainfall_1h /
+        // rainfall_24h) and the leaf renames (relativeHumidity→humidity,
+        // barometricPressure→pressure, voltage→envVoltage, current→envCurrent)
+        // are handled centrally rather than with per-field fallbacks here.
+        await this.saveTelemetryMetrics(
+          this.buildCanonicalMetrics('environment', envMetrics),
+          nodeId, fromNum, timestamp, packetTimestamp, packetId
+        );
       } else if (telemetry.powerMetrics) {
         const powerMetrics = telemetry.powerMetrics;
 
@@ -6499,61 +6485,27 @@ class MeshtasticManager implements ISourceManager {
         }
         logger.debug(`⚡ Power telemetry: ${channelInfo.join(', ')}`);
 
-        // Process all 8 power channels
-        for (let ch = 1; ch <= 8; ch++) {
-          const voltageKey = `ch${ch}Voltage` as keyof typeof powerMetrics;
-          const currentKey = `ch${ch}Current` as keyof typeof powerMetrics;
-
-          // Save voltage for this channel
-          const voltage = powerMetrics[voltageKey];
-          if (voltage !== undefined && voltage !== null && !isNaN(Number(voltage))) {
-            await databaseService.telemetry.insertTelemetry({
-              nodeId, nodeNum: fromNum, telemetryType: String(voltageKey),
-              timestamp, value: Number(voltage), unit: 'V', createdAt: now, packetTimestamp, packetId
-            }, this.sourceId);
-          }
-
-          // Save current for this channel
-          const current = powerMetrics[currentKey];
-          if (current !== undefined && current !== null && !isNaN(Number(current))) {
-            await databaseService.telemetry.insertTelemetry({
-              nodeId, nodeNum: fromNum, telemetryType: String(currentKey),
-              timestamp, value: Number(current), unit: 'mA', createdAt: now, packetTimestamp, packetId
-            }, this.sourceId);
-          }
-        }
+        // Save all 8 channels' voltage/current through the shared canonical path
+        // (ch1Voltage … ch8Current, units V / mA from CANONICAL_TELEMETRY_UNITS).
+        await this.saveTelemetryMetrics(
+          this.buildCanonicalMetrics('power', powerMetrics),
+          nodeId, fromNum, timestamp, packetTimestamp, packetId
+        );
       } else if (telemetry.airQualityMetrics) {
         const aqMetrics = telemetry.airQualityMetrics;
         logger.debug(`🌬️ Air Quality telemetry: PM2.5=${aqMetrics.pm25Standard}µg/m³, CO2=${aqMetrics.co2}ppm`);
 
-        // Save all AirQuality metrics to telemetry table
-        await this.saveTelemetryMetrics([
-          // PM Standard measurements (µg/m³)
-          { type: 'pm10Standard', value: aqMetrics.pm10Standard, unit: 'µg/m³' },
-          { type: 'pm25Standard', value: aqMetrics.pm25Standard, unit: 'µg/m³' },
-          { type: 'pm100Standard', value: aqMetrics.pm100Standard, unit: 'µg/m³' },
-          // PM Environmental measurements (µg/m³)
-          { type: 'pm10Environmental', value: aqMetrics.pm10Environmental, unit: 'µg/m³' },
-          { type: 'pm25Environmental', value: aqMetrics.pm25Environmental, unit: 'µg/m³' },
-          { type: 'pm100Environmental', value: aqMetrics.pm100Environmental, unit: 'µg/m³' },
-          // Particle counts (#/0.1L).
-          // protobuf.js only camelCases an underscore followed by a *letter*, so
-          // these underscore-before-digit fields (particles_03um …) stay
-          // snake_case on the decoded message — `aqMetrics.particles03um` is
-          // undefined and the data was silently dropped. Read the snake_case form
-          // the decoder actually produces, with the camelCase as a fallback in
-          // case a future protobuf.js / keepCase config changes the shape.
-          { type: 'particles03um', value: aqMetrics.particles03um ?? aqMetrics.particles_03um, unit: '#/0.1L' },
-          { type: 'particles05um', value: aqMetrics.particles05um ?? aqMetrics.particles_05um, unit: '#/0.1L' },
-          { type: 'particles10um', value: aqMetrics.particles10um ?? aqMetrics.particles_10um, unit: '#/0.1L' },
-          { type: 'particles25um', value: aqMetrics.particles25um ?? aqMetrics.particles_25um, unit: '#/0.1L' },
-          { type: 'particles50um', value: aqMetrics.particles50um ?? aqMetrics.particles_50um, unit: '#/0.1L' },
-          { type: 'particles100um', value: aqMetrics.particles100um ?? aqMetrics.particles_100um, unit: '#/0.1L' },
-          // CO2 and related
-          { type: 'co2', value: aqMetrics.co2, unit: 'ppm' },
-          { type: 'co2Temperature', value: aqMetrics.co2Temperature, unit: '°C' },
-          { type: 'co2Humidity', value: aqMetrics.co2Humidity, unit: '%' }
-        ], nodeId, fromNum, timestamp, packetTimestamp, packetId);
+        // Save all AirQuality metrics to telemetry table. The particle counts
+        // (particles_03um … particles_100um) hit the protobuf.js
+        // underscore-before-digit quirk and stay snake_case on the decoded
+        // message; buildCanonicalMetrics normalizes each decoded leaf through the
+        // shared digit-aware map, so they're captured without per-field
+        // `?? particles_NNum` fallbacks (and new particle bins are picked up
+        // automatically once their unit is added to CANONICAL_TELEMETRY_UNITS).
+        await this.saveTelemetryMetrics(
+          this.buildCanonicalMetrics('airQuality', aqMetrics),
+          nodeId, fromNum, timestamp, packetTimestamp, packetId
+        );
       } else if (telemetry.localStats) {
         const localStats = telemetry.localStats;
         logger.debug(`📊 LocalStats telemetry: uptime=${localStats.uptimeSeconds}s, heap_free=${localStats.heapFreeBytes}B`);


### PR DESCRIPTION
## Summary

Closes #3506. Durable fix for the protobuf.js underscore-before-digit recurrence class (#3483).

The serial telemetry path (`processTelemetryMessageProtobuf`) read each device/environment/airQuality/power metric by a hand-maintained camelCase property name, carrying per-field `?? particles_NNum` / `?? rainfall_Nh` fallbacks to survive the protobuf.js quirk where `particles_03um` / `rainfall_1h` stay **snake_case** on the decoded message. Any new underscore-before-digit field upstream would silently drop again until someone added another fallback.

## What changed

- New `buildCanonicalMetrics(group, decoded)` helper iterates the fields the decoder actually produced and resolves each leaf through the shared `canonicalTelemetryType` / `canonicalTelemetryUnit` map — the same digit-aware `snakeToCamel` the MQTT path already uses.
- The four static metric lists (device, environment, airQuality, power) collapse to one helper call each. New `_<digit>` fields are picked up automatically once their unit lands in `CANONICAL_TELEMETRY_UNITS` (this is what #3507 will extend), with no per-field fallback to maintain.
- Device branch keeps its `nodeData` + `localChannelUtilization` side-effects; only its telemetry inserts route through the helper.

## Verification

Confirmed empirically against the **real decoder shape** (`Telemetry.decode`, a protobuf.js message instance):
- `Object.entries` yields only wire-present own fields — unset scalars read as `null` and are excluded (no spurious 0s).
- Genuine `0` readings are own properties → preserved.
- protobuf.js repeated fields (e.g. `oneWireTemperature` → own `[]`) and untracked leaves are skipped via `typeof === 'number'` + known-unit guards.

Behavior-preserving for the current protobuf. Existing #3483 regression test (`meshtasticManager.airQualityParticles.test.ts`) still passes; new `meshtasticManager.telemetryCanonical.test.ts` covers env leaf renames, device/power channels, genuine-0, and the repeated/unknown-field skips.

Full suite: **6569 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)