### PR TITLE
fix(meshcore): seed in-memory contacts from DB so the DM list isn't empty on a flaky source

### DIFF
--- a/src/server/meshcoreManager.seedContacts.test.ts
+++ b/src/server/meshcoreManager.seedContacts.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for MeshCoreManager.seedContactsFromDb().
+ *
+ * Regression: the DM contact list is sourced from getContacts() (in-memory
+ * this.contacts), which is only populated by the live device get_contacts.
+ * On a flaky/slow companion that returns empty (or times out), the in-memory
+ * list stayed nearly empty — so the DM list showed a handful of unnamed
+ * entries while the node/map view (DB-backed getAllNodes) showed the full set.
+ * seedContactsFromDb pre-fills this.contacts from the persisted node list so
+ * the two stay consistent when the live sync degrades.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const getNodesBySource = vi.fn();
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      getNodesBySource: (...args: unknown[]) => getNodesBySource(...args),
+    },
+  },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: {
+    emitMeshCoreContactUpdated: vi.fn(),
+    emitMeshCoreMessage: vi.fn(),
+    emitMeshCoreSelfInfoUpdated: vi.fn(),
+  },
+}));
+
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+const dbNode = (publicKey: string, name: string | null, advType = MeshCoreDeviceType.REPEATER, extra: Record<string, unknown> = {}) => ({
+  publicKey,
+  name,
+  advType,
+  isLocalNode: false,
+  rssi: null,
+  snr: null,
+  latitude: null,
+  longitude: null,
+  lastHeard: 1_700_000_000,
+  outPath: null,
+  pathLen: null,
+  ...extra,
+});
+
+// seedContactsFromDb is private; invoke it directly to exercise the seed path
+// without standing up the native backend.
+const seed = (m: MeshCoreManager) => (m as unknown as { seedContactsFromDb(): Promise<void> }).seedContactsFromDb();
+const setCompanion = (m: MeshCoreManager) => { (m as unknown as { deviceType: MeshCoreDeviceType }).deviceType = MeshCoreDeviceType.COMPANION; };
+
+describe('MeshCoreManager.seedContactsFromDb', () => {
+  beforeEach(() => getNodesBySource.mockReset());
+
+  it('seeds named contacts from the DB into getContacts()', async () => {
+    getNodesBySource.mockResolvedValue([
+      dbNode('b1'.repeat(32), 'North Repeater'),
+      dbNode('7f'.repeat(32), 'East Repeater', MeshCoreDeviceType.COMPANION),
+    ]);
+    const m = new MeshCoreManager('src-a');
+    setCompanion(m);
+    await seed(m);
+
+    const contacts = m.getContacts();
+    expect(contacts).toHaveLength(2);
+    const north = contacts.find((c) => c.publicKey === 'b1'.repeat(32))!;
+    expect(north.advName).toBe('North Repeater');
+    expect(north.advType).toBe(MeshCoreDeviceType.REPEATER);
+  });
+
+  it('skips the local node', async () => {
+    getNodesBySource.mockResolvedValue([
+      dbNode('aa'.repeat(32), 'Me', MeshCoreDeviceType.COMPANION, { isLocalNode: true }),
+      dbNode('b1'.repeat(32), 'North Repeater'),
+    ]);
+    const m = new MeshCoreManager('src-a');
+    setCompanion(m);
+    await seed(m);
+    expect(m.getContacts().map((c) => c.publicKey)).toEqual(['b1'.repeat(32)]);
+  });
+
+  it('does not clobber an existing in-memory contact (e.g. a live advert)', async () => {
+    getNodesBySource.mockResolvedValue([dbNode('b1'.repeat(32), 'Stale DB Name')]);
+    const m = new MeshCoreManager('src-a');
+    setCompanion(m);
+    (m as unknown as { contacts: Map<string, unknown> }).contacts.set('b1'.repeat(32), {
+      publicKey: 'b1'.repeat(32),
+      advName: 'Fresh Advert Name',
+    });
+    await seed(m);
+    expect(m.getContacts().find((c) => c.publicKey === 'b1'.repeat(32))!.advName).toBe('Fresh Advert Name');
+  });
+
+  it('is a no-op for repeater sources', async () => {
+    getNodesBySource.mockResolvedValue([dbNode('b1'.repeat(32), 'North Repeater')]);
+    const m = new MeshCoreManager('src-a');
+    (m as unknown as { deviceType: MeshCoreDeviceType }).deviceType = MeshCoreDeviceType.REPEATER;
+    await seed(m);
+    expect(m.getContacts()).toHaveLength(0);
+    expect(getNodesBySource).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -652,6 +652,15 @@ class MeshCoreManager extends EventEmitter {
 
       // Get initial info
       await this.refreshLocalNode();
+      // Pre-seed the in-memory contact list from the DB BEFORE the live
+      // get_contacts. On a flaky/slow companion the live refresh can return
+      // empty or time out (and refreshContacts deliberately won't wipe on
+      // empty), which previously left getContacts() — the source for the DM
+      // contact list — nearly empty even though the node list (DB-backed) was
+      // full. Seeding first means the DM list mirrors the known contacts when
+      // the live sync degrades; a successful refresh then replaces it with the
+      // device-authoritative list.
+      await this.seedContactsFromDb();
       await this.refreshContacts();
       // Pull the device's channel list and mirror it into the DB. MeshCore has
       // no push event for channel changes, so re-sync is connect-time and
@@ -1829,6 +1838,44 @@ class MeshCoreManager extends EventEmitter {
     }
 
     return this.contacts;
+  }
+
+  /**
+   * Pre-seed `this.contacts` from the persisted node list (the same DB the
+   * node/map view reads) so the DM contact list isn't empty when the live
+   * `get_contacts` sync degrades. Existing in-memory entries (e.g. a live
+   * advert push that raced ahead) are left untouched. Companion-only — repeater
+   * sources don't maintain a companion contact list. Non-fatal on DB error.
+   */
+  private async seedContactsFromDb(): Promise<void> {
+    if (this.deviceType === MeshCoreDeviceType.REPEATER) return;
+    try {
+      const dbNodes = await databaseService.meshcore.getNodesBySource(this.sourceId);
+      let seeded = 0;
+      for (const n of dbNodes) {
+        if (n.isLocalNode) continue;
+        if (this.contacts.has(n.publicKey)) continue;
+        this.contacts.set(n.publicKey, {
+          publicKey: n.publicKey,
+          advName: n.name ?? undefined,
+          name: n.name ?? undefined,
+          advType: (n.advType ?? undefined) as MeshCoreDeviceType | undefined,
+          rssi: n.rssi ?? undefined,
+          snr: n.snr ?? undefined,
+          latitude: n.latitude ?? undefined,
+          longitude: n.longitude ?? undefined,
+          lastSeen: n.lastHeard ?? undefined,
+          outPath: n.outPath ?? null,
+          pathLen: n.pathLen ?? null,
+        });
+        seeded++;
+      }
+      if (seeded > 0) {
+        logger.info(`[MeshCore:${this.sourceId}] Seeded ${seeded} contact(s) from DB`);
+      }
+    } catch (err) {
+      logger.warn(`[MeshCore:${this.sourceId}] seedContactsFromDb failed: ${(err as Error).message}`);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

On multi-source MeshCore, the **map page showed a full node list but the DM page showed only a handful of unnamed entries** for one source. Root cause:

- The **map / node list** reads `getAllNodes()` → `databaseService.meshcore.getNodesBySource()` (**DB-backed**) → full list ✓
- The **DM contact list** reads `getContacts()` → `this.contacts` (**in-memory only**), which is populated solely by the live device `get_contacts`.

`this.contacts` was **never seeded from the DB**. On a flaky/slow companion whose `get_contacts` returns empty or times out — and `refreshContacts()` deliberately won't wipe the list on an empty result (the "node list collapses to 1" guard) — the in-memory map stayed nearly empty, with only stray advert-push entries (often without `advName`, hence the unnamed "ID#" rows). Meanwhile the DB still held the full set, so the map looked fine. That's why it was **per-source**: a healthy companion's DM list worked; a flaky one's didn't.

(Observed on a source that was logging `Native command timeout: get_channels`.)

## Fix

Add `seedContactsFromDb()`, called in `connect()` immediately **before** the live `refreshContacts()`:
- Pre-fills `this.contacts` from the persisted node list (the same DB the map reads).
- Skips the local node; never clobbers a fresher in-memory entry (e.g. a live advert that raced ahead).
- A **successful** live refresh still replaces it with the device-authoritative list; a **degraded** one keeps the DB-seeded contacts → DM and map views stay consistent.
- Companion-only (repeaters have no companion contact list); non-fatal on DB error.

Mirrors the existing message-seeding-from-DB pattern already in `connect()`.

## Testing

- New `meshcoreManager.seedContacts.test.ts`: seeds named contacts, skips the local node, doesn't clobber a live in-memory entry, and is a no-op for repeater sources.
- All 42 meshcore manager suites pass; full Vitest suite green; `tsc` clean.

## Relation to #3550

Independent of the "define a path by name" PR (#3550). That PR touched the path editor; this touches contact loading. Branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)