### PR TITLE
feat(ui): #3557 UI tweaks + map unification pass

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -51,7 +51,7 @@
   "auto_favorite.save_failed": "Failed to save auto-favorite settings",
   "auto_favorite.load_failed": "Failed to load auto-favorite config",
   "nav.nodes": "Nodes",
-  "nav.messages": "Messages",
+  "nav.messages": "Node Details",
   "nav.channels": "Channels",
   "nav.info": "Info",
   "nav.dashboard": "Dashboard",
@@ -2508,7 +2508,7 @@
   "automation.schedule.ending_at": "Ending At",
 
   "automation.time_sync.title": "Auto Time Sync",
-  "automation.time_sync.description": "Automatically synchronize the MeshMonitor server time to nodes that have remote admin access. Useful for nodes without NTP or GPS time sync capabilities. Each interval syncs one eligible node.",
+  "automation.time_sync.description": "Push the MeshMonitor server's time to your nodes (the server is the time authority). Targets nodes that have remote admin access — useful for nodes without NTP or GPS time sync. Each interval syncs one eligible node.",
   "automation.time_sync.interval": "Sync Interval (minutes)",
   "automation.time_sync.interval_description": "How often to sync time to nodes. Each interval syncs one eligible node. Range: 15-1440 minutes",
   "automation.time_sync.expiration_hours": "Re-sync After (hours)",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,7 +78,7 @@ import { AutomationProvider, useAutomation } from './contexts/AutomationContext'
 import { useAuth } from './contexts/AuthContext';
 import { useCsrf } from './contexts/CsrfContext';
 import { useSource } from './contexts/SourceContext';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useWebSocketConnected } from './contexts/WebSocketContext';
 import { useHealth } from './hooks/useHealth';
 import { useTxStatus } from './hooks/useTxStatus';
@@ -129,6 +129,7 @@ function App() {
   // surfaces; the bridge feeds us inbound packets only.
   const isMqttBridge = sourceType === 'mqtt_bridge';
   const navigate = useNavigate();
+const location = useLocation();
   const webSocketConnected = useWebSocketConnected();
   const { showToast } = useToast();
   const [showLoginModal, setShowLoginModal] = useState(false);
@@ -560,6 +561,22 @@ function App() {
     showIncompleteNodes,
     setShowIncompleteNodes,
   } = useUI();
+
+  // When the user clicks a source row in the Unified map's node popup, we
+  // navigate here (this source) with `state.focusDmNodeId` set. Open that
+  // node's direct-message conversation once on mount. The active tab itself
+  // comes from the `#messages` hash, so we only need to focus the DM target.
+  const focusDmFromNavRef = useRef(false);
+  useEffect(() => {
+    if (focusDmFromNavRef.current) return;
+    const navState = location.state as { focusDmNodeId?: string } | null;
+    const focusId = navState?.focusDmNodeId;
+    if (!focusId) return;
+    focusDmFromNavRef.current = true;
+    setActiveTab('messages');
+    setSelectedChannel(-1);
+    setSelectedDMNode(focusId);
+  }, [location.state, setActiveTab, setSelectedChannel, setSelectedDMNode]);
 
   // Automation context
   const {

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -17,10 +17,12 @@ import { MapContainer, TileLayer, Marker, Popup, Polyline, Rectangle, useMap } f
 import L from 'leaflet';
 import { createNodeIcon } from '../../utils/mapIcons';
 import { getTilesetById } from '../../config/tilesets';
-import type { CustomTileset } from '../../config/tilesets';
+import type { CustomTileset, TilesetId } from '../../config/tilesets';
 import DashboardWaypoints from './DashboardWaypoints';
-import DashboardNodePopup from './DashboardNodePopup';
+import DashboardNodePopup, { type NodeSourceRef } from './DashboardNodePopup';
 import GeoJsonOverlay from '../GeoJsonOverlay';
+import { TilesetSelector } from '../TilesetSelector';
+import MapLegend from '../MapLegend';
 import type { GeoJsonLayer } from '../../server/services/geojsonService.js';
 import { useMapContext } from '../../contexts/MapContext';
 import { useSettings } from '../../contexts/SettingsContext';
@@ -46,6 +48,11 @@ export interface DashboardMapProps {
   sourceId: string | null;
   /** Hours since lastHeard to count a node as "active". Favorites bypass this gate. */
   maxNodeAgeHours: number;
+  /**
+   * On the Unified map, called when a node popup's source row is clicked so the
+   * page can navigate to that source's Node Details view for the node.
+   */
+  onNodeSourceSelect?: (source: NodeSourceRef, nodeId: string | undefined) => void;
 }
 
 /** Extract lat/lng from a node — handles both flat (API) and nested (position) shapes. */
@@ -144,9 +151,26 @@ export default function DashboardMap({
   defaultCenter,
   sourceId,
   maxNodeAgeHours,
+  onNodeSourceSelect,
 }: DashboardMapProps) {
   const tileset = getTilesetById(tilesetId, customTilesets);
-  const { mapPinStyle } = useSettings();
+  const { mapPinStyle, setMapTileset } = useSettings();
+
+  // Tile selector + legend overlays — hidden by default, toggled from the Map
+  // Features panel. Persisted under the same localStorage keys the NodesTab map
+  // uses so the preference is unified across every map surface.
+  const [showTileSelector, setShowTileSelector] = useState(
+    () => localStorage.getItem('meshmonitor-showTileSelector') === 'true',
+  );
+  const [showLegend, setShowLegend] = useState(
+    () => localStorage.getItem('meshmonitor-showLegend') === 'true',
+  );
+  useEffect(() => {
+    localStorage.setItem('meshmonitor-showTileSelector', String(showTileSelector));
+  }, [showTileSelector]);
+  useEffect(() => {
+    localStorage.setItem('meshmonitor-showLegend', String(showLegend));
+  }, [showLegend]);
 
   const {
     showPaths,
@@ -185,7 +209,7 @@ export default function DashboardMap({
         const response = await fetch(`${baseUrl}/api/geojson/layers`);
         if (!response.ok) return;
         const data = await response.json();
-        if (!cancelled) setGeoJsonLayers(data);
+        if (!cancelled) setGeoJsonLayers(Array.isArray(data) ? data : []);
       } catch (err) {
         console.error('Failed to fetch GeoJSON layers:', err);
       }
@@ -339,6 +363,8 @@ export default function DashboardMap({
 
         <MapBoundsUpdater positions={nodePositions} sourceId={sourceId} />
 
+        {showLegend && <MapLegend />}
+
         {geoJsonLayers.length > 0 && <GeoJsonOverlay layers={geoJsonLayers} />}
 
         {showWaypoints && <DashboardWaypoints sourceId={sourceId} />}
@@ -364,7 +390,7 @@ export default function DashboardMap({
               icon={icon}
             >
               <Popup>
-                <DashboardNodePopup node={node} pos={pos} />
+                <DashboardNodePopup node={node} pos={pos} onSourceSelect={onNodeSourceSelect} />
               </Popup>
             </Marker>
           );
@@ -476,6 +502,13 @@ export default function DashboardMap({
         })}
       </MapContainer>
 
+      {showTileSelector && (
+        <TilesetSelector
+          selectedTilesetId={tilesetId as TilesetId}
+          onTilesetChange={setMapTileset}
+        />
+      )}
+
       {/* Map Features control panel — mirrors NodesTab's "Features" panel but
           trimmed to the toggles meaningful on a cross-source map. */}
       <div className="map-controls dashboard-map-controls">
@@ -581,6 +614,22 @@ export default function DashboardMap({
               onChange={(e) => setShowWaypoints(e.target.checked)}
             />
             <span>Show Waypoints</span>
+          </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showTileSelector}
+              onChange={(e) => setShowTileSelector(e.target.checked)}
+            />
+            <span>Show Tile Selection</span>
+          </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showLegend}
+              onChange={(e) => setShowLegend(e.target.checked)}
+            />
+            <span>Show Legend</span>
           </label>
           {/* GeoJSON overlay layers — per-layer on/off, mirroring NodesTab. */}
           {geoJsonLayers.map(layer => (

--- a/src/components/Dashboard/DashboardNodePopup.test.tsx
+++ b/src/components/Dashboard/DashboardNodePopup.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import DashboardNodePopup from './DashboardNodePopup';
 
 vi.mock('../../contexts/SettingsContext', () => ({
@@ -74,6 +74,45 @@ describe('DashboardNodePopup', () => {
     expect(screen.getByText('Core Bravo')).toBeInTheDocument();
     expect(screen.getByText('Meshtastic')).toBeInTheDocument();
     expect(screen.getByText('MeshCore')).toBeInTheDocument();
+  });
+
+  it('calls onSourceSelect with the source and node id when a source row is clicked', () => {
+    const onSourceSelect = vi.fn();
+    render(
+      <DashboardNodePopup
+        pos={pos}
+        onSourceSelect={onSourceSelect}
+        node={{
+          nodeNum: 100,
+          nodeId: '!00000064',
+          longName: 'Shared Node',
+          sources: [
+            { sourceId: 'a', sourceName: 'Tower Alpha', protocol: 'Meshtastic' },
+            { sourceId: 'b', sourceName: 'Core Bravo', protocol: 'MeshCore' },
+          ],
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByText('Core Bravo'));
+    expect(onSourceSelect).toHaveBeenCalledWith(
+      { sourceId: 'b', sourceName: 'Core Bravo', protocol: 'MeshCore' },
+      '!00000064',
+    );
+  });
+
+  it('renders source rows as disabled (non-clickable) when no onSourceSelect is given', () => {
+    render(
+      <DashboardNodePopup
+        pos={pos}
+        node={{
+          nodeNum: 100,
+          longName: 'Shared Node',
+          sources: [{ sourceId: 'a', sourceName: 'Tower Alpha', protocol: 'Meshtastic' }],
+        }}
+      />,
+    );
+    const row = screen.getByText('Tower Alpha').closest('button');
+    expect(row).toBeDisabled();
   });
 
   it('omits the sources section for single-source nodes', () => {

--- a/src/components/Dashboard/DashboardNodePopup.tsx
+++ b/src/components/Dashboard/DashboardNodePopup.tsx
@@ -26,6 +26,11 @@ export interface NodeSourceRef {
 interface DashboardNodePopupProps {
   node: any;
   pos: { lat: number; lng: number };
+  /**
+   * Called when the user clicks one of the "seen by" source rows. The Unified
+   * map uses this to jump to that source's Node Details view for this node.
+   */
+  onSourceSelect?: (source: NodeSourceRef, nodeId: string | undefined) => void;
 }
 
 /** Coerce a field that may live on the flat node or its nested `user`. */
@@ -36,7 +41,7 @@ function pick<T>(node: any, flatKey: string, userKey: string): T | undefined {
   return nested === null ? undefined : (nested as T | undefined);
 }
 
-export default function DashboardNodePopup({ node, pos }: DashboardNodePopupProps) {
+export default function DashboardNodePopup({ node, pos, onSourceSelect }: DashboardNodePopupProps) {
   const { timeFormat, dateFormat } = useDisplaySettings();
 
   const longName = pick<string>(node, 'longName', 'longName')
@@ -145,20 +150,31 @@ export default function DashboardNodePopup({ node, pos }: DashboardNodePopupProp
           </div>
         )}
 
-        {/* Unified view: which sources reported this node + protocol. */}
+        {/* Unified view: which sources reported this node + protocol. Each row
+            links to that source's Node Details view for this node. */}
         {sources && sources.length > 0 && (
           <div className="node-popup-sources">
             <div className="node-popup-sources-title">
               Seen by {sources.length} source{sources.length !== 1 ? 's' : ''}
             </div>
-            {sources.map((s) => (
-              <div key={s.sourceId} className="node-popup-source-row">
-                <span className={`node-popup-protocol-badge protocol-${s.protocol.toLowerCase()}`}>
-                  {s.protocol}
-                </span>
-                <span className="node-popup-source-name">{s.sourceName}</span>
-              </div>
-            ))}
+            {sources.map((s) => {
+              const clickable = !!onSourceSelect;
+              return (
+                <button
+                  key={s.sourceId}
+                  type="button"
+                  className="node-popup-source-row node-popup-source-row-button"
+                  disabled={!clickable}
+                  onClick={clickable ? () => onSourceSelect!(s, nodeId) : undefined}
+                  title={clickable ? `Open ${s.sourceName} → Node Details` : undefined}
+                >
+                  <span className={`node-popup-protocol-badge protocol-${s.protocol.toLowerCase()}`}>
+                    {s.protocol}
+                  </span>
+                  <span className="node-popup-source-name">{s.sourceName}</span>
+                </button>
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -4,9 +4,14 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { useSettings } from '../../contexts/SettingsContext';
 import { useSource } from '../../contexts/SourceContext';
-import { getTilesetById } from '../../config/tilesets';
+import { getTilesetById, type TilesetId } from '../../config/tilesets';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import api from '../../services/api';
+import { useCsrfFetch } from '../../hooks/useCsrfFetch';
+import GeoJsonOverlay from '../GeoJsonOverlay';
+import type { GeoJsonLayer } from '../../server/services/geojsonService.js';
+import { TilesetSelector } from '../TilesetSelector';
+import MapLegend from '../MapLegend';
 
 const MESHCORE_COLOR = '#cba6f7';
 const NEIGHBOR_COLOR = '#06b6d4';
@@ -85,12 +90,60 @@ function makeIcon(name: string): L.DivIcon {
 }
 
 export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPublicKey, localNodePosition, onNavigateToDm }) => {
-  const { mapTileset, customTilesets } = useSettings();
+  const { mapTileset, customTilesets, setMapTileset } = useSettings();
   const { sourceId } = useSource();
+  const csrfFetch = useCsrfFetch();
   const tileset = getTilesetById(mapTileset, customTilesets);
   const [showPaths, setShowPaths] = useState(true);
   const [showNeighbors, setShowNeighbors] = useState(true);
   const [neighborEdges, setNeighborEdges] = useState<NeighborEdge[]>([]);
+
+  // Tile selector + legend overlays — hidden by default, toggled from the Map
+  // Features panel. Persisted under the same localStorage keys the other maps
+  // use so the preference is unified across every map surface.
+  const [showTileSelector, setShowTileSelector] = useState(
+    () => localStorage.getItem('meshmonitor-showTileSelector') === 'true',
+  );
+  const [showLegend, setShowLegend] = useState(
+    () => localStorage.getItem('meshmonitor-showLegend') === 'true',
+  );
+  useEffect(() => {
+    localStorage.setItem('meshmonitor-showTileSelector', String(showTileSelector));
+  }, [showTileSelector]);
+  useEffect(() => {
+    localStorage.setItem('meshmonitor-showLegend', String(showLegend));
+  }, [showLegend]);
+
+  // GeoJSON overlay layers (global, file-based) — fetched and toggled here so
+  // the MeshCore map matches the NodesTab and Dashboard maps. Layer visibility
+  // is global and shared with those maps' controls.
+  const [geoJsonLayers, setGeoJsonLayers] = useState<GeoJsonLayer[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const baseUrl = await api.getBaseUrl();
+        const response = await fetch(`${baseUrl}/api/geojson/layers`);
+        if (!response.ok) return;
+        const data = await response.json();
+        if (!cancelled) setGeoJsonLayers(Array.isArray(data) ? data : []);
+      } catch (err) {
+        console.error('Failed to fetch GeoJSON layers:', err);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const toggleGeoJsonLayer = (id: string, visible: boolean) => {
+    setGeoJsonLayers(prev => prev.map(l => (l.id === id ? { ...l, visible } : l)));
+    api.getBaseUrl().then(baseUrl => {
+      csrfFetch(`${baseUrl}/api/geojson/layers/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ visible }),
+      }).catch(err => console.error('Failed to update layer visibility:', err));
+    }).catch(err => console.error('Failed to get base URL:', err));
+  };
 
   const positioned = useMemo(
     () => contacts.filter(c =>
@@ -177,6 +230,8 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
           url={tileset.url}
           maxZoom={tileset.maxZoom}
         />
+        {showLegend && <MapLegend />}
+        {geoJsonLayers.length > 0 && <GeoJsonOverlay layers={geoJsonLayers} />}
         {positioned.map(c => {
           const name = c.advName || c.name || 'MeshCore';
           return (
@@ -262,6 +317,13 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
         ))}
       </MapContainer>
 
+      {showTileSelector && (
+        <TilesetSelector
+          selectedTilesetId={mapTileset as TilesetId}
+          onTilesetChange={setMapTileset}
+        />
+      )}
+
       <div className="map-controls dashboard-map-controls">
         <div className="map-controls-body">
           <div className="map-controls-title">Features</div>
@@ -281,6 +343,39 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
             />
             <span>Show Neighbors</span>
           </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showTileSelector}
+              onChange={(e) => setShowTileSelector(e.target.checked)}
+            />
+            <span>Show Tile Selection</span>
+          </label>
+          <label className="map-control-item">
+            <input
+              type="checkbox"
+              checked={showLegend}
+              onChange={(e) => setShowLegend(e.target.checked)}
+            />
+            <span>Show Legend</span>
+          </label>
+          {/* GeoJSON overlay layers — per-layer on/off, mirroring the other maps. */}
+          {geoJsonLayers.map(layer => (
+            <label key={layer.id} className="map-control-item">
+              <input
+                type="checkbox"
+                checked={layer.visible}
+                onChange={(e) => toggleGeoJsonLayer(layer.id, e.target.checked)}
+              />
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
+                <span style={{
+                  display: 'inline-block', width: '8px', height: '8px',
+                  borderRadius: '50%', backgroundColor: layer.style.color,
+                }} />
+                {layer.name}
+              </span>
+            </label>
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/NewsPopup/NewsPopup.tsx
+++ b/src/components/NewsPopup/NewsPopup.tsx
@@ -29,7 +29,6 @@ export const NewsPopup: React.FC<NewsPopupProps> = ({
   const [newsItems, setNewsItems] = useState<NewsItem[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [dontShowAgain, setDontShowAgain] = useState(false);
 
   // Track the full feed for updating lastSeenNewsId
   const [fullFeed, setFullFeed] = useState<NewsItem[]>([]);
@@ -106,14 +105,15 @@ export const NewsPopup: React.FC<NewsPopupProps> = ({
   // Reset state when popup closes
   useEffect(() => {
     if (!isOpen) {
-      setDontShowAgain(false);
       setCurrentIndex(0);
     }
   }, [isOpen]);
 
   const handleClose = useCallback(async () => {
-    // If "don't show again" is checked and we're authenticated, dismiss ALL currently shown items
-    if (dontShowAgain && isAuthenticated && newsItems.length > 0) {
+    // Closing the popup always marks the shown items as "don't show again"
+    // (unless we're in the forced "view all" mode opened via the News icon).
+    // Users can re-open the feed any time from the News icon.
+    if (isAuthenticated && !forceShowAll && newsItems.length > 0) {
       try {
         for (const item of newsItems) {
           await api.dismissNewsItem(item.id);
@@ -140,7 +140,7 @@ export const NewsPopup: React.FC<NewsPopupProps> = ({
     }
 
     onClose();
-  }, [dontShowAgain, isAuthenticated, newsItems, currentIndex, onClose, fullFeed, forceShowAll]);
+  }, [isAuthenticated, newsItems, onClose, fullFeed, forceShowAll]);
 
   const handleNext = useCallback(() => {
     if (currentIndex < newsItems.length - 1) {
@@ -155,7 +155,6 @@ export const NewsPopup: React.FC<NewsPopupProps> = ({
   const handlePrevious = useCallback(() => {
     if (currentIndex > 0) {
       setCurrentIndex(prev => prev - 1);
-      setDontShowAgain(false);
       // Scroll content to top for new item
       contentRef.current?.scrollTo({ top: 0, behavior: 'instant' });
     }
@@ -281,18 +280,9 @@ export const NewsPopup: React.FC<NewsPopupProps> = ({
         </div>
 
         <div className="modal-footer news-modal-footer">
-          <div className="news-footer-left">
-            {isAuthenticated && !forceShowAll && (
-              <label className="news-dont-show-checkbox">
-                <input
-                  type="checkbox"
-                  checked={dontShowAgain}
-                  onChange={e => setDontShowAgain(e.target.checked)}
-                />
-                {t('news.do_not_show_again', "Don't show these again")}
-              </label>
-            )}
-          </div>
+          {/* Closing the popup marks items as seen by default; the News icon
+              re-opens the feed at any time. */}
+          <div className="news-footer-left" />
 
           <div className="news-footer-right">
             {currentIndex > 0 && (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -104,12 +104,16 @@ const Sidebar: React.FC<SidebarProps> = ({
       : (LUCIDE_ICONS[name] || null);
   }, [iconStyle]);
 
-  // Start collapsed (narrow/icon-only) by default for cleaner desktop UI
-  const [isCollapsed, setIsCollapsed] = useState(true);
   // Pin state persisted to localStorage - when pinned, sidebar won't auto-collapse on nav click
   const [isPinned, setIsPinned] = useState(() => {
     const saved = localStorage.getItem('sidebar-pinned');
     return saved === 'true';
+  });
+  // Start collapsed (narrow/icon-only) by default for cleaner desktop UI, but if
+  // the sidebar was pinned expanded, honor that on load instead of rendering
+  // collapsed-with-pin-selected.
+  const [isCollapsed, setIsCollapsed] = useState(() => {
+    return localStorage.getItem('sidebar-pinned') !== 'true';
   });
 
   // Persist pin state to localStorage

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -26,6 +26,7 @@ import { useMeshCoreNeighbors } from '../hooks/useMapAnalysisData';
 import type { DashboardSource } from '../hooks/useDashboardData';
 import DashboardSidebar from '../components/Dashboard/DashboardSidebar';
 import DashboardMap from '../components/Dashboard/DashboardMap';
+import type { NodeSourceRef } from '../components/Dashboard/DashboardNodePopup';
 import { buildBridgeConfig, formFromBridgeConfig } from '../components/MQTT/mqttBridgeConfig';
 import LoginModal from '../components/LoginModal';
 import UserMenu from '../components/UserMenu';
@@ -58,6 +59,22 @@ function DashboardInner() {
    */
   const refreshSources = () => {
     queryClient.invalidateQueries({ queryKey: ['dashboard', 'sources'] });
+  };
+
+  /**
+   * Unified map: clicking a "seen by" source row in a node popup jumps to that
+   * source's Node Details view for the node. Meshtastic sources open the
+   * Node Details (Messages) tab focused on the node's DM; MeshCore sources use
+   * their own internal panes, so we just switch to that source.
+   */
+  const handleNodeSourceSelect = (source: NodeSourceRef, nodeId: string | undefined) => {
+    if (source.protocol === 'MeshCore') {
+      navigate(`/source/${source.sourceId}/`);
+      return;
+    }
+    navigate(`/source/${source.sourceId}/#messages`, {
+      state: nodeId ? { focusDmNodeId: nodeId } : undefined,
+    });
   };
 
   const isAuthenticated = authStatus?.authenticated ?? false;
@@ -977,6 +994,7 @@ function DashboardInner() {
           defaultCenter={defaultCenter}
           sourceId={selectedSourceId}
           maxNodeAgeHours={maxNodeAgeHours}
+          onNodeSourceSelect={handleNodeSourceSelect}
         />
       </div>
 

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1988,6 +1988,28 @@
   font-size: 0.82rem;
 }
 
+/* Clickable variant used on the Unified map: links to the source's Node Details. */
+.node-popup-source-row-button {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  transition: background-color 0.12s ease;
+}
+
+.node-popup-source-row-button:hover:not(:disabled) {
+  background: var(--ctp-surface1);
+}
+
+.node-popup-source-row-button:disabled {
+  cursor: default;
+}
+
 .node-popup-source-name {
   color: var(--ctp-text);
   font-weight: 500;


### PR DESCRIPTION
Closes #3557.

## Summary
Implements the six UI tweaks from #3557 plus a basic map UI-unification pass across the Meshtastic, MeshCore, and Global/Dashboard maps.

### Issue #3557 items
1. **Auto Time Sync** — reworded the description so it's clear the MeshMonitor server pushes its time *to* the node (server is the time authority).
2. **Source sidebar "Messages" → "Node Details"** — renamed the `nav.messages` label globally (also relabels the messages permission in the Users admin UI).
3. **Unified map popup → clickable source rows** — each "Seen by" source row is now a button. Meshtastic rows open that source's Node Details (`#messages`) tab focused on the node's DM (via router `location.state`, consumed by a mount effect in `App.tsx`); MeshCore rows switch to that source.
4. **Sidebar pinned-but-collapsed bug** — `isCollapsed` now initializes from the persisted pin state, so a pinned-expanded sidebar loads expanded instead of collapsed-with-pin-lit.
5. **ChangeLog popup** — removed the "Don't show again" checkbox; closing now marks shown items dismissed by default. The News icon still re-opens the feed.
6. **Tile selector copied to MeshCore + Global maps** — hidden by default, enabled via a Map Features checkbox.

### Map unification pass
- Added **tile selector** + **legend** toggles (hidden by default, in the Map Features panel) to both the Global/Dashboard and MeshCore maps.
- Added **GeoJSON layer enable/disable** toggles to the MeshCore map (Dashboard already had them).
- All three maps share the same `meshmonitor-showTileSelector` / `meshmonitor-showLegend` localStorage keys.
- Made the GeoJSON layers fetch defensive (`Array.isArray`).

## Testing
- `tsc --noEmit`: clean.
- Full Vitest suite: **7458 tests, 0 failures**.
- Added a regression test for the clickable popup source rows.

## Notes
- MeshCore's legend reuses the shared `MapLegend` (Meshtastic hop-gradient + line types) for consistency; its polylines use a separate direct/short/long palette, so a follow-up could unify MeshCore line colors to the overlay palette.
- The now-orphaned `news.do_not_show_again` locale key is left in place (harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)