### PR TITLE
fix(migration): remove dead channel_database.sourceId backfill from migration 033 (fixes #3657)

### DIFF
--- a/src/server/migrations/033_per_source_permissions.ts
+++ b/src/server/migrations/033_per_source_permissions.ts
@@ -14,7 +14,8 @@
  *   3. Drop the old unique constraint on (user_id, resource) which prevents
  *      multiple per-source rows for the same user+resource.
  *   4. Create a new unique index on (user_id, resource, sourceId).
- *   5. Update channel_database rows with NULL sourceId to use the first source.
+ *   (Step 5 — channel_database.sourceId backfill — removed: migration 021 no longer
+ *    adds sourceId to channel_database and migration 063 drops it; see #3657.)
  *
  * Dialect notes:
  *   - SQLite column names: user_id, resource, can_view_on_map, can_read,
@@ -141,16 +142,10 @@ export const migration = {
     `);
     logger.info(`Migration 033 (SQLite): created unique index '${NEW_INDEX_NAME}'`);
 
-    // Fix orphaned channel_database rows
-    if (sources.length > 0) {
-      const firstSource = sources[0].id;
-      const cdResult = db.prepare(`
-        UPDATE channel_database SET sourceId = ? WHERE sourceId IS NULL
-      `).run(firstSource);
-      if (cdResult.changes > 0) {
-        logger.info(`Migration 033 (SQLite): migrated ${cdResult.changes} channel_database row(s) to source '${firstSource}'`);
-      }
-    }
+    // NOTE: channel_database.sourceId backfill intentionally removed.
+    // Migration 021 no longer adds sourceId to channel_database (global-by-design;
+    // see issue #3639), and migration 063 drops the column. Attempting to UPDATE
+    // a column that no longer exists crashes PostgreSQL on every boot (#3657).
 
     logger.info('Migration 033 complete (SQLite)');
   },
@@ -221,16 +216,10 @@ export async function runMigration033Postgres(client: any): Promise<void> {
   `);
   logger.info(`Migration 033 (PostgreSQL): created unique index '${NEW_INDEX_NAME}'`);
 
-  // Fix orphaned channel_database rows
-  if (sources.length > 0) {
-    const firstSource = sources[0];
-    const cdRes = await client.query(`
-      UPDATE channel_database SET "sourceId" = $1 WHERE "sourceId" IS NULL
-    `, [firstSource]);
-    if (cdRes.rowCount && cdRes.rowCount > 0) {
-      logger.info(`Migration 033 (PostgreSQL): migrated ${cdRes.rowCount} channel_database row(s) to source '${firstSource}'`);
-    }
-  }
+  // NOTE: channel_database.sourceId backfill intentionally removed.
+  // Migration 021 no longer adds sourceId to channel_database (global-by-design;
+  // see issue #3639), and migration 063 drops the column. Attempting to UPDATE
+  // a column that no longer exists crashes PostgreSQL on every boot (#3657).
 
   logger.info('Migration 033 complete (PostgreSQL)');
 }
@@ -313,18 +302,10 @@ export async function runMigration033Mysql(pool: any): Promise<void> {
       logger.debug(`Migration 033 (MySQL): unique index '${NEW_INDEX_NAME}' already exists`);
     }
 
-    // Fix orphaned channel_database rows
-    if (sources.length > 0) {
-      const firstSource = sources[0];
-      const [cdResult] = await conn.query(
-        `UPDATE channel_database SET sourceId = ? WHERE sourceId IS NULL`,
-        [firstSource],
-      );
-      const cdAffected = (cdResult as any)?.affectedRows ?? 0;
-      if (cdAffected > 0) {
-        logger.info(`Migration 033 (MySQL): migrated ${cdAffected} channel_database row(s) to source '${firstSource}'`);
-      }
-    }
+    // NOTE: channel_database.sourceId backfill intentionally removed.
+    // Migration 021 no longer adds sourceId to channel_database (global-by-design;
+    // see issue #3639), and migration 063 drops the column. Attempting to UPDATE
+    // a column that no longer exists crashes on every boot (#3657).
   } finally {
     conn.release();
   }


### PR DESCRIPTION
## Summary

- **Root cause of #3657**: Migration 033 unconditionally runs `UPDATE channel_database SET "sourceId" = $1 WHERE "sourceId" IS NULL` on every PostgreSQL startup, but the `channel_database.sourceId` column no longer exists after a v4.11.3 boot (migration 063 drops it at the end of every boot). The fix in #3640 (v4.11.4) correctly stopped migration 021 from adding the column, but left migration 033 still trying to update it — causing a hard crash on the very first v4.11.4 startup.
- **Fix**: Remove the `channel_database.sourceId` backfill from migration 033 in all three backends (SQLite, PostgreSQL, MySQL). The backfill was already dead code: migration 063 drops the column in the same startup immediately after migration 033 runs.

### Root cause trace

```
v4.11.3 boot (any):
  migration 021 → ADD COLUMN IF NOT EXISTS "sourceId" to channel_database  ✓
  migration 033 → UPDATE channel_database SET "sourceId" = ...              ✓
  migration 063 → DROP COLUMN IF EXISTS "sourceId" from channel_database    ✓
  → boot ends, channel_database has NO sourceId column

v4.11.4 first boot:
  migration 021 → skips channel_database (fix from #3640)
  migration 033 → UPDATE channel_database SET "sourceId" = ...  ← FAILS
  error: column "sourceId" does not exist
  ❌ Database initialization failed
```

## Test plan

- [x] All migration and repository tests pass (`src/db/` and `src/server/migrations/`)
- [x] Full Vitest suite: 7114 passed, 3 pre-existing failures (protobuf/MQTT environment issues unrelated to this change)
- [ ] Deploy a v4.11.3 PostgreSQL instance, upgrade to this branch, verify it boots successfully
- [ ] Verify second and subsequent boots also succeed (no lingering issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDMHH6pswhsevbMYb5UgTY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDMHH6pswhsevbMYb5UgTY)_