### PR TITLE
fix: exclude channel_database from migration 021 to prevent PostgreSQL boot-loop

### DIFF
--- a/src/server/migrations/021_add_source_id_columns.ts
+++ b/src/server/migrations/021_add_source_id_columns.ts
@@ -6,7 +6,15 @@
  * source" (assigned during startup by server.ts).
  *
  * Tables: nodes, messages, telemetry, traceroutes, channels,
- *         neighbor_info, packet_log, ignored_nodes, channel_database
+ *         neighbor_info, packet_log, ignored_nodes
+ *
+ * NOTE: channel_database is intentionally excluded. It is global-by-design
+ * (channelDecryptionService queries all rows regardless of source). Migration
+ * 063 drops any sourceId that was added here by earlier runs of this migration.
+ * Including channel_database caused a boot-loop on PostgreSQL: because PG runs
+ * all migrations on every startup, the ADD/DROP cycle (021 adds, 063 drops,
+ * repeat) steadily consumed PostgreSQL's 1600-column tombstone limit on the
+ * channel_database table. See: https://github.com/Yeraze/meshmonitor/issues/3639
  *
  * Indexes are created on nodes, messages, and telemetry for query efficiency.
  */
@@ -15,7 +23,7 @@ import { logger } from '../../utils/logger.js';
 
 const DATA_TABLES = [
   'nodes', 'messages', 'telemetry', 'traceroutes',
-  'channels', 'neighbor_info', 'packet_log', 'ignored_nodes', 'channel_database',
+  'channels', 'neighbor_info', 'packet_log', 'ignored_nodes',
 ] as const;
 
 // ============ SQLite ============


### PR DESCRIPTION
## Summary

Fixes #3639 — PostgreSQL users experiencing a boot-loop with `tables can have at most 1600 columns` after many restarts.

## Root Cause

PostgreSQL runs **all migrations on every startup** (no per-migration tracking, unlike SQLite which uses `settingsKey`). This is intentional — each migration is supposed to be idempotent via `IF NOT EXISTS` guards.

However, there's a dangerous interaction between two migrations:
- **Migration 021** adds `sourceId` to `channel_database` with `ADD COLUMN IF NOT EXISTS`
- **Migration 063** drops `sourceId` from `channel_database` with `DROP COLUMN IF EXISTS`

On every boot, the cycle runs: **add → drop → add → drop → …**

PostgreSQL counts dropped column "tombstones" in `pg_attribute` toward its hard **1600-column limit per table**, and never reclaims those slots automatically. After ~1600 boots, any `ALTER TABLE channel_database ADD COLUMN` fails with the error the reporter sees.

## Fix

Remove `channel_database` from migration 021's `DATA_TABLES` array.

`channel_database` is [global-by-design](https://github.com/Yeraze/meshmonitor/blob/main/src/server/migrations/063_drop_source_id_from_channel_database.ts) — `channelDecryptionService` queries all rows regardless of source. Migration 063 already handles cleanup of any `sourceId` that was added by prior runs of migration 021 (`DROP COLUMN IF EXISTS` is a safe no-op if the column isn't there).

The net result: migration 021 no longer touches `channel_database`, the add/drop cycle stops, and the tombstone count stops growing.

## Impact on existing affected users

Users who have already hit the limit can simply update to this version and restart — migration 021 will no longer attempt `ADD COLUMN` on `channel_database`, so the 1600-column error won't fire. Their table will still have many dead tombstone slots, but since no migration adds further columns to `channel_database`, this is harmless at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cu5UZv6q58JhV62cWjM6KG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu5UZv6q58JhV62cWjM6KG)_