### PR TITLE
fix(map): anchor neighbor-info lines to the merged node marker position (#3642)

### DIFF
--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -11,7 +11,7 @@ import { effectiveMapMaxAgeHours } from '../utils/mapAge';
 import { createNodeIcon, getHopColor } from '../utils/mapIcons';
 import { getPositionHistoryColor, generateHeadingAwarePath, generatePositionHistoryArrows, createArrowIcon } from '../utils/mapHelpers.tsx';
 import { convertSpeed } from '../utils/speedConversion';
-import { getEffectivePosition, getRoleName, hasValidEffectivePosition, isNodeComplete, parseNodeId } from '../utils/nodeHelpers';
+import { getEffectivePosition, getRoleName, hasValidEffectivePosition, isNodeComplete, parseNodeId, resolveMapEndpoint } from '../utils/nodeHelpers';
 import MapLegend from './MapLegend';
 import { formatTime, formatDateTime } from '../utils/datetime';
 import { getDistanceToNode, calculateDistance, formatDistance } from '../utils/distance';
@@ -2441,10 +2441,19 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
               {/* Draw neighbor info connections */}
               {showNeighborInfo && neighborInfo.length > 0 && neighborInfo.map((ni, idx) => {
-                // Skip if either node doesn't have position
-                if (!ni.nodeLatitude || !ni.nodeLongitude || !ni.neighborLatitude || !ni.neighborLongitude) {
+                // Anchor each endpoint to where the node's MARKER is rendered
+                // (merged / override-aware position, keyed by nodeNum) so the
+                // line connects to the visible marker rather than the
+                // source-specific reported coords (#3642). Falls back to the
+                // record's embedded coords when the node isn't on the map.
+                const nodeEndpoint = resolveMapEndpoint(nodePositions, ni.nodeNum, ni.nodeLatitude, ni.nodeLongitude);
+                const neighborEndpoint = resolveMapEndpoint(nodePositions, ni.neighborNodeNum, ni.neighborLatitude, ni.neighborLongitude);
+                // Skip if either endpoint has no resolvable position
+                if (!nodeEndpoint || !neighborEndpoint) {
                   return null;
                 }
+                const [nodeLat, nodeLng] = nodeEndpoint;
+                const [neighborLat, neighborLng] = neighborEndpoint;
 
                 // Filter out segments where either endpoint is not visible (Issue #1149)
                 if (visibleNodeNums && (!visibleNodeNums.has(ni.nodeNum) || !visibleNodeNums.has(ni.neighborNodeNum))) {
@@ -2457,8 +2466,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 }
 
                 const positions: [number, number][] = [
-                  [ni.nodeLatitude, ni.nodeLongitude],
-                  [ni.neighborLatitude, ni.neighborLongitude]
+                  [nodeLat, nodeLng],
+                  [neighborLat, neighborLng]
                 ];
 
                 // Zoom-adaptive: hide neighbor lines at low zoom
@@ -2476,7 +2485,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 } else { lineWeight = 2; lineOpacity = 0.3; }
 
                 // Calculate distance between nodes (coordinates guaranteed non-null by early return above)
-                const distKm = calculateDistance(ni.nodeLatitude!, ni.nodeLongitude!, ni.neighborLatitude!, ni.neighborLongitude!);
+                const distKm = calculateDistance(nodeLat, nodeLng, neighborLat, neighborLng);
                 const distStr = formatDistance(distKm, distanceUnit);
 
                 // Normalize timestamp: old data may be in seconds, new data in milliseconds
@@ -2494,11 +2503,11 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 // Calculate bearing for unidirectional arrow (degrees from north)
                 // Arrow points FROM neighbor TO node (neighbor→node = "I heard this neighbor")
                 // Scale longitude difference by cos(lat) to correct for latitude
-                const latMid = (ni.nodeLatitude! + ni.neighborLatitude!) / 2;
+                const latMid = (nodeLat + neighborLat) / 2;
                 const bearing = !isBidirectional
                   ? Math.atan2(
-                      (ni.nodeLongitude! - ni.neighborLongitude!) * Math.cos(latMid * Math.PI / 180),
-                      ni.nodeLatitude! - ni.neighborLatitude!
+                      (nodeLng - neighborLng) * Math.cos(latMid * Math.PI / 180),
+                      nodeLat - neighborLat
                     ) * (180 / Math.PI)
                   : 0;
 
@@ -2542,14 +2551,14 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                       </Popup>
                     </Polyline>
                     {/* Direction arrows along unidirectional lines at 25%, 50%, 75% for visibility at any zoom */}
-                    {!isBidirectional && ni.nodeLatitude && ni.neighborLatitude && (
+                    {!isBidirectional && (
                       <>
                         {[0.25, 0.5, 0.75].map(fraction => (
                           <Marker
                             key={`arrow-${fraction}`}
                             position={[
-                              ni.neighborLatitude! + (ni.nodeLatitude! - ni.neighborLatitude!) * fraction,
-                              ni.neighborLongitude! + (ni.nodeLongitude! - ni.neighborLongitude!) * fraction
+                              neighborLat + (nodeLat - neighborLat) * fraction,
+                              neighborLng + (nodeLng - neighborLng) * fraction
                             ]}
                             icon={createArrowIcon(bearing, overlayColors.neighborLine)}
                             interactive={false}

--- a/src/utils/nodeHelpers.test.ts
+++ b/src/utils/nodeHelpers.test.ts
@@ -1,7 +1,28 @@
 import { describe, it, expect } from 'vitest';
-import { getEffectivePosition, getRoleName, getHardwareModelName, getNodeName, getNodeShortName, hasValidEffectivePosition, isNodeComplete } from './nodeHelpers';
+import { getEffectivePosition, getRoleName, getHardwareModelName, getNodeName, getNodeShortName, hasValidEffectivePosition, isNodeComplete, resolveMapEndpoint } from './nodeHelpers';
 import { ROLE_NAMES, HARDWARE_MODELS } from '../constants/index.js';
 import type { DeviceInfo } from '../types/device';
+
+describe('resolveMapEndpoint (#3642)', () => {
+  it('prefers the rendered marker position over the record-embedded coords', () => {
+    // Marker is rendered at the merged position (37.0); the neighbor record
+    // carries a divergent source-specific position (36.9). The line endpoint
+    // must follow the marker.
+    const markers = new Map<number, [number, number]>([[0x11223344, [37.0, -122.0]]]);
+    expect(resolveMapEndpoint(markers, 0x11223344, 36.9, -121.9)).toEqual([37.0, -122.0]);
+  });
+
+  it('falls back to embedded coords when the node is not on the map', () => {
+    const markers = new Map<number, [number, number]>();
+    expect(resolveMapEndpoint(markers, 0xAABBCCDD, 40.5, -74.0)).toEqual([40.5, -74.0]);
+  });
+
+  it('returns null when neither a marker nor embedded coords are available', () => {
+    const markers = new Map<number, [number, number]>();
+    expect(resolveMapEndpoint(markers, 1, null, null)).toBeNull();
+    expect(resolveMapEndpoint(markers, 1, 40.5, undefined)).toBeNull();
+  });
+});
 
 describe('Node Helpers', () => {
   describe('getRoleName', () => {

--- a/src/utils/nodeHelpers.ts
+++ b/src/utils/nodeHelpers.ts
@@ -106,6 +106,31 @@ export const hasValidEffectivePosition = (node: DeviceInfo): boolean => {
   return pos.latitude != null && pos.longitude != null;
 };
 
+/**
+ * Resolve a map-overlay line endpoint (e.g. a neighbor-info link) to the
+ * position the node's MARKER is actually rendered at.
+ *
+ * On the Unified (multi-source) map a node's marker uses the merged /
+ * override-aware position (keyed by nodeNum in the rendered position map), but
+ * neighbor-info records carry the source-specific reported coordinates. Drawing
+ * a line from those embedded coords makes it float away from the marker when the
+ * two differ (#3642). Prefer the rendered marker position; fall back to the
+ * record's embedded coords only when the node isn't currently on the map.
+ *
+ * Returns `null` when no position can be resolved (caller should skip the line).
+ */
+export const resolveMapEndpoint = (
+  markerPositions: Map<number, [number, number]>,
+  nodeNum: number,
+  embeddedLat: number | null | undefined,
+  embeddedLng: number | null | undefined,
+): [number, number] | null => {
+  const marker = markerPositions.get(nodeNum);
+  if (marker) return marker;
+  if (embeddedLat != null && embeddedLng != null) return [embeddedLat, embeddedLng];
+  return null;
+};
+
 export const getRoleName = (role: number | string | undefined): string | null => {
   if (role === undefined || role === null) return null;
   const roleNum = typeof role === 'string' ? parseInt(role) : role;


### PR DESCRIPTION
## Summary

Closes #3642.

On the Unified (multi-source) map, a node's **marker** renders at its merged / override-aware position, but **neighbor-info lines** were drawn from the source-specific coordinates embedded in each neighbor record (`ni.nodeLatitude/Longitude`, `ni.neighborLatitude/Longitude`). When the same node is reported at different positions by different sources, the line floats away from the marker it should connect to.

## Fix

`NodesTab.tsx` now resolves each neighbor-line endpoint to the **rendered marker position** — `nodePositions` (keyed by `nodeNum`), the same memoized merged-position map the markers use — via a new pure helper `resolveMapEndpoint`. It falls back to the record's embedded coords only when the node isn't currently on the map. The resolved coords are used consistently for the line, the distance readout, the bearing, and the direction arrows.

## Testing
- [x] New unit tests for `resolveMapEndpoint` (prefer marker, fall back to embedded, return null when neither) — `nodeHelpers.test.ts` (62 passed).
- [x] `tsc` clean on the edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)