### PR TITLE
fix(map): actually drop mobile Features panel below sidebar drawer (#3532)

### DIFF
--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1332,18 +1332,11 @@
     height: 100%;
   }
 
-  /* Adjust map controls on mobile - keep in upper right, no dragging */
-  .map-controls {
-    top: 16px;
-    right: 8px;
-    left: auto;
-    max-width: calc(100vw - 64px);
-    /* Sit below the mobile sidebar drawer (999) and its backdrop (998) so the
-       Features panel yields when the Sources sidebar is open (#3532). When the
-       drawer is closed the backdrop is opacity:0/pointer-events:none, so this
-       has no effect on the normal map-controls interaction. */
-    z-index: 997;
-  }
+  /* NOTE: the mobile `.map-controls` position + z-index override lives AFTER
+     the base `.map-controls` rule (search "Map Controls (mobile override)"),
+     not here. The base rule is declared later in this file; since media
+     queries add no specificity, an override placed here would lose the cascade
+     to the base rule's `top/right/z-index` and silently do nothing (#3532). */
 
   .map-controls .map-controls-body {
     padding: 0.5rem;
@@ -2253,6 +2246,27 @@
   flex-direction: row;
   align-items: stretch;
   overflow: hidden;
+}
+
+/* Map Controls (mobile override)
+   Declared AFTER the base `.map-controls` rule on purpose: media queries add
+   no specificity, so this must come later in source order to win the cascade
+   over the base `top/right/z-index` above. (Issue #3532 — the original fix
+   placed this in an earlier media block and was silently overridden, so the
+   Features panel still painted over the slide-in Sources sidebar on mobile.) */
+@media (max-width: 768px) {
+  .map-controls {
+    top: 16px;
+    right: 8px;
+    left: auto;
+    max-width: calc(100vw - 64px);
+    /* Sit below the mobile sidebar drawer (.dashboard-sidebar, z-index 999)
+       and its backdrop (998) so the Features panel yields when the Sources
+       sidebar is open. When the drawer is closed its backdrop is
+       opacity:0/pointer-events:none, so this has no effect on the normal
+       map-controls interaction. */
+    z-index: 997;
+  }
 }
 
 .map-controls-body {


### PR DESCRIPTION
## Summary

Re-fixes #3532. The earlier fix (#3548) was **inert** — the mobile map **Features** panel still painted on top of the slide-in Sources sidebar drawer on mobile portrait, blocking the source **Connect** buttons.

## Why the previous fix did nothing

#3548 added `.map-controls { z-index: 997 }` inside the `@media (max-width: 768px)` block (`nodes.css` ~L1336), to drop the panel below the sidebar drawer (`z-index: 999`).

But the **base** `.map-controls { z-index: 1000 }` rule is declared **later** in the file (~L2242, top-level, not in any media query). Media queries add **no specificity**, so with equal specificity (`.map-controls` = 0,0,1,0) the later base rule wins the cascade — even on mobile. `z-index` resolved to **1000**, still above the drawer. (The base `top:10px/right:10px` likewise clobbered the mobile `top:16px/right:8px`; only `left`/`max-width` survived since the base doesn't set them.)

| Element | z-index | Result before fix |
|---|---|---|
| `.dashboard-sidebar` (mobile drawer) | 999 | |
| `.dashboard-sidebar-backdrop` | 998 | |
| `.map-controls` mobile override | 997 (L1336) | **overridden** ⤵ |
| `.map-controls` base (later in source) | 1000 (L2242) | **wins → paints over drawer** |

## Fix

Move the mobile `.map-controls` override into a `@media (max-width: 768px)` block placed **after** the base rule, so it wins source order. A breadcrumb comment at the old location explains why the override can't live there.

CSS-only, no JS/state coupling.

## Testing

- `tsc --noEmit`: no errors.
- Full Vitest suite: **6784 passed / 0 failed** (0 failed suites).
- **Manual visual verification** at mobile 390×844 (the step that was missing last time): deployed the dev container, opened the Dashboard, opened the Sources drawer, opened the Features panel. The Features panel now sits **behind** the drawer backdrop and the source **Connect / "Open →"** buttons are fully accessible. Screenshot attached in the PR thread / linked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)