### PR TITLE
feat(docker): bundle MeshCore CLI Python package alongside Meshtastic CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,10 @@ RUN apk add --no-cache \
     su-exec \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && python3 -m venv /opt/apprise-venv \
-    && /opt/apprise-venv/bin/pip install --no-cache-dir apprise "paho-mqtt<2.0" meshtastic \
+    && /opt/apprise-venv/bin/pip install --no-cache-dir apprise "paho-mqtt<2.0" meshtastic meshcore-cli \
     && ln -sf /opt/apprise-venv/bin/meshtastic /usr/local/bin/meshtastic \
+    && ln -sf /opt/apprise-venv/bin/meshcore-cli /usr/local/bin/meshcore-cli \
+    && ln -sf /opt/apprise-venv/bin/meshcli /usr/local/bin/meshcli \
     && ln -sf /usr/bin/python3 /usr/local/bin/python3
 
 # Copy package files


### PR DESCRIPTION
## Summary

Closes #3587.

The MeshMonitor Docker image already bundles the official Meshtastic Python CLI. This adds the **MeshCore CLI** Python application alongside it, using the exact same mechanism (pip install into the existing `apprise` virtualenv, same `RUN` layer, `--no-cache-dir`).

## Changes

- Add `meshcore-cli` to the `pip install` line in the Python/Apprise `RUN` layer in `Dockerfile`.
- Symlink both console scripts the package provides — `meshcore-cli` and `meshcli` — into `/usr/local/bin`, mirroring the existing `meshtastic` symlink.

## Package details

- **PyPI package:** `meshcore-cli` (summary: "Command line interface to meshcore companion radios and repeaters").
- **Version:** unpinned, matching the existing unpinned `meshtastic` package on the same line (resolved to `meshcore-cli 1.5.7` + `meshcore 2.3.7` at build time).
- **Console scripts:** the wheel's `entry_points.txt` declares both `meshcore-cli` and `meshcli`; both are symlinked onto PATH.

Note: the codebase does not shell out to a `meshcore-cli` binary — MeshCore uses the native `meshcore.js` library (companion) and direct serial CLI (repeater). The few `meshcore-cli` references in `meshcoreManager.ts` are comments about users running the CLI out-of-band. Bundling is purely additive operator convenience, consistent with the bundled Meshtastic CLI.

## Verification

- Built a minimal image replicating the modified `RUN` layer on the same `node:24.15.0-alpine3.22` base. The `pip install` succeeded and `which meshtastic meshcore-cli meshcli` resolved all three; `meshcore-cli --help` and `meshtastic --version` both ran successfully. The Meshtastic install is unaffected (`meshtastic-2.7.9`).
- Confirmed package name/version/deps via the PyPI JSON API.
- `tsc`: passes. Full Vitest suite: 7012 passed, 0 failed (Dockerfile change does not affect JS tests). Pre-existing ESLint errors in the repo are unrelated (diff touches only `Dockerfile`).
- A full production image build was **not** run (the targeted stage build is sufficient to validate the install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)