### PR TITLE
fix(traceroute): prevent fictitious direct-connection segments for target-node traceroutes (#3622)

### DIFF
--- a/src/hooks/useTracerouteAnalysis.emptyBack.test.ts
+++ b/src/hooks/useTracerouteAnalysis.emptyBack.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for issue #3622 — fictitious direct-connection line from empty routeBack.
+ *
+ * When MeshMonitor is connected to the TARGET node (L) of a traceroute:
+ *  1. L receives an incoming REQUEST (from=A, to=L, requestId=0).
+ *     - Old behaviour: saved as a traceroute record with routeBack='[]', snrBack='[]'.
+ *     - New behaviour (meshtasticManager fix): REQUEST is skipped entirely.
+ *  2. L immediately sends a RESPONSE (from=L, to=A, requestId≠0).
+ *     - routeBack is still '[]' at this point — relay nodes haven't populated it yet.
+ *     - Old behaviour: `segmentsForTraceroute` built backPath=[L, A] → direct segment.
+ *     - New behaviour: empty routeBack + empty snrBack → backPath suppressed.
+ *
+ * These tests validate the `segmentsForTraceroute` / `analyzeTraceroutes` half of the fix.
+ * The `formatTracerouteRoute` half is validated in utils/traceroute.emptyBack.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  analyzeTraceroutes,
+  type TracerouteAnalysisInput,
+  type AnalyzeParams,
+  type TracerouteAnalysisOptions,
+} from './useTracerouteAnalysis';
+
+// Node numbers: A (requester), L (responder / local / target), C (relay).
+const A = 0xaaaa0001; // requester
+const L = 0xbbbb0002; // responder (local node — MeshMonitor is on this node)
+const C = 0xcccc0003; // relay between them
+
+function positions(...nums: number[]): Map<string, [number, number]> {
+  const m = new Map<string, [number, number]>();
+  nums.forEach((n, i) => m.set(`s1:${n}`, [10 + i, 20 + i]));
+  return m;
+}
+
+const defaultOptions: TracerouteAnalysisOptions = {
+  directionMode: 'both',
+  scopeToSelectedNode: true,
+  minOccurrences: 1,
+  minSnr: null,
+};
+
+function makeParams(overrides: Partial<AnalyzeParams>): AnalyzeParams {
+  return {
+    traceroutes: [],
+    positionByKey: positions(A, L, C),
+    selectedNodeNum: null,
+    selectedSourceId: null,
+    options: defaultOptions,
+    visibleNodeNums: null,
+    timeWindow: null,
+    ...overrides,
+  };
+}
+
+describe('analyzeTraceroutes — empty routeBack + empty snrBack (issue #3622)', () => {
+  it('does NOT draw a direct segment when routeBack=[] and snrBack=[] (unresolved return path)', () => {
+    // This represents the "local node response seen before relay nodes populate routeBack":
+    //   fromNodeNum = L (responder/local), toNodeNum = A (requester)
+    //   route = [C] (forward path A→C→L), routeBack = [] (not yet populated)
+    //   snrTowards = [raw_snr1, raw_snr2], snrBack = []
+    const tr: TracerouteAnalysisInput = {
+      id: 1,
+      fromNodeNum: L,
+      toNodeNum: A,
+      sourceId: 's1',
+      route: JSON.stringify([C]),
+      routeBack: '[]',
+      snrTowards: JSON.stringify([40, 32]), // 10 dB@C, 8 dB@L
+      snrBack: JSON.stringify([]),          // empty — return path not recorded yet
+      timestamp: 1_000,
+    };
+
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [tr],
+        selectedNodeNum: L,
+        selectedSourceId: 's1',
+      }),
+    );
+
+    // The ONLY segments incident to L should be from the forward path:
+    //   A→C (L is not involved) — filtered out by focus scoping
+    //   C→L (inbound to L) — survives
+    // The backPath (L→A direct) must NOT appear.
+    const backPathSegment = segments.find(
+      (s) => s.from === L && s.to === A,
+    );
+    expect(backPathSegment).toBeUndefined();
+
+    // The forward-path inbound segment C→L should still be present.
+    const inboundFromC = segments.find(
+      (s) => s.from === C && s.to === L,
+    );
+    expect(inboundFromC).toBeDefined();
+    expect(inboundFromC!.direction).toBe('inbound');
+  });
+
+  it('DOES draw a direct segment when routeBack=[] but snrBack has data (genuine direct RF hop)', () => {
+    // This is a legitimate single-hop traceroute where the return path is direct
+    // but the firmware reports an SNR for that hop.
+    //   fromNodeNum = L, toNodeNum = A
+    //   route = [], routeBack = []
+    //   snrBack = [raw_snr] — confirms an actual RF reception at A
+    const tr: TracerouteAnalysisInput = {
+      id: 2,
+      fromNodeNum: L,
+      toNodeNum: A,
+      sourceId: 's1',
+      route: '[]',
+      routeBack: '[]',
+      snrTowards: JSON.stringify([40]),  // A→L direct, 10 dB@L
+      snrBack: JSON.stringify([32]),     // L→A direct, 8 dB@A
+      timestamp: 1_000,
+    };
+
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [tr],
+        selectedNodeNum: L,
+        selectedSourceId: 's1',
+      }),
+    );
+
+    // snrBack is non-empty so the backPath IS drawn: L→A (outbound from L's POV).
+    const outboundToA = segments.find(
+      (s) => s.from === L && s.to === A,
+    );
+    expect(outboundToA).toBeDefined();
+    expect(outboundToA!.direction).toBe('outbound');
+    expect(outboundToA!.avgSnr).toBe(8); // 32 / 4
+  });
+
+  it('suppresses only the back path — forward path segments are unaffected', () => {
+    // Verifies that when backPath is suppressed, the forward route still produces
+    // its full set of directed segments.
+    const tr: TracerouteAnalysisInput = {
+      id: 3,
+      fromNodeNum: L,
+      toNodeNum: A,
+      sourceId: 's1',
+      route: JSON.stringify([C]),
+      routeBack: '[]',
+      snrTowards: JSON.stringify([40, 32]),
+      snrBack: '[]',
+      timestamp: 1_000,
+    };
+
+    // Use global (non-focused) view so we can see all segments.
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [tr],
+        selectedNodeNum: null,
+        options: { ...defaultOptions, scopeToSelectedNode: false },
+      }),
+    );
+
+    // Forward path: A→C→L produces 2 directed segments.
+    const fwdAtoC = segments.find((s) => s.from === A && s.to === C);
+    const fwdCtoL = segments.find((s) => s.from === C && s.to === L);
+    expect(fwdAtoC).toBeDefined();
+    expect(fwdCtoL).toBeDefined();
+
+    // Back path entirely absent (both routeBack and snrBack are empty).
+    const anyBack = segments.filter((s) => s.from === L || (s.from === C && s.to === A));
+    // L→A and L→C and C→A are all back-path segments — none should exist.
+    const backSegments = segments.filter((s) => s.from === L);
+    expect(backSegments).toHaveLength(0);
+  });
+
+  it('handles routeBack populated (normal case) — back path is drawn correctly', () => {
+    // Confirms that once relay nodes populate routeBack, the return path is visible.
+    const tr: TracerouteAnalysisInput = {
+      id: 4,
+      fromNodeNum: L,
+      toNodeNum: A,
+      sourceId: 's1',
+      route: JSON.stringify([C]),
+      routeBack: JSON.stringify([C]),  // relay populated the return path
+      snrTowards: JSON.stringify([40, 32]),
+      snrBack: JSON.stringify([36, 28]),
+      timestamp: 1_000,
+    };
+
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [tr],
+        selectedNodeNum: L,
+        selectedSourceId: 's1',
+      }),
+    );
+
+    // Back path: L→C (outbound from L's perspective) — should exist.
+    const outboundToC = segments.find((s) => s.from === L && s.to === C);
+    expect(outboundToC).toBeDefined();
+    expect(outboundToC!.direction).toBe('outbound');
+
+    // Direct L→A must NOT appear since routeBack=[C] routes through C.
+    const directBack = segments.find((s) => s.from === L && s.to === A);
+    expect(directBack).toBeUndefined();
+  });
+});

--- a/src/hooks/useTracerouteAnalysis.ts
+++ b/src/hooks/useTracerouteAnalysis.ts
@@ -147,15 +147,21 @@ function segmentsForTraceroute(tr: TracerouteAnalysisInput): RawSegment[] {
     });
   }
 
-  // Response leg: responder -> ...routeBack -> requester
-  const backPath = [responder, ...routeBack, requester];
-  for (let i = 0; i < backPath.length - 1; i++) {
-    out.push({
-      sourceId: tr.sourceId,
-      from: backPath[i],
-      to: backPath[i + 1],
-      snr: scaleSnr(snrBack[i]),
-    });
+  // Response leg: responder -> ...routeBack -> requester.
+  // When routeBack AND snrBack are both empty the return path has not been
+  // recorded yet (e.g. MeshMonitor sees its own outgoing response before relay
+  // nodes populate routeBack). Skip rather than drawing a fictitious direct
+  // responder→requester line. (Issues #1140, #3622)
+  if (routeBack.length > 0 || snrBack.length > 0) {
+    const backPath = [responder, ...routeBack, requester];
+    for (let i = 0; i < backPath.length - 1; i++) {
+      out.push({
+        sourceId: tr.sourceId,
+        from: backPath[i],
+        to: backPath[i + 1],
+        snr: scaleSnr(snrBack[i]),
+      });
+    }
   }
 
   return out;

--- a/src/server/meshtasticManager.traceroute-hops.test.ts
+++ b/src/server/meshtasticManager.traceroute-hops.test.ts
@@ -254,7 +254,9 @@ describe('MeshtasticManager — traceroute intermediate hop handling (issues 261
     id: 99999,
     channel: 0,
     rxTime: Math.floor(Date.now() / 1000),
-    decoded: { portnum: 70 },
+    // requestId must be non-zero to pass the REQUEST-skip guard added in issue #3622.
+    // All packets in this test file represent RESPONSE packets.
+    decoded: { portnum: 70, requestId: 12345 },
   });
 
   /** All upsertNode calls that targeted a specific nodeNum. */

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6747,13 +6747,30 @@ class MeshtasticManager implements ISourceManager {
       const toNum = Number(meshPacket.to);
       const toNodeId = `!${toNum.toString(16).padStart(8, '0')}`;
 
-      // Skip traceroute responses FROM our local node (Issue #1140)
-      // When another node traceroutes us, we capture our own outgoing response.
-      // This response only has the forward path (route), not a meaningful return path (routeBack),
-      // which causes incorrect "direct line" route segments to be displayed on the map.
-      if (this.localNodeInfo && fromNum === this.localNodeInfo.nodeNum) {
-        logger.debug(`🗺️ Skipping traceroute response from local node ${fromNodeId} (our response to someone else's request)`);
+      // Determine whether this is a traceroute RESPONSE (requestId ≠ 0) or a
+      // traceroute REQUEST (requestId = 0, the initiating packet).
+      const tracerouteRequestId = Number(meshPacket.decoded?.requestId ?? 0);
+      const isTracerouteResponse = tracerouteRequestId !== 0;
+
+      if (!isTracerouteResponse) {
+        // This is an incoming traceroute REQUEST addressed to our local node —
+        // another node is discovering the path to us. Our firmware will
+        // immediately send a response; we record THAT response when it arrives
+        // (below). Processing the request here would save a record with the
+        // wrong from/to orientation and an empty routeBack, which previously
+        // caused a fictitious direct-connection line on the map. (Issue #3622)
+        logger.debug(`🗺️ Skipping traceroute REQUEST from ${fromNodeId} to ${toNodeId} — will record when our response is processed`);
         return;
+      }
+
+      // When another node traceroutes us, we see our OWN outgoing response via
+      // TCP before relay nodes have populated routeBack. Save the record so the
+      // traceroute is visible, but skip route-segment creation — segments from
+      // an empty routeBack would draw a fictitious direct line on the map.
+      // (Issues #1140, #3622)
+      const isLocalNodeResponse = this.localNodeInfo != null && fromNum === this.localNodeInfo.nodeNum;
+      if (isLocalNodeResponse) {
+        logger.debug(`🗺️ Outgoing traceroute response from local node ${fromNodeId} — will record without segments`);
       }
 
       logger.info(`🗺️ Traceroute response from ${fromNodeId}:`, JSON.stringify(routeDiscovery, null, 2));
@@ -7238,8 +7255,10 @@ class MeshtasticManager implements ISourceManager {
         .then(sourceName => notificationService.notifyTraceroute(fromNodeId, toNodeId, routeText, this.sourceId, sourceName))
         .catch(err => logger.error('Failed to send traceroute notification:', err));
 
-      // Calculate and store route segment distances, and estimate positions for nodes without GPS
-      try {
+      // Calculate and store route segment distances, and estimate positions for nodes without GPS.
+      // Skip for our own outgoing response: routeBack is not yet populated by relay nodes, so
+      // creating segments now would draw fictitious direct-line connections. (Issues #1140, #3622)
+      if (!isLocalNodeResponse) try {
         // Build the full route path: toNode (requester) -> route intermediates -> fromNode (responder)
         // route contains intermediate hops from requester toward responder
         // So the full path is: requester -> route[0] -> route[1] -> ... -> route[N-1] -> responder

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7263,6 +7263,9 @@ class MeshtasticManager implements ISourceManager {
       //      null (e.g. connection not yet fully initialized), closing a pre-existing race window.
       // Either condition is sufficient; both are checked for defence-in-depth. (Issues #1140, #3622)
       const isEmptyReturnPath = routeBack.length === 0 && snrBack.length === 0;
+      if (!isLocalNodeResponse && isEmptyReturnPath) {
+        logger.debug(`🗺️ Skipping segment creation — empty return path from remote node ${fromNodeId} (old firmware or unresolved path)`);
+      }
       if (!isLocalNodeResponse && !isEmptyReturnPath) try {
         // Build the full route path: toNode (requester) -> route intermediates -> fromNode (responder)
         // route contains intermediate hops from requester toward responder

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7256,9 +7256,14 @@ class MeshtasticManager implements ISourceManager {
         .catch(err => logger.error('Failed to send traceroute notification:', err));
 
       // Calculate and store route segment distances, and estimate positions for nodes without GPS.
-      // Skip for our own outgoing response: routeBack is not yet populated by relay nodes, so
-      // creating segments now would draw fictitious direct-line connections. (Issues #1140, #3622)
-      if (!isLocalNodeResponse) try {
+      // Guard: skip segment creation when the return path has not been populated yet. Two conditions
+      // cover this:
+      //   1. isLocalNodeResponse — our own outgoing response seen before relay nodes fill routeBack.
+      //   2. routeBack and snrBack both empty — catches the same state even when localNodeInfo is
+      //      null (e.g. connection not yet fully initialized), closing a pre-existing race window.
+      // Either condition is sufficient; both are checked for defence-in-depth. (Issues #1140, #3622)
+      const isEmptyReturnPath = routeBack.length === 0 && snrBack.length === 0;
+      if (!isLocalNodeResponse && !isEmptyReturnPath) try {
         // Build the full route path: toNode (requester) -> route intermediates -> fromNode (responder)
         // route contains intermediate hops from requester toward responder
         // So the full path is: requester -> route[0] -> route[1] -> ... -> route[N-1] -> responder

--- a/src/utils/traceroute.emptyBack.test.ts
+++ b/src/utils/traceroute.emptyBack.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for formatTracerouteRoute empty-array guard (issue #3622).
+ *
+ * TracerouteHistoryModal calls:
+ *   formatTracerouteRoute(tr.routeBack, tr.snrBack, tr.toNodeNum, tr.fromNodeNum, ...)
+ *
+ * When the local node (L) sees its own outgoing RESPONSE before relay nodes have
+ * populated routeBack, both `route` and `snr` are empty JSON arrays ('[]').
+ * Before the fix, this rendered a fictitious "L → A" direct-connection line.
+ * After the fix, it returns '(No return path data)'.
+ *
+ * Contrast with a genuine direct hop, where route=[] but snr has data.
+ */
+import { describe, it, expect } from 'vitest';
+import { formatTracerouteRoute } from './traceroute';
+import { DeviceInfo } from '../types/device';
+
+const mockNodes: DeviceInfo[] = [
+  {
+    nodeNum: 0xaaaa0001,
+    user: { id: '!aaaa0001', longName: 'Node A', shortName: 'NDEA' },
+  },
+  {
+    nodeNum: 0xbbbb0002,
+    user: { id: '!bbbb0002', longName: 'Node L', shortName: 'NDEL' },
+  },
+];
+
+describe('formatTracerouteRoute — empty route + empty snr (issue #3622)', () => {
+  it('returns "(No return path data)" when both route and snr are empty arrays', () => {
+    // This is the case seen when L's own outgoing RESPONSE is observed before
+    // relay nodes have populated routeBack. Both fields are '[]', not null.
+    const result = formatTracerouteRoute(
+      '[]',   // routeBack = empty, not yet populated
+      '[]',   // snrBack   = empty
+      0xbbbb0002, // toNodeNum  = L (requester's POV: L is the from in return display)
+      0xaaaa0001, // fromNodeNum = A (requester's POV: A is the to in return display)
+      mockNodes,
+    );
+
+    expect(result).toBe('(No return path data)');
+  });
+
+  it('renders normally when route is [] but snr has entries (genuine direct hop)', () => {
+    // A single-hop traceroute: no intermediate nodes, but the firmware recorded
+    // an SNR for the single RF link. This is a real direct connection — should render.
+    const result = formatTracerouteRoute(
+      '[]',            // no intermediate hops
+      '[32]',          // 8 dB SNR for the single hop
+      0xbbbb0002,
+      0xaaaa0001,
+      mockNodes,
+    );
+
+    // Should render node names (not the "(No return path data)" sentinel).
+    const str = typeof result === 'string' ? result : JSON.stringify(result);
+    expect(str).not.toBe('(No return path data)');
+    expect(str).not.toBe('(No response received)');
+  });
+
+  it('still returns "(No response received)" for a null route', () => {
+    // Existing behaviour: a completely missing/null route means the traceroute failed.
+    const result = formatTracerouteRoute(
+      null,
+      null,
+      0xbbbb0002,
+      0xaaaa0001,
+      mockNodes,
+    );
+
+    expect(result).toBe('(No response received)');
+  });
+
+  it('renders a multi-hop route correctly when both route and snr have data', () => {
+    // The guard must not accidentally block valid multi-hop paths.
+    const result = formatTracerouteRoute(
+      '[3221291011]',  // one intermediate hop (0xcccc0003)
+      '[40, 32]',      // SNR for each hop
+      0xbbbb0002,
+      0xaaaa0001,
+      mockNodes,
+    );
+
+    const str = typeof result === 'string' ? result : JSON.stringify(result);
+    expect(str).not.toBe('(No return path data)');
+    expect(str).not.toBe('(No response received)');
+  });
+});

--- a/src/utils/traceroute.emptyBack.test.ts
+++ b/src/utils/traceroute.emptyBack.test.ts
@@ -74,7 +74,7 @@ describe('formatTracerouteRoute — empty route + empty snr (issue #3622)', () =
   it('renders a multi-hop route correctly when both route and snr have data', () => {
     // The guard must not accidentally block valid multi-hop paths.
     const result = formatTracerouteRoute(
-      '[3221291011]',  // one intermediate hop (0xcccc0003)
+      '[3221291011]',  // one intermediate hop (0xc0010003)
       '[40, 32]',      // SNR for each hop
       0xbbbb0002,
       0xaaaa0001,

--- a/src/utils/traceroute.tsx
+++ b/src/utils/traceroute.tsx
@@ -115,6 +115,19 @@ export function formatTracerouteRoute(
     return '(No response received)';
   }
 
+  // When both route and snr are empty arrays the return path has not been
+  // recorded yet (e.g. seen from the target node before relays populate
+  // routeBack). Avoid rendering a fictitious direct A→B line. (Issue #3622)
+  try {
+    const _r = JSON.parse(route);
+    const _s = snr ? JSON.parse(snr) : [];
+    if (Array.isArray(_r) && _r.length === 0 && Array.isArray(_s) && _s.length === 0) {
+      return '(No return path data)';
+    }
+  } catch {
+    // fall through to normal parsing below
+  }
+
   // Filter function to remove invalid/reserved node numbers from route arrays.
   // BROADCAST_ADDR (0xffffffff) is intentionally NOT filtered — the firmware
   // uses it as a placeholder for relay-role hops that refused to self-identify.


### PR DESCRIPTION
## Summary

Fixes #3622 — two interacting bugs when MeshMonitor is connected to the **target node** (L) of an incoming traceroute from A:

- **Bug 1 (fictitious segment):** The traceroute REQUEST (from=A, to=L, `requestId=0`) was being processed and saved with `routeBack=[]`. `segmentsForTraceroute` then built `backPath=[A, L]` — a fictitious direct-connection line on the map overlay, even when the actual path went through relay nodes.
- **Bug 2 (invisible traceroute):** The prior fix for #1140 used a broad guard (`if fromNum === localNode → return`) that blocked saving the RESPONSE entirely, making the traceroute invisible to the user.

## Three-part fix

**`meshtasticManager.ts`** — Replace broad `from===localNode` guard with `requestId`-based logic:
- `requestId=0` (REQUEST): skip entirely — firmware will respond, record comes when RESPONSE arrives
- `requestId≠0` from localNode (RESPONSE): save the DB record but skip route-segment creation (routeBack is not yet populated by relay nodes)

**`useTracerouteAnalysis.ts`** — Guard `segmentsForTraceroute` back-path loop:
- Skip when **both** `routeBack` and `snrBack` are empty (unresolved return path, not a genuine direct hop)
- Draw when `snrBack` has data (genuine single-hop with measured SNR)

**`utils/traceroute.tsx`** — Guard `formatTracerouteRoute` for history modal:
- Return `'(No return path data)'` when route and snr both parse to empty arrays

## Test plan

- [x] `src/hooks/useTracerouteAnalysis.emptyBack.test.ts` — 4 new tests: empty routeBack+snrBack → no segment; snrBack present → segment drawn; forward path unaffected; populated routeBack works
- [x] `src/utils/traceroute.emptyBack.test.ts` — 4 new tests: empty arrays → sentinel string; snr present → renders; null → existing behavior; multi-hop → renders
- [x] `src/server/meshtasticManager.traceroute-hops.test.ts` — updated packet fixtures to include `requestId: 12345` (responses, not requests) so all 7 existing tests pass the new REQUEST-skip guard
- [x] Full Vitest suite passes (pre-existing `mqttBrokerManager` failures are unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZwPi1Waokuoyv8pppjtCA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZwPi1Waokuoyv8pppjtCA)_