### PR TITLE
feat(meshcore): manual telemetry poll buttons (#3674)

### DIFF
--- a/src/components/MeshCore/MeshCoreNodeTelemetryConfig.test.tsx
+++ b/src/components/MeshCore/MeshCoreNodeTelemetryConfig.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the manual telemetry-poll buttons (#3674) on the per-node
+ * MeshCore telemetry config panel.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MeshCoreNodeTelemetryConfig } from './MeshCoreNodeTelemetryConfig';
+
+const { csrfFetchMock, hasPermissionMock } = vi.hoisted(() => ({
+  csrfFetchMock: vi.fn(),
+  hasPermissionMock: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string | Record<string, unknown>) =>
+      typeof fallback === 'string' ? fallback : _key,
+  }),
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: hasPermissionMock }),
+}));
+
+vi.mock('../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => csrfFetchMock,
+}));
+
+const PK = 'a'.repeat(64);
+
+const okResponse = (body: unknown) => ({ ok: true, json: async () => body });
+
+const renderPanel = () =>
+  render(<MeshCoreNodeTelemetryConfig baseUrl="" sourceId="test-source" publicKey={PK} />);
+
+describe('MeshCoreNodeTelemetryConfig — manual poll buttons', () => {
+  beforeEach(() => {
+    hasPermissionMock.mockReset().mockReturnValue(true);
+    csrfFetchMock.mockReset().mockImplementation((_url: string, opts?: { method?: string; body?: string }) => {
+      if (opts?.method === 'POST') {
+        const type = JSON.parse(opts.body ?? '{}').type;
+        return Promise.resolve(okResponse({ success: true, data: { type, written: 16, sources: ['status:16'] } }));
+      }
+      // Initial telemetry-config GET on mount.
+      return Promise.resolve(
+        okResponse({ success: true, data: { enabled: false, intervalMinutes: 60, lastRequestAt: null } }),
+      );
+    });
+  });
+
+  it('renders both poll buttons once loaded', async () => {
+    renderPanel();
+    expect(await screen.findByText('Poll Status')).toBeInTheDocument();
+    expect(screen.getByText('Poll Environment (LPP)')).toBeInTheDocument();
+  });
+
+  it('POSTs { type: "status" } and shows the written-row count', async () => {
+    renderPanel();
+    const btn = await screen.findByText('Poll Status');
+    fireEvent.click(btn);
+
+    await waitFor(() =>
+      expect(csrfFetchMock).toHaveBeenCalledWith(
+        '/api/sources/test-source/meshcore/nodes/' + PK + '/telemetry/poll',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ type: 'status' }) }),
+      ),
+    );
+    await waitFor(() => expect(screen.getByText(/Wrote 16 telemetry row/)).toBeInTheDocument());
+  });
+
+  it('POSTs { type: "lpp" } for the environment button', async () => {
+    renderPanel();
+    const btn = await screen.findByText('Poll Environment (LPP)');
+    fireEvent.click(btn);
+    await waitFor(() =>
+      expect(csrfFetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/telemetry/poll'),
+        expect.objectContaining({ body: JSON.stringify({ type: 'lpp' }) }),
+      ),
+    );
+  });
+
+  it('surfaces a 429 throttle error from the backend', async () => {
+    csrfFetchMock.mockImplementation((_url: string, opts?: { method?: string }) => {
+      if (opts?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          json: async () => ({ success: false, error: 'Too soon since last mesh transmission; retry in 42s' }),
+        });
+      }
+      return Promise.resolve(
+        okResponse({ success: true, data: { enabled: false, intervalMinutes: 60, lastRequestAt: null } }),
+      );
+    });
+    renderPanel();
+    fireEvent.click(await screen.findByText('Poll Status'));
+    await waitFor(() =>
+      expect(screen.getByText(/Too soon since last mesh transmission/)).toBeInTheDocument(),
+    );
+  });
+
+  it('disables the poll buttons without nodes:read permission', async () => {
+    hasPermissionMock.mockImplementation((resource: string) => resource !== 'nodes');
+    renderPanel();
+    const btn = await screen.findByText('Poll Status');
+    expect(btn.closest('button')).toBeDisabled();
+  });
+});

--- a/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
+++ b/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
@@ -48,6 +48,9 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
   const csrfFetch = useCsrfFetch();
   const { hasPermission } = useAuth();
   const canWriteConfig = hasPermission('configuration', 'write');
+  // A manual poll is a user-initiated read that happens to transmit, so it's
+  // gated on nodes:read to match the backend route (#3674).
+  const canPoll = hasPermission('nodes', 'read');
 
   const [cfg, setCfg] = useState<TelemetryConfigState>(DEFAULT_CFG);
   const [intervalDraft, setIntervalDraft] = useState<string>('60');
@@ -55,8 +58,11 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [polling, setPolling] = useState<null | 'status' | 'lpp'>(null);
+  const [pollMsg, setPollMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
 
   const endpoint = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/nodes/${encodeURIComponent(publicKey)}/telemetry-config`;
+  const pollEndpoint = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/nodes/${encodeURIComponent(publicKey)}/telemetry/poll`;
 
   // Refetch whenever the selected node or source changes.
   useEffect(() => {
@@ -64,6 +70,7 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
     setLoading(true);
     setError(null);
     setSaved(false);
+    setPollMsg(null);
     (async () => {
       try {
         const response = await csrfFetch(endpoint);
@@ -136,6 +143,38 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
     }
     if (n === cfg.intervalMinutes) return;
     void save({ intervalMinutes: n });
+  };
+
+  const poll = async (type: 'status' | 'lpp') => {
+    setPolling(type);
+    setPollMsg(null);
+    try {
+      const response = await csrfFetch(pollEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type }),
+      });
+      const data = await response.json();
+      if (response.ok && data.success) {
+        const written: number = typeof data.data?.written === 'number' ? data.data.written : 0;
+        setPollMsg({
+          kind: 'ok',
+          text:
+            written > 0
+              ? t('meshcore.telemetry_config.poll_wrote', `Wrote ${written} telemetry row(s).`)
+              : t('meshcore.telemetry_config.poll_empty', 'Request sent — no telemetry returned.'),
+        });
+      } else {
+        setPollMsg({
+          kind: 'err',
+          text: data.error || t('meshcore.telemetry_config.poll_error', 'Poll failed'),
+        });
+      }
+    } catch (_err) {
+      setPollMsg({ kind: 'err', text: t('meshcore.telemetry_config.poll_error', 'Poll failed') });
+    } finally {
+      setPolling(null);
+    }
   };
 
   return (
@@ -222,6 +261,51 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
           )}
         </div>
       )}
+
+      <div style={{ marginTop: '1rem', borderTop: '1px solid var(--ctp-surface0)', paddingTop: '0.75rem' }}>
+        <div className="node-details-header">
+          <h4 className="node-details-title" style={{ fontSize: '0.95rem' }}>
+            {t('meshcore.telemetry_config.poll_title', 'Poll Now')}
+          </h4>
+        </div>
+        <p className="hint" style={{ marginBottom: '0.5rem' }}>
+          {t(
+            'meshcore.telemetry_config.poll_hint',
+            'Request telemetry immediately, outside the scheduled interval. Subject to the same 60-second mesh-TX spacing. Status applies to repeaters; Environment (LPP) to nodes with sensors.',
+          )}
+        </p>
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={() => void poll('status')}
+            disabled={!canPoll || polling !== null}
+          >
+            {polling === 'status'
+              ? t('meshcore.telemetry_config.polling', 'Polling…')
+              : t('meshcore.telemetry_config.poll_status', 'Poll Status')}
+          </button>
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={() => void poll('lpp')}
+            disabled={!canPoll || polling !== null}
+          >
+            {polling === 'lpp'
+              ? t('meshcore.telemetry_config.polling', 'Polling…')
+              : t('meshcore.telemetry_config.poll_lpp', 'Poll Environment (LPP)')}
+          </button>
+        </div>
+        {pollMsg && (
+          <div
+            className="meshcore-empty-state"
+            style={{ marginTop: '0.5rem', color: pollMsg.kind === 'ok' ? 'var(--ctp-green)' : 'var(--ctp-red)' }}
+            role={pollMsg.kind === 'ok' ? 'status' : 'alert'}
+          >
+            {pollMsg.text}
+          </div>
+        )}
+      </div>
 
       {error && (
         <div className="meshcore-empty-state" style={{ marginTop: '0.5rem', color: 'var(--ctp-red)' }} role="alert">

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -7,7 +7,7 @@
  * - Authentication requirements
  */
 
-import { describe, it, expect, beforeEach, beforeAll, vi, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, vi, afterAll, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import * as schema from '../../db/schema/index.js';
@@ -68,6 +68,9 @@ const meshcoreManager = {
   importPrivateKey: vi.fn().mockResolvedValue(true),
   exportPrivateKey: vi.fn().mockResolvedValue('a'.repeat(128)),
   isConnected: vi.fn().mockReturnValue(false),
+  // Mesh-TX throttle primitives read by the manual telemetry-poll route.
+  getLastMeshTxAt: vi.fn().mockReturnValue(0),
+  recordMeshTx: vi.fn(),
 };
 
 vi.mock('../meshcoreManager.js', () => ({
@@ -167,6 +170,7 @@ import DatabaseService from '../../services/database.js';
 
 import meshcoreRoutes from './meshcoreRoutes.js';
 import authRoutes from './authRoutes.js';
+import { setMeshCoreRemoteTelemetryScheduler } from '../services/meshcoreRemoteTelemetryScheduler.js';
 
 describe('MeshCore Routes', () => {
   let app: Express;
@@ -1207,6 +1211,120 @@ describe('MeshCore Routes', () => {
       expect(response.status).toBe(200);
       expect(upsertNode).not.toHaveBeenCalled();
       expect(setNodeTelemetryConfig).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('POST /api/sources/test-source/meshcore/nodes/:publicKey/telemetry/poll', () => {
+    const POLL_PUBKEY = 'a'.repeat(64);
+    const MALFORMED = 'abcd1234';
+    const getNodeByPublicKeyAndSource = vi.fn();
+    const markTelemetryRequested = vi.fn();
+    const requestTelemetryForNode = vi.fn();
+
+    beforeEach(() => {
+      (DatabaseService as any).meshcore = {
+        getNodeByPublicKeyAndSource,
+        markTelemetryRequested,
+      };
+      getNodeByPublicKeyAndSource.mockReset().mockResolvedValue({ publicKey: POLL_PUBKEY, advType: 2 });
+      markTelemetryRequested.mockReset().mockResolvedValue(undefined);
+      requestTelemetryForNode.mockReset().mockResolvedValue({ written: 16, sources: ['status:16'] });
+      meshcoreManager.isConnected.mockReturnValue(true);
+      meshcoreManager.getLastMeshTxAt.mockReturnValue(0);
+      meshcoreManager.recordMeshTx.mockReset();
+      setMeshCoreRemoteTelemetryScheduler({ requestTelemetryForNode } as any);
+    });
+
+    afterEach(() => {
+      setMeshCoreRemoteTelemetryScheduler(null);
+      meshcoreManager.isConnected.mockReturnValue(false);
+      meshcoreManager.getLastMeshTxAt.mockReturnValue(0);
+    });
+
+    it('requires authentication', async () => {
+      const res = await request(app)
+        .post(`/api/sources/test-source/meshcore/nodes/${POLL_PUBKEY}/telemetry/poll`)
+        .send({ type: 'status' });
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects a malformed public key', async () => {
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${MALFORMED}/telemetry/poll`)
+        .send({ type: 'status' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an invalid poll type', async () => {
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${POLL_PUBKEY}/telemetry/poll`)
+        .send({ type: 'bogus' });
+      expect(res.status).toBe(400);
+      expect(requestTelemetryForNode).not.toHaveBeenCalled();
+    });
+
+    it('polls status: stamps the gate and returns the written count', async () => {
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${POLL_PUBKEY}/telemetry/poll`)
+        .send({ type: 'status' });
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toMatchObject({ type: 'status', written: 16 });
+      expect(requestTelemetryForNode).toHaveBeenCalledWith(
+        meshcoreManager,
+        { publicKey: POLL_PUBKEY, advType: 2 },
+        { includeStatus: true, includeLpp: false },
+      );
+      expect(meshcoreManager.recordMeshTx).toHaveBeenCalledTimes(1);
+      expect(markTelemetryRequested).toHaveBeenCalledWith('test-source', POLL_PUBKEY, expect.any(Number));
+    });
+
+    it('polls lpp with includeLpp set', async () => {
+      requestTelemetryForNode.mockResolvedValueOnce({ written: 3, sources: ['lpp:3'] });
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${POLL_PUBKEY}/telemetry/poll`)
+        .send({ type: 'lpp' });
+      expect(res.status).toBe(200);
+      expect(res.body.data).toMatchObject({ type: 'lpp', written: 3 });
+      expect(requestTelemetryForNode).toHaveBeenCalledWith(
+        meshcoreManager,
+        expect.objectContaining({ publicKey: POLL_PUBKEY }),
+        { includeStatus: false, includeLpp: true },
+      );
+    });
+
+    it('treats an unknown node as a companion (advType null)', async () => {
+      getNodeByPublicKeyAndSource.mockResolvedValueOnce(null);
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${POLL_PUBKEY}/telemetry/poll`)
+        .send({ type: 'lpp' });
+      expect(res.status).toBe(200);
+      expect(requestTelemetryForNode).toHaveBeenCalledWith(
+        meshcoreManager,
+        { publicKey: POLL_PUBKEY, advType: null },
+        { includeStatus: false, includeLpp: true },
+      );
+    });
+
+    it('returns 409 when the source is not connected', async () => {
+      meshcoreManager.isConnected.mockReturnValue(false);
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${POLL_PUBKEY}/telemetry/poll`)
+        .send({ type: 'status' });
+      expect(res.status).toBe(409);
+      expect(requestTelemetryForNode).not.toHaveBeenCalled();
+    });
+
+    it('enforces the 60s mesh-TX gate with 429 + Retry-After', async () => {
+      meshcoreManager.getLastMeshTxAt.mockReturnValue(Date.now() - 5_000);
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${POLL_PUBKEY}/telemetry/poll`)
+        .send({ type: 'status' });
+      expect(res.status).toBe(429);
+      expect(res.body.retryAfterSecs).toBeGreaterThan(0);
+      expect(res.headers['retry-after']).toBeDefined();
+      expect(requestTelemetryForNode).not.toHaveBeenCalled();
+      expect(meshcoreManager.recordMeshTx).not.toHaveBeenCalled();
     });
   });
 

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -12,7 +12,11 @@ import { Router, Request, Response } from 'express';
 import { ConnectionType, MeshCoreDeviceType, MeshCoreManager, MeshCoreDiscoverFilter, type MeshCoreDiscoverMode } from '../meshcoreManager.js';
 import { meshcoreManagerRegistry } from '../meshcoreRegistry.js';
 import { getMeshCoreTelemetryPoller, nodeNumFromPubkey } from '../services/meshcoreTelemetryPoller.js';
-import { MAX_INTERVAL_MINUTES } from '../services/meshcoreRemoteTelemetryScheduler.js';
+import {
+  MAX_INTERVAL_MINUTES,
+  MIN_INTERVAL_BETWEEN_REQUESTS_MS,
+  getMeshCoreRemoteTelemetryScheduler,
+} from '../services/meshcoreRemoteTelemetryScheduler.js';
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
@@ -2338,6 +2342,93 @@ router.get(
     } catch (error) {
       logger.error('[API] Error getting per-node telemetry-config:', error);
       res.status(500).json({ success: false, error: 'Failed to read telemetry-config' });
+    }
+  },
+);
+
+/**
+ * POST /api/sources/:id/meshcore/nodes/:publicKey/telemetry/poll
+ *
+ * Manually trigger an immediate remote-telemetry poll for one node,
+ * outside the scheduler's cadence (issue #3674). Body:
+ *   { type: 'status' | 'lpp' }
+ * selecting which telemetry path to request — the UI exposes one button
+ * per type. Reuses the scheduler's shared request → convert → insert
+ * logic and honours the same per-source 60s mesh-TX gate so the buttons
+ * can't be spammed onto the air.
+ *
+ * Gated by `nodes:read` (a manual poll is a user-initiated read that
+ * happens to transmit), and additionally rate-limited at the HTTP layer
+ * by `meshcoreDeviceLimiter`.
+ */
+router.post(
+  '/nodes/:publicKey/telemetry/poll',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id: string }).id;
+      const { publicKey } = req.params;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
+      }
+
+      const type = (req.body?.type ?? '') as string;
+      if (type !== 'status' && type !== 'lpp') {
+        return res.status(400).json({ success: false, error: "type must be 'status' or 'lpp'" });
+      }
+
+      const manager = meshcoreManagerRegistry.get(sourceId);
+      if (!manager || !manager.isConnected()) {
+        return res.status(409).json({ success: false, error: 'MeshCore source is not connected' });
+      }
+
+      const scheduler = getMeshCoreRemoteTelemetryScheduler();
+      if (!scheduler) {
+        return res.status(503).json({ success: false, error: 'Telemetry scheduler unavailable' });
+      }
+
+      // Per-source 60s mesh-TX gate — the same primitive the scheduler
+      // uses, so a manual poll can't flood the air or collide with a
+      // scheduled request already in flight on this source.
+      const lastTx = manager.getLastMeshTxAt();
+      const sinceLastTx = Date.now() - lastTx;
+      if (lastTx > 0 && sinceLastTx < MIN_INTERVAL_BETWEEN_REQUESTS_MS) {
+        const retryAfterSecs = Math.ceil((MIN_INTERVAL_BETWEEN_REQUESTS_MS - sinceLastTx) / 1000);
+        res.set('Retry-After', String(retryAfterSecs));
+        return res.status(429).json({
+          success: false,
+          error: `Too soon since last mesh transmission; retry in ${retryAfterSecs}s`,
+          retryAfterSecs,
+        });
+      }
+
+      // Load the persisted node (if any) so the scheduler can classify
+      // advType for guest-login decisions. A node not yet in the DB is
+      // fine — requestTelemetryForNode treats an unknown advType as a
+      // companion (LPP-only, no guest login).
+      const node = await databaseService.meshcore.getNodeByPublicKeyAndSource(publicKey, sourceId);
+
+      // Stamp before issuing so the gate applies regardless of result and
+      // the scheduler's fair-rotation clock advances too.
+      const now = Date.now();
+      manager.recordMeshTx(now);
+      await databaseService.meshcore.markTelemetryRequested(sourceId, publicKey, now);
+
+      const result = await scheduler.requestTelemetryForNode(
+        manager,
+        { publicKey, advType: node?.advType ?? null },
+        { includeStatus: type === 'status', includeLpp: type === 'lpp' },
+      );
+
+      res.json({
+        success: true,
+        data: { type, written: result.written, sources: result.sources },
+      });
+    } catch (error) {
+      logger.error('[API] Error polling node telemetry:', error);
+      res.status(500).json({ success: false, error: 'Telemetry poll failed' });
     }
   },
 );

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.ts
@@ -371,6 +371,42 @@ export class MeshCoreRemoteTelemetryScheduler {
     await this.database.meshcore.markTelemetryRequested(manager.sourceId, target.publicKey, now);
     manager.recordMeshTx(now);
 
+    // For repeater-like targets, request both the status blob and LPP;
+    // companions only ship LPP. Throttle/stamp bookkeeping is owned here
+    // (above); the actual request → convert → insert is shared with the
+    // manual-poll routes via requestTelemetryForNode.
+    await this.requestTelemetryForNode(manager, target, {
+      includeStatus: isRepeaterLike,
+      includeLpp: true,
+    });
+  }
+
+  /**
+   * Issue the telemetry request(s) for a single target and persist any
+   * resulting rows. Shared by the scheduler tick and the manual-poll
+   * routes so both paths use identical request → convert → insert logic.
+   *
+   * This does NOT enforce the per-source 60s gate or stamp
+   * `lastMeshTxAt` / `lastTelemetryRequestAt` — callers own that policy
+   * (the scheduler pre-stamps for fair rotation; the manual routes gate
+   * and stamp themselves before calling in).
+   *
+   * @param opts.includeStatus request the `SendStatusReq` stats blob
+   *   (path #1). Only meaningful for Repeater / Room Server targets;
+   *   companions don't ship these counters.
+   * @param opts.includeLpp request `GetTelemetryData` LPP sensor data
+   *   (path #3), best-effort guest-login first on repeater-like targets.
+   * @returns the number of telemetry rows written and the per-path
+   *   source tags (e.g. `['status:16', 'lpp:3']`).
+   */
+  async requestTelemetryForNode(
+    manager: MeshCoreManager,
+    target: Pick<DbMeshCoreNode, 'publicKey'> & { advType?: number | null },
+    opts: { includeStatus: boolean; includeLpp: boolean },
+  ): Promise<{ written: number; sources: string[] }> {
+    const isRepeaterLike =
+      typeof target.advType === 'number' && REPEATER_ADV_TYPES.has(target.advType);
+    const keyShort = target.publicKey.substring(0, 16);
     const nodeNum = nodeNumFromPubkey(target.publicKey);
     const ts = this.nowFn();
     const rows: DbTelemetry[] = [];
@@ -380,9 +416,9 @@ export class MeshCoreRemoteTelemetryScheduler {
     // Repeater / Room Server with no login required, returns the
     // 16-field operational stats blob (battery, uptime, queue, packet
     // counters, RSSI/SNR, errors). Companion firmware doesn't ship
-    // these counters, so we skip the call there to avoid wasted air
-    // time. See https://github.com/Yeraze/meshmonitor/issues/3092.
-    if (isRepeaterLike) {
+    // these counters, so the scheduler skips the call there to avoid
+    // wasted air time. See https://github.com/Yeraze/meshmonitor/issues/3092.
+    if (opts.includeStatus) {
       try {
         const status = await manager.requestNodeStatus(target.publicKey);
         if (status) {
@@ -415,7 +451,13 @@ export class MeshCoreRemoteTelemetryScheduler {
           err,
         );
       }
+    }
 
+    // Path #3: GetTelemetryData binary request → BinaryResponse with a
+    // Cayenne-LPP payload. Companion targets are the primary consumer of
+    // this path (they're where actual sensors live), and Repeater targets
+    // may also expose LPP channels once a guest session is established.
+    if (opts.includeLpp) {
       // Best-effort guest-login: empty-password login is the canonical
       // way to unlock LPP `GetTelemetryData` responses on repeaters
       // whose `telemetry_mode_*` is set to `Disabled` for anonymous
@@ -423,41 +465,41 @@ export class MeshCoreRemoteTelemetryScheduler {
       // every tick. Failure is silently fine — the LPP request below
       // still runs in case the repeater is configured for anonymous
       // access.
-      try {
-        await manager.ensureGuestLogin(target.publicKey);
-      } catch (err) {
-        logger.debug(
-          `[MeshCoreRemoteTelem:${manager.sourceId}] ensureGuestLogin(${keyShort}…) threw:`,
-          err,
-        );
+      if (isRepeaterLike) {
+        try {
+          await manager.ensureGuestLogin(target.publicKey);
+        } catch (err) {
+          logger.debug(
+            `[MeshCoreRemoteTelem:${manager.sourceId}] ensureGuestLogin(${keyShort}…) threw:`,
+            err,
+          );
+        }
       }
-    }
 
-    // Path #3: GetTelemetryData binary request → BinaryResponse with a
-    // Cayenne-LPP payload. Always attempted: Companion targets are the
-    // primary consumer of this path (they're where actual sensors
-    // live), and Repeater targets may also expose LPP channels once a
-    // guest session is established.
-    const records = await manager.requestRemoteTelemetry(target.publicKey);
-    if (records && records.length > 0) {
-      const lppRows: DbTelemetry[] = [];
-      for (const rec of records) {
-        lppRows.push(...recordToTelemetryRows(rec, target.publicKey, nodeNum, ts));
-      }
-      if (lppRows.length > 0) {
-        rows.push(...lppRows);
-        sources.push(`lpp:${lppRows.length}`);
+      const records = await manager.requestRemoteTelemetry(target.publicKey);
+      if (records && records.length > 0) {
+        const lppRows: DbTelemetry[] = [];
+        for (const rec of records) {
+          lppRows.push(...recordToTelemetryRows(rec, target.publicKey, nodeNum, ts));
+        }
+        if (lppRows.length > 0) {
+          rows.push(...lppRows);
+          sources.push(`lpp:${lppRows.length}`);
+        }
       }
     }
 
     if (rows.length === 0) {
-      // Promoted from debug → info so silent-empty failures are visible
-      // in normal log levels. Operators have no other signal when a
-      // repeater's `telemetry_mode_*` is set restrictively.
+      // Logged at info so silent-empty results are visible at normal log
+      // levels. Operators have no other signal when a repeater's
+      // `telemetry_mode_*` is set restrictively.
+      const wanted = [opts.includeStatus ? 'status' : null, opts.includeLpp ? 'LPP' : null]
+        .filter(Boolean)
+        .join(' + ');
       logger.info(
-        `[MeshCoreRemoteTelem:${manager.sourceId}] No telemetry from ${keyShort}… (${isRepeaterLike ? 'status + LPP both empty/timeout' : 'LPP empty/timeout'})`,
+        `[MeshCoreRemoteTelem:${manager.sourceId}] No telemetry from ${keyShort}… (${wanted} empty/timeout)`,
       );
-      return;
+      return { written: 0, sources };
     }
 
     try {
@@ -465,8 +507,10 @@ export class MeshCoreRemoteTelemetryScheduler {
       logger.info(
         `[MeshCoreRemoteTelem:${manager.sourceId}] Wrote ${rows.length} telemetry rows for ${keyShort}… (${sources.join(', ')})`,
       );
+      return { written: rows.length, sources };
     } catch (err) {
       logger.warn(`[MeshCoreRemoteTelem:${manager.sourceId}] insertTelemetryBatch failed:`, err);
+      return { written: 0, sources };
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #3674 — adds on-demand MeshCore telemetry polling with **two buttons**, one per telemetry type, so users no longer have to wait for the scheduled interval.

MeshCore remote telemetry has two independent request paths:
- **Status** (`requestNodeStatus`) — the operational stats blob (battery, uptime, counters); repeater/room-server oriented.
- **Environment / LPP** (`requestRemoteTelemetry`) — Cayenne-LPP sensor data; the primary path for companion nodes.

Both already existed but were driven only by the background scheduler. This exposes them as manual triggers.

## Backend

- **Refactor:** extracted the scheduler's per-node `request → convert → insert` body into a shared `MeshCoreRemoteTelemetryScheduler.requestTelemetryForNode(manager, target, { includeStatus, includeLpp })`. The scheduler tick and the new route now use identical logic; throttle/stamp bookkeeping stays with each caller. No behavior change to the scheduler (its 32 tests pass unchanged).
- **New route:** `POST /api/sources/:id/meshcore/nodes/:publicKey/telemetry/poll`, body `{ type: 'status' | 'lpp' }`.
  - Honours the same per-source **60s mesh-TX gate** as the scheduler — returns `429` + `Retry-After` when too soon, so the buttons can't flood the air or collide with a scheduled request in flight.
  - Stamps `recordMeshTx` + `markTelemetryRequested` before issuing so the gate and fair-rotation clock advance regardless of result.
  - Gated on `nodes:read` (a user-initiated read that transmits) plus the HTTP `meshcoreDeviceLimiter`. Returns `409` if the source isn't connected.

## Frontend

- Two buttons — **Poll Status** and **Poll Environment (LPP)** — added to `MeshCoreNodeTelemetryConfig`, with pending state, a written-row-count result message, and backend-error surfacing (including the 429 throttle message). Gated on `nodes:read`.

## Testing

- 8 route tests: auth, malformed key, invalid type, status/lpp dispatch + arg assertions, unknown-node companion fallback, not-connected `409`, throttle `429` + `Retry-After`.
- 5 component tests: renders both buttons, POSTs the right `type`, surfaces a 429, disables without `nodes:read`.
- Full Vitest suite: **7349 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)