### PR TITLE
fix(meshcore): stop virtual node server during transport teardown

### DIFF
--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -4062,6 +4062,12 @@ class MeshCoreManager extends EventEmitter {
    * relevant half of `disconnect()` but preserves reconnect intent.
    */
   private async teardownTransportOnly(): Promise<void> {
+    // Stop the Virtual Node server first, same as disconnect() does. Without
+    // this, the VN server keeps accepting app connections while isConnected()
+    // is false, causing every AppStart to get BadState and the app to loop in
+    // "Connecting". The server restarts in connect() once the real node is back.
+    await this.stopVirtualNodeServer();
+
     if (this.nativeBackend) {
       try {
         await this.nativeBackend.disconnect();

--- a/src/server/meshcoreManager.virtualNode.test.ts
+++ b/src/server/meshcoreManager.virtualNode.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression test for the MeshCore reconnect teardown path (PR #3706, issue #3705).
+ *
+ * When the real node connection drops, `beginReconnect()` calls
+ * `teardownTransportOnly()` to tear down the live transport while preserving
+ * reconnect intent. Previously this left the Virtual Node server running, so the
+ * VN server kept accepting MeshCore mobile-app connections while
+ * `isConnected()` was false — every AppStart got BadState and the app looped in
+ * "Connecting". The fix stops the Virtual Node server at the top of
+ * `teardownTransportOnly()`, mirroring `disconnect()`. The server restarts in
+ * `connect()` once the real node is back.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MeshCoreManager } from './meshcoreManager.js';
+
+describe('MeshCoreManager.teardownTransportOnly() — Virtual Node teardown', () => {
+  let manager: MeshCoreManager;
+
+  beforeEach(() => {
+    manager = new MeshCoreManager('test-source');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('stops the Virtual Node server when tearing down the transport for reconnect', async () => {
+    const stopVnSpy = vi
+      .spyOn(manager as any, 'stopVirtualNodeServer')
+      .mockResolvedValue(undefined);
+
+    await (manager as any).teardownTransportOnly();
+
+    expect(stopVnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('tears down the native backend after stopping the Virtual Node server', async () => {
+    const stopVnSpy = vi
+      .spyOn(manager as any, 'stopVirtualNodeServer')
+      .mockResolvedValue(undefined);
+
+    const backendDisconnect = vi.fn().mockResolvedValue(undefined);
+    (manager as any).nativeBackend = { disconnect: backendDisconnect };
+
+    await (manager as any).teardownTransportOnly();
+
+    expect(stopVnSpy).toHaveBeenCalledTimes(1);
+    expect(backendDisconnect).toHaveBeenCalledTimes(1);
+    // VN server must be stopped before the transport goes away — the VN server
+    // reads connection state to answer AppStart.
+    expect(stopVnSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      backendDisconnect.mock.invocationCallOrder[0],
+    );
+    // Transport is torn down but reconnect intent (localNode/contacts cache) is
+    // preserved for the next connect().
+    expect((manager as any).connected).toBe(false);
+    expect((manager as any).nativeBackend).toBeNull();
+  });
+
+  it('delegates to the Virtual Node server stop() through stopVirtualNodeServer()', async () => {
+    const vnStop = vi.fn().mockResolvedValue(undefined);
+    (manager as any).virtualNodeServer = { stop: vnStop, isRunning: () => true };
+
+    await (manager as any).teardownTransportOnly();
+
+    expect(vnStop).toHaveBeenCalledTimes(1);
+    expect((manager as any).virtualNodeServer).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3705 — MeshCore virtual node stuck in "Connecting" when the real node connection drops.

- When the real MeshCore node loses connectivity, `teardownTransportOnly()` sets `isConnected() = false` but left the virtual node server running. Every `AppStart` from the mobile app got `BadState` → app looped in "Connecting".
- Added `await this.stopVirtualNodeServer()` at the top of `teardownTransportOnly()`, mirroring what the full `disconnect()` path already does. The server restarts in `connect()` once the real node is back.

## Test plan

- [ ] Verify existing virtual node unit tests still pass (`src/server/meshcoreVirtualNodeServer.test.ts`)
- [ ] Manual: connect mobile app to virtual node with a stable real-node connection → should work as before
- [ ] Manual: simulate real-node disconnect (unplug/stop the device) → virtual node server stops (app drops); reconnect real node → virtual node restarts; app can connect again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBEuSU2sHGZS3xNiXshTxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBEuSU2sHGZS3xNiXshTxm)_