### PR TITLE
fix: exclude traceroute packets from v1 messages API endpoint

### DIFF
--- a/src/server/routes/v1/messages.ts
+++ b/src/server/routes/v1/messages.ts
@@ -13,7 +13,7 @@ import { hasPermission } from '../../auth/authMiddleware.js';
 import { ResourceType } from '../../../types/permission.js';
 import { messageLimiter } from '../../middleware/rateLimiters.js';
 import { logger } from '../../../utils/logger.js';
-import { MAX_MESSAGE_BYTES } from '../../constants/meshtastic.js';
+import { MAX_MESSAGE_BYTES, PortNum } from '../../constants/meshtastic.js';
 
 /** Maximum number of message parts allowed when splitting long messages */
 const MAX_MESSAGE_PARTS = 3;
@@ -125,7 +125,7 @@ router.get('/', async (req: Request, res: Response) => {
       messages = await databaseService.messages.getMessagesAfterTimestamp(sinceTimestamp, sourceIdStr);
       messages = messages.slice(0, maxLimit);
     } else {
-      messages = await databaseService.messages.getMessages(maxLimit, 0, sourceIdStr);
+      messages = await databaseService.messages.getMessages(maxLimit, 0, sourceIdStr, [PortNum.TRACEROUTE_APP]);
     }
 
     // Filter messages by accessible channels (unless admin)


### PR DESCRIPTION
## Summary

The `/api/v1/sources/{sourceId}/messages` endpoint was returning traceroute packets (portnum 70) alongside regular messages. The internal UI endpoint (`sourceRoutes.ts:1067`) already excludes these via `[PortNum.TRACEROUTE_APP]`, but the v1 API handler was missing this filter.

**Changes:**
- `src/server/routes/v1/messages.ts` — added `PortNum` to the `meshtastic.js` import and passed `[PortNum.TRACEROUTE_APP]` as the `excludePortnums` arg to `getMessages()`, matching the existing `sourceRoutes.ts` pattern

**Workaround (can be dropped after this ships):** client-side `portnum === 70` filter

Authored by NodeZero 0️⃣
