### PR TITLE
fix(channels): stop proto3 boolean elision re-enabling uplink/downlink (#3594)

### DIFF
--- a/src/db/repositories/channels.ts
+++ b/src/db/repositories/channels.ts
@@ -172,8 +172,12 @@ export class ChannelsRepository extends BaseRepository {
         name: data.name,
         psk: data.psk ?? null,
         role: data.role ?? null,
-        uplinkEnabled: data.uplinkEnabled ?? true,
-        downlinkEnabled: data.downlinkEnabled ?? true,
+        // proto3 elides boolean `false` (the zero value), so an absent
+        // uplink/downlink must reconstruct to `false`, matching the Meshtastic
+        // ChannelSettings proto where both default to false (#3594). The update
+        // branch above preserves the existing stored value instead.
+        uplinkEnabled: data.uplinkEnabled ?? false,
+        downlinkEnabled: data.downlinkEnabled ?? false,
         positionPrecision: data.positionPrecision ?? null,
         createdAt: now,
         updatedAt: now,

--- a/src/server/meshtasticManager.channelProto3Elision.test.ts
+++ b/src/server/meshtasticManager.channelProto3Elision.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ─── Mocks (must be defined before importing meshtasticManager) ──────────────
+//
+// Regression test for #3594: proto3 boolean elision in processChannelProtobuf.
+//
+// proto3 omits boolean `false` on the wire (it's the zero/default value). When
+// the device streams its channel config on reconnect, a user-disabled
+// `downlink_enabled`/`uplink_enabled` arrives DECODED AS `undefined` (per the
+// repo's "protobuf.js decoded-message shape" gotcha — an unset scalar reads as
+// null/undefined, not the proto default). The old `?? true` fallback then
+// incorrectly stored `true`, silently re-enabling the setting after a container
+// restart. Both fields default to `false` in the Meshtastic ChannelSettings
+// proto, so the correct reconstruction of an absent value is `false`.
+
+const mockUpsertChannel = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    getSetting: vi.fn().mockResolvedValue(null),
+    setSetting: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+      getSettingForSource: vi.fn().mockResolvedValue(null),
+      setSourceSetting: vi.fn().mockResolvedValue(undefined),
+      getAllSettings: vi.fn().mockResolvedValue({}),
+      setSettings: vi.fn().mockResolvedValue(undefined),
+    },
+    channels: {
+      getChannelById: vi.fn().mockResolvedValue(null),
+      getAllChannels: vi.fn().mockResolvedValue([]),
+      upsertChannel: mockUpsertChannel,
+      getChannelCount: vi.fn().mockResolvedValue(0),
+    },
+  },
+}));
+
+vi.mock('./meshtasticProtobufService.js', () => ({
+  default: { initialize: vi.fn(), createMeshPacket: vi.fn() },
+}));
+
+vi.mock('./protobufService.js', () => ({
+  default: { encode: vi.fn(), decode: vi.fn() },
+  convertIpv4ConfigToStrings: vi.fn(),
+}));
+
+vi.mock('./protobufLoader.js', () => ({ getProtobufRoot: vi.fn() }));
+
+vi.mock('./tcpTransport.js', () => ({ TcpTransport: vi.fn() }));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('./services/notificationService.js', () => ({
+  notificationService: { checkAndSendNotifications: vi.fn() },
+}));
+
+vi.mock('./services/serverEventNotificationService.js', () => ({
+  serverEventNotificationService: {
+    notifyNodeConnected: vi.fn(),
+    notifyNodeDisconnected: vi.fn(),
+  },
+}));
+
+vi.mock('./services/packetLogService.js', () => ({
+  default: { logPacket: vi.fn() },
+}));
+
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: { tryDecrypt: vi.fn() },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: { emit: vi.fn(), on: vi.fn() },
+}));
+
+vi.mock('./messageQueueService.js', () => {
+  const mockInstance = {
+    enqueue: vi.fn(),
+    setSendCallback: vi.fn(),
+    handleAck: vi.fn(),
+    handleFailure: vi.fn(),
+    recordExternalSend: vi.fn(),
+    clear: vi.fn(),
+    getStatus: vi.fn(() => ({ queueLength: 0, pendingAcks: 0, processing: false })),
+  };
+  function MessageQueueService() { return mockInstance as any; }
+  return { messageQueueService: mockInstance, MessageQueueService };
+});
+
+vi.mock('./utils/cronScheduler.js', () => ({
+  validateCron: vi.fn(() => true),
+  scheduleCron: vi.fn(() => ({ stop: vi.fn() })),
+}));
+
+vi.mock('./config/environment.js', () => ({
+  getEnvironmentConfig: vi.fn(() => ({ NODE_IP: '127.0.0.1', TCP_PORT: 4403, LOG_LEVEL: 'info' })),
+}));
+
+vi.mock('../utils/autoResponderUtils.js', () => ({ normalizeTriggerPatterns: vi.fn() }));
+
+vi.mock('../utils/nodeHelpers.js', () => ({ isNodeComplete: vi.fn() }));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+const SOURCE = 'default';
+
+describe('MeshtasticManager - processChannelProtobuf proto3 boolean elision (#3594)', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module = await import('./meshtasticManager.js');
+    manager = module.default;
+    manager.sourceId = SOURCE;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('stores downlinkEnabled=false when the field is elided (undefined) on the wire', async () => {
+    // Simulates a secondary channel whose user disabled "Downlink Enabled".
+    // proto3 elides the false value, so the decoded message has no downlinkEnabled.
+    const channel = {
+      index: 1,
+      role: 2, // SECONDARY
+      settings: {
+        name: 'gauntlet',
+        psk: Buffer.from('0123456789abcdef'),
+        // uplinkEnabled present + true; downlinkEnabled elided (was false)
+        uplinkEnabled: true,
+        // downlinkEnabled: <absent>
+      },
+    };
+
+    await manager.processChannelProtobuf(channel);
+
+    expect(mockUpsertChannel).toHaveBeenCalledTimes(1);
+    const [stored] = mockUpsertChannel.mock.calls[0];
+    expect(stored.downlinkEnabled).toBe(false);
+    // Bug would have stored true via `?? true`.
+    expect(stored.downlinkEnabled).not.toBe(true);
+  });
+
+  it('stores uplinkEnabled=false when the field is elided (undefined) on the wire', async () => {
+    const channel = {
+      index: 2,
+      role: 2,
+      settings: {
+        name: 'private',
+        psk: Buffer.from('fedcba9876543210'),
+        // uplinkEnabled elided (was false); downlinkEnabled present + true
+        downlinkEnabled: true,
+      },
+    };
+
+    await manager.processChannelProtobuf(channel);
+
+    expect(mockUpsertChannel).toHaveBeenCalledTimes(1);
+    const [stored] = mockUpsertChannel.mock.calls[0];
+    expect(stored.uplinkEnabled).toBe(false);
+    expect(stored.uplinkEnabled).not.toBe(true);
+  });
+
+  it('stores both as false when both booleans are elided', async () => {
+    const channel = {
+      index: 3,
+      role: 2,
+      settings: {
+        name: 'quiet',
+        psk: Buffer.from('00112233445566778899aabbccddeeff', 'hex'),
+        // both elided
+      },
+    };
+
+    await manager.processChannelProtobuf(channel);
+
+    expect(mockUpsertChannel).toHaveBeenCalledTimes(1);
+    const [stored] = mockUpsertChannel.mock.calls[0];
+    expect(stored.uplinkEnabled).toBe(false);
+    expect(stored.downlinkEnabled).toBe(false);
+  });
+
+  it('preserves an explicitly-true value (no false-positive regression)', async () => {
+    const channel = {
+      index: 4,
+      role: 2,
+      settings: {
+        name: 'public',
+        psk: Buffer.from('00112233445566778899aabbccddeeff', 'hex'),
+        uplinkEnabled: true,
+        downlinkEnabled: true,
+      },
+    };
+
+    await manager.processChannelProtobuf(channel);
+
+    expect(mockUpsertChannel).toHaveBeenCalledTimes(1);
+    const [stored] = mockUpsertChannel.mock.calls[0];
+    expect(stored.uplinkEnabled).toBe(true);
+    expect(stored.downlinkEnabled).toBe(true);
+  });
+
+  it('preserves an explicit false value verbatim', async () => {
+    const channel = {
+      index: 5,
+      role: 2,
+      settings: {
+        name: 'explicit',
+        psk: Buffer.from('00112233445566778899aabbccddeeff', 'hex'),
+        uplinkEnabled: false,
+        downlinkEnabled: false,
+      },
+    };
+
+    await manager.processChannelProtobuf(channel);
+
+    expect(mockUpsertChannel).toHaveBeenCalledTimes(1);
+    const [stored] = mockUpsertChannel.mock.calls[0];
+    expect(stored.uplinkEnabled).toBe(false);
+    expect(stored.downlinkEnabled).toBe(false);
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5081,8 +5081,15 @@ class MeshtasticManager implements ISourceManager {
             name: channelName,
             psk: pskString,
             role: channelRole,
-            uplinkEnabled: channel.settings.uplinkEnabled ?? true,
-            downlinkEnabled: channel.settings.downlinkEnabled ?? true,
+            // proto3 elides boolean `false` on the wire (it's the zero value), so a
+            // disabled uplink/downlink arrives as undefined when the device streams
+            // its channel config on reconnect. `uplink_enabled`/`downlink_enabled`
+            // both default to false in the Meshtastic ChannelSettings proto, so the
+            // correct reconstruction of an absent value is `false`, not `true`.
+            // Defaulting to `true` here silently re-enabled a user-disabled downlink
+            // after a container restart (#3594).
+            uplinkEnabled: channel.settings.uplinkEnabled ?? false,
+            downlinkEnabled: channel.settings.downlinkEnabled ?? false,
             positionPrecision: positionPrecision !== undefined ? positionPrecision : undefined
           }, this.sourceId);
           logger.debug(`📡 Saved channel: ${displayName} (role: ${channel.role}, index: ${channel.index}, psk: ${pskString ? 'set' : 'none'}, uplink: ${channel.settings.uplinkEnabled}, downlink: ${channel.settings.downlinkEnabled}, positionPrecision: ${positionPrecision})`);


### PR DESCRIPTION
## Problem

When a user disables **Downlink Enabled** (or **Uplink Enabled**) on a secondary channel, the change saves (success toast, JSON export confirms `"downlinkEnabled": false`), but after restarting the MeshMonitor container the setting reverts to `true`.

## Root cause

proto3 omits boolean `false` on the wire — it's the zero/default value. When the device streams its channel config on reconnect, `processChannelProtobuf()` in `src/server/meshtasticManager.ts` decodes a user-disabled `downlink_enabled`/`uplink_enabled` as `undefined` (consistent with the repo's known "protobuf.js decoded-message shape" gotcha: an unset scalar reads as null/undefined, not the proto default).

The old `?? true` fallback then coerced that `undefined` to `true` **before** it reached the repository, overwriting the user's saved setting. Both `uplink_enabled` and `downlink_enabled` are plain `bool` in the Meshtastic `ChannelSettings` proto and default to **false**, so the correct reconstruction of an absent value is `false`.

## Fix

- **`processChannelProtobuf()`** (the actual bug): `?? true` → `?? false` for both `uplinkEnabled` and `downlinkEnabled`.
- **`ChannelsRepository.upsertChannel()` INSERT branch**: `?? true` → `?? false` for both fields, to match proto3 semantics for any caller that passes `undefined`.
- **UPDATE branch left untouched**: it already coalesces to the existing stored value (`?? existingChannel.X`), which is correct for an absent field on an already-known channel — changing it would have re-introduced data loss.

### Fields deliberately left alone
- `buildDeviceConfigFromActual()` reads `ch.uplinkEnabled`/`ch.downlinkEnabled` from the DB (not the protobuf decode path) — no elision risk.
- The hardcoded `{ uplinkEnabled: true, downlinkEnabled: true }` Primary-channel display fallback (used only when no channels exist) is a legitimate UI default, not a decode default.
- The user-save route (`channelRoutes.ts`) passes the boolean explicitly (or `existingChannel?.X ?? null`), so saves already worked; this PR fixes only the device-reconnect ingest path.

## Tests

Added `src/server/meshtasticManager.channelProto3Elision.test.ts` (5 cases): drives `processChannelProtobuf` with elided and explicit booleans and asserts the value handed to `upsertChannel` is `false` when elided and preserved verbatim when explicit. Verified the test **fails** against the pre-fix `?? true` code.

- Full Vitest suite: `success=true`, 0 failed suites, 0 failed tests (7017 passed).
- `tsc -p tsconfig.server.json --noEmit`: no new errors (the 5 reported are pre-existing `TelemetryChart.tsx` frontend issues, untouched here).

Closes #3594

🤖 Generated with [Claude Code](https://claude.com/claude-code)