### PR TITLE
feat(meshcore): 2/3-byte path hash support in Define Path editor (#3670)

### DIFF
--- a/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
@@ -150,7 +150,7 @@ describe('MeshCoreContactDetailPanel', () => {
     expect(screen.getByText('North Repeater')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Save Path' }));
-    await waitFor(() => expect(onSetOutPath).toHaveBeenCalledWith(PK, 'b1'));
+    await waitFor(() => expect(onSetOutPath).toHaveBeenCalledWith(PK, 'b1', 1));
   });
 
   it('reorders hops with the up button before saving', async () => {
@@ -171,7 +171,7 @@ describe('MeshCoreContactDetailPanel', () => {
     // Move the second hop (East/7f) up → [7f, b1].
     fireEvent.click(screen.getAllByRole('button', { name: 'Move hop up' })[1]);
     fireEvent.click(screen.getByRole('button', { name: 'Save Path' }));
-    await waitFor(() => expect(onSetOutPath).toHaveBeenCalledWith(PK, '7f,b1'));
+    await waitFor(() => expect(onSetOutPath).toHaveBeenCalledWith(PK, '7f,b1', 1));
   });
 
   it('adds a custom hex byte and rejects an invalid one', async () => {
@@ -186,12 +186,49 @@ describe('MeshCoreContactDetailPanel', () => {
     // Invalid byte → error, no hop added.
     fireEvent.change(input, { target: { value: 'zz' } });
     fireEvent.click(screen.getByRole('button', { name: 'Add' }));
-    expect(screen.getByText(/single hex byte/i)).toBeTruthy();
+    expect(screen.getByText(/hex hash/i)).toBeTruthy();
     // Valid byte → hop added and saved.
     fireEvent.change(input, { target: { value: 'ab' } });
     fireEvent.click(screen.getByRole('button', { name: 'Add' }));
     fireEvent.click(screen.getByRole('button', { name: 'Save Path' }));
-    await waitFor(() => expect(onSetOutPath).toHaveBeenCalledWith(PK, 'ab'));
+    await waitFor(() => expect(onSetOutPath).toHaveBeenCalledWith(PK, 'ab', 1));
+  });
+
+  it('builds a 2-byte-width path and saves it with hashBytes=2', async () => {
+    const contact: MeshCoreContact = { publicKey: PK, advType: 1 };
+    const repeaters: MeshCoreContact[] = [
+      { publicKey: 'b1f2' + 'c'.repeat(60), advType: 2, advName: 'North Repeater' },
+    ];
+    const onSetOutPath = vi.fn().mockResolvedValue(true);
+    render(
+      <MeshCoreContactDetailPanel contact={contact} publicKey={PK} onSetOutPath={onSetOutPath}
+        repeaters={repeaters} canWriteNodes isCompanion />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Define Path…' }));
+    // Switch the hop hash width to 2 bytes.
+    fireEvent.change(screen.getByRole('combobox', { name: 'Hop hash width:' }), { target: { value: '2' } });
+    // The repeater's hop is now its 2-byte prefix.
+    const select = screen.getByRole('combobox', { name: 'Add repeater hop' });
+    fireEvent.change(select, { target: { value: 'b1f2' } });
+    expect(screen.getByText('North Repeater')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Save Path' }));
+    await waitFor(() => expect(onSetOutPath).toHaveBeenCalledWith(PK, 'b1f2', 2));
+  });
+
+  it('infers 2-byte width from an existing multi-byte out_path', () => {
+    const contact: MeshCoreContact = { publicKey: PK, advType: 1, outPath: 'b1f2,7f01' };
+    const repeaters: MeshCoreContact[] = [
+      { publicKey: 'b1f2' + 'c'.repeat(60), advType: 2, advName: 'North Repeater' },
+    ];
+    render(
+      <MeshCoreContactDetailPanel contact={contact} publicKey={PK}
+        onSetOutPath={vi.fn().mockResolvedValue(true)} repeaters={repeaters} canWriteNodes isCompanion />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Define Path…' }));
+    // Width selector pre-selected to 2 bytes; known 2-byte hop resolves by name.
+    expect((screen.getByRole('combobox', { name: 'Hop hash width:' }) as HTMLSelectElement).value).toBe('2');
+    expect(screen.getByText('North Repeater')).toBeTruthy();
+    expect(screen.getByText('Unknown (0x7f01)')).toBeTruthy();
   });
 
   it('pre-populates the editor from the existing out_path, resolving names', () => {

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -4,6 +4,7 @@ import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import {
   parsePathHops,
   joinPathHops,
+  pathHashBytesOf,
   repeaterHopOptions,
   resolveHop,
   type PathHop,
@@ -36,7 +37,7 @@ interface MeshCoreContactDetailPanelProps {
   /** Manually push a forwarding route into the device's contact record
    *  via CMD_ADD_UPDATE_CONTACT. `outPath` is a comma-separated hex chain
    *  ("a3,7f,02"). Unset hides the Define Path… button. */
-  onSetOutPath?: (publicKey: string, outPath: string) => Promise<boolean>;
+  onSetOutPath?: (publicKey: string, outPath: string, hashBytes?: 1 | 2 | 3) => Promise<boolean>;
   /** Known contacts used to build a path by repeater name (the picker maps a
    *  repeater to its first-public-key-byte hop). Typically the full contact
    *  list; the panel filters to repeaters/room servers internally. */
@@ -142,6 +143,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   // hop is a 1-byte hex routing hash.
   const [editorOpen, setEditorOpen] = useState(false);
   const [editorHops, setEditorHops] = useState<PathHop[]>([]);
+  const [editorHashBytes, setEditorHashBytes] = useState<1 | 2 | 3>(1);
   const [customByte, setCustomByte] = useState('');
   const [editorSaving, setEditorSaving] = useState(false);
   const [editorError, setEditorError] = useState<string | null>(null);
@@ -224,7 +226,10 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     !!onSetOutPath && canWriteNodes && isCompanion;
 
   // Repeater/room options for the path picker, derived from the contact list.
-  const hopOptions = React.useMemo(() => repeaterHopOptions(repeaters ?? []), [repeaters]);
+  const hopOptions = React.useMemo(
+    () => repeaterHopOptions(repeaters ?? [], editorHashBytes),
+    [repeaters, editorHashBytes],
+  );
   const canShowTraceButton =
     !!onTracePath && canWriteNodes && isCompanion && pathKnown && pathLen! > 0;
   const canShowDiscoverButton =
@@ -289,27 +294,43 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   };
 
   const openEditor = () => {
-    setEditorHops(parsePathHops(outPath));
+    const hops = parsePathHops(outPath);
+    setEditorHops(hops);
+    setEditorHashBytes(pathHashBytesOf(hops));
     setCustomByte('');
     setEditorError(null);
     setEditorOpen(true);
   };
 
+  // Max hops the firmware allows (bottom 6 bits of the packed path_len byte),
+  // also bounded by the 64-byte path buffer (hops * hashBytes <= 64).
+  const maxHops = Math.min(63, Math.floor(64 / editorHashBytes));
+
   const addHop = (byte: PathHop) => {
-    if (editorHops.length >= 64) return;
+    if (editorHops.length >= maxHops) return;
     setEditorHops((prev) => [...prev, byte]);
+  };
+
+  // Changing the hash width invalidates existing hex hops (a 1-byte "a3" can't
+  // be widened without the repeater's extra bytes), so clear them.
+  const changeHashBytes = (next: 1 | 2 | 3) => {
+    if (next === editorHashBytes) return;
+    setEditorHashBytes(next);
+    setEditorHops([]);
+    setCustomByte('');
+    setEditorError(null);
   };
 
   const addCustomHop = () => {
     const tok = customByte.trim().toLowerCase();
-    if (!/^[0-9a-f]{1,2}$/.test(tok)) {
+    if (!new RegExp(`^[0-9a-f]{${editorHashBytes * 2}}$`).test(tok)) {
       setEditorError(
-        t('meshcore.contact_details.edit_path_invalid_byte', 'Enter a single hex byte, e.g. "a3".'),
+        t('meshcore.contact_details.edit_path_invalid_byte', `Enter a ${editorHashBytes}-byte hex hash (${editorHashBytes * 2} hex chars).`),
       );
       return;
     }
     setEditorError(null);
-    addHop(tok.padStart(2, '0'));
+    addHop(tok);
     setCustomByte('');
   };
 
@@ -329,16 +350,16 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
 
   const handleSaveEditor = async () => {
     if (!onSetOutPath || editorSaving) return;
-    if (editorHops.length > 64) {
+    if (editorHops.length > maxHops) {
       setEditorError(
-        t('meshcore.contact_details.edit_path_too_long', `Path too long: ${editorHops.length} hops (max 64).`),
+        t('meshcore.contact_details.edit_path_too_long', `Path too long: ${editorHops.length} hops (max ${maxHops}).`),
       );
       return;
     }
     setEditorSaving(true);
     setEditorError(null);
     try {
-      const ok = await onSetOutPath(publicKey, joinPathHops(editorHops));
+      const ok = await onSetOutPath(publicKey, joinPathHops(editorHops), editorHashBytes);
       if (!ok) {
         setEditorError(
           t('meshcore.contact_details.edit_path_save_failed', 'Save failed.'),
@@ -882,6 +903,26 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
               )}
             </div>
 
+            {/* Per-hop hash width (1/2/3 bytes). Changing it clears the
+                current hops since the hex hashes are width-specific. */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.75rem', flexWrap: 'wrap' }}>
+              <label htmlFor="mc-path-hash-bytes">
+                {t('meshcore.contact_details.edit_path_hash_width', 'Hop hash width:')}
+              </label>
+              <select
+                id="mc-path-hash-bytes"
+                aria-label={t('meshcore.contact_details.edit_path_hash_width', 'Hop hash width:')}
+                value={editorHashBytes}
+                disabled={editorSaving}
+                onChange={(e) => changeHashBytes(Number(e.target.value) as 1 | 2 | 3)}
+                style={{ padding: '0.4rem', boxSizing: 'border-box' }}
+              >
+                <option value={1}>{t('meshcore.contact_details.edit_path_hash_1', '1 byte (default)')}</option>
+                <option value={2}>{t('meshcore.contact_details.edit_path_hash_2', '2 bytes')}</option>
+                <option value={3}>{t('meshcore.contact_details.edit_path_hash_3', '3 bytes')}</option>
+              </select>
+            </div>
+
             {/* Ordered hop list */}
             <label style={{ display: 'block', marginBottom: '0.4rem' }}>
               {t('meshcore.contact_details.edit_path_label', 'Path ({{count}} hops):', { count: editorHops.length })}
@@ -933,7 +974,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
             <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem', flexWrap: 'wrap' }}>
               <select
                 aria-label={t('meshcore.contact_details.edit_path_add_repeater_aria', 'Add repeater hop')}
-                disabled={editorSaving || editorHops.length >= 64}
+                disabled={editorSaving || editorHops.length >= maxHops}
                 value=""
                 onChange={(e) => { if (e.target.value) addHop(e.target.value); }}
                 style={{ flex: 1, minWidth: '12rem', padding: '0.45rem', boxSizing: 'border-box' }}
@@ -958,12 +999,12 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                 value={customByte}
                 onChange={(e) => setCustomByte(e.target.value)}
                 onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addCustomHop(); } }}
-                disabled={editorSaving || editorHops.length >= 64}
+                disabled={editorSaving || editorHops.length >= maxHops}
                 placeholder={t('meshcore.contact_details.edit_path_custom_byte', 'or hex byte (a3)')}
                 style={{ width: '8rem', padding: '0.45rem', fontFamily: 'var(--font-mono, monospace)', boxSizing: 'border-box' }}
               />
               <button type="button" className="btn-secondary" onClick={addCustomHop}
-                disabled={editorSaving || editorHops.length >= 64 || customByte.trim() === ''}>
+                disabled={editorSaving || editorHops.length >= maxHops || customByte.trim() === ''}>
                 {t('meshcore.contact_details.edit_path_add_byte', 'Add')}
               </button>
             </div>

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -113,7 +113,7 @@ export interface MeshCoreActions {
   /** Manually push a forwarding route into the device's contact record.
    *  `outPath` is a comma-separated hex chain ("a3,7f,02"); empty string
    *  sets a zero-hop direct path. Requires nodes:write. */
-  setContactOutPath: (publicKey: string, outPath: string) => Promise<boolean>;
+  setContactOutPath: (publicKey: string, outPath: string, hashBytes?: 1 | 2 | 3) => Promise<boolean>;
   /** Send a trace-path diagnostic along the contact's cached forwarding
    *  route and return per-hop SNR data. Resolves `null` on failure. */
   traceContactPath: (publicKey: string) => Promise<TracePathResult | null>;
@@ -917,14 +917,14 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch]);
 
-  const setContactOutPath = useCallback(async (publicKey: string, outPath: string): Promise<boolean> => {
+  const setContactOutPath = useCallback(async (publicKey: string, outPath: string, hashBytes: 1 | 2 | 3 = 1): Promise<boolean> => {
     try {
       const response = await csrfFetch(
         `${mcPrefix}/contacts/${encodeURIComponent(publicKey)}/out-path`,
         {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ outPath }),
+          body: JSON.stringify({ outPath, hashBytes }),
         },
       );
       const data = await response.json();

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2322,8 +2322,18 @@ class MeshCoreManager extends EventEmitter {
       logger.warn(`[MeshCore] Trace-path: no known path for ${publicKey.substring(0, 16)}…`);
       return null;
     }
+    // Expand each comma-separated hop token into its constituent bytes so
+    // multi-byte hops (e.g. "a3f2") yield [0xa3, 0xf2] rather than being
+    // truncated to a single byte by parseInt. 1-byte paths are unaffected.
     const pathBytes = Uint8Array.from(
-      contact.outPath.split(',').map((h) => parseInt(h, 16)),
+      contact.outPath.split(',').flatMap((h) => {
+        const tok = h.trim();
+        const bytes: number[] = [];
+        for (let i = 0; i + 2 <= tok.length; i += 2) {
+          bytes.push(parseInt(tok.slice(i, i + 2), 16));
+        }
+        return bytes;
+      }),
     );
     try {
       const response = await this.sendBridgeCommand('trace_path', {
@@ -2412,7 +2422,11 @@ class MeshCoreManager extends EventEmitter {
    * Returns `true` on success, `false` if the device rejected the
    * request or this isn't a connected Companion.
    */
-  async setContactOutPath(publicKey: string, outPathBytes: Uint8Array): Promise<boolean> {
+  async setContactOutPath(
+    publicKey: string,
+    outPathBytes: Uint8Array,
+    hashBytes: 1 | 2 | 3 = 1,
+  ): Promise<boolean> {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
       logger.warn('[MeshCore] Set-out-path requires Companion firmware');
       return false;
@@ -2424,12 +2438,17 @@ class MeshCoreManager extends EventEmitter {
       logger.warn(`[MeshCore] Set-out-path rejected: ${outPathBytes.length} > 64 bytes`);
       return false;
     }
+    if (outPathBytes.length % hashBytes !== 0) {
+      logger.warn(`[MeshCore] Set-out-path rejected: ${outPathBytes.length} bytes not a multiple of hashBytes ${hashBytes}`);
+      return false;
+    }
     try {
       // 12 s is generous for a single serial write; fail fast so the UI
       // doesn't leave the user stuck waiting for an unresponsive device.
       const response = await this.sendBridgeCommand('set_out_path', {
         public_key: publicKey,
         out_path: outPathBytes,
+        hash_bytes: hashBytes,
       }, 12000);
       if (!response.success) {
         const isTimeout = response.error?.includes('timeout');
@@ -2439,15 +2458,25 @@ class MeshCoreManager extends EventEmitter {
         );
         return false;
       }
-      const hex = Array.from(outPathBytes)
-        .map((b) => b.toString(16).padStart(2, '0'))
-        .join(',');
+      // Group the flat byte buffer into hashBytes-wide hop tokens so the
+      // mirrored outPath string carries the per-hop width (e.g. "a3f2,7f01"
+      // for a 2-byte path) and pathLen reflects hop COUNT, not byte count.
+      const hopCount = outPathBytes.length / hashBytes;
+      const hopTokens: string[] = [];
+      for (let i = 0; i + hashBytes <= outPathBytes.length; i += hashBytes) {
+        let tok = '';
+        for (let j = 0; j < hashBytes; j++) {
+          tok += outPathBytes[i + j].toString(16).padStart(2, '0');
+        }
+        hopTokens.push(tok);
+      }
+      const hex = hopTokens.join(',');
       const existing = this.contacts.get(publicKey);
       if (existing) {
         const updated: MeshCoreContact = {
           ...existing,
           outPath: hex,
-          pathLen: outPathBytes.length,
+          pathLen: hopCount,
           lastSeen: Date.now(),
         };
         this.contacts.set(publicKey, updated);
@@ -2455,7 +2484,7 @@ class MeshCoreManager extends EventEmitter {
         this.emit('contacts_updated', { sourceId: this.sourceId, contact: updated });
         dataEventEmitter.emitMeshCoreContactUpdated(updated, this.sourceId);
       }
-      logger.info(`[MeshCore] Set out_path (${outPathBytes.length} hops) for ${publicKey.substring(0, 16)}…`);
+      logger.info(`[MeshCore] Set out_path (${hopCount} hops, ${hashBytes}-byte) for ${publicKey.substring(0, 16)}…`);
       return true;
     } catch (error) {
       logger.error('[MeshCore] setContactOutPath threw:', error);

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -225,6 +225,11 @@ class MockConnection extends EventEmitter {
   async setContactPath(contact: any, path: Uint8Array) {
     this.setContactPathCalls.push({ contact, path });
   }
+
+  public addOrUpdateContactCalls: Array<any[]> = [];
+  async addOrUpdateContact(...args: any[]) {
+    this.addOrUpdateContactCalls.push(args);
+  }
 }
 
 function installMockModule(MockConn: typeof MockConnection): MockConnection {
@@ -1062,6 +1067,55 @@ describe('MeshCoreNativeBackend', () => {
     expect(conn.setContactPathCalls).toHaveLength(1);
     expect(conn.setContactPathCalls[0].contact).toBe(fullContact);
     expect(Array.from(conn.setContactPathCalls[0].path)).toEqual([0xa3, 0x7f, 0x02]);
+    // 1-byte width keeps the proven library path, never the packed bypass.
+    expect(conn.addOrUpdateContactCalls).toHaveLength(0);
+  });
+
+  it('set_out_path packs out_path_len for a 2-byte-width path via addOrUpdateContact', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    const targetBytes = new Uint8Array(32);
+    targetBytes[0] = 0xab; targetBytes[1] = 0xcd; targetBytes[2] = 0xef; targetBytes[3] = 0x01;
+    const fullContact = {
+      publicKey: targetBytes,
+      type: AdvType.Chat,
+      flags: 0,
+      outPathLen: 0xff,
+      outPath: new Uint8Array(64),
+      advName: 'Bob',
+      lastAdvert: 1700000000,
+      advLat: 10_000_000,
+      advLon: 20_000_000,
+      lastMod: 1700000000,
+    };
+    conn.contactsResponse = [fullContact];
+
+    // Two 2-byte hops: a3f2, 7f01 → 4 flat bytes, hop_count 2.
+    const pathBytes = Uint8Array.from([0xa3, 0xf2, 0x7f, 0x01]);
+    const resp = await backend.sendCommand('set_out_path', {
+      public_key: 'abcdef01' + '0'.repeat(56),
+      out_path: pathBytes,
+      hash_bytes: 2,
+    });
+
+    expect(resp.success).toBe(true);
+    // Multi-byte width must bypass the library's plain-count setContactPath.
+    expect(conn.setContactPathCalls).toHaveLength(0);
+    expect(conn.addOrUpdateContactCalls).toHaveLength(1);
+    const args = conn.addOrUpdateContactCalls[0];
+    // addOrUpdateContact(publicKey, type, flags, outPathLen, outPath, advName, lastAdvert, advLat, advLon)
+    const packedLen = args[3];
+    const outPath = args[4] as Uint8Array;
+    // packed = ((2-1)<<6) | hop_count(2) = 0x42 (66)
+    expect(packedLen).toBe(0x42);
+    expect(Array.from(outPath.slice(0, 4))).toEqual([0xa3, 0xf2, 0x7f, 0x01]);
+    expect(outPath.length).toBe(64);
+    expect(args[1]).toBe(fullContact.type); // preserves contact fields
+    expect(args[5]).toBe('Bob');
   });
 
   it('set_out_path rejects oversize paths (>64 bytes)', async () => {

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -974,16 +974,19 @@ export class MeshCoreNativeBackend extends EventEmitter {
 
       case 'set_out_path': {
         // Manually push a forwarding route into the device's contact
-        // record. Wraps meshcore.js's setContactPath(contact, path),
-        // which reads the contact's existing type/flags/name/advert
-        // timestamp/lat/lon and only mutates outPath + outPathLen via
-        // CMD_ADD_UPDATE_CONTACT (opcode 9). Stale hops silently drop
-        // direct sends, so this is gated behind the advanced toggle at
+        // record via CMD_ADD_UPDATE_CONTACT (opcode 9). Stale hops silently
+        // drop direct sends, so this is gated behind the advanced toggle at
         // the route layer.
         //
-        // `out_path` is the parsed Uint8Array of hop hashes (0..64 bytes).
-        // Caller is responsible for validating the byte length; we just
-        // forward.
+        // `out_path` is the parsed Uint8Array of hop hashes
+        // (hop_count * hash_bytes, 0..64 bytes). `hash_bytes` (1/2/3) is the
+        // per-hop hash width; the firmware stores it packed in the top 2
+        // bits of out_path_len (= ((hash_bytes-1)<<6) | hop_count) — the
+        // same encoding it uses for OTA packets. meshcore.js's
+        // setContactPath() only ever writes a PLAIN byte count (correct only
+        // for 1-byte hops), so for 2/3-byte widths we bypass it and call
+        // addOrUpdateContact() directly with a hand-packed length. Caller is
+        // responsible for validating lengths; we just forward.
         const publicKey = await this.resolvePublicKey(params.public_key as string);
         if (!publicKey) throw new Error('Set-out-path target not found');
         const pathBytes = params.out_path as Uint8Array | number[] | undefined;
@@ -992,13 +995,39 @@ export class MeshCoreNativeBackend extends EventEmitter {
         if (path.length > 64) {
           throw new Error(`out_path too long: ${path.length} > 64`);
         }
+        const hashBytesRaw = params.hash_bytes;
+        const hashBytes = hashBytesRaw === 2 || hashBytesRaw === 3 ? hashBytesRaw : 1;
+        if (path.length % hashBytes !== 0) {
+          throw new Error(`out_path length ${path.length} not a multiple of hash_bytes ${hashBytes}`);
+        }
         const contacts: any[] = await c.getContacts();
         const contact = contacts.find((ct) => {
           const hex = bytesToHex(ct.publicKey);
           return hex === bytesToHex(publicKey);
         });
         if (!contact) throw new Error('Set-out-path target not in device contact list');
-        await c.setContactPath(contact, path);
+        if (hashBytes === 1) {
+          // Default width: keep the proven library path (its plain byte
+          // count == packed length when the hash-size bits are 0).
+          await c.setContactPath(contact, path);
+        } else {
+          // Multi-byte width: pack out_path_len ourselves.
+          const hopCount = path.length / hashBytes;
+          const packedLen = path.length === 0 ? 0 : (((hashBytes - 1) << 6) | (hopCount & 0x3f));
+          const outPath = new Uint8Array(64);
+          outPath.set(path.subarray(0, Math.min(path.length, 64)));
+          await c.addOrUpdateContact(
+            contact.publicKey,
+            contact.type,
+            contact.flags,
+            packedLen,
+            outPath,
+            contact.advName,
+            contact.lastAdvert,
+            contact.advLat,
+            contact.advLon,
+          );
+        }
         return { ok: true };
       }
 

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -1655,9 +1655,37 @@ describe('MeshCore Routes', () => {
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(meshcoreManager.setContactOutPath).toHaveBeenCalledTimes(1);
-      const [pk, bytes] = meshcoreManager.setContactOutPath.mock.calls[0];
+      const [pk, bytes, hashBytes] = meshcoreManager.setContactOutPath.mock.calls[0];
       expect(pk).toBe(VALID_PUBKEY);
       expect(Array.from(bytes)).toEqual([0xa3, 0x7f, 0x02]);
+      expect(hashBytes).toBe(1); // defaults to 1-byte when omitted
+    });
+
+    it('forwards a 2-byte-width path as flat bytes plus hashBytes=2', async () => {
+      const response = await authenticatedAgent
+        .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
+        .send({ outPath: 'a3f2,7f01', hashBytes: 2 });
+      expect(response.status).toBe(200);
+      const [, bytes, hashBytes] = meshcoreManager.setContactOutPath.mock.calls[0];
+      expect(Array.from(bytes)).toEqual([0xa3, 0xf2, 0x7f, 0x01]);
+      expect(hashBytes).toBe(2);
+    });
+
+    it('rejects a hop token whose width does not match hashBytes', async () => {
+      const response = await authenticatedAgent
+        .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
+        .send({ outPath: 'a3,7f', hashBytes: 2 }); // 1-byte tokens under a 2-byte width
+      expect(response.status).toBe(400);
+      expect(meshcoreManager.setContactOutPath).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid hashBytes value', async () => {
+      const response = await authenticatedAgent
+        .put(`/api/sources/test-source/meshcore/contacts/${VALID_PUBKEY}/out-path`)
+        .send({ outPath: 'a3', hashBytes: 4 });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatch(/hashBytes/);
+      expect(meshcoreManager.setContactOutPath).not.toHaveBeenCalled();
     });
 
     it('accepts an empty path as zero-hop direct', async () => {

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -169,21 +169,27 @@ function enhanceNeighborsReply(reply: string, manager: ReturnType<typeof manager
 }
 
 /**
- * Parse a comma-separated hex chain like "a3,7f,02" into a Uint8Array.
+ * Parse a comma-separated hex chain into a flat Uint8Array of hop bytes.
+ *
+ * Each token is exactly `hashBytes` bytes wide (`hashBytes * 2` hex chars):
+ * "a3,7f,02" for the default 1-byte width, "a3f2,7f01" for 2-byte, etc.
  * Empty string parses to a zero-length array (zero-hop direct path).
- * Returns null on any malformed token so the route can return a 400.
+ * Returns null on any malformed/wrong-width token so the route can 400.
  */
-function parseHexPathChain(input: string): Uint8Array | null {
+function parseHexPathChain(input: string, hashBytes: 1 | 2 | 3 = 1): Uint8Array | null {
   const trimmed = input.trim();
   if (trimmed.length === 0) return new Uint8Array(0);
   const parts = trimmed.split(',');
-  const out = new Uint8Array(parts.length);
+  const out = new Uint8Array(parts.length * hashBytes);
+  const tokenRe = new RegExp(`^[0-9a-fA-F]{${hashBytes * 2}}$`);
   for (let i = 0; i < parts.length; i++) {
     const tok = parts[i].trim();
-    if (!/^[0-9a-fA-F]{1,2}$/.test(tok)) return null;
-    const n = parseInt(tok, 16);
-    if (!Number.isFinite(n) || n < 0 || n > 0xff) return null;
-    out[i] = n;
+    if (!tokenRe.test(tok)) return null;
+    for (let j = 0; j < hashBytes; j++) {
+      const n = parseInt(tok.slice(j * 2, j * 2 + 2), 16);
+      if (!Number.isFinite(n) || n < 0 || n > 0xff) return null;
+      out[i * hashBytes + j] = n;
+    }
   }
   return out;
 }
@@ -705,11 +711,26 @@ router.put(
           error: 'Body must include `outPath` as a comma-separated hex string',
         });
       }
-      const parsed = parseHexPathChain(rawPath);
+      // Per-hop hash width (1/2/3 bytes). Defaults to 1 for backward
+      // compatibility with callers that don't send it. MeshCore packs the
+      // width into the top 2 bits of out_path_len; 4-byte (and up) is
+      // rejected by firmware, so only 1/2/3 are accepted here. See #3670.
+      const rawHashBytes = (req.body ?? {}).hashBytes;
+      let hashBytes: 1 | 2 | 3 = 1;
+      if (rawHashBytes !== undefined) {
+        if (rawHashBytes !== 1 && rawHashBytes !== 2 && rawHashBytes !== 3) {
+          return res.status(400).json({
+            success: false,
+            error: 'hashBytes must be 1, 2, or 3',
+          });
+        }
+        hashBytes = rawHashBytes;
+      }
+      const parsed = parseHexPathChain(rawPath, hashBytes);
       if (!parsed) {
         return res.status(400).json({
           success: false,
-          error: 'Invalid outPath — expected comma-separated hex bytes, e.g. "a3,7f,02"',
+          error: `Invalid outPath — expected a comma-separated hex chain of ${hashBytes}-byte hops (${hashBytes * 2} hex chars each), e.g. "${'a3f27f01'.slice(0, hashBytes * 2)}"`,
         });
       }
       if (parsed.length > 64) {
@@ -718,7 +739,14 @@ router.put(
           error: `outPath too long: ${parsed.length} bytes (max 64)`,
         });
       }
-      const ok = await managerFor(req).setContactOutPath(publicKey, parsed);
+      const hopCount = parsed.length / hashBytes;
+      if (hopCount > 63) {
+        return res.status(400).json({
+          success: false,
+          error: `outPath too long: ${hopCount} hops (max 63)`,
+        });
+      }
+      const ok = await managerFor(req).setContactOutPath(publicKey, parsed, hashBytes);
       if (!ok) {
         return res.status(409).json({
           success: false,

--- a/src/utils/meshcorePath.test.ts
+++ b/src/utils/meshcorePath.test.ts
@@ -3,6 +3,7 @@ import {
   parsePathHops,
   joinPathHops,
   hopByteForKey,
+  pathHashBytesOf,
   repeaterHopOptions,
   resolveHop,
 } from './meshcorePath.js';
@@ -32,6 +33,49 @@ describe('meshcorePath', () => {
 
   it('hopByteForKey returns the first key byte, lowercased', () => {
     expect(hopByteForKey('A3B4C5'.padEnd(64, '0'))).toBe('a3');
+  });
+
+  it('parsePathHops preserves multi-byte hop tokens (2/3-byte widths)', () => {
+    expect(parsePathHops('a3f2,7f01')).toEqual(['a3f2', '7f01']);
+    expect(parsePathHops('A3F2C1,7F0102')).toEqual(['a3f2c1', '7f0102']);
+    // drops odd-length / oversize tokens but keeps valid ones
+    expect(parsePathHops('a3f2,abc,7f0102')).toEqual(['a3f2', '7f0102']);
+  });
+
+  it('hopByteForKey honors the hash width', () => {
+    const key = 'a3f2c1'.padEnd(64, '0');
+    expect(hopByteForKey(key, 1)).toBe('a3');
+    expect(hopByteForKey(key, 2)).toBe('a3f2');
+    expect(hopByteForKey(key, 3)).toBe('a3f2c1');
+  });
+
+  it('pathHashBytesOf infers width from the first hop, defaulting to 1', () => {
+    expect(pathHashBytesOf([])).toBe(1);
+    expect(pathHashBytesOf(['a3'])).toBe(1);
+    expect(pathHashBytesOf(['a3f2', '7f01'])).toBe(2);
+    expect(pathHashBytesOf(['a3f2c1'])).toBe(3);
+  });
+
+  it('repeaterHopOptions widens hop hashes to the requested width', () => {
+    const contacts = [mk('a3f2c1'.padEnd(64, '0'), 2, 'Wide Repeater')];
+    expect(repeaterHopOptions(contacts, 1)[0].hopByte).toBe('a3');
+    expect(repeaterHopOptions(contacts, 2)[0].hopByte).toBe('a3f2');
+    expect(repeaterHopOptions(contacts, 3)[0].hopByte).toBe('a3f2c1');
+  });
+
+  it('resolveHop matches and labels multi-byte hops', () => {
+    const opts = repeaterHopOptions(
+      [
+        mk('a3f2'.padEnd(64, '0'), 2, 'North Repeater'),
+        mk('a3c9'.padEnd(64, '0'), 2, 'South Repeater'), // shares 1-byte prefix, differs at 2-byte
+      ],
+      2,
+    );
+    // At 2-byte width the 1-byte collision disappears.
+    expect(resolveHop('a3f2', opts).label).toBe('North Repeater');
+    expect(resolveHop('a3f2', opts).matches).toHaveLength(1);
+    expect(resolveHop('a3c9', opts).label).toBe('South Repeater');
+    expect(resolveHop('beef', opts).label).toBe('Unknown (0xbeef)');
   });
 
   it('repeaterHopOptions includes only repeaters/rooms, sorted by name', () => {

--- a/src/utils/meshcorePath.ts
+++ b/src/utils/meshcorePath.ts
@@ -4,76 +4,93 @@ import type { MeshCoreContact } from './meshcoreHelpers';
  * Helpers for composing a MeshCore contact forwarding path ("out_path") from
  * named repeaters instead of raw hex.
  *
- * A MeshCore out_path is an ordered list of 1-byte routing hashes — each hop is
- * the **first byte of that repeater's public key** (the default 1-byte path
- * hash width). The companion API stores/accepts the path as a comma-separated
- * hex chain (e.g. "a3,7f,02"); these helpers convert between that wire form and
- * a name-aware UI.
+ * A MeshCore out_path is an ordered list of per-hop routing hashes. Each hop is
+ * the first `hashBytes` bytes of that repeater's public key, where `hashBytes`
+ * is the path hash width (1, 2, or 3 — MeshCore packs `hash_size − 1` into the
+ * top 2 bits of the on-wire `path_len`; 1-byte is the default). The companion
+ * API stores/accepts the path as a comma-separated hex chain where each hop is
+ * `hashBytes * 2` hex chars — "a3,7f,02" at 1-byte, "a3f2,7f01" at 2-byte.
+ * These helpers convert between that wire form and a name-aware UI.
  */
 
-/** A single forwarding hop as a normalized 2-char lowercase hex byte. */
+/** A single forwarding hop as a normalized lowercase hex hash (2/4/6 chars). */
 export type PathHop = string;
 
-/** Parse a stored out_path ("a3,7f,02") into normalized hop bytes. */
+/**
+ * Parse a stored out_path into normalized hop hashes. Width-agnostic: each
+ * token keeps its own width (2, 4, or 6 hex chars), so a mixed call site
+ * doesn't need to know the path's hash width up front. Legacy single-hex-char
+ * tokens are left-padded to one byte.
+ */
 export function parsePathHops(outPath: string | null | undefined): PathHop[] {
   if (!outPath) return [];
   return outPath
     .split(',')
     .map((s) => s.trim().toLowerCase())
-    .filter((s) => /^[0-9a-f]{1,2}$/.test(s))
-    .map((s) => s.padStart(2, '0'));
+    .map((s) => (/^[0-9a-f]$/.test(s) ? `0${s}` : s))
+    .filter((s) => /^[0-9a-f]+$/.test(s) && s.length % 2 === 0 && s.length >= 2 && s.length <= 6);
 }
 
-/** Join hop bytes back into the comma-separated chain the API expects. */
+/** Join hop hashes back into the comma-separated chain the API expects. */
 export function joinPathHops(hops: PathHop[]): string {
   return hops.join(',');
 }
 
 /**
- * The routing hop byte for a node = the first byte of its public key.
- *
- * NOTE: assumes the **1-byte path hash width**, which is MeshCore's default and
- * the only width this name-picker supports. The firmware can negotiate 2- or
- * 3-byte hashes (`outPathLenRaw >> 6` on the wire); on such a network the mapped
- * byte would be wrong. 1-byte is overwhelmingly the norm, so we scope to it here
- * rather than plumb hash-width through the UI — revisit if multi-byte hashes
- * become common.
+ * Infer the path hash width (1/2/3 bytes per hop) from a parsed hop list by
+ * looking at the first hop's hex length. Empty list defaults to 1. Used to
+ * pre-select the width selector when editing an existing path.
  */
-export function hopByteForKey(publicKey: string): PathHop {
-  return publicKey.slice(0, 2).toLowerCase();
+export function pathHashBytesOf(hops: PathHop[]): 1 | 2 | 3 {
+  if (hops.length === 0) return 1;
+  const w = hops[0].length / 2;
+  return w === 2 || w === 3 ? w : 1;
+}
+
+/**
+ * The routing hop hash for a node = the first `hashBytes` bytes of its public
+ * key, as lowercase hex. At the default 1-byte width this is the leading byte;
+ * at 2/3-byte widths the collision space shrinks accordingly.
+ */
+export function hopByteForKey(publicKey: string, hashBytes: 1 | 2 | 3 = 1): PathHop {
+  return publicKey.slice(0, hashBytes * 2).toLowerCase();
 }
 
 export interface RepeaterOption {
   publicKey: string;
   name: string;
+  /** The hop hash for this repeater at the active path hash width. */
   hopByte: PathHop;
 }
 
 /**
  * Candidate hops for the path picker: repeaters (advType 2) and room servers
  * (advType 3) — the relay infrastructure a path traverses — with display names
- * and their hop byte, sorted by name.
+ * and their hop hash at the active `hashBytes` width, sorted by name.
  */
-export function repeaterHopOptions(contacts: MeshCoreContact[]): RepeaterOption[] {
+export function repeaterHopOptions(
+  contacts: MeshCoreContact[],
+  hashBytes: 1 | 2 | 3 = 1,
+): RepeaterOption[] {
   return contacts
     .filter((c) => c.advType === 2 || c.advType === 3)
     .map((c) => ({
       publicKey: c.publicKey,
       name: c.advName || c.name || `${c.publicKey.slice(0, 8)}…`,
-      hopByte: hopByteForKey(c.publicKey),
+      hopByte: hopByteForKey(c.publicKey, hashBytes),
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export interface ResolvedHop {
   byte: PathHop;
-  /** Repeaters whose key starts with this byte (0, 1, or many — 1-byte hashes collide). */
+  /** Repeaters whose key starts with this hash (0, 1, or many — narrower at higher widths). */
   matches: RepeaterOption[];
   /** Human label: the repeater name, "name (+N)" on collision, or "Unknown (0xAB)". */
   label: string;
 }
 
-/** Resolve a hop byte to a human label using the known-repeater list. */
+/** Resolve a hop hash to a human label using the known-repeater list. */
 export function resolveHop(byte: PathHop, options: RepeaterOption[]): ResolvedHop {
   const matches = options.filter((o) => o.hopByte === byte);
   let label: string;


### PR DESCRIPTION
## Summary

Closes #3670 — lets users author MeshCore forwarding paths with **2- and 3-byte per-hop routing hashes**, not just the 1-byte default, in *Direct Messages → Contact Details → Define Path*.

## Protocol verification

Before writing any device-facing code I traced this through the **MeshCore firmware** (`ripplebiz/MeshCore`, `main`) because the write path was ambiguous:

- `path_len` is a single **packed** byte — top 2 bits = `hash_size − 1` (1/2/3-byte hops; 4-byte rejected by `isValidPathLen`), bottom 6 bits = hop count. (`Packet.h` `getPathHashSize/Count`, `setPathHashSizeAndCount`.)
- **Contacts use the identical packed format** as OTA packets (not a plain byte count, contrary to older notes). `ContactInfo.out_path_len` is stored raw and `Mesh::sendDirect` copies `contact.out_path`/`out_path_len` **verbatim** into the routed packet via `copyPath`. So a packed contact length round-trips and routes correctly.
- **1-byte packed == plain** (top bits 0), which is exactly why only 1-byte worked until now.
- meshcore.js `setContactPath()` hardcodes `outPathLen = path.length` (plain) — correct only for 1-byte. For 2/3-byte we must bypass it.

## Backend

- **`meshcoreNativeBackend` `set_out_path`**: accepts `hash_bytes` (1/2/3). 1-byte keeps the proven `setContactPath`; 2/3-byte bypasses it and calls `addOrUpdateContact` directly with a hand-packed `out_path_len = ((hash_bytes-1)<<6)|hop_count` and the flat hop buffer.
- **`meshcoreManager.setContactOutPath(pk, bytes, hashBytes)`**: forwards `hash_bytes`; the optimistic mirror now groups the byte buffer into width-wide hop tokens (`"a3f2,7f01"`) and stores `pathLen` as hop **count**.
- **`parseHexPathChain(input, hashBytes)`**: each token must be exactly `hashBytes*2` hex chars.
- **PUT `/contacts/:pk/out-path`**: validates `hashBytes` ∈ {1,2,3} and hop count ≤ 63.
- **`traceContactPath`**: expands multi-byte hop tokens into their constituent bytes instead of truncating each token to one byte (silent corruption now that multi-byte paths can exist).

**No DB migration** — the per-hop width is encoded in the stored `out_path` hex string (token length), so it round-trips without a schema change.

## Frontend

- `meshcorePath.ts` utils are threaded with `hashBytes`; new `pathHashBytesOf()` infers width from an existing path.
- The Define-Path editor gains a **1/2/3-byte hop-hash-width selector**, pre-selected from the current path, with width-aware hop add/validation; it sends `hashBytes` in the PUT. Changing width clears the (width-specific) hop list.

## Testing

- Path-utils multi-byte parse/derive/resolve; **native-backend packed-byte assertion** (verifies `0x42` for a 2-byte/2-hop path via `addOrUpdateContact`, and that 1-byte still uses `setContactPath`); route multi-byte forwarding + `hashBytes`/width validation; component width-selector + width-inference tests.
- Full Vitest suite: **7347 passed, 0 failed**.

## Follow-up (not in this PR)

Full multi-byte support for the *trace-path* diagnostic at the bridge/firmware layer (this PR only fixes the byte extraction so it no longer truncates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)