### PR TITLE
feat(meshcore): per-message scope/region override (#3701)

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -39,6 +39,8 @@ interface MeshCoreChannelsViewProps {
 interface ChannelRow {
   id: number;
   name: string;
+  /** Persisted per-channel region/scope (#3667). null/'' = no channel scope. */
+  scope: string | null;
 }
 
 /** Synthesised pseudo-pubkey used to scope channel messages. Must match the
@@ -94,6 +96,19 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // so a quiet channel doesn't read as empty next to a busy one just because
   // the shared pool's recent-tail happened to exclude it.
   const [counts, setCounts] = useState<Record<number, number>>({});
+  // Per-message scope/region override (#3701). `null` means "no override —
+  // use the channel's resolved scope". A string is a one-off override applied
+  // to the NEXT send only; it is never persisted to the channel row. Reset on
+  // channel switch so the override doesn't leak across channels.
+  const [overrideScope, setOverrideScope] = useState<string | null>(null);
+  const [showScopeOverride, setShowScopeOverride] = useState(false);
+  // Source default scope (#3667) — used as the displayed default when a channel
+  // has no scope of its own, so the operator can see what scope a normal send
+  // would use before deciding to override it.
+  const [defaultScope, setDefaultScope] = useState<string>('');
+  // Region names served by nearby repeaters (#3667 phase 3) for the datalist
+  // suggestions on the override input.
+  const [discoveredRegions, setDiscoveredRegions] = useState<string[]>([]);
 
   useEffect(() => {
     const onResize = () => {
@@ -125,7 +140,11 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
         const rows: ChannelRow[] = Array.isArray(raw)
           ? raw
               .filter((c: any) => typeof c?.id === 'number')
-              .map((c: any) => ({ id: c.id as number, name: String(c.name ?? '') }))
+              .map((c: any) => ({
+                id: c.id as number,
+                name: String(c.name ?? ''),
+                scope: typeof c?.scope === 'string' && c.scope ? c.scope : null,
+              }))
               .sort((a, b) => a.id - b.id)
           : [];
         if (!cancelled) setChannels(rows);
@@ -149,7 +168,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // primary channel that hasn't been read yet.
   const displayChannels: ChannelRow[] = useMemo(() => {
     if (channels.length > 0) return channels;
-    return [{ id: 0, name: t('meshcore.channels.public_fallback', 'Public') }];
+    return [{ id: 0, name: t('meshcore.channels.public_fallback', 'Public'), scope: null }];
   }, [channels, t]);
 
   // Keep `selectedIdx` valid if channels change underneath us.
@@ -182,6 +201,40 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
 
   const active = displayChannels.find(c => c.id === selectedIdx) ?? displayChannels[0];
   const activeFilter = useMemo(() => buildChannelFilter(active.id), [active.id]);
+
+  // The scope a *normal* send on the active channel would assert: the channel's
+  // own scope, else the source default, else unscoped. Used as the override
+  // field's default/placeholder so the operator overrides from a known baseline.
+  const resolvedScope = (active.scope && active.scope.trim()) || defaultScope.trim() || '';
+
+  // Load the source default scope and discovered regions when (re)connected, so
+  // the override control can show the baseline + offer region suggestions.
+  useEffect(() => {
+    if (!status?.connected) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const def = await actions.getDefaultScope();
+        if (!cancelled) setDefaultScope(def ?? '');
+      } catch {
+        /* non-fatal — the override still works without a baseline */
+      }
+      try {
+        const res = await actions.discoverRegions();
+        if (!cancelled && res?.regions) setDiscoveredRegions(res.regions);
+      } catch {
+        /* non-fatal — suggestions are optional */
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [status?.connected, actions]);
+
+  // Reset the one-off override when switching channels so it never leaks across
+  // channels, and collapse the control back to its unobtrusive default.
+  useEffect(() => {
+    setOverrideScope(null);
+    setShowScopeOverride(false);
+  }, [active.id]);
 
   // Fetch the active channel's backlog from the per-channel endpoint. Re-runs on
   // channel switch and on (re)connect. The shared `messages` pool only carries a
@@ -286,13 +339,72 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
             </span>
           </div>
         )}
+        {canSend && connected && (
+          <div className="mc-scope-override">
+            {showScopeOverride ? (
+              <div className="mc-scope-override-row">
+                <label className="mc-scope-override-label" htmlFor={`mc-scope-${active.id}`}>
+                  {t('meshcore.scope.override_label', 'Send scope')}
+                </label>
+                <input
+                  id={`mc-scope-${active.id}`}
+                  className="mc-scope-override-input"
+                  type="text"
+                  list="mc-scope-region-suggestions"
+                  value={overrideScope ?? ''}
+                  placeholder={resolvedScope
+                    ? t('meshcore.scope.override_placeholder', 'e.g. {{scope}}', { scope: resolvedScope })
+                    : t('meshcore.scope.override_placeholder_unscoped', 'unscoped')}
+                  onChange={e => setOverrideScope(e.target.value)}
+                  spellCheck={false}
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                />
+                <datalist id="mc-scope-region-suggestions">
+                  {discoveredRegions.map(r => <option key={r} value={r} />)}
+                </datalist>
+                <button
+                  type="button"
+                  className="mc-scope-override-clear"
+                  onClick={() => { setOverrideScope(null); setShowScopeOverride(false); }}
+                  title={t('meshcore.scope.override_clear', 'Use channel scope')}
+                >
+                  ✕
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="mc-scope-override-toggle"
+                onClick={() => setShowScopeOverride(true)}
+                title={t(
+                  'meshcore.scope.override_toggle_title',
+                  'Send this message under a one-off region/scope override',
+                )}
+              >
+                {t('meshcore.scope.override_toggle', 'Scope: {{scope}}', {
+                  scope: resolvedScope || t('meshcore.scope.unscoped', 'unscoped'),
+                })}
+              </button>
+            )}
+          </div>
+        )}
         <MeshCoreMessageStream
           messages={filtered}
           contacts={contacts}
           selfPublicKey={selfKey}
           disabled={!connected || !canSend}
           emptyText={t('meshcore.no_messages', 'No messages on this channel yet')}
-          onSend={text => actions.sendMessage(text, undefined, active.id)}
+          onSend={async text => {
+            // Pass the one-off scope override only when the operator has opened
+            // the control AND typed a value (incl. '' to mean unscoped). When
+            // collapsed, omit the arg so the backend resolves the channel /
+            // default scope as usual (#3701).
+            const ok = showScopeOverride && overrideScope !== null
+              ? await actions.sendMessage(text, undefined, active.id, overrideScope)
+              : await actions.sendMessage(text, undefined, active.id);
+            return ok;
+          }}
           onNodeNameClick={onNodeNameClick}
           conversationKey={`channel-${active.id}`}
         />

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -14,7 +14,7 @@
  * send (meshcoreManager.ts:sendMessage, phase 2 addition). The per-channel
  * filter therefore matches either direction.
  */
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { MeshCoreMessage, MeshCoreActions, ConnectionStatus } from './hooks/useMeshCore';
@@ -109,6 +109,11 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // Region names served by nearby repeaters (#3667 phase 3) for the datalist
   // suggestions on the override input.
   const [discoveredRegions, setDiscoveredRegions] = useState<string[]>([]);
+  // Guard so region discovery — which emits active radio traffic — runs at most
+  // once per mount, and only after the operator signals intent by opening the
+  // scope-override control. We must NOT re-discover on every reconnect (#3704
+  // review): status flapping would flood the mesh with discovery requests.
+  const regionsDiscoveredRef = useRef(false);
 
   useEffect(() => {
     const onResize = () => {
@@ -207,8 +212,9 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // field's default/placeholder so the operator overrides from a known baseline.
   const resolvedScope = (active.scope && active.scope.trim()) || defaultScope.trim() || '';
 
-  // Load the source default scope and discovered regions when (re)connected, so
-  // the override control can show the baseline + offer region suggestions.
+  // Load the source default scope when (re)connected so the override control can
+  // show the baseline. This is a cheap local DB read (no radio traffic), so it's
+  // safe to re-run on reconnect.
   useEffect(() => {
     if (!status?.connected) return;
     let cancelled = false;
@@ -219,15 +225,30 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
       } catch {
         /* non-fatal — the override still works without a baseline */
       }
+    })();
+    return () => { cancelled = true; };
+  }, [status?.connected, actions]);
+
+  // Lazily discover regions for the suggestion datalist ONLY once the operator
+  // opens the scope-override control (explicit intent), and at most once per
+  // mount. discoverRegions() emits active radio traffic, so we must never tie it
+  // to status?.connected — reconnect flapping would flood the mesh (#3704 review).
+  useEffect(() => {
+    if (!showScopeOverride || !status?.connected) return;
+    if (regionsDiscoveredRef.current) return;
+    regionsDiscoveredRef.current = true;
+    let cancelled = false;
+    (async () => {
       try {
         const res = await actions.discoverRegions();
         if (!cancelled && res?.regions) setDiscoveredRegions(res.regions);
       } catch {
+        regionsDiscoveredRef.current = false; // allow a retry on next open
         /* non-fatal — suggestions are optional */
       }
     })();
     return () => { cancelled = true; };
-  }, [status?.connected, actions]);
+  }, [showScopeOverride, status?.connected, actions]);
 
   // Reset the one-off override when switching channels so it never leaks across
   // channels, and collapse the control back to its unobtrusive default.

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -1607,3 +1607,61 @@
     padding: 1.25rem;
   }
 }
+
+/* --- Per-message scope override (#3701) ---------------------------------- */
+.mc-scope-override {
+  padding: 0.35rem 0.75rem 0;
+}
+
+.mc-scope-override-toggle {
+  background: none;
+  border: none;
+  color: var(--ctp-subtext0);
+  font-size: 0.75rem;
+  padding: 0.15rem 0.25rem;
+  cursor: pointer;
+  border-radius: var(--radius-sm, 4px);
+}
+
+.mc-scope-override-toggle:hover {
+  color: var(--ctp-text);
+  background: var(--ctp-surface0);
+}
+
+.mc-scope-override-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.mc-scope-override-label {
+  font-size: 0.75rem;
+  color: var(--ctp-subtext0);
+  white-space: nowrap;
+}
+
+.mc-scope-override-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.8rem;
+  padding: 0.25rem 0.4rem;
+  background: var(--ctp-surface0);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: var(--radius-sm, 4px);
+  color: var(--ctp-text);
+}
+
+.mc-scope-override-clear {
+  background: none;
+  border: none;
+  color: var(--ctp-subtext0);
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.15rem 0.3rem;
+  border-radius: var(--radius-sm, 4px);
+}
+
+.mc-scope-override-clear:hover {
+  color: var(--ctp-red);
+  background: var(--ctp-surface0);
+}

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -163,7 +163,11 @@ export interface MeshCoreActions {
   /** Import an Ed25519 private key onto the device. Destructive — replaces identity. */
   importPrivateKey: (hexKey: string, opts?: { confirm?: boolean }) => Promise<boolean>;
   sendAdvert: () => Promise<void>;
-  sendMessage: (text: string, toPublicKey?: string, channelIdx?: number) => Promise<boolean>;
+  /** Send a message. `scope` is an optional one-off region/scope override
+   *  (#3701) for THIS send only — it is not persisted to the channel; the next
+   *  send re-asserts the channel/default scope. Omit (or pass `undefined`) for
+   *  the normal channel/default resolution. */
+  sendMessage: (text: string, toPublicKey?: string, channelIdx?: number, scope?: string | null) => Promise<boolean>;
   setDeviceName: (name: string) => Promise<boolean>;
   setRadioParams: (params: { freq: number; bw: number; sf: number; cr: number }) => Promise<boolean>;
   setTxPower: (power: number) => Promise<boolean>;
@@ -1174,7 +1178,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     }
   }, [mcPrefix, csrfFetch]);
 
-  const sendMessage = useCallback(async (text: string, toPublicKey?: string, channelIdx?: number): Promise<boolean> => {
+  const sendMessage = useCallback(async (text: string, toPublicKey?: string, channelIdx?: number, scope?: string | null): Promise<boolean> => {
     if (!text.trim()) return false;
     try {
       const response = await csrfFetch(`${mcPrefix}/messages/send`, {
@@ -1184,6 +1188,9 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
           text,
           toPublicKey: toPublicKey || undefined,
           channelIdx,
+          // Only include the override when explicitly provided; omitting the key
+          // lets the backend resolve the channel/default scope as usual (#3701).
+          ...(scope !== undefined ? { scope } : {}),
         }),
       });
       const data = await response.json();

--- a/src/server/meshcoreManager.scope.test.ts
+++ b/src/server/meshcoreManager.scope.test.ts
@@ -174,6 +174,54 @@ describe('MeshCoreManager — scope resolution on send (#3667)', () => {
   });
 });
 
+describe('MeshCoreManager — per-message scope override (#3701)', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('a per-message override beats the channel scope (and still asserts before send)', async () => {
+    const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: 'muenchen' } });
+    const ok = await manager.sendMessage('hi', undefined, 1, 'augsburg');
+    expect(ok).toBe(true);
+    // The override is asserted on the device immediately before the send.
+    expect(cmdSeq(bridgeCalls)).toEqual(['set_flood_scope', 'send_message']);
+    expect(scopeOf(bridgeCalls)).toEqual(['augsburg']);
+  });
+
+  it('a per-message override beats the source default scope', async () => {
+    const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: null }, defaultScope: 'berlin' });
+    await manager.sendMessage('hi', undefined, 1, 'augsburg');
+    expect(scopeOf(bridgeCalls)).toEqual(['augsburg']);
+  });
+
+  it('normalizes the override (strips leading # and disallowed chars)', async () => {
+    const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: 'muenchen' } });
+    await manager.sendMessage('hi', undefined, 1, '#Bad Scope!');
+    // '#' stripped, space + '!' removed, letters/digits kept.
+    expect(scopeOf(bridgeCalls)).toEqual(['BadScope']);
+  });
+
+  it('an empty/whitespace override is an explicit unscoped send (null)', async () => {
+    const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: 'muenchen' }, defaultScope: 'berlin' });
+    await manager.sendMessage('hi', undefined, 1, '   ');
+    expect(scopeOf(bridgeCalls)).toEqual([null]);
+  });
+
+  it('omitting the override falls back to the channel scope (unchanged behaviour)', async () => {
+    const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: 'muenchen' }, defaultScope: 'berlin' });
+    await manager.sendMessage('hi', undefined, 1);
+    expect(scopeOf(bridgeCalls)).toEqual(['muenchen']);
+  });
+
+  it('does NOT persist the override — the next normal send re-asserts the channel scope', async () => {
+    const { manager, bridgeCalls, scopeUpdates } = makeManager({ channelScopes: { 1: 'muenchen' } });
+    await manager.sendMessage('one', undefined, 1, 'augsburg');
+    await manager.sendMessage('two', undefined, 1);
+    // First send used the override, second re-asserts the channel scope.
+    expect(scopeOf(bridgeCalls)).toEqual(['augsburg', 'muenchen']);
+    // The channel row was never written.
+    expect(scopeUpdates).toHaveLength(0);
+  });
+});
+
 describe('MeshCoreManager — setChannel / setDefaultScope scope handling (#3667)', () => {
   beforeEach(() => vi.restoreAllMocks());
 

--- a/src/server/meshcoreManager.scope.test.ts
+++ b/src/server/meshcoreManager.scope.test.ts
@@ -220,6 +220,32 @@ describe('MeshCoreManager — per-message scope override (#3701)', () => {
     // The channel row was never written.
     expect(scopeUpdates).toHaveLength(0);
   });
+
+  it('serialises a per-message override send concurrent with a normal send so each scope pairs with its own send', async () => {
+    // #3704 review item 4: the existing concurrency test (above, in the #3667
+    // block) only covers two different *channel* scopes. This proves the
+    // serializer also atomically pairs an explicit per-message override with its
+    // send, and the channel/default scope with the non-override send, without
+    // interleaving. floodScopeDelayMs forces a real yield between scope-assert
+    // and send, so a broken lock would let the second send slip in between.
+    const { manager, bridgeCalls } = makeManager({
+      channelScopes: { 1: 'muenchen' },
+      defaultScope: 'berlin',
+      floodScopeDelayMs: 5,
+    });
+    // Fire both at once: an override send on ch1, and a normal send on ch1.
+    await Promise.all([
+      manager.sendMessage('override', undefined, 1, 'augsburg'),
+      manager.sendMessage('normal', undefined, 1),
+    ]);
+    // Each scope is asserted immediately before its own send — never the broken
+    // ordering scope, scope, send, send. The override asserts 'augsburg', the
+    // normal send re-asserts the channel scope 'muenchen'.
+    const relevant = bridgeCalls
+      .filter(c => c.cmd === 'set_flood_scope' || c.cmd === 'send_message')
+      .map(c => c.cmd === 'set_flood_scope' ? `scope:${c.params.region}` : c.cmd);
+    expect(relevant).toEqual(['scope:augsburg', 'send_message', 'scope:muenchen', 'send_message']);
+  });
 });
 
 describe('MeshCoreManager — setChannel / setDefaultScope scope handling (#3667)', () => {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1958,7 +1958,7 @@ class MeshCoreManager extends EventEmitter {
    * channel 1" from "I sent this to channel 0" — both used to be indistinguishable
    * when only channel 0 was supported (issue follow-up to MeshCore channels plan).
    */
-  async sendMessage(text: string, toPublicKey?: string, channelIdx?: number): Promise<boolean> {
+  async sendMessage(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null): Promise<boolean> {
     if (!this.connected) {
       logger.error('[MeshCore] Not connected');
       return false;
@@ -1973,7 +1973,27 @@ class MeshCoreManager extends EventEmitter {
     // flood scope is a single global setting; two concurrent sends with
     // different scopes must not interleave, or a message could ship under the
     // wrong region.
-    return this.runSerialized(() => this.performScopedSend(text, toPublicKey, channelIdx));
+    return this.runSerialized(() => this.performScopedSend(text, toPublicKey, channelIdx, scopeOverride));
+  }
+
+  /**
+   * Normalise a per-message scope override (#3701): trim, strip a leading '#',
+   * keep only letters/digits/hyphens (matching the channel/default scope
+   * normalisation). The override is one-off — it is NOT persisted to the
+   * channel row; the next normal send re-asserts the channel/default scope.
+   *
+   * Returns:
+   *  - `undefined` when there is no override (caller resolves the scope
+   *    normally via {@link resolveScopeForSend}),
+   *  - `null` when the override is an explicit "unscoped" choice (the device
+   *    flood scope is cleared for this one send),
+   *  - the plain region name otherwise.
+   */
+  private static normalizeScopeOverride(scope: string | null | undefined): string | null | undefined {
+    if (scope === undefined) return undefined;
+    if (scope === null) return null;
+    const normalized = scope.trim().replace(/^#/, '').replace(/[^0-9A-Za-z-]/g, '');
+    return normalized || null;
   }
 
   /**
@@ -2040,7 +2060,7 @@ class MeshCoreManager extends EventEmitter {
     }
   }
 
-  private async performScopedSend(text: string, toPublicKey?: string, channelIdx?: number): Promise<boolean> {
+  private async performScopedSend(text: string, toPublicKey?: string, channelIdx?: number, scopeOverride?: string | null): Promise<boolean> {
     try {
       const isChannelSend = !toPublicKey && channelIdx !== undefined;
 
@@ -2051,7 +2071,16 @@ class MeshCoreManager extends EventEmitter {
       // When the DM has a known direct path the scope is simply inert. Setting
       // it changes the device's single global scope, but the activeFloodScope
       // cache + re-assert keeps a later channel send correct regardless.
-      const region = await this.resolveScopeForSend(isChannelSend ? channelIdx : undefined);
+      //
+      // A per-message scope override (#3701) wins over the channel/default
+      // scope for this one send only — it is NOT persisted, so the next normal
+      // send re-asserts the channel/default scope. It still goes through
+      // applyFloodScope inside runSerialized, so the scope-assert→send pair
+      // stays atomic and the cache + re-assert invariants hold.
+      const normalizedOverride = MeshCoreManager.normalizeScopeOverride(scopeOverride);
+      const region = normalizedOverride !== undefined
+        ? normalizedOverride
+        : await this.resolveScopeForSend(isChannelSend ? channelIdx : undefined);
       await this.applyFloodScope(region);
 
       const response = await this.sendBridgeCommand('send_message', {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1982,17 +1982,33 @@ class MeshCoreManager extends EventEmitter {
    * normalisation). The override is one-off — it is NOT persisted to the
    * channel row; the next normal send re-asserts the channel/default scope.
    *
-   * Returns:
-   *  - `undefined` when there is no override (caller resolves the scope
-   *    normally via {@link resolveScopeForSend}),
-   *  - `null` when the override is an explicit "unscoped" choice (the device
-   *    flood scope is cleared for this one send),
-   *  - the plain region name otherwise.
+   * Contract (#3704 review — kept unambiguous and aligned with the send route):
+   *  - `undefined` OR `null` ⇒ NO override. The caller resolves the scope
+   *    normally via {@link resolveScopeForSend} (channel → default → unscoped).
+   *    The route collapses a JSON `null`/absent key to `undefined`, so both
+   *    arrive here as "no override"; we treat them identically.
+   *  - `''` or whitespace/punctuation-only ⇒ explicit UNSCOPED (returns `null`):
+   *    the device flood scope is cleared for this one send.
+   *  - a non-empty string ⇒ the normalised plain region name.
+   *
+   * Normalisation here is intentionally LENIENT (it strips invalid chars rather
+   * than rejecting), unlike the persisted `POST /config/default-scope` setting
+   * which returns 400. Rationale: the override is a transient one-off send, not
+   * stored config, so silently sanitising is lower-risk than failing the send;
+   * but we WARN when characters are dropped so the mangling isn't invisible
+   * (#3704 review item 2). The send route still rejects non-string types and
+   * over-length input up front, so only stray punctuation reaches this strip.
    */
   private static normalizeScopeOverride(scope: string | null | undefined): string | null | undefined {
-    if (scope === undefined) return undefined;
-    if (scope === null) return null;
-    const normalized = scope.trim().replace(/^#/, '').replace(/[^0-9A-Za-z-]/g, '');
+    if (scope === undefined || scope === null) return undefined;
+    const stripped = scope.trim().replace(/^#/, '');
+    const normalized = stripped.replace(/[^0-9A-Za-z-]/g, '');
+    if (normalized !== stripped) {
+      logger.warn(
+        `[MeshCore] Per-message scope override "${scope}" contained invalid characters; ` +
+        `normalised to "${normalized || '(unscoped)'}"`,
+      );
+    }
     return normalized || null;
   }
 

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -1424,11 +1424,18 @@ router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('
       parsedChannelIdx = n;
     }
 
-    // Optional per-message scope/region override (#3701). `undefined` (key
-    // absent) means "no override — resolve the channel/default scope as usual".
-    // A string (incl. '') is a one-off override for this send only; it is NOT
-    // persisted to the channel. The manager normalises it (strip '#', keep
-    // letters/digits/hyphens). Reject obviously-wrong non-string types so a
+    // Optional per-message scope/region override (#3701). Contract (#3704
+    // review — kept unambiguous and matching normalizeScopeOverride):
+    //   - key ABSENT (`undefined`) OR JSON `null` ⇒ NO override; the manager
+    //     resolves the channel/default scope as usual. We collapse both to
+    //     `undefined` here so "no override" has a single representation.
+    //   - `''` (or whitespace/punctuation-only) ⇒ explicit UNSCOPED for this
+    //     one send only.
+    //   - a non-empty string ⇒ a one-off region override for this send only.
+    // The override is NEVER persisted to the channel; the next normal send
+    // re-asserts the channel/default scope. The manager normalises the value
+    // leniently (strip '#', keep letters/digits/hyphens, warn on stripped
+    // chars). Here we only reject wrong types / over-length up front so a
     // malformed body can't silently change scoping.
     let scopeOverride: string | undefined;
     if (scope !== undefined && scope !== null) {

--- a/src/server/routes/meshcoreRoutes.ts
+++ b/src/server/routes/meshcoreRoutes.ts
@@ -1399,7 +1399,7 @@ router.get('/info', optionalAuth(), requirePermission('connection', 'read', { so
  */
 router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('messages', 'write', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
-    const { text, toPublicKey, channelIdx } = req.body;
+    const { text, toPublicKey, channelIdx, scope } = req.body;
 
     // Validate message text
     const textValidation = isValidMessage(text);
@@ -1424,7 +1424,24 @@ router.post('/messages/send', messageLimiter, requireAuth(), requirePermission('
       parsedChannelIdx = n;
     }
 
-    const success = await managerFor(req).sendMessage(text, toPublicKey, parsedChannelIdx);
+    // Optional per-message scope/region override (#3701). `undefined` (key
+    // absent) means "no override — resolve the channel/default scope as usual".
+    // A string (incl. '') is a one-off override for this send only; it is NOT
+    // persisted to the channel. The manager normalises it (strip '#', keep
+    // letters/digits/hyphens). Reject obviously-wrong non-string types so a
+    // malformed body can't silently change scoping.
+    let scopeOverride: string | undefined;
+    if (scope !== undefined && scope !== null) {
+      if (typeof scope !== 'string') {
+        return res.status(400).json({ success: false, error: 'scope must be a string' });
+      }
+      if (scope.length > 63) {
+        return res.status(400).json({ success: false, error: 'scope must be 63 characters or fewer' });
+      }
+      scopeOverride = scope;
+    }
+
+    const success = await managerFor(req).sendMessage(text, toPublicKey, parsedChannelIdx, scopeOverride);
 
     if (success) {
       res.json({ success: true, message: 'Message sent' });


### PR DESCRIPTION
## Summary

Implements issue #3701: let operators send a single MeshCore channel message under a one-off scope/region override without changing the channel's persistent scope. Builds on the scope infrastructure from #3667.

## Changes

**Backend (`meshcoreManager.ts`)**
- `sendMessage` / `performScopedSend` accept an optional `scopeOverride?: string | null`.
- When provided, the override is used INSTEAD of `resolveScopeForSend(...)` but STILL inside `runSerialized` and STILL via `applyFloodScope` — the scope-assert -> send serialization is load-bearing because the device flood scope is a single global stateful value.
- Override is normalized like elsewhere (strip leading `#`, keep letters/digits/hyphens). One-off only: never persisted to the channel row, so the next normal send re-asserts the channel/default scope.
- Empty/whitespace override = explicit unscoped (`null`); omitted = resolve channel/default as usual.

**API (`meshcoreRoutes.ts`)**
- `POST .../messages/send` accepts an optional `scope` field, validated as a string (<= 63 chars). Absent = no override.

**Frontend (`useMeshCore.ts`, `MeshCoreChannelsView.tsx`, `MeshCorePage.css`)**
- `sendMessage` action gains the optional override arg.
- An unobtrusive per-message scope control sits next to the channel compose box, defaulting/placeholdering to the channel's resolved scope and offering discovered-region suggestions (`discoverRegions`) via a `<datalist>`. The override resets on channel switch so it never leaks across channels.

**Tests (`meshcoreManager.scope.test.ts`)**
- Override beats both channel and default scope.
- Override is normalized; explicit-unscoped supported; override is NOT persisted (channel row untouched, next send re-asserts channel scope).
- `set_flood_scope` is still issued before `send_message`.

## Testing
- Full Vitest suite: `success: true`, 7387 passed, 0 failed, 0 failed suites.
- `tsc --noEmit`: no errors in touched files.
- `eslint`: clean.

Closes #3701

🤖 Generated with [Claude Code](https://claude.com/claude-code)