### PR TITLE
fix(autoping): match acks by destination node + close duplicate-send race

### DIFF
--- a/src/server/meshtasticManager.autoPingAck.test.ts
+++ b/src/server/meshtasticManager.autoPingAck.test.ts
@@ -118,6 +118,16 @@ describe('MeshtasticManager - auto-ping ACK matching (request_id + from)', () =>
     expect(s.pendingTimeout).toBeNull();
   });
 
+  it('clears the pending ack timeout on a NAK too', () => {
+    const fakeTimer = setTimeout(() => {}, 60000);
+    const s = makeSession({ pendingTimeout: fakeTimer });
+    const clearSpy = vi.spyOn(global, 'clearTimeout');
+    manager.handleAutoPingResponse(REQ_ID, LOCAL, 34 /* MAX_RETRANSMIT */);
+    expect(clearSpy).toHaveBeenCalledWith(fakeTimer);
+    expect(s.pendingTimeout).toBeNull();
+    expect(s.results[0].status).toBe('nak');
+  });
+
   it('does not match a different request_id', () => {
     const s = makeSession();
     manager.handleAutoPingResponse(9999, REQUESTER, 0);

--- a/src/server/meshtasticManager.autoPingAck.test.ts
+++ b/src/server/meshtasticManager.autoPingAck.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Regression tests for the auto-ping ACK-matching + send-race fixes.
+ *
+ * These drive the REAL manager methods (handleAutoPingResponse / sendNextAutoPing),
+ * unlike meshtasticManager.auto-ping.test.ts which re-implements the logic inline.
+ *
+ * Bug 1: a want_ack DM yields two Routing packets with the SAME request_id, both
+ * error_reason=NONE, differing only by `from` — an implicit transmit ACK from our
+ * OWN local node (first) and the real end-to-end ACK from the destination (second).
+ * The matcher used to latch the transmit ACK and report a false success.
+ *
+ * Bug 2: sendNextAutoPing checked `pendingRequestId` then awaited the send before
+ * setting it, so a second interval tick during the send could launch a duplicate.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetSettingForSource = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    settings: { getSettingForSource: mockGetSettingForSource, getSetting: vi.fn() },
+    telemetry: { insertTelemetry: vi.fn() },
+    nodes: { upsertNode: vi.fn().mockResolvedValue(undefined), getAllNodes: vi.fn().mockResolvedValue([]), getNode: vi.fn().mockResolvedValue(null) },
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const LOCAL = 0x0a0a0a0a;     // our local node
+const REQUESTER = 0x11111111; // the node that asked for pings (= the DM destination)
+const RELAY = 0x99999999;     // some intermediate node
+const REQ_ID = 4242;          // pending sent packet id
+
+describe('MeshtasticManager - auto-ping ACK matching (request_id + from)', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module = await import('./meshtasticManager.js');
+    manager = module.default;
+    manager.localNodeInfo = { nodeNum: LOCAL };
+    (manager as any).autoPingSessions.clear();
+    vi.spyOn(manager as any, 'emitAutoPingUpdate').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    (manager as any).autoPingSessions.clear();
+    vi.restoreAllMocks();
+  });
+
+  function makeSession(over: Record<string, unknown> = {}) {
+    const session = {
+      requestedBy: REQUESTER, channel: 0, totalPings: 3,
+      completedPings: 0, successfulPings: 0, failedPings: 0,
+      intervalMs: 30000, timeoutMs: 60000, timer: null, sending: false,
+      pendingRequestId: REQ_ID, pendingTimeout: null,
+      startTime: Date.now(), lastPingSentAt: Date.now(), results: [] as any[],
+      ...over,
+    };
+    (manager as any).autoPingSessions.set(session.requestedBy, session);
+    return session;
+  }
+
+  it('ignores the local transmit ACK (from == our node) and keeps the ping pending', () => {
+    const s = makeSession();
+    // error_reason=NONE from our OWN node = "transmitted to mesh", not delivery.
+    manager.handleAutoPingResponse(REQ_ID, LOCAL, 0);
+    expect(s.completedPings).toBe(0);
+    expect(s.pendingRequestId).toBe(REQ_ID); // still waiting for the real ack
+    expect(s.results).toHaveLength(0);
+  });
+
+  it('ignores a relay NONE (from an intermediate node, not the destination)', () => {
+    const s = makeSession();
+    manager.handleAutoPingResponse(REQ_ID, RELAY, 0);
+    expect(s.completedPings).toBe(0);
+    expect(s.pendingRequestId).toBe(REQ_ID);
+  });
+
+  it('records an ACK only on the destination end-to-end ack (from == requester)', () => {
+    const s = makeSession();
+    manager.handleAutoPingResponse(REQ_ID, REQUESTER, 0);
+    expect(s.completedPings).toBe(1);
+    expect(s.successfulPings).toBe(1);
+    expect(s.failedPings).toBe(0);
+    expect(s.pendingRequestId).toBeNull();
+    expect(s.results[0].status).toBe('ack');
+  });
+
+  it('the transmit ACK then the destination ACK resolves exactly one successful ping', () => {
+    const s = makeSession();
+    manager.handleAutoPingResponse(REQ_ID, LOCAL, 0);     // self-transmit (ignored)
+    manager.handleAutoPingResponse(REQ_ID, REQUESTER, 0); // real ack (counts)
+    expect(s.completedPings).toBe(1);
+    expect(s.successfulPings).toBe(1);
+    expect(s.results).toHaveLength(1);
+  });
+
+  it('records a NAK on a non-zero error_reason (e.g. MAX_RETRANSMIT delivery failure)', () => {
+    const s = makeSession();
+    manager.handleAutoPingResponse(REQ_ID, LOCAL, 34 /* MAX_RETRANSMIT */);
+    expect(s.completedPings).toBe(1);
+    expect(s.failedPings).toBe(1);
+    expect(s.successfulPings).toBe(0);
+    expect(s.pendingRequestId).toBeNull();
+    expect(s.results[0].status).toBe('nak');
+  });
+
+  it('clears the pending ack timeout when a ping resolves', () => {
+    const fakeTimer = setTimeout(() => {}, 60000);
+    const s = makeSession({ pendingTimeout: fakeTimer });
+    const clearSpy = vi.spyOn(global, 'clearTimeout');
+    manager.handleAutoPingResponse(REQ_ID, REQUESTER, 0);
+    expect(clearSpy).toHaveBeenCalledWith(fakeTimer);
+    expect(s.pendingTimeout).toBeNull();
+  });
+
+  it('does not match a different request_id', () => {
+    const s = makeSession();
+    manager.handleAutoPingResponse(9999, REQUESTER, 0);
+    expect(s.completedPings).toBe(0);
+    expect(s.pendingRequestId).toBe(REQ_ID);
+  });
+});
+
+describe('MeshtasticManager - auto-ping send race', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module = await import('./meshtasticManager.js');
+    manager = module.default;
+    manager.localNodeInfo = { nodeNum: LOCAL };
+    (manager as any).autoPingSessions.clear();
+    (manager as any).messageQueue = { recordExternalSend: vi.fn(), handleAck: vi.fn() };
+    vi.spyOn(manager as any, 'emitAutoPingUpdate').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    (manager as any).autoPingSessions.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('does not launch a duplicate ping when a tick fires during an in-flight send', async () => {
+    const session = {
+      requestedBy: REQUESTER, channel: 0, totalPings: 3,
+      completedPings: 0, successfulPings: 0, failedPings: 0,
+      intervalMs: 30000, timeoutMs: 60000, timer: null, sending: false,
+      pendingRequestId: null as number | null, pendingTimeout: null as any,
+      startTime: Date.now(), lastPingSentAt: 0, results: [] as any[],
+    };
+    (manager as any).autoPingSessions.set(REQUESTER, session);
+
+    // Make the send hang so a second tick lands mid-send.
+    let resolveSend: (id: number) => void = () => {};
+    const sendSpy = vi.spyOn(manager, 'sendTextMessage')
+      .mockImplementation(() => new Promise<number>((r) => { resolveSend = r; }));
+
+    const p1 = (manager as any).sendNextAutoPing(session); // starts send, sets sending=true
+    (manager as any).sendNextAutoPing(session);            // second tick — must be guarded
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+
+    resolveSend(REQ_ID);
+    await p1;
+
+    expect(session.pendingRequestId).toBe(REQ_ID);
+    expect(session.sending).toBe(false);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+
+    if (session.pendingTimeout) clearTimeout(session.pendingTimeout); // avoid leaking the 60s timer
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -410,7 +410,9 @@ interface AutoPingSession {
   successfulPings: number;
   failedPings: number;
   intervalMs: number;
+  timeoutMs: number;        // per-ping ack timeout, resolved once at session start
   timer: ReturnType<typeof setInterval> | null;
+  sending: boolean;         // true while a send is in-flight (closes the check-then-act race)
   pendingRequestId: number | null;
   pendingTimeout: ReturnType<typeof setTimeout> | null;
   startTime: number;
@@ -7211,13 +7213,14 @@ class MeshtasticManager implements ISourceManager {
         }
       }
 
-      // Check if this routing update is for an auto-ping session
+      // Check if this routing update is for an auto-ping session. Pass the
+      // emitting node + error_reason through so the handler can distinguish a
+      // real end-to-end ACK (from the destination) from the local transmit ACK
+      // and from a delivery-failure NAK — see handleAutoPingResponse.
       if (requestId) {
-        if (errorReason === 0) {
-          this.handleAutoPingResponse(requestId, 'ack');
-        } else {
-          this.handleAutoPingResponse(requestId, 'nak');
-        }
+        // errorReason is 0 (NONE) on success; non-zero — or absent — is a failure.
+        const reason = typeof errorReason === 'number' ? errorReason : 1;
+        this.handleAutoPingResponse(requestId, fromNum, reason);
       }
 
       // Handle successful ACKs (error_reason = 0 means success)
@@ -9295,6 +9298,10 @@ class MeshtasticManager implements ISourceManager {
       const count = parseInt(pingStartMatch[1], 10);
       const maxPings = parseInt((await databaseService.settings.getSettingForSource(this.sourceId, 'autoPingMaxPings')) || '20', 10);
       const intervalSeconds = parseInt((await databaseService.settings.getSettingForSource(this.sourceId, 'autoPingIntervalSeconds')) || '30', 10);
+      // Resolve the ack timeout once here rather than per-ping: it lets us arm
+      // pendingRequestId + pendingTimeout synchronously after each send (no await
+      // between), closing the window where a fast response could be missed.
+      const timeoutSeconds = parseInt((await databaseService.settings.getSettingForSource(this.sourceId, 'autoPingTimeoutSeconds')) || '60', 10);
 
       // Validate count
       if (count <= 0) {
@@ -9321,7 +9328,9 @@ class MeshtasticManager implements ISourceManager {
         successfulPings: 0,
         failedPings: 0,
         intervalMs: intervalSeconds * 1000,
+        timeoutMs: timeoutSeconds * 1000,
         timer: null,
+        sending: false,
         pendingRequestId: null,
         pendingTimeout: null,
         startTime: Date.now(),
@@ -9371,10 +9380,15 @@ class MeshtasticManager implements ISourceManager {
       return;
     }
 
-    // Don't send another ping if one is still pending
-    if (session.pendingRequestId !== null) {
+    // Don't send another ping if one is still pending OR a send is in-flight.
+    // `sending` is set synchronously below before the first await, so a second
+    // interval tick that fires during sendTextMessage() can't slip past this
+    // guard and launch a duplicate ping (the check-then-act race that produced
+    // orphaned pings whose acks never matched).
+    if (session.pendingRequestId !== null || session.sending) {
       return;
     }
+    session.sending = true;
 
     try {
       const pingNum = session.completedPings + 1;
@@ -9382,16 +9396,16 @@ class MeshtasticManager implements ISourceManager {
 
       const requestId = await this.sendTextMessage(pingMessage, 0, session.requestedBy);
       this.messageQueue.recordExternalSend();
+      // Arm pendingRequestId and the ack timeout synchronously (timeoutMs was
+      // resolved at session start) so a fast response can't arrive between the
+      // two and leave an orphaned timeout that double-counts the ping.
       session.pendingRequestId = requestId;
       session.lastPingSentAt = Date.now();
-
-      logger.debug(`📡 Auto-ping ${pingNum}/${session.totalPings} sent to !${session.requestedBy.toString(16).padStart(8, '0')} (requestId: ${requestId})`);
-
-      // Set timeout for this ping
-      const timeoutSeconds = parseInt((await databaseService.settings.getSettingForSource(this.sourceId, 'autoPingTimeoutSeconds')) || '60', 10);
       session.pendingTimeout = setTimeout(() => {
         this.handleAutoPingTimeout(session);
-      }, timeoutSeconds * 1000);
+      }, session.timeoutMs);
+
+      logger.debug(`📡 Auto-ping ${pingNum}/${session.totalPings} sent to !${session.requestedBy.toString(16).padStart(8, '0')} (requestId: ${requestId})`);
     } catch (error) {
       logger.error(`❌ Auto-ping failed to send to !${session.requestedBy.toString(16).padStart(8, '0')}:`, error);
       // Record as failed
@@ -9405,45 +9419,78 @@ class MeshtasticManager implements ISourceManager {
       await this.emitAutoPingUpdate(session, 'ping_result');
 
       // Session completion is handled by the next interval tick
+    } finally {
+      session.sending = false;
     }
   }
 
   /**
-   * Handle an ACK or NAK response for a pending auto-ping
+   * Handle a Routing (ACK/NAK) packet for a pending auto-ping.
+   *
+   * A want_ack DM produces TWO Routing packets with the SAME request_id, both
+   * with error_reason=NONE, differing only by `from` (confirmed against firmware):
+   *   1. an implicit transmit ACK from OUR OWN local node (it overheard the
+   *      rebroadcast) — arrives first, only proves the packet entered the mesh;
+   *   2. the real end-to-end ACK from the DESTINATION — arrives second, or never.
+   * A genuine delivery failure is a NAK (non-zero error_reason, e.g.
+   * MAX_RETRANSMIT) emitted by the originating (local) node.
+   *
+   * Matching on request_id alone latched the transmit ACK first and reported a
+   * false success with a bogus (transmit-only) duration, dropping the real ACK
+   * and any later failure NAK. So we now resolve a ping ONLY on:
+   *   - error_reason != 0  → NAK (delivery failed), or
+   *   - error_reason == 0 AND from == the destination (the requester) → real ACK.
+   * Any other request_id match (error_reason 0 from our local node or a relay)
+   * is a transmit/relay confirmation and is ignored so the session keeps waiting.
+   *
+   * @param requestId   the original sent packet id the Routing packet references
+   * @param fromNum     the node that emitted this Routing packet
+   * @param errorReason Routing.Error value (0 = NONE/success)
    */
-  handleAutoPingResponse(requestId: number, status: 'ack' | 'nak'): void {
+  handleAutoPingResponse(requestId: number, fromNum: number, errorReason: number): void {
     // Find session with matching pendingRequestId
     for (const [nodeNum, session] of this.autoPingSessions) {
-      if (session.pendingRequestId === requestId) {
-        // Clear the timeout
-        if (session.pendingTimeout) {
-          clearTimeout(session.pendingTimeout);
-          session.pendingTimeout = null;
-        }
+      if (session.pendingRequestId !== requestId) continue;
 
-        const durationMs = Date.now() - session.lastPingSentAt;
-        session.results.push({
-          pingNum: session.completedPings + 1,
-          status,
-          durationMs,
-          sentAt: session.lastPingSentAt,
-        });
+      const isFailure = errorReason !== 0;
+      const isDestinationAck = errorReason === 0 && fromNum === session.requestedBy;
 
-        session.completedPings++;
-        if (status === 'ack') {
-          session.successfulPings++;
-        } else {
-          session.failedPings++;
-        }
-        session.pendingRequestId = null;
-
-        logger.info(`📡 Auto-ping ${session.completedPings}/${session.totalPings} ${status.toUpperCase()} from !${nodeNum.toString(16).padStart(8, '0')} (${durationMs}ms)`);
-
-        this.emitAutoPingUpdate(session, 'ping_result').catch(err => logger.error('Error emitting auto-ping update:', err));
-
-        // Session completion is handled by the next interval tick in sendNextAutoPing
+      // Not a terminal signal for this ping (transmit-only self-ack or a relay's
+      // NONE) — leave the ping pending so the real ack / failure / timeout wins.
+      if (!isFailure && !isDestinationAck) {
         return;
       }
+
+      const status: 'ack' | 'nak' = isDestinationAck ? 'ack' : 'nak';
+
+      // Clear the timeout
+      if (session.pendingTimeout) {
+        clearTimeout(session.pendingTimeout);
+        session.pendingTimeout = null;
+      }
+
+      const durationMs = Date.now() - session.lastPingSentAt;
+      session.results.push({
+        pingNum: session.completedPings + 1,
+        status,
+        durationMs,
+        sentAt: session.lastPingSentAt,
+      });
+
+      session.completedPings++;
+      if (status === 'ack') {
+        session.successfulPings++;
+      } else {
+        session.failedPings++;
+      }
+      session.pendingRequestId = null;
+
+      logger.info(`📡 Auto-ping ${session.completedPings}/${session.totalPings} ${status.toUpperCase()} from !${nodeNum.toString(16).padStart(8, '0')} (${durationMs}ms)`);
+
+      this.emitAutoPingUpdate(session, 'ping_result').catch(err => logger.error('Error emitting auto-ping update:', err));
+
+      // Session completion is handled by the next interval tick in sendNextAutoPing
+      return;
     }
   }
 


### PR DESCRIPTION
## Summary

Users reported auto-ping responses arriving **out of order or failing** even when the target node was reachable. Investigation found two root causes (source-awareness itself was already correct — sessions, settings, and response handling are all per-source).

### Bug 1 — local *transmit* ACK misread as a delivery success
A `want_ack` DM produces **two** Routing packets with the **same `request_id`**, both `error_reason=NONE`, differing only by `from` (confirmed against current firmware — `ReliableRouter` implicit-ack vs destination ack):
1. an implicit **transmit ACK from our own local node** — arrives first, only means the packet entered the mesh;
2. the real **end-to-end ACK from the destination** — arrives second, or never.

A genuine delivery failure is a **non-zero `error_reason` NAK** (e.g. `MAX_RETRANSMIT`) from the local node.

`handleAutoPingResponse` matched on `request_id` **alone**, so it latched the transmit ACK, recorded a false success with a transmit-only duration, and cleared the pending slot — **dropping the real ACK and any later failure NAK**. Behavior therefore varied by topology (zero-hop direct often worked; multi-hop reported false successes), which matches "mostly works but many fail / out of order."

**Fix:** resolve a ping only on `error_reason != 0` (NAK) **or** `error_reason == 0 AND from == the destination` (real ACK). Transmit/relay confirmations (`error_reason 0` not from the destination) are ignored so the session keeps waiting for the real signal/timeout.

### Bug 2 — check-then-act send race
`sendNextAutoPing` checked `pendingRequestId`, then **awaited the send before setting it**, and the `setInterval` callback isn't awaited. A tick firing during a slow send (queue/airtime backpressure, or a short user interval) slipped past the guard and launched a **duplicate ping** whose ack never matched → recorded as a timeout, clobbered timers.

**Fix:** a synchronous `sending` guard set before the first await; and arm `pendingRequestId` + the ack timeout **synchronously** after the send (`timeoutMs` resolved once at session start) so a fast response can't leave an orphaned timeout.

## Tests

New `meshtasticManager.autoPingAck.test.ts` drives the **real** methods (the existing `auto-ping.test.ts` only re-implements logic inline):
- self-transmit ACK and relay NONE are ignored; destination ACK counts exactly once
- non-zero `error_reason` ⇒ NAK; pending timeout cleared on resolve
- the duplicate-send guard (a second tick during an in-flight send sends nothing)

Full suite: **6631 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)