### PR TITLE
fix(map): stop mobile Features panel from blocking sidebar connect button (#3532)

### DIFF
--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1291,6 +1291,11 @@
     right: 8px;
     left: auto;
     max-width: calc(100vw - 64px);
+    /* Sit below the mobile sidebar drawer (999) and its backdrop (998) so the
+       Features panel yields when the Sources sidebar is open (#3532). When the
+       drawer is closed the backdrop is opacity:0/pointer-events:none, so this
+       has no effect on the normal map-controls interaction. */
+    z-index: 997;
   }
 
   .map-controls .map-controls-body {


### PR DESCRIPTION
## Summary

Fixes #3532. On mobile portrait, the map **Features** panel (`.map-controls`) painted on top of the slide-in Sources sidebar drawer, covering the source **Connect** button. Users had to rotate to landscape or zoom out to reach it.

## Root cause

A z-index stacking conflict on the `max-width: 768px` breakpoint:

| Element | z-index |
|---|---|
| Map Features panel (`.map-controls`) | **1000** |
| Sidebar drawer (`.dashboard-sidebar`) | 999 |
| Backdrop (`.dashboard-sidebar-backdrop`) | 998 |

The Features panel's base `z-index: 1000` was never overridden on mobile, and its `max-width: calc(100vw - 64px)` spans nearly the full viewport — so when the drawer slid in, the panel stayed on top and blocked the Connect button.

## Fix

Lower `.map-controls` to `z-index: 997` inside the existing mobile media query (`src/styles/nodes.css`) so it yields to the drawer + backdrop when the sidebar is open.

This is safe for the closed state: the backdrop is `opacity: 0; pointer-events: none` when the drawer is closed, so the map controls interact exactly as before. The panel only drops behind the overlay while the sidebar is actually open — the desired behavior.

CSS-only, behavior-preserving. No JS/state coupling between the sidebar and map components was needed.

## Testing

- `tsc --noEmit`: no new errors introduced (CSS-only change).
- Full Vitest suite: **6784 passed / 0 failed** (2298 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)