### PR TITLE
fix(docker): entrypoint integrity check for 0-byte server.js (#3542)

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -156,6 +156,20 @@ if [ -d "$SCRIPTS_SOURCE_DIR" ]; then
     fi
 fi
 
+# Image integrity check (issue #3542): a corrupt or incomplete image pull can
+# leave dist/server/server.js as a 0-byte file. Node then exits 0 immediately,
+# supervisord retries to FATAL, and the container crash-loops with no actionable
+# message beyond "exited: meshmonitor (exit status 0; not expected)". Verify the
+# server bundle is present and non-empty here so the real cause is visible in
+# `docker compose logs` instead.
+SERVER_ENTRY="/app/dist/server/server.js"
+if [ ! -s "$SERVER_ENTRY" ]; then
+    echo "❌ FATAL: $SERVER_ENTRY is missing or empty — the image may be corrupt or incompletely pulled." >&2
+    echo "   Fix: docker rmi ghcr.io/yeraze/meshmonitor && docker compose pull && docker compose up -d" >&2
+    exit 1
+fi
+echo "✓ Server bundle present ($(wc -c < "$SERVER_ENTRY") bytes)"
+
 # When running as non-root, we need to modify supervisord.conf
 # because it has user=root and uses su-exec which won't work
 if [ "$RUNNING_AS_ROOT" = "false" ]; then

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -165,7 +165,8 @@ fi
 SERVER_ENTRY="/app/dist/server/server.js"
 if [ ! -s "$SERVER_ENTRY" ]; then
     echo "❌ FATAL: $SERVER_ENTRY is missing or empty — the image may be corrupt or incompletely pulled." >&2
-    echo "   Fix: docker rmi ghcr.io/yeraze/meshmonitor && docker compose pull && docker compose up -d" >&2
+    echo "   Fix: remove the cached image and re-pull, e.g.:" >&2
+    echo "        docker rmi <meshmonitor image> && docker compose pull && docker compose up -d" >&2
     exit 1
 fi
 echo "✓ Server bundle present ($(wc -c < "$SERVER_ENTRY") bytes)"


### PR DESCRIPTION
## Summary

Fixes #3542. A corrupt or incomplete `docker compose pull` can leave `dist/server/server.js` as a **0-byte file**. Node then exits `0` immediately, supervisord retries until FATAL, and the container crash-loops with no actionable message beyond `exited: meshmonitor (exit status 0; not expected)`.

This adds the recommended **entrypoint integrity check**: before handing off to supervisord, verify `/app/dist/server/server.js` exists and is non-empty. If not, print a clear error with the remediation and exit non-zero so the real cause is visible in `docker compose logs`.

```
❌ FATAL: /app/dist/server/server.js is missing or empty — the image may be corrupt or incompletely pulled.
   Fix: docker rmi ghcr.io/yeraze/meshmonitor && docker compose pull && docker compose up -d
```

## Why this approach

Per the issue's analysis, the entrypoint check is the lowest-friction option — actionable error, zero ongoing maintenance (vs. SHA digest pinning) and it explains *why* (vs. a bare healthcheck).

## Details

- Added to `docker/docker-entrypoint.sh` immediately before the supervisord `exec`, so it runs ahead of **both** the root and non-root execution paths.
- Confirmed entry path: `npm start` → `node dist/server/server.js` (working dir `/app`).
- POSIX `sh` (`[ ! -s … ]`); `sh -n` syntax-clean.

## Testing

- `sh -n` passes.
- Logic verified both ways: 0-byte file → detected (exit 1); non-empty file → passes with byte count.
- On a healthy image the check is a no-op (`✓ Server bundle present (N bytes)`); CI's system tests exercise normal container startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)