### PR TITLE
fix(migration): supply createdAt/updatedAt in 093 settings inserts (v4.11.2 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.11.2] - 2026-06-20
+
+### Bug Fixes
+
+- **Startup crash loop after upgrading to 4.11.1 with an existing Auto-Acknowledge config (PostgreSQL/MySQL)**: Migration 093 (the Auto-Acknowledge 2×2 matrix backfill, new in 4.11.1) inserted `settings` rows without the table's NOT NULL `createdAt`/`updatedAt` columns. On PostgreSQL/MySQL this aborted the migration with a `null value in column "createdAt" … violates not-null constraint` error, failing database initialization on boot — a restart loop. On SQLite the `INSERT OR IGNORE` silently swallowed the violation, so the matrix settings were never actually written. The migration now supplies both timestamps (and a regression test runs it against a real settings table). Affected instances recover automatically on upgrade: the migration had not been marked complete, so it re-runs and succeeds, correctly migrating the auto-ack settings.
+
 ## [4.11.1] - 2026-06-20
 
 ### Features

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.11.1",
+  "version": "4.11.2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.11.1",
+  "version": "4.11.2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.11.1
-appVersion: "4.11.1"
+version: 4.11.2
+appVersion: "4.11.2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.11.1",
+  "version": "4.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.11.1",
+      "version": "4.11.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.11.1",
+  "version": "4.11.2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/server/migrations/093_autoack_matrix.test.ts
+++ b/src/server/migrations/093_autoack_matrix.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { computeMatrixValues, computeMigrationInserts } from './093_autoack_matrix.js';
+import Database from 'better-sqlite3';
+import { computeMatrixValues, computeMigrationInserts, migration } from './093_autoack_matrix.js';
+
+// Mirrors src/db/schema/settings.ts — createdAt/updatedAt are NOT NULL with no
+// DB default, which is exactly what the migration insert must satisfy.
+function makeSettingsDb() {
+  const db = new Database(':memory:');
+  db.exec(`CREATE TABLE settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    createdAt INTEGER NOT NULL,
+    updatedAt INTEGER NOT NULL
+  )`);
+  return db;
+}
 
 describe('093 auto-ack matrix migration — computeMatrixValues', () => {
   it('uses legacy defaults (behavior ON, DM gates OFF) when nothing is set', () => {
@@ -106,5 +120,52 @@ describe('093 auto-ack matrix migration — computeMigrationInserts', () => {
     // Defaults: channel cells active, direct cells off.
     expect(rows.find((r) => r.key === 'source:s3:autoAckChannelZeroHopReplyEnabled')?.value).toBe('true');
     expect(rows.find((r) => r.key === 'source:s3:autoAckDirectZeroHopReplyEnabled')?.value).toBe('false');
+  });
+});
+
+describe('093 SQLite migration — runs against a real settings table', () => {
+  it('inserts the 12 matrix rows with non-null createdAt/updatedAt', () => {
+    const db = makeSettingsDb();
+    const now = 1_700_000_000_000;
+    db.prepare('INSERT INTO settings (key, value, createdAt, updatedAt) VALUES (?,?,?,?)')
+      .run('autoAckEnabled', 'true', now, now);
+    db.prepare('INSERT INTO settings (key, value, createdAt, updatedAt) VALUES (?,?,?,?)')
+      .run('autoAckDirectMessages', 'true', now, now);
+
+    // Must not throw (the bug was a NOT NULL violation on createdAt/updatedAt).
+    expect(() => migration.up(db as any)).not.toThrow();
+
+    const matrixRows = db.prepare(
+      "SELECT key, value, createdAt, updatedAt FROM settings WHERE key LIKE 'autoAck%Hop%Enabled'",
+    ).all() as Array<{ key: string; value: string; createdAt: number; updatedAt: number }>;
+    expect(matrixRows).toHaveLength(12);
+    for (const row of matrixRows) {
+      expect(row.createdAt).not.toBeNull();
+      expect(typeof row.createdAt).toBe('number');
+      expect(typeof row.updatedAt).toBe('number');
+    }
+    // DM column enabled because autoAckDirectMessages was true.
+    expect(matrixRows.find((r) => r.key === 'autoAckDirectZeroHopReplyEnabled')?.value).toBe('true');
+    db.close();
+  });
+
+  it('is idempotent — a second run does not throw or duplicate', () => {
+    const db = makeSettingsDb();
+    const now = 1_700_000_000_000;
+    db.prepare('INSERT INTO settings (key, value, createdAt, updatedAt) VALUES (?,?,?,?)')
+      .run('autoAckEnabled', 'true', now, now);
+    migration.up(db as any);
+    expect(() => migration.up(db as any)).not.toThrow();
+    const count = (db.prepare("SELECT COUNT(*) c FROM settings WHERE key LIKE 'autoAck%Hop%Enabled'").get() as { c: number }).c;
+    expect(count).toBe(12);
+    db.close();
+  });
+
+  it('writes nothing when there is no legacy auto-ack config', () => {
+    const db = makeSettingsDb();
+    migration.up(db as any);
+    const count = (db.prepare('SELECT COUNT(*) c FROM settings').get() as { c: number }).c;
+    expect(count).toBe(0);
+    db.close();
   });
 });

--- a/src/server/migrations/093_autoack_matrix.ts
+++ b/src/server/migrations/093_autoack_matrix.ts
@@ -127,10 +127,15 @@ export const migration = {
       logger.debug(`${LABEL} (SQLite): no legacy auto-ack config to migrate`);
       return;
     }
+    // The settings table has NOT NULL createdAt/updatedAt (no DB default), so a
+    // (key, value)-only insert violates the constraint — on SQLite `OR IGNORE`
+    // would silently swallow it (writing nothing); on Postgres it hard-fails.
+    // Always supply the timestamps.
+    const now = Date.now();
     // eslint-disable-next-line no-restricted-syntax -- migrations require raw SQL
-    const stmt = db.prepare(`INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)`);
+    const stmt = db.prepare(`INSERT OR IGNORE INTO settings (key, value, createdAt, updatedAt) VALUES (?, ?, ?, ?)`);
     const tx = db.transaction((items: SettingRow[]) => {
-      for (const it of items) stmt.run(it.key, it.value);
+      for (const it of items) stmt.run(it.key, it.value, now, now);
     });
     tx(inserts);
     logger.info(`${LABEL} (SQLite): wrote ${inserts.length} matrix setting(s)`);
@@ -147,10 +152,13 @@ export async function runMigration093Postgres(client: any): Promise<void> {
   logger.info(`${LABEL} (PostgreSQL): folding legacy auto-ack settings into the 2x2 matrix...`);
   const res = await client.query(`SELECT key, value FROM settings WHERE key LIKE '%autoAck%'`);
   const inserts = computeMigrationInserts(res.rows as SettingRow[]);
+  // createdAt/updatedAt are NOT NULL with no DB default (camelCase → must be
+  // quoted in Postgres). Supplying them avoids the not-null violation.
+  const now = Date.now();
   for (const it of inserts) {
     await client.query(
-      `INSERT INTO settings (key, value) VALUES ($1, $2) ON CONFLICT (key) DO NOTHING`,
-      [it.key, it.value],
+      `INSERT INTO settings (key, value, "createdAt", "updatedAt") VALUES ($1, $2, $3, $4) ON CONFLICT (key) DO NOTHING`,
+      [it.key, it.value, now, now],
     );
   }
   logger.info(`${LABEL} (PostgreSQL): wrote up to ${inserts.length} matrix setting(s)`);
@@ -164,8 +172,13 @@ export async function runMigration093Mysql(pool: any): Promise<void> {
   try {
     const [rows] = await conn.query("SELECT `key`, value FROM settings WHERE `key` LIKE '%autoAck%'");
     const inserts = computeMigrationInserts(rows as SettingRow[]);
+    // createdAt/updatedAt are NOT NULL with no DB default — supply them.
+    const now = Date.now();
     for (const it of inserts) {
-      await conn.query('INSERT IGNORE INTO settings (`key`, value) VALUES (?, ?)', [it.key, it.value]);
+      await conn.query(
+        'INSERT IGNORE INTO settings (`key`, value, createdAt, updatedAt) VALUES (?, ?, ?, ?)',
+        [it.key, it.value, now, now],
+      );
     }
     logger.info(`${LABEL} (MySQL): wrote up to ${inserts.length} matrix setting(s)`);
   } finally {


### PR DESCRIPTION
## Summary
**Production hotfix.** 4.11.1 fails to boot on PostgreSQL/MySQL when the instance has an existing Auto-Acknowledge configuration. Migration 093 (the Auto-Acknowledge 2×2 matrix backfill) inserts new `settings` rows with only `(key, value)`, but the `settings` table has **NOT NULL `createdAt`/`updatedAt`** columns with no DB default:

```
null value in column "createdAt" of relation "settings" violates not-null constraint
detail: Failing row contains (autoAckChannelZeroHopReplyEnabled, true, null, null)
  at async runMigration093Postgres (.../093_autoack_matrix.js)
```

- **PostgreSQL/MySQL:** the INSERT aborts → database initialization fails on boot → **restart loop** (app never launches).
- **SQLite:** `INSERT OR IGNORE` silently swallowed the violation, so the matrix settings were **never written** (latent data bug — migration appeared to succeed but did nothing).

## Fix
Supply `createdAt`/`updatedAt` (= `Date.now()`) in all three backend INSERTs. Postgres camelCase columns are quoted (`"createdAt"`). Bump to **4.11.2**.

## Recovery
Affected instances recover automatically on upgrade to 4.11.2: migration 093 was never marked complete (it threw before committing), so it re-runs and now succeeds — the auto-ack settings migrate correctly. No manual DB surgery needed. (Idempotent: `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING`.)

## Changes
- `src/server/migrations/093_autoack_matrix.ts` — add `createdAt`/`updatedAt` to the SQLite / PostgreSQL / MySQL inserts.
- `src/server/migrations/093_autoack_matrix.test.ts` — new **integration test** that runs `migration.up()` against a real in-memory SQLite `settings` table with the NOT NULL schema, asserting the 12 rows insert with non-null timestamps, idempotency, and the no-op case. (The original tests only covered the pure value-mapping function, which is why this slipped through.)
- Version bump to 4.11.2: `package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml`, `desktop/src-tauri/tauri.conf.json`, `desktop/package.json`.
- CHANGELOG.

## Issues Resolved
Fixes the 4.11.1 boot failure reported against PostgreSQL backends.

## Testing
- [x] New SQLite integration test reproduces the failure on the old code and passes on the fixed code
- [x] Migration registry + 093 tests green (23)
- [x] `tsc --noEmit` clean
- [ ] CI Postgres/MySQL matrix exercises the real backends
- [ ] Reviewer: confirm the quoted `"createdAt"`/`"updatedAt"` identifiers match the Drizzle-created Postgres columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)