### PR TITLE
fix(migration): guard 033 channel_database backfill — v4.11.5 hotfix (#3657)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.11.4",
+  "version": "4.11.5",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.11.4",
+  "version": "4.11.5",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.11.4
-appVersion: "4.11.4"
+version: 4.11.5
+appVersion: "4.11.5"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.11.4",
+  "version": "4.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.11.4",
+      "version": "4.11.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.11.4",
+  "version": "4.11.5",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/server/migrations/033_per_source_permissions.test.ts
+++ b/src/server/migrations/033_per_source_permissions.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Migration 033 — per-source permissions expansion. SQLite-only test.
+ *
+ * Regression for #3657: 033 backfills `channel_database.sourceId`, but
+ * channel_database is global-by-design — migration 021 no longer adds that
+ * column and migration 063 drops it. On PostgreSQL (which re-runs every
+ * migration on every boot) and on fresh installs, the column is absent when 033
+ * runs, so the unguarded `UPDATE channel_database SET sourceId ...` crashed with
+ * `column "sourceId" does not exist`. The crash only surfaces when at least one
+ * source is registered (the backfill is gated on `sources.length > 0`), which is
+ * why the CI fixtures — having no sources — never caught it.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './033_per_source_permissions.js';
+
+/** Pre-033 schema with permissions already in the post-rebuild shape (named
+ *  sourceId column, no old inline UNIQUE) so 033 skips the table rebuild. */
+function createBaseSchema(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE sources (id TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT UNIQUE NOT NULL,
+      is_admin INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE permissions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      resource TEXT NOT NULL,
+      can_view_on_map INTEGER NOT NULL DEFAULT 0,
+      can_read INTEGER NOT NULL DEFAULT 0,
+      can_write INTEGER NOT NULL DEFAULT 0,
+      can_delete INTEGER NOT NULL DEFAULT 0,
+      granted_at INTEGER NOT NULL,
+      granted_by INTEGER,
+      sourceId TEXT
+    );
+  `);
+}
+
+function columnNames(db: Database.Database, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((c) => c.name);
+}
+
+describe('Migration 033 — channel_database backfill guard (#3657)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createBaseSchema(db);
+    db.prepare(`INSERT INTO sources (id, name) VALUES (?, ?)`).run('src-a', 'Source A');
+  });
+
+  it('does NOT throw when channel_database has no sourceId column and a source exists', () => {
+    // The #3657 condition: channel_database without sourceId (post-021-fix / post-063).
+    db.exec(`CREATE TABLE channel_database (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, psk TEXT)`);
+    db.prepare(`INSERT INTO channel_database (name, psk) VALUES (?, ?)`).run('LongFast', 'AQ==');
+
+    expect(() => migration.up(db)).not.toThrow();
+    // The guard skipped the backfill; the column was never (re)introduced.
+    expect(columnNames(db, 'channel_database')).not.toContain('sourceId');
+  });
+
+  it('still backfills channel_database.sourceId when the legacy column is present', () => {
+    // Back-compat: a mid-upgrade DB where 021 had added sourceId and 063 has not
+    // yet dropped it. The backfill must still run.
+    db.exec(`CREATE TABLE channel_database (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, psk TEXT, sourceId TEXT)`);
+    db.prepare(`INSERT INTO channel_database (name, psk, sourceId) VALUES (?, ?, NULL)`).run('LongFast', 'AQ==');
+
+    expect(() => migration.up(db)).not.toThrow();
+    const row = db.prepare(`SELECT sourceId FROM channel_database WHERE name = 'LongFast'`).get() as { sourceId: string | null };
+    expect(row.sourceId).toBe('src-a');
+  });
+
+  it('does not throw with no sources registered (channel_database column absent)', () => {
+    db.exec(`DELETE FROM sources`);
+    db.exec(`CREATE TABLE channel_database (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, psk TEXT)`);
+    expect(() => migration.up(db)).not.toThrow();
+  });
+});

--- a/src/server/migrations/033_per_source_permissions.ts
+++ b/src/server/migrations/033_per_source_permissions.ts
@@ -141,14 +141,22 @@ export const migration = {
     `);
     logger.info(`Migration 033 (SQLite): created unique index '${NEW_INDEX_NAME}'`);
 
-    // Fix orphaned channel_database rows
+    // Fix orphaned channel_database rows — ONLY when the legacy `sourceId`
+    // column still exists. channel_database is global-by-design: migration 021
+    // no longer adds `sourceId` and migration 063 drops it, so on current
+    // databases the column is absent and this backfill is a no-op. Guard so 033
+    // doesn't crash with "no such column: sourceId" on fresh installs (#3657).
     if (sources.length > 0) {
-      const firstSource = sources[0].id;
-      const cdResult = db.prepare(`
-        UPDATE channel_database SET sourceId = ? WHERE sourceId IS NULL
-      `).run(firstSource);
-      if (cdResult.changes > 0) {
-        logger.info(`Migration 033 (SQLite): migrated ${cdResult.changes} channel_database row(s) to source '${firstSource}'`);
+      const cdHasSourceId = (db.prepare(`PRAGMA table_info(channel_database)`).all() as Array<{ name: string }>)
+        .some((c) => c.name === 'sourceId');
+      if (cdHasSourceId) {
+        const firstSource = sources[0].id;
+        const cdResult = db.prepare(`
+          UPDATE channel_database SET sourceId = ? WHERE sourceId IS NULL
+        `).run(firstSource);
+        if (cdResult.changes > 0) {
+          logger.info(`Migration 033 (SQLite): migrated ${cdResult.changes} channel_database row(s) to source '${firstSource}'`);
+        }
       }
     }
 
@@ -221,14 +229,24 @@ export async function runMigration033Postgres(client: any): Promise<void> {
   `);
   logger.info(`Migration 033 (PostgreSQL): created unique index '${NEW_INDEX_NAME}'`);
 
-  // Fix orphaned channel_database rows
+  // Fix orphaned channel_database rows — ONLY when the legacy `sourceId` column
+  // still exists. channel_database is global-by-design: migration 021 no longer
+  // adds `sourceId` and migration 063 drops it, so on current databases the
+  // column is absent and this backfill is a no-op. Without this guard, 033
+  // crashes on every PostgreSQL boot (PG re-runs all migrations) with
+  // `column "sourceId" does not exist` (#3657).
   if (sources.length > 0) {
-    const firstSource = sources[0];
-    const cdRes = await client.query(`
-      UPDATE channel_database SET "sourceId" = $1 WHERE "sourceId" IS NULL
-    `, [firstSource]);
-    if (cdRes.rowCount && cdRes.rowCount > 0) {
-      logger.info(`Migration 033 (PostgreSQL): migrated ${cdRes.rowCount} channel_database row(s) to source '${firstSource}'`);
+    const { rows: cdCol } = await client.query(
+      `SELECT 1 FROM information_schema.columns WHERE table_name = 'channel_database' AND column_name = 'sourceId'`
+    );
+    if (cdCol.length > 0) {
+      const firstSource = sources[0];
+      const cdRes = await client.query(`
+        UPDATE channel_database SET "sourceId" = $1 WHERE "sourceId" IS NULL
+      `, [firstSource]);
+      if (cdRes.rowCount && cdRes.rowCount > 0) {
+        logger.info(`Migration 033 (PostgreSQL): migrated ${cdRes.rowCount} channel_database row(s) to source '${firstSource}'`);
+      }
     }
   }
 
@@ -313,16 +331,25 @@ export async function runMigration033Mysql(pool: any): Promise<void> {
       logger.debug(`Migration 033 (MySQL): unique index '${NEW_INDEX_NAME}' already exists`);
     }
 
-    // Fix orphaned channel_database rows
+    // Fix orphaned channel_database rows — ONLY when the legacy `sourceId`
+    // column still exists. channel_database is global-by-design: migration 021
+    // no longer adds `sourceId` and migration 063 drops it, so on current
+    // databases the column is absent and this backfill is a no-op. Guard so 033
+    // doesn't crash with "Unknown column 'sourceId'" (#3657).
     if (sources.length > 0) {
-      const firstSource = sources[0];
-      const [cdResult] = await conn.query(
-        `UPDATE channel_database SET sourceId = ? WHERE sourceId IS NULL`,
-        [firstSource],
+      const [cdCols] = await conn.query(
+        `SELECT 1 FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'channel_database' AND COLUMN_NAME = 'sourceId'`,
       );
-      const cdAffected = (cdResult as any)?.affectedRows ?? 0;
-      if (cdAffected > 0) {
-        logger.info(`Migration 033 (MySQL): migrated ${cdAffected} channel_database row(s) to source '${firstSource}'`);
+      if (Array.isArray(cdCols) && cdCols.length > 0) {
+        const firstSource = sources[0];
+        const [cdResult] = await conn.query(
+          `UPDATE channel_database SET sourceId = ? WHERE sourceId IS NULL`,
+          [firstSource],
+        );
+        const cdAffected = (cdResult as any)?.affectedRows ?? 0;
+        if (cdAffected > 0) {
+          logger.info(`Migration 033 (MySQL): migrated ${cdAffected} channel_database row(s) to source '${firstSource}'`);
+        }
       }
     }
   } finally {


### PR DESCRIPTION
## 🚨 Hotfix for #3657 — v4.11.4 broke Postgres / fresh-install startup

**v4.11.4 has been retracted (unpublished).** This PR fixes the regression and bumps to **v4.11.5**.

### Root cause
#3640 (in v4.11.4) removed `channel_database` from migration 021's `sourceId`-add to stop the PG boot-loop (#3639). But migration **033** still runs `UPDATE channel_database SET sourceId ...`. Migration order is 021 (add) → 033 (update) → 063 (drop). On PostgreSQL — which **re-runs every migration on every boot** — v4.11.3 worked because 021 re-added the column before 033 ran. With 021 no longer adding it, 033 crashes during DB init:

```
[ERROR] Database initialization failed: error: column "sourceId" does not exist
```

This also breaks **fresh installs on all backends** (021 → 033 with no column). It only triggers when ≥1 source is registered (the backfill is gated on `sources.length > 0`) — the CI fixtures have **no sources**, which is exactly why it slipped through.

### Fix
Guard migration 033's `channel_database` backfill on the legacy `sourceId` column still existing — `PRAGMA table_info` (SQLite), `information_schema.columns` (PG/MySQL). `channel_database` is global-by-design (063 drops `sourceId`), so on current DBs the column is absent and the backfill is correctly a no-op; on a mid-upgrade DB where it's still present, it still runs.

### Testing
- [x] New `033_per_source_permissions.test.ts` — reproduces #3657 (source present + `channel_database` without `sourceId` → no throw; the previous code threw "no such column"), confirms the back-compat backfill still runs when the column exists, and the no-sources case.
- [x] `tsc -p tsconfig.server.json` clean.
- [x] System tests enabled on this PR.

### Version
- [x] All five version files bumped 4.11.4 → 4.11.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)