### PR TITLE
release: v4.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.11.1] - 2026-06-20
+
 ### Features
 
 - **Device notifications surfaced as toasts + firmware 2.8 favorite/ignore cap handling (#3548)**: MeshMonitor now shows `ClientNotification` messages the connected node emits about its own operation — duplicate-key security warnings, invalid-config errors, duty-cycle limits, and more — as top-right toasts. These were always sent by the node but previously decoded and dropped. A server-side policy (`clientNotificationPolicy.ts`) suppresses the routine recurring ones (e.g. the power-saving "sleeping for N interval" message) and dedupes identical messages to at most once per minute per source, so the feed stays useful rather than noisy. On firmware **2.8**, when a Set Favorite / Ignore is refused because the device's protected-node list is full, MeshMonitor reverts its optimistic star/ignore toggle to match the device and surfaces the refusal (this warning is only emitted for the locally-connected node, not remote-admin targets). No protobuf changes were needed — the 2.8 NodeDB warm-tier restructure and the `snr_q4` on-disk field do not affect the over-the-air wire MeshMonitor reads (SNR stays a `float` in dB; a regression test guards this). See `docs/internal/dev-notes/MT28_NODEDB_SUPPORT_PLAN.md`.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.11.0",
+  "version": "4.11.1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.11.0
-appVersion: "4.11.0"
+version: 4.11.1
+appVersion: "4.11.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.11.0",
+      "version": "4.11.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Version bump to **4.11.1**.

Bumps the version across all five tracked files and rolls the `CHANGELOG.md` `[Unreleased]` section into `[4.11.1]`:
- `package.json`
- `package-lock.json` (regenerated)
- `desktop/package.json`
- `desktop/src-tauri/tauri.conf.json`
- `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`)

## Changes since 4.11.0 (now under [4.11.1])

- **Device notifications surfaced as toasts + firmware 2.8 favorite/ignore cap handling (#3548, #3578)**
- **Auto-Acknowledge 2×2 matrix — message type × hop distance (#3564, #3580)**
- **MeshCore node-type icons & filter on the source map (#3546, #3576)**

## Notes

- System tests enabled on this PR via the `system-test` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEaCGwY9Wz8jeV4e22GW4