### PR TITLE
fix(meshcore): widen neighbor_info timestamp columns to BIGINT (int32 overflow)

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 94 migrations registered', () => {
-    expect(registry.count()).toBe(94);
+  it('has all 95 migrations registered', () => {
+    expect(registry.count()).toBe(95);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is add_meshcore_node_favorite', () => {
+  it('last migration is meshcore_neighbor_timestamp_bigint', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(94);
-    expect(last.name).toContain('add_meshcore_node_favorite');
+    expect(last.number).toBe(95);
+    expect(last.name).toContain('meshcore_neighbor_timestamp_bigint');
   });
 
-  it('migrations are sequentially numbered from 1 to 94', () => {
+  it('migrations are sequentially numbered from 1 to 95', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -109,6 +109,7 @@ import { migration as estimatedPositionsDoublePrecisionMigration, runMigration09
 import { migration as hideFromMapMigration, runMigration092Postgres as runHideFromMapPostgres, runMigration092Mysql as runHideFromMapMysql } from '../server/migrations/092_add_hide_from_map_to_nodes.js';
 import { migration as autoackMatrixMigration, runMigration093Postgres as runAutoackMatrixPostgres, runMigration093Mysql as runAutoackMatrixMysql } from '../server/migrations/093_autoack_matrix.js';
 import { migration as meshcoreNodeFavoriteMigration, runMigration094Postgres as runMeshcoreNodeFavoritePostgres, runMigration094Mysql as runMeshcoreNodeFavoriteMysql } from '../server/migrations/094_add_meshcore_node_favorite.js';
+import { migration as meshcoreNeighborTimestampBigintMigration, runMigration095Postgres as runMeshcoreNeighborTimestampBigintPostgres, runMigration095Mysql as runMeshcoreNeighborTimestampBigintMysql } from '../server/migrations/095_meshcore_neighbor_timestamp_bigint.js';
 
 // ============================================================================
 // Registry
@@ -1501,4 +1502,20 @@ registry.register({
   sqlite: (db) => meshcoreNodeFavoriteMigration.up(db),
   postgres: (client) => runMeshcoreNodeFavoritePostgres(client),
   mysql: (pool) => runMeshcoreNodeFavoriteMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 095: widen meshcore_neighbor_info.timestamp / .createdAt to BIGINT
+// on PostgreSQL and MySQL. Both store ms-epoch values (Date.now()), which
+// overflow signed 32-bit INTEGER/INT and crashed getNeighbors in production.
+// SQLite INTEGER is already 64-bit (no-op there).
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 95,
+  name: 'meshcore_neighbor_timestamp_bigint',
+  settingsKey: 'migration_095_meshcore_neighbor_timestamp_bigint',
+  sqlite: (db) => meshcoreNeighborTimestampBigintMigration.up(db),
+  postgres: (client) => runMeshcoreNeighborTimestampBigintPostgres(client),
+  mysql: (pool) => runMeshcoreNeighborTimestampBigintMysql(pool),
 });

--- a/src/db/schema/meshcoreNeighbors.ts
+++ b/src/db/schema/meshcoreNeighbors.ts
@@ -1,6 +1,6 @@
 import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
-import { pgTable, text as pgText, integer as pgInteger, real as pgReal } from 'drizzle-orm/pg-core';
-import { mysqlTable, varchar as myVarchar, int as myInt, double as myDouble, serial as mySerial } from 'drizzle-orm/mysql-core';
+import { pgTable, text as pgText, integer as pgInteger, real as pgReal, bigint as pgBigint } from 'drizzle-orm/pg-core';
+import { mysqlTable, varchar as myVarchar, int as myInt, double as myDouble, serial as mySerial, bigint as myBigint } from 'drizzle-orm/mysql-core';
 
 // ============ SQLite Schema ============
 
@@ -24,8 +24,9 @@ export const meshcoreNeighborsPostgres = pgTable('meshcore_neighbor_info', {
   neighborPublicKey: pgText('neighborPublicKey').notNull(),
   snr: pgReal('snr'),
   lastHeardSecs: pgInteger('lastHeardSecs'),
-  timestamp: pgInteger('timestamp').notNull(),
-  createdAt: pgInteger('createdAt').notNull(),
+  // ms-epoch timestamps overflow 32-bit INTEGER (~2.1e9); JS Date.now() is ~1.8e12.
+  timestamp: pgBigint('timestamp', { mode: 'number' }).notNull(),
+  createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
 });
 
 // ============ MySQL Schema ============
@@ -37,6 +38,7 @@ export const meshcoreNeighborsMysql = mysqlTable('meshcore_neighbor_info', {
   neighborPublicKey: myVarchar('neighborPublicKey', { length: 64 }).notNull(),
   snr: myDouble('snr'),
   lastHeardSecs: myInt('lastHeardSecs'),
-  timestamp: myInt('timestamp').notNull(),
-  createdAt: myInt('createdAt').notNull(),
+  // ms-epoch timestamps overflow 32-bit INT (~2.1e9); JS Date.now() is ~1.8e12.
+  timestamp: myBigint('timestamp', { mode: 'number' }).notNull(),
+  createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
 });

--- a/src/server/migrations/095_meshcore_neighbor_timestamp_bigint.ts
+++ b/src/server/migrations/095_meshcore_neighbor_timestamp_bigint.ts
@@ -1,0 +1,96 @@
+/**
+ * Migration 095: Widen meshcore_neighbor_info timestamp columns to BIGINT (PG/MySQL only).
+ *
+ * The meshcore_neighbor_info table (created in migration 073) declared its
+ * `timestamp` and `createdAt` columns as 32-bit INTEGER on PostgreSQL and INT
+ * on MySQL. Both columns store millisecond-epoch values written via
+ * `Date.now()` (see MeshCoreRepository.insertNeighborsBatch), e.g.
+ * 1781969045993, which overflows signed 32-bit integers (max 2,147,483,647).
+ *
+ * Production PostgreSQL deployments crashed on MeshCoreRepository.getNeighbors
+ * with:
+ *   error: value "1781969045993" is out of range for type integer (22003)
+ *
+ * This migration promotes both columns to BIGINT, matching the convention
+ * already used by the sibling meshcore_messages / meshcore_nodes /
+ * meshcore_packet_log tables for ms-epoch columns.
+ *
+ * SQLite: INTEGER is a 64-bit / dynamically-typed affinity — no change needed.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 095';
+const TABLE = 'meshcore_neighbor_info';
+const COLUMNS = ['timestamp', 'createdAt'];
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (_db: Database): void => {
+    // SQLite INTEGER columns hold 64-bit signed values (up to 8 bytes) and use
+    // dynamic type affinity — ms-epoch timestamps never overflowed here.
+    logger.info(`${LABEL} (SQLite): no-op (INTEGER is already 64-bit in SQLite)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration095Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): widening ${TABLE} timestamp columns to BIGINT...`);
+  for (const col of COLUMNS) {
+    // Check information_schema first so the ALTER is idempotent (re-runnable).
+    // eslint-disable-next-line no-restricted-syntax -- migrations require raw DDL
+    const { rows } = await client.query(
+      `SELECT data_type FROM information_schema.columns
+       WHERE table_name = $1 AND column_name = $2`,
+      [TABLE, col]
+    );
+    const currentType: string | undefined = rows[0]?.data_type?.toLowerCase();
+    if (currentType === undefined) {
+      logger.debug(`${LABEL} (PostgreSQL): ${TABLE}.${col} not found, skipping`);
+      continue;
+    }
+    if (currentType === 'bigint') {
+      logger.debug(`${LABEL} (PostgreSQL): ${col} already BIGINT, skipping`);
+      continue;
+    }
+    // eslint-disable-next-line no-restricted-syntax -- migrations require raw DDL
+    await client.query(`ALTER TABLE ${TABLE} ALTER COLUMN "${col}" TYPE BIGINT`);
+    logger.info(`${LABEL} (PostgreSQL): ${col} widened from ${currentType} → BIGINT`);
+  }
+}
+
+// ============ MySQL ============
+
+export async function runMigration095Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): widening ${TABLE} timestamp columns to BIGINT...`);
+  const conn = await pool.getConnection();
+  try {
+    for (const col of COLUMNS) {
+      // eslint-disable-next-line no-restricted-syntax -- migrations require raw DDL
+      const [rows] = await conn.query(
+        `SELECT DATA_TYPE FROM information_schema.COLUMNS
+         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+        [TABLE, col]
+      );
+      const currentType: string | undefined = (rows as any[])[0]?.DATA_TYPE?.toLowerCase();
+      if (currentType === undefined) {
+        logger.debug(`${LABEL} (MySQL): ${TABLE}.${col} not found, skipping`);
+        continue;
+      }
+      if (currentType === 'bigint') {
+        logger.debug(`${LABEL} (MySQL): ${col} already BIGINT, skipping`);
+        continue;
+      }
+      // Both columns are NOT NULL in the original DDL; preserve that on MODIFY.
+      // eslint-disable-next-line no-restricted-syntax -- migrations require raw DDL
+      await conn.query(`ALTER TABLE ${TABLE} MODIFY COLUMN \`${col}\` BIGINT NOT NULL`);
+      logger.info(`${LABEL} (MySQL): ${col} widened from ${currentType} → BIGINT`);
+    }
+  } finally {
+    conn.release();
+  }
+}


### PR DESCRIPTION
## Problem

A production PostgreSQL deployment crashes in `MeshCoreRepository.getNeighbors` (surfaced as "Error fetching MeshCore neighbors" via `meshcoreRoutes.ts`):

```
DrizzleQueryError: Failed query: select ... from "meshcore_neighbor_info"
where ("sourceId" in ($1) and "timestamp" >= $2) order by "timestamp" desc
params: [ 'b4e6c07e-...', 1781969045993 ]
cause: error: value "1781969045993" is out of range for type integer
       (code 22003, pg_strtoint32_safe, numutils.c)
```

## Root cause

The `meshcore_neighbor_info` table (created in migration 073) declared its `timestamp` and `createdAt` columns as **32-bit `INTEGER`** on PostgreSQL and **`INT`** on MySQL. Both columns store **millisecond-epoch** values written via `Date.now()` in `MeshCoreRepository.insertNeighborsBatch` (e.g. `1781969045993`), which overflows the signed 32-bit max of `2,147,483,647`.

SQLite was unaffected because its `INTEGER` is 64-bit / dynamically typed. This is the same int32-overflow class documented in CLAUDE.md ("Node IDs / packet IDs are BIGINT in PostgreSQL/MySQL") — ms timestamps share the defect.

This table was the **lone offender**: the sibling `meshcore_messages`, `meshcore_nodes`, and `meshcore_packet_log` tables already use `bigint(..., { mode: 'number' })` for their ms-epoch columns. A full audit of every PG `pgInteger`/MySQL `myInt` column with a timestamp-shaped name confirmed no other ms-epoch columns remain mis-typed.

## Columns changed

| Table | Column | Before (PG / MySQL) | After |
|-------|--------|---------------------|-------|
| `meshcore_neighbor_info` | `timestamp` | `integer` / `int` | `bigint` / `bigint` |
| `meshcore_neighbor_info` | `createdAt` | `integer` / `int` | `bigint` / `bigint` |

Deliberately left as `int`: `lastHeardSecs` (small "seconds-ago" value, not ms-epoch), `id`, `snr`, `rssi` — none can overflow.

## Changes

- **`src/db/schema/meshcoreNeighbors.ts`** — PG/MySQL `timestamp` + `createdAt` → `bigint('...', { mode: 'number' })`. SQLite unchanged (64-bit already). `mode: 'number'` keeps reads as JS numbers, matching `meshcore_packet_log`, so **no read-site `Number()` coercion was needed**.
- **`src/server/migrations/095_meshcore_neighbor_timestamp_bigint.ts`** — idempotent migration:
  - PostgreSQL: `ALTER TABLE ... ALTER COLUMN ... TYPE BIGINT`, guarded by `information_schema.columns` data-type check.
  - MySQL: `ALTER TABLE ... MODIFY COLUMN ... BIGINT NOT NULL`, guarded by `information_schema.COLUMNS` check.
  - SQLite: no-op (INTEGER is already 64-bit).
- Registered migration 095 in `src/db/migrations.ts`; bumped `src/db/migrations.test.ts` count to 95 and last-name assertion.

## Verification

- Full Vitest suite: **21199 passed, 0 failed** (exit 0).
- `tsc -p tsconfig.server.json --noEmit`: no new errors (only the ~5 pre-existing `TelemetryChart.tsx` frontend errors remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)