### PR TITLE
feat(meshcore): define a contact's forwarding path by repeater name

### DIFF
--- a/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
@@ -21,6 +21,10 @@ vi.mock('../../contexts/SettingsContext', () => ({
   useSettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
 }));
 
+vi.mock('../../contexts/SourceContext', () => ({
+  useSource: () => ({ sourceId: 'test-source', sourceName: 'Test' }),
+}));
+
 const PK = 'a'.repeat(64);
 
 describe('MeshCoreContactDetailPanel', () => {
@@ -147,6 +151,47 @@ describe('MeshCoreContactDetailPanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Save Path' }));
     await waitFor(() => expect(onSetOutPath).toHaveBeenCalledWith(PK, 'b1'));
+  });
+
+  it('reorders hops with the up button before saving', async () => {
+    const contact: MeshCoreContact = { publicKey: PK, advType: 1 };
+    const repeaters: MeshCoreContact[] = [
+      { publicKey: 'b1' + 'c'.repeat(62), advType: 2, advName: 'North Repeater' },
+      { publicKey: '7f' + 'd'.repeat(62), advType: 2, advName: 'East Repeater' },
+    ];
+    const onSetOutPath = vi.fn().mockResolvedValue(true);
+    render(
+      <MeshCoreContactDetailPanel contact={contact} publicKey={PK} onSetOutPath={onSetOutPath}
+        repeaters={repeaters} canWriteNodes isCompanion />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Define Path…' }));
+    const select = screen.getByRole('combobox', { name: 'Add repeater hop' });
+    fireEvent.change(select, { target: { value: 'b1' } });
+    fireEvent.change(select, { target: { value: '7f' } }); // hops: [b1, 7f]
+    // Move the second hop (East/7f) up → [7f, b1].
+    fireEvent.click(screen.getAllByRole('button', { name: 'Move hop up' })[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Save Path' }));
+    await waitFor(() => expect(onSetOutPath).toHaveBeenCalledWith(PK, '7f,b1'));
+  });
+
+  it('adds a custom hex byte and rejects an invalid one', async () => {
+    const contact: MeshCoreContact = { publicKey: PK, advType: 1 };
+    const onSetOutPath = vi.fn().mockResolvedValue(true);
+    render(
+      <MeshCoreContactDetailPanel contact={contact} publicKey={PK} onSetOutPath={onSetOutPath}
+        repeaters={[]} canWriteNodes isCompanion />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Define Path…' }));
+    const input = screen.getByPlaceholderText('or hex byte (a3)');
+    // Invalid byte → error, no hop added.
+    fireEvent.change(input, { target: { value: 'zz' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    expect(screen.getByText(/single hex byte/i)).toBeTruthy();
+    // Valid byte → hop added and saved.
+    fireEvent.change(input, { target: { value: 'ab' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save Path' }));
+    await waitFor(() => expect(onSetOutPath).toHaveBeenCalledWith(PK, 'ab'));
   });
 
   it('pre-populates the editor from the existing out_path, resolving names', () => {

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
@@ -116,6 +116,60 @@ describe('MeshCoreContactDetailPanel', () => {
     confirmSpy.mockRestore();
   });
 
+  it('builds a path by repeater name and saves the hex chain', async () => {
+    const contact: MeshCoreContact = { publicKey: PK, advType: 1 };
+    const repeaters: MeshCoreContact[] = [
+      { publicKey: 'b1' + 'c'.repeat(62), advType: 2, advName: 'North Repeater' },
+      { publicKey: '7f' + 'd'.repeat(62), advType: 2, advName: 'East Repeater' },
+    ];
+    const onSetOutPath = vi.fn().mockResolvedValue(true);
+
+    render(
+      <MeshCoreContactDetailPanel
+        contact={contact}
+        publicKey={PK}
+        onSetOutPath={onSetOutPath}
+        repeaters={repeaters}
+        canWriteNodes
+        isCompanion
+      />,
+    );
+
+    // Define Path… is visible without any advanced toggle.
+    fireEvent.click(screen.getByRole('button', { name: 'Define Path…' }));
+
+    // Pick a repeater by name from the hop selector.
+    const select = screen.getByRole('combobox', { name: 'Add repeater hop' });
+    fireEvent.change(select, { target: { value: 'b1' } });
+
+    // The hop appears with its repeater name.
+    expect(screen.getByText('North Repeater')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Path' }));
+    await waitFor(() => expect(onSetOutPath).toHaveBeenCalledWith(PK, 'b1'));
+  });
+
+  it('pre-populates the editor from the existing out_path, resolving names', () => {
+    const contact: MeshCoreContact = { publicKey: PK, advType: 1, outPath: 'b1,7f' };
+    const repeaters: MeshCoreContact[] = [
+      { publicKey: 'b1' + 'c'.repeat(62), advType: 2, advName: 'North Repeater' },
+    ];
+    render(
+      <MeshCoreContactDetailPanel
+        contact={contact}
+        publicKey={PK}
+        onSetOutPath={vi.fn().mockResolvedValue(true)}
+        repeaters={repeaters}
+        canWriteNodes
+        isCompanion
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Define Path…' }));
+    // Known hop resolves to its name; unknown hop falls back to "Unknown (0x..)".
+    expect(screen.getByText('North Repeater')).toBeTruthy();
+    expect(screen.getByText('Unknown (0x7f)')).toBeTruthy();
+  });
+
   it('falls back to a generic message when onShareContact returns no error text', async () => {
     const contact: MeshCoreContact = { publicKey: PK, advType: 1 };
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -1,6 +1,13 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
+import {
+  parsePathHops,
+  joinPathHops,
+  repeaterHopOptions,
+  resolveHop,
+  type PathHop,
+} from '../../utils/meshcorePath';
 import { formatRelativeTime } from '../../utils/datetime';
 import { useSettings } from '../../contexts/SettingsContext';
 import { useSource } from '../../contexts/SourceContext';
@@ -28,9 +35,12 @@ interface MeshCoreContactDetailPanelProps {
   onShareContact?: (publicKey: string) => Promise<{ ok: boolean; error?: string }>;
   /** Manually push a forwarding route into the device's contact record
    *  via CMD_ADD_UPDATE_CONTACT. `outPath` is a comma-separated hex chain
-   *  ("a3,7f,02"). Unset OR `advancedPathEditEnabled=false` hides the
-   *  Edit Path… button. */
+   *  ("a3,7f,02"). Unset hides the Define Path… button. */
   onSetOutPath?: (publicKey: string, outPath: string) => Promise<boolean>;
+  /** Known contacts used to build a path by repeater name (the picker maps a
+   *  repeater to its first-public-key-byte hop). Typically the full contact
+   *  list; the panel filters to repeaters/room servers internally. */
+  repeaters?: MeshCoreContact[];
   /** Send a trace-path diagnostic along the contact's cached path and
    *  return per-hop SNR data. Unset hides the Trace Path button. */
   onTracePath?: (publicKey: string) => Promise<TracePathResult | null>;
@@ -46,10 +56,6 @@ interface MeshCoreContactDetailPanelProps {
    *  that don't pass this still see the buttons when handlers are
    *  supplied. */
   isCompanion?: boolean;
-  /** Server-side gated advanced toggle (settings.meshcoreAdvancedPathEdit).
-   *  When false the Edit Path… button is hidden even if onSetOutPath is
-   *  supplied. The server route also enforces this for defense in depth. */
-  advancedPathEditEnabled?: boolean;
   /** Remove a contact from the device. Unset hides the Remove button. */
   onRemoveContact?: (publicKey: string) => Promise<boolean>;
   /** Export a contact as a signed advert blob. Unset hides the Export button. */
@@ -87,6 +93,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   onResetPath,
   onShareContact,
   onSetOutPath,
+  repeaters,
   onTracePath,
   onDiscoverPath,
   onRemoveContact,
@@ -94,7 +101,6 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   onGetNeighbours,
   canWriteNodes = false,
   isCompanion = true,
-  advancedPathEditEnabled = false,
   remoteAdminActions,
   canRemoteAdmin = false,
 }) => {
@@ -132,9 +138,11 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     fetchedAt?: number;
   } | null>(null);
 
-  // Path-editor modal state. Only mounted when advancedPathEditEnabled.
+  // Path-editor modal state. The hop chain is built by repeater name; each
+  // hop is a 1-byte hex routing hash.
   const [editorOpen, setEditorOpen] = useState(false);
-  const [editorDraft, setEditorDraft] = useState('');
+  const [editorHops, setEditorHops] = useState<PathHop[]>([]);
+  const [customByte, setCustomByte] = useState('');
   const [editorSaving, setEditorSaving] = useState(false);
   const [editorError, setEditorError] = useState<string | null>(null);
 
@@ -213,7 +221,10 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   const canShowShareButton =
     !!onShareContact && canWriteNodes && isCompanion;
   const canShowEditButton =
-    !!onSetOutPath && canWriteNodes && isCompanion && advancedPathEditEnabled;
+    !!onSetOutPath && canWriteNodes && isCompanion;
+
+  // Repeater/room options for the path picker, derived from the contact list.
+  const hopOptions = React.useMemo(() => repeaterHopOptions(repeaters ?? []), [repeaters]);
   const canShowTraceButton =
     !!onTracePath && canWriteNodes && isCompanion && pathKnown && pathLen! > 0;
   const canShowDiscoverButton =
@@ -278,39 +289,56 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   };
 
   const openEditor = () => {
-    setEditorDraft(outPath ?? '');
+    setEditorHops(parsePathHops(outPath));
+    setCustomByte('');
     setEditorError(null);
     setEditorOpen(true);
   };
 
-  const HEX_PATH_REGEX = /^\s*([0-9a-fA-F]{1,2})(\s*,\s*[0-9a-fA-F]{1,2})*\s*$/;
+  const addHop = (byte: PathHop) => {
+    if (editorHops.length >= 64) return;
+    setEditorHops((prev) => [...prev, byte]);
+  };
 
-  const handleSaveEditor = async () => {
-    if (!onSetOutPath || editorSaving) return;
-    const draft = editorDraft.trim();
-    if (draft !== '' && !HEX_PATH_REGEX.test(draft)) {
+  const addCustomHop = () => {
+    const tok = customByte.trim().toLowerCase();
+    if (!/^[0-9a-f]{1,2}$/.test(tok)) {
       setEditorError(
-        t(
-          'meshcore.contact_details.edit_path_invalid',
-          'Path must be comma-separated hex bytes, e.g. "a3,7f,02" (max 64).',
-        ),
+        t('meshcore.contact_details.edit_path_invalid_byte', 'Enter a single hex byte, e.g. "a3".'),
       );
       return;
     }
-    const hopCount = draft === '' ? 0 : draft.split(',').length;
-    if (hopCount > 64) {
+    setEditorError(null);
+    addHop(tok.padStart(2, '0'));
+    setCustomByte('');
+  };
+
+  const removeHop = (index: number) => {
+    setEditorHops((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const moveHop = (index: number, delta: number) => {
+    setEditorHops((prev) => {
+      const next = [...prev];
+      const target = index + delta;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  };
+
+  const handleSaveEditor = async () => {
+    if (!onSetOutPath || editorSaving) return;
+    if (editorHops.length > 64) {
       setEditorError(
-        t(
-          'meshcore.contact_details.edit_path_too_long',
-          `Path too long: ${hopCount} hops (max 64).`,
-        ),
+        t('meshcore.contact_details.edit_path_too_long', `Path too long: ${editorHops.length} hops (max 64).`),
       );
       return;
     }
     setEditorSaving(true);
     setEditorError(null);
     try {
-      const ok = await onSetOutPath(publicKey, draft);
+      const ok = await onSetOutPath(publicKey, joinPathHops(editorHops));
       if (!ok) {
         setEditorError(
           t('meshcore.contact_details.edit_path_save_failed', 'Save failed.'),
@@ -533,9 +561,9 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     type="button"
                     className="btn-secondary"
                     onClick={openEditor}
-                    aria-label={t('meshcore.contact_details.edit_path_button', 'Edit Path…')}
+                    aria-label={t('meshcore.contact_details.edit_path_button', 'Define Path…')}
                   >
-                    {t('meshcore.contact_details.edit_path_button', 'Edit Path…')}
+                    {t('meshcore.contact_details.edit_path_button', 'Define Path…')}
                   </button>
                 )}
                 {canShowTraceButton && (
@@ -829,12 +857,12 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
             }}
           >
             <h3 style={{ marginTop: 0 }}>
-              {t('meshcore.contact_details.edit_path_dialog_title', 'Edit forwarding path')}
+              {t('meshcore.contact_details.edit_path_dialog_title', 'Define forwarding path')}
             </h3>
             <p style={{ marginBottom: '0.75rem' }}>
               {t(
                 'meshcore.contact_details.edit_path_dialog_hint',
-                'Enter the new hop chain as comma-separated hex bytes (e.g. "a3,7f,02"). Each byte is one hop hash; 0..64 bytes total. Leave empty to set a zero-hop direct path.',
+                'Build the route to this contact by adding repeater hops in order, from your node outward. An empty path is a zero-hop direct send (0..64 hops).',
               )}
             </p>
             <div
@@ -853,28 +881,91 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                 'Manual paths bypass auto-discovery. Stale hops silently drop direct sends until the next flood. Use "Reset Path" instead if you just want to re-discover.',
               )}
             </div>
-            <label style={{ display: 'block', marginBottom: '0.5rem' }}>
-              {t('meshcore.contact_details.edit_path_label', 'New path (hex chain):')}
+
+            {/* Ordered hop list */}
+            <label style={{ display: 'block', marginBottom: '0.4rem' }}>
+              {t('meshcore.contact_details.edit_path_label', 'Path ({{count}} hops):', { count: editorHops.length })}
             </label>
-            <input
-              type="text"
-              value={editorDraft}
-              onChange={(e) => setEditorDraft(e.target.value)}
-              disabled={editorSaving}
-              placeholder="a3,7f,02"
-              style={{
-                width: '100%',
-                padding: '0.5rem',
-                marginBottom: '0.5rem',
-                fontFamily: 'var(--font-mono, monospace)',
-                boxSizing: 'border-box',
-              }}
-              autoFocus
-            />
-            <div style={{ fontSize: '0.85em', opacity: 0.8, marginBottom: '0.75rem' }}>
-              {editorDraft.trim() === ''
-                ? t('meshcore.contact_details.edit_path_zero_hops', '0 hops (direct path)')
-                : t('meshcore.contact_details.edit_path_hop_count', { count: editorDraft.trim().split(',').length })}
+            {editorHops.length === 0 ? (
+              <div style={{ fontSize: '0.85em', opacity: 0.7, marginBottom: '0.6rem' }}>
+                {t('meshcore.contact_details.edit_path_zero_hops', 'Direct path (no repeater hops).')}
+              </div>
+            ) : (
+              <ol style={{ listStyle: 'none', padding: 0, margin: '0 0 0.6rem' }}>
+                {editorHops.map((byte, i) => {
+                  const resolved = resolveHop(byte, hopOptions);
+                  return (
+                    <li
+                      key={`${byte}-${i}`}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.5rem',
+                        padding: '0.35rem 0.5rem',
+                        marginBottom: '0.25rem',
+                        background: 'var(--ctp-surface0, #313244)',
+                        borderRadius: '4px',
+                      }}
+                    >
+                      <span style={{ opacity: 0.6, minWidth: '1.4rem' }}>{i + 1}.</span>
+                      <span style={{ flex: 1 }}>
+                        {resolved.label}
+                        <span style={{ opacity: 0.6, fontFamily: 'var(--font-mono, monospace)', marginLeft: '0.4rem' }}>
+                          (0x{byte})
+                        </span>
+                      </span>
+                      <button type="button" className="btn-secondary" disabled={editorSaving || i === 0}
+                        aria-label={t('meshcore.contact_details.edit_path_move_up', 'Move hop up')}
+                        onClick={() => moveHop(i, -1)} style={{ padding: '0.1rem 0.4rem' }}>↑</button>
+                      <button type="button" className="btn-secondary" disabled={editorSaving || i === editorHops.length - 1}
+                        aria-label={t('meshcore.contact_details.edit_path_move_down', 'Move hop down')}
+                        onClick={() => moveHop(i, 1)} style={{ padding: '0.1rem 0.4rem' }}>↓</button>
+                      <button type="button" className="btn-secondary" disabled={editorSaving}
+                        aria-label={t('meshcore.contact_details.edit_path_remove_hop', 'Remove hop')}
+                        onClick={() => removeHop(i)} style={{ padding: '0.1rem 0.4rem' }}>✕</button>
+                    </li>
+                  );
+                })}
+              </ol>
+            )}
+
+            {/* Add a repeater hop by name */}
+            <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem', flexWrap: 'wrap' }}>
+              <select
+                aria-label={t('meshcore.contact_details.edit_path_add_repeater_aria', 'Add repeater hop')}
+                disabled={editorSaving || editorHops.length >= 64}
+                value=""
+                onChange={(e) => { if (e.target.value) addHop(e.target.value); }}
+                style={{ flex: 1, minWidth: '12rem', padding: '0.45rem', boxSizing: 'border-box' }}
+              >
+                <option value="">
+                  {hopOptions.length === 0
+                    ? t('meshcore.contact_details.edit_path_no_repeaters', 'No known repeaters')
+                    : t('meshcore.contact_details.edit_path_add_repeater', '+ Add repeater hop…')}
+                </option>
+                {hopOptions.map((o) => (
+                  <option key={o.publicKey} value={o.hopByte}>
+                    {o.name} (0x{o.hopByte})
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Add a raw byte for a repeater you haven't met */}
+            <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem', alignItems: 'center' }}>
+              <input
+                type="text"
+                value={customByte}
+                onChange={(e) => setCustomByte(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addCustomHop(); } }}
+                disabled={editorSaving || editorHops.length >= 64}
+                placeholder={t('meshcore.contact_details.edit_path_custom_byte', 'or hex byte (a3)')}
+                style={{ width: '8rem', padding: '0.45rem', fontFamily: 'var(--font-mono, monospace)', boxSizing: 'border-box' }}
+              />
+              <button type="button" className="btn-secondary" onClick={addCustomHop}
+                disabled={editorSaving || editorHops.length >= 64 || customByte.trim() === ''}>
+                {t('meshcore.contact_details.edit_path_add_byte', 'Add')}
+              </button>
             </div>
             {editorError && (
               <div style={{ color: 'var(--ctp-red)', marginBottom: '0.75rem' }} role="alert">

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -85,25 +85,6 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
   // default; flipping it on/off in the Settings tab takes effect on the
   // next mount. We don't subscribe to settings changes here — the panel
   // is mounted often enough that polling isn't worth the complexity.
-  const [advancedPathEditEnabled, setAdvancedPathEditEnabled] = useState(false);
-  useEffect(() => {
-    let cancelled = false;
-    const base = (baseUrl ?? '').replace(/\/$/, '');
-    fetch(`${base}/api/settings`, { credentials: 'include' })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((j) => {
-        if (cancelled || !j) return;
-        const value = j?.data?.meshcoreAdvancedPathEdit ?? j?.meshcoreAdvancedPathEdit;
-        setAdvancedPathEditEnabled(value === 'true' || value === '1' || value === true);
-      })
-      .catch(() => {
-        /* leave default false on error */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [baseUrl]);
-
   // Contacts that have at least one DM thread (filtered on top).
   const contactsByKey = useMemo(() => {
     const map = new Map<string, MeshCoreContact>();
@@ -371,7 +352,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                 onGetNeighbours={actions.getNeighbours}
                 canWriteNodes={canWriteNodes && connected}
                 isCompanion={isCompanion}
-                advancedPathEditEnabled={advancedPathEditEnabled}
+                repeaters={contacts}
                 canRemoteAdmin={canRemoteAdmin && connected}
                 remoteAdminActions={{
                   loginRemote: actions.loginRemote,

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -109,9 +109,7 @@ export interface MeshCoreActions {
   shareContact: (publicKey: string) => Promise<{ ok: boolean; error?: string }>;
   /** Manually push a forwarding route into the device's contact record.
    *  `outPath` is a comma-separated hex chain ("a3,7f,02"); empty string
-   *  sets a zero-hop direct path. Server gates this on the
-   *  `meshcoreAdvancedPathEdit` toggle, so a 403 is expected when the
-   *  setting is off. */
+   *  sets a zero-hop direct path. Requires nodes:write. */
   setContactOutPath: (publicKey: string, outPath: string) => Promise<boolean>;
   /** Send a trace-path diagnostic along the contact's cached forwarding
    *  route and return per-hop SNR data. Resolves `null` on failure. */

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -249,7 +249,6 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   // the UI checkbox says "Hide" while the context uses "show" semantics
   const [localHideIncompleteNodes, setLocalHideIncompleteNodes] = useState(!showIncompleteNodes);
   const [localHomoglyphEnabled, setLocalHomoglyphEnabled] = useState(false);
-  const [localMeshcoreAdvancedPathEdit, setLocalMeshcoreAdvancedPathEdit] = useState(false);
   const [localLocalStatsIntervalMinutes, setLocalLocalStatsIntervalMinutes] = useState(15);
   const [initialLocalStatsIntervalMinutes, setInitialLocalStatsIntervalMinutes] = useState(15);
   const [isFetchingSolarEstimates, setIsFetchingSolarEstimates] = useState(false);
@@ -337,13 +336,6 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           // Load link preview setting (issue #3416). Absent key => enabled.
           const linkPreviewsOn = !(settings.linkPreviewsEnabled === '0' || settings.linkPreviewsEnabled === 'false');
           setLocalLinkPreviewsEnabled(linkPreviewsOn);
-
-          // Load MeshCore advanced path-edit toggle (gates the manual
-          // Edit Path… button on the per-contact detail panel and is
-          // server-side-checked by the matching PUT route).
-          const meshcorePathEditOn = settings.meshcoreAdvancedPathEdit === 'true';
-          setLocalMeshcoreAdvancedPathEdit(meshcorePathEditOn);
-          setInitialMeshcoreAdvancedPathEdit(meshcorePathEditOn);
 
           // Load LocalStats interval setting
           const statsInterval = parseInt(settings.localStatsIntervalMinutes || '15', 10);
@@ -440,7 +432,6 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   // Instead, we'll track initial packet monitor values separately
   const [initialPacketMonitorSettings, setInitialPacketMonitorSettings] = useState({ enabled: false, maxCount: 1000, maxAgeHours: 24 });
   const [initialHomoglyphEnabled, setInitialHomoglyphEnabled] = useState(false);
-  const [initialMeshcoreAdvancedPathEdit, setInitialMeshcoreAdvancedPathEdit] = useState(false);
   const [initialNodeDimmingSettings, setInitialNodeDimmingSettings] = useState({
     enabled: nodeDimmingEnabled,
     startHours: nodeDimmingStartHours,
@@ -486,7 +477,6 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       localLinkPreviewsEnabled !== linkPreviewsEnabled ||
       localHideIncompleteNodes !== !showIncompleteNodes ||
       localHomoglyphEnabled !== initialHomoglyphEnabled ||
-      localMeshcoreAdvancedPathEdit !== initialMeshcoreAdvancedPathEdit ||
       localLocalStatsIntervalMinutes !== initialLocalStatsIntervalMinutes ||
       nodeDimmingEnabled !== initialNodeDimmingSettings.enabled ||
       nodeDimmingStartHours !== initialNodeDimmingSettings.startHours ||
@@ -502,7 +492,6 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination,
       localLinkPreviewsEnabled, linkPreviewsEnabled,
       localHideIncompleteNodes, showIncompleteNodes, localHomoglyphEnabled, initialHomoglyphEnabled,
-      localMeshcoreAdvancedPathEdit, initialMeshcoreAdvancedPathEdit,
       localLocalStatsIntervalMinutes, initialLocalStatsIntervalMinutes,
       nodeDimmingEnabled, nodeDimmingStartHours, nodeDimmingMinOpacity, initialNodeDimmingSettings,
       localAnalyticsProvider, localAnalyticsConfig, initialAnalyticsProvider, initialAnalyticsConfig,
@@ -546,7 +535,6 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setLocalLinkPreviewsEnabled(linkPreviewsEnabled);
     setLocalHideIncompleteNodes(!showIncompleteNodes);
     setLocalHomoglyphEnabled(initialHomoglyphEnabled);
-    setLocalMeshcoreAdvancedPathEdit(initialMeshcoreAdvancedPathEdit);
     setLocalLocalStatsIntervalMinutes(initialLocalStatsIntervalMinutes);
     setNodeDimmingEnabled(initialNodeDimmingSettings.enabled);
     setNodeDimmingStartHours(initialNodeDimmingSettings.startHours);
@@ -561,7 +549,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       initialPacketMonitorSettings, solarMonitoringEnabled, solarMonitoringLatitude,
       solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination, showIncompleteNodes,
       linkPreviewsEnabled,
-      initialHomoglyphEnabled, initialMeshcoreAdvancedPathEdit, initialLocalStatsIntervalMinutes, initialNodeDimmingSettings,
+      initialHomoglyphEnabled, initialLocalStatsIntervalMinutes, initialNodeDimmingSettings,
       setNodeDimmingEnabled, setNodeDimmingStartHours, setNodeDimmingMinOpacity,
       initialAnalyticsProvider, initialAnalyticsConfig, initialAppriseApiServerUrl]);
 
@@ -615,7 +603,6 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         linkPreviewsEnabled: localLinkPreviewsEnabled ? '1' : '0',
         hideIncompleteNodes: localHideIncompleteNodes ? '1' : '0',
         homoglyphEnabled: String(localHomoglyphEnabled),
-        meshcoreAdvancedPathEdit: String(localMeshcoreAdvancedPathEdit),
         localStatsIntervalMinutes: localLocalStatsIntervalMinutes.toString(),
         nodeHopsCalculation: localNodeHopsCalculation,
         nodeDimmingEnabled: nodeDimmingEnabled ? '1' : '0',
@@ -1721,25 +1708,6 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
                 {t('settings.homoglyph_enabled')}
               </span>
               <span className="setting-description">{t('settings.homoglyph_description')}</span>
-            </label>
-          </div>
-          <div className="setting-item">
-            <label>
-              <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
-                <input
-                  type="checkbox"
-                  checked={localMeshcoreAdvancedPathEdit}
-                  onChange={(e) => setLocalMeshcoreAdvancedPathEdit(e.target.checked)}
-                  style={{ cursor: 'pointer' }}
-                />
-                {t('settings.meshcore_advanced_path_edit', 'MeshCore: enable manual path editing (advanced)')}
-              </span>
-              <span className="setting-description">
-                {t(
-                  'settings.meshcore_advanced_path_edit_description',
-                  'Exposes an Edit Path… button on each MeshCore contact that lets you push arbitrary hop bytes into the device. Stale hops silently drop direct sends until the next flood, so leave this off unless you know exactly what you\'re doing.',
-                )}
-              </span>
             </label>
           </div>
         </div>}

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -185,12 +185,6 @@ export const VALID_SETTINGS_KEYS = [
   'remoteLocalStatsFilterLastHeardHours',
   'defaultLandingPage',
   'appriseApiServerUrl',
-  // Advanced/unsafe MeshCore actions. When true the per-contact detail
-  // panel exposes a manual "Edit Path…" button that lets the user push
-  // arbitrary hop hashes into the device's contact record. Stale hops
-  // silently drop direct sends, so this is gated behind an explicit
-  // toggle (off by default).
-  'meshcoreAdvancedPathEdit',
   // MeshCore auto-pathfinding
   'meshcoreAutoPathfindingEnabled',
   'meshcoreAutoPathfindingPathDiscoveryEnabled',

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -163,11 +163,6 @@ vi.mock('../services/meshcorePacketLogService.js', () => ({ default: mockPacketS
 
 import DatabaseService from '../../services/database.js';
 
-// Mutable holder so individual tests can flip the toggle for the
-// feature-flag-gated out-path route.
-const globalSettingsMock = {
-  meshcoreAdvancedPathEdit: 'false' as string | boolean | null,
-};
 import meshcoreRoutes from './meshcoreRoutes.js';
 import authRoutes from './authRoutes.js';
 
@@ -213,14 +208,8 @@ describe('MeshCore Routes', () => {
     (DatabaseService as any).auditLogAsync = vi.fn(async () => undefined);
     (DatabaseService as any).drizzleDbType = 'sqlite';
 
-    // The out-path PUT route reads the advanced-path-edit toggle from
-    // global settings. Default the mock to "off" so tests opt-in to the
-    // "feature flag enabled" branch.
     (DatabaseService as any).settings = {
-      getSetting: vi.fn(async (key: string) => {
-        if (key === 'meshcoreAdvancedPathEdit') return globalSettingsMock.meshcoreAdvancedPathEdit;
-        return null;
-      }),
+      getSetting: vi.fn(async () => null),
     };
 
     // Add async method mocks
@@ -1503,7 +1492,6 @@ describe('MeshCore Routes', () => {
     beforeEach(() => {
       meshcoreManager.setContactOutPath.mockReset();
       meshcoreManager.setContactOutPath.mockResolvedValue(true);
-      globalSettingsMock.meshcoreAdvancedPathEdit = 'false';
     });
 
     it('requires authentication', async () => {
@@ -1513,18 +1501,7 @@ describe('MeshCore Routes', () => {
       expect(response.status).toBe(401);
     });
 
-    it('returns 403 when the advanced toggle is off', async () => {
-      globalSettingsMock.meshcoreAdvancedPathEdit = 'false';
-      const response = await authenticatedAgent
-        .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
-        .send({ outPath: 'a3,7f,02' });
-      expect(response.status).toBe(403);
-      expect(response.body.error).toMatch(/meshcoreAdvancedPathEdit/);
-      expect(meshcoreManager.setContactOutPath).not.toHaveBeenCalled();
-    });
-
-    it('rejects an invalid public key (regardless of toggle)', async () => {
-      globalSettingsMock.meshcoreAdvancedPathEdit = 'true';
+    it('rejects an invalid public key', async () => {
       const response = await authenticatedAgent
         .put('/api/sources/test-source/meshcore/contacts/not-hex/out-path')
         .send({ outPath: 'a3,7f,02' });
@@ -1534,7 +1511,6 @@ describe('MeshCore Routes', () => {
     });
 
     it('rejects a malformed hex chain', async () => {
-      globalSettingsMock.meshcoreAdvancedPathEdit = 'true';
       const response = await authenticatedAgent
         .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
         .send({ outPath: 'a3,nothex,02' });
@@ -1544,7 +1520,6 @@ describe('MeshCore Routes', () => {
     });
 
     it('rejects an oversize path (>64 hops)', async () => {
-      globalSettingsMock.meshcoreAdvancedPathEdit = 'true';
       const oversized = Array(65).fill('aa').join(',');
       const response = await authenticatedAgent
         .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
@@ -1555,7 +1530,6 @@ describe('MeshCore Routes', () => {
     });
 
     it('forwards valid path bytes to the manager and returns 200', async () => {
-      globalSettingsMock.meshcoreAdvancedPathEdit = 'true';
       const response = await authenticatedAgent
         .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
         .send({ outPath: 'a3,7f,02' });
@@ -1568,7 +1542,6 @@ describe('MeshCore Routes', () => {
     });
 
     it('accepts an empty path as zero-hop direct', async () => {
-      globalSettingsMock.meshcoreAdvancedPathEdit = 'true';
       const response = await authenticatedAgent
         .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
         .send({ outPath: '' });
@@ -1578,7 +1551,6 @@ describe('MeshCore Routes', () => {
     });
 
     it('returns 409 when the manager rejects', async () => {
-      globalSettingsMock.meshcoreAdvancedPathEdit = 'true';
       meshcoreManager.setContactOutPath.mockResolvedValueOnce(false);
       const response = await authenticatedAgent
         .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -625,9 +625,9 @@ router.post(
  * opcode 9), with the non-path fields preserved verbatim by
  * meshcore.js's setContactPath helper.
  *
- * Gated by the `meshcoreAdvancedPathEdit` setting because stale hops
- * silently drop direct sends to this contact. When the toggle is off
- * (default), the route returns 403 even for users with nodes:write.
+ * Requires nodes:write. Note: a stale manual path silently drops direct
+ * sends to this contact until the next flood — the UI surfaces this and
+ * offers "Reset Path" to re-discover.
  *
  * Body: { outPath: "a3,7f,02" }  — comma-separated hex chain, 0..64
  *                                   bytes (empty string = 0 hops).
@@ -644,16 +644,6 @@ router.put(
         return res.status(400).json({
           success: false,
           error: 'Invalid public key — must be 64-char hex',
-        });
-      }
-      // Settings are stored as string values; the boolean check is here
-      // only for robustness against future schema changes.
-      const flagRaw: unknown = await databaseService.settings.getSetting('meshcoreAdvancedPathEdit');
-      const flagEnabled = flagRaw === 'true' || flagRaw === '1' || flagRaw === true;
-      if (!flagEnabled) {
-        return res.status(403).json({
-          success: false,
-          error: 'Advanced MeshCore path editing is disabled. Enable meshcoreAdvancedPathEdit in Settings to use this endpoint.',
         });
       }
       const rawPath = (req.body ?? {}).outPath;

--- a/src/server/server.settings-persistence.test.ts
+++ b/src/server/server.settings-persistence.test.ts
@@ -416,11 +416,6 @@ describe('Settings Persistence', () => {
         // Apprise API server URL (#3012) — loaded directly by SettingsTab,
         // not surfaced via SettingsContext (admin-only field, no global hook).
         'appriseApiServerUrl',
-        // MeshCore advanced path-edit toggle — gates the manual Edit Path…
-        // button + the server-side route. Read by the route directly via
-        // databaseService.settings.getSetting and lazy-fetched on the
-        // MeshCore page; not part of SettingsContext.
-        'meshcoreAdvancedPathEdit',
       ];
 
       const keysNotLoaded = SETTINGS_TAB_SENDS.filter(

--- a/src/utils/meshcorePath.test.ts
+++ b/src/utils/meshcorePath.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parsePathHops,
+  joinPathHops,
+  hopByteForKey,
+  repeaterHopOptions,
+  resolveHop,
+} from './meshcorePath.js';
+import type { MeshCoreContact } from './meshcoreHelpers';
+
+const mk = (publicKey: string, advType: number, advName?: string): MeshCoreContact => ({
+  publicKey,
+  advType,
+  advName,
+});
+
+describe('meshcorePath', () => {
+  it('parsePathHops normalizes a hex chain to 2-char lowercase bytes', () => {
+    expect(parsePathHops('A3,7f,2')).toEqual(['a3', '7f', '02']);
+    expect(parsePathHops('')).toEqual([]);
+    expect(parsePathHops(null)).toEqual([]);
+    expect(parsePathHops(undefined)).toEqual([]);
+    // drops junk tokens
+    expect(parsePathHops('a3,zz,7f')).toEqual(['a3', '7f']);
+  });
+
+  it('joinPathHops round-trips with parsePathHops', () => {
+    expect(joinPathHops(['a3', '7f', '02'])).toBe('a3,7f,02');
+    expect(joinPathHops([])).toBe('');
+    expect(parsePathHops(joinPathHops(['a3', '7f']))).toEqual(['a3', '7f']);
+  });
+
+  it('hopByteForKey returns the first key byte, lowercased', () => {
+    expect(hopByteForKey('A3B4C5'.padEnd(64, '0'))).toBe('a3');
+  });
+
+  it('repeaterHopOptions includes only repeaters/rooms, sorted by name', () => {
+    const contacts = [
+      mk('aa'.repeat(32), 1, 'A Chat Node'), // Chat — excluded
+      mk('b1'.repeat(32), 2, 'Zeta Repeater'),
+      mk('c2'.repeat(32), 3, 'Alpha Room'),
+      mk('d3'.repeat(32), 2, 'Mid Repeater'),
+    ];
+    const opts = repeaterHopOptions(contacts);
+    expect(opts.map((o) => o.name)).toEqual(['Alpha Room', 'Mid Repeater', 'Zeta Repeater']);
+    expect(opts.find((o) => o.name === 'Zeta Repeater')!.hopByte).toBe('b1');
+  });
+
+  it('repeaterHopOptions falls back to a key prefix when unnamed', () => {
+    const opts = repeaterHopOptions([mk('ab'.repeat(32), 2)]);
+    expect(opts[0].name).toBe('abababab…');
+  });
+
+  it('resolveHop labels known, ambiguous, and unknown hops', () => {
+    const opts = repeaterHopOptions([
+      mk('a3' + 'b'.repeat(62), 2, 'North Repeater'),
+      mk('a3' + 'c'.repeat(62), 2, 'South Repeater'), // same hop byte → collision
+      mk('7f' + 'd'.repeat(62), 2, 'East Repeater'),
+    ]);
+    expect(resolveHop('7f', opts).label).toBe('East Repeater');
+    expect(resolveHop('a3', opts).label).toMatch(/^(North|South) Repeater \(\+1\)$/);
+    expect(resolveHop('a3', opts).matches).toHaveLength(2);
+    expect(resolveHop('ff', opts).label).toBe('Unknown (0xff)');
+    expect(resolveHop('ff', opts).matches).toHaveLength(0);
+  });
+});

--- a/src/utils/meshcorePath.ts
+++ b/src/utils/meshcorePath.ts
@@ -29,7 +29,16 @@ export function joinPathHops(hops: PathHop[]): string {
   return hops.join(',');
 }
 
-/** The routing hop byte for a node = the first byte of its public key. */
+/**
+ * The routing hop byte for a node = the first byte of its public key.
+ *
+ * NOTE: assumes the **1-byte path hash width**, which is MeshCore's default and
+ * the only width this name-picker supports. The firmware can negotiate 2- or
+ * 3-byte hashes (`outPathLenRaw >> 6` on the wire); on such a network the mapped
+ * byte would be wrong. 1-byte is overwhelmingly the norm, so we scope to it here
+ * rather than plumb hash-width through the UI — revisit if multi-byte hashes
+ * become common.
+ */
 export function hopByteForKey(publicKey: string): PathHop {
   return publicKey.slice(0, 2).toLowerCase();
 }

--- a/src/utils/meshcorePath.ts
+++ b/src/utils/meshcorePath.ts
@@ -1,0 +1,75 @@
+import type { MeshCoreContact } from './meshcoreHelpers';
+
+/**
+ * Helpers for composing a MeshCore contact forwarding path ("out_path") from
+ * named repeaters instead of raw hex.
+ *
+ * A MeshCore out_path is an ordered list of 1-byte routing hashes — each hop is
+ * the **first byte of that repeater's public key** (the default 1-byte path
+ * hash width). The companion API stores/accepts the path as a comma-separated
+ * hex chain (e.g. "a3,7f,02"); these helpers convert between that wire form and
+ * a name-aware UI.
+ */
+
+/** A single forwarding hop as a normalized 2-char lowercase hex byte. */
+export type PathHop = string;
+
+/** Parse a stored out_path ("a3,7f,02") into normalized hop bytes. */
+export function parsePathHops(outPath: string | null | undefined): PathHop[] {
+  if (!outPath) return [];
+  return outPath
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => /^[0-9a-f]{1,2}$/.test(s))
+    .map((s) => s.padStart(2, '0'));
+}
+
+/** Join hop bytes back into the comma-separated chain the API expects. */
+export function joinPathHops(hops: PathHop[]): string {
+  return hops.join(',');
+}
+
+/** The routing hop byte for a node = the first byte of its public key. */
+export function hopByteForKey(publicKey: string): PathHop {
+  return publicKey.slice(0, 2).toLowerCase();
+}
+
+export interface RepeaterOption {
+  publicKey: string;
+  name: string;
+  hopByte: PathHop;
+}
+
+/**
+ * Candidate hops for the path picker: repeaters (advType 2) and room servers
+ * (advType 3) — the relay infrastructure a path traverses — with display names
+ * and their hop byte, sorted by name.
+ */
+export function repeaterHopOptions(contacts: MeshCoreContact[]): RepeaterOption[] {
+  return contacts
+    .filter((c) => c.advType === 2 || c.advType === 3)
+    .map((c) => ({
+      publicKey: c.publicKey,
+      name: c.advName || c.name || `${c.publicKey.slice(0, 8)}…`,
+      hopByte: hopByteForKey(c.publicKey),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export interface ResolvedHop {
+  byte: PathHop;
+  /** Repeaters whose key starts with this byte (0, 1, or many — 1-byte hashes collide). */
+  matches: RepeaterOption[];
+  /** Human label: the repeater name, "name (+N)" on collision, or "Unknown (0xAB)". */
+  label: string;
+}
+
+/** Resolve a hop byte to a human label using the known-repeater list. */
+export function resolveHop(byte: PathHop, options: RepeaterOption[]): ResolvedHop {
+  const matches = options.filter((o) => o.hopByte === byte);
+  let label: string;
+  if (matches.length === 1) label = matches[0].name;
+  else if (matches.length > 1) label = `${matches[0].name} (+${matches.length - 1})`;
+  else label = `Unknown (0x${byte})`;
+  return { byte, matches, label };
+}


### PR DESCRIPTION
## Summary

MeshCore lets a user manually **define a contact's forwarding path** (the `out_path` — the ordered list of repeater hops a message takes). MeshMonitor already had the backend for this, but the UI was a raw comma-separated hex input hidden behind an off-by-default `meshcoreAdvancedPathEdit` toggle. This makes it a first-class, **on-by-default** feature with a **name-aware** editor that mirrors the MeshCore app's flow.

## What changed

**Name-based path editor** (`MeshCoreContactDetailPanel`):
- "Define Path…" modal builds the route by **picking repeaters/room servers by name** from a dropdown, in order from your node outward.
- Ordered hop list with **reorder (↑/↓)** and **remove (✕)**.
- **Pre-fills** from the contact's existing `out_path`, resolving each hop byte back to a repeater name (or "Unknown (0x..)" for repeaters you haven't met).
- **Raw-hex byte** fallback for hops to unknown repeaters.
- Emits the same comma-separated hex chain the existing `PUT .../out-path` route accepts — no backend protocol change.

**New helper** (`src/utils/meshcorePath.ts`): pure functions mapping repeaters ↔ hops. A hop is the **first byte of the repeater's public key** (MeshCore's default 1-byte path hash). Handles hash collisions and unknown hops. Unit-tested.

**Enabled by default (toggle removed):**
- Dropped the `meshcoreAdvancedPathEdit` 403 gate from the `PUT .../out-path` route.
- Removed the panel's `advancedPathEditEnabled` gate and the DM view's toggle fetch.
- Removed the Settings toggle UI **and the `meshcoreAdvancedPathEdit` setting key** entirely.
- Now gated only by `nodes:write` + a Companion device (unchanged access model otherwise).

## Testing

- `meshcorePath` unit suite (parse/join/resolve, name resolution + collisions).
- Panel tests: build-a-path-by-name → save the right hex chain; pre-populate + resolve an existing path to names.
- Route + settings-persistence tests updated (the 403-gate test removed).
- Full Vitest suite green; `tsc` clean for touched files.
- Deployed to the dev container and verified against real MeshCore hardware.

## Not in this PR

The backend stack (`set_out_path` bridge → meshcore.js `setContactPath` → `CMD_ADD_UPDATE_CONTACT`, and the manager's `setContactOutPath`) already existed — this is the UX + access-model change on top.

A **separate, pre-existing issue** (not touched here): the MeshCore DM contact list is sourced from `getContacts()` (the device's in-memory companion contact list) rather than the richer observed-node list, which can show a sparse/unnamed set on some sources. To be investigated in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)