### PR TITLE
feat(meshcore): virtual node — connect the MeshCore app to a node through MeshMonitor over WiFi (#3535)

### DIFF
--- a/.claude/commands/ci-monitor.md
+++ b/.claude/commands/ci-monitor.md
@@ -1,6 +1,6 @@
 # CI Monitor & Auto-Fix
 
-Monitor a PR's CI pipeline, auto-diagnose failures, apply targeted fixes, and re-push until green.
+Monitor a PR's CI pipeline, auto-diagnose failures, apply targeted fixes, and re-push until green — then review the PR feedback (automated review bots + human reviewers) and address any concerns raised.
 
 ## Usage
 
@@ -82,6 +82,34 @@ After pushing the fix:
 2. Run `bash scripts/watch-ci.sh -q <PR_NUMBER>` again — back to Phase 1's exit-code dispatch
 3. **Maximum 3 fix cycles** — if CI is still red after 3 attempts, stop and report what was tried
 
+### Phase 5: Review feedback
+
+Once CI is green, the PR can still have **review concerns** that are not CI failures — comments from the Claude Code Review bot, and reviews/inline threads from human reviewers. A green checkmark is not "done"; address the feedback too.
+
+1. Gather the feedback (run after CI is green, and again after each push since new comments may arrive):
+   ```bash
+   # Top-level reviews (APPROVED / CHANGES_REQUESTED / COMMENTED) + their summary bodies
+   gh pr view <PR_NUMBER> --json reviews,comments \
+     -q '.reviews[] | "\(.author.login) [\(.state)]: \(.body)"'
+   # Inline review comments anchored to specific lines (the bot posts here)
+   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments \
+     -q '.[] | "\(.user.login) \(.path):\(.line) — \(.body)"'
+   ```
+2. **Triage each concern** — do not blanket-apply or blanket-ignore:
+   - **Real bug / correctness / security issue** → fix it (same minimal-diff discipline as Phase 3).
+   - **Valid improvement** (naming, edge case, missing test, simplification) → apply it.
+   - **False positive / out-of-scope / intentional** → do NOT silently ignore. Leave a brief reply on the thread explaining why, so the reviewer sees it was considered.
+   - **Ambiguous or a judgment call you're not sure about** → surface it to the user rather than guessing.
+3. **Apply fixes** as one or more focused commits (group related concerns; reference the comment, e.g. `address review: <concern>`). Push.
+4. **Close the loop on each thread** so reviewers know it's handled — reply with the commit SHA that addressed it, or the reason it won't change:
+   ```bash
+   gh pr comment <PR_NUMBER> --body "Addressed in <sha>: <what changed>"
+   # or reply to a specific inline thread:
+   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments/<comment_id>/replies -f body="..."
+   ```
+5. Any push re-triggers CI → **go back to Phase 1** and re-verify green before considering the feedback resolved. Re-check for new comments after each round (a review may respond to your fix).
+6. **Bound the effort** like the fix loop: at most a few feedback rounds. If concerns are large, contradictory, or you disagree, stop and hand the open items to the user rather than churning.
+
 ### Reporting
 
 When complete (success or max attempts reached), output a summary:
@@ -96,10 +124,17 @@ When complete (success or max attempts reached), output a summary:
 1. [Cycle 1] Fixed: <description> — Files: <list>
 2. [Cycle 2] Fixed: <description> — Files: <list>
 
+### Review Feedback
+- <reviewer/bot>: <concern> → Addressed in <sha> / Declined (<reason>) / Deferred to user
+- (or "No review feedback raised")
+
 ### Final CI Status
 - PR Tests: PASS/FAIL
 - CI: PASS/FAIL
 - Claude Code Review: PASS/FAIL
+
+### Open Items (if any)
+- <concerns handed back to the user — judgment calls, large refactors, disagreements>
 ```
 
 ## Important Rules
@@ -109,3 +144,5 @@ When complete (success or max attempts reached), output a summary:
 - **Always run failing tests locally before pushing** — don't push blind fixes
 - **Check that the branch is up to date** before applying fixes
 - **Don't poll `gh run list` in a loop yourself.** Delegate the wait to `scripts/watch-ci.sh -q <PR>` and dispatch on its exit code. That's the whole point of the script — it keeps polling output out of the model's context.
+- **Green CI is not the finish line** — check PR review feedback (Phase 5) before declaring done.
+- **Never silently ignore a review concern.** Fix it, or reply explaining why not. Don't blindly apply every suggestion either — use judgment and escalate genuine disagreements to the user.

--- a/.claude/skills/ci-monitor.md
+++ b/.claude/skills/ci-monitor.md
@@ -1,6 +1,6 @@
 # CI Monitor & Auto-Fix
 
-Monitor a PR's CI pipeline, auto-diagnose failures, apply targeted fixes, and re-push until green.
+Monitor a PR's CI pipeline, auto-diagnose failures, apply targeted fixes, and re-push until green — then review the PR feedback (automated review bots + human reviewers) and address any concerns raised.
 
 ## Usage
 
@@ -82,6 +82,34 @@ After pushing the fix:
 2. Run `bash scripts/watch-ci.sh -q <PR_NUMBER>` again — back to Phase 1's exit-code dispatch
 3. **Maximum 3 fix cycles** — if CI is still red after 3 attempts, stop and report what was tried
 
+### Phase 5: Review feedback
+
+Once CI is green, the PR can still have **review concerns** that are not CI failures — comments from the Claude Code Review bot, and reviews/inline threads from human reviewers. A green checkmark is not "done"; address the feedback too.
+
+1. Gather the feedback (run after CI is green, and again after each push since new comments may arrive):
+   ```bash
+   # Top-level reviews (APPROVED / CHANGES_REQUESTED / COMMENTED) + their summary bodies
+   gh pr view <PR_NUMBER> --json reviews,comments \
+     -q '.reviews[] | "\(.author.login) [\(.state)]: \(.body)"'
+   # Inline review comments anchored to specific lines (the bot posts here)
+   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments \
+     -q '.[] | "\(.user.login) \(.path):\(.line) — \(.body)"'
+   ```
+2. **Triage each concern** — do not blanket-apply or blanket-ignore:
+   - **Real bug / correctness / security issue** → fix it (same minimal-diff discipline as Phase 3).
+   - **Valid improvement** (naming, edge case, missing test, simplification) → apply it.
+   - **False positive / out-of-scope / intentional** → do NOT silently ignore. Leave a brief reply on the thread explaining why, so the reviewer sees it was considered.
+   - **Ambiguous or a judgment call you're not sure about** → surface it to the user rather than guessing.
+3. **Apply fixes** as one or more focused commits (group related concerns; reference the comment, e.g. `address review: <concern>`). Push.
+4. **Close the loop on each thread** so reviewers know it's handled — reply with the commit SHA that addressed it, or the reason it won't change:
+   ```bash
+   gh pr comment <PR_NUMBER> --body "Addressed in <sha>: <what changed>"
+   # or reply to a specific inline thread:
+   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments/<comment_id>/replies -f body="..."
+   ```
+5. Any push re-triggers CI → **go back to Phase 1** and re-verify green before considering the feedback resolved. Re-check for new comments after each round (a review may respond to your fix).
+6. **Bound the effort** like the fix loop: at most a few feedback rounds. If concerns are large, contradictory, or you disagree, stop and hand the open items to the user rather than churning.
+
 ### Reporting
 
 When complete (success or max attempts reached), output a summary:
@@ -96,10 +124,17 @@ When complete (success or max attempts reached), output a summary:
 1. [Cycle 1] Fixed: <description> — Files: <list>
 2. [Cycle 2] Fixed: <description> — Files: <list>
 
+### Review Feedback
+- <reviewer/bot>: <concern> → Addressed in <sha> / Declined (<reason>) / Deferred to user
+- (or "No review feedback raised")
+
 ### Final CI Status
 - PR Tests: PASS/FAIL
 - CI: PASS/FAIL
 - Claude Code Review: PASS/FAIL
+
+### Open Items (if any)
+- <concerns handed back to the user — judgment calls, large refactors, disagreements>
 ```
 
 ## Important Rules
@@ -109,3 +144,5 @@ When complete (success or max attempts reached), output a summary:
 - **Always run failing tests locally before pushing** — don't push blind fixes
 - **Check that the branch is up to date** before applying fixes
 - **Don't poll `gh run list` in a loop yourself.** Delegate the wait to `scripts/watch-ci.sh -q <PR>` and dispatch on its exit code. That's the whole point of the script — it keeps polling output out of the model's context.
+- **Green CI is not the finish line** — check PR review feedback (Phase 5) before declaring done.
+- **Never silently ignore a review concern.** Fix it, or reply explaining why not. Don't blindly apply every suggestion either — use judgment and escalate genuine disagreements to the user.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,6 +57,7 @@ services:
       - "4503:4503"  # Per-source VN
       - "4504:4504"  # Per-source VN
       - "4505:4505"  # Per-source VN
+      - "5000:5000"  # MeshCore Virtual Node (#3535)
       - "1883:1883"  # Embedded MQTT broker (issue #3003)
     restart: unless-stopped
     volumes:
@@ -104,6 +105,7 @@ services:
       - "4503:4503"  # Per-source VN
       - "4504:4504"  # Per-source VN
       - "4505:4505"  # Per-source VN
+      - "5000:5000"  # MeshCore Virtual Node (#3535)
       - "1883:1883"  # Embedded MQTT broker (issue #3003)
     restart: unless-stopped
     extra_hosts:
@@ -175,6 +177,7 @@ services:
       - "4503:4503"  # Per-source VN
       - "4504:4504"  # Per-source VN
       - "4505:4505"  # Per-source VN
+      - "5000:5000"  # MeshCore Virtual Node (#3535)
       - "1883:1883"  # Embedded MQTT broker (issue #3003)
     restart: unless-stopped
     volumes:

--- a/docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md
+++ b/docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md
@@ -2,7 +2,14 @@
 
 **Issue:** [#3535](https://github.com/Yeraze/meshmonitor/issues/3535) — expose a real MeshCore node, that MeshMonitor already manages, as a virtual node the MeshCore **mobile app** can connect to over WiFi/TCP.
 
-**Status:** Phase 0 (handshake) implemented — see "Phasing" below. Phases 1-3 pending.
+**Status:** Phases 0–2 implemented and verified against the real MeshCore
+(`meshcore-flutter`) app over WiFi — see "Phasing" below. Phase 3 (config writes +
+DM delivery receipts) pending.
+
+> **Verified end-to-end:** the app connects over WiFi, shows the node identity,
+> loads contacts + channels, and sends/receives channel messages through the real
+> node (incl. an auto-responder round-trip). Two protocol subtleties were found
+> only by watching the live command stream and are captured below.
 
 > **Confirmed prerequisite:** the MeshCore mobile app supports a WiFi/TCP companion
 > connection. Without that this feature would be impossible (MeshMonitor is
@@ -164,14 +171,27 @@ is **always** refused regardless of the gate. All connects/admin-forwards are au
   **Exit criterion (pending hardware):** the real MeshCore app connects over WiFi and shows
   the node as connected with its correct name/identity. The automated round-trip tests give
   high confidence ahead of that manual check.
-- **Phase 1 — Read-only mirror.** Contacts, channels (`GetChannel`/`ChannelInfo`), message
-  history via `SyncNextMessage` (`ContactMsgRecv`/`ChannelMsgRecv`), battery/stats/telemetry
-  reads. App shows real contacts, history, telemetry — all from DB.
-- **Phase 2 — Send path.** `SendTxtMsg`/`SendChannelTxtMsg` forwarded through
-  `meshcoreManager`; `Sent`(6) ack; live `MsgWaiting`(0x83) push on incoming so the app
-  syncs new messages; `SendConfirmed`(0x82) when the node confirms delivery.
-- **Phase 3 — Admin/config + UX.** Admin-gated config commands, source-config UI toggle +
-  port, status/among-clients indicator, docs (`docs/features/meshcore.md`), audit logging.
+- **Phase 1 — Read-only mirror. ✅ IMPLEMENTED.** Contacts (`GetContacts`), channels
+  (`GetChannel`/`ChannelInfo`), battery (`GetBatteryVoltage`), and live incoming messages
+  via the `MsgWaiting`(0x83) push → `SyncNextMessage` → `ContactMsgRecv`/`ChannelMsgRecv`.
+  `SetFloodScope` is acked as a no-op so the app doesn't treat it as fatal. Per-client
+  message queue seeds empty (no history replay → no dupes on reconnect).
+- **Phase 2 — Send path. ✅ IMPLEMENTED.** `SendChannelTxtMsg`/`SendTxtMsg` forwarded
+  through `meshcoreManager.sendMessage`; DM prefixes resolved to full keys via the contact
+  list.
+- **Phase 3 — Admin/config + DM receipts. ⏳ PENDING.** Admin-gated config commands
+  (`SetRadioParams`, `SetAdvertName`, …), and DM delivery receipts: relay the node's real
+  `expectedAckCrc` (currently logged-but-discarded by `sendMessage`) so the
+  `SendConfirmed`(0x82) push can be correlated and the app shows the delivered tick.
+
+### Protocol subtleties found in testing (don't regress these)
+- **Channel send acks `Ok`, DM send acks `Sent`.** meshcore.js's `sendChannelTextMessage`
+  awaits `Ok`(0) (fire-and-forget broadcast); `sendTextMessage` (DM) awaits `Sent`(6) (carries
+  the ack CRC). Replying `Sent` to a channel send hangs the app's send promise forever.
+- **The `channel-N` marker moves fields by direction.** `meshcoreManager` tags channel
+  messages with the synthetic `channel-N` key in `toPublicKey` for messages we *sent* but in
+  `fromPublicKey` for messages we *received* (`toPublicKey` unset on RX). Detect it in both
+  fields, or incoming channel replies get mis-encoded as a `ContactMsgRecv` and dropped.
 
 ## 6. Key risks & how the plan retires them
 

--- a/docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md
+++ b/docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md
@@ -1,0 +1,202 @@
+# MeshCore Virtual Node — Design Plan
+
+**Issue:** [#3535](https://github.com/Yeraze/meshmonitor/issues/3535) — expose a real MeshCore node, that MeshMonitor already manages, as a virtual node the MeshCore **mobile app** can connect to over WiFi/TCP.
+
+**Status:** Phase 0 (handshake) implemented — see "Phasing" below. Phases 1-3 pending.
+
+> **Confirmed prerequisite:** the MeshCore mobile app supports a WiFi/TCP companion
+> connection. Without that this feature would be impossible (MeshMonitor is
+> headless/Docker and cannot present a BLE peripheral). With it, the feature
+> reduces to "implement the *device end* of the companion frame protocol over a
+> TCP server."
+
+---
+
+## 1. Goal & non-goals
+
+**Goal.** A user whose phone cannot reach a MeshCore node directly (no BLE/USB range)
+points the MeshCore app at `meshmonitor-host:PORT`. MeshMonitor answers the companion
+protocol as if it *were* that node: the app sees the node's identity, contacts,
+channels, message history, and telemetry, and can send messages / issue commands that
+MeshMonitor relays to the real node it already holds the companion slot on.
+
+**Non-goals (initial scope).**
+- Not a BLE bridge — TCP/WiFi only (matches our existing transport story; see `meshcoreNativeBackend.ts`).
+- Not a generic MeshCore-protocol simulator / test fixture — it is a *bridge to a real node*.
+- Not multi-node aggregation — one virtual node maps to exactly one MeshCore source.
+
+## 2. Why this is "implement the device end," not "passthrough"
+
+MeshMonitor **already occupies the real node's single companion slot** via
+`meshcore.js` (`TCPConnection` / `NodeJSSerialConnection` in
+`src/server/meshcoreNativeBackend.ts`). We therefore **cannot** transparently splice the
+phone's socket onto the node's companion link — there is only one slot and we hold it.
+
+So, exactly like the existing **Meshtastic** `src/server/virtualNodeServer.ts`, this must be
+a **synthesize-and-proxy** server:
+
+- **Reads** (contacts, self-info, time, message history, channels, telemetry) are
+  **answered from MeshMonitor's mirrored DB state** for this source.
+- **Writes** (send message, set name, set radio params, …) are **forwarded to the real
+  node** through the existing `meshcoreManager` for that source.
+
+The Meshtastic VN is the proven template for every cross-cutting concern (multi-client TCP
+server, framing, per-client buffers, inactivity cleanup, audit logging, an
+`allowAdminCommands` safety gate, broadcast-on-incoming). We mirror its structure and swap
+the wire protocol.
+
+## 3. The MeshCore companion wire protocol (from `@liamcottle/meshcore.js` v1.13.0)
+
+### 3.1 Framing (TCP)
+
+Source: `src/connection/tcp_connection.js`, `connection.js`, `constants.js`.
+
+```
+frame = [ frameType:u8 ] [ frameLength:u16 little-endian ] [ payload:frameLength bytes ]
+        frameType 0x3c '<'  = app  -> node   (commands)
+        frameType 0x3e '>'  = node -> app    (responses + pushes)
+        payload[0]          = command / response / push code (see below)
+```
+
+- The app **writes** `0x3c` frames (`sendToRadioFrame`). Our server **reads** these.
+- The node **writes** `0x3e` frames. Our server **emits** these.
+- BLE uses GATT characteristics instead of the length-prefixed framing, but we are
+  TCP-only, so the 3-byte header above is the whole framing story.
+
+> Contrast with Meshtastic VN, whose header is `0x94 0xc3 <len:u16 BE>`. MeshCore is
+> `0x3c|0x3e <len:u16 LE>`. Same *idea*, different magic + endianness + a type byte.
+
+### 3.2 Codes we must handle (`Constants` in `constants.js`)
+
+**Commands the app sends → we must answer (`CommandCodes`):**
+
+| Code | Command | Phase | Server behaviour |
+|---:|---|:--:|---|
+| 1 | `AppStart` | 0 | Reply `SelfInfo`(5) for the real node's identity |
+| 5 | `GetDeviceTime` | 0 | Reply `CurrTime`(9) |
+| 6 | `SetDeviceTime` | 3 | Forward to node (or no-op + `Ok`) |
+| 4 | `GetContacts` | 1 | Reply `ContactsStart`(2), N×`Contact`(3), `EndOfContacts`(4) from DB |
+| 10 | `SyncNextMessage` | 1 | Drain mirrored inbox: `ContactMsgRecv`(7)/`ChannelMsgRecv`(8) or `NoMoreMessages`(10) |
+| 31 | `GetChannel` | 1 | Reply `ChannelInfo`(18) from DB |
+| 2 | `SendTxtMsg` | 2 | Forward to node via `meshcoreManager`; reply `Sent`(6); later `SendConfirmed`(0x82) push |
+| 3 | `SendChannelTxtMsg` | 2 | Forward to node; reply `Sent`(6) |
+| 7 | `SendSelfAdvert` | 3 | Forward to node |
+| 8 | `SetAdvertName` | 3 | Forward to node (admin-gated) |
+| 11/12/38 | `SetRadioParams`/`SetTxPower`/`SetOtherParams` | 3 | Forward to node (admin-gated) |
+| 20 | `GetBatteryVoltage` | 1 | Reply `BatteryVoltage`(12) from DB telemetry |
+| 22 | `DeviceQuery` | 0 | Reply `DeviceInfo`(13) |
+| 56 | `GetStats` | 1 | Reply `Stats`(24) from DB |
+| 39/50 | `SendTelemetryReq`/`SendBinaryReq` | 2 | Forward to node; relay `TelemetryResponse`(0x8B)/`BinaryResponse`(0x8C) push |
+
+**Responses we must *encode* (`ResponseCodes`):** `Ok`(0), `Err`(1), `ContactsStart`(2),
+`Contact`(3), `EndOfContacts`(4), `SelfInfo`(5), `Sent`(6), `ContactMsgRecv`(7),
+`ChannelMsgRecv`(8), `CurrTime`(9), `NoMoreMessages`(10), `BatteryVoltage`(12),
+`DeviceInfo`(13), `ChannelInfo`(18), `Stats`(24).
+
+**Pushes we must *emit* on live events (`PushCodes`):** `Advert`(0x80), `SendConfirmed`(0x82),
+`MsgWaiting`(0x83), `TelemetryResponse`(0x8B), `BinaryResponse`(0x8C). `MsgWaiting` is the
+key one — emitted when a new mesh message arrives for this source so the app knows to call
+`SyncNextMessage`.
+
+### 3.3 The encoding problem (the real work)
+
+`meshcore.js` is a **client**: it *decodes* `0x3e` frames (`onFrameReceived` →
+`packet.js`, `advert.js`, `buffer_reader.js`) and *encodes* `0x3c` command frames. We need
+the **inverse**: encode `0x3e` responses/pushes and decode `0x3c` commands.
+
+- **Decoders → our encoders.** Every field layout we need to *emit* is already pinned down
+  by meshcore.js's *decoder* for that same struct (it has to parse what the firmware sends).
+  We invert those readers using `BufferWriter` (`buffer_writer.js`) — e.g. read the
+  `SelfInfo` decoder to learn the exact byte order of `{adv_type, tx_power, lat, lon,
+  radio_freq, radio_bw, radio_sf, radio_cr, name, public_key}`, then write it back in the
+  same order.
+- **Cross-check against firmware.** Where meshcore.js is ambiguous or marked `// todo`,
+  confirm against the MeshCore firmware companion serial handler (`CommandFrame` /
+  `sendSelfInfo` etc.) before trusting the layout.
+- We will add a small `meshcoreCompanionCodec.ts` (encode responses/pushes, decode
+  commands) with unit tests that **round-trip against meshcore.js's own decoders** — i.e.
+  feed our encoder output into `meshcore.js`'s parser and assert it reads back what we put
+  in. That gives high-confidence fidelity without a physical device.
+
+## 4. Proposed architecture
+
+```
+ MeshCore app (phone, WiFi)
+        │  TCP  0x3c/0x3e frames
+        ▼
+ MeshCoreVirtualNodeServer  (NEW: src/server/meshcoreVirtualNodeServer.ts)
+   • net.Server, per-client buffers, 3-byte framing
+   • decode 0x3c command  ──► dispatch
+        ├─ read  ► synthesize 0x3e response from DB (meshcore repos)
+        └─ write ► meshcoreManager.<send/admin>()  ► real node
+   • on live mesh event (meshcoreManager emits) ► 0x3e push (MsgWaiting/Advert/SendConfirmed)
+        ▲
+        │ uses
+ meshcoreCompanionCodec.ts  (NEW: encode resp/push, decode cmd; round-trip tested)
+ meshcoreManager / meshcore repositories (EXISTING: state + write path)
+```
+
+**Lifecycle & ownership.** One `MeshCoreVirtualNodeServer` per MeshCore source, owned by
+that source's `meshcoreManager`, started/stopped with the source. Config lives on the
+source row (`sources.config.virtualNode = { enabled, port, allowAdminCommands }`), mirroring
+the Meshtastic `VirtualNodeConfig` shape so the existing source-config UI extends naturally.
+
+**Identity.** `SelfInfo` advertises the **real node's** public key + name (already captured
+by `meshcoreManager`). This is essential: the phone's contacts and any PKI the app displays
+must line up with the physical node, since the real node — not the app — performs LoRa
+crypto in companion mode. The app↔VN link is plaintext companion frames over local WiFi.
+
+**Safety.** Reuse the Meshtastic VN's `allowAdminCommands` gate (default **false**). With it
+off, read + send-message work, but config-mutating commands (`SetRadioParams`, `SetAdvertName`,
+`ImportPrivateKey`, `Reboot`, …) are refused with `Err`(1)/`Disabled`(15). `ExportPrivateKey`(23)
+is **always** refused regardless of the gate. All connects/admin-forwards are audit-logged.
+
+## 5. Phasing (one mergeable PR per phase, behaviour-preserving, green-CI gated)
+
+- **Phase 0 — Spike / handshake (de-risk first). ✅ IMPLEMENTED.** TCP server + framing +
+  codec for `AppStart→SelfInfo`, `GetDeviceTime→CurrTime`, `DeviceQuery→DeviceInfo`,
+  `GetContacts→`empty, `SyncNextMessage→NoMoreMessages`, `SetDeviceTime→Ok`, unsupported
+  →`Err(UnsupportedCmd)`. Wired into `meshcoreManager` lifecycle (start after local-node
+  refresh, stop on disconnect), config via `sources.config.virtualNode`
+  (`meshcoreRegistry.meshcoreConfigFromSource`), and a dashboard Source-config UI (enable
+  toggle + port). Encoder fidelity is unit-tested by **round-tripping through meshcore.js's
+  own decoders**; the server handshake is covered by a loopback-socket integration test.
+  **Exit criterion (pending hardware):** the real MeshCore app connects over WiFi and shows
+  the node as connected with its correct name/identity. The automated round-trip tests give
+  high confidence ahead of that manual check.
+- **Phase 1 — Read-only mirror.** Contacts, channels (`GetChannel`/`ChannelInfo`), message
+  history via `SyncNextMessage` (`ContactMsgRecv`/`ChannelMsgRecv`), battery/stats/telemetry
+  reads. App shows real contacts, history, telemetry — all from DB.
+- **Phase 2 — Send path.** `SendTxtMsg`/`SendChannelTxtMsg` forwarded through
+  `meshcoreManager`; `Sent`(6) ack; live `MsgWaiting`(0x83) push on incoming so the app
+  syncs new messages; `SendConfirmed`(0x82) when the node confirms delivery.
+- **Phase 3 — Admin/config + UX.** Admin-gated config commands, source-config UI toggle +
+  port, status/among-clients indicator, docs (`docs/features/meshcore.md`), audit logging.
+
+## 6. Key risks & how the plan retires them
+
+| Risk | Mitigation |
+|---|---|
+| **Encoder byte-fidelity** (firmware expects exact layout) | Invert meshcore.js decoders; **round-trip unit tests** through meshcore.js's own parser; Phase-0 spike against a real app before building further |
+| **Companion protocol version** (`SupportedCompanionProtocolVersion = 1`) | `SelfInfo`/`DeviceInfo` advertise v1; pin and assert in tests; revisit if app negotiates higher |
+| **Slot exclusivity** (one companion slot) | Non-issue by design — we synthesize from DB, never passthrough; the real slot stays held by `meshcoreManager` |
+| **`// todo` gaps in meshcore.js** (`SendLogin`, `SendStatusReq`, tuning) | Cross-check firmware source for those layouts; defer non-essential commands, answer `UnsupportedCmd`(1) until implemented |
+| **Crypto / key exposure** | App↔VN is plaintext local WiFi; node does LoRa crypto. Never expose `ExportPrivateKey`; bind server to a configurable interface; document the trust boundary |
+| **Multi-source bleed** | Server is per-source; every DB read scoped by `sourceId` (project invariant) |
+
+## 7. New / touched files (estimate)
+
+- **New:** `src/server/meshcoreVirtualNodeServer.ts`, `src/server/meshcoreCompanionCodec.ts`,
+  `*.test.ts` for both (incl. round-trip-vs-meshcore.js tests).
+- **Touched:** `meshcoreManager.ts` (own/start/stop server, emit live events, expose
+  send/admin entry points), source-config schema + UI for `virtualNode`, `docs/features/meshcore.md`.
+- **Reference, not reused:** `src/server/virtualNodeServer.ts` (Meshtastic) — structural template.
+
+## 8. Open questions to confirm before Phase 1
+
+1. Which app build/version is the target, and does it pin companion protocol v1?
+2. Default port — reuse MeshCore's conventional companion TCP port (4403) or a distinct
+   MeshMonitor port to avoid colliding with a node also exposed on the LAN?
+3. Telemetry/binary-request relay: does the app tolerate VN synthesizing telemetry from DB,
+   or must those always round-trip to the live node? (Phase 2 forwards; Phase 1 may synth.)
+```

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -502,6 +502,18 @@ function DashboardInner() {
           autoConnect: formAutoConnect,
         };
       }
+
+      // Virtual Node server (opt-in): expose this MeshCore node to the MeshCore
+      // mobile app over WiFi/TCP (#3535). Shares the formVn* state with the
+      // Meshtastic form.
+      if (formVnEnabled) {
+        const vnPort = parseInt(formVnPort, 10);
+        if (isNaN(vnPort) || vnPort < 1 || vnPort > 65535) {
+          setFormError(t('source.form.error_vn_port_range'));
+          return;
+        }
+        cfg.virtualNode = { enabled: true, port: vnPort, allowAdminCommands: false };
+      }
     } else {
       if (!formHost.trim()) { setFormError(t('source.form.error_host_required')); return; }
       const port = parseInt(formPort, 10);
@@ -1426,6 +1438,35 @@ function DashboardInner() {
                 <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '0 0 8px 24px' }}>
                   {t('source.form.auto_connect_help')}
                 </p>
+
+                <fieldset style={{ border: '1px solid var(--ctp-surface1)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
+                  <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--ctp-subtext0)' }}>{t('source.form.virtual_node')}</legend>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, marginTop: 4 }}>
+                    <input
+                      type="checkbox"
+                      checked={formVnEnabled}
+                      onChange={(e) => setFormVnEnabled(e.target.checked)}
+                    />
+                    {t('meshcore.form.enable_virtual_node', 'Expose this node to the MeshCore app over WiFi')}
+                  </label>
+                  {formVnEnabled && (
+                    <label className="dashboard-form-field" style={{ marginTop: 8 }}>
+                      <span className="dashboard-form-label">{t('source.form.virtual_node_port')}</span>
+                      <input
+                        className="dashboard-form-input"
+                        type="number"
+                        min={1}
+                        max={65535}
+                        value={formVnPort}
+                        onChange={(e) => setFormVnPort(e.target.value)}
+                        placeholder="5000"
+                      />
+                      <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                        {t('meshcore.form.virtual_node_help', 'TCP port the MeshCore mobile app connects to. Point the app at this host and port over WiFi.')}
+                      </p>
+                    </label>
+                  )}
+                </fieldset>
               </>
             ) : (
             <>

--- a/src/server/meshcoreCompanionCodec.test.ts
+++ b/src/server/meshcoreCompanionCodec.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+// Round-trip fidelity check: feed OUR encoder output into meshcore.js's OWN
+// decoders and assert it reads back what we put in. This is the cheap, deviceless
+// guarantee that our wire layout matches the firmware the app expects.
+import { Connection, Constants } from '@liamcottle/meshcore.js';
+import {
+  CommandCodes,
+  ResponseCodes,
+  FRAME_APP_TO_NODE,
+  FRAME_NODE_TO_APP,
+  parseAppFrames,
+  decodeCommand,
+  frameNodeToApp,
+  encodeSelfInfo,
+  encodeCurrTime,
+  encodeDeviceInfo,
+  encodeContactsStart,
+  encodeEndOfContacts,
+  encodeNoMoreMessages,
+  packTelemetryMode,
+  pubKeyHexToBytes,
+  degreesToFixed,
+  type SelfInfoWire,
+} from './meshcoreCompanionCodec.js';
+
+/** Decode one of our response payloads via meshcore.js and return the event object. */
+function decodeWithMeshcore(responseCode: number, payload: Buffer): Promise<any> {
+  return new Promise((resolve) => {
+    const conn: any = new (Connection as any)();
+    conn.once(responseCode, (event: any) => resolve(event));
+    // onFrameReceived expects the frame payload (response code byte first).
+    conn.onFrameReceived(new Uint8Array(payload));
+  });
+}
+
+/** Build a synthetic app→node command frame for parser tests. */
+function frameAppToNode(payload: Uint8Array): Buffer {
+  const header = Buffer.alloc(3);
+  header[0] = FRAME_APP_TO_NODE;
+  header.writeUInt16LE(payload.length, 1);
+  return Buffer.concat([header, Buffer.from(payload)]);
+}
+
+const SAMPLE_PUBKEY = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+
+describe('meshcoreCompanionCodec — constants stay in sync with meshcore.js', () => {
+  it('command/response codes match the library', () => {
+    expect(CommandCodes.AppStart).toBe(Constants.CommandCodes.AppStart);
+    expect(CommandCodes.GetContacts).toBe(Constants.CommandCodes.GetContacts);
+    expect(CommandCodes.SyncNextMessage).toBe(Constants.CommandCodes.SyncNextMessage);
+    expect(ResponseCodes.SelfInfo).toBe(Constants.ResponseCodes.SelfInfo);
+    expect(ResponseCodes.CurrTime).toBe(Constants.ResponseCodes.CurrTime);
+    expect(ResponseCodes.DeviceInfo).toBe(Constants.ResponseCodes.DeviceInfo);
+    expect(ResponseCodes.NoMoreMessages).toBe(Constants.ResponseCodes.NoMoreMessages);
+  });
+});
+
+describe('meshcoreCompanionCodec — encoders round-trip through meshcore.js decoders', () => {
+  it('SelfInfo decodes back to the same identity + radio params', async () => {
+    const wire: SelfInfoWire = {
+      type: Constants.AdvType.Chat,
+      txPower: 22,
+      maxTxPower: 30,
+      publicKey: pubKeyHexToBytes(SAMPLE_PUBKEY),
+      advLat: degreesToFixed(29.7604),
+      advLon: degreesToFixed(-95.3698),
+      multiAcks: 0,
+      advLocPolicy: Constants.AdvLocPolicy.Share,
+      telemetryMode: packTelemetryMode(1, 2, 1),
+      manualAddContacts: 0,
+      radioFreq: 917375, // wire kHz == 917.375 MHz
+      radioBw: 250000, // wire Hz == 250 kHz
+      radioSf: 11,
+      radioCr: 5,
+      name: 'MeshMonitor VNode',
+    };
+
+    const decoded = await decodeWithMeshcore(ResponseCodes.SelfInfo, encodeSelfInfo(wire));
+
+    expect(decoded.type).toBe(wire.type);
+    expect(decoded.txPower).toBe(22);
+    expect(decoded.maxTxPower).toBe(30);
+    expect(Buffer.from(decoded.publicKey).toString('hex')).toBe(SAMPLE_PUBKEY);
+    expect(decoded.advLat).toBe(degreesToFixed(29.7604));
+    expect(decoded.advLon).toBe(degreesToFixed(-95.3698));
+    expect(decoded.advLocPolicy).toBe(Constants.AdvLocPolicy.Share);
+    expect(decoded.telemetryModeBase).toBe(1);
+    expect(decoded.telemetryModeLoc).toBe(2);
+    expect(decoded.telemetryModeEnv).toBe(1);
+    expect(decoded.radioFreq).toBe(917375);
+    expect(decoded.radioBw).toBe(250000);
+    expect(decoded.radioSf).toBe(11);
+    expect(decoded.radioCr).toBe(5);
+    expect(decoded.name).toBe('MeshMonitor VNode');
+  });
+
+  it('CurrTime decodes to the same epoch seconds', async () => {
+    const epoch = 1_750_000_000;
+    const decoded = await decodeWithMeshcore(ResponseCodes.CurrTime, encodeCurrTime(epoch));
+    expect(decoded.epochSecs).toBe(epoch);
+  });
+
+  it('DeviceInfo decodes firmware version, build date and model', async () => {
+    const decoded = await decodeWithMeshcore(
+      ResponseCodes.DeviceInfo,
+      encodeDeviceInfo({ firmwareVer: 7, firmwareBuildDate: '19 Feb 2025', manufacturerModel: 'MeshMonitor Virtual Node' }),
+    );
+    expect(decoded.firmwareVer).toBe(7);
+    expect(decoded.firmware_build_date).toBe('19 Feb 2025');
+    expect(decoded.manufacturerModel).toBe('MeshMonitor Virtual Node');
+  });
+
+  it('ContactsStart decodes the announced count', async () => {
+    const decoded = await decodeWithMeshcore(ResponseCodes.ContactsStart, encodeContactsStart(0));
+    expect(decoded.count).toBe(0);
+  });
+
+  it('EndOfContacts decodes mostRecentLastmod', async () => {
+    const decoded = await decodeWithMeshcore(ResponseCodes.EndOfContacts, encodeEndOfContacts(0));
+    expect(decoded.mostRecentLastmod).toBe(0);
+  });
+
+  it('NoMoreMessages is a bare response code', () => {
+    const payload = encodeNoMoreMessages();
+    expect(payload).toHaveLength(1);
+    expect(payload[0]).toBe(ResponseCodes.NoMoreMessages);
+  });
+});
+
+describe('meshcoreCompanionCodec — framing + command decode', () => {
+  it('frameNodeToApp prefixes the 0x3e header with little-endian length', () => {
+    const framed = frameNodeToApp(Buffer.from([0x05, 0xaa, 0xbb]));
+    expect(framed[0]).toBe(FRAME_NODE_TO_APP);
+    expect(framed.readUInt16LE(1)).toBe(3);
+    expect(framed.subarray(3)).toEqual(Buffer.from([0x05, 0xaa, 0xbb]));
+  });
+
+  it('parseAppFrames extracts whole frames and retains a trailing partial', () => {
+    const a = frameAppToNode(Buffer.from([CommandCodes.GetDeviceTime]));
+    const b = frameAppToNode(Buffer.from([CommandCodes.SyncNextMessage]));
+    const partial = b.subarray(0, 2); // first 2 bytes of a 4-byte frame
+    const { commands, rest } = parseAppFrames(Buffer.concat([a, b, partial]));
+
+    expect(commands.map((c) => c.code)).toEqual([CommandCodes.GetDeviceTime, CommandCodes.SyncNextMessage]);
+    expect(rest).toEqual(partial);
+  });
+
+  it('parseAppFrames resyncs past a garbage byte', () => {
+    const good = frameAppToNode(Buffer.from([CommandCodes.GetDeviceTime]));
+    const { commands } = parseAppFrames(Buffer.concat([Buffer.from([0x00]), good]));
+    expect(commands.map((c) => c.code)).toEqual([CommandCodes.GetDeviceTime]);
+  });
+
+  it('decodeCommand parses an AppStart body the way meshcore.js encodes it', () => {
+    // meshcore.js AppStart: [code][appVer:1][reserved:6][appName]
+    const body = Buffer.concat([
+      Buffer.from([CommandCodes.AppStart, 1]),
+      Buffer.alloc(6),
+      Buffer.from('mc-app', 'utf8'),
+    ]);
+    const parsed = decodeCommand(body);
+    expect(parsed.code).toBe(CommandCodes.AppStart);
+    expect(parsed.appVer).toBe(1);
+    expect(parsed.appName).toBe('mc-app');
+  });
+
+  it('decodeCommand parses a DeviceQuery target version', () => {
+    const parsed = decodeCommand(Buffer.from([CommandCodes.DeviceQuery, 1]));
+    expect(parsed.code).toBe(CommandCodes.DeviceQuery);
+    expect(parsed.appTargetVer).toBe(1);
+  });
+});

--- a/src/server/meshcoreCompanionCodec.test.ts
+++ b/src/server/meshcoreCompanionCodec.test.ts
@@ -21,6 +21,7 @@ import {
   encodeBatteryVoltage,
   encodeContactMsgRecv,
   encodeChannelMsgRecv,
+  encodeSent,
   encodeNoMoreMessages,
   packTelemetryMode,
   pubKeyHexToBytes,
@@ -192,6 +193,13 @@ describe('meshcoreCompanionCodec — encoders round-trip through meshcore.js dec
     expect(decoded.pathLen).toBe(0xff);
     expect(decoded.senderTimestamp).toBe(1_750_000_000);
     expect(decoded.text).toBe('hello there');
+  });
+
+  it('Sent decodes result, expectedAckCrc and estTimeout', async () => {
+    const decoded = await decodeWithMeshcore(ResponseCodes.Sent, encodeSent(0, 0xdeadbeef, 8000));
+    expect(decoded.result).toBe(0);
+    expect(decoded.expectedAckCrc).toBe(0xdeadbeef);
+    expect(decoded.estTimeout).toBe(8000);
   });
 
   it('ChannelMsgRecv decodes channel index and text', async () => {

--- a/src/server/meshcoreCompanionCodec.test.ts
+++ b/src/server/meshcoreCompanionCodec.test.ts
@@ -15,11 +15,18 @@ import {
   encodeCurrTime,
   encodeDeviceInfo,
   encodeContactsStart,
+  encodeContact,
   encodeEndOfContacts,
+  encodeChannelInfo,
+  encodeBatteryVoltage,
+  encodeContactMsgRecv,
+  encodeChannelMsgRecv,
   encodeNoMoreMessages,
   packTelemetryMode,
   pubKeyHexToBytes,
+  hexToBytes,
   degreesToFixed,
+  toEpochSeconds,
   type SelfInfoWire,
 } from './meshcoreCompanionCodec.js';
 
@@ -124,6 +131,88 @@ describe('meshcoreCompanionCodec — encoders round-trip through meshcore.js dec
     const payload = encodeNoMoreMessages();
     expect(payload).toHaveLength(1);
     expect(payload[0]).toBe(ResponseCodes.NoMoreMessages);
+  });
+
+  it('Contact decodes back to the same key, name, path and position', async () => {
+    const decoded = await decodeWithMeshcore(ResponseCodes.Contact, encodeContact({
+      publicKey: pubKeyHexToBytes(SAMPLE_PUBKEY),
+      type: Constants.AdvType.Chat,
+      flags: 0,
+      outPathLen: 3,
+      outPath: hexToBytes('a37f02'),
+      advName: 'Repeater North',
+      lastAdvert: 1_750_000_000,
+      advLat: degreesToFixed(40.1),
+      advLon: degreesToFixed(-105.2),
+      lastMod: 1_750_000_500,
+    }));
+
+    expect(Buffer.from(decoded.publicKey).toString('hex')).toBe(SAMPLE_PUBKEY);
+    expect(decoded.type).toBe(Constants.AdvType.Chat);
+    expect(decoded.outPathLen).toBe(3);
+    expect(Buffer.from(decoded.outPath).subarray(0, 3).toString('hex')).toBe('a37f02');
+    expect(decoded.advName).toBe('Repeater North');
+    expect(decoded.lastAdvert).toBe(1_750_000_000);
+    expect(decoded.advLat).toBe(degreesToFixed(40.1));
+    expect(decoded.advLon).toBe(degreesToFixed(-105.2));
+    expect(decoded.lastMod).toBe(1_750_000_500);
+  });
+
+  it('Contact encodes OUT_PATH_UNKNOWN (-1) for an unknown route', async () => {
+    const decoded = await decodeWithMeshcore(ResponseCodes.Contact, encodeContact({
+      publicKey: pubKeyHexToBytes(SAMPLE_PUBKEY),
+      type: 1, flags: 0, outPathLen: -1, outPath: Buffer.alloc(0),
+      advName: 'X', lastAdvert: 0, advLat: 0, advLon: 0, lastMod: 0,
+    }));
+    expect(decoded.outPathLen).toBe(-1);
+  });
+
+  it('ChannelInfo decodes index, name and 16-byte secret', async () => {
+    const secret = Buffer.from('0123456789abcdef0123456789abcdef', 'hex'); // 16 bytes
+    const decoded = await decodeWithMeshcore(ResponseCodes.ChannelInfo, encodeChannelInfo(0, 'Public', secret));
+    expect(decoded.channelIdx).toBe(0);
+    expect(decoded.name).toBe('Public');
+    expect(Buffer.from(decoded.secret).toString('hex')).toBe('0123456789abcdef0123456789abcdef');
+  });
+
+  it('BatteryVoltage decodes millivolts', async () => {
+    const decoded = await decodeWithMeshcore(ResponseCodes.BatteryVoltage, encodeBatteryVoltage(4100));
+    expect(decoded.batteryMilliVolts).toBe(4100);
+  });
+
+  it('ContactMsgRecv decodes prefix, type, timestamp and text', async () => {
+    const decoded = await decodeWithMeshcore(ResponseCodes.ContactMsgRecv, encodeContactMsgRecv({
+      pubKeyPrefix: hexToBytes(SAMPLE_PUBKEY).subarray(0, 6),
+      pathLen: 0xff,
+      txtType: 0,
+      senderTimestamp: 1_750_000_000,
+      text: 'hello there',
+    }));
+    expect(Buffer.from(decoded.pubKeyPrefix).toString('hex')).toBe(SAMPLE_PUBKEY.slice(0, 12));
+    expect(decoded.pathLen).toBe(0xff);
+    expect(decoded.senderTimestamp).toBe(1_750_000_000);
+    expect(decoded.text).toBe('hello there');
+  });
+
+  it('ChannelMsgRecv decodes channel index and text', async () => {
+    const decoded = await decodeWithMeshcore(ResponseCodes.ChannelMsgRecv, encodeChannelMsgRecv({
+      channelIdx: 0,
+      pathLen: 0xff,
+      txtType: 0,
+      senderTimestamp: 1_750_000_000,
+      text: 'Alice: hi all',
+    }));
+    expect(decoded.channelIdx).toBe(0);
+    expect(decoded.text).toBe('Alice: hi all');
+  });
+});
+
+describe('meshcoreCompanionCodec — timestamp normalization', () => {
+  it('passes through epoch seconds and downscales milliseconds', () => {
+    expect(toEpochSeconds(1_750_000_000)).toBe(1_750_000_000);
+    expect(toEpochSeconds(1_750_000_000_000)).toBe(1_750_000_000);
+    expect(toEpochSeconds(0)).toBe(0);
+    expect(toEpochSeconds(undefined)).toBe(0);
   });
 });
 

--- a/src/server/meshcoreCompanionCodec.ts
+++ b/src/server/meshcoreCompanionCodec.ts
@@ -30,7 +30,7 @@ export const FRAME_NODE_TO_APP = 0x3e; // ">" — frames we send the app
 /** Companion protocol version this virtual node speaks (meshcore.js v1.13.0). */
 export const SUPPORTED_COMPANION_PROTOCOL_VERSION = 1;
 
-/** Command codes the app sends (subset; full list in meshcore.js Constants). */
+/** Command codes the app sends (mirrors meshcore.js Constants.CommandCodes). */
 export const CommandCodes = {
   AppStart: 1,
   SendTxtMsg: 2,
@@ -38,10 +38,33 @@ export const CommandCodes = {
   GetContacts: 4,
   GetDeviceTime: 5,
   SetDeviceTime: 6,
+  SendSelfAdvert: 7,
+  SetAdvertName: 8,
+  AddUpdateContact: 9,
   SyncNextMessage: 10,
-  GetChannel: 31,
-  DeviceQuery: 22,
+  SetRadioParams: 11,
+  SetTxPower: 12,
+  ResetPath: 13,
+  SetAdvertLatLon: 14,
+  RemoveContact: 15,
+  ShareContact: 16,
+  ExportContact: 17,
+  ImportContact: 18,
+  Reboot: 19,
   GetBatteryVoltage: 20,
+  DeviceQuery: 22,
+  ExportPrivateKey: 23,
+  ImportPrivateKey: 24,
+  SendRawData: 25,
+  SendLogin: 26,
+  SendStatusReq: 27,
+  GetChannel: 31,
+  SetChannel: 32,
+  SendTracePath: 36,
+  SetOtherParams: 38,
+  SendTelemetryReq: 39,
+  SendBinaryReq: 50,
+  SetFloodScope: 54,
   GetStats: 56,
 } as const;
 
@@ -54,8 +77,11 @@ export const ResponseCodes = {
   EndOfContacts: 4,
   SelfInfo: 5,
   Sent: 6,
+  ContactMsgRecv: 7,
+  ChannelMsgRecv: 8,
   CurrTime: 9,
   NoMoreMessages: 10,
+  BatteryVoltage: 12,
   DeviceInfo: 13,
   ChannelInfo: 18,
 } as const;
@@ -95,10 +121,11 @@ export interface ParsedCommand {
   code: number;
   /** The command payload INCLUDING the leading code byte. */
   payload: Buffer;
-  // Parsed fields for the handshake commands we act on; undefined otherwise.
+  // Parsed fields for the commands we act on; undefined otherwise.
   appVer?: number;
   appName?: string;
   appTargetVer?: number;
+  channelIdx?: number;
 }
 
 /**
@@ -154,6 +181,11 @@ export function decodeCommand(payload: Buffer): ParsedCommand {
     case CommandCodes.DeviceQuery: {
       // [code][appTargetVer:u8]
       if (payload.length >= 2) cmd.appTargetVer = payload[1];
+      break;
+    }
+    case CommandCodes.GetChannel: {
+      // [code][channelIdx:u8]
+      if (payload.length >= 2) cmd.channelIdx = payload[1];
       break;
     }
     default:
@@ -259,6 +291,122 @@ export function encodeEndOfContacts(mostRecentLastmod: number): Buffer {
   return b;
 }
 
+export interface ContactWire {
+  /** 32-byte public key. */
+  publicKey: Uint8Array;
+  type: number;
+  flags: number;
+  /** Cached out-path hop count; -1 (OUT_PATH_UNKNOWN) when the route is unknown. */
+  outPathLen: number;
+  /** Out-path hop-hash bytes (≤64); zero-padded to 64 on the wire. */
+  outPath: Uint8Array;
+  advName: string;
+  /** Last advert time, epoch seconds. */
+  lastAdvert: number;
+  advLat: number;
+  advLon: number;
+  /** Last-modified time, epoch seconds. */
+  lastMod: number;
+}
+
+/** Encode a Contact(3) response — one per known contact between ContactsStart/EndOfContacts. */
+export function encodeContact(c: ContactWire): Buffer {
+  const pubKey = Buffer.alloc(32);
+  Buffer.from(c.publicKey).copy(pubKey, 0, 0, 32);
+  const outPath = Buffer.alloc(64);
+  Buffer.from(c.outPath ?? []).copy(outPath, 0, 0, 64);
+
+  const head = Buffer.alloc(1 + 32 + 1 + 1 + 1 + 64); // code + pubkey + type + flags + outPathLen + outPath
+  let o = 0;
+  head[o++] = ResponseCodes.Contact;
+  pubKey.copy(head, o); o += 32;
+  head[o++] = c.type & 0xff;
+  head[o++] = c.flags & 0xff;
+  head.writeInt8(clampInt8(c.outPathLen), o); o += 1;
+  outPath.copy(head, o); o += 64;
+
+  const tail = Buffer.alloc(4 + 4 + 4 + 4); // lastAdvert + advLat + advLon + lastMod
+  let t = 0;
+  // advName is a fixed 32-byte C string between outPath and lastAdvert.
+  const advName = Buffer.alloc(32);
+  writeCString(advName, 0, c.advName ?? '', 32);
+  tail.writeUInt32LE(c.lastAdvert >>> 0, t); t += 4;
+  tail.writeInt32LE(c.advLat | 0, t); t += 4;
+  tail.writeInt32LE(c.advLon | 0, t); t += 4;
+  tail.writeUInt32LE(c.lastMod >>> 0, t); t += 4;
+
+  return Buffer.concat([head, advName, tail]);
+}
+
+/** Encode a ChannelInfo(18) response: index + 32-byte C-string name + 16-byte secret. */
+export function encodeChannelInfo(channelIdx: number, name: string, secret: Uint8Array): Buffer {
+  const head = Buffer.alloc(1 + 1 + 32);
+  head[0] = ResponseCodes.ChannelInfo;
+  head[1] = channelIdx & 0xff;
+  writeCString(head, 2, name ?? '', 32);
+  const key = Buffer.alloc(16);
+  Buffer.from(secret ?? []).copy(key, 0, 0, 16);
+  return Buffer.concat([head, key]);
+}
+
+/** Encode a BatteryVoltage(12) response. */
+export function encodeBatteryVoltage(milliVolts: number): Buffer {
+  const b = Buffer.alloc(3);
+  b[0] = ResponseCodes.BatteryVoltage;
+  b.writeUInt16LE(Math.max(0, Math.min(0xffff, Math.round(milliVolts || 0))), 1);
+  return b;
+}
+
+export interface ContactMsgRecvWire {
+  /** First 6 bytes of the sender's public key. */
+  pubKeyPrefix: Uint8Array;
+  /** Hop count, or 0xFF if delivered direct. */
+  pathLen: number;
+  /** TxtType (0 = plain, 1 = CLI data, 2 = signed plain). */
+  txtType: number;
+  senderTimestamp: number;
+  text: string;
+}
+
+/** Encode a ContactMsgRecv(7) response — an incoming direct message. */
+export function encodeContactMsgRecv(m: ContactMsgRecvWire): Buffer {
+  const prefix = Buffer.alloc(6);
+  Buffer.from(m.pubKeyPrefix ?? []).copy(prefix, 0, 0, 6);
+  const head = Buffer.alloc(1 + 6 + 1 + 1 + 4);
+  let o = 0;
+  head[o++] = ResponseCodes.ContactMsgRecv;
+  prefix.copy(head, o); o += 6;
+  head[o++] = m.pathLen & 0xff;
+  head[o++] = m.txtType & 0xff;
+  head.writeUInt32LE(m.senderTimestamp >>> 0, o); o += 4;
+  return Buffer.concat([head, Buffer.from(m.text ?? '', 'utf8')]);
+}
+
+export interface ChannelMsgRecvWire {
+  channelIdx: number;
+  pathLen: number;
+  txtType: number;
+  senderTimestamp: number;
+  text: string;
+}
+
+/** Encode a ChannelMsgRecv(8) response — an incoming channel message. */
+export function encodeChannelMsgRecv(m: ChannelMsgRecvWire): Buffer {
+  const head = Buffer.alloc(1 + 1 + 1 + 1 + 4);
+  let o = 0;
+  head[o++] = ResponseCodes.ChannelMsgRecv;
+  head.writeInt8(clampInt8(m.channelIdx), o); o += 1;
+  head[o++] = m.pathLen & 0xff;
+  head[o++] = m.txtType & 0xff;
+  head.writeUInt32LE(m.senderTimestamp >>> 0, o); o += 4;
+  return Buffer.concat([head, Buffer.from(m.text ?? '', 'utf8')]);
+}
+
+/** Encode a MsgWaiting(0x83) push — tells the app to drain via SyncNextMessage. */
+export function encodeMsgWaitingPush(): Buffer {
+  return Buffer.from([PushCodes.MsgWaiting]);
+}
+
 /** Encode a NoMoreMessages(10) response — mailbox drained. */
 export function encodeNoMoreMessages(): Buffer {
   return Buffer.from([ResponseCodes.NoMoreMessages]);
@@ -294,6 +442,12 @@ function writeCString(target: Buffer, offset: number, value: string, maxLength: 
   }
 }
 
+/** Clamp a number to the signed-8-bit range (for int8 wire fields). */
+function clampInt8(v: number): number {
+  if (!Number.isFinite(v)) return 0;
+  return Math.max(-128, Math.min(127, Math.trunc(v)));
+}
+
 /** Convert a hex public-key string to a 32-byte buffer (tolerant of `0x`/odd input). */
 export function pubKeyHexToBytes(hex: string | undefined | null): Buffer {
   const out = Buffer.alloc(32);
@@ -301,6 +455,19 @@ export function pubKeyHexToBytes(hex: string | undefined | null): Buffer {
   const clean = hex.replace(/^0x/i, '').replace(/[^0-9a-f]/gi, '');
   Buffer.from(clean.length % 2 === 0 ? clean : clean.slice(0, -1), 'hex').copy(out, 0, 0, 32);
   return out;
+}
+
+/** Decode a loose hex string (any non-hex separators ignored) to bytes. */
+export function hexToBytes(hex: string | undefined | null): Buffer {
+  if (!hex) return Buffer.alloc(0);
+  const clean = hex.replace(/[^0-9a-f]/gi, '');
+  return Buffer.from(clean.length % 2 === 0 ? clean : clean.slice(0, -1), 'hex');
+}
+
+/** Normalize a timestamp (seconds or milliseconds) to epoch seconds. */
+export function toEpochSeconds(v: number | undefined | null): number {
+  if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) return 0;
+  return Math.floor(v > 1e12 ? v / 1000 : v);
 }
 
 /** Convert decimal degrees to MeshCore fixed-point (degrees×1e6, int32). */

--- a/src/server/meshcoreCompanionCodec.ts
+++ b/src/server/meshcoreCompanionCodec.ts
@@ -126,6 +126,11 @@ export interface ParsedCommand {
   appName?: string;
   appTargetVer?: number;
   channelIdx?: number;
+  // Send-message fields (SendTxtMsg / SendChannelTxtMsg).
+  txtType?: number;
+  senderTimestamp?: number;
+  pubKeyPrefix?: Buffer;
+  text?: string;
 }
 
 /**
@@ -186,6 +191,26 @@ export function decodeCommand(payload: Buffer): ParsedCommand {
     case CommandCodes.GetChannel: {
       // [code][channelIdx:u8]
       if (payload.length >= 2) cmd.channelIdx = payload[1];
+      break;
+    }
+    case CommandCodes.SendTxtMsg: {
+      // [code][txtType:u8][attempt:u8][senderTimestamp:u32 LE][pubKeyPrefix:6][text…]
+      if (payload.length >= 13) {
+        cmd.txtType = payload[1];
+        cmd.senderTimestamp = payload.readUInt32LE(3);
+        cmd.pubKeyPrefix = Buffer.from(payload.subarray(7, 13));
+        cmd.text = payload.subarray(13).toString('utf8');
+      }
+      break;
+    }
+    case CommandCodes.SendChannelTxtMsg: {
+      // [code][txtType:u8][channelIdx:u8][senderTimestamp:u32 LE][text…]
+      if (payload.length >= 7) {
+        cmd.txtType = payload[1];
+        cmd.channelIdx = payload[2];
+        cmd.senderTimestamp = payload.readUInt32LE(3);
+        cmd.text = payload.subarray(7).toString('utf8');
+      }
       break;
     }
     default:
@@ -405,6 +430,21 @@ export function encodeChannelMsgRecv(m: ChannelMsgRecvWire): Buffer {
 /** Encode a MsgWaiting(0x83) push — tells the app to drain via SyncNextMessage. */
 export function encodeMsgWaitingPush(): Buffer {
   return Buffer.from([PushCodes.MsgWaiting]);
+}
+
+/**
+ * Encode a Sent(6) response — the node's acknowledgement that an outbound
+ * message was accepted for transmission. `result` 0 = queued/sent;
+ * `expectedAckCrc` (DMs) correlates a later SendConfirmed push; `estTimeout`
+ * is the app's hint for how long to wait for delivery.
+ */
+export function encodeSent(result: number, expectedAckCrc = 0, estTimeout = 0): Buffer {
+  const b = Buffer.alloc(1 + 1 + 4 + 4);
+  b[0] = ResponseCodes.Sent;
+  b.writeInt8(clampInt8(result), 1);
+  b.writeUInt32LE(expectedAckCrc >>> 0, 2);
+  b.writeUInt32LE(estTimeout >>> 0, 6);
+  return b;
 }
 
 /** Encode a NoMoreMessages(10) response — mailbox drained. */

--- a/src/server/meshcoreCompanionCodec.ts
+++ b/src/server/meshcoreCompanionCodec.ts
@@ -1,0 +1,320 @@
+/**
+ * MeshCore companion-protocol codec — the *device end*.
+ *
+ * `@liamcottle/meshcore.js` implements the *app/companion* end: it ENCODES the
+ * `0x3c` command frames an app sends to a node, and DECODES the `0x3e` response
+ * /push frames a node sends back. To act as a virtual MeshCore node (issue
+ * #3535) MeshMonitor needs the inverse — DECODE the app's commands and ENCODE
+ * the node's responses/pushes.
+ *
+ * This module is pure protocol: it takes/produces wire-native values (no unit
+ * conversion, no DB access) so it can be round-trip tested directly against
+ * meshcore.js's own decoders. Byte layouts here are derived by inverting the
+ * decoders in `@liamcottle/meshcore.js/src/connection/connection.js` and the
+ * command encoders in the same file (meshcore.js v1.13.0).
+ *
+ * Framing (TCP companion link):
+ *   frame = [ frameType:u8 ] [ frameLength:u16 LE ] [ payload:frameLength ]
+ *     frameType 0x3c '<'  app  -> node  (commands we READ)
+ *     frameType 0x3e '>'  node -> app   (responses/pushes we WRITE)
+ *   payload[0] = command / response / push code.
+ *
+ * Scope: Phase 0 (handshake) implements the encoders/decoders needed to bring
+ * a MeshCore app to a "connected, identity shown, empty mailbox" state. Later
+ * phases extend the encoders (contacts, message recv, channels) in place.
+ */
+
+export const FRAME_APP_TO_NODE = 0x3c; // "<" — frames the app sends us
+export const FRAME_NODE_TO_APP = 0x3e; // ">" — frames we send the app
+
+/** Companion protocol version this virtual node speaks (meshcore.js v1.13.0). */
+export const SUPPORTED_COMPANION_PROTOCOL_VERSION = 1;
+
+/** Command codes the app sends (subset; full list in meshcore.js Constants). */
+export const CommandCodes = {
+  AppStart: 1,
+  SendTxtMsg: 2,
+  SendChannelTxtMsg: 3,
+  GetContacts: 4,
+  GetDeviceTime: 5,
+  SetDeviceTime: 6,
+  SyncNextMessage: 10,
+  GetChannel: 31,
+  DeviceQuery: 22,
+  GetBatteryVoltage: 20,
+  GetStats: 56,
+} as const;
+
+/** Response codes the node sends back (subset). */
+export const ResponseCodes = {
+  Ok: 0,
+  Err: 1,
+  ContactsStart: 2,
+  Contact: 3,
+  EndOfContacts: 4,
+  SelfInfo: 5,
+  Sent: 6,
+  CurrTime: 9,
+  NoMoreMessages: 10,
+  DeviceInfo: 13,
+  ChannelInfo: 18,
+} as const;
+
+/** Push codes the node emits on live events (subset). */
+export const PushCodes = {
+  Advert: 0x80,
+  SendConfirmed: 0x82,
+  MsgWaiting: 0x83,
+} as const;
+
+/** Error codes carried by an Err(1) response. */
+export const ErrorCodes = {
+  UnsupportedCmd: 1,
+  NotFound: 2,
+  TableFull: 3,
+  BadState: 4,
+  FileIoError: 5,
+  IllegalArg: 6,
+} as const;
+
+// ───────────────────────── framing ─────────────────────────
+
+/**
+ * Wrap a response/push payload in a node→app (`0x3e`) frame:
+ *   [0x3e][len:u16 LE][payload].
+ */
+export function frameNodeToApp(payload: Uint8Array): Buffer {
+  const header = Buffer.alloc(3);
+  header[0] = FRAME_NODE_TO_APP;
+  header.writeUInt16LE(payload.length, 1);
+  return Buffer.concat([header, Buffer.from(payload)]);
+}
+
+export interface ParsedCommand {
+  /** Command code (`payload[0]`). */
+  code: number;
+  /** The command payload INCLUDING the leading code byte. */
+  payload: Buffer;
+  // Parsed fields for the handshake commands we act on; undefined otherwise.
+  appVer?: number;
+  appName?: string;
+  appTargetVer?: number;
+}
+
+/**
+ * Extract complete app→node (`0x3c`) command frames from a rolling buffer.
+ * Returns the parsed commands and any trailing partial bytes to retain.
+ *
+ * Mirrors the resync behaviour of meshcore.js's read loop: a byte that is not
+ * a known frame-type marker (or a zero-length frame) is skipped one byte at a
+ * time rather than aborting the whole buffer.
+ */
+export function parseAppFrames(buffer: Buffer): { commands: ParsedCommand[]; rest: Buffer } {
+  const commands: ParsedCommand[] = [];
+  let buf = buffer;
+
+  const HEADER = 3;
+  while (buf.length >= HEADER) {
+    const frameType = buf[0];
+    // Accept either marker for robustness, but we only ever expect 0x3c here.
+    if (frameType !== FRAME_APP_TO_NODE && frameType !== FRAME_NODE_TO_APP) {
+      buf = buf.subarray(1);
+      continue;
+    }
+
+    const frameLength = buf.readUInt16LE(1);
+    if (frameLength === 0) {
+      buf = buf.subarray(1);
+      continue;
+    }
+
+    const total = HEADER + frameLength;
+    if (buf.length < total) break; // wait for more bytes
+
+    const payload = Buffer.from(buf.subarray(HEADER, total));
+    buf = buf.subarray(total);
+    commands.push(decodeCommand(payload));
+  }
+
+  return { commands, rest: Buffer.from(buf) };
+}
+
+/** Decode a command payload (incl. leading code byte) into its known fields. */
+export function decodeCommand(payload: Buffer): ParsedCommand {
+  const code = payload.length > 0 ? payload[0] : -1;
+  const cmd: ParsedCommand = { code, payload };
+
+  switch (code) {
+    case CommandCodes.AppStart: {
+      // [code][appVer:u8][reserved:6][appName:string]
+      if (payload.length >= 2) cmd.appVer = payload[1];
+      if (payload.length > 8) cmd.appName = payload.subarray(8).toString('utf8');
+      break;
+    }
+    case CommandCodes.DeviceQuery: {
+      // [code][appTargetVer:u8]
+      if (payload.length >= 2) cmd.appTargetVer = payload[1];
+      break;
+    }
+    default:
+      break;
+  }
+
+  return cmd;
+}
+
+// ───────────────────────── response encoders ─────────────────────────
+// Each returns a payload (response code byte first), NOT yet framed. Wrap with
+// frameNodeToApp() before writing to the socket.
+
+export interface SelfInfoWire {
+  type: number;
+  txPower: number;
+  maxTxPower: number;
+  /** Node X25519 public key, 32 bytes (padded/truncated to 32 if needed). */
+  publicKey: Uint8Array;
+  /** Advertised latitude as fixed-point degrees×1e6 (int32). */
+  advLat: number;
+  /** Advertised longitude as fixed-point degrees×1e6 (int32). */
+  advLon: number;
+  multiAcks: number;
+  advLocPolicy: number;
+  /** Packed telemetry-mode byte: base | (loc<<2) | (env<<4). */
+  telemetryMode: number;
+  manualAddContacts: number;
+  /** Radio frequency in wire units (kHz, e.g. 917375 == 917.375 MHz). */
+  radioFreq: number;
+  /** Radio bandwidth in wire units (Hz, e.g. 250000 == 250 kHz). */
+  radioBw: number;
+  radioSf: number;
+  radioCr: number;
+  name: string;
+}
+
+/** Encode a SelfInfo(5) response — the reply to AppStart. */
+export function encodeSelfInfo(info: SelfInfoWire): Buffer {
+  const pubKey = Buffer.alloc(32);
+  Buffer.from(info.publicKey).copy(pubKey, 0, 0, 32);
+
+  const nameBytes = Buffer.from(info.name ?? '', 'utf8');
+  const fixed = Buffer.alloc(1 + 3 + 32 + 4 + 4 + 4 + 4 + 4 + 2); // up to name
+  let o = 0;
+  fixed[o++] = ResponseCodes.SelfInfo;
+  fixed[o++] = info.type & 0xff;
+  fixed[o++] = info.txPower & 0xff;
+  fixed[o++] = info.maxTxPower & 0xff;
+  pubKey.copy(fixed, o); o += 32;
+  fixed.writeInt32LE(info.advLat | 0, o); o += 4;
+  fixed.writeInt32LE(info.advLon | 0, o); o += 4;
+  fixed[o++] = info.multiAcks & 0xff;
+  fixed[o++] = info.advLocPolicy & 0xff;
+  fixed[o++] = info.telemetryMode & 0xff;
+  fixed[o++] = info.manualAddContacts & 0xff;
+  fixed.writeUInt32LE(info.radioFreq >>> 0, o); o += 4;
+  fixed.writeUInt32LE(info.radioBw >>> 0, o); o += 4;
+  fixed[o++] = info.radioSf & 0xff;
+  fixed[o++] = info.radioCr & 0xff;
+
+  return Buffer.concat([fixed.subarray(0, o), nameBytes]);
+}
+
+/** Encode a CurrTime(9) response. */
+export function encodeCurrTime(epochSecs: number): Buffer {
+  const b = Buffer.alloc(5);
+  b[0] = ResponseCodes.CurrTime;
+  b.writeUInt32LE(epochSecs >>> 0, 1);
+  return b;
+}
+
+export interface DeviceInfoWire {
+  firmwareVer: number;
+  firmwareBuildDate: string; // e.g. "19 Feb 2025", max 12 incl. null terminator
+  manufacturerModel: string; // remainder of frame
+}
+
+/** Encode a DeviceInfo(13) response (reply to DeviceQuery). */
+export function encodeDeviceInfo(info: DeviceInfoWire): Buffer {
+  const head = Buffer.alloc(1 + 1 + 6 + 12); // code + firmwareVer + reserved(6) + cstring(12)
+  head[0] = ResponseCodes.DeviceInfo;
+  head.writeInt8(info.firmwareVer | 0, 1);
+  // reserved[6] left zero
+  writeCString(head, 8, info.firmwareBuildDate ?? '', 12);
+  const model = Buffer.from(info.manufacturerModel ?? '', 'utf8');
+  return Buffer.concat([head, model]);
+}
+
+/** Encode a ContactsStart(2) response announcing how many Contact frames follow. */
+export function encodeContactsStart(count: number): Buffer {
+  const b = Buffer.alloc(5);
+  b[0] = ResponseCodes.ContactsStart;
+  b.writeUInt32LE(count >>> 0, 1);
+  return b;
+}
+
+/** Encode an EndOfContacts(4) response. */
+export function encodeEndOfContacts(mostRecentLastmod: number): Buffer {
+  const b = Buffer.alloc(5);
+  b[0] = ResponseCodes.EndOfContacts;
+  b.writeUInt32LE(mostRecentLastmod >>> 0, 1);
+  return b;
+}
+
+/** Encode a NoMoreMessages(10) response — mailbox drained. */
+export function encodeNoMoreMessages(): Buffer {
+  return Buffer.from([ResponseCodes.NoMoreMessages]);
+}
+
+/** Encode an Ok(0) response. */
+export function encodeOk(): Buffer {
+  return Buffer.from([ResponseCodes.Ok]);
+}
+
+/** Encode an Err(1) response with an optional error code. */
+export function encodeErr(errCode?: number): Buffer {
+  return errCode === undefined
+    ? Buffer.from([ResponseCodes.Err])
+    : Buffer.from([ResponseCodes.Err, errCode & 0xff]);
+}
+
+/**
+ * Pack a per-section telemetry mode triple into the single SelfInfo byte:
+ * base (bits 0-1) | loc (bits 2-3) | env (bits 4-5). Mirrors meshcore.js.
+ */
+export function packTelemetryMode(base = 0, loc = 0, env = 0): number {
+  return (base & 0b11) | ((loc & 0b11) << 2) | ((env & 0b11) << 4);
+}
+
+// ───────────────────────── helpers ─────────────────────────
+
+/** Write a null-terminated, fixed-width C string (last byte always 0). */
+function writeCString(target: Buffer, offset: number, value: string, maxLength: number): void {
+  const bytes = Buffer.from(value, 'utf8');
+  for (let i = 0; i < maxLength; i++) {
+    target[offset + i] = i < maxLength - 1 && i < bytes.length ? bytes[i] : 0;
+  }
+}
+
+/** Convert a hex public-key string to a 32-byte buffer (tolerant of `0x`/odd input). */
+export function pubKeyHexToBytes(hex: string | undefined | null): Buffer {
+  const out = Buffer.alloc(32);
+  if (!hex) return out;
+  const clean = hex.replace(/^0x/i, '').replace(/[^0-9a-f]/gi, '');
+  Buffer.from(clean.length % 2 === 0 ? clean : clean.slice(0, -1), 'hex').copy(out, 0, 0, 32);
+  return out;
+}
+
+/** Convert decimal degrees to MeshCore fixed-point (degrees×1e6, int32). */
+export function degreesToFixed(deg: number | undefined | null): number {
+  if (typeof deg !== 'number' || !Number.isFinite(deg)) return 0;
+  return Math.round(deg * 1e6) | 0;
+}
+
+/** Convert MHz to wire frequency units (kHz). */
+export function mhzToWireFreq(mhz: number | undefined | null): number {
+  return typeof mhz === 'number' && Number.isFinite(mhz) ? Math.round(mhz * 1000) : 0;
+}
+
+/** Convert kHz to wire bandwidth units (Hz). */
+export function khzToWireBw(khz: number | undefined | null): number {
+  return typeof khz === 'number' && Number.isFinite(khz) ? Math.round(khz * 1000) : 0;
+}

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -17,6 +17,10 @@ import { scheduleCron, validateCron, type CronJob } from './utils/cronScheduler.
 import { replaceMeshCoreAnnounceTokens } from './utils/meshcoreAnnounceTokens.js';
 import { runScript, type RunScriptResult } from './utils/scriptRunner.js';
 import { MeshCoreNativeBackend, type BridgeShapedEvent } from './meshcoreNativeBackend.js';
+import {
+  MeshCoreVirtualNodeServer,
+  type MeshCoreVirtualNodeConfig,
+} from './meshcoreVirtualNodeServer.js';
 import meshcorePacketLogService from './services/meshcorePacketLogService.js';
 import { notificationService } from './services/notificationService.js';
 import type { DbMeshCorePacket } from '../db/repositories/meshcore.js';
@@ -254,6 +258,11 @@ export interface MeshCoreConfig {
   reconnectInitialDelayMs?: number;    // default 1000.
   reconnectMaxDelayMs?: number;        // default 60000.
   reconnectMaxAttempts?: number;       // default 0 (forever).
+
+  // Virtual Node server (opt-in). Exposes this MeshCore node over TCP so the
+  // MeshCore mobile app can connect through MeshMonitor over WiFi (issue #3535).
+  // See docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md.
+  virtualNode?: MeshCoreVirtualNodeConfig;
 }
 
 export type MeshCoreConnectionState =
@@ -489,6 +498,7 @@ class MeshCoreManager extends EventEmitter {
 
   // Companion: native JS backend (meshcore.js). sendBridgeCommand delegates here.
   private nativeBackend: MeshCoreNativeBackend | null = null;
+  private virtualNodeServer: MeshCoreVirtualNodeServer | null = null;
 
   // Heartbeat / auto-reconnect state (native-backend only).
   private connectionState: MeshCoreConnectionState = 'disconnected';
@@ -672,6 +682,10 @@ class MeshCoreManager extends EventEmitter {
         this.startHeartbeat();
       }
 
+      // Start the Virtual Node server (opt-in) now that the local node identity
+      // is known — the server synthesizes SelfInfo from it. Non-fatal on error.
+      await this.startVirtualNodeServer();
+
       // Start auto-pathfinding scheduler if configured for this source.
       this.startAutoPathfinding().catch(err =>
         logger.warn(`[MeshCore:${this.sourceId}] Failed to start auto-pathfinding: ${(err as Error).message}`),
@@ -717,6 +731,47 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
+   * Start the Virtual Node TCP server if this source has it enabled. Exposes
+   * the connected MeshCore node to the MeshCore mobile app over WiFi (#3535).
+   * Idempotent and non-fatal: a bind failure is logged but does not abort the
+   * connection.
+   */
+  private async startVirtualNodeServer(): Promise<void> {
+    const vn = this.config?.virtualNode;
+    if (!vn?.enabled || this.virtualNodeServer) return;
+
+    try {
+      this.virtualNodeServer = new MeshCoreVirtualNodeServer({
+        port: vn.port,
+        manager: this,
+        allowAdminCommands: vn.allowAdminCommands,
+      });
+      await this.virtualNodeServer.start();
+    } catch (err) {
+      logger.error(
+        `[MeshCore:${this.sourceId}] Failed to start Virtual Node server on port ${vn.port}: ${(err as Error).message}`,
+      );
+      this.virtualNodeServer = null;
+    }
+  }
+
+  /** Stop the Virtual Node server if running. Safe to call when not started. */
+  private async stopVirtualNodeServer(): Promise<void> {
+    if (!this.virtualNodeServer) return;
+    try {
+      await this.virtualNodeServer.stop();
+    } catch (err) {
+      logger.debug(`[MeshCore:${this.sourceId}] Virtual Node server stop threw: ${(err as Error).message}`);
+    }
+    this.virtualNodeServer = null;
+  }
+
+  /** Whether the Virtual Node server is currently listening. */
+  isVirtualNodeServerRunning(): boolean {
+    return this.virtualNodeServer?.isRunning() ?? false;
+  }
+
+  /**
    * Disconnect from the device
    */
   async disconnect(): Promise<void> {
@@ -744,6 +799,10 @@ class MeshCoreManager extends EventEmitter {
     // Stop auto-announce + timer-trigger schedulers.
     this.stopAutoAnnounce();
     this.stopTimerTriggers();
+
+    // Stop the Virtual Node server (if running) before tearing down the link
+    // and clearing localNode — it reads localNode to answer AppStart.
+    await this.stopVirtualNodeServer();
 
     // Tear down native backend, if active.
     if (this.nativeBackend) {

--- a/src/server/meshcoreRegistry.ts
+++ b/src/server/meshcoreRegistry.ts
@@ -22,6 +22,30 @@ interface MeshCoreSourceConfig {
   tcpPort?: number;
   deviceType?: 'companion' | 'repeater';
   autoConnect?: boolean;
+  // Virtual Node server — expose this node to the MeshCore app over WiFi (#3535).
+  virtualNode?: {
+    enabled?: boolean;
+    port?: number;
+    allowAdminCommands?: boolean;
+  };
+}
+
+/** Default TCP port the Virtual Node server listens on when none is given. */
+const DEFAULT_VIRTUAL_NODE_PORT = 5000;
+
+/**
+ * Build the runtime virtual-node config from a source's saved config, or
+ * undefined when disabled/absent. A non-positive or missing port falls back to
+ * the default so an enabled server always binds to a usable port.
+ */
+function virtualNodeConfigFromSource(cfg: MeshCoreSourceConfig): MeshCoreConfig['virtualNode'] {
+  const vn = cfg.virtualNode;
+  if (!vn?.enabled) return undefined;
+  return {
+    enabled: true,
+    port: typeof vn.port === 'number' && vn.port > 0 ? vn.port : DEFAULT_VIRTUAL_NODE_PORT,
+    allowAdminCommands: vn.allowAdminCommands === true,
+  };
 }
 
 /**
@@ -32,6 +56,7 @@ interface MeshCoreSourceConfig {
 export function meshcoreConfigFromSource(source: Source): MeshCoreConfig | null {
   const cfg = (source.config ?? {}) as MeshCoreSourceConfig;
   const firmwareType = cfg.deviceType === 'repeater' ? 'repeater' : 'companion';
+  const virtualNode = virtualNodeConfigFromSource(cfg);
 
   // Companion-USB / direct serial — the v1 path.
   const port = cfg.serialPort || cfg.port;
@@ -41,6 +66,7 @@ export function meshcoreConfigFromSource(source: Source): MeshCoreConfig | null 
       serialPort: port,
       baudRate: cfg.baudRate ?? 115200,
       firmwareType,
+      virtualNode,
     };
   }
 
@@ -50,6 +76,7 @@ export function meshcoreConfigFromSource(source: Source): MeshCoreConfig | null 
       tcpHost: cfg.tcpHost,
       tcpPort: cfg.tcpPort ?? 4403,
       firmwareType,
+      virtualNode,
     };
   }
 

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -1,14 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
 import { Socket } from 'net';
 import { Constants } from '@liamcottle/meshcore.js';
 import { MeshCoreVirtualNodeServer, type MeshCoreVirtualNodeManager } from './meshcoreVirtualNodeServer.js';
 import {
   CommandCodes,
   ResponseCodes,
+  PushCodes,
   FRAME_APP_TO_NODE,
   FRAME_NODE_TO_APP,
 } from './meshcoreCompanionCodec.js';
-import type { MeshCoreNode } from './meshcoreManager.js';
+import type { MeshCoreNode, MeshCoreContact, MeshCoreMessage } from './meshcoreManager.js';
 
 // Audit logging is fire-and-forget; stub it so the test doesn't touch the DB.
 vi.mock('../services/database.js', () => ({
@@ -29,13 +31,49 @@ const LOCAL_NODE: MeshCoreNode = {
   longitude: -95.3698,
 };
 
+const SAMPLE_CONTACTS: MeshCoreContact[] = [
+  {
+    publicKey: 'b1'.repeat(32),
+    advName: 'Repeater North',
+    advType: Constants.AdvType.Repeater,
+    latitude: 40.1,
+    longitude: -105.2,
+    lastAdvert: 1_750_000_000,
+    lastSeen: 1_750_000_500,
+    pathLen: 2,
+    outPath: 'a3,7f',
+  },
+];
+
+/** A fake manager backed by a real EventEmitter so the server can subscribe. */
+class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
+  readonly sourceId = 'src-test';
+  private localNode: MeshCoreNode | null;
+  private contacts: MeshCoreContact[];
+  constructor(localNode: MeshCoreNode | null = LOCAL_NODE, contacts = SAMPLE_CONTACTS) {
+    super();
+    this.localNode = localNode;
+    this.contacts = contacts;
+  }
+  isConnected() { return this.localNode !== null; }
+  getLocalNode() { return this.localNode; }
+  getContacts() { return this.contacts; }
+  emitMessage(msg: MeshCoreMessage) { this.emit('message', msg); }
+}
+
+const CHANNELS_DB = {
+  channels: {
+    getAllChannels: vi.fn().mockResolvedValue([
+      { id: 0, name: 'Public', psk: Buffer.from('0123456789abcdef0123456789abcdef', 'hex').toString('base64') },
+    ]),
+  },
+};
+
 function makeManager(overrides: Partial<MeshCoreVirtualNodeManager> = {}): MeshCoreVirtualNodeManager {
-  return {
-    sourceId: 'src-test',
-    isConnected: () => true,
-    getLocalNode: () => LOCAL_NODE,
-    ...overrides,
-  };
+  const base = new FakeManager(
+    'getLocalNode' in overrides ? (overrides.getLocalNode as () => MeshCoreNode | null)() : LOCAL_NODE,
+  );
+  return Object.assign(base, overrides) as MeshCoreVirtualNodeManager;
 }
 
 /** Frame an app→node command (the byte layout the MeshCore app would send). */
@@ -102,9 +140,11 @@ class TestClient {
 describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
   let server: MeshCoreVirtualNodeServer;
   let client: TestClient;
+  let manager: FakeManager;
 
   beforeEach(async () => {
-    server = new MeshCoreVirtualNodeServer({ port: 0, manager: makeManager() });
+    manager = new FakeManager();
+    server = new MeshCoreVirtualNodeServer({ port: 0, manager, databaseService: CHANNELS_DB });
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
@@ -136,15 +176,69 @@ describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
     expect(payload[0]).toBe(ResponseCodes.DeviceInfo);
   });
 
-  it('replies to GetContacts with ContactsStart(0) then EndOfContacts', async () => {
+  it('replies to GetContacts with ContactsStart(N), Contact frames, then EndOfContacts', async () => {
     client.send([CommandCodes.GetContacts, 0, 0, 0, 0]); // since:u32
-    const [start, end] = await client.expectFrames(2);
+    const [start, contact, end] = await client.expectFrames(3);
     expect(start[0]).toBe(ResponseCodes.ContactsStart);
-    expect(start.readUInt32LE(1)).toBe(0);
+    expect(start.readUInt32LE(1)).toBe(1);
+    expect(contact[0]).toBe(ResponseCodes.Contact);
+    // public key is the 32 bytes right after the response code
+    expect(contact.subarray(1, 33).toString('hex')).toBe('b1'.repeat(32));
     expect(end[0]).toBe(ResponseCodes.EndOfContacts);
   });
 
-  it('replies to SyncNextMessage with NoMoreMessages', async () => {
+  it('replies to GetChannel(0) with ChannelInfo from the channels DB', async () => {
+    const payload = await client.request([CommandCodes.GetChannel, 0]);
+    expect(payload[0]).toBe(ResponseCodes.ChannelInfo);
+    expect(payload[1]).toBe(0); // channel index
+  });
+
+  it('replies to GetChannel for an unknown slot with Err(NotFound)', async () => {
+    const payload = await client.request([CommandCodes.GetChannel, 7]);
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(Constants.ErrorCodes.NotFound);
+  });
+
+  it('replies to GetBatteryVoltage with BatteryVoltage', async () => {
+    const payload = await client.request([CommandCodes.GetBatteryVoltage]);
+    expect(payload[0]).toBe(ResponseCodes.BatteryVoltage);
+  });
+
+  it('acknowledges SetFloodScope with Ok (read-only no-op)', async () => {
+    const payload = await client.request([0x36 /* SetFloodScope=54 */, 0]);
+    expect(payload[0]).toBe(ResponseCodes.Ok);
+  });
+
+  it('SyncNextMessage returns NoMoreMessages when the queue is empty', async () => {
+    const payload = await client.request([CommandCodes.SyncNextMessage]);
+    expect(payload[0]).toBe(ResponseCodes.NoMoreMessages);
+  });
+
+  it('pushes MsgWaiting on a live incoming message and delivers it via SyncNextMessage', async () => {
+    const push = new Promise<Buffer>((resolve) => (client as any).waiters.push(resolve));
+    manager.emitMessage({
+      id: 'm1',
+      fromPublicKey: 'b1'.repeat(32),
+      toPublicKey: undefined,
+      text: 'incoming dm',
+      timestamp: 1_750_000_000_000,
+    });
+    const pushFrame = await push;
+    expect(pushFrame[0]).toBe(PushCodes.MsgWaiting);
+
+    const recv = await client.request([CommandCodes.SyncNextMessage]);
+    expect(recv[0]).toBe(ResponseCodes.ContactMsgRecv);
+    expect(recv.subarray(-'incoming dm'.length).toString('utf8')).toBe('incoming dm');
+  });
+
+  it('does not echo a message our own node originated', async () => {
+    manager.emitMessage({
+      id: 'm2',
+      fromPublicKey: LOCAL_NODE.publicKey, // self
+      text: 'our own send',
+      timestamp: 1_750_000_000_000,
+    });
+    // No MsgWaiting push should arrive; the queue stays empty.
     const payload = await client.request([CommandCodes.SyncNextMessage]);
     expect(payload[0]).toBe(ResponseCodes.NoMoreMessages);
   });

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -253,11 +253,12 @@ describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
     expect(payload[1]).toBe(Constants.ErrorCodes.UnsupportedCmd);
   });
 
-  it('forwards SendChannelTxtMsg to the node and replies Sent', async () => {
+  it('forwards SendChannelTxtMsg to the node and replies Ok (not Sent)', async () => {
+    // The app's sendChannelTextMessage awaits Ok(0), not Sent(6).
     // [code=3][txtType=0][channelIdx=1][senderTimestamp:u32=0][text]
     const frame = [CommandCodes.SendChannelTxtMsg, 0, 1, 0, 0, 0, 0, ...Buffer.from('hi chan', 'utf8')];
     const payload = await client.request(frame);
-    expect(payload[0]).toBe(ResponseCodes.Sent);
+    expect(payload[0]).toBe(ResponseCodes.Ok);
     expect(manager.sendMessageMock).toHaveBeenCalledWith('hi chan', undefined, 1);
   });
 

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -55,9 +55,13 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
     this.localNode = localNode;
     this.contacts = contacts;
   }
+  sendMessageMock = vi.fn().mockResolvedValue(true);
   isConnected() { return this.localNode !== null; }
   getLocalNode() { return this.localNode; }
   getContacts() { return this.contacts; }
+  sendMessage(text: string, toPublicKey?: string, channelIdx?: number) {
+    return this.sendMessageMock(text, toPublicKey, channelIdx) as Promise<boolean>;
+  }
   emitMessage(msg: MeshCoreMessage) { this.emit('message', msg); }
 }
 
@@ -247,6 +251,39 @@ describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
     const payload = await client.request([0x7f]); // not a Phase-0 command
     expect(payload[0]).toBe(ResponseCodes.Err);
     expect(payload[1]).toBe(Constants.ErrorCodes.UnsupportedCmd);
+  });
+
+  it('forwards SendChannelTxtMsg to the node and replies Sent', async () => {
+    // [code=3][txtType=0][channelIdx=1][senderTimestamp:u32=0][text]
+    const frame = [CommandCodes.SendChannelTxtMsg, 0, 1, 0, 0, 0, 0, ...Buffer.from('hi chan', 'utf8')];
+    const payload = await client.request(frame);
+    expect(payload[0]).toBe(ResponseCodes.Sent);
+    expect(manager.sendMessageMock).toHaveBeenCalledWith('hi chan', undefined, 1);
+  });
+
+  it('forwards SendTxtMsg as a DM after resolving the contact prefix, replies Sent', async () => {
+    const prefix = Buffer.from('b1'.repeat(6), 'hex'); // first 6 bytes of the sample contact
+    // [code=2][txtType=0][attempt=0][senderTimestamp:u32=0][prefix:6][text]
+    const frame = [CommandCodes.SendTxtMsg, 0, 0, 0, 0, 0, 0, ...prefix, ...Buffer.from('hi dm', 'utf8')];
+    const payload = await client.request(frame);
+    expect(payload[0]).toBe(ResponseCodes.Sent);
+    expect(manager.sendMessageMock).toHaveBeenCalledWith('hi dm', 'b1'.repeat(32), undefined);
+  });
+
+  it('replies Err(NotFound) for a DM to an unknown contact prefix', async () => {
+    const prefix = Buffer.from('ff'.repeat(6), 'hex'); // no matching contact
+    const frame = [CommandCodes.SendTxtMsg, 0, 0, 0, 0, 0, 0, ...prefix, ...Buffer.from('x', 'utf8')];
+    const payload = await client.request(frame);
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(Constants.ErrorCodes.NotFound);
+    expect(manager.sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('replies Err when the node rejects the channel send', async () => {
+    manager.sendMessageMock.mockResolvedValueOnce(false);
+    const frame = [CommandCodes.SendChannelTxtMsg, 0, 0, 0, 0, 0, 0, ...Buffer.from('nope', 'utf8')];
+    const payload = await client.request(frame);
+    expect(payload[0]).toBe(ResponseCodes.Err);
   });
 
   it('counts connected clients', () => {

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Socket } from 'net';
+import { Constants } from '@liamcottle/meshcore.js';
+import { MeshCoreVirtualNodeServer, type MeshCoreVirtualNodeManager } from './meshcoreVirtualNodeServer.js';
+import {
+  CommandCodes,
+  ResponseCodes,
+  FRAME_APP_TO_NODE,
+  FRAME_NODE_TO_APP,
+} from './meshcoreCompanionCodec.js';
+import type { MeshCoreNode } from './meshcoreManager.js';
+
+// Audit logging is fire-and-forget; stub it so the test doesn't touch the DB.
+vi.mock('../services/database.js', () => ({
+  default: { auditLogAsync: vi.fn().mockResolvedValue(undefined) },
+}));
+
+const LOCAL_NODE: MeshCoreNode = {
+  publicKey: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2',
+  name: 'Phase0 Node',
+  advType: Constants.AdvType.Chat,
+  txPower: 20,
+  maxTxPower: 30,
+  radioFreq: 917.375, // MHz
+  radioBw: 250, // kHz
+  radioSf: 11,
+  radioCr: 5,
+  latitude: 29.7604,
+  longitude: -95.3698,
+};
+
+function makeManager(overrides: Partial<MeshCoreVirtualNodeManager> = {}): MeshCoreVirtualNodeManager {
+  return {
+    sourceId: 'src-test',
+    isConnected: () => true,
+    getLocalNode: () => LOCAL_NODE,
+    ...overrides,
+  };
+}
+
+/** Frame an app→node command (the byte layout the MeshCore app would send). */
+function frameCommand(payload: number[]): Buffer {
+  const header = Buffer.alloc(3);
+  header[0] = FRAME_APP_TO_NODE;
+  header.writeUInt16LE(payload.length, 1);
+  return Buffer.concat([header, Buffer.from(payload)]);
+}
+
+/**
+ * Tiny client: connects, lets you send command frames, and resolves the next
+ * complete node→app (0x3e) response frame's payload (response code byte first).
+ */
+class TestClient {
+  private socket = new Socket();
+  private buffer = Buffer.alloc(0);
+  private waiters: Array<(payload: Buffer) => void> = [];
+
+  async connect(port: number): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.socket.once('error', reject);
+      this.socket.connect(port, '127.0.0.1', () => resolve());
+    });
+    this.socket.on('data', (data) => this.onData(data));
+  }
+
+  private onData(data: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, data]);
+    while (this.buffer.length >= 3) {
+      if (this.buffer[0] !== FRAME_NODE_TO_APP) {
+        this.buffer = this.buffer.subarray(1);
+        continue;
+      }
+      const len = this.buffer.readUInt16LE(1);
+      if (this.buffer.length < 3 + len) break;
+      const payload = Buffer.from(this.buffer.subarray(3, 3 + len));
+      this.buffer = this.buffer.subarray(3 + len);
+      this.waiters.shift()?.(payload);
+    }
+  }
+
+  /** Send a command and await the next response payload. */
+  request(payload: number[]): Promise<Buffer> {
+    const p = new Promise<Buffer>((resolve) => this.waiters.push(resolve));
+    this.socket.write(frameCommand(payload));
+    return p;
+  }
+
+  /** Await the next N response payloads (for commands that reply with several frames). */
+  expectFrames(n: number): Promise<Buffer[]> {
+    return Promise.all(Array.from({ length: n }, () => new Promise<Buffer>((resolve) => this.waiters.push(resolve))));
+  }
+
+  send(payload: number[]): void {
+    this.socket.write(frameCommand(payload));
+  }
+
+  close(): void {
+    this.socket.destroy();
+  }
+}
+
+describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
+  let server: MeshCoreVirtualNodeServer;
+  let client: TestClient;
+
+  beforeEach(async () => {
+    server = new MeshCoreVirtualNodeServer({ port: 0, manager: makeManager() });
+    await server.start();
+    client = new TestClient();
+    await client.connect(server.getListeningPort()!);
+  });
+
+  afterEach(async () => {
+    client.close();
+    await server.stop();
+  });
+
+  it('replies to AppStart with SelfInfo carrying the real node identity', async () => {
+    const payload = await client.request([CommandCodes.AppStart, 1, 0, 0, 0, 0, 0, 0]); // appVer + 6 reserved
+    expect(payload[0]).toBe(ResponseCodes.SelfInfo);
+    // name is the remainder of the frame after the fixed SelfInfo fields
+    expect(payload.subarray(-LOCAL_NODE.name.length).toString('utf8')).toBe('Phase0 Node');
+  });
+
+  it('replies to GetDeviceTime with a plausible CurrTime', async () => {
+    const before = Math.floor(Date.now() / 1000);
+    const payload = await client.request([CommandCodes.GetDeviceTime]);
+    expect(payload[0]).toBe(ResponseCodes.CurrTime);
+    const epoch = payload.readUInt32LE(1);
+    expect(epoch).toBeGreaterThanOrEqual(before);
+    expect(epoch).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + 1);
+  });
+
+  it('replies to DeviceQuery with DeviceInfo', async () => {
+    const payload = await client.request([CommandCodes.DeviceQuery, 1]);
+    expect(payload[0]).toBe(ResponseCodes.DeviceInfo);
+  });
+
+  it('replies to GetContacts with ContactsStart(0) then EndOfContacts', async () => {
+    client.send([CommandCodes.GetContacts, 0, 0, 0, 0]); // since:u32
+    const [start, end] = await client.expectFrames(2);
+    expect(start[0]).toBe(ResponseCodes.ContactsStart);
+    expect(start.readUInt32LE(1)).toBe(0);
+    expect(end[0]).toBe(ResponseCodes.EndOfContacts);
+  });
+
+  it('replies to SyncNextMessage with NoMoreMessages', async () => {
+    const payload = await client.request([CommandCodes.SyncNextMessage]);
+    expect(payload[0]).toBe(ResponseCodes.NoMoreMessages);
+  });
+
+  it('replies to an unsupported command with Err(UnsupportedCmd)', async () => {
+    const payload = await client.request([0x7f]); // not a Phase-0 command
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(Constants.ErrorCodes.UnsupportedCmd);
+  });
+
+  it('counts connected clients', () => {
+    expect(server.getClientCount()).toBe(1);
+  });
+});
+
+describe('MeshCoreVirtualNodeServer — local node not ready', () => {
+  it('replies to AppStart with Err(BadState) when no local node', async () => {
+    const server = new MeshCoreVirtualNodeServer({
+      port: 0,
+      manager: makeManager({ getLocalNode: () => null, isConnected: () => false }),
+    });
+    await server.start();
+    const client = new TestClient();
+    await client.connect(server.getListeningPort()!);
+
+    const payload = await client.request([CommandCodes.AppStart, 1, 0, 0, 0, 0, 0, 0]);
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(Constants.ErrorCodes.BadState);
+
+    client.close();
+    await server.stop();
+  });
+});

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -235,6 +235,39 @@ describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
     expect(recv.subarray(-'incoming dm'.length).toString('utf8')).toBe('incoming dm');
   });
 
+  it('delivers an incoming CHANNEL message as ChannelMsgRecv (marker in fromPublicKey)', async () => {
+    const push = new Promise<Buffer>((resolve) => (client as any).waiters.push(resolve));
+    // Incoming channel messages carry the channel marker in fromPublicKey, with
+    // toPublicKey unset, and the sender name in fromName.
+    manager.emitMessage({
+      id: 'c1',
+      fromPublicKey: 'channel-1',
+      fromName: 'Yeraze MC Sandbox',
+      text: '🤖 Copy that',
+      timestamp: 1_750_000_000_000,
+    });
+    expect((await push)[0]).toBe(PushCodes.MsgWaiting);
+
+    const recv = await client.request([CommandCodes.SyncNextMessage]);
+    expect(recv[0]).toBe(ResponseCodes.ChannelMsgRecv);
+    expect(recv.readInt8(1)).toBe(1); // channel index
+    // sender name is reconstructed into the channel body the firmware would deliver.
+    // ChannelMsgRecv header = code + channelIdx + pathLen + txtType + senderTs(4) = 8 bytes.
+    expect(recv.subarray(8).toString('utf8')).toBe('Yeraze MC Sandbox: 🤖 Copy that');
+  });
+
+  it('does not echo our own channel transmission heard back (matching local name)', async () => {
+    manager.emitMessage({
+      id: 'c2',
+      fromPublicKey: 'channel-1',
+      fromName: LOCAL_NODE.name, // our own node's name → our transmission
+      text: 'my own msg',
+      timestamp: 1_750_000_000_000,
+    });
+    const payload = await client.request([CommandCodes.SyncNextMessage]);
+    expect(payload[0]).toBe(ResponseCodes.NoMoreMessages);
+  });
+
   it('does not echo a message our own node originated', async () => {
     manager.emitMessage({
       id: 'm2',

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -1,0 +1,344 @@
+import { Server, Socket } from 'net';
+import { EventEmitter } from 'events';
+import { logger } from '../utils/logger.js';
+import databaseService from '../services/database.js';
+import type { MeshCoreNode, TelemetryMode } from './meshcoreManager.js';
+import {
+  CommandCodes,
+  ErrorCodes,
+  SUPPORTED_COMPANION_PROTOCOL_VERSION,
+  parseAppFrames,
+  frameNodeToApp,
+  encodeSelfInfo,
+  encodeCurrTime,
+  encodeDeviceInfo,
+  encodeContactsStart,
+  encodeEndOfContacts,
+  encodeNoMoreMessages,
+  encodeOk,
+  encodeErr,
+  packTelemetryMode,
+  pubKeyHexToBytes,
+  degreesToFixed,
+  mhzToWireFreq,
+  khzToWireBw,
+  type ParsedCommand,
+} from './meshcoreCompanionCodec.js';
+
+/**
+ * Minimal surface the virtual node server needs from a MeshCoreManager. Kept as
+ * a narrow interface (rather than importing the whole manager) so the server is
+ * unit-testable with a fake and so we avoid a runtime import cycle — the manager
+ * imports this module to construct the server.
+ */
+export interface MeshCoreVirtualNodeManager {
+  readonly sourceId: string;
+  isConnected(): boolean;
+  getLocalNode(): MeshCoreNode | null;
+}
+
+export interface MeshCoreVirtualNodeServerOptions {
+  port: number;
+  manager: MeshCoreVirtualNodeManager;
+  /** Allow config-mutating commands through to the real node (default false). */
+  allowAdminCommands?: boolean;
+}
+
+/**
+ * Per-source virtual node config persisted in `sources.config.virtualNode` for
+ * meshcore sources. Mirrors the Meshtastic `VirtualNodeConfig` shape.
+ */
+export interface MeshCoreVirtualNodeConfig {
+  enabled: boolean;
+  port: number;
+  allowAdminCommands: boolean;
+}
+
+interface ConnectedClient {
+  socket: Socket;
+  id: string;
+  buffer: Buffer;
+  connectedAt: Date;
+  lastActivity: Date;
+}
+
+/**
+ * MeshCore Virtual Node Server — Phase 0 (handshake).
+ *
+ * Acts as the *device end* of the MeshCore companion protocol over TCP, letting
+ * the MeshCore mobile app connect to MeshMonitor over WiFi and see the real
+ * node (which MeshMonitor already holds the companion slot on) as if it were
+ * local. See docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md.
+ *
+ * Phase 0 brings the app to "connected, identity shown, empty mailbox":
+ *   AppStart→SelfInfo, GetDeviceTime→CurrTime, DeviceQuery→DeviceInfo,
+ *   GetContacts→(empty), SyncNextMessage→NoMoreMessages.
+ * Reads are synthesized from the manager's local-node state; nothing is
+ * forwarded to the real node yet (that arrives in Phase 2). Structure mirrors
+ * src/server/virtualNodeServer.ts (the proven Meshtastic equivalent).
+ */
+export class MeshCoreVirtualNodeServer extends EventEmitter {
+  private readonly options: MeshCoreVirtualNodeServerOptions;
+  private readonly allowAdminCommands: boolean;
+  private server: Server | null = null;
+  private clients: Map<string, ConnectedClient> = new Map();
+  private nextClientId = 1;
+  private cleanupTimer: NodeJS.Timeout | null = null;
+
+  private readonly MAX_FRAME_BYTES = 4096;
+  private readonly CLIENT_TIMEOUT_MS = 300000; // 5 min inactivity
+  private readonly CLEANUP_INTERVAL_MS = 60000;
+
+  constructor(options: MeshCoreVirtualNodeServerOptions) {
+    super();
+    this.options = options;
+    this.allowAdminCommands = options.allowAdminCommands ?? false;
+  }
+
+  get sourceId(): string {
+    return this.options.manager.sourceId;
+  }
+
+  async start(): Promise<void> {
+    if (this.server) {
+      logger.warn(`[MeshCore VN ${this.sourceId}] already started`);
+      return;
+    }
+
+    return new Promise((resolve, reject) => {
+      this.server = new Server((socket) => this.handleNewClient(socket));
+
+      this.server.on('error', (error) => {
+        logger.error(`[MeshCore VN ${this.sourceId}] server error:`, error);
+        this.emit('error', error);
+        reject(error);
+      });
+
+      this.server.listen(this.options.port, () => {
+        logger.info(`🌐 [MeshCore VN ${this.sourceId}] listening on port ${this.options.port}`);
+        this.cleanupTimer = setInterval(() => this.cleanupInactiveClients(), this.CLEANUP_INTERVAL_MS);
+        this.emit('listening');
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+
+    for (const client of this.clients.values()) {
+      client.socket.destroy();
+    }
+    this.clients.clear();
+
+    return new Promise((resolve) => {
+      this.server?.close(() => {
+        logger.info(`🛑 [MeshCore VN ${this.sourceId}] stopped`);
+        this.server = null;
+        resolve();
+      });
+    });
+  }
+
+  isRunning(): boolean {
+    return this.server !== null;
+  }
+
+  getClientCount(): number {
+    return this.clients.size;
+  }
+
+  /** Actual listening port (useful when started on port 0 in tests). */
+  getListeningPort(): number | null {
+    const addr = this.server?.address();
+    return addr && typeof addr === 'object' ? addr.port : null;
+  }
+
+  isAdminCommandsAllowed(): boolean {
+    return this.allowAdminCommands;
+  }
+
+  // ───────────────────────── client lifecycle ─────────────────────────
+
+  private handleNewClient(socket: Socket): void {
+    const clientId = `mcvn-${this.nextClientId++}`;
+    const now = new Date();
+    this.clients.set(clientId, { socket, id: clientId, buffer: Buffer.alloc(0), connectedAt: now, lastActivity: now });
+    logger.info(`📱 [MeshCore VN ${this.sourceId}] client connected: ${clientId} (${this.clients.size} total)`);
+
+    databaseService.auditLogAsync(
+      null,
+      'meshcore_virtual_node_connect',
+      'meshcore_virtual_node',
+      JSON.stringify({ clientId, sourceId: this.sourceId, ip: socket.remoteAddress || 'unknown' }),
+      socket.remoteAddress || null,
+    ).catch((error) => logger.error(`[MeshCore VN ${this.sourceId}] audit log (connect) failed:`, error));
+
+    socket.on('data', (data: Buffer) => this.handleClientData(clientId, data));
+    socket.on('close', () => this.handleClientDisconnect(clientId));
+    socket.on('error', (error) => {
+      logger.error(`[MeshCore VN ${this.sourceId}] client ${clientId} error:`, error.message);
+      this.handleClientDisconnect(clientId);
+    });
+
+    this.emit('client-connected', clientId);
+  }
+
+  private handleClientDisconnect(clientId: string): void {
+    const client = this.clients.get(clientId);
+    if (!client) return;
+    this.clients.delete(clientId);
+    logger.info(`📱 [MeshCore VN ${this.sourceId}] client disconnected: ${clientId} (${this.clients.size} remaining)`);
+
+    databaseService.auditLogAsync(
+      null,
+      'meshcore_virtual_node_disconnect',
+      'meshcore_virtual_node',
+      JSON.stringify({ clientId, sourceId: this.sourceId, ip: client.socket.remoteAddress || 'unknown' }),
+      client.socket.remoteAddress || null,
+    ).catch((error) => logger.error(`[MeshCore VN ${this.sourceId}] audit log (disconnect) failed:`, error));
+
+    this.emit('client-disconnected', clientId);
+  }
+
+  private handleClientData(clientId: string, data: Buffer): void {
+    const client = this.clients.get(clientId);
+    if (!client) return;
+    client.lastActivity = new Date();
+    client.buffer = Buffer.concat([client.buffer, data]);
+
+    // Guard against an unbounded buffer from a misbehaving / non-protocol peer.
+    if (client.buffer.length > this.MAX_FRAME_BYTES * 4) {
+      logger.warn(`[MeshCore VN ${this.sourceId}] ${clientId} buffer overflow, dropping`);
+      client.socket.destroy();
+      return;
+    }
+
+    const { commands, rest } = parseAppFrames(client.buffer);
+    client.buffer = rest;
+    for (const command of commands) {
+      this.dispatchCommand(clientId, command);
+    }
+  }
+
+  // ───────────────────────── command dispatch ─────────────────────────
+
+  private dispatchCommand(clientId: string, command: ParsedCommand): void {
+    try {
+      switch (command.code) {
+        case CommandCodes.AppStart:
+          this.handleAppStart(clientId, command);
+          break;
+        case CommandCodes.GetDeviceTime:
+          this.send(clientId, encodeCurrTime(Math.floor(Date.now() / 1000)));
+          break;
+        case CommandCodes.SetDeviceTime:
+          // Phase 0: accept but no-op (the real node keeps its own clock).
+          this.send(clientId, encodeOk());
+          break;
+        case CommandCodes.DeviceQuery:
+          this.handleDeviceQuery(clientId);
+          break;
+        case CommandCodes.GetContacts:
+          // Phase 0: advertise an empty contact list. Phase 1 fills this in.
+          this.send(clientId, encodeContactsStart(0));
+          this.send(clientId, encodeEndOfContacts(0));
+          break;
+        case CommandCodes.SyncNextMessage:
+          // Phase 0: mailbox always empty. Phase 1 drains mirrored messages.
+          this.send(clientId, encodeNoMoreMessages());
+          break;
+        default:
+          logger.debug(`[MeshCore VN ${this.sourceId}] unsupported command ${command.code} from ${clientId} (phase 0)`);
+          this.send(clientId, encodeErr(ErrorCodes.UnsupportedCmd));
+          break;
+      }
+    } catch (error) {
+      logger.error(`[MeshCore VN ${this.sourceId}] error handling command ${command.code} from ${clientId}:`, error);
+    }
+  }
+
+  private handleAppStart(clientId: string, command: ParsedCommand): void {
+    const localNode = this.options.manager.getLocalNode();
+    if (!localNode || !this.options.manager.isConnected()) {
+      logger.warn(`[MeshCore VN ${this.sourceId}] AppStart from ${clientId} but local node not ready — replying BadState`);
+      this.send(clientId, encodeErr(ErrorCodes.BadState));
+      return;
+    }
+
+    logger.info(
+      `[MeshCore VN ${this.sourceId}] AppStart from ${clientId}` +
+        `${command.appName ? ` (app "${command.appName}")` : ''} → SelfInfo for "${localNode.name}"`,
+    );
+    this.send(clientId, encodeSelfInfo(this.buildSelfInfo(localNode)));
+  }
+
+  private handleDeviceQuery(clientId: string): void {
+    const localNode = this.options.manager.getLocalNode();
+    this.send(clientId, encodeDeviceInfo({
+      firmwareVer: localNode?.firmwareVer ?? SUPPORTED_COMPANION_PROTOCOL_VERSION,
+      firmwareBuildDate: localNode?.firmwareBuild ?? '',
+      manufacturerModel: localNode?.model || 'MeshMonitor Virtual Node',
+    }));
+  }
+
+  /** Map MeshMonitor's local-node record to the SelfInfo wire structure. */
+  private buildSelfInfo(node: MeshCoreNode): Parameters<typeof encodeSelfInfo>[0] {
+    return {
+      type: node.advType ?? 1,
+      txPower: node.txPower ?? 0,
+      maxTxPower: node.maxTxPower ?? 0,
+      publicKey: pubKeyHexToBytes(node.publicKey),
+      advLat: degreesToFixed(node.latitude),
+      advLon: degreesToFixed(node.longitude),
+      multiAcks: 0,
+      advLocPolicy: node.advLocPolicy ?? 0,
+      telemetryMode: packTelemetryMode(
+        this.telemetryModeToWire(node.telemetryModeBase),
+        this.telemetryModeToWire(node.telemetryModeLoc),
+        this.telemetryModeToWire(node.telemetryModeEnv),
+      ),
+      manualAddContacts: 0,
+      radioFreq: mhzToWireFreq(node.radioFreq),
+      radioBw: khzToWireBw(node.radioBw),
+      radioSf: node.radioSf ?? 0,
+      radioCr: node.radioCr ?? 0,
+      name: node.name ?? '',
+    };
+  }
+
+  /** Map MeshMonitor's string telemetry mode back to the wire's 2-bit value. */
+  private telemetryModeToWire(mode?: TelemetryMode): number {
+    switch (mode) {
+      case 'device': return 1;
+      case 'always': return 2;
+      default: return 0; // 'never' / undefined
+    }
+  }
+
+  // ───────────────────────── io ─────────────────────────
+
+  private send(clientId: string, payload: Uint8Array): void {
+    const client = this.clients.get(clientId);
+    if (!client || client.socket.destroyed || !client.socket.writable) return;
+    client.socket.write(frameNodeToApp(payload), (error) => {
+      if (error) logger.error(`[MeshCore VN ${this.sourceId}] failed to send to ${clientId}:`, error.message);
+    });
+  }
+
+  private cleanupInactiveClients(): void {
+    const now = Date.now();
+    for (const [clientId, client] of this.clients.entries()) {
+      if (now - client.lastActivity.getTime() > this.CLIENT_TIMEOUT_MS) {
+        logger.info(`[MeshCore VN ${this.sourceId}] ${clientId} inactive, disconnecting`);
+        client.socket.destroy();
+        this.handleClientDisconnect(clientId);
+      }
+    }
+  }
+}

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -2,7 +2,8 @@ import { Server, Socket } from 'net';
 import { EventEmitter } from 'events';
 import { logger } from '../utils/logger.js';
 import databaseService from '../services/database.js';
-import type { MeshCoreNode, TelemetryMode } from './meshcoreManager.js';
+import type { MeshCoreNode, TelemetryMode, MeshCoreContact, MeshCoreMessage } from './meshcoreManager.js';
+import databaseServiceDefault from '../services/database.js';
 import {
   CommandCodes,
   ErrorCodes,
@@ -13,13 +14,21 @@ import {
   encodeCurrTime,
   encodeDeviceInfo,
   encodeContactsStart,
+  encodeContact,
   encodeEndOfContacts,
+  encodeChannelInfo,
+  encodeBatteryVoltage,
+  encodeContactMsgRecv,
+  encodeChannelMsgRecv,
+  encodeMsgWaitingPush,
   encodeNoMoreMessages,
   encodeOk,
   encodeErr,
   packTelemetryMode,
   pubKeyHexToBytes,
+  hexToBytes,
   degreesToFixed,
+  toEpochSeconds,
   mhzToWireFreq,
   khzToWireBw,
   type ParsedCommand,
@@ -35,6 +44,25 @@ export interface MeshCoreVirtualNodeManager {
   readonly sourceId: string;
   isConnected(): boolean;
   getLocalNode(): MeshCoreNode | null;
+  getContacts(): MeshCoreContact[];
+  /** EventEmitter surface — the manager emits 'message' with a MeshCoreMessage. */
+  on(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
+  off(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
+}
+
+/** Reverse map of command codes → names, for human-readable command logging. */
+const COMMAND_NAMES: Record<number, string> = Object.fromEntries(
+  Object.entries(CommandCodes).map(([name, code]) => [code, name]),
+);
+
+/** Minimal channels-repo surface the server needs (subset of DbChannel). */
+interface ChannelRow {
+  id: number;
+  name: string;
+  psk?: string; // base64-encoded 16-byte secret
+}
+interface ChannelsDb {
+  channels: { getAllChannels(sourceId?: string): Promise<ChannelRow[]> };
 }
 
 export interface MeshCoreVirtualNodeServerOptions {
@@ -42,6 +70,8 @@ export interface MeshCoreVirtualNodeServerOptions {
   manager: MeshCoreVirtualNodeManager;
   /** Allow config-mutating commands through to the real node (default false). */
   allowAdminCommands?: boolean;
+  /** Injectable channels source; defaults to the real DatabaseService facade. */
+  databaseService?: ChannelsDb;
 }
 
 /**
@@ -60,6 +90,13 @@ interface ConnectedClient {
   buffer: Buffer;
   connectedAt: Date;
   lastActivity: Date;
+  /**
+   * Per-client inbound message queue. Seeded empty at connect (mirroring a
+   * freshly-synced device) and filled with LIVE messages as they arrive, so
+   * the app's local history isn't duplicated on every reconnect. Drained one
+   * at a time by SyncNextMessage.
+   */
+  pendingMessages: MeshCoreMessage[];
 }
 
 /**
@@ -80,10 +117,12 @@ interface ConnectedClient {
 export class MeshCoreVirtualNodeServer extends EventEmitter {
   private readonly options: MeshCoreVirtualNodeServerOptions;
   private readonly allowAdminCommands: boolean;
+  private readonly db: ChannelsDb;
   private server: Server | null = null;
   private clients: Map<string, ConnectedClient> = new Map();
   private nextClientId = 1;
   private cleanupTimer: NodeJS.Timeout | null = null;
+  private readonly onManagerMessage = (msg: MeshCoreMessage) => this.handleIncomingMessage(msg);
 
   private readonly MAX_FRAME_BYTES = 4096;
   private readonly CLIENT_TIMEOUT_MS = 300000; // 5 min inactivity
@@ -93,6 +132,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     super();
     this.options = options;
     this.allowAdminCommands = options.allowAdminCommands ?? false;
+    this.db = options.databaseService ?? (databaseServiceDefault as unknown as ChannelsDb);
   }
 
   get sourceId(): string {
@@ -117,6 +157,8 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       this.server.listen(this.options.port, () => {
         logger.info(`🌐 [MeshCore VN ${this.sourceId}] listening on port ${this.options.port}`);
         this.cleanupTimer = setInterval(() => this.cleanupInactiveClients(), this.CLEANUP_INTERVAL_MS);
+        // Relay live incoming mesh messages to connected app clients.
+        this.options.manager.on('message', this.onManagerMessage);
         this.emit('listening');
         resolve();
       });
@@ -130,6 +172,8 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       clearInterval(this.cleanupTimer);
       this.cleanupTimer = null;
     }
+
+    this.options.manager.off('message', this.onManagerMessage);
 
     for (const client of this.clients.values()) {
       client.socket.destroy();
@@ -168,7 +212,14 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
   private handleNewClient(socket: Socket): void {
     const clientId = `mcvn-${this.nextClientId++}`;
     const now = new Date();
-    this.clients.set(clientId, { socket, id: clientId, buffer: Buffer.alloc(0), connectedAt: now, lastActivity: now });
+    this.clients.set(clientId, {
+      socket,
+      id: clientId,
+      buffer: Buffer.alloc(0),
+      connectedAt: now,
+      lastActivity: now,
+      pendingMessages: [],
+    });
     logger.info(`📱 [MeshCore VN ${this.sourceId}] client connected: ${clientId} (${this.clients.size} total)`);
 
     databaseService.auditLogAsync(
@@ -229,6 +280,13 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
   // ───────────────────────── command dispatch ─────────────────────────
 
   private dispatchCommand(clientId: string, command: ParsedCommand): void {
+    // Phase-0 visibility: log every inbound command (name + raw bytes) so we
+    // can observe exactly what the MeshCore app requests and in what order.
+    // TODO(phase1): drop to debug once the command surface is implemented.
+    logger.info(
+      `[MeshCore VN ${this.sourceId}] ◀ cmd ${command.code} (${COMMAND_NAMES[command.code] ?? 'unknown'}) ` +
+        `from ${clientId} [${command.payload.length}B]`,
+    );
     try {
       switch (command.code) {
         case CommandCodes.AppStart:
@@ -245,16 +303,24 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
           this.handleDeviceQuery(clientId);
           break;
         case CommandCodes.GetContacts:
-          // Phase 0: advertise an empty contact list. Phase 1 fills this in.
-          this.send(clientId, encodeContactsStart(0));
-          this.send(clientId, encodeEndOfContacts(0));
+          this.handleGetContacts(clientId);
+          break;
+        case CommandCodes.GetChannel:
+          void this.handleGetChannel(clientId, command.channelIdx ?? 0);
+          break;
+        case CommandCodes.GetBatteryVoltage:
+          this.handleGetBatteryVoltage(clientId);
           break;
         case CommandCodes.SyncNextMessage:
-          // Phase 0: mailbox always empty. Phase 1 drains mirrored messages.
-          this.send(clientId, encodeNoMoreMessages());
+          this.handleSyncNextMessage(clientId);
+          break;
+        case CommandCodes.SetFloodScope:
+          // Read-only phase: acknowledge but don't apply (avoids the app
+          // treating an Err as a fatal handshake failure). Phase 3 forwards it.
+          this.send(clientId, encodeOk());
           break;
         default:
-          logger.debug(`[MeshCore VN ${this.sourceId}] unsupported command ${command.code} from ${clientId} (phase 0)`);
+          logger.debug(`[MeshCore VN ${this.sourceId}] unsupported command ${command.code} from ${clientId}`);
           this.send(clientId, encodeErr(ErrorCodes.UnsupportedCmd));
           break;
       }
@@ -285,6 +351,110 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       firmwareBuildDate: localNode?.firmwareBuild ?? '',
       manufacturerModel: localNode?.model || 'MeshMonitor Virtual Node',
     }));
+  }
+
+  /** GetContacts → ContactsStart(N) · N×Contact · EndOfContacts. */
+  private handleGetContacts(clientId: string): void {
+    const contacts = this.options.manager.getContacts();
+    this.send(clientId, encodeContactsStart(contacts.length));
+    let mostRecentLastMod = 0;
+    for (const c of contacts) {
+      const lastAdvert = toEpochSeconds(c.lastAdvert ?? c.lastSeen);
+      const lastMod = toEpochSeconds(c.lastSeen ?? c.lastAdvert);
+      mostRecentLastMod = Math.max(mostRecentLastMod, lastMod);
+      this.send(clientId, encodeContact({
+        publicKey: pubKeyHexToBytes(c.publicKey),
+        type: c.advType ?? 1,
+        flags: 0,
+        // OUT_PATH_UNKNOWN (-1) when no cached route, else the hop count.
+        outPathLen: c.pathLen == null ? -1 : c.pathLen,
+        outPath: c.outPath ? hexToBytes(c.outPath) : Buffer.alloc(0),
+        advName: c.advName || c.name || '',
+        lastAdvert,
+        advLat: degreesToFixed(c.latitude),
+        advLon: degreesToFixed(c.longitude),
+        lastMod,
+      }));
+    }
+    this.send(clientId, encodeEndOfContacts(mostRecentLastMod));
+    logger.info(`[MeshCore VN ${this.sourceId}] ▶ ${contacts.length} contacts to ${clientId}`);
+  }
+
+  /** GetChannel(idx) → ChannelInfo from the synced channel list, or Err(NotFound). */
+  private async handleGetChannel(clientId: string, channelIdx: number): Promise<void> {
+    try {
+      const channels = await this.db.channels.getAllChannels(this.sourceId);
+      const row = channels.find((ch) => ch.id === channelIdx);
+      if (!row) {
+        // Tells the app it has reached the end of the configured slots.
+        this.send(clientId, encodeErr(ErrorCodes.NotFound));
+        return;
+      }
+      const secret = row.psk ? Buffer.from(row.psk, 'base64') : Buffer.alloc(16);
+      this.send(clientId, encodeChannelInfo(channelIdx, row.name || '', secret));
+      logger.info(`[MeshCore VN ${this.sourceId}] ▶ channel ${channelIdx} ("${row.name}") to ${clientId}`);
+    } catch (err) {
+      logger.error(`[MeshCore VN ${this.sourceId}] GetChannel ${channelIdx} failed: ${(err as Error).message}`);
+      this.send(clientId, encodeErr(ErrorCodes.NotFound));
+    }
+  }
+
+  /** GetBatteryVoltage → BatteryVoltage from the local node's last telemetry. */
+  private handleGetBatteryVoltage(clientId: string): void {
+    const mv = this.options.manager.getLocalNode()?.batteryMv ?? 0;
+    this.send(clientId, encodeBatteryVoltage(mv));
+  }
+
+  /** SyncNextMessage → next queued incoming message, or NoMoreMessages. */
+  private handleSyncNextMessage(clientId: string): void {
+    const client = this.clients.get(clientId);
+    const msg = client?.pendingMessages.shift();
+    if (!msg) {
+      this.send(clientId, encodeNoMoreMessages());
+      return;
+    }
+    this.send(clientId, this.encodeIncomingMessage(msg));
+  }
+
+  /**
+   * Fan a newly-arrived incoming mesh message out to every connected app
+   * client: enqueue it and nudge the app with a MsgWaiting push so it drains
+   * via SyncNextMessage. Messages our own node originated are skipped so the
+   * app doesn't see its/our own sends echoed back.
+   */
+  private handleIncomingMessage(msg: MeshCoreMessage): void {
+    const selfKey = this.options.manager.getLocalNode()?.publicKey?.toLowerCase();
+    if (selfKey && msg.fromPublicKey?.toLowerCase() === selfKey) return;
+
+    for (const [clientId, client] of this.clients.entries()) {
+      client.pendingMessages.push(msg);
+      this.send(clientId, encodeMsgWaitingPush());
+    }
+  }
+
+  /** Map a stored MeshCoreMessage to the right recv frame (channel vs direct). */
+  private encodeIncomingMessage(msg: MeshCoreMessage): Buffer {
+    const senderTimestamp = toEpochSeconds(msg.timestamp);
+    const channelMatch = /^channel-(\d+)$/.exec(msg.toPublicKey ?? '');
+    if (channelMatch) {
+      // Channel packets carry the sender's name inline; reconstruct it so the
+      // app renders the originator the way the firmware would deliver it.
+      const text = msg.fromName ? `${msg.fromName}: ${msg.text}` : msg.text;
+      return encodeChannelMsgRecv({
+        channelIdx: Number(channelMatch[1]),
+        pathLen: 0xff, // delivered direct (we don't track the relay path here)
+        txtType: 0,
+        senderTimestamp,
+        text,
+      });
+    }
+    return encodeContactMsgRecv({
+      pubKeyPrefix: hexToBytes(msg.fromPublicKey).subarray(0, 6),
+      pathLen: 0xff,
+      txtType: 0,
+      senderTimestamp,
+      text: msg.text,
+    });
   }
 
   /** Map MeshMonitor's local-node record to the SelfInfo wire structure. */

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -490,8 +490,15 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
    * app doesn't see its/our own sends echoed back.
    */
   private handleIncomingMessage(msg: MeshCoreMessage): void {
-    const selfKey = this.options.manager.getLocalNode()?.publicKey?.toLowerCase();
+    const local = this.options.manager.getLocalNode();
+    const selfKey = local?.publicKey?.toLowerCase();
+    // Skip DMs our own node originated (echoed back through the manager).
     if (selfKey && msg.fromPublicKey?.toLowerCase() === selfKey) return;
+    // Skip our own channel transmissions heard back over the air: channel
+    // packets carry no sender key (fromPublicKey is the synthetic `channel-N`),
+    // so identify them by the name prefix. The app already shows these
+    // optimistically on send — re-delivering would duplicate them.
+    if (this.isChannelMessage(msg) && local?.name && msg.fromName === local.name) return;
 
     for (const [clientId, client] of this.clients.entries()) {
       client.pendingMessages.push(msg);
@@ -499,10 +506,18 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     }
   }
 
+  /** True when the message belongs to a channel (marker in either key field). */
+  private isChannelMessage(msg: MeshCoreMessage): boolean {
+    return /^channel-\d+$/.test(msg.fromPublicKey ?? '') || /^channel-\d+$/.test(msg.toPublicKey ?? '');
+  }
+
   /** Map a stored MeshCoreMessage to the right recv frame (channel vs direct). */
   private encodeIncomingMessage(msg: MeshCoreMessage): Buffer {
     const senderTimestamp = toEpochSeconds(msg.timestamp);
-    const channelMatch = /^channel-(\d+)$/.exec(msg.toPublicKey ?? '');
+    // The `channel-N` marker lands in toPublicKey for messages we sent and in
+    // fromPublicKey for messages we received — check both.
+    const channelMatch =
+      /^channel-(\d+)$/.exec(msg.toPublicKey ?? '') ?? /^channel-(\d+)$/.exec(msg.fromPublicKey ?? '');
     if (channelMatch) {
       // Channel packets carry the sender's name inline; reconstruct it so the
       // app renders the originator the way the firmware would deliver it.

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -21,6 +21,7 @@ import {
   encodeContactMsgRecv,
   encodeChannelMsgRecv,
   encodeMsgWaitingPush,
+  encodeSent,
   encodeNoMoreMessages,
   encodeOk,
   encodeErr,
@@ -45,6 +46,8 @@ export interface MeshCoreVirtualNodeManager {
   isConnected(): boolean;
   getLocalNode(): MeshCoreNode | null;
   getContacts(): MeshCoreContact[];
+  /** Send a text message to the real node: channel (by index) or DM (full key). */
+  sendMessage(text: string, toPublicKey?: string, channelIdx?: number): Promise<boolean>;
   /** EventEmitter surface — the manager emits 'message' with a MeshCoreMessage. */
   on(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
   off(event: 'message', listener: (msg: MeshCoreMessage) => void): unknown;
@@ -314,6 +317,12 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
         case CommandCodes.SyncNextMessage:
           this.handleSyncNextMessage(clientId);
           break;
+        case CommandCodes.SendChannelTxtMsg:
+          void this.handleSendChannelTxtMsg(clientId, command);
+          break;
+        case CommandCodes.SendTxtMsg:
+          void this.handleSendTxtMsg(clientId, command);
+          break;
         case CommandCodes.SetFloodScope:
           // Read-only phase: acknowledge but don't apply (avoids the app
           // treating an Err as a fatal handshake failure). Phase 3 forwards it.
@@ -414,6 +423,61 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       return;
     }
     this.send(clientId, this.encodeIncomingMessage(msg));
+  }
+
+  /** Default delivery-timeout hint (ms) returned in Sent responses. */
+  private readonly SEND_EST_TIMEOUT_MS = 8000;
+
+  /** SendChannelTxtMsg → forward to the real node on the given channel, reply Sent. */
+  private async handleSendChannelTxtMsg(clientId: string, cmd: ParsedCommand): Promise<void> {
+    const text = cmd.text ?? '';
+    const channelIdx = cmd.channelIdx ?? 0;
+    try {
+      const ok = await this.options.manager.sendMessage(text, undefined, channelIdx);
+      if (ok) {
+        logger.info(`[MeshCore VN ${this.sourceId}] ▶ forwarded channel ${channelIdx} msg from ${clientId} (${text.length} chars)`);
+        // Channel sends have no per-message ACK → no expectedAckCrc.
+        this.send(clientId, encodeSent(0, 0, this.SEND_EST_TIMEOUT_MS));
+      } else {
+        logger.warn(`[MeshCore VN ${this.sourceId}] channel send from ${clientId} failed at the node`);
+        this.send(clientId, encodeErr(ErrorCodes.BadState));
+      }
+    } catch (err) {
+      logger.error(`[MeshCore VN ${this.sourceId}] channel send from ${clientId} threw: ${(err as Error).message}`);
+      this.send(clientId, encodeErr(ErrorCodes.BadState));
+    }
+  }
+
+  /** SendTxtMsg → resolve the 6-byte prefix to a contact, forward a DM, reply Sent. */
+  private async handleSendTxtMsg(clientId: string, cmd: ParsedCommand): Promise<void> {
+    const text = cmd.text ?? '';
+    const prefixHex = (cmd.pubKeyPrefix ?? Buffer.alloc(0)).toString('hex');
+    const fullKey = this.resolveContactKey(prefixHex);
+    if (!fullKey) {
+      logger.warn(`[MeshCore VN ${this.sourceId}] DM from ${clientId} to unknown contact prefix ${prefixHex}`);
+      this.send(clientId, encodeErr(ErrorCodes.NotFound));
+      return;
+    }
+    try {
+      const ok = await this.options.manager.sendMessage(text, fullKey);
+      if (ok) {
+        logger.info(`[MeshCore VN ${this.sourceId}] ▶ forwarded DM from ${clientId} to ${prefixHex}… (${text.length} chars)`);
+        this.send(clientId, encodeSent(0, 0, this.SEND_EST_TIMEOUT_MS));
+      } else {
+        logger.warn(`[MeshCore VN ${this.sourceId}] DM from ${clientId} failed at the node`);
+        this.send(clientId, encodeErr(ErrorCodes.BadState));
+      }
+    } catch (err) {
+      logger.error(`[MeshCore VN ${this.sourceId}] DM from ${clientId} threw: ${(err as Error).message}`);
+      this.send(clientId, encodeErr(ErrorCodes.BadState));
+    }
+  }
+
+  /** Resolve a (≥6-byte) public-key prefix to a full contact key, or null. */
+  private resolveContactKey(prefixHex: string): string | undefined {
+    if (!prefixHex) return undefined;
+    const lc = prefixHex.toLowerCase();
+    return this.options.manager.getContacts().find((c) => c.publicKey?.toLowerCase().startsWith(lc))?.publicKey;
   }
 
   /**

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -283,10 +283,9 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
   // ───────────────────────── command dispatch ─────────────────────────
 
   private dispatchCommand(clientId: string, command: ParsedCommand): void {
-    // Phase-0 visibility: log every inbound command (name + raw bytes) so we
-    // can observe exactly what the MeshCore app requests and in what order.
-    // TODO(phase1): drop to debug once the command surface is implemented.
-    logger.info(
+    // Per-command trace — useful when debugging app behaviour, but too chatty
+    // for production, so keep it at debug.
+    logger.debug(
       `[MeshCore VN ${this.sourceId}] ◀ cmd ${command.code} (${COMMAND_NAMES[command.code] ?? 'unknown'}) ` +
         `from ${clientId} [${command.payload.length}B]`,
     );
@@ -386,7 +385,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       }));
     }
     this.send(clientId, encodeEndOfContacts(mostRecentLastMod));
-    logger.info(`[MeshCore VN ${this.sourceId}] ▶ ${contacts.length} contacts to ${clientId}`);
+    logger.debug(`[MeshCore VN ${this.sourceId}] ▶ ${contacts.length} contacts to ${clientId}`);
   }
 
   /** GetChannel(idx) → ChannelInfo from the synced channel list, or Err(NotFound). */
@@ -401,7 +400,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       }
       const secret = row.psk ? Buffer.from(row.psk, 'base64') : Buffer.alloc(16);
       this.send(clientId, encodeChannelInfo(channelIdx, row.name || '', secret));
-      logger.info(`[MeshCore VN ${this.sourceId}] ▶ channel ${channelIdx} ("${row.name}") to ${clientId}`);
+      logger.debug(`[MeshCore VN ${this.sourceId}] ▶ channel ${channelIdx} ("${row.name}") to ${clientId}`);
     } catch (err) {
       logger.error(`[MeshCore VN ${this.sourceId}] GetChannel ${channelIdx} failed: ${(err as Error).message}`);
       this.send(clientId, encodeErr(ErrorCodes.NotFound));

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -436,8 +436,11 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
       const ok = await this.options.manager.sendMessage(text, undefined, channelIdx);
       if (ok) {
         logger.info(`[MeshCore VN ${this.sourceId}] ▶ forwarded channel ${channelIdx} msg from ${clientId} (${text.length} chars)`);
-        // Channel sends have no per-message ACK → no expectedAckCrc.
-        this.send(clientId, encodeSent(0, 0, this.SEND_EST_TIMEOUT_MS));
+        // A channel send is a fire-and-forget broadcast — the app's
+        // sendChannelTextMessage awaits Ok(0), NOT Sent(6) (which is the
+        // DM-with-ack response). Replying Sent here leaves the app's send
+        // promise pending forever (the message never shows as sent).
+        this.send(clientId, encodeOk());
       } else {
         logger.warn(`[MeshCore VN ${this.sourceId}] channel send from ${clientId} failed at the node`);
         this.send(clientId, encodeErr(ErrorCodes.BadState));

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -27,15 +27,16 @@ function stripTrailingSlashes(s: string): string {
 
 // Validate virtualNode config nested inside a source config blob.
 // Returns null on success, or { status, error } on failure.
-async function validateVirtualNodeConfig(
+// Exported for unit testing the source-type gate (#3535).
+export async function validateVirtualNodeConfig(
   type: string,
   config: any,
   excludeSourceId?: string
 ): Promise<{ status: number; error: string } | null> {
   const vn = config?.virtualNode;
   if (vn === undefined || vn === null) return null;
-  if (type !== 'meshtastic_tcp') {
-    return { status: 400, error: 'virtualNode config is only supported on meshtastic_tcp sources' };
+  if (type !== 'meshtastic_tcp' && type !== 'meshcore') {
+    return { status: 400, error: 'virtualNode config is only supported on meshtastic_tcp and meshcore sources' };
   }
   if (vn.enabled !== true) return null;
   const port = vn.port;

--- a/src/server/routes/sourceRoutes.virtualNode.test.ts
+++ b/src/server/routes/sourceRoutes.virtualNode.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// validateVirtualNodeConfig consults the sources repo for port-collision
+// checks; stub it so the type-gate assertions don't need a real DB.
+const getAllSources = vi.fn();
+vi.mock('../../services/database.js', () => ({
+  default: { sources: { getAllSources: (...a: unknown[]) => getAllSources(...a) } },
+}));
+
+const { validateVirtualNodeConfig } = await import('./sourceRoutes.js');
+
+describe('validateVirtualNodeConfig — source-type gate (#3535)', () => {
+  beforeEach(() => {
+    getAllSources.mockReset();
+    getAllSources.mockResolvedValue([]);
+  });
+
+  it('returns null when there is no virtualNode block', async () => {
+    expect(await validateVirtualNodeConfig('meshcore', {})).toBeNull();
+    expect(await validateVirtualNodeConfig('mqtt_broker', { virtualNode: undefined })).toBeNull();
+  });
+
+  it('rejects virtualNode on unsupported source types', async () => {
+    const result = await validateVirtualNodeConfig('mqtt_broker', { virtualNode: { enabled: true, port: 5000 } });
+    expect(result).toEqual({ status: 400, error: expect.stringContaining('only supported') });
+  });
+
+  it('allows virtualNode on meshcore sources', async () => {
+    const result = await validateVirtualNodeConfig('meshcore', { virtualNode: { enabled: true, port: 5000 } });
+    expect(result).toBeNull();
+  });
+
+  it('allows virtualNode on meshtastic_tcp sources', async () => {
+    const result = await validateVirtualNodeConfig('meshtastic_tcp', { virtualNode: { enabled: true, port: 5000 } });
+    expect(result).toBeNull();
+  });
+
+  it('still validates the port range for meshcore', async () => {
+    const result = await validateVirtualNodeConfig('meshcore', { virtualNode: { enabled: true, port: 70000 } });
+    expect(result).toEqual({ status: 400, error: expect.stringContaining('port') });
+  });
+
+  it('detects a port collision against another enabled source', async () => {
+    getAllSources.mockResolvedValue([
+      { id: 'other', name: 'Other Node', config: { virtualNode: { enabled: true, port: 5000 } } },
+    ]);
+    const result = await validateVirtualNodeConfig('meshcore', { virtualNode: { enabled: true, port: 5000 } });
+    expect(result).toEqual({ status: 409, error: expect.stringContaining('already in use') });
+  });
+
+  it('ignores the collision check for the source being edited (excludeSourceId)', async () => {
+    getAllSources.mockResolvedValue([
+      { id: 'self', name: 'Self', config: { virtualNode: { enabled: true, port: 5000 } } },
+    ]);
+    const result = await validateVirtualNodeConfig('meshcore', { virtualNode: { enabled: true, port: 5000 } }, 'self');
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Implements a **MeshCore virtual node** (#3535): MeshMonitor exposes a MeshCore node it already manages as a TCP companion endpoint, so the **MeshCore mobile app** can connect to it over WiFi and use the node as if it were local — see contacts/channels, and send/receive messages — when the phone has no direct BLE/USB range.

This is the *device end* of the MeshCore companion protocol. Since MeshMonitor already holds the node's single companion slot (via `meshcore.js` as a client), the server **synthesizes reads from mirrored state** and **forwards writes to the real node** — structurally parallel to the existing Meshtastic `virtualNodeServer.ts`, with MeshCore's binary frame format instead of protobuf.

**Verified end-to-end against the real `meshcore-flutter` app over WiFi:** connect → identity → 94 contacts + channels → channel send → auto-responder reply received back in the app.

## What's included (Phases 0–2)

- **Phase 0 — handshake.** `AppStart→SelfInfo`, `DeviceQuery→DeviceInfo`, `GetDeviceTime→CurrTime`, `SetDeviceTime→Ok`.
- **Phase 1 — read mirror.** `GetContacts` (real contacts), `GetChannel→ChannelInfo`, `GetBatteryVoltage`, `SetFloodScope→Ok` (no-op), and live incoming messages via the `MsgWaiting` push → `SyncNextMessage` → `ContactMsgRecv`/`ChannelMsgRecv`.
- **Phase 2 — sends.** `SendChannelTxtMsg`/`SendTxtMsg` forwarded to the node; DM key-prefixes resolved to full contact keys.
- **UI.** A "Virtual Node" enable + listening-port control on the MeshCore source form (`DashboardPage`); config persisted in `sources.config.virtualNode` and parsed in `meshcoreRegistry`. The `sourceRoutes` validation gate now allows `meshcore` (not just `meshtastic_tcp`).
- **Lifecycle.** `meshcoreManager` starts the server after the local node is known and stops it on disconnect.

## Files

- **New:** `meshcoreCompanionCodec.ts` (pure protocol: frame parse/build, command decode, response/push encoders), `meshcoreVirtualNodeServer.ts` (per-source TCP server), + tests for both, + `sourceRoutes.virtualNode.test.ts`.
- **Touched:** `meshcoreManager.ts`, `meshcoreRegistry.ts`, `routes/sourceRoutes.ts`, `pages/DashboardPage.tsx`, `docker-compose.dev.yml` (exposes dev port 5000).
- **Design:** `docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md`.

## Testing

- Every wire encoder is **round-tripped through meshcore.js's own decoders** — a deviceless fidelity guarantee that our byte layout matches what the app expects.
- The server is covered by loopback-socket integration tests (handshake, contacts, channels, battery, send forwarding, live RX, echo suppression).
- Full Vitest suite green (**0 failures**, 2308 suites); `tsc` clean.

### Two protocol subtleties found in live testing (documented + regression-tested)
1. **Channel send acks `Ok(0)`, DM send acks `Sent(6)`** — replying `Sent` to a channel send hangs the app's send promise.
2. **The `channel-N` marker is in `toPublicKey` for sent messages but `fromPublicKey` for received** — incoming channel replies must be detected in both fields or they get mis-encoded as a DM and dropped.

## Not included (Phase 3 — follow-up)

- Admin-gated config writes (`SetRadioParams`, `SetAdvertName`, …).
- **DM delivery receipts:** the node returns a real `expectedAckCrc` that `sendMessage` currently logs but discards; relaying it would let the `SendConfirmed` push light up the app's delivered tick. DMs currently show **sent** but not **delivered**.

## Notes

- TCP/WiFi only (no BLE — MeshMonitor is typically headless). Default VN port 5000, distinct from the node's own 4403 companion port.
- Per-source scoped; reads scope by `sourceId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)