### PR TITLE
fix(map): adaptive node-type filter per connected source protocol (#3610)

### DIFF
--- a/src/components/MapAnalysis/MapLegend.tsx
+++ b/src/components/MapAnalysis/MapLegend.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
+import { useVisibleNodeTypeCategories } from './useVisibleNodeTypeCategories';
 import { roleGlyphInnerSvg } from '../../utils/mapIcons';
 import {
-  NODE_TYPE_CATEGORIES,
+  categoryGlyphFamily,
   NODE_TYPE_CATEGORY_META,
   type NodeTypeCategory,
 } from '../../utils/nodeTypeCategory';
@@ -57,6 +58,12 @@ export default function MapLegend() {
   const { config } = useMapAnalysisCtx();
   const { t } = useTranslation();
   const [collapsed, setCollapsed] = useState(false);
+  const visibleCategories = useVisibleNodeTypeCategories();
+  // Only categories with a distinct glyph deserve a legend row; client/standard
+  // buckets render as the default pin and would be a meaningless swatch.
+  const legendCategories = visibleCategories.filter(
+    (c) => categoryGlyphFamily(c) !== 'standard',
+  );
 
   const showTraceroutes = config.layers.traceroutes.enabled;
   const showNeighbors = config.layers.neighbors.enabled;
@@ -92,10 +99,10 @@ export default function MapLegend() {
               <div className="row"><Swatch color="#6698f5" /> Node</div>
             </section>
           )}
-          {showMarkers && (
+          {showMarkers && legendCategories.length > 0 && (
             <section>
               <h4>{t('map.nodeType.legendTitle', 'Node Types')}</h4>
-              {NODE_TYPE_CATEGORIES.filter((c) => c !== 'standard').map((c) => (
+              {legendCategories.map((c) => (
                 <div className="row" key={c}>
                   <RoleIcon category={c} /> {t(NODE_TYPE_CATEGORY_META[c].labelKey, NODE_TYPE_CATEGORY_META[c].label)}
                 </div>

--- a/src/components/MapAnalysis/NodeTypeFilterControl.tsx
+++ b/src/components/MapAnalysis/NodeTypeFilterControl.tsx
@@ -1,22 +1,30 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
-import {
-  NODE_TYPE_CATEGORIES,
-  NODE_TYPE_CATEGORY_META,
-} from '../../utils/nodeTypeCategory';
+import { useVisibleNodeTypeCategories } from './useVisibleNodeTypeCategories';
+import { NODE_TYPE_CATEGORY_META } from '../../utils/nodeTypeCategory';
 
 /**
  * Popover of node-type checkboxes that show/hide map markers by role
  * (issue #3546). Mirrors {@link SourceMultiSelect}'s pill + popover pattern.
  * State lives in `config.nodeTypes`; a missing/true value means visible.
+ *
+ * The list of categories adapts to the connected source types (issue #3610):
+ * a Meshtastic-only instance gets Meshtastic role categories, MeshCore-only
+ * gets the MeshCore categories, and a mixed instance gets the union. The
+ * persisted toggle map still keys on stable category names, so a hidden
+ * category that drops out of scope is simply inert (default visible) and never
+ * permanently hides a node when the source mix changes.
  */
 export default function NodeTypeFilterControl() {
   const { config, setNodeTypeEnabled } = useMapAnalysisCtx();
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const categories = useVisibleNodeTypeCategories();
 
-  const hidden = NODE_TYPE_CATEGORIES.filter((c) => config.nodeTypes[c] === false);
+  // Only count toggles for categories that are currently shown, so the pill
+  // label reflects what the user can actually see/change.
+  const hidden = categories.filter((c) => config.nodeTypes[c] === false);
   const label =
     hidden.length === 0
       ? t('map.nodeType.allTypes', 'All node types')
@@ -29,7 +37,7 @@ export default function NodeTypeFilterControl() {
       </button>
       {open && (
         <div className="map-analysis-source-popover" role="dialog">
-          {NODE_TYPE_CATEGORIES.map((c) => {
+          {categories.map((c) => {
             const meta = NODE_TYPE_CATEGORY_META[c];
             return (
               <label key={c} className="map-analysis-source-row">

--- a/src/components/MapAnalysis/useVisibleNodeTypeCategories.ts
+++ b/src/components/MapAnalysis/useVisibleNodeTypeCategories.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+import { useDashboardSources, type DashboardSource } from '../../hooks/useDashboardData';
+import { useMapAnalysisCtx } from './MapAnalysisContext';
+import {
+  categoriesForProtocols,
+  sourceTypeProtocol,
+  type NodeTypeCategory,
+} from '../../utils/nodeTypeCategory';
+
+/**
+ * The node-type categories the Map Analysis filter/legend should expose, given
+ * which protocol families are actually in scope (issue #3610).
+ *
+ * "In scope" = the sources currently selected in the Map Analysis source filter
+ * (`config.sources`), or every enabled source when the selection is empty
+ * ("all" semantics). A Meshtastic-only instance therefore sees only Meshtastic
+ * role categories; MeshCore-only sees the MeshCore categories; a mixed instance
+ * sees the union. While the source list is still loading we fall back to the
+ * full category set so the control is never empty.
+ */
+export function useVisibleNodeTypeCategories(): NodeTypeCategory[] {
+  const { config } = useMapAnalysisCtx();
+  const { data: sources } = useDashboardSources();
+
+  return useMemo(() => {
+    const list: DashboardSource[] = sources ?? [];
+    const inScope = list.filter((s) => {
+      if (s.enabled === false) return false;
+      if (config.sources.length === 0) return true;
+      return config.sources.includes(s.id);
+    });
+    let meshcore = false;
+    let meshtastic = false;
+    for (const s of inScope) {
+      if (sourceTypeProtocol(s.type) === 'meshcore') meshcore = true;
+      else meshtastic = true;
+    }
+    return categoriesForProtocols({ meshcore, meshtastic });
+  }, [sources, config.sources]);
+}

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useSettings, TimeFormat, DateFormat } from '../contexts/SettingsContext';
 import { formatDateTime } from '../utils/datetime';
 import { DraggableOverlay } from './DraggableOverlay';
-import { NODE_TYPE_CATEGORIES, NODE_TYPE_CATEGORY_META } from '../utils/nodeTypeCategory';
+import { MESHCORE_CATEGORIES, NODE_TYPE_CATEGORY_META } from '../utils/nodeTypeCategory';
 import { roleGlyphMarkerSvg } from '../utils/mapIcons';
 import './MapLegend.css';
 
@@ -140,7 +140,7 @@ const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount, s
                 <span className="legend-title">{t('map.nodeType.legendTitle', 'Node Types')}</span>
                 {/* Standard nodes keep the default marker, so only the four
                     glyph categories are listed (matches the analysis legend). */}
-                {NODE_TYPE_CATEGORIES.filter((c) => c !== 'standard').map((category) => {
+                {MESHCORE_CATEGORIES.filter((c) => c !== 'standard').map((category) => {
                   const meta = NODE_TYPE_CATEGORY_META[category];
                   return (
                     <div key={category} className="legend-item">

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -7,7 +7,7 @@ import { useSettings } from '../../contexts/SettingsContext';
 import {
   getNodeTypeCategory,
   nodePassesTypeFilter,
-  NODE_TYPE_CATEGORIES,
+  MESHCORE_CATEGORIES,
   NODE_TYPE_CATEGORY_META,
   type NodeTypeCategory,
 } from '../../utils/nodeTypeCategory';
@@ -410,7 +410,7 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
           <div className="map-controls-title" style={{ marginTop: '0.5rem' }}>
             {t('map.nodeType.legendTitle', 'Node Types')}
           </div>
-          {NODE_TYPE_CATEGORIES.map((category) => {
+          {MESHCORE_CATEGORIES.map((category) => {
             const meta = NODE_TYPE_CATEGORY_META[category];
             return (
               <label key={category} className="map-control-item">

--- a/src/utils/mapIcons.test.ts
+++ b/src/utils/mapIcons.test.ts
@@ -191,4 +191,16 @@ describe('roleGlyphMarkerSvg', () => {
   it('returns empty string for standard (so callers keep their default marker)', () => {
     expect(roleGlyphMarkerSvg('standard', COLOR, 24)).toBe('');
   });
+
+  it('renders Meshtastic role categories via their shared glyph family (issue #3610)', () => {
+    // A Meshtastic ROUTER draws as the repeater tower; identical markup.
+    expect(roleGlyphMarkerSvg('mtRouter', COLOR, 24)).toBe(roleGlyphMarkerSvg('repeater', COLOR, 24));
+    expect(roleGlyphMarkerSvg('mtRouterLate', COLOR, 24)).toBe(roleGlyphMarkerSvg('repeater', COLOR, 24));
+    expect(roleGlyphMarkerSvg('mtSensor', COLOR, 24)).toBe(roleGlyphMarkerSvg('sensor', COLOR, 24));
+  });
+
+  it('returns empty string for Meshtastic client-type roles (default pin)', () => {
+    expect(roleGlyphMarkerSvg('mtClient', COLOR, 24)).toBe('');
+    expect(roleGlyphMarkerSvg('mtTracker', COLOR, 24)).toBe('');
+  });
 });

--- a/src/utils/mapIcons.ts
+++ b/src/utils/mapIcons.ts
@@ -1,15 +1,18 @@
 import L from 'leaflet';
 import { isEmoji } from './text';
-import type { NodeTypeCategory } from './nodeTypeCategory';
+import { categoryGlyphFamily, type NodeTypeCategory } from './nodeTypeCategory';
 
 /**
  * Inner SVG markup for a node-type role glyph, drawn inside the 48×48 viewBox
  * over a white background circle (issue #3546). Returns '' for 'standard' so
  * callers fall back to the default pin/circle. `color` is the hop color so the
  * glyph stays consistent with the marker's stroke.
+ *
+ * Meshtastic role categories (issue #3610) reuse the MeshCore glyph silhouettes
+ * via {@link categoryGlyphFamily} (a ROUTER draws as a repeater tower, etc.).
  */
 export function roleGlyphInnerSvg(category: NodeTypeCategory, color: string): string {
-  switch (category) {
+  switch (categoryGlyphFamily(category)) {
     case 'repeater':
       // Tower with signal waves — the existing router silhouette, overflows
       // the circle so backbone nodes read at a glance.

--- a/src/utils/nodeTypeCategory.test.ts
+++ b/src/utils/nodeTypeCategory.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect } from 'vitest';
 import {
   getNodeTypeCategory,
   nodePassesTypeFilter,
+  categoriesForProtocols,
+  categoryGlyphFamily,
+  sourceTypeProtocol,
+  isMeshCoreNode,
+  MESHCORE_CATEGORIES,
+  MESHTASTIC_CATEGORIES,
   NODE_TYPE_CATEGORIES,
 } from './nodeTypeCategory';
 
@@ -28,24 +34,35 @@ describe('getNodeTypeCategory', () => {
     });
   });
 
-  describe('Meshtastic nodes (by role)', () => {
-    it('maps ROUTER role (2) to repeater', () => {
-      expect(getNodeTypeCategory({ user: { role: 2 } })).toBe('repeater');
+  describe('Meshtastic nodes (by role) — granular categories (issue #3610)', () => {
+    it('maps ROUTER role (2) to its own mtRouter category', () => {
+      expect(getNodeTypeCategory({ user: { role: 2 } })).toBe('mtRouter');
     });
     it('parses a stringified role', () => {
-      expect(getNodeTypeCategory({ user: { role: '2' } })).toBe('repeater');
+      expect(getNodeTypeCategory({ user: { role: '2' } })).toBe('mtRouter');
     });
     it('reads a top-level role fallback', () => {
-      expect(getNodeTypeCategory({ role: 2 })).toBe('repeater');
+      expect(getNodeTypeCategory({ role: 2 })).toBe('mtRouter');
     });
-    it('maps client roles to standard', () => {
-      expect(getNodeTypeCategory({ user: { role: 0 } })).toBe('standard');
-      expect(getNodeTypeCategory({ user: { role: 1 } })).toBe('standard');
+    it('distinguishes CLIENT, CLIENT_MUTE, TRACKER, SENSOR, etc.', () => {
+      expect(getNodeTypeCategory({ user: { role: 0 } })).toBe('mtClient');
+      expect(getNodeTypeCategory({ user: { role: 1 } })).toBe('mtClientMute');
+      expect(getNodeTypeCategory({ user: { role: 3 } })).toBe('mtRouterClient');
+      expect(getNodeTypeCategory({ user: { role: 4 } })).toBe('mtRepeater');
+      expect(getNodeTypeCategory({ user: { role: 5 } })).toBe('mtTracker');
+      expect(getNodeTypeCategory({ user: { role: 6 } })).toBe('mtSensor');
+      expect(getNodeTypeCategory({ user: { role: 7 } })).toBe('mtTak');
+      expect(getNodeTypeCategory({ user: { role: 8 } })).toBe('mtClientHidden');
+      expect(getNodeTypeCategory({ user: { role: 9 } })).toBe('mtLostAndFound');
+      expect(getNodeTypeCategory({ user: { role: 10 } })).toBe('mtTakTracker');
+      expect(getNodeTypeCategory({ user: { role: 11 } })).toBe('mtRouterLate');
+      expect(getNodeTypeCategory({ user: { role: 12 } })).toBe('mtClientBase');
     });
-    it('falls back to standard for missing/garbage role', () => {
-      expect(getNodeTypeCategory({})).toBe('standard');
-      expect(getNodeTypeCategory({ user: { role: null } })).toBe('standard');
-      expect(getNodeTypeCategory({ user: { role: 'nonsense' } })).toBe('standard');
+    it('falls back to mtClient (default role) for missing/garbage role', () => {
+      expect(getNodeTypeCategory({})).toBe('mtClient');
+      expect(getNodeTypeCategory({ user: { role: null } })).toBe('mtClient');
+      expect(getNodeTypeCategory({ user: { role: 'nonsense' } })).toBe('mtClient');
+      expect(getNodeTypeCategory({ user: { role: 99 } })).toBe('mtClient');
     });
   });
 
@@ -54,6 +71,7 @@ describe('getNodeTypeCategory', () => {
       { isMeshCore: true, advType: 1 },
       { isMeshCore: true, advType: 4 },
       { user: { role: 2 } },
+      { user: { role: 5 } },
       {},
     ];
     for (const s of samples) {
@@ -62,17 +80,94 @@ describe('getNodeTypeCategory', () => {
   });
 });
 
+describe('isMeshCoreNode', () => {
+  it('detects MeshCore by isMeshCore flag or numeric advType', () => {
+    expect(isMeshCoreNode({ isMeshCore: true })).toBe(true);
+    expect(isMeshCoreNode({ advType: 0 })).toBe(true);
+    expect(isMeshCoreNode({ user: { role: 2 } })).toBe(false);
+    expect(isMeshCoreNode({})).toBe(false);
+  });
+});
+
 describe('nodePassesTypeFilter', () => {
   it('shows a node whose category is enabled or absent (default visible)', () => {
     expect(nodePassesTypeFilter({ isMeshCore: true, advType: 2 }, {})).toBe(true);
     expect(nodePassesTypeFilter({ isMeshCore: true, advType: 2 }, { repeater: true })).toBe(true);
+    // Meshtastic node with no relevant toggle => visible.
+    expect(nodePassesTypeFilter({ user: { role: 5 } }, {})).toBe(true);
   });
   it('hides a node whose category is explicitly disabled', () => {
     expect(nodePassesTypeFilter({ isMeshCore: true, advType: 2 }, { repeater: false })).toBe(false);
+    expect(nodePassesTypeFilter({ user: { role: 5 } }, { mtTracker: false })).toBe(false);
   });
   it('does not hide other categories when one is disabled', () => {
-    const filter = { repeater: false };
+    const filter = { repeater: false, mtRouter: false };
     expect(nodePassesTypeFilter({ isMeshCore: true, advType: 1 }, filter)).toBe(true);
     expect(nodePassesTypeFilter({ user: { role: 0 } }, filter)).toBe(true);
+  });
+  it('a stale MeshCore toggle does not hide Meshtastic nodes (graceful degradation)', () => {
+    // Source mix changed from MeshCore to Meshtastic-only; the old "roomServer: false"
+    // toggle is inert because no Meshtastic node ever maps to roomServer.
+    const filter = { roomServer: false, companion: false };
+    expect(nodePassesTypeFilter({ user: { role: 2 } }, filter)).toBe(true);
+    expect(nodePassesTypeFilter({ user: { role: 0 } }, filter)).toBe(true);
+  });
+});
+
+describe('categoryGlyphFamily', () => {
+  it('keeps MeshCore categories as their own family', () => {
+    for (const c of MESHCORE_CATEGORIES) {
+      expect(categoryGlyphFamily(c)).toBe(c);
+    }
+  });
+  it('draws Meshtastic routers/repeaters as the repeater tower', () => {
+    expect(categoryGlyphFamily('mtRouter')).toBe('repeater');
+    expect(categoryGlyphFamily('mtRouterLate')).toBe('repeater');
+    expect(categoryGlyphFamily('mtRepeater')).toBe('repeater');
+  });
+  it('draws a Meshtastic sensor as the sensor glyph', () => {
+    expect(categoryGlyphFamily('mtSensor')).toBe('sensor');
+  });
+  it('falls back to the default pin (standard) for Meshtastic client-type roles', () => {
+    expect(categoryGlyphFamily('mtClient')).toBe('standard');
+    expect(categoryGlyphFamily('mtTracker')).toBe('standard');
+    expect(categoryGlyphFamily('mtTak')).toBe('standard');
+    expect(categoryGlyphFamily('mtClientBase')).toBe('standard');
+  });
+});
+
+describe('sourceTypeProtocol', () => {
+  it('classifies meshcore vs meshtastic source types', () => {
+    expect(sourceTypeProtocol('meshcore')).toBe('meshcore');
+    expect(sourceTypeProtocol('meshtastic_tcp')).toBe('meshtastic');
+    expect(sourceTypeProtocol('meshtastic_mqtt')).toBe('meshtastic');
+    expect(sourceTypeProtocol(undefined)).toBe('meshtastic');
+    expect(sourceTypeProtocol(null)).toBe('meshtastic');
+  });
+});
+
+describe('categoriesForProtocols (adaptive filter set, issue #3610)', () => {
+  it('Meshtastic-only instance exposes only Meshtastic role categories', () => {
+    const cats = categoriesForProtocols({ meshcore: false, meshtastic: true });
+    expect(cats).toEqual(MESHTASTIC_CATEGORIES);
+    // None of the MeshCore-only options leak in (the core bug).
+    expect(cats).not.toContain('companion');
+    expect(cats).not.toContain('roomServer');
+    expect(cats).not.toContain('sensor');
+    expect(cats).toContain('mtRouter');
+    expect(cats).toContain('mtTracker');
+  });
+  it('MeshCore-only instance exposes only the MeshCore categories', () => {
+    const cats = categoriesForProtocols({ meshcore: true, meshtastic: false });
+    expect(cats).toEqual(MESHCORE_CATEGORIES);
+    expect(cats).not.toContain('mtRouter');
+  });
+  it('both connected unions both sets (MeshCore first)', () => {
+    const cats = categoriesForProtocols({ meshcore: true, meshtastic: true });
+    expect(cats).toEqual([...MESHCORE_CATEGORIES, ...MESHTASTIC_CATEGORIES]);
+  });
+  it('nothing connected yet falls back to the full set (never empty)', () => {
+    const cats = categoriesForProtocols({ meshcore: false, meshtastic: false });
+    expect(cats).toEqual(NODE_TYPE_CATEGORIES);
   });
 });

--- a/src/utils/nodeTypeCategory.ts
+++ b/src/utils/nodeTypeCategory.ts
@@ -1,30 +1,109 @@
 /**
  * Node-type categorization shared by the map's role icons, the node-type
- * filter, and the legend (issue #3546). One function decides a node's category
- * so the icon a user sees and the checkbox that hides it can never disagree.
+ * filter, and the legend (issue #3546, refined for #3610). One function decides
+ * a node's category so the icon a user sees and the checkbox that hides it can
+ * never disagree.
  *
- * MeshCore advert types (firmware): Chat/Companion=1, Repeater=2, Room=3,
- * Sensor=4 (`ADV_TYPE_NAME` in meshcorePacketDecode.ts; `MeshCoreDeviceType`
- * in meshcoreManager.ts). The feature request's "Observer" maps to the real
- * Sensor advert type. Meshtastic nodes have no advert type — their ROUTER role
- * (value 2) is treated as a repeater so infrastructure folds into one category
- * across both protocols; everything else is "standard".
+ * Two protocols, two category families:
+ *
+ * - **MeshCore** advert types (firmware): Chat/Companion=1, Repeater=2, Room=3,
+ *   Sensor=4 (`ADV_TYPE_NAME` in meshcorePacketDecode.ts; `MeshCoreDeviceType`
+ *   in meshcoreManager.ts). These map to the `companion`/`repeater`/`roomServer`/
+ *   `sensor` categories; anything else is `standard`.
+ *
+ * - **Meshtastic** device roles (`DEVICE_ROLES` in deviceRole.ts). Pre-#3610 the
+ *   filter folded *every* Meshtastic node into either `repeater` (ROUTER) or
+ *   `standard`, so a Meshtastic-only instance got three permanently-empty
+ *   MeshCore options and no way to tell a TRACKER from a CLIENT. Now each
+ *   meaningful role gets its own `mt*` category so the filter is useful.
+ *
+ * The filter UI and legend compute the *visible* category set from the source
+ * types actually connected, so a Meshtastic-only instance never shows
+ * MeshCore-only options and vice-versa. The persisted filter still keys on
+ * these stable category names; a stale toggle for a category that isn't
+ * currently present is simply inert (default visible).
  */
 
-export type NodeTypeCategory =
+import { DEVICE_ROLES } from './deviceRole';
+
+/** MeshCore advert-type categories (issue #3546). */
+export type MeshCoreCategory =
   | 'repeater'
   | 'roomServer'
   | 'sensor'
   | 'companion'
   | 'standard';
 
-/** Display order for the filter checkboxes and legend (infrastructure first). */
-export const NODE_TYPE_CATEGORIES: NodeTypeCategory[] = [
+/** Meshtastic device-role categories (issue #3610). */
+export type MeshtasticCategory =
+  | 'mtClient'
+  | 'mtClientMute'
+  | 'mtRouter'
+  | 'mtRouterClient'
+  | 'mtRepeater'
+  | 'mtTracker'
+  | 'mtSensor'
+  | 'mtTak'
+  | 'mtClientHidden'
+  | 'mtLostAndFound'
+  | 'mtTakTracker'
+  | 'mtRouterLate'
+  | 'mtClientBase';
+
+export type NodeTypeCategory = MeshCoreCategory | MeshtasticCategory;
+
+/** Display order for MeshCore categories (infrastructure first). */
+export const MESHCORE_CATEGORIES: MeshCoreCategory[] = [
   'repeater',
   'roomServer',
   'sensor',
   'companion',
   'standard',
+];
+
+/**
+ * Maps a Meshtastic numeric role (see {@link DEVICE_ROLES}) to its category.
+ */
+export const MESHTASTIC_ROLE_TO_CATEGORY: Record<number, MeshtasticCategory> = {
+  0: 'mtClient',
+  1: 'mtClientMute',
+  2: 'mtRouter',
+  3: 'mtRouterClient', // deprecated
+  4: 'mtRepeater', // deprecated
+  5: 'mtTracker',
+  6: 'mtSensor',
+  7: 'mtTak',
+  8: 'mtClientHidden',
+  9: 'mtLostAndFound',
+  10: 'mtTakTracker',
+  11: 'mtRouterLate',
+  12: 'mtClientBase',
+};
+
+/** Display order for Meshtastic categories (infrastructure first, then clients). */
+export const MESHTASTIC_CATEGORIES: MeshtasticCategory[] = [
+  'mtRouter',
+  'mtRouterLate',
+  'mtRepeater',
+  'mtClient',
+  'mtClientMute',
+  'mtClientHidden',
+  'mtClientBase',
+  'mtRouterClient',
+  'mtTracker',
+  'mtSensor',
+  'mtTak',
+  'mtTakTracker',
+  'mtLostAndFound',
+];
+
+/**
+ * Every category, for code that needs the full universe (config defaults,
+ * persisted-state hydration). Order is MeshCore-first then Meshtastic.
+ */
+export const NODE_TYPE_CATEGORIES: NodeTypeCategory[] = [
+  ...MESHCORE_CATEGORIES,
+  ...MESHTASTIC_CATEGORIES,
 ];
 
 export interface NodeTypeCategoryMeta {
@@ -33,15 +112,67 @@ export interface NodeTypeCategoryMeta {
   labelKey: string;
   /** English fallback so untranslated locales still render. */
   label: string;
+  /** Which protocol family this category belongs to. */
+  protocol: 'meshcore' | 'meshtastic';
 }
 
 export const NODE_TYPE_CATEGORY_META: Record<NodeTypeCategory, NodeTypeCategoryMeta> = {
-  repeater:   { key: 'repeater',   labelKey: 'map.nodeType.repeater',   label: 'Repeater' },
-  roomServer: { key: 'roomServer', labelKey: 'map.nodeType.roomServer', label: 'Room Server' },
-  sensor:     { key: 'sensor',     labelKey: 'map.nodeType.sensor',     label: 'Sensor' },
-  companion:  { key: 'companion',  labelKey: 'map.nodeType.companion',  label: 'Companion' },
-  standard:   { key: 'standard',   labelKey: 'map.nodeType.standard',   label: 'Standard' },
+  // MeshCore
+  repeater:   { key: 'repeater',   labelKey: 'map.nodeType.repeater',   label: 'Repeater',    protocol: 'meshcore' },
+  roomServer: { key: 'roomServer', labelKey: 'map.nodeType.roomServer', label: 'Room Server', protocol: 'meshcore' },
+  sensor:     { key: 'sensor',     labelKey: 'map.nodeType.sensor',     label: 'Sensor',      protocol: 'meshcore' },
+  companion:  { key: 'companion',  labelKey: 'map.nodeType.companion',  label: 'Companion',   protocol: 'meshcore' },
+  standard:   { key: 'standard',   labelKey: 'map.nodeType.standard',   label: 'Standard',    protocol: 'meshcore' },
+  // Meshtastic — labels reuse DEVICE_ROLES names for consistency with the node list.
+  mtRouter:       { key: 'mtRouter',       labelKey: 'map.nodeType.mtRouter',       label: DEVICE_ROLES[2],  protocol: 'meshtastic' },
+  mtRouterLate:   { key: 'mtRouterLate',   labelKey: 'map.nodeType.mtRouterLate',   label: DEVICE_ROLES[11], protocol: 'meshtastic' },
+  mtRepeater:     { key: 'mtRepeater',     labelKey: 'map.nodeType.mtRepeater',     label: DEVICE_ROLES[4],  protocol: 'meshtastic' },
+  mtClient:       { key: 'mtClient',       labelKey: 'map.nodeType.mtClient',       label: DEVICE_ROLES[0],  protocol: 'meshtastic' },
+  mtClientMute:   { key: 'mtClientMute',   labelKey: 'map.nodeType.mtClientMute',   label: DEVICE_ROLES[1],  protocol: 'meshtastic' },
+  mtClientHidden: { key: 'mtClientHidden', labelKey: 'map.nodeType.mtClientHidden', label: DEVICE_ROLES[8],  protocol: 'meshtastic' },
+  mtClientBase:   { key: 'mtClientBase',   labelKey: 'map.nodeType.mtClientBase',   label: DEVICE_ROLES[12], protocol: 'meshtastic' },
+  mtRouterClient: { key: 'mtRouterClient', labelKey: 'map.nodeType.mtRouterClient', label: DEVICE_ROLES[3],  protocol: 'meshtastic' },
+  mtTracker:      { key: 'mtTracker',      labelKey: 'map.nodeType.mtTracker',      label: DEVICE_ROLES[5],  protocol: 'meshtastic' },
+  mtSensor:       { key: 'mtSensor',       labelKey: 'map.nodeType.mtSensor',       label: DEVICE_ROLES[6],  protocol: 'meshtastic' },
+  mtTak:          { key: 'mtTak',          labelKey: 'map.nodeType.mtTak',          label: DEVICE_ROLES[7],  protocol: 'meshtastic' },
+  mtTakTracker:   { key: 'mtTakTracker',   labelKey: 'map.nodeType.mtTakTracker',   label: DEVICE_ROLES[10], protocol: 'meshtastic' },
+  mtLostAndFound: { key: 'mtLostAndFound', labelKey: 'map.nodeType.mtLostAndFound', label: DEVICE_ROLES[9],  protocol: 'meshtastic' },
 };
+
+/**
+ * The glyph "family" a category draws with. Several Meshtastic roles share the
+ * MeshCore glyph silhouettes (a ROUTER is drawn as a repeater tower, a SENSOR
+ * as a sensor broadcast, etc.) so map icons stay recognizable without inventing
+ * a unique glyph per role. `'standard'` = fall back to the default pin.
+ */
+export function categoryGlyphFamily(category: NodeTypeCategory): MeshCoreCategory {
+  switch (category) {
+    case 'repeater':
+    case 'roomServer':
+    case 'sensor':
+    case 'companion':
+    case 'standard':
+      return category;
+    case 'mtRouter':
+    case 'mtRouterLate':
+    case 'mtRepeater':
+      return 'repeater';
+    case 'mtSensor':
+      return 'sensor';
+    case 'mtClient':
+    case 'mtClientMute':
+    case 'mtClientHidden':
+    case 'mtClientBase':
+    case 'mtRouterClient':
+    case 'mtTracker':
+    case 'mtTak':
+    case 'mtTakTracker':
+    case 'mtLostAndFound':
+      return 'standard';
+    default:
+      return 'standard';
+  }
+}
 
 /** The subset of a node record needed to determine its category. */
 export interface CategorizableNode {
@@ -63,13 +194,19 @@ function toRoleNum(value: number | string | null | undefined): number {
   return NaN;
 }
 
+/** True when a node carries MeshCore identity (advType present / isMeshCore). */
+export function isMeshCoreNode(node: CategorizableNode): boolean {
+  return !!node.isMeshCore || typeof node.advType === 'number';
+}
+
 /**
- * Classify a node into one of the five {@link NodeTypeCategory} buckets. Pure
- * and total — unknown/missing role data falls back to `'standard'`.
+ * Classify a node into one {@link NodeTypeCategory} bucket. Pure and total —
+ * MeshCore nodes map by advType, Meshtastic nodes map by device role, and
+ * unknown/missing data falls back to `'standard'` (MeshCore) or `'mtClient'`
+ * (Meshtastic, the default role).
  */
 export function getNodeTypeCategory(node: CategorizableNode): NodeTypeCategory {
-  const isMeshCore = !!node.isMeshCore || typeof node.advType === 'number';
-  if (isMeshCore) {
+  if (isMeshCoreNode(node)) {
     switch (toRoleNum(node.advType)) {
       case 1: return 'companion';
       case 2: return 'repeater';
@@ -78,10 +215,11 @@ export function getNodeTypeCategory(node: CategorizableNode): NodeTypeCategory {
       default: return 'standard';
     }
   }
-  // Meshtastic: ROUTER (role 2) is infrastructure; mirror the existing
-  // `isRouter` test in NodeMarkersLayer so the tower icon stays consistent.
-  if (toRoleNum(node.user?.role ?? node.role) === 2) return 'repeater';
-  return 'standard';
+  // Meshtastic: map each role to its own category so the filter is meaningful
+  // on a Meshtastic-only instance (issue #3610). Missing/garbage role => the
+  // default CLIENT bucket rather than an unrelated MeshCore "standard".
+  const roleNum = toRoleNum(node.user?.role ?? node.role);
+  return MESHTASTIC_ROLE_TO_CATEGORY[roleNum] ?? 'mtClient';
 }
 
 /** A node passes the filter when its category is enabled (default: enabled). */
@@ -90,4 +228,31 @@ export function nodePassesTypeFilter(
   enabledByCategory: Partial<Record<NodeTypeCategory, boolean>>,
 ): boolean {
   return enabledByCategory[getNodeTypeCategory(node)] !== false;
+}
+
+/**
+ * Compute the ordered set of categories the filter/legend should expose, given
+ * the protocol families that are actually connected. A Meshtastic-only instance
+ * gets only Meshtastic role categories; MeshCore-only gets the MeshCore
+ * categories; both connected unions them (MeshCore first, then Meshtastic).
+ *
+ * `'standard'` (the MeshCore catch-all) is only meaningful for MeshCore, so it
+ * rides along with the MeshCore set.
+ */
+export function categoriesForProtocols(opts: {
+  meshcore: boolean;
+  meshtastic: boolean;
+}): NodeTypeCategory[] {
+  const { meshcore, meshtastic } = opts;
+  // When nothing is known yet, show everything rather than an empty filter.
+  if (!meshcore && !meshtastic) return NODE_TYPE_CATEGORIES;
+  const out: NodeTypeCategory[] = [];
+  if (meshcore) out.push(...MESHCORE_CATEGORIES);
+  if (meshtastic) out.push(...MESHTASTIC_CATEGORIES);
+  return out;
+}
+
+/** Classify a source `type` string into its protocol family. */
+export function sourceTypeProtocol(type: string | undefined | null): 'meshcore' | 'meshtastic' {
+  return type === 'meshcore' ? 'meshcore' : 'meshtastic';
 }


### PR DESCRIPTION
## Problem

Closes #3610.

The Map Analysis node-type filter exposed **five fixed MeshCore-centric categories** (Companion / Repeater / Room Server / Sensor / Standard) regardless of which source types were connected. On a **Meshtastic-only** instance this was wrong:

- *Companion*, *Room Server*, *Sensor* mapped to MeshCore advTypes only and were permanently empty.
- *Standard* collapsed every non-Router Meshtastic role (CLIENT, CLIENT_MUTE, TRACKER, SENSOR, CLIENT_HIDDEN, ROUTER_LATE, CLIENT_BASE, TAK, …) into one indistinguishable bucket.

## Fix — adaptive categories

The filter (and the analysis legend) now adapt to the protocol families actually in scope:

| Connected sources | Categories shown |
|---|---|
| Meshtastic-only | Granular Meshtastic role categories (Router, Router Late, Tracker, Sensor, Client, Client Mute, Client Hidden, Client Base, TAK, …) |
| MeshCore-only | Existing MeshCore advType categories (unchanged) |
| Both | Union — MeshCore first, then Meshtastic |

### How it works
- `getNodeTypeCategory()` now maps each Meshtastic device role to its own `mt*` category instead of folding into `repeater`/`standard`. Labels reuse the shared `DEVICE_ROLES` map so they match the node list.
- `categoriesForProtocols({ meshcore, meshtastic })` computes the ordered visible set; `useVisibleNodeTypeCategories()` derives the connected protocols from the sources in Map Analysis scope (`config.sources`, or all enabled sources).
- Map glyphs are preserved via a new `categoryGlyphFamily()`: Meshtastic ROUTER / ROUTER_LATE / REPEATER draw the repeater tower, SENSOR draws the sensor glyph, client roles fall back to the default pin. `roleGlyphInnerSvg`/`roleGlyphMarkerSvg` resolve through it, so the marker a user sees still matches the checkbox.
- **MeshCore-only surfaces are unchanged**: `MeshCoreMap` and the legacy `MapLegend` now iterate `MESHCORE_CATEGORIES` explicitly, so the #3546/#3563 MeshCore icons/filter behavior is identical.

### Persisted-state degradation
Toggles still key on stable category names and default to **visible** when missing. A stale `false` toggle for a category that drops out of scope (e.g. a MeshCore category after switching to Meshtastic-only) is inert and never permanently hides a node when the source mix changes. Covered by a dedicated test.

## Tests
- Extended `nodeTypeCategory.test.ts`: Meshtastic role→category mapping (all 13 roles), MeshCore advType mapping, `categoriesForProtocols` for Meshtastic-only / MeshCore-only / both / none, `categoryGlyphFamily`, `sourceTypeProtocol`, graceful-degradation case.
- Extended `mapIcons.test.ts`: Meshtastic categories render via shared glyph family; client roles return empty glyph.
- Full Vitest suite: **success=true, 7101 passed, 0 failed, 0 failed suites** (JSON reporter).
- `tsc -p tsconfig.server.json --noEmit` and frontend `tsc --noEmit`: no new errors in changed files (only the pre-existing TelemetryChart / 57 frontend errors remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)