### PR TITLE
fix(meshcore): node list collapsing to a single node with multiple sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **Native OIDC group → role mapping (#3485)**: When using OIDC directly (no reverse proxy), MeshMonitor can now map identity-provider groups to roles via three new env vars: `OIDC_GROUPS_CLAIM` (default `groups`, supports dot notation like `realm_access.roles` for Keycloak), `OIDC_ADMIN_GROUPS` (comma-separated groups granted admin), and `OIDC_ALLOWED_GROUPS` (groups allowed to log in; empty = all). When `OIDC_ADMIN_GROUPS` is set, admin status tracks group membership on every login (promote and demote) and the IdP becomes authoritative; when unset, the existing first-login bootstrap + manual-promotion behaviour is preserved. `OIDC_ALLOWED_GROUPS` gates login (admins always pass). Group changes apply on next login. The dot-notation claim traversal and group normalization are shared with proxy auth (`src/server/auth/claims.ts`). No schema changes.
 
+### Bug Fixes
+
+- **MeshCore node list intermittently collapsed to a single node**: With multiple MeshCore sources, one source's node list could show just the local node even though the device had (and the DB persisted) dozens of contacts. Two causes: `refreshContacts()` cleared the in-memory contact map on *any* successful `get_contacts` response — including a transient empty read on a busy companion — and `getAllNodes()` served only that volatile in-memory map. The node list (`GET /api/sources/:id/meshcore/nodes`, dashboard map, source summaries) now merges the durable per-source `meshcore_nodes` rows with the live in-memory contacts, and an empty `get_contacts` response no longer wipes the known list. New per-source repo read `getNodesBySource(sourceId)`.
+
 ### Documentation
 
 - **SSO docs corrected and expanded (#3485)**: Documented `DISABLE_LOCAL_AUTH` in the SSO guide (it was missing) and corrected the inaccurate claim that local auth "remains available via API" when disabled — the login endpoint returns `403` unconditionally with no bypass. Added a Group → Role Mapping section with Keycloak/Authentik examples and noted the proxy-auth group vars.

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -159,6 +159,23 @@ export class MeshCoreRepository extends BaseRepository {
   }
 
   /**
+   * Get all MeshCore nodes for a single source. This is the per-source-scoped
+   * read the node list / dashboard map should use — the manager merges these
+   * durable rows with its live in-memory contacts so the UI reflects every
+   * known node even when the in-memory contact map is transiently empty
+   * (e.g. right after a reconnect).
+   */
+  async getNodesBySource(sourceId: string): Promise<DbMeshCoreNode[]> {
+    const { meshcoreNodes } = this.tables;
+    const result = await this.db
+      .select()
+      .from(meshcoreNodes)
+      .where(eq(meshcoreNodes.sourceId, sourceId))
+      .orderBy(desc(meshcoreNodes.lastHeard));
+    return this.normalizeBigInts(result) as unknown as DbMeshCoreNode[];
+  }
+
+  /**
    * Get a specific node by public key, ignoring source ownership.
    * Prefer `getNodeByPublicKeyAndSource` for write paths — this variant
    * exists for cross-source read paths that legitimately don't care which

--- a/src/server/meshcoreManager.getAllNodes.test.ts
+++ b/src/server/meshcoreManager.getAllNodes.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Regression tests for the MeshCore node list collapsing to a single node.
+ *
+ * Symptom: with two MeshCore sources, one showed ~95 nodes and the other only
+ * 1, even though the DB held all of both sources' `meshcore_nodes` rows.
+ *
+ * Two independent bugs combined to produce it:
+ *   1. `refreshContacts()` cleared the in-memory contact map on ANY successful
+ *      `get_contacts` response, including a transient empty one — wiping the
+ *      known list until adverts slowly refilled it.
+ *   2. `getAllNodes()` served only the in-memory map, so a momentarily-empty
+ *      map collapsed the served list to just the local node.
+ *
+ * The fix makes `getAllNodes()` merge durable per-source `meshcore_nodes` rows
+ * with the live in-memory contacts, and stops `refreshContacts()` from wiping
+ * on an empty response.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const getNodesBySource = vi.fn();
+const upsertNode = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      getNodesBySource: (...args: unknown[]) => getNodesBySource(...args),
+      upsertNode: (...args: unknown[]) => upsertNode(...args),
+    },
+    sources: {
+      getSource: vi.fn().mockResolvedValue({ name: 'Source A' }),
+    },
+  },
+}));
+
+vi.mock('./services/notificationService.js', () => ({
+  notificationService: {
+    notifyNewMeshCoreNode: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Any emit accessed by the contact handlers resolves to a no-op spy.
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: new Proxy({}, { get: () => vi.fn() }),
+}));
+
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+interface BridgeEvent {
+  event_type: string;
+  data: Record<string, unknown>;
+}
+
+function dispatchBridgeEvent(m: MeshCoreManager, evt: BridgeEvent): void {
+  // @ts-expect-error - exercising the private contact-event path directly
+  m.handleBridgeEvent(evt);
+}
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const KEY_B = 'b'.repeat(64);
+const KEY_C = 'c'.repeat(64);
+const KEY_LOCAL = 'd'.repeat(64);
+
+describe('MeshCoreManager.getAllNodes (node-list-collapses-to-1 regression)', () => {
+  beforeEach(() => {
+    getNodesBySource.mockReset();
+    getNodesBySource.mockResolvedValue([]);
+    upsertNode.mockClear();
+  });
+
+  it('serves persisted per-source nodes even when the in-memory contact map is empty', async () => {
+    getNodesBySource.mockResolvedValue([
+      { publicKey: KEY_B, name: 'Node B', advType: MeshCoreDeviceType.REPEATER, rssi: -80, snr: 5, latitude: 1, longitude: 2, isLocalNode: false, lastHeard: 1_700_000 },
+      { publicKey: KEY_C, name: 'Node C', advType: MeshCoreDeviceType.COMPANION, isLocalNode: false },
+    ]);
+
+    const m = new MeshCoreManager('src-a');
+    const nodes = await m.getAllNodes();
+
+    expect(getNodesBySource).toHaveBeenCalledWith('src-a');
+    expect(nodes.map((n) => n.publicKey).sort()).toEqual([KEY_B, KEY_C].sort());
+    expect(nodes.find((n) => n.publicKey === KEY_B)).toMatchObject({
+      name: 'Node B',
+      rssi: -80,
+      snr: 5,
+    });
+  });
+
+  it('overlays live in-memory contacts over persisted rows without duplicating, preserving DB-only fields', async () => {
+    // Persisted (stale) row carries battery; in-memory advert carries a fresher name.
+    getNodesBySource.mockResolvedValue([
+      { publicKey: KEY_B, name: 'Stale Name', advType: MeshCoreDeviceType.REPEATER, rssi: -95, batteryMv: 4010, isLocalNode: false },
+    ]);
+
+    const m = new MeshCoreManager('src-a');
+    dispatchBridgeEvent(m, {
+      event_type: 'contact_advertised',
+      data: { public_key: KEY_B, adv_name: 'Fresh Name', adv_type: MeshCoreDeviceType.REPEATER },
+    });
+    await flushMicrotasks();
+
+    const nodes = await m.getAllNodes();
+    const matches = nodes.filter((n) => n.publicKey === KEY_B);
+
+    expect(matches).toHaveLength(1); // deduped across DB + memory
+    expect(matches[0].name).toBe('Fresh Name'); // in-memory wins
+    expect(matches[0].batteryMv).toBe(4010); // DB-only field preserved through the merge
+  });
+
+  it('lists the live local node first and does not duplicate its persisted row', async () => {
+    getNodesBySource.mockResolvedValue([
+      { publicKey: KEY_LOCAL, name: 'Me (stale)', advType: MeshCoreDeviceType.COMPANION, isLocalNode: true },
+      { publicKey: KEY_B, name: 'Node B', advType: MeshCoreDeviceType.REPEATER, isLocalNode: false },
+    ]);
+
+    const m = new MeshCoreManager('src-a');
+    // @ts-expect-error - seed the live local node directly
+    m.localNode = { publicKey: KEY_LOCAL, name: 'Me (live)', advType: MeshCoreDeviceType.COMPANION };
+
+    const nodes = await m.getAllNodes();
+
+    expect(nodes[0]).toMatchObject({ publicKey: KEY_LOCAL, name: 'Me (live)' });
+    expect(nodes.filter((n) => n.publicKey === KEY_LOCAL)).toHaveLength(1);
+  });
+
+  it('falls back to in-memory contacts when the DB read throws', async () => {
+    getNodesBySource.mockRejectedValue(new Error('db down'));
+
+    const m = new MeshCoreManager('src-a');
+    dispatchBridgeEvent(m, {
+      event_type: 'contact_advertised',
+      data: { public_key: KEY_B, adv_name: 'B', adv_type: MeshCoreDeviceType.REPEATER },
+    });
+    await flushMicrotasks();
+
+    const nodes = await m.getAllNodes();
+    expect(nodes.map((n) => n.publicKey)).toContain(KEY_B);
+  });
+});
+
+describe('MeshCoreManager.refreshContacts (empty-response must not wipe)', () => {
+  beforeEach(() => {
+    getNodesBySource.mockReset();
+    getNodesBySource.mockResolvedValue([]);
+    upsertNode.mockClear();
+  });
+
+  it('does not clear known contacts when get_contacts returns a successful but empty list', async () => {
+    const m = new MeshCoreManager('src-a');
+    // @ts-expect-error - companion gate is required for refreshContacts to run
+    m.deviceType = MeshCoreDeviceType.COMPANION;
+
+    dispatchBridgeEvent(m, {
+      event_type: 'contact_advertised',
+      data: { public_key: KEY_B, adv_name: 'B', adv_type: MeshCoreDeviceType.REPEATER },
+    });
+    await flushMicrotasks();
+    expect(m.getContacts()).toHaveLength(1);
+
+    // @ts-expect-error - stub the private bridge call with an empty response
+    m.sendBridgeCommand = vi.fn().mockResolvedValue({ success: true, data: [] });
+    await m.refreshContacts();
+
+    expect(m.getContacts()).toHaveLength(1);
+    expect(m.getContact(KEY_B)?.advName).toBe('B');
+  });
+
+  it('still replaces the contact list when the device returns contacts', async () => {
+    const m = new MeshCoreManager('src-a');
+    // @ts-expect-error - companion gate
+    m.deviceType = MeshCoreDeviceType.COMPANION;
+
+    // @ts-expect-error - stub the private bridge call with a real contact
+    m.sendBridgeCommand = vi.fn().mockResolvedValue({
+      success: true,
+      data: [{ public_key: KEY_C, adv_name: 'C', adv_type: MeshCoreDeviceType.COMPANION }],
+    });
+    await m.refreshContacts();
+
+    expect(m.getContacts().map((c) => c.publicKey)).toEqual([KEY_C]);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1731,7 +1731,14 @@ class MeshCoreManager extends EventEmitter {
 
     try {
       const response = await this.sendBridgeCommand('get_contacts', {});
-      if (response.success && Array.isArray(response.data)) {
+      // Only clear-and-replace when the device actually returned contacts. A
+      // successful-but-empty `get_contacts` (seen as a transient read on a busy
+      // companion, e.g. right after a reconnect or mid path-refresh) must NOT
+      // wipe the known list — that would empty getAllNodes() down to just the
+      // local node until adverts slowly refill it. Issue: MeshCore node list
+      // intermittently collapses to 1 node. (DB rows survive either way; this
+      // keeps the in-memory map authoritative too.)
+      if (response.success && Array.isArray(response.data) && response.data.length > 0) {
         this.contacts.clear();
         for (const c of response.data) {
           this.contacts.set(c.public_key, {
@@ -3435,26 +3442,72 @@ class MeshCoreManager extends EventEmitter {
     return this.contacts.get(publicKey);
   }
 
-  getAllNodes(): MeshCoreNode[] {
-    const nodes: MeshCoreNode[] = [];
+  /**
+   * Full node list for this source: durable per-source `meshcore_nodes` rows
+   * merged with the live in-memory contact map and the live local node.
+   *
+   * The DB rows are the base so the list reflects every known node even when
+   * `this.contacts` is transiently empty (e.g. right after a reconnect, before
+   * `refreshContacts` has refilled it) — previously this returned only the
+   * in-memory map, so a momentarily-empty map collapsed the UI to a single
+   * node. In-memory contacts overlay the DB rows since they carry the freshest
+   * rssi/snr/position; DB-only fields (battery, uptime, radio) are preserved.
+   */
+  async getAllNodes(): Promise<MeshCoreNode[]> {
+    const byKey = new Map<string, MeshCoreNode>();
 
-    if (this.localNode) {
-      nodes.push(this.localNode);
+    try {
+      const dbNodes = await databaseService.meshcore.getNodesBySource(this.sourceId);
+      for (const n of dbNodes) {
+        if (n.isLocalNode) continue; // local node is appended live below
+        byKey.set(n.publicKey, {
+          publicKey: n.publicKey,
+          name: n.name || 'Unknown',
+          advType: (n.advType ?? MeshCoreDeviceType.UNKNOWN) as MeshCoreDeviceType,
+          lastHeard: n.lastHeard ?? undefined,
+          rssi: n.rssi ?? undefined,
+          snr: n.snr ?? undefined,
+          latitude: n.latitude ?? undefined,
+          longitude: n.longitude ?? undefined,
+          batteryMv: n.batteryMv ?? undefined,
+          uptimeSecs: n.uptimeSecs ?? undefined,
+          txPower: n.txPower ?? undefined,
+          maxTxPower: n.maxTxPower ?? undefined,
+          radioFreq: n.radioFreq ?? undefined,
+          radioBw: n.radioBw ?? undefined,
+          radioSf: n.radioSf ?? undefined,
+          radioCr: n.radioCr ?? undefined,
+        });
+      }
+    } catch (err) {
+      logger.warn(
+        `[MeshCore:${this.sourceId}] getAllNodes: DB read failed, falling back to in-memory contacts: ${(err as Error).message}`,
+      );
     }
 
+    // Overlay live in-memory contacts (freshest rssi/snr/position), merging
+    // over any persisted row so DB-only fields aren't lost.
     for (const contact of this.contacts.values()) {
-      nodes.push({
+      const base = byKey.get(contact.publicKey);
+      byKey.set(contact.publicKey, {
+        ...base,
         publicKey: contact.publicKey,
-        name: contact.advName || contact.name || 'Unknown',
-        advType: contact.advType || MeshCoreDeviceType.UNKNOWN,
-        lastHeard: contact.lastSeen,
-        rssi: contact.rssi,
-        snr: contact.snr,
-        latitude: contact.latitude,
-        longitude: contact.longitude,
+        name: contact.advName || contact.name || base?.name || 'Unknown',
+        advType: (contact.advType ?? base?.advType ?? MeshCoreDeviceType.UNKNOWN) as MeshCoreDeviceType,
+        lastHeard: contact.lastSeen ?? base?.lastHeard,
+        rssi: contact.rssi ?? base?.rssi,
+        snr: contact.snr ?? base?.snr,
+        latitude: contact.latitude ?? base?.latitude,
+        longitude: contact.longitude ?? base?.longitude,
       });
     }
 
+    const nodes: MeshCoreNode[] = [];
+    if (this.localNode) {
+      nodes.push(this.localNode);
+      byKey.delete(this.localNode.publicKey);
+    }
+    nodes.push(...byKey.values());
     return nodes;
   }
 

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -348,7 +348,7 @@ router.post('/disconnect', meshcoreDeviceLimiter, requireAuth(), requirePermissi
  */
 router.get('/nodes', optionalAuth(), requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
-    const nodes = managerFor(req).getAllNodes();
+    const nodes = await managerFor(req).getAllNodes();
     res.json({
       success: true,
       data: nodes,
@@ -1186,7 +1186,7 @@ router.get('/snapshot', optionalAuth(), requirePermission('connection', 'read', 
     const status = manager.getConnectionStatus();
     const localNode = manager.getLocalNode();
     const contacts = manager.getContacts();
-    const nodes = manager.getAllNodes();
+    const nodes = await manager.getAllNodes();
     const messages = manager.getRecentMessages(50);
     const seqCursor = messages.length > 0 ? Math.max(...messages.map(m => m.timestamp)) : 0;
 

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -816,7 +816,7 @@ router.get('/:id/status', optionalAuth(), async (req: Request, res: Response) =>
     if (source.type === 'meshcore') {
       const mcManager = meshcoreManagerRegistry.get(source.id);
       if (mcManager) {
-        const all = mcManager.getAllNodes();
+        const all = await mcManager.getAllNodes();
         nodeCount = all.length;
         const cutoffMs = Date.now() - 7_200_000;
         const localHasLastHeard = mcManager.getLocalNode()?.lastHeard != null;
@@ -941,7 +941,7 @@ router.get('/:id/nodes', requirePermission('nodes', 'read', { sourceIdFrom: 'par
       const mcManager = meshcoreManagerRegistry.get(source.id);
       const mcNodes: any[] = [];
       if (mcManager) {
-        for (const n of mcManager.getAllNodes()) {
+        for (const n of await mcManager.getAllNodes()) {
           if (n.latitude == null || n.longitude == null) continue;
           if (n.latitude === 0 && n.longitude === 0) continue;
           const lastHeard = typeof n.lastHeard === 'number'

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -1242,7 +1242,7 @@ router.get('/status', async (req: Request, res: Response) => {
     for (const id of meshcoreAllowedIds) {
       const mcManager = meshcoreManagerRegistry.get(id);
       if (mcManager) {
-        const all = mcManager.getAllNodes();
+        const all = await mcManager.getAllNodes();
         mcNodeCount += all.length;
         const localHasLastHeard = mcManager.getLocalNode()?.lastHeard != null;
         mcActiveNodeCount += all.filter((n: any, i: number) => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1186,7 +1186,7 @@ apiRouter.get('/nodes', optionalAuth(), async (req, res) => {
     const includeAllMeshcore = req.query.includeAllMeshcore === 'true';
     const meshcoreNodes: any[] = [];
     for (const mgr of meshcoreManagers) {
-      for (const n of mgr.getAllNodes()) {
+      for (const n of await mgr.getAllNodes()) {
         const hasPosition = n.latitude != null && n.longitude != null && !(n.latitude === 0 && n.longitude === 0);
         if (!hasPosition && !includeAllMeshcore) continue;
         const lastHeard = typeof n.lastHeard === 'number'


### PR DESCRIPTION
## Summary
With multiple MeshCore sources, one source's node list could intermittently collapse to just the local node (e.g. one source showing 95 nodes, another showing 1) even though the device had — and the database had persisted — dozens of contacts. This was a **read-path** bug, not a data/processing bug: both sources' `meshcore_nodes` rows were present and fresh in the DB.

Diagnosed against a live two-MeshCore-source instance: the DB held 94 and 95 nodes for the two sources respectively, both freshly written, yet the UI served 1 for one of them.

## Root cause
Two independent issues combined:

1. **`refreshContacts()` wiped the in-memory contact map on a transient empty read.** It called `this.contacts.clear()` on *any* `response.success && Array.isArray(response.data)` — including a successful-but-empty `get_contacts`, which a busy companion can return right after a reconnect or mid path-refresh (these refreshes are debounced off every `PathUpdated` push). The list then stayed empty until adverts slowly refilled it.
2. **`getAllNodes()` served only the volatile in-memory map** (`this.localNode` + `this.contacts`), never the durable per-source DB rows. So a momentarily-empty map collapsed the served list to a single node.

## Changes
- `MeshCoreManager.getAllNodes()` is now async and **merges** the durable per-source `meshcore_nodes` rows with the live in-memory contacts: DB rows are the base (so the list survives in-memory churn), in-memory contacts overlay them for freshness (rssi/snr/position), and DB-only fields (battery/uptime/radio) are preserved through the merge. The live local node is listed first and de-duplicated against its persisted row.
- `refreshContacts()` now only clears+replaces when `get_contacts` returns at least one entry — an empty response no longer wipes the known list.
- New per-source repo read `MeshCoreRepository.getNodesBySource(sourceId)` (the existing `getAllNodes()` was global/unscoped).
- Updated all callers of the now-async manager `getAllNodes()` to await: `meshcoreRoutes` (`/nodes`, `/status`), `sourceRoutes` (node count + map), `unifiedRoutes` (aggregate counts), and the server-side map aggregation in `server.ts`.

## Issues Resolved
None filed — reported directly. Relates to the multi-source MeshCore work.

## Documentation Updates
- CHANGELOG.md — Unreleased → Bug Fixes entry.

## Testing
- [x] Full unit suite passes (7381 tests, 0 failures)
- [x] TypeScript compiles cleanly
- [x] New `src/server/meshcoreManager.getAllNodes.test.ts` (6 tests): DB-backed list when in-memory empty; in-memory overlay without duplication preserving DB-only fields; live local node first + de-duped; DB-failure fallback to in-memory; empty `get_contacts` does not wipe; non-empty `get_contacts` still replaces.
- [ ] Reviewer / maintainer: on a multi-MeshCore-source deployment, confirm each source's node list reflects its persisted `meshcore_nodes` count and no longer drops to 1 after a reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)