### PR TITLE
refactor(server): extract device & system route groups (Refs #3502)

### DIFF
--- a/src/server/routes/deviceRoutes.test.ts
+++ b/src/server/routes/deviceRoutes.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const mockManager = vi.hoisted(() => ({
+  getDeviceConfig: vi.fn(),
+  getLocalNodeInfo: vi.fn(),
+  rebootDevice: vi.fn(),
+  purgeNodeDb: vi.fn(),
+}));
+
+vi.mock('../utils/resolveSourceManager.js', () => ({
+  resolveSourceManager: vi.fn().mockReturnValue(mockManager),
+}));
+
+const mockDeviceBackupService = vi.hoisted(() => ({
+  generateBackup: vi.fn(),
+}));
+vi.mock('../services/deviceBackupService.js', () => ({
+  deviceBackupService: mockDeviceBackupService,
+}));
+
+const mockBackupFileService = vi.hoisted(() => ({
+  saveBackup: vi.fn(),
+}));
+vi.mock('../services/backupFileService.js', () => ({
+  backupFileService: mockBackupFileService,
+}));
+
+const mockDb = vi.hoisted(() => ({
+  purgeAllNodesAsync: vi.fn(),
+}));
+vi.mock('../../services/database.js', () => ({
+  default: mockDb,
+}));
+
+vi.mock('../auth/authMiddleware.js', () => ({
+  requirePermission: () => (req: any, _res: any, next: any) => { req.user = { id: 1, isAdmin: true }; next(); },
+}));
+
+import deviceRoutes from './deviceRoutes.js';
+
+const app = express();
+app.use(express.json());
+app.use('/', deviceRoutes);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /device-config', () => {
+  it('returns the device config when available', async () => {
+    mockManager.getDeviceConfig.mockResolvedValue({ region: 'US' });
+    const res = await request(app).get('/device-config?sourceId=src-1');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ region: 'US' });
+  });
+
+  it('returns 503 when no config is available', async () => {
+    mockManager.getDeviceConfig.mockResolvedValue(null);
+    const res = await request(app).get('/device-config');
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('Unable to retrieve device configuration');
+  });
+
+  it('returns 500 on error', async () => {
+    mockManager.getDeviceConfig.mockRejectedValue(new Error('boom'));
+    const res = await request(app).get('/device-config');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to fetch device configuration');
+  });
+});
+
+describe('GET /device/backup', () => {
+  it('downloads YAML without saving by default', async () => {
+    mockDeviceBackupService.generateBackup.mockResolvedValue('yaml-content');
+    mockManager.getLocalNodeInfo.mockReturnValue({ nodeId: '!abcd1234' });
+    const res = await request(app).get('/device/backup');
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('yaml-content');
+    expect(res.headers['content-disposition']).toContain('abcd1234');
+    expect(mockBackupFileService.saveBackup).not.toHaveBeenCalled();
+  });
+
+  it('saves to disk when save=true', async () => {
+    mockDeviceBackupService.generateBackup.mockResolvedValue('yaml-content');
+    mockManager.getLocalNodeInfo.mockReturnValue({ nodeId: '!abcd1234' });
+    mockBackupFileService.saveBackup.mockResolvedValue('saved.yaml');
+    const res = await request(app).get('/device/backup?save=true');
+    expect(res.status).toBe(200);
+    expect(mockBackupFileService.saveBackup).toHaveBeenCalledWith('yaml-content', 'manual', '!abcd1234');
+    expect(res.headers['content-disposition']).toContain('saved.yaml');
+  });
+
+  it('returns 500 on backup failure', async () => {
+    mockDeviceBackupService.generateBackup.mockRejectedValue(new Error('fail'));
+    const res = await request(app).get('/device/backup');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to generate device backup');
+  });
+});
+
+describe('POST /device/reboot', () => {
+  it('reboots with provided seconds', async () => {
+    mockManager.rebootDevice.mockResolvedValue(undefined);
+    const res = await request(app).post('/device/reboot').send({ seconds: 30 });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockManager.rebootDevice).toHaveBeenCalledWith(30);
+  });
+
+  it('defaults to 10 seconds', async () => {
+    mockManager.rebootDevice.mockResolvedValue(undefined);
+    const res = await request(app).post('/device/reboot').send({});
+    expect(res.status).toBe(200);
+    expect(mockManager.rebootDevice).toHaveBeenCalledWith(10);
+  });
+
+  it('returns 500 on failure', async () => {
+    mockManager.rebootDevice.mockRejectedValue(new Error('fail'));
+    const res = await request(app).post('/device/reboot').send({});
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to reboot device');
+  });
+});
+
+describe('POST /device/purge-nodedb', () => {
+  it('purges device and local db scoped to source', async () => {
+    mockManager.purgeNodeDb.mockResolvedValue(undefined);
+    mockDb.purgeAllNodesAsync.mockResolvedValue(undefined);
+    const res = await request(app).post('/device/purge-nodedb').send({ sourceId: 'src-1' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockManager.purgeNodeDb).toHaveBeenCalledWith(0);
+    expect(mockDb.purgeAllNodesAsync).toHaveBeenCalledWith('src-1');
+  });
+
+  it('returns 500 on failure', async () => {
+    mockManager.purgeNodeDb.mockRejectedValue(new Error('fail'));
+    const res = await request(app).post('/device/purge-nodedb').send({});
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to purge node database');
+  });
+});

--- a/src/server/routes/deviceRoutes.ts
+++ b/src/server/routes/deviceRoutes.ts
@@ -1,0 +1,129 @@
+/**
+ * Device Routes
+ *
+ * GET  /device-config        — fetch the device configuration
+ * GET  /device/backup        — export device config as YAML (optionally save to disk)
+ * POST /device/reboot        — reboot the device
+ * POST /device/purge-nodedb  — purge the device + local node database
+ *
+ * Extracted from server.ts. All handlers resolve the per-source manager via
+ * resolveSourceManager and delegate to importable services, so the module has
+ * no server.ts-local coupling.
+ */
+
+import { Router, Request, Response } from 'express';
+import { requirePermission } from '../auth/authMiddleware.js';
+import databaseService from '../../services/database.js';
+import { logger } from '../../utils/logger.js';
+import { resolveSourceManager } from '../utils/resolveSourceManager.js';
+import { deviceBackupService } from '../services/deviceBackupService.js';
+import { backupFileService } from '../services/backupFileService.js';
+
+const router: Router = Router();
+
+router.get('/device-config', requirePermission('configuration', 'read'), async (req: Request, res: Response) => {
+  try {
+    const dcSourceId = req.query.sourceId as string | undefined;
+    const dcManager = resolveSourceManager(dcSourceId);
+    const config = await dcManager.getDeviceConfig();
+    if (config) {
+      res.json(config);
+    } else {
+      res.status(503).json({ error: 'Unable to retrieve device configuration' });
+    }
+  } catch (error) {
+    logger.error('Error fetching device config:', error);
+    res.status(500).json({ error: 'Failed to fetch device configuration' });
+  }
+});
+
+// Export complete device configuration as YAML backup
+// Compatible with Meshtastic CLI --export-config format
+// Query param ?save=true will save to disk instead of just downloading
+router.get('/device/backup', requirePermission('configuration', 'read'), async (req: Request, res: Response) => {
+  try {
+    const saveToFile = req.query.save === 'true';
+    const backupSourceId = req.query.sourceId as string | undefined;
+    const backupManager = resolveSourceManager(backupSourceId);
+    logger.info(`📦 Device backup requested (save=${saveToFile})...`);
+
+    // Generate YAML backup using the device backup service
+    const yamlBackup = await deviceBackupService.generateBackup(backupManager);
+
+    // Get node ID for filename
+    const localNodeInfo = backupManager.getLocalNodeInfo();
+    const nodeId = localNodeInfo?.nodeId || '!unknown';
+
+    if (saveToFile) {
+      // Save to disk with new filename format
+      const filename = await backupFileService.saveBackup(yamlBackup, 'manual', nodeId);
+
+      // Also send the file for download
+      res.setHeader('Content-Type', 'application/x-yaml');
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      res.send(yamlBackup);
+
+      logger.info(`✅ Device backup saved and downloaded: ${filename}`);
+    } else {
+      // Just download, don't save - generate filename for display
+      const nodeIdNumber = nodeId.startsWith('!') ? nodeId.substring(1) : nodeId;
+      const now = new Date();
+      const date = now.toISOString().split('T')[0];
+      const time = now.toTimeString().split(' ')[0].replace(/:/g, '-');
+      const filename = `${nodeIdNumber}-${date}-${time}.yaml`;
+
+      res.setHeader('Content-Type', 'application/x-yaml');
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      res.send(yamlBackup);
+
+      logger.info(`✅ Device backup generated: ${filename}`);
+    }
+  } catch (error) {
+    logger.error('❌ Error generating device backup:', error);
+    res.status(500).json({
+      error: 'Failed to generate device backup',
+      details: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+router.post('/device/reboot', requirePermission('configuration', 'write'), async (req: Request, res: Response) => {
+  try {
+    const { seconds: rebootSeconds, sourceId: rebootSourceId } = req.body || {};
+    const seconds = rebootSeconds || 10;
+    const rebootManager = resolveSourceManager(rebootSourceId);
+    await rebootManager.rebootDevice(seconds);
+    res.json({ success: true, message: `Device will reboot in ${seconds} seconds` });
+  } catch (error) {
+    logger.error('Error rebooting device:', error);
+    res.status(500).json({ error: 'Failed to reboot device' });
+  }
+});
+
+router.post('/device/purge-nodedb', requirePermission('configuration', 'write'), async (req: Request, res: Response) => {
+  try {
+    const { seconds: purgeSeconds, sourceId: purgeSourceId } = req.body || {};
+    const seconds = purgeSeconds || 0;
+    const purgeManager = resolveSourceManager(purgeSourceId);
+
+    // Purge the device's node database
+    await purgeManager.purgeNodeDb(seconds);
+
+    // Also purge the local database (scoped to the source we just told the
+    // device to wipe — purging globally on a per-source admin command would
+    // wipe siblings)
+    logger.info('🗑️ Purging local node database');
+    await databaseService.purgeAllNodesAsync(purgeSourceId);
+    logger.info('✅ Local node database purged successfully');
+
+    res.json({
+      success: true,
+      message: `Node database purged (both device and local)${seconds > 0 ? ` in ${seconds} seconds` : ''}`,
+    });
+  } catch (error) {
+    logger.error('Error purging node database:', error);
+    res.status(500).json({ error: 'Failed to purge node database' });
+  }
+});
+
+export default router;

--- a/src/server/routes/systemRoutes.test.ts
+++ b/src/server/routes/systemRoutes.test.ts
@@ -1,186 +1,177 @@
 /**
  * System Routes Tests
  *
- * Tests system management functionality including Docker detection and restart
+ * Tests /system/status, /status, /version/check and /system/restart, plus the
+ * gracefulShutdown callback injection.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi, Mock } from 'vitest';
-import fs from 'fs';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
 
-describe('System Management', () => {
-  // Mock fs.existsSync for Docker detection
-  const originalExistsSync = fs.existsSync;
-  let mockExistsSync: Mock;
+const mockManager = vi.hoisted(() => ({
+  getConnectionStatus: vi.fn(),
+  getLocalNodeInfo: vi.fn(),
+}));
+vi.mock('../meshtasticManager.js', () => ({
+  default: mockManager,
+}));
 
-  beforeEach(() => {
-    mockExistsSync = vi.fn();
-    (fs as any).existsSync = mockExistsSync;
+const mockDb = vi.hoisted(() => ({
+  getDatabaseType: vi.fn().mockReturnValue('sqlite'),
+  getDatabaseVersion: vi.fn().mockResolvedValue('3.45.0'),
+  nodes: { getNodeCount: vi.fn().mockResolvedValue(5) },
+  messages: { getMessageCount: vi.fn().mockResolvedValue(10) },
+  channels: { getChannelCount: vi.fn().mockResolvedValue(3) },
+  settings: { getSetting: vi.fn() },
+  auditLogAsync: vi.fn(),
+}));
+vi.mock('../../services/database.js', () => ({
+  default: mockDb,
+}));
+
+const mockUpgradeService = vi.hoisted(() => ({
+  isEnabled: vi.fn().mockReturnValue(false),
+  isUpgradeInProgress: vi.fn(),
+  triggerUpgrade: vi.fn(),
+}));
+vi.mock('../services/upgradeService.js', () => ({
+  upgradeService: mockUpgradeService,
+}));
+
+const mockEnv = vi.hoisted(() => ({ nodeEnv: 'test', versionCheckDisabled: false }));
+vi.mock('../config/environment.js', () => ({
+  getEnvironmentConfig: vi.fn(() => mockEnv),
+}));
+
+const mockSystemInfo = vi.hoisted(() => ({
+  serverStartTime: Date.now() - 5000,
+  isRunningInDocker: vi.fn().mockReturnValue(false),
+  compareVersions: vi.fn(),
+  checkDockerImageExists: vi.fn(),
+}));
+vi.mock('../utils/systemInfo.js', () => mockSystemInfo);
+
+vi.mock('../auth/authMiddleware.js', () => ({
+  optionalAuth: () => (req: any, _res: any, next: any) => { req.session = req.session || {}; next(); },
+  requirePermission: () => (req: any, _res: any, next: any) => { req.user = { id: 1, isAdmin: true }; next(); },
+}));
+
+import systemRoutes, { setSystemCallbacks } from './systemRoutes.js';
+
+const app = express();
+app.use(express.json());
+app.use('/', systemRoutes);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEnv.versionCheckDisabled = false;
+  mockSystemInfo.isRunningInDocker.mockReturnValue(false);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('GET /system/status', () => {
+  it('returns system info with capitalised db type and docker flag', async () => {
+    mockSystemInfo.isRunningInDocker.mockReturnValue(true);
+    const res = await request(app).get('/system/status');
+    expect(res.status).toBe(200);
+    expect(res.body.database).toEqual({ type: 'Sqlite', version: '3.45.0' });
+    expect(res.body.isDocker).toBe(true);
+    expect(res.body.uptimeSeconds).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('GET /status', () => {
+  it('reports connection and statistics', async () => {
+    mockManager.getConnectionStatus.mockResolvedValue({ connected: true });
+    mockManager.getLocalNodeInfo.mockReturnValue({ nodeNum: 1, nodeId: '!1', longName: 'A', shortName: 'A' });
+    const res = await request(app).get('/status');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.connection.connected).toBe(true);
+    expect(res.body.connection.localNode.nodeNum).toBe(1);
+    expect(res.body.statistics).toEqual({ nodes: 5, messages: 10, channels: 3 });
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-    vi.useRealTimers(); // Reset timers after each test to prevent leakage
+  it('returns null localNode when none present', async () => {
+    mockManager.getConnectionStatus.mockResolvedValue({ connected: false });
+    mockManager.getLocalNodeInfo.mockReturnValue(null);
+    const res = await request(app).get('/status');
+    expect(res.status).toBe(200);
+    expect(res.body.connection.localNode).toBeNull();
+  });
+});
+
+describe('GET /version/check', () => {
+  it('returns 404 when version check is disabled', async () => {
+    mockEnv.versionCheckDisabled = true;
+    const res = await request(app).get('/version/check');
+    expect(res.status).toBe(404);
   });
 
-  afterEach(() => {
-    // Restore original fs.existsSync
-    (fs as any).existsSync = originalExistsSync;
+  // Note: GitHub API failures are NOT cached (the handler returns early), while a
+  // successful response IS cached for 5 minutes at module scope. This failure test
+  // therefore runs before the success test so it observes a fresh (uncached) miss.
+  it('handles GitHub API failure gracefully', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+    vi.stubGlobal('fetch', fetchMock);
+    const res = await request(app).get('/version/check');
+    expect(res.status).toBe(200);
+    expect(res.body.updateAvailable).toBe(false);
+    expect(res.body.error).toBe('Unable to check for updates');
+    vi.unstubAllGlobals();
   });
 
-  describe('isDocker Detection Logic', () => {
-    it('should detect Docker environment when /.dockerenv exists', () => {
-      mockExistsSync.mockImplementation((path: string) => {
-        return path === '/.dockerenv';
-      });
-
-      const isDocker = mockExistsSync('/.dockerenv');
-      expect(isDocker).toBe(true);
-      expect(mockExistsSync).toHaveBeenCalledWith('/.dockerenv');
+  it('reports an available update when newer and image ready', async () => {
+    mockSystemInfo.compareVersions.mockReturnValue(1);
+    mockSystemInfo.checkDockerImageExists.mockResolvedValue(true);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        tag_name: 'v9.9.9',
+        html_url: 'https://example/release',
+        name: 'Release',
+        published_at: '2026-01-01T00:00:00Z',
+      }),
     });
+    vi.stubGlobal('fetch', fetchMock);
 
-    it('should not detect Docker when /.dockerenv does not exist', () => {
-      mockExistsSync.mockImplementation(() => {
-        return false;
-      });
+    const res = await request(app).get('/version/check');
+    expect(res.status).toBe(200);
+    expect(res.body.updateAvailable).toBe(true);
+    expect(res.body.latestVersion).toBe('9.9.9');
+    expect(res.body.imageReady).toBe(true);
+    vi.unstubAllGlobals();
+  });
+});
 
-      const isDocker = mockExistsSync('/.dockerenv');
-      expect(isDocker).toBe(false);
-      expect(mockExistsSync).toHaveBeenCalledWith('/.dockerenv');
-    });
+describe('POST /system/restart', () => {
+  it('returns restart action and invokes gracefulShutdown in Docker', async () => {
+    vi.useFakeTimers();
+    const gracefulShutdown = vi.fn();
+    setSystemCallbacks({ gracefulShutdown });
+    mockSystemInfo.isRunningInDocker.mockReturnValue(true);
 
-    it('should handle errors gracefully', () => {
-      mockExistsSync.mockImplementation(() => {
-        throw new Error('File system error');
-      });
-
-      // In the actual implementation, errors are caught and return false
-      expect(() => mockExistsSync('/.dockerenv')).toThrow('File system error');
-    });
+    const res = await request(app).post('/system/restart').send({});
+    expect(res.status).toBe(200);
+    expect(res.body.action).toBe('restart');
+    vi.advanceTimersByTime(500);
+    expect(gracefulShutdown).toHaveBeenCalledWith('Admin-requested container restart');
   });
 
-  describe('Graceful Shutdown Logic', () => {
-    it('should properly sequence shutdown steps', () => {
-      const shutdownSteps: string[] = [];
+  it('returns shutdown action when not in Docker', async () => {
+    vi.useFakeTimers();
+    const gracefulShutdown = vi.fn();
+    setSystemCallbacks({ gracefulShutdown });
+    mockSystemInfo.isRunningInDocker.mockReturnValue(false);
 
-      const mockServer = {
-        close: vi.fn((callback) => {
-          shutdownSteps.push('server-closed');
-          callback();
-        })
-      };
-
-      const mockMeshtastic = {
-        disconnect: vi.fn(() => {
-          shutdownSteps.push('meshtastic-disconnected');
-        })
-      };
-
-      const mockDatabase = {
-        close: vi.fn(() => {
-          shutdownSteps.push('database-closed');
-        })
-      };
-
-      // Simulate graceful shutdown sequence
-      mockServer.close(() => {
-        mockMeshtastic.disconnect();
-        mockDatabase.close();
-      });
-
-      expect(shutdownSteps).toEqual([
-        'server-closed',
-        'meshtastic-disconnected',
-        'database-closed'
-      ]);
-    });
-
-    it('should timeout if shutdown takes too long', () => {
-      vi.useRealTimers(); // Reset any existing fake timers first
-      vi.useFakeTimers();
-
-      const mockServer = {
-        close: vi.fn(() => {
-          // Never call the callback - simulate hung server
-        })
-      };
-
-      const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-
-      // Simulate shutdown with timeout
-      mockServer.close();
-
-      const timeout = setTimeout(() => {
-        process.exit(1);
-      }, 10000);
-
-      // Fast-forward time
-      vi.advanceTimersByTime(10000);
-
-      expect(mockExit).toHaveBeenCalledWith(1);
-
-      clearTimeout(timeout);
-      mockExit.mockRestore();
-      vi.useRealTimers();
-    });
-
-    it('should handle errors during shutdown gracefully', () => {
-      const mockMeshtastic = {
-        disconnect: vi.fn(() => {
-          throw new Error('Meshtastic error');
-        })
-      };
-
-      const mockDatabase = {
-        close: vi.fn(() => {
-          throw new Error('Database error');
-        })
-      };
-
-      // Shutdown should continue even if components error
-      expect(() => {
-        try {
-          mockMeshtastic.disconnect();
-        } catch (e) {
-          // Caught and logged
-        }
-        try {
-          mockDatabase.close();
-        } catch (e) {
-          // Caught and logged
-        }
-      }).not.toThrow();
-    });
-  });
-
-  describe('Restart API Response', () => {
-    it('should return correct response for Docker restart', () => {
-      const isDocker = true;
-      const response = {
-        success: true,
-        message: isDocker ? 'Container will restart now' : 'MeshMonitor will shut down now',
-        action: isDocker ? 'restart' : 'shutdown'
-      };
-
-      expect(response).toMatchObject({
-        success: true,
-        action: 'restart',
-        message: 'Container will restart now'
-      });
-    });
-
-    it('should return correct response for non-Docker shutdown', () => {
-      const isDocker = false;
-      const response = {
-        success: true,
-        message: isDocker ? 'Container will restart now' : 'MeshMonitor will shut down now',
-        action: isDocker ? 'restart' : 'shutdown'
-      };
-
-      expect(response).toMatchObject({
-        success: true,
-        action: 'shutdown',
-        message: 'MeshMonitor will shut down now'
-      });
-    });
+    const res = await request(app).post('/system/restart').send({});
+    expect(res.status).toBe(200);
+    expect(res.body.action).toBe('shutdown');
+    vi.advanceTimersByTime(500);
+    expect(gracefulShutdown).toHaveBeenCalledWith('Admin-requested shutdown');
   });
 });

--- a/src/server/routes/systemRoutes.ts
+++ b/src/server/routes/systemRoutes.ts
@@ -1,0 +1,254 @@
+/**
+ * System Routes
+ *
+ * GET  /system/status   — system statistics (uptime, memory, db, docker)
+ * GET  /status          — connection + statistics status
+ * GET  /version/check   — compare current version with latest GitHub release
+ * POST /system/restart  — restart (Docker) or shutdown (baremetal) the process
+ *
+ * Extracted from server.ts. The Docker/version helpers live in
+ * ../utils/systemInfo.js (shared with the startup auto-upgrade scheduler).
+ * The restart handler needs the server-lifecycle `gracefulShutdown`, which is
+ * injected from server.ts via setSystemCallbacks() so this module stays free
+ * of the HTTP-server reference.
+ */
+
+import { createRequire } from 'module';
+import { Router, Request, Response } from 'express';
+import { optionalAuth, requirePermission } from '../auth/authMiddleware.js';
+import databaseService from '../../services/database.js';
+import { logger } from '../../utils/logger.js';
+import { getEnvironmentConfig } from '../config/environment.js';
+import { upgradeService } from '../services/upgradeService.js';
+import meshtasticManager from '../meshtasticManager.js';
+import {
+  serverStartTime,
+  isRunningInDocker,
+  compareVersions,
+  checkDockerImageExists,
+} from '../utils/systemInfo.js';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../../../package.json');
+
+const env = getEnvironmentConfig();
+
+export interface SystemCallbacks {
+  gracefulShutdown: (reason: string) => void;
+}
+
+let callbacks: SystemCallbacks = {
+  gracefulShutdown: () => {
+    logger.warn('gracefulShutdown called before system callbacks were registered');
+  },
+};
+
+export function setSystemCallbacks(cb: SystemCallbacks): void {
+  callbacks = cb;
+}
+
+const router: Router = Router();
+
+// System status endpoint
+router.get('/system/status', requirePermission('dashboard', 'read'), async (_req: Request, res: Response) => {
+  const uptimeSeconds = Math.floor((Date.now() - serverStartTime) / 1000);
+  const days = Math.floor(uptimeSeconds / 86400);
+  const hours = Math.floor((uptimeSeconds % 86400) / 3600);
+  const minutes = Math.floor((uptimeSeconds % 3600) / 60);
+  const seconds = uptimeSeconds % 60;
+
+  let uptimeString = '';
+  if (days > 0) uptimeString += `${days}d `;
+  if (hours > 0 || days > 0) uptimeString += `${hours}h `;
+  if (minutes > 0 || hours > 0 || days > 0) uptimeString += `${minutes}m `;
+  uptimeString += `${seconds}s`;
+
+  // Get database info
+  const databaseType = databaseService.getDatabaseType();
+  const databaseVersion = await databaseService.getDatabaseVersion();
+
+  res.json({
+    version: packageJson.version,
+    nodeVersion: process.version,
+    platform: process.platform,
+    architecture: process.arch,
+    uptime: uptimeString,
+    uptimeSeconds,
+    environment: env.nodeEnv,
+    isDocker: isRunningInDocker(),
+    memoryUsage: {
+      heapUsed: Math.round(process.memoryUsage().heapUsed / 1024 / 1024) + ' MB',
+      heapTotal: Math.round(process.memoryUsage().heapTotal / 1024 / 1024) + ' MB',
+      rss: Math.round(process.memoryUsage().rss / 1024 / 1024) + ' MB',
+    },
+    database: {
+      type: databaseType.charAt(0).toUpperCase() + databaseType.slice(1), // Capitalize
+      version: databaseVersion,
+    },
+  });
+});
+
+// Detailed status endpoint - provides system statistics and connection status
+router.get('/status', optionalAuth(), async (_req: Request, res: Response) => {
+  const connectionStatus = await meshtasticManager.getConnectionStatus();
+  const localNode = meshtasticManager.getLocalNodeInfo();
+
+  res.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    version: packageJson.version,
+    nodeEnv: env.nodeEnv,
+    connection: {
+      connected: connectionStatus.connected,
+      localNode: localNode
+        ? {
+            nodeNum: localNode.nodeNum,
+            nodeId: localNode.nodeId,
+            longName: localNode.longName,
+            shortName: localNode.shortName,
+          }
+        : null,
+    },
+    statistics: {
+      nodes: await databaseService.nodes.getNodeCount(),
+      messages: await databaseService.messages.getMessageCount(),
+      channels: await databaseService.channels.getChannelCount(),
+    },
+    uptime: process.uptime(),
+  });
+});
+
+// Version check endpoint - compares current version with latest GitHub release
+let versionCheckCache: { data: any; timestamp: number } | null = null;
+const VERSION_CHECK_CACHE_MS = 5 * 60 * 1000; // 5 minute cache (reduced to detect image availability sooner)
+
+router.get('/version/check', optionalAuth(), async (_req: Request, res: Response) => {
+  if (env.versionCheckDisabled) {
+    return res.status(404).send();
+  }
+  try {
+    // Check cache first
+    if (versionCheckCache && Date.now() - versionCheckCache.timestamp < VERSION_CHECK_CACHE_MS) {
+      return res.json(versionCheckCache.data);
+    }
+
+    // Fetch latest release from GitHub
+    const response = await fetch('https://api.github.com/repos/Yeraze/meshmonitor/releases/latest');
+
+    if (!response.ok) {
+      logger.warn(`GitHub API returned ${response.status} for version check`);
+      return res.json({ updateAvailable: false, error: 'Unable to check for updates' });
+    }
+
+    const release = await response.json();
+    const currentVersion = packageJson.version;
+    const latestVersionRaw = release.tag_name;
+
+    // Strip 'v' prefix from version strings for comparison
+    const latestVersion = latestVersionRaw.replace(/^v/, '');
+    const current = currentVersion.replace(/^v/, '');
+
+    // Simple semantic version comparison
+    const isNewerVersion = compareVersions(latestVersion, current) > 0;
+
+    // Check if Docker image exists for this version (pass publish time for time-based heuristic)
+    const imageReady = await checkDockerImageExists(latestVersion, release.published_at);
+
+    // Only mark update as available if it's a newer version AND container image exists
+    const updateAvailable = isNewerVersion && imageReady;
+
+    // Check if auto-upgrade immediate is enabled and trigger upgrade automatically
+    let autoUpgradeTriggered = false;
+    if (updateAvailable && upgradeService.isEnabled()) {
+      const autoUpgradeImmediate = await databaseService.settings.getSetting('autoUpgradeImmediate') === 'true';
+      if (autoUpgradeImmediate) {
+        // Check if an upgrade is already in progress before triggering
+        try {
+          const inProgress = await upgradeService.isUpgradeInProgress();
+          if (inProgress) {
+            logger.debug(`ℹ️ Auto-upgrade skipped: upgrade already in progress`);
+          } else {
+            logger.info(`🚀 Auto-upgrade immediate enabled, triggering upgrade to ${latestVersion}`);
+            const upgradeResult = await upgradeService.triggerUpgrade(
+              { targetVersion: latestVersion, backup: true },
+              currentVersion,
+              'system-auto-upgrade'
+            );
+            if (upgradeResult.success) {
+              autoUpgradeTriggered = true;
+              logger.info(`✅ Auto-upgrade triggered successfully: ${upgradeResult.upgradeId}`);
+              databaseService.auditLogAsync(
+                null,
+                'auto_upgrade_triggered',
+                'system',
+                `Auto-upgrade initiated: ${currentVersion} → ${latestVersion}`,
+                null
+              );
+            } else {
+              // Check if failure was due to upgrade already in progress (race condition)
+              if (upgradeResult.message === 'An upgrade is already in progress') {
+                logger.debug(`ℹ️ Auto-upgrade skipped: upgrade started by another process`);
+              } else {
+                logger.warn(`⚠️ Auto-upgrade failed to trigger: ${upgradeResult.message}`);
+              }
+            }
+          }
+        } catch (upgradeError) {
+          logger.error('❌ Error triggering auto-upgrade:', upgradeError);
+        }
+      }
+    }
+
+    const result = {
+      updateAvailable,
+      currentVersion,
+      latestVersion,
+      releaseUrl: release.html_url,
+      releaseName: release.name,
+      publishedAt: release.published_at,
+      imageReady,
+      autoUpgradeTriggered,
+    };
+
+    // Cache the result
+    versionCheckCache = { data: result, timestamp: Date.now() };
+
+    return res.json(result);
+  } catch (error) {
+    logger.error('Error checking for version updates:', error);
+    return res.json({ updateAvailable: false, error: 'Unable to check for updates' });
+  }
+});
+
+// Restart/shutdown container endpoint
+router.post('/system/restart', requirePermission('settings', 'write'), (_req: Request, res: Response) => {
+  const isDocker = isRunningInDocker();
+
+  if (isDocker) {
+    logger.info('🔄 Container restart requested by admin');
+    res.json({
+      success: true,
+      message: 'Container will restart now',
+      action: 'restart',
+    });
+
+    // Gracefully shutdown - Docker will restart the container automatically
+    setTimeout(() => {
+      callbacks.gracefulShutdown('Admin-requested container restart');
+    }, 500);
+  } else {
+    logger.info('🛑 Shutdown requested by admin');
+    res.json({
+      success: true,
+      message: 'MeshMonitor will shut down now',
+      action: 'shutdown',
+    });
+
+    // Gracefully shutdown - will need to be manually restarted
+    setTimeout(() => {
+      callbacks.gracefulShutdown('Admin-requested shutdown');
+    }, 500);
+  }
+});
+
+export default router;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -28,8 +28,6 @@ import { setupAccessLogger } from './middleware/accessLogger.js';
 import { getEnvironmentConfig, resetEnvironmentConfig } from './config/environment.js';
 import { pushNotificationService } from './services/pushNotificationService.js';
 import { appriseNotificationService } from './services/appriseNotificationService.js';
-import { deviceBackupService } from './services/deviceBackupService.js';
-import { backupFileService } from './services/backupFileService.js';
 import { backupSchedulerService } from './services/backupSchedulerService.js';
 import { databaseMaintenanceService } from './services/databaseMaintenanceService.js';
 import { positionEstimationScheduler } from './services/positionEstimationScheduler.js';
@@ -51,6 +49,7 @@ import { generateAnalyticsScript, AnalyticsProvider } from './utils/analyticsScr
 import { rewriteHtml } from './utils/htmlRewriter.js';
 import { migrateAutomationChannels } from './utils/automationChannelMigration.js';
 import { resolveRequestSourceId } from './utils/sourceResolver.js';
+import { compareVersions, checkDockerImageExists } from './utils/systemInfo.js';
 import { parseDestinationNum } from './utils/parseDestination.js';
 import { PortNum, modemPresetChannelName, getRoutingErrorName } from './constants/meshtastic.js';
 import { isValidModuleConfigType } from './constants/moduleConfig.js';
@@ -81,7 +80,6 @@ const env = getEnvironmentConfig();
 const app = express();
 const PORT = env.port;
 const BASE_URL = env.baseUrl;
-const serverStartTime = Date.now();
 
 // Custom JSON replacer to handle BigInt values
 const jsonReplacer = (_key: string, value: any) => {
@@ -937,6 +935,8 @@ import statusRoutes from './routes/statusRoutes.js';
 import dataExchangeRoutes from './routes/dataExchangeRoutes.js';
 import serverInfoRoutes from './routes/serverInfoRoutes.js';
 import scriptRoutes, { scriptsEndpoint, getScriptsDirectory } from './routes/scriptRoutes.js';
+import deviceRoutes from './routes/deviceRoutes.js';
+import systemRoutes, { setSystemCallbacks } from './routes/systemRoutes.js';
 
 // CSRF token endpoint (must be before CSRF protection middleware)
 apiRouter.get('/csrf-token', csrfTokenEndpoint);
@@ -1066,6 +1066,10 @@ apiRouter.use('/', deviceStatusRoutes);
 apiRouter.use('/', statusRoutes);
 apiRouter.use('/', serverInfoRoutes);
 apiRouter.use('/', dataExchangeRoutes);
+// Mounted at '/' because these routers contain mixed top-level paths
+// (/device-config, /device/*, /system/*, /status, /version/check).
+apiRouter.use('/', deviceRoutes);
+apiRouter.use('/', systemRoutes);
 // Mounted at '/' because the script routes use mixed top-level paths
 // (/scripts/*, /http/test). The public /api/scripts listing endpoint is
 // mounted separately on the app below (bypasses CSRF).
@@ -1142,6 +1146,12 @@ setSettingsCallbacks({
   restartAutoDeleteByDistanceService: (intervalHours: number) =>
     autoDeleteByDistanceService.start(intervalHours),
   stopAutoDeleteByDistanceService: () => autoDeleteByDistanceService.stop(),
+});
+
+// Wire up side-effect callbacks for systemRoutes (server-lifecycle shutdown).
+// gracefulShutdown is a hoisted function declaration defined later in this file.
+setSystemCallbacks({
+  gracefulShutdown,
 });
 
 // API Routes
@@ -4308,72 +4318,6 @@ apiRouter.get('/config', optionalAuth(), async (req, res) => {
 });
 
 // Device configuration endpoint
-apiRouter.get('/device-config', requirePermission('configuration', 'read'), async (req, res) => {
-  try {
-    const dcSourceId = req.query.sourceId as string | undefined;
-    const dcManager = resolveSourceManager(dcSourceId);
-    const config = await dcManager.getDeviceConfig();
-    if (config) {
-      res.json(config);
-    } else {
-      res.status(503).json({ error: 'Unable to retrieve device configuration' });
-    }
-  } catch (error) {
-    logger.error('Error fetching device config:', error);
-    res.status(500).json({ error: 'Failed to fetch device configuration' });
-  }
-});
-
-// Export complete device configuration as YAML backup
-// Compatible with Meshtastic CLI --export-config format
-// Query param ?save=true will save to disk instead of just downloading
-apiRouter.get('/device/backup', requirePermission('configuration', 'read'), async (req, res) => {
-  try {
-    const saveToFile = req.query.save === 'true';
-    const backupSourceId = req.query.sourceId as string | undefined;
-    const backupManager = resolveSourceManager(backupSourceId);
-    logger.info(`📦 Device backup requested (save=${saveToFile})...`);
-
-    // Generate YAML backup using the device backup service
-    const yamlBackup = await deviceBackupService.generateBackup(backupManager);
-
-    // Get node ID for filename
-    const localNodeInfo = backupManager.getLocalNodeInfo();
-    const nodeId = localNodeInfo?.nodeId || '!unknown';
-
-    if (saveToFile) {
-      // Save to disk with new filename format
-      const filename = await backupFileService.saveBackup(yamlBackup, 'manual', nodeId);
-
-      // Also send the file for download
-      res.setHeader('Content-Type', 'application/x-yaml');
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-      res.send(yamlBackup);
-
-      logger.info(`✅ Device backup saved and downloaded: ${filename}`);
-    } else {
-      // Just download, don't save - generate filename for display
-      const nodeIdNumber = nodeId.startsWith('!') ? nodeId.substring(1) : nodeId;
-      const now = new Date();
-      const date = now.toISOString().split('T')[0];
-      const time = now.toTimeString().split(' ')[0].replace(/:/g, '-');
-      const filename = `${nodeIdNumber}-${date}-${time}.yaml`;
-
-      res.setHeader('Content-Type', 'application/x-yaml');
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-      res.send(yamlBackup);
-
-      logger.info(`✅ Device backup generated: ${filename}`);
-    }
-  } catch (error) {
-    logger.error('❌ Error generating device backup:', error);
-    res.status(500).json({
-      error: 'Failed to generate device backup',
-      details: error instanceof Error ? error.message : 'Unknown error',
-    });
-  }
-});
-
 // ==========================================
 // Refresh nodes from device endpoint
 apiRouter.post('/nodes/refresh', requirePermission('nodes', 'write'), async (req, res) => {
@@ -5553,19 +5497,6 @@ apiRouter.post('/config/module/request', requirePermission('configuration', 'wri
   } catch (error) {
     logger.error('Error requesting module config:', error);
     res.status(500).json({ error: 'Failed to request module configuration' });
-  }
-});
-
-apiRouter.post('/device/reboot', requirePermission('configuration', 'write'), async (req, res) => {
-  try {
-    const { seconds: rebootSeconds, sourceId: rebootSourceId } = req.body || {};
-    const seconds = rebootSeconds || 10;
-    const rebootManager = resolveSourceManager(rebootSourceId);
-    await rebootManager.rebootDevice(seconds);
-    res.json({ success: true, message: `Device will reboot in ${seconds} seconds` });
-  } catch (error) {
-    logger.error('Error rebooting device:', error);
-    res.status(500).json({ error: 'Failed to reboot device' });
   }
 });
 
@@ -6932,349 +6863,6 @@ apiRouter.post('/admin/commands', requireAdmin(), async (req, res) => {
     res.status(500).json({ error: error.message || 'Failed to execute admin command' });
   }
 });
-
-apiRouter.post('/device/purge-nodedb', requirePermission('configuration', 'write'), async (req, res) => {
-  try {
-    const { seconds: purgeSeconds, sourceId: purgeSourceId } = req.body || {};
-    const seconds = purgeSeconds || 0;
-    const purgeManager = resolveSourceManager(purgeSourceId);
-
-    // Purge the device's node database
-    await purgeManager.purgeNodeDb(seconds);
-
-    // Also purge the local database (scoped to the source we just told the
-    // device to wipe — purging globally on a per-source admin command would
-    // wipe siblings)
-    logger.info('🗑️ Purging local node database');
-    await databaseService.purgeAllNodesAsync(purgeSourceId);
-    logger.info('✅ Local node database purged successfully');
-
-    res.json({
-      success: true,
-      message: `Node database purged (both device and local)${seconds > 0 ? ` in ${seconds} seconds` : ''}`,
-    });
-  } catch (error) {
-    logger.error('Error purging node database:', error);
-    res.status(500).json({ error: 'Failed to purge node database' });
-  }
-});
-
-// Helper to detect if running in Docker
-function isRunningInDocker(): boolean {
-  try {
-    return fs.existsSync('/.dockerenv');
-  } catch {
-    return false;
-  }
-}
-
-// System status endpoint
-apiRouter.get('/system/status', requirePermission('dashboard', 'read'), async (_req, res) => {
-  const uptimeSeconds = Math.floor((Date.now() - serverStartTime) / 1000);
-  const days = Math.floor(uptimeSeconds / 86400);
-  const hours = Math.floor((uptimeSeconds % 86400) / 3600);
-  const minutes = Math.floor((uptimeSeconds % 3600) / 60);
-  const seconds = uptimeSeconds % 60;
-
-  let uptimeString = '';
-  if (days > 0) uptimeString += `${days}d `;
-  if (hours > 0 || days > 0) uptimeString += `${hours}h `;
-  if (minutes > 0 || hours > 0 || days > 0) uptimeString += `${minutes}m `;
-  uptimeString += `${seconds}s`;
-
-  // Get database info
-  const databaseType = databaseService.getDatabaseType();
-  const databaseVersion = await databaseService.getDatabaseVersion();
-
-  res.json({
-    version: packageJson.version,
-    nodeVersion: process.version,
-    platform: process.platform,
-    architecture: process.arch,
-    uptime: uptimeString,
-    uptimeSeconds,
-    environment: env.nodeEnv,
-    isDocker: isRunningInDocker(),
-    memoryUsage: {
-      heapUsed: Math.round(process.memoryUsage().heapUsed / 1024 / 1024) + ' MB',
-      heapTotal: Math.round(process.memoryUsage().heapTotal / 1024 / 1024) + ' MB',
-      rss: Math.round(process.memoryUsage().rss / 1024 / 1024) + ' MB',
-    },
-    database: {
-      type: databaseType.charAt(0).toUpperCase() + databaseType.slice(1), // Capitalize
-      version: databaseVersion,
-    },
-  });
-});
-
-// Detailed status endpoint - provides system statistics and connection status
-apiRouter.get('/status', optionalAuth(), async (_req, res) => {
-  const connectionStatus = await meshtasticManager.getConnectionStatus();
-  const localNode = meshtasticManager.getLocalNodeInfo();
-
-  res.json({
-    status: 'ok',
-    timestamp: new Date().toISOString(),
-    version: packageJson.version,
-    nodeEnv: env.nodeEnv,
-    connection: {
-      connected: connectionStatus.connected,
-      localNode: localNode
-        ? {
-            nodeNum: localNode.nodeNum,
-            nodeId: localNode.nodeId,
-            longName: localNode.longName,
-            shortName: localNode.shortName,
-          }
-        : null,
-    },
-    statistics: {
-      nodes: await databaseService.nodes.getNodeCount(),
-      messages: await databaseService.messages.getMessageCount(),
-      channels: await databaseService.channels.getChannelCount(),
-    },
-    uptime: process.uptime(),
-  });
-});
-
-// Helper function to check if Docker image exists in GHCR
-async function checkDockerImageExists(version: string, publishedAt?: string): Promise<boolean> {
-  try {
-    const owner = 'yeraze';
-    const repo = 'meshmonitor';
-
-    // STRATEGY 1: Query manifest directly (most reliable, avoids pagination issues)
-    // Try both with and without 'v' prefix as GHCR may use either
-    const tagsToTry = [version, `v${version}`];
-
-    for (const tag of tagsToTry) {
-      try {
-        // Step 1: Get anonymous token from GHCR
-        const tokenUrl = `https://ghcr.io/token?scope=repository:${owner}/${repo}:pull`;
-        const tokenResponse = await fetch(tokenUrl);
-
-        if (tokenResponse.ok) {
-          const tokenData = await tokenResponse.json();
-          const token = tokenData.token;
-
-          // Step 2: Try to fetch the manifest for this specific tag
-          const manifestUrl = `https://ghcr.io/v2/${owner}/${repo}/manifests/${tag}`;
-          const manifestResponse = await fetch(manifestUrl, {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              Accept: 'application/vnd.docker.distribution.manifest.v2+json',
-            },
-          });
-
-          if (manifestResponse.ok) {
-            logger.info(`✓ Image for ${version} (tag: ${tag}) found in GitHub Container Registry`);
-            return true;
-          }
-        }
-      } catch (manifestError) {
-        logger.debug(`Manifest check failed for tag ${tag}:`, manifestError);
-        // Try next tag variant
-      }
-    }
-
-    // If we reach here, manifest check failed for all tag variants
-    logger.info(`⏳ Image for ${version} not found via manifest check, falling back to time-based heuristic`);
-
-    // STRATEGY 2: Time-based heuristic fallback (only if manifest check failed)
-    // GitHub Actions typically takes 10-30 minutes to build and push container images
-    // If release was published more than 30 minutes ago, assume the build completed
-    if (publishedAt) {
-      const publishTime = new Date(publishedAt).getTime();
-      const now = Date.now();
-      const minutesSincePublish = (now - publishTime) / (60 * 1000);
-
-      if (minutesSincePublish >= 30) {
-        logger.info(
-          `✓ Image for ${version} assumed ready (${Math.round(
-            minutesSincePublish
-          )} minutes since release, API check failed)`
-        );
-        return true;
-      } else {
-        logger.info(
-          `⏳ Image for ${version} still building (${Math.round(minutesSincePublish)}/30 minutes since release)`
-        );
-        return false;
-      }
-    }
-
-    // If no publish time provided and API failed, be conservative and return false
-    logger.warn(`Cannot verify image availability for ${version} (no publish time and API failed)`);
-    return false;
-  } catch (error) {
-    logger.warn(`Error checking Docker image existence for ${version}:`, error);
-    // On error with known publish time, use time-based fallback
-    if (publishedAt) {
-      const minutesSincePublish = (Date.now() - new Date(publishedAt).getTime()) / (60 * 1000);
-      const assumeReady = minutesSincePublish >= 30;
-      if (assumeReady) {
-        logger.info(
-          `✓ Image for ${version} assumed ready (${Math.round(
-            minutesSincePublish
-          )} minutes since release, error during check)`
-        );
-      }
-      return assumeReady;
-    }
-    // Otherwise fail closed to avoid false positives
-    return false;
-  }
-}
-
-// Version check endpoint - compares current version with latest GitHub release
-let versionCheckCache: { data: any; timestamp: number } | null = null;
-const VERSION_CHECK_CACHE_MS = 5 * 60 * 1000; // 5 minute cache (reduced to detect image availability sooner)
-
-apiRouter.get('/version/check', optionalAuth(), async (_req, res) => {
-  if (env.versionCheckDisabled) {
-    return res.status(404).send();
-  }
-  try {
-    // Check cache first
-    if (versionCheckCache && Date.now() - versionCheckCache.timestamp < VERSION_CHECK_CACHE_MS) {
-      return res.json(versionCheckCache.data);
-    }
-
-    // Fetch latest release from GitHub
-    const response = await fetch('https://api.github.com/repos/Yeraze/meshmonitor/releases/latest');
-
-    if (!response.ok) {
-      logger.warn(`GitHub API returned ${response.status} for version check`);
-      return res.json({ updateAvailable: false, error: 'Unable to check for updates' });
-    }
-
-    const release = await response.json();
-    const currentVersion = packageJson.version;
-    const latestVersionRaw = release.tag_name;
-
-    // Strip 'v' prefix from version strings for comparison
-    const latestVersion = latestVersionRaw.replace(/^v/, '');
-    const current = currentVersion.replace(/^v/, '');
-
-    // Simple semantic version comparison
-    const isNewerVersion = compareVersions(latestVersion, current) > 0;
-
-    // Check if Docker image exists for this version (pass publish time for time-based heuristic)
-    const imageReady = await checkDockerImageExists(latestVersion, release.published_at);
-
-    // Only mark update as available if it's a newer version AND container image exists
-    const updateAvailable = isNewerVersion && imageReady;
-
-    // Check if auto-upgrade immediate is enabled and trigger upgrade automatically
-    let autoUpgradeTriggered = false;
-    if (updateAvailable && upgradeService.isEnabled()) {
-      const autoUpgradeImmediate = await databaseService.settings.getSetting('autoUpgradeImmediate') === 'true';
-      if (autoUpgradeImmediate) {
-        // Check if an upgrade is already in progress before triggering
-        try {
-          const inProgress = await upgradeService.isUpgradeInProgress();
-          if (inProgress) {
-            logger.debug(`ℹ️ Auto-upgrade skipped: upgrade already in progress`);
-          } else {
-            logger.info(`🚀 Auto-upgrade immediate enabled, triggering upgrade to ${latestVersion}`);
-            const upgradeResult = await upgradeService.triggerUpgrade(
-              { targetVersion: latestVersion, backup: true },
-              currentVersion,
-              'system-auto-upgrade'
-            );
-            if (upgradeResult.success) {
-              autoUpgradeTriggered = true;
-              logger.info(`✅ Auto-upgrade triggered successfully: ${upgradeResult.upgradeId}`);
-              databaseService.auditLogAsync(
-                null,
-                'auto_upgrade_triggered',
-                'system',
-                `Auto-upgrade initiated: ${currentVersion} → ${latestVersion}`,
-                null
-              );
-            } else {
-              // Check if failure was due to upgrade already in progress (race condition)
-              if (upgradeResult.message === 'An upgrade is already in progress') {
-                logger.debug(`ℹ️ Auto-upgrade skipped: upgrade started by another process`);
-              } else {
-                logger.warn(`⚠️ Auto-upgrade failed to trigger: ${upgradeResult.message}`);
-              }
-            }
-          }
-        } catch (upgradeError) {
-          logger.error('❌ Error triggering auto-upgrade:', upgradeError);
-        }
-      }
-    }
-
-    const result = {
-      updateAvailable,
-      currentVersion,
-      latestVersion,
-      releaseUrl: release.html_url,
-      releaseName: release.name,
-      publishedAt: release.published_at,
-      imageReady,
-      autoUpgradeTriggered,
-    };
-
-    // Cache the result
-    versionCheckCache = { data: result, timestamp: Date.now() };
-
-    return res.json(result);
-  } catch (error) {
-    logger.error('Error checking for version updates:', error);
-    return res.json({ updateAvailable: false, error: 'Unable to check for updates' });
-  }
-});
-
-// Helper function to compare semantic versions
-function compareVersions(a: string, b: string): number {
-  const aParts = a.split(/[-.]/).map(p => parseInt(p) || 0);
-  const bParts = b.split(/[-.]/).map(p => parseInt(p) || 0);
-
-  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
-    const aPart = aParts[i] || 0;
-    const bPart = bParts[i] || 0;
-
-    if (aPart > bPart) return 1;
-    if (aPart < bPart) return -1;
-  }
-
-  return 0;
-}
-
-// Restart/shutdown container endpoint
-apiRouter.post('/system/restart', requirePermission('settings', 'write'), (_req, res) => {
-  const isDocker = isRunningInDocker();
-
-  if (isDocker) {
-    logger.info('🔄 Container restart requested by admin');
-    res.json({
-      success: true,
-      message: 'Container will restart now',
-      action: 'restart',
-    });
-
-    // Gracefully shutdown - Docker will restart the container automatically
-    setTimeout(() => {
-      gracefulShutdown('Admin-requested container restart');
-    }, 500);
-  } else {
-    logger.info('🛑 Shutdown requested by admin');
-    res.json({
-      success: true,
-      message: 'MeshMonitor will shut down now',
-      action: 'shutdown',
-    });
-
-    // Gracefully shutdown - will need to be manually restarted
-    setTimeout(() => {
-      gracefulShutdown('Admin-requested shutdown');
-    }, 500);
-  }
-});
-
 
 // Serve static files from the React app build
 const buildPath = path.join(__dirname, '../../dist');

--- a/src/server/utils/systemInfo.ts
+++ b/src/server/utils/systemInfo.ts
@@ -1,0 +1,131 @@
+/**
+ * System / version utilities
+ *
+ * Pure helpers extracted from server.ts so they can be shared between the
+ * system route handlers (routes/systemRoutes.ts) and the startup
+ * auto-upgrade scheduler (checkForAutoUpgrade in server.ts) without
+ * pulling in the whole monolith.
+ */
+
+import fs from 'fs';
+import { logger } from '../../utils/logger.js';
+
+/** Process start time, captured when this module is first loaded at boot. */
+export const serverStartTime = Date.now();
+
+/** Detect whether the process is running inside a Docker container. */
+export function isRunningInDocker(): boolean {
+  try {
+    return fs.existsSync('/.dockerenv');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Compare two semantic version strings.
+ * Returns 1 if a > b, -1 if a < b, 0 if equal.
+ */
+export function compareVersions(a: string, b: string): number {
+  const aParts = a.split(/[-.]/).map(p => parseInt(p) || 0);
+  const bParts = b.split(/[-.]/).map(p => parseInt(p) || 0);
+
+  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+    const aPart = aParts[i] || 0;
+    const bPart = bParts[i] || 0;
+
+    if (aPart > bPart) return 1;
+    if (aPart < bPart) return -1;
+  }
+
+  return 0;
+}
+
+/** Check if a Docker image for the given version exists in GHCR. */
+export async function checkDockerImageExists(version: string, publishedAt?: string): Promise<boolean> {
+  try {
+    const owner = 'yeraze';
+    const repo = 'meshmonitor';
+
+    // STRATEGY 1: Query manifest directly (most reliable, avoids pagination issues)
+    // Try both with and without 'v' prefix as GHCR may use either
+    const tagsToTry = [version, `v${version}`];
+
+    for (const tag of tagsToTry) {
+      try {
+        // Step 1: Get anonymous token from GHCR
+        const tokenUrl = `https://ghcr.io/token?scope=repository:${owner}/${repo}:pull`;
+        const tokenResponse = await fetch(tokenUrl);
+
+        if (tokenResponse.ok) {
+          const tokenData = await tokenResponse.json();
+          const token = tokenData.token;
+
+          // Step 2: Try to fetch the manifest for this specific tag
+          const manifestUrl = `https://ghcr.io/v2/${owner}/${repo}/manifests/${tag}`;
+          const manifestResponse = await fetch(manifestUrl, {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Accept: 'application/vnd.docker.distribution.manifest.v2+json',
+            },
+          });
+
+          if (manifestResponse.ok) {
+            logger.info(`✓ Image for ${version} (tag: ${tag}) found in GitHub Container Registry`);
+            return true;
+          }
+        }
+      } catch (manifestError) {
+        logger.debug(`Manifest check failed for tag ${tag}:`, manifestError);
+        // Try next tag variant
+      }
+    }
+
+    // If we reach here, manifest check failed for all tag variants
+    logger.info(`⏳ Image for ${version} not found via manifest check, falling back to time-based heuristic`);
+
+    // STRATEGY 2: Time-based heuristic fallback (only if manifest check failed)
+    // GitHub Actions typically takes 10-30 minutes to build and push container images
+    // If release was published more than 30 minutes ago, assume the build completed
+    if (publishedAt) {
+      const publishTime = new Date(publishedAt).getTime();
+      const now = Date.now();
+      const minutesSincePublish = (now - publishTime) / (60 * 1000);
+
+      if (minutesSincePublish >= 30) {
+        logger.info(
+          `✓ Image for ${version} assumed ready (${Math.round(
+            minutesSincePublish
+          )} minutes since release, API check failed)`
+        );
+        return true;
+      } else {
+        logger.info(
+          `⏳ Image for ${version} still building (${Math.round(minutesSincePublish)}/30 minutes since release)`
+        );
+        return false;
+      }
+    }
+
+    // If no publish time provided and API failed, be conservative and return false
+    logger.warn(`Cannot verify image availability for ${version} (no publish time and API failed)`);
+    return false;
+  } catch (error) {
+    logger.warn(`Error checking Docker image existence for ${version}:`, error);
+    // On error with known publish time, use time-based fallback
+    if (publishedAt) {
+      const minutesSincePublish = (Date.now() - new Date(publishedAt).getTime()) / (60 * 1000);
+      const assumeReady = minutesSincePublish >= 30;
+      if (assumeReady) {
+        logger.info(
+          `✓ Image for ${version} assumed ready (${Math.round(
+            minutesSincePublish
+          )} minutes since release, error during check)`
+        );
+      }
+      return assumeReady;
+    }
+    // Otherwise fail closed to avoid false positives
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Continues the server.ts route-extraction effort tracked in #3502. This batch extracts two **cleanly-decoupled** handler groups; the remaining inline groups are genuinely coupled to server.ts-local state (see below) and were intentionally left.

## Groups extracted

**`routes/deviceRoutes.ts`** (mounted verbatim at `/`):
- `GET /device-config`
- `GET /device/backup`
- `POST /device/reboot`
- `POST /device/purge-nodedb`

All resolve the per-source manager via `resolveSourceManager` and delegate to importable services (`deviceBackupService`, `backupFileService`, `databaseService`) — zero server.ts coupling.

**`routes/systemRoutes.ts`** (mounted verbatim at `/`):
- `GET /system/status`
- `GET /status`
- `GET /version/check`
- `POST /system/restart`

Supporting helper moves:
- `isRunningInDocker`, `compareVersions`, `checkDockerImageExists`, and `serverStartTime` moved to a shared **`utils/systemInfo.ts`**. The startup auto-upgrade scheduler (`checkForAutoUpgrade`, still in server.ts) keeps using `compareVersions`/`checkDockerImageExists` via the new import.
- `gracefulShutdown` (server-lifecycle: closes the module-local HTTP `server` + managers) is injected into the route module via `setSystemCallbacks()`, matching the existing `setSettingsCallbacks` pattern — the route module never references the HTTP server.

Handler bodies were moved verbatim; auth/validation middleware preserved identically. Orphaned `deviceBackupService`/`backupFileService` imports removed from server.ts.

## Inline handler count

- Before: **98** inline `apiRouter.*` handlers
- After: **90**

## Tests

- New `routes/deviceRoutes.test.ts` (config/backup/reboot/purge happy + error paths).
- Rewrote `routes/systemRoutes.test.ts` as supertest coverage (status/version-check/restart incl. the gracefulShutdown callback and the module-level version-check cache ordering).
- Full Vitest suite: **success=true, 0 failed tests, 0 failed suites** (6751 passed). `tsc` clean. ESLint clean on new files.

## Remaining groups — too coupled to extract cleanly (left intentionally)

- **`/channels` (11)** — large mixed-concern group (CRUD + import/export + decode/encode-url + MeshCore push). The 3 channel-move helpers (`detectChannelMoves`/`snapshotChannelsBeforeChange`/`migrateMessagesIfChannelsMoved`) are self-contained, but the handlers also reach into `meshcoreManagerRegistry`, `resolveSourceManager`, and message-transform logic. Extractable but warrants its own dedicated PR for reviewability, not a "clean small batch."
- **`/nodes` (17)** — depends on `getEffectivePosition` + node-enrichment closures over server.ts state.
- **`/admin` (17)** — session-passkey / admin-command state held in server.ts.
- **`/config` (15)** — config-marshalling registry + `resolveSourceConnectionConfig`.
- **`/settings/*` (scheduler routes)** — coupled to per-source scheduler state; the existing `settingsRoutes.ts` callback-injection surface would need significant expansion.
- **`/messages/send`, `/poll`** — manager/connection state.
- **`/debug/ip`** — app/env locals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)