### PR TITLE
fix(neighbors): align live map "Show Neighbor Info" with the Map Analysis Neighbors view

### DIFF
--- a/src/server/routes/neighborInfoRoutes.ts
+++ b/src/server/routes/neighborInfoRoutes.ts
@@ -40,11 +40,14 @@ router.get('/', requirePermission('info', 'read'), async (req: Request, res: Res
         };
       })))
       .filter(ni => {
-        if (!ni.node?.lastHeard || ni.node.lastHeard < cutoffTime) return false;
-        if (ni.neighbor?.lastHeard && ni.neighbor.lastHeard >= cutoffTime) return true;
+        // Report-time freshness: show a neighbor edge only when its NeighborInfo
+        // *report* falls within the window, matching the Map Analysis
+        // "Neighbors" layer (which filters on the record `timestamp`). See the
+        // longer note on GET /api/sources/:id/neighbor-info in sourceRoutes.ts.
+        // Keying off the record timestamp keeps indirect-neighbor links whose
+        // neighbor row has a null `lastHeard` (#3025/#2615).
         const reportSec = Math.floor((ni.timestamp ?? 0) / 1000);
-        const rxSec = ni.lastRxTime ?? 0;
-        return Math.max(reportSec, rxSec) >= cutoffTime;
+        return reportSec >= cutoffTime;
       })
       .map(({ node, neighbor, ...rest }) => rest);
 

--- a/src/server/routes/sourceRoutes.neighbor-info.test.ts
+++ b/src/server/routes/sourceRoutes.neighbor-info.test.ts
@@ -182,16 +182,18 @@ describe('GET /:id/neighbor-info', () => {
     expect(res.body[0].bidirectional).toBe(false);
   });
 
-  it('filters out records where the reporter lastHeard is older than maxNodeAge', async () => {
-    const staleTime = nowSec() - 30 * 60 * 60; // 30 hours ago — beyond default 24h
-    const ni = makeNeighborRecord({ nodeNum: 111, neighborNodeNum: 222 });
+  it('filters out records whose NeighborInfo report is older than maxNodeAge', async () => {
+    // Report-time semantics: a stale report drops out, which is what aligns the
+    // live map with the Map Analysis "Neighbors" view (both filter on the record
+    // timestamp, not on whether the endpoint nodes are still otherwise active).
+    const staleMs = Date.now() - 30 * 60 * 60 * 1000; // 30 hours ago — beyond default 24h
+    const ni = makeNeighborRecord({ nodeNum: 111, neighborNodeNum: 222, timestamp: staleMs });
 
     mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
     mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([ni]);
-    // reporter (111) is stale — we haven't heard from them recently, so we can't
-    // trust the link even if the NeighborInfo row in the DB is otherwise recent.
+    // Both endpoint nodes are still fresh — only the report itself is stale.
     mockDb.nodes.getNodesByNums.mockImplementation(async (nums: number[]) =>
-      new Map(nums.map(n => [n, n === 111 ? makeNode(n, { lastHeard: staleTime }) : makeNode(n)]))
+      new Map(nums.map(n => [n, makeNode(n)]))
     );
 
     const res = await request(createApp()).get('/src-abc/neighbor-info');
@@ -200,12 +202,35 @@ describe('GET /:id/neighbor-info', () => {
     expect(res.body).toEqual([]);
   });
 
-  it('filters out records where the reporter node has no lastHeard', async () => {
-    const ni = makeNeighborRecord({ nodeNum: 111, neighborNodeNum: 222 });
+  it('keeps a fresh report even when an endpoint node lastHeard is stale (aligns with Map Analysis)', async () => {
+    // Core of the neighbor-view alignment fix: freshness is determined by the
+    // report timestamp, not by whether the nodes are otherwise still active.
+    // Previously a fresh report was dropped whenever the reporter's node row had
+    // a stale/null lastHeard, surfacing far fewer links than the analysis view
+    // (and conversely keeping stale reports of active nodes — the user-reported
+    // mismatch).
+    const ni = makeNeighborRecord({ nodeNum: 111, neighborNodeNum: 222 }); // fresh report
+    const staleNodeTime = nowSec() - 72 * 60 * 60;
 
     mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
     mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([ni]);
-    // reporter (111) has null lastHeard — we never heard from them directly
+    mockDb.nodes.getNodesByNums.mockImplementation(async (nums: number[]) =>
+      new Map(nums.map(n => [n, makeNode(n, { lastHeard: staleNodeTime })]))
+    );
+
+    const res = await request(createApp()).get('/src-abc/neighbor-info');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+
+  it('keeps a fresh report even when the reporter node row has no lastHeard', async () => {
+    // We no longer gate on node.lastHeard, so the #3025 local-node lastHeard
+    // refresh is no longer load-bearing for this path.
+    const ni = makeNeighborRecord({ nodeNum: 111, neighborNodeNum: 222 }); // fresh report
+
+    mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
+    mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([ni]);
     mockDb.nodes.getNodesByNums.mockImplementation(async (nums: number[]) =>
       new Map(nums.map(n => [n, n === 111 ? makeNode(n, { lastHeard: null }) : makeNode(n)]))
     );
@@ -213,7 +238,7 @@ describe('GET /:id/neighbor-info', () => {
     const res = await request(createApp()).get('/src-abc/neighbor-info');
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual([]);
+    expect(res.body).toHaveLength(1);
   });
 
   it('keeps records where the neighbor has null lastHeard but the NeighborInfo report is fresh', async () => {
@@ -258,26 +283,28 @@ describe('GET /:id/neighbor-info', () => {
     expect(res.body).toEqual([]);
   });
 
-  it('keeps records when neighbor lastHeard is null but lastRxTime (seconds) is fresh', async () => {
-    // Stale NI report row timestamp but recent firmware-supplied lastRxTime
+  it('filters out a stale report even when firmware lastRxTime is fresh', async () => {
+    // We key freshness off our own receipt timestamp (reliable) rather than the
+    // firmware-supplied lastRxTime (subject to device clock skew), matching the
+    // Map Analysis "Neighbors" view which filters on `timestamp` alone.
     const staleMs = Date.now() - 48 * 60 * 60 * 1000;
     const ni = makeNeighborRecord({
       nodeNum: 111,
       neighborNodeNum: 222,
       timestamp: staleMs,
-      lastRxTime: nowSec(), // firmware time, seconds
+      lastRxTime: nowSec(), // firmware time, seconds — no longer rescues a stale report
     });
 
     mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
     mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([ni]);
     mockDb.nodes.getNodesByNums.mockImplementation(async (nums: number[]) =>
-      new Map(nums.map(n => [n, n === 222 ? makeNode(n, { lastHeard: null }) : makeNode(n)]))
+      new Map(nums.map(n => [n, makeNode(n)]))
     );
 
     const res = await request(createApp()).get('/src-abc/neighbor-info');
 
     expect(res.status).toBe(200);
-    expect(res.body).toHaveLength(1);
+    expect(res.body).toEqual([]);
   });
 
   it('uses positionOverride when positionOverrideEnabled is true', async () => {
@@ -302,16 +329,16 @@ describe('GET /:id/neighbor-info', () => {
   });
 
   it('uses custom maxNodeAge from settings', async () => {
-    // maxNodeAge = 1 hour; stale reporter is 2 hours old
-    const staleTime = nowSec() - 2 * 60 * 60;
-    const ni = makeNeighborRecord({ nodeNum: 111, neighborNodeNum: 222 });
+    // maxNodeAge = 1 hour; the NeighborInfo report is 2 hours old
+    const staleMs = Date.now() - 2 * 60 * 60 * 1000;
+    const ni = makeNeighborRecord({ nodeNum: 111, neighborNodeNum: 222, timestamp: staleMs });
 
     mockDb.sources.getSource.mockResolvedValue(MOCK_SOURCE);
     mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([ni]);
     mockDb.settings.getSetting.mockResolvedValue('1'); // 1-hour window
-    // Reporter (111) is stale relative to the custom 1-hour window
+    // Endpoint nodes are fresh — the report is stale relative to the 1-hour window.
     mockDb.nodes.getNodesByNums.mockImplementation(async (nums: number[]) =>
-      new Map(nums.map(n => [n, n === 111 ? makeNode(n, { lastHeard: staleTime }) : makeNode(n)]))
+      new Map(nums.map(n => [n, makeNode(n)]))
     );
 
     const res = await request(createApp()).get('/src-abc/neighbor-info');

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -1193,17 +1193,21 @@ router.get('/:id/neighbor-info', requirePermission('nodes', 'read', { sourceIdFr
       };
     })
       .filter(ni => {
-        // The reporter (`node`) is a node we've directly heard from — we require a fresh
-        // `lastHeard` on them. The neighbor side may be a node we've only learned about
-        // second-hand through this NeighborInfo report (see #2615 zombie-node guard,
-        // which intentionally NULLs `lastHeard` on placeholder rows). For those, fall
-        // back to the freshness of the NeighborInfo record itself so we don't drop
-        // every indirect-neighbor link (#3025).
-        if (!ni.node?.lastHeard || ni.node.lastHeard < cutoffTime) return false;
-        if (ni.neighbor?.lastHeard && ni.neighbor.lastHeard >= cutoffTime) return true;
+        // Report-time freshness: show a neighbor edge only when its NeighborInfo
+        // *report* falls within the window. This matches the Map Analysis
+        // "Neighbors" layer (GET /api/analysis/neighbors), which filters purely
+        // on the record `timestamp`. Previously this gated on the endpoint
+        // nodes' `lastHeard`, so a node's stale last-known neighbor list stayed
+        // on the map for as long as the node was otherwise active (e.g. still
+        // sending position/telemetry) — surfacing far more links than the
+        // analysis view and misrepresenting how recently each RF link was seen.
+        // Keying off the record timestamp also naturally keeps indirect-neighbor
+        // links whose neighbor row has a null `lastHeard` (#3025/#2615), since
+        // `lastHeard` is no longer consulted here. `timestamp` is set to the
+        // packet-receipt time (ms) when the report is stored, so a fresh report
+        // implies we heard the reporter within the window.
         const reportSec = Math.floor((ni.timestamp ?? 0) / 1000);
-        const rxSec = ni.lastRxTime ?? 0;
-        return Math.max(reportSec, rxSec) >= cutoffTime;
+        return reportSec >= cutoffTime;
       })
       .map(({ node, neighbor, ...rest }) => rest);
 

--- a/src/server/server.neighbor-info-position.test.ts
+++ b/src/server/server.neighbor-info-position.test.ts
@@ -147,13 +147,12 @@ describe('Neighbor Info API with Position Overrides', () => {
             };
           })
           .filter(ni => {
-            // Mirror server.ts filter — reporter must be fresh, but neighbor can
-            // fall back to NeighborInfo report freshness when lastHeard is null (#3025)
-            if (!ni.node?.lastHeard || ni.node.lastHeard < cutoffTime) return false;
-            if (ni.neighbor?.lastHeard && ni.neighbor.lastHeard >= cutoffTime) return true;
+            // Mirror the route filter — report-time freshness: keep a neighbor
+            // edge only when its NeighborInfo report is within the window
+            // (matches the Map Analysis "Neighbors" view). lastHeard is no longer
+            // consulted, which also preserves indirect-neighbor links (#3025/#2615).
             const reportSec = Math.floor(((ni as any).timestamp ?? 0) / 1000);
-            const rxSec = (ni as any).lastRxTime ?? 0;
-            return Math.max(reportSec, rxSec) >= cutoffTime;
+            return reportSec >= cutoffTime;
           })
           .map(({ node, neighbor, ...rest }) => rest);
 


### PR DESCRIPTION
## Problem

A user reported (via Discord) that the **Neighbors** drawn on the **Map Analysis** page don't match the **Show Neighbor Info** links on the main source map — even with *Show Route Segments* and *Show Traceroute* disabled. The live map showed many more links than the analysis view.

## Root cause

Both views read the same `neighbor_info` table (each NeighborInfo packet deletes-then-reinserts the reporter's full list with a fresh `timestamp`, so the table holds each reporter's *latest* list). They diverged purely in the **freshness filter**:

| View | Endpoint | Freshness gate |
|------|----------|----------------|
| Map Analysis "Neighbors" | `/api/analysis/neighbors` | record `timestamp` within lookback (report recency) |
| Live map "Show Neighbor Info" | `/api/sources/:id/neighbor-info` (+ legacy `/api/neighbor-info`) | endpoint **nodes' `lastHeard`** within `maxNodeAgeHours` |

So the live map kept showing a node's **stale last-known neighbor list** for as long as the node stayed otherwise active (still sending position/telemetry), surfacing far more links than the analysis view and misrepresenting how recently each RF link was observed.

## Fix

Per maintainer decision (report-time is the canonical "neighbor" definition), switch the live-map endpoints to **report-time freshness** — keep an edge only when its NeighborInfo record `timestamp` is within `maxNodeAgeHours` — matching the analysis view.

- A fresh record inherently means we heard the reporter within the window (timestamp = packet-receipt time), so dropping the `node.lastHeard` gate loses no real signal.
- Keying off the record timestamp **preserves indirect-neighbor links** whose neighbor row has a null `lastHeard` (#3025/#2615), since `lastHeard` is no longer consulted — the prior special-case fallback is now the default behavior.
- Firmware-supplied `lastRxTime` is dropped from the predicate (device-clock-skew prone; the analysis view doesn't use it, so it would reintroduce divergence).

Applied to both `/api/sources/:id/neighbor-info` (used by the live map) and the legacy `/api/neighbor-info` for consistency.

## Tests

- Updated `sourceRoutes.neighbor-info.test.ts` to assert report-time semantics: a stale report is dropped even when endpoint nodes are still active; a fresh report is kept even when a node's `lastHeard` is stale/null (locks in the alignment direction). #3025 null-neighbor and #3092 channel-permission cases retained.
- Updated the inline filter copy in `server.neighbor-info-position.test.ts`.
- Full suite: **6878 passed, 0 failed** (0 failed suites).

## Notes / possible follow-up

- The window size is still per-view (`maxNodeAgeHours` for the live map vs the analysis page's `LOOKBACK` selector); set both to the same value to compare like-for-like. Semantics (the filtered field) now match.
- The analysis endpoint applies only source-level permission scoping, while the live map also applies per-channel `viewOnMap` filtering. For non-admins this can still differ — out of scope here, flagging for a possible future pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)