### PR TITLE
feat(channels): warn when a device channel is overshadowed by a server-decryption entry (refs #3644)

### DIFF
--- a/src/components/configuration/ChannelsConfigSection.tsx
+++ b/src/components/configuration/ChannelsConfigSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useMemo, useCallback } from 'react';
+import React, { useState, useRef, useMemo, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DndContext,
@@ -29,6 +29,15 @@ import { formatPrecisionAccuracy } from '../../utils/distance';
 
 // Default public PSK (base64 encoded value of single byte 0x01)
 const DEFAULT_PUBLIC_PSK = 'AQ==';
+
+/** A device channel sharing its key with a differently-named Channel Database
+ *  (server-decryption) entry (#3644). */
+interface ChannelCollision {
+  channelId: number;
+  channelName: string;
+  dbId: number;
+  dbName: string;
+}
 
 type EncryptionStatus = 'none' | 'default' | 'secure';
 
@@ -137,6 +146,30 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
   const { showToast } = useToast();
   const { distanceUnit } = useSettings();
   const { sourceId } = useSource();
+
+  // #3644: device channels whose PSK matches a server-side decryption (Channel
+  // Database) entry under a DIFFERENT name. Messages on such a channel get filed
+  // under that entry's tab instead of this channel. Detected server-side because
+  // readers don't receive raw PSKs.
+  const [channelCollisions, setChannelCollisions] = useState<ChannelCollision[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    const qs = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
+    apiService.get<{ collisions: ChannelCollision[] }>(`/api/channels/collisions${qs}`)
+      .then(res => { if (!cancelled) setChannelCollisions(res.collisions ?? []); })
+      .catch(() => { if (!cancelled) setChannelCollisions([]); });
+    return () => { cancelled = true; };
+  }, [sourceId, channels]);
+  const collisionDbNamesByChannelId = useMemo(() => {
+    const m = new Map<number, string[]>();
+    for (const c of channelCollisions) {
+      const list = m.get(c.channelId) ?? [];
+      list.push(c.dbName);
+      m.set(c.channelId, list);
+    }
+    return m;
+  }, [channelCollisions]);
+
   const [editingChannel, setEditingChannel] = useState<ChannelEditState | null>(null);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showImportModal, setShowImportModal] = useState(false);
@@ -537,6 +570,17 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                             ? `📍 ${t('channels_config.location_auto_broadcast')}`
                             : `📌 ${t('channels_config.location_enabled')}`}
                           {` (${formatPrecisionAccuracy(channel.positionPrecision ?? 0, distanceUnit)})`}
+                        </div>
+                      )}
+                      {collisionDbNamesByChannelId.has(channel.id) && (
+                        <div
+                          style={{ marginTop: '0.5rem', color: 'var(--ctp-yellow)', fontSize: '0.85rem' }}
+                          title={t('channels_config.collision_tooltip', 'This channel shares its encryption key with a Channel Database (server-side decryption) entry under a different name, so its messages are filed under that entry instead.')}
+                        >
+                          ⚠️ {t('channels_config.collision_warning', {
+                            defaultValue: 'Key shared with Channel Database entry "{{names}}" — messages may appear under that name instead of here.',
+                            names: collisionDbNamesByChannelId.get(channel.id)!.join('", "'),
+                          })}
                         </div>
                       )}
                     </div>

--- a/src/pages/UnifiedMessagesPage.tsx
+++ b/src/pages/UnifiedMessagesPage.tsx
@@ -73,6 +73,15 @@ interface UnifiedChannel {
   sources: Array<{ sourceId: string; sourceName: string; channelNumber: number }>;
 }
 
+/** A device channel sharing its key with a differently-named Channel Database
+ *  (server-decryption) entry (#3644). */
+interface ChannelCollisionRow {
+  channelId: number;
+  channelName: string;
+  dbId: number;
+  dbName: string;
+}
+
 // ── Constants ────────────────────────────────────────────────────────────
 
 const PAGE_SIZE = 100;
@@ -186,6 +195,53 @@ export default function UnifiedMessagesPage() {
       setSelectedChannel(preferred?.name ?? channels[0].name);
     }
   }, [channels, selectedChannel]);
+
+  // ── Channel collisions (#3644) ────────────────────────────────────────
+  // A device channel can share its key with a differently-named server-side
+  // decryption (Channel Database) entry; matching messages then appear under
+  // that entry's tab rather than the device channel. Detect it per source
+  // (channel_database is global) so we can warn when the viewed channel may be
+  // overshadowed.
+  const collisionSourceIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const c of channels) for (const src of c.sources) ids.add(src.sourceId);
+    return Array.from(ids).sort();
+  }, [channels]);
+
+  const { data: channelCollisions = [] } = useQuery<ChannelCollisionRow[]>({
+    queryKey: ['unified', 'channel-collisions', collisionSourceIds],
+    enabled: canReadAnyMessages && collisionSourceIds.length > 0,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const perSource = await Promise.all(
+        collisionSourceIds.map(async (sid) => {
+          const res = await fetch(
+            `${appBasename}/api/channels/collisions?sourceId=${encodeURIComponent(sid)}`,
+            { credentials: 'include' },
+          );
+          if (!res.ok) return [] as ChannelCollisionRow[];
+          const json = await res.json();
+          return (json.collisions ?? []) as ChannelCollisionRow[];
+        }),
+      );
+      return perSource.flat();
+    },
+  });
+
+  // Names of channels colliding with the viewed channel — the "other side" of
+  // each collision (the entry messages may be landing under, or vice versa).
+  const overshadowNames = useMemo(() => {
+    if (!selectedChannel) return [] as string[];
+    const sel = selectedChannel.trim().toLowerCase();
+    const names = new Set<string>();
+    for (const c of channelCollisions) {
+      const ch = c.channelName.trim().toLowerCase();
+      const db = c.dbName.trim().toLowerCase();
+      if (ch === sel && c.dbName.trim()) names.add(c.dbName);
+      else if (db === sel && c.channelName.trim()) names.add(c.channelName);
+    }
+    return Array.from(names);
+  }, [channelCollisions, selectedChannel]);
 
   // ── Messages infinite query ───────────────────────────────────────────
   const {
@@ -452,6 +508,14 @@ export default function UnifiedMessagesPage() {
       <div className="unified-scroll" ref={scrollRef} onScroll={handleScroll}>
       <div className="unified-body">
         {!canReadAnyMessages && <div className="unified-empty">{t('unified.messages.sign_in_required')}</div>}
+        {canReadAnyMessages && overshadowNames.length > 0 && (
+          <div className="unified-warning" role="status">
+            ⚠️ {t('unified.messages.channel_collision_warning', {
+              defaultValue: 'This channel shares its key with "{{names}}" (a Channel Database / device channel under a different name). Messages may be split between those tabs — reconcile the names on the Channels page.',
+              names: overshadowNames.join('", "'),
+            })}
+          </div>
+        )}
         {canReadAnyMessages && channelsError && <div className="unified-error">{t('unified.messages.failed_channels')}</div>}
         {canReadAnyMessages && messagesError && <div className="unified-error">{t('unified.messages.failed_messages')}</div>}
         {canReadAnyMessages && loadingMessages && feedMessages.length === 0 && (

--- a/src/server/routes/channelRoutes.test.ts
+++ b/src/server/routes/channelRoutes.test.ts
@@ -63,6 +63,9 @@ const mockDb = vi.hoisted(() => ({
     deleteChannel: vi.fn().mockResolvedValue(undefined),
     getChannelCount: vi.fn().mockResolvedValue(0),
   },
+  channelDatabase: {
+    getAllAsync: vi.fn().mockResolvedValue([]),
+  },
   messages: {
     purgeChannelMessages: vi.fn().mockResolvedValue(0),
     migrateMessagesForChannelMoves: vi.fn().mockResolvedValue(undefined),
@@ -108,6 +111,7 @@ beforeEach(() => {
   // mockResolvedValue/mockRejectedValue, so re-assert the defaults each test.
   mockDb.channels.getAllChannels.mockResolvedValue([]);
   mockDb.channels.getChannelCount.mockResolvedValue(0);
+  mockDb.channelDatabase.getAllAsync.mockResolvedValue([]);
   mockDb.messages.purgeChannelMessages.mockResolvedValue(0);
   mockDb.sources.getSource.mockResolvedValue({ type: 'meshtastic_tcp' });
   mockMeshcoreRegistry.get.mockReturnValue(mockMeshcoreManager);
@@ -139,6 +143,41 @@ describe('GET /channels and /channels/all', () => {
     const res = await request(app).get('/channels');
     expect(res.status).toBe(500);
     expect(res.body.error).toBe('Failed to fetch channels');
+  });
+});
+
+describe('GET /channels/collisions (#3644)', () => {
+  it('flags a device channel sharing a key with a differently-named Channel Database entry', async () => {
+    mockDb.channels.getAllChannels.mockResolvedValue([
+      { id: 0, name: 'Custom', role: 1, psk: 'AQ==' },
+    ]);
+    mockDb.channelDatabase.getAllAsync.mockResolvedValue([
+      { id: 5, name: 'LongFast', psk: 'AQ==' },
+    ]);
+    const res = await request(app).get('/channels/collisions');
+    expect(res.status).toBe(200);
+    expect(res.body.collisions).toEqual([
+      { channelId: 0, channelName: 'Custom', dbId: 5, dbName: 'LongFast' },
+    ]);
+  });
+
+  it('returns no collisions for a same-name mirror', async () => {
+    mockDb.channels.getAllChannels.mockResolvedValue([
+      { id: 0, name: 'LongFast', role: 1, psk: 'AQ==' },
+    ]);
+    mockDb.channelDatabase.getAllAsync.mockResolvedValue([
+      { id: 5, name: 'LongFast', psk: 'AQ==' },
+    ]);
+    const res = await request(app).get('/channels/collisions');
+    expect(res.status).toBe(200);
+    expect(res.body.collisions).toEqual([]);
+  });
+
+  it('returns 500 when the DB query throws', async () => {
+    mockDb.channels.getAllChannels.mockRejectedValue(new Error('boom'));
+    const res = await request(app).get('/channels/collisions');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to detect channel collisions');
   });
 });
 

--- a/src/server/routes/channelRoutes.ts
+++ b/src/server/routes/channelRoutes.ts
@@ -176,10 +176,27 @@ router.get('/', optionalAuth(), async (req: Request, res: Response) => {
 router.get('/collisions', optionalAuth(), async (req: Request, res: Response) => {
   try {
     const sourceId = req.query.sourceId as string | undefined;
-    const channels = await databaseService.channels.getAllChannels(sourceId);
+    const allChannels = await databaseService.channels.getAllChannels(sourceId);
+    const isAdmin = req.user?.isAdmin === true;
+
+    // Per-row permission gate (MM-SEC-2), mirroring GET /. Only consider
+    // channels the caller may read so collision detection can't leak the names
+    // of restricted channels to unauthorized callers.
+    const accessible: typeof allChannels = [];
+    for (const channel of allChannels) {
+      if (isAdmin) {
+        accessible.push(channel);
+        continue;
+      }
+      const channelResource = `channel_${channel.id}` as import('../../types/permission.js').ResourceType;
+      if (req.user && await hasPermission(req.user, channelResource, 'read')) {
+        accessible.push(channel);
+      }
+    }
+
     const dbEntries = await databaseService.channelDatabase.getAllAsync();
     const collisions = detectChannelCollisions(
-      channels.map(c => ({ id: c.id, name: c.name, psk: c.psk })),
+      accessible.map(c => ({ id: c.id, name: c.name, psk: c.psk })),
       dbEntries
         .filter((d): d is typeof d & { id: number } => typeof d.id === 'number')
         .map(d => ({ id: d.id, name: d.name, psk: d.psk })),

--- a/src/server/routes/channelRoutes.ts
+++ b/src/server/routes/channelRoutes.ts
@@ -27,6 +27,7 @@ import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { optionalAuth, requireAuth, requirePermission, hasPermission } from '../auth/authMiddleware.js';
 import { transformChannel } from '../utils/channelView.js';
+import { detectChannelCollisions } from '../utils/channelCollision.js';
 import { resolveSourceManager } from '../utils/resolveSourceManager.js';
 import { migrateAutomationChannels } from '../utils/automationChannelMigration.js';
 import { modemPresetChannelName } from '../constants/meshtastic.js';
@@ -163,6 +164,30 @@ router.get('/', optionalAuth(), async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Error fetching channels:', error);
     res.status(500).json({ error: 'Failed to fetch channels' });
+  }
+});
+
+// GET /collisions — device channels whose PSK matches a channel_database
+// (server-decryption) entry under a DIFFERENT name (#3644). Such a channel's
+// messages get filed under the other name's tab, leaving the device channel's
+// own tab empty. PSKs are compared server-side (readers don't receive raw PSKs)
+// and only names/ids are returned. Registered before `/:id` so it isn't
+// swallowed by the id param route.
+router.get('/collisions', optionalAuth(), async (req: Request, res: Response) => {
+  try {
+    const sourceId = req.query.sourceId as string | undefined;
+    const channels = await databaseService.channels.getAllChannels(sourceId);
+    const dbEntries = await databaseService.channelDatabase.getAllAsync();
+    const collisions = detectChannelCollisions(
+      channels.map(c => ({ id: c.id, name: c.name, psk: c.psk })),
+      dbEntries
+        .filter((d): d is typeof d & { id: number } => typeof d.id === 'number')
+        .map(d => ({ id: d.id, name: d.name, psk: d.psk })),
+    );
+    res.json({ collisions });
+  } catch (error) {
+    logger.error('Error detecting channel collisions:', error);
+    res.status(500).json({ error: 'Failed to detect channel collisions' });
   }
 });
 

--- a/src/server/utils/channelCollision.test.ts
+++ b/src/server/utils/channelCollision.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { detectChannelCollisions, normalizePsk } from './channelCollision.js';
+
+describe('normalizePsk', () => {
+  it('maps empty / null PSKs to null', () => {
+    expect(normalizePsk(null)).toBeNull();
+    expect(normalizePsk(undefined)).toBeNull();
+    expect(normalizePsk('')).toBeNull();
+    expect(normalizePsk('   ')).toBeNull();
+  });
+  it('trims but otherwise preserves a base64 PSK', () => {
+    expect(normalizePsk(' AQ== ')).toBe('AQ==');
+    expect(normalizePsk('1PG7OiApB1nwvP+rz05pAQ==')).toBe('1PG7OiApB1nwvP+rz05pAQ==');
+  });
+});
+
+describe('detectChannelCollisions (#3644)', () => {
+  it('flags a device channel sharing the default key with a differently-named DB entry', () => {
+    // The reported case: device channel 0 named "Custom" on the default PSK,
+    // and an auto-seeded "LongFast" channel_database entry on the same key.
+    const channels = [{ id: 0, name: 'Custom', psk: 'AQ==' }];
+    const db = [{ id: 5, name: 'LongFast', psk: 'AQ==' }];
+    const collisions = detectChannelCollisions(channels, db);
+    expect(collisions).toEqual([
+      { channelId: 0, channelName: 'Custom', dbId: 5, dbName: 'LongFast' },
+    ]);
+  });
+
+  it('does NOT flag a same-name same-key mirror', () => {
+    const channels = [{ id: 0, name: 'LongFast', psk: 'AQ==' }];
+    const db = [{ id: 5, name: 'LongFast', psk: 'AQ==' }];
+    expect(detectChannelCollisions(channels, db)).toEqual([]);
+  });
+
+  it('does NOT flag when keys differ', () => {
+    const channels = [{ id: 1, name: 'Secret', psk: 'aaaa' }];
+    const db = [{ id: 9, name: 'Other', psk: 'bbbb' }];
+    expect(detectChannelCollisions(channels, db)).toEqual([]);
+  });
+
+  it('ignores unencrypted (empty PSK) channels', () => {
+    const channels = [{ id: 0, name: 'Open', psk: '' }];
+    const db = [{ id: 1, name: 'Open2', psk: '' }];
+    expect(detectChannelCollisions(channels, db)).toEqual([]);
+  });
+
+  it('matches a custom key regardless of surrounding whitespace', () => {
+    const channels = [{ id: 2, name: 'Team', psk: 'Zm9vYmFy' }];
+    const db = [{ id: 3, name: 'TeamMirror', psk: ' Zm9vYmFy ' }];
+    const collisions = detectChannelCollisions(channels, db);
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0]).toMatchObject({ channelId: 2, dbId: 3, dbName: 'TeamMirror' });
+  });
+
+  it('reports each colliding pair when multiple DB entries share a key', () => {
+    const channels = [{ id: 0, name: 'Custom', psk: 'AQ==' }];
+    const db = [
+      { id: 5, name: 'LongFast', psk: 'AQ==' },
+      { id: 6, name: 'Public', psk: 'AQ==' },
+    ];
+    expect(detectChannelCollisions(channels, db)).toHaveLength(2);
+  });
+});

--- a/src/server/utils/channelCollision.ts
+++ b/src/server/utils/channelCollision.ts
@@ -1,0 +1,77 @@
+/**
+ * Channel collision detection (#3644).
+ *
+ * A "collision" is when a server-side decryption entry (`channel_database`)
+ * shares a PSK with a configured device channel but carries a DIFFERENT display
+ * name. When that happens, MeshMonitor server-decrypts matching packets and
+ * files them under the channel_database entry's synthetic tab
+ * (`CHANNEL_DB_OFFSET + id`) instead of the device channel — so the device
+ * channel's own tab looks empty while its messages appear under the other name.
+ *
+ * Surfacing the collision lets the operator reconcile the names (rename one, or
+ * remove the redundant server-decryption entry).
+ *
+ * Same-name + same-PSK is intentionally NOT a collision: that's the normal case
+ * where a channel_database entry simply mirrors the device channel under the
+ * same label. An unencrypted (empty PSK) channel never collides.
+ *
+ * PSKs are compared server-side because the channels API only exposes raw PSKs
+ * to authorized writers — readers (e.g. the Unified Messaging view) can't do the
+ * comparison client-side.
+ */
+
+/**
+ * Normalize a base64 PSK for comparison. Trims surrounding whitespace and maps
+ * the empty / no-encryption case to `null` (which never matches). Device slots
+ * and channel_database rows both persist the 1-byte default-public shorthand
+ * (`AQ==`) identically, so no key expansion is required here.
+ */
+export function normalizePsk(psk: string | null | undefined): string | null {
+  if (psk == null) return null;
+  const trimmed = psk.trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+export interface CollisionChannel {
+  id: number;
+  name: string;
+  psk?: string | null;
+}
+
+export interface CollisionDbEntry {
+  id: number;
+  name: string;
+  psk: string;
+}
+
+export interface ChannelCollision {
+  /** Device channel slot id (0–7). */
+  channelId: number;
+  /** Device channel display name. */
+  channelName: string;
+  /** Colliding channel_database entry id. */
+  dbId: number;
+  /** Colliding channel_database entry name (the tab messages actually land under). */
+  dbName: string;
+}
+
+/**
+ * Find device channels whose PSK matches a channel_database entry under a
+ * different name. Returns one entry per colliding (channel, db-entry) pair.
+ */
+export function detectChannelCollisions(
+  channels: CollisionChannel[],
+  dbEntries: CollisionDbEntry[],
+): ChannelCollision[] {
+  const out: ChannelCollision[] = [];
+  for (const ch of channels) {
+    const chPsk = normalizePsk(ch.psk);
+    if (chPsk == null) continue; // unencrypted — never collides
+    for (const db of dbEntries) {
+      if (normalizePsk(db.psk) !== chPsk) continue; // different key
+      if (db.name.trim() === ch.name.trim()) continue; // same label — benign mirror
+      out.push({ channelId: ch.id, channelName: ch.name, dbId: db.id, dbName: db.name });
+    }
+  }
+  return out;
+}

--- a/src/styles/unified.css
+++ b/src/styles/unified.css
@@ -204,6 +204,18 @@ button.unified-source-pill.is-active {
   color: var(--ctp-red);
 }
 
+/* Channel overshadow / key-collision notice (#3644) */
+.unified-warning {
+  margin: 8px 12px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: var(--ctp-surface0);
+  border: 1px solid var(--ctp-yellow);
+  color: var(--ctp-yellow);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
 /* ── Date divider (messages) ─────────────────────────────────────────────── */
 
 .unified-date-divider {


### PR DESCRIPTION
## Summary

Refs #3644 (the underlying preset bug is fixed separately). This adds a **detection/notification aid** for a related way the "messages under the wrong channel" symptom can occur: when a server-side decryption (**Channel Database**) entry shares a PSK with a device channel but under a **different name**.

In that case MeshMonitor server-decrypts matching packets and files them under the Channel Database entry's synthetic tab (`CHANNEL_DB_OFFSET + id`) instead of the device channel — so the device channel's own tab looks empty while its messages appear under the other name. This PR surfaces the collision so the operator can reconcile the names; it does **not** change message routing.

## Changes
- **Pure server helper** `detectChannelCollisions` (`src/server/utils/channelCollision.ts`) — flags same-PSK / different-name pairs; ignores unencrypted channels and benign same-name mirrors. Unit-tested.
- **`GET /api/channels/collisions?sourceId=`** — PSKs are compared server-side (readers don't receive raw PSKs); only names/ids are returned.
- **Device Channels page** (`ChannelsConfigSection`) — per-channel ⚠ notice naming the colliding Channel Database entry.
- **Unified Messaging page** — a banner when the viewed channel may be overshadowed, aggregated across the sources in view.

## Testing
- [x] `channelCollision.test.ts` (8 cases incl. the default-key Custom↔LongFast scenario) + existing `channelRoutes.test.ts` green (39 total).
- [x] `tsc` clean (server + edited frontend files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)