### PR TITLE
fix(config): persist & surface local node isUnmessagable/isLicensed (#3684)

### DIFF
--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { registry } from './migrations.js';
 
 describe('migrations registry', () => {
-  it('has all 100 migrations registered', () => {
-    expect(registry.count()).toBe(100);
+  it('has all 101 migrations registered', () => {
+    expect(registry.count()).toBe(101);
   });
 
   // Bumping these counts: when adding a new migration, increment to <N>+1 and
@@ -15,14 +15,14 @@ describe('migrations registry', () => {
     expect(all[0].name).toContain('v37_baseline');
   });
 
-  it('last migration is meshcore_channel_scope', () => {
+  it('last migration is add_node_unmessagable', () => {
     const all = registry.getAll();
     const last = all[all.length - 1];
-    expect(last.number).toBe(100);
-    expect(last.name).toContain('meshcore_channel_scope');
+    expect(last.number).toBe(101);
+    expect(last.name).toContain('add_node_unmessagable');
   });
 
-  it('migrations are sequentially numbered from 1 to 100', () => {
+  it('migrations are sequentially numbered from 1 to 101', () => {
     const all = registry.getAll();
     for (let i = 0; i < all.length; i++) {
       expect(all[i].number).toBe(i + 1);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -115,6 +115,7 @@ import { migration as traceroutePacketIdMigration, runMigration097Postgres as ru
 import { migration as createAutomationsMigration, runMigration098Postgres, runMigration098Mysql } from '../server/migrations/098_create_automations.js';
 import { migration as createAutomationVariablesMigration, runMigration099Postgres, runMigration099Mysql } from '../server/migrations/099_create_automation_variables.js';
 import { migration as meshcoreChannelScopeMigration, runMigration100Postgres as runMeshcoreChannelScopePostgres, runMigration100Mysql as runMeshcoreChannelScopeMysql } from '../server/migrations/100_meshcore_channel_scope.js';
+import { migration as nodeUnmessagableMigration, runMigration101Postgres as runNodeUnmessagablePostgres, runMigration101Mysql as runNodeUnmessagableMysql } from '../server/migrations/101_add_node_unmessagable.js';
 
 // ============================================================================
 // Registry
@@ -1598,4 +1599,13 @@ registry.register({
   sqlite: (db) => meshcoreChannelScopeMigration.up(db),
   postgres: (client) => runMeshcoreChannelScopePostgres(client),
   mysql: (pool) => runMeshcoreChannelScopeMysql(pool),
+});
+
+registry.register({
+  number: 101,
+  name: 'add_node_unmessagable',
+  settingsKey: 'migration_101_add_node_unmessagable',
+  sqlite: (db) => nodeUnmessagableMigration.up(db),
+  postgres: (client) => runNodeUnmessagablePostgres(client),
+  mysql: (pool) => runNodeUnmessagableMysql(pool),
 });

--- a/src/db/repositories/nodes.test.ts
+++ b/src/db/repositories/nodes.test.ts
@@ -78,6 +78,8 @@ const POSTGRES_CREATE = `
     "altitudeOverride" REAL,
     "positionOverrideIsPrivate" BOOLEAN DEFAULT FALSE,
     "hideFromMap" BOOLEAN DEFAULT FALSE,
+    "isUnmessagable" BOOLEAN DEFAULT FALSE,
+    "isLicensed" BOOLEAN DEFAULT FALSE,
     "hasRemoteAdmin" BOOLEAN DEFAULT FALSE,
     "lastRemoteAdminCheck" BIGINT,
     "remoteAdminMetadata" TEXT,
@@ -147,6 +149,8 @@ const MYSQL_CREATE = `
     altitudeOverride DOUBLE,
     positionOverrideIsPrivate BOOLEAN DEFAULT FALSE,
     hideFromMap BOOLEAN DEFAULT FALSE,
+    isUnmessagable BOOLEAN DEFAULT FALSE,
+    isLicensed BOOLEAN DEFAULT FALSE,
     hasRemoteAdmin BOOLEAN DEFAULT FALSE,
     lastRemoteAdminCheck BIGINT,
     remoteAdminMetadata TEXT,
@@ -213,6 +217,35 @@ function runNodesTests(getBackend: () => TestBackend) {
     const node = await repo.getNode(200);
     expect(node).not.toBeNull();
     expect(node!.longName).toBe('Updated');
+  });
+
+  // #3684: isUnmessagable / isLicensed must round-trip through upsert + getNode
+  it('upsertNode - persists isUnmessagable / isLicensed (#3684)', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    // Defaults to false when not supplied (insert path)
+    await repo.upsertNode(makeNode(220));
+    const defaulted = await repo.getNode(220);
+    expect(defaulted).not.toBeNull();
+    expect(Boolean(defaulted!.isUnmessagable)).toBe(false);
+    expect(Boolean(defaulted!.isLicensed)).toBe(false);
+
+    // Stored true on insert
+    await repo.upsertNode(makeNode(221, { isUnmessagable: true, isLicensed: true }));
+    const stored = await repo.getNode(221);
+    expect(stored).not.toBeNull();
+    expect(Boolean(stored!.isUnmessagable)).toBe(true);
+    expect(Boolean(stored!.isLicensed)).toBe(true);
+
+    // Updated on a subsequent upsert (update path)
+    await repo.upsertNode(makeNode(221, { isUnmessagable: false, isLicensed: false }));
+    const updated = await repo.getNode(221);
+    expect(Boolean(updated!.isUnmessagable)).toBe(false);
+    expect(Boolean(updated!.isLicensed)).toBe(false);
   });
 
   it('upsertNode - does NOT clobber learned name/macaddr/hwModel with blanks (#3505)', async () => {

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -408,6 +408,9 @@ export class NodesRepository extends BaseRepository {
           positionOverrideIsPrivate: nodeData.positionOverrideIsPrivate ?? existingNode.positionOverrideIsPrivate,
           // #3549: preserve the user's "Hide from Map" toggle across packet-driven updates
           hideFromMap: nodeData.hideFromMap ?? existingNode.hideFromMap,
+          // #3684: User capability flags from NodeInfo (preserve prior value if not present)
+          isUnmessagable: nodeData.isUnmessagable ?? existingNode.isUnmessagable,
+          isLicensed: nodeData.isLicensed ?? existingNode.isLicensed,
           updatedAt: now,
         })
         .where(and(eq(nodes.nodeNum, nodeData.nodeNum), eq(nodes.sourceId, effectiveSourceId)));
@@ -456,6 +459,8 @@ export class NodesRepository extends BaseRepository {
         altitudeOverride: nodeData.altitudeOverride ?? null,
         positionOverrideIsPrivate: nodeData.positionOverrideIsPrivate ?? false,
         hideFromMap: nodeData.hideFromMap ?? false,
+        isUnmessagable: nodeData.isUnmessagable ?? false,
+        isLicensed: nodeData.isLicensed ?? false,
         createdAt: now,
         updatedAt: now,
       } as any;
@@ -514,6 +519,8 @@ export class NodesRepository extends BaseRepository {
         altitudeOverride: nodeData.altitudeOverride ?? null,
         positionOverrideIsPrivate: nodeData.positionOverrideIsPrivate ?? false,
         hideFromMap: nodeData.hideFromMap ?? false,
+        isUnmessagable: nodeData.isUnmessagable ?? false,
+        isLicensed: nodeData.isLicensed ?? false,
         updatedAt: now,
       };
 

--- a/src/db/schema/nodes.ts
+++ b/src/db/schema/nodes.ts
@@ -73,6 +73,9 @@ export const nodesSqlite = sqliteTable('nodes', {
   positionOverrideIsPrivate: integer('positionOverrideIsPrivate', { mode: 'boolean' }).default(false),
   // Map visibility — when true, suppress this node's marker on maps only (issue #3549)
   hideFromMap: integer('hideFromMap', { mode: 'boolean' }).default(false),
+  // User capability flags from the node's User protobuf (issue #3684)
+  isUnmessagable: integer('isUnmessagable', { mode: 'boolean' }).default(false),
+  isLicensed: integer('isLicensed', { mode: 'boolean' }).default(false),
   // Remote admin discovery
   hasRemoteAdmin: integer('hasRemoteAdmin', { mode: 'boolean' }).default(false),
   lastRemoteAdminCheck: integer('lastRemoteAdminCheck'),
@@ -153,6 +156,9 @@ export const nodesPostgres = pgTable('nodes', {
   positionOverrideIsPrivate: pgBoolean('positionOverrideIsPrivate').default(false),
   // Map visibility — when true, suppress this node's marker on maps only (issue #3549)
   hideFromMap: pgBoolean('hideFromMap').default(false),
+  // User capability flags from the node's User protobuf (issue #3684)
+  isUnmessagable: pgBoolean('isUnmessagable').default(false),
+  isLicensed: pgBoolean('isLicensed').default(false),
   // Remote admin discovery
   hasRemoteAdmin: pgBoolean('hasRemoteAdmin').default(false),
   lastRemoteAdminCheck: pgBigint('lastRemoteAdminCheck', { mode: 'number' }),
@@ -232,6 +238,9 @@ export const nodesMysql = mysqlTable('nodes', {
   positionOverrideIsPrivate: myBoolean('positionOverrideIsPrivate').default(false),
   // Map visibility — when true, suppress this node's marker on maps only (issue #3549)
   hideFromMap: myBoolean('hideFromMap').default(false),
+  // User capability flags from the node's User protobuf (issue #3684)
+  isUnmessagable: myBoolean('isUnmessagable').default(false),
+  isLicensed: myBoolean('isLicensed').default(false),
   // Remote admin discovery
   hasRemoteAdmin: myBoolean('hasRemoteAdmin').default(false),
   lastRemoteAdminCheck: myBigint('lastRemoteAdminCheck', { mode: 'number' }),

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -83,6 +83,9 @@ export interface DbNode {
   positionOverrideIsPrivate?: boolean | null;
   // Map visibility — #3549: suppress this node's marker on maps only
   hideFromMap?: boolean | null;
+  // User capability flags from the node's User protobuf — #3684
+  isUnmessagable?: boolean | null;
+  isLicensed?: boolean | null;
   // Spam detection
   isExcessivePackets?: boolean | null;
   packetRatePerHour?: number | null;

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -617,6 +617,10 @@ class MeshtasticManager implements ISourceManager {
     hasWifi?: boolean;
     hasEthernet?: boolean;
     hasBluetooth?: boolean;
+    // #3684: User capability flags from the local node's NodeInfo, surfaced to the
+    // frontend Config tab via getCurrentConfig().localNodeInfo.
+    isUnmessagable?: boolean;
+    isLicensed?: boolean;
   } | null = null;
   private actualDeviceConfig: any = null;  // Store actual device config (local node)
   private actualModuleConfig: any = null;  // Store actual module config (local node)
@@ -7919,6 +7923,11 @@ class MeshtasticManager implements ISourceManager {
         nodeData.shortName = nodeInfo.user.shortName;
         nodeData.hwModel = nodeInfo.user.hwModel;
         nodeData.role = nodeInfo.user.role;
+        // #3684: persist User capability flags so the Config tab "Unmessageable"
+        // checkbox reflects the local node's actual setting (is_unmessagable is an
+        // optional proto field → default false; is_licensed is a required bool).
+        nodeData.isUnmessagable = nodeInfo.user.isUnmessagable ?? false;
+        nodeData.isLicensed = nodeInfo.user.isLicensed ?? false;
 
         // Capture public key if present (important for local node)
         if (nodeInfo.user.publicKey && nodeInfo.user.publicKey.length > 0) {
@@ -8116,6 +8125,13 @@ class MeshtasticManager implements ISourceManager {
           this.localNodeInfo.shortName = nodeInfo.user.shortName;
           this.localNodeInfo.isLocked = true;  // Lock it now that we have complete info
           logger.debug(`📱 Local node: ${nodeInfo.user.longName} (${nodeInfo.user.shortName}) - LOCKED`);
+        }
+        // #3684: surface the local node's User capability flags to the Config tab.
+        // Updated independently of the names guard since is_unmessagable can change
+        // without a name change. is_unmessagable is an optional proto field.
+        if (nodeInfo.user) {
+          this.localNodeInfo.isUnmessagable = nodeInfo.user.isUnmessagable ?? false;
+          this.localNodeInfo.isLicensed = nodeInfo.user.isLicensed ?? false;
         }
       }
 

--- a/src/server/migrations/101_add_node_unmessagable.ts
+++ b/src/server/migrations/101_add_node_unmessagable.ts
@@ -1,0 +1,88 @@
+/**
+ * Migration 101: Add isUnmessagable / isLicensed columns to the nodes table (#3684)
+ *
+ * The Meshtastic User protobuf carries two capability flags:
+ *   - is_unmessagable (optional bool) — node will not receive direct messages
+ *   - is_licensed     (bool)          — amateur-radio licensed operator
+ *
+ * These were never persisted, so the Config tab's "Unmessageable" checkbox for
+ * the LOCAL node always rendered unchecked (the /admin/get-owner local branch
+ * hardcoded both to false). We now ingest them from NodeInfo and store them per
+ * node so the checkbox reflects the device's real setting.
+ *
+ * Both columns default to false / 0.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info('Running migration 101 (SQLite): Adding isUnmessagable/isLicensed to nodes...');
+
+    for (const col of ['isUnmessagable', 'isLicensed']) {
+      try {
+        db.exec(`ALTER TABLE nodes ADD COLUMN ${col} INTEGER DEFAULT 0`);
+        logger.debug(`Added nodes.${col}`);
+      } catch (e: any) {
+        if (e.message?.includes('duplicate column')) {
+          logger.debug(`nodes.${col} already exists, skipping`);
+        } else {
+          logger.warn(`Could not add nodes.${col}:`, e.message);
+        }
+      }
+    }
+
+    logger.info('Migration 101 complete (SQLite): nodes.isUnmessagable/isLicensed added');
+  },
+
+  down: (_db: Database): void => {
+    logger.debug('Migration 101 down: Not implemented (destructive column drops)');
+  }
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration101Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info('Running migration 101 (PostgreSQL): Adding isUnmessagable/isLicensed to nodes...');
+
+  try {
+    await client.query('ALTER TABLE nodes ADD COLUMN IF NOT EXISTS "isUnmessagable" BOOLEAN DEFAULT FALSE');
+    await client.query('ALTER TABLE nodes ADD COLUMN IF NOT EXISTS "isLicensed" BOOLEAN DEFAULT FALSE');
+    logger.debug('Ensured nodes.isUnmessagable / nodes.isLicensed exist');
+  } catch (error: any) {
+    logger.error('Migration 101 (PostgreSQL) failed:', error.message);
+    throw error;
+  }
+
+  logger.info('Migration 101 complete (PostgreSQL): nodes.isUnmessagable/isLicensed added');
+}
+
+// ============ MySQL ============
+
+export async function runMigration101Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info('Running migration 101 (MySQL): Adding isUnmessagable/isLicensed to nodes...');
+
+  try {
+    for (const col of ['isUnmessagable', 'isLicensed']) {
+      const [rows] = await pool.query(`
+        SELECT COLUMN_NAME FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'nodes' AND COLUMN_NAME = ?
+      `, [col]);
+      if (!Array.isArray(rows) || rows.length === 0) {
+        await pool.query(`ALTER TABLE nodes ADD COLUMN ${col} BOOLEAN DEFAULT FALSE`);
+        logger.debug(`Added nodes.${col}`);
+      } else {
+        logger.debug(`nodes.${col} already exists, skipping`);
+      }
+    }
+  } catch (error: any) {
+    logger.error('Migration 101 (MySQL) failed:', error.message);
+    throw error;
+  }
+
+  logger.info('Migration 101 complete (MySQL): nodes.isUnmessagable/isLicensed added');
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5069,15 +5069,23 @@ apiRouter.post('/admin/load-owner', requireAdmin(), async (req, res) => {
         // specific source, not a possibly-stale row with the same nodeNum on
         // another source.
         let publicKeyBase64: string | undefined;
+        // #3684: read the persisted User capability flags so the Config tab's
+        // "Unmessageable"/"Licensed" checkboxes reflect the local node's actual
+        // setting instead of always showing unchecked. nodeNum may be absent
+        // before the local node row exists — fall back to false in that case.
+        let isUnmessagable = false;
+        let isLicensed = false;
         if (localNodeInfo.nodeNum) {
           const nodeData = await databaseService.nodes.getNode(localNodeInfo.nodeNum, loSourceId);
           publicKeyBase64 = nodeData?.publicKey || undefined;
+          isUnmessagable = nodeData?.isUnmessagable ?? false;
+          isLicensed = nodeData?.isLicensed ?? false;
         }
         return res.json({ owner: {
           longName: localNodeInfo.longName || '' ,
           shortName: localNodeInfo.shortName || '' ,
-          isUnmessagable: false,
-          isLicensed: false,
+          isUnmessagable,
+          isLicensed,
           publicKey: publicKeyBase64
         }});
       } else {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -104,6 +104,8 @@ export interface DbNode {
   altitudeOverride?: number; // Override altitude
   positionOverrideIsPrivate?: boolean; // Override privacy (false = public, true = private)
   hideFromMap?: boolean; // #3549: suppress this node's marker on maps only
+  isUnmessagable?: boolean; // #3684: User.is_unmessagable — node won't receive DMs
+  isLicensed?: boolean; // #3684: User.is_licensed — amateur-radio licensed operator
   // Remote admin discovery (Migration 055)
   hasRemoteAdmin?: boolean; // Has remote admin access
   lastRemoteAdminCheck?: number; // Unix timestamp ms of last check

--- a/src/types/device.ts
+++ b/src/types/device.ts
@@ -42,6 +42,8 @@ export interface DeviceInfo {
   favoriteLocked?: boolean;
   isIgnored?: boolean;
   hideFromMap?: boolean; // #3549: suppress this node's marker on maps only
+  isUnmessagable?: boolean; // #3684: User.is_unmessagable — node won't receive DMs
+  isLicensed?: boolean; // #3684: User.is_licensed — amateur-radio licensed operator
   keyIsLowEntropy?: boolean;
   duplicateKeyDetected?: boolean;
   keyMismatchDetected?: boolean;


### PR DESCRIPTION
## Summary

Closes #3684 (and resolves the duplicate #3683). Fixes **Bug 1**: the Configuration tab's **Unmessageable** checkbox always rendered unchecked for the **local node**, because the flag was never ingested or persisted and `/admin/get-owner`'s local branch hardcoded it to `false`. (Bug 2 — a map indicator for unmessageable nodes — is intentionally deferred as a separate enhancement.)

The Meshtastic `User` protobuf carries `is_unmessagable` (optional bool) and `is_licensed` (bool), which decode to `isUnmessagable` / `isLicensed` on `nodeInfo.user`. These were dropped on ingest, so the frontend (already wired to `config.localNodeInfo.isUnmessagable`) had nothing to show.

## Changes

- **Schema** (`src/db/schema/nodes.ts`): new `isUnmessagable` / `isLicensed` boolean columns across SQLite / PostgreSQL / MySQL (default false).
- **Migration 101** (`src/server/migrations/101_add_node_unmessagable.ts`): idempotent across all three backends (SQLite try/catch duplicate-column, PG `IF NOT EXISTS`, MySQL `information_schema`). Registered in `src/db/migrations.ts`; count test bumped 100→101. *(Note: the CLAUDE.md brief said "next is 100," but `origin/main` already shipped migration 100 `meshcore_channel_scope`, so this is 101.)*
- **Repository** (`src/db/repositories/nodes.ts`): read/write both columns on the update (preserves prior value via `?? existing`), insert, and upsert paths.
- **Ingest** (`src/server/meshtasticManager.ts`): store `nodeInfo.user.isUnmessagable/isLicensed ?? false`; extend the `localNodeInfo` type and populate it from the local NodeInfo (outside the name-change guard, since the flag can change without a name change).
- **get-owner** (`src/server/server.ts`): the local-node branch now returns the persisted DB values (guarded for an absent nodeNum) instead of hardcoded `false`. The remote branch already did this.
- **Types**: added the two fields to `DbNode` (`src/db/types.ts`), the service-facing `DbNode` (`src/services/database.ts`), and `DeviceInfo` (`src/types/device.ts`).

## Testing

- New round-trip test in `src/db/repositories/nodes.test.ts` (default false on insert, stored true round-trips, update path) plus extended PG/MySQL DDL.
- Migration count/last-name test updated.
- Full Vitest suite: **14680 passed, 0 failed**. `tsc --noEmit`: 0 errors in any touched file.

## Frontend

No frontend change needed — `ConfigurationTab.tsx` already reads `config.localNodeInfo.isUnmessagable`, and `getCurrentConfig()` returns `localNodeInfo` directly, so the now-populated flags surface to the checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)