### PR TITLE
feat(meshcore): region discovery from nearby repeaters — phase 3 (#3667)

### DIFF
--- a/docs/internal/dev-notes/MESHCORE_REGION_SCOPE_PLAN.md
+++ b/docs/internal/dev-notes/MESHCORE_REGION_SCOPE_PLAN.md
@@ -2,10 +2,11 @@
 
 Tracking issue: **#3667** ([FEAT] MeshCore: Region/Scope Support)
 
-> Status: **Phase 1 merged** (PR #3669, migration 100). **Phase 2 in progress** —
-> scoping all originated flood traffic (adverts, logins, telemetry/CLI requests)
-> via the shared `sendWithDefaultScope` helper on the per-source send mutex.
-> Phase 3 (region discovery) not started.
+> Status: **Phase 1 merged** (PR #3669, migration 100). **Phase 2 merged**
+> (PR #3673) — all originated flood traffic scoped via `sendWithDefaultScope`.
+> **Phase 3 in progress** — region discovery from nearby repeaters via the
+> firmware ANON_REQ regions request (CMD 57 → BinaryResponse 0x8C), implemented
+> in MeshMonitor's native backend with no meshcore.js fork change.
 
 ## 1. Background — how scopes/regions work in MeshCore
 

--- a/src/components/MeshCore/MeshCoreSettingsView.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.tsx
@@ -54,6 +54,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
       }
       setDefaultScopeState(result);
       setScopeInput(result);
+      setDiscoveredRegions(null); // collapse the suggestion chips once applied
       showToast(t('meshcore.scope.saved', 'Default scope saved'), 'success');
     } finally {
       setSavingScope(false);
@@ -180,7 +181,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
           <div style={{ display: 'flex', gap: '0.5rem' }}>
             <button
               onClick={() => void handleDiscover('nearby')}
-              disabled={!connected || loading || discovering !== null}
+              disabled={!connected || loading || discovering !== null || discoveringRegions}
             >
               {discovering === 'nearby'
                 ? t('meshcore.discover.running', 'Discovering…')
@@ -188,7 +189,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
             </button>
             <button
               onClick={() => void handleDiscover('repeaters')}
-              disabled={!connected || loading || discovering !== null}
+              disabled={!connected || loading || discovering !== null || discoveringRegions}
             >
               {discovering === 'repeaters'
                 ? t('meshcore.discover.running', 'Discovering…')
@@ -196,7 +197,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
             </button>
             <button
               onClick={() => void handleDiscover('sensors')}
-              disabled={!connected || loading || discovering !== null}
+              disabled={!connected || loading || discovering !== null || discoveringRegions}
             >
               {discovering === 'sensors'
                 ? t('meshcore.discover.running', 'Discovering…')
@@ -253,7 +254,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
           <div style={{ marginTop: '0.75rem' }}>
             <button
               onClick={() => void handleDiscoverRegions()}
-              disabled={!connected || loading || discoveringRegions}
+              disabled={!connected || loading || discoveringRegions || discovering !== null}
             >
               {discoveringRegions
                 ? t('meshcore.scope.discovering', 'Discovering regions…')

--- a/src/components/MeshCore/MeshCoreSettingsView.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.tsx
@@ -26,13 +26,16 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
   const [discovering, setDiscovering] = useState<'nearby' | 'repeaters' | 'sensors' | null>(null);
   // "Be discoverable" toggle — whether we answer inbound discovery requests.
   const [discoverable, setDiscoverableState] = useState(false);
-  const { getDiscoverable, setDiscoverable, getDefaultScope, setDefaultScope } = actions;
+  const { getDiscoverable, setDiscoverable, getDefaultScope, setDefaultScope, discoverRegions } = actions;
 
   // Default region/scope (#3667). `defaultScope` is the persisted value;
   // `scopeInput` is the editable field (so we can show a dirty state).
   const [defaultScope, setDefaultScopeState] = useState('');
   const [scopeInput, setScopeInput] = useState('');
   const [savingScope, setSavingScope] = useState(false);
+  // Region discovery (#3667 phase 3) — names served by nearby repeaters.
+  const [discoveredRegions, setDiscoveredRegions] = useState<string[] | null>(null);
+  const [discoveringRegions, setDiscoveringRegions] = useState(false);
 
   useEffect(() => {
     if (connected && isCompanion) {
@@ -54,6 +57,26 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
       showToast(t('meshcore.scope.saved', 'Default scope saved'), 'success');
     } finally {
       setSavingScope(false);
+    }
+  };
+
+  const handleDiscoverRegions = async () => {
+    setDiscoveringRegions(true);
+    try {
+      const result = await discoverRegions();
+      if (!result) {
+        showToast(t('meshcore.scope.discover_failed', 'Failed to discover regions'), 'error');
+        return;
+      }
+      setDiscoveredRegions(result.regions);
+      if (result.regions.length === 0) {
+        showToast(
+          t('meshcore.scope.discover_none', 'No regions found. Try "Discover Repeaters" first, then retry.'),
+          'info',
+        );
+      }
+    } finally {
+      setDiscoveringRegions(false);
     }
   };
 
@@ -225,6 +248,41 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
             >
               {savingScope ? t('common.saving', 'Saving…') : t('common.save', 'Save')}
             </button>
+          </div>
+
+          <div style={{ marginTop: '0.75rem' }}>
+            <button
+              onClick={() => void handleDiscoverRegions()}
+              disabled={!connected || loading || discoveringRegions}
+            >
+              {discoveringRegions
+                ? t('meshcore.scope.discovering', 'Discovering regions…')
+                : t('meshcore.scope.discover', 'Discover regions from repeaters')}
+            </button>
+            <p className="hint" style={{ fontSize: '0.8rem', marginTop: '0.25rem' }}>
+              {t('meshcore.scope.discover_hint',
+                'Queries known repeaters for the regions they serve. Run "Discover Repeaters" (above) first for the fullest list.')}
+            </p>
+            {discoveredRegions && discoveredRegions.length > 0 && (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', marginTop: '0.5rem' }}>
+                {discoveredRegions.map((region) => (
+                  <button
+                    key={region}
+                    type="button"
+                    onClick={() => setScopeInput(region)}
+                    title={t('meshcore.scope.use_region', 'Use "{{region}}" as the default scope', { region })}
+                    style={{
+                      padding: '0.2rem 0.6rem',
+                      borderRadius: 999,
+                      border: '1px solid var(--ctp-blue)',
+                      background: scopeInput.trim().replace(/^#/, '') === region ? 'var(--ctp-blue)' : 'transparent',
+                    }}
+                  >
+                    {region}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -133,6 +133,8 @@ export interface MeshCoreActions {
   getDefaultScope: () => Promise<string>;
   /** Set the per-source default region/scope. Returns the normalized value, or null on error. */
   setDefaultScope: (scope: string) => Promise<string | null>;
+  /** Discover region/scope names served by nearby repeaters (#3667 phase 3). */
+  discoverRegions: () => Promise<{ regions: string[]; perRepeater: Array<{ publicKey: string; name: string; regions: string[] }> } | null>;
   /** Remove a contact from the device's contact list. Resolves `true` when
    *  the device ACKed the removal; `false` for any error. */
   removeContact: (publicKey: string) => Promise<boolean>;
@@ -763,6 +765,24 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       return typeof data.scope === 'string' ? data.scope : '';
     } catch (_err) {
       setError('Failed to update default scope');
+      return null;
+    }
+  }, [mcPrefix, csrfFetch]);
+
+  const discoverRegions = useCallback(async () => {
+    try {
+      const response = await csrfFetch(`${mcPrefix}/regions/discover`, { method: 'POST' });
+      const data = await response.json();
+      if (!data.success) {
+        setError(data.error || 'Failed to discover regions');
+        return null;
+      }
+      return {
+        regions: Array.isArray(data.regions) ? data.regions : [],
+        perRepeater: Array.isArray(data.perRepeater) ? data.perRepeater : [],
+      };
+    } catch (_err) {
+      setError('Failed to discover regions');
       return null;
     }
   }, [mcPrefix, csrfFetch]);
@@ -1425,6 +1445,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       setDiscoverable,
       getDefaultScope,
       setDefaultScope,
+      discoverRegions,
       shareContact,
       setContactOutPath,
       traceContactPath,

--- a/src/server/meshcoreManager.scope.test.ts
+++ b/src/server/meshcoreManager.scope.test.ts
@@ -25,10 +25,18 @@ function makeManager(opts: {
   /** make `set_flood_scope` await a real macrotask so interleaving is actually
    *  exercised (the lock must hold scope-assert→send together) */
   floodScopeDelayMs?: number;
+  /** contacts to seed for region discovery (advType 2=repeater, 3=room) */
+  contacts?: Array<{ publicKey: string; advType: number; name?: string }>;
+  /** per-repeater `request_regions` replies, keyed by publicKey. A value of
+   *  'fail' makes that repeater's request reject. */
+  regionsByRepeater?: Record<string, string[] | 'fail'>;
 } = {}): { manager: MeshCoreManager; bridgeCalls: BridgeCall[]; scopeUpdates: Array<{ id: number; scope: string | null }> } {
   const m = new MeshCoreManager('test-source');
   (m as any).deviceType = MeshCoreDeviceType.COMPANION;
   (m as any).connected = true;
+  if (opts.contacts) {
+    (m as any).contacts = new Map(opts.contacts.map((c) => [c.publicKey, c]));
+  }
 
   const bridgeCalls: BridgeCall[] = [];
   const scopeUpdates: Array<{ id: number; scope: string | null }> = [];
@@ -37,6 +45,12 @@ function makeManager(opts: {
   (m as any).sendBridgeCommand = async (cmd: string, params: Record<string, unknown>) => {
     bridgeCalls.push({ cmd, params });
     if (cmd === 'get_channels') return { id: '1', success: true, data: [] };
+    if (cmd === 'request_regions') {
+      const pk = params.public_key as string;
+      const r = opts.regionsByRepeater?.[pk];
+      if (r === 'fail') throw new Error('repeater did not answer');
+      return { id: '1', success: true, data: { clock: 0, regions: r ?? [] } };
+    }
     if (cmd === 'set_flood_scope') {
       if (floodScopeFailsLeft > 0) {
         floodScopeFailsLeft -= 1;
@@ -262,5 +276,58 @@ describe('MeshCoreManager — Phase 2: scope on originated flood traffic (#3667)
     const ok = await manager.sendAdvert();
     expect(ok).toBe(false);
     expect(bridgeCalls.some(c => c.cmd === 'send_advert')).toBe(false);
+  });
+});
+
+describe('MeshCoreManager — Phase 3: region discovery (#3667)', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('queries repeater/room contacts and returns the de-duplicated, sorted region set', async () => {
+    const { manager, bridgeCalls } = makeManager({
+      contacts: [
+        { publicKey: 'aa'.repeat(32), advType: 2, name: 'Rptr-A' }, // repeater
+        { publicKey: 'bb'.repeat(32), advType: 3, name: 'Room-B' },  // room server
+        { publicKey: 'cc'.repeat(32), advType: 0, name: 'Chat-C' },  // plain chat — must be skipped
+      ],
+      regionsByRepeater: {
+        ['aa'.repeat(32)]: ['muenchen', 'bayern', '*'], // '*' wildcard must be filtered
+        ['bb'.repeat(32)]: ['bayern', 'augsburg'],       // 'bayern' overlaps → deduped
+      },
+    });
+
+    const result = await manager.discoverRegions();
+
+    // Only the two infra contacts were queried (chat contact skipped).
+    expect(bridgeCalls.filter(c => c.cmd === 'request_regions').map(c => c.params.public_key))
+      .toEqual(['aa'.repeat(32), 'bb'.repeat(32)]);
+    // De-duplicated, sorted, wildcard removed.
+    expect(result.regions).toEqual(['augsburg', 'bayern', 'muenchen']);
+    expect(result.perRepeater).toHaveLength(2);
+    expect(result.perRepeater[0].regions).toEqual(['muenchen', 'bayern']);
+  });
+
+  it('skips repeaters that do not answer and still returns the rest', async () => {
+    const { manager } = makeManager({
+      contacts: [
+        { publicKey: 'aa'.repeat(32), advType: 2 },
+        { publicKey: 'bb'.repeat(32), advType: 2 },
+      ],
+      regionsByRepeater: {
+        ['aa'.repeat(32)]: 'fail',
+        ['bb'.repeat(32)]: ['muenchen'],
+      },
+    });
+    const result = await manager.discoverRegions();
+    expect(result.regions).toEqual(['muenchen']);
+    expect(result.perRepeater.map(r => r.publicKey)).toEqual(['bb'.repeat(32)]);
+  });
+
+  it('returns empty when there are no repeater contacts', async () => {
+    const { manager, bridgeCalls } = makeManager({
+      contacts: [{ publicKey: 'cc'.repeat(32), advType: 0 }],
+    });
+    const result = await manager.discoverRegions();
+    expect(result).toEqual({ regions: [], perRepeater: [] });
+    expect(bridgeCalls.some(c => c.cmd === 'request_regions')).toBe(false);
   });
 });

--- a/src/server/meshcoreManager.scope.test.ts
+++ b/src/server/meshcoreManager.scope.test.ts
@@ -330,4 +330,15 @@ describe('MeshCoreManager — Phase 3: region discovery (#3667)', () => {
     expect(result).toEqual({ regions: [], perRepeater: [] });
     expect(bridgeCalls.some(c => c.cmd === 'request_regions')).toBe(false);
   });
+
+  it('returns empty on a non-companion device without querying', async () => {
+    const { manager, bridgeCalls } = makeManager({
+      contacts: [{ publicKey: 'aa'.repeat(32), advType: 2 }],
+      regionsByRepeater: { ['aa'.repeat(32)]: ['muenchen'] },
+    });
+    (manager as any).deviceType = MeshCoreDeviceType.REPEATER;
+    const result = await manager.discoverRegions();
+    expect(result).toEqual({ regions: [], perRepeater: [] });
+    expect(bridgeCalls.some(c => c.cmd === 'request_regions')).toBe(false);
+  });
 });

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2300,6 +2300,46 @@ class MeshCoreManager extends EventEmitter {
   }
 
   /**
+   * Discover the region/scope names served by nearby repeaters (#3667 phase 3).
+   * Queries each known repeater / room-server contact with a "regions request"
+   * (firmware ANON_REQ sub-type 0x01) and collects the region names each one
+   * reports. Like the official app, coverage depends on which repeaters are in
+   * the contact list — run "Discover Repeaters" first for the fullest picture.
+   *
+   * Queries are issued sequentially: the firmware's per-request `tag` only
+   * arrives on the `Sent` ack, so overlapping requests could cross-match
+   * replies. The wildcard `*` (null region) is filtered out — it isn't a
+   * selectable scope. Repeaters that don't answer in time are skipped.
+   */
+  async discoverRegions(): Promise<{
+    regions: string[];
+    perRepeater: Array<{ publicKey: string; name: string; regions: string[] }>;
+  }> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
+      return { regions: [], perRepeater: [] };
+    }
+    const repeaters = [...this.contacts.values()].filter(
+      (c) => c.advType === MeshCoreDeviceType.REPEATER || c.advType === MeshCoreDeviceType.ROOM_SERVER,
+    );
+    const perRepeater: Array<{ publicKey: string; name: string; regions: string[] }> = [];
+    const all = new Set<string>();
+    for (const r of repeaters) {
+      try {
+        const resp = await this.sendBridgeCommand('request_regions', { public_key: r.publicKey }, 20_000);
+        if (!resp.success) continue;
+        const regions: string[] = (Array.isArray(resp.data?.regions) ? resp.data.regions : [])
+          .map((x: unknown) => String(x).trim())
+          .filter((x: string) => x.length > 0 && x !== '*');
+        perRepeater.push({ publicKey: r.publicKey, name: r.name || r.advName || r.publicKey.substring(0, 12), regions });
+        regions.forEach((x) => all.add(x));
+      } catch (err) {
+        logger.debug(`[MeshCore:${this.sourceId}] regions request to ${r.publicKey.substring(0, 12)}… failed: ${(err as Error).message}`);
+      }
+    }
+    return { regions: [...all].sort((a, b) => a.localeCompare(b)), perRepeater };
+  }
+
+  /**
    * Trace the cached forwarding path to a contact, collecting per-hop SNR.
    * The contact must have a known `outPath`; trace path sends a diagnostic
    * packet along that exact route and each repeater appends its received

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2326,7 +2326,10 @@ class MeshCoreManager extends EventEmitter {
     for (const r of repeaters) {
       try {
         const resp = await this.sendBridgeCommand('request_regions', { public_key: r.publicKey }, 20_000);
-        if (!resp.success) continue;
+        if (!resp.success) {
+          logger.debug(`[MeshCore:${this.sourceId}] regions request to ${r.publicKey.substring(0, 12)}… returned an error: ${resp.error}`);
+          continue;
+        }
         const regions: string[] = (Array.isArray(resp.data?.regions) ? resp.data.regions : [])
           .map((x: unknown) => String(x).trim())
           .filter((x: string) => x.length > 0 && x !== '*');

--- a/src/server/meshcoreNativeBackend.discovery.test.ts
+++ b/src/server/meshcoreNativeBackend.discovery.test.ts
@@ -22,7 +22,7 @@ const ResponseCodes = {
 };
 const PushCodes = {
   Advert: 0x80, PathUpdated: 0x81, MsgWaiting: 0x83, NewAdvert: 0x8a,
-  ControlData: 0x8e,
+  BinaryResponse: 0x8c, ControlData: 0x8e,
 };
 const StatsTypes = { Core: 0, Radio: 1, Packets: 2 };
 const SelfAdvertTypes = { ZeroHop: 0, Flood: 1 };
@@ -33,15 +33,26 @@ const TxtTypes = { Plain: 0, CliData: 1, SignedPlain: 2 };
 class MockConnection extends EventEmitter {
   sentFrames: Uint8Array[] = [];
   addOrUpdateContact = vi.fn().mockResolvedValue(undefined);
+  /** Reply bytes a `request_regions` (CMD 57) frame should produce. */
+  regionsResponseData: Uint8Array | null = null;
   async connect() { /* no-op */ }
   async close() { /* no-op */ }
   async getSelfInfo() {
     return { type: AdvType.Chat, publicKey: Uint8Array.from(Array(32).fill(0)), name: 'TestNode' };
   }
-  // The discover_nodes command sends the frame then waits for an OK ack.
   sendToRadioFrame(frame: Uint8Array) {
     this.sentFrames.push(frame);
-    // Ack on the next tick so the awaiting command resolves.
+    if (frame[0] === 57) {
+      // CMD_SEND_ANON_REQ (regions): reply with a Sent ack (carrying the tag)
+      // then the BinaryResponse push with the canned region bytes.
+      const tag = 0x99;
+      setImmediate(() => {
+        this.emit(ResponseCodes.Sent, { expectedAckCrc: tag, estTimeout: 1000 });
+        this.emit(PushCodes.BinaryResponse, { reserved: 0, tag, responseData: this.regionsResponseData ?? new Uint8Array() });
+      });
+      return;
+    }
+    // discover_nodes (CMD 55) and others: ack with OK on the next tick.
     setImmediate(() => this.emit(ResponseCodes.Ok));
   }
 }
@@ -239,5 +250,32 @@ describe('MeshCoreNativeBackend — discovery responder', () => {
       conn.emit('rx', buildDiscoverReq({ snrX4: 12, filter: selfTypeBit, tag: 0x40000000 + i }));
     }
     expect(conn.sentFrames.filter((f) => f[0] === 55).length).toBe(4);
+  });
+
+  it('request_regions sends [57, pubkey, 0x01, 0x00] and parses clock + region names (#3667)', async () => {
+    const { backend, conn } = await connectedBackend();
+    // clock(4 LE)=1 + "muenchen,bayern,*" + NUL + trailing junk (must be ignored)
+    conn.regionsResponseData = Uint8Array.from([
+      1, 0, 0, 0,
+      ...Buffer.from('muenchen,bayern,*', 'ascii'),
+      0,
+      ...Buffer.from('JUNK', 'ascii'),
+    ]);
+
+    const res = await backend.sendCommand('request_regions', { public_key: 'aa'.repeat(32) });
+    expect(res.success).toBe(true);
+
+    // Outbound frame layout: CMD 57 + 32-byte pubkey + req_type 0x01 + reply_path_len 0.
+    const frame = conn.sentFrames.at(-1)!;
+    expect(frame.length).toBe(1 + 32 + 2);
+    expect(frame[0]).toBe(57);
+    expect(Array.from(frame.slice(1, 33))).toEqual(Array(32).fill(0xaa));
+    expect(frame[33]).toBe(0x01);
+    expect(frame[34]).toBe(0x00);
+
+    // Parsed reply: clock from the first 4 bytes, names split on ',' up to the
+    // NUL. The wildcard '*' is preserved here (the manager filters it).
+    expect(res.data.clock).toBe(1);
+    expect(res.data.regions).toEqual(['muenchen', 'bayern', '*']);
   });
 });

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -960,8 +960,10 @@ export class MeshCoreNativeBackend extends EventEmitter {
           }, timeoutMs);
           const onSent = (r: any) => { tag = (r?.expectedAckCrc ?? null); };
           const onResp = (r: any) => {
-            // Match the reply to our request by tag once the Sent ack has set it.
-            if (tag !== null && r?.tag !== tag) return;
+            // Only accept the reply once the Sent ack has given us our tag (the
+            // firmware always sends Sent before the BinaryResponse). A response
+            // arriving before that, or carrying a different tag, isn't ours.
+            if (tag === null || r?.tag !== tag) return;
             cleanup();
             resolve((r?.responseData ?? new Uint8Array()) as Uint8Array);
           };

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -931,6 +931,65 @@ export class MeshCoreNativeBackend extends EventEmitter {
         return { ok: true };
       }
 
+      case 'request_regions': {
+        // Ask a repeater/room-server for its allowed region/scope list (#3667
+        // phase 3). Sends CMD_SEND_ANON_REQ (57) with the "regions" sub-type
+        // (0x01); the node replies with PUSH_CODE_BINARY_RESPONSE (0x8C)
+        // carrying clock(4 LE) + a NUL-terminated, comma-separated ASCII list
+        // of region names (the wildcard '*' is the legacy null region). This
+        // command isn't in meshcore.js, so we build the raw frame and match the
+        // reply by tag, mirroring the library's sendBinaryRequest().
+        const publicKey = await this.resolvePublicKey(params.public_key as string);
+        if (!publicKey || publicKey.length !== 32) {
+          throw new Error('request_regions: repeater public key not found');
+        }
+        const timeoutMs = Number(params.timeout_ms) || 15_000;
+        const K = this.constants!;
+        // Frame: [57][pubkey:32][0x01 regions][0x00 reply_path_len → flood reply]
+        const frame = new Uint8Array(1 + 32 + 2);
+        frame[0] = 57; // CMD_SEND_ANON_REQ
+        frame.set(publicKey, 1);
+        frame[33] = 0x01; // ANON_REQ_TYPE_REGIONS
+        frame[34] = 0x00; // reply_path_len = 0
+
+        const responseData: Uint8Array = await new Promise((resolve, reject) => {
+          let tag: number | null = null;
+          let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+            cleanup();
+            reject(new Error('request_regions timed out'));
+          }, timeoutMs);
+          const onSent = (r: any) => { tag = (r?.expectedAckCrc ?? null); };
+          const onResp = (r: any) => {
+            // Match the reply to our request by tag once the Sent ack has set it.
+            if (tag !== null && r?.tag !== tag) return;
+            cleanup();
+            resolve((r?.responseData ?? new Uint8Array()) as Uint8Array);
+          };
+          const onErr = () => { cleanup(); reject(new Error('Device rejected regions request')); };
+          function cleanup() {
+            if (timer) { clearTimeout(timer); timer = null; }
+            c.off(K.ResponseCodes.Sent, onSent);
+            c.off(K.PushCodes.BinaryResponse, onResp);
+            c.off(K.ResponseCodes.Err, onErr);
+          }
+          // `on` (not `once`) so a non-matching binary response doesn't consume
+          // our listener; cleanup removes them once we resolve/fail.
+          c.on(K.ResponseCodes.Sent, onSent);
+          c.on(K.PushCodes.BinaryResponse, onResp);
+          c.once(K.ResponseCodes.Err, onErr);
+          void c.sendToRadioFrame(frame);
+        });
+
+        // Parse: clock(4 LE) + NUL-terminated, comma-separated ASCII names.
+        const buf = Buffer.from(responseData);
+        const clock = buf.length >= 4 ? buf.readUInt32LE(0) : 0;
+        let end = buf.indexOf(0, 4);
+        if (end < 0) end = buf.length;
+        const namesStr = buf.length > 4 ? buf.toString('ascii', 4, end) : '';
+        const regions = namesStr.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+        return { ok: true, clock, regions };
+      }
+
       case 'trace_path': {
         const pathBytes = params.path as Uint8Array | number[] | undefined;
         if (!pathBytes || (Array.isArray(pathBytes) ? pathBytes.length : pathBytes.byteLength) === 0) {

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -541,12 +541,15 @@ router.post(
  * de-duplicated set plus a per-repeater breakdown. Coverage depends on which
  * repeaters are in the contact list; run POST /discover (mode 'repeaters')
  * first for the fullest picture.
+ *
+ * Requires 'nodes' 'write' — like POST /discover, this transmits radio frames
+ * (a regions request to each repeater), not just a DB read.
  */
 router.post(
   '/regions/discover',
   meshcoreDeviceLimiter,
   requireAuth(),
-  requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }),
+  requirePermission('nodes', 'write', { sourceIdFrom: 'params.id' }),
   async (req: Request, res: Response) => {
     try {
       const result = await managerFor(req).discoverRegions();

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -534,6 +534,31 @@ router.post(
 );
 
 /**
+ * POST /api/sources/:id/meshcore/regions/discover
+ *
+ * Region/scope discovery (#3667 phase 3) — queries each known repeater /
+ * room-server contact for the list of regions it serves, and returns the
+ * de-duplicated set plus a per-repeater breakdown. Coverage depends on which
+ * repeaters are in the contact list; run POST /discover (mode 'repeaters')
+ * first for the fullest picture.
+ */
+router.post(
+  '/regions/discover',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const result = await managerFor(req).discoverRegions();
+      res.json({ success: true, ...result });
+    } catch (error) {
+      logger.error('[API] Error discovering regions:', error);
+      res.status(500).json({ success: false, error: 'Failed to discover regions' });
+    }
+  },
+);
+
+/**
  * GET /api/sources/:id/meshcore/config/discoverable
  *
  * Whether this node answers inbound discovery requests (is discoverable by


### PR DESCRIPTION
## Summary

**Phase 3** of MeshCore region/scope support (#3667), completing the feature. Phases 1+2 (merged) let users set per-channel and default scopes; this lets them **discover the regions nearby repeaters actually serve**, so they pick a valid scope instead of guessing.

## Mechanism
Per the firmware (`docs/payloads.md`), a "regions request" is an **ANON_REQ sub-type `0x01`** sent to a repeater via `CMD_SEND_ANON_REQ (57)`. The repeater replies with **`PUSH_CODE_BINARY_RESPONSE (0x8C)`** = `clock(4 LE)` + a NUL-terminated, comma-separated ASCII list of region names (`*` = legacy null region).

meshcore.js (ours **and** upstream) doesn't expose command 57 — but it **does** parse the `0x8C` reply. So we build the raw frame and tag-match the reply in the native backend. **No meshcore.js fork change required.**

## Changes
- **Native backend** — `request_regions` bridge command: builds `[57][pubkey:32][0x01][0x00]`, awaits `Sent`(tag) + `BinaryResponse(0x8C)`, parses clock + region names.
- **Manager** — `discoverRegions()`: queries each repeater/room-server contact **sequentially** (the firmware tag only arrives on the `Sent` ack, so overlapping requests could cross-match), de-dupes, drops the `*` wildcard, tolerates non-responders. The request is zero-hop/direct → no scope assertion needed.
- **Route** — `POST /api/sources/:id/meshcore/regions/discover`.
- **UI** — "Discover regions from repeaters" button in the default-scope section; results render as chips that fill the scope field on click.

## Coverage note
Like the official app, coverage depends on which repeaters are in the contact list — the UI hints to run "Discover Repeaters" first (see upstream [#1881](https://github.com/meshcore-dev/MeshCore/issues/1881)).

## Testing
- ✅ `tsc` typecheck clean (server + frontend)
- ✅ Full Vitest suite green (7340 passed, 0 failed)
- New tests: native-backend frame layout + reply parsing (clock / NUL termination / CSV / trailing junk); manager dedupe+sort, `*` filtering, non-repeater skip, non-responder tolerance.

Completes #3667 (Phases 1–3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)