### PR TITLE
feat(meshcore): pin favorited nodes to top of DM list (#3620)

### DIFF
--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -289,6 +289,43 @@ describe('MeshCoreDirectMessagesView — per-node telemetry-config panel', () =>
     expect(document.querySelector('.mc-node-row .mc-dm-row-favorite')?.textContent).toBe('★');
   });
 
+  // The `aFav !== bFav` pin runs ahead of BOTH sort branches, so favorites must
+  // also stay on top under name sort (not just the default lastMessage sort).
+  it('keeps favorited peers pinned when the user switches to name sort', () => {
+    const contactsList: MeshCoreContact[] = [
+      { publicKey: REAL_PK, advName: 'Charlie', advType: 1, lastSeen: 1000 },
+      { publicKey: REAL_PK_2, advName: 'alpha', advType: 1, lastSeen: 2000 },
+      { publicKey: 'c'.repeat(64), advName: 'Zeta', advType: 1, lastSeen: 3000 },
+    ];
+    // 'Zeta' is favorited — alphabetically last, so it would normally sort to
+    // the bottom under name/asc; the favorite pin must override that.
+    const nodes: MeshCoreNode[] = [
+      { publicKey: REAL_PK, name: 'Charlie', advType: 1, isFavorite: false },
+      { publicKey: REAL_PK_2, name: 'alpha', advType: 1, isFavorite: false },
+      { publicKey: 'c'.repeat(64), name: 'Zeta', advType: 1, isFavorite: true },
+    ];
+
+    render(
+      <MeshCoreDirectMessagesView
+        messages={[]}
+        contacts={contactsList}
+        nodes={nodes}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+
+    const dropdown = screen.getByTitle('Sort by') as HTMLSelectElement;
+    fireEvent.change(dropdown, { target: { value: 'name' } });
+    // Flip from the default 'desc' to ascending.
+    fireEvent.click(screen.getByTitle('Descending'));
+
+    const names = Array.from(document.querySelectorAll('.mc-node-row .mc-node-row-name'))
+      .map((el) => el.querySelector('span:not(.mc-dm-row-favorite)')?.textContent || '');
+    // Zeta pinned first despite name/asc; non-favorites follow in name order.
+    expect(names).toEqual(['Zeta', 'alpha', 'Charlie']);
+  });
+
   it('collapses the node list when the toggle button is clicked, and restores it on re-click', () => {
     render(
       <MeshCoreDirectMessagesView

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -43,7 +43,7 @@ vi.mock('../TelemetryGraphs', () => ({
 }));
 
 import { MeshCoreDirectMessagesView } from './MeshCoreDirectMessagesView';
-import type { MeshCoreActions, ConnectionStatus, MeshCoreMessage } from './hooks/useMeshCore';
+import type { MeshCoreActions, ConnectionStatus, MeshCoreMessage, MeshCoreNode } from './hooks/useMeshCore';
 import type { MeshCoreContact } from '../../utils/meshcoreHelpers';
 
 function makeActions(overrides: Partial<MeshCoreActions> = {}): MeshCoreActions {
@@ -252,6 +252,41 @@ describe('MeshCoreDirectMessagesView — per-node telemetry-config panel', () =>
     const names = Array.from(document.querySelectorAll('.mc-node-row .mc-node-row-name'))
       .map((el) => el.querySelector('span')?.textContent || '');
     expect(names).toEqual(['alpha', 'Bravo', 'Charlie']);
+  });
+
+  // Issue #3620: favorited MeshCore nodes pin to the top of the DM contact
+  // list, consistent with the Meshtastic DM list and the MeshCore node list.
+  // The favorite flag lives server-side on the node list (issue #3588), not on
+  // contacts, so it's threaded in via the `nodes` prop.
+  it('pins favorited peers to the top of the DM list regardless of sort order', () => {
+    const contactsList: MeshCoreContact[] = [
+      { publicKey: REAL_PK, advName: 'Charlie', advType: 1, lastSeen: 3000 },
+      { publicKey: REAL_PK_2, advName: 'alpha', advType: 1, lastSeen: 2000 },
+      { publicKey: 'c'.repeat(64), advName: 'Bravo', advType: 1, lastSeen: 1000 },
+    ];
+    // Only 'Bravo' is favorited; it has the OLDEST lastSeen and would normally
+    // sort last under the default (lastMessage / desc) order.
+    const nodes: MeshCoreNode[] = [
+      { publicKey: REAL_PK, name: 'Charlie', advType: 1, isFavorite: false },
+      { publicKey: REAL_PK_2, name: 'alpha', advType: 1, isFavorite: false },
+      { publicKey: 'c'.repeat(64), name: 'Bravo', advType: 1, isFavorite: true },
+    ];
+
+    render(
+      <MeshCoreDirectMessagesView
+        messages={[]}
+        contacts={contactsList}
+        nodes={nodes}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+
+    const names = Array.from(document.querySelectorAll('.mc-node-row .mc-node-row-name'))
+      .map((el) => el.querySelector('span:not(.mc-dm-row-favorite)')?.textContent || '');
+    // Bravo (favorite) pinned first despite oldest lastSeen; ★ indicator shown.
+    expect(names[0]).toBe('Bravo');
+    expect(document.querySelector('.mc-node-row .mc-dm-row-favorite')?.textContent).toBe('★');
   });
 
   it('collapses the node list when the toggle button is clicked, and restores it on re-click', () => {

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  MeshCoreMessage, MeshCoreActions, ConnectionStatus,
+  MeshCoreMessage, MeshCoreActions, ConnectionStatus, MeshCoreNode,
 } from './hooks/useMeshCore';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
@@ -13,6 +13,14 @@ import { useAuth } from '../../contexts/AuthContext';
 interface MeshCoreDirectMessagesViewProps {
   messages: MeshCoreMessage[];
   contacts: MeshCoreContact[];
+  /**
+   * Full node list for this source. Contacts carry no favorite flag (it lives
+   * server-side, issue #3588), so the favorite status — used to pin favorited
+   * peers to the top of the DM list (issue #3620) — is sourced from here, keyed
+   * by publicKey. Optional — when omitted (e.g. legacy callers/tests) no peer
+   * is pinned and the list sorts purely by the chosen field.
+   */
+  nodes?: MeshCoreNode[];
   status: ConnectionStatus | null;
   actions: MeshCoreActions;
   /** Frontend basename — required for the per-node telemetry-config panel. */
@@ -42,6 +50,7 @@ const isMobileViewport = (): boolean =>
 export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProps> = ({
   messages,
   contacts,
+  nodes = [],
   status,
   actions,
   baseUrl,
@@ -93,6 +102,18 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     }
     return map;
   }, [contacts]);
+
+  // Favorite status lives server-side on the node list (issue #3588), not on
+  // contacts. Build a publicKey -> isFavorite lookup so favorited peers can be
+  // pinned to the top of the DM list (issue #3620), mirroring the Meshtastic
+  // DM list and the MeshCore node list.
+  const favoriteByKey = useMemo(() => {
+    const map = new Map<string, boolean>();
+    for (const n of nodes) {
+      if (n.publicKey && n.isFavorite) map.set(n.publicKey, true);
+    }
+    return map;
+  }, [nodes]);
 
   // Inbound `contact_message` arrives with only `pubkey_prefix` (typically
   // 12 hex chars), while contacts and outbound messages use the full pubkey.
@@ -171,6 +192,11 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
     };
     const dir = sortDirection === 'asc' ? 1 : -1;
     return Array.from(peers).sort((a, b) => {
+      // Favorites pin to the top regardless of sort field/direction, matching
+      // the Meshtastic DM list and the MeshCore node list (issue #3620).
+      const aFav = favoriteByKey.get(a) ?? false;
+      const bFav = favoriteByKey.get(b) ?? false;
+      if (aFav !== bFav) return aFav ? -1 : 1;
       if (sortField === 'name') {
         return peerNameFor(a).localeCompare(peerNameFor(b), undefined, { sensitivity: 'base' }) * dir;
       }
@@ -178,7 +204,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
       const bt = lastMessageAt.get(b) ?? 0;
       return (at - bt) * dir;
     });
-  }, [messages, contacts, selfKey, canonicalize, contactsByKey, sortField, sortDirection]);
+  }, [messages, contacts, selfKey, canonicalize, contactsByKey, favoriteByKey, sortField, sortDirection]);
 
   const filteredPeers = useMemo(() => {
     if (!searchQuery.trim()) return dmPeers;
@@ -295,6 +321,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
             ) : filteredPeers.map(key => {
               const c = contactsByKey.get(key);
               const name = c?.advName || c?.name || `${key.substring(0, 8)}…`;
+              const isFavorite = favoriteByKey.get(key) ?? false;
               return (
                 <button
                   key={key}
@@ -302,6 +329,9 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                   onClick={() => handleSelectContact(key)}
                 >
                   <div className="mc-node-row-name">
+                    {isFavorite && (
+                      <span className="mc-dm-row-favorite" aria-label={t('meshcore.favorite.is_favorite', 'Favorite')} title={t('meshcore.favorite.is_favorite', 'Favorite')}>★</span>
+                    )}
                     <span>{name}</span>
                   </div>
                   <div className="mc-node-row-key">{key.substring(0, 20)}…</div>

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -444,6 +444,14 @@
   cursor: default;
 }
 
+/* Read-only favorite star shown next to pinned peers in the DM list (#3620) */
+.mc-dm-row-favorite {
+  flex: 0 0 auto;
+  margin-right: 0.35rem;
+  color: var(--ctp-yellow);
+  line-height: 1;
+}
+
 /* Discover dropdown in the nodes list header (#3351) */
 .mc-discover-menu-anchor {
   position: relative;

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -144,6 +144,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
             <MeshCoreDirectMessagesView
               messages={messages}
               contacts={contacts}
+              nodes={nodes}
               status={status}
               actions={actions}
               baseUrl={baseUrl}


### PR DESCRIPTION
## Summary

Closes #3620.

MeshCore node favorites (#3588) pinned nodes to the top of the **node list** but had no effect on the **Direct Messages** contact list, which sorted only by name or last-message time — unlike Meshtastic, where favorites pin to the top of the DM list.

**Root cause:** The favorite flag lives server-side on the *node* list (MeshCore firmware has no native favorite concept), not on the *contact* records that feed the DM view. `MeshCoreDirectMessagesView` only received `contacts`, which carry no `isFavorite`, so the sort couldn't see it.

## Changes

Frontend-only — no backend/API/migration changes needed, since the `useMeshCore` hook already maintains a reliably-reconciled `nodes` list with `isFavorite`.

- **`MeshCorePage.tsx`** — pass the existing `nodes` array to the DM view.
- **`MeshCoreDirectMessagesView.tsx`** — accept an optional `nodes` prop, build a `publicKey → isFavorite` lookup, pin favorited peers to the top of the sort (regardless of sort field/direction, matching the Meshtastic DM list and the MeshCore node list), and render a read-only ★ next to favorited rows. The `nodes` prop is optional so legacy callers degrade gracefully (no pinning).
- **`MeshCorePage.css`** — style the ★ indicator (`.mc-dm-row-favorite`).
- **`MeshCoreDirectMessagesView.test.tsx`** — new test asserting a favorited peer pins to the top despite oldest last-message time, plus the ★ indicator.

## Testing

- All 11 tests in `MeshCoreDirectMessagesView.test.tsx` pass (`success: true`).
- New regression test covers favorite-first ordering and the ★ indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)