### PR TITLE
fix(traceroute): scope traceroute history to the active source

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4700,6 +4700,7 @@ const location = useLocation();
           fromNodeName={getNodeName(currentNodeId)}
           toNodeName={getNodeName(selectedDMNode)}
           nodes={nodes}
+          sourceId={sourceId}
           onClose={() => setShowTracerouteHistoryModal(false)}
         />
       )}

--- a/src/components/TracerouteHistoryModal.test.tsx
+++ b/src/components/TracerouteHistoryModal.test.tsx
@@ -109,7 +109,7 @@ describe('TracerouteHistoryModal - Node Direction Display', () => {
 
     // Wait for the component to load data
     await waitFor(() => {
-      expect(ApiService.getTracerouteHistory).toHaveBeenCalledWith(100, 200, undefined);
+      expect(ApiService.getTracerouteHistory).toHaveBeenCalledWith(100, 200, undefined, undefined);
     });
 
     // The header should show the correct direction
@@ -168,7 +168,7 @@ describe('TracerouteHistoryModal - Node Direction Display', () => {
     );
 
     await waitFor(() => {
-      expect(ApiService.getTracerouteHistory).toHaveBeenCalledWith(100, 200, 'c9dde95e-radio');
+      expect(ApiService.getTracerouteHistory).toHaveBeenCalledWith(100, 200, undefined, 'c9dde95e-radio');
     });
   });
 
@@ -277,9 +277,9 @@ describe('TracerouteHistoryModal - Node Direction Display', () => {
       />
     );
 
-    expect(ApiService.getTracerouteHistory).toHaveBeenCalledWith(100, 200, undefined);
+    expect(ApiService.getTracerouteHistory).toHaveBeenCalledWith(100, 200, undefined, undefined);
     // Ensure it's NOT called with reversed parameters
-    expect(ApiService.getTracerouteHistory).not.toHaveBeenCalledWith(200, 100, undefined);
+    expect(ApiService.getTracerouteHistory).not.toHaveBeenCalledWith(200, 100, undefined, undefined);
   });
 
   /**

--- a/src/components/TracerouteHistoryModal.test.tsx
+++ b/src/components/TracerouteHistoryModal.test.tsx
@@ -109,7 +109,7 @@ describe('TracerouteHistoryModal - Node Direction Display', () => {
 
     // Wait for the component to load data
     await waitFor(() => {
-      expect(ApiService.getTracerouteHistory).toHaveBeenCalledWith(100, 200);
+      expect(ApiService.getTracerouteHistory).toHaveBeenCalledWith(100, 200, undefined);
     });
 
     // The header should show the correct direction
@@ -147,6 +147,29 @@ describe('TracerouteHistoryModal - Node Direction Display', () => {
     // The header text should NOT have Remote Node before Local Node
     const headerText = screen.getByText(/Local Node/).closest('div');
     expect(headerText?.textContent).not.toMatch(/traceroute_history\.from.*Remote Node.*→.*traceroute_history\.to.*Local Node/);
+  });
+
+  /**
+   * REGRESSION: history must be scoped to the active source so a single-source
+   * view (e.g. the radio/TCP source) does not mix in traceroutes recorded by
+   * other sources (MQTT broker/bridge sources record many flood-relayed copies).
+   */
+  it('passes the active sourceId through to the API so history is source-scoped', async () => {
+    render(
+      <TracerouteHistoryModal
+        fromNodeNum={100}
+        toNodeNum={200}
+        fromNodeName="Local Node"
+        toNodeName="Remote Node"
+        nodes={mockNodes}
+        sourceId="c9dde95e-radio"
+        onClose={mockOnClose}
+      />
+    );
+
+    await waitFor(() => {
+      expect(ApiService.getTracerouteHistory).toHaveBeenCalledWith(100, 200, 'c9dde95e-radio');
+    });
   });
 
   /**
@@ -254,9 +277,9 @@ describe('TracerouteHistoryModal - Node Direction Display', () => {
       />
     );
 
-    expect(ApiService.getTracerouteHistory).toHaveBeenCalledWith(100, 200);
+    expect(ApiService.getTracerouteHistory).toHaveBeenCalledWith(100, 200, undefined);
     // Ensure it's NOT called with reversed parameters
-    expect(ApiService.getTracerouteHistory).not.toHaveBeenCalledWith(200, 100);
+    expect(ApiService.getTracerouteHistory).not.toHaveBeenCalledWith(200, 100, undefined);
   });
 
   /**

--- a/src/components/TracerouteHistoryModal.tsx
+++ b/src/components/TracerouteHistoryModal.tsx
@@ -44,7 +44,7 @@ const TracerouteHistoryModal: React.FC<TracerouteHistoryModalProps> = ({
     const fetchHistory = async () => {
       try {
         setLoading(true);
-        const data = await ApiService.getTracerouteHistory(fromNodeNum, toNodeNum, sourceId);
+        const data = await ApiService.getTracerouteHistory(fromNodeNum, toNodeNum, undefined, sourceId);
         if (!isMounted.current) return;
         setTraceroutes(data);
         setError(null);

--- a/src/components/TracerouteHistoryModal.tsx
+++ b/src/components/TracerouteHistoryModal.tsx
@@ -14,6 +14,8 @@ interface TracerouteHistoryModalProps {
   fromNodeName: string;
   toNodeName: string;
   nodes: DeviceInfo[];
+  /** Active source to scope history to. When null/undefined, history is unscoped (legacy single-source views). */
+  sourceId?: string | null;
   onClose: () => void;
 }
 
@@ -27,6 +29,7 @@ const TracerouteHistoryModal: React.FC<TracerouteHistoryModalProps> = ({
   fromNodeName,
   toNodeName,
   nodes,
+  sourceId,
   onClose,
 }) => {
   const { t } = useTranslation();
@@ -41,7 +44,7 @@ const TracerouteHistoryModal: React.FC<TracerouteHistoryModalProps> = ({
     const fetchHistory = async () => {
       try {
         setLoading(true);
-        const data = await ApiService.getTracerouteHistory(fromNodeNum, toNodeNum);
+        const data = await ApiService.getTracerouteHistory(fromNodeNum, toNodeNum, sourceId);
         if (!isMounted.current) return;
         setTraceroutes(data);
         setError(null);
@@ -58,7 +61,7 @@ const TracerouteHistoryModal: React.FC<TracerouteHistoryModalProps> = ({
     return () => {
       isMounted.current = false;
     };
-  }, [fromNodeNum, toNodeNum]);
+  }, [fromNodeNum, toNodeNum, sourceId]);
 
   // Filter traceroutes based on the checkbox state
   const filteredTraceroutes = useMemo(() => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -735,9 +735,14 @@ class ApiService {
     return response.json();
   }
 
-  async getTracerouteHistory(fromNodeNum: number, toNodeNum: number, limit: number = 50) {
+  async getTracerouteHistory(fromNodeNum: number, toNodeNum: number, sourceId?: string | null, limit: number = 50) {
     await this.ensureBaseUrl();
-    const response = await fetch(`${this.baseUrl}/api/traceroutes/history/${fromNodeNum}/${toNodeNum}?limit=${limit}`);
+    // Scope to the active source so a single-source view (e.g. the radio/TCP
+    // source) does not mix in traceroutes recorded by other sources — MQTT
+    // broker/bridge sources record many flood-relayed copies of the same reply
+    // (see backend traceroute history handler).
+    const sourceQuery = sourceId ? `&sourceId=${encodeURIComponent(sourceId)}` : '';
+    const response = await fetch(`${this.baseUrl}/api/traceroutes/history/${fromNodeNum}/${toNodeNum}?limit=${limit}${sourceQuery}`);
     if (!response.ok) throw new Error('Failed to fetch traceroute history');
     return response.json();
   }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -735,7 +735,7 @@ class ApiService {
     return response.json();
   }
 
-  async getTracerouteHistory(fromNodeNum: number, toNodeNum: number, sourceId?: string | null, limit: number = 50) {
+  async getTracerouteHistory(fromNodeNum: number, toNodeNum: number, limit: number = 50, sourceId?: string | null) {
     await this.ensureBaseUrl();
     // Scope to the active source so a single-source view (e.g. the radio/TCP
     // source) does not mix in traceroutes recorded by other sources — MQTT


### PR DESCRIPTION
## Problem

Viewing a node's **Traceroute History** while on the Meshtastic (radio/TCP) source showed entries from *all* sources merged together — including the MQTT broker/bridge sources, which record many flood-relayed copies of the same reply. This surfaced as "~50 entries all at the same time."

### Root cause

The history endpoint (`GET /api/traceroutes/history/:from/:to`) already supports a `?sourceId=` query param and scopes via `withSourceScope`. But the frontend never sent it:

- `TracerouteHistoryModal` → `ApiService.getTracerouteHistory(from, to)` (no sourceId)
- `ApiService.getTracerouteHistory` didn't accept or forward a sourceId
- Backend → `req.query.sourceId` = `undefined` → `withSourceScope(table, undefined)` returns no filter → **all sources merged**

Investigation against live data confirmed the radio/TCP source records exactly **1 traceroute row per exchange**, while the MQTT broker source records **5–10 rows** (flood copies), and the unscoped query merged them.

## Fix

Thread the active `sourceId` (from `useSource()`) through the whole chain into the existing query param. No backend change required.

- `src/services/api.ts` — `getTracerouteHistory(from, to, sourceId?, limit)` appends `&sourceId=`
- `src/components/TracerouteHistoryModal.tsx` — new `sourceId` prop; refetch when it changes
- `src/App.tsx` — pass `sourceId` from `useSource()`

## Tests

- Added a regression test asserting the active `sourceId` is forwarded to the API
- Updated existing call-shape assertions
- **23/23 pass** across `TracerouteHistoryModal`, `tracerouteRoutes`, and `sourceRoutes.traceroutes`; changed files are tsc-clean

## Scope / follow-up

This fixes cross-source **mixing**. The separate behavior where the MQTT source itself stores multiple flood copies per traceroute is intentionally left as-is (useful for later mesh-path analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)