### PR TITLE
release: v4.11.0-rc1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.10.4",
+  "version": "4.11.0-rc1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.10.4",
+  "version": "4.11.0-rc1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.10.4
-appVersion: "4.10.4"
+version: 4.11.0-rc1
+appVersion: "4.11.0-rc1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.10.4",
+  "version": "4.11.0-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.10.4",
+      "version": "4.11.0-rc1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.10.4",
+  "version": "4.11.0-rc1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Release candidate v4.11.0-rc1

Bumps the version across all five tracked locations:
- `package.json` + `package-lock.json`
- `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`)
- `desktop/package.json`
- `desktop/src-tauri/tauri.conf.json`

### What's in 4.11.0 (since 4.10.4)
- **Telemetry**: serial ingest unified onto the shared digit-aware normalizer + newer AirQualityMetrics fields + localStats/host/trafficManagement onto the canonical path (#3506, #3507, #3515)
- **Auto-ping**: match acks by destination + close the duplicate-send race (#3522)
- **Positions**: NodeInfo no longer downgrades high-precision positions; estimated_positions → DOUBLE PRECISION on PG (#3516)
- **Backup routes**: async existence check + headersSent guards (#3524)
- **Node Details**: telemetry time-range selector (15m–7d) (#3530)
- **Refactor**: large `server.ts` route-extraction effort (Refs #3502) and the test-DDL `createTestDb` migration (#3501)

### Note
`tauri.conf.json` carries the `-rc1` semver pre-release tag — fine for the SemVer/npm/Helm toolchains; if the Windows MSI desktop build is strict about pre-release suffixes it'll surface in the release builds (this is an RC, so acceptable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)