### PR TITLE
fix(meshcore): derive hashtag channel secret at save time (#3607)

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsConfigSection.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsConfigSection.test.tsx
@@ -253,14 +253,65 @@ describe('MeshCoreChannelsConfigSection — hashtag channels', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    const putCall = csrfFetchMock.mock.calls.find(
-      c => typeof c[1]?.method === 'string' && c[1].method === 'PUT',
-    );
-    expect(putCall).toBeDefined();
+    let putCall: any;
+    await waitFor(() => {
+      putCall = csrfFetchMock.mock.calls.find(
+        c => typeof c[1]?.method === 'string' && c[1].method === 'PUT',
+      );
+      expect(putCall).toBeDefined();
+    });
     const body = JSON.parse(putCall![1].body);
     expect(body.name).toBe('#test');
     // base64 of 9cd8fcf22a47333b591d96a2b848b73f.
     expect(body.psk).toBe('nNj88ipHMztZHZaiuEi3Pw==');
+  });
+
+  // Regression for #3607: a user who typed a #hashtag name and clicked Save
+  // before the async live-derive useEffect committed could persist the random
+  // placeholder secret (different on every attempt, never matching the app).
+  // handleSave now re-derives the deterministic key at save time, so the PUT
+  // must carry SHA-256("#bot")[0:16] even when we never wait for the field to
+  // update first.
+  it('re-derives the deterministic hashtag PSK at save time (no race on the live-derive effect)', async () => {
+    csrfFetchMock
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse({ success: true }))
+      .mockResolvedValueOnce(jsonResponse([
+        { id: 0, name: '#bot', psk: '61ChvLPk5de/aaV8na2iEQ==' },
+      ]));
+
+    render(
+      <MeshCoreChannelsConfigSection baseUrl="" sourceId="src-a" canWrite={true} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText('No channels reported by the device yet.')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByText('+ Add channel'));
+    const nameInput = screen.getByLabelText('Name') as HTMLInputElement;
+
+    // Type the hashtag name AND save inside the same act() flush — without a
+    // waitFor on the derived secret. The displayed field may still hold the
+    // random placeholder, but the saved PSK must be the deterministic key.
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: '#bot' } });
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    let putCall: any;
+    await waitFor(() => {
+      putCall = csrfFetchMock.mock.calls.find(
+        c => typeof c[1]?.method === 'string' && c[1].method === 'PUT',
+      );
+      expect(putCall).toBeDefined();
+    });
+    const body = JSON.parse(putCall![1].body);
+    expect(body.name).toBe('#bot');
+    // SHA-256("#bot")[0:16] = eb50a1bcb3e4e5d7bf69a57c9dada211 → base64 below.
+    // This is NOT the random getRandomValues placeholder (which would be
+    // 0102…0f10 base64 'AQIDBAUGBwgJCgsMDQ4PEA==').
+    expect(body.psk).toBe('61ChvLPk5de/aaV8na2iEQ==');
+    expect(body.psk).not.toBe('AQIDBAUGBwgJCgsMDQ4PEA==');
   });
 });
 

--- a/src/components/MeshCore/MeshCoreChannelsConfigSection.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsConfigSection.tsx
@@ -217,14 +217,33 @@ export const MeshCoreChannelsConfigSection: React.FC<MeshCoreChannelsConfigSecti
       showToast(t('meshcore.channels.name_too_long', 'Channel name must be {{max}} bytes or less', { max: MAX_NAME_BYTES }), 'error');
       return;
     }
-    if (!isValid16ByteHex(editSecretHex)) {
+
+    // For hashtag channels the secret MUST be the deterministic
+    // SHA-256("#name")[0:16] key — never the random placeholder set by
+    // startAdd()/regenerate. The live-derive useEffect also computes this,
+    // but it runs asynchronously, so a user who types "#bot" and saves
+    // quickly can race ahead of it and persist the stale random secret
+    // (issue #3607). Re-derive here at save time so the stored/displayed key
+    // is always deterministic and matches the MeshCore app.
+    let secretHexToSave = editSecretHex;
+    if (isHashtagChannelName(trimmedName)) {
+      try {
+        secretHexToSave = await deriveHashtagSecretHex(trimmedName);
+      } catch (err) {
+        logger.error('Failed to derive hashtag channel secret on save:', err);
+        showToast(t('meshcore.channels.invalid_secret', 'Secret must be exactly 32 hex characters (16 bytes)'), 'error');
+        return;
+      }
+    }
+
+    if (!isValid16ByteHex(secretHexToSave)) {
       showToast(t('meshcore.channels.invalid_secret', 'Secret must be exactly 32 hex characters (16 bytes)'), 'error');
       return;
     }
 
     setSaving(true);
     try {
-      const pskBase64 = hexToBase64(editSecretHex);
+      const pskBase64 = hexToBase64(secretHexToSave);
       const response = await csrfFetch(`${baseUrl}/api/channels/${editingIdx}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

Closes #3607.

MeshCore `#` (hashtag) channels created in MeshMonitor were being saved with a **random** secret that differed on every attempt and never matched the MeshCore app's well-known key. Reporters on v4.11.3 saw two different secrets for the same `#bot` channel (`e16510550f7c984bea37d0005b28c4a1`, `1e8fdf3de67a9d01cfcbda1a1961724a`) — both random, neither equal to the deterministic `SHA-256("#bot")[0:16]`.

## Root cause

Both symptoms (non-determinism **and** mismatch) had a single cause: a **race condition**, not a wrong algorithm.

`MeshCoreChannelsConfigSection` already had a correct deterministic helper (`deriveHashtagSecretHex` → `SHA-256("#name")[0:16]`) and a live-derive `useEffect` that fills the secret field when the name starts with `#`. But:

- `startAdd()`/`Regenerate` seed the field with `crypto.getRandomValues` (random placeholder).
- The live-derive effect runs **asynchronously** (it `await`s `crypto.subtle.digest`).
- `handleSave()` read the secret straight from the `editSecretHex` **state**.

A user who typed `#bot` and clicked Save before the async derivation effect committed persisted the **stale random placeholder**. Because it's random, it differs every attempt and never matches the app.

## Fix

`handleSave()` now re-derives the deterministic key at save time whenever the (trimmed) name is a hashtag channel, ignoring whatever value sits in the field:

```ts
let secretHexToSave = editSecretHex;
if (isHashtagChannelName(trimmedName)) {
  secretHexToSave = await deriveHashtagSecretHex(trimmedName);
}
```

Non-hashtag channels are untouched — they keep their explicit/random PSK (a legitimate, different case).

## Derivation algorithm (verified)

`secret = SHA-256(<name including the leading "#">)[0:16]`, UTF-8, case-sensitive, displayed as lowercase hex.

Confirmed against:
- The MeshCore reference / public docs (the well-known `#test` key is `9cd8fcf22a47333b591d96a2b848b73f` = `SHA-256("#test")[0:16]`, hashing **with** the `#`), and
- The existing in-repo helper + its pinned test (`src/utils/meshcoreHelpers.ts`, `meshcoreHelpers.test.ts`), which already encode this scheme.

Worked examples: `#test` → `9cd8fcf22a47333b591d96a2b848b73f`, `#bot` → `eb50a1bcb3e4e5d7bf69a57c9dada211`.

## Tests

Added a regression test that types `#bot` and clicks Save in the **same** flush — i.e. without waiting for the live-derive effect — and asserts the PUT body carries the deterministic key (`eb50a1bcb3e4e5d7bf69a57c9dada211`, base64 `61ChvLPk5de/aaV8na2iEQ==`) and **not** the random placeholder. Two existing hashtag PUT assertions were made robust to the extra async derive tick via `waitFor`.

- Full Vitest suite: success=true, 7088 passed, 0 failed (0 failed suites).
- `tsc -p tsconfig.server.json --noEmit`: only pre-existing `TelemetryChart.tsx` errors (unrelated, untouched).

## Files changed
- `src/components/MeshCore/MeshCoreChannelsConfigSection.tsx`
- `src/components/MeshCore/MeshCoreChannelsConfigSection.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)