### PR TITLE
fix: MeshCore low battery and inactive node notifications never fire

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3936,9 +3936,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/server/services/inactiveNodeNotificationService.test.ts
+++ b/src/server/services/inactiveNodeNotificationService.test.ts
@@ -25,7 +25,6 @@ vi.mock('../../services/database.js', () => ({
     notifications: {
       getUsersWithInactiveNodeNotifications: mockGetUsersWithInactiveNodeNotifications,
     },
-    getInactiveMonitoredNodesAsync: mockGetInactiveMonitoredNodesAsync,
     nodes: {
       getInactiveMonitoredNodes: mockGetInactiveMonitoredNodesAsync,
     },

--- a/src/server/services/inactiveNodeNotificationService.test.ts
+++ b/src/server/services/inactiveNodeNotificationService.test.ts
@@ -50,6 +50,13 @@ vi.mock('../sourceManagerRegistry.js', () => ({
   },
 }));
 
+const mockMeshcoreList = vi.fn();
+vi.mock('../meshcoreRegistry.js', () => ({
+  meshcoreManagerRegistry: {
+    list: mockMeshcoreList,
+  },
+}));
+
 const mockBroadcastToPreferenceUsers = vi.fn();
 vi.mock('./notificationService.js', () => ({
   notificationService: {
@@ -74,8 +81,9 @@ describe('InactiveNodeNotificationService', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-15T12:00:00Z'));
 
-    // Phase C defaults: one source, name resolves, all permissions allowed
-    mockGetAllManagers.mockReturnValue([{ sourceId: 'src1' }]);
+    // Phase C defaults: one Meshtastic source, no MeshCore sources
+    mockGetAllManagers.mockReturnValue([{ sourceId: 'src1', sourceType: 'meshtastic_tcp' }]);
+    mockMeshcoreList.mockReturnValue([]);
     mockGetSource.mockResolvedValue({ id: 'src1', name: 'Source One' });
     mockCheckPermissionAsync.mockResolvedValue(true);
 
@@ -234,9 +242,10 @@ describe('InactiveNodeNotificationService', () => {
     const MC_NODE_ID = 'mc:mc1:aabbccddeeff';
 
     beforeEach(() => {
-      // A single MeshCore source. The presence of sourceType==='meshcore'
-      // routes the service down the MeshCore collection branch.
-      mockGetAllManagers.mockReturnValue([{ sourceId: 'mc1', sourceType: 'meshcore' }]);
+      // MeshCore managers come from meshcoreManagerRegistry, not sourceManagerRegistry.
+      // The service adapts them to { sourceId, sourceType: 'meshcore' }.
+      mockGetAllManagers.mockReturnValue([]);
+      mockMeshcoreList.mockReturnValue([{ sourceId: 'mc1' }]);
       mockGetSource.mockResolvedValue({ id: 'mc1', name: 'MeshCore One' });
     });
 

--- a/src/server/services/inactiveNodeNotificationService.ts
+++ b/src/server/services/inactiveNodeNotificationService.ts
@@ -2,6 +2,7 @@ import { logger } from '../../utils/logger.js';
 import databaseService from '../../services/database.js';
 import { notificationService } from './notificationService.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
 
 interface InactiveNodeCheck {
   nodeId: string;
@@ -103,8 +104,14 @@ class InactiveNodeNotificationService {
 
       logger.debug(`🔍 Checking inactive nodes for ${users.length} user(s)`);
 
-      // Phase C: iterate every active source and run the inactivity check per source
-      const managers = sourceManagerRegistry.getAllManagers();
+      // Phase C: iterate every active source and run the inactivity check per source.
+      // MeshCore managers live in meshcoreManagerRegistry (not sourceManagerRegistry),
+      // so combine both to ensure inactivity checks run for MeshCore sources.
+      type MinimalManager = { sourceId: string; sourceType: string };
+      const managers: MinimalManager[] = [
+        ...sourceManagerRegistry.getAllManagers(),
+        ...meshcoreManagerRegistry.list().map(m => ({ sourceId: m.sourceId, sourceType: 'meshcore' as const })),
+      ];
       if (managers.length === 0) {
         logger.debug('No source managers registered — skipping inactive node check');
         return;

--- a/src/server/services/lowBatteryNotificationService.test.ts
+++ b/src/server/services/lowBatteryNotificationService.test.ts
@@ -43,6 +43,13 @@ vi.mock('../sourceManagerRegistry.js', () => ({
   },
 }));
 
+const mockMeshcoreList = vi.fn();
+vi.mock('../meshcoreRegistry.js', () => ({
+  meshcoreManagerRegistry: {
+    list: mockMeshcoreList,
+  },
+}));
+
 const mockBroadcastToPreferenceUsers = vi.fn();
 vi.mock('./notificationService.js', () => ({
   notificationService: {
@@ -68,6 +75,7 @@ describe('LowBatteryNotificationService', () => {
     vi.setSystemTime(new Date('2026-03-15T12:00:00Z'));
 
     mockGetAllManagers.mockReturnValue([{ sourceId: 'src1', sourceType: 'meshtastic_tcp' }]);
+    mockMeshcoreList.mockReturnValue([]);
     mockGetSource.mockResolvedValue({ id: 'src1', name: 'Source One' });
     mockCheckPermissionAsync.mockResolvedValue(true);
 
@@ -213,8 +221,10 @@ describe('LowBatteryNotificationService', () => {
     const NODE_ID = `mc:mc1:${PUBKEY.substring(0, 12)}`; // mc:mc1:aabbccddeeff
 
     beforeEach(() => {
-      // Only a MeshCore source is registered for these tests
-      mockGetAllManagers.mockReturnValue([{ sourceId: 'mc1', sourceType: 'meshcore' }]);
+      // MeshCore managers come from meshcoreManagerRegistry, not sourceManagerRegistry.
+      // The service adapts them to { sourceId, sourceType: 'meshcore' }.
+      mockGetAllManagers.mockReturnValue([]);
+      mockMeshcoreList.mockReturnValue([{ sourceId: 'mc1' }]);
       mockGetSource.mockResolvedValue({ id: 'mc1', name: 'MeshCore One' });
     });
 

--- a/src/server/services/lowBatteryNotificationService.ts
+++ b/src/server/services/lowBatteryNotificationService.ts
@@ -2,6 +2,7 @@ import { logger } from '../../utils/logger.js';
 import databaseService from '../../services/database.js';
 import { notificationService } from './notificationService.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
 
 interface LowBatteryNodeCheck {
   nodeId: string;
@@ -106,7 +107,13 @@ class LowBatteryNotificationService {
 
       logger.debug(`🔍 Checking low battery for ${users.length} user(s)`);
 
-      const managers = sourceManagerRegistry.getAllManagers();
+      // MeshCore managers live in meshcoreManagerRegistry (not sourceManagerRegistry),
+      // so combine both to ensure voltage-threshold checks run for MeshCore sources.
+      type MinimalManager = { sourceId: string; sourceType: string };
+      const managers: MinimalManager[] = [
+        ...sourceManagerRegistry.getAllManagers(),
+        ...meshcoreManagerRegistry.list().map(m => ({ sourceId: m.sourceId, sourceType: 'meshcore' as const })),
+      ];
       if (managers.length === 0) {
         logger.debug('No source managers registered — skipping low battery check');
         return;


### PR DESCRIPTION
## Summary

Fixes #3671 — MeshCore "Notify on Low Battery" never fires regardless of threshold configured.

**Root cause:** Both `lowBatteryNotificationService` and `inactiveNodeNotificationService` build their list of sources to scan by calling `sourceManagerRegistry.getAllManagers()`. However, MeshCore managers are registered exclusively in `meshcoreManagerRegistry` and are **never added to `sourceManagerRegistry`**. This is even noted in a comment in `meshcoreManager.ts`:

> *"even though MeshCoreManager isn't registered in `sourceManagerRegistry`"*

As a result:
- The voltage-threshold battery check never ran for any MeshCore source
- Inactive-node notifications also never fired for MeshCore sources (same bug, same fix)
- The threshold setting itself saves correctly — the service just never reaches MeshCore

## Changes

- **`lowBatteryNotificationService.ts`** — combine both registries when building the manager list; map `MeshCoreManager` instances to the minimal `{ sourceId, sourceType: 'meshcore' }` shape the loop needs
- **`inactiveNodeNotificationService.ts`** — same fix
- **Both test files** — add `meshcoreManagerRegistry` mock; update the MeshCore-specific test cases to set managers via `meshcoreManagerRegistry.list()` (the actual production path) rather than `sourceManagerRegistry.getAllManagers()`

## Test plan

- [x] All 27 tests in `lowBatteryNotificationService.test.ts` pass
- [x] All tests in `inactiveNodeNotificationService.test.ts` pass
- [x] Full Vitest suite passes (0 failures)
- MeshCore tests now go through `meshcoreManagerRegistry.list()` → adapter, matching production code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lr9Jh3yPne1NVhnw4JmUNY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lr9Jh3yPne1NVhnw4JmUNY)_