### PR TITLE
feat(traceroutes): add packetId column for cross-source trace correlation (#3623)

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 96 migrations registered', () => {
-    expect(registry.count()).toBe(96);
+  it('has all 97 migrations registered', () => {
+    expect(registry.count()).toBe(97);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is meshcore_neighbor_timestamp_bigint', () => {
+  it('last migration is add_packet_id_to_traceroutes', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(96);
-    expect(last.name).toContain('meshcore_neighbor_timestamp_bigint');
+    expect(last.number).toBe(97);
+    expect(last.name).toContain('add_packet_id_to_traceroutes');
   });
 
-  it('migrations are sequentially numbered from 1 to 96', () => {
+  it('migrations are sequentially numbered from 1 to 97', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -111,6 +111,7 @@ import { migration as autoackMatrixMigration, runMigration093Postgres as runAuto
 import { migration as meshcoreNodeFavoriteMigration, runMigration094Postgres as runMeshcoreNodeFavoritePostgres, runMigration094Mysql as runMeshcoreNodeFavoriteMysql } from '../server/migrations/094_add_meshcore_node_favorite.js';
 import { migration as deadDropMigration, runMigration095Postgres as runDeadDropPostgres, runMigration095Mysql as runDeadDropMysql } from '../server/migrations/095_create_dead_drop.js';
 import { migration as meshcoreNeighborTimestampBigintMigration, runMigration096Postgres as runMeshcoreNeighborTimestampBigintPostgres, runMigration096Mysql as runMeshcoreNeighborTimestampBigintMysql } from '../server/migrations/096_meshcore_neighbor_timestamp_bigint.js';
+import { migration as traceroutePacketIdMigration, runMigration097Postgres as runTraceroutePacketIdPostgres, runMigration097Mysql as runTraceroutePacketIdMysql } from '../server/migrations/097_add_packet_id_to_traceroutes.js';
 
 // ============================================================================
 // Registry
@@ -1533,4 +1534,20 @@ registry.register({
   sqlite: (db) => meshcoreNeighborTimestampBigintMigration.up(db),
   postgres: (client) => runMeshcoreNeighborTimestampBigintPostgres(client),
   mysql: (pool) => runMeshcoreNeighborTimestampBigintMysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 097: add traceroutes.packetId (#3623). Records the originating
+// Meshtastic packet id so traces can be correlated across sources and grouped
+// per-packet. BIGINT on PG/MySQL (packet ids are unsigned 32-bit); SQLite
+// INTEGER is already 64-bit.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 97,
+  name: 'add_packet_id_to_traceroutes',
+  settingsKey: 'migration_097_add_packet_id_to_traceroutes',
+  sqlite: (db) => traceroutePacketIdMigration.up(db),
+  postgres: (client) => runTraceroutePacketIdPostgres(client),
+  mysql: (pool) => runTraceroutePacketIdMysql(pool),
 });

--- a/src/db/repositories/traceroutes.test.ts
+++ b/src/db/repositories/traceroutes.test.ts
@@ -36,6 +36,7 @@ const POSTGRES_CREATE = `
     "snrBack" TEXT,
     "routePositions" TEXT,
     channel INTEGER,
+    "packetId" BIGINT,
     timestamp BIGINT NOT NULL,
     "createdAt" BIGINT NOT NULL,
     "sourceId" TEXT
@@ -74,6 +75,7 @@ const MYSQL_CREATE = `
     snrBack TEXT,
     routePositions TEXT,
     channel INT,
+    packetId BIGINT,
     timestamp BIGINT NOT NULL,
     createdAt BIGINT NOT NULL,
     sourceId VARCHAR(36)
@@ -253,6 +255,53 @@ function runTraceroutesTests(getBackend: () => TestBackend) {
     expect(all[0].snrTowards).toBe('10.5,8.2');
     expect(all[0].snrBack).toBe('9.1,7.3');
     expect(Number(all[0].timestamp)).toBe(updatedTs);
+  });
+
+  it('packetId (#3623) - persists on insert and is returned', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    const now = Date.now();
+    // Unsigned 32-bit packet id near the top of the range — would overflow a
+    // signed 32-bit INTEGER, which is why PG/MySQL store it as BIGINT.
+    const packetId = 4_000_000_001;
+    await repo.insertTraceroute(makeTraceroute({ timestamp: now, createdAt: now, packetId }));
+
+    const all = await repo.getAllTraceroutes();
+    expect(all.length).toBe(1);
+    expect(Number(all[0].packetId)).toBe(packetId);
+  });
+
+  it('packetId (#3623) - populated when a pending traceroute gets its response', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    const now = Date.now();
+    // Pending row inserted with no packetId (route null).
+    await repo.insertTraceroute(makeTraceroute({ timestamp: now, createdAt: now }));
+    const pending = await repo.findPendingTraceroute(1001, 2002, now - 60000);
+    expect(pending).not.toBeNull();
+
+    const packetId = 3_500_000_123;
+    await repo.updateTracerouteResponse(
+      pending!.id,
+      '1001,3003,2002',
+      '2002,3003,1001',
+      '10.5,8.2',
+      '9.1,7.3',
+      now + 5000,
+      packetId,
+    );
+
+    const all = await repo.getAllTraceroutes();
+    expect(all.length).toBe(1);
+    expect(Number(all[0].packetId)).toBe(packetId);
   });
 
   it('getTraceroutesByNodes - filter by from/to (bidirectional)', async () => {

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -34,6 +34,7 @@ export class TraceroutesRepository extends BaseRepository {
       snrBack: tracerouteData.snrBack,
       routePositions: tracerouteData.routePositions ?? null,
       channel: tracerouteData.channel ?? null,
+      packetId: tracerouteData.packetId ?? null,
       timestamp: tracerouteData.timestamp,
       createdAt: tracerouteData.createdAt,
     };
@@ -70,11 +71,15 @@ export class TraceroutesRepository extends BaseRepository {
   /**
    * Update a pending traceroute with response data
    */
-  async updateTracerouteResponse(id: number, route: string | null, routeBack: string | null, snrTowards: string | null, snrBack: string | null, timestamp: number): Promise<void> {
+  async updateTracerouteResponse(id: number, route: string | null, routeBack: string | null, snrTowards: string | null, snrBack: string | null, timestamp: number, packetId?: number | null): Promise<void> {
     const { traceroutes } = this.tables;
+    const set: any = { route, routeBack, snrTowards, snrBack, timestamp };
+    // Only overwrite packetId when the response carries one — preserves any id
+    // already stored on the pending row if this update doesn't supply it.
+    if (packetId !== undefined) set.packetId = packetId;
     await this.db
       .update(traceroutes)
-      .set({ route, routeBack, snrTowards, snrBack, timestamp })
+      .set(set)
       .where(eq(traceroutes.id, id));
   }
 
@@ -543,6 +548,7 @@ export class TraceroutesRepository extends BaseRepository {
             routeBack: tracerouteData.routeBack || null,
             snrTowards: tracerouteData.snrTowards || null,
             snrBack: tracerouteData.snrBack || null,
+            packetId: tracerouteData.packetId ?? null,
             timestamp: tracerouteData.timestamp,
           })
           .where(eq(traceroutes.id, id))
@@ -557,6 +563,7 @@ export class TraceroutesRepository extends BaseRepository {
           routeBack: tracerouteData.routeBack || null,
           snrTowards: tracerouteData.snrTowards || null,
           snrBack: tracerouteData.snrBack || null,
+          packetId: tracerouteData.packetId ?? null,
           timestamp: tracerouteData.timestamp,
           createdAt: tracerouteData.createdAt,
           sourceId: sourceId ?? null,
@@ -857,6 +864,7 @@ export class TraceroutesRepository extends BaseRepository {
   private normalizeTracerouteRow(r: any): DbTraceroute {
     const n = this.normalizeBigInts(r) as any;
     if (n.channel === null) n.channel = undefined;
+    if (n.packetId === null) n.packetId = undefined;
     if (n.routePositions === null) n.routePositions = undefined;
     if (n.sourceId === null) n.sourceId = undefined;
     if (n.route === null) n.route = undefined;
@@ -881,6 +889,7 @@ export class TraceroutesRepository extends BaseRepository {
     return (rows as any[]).map((r) => {
       const n = this.normalizeBigInts(r) as any;
       if (n.channel === null) n.channel = undefined;
+      if (n.packetId === null) n.packetId = undefined;
       if (n.routePositions === null) n.routePositions = undefined;
       if (n.sourceId === null) n.sourceId = undefined;
       return n as DbTraceroute;

--- a/src/db/schema/traceroutes.ts
+++ b/src/db/schema/traceroutes.ts
@@ -20,6 +20,7 @@ export const traceroutesSqlite = sqliteTable('traceroutes', {
   snrBack: text('snrBack'), // JSON string of return SNR values
   routePositions: text('routePositions'), // JSON: { nodeNum: { lat, lng, alt? } } position snapshot at traceroute time
   channel: integer('channel'), // Mesh channel this traceroute was received on (null = unknown/pre-migration)
+  packetId: integer('packetId'), // Originating Meshtastic packet id (null = pre-migration). Enables cross-source correlation (#3623)
   timestamp: integer('timestamp').notNull(),
   createdAt: integer('createdAt').notNull(),
   // Source association (nullable — NULL = legacy default source)
@@ -57,6 +58,7 @@ export const traceroutesPostgres = pgTable('traceroutes', {
   snrBack: pgText('snrBack'), // JSON string of return SNR values
   routePositions: pgText('routePositions'), // JSON: { nodeNum: { lat, lng, alt? } } position snapshot at traceroute time
   channel: pgInteger('channel'), // Mesh channel this traceroute was received on (null = unknown/pre-migration)
+  packetId: pgBigint('packetId', { mode: 'number' }), // Originating Meshtastic packet id (null = pre-migration). Enables cross-source correlation (#3623)
   timestamp: pgBigint('timestamp', { mode: 'number' }).notNull(),
   createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
   // Source association (nullable — NULL = legacy default source)
@@ -94,6 +96,7 @@ export const traceroutesMysql = mysqlTable('traceroutes', {
   snrBack: myText('snrBack'), // JSON string of return SNR values
   routePositions: myText('routePositions'), // JSON: { nodeNum: { lat, lng, alt? } } position snapshot at traceroute time
   channel: myInt('channel'), // Mesh channel this traceroute was received on (null = unknown/pre-migration)
+  packetId: myBigint('packetId', { mode: 'number' }), // Originating Meshtastic packet id (null = pre-migration). Enables cross-source correlation (#3623)
   timestamp: myBigint('timestamp', { mode: 'number' }).notNull(),
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
   // Source association (nullable — NULL = legacy default source)

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -193,6 +193,7 @@ export interface DbTraceroute {
   snrBack: string | null;
   routePositions?: string | null;
   channel?: number | null;
+  packetId?: number | null;
   timestamp: number;
   createdAt: number;
 }

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7182,6 +7182,7 @@ class MeshtasticManager implements ISourceManager {
         snrBack: JSON.stringify(snrBack),
         routePositions: JSON.stringify(routePositions),
         channel: channelIndex >= 0 ? channelIndex : null,
+        packetId: meshPacket.id != null ? Number(meshPacket.id) : null,
         timestamp: timestamp,
         createdAt: Date.now()
       };

--- a/src/server/migrations/097_add_packet_id_to_traceroutes.ts
+++ b/src/server/migrations/097_add_packet_id_to_traceroutes.ts
@@ -1,0 +1,84 @@
+/**
+ * Migration 097: Add packetId column to traceroutes table (#3623)
+ *
+ * Traceroute rows previously stored no reference to the originating Meshtastic
+ * packet. Recording the packet id lets callers:
+ *   - correlate the same physical traceroute received via multiple sources
+ *     (e.g. a local TCP mesh and an MQTT feed both hearing the same response), and
+ *   - group/display individual traces (all flood-routing branches of one packet)
+ *     rather than only the collapsed resulting path.
+ *
+ * NULL indicates the packet id was not captured (pre-migration rows).
+ *
+ * Meshtastic packet ids are unsigned 32-bit values, which overflow a signed
+ * 32-bit INTEGER, so PostgreSQL/MySQL use BIGINT. SQLite INTEGER is 64-bit.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 097 (SQLite): Adding packetId column to traceroutes...');
+
+    try {
+      db.exec('ALTER TABLE traceroutes ADD COLUMN packetId INTEGER');
+      logger.debug('Added packetId column to traceroutes');
+    } catch (e: any) {
+      if (e.message?.includes('duplicate column')) {
+        logger.debug('traceroutes.packetId already exists, skipping');
+      } else {
+        logger.warn('Could not add packetId to traceroutes:', e.message);
+      }
+    }
+
+    logger.info('Migration 097 complete (SQLite): traceroutes.packetId added');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 097 down: Not implemented (destructive column drops)');
+  }
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration097Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 097 (PostgreSQL): Adding packetId to traceroutes...');
+
+  try {
+    await client.query('ALTER TABLE traceroutes ADD COLUMN IF NOT EXISTS "packetId" BIGINT');
+    logger.debug('Ensured traceroutes.packetId exists');
+  } catch (error: any) {
+    logger.error('Migration 097 (PostgreSQL) failed:', error.message);
+    throw error;
+  }
+
+  logger.info('Migration 097 complete (PostgreSQL): traceroutes.packetId added');
+}
+
+// ============ MySQL ============
+
+export async function runMigration097Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 097 (MySQL): Adding packetId to traceroutes...');
+
+  try {
+    const [rows] = await pool.query(`
+      SELECT COLUMN_NAME FROM information_schema.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'traceroutes' AND COLUMN_NAME = 'packetId'
+    `);
+    if (!Array.isArray(rows) || rows.length === 0) {
+      await pool.query('ALTER TABLE traceroutes ADD COLUMN packetId BIGINT');
+      logger.debug('Added packetId to traceroutes');
+    } else {
+      logger.debug('traceroutes.packetId already exists, skipping');
+    }
+  } catch (error: any) {
+    logger.error('Migration 097 (MySQL) failed:', error.message);
+    throw error;
+  }
+
+  logger.info('Migration 097 complete (MySQL): traceroutes.packetId added');
+}

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -582,6 +582,9 @@ async function ingestTraceroute(
     snrTowards: JSON.stringify(snrTowards),
     snrBack: JSON.stringify(snrBack),
     routePositions: JSON.stringify(routePositions),
+    // Originating packet id enables correlating this trace with the same packet
+    // heard on another source (e.g. a direct TCP listener) — issue #3623.
+    packetId: typeof packet.id === 'number' ? packet.id >>> 0 : null,
     timestamp: nowMs,
     createdAt: nowMs,
   };

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -188,6 +188,8 @@ export interface DbTraceroute {
   snrBack: string;
   /** JSON: `{ [nodeNum]: { lat, lng, alt? } }` — position snapshot at traceroute time. */
   routePositions?: string;
+  /** Originating Meshtastic packet id (null/undefined = not captured). Enables cross-source correlation (#3623). */
+  packetId?: number | null;
   timestamp: number;
   createdAt: number;
 }
@@ -4346,7 +4348,8 @@ class DatabaseService {
                 tracerouteData.routeBack || null,
                 tracerouteData.snrTowards || null,
                 tracerouteData.snrBack || null,
-                tracerouteData.timestamp
+                tracerouteData.timestamp,
+                tracerouteData.packetId ?? null
               );
             } else {
               // Insert new traceroute


### PR DESCRIPTION
## Summary

Closes #3623.

The `traceroutes` table stored no reference to the originating Meshtastic packet, so the same physical traceroute heard on multiple sources (e.g. a direct TCP listener and an MQTT feed) couldn't be correlated, and individual traces couldn't be grouped/displayed per-packet (all flood-routing branches of one packet) instead of only the collapsed resulting path.

This adds a nullable **`packetId`** column to the traceroutes table and populates it on every ingestion path.

## Changes

- **Migration 097** (`097_add_packet_id_to_traceroutes.ts`) — adds `packetId` across SQLite / PostgreSQL / MySQL, idempotent. **BIGINT** on PG/MySQL since Meshtastic packet ids are unsigned 32-bit and overflow a signed INTEGER; SQLite INTEGER is already 64-bit. `NULL` = pre-migration rows.
- **Schema** (`db/schema/traceroutes.ts`, all three backends) + **types** (`db/types.ts` and the `database.ts` facade interface).
- **Repository** (`db/repositories/traceroutes.ts`) — threads `packetId` through `insertTraceroute`, `upsertTracerouteSync` (insert + pending-update branches), `updateTracerouteResponse`, and the row-normalization helpers.
- **Population** — `meshPacket.id` on the TCP path (`meshtasticManager.ts`) and `packet.id` on the MQTT path (`mqttIngestion.ts`). For traceroutes we initiate, the pending row's `packetId` is filled in when the response arrives via `updateTracerouteResponse`.

### Note on `routeBack`
The issue discussion suggested return-path persistence was also missing. It turns out **`routeBack` is already persisted and returned end-to-end** (column, insert/upsert, select, normalization all present), so no change was needed there.

### Scope
This delivers the storage/correlation foundation. The per-packet branch **visualization** shown in the issue is a separate frontend feature that this unblocks (the `packetId` is now stored and returned by the traceroute queries).

## Testing
- [x] 2 new repository round-trip tests — insert-with-packetId, and pending→response fill — run across SQLite/PostgreSQL/MySQL.
- [x] Migration count (96→97) and last-migration assertions updated.
- [x] Full Vitest suite green (**7127 passed, 0 failed**).
- [x] `tsc -p tsconfig.server.json --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)