### PR TITLE
fix: return 503 when Meshtastic node is not connected (traceroute and mesh requests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Mesh request endpoints return 503 (not a generic 500) when the node is disconnected (#3596)**: `/api/traceroute`, `/api/position/request`, `/api/nodeinfo/request`, `/api/neighborinfo/request`, and `/api/telemetry/request` previously re-emitted a `"Not connected to Meshtastic node"` failure as an opaque `500 { error: 'Failed to send …' }`, so the UI couldn't tell the user what was wrong. They now return **503** with the v1-API error shape (`{ success: false, error: 'Service Unavailable', message: 'Not connected to Meshtastic node' }`), and the `api.ts` callers surface the specific `message`.
+
 ## [4.11.2] - 2026-06-20
 
 ### Bug Fixes

--- a/src/server/routes/meshRequestRoutes.test.ts
+++ b/src/server/routes/meshRequestRoutes.test.ts
@@ -77,7 +77,9 @@ describe('POST /traceroute', () => {
     mockManager.sendTraceroute.mockRejectedValue(new Error('Not connected to Meshtastic node'));
     const res = await request(app).post('/traceroute').send({ destination: '!12345678' });
     expect(res.status).toBe(503);
-    expect(res.body.error).toContain('Not connected');
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Service Unavailable');
+    expect(res.body.message).toContain('Not connected');
   });
 });
 
@@ -99,7 +101,9 @@ describe('POST /position/request', () => {
     mockManager.sendPositionRequest.mockRejectedValue(new Error('Not connected to Meshtastic node'));
     const res = await request(app).post('/position/request').send({ destination: '!12345678' });
     expect(res.status).toBe(503);
-    expect(res.body.error).toContain('Not connected');
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Service Unavailable');
+    expect(res.body.message).toContain('Not connected');
   });
 });
 
@@ -110,6 +114,15 @@ describe('POST /nodeinfo/request', () => {
     expect(res.status).toBe(200);
     expect(mockManager.sendNodeInfoRequest).toHaveBeenCalledWith(0x12345678, 2);
     expect(databaseService.messages.insertMessage).toHaveBeenCalled();
+  });
+
+  it('returns 503 when node is not connected', async () => {
+    mockManager.sendNodeInfoRequest.mockRejectedValue(new Error('Not connected to Meshtastic node'));
+    const res = await request(app).post('/nodeinfo/request').send({ destination: '!12345678' });
+    expect(res.status).toBe(503);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Service Unavailable');
+    expect(res.body.message).toContain('Not connected');
   });
 });
 
@@ -144,6 +157,19 @@ describe('POST /neighborinfo/request', () => {
     expect(res.status).toBe(429);
     expect(res.body.retryAfter).toBeGreaterThan(0);
   });
+
+  it('returns 503 when node is not connected (after eligibility passes)', async () => {
+    // Unique destination so the module-level rate-limit map doesn't bleed across tests.
+    (parseDestinationNum as any).mockResolvedValue(0x0000cccc);
+    mockManager.getLocalNodeInfo.mockReturnValue({ nodeNum: 1, nodeId: '!00000001' });
+    (databaseService.nodes.getNode as any).mockResolvedValue({ channel: 1, hopsAway: 0 });
+    mockManager.sendNeighborInfoRequest.mockRejectedValue(new Error('Not connected to Meshtastic node'));
+    const res = await request(app).post('/neighborinfo/request').send({ destination: '!0000cccc' });
+    expect(res.status).toBe(503);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Service Unavailable');
+    expect(res.body.message).toContain('Not connected');
+  });
 });
 
 describe('POST /telemetry/request', () => {
@@ -173,5 +199,14 @@ describe('POST /telemetry/request', () => {
     mockManager.sendTelemetryRequest.mockResolvedValue({ packetId: 1, requestId: 2 });
     await request(app).post('/telemetry/request').send({ destination: '!12345678', telemetryType: 'device' });
     expect(mockManager.sendTelemetryRequest).toHaveBeenCalledWith(0x12345678, 0, 'device');
+  });
+
+  it('returns 503 when node is not connected', async () => {
+    mockManager.sendTelemetryRequest.mockRejectedValue(new Error('Not connected to Meshtastic node'));
+    const res = await request(app).post('/telemetry/request').send({ destination: '!12345678', telemetryType: 'environment' });
+    expect(res.status).toBe(503);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Service Unavailable');
+    expect(res.body.message).toContain('Not connected');
   });
 });

--- a/src/server/routes/meshRequestRoutes.test.ts
+++ b/src/server/routes/meshRequestRoutes.test.ts
@@ -72,6 +72,13 @@ describe('POST /traceroute', () => {
     expect(res.body.success).toBe(true);
     expect(mockManager.sendTraceroute).toHaveBeenCalledWith(0x12345678, 2);
   });
+
+  it('returns 503 when node is not connected', async () => {
+    mockManager.sendTraceroute.mockRejectedValue(new Error('Not connected to Meshtastic node'));
+    const res = await request(app).post('/traceroute').send({ destination: '!12345678' });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toContain('Not connected');
+  });
 });
 
 describe('POST /position/request', () => {
@@ -86,6 +93,13 @@ describe('POST /position/request', () => {
   it('returns 400 when destination missing', async () => {
     const res = await request(app).post('/position/request').send({});
     expect(res.status).toBe(400);
+  });
+
+  it('returns 503 when node is not connected', async () => {
+    mockManager.sendPositionRequest.mockRejectedValue(new Error('Not connected to Meshtastic node'));
+    const res = await request(app).post('/position/request').send({ destination: '!12345678' });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toContain('Not connected');
   });
 });
 

--- a/src/server/routes/meshRequestRoutes.ts
+++ b/src/server/routes/meshRequestRoutes.ts
@@ -30,8 +30,11 @@ router.post('/traceroute', requirePermission('traceroute', 'write'), async (req:
       success: true,
       message: `Traceroute request sent to ${destinationNum.toString(16)} on channel ${channel}`,
     });
-  } catch (error) {
+  } catch (error: any) {
     logger.error('Error sending traceroute:', error);
+    if (error?.message?.includes('Not connected')) {
+      return res.status(503).json({ error: 'Not connected to Meshtastic node' });
+    }
     res.status(500).json({ error: 'Failed to send traceroute' });
   }
 });
@@ -102,8 +105,11 @@ router.post('/position/request', requirePermission('messages', 'write'), async (
       success: true,
       message: `Position request sent to ${destinationNum.toString(16)} on channel ${channel}`,
     });
-  } catch (error) {
+  } catch (error: any) {
     logger.error('Error sending position request:', error);
+    if (error?.message?.includes('Not connected')) {
+      return res.status(503).json({ error: 'Not connected to Meshtastic node' });
+    }
     res.status(500).json({ error: 'Failed to send position request' });
   }
 });
@@ -170,8 +176,11 @@ router.post('/nodeinfo/request', requirePermission('messages', 'write'), async (
       success: true,
       message: `NodeInfo request sent to ${destinationNum.toString(16)} on channel ${channel}`,
     });
-  } catch (error) {
+  } catch (error: any) {
     logger.error('Error sending nodeinfo request:', error);
+    if (error?.message?.includes('Not connected')) {
+      return res.status(503).json({ error: 'Not connected to Meshtastic node' });
+    }
     res.status(500).json({ error: 'Failed to send nodeinfo request' });
   }
 });
@@ -242,8 +251,11 @@ router.post('/neighborinfo/request', requirePermission('traceroute', 'write'), a
       packetId,
       requestId
     });
-  } catch (error) {
+  } catch (error: any) {
     logger.error('Error sending neighborinfo request:', error);
+    if (error?.message?.includes('Not connected')) {
+      return res.status(503).json({ error: 'Not connected to Meshtastic node' });
+    }
     res.status(500).json({ error: 'Failed to send neighborinfo request' });
   }
 });
@@ -289,8 +301,11 @@ router.post('/telemetry/request', requirePermission('messages', 'write'), async 
       packetId,
       requestId
     });
-  } catch (error) {
+  } catch (error: any) {
     logger.error('Error sending telemetry request:', error);
+    if (error?.message?.includes('Not connected')) {
+      return res.status(503).json({ error: 'Not connected to Meshtastic node' });
+    }
     res.status(500).json({ error: 'Failed to send telemetry request' });
   }
 });

--- a/src/server/routes/meshRequestRoutes.ts
+++ b/src/server/routes/meshRequestRoutes.ts
@@ -33,7 +33,11 @@ router.post('/traceroute', requirePermission('traceroute', 'write'), async (req:
   } catch (error: any) {
     logger.error('Error sending traceroute:', error);
     if (error?.message?.includes('Not connected')) {
-      return res.status(503).json({ error: 'Not connected to Meshtastic node' });
+      return res.status(503).json({
+        success: false,
+        error: 'Service Unavailable',
+        message: 'Not connected to Meshtastic node',
+      });
     }
     res.status(500).json({ error: 'Failed to send traceroute' });
   }
@@ -108,7 +112,11 @@ router.post('/position/request', requirePermission('messages', 'write'), async (
   } catch (error: any) {
     logger.error('Error sending position request:', error);
     if (error?.message?.includes('Not connected')) {
-      return res.status(503).json({ error: 'Not connected to Meshtastic node' });
+      return res.status(503).json({
+        success: false,
+        error: 'Service Unavailable',
+        message: 'Not connected to Meshtastic node',
+      });
     }
     res.status(500).json({ error: 'Failed to send position request' });
   }
@@ -179,7 +187,11 @@ router.post('/nodeinfo/request', requirePermission('messages', 'write'), async (
   } catch (error: any) {
     logger.error('Error sending nodeinfo request:', error);
     if (error?.message?.includes('Not connected')) {
-      return res.status(503).json({ error: 'Not connected to Meshtastic node' });
+      return res.status(503).json({
+        success: false,
+        error: 'Service Unavailable',
+        message: 'Not connected to Meshtastic node',
+      });
     }
     res.status(500).json({ error: 'Failed to send nodeinfo request' });
   }
@@ -254,7 +266,11 @@ router.post('/neighborinfo/request', requirePermission('traceroute', 'write'), a
   } catch (error: any) {
     logger.error('Error sending neighborinfo request:', error);
     if (error?.message?.includes('Not connected')) {
-      return res.status(503).json({ error: 'Not connected to Meshtastic node' });
+      return res.status(503).json({
+        success: false,
+        error: 'Service Unavailable',
+        message: 'Not connected to Meshtastic node',
+      });
     }
     res.status(500).json({ error: 'Failed to send neighborinfo request' });
   }
@@ -304,7 +320,11 @@ router.post('/telemetry/request', requirePermission('messages', 'write'), async 
   } catch (error: any) {
     logger.error('Error sending telemetry request:', error);
     if (error?.message?.includes('Not connected')) {
-      return res.status(503).json({ error: 'Not connected to Meshtastic node' });
+      return res.status(503).json({
+        success: false,
+        error: 'Service Unavailable',
+        message: 'Not connected to Meshtastic node',
+      });
     }
     res.status(500).json({ error: 'Failed to send telemetry request' });
   }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -699,7 +699,9 @@ class ApiService {
 
     if (!response.ok) {
       const error = await response.json();
-      throw new Error(error.error || 'Failed to send traceroute');
+      // Prefer the specific `message` (e.g. "Not connected to Meshtastic node")
+      // over the generic `error` status reason, matching the v1 API error shape.
+      throw new Error(error.message || error.error || 'Failed to send traceroute');
     }
 
     return response.json();
@@ -722,7 +724,7 @@ class ApiService {
 
     if (!response.ok) {
       const error = await response.json();
-      throw new Error(error.error || 'Failed to request position');
+      throw new Error(error.message || error.error || 'Failed to request position');
     }
 
     return response.json();


### PR DESCRIPTION
## Summary

Fixes #3596

When the Meshtastic node is disconnected, `sendTraceroute` (and all other `meshRequestRoutes` handlers) threw `Error: Not connected to Meshtastic node` which was caught and blindly re-emitted as a generic `500 { error: 'Failed to send traceroute' }`. The frontend had no way to tell the user what actually went wrong.

- Detect `"Not connected"` errors in the catch block of all five route handlers (`/traceroute`, `/position/request`, `/nodeinfo/request`, `/neighborinfo/request`, `/telemetry/request`) and return **503** with the message `"Not connected to Meshtastic node"` — matching the pattern already used in `src/server/routes/v1/messages.ts`.
- Added two regression tests (traceroute and position request) that verify the 503 response.

## Test plan

- [ ] Existing 13 tests in `meshRequestRoutes.test.ts` still pass
- [ ] Two new 503 tests pass
- [ ] Manually: disconnect the Meshtastic source, attempt a traceroute — UI should now see a 503 with a clear "not connected" message instead of a generic error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3W1sLHSwNrrUzDQutFnyy

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3W1sLHSwNrrUzDQutFnyy)_