### PR TITLE
fix: rebuild re2 for x64 on arm64 macOS CI runner (fixes #3603)

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -330,7 +330,27 @@ jobs:
           cp package-lock.json desktop/resources/dist/
           # Install production-only dependencies into the bundle (matches Windows step).
           # Excludes dev deps — shrinks the debug build proportionally to the release build.
-          (cd desktop/resources/dist && npm ci --omit=dev --legacy-peer-deps --no-audit --no-fund)
+          # IMPORTANT: this runner is macos-14 (arm64) but the bundle ships x64 binaries.
+          # Force prebuild-install (better-sqlite3 et al.) to fetch x64 prebuilds — without
+          # this, native .node files are downloaded for arm64 and the x64 DMG fails to load
+          # them at runtime (see issue #2901).
+          (cd desktop/resources/dist && \
+            npm_config_arch=x64 \
+            npm_config_target_arch=x64 \
+            npm_config_platform=darwin \
+            npm_config_target_platform=darwin \
+            npm ci --omit=dev --legacy-peer-deps --no-audit --no-fund)
+          # re2 uses install-artifact-from-github (not prebuild-install) to download
+          # prebuilt binaries. That tool reads process.arch — arm64 on this runner —
+          # instead of npm_config_arch, so it fetches an arm64 re2.node even when the
+          # arch env vars are set. Delete it and rebuild from source with clang
+          # -arch x86_64 so the bundled binary is x86_64. See issue #3603 and #2901.
+          rm -f desktop/resources/dist/node_modules/re2/build/Release/re2.node
+          (cd desktop/resources/dist/node_modules/re2 && \
+            CFLAGS="-arch x86_64" CXXFLAGS="-arch x86_64" LDFLAGS="-arch x86_64" \
+            ../.bin/node-gyp rebuild --arch=x64)
+          echo "re2.node architecture after rebuild:"
+          file desktop/resources/dist/node_modules/re2/build/Release/re2.node
 
       - name: Download Node.js binary for bundling (x64)
         run: |

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -730,6 +730,17 @@ jobs:
             npm_config_platform=darwin \
             npm_config_target_platform=darwin \
             npm ci --omit=dev --legacy-peer-deps --no-audit --no-fund)
+          # re2 uses install-artifact-from-github (not prebuild-install) to download
+          # prebuilt binaries. That tool reads process.arch — arm64 on this runner —
+          # instead of npm_config_arch, so it fetches an arm64 re2.node even when the
+          # arch env vars are set. Delete it and rebuild from source with clang
+          # -arch x86_64 so the bundled binary is x86_64. See issue #3603 and #2901.
+          rm -f desktop/resources/dist/node_modules/re2/build/Release/re2.node
+          (cd desktop/resources/dist/node_modules/re2 && \
+            CFLAGS="-arch x86_64" CXXFLAGS="-arch x86_64" LDFLAGS="-arch x86_64" \
+            ../.bin/node-gyp rebuild --arch=x64)
+          echo "re2.node architecture after rebuild:"
+          file desktop/resources/dist/node_modules/re2/build/Release/re2.node
 
       # Sign all native binaries in node_modules for notarization
       # Native addons with JIT also need the entitlements


### PR DESCRIPTION
## Summary

Fixes #3603 — the macOS x64 DMG bundles `re2.node` as arm64, crashing on Intel Macs.

- `re2@1.25.0` uses `install-artifact-from-github` to fetch prebuilts. Unlike `prebuild-install`, it reads `process.arch` (always `arm64` on the `macos-14` runner), not `npm_config_arch` — so it downloads an arm64 binary regardless of the arch env vars set by the #2901 fix.
- After `npm ci`, the workflow now deletes the wrong arm64 `re2.node` and rebuilds it from source via `node-gyp` with `CFLAGS/CXXFLAGS/LDFLAGS="-arch x86_64"`. Apple's clang supports this cross-compilation natively.
- Also adds the missing `npm_config_arch=x64` flags to `desktop-ci.yml`'s x64 job (the release workflow had them; the CI workflow did not).

## Test plan

- [ ] Trigger a `desktop-release.yml` x64 macOS build and verify `re2.node` inside the DMG is `x86_64` (`file` output in the build log should confirm this)
- [ ] Install the resulting DMG on an Intel Mac and confirm the app starts without the `ERR_DLOPEN_FAILED` crash
- [ ] Verify arm64 build is unaffected (that job runs natively on arm64 and is not modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kijmf1ZHtCJHuGWXV57hGc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kijmf1ZHtCJHuGWXV57hGc)_