### PR TITLE
fix(meshtastic): resolve position-packet channel from decryption context, not raw hash (#3682)

### DIFF
--- a/src/server/meshtasticManager.positionChannel.test.ts
+++ b/src/server/meshtasticManager.positionChannel.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Regression for issue #3682
+//
+// Position packets received on a private secondary channel (server-decrypted
+// via a Channel Database entry) used to store the RAW `meshPacket.channel`
+// value — which is the on-wire LoRa channel *hash* (e.g. 39), NOT a channel
+// slot index. Text messages on the SAME channel resolved correctly because the
+// TEXT_MESSAGE_APP dispatch threads the decryption context
+// (decryptedBy/decryptedChannelId) through to its handler.
+//
+// The fix threads that same context into processPositionMessageProtobuf and
+// resolves the channel from it (matching the text path) via the shared
+// resolveBroadcastChannelIndex helper, falling back to the raw meshPacket.channel
+// ONLY when there is no server-decryption context (unencrypted/primary).
+// ---------------------------------------------------------------------------
+
+// Hoisted mocks — must be set up before MeshtasticManager is imported.
+
+vi.mock('./virtualNodeServer.js', () => ({
+  VirtualNodeServer: vi.fn(function (this: any) {
+    this.start = vi.fn().mockResolvedValue(undefined);
+    this.stop = vi.fn().mockResolvedValue(undefined);
+    this.broadcastToClients = vi.fn().mockResolvedValue(undefined);
+    this.isRunning = () => true;
+    this.getClientCount = () => 0;
+  }),
+}));
+
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+const { insertTelemetryMock, getByIdAsyncMock, getAllChannelsMock } = vi.hoisted(() => ({
+  insertTelemetryMock: vi.fn().mockResolvedValue(undefined),
+  getByIdAsyncMock: vi.fn(),
+  getAllChannelsMock: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+    sources: { getSource: vi.fn().mockResolvedValue(null) },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    telemetry: {
+      insertTelemetry: insertTelemetryMock,
+    },
+    messages: {
+      getDirectMessages: vi.fn().mockResolvedValue([]),
+      updateMessageDeliveryState: vi.fn().mockResolvedValue(undefined),
+    },
+    channelDatabase: {
+      getByIdAsync: getByIdAsyncMock,
+    },
+    channels: {
+      getAllChannels: getAllChannelsMock,
+    },
+    updateNodeMobilityAsync: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+vi.mock('./meshtasticProtobufService.js', () => {
+  const svc = {
+    getPortNumName: (n: number) => `PORT_${n}`,
+    normalizePortNum: (n: any) => (typeof n === 'number' ? n : 0),
+    processPayload: vi.fn(),
+    convertCoordinates: (latI: number, lonI: number) => ({
+      latitude: latI / 1e7,
+      longitude: lonI / 1e7,
+    }),
+  };
+  return { default: svc, meshtasticProtobufService: svc };
+});
+
+vi.mock('./services/packetLogService.js', () => {
+  const svc = { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() };
+  return { default: svc, packetLogService: svc };
+});
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: { isEnabled: () => false, tryDecrypt: vi.fn() },
+}));
+
+import { MeshtasticManager, CHANNEL_DB_OFFSET } from './meshtasticManager.js';
+
+function makeManager(): MeshtasticManager {
+  const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+  (mgr as any).isConnected = true;
+  (mgr as any).localNodeInfo = { nodeNum: 555, nodeId: '!0000022b' };
+  // Avoid touching geofence / event-emitter side effects.
+  (mgr as any).checkGeofencesForNode = vi.fn().mockResolvedValue(undefined);
+  (mgr as any).trackPKIEncryption = vi.fn().mockResolvedValue(undefined);
+  return mgr;
+}
+
+describe('MeshtasticManager — position channel resolution (issue #3682)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAllChannelsMock.mockResolvedValue([]);
+    getByIdAsyncMock.mockResolvedValue(null);
+  });
+
+  describe('resolveBroadcastChannelIndex', () => {
+    it('resolves a server-decrypted secondary channel to CHANNEL_DB_OFFSET + dbId, NOT the raw hash', async () => {
+      const mgr = makeManager();
+      // Channel DB entry 3, no matching device channel.
+      getByIdAsyncMock.mockResolvedValue({ id: 3, name: 'private', psk: 'AbCdEf==' });
+      getAllChannelsMock.mockResolvedValue([]);
+
+      // meshPacket.channel here is the raw LoRa hash (e.g. 39) — must be ignored.
+      const meshPacket = { channel: 39, from: 123456 };
+      const channelIndex = await (mgr as any).resolveBroadcastChannelIndex(meshPacket, {
+        decryptedBy: 'server',
+        decryptedChannelId: 3,
+      });
+
+      expect(channelIndex).toBe(CHANNEL_DB_OFFSET + 3); // 103
+      expect(channelIndex).not.toBe(39); // never the raw hash
+    });
+
+    it('prefers a matching device channel slot (same psk + name) over the DB-offset index', async () => {
+      const mgr = makeManager();
+      getByIdAsyncMock.mockResolvedValue({ id: 3, name: 'gauntlet', psk: 'SharedPSK==' });
+      // Device slot 2 has the same psk + name and is a non-primary role.
+      getAllChannelsMock.mockResolvedValue([
+        { id: 0, name: 'LongFast', psk: 'AQ==', role: 1 },
+        { id: 2, name: 'gauntlet', psk: 'SharedPSK==', role: 2 },
+      ]);
+
+      const meshPacket = { channel: 39, from: 123456 };
+      const channelIndex = await (mgr as any).resolveBroadcastChannelIndex(meshPacket, {
+        decryptedBy: 'server',
+        decryptedChannelId: 3,
+      });
+
+      expect(channelIndex).toBe(2); // device slot, not 103 and not 39
+    });
+
+    it('falls back to the raw meshPacket.channel for unencrypted/primary packets (no context)', async () => {
+      const mgr = makeManager();
+      const meshPacket = { channel: 2, from: 123456 };
+      const channelIndex = await (mgr as any).resolveBroadcastChannelIndex(meshPacket, undefined);
+      expect(channelIndex).toBe(2);
+    });
+
+    it('falls back to the raw meshPacket.channel for node-decrypted packets (decryptedBy=node)', async () => {
+      const mgr = makeManager();
+      const meshPacket = { channel: 1, from: 123456 };
+      const channelIndex = await (mgr as any).resolveBroadcastChannelIndex(meshPacket, {
+        decryptedBy: 'node',
+        decryptedChannelId: undefined,
+      });
+      expect(channelIndex).toBe(1);
+    });
+
+    it('defaults to channel 0 when meshPacket.channel is undefined and no context', async () => {
+      const mgr = makeManager();
+      const channelIndex = await (mgr as any).resolveBroadcastChannelIndex({ from: 1 }, undefined);
+      expect(channelIndex).toBe(0);
+    });
+  });
+
+  describe('processPositionMessageProtobuf stores the resolved channel', () => {
+    it('stores CHANNEL_DB_OFFSET + dbId (not the raw hash) in position telemetry when server-decrypted', async () => {
+      const mgr = makeManager();
+      getByIdAsyncMock.mockResolvedValue({ id: 5, name: 'secret', psk: 'AbCdEf==' });
+      getAllChannelsMock.mockResolvedValue([]);
+
+      const meshPacket = { channel: 39, from: 123456, id: 999 };
+      const position = { latitudeI: 400000000, longitudeI: -750000000 };
+
+      await (mgr as any).processPositionMessageProtobuf(meshPacket, position, {
+        decryptedBy: 'server',
+        decryptedChannelId: 5,
+      });
+
+      expect(insertTelemetryMock).toHaveBeenCalled();
+      const latCall = insertTelemetryMock.mock.calls.find(
+        (c: any[]) => c[0]?.telemetryType === 'latitude',
+      );
+      expect(latCall).toBeDefined();
+      expect(latCall![0].channel).toBe(CHANNEL_DB_OFFSET + 5); // 105
+      expect(latCall![0].channel).not.toBe(39); // never the raw hash
+    });
+
+    it('stores the raw meshPacket.channel for unencrypted/primary position packets', async () => {
+      const mgr = makeManager();
+      const meshPacket = { channel: 0, from: 123456, id: 999 };
+      const position = { latitudeI: 400000000, longitudeI: -750000000 };
+
+      await (mgr as any).processPositionMessageProtobuf(meshPacket, position, {
+        decryptedBy: null,
+        decryptedChannelId: undefined,
+      });
+
+      const latCall = insertTelemetryMock.mock.calls.find(
+        (c: any[]) => c[0]?.telemetryType === 'latitude',
+      );
+      expect(latCall).toBeDefined();
+      expect(latCall![0].channel).toBe(0);
+    });
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5531,7 +5531,14 @@ class MeshtasticManager implements ISourceManager {
             });
             break;
           case PortNum.POSITION_APP:
-            await this.processPositionMessageProtobuf(meshPacket, processedPayload as any);
+            // Thread the decryption context so the position's channel resolves
+            // from the channel it was decrypted on (issue #3682), matching the
+            // TEXT_MESSAGE_APP path — not the raw meshPacket.channel hash.
+            await this.processPositionMessageProtobuf(meshPacket, processedPayload as any, {
+              ...context,
+              decryptedBy,
+              decryptedChannelId: decryptedChannelId ?? undefined,
+            });
             break;
           case PortNum.NODEINFO_APP:
             await this.processNodeInfoMessageProtobuf(meshPacket, processedPayload as any);
@@ -6059,9 +6066,55 @@ class MeshtasticManager implements ISourceManager {
   }
 
   /**
+   * Resolve the broadcast channel slot/index for a packet from its decryption
+   * context, falling back to the raw `meshPacket.channel` only when there is no
+   * server-decryption context.
+   *
+   * IMPORTANT: `meshPacket.channel` is the on-wire LoRa channel *hash*
+   * (`xorHash(name) ^ xorHash(psk)`), NOT a channel slot index. For packets
+   * decrypted server-side via a Channel Database entry it is meaningless as a
+   * slot identifier (e.g. it surfaces as "channel 39" in the UI — issue #3682).
+   * This mirrors exactly the channel resolution that the TEXT_MESSAGE_APP path
+   * performs in {@link processTextMessageProtobuf} so every packet type shows a
+   * consistent channel. Only broadcast (non-DM) packets call this.
+   */
+  private async resolveBroadcastChannelIndex(
+    meshPacket: any,
+    context?: ProcessingContext,
+  ): Promise<number> {
+    if (context?.decryptedBy === 'server' && context?.decryptedChannelId !== undefined) {
+      // Check if the database channel's PSK matches a device channel — if so, prefer the device channel
+      // This prevents database channels from "shadowing" device channels with the same key (#2375, #2413)
+      const dbChannel = await databaseService.channelDatabase.getByIdAsync(context.decryptedChannelId);
+      const deviceChannels = await databaseService.channels.getAllChannels(this.sourceId);
+      // Match by BOTH psk AND name (see processTextMessageProtobuf for the
+      // detailed rationale — the on-wire hash includes the name, so two slots
+      // sharing the default PSK but differing in name are distinct channels).
+      const dbName = (dbChannel?.name ?? '').trim();
+      const matchingDeviceChannel = dbChannel?.psk
+        ? deviceChannels.find(dc =>
+            dc.psk === dbChannel.psk
+            && (dc.name ?? '').trim() === dbName
+            && dc.role !== 0,
+          )
+        : null;
+
+      if (matchingDeviceChannel) {
+        logger.debug(`📡 Server-decrypted packet matches device channel ${matchingDeviceChannel.id} ("${matchingDeviceChannel.name}") — using device channel instead of database channel`);
+        return matchingDeviceChannel.id;
+      }
+      return CHANNEL_DB_OFFSET + context.decryptedChannelId;
+    }
+    // No server-decryption context: unencrypted/primary/node-decrypted packet.
+    // The raw meshPacket.channel here IS a usable slot index (the device
+    // populates it for firmware-decoded packets), so preserve existing behavior.
+    return meshPacket.channel !== undefined ? meshPacket.channel : 0;
+  }
+
+  /**
    * Process position message using protobuf types
    */
-  private async processPositionMessageProtobuf(meshPacket: any, position: any): Promise<void> {
+  private async processPositionMessageProtobuf(meshPacket: any, position: any, context?: ProcessingContext): Promise<void> {
     try {
       logger.debug(`🗺️ Position message: lat=${position.latitudeI}, lng=${position.longitudeI}`);
 
@@ -6089,7 +6142,13 @@ class MeshtasticManager implements ISourceManager {
         // precision setting. We must NOT fall back to the local channel's positionPrecision —
         // that record reflects this MeshMonitor instance's channel config, not the remote
         // node's, and using it caused accuracy boxes to all match the local node (issue #3030).
-        const channelIndex = meshPacket.channel !== undefined ? meshPacket.channel : 0;
+        // Resolve the channel slot from the decryption context — NOT the raw
+        // meshPacket.channel, which is the on-wire LoRa hash (e.g. "channel 39")
+        // for packets decrypted server-side on a secondary channel (issue #3682).
+        // This mirrors the TEXT_MESSAGE_APP path so positions show the same
+        // channel as text messages on the same channel. Falls back to the raw
+        // meshPacket.channel only for unencrypted/primary packets.
+        const channelIndex = await this.resolveBroadcastChannelIndex(meshPacket, context);
         const precisionBits = position.precisionBits ?? position.precision_bits ?? undefined;
         const gpsAccuracy = position.gpsAccuracy ?? position.gps_accuracy ?? undefined;
         const hdop = position.HDOP ?? position.hdop ?? undefined;


### PR DESCRIPTION
## Summary

Fixes #3682. Position packets received on a private secondary channel displayed as **"channel N"** where N was a raw numeric hash (e.g. 39), instead of the correct channel slot/name. Text messages on the **same** channel displayed the correct channel.

## Root cause

Channel resolution differed by packet type in `src/server/meshtasticManager.ts`:

- **TEXT_MESSAGE_APP**: the dispatch threads the decryption context (`decryptedBy` / `decryptedChannelId`) into `processTextMessageProtobuf`, which resolves the channel slot from the Channel Database entry the packet was decrypted on — either a matching device-channel slot (same PSK + name) or `CHANNEL_DB_OFFSET + decryptedChannelId`.
- **POSITION_APP**: the dispatch **dropped** that context, and `processPositionMessageProtobuf` read `meshPacket.channel` directly. That field is the on-wire LoRa channel **hash** (`xorHash(name) ^ xorHash(psk)`), **not** a channel slot index — so for a server-decrypted secondary channel it surfaced as a meaningless number (the "39").

## Fix

- Extracted the text path's channel-resolution logic into a shared `resolveBroadcastChannelIndex(meshPacket, context)` helper, mirroring `processTextMessageProtobuf` exactly (device-channel PSK+name match preference, then `CHANNEL_DB_OFFSET + decryptedChannelId`).
- Threaded the decryption context (`decryptedBy` / `decryptedChannelId`) into `processPositionMessageProtobuf` from the POSITION_APP dispatch case.
- Position telemetry/node `positionChannel` now store the **resolved channel slot**, consistent with text messages on the same channel.
- **Raw-hash fallback preserved**: when there is no server-decryption context (unencrypted / primary / node-decrypted packets), the helper returns `meshPacket.channel` exactly as before.
- Per-source scoping is unchanged (channel-database lookups remain global-by-design; `channels.getAllChannels(this.sourceId)` stays source-scoped).

## Test

New `src/server/meshtasticManager.positionChannel.test.ts` (7 tests):
- `resolveBroadcastChannelIndex`: server-decrypted → `CHANNEL_DB_OFFSET + dbId` (not the raw hash); device-channel slot preferred on PSK+name match; raw-hash fallback for no-context / node-decrypted; default 0 when channel undefined.
- `processPositionMessageProtobuf`: telemetry `channel` is the resolved slot (not the raw hash) when server-decrypted; raw `meshPacket.channel` for unencrypted/primary.

Full Vitest suite: **success, 7377 passed, 0 failed, 0 failed suites**. `tsc --noEmit`: no new errors in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)