### PR TITLE
fix(channels): don't label a custom-LoRa-config primary channel as "LongFast" (#3644)

### DIFF
--- a/src/server/meshtasticManager.modemPreset.test.ts
+++ b/src/server/meshtasticManager.modemPreset.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression test for #3644: the per-source modem preset (used as the slot-0
+ * channel display-name fallback) must only be persisted when the node actually
+ * runs on a preset (usePreset=true). With a custom LoRa config (usePreset=false)
+ * the modemPreset field sits at its proto3 default of 0 (=LONG_FAST), so
+ * persisting it would mislabel a blank-named primary channel as "LongFast".
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const setSetting = vi.fn().mockResolvedValue(undefined);
+const deleteSetting = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: (...a: unknown[]) => setSetting(...a),
+      deleteSetting: (...a: unknown[]) => deleteSetting(...a),
+      getSettingForSource: vi.fn().mockResolvedValue(null),
+      setSourceSetting: vi.fn().mockResolvedValue(undefined),
+      getAllSettings: vi.fn().mockResolvedValue({}),
+    },
+    channels: {
+      getChannelById: vi.fn().mockResolvedValue(null),
+      getAllChannels: vi.fn().mockResolvedValue([]),
+      upsertChannel: vi.fn().mockResolvedValue(undefined),
+      getChannelCount: vi.fn().mockResolvedValue(0),
+    },
+  },
+}));
+
+vi.mock('./meshtasticProtobufService.js', () => ({ default: { initialize: vi.fn(), createMeshPacket: vi.fn() } }));
+vi.mock('./protobufService.js', () => ({ default: { encode: vi.fn(), decode: vi.fn() }, convertIpv4ConfigToStrings: vi.fn() }));
+vi.mock('./protobufLoader.js', () => ({ getProtobufRoot: vi.fn() }));
+vi.mock('./tcpTransport.js', () => ({ TcpTransport: vi.fn() }));
+vi.mock('../utils/logger.js', () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
+vi.mock('./services/notificationService.js', () => ({ notificationService: { checkAndSendNotifications: vi.fn() } }));
+vi.mock('./services/serverEventNotificationService.js', () => ({ serverEventNotificationService: { notifyNodeConnected: vi.fn(), notifyNodeDisconnected: vi.fn() } }));
+vi.mock('./services/packetLogService.js', () => ({ default: { logPacket: vi.fn() } }));
+vi.mock('./services/channelDecryptionService.js', () => ({ channelDecryptionService: { tryDecrypt: vi.fn() } }));
+vi.mock('./services/dataEventEmitter.js', () => ({ dataEventEmitter: { emit: vi.fn(), on: vi.fn() } }));
+vi.mock('./messageQueueService.js', () => {
+  const mockInstance = { enqueue: vi.fn(), setSendCallback: vi.fn(), handleAck: vi.fn(), handleFailure: vi.fn(), recordExternalSend: vi.fn(), clear: vi.fn(), getStatus: vi.fn(() => ({ queueLength: 0, pendingAcks: 0, processing: false })) };
+  function MessageQueueService() { return mockInstance as any; }
+  return { messageQueueService: mockInstance, MessageQueueService };
+});
+vi.mock('./utils/cronScheduler.js', () => ({ validateCron: vi.fn(() => true), scheduleCron: vi.fn(() => ({ stop: vi.fn() })) }));
+vi.mock('./config/environment.js', () => ({ getEnvironmentConfig: vi.fn(() => ({ NODE_IP: '127.0.0.1', TCP_PORT: 4403, LOG_LEVEL: 'info' })) }));
+vi.mock('../utils/autoResponderUtils.js', () => ({ normalizeTriggerPatterns: vi.fn() }));
+vi.mock('../utils/nodeHelpers.js', () => ({ isNodeComplete: vi.fn() }));
+
+const SOURCE = 'default';
+
+describe('MeshtasticManager - persistModemPreset (#3644)', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module = await import('./meshtasticManager.js');
+    manager = module.default;
+    manager.sourceId = SOURCE;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists the preset when the node runs on a preset (usePreset=true)', async () => {
+    await manager.persistModemPreset({ usePreset: true, modemPreset: 3 });
+    expect(setSetting).toHaveBeenCalledWith(`lora.preset.${SOURCE}`, '3');
+    expect(deleteSetting).not.toHaveBeenCalled();
+  });
+
+  it('CLEARS the preset for a custom config (usePreset=false), even with modemPreset=0', async () => {
+    // The reported case: custom LoRa config, modemPreset defaulted to 0.
+    await manager.persistModemPreset({ usePreset: false, modemPreset: 0 });
+    expect(deleteSetting).toHaveBeenCalledWith(`lora.preset.${SOURCE}`);
+    expect(setSetting).not.toHaveBeenCalled();
+  });
+
+  it('clears the preset when usePreset is absent (treated as non-preset)', async () => {
+    await manager.persistModemPreset({ modemPreset: 5 });
+    expect(deleteSetting).toHaveBeenCalledWith(`lora.preset.${SOURCE}`);
+    expect(setSetting).not.toHaveBeenCalled();
+  });
+
+  it('persists the LONG_FAST preset (0) when usePreset is genuinely true', async () => {
+    await manager.persistModemPreset({ usePreset: true, modemPreset: 0 });
+    expect(setSetting).toHaveBeenCalledWith(`lora.preset.${SOURCE}`, '0');
+    expect(deleteSetting).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when there is no sourceId', async () => {
+    manager.sourceId = null;
+    await manager.persistModemPreset({ usePreset: true, modemPreset: 2 });
+    expect(setSetting).not.toHaveBeenCalled();
+    expect(deleteSetting).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1742,6 +1742,35 @@ class MeshtasticManager implements ISourceManager {
     }
   }
 
+  /**
+   * Persist (or clear) the per-source modem preset used as the slot-0
+   * display-name fallback (`lora.preset.<sourceId>` → `computeChannelDisplayName`
+   * / `unifiedChannelDisplayName`).
+   *
+   * Only persist when the node is ACTUALLY running on a preset
+   * (`usePreset === true`). With a custom LoRa config (`usePreset === false`) the
+   * `modemPreset` field is meaningless and sits at its proto3 default of 0
+   * (= LONG_FAST), so persisting it would mislabel a blank-named primary channel
+   * as "LongFast" even though the node isn't using that preset (#3644). In that
+   * case delete any stale preset so slot 0 falls back to "Primary".
+   *
+   * `usePreset` is normalized to a real boolean by the proto3-defaults pass
+   * before this runs (proto3 elides `false`).
+   */
+  private async persistModemPreset(lora: { usePreset?: boolean; modemPreset?: number } | undefined): Promise<void> {
+    if (!this.sourceId || !lora) return;
+    const presetKey = `lora.preset.${this.sourceId}`;
+    try {
+      if (lora.usePreset === true && typeof lora.modemPreset === 'number') {
+        await databaseService.settings.setSetting(presetKey, String(lora.modemPreset));
+      } else {
+        await databaseService.settings.deleteSetting(presetKey);
+      }
+    } catch (err) {
+      logger.debug(`Failed to persist ${presetKey}:`, err);
+    }
+  }
+
   private async ensureBasicSetup(): Promise<void> {
     logger.debug('🔧 Ensuring basic setup is complete...');
 
@@ -4025,21 +4054,10 @@ class MeshtasticManager implements ISourceManager {
               logger.info('📊 Set femLnaMode to 0 (DISABLED - was undefined, Proto3 default)');
             }
 
-            // Persist the modem preset per-source so the unified channels
-            // endpoint can use it as the display-name fallback for slot 0
-            // (which the firmware leaves blank when running on a preset).
-            // See `unifiedChannelDisplayName` in unifiedRoutes.ts.
-            if (this.sourceId && typeof parsed.data.lora.modemPreset === 'number') {
-              const presetKey = `lora.preset.${this.sourceId}`;
-              try {
-                await databaseService.settings.setSetting(
-                  presetKey,
-                  String(parsed.data.lora.modemPreset),
-                );
-              } catch (err) {
-                logger.debug(`Failed to persist ${presetKey}:`, err);
-              }
-            }
+            // Persist the per-source modem preset used as the slot-0
+            // display-name fallback — only when the node actually runs on a
+            // preset. See persistModemPreset (#3644).
+            await this.persistModemPreset(parsed.data.lora);
           }
 
           // Apply Proto3 defaults to device config


### PR DESCRIPTION
## Summary

Closes #3644.

A node running a **custom LoRa config** (`usePreset = false`) has a meaningless `modemPreset` that sits at its proto3 default of `0` (= LONG_FAST). MeshMonitor persisted `lora.preset.<source>` from that value **unconditionally**, so the blank-named primary channel was displayed as **"LongFast"** even though the node isn't using the LongFast preset — exactly the reported symptom ("messages always shown under #LongFast regardless of the actual channel").

## Root cause (confirmed in `meshtasticManager.ts`)
1. `modemPreset` absent on the wire → forced to `0` (LONG_FAST).
2. `lora.preset.<source>` persisted from it with **no `usePreset` check**.
3. `computeChannelDisplayName` labels the empty-named slot 0 as `modemPresetChannelName(0)` = "LongFast".

## Fix
Extract the persistence into `persistModemPreset` and gate it on `usePreset`:
- **`usePreset = true`** → persist the modem preset (slot-0 display falls back to the firmware preset name, unchanged).
- **`usePreset = false` / absent** → **delete** any stored preset so slot 0 falls back to **"Primary"** instead of a preset the node isn't running.

Deleting (rather than storing `""`) is required because the readers do `Number(raw)`, and `Number("") === 0` would resolve right back to LONG_FAST. `usePreset` is already normalized to a real boolean by the proto3-defaults pass before this runs.

## Testing
- [x] New `meshtasticManager.modemPreset.test.ts` — persist-on-preset, clear-on-custom (incl. `modemPreset=0`), absent `usePreset`, genuine LONG_FAST, no-sourceId no-op.
- [x] Existing `channelProto3Elision` regression still green.
- [x] `tsc -p tsconfig.server.json` clean.

## Related
A separate enhancement (#3651) adds a warning when a device channel is *overshadowed by a server-decryption entry* — a different mechanism that can produce a similar "wrong channel name" symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)