### PR TITLE
feat(lora): surface FEM LNA Mode config on Device Config + Remote Admin (#3599)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3192,6 +3192,8 @@
   "lora_config.tx_power_description": "LoRa transmit power in dBm. A value of 0 uses the default maximum safe power for your hardware. Negative values are permitted (the field is signed) but only meaningful on radios that support reduced/negative output power, e.g. SX126x; firmware does not clamp the lower bound, so behavior for negatives is radio-dependent.",
   "lora_config.channel_num": "Channel Number",
   "lora_config.channel_num_description": "LoRa channel number for frequency hopping. Range: 0-255 (default: 0)",
+  "lora_config.fem_lna_mode": "FEM LNA Mode",
+  "lora_config.fem_lna_mode_description": "Front-End Module (FEM) Low Noise Amplifier (LNA) mode for amplified boards with an external LNA (e.g. certain RAK modules). Requires firmware v2.7.20 or later; leave DISABLED on hardware without an external LNA.",
   "lora_config.rx_boosted_gain": "RX Boosted Gain (SX126x)",
   "lora_config.rx_boosted_gain_description": "Enable boosted receive gain for SX126x radios (improves sensitivity but increases power consumption)",
   "lora_config.ignore_mqtt": "Ignore MQTT",

--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import apiService from '../services/api';
 import { useToast } from './ToastContainer';
 import { useSource } from '../contexts/SourceContext';
-import { MODEM_PRESET_OPTIONS, REGION_OPTIONS } from './configuration/constants';
+import { MODEM_PRESET_OPTIONS, REGION_OPTIONS, FEM_LNA_MODE_OPTIONS } from './configuration/constants';
 import type { Channel } from '../types/device';
 import { ImportConfigModal } from './configuration/ImportConfigModal';
 import { ExportConfigModal } from './configuration/ExportConfigModal';
@@ -492,6 +492,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
           hopLimit: config.hopLimit,
           txPower: config.txPower,
           channelNum: config.channelNum,
+          // FEM_LNA_Mode: proto3 elides the zero value, so default undefined to 0 (DISABLED)
+          femLnaMode: config.femLnaMode ?? 0,
           sx126xRxBoostedGain: config.sx126xRxBoostedGain,
           ignoreMqtt: config.ignoreMqtt,
           configOkToMqtt: config.configOkToMqtt,
@@ -1046,6 +1048,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                   hopLimit: config.hopLimit,
                   txPower: config.txPower,
                   channelNum: config.channelNum,
+                  // FEM_LNA_Mode: proto3 elides the zero value, so default undefined to 0 (DISABLED)
+                  femLnaMode: config.femLnaMode ?? 0,
                   sx126xRxBoostedGain: config.sx126xRxBoostedGain,
                   ignoreMqtt: config.ignoreMqtt,
                   configOkToMqtt: config.configOkToMqtt,
@@ -1638,6 +1642,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       hopLimit: validHopLimit,
       txPower: configState.lora.txPower,
       channelNum: configState.lora.channelNum,
+      femLnaMode: configState.lora.femLnaMode,
       sx126xRxBoostedGain: configState.lora.sx126xRxBoostedGain,
       ignoreMqtt: configState.lora.ignoreMqtt,
       configOkToMqtt: configState.lora.configOkToMqtt,
@@ -2730,6 +2735,26 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             className="setting-input"
             style={{ width: '200px' }}
           />
+        </div>
+        <div className="setting-item">
+          <label htmlFor="adminFemLnaMode">
+            FEM LNA Mode
+            <span className="setting-description">Front-End Module (FEM) Low Noise Amplifier (LNA) mode for amplified boards with an external LNA. Requires firmware v2.7.20 or later.</span>
+          </label>
+          <select
+            id="adminFemLnaMode"
+            value={configState.lora.femLnaMode}
+            onChange={(e) => setLoRaConfig({ femLnaMode: Number(e.target.value) })}
+            disabled={isExecuting}
+            className="setting-input"
+            style={{ width: '400px' }}
+          >
+            {FEM_LNA_MODE_OPTIONS.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
         </div>
         <div className="setting-item">
           <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>

--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -80,6 +80,8 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
   const [hopLimit, setHopLimit] = useState<number>(3);
   const [txPower, setTxPower] = useState<number>(0);
   const [channelNum, setChannelNum] = useState<number>(0);
+  // FEM_LNA_Mode enum (firmware >= v2.7.20): 0=DISABLED (proto3 zero/default), 1=ENABLED, 2=NOT_PRESENT
+  const [femLnaMode, setFemLnaMode] = useState<number>(0);
   const [sx126xRxBoostedGain, setSx126xRxBoostedGain] = useState<boolean>(false);
   const [ignoreMqtt, setIgnoreMqtt] = useState<boolean>(false);
   const [configOkToMqtt, setConfigOkToMqtt] = useState<boolean>(false);
@@ -406,6 +408,9 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
           }
           if (config.deviceConfig.lora.channelNum !== undefined) {
             setChannelNum(config.deviceConfig.lora.channelNum);
+          }
+          if (config.deviceConfig.lora.femLnaMode !== undefined) {
+            setFemLnaMode(config.deviceConfig.lora.femLnaMode);
           }
           if (config.deviceConfig.lora.sx126xRxBoostedGain !== undefined) {
             setSx126xRxBoostedGain(config.deviceConfig.lora.sx126xRxBoostedGain);
@@ -873,6 +878,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
         hopLimit: validHopLimit,
         txPower,
         channelNum,
+        femLnaMode,
         sx126xRxBoostedGain,
         ignoreMqtt,
         configOkToMqtt,
@@ -1626,6 +1632,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
         if (lora.frequencyOffset !== undefined) setFrequencyOffset(lora.frequencyOffset);
         if (lora.overrideFrequency !== undefined) setOverrideFrequency(lora.overrideFrequency);
         if (lora.channelNum !== undefined) setChannelNum(lora.channelNum);
+        if (lora.femLnaMode !== undefined) setFemLnaMode(lora.femLnaMode);
         if (lora.sx126xRxBoostedGain !== undefined) setSx126xRxBoostedGain(lora.sx126xRxBoostedGain);
         if (lora.ignoreMqtt !== undefined) setIgnoreMqtt(lora.ignoreMqtt);
         if (lora.configOkToMqtt !== undefined) setConfigOkToMqtt(lora.configOkToMqtt);
@@ -2113,6 +2120,8 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
             setTxPower={setTxPower}
             channelNum={channelNum}
             setChannelNum={setChannelNum}
+            femLnaMode={femLnaMode}
+            setFemLnaMode={setFemLnaMode}
             sx126xRxBoostedGain={sx126xRxBoostedGain}
             setSx126xRxBoostedGain={setSx126xRxBoostedGain}
             ignoreMqtt={ignoreMqtt}

--- a/src/components/admin-commands/useAdminCommandsState.ts
+++ b/src/components/admin-commands/useAdminCommandsState.ts
@@ -19,6 +19,7 @@ export interface LoRaConfigState {
   hopLimit: number;
   txPower: number;
   channelNum: number;
+  femLnaMode: number;
   sx126xRxBoostedGain: boolean;
   ignoreMqtt: boolean;
   configOkToMqtt: boolean;
@@ -215,6 +216,7 @@ const initialState: AdminCommandsState = {
     hopLimit: 3,
     txPower: 0,
     channelNum: 0,
+    femLnaMode: 0, // FEM_LNA_Mode DISABLED (proto3 zero/default; firmware >= v2.7.20)
     sx126xRxBoostedGain: false,
     ignoreMqtt: false,
     configOkToMqtt: false,

--- a/src/components/configuration/LoRaConfigSection.test.tsx
+++ b/src/components/configuration/LoRaConfigSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { MODEM_PRESET_OPTIONS } from './constants';
+import { MODEM_PRESET_OPTIONS, FEM_LNA_MODE_OPTIONS } from './constants';
 
 /**
  * LoRaConfigSection Tests
@@ -119,7 +119,42 @@ describe('LoRaConfigSection', () => {
     });
   });
 
+  describe('FEM LNA Mode Constants', () => {
+    it('exposes the three FEM_LNA_Mode enum values in order', () => {
+      expect(FEM_LNA_MODE_OPTIONS.map(o => o.value)).toEqual([0, 1, 2]);
+    });
+
+    it('uses DISABLED (0) as the proto3 zero/default option', () => {
+      expect(FEM_LNA_MODE_OPTIONS[0].value).toBe(0);
+      expect(FEM_LNA_MODE_OPTIONS[0].label).toMatch(/DISABLED/);
+    });
+
+    it('labels the ENABLED and NOT_PRESENT modes', () => {
+      expect(FEM_LNA_MODE_OPTIONS[1].value).toBe(1);
+      expect(FEM_LNA_MODE_OPTIONS[1].label).toMatch(/ENABLED/);
+      expect(FEM_LNA_MODE_OPTIONS[2].value).toBe(2);
+      expect(FEM_LNA_MODE_OPTIONS[2].label).toMatch(/NOT_PRESENT/);
+    });
+  });
+
   describe('Save Configuration Logic', () => {
+    it('includes femLnaMode in the LoRa save payload', () => {
+      // Mirrors the Device Configuration save (ConfigurationTab) and Remote Admin
+      // save (AdminCommandsTab.handleSetLoRaConfig), both of which now carry femLnaMode.
+      const config = {
+        usePreset: true,
+        modemPreset: 0,
+        region: 1,
+        hopLimit: 3,
+        channelNum: 0,
+        femLnaMode: 1,
+        sx126xRxBoostedGain: false
+      };
+
+      expect(config).toHaveProperty('femLnaMode');
+      expect(config.femLnaMode).toBe(1);
+    });
+
     it('should include all parameters when usePreset is false', () => {
       const config = {
         usePreset: false,

--- a/src/components/configuration/LoRaConfigSection.tsx
+++ b/src/components/configuration/LoRaConfigSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MODEM_PRESET_OPTIONS, REGION_OPTIONS } from './constants';
+import { MODEM_PRESET_OPTIONS, REGION_OPTIONS, FEM_LNA_MODE_OPTIONS } from './constants';
 import { useSaveBar } from '../../hooks/useSaveBar';
 
 interface LoRaConfigSectionProps {
@@ -15,6 +15,7 @@ interface LoRaConfigSectionProps {
   hopLimit: number;
   txPower: number;
   channelNum: number;
+  femLnaMode: number;
   sx126xRxBoostedGain: boolean;
   ignoreMqtt: boolean;
   configOkToMqtt: boolean;
@@ -32,6 +33,7 @@ interface LoRaConfigSectionProps {
   setHopLimit: (value: number) => void;
   setTxPower: (value: number) => void;
   setChannelNum: (value: number) => void;
+  setFemLnaMode: (value: number) => void;
   setSx126xRxBoostedGain: (value: boolean) => void;
   setIgnoreMqtt: (value: boolean) => void;
   setConfigOkToMqtt: (value: boolean) => void;
@@ -54,6 +56,7 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
   hopLimit,
   txPower,
   channelNum,
+  femLnaMode,
   sx126xRxBoostedGain,
   ignoreMqtt,
   configOkToMqtt,
@@ -71,6 +74,7 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
   setHopLimit,
   setTxPower,
   setChannelNum,
+  setFemLnaMode,
   setSx126xRxBoostedGain,
   setIgnoreMqtt,
   setConfigOkToMqtt,
@@ -86,7 +90,7 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
   // Track initial values for change detection
   const initialValuesRef = useRef({
     usePreset, modemPreset, bandwidth, spreadFactor, codingRate, frequencyOffset,
-    overrideFrequency, region, hopLimit, txPower, channelNum, sx126xRxBoostedGain,
+    overrideFrequency, region, hopLimit, txPower, channelNum, femLnaMode, sx126xRxBoostedGain,
     ignoreMqtt, configOkToMqtt, txEnabled, overrideDutyCycle, paFanDisabled
   });
 
@@ -105,6 +109,7 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
       hopLimit !== initial.hopLimit ||
       txPower !== initial.txPower ||
       channelNum !== initial.channelNum ||
+      femLnaMode !== initial.femLnaMode ||
       sx126xRxBoostedGain !== initial.sx126xRxBoostedGain ||
       ignoreMqtt !== initial.ignoreMqtt ||
       configOkToMqtt !== initial.configOkToMqtt ||
@@ -113,7 +118,7 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
       paFanDisabled !== initial.paFanDisabled
     );
   }, [usePreset, modemPreset, bandwidth, spreadFactor, codingRate, frequencyOffset,
-      overrideFrequency, region, hopLimit, txPower, channelNum, sx126xRxBoostedGain,
+      overrideFrequency, region, hopLimit, txPower, channelNum, femLnaMode, sx126xRxBoostedGain,
       ignoreMqtt, configOkToMqtt, txEnabled, overrideDutyCycle, paFanDisabled]);
 
   // Reset to initial values (for SaveBar dismiss)
@@ -130,6 +135,7 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
     setHopLimit(initial.hopLimit);
     setTxPower(initial.txPower);
     setChannelNum(initial.channelNum);
+    setFemLnaMode(initial.femLnaMode);
     setSx126xRxBoostedGain(initial.sx126xRxBoostedGain);
     setIgnoreMqtt(initial.ignoreMqtt);
     setConfigOkToMqtt(initial.configOkToMqtt);
@@ -138,7 +144,7 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
     setPaFanDisabled(initial.paFanDisabled);
   }, [setUsePreset, setModemPreset, setBandwidth, setSpreadFactor, setCodingRate,
       setFrequencyOffset, setOverrideFrequency, setRegion, setHopLimit, setTxPower,
-      setChannelNum, setSx126xRxBoostedGain, setIgnoreMqtt, setConfigOkToMqtt,
+      setChannelNum, setFemLnaMode, setSx126xRxBoostedGain, setIgnoreMqtt, setConfigOkToMqtt,
       setTxEnabled, setOverrideDutyCycle, setPaFanDisabled]);
 
   // Update initial values after successful save
@@ -146,11 +152,11 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
     await onSave();
     initialValuesRef.current = {
       usePreset, modemPreset, bandwidth, spreadFactor, codingRate, frequencyOffset,
-      overrideFrequency, region, hopLimit, txPower, channelNum, sx126xRxBoostedGain,
+      overrideFrequency, region, hopLimit, txPower, channelNum, femLnaMode, sx126xRxBoostedGain,
       ignoreMqtt, configOkToMqtt, txEnabled, overrideDutyCycle, paFanDisabled
     };
   }, [onSave, usePreset, modemPreset, bandwidth, spreadFactor, codingRate, frequencyOffset,
-      overrideFrequency, region, hopLimit, txPower, channelNum, sx126xRxBoostedGain,
+      overrideFrequency, region, hopLimit, txPower, channelNum, femLnaMode, sx126xRxBoostedGain,
       ignoreMqtt, configOkToMqtt, txEnabled, overrideDutyCycle, paFanDisabled]);
 
   // Register with SaveBar
@@ -424,6 +430,24 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
           onChange={(e) => setChannelNum(parseInt(e.target.value))}
           className="setting-input"
         />
+      </div>
+      <div className="setting-item">
+        <label htmlFor="femLnaMode">
+          {t('lora_config.fem_lna_mode')}
+          <span className="setting-description">{t('lora_config.fem_lna_mode_description')}</span>
+        </label>
+        <select
+          id="femLnaMode"
+          value={femLnaMode}
+          onChange={(e) => setFemLnaMode(parseInt(e.target.value))}
+          className="setting-input"
+        >
+          {FEM_LNA_MODE_OPTIONS.map(option => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
       </div>
       <div className="setting-item">
         <label htmlFor="sx126xRxBoostedGain" style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>

--- a/src/components/configuration/constants.ts
+++ b/src/components/configuration/constants.ts
@@ -124,6 +124,14 @@ export const REGION_OPTIONS: RegionOption[] = [
   { value: 32, label: 'EU_N_868 - European Union 868MHz Narrow' }
 ];
 
+// Config.LoRaConfig.FEM_LNA_Mode (firmware >= v2.7.20, meshtastic/firmware#9809).
+// Value 0 (DISABLED) is the proto3 zero/default and a real selectable mode.
+export const FEM_LNA_MODE_OPTIONS: RegionOption[] = [
+  { value: 0, label: 'DISABLED - FEM LNA present but disabled' },
+  { value: 1, label: 'ENABLED - FEM LNA present and enabled' },
+  { value: 2, label: 'NOT_PRESENT - No FEM LNA on this device' }
+];
+
 // Mapping from string role names to numeric values
 export const ROLE_MAP: Record<string, number> = {
   'CLIENT': 0,

--- a/src/server/constants/meshtastic.ts
+++ b/src/server/constants/meshtastic.ts
@@ -125,6 +125,36 @@ export function isViaMqtt(mechanism: number | undefined): boolean {
 }
 
 /**
+ * Config.LoRaConfig.FEM_LNA_Mode — FEM (Front-End Module) LNA (Low Noise Amplifier) mode.
+ * Added in Meshtastic firmware v2.7.20 (meshtastic/firmware#9809). Surfaced from
+ * meshtastic/protobufs config.proto `enum FEM_LNA_Mode` (field `fem_lna_mode = 106`).
+ * The zero value (DISABLED) is a real selectable mode, so proto3 elision must default to it.
+ */
+export const FemLnaMode = {
+  /** FEM_LNA is present but disabled */
+  DISABLED: 0,
+  /** FEM_LNA is present and enabled */
+  ENABLED: 1,
+  /** FEM_LNA is not present on the device */
+  NOT_PRESENT: 2,
+} as const;
+
+export type FemLnaModeType = typeof FemLnaMode[keyof typeof FemLnaMode];
+
+/**
+ * Get the name of a FEM LNA mode value.
+ */
+export function getFemLnaModeName(mode: number): string {
+  const entries = Object.entries(FemLnaMode);
+  for (const [name, value] of entries) {
+    if (value === mode) {
+      return name;
+    }
+  }
+  return 'UNKNOWN';
+}
+
+/**
  * Get the name of a port number
  */
 export function getPortNumName(portnum: number): string {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -4009,6 +4009,12 @@ class MeshtasticManager implements ISourceManager {
               parsed.data.lora.channelNum = 0;
               logger.info('📊 Set channelNum to 0 (was undefined - Proto3 default)');
             }
+            // femLnaMode (FEM_LNA_Mode enum) — zero value DISABLED is a real mode, so
+            // proto3 elision must default to 0, NOT to a non-zero fallback (see #3594).
+            if (parsed.data.lora.femLnaMode === undefined) {
+              parsed.data.lora.femLnaMode = 0;
+              logger.info('📊 Set femLnaMode to 0 (DISABLED - was undefined, Proto3 default)');
+            }
 
             // Persist the modem preset per-source so the unified channels
             // endpoint can use it as the display-name fallback for slot 0
@@ -4761,7 +4767,9 @@ class MeshtasticManager implements ISourceManager {
         frequencyOffset: deviceConfig.lora.frequencyOffset !== undefined ? deviceConfig.lora.frequencyOffset : 0,
         overrideFrequency: deviceConfig.lora.overrideFrequency !== undefined ? deviceConfig.lora.overrideFrequency : 0,
         modemPreset: deviceConfig.lora.modemPreset !== undefined ? deviceConfig.lora.modemPreset : 0,
-        channelNum: deviceConfig.lora.channelNum !== undefined ? deviceConfig.lora.channelNum : 0
+        channelNum: deviceConfig.lora.channelNum !== undefined ? deviceConfig.lora.channelNum : 0,
+        // FEM_LNA_Mode enum: default to 0 (DISABLED), the proto3 zero value (firmware ≥ v2.7.20)
+        femLnaMode: deviceConfig.lora.femLnaMode !== undefined ? deviceConfig.lora.femLnaMode : 0
       };
 
       deviceConfig = {
@@ -8310,7 +8318,8 @@ class MeshtasticManager implements ISourceManager {
         ),
         txEnabled: loraConfigWithDefaults.txEnabled !== undefined ? loraConfigWithDefaults.txEnabled : 'Unknown',
         sx126xRxBoostedGain: loraConfigWithDefaults.sx126xRxBoostedGain !== undefined ? loraConfigWithDefaults.sx126xRxBoostedGain : 'Unknown',
-        configOkToMqtt: loraConfigWithDefaults.configOkToMqtt !== undefined ? loraConfigWithDefaults.configOkToMqtt : 'Unknown'
+        configOkToMqtt: loraConfigWithDefaults.configOkToMqtt !== undefined ? loraConfigWithDefaults.configOkToMqtt : 'Unknown',
+        femLnaMode: loraConfigWithDefaults.femLnaMode !== undefined ? loraConfigWithDefaults.femLnaMode : 'Unknown'
       },
       mqtt: {
         enabled: mqttConfigWithDefaults.enabled,

--- a/src/server/protobufService.femLnaMode.test.ts
+++ b/src/server/protobufService.femLnaMode.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    upsertNode: vi.fn(),
+    insertMessage: vi.fn().mockReturnValue(true),
+    insertTelemetry: vi.fn(),
+  },
+}));
+
+import protobufService from './protobufService.js';
+import { loadProtobufDefinitions, getProtobufRoot } from './protobufLoader.js';
+import { FemLnaMode } from './constants/meshtastic.js';
+
+/**
+ * Round-trip tests for Config.LoRaConfig.fem_lna_mode (FEM_LNA_Mode enum), surfaced
+ * for issue #3599. protobufjs silently DROPS keys that aren't fields of the looked-up
+ * type, so this locks the camelCase field name (`femLnaMode`) against the proto. Both
+ * the Device Configuration save and the Remote Admin save funnel through
+ * createSetLoRaConfigMessage, so this single round-trip covers both surfaces.
+ *
+ * It also guards the proto3 elision class (#3594): the zero enum value (DISABLED) is a
+ * real selectable mode, so writing it must not be inflated to a non-zero default.
+ */
+describe('createSetLoRaConfigMessage femLnaMode round-trip', () => {
+  beforeAll(async () => {
+    await loadProtobufDefinitions();
+  });
+
+  const decode = (encoded: Uint8Array) => {
+    const AdminMessage = getProtobufRoot()!.lookupType('meshtastic.AdminMessage');
+    return AdminMessage.toObject(AdminMessage.decode(encoded), {
+      defaults: true,
+      oneofs: true,
+      enums: Number,
+    }) as any;
+  };
+
+  it('encodes femLnaMode ENABLED and it survives the round-trip', () => {
+    const encoded = protobufService.createSetLoRaConfigMessage({
+      femLnaMode: FemLnaMode.ENABLED,
+    });
+    const msg = decode(encoded);
+
+    expect(msg.setConfig.payloadVariant).toBe('lora');
+    expect(msg.setConfig.lora.femLnaMode).toBe(FemLnaMode.ENABLED);
+    expect(msg.setConfig.lora.femLnaMode).toBe(1);
+  });
+
+  it('encodes femLnaMode NOT_PRESENT and it survives the round-trip', () => {
+    const encoded = protobufService.createSetLoRaConfigMessage({
+      femLnaMode: FemLnaMode.NOT_PRESENT,
+    });
+    const msg = decode(encoded);
+
+    expect(msg.setConfig.lora.femLnaMode).toBe(FemLnaMode.NOT_PRESENT);
+    expect(msg.setConfig.lora.femLnaMode).toBe(2);
+  });
+
+  it('encodes femLnaMode DISABLED (proto3 zero) without inflating it to a non-zero value', () => {
+    const encoded = protobufService.createSetLoRaConfigMessage({
+      femLnaMode: FemLnaMode.DISABLED,
+    });
+    // decode WITHOUT defaults to confirm proto3 elision behaviour: the wire
+    // representation of the zero value is absent, and decoding yields 0/undefined,
+    // never a non-zero fallback.
+    const AdminMessage = getProtobufRoot()!.lookupType('meshtastic.AdminMessage');
+    const raw = AdminMessage.toObject(AdminMessage.decode(encoded)) as any;
+    const decodedMode = raw.setConfig?.lora?.femLnaMode ?? 0;
+    expect(decodedMode).toBe(FemLnaMode.DISABLED);
+    expect(decodedMode).toBe(0);
+  });
+
+  it('does not set femLnaMode when the field is absent from the config payload', () => {
+    const encoded = protobufService.createSetLoRaConfigMessage({
+      usePreset: true,
+      modemPreset: 0,
+    });
+    const AdminMessage = getProtobufRoot()!.lookupType('meshtastic.AdminMessage');
+    const raw = AdminMessage.toObject(AdminMessage.decode(encoded)) as any;
+    // Absent in payload => elided on the wire (decodes to undefined / proto3 default 0).
+    expect(raw.setConfig?.lora?.femLnaMode ?? 0).toBe(0);
+  });
+});

--- a/src/server/protobufService.ts
+++ b/src/server/protobufService.ts
@@ -1110,6 +1110,10 @@ class ProtobufService {
       if (config.overrideFrequency !== undefined) loraConfigData.overrideFrequency = config.overrideFrequency;
       if (config.paFanDisabled !== undefined) loraConfigData.paFanDisabled = config.paFanDisabled;
       if (config.ignoreMqtt !== undefined) loraConfigData.ignoreMqtt = config.ignoreMqtt;
+      // FEM_LNA_Mode enum (firmware ≥ v2.7.20). Writing 0 (DISABLED) is harmless on older
+      // firmware that doesn't know field 106. Both local config-set and remote admin set
+      // funnel through here, so this covers Device Config and Remote Admin save paths.
+      if (config.femLnaMode !== undefined) loraConfigData.femLnaMode = config.femLnaMode;
 
       logger.debug('LoRa config data being sent to device:', JSON.stringify(loraConfigData, null, 2));
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4576,7 +4576,8 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
                 channelNum: finalConfig.deviceConfig.lora.channelNum,
                 sx126xRxBoostedGain: finalConfig.deviceConfig.lora.sx126xRxBoostedGain,
                 ignoreMqtt: finalConfig.deviceConfig.lora.ignoreMqtt,
-                configOkToMqtt: finalConfig.deviceConfig.lora.configOkToMqtt
+                configOkToMqtt: finalConfig.deviceConfig.lora.configOkToMqtt,
+                femLnaMode: finalConfig.deviceConfig.lora.femLnaMode
               };
             } else {
               return res.status(404).json({ error: 'LoRa config not available. The device may not have sent its configuration yet.' });
@@ -4753,7 +4754,8 @@ apiRouter.post('/admin/load-config', requireAdmin(), async (req, res) => {
               channelNum: remoteConfig.channelNum,
               sx126xRxBoostedGain: remoteConfig.sx126xRxBoostedGain,
               ignoreMqtt: remoteConfig.ignoreMqtt,
-              configOkToMqtt: remoteConfig.configOkToMqtt
+              configOkToMqtt: remoteConfig.configOkToMqtt,
+              femLnaMode: remoteConfig.femLnaMode
             };
             break;
           case 'position':


### PR DESCRIPTION
## Summary

Adds support for `Config.LoRaConfig.fem_lna_mode` (the `FEM_LNA_Mode` enum), a LoRa Front-End Module (FEM) / Low Noise Amplifier (LNA) mode option added in Meshtastic firmware **v2.7.20** (meshtastic/firmware#9809). Users on amplified boards with an external LNA (e.g. certain RAK modules) can now configure it from the MeshMonitor UI instead of dropping to the Python CLI.

Closes #3599

## Protobuf

The field was **already vendored** — the `protobufs` submodule on `main` is at **v2.7.25**, which defines `enum FEM_LNA_Mode { DISABLED = 0; ENABLED = 1; NOT_PRESENT = 2; }` and `FEM_LNA_Mode fem_lna_mode = 106;` inside `Config.LoRaConfig`. **No submodule bump was required.** The enum is mirrored into shared constants (`src/server/constants/meshtastic.ts`) per project rules — no magic numbers.

## Both surfaces (read + display + write)

- **Device Configuration** (`LoRaConfigSection` / `ConfigurationTab`): new "FEM LNA Mode" select. Load, change-tracking (save bar), save payload, and config-import all carry `femLnaMode`.
- **Remote Admin** (`AdminCommandsTab`): new "FEM LNA Mode" select. Both remote-config read spots and the `setLoRaConfig` save payload carry `femLnaMode`.

Both save paths funnel through `protobufService.createSetLoRaConfigMessage`, which now encodes `femLnaMode` for the local config-set and for the remote admin message.

## proto3 elision (#3594)

The zero enum value `DISABLED` is a real selectable mode, so:
- It is read with a **`0` default** (never a non-zero `?? fallback`).
- The backend proto3-default block fills `femLnaMode = 0` when the field is elided on the wire.

## Firmware gating

The control is shown **unconditionally**; writing `0` (DISABLED) is harmless on older firmware that doesn't know field 106. No new gating framework was introduced.

## Tests

- `src/server/protobufService.femLnaMode.test.ts` — round-trips `femLnaMode` through encode/decode (ENABLED, NOT_PRESENT, and the proto3-zero DISABLED elision case, plus an absent-field case).
- `src/components/configuration/LoRaConfigSection.test.tsx` — covers the `FEM_LNA_MODE_OPTIONS` constants and the save payload.
- Full Vitest suite passes: **7051 tests, 0 failures**.
- `tsc -p tsconfig.server.json` and frontend `tsc --noEmit` show **no new errors** (only the documented pre-existing baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)