### PR TITLE
feat(meshcore-map): node-type icons, filter & legend on the source map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Features
+
+- **MeshCore node-type icons & filter on the source map (#3546, #3576)**: The per-source MeshCore map now renders role-based marker glyphs by advert type — Repeater (tower), Room Server (server rack), Sensor (broadcast), Companion (person) — instead of the generic "MC" badge (kept as the fallback for standard/unknown nodes). The Map Features panel gains a **Node Types** filter (per-category checkboxes, persisted) to show/hide markers by role, and the legend gains a matching **Node Types** section when shown. This brings the MeshCore source map to parity with the Map Analysis workspace. The shared map legend opts into the new section via a `showNodeTypes` prop, so the Meshtastic maps are unchanged.
+
 ## [4.11.0] - 2026-06-19
 
 ### Features

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -3,7 +3,13 @@ import { useTranslation } from 'react-i18next';
 import { useSettings, TimeFormat, DateFormat } from '../contexts/SettingsContext';
 import { formatDateTime } from '../utils/datetime';
 import { DraggableOverlay } from './DraggableOverlay';
+import { NODE_TYPE_CATEGORIES, NODE_TYPE_CATEGORY_META } from '../utils/nodeTypeCategory';
+import { roleGlyphMarkerSvg } from '../utils/mapIcons';
 import './MapLegend.css';
+
+// Color for the node-type glyph swatches. Matches the MeshCore map's marker
+// accent (the only surface that currently opts into the node-type legend).
+const NODE_TYPE_LEGEND_COLOR = '#cba6f7';
 
 interface LinkLegendItem {
   color: string;
@@ -24,6 +30,9 @@ interface MapLegendProps {
   positionHistory?: PositionHistoryData;
   /** Count of known nodes with neither a real nor an estimated position (issue #3271). */
   unmappedCount?: number;
+  /** Render the MeshCore node-type glyph legend (issue #3546). Opt-in so the
+   *  Meshtastic maps that share this component are unaffected. */
+  showNodeTypes?: boolean;
 }
 
 // Default position: top-right, below the Features checkbox panel, right-aligned with it
@@ -34,7 +43,7 @@ const getDefaultPosition = () => ({
   y: 60 + 10 + 250 + 20 // header + features top + features height + gap = 340
 });
 
-const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount }) => {
+const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount, showNodeTypes }) => {
   const { t } = useTranslation();
   const { overlayColors } = useSettings();
   const [isCollapsed, setIsCollapsed] = useState(() => {
@@ -125,6 +134,28 @@ const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount })
                 <span className="legend-label">{item.label}</span>
               </div>
             ))}
+            {showNodeTypes && (
+              <>
+                <div className="legend-divider" />
+                <span className="legend-title">{t('map.nodeType.legendTitle', 'Node Types')}</span>
+                {/* Standard nodes keep the default marker, so only the four
+                    glyph categories are listed (matches the analysis legend). */}
+                {NODE_TYPE_CATEGORIES.filter((c) => c !== 'standard').map((category) => {
+                  const meta = NODE_TYPE_CATEGORY_META[category];
+                  return (
+                    <div key={category} className="legend-item">
+                      <span
+                        className="legend-line-sample"
+                        style={{ display: 'inline-flex', width: 20, height: 20 }}
+                        aria-hidden="true"
+                        dangerouslySetInnerHTML={{ __html: roleGlyphMarkerSvg(category, NODE_TYPE_LEGEND_COLOR, 20) }}
+                      />
+                      <span className="legend-label">{t(meta.labelKey, meta.label)}</span>
+                    </div>
+                  );
+                })}
+              </>
+            )}
             {positionHistory && (
               <>
                 <div className="legend-divider" />

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -1,8 +1,17 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { MapContainer, TileLayer, Marker, Popup, Tooltip, Polyline } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { useSettings } from '../../contexts/SettingsContext';
+import {
+  getNodeTypeCategory,
+  nodePassesTypeFilter,
+  NODE_TYPE_CATEGORIES,
+  NODE_TYPE_CATEGORY_META,
+  type NodeTypeCategory,
+} from '../../utils/nodeTypeCategory';
+import { roleGlyphMarkerSvg } from '../../utils/mapIcons';
 import { useSource } from '../../contexts/SourceContext';
 import { getTilesetById, type TilesetId } from '../../config/tilesets';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
@@ -53,10 +62,17 @@ interface MeshCoreMapProps {
   onNavigateToDm?: (publicKey: string) => void;
 }
 
-function makeIcon(name: string): L.DivIcon {
-  return L.divIcon({
-    className: 'meshcore-marker',
-    html: `
+/**
+ * Marker body: a node-type role glyph (repeater/room/sensor/companion) on a
+ * white circle when the contact's advert type is known (issue #3546), else the
+ * original purple "MC" badge for standard/unknown nodes. The name label is
+ * unchanged so existing behavior is preserved.
+ */
+function makeIcon(name: string, category: NodeTypeCategory): L.DivIcon {
+  const glyph = roleGlyphMarkerSvg(category, MESHCORE_COLOR, 24);
+  const body = glyph
+    ? `<div style="width:24px;height:24px;filter:drop-shadow(0 2px 4px rgba(0,0,0,0.3));">${glyph}</div>`
+    : `
       <div style="
         width: 24px;
         height: 24px;
@@ -70,7 +86,11 @@ function makeIcon(name: string): L.DivIcon {
         color: #1e1e2e;
         font-size: 10px;
         font-weight: bold;
-      ">MC</div>
+      ">MC</div>`;
+  return L.divIcon({
+    className: 'meshcore-marker',
+    html: `
+      ${body}
       <div style="
         position: absolute;
         top: -20px;
@@ -90,6 +110,7 @@ function makeIcon(name: string): L.DivIcon {
 }
 
 export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPublicKey, localNodePosition, onNavigateToDm }) => {
+  const { t } = useTranslation();
   const { mapTileset, customTilesets, setMapTileset } = useSettings();
   const { sourceId } = useSource();
   const csrfFetch = useCsrfFetch();
@@ -97,6 +118,23 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
   const [showPaths, setShowPaths] = useState(true);
   const [showNeighbors, setShowNeighbors] = useState(true);
   const [neighborEdges, setNeighborEdges] = useState<NeighborEdge[]>([]);
+
+  // Per-node-type visibility filter (issue #3546), persisted like the other map
+  // toggles. Missing/true => visible; a category is hidden only when explicitly
+  // set false. Mirrors the Map Analysis workspace so behavior matches there.
+  const [nodeTypeFilter, setNodeTypeFilter] = useState<Partial<Record<NodeTypeCategory, boolean>>>(() => {
+    try {
+      const raw = localStorage.getItem('meshmonitor-meshcore-nodeTypeFilter');
+      return raw ? (JSON.parse(raw) as Partial<Record<NodeTypeCategory, boolean>>) : {};
+    } catch {
+      return {};
+    }
+  });
+  useEffect(() => {
+    localStorage.setItem('meshmonitor-meshcore-nodeTypeFilter', JSON.stringify(nodeTypeFilter));
+  }, [nodeTypeFilter]);
+  const setNodeTypeEnabled = (category: NodeTypeCategory, enabled: boolean) =>
+    setNodeTypeFilter((prev) => ({ ...prev, [category]: enabled }));
 
   // Tile selector + legend overlays — hidden by default, toggled from the Map
   // Features panel. Persisted under the same localStorage keys the other maps
@@ -150,6 +188,14 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
       typeof c.latitude === 'number' && isFinite(c.latitude)
       && typeof c.longitude === 'number' && isFinite(c.longitude)),
     [contacts],
+  );
+
+  // Markers visible after the node-type filter. Paths/neighbor lines keep using
+  // `positioned` so the filter only hides markers — matching the Map Analysis
+  // workspace, where the type filter never removes route/neighbor overlays.
+  const visibleContacts = useMemo(
+    () => positioned.filter(c => nodePassesTypeFilter({ advType: c.advType }, nodeTypeFilter)),
+    [positioned, nodeTypeFilter],
   );
 
   const localPos = useMemo((): [number, number] | null => {
@@ -230,15 +276,15 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
           url={tileset.url}
           maxZoom={tileset.maxZoom}
         />
-        {showLegend && <MapLegend />}
+        {showLegend && <MapLegend showNodeTypes />}
         {geoJsonLayers.length > 0 && <GeoJsonOverlay layers={geoJsonLayers} />}
-        {positioned.map(c => {
+        {visibleContacts.map(c => {
           const name = c.advName || c.name || 'MeshCore';
           return (
             <Marker
               key={c.publicKey}
               position={[c.latitude!, c.longitude!]}
-              icon={makeIcon(name)}
+              icon={makeIcon(name, getNodeTypeCategory({ advType: c.advType }))}
             >
               <Tooltip>
                 <strong>{name}</strong>
@@ -359,6 +405,24 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
             />
             <span>Show Legend</span>
           </label>
+          {/* Per-node-type visibility (issue #3546) — hide infrastructure or
+              end-user nodes to focus the map. Same categories as the legend. */}
+          <div className="map-controls-title" style={{ marginTop: '0.5rem' }}>
+            {t('map.nodeType.legendTitle', 'Node Types')}
+          </div>
+          {NODE_TYPE_CATEGORIES.map((category) => {
+            const meta = NODE_TYPE_CATEGORY_META[category];
+            return (
+              <label key={category} className="map-control-item">
+                <input
+                  type="checkbox"
+                  checked={nodeTypeFilter[category] !== false}
+                  onChange={(e) => setNodeTypeEnabled(category, e.target.checked)}
+                />
+                <span>{t(meta.labelKey, meta.label)}</span>
+              </label>
+            );
+          })}
           {/* GeoJSON overlay layers — per-layer on/off, mirroring the other maps. */}
           {geoJsonLayers.map(layer => (
             <label key={layer.id} className="map-control-item">

--- a/src/utils/mapIcons.test.ts
+++ b/src/utils/mapIcons.test.ts
@@ -8,7 +8,7 @@ vi.mock('leaflet', () => ({
   },
 }));
 
-import { getHopColor } from './mapIcons';
+import { getHopColor, roleGlyphMarkerSvg } from './mapIcons';
 
 describe('getHopColor', () => {
   describe('special hop counts', () => {
@@ -166,5 +166,29 @@ describe('getHopColor', () => {
         expect(getHopColor(hops)).toBe(expectedColor);
       });
     });
+  });
+});
+
+describe('roleGlyphMarkerSvg', () => {
+  const COLOR = '#cba6f7';
+
+  it('returns an <svg> with a backing circle and the glyph for known categories', () => {
+    for (const category of ['repeater', 'roomServer', 'sensor', 'companion'] as const) {
+      const svg = roleGlyphMarkerSvg(category, COLOR, 24);
+      expect(svg).toContain('<svg');
+      expect(svg).toContain('viewBox="0 0 48 48"');
+      expect(svg).toContain('<circle'); // white backing circle
+      expect(svg).toContain(COLOR);     // glyph/stroke uses the passed color
+    }
+  });
+
+  it('honors the requested size', () => {
+    const svg = roleGlyphMarkerSvg('repeater', COLOR, 30);
+    expect(svg).toContain('width="30"');
+    expect(svg).toContain('height="30"');
+  });
+
+  it('returns empty string for standard (so callers keep their default marker)', () => {
+    expect(roleGlyphMarkerSvg('standard', COLOR, 24)).toBe('');
   });
 });

--- a/src/utils/mapIcons.ts
+++ b/src/utils/mapIcons.ts
@@ -50,6 +50,26 @@ export function roleGlyphInnerSvg(category: NodeTypeCategory, color: string): st
 }
 
 /**
+ * Standalone role-glyph marker: the node-type glyph ({@link roleGlyphInnerSvg})
+ * drawn over a white background circle, as a complete `<svg>` string sized to
+ * `size`px. Used by maps that render their own markers (e.g. the MeshCore
+ * source map) and by the legend swatches, so the glyph stays identical to the
+ * one `createNodeIcon`'s official style produces. Returns '' for 'standard'
+ * (and unknown categories) so callers fall back to their default marker.
+ */
+export function roleGlyphMarkerSvg(
+  category: NodeTypeCategory,
+  color: string,
+  size = 24,
+): string {
+  const inner = roleGlyphInnerSvg(category, color);
+  if (!inner) return '';
+  return `<svg width="${size}" height="${size}" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">`
+    + `<circle cx="24" cy="24" r="20" fill="white" fill-opacity="0.95" stroke="${color}" stroke-width="2" />`
+    + `${inner}</svg>`;
+}
+
+/**
  * Get color based on hop count
  * Uses a blue-to-red gradient (through purple/magenta)
  * 0 hops: Green (#22c55e) - Direct connection (local node)


### PR DESCRIPTION
## Summary
Extends the node-type work from #3546 (which shipped only on the `/analysis` Map Analysis workspace) to the **standard per-source MeshCore map**. That map previously drew a generic purple "MC" badge for every node, so operators couldn't distinguish infrastructure (repeaters/room servers) from end-user nodes at a glance, nor focus the map by type. This brings it to parity with the analysis view.

## Changes
- **`src/utils/mapIcons.ts`** — new `roleGlyphMarkerSvg(category, color, size)` helper: the role glyph (`roleGlyphInnerSvg`) on a white backing circle, as a complete `<svg>` string. Reused by both the map marker and the legend swatches so the icon a user sees and the legend entry can't diverge. Returns `''` for `standard` so callers keep their default marker.
- **`src/components/MeshCore/MeshCoreMap.tsx`**:
  - Markers classify each contact via `getNodeTypeCategory({ advType })` and render the role glyph (Repeater = tower, Room Server = server rack, Sensor = broadcast, Companion = person). The "MC" badge stays as the fallback for standard/unknown nodes.
  - New **Node Types** filter in the Map Features panel (per-category checkboxes), persisted to `localStorage`. Hides markers by category; paths/neighbor lines are left untouched, matching how the analysis view's type filter only affects markers.
  - Opts the legend into the new section (`<MapLegend showNodeTypes />`).
- **`src/components/MapLegend.tsx`** — opt-in `showNodeTypes` prop renders a **Node Types** legend section (Repeater/Room Server/Sensor/Companion glyph swatches). **Off by default**, so the Meshtastic maps that share this component are unaffected.
- **`src/utils/mapIcons.test.ts`** — unit tests for `roleGlyphMarkerSvg`.
- **CHANGELOG.md** — Features entry.

Reuses the existing, already-tested `getNodeTypeCategory` / `nodePassesTypeFilter` from #3546 — no new categorization logic.

## Issues Resolved
Relates to #3546 (extends it to the MeshCore source map).

## Documentation Updates
CHANGELOG.md updated. No feature/API docs affected.

## Testing
- [x] Full Vitest suite: **6924 passed, 0 failed** (2339 suites)
- [x] New `mapIcons.test.ts` cases for `roleGlyphMarkerSvg` (glyph + circle + size; `''` for standard)
- [x] TypeScript: touched files compile cleanly
- [x] **Verified live** in the dev container on a MeshCore source (MC-Sandbox, 97 nodes): 70/70 markers rendered the glyph SVG; the Features panel showed all five Node Types checkboxes; unchecking **Companion** dropped markers **70 → 51** and persisted `{"companion":false}` to localStorage; the legend showed the Node Types section.
- [ ] Reviewer: confirm the marker glyph reads well against your tile style (white backing circle is intended to keep it legible on light & dark tiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)