### PR TITLE
feat(map-analysis): rich multi-source node popups matching the Unified map

### DIFF
--- a/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 import MapAnalysisCanvas from './MapAnalysisCanvas';
 import { MapAnalysisProvider } from './MapAnalysisContext';
 
@@ -61,6 +62,11 @@ vi.mock('../../hooks/useDashboardData', () => ({
         longName: 'Alpha',
         shortName: 'A',
         position: { latitude: 30, longitude: -90 },
+        // Reported by two sources — exercises the popup's multi-source list.
+        sources: [
+          { sourceId: 'a', sourceName: 'Alpha Src', protocol: 'Meshtastic' },
+          { sourceId: 'b', sourceName: 'Beta Src', protocol: 'MeshCore' },
+        ],
       },
     ],
     traceroutes: [],
@@ -82,13 +88,17 @@ vi.mock('../../contexts/SettingsContext', () => ({
     customTilesets: [],
     setMapTileset: vi.fn(),
   }),
+  // Used by DashboardNodePopup, which now renders inside the node marker popups.
+  useDisplaySettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
 }));
 
 const wrapper = ({ children }: { children: React.ReactNode }) => {
   const qc = new QueryClient();
   return (
     <QueryClientProvider client={qc}>
-      <MapAnalysisProvider>{children}</MapAnalysisProvider>
+      <MemoryRouter>
+        <MapAnalysisProvider>{children}</MapAnalysisProvider>
+      </MemoryRouter>
     </QueryClientProvider>
   );
 };
@@ -105,5 +115,14 @@ describe('MapAnalysisCanvas', () => {
   it('renders a marker per node when markers layer is enabled (default)', () => {
     render(<MapAnalysisCanvas />, { wrapper });
     expect(screen.getAllByTestId('marker').length).toBeGreaterThan(0);
+  });
+
+  it('node popup lists every source that reported the node', () => {
+    render(<MapAnalysisCanvas />, { wrapper });
+    // The rich DashboardNodePopup now renders inside the marker popup and shows
+    // a "Seen by N sources" list for multi-source nodes (#2805 / Unified parity).
+    expect(screen.getByText(/Seen by 2 sources/i)).toBeInTheDocument();
+    expect(screen.getByText('Alpha Src')).toBeInTheDocument();
+    expect(screen.getByText('Beta Src')).toBeInTheDocument();
   });
 });

--- a/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
+++ b/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
@@ -136,7 +136,10 @@ export default function NodeMarkersLayer() {
   const { data: sources = [] } = useDashboardSources();
   const sourceList = sources as Array<{ id: string; name: string }>;
   const sourceIds = sourceList.map((s) => s.id);
-  const { nodes } = useDashboardUnifiedData(sourceIds, sourceIds.length > 0);
+  // Pass the FULL source objects (not bare ids) so the unified merge stamps the
+  // per-node `sources` array used by the popup's "Seen by N sources" list and by
+  // the multi-source filter. Bare-string callers get no `sources` field.
+  const { nodes } = useDashboardUnifiedData(sources, sourceIds.length > 0);
   const hop = useHopCounts({
     enabled: config.layers.hopShading.enabled,
     sources: config.sources.length === 0 ? sourceIds : config.sources,

--- a/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
+++ b/src/components/MapAnalysis/layers/NodeMarkersLayer.tsx
@@ -1,5 +1,6 @@
 import { Marker, Popup } from 'react-leaflet';
 import { useEffect, useMemo, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import type { Marker as LeafletMarker } from 'leaflet';
 import {
   useDashboardSources,
@@ -13,6 +14,8 @@ import { resolveNodeLatLng, type MaybePositionedNode } from '../nodePositionUtil
 import { nodeMatchesSearch } from '../nodeSearch';
 import { createNodeIcon } from '../../../utils/mapIcons';
 import { getNodeTypeCategory } from '../../../utils/nodeTypeCategory';
+import DashboardNodePopup, { type NodeSourceRef } from '../../Dashboard/DashboardNodePopup';
+import '../../../styles/nodes.css'; // `.node-popup-*` classes used by DashboardNodePopup
 
 interface NodeRecord extends MaybePositionedNode {
   nodeNum: number;
@@ -24,6 +27,8 @@ interface NodeRecord extends MaybePositionedNode {
   user?: { role?: string | number | null } | null;
   isMeshCore?: boolean;
   advType?: number | null;
+  /** Every configured source that reported this node (unified merge, #2805). */
+  sources?: NodeSourceRef[];
 }
 
 interface HopEntry {
@@ -46,6 +51,19 @@ interface HopEntry {
 export default function NodeMarkersLayer() {
   const { config, selected, setSelected, nodeFilter } = useMapAnalysisCtx();
   const { mapPinStyle } = useSettings();
+  const navigate = useNavigate();
+
+  // Clicking a "Seen by" source row in the popup jumps to that source's view —
+  // mirrors the Unified/Dashboard map (DashboardPage.handleNodeSourceSelect).
+  const handleSourceSelect = (source: NodeSourceRef, nodeId: string | undefined) => {
+    if (source.protocol === 'MeshCore') {
+      navigate(`/source/${source.sourceId}/`);
+      return;
+    }
+    navigate(`/source/${source.sourceId}/#messages`, {
+      state: nodeId ? { focusDmNodeId: nodeId } : undefined,
+    });
+  };
 
   // Spiderfier fans out markers that share (rounded) coordinates so each node in
   // a cluster is individually selectable (issues #3399, #3612). Same bridge
@@ -118,11 +136,6 @@ export default function NodeMarkersLayer() {
   const { data: sources = [] } = useDashboardSources();
   const sourceList = sources as Array<{ id: string; name: string }>;
   const sourceIds = sourceList.map((s) => s.id);
-  const sourceNameById = useMemo(() => {
-    const m = new Map<string, string>();
-    for (const s of sourceList) m.set(s.id, s.name);
-    return m;
-  }, [sourceList]);
   const { nodes } = useDashboardUnifiedData(sourceIds, sourceIds.length > 0);
   const hop = useHopCounts({
     enabled: config.layers.hopShading.enabled,
@@ -149,8 +162,14 @@ export default function NodeMarkersLayer() {
       // Node-type filter (issue #3546): hide categories the user toggled off.
       if (config.nodeTypes[getNodeTypeCategory(node)] === false) return false;
       if (config.sources.length === 0) return true;
-      if (!node.sourceId) return false;
-      return config.sources.includes(node.sourceId);
+      // Source filter: a unified-merged node can be reported by several sources
+      // (node.sources). It must stay visible if ANY of those is enabled — not
+      // just its primary sourceId — so multi-source nodes don't vanish when only
+      // one of their sources is selected. Fall back to sourceId for unmerged rows.
+      const sourceIds = node.sources && node.sources.length > 0
+        ? node.sources.map((s) => s.sourceId)
+        : (node.sourceId ? [node.sourceId] : []);
+      return sourceIds.some((id) => config.sources.includes(id));
     });
 
   // Genuine removals (a node aged out / filtered away) are reconciled here
@@ -223,16 +242,18 @@ export default function NodeMarkersLayer() {
                 }),
             }}
           >
-            {/* Render in the default popupPane (z-index 700). Without this the
-                Popup inherits the surrounding <Pane name="markers"> (z-index
-                600) from MapAnalysisCanvas, so node markers paint over the
-                popup ("details popup under the markers"). */}
+            {/* Same rich card as the Unified/Dashboard map, incl. the "Seen by
+                N sources" list for multi-source nodes. Rendered in the default
+                popupPane (z-index 700): without this the Popup inherits the
+                surrounding <Pane name="markers"> (z600) from MapAnalysisCanvas
+                and the markers paint over it. Inject the hop count computed from
+                /api/analysis/hopCounts so the popup shows it. */}
             <Popup pane="popupPane">
-              <strong>
-                {n.longName ?? n.shortName ?? `!${Number(n.nodeNum).toString(16)}`}
-              </strong>
-              <div>Source: {sourceNameById.get(sourceId) ?? sourceId ?? '(unknown)'}</div>
-              {hopVal !== undefined && <div>Hops: {hopVal}</div>}
+              <DashboardNodePopup
+                node={hopVal !== undefined ? { ...n, hopsAway: hopVal } : n}
+                pos={{ lat, lng: lon }}
+                onSourceSelect={handleSourceSelect}
+              />
             </Popup>
           </Marker>
         );


### PR DESCRIPTION
## Summary

Brings the **Map Analysis** node-marker popups up to parity with the **Unified/Dashboard** map, and makes the page properly multi-source-aware.

### 1. Popups look like the Unified map
Map Analysis markers now render the same rich `DashboardNodePopup` (the `.node-popup-*` card — name/short name header, role, hops, hardware, battery, SNR, altitude, position, last-heard) instead of the bare inline `<strong>name</strong> / Source / Hops` popup.

### 2. Multi-source nodes list all their sources
`DashboardNodePopup` renders the **"Seen by N sources"** list for unified-merged nodes. Map Analysis uses the same `useDashboardUnifiedData` merge (which attaches `node.sources`), so a node reported by several sources now shows each one, with rows that link to that source's view (mirrors `DashboardPage.handleNodeSourceSelect`).

### 3. Source selection handles multi-source nodes
The top-of-page source filter now keeps a node visible when **any** of its reporting sources is enabled — it checks `node.sources` rather than only the node's primary `sourceId`. Previously a multi-source node whose *primary* source wasn't selected would vanish even if one of its other sources was enabled.

## Testing

- `MapAnalysisCanvas.test`: new assertion that the popup lists every reporting source ("Seen by 2 sources" + both names); wrapped in `MemoryRouter` and mocks `useDisplaySettings` for the new popup.
- Full Map Analysis + MeshCoreSourcePage suites pass; tsc clean.

Builds on #3687 (now merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)