### PR TITLE
feat(messages): add telemetry time-range selector to Node Details

### DIFF
--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -2039,6 +2039,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                 temperatureUnit={temperatureUnit}
                 telemetryHours={telemetryVisualizationHours}
                 baseUrl={baseUrl}
+                showTimeRangeSelector
               />
               <SmartHopsGraphs
                 nodeId={selectedDMNode}


### PR DESCRIPTION
## Summary

The Node Details panel (Messages view → selected node) renders its telemetry graphs with a **fixed** `telemetryVisualizationHours` window (24h by default), so longer history couldn't be viewed there — e.g. a node whose environment readings are a few days old shows an empty environment graph even though the data exists.

The Device Info page (`InfoTab`) already exposes the **15m–7d range buttons** via `TelemetryGraphs`' `showTimeRangeSelector` prop. This enables the same on the Node Details graphs.

## Change
One line: pass `showTimeRangeSelector` to the `<TelemetryGraphs>` in `MessagesTab.tsx` (the node-details panel).

Behavior (already implemented in the component):
- Renders the range buttons above the graphs.
- Seeds from the global `telemetryVisualizationHours` as the default, and persists the user's choice (shared localStorage key with Device Info).
- When the selector is shown, `effectiveHours` follows the selected range instead of the fixed prop.

## Why
Lets users widen any selected node's telemetry to 7d to view longer history (the prompting case: a node with environment telemetry from ~4 days ago that didn't appear in the default 24h node-details view).

Scope note: `MeshCoreTelemetryView` is a favorites-dashboard, not a per-node graph, so it's intentionally untouched.

## Verification
Typecheck clean; all 28 `TelemetryGraphs` tests pass (incl. the existing `showTimeRangeSelector` cases). Built and deployed to the local dev container for manual confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)