### PR TITLE
fix(savebar): save all changed sections in a group with one click (#3552)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -234,6 +234,8 @@
   "common.days_ago": "{{count}}d ago",
 
   "savebar.save_changes_to": "Save changes to {{section}}",
+  "savebar.save_all_changes": "Save unsaved changes in {{count}} sections",
+  "savebar.save_all": "Save All",
 
   "auth.login": "Login",
   "auth.username": "Username",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,7 +87,7 @@ import { useTraceroutePaths } from './hooks/useTraceroutePaths';
 import { useNotificationNavigationHandler } from './hooks/useNotificationNavigationHandler';
 import LoginModal from './components/LoginModal';
 import LoginPage from './components/LoginPage';
-import { SaveBarProvider } from './contexts/SaveBarContext';
+import { SaveBarProvider, SaveBarGroup } from './contexts/SaveBarContext';
 import { SaveBar } from './components/SaveBar';
 import ErrorBoundary from './components/common/ErrorBoundary';
 
@@ -4918,6 +4918,7 @@ function App() {
         )}
         {activeTab === 'settings' && (
           <ErrorBoundary fallbackTitle="Settings failed to load">
+          <SaveBarGroup id="settings">
           <SettingsTab
             mode="source"
             maxNodeAgeHours={maxNodeAgeHours}
@@ -4969,10 +4970,12 @@ function App() {
             onSolarMonitoringAzimuthChange={setSolarMonitoringAzimuth}
             onSolarMonitoringDeclinationChange={setSolarMonitoringDeclination}
           />
+          </SaveBarGroup>
           </ErrorBoundary>
         )}
         {activeTab === 'automation' && (
           <ErrorBoundary fallbackTitle="Automation failed to load">
+          <SaveBarGroup id="automation">
           <div className="settings-tab">
             <SectionNav
               items={[
@@ -5192,6 +5195,7 @@ function App() {
               </div>
             </div>
           </div>
+          </SaveBarGroup>
           </ErrorBoundary>
         )}
         {activeTab === 'configuration' && (

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -29,7 +29,7 @@ import { MeshCoreRoomsView } from './MeshCoreRoomsView';
 import { MeshCoreAutomationsView } from './MeshCoreAutomationsView';
 import NotificationsTab from '../NotificationsTab';
 import { useAuth } from '../../contexts/AuthContext';
-import { SaveBarProvider } from '../../contexts/SaveBarContext';
+import { SaveBarProvider, SaveBarGroup } from '../../contexts/SaveBarContext';
 import { SaveBar } from '../SaveBar';
 import './MeshCoreTab.css';
 import './MeshCorePage.css';
@@ -169,10 +169,12 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
           )}
           {view === 'automations' && (
             <SaveBarProvider>
-              <MeshCoreAutomationsView
-                baseUrl={baseUrl}
-                sourceId={sourceId}
-              />
+              <SaveBarGroup id="meshcore-automation">
+                <MeshCoreAutomationsView
+                  baseUrl={baseUrl}
+                  sourceId={sourceId}
+                />
+              </SaveBarGroup>
               <SaveBar />
             </SaveBarProvider>
           )}

--- a/src/components/SaveBar/SaveBar.test.tsx
+++ b/src/components/SaveBar/SaveBar.test.tsx
@@ -95,6 +95,41 @@ describe('SaveBar grouped save', () => {
     expect(dismissB).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps the buttons disabled for the whole batch while saving', async () => {
+    // Section A's save is held open so we can observe the in-flight state
+    // between sequential saves (regression guard for the double-click window).
+    let resolveA: () => void = () => {};
+    const saveA = vi.fn(() => new Promise<void>((resolve) => { resolveA = resolve; }));
+    const saveB = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <SaveBarProvider>
+        <SaveBarGroup id="settings">
+          <Section id="a" name="Section A" hasChanges onSave={saveA} onDismiss={vi.fn()} />
+          <Section id="b" name="Section B" hasChanges onSave={saveB} onDismiss={vi.fn()} />
+        </SaveBarGroup>
+        <SaveBar />
+      </SaveBarProvider>
+    );
+
+    const saveButton = await screen.findByText('savebar.save_all');
+    await act(async () => {
+      fireEvent.click(saveButton);
+    });
+
+    // Mid-batch: A is still saving, B hasn't started, and the button is disabled.
+    expect(saveB).not.toHaveBeenCalled();
+    const savingButton = screen.getByText('common.saving').closest('button')!;
+    expect(savingButton).toBeDisabled();
+    expect(screen.getByText('common.dismiss').closest('button')!).toBeDisabled();
+
+    // Let the batch finish.
+    await act(async () => {
+      resolveA();
+    });
+    await waitFor(() => expect(saveB).toHaveBeenCalledTimes(1));
+  });
+
   it('continues saving remaining sections if one section save throws', async () => {
     const saveA = vi.fn().mockRejectedValue(new Error('boom'));
     const saveB = vi.fn().mockResolvedValue(undefined);
@@ -141,6 +176,9 @@ describe('SaveBar grouped save', () => {
 
     await waitFor(() => {
       // Only the active section is saved — exactly one of the two, never both.
+      // We assert order-independently because the auto-select effect makes the
+      // LAST-registered changed section active (last write wins), not the first,
+      // so which specific mock fires is an implementation detail.
       expect(saveA.mock.calls.length + saveB.mock.calls.length).toBe(1);
     });
   });

--- a/src/components/SaveBar/SaveBar.test.tsx
+++ b/src/components/SaveBar/SaveBar.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Tests for the unified SaveBar, focused on grouped ("Save All") behavior.
+ *
+ * Regression coverage for issue #3552: when multiple sections in a group have
+ * unsaved changes, a single Save action must persist ALL of them, not just the
+ * active one. Ungrouped sections (Device Configuration) keep per-section saving.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { SaveBarProvider, SaveBarGroup } from '../../contexts/SaveBarContext';
+import { useSaveBar } from '../../hooks/useSaveBar';
+import { SaveBar } from './SaveBar';
+
+/** A throwaway section component that registers itself with the SaveBar. */
+function Section({
+  id,
+  name,
+  hasChanges,
+  onSave,
+  onDismiss,
+  group,
+}: {
+  id: string;
+  name: string;
+  hasChanges: boolean;
+  onSave: () => Promise<void>;
+  onDismiss: () => void;
+  group?: string | null;
+}) {
+  useSaveBar({
+    id,
+    sectionName: name,
+    hasChanges,
+    isSaving: false,
+    onSave,
+    onDismiss,
+    group,
+  });
+  return null;
+}
+
+describe('SaveBar grouped save', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('saves every changed section in the group with one click (issue #3552)', async () => {
+    const saveA = vi.fn().mockResolvedValue(undefined);
+    const saveB = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <SaveBarProvider>
+        <SaveBarGroup id="settings">
+          <Section id="a" name="Section A" hasChanges onSave={saveA} onDismiss={vi.fn()} />
+          <Section id="b" name="Section B" hasChanges onSave={saveB} onDismiss={vi.fn()} />
+        </SaveBarGroup>
+        <SaveBar />
+      </SaveBarProvider>
+    );
+
+    const saveButton = await screen.findByText('savebar.save_all');
+    await act(async () => {
+      fireEvent.click(saveButton);
+    });
+
+    await waitFor(() => {
+      expect(saveA).toHaveBeenCalledTimes(1);
+      expect(saveB).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('dismisses every changed section in the group with one click', async () => {
+    const dismissA = vi.fn();
+    const dismissB = vi.fn();
+
+    render(
+      <SaveBarProvider>
+        <SaveBarGroup id="settings">
+          <Section id="a" name="Section A" hasChanges onSave={vi.fn().mockResolvedValue(undefined)} onDismiss={dismissA} />
+          <Section id="b" name="Section B" hasChanges onSave={vi.fn().mockResolvedValue(undefined)} onDismiss={dismissB} />
+        </SaveBarGroup>
+        <SaveBar />
+      </SaveBarProvider>
+    );
+
+    const dismissButton = await screen.findByText('common.dismiss');
+    await act(async () => {
+      fireEvent.click(dismissButton);
+    });
+
+    expect(dismissA).toHaveBeenCalledTimes(1);
+    expect(dismissB).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues saving remaining sections if one section save throws', async () => {
+    const saveA = vi.fn().mockRejectedValue(new Error('boom'));
+    const saveB = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <SaveBarProvider>
+        <SaveBarGroup id="settings">
+          <Section id="a" name="Section A" hasChanges onSave={saveA} onDismiss={vi.fn()} />
+          <Section id="b" name="Section B" hasChanges onSave={saveB} onDismiss={vi.fn()} />
+        </SaveBarGroup>
+        <SaveBar />
+      </SaveBarProvider>
+    );
+
+    const saveButton = await screen.findByText('savebar.save_all');
+    await act(async () => {
+      fireEvent.click(saveButton);
+    });
+
+    await waitFor(() => {
+      expect(saveA).toHaveBeenCalledTimes(1);
+      expect(saveB).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('only saves the active section for ungrouped sections (per-section behavior)', async () => {
+    const saveA = vi.fn().mockResolvedValue(undefined);
+    const saveB = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <SaveBarProvider>
+        {/* No SaveBarGroup wrapper => ungrouped => per-section save */}
+        <Section id="a" name="Device Config A" hasChanges onSave={saveA} onDismiss={vi.fn()} />
+        <Section id="b" name="Device Config B" hasChanges onSave={saveB} onDismiss={vi.fn()} />
+        <SaveBar />
+      </SaveBarProvider>
+    );
+
+    // Ungrouped multi-section shows the per-section "Save" label, not "Save All"
+    const saveButton = await screen.findByText('common.save');
+    await act(async () => {
+      fireEvent.click(saveButton);
+    });
+
+    await waitFor(() => {
+      // Only the active section is saved — exactly one of the two, never both.
+      expect(saveA.mock.calls.length + saveB.mock.calls.length).toBe(1);
+    });
+  });
+
+});

--- a/src/components/SaveBar/SaveBar.tsx
+++ b/src/components/SaveBar/SaveBar.tsx
@@ -33,23 +33,47 @@ export const SaveBar: React.FC = () => {
     return null;
   }
 
+  // When the active section belongs to a group, a single Save/Dismiss action
+  // applies to every changed section in that group ("Save All"). Ungrouped
+  // sections (e.g. Device Configuration) keep the per-section tab behavior.
+  const groupSections = effectiveSection.group
+    ? sectionsWithChanges.filter(s => s.group === effectiveSection.group)
+    : [effectiveSection];
+  const isBatch = groupSections.length > 1;
+  const anySaving = groupSections.some(s => s.isSaving);
+
   const handleSave = async () => {
-    await effectiveSection.onSave();
+    // Save sequentially so sections that hit the same endpoint don't race.
+    // Each section's onSave handles its own errors/toasts, but guard anyway so
+    // one failure doesn't abort the rest of the batch.
+    for (const section of groupSections) {
+      try {
+        await section.onSave();
+      } catch {
+        // section reports its own failure; continue with the remaining sections
+      }
+    }
   };
 
   const handleDismiss = () => {
-    effectiveSection.onDismiss();
+    for (const section of groupSections) {
+      section.onDismiss();
+    }
   };
 
   const handleSectionClick = (sectionId: string) => {
     setActiveSection(sectionId);
   };
 
+  // Per-section tabs are only meaningful for ungrouped sections — a grouped
+  // batch saves them all at once, so picking one isn't necessary.
+  const showTabs = !effectiveSection.group && sectionsWithChanges.length > 1;
+
   return (
     <div className="save-bar">
       <div className="save-bar-content">
         <div className="save-bar-left">
-          {sectionsWithChanges.length > 1 && (
+          {showTabs && (
             <div className="save-bar-section-tabs">
               {sectionsWithChanges.map(section => (
                 <button
@@ -64,27 +88,33 @@ export const SaveBar: React.FC = () => {
             </div>
           )}
           <span className="save-bar-message">
-            {t('savebar.save_changes_to', { section: effectiveSection.sectionName })}
+            {isBatch
+              ? t('savebar.save_all_changes', { count: groupSections.length })
+              : t('savebar.save_changes_to', { section: effectiveSection.sectionName })}
           </span>
         </div>
         <div className="save-bar-actions">
           <button
             className="save-bar-dismiss"
             onClick={handleDismiss}
-            disabled={effectiveSection.isSaving}
+            disabled={anySaving}
           >
             {t('common.dismiss')}
           </button>
           <button
             className="save-bar-save"
             onClick={handleSave}
-            disabled={effectiveSection.isSaving}
+            disabled={anySaving}
           >
-            {effectiveSection.isSaving ? t('common.saving') : t('common.save')}
+            {anySaving
+              ? t('common.saving')
+              : isBatch
+                ? t('savebar.save_all')
+                : t('common.save')}
           </button>
         </div>
       </div>
-      {sectionsWithChanges.length > 1 && (
+      {showTabs && (
         <div className="save-bar-badge">
           {sectionsWithChanges.length}
         </div>

--- a/src/components/SaveBar/SaveBar.tsx
+++ b/src/components/SaveBar/SaveBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSaveBarContext, SaveBarSection } from '../../contexts/SaveBarContext';
 import './SaveBar.css';
@@ -6,6 +6,9 @@ import './SaveBar.css';
 export const SaveBar: React.FC = () => {
   const { t } = useTranslation();
   const { sections, activeSection, setActiveSection } = useSaveBarContext();
+  // True for the full duration of a batch save, so the buttons stay disabled
+  // between sequential section saves (no re-enable window for double-clicks).
+  const [isBatchSaving, setIsBatchSaving] = useState(false);
 
   // Get sections with changes
   const sectionsWithChanges: SaveBarSection[] = [];
@@ -40,18 +43,23 @@ export const SaveBar: React.FC = () => {
     ? sectionsWithChanges.filter(s => s.group === effectiveSection.group)
     : [effectiveSection];
   const isBatch = groupSections.length > 1;
-  const anySaving = groupSections.some(s => s.isSaving);
+  const anySaving = isBatchSaving || groupSections.some(s => s.isSaving);
 
   const handleSave = async () => {
     // Save sequentially so sections that hit the same endpoint don't race.
     // Each section's onSave handles its own errors/toasts, but guard anyway so
     // one failure doesn't abort the rest of the batch.
-    for (const section of groupSections) {
-      try {
-        await section.onSave();
-      } catch {
-        // section reports its own failure; continue with the remaining sections
+    setIsBatchSaving(true);
+    try {
+      for (const section of groupSections) {
+        try {
+          await section.onSave();
+        } catch {
+          // section reports its own failure; continue with the remaining sections
+        }
       }
+    } finally {
+      setIsBatchSaving(false);
     }
   };
 

--- a/src/contexts/SaveBarContext.tsx
+++ b/src/contexts/SaveBarContext.tsx
@@ -7,6 +7,13 @@ export interface SaveBarSection {
   isSaving: boolean;
   onSave: () => Promise<void>;
   onDismiss: () => void;
+  /**
+   * Optional grouping key. Sections sharing a group are saved/dismissed together
+   * by a single SaveBar action ("Save All"). Sections without a group are saved
+   * individually (the default — e.g. Device Configuration, where each section is a
+   * separate device admin write).
+   */
+  group?: string;
 }
 
 interface SaveBarContextType {
@@ -73,3 +80,21 @@ export const useSaveBarContext = (): SaveBarContextType => {
   }
   return context;
 };
+
+/**
+ * Context carrying the active SaveBar group id for a region of the tree.
+ * Sections rendered inside a <SaveBarGroup> inherit its id (unless they pass an
+ * explicit `group` to useSaveBar). `null` means "no group" (per-section save).
+ */
+const SaveBarGroupContext = createContext<string | null>(null);
+
+/**
+ * Wraps a region whose SaveBar sections should be saved together with a single
+ * "Save All" action. Used for Settings/Automation areas; Device Configuration is
+ * intentionally left ungrouped so each section saves on its own.
+ */
+export const SaveBarGroup: React.FC<{ id: string; children: ReactNode }> = ({ id, children }) => (
+  <SaveBarGroupContext.Provider value={id}>{children}</SaveBarGroupContext.Provider>
+);
+
+export const useSaveBarGroup = (): string | null => useContext(SaveBarGroupContext);

--- a/src/hooks/useSaveBar.ts
+++ b/src/hooks/useSaveBar.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback } from 'react';
-import { useSaveBarContext, SaveBarSection } from '../contexts/SaveBarContext';
+import { useSaveBarContext, useSaveBarGroup, SaveBarSection } from '../contexts/SaveBarContext';
 
 export interface UseSaveBarOptions {
   id: string;
@@ -8,6 +8,11 @@ export interface UseSaveBarOptions {
   isSaving: boolean;
   onSave: () => Promise<void>;
   onDismiss: () => void;
+  /**
+   * Optional grouping key. Defaults to the nearest <SaveBarGroup> in the tree.
+   * Pass `null` to force this section to save individually even inside a group.
+   */
+  group?: string | null;
 }
 
 /**
@@ -17,6 +22,9 @@ export interface UseSaveBarOptions {
 export const useSaveBar = (options: UseSaveBarOptions): void => {
   const { id, sectionName, hasChanges, isSaving, onSave, onDismiss } = options;
   const { registerSection, unregisterSection, updateSection, setActiveSection, activeSection } = useSaveBarContext();
+  const inheritedGroup = useSaveBarGroup();
+  // Explicit option wins; otherwise inherit from the nearest <SaveBarGroup>.
+  const group = options.group !== undefined ? options.group ?? undefined : inheritedGroup ?? undefined;
 
   // Store callbacks in refs to avoid triggering effects on callback identity changes
   const onSaveRef = useRef(onSave);
@@ -47,14 +55,15 @@ export const useSaveBar = (options: UseSaveBarOptions): void => {
       hasChanges,
       isSaving,
       onSave: stableOnSave,
-      onDismiss: stableOnDismiss
+      onDismiss: stableOnDismiss,
+      group
     };
     registerSection(section);
 
     return () => {
       unregisterSection(id);
     };
-  }, [id, sectionName, registerSection, unregisterSection, stableOnSave, stableOnDismiss]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id, sectionName, group, registerSection, unregisterSection, stableOnSave, stableOnDismiss]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Update hasChanges and isSaving when they change
   useEffect(() => {

--- a/src/hooks/useSaveBar.ts
+++ b/src/hooks/useSaveBar.ts
@@ -23,8 +23,15 @@ export const useSaveBar = (options: UseSaveBarOptions): void => {
   const { id, sectionName, hasChanges, isSaving, onSave, onDismiss } = options;
   const { registerSection, unregisterSection, updateSection, setActiveSection, activeSection } = useSaveBarContext();
   const inheritedGroup = useSaveBarGroup();
-  // Explicit option wins; otherwise inherit from the nearest <SaveBarGroup>.
-  const group = options.group !== undefined ? options.group ?? undefined : inheritedGroup ?? undefined;
+  // Resolve the group: an explicit option wins (including `null` to opt out of
+  // an inherited group); otherwise inherit from the nearest <SaveBarGroup>.
+  // Normalize `null` -> `undefined` so "no group" has a single representation.
+  let group: string | undefined;
+  if (options.group !== undefined) {
+    group = options.group ?? undefined; // explicit `null` => no group
+  } else {
+    group = inheritedGroup ?? undefined; // inherit, `null` => no group
+  }
 
   // Store callbacks in refs to avoid triggering effects on callback identity changes
   const onSaveRef = useRef(onSave);

--- a/src/pages/GlobalSettingsPage.tsx
+++ b/src/pages/GlobalSettingsPage.tsx
@@ -10,7 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { SettingsProvider, useSettings } from '../contexts/SettingsContext';
 import { UIProvider } from '../contexts/UIContext';
-import { SaveBarProvider } from '../contexts/SaveBarContext';
+import { SaveBarProvider, SaveBarGroup } from '../contexts/SaveBarContext';
 import { ToastProvider } from '../components/ToastContainer';
 import { SaveBar } from '../components/SaveBar';
 import SettingsTab from '../components/SettingsTab';
@@ -84,6 +84,7 @@ function GlobalSettingsInner() {
       >
         {t('admin.back_to_dashboard')}
       </button>
+      <SaveBarGroup id="settings">
       <SettingsTab
         mode="global"
         maxNodeAgeHours={maxNodeAgeHours}
@@ -135,6 +136,7 @@ function GlobalSettingsInner() {
         onSolarMonitoringAzimuthChange={setSolarMonitoringAzimuth}
         onSolarMonitoringDeclinationChange={setSolarMonitoringDeclination}
       />
+      </SaveBarGroup>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #3552 — editing settings across multiple sections before clicking **Save** only persisted some changes; the others silently reverted.

**Root cause:** the unified `SaveBar` only called `effectiveSection.onSave()` — the single active section. Any other section with unsaved changes was never saved.

## Fix

Introduce an optional section **group**. Sections sharing a group are saved (and dismissed) together by a single **"Save All"** action. The group is supplied via a `<SaveBarGroup id="…">` provider wrapping a render region, so sections inherit it from context — no need to edit each of the ~25 section files.

- `SaveBarContext.tsx` — `group?` on `SaveBarSection`; new `SaveBarGroup` provider + `useSaveBarGroup` hook.
- `useSaveBar.ts` — sections inherit the nearest `SaveBarGroup` (explicit `group` option still wins; pass `null` to opt out).
- `SaveBar.tsx` — grouped active section ⇒ Save/Dismiss apply to **every changed section in the group**; saves run sequentially, each guarded so one failure doesn't abort the batch. Shows "Save All" with the changed-section count in the message text.
- Wrapped **Settings** + **Automation** (`App.tsx`), the **Global Settings** page, and **MeshCore Automations** (`MeshCorePage.tsx`) in `SaveBarGroup`.
- `en.json` — `savebar.save_all` / `savebar.save_all_changes`.

**Device Configuration is intentionally left ungrouped** — each section is a separate device admin write, so it keeps the per-section tab behavior, exactly as before.

> Note: the Settings tab itself registers **two** SaveBar sections — `SettingsTab` and the nested `PositionEstimationSection` — which is the Settings-tab manifestation of this bug. Wrapping `<SettingsTab>` batches both.

## Behavior change

- **Grouped** (Settings / Automation / MeshCore Automations): one click saves all changed sections.
- **Ungrouped** (Device Configuration): unchanged — per-section save via tabs.

## Testing

- New `SaveBar.test.tsx` (4 tests): grouped batch-save, batch-dismiss, resilience when one save throws, and ungrouped sections still save only the active section.
- Full suite: **6876 passed, 0 failed** (2327 suites, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
