### PR TITLE
fix(meshcore): Discover Regions always timed out due to missing Sent payload

### DIFF
--- a/src/server/meshcoreNativeBackend.discovery.test.ts
+++ b/src/server/meshcoreNativeBackend.discovery.test.ts
@@ -278,4 +278,40 @@ describe('MeshCoreNativeBackend — discovery responder', () => {
     expect(res.data.clock).toBe(1);
     expect(res.data.regions).toEqual(['muenchen', 'bayern', '*']);
   });
+
+  it('request_regions succeeds when Sent ack carries no expectedAckCrc (sendToRadioFrame path)', async () => {
+    // sendToRadioFrame fires the Sent event without a payload, unlike
+    // sendTextMessage which includes expectedAckCrc. The fix should accept
+    // the first BinaryResponse after Sent when no tag is available.
+    const { backend, conn } = await connectedBackend();
+
+    // Override sendToRadioFrame to emit Sent WITHOUT expectedAckCrc, then
+    // emit BinaryResponse with a non-zero tag (what firmware would send).
+    (conn as any).sendToRadioFrame = (frame: Uint8Array) => {
+      conn.sentFrames.push(frame);
+      if (frame[0] === 57) {
+        const firmwareTag = 0xdeadbeef;
+        setImmediate(() => {
+          // Sent event with no payload — simulates sendToRadioFrame behavior.
+          conn.emit(ResponseCodes.Sent);
+          conn.emit(PushCodes.BinaryResponse, {
+            reserved: 0,
+            tag: firmwareTag,
+            responseData: Uint8Array.from([
+              2, 0, 0, 0, // clock = 2
+              ...Buffer.from('berlin', 'ascii'),
+              0,
+            ]),
+          });
+        });
+        return;
+      }
+      setImmediate(() => conn.emit(ResponseCodes.Ok));
+    };
+
+    const res = await backend.sendCommand('request_regions', { public_key: 'bb'.repeat(32) });
+    expect(res.success).toBe(true);
+    expect(res.data.clock).toBe(2);
+    expect(res.data.regions).toEqual(['berlin']);
+  });
 });

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -953,17 +953,27 @@ export class MeshCoreNativeBackend extends EventEmitter {
         frame[34] = 0x00; // reply_path_len = 0
 
         const responseData: Uint8Array = await new Promise((resolve, reject) => {
+          let sentReceived = false;
           let tag: number | null = null;
           let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
             cleanup();
             reject(new Error('request_regions timed out'));
           }, timeoutMs);
-          const onSent = (r: any) => { tag = (r?.expectedAckCrc ?? null); };
+          const onSent = (r: any) => {
+            sentReceived = true;
+            // sendToRadioFrame fires Sent without a payload (unlike sendTextMessage
+            // which includes expectedAckCrc). Capture it when present; fall back to
+            // tag-less mode when absent so the BinaryResponse isn't silently dropped.
+            tag = (r?.expectedAckCrc ?? null);
+          };
           const onResp = (r: any) => {
-            // Only accept the reply once the Sent ack has given us our tag (the
-            // firmware always sends Sent before the BinaryResponse). A response
-            // arriving before that, or carrying a different tag, isn't ours.
-            if (tag === null || r?.tag !== tag) return;
+            // Wait for the Sent ack before accepting any BinaryResponse.
+            if (!sentReceived) return;
+            // When the Sent ack carried a non-zero tag, require the response to
+            // carry the same tag. When the tag is null/0 (sendToRadioFrame doesn't
+            // populate expectedAckCrc), accept the first BinaryResponse — the
+            // requests are sequential so there's no concurrent reply to confuse.
+            if (tag !== null && tag !== 0 && r?.tag !== tag) return;
             cleanup();
             resolve((r?.responseData ?? new Uint8Array()) as Uint8Array);
           };

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -984,9 +984,12 @@ export class MeshCoreNativeBackend extends EventEmitter {
             c.off(K.PushCodes.BinaryResponse, onResp);
             c.off(K.ResponseCodes.Err, onErr);
           }
-          // `on` (not `once`) so a non-matching binary response doesn't consume
-          // our listener; cleanup removes them once we resolve/fail.
-          c.on(K.ResponseCodes.Sent, onSent);
+          // Sent: `once` — there's exactly one Sent ack per frame send, and a
+          // duplicate firing could otherwise overwrite `tag` after the response
+          // has already been matched. BinaryResponse: `on` (not `once`) so a
+          // non-matching response from a different operation doesn't consume our
+          // listener; cleanup removes them both once we resolve/fail.
+          c.once(K.ResponseCodes.Sent, onSent);
           c.on(K.PushCodes.BinaryResponse, onResp);
           c.once(K.ResponseCodes.Err, onErr);
           void c.sendToRadioFrame(frame);


### PR DESCRIPTION
## Summary

Fixes #3698 — "Discover regions from repeater" never returned any regions even with a working nearby repeater.

- **Root cause**: `sendToRadioFrame` fires the `Sent` event without a payload. The `request_regions` handler expected `expectedAckCrc` in that payload (like `sendTextMessage` provides), leaving `tag = null` permanently. Every `BinaryResponse` was then discarded by the `tag === null` guard, the 15 s inner timeout fired silently, and all repeaters were skipped.
- **Fix**: Track `sentReceived` as a separate boolean. When `tag` is null/0 (no usable CRC from the Sent ack), accept the first `BinaryResponse` after the Sent ack fires. When a non-zero tag is present, the original tag-matching logic is preserved.
- **Test**: Added a regression test that simulates a payload-less `Sent` event and verifies the regions response is still resolved correctly.

## Test plan

- [ ] Run `npm test` — existing `request_regions` test still passes (tag-matching path exercised by the mock's `expectedAckCrc: 0x99`)
- [ ] New test `request_regions succeeds when Sent ack carries no expectedAckCrc` passes
- [ ] Manual verification: click "Discover regions from repeaters" with a nearby MeshCore repeater — regions should now appear (or "No regions found" if the repeater has no configured regions, which is correct behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gqwwKYeyPEfZpMTWn5jX4

---
_Generated by [Claude Code](https://claude.ai/code/session_017gqwwKYeyPEfZpMTWn5jX4)_