### PR TITLE
fix(meshcore): fetch full contact record when a new node is heard live (#3646)

### DIFF
--- a/src/server/meshcoreManager.newNodeRefresh.test.ts
+++ b/src/server/meshcoreManager.newNodeRefresh.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for MeshCoreManager fetching the full contact record when a brand-new
+ * node is heard live with an incomplete advert (#3646).
+ *
+ * A USB-serial companion can surface a new node's advert carrying only its
+ * public key (Name/type/Position absent). The full record lives on the device's
+ * contact list, so the manager schedules a debounced refreshContacts() — the
+ * same coalescing path used for PATH_UPDATED — so those fields populate
+ * immediately instead of only after a manual reconnect.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const upsertNode = vi.fn().mockResolvedValue(undefined);
+const emitMeshCoreContactUpdated = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      upsertNode: (...args: unknown[]) => upsertNode(...args),
+    },
+  },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: {
+    emitMeshCoreContactUpdated: (...args: unknown[]) => emitMeshCoreContactUpdated(...args),
+    emitMeshCoreMessage: vi.fn(),
+    emitMeshCoreSelfInfoUpdated: vi.fn(),
+  },
+}));
+
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+interface BridgeEvent {
+  event_type: string;
+  data: Record<string, unknown>;
+}
+
+function dispatchBridgeEvent(m: MeshCoreManager, evt: BridgeEvent): void {
+  // @ts-expect-error - exercising private method
+  m.handleBridgeEvent(evt);
+}
+
+const NEW_KEY = 'c'.repeat(64);
+
+function makeCompanionManager(): {
+  manager: MeshCoreManager;
+  bridgeCalls: Array<{ cmd: string; params: Record<string, unknown> }>;
+} {
+  const m = new MeshCoreManager('src-a');
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  const bridgeCalls: Array<{ cmd: string; params: Record<string, unknown> }> = [];
+
+  // get_contacts returns the FULL record for the new node — what a reconnect
+  // would have fetched.
+  (m as any).sendBridgeCommand = async (cmd: string, params: Record<string, unknown>) => {
+    bridgeCalls.push({ cmd, params });
+    if (cmd === 'get_contacts') {
+      return {
+        id: '1', success: true, data: [
+          {
+            public_key: NEW_KEY,
+            adv_name: 'Repeater One',
+            name: 'Repeater One',
+            adv_type: 2, // Repeater
+            latitude: 37.7749,
+            longitude: -122.4194,
+            last_advert: 0,
+          },
+        ],
+      };
+    }
+    return { id: '1', success: true, data: {} };
+  };
+
+  return { manager: m, bridgeCalls };
+}
+
+describe('MeshCoreManager — new-node contact refresh (#3646)', () => {
+  beforeEach(() => {
+    upsertNode.mockClear();
+    emitMeshCoreContactUpdated.mockClear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fetches the full record when a new node advertises with only its public key', async () => {
+    const { manager, bridgeCalls } = makeCompanionManager();
+
+    // Advert push carries ONLY the public key — no name/type/position.
+    dispatchBridgeEvent(manager, { event_type: 'contact_advertised', data: { public_key: NEW_KEY } });
+
+    // Debounced — nothing on the wire yet.
+    expect(bridgeCalls.filter(c => c.cmd === 'get_contacts')).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(1600);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // A single get_contacts ran, and the in-memory contact is now complete.
+    expect(bridgeCalls.filter(c => c.cmd === 'get_contacts')).toHaveLength(1);
+    const contact = manager.getContact(NEW_KEY);
+    expect(contact?.advName).toBe('Repeater One');
+    expect(contact?.advType).toBe(2);
+    expect(contact?.latitude).toBeCloseTo(37.7749);
+  });
+
+  it('does NOT schedule a refresh when the advert already carries name + type', async () => {
+    const { manager, bridgeCalls } = makeCompanionManager();
+
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_advertised',
+      data: { public_key: NEW_KEY, adv_name: 'Already Named', adv_type: 1 },
+    });
+
+    await vi.advanceTimersByTimeAsync(1600);
+    await Promise.resolve();
+
+    // Complete advert → no wasteful device round-trip.
+    expect(bridgeCalls.filter(c => c.cmd === 'get_contacts')).toHaveLength(0);
+  });
+
+  it('does NOT re-fetch for an already-known node re-advertising', async () => {
+    const { manager, bridgeCalls } = makeCompanionManager();
+    // Seed the node as already known.
+    (manager as any).contacts.set(NEW_KEY, { publicKey: NEW_KEY, advName: 'Known', advType: 1 });
+
+    dispatchBridgeEvent(manager, { event_type: 'contact_advertised', data: { public_key: NEW_KEY } });
+
+    await vi.advanceTimersByTimeAsync(1600);
+    await Promise.resolve();
+
+    expect(bridgeCalls.filter(c => c.cmd === 'get_contacts')).toHaveLength(0);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1044,6 +1044,14 @@ class MeshCoreManager extends EventEmitter {
         dataEventEmitter.emitMeshCoreContactUpdated(updated, this.sourceId);
         if (!wasKnown) {
           void this.notifyNewNodeDiscovered(updated);
+          // A brand-new node whose advert didn't carry its name/type — the full
+          // record (name, type, position) lives on the device's contact list.
+          // Pull it via a debounced refreshContacts() so those fields populate
+          // immediately instead of only after a manual disconnect/reconnect
+          // (#3646). Coalesced with path-refreshes over the same window.
+          if (!updated.advName || updated.advType === undefined) {
+            this.schedulePathRefresh(publicKey);
+          }
         }
         logger.info(`[MeshCore] ${event_type} for ${publicKey} (${data.adv_name ?? ''})`);
       }
@@ -1159,6 +1167,15 @@ class MeshCoreManager extends EventEmitter {
         void this.persistContact(updated);
         this.emit('contacts_updated', { sourceId: this.sourceId, contact: updated });
         dataEventEmitter.emitMeshCoreContactUpdated(updated, this.sourceId);
+
+        // A discovery response carries only key+type — name and position aren't
+        // included. For a newly-seen node, pull the full contact record
+        // (debounced) so those fields populate without a manual reconnect
+        // (#3646) rather than waiting on a later passive advert that may not
+        // carry them either.
+        if (isNew) {
+          this.schedulePathRefresh(publicKey);
+        }
 
         // Tally the burst, de-duplicating repeated responses from the same node.
         if (this.activeDiscovery && !this.activeDiscovery.seen.has(publicKey)) {
@@ -1768,7 +1785,7 @@ class MeshCoreManager extends EventEmitter {
       const pending = Array.from(this.pathRefreshPendingKeys);
       this.pathRefreshPendingKeys.clear();
       logger.info(
-        `[MeshCore:${this.sourceId}] Refreshing contacts after ${pending.length} path-update push(es)`,
+        `[MeshCore:${this.sourceId}] Refreshing contacts after ${pending.length} contact push(es) (path/new-node)`,
       );
       void this.refreshContacts()
         .then(() => {


### PR DESCRIPTION
## Summary

Closes #3646.

When a brand-new MeshCore node was heard live via advert (companion source, including USB-serial), it could appear with only its **public key** populated — Name, device type, and Position showed "Unknown" until the user manually disconnected and reconnected (which re-read the device's full contact list).

## Root cause

The live `contact_advertised` push handler *does* populate fields from the push payload (`adv_name`/`adv_type`/`latitude`/`longitude`), but for a brand-new node that payload can carry **only the public key**. The `node_discovered` (discovery-burst) path likewise only has key + type. The full record lives on the device's contact list and was only fetched by the **connect-time** sync — hence the "reconnect fixes it" symptom.

## Fix

When a **newly-seen** node arrives incomplete (missing `advName` or `advType`, or any discovery-burst node), schedule a **debounced `refreshContacts()`** — reusing the existing path-update coalescing window — so the full record is pulled from the device and Name/type/Position populate immediately, no manual reconnect needed.

Guards keep it cheap:
- Only **new** nodes trigger it (`!wasKnown` / `isNew`).
- Adverts that already carry name + type don't trigger a refresh.
- Multiple new-node pushes coalesce into a single `get_contacts` over the debounce window.

**Scope note:** `refreshContacts()` is companion-only (no-op for repeater / serial-CLI sources), matching the reported companion scenario.

## Testing
- [x] New `meshcoreManager.newNodeRefresh.test.ts` — 3 tests: pubkey-only advert → full record fetched; complete advert → no refresh; known node → no refetch.
- [x] Existing `meshcoreManager.pathUpdate.test.ts` still green (shared coalescing path unbroken).
- [x] `tsc -p tsconfig.server.json` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)