### PR TITLE
fix(meshcore): honor Temperature Unit on the DM telemetry graph (#3659)

### DIFF
--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -24,7 +24,7 @@ vi.mock('../../contexts/AuthContext', () => ({
 }));
 
 vi.mock('../../contexts/SettingsContext', () => ({
-  useSettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
+  useSettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY', temperatureUnit: 'F', telemetryVisualizationHours: 48 }),
 }));
 
 const csrfFetchMock = vi.fn();
@@ -37,8 +37,14 @@ vi.mock('../../hooks/useCsrfFetch', () => ({
 // met. Stub the heavy graphs component with a sentinel so we don't need
 // ToastProvider / QueryClientProvider / SourceProvider in this test.
 vi.mock('../TelemetryGraphs', () => ({
-  default: (props: { nodeId: string; baseUrl?: string }) => (
-    <div data-testid="telemetry-graphs" data-node-id={props.nodeId} data-base-url={props.baseUrl ?? ''} />
+  default: (props: { nodeId: string; baseUrl?: string; temperatureUnit?: string; telemetryHours?: number }) => (
+    <div
+      data-testid="telemetry-graphs"
+      data-node-id={props.nodeId}
+      data-base-url={props.baseUrl ?? ''}
+      data-temp-unit={props.temperatureUnit ?? ''}
+      data-telemetry-hours={props.telemetryHours ?? ''}
+    />
   ),
 }));
 
@@ -189,6 +195,10 @@ describe('MeshCoreDirectMessagesView — per-node telemetry-config panel', () =>
     const graphs = await screen.findByTestId('telemetry-graphs');
     expect(graphs.getAttribute('data-node-id')).toBe(REAL_PK);
     expect(graphs.getAttribute('data-base-url')).toBe('/meshmonitor');
+    // #3659: the user's Temperature Unit + telemetry time-range settings are
+    // forwarded so the graph isn't hardcoded to Celsius / 24h.
+    expect(graphs.getAttribute('data-temp-unit')).toBe('F');
+    expect(graphs.getAttribute('data-telemetry-hours')).toBe('48');
   });
 
   it('does NOT mount TelemetryGraphs for a non-real-pubkey peer', () => {

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -10,6 +10,7 @@ import { MeshCoreContactDetailPanel } from './MeshCoreContactDetailPanel';
 import { MeshCoreNodeTelemetryConfig } from './MeshCoreNodeTelemetryConfig';
 import TelemetryGraphs from '../TelemetryGraphs';
 import { useAuth } from '../../contexts/AuthContext';
+import { useSettings } from '../../contexts/SettingsContext';
 
 interface MeshCoreDirectMessagesViewProps {
   messages: MeshCoreMessage[];
@@ -60,6 +61,10 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
 }) => {
   const { t } = useTranslation();
   const { hasPermission } = useAuth();
+  // Honor the user's Temperature Unit + telemetry time-range settings on the
+  // per-node telemetry graph, consistent with the Meshtastic DM view and the
+  // MeshCore Telemetry dashboard (#3659).
+  const { temperatureUnit, telemetryVisualizationHours } = useSettings();
   const canSend = hasPermission('messages', 'write');
   const canWriteNodes = hasPermission('nodes', 'write');
   const canRemoteAdmin = hasPermission('remote_admin', 'write');
@@ -412,7 +417,12 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                     sourceId={sourceId}
                     publicKey={selected}
                   />
-                  <TelemetryGraphs nodeId={selected} baseUrl={baseUrl} />
+                  <TelemetryGraphs
+                    nodeId={selected}
+                    temperatureUnit={temperatureUnit}
+                    telemetryHours={telemetryVisualizationHours}
+                    baseUrl={baseUrl}
+                  />
                 </>
               )}
             </div>


### PR DESCRIPTION
## Summary

Closes #3659.

The per-node telemetry graph on the MeshCore **Direct Messages** page always showed temperature in Celsius regardless of the user's **Temperature Unit** setting. Root cause: it mounted `<TelemetryGraphs nodeId=… baseUrl=… />` **without** the `temperatureUnit` prop, which defaults to `'C'`.

`TelemetryGraphs` already does the conversion (via `formatTemperature`), and both the Meshtastic DM view (`MessagesTab.tsx`) and the MeshCore **Telemetry dashboard** (`MeshCoreTelemetryView.tsx`) already pass `temperatureUnit` — only this one call site was missing it.

## Fix
Pass `temperatureUnit` and `telemetryVisualizationHours` from `useSettings()` into the DM-page `TelemetryGraphs`, mirroring `MessagesTab`. Axis label + tooltip now reflect °F/°C per the setting.

## Testing
- [x] Extended `MeshCoreDirectMessagesView.test.tsx` — asserts the graph receives `temperatureUnit` and the telemetry hours from settings (12 tests pass).
- [x] `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)