### PR TITLE
release: v4.11.0-rc2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.11.0-rc1",
+  "version": "4.11.0-rc2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.11.0-rc1",
+  "version": "4.11.0-rc2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.11.0-rc1
-appVersion: "4.11.0-rc1"
+version: 4.11.0-rc2
+appVersion: "4.11.0-rc2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.11.0-rc1",
+  "version": "4.11.0-rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.11.0-rc1",
+      "version": "4.11.0-rc2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.11.0-rc1",
+  "version": "4.11.0-rc2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Bumps the version **4.11.0-rc1 → 4.11.0-rc2** across all five version-tracked files:

- `package.json`
- `package-lock.json` (root + `packages[""]` — regenerated via `npm install --package-lock-only`, version-only diff)
- `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`)
- `desktop/src-tauri/tauri.conf.json`
- `desktop/package.json`

Version-only change; no code or dependency drift (lockfile diff is the two version fields).

## What's in rc2 since rc1

- MeshCore virtual node — connect the MeshCore app through MeshMonitor over WiFi (#3540)
- Mobile map Features panel no longer blocks the sidebar connect button (#3536)
- Entrypoint integrity check for a corrupt/0-byte server bundle (#3543)
- RE2 for user-supplied regexes; CodeQL regex-injection alerts resolved (#3544)

🤖 Generated with [Claude Code](https://claude.com/claude-code)