### PR TITLE
feat(meshcore): scope all originated flood traffic — phase 2 (#3667)

### DIFF
--- a/docs/internal/dev-notes/MESHCORE_REGION_SCOPE_PLAN.md
+++ b/docs/internal/dev-notes/MESHCORE_REGION_SCOPE_PLAN.md
@@ -2,7 +2,10 @@
 
 Tracking issue: **#3667** ([FEAT] MeshCore: Region/Scope Support)
 
-> Status: Draft plan. No code written yet.
+> Status: **Phase 1 merged** (PR #3669, migration 100). **Phase 2 in progress** —
+> scoping all originated flood traffic (adverts, logins, telemetry/CLI requests)
+> via the shared `sendWithDefaultScope` helper on the per-source send mutex.
+> Phase 3 (region discovery) not started.
 
 ## 1. Background — how scopes/regions work in MeshCore
 

--- a/src/server/meshcoreManager.scope.test.ts
+++ b/src/server/meshcoreManager.scope.test.ts
@@ -22,6 +22,9 @@ function makeManager(opts: {
   defaultScope?: string | null;
   /** make the first N `set_flood_scope` bridge calls fail (transport error) */
   failFloodScopeTimes?: number;
+  /** make `set_flood_scope` await a real macrotask so interleaving is actually
+   *  exercised (the lock must hold scope-assert→send together) */
+  floodScopeDelayMs?: number;
 } = {}): { manager: MeshCoreManager; bridgeCalls: BridgeCall[]; scopeUpdates: Array<{ id: number; scope: string | null }> } {
   const m = new MeshCoreManager('test-source');
   (m as any).deviceType = MeshCoreDeviceType.COMPANION;
@@ -34,9 +37,14 @@ function makeManager(opts: {
   (m as any).sendBridgeCommand = async (cmd: string, params: Record<string, unknown>) => {
     bridgeCalls.push({ cmd, params });
     if (cmd === 'get_channels') return { id: '1', success: true, data: [] };
-    if (cmd === 'set_flood_scope' && floodScopeFailsLeft > 0) {
-      floodScopeFailsLeft -= 1;
-      return { id: '1', success: false, error: 'transport closed' };
+    if (cmd === 'set_flood_scope') {
+      if (floodScopeFailsLeft > 0) {
+        floodScopeFailsLeft -= 1;
+        return { id: '1', success: false, error: 'transport closed' };
+      }
+      if (opts.floodScopeDelayMs) {
+        await new Promise((r) => setTimeout(r, opts.floodScopeDelayMs));
+      }
     }
     return { id: '1', success: true, data: {} };
   };
@@ -216,8 +224,27 @@ describe('MeshCoreManager — Phase 2: scope on originated flood traffic (#3667)
     expect(scopeOf(bridgeCalls)).toEqual([null]);
   });
 
+  it('asserts the default scope before a remote CLI command', async () => {
+    const { manager, bridgeCalls } = makeManager({ defaultScope: 'berlin' });
+    // The reply never arrives in the harness, so the command times out — but by
+    // then the scope-assert→send ordering is already observable.
+    await expect(manager.sendCliCommand('ab'.repeat(32), 'ver', { timeoutMs: 50 }))
+      .rejects.toThrow(/timed out/);
+    expect(seq(bridgeCalls, 'send_cli')).toEqual(['set_flood_scope', 'send_cli']);
+  });
+
+  it('rejects a CLI command without sending when the scope assertion fails', async () => {
+    const { manager, bridgeCalls } = makeManager({ defaultScope: 'berlin', failFloodScopeTimes: 1 });
+    await expect(manager.sendCliCommand('ab'.repeat(32), 'ver', { timeoutMs: 1000 }))
+      .rejects.toThrow('transport closed');
+    expect(bridgeCalls.some(c => c.cmd === 'send_cli')).toBe(false);
+  });
+
   it('serialises an advert (default scope) concurrent with a channel send (channel scope)', async () => {
-    const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: 'muenchen' }, defaultScope: 'berlin' });
+    // floodScopeDelayMs forces a real yield between scope-assert and send, so a
+    // broken lock would let the second send interleave — the ordering assertion
+    // below would then fail.
+    const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: 'muenchen' }, defaultScope: 'berlin', floodScopeDelayMs: 5 });
     // Advert first, then a channel message — both serialise on the same lock.
     await Promise.all([
       manager.sendAdvert(),

--- a/src/server/meshcoreManager.scope.test.ts
+++ b/src/server/meshcoreManager.scope.test.ts
@@ -182,3 +182,58 @@ describe('MeshCoreManager — setChannel / setDefaultScope scope handling (#3667
     expect(await manager.setDefaultScope('  ')).toBe('');
   });
 });
+
+describe('MeshCoreManager — Phase 2: scope on originated flood traffic (#3667)', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  // Sequence of scope-asserts + the originated command under test.
+  const seq = (calls: BridgeCall[], cmd: string) =>
+    calls.filter(c => c.cmd === 'set_flood_scope' || c.cmd === cmd).map(c => c.cmd);
+
+  it('asserts the default scope before a companion advert', async () => {
+    const { manager, bridgeCalls } = makeManager({ defaultScope: 'berlin' });
+    const ok = await manager.sendAdvert();
+    expect(ok).toBe(true);
+    expect(seq(bridgeCalls, 'send_advert')).toEqual(['set_flood_scope', 'send_advert']);
+    expect(scopeOf(bridgeCalls)).toEqual(['berlin']);
+  });
+
+  it('asserts the default scope before a remote login', async () => {
+    const { manager, bridgeCalls } = makeManager({ defaultScope: 'berlin' });
+    await manager.loginToNode('deadbeef', 'pw');
+    expect(seq(bridgeCalls, 'login')).toEqual(['set_flood_scope', 'login']);
+  });
+
+  it('asserts the default scope before a telemetry request', async () => {
+    const { manager, bridgeCalls } = makeManager({ defaultScope: 'berlin' });
+    await manager.requestRemoteTelemetry('deadbeef');
+    expect(seq(bridgeCalls, 'request_telemetry')).toEqual(['set_flood_scope', 'request_telemetry']);
+  });
+
+  it('asserts unscoped (null) for originated traffic when no default scope is set', async () => {
+    const { manager, bridgeCalls } = makeManager({});
+    await manager.sendAdvert();
+    expect(scopeOf(bridgeCalls)).toEqual([null]);
+  });
+
+  it('serialises an advert (default scope) concurrent with a channel send (channel scope)', async () => {
+    const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: 'muenchen' }, defaultScope: 'berlin' });
+    // Advert first, then a channel message — both serialise on the same lock.
+    await Promise.all([
+      manager.sendAdvert(),
+      manager.sendMessage('hi', undefined, 1),
+    ]);
+    // Each scope is asserted immediately before its own send — never interleaved.
+    const relevant = bridgeCalls
+      .filter(c => ['set_flood_scope', 'send_advert', 'send_message'].includes(c.cmd))
+      .map(c => c.cmd === 'set_flood_scope' ? `scope:${c.params.region}` : c.cmd);
+    expect(relevant).toEqual(['scope:berlin', 'send_advert', 'scope:muenchen', 'send_message']);
+  });
+
+  it('does not emit the advert when the scope assertion fails', async () => {
+    const { manager, bridgeCalls } = makeManager({ defaultScope: 'berlin', failFloodScopeTimes: 1 });
+    const ok = await manager.sendAdvert();
+    expect(ok).toBe(false);
+    expect(bridgeCalls.some(c => c.cmd === 'send_advert')).toBe(false);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1999,7 +1999,7 @@ class MeshCoreManager extends EventEmitter {
    */
   private async sendWithDefaultScope<T>(fn: () => Promise<T>): Promise<T> {
     return this.runSerialized(async () => {
-      await this.applyFloodScope(await this.resolveScopeForSend(undefined));
+      await this.applyFloodScope(await this.resolveScopeForSend());
       return fn();
     });
   }
@@ -3171,6 +3171,13 @@ class MeshCoreManager extends EventEmitter {
       // carries the default scope (#3667). The scope assertion is serialised
       // with all other sends; if it fails the command rejects rather than
       // leaving un-scoped.
+      //
+      // Intentionally fire-and-forget (`void` + `.then`/`.catch`) rather than
+      // `await`ed: we're already inside the per-prefix `cliCommandLocks` chain,
+      // and awaiting the global `sendScopeLock` here would nest the two locks.
+      // Keeping it non-awaited means neither lock is held while waiting on the
+      // other. A scope-assert failure still surfaces — it rejects via the
+      // `.catch` below, which clears the timer and rejects the outer promise.
       void this.sendWithDefaultScope(() => this.sendBridgeCommand('send_cli', { public_key: fullKey, text: command }, timeoutMs))
         .then((resp) => {
           if (!resp.success) {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1972,11 +1972,36 @@ class MeshCoreManager extends EventEmitter {
     // Serialise the scope-assert→send pair per source (#3667). The device's
     // flood scope is a single global setting; two concurrent sends with
     // different scopes must not interleave, or a message could ship under the
-    // wrong region. Chain on the lock and keep the chain alive regardless of
-    // this send's outcome.
-    const task = this.sendScopeLock.then(() => this.performScopedSend(text, toPublicKey, channelIdx));
+    // wrong region.
+    return this.runSerialized(() => this.performScopedSend(text, toPublicKey, channelIdx));
+  }
+
+  /**
+   * Serialise an originated send on the per-source scope lock so the global
+   * device flood scope can't be changed by another send mid-flight (#3667).
+   * The lock chain continues on both success and failure so one failed send
+   * can't wedge the queue.
+   */
+  private runSerialized<T>(fn: () => Promise<T>): Promise<T> {
+    const task = this.sendScopeLock.then(fn);
     this.sendScopeLock = task.then(() => undefined, () => undefined);
     return task;
+  }
+
+  /**
+   * Assert the source default scope on the device (serialised with all other
+   * sends) and then run `fn`. For flood-originating traffic that is NOT a
+   * channel message — adverts, logins, telemetry/CLI/stats requests
+   * (#3667 phase 2). If the scope can't be asserted, `fn` does not run and the
+   * error propagates, so nothing leaves un-scoped in a `region denyf *` mesh.
+   * (Zero-hop traffic like node discovery is exempt — it is never repeater-
+   * forwarded, so scope is irrelevant.)
+   */
+  private async sendWithDefaultScope<T>(fn: () => Promise<T>): Promise<T> {
+    return this.runSerialized(async () => {
+      await this.applyFloodScope(await this.resolveScopeForSend(undefined));
+      return fn();
+    });
   }
 
   /**
@@ -2089,7 +2114,9 @@ class MeshCoreManager extends EventEmitter {
       }
     } else {
       try {
-        const response = await this.sendBridgeCommand('send_advert', {});
+        // Adverts flood, so they carry the default scope (#3667). Repeaters
+        // (handled above) scope via their own `region` config instead.
+        const response = await this.sendWithDefaultScope(() => this.sendBridgeCommand('send_advert', {}));
         if (response.success) {
           logger.info('[MeshCore] Advert sent (Companion)');
           return true;
@@ -2716,10 +2743,12 @@ class MeshCoreManager extends EventEmitter {
     }
 
     try {
-      const response = await this.sendBridgeCommand('login', {
+      // A login request floods when the path to the node is unknown, so it
+      // carries the default scope (#3667).
+      const response = await this.sendWithDefaultScope(() => this.sendBridgeCommand('login', {
         public_key: publicKey,
         password: password,
-      });
+      }));
 
       if (response.success) {
         logger.info(`[MeshCore] Logged into node ${publicKey.substring(0, 8)}...`);
@@ -3138,7 +3167,11 @@ class MeshCoreManager extends EventEmitter {
         sentAt,
       });
 
-      void this.sendBridgeCommand('send_cli', { public_key: fullKey, text: command }, timeoutMs)
+      // A CLI command to a remote node floods when its path is unknown, so it
+      // carries the default scope (#3667). The scope assertion is serialised
+      // with all other sends; if it fails the command rejects rather than
+      // leaving un-scoped.
+      void this.sendWithDefaultScope(() => this.sendBridgeCommand('send_cli', { public_key: fullKey, text: command }, timeoutMs))
         .then((resp) => {
           if (!resp.success) {
             clearTimeout(timer);
@@ -3529,8 +3562,9 @@ class MeshCoreManager extends EventEmitter {
       }
       // request_telemetry can wait several seconds on the air; widen the
       // command timeout so a slow node doesn't trip the default 30s ceiling
-      // on a back-to-back retry.
-      const response = await this.sendBridgeCommand('request_telemetry', params, 45_000);
+      // on a back-to-back retry. It floods when the path is unknown, so it
+      // carries the default scope (#3667).
+      const response = await this.sendWithDefaultScope(() => this.sendBridgeCommand('request_telemetry', params, 45_000));
       if (!response.success) {
         logger.warn(
           `[MeshCore:${this.sourceId}] requestRemoteTelemetry(${publicKey.substring(0, 16)}…) failed: ${response.error}`,


### PR DESCRIPTION
## Summary

**Phase 2** of MeshCore region/scope support (#3667), building on the merged Phase 1 (#3669). Phase 1 scoped channel/DM messages; this extends the same per-source scope mutex to **every other flood-originating send**, so MeshMonitor is fully usable in a `region denyf *` mesh (which drops un-scoped flood traffic).

## Changes
- New helpers on `MeshCoreManager`:
  - `runSerialized(fn)` — serialize a send on the per-source scope lock (extracted from Phase 1's inline chain; `sendMessage` now uses it).
  - `sendWithDefaultScope(fn)` — assert the source **default** scope (serialized) then run `fn`; if the scope can't be asserted, `fn` does not run (nothing leaves un-scoped).
- Applied `sendWithDefaultScope` to the originated-flood sends:
  - **`sendAdvert`** (companion branch) — repeaters scope via their own `region` config, so the repeater branch is untouched.
  - **`loginToNode`** (remote admin login)
  - **`requestRemoteTelemetry`**
  - **`sendCliCommand`** (remote CLI)
- **Transitively covered:** auto-announce / timer advert bursts and auto-ack/announce messages already route through `sendAdvert` / `sendMessage`.
- **Intentionally exempt:** node discovery — it's zero-hop and never repeater-forwarded, so scope is irrelevant.

## Why these and not others
Config/local-only commands (`set_channel`, radio params, `get_*`, reboot, etc.) don't transmit a packet onto the mesh, and direct-routed traffic (trace along a known path) isn't flood-forwarded — neither needs a scope assertion.

## Testing
- ✅ `tsc` server typecheck clean
- ✅ Full Vitest suite green (7334 passed, 0 failed)
- New tests: advert/login/telemetry assert default scope before the command; unscoped fallback; **advert-concurrent-with-channel-send serialization** (each scope asserted immediately before its own send); scope-assertion failure aborts the advert.

## Follow-up
- Phase 3: region discovery from nearby repeaters (companion-protocol mechanism still TBD).

Part of #3667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)