### PR TITLE
fix(position-estimation): large uncertainty for weight-dominated single-anchor solves (#3616)

### DIFF
--- a/src/server/services/positionEstimationService.test.ts
+++ b/src/server/services/positionEstimationService.test.ts
@@ -97,6 +97,65 @@ describe('solveNodePosition', () => {
     const dayOld = observationWeight(obs({ timestamp: NOW - 24 * 60 * 60 * 1000 }), NOW);
     expect(dayOld).toBeCloseTo(fresh / 2, 5); // 24h half-life
   });
+
+  describe('SNR → weight ordering (issue #3616)', () => {
+    // The weight model must be 10^(snr/10): higher (less negative) SNR → higher
+    // weight → node pulled toward that anchor. A weak link must NOT pull harder.
+    it('maps higher SNR to higher weight (not inverted)', () => {
+      const w = (snrDb: number) => observationWeight(obs({ snrDb }), NOW);
+      // Independently computed expected weights: 10^(-12/10)≈0.063, 10^0=1, 10^1=10.
+      expect(w(-12)).toBeCloseTo(0.0631, 4);
+      expect(w(0)).toBeCloseTo(1, 5);
+      expect(w(10)).toBeCloseTo(10, 5);
+      // Strictly increasing with SNR — the whole point of issue #3616.
+      expect(w(-12)).toBeLessThan(w(0));
+      expect(w(0)).toBeLessThan(w(10));
+    });
+  });
+
+  describe('single low-confidence anchor stays uncertain (issue #3616)', () => {
+    // A node seen by exactly one anchor at -12 dB collapses to that anchor (the
+    // max-likelihood point for a single observation) but MUST report a large,
+    // unreliable radius — not a tight confident one.
+    it('a lone -12 dB anchor reports the full radio-range uncertainty', () => {
+      const solved = solveNodePosition([
+        obs({ anchorLat: 10, anchorLon: 20, snrDb: -12 }),
+      ], NOW)!;
+      expect(solved.latitude).toBeCloseTo(10, 5);  // at the anchor
+      expect(solved.uncertaintyKm).toBe(5);        // DEFAULT_SINGLE_ANCHOR_KM, unreliable
+    });
+
+    // The regression case from issue #3616: a strong anchor and a far weak (-12 dB)
+    // anchor. The centroid collapses onto the strong anchor and the weak/far one
+    // barely contributes to the weighted RMS. Before the fix nEff was ~1.01 (just
+    // above the old `nEff <= 1` cutoff) so it skipped the radio-range default and
+    // reported a spuriously tight <1 km radius. It must now stay large/unreliable.
+    it('does not report false confidence when one strong anchor dominates a far weak one', () => {
+      const solved = solveNodePosition([
+        obs({ anchorLat: 10.0, anchorLon: 20, snrDb: 10 }),    // strong, "reporter's house"
+        obs({ anchorLat: 10.036, anchorLon: 20, snrDb: -12 }), // weak, ~4 km away
+      ], NOW)!;
+      // Estimate collapses onto the strong anchor (expected — it dominates).
+      expect(solved.latitude).toBeCloseTo(10.0, 2);
+      // ...but the radius reflects the near-single-observation confidence: large,
+      // close to the radio-range default — NOT a sub-km confident circle.
+      expect(solved.uncertaintyKm).toBeGreaterThan(4);
+    });
+
+    // Guard against regressing genuinely balanced multi-anchor estimates: equal
+    // SNR anchors give nEff == anchor count, confidence == 1, so the radius is the
+    // pure statistical estimate. A tight cluster must stay confident (small).
+    it('keeps a balanced tight 4-anchor cluster confident', () => {
+      const tight = solveNodePosition([
+        obs({ anchorLat: 10.005, anchorLon: 20, snrDb: 0 }),
+        obs({ anchorLat: 9.995, anchorLon: 20, snrDb: 0 }),
+        obs({ anchorLat: 10, anchorLon: 20.005, snrDb: 0 }),
+        obs({ anchorLat: 10, anchorLon: 19.995, snrDb: 0 }),
+      ], NOW)!;
+      expect(tight.latitude).toBeCloseTo(10, 4);
+      expect(tight.uncertaintyKm).toBeLessThan(1); // confident, unchanged by the fix
+    });
+  });
 });
 
 describe('buildObservations', () => {

--- a/src/server/services/positionEstimationService.ts
+++ b/src/server/services/positionEstimationService.ts
@@ -95,6 +95,18 @@ export function observationWeight(obs: PositionObservation, now: number): number
  * few / spread-out observations → large radius. A lone anchor falls back to a
  * radio-range default.
  *
+ * Effective-sample-size guard (issue #3616): with skewed SNR weights one strong
+ * anchor can dominate, collapsing the centroid onto it while the weak/far anchors
+ * contribute almost nothing to the weighted RMS — yielding a tiny, falsely
+ * confident radius for what is effectively a single observation. The weight model
+ * itself is correct (higher SNR → higher weight → pulled toward that anchor); the
+ * fix is purely on uncertainty. We blend the radio-range default toward the
+ * statistical radius using the Kish effective sample size `nEff`: at `nEff = 1`
+ * (a lone — or weight-dominated — anchor) uncertainty is the full radio-range
+ * default; it reaches the pure statistical estimate only once `nEff >= 2` (a
+ * genuinely balanced multi-anchor solve). This does not change balanced
+ * multi-anchor estimates, only the degenerate near-single cases.
+ *
  * @returns null if there are no usable (positive-weight) observations.
  */
 export function solveNodePosition(observations: PositionObservation[], now: number): SolvedPosition | null {
@@ -131,12 +143,19 @@ export function solveNodePosition(observations: PositionObservation[], now: numb
   }
   const rmsKm = Math.sqrt(weightedDist2 / wSum);
 
-  let uncertaintyKm: number;
-  if (nEff <= 1) {
-    uncertaintyKm = DEFAULT_SINGLE_ANCHOR_KM;
-  } else {
-    uncertaintyKm = Math.max(MIN_UNCERTAINTY_KM, rmsKm / Math.sqrt(nEff));
-  }
+  // Statistical radius: weighted-RMS spread shrunk by sqrt(effective N). Only
+  // trustworthy once we genuinely have multiple balanced observations.
+  const statisticalKm = Math.max(MIN_UNCERTAINTY_KM, rmsKm / Math.sqrt(Math.max(nEff, 1)));
+
+  // Blend factor from 0 (nEff = 1, effectively a single observation) to 1
+  // (nEff >= 2, a balanced multi-anchor solve). This closes issue #3616: a
+  // strong anchor that dominates the weights (nEff barely above 1) no longer
+  // skips the radio-range default and report a spuriously tight radius.
+  const confidence = Math.min(1, Math.max(0, nEff - 1));
+  const uncertaintyKm = Math.max(
+    MIN_UNCERTAINTY_KM,
+    DEFAULT_SINGLE_ANCHOR_KM * (1 - confidence) + statisticalKm * confidence,
+  );
 
   return { latitude, longitude, uncertaintyKm, observationCount: observations.length };
 }


### PR DESCRIPTION
## Summary

Issue #3616 hypothesized that the SNR weighting in position estimation was **inverted**, collapsing weak-signal nodes onto the anchor. After reading `positionEstimationService.ts` end-to-end, the weighting is **correct** — the real bug is in the **uncertainty calculation**.

## Root cause (investigation)

The weight model is `10^(snrDb/10)` (`observationWeight`, lines 77-84):
- `-12 dB → 0.063`, `0 dB → 1`, `+10 dB → 10`. **Higher SNR → higher weight → pulled toward that anchor.** Not inverted.

The actual bug: `solveNodePosition` computed uncertainty as
```ts
if (nEff <= 1) uncertaintyKm = DEFAULT_SINGLE_ANCHOR_KM; // 5km
else uncertaintyKm = max(MIN, rmsKm / sqrt(nEff));
```
With **skewed weights** (one strong anchor + one far weak -12 dB anchor, the exact symptom), the weighted centroid collapses onto the strong anchor, the far/weak anchor barely contributes to the weighted RMS, and the Kish effective sample size `nEff` lands just **above** 1 (~1.01). That skips the 5 km single-anchor branch and the `rmsKm/sqrt(nEff)` formula reports a spuriously tight **sub-km** radius — a confident, wrong "inside the reporter's house" estimate.

So this is the uncertainty-calc bug (hypothesis b/c), not inverted weighting (hypothesis a).

## Fix

Blend the radio-range default toward the statistical radius using `nEff`:
- `nEff = 1` (lone or weight-dominated anchor) → full 5 km radio-range default.
- `nEff >= 2` (balanced multi-anchor) → pure statistical estimate (unchanged).
- Linear blend in between (`confidence = clamp(nEff - 1, 0, 1)`).

The weight model is left as-is (it is physically correct). No sign was flipped.

## Before / after — issue's case (strong +10 dB anchor + weak −12 dB anchor ~4 km apart) | | latitude | nEff | uncertaintyKm |
|---|---|---|---|
| **Before** | 10.0002 (at anchor) | 1.013 | **0.31 km (falsely confident)** |
| **After** | 10.0002 (at anchor) | 1.013 | **4.94 km (correctly unreliable)** |

The estimate still collapses onto the dominant anchor (the max-likelihood point for an effectively-single observation), but now carries a large uncertainty radius flagging it as unreliable.

A truly lone −12 dB anchor still reports exactly 5 km. Balanced tight 4-anchor clusters stay confident (<1 km), unchanged.

## Tests

Added to `positionEstimationService.test.ts`:
- SNR→weight ordering: `weight(-12) < weight(0) < weight(+10)` with independently-computed values (0.063 / 1 / 10).
- Lone −12 dB anchor → estimate at anchor, `uncertaintyKm === 5`.
- Issue regression: strong + far weak anchor → `uncertaintyKm > 4` (not a sub-km confident circle).
- Balanced tight 4-anchor cluster → `uncertaintyKm < 1` (no regression to confident estimates).

## Verification

- Full Vitest suite: **success=true, 7099 passed, 0 failed, 2392 suites** (JSON reporter).
- `tsc -p tsconfig.server.json --noEmit`: no new errors (the only errors are 5 pre-existing unrelated ones in `TelemetryChart.tsx`).

Closes #3616

🤖 Generated with [Claude Code](https://claude.com/claude-code)