### PR TITLE
fix(meshcore): accurate error when USB-serial time sync fails (#3570)

### DIFF
--- a/src/server/meshcoreManager.syncDeviceTime.test.ts
+++ b/src/server/meshcoreManager.syncDeviceTime.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for MeshCoreManager.syncDeviceTime().
+ *
+ * Sync wraps the firmware's CMD_SET_DEVICE_TIME. The underlying meshcore.js
+ * call rejects with NO argument on a firmware Err, which surfaces as the
+ * literal string "undefined" — so before issue #3570 the route reported every
+ * failure as "disconnected or not a Companion device" even when the guards had
+ * passed and the device had actually rejected the command. The method now
+ * returns a discriminated result so the caller can tell the guard cases apart
+ * from a real command failure and surface an actionable reason.
+ *
+ * Uses the private-method-stubbing pattern from meshcoreManager.shareContact.test.ts.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+interface BridgeCall {
+  cmd: string;
+  params: Record<string, unknown>;
+  timeout?: number;
+}
+
+function makeManager(opts: {
+  deviceType?: MeshCoreDeviceType;
+  connected?: boolean;
+  response?: { success: boolean; data?: unknown; error?: string };
+}): { manager: MeshCoreManager; bridgeCalls: BridgeCall[] } {
+  const m = new MeshCoreManager('test-source');
+  (m as any).deviceType = opts.deviceType ?? MeshCoreDeviceType.COMPANION;
+  (m as any).connected = opts.connected ?? true;
+
+  const bridgeCalls: BridgeCall[] = [];
+  (m as any).sendBridgeCommand = async (
+    cmd: string,
+    params: Record<string, unknown>,
+    timeout?: number,
+  ) => {
+    bridgeCalls.push({ cmd, params, timeout });
+    return { id: '1', ...(opts.response ?? { success: true, data: { ok: true } }) };
+  };
+
+  return { manager: m, bridgeCalls };
+}
+
+describe('MeshCoreManager — syncDeviceTime', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns ok:true and issues set_device_time on success', async () => {
+    const { manager, bridgeCalls } = makeManager({});
+    const result = await manager.syncDeviceTime();
+
+    expect(result).toEqual({ ok: true });
+    expect(bridgeCalls).toHaveLength(1);
+    expect(bridgeCalls[0].cmd).toBe('set_device_time');
+  });
+
+  it('reports reason:not-companion without issuing a command', async () => {
+    const { manager, bridgeCalls } = makeManager({ deviceType: MeshCoreDeviceType.REPEATER });
+    const result = await manager.syncDeviceTime();
+
+    expect(result).toEqual({ ok: false, reason: 'not-companion' });
+    expect(bridgeCalls).toHaveLength(0);
+  });
+
+  it('reports reason:disconnected without issuing a command', async () => {
+    const { manager, bridgeCalls } = makeManager({ connected: false });
+    const result = await manager.syncDeviceTime();
+
+    expect(result).toEqual({ ok: false, reason: 'disconnected' });
+    expect(bridgeCalls).toHaveLength(0);
+  });
+
+  it('reports reason:command-failed and replaces a useless "undefined" error with a hint (issue #3570)', async () => {
+    // meshcore.js reject() with no argument → String(undefined) === "undefined".
+    const { manager } = makeManager({ response: { success: false, error: 'undefined' } });
+    const result = await manager.syncDeviceTime();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('command-failed');
+    expect(result.error).toMatch(/firmware may not support/i);
+    expect(result.error).not.toMatch(/undefined/);
+  });
+
+  it('maps a backend timeout to a no-response hint', async () => {
+    const { manager } = makeManager({
+      response: { success: false, error: 'Native command timeout: set_device_time' },
+    });
+    const result = await manager.syncDeviceTime();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('command-failed');
+    expect(result.error).toMatch(/did not respond/i);
+  });
+
+  it('forwards a descriptive backend error verbatim', async () => {
+    const descriptive =
+      'device returned Err to set_device_time (firmware may not support setting the RTC over this transport)';
+    const { manager } = makeManager({ response: { success: false, error: descriptive } });
+    const result = await manager.syncDeviceTime();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('command-failed');
+    expect(result.error).toBe(descriptive);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -162,6 +162,15 @@ export interface ShareContactResult {
   error?: string;
 }
 
+/**
+ * Result of {@link MeshCoreManager.syncDeviceTime}. `reason` distinguishes the
+ * pre-flight guard failures (which the route reports as a 409) from an actual
+ * device/command failure (`command-failed`, reported as a 502 with `error`).
+ */
+export type SyncDeviceTimeResult =
+  | { ok: true }
+  | { ok: false; reason: 'not-companion' | 'disconnected' | 'command-failed'; error?: string };
+
 // Connection types
 export enum ConnectionType {
   SERIAL = 'serial',
@@ -2394,24 +2403,40 @@ class MeshCoreManager extends EventEmitter {
 
   /**
    * Sync the device's RTC to the server's clock. Companion only.
+   *
+   * Returns a discriminated result so the caller can tell the guard cases
+   * (wrong device type / disconnected) apart from an actual command failure,
+   * and surface the real reason. Previously this returned a bare boolean and
+   * the route reported every failure as "disconnected or not a Companion
+   * device" even when the device had rejected the command (issue #3570).
    */
-  async syncDeviceTime(): Promise<boolean> {
+  async syncDeviceTime(): Promise<SyncDeviceTimeResult> {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
       logger.warn('[MeshCore] Sync-device-time requires Companion firmware');
-      return false;
+      return { ok: false, reason: 'not-companion' };
     }
-    if (!this.connected) return false;
+    if (!this.connected) return { ok: false, reason: 'disconnected' };
     try {
       const response = await this.sendBridgeCommand('set_device_time', {});
       if (!response.success) {
-        logger.warn(`[MeshCore] set_device_time failed: ${response.error}`);
-        return false;
+        // meshcore.js rejects with NO argument on a firmware Err, which can
+        // surface as the literal string "undefined" (issue #3570). Manufacture
+        // an actionable reason rather than logging/returning "undefined".
+        const raw = response.error ?? '';
+        const friendly = /timeout/i.test(raw)
+          ? 'Device did not respond to the time-sync command — the firmware may not support setting the RTC over this transport.'
+          : raw && raw !== 'undefined'
+            ? raw
+            : 'Device rejected the time-sync command — the firmware may not support setting the RTC over this transport.';
+        logger.warn(`[MeshCore:${this.sourceId}] set_device_time failed: ${friendly}`);
+        return { ok: false, reason: 'command-failed', error: friendly };
       }
       logger.info(`[MeshCore:${this.sourceId}] Device time synced to server clock`);
-      return true;
+      return { ok: true };
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       logger.error('[MeshCore] syncDeviceTime threw:', error);
-      return false;
+      return { ok: false, reason: 'command-failed', error: message };
     }
   }
 

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -57,6 +57,8 @@ class MockConnection extends EventEmitter {
   public statsRequests: number[] = [];
   public binaryRequests: Array<{ key: Uint8Array; req: number[] }> = [];
   public syncNextMessageQueue: any[] = [];
+  public setDeviceTimeCalls: number[] = [];
+  public setDeviceTimeErr = false;
   public deviceTimeResponse: { epochSecs: number } | null = { epochSecs: 1700000000 };
   public statsResponse: any = {
     type: StatsTypes.Core,
@@ -127,6 +129,16 @@ class MockConnection extends EventEmitter {
 
   async setRadioParams(freq: number, bw: number, sf: number, cr: number) {
     this.setRadioParamsCalls.push([freq, bw, sf, cr]);
+  }
+
+  // The backend drives set_device_time via this low-level send and then waits
+  // for an Ok/Err response event (issue #3570). Emit on the next tick so the
+  // backend's once() listeners are attached first.
+  async sendCommandSetDeviceTime(epochSecs: number) {
+    this.setDeviceTimeCalls.push(epochSecs);
+    setTimeout(() => {
+      this.emit(this.setDeviceTimeErr ? ResponseCodes.Err : ResponseCodes.Ok, {});
+    }, 1);
   }
 
   async setAdvertLocPolicy(policy: number) {
@@ -342,6 +354,36 @@ describe('MeshCoreNativeBackend', () => {
     // Not the useless "undefined" — a real, actionable message.
     expect(resp.error).toMatch(/firmware may not support CMD_SHARE_CONTACT/i);
     expect(resp.error).not.toBe('undefined');
+  });
+
+  it('set_device_time resolves on Ok and forwards the epoch', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+
+    const resp = await backend.sendCommand('set_device_time', { epoch: 1700000000 });
+    expect(resp.success).toBe(true);
+    expect(conn.setDeviceTimeCalls).toEqual([1700000000]);
+  });
+
+  it('set_device_time turns a firmware Err into an actionable error, not "undefined" (issue #3570)', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    conn.setDeviceTimeErr = true;
+
+    const resp = await backend.sendCommand('set_device_time', {});
+    expect(resp.success).toBe(false);
+    expect(resp.error).toMatch(/Err to set_device_time/i);
+    expect(resp.error).not.toBe('undefined');
+    // Falls back to "now" when no epoch is supplied (still issues the command).
+    expect(conn.setDeviceTimeCalls).toHaveLength(1);
   });
 
   it('maps get_contacts to bridge-shaped contact rows', async () => {

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -1217,12 +1217,28 @@ export class MeshCoreNativeBackend extends EventEmitter {
       }
 
       case 'set_device_time': {
-        const epoch = params.epoch as number | undefined;
-        if (epoch !== undefined) {
-          await c.setDeviceTime(epoch);
-        } else {
-          await c.syncDeviceTime();
-        }
+        // meshcore.js's setDeviceTime()/syncDeviceTime() reject with NO argument
+        // on an `Err` response, which surfaces upstream as the literal string
+        // "undefined" (issue #3570). Drive the command ourselves with the same
+        // descriptive Ok/Err idiom used by discover_nodes so a device rejection
+        // produces an actionable error instead of `undefined`.
+        const epoch = (params.epoch as number | undefined) ?? Math.floor(Date.now() / 1000);
+        logger.debug(`[MeshCoreNative:${this.sourceId}] set_device_time → epoch=${epoch}`);
+        await new Promise<void>((resolve, reject) => {
+          const onOk = () => {
+            c.off(this.constants!.ResponseCodes.Ok, onOk);
+            c.off(this.constants!.ResponseCodes.Err, onErr);
+            resolve();
+          };
+          const onErr = () => {
+            c.off(this.constants!.ResponseCodes.Ok, onOk);
+            c.off(this.constants!.ResponseCodes.Err, onErr);
+            reject(new Error('device returned Err to set_device_time (firmware may not support setting the RTC over this transport)'));
+          };
+          c.once(this.constants!.ResponseCodes.Ok, onOk);
+          c.once(this.constants!.ResponseCodes.Err, onErr);
+          c.sendCommandSetDeviceTime(epoch).catch(reject);
+        });
         return { ok: true };
       }
 

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -1224,6 +1224,11 @@ export class MeshCoreNativeBackend extends EventEmitter {
         // produces an actionable error instead of `undefined`.
         const epoch = (params.epoch as number | undefined) ?? Math.floor(Date.now() / 1000);
         logger.debug(`[MeshCoreNative:${this.sourceId}] set_device_time → epoch=${epoch}`);
+        // Resolution depends on the radio emitting Ok or Err. A synchronous
+        // send failure propagates via `.catch(reject)`; if the firmware never
+        // answers at all, the outer `withTimeout` wrapper in sendCommand() is
+        // the only safety net (surfacing a generic timeout). Same structure as
+        // discover_nodes / discover_path.
         await new Promise<void>((resolve, reject) => {
           const onOk = () => {
             c.off(this.constants!.ResponseCodes.Ok, onOk);

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -63,6 +63,7 @@ const meshcoreManager = {
   sendLocalCliCommand: vi.fn().mockResolvedValue({ reply: 'v1.7.0', elapsedMs: 12 }),
   setName: vi.fn().mockResolvedValue(true),
   setRadio: vi.fn().mockResolvedValue(true),
+  syncDeviceTime: vi.fn().mockResolvedValue({ ok: true }),
   importPrivateKey: vi.fn().mockResolvedValue(true),
   exportPrivateKey: vi.fn().mockResolvedValue('a'.repeat(128)),
   isConnected: vi.fn().mockReturnValue(false),
@@ -972,6 +973,45 @@ describe('MeshCore Routes', () => {
         .send({ freq: 915.0, bw: 125, sf: 7, cr: 5 });
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
+    });
+  });
+
+  describe('POST /api/sources/test-source/meshcore/config/sync-time', () => {
+    it('should require authentication', async () => {
+      const response = await request(app)
+        .post('/api/sources/test-source/meshcore/config/sync-time');
+      expect(response.status).toBe(401);
+    });
+
+    it('returns 200 when the device time sync succeeds', async () => {
+      meshcoreManager.syncDeviceTime.mockResolvedValueOnce({ ok: true });
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/config/sync-time');
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+    });
+
+    it('returns 409 for the guard cases (not a Companion / disconnected)', async () => {
+      meshcoreManager.syncDeviceTime.mockResolvedValueOnce({ ok: false, reason: 'not-companion' });
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/config/sync-time');
+      expect(response.status).toBe(409);
+      expect(response.body.error).toMatch(/Companion device/i);
+    });
+
+    it('returns 502 with the real reason when the device rejects the command (issue #3570)', async () => {
+      meshcoreManager.syncDeviceTime.mockResolvedValueOnce({
+        ok: false,
+        reason: 'command-failed',
+        error: 'device returned Err to set_device_time (firmware may not support setting the RTC over this transport)',
+      });
+      const response = await authenticatedAgent
+        .post('/api/sources/test-source/meshcore/config/sync-time');
+      expect(response.status).toBe(502);
+      // The misleading "disconnected or not a Companion device" must NOT appear.
+      expect(response.body.error).not.toMatch(/disconnected or not a Companion/i);
+      expect(response.body.error).toMatch(/Device rejected the time-sync command/i);
+      expect(response.body.error).toMatch(/firmware may not support/i);
     });
   });
 

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -919,8 +919,19 @@ router.post(
   requirePermission('configuration', 'write', { sourceIdFrom: 'params.id' }),
   async (req: Request, res: Response) => {
     try {
-      const ok = await managerFor(req).syncDeviceTime();
-      if (!ok) {
+      const result = await managerFor(req).syncDeviceTime();
+      if (!result.ok) {
+        if (result.reason === 'command-failed') {
+          // The guards passed but the device rejected (or never acked) the
+          // command — surface the real reason instead of the misleading
+          // "disconnected or not a Companion device" (issue #3570).
+          return res.status(502).json({
+            success: false,
+            error: result.error
+              ? `Device rejected the time-sync command: ${result.error}`
+              : 'Device rejected the time-sync command',
+          });
+        }
         return res.status(409).json({
           success: false,
           error: 'Sync time failed — source disconnected or not a Companion device',


### PR DESCRIPTION
## Summary

Fixes #3570. On a MeshCore Companion source connected via **USB serial**, clicking **Sync** next to "RTC drift vs server" failed with the misleading error **"Sync time failed — source disconnected or not a Companion device"** and logged `set_device_time failed: undefined`, even though the connection and device-type guards had passed.

## Root cause

The `set_device_time` bridge command delegated to meshcore.js's `syncDeviceTime()` / `setDeviceTime()`, whose `Err` response handler calls `reject()` **with no argument**. That bare rejection was stringified to the literal `"undefined"`, and the route returned the same generic `409` for *any* falsy result — so a real device rejection was reported as "disconnected or not a Companion device".

## Fix

- **`meshcoreNativeBackend.ts`** — drive `set_device_time` directly with descriptive `Ok`/`Err` listeners (the same idiom already used by `discover_nodes`) instead of the library's bare-reject path, so a device `Err` produces an actionable message rather than `undefined`. Adds a debug log of the epoch being set (addresses "no debug output").
- **`meshcoreManager.syncDeviceTime()`** — now returns a discriminated result (`{ ok: true } | { ok: false; reason; error? }`) and normalizes a useless `"undefined"`/timeout backend error into a firmware-support hint (mirrors the existing `shareContact` treatment of the same meshcore.js quirk).
- **`meshcoreRoutes.ts` `/config/sync-time`** — reports the real reason: **502** with the device's error for a command failure, **409** only for the guard cases (not a Companion / disconnected).

The frontend already surfaces the server's `error` field in a toast, so the accurate message now reaches the user.

## Behavior after fix

- Time sync succeeds → `200`.
- Wrong device type / disconnected → `409` (accurate).
- Device rejects / never acks the command → `502` with e.g. *"Device rejected the time-sync command: device returned Err to set_device_time (firmware may not support setting the RTC over this transport)"* — instead of the misleading message and `undefined` log.

## Tests

- New `meshcoreManager.syncDeviceTime` suite (success / guard reasons / `undefined` + timeout normalization / verbatim passthrough).
- Route tests for `/config/sync-time`: 200, 409 guard, and 502 with the real reason (asserting the old misleading text is gone).
- Native-backend tests: `set_device_time` resolves on `Ok` (and forwards the epoch); a firmware `Err` yields an actionable error, not `"undefined"`.

Full Vitest suite green (470 files, 6933 tests, 0 failures); `tsc --noEmit` clean.

> Note: hardware verification of an actual successful sync over USB serial requires a physical MeshCore Companion; this change is verified by unit tests and fully satisfies the issue's stated expected behavior (succeed, or fail with an accurate message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)