### PR TITLE
release: v4.11.4

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.11.3",
+  "version": "4.11.4",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.11.3",
+  "version": "4.11.4",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.11.3
-appVersion: "4.11.3"
+version: 4.11.4
+appVersion: "4.11.4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.11.3",
+  "version": "4.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.11.3",
+      "version": "4.11.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -14,7 +14,6 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#feat/meshmonitor-helpers",
         "@maplibre/maplibre-gl-leaflet": "^0.1.3",
-        "@rollup/rollup-linux-arm64-musl": "4.62.2",
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-virtual": "^3.14.3",
         "@tmcw/togeojson": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.11.3",
+  "version": "4.11.4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Release v4.11.4

Patch release. Bumps all five version files (`package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml` version + appVersion, `desktop/src-tauri/tauri.conf.json`, `desktop/package.json`) 4.11.3 → 4.11.4, and rolls up everything merged since v4.11.3.

### 🔴 Critical
- **PostgreSQL boot-loop fixed** (#3639) — Postgres deployments could fail to start with `tables can have at most 1600 columns`. Update recommended for all Postgres users.

### ✨ Features
- MeshCore role icons in the map + Direct Messages node lists (#3647)
- MeshCore favorites pinned to the top of the Direct Messages list (#3620)
- Marker spiderfying for overlapping nodes on Map Analysis + Unified maps (#3612)
- Channel "overshadow" warning when a device channel shares its key with a differently-named Channel Database entry (#3644)
- Traceroute `packetId` stored for cross-source trace correlation (#3623)

### 🐛 Fixes
- Node disconnects / TX failures since 4.11.x (stuck module-config fetch) (#3637)
- Custom-LoRa-config primary channel no longer mislabeled "LongFast" (#3644)
- TCP source reconnect shows the real per-source address (#3611)
- Fictitious traceroute segments removed; incoming traceroutes visible again (#3622)
- MeshCore hashtag `#channel` secrets derive correctly over plain HTTP-via-IP and at save time (#3606, #3607)
- MeshCore Last Heard preserved across reconnect (#3645)
- MeshCore new nodes populate Name/type/Position immediately when heard live (#3646)
- Unified-map neighbor lines follow the merged node marker (#3642)
- Adaptive node-type filter per connected source protocol (#3610)
- Saner uncertainty for weight-dominated single-anchor position estimates (#3616)

### Verification
- [x] All five version files bumped to 4.11.4
- [x] Built and deployed to the dev container; running container confirmed reporting 4.11.4 with a clean boot
- [x] System tests enabled on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)