### PR TITLE
fix(meshcore): clarify LPP telemetry WARN and stop pubkey nodeNum log spam

### DIFF
--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -3573,8 +3573,12 @@ class MeshCoreManager extends EventEmitter {
       // carries the default scope (#3667).
       const response = await this.sendWithDefaultScope(() => this.sendBridgeCommand('request_telemetry', params, 45_000));
       if (!response.success) {
+        // This is the LPP (environment telemetry) path specifically — name it
+        // so operators don't confuse it with the separate status/stats request
+        // that runs alongside it for repeater-like targets (#3676). An LPP
+        // timeout here is common and non-fatal; the status path is unaffected.
         logger.warn(
-          `[MeshCore:${this.sourceId}] requestRemoteTelemetry(${publicKey.substring(0, 16)}…) failed: ${response.error}`,
+          `[MeshCore:${this.sourceId}] requestRemoteTelemetry (LPP) (${publicKey.substring(0, 16)}…) failed: ${response.error}`,
         );
         return null;
       }
@@ -3584,7 +3588,7 @@ class MeshCoreManager extends EventEmitter {
       return records;
     } catch (error) {
       logger.warn(
-        `[MeshCore:${this.sourceId}] requestRemoteTelemetry(${publicKey.substring(0, 16)}…) threw:`,
+        `[MeshCore:${this.sourceId}] requestRemoteTelemetry (LPP) (${publicKey.substring(0, 16)}…) threw:`,
         error,
       );
       return null;

--- a/src/server/routes/telemetryRoutes.test.ts
+++ b/src/server/routes/telemetryRoutes.test.ts
@@ -77,6 +77,19 @@ describe('GET /telemetry/:nodeId', () => {
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
   });
+
+  it('skips the node lookup for a 64-hex MeshCore pubkey (no out-of-range nodeNum) (#3677)', async () => {
+    // A 64-char pubkey would overflow parseInt and trip getNode's
+    // out-of-range guard on every poll; the route must not call getNode.
+    (databaseService.getTelemetryByNodeAveragedAsync as any).mockResolvedValue([
+      { telemetryType: 'temperature', value: 20 },
+    ]);
+    const pubkey = 'a'.repeat(64);
+    const res = await request(app).get(`/telemetry/${pubkey}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(databaseService.nodes.getNode).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /telemetry/:nodeId/rates', () => {

--- a/src/server/routes/telemetryRoutes.ts
+++ b/src/server/routes/telemetryRoutes.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { optionalAuth, requireAuth, requirePermission, hasPermission } from '../auth/authMiddleware.js';
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
+import { isValidNodeNum } from '../constants/meshtastic.js';
 import {
   filterNodesByChannelPermission,
   checkNodeChannelAccess,
@@ -55,9 +56,17 @@ router.get('/telemetry/:nodeId', optionalAuth(), async (req: Request, res: Respo
     // Calculate cutoff timestamp for filtering
     const cutoffTime = Date.now() - hoursParam * 60 * 60 * 1000;
 
-    // Check if node has private position override
-    const nodeNum = parseInt(nodeId.replace('!', ''), 16);
-    const node = await databaseService.nodes.getNode(nodeNum, telSourceId);
+    // Check if node has private position override. Meshtastic nodeIds are an
+    // 8-hex nodeNum; MeshCore peers arrive here as a 64-hex public key, which
+    // overflows parseInt to ~6e+76 and trips the getNode out-of-range guard on
+    // every poll (#3677). Skip the lookup for non-Meshtastic ids — they have no
+    // Meshtastic position-override semantics, so isPrivate is simply false.
+    const nodeNum = /^[0-9a-fA-F]{64}$/.test(nodeId)
+      ? NaN
+      : parseInt(nodeId.replace('!', ''), 16);
+    const node = isValidNodeNum(nodeNum)
+      ? await databaseService.nodes.getNode(nodeNum, telSourceId)
+      : null;
     const isPrivate = node?.positionOverrideIsPrivate === true;
     const canViewPrivate = !!req.user && await hasPermission(req.user, 'nodes_private', 'read');
 


### PR DESCRIPTION
## Summary

Two small MeshCore telemetry log-clarity fixes.

### #3676 — ambiguous LPP timeout WARN
For repeater-like targets the scheduler runs two independent telemetry paths: **status** (`requestNodeStatus`) and **LPP** (`requestRemoteTelemetry`). A common, non-fatal LPP timeout logged:

```
[WARN] requestRemoteTelemetry(...) failed: timeout
[INFO] Wrote 16 telemetry rows ... (status:16)
```

which reads like a hard failure even though the status path succeeded. The WARN now names the path explicitly — `requestRemoteTelemetry (LPP) (...) failed: ...` — so operators can tell which path timed out. The sibling `threw` WARN is labeled the same way.

### #3677 — `rejecting out-of-range nodeNum 6.027...e+76` spam
`GET /api/telemetry/:nodeId` unconditionally ran `parseInt(nodeId, 16)` and called `getNode` to read the private-position flag. MeshCore peers arrive here as a **64-hex public key**, which overflows `parseInt` to ~6e+76 and trips `NodesRepository.getNode`'s out-of-range guard on **every poll** (the MeshCore Info view auto-refreshes). The lookup is now skipped for 64-hex ids — they have no Meshtastic position-override semantics, so `isPrivate` is simply `false`, and the warning stops.

## Testing

- Added a regression test asserting `getNode` is **not** called for a 64-hex pubkey id.
- Full Vitest suite: **7337 passed, 0 failed**.

Closes #3676
Closes #3677

🤖 Generated with [Claude Code](https://claude.com/claude-code)