### PR TITLE
feat(meshcore): Last Heard shows date when heard before today (#3656)

### DIFF
--- a/src/components/MeshCore/MeshCoreNodesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.test.tsx
@@ -25,6 +25,10 @@ vi.mock('../ToastContainer', () => ({
   useToast: () => ({ showToast }),
 }));
 
+vi.mock('../../contexts/SettingsContext', () => ({
+  useSettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
+}));
+
 import { MeshCoreNodesView } from './MeshCoreNodesView';
 import type { MeshCoreNode } from './hooks/useMeshCore';
 import type { MeshCoreContact } from '../../utils/meshcoreHelpers';

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -5,6 +5,8 @@ import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMap } from './MeshCoreMap';
 import { meshcoreRoleIcon, meshcoreRoleLabelKey, meshcoreRoleLabel } from './meshcoreRole';
 import { useToast } from '../ToastContainer';
+import { useSettings } from '../../contexts/SettingsContext';
+import { formatTimeOrDate } from '../../utils/datetime';
 
 type DiscoverMode = 'nearby' | 'repeaters' | 'sensors';
 
@@ -118,6 +120,7 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
 }) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
+  const { timeFormat, dateFormat } = useSettings();
   const [favoriteBusy, setFavoriteBusy] = useState<string | null>(null);
 
   const handleToggleFavorite = useCallback(async (publicKey: string, next: boolean) => {
@@ -358,7 +361,7 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
                   {typeof row.rssi === 'number' && <span>RSSI {row.rssi}</span>}
                   {typeof row.snr === 'number' && <span>SNR {row.snr}</span>}
                   {row.lastHeard && (
-                    <span>{new Date(row.lastHeard).toLocaleTimeString()}</span>
+                    <span>{formatTimeOrDate(new Date(row.lastHeard), timeFormat, dateFormat)}</span>
                   )}
                   {row.hasPosition && <span>📍</span>}
                 </div>

--- a/src/utils/datetime.test.ts
+++ b/src/utils/datetime.test.ts
@@ -3,6 +3,7 @@ import {
   formatTime,
   formatDate,
   formatDateTime,
+  formatTimeOrDate,
   formatRelativeTime,
   formatMessageTime,
   getMessageDateSeparator,
@@ -68,6 +69,35 @@ describe('datetime utilities', () => {
       const date = new Date('2024-03-15T14:30:00');
       expect(formatDateTime(date)).toBe('03/15/2024 14:30');
       expect(formatDateTime(date, '12', 'DD/MM/YYYY')).toMatch(/15\/03\/2024 2:30\s*PM/i);
+    });
+  });
+
+  describe('formatTimeOrDate (#3656)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      // "now" = 2024-03-15 14:32 local
+      vi.setSystemTime(new Date('2024-03-15T14:32:00'));
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('shows the TIME when the date is today', () => {
+      const earlierToday = new Date('2024-03-15T09:05:00');
+      expect(formatTimeOrDate(earlierToday, '24')).toBe('09:05');
+      expect(formatTimeOrDate(earlierToday, '12')).toMatch(/9:05\s*AM/i);
+    });
+
+    it('shows the DATE (per dateFormat) when the date is before today', () => {
+      const yesterday = new Date('2024-03-14T20:00:00');
+      expect(formatTimeOrDate(yesterday, '24', 'MM/DD/YYYY')).toBe('03/14/2024');
+      expect(formatTimeOrDate(yesterday, '24', 'DD/MM/YYYY')).toBe('14/03/2024');
+      expect(formatTimeOrDate(yesterday, '24', 'YYYY-MM-DD')).toBe('2024-03-14');
+    });
+
+    it('treats local midnight today as today (time), and 23:59 yesterday as a date', () => {
+      expect(formatTimeOrDate(new Date('2024-03-15T00:00:00'), '24')).toBe('00:00');
+      expect(formatTimeOrDate(new Date('2024-03-14T23:59:00'), '24', 'MM/DD/YYYY')).toBe('03/14/2024');
     });
   });
 

--- a/src/utils/datetime.test.ts
+++ b/src/utils/datetime.test.ts
@@ -96,7 +96,10 @@ describe('datetime utilities', () => {
     });
 
     it('treats local midnight today as today (time), and 23:59 yesterday as a date', () => {
-      expect(formatTimeOrDate(new Date('2024-03-15T00:00:00'), '24')).toBe('00:00');
+      // Midnight today must render as a TIME, not a date. The exact 24h midnight
+      // form is ICU-version-dependent ("00:00" on newer Node, "24:00" on Node 20),
+      // so assert it's a time rather than pinning the value.
+      expect(formatTimeOrDate(new Date('2024-03-15T00:00:00'), '24')).toMatch(/^(00|24):00$/);
       expect(formatTimeOrDate(new Date('2024-03-14T23:59:00'), '24', 'MM/DD/YYYY')).toBe('03/14/2024');
     });
   });

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -58,6 +58,28 @@ export function formatDateTime(
 }
 
 /**
+ * Compact "last heard"-style label: show the TIME when `date` falls on the
+ * current local day, otherwise show the DATE. Keeps recent activity readable as
+ * a time while disambiguating older activity by date (#3656). "Today" is the
+ * local calendar day (consistent with how times are otherwise displayed).
+ * @param date - Date to format
+ * @param timeFormat - '12' or '24' (used when the date is today)
+ * @param dateFormat - 'MM/DD/YYYY' | 'DD/MM/YYYY' | 'YYYY-MM-DD' (used otherwise)
+ */
+export function formatTimeOrDate(
+  date: Date,
+  timeFormat: TimeFormat = '24',
+  dateFormat: DateFormat = 'MM/DD/YYYY'
+): string {
+  const now = new Date();
+  const isToday =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+  return isToday ? formatTime(date, timeFormat) : formatDate(date, dateFormat);
+}
+
+/**
  * Formats a timestamp (milliseconds since epoch) according to user preferences
  * @param timestamp - Timestamp in milliseconds
  * @param timeFormat - '12' for 12-hour format, '24' for 24-hour format


### PR DESCRIPTION
## Summary

Closes #3656.

On the MeshCore **Nodes** list, the **Last Heard** label always rendered a time (`toLocaleTimeString`), which is ambiguous for a node last heard on a previous day. Now:
- **Last heard today** (local day) → show the time (as before).
- **Last heard before today** → show the **date**, formatted per the user's **Date Format** setting.

## Implementation
- New `formatTimeOrDate(date, timeFormat, dateFormat)` in `src/utils/datetime.ts` — reuses the existing `formatTime`/`formatDate`. "Today" is the local calendar day, consistent with how times are otherwise displayed (no server-TZ plumbing — the rest of the UI also renders local time).
- Wired into `MeshCoreNodesView` via `timeFormat`/`dateFormat` from `useSettings`.

(`formatMessageTime` was not reused — it appends a time even to old dates and uses "Yesterday"/day-name forms, which is not this issue's spec.)

## Testing
- [x] `datetime.test.ts` — today→time (12h/24h), before-today→date across all three Date Formats, and the local-midnight / 23:59-yesterday boundaries.
- [x] `MeshCoreNodesView.test.tsx` updated (mock `useSettings`); full MeshCore node-view suite green (53 tests).
- [x] `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)