### PR TITLE
fix(meshcore): honor packet-monitor Max count setting in the live list (#3690)

### DIFF
--- a/src/components/MeshCore/MeshCorePacketMonitorView.tsx
+++ b/src/components/MeshCore/MeshCorePacketMonitorView.tsx
@@ -35,7 +35,6 @@ interface MeshCorePacketMonitorViewProps {
 type Packet = MeshCoreOtaPacketEvent;
 
 const MAX_BUFFER = 2000;
-const PAGE_LIMIT = 200;
 
 function payloadLabel(p: Packet): string {
   if (p.payloadTypeName) return p.payloadTypeName;
@@ -89,7 +88,9 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
     setLoading(true);
     setError(null);
     try {
-      const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+      // Don't send an explicit limit: let the server apply the configured
+      // meshcore_packet_log_max_count as the effective page size (issue #3690).
+      const params = new URLSearchParams();
       if (payloadFilter !== '') params.set('payload_type', String(payloadFilter));
       if (routeFilter !== '') params.set('route_type', String(routeFilter));
       const res = await csrfFetch(`${mcPrefix}/packets?${params.toString()}`);

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -2087,6 +2087,59 @@ describe('MeshCore Routes', () => {
     });
   });
 
+  describe('GET /api/sources/test-source/meshcore/packets (list)', () => {
+    const samplePackets = [
+      { id: 2, sourceId: 'test-source', timestamp: 1700000002000, payloadType: 1, routeType: 0, rawHex: 'beef' },
+      { id: 1, sourceId: 'test-source', timestamp: 1700000001000, payloadType: 2, routeType: 1, rawHex: 'cafe' },
+    ];
+
+    beforeEach(() => {
+      mockPacketService.getPackets.mockResolvedValue(samplePackets);
+      mockPacketService.getPacketCount.mockResolvedValue(samplePackets.length);
+      mockPacketService.isEnabled.mockResolvedValue(true);
+      mockPacketService.getMaxAgeHours.mockResolvedValue(24);
+      mockPacketService.getMaxCount.mockResolvedValue(1000);
+    });
+
+    it('honors meshcore_packet_log_max_count as the default query limit (#3690)', async () => {
+      // The user has configured a max count of 500. With no explicit ?limit,
+      // the list endpoint must query up to 500 rows — not the old hard-coded 100.
+      mockPacketService.getMaxCount.mockResolvedValue(500);
+
+      const response = await authenticatedAgent.get('/api/sources/test-source/meshcore/packets');
+
+      expect(response.status).toBe(200);
+      expect(response.body.maxCount).toBe(500);
+      expect(mockPacketService.getPackets).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceId: 'test-source', offset: 0, limit: 500 }),
+      );
+      expect(response.body.limit).toBe(500);
+    });
+
+    it('clamps the configured max count to the hard ceiling (1000)', async () => {
+      mockPacketService.getMaxCount.mockResolvedValue(5000);
+
+      const response = await authenticatedAgent.get('/api/sources/test-source/meshcore/packets');
+
+      expect(response.status).toBe(200);
+      expect(mockPacketService.getPackets).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 1000 }),
+      );
+    });
+
+    it('honors an explicit smaller client-supplied limit', async () => {
+      mockPacketService.getMaxCount.mockResolvedValue(500);
+
+      const response = await authenticatedAgent.get('/api/sources/test-source/meshcore/packets?limit=50');
+
+      expect(response.status).toBe(200);
+      expect(mockPacketService.getPackets).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 50 }),
+      );
+      expect(response.body.limit).toBe(50);
+    });
+  });
+
   describe('GET /api/sources/test-source/meshcore/packets/export', () => {
     const samplePackets = [
       { id: 2, sourceId: 'test-source', timestamp: 1700000002000, payloadType: 1, routeType: 0, rawHex: 'beef' },

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -3274,7 +3274,14 @@ router.get(
     try {
       const sourceId = (req.params as { id?: string }).id!;
       const offset = Math.max(parseInt(req.query.offset as string, 10) || 0, 0);
-      const limit = Math.min(Math.max(parseInt(req.query.limit as string, 10) || 100, 1), MESHCORE_PACKET_MAX_LIMIT);
+      // Honor the user-configured retention cap (meshcore_packet_log_max_count)
+      // as the default effective limit, the same way the export endpoint does
+      // (issue #3690). An explicit client-supplied `limit` still wins so a
+      // caller can request fewer rows; both are clamped by the hard ceiling.
+      const maxCount = await meshcorePacketLogService.getMaxCount();
+      const requestedLimit = parseInt(req.query.limit as string, 10);
+      const effectiveLimit = Number.isFinite(requestedLimit) && requestedLimit > 0 ? requestedLimit : maxCount;
+      const limit = Math.min(Math.max(effectiveLimit, 1), MESHCORE_PACKET_MAX_LIMIT);
       const payloadType = req.query.payload_type !== undefined ? parseInt(req.query.payload_type as string, 10) : undefined;
       const routeType = req.query.route_type !== undefined ? parseInt(req.query.route_type as string, 10) : undefined;
       let since = req.query.since !== undefined ? parseInt(req.query.since as string, 10) : undefined;
@@ -3290,11 +3297,10 @@ router.get(
         since: Number.isFinite(since as number) ? since : undefined,
       };
 
-      const [packets, total, enabled, maxCount, maxAgeHours] = await Promise.all([
+      const [packets, total, enabled, maxAgeHours] = await Promise.all([
         meshcorePacketLogService.getPackets(query),
         meshcorePacketLogService.getPacketCount({ sourceId, payloadType: query.payloadType, routeType: query.routeType, since: query.since }),
         meshcorePacketLogService.isEnabled(),
-        meshcorePacketLogService.getMaxCount(),
         meshcorePacketLogService.getMaxAgeHours(),
       ]);
 


### PR DESCRIPTION
## Root cause

The MeshCore Packet Monitor live-list endpoint `GET /api/sources/:id/meshcore/packets` ignored the user-configured `meshcore_packet_log_max_count` setting. It applied a hard-coded default limit of `100`, clamped only by `MESHCORE_PACKET_MAX_LIMIT` (1000), against whatever `limit` the client sent. The frontend always sent `limit=200` (`PAGE_LIMIT`), so the monitor showed at most ~200 packets regardless of the configured Max count.

The **export** endpoint (`GET .../packets/export`) already read `meshcorePacketLogService.getMaxCount()` and used it as the query limit — so the two endpoints behaved inconsistently, and the live monitor never honored the setting users could change in the UI.

## Fix

- **List endpoint (server, authoritative):** now reads `meshcorePacketLogService.getMaxCount()` and uses it as the effective query limit when the client does not supply an explicit `?limit`, mirroring the export endpoint precisely. An explicit, smaller client-supplied `limit` still wins so a caller can request fewer rows; both are clamped by the `MESHCORE_PACKET_MAX_LIMIT` ceiling (1000). The previously-fetched `maxCount` in the response `Promise.all` was deduplicated into the new single read.
- **Frontend view:** `MeshCorePacketMonitorView.tsx` no longer hard-codes `limit=200` on load, so the server-side setting governs the page size. The unused `PAGE_LIMIT` constant was removed; the live `MAX_BUFFER` (2000) cap is unchanged.

The setting-read mirrors export exactly:
```ts
const maxCount = await meshcorePacketLogService.getMaxCount();
```
(`getMaxCount()` reads the global `meshcore_packet_log_max_count` setting via `databaseService.getSettingAsync`, defaulting to `DEFAULT_MAX_COUNT` when unset/invalid.)

## Tests

Added a `GET .../packets (list)` describe block in `meshcoreRoutes.test.ts` asserting the list endpoint:
- queries with `limit: 500` when `getMaxCount()` returns 500 (no explicit client limit),
- clamps a configured max count of 5000 down to the 1000 ceiling,
- honors an explicit smaller client-supplied `limit=50`.

Full Vitest suite: **7373 passed, 0 failed, 0 failed suites** (`success: true`). `tsc --noEmit` reports no new errors in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)