### PR TITLE
fix(meshcore): correlate buffered SNR/route to the matching packet for auto-ack {SNR}/{ROUTE} (#3589)

### DIFF
--- a/src/server/meshcoreNativeBackend.otaPacket.test.ts
+++ b/src/server/meshcoreNativeBackend.otaPacket.test.ts
@@ -12,7 +12,7 @@
  * meshcoreNativeBackend.test.ts — provides a `Packet` constructor and the
  * LogRxData push code.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'events';
 import { MeshCoreNativeBackend, __setMeshCoreModule } from './meshcoreNativeBackend.js';
 
@@ -200,5 +200,109 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
     const { conn, events } = await connectedBackend();
     expect(() => conn.emit(PushCodes.LogRxData, { lastSnr: 0, lastRssi: 0, raw: new Uint8Array(0) })).not.toThrow();
     expect(events.find((e) => e.event_type === 'ota_packet')).toBeUndefined();
+  });
+
+  // --- issue #3589: buffered-path mis-correlation guards ---------------------
+
+  it('does NOT attach a buffered path when the recv pathLen differs (different packet)', async () => {
+    const { conn, events } = await connectedBackend();
+    // LogRxData buffers a 2-hop path with pathLen=0x02.
+    const raw = Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]);
+    conn.emit(PushCodes.LogRxData, { lastSnr: 9, lastRssi: -30, raw });
+    // The recv that follows is a DIFFERENT packet (direct, pathLen=0xff) whose
+    // own LogRxData never arrived. The buffered 0x02 path must NOT be attached.
+    conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
+      text: 'hello',
+      senderTimestamp: 1700,
+      pathLen: 0xff,
+      txtType: TxtTypes.Plain,
+    });
+    const msg = events.find((e) => e.event_type === 'contact_message');
+    expect(msg).toBeDefined();
+    expect(msg.data.snr).toBeUndefined();
+    expect(msg.data.path_hops).toBeUndefined();
+  });
+
+  it('does NOT attach a stale buffered path (older than the freshness window)', async () => {
+    vi.useFakeTimers();
+    try {
+      const { conn, events } = await connectedBackend();
+      const raw = Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]);
+      conn.emit(PushCodes.LogRxData, { lastSnr: 7, lastRssi: -35, raw });
+      // Advance well past PENDING_PATH_MAX_AGE_MS (500ms) before the recv lands.
+      vi.advanceTimersByTime(1000);
+      conn.emit(ResponseCodes.ContactMsgRecv, {
+        pubKeyPrefix: Uint8Array.from([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
+        text: 'late',
+        senderTimestamp: 1700,
+        pathLen: 0x02,
+        txtType: TxtTypes.Plain,
+      });
+      const msg = events.find((e) => e.event_type === 'contact_message');
+      expect(msg).toBeDefined();
+      expect(msg.data.snr).toBeUndefined();
+      expect(msg.data.path_hops).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('consumes the buffer once — a second recv with no LogRxData gets nothing', async () => {
+    const { conn, events } = await connectedBackend();
+    const raw = Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]);
+    conn.emit(PushCodes.LogRxData, { lastSnr: 4, lastRssi: -50, raw });
+    // First recv consumes the buffer.
+    conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]),
+      text: 'first',
+      senderTimestamp: 1700,
+      pathLen: 0x02,
+      txtType: TxtTypes.Plain,
+    });
+    // Second recv (no preceding LogRxData) must NOT reuse the consumed buffer.
+    conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from([0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc]),
+      text: 'second',
+      senderTimestamp: 1800,
+      pathLen: 0x02,
+      txtType: TxtTypes.Plain,
+    });
+    const msgs = events.filter((e) => e.event_type === 'contact_message');
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].data.snr).toBe(4);
+    expect(msgs[0].data.path_hops).toEqual(['a3', '7f']);
+    expect(msgs[1].data.snr).toBeUndefined();
+    expect(msgs[1].data.path_hops).toBeUndefined();
+  });
+
+  it('a room post consumes (and discards) the buffer so it cannot leak onto the next message', async () => {
+    const { conn, events } = await connectedBackend();
+    // LogRxData for the room post's own packet.
+    const raw = Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]);
+    conn.emit(PushCodes.LogRxData, { lastSnr: 8, lastRssi: -25, raw });
+    // Room post (SignedPlain) — first 4 bytes of text are the author prefix.
+    conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]),
+      text: '\x01\x02\x03\x04hello room',
+      senderTimestamp: 1700,
+      pathLen: 0x02,
+      txtType: TxtTypes.SignedPlain,
+    });
+    // A subsequent DM (no LogRxData of its own) must NOT inherit the room
+    // post's buffered SNR/path.
+    conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]),
+      text: 'plain dm',
+      senderTimestamp: 1800,
+      pathLen: 0x02,
+      txtType: TxtTypes.Plain,
+    });
+    const room = events.find((e) => e.event_type === 'room_message');
+    expect(room).toBeDefined();
+    const dm = events.find((e) => e.event_type === 'contact_message');
+    expect(dm).toBeDefined();
+    expect(dm.data.snr).toBeUndefined();
+    expect(dm.data.path_hops).toBeUndefined();
   });
 });

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -217,7 +217,21 @@ export class MeshCoreNativeBackend extends EventEmitter {
    * (it only appears on LogRxData, not on the txt-msg recv event) so the
    * message event — and {SNR} in auto-ack/auto-responder templates — has it.
    */
-  private pendingTxtMsgPath: { hops: string[]; rawPathLen: number; snr?: number } | null = null;
+  private pendingTxtMsgPath: { hops: string[]; rawPathLen: number; snr?: number; bufferedAt: number } | null = null;
+
+  /**
+   * Maximum age (ms) of a buffered LogRxData path before we treat it as stale
+   * and refuse to attach it to a message-recv event. LogRxData is emitted by
+   * the firmware immediately before the matching txt-msg recv for the SAME
+   * packet, so the correlated recv lands within the same I/O tick (sub-ms). A
+   * buffer older than this window almost certainly belongs to a *different*
+   * packet whose recv event never arrived (e.g. a non-TXT packet, or a
+   * LogRxData with no following recv), so consuming it would attach the wrong
+   * SNR/route to {SNR}/{ROUTE}. 500ms is generous enough to absorb event-loop
+   * scheduling jitter while still rejecting genuinely stale buffers — this is
+   * a core guard against the intermittent mis-correlation in issue #3589.
+   */
+  private static readonly PENDING_PATH_MAX_AGE_MS = 500;
   /** Constructor reference for the meshcore.js Packet parser, populated when the module loads. */
   private PacketCtor: MeshCoreJsModule['Packet'] | null = null;
   /**
@@ -334,6 +348,47 @@ export class MeshCoreNativeBackend extends EventEmitter {
     return hops;
   }
 
+  /**
+   * Consume the LogRxData path/SNR buffered by the preceding push event,
+   * correlating it to the current message-recv event so {SNR}/{ROUTE} only
+   * populate from the *matching* packet (issue #3589).
+   *
+   * The buffer is ALWAYS cleared (single-slot, consume-once) so a later recv
+   * that got no LogRxData of its own can't reuse a stale buffer. Two guards
+   * decide whether the buffered data is actually attached:
+   *
+   *  1. Freshness — the buffer must be younger than `PENDING_PATH_MAX_AGE_MS`.
+   *     LogRxData fires immediately before its txt-msg recv on the same tick;
+   *     an older buffer belongs to a packet whose recv never arrived.
+   *  2. pathLen correlation — when the recv event carries its own packed
+   *     `pathLen` byte, it must equal the buffered packet's `rawPathLen`.
+   *     They are the same wire byte for the same packet, so a mismatch proves
+   *     the buffer is from a *different* packet and must not be attached.
+   *
+   * Returns `{ hops, snr }` to attach, or `undefined` when the buffer is
+   * absent, stale, or for a different packet.
+   */
+  private consumePendingPath(msgPathLen: unknown): { hops: string[]; snr?: number } | undefined {
+    const buffered = this.pendingTxtMsgPath;
+    // Consume-once: clear regardless of whether we end up attaching it.
+    this.pendingTxtMsgPath = null;
+    if (!buffered) return undefined;
+
+    if (Date.now() - buffered.bufferedAt > MeshCoreNativeBackend.PENDING_PATH_MAX_AGE_MS) {
+      // Stale buffer — its matching recv never arrived. Don't mis-attach.
+      return undefined;
+    }
+    if (
+      typeof msgPathLen === 'number' &&
+      typeof buffered.rawPathLen === 'number' &&
+      msgPathLen !== buffered.rawPathLen
+    ) {
+      // Buffer is from a different packet (packed pathLen bytes differ).
+      return undefined;
+    }
+    return { hops: buffered.hops, snr: buffered.snr };
+  }
+
   private wirePushEvents(): void {
     if (!this.connection || !this.constants) return;
     const { PushCodes, ResponseCodes } = this.constants;
@@ -369,8 +424,10 @@ export class MeshCoreNativeBackend extends EventEmitter {
           const rssi = typeof rx?.lastRssi === 'number' ? rx.lastRssi : undefined;
 
           // Buffer the relay-hash chain + SNR for the next TXT_MSG recv event.
+          // `bufferedAt` lets the recv handler reject a stale buffer whose
+          // matching recv never arrived (issue #3589 mis-correlation guard).
           if (pkt.payload_type === TXT_MSG) {
-            this.pendingTxtMsgPath = { hops, rawPathLen: pkt.pathLen, snr };
+            this.pendingTxtMsgPath = { hops, rawPathLen: pkt.pathLen, snr, bufferedAt: Date.now() };
           }
           this.emitBridgeEvent('ota_packet', {
             payload_type: pkt.payload_type,
@@ -409,6 +466,13 @@ export class MeshCoreNativeBackend extends EventEmitter {
         // SignedPlain: room server post. The first 4 bytes of the text body
         // are the original author's public-key prefix (raw binary); the
         // remainder is the post text.
+        //
+        // A room post is still a TXT_MSG on the wire, so the preceding
+        // LogRxData buffered a path for it. Consume (and discard) it here so
+        // the room post's own buffer can't leak onto the NEXT contact/channel
+        // message — that leak attached a stale SNR/route to an unrelated
+        // message (part of issue #3589). We don't surface SNR on room posts.
+        this.consumePendingPath(msg.pathLen);
         const rawText: string = msg.text ?? '';
         const authorPrefixHex = Array.from(rawText.substring(0, 4))
           .map((ch: string) => ch.charCodeAt(0).toString(16).padStart(2, '0'))
@@ -425,11 +489,10 @@ export class MeshCoreNativeBackend extends EventEmitter {
         return;
       }
 
-      // Consume the path buffered by the preceding LogRxData event (if any).
-      // Same-tick consumption: clear the buffer so a subsequent recv that
-      // didn't get a matching LogRxData (rare) doesn't reuse stale hops.
-      const consumedPath = this.pendingTxtMsgPath;
-      this.pendingTxtMsgPath = null;
+      // Consume the path buffered by the preceding LogRxData event, correlated
+      // to THIS packet (freshness + pathLen match). Returns undefined when the
+      // buffer is absent, stale, or for a different packet (issue #3589).
+      const consumedPath = this.consumePendingPath(msg.pathLen);
       const payload = {
         pubkey_prefix: bytesToHex(msg.pubKeyPrefix),
         text: msg.text,
@@ -450,8 +513,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
 
     // ChannelMsgRecv → channel_message
     this.connection.on(ResponseCodes.ChannelMsgRecv, (msg: any) => {
-      const consumedPath = this.pendingTxtMsgPath;
-      this.pendingTxtMsgPath = null;
+      const consumedPath = this.consumePendingPath(msg.pathLen);
       this.emitBridgeEvent('channel_message', {
         channel_idx: msg.channelIdx,
         text: msg.text,


### PR DESCRIPTION
## Problem

`{SNR}` and `{ROUTE}` in MeshCore companion auto-acknowledge templates were **intermittently empty** for both DMs and channel messages (issue #3589) — direct-hop messages dropped `{SNR}`, multi-hop dropped both, with no apparent pattern.

## Root cause

The per-packet **SNR** and the **relay-hash chain** are *not* delivered on the MeshCore `ContactMsgRecv` / `ChannelMsgRecv` events (confirmed in `meshcore.js`: those events only carry `pathLen`, no SNR, no hashes). They arrive on a **separate `LogRxData` push**, which the firmware emits immediately before the matching txt-msg recv. The backend buffered that data in a single slot (`pendingTxtMsgPath`) and consumed it on the next recv.

That single-slot correlation was fragile and produced the intermittent loss:

1. **Room-post buffer leak** — a room post is also a `TXT_MSG`, so the preceding `LogRxData` buffered a path for it, but the room-post handler `return`ed early **without consuming** the buffer. The stale SNR/route then leaked onto the *next* unrelated DM/channel message.
2. **Stale / mis-correlated buffer** — when a packet's `LogRxData` fired but its recv never arrived (a non-TXT packet, or raw logging gaps), the buffer lingered and could be attached to a later, unrelated message.

## Fix

Introduce a shared `consumePendingPath(msgPathLen)` helper used by both recv handlers and the room-post path. It always clears the buffer (consume-once) and attaches the buffered SNR/hops only when **both** guards pass:

1. **Freshness** — buffer must be younger than `PENDING_PATH_MAX_AGE_MS` (500 ms). `LogRxData` and its matching recv land on the same I/O tick; an older buffer belongs to a packet whose recv never arrived.
2. **pathLen correlation** — the recv's packed `pathLen` byte must equal the buffered packet's `rawPathLen` (same wire byte for the same packet); a mismatch proves it's a different packet.

When the data genuinely isn't present, the tokens degrade as before (`{SNR}` → `—`, `{ROUTE}` → `direct`/`—`), but they no longer get a *wrong* value from an unrelated packet, and the leak that silently blanked them is eliminated.

## Tests

Added to `meshcoreNativeBackend.otaPacket.test.ts`:
- buffered path **not** attached when recv `pathLen` differs (different packet)
- stale buffer (past the freshness window) **not** attached (fake timers)
- consume-once: a second recv with no `LogRxData` gets nothing
- room post consumes/discards its buffer so it can't leak onto the next message

Existing SNR/path correlation tests still pass.

## Verification

- Full Vitest suite: **7600 total, 7016 passed, 0 failed, 0 failed suites** (`success: true`)
- `tsc --noEmit`: no new errors introduced (pre-existing repo-wide frontend errors unchanged at 61)
- Changed files add no new lint findings

Closes #3589

🤖 Generated with [Claude Code](https://claude.com/claude-code)