### PR TITLE
feat(map): spiderfy overlapping markers on Map Analysis and Unified maps (#3612)

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -88,6 +88,14 @@ vi.mock('./DashboardWaypoints', () => ({
   default: () => <div data-testid="dashboard-waypoints" />,
 }));
 
+// SpiderfierController drives the real Leaflet OverlappingMarkerSpiderfier, which
+// needs a live map instance. In these DOM-light tests the map is mocked, so stub
+// the controller to a no-op that still renders (#3612). The marker-ref bridge
+// only invokes spiderfierRef methods, so a null ref is harmless here.
+vi.mock('../SpiderfierController', () => ({
+  SpiderfierController: () => <div data-testid="spiderfier-controller" />,
+}));
+
 // ---------------------------------------------------------------------------
 // Test data
 // ---------------------------------------------------------------------------
@@ -190,6 +198,11 @@ describe('DashboardMap', () => {
     render(<DashboardMap {...defaultProps} />);
     expect(screen.getByTestId('map-container')).toBeInTheDocument();
     expect(screen.getByTestId('tile-layer')).toBeInTheDocument();
+  });
+
+  it('mounts the shared SpiderfierController so co-located markers fan out (#3612)', () => {
+    render(<DashboardMap {...defaultProps} nodes={[nodeWithPosition]} />);
+    expect(screen.getByTestId('spiderfier-controller')).toBeInTheDocument();
   });
 
   it('renders markers for nodes with valid positions', () => {

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -14,8 +14,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import 'leaflet/dist/leaflet.css';
 import { MapContainer, TileLayer, Marker, Popup, Polyline, Rectangle, useMap } from 'react-leaflet';
-import L from 'leaflet';
+import L, { type Marker as LeafletMarker } from 'leaflet';
 import { createNodeIcon } from '../../utils/mapIcons';
+import { SpiderfierController, type SpiderfierControllerRef } from '../SpiderfierController';
 import { getTilesetById } from '../../config/tilesets';
 import type { CustomTileset, TilesetId } from '../../config/tilesets';
 import DashboardWaypoints from './DashboardWaypoints';
@@ -155,6 +156,33 @@ export default function DashboardMap({
 }: DashboardMapProps) {
   const tileset = getTilesetById(tilesetId, customTilesets);
   const { mapPinStyle, setMapTileset } = useSettings();
+
+  // Spiderfier: fan out co-located markers so each node (incl. estimated-position
+  // nodes that collapse onto the same anchor) is individually selectable (#3612).
+  // Reuses the SAME shared SpiderfierController + tuning as the per-source NodesTab
+  // map and Map Analysis. Stable per-key ref handlers bridge react-leaflet's
+  // declarative <Marker> to the imperative Leaflet markers the spiderfier tracks.
+  const spiderfierRef = useRef<SpiderfierControllerRef>(null);
+  const markerByKey = useRef<Map<string, LeafletMarker>>(new Map());
+  const refHandlers = useRef<Map<string, (m: LeafletMarker | null) => void>>(new Map());
+  const getMarkerRef = (key: string) => {
+    let h = refHandlers.current.get(key);
+    if (!h) {
+      h = (m: LeafletMarker | null) => {
+        const prev = markerByKey.current.get(key);
+        if (m) {
+          markerByKey.current.set(key, m);
+          spiderfierRef.current?.addMarker(m, key);
+        } else {
+          if (prev) spiderfierRef.current?.removeMarker(prev);
+          markerByKey.current.delete(key);
+          refHandlers.current.delete(key);
+        }
+      };
+      refHandlers.current.set(key, h);
+    }
+    return h;
+  };
 
   // Tile selector + legend overlays — hidden by default, toggled from the Map
   // Features panel. Persisted under the same localStorage keys the NodesTab map
@@ -362,6 +390,8 @@ export default function DashboardMap({
           maxZoom={tileset.maxZoom}
         />
 
+        <SpiderfierController ref={spiderfierRef} />
+
         <MapBoundsUpdater positions={nodePositions} sourceId={sourceId} />
 
         {showLegend && <MapLegend />}
@@ -383,10 +413,18 @@ export default function DashboardMap({
             showLabel: true,
             pinStyle: mapPinStyle,
           });
+          // Stable spiderfier key — prefer the cross-source identity, fall back to
+          // nodeId so MeshCore (no nodeNum) and unmerged rows still register.
+          const markerKey = String(
+            node.sourceId != null && node.nodeNum != null
+              ? `${node.sourceId}:${node.nodeNum}`
+              : nodeId ?? node.nodeNum,
+          );
 
           return (
             <Marker
               key={nodeId}
+              ref={getMarkerRef(markerKey)}
               position={[pos.lat, pos.lng]}
               icon={icon}
             >

--- a/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
+++ b/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
@@ -8,7 +8,7 @@ import {
 import { useHopCounts } from '../../../hooks/useMapAnalysisData';
 import { useSettings } from '../../../contexts/SettingsContext';
 import { useMapAnalysisCtx } from '../MapAnalysisContext';
-import { useMarkerSpiderfier } from '../../../hooks/useMarkerSpiderfier';
+import { useMarkerSpiderfier, SHARED_SPIDERFIER_OPTIONS } from '../../../hooks/useMarkerSpiderfier';
 import { resolveNodeLatLng, type MaybePositionedNode } from '../nodePositionUtil';
 import { nodeMatchesSearch } from '../nodeSearch';
 import { createNodeIcon } from '../../../utils/mapIcons';
@@ -48,9 +48,12 @@ export default function NodeMarkersLayer() {
   const { mapPinStyle } = useSettings();
 
   // Spiderfier fans out markers that share (rounded) coordinates so each node in
-  // a cluster is individually selectable (issue #3399). Same bridge pattern as
-  // NodesTab: stable per-key ref handlers feed the imperative Leaflet markers in.
-  const { addMarker, removeMarker } = useMarkerSpiderfier({ keepSpiderfied: true });
+  // a cluster is individually selectable (issues #3399, #3612). Same bridge
+  // pattern as NodesTab: stable per-key ref handlers feed the imperative Leaflet
+  // markers in. Uses the SHARED tuning (50px nearbyDistance etc.) so every map
+  // surface fans out identically — the prior default 20px radius missed
+  // near-but-not-identical co-located nodes.
+  const { addMarker, removeMarker } = useMarkerSpiderfier(SHARED_SPIDERFIER_OPTIONS);
   const markerByKey = useRef<Map<string, LeafletMarker>>(new Map());
   const refHandlers = useRef<Map<string, (m: LeafletMarker | null) => void>>(new Map());
   const getMarkerRef = (key: string) => {

--- a/src/components/SpiderfierController.test.tsx
+++ b/src/components/SpiderfierController.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Covers the shared spiderfy primitive used by ALL three map surfaces
+ * (per-source NodesTab map, Map Analysis, Unified/Dashboard map) — issue #3612.
+ *
+ * The real OverlappingMarkerSpiderfier needs a live Leaflet map, so we mock
+ * `useMarkerSpiderfier` and assert that:
+ *   1. SpiderfierController feeds it the SHARED tuning (so every map fans out
+ *      identically — notably the 50px nearbyDistance that catches co-located /
+ *      estimated-position nodes the library's 20px default misses), and
+ *   2. its imperative ref methods are exposed to callers (the marker ref bridge).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createRef } from 'react';
+import { SHARED_SPIDERFIER_OPTIONS } from '../hooks/useMarkerSpiderfier';
+
+const addMarker = vi.fn();
+const removeMarker = vi.fn();
+const addListener = vi.fn();
+const removeListener = vi.fn();
+const getSpiderfier = vi.fn();
+const useMarkerSpiderfierMock = vi.fn(() => ({
+  addMarker,
+  removeMarker,
+  addListener,
+  removeListener,
+  getSpiderfier,
+}));
+
+vi.mock('../hooks/useMarkerSpiderfier', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../hooks/useMarkerSpiderfier')>();
+  return {
+    ...actual,
+    useMarkerSpiderfier: (...args: unknown[]) => useMarkerSpiderfierMock(...(args as [])),
+  };
+});
+
+import { SpiderfierController, type SpiderfierControllerRef } from './SpiderfierController';
+
+describe('SHARED_SPIDERFIER_OPTIONS', () => {
+  it('uses the tuned 50px nearbyDistance from the per-source reference (not the 20px default)', () => {
+    // 50px is what lets co-located / estimated-position nodes group + spread.
+    expect(SHARED_SPIDERFIER_OPTIONS.nearbyDistance).toBe(50);
+    expect(SHARED_SPIDERFIER_OPTIONS.keepSpiderfied).toBe(true);
+    expect(SHARED_SPIDERFIER_OPTIONS.circleFootSeparation).toBe(50);
+    expect(SHARED_SPIDERFIER_OPTIONS.spiralFootSeparation).toBe(50);
+  });
+});
+
+describe('SpiderfierController', () => {
+  it('initializes the spiderfier with the SHARED tuning', () => {
+    render(<SpiderfierController />);
+    expect(useMarkerSpiderfierMock).toHaveBeenCalledWith(SHARED_SPIDERFIER_OPTIONS);
+  });
+
+  it('exposes the imperative add/remove API the marker ref bridge depends on', () => {
+    const ref = createRef<SpiderfierControllerRef>();
+    render(<SpiderfierController ref={ref} />);
+    expect(ref.current).toBeTruthy();
+
+    const marker = {} as never;
+    ref.current!.addMarker(marker, 'src:42');
+    expect(addMarker).toHaveBeenCalledWith(marker, 'src:42');
+
+    ref.current!.removeMarker(marker);
+    expect(removeMarker).toHaveBeenCalledWith(marker);
+  });
+
+  it('accepts an optional zoomLevel without requiring it', () => {
+    // Map Analysis / Dashboard mount it with no zoom prop; NodesTab passes one.
+    expect(() => render(<SpiderfierController zoomLevel={12} />)).not.toThrow();
+  });
+});

--- a/src/components/SpiderfierController.tsx
+++ b/src/components/SpiderfierController.tsx
@@ -6,34 +6,16 @@
 import { useImperativeHandle, forwardRef } from 'react';
 import { Marker as LeafletMarker } from 'leaflet';
 import { OverlappingMarkerSpiderfier, type SpiderfierEventMap, type SpiderfierEventHandler } from 'ts-overlapping-marker-spiderfier-leaflet';
-import { useMarkerSpiderfier } from '../hooks/useMarkerSpiderfier';
-
-/**
- * Spiderfier configuration constants
- */
-const SPIDERFIER_CONFIG = {
-  /** Pixel radius for detecting overlapping markers - 50px catches markers at same GPS coords */
-  NEARBY_DISTANCE: 50,
-  /** Number of markers before switching from circle to spiral layout */
-  CIRCLE_SPIRAL_SWITCHOVER: 9,
-  /** Distance between markers in circle layout (pixels) - increased for better separation */
-  CIRCLE_FOOT_SEPARATION: 50,
-  /** Distance between markers in spiral layout (pixels) - increased for better separation */
-  SPIRAL_FOOT_SEPARATION: 50,
-  /** Starting radius for spiral layout (pixels) - larger start for better spacing */
-  SPIRAL_LENGTH_START: 20,
-  /** How quickly spiral grows - higher = faster growth and more spacing */
-  SPIRAL_LENGTH_FACTOR: 8,
-  /** Line thickness for spider legs */
-  LEG_WEIGHT: 2,
-} as const;
+import { useMarkerSpiderfier, SHARED_SPIDERFIER_OPTIONS } from '../hooks/useMarkerSpiderfier';
 
 interface SpiderfierControllerProps {
   /**
-   * Current zoom level of the map
-   * Used to adjust spiderfier behavior based on zoom
+   * Current zoom level of the map.
+   * Reserved for future zoom-dependent tuning; currently unused but kept so
+   * existing callers (NodesTab) don't need to change. Optional so the shared
+   * maps (Map Analysis, Dashboard) can mount it without a zoom prop.
    */
-  zoomLevel: number;
+  zoomLevel?: number;
 }
 
 export interface SpiderfierControllerRef {
@@ -52,20 +34,8 @@ export interface SpiderfierControllerRef {
 
 export const SpiderfierController = forwardRef<SpiderfierControllerRef, SpiderfierControllerProps>(
   ({}, ref) => {
-    const { addMarker, removeMarker, addListener, removeListener, getSpiderfier } = useMarkerSpiderfier({
-      keepSpiderfied: true, // Keep markers fanned out after clicking
-      nearbyDistance: SPIDERFIER_CONFIG.NEARBY_DISTANCE,
-      circleSpiralSwitchover: SPIDERFIER_CONFIG.CIRCLE_SPIRAL_SWITCHOVER,
-      circleFootSeparation: SPIDERFIER_CONFIG.CIRCLE_FOOT_SEPARATION,
-      spiralFootSeparation: SPIDERFIER_CONFIG.SPIRAL_FOOT_SEPARATION,
-      spiralLengthStart: SPIDERFIER_CONFIG.SPIRAL_LENGTH_START,
-      spiralLengthFactor: SPIDERFIER_CONFIG.SPIRAL_LENGTH_FACTOR,
-      legWeight: SPIDERFIER_CONFIG.LEG_WEIGHT,
-      legColors: {
-        usual: 'rgba(100, 100, 100, 0.6)', // Semi-transparent gray
-        highlighted: 'rgba(50, 50, 50, 0.8)', // Darker when hovering
-      },
-    });
+    const { addMarker, removeMarker, addListener, removeListener, getSpiderfier } =
+      useMarkerSpiderfier(SHARED_SPIDERFIER_OPTIONS);
 
     // Expose methods via ref
     useImperativeHandle(ref, () => ({

--- a/src/hooks/useMarkerSpiderfier.ts
+++ b/src/hooks/useMarkerSpiderfier.ts
@@ -8,6 +8,40 @@ import { useMap } from 'react-leaflet';
 import { Marker as LeafletMarker } from 'leaflet';
 import { OverlappingMarkerSpiderfier, type SpiderfierEventMap, type SpiderfierEventHandler } from 'ts-overlapping-marker-spiderfier-leaflet';
 
+/**
+ * Shared spiderfier tuning used by every map surface (per-source NodesTab map,
+ * Map Analysis, and the Unified/Dashboard map) so overlapping markers fan out
+ * identically everywhere (issue #3612).
+ *
+ * These values come from the per-source NodesTab map (`SpiderfierController`),
+ * which is the working reference. A 50px `nearbyDistance` is deliberately
+ * larger than the library default (20px) so that co-located nodes — including
+ * estimated-position nodes that collapse onto the same anchor point — are
+ * reliably grouped and separable.
+ */
+export const SHARED_SPIDERFIER_OPTIONS: SpiderfierOptions = {
+  /** Keep markers fanned out after clicking so each is individually selectable. */
+  keepSpiderfied: true,
+  /** Pixel radius for detecting overlapping markers — 50px catches markers at (near-)identical coords. */
+  nearbyDistance: 50,
+  /** Number of markers before switching from circle to spiral layout. */
+  circleSpiralSwitchover: 9,
+  /** Distance between markers in circle layout (pixels). */
+  circleFootSeparation: 50,
+  /** Distance between markers in spiral layout (pixels). */
+  spiralFootSeparation: 50,
+  /** Starting radius for spiral layout (pixels). */
+  spiralLengthStart: 20,
+  /** How quickly the spiral grows — higher = faster growth and more spacing. */
+  spiralLengthFactor: 8,
+  /** Line thickness for spider legs. */
+  legWeight: 2,
+  legColors: {
+    usual: 'rgba(100, 100, 100, 0.6)', // Semi-transparent gray
+    highlighted: 'rgba(50, 50, 50, 0.8)', // Darker when hovering
+  },
+};
+
 export interface SpiderfierOptions {
   /**
    * Keep markers spiderfied after clicking (default: false)


### PR DESCRIPTION
## Summary

Brings the per-source NodesTab map's marker **spiderfy** behavior to the **Map Analysis** view and the **Unified/Dashboard** map, so co-located / overlapping markers (same tower, same building, or estimated-position nodes that collapse onto a single anchor) can be fanned out and individually selected on every map surface.

Closes #3612

## What was wrong

- **Per-source NodesTab map** (working reference): fans out overlapping markers via the shared `SpiderfierController` + `useMarkerSpiderfier` hook, which wraps `OverlappingMarkerSpiderfier` (`ts-overlapping-marker-spiderfier-leaflet`) with a tuned 50px `nearbyDistance`.
- **Map Analysis** (`NodeMarkersLayer`): used the hook but with the library's weak defaults (`{ keepSpiderfied: true }` → 20px `nearbyDistance`), missing near-but-not-identical co-located nodes.
- **Unified/Dashboard map** (`DashboardMap`): plain `<Marker>`s with **no spiderfy at all**.

## Approach — reuse, don't reinvent

- Extracted the per-source map's tuning into `SHARED_SPIDERFIER_OPTIONS` in `useMarkerSpiderfier.ts` (50px `nearbyDistance`, 50px foot separation, keep-spiderfied, shared leg colors).
- `SpiderfierController` and `NodeMarkersLayer` now both consume `SHARED_SPIDERFIER_OPTIONS`, so all surfaces fan out **identically**.
- Added the **same** `SpiderfierController` to `DashboardMap` and bridged each `<Marker>` ref into it using the same stable per-key ref-handler pattern already used by `NodeMarkersLayer`.
- Made `SpiderfierController`'s `zoomLevel` prop optional (it was unused) so the shared maps can mount it with no zoom prop; NodesTab keeps passing one.

No new clustering library — `OverlappingMarkerSpiderfier` draws its legs with `L.Polyline`, so no extra CSS/assets are needed (consistent with the per-source map, which imports none).

## Preserved

- Custom marker glyphs (role / advType icons via `createNodeIcon`), popups, and click-to-select.
- Map Analysis **node-type filter** and per-node **"Hide from Map"** — filtered-out nodes never render a `<Marker>`, so they never enter the spiderfier or its clusters.
- Source attribution, transport/age filters, and all layer toggles on the Unified map.
- Per-source NodesTab map behavior is unchanged (it already used `SpiderfierController` with the same values, now sourced from the shared constant).

## Tests

- New `SpiderfierController.test.tsx`: asserts the shared tuning (50px etc.), that the controller initializes the spiderfier with `SHARED_SPIDERFIER_OPTIONS`, that its imperative add/remove ref API works (the marker bridge), and that `zoomLevel` is optional.
- `DashboardMap.test.tsx`: asserts the shared `SpiderfierController` mounts.
- The Leaflet DOM bridge inside the map components is hard to unit-test (the real spiderfier needs a live Leaflet map), so the imperative bridge contract is covered by the controller test; the live fan-out is verified by reading against the working per-source reference.

## Verification

- Full Vitest suite: `success=true`, 7113 passed, 0 failed (JSON reporter).
- `tsc -p tsconfig.server.json --noEmit`: no new errors in changed files (5 pre-existing errors in `TelemetryChart.tsx`, untouched).
- `tsc --noEmit` (frontend): 57 pre-existing errors, none in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)