### PR TITLE
fix(telemetry): scope mesh-request channel to the sending source (#3573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Features
+
+- **MeshCore node-type icons & filter on the source map (#3546, #3576)**: The per-source MeshCore map now renders role-based marker glyphs by advert type — Repeater (tower), Room Server (server rack), Sensor (broadcast), Companion (person) — instead of the generic "MC" badge (kept as the fallback for standard/unknown nodes). The Map Features panel gains a **Node Types** filter (per-category checkboxes, persisted) to show/hide markers by role, and the legend gains a matching **Node Types** section when shown. This brings the MeshCore source map to parity with the Map Analysis workspace. The shared map legend opts into the new section via a `showNodeTypes` prop, so the Meshtastic maps are unchanged.
+
 ## [4.11.0] - 2026-06-19
 
 ### Features

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3011,14 +3011,22 @@ const location = useLocation();
       const nodeNumStr = nodeId.replace('!', '');
       const nodeNum = parseInt(nodeNumStr, 16);
 
-      // Use direct fetch with CSRF token
-      await authFetch(`${baseUrl}/api/telemetry/request`, {
+      // Use direct fetch with CSRF token. Pass sourceId so the request is routed
+      // through the correct source's manager AND the destination channel is looked
+      // up on that source (issue #3573) — omitting it let the backend cross-source
+      // match a wrong channel and send the request unanswerably.
+      const response = await authFetch(`${baseUrl}/api/telemetry/request`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ destination: nodeNum, telemetryType }),
+        body: JSON.stringify({ destination: nodeNum, telemetryType, sourceId: sourceId || undefined }),
       });
+
+      if (!response.ok) {
+        const detail = await response.json().catch(() => ({}));
+        throw new Error(detail.error || `Telemetry request failed (${response.status})`);
+      }
 
       logger.debug(`📊 Telemetry request (${telemetryType}) sent to ${nodeId}`);
 

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -3,7 +3,13 @@ import { useTranslation } from 'react-i18next';
 import { useSettings, TimeFormat, DateFormat } from '../contexts/SettingsContext';
 import { formatDateTime } from '../utils/datetime';
 import { DraggableOverlay } from './DraggableOverlay';
+import { NODE_TYPE_CATEGORIES, NODE_TYPE_CATEGORY_META } from '../utils/nodeTypeCategory';
+import { roleGlyphMarkerSvg } from '../utils/mapIcons';
 import './MapLegend.css';
+
+// Color for the node-type glyph swatches. Matches the MeshCore map's marker
+// accent (the only surface that currently opts into the node-type legend).
+const NODE_TYPE_LEGEND_COLOR = '#cba6f7';
 
 interface LinkLegendItem {
   color: string;
@@ -24,6 +30,9 @@ interface MapLegendProps {
   positionHistory?: PositionHistoryData;
   /** Count of known nodes with neither a real nor an estimated position (issue #3271). */
   unmappedCount?: number;
+  /** Render the MeshCore node-type glyph legend (issue #3546). Opt-in so the
+   *  Meshtastic maps that share this component are unaffected. */
+  showNodeTypes?: boolean;
 }
 
 // Default position: top-right, below the Features checkbox panel, right-aligned with it
@@ -34,7 +43,7 @@ const getDefaultPosition = () => ({
   y: 60 + 10 + 250 + 20 // header + features top + features height + gap = 340
 });
 
-const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount }) => {
+const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount, showNodeTypes }) => {
   const { t } = useTranslation();
   const { overlayColors } = useSettings();
   const [isCollapsed, setIsCollapsed] = useState(() => {
@@ -125,6 +134,28 @@ const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount })
                 <span className="legend-label">{item.label}</span>
               </div>
             ))}
+            {showNodeTypes && (
+              <>
+                <div className="legend-divider" />
+                <span className="legend-title">{t('map.nodeType.legendTitle', 'Node Types')}</span>
+                {/* Standard nodes keep the default marker, so only the four
+                    glyph categories are listed (matches the analysis legend). */}
+                {NODE_TYPE_CATEGORIES.filter((c) => c !== 'standard').map((category) => {
+                  const meta = NODE_TYPE_CATEGORY_META[category];
+                  return (
+                    <div key={category} className="legend-item">
+                      <span
+                        className="legend-line-sample"
+                        style={{ display: 'inline-flex', width: 20, height: 20 }}
+                        aria-hidden="true"
+                        dangerouslySetInnerHTML={{ __html: roleGlyphMarkerSvg(category, NODE_TYPE_LEGEND_COLOR, 20) }}
+                      />
+                      <span className="legend-label">{t(meta.labelKey, meta.label)}</span>
+                    </div>
+                  );
+                })}
+              </>
+            )}
             {positionHistory && (
               <>
                 <div className="legend-divider" />

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -1,8 +1,17 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { MapContainer, TileLayer, Marker, Popup, Tooltip, Polyline } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { useSettings } from '../../contexts/SettingsContext';
+import {
+  getNodeTypeCategory,
+  nodePassesTypeFilter,
+  NODE_TYPE_CATEGORIES,
+  NODE_TYPE_CATEGORY_META,
+  type NodeTypeCategory,
+} from '../../utils/nodeTypeCategory';
+import { roleGlyphMarkerSvg } from '../../utils/mapIcons';
 import { useSource } from '../../contexts/SourceContext';
 import { getTilesetById, type TilesetId } from '../../config/tilesets';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
@@ -53,10 +62,17 @@ interface MeshCoreMapProps {
   onNavigateToDm?: (publicKey: string) => void;
 }
 
-function makeIcon(name: string): L.DivIcon {
-  return L.divIcon({
-    className: 'meshcore-marker',
-    html: `
+/**
+ * Marker body: a node-type role glyph (repeater/room/sensor/companion) on a
+ * white circle when the contact's advert type is known (issue #3546), else the
+ * original purple "MC" badge for standard/unknown nodes. The name label is
+ * unchanged so existing behavior is preserved.
+ */
+function makeIcon(name: string, category: NodeTypeCategory): L.DivIcon {
+  const glyph = roleGlyphMarkerSvg(category, MESHCORE_COLOR, 24);
+  const body = glyph
+    ? `<div style="width:24px;height:24px;filter:drop-shadow(0 2px 4px rgba(0,0,0,0.3));">${glyph}</div>`
+    : `
       <div style="
         width: 24px;
         height: 24px;
@@ -70,7 +86,11 @@ function makeIcon(name: string): L.DivIcon {
         color: #1e1e2e;
         font-size: 10px;
         font-weight: bold;
-      ">MC</div>
+      ">MC</div>`;
+  return L.divIcon({
+    className: 'meshcore-marker',
+    html: `
+      ${body}
       <div style="
         position: absolute;
         top: -20px;
@@ -90,6 +110,7 @@ function makeIcon(name: string): L.DivIcon {
 }
 
 export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPublicKey, localNodePosition, onNavigateToDm }) => {
+  const { t } = useTranslation();
   const { mapTileset, customTilesets, setMapTileset } = useSettings();
   const { sourceId } = useSource();
   const csrfFetch = useCsrfFetch();
@@ -97,6 +118,23 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
   const [showPaths, setShowPaths] = useState(true);
   const [showNeighbors, setShowNeighbors] = useState(true);
   const [neighborEdges, setNeighborEdges] = useState<NeighborEdge[]>([]);
+
+  // Per-node-type visibility filter (issue #3546), persisted like the other map
+  // toggles. Missing/true => visible; a category is hidden only when explicitly
+  // set false. Mirrors the Map Analysis workspace so behavior matches there.
+  const [nodeTypeFilter, setNodeTypeFilter] = useState<Partial<Record<NodeTypeCategory, boolean>>>(() => {
+    try {
+      const raw = localStorage.getItem('meshmonitor-meshcore-nodeTypeFilter');
+      return raw ? (JSON.parse(raw) as Partial<Record<NodeTypeCategory, boolean>>) : {};
+    } catch {
+      return {};
+    }
+  });
+  useEffect(() => {
+    localStorage.setItem('meshmonitor-meshcore-nodeTypeFilter', JSON.stringify(nodeTypeFilter));
+  }, [nodeTypeFilter]);
+  const setNodeTypeEnabled = (category: NodeTypeCategory, enabled: boolean) =>
+    setNodeTypeFilter((prev) => ({ ...prev, [category]: enabled }));
 
   // Tile selector + legend overlays — hidden by default, toggled from the Map
   // Features panel. Persisted under the same localStorage keys the other maps
@@ -150,6 +188,14 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
       typeof c.latitude === 'number' && isFinite(c.latitude)
       && typeof c.longitude === 'number' && isFinite(c.longitude)),
     [contacts],
+  );
+
+  // Markers visible after the node-type filter. Paths/neighbor lines keep using
+  // `positioned` so the filter only hides markers — matching the Map Analysis
+  // workspace, where the type filter never removes route/neighbor overlays.
+  const visibleContacts = useMemo(
+    () => positioned.filter(c => nodePassesTypeFilter({ advType: c.advType }, nodeTypeFilter)),
+    [positioned, nodeTypeFilter],
   );
 
   const localPos = useMemo((): [number, number] | null => {
@@ -230,15 +276,15 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
           url={tileset.url}
           maxZoom={tileset.maxZoom}
         />
-        {showLegend && <MapLegend />}
+        {showLegend && <MapLegend showNodeTypes />}
         {geoJsonLayers.length > 0 && <GeoJsonOverlay layers={geoJsonLayers} />}
-        {positioned.map(c => {
+        {visibleContacts.map(c => {
           const name = c.advName || c.name || 'MeshCore';
           return (
             <Marker
               key={c.publicKey}
               position={[c.latitude!, c.longitude!]}
-              icon={makeIcon(name)}
+              icon={makeIcon(name, getNodeTypeCategory({ advType: c.advType }))}
             >
               <Tooltip>
                 <strong>{name}</strong>
@@ -359,6 +405,24 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
             />
             <span>Show Legend</span>
           </label>
+          {/* Per-node-type visibility (issue #3546) — hide infrastructure or
+              end-user nodes to focus the map. Same categories as the legend. */}
+          <div className="map-controls-title" style={{ marginTop: '0.5rem' }}>
+            {t('map.nodeType.legendTitle', 'Node Types')}
+          </div>
+          {NODE_TYPE_CATEGORIES.map((category) => {
+            const meta = NODE_TYPE_CATEGORY_META[category];
+            return (
+              <label key={category} className="map-control-item">
+                <input
+                  type="checkbox"
+                  checked={nodeTypeFilter[category] !== false}
+                  onChange={(e) => setNodeTypeEnabled(category, e.target.checked)}
+                />
+                <span>{t(meta.labelKey, meta.label)}</span>
+              </label>
+            );
+          })}
           {/* GeoJSON overlay layers — per-layer on/off, mirroring the other maps. */}
           {geoJsonLayers.map(layer => (
             <label key={layer.id} className="map-control-item">

--- a/src/server/routes/meshRequestRoutes.test.ts
+++ b/src/server/routes/meshRequestRoutes.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import express from 'express';
 
 const mockManager = vi.hoisted(() => ({
+  sourceId: 'mgr-src',
   sendTraceroute: vi.fn(),
   sendPositionRequest: vi.fn(),
   sendNodeInfoRequest: vi.fn(),
@@ -142,5 +143,21 @@ describe('POST /telemetry/request', () => {
     const res = await request(app).post('/telemetry/request').send({ destination: '!12345678', telemetryType: 'environment' });
     expect(res.status).toBe(200);
     expect(mockManager.sendTelemetryRequest).toHaveBeenCalledWith(0x12345678, 2, 'environment');
+  });
+
+  // Regression for #3573: when the frontend omits sourceId, the channel lookup
+  // must be scoped to the resolved manager's source (not undefined, which would
+  // cross-source-match a wrong row and send on an invalid channel).
+  it('scopes the channel lookup to the manager source when no sourceId is sent', async () => {
+    mockManager.sendTelemetryRequest.mockResolvedValue({ packetId: 1, requestId: 2 });
+    await request(app).post('/telemetry/request').send({ destination: '!12345678', telemetryType: 'device' });
+    expect(databaseService.nodes.getNode).toHaveBeenCalledWith(0x12345678, 'mgr-src');
+  });
+
+  it('clamps an out-of-range stored channel (the MQTT channel=101 case) to 0', async () => {
+    (databaseService.nodes.getNode as any).mockResolvedValue({ channel: 101 });
+    mockManager.sendTelemetryRequest.mockResolvedValue({ packetId: 1, requestId: 2 });
+    await request(app).post('/telemetry/request').send({ destination: '!12345678', telemetryType: 'device' });
+    expect(mockManager.sendTelemetryRequest).toHaveBeenCalledWith(0x12345678, 0, 'device');
   });
 });

--- a/src/server/routes/meshRequestRoutes.ts
+++ b/src/server/routes/meshRequestRoutes.ts
@@ -4,6 +4,7 @@ import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { resolveSourceManager } from '../utils/resolveSourceManager.js';
 import { parseDestinationNum } from '../utils/parseDestination.js';
+import { resolveDestinationChannel } from '../utils/resolveDestinationChannel.js';
 import { PortNum } from '../constants/meshtastic.js';
 
 const router = Router();
@@ -20,12 +21,10 @@ router.post('/traceroute', requirePermission('traceroute', 'write'), async (req:
       return res.status(400).json({ error: `Invalid destination: ${destination}` });
     }
 
-    // Look up the node to get its channel — scope to this source so the channel
-    // reflects the mesh this traceroute will actually traverse.
-    const node = await databaseService.nodes.getNode(destinationNum, traceSourceId);
-    const channel = node?.channel ?? 0; // Default to 0 if node not found or channel not set
-
+    // Scope the channel lookup to the source we actually send through (issue
+    // #3573) so the channel reflects the mesh this traceroute will traverse.
     const traceManager = (resolveSourceManager(traceSourceId));
+    const channel = await resolveDestinationChannel(destinationNum, traceManager, databaseService);
     await traceManager.sendTraceroute(destinationNum, channel);
     res.json({
       success: true,
@@ -50,14 +49,10 @@ router.post('/position/request', requirePermission('messages', 'write'), async (
       return res.status(400).json({ error: `Invalid destination: ${destination}` });
     }
 
-    // Look up the node to get its channel (scoped to this source)
-    const node = await databaseService.nodes.getNode(destinationNum, posSourceId);
-    // Use explicit channel from request if provided and valid (0-7), otherwise fall back to node's stored channel
-    const channel = (typeof req.body.channel === 'number' && req.body.channel >= 0 && req.body.channel <= 7)
-      ? req.body.channel
-      : (node?.channel ?? 0);
-
+    // Scope the channel lookup to the source we actually send through (issue
+    // #3573). An explicit, valid (0-7) channel from the request still wins.
     const posManager = (resolveSourceManager(posSourceId));
+    const channel = await resolveDestinationChannel(destinationNum, posManager, databaseService, req.body.channel);
     const { packetId, requestId } = await posManager.sendPositionRequest(destinationNum, channel);
 
     // Get local node info to create system message
@@ -126,11 +121,9 @@ router.post('/nodeinfo/request', requirePermission('messages', 'write'), async (
       return res.status(400).json({ error: `Invalid destination: ${destination}` });
     }
 
-    // Look up the node to get its channel (scoped to this source)
-    const node = await databaseService.nodes.getNode(destinationNum, niSourceId);
-    const channel = node?.channel ?? 0; // Default to 0 if node not found or channel not set
-
+    // Scope the channel lookup to the source we actually send through (issue #3573).
     const niManager = (resolveSourceManager(niSourceId));
+    const channel = await resolveDestinationChannel(destinationNum, niManager, databaseService);
     const { packetId, requestId } = await niManager.sendNodeInfoRequest(destinationNum, channel);
 
     // Get local node info to create system message
@@ -204,8 +197,10 @@ router.post('/neighborinfo/request', requirePermission('traceroute', 'write'), a
     // Eligibility check: only allow requests to local node or 0-hop nodes
     const neighborManager = (resolveSourceManager(neighborSourceId));
     const localNodeNum = neighborManager.getLocalNodeInfo()?.nodeNum;
-    // Scope to the target source so hopsAway/channel reflect this mesh
-    const node = await databaseService.nodes.getNode(destinationNum, neighborSourceId);
+    // Scope to the source we actually send through so hopsAway/channel reflect
+    // this mesh (issue #3573) — not the request-body sourceId, which may be
+    // undefined and cross-source-match a wrong row.
+    const node = await databaseService.nodes.getNode(destinationNum, neighborManager.sourceId);
     const isLocalNode = localNodeNum != null && Number(destinationNum) === Number(localNodeNum);
     const isDirectNode = node != null && node.hopsAway != null && Number(node.hopsAway) === 0;
 
@@ -231,7 +226,8 @@ router.post('/neighborinfo/request', requirePermission('traceroute', 'write'), a
       neighborInfoRequestTimestamps.delete(Number(destinationNum));
     }
 
-    const channel = node?.channel ?? 0; // Default to 0 if node not found or channel not set
+    // node is already scoped to neighborManager.sourceId above; clamp to a valid index.
+    const channel = await resolveDestinationChannel(destinationNum, neighborManager, databaseService);
 
     const { packetId, requestId } = await neighborManager.sendNeighborInfoRequest(destinationNum, channel);
     neighborInfoRequestTimestamps.set(Number(destinationNum), now);
@@ -269,11 +265,13 @@ router.post('/telemetry/request', requirePermission('messages', 'write'), async 
       return res.status(400).json({ error: `Invalid destination: ${destination}` });
     }
 
-    // Look up the node to get its channel (scoped to this source)
-    const node = await databaseService.nodes.getNode(destinationNum, telSourceId);
-    const channel = node?.channel ?? 0; // Default to 0 if node not found or channel not set
-
+    // Resolve the manager first, then scope the channel lookup to the source it
+    // actually sends through (issue #3573) — not the request-body sourceId, which
+    // the frontend often omits and which can cross-source-match an MQTT row whose
+    // `channel` (e.g. 101) is not a valid Meshtastic channel index.
     const telManager = (resolveSourceManager(telSourceId));
+    const channel = await resolveDestinationChannel(destinationNum, telManager, databaseService);
+
     const { packetId, requestId } = await telManager.sendTelemetryRequest(
       destinationNum,
       channel,

--- a/src/server/routes/meshRequestRoutes.ts
+++ b/src/server/routes/meshRequestRoutes.ts
@@ -226,8 +226,10 @@ router.post('/neighborinfo/request', requirePermission('traceroute', 'write'), a
       neighborInfoRequestTimestamps.delete(Number(destinationNum));
     }
 
-    // node is already scoped to neighborManager.sourceId above; clamp to a valid index.
-    const channel = await resolveDestinationChannel(destinationNum, neighborManager, databaseService);
+    // node is already scoped to neighborManager.sourceId above; reuse its channel
+    // (passed as explicitChannel) so we don't re-query the same row, while still
+    // clamping any out-of-range value to a valid index.
+    const channel = await resolveDestinationChannel(destinationNum, neighborManager, databaseService, node?.channel);
 
     const { packetId, requestId } = await neighborManager.sendNeighborInfoRequest(destinationNum, channel);
     neighborInfoRequestTimestamps.set(Number(destinationNum), now);

--- a/src/server/utils/resolveDestinationChannel.test.ts
+++ b/src/server/utils/resolveDestinationChannel.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for `resolveDestinationChannel` — the shared channel resolver used by
+ * the telemetry / traceroute / position / nodeInfo / neighborInfo request routes.
+ *
+ * Issue #3573 background: these routes used to look up the destination's channel
+ * with the request-body `sourceId`, which the telemetry frontend never sent. With
+ * `sourceId` undefined, `getNode` cross-source-matched a row from an MQTT source
+ * whose stored `channel` was an out-of-range value (e.g. 101 — Meshtastic channels
+ * are 0–7). The request then went out on that bogus channel and was never answered.
+ * This helper scopes the lookup to the manager's real `sourceId` and clamps to 0–7.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveDestinationChannel } from './resolveDestinationChannel.js';
+
+type DbFacade = Parameters<typeof resolveDestinationChannel>[2];
+
+function fakeDb(getNode: ReturnType<typeof vi.fn>): DbFacade {
+  return { nodes: { getNode } } as unknown as DbFacade;
+}
+
+const manager = { sourceId: 'meshtastic-src' };
+
+describe('resolveDestinationChannel', () => {
+  let getNode: ReturnType<typeof vi.fn>;
+  let db: DbFacade;
+
+  beforeEach(() => {
+    getNode = vi.fn();
+    db = fakeDb(getNode);
+  });
+
+  it('scopes the node lookup to the manager sourceId, not any body sourceId', async () => {
+    getNode.mockResolvedValue({ channel: 0 });
+    await resolveDestinationChannel(0x1234, manager, db);
+    expect(getNode).toHaveBeenCalledWith(0x1234, 'meshtastic-src');
+  });
+
+  it('returns the stored channel when it is a valid index', async () => {
+    getNode.mockResolvedValue({ channel: 3 });
+    expect(await resolveDestinationChannel(0x1234, manager, db)).toBe(3);
+  });
+
+  it('clamps an out-of-range stored channel (the MQTT channel=101 bug) to 0', async () => {
+    getNode.mockResolvedValue({ channel: 101 });
+    expect(await resolveDestinationChannel(0x1234, manager, db)).toBe(0);
+  });
+
+  it('defaults to 0 when the node is not found on this source', async () => {
+    getNode.mockResolvedValue(null);
+    expect(await resolveDestinationChannel(0x1234, manager, db)).toBe(0);
+  });
+
+  it('defaults to 0 when the stored channel is null/undefined', async () => {
+    getNode.mockResolvedValue({ channel: null });
+    expect(await resolveDestinationChannel(0x1234, manager, db)).toBe(0);
+  });
+
+  it('honors a valid explicit channel without querying the database', async () => {
+    expect(await resolveDestinationChannel(0x1234, manager, db, 5)).toBe(5);
+    expect(getNode).not.toHaveBeenCalled();
+  });
+
+  it('ignores an out-of-range explicit channel and falls back to the stored channel', async () => {
+    getNode.mockResolvedValue({ channel: 2 });
+    expect(await resolveDestinationChannel(0x1234, manager, db, 101)).toBe(2);
+    expect(getNode).toHaveBeenCalledWith(0x1234, 'meshtastic-src');
+  });
+
+  it('ignores a non-numeric explicit channel and uses the stored channel', async () => {
+    getNode.mockResolvedValue({ channel: 1 });
+    expect(await resolveDestinationChannel(0x1234, manager, db, 'two' as unknown as number)).toBe(1);
+  });
+
+  it('rejects a negative explicit channel', async () => {
+    getNode.mockResolvedValue({ channel: 0 });
+    expect(await resolveDestinationChannel(0x1234, manager, db, -1)).toBe(0);
+  });
+});

--- a/src/server/utils/resolveDestinationChannel.ts
+++ b/src/server/utils/resolveDestinationChannel.ts
@@ -1,0 +1,66 @@
+import type databaseService from '../../services/database.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Meshtastic supports channel indexes 0–7 (PRIMARY plus up to seven
+ * secondary channels). Anything outside this range is not a transmittable
+ * channel index.
+ */
+export const MAX_MESHTASTIC_CHANNEL_INDEX = 7;
+
+function isValidChannelIndex(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value <= MAX_MESHTASTIC_CHANNEL_INDEX
+  );
+}
+
+/**
+ * Resolve the channel index to transmit a mesh request (telemetry, traceroute,
+ * position, NodeInfo, NeighborInfo) on, scoped to the source that will actually
+ * send it.
+ *
+ * Background (issue #3573): these routes used to look up the destination node's
+ * channel with the request body's `sourceId`, which several frontend callers
+ * never send. With `sourceId` undefined, `NodesRepository.getNode` falls back to
+ * a cross-source first-match and can return a row from an MQTT broker/bridge
+ * source whose stored `channel` is not a valid Meshtastic channel index (e.g.
+ * 101). The request was then transmitted on that bogus channel, so the target
+ * node never received or answered it — the telemetry/traceroute/etc. silently
+ * produced no response.
+ *
+ * Scoping the lookup to the *resolved manager's* `sourceId` guarantees the
+ * channel reflects the mesh the request will traverse, and clamping to 0–7
+ * defends against any residual out-of-range value.
+ *
+ * @param destinationNum Target node number.
+ * @param manager The source manager the request will be sent through. Its
+ *   `sourceId` is authoritative for the channel lookup.
+ * @param db Injected database facade.
+ * @param explicitChannel Optional caller-supplied channel (e.g. position
+ *   requests accept one). Used as-is when it is a valid 0–7 index.
+ * @returns A valid Meshtastic channel index (0–7), defaulting to 0.
+ */
+export async function resolveDestinationChannel(
+  destinationNum: number,
+  manager: { sourceId: string },
+  db: typeof databaseService,
+  explicitChannel?: unknown,
+): Promise<number> {
+  if (isValidChannelIndex(explicitChannel)) {
+    return explicitChannel;
+  }
+
+  const node = await db.nodes.getNode(destinationNum, manager.sourceId);
+  const stored = node?.channel ?? 0;
+  if (isValidChannelIndex(stored)) {
+    return stored;
+  }
+
+  logger.warn(
+    `resolveDestinationChannel: node ${destinationNum.toString(16)} on source ${manager.sourceId} has out-of-range channel ${stored}; falling back to channel 0`,
+  );
+  return 0;
+}

--- a/src/utils/mapIcons.test.ts
+++ b/src/utils/mapIcons.test.ts
@@ -8,7 +8,7 @@ vi.mock('leaflet', () => ({
   },
 }));
 
-import { getHopColor } from './mapIcons';
+import { getHopColor, roleGlyphMarkerSvg } from './mapIcons';
 
 describe('getHopColor', () => {
   describe('special hop counts', () => {
@@ -166,5 +166,29 @@ describe('getHopColor', () => {
         expect(getHopColor(hops)).toBe(expectedColor);
       });
     });
+  });
+});
+
+describe('roleGlyphMarkerSvg', () => {
+  const COLOR = '#cba6f7';
+
+  it('returns an <svg> with a backing circle and the glyph for known categories', () => {
+    for (const category of ['repeater', 'roomServer', 'sensor', 'companion'] as const) {
+      const svg = roleGlyphMarkerSvg(category, COLOR, 24);
+      expect(svg).toContain('<svg');
+      expect(svg).toContain('viewBox="0 0 48 48"');
+      expect(svg).toContain('<circle'); // white backing circle
+      expect(svg).toContain(COLOR);     // glyph/stroke uses the passed color
+    }
+  });
+
+  it('honors the requested size', () => {
+    const svg = roleGlyphMarkerSvg('repeater', COLOR, 30);
+    expect(svg).toContain('width="30"');
+    expect(svg).toContain('height="30"');
+  });
+
+  it('returns empty string for standard (so callers keep their default marker)', () => {
+    expect(roleGlyphMarkerSvg('standard', COLOR, 24)).toBe('');
   });
 });

--- a/src/utils/mapIcons.ts
+++ b/src/utils/mapIcons.ts
@@ -50,6 +50,26 @@ export function roleGlyphInnerSvg(category: NodeTypeCategory, color: string): st
 }
 
 /**
+ * Standalone role-glyph marker: the node-type glyph ({@link roleGlyphInnerSvg})
+ * drawn over a white background circle, as a complete `<svg>` string sized to
+ * `size`px. Used by maps that render their own markers (e.g. the MeshCore
+ * source map) and by the legend swatches, so the glyph stays identical to the
+ * one `createNodeIcon`'s official style produces. Returns '' for 'standard'
+ * (and unknown categories) so callers fall back to their default marker.
+ */
+export function roleGlyphMarkerSvg(
+  category: NodeTypeCategory,
+  color: string,
+  size = 24,
+): string {
+  const inner = roleGlyphInnerSvg(category, color);
+  if (!inner) return '';
+  return `<svg width="${size}" height="${size}" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">`
+    + `<circle cx="24" cy="24" r="20" fill="white" fill-opacity="0.95" stroke="${color}" stroke-width="2" />`
+    + `${inner}</svg>`;
+}
+
+/**
  * Get color based on hop count
  * Uses a blue-to-red gradient (through purple/magenta)
  * 0 hops: Green (#22c55e) - Direct connection (local node)


### PR DESCRIPTION
## Problem

Fixes #3573. Requesting telemetry (e.g. Device Metrics) from a node never updates battery/telemetry — the request appears to do nothing and no response packet arrives. The Meshtastic Android app works against the same node.

## Root cause (reproduced on hardware)

The telemetry request route (and its siblings: traceroute / position / nodeInfo / neighborInfo) looked up the destination node's **channel** using the request-body `sourceId`. The telemetry frontend (`handleRequestTelemetry`) **never sent `sourceId`**, so the backend received `undefined`. `NodesRepository.getNode(num, undefined)` falls back to a **cross-source first-match** and can return a row from an MQTT broker/bridge source whose stored `channel` is **not a valid Meshtastic channel index** (observed value: **101** — valid range is 0–7).

The request was then transmitted on channel 101, so the target node never received/answered it.

Reproduced against a live mesh:

| Request | Channel sent on | Telemetry responses |
|---|---|---|
| no `sourceId` (original frontend behavior) | **101** | **0** |
| correct `sourceId` | **0** | responses arrive (incl. a node that had no prior battery reading) |

The bug triggers whenever the same node also exists under a second source — an MQTT broker/bridge is extremely common, which is why most affected users see "telemetry request does nothing" while passive broadcasts still update battery.

## Fix

- New `resolveDestinationChannel()` util: scopes the channel lookup to the **resolved manager's own `sourceId`** (the mesh the request actually traverses) and **clamps to a valid 0–7 index**, defaulting to 0.
- Applied across all five mesh-request routes in `meshRequestRoutes.ts` (defense-in-depth: correct even when a frontend omits `sourceId`).
- Telemetry frontend now sends `sourceId` (so the correct source's manager is selected in multi-source) and **checks `response.ok`** instead of silently swallowing backend errors.

## Validation

- New unit test `resolveDestinationChannel.test.ts` (9 cases incl. the channel=101 clamp and source-scoping).
- Full Vitest suite: **6945 passed, 0 failed**.
- Re-ran the original failing repro on the rebuilt dev container with **no `sourceId`** → now sends on channel **0** and telemetry returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
