### PR TITLE
feat(meshcore): show role icon left of node name on map + DM lists (#3647)

### DIFF
--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -250,7 +250,7 @@ describe('MeshCoreDirectMessagesView — per-node telemetry-config panel', () =>
     fireEvent.click(screen.getByTitle('Descending'));
 
     const names = Array.from(document.querySelectorAll('.mc-node-row .mc-node-row-name'))
-      .map((el) => el.querySelector('span')?.textContent || '');
+      .map((el) => el.querySelector('.mc-node-row-display-name')?.textContent || '');
     expect(names).toEqual(['alpha', 'Bravo', 'Charlie']);
   });
 
@@ -283,7 +283,7 @@ describe('MeshCoreDirectMessagesView — per-node telemetry-config panel', () =>
     );
 
     const names = Array.from(document.querySelectorAll('.mc-node-row .mc-node-row-name'))
-      .map((el) => el.querySelector('span:not(.mc-dm-row-favorite)')?.textContent || '');
+      .map((el) => el.querySelector('.mc-node-row-display-name')?.textContent || '');
     // Bravo (favorite) pinned first despite oldest lastSeen; ★ indicator shown.
     expect(names[0]).toBe('Bravo');
     expect(document.querySelector('.mc-node-row .mc-dm-row-favorite')?.textContent).toBe('★');
@@ -321,7 +321,7 @@ describe('MeshCoreDirectMessagesView — per-node telemetry-config panel', () =>
     fireEvent.click(screen.getByTitle('Descending'));
 
     const names = Array.from(document.querySelectorAll('.mc-node-row .mc-node-row-name'))
-      .map((el) => el.querySelector('span:not(.mc-dm-row-favorite)')?.textContent || '');
+      .map((el) => el.querySelector('.mc-node-row-display-name')?.textContent || '');
     // Zeta pinned first despite name/asc; non-favorites follow in name order.
     expect(names).toEqual(['Zeta', 'alpha', 'Charlie']);
   });

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -4,6 +4,7 @@ import {
   MeshCoreMessage, MeshCoreActions, ConnectionStatus, MeshCoreNode,
 } from './hooks/useMeshCore';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
+import { meshcoreRoleIcon, meshcoreRoleLabelKey, meshcoreRoleLabel } from './meshcoreRole';
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
 import { MeshCoreContactDetailPanel } from './MeshCoreContactDetailPanel';
 import { MeshCoreNodeTelemetryConfig } from './MeshCoreNodeTelemetryConfig';
@@ -322,6 +323,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
               const c = contactsByKey.get(key);
               const name = c?.advName || c?.name || `${key.substring(0, 8)}…`;
               const isFavorite = favoriteByKey.get(key) ?? false;
+              const roleIcon = meshcoreRoleIcon(c?.advType);
               return (
                 <button
                   key={key}
@@ -329,10 +331,20 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                   onClick={() => handleSelectContact(key)}
                 >
                   <div className="mc-node-row-name">
+                    {roleIcon && (
+                      <span
+                        className="mc-node-role-icon"
+                        role="img"
+                        aria-label={t(meshcoreRoleLabelKey(c?.advType), meshcoreRoleLabel(c?.advType))}
+                        title={t(meshcoreRoleLabelKey(c?.advType), meshcoreRoleLabel(c?.advType))}
+                      >
+                        {roleIcon}
+                      </span>
+                    )}
                     {isFavorite && (
                       <span className="mc-dm-row-favorite" aria-label={t('meshcore.favorite.is_favorite', 'Favorite')} title={t('meshcore.favorite.is_favorite', 'Favorite')}>★</span>
                     )}
-                    <span>{name}</span>
+                    <span className="mc-node-row-display-name">{name}</span>
                   </div>
                   <div className="mc-node-row-key">{key.substring(0, 20)}…</div>
                 </button>

--- a/src/components/MeshCore/MeshCoreNodesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.test.tsx
@@ -42,10 +42,10 @@ const nodes: MeshCoreNode[] = [
 const contacts: MeshCoreContact[] = [];
 
 function listedNames(): string[] {
-  // The first span inside `.mc-node-row-name` is the display name; the
-  // second (when present) is the device-type label.
+  // The display name carries the stable `.mc-node-row-display-name` class; a
+  // role icon (#3647) and other indicators may precede it in the row.
   const rows = Array.from(document.querySelectorAll('.mc-node-row .mc-node-row-name'));
-  return rows.map((el) => el.querySelector('span')?.textContent || '');
+  return rows.map((el) => el.querySelector('.mc-node-row-display-name')?.textContent || '');
 }
 
 describe('MeshCoreNodesView — sort controls', () => {
@@ -70,6 +70,25 @@ describe('MeshCoreNodesView — sort controls', () => {
     fireEvent.change(dropdown, { target: { value: 'name' } });
     // After selecting name, direction is still 'desc' from default — Z..A.
     expect(listedNames()).toEqual(['Charlie', 'Bravo', 'alpha']);
+  });
+});
+
+describe('MeshCoreNodesView — role icon (#3647)', () => {
+  it('renders a role icon to the LEFT of the name and no text role label', () => {
+    render(<MeshCoreNodesView nodes={nodes} contacts={contacts} />);
+    // Companion (advType=1) → 📱, one per row.
+    const icons = document.querySelectorAll('.mc-node-row-name .mc-node-role-icon');
+    expect(icons).toHaveLength(3);
+    expect(icons[0].textContent).toBe('📱');
+    // The old text role label (.mc-node-row-type) is gone.
+    expect(document.querySelector('.mc-node-row-type')).toBeNull();
+    // The icon precedes the display name within the row.
+    const rowName = document.querySelector('.mc-node-row-name')!;
+    const spans = Array.from(rowName.querySelectorAll('span'));
+    const iconIdx = spans.findIndex((s) => s.classList.contains('mc-node-role-icon'));
+    const nameIdx = spans.findIndex((s) => s.classList.contains('mc-node-row-display-name'));
+    expect(iconIdx).toBeGreaterThanOrEqual(0);
+    expect(iconIdx).toBeLessThan(nameIdx);
   });
 });
 

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -326,7 +326,9 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
                 ? t('meshcore.no_search_results', 'No nodes match your search')
                 : t('meshcore.no_nodes', 'No nodes seen yet')}
             </div>
-          ) : rows.map(row => (
+          ) : rows.map(row => {
+            const roleIcon = meshcoreRoleIcon(row.advType);
+            return (
             // Wrapper div (not a button) so the details quick-access can be a
             // real sibling <button> — nested buttons are invalid HTML.
             <div
@@ -340,14 +342,14 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
                 onDoubleClick={onNavigateToDm ? () => onNavigateToDm(row.publicKey) : undefined}
               >
                 <div className="mc-node-row-name">
-                  {meshcoreRoleIcon(row.advType) && (
+                  {roleIcon && (
                     <span
                       className="mc-node-role-icon"
                       role="img"
                       aria-label={t(meshcoreRoleLabelKey(row.advType), meshcoreRoleLabel(row.advType))}
                       title={t(meshcoreRoleLabelKey(row.advType), meshcoreRoleLabel(row.advType))}
                     >
-                      {meshcoreRoleIcon(row.advType)}
+                      {roleIcon}
                     </span>
                   )}
                   <span className="mc-node-row-display-name">{row.name}</span>
@@ -393,7 +395,8 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
                 </button>
               )}
             </div>
-          ))}
+            );
+          })}
         </div>
       </div>
       <div className="meshcore-main-pane">

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { MeshCoreNode } from './hooks/useMeshCore';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMap } from './MeshCoreMap';
+import { meshcoreRoleIcon, meshcoreRoleLabelKey, meshcoreRoleLabel } from './meshcoreRole';
 import { useToast } from '../ToastContainer';
 
 type DiscoverMode = 'nearby' | 'repeaters' | 'sensors';
@@ -10,13 +11,6 @@ type DiscoverMode = 'nearby' | 'repeaters' | 'sensors';
 const MOBILE_BREAKPOINT = 768;
 const isMobileViewport = (): boolean =>
   typeof window !== 'undefined' && window.innerWidth <= MOBILE_BREAKPOINT;
-
-const DEVICE_TYPE_KEYS: Record<number, string> = {
-  0: 'meshcore.device_type.unknown',
-  1: 'meshcore.device_type.companion',
-  2: 'meshcore.device_type.repeater',
-  3: 'meshcore.device_type.room_server',
-};
 
 interface MeshCoreNodesViewProps {
   nodes: MeshCoreNode[];
@@ -346,12 +340,17 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
                 onDoubleClick={onNavigateToDm ? () => onNavigateToDm(row.publicKey) : undefined}
               >
                 <div className="mc-node-row-name">
-                  <span>{row.name}</span>
-                  {typeof row.advType === 'number' && (
-                    <span className="mc-node-row-type">
-                      {t(DEVICE_TYPE_KEYS[row.advType] || 'meshcore.device_type.unknown', '')}
+                  {meshcoreRoleIcon(row.advType) && (
+                    <span
+                      className="mc-node-role-icon"
+                      role="img"
+                      aria-label={t(meshcoreRoleLabelKey(row.advType), meshcoreRoleLabel(row.advType))}
+                      title={t(meshcoreRoleLabelKey(row.advType), meshcoreRoleLabel(row.advType))}
+                    >
+                      {meshcoreRoleIcon(row.advType)}
                     </span>
                   )}
+                  <span className="mc-node-row-display-name">{row.name}</span>
                 </div>
                 <div className="mc-node-row-meta">
                   {typeof row.rssi === 'number' && <span>RSSI {row.rssi}</span>}

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -559,6 +559,14 @@
   font-weight: normal;
 }
 
+/* Compact role icon shown to the LEFT of the node name (#3647) — node list
+   (map page) and Direct Messages peer list. */
+.mc-node-role-icon {
+  flex: 0 0 auto;
+  line-height: 1;
+  font-size: 0.95rem;
+}
+
 .mc-node-row-meta {
   display: flex;
   gap: 0.6rem;

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -358,7 +358,6 @@
 }
 
 .mc-node-row.selected .mc-node-row-name,
-.mc-node-row.selected .mc-node-row-type,
 .mc-node-row.selected .mc-node-row-meta,
 .mc-node-row.selected .mc-node-row-key {
   color: var(--ctp-accent-text);
@@ -548,15 +547,6 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-}
-
-.mc-node-row-type {
-  background: var(--ctp-surface0);
-  color: var(--ctp-subtext0);
-  font-size: 0.7rem;
-  padding: 0.1rem 0.4rem;
-  border-radius: var(--radius-sm);
-  font-weight: normal;
 }
 
 /* Compact role icon shown to the LEFT of the node name (#3647) — node list

--- a/src/components/MeshCore/meshcoreRole.test.ts
+++ b/src/components/MeshCore/meshcoreRole.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { meshcoreRoleIcon, meshcoreRoleLabelKey, meshcoreRoleLabel } from './meshcoreRole';
+
+describe('meshcoreRole (#3647)', () => {
+  it('maps each known advert type to a compact icon', () => {
+    expect(meshcoreRoleIcon(1)).toBe('📱'); // Companion
+    expect(meshcoreRoleIcon(2)).toBe('📡'); // Repeater
+    expect(meshcoreRoleIcon(3)).toBe('🏠'); // Room Server
+    expect(meshcoreRoleIcon(4)).toBe('🌡️'); // Sensor
+  });
+
+  it('returns an empty string for unknown/unset types so callers can skip rendering', () => {
+    expect(meshcoreRoleIcon(0)).toBe('');
+    expect(meshcoreRoleIcon(undefined)).toBe('');
+    expect(meshcoreRoleIcon(null)).toBe('');
+    expect(meshcoreRoleIcon(99)).toBe('');
+  });
+
+  it('provides an i18n key and English fallback label per type', () => {
+    expect(meshcoreRoleLabelKey(2)).toBe('meshcore.device_type.repeater');
+    expect(meshcoreRoleLabel(2)).toBe('Repeater');
+    expect(meshcoreRoleLabel(3)).toBe('Room Server');
+    // unknown / unset fall back to the "unknown" entry
+    expect(meshcoreRoleLabelKey(undefined)).toBe('meshcore.device_type.unknown');
+    expect(meshcoreRoleLabel(undefined)).toBe('Unknown');
+  });
+});

--- a/src/components/MeshCore/meshcoreRole.ts
+++ b/src/components/MeshCore/meshcoreRole.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared MeshCore advert-type (role) presentation: the i18n label key and a
+ * compact role icon. Used by the node list (map page) and the Direct Messages
+ * peer list so the role is shown consistently as an icon to the LEFT of the
+ * node name (#3647).
+ *
+ * MeshCore advert types (firmware): 1=Companion, 2=Repeater, 3=Room Server,
+ * 4=Sensor; 0/undefined = unknown.
+ */
+export const MESHCORE_DEVICE_TYPE_KEYS: Record<number, string> = {
+  0: 'meshcore.device_type.unknown',
+  1: 'meshcore.device_type.companion',
+  2: 'meshcore.device_type.repeater',
+  3: 'meshcore.device_type.room_server',
+  4: 'meshcore.device_type.sensor',
+};
+
+/** English fallbacks for the role label (used as the t() default + title text). */
+export const MESHCORE_DEVICE_TYPE_LABELS: Record<number, string> = {
+  0: 'Unknown',
+  1: 'Companion',
+  2: 'Repeater',
+  3: 'Room Server',
+  4: 'Sensor',
+};
+
+/**
+ * Compact role icon (emoji) for a MeshCore advert type. Returns an empty string
+ * for unknown/unset types so callers can skip rendering rather than showing a
+ * meaningless glyph.
+ */
+export function meshcoreRoleIcon(advType: number | null | undefined): string {
+  switch (advType) {
+    case 1: return '📱'; // Companion
+    case 2: return '📡'; // Repeater
+    case 3: return '🏠'; // Room Server
+    case 4: return '🌡️'; // Sensor
+    default: return '';   // Unknown / unset
+  }
+}
+
+export function meshcoreRoleLabelKey(advType: number | null | undefined): string {
+  return MESHCORE_DEVICE_TYPE_KEYS[advType ?? 0] ?? MESHCORE_DEVICE_TYPE_KEYS[0];
+}
+
+export function meshcoreRoleLabel(advType: number | null | undefined): string {
+  return MESHCORE_DEVICE_TYPE_LABELS[advType ?? 0] ?? MESHCORE_DEVICE_TYPE_LABELS[0];
+}


### PR DESCRIPTION
## Summary

Closes #3647.

For MeshCore sources, the node's role is now shown as a **compact icon to the LEFT of the name**, consistently across both node lists:

- **Map page node list** (`MeshCoreNodesView`) — replaces the text role label that was shown to the *right* of the name with a role icon on the *left*.
- **Direct Messages peer list** (`MeshCoreDirectMessagesView`) — adds a role icon on the left (previously there was no role indication here at all).

## Details
- Icons by advert type: 📱 Companion, 📡 Repeater, 🏠 Room Server, 🌡️ Sensor. Unknown/unset types render no icon.
- Each icon carries an `aria-label`/`title` with the localized role name (`role="img"`).
- New shared **`meshcoreRole`** helper centralizes the icon + label mapping (the `DEVICE_TYPE_KEYS` map had been duplicated across components).
- The display-name span now carries a stable `mc-node-row-display-name` class.

## Testing
- [x] `meshcoreRole.test.ts` — icon mapping, empty-for-unknown, label/key fallbacks.
- [x] `MeshCoreNodesView` role-icon render test (icon left of name; old text label removed).
- [x] Existing sort/favorite tests updated to the stable name selector — full MeshCore view suites green (33 tests).
- [x] `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)