### PR TITLE
fix(traceroute): always send on channel 0 (Primary) — fixes #3696

### DIFF
--- a/src/server/routes/meshRequestRoutes.test.ts
+++ b/src/server/routes/meshRequestRoutes.test.ts
@@ -65,12 +65,14 @@ describe('POST /traceroute', () => {
     expect(res.status).toBe(400);
   });
 
-  it('sends traceroute on the node channel', async () => {
+  it('always sends traceroute on channel 0 (Primary) regardless of node stored channel', async () => {
+    // node.channel is 2 from the beforeEach mock, but traceroutes must use
+    // channel 0 so intermediate nodes can read the unencrypted packet (issue #3696).
     mockManager.sendTraceroute.mockResolvedValue(undefined);
     const res = await request(app).post('/traceroute').send({ destination: '!12345678' });
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
-    expect(mockManager.sendTraceroute).toHaveBeenCalledWith(0x12345678, 2);
+    expect(mockManager.sendTraceroute).toHaveBeenCalledWith(0x12345678, 0);
   });
 
   it('returns 503 when node is not connected', async () => {

--- a/src/server/routes/meshRequestRoutes.ts
+++ b/src/server/routes/meshRequestRoutes.ts
@@ -21,10 +21,12 @@ router.post('/traceroute', requirePermission('traceroute', 'write'), async (req:
       return res.status(400).json({ error: `Invalid destination: ${destination}` });
     }
 
-    // Scope the channel lookup to the source we actually send through (issue
-    // #3573) so the channel reflects the mesh this traceroute will traverse.
+    // Traceroutes must always use channel 0 (Primary) so every intermediate
+    // node can read and append to the packet. Sending on a secondary encrypted
+    // channel causes intermediate nodes to see an opaque payload and appear as
+    // "Unknown" in the route (issue #3696).
     const traceManager = (resolveSourceManager(traceSourceId));
-    const channel = await resolveDestinationChannel(destinationNum, traceManager, databaseService);
+    const channel = await resolveDestinationChannel(destinationNum, traceManager, databaseService, 0);
     await traceManager.sendTraceroute(destinationNum, channel);
     res.json({
       success: true,


### PR DESCRIPTION
## Summary

Traceroutes were being sent on whatever channel the destination node was last heard on, rather than the Primary channel (index 0). When a user had exchanged messages with a node on a secondary encrypted channel, the node's stored `channel` field reflected that secondary channel — and subsequent traceroutes were sent on it. Intermediate nodes that don't have the encrypted channel can't decode the payload and appear as "Unknown" in the route, making traceroutes from MeshMonitor useless.

This fix forces traceroutes to always use channel 0 by passing it as the explicit channel to `resolveDestinationChannel`. Channel 0 (Primary/LongFast) is the only channel guaranteed to be present on all nodes, which is a prerequisite for traceroute to function correctly.

## Root Cause

`resolveDestinationChannel` without an explicit channel falls back to `node.channel` from the database, which is updated on every incoming packet regardless of channel index. Receiving a DM on channel 2 sets `node.channel = 2`, poisoning all subsequent traceroutes to that node.

Position requests already accepted an explicit caller-supplied channel (and the frontend's channel-picker widget overrides it). Traceroutes had no such override, so the poisoned value always won.

## Changes

- `src/server/routes/meshRequestRoutes.ts`: pass `0` as the explicit channel argument when calling `resolveDestinationChannel` for traceroutes
- `src/server/routes/meshRequestRoutes.test.ts`: update test name and assertion to reflect the corrected behavior (channel 0, not the node's stored channel)

## Issues Resolved

Fixes #3696

## Documentation Updates

No documentation changes needed — this corrects existing behavior to match user expectations.

## Testing

- [x] Unit tests pass (18 tests in meshRequestRoutes.test.ts, full suite running in CI)
- [x] TypeScript compiles cleanly (`tsc -p tsconfig.server.json --noEmit`)
- [ ] Manual: create a secondary encrypted channel, exchange messages on it with another node, then request a traceroute — route should now show intermediate nodes correctly instead of "Unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC5zHztyQEcdUw2ehM8k7x)_