### PR TITLE
fix(map): apply per-node position override on multi-source nodes endpoint

### DIFF
--- a/src/server/routes/sourceRoutes.positionOverride.test.ts
+++ b/src/server/routes/sourceRoutes.positionOverride.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Source Routes — nodes endpoint position-override tests
+ *
+ * Regression for #3551: GET /api/sources/:id/nodes returns raw DB rows that
+ * (unlike /api/poll) never pass through enhanceNodeForClient. The per-node
+ * position override therefore wasn't being applied to the flat lat/lng the
+ * dashboard map reads, so overridden nodes kept rendering at their raw GPS
+ * position. The endpoint must surface the override coordinates as the
+ * effective latitude/longitude, while honoring the private-override flag.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import sourceRoutes from './sourceRoutes.js';
+import databaseService from '../../services/database.js';
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    sources: {
+      getSource: vi.fn(),
+      getAllSources: vi.fn(),
+    },
+    nodes: {
+      getAllNodes: vi.fn(),
+      getNode: vi.fn(),
+    },
+    settings: {
+      getSetting: vi.fn(),
+    },
+    checkPermissionAsync: vi.fn(),
+    findUserByIdAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn(),
+    getUserPermissionSetAsync: vi.fn(),
+    getChannelDatabasePermissionsForUserAsSetAsync: vi.fn(),
+  },
+}));
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    getManager: vi.fn().mockReturnValue(null),
+    startManager: vi.fn(),
+    stopManager: vi.fn(),
+  },
+}));
+
+vi.mock('../meshtasticManager.js', () => ({
+  MeshtasticManager: vi.fn().mockImplementation(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+const mockDb = databaseService as any;
+
+const MOCK_SOURCE = { id: 'src-tcp', name: 'Test TCP', type: 'meshtastic_tcp', enabled: true };
+
+const createApp = (user: any): Express => {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: 'test-secret',
+      resave: false,
+      saveUninitialized: false,
+      cookie: { secure: false },
+    }),
+  );
+  app.use((req: any, _res: any, next: any) => {
+    if (user) {
+      req.session.userId = user.id;
+      mockDb.findUserByIdAsync.mockResolvedValue(user);
+    }
+    next();
+  });
+  app.use('/', sourceRoutes);
+  return app;
+};
+
+const adminUser = { id: 1, username: 'admin', isActive: true, isAdmin: true };
+const regularUser = { id: 7, username: 'viewer', isActive: true, isAdmin: false };
+
+// A node with both raw GPS and an enabled position override.
+const overriddenNode = () => ({
+  nodeNum: 100,
+  nodeId: '!00000064',
+  longName: 'Spoofed Node',
+  shortName: 'SPF',
+  channel: 0,
+  // Raw GPS (off in Europe/Africa per the bug report)
+  latitude: 9.123456,
+  longitude: 38.987654,
+  altitude: 100,
+  // User-set override (the correct location)
+  positionOverrideEnabled: true,
+  latitudeOverride: 40.7128,
+  longitudeOverride: -74.006,
+  altitudeOverride: 10,
+  positionOverrideIsPrivate: false,
+});
+
+describe('GET /:id/nodes — position override application (#3551)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+    mockDb.findUserByUsernameAsync.mockResolvedValue(null);
+    mockDb.checkPermissionAsync.mockResolvedValue(true);
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({});
+    mockDb.getChannelDatabasePermissionsForUserAsSetAsync.mockResolvedValue({});
+    mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
+  });
+
+  it('replaces flat latitude/longitude with the override coordinates', async () => {
+    mockDb.nodes.getAllNodes.mockResolvedValue([overriddenNode()]);
+
+    const res = await request(createApp(adminUser)).get('/src-tcp/nodes');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    const node = res.body[0];
+    expect(node.latitude).toBe(40.7128);
+    expect(node.longitude).toBe(-74.006);
+    expect(node.altitude).toBe(10);
+    expect(node.positionIsOverride).toBe(true);
+  });
+
+  it('leaves raw GPS untouched when no override is enabled', async () => {
+    const node = overriddenNode();
+    node.positionOverrideEnabled = false;
+    mockDb.nodes.getAllNodes.mockResolvedValue([node]);
+
+    const res = await request(createApp(adminUser)).get('/src-tcp/nodes');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].latitude).toBe(9.123456);
+    expect(res.body[0].longitude).toBe(38.987654);
+    expect(res.body[0].positionIsOverride).toBeUndefined();
+  });
+
+  it('does not apply an override missing its coordinates', async () => {
+    const node = overriddenNode();
+    node.latitudeOverride = null as any;
+    node.longitudeOverride = null as any;
+    mockDb.nodes.getAllNodes.mockResolvedValue([node]);
+
+    const res = await request(createApp(adminUser)).get('/src-tcp/nodes');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].latitude).toBe(9.123456);
+    expect(res.body[0].longitude).toBe(38.987654);
+  });
+
+  it('applies a private override for an admin (can view private)', async () => {
+    const node = overriddenNode();
+    node.positionOverrideIsPrivate = true;
+    mockDb.nodes.getAllNodes.mockResolvedValue([node]);
+
+    const res = await request(createApp(adminUser)).get('/src-tcp/nodes');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].latitude).toBe(40.7128);
+    expect(res.body[0].longitude).toBe(-74.006);
+    expect(res.body[0].positionIsOverride).toBe(true);
+  });
+
+  it('hides a private override from a user without nodes_private read', async () => {
+    const node = overriddenNode();
+    node.positionOverrideIsPrivate = true;
+    mockDb.nodes.getAllNodes.mockResolvedValue([node]);
+    mockDb.findUserByIdAsync.mockResolvedValue(regularUser);
+    // Grant nodes:read + channel_0 viewOnMap, but deny nodes_private:read.
+    mockDb.checkPermissionAsync.mockImplementation(
+      (_userId: number, resource: string) => Promise.resolve(resource !== 'nodes_private'),
+    );
+    mockDb.getUserPermissionSetAsync.mockResolvedValue({
+      channel_0: { read: true, write: false, viewOnMap: true },
+    });
+
+    const res = await request(createApp(regularUser)).get('/src-tcp/nodes');
+
+    expect(res.status).toBe(200);
+    const result = res.body[0];
+    // Override not applied — raw GPS preserved.
+    expect(result.latitude).toBe(9.123456);
+    expect(result.longitude).toBe(38.987654);
+    expect(result.positionIsOverride).toBeUndefined();
+    // Private override coordinates stripped from the response.
+    expect(result.latitudeOverride).toBeUndefined();
+    expect(result.longitudeOverride).toBeUndefined();
+    expect(result.altitudeOverride).toBeUndefined();
+  });
+});

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -1008,7 +1008,42 @@ router.get('/:id/nodes', requirePermission('nodes', 'read', { sourceIdFrom: 'par
     // Filter by channel viewOnMap permissions and mask private position channels
     const filtered = await filterNodesByChannelPermission(nodes, user, source.id);
     const masked = await maskNodeLocationByChannel(filtered, user, source.id);
-    res.json(masked);
+
+    // Apply per-node position override to the flat lat/lng the dashboard map
+    // reads (issue #3551). These are raw DB rows, so unlike /api/poll they
+    // never passed through enhanceNodeForClient — without this the map renders
+    // the raw GPS position and ignores the override. Mirror that helper's
+    // privacy semantics: private overrides are honored only for callers with
+    // nodes_private read, and the override coords are stripped for everyone else.
+    const canViewPrivate = user?.isAdmin
+      ? true
+      : (user ? await hasPermission(user, 'nodes_private', 'read') : false);
+    const withOverride = masked.map(node => {
+      const n = node as any;
+      const isPrivate = n.positionOverrideIsPrivate === true;
+
+      // Hide the override coordinates from callers who can't view private positions.
+      if (isPrivate && !canViewPrivate) {
+        const stripped = { ...n };
+        delete stripped.latitudeOverride;
+        delete stripped.longitudeOverride;
+        delete stripped.altitudeOverride;
+        return stripped;
+      }
+
+      const eff = getEffectivePosition(n);
+      if (eff.isOverride) {
+        return {
+          ...n,
+          latitude: eff.latitude,
+          longitude: eff.longitude,
+          altitude: eff.altitude,
+          positionIsOverride: true,
+        };
+      }
+      return n;
+    });
+    res.json(withOverride);
   } catch (error) {
     logger.error('Error fetching nodes for source:', error);
     res.status(500).json({ error: 'Failed to fetch nodes' });

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -54,10 +54,6 @@ export async function validateVirtualNodeConfig(
   return null;
 }
 
-// Pure utility — no request-specific state. Delegates to the shared helper
-// so override behaviour matches the rest of the API surface (issue #2847).
-const getEffectivePosition = (node: any) => getEffectiveDbNodePosition(node);
-
 // Build the right ISourceManager for a stored Source row. Used by both the
 // HTTP create path and the startup wiring in server.ts.
 export function buildMqttManagerForSource(
@@ -937,7 +933,10 @@ router.get('/:id/nodes', requirePermission('nodes', 'read', { sourceIdFrom: 'par
 
     // MeshCore sources don't share the meshtastic node table — pull contacts
     // (and localNode) directly from the per-source MeshCoreManager and map
-    // them into the dashboard's flat node shape.
+    // them into the dashboard's flat node shape. These return early and never
+    // reach the position-override logic below: MeshCore contacts have no
+    // override columns (that's a Meshtastic-node feature, #3551), so there's
+    // nothing to apply.
     if (source.type === 'meshcore') {
       const mcManager = meshcoreManagerRegistry.get(source.id);
       const mcNodes: any[] = [];
@@ -1031,7 +1030,7 @@ router.get('/:id/nodes', requirePermission('nodes', 'read', { sourceIdFrom: 'par
         return stripped;
       }
 
-      const eff = getEffectivePosition(n);
+      const eff = getEffectiveDbNodePosition(n);
       if (eff.isOverride) {
         return {
           ...n,
@@ -1200,8 +1199,8 @@ router.get('/:id/neighbor-info', requirePermission('nodes', 'read', { sourceIdFr
       .map(ni => {
       const node = nodeMap.get(ni.nodeNum) ?? null;
       const neighbor = nodeMap.get(ni.neighborNodeNum) ?? null;
-      const nodePos = getEffectivePosition(node);
-      const neighborPos = getEffectivePosition(neighbor);
+      const nodePos = getEffectiveDbNodePosition(node);
+      const neighborPos = getEffectiveDbNodePosition(neighbor);
 
       const TX_MQTT = 5;
       const TX_UDP = 6;


### PR DESCRIPTION
## Summary
The per-node position override was being saved correctly but never appeared on the map. The multi-source DashboardPage map fetches nodes via `GET /api/sources/:id/nodes`, which returns raw DB rows. Unlike `/api/poll` (which runs nodes through `enhanceNodeForClient`), this endpoint never applied the override, so the map kept rendering the raw — potentially spoofed — GPS position. This fixes #3551 by surfacing the effective (override) coordinates on that endpoint.

## Changes
- `src/server/routes/sourceRoutes.ts` — `GET /:id/nodes` now applies `getEffectiveDbNodePosition` to each node, overwriting the flat `latitude`/`longitude`/`altitude` the map reads and setting `positionIsOverride: true` (which suppresses the misleading GPS accuracy circle).
- Mirrors `enhanceNodeForClient`'s privacy semantics: private overrides are honored only for callers with `nodes_private` read, and the override coordinates are stripped from the response for everyone else.
- Added `src/server/routes/sourceRoutes.positionOverride.test.ts` covering: override applied to flat coords, no-override left untouched, incomplete override ignored, admin sees private override, and non-admin gets the private override hidden + coords stripped.

## Issues Resolved
Fixes #3551. Unblocks the "Hide from Map" workaround discussed in #3549 (which depends on the override working).

## Documentation Updates
No documentation changes needed — this restores already-documented override behavior on a second endpoint.

## Testing
- [x] Targeted suites pass: new override test (5) + full sourceRoutes & nodeEnhancer suites (120), 0 failures
- [x] `tsconfig.server.json` typechecks cleanly for the changed files
- [ ] Reviewer: set a position override on a node via the node edit view, then confirm the marker on the multi-source Dashboard map moves to the override coordinates (and the accuracy circle disappears)
- [ ] Reviewer: confirm a *private* override is hidden from a non-admin without `nodes_private` read (marker stays at raw GPS, no `*Override` fields in the API response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)