### PR TITLE
fix: prevent NodeInfo from overwriting high-precision positions (#3513)

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 90 migrations registered', () => {
-    expect(registry.count()).toBe(90);
+  it('has all 91 migrations registered', () => {
+    expect(registry.count()).toBe(91);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_position_points_only_to_map_prefs', () => {
+  it('last migration is estimated_positions_double_precision', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(90);
-    expect(last.name).toContain('add_position_points_only_to_map_prefs');
+    expect(last.number).toBe(91);
+    expect(last.name).toContain('estimated_positions_double_precision');
   });
 
-  it('migrations are sequentially numbered from 1 to 90', () => {
+  it('migrations are sequentially numbered from 1 to 91', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -105,6 +105,7 @@ import { migration as mapMaxAgeMigration, runMigration087Postgres as runMapMaxAg
 import { migration as sourcePkiKeysMigration, runMigration088Postgres as runSourcePkiKeysPostgres, runMigration088Mysql as runSourcePkiKeysMysql } from '../server/migrations/088_add_source_pki_keys.js';
 import { migration as positionSnrHopsMigration, runMigration089Postgres as runPositionSnrHopsPostgres, runMigration089Mysql as runPositionSnrHopsMysql } from '../server/migrations/089_add_position_snr_hops.js';
 import { migration as positionPointsOnlyMigration, runMigration090Postgres as runPositionPointsOnlyPostgres, runMigration090Mysql as runPositionPointsOnlyMysql } from '../server/migrations/090_add_position_points_only_to_map_prefs.js';
+import { migration as estimatedPositionsDoublePrecisionMigration, runMigration091Postgres as runEstimatedPositionsDoublePrecisionPostgres, runMigration091Mysql as runEstimatedPositionsDoublePrecisionMysql } from '../server/migrations/091_estimated_positions_double_precision.js';
 
 // ============================================================================
 // Registry
@@ -1438,4 +1439,19 @@ registry.register({
   sqlite: (db) => positionPointsOnlyMigration.up(db),
   postgres: (client) => runPositionPointsOnlyPostgres(client),
   mysql: (pool) => runPositionPointsOnlyMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 091: estimated_positions lat/lon/uncertaintyKm → DOUBLE PRECISION
+// (PostgreSQL only). The original REAL columns (~7 sig. digits) caused visible
+// coordinate rounding for estimated node positions (#3513).
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 91,
+  name: 'estimated_positions_double_precision',
+  settingsKey: 'migration_091_estimated_positions_double_precision',
+  sqlite: (db) => estimatedPositionsDoublePrecisionMigration.up(db),
+  postgres: (client) => runEstimatedPositionsDoublePrecisionPostgres(client),
+  mysql: (pool) => runEstimatedPositionsDoublePrecisionMysql(pool),
 });

--- a/src/db/schema/estimatedPositions.ts
+++ b/src/db/schema/estimatedPositions.ts
@@ -15,7 +15,7 @@
  * Supports SQLite, PostgreSQL, and MySQL.
  */
 import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
-import { pgTable, text as pgText, real as pgReal, bigint as pgBigint } from 'drizzle-orm/pg-core';
+import { pgTable, text as pgText, doublePrecision as pgDoublePrecision, bigint as pgBigint } from 'drizzle-orm/pg-core';
 import { mysqlTable, varchar as myVarchar, double as myDouble, bigint as myBigint, int as myInt } from 'drizzle-orm/mysql-core';
 
 // SQLite schema
@@ -35,9 +35,10 @@ export const estimatedPositionsSqlite = sqliteTable('estimated_positions', {
 export const estimatedPositionsPostgres = pgTable('estimated_positions', {
   nodeNum: pgBigint('nodeNum', { mode: 'number' }).primaryKey(),
   nodeId: pgText('nodeId').notNull(),
-  latitude: pgReal('latitude').notNull(),
-  longitude: pgReal('longitude').notNull(),
-  uncertaintyKm: pgReal('uncertaintyKm'),
+  // Using doublePrecision (REAL only has ~7 significant digits, causes position rounding)
+  latitude: pgDoublePrecision('latitude').notNull(),
+  longitude: pgDoublePrecision('longitude').notNull(),
+  uncertaintyKm: pgDoublePrecision('uncertaintyKm'),
   observationCount: pgBigint('observationCount', { mode: 'number' }).notNull().default(0),
   updatedAt: pgBigint('updatedAt', { mode: 'number' }).notNull(),
 });

--- a/src/server/meshtasticManager.position-precision.test.ts
+++ b/src/server/meshtasticManager.position-precision.test.ts
@@ -277,6 +277,110 @@ describe('MeshtasticManager - Position Precision Tracking', () => {
     });
   });
 
+  describe('NodeInfo precision guard (issue #3513)', () => {
+    // When a node has a statically-set GPS position, NODEINFO_APP packets carry
+    // a lat/lon that has been grid-snapped by the channel's positionPrecision setting.
+    // The guard prevents these lower-precision coordinates from overwriting a
+    // higher-precision value that was already stored (e.g. from a POSITION_APP packet).
+
+    // Guard logic (mirrors meshtasticManager.ts):
+    // shouldUpdateLatLon =
+    //   existingNode?.latitude == null || existingNode?.longitude == null ||
+    //   !precisionBits || !storedPrecisionBits || precisionBits >= storedPrecisionBits
+
+    function evalGuard(
+      existingLat: number | null | undefined,
+      existingLon: number | null | undefined,
+      storedPrecisionBits: number | undefined,
+      incomingPrecisionBits: number | undefined
+    ): boolean {
+      return (
+        existingLat == null ||
+        existingLon == null ||
+        !incomingPrecisionBits ||
+        !storedPrecisionBits ||
+        incomingPrecisionBits >= storedPrecisionBits
+      );
+    }
+
+    it('blocks lat/lon update when incoming precision is lower than stored', () => {
+      // Core case for issue #3513: node has high-precision GPS, NodeInfo arrives
+      // with positionPrecision-reduced coords.
+      expect(evalGuard(40.12345678, -74.98765432, 32, 14)).toBe(false);
+    });
+
+    it('allows lat/lon update when incoming precision equals stored', () => {
+      expect(evalGuard(40.0, -74.0, 14, 14)).toBe(true);
+    });
+
+    it('allows lat/lon update when incoming precision is higher than stored', () => {
+      expect(evalGuard(40.0, -74.0, 14, 32)).toBe(true);
+    });
+
+    it('allows lat/lon update when existing node has no coordinates (first write)', () => {
+      // Even low precision is accepted if the node has no position at all.
+      expect(evalGuard(null, null, 32, 12)).toBe(true);
+    });
+
+    it('allows lat/lon update when existing latitude is null', () => {
+      expect(evalGuard(null, -74.0, 32, 12)).toBe(true);
+    });
+
+    it('allows lat/lon update when stored precision is 0 (unknown)', () => {
+      // 0 means the existing record has no precision metadata — must accept any update.
+      expect(evalGuard(40.0, -74.0, 0, 14)).toBe(true);
+    });
+
+    it('allows lat/lon update when stored precision is undefined', () => {
+      expect(evalGuard(40.0, -74.0, undefined, 14)).toBe(true);
+    });
+
+    it('allows lat/lon update when incoming precision is 0 (absent/unknown)', () => {
+      // 0 from the wire means "no precision masking / not set"; treat as no info,
+      // so always accept (do not block on an unknown incoming value).
+      expect(evalGuard(40.0, -74.0, 32, 0)).toBe(true);
+    });
+
+    it('does not update positionPrecisionBits when lat/lon is blocked (prevents one-shot guard)', () => {
+      // Critical regression guard: if positionPrecisionBits were written even when
+      // the lat/lon update was blocked, the stored precision would decrease and the
+      // guard would pass on the very next packet (one-shot defect).
+      const existingPrecisionBits = 32;
+      const incomingPrecisionBits = 14;
+      const shouldUpdateLatLon = evalGuard(40.0, -74.0, existingPrecisionBits, incomingPrecisionBits);
+
+      expect(shouldUpdateLatLon).toBe(false);
+
+      // Simulate the conditional write: precision only updated inside shouldUpdateLatLon block
+      let storedAfter = existingPrecisionBits;
+      if (shouldUpdateLatLon && incomingPrecisionBits !== 0) {
+        storedAfter = incomingPrecisionBits;
+      }
+
+      expect(storedAfter).toBe(32); // stored precision unchanged
+    });
+
+    it('updates altitude independently even when lat/lon is blocked', () => {
+      // Altitude is NOT reduced by firmware positionPrecision — firmware only
+      // grid-snaps lat/lon. So altitude from a "low-precision" NodeInfo is valid
+      // and must be written even when the lat/lon update is blocked.
+      const shouldUpdateLatLon = evalGuard(40.0, -74.0, 32, 14);
+      expect(shouldUpdateLatLon).toBe(false);
+
+      const existingAltitude = 5;
+      const incomingAltitude = 25;
+
+      let altitude = existingAltitude;
+      if (shouldUpdateLatLon) {
+        altitude = incomingAltitude; // lat/lon path also writes altitude
+      } else if (incomingAltitude !== undefined && incomingAltitude !== null) {
+        altitude = incomingAltitude; // independent altitude update in else-branch
+      }
+
+      expect(altitude).toBe(25);
+    });
+  });
+
   describe('packetId propagation', () => {
     it('should include packetId in position telemetry from mesh packets', () => {
       const now = Date.now();

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7906,10 +7906,6 @@ class MeshtasticManager implements ISourceManager {
 
         // Validate coordinates before saving
         if (this.isValidPosition(coords.latitude, coords.longitude)) {
-          nodeData.latitude = coords.latitude;
-          nodeData.longitude = coords.longitude;
-          nodeData.altitude = nodeInfo.position.altitude;
-
           // Extract position precision if present in NodeInfo's embedded Position.
           // The protobuf decoder normalizes a missing precision_bits field to 0, so we
           // treat 0 as "absent" here and leave any existing positionPrecisionBits intact.
@@ -7919,13 +7915,39 @@ class MeshtasticManager implements ISourceManager {
           const precisionBits = nodeInfo.position.precisionBits ?? nodeInfo.position.precision_bits ?? undefined;
           const channelIndex = nodeInfo.channel !== undefined ? nodeInfo.channel : 0;
 
+          // Guard against precision downgrade (issue #3513): only update lat/lon from NodeInfo
+          // if the incoming position is not lower precision than what's already stored.
+          // NodeInfo positions may arrive reduced by the sending node's channel positionPrecision
+          // setting (firmware applies grid-snapping before broadcast). POSITION_APP packets are
+          // the authoritative source; NodeInfo should not silently downgrade them.
+          // We only skip when BOTH sides carry explicit non-zero precision info AND the incoming
+          // is clearly lower — if either side is unknown (0/null), we accept the update.
+          const storedPrecisionBits = existingNode?.positionPrecisionBits;
+          const shouldUpdateLatLon =
+            existingNode?.latitude == null || existingNode?.longitude == null || // no existing position
+            !precisionBits ||        // incoming precision unknown (0 = not set), accept
+            !storedPrecisionBits ||  // stored precision unknown, accept
+            precisionBits >= storedPrecisionBits; // incoming is same or better precision
+
+          if (shouldUpdateLatLon) {
+            nodeData.latitude = coords.latitude;
+            nodeData.longitude = coords.longitude;
+            nodeData.altitude = nodeInfo.position.altitude;
+          } else {
+            logger.debug(
+              `🗺️ Skipping NodeInfo position update for ${nodeId}: ` +
+              `incoming precision (${precisionBits} bits) < stored (${storedPrecisionBits} bits)`
+            );
+          }
+
           if (precisionBits !== undefined && precisionBits !== 0) {
             nodeData.positionPrecisionBits = precisionBits;
             nodeData.positionChannel = channelIndex;
             nodeData.positionTimestamp = Date.now();
           }
 
-          // Store position telemetry data to be inserted after node is created
+          // Always record position telemetry for history (regardless of whether the
+          // current-position columns were updated), using the actual incoming coordinates.
           const timestamp = nodeInfo.position.time ? Number(nodeInfo.position.time) * 1000 : Date.now();
           positionTelemetryData = {
             timestamp,

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7933,17 +7933,25 @@ class MeshtasticManager implements ISourceManager {
             nodeData.latitude = coords.latitude;
             nodeData.longitude = coords.longitude;
             nodeData.altitude = nodeInfo.position.altitude;
+            // Only update precision metadata when we actually accept the lat/lon. Updating
+            // positionPrecisionBits even on a rejected downgrade would lower the stored
+            // value and make the guard one-shot — the next packet at the same low precision
+            // would pass the ">= stored" check and overwrite the coordinates.
+            if (precisionBits !== undefined && precisionBits !== 0) {
+              nodeData.positionPrecisionBits = precisionBits;
+              nodeData.positionChannel = channelIndex;
+              nodeData.positionTimestamp = Date.now();
+            }
           } else {
             logger.debug(
-              `🗺️ Skipping NodeInfo position update for ${nodeId}: ` +
+              `🗺️ Skipping NodeInfo lat/lon update for ${nodeId}: ` +
               `incoming precision (${precisionBits} bits) < stored (${storedPrecisionBits} bits)`
             );
-          }
-
-          if (precisionBits !== undefined && precisionBits !== 0) {
-            nodeData.positionPrecisionBits = precisionBits;
-            nodeData.positionChannel = channelIndex;
-            nodeData.positionTimestamp = Date.now();
+            // Altitude is not grid-snapped by the firmware's positionPrecision setting,
+            // so update it independently even when lat/lon is being skipped.
+            if (nodeInfo.position.altitude !== undefined && nodeInfo.position.altitude !== null) {
+              nodeData.altitude = nodeInfo.position.altitude;
+            }
           }
 
           // Always record position telemetry for history (regardless of whether the

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7912,7 +7912,7 @@ class MeshtasticManager implements ISourceManager {
           // We must NOT fall back to the local channel's positionPrecision — that record
           // reflects this MeshMonitor instance's channel config, not the remote node's,
           // and was causing every node's accuracy box to track the local node (issue #3030).
-          const precisionBits = nodeInfo.position.precisionBits ?? nodeInfo.position.precision_bits ?? undefined;
+          const precisionBits = nodeInfo.position.precisionBits ?? nodeInfo.position.precision_bits;
           const channelIndex = nodeInfo.channel !== undefined ? nodeInfo.channel : 0;
 
           // Guard against precision downgrade (issue #3513): only update lat/lon from NodeInfo

--- a/src/server/migrations/091_estimated_positions_double_precision.ts
+++ b/src/server/migrations/091_estimated_positions_double_precision.ts
@@ -1,0 +1,55 @@
+/**
+ * Migration 091: Upgrade estimated_positions lat/lon/uncertaintyKm to DOUBLE PRECISION (PG only).
+ *
+ * The estimated_positions table was created with REAL columns in PostgreSQL, which is
+ * only 32-bit (~7 significant digits). GPS coordinates typically need ~9 significant
+ * digits to avoid visible position jumps. This migration promotes all three numeric
+ * columns to DOUBLE PRECISION (64-bit), matching the existing nodes table schema
+ * and fixing issue #3513.
+ *
+ * SQLite: REAL is already 64-bit in SQLite — no change needed.
+ * MySQL:  Already uses DOUBLE — no change needed.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 091';
+const TABLE = 'estimated_positions';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (_db: Database): void => {
+    // SQLite REAL is 64-bit IEEE 754 — no schema change required.
+    logger.info(`${LABEL} (SQLite): no-op (REAL is already 64-bit in SQLite)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration091Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): upgrading ${TABLE} coordinate columns to DOUBLE PRECISION...`);
+  for (const col of ['latitude', 'longitude', 'uncertaintyKm']) {
+    try {
+      // eslint-disable-next-line no-restricted-syntax -- migrations require raw DDL
+      await client.query(
+        `ALTER TABLE ${TABLE} ALTER COLUMN "${col}" TYPE DOUBLE PRECISION`
+      );
+      logger.info(`${LABEL} (PostgreSQL): ${col} → DOUBLE PRECISION`);
+    } catch (e: any) {
+      // Already DOUBLE PRECISION — safe to ignore
+      if (e.message?.includes('cannot be cast') || e.message?.includes('already')) {
+        logger.debug(`${LABEL} (PostgreSQL): ${col} already DOUBLE PRECISION, skipping`);
+      } else {
+        throw e;
+      }
+    }
+  }
+}
+
+// ============ MySQL ============
+
+export async function runMigration091Mysql(_pool: any): Promise<void> {
+  // MySQL already uses DOUBLE for these columns — no change needed.
+  logger.info(`${LABEL} (MySQL): no-op (columns are already DOUBLE)`);
+}

--- a/src/server/migrations/091_estimated_positions_double_precision.ts
+++ b/src/server/migrations/091_estimated_positions_double_precision.ts
@@ -30,20 +30,23 @@ export const migration = {
 export async function runMigration091Postgres(client: any): Promise<void> {
   logger.info(`${LABEL} (PostgreSQL): upgrading ${TABLE} coordinate columns to DOUBLE PRECISION...`);
   for (const col of ['latitude', 'longitude', 'uncertaintyKm']) {
-    try {
-      // eslint-disable-next-line no-restricted-syntax -- migrations require raw DDL
-      await client.query(
-        `ALTER TABLE ${TABLE} ALTER COLUMN "${col}" TYPE DOUBLE PRECISION`
-      );
-      logger.info(`${LABEL} (PostgreSQL): ${col} → DOUBLE PRECISION`);
-    } catch (e: any) {
-      // Already DOUBLE PRECISION — safe to ignore
-      if (e.message?.includes('cannot be cast') || e.message?.includes('already')) {
-        logger.debug(`${LABEL} (PostgreSQL): ${col} already DOUBLE PRECISION, skipping`);
-      } else {
-        throw e;
-      }
+    // Check information_schema first so the ALTER is idempotent without relying on
+    // brittle error-message string matching (PG doesn't error on REAL→REAL no-ops anyway,
+    // but being explicit avoids any edge-case surprises).
+    // eslint-disable-next-line no-restricted-syntax -- migrations require raw DDL
+    const { rows } = await client.query(
+      `SELECT data_type FROM information_schema.columns
+       WHERE table_name = $1 AND column_name = $2`,
+      [TABLE, col]
+    );
+    const currentType: string | undefined = rows[0]?.data_type?.toLowerCase();
+    if (currentType === 'double precision') {
+      logger.debug(`${LABEL} (PostgreSQL): ${col} already DOUBLE PRECISION, skipping`);
+      continue;
     }
+    // eslint-disable-next-line no-restricted-syntax -- migrations require raw DDL
+    await client.query(`ALTER TABLE ${TABLE} ALTER COLUMN "${col}" TYPE DOUBLE PRECISION`);
+    logger.info(`${LABEL} (PostgreSQL): ${col} upgraded from ${currentType ?? '?'} → DOUBLE PRECISION`);
   }
 }
 


### PR DESCRIPTION
## Summary

When a `NODEINFO_APP` packet arrives over a direct TCP connection, MeshMonitor was unconditionally overwriting the stored `latitude`/`longitude` with whatever position was embedded — even when that position had *lower* precision than what was already stored. Meshtastic firmware applies the channel's `positionPrecision` setting to positions embedded in NodeInfo broadcasts, grid-snapping coordinates before broadcast. Every periodic NodeInfo from a node with reduced positionPrecision silently degraded the stored coordinates. The MQTT position monitor referenced in the issue only captures standalone `POSITION_APP` packets (not embedded NodeInfo positions), which is why it showed accurate coordinates while MeshMonitor showed rounded ones.

A secondary issue: the `estimated_positions` table in PostgreSQL used `REAL` columns (32-bit, ~7 significant digits) instead of `DOUBLE PRECISION` (64-bit), causing visible coordinate rounding for estimated-position nodes — inconsistent with the `nodes` table which already uses `DOUBLE PRECISION`.

## Changes

- **`src/server/meshtasticManager.ts`**: Add a precision downgrade guard in the NodeInfo position handler. Before writing `latitude`/`longitude`, compare incoming `precisionBits` against the stored `positionPrecisionBits`. Skip the lat/lon update only when both sides carry explicit non-zero precision info AND the incoming is clearly lower. Position telemetry history rows are still written unconditionally (full historical record preserved).
- **`src/db/schema/estimatedPositions.ts`**: Change PostgreSQL `latitude`, `longitude`, and `uncertaintyKm` columns from `pgReal` to `pgDoublePrecision`.
- **`src/server/migrations/091_estimated_positions_double_precision.ts`**: Migration 091 — ALTERs the three columns on PostgreSQL deployments; no-op for SQLite (REAL is already 64-bit) and MySQL (already DOUBLE).
- **`src/db/migrations.ts`** / **`src/db/migrations.test.ts`**: Register migration 091, update count/name assertions.

## Issues Resolved

Fixes #3513

## Documentation Updates

No documentation changes needed — this is an internal bug fix with no user-facing behavior changes beyond correcting the displayed positions.

## Testing

- [x] Unit tests pass (6522 passed — 3 pre-existing failures in protobuf encode tests unrelated to this change, present before this commit)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Migration count test updated and passes (91 migrations, correct last-migration name)
- [ ] Verify: configure a channel's `positionPrecision` to a low value (e.g. 14 bits) on a Meshtastic device and confirm MeshMonitor no longer replaces the stored accurate coordinates after the next NodeInfo broadcast
- [ ] Verify: for a node with no existing stored position, NodeInfo with reduced precision still seeds the initial position (guard only blocks downgrades, not initial seeding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013jNq9fvemyLZVB1fqv3YGb)_