### PR TITLE
chore(skills): add /deploy, /merge, /migration; fix create-pr & ci-monitor footguns

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -58,12 +58,57 @@ Runs the complete PR workflow: unit tests, TypeScript check, documentation revie
 ```
 
 **What it does:**
-1. Runs unit tests and TypeScript check
+1. Runs unit tests (via the JSON reporter — `success: true`, not the rtk summary) and the server TypeScript check
 2. Reviews internal and website documentation for accuracy
-3. Creates branch and pushes if needed
+3. Creates branch and pushes (explicit branch ref) if needed
 4. Creates PR with detailed description (intent, changes, issues, testing steps)
-5. Waits 5 minutes for CI, then reviews feedback
+5. Watches CI via `scripts/watch-ci.sh`, then reviews feedback (hands off to `/ci-monitor` on failure)
 6. Fixes urgent findings automatically, prompts for non-urgent ones
+
+---
+
+### /deploy
+**Build and deploy the dev container from local code, then verify**
+
+The "build and deploy for testing" / "rebuild and redeploy" / "tear it down" loop, with the data-loss guardrails (never `down -v`), the mandatory USB override, and the access details baked in.
+
+**Usage:**
+```bash
+/deploy                # redeploy (build + up -d), preserves data
+/deploy fresh          # build --no-cache + up -d
+/deploy tear down      # docker compose down (no -v)
+```
+
+**What it does:**
+1. Pre-flight (no competing `npm run dev`; copy the gitignored USB override into worktrees)
+2. `build` + `up -d` with both `-f docker-compose.dev.yml -f docker-compose.dev.local.yml`
+3. Verifies the *right* commit is actually running (not a stale cached layer)
+4. Reports access URL (`http://localhost:8081/meshmonitor`), login `admin/changeme`
+
+---
+
+### /merge
+**Merge a green/approved PR and clean up afterward**
+
+The full "Merge it" sequence: pre-merge gate → squash-merge → fast-forward local `main` (stashing `.claude/agent-memory/` first) → worktree/branch cleanup. Safe under concurrent shared-checkout sessions.
+
+**Usage:**
+```bash
+/merge 3621
+/merge            # resolves the PR from the current branch
+```
+
+---
+
+### /migration
+**Scaffold a migration across all three backends**
+
+Creates `NNN_<name>.ts` (SQLite + PostgreSQL + MySQL, idempotent), registers it in `src/db/migrations.ts`, and updates the count/last-name assertions in `migrations.test.ts`. Determines the next number dynamically.
+
+**Usage:**
+```bash
+/migration add isPinned to messages
+```
 
 ---
 

--- a/.claude/commands/ci-monitor.md
+++ b/.claude/commands/ci-monitor.md
@@ -72,7 +72,12 @@ Apply a **minimal targeted fix** — touch ONLY the files related to the failure
 
 After fixing:
 - Run the failing test file locally first: `node_modules/.bin/vitest run <failing_test_file>`
-- If green, run the relevant suite: `npm test 2>&1 | tail -5`
+- If green, run the full suite. **Do NOT trust the `PASS (N) FAIL (0)` summary line** — the rtk wrapper counts only assertion failures, so suite-level (collection/import) failures slip through. Confirm `success: true` via the JSON reporter:
+  ```bash
+  npx vitest run --reporter=json --outputFile=/tmp/vitest.json >/dev/null 2>&1
+  python3 -c "import json; d=json.load(open('/tmp/vitest.json')); print('success:', d['success'], 'passed:', d['numPassedTests'], 'failed:', d['numFailedTests'], 'suitesFailed:', d['numFailedTestSuites'])"
+  ```
+- **TypeScript check:** use `npx tsc -p tsconfig.server.json --noEmit` for server code. The base `npx tsc --noEmit` reports ~57–60 **pre-existing** frontend errors (TelemetryChart.tsx, etc.) on clean `origin/main` — ignore those; **only NEW errors you introduced matter**. Do not waste cycles "fixing" the pre-existing noise.
 - Commit and push: `git add -A && git commit -m "fix: <describe>" && git push`
 
 ### Phase 4: Re-monitor

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -15,15 +15,18 @@ If arguments contain descriptive text, use it as context for the PR description.
 
 ### 1a. Run Unit Tests
 ```bash
-npx vitest run
+npx vitest run --reporter=json --outputFile=/tmp/vitest.json >/dev/null 2>&1
+python3 -c "import json; d=json.load(open('/tmp/vitest.json')); print('success:', d['success'], 'passed:', d['numPassedTests'], 'failed:', d['numFailedTests'], 'suitesFailed:', d['numFailedTestSuites'])"
 ```
-All tests MUST pass. If any fail, fix them before proceeding. Do NOT create a PR with failing tests.
+All tests MUST pass. **Confirm `success: true`** — do NOT trust the rtk `PASS (N) FAIL (0)` summary line, which counts only assertion failures and lets suite-level (collection/import) failures slip through. Do NOT create a PR with failing tests.
+
+> In a fresh worktree, run `git submodule update --init` first — otherwise a few protobuf-dependent tests fail with "encode failed".
 
 ### 1b. TypeScript Check
 ```bash
-npx tsc --noEmit
+npx tsc -p tsconfig.server.json --noEmit
 ```
-Must compile cleanly. Fix any errors.
+Server code must compile cleanly. **Note:** the base `npx tsc --noEmit` reports ~57–60 **pre-existing** frontend errors (TelemetryChart.tsx, etc.) on clean `origin/main` — those are NOT yours; **only NEW errors you introduced matter**. Don't try to "fix" the pre-existing noise.
 
 ### 1c. Check for uncommitted changes
 ```bash
@@ -55,9 +58,9 @@ Ensure:
 - Branch has a descriptive name (fix/, feature/, docs/)
 - All commits are meaningful
 
-Push the branch:
+Push the branch using an **explicit branch ref** (this checkout may be shared with concurrent sessions, and worktree upstream tracking can be misconfigured — never rely on the currently-checked-out branch staying put):
 ```bash
-git push -u origin $(git branch --show-current)
+git push -u origin <branch-name>
 ```
 
 ## Step 4: Create the Pull Request
@@ -97,21 +100,18 @@ EOF
 
 ## Step 5: Monitor CI Feedback
 
-After creating or pushing the PR, wait 5 minutes for CI to run:
+Don't hand-poll the GitHub API. Delegate the wait to the same watcher `/ci-monitor` uses — it blocks until the picture is decided and emits one terminal line plus an exit code (`0`=green, `1`=failure, `2`=usage/API error):
 
 ```bash
-sleep 300
+bash scripts/watch-ci.sh -q <PR_NUMBER>; echo "EXIT=$?"
 ```
 
-Then check CI results:
-```bash
-gh pr view <PR_NUMBER> --json statusCheckRollup --jq '[.statusCheckRollup[] | {name: .name, status: .status, conclusion: .conclusion}]'
-```
+Run it in the background with an explicit long timeout (full CI exceeds the 2-min default), and read the output file's final `EXIT=` line — don't trust the task exit code, the backgrounded watcher occasionally loses network and dies with EXIT=2.
 
-Also check for review comments:
+On exit `1`, hand off to **`/ci-monitor <PR_NUMBER>`** rather than re-implementing diagnosis here. Once green, gather review feedback (bot + humans):
 ```bash
-gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/reviews
-gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments
+gh pr view <PR_NUMBER> --json reviews -q '.reviews[] | "\(.author.login) [\(.state)]: \(.body)"'
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments -q '.[] | "\(.user.login) \(.path):\(.line) — \(.body)"'
 ```
 
 ### Handling CI Findings

--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,0 +1,74 @@
+---
+name: deploy
+description: Build and deploy the MeshMonitor dev container from local code, then verify the right code is running. Use for "build and deploy for testing", "rebuild and redeploy", "tear it down".
+---
+
+Build, deploy, and verify the MeshMonitor dev container from the **local working tree** so the user can test the current code.
+
+## Arguments
+$ARGUMENTS
+
+- Empty / "deploy" / "redeploy" → build + `up -d` (preserves data).
+- "fresh" / "clean" / "no-cache" / "from scratch" → `build --no-cache` + `up -d` (rebuilds the **image**, never the volume).
+- "tear down" / "stop" / "down" → `docker compose ... down` (NO `-v`).
+- A profile name (`sqlite`, `postgres`, `mysql`) overrides the default `sqlite`.
+
+## ⛔ Data-loss guardrails (read first — non-negotiable)
+
+A prior run destroyed the user's `meshmonitor_*` data volume (2026-04-18, unrecoverable). Before running ANY docker command, check it against this list:
+
+- **NEVER** use `-v` / `--volumes` on `docker compose down` or `docker compose rm`. Not for "cleanup", not ever, unless the user explicitly types "wipe the volume" in this turn.
+- **NEVER** rename the compose project/file as part of a deploy (different project name = orphaned volumes).
+- "Deploy" / "redeploy" = `build` + `up -d`. "Fresh" / "clean" = `build --no-cache` + `up -d`. None of these touch volumes.
+- Before and after `up -d`, run `docker volume ls | grep meshmonitor`. If the data volume's creation timestamp changed, you destroyed data — STOP and report immediately.
+
+When in doubt about a destructive command, delegate the whole job to the **`docker-dev-deployer`** agent, which carries the full guardrail checklist.
+
+## Steps
+
+### 1. Pre-flight
+- Confirm no local `npm run dev` is running — it fights the container for ports. (`docker ps` / check.)
+- **If you are in a git worktree:** `docker-compose.dev.local.yml` is **gitignored** and won't exist. Copy it from the main checkout first, or the container gets no USB devices:
+  ```bash
+  [ -f docker-compose.dev.local.yml ] || cp ../meshmonitor/docker-compose.dev.local.yml .
+  ```
+- Note the deployed commit so you can verify later: `git rev-parse --short HEAD`.
+
+### 2. Build + deploy
+The USB override (`docker-compose.dev.local.yml`) maps `/dev/ttyUSB0-3` and adds the `dialout` group — **required** for serial nodes, and it only patches the `meshmonitor-sqlite` service. Always include both `-f` files:
+
+```bash
+# redeploy (default)
+COMPOSE_PROFILES=sqlite docker compose -f docker-compose.dev.yml -f docker-compose.dev.local.yml build
+COMPOSE_PROFILES=sqlite docker compose -f docker-compose.dev.yml -f docker-compose.dev.local.yml up -d
+
+# fresh image (only when asked)
+COMPOSE_PROFILES=sqlite docker compose -f docker-compose.dev.yml -f docker-compose.dev.local.yml build --no-cache && \
+COMPOSE_PROFILES=sqlite docker compose -f docker-compose.dev.yml -f docker-compose.dev.local.yml up -d
+
+# tear down (NO -v, ever)
+COMPOSE_PROFILES=sqlite docker compose -f docker-compose.dev.yml -f docker-compose.dev.local.yml down
+```
+
+Use `docker compose` (space), never the legacy `docker-compose`. Pass the profile via `COMPOSE_PROFILES=`, not `--profile`.
+
+### 3. Verify the *right* code deployed
+A successful `up -d` does NOT mean your code is in the image — a cached layer can ship stale code.
+
+```bash
+COMPOSE_PROFILES=sqlite docker compose -f docker-compose.dev.yml -f docker-compose.dev.local.yml ps
+COMPOSE_PROFILES=sqlite docker compose -f docker-compose.dev.yml -f docker-compose.dev.local.yml logs --tail=40 meshmonitor-sqlite
+```
+
+- Container is `Up`/healthy.
+- Confirm a string unique to this change is present in the served bundle, or that startup logs show the expected migration/version. Don't just assert "it's running".
+
+### 4. Access details (for the user / for testing)
+- App: **http://localhost:8081/meshmonitor** (the sqlite app publishes `8081:3001`; `BASE_URL=/meshmonitor`). *(CLAUDE.md mentions :8080 — that's a host proxy, not the container port; the container itself is 8081.)*
+- Tileserver: http://localhost:8082
+- Login: `admin` / `changeme` (the seeded default — **not** `changeme1`, which is only the `api-test.sh` default). Login is rate-limited; if you lock yourself out, wait it out — the container has **no `sqlite3` CLI** to reset it.
+- Send test messages on the `gauntlet` channel, never Primary.
+
+### 5. Report
+- What was built (redeploy vs no-cache), the deployed short SHA, container status, the verification you used to confirm *this* code is live, and the access URL.
+- Do **not** push, open PRs, or run the test suite — this skill is build/deploy/verify only.

--- a/.claude/commands/merge.md
+++ b/.claude/commands/merge.md
@@ -1,0 +1,71 @@
+---
+name: merge
+description: Merge an approved/green PR, fast-forward local main, and clean up the worktree/branch — the full "Merge it" sequence, safe under concurrent shared-checkout sessions.
+---
+
+Merge a PR and leave the workspace clean. This bundles the post-merge hygiene that's otherwise re-done by hand every time.
+
+## Arguments
+$ARGUMENTS
+
+A PR number (e.g. `3621` / `#3621`). If omitted, resolve it from the current branch: `gh pr view --json number,headRefName,state,mergeStateStatus`.
+
+## Step 1: Pre-merge gate
+
+Do NOT merge a red or unreviewed PR unless the user explicitly said so.
+
+```bash
+gh pr view <PR> --json number,title,state,mergeStateStatus,reviewDecision,headRefName,statusCheckRollup \
+  -q '{num:.number,title:.title,state:.state,merge:.mergeStateStatus,review:.reviewDecision,branch:.headRefName}'
+```
+
+- `state` must be `OPEN`.
+- CI green (`mergeStateStatus` not `BLOCKED`/`DIRTY`/`BEHIND`; `statusCheckRollup` all `SUCCESS`/skipped).
+- If there are merge conflicts (`DIRTY`/`BEHIND`), STOP and report — the branch needs a rebase/merge first, which is the user's call.
+- Capture `headRefName` — you'll need it for cleanup.
+
+## Step 2: Merge
+
+This repo squash-merges (PR titles in history read `feat(scope): … (#NNNN)`). Merge and delete the remote branch in one shot:
+
+```bash
+gh pr merge <PR> --squash --delete-branch
+```
+
+If the user asked for a different method, honor it (`--merge` / `--rebase`).
+
+## Step 3: Fast-forward local `main`
+
+The primary checkout's `main` drifts behind `origin/main` after every merge. Bring it current — but this is a **shared working directory** that other sessions may be using, and `.claude/agent-memory/` carries untracked files that a checkout would trip over. Stash those first, fast-forward, then restore:
+
+```bash
+git fetch origin main
+git stash push -u -m "pre-ff-agent-memory" -- .claude/agent-memory/ 2>/dev/null || true
+git checkout main && git merge --ff-only origin/main
+git stash pop 2>/dev/null || true
+```
+
+- Use `--ff-only` — never create a merge commit on `main`, and never `git push` to `main`.
+- If `--ff-only` fails, local `main` has diverged (someone committed to it directly). STOP and report rather than forcing.
+- If another session has the checkout on a different branch and switching would disrupt it, note that and ask before changing branches.
+
+## Step 4: Clean up the worktree / branch
+
+If the work was done in a worktree:
+```bash
+git worktree list                       # find the worktree backing <headRefName>
+git worktree remove <path>              # NOT --force unless the user OKs uncommitted changes
+git worktree prune
+```
+If it was a local branch in this checkout (now merged), delete it:
+```bash
+git branch -d <headRefName>             # -d (safe); never -D without asking
+```
+For anything non-trivial (multiple worktrees, uncommitted changes), defer to **`/worktree-cleanup`** and let it confirm with the user.
+
+## Step 5: Report
+
+- PR merged (number + title), merge method.
+- Local `main` fast-forwarded to `<short-sha>` (or why it couldn't be).
+- Worktree/branch cleaned up (or left, with reason).
+- Surface any `/schedule`-worthy follow-up only if the merged work left a concrete dated obligation (flag ramp, `.skip` removal) — otherwise don't.

--- a/.claude/commands/migration.md
+++ b/.claude/commands/migration.md
@@ -1,0 +1,77 @@
+---
+name: migration
+description: Scaffold a new database migration across all three backends (SQLite/PostgreSQL/MySQL), register it, and update the count test. Use when adding/altering a table or column.
+---
+
+Create a new MeshMonitor migration. Migrations run on every boot against whichever backend is configured, so **all three** must be implemented and idempotent.
+
+## Arguments
+$ARGUMENTS
+
+A short description of the schema change (e.g. "add isPinned to messages"). Convert to `snake_case` for the migration name.
+
+## Step 0: Determine the next number (never hardcode)
+
+```bash
+ls src/server/migrations/ | grep -E '^[0-9]{3}_' | sort | tail -1
+```
+Take the highest `NNN` and add 1. Zero-pad to 3 digits (`NNN`). Confirm it's free on current `origin/main` — if another in-flight branch already claimed it, bump again to avoid a collision on merge.
+
+## Step 1: Schema change (if adding/altering columns)
+
+Edit `src/db/schema/<table>.ts` — it defines the table **three times** (sqlite / postgres / mysql). Update all three:
+- SQLite columns are `snake_case`; PostgreSQL/MySQL use `camelCase`.
+- Node IDs / packet IDs are **BIGINT** in PG/MySQL (`nodeNum` is unsigned 32-bit; PG/MySQL `INTEGER` is signed 32-bit and overflows). Coerce with `Number(row.x)` at read sites.
+- Booleans: SQLite 0/1, PG/MySQL true/false — Drizzle handles it.
+- If this is per-source data, add a `sourceId` column to all three (unless it's global-by-design like `channel_database`/`estimated_positions`), and plan a backfill of existing rows with the default source.
+
+## Step 2: Create `src/server/migrations/NNN_<name>.ts`
+
+Mirror an existing recent one (e.g. `096_meshcore_neighbor_timestamp_bigint.ts`). It must export:
+- `export const migration = { up: (db: Database) => {...} }` — SQLite
+- `export async function runMigrationNNNPostgres(client) {...}` — PostgreSQL
+- `export async function runMigrationNNNMysql(pool) {...}` — MySQL
+
+**Idempotency is mandatory** (migrations may re-run / partially-applied DBs exist):
+- SQLite: wrap `ALTER TABLE … ADD COLUMN` in try/catch and swallow `duplicate column`.
+- PostgreSQL: `ADD COLUMN IF NOT EXISTS` / `CREATE TABLE IF NOT EXISTS`.
+- MySQL: guard with an `information_schema.columns` / `information_schema.tables` existence check (MySQL has no `IF NOT EXISTS` for `ADD COLUMN` on older versions).
+
+Raw SQL **is** allowed inside `src/server/migrations/**` (it's exempt from the ESLint raw-SQL ban). Branch dialect-specific syntax on the backend.
+
+## Step 3: Register in `src/db/migrations.ts`
+
+1. Add the import near the other `NNN` imports (top of file):
+   ```ts
+   import { migration as <name>Migration, runMigrationNNNPostgres as <name>Postgres, runMigrationNNNMysql as <name>Mysql } from '../server/migrations/NNN_<name>.js';
+   ```
+   (Note the `.js` extension — these are ESM imports.)
+2. Add the registration (keep them in numeric order):
+   ```ts
+   registry.register({
+     number: NNN,
+     name: '<name>',
+     settingsKey: 'migration_NNN_<name>',
+     sqlite: (db) => <name>Migration.up(db),
+     postgres: (client) => <name>Postgres(client),
+     mysql: (pool) => <name>Mysql(pool),
+   });
+   ```
+
+## Step 4: Update `src/db/migrations.test.ts`
+
+Two assertions are pinned to the latest migration — update both:
+- `expect(registry.count()).toBe(NNN);`
+- the `last migration is …` block: `expect(last.number).toBe(NNN);` and `expect(last.name).toContain('<name>');`
+
+## Step 5: Verify
+
+```bash
+npx vitest run src/db/migrations.test.ts --reporter=json --outputFile=/tmp/mig.json >/dev/null 2>&1
+python3 -c "import json; d=json.load(open('/tmp/mig.json')); print('success:', d['success'], 'failed:', d['numFailedTests'])"
+npx tsc -p tsconfig.server.json --noEmit
+```
+Confirm `success: true`. Then run the full suite before a PR (migration changes can ripple). To exercise the migration against a real DB, `/deploy` and check the startup logs for the `migration_NNN_*` run, and test SQLite first (the default, most common deployment).
+
+## Step 6: Report
+- Migration number + name, the tables/columns touched (and which backends), how you confirmed the number was free, and test/tsc results.

--- a/.claude/skills/ci-monitor.md
+++ b/.claude/skills/ci-monitor.md
@@ -72,7 +72,12 @@ Apply a **minimal targeted fix** — touch ONLY the files related to the failure
 
 After fixing:
 - Run the failing test file locally first: `node_modules/.bin/vitest run <failing_test_file>`
-- If green, run the relevant suite: `npm test 2>&1 | tail -5`
+- If green, run the full suite. **Do NOT trust the `PASS (N) FAIL (0)` summary line** — the rtk wrapper counts only assertion failures, so suite-level (collection/import) failures slip through. Confirm `success: true` via the JSON reporter:
+  ```bash
+  npx vitest run --reporter=json --outputFile=/tmp/vitest.json >/dev/null 2>&1
+  python3 -c "import json; d=json.load(open('/tmp/vitest.json')); print('success:', d['success'], 'passed:', d['numPassedTests'], 'failed:', d['numFailedTests'], 'suitesFailed:', d['numFailedTestSuites'])"
+  ```
+- **TypeScript check:** use `npx tsc -p tsconfig.server.json --noEmit` for server code. The base `npx tsc --noEmit` reports ~57–60 **pre-existing** frontend errors (TelemetryChart.tsx, etc.) on clean `origin/main` — ignore those; **only NEW errors you introduced matter**. Do not waste cycles "fixing" the pre-existing noise.
 - Commit and push: `git add -A && git commit -m "fix: <describe>" && git push`
 
 ### Phase 4: Re-monitor


### PR DESCRIPTION
## Summary

Promotes hard-won, repeatedly-relearned workflow knowledge (currently scattered across agent-memory notes) into executable slash commands, and corrects two existing skills whose instructions were actively misleading. Documentation/tooling only — no application code changes.

## New skills

- **`/deploy`** — dev-container build/deploy/verify. Bakes in the data-loss guardrails (never `down -v`; references the 2026-04-18 volume-wipe incident), the **mandatory USB override** (`-f docker-compose.dev.local.yml`, gitignored → copy into worktrees), the real access URL (`localhost:8081/meshmonitor`), login `admin/changeme`, and a "verify the right commit actually deployed" step.
- **`/merge`** — the "Merge it" sequence: pre-merge gate → squash-merge → fast-forward local `main` (stashing `.claude/agent-memory/` first) → worktree/branch cleanup, safe under concurrent shared-checkout sessions.
- **`/migration`** — scaffolds an `NNN` migration across SQLite/PostgreSQL/MySQL (idempotent), registers it in `migrations.ts`, and updates the count/last-name assertions in `migrations.test.ts`. Computes the next number dynamically.

## Fixes to existing skills

- **`create-pr` & `ci-monitor`:** replace the rtk-maskable `PASS/FAIL` test summary with the JSON-reporter `success: true` check — suite-level (collection/import) failures otherwise slip through.
- **`create-pr`:** `npx tsc --noEmit` "must compile cleanly" was **wrong** — base tsc reports ~57–60 pre-existing frontend errors on clean `origin/main`. Switched to `tsc -p tsconfig.server.json --noEmit`; only NEW errors matter.
- **`create-pr`:** converge CI monitoring onto `scripts/watch-ci.sh` (was `sleep 300` + manual polling); add worktree submodule-init and explicit-branch-ref push notes for shared checkouts.
- **`README`:** document the three new commands; correct the stale `/create-pr` description.
- Sync the duplicated `.claude/skills/ci-monitor.md` copy.

## Issues Resolved
None (workflow tooling improvement).

## Testing
- [x] Skills load (`/deploy`, `/merge`, `/migration` register in the slash menu)
- [x] No application code touched — `.claude/` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)